### PR TITLE
fix(markets): restore sector valuation enrichment

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -27,6 +27,8 @@ RUN npm ci --prefix scripts --omit=dev --omit=optional --ignore-scripts
 # Relay script and shared helpers
 COPY scripts/ais-relay.cjs ./scripts/ais-relay.cjs
 COPY scripts/_proxy-utils.cjs ./scripts/_proxy-utils.cjs
+# Authenticated Yahoo sector valuation client required at relay startup.
+COPY scripts/_yahoo-sector-valuations.cjs ./scripts/_yahoo-sector-valuations.cjs
 COPY scripts/lib/usni-fleet-parser.cjs ./scripts/lib/usni-fleet-parser.cjs
 # llm-telemetry.cjs is transitively imported by _seed-utils.mjs (SIGTERM
 # telemetry flush, #4954) — missing it = silent startup crash in the image.

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -223,7 +223,7 @@ export const CACHE_TOOLS: ToolDef[] = [
   {
     name: 'get_market_data',
     _outputBudgetBytes: 131072,
-    description: 'Real-time equity quotes, commodity prices (including gold futures GC=F), crypto prices, forex FX rates (USD/EUR, USD/JPY etc.), sector performance, ETF flows, and Gulf market quotes from WorldMonitor\'s curated bootstrap cache.',
+    description: 'Real-time equity quotes, commodity prices (including gold futures GC=F), crypto prices, forex FX rates (USD/EUR, USD/JPY etc.), sector performance and valuation coverage, ETF flows, and Gulf market quotes from WorldMonitor\'s curated bootstrap cache.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -268,6 +268,17 @@ export const CACHE_TOOLS: ToolDef[] = [
         properties: {
           sectors: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, name: { type: 'string' }, changePercent: { type: 'number' } } } },
           valuations: { type: ['object', 'array', 'null'] },
+          valuationCoverage: {
+            type: ['object', 'null'],
+            properties: {
+              valuationCount: { type: 'number' },
+              expectedValuationCount: { type: 'number' },
+              sourceStatus: { type: 'string', enum: ['ok', 'partial', 'degraded'] },
+              source: { type: 'string' },
+              fetchedAt: { type: 'number' },
+              stale: { type: 'boolean' },
+            },
+          },
         },
       },
       'etf-flows': {

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -219,6 +219,29 @@ function projectChinaMacroForMcp(value: unknown): unknown {
   };
 }
 
+const MARKET_SECTOR_MAX_STALE_MIN = 30;
+
+// `get_market_data` bundles several independently seeded caches. The outer
+// envelope carries aggregate freshness, but sector valuation coverage also
+// needs a field-level freshness bit so a caller filtering to sectors does not
+// mistake an old valuation snapshot for a current one.
+export function applySectorValuationFreshness(
+  data: Record<string, unknown>,
+  now = Date.now(),
+): Record<string, unknown> {
+  const sectors = data.sectors;
+  if (!sectors || typeof sectors !== 'object' || Array.isArray(sectors)) return data;
+  const coverage = (sectors as Record<string, unknown>).valuationCoverage;
+  if (!coverage || typeof coverage !== 'object' || Array.isArray(coverage)) return data;
+  const fetchedAtValue = (coverage as Record<string, unknown>).fetchedAt;
+  const fetchedAt = typeof fetchedAtValue === 'number' || typeof fetchedAtValue === 'string'
+    ? Number(fetchedAtValue)
+    : Number.NaN;
+  (coverage as Record<string, unknown>).stale = !Number.isFinite(fetchedAt)
+    || (now - fetchedAt) / 60_000 > MARKET_SECTOR_MAX_STALE_MIN;
+  return data;
+}
+
 export const CACHE_TOOLS: ToolDef[] = [
   {
     name: 'get_market_data',
@@ -327,6 +350,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       }
       capNested(data, 'sectors', 'sectors', limit);
       capNested(data, 'etf-flows', 'etfs', limit);
+      applySectorValuationFreshness(data);
       const cls = argStrList(params.asset_class);
       if (cls.length > 0) {
         const map: Record<string, string> = {
@@ -351,6 +375,10 @@ export const CACHE_TOOLS: ToolDef[] = [
     ],
     _seedMetaKey: 'seed-meta:market:stocks',
     _maxStaleMin: 30,
+    _freshnessChecks: [
+      { key: 'seed-meta:market:stocks', maxStaleMin: 30 },
+      { key: 'seed-meta:market:sectors', maxStaleMin: MARKET_SECTOR_MAX_STALE_MIN },
+    ],
     // NOTE: `GET /api/market/v1/get-gold-intelligence` is NOT covered here.
     // The audit-time cross-reference matched on the single `market:commodities-bootstrap:v1`
     // key shared between this tool and the gold-intel handler, but the handler also reads 4

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -34,7 +34,7 @@
   "tools": [
     {
       "name": "get_market_data",
-      "description": "Real-time equity quotes, commodity prices (including gold futures GC=F), crypto prices, forex FX rates (USD/EUR, USD/JPY etc.), sector performance, ETF flows, and Gulf market quotes from WorldMonitor's curated bootstrap cache."
+      "description": "Real-time equity quotes, commodity prices (including gold futures GC=F), crypto prices, forex FX rates (USD/EUR, USD/JPY etc.), sector performance and valuation coverage, ETF flows, and Gulf market quotes from WorldMonitor's curated bootstrap cache."
     },
     {
       "name": "get_conflict_events",

--- a/scripts/_yahoo-sector-valuations.cjs
+++ b/scripts/_yahoo-sector-valuations.cjs
@@ -13,26 +13,64 @@ const YAHOO_SUMMARY_MODULES = 'summaryDetail,defaultKeyStatistics';
 const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
 const DEFAULT_SESSION_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_REQUEST_SPACING_MS = 150;
+const DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function requestHttpsText(url, { headers = {}, timeoutMs = 12_000 } = {}) {
+function requestHttpsText(
+  url,
+  {
+    headers = {},
+    timeoutMs = 12_000,
+    maxResponseBytes = DEFAULT_MAX_RESPONSE_BYTES,
+    httpsGet = https.get,
+  } = {},
+) {
   return new Promise((resolve, reject) => {
-    const req = https.get(url, { headers, timeout: timeoutMs }, (response) => {
+    let settled = false;
+    let req;
+    req = httpsGet(url, { headers, timeout: timeoutMs }, (response) => {
       let body = '';
+      let bodyBytes = 0;
       response.setEncoding('utf8');
-      response.on('data', (chunk) => { body += chunk; });
+      response.on('data', (chunk) => {
+        if (settled) return;
+        bodyBytes += Buffer.byteLength(chunk, 'utf8');
+        if (bodyBytes > maxResponseBytes) {
+          settled = true;
+          const error = new Error(
+            `Yahoo response exceeded ${maxResponseBytes} byte limit`,
+          );
+          error.code = 'RESPONSE_TOO_LARGE';
+          response.destroy();
+          req?.destroy(error);
+          reject(error);
+          return;
+        }
+        body += chunk;
+      });
       response.on('end', () => {
+        if (settled) return;
+        settled = true;
         resolve({
           status: response.statusCode || 0,
           headers: response.headers,
           body,
         });
       });
+      response.on('error', (error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      });
     });
-    req.on('error', reject);
+    req.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    });
     req.on('timeout', () => {
       req.destroy(new Error(`Yahoo request timed out after ${timeoutMs}ms`));
     });

--- a/scripts/_yahoo-sector-valuations.cjs
+++ b/scripts/_yahoo-sector-valuations.cjs
@@ -1,10 +1,7 @@
 'use strict';
 
 const https = require('node:https');
-const { execFile } = require('node:child_process');
-const { promisify } = require('node:util');
-
-const execFileAsync = promisify(execFile);
+const { spawn } = require('node:child_process');
 
 const YAHOO_COOKIE_URL = 'https://fc.yahoo.com';
 const YAHOO_CRUMB_URL = 'https://query1.finance.yahoo.com/v1/test/getcrumb';
@@ -14,6 +11,7 @@ const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
 const DEFAULT_SESSION_TTL_MS = 30 * 60 * 1000;
 const DEFAULT_REQUEST_SPACING_MS = 150;
 const DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const CURL_PROCESS_GRACE_MS = 5_000;
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -120,9 +118,29 @@ function parseCurlResponse(stdout) {
   };
 }
 
+function curlConfigValue(value) {
+  const text = String(value);
+  if (/\r|\n/.test(text)) throw new Error('Yahoo proxy config value contains a newline');
+  return `"${text.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`;
+}
+
+function buildCurlConfig(url, { headers = {}, proxy } = {}) {
+  const lines = [`proxy = ${curlConfigValue(`http://${proxy}`)}`];
+  for (const [name, value] of Object.entries(headers)) {
+    lines.push(`header = ${curlConfigValue(`${name}: ${value}`)}`);
+  }
+  lines.push(`url = ${curlConfigValue(url)}`);
+  return `${lines.join('\n')}\n`;
+}
+
 async function requestCurlText(
   url,
-  { headers = {}, timeoutMs = 15_000, proxy } = {},
+  {
+    headers = {},
+    timeoutMs = 15_000,
+    proxy,
+    spawnFn = spawn,
+  } = {},
 ) {
   if (!proxy) throw new Error('Yahoo proxy route is not configured');
   const args = [
@@ -130,22 +148,75 @@ async function requestCurlText(
     '--compressed',
     '--max-time',
     String(Math.max(1, Math.ceil(timeoutMs / 1000))),
-    '-x',
-    `http://${proxy}`,
     '-D',
     '-',
+    '-w',
+    '\n__WM_HTTP_STATUS__:%{http_code}',
+    '--config',
+    '-',
   ];
-  for (const [name, value] of Object.entries(headers)) {
-    args.push('-H', `${name}: ${value}`);
-  }
-  args.push('-w', '\n__WM_HTTP_STATUS__:%{http_code}', url);
+  const config = buildCurlConfig(url, { headers, proxy });
 
-  const { stdout } = await execFileAsync('curl', args, {
-    encoding: 'utf8',
-    timeout: timeoutMs + 5_000,
-    maxBuffer: 2 * 1024 * 1024,
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let stdoutBytes = 0;
+    const chunks = [];
+    let child;
+    let timer;
+
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    };
+
+    try {
+      child = spawnFn('curl', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    } catch (error) {
+      fail(error);
+      return;
+    }
+
+    timer = setTimeout(() => {
+      const error = new Error(`Yahoo proxy request timed out after ${timeoutMs}ms`);
+      error.code = 'ETIMEDOUT';
+      try { child.kill('SIGKILL'); } catch {}
+      fail(error);
+    }, timeoutMs + CURL_PROCESS_GRACE_MS);
+
+    child.stdout.on('data', (chunk) => {
+      if (settled) return;
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      stdoutBytes += buffer.byteLength;
+      if (stdoutBytes > DEFAULT_MAX_RESPONSE_BYTES) {
+        const error = new Error(`Yahoo proxy response exceeded ${DEFAULT_MAX_RESPONSE_BYTES} byte limit`);
+        error.code = 'RESPONSE_TOO_LARGE';
+        try { child.kill('SIGKILL'); } catch {}
+        fail(error);
+        return;
+      }
+      chunks.push(buffer);
+    });
+    child.stderr.on('data', () => {});
+    child.on('error', fail);
+    child.on('close', (code, signal) => {
+      if (settled) return;
+      if (code !== 0) {
+        fail(new Error(`Yahoo proxy curl exited with ${signal || `code ${code}`}`));
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      try {
+        resolve(parseCurlResponse(Buffer.concat(chunks).toString('utf8')));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    child.stdin.on('error', fail);
+    child.stdin.end(config);
   });
-  return parseCurlResponse(stdout);
 }
 
 function headerValues(headers, name) {
@@ -413,6 +484,32 @@ function buildSectorValuationCoverage({
   };
 }
 
+async function collectSectorValuations({
+  symbols,
+  fetchValue,
+  parseValue,
+  sleepFn = sleep,
+}) {
+  const valuations = {};
+  const valuationSources = new Set();
+  let valuationCount = 0;
+  for (const symbol of symbols) {
+    const raw = await fetchValue(symbol);
+    const parsed = parseValue(raw);
+    if (parsed) {
+      valuations[symbol] = parsed;
+      if (raw?.source) valuationSources.add(raw.source);
+      valuationCount++;
+    }
+    await sleepFn(DEFAULT_REQUEST_SPACING_MS);
+  }
+  return {
+    valuations,
+    valuationSources: [...valuationSources],
+    valuationCount,
+  };
+}
+
 function buildSectorValuationPublication({
   sectors,
   valuations,
@@ -446,8 +543,10 @@ function buildSectorValuationPublication({
 
 module.exports = {
   YahooQuoteSummaryClient,
+  buildCurlConfig,
   buildSectorValuationCoverage,
   buildSectorValuationPublication,
+  collectSectorValuations,
   parseCurlResponse,
   parseQuoteSummary,
   requestHttpsText,

--- a/scripts/_yahoo-sector-valuations.cjs
+++ b/scripts/_yahoo-sector-valuations.cjs
@@ -1,0 +1,417 @@
+'use strict';
+
+const https = require('node:https');
+const { execFile } = require('node:child_process');
+const { promisify } = require('node:util');
+
+const execFileAsync = promisify(execFile);
+
+const YAHOO_COOKIE_URL = 'https://fc.yahoo.com';
+const YAHOO_CRUMB_URL = 'https://query1.finance.yahoo.com/v1/test/getcrumb';
+const YAHOO_SUMMARY_BASE_URL = 'https://query1.finance.yahoo.com/v10/finance/quoteSummary';
+const YAHOO_SUMMARY_MODULES = 'summaryDetail,defaultKeyStatistics';
+const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
+const DEFAULT_SESSION_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_REQUEST_SPACING_MS = 150;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function requestHttpsText(url, { headers = {}, timeoutMs = 12_000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, { headers, timeout: timeoutMs }, (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => { body += chunk; });
+      response.on('end', () => {
+        resolve({
+          status: response.statusCode || 0,
+          headers: response.headers,
+          body,
+        });
+      });
+    });
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy(new Error(`Yahoo request timed out after ${timeoutMs}ms`));
+    });
+  });
+}
+
+function parseCurlResponse(stdout) {
+  const marker = '\n__WM_HTTP_STATUS__:';
+  const markerIndex = stdout.lastIndexOf(marker);
+  if (markerIndex === -1) throw new Error('Yahoo proxy response omitted HTTP status');
+
+  const responseText = stdout.slice(0, markerIndex);
+  const status = Number(stdout.slice(markerIndex + marker.length).trim());
+  let cursor = 0;
+  let headers = null;
+  while (responseText.startsWith('HTTP/', cursor)) {
+    const crlfHeaderEnd = responseText.indexOf('\r\n\r\n', cursor);
+    const lfHeaderEnd = responseText.indexOf('\n\n', cursor);
+    const useCrlf = crlfHeaderEnd >= 0
+      && (lfHeaderEnd < 0 || crlfHeaderEnd <= lfHeaderEnd);
+    const headerEnd = useCrlf ? crlfHeaderEnd : lfHeaderEnd;
+    const separatorLength = useCrlf ? 4 : 2;
+    if (headerEnd < 0) throw new Error('Yahoo proxy response omitted HTTP headers');
+
+    const headerLines = responseText.slice(cursor, headerEnd).split(/\r?\n/).slice(1);
+    headers = {};
+    for (const line of headerLines) {
+      const colon = line.indexOf(':');
+      if (colon <= 0) continue;
+      const name = line.slice(0, colon).trim().toLowerCase();
+      const value = line.slice(colon + 1).trim();
+      if (name === 'set-cookie') {
+        if (!Array.isArray(headers[name])) headers[name] = [];
+        headers[name].push(value);
+      } else {
+        headers[name] = value;
+      }
+    }
+    cursor = headerEnd + separatorLength;
+  }
+  if (!headers) throw new Error('Yahoo proxy response omitted HTTP headers');
+
+  return {
+    status,
+    headers,
+    body: responseText.slice(cursor),
+  };
+}
+
+async function requestCurlText(
+  url,
+  { headers = {}, timeoutMs = 15_000, proxy } = {},
+) {
+  if (!proxy) throw new Error('Yahoo proxy route is not configured');
+  const args = [
+    '-sS',
+    '--compressed',
+    '--max-time',
+    String(Math.max(1, Math.ceil(timeoutMs / 1000))),
+    '-x',
+    `http://${proxy}`,
+    '-D',
+    '-',
+  ];
+  for (const [name, value] of Object.entries(headers)) {
+    args.push('-H', `${name}: ${value}`);
+  }
+  args.push('-w', '\n__WM_HTTP_STATUS__:%{http_code}', url);
+
+  const { stdout } = await execFileAsync('curl', args, {
+    encoding: 'utf8',
+    timeout: timeoutMs + 5_000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+  return parseCurlResponse(stdout);
+}
+
+function headerValues(headers, name) {
+  if (!headers) return [];
+  const value = headers[name] ?? headers[name.toLowerCase()];
+  if (Array.isArray(value)) return value;
+  return typeof value === 'string' ? [value] : [];
+}
+
+function cookieHeaderFromResponse(response) {
+  return headerValues(response?.headers, 'set-cookie')
+    .map((value) => value.split(';', 1)[0]?.trim())
+    .filter((value) => value && value.includes('='))
+    .join('; ');
+}
+
+function validCrumb(body) {
+  const crumb = String(body || '').trim();
+  if (!crumb || crumb.length > 256 || crumb.startsWith('<')) return null;
+  return crumb;
+}
+
+function rawYahooValue(value) {
+  if (value && typeof value === 'object') return value.raw ?? value.fmt ?? null;
+  return typeof value === 'number' ? value : null;
+}
+
+function parseQuoteSummary(body) {
+  let data;
+  try {
+    data = JSON.parse(body);
+  } catch {
+    return { kind: 'invalid_json', value: null };
+  }
+  const result = data?.quoteSummary?.result?.[0];
+  if (!result) return { kind: 'no_data', value: null };
+  const summaryDetail = result.summaryDetail || {};
+  const keyStatistics = result.defaultKeyStatistics || {};
+  return {
+    kind: 'success',
+    value: {
+      trailingPE: rawYahooValue(summaryDetail.trailingPE),
+      forwardPE: rawYahooValue(summaryDetail.forwardPE),
+      beta: rawYahooValue(summaryDetail.beta) ?? rawYahooValue(keyStatistics.beta3Year),
+      ytdReturn: rawYahooValue(keyStatistics.ytdReturn),
+      threeYearReturn: rawYahooValue(keyStatistics.threeYearAverageReturn),
+      fiveYearReturn: rawYahooValue(keyStatistics.fiveYearAverageReturn),
+    },
+  };
+}
+
+function responseFailure(response) {
+  if (!response) return 'no_response';
+  try {
+    const parsed = JSON.parse(response.body);
+    const description = parsed?.finance?.error?.description
+      || parsed?.quoteSummary?.error?.description;
+    if (description) return `HTTP ${response.status} ${description}`;
+  } catch {}
+  return `HTTP ${response.status || 0}`;
+}
+
+function transportFailure(error, transport) {
+  if (transport === 'proxy') {
+    const code = typeof error?.code === 'string'
+      && /^[A-Z0-9_]{1,32}$/i.test(error.code)
+      ? error.code
+      : null;
+    return code ? `proxy request failed (${code})` : 'proxy request failed';
+  }
+  return error?.message || error?.name || 'request failed';
+}
+
+class YahooQuoteSummaryClient {
+  constructor({
+    userAgent = 'Mozilla/5.0',
+    resolveProxyString = () => '',
+    directRequest = requestHttpsText,
+    proxyRequest = requestCurlText,
+    now = Date.now,
+    cooldownMs = DEFAULT_COOLDOWN_MS,
+    sessionTtlMs = DEFAULT_SESSION_TTL_MS,
+    requestSpacingMs = DEFAULT_REQUEST_SPACING_MS,
+    sleepFn = sleep,
+    logger = console,
+  } = {}) {
+    this.userAgent = userAgent;
+    this.resolveProxyString = resolveProxyString;
+    this.directRequest = directRequest;
+    this.proxyRequest = proxyRequest;
+    this.now = now;
+    this.cooldownMs = cooldownMs;
+    this.sessionTtlMs = sessionTtlMs;
+    this.requestSpacingMs = requestSpacingMs;
+    this.sleep = sleepFn;
+    this.logger = logger;
+    this.states = {
+      direct: { session: null, sessionPromise: null, cooldownUntil: 0 },
+      proxy: { session: null, sessionPromise: null, cooldownUntil: 0 },
+    };
+  }
+
+  async _request(transport, url, headers, proxy) {
+    const request = transport === 'direct' ? this.directRequest : this.proxyRequest;
+    if (this.requestSpacingMs > 0) await this.sleep(this.requestSpacingMs);
+    return request(url, {
+      headers: {
+        'User-Agent': this.userAgent,
+        Accept: 'application/json',
+        ...headers,
+      },
+      timeoutMs: transport === 'direct' ? 12_000 : 15_000,
+      proxy,
+    });
+  }
+
+  async _bootstrapSession(transport, proxy) {
+    const cookieResponse = await this._request(transport, YAHOO_COOKIE_URL, {}, proxy);
+    const cookie = cookieHeaderFromResponse(cookieResponse);
+    if (!cookie) throw new Error(`cookie bootstrap HTTP ${cookieResponse?.status || 0}`);
+
+    const crumbResponse = await this._request(
+      transport,
+      YAHOO_CRUMB_URL,
+      { Cookie: cookie, Accept: 'text/plain,*/*' },
+      proxy,
+    );
+    const crumb = crumbResponse?.status === 200 ? validCrumb(crumbResponse.body) : null;
+    if (!crumb) throw new Error(`crumb bootstrap HTTP ${crumbResponse?.status || 0}`);
+
+    return { cookie, crumb, fetchedAt: this.now() };
+  }
+
+  async _getSession(transport, proxy, forceRefresh = false) {
+    const state = this.states[transport];
+    if (forceRefresh) state.session = null;
+    if (
+      state.session
+      && this.now() - state.session.fetchedAt < this.sessionTtlMs
+    ) return state.session;
+    if (state.sessionPromise) return state.sessionPromise;
+
+    state.sessionPromise = this._bootstrapSession(transport, proxy);
+    try {
+      state.session = await state.sessionPromise;
+      return state.session;
+    } finally {
+      state.sessionPromise = null;
+    }
+  }
+
+  async _fetchVia(transport, symbol, proxy = '') {
+    const state = this.states[transport];
+    if (this.now() < state.cooldownUntil) return { kind: 'cooldown', value: null };
+
+    let lastFailure = 'unknown';
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const session = await this._getSession(transport, proxy, attempt > 0);
+        const query = new URLSearchParams({
+          modules: YAHOO_SUMMARY_MODULES,
+          crumb: session.crumb,
+        });
+        const response = await this._request(
+          transport,
+          `${YAHOO_SUMMARY_BASE_URL}/${encodeURIComponent(symbol)}?${query}`,
+          { Cookie: session.cookie },
+          proxy,
+        );
+        if (response.status === 401 && attempt === 0) {
+          lastFailure = responseFailure(response);
+          continue;
+        }
+        if (response.status !== 200) {
+          lastFailure = responseFailure(response);
+          break;
+        }
+
+        const parsed = parseQuoteSummary(response.body);
+        if (parsed.kind === 'success') {
+          state.cooldownUntil = 0;
+          return {
+            kind: 'success',
+            value: {
+              ...parsed.value,
+              source: `yahoo_quote_summary_authenticated_${transport}`,
+            },
+          };
+        }
+        if (parsed.kind === 'no_data') return parsed;
+        lastFailure = parsed.kind;
+        break;
+      } catch (error) {
+        lastFailure = transportFailure(error, transport);
+        break;
+      }
+    }
+
+    state.session = null;
+    state.cooldownUntil = this.now() + this.cooldownMs;
+    this.logger.warn(
+      `[Sector] Yahoo authenticated ${transport} route unavailable (${lastFailure}); cooldown ${Math.round(this.cooldownMs / 60_000)}min`,
+      { transport, failure: lastFailure },
+    );
+    return { kind: 'failed', value: null };
+  }
+
+  async fetch(symbol) {
+    const direct = await this._fetchVia('direct', symbol);
+    if (direct.kind === 'success' || direct.kind === 'no_data') return direct.value;
+
+    const proxy = this.resolveProxyString();
+    if (!proxy) return null;
+    const proxied = await this._fetchVia('proxy', symbol, proxy);
+    return proxied.kind === 'success' ? proxied.value : null;
+  }
+}
+
+function buildSectorValuationCoverage({
+  valuationCount,
+  expectedCount,
+  fetchedAt,
+  sources,
+}) {
+  const count = Number.isFinite(valuationCount) ? Math.max(0, valuationCount) : 0;
+  const expected = Number.isFinite(expectedCount) ? Math.max(0, expectedCount) : 0;
+  const orderedSources = [...new Set((sources || []).filter(Boolean))].sort();
+  const source = orderedSources.length > 0
+    ? orderedSources.join('+')
+    : 'yahoo_quote_summary_authenticated';
+
+  if (count <= 0) {
+    return {
+      valuationCount: 0,
+      expectedValuationCount: expected,
+      sourceStatus: 'degraded',
+      source,
+      fetchedAt,
+      stale: false,
+      seedSourceState: 'error',
+      errorCode: 'SECTOR_VALUATIONS_UNAVAILABLE',
+    };
+  }
+  if (count < expected) {
+    return {
+      valuationCount: count,
+      expectedValuationCount: expected,
+      sourceStatus: 'partial',
+      source,
+      fetchedAt,
+      stale: false,
+      seedSourceState: 'partial',
+      errorCode: 'SECTOR_VALUATIONS_PARTIAL',
+    };
+  }
+  return {
+    valuationCount: count,
+    expectedValuationCount: expected,
+    sourceStatus: 'ok',
+    source,
+    fetchedAt,
+    stale: false,
+    seedSourceState: 'ok',
+    errorCode: null,
+  };
+}
+
+function buildSectorValuationPublication({
+  sectors,
+  valuations,
+  valuationCoverage,
+}) {
+  const {
+    seedSourceState,
+    errorCode,
+    ...publishedValuationCoverage
+  } = valuationCoverage;
+  return {
+    payload: {
+      sectors,
+      valuations,
+      valuationCoverage: publishedValuationCoverage,
+    },
+    meta: {
+      fetchedAt: valuationCoverage.fetchedAt,
+      recordCount: sectors.length,
+      sectorRecordCount: sectors.length,
+      valuationRecordCount: valuationCoverage.valuationCount,
+      expectedValuationRecordCount: valuationCoverage.expectedValuationCount,
+      valuationSourceStatus: valuationCoverage.sourceStatus,
+      valuationSource: valuationCoverage.source,
+      sourceState: seedSourceState,
+      sourceVersion: 'market-sectors',
+      ...(errorCode ? { errorCode } : {}),
+    },
+  };
+}
+
+module.exports = {
+  YahooQuoteSummaryClient,
+  buildSectorValuationCoverage,
+  buildSectorValuationPublication,
+  parseCurlResponse,
+  parseQuoteSummary,
+  requestHttpsText,
+  requestCurlText,
+};

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -29,6 +29,7 @@ const {
   YahooQuoteSummaryClient,
   buildSectorValuationCoverage,
   buildSectorValuationPublication,
+  collectSectorValuations,
 } = require('./_yahoo-sector-valuations.cjs');
 const { countryNameToIso2 } = require('./shared/country-name-to-iso2.cjs');
 const {
@@ -2340,25 +2341,22 @@ async function seedSectorSummary() {
     return 0;
   }
 
-  const valuations = {};
-  const valuationSources = new Set();
-  let valCount = 0;
-  for (const s of SECTOR_SYMBOLS) {
-    const raw = await fetchYahooQuoteSummary(s);
-    const parsed = parseSectorValuation(raw);
-    if (parsed) {
-      valuations[s] = parsed;
-      if (raw?.source) valuationSources.add(raw.source);
-      valCount++;
-    }
-    await sleep(150);
-  }
+  const {
+    valuations,
+    valuationSources,
+    valuationCount: valCount,
+  } = await collectSectorValuations({
+    symbols: SECTOR_SYMBOLS,
+    fetchValue: fetchYahooQuoteSummary,
+    parseValue: parseSectorValuation,
+    sleepFn: sleep,
+  });
 
   const valuationCoverage = buildSectorValuationCoverage({
     valuationCount: valCount,
     expectedCount: SECTOR_SYMBOLS.length,
     fetchedAt: Date.now(),
-    sources: [...valuationSources],
+    sources: valuationSources,
   });
   const { payload, meta: sectorMeta } = buildSectorValuationPublication({
     sectors,

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -21,12 +21,15 @@ const zlib = require('zlib');
 const path = require('path');
 const { readFileSync } = require('fs');
 const { execFile } = require('child_process');
-const { promisify } = require('util');
-const execFileAsync = promisify(execFile);
 const crypto = require('crypto');
 const v8 = require('v8');
 const { WebSocketServer, WebSocket } = require('ws');
 const { parseProxyConfig, resolveProxyString } = require('./_proxy-utils.cjs');
+const {
+  YahooQuoteSummaryClient,
+  buildSectorValuationCoverage,
+  buildSectorValuationPublication,
+} = require('./_yahoo-sector-valuations.cjs');
 const { countryNameToIso2 } = require('./shared/country-name-to-iso2.cjs');
 const {
   buildDedupMaterial,
@@ -2022,8 +2025,6 @@ function _parseYahooChartJson(body) {
 const _YAHOO_PROXY_COOLDOWN_MS = 5 * 60 * 1000;
 let _yahooConnectProxyFailCount = 0;   // fetchYahooChartDirect via gate.decodo.com (CONNECT)
 let _yahooConnectProxyCooldownUntil = 0;
-let _yahooCurlProxyFailCount = 0;      // fetchYahooQuoteSummary via us.decodo.com (curl)
-let _yahooCurlProxyCooldownUntil = 0;
 
 function _fetchYahooChartNoProxy(symbol, query = '') {
   return new Promise((resolve) => {
@@ -2069,113 +2070,24 @@ function fetchYahooChartDirect(symbol, query = '') {
   });
 }
 
-// Yahoo's /v10 quoteSummary 401s on Railway container IPs (seen 2026-04-16
-// logs — all 12 sector ETFs failing). Direct first, then curl via Decodo
-// us.decodo.com. Must be curl (NOT CONNECT): Yahoo's edge blocks Decodo's
-// CONNECT egress (gate.decodo.com) but accepts the curl egress — probed
-// 2026-04-16, see scripts/_yahoo-fetch.mjs header.
-function fetchYahooQuoteSummary(symbol) {
-  return new Promise((resolve) => {
-    const modules = 'summaryDetail,defaultKeyStatistics';
-    const url = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(symbol)}?modules=${modules}`;
-    let settled = false;
-    const settle = (value) => { if (settled) return; settled = true; resolve(value); };
-    const req = https.get(url, {
-      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-      timeout: 12000,
-    }, (resp) => {
-      if (resp.statusCode !== 200) {
-        resp.resume();
-        logThrottled('warn', `yahoo-summary-${resp.statusCode}:${symbol}`, `[Sector] Yahoo quoteSummary ${symbol} HTTP ${resp.statusCode}`);
-        return settle(_yahooQuoteSummaryProxyFallback(symbol, url));
-      }
-      let body = '';
-      resp.on('data', (chunk) => { body += chunk; });
-      resp.on('end', () => {
-        try {
-          const data = JSON.parse(body);
-          const result = data?.quoteSummary?.result?.[0];
-          if (!result) return settle(null); // app-level "no data" — proxy won't change it
-          const sd = result.summaryDetail || {};
-          const ks = result.defaultKeyStatistics || {};
-          const raw = (obj) => typeof obj === 'object' && obj !== null ? (obj.raw ?? obj.fmt ?? null) : (typeof obj === 'number' ? obj : null);
-          settle({
-            trailingPE: raw(sd.trailingPE),
-            forwardPE: raw(sd.forwardPE),
-            beta: raw(sd.beta) ?? raw(ks.beta3Year),
-            ytdReturn: raw(ks.ytdReturn),
-            threeYearReturn: raw(ks.threeYearAverageReturn),
-            fiveYearReturn: raw(ks.fiveYearAverageReturn),
-          });
-        } catch { settle(_yahooQuoteSummaryProxyFallback(symbol, url)); }
-      });
-    });
-    req.on('error', (err) => { if (settled) return; logThrottled('warn', `yahoo-summary-err:${symbol}`, `[Sector] Yahoo quoteSummary ${symbol} error: ${err.message}`); settle(_yahooQuoteSummaryProxyFallback(symbol, url)); });
-    req.on('timeout', () => { if (settled) return; req.destroy(); logThrottled('warn', `yahoo-summary-timeout:${symbol}`, `[Sector] Yahoo quoteSummary ${symbol} timeout`); settle(_yahooQuoteSummaryProxyFallback(symbol, url)); });
-  });
-}
+// Yahoo quoteSummary now requires a cookie + crumb session. The client caches
+// that session, refreshes it once on 401, then cools the whole route down so a
+// single auth failure cannot produce 12 direct + 12 proxy retries per cycle.
+// The Decodo fallback performs the same authenticated handshake through curl;
+// proxy credentials remain process-local and are never included in logs.
+const _yahooQuoteSummaryClient = new YahooQuoteSummaryClient({
+  userAgent: CHROME_UA,
+  resolveProxyString,
+  cooldownMs: _YAHOO_PROXY_COOLDOWN_MS,
+  logger: {
+    warn(message, { transport }) {
+      logThrottled('warn', `sector-yahoo-auth-${transport}`, message);
+    },
+  },
+});
 
-// Async so the curl call doesn't block the relay event loop. Returns a
-// Promise; resolve(promise) in the caller chains the Promise state through
-// to fetchYahooQuoteSummary's outer Promise, so awaiting fetchYahoo* in
-// seedSectorSummary yields the event loop during the curl round-trip.
-async function _yahooQuoteSummaryProxyFallback(symbol, url) {
-  const proxyAuth = resolveProxyString();
-  if (!proxyAuth) return null;
-  if (Date.now() < _yahooCurlProxyCooldownUntil) return null;
-  // Transport failures (timeout, proxy-connect refused, garbage body) must
-  // tick the cooldown too — the failure mode this PR hardens against would
-  // otherwise thrash through N curl attempts per tick with no backoff.
-  const bumpCooldown = () => {
-    _yahooCurlProxyFailCount++;
-    if (_yahooCurlProxyFailCount >= 5) {
-      _yahooCurlProxyCooldownUntil = Date.now() + _YAHOO_PROXY_COOLDOWN_MS;
-      _yahooCurlProxyFailCount = 0;
-      logThrottled('warn', 'sector-yahoo-proxy-cooldown', '[Sector] Yahoo curl proxy cooldown 5min after 5 failures');
-    }
-  };
-  try {
-    const args = [
-      '-sS', '--compressed', '--max-time', '15', '-L',
-      '-x', `http://${proxyAuth}`,
-      '-H', `User-Agent: ${CHROME_UA}`,
-      '-H', 'Accept: application/json',
-      '-w', '\n%{http_code}',
-      url,
-    ];
-    const { stdout } = await execFileAsync('curl', args, { encoding: 'utf8', timeout: 20000 });
-    const nl = stdout.lastIndexOf('\n');
-    const status = parseInt(stdout.slice(nl + 1).trim(), 10);
-    if (status < 200 || status >= 300) {
-      bumpCooldown();
-      logThrottled('warn', `sector-yahoo-proxy-${status}:${symbol}`, `[Sector] Yahoo quoteSummary ${symbol} proxy HTTP ${status}`);
-      return null;
-    }
-    const data = JSON.parse(stdout.slice(0, nl));
-    const result = data?.quoteSummary?.result?.[0];
-    if (!result) {
-      // Proxy reached Yahoo and got a valid 200 — route is healthy. Reset
-      // the counter even if this specific symbol has no data.
-      _yahooCurlProxyFailCount = 0;
-      return null;
-    }
-    _yahooCurlProxyFailCount = 0;
-    const sd = result.summaryDetail || {};
-    const ks = result.defaultKeyStatistics || {};
-    const raw = (obj) => typeof obj === 'object' && obj !== null ? (obj.raw ?? obj.fmt ?? null) : (typeof obj === 'number' ? obj : null);
-    return {
-      trailingPE: raw(sd.trailingPE),
-      forwardPE: raw(sd.forwardPE),
-      beta: raw(sd.beta) ?? raw(ks.beta3Year),
-      ytdReturn: raw(ks.ytdReturn),
-      threeYearReturn: raw(ks.threeYearAverageReturn),
-      fiveYearReturn: raw(ks.fiveYearAverageReturn),
-    };
-  } catch (err) {
-    bumpCooldown();
-    logThrottled('warn', `sector-yahoo-proxy-err:${symbol}`, `[Sector] Yahoo quoteSummary ${symbol} proxy error: ${err.message}`);
-    return null;
-  }
+function fetchYahooQuoteSummary(symbol) {
+  return _yahooQuoteSummaryClient.fetch(symbol);
 }
 
 function parseSectorValuation(raw) {
@@ -2429,15 +2341,30 @@ async function seedSectorSummary() {
   }
 
   const valuations = {};
+  const valuationSources = new Set();
   let valCount = 0;
   for (const s of SECTOR_SYMBOLS) {
     const raw = await fetchYahooQuoteSummary(s);
     const parsed = parseSectorValuation(raw);
-    if (parsed) { valuations[s] = parsed; valCount++; }
+    if (parsed) {
+      valuations[s] = parsed;
+      if (raw?.source) valuationSources.add(raw.source);
+      valCount++;
+    }
     await sleep(150);
   }
 
-  const payload = { sectors, valuations };
+  const valuationCoverage = buildSectorValuationCoverage({
+    valuationCount: valCount,
+    expectedCount: SECTOR_SYMBOLS.length,
+    fetchedAt: Date.now(),
+    sources: [...valuationSources],
+  });
+  const { payload, meta: sectorMeta } = buildSectorValuationPublication({
+    sectors,
+    valuations,
+    valuationCoverage,
+  });
   const ok = await envelopeWrite('market:sectors:v2', payload, MARKET_SEED_TTL, { recordCount: sectors.length, sourceVersion: 'market-sectors' });
   const quotesKey = `market:quotes:v1:${[...SECTOR_SYMBOLS].sort().join(',')}`;
   const sectorQuotes = sectors.map((s) => ({
@@ -2446,8 +2373,8 @@ async function seedSectorSummary() {
   }));
   const quotesPayload = { quotes: sectorQuotes, finnhubSkipped: false, skipReason: '', rateLimited: false };
   const ok2 = await envelopeWrite(quotesKey, quotesPayload, MARKET_SEED_TTL, { recordCount: sectorQuotes.length, sourceVersion: 'market-sectors' });
-  const ok3 = await upstashSet('seed-meta:market:sectors', { fetchedAt: Date.now(), recordCount: sectors.length }, 604800);
-  console.log(`[Market] Seeded ${sectors.length}/${SECTOR_SYMBOLS.length} sectors, ${valCount} valuations (redis: ${ok && ok2 && ok3 ? 'OK' : 'PARTIAL'})`);
+  const ok3 = await upstashSet('seed-meta:market:sectors', sectorMeta, 604800);
+  console.log(`[Market] Seeded ${sectors.length}/${SECTOR_SYMBOLS.length} sectors, ${valCount}/${SECTOR_SYMBOLS.length} valuations (${valuationCoverage.sourceStatus}; redis: ${ok && ok2 && ok3 ? 'OK' : 'PARTIAL'})`);
   return sectors.length;
 }
 

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -106,6 +106,49 @@ test('classifyKey: riskScores partial realtime family coverage → COVERAGE_PART
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+test('classifyKey: sector valuation partial/total loss degrades despite 12 price rows', () => {
+  for (const valuationState of [
+    { sourceState: 'partial', valuationRecordCount: 3 },
+    { sourceState: 'error', valuationRecordCount: 0 },
+  ]) {
+    const entry = classifyKey('sectors', BOOTSTRAP_KEYS.sectors, { allowOnDemand: false },
+      makeCtx({
+        strens: { [BOOTSTRAP_KEYS.sectors]: 1234 },
+        metaValues: {
+          'seed-meta:market:sectors': seedMeta({
+            recordCount: 12,
+            sectorRecordCount: 12,
+            expectedValuationRecordCount: 12,
+            ...valuationState,
+          }),
+        },
+      }));
+
+    assert.equal(entry.status, 'SEED_ERROR');
+    assert.equal(entry.records, 12, 'price coverage remains visible');
+    assert.equal(STATUS_COUNTS[entry.status], 'warn');
+  }
+});
+
+test('classifyKey: sector valuation recovery returns health to OK', () => {
+  const entry = classifyKey('sectors', BOOTSTRAP_KEYS.sectors, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.sectors]: 1234 },
+      metaValues: {
+        'seed-meta:market:sectors': seedMeta({
+          recordCount: 12,
+          sectorRecordCount: 12,
+          valuationRecordCount: 12,
+          expectedValuationRecordCount: 12,
+          sourceState: 'ok',
+        }),
+      },
+    }));
+
+  assert.equal(entry.status, 'OK');
+  assert.equal(entry.records, 12);
+});
+
 test('classifyKey: portwatchPortActivity below 174 countries → COVERAGE_PARTIAL', () => {
   const entry = classifyKey('portwatchPortActivity', STANDALONE_KEYS.portwatchPortActivity, { allowOnDemand: true },
     makeCtx({

--- a/tests/mcp-sector-valuation-coverage.test.mts
+++ b/tests/mcp-sector-valuation-coverage.test.mts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { CACHE_TOOLS } from '../api/mcp/registry/cache-tools';
+
+describe('get_market_data sector valuation coverage contract', () => {
+  it('declares the valuation coverage agents receive from market:sectors:v2', () => {
+    const tool = CACHE_TOOLS.find((candidate) => candidate.name === 'get_market_data');
+    assert.ok(tool);
+    assert.match(tool.description, /valuation coverage/i);
+
+    const sectors = tool.outputSchema?.properties?.data?.properties?.sectors;
+    const coverage = sectors?.properties?.valuationCoverage;
+    assert.ok(coverage, 'valuationCoverage must be discoverable in the MCP output schema');
+    assert.deepEqual(
+      Object.keys(coverage.properties || {}).sort(),
+      [
+        'expectedValuationCount',
+        'fetchedAt',
+        'source',
+        'sourceStatus',
+        'stale',
+        'valuationCount',
+      ],
+    );
+    assert.deepEqual(coverage.properties?.sourceStatus?.enum, ['ok', 'partial', 'degraded']);
+  });
+});

--- a/tests/mcp-sector-valuation-coverage.test.mts
+++ b/tests/mcp-sector-valuation-coverage.test.mts
@@ -1,7 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { CACHE_TOOLS } from '../api/mcp/registry/cache-tools';
+import {
+  applySectorValuationFreshness,
+  CACHE_TOOLS,
+} from '../api/mcp/registry/cache-tools';
 
 describe('get_market_data sector valuation coverage contract', () => {
   it('declares the valuation coverage agents receive from market:sectors:v2', () => {
@@ -24,5 +27,39 @@ describe('get_market_data sector valuation coverage contract', () => {
       ],
     );
     assert.deepEqual(coverage.properties?.sourceStatus?.enum, ['ok', 'partial', 'degraded']);
+  });
+
+  it('checks the sector seed metadata as part of aggregate market freshness', () => {
+    const tool = CACHE_TOOLS.find((candidate) => candidate.name === 'get_market_data');
+    assert.ok(tool);
+    const sectorCheck = tool._freshnessChecks?.find(
+      (check) => check.key === 'seed-meta:market:sectors',
+    );
+    assert.deepEqual(sectorCheck, {
+      key: 'seed-meta:market:sectors',
+      maxStaleMin: 30,
+    });
+  });
+
+  it('marks valuation coverage stale once the published snapshot ages past the sector budget', () => {
+    const now = 1_700_000_000_000;
+    const data = {
+      sectors: {
+        valuationCoverage: {
+          valuationCount: 12,
+          expectedValuationCount: 12,
+          sourceStatus: 'ok',
+          source: 'yahoo_quote_summary_authenticated_direct',
+          fetchedAt: now - 31 * 60_000,
+          stale: false,
+        },
+      },
+    };
+
+    applySectorValuationFreshness(data, now);
+    assert.equal(data.sectors.valuationCoverage.stale, true);
+
+    applySectorValuationFreshness(data, now - 31 * 60_000);
+    assert.equal(data.sectors.valuationCoverage.stale, false);
   });
 });

--- a/tests/sector-valuations.test.mjs
+++ b/tests/sector-valuations.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const src = readFileSync('scripts/ais-relay.cjs', 'utf8');
+const valuationFetcherSrc = readFileSync('scripts/_yahoo-sector-valuations.cjs', 'utf8');
 
 const extractFn = (name) => {
   const start = src.indexOf(`function ${name}(`);
@@ -96,42 +97,48 @@ describe('parseSectorValuation', () => {
   });
 });
 
-describe('fetchYahooQuoteSummary (static analysis)', () => {
+describe('authenticated Yahoo quoteSummary integration (static analysis)', () => {
   const fnStart = src.indexOf('function fetchYahooQuoteSummary(');
-  // Window sized to cover the direct-fetch block (headers, timeout, field
-  // extraction). Grown to 2000 when proxy-fallback wiring (settled guard,
-  // curl helper reference) was added — field extraction must stay visible.
-  const fnChunk = src.slice(fnStart, fnStart + 2000);
+  const fnChunk = src.slice(fnStart, fnStart + 300);
 
   it('exists in ais-relay.cjs', () => {
     assert.ok(fnStart > -1, 'fetchYahooQuoteSummary function not found');
   });
 
+  it('delegates to the cached authenticated client', () => {
+    assert.match(fnChunk, /_yahooQuoteSummaryClient\.fetch\(symbol\)/);
+  });
+
+  it('bootstraps both the Yahoo cookie and crumb before quoteSummary', () => {
+    assert.match(valuationFetcherSrc, /https:\/\/fc\.yahoo\.com/);
+    assert.match(valuationFetcherSrc, /\/v1\/test\/getcrumb/);
+    assert.match(valuationFetcherSrc, /v10\/finance\/quoteSummary/);
+  });
+
   it('uses summaryDetail and defaultKeyStatistics modules', () => {
-    assert.match(fnChunk, /summaryDetail/, 'should request summaryDetail module');
-    assert.match(fnChunk, /defaultKeyStatistics/, 'should request defaultKeyStatistics module');
+    assert.match(valuationFetcherSrc, /summaryDetail,defaultKeyStatistics/);
   });
 
-  it('uses v10/finance/quoteSummary endpoint', () => {
-    assert.match(fnChunk, /v10\/finance\/quoteSummary/, 'should call Yahoo quoteSummary v10 API');
-  });
-
-  it('extracts trailingPE, forwardPE, and beta', () => {
-    assert.match(fnChunk, /trailingPE/, 'should extract trailingPE');
-    assert.match(fnChunk, /forwardPE/, 'should extract forwardPE');
-    assert.match(fnChunk, /beta/, 'should extract beta');
-  });
-
-  it('extracts return metrics from defaultKeyStatistics', () => {
-    assert.match(fnChunk, /ytdReturn/, 'should extract ytdReturn');
+  it('extracts PE, beta, and return metrics', () => {
+    for (const field of [
+      'trailingPE',
+      'forwardPE',
+      'beta3Year',
+      'ytdReturn',
+      'threeYearAverageReturn',
+      'fiveYearAverageReturn',
+    ]) {
+      assert.match(valuationFetcherSrc, new RegExp(field));
+    }
   });
 
   it('includes User-Agent header', () => {
-    assert.match(fnChunk, /User-Agent/, 'should include User-Agent for Yahoo requests');
+    assert.match(valuationFetcherSrc, /'User-Agent'/);
   });
 
-  it('has timeout configured', () => {
-    assert.match(fnChunk, /timeout:\s*\d+/, 'should have a timeout set');
+  it('bounds route failures with one refresh and a cooldown', () => {
+    assert.match(valuationFetcherSrc, /attempt < 2/);
+    assert.match(valuationFetcherSrc, /cooldownUntil/);
   });
 });
 
@@ -150,6 +157,13 @@ describe('seedSectorSummary valuation integration (static analysis)', () => {
 
   it('includes valuations in payload', () => {
     assert.match(fnBody, /valuations/, 'payload should include valuations object');
+  });
+
+  it('publishes valuation coverage separately from sector price count', () => {
+    assert.match(fnBody, /buildSectorValuationPublication\(\{/);
+    assert.match(fnBody, /const \{ payload, meta: sectorMeta \}/);
+    assert.match(fnBody, /envelopeWrite\('market:sectors:v2', payload/);
+    assert.match(fnBody, /upstashSet\('seed-meta:market:sectors', sectorMeta/);
   });
 
   it('sleeps between Yahoo requests (rate limit)', () => {

--- a/tests/sector-valuations.test.mjs
+++ b/tests/sector-valuations.test.mjs
@@ -2,6 +2,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
+import { collectSectorValuations } from '../scripts/_yahoo-sector-valuations.cjs';
+
 const src = readFileSync('scripts/ais-relay.cjs', 'utf8');
 const valuationFetcherSrc = readFileSync('scripts/_yahoo-sector-valuations.cjs', 'utf8');
 
@@ -142,35 +144,38 @@ describe('authenticated Yahoo quoteSummary integration (static analysis)', () =>
   });
 });
 
-describe('seedSectorSummary valuation integration (static analysis)', () => {
-  const fnStart = src.indexOf('async function seedSectorSummary()');
-  const fnEnd = src.indexOf('\n// Gulf Quotes');
-  const fnBody = src.slice(fnStart, fnEnd);
+describe('sector valuation collection', () => {
+  it('executes one bounded, paced fetch per symbol and preserves source coverage', async () => {
+    const calls = [];
+    const delays = [];
+    const result = await collectSectorValuations({
+      symbols: ['XLK', 'XLF', 'XLE'],
+      fetchValue: async (symbol) => {
+        calls.push(symbol);
+        if (symbol === 'XLF') return null;
+        return {
+          source: symbol === 'XLK'
+            ? 'yahoo_quote_summary_authenticated_direct'
+            : 'yahoo_quote_summary_authenticated_proxy',
+          value: { trailingPE: symbol === 'XLK' ? 25 : 18 },
+        };
+      },
+      parseValue: (raw) => raw?.value ?? null,
+      sleepFn: async (ms) => delays.push(ms),
+    });
 
-  it('calls fetchYahooQuoteSummary for each sector', () => {
-    assert.match(fnBody, /fetchYahooQuoteSummary\(s\)/, 'should call fetchYahooQuoteSummary per sector');
-  });
-
-  it('calls parseSectorValuation on raw response', () => {
-    assert.match(fnBody, /parseSectorValuation\(raw\)/, 'should parse raw valuation data');
-  });
-
-  it('includes valuations in payload', () => {
-    assert.match(fnBody, /valuations/, 'payload should include valuations object');
-  });
-
-  it('publishes valuation coverage separately from sector price count', () => {
-    assert.match(fnBody, /buildSectorValuationPublication\(\{/);
-    assert.match(fnBody, /const \{ payload, meta: sectorMeta \}/);
-    assert.match(fnBody, /envelopeWrite\('market:sectors:v2', payload/);
-    assert.match(fnBody, /upstashSet\('seed-meta:market:sectors', sectorMeta/);
-  });
-
-  it('sleeps between Yahoo requests (rate limit)', () => {
-    assert.match(fnBody, /await sleep\(150\)/, 'should sleep 150ms between Yahoo calls');
-  });
-
-  it('logs valuation count', () => {
-    assert.match(fnBody, /valCount/, 'should log how many valuations were fetched');
+    assert.deepEqual(calls, ['XLK', 'XLF', 'XLE']);
+    assert.deepEqual(delays, [150, 150, 150]);
+    assert.deepEqual(result, {
+      valuations: {
+        XLK: { trailingPE: 25 },
+        XLE: { trailingPE: 18 },
+      },
+      valuationSources: [
+        'yahoo_quote_summary_authenticated_direct',
+        'yahoo_quote_summary_authenticated_proxy',
+      ],
+      valuationCount: 2,
+    });
   });
 });

--- a/tests/yahoo-sector-valuations.test.mjs
+++ b/tests/yahoo-sector-valuations.test.mjs
@@ -4,9 +4,12 @@ import { EventEmitter } from 'node:events';
 
 import {
   YahooQuoteSummaryClient,
+  buildCurlConfig,
   buildSectorValuationCoverage,
   buildSectorValuationPublication,
   parseCurlResponse,
+  parseQuoteSummary,
+  requestCurlText,
   requestHttpsText,
 } from '../scripts/_yahoo-sector-valuations.cjs';
 
@@ -98,6 +101,85 @@ describe('requestHttpsText', () => {
     );
     assert.equal(requestDestroyed, true);
     assert.equal(responseDestroyed, true);
+  });
+});
+
+describe('requestCurlText', () => {
+  function fakeCurlProcess(responseText, onSpawn) {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = new EventEmitter();
+    child.kill = () => {};
+    child.stdin.end = (config) => {
+      onSpawn(config);
+      queueMicrotask(() => {
+        child.stdout.emit('data', responseText);
+        child.emit('close', 0, null);
+      });
+    };
+    return child;
+  }
+
+  it('keeps proxy credentials and Yahoo cookies out of curl argv', async () => {
+    const secretProxy = 'proxy-user:proxy-password@proxy.example:10000';
+    const secretCookie = 'A3=private-cookie';
+    let spawnedArgs;
+    let config;
+    const responseText = 'HTTP/1.1 200 OK\r\ncontent-type: application/json\r\n\r\n{}\n__WM_HTTP_STATUS__:200';
+    const result = await requestCurlText('https://query1.finance.yahoo.com/test', {
+      proxy: secretProxy,
+      headers: { Cookie: secretCookie },
+      spawnFn: (command, args) => {
+        assert.equal(command, 'curl');
+        spawnedArgs = args;
+        return fakeCurlProcess(responseText, (input) => { config = input; });
+      },
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(spawnedArgs.includes(secretProxy), false);
+    assert.equal(spawnedArgs.some((arg) => arg.includes(secretCookie)), false);
+    assert.match(config, /proxy = "http:\/\/proxy-user:proxy-password@proxy\.example:10000"/);
+    assert.match(config, /header = "Cookie: A3=private-cookie"/);
+    assert.match(buildCurlConfig('https://query1.finance.yahoo.com/test', {
+      proxy: secretProxy,
+      headers: { Cookie: secretCookie },
+    }), /url = "https:\/\/query1\.finance\.yahoo\.com\/test"/);
+  });
+
+  it('bounds proxy response buffering', async () => {
+    let killed = false;
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = new EventEmitter();
+    child.kill = () => { killed = true; };
+    child.stdin.end = () => {
+      queueMicrotask(() => child.stdout.emit('data', Buffer.alloc(2 * 1024 * 1024 + 1, 'x')));
+    };
+
+    await assert.rejects(
+      requestCurlText('https://query1.finance.yahoo.com/test', {
+        proxy: 'proxy.example:10000',
+        spawnFn: () => child,
+      }),
+      (error) => error.code === 'RESPONSE_TOO_LARGE',
+    );
+    assert.equal(killed, true);
+  });
+});
+
+describe('parseQuoteSummary', () => {
+  it('classifies malformed upstream JSON as invalid_json', () => {
+    assert.deepEqual(parseQuoteSummary('{not-json'), { kind: 'invalid_json', value: null });
+  });
+
+  it('classifies an empty Yahoo result as no_data', () => {
+    assert.deepEqual(parseQuoteSummary(JSON.stringify({ quoteSummary: { result: [] } })), {
+      kind: 'no_data',
+      value: null,
+    });
   });
 });
 

--- a/tests/yahoo-sector-valuations.test.mjs
+++ b/tests/yahoo-sector-valuations.test.mjs
@@ -1,0 +1,337 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  YahooQuoteSummaryClient,
+  buildSectorValuationCoverage,
+  buildSectorValuationPublication,
+  parseCurlResponse,
+} from '../scripts/_yahoo-sector-valuations.cjs';
+
+const cookieResponse = () => ({
+  status: 404,
+  headers: { 'set-cookie': ['A3=test-cookie; Path=/; Secure'] },
+  body: '',
+});
+
+const crumbResponse = () => ({
+  status: 200,
+  headers: {},
+  body: 'test-crumb',
+});
+
+const unauthorizedResponse = () => ({
+  status: 401,
+  headers: {},
+  body: JSON.stringify({
+    finance: {
+      result: null,
+      error: { code: 'Unauthorized', description: 'Invalid Crumb' },
+    },
+  }),
+});
+
+const valuationResponse = () => ({
+  status: 200,
+  headers: {},
+  body: JSON.stringify({
+    quoteSummary: {
+      result: [{
+        summaryDetail: {
+          trailingPE: { raw: 31.2 },
+          forwardPE: { raw: 27.4 },
+        },
+        defaultKeyStatistics: {
+          beta3Year: { raw: 1.08 },
+          ytdReturn: { raw: 0.16 },
+          threeYearAverageReturn: { raw: 0.24 },
+          fiveYearAverageReturn: { raw: 0.18 },
+        },
+      }],
+      error: null,
+    },
+  }),
+});
+
+function requestKind(url) {
+  if (url.includes('fc.yahoo.com')) return 'cookie';
+  if (url.includes('/v1/test/getcrumb')) return 'crumb';
+  if (url.includes('/v10/finance/quoteSummary/')) return 'summary';
+  throw new Error(`Unexpected Yahoo URL: ${url}`);
+}
+
+describe('YahooQuoteSummaryClient', () => {
+  it('bounds direct and proxy Invalid Crumb retries, cools down, then recovers', async () => {
+    let now = 1_700_000_000_000;
+    let recovered = false;
+    const calls = [];
+    const warnings = [];
+
+    const makeRequest = (transport) => async (url) => {
+      const kind = requestKind(url);
+      calls.push(`${transport}:${kind}`);
+      if (kind === 'cookie') return cookieResponse();
+      if (kind === 'crumb') return crumbResponse();
+      return recovered ? valuationResponse() : unauthorizedResponse();
+    };
+
+    const client = new YahooQuoteSummaryClient({
+      directRequest: makeRequest('direct'),
+      proxyRequest: makeRequest('proxy'),
+      resolveProxyString: () => 'redacted-proxy',
+      now: () => now,
+      cooldownMs: 300_000,
+      sleepFn: async () => {},
+      logger: { warn: (message, context) => warnings.push({ message, context }) },
+    });
+
+    assert.equal(await client.fetch('XLK'), null);
+    assert.equal(
+      calls.filter((call) => call === 'direct:summary').length,
+      2,
+      'a direct 401 refreshes the session exactly once',
+    );
+    assert.equal(
+      calls.filter((call) => call === 'proxy:summary').length,
+      2,
+      'a proxy 401 refreshes the session exactly once',
+    );
+    assert.equal(warnings.length, 2, 'one bounded warning is emitted per failed route');
+    assert.deepEqual(
+      warnings.map((warning) => warning.context.transport),
+      ['direct', 'proxy'],
+      'route identity is structured rather than parsed from log text',
+    );
+
+    const callsAfterFailure = calls.length;
+    assert.equal(await client.fetch('XLF'), null);
+    assert.equal(calls.length, callsAfterFailure, 'cooldown prevents per-symbol retry storms');
+
+    recovered = true;
+    now += 300_001;
+    const recoveredValue = await client.fetch('XLE');
+    assert.deepEqual(recoveredValue, {
+      trailingPE: 31.2,
+      forwardPE: 27.4,
+      beta: 1.08,
+      ytdReturn: 0.16,
+      threeYearReturn: 0.24,
+      fiveYearReturn: 0.18,
+      source: 'yahoo_quote_summary_authenticated_direct',
+    });
+  });
+
+  it('never includes proxy credentials in transport failure logs', async () => {
+    const secretProxy = 'proxy-user:proxy-password@proxy.example:10000';
+    const warnings = [];
+    const client = new YahooQuoteSummaryClient({
+      directRequest: async () => ({ status: 503, headers: {}, body: '' }),
+      proxyRequest: async () => {
+        throw new Error(`Command failed: curl -x http://${secretProxy}`);
+      },
+      resolveProxyString: () => secretProxy,
+      sleepFn: async () => {},
+      logger: { warn: (message, context) => warnings.push({ message, context }) },
+    });
+
+    assert.equal(await client.fetch('XLK'), null);
+    assert.equal(warnings.at(-1).context.transport, 'proxy');
+    assert.doesNotMatch(JSON.stringify(warnings), /proxy-user|proxy-password/);
+  });
+
+  it('falls back to an authenticated proxy route and forwards its session', async () => {
+    const proxyCalls = [];
+    const client = new YahooQuoteSummaryClient({
+      directRequest: async () => ({ status: 503, headers: {}, body: '' }),
+      proxyRequest: async (url, options) => {
+        proxyCalls.push({ url, options });
+        const kind = requestKind(url);
+        if (kind === 'cookie') return cookieResponse();
+        if (kind === 'crumb') return crumbResponse();
+        return valuationResponse();
+      },
+      resolveProxyString: () => 'proxy-user:proxy-password@proxy.example:10000',
+      sleepFn: async () => {},
+      logger: { warn() {} },
+    });
+
+    const value = await client.fetch('XLK');
+    assert.equal(value?.source, 'yahoo_quote_summary_authenticated_proxy');
+    assert.equal(proxyCalls.length, 3);
+    assert.ok(proxyCalls.every((call) => call.options.proxy.includes('proxy.example')));
+    assert.match(proxyCalls[2].url, /crumb=test-crumb/);
+    assert.equal(proxyCalls[2].options.headers.Cookie, 'A3=test-cookie');
+  });
+
+  it('reuses an authenticated session until its TTL expires', async () => {
+    let now = 1_700_000_000_000;
+    const calls = [];
+    const client = new YahooQuoteSummaryClient({
+      directRequest: async (url) => {
+        const kind = requestKind(url);
+        calls.push(kind);
+        if (kind === 'cookie') return cookieResponse();
+        if (kind === 'crumb') return crumbResponse();
+        return valuationResponse();
+      },
+      now: () => now,
+      sessionTtlMs: 60_000,
+      sleepFn: async () => {},
+    });
+
+    await client.fetch('XLK');
+    await client.fetch('XLF');
+    assert.equal(calls.filter((call) => call === 'cookie').length, 1);
+    assert.equal(calls.filter((call) => call === 'crumb').length, 1);
+    assert.equal(calls.filter((call) => call === 'summary').length, 2);
+
+    now += 60_001;
+    await client.fetch('XLE');
+    assert.equal(calls.filter((call) => call === 'cookie').length, 2);
+    assert.equal(calls.filter((call) => call === 'crumb').length, 2);
+  });
+
+  it('paces every Yahoo authentication and summary request', async () => {
+    const delays = [];
+    const client = new YahooQuoteSummaryClient({
+      directRequest: async (url) => {
+        const kind = requestKind(url);
+        if (kind === 'cookie') return cookieResponse();
+        if (kind === 'crumb') return crumbResponse();
+        return valuationResponse();
+      },
+      requestSpacingMs: 150,
+      sleepFn: async (ms) => delays.push(ms),
+    });
+
+    await client.fetch('XLK');
+    assert.deepEqual(delays, [150, 150, 150]);
+  });
+});
+
+describe('parseCurlResponse', () => {
+  it('ignores the proxy CONNECT preamble and parses the upstream response', () => {
+    const parsed = parseCurlResponse([
+      'HTTP/1.1 200 Connection established',
+      '',
+      'HTTP/2 401',
+      'content-type: application/json',
+      'set-cookie: A3=proxy-cookie; Path=/',
+      '',
+      '{"finance":{"error":{"description":"Invalid Crumb"}}}',
+      '__WM_HTTP_STATUS__:401',
+    ].join('\r\n').replace('\r\n__WM_HTTP_STATUS__:', '\n__WM_HTTP_STATUS__:'));
+
+    assert.equal(parsed.status, 401);
+    assert.deepEqual(parsed.headers['set-cookie'], ['A3=proxy-cookie; Path=/']);
+    assert.equal(
+      JSON.parse(parsed.body).finance.error.description,
+      'Invalid Crumb',
+    );
+  });
+});
+
+describe('buildSectorValuationCoverage', () => {
+  const fetchedAt = 1_700_000_000_000;
+
+  it('marks partial valuation coverage separately from sector prices', () => {
+    assert.deepEqual(buildSectorValuationCoverage({
+      valuationCount: 3,
+      expectedCount: 12,
+      fetchedAt,
+      sources: ['yahoo_quote_summary_authenticated_direct'],
+    }), {
+      valuationCount: 3,
+      expectedValuationCount: 12,
+      sourceStatus: 'partial',
+      source: 'yahoo_quote_summary_authenticated_direct',
+      fetchedAt,
+      stale: false,
+      seedSourceState: 'partial',
+      errorCode: 'SECTOR_VALUATIONS_PARTIAL',
+    });
+  });
+
+  it('marks total valuation loss degraded instead of healthy', () => {
+    assert.deepEqual(buildSectorValuationCoverage({
+      valuationCount: 0,
+      expectedCount: 12,
+      fetchedAt,
+      sources: [],
+    }), {
+      valuationCount: 0,
+      expectedValuationCount: 12,
+      sourceStatus: 'degraded',
+      source: 'yahoo_quote_summary_authenticated',
+      fetchedAt,
+      stale: false,
+      seedSourceState: 'error',
+      errorCode: 'SECTOR_VALUATIONS_UNAVAILABLE',
+    });
+  });
+
+  it('clears degraded state after full recovery', () => {
+    assert.deepEqual(buildSectorValuationCoverage({
+      valuationCount: 12,
+      expectedCount: 12,
+      fetchedAt,
+      sources: [
+        'yahoo_quote_summary_authenticated_proxy',
+        'yahoo_quote_summary_authenticated_direct',
+      ],
+    }), {
+      valuationCount: 12,
+      expectedValuationCount: 12,
+      sourceStatus: 'ok',
+      source: 'yahoo_quote_summary_authenticated_direct+yahoo_quote_summary_authenticated_proxy',
+      fetchedAt,
+      stale: false,
+      seedSourceState: 'ok',
+      errorCode: null,
+    });
+  });
+});
+
+describe('buildSectorValuationPublication', () => {
+  it('builds the exact cache payload and degraded seed metadata', () => {
+    const sectors = [{ symbol: 'XLK', name: 'XLK', change: 1.2 }];
+    const valuations = {};
+    const valuationCoverage = buildSectorValuationCoverage({
+      valuationCount: 0,
+      expectedCount: 12,
+      fetchedAt: 1_700_000_000_000,
+      sources: [],
+    });
+
+    assert.deepEqual(buildSectorValuationPublication({
+      sectors,
+      valuations,
+      valuationCoverage,
+    }), {
+      payload: {
+        sectors,
+        valuations,
+        valuationCoverage: {
+          valuationCount: 0,
+          expectedValuationCount: 12,
+          sourceStatus: 'degraded',
+          source: 'yahoo_quote_summary_authenticated',
+          fetchedAt: 1_700_000_000_000,
+          stale: false,
+        },
+      },
+      meta: {
+        fetchedAt: 1_700_000_000_000,
+        recordCount: 1,
+        sectorRecordCount: 1,
+        valuationRecordCount: 0,
+        expectedValuationRecordCount: 12,
+        valuationSourceStatus: 'degraded',
+        valuationSource: 'yahoo_quote_summary_authenticated',
+        sourceState: 'error',
+        sourceVersion: 'market-sectors',
+        errorCode: 'SECTOR_VALUATIONS_UNAVAILABLE',
+      },
+    });
+  });
+});

--- a/tests/yahoo-sector-valuations.test.mjs
+++ b/tests/yahoo-sector-valuations.test.mjs
@@ -1,11 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 
 import {
   YahooQuoteSummaryClient,
   buildSectorValuationCoverage,
   buildSectorValuationPublication,
   parseCurlResponse,
+  requestHttpsText,
 } from '../scripts/_yahoo-sector-valuations.cjs';
 
 const cookieResponse = () => ({
@@ -59,6 +61,45 @@ function requestKind(url) {
   if (url.includes('/v10/finance/quoteSummary/')) return 'summary';
   throw new Error(`Unexpected Yahoo URL: ${url}`);
 }
+
+describe('requestHttpsText', () => {
+  it('rejects and destroys direct responses larger than 2 MiB', async () => {
+    let requestDestroyed = false;
+    let responseDestroyed = false;
+    const httpsGet = (_url, _options, onResponse) => {
+      const request = new EventEmitter();
+      request.destroy = () => {
+        requestDestroyed = true;
+      };
+
+      queueMicrotask(() => {
+        const response = new EventEmitter();
+        response.statusCode = 200;
+        response.headers = {};
+        response.setEncoding = () => {};
+        response.destroy = () => {
+          responseDestroyed = true;
+        };
+        onResponse(response);
+        response.emit('data', 'a'.repeat(2 * 1024 * 1024));
+        response.emit('data', 'b');
+        response.emit('end');
+      });
+      return request;
+    };
+
+    await assert.rejects(
+      requestHttpsText('https://query1.finance.yahoo.com/test', { httpsGet }),
+      (error) => {
+        assert.equal(error.code, 'RESPONSE_TOO_LARGE');
+        assert.doesNotMatch(error.message, /a{100}/);
+        return true;
+      },
+    );
+    assert.equal(requestDestroyed, true);
+    assert.equal(responseDestroyed, true);
+  });
+});
 
 describe('YahooQuoteSummaryClient', () => {
   it('bounds direct and proxy Invalid Crumb retries, cools down, then recovers', async () => {


### PR DESCRIPTION
## Summary

Sector prices were publishing normally while every Yahoo valuation request failed with `401 Invalid Crumb`, leaving the dashboard with 12 healthy-looking sectors and zero valuation coverage. This restores valuation enrichment with Yahoo's authenticated cookie-and-crumb flow on both the direct and Decodo routes, while bounding retries and preventing proxy credentials from reaching logs.

Valuation health is now independent from price coverage: the cache payload and seed metadata report valuation count, expected count, source, timestamp, and `ok`/`partial`/`degraded` status. Zero or partial valuation coverage degrades health even when all 12 sector price rows remain present, and full coverage clears the degraded state on the next successful cycle. The same coverage contract is declared on `get_market_data` so MCP clients can inspect it.

The relay image now includes the authenticated Yahoo helper explicitly; the Docker import-closure gate protects against a deploy-time startup failure.

Fixes #5903.

## Validation

- Authenticated direct Yahoo route returned valuation data for representative `XLK`, `XLF`, and `XLE` probes.
- The production-configured Decodo route returned the same representative data when direct transport was forced unavailable.
- A full direct probe returned non-empty valuation data for all 12 configured sector ETFs.
- 78 focused tests passed across Yahoo authentication/fallback, session reuse, secret-safe logging, coverage publication, health classification, MCP schema, and relay Docker closure.
- Full pre-push gates passed: frontend/API typechecks, CJS syntax, architectural boundaries, edge bundling/tests, changed tests, and version sync.

The repository-wide `npm run test:data` runner could not complete in this sandbox because `tsx` IPC was denied and a manual fallback encountered an unrelated Clerk timeout; the changed-test and pre-push gates completed cleanly.

## Post-deploy monitoring

Owner: WorldMonitor maintainer. Observe the first 15 minutes after the relay deployment, covering at least two consecutive five-minute sector seed cycles.

- Confirm both cycles log `Seeded 12/12 sectors, 12/12 valuations (ok; redis: OK)`.
- Confirm `seed-meta:market:sectors` reports `sectorRecordCount: 12`, `valuationRecordCount: 12`, `expectedValuationRecordCount: 12`, and `sourceState: ok`.
- Confirm `/api/health?compact=1` and `/api/seed-health` no longer classify sector valuations as `SEED_ERROR`.
- Watch for bounded `Yahoo authenticated direct|proxy route unavailable` warnings; they must not repeat per symbol or contain proxy credentials.

Rollback or repair if two consecutive post-deploy cycles report zero/partial valuation coverage, the relay fails its startup health check, or the authenticated routes remain in cooldown. Production acceptance for #5903 is complete only after those two consecutive non-empty cycles; this PR does not mutate production or claim that post-merge proof in advance.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
