### PR TITLE
fix(ci): replace invalid Actions pin with the commit SHA it resolves to

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -85,7 +85,7 @@ jobs:
           targets: ${{ contains(matrix.platform, 'macos') && 'aarch64-apple-darwin,x86_64-apple-darwin' || (matrix.label == 'Linux-ARM64' && 'aarch64-unknown-linux-gnu' || '') }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db
+        uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
         with:
           workspaces: './src-tauri -> target'
           cache-on-failure: true
@@ -202,7 +202,7 @@ jobs:
       # ── Build: Full variant (signed) ──
       - name: Build Tauri app (full, signed)
         if: env.BUILD_VARIANT == 'full' && steps.apple-signing.outputs.available == 'true' && env.SKIP_SIGNING != 'true'
-        uses: tauri-apps/tauri-action@79c624843491f12ae9d63592534ed49df3bc4adb
+        uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_VARIANT: full
@@ -227,7 +227,7 @@ jobs:
       # ── Build: Full variant (unsigned — no Apple certs) ──
       - name: Build Tauri app (full, unsigned)
         if: env.BUILD_VARIANT == 'full' && (steps.apple-signing.outputs.available != 'true' || env.SKIP_SIGNING == 'true')
-        uses: tauri-apps/tauri-action@79c624843491f12ae9d63592534ed49df3bc4adb
+        uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_VARIANT: full
@@ -246,7 +246,7 @@ jobs:
       # ── Build: Tech variant (signed) ──
       - name: Build Tauri app (tech, signed)
         if: env.BUILD_VARIANT == 'tech' && steps.apple-signing.outputs.available == 'true' && env.SKIP_SIGNING != 'true'
-        uses: tauri-apps/tauri-action@79c624843491f12ae9d63592534ed49df3bc4adb
+        uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_VARIANT: tech
@@ -272,7 +272,7 @@ jobs:
       # ── Build: Tech variant (unsigned — no Apple certs) ──
       - name: Build Tauri app (tech, unsigned)
         if: env.BUILD_VARIANT == 'tech' && (steps.apple-signing.outputs.available != 'true' || env.SKIP_SIGNING == 'true')
-        uses: tauri-apps/tauri-action@79c624843491f12ae9d63592534ed49df3bc4adb
+        uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_VARIANT: tech

--- a/.github/workflows/test-linux-app.yml
+++ b/.github/workflows/test-linux-app.yml
@@ -46,7 +46,7 @@ jobs:
           toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db
+        uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
         with:
           workspaces: './src-tauri -> target'
           cache-on-failure: true
@@ -77,7 +77,7 @@ jobs:
         run: bash scripts/download-node.sh --target "$NODE_TARGET"
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@79c624843491f12ae9d63592534ed49df3bc4adb
+        uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VITE_VARIANT: full

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -290,7 +290,7 @@ jobs:
         with:
           toolchain: stable
       - name: Rust cache
-        uses: swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db
+        uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
         with:
           workspaces: './src-tauri -> target'
           cache-on-failure: true


### PR DESCRIPTION
## Problem

These workflow `uses:` pins are invalid as written. Each item below shows the current value, why it is wrong, and the correct ref that must be used instead.

### 1. `.github/workflows/build-desktop.yml`

**Current (invalid):**

```yaml
uses: swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db
```

**Why this is wrong:**

- `ad397744b0d591a723ab90405b7247fac0e6b8db` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `779680da715d629ac1d338a641029a2f4372abb5`.

**Correct pin:**

```yaml
uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
```

### 2. `.github/workflows/build-desktop.yml`

**Current (invalid):**

```yaml
uses: tauri-apps/tauri-action@79c624843491f12ae9d63592534ed49df3bc4adb
```

**Why this is wrong:**

- `79c624843491f12ae9d63592534ed49df3bc4adb` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `73fb865345c54760d875b94642314f8c0c894afa`.

**Correct pin:**

```yaml
uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa
```

### 3. `.github/workflows/test-linux-app.yml`

**Current (invalid):**

```yaml
uses: swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db
```

**Why this is wrong:**

- `ad397744b0d591a723ab90405b7247fac0e6b8db` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `779680da715d629ac1d338a641029a2f4372abb5`.

**Correct pin:**

```yaml
uses: swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
```

### 4. `.github/workflows/test-linux-app.yml`

**Current (invalid):**

```yaml
uses: tauri-apps/tauri-action@79c624843491f12ae9d63592534ed49df3bc4adb
```

**Why this is wrong:**

- `79c624843491f12ae9d63592534ed49df3bc4adb` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `73fb865345c54760d875b94642314f8c0c894afa`.

**Correct pin:**

```yaml
uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa
```

## Test plan

- [ ] Each updated `uses:` ref resolves as a commit via the GitHub Commits API
- [ ] Relevant CI jobs on this branch look healthy
