### PR TITLE
fix(seed): recover OFAC sanctions freshness

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -506,11 +506,11 @@ const SEED_META = {
   comtradeFlows:       { key: 'seed-meta:trade:comtrade-flows',               maxStaleMin: 2880 }, // 24h cron; 2880min = 48h = 2x interval
   comtradeBilateralHs4: { key: 'seed-meta:comtrade:bilateral-hs4',             maxStaleMin: 50400, minRecordCount: 110 }, // 35d health budget for monthly seed; 40d payload/meta TTL leaves a 5d stale-but-queryable warning window. minRecordCount mirrors MIN_COUNTRY_COVERAGE in scripts/seed-comtrade-bilateral-hs4.mjs (110 of 197 clusters) so a shrunken run reads COVERAGE_PARTIAL, not OK — without it 3-of-197 and 197-of-197 were indistinguishable for the full 35d window.
   blsSeries:           { key: 'seed-meta:economic:bls-series',                maxStaleMin: 2880 }, // daily seed; 2880min = 48h = 2x interval
-  sanctionsPressure:   { key: 'seed-meta:sanctions:pressure',                 maxStaleMin: 720 },
+  sanctionsPressure:   { key: 'seed-meta:sanctions:pressure',                 maxStaleMin: 720 }, // 6h cron; 12h = 2× interval, before the 18h data TTL
   crossSourceSignals:  { key: 'seed-meta:intelligence:cross-source-signals',  maxStaleMin: 30 }, // 15min cron; 30min = 2x interval
   regionalSnapshots:   { key: 'seed-meta:intelligence:regional-snapshots',    maxStaleMin: 720 }, // 6h cron via seed-bundle-derived-signals; 720min = 12h = 2x interval
   regionalBriefs:      { key: 'seed-meta:intelligence:regional-briefs',      maxStaleMin: 20160 }, // weekly cron; 20160min = 14 days = 2x interval
-  sanctionsEntities:   { key: 'seed-meta:sanctions:entities',                 maxStaleMin: 1440 }, // 12h cron; 1440min = 24h = 2x interval
+  sanctionsEntities:   { key: 'seed-meta:sanctions:entities',                 maxStaleMin: 720 }, // same 6h producer; co-pinned with pressure so both alarm before the 18h TTL
   radiationWatch:      { key: 'seed-meta:radiation:observations',             maxStaleMin: 30 },
   groceryBasket:       { key: 'seed-meta:economic:grocery-basket',            maxStaleMin: 10080 }, // weekly seed; 10080 = 7 days
   bigmac:              { key: 'seed-meta:economic:bigmac',                    maxStaleMin: 10080 }, // weekly seed; 10080 = 7 days

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -165,6 +165,7 @@ const SEED_DOMAINS = {
   'thermal:escalation':       { key: 'seed-meta:thermal:escalation',       intervalMin: 180 },
   'radiation:observations':   { key: 'seed-meta:radiation:observations',   intervalMin: 15 },
   'sanctions:pressure':       { key: 'seed-meta:sanctions:pressure',       intervalMin: 360 },
+  'sanctions:entities':       { key: 'seed-meta:sanctions:entities',       intervalMin: 360 },
   'health:air-quality':       { key: 'seed-meta:health:air-quality',       intervalMin: 60 },  // hourly cron (shared seeder writes health + climate keys)
   'economic:grocery-basket':  { key: 'seed-meta:economic:grocery-basket',  intervalMin: 5040 }, // weekly seed; intervalMin = maxStaleMin / 2
   'economic:bigmac':          { key: 'seed-meta:economic:bigmac',          intervalMin: 5040 }, // weekly seed; intervalMin = maxStaleMin / 2

--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -250,6 +250,8 @@ function proxyFetch(url, proxyConfig, {
   maxResponseBytes = Infinity,
   timeoutMs = 20_000,
   signal,
+  connectTunnel = proxyConnectTunnel,
+  requestFn = https.request,
 } = {}) {
   const targetUrl = new URL(url);
 
@@ -257,7 +259,7 @@ function proxyFetch(url, proxyConfig, {
     return Promise.reject(signal.reason || new Error('aborted'));
   }
 
-  return proxyConnectTunnel(targetUrl.hostname, proxyConfig, { timeoutMs, signal }).then(({ socket: tlsSocket, destroy }) => {
+  return connectTunnel(targetUrl.hostname, proxyConfig, { timeoutMs, signal }).then(({ socket: tlsSocket, destroy }) => {
     return new Promise((resolve, reject) => {
       let settled = false;
       let onAbort = null;
@@ -287,7 +289,7 @@ function proxyFetch(url, proxyConfig, {
         reqHeaders['Content-Length'] = Buffer.byteLength(body);
       }
 
-      const req = https.request({
+      const req = requestFn({
         hostname: targetUrl.hostname,
         path: targetUrl.pathname + targetUrl.search,
         method,
@@ -303,6 +305,7 @@ function proxyFetch(url, proxyConfig, {
           (buffer) => resolveOnce({
             ok: resp.statusCode >= 200 && resp.statusCode < 300,
             status: resp.statusCode,
+            location: resp.headers.location || '',
             buffer,
             contentType: resp.headers['content-type'] || '',
           }),

--- a/scripts/_sanctions-source.mjs
+++ b/scripts/_sanctions-source.mjs
@@ -1,0 +1,160 @@
+import {
+  CHROME_UA,
+  httpRetryError,
+  isRetryableHttpStatus,
+  sleep,
+} from './_seed-utils.mjs';
+import {
+  parseProxyConfigForAttempt,
+  proxyFetch,
+} from './_proxy-utils.cjs';
+
+const OFAC_ACCEPT = 'application/xml, text/xml, */*';
+const OFAC_SIGNED_DOWNLOAD_TIMEOUT_MS = 45_000;
+// Native fetch follows the bootstrap redirect before returning the streaming
+// XML Response, so this signal remains attached during body consumption. Keep
+// the healthy direct path on the full bounded download budget.
+const OFAC_DIRECT_TIMEOUT_MS = OFAC_SIGNED_DOWNLOAD_TIMEOUT_MS;
+const OFAC_PROXY_TIMEOUT_MS = 10_000;
+const OFAC_PROXY_BOOTSTRAP_MAX_BYTES = 64 * 1024;
+const OFAC_DIRECT_MAX_ATTEMPTS = 2;
+const OFAC_PROXY_MAX_ATTEMPTS = 3;
+const OFAC_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const OFAC_SIGNED_DOWNLOAD_HOST = 'wc2h-sls-prod-public-published.s3.us-gov-west-1.amazonaws.com';
+
+export function resolveOfacProxyUrl(env = process.env) {
+  return env.OFAC_PROXY_URL || env.PROXY_URL || '';
+}
+
+function isRetryableProxyBootstrapStatus(status) {
+  // A different residential exit can recover an origin-level 403. A proxy
+  // CONNECT 407 is thrown separately with `proxyConnect: true` and is not
+  // retried, because rotating an exit cannot repair credentials.
+  return status === 403 || isRetryableHttpStatus(status);
+}
+
+function nonRetryableError(message) {
+  return Object.assign(new Error(message), { nonRetryable: true });
+}
+
+async function fetchDirectWithRetry(url, {
+  fetchFn,
+  maxAttempts,
+  sleepFn,
+  timeoutMs,
+}) {
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetchFn(url, {
+        headers: { 'User-Agent': CHROME_UA, Accept: OFAC_ACCEPT },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (response.ok) return response;
+      const error = httpRetryError(response, { maxRetryAfterMs: 5_000 });
+      try {
+        await response.body?.cancel();
+      } catch {
+        // Preserve the HTTP failure if response-body cleanup also fails.
+      }
+      throw error;
+    } catch (error) {
+      lastError = error;
+      if (error?.nonRetryable || attempt === maxAttempts) break;
+      await sleepFn(500 * attempt);
+    }
+  }
+  throw lastError;
+}
+
+function trustedSignedDownloadUrl(location, sourceUrl) {
+  let redirect;
+  try {
+    redirect = new URL(location, sourceUrl);
+  } catch {
+    throw nonRetryableError('OFAC proxy returned an invalid redirect URL');
+  }
+  if (redirect.protocol !== 'https:' || redirect.hostname !== OFAC_SIGNED_DOWNLOAD_HOST) {
+    throw nonRetryableError(`OFAC proxy returned an untrusted redirect host: ${redirect.hostname || 'missing'}`);
+  }
+  return redirect.href;
+}
+
+async function fetchRedirectViaProxy(sourceUrl, {
+  proxyFetchFn,
+  proxyUrl,
+  sleepFn,
+}) {
+  let lastError;
+  for (let attempt = 0; attempt < OFAC_PROXY_MAX_ATTEMPTS; attempt += 1) {
+    const proxyConfig = parseProxyConfigForAttempt(proxyUrl, attempt);
+    if (!proxyConfig) throw nonRetryableError('OFAC proxy configuration is invalid');
+    try {
+      const result = await proxyFetchFn(sourceUrl, proxyConfig, {
+        accept: OFAC_ACCEPT,
+        headers: { 'User-Agent': CHROME_UA },
+        maxResponseBytes: OFAC_PROXY_BOOTSTRAP_MAX_BYTES,
+        timeoutMs: OFAC_PROXY_TIMEOUT_MS,
+      });
+      if (OFAC_REDIRECT_STATUSES.has(result.status) && result.location) {
+        return trustedSignedDownloadUrl(result.location, sourceUrl);
+      }
+      const error = new Error(`OFAC proxy bootstrap HTTP ${result.status}`);
+      error.status = result.status;
+      error.nonRetryable = !isRetryableProxyBootstrapStatus(result.status);
+      throw error;
+    } catch (error) {
+      lastError = error;
+      // CONNECT-layer rejections are gateway auth/quota/policy failures. A
+      // different OFAC exit cannot repair them, and runSeed's outer withRetry
+      // recognizes only `nonRetryable`, so preserve that contract on escape.
+      if (error?.proxyConnect) error.nonRetryable = true;
+      if (error?.proxyConnect || error?.nonRetryable || attempt === OFAC_PROXY_MAX_ATTEMPTS - 1) break;
+      await sleepFn(500 * (attempt + 1));
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Fetch an OFAC Advanced XML source without ever buffering its large body.
+ *
+ * Direct fetch follows OFAC's signed S3 redirect and returns the streaming
+ * Response. If Railway's egress is rejected at the OFAC bootstrap host, the
+ * proxy is used only for that small redirect response. The signed S3 URL is
+ * host-validated, then fetched directly so the SAX consumer retains O(1)
+ * response-body memory.
+ */
+export async function fetchOfacSourceResponse(sourceUrl, {
+  fetchFn = globalThis.fetch,
+  proxyFetchFn = proxyFetch,
+  proxyUrl = resolveOfacProxyUrl(),
+  sleepFn = sleep,
+} = {}) {
+  let directError;
+  try {
+    return await fetchDirectWithRetry(sourceUrl, {
+      fetchFn,
+      maxAttempts: OFAC_DIRECT_MAX_ATTEMPTS,
+      sleepFn,
+      timeoutMs: OFAC_DIRECT_TIMEOUT_MS,
+    });
+  } catch (error) {
+    directError = error;
+  }
+
+  if (!proxyUrl) throw directError;
+  console.warn(`  OFAC direct fetch failed (${directError?.message || directError}); retrying redirect bootstrap via proxy`);
+
+  const signedUrl = await fetchRedirectViaProxy(sourceUrl, {
+    proxyFetchFn,
+    proxyUrl,
+    sleepFn,
+  });
+  return fetchDirectWithRetry(signedUrl, {
+    fetchFn,
+    maxAttempts: OFAC_DIRECT_MAX_ATTEMPTS,
+    sleepFn,
+    timeoutMs: OFAC_SIGNED_DOWNLOAD_TIMEOUT_MS,
+  });
+}

--- a/scripts/_sanctions-source.mjs
+++ b/scripts/_sanctions-source.mjs
@@ -37,6 +37,14 @@ function nonRetryableError(message) {
   return Object.assign(new Error(message), { nonRetryable: true });
 }
 
+function terminalFetchError(error) {
+  if (error && typeof error === 'object') {
+    error.nonRetryable = true;
+    return error;
+  }
+  return nonRetryableError(String(error));
+}
+
 async function fetchDirectWithRetry(url, {
   fetchFn,
   maxAttempts,
@@ -61,7 +69,7 @@ async function fetchDirectWithRetry(url, {
     } catch (error) {
       lastError = error;
       if (error?.nonRetryable || attempt === maxAttempts) break;
-      await sleepFn(500 * attempt);
+      await sleepFn(Math.max(500 * attempt, error.retryAfterMs ?? 0));
     }
   }
   throw lastError;
@@ -143,18 +151,24 @@ export async function fetchOfacSourceResponse(sourceUrl, {
     directError = error;
   }
 
-  if (!proxyUrl) throw directError;
+  if (!proxyUrl) throw terminalFetchError(directError);
   console.warn(`  OFAC direct fetch failed (${directError?.message || directError}); retrying redirect bootstrap via proxy`);
 
-  const signedUrl = await fetchRedirectViaProxy(sourceUrl, {
-    proxyFetchFn,
-    proxyUrl,
-    sleepFn,
-  });
-  return fetchDirectWithRetry(signedUrl, {
-    fetchFn,
-    maxAttempts: OFAC_DIRECT_MAX_ATTEMPTS,
-    sleepFn,
-    timeoutMs: OFAC_SIGNED_DOWNLOAD_TIMEOUT_MS,
-  });
+  try {
+    const signedUrl = await fetchRedirectViaProxy(sourceUrl, {
+      proxyFetchFn,
+      proxyUrl,
+      sleepFn,
+    });
+    return await fetchDirectWithRetry(signedUrl, {
+      fetchFn,
+      maxAttempts: OFAC_DIRECT_MAX_ATTEMPTS,
+      sleepFn,
+      timeoutMs: OFAC_SIGNED_DOWNLOAD_TIMEOUT_MS,
+    });
+  } catch (error) {
+    // The helper owns the complete bounded recovery ladder. Do not let
+    // runSeed's outer withRetry replay the same direct/proxy sequence.
+    throw terminalFetchError(error);
+  }
 }

--- a/scripts/seed-sanctions-pressure.mjs
+++ b/scripts/seed-sanctions-pressure.mjs
@@ -6,17 +6,20 @@
 // 120MB XML download against Railway's 512MB container limit.
 import sax from 'sax';
 
-import { CHROME_UA, loadEnvFile, runSeed, verifySeedKey, writeExtraKeyWithMeta } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed, verifySeedKey, writeExtraKeyWithMeta } from './_seed-utils.mjs';
+import { fetchOfacSourceResponse } from './_sanctions-source.mjs';
 
 loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'sanctions:pressure:v1';
 const STATE_KEY = 'sanctions:pressure:state:v1';
 const ENTITY_INDEX_KEY = 'sanctions:entities:v1';
+const ENTITY_INDEX_META_KEY = 'seed-meta:sanctions:entities';
 // Full ISO2 -> count map consumed by CII/country-risk scoring; do not replace
 // with the top-pressure display list written under CANONICAL_KEY.countries.
 const COUNTRY_COUNTS_KEY = 'sanctions:country-counts:v1';
-const CACHE_TTL = 15 * 60 * 60; // 15h — 3h buffer over 12h cron cadence (was 12h = 0 buffer)
+const COUNTRY_COUNTS_META_KEY = 'seed-meta:sanctions:country-counts';
+const CACHE_TTL = 18 * 60 * 60; // 18h — 3× live 6h cron; remains queryable after the 12h freshness alarm
 // Compact entity type codes for the lookup index (saves space vs full enum strings)
 const ET_CODE = {
   SANCTIONS_ENTITY_TYPE_VESSEL: 'vessel',
@@ -25,7 +28,6 @@ const ET_CODE = {
   SANCTIONS_ENTITY_TYPE_ENTITY: 'entity',
 };
 const DEFAULT_RECENT_LIMIT = 60;
-const OFAC_TIMEOUT_MS = 45_000;
 const PROGRAM_CODE_RE = /^[A-Z0-9][A-Z0-9-]{1,24}$/;
 
 const OFAC_SOURCES = [
@@ -120,11 +122,7 @@ function buildProgramPressure(entries) {
 async function fetchSource(source) {
   console.log(`  Fetching OFAC ${source.label}...`);
   const t0 = Date.now();
-  const response = await fetch(source.url, {
-    headers: { 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(OFAC_TIMEOUT_MS),
-  });
-  if (!response.ok) throw new Error(`OFAC ${source.label} HTTP ${response.status}`);
+  const response = await fetchOfacSourceResponse(source.url);
 
   return new Promise((resolve, reject) => {
     // strict=true: case-sensitive tag names. xmlns=false: we strip prefixes manually.
@@ -569,6 +567,15 @@ runSeed('sanctions', 'pressure', CANONICAL_KEY, fetchSanctionsPressure, {
       transform: (data) => data._state,
     },
   ],
+  // afterPublish owns these companion keys, so runSeed cannot infer them from
+  // extraKeys. Preserve their data and health metadata with the canonical
+  // last-good cohort when a later OFAC fetch fails.
+  preserveKeys: [
+    ENTITY_INDEX_KEY,
+    ENTITY_INDEX_META_KEY,
+    COUNTRY_COUNTS_KEY,
+    COUNTRY_COUNTS_META_KEY,
+  ],
   afterPublish: async (data, _ctx) => {
     // Write entity lookup index with seed-meta so health.js can monitor it.
     // Uses writeExtraKeyWithMeta rather than extraKeys because runSeed's extraKeys
@@ -579,6 +586,7 @@ runSeed('sanctions', 'pressure', CANONICAL_KEY, fetchSanctionsPressure, {
         data._entityIndex,
         CACHE_TTL,
         data._entityIndex.length,
+        ENTITY_INDEX_META_KEY,
       );
     }
     // Write full ISO2→count map for per-country sanctions lookup (no top-12 truncation).
@@ -588,6 +596,7 @@ runSeed('sanctions', 'pressure', CANONICAL_KEY, fetchSanctionsPressure, {
         data._countryCounts,
         CACHE_TTL,
         Object.keys(data._countryCounts).length,
+        COUNTRY_COUNTS_META_KEY,
       );
     }
     delete data._state;

--- a/scripts/seed-sanctions-pressure.mjs
+++ b/scripts/seed-sanctions-pressure.mjs
@@ -551,6 +551,11 @@ export function declareRecords(data) {
 
 runSeed('sanctions', 'pressure', CANONICAL_KEY, fetchSanctionsPressure, {
   ttlSeconds: CACHE_TTL,
+  // The bounded direct/proxy/signed recovery ladder can spend about 7 minutes
+  // across both serial XML sources. Keep its fetch deadline explicit and the
+  // lock alive longer so a slow recovery cannot leave a second run racing it.
+  lockTtlMs: 600_000,
+  fetchPhaseTimeoutMs: 480_000,
   validateFn: validate,
   sourceVersion: 'ofac-sls-advanced-xml-v1',
   recordCount: (data) => data.totalCount ?? 0,

--- a/tests/proxy-utils.test.mjs
+++ b/tests/proxy-utils.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import { createRequire } from 'node:module';
 import { Readable } from 'node:stream';
 import { describe, it } from 'node:test';
@@ -7,8 +8,26 @@ const {
   _readBoundedResponseStream,
   parseProxyConfig,
   parseProxyConfigForAttempt,
+  proxyFetch,
   resolveProxyString,
 } = createRequire(import.meta.url)('../scripts/_proxy-utils.cjs');
+
+function proxyFetchHarness(response, { maxResponseBytes = Infinity } = {}) {
+  let destroyed = 0;
+  return {
+    options: {
+      maxResponseBytes,
+      connectTunnel: async () => ({ socket: {}, destroy: () => { destroyed += 1; } }),
+      requestFn: (_options, onResponse) => {
+        const req = new EventEmitter();
+        req.end = () => queueMicrotask(() => onResponse(response));
+        req.write = () => {};
+        return req;
+      },
+    },
+    destroyed: () => destroyed,
+  };
+}
 
 describe('proxy utilities', () => {
   it('applies standard ports when URL parsing normalizes them away', () => {
@@ -132,5 +151,41 @@ describe('proxy utilities', () => {
       128,
     );
     assert.equal(exactLimit.byteLength, 128);
+  });
+
+  it('preserves redirect Location through proxyFetch and still bounds its body', async () => {
+    const redirectResponse = Readable.from([Buffer.from('redirect')]);
+    redirectResponse.statusCode = 302;
+    redirectResponse.headers = {
+      location: 'https://trusted.example/signed.xml',
+      'content-type': 'text/plain',
+    };
+    const redirectHarness = proxyFetchHarness(redirectResponse, { maxResponseBytes: 64 });
+
+    const redirect = await proxyFetch('https://origin.example/sdn.xml', {
+      host: 'proxy.example', port: 443, auth: 'user:pass', tls: true,
+    }, redirectHarness.options);
+
+    assert.deepEqual(redirect, {
+      ok: false,
+      status: 302,
+      location: 'https://trusted.example/signed.xml',
+      buffer: Buffer.from('redirect'),
+      contentType: 'text/plain',
+    });
+    assert.equal(redirectHarness.destroyed(), 1);
+
+    const oversizedResponse = Readable.from([Buffer.alloc(65)]);
+    oversizedResponse.statusCode = 302;
+    oversizedResponse.headers = { location: 'https://trusted.example/signed.xml' };
+    const oversizedHarness = proxyFetchHarness(oversizedResponse, { maxResponseBytes: 64 });
+
+    await assert.rejects(
+      proxyFetch('https://origin.example/sdn.xml', {
+        host: 'proxy.example', port: 443, auth: 'user:pass', tls: true,
+      }, oversizedHarness.options),
+      (error) => error.code === 'RESPONSE_TOO_LARGE',
+    );
+    assert.equal(oversizedHarness.destroyed(), 1);
   });
 });

--- a/tests/sanctions-pressure.test.mjs
+++ b/tests/sanctions-pressure.test.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 
 const handlerSrc = readFileSync('server/worldmonitor/sanctions/v1/list-sanctions-pressure.ts', 'utf8');
 const seedSrc = readFileSync('scripts/seed-sanctions-pressure.mjs', 'utf8');
+const healthSrc = readFileSync('api/health.js', 'utf8');
 
 // ---------------------------------------------------------------------------
 // Gold standard: handler must be Redis-read-only (no XML parsing, no live fetch)
@@ -54,10 +55,12 @@ describe('handler: _state stripping', () => {
 
   it('seed writes country counts only through afterPublish metadata path', () => {
     const extraKeysStart = seedSrc.indexOf('extraKeys: [');
+    const preserveStart = seedSrc.indexOf('preserveKeys: [', extraKeysStart);
     const afterPublishStart = seedSrc.indexOf('afterPublish: async');
-    assert.ok(extraKeysStart >= 0 && afterPublishStart > extraKeysStart, 'seed must define extraKeys before afterPublish');
+    assert.ok(extraKeysStart >= 0 && preserveStart > extraKeysStart && afterPublishStart > preserveStart,
+      'seed must define extraKeys, preservation, and afterPublish in order');
 
-    const extraKeysBlock = seedSrc.slice(extraKeysStart, afterPublishStart);
+    const extraKeysBlock = seedSrc.slice(extraKeysStart, preserveStart);
     assert.doesNotMatch(
       extraKeysBlock,
       /COUNTRY_COUNTS_KEY/,
@@ -68,6 +71,24 @@ describe('handler: _state stripping', () => {
       /writeExtraKeyWithMeta\(\s*COUNTRY_COUNTS_KEY/s,
       'afterPublish must keep writing COUNTRY_COUNTS_KEY with freshness metadata',
     );
+  });
+
+  it('preserves every afterPublish companion key and its seed metadata on failed runs', () => {
+    const preserveStart = seedSrc.indexOf('preserveKeys: [');
+    const preserveEnd = seedSrc.indexOf('afterPublish: async', preserveStart);
+    assert.ok(preserveStart >= 0 && preserveEnd > preserveStart,
+      'seed must declare afterPublish companion keys for runSeed preservation');
+
+    const preserveBlock = seedSrc.slice(preserveStart, preserveEnd);
+    for (const key of [
+      'ENTITY_INDEX_KEY',
+      'ENTITY_INDEX_META_KEY',
+      'COUNTRY_COUNTS_KEY',
+      'COUNTRY_COUNTS_META_KEY',
+    ]) {
+      assert.match(preserveBlock, new RegExp(`\\b${key}\\b`),
+        `${key} must retain last-good data or metadata when OFAC fetches fail`);
+    }
   });
 });
 
@@ -101,5 +122,29 @@ describe('sanctions seed: DEFAULT_RECENT_LIMIT vs MAX_ITEMS_LIMIT', () => {
       seedLimit <= handlerLimit,
       `DEFAULT_RECENT_LIMIT (${seedLimit}) must not exceed MAX_ITEMS_LIMIT (${handlerLimit}): entries above the handler limit are never served`,
     );
+  });
+});
+
+describe('sanctions seed: production freshness contract', () => {
+  function maxStaleMin(name) {
+    const match = healthSrc.match(new RegExp(`${name}:\\s*\\{[^}]*maxStaleMin:\\s*(\\d+)`));
+    assert.ok(match, `${name}.maxStaleMin must be declared`);
+    return Number(match[1]);
+  }
+
+  it('co-produced pressure and entity keys alarm on the same two-missed-run boundary', () => {
+    assert.equal(maxStaleMin('sanctionsPressure'), 720);
+    assert.equal(maxStaleMin('sanctionsEntities'), 720);
+  });
+
+  it('keeps data alive beyond both paired freshness alarms', () => {
+    const ttlMatch = seedSrc.match(/const CACHE_TTL\s*=\s*(\d+)\s*\*\s*60\s*\*\s*60/);
+    assert.ok(ttlMatch, 'sanctions CACHE_TTL must stay expressed in whole hours');
+    const ttlMinutes = Number(ttlMatch[1]) * 60;
+
+    assert.ok(ttlMinutes > maxStaleMin('sanctionsPressure'),
+      'canonical pressure data must still exist when STALE_SEED first alarms');
+    assert.ok(ttlMinutes > maxStaleMin('sanctionsEntities'),
+      'entity data must still exist when STALE_SEED first alarms');
   });
 });

--- a/tests/sanctions-pressure.test.mjs
+++ b/tests/sanctions-pressure.test.mjs
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs';
 const handlerSrc = readFileSync('server/worldmonitor/sanctions/v1/list-sanctions-pressure.ts', 'utf8');
 const seedSrc = readFileSync('scripts/seed-sanctions-pressure.mjs', 'utf8');
 const healthSrc = readFileSync('api/health.js', 'utf8');
+const seedHealthSrc = readFileSync('api/seed-health.js', 'utf8');
 
 // ---------------------------------------------------------------------------
 // Gold standard: handler must be Redis-read-only (no XML parsing, no live fetch)
@@ -54,32 +55,23 @@ describe('handler: _state stripping', () => {
   });
 
   it('seed writes country counts only through afterPublish metadata path', () => {
-    const extraKeysStart = seedSrc.indexOf('extraKeys: [');
-    const preserveStart = seedSrc.indexOf('preserveKeys: [', extraKeysStart);
-    const afterPublishStart = seedSrc.indexOf('afterPublish: async');
-    assert.ok(extraKeysStart >= 0 && preserveStart > extraKeysStart && afterPublishStart > preserveStart,
-      'seed must define extraKeys, preservation, and afterPublish in order');
-
-    const extraKeysBlock = seedSrc.slice(extraKeysStart, preserveStart);
+    const extraKeysBlock = seedSrc.match(/extraKeys:\s*\[([\s\S]*?)\]/)?.[1];
+    assert.ok(extraKeysBlock, 'seed must declare its extraKeys contract');
     assert.doesNotMatch(
       extraKeysBlock,
       /COUNTRY_COUNTS_KEY/,
       'COUNTRY_COUNTS_KEY must not be duplicated in extraKeys; afterPublish writes it with seed-meta for health',
     );
     assert.match(
-      seedSrc.slice(afterPublishStart),
+      seedSrc,
       /writeExtraKeyWithMeta\(\s*COUNTRY_COUNTS_KEY/s,
       'afterPublish must keep writing COUNTRY_COUNTS_KEY with freshness metadata',
     );
   });
 
   it('preserves every afterPublish companion key and its seed metadata on failed runs', () => {
-    const preserveStart = seedSrc.indexOf('preserveKeys: [');
-    const preserveEnd = seedSrc.indexOf('afterPublish: async', preserveStart);
-    assert.ok(preserveStart >= 0 && preserveEnd > preserveStart,
-      'seed must declare afterPublish companion keys for runSeed preservation');
-
-    const preserveBlock = seedSrc.slice(preserveStart, preserveEnd);
+    const preserveBlock = seedSrc.match(/preserveKeys:\s*\[([\s\S]*?)\]/)?.[1];
+    assert.ok(preserveBlock, 'seed must declare afterPublish companion keys for runSeed preservation');
     for (const key of [
       'ENTITY_INDEX_KEY',
       'ENTITY_INDEX_META_KEY',
@@ -135,6 +127,10 @@ describe('sanctions seed: production freshness contract', () => {
   it('co-produced pressure and entity keys alarm on the same two-missed-run boundary', () => {
     assert.equal(maxStaleMin('sanctionsPressure'), 720);
     assert.equal(maxStaleMin('sanctionsEntities'), 720);
+    const seedHealthEntity = seedHealthSrc.match(/'sanctions:entities':\s*\{[^}]*intervalMin:\s*(\d+)/);
+    assert.ok(seedHealthEntity, '/api/seed-health must register the sanctions entity companion');
+    assert.equal(Number(seedHealthEntity[1]), 360,
+      '/api/seed-health must use the same 6h producer cadence as sanctions pressure');
   });
 
   it('keeps data alive beyond both paired freshness alarms', () => {
@@ -146,5 +142,20 @@ describe('sanctions seed: production freshness contract', () => {
       'canonical pressure data must still exist when STALE_SEED first alarms');
     assert.ok(ttlMinutes > maxStaleMin('sanctionsEntities'),
       'entity data must still exist when STALE_SEED first alarms');
+  });
+
+  it('gives the serial recovery ladder a deadline above its two-source worst case', () => {
+    function optionMs(name) {
+      const match = seedSrc.match(new RegExp(`${name}:\\s*(\\d[\\d_]*)`));
+      assert.ok(match, `${name} must be explicit for the OFAC recovery budget`);
+      return Number(match[1].replaceAll('_', ''));
+    }
+
+    const fetchPhaseTimeoutMs = optionMs('fetchPhaseTimeoutMs');
+    const lockTtlMs = optionMs('lockTtlMs');
+    assert.ok(fetchPhaseTimeoutMs >= 7 * 60 * 1000,
+      'the two serial OFAC source ladders need at least a seven-minute fetch budget');
+    assert.ok(lockTtlMs > fetchPhaseTimeoutMs,
+      'the lock must outlive the explicit fetch deadline during slow recovery');
   });
 });

--- a/tests/sanctions-source-recovery.test.mjs
+++ b/tests/sanctions-source-recovery.test.mjs
@@ -1,0 +1,282 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  fetchOfacSourceResponse,
+  resolveOfacProxyUrl,
+} from '../scripts/_sanctions-source.mjs';
+import { withRetry } from '../scripts/_seed-utils.mjs';
+
+const SOURCE_URL = 'https://sanctionslistservice.ofac.treas.gov/api/PublicationPreview/exports/sdn_advanced.xml';
+const SIGNED_S3_URL = 'https://wc2h-sls-prod-public-published.s3.us-gov-west-1.amazonaws.com/Published/example/SDN_ADVANCED.XML?X-Amz-Signature=redacted';
+
+function response(status, body = '<xml/>', headers = {}) {
+  return new Response(body, { status, headers });
+}
+
+describe('OFAC source transport recovery', () => {
+  it('returns a healthy direct response without touching the proxy', async () => {
+    let proxyCalls = 0;
+    const direct = response(200);
+
+    const result = await fetchOfacSourceResponse(SOURCE_URL, {
+      fetchFn: async () => direct,
+      proxyFetchFn: async () => { proxyCalls += 1; },
+      proxyUrl: 'http://user:pass@proxy.test:8000',
+      sleepFn: async () => {},
+    });
+
+    assert.equal(result, direct);
+    assert.equal(proxyCalls, 0);
+  });
+
+  it('uses the proxy only to obtain the redirect, then streams the trusted S3 response directly', async () => {
+    const directCalls = [];
+    const proxyCalls = [];
+    const s3Response = response(200, '<large-stream/>');
+
+    const result = await fetchOfacSourceResponse(SOURCE_URL, {
+      fetchFn: async (url) => {
+        directCalls.push(String(url));
+        return directCalls.length === 1 ? response(403, 'blocked') : s3Response;
+      },
+      proxyFetchFn: async (url, proxyConfig, options) => {
+        proxyCalls.push({ url, proxyConfig, options });
+        return {
+          ok: false,
+          status: 302,
+          location: SIGNED_S3_URL,
+          buffer: Buffer.alloc(0),
+          contentType: '',
+        };
+      },
+      proxyUrl: 'http://user:pass@proxy.test:8000',
+      sleepFn: async () => {},
+    });
+
+    assert.equal(result, s3Response);
+    assert.deepEqual(directCalls, [SOURCE_URL, SIGNED_S3_URL]);
+    assert.equal(proxyCalls.length, 1);
+    assert.equal(proxyCalls[0].url, SOURCE_URL);
+    assert.equal(proxyCalls[0].options.maxResponseBytes, 64 * 1024,
+      'the proxy bootstrap must never buffer the large XML payload');
+  });
+
+  it('exhausts direct network retries before proxying only the redirect bootstrap', async () => {
+    const events = [];
+    const s3Response = response(200, '<large-stream/>');
+
+    const result = await fetchOfacSourceResponse(SOURCE_URL, {
+      fetchFn: async (url) => {
+        if (String(url) === SOURCE_URL) {
+          events.push('direct:source');
+          throw new TypeError('fetch failed');
+        }
+        events.push('direct:signed-s3');
+        return s3Response;
+      },
+      proxyFetchFn: async (_url, _proxyConfig, options) => {
+        events.push('proxy:bootstrap');
+        assert.equal(options.maxResponseBytes, 64 * 1024);
+        return {
+          ok: false,
+          status: 302,
+          location: SIGNED_S3_URL,
+          buffer: Buffer.alloc(0),
+          contentType: '',
+        };
+      },
+      proxyUrl: 'http://user:pass@proxy.test:8000',
+      sleepFn: async () => {},
+    });
+
+    assert.equal(result, s3Response);
+    assert.deepEqual(events, [
+      'direct:source',
+      'direct:source',
+      'proxy:bootstrap',
+      'direct:signed-s3',
+    ]);
+  });
+
+  it('retries a transient direct response before falling back', async () => {
+    let attempts = 0;
+    let proxyCalls = 0;
+    let cancelled = false;
+
+    const result = await fetchOfacSourceResponse(SOURCE_URL, {
+      fetchFn: async () => {
+        attempts += 1;
+        if (attempts > 1) return response(200);
+        return new Response(new ReadableStream({
+          cancel() {
+            cancelled = true;
+          },
+        }), { status: 503 });
+      },
+      proxyFetchFn: async () => { proxyCalls += 1; },
+      proxyUrl: 'http://user:pass@proxy.test:8000',
+      sleepFn: async () => {},
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(cancelled, true, 'rejected response bodies must be cancelled before retrying');
+    assert.equal(attempts, 2);
+    assert.equal(proxyCalls, 0);
+  });
+
+  it('rotates sticky proxy exits when OFAC rejects the first proxy request', async () => {
+    const ports = [];
+
+    const result = await fetchOfacSourceResponse(SOURCE_URL, {
+      fetchFn: async (url) => String(url) === SOURCE_URL
+        ? response(403, 'blocked')
+        : response(200),
+      proxyFetchFn: async (_url, proxyConfig) => {
+        ports.push(proxyConfig.port);
+        return ports.length === 1
+          ? { ok: false, status: 403, location: '', buffer: Buffer.from('blocked'), contentType: 'text/html' }
+          : { ok: false, status: 302, location: SIGNED_S3_URL, buffer: Buffer.alloc(0), contentType: '' };
+      },
+      proxyUrl: 'gate.decodo.com:10001:user:pass',
+      sleepFn: async () => {},
+    });
+
+    assert.equal(result.status, 200);
+    assert.deepEqual(ports, [10001, 10002]);
+  });
+
+  it('marks an untrusted redirect terminal before the outer seed retry layer', async () => {
+    const directCalls = [];
+    let proxyCalls = 0;
+
+    await assert.rejects(
+      withRetry(
+        () => fetchOfacSourceResponse(SOURCE_URL, {
+          fetchFn: async (url) => {
+            directCalls.push(String(url));
+            return response(403, 'blocked');
+          },
+          proxyFetchFn: async () => {
+            proxyCalls += 1;
+            return {
+              ok: false,
+              status: 302,
+              location: 'https://attacker.example/ofac.xml',
+              buffer: Buffer.alloc(0),
+              contentType: '',
+            };
+          },
+          proxyUrl: 'http://user:pass@proxy.test:8000',
+          sleepFn: async () => {},
+        }),
+        3,
+        0,
+      ),
+      (error) => error.nonRetryable === true && /untrusted redirect host/.test(error.message),
+    );
+
+    assert.deepEqual(directCalls, [SOURCE_URL]);
+    assert.equal(proxyCalls, 1);
+  });
+
+  it('marks proxy CONNECT rejection terminal without exposing credentials', async () => {
+    let directCalls = 0;
+    let proxyCalls = 0;
+
+    await assert.rejects(
+      withRetry(
+        () => fetchOfacSourceResponse(SOURCE_URL, {
+          fetchFn: async () => {
+            directCalls += 1;
+            return response(403, 'blocked');
+          },
+          proxyFetchFn: async () => {
+            proxyCalls += 1;
+            throw Object.assign(
+              new Error('Proxy CONNECT: HTTP/1.1 407 Proxy Authentication Required'),
+              { proxyConnect: true, status: 407 },
+            );
+          },
+          proxyUrl: 'http://proxy-user:proxy-secret@proxy.test:8000',
+          sleepFn: async () => {},
+        }),
+        3,
+        0,
+      ),
+      (error) => error.nonRetryable === true
+        && error.proxyConnect === true
+        && !error.message.includes('proxy-secret'),
+    );
+
+    assert.equal(directCalls, 1);
+    assert.equal(proxyCalls, 1);
+  });
+
+  it('marks invalid proxy configuration terminal before making a proxy request', async () => {
+    let directCalls = 0;
+    let proxyCalls = 0;
+
+    await assert.rejects(
+      withRetry(
+        () => fetchOfacSourceResponse(SOURCE_URL, {
+          fetchFn: async () => {
+            directCalls += 1;
+            return response(403, 'blocked');
+          },
+          proxyFetchFn: async () => { proxyCalls += 1; },
+          proxyUrl: 'not-a-proxy',
+          sleepFn: async () => {},
+        }),
+        3,
+        0,
+      ),
+      (error) => error.nonRetryable === true
+        && error.message === 'OFAC proxy configuration is invalid',
+    );
+
+    assert.equal(directCalls, 1);
+    assert.equal(proxyCalls, 0);
+  });
+
+  it('never sends signed XML through the proxy when the direct S3 download fails', async () => {
+    const directCalls = [];
+    let proxyCalls = 0;
+
+    await assert.rejects(
+      fetchOfacSourceResponse(SOURCE_URL, {
+        fetchFn: async (url) => {
+          directCalls.push(String(url));
+          if (String(url) === SOURCE_URL) return response(403, 'blocked');
+          throw new TypeError('signed S3 network failure');
+        },
+        proxyFetchFn: async () => {
+          proxyCalls += 1;
+          return {
+            ok: false,
+            status: 302,
+            location: SIGNED_S3_URL,
+            buffer: Buffer.alloc(0),
+            contentType: '',
+          };
+        },
+        proxyUrl: 'http://user:pass@proxy.test:8000',
+        sleepFn: async () => {},
+      }),
+      /signed S3 network failure/,
+    );
+
+    assert.deepEqual(directCalls, [SOURCE_URL, SIGNED_S3_URL, SIGNED_S3_URL]);
+    assert.equal(proxyCalls, 1);
+  });
+
+  it('prefers OFAC_PROXY_URL while retaining PROXY_URL as a compatibility fallback', () => {
+    assert.equal(resolveOfacProxyUrl({
+      OFAC_PROXY_URL: 'http://ofac-exit.test:8000',
+      PROXY_URL: 'http://shared-exit.test:9000',
+    }), 'http://ofac-exit.test:8000');
+    assert.equal(resolveOfacProxyUrl({ PROXY_URL: 'http://shared-exit.test:9000' }),
+      'http://shared-exit.test:9000');
+    assert.equal(resolveOfacProxyUrl({}), '');
+  });
+});

--- a/tests/sanctions-source-recovery.test.mjs
+++ b/tests/sanctions-source-recovery.test.mjs
@@ -125,6 +125,53 @@ describe('OFAC source transport recovery', () => {
     assert.equal(proxyCalls, 0);
   });
 
+  it('honors a capped Retry-After hint when retrying a direct response', async () => {
+    const delays = [];
+    let attempts = 0;
+
+    const result = await fetchOfacSourceResponse(SOURCE_URL, {
+      fetchFn: async () => {
+        attempts += 1;
+        return attempts === 1
+          ? response(429, 'rate limited', { 'retry-after': '2' })
+          : response(200);
+      },
+      proxyUrl: '',
+      sleepFn: async (delayMs) => { delays.push(delayMs); },
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(attempts, 2);
+    assert.deepEqual(delays, [2000]);
+  });
+
+  it('does not replay the bounded transport ladder through runSeed retry', async () => {
+    let outerAttempts = 0;
+    let directAttempts = 0;
+
+    await assert.rejects(
+      withRetry(
+        () => {
+          outerAttempts += 1;
+          return fetchOfacSourceResponse(SOURCE_URL, {
+            fetchFn: async () => {
+              directAttempts += 1;
+              throw new TypeError('OFAC unavailable');
+            },
+            proxyUrl: '',
+            sleepFn: async () => {},
+          });
+        },
+        3,
+        0,
+      ),
+      (error) => error.nonRetryable === true && /OFAC unavailable/.test(error.message),
+    );
+
+    assert.equal(outerAttempts, 1);
+    assert.equal(directAttempts, 2);
+  });
+
   it('rotates sticky proxy exits when OFAC rejects the first proxy request', async () => {
     const ports = [];
 


### PR DESCRIPTION
## Summary

Sanctions freshness no longer depends on Railway’s direct egress being accepted by the initial OFAC download host. When that small redirect bootstrap is rejected, the seeder can rotate its existing proxy exits to obtain a host-validated signed S3 URL, then stream the large XML directly so the 2 GB service does not proxy or buffer the payload.

The failure path now also preserves the full last-good sanctions cohort—pressure, entity index, country counts, and their freshness metadata—and gives both co-produced health signals the same 12-hour stale boundary ahead of an 18-hour data TTL. Invalid proxy configuration, proxy authentication failures, and untrusted redirects fail closed without multiplying outer seed retries.

## Verification

- All repository pre-push gates passed, including frontend/API typechecks, edge bundling, changed tests, architectural boundaries, Unicode safety, and version sync.
- Focused sanctions/proxy/seed contract sweep: 102/102 passed.
- Full Node data sweep: 19,572 passed and 6 skipped; its only two initial failures required built dashboard output. A full `VITE_VARIANT=full` production build then passed, and both built-output CSS assertions passed on rerun.
- Structured multi-review covered correctness, security, reliability, performance, maintainability, project standards, and test fidelity; all five actionable findings were repaired and reverified.

## Post-Deploy Monitoring & Validation

- **Owner:** PR author / ingestion on-call.
- **Window:** verify the exact merged SHA is deployed, observe the next `seed-sanctions-pressure` 6-hour cron, then require two consecutive scheduled non-empty runs before declaring operational recovery.
- **Logs:** watch for `Fetching OFAC`, `OFAC direct fetch failed`, `retrying redirect bootstrap via proxy`, `seed_complete`, and `FETCH FAILED`. Proxy credentials must never appear, and the signed S3 XML must never be sent through the proxy.
- **Health:** inspect `/api/health?compact=1` plus `seed-meta:sanctions:pressure` and `seed-meta:sanctions:entities`. Healthy means non-zero records, synchronized freshness, and neither `STALE_SEED` nor `EMPTY` after the cron.
- **Runtime:** inspect Railway request/egress telemetry and memory for `seed-sanctions-pressure`. Healthy means the bootstrap may use a proxy exit while the large signed download remains direct and memory stays below the 2 GB limit.
- **Failure / rollback:** repeated direct-plus-proxy failures, untrusted redirect errors, empty entity coverage, or a memory spike are rollback signals. Revert this commit or repair the routing/configuration; do not disable the freshness monitor.

No Railway configuration or production data was mutated during this change. The PR and local verification establish the code contract; live recovery remains gated on deployment and the scheduled-run evidence above.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
