### PR TITLE
fix(auth): keep the Clerk token when its forced refresh fails

### DIFF
--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -570,10 +570,24 @@ export function shouldReuseCachedClerkToken(input: {
   return now < expiresAt - TOKEN_EXPIRY_SAFETY_MARGIN_MS;
 }
 
-async function fetchClerkToken(session: ClerkSession, skipCache = false): Promise<string | null> {
+type ClerkTokenFetchResult = {
+  token: string | null;
+  unavailable: boolean;
+};
+
+async function fetchClerkToken(session: ClerkSession, skipCache = false): Promise<ClerkTokenFetchResult> {
   const cacheOptions = skipCache ? { skipCache: true } : {};
-  return (await session.getToken({ template: 'convex', ...cacheOptions }).catch(() => null))
-    ?? await session.getToken(cacheOptions).catch(() => null);
+  let firstRequestSucceeded = false;
+  try {
+    const token = await session.getToken({ template: 'convex', ...cacheOptions });
+    firstRequestSucceeded = true;
+    if (token) return { token, unavailable: false };
+  } catch { /* Try the standard session token below. */ }
+  try {
+    return { token: await session.getToken(cacheOptions), unavailable: false };
+  } catch {
+    return { token: null, unavailable: !firstRequestSucceeded };
+  }
 }
 
 export async function getClerkToken(): Promise<string | null> {
@@ -597,7 +611,8 @@ export async function getClerkToken(): Promise<string | null> {
     try {
       // Try the 'convex' template first (includes plan claim for faster server-side checks).
       // Fall back to the standard session token if the template isn't configured in Clerk.
-      let token = await fetchClerkToken(session);
+      const initial = await fetchClerkToken(session);
+      let token = initial.token;
       const firstFetchedAt = Date.now();
       let refreshUnavailable = false;
       if (token && !shouldReuseCachedClerkToken({ token, cachedAt: firstFetchedAt, now: firstFetchedAt })) {
@@ -612,8 +627,8 @@ export async function getClerkToken(): Promise<string | null> {
         // the only one there is, and its remaining seconds can still sign the
         // request being made right now — so keep it rather than manufacturing a
         // signed-out state for a live session (Sentry WORLDMONITOR-Q9).
-        if (refreshed) token = refreshed;
-        else refreshUnavailable = true;
+        if (refreshed.token) token = refreshed.token;
+        else refreshUnavailable = refreshed.unavailable;
       }
       // If the session generation advanced while getToken() was in
       // flight, this JWT belongs to the previous user. Drop it on the
@@ -628,7 +643,11 @@ export async function getClerkToken(): Promise<string | null> {
       // Deliberately uncached: serving a near-expiry token for the full TTL is
       // the stacked-cache defect this function was rewritten to fix, so the next
       // caller must go back to Clerk once it is reachable again.
-      return refreshUnavailable ? token : null;
+      if (refreshUnavailable) {
+        const expiresAt = clerkTokenExpiresAtMs(token);
+        if (expiresAt === null || fetchedAt < expiresAt) return token;
+      }
+      return null;
     } catch {
       return null;
     } finally {

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -599,11 +599,21 @@ export async function getClerkToken(): Promise<string | null> {
       // Fall back to the standard session token if the template isn't configured in Clerk.
       let token = await fetchClerkToken(session);
       const firstFetchedAt = Date.now();
+      let refreshUnavailable = false;
       if (token && !shouldReuseCachedClerkToken({ token, cachedAt: firstFetchedAt, now: firstFetchedAt })) {
         // Clerk may return a near-expiry cached token while refreshing it in the
         // background. The initiating caller must not receive that stale token:
         // force one server refresh, then accept only a token outside the margin.
-        token = await fetchClerkToken(session, true);
+        const refreshed = await fetchClerkToken(session, true);
+        // A refresh that fails outright (Clerk unreachable, blocked, 5xx) is a
+        // different event from one that succeeds and still returns a near-expiry
+        // token. Only the latter justifies null: there, a better credential
+        // exists and the caller should retry for it. Here the token in hand is
+        // the only one there is, and its remaining seconds can still sign the
+        // request being made right now — so keep it rather than manufacturing a
+        // signed-out state for a live session (Sentry WORLDMONITOR-Q9).
+        if (refreshed) token = refreshed;
+        else refreshUnavailable = true;
       }
       // If the session generation advanced while getToken() was in
       // flight, this JWT belongs to the previous user. Drop it on the
@@ -615,7 +625,10 @@ export async function getClerkToken(): Promise<string | null> {
         _cachedTokenAt = fetchedAt;
         return token;
       }
-      return null;
+      // Deliberately uncached: serving a near-expiry token for the full TTL is
+      // the stacked-cache defect this function was rewritten to fix, so the next
+      // caller must go back to Clerk once it is reachable again.
+      return refreshUnavailable ? token : null;
     } catch {
       return null;
     } finally {

--- a/tests/clerk-token-cache-expiry.test.mts
+++ b/tests/clerk-token-cache-expiry.test.mts
@@ -200,6 +200,41 @@ describe('getClerkToken', () => {
     assert.equal(await getClerkToken(), nearExpiry);
   });
 
+  it('does not fall back when the forced refresh resolves without a token', async () => {
+    const nearExpiry = tokenExpiringAt(Date.now() + 5_000);
+    const session = {
+      async getToken(options: { template?: string; skipCache?: boolean } = {}) {
+        return options.skipCache ? null : nearExpiry;
+      },
+    };
+    __setClerkInstanceForTests({ session } as never);
+
+    assert.equal(await getClerkToken(), null);
+  });
+
+  it('does not return a token that expires during a failed refresh', async () => {
+    const originalDateNow = Date.now;
+    let now = 1_760_000_000_000;
+    Date.now = () => now;
+    const nearExpiry = tokenExpiringAt(now + 5_000);
+    const session = {
+      async getToken(options: { template?: string; skipCache?: boolean } = {}) {
+        if (options.skipCache) {
+          now += 6_000;
+          throw new Error('network');
+        }
+        return nearExpiry;
+      },
+    };
+
+    try {
+      __setClerkInstanceForTests({ session } as never);
+      assert.equal(await getClerkToken(), null);
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
   /**
    * The fallback must not strand the session on the degraded token: once Clerk
    * is reachable again the very next caller gets a healthy one.

--- a/tests/clerk-token-cache-expiry.test.mts
+++ b/tests/clerk-token-cache-expiry.test.mts
@@ -173,4 +173,59 @@ describe('getClerkToken', () => {
 
     assert.equal(await getClerkToken(), null);
   });
+
+  /**
+   * Sentry WORLDMONITOR-Q9. A forced refresh that fails outright is not the same
+   * event as one that succeeds and still hands back a near-expiry token (the case
+   * above, which must stay null). When Clerk is unreachable the near-expiry token
+   * already in hand is the only credential that exists, and seconds of remaining
+   * life are enough to sign the request being made right now — whereas null is a
+   * guaranteed failure that `startCheckout` surfaces to a live session as
+   * `session_expired`, dead-ending a user who was trying to pay.
+   */
+  it('falls back to the near-expiry token when the forced refresh fails outright', async () => {
+    const nearExpiry = tokenExpiringAt(Date.now() + 5_000);
+    let call = 0;
+    const session = {
+      async getToken() {
+        call += 1;
+        // First pair: Clerk's stale-while-revalidate near-expiry token.
+        // Second pair (skipCache): Clerk is unreachable, both templates reject.
+        if (call <= 1) return nearExpiry;
+        throw new Error('network');
+      },
+    };
+    __setClerkInstanceForTests({ session } as never);
+
+    assert.equal(await getClerkToken(), nearExpiry);
+  });
+
+  /**
+   * The fallback must not strand the session on the degraded token: once Clerk
+   * is reachable again the very next caller gets a healthy one.
+   *
+   * Note this does NOT assert the fallback goes uncached, and no test can —
+   * a token rejected by the freshness gate at fetch time can never satisfy that
+   * same gate on a later read, so the cache entry is unreachable either way.
+   * Mutating the source to cache it leaves every test in this file green.
+   */
+  it('recovers to a healthy token as soon as the forced refresh works again', async () => {
+    const nearExpiry = tokenExpiringAt(Date.now() + 5_000);
+    const healthy = tokenExpiringAt(Date.now() + 60_000);
+    let refreshBroken = true;
+    const session = {
+      async getToken(options: { template?: string; skipCache?: boolean } = {}) {
+        if (options.skipCache) {
+          if (refreshBroken) throw new Error('network');
+          return healthy;
+        }
+        return nearExpiry;
+      },
+    };
+    __setClerkInstanceForTests({ session } as never);
+
+    assert.equal(await getClerkToken(), nearExpiry);
+    refreshBroken = false;
+    assert.equal(await getClerkToken(), healthy);
+  });
 });


### PR DESCRIPTION
## Summary

Signed-in users who clicked upgrade were told **"your session has expired"** and dropped back to the pricing page — while their Clerk session was perfectly alive. They could not pay. Sentry WORLDMONITOR-Q9 went from 1 event in three months to 4 events from 4 distinct users in three days, starting ~14h after #5753 deployed.

#5753 correctly bounded the Clerk token cache by the token's own `exp`, but wrote the forced refresh as an unconditional overwrite. `fetchClerkToken` swallows failures into `null`, so whenever Clerk was unreachable — network blip, blocked by an extension or proxy, FAPI 5xx — the refresh discarded a token that still had seconds of usable life and `getClerkToken()` returned `null`. `startCheckout` reads a null token as `session_expired` and renders a dead end. Before #5753 that same token was returned and signed the request fine.

The failure is not checkout-specific; it is every `getClerkToken()` consumer. The Axiom join for these users shows the premium route `get-country-intel-brief` returning 401 repeatedly (6× in 70s for one user) around each checkout failure — the same missing bearer, just a different symptom.

## Why this doesn't reintroduce the bug #5753 fixed

A refresh that **fails outright** is a different event from one that **succeeds and still returns a near-expiry token**. Only the second justifies `null`: there a better credential demonstrably exists, so the caller should retry for it — that invariant is untouched and still has its test. The first case has no better credential anywhere, and the token in hand can still sign the request being made right now.

The fallback token is deliberately **not cached**, so the next caller goes back to Clerk once it is reachable rather than being served a degraded token for the full 50s TTL. Serving it for the TTL was the original WORLDMONITOR-XR defect and stays fixed.

## Validation

The two new tests were written first and confirmed red against the current code (`getClerkToken()` returned `null` where the token was expected), then green after the change — 13/13 in the file.

Each guard was mutation-tested individually: restoring the unconditional overwrite reddens exactly the 2 new tests, and dropping the fallback gate reddens exactly the pre-existing "still near-expiry ⇒ null" invariant, so both directions are pinned. A third mutation — caching the fallback — reddened nothing, which exposed one of my own new tests as vacuous: a token rejected by the freshness gate at fetch time can never satisfy that gate on a later read, so the cache entry is unreachable either way and no test can pin it. That test is renamed to the property it actually verifies (recovery once Clerk returns), with the un-testable part stated in a comment rather than left as a name that over-claims.

Also green: `npx tsc --noEmit`, biome, and the adjacent clerk/checkout suites (`clerk-surface-open`, `checkout-report-error`, `checkout-overlay-lifecycle`, `checkout-unparsable-success-body` — 36 tests).

Fixes #5931

Related: #5932 — a client whose clock runs ≥50s fast still sees every freshly minted 60s token as near-expiry and gets `null` forever. That path is untouched here (the refresh succeeds, so the judgment differs) and is the residual #5753's own commit message named.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5_%281M%29-D97757?logo=claude&logoColor=white)
