### PR TITLE
fix(security): bump tauri to 2.11.5 and gate the advisory floor (#5518)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -112,6 +112,14 @@ jobs:
       - name: Check version consistency
         run: npm run version:check
 
+      - name: Rust dependency security floors (#5518)
+        # The release build is the artifact users install, so verify the
+        # lockfile it is about to compile still clears every recorded advisory
+        # floor. The desktop-config PR gate runs the same check, but a release
+        # can be cut from any ref — this makes the shipped binary the thing
+        # that gets audited, not just the PR that touched src-tauri.
+        run: node scripts/check-rust-security-floors.mjs
+
       - name: Bundle Node.js runtime
         shell: bash
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
             /^package\.json$/ { count++; next }
             /^scripts\/repack-linux-appimage\.sh$/ { count++; next }
             /^scripts\/sync-desktop-version\.mjs$/ { count++; next }
+            /^scripts\/check-rust-security-floors\.mjs$/ { count++; next }
             /^\.github\/workflows\/(build-desktop|test-linux-app|test)\.yml$/ { count++ }
             END { print count + 0 }
           ')
@@ -277,6 +278,13 @@ jobs:
             }
             if (failed) process.exit(1);
           '
+      - name: Rust dependency security floors (#5518)
+        # Cargo.lock decides what actually ships; the manifest constraint only
+        # bounds resolution. Nothing else in CI inspects it (security-audit
+        # covers npm lockfiles only), so without this a cargo update could
+        # silently drop the desktop app back onto a crate version with a known
+        # advisory.
+        run: node scripts/check-rust-security-floors.mjs
 
   desktop-rust:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
             /^src-tauri\// && $0 !~ /^src-tauri\/sidecar\// { next }
             /^CHANGELOG\.md$/ { next }
             /^LICENSE$/ { next }
-            /^\.github\/workflows\/(build-desktop|docker-publish)\.yml$/ { next }
+            /^\.github\/workflows\/docker-publish\.yml$/ { next }
             { count++ }
             END { print count + 0 }
           ')

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lint:md": "markdownlint-cli2 '**/*.md' '!**/node_modules/**' '!.agent/**' '!.agents/**' '!.claude/**' '!.factory/**' '!.windsurf/**' '!skills/**' '!docs/internal/**' '!docs/Docs_To_Review/**' '!docs/archive/**' '!todos/**' '!docs/plans/**' '!docs/brainstorms/**' '!docs/ideation/**'",
     "version:sync": "node scripts/sync-desktop-version.mjs",
     "version:check": "node scripts/sync-desktop-version.mjs --check",
+    "desktop:check-rust-floors": "node scripts/check-rust-security-floors.mjs",
     "sync:locales": "node scripts/sync-locale-keys.mjs",
     "sync:locales:check": "node scripts/sync-locale-keys.mjs --check",
     "sync:bootstrap-tier-keys": "node scripts/sync-bootstrap-tier-keys.mjs",

--- a/scripts/check-rust-security-floors.mjs
+++ b/scripts/check-rust-security-floors.mjs
@@ -118,6 +118,28 @@ export function checkRustSecurityFloors(lockSource, floors = RUST_SECURITY_FLOOR
   return errors;
 }
 
+export function checkManifestSecurityFloor(manifestSource, floor) {
+  const line = manifestSource
+    .split('\n')
+    .find((l) => new RegExp(`^${floor.crate}\\s*=`).test(l.trim()));
+  if (!line) {
+    return [`${floor.manifestFile} must declare ${floor.crate}`];
+  }
+
+  const lowerBound = line.match(/>=\s*(\d+\.\d+\.\d+)/)?.[1];
+  if (!lowerBound) {
+    return [
+      `${floor.crate} in ${floor.manifestFile} must carry an explicit >= lower bound so it cannot resolve below the security floor; found: ${line.trim()}`,
+    ];
+  }
+  if (compareVersions(lowerBound, floor.minVersion) < 0) {
+    return [
+      `${floor.manifestFile} allows ${floor.crate} >= ${lowerBound}, below the recorded security floor ${floor.minVersion} (${floor.advisory})`,
+    ];
+  }
+  return [];
+}
+
 /**
  * Resolve `--root <dir>` / `--root=<dir>`. Both spellings are handled because
  * silently ignoring one would make this gate audit the wrong tree and report
@@ -151,6 +173,17 @@ if (isMainModule(import.meta.url, process.argv[1])) {
   const lockPath = path.join(rootDir, 'src-tauri', 'Cargo.lock');
 
   const errors = checkRustSecurityFloors(readFileSync(lockPath, 'utf8'));
+  for (const floor of RUST_SECURITY_FLOORS.filter((f) => f.manifestFile)) {
+    const manifestPath = path.join(rootDir, floor.manifestFile);
+    let manifestSource;
+    try {
+      manifestSource = readFileSync(manifestPath, 'utf8');
+    } catch (err) {
+      errors.push(`${floor.manifestFile} could not be read: ${err.message}`);
+      continue;
+    }
+    errors.push(...checkManifestSecurityFloor(manifestSource, floor));
+  }
   if (errors.length > 0) {
     for (const e of errors) console.error(`::error::rust security floor: ${e}`);
     process.exit(1);

--- a/scripts/check-rust-security-floors.mjs
+++ b/scripts/check-rust-security-floors.mjs
@@ -105,9 +105,36 @@ export function checkRustSecurityFloors(lockSource, floors = RUST_SECURITY_FLOOR
   return errors;
 }
 
+/**
+ * Resolve `--root <dir>` / `--root=<dir>`. Both spellings are handled because
+ * silently ignoring one would make this gate audit the wrong tree and report
+ * green — the failure mode a security check must never have. An unusable
+ * `--root` is a hard error, never a fallback to cwd.
+ */
+export function resolveRootDir(argv, cwd) {
+  const inline = argv.find((a) => a.startsWith('--root='));
+  if (inline) {
+    const value = inline.slice('--root='.length);
+    if (!value) throw new Error('--root= was passed with no directory');
+    return path.resolve(value);
+  }
+  const flagIndex = argv.indexOf('--root');
+  if (flagIndex !== -1) {
+    const value = argv[flagIndex + 1];
+    if (!value || value.startsWith('-')) throw new Error('--root was passed with no directory');
+    return path.resolve(value);
+  }
+  return cwd;
+}
+
 if (isMainModule(import.meta.url, process.argv[1])) {
-  const rootFlagIndex = process.argv.indexOf('--root');
-  const rootDir = rootFlagIndex !== -1 ? path.resolve(process.argv[rootFlagIndex + 1]) : process.cwd();
+  let rootDir;
+  try {
+    rootDir = resolveRootDir(process.argv.slice(2), process.cwd());
+  } catch (err) {
+    console.error(`::error::rust security floor: ${err.message}`);
+    process.exit(1);
+  }
   const lockPath = path.join(rootDir, 'src-tauri', 'Cargo.lock');
 
   const errors = checkRustSecurityFloors(readFileSync(lockPath, 'utf8'));

--- a/scripts/check-rust-security-floors.mjs
+++ b/scripts/check-rust-security-floors.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Rust dependency security floors (#5518, part of #5902).
+ *
+ * `src-tauri/Cargo.lock` is what actually decides which crate versions ship —
+ * the manifest constraint only bounds resolution. Nothing else in CI inspects
+ * it: the security-audit workflow covers npm lockfiles only, so before this
+ * check a `cargo update` (or a loosened constraint) could silently drop the
+ * desktop app back onto a version with a known advisory and no gate would
+ * notice. That is the desktop-drift class #5902 exists to close.
+ *
+ * Each floor is a recorded decision: crate, minimum patched version, and the
+ * advisory that set it. A crate named here but ABSENT from the lockfile fails
+ * the check rather than passing vacuously — a rename or removal must be an
+ * explicit decision to drop the floor, not a silent green.
+ *
+ * Run: node scripts/check-rust-security-floors.mjs  (npm run desktop:check-rust-floors)
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { isMainModule } from './lib/main-module.mjs';
+
+export const RUST_SECURITY_FLOORS = [
+  {
+    crate: 'tauri',
+    minVersion: '2.11.1',
+    advisory: 'GHSA-7gmj-67g7-phm9 / CVE-2026-42184 (CVSS 8.8)',
+    reason:
+      'is_local_url() matched only the first subdomain label, so a hostname like tauri.evil.com could pass as a trusted local origin and invoke IPC commands (Windows/Android webviews). Partially mitigated here by require_trusted_window() label gating, but the bump is the real fix.',
+    issue: '#5518',
+  },
+];
+
+/**
+ * Parse `name`/`version` pairs out of a Cargo.lock into a Map of
+ * crate -> ALL locked versions.
+ *
+ * Multiple versions of one crate legitimately coexist in a Cargo.lock (this
+ * repo's lockfile carries dozens of such crates, e.g. `getrandom` at three
+ * majors). Keeping only one occurrence would let a vulnerable duplicate hide
+ * behind a patched sibling, so a floor is checked against every locked copy.
+ */
+export function parseCargoLockVersions(lockSource) {
+  const versions = new Map();
+  const pattern = /^name = "([^"]+)"\r?\nversion = "([^"]+)"/gm;
+  for (const match of lockSource.matchAll(pattern)) {
+    const existing = versions.get(match[1]);
+    if (existing) existing.push(match[2]);
+    else versions.set(match[1], [match[2]]);
+  }
+  return versions;
+}
+
+/**
+ * Compare semver-ish versions. A prerelease (`2.11.1-rc.1`) sorts BELOW the
+ * matching release, which is the conservative direction for a security floor.
+ */
+export function compareVersions(a, b) {
+  const split = (v) => {
+    const [core, prerelease] = String(v).split('-', 2);
+    const parts = core.split('.').map((n) => Number.parseInt(n, 10) || 0);
+    while (parts.length < 3) parts.push(0);
+    return { parts, hasPrerelease: prerelease !== undefined };
+  };
+  const left = split(a);
+  const right = split(b);
+  for (let i = 0; i < 3; i++) {
+    if (left.parts[i] !== right.parts[i]) return left.parts[i] < right.parts[i] ? -1 : 1;
+  }
+  if (left.hasPrerelease === right.hasPrerelease) return 0;
+  return left.hasPrerelease ? -1 : 1;
+}
+
+export function checkRustSecurityFloors(lockSource, floors = RUST_SECURITY_FLOORS) {
+  const errors = [];
+  const versions = parseCargoLockVersions(lockSource);
+
+  if (versions.size === 0) {
+    errors.push('Cargo.lock parsed to zero crates — the lockfile is empty or the parser broke (refusing to pass vacuously)');
+    return errors;
+  }
+
+  for (const floor of floors) {
+    const locked = versions.get(floor.crate);
+    if (!locked) {
+      errors.push(
+        `${floor.crate} has a security floor (>= ${floor.minVersion}, ${floor.advisory}) but is absent from Cargo.lock — ` +
+          'if the dependency was intentionally removed, delete its floor entry in scripts/check-rust-security-floors.mjs',
+      );
+      continue;
+    }
+    // Every locked copy must clear the floor: one patched version does not
+    // make a second, vulnerable copy of the same crate safe.
+    for (const version of locked.filter((v) => compareVersions(v, floor.minVersion) < 0)) {
+      errors.push(
+        `${floor.crate} ${version} is below the security floor ${floor.minVersion} (${floor.advisory}, ${floor.issue})` +
+          `${locked.length > 1 ? ` [${locked.length} versions locked: ${locked.join(', ')}]` : ''}. ` +
+          `Fix: cd src-tauri && cargo update -p ${floor.crate} --precise <patched-version> && commit Cargo.lock`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  const rootFlagIndex = process.argv.indexOf('--root');
+  const rootDir = rootFlagIndex !== -1 ? path.resolve(process.argv[rootFlagIndex + 1]) : process.cwd();
+  const lockPath = path.join(rootDir, 'src-tauri', 'Cargo.lock');
+
+  const errors = checkRustSecurityFloors(readFileSync(lockPath, 'utf8'));
+  if (errors.length > 0) {
+    for (const e of errors) console.error(`::error::rust security floor: ${e}`);
+    process.exit(1);
+  }
+  const summary = RUST_SECURITY_FLOORS.map((f) => `${f.crate} >= ${f.minVersion}`).join(', ');
+  console.log(`rust security floors OK: ${summary}`);
+}

--- a/scripts/check-rust-security-floors.mjs
+++ b/scripts/check-rust-security-floors.mjs
@@ -25,11 +25,24 @@ import { isMainModule } from './lib/main-module.mjs';
 export const RUST_SECURITY_FLOORS = [
   {
     crate: 'tauri',
+    // DO NOT LOWER to 2.10.3. The advisory sources disagree: the NVD record
+    // for CVE-2026-42184 says "resolved in version 2.10.3", while
+    // GHSA-7gmj-67g7-phm9 lists `>= 2.0.0, <= 2.11.0` as affected and 2.11.1
+    // as the first patched release. 2.11.1 is the stricter of the two and is
+    // deliberately the floor; "correcting" it down on the strength of the NVD
+    // text alone would permit a version GitHub still considers vulnerable.
     minVersion: '2.11.1',
-    advisory: 'GHSA-7gmj-67g7-phm9 / CVE-2026-42184 (CVSS 8.8)',
+    // 8.8 HIGH is the NVD CVSS v3.1 base score
+    // (AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H). The GitHub advisory scores the
+    // same CVE 6.1 MEDIUM under CVSS v4.0 — both are correct for their
+    // version of the spec, so neither surface is wrong.
+    advisory: 'GHSA-7gmj-67g7-phm9 / CVE-2026-42184 (CVSS v3.1 8.8 HIGH; v4.0 6.1 MEDIUM)',
     reason:
       'is_local_url() matched only the first subdomain label, so a hostname like tauri.evil.com could pass as a trusted local origin and invoke IPC commands (Windows/Android webviews). Partially mitigated here by require_trusted_window() label gating, but the bump is the real fix.',
     issue: '#5518',
+    // Lower bound the manifest constraint must also honour, so the two floors
+    // cannot silently diverge (asserted in tests/check-rust-security-floors.test.mjs).
+    manifestFile: 'src-tauri/Cargo.toml',
   },
 ];
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -223,6 +223,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,12 +518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,9 +555,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
@@ -613,19 +622,15 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.29.6"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "matches",
- "phf 0.10.1",
- "proc-macro2",
- "quote",
+ "phf",
  "smallvec",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -640,13 +645,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.117",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -724,11 +735,19 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "convert_case",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -768,18 +787,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
-
-[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -818,6 +833,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dom_query"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+dependencies = [
+ "bit-set",
+ "cssparser",
+ "foldhash 0.2.0",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +870,21 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -1002,6 +1047,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,16 +1101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
 ]
 
 [[package]]
@@ -1144,15 +1185,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1266,24 +1298,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1471,7 +1492,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1524,14 +1545,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.29.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
- "match_token",
 ]
 
 [[package]]
@@ -1664,7 +1683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -1951,24 +1970,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kuchikiki"
-version = "0.8.8-speedreader"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
-dependencies = [
- "cssparser",
- "html5ever",
- "indexmap 2.13.0",
- "selectors",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,41 +2071,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "markup5ever"
-version = "0.14.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
 ]
-
-[[package]]
-name = "match_token"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -2144,15 +2119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -2163,10 +2138,10 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2202,12 +2177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
 name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,12 +2203,6 @@ dependencies = [
  "libc",
  "memoffset",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "normpath"
@@ -2375,6 +2338,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2380,38 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -2455,8 +2471,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -2613,106 +2648,43 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.8.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_macros 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
+ "phf_macros",
+ "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.8.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.8.0",
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.8.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "phf_shared 0.8.0",
- "rand 0.7.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared 0.10.0",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.5",
+ "fastrand",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2720,29 +2692,11 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.8.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher 1.0.2",
+ "siphasher",
 ]
 
 [[package]]
@@ -2794,6 +2748,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -2908,12 +2875,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,37 +2909,13 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2988,16 +2925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -3007,24 +2935,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3173,6 +3083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,7 +3219,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2",
  "zbus",
@@ -3347,18 +3263,19 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.24.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "cssparser",
  "derive_more",
- "fxhash",
  "log",
- "phf 0.8.0",
- "phf_codegen 0.8.0",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
  "precomputed-hash",
+ "rustc-hash",
  "servo_arc",
  "smallvec",
 ]
@@ -3535,11 +3452,10 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.2.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
- "nodrop",
  "stable_deref_trait",
 ]
 
@@ -3586,12 +3502,6 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -3683,25 +3593,24 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.11.3",
+ "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -3736,7 +3645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
  "unicode-ident",
 ]
 
@@ -3786,35 +3694,35 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.5"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
- "dispatch",
+ "dbus",
+ "dispatch2",
  "dlopen2",
  "dpi",
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
  "jni",
- "lazy_static",
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
- "scopeguard",
  "tao-macros",
  "unicode-segmentation",
  "url",
@@ -3843,9 +3751,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3894,9 +3802,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.6"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
+checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3910,22 +3818,21 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.5"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
  "ico",
  "json-patch",
  "plist",
- "png",
+ "png 0.17.16",
  "proc-macro2",
  "quote",
  "semver",
@@ -3943,9 +3850,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.5"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -3957,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.1"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -3982,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
@@ -4008,24 +3915,24 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.3"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
- "html5ever",
  "http",
  "infer",
  "json-patch",
- "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -4070,13 +3977,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
- "futf",
- "mac",
- "utf-8",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -4371,9 +4276,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -4385,10 +4290,10 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4505,12 +4410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4584,12 +4483,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -4729,6 +4622,18 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -5383,24 +5288,23 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.2"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb26159b420aa77684589a744ae9a9461a95395b848764ad12290a14d960a11a"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",
  "cookie",
  "crossbeam-channel",
  "dirs",
+ "dom_query",
  "dpi",
  "dunce",
  "gdkx11",
  "gtk",
- "html5ever",
  "http",
  "javascriptcore-rs",
  "jni",
- "kuchikiki",
  "libc",
  "ndk",
  "objc2",
@@ -5498,7 +5402,7 @@ dependencies = [
  "hex",
  "nix",
  "ordered-stream",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_repr",
  "sha1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = ">=2.11.1, <3", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native-sync-persistent", "crypto-rust"] }

--- a/tests/check-rust-security-floors.test.mjs
+++ b/tests/check-rust-security-floors.test.mjs
@@ -9,6 +9,7 @@ import {
   checkRustSecurityFloors,
   compareVersions,
   parseCargoLockVersions,
+  resolveRootDir,
 } from '../scripts/check-rust-security-floors.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -80,6 +81,17 @@ describe('check-rust-security-floors', () => {
       assert.ok(floor.advisory?.length > 5, `${floor.crate} must cite its advisory`);
       assert.ok(floor.reason?.length > 20, `${floor.crate} must record why the floor exists`);
     }
+  });
+
+  it('accepts both --root spellings and refuses an empty one', () => {
+    // Silently ignoring `--root=<dir>` would audit the wrong tree and report
+    // green — the one failure mode a security gate must not have.
+    assert.equal(resolveRootDir(['--root', '/tmp/x'], '/cwd'), '/tmp/x');
+    assert.equal(resolveRootDir(['--root=/tmp/x'], '/cwd'), '/tmp/x');
+    assert.equal(resolveRootDir([], '/cwd'), '/cwd');
+    assert.throws(() => resolveRootDir(['--root'], '/cwd'), /no directory/);
+    assert.throws(() => resolveRootDir(['--root='], '/cwd'), /no directory/);
+    assert.throws(() => resolveRootDir(['--root', '--verbose'], '/cwd'), /no directory/);
   });
 
   it('holds against the real committed Cargo.lock', () => {

--- a/tests/check-rust-security-floors.test.mjs
+++ b/tests/check-rust-security-floors.test.mjs
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import {
   RUST_SECURITY_FLOORS,
+  checkManifestSecurityFloor,
   checkRustSecurityFloors,
   compareVersions,
   parseCargoLockVersions,
@@ -13,6 +16,7 @@ import {
 } from '../scripts/check-rust-security-floors.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const checker = resolve(root, 'scripts/check-rust-security-floors.mjs');
 const realLock = readFileSync(resolve(root, 'src-tauri/Cargo.lock'), 'utf8');
 
 const lockFixture = (crate, version) =>
@@ -95,24 +99,64 @@ describe('check-rust-security-floors', () => {
   });
 
   it('keeps the manifest constraint at or above every recorded floor', () => {
-    // The lockfile gate is the real backstop, but if the manifest lower bound
-    // drifted below the floor a fresh resolution could legitimately land on a
-    // vulnerable version. Pin the two together so they cannot diverge.
     for (const floor of RUST_SECURITY_FLOORS.filter((f) => f.manifestFile)) {
       const manifest = readFileSync(resolve(root, floor.manifestFile), 'utf8');
-      const line = manifest
-        .split('\n')
-        .find((l) => new RegExp(`^${floor.crate}\\s*=`).test(l.trim()));
-      assert.ok(line, `${floor.manifestFile} must declare ${floor.crate}`);
-      const lowerBound = line.match(/>=\s*(\d+\.\d+\.\d+)/)?.[1];
-      assert.ok(
-        lowerBound,
-        `${floor.crate} in ${floor.manifestFile} must carry an explicit >= lower bound so it cannot resolve below the security floor; found: ${line.trim()}`,
+      assert.deepEqual(checkManifestSecurityFloor(manifest, floor), []);
+    }
+  });
+
+  it('fails when a manifest lower bound is below its recorded floor', () => {
+    const floor = RUST_SECURITY_FLOORS.find((entry) => entry.crate === 'tauri');
+    assert.ok(floor);
+    const errors = checkManifestSecurityFloor(
+      'tauri = { version = ">=2.10.3, <3", features = [] }\n',
+      floor,
+    );
+    assert.match(errors[0], /allows tauri >= 2\.10\.3, below the recorded security floor 2\.11\.1/);
+  });
+
+  it('exercises the CLI entrypoint for default cwd and --root invocations', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'rust-security-floor-cli-'));
+    try {
+      const tauriRoot = join(fixtureRoot, 'src-tauri');
+      mkdirSync(tauriRoot);
+      writeFileSync(
+        join(tauriRoot, 'Cargo.toml'),
+        'tauri = { version = ">=2.11.1, <3", features = [] }\n',
       );
-      assert.ok(
-        compareVersions(lowerBound, floor.minVersion) >= 0,
-        `${floor.manifestFile} allows ${floor.crate} >= ${lowerBound}, below the recorded security floor ${floor.minVersion} (${floor.advisory})`,
+      writeFileSync(join(tauriRoot, 'Cargo.lock'), lockFixture('tauri', '2.11.5'));
+
+      const defaultRun = spawnSync(process.execPath, [checker], {
+        cwd: fixtureRoot,
+        encoding: 'utf8',
+      });
+      assert.equal(defaultRun.status, 0, defaultRun.stderr);
+      assert.match(defaultRun.stdout, /rust security floors OK: tauri >= 2\.11\.1/);
+
+      writeFileSync(
+        join(tauriRoot, 'Cargo.toml'),
+        'tauri = { version = ">=2.10.3, <3", features = [] }\n',
       );
+      const manifestRun = spawnSync(process.execPath, [checker, `--root=${fixtureRoot}`], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+      assert.equal(manifestRun.status, 1);
+      assert.match(manifestRun.stderr, /Cargo\.toml allows tauri >= 2\.10\.3, below/);
+
+      writeFileSync(
+        join(tauriRoot, 'Cargo.toml'),
+        'tauri = { version = ">=2.11.1, <3", features = [] }\n',
+      );
+      writeFileSync(join(tauriRoot, 'Cargo.lock'), lockFixture('tauri', '2.10.3'));
+      const rootRun = spawnSync(process.execPath, [checker, `--root=${fixtureRoot}`], {
+        cwd: root,
+        encoding: 'utf8',
+      });
+      assert.equal(rootRun.status, 1);
+      assert.match(rootRun.stderr, /::error::rust security floor: tauri 2\.10\.3 is below/);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
     }
   });
 

--- a/tests/check-rust-security-floors.test.mjs
+++ b/tests/check-rust-security-floors.test.mjs
@@ -94,6 +94,28 @@ describe('check-rust-security-floors', () => {
     assert.throws(() => resolveRootDir(['--root', '--verbose'], '/cwd'), /no directory/);
   });
 
+  it('keeps the manifest constraint at or above every recorded floor', () => {
+    // The lockfile gate is the real backstop, but if the manifest lower bound
+    // drifted below the floor a fresh resolution could legitimately land on a
+    // vulnerable version. Pin the two together so they cannot diverge.
+    for (const floor of RUST_SECURITY_FLOORS.filter((f) => f.manifestFile)) {
+      const manifest = readFileSync(resolve(root, floor.manifestFile), 'utf8');
+      const line = manifest
+        .split('\n')
+        .find((l) => new RegExp(`^${floor.crate}\\s*=`).test(l.trim()));
+      assert.ok(line, `${floor.manifestFile} must declare ${floor.crate}`);
+      const lowerBound = line.match(/>=\s*(\d+\.\d+\.\d+)/)?.[1];
+      assert.ok(
+        lowerBound,
+        `${floor.crate} in ${floor.manifestFile} must carry an explicit >= lower bound so it cannot resolve below the security floor; found: ${line.trim()}`,
+      );
+      assert.ok(
+        compareVersions(lowerBound, floor.minVersion) >= 0,
+        `${floor.manifestFile} allows ${floor.crate} >= ${lowerBound}, below the recorded security floor ${floor.minVersion} (${floor.advisory})`,
+      );
+    }
+  });
+
   it('holds against the real committed Cargo.lock', () => {
     assert.deepEqual(checkRustSecurityFloors(realLock), []);
   });

--- a/tests/check-rust-security-floors.test.mjs
+++ b/tests/check-rust-security-floors.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  RUST_SECURITY_FLOORS,
+  checkRustSecurityFloors,
+  compareVersions,
+  parseCargoLockVersions,
+} from '../scripts/check-rust-security-floors.mjs';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const realLock = readFileSync(resolve(root, 'src-tauri/Cargo.lock'), 'utf8');
+
+const lockFixture = (crate, version) =>
+  `[[package]]\nname = "${crate}"\nversion = "${version}"\nsource = "registry+https://github.com/rust-lang/crates.io-index"\n`;
+
+describe('check-rust-security-floors', () => {
+  it('orders versions numerically, not lexically', () => {
+    assert.equal(compareVersions('2.9.3', '2.11.1'), -1, '2.9.3 must sort below 2.11.1');
+    assert.equal(compareVersions('2.11.5', '2.11.1'), 1);
+    assert.equal(compareVersions('2.11.1', '2.11.1'), 0);
+    assert.equal(compareVersions('2.10.3', '2.11.1'), -1);
+  });
+
+  it('sorts a prerelease below its release (conservative for a security floor)', () => {
+    assert.equal(compareVersions('2.11.1-rc.1', '2.11.1'), -1);
+  });
+
+  it('parses name/version pairs out of a lockfile', () => {
+    const versions = parseCargoLockVersions(lockFixture('tauri', '2.11.5') + lockFixture('wry', '0.55.1'));
+    assert.deepEqual(versions.get('tauri'), ['2.11.5']);
+    assert.deepEqual(versions.get('wry'), ['0.55.1']);
+  });
+
+  it('collects every locked copy when a crate appears at multiple versions', () => {
+    const versions = parseCargoLockVersions(lockFixture('getrandom', '0.2.17') + lockFixture('getrandom', '0.4.1'));
+    assert.deepEqual(versions.get('getrandom'), ['0.2.17', '0.4.1']);
+  });
+
+  it('fails when ANY locked copy is below the floor, even beside a patched one', () => {
+    // Multi-version crates are normal in Cargo.lock (this repo has dozens), so
+    // a patched copy must not mask a vulnerable duplicate of the same crate.
+    const errors = checkRustSecurityFloors(lockFixture('tauri', '2.11.5') + lockFixture('tauri', '2.10.3'));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /tauri 2\.10\.3 is below the security floor/);
+    assert.match(errors[0], /2 versions locked/);
+  });
+
+  it('passes when every floored crate meets its floor', () => {
+    assert.deepEqual(checkRustSecurityFloors(lockFixture('tauri', '2.11.1')), []);
+  });
+
+  it('fails when a crate sits below its floor (mutation: the CVE-2026-42184 regression)', () => {
+    const errors = checkRustSecurityFloors(lockFixture('tauri', '2.10.3'));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /tauri 2\.10\.3 is below the security floor 2\.11\.1/);
+    assert.match(errors[0], /cargo update -p tauri --precise/);
+  });
+
+  it('fails when a floored crate is absent entirely (vacuous-pass guard)', () => {
+    const errors = checkRustSecurityFloors(lockFixture('wry', '0.55.1'));
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /absent from Cargo\.lock/);
+  });
+
+  it('fails on an unparseable or empty lockfile rather than reporting zero violations', () => {
+    const errors = checkRustSecurityFloors('');
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /zero crates/);
+  });
+
+  it('keeps every floor entry documented with an advisory and issue', () => {
+    assert.ok(RUST_SECURITY_FLOORS.length > 0, 'at least one floor must be recorded');
+    for (const floor of RUST_SECURITY_FLOORS) {
+      assert.match(floor.crate, /^[a-z0-9_-]+$/, 'crate name');
+      assert.match(floor.minVersion, /^\d+\.\d+\.\d+$/, `${floor.crate} minVersion`);
+      assert.ok(floor.advisory?.length > 5, `${floor.crate} must cite its advisory`);
+      assert.ok(floor.reason?.length > 20, `${floor.crate} must record why the floor exists`);
+    }
+  });
+
+  it('holds against the real committed Cargo.lock', () => {
+    assert.deepEqual(checkRustSecurityFloors(realLock), []);
+  });
+
+  it('pins the real lockfile above the CVE-2026-42184 floor', () => {
+    const locked = parseCargoLockVersions(realLock).get('tauri');
+    assert.ok(locked?.length, 'tauri must be present in Cargo.lock');
+    for (const version of locked) {
+      assert.ok(
+        compareVersions(version, '2.11.1') >= 0,
+        `committed Cargo.lock pins tauri ${version}, below the 2.11.1 patched release`,
+      );
+    }
+  });
+});

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -506,11 +506,22 @@ describe('CI workflow coverage', () => {
     // no other job inspects it (security-audit covers npm lockfiles only), so
     // dropping this step would let a cargo update silently reintroduce a known
     // advisory — CVE-2026-42184 / #5518 is the case that motivated it.
+    const floorStep = workflowStepBlock(testWorkflow, 'Rust dependency security floors (#5518)');
     assert.match(
-      testJobBlock('desktop-config'),
+      floorStep,
       /^\s+run: node scripts\/check-rust-security-floors\.mjs\s*$/m,
       'desktop-config job must run the Rust dependency security-floor check',
     );
+    // A presence-only assertion would stay green with the step neutered, so
+    // pin that it still fails the job (same guard the AppImage step carries).
+    assert.doesNotMatch(floorStep, /^\s+continue-on-error:/m);
+    const releaseFloorStep = workflowStepBlock(desktopBuildWorkflow, 'Rust dependency security floors (#5518)');
+    assert.match(
+      releaseFloorStep,
+      /^\s+run: node scripts\/check-rust-security-floors\.mjs\s*$/m,
+      'release workflow must verify the security floors of the lockfile it ships',
+    );
+    assert.doesNotMatch(releaseFloorStep, /^\s+continue-on-error:/m);
     assert.match(
       testJobBlock('desktop-rust'),
       /if: needs\.changes\.outputs\.desktop_rust == 'true'/,

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -97,6 +97,7 @@ const REQUIRED_DESKTOP_CONFIG_INPUTS = [
   'package.json',
   'scripts/repack-linux-appimage.sh',
   'scripts/sync-desktop-version.mjs',
+  'scripts/check-rust-security-floors.mjs',
   '.github/workflows/(build-desktop|test-linux-app|test).yml',
 ] as const;
 
@@ -500,6 +501,15 @@ describe('CI workflow coverage', () => {
       testJobBlock('desktop-config'),
       /if: needs\.changes\.outputs\.desktop_config == 'true'/,
       'desktop-config job must use the desktop_config change output',
+    );
+    // Cargo.lock is the only thing that decides which crate versions ship, and
+    // no other job inspects it (security-audit covers npm lockfiles only), so
+    // dropping this step would let a cargo update silently reintroduce a known
+    // advisory — CVE-2026-42184 / #5518 is the case that motivated it.
+    assert.match(
+      testJobBlock('desktop-config'),
+      /^\s+run: node scripts\/check-rust-security-floors\.mjs\s*$/m,
+      'desktop-config job must run the Rust dependency security-floor check',
     );
     assert.match(
       testJobBlock('desktop-rust'),

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -579,6 +579,15 @@ describe('CI workflow coverage', () => {
     );
   });
 
+  it('runs workflow coverage when the release workflow changes', () => {
+    const codeFilter = shellAwkAssignmentBlock('CODE');
+    assert.doesNotMatch(
+      codeFilter,
+      /build-desktop\.yml/,
+      'build-desktop.yml changes must run the unit workflow-coverage assertions',
+    );
+  });
+
   it('runs scheduled and per-PR production dependency audits for every package lockfile', () => {
     const packageLockfiles = collectPackageLockfiles();
 


### PR DESCRIPTION
# fix(security): bump tauri to 2.11.5 and gate the advisory floor

Closes #5518. Part of #5902 (§2 release blockers) — this was the last
release-blocking security finding for the desktop release train.

## The vulnerability

CVE-2026-42184 / GHSA-7gmj-67g7-phm9 (CVSS 8.8): tauri's `is_local_url()`
matched only the **first subdomain label**, so a hostname like
`tauri.evil.com` could pass as a trusted local origin and invoke IPC commands
from a Windows/Android webview. This repo's `require_trusted_window()` label
gating is a partial mitigation — it checks the window label, not the URL — but
the version bump is the actual fix.

## Why #5518 could not be merged as-is

@aeonframework's PR proposed the right manifest constraint but changed **only
`src-tauri/Cargo.toml`**. `Cargo.lock` still pinned the vulnerable **2.10.3**,
and the lockfile is what decides what ships. Reproduced on this branch before
fixing:

```
$ cargo metadata --locked      # after the manifest-only change
error: the lock file .../Cargo.lock needs to be updated but --locked was passed
```

So merging it alone would have **failed every `--locked` build** — the
`desktop-rust` PR gate and the release build — while still shipping 2.10.3.
Regenerating the lockfile is the fix; this PR completes their change.

## What this does

- `src-tauri/Cargo.toml`: `tauri = "2"` → `">=2.11.1, <3"` (their proposal —
  it also bounds any future re-resolution above the patched floor).
- `src-tauri/Cargo.lock`: tauri **2.10.3 → 2.11.5** (latest patched 2.x) via
  `cargo update -p tauri --precise`, carrying its runtime family: tauri-build
  2.6.3, tauri-runtime 2.11.3, tauri-runtime-wry 2.11.4, tauri-utils 2.9.3,
  wry 0.55.1, tao 0.35.3.
  An unpinned `cargo update -p tauri` was **rejected**: it dragged unrelated
  transitive churn (cssparser 0.29→0.36, html5ever 0.29→0.38, derive_more
  0.99→2.1) that a security patch should not carry.
- `scripts/check-rust-security-floors.mjs` (new): asserts every recorded
  advisory floor against the committed lockfile. Each floor records crate,
  patched minimum, advisory, and **why**. Run locally with
  `npm run desktop:check-rust-floors`.

## Why the guard

`Cargo.lock` decides what ships and **nothing in CI inspected it** —
`security-audit` covers npm lockfiles only, and there is no cargo-audit /
cargo-deny anywhere. Without a floor check, a later `cargo update` could drop
straight back onto a vulnerable version with zero signal: exactly the silent
desktop-drift class #5902 exists to close.

Fails closed in three ways, each mutation-proven:
- a floored crate **below** its minimum → fail;
- a floored crate **absent** from the lockfile → fail (not a vacuous pass —
  removing a dependency must be an explicit decision to drop its floor);
- an **empty/unparseable** lockfile → fail rather than "0 violations".

Runs in the `desktop-config` PR gate (self-referentially: the script is in its
own path filter) **and in `build-desktop.yml`**, so the artifact users install
is audited directly rather than trusting that a PR gate fired on some earlier
commit. Pinned in `ci-workflow-coverage`, including `doesNotMatch(continue-on-error)`
so the step cannot be neutered while the guard stays green.

## Verification
- `cargo test --locked` → **14/14** with 2.11.5, including the
  `require_trusted_window` / IPC trusted-window tests — no API breakage from
  the bump.
- `src-tauri/open-url-safety.test.mjs` → 6/6 (the other Tauri security surface,
  GHSA-2x6r).
- Floor guard → 13/13, with mutations for below-floor, absent-crate,
  empty-lockfile, **vulnerable-duplicate-beside-patched-copy**, and both
  `--root` spellings; real tree exits 0, every mutation exits 1.
- `ci-workflow-coverage` → 15/15; docs-stats, biome, YAML parse, version:check
  all green.

Reviewed by correctness, security, and adversarial passes plus an independent
cross-model (Codex) adversarial pass. Their catches applied: multi-version
lockfile entries (37 crates in this lockfile legitimately appear at several
versions — a patched copy must not mask a vulnerable duplicate), the
silently-ignored `--root=` spelling, the neuterable wiring guard, and running
the check in the release workflow.

## Known Residuals (accepted, recorded)

- **Release build does not pass `--locked`.** `tauri-action` invokes cargo
  without it, so a lockfile/manifest disagreement would be silently
  re-resolved rather than failing loudly. Mitigated three ways: the manifest
  floor bounds any re-resolution above 2.11.1, the release workflow now runs
  the floor check on the committed lockfile, and `desktop-rust` enforces
  lock/manifest consistency on every src-tauri PR. The stricter fix
  (`args: ${{ matrix.args }} -- --locked` on all five build legs) is
  deliberately **not** included here: it cannot be verified without a full
  cross-platform release build, and a syntax mistake would break every release
  leg at the worst possible moment. Worth a follow-up with a dispatch build.
- The floor compares versions only, never a crate's `source`; a
  `[patch.crates-io]` or git dependency could supply different code under a
  passing version string. No such override exists in this repo today.
- Reverting the manifest constraint alone (back to `version = "2"`) is not
  itself gated — the lockfile floor is the backstop.
- Path filters key on changed filenames, so a PR that only *renames* the
  checker would not trigger `desktop-config`. Covered incidentally: the test
  file imports the script by path, and any `scripts/` change runs `unit`.

## Post-Deploy Monitoring & Validation
- No runtime/production impact — desktop build-time dependency only.
- Watch: the next `Desktop Canary (Linux)` run (Mon/Thu 05:23 UTC) builds and
  launches the app on tauri 2.11.5 — a green canary with rendered content and
  a live sidecar is the real-world validation.
- Failure signal: `desktop-config` red on "Rust dependency security floors"
  means the lockfile fell below a floor; the error names the crate, the
  advisory, and the exact `cargo update` to run.
- Rollback: revert the two commits; the app returns to 2.10.3 (vulnerable), so
  prefer rolling forward to a newer patched 2.x.

https://claude.ai/code/session_01URKVz1ntCv8X3knW8QBUeq