### PR TITLE
fix(auth): reject stale Clerk fallback after session switch

### DIFF
--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -545,6 +545,18 @@ export function clerkTokenExpiresAtMs(token: string | null): number | null {
 }
 
 /**
+ * Whether a token still has any lifetime left. This is intentionally weaker
+ * than shouldReuseCachedClerkToken(): a failed forced refresh may return the
+ * token already in hand for the request being made now, but never after its
+ * own expiry has passed.
+ */
+function hasTokenRemainingLifetime(token: string | null, now: number): boolean {
+  if (!token) return false;
+  const expiresAt = clerkTokenExpiresAtMs(token);
+  return expiresAt === null || now < expiresAt;
+}
+
+/**
  * Whether the cached token can still sign a request. Both bounds must hold.
  *
  * The TTL alone was the bug (Sentry WORLDMONITOR-XR/XQ): Clerk's `getToken()`
@@ -633,7 +645,7 @@ export async function getClerkToken(): Promise<string | null> {
       // If the session generation advanced while getToken() was in
       // flight, this JWT belongs to the previous user. Drop it on the
       // floor — do not cache, do not return.
-      if (myGen !== _tokenGen) return null;
+      if (myGen !== _tokenGen || clerkInstance?.session !== session) return null;
       const fetchedAt = Date.now();
       if (shouldReuseCachedClerkToken({ token, cachedAt: fetchedAt, now: fetchedAt })) {
         _cachedToken = token;
@@ -643,11 +655,7 @@ export async function getClerkToken(): Promise<string | null> {
       // Deliberately uncached: serving a near-expiry token for the full TTL is
       // the stacked-cache defect this function was rewritten to fix, so the next
       // caller must go back to Clerk once it is reachable again.
-      if (refreshUnavailable) {
-        const expiresAt = clerkTokenExpiresAtMs(token);
-        if (expiresAt === null || fetchedAt < expiresAt) return token;
-      }
-      return null;
+      return refreshUnavailable && hasTokenRemainingLifetime(token, Date.now()) ? token : null;
     } catch {
       return null;
     } finally {

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -469,6 +469,7 @@ export function getClerkUserCreatedAt(): number | null {
 export async function signOut(): Promise<void> {
   _cachedToken = null;
   _cachedTokenAt = 0;
+  _cachedSession = null;
   _tokenInflight = null;
   _tokenGen++;
   await clerkInstance?.signOut();
@@ -490,6 +491,7 @@ export async function signOut(): Promise<void> {
 export function clearClerkTokenCache(): void {
   _cachedToken = null;
   _cachedTokenAt = 0;
+  _cachedSession = null;
   _tokenInflight = null;
   _tokenGen++;
 }
@@ -508,6 +510,7 @@ export function clearClerkTokenCache(): void {
  */
 let _cachedToken: string | null = null;
 let _cachedTokenAt = 0;
+let _cachedSession: ClerkSession | null = null;
 let _tokenInflight: Promise<string | null> | null = null;
 let _tokenGen = 0;
 const TOKEN_CACHE_TTL_MS = 50_000;
@@ -603,7 +606,10 @@ async function fetchClerkToken(session: ClerkSession, skipCache = false): Promis
 }
 
 export async function getClerkToken(): Promise<string | null> {
-  if (shouldReuseCachedClerkToken({ token: _cachedToken, cachedAt: _cachedTokenAt, now: Date.now() })) {
+  if (
+    clerkInstance?.session === _cachedSession &&
+    shouldReuseCachedClerkToken({ token: _cachedToken, cachedAt: _cachedTokenAt, now: Date.now() })
+  ) {
     return _cachedToken;
   }
   if (_tokenInflight) return _tokenInflight;
@@ -650,6 +656,7 @@ export async function getClerkToken(): Promise<string | null> {
       if (shouldReuseCachedClerkToken({ token, cachedAt: fetchedAt, now: fetchedAt })) {
         _cachedToken = token;
         _cachedTokenAt = fetchedAt;
+        _cachedSession = session;
         return token;
       }
       // Deliberately uncached: serving a near-expiry token for the full TTL is

--- a/tests/clerk-token-cache-expiry.test.mts
+++ b/tests/clerk-token-cache-expiry.test.mts
@@ -261,19 +261,49 @@ describe('getClerkToken', () => {
 
   it('rejects a fallback when Clerk switches sessions before refresh failure returns', async () => {
     const nearExpiry = tokenExpiringAt(Date.now() + 5_000);
+    const replacementSession = {
+      async getToken() {
+        return null;
+      },
+    };
     const session = {
       async getToken(options: { template?: string; skipCache?: boolean } = {}) {
         if (options.skipCache) {
-          clerk.session = null;
+          clerk.session = replacementSession;
           throw new Error('network');
         }
         return nearExpiry;
       },
     };
-    const clerk: { session: typeof session | null } = { session };
+    const clerk: { session: typeof session | typeof replacementSession | null } = { session };
     __setClerkInstanceForTests(clerk as never);
 
     assert.equal(await getClerkToken(), null);
+  });
+
+  it('does not reuse a cached token after Clerk switches to another session', async () => {
+    const tokenA = tokenExpiringAt(Date.now() + 60_000);
+    const tokenB = tokenExpiringAt(Date.now() + 60_000);
+    let sessionBCalls = 0;
+    const sessionA = {
+      async getToken() {
+        return tokenA;
+      },
+    };
+    const sessionB = {
+      async getToken() {
+        sessionBCalls += 1;
+        return tokenB;
+      },
+    };
+    const clerk: { session: typeof sessionA | typeof sessionB | null } = { session: sessionA };
+    __setClerkInstanceForTests(clerk as never);
+
+    assert.equal(await getClerkToken(), tokenA);
+    clerk.session = sessionB;
+
+    assert.equal(await getClerkToken(), tokenB);
+    assert.equal(sessionBCalls, 1);
   });
 
   it('does not cache a fallback token', async () => {

--- a/tests/clerk-token-cache-expiry.test.mts
+++ b/tests/clerk-token-cache-expiry.test.mts
@@ -238,11 +238,6 @@ describe('getClerkToken', () => {
   /**
    * The fallback must not strand the session on the degraded token: once Clerk
    * is reachable again the very next caller gets a healthy one.
-   *
-   * Note this does NOT assert the fallback goes uncached, and no test can —
-   * a token rejected by the freshness gate at fetch time can never satisfy that
-   * same gate on a later read, so the cache entry is unreachable either way.
-   * Mutating the source to cache it leaves every test in this file green.
    */
   it('recovers to a healthy token as soon as the forced refresh works again', async () => {
     const nearExpiry = tokenExpiringAt(Date.now() + 5_000);
@@ -262,5 +257,50 @@ describe('getClerkToken', () => {
     assert.equal(await getClerkToken(), nearExpiry);
     refreshBroken = false;
     assert.equal(await getClerkToken(), healthy);
+  });
+
+  it('rejects a fallback when Clerk switches sessions before refresh failure returns', async () => {
+    const nearExpiry = tokenExpiringAt(Date.now() + 5_000);
+    const session = {
+      async getToken(options: { template?: string; skipCache?: boolean } = {}) {
+        if (options.skipCache) {
+          clerk.session = null;
+          throw new Error('network');
+        }
+        return nearExpiry;
+      },
+    };
+    const clerk: { session: typeof session | null } = { session };
+    __setClerkInstanceForTests(clerk as never);
+
+    assert.equal(await getClerkToken(), null);
+  });
+
+  it('does not cache a fallback token', async () => {
+    const originalNow = Date.now;
+    let now = 10_000;
+    Date.now = () => now;
+    try {
+      const nearExpiry = tokenExpiringAt(20_000);
+      const healthy = tokenExpiringAt(100_000);
+      let normalCalls = 0;
+      const session = {
+        async getToken(options: { skipCache?: boolean } = {}) {
+          if (options.skipCache) throw new Error('network');
+          normalCalls += 1;
+          return normalCalls === 1 ? nearExpiry : healthy;
+        },
+      };
+      __setClerkInstanceForTests({ session } as never);
+
+      assert.equal(await getClerkToken(), nearExpiry);
+      // Move back one millisecond so a mutant that caches the fallback would
+      // pass the freshness gate; the real implementation must call Clerk.
+      now -= 1;
+      assert.equal(await getClerkToken(), healthy);
+      assert.equal(normalCalls, 2);
+    } finally {
+      Date.now = originalNow;
+    }
   });
 });


### PR DESCRIPTION
Summary
Follow-up to merged #5933 / issue #5931.\n\nThe merged forced-refresh fallback can still finish after Clerk's session object has switched. _tokenGen only changes when the auth listener observes the change; during that window a near-expiry token from the prior session can be returned to a caller. This change verifies session object identity as well as generation before caching or returning a token.\n\nIt also replaces the expiry check's captured timestamp with a final current-time check, and adds a regression that proves the degraded fallback is not cached.\n\n## Validation\n\n- 53 adjacent auth/checkout tests pass.\n- npm run typecheck passes.\n- Biome and npm run lint pass.\n- Pre-push gates pass, including 240 changed/edge tests.\n- Mutation checks: restoring the unconditional refresh overwrite fails 3 tests; caching the fallback fails the no-cache test; removing the session-identity guard fails the session-switch test.\n\n## Post-Deploy Monitoring & Validation\n\n- Search Sentry for WORLDMONITOR-Q9, Checkout error: session_expired, action:no-token, and premium-route 401s.\n- Healthy signals: no new signed-in session_expired/no-token cluster; token-bearing premium calls succeed; session-switch calls return no stale token.\n- Failure/rollback: any renewed cluster of those events or wrong-account token observations triggers rollback to the prior deployment and investigation of Clerk reachability and session transitions.\n- Window/owner: monitor the first 24 hours after deployment against the prior 72-hour baseline; WorldMonitor maintainer/on-call owns follow-up.