### PR TITLE
feat(growth): operationalize AI visibility evidence loop

### DIFF
--- a/docs/research/seo-ai-visibility/README.md
+++ b/docs/research/seo-ai-visibility/README.md
@@ -12,10 +12,13 @@ missing source cannot silently become a zero or a site-wide vanity score.
   windows, manual AI observations, the exact query-contract digest,
   reproduction context, and the prioritized opportunity queue.
 - `scorecards/<date>.md` — deterministic human report generated from a baseline.
+- `scripts/seo-ai-visibility-collector.mjs` — secure local importer for bounded
+  first-party exports; it emits only the normalized baseline contract.
 - `scripts/seo-ai-visibility-scorecard.mjs` — validator, scorecard renderer, and
   monthly comparison.
-- `tests/seo-ai-visibility-scorecard.test.mjs` — schema, missingness, aggregation,
-  comparison, and reproducibility coverage.
+- `tests/seo-ai-visibility-collector.test.mjs` and
+  `tests/seo-ai-visibility-scorecard.test.mjs` — importer, schema, missingness,
+  aggregation, comparison, and reproducibility coverage.
 
 The committed initial period is `2026-07-27`. It contains a four-platform manual
 observation for `q01`. Search Console, Bing Webmaster, and referral values are
@@ -51,6 +54,61 @@ start a new baseline series with the digest computed by
 `computeQuerySetDigest()` in the scorecard module. Existing baselines must keep
 their original ID and digest; the validator rejects silently reinterpreting
 historical observations with a newer query definition.
+
+## First-party collection and secure import
+
+`scripts/seo-ai-visibility-collector.mjs` turns a local source manifest into a
+dated baseline. It does not authenticate to providers, scrape result pages, or
+write raw exports. Operators should obtain read-only exports through the
+provider UI/API, keep credentials and raw files outside the repository, and
+pass only the bounded manifest to the collector:
+
+```bash
+node scripts/seo-ai-visibility-collector.mjs \
+  --queries docs/research/seo-ai-visibility/query-set.json \
+  --template docs/research/seo-ai-visibility/baselines/2026-07-27.json \
+  --sources "$SEO_VISIBILITY_SOURCE_MANIFEST" \
+  --observed-at "$SEO_VISIBILITY_OBSERVED_AT" \
+  --output "$SEO_VISIBILITY_RUN_DIR/baseline.json"
+```
+
+The manifest is intentionally narrow:
+
+- `googleSearchConsole` and `bingWebmaster.search` contain trailing `28d` and
+  `90d` windows with aggregate metrics, exact reviewed `query`/`queryId` rows,
+  and `page`/`pageFamily` rows. Query text must exactly match `query-set.json`;
+  unknown queries and page families fail closed. The normalized artifact drops
+  property IDs and tokens.
+- `bingWebmaster.aiPerformance` contains the same two windows plus provider-
+  reported `totalCitations`, `averageCitedPages`, `groundingQueries`, and
+  `citedPages`. Cited pages must be HTTPS `worldmonitor.app` URLs. Citation
+  totals describe observed source usage, not ranking or authority.
+- `referrals` contains bounded aggregate `metrics` or event `rows` grouped only
+  by the reviewed `referrerFamily` and `landingPageFamily`. Supported events are
+  sessions, dashboard launches, pricing views, sign-ups, checkout success,
+  completed `pro-activation-exit`, successful API-key actions, and successful
+  MCP connections. Attempt events are not counted as successful outcomes.
+- `collectionContext`, `aiSurfaces`, and `aiObservations` are copied through a
+  whitelist. Unknown provider fields and raw prompt, account/session, key, and
+  user-level payload fields are never written to the baseline; keep personal
+  prompt content out of the reviewed summary fields as well.
+
+For every source, use `status: "partial"` when only some windows/metrics are
+supported and `status: "unavailable"` with a reason when access is missing.
+The collector preserves provider-reported zeroes and emits `null` for omitted
+metrics. It requires two trailing windows for search and Bing AI Performance;
+missing referral dimensions remain partial rather than being inferred. Validate
+the generated file before rendering the report:
+
+```bash
+node scripts/seo-ai-visibility-collector.mjs \
+  --queries docs/research/seo-ai-visibility/query-set.json \
+  --template docs/research/seo-ai-visibility/baselines/2026-07-27.json \
+  --sources "$SEO_VISIBILITY_SOURCE_MANIFEST" \
+  --observed-at "$SEO_VISIBILITY_OBSERVED_AT" \
+  --output "$SEO_VISIBILITY_RUN_DIR/baseline.json" \
+  --check
+```
 
 ## Weekly collection
 
@@ -132,8 +190,9 @@ The normalized outcome fields are:
 | `pricingViews` | `/pro` pricing pageviews |
 | `signUps` | `sign-up` |
 | `proConversions` | `checkout-success`, reconciled to aggregate commerce totals |
-| `apiActions` | Bounded API-reference/key-management actions when available |
-| `mcpActions` | `mcp-connect-attempt` / `mcp-connect-success` |
+| `activations` | Completed `pro-activation-exit` events only |
+| `apiActions` | Successful, bounded API-key lifecycle actions when available |
+| `mcpActions` | `mcp-connect-success` only; attempts remain separate telemetry |
 
 Put aggregate totals in `referrals.windows`. Put bounded cross-sections in
 `referrals.segments`, keyed by `windowLabel`, `referrerFamily`, and
@@ -181,7 +240,9 @@ starting a new baseline series instead of presenting incomparable audits as
 month-over-month movement.
 
 Thresholds are diagnostics, not causal claims. A single answer, citation, or
-traffic change never proves uplift.
+traffic change never proves uplift. Sparse observations, a missing provider, or
+a citation-only change cannot be presented as causal traffic, sign-up,
+conversion, activation, API, or MCP uplift.
 
 ## Secure configuration
 

--- a/docs/research/seo-ai-visibility/baselines/2026-07-27.json
+++ b/docs/research/seo-ai-visibility/baselines/2026-07-27.json
@@ -107,7 +107,35 @@
         }
       ],
       "queryRows": [],
-      "pageFamilyRows": []
+      "pageFamilyRows": [],
+      "aiPerformance": {
+        "status": "unavailable",
+        "reason": "No Bing AI Performance export or property access was available. Citation totals, cited pages, and grounding queries remain null rather than being inferred.",
+        "windows": [
+          {
+            "label": "28d",
+            "startDate": "2026-06-30",
+            "endDate": "2026-07-27",
+            "metrics": {
+              "totalCitations": null,
+              "averageCitedPages": null
+            },
+            "groundingQueries": [],
+            "citedPages": []
+          },
+          {
+            "label": "90d",
+            "startDate": "2026-04-29",
+            "endDate": "2026-07-27",
+            "metrics": {
+              "totalCitations": null,
+              "averageCitedPages": null
+            },
+            "groundingQueries": [],
+            "citedPages": []
+          }
+        ]
+      }
     }
   },
   "referrals": {
@@ -202,6 +230,7 @@
           "pricingViews": null,
           "signUps": null,
           "proConversions": null,
+          "activations": null,
           "apiActions": null,
           "mcpActions": null
         }
@@ -216,6 +245,7 @@
           "pricingViews": null,
           "signUps": null,
           "proConversions": null,
+          "activations": null,
           "apiActions": null,
           "mcpActions": null
         }

--- a/docs/research/seo-ai-visibility/scorecards/2026-07-27.md
+++ b/docs/research/seo-ai-visibility/scorecards/2026-07-27.md
@@ -20,6 +20,7 @@ Query contract: `seo-ai-visibility-v1` / `sha256:b31f4c299f414d1ffe889d1a3cdbb86
 | Google Search Console | Unavailable — No supported Search Console export or read-only property credential was available. Values remain null rather than being estimated from public result pages. | 28d, 90d |
 | Bing Webmaster | Unavailable — No Bing Webmaster export or property access was available. IndexNow support does not substitute for Bing query and click reporting. | 28d, 90d |
 | Referral analytics | Unavailable — The Umami/commerce aggregates were not exported into this clean environment. Existing event names are documented for the next read-only reconciliation, but no session or conversion count is inferred. | 28d, 90d |
+| Bing AI Performance | Unavailable — No Bing AI Performance export or property access was available. Citation totals, cited pages, and grounding queries remain null rather than being inferred. | 28d, 90d |
 
 | AI surface | Status |
 | --- | --- |
@@ -29,6 +30,15 @@ Query contract: `seo-ai-visibility-v1` / `sha256:b31f4c299f414d1ffe889d1a3cdbb86
 | Copilot Search | Available |
 
 Referral families: ChatGPT, Perplexity, Google Search / AI, Copilot / Bing, Claude, Other identified AI/search, Unknown / direct.
+
+## Bing AI Performance
+
+Citation counts describe observed source usage, not ranking, authority, or causal traffic.
+
+| Window | Total citations | Average cited pages | Grounding phrases | Cited pages |
+| --- | ---: | ---: | ---: | ---: |
+| 28d | Unavailable | Unavailable | Unavailable | Unavailable |
+| 90d | Unavailable | Unavailable | Unavailable | Unavailable |
 
 ## Query registry
 
@@ -60,28 +70,28 @@ Referral families: ChatGPT, Perplexity, Google Search / AI, Copilot / Bing, Clau
 Referral segments retain both the major referrer family and landing-page family.
 Unavailable aggregates remain unavailable in every slice.
 
-| Referrer family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | API actions | MCP actions |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| ChatGPT | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Perplexity | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Google Search / AI | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Copilot / Bing | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Claude | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Other identified AI/search | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Unknown / direct | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Referrer family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | Activations | API actions | MCP actions |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| ChatGPT | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Perplexity | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Google Search / AI | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Copilot / Bing | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Claude | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Other identified AI/search | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Unknown / direct | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
 
-| Landing-page family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | API actions | MCP actions |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| Homepage | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Dashboard | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Blog | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Documentation | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Country pages | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Chokepoints | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Crises | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Tools | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Pricing | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
-| Developer / MCP | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Landing-page family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | Activations | API actions | MCP actions |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Homepage | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Dashboard | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Blog | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Documentation | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Country pages | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Chokepoints | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Crises | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Tools | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Pricing | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
+| Developer / MCP | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable | Unavailable |
 
 ## AI-answer audit
 

--- a/scripts/seo-ai-visibility-collector.mjs
+++ b/scripts/seo-ai-visibility-collector.mjs
@@ -1,0 +1,760 @@
+#!/usr/bin/env node
+
+/**
+ * Normalize first-party SEO and product-outcome exports into the reviewed
+ * scorecard baseline contract.
+ *
+ * The collector accepts only bounded aggregate exports. It deliberately picks
+ * fields from the input instead of copying arbitrary provider payloads, so
+ * property identifiers, credentials, prompts, session ids, and user ids never
+ * reach a committed baseline.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+
+import {
+  PAGE_FAMILIES,
+  BING_AI_METRICS,
+  REFERRAL_METRICS,
+  SEARCH_PERFORMANCE_METRICS,
+  SEARCH_METRICS,
+  computeQuerySetDigest,
+  isNonEmptyString,
+  isWorldMonitorUrl,
+  validateBaseline,
+} from './seo-ai-visibility-scorecard.mjs';
+import { isMainModule } from './lib/main-module.mjs';
+
+const UTC_DAY_MS = 86_400_000;
+const WINDOW_DAYS = Object.freeze({ '28d': 28, '90d': 90 });
+const REFERRER_FAMILIES = new Set([
+  'chatgpt',
+  'perplexity',
+  'google_search_ai',
+  'copilot_bing',
+  'claude',
+  'other_ai_search',
+  'unknown_direct',
+]);
+const EVENT_METRICS = Object.freeze({
+  session: 'sessions',
+  sessions: 'sessions',
+  'dashboard-launch': 'dashboardLaunches',
+  'dashboard-launches': 'dashboardLaunches',
+  'pricing-view': 'pricingViews',
+  'pricing-views': 'pricingViews',
+  'sign-up': 'signUps',
+  'checkout-success': 'proConversions',
+  'pro-activation-exit': 'activations',
+  activation: 'activations',
+  'api-action': 'apiActions',
+  'api-key-created': 'apiActions',
+  'api-key-revoked': 'apiActions',
+  'mcp-connect-success': 'mcpActions',
+});
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(`[seo-visibility-collector] ${message}`);
+}
+
+function isIsoCalendarDate(value) {
+  if (!isNonEmptyString(value) || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return parsed.toISOString().slice(0, 10) === value;
+}
+
+function assertIsoCalendarDate(value, field) {
+  invariant(isIsoCalendarDate(value), `${field} must be an ISO calendar date`);
+}
+
+function assertIsoUtcDateTime(value, field) {
+  invariant(
+    isNonEmptyString(value)
+      && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/.test(value)
+      && Number.isFinite(Date.parse(value)),
+    `${field} must be an ISO UTC date-time`,
+  );
+}
+
+function observationDate(observedAt) {
+  assertIsoUtcDateTime(observedAt, 'observedAt');
+  return observedAt.slice(0, 10);
+}
+
+function dateMinusInclusiveDays(endDate, days) {
+  const start = new Date(`${endDate}T00:00:00Z`).getTime() - ((days - 1) * UTC_DAY_MS);
+  return new Date(start).toISOString().slice(0, 10);
+}
+
+export function deriveTrailingWindows(observedAt) {
+  const endDate = observationDate(observedAt);
+  return Object.entries(WINDOW_DAYS).map(([label, days]) => ({
+    label,
+    startDate: dateMinusInclusiveDays(endDate, days),
+    endDate,
+  }));
+}
+
+function finiteNumber(value, field, { nullable = true, maximum = Infinity } = {}) {
+  if (value === undefined || value === null || value === '') {
+    invariant(nullable, `${field} is required`);
+    return null;
+  }
+  invariant(
+    typeof value === 'number' && Number.isFinite(value),
+    `${field} must be a finite number or null`,
+  );
+  invariant(value >= 0, `${field} must be non-negative`);
+  invariant(value <= maximum, `${field} is outside its allowed range`);
+  return value;
+}
+
+function sourceValue(raw, key, aliases = []) {
+  const record = raw?.metrics && typeof raw.metrics === 'object' ? raw.metrics : raw;
+  for (const candidate of [key, ...aliases]) {
+    if (record && candidate in record) return record[candidate];
+    if (raw && candidate in raw) return raw[candidate];
+  }
+  return undefined;
+}
+
+function normalizeSearchMetrics(raw, { includeIndexedPages }) {
+  return {
+    indexedPages: includeIndexedPages
+      ? finiteNumber(sourceValue(raw, 'indexedPages'), 'indexedPages')
+      : null,
+    impressions: finiteNumber(sourceValue(raw, 'impressions'), 'impressions'),
+    clicks: finiteNumber(sourceValue(raw, 'clicks'), 'clicks'),
+    ctr: finiteNumber(sourceValue(raw, 'ctr'), 'ctr', { maximum: 1 }),
+    averagePosition: finiteNumber(
+      sourceValue(raw, 'averagePosition', ['position']),
+      'averagePosition',
+    ),
+  };
+}
+
+function aggregateSearchRows(rows, includeIndexedPages) {
+  const metricSum = (metric) => (
+    rows.length > 0 && rows.every(({ metrics }) => Number.isFinite(metrics[metric]))
+      ? rows.reduce((total, row) => total + row.metrics[metric], 0)
+      : null
+  );
+  const impressions = metricSum('impressions');
+  const clicks = metricSum('clicks');
+  const ctr = impressions !== null && clicks !== null
+    ? (impressions > 0 ? clicks / impressions : 0)
+    : null;
+  const averagePosition = impressions !== null
+    && impressions > 0
+    && rows.every(({ metrics }) => (
+      Number.isFinite(metrics.averagePosition)
+      && Number.isFinite(metrics.impressions)
+    ))
+    ? rows.reduce(
+      (total, row) => total + (row.metrics.averagePosition * row.metrics.impressions),
+      0,
+    ) / impressions
+    : null;
+  return {
+    indexedPages: includeIndexedPages ? metricSum('indexedPages') : null,
+    impressions,
+    clicks,
+    ctr,
+    averagePosition,
+  };
+}
+
+function mergeMetrics(explicit, aggregate) {
+  return Object.fromEntries(
+    SEARCH_METRICS.map((metric) => [
+      metric,
+      explicit[metric] ?? aggregate[metric],
+    ]),
+  );
+}
+
+function metricsAreComplete(metrics) {
+  return SEARCH_METRICS.every((metric) => Number.isFinite(metrics[metric]));
+}
+
+function performanceMetricsAreComplete(metrics) {
+  return SEARCH_PERFORMANCE_METRICS.every((metric) => Number.isFinite(metrics[metric]));
+}
+
+function canonicalWindows(rawWindows, observedAt, { requireTrailing = false } = {}) {
+  const fallback = new Map(deriveTrailingWindows(observedAt).map((window) => [window.label, window]));
+  const windows = Array.isArray(rawWindows) && rawWindows.length > 0
+    ? rawWindows
+    : [...fallback.values()];
+  const labels = new Set();
+  const normalized = windows.map((window, index) => {
+    invariant(window && typeof window === 'object', `windows[${index}] must be an object`);
+    const label = window.label;
+    invariant(isNonEmptyString(label), `windows[${index}].label is required`);
+    invariant(!labels.has(label), `duplicate window ${label}`);
+    labels.add(label);
+    const defaultWindow = fallback.get(label);
+    const startDate = window.startDate ?? defaultWindow?.startDate;
+    const endDate = window.endDate ?? defaultWindow?.endDate;
+    assertIsoCalendarDate(startDate, `windows[${index}].startDate`);
+    assertIsoCalendarDate(endDate, `windows[${index}].endDate`);
+    invariant(
+      Date.parse(startDate) <= Date.parse(endDate),
+      `windows[${index}].startDate must not be after endDate`,
+    );
+    invariant(
+      Date.parse(endDate) <= Date.parse(observationDate(observedAt)),
+      `windows[${index}].endDate must not be after observedAt`,
+    );
+    return { label, startDate, endDate, raw: window };
+  });
+  if (requireTrailing) {
+    for (const label of Object.keys(WINDOW_DAYS)) {
+      invariant(labels.has(label), `source must include trailing ${label} window`);
+    }
+  }
+  return normalized;
+}
+
+function unavailableSearchSource(observedAt, reason) {
+  return {
+    status: 'unavailable',
+    property: null,
+    reason,
+    windows: deriveTrailingWindows(observedAt).map((window) => ({
+      ...window,
+      metrics: Object.fromEntries(SEARCH_METRICS.map((metric) => [metric, null])),
+    })),
+    queryRows: [],
+    pageFamilyRows: [],
+  };
+}
+
+function unavailableBingAiPerformance(observedAt, reason) {
+  return {
+    status: 'unavailable',
+    reason,
+    windows: deriveTrailingWindows(observedAt).map((window) => ({
+      ...window,
+      metrics: Object.fromEntries(BING_AI_METRICS.map((metric) => [metric, null])),
+      groundingQueries: [],
+      citedPages: [],
+    })),
+  };
+}
+
+function pageRoute(value, field) {
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`[seo-visibility-collector] ${field} must be an HTTPS URL`);
+  }
+  invariant(parsed.protocol === 'https:', `${field} must be an HTTPS URL`);
+  const normalizedPath = parsed.pathname.replace(/\/+$/, '') || '/';
+  return `${parsed.hostname}${normalizedPath}`;
+}
+
+function createQueryIndexes(querySet) {
+  const queryById = new Map(querySet.queries.map((query) => [query.id, query]));
+  const queryByText = new Map(querySet.queries.map((query) => [query.query, query]));
+  const pageFamilyByRoute = new Map();
+  for (const query of querySet.queries) {
+    const route = pageRoute(query.targetPage.url, `${query.id}.targetPage.url`);
+    if (!pageFamilyByRoute.has(route)) pageFamilyByRoute.set(route, query.targetPage.family);
+  }
+  return { queryById, queryByText, pageFamilyByRoute };
+}
+
+function queryIdForRow(row, { queryById, queryByText }) {
+  const declaredId = row.queryId ?? null;
+  const declaredText = row.query ?? row.queryText ?? null;
+  const query = declaredId ? queryById.get(declaredId) : queryByText.get(declaredText);
+  invariant(query, 'imported row must reference an exact reviewed query text or queryId');
+  if (declaredText !== null) {
+    invariant(
+      declaredText === query.query,
+      `${declaredId ?? declaredText} must use exact reviewed query text`,
+    );
+  }
+  return query.id;
+}
+
+function normalizePageFamily(row, { pageFamilyByRoute }) {
+  if (isNonEmptyString(row.pageFamily)) {
+    invariant(PAGE_FAMILIES.includes(row.pageFamily), `unknown page family ${row.pageFamily}`);
+    return row.pageFamily;
+  }
+  const page = row.page ?? row.url ?? null;
+  invariant(isNonEmptyString(page), 'page-family row requires page or pageFamily');
+  const family = pageFamilyByRoute.get(pageRoute(page, 'page'));
+  invariant(family, `page does not map to a reviewed page family: ${page}`);
+  return family;
+}
+
+function sourceStatus(raw, windows, queryRows, pageFamilyRows) {
+  if (raw?.status === 'unavailable') return 'unavailable';
+  const requested = raw?.status === 'partial' ? 'partial' : 'available';
+  const complete = windows.every(({ metrics }) => metricsAreComplete(metrics))
+    && queryRows.every(({ metrics }) => performanceMetricsAreComplete(metrics))
+    && pageFamilyRows.every(({ metrics }) => metricsAreComplete(metrics));
+  return requested === 'partial' || !complete ? 'partial' : 'available';
+}
+
+export function normalizeSearchExport(raw, { querySet, observedAt, provider = 'search' }) {
+  if (!raw || raw.status === 'unavailable') {
+    return unavailableSearchSource(
+      observedAt,
+      raw?.reason ?? `No supported ${provider} export was supplied.`,
+    );
+  }
+  const windows = canonicalWindows(raw.windows, observedAt, { requireTrailing: true });
+  const queryIndexes = createQueryIndexes(querySet);
+  const queryRows = [];
+  const pageFamilyRows = [];
+  const normalizedWindows = [];
+  for (const window of windows) {
+    const rawWindow = window.raw;
+    const normalizedQueryRows = (rawWindow.queryRows ?? []).map((row) => {
+      const { indexedPages: _indexedPages, ...metrics } = normalizeSearchMetrics(
+        row,
+        { includeIndexedPages: false },
+      );
+      return {
+        windowLabel: window.label,
+        queryId: queryIdForRow(row, queryIndexes),
+        metrics,
+      };
+    });
+    const normalizedPageRows = (rawWindow.pageFamilyRows ?? rawWindow.pageRows ?? []).map((row) => ({
+      windowLabel: window.label,
+      pageFamily: normalizePageFamily(row, queryIndexes),
+      metrics: normalizeSearchMetrics(row, { includeIndexedPages: true }),
+    }));
+    const explicitMetrics = normalizeSearchMetrics(rawWindow, { includeIndexedPages: true });
+    const aggregate = aggregateSearchRows(normalizedQueryRows, false);
+    const metrics = mergeMetrics(explicitMetrics, aggregate);
+    queryRows.push(...normalizedQueryRows);
+    pageFamilyRows.push(...normalizedPageRows);
+    normalizedWindows.push({
+      label: window.label,
+      startDate: window.startDate,
+      endDate: window.endDate,
+      metrics,
+    });
+  }
+  const status = sourceStatus(raw, normalizedWindows, queryRows, pageFamilyRows);
+  return {
+    status,
+    property: null,
+    reason: status === 'available' ? null : (raw.reason ?? 'The imported provider data is partial.'),
+    windows: normalizedWindows,
+    queryRows: status === 'unavailable' ? [] : queryRows,
+    pageFamilyRows: status === 'unavailable' ? [] : pageFamilyRows,
+  };
+}
+
+function normalizeBingAiWindow(window) {
+  const totalCitations = finiteNumber(
+    window.totalCitations ?? window.citationTotal,
+    'totalCitations',
+  );
+  const averageCitedPages = finiteNumber(
+    window.averageCitedPages,
+    'averageCitedPages',
+  );
+  const groundingQueries = (window.groundingQueries ?? []).map((query, index) => ({
+    phrase: query.phrase ?? query.query ?? query.groundingQuery,
+    citationCount: finiteNumber(
+      query.citationCount ?? query.citations ?? query.count,
+      `groundingQueries[${index}].citationCount`,
+    ),
+  }));
+  const citedPages = (window.citedPages ?? window.citedUrls ?? []).map((page, index) => {
+    const url = page.url ?? page.page;
+    invariant(isNonEmptyString(url), `citedPages[${index}].url is required`);
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new Error(`[seo-visibility-collector] citedPages[${index}].url must be an HTTPS URL`);
+    }
+    invariant(
+      parsed.protocol === 'https:' && isWorldMonitorUrl(url),
+      `citedPages[${index}].url must be a World Monitor HTTPS URL`,
+    );
+    return {
+      url,
+      citationCount: finiteNumber(
+        page.citationCount ?? page.citations ?? page.count,
+        `citedPages[${index}].citationCount`,
+      ),
+    };
+  });
+  return {
+    metrics: { totalCitations, averageCitedPages },
+    groundingQueries,
+    citedPages,
+  };
+}
+
+export function normalizeBingAiPerformance(raw, { observedAt }) {
+  if (!raw || raw.status === 'unavailable') {
+    return unavailableBingAiPerformance(
+      observedAt,
+      raw?.reason ?? 'No Bing AI Performance export was supplied.',
+    );
+  }
+  const windows = canonicalWindows(raw.windows, observedAt, { requireTrailing: true });
+  const normalizedWindows = windows.map((window) => ({
+    label: window.label,
+    startDate: window.startDate,
+    endDate: window.endDate,
+    ...normalizeBingAiWindow(window.raw),
+  }));
+  const complete = normalizedWindows.every(({ metrics }) => (
+    BING_AI_METRICS.every((metric) => Number.isFinite(metrics[metric]))
+  ));
+  const status = raw.status === 'partial' || !complete ? 'partial' : 'available';
+  return {
+    status,
+    reason: status === 'available' ? null : (raw.reason ?? 'The imported Bing AI Performance data is partial.'),
+    windows: normalizedWindows,
+  };
+}
+
+function unavailableReferralExport(observedAt, classification, reason) {
+  return {
+    status: 'unavailable',
+    property: null,
+    reason,
+    classification: structuredClone(classification),
+    windows: deriveTrailingWindows(observedAt).map((window) => ({
+      ...window,
+      metrics: Object.fromEntries(REFERRAL_METRICS.map((metric) => [metric, null])),
+    })),
+    segments: [],
+  };
+}
+
+function normalizeReferrerFamily(value) {
+  const family = value ?? 'unknown_direct';
+  invariant(REFERRER_FAMILIES.has(family), `unknown referrer family ${family}`);
+  return family;
+}
+
+function normalizeLandingPageFamily(value) {
+  invariant(PAGE_FAMILIES.includes(value), `unknown landing page family ${value}`);
+  return value;
+}
+
+function eventMetric(row) {
+  const event = row.event ?? row.eventName ?? null;
+  if (event === 'pageview') {
+    if (row.landingPageFamily === 'dashboard' || row.landingPageFamily === 'homepage') {
+      return 'dashboardLaunches';
+    }
+    if (row.landingPageFamily === 'pricing') return 'pricingViews';
+    return null;
+  }
+  if (event === 'pro-activation-exit' && row.completion !== 'complete') return null;
+  return EVENT_METRICS[event] ?? null;
+}
+
+function eventCount(row, field) {
+  return finiteNumber(
+    row.count ?? row.value ?? row.total,
+    `${field}.count`,
+    { nullable: false },
+  );
+}
+
+function emptyReferralMetrics() {
+  return Object.fromEntries(REFERRAL_METRICS.map((metric) => [metric, null]));
+}
+
+function mergeReferralMetric(target, metric, value) {
+  if (value === null) return;
+  target[metric] = target[metric] === null ? value : target[metric] + value;
+}
+
+function normalizeReferralRows(rows, windowLabel) {
+  const segments = new Map();
+  for (const [index, row] of rows.entries()) {
+    const referrerFamily = normalizeReferrerFamily(row.referrerFamily);
+    const landingPageFamily = normalizeLandingPageFamily(row.landingPageFamily);
+    const key = `${referrerFamily}:${landingPageFamily}`;
+    const metrics = segments.get(key) ?? {
+      windowLabel,
+      referrerFamily,
+      landingPageFamily,
+      metrics: emptyReferralMetrics(),
+    };
+    if (row.metrics && typeof row.metrics === 'object') {
+      for (const metric of REFERRAL_METRICS) {
+        const value = finiteNumber(row.metrics[metric], `rows[${index}].metrics.${metric}`);
+        mergeReferralMetric(metrics.metrics, metric, value);
+      }
+    } else {
+      const metric = eventMetric(row);
+      if (metric) mergeReferralMetric(metrics.metrics, metric, eventCount(row, `rows[${index}]`));
+    }
+    segments.set(key, metrics);
+  }
+  return [...segments.values()].filter(({ metrics }) => (
+    REFERRAL_METRICS.some((metric) => Number.isFinite(metrics[metric]))
+  ));
+}
+
+function aggregateReferralSegments(segments) {
+  return Object.fromEntries(REFERRAL_METRICS.map((metric) => {
+    const values = segments
+      .map((segment) => segment.metrics[metric])
+      .filter((value) => Number.isFinite(value));
+    return [metric, values.length > 0 ? values.reduce((sum, value) => sum + value, 0) : null];
+  }));
+}
+
+function normalizeStringArray(value, field) {
+  invariant(Array.isArray(value), `${field} must be an array`);
+  return value.map((item, index) => {
+    invariant(isNonEmptyString(item), `${field}[${index}] must be a non-empty string`);
+    return item;
+  });
+}
+
+function normalizeCollectionContext(raw, fallback) {
+  const context = raw ?? fallback;
+  invariant(context && typeof context === 'object', 'collection context is required');
+  return {
+    geography: context.geography,
+    locale: context.locale,
+    signedInStates: normalizeStringArray(context.signedInStates, 'collectionContext.signedInStates'),
+    device: context.device,
+    limitations: normalizeStringArray(context.limitations, 'collectionContext.limitations'),
+  };
+}
+
+function normalizeAiSurfaces(raw, fallback) {
+  const surfaces = raw ?? fallback;
+  invariant(Array.isArray(surfaces), 'AI surface manifest is required');
+  return surfaces.map((surface) => ({
+    platform: surface.platform,
+    status: surface.status,
+    reason: surface.reason ?? null,
+  }));
+}
+
+function normalizeAiObservations(raw, querySet) {
+  if (raw == null) return [];
+  invariant(Array.isArray(raw), 'aiObservations must be an array');
+  const queryIds = new Set(querySet.queries.map((query) => query.id));
+  return raw.map((observation, index) => {
+    invariant(observation && typeof observation === 'object', `aiObservations[${index}] must be an object`);
+    invariant(queryIds.has(observation.queryId), `aiObservations[${index}].queryId is not reviewed`);
+    // Whitelist the reviewed artifact fields. Raw prompts, account/session ids,
+    // and provider payload extensions are intentionally not copied.
+    return {
+      queryId: observation.queryId,
+      platform: observation.platform,
+      observedAt: observation.observedAt,
+      geography: observation.geography,
+      locale: observation.locale,
+      signedInState: observation.signedInState,
+      brandMention: observation.brandMention,
+      directCitation: observation.directCitation,
+      citedUrls: normalizeStringArray(observation.citedUrls, `aiObservations[${index}].citedUrls`),
+      competitorsCited: normalizeStringArray(observation.competitorsCited, `aiObservations[${index}].competitorsCited`),
+      sentiment: observation.sentiment,
+      accuracy: observation.accuracy,
+      summary: observation.summary,
+      limitations: normalizeStringArray(observation.limitations, `aiObservations[${index}].limitations`),
+    };
+  });
+}
+
+export function normalizeReferralExport(raw, { observedAt, classification }) {
+  invariant(classification && typeof classification === 'object', 'referral classification is required');
+  if (!raw || raw.status === 'unavailable') {
+    return unavailableReferralExport(
+      observedAt,
+      classification,
+      raw?.reason ?? 'No aggregate analytics export was supplied.',
+    );
+  }
+  const windows = canonicalWindows(raw.windows, observedAt);
+  const segments = [];
+  const normalizedWindows = windows.map((window) => {
+    const windowSegments = normalizeReferralRows(
+      window.raw.rows ?? window.raw.segments ?? [],
+      window.label,
+    );
+    segments.push(...windowSegments);
+    const explicitMetrics = Object.fromEntries(REFERRAL_METRICS.map((metric) => [
+      metric,
+      finiteNumber(window.raw.metrics?.[metric], `windows.${window.label}.metrics.${metric}`),
+    ]));
+    const aggregate = aggregateReferralSegments(windowSegments);
+    const metrics = Object.fromEntries(REFERRAL_METRICS.map((metric) => [
+      metric,
+      explicitMetrics[metric] ?? aggregate[metric],
+    ]));
+    return {
+      label: window.label,
+      startDate: window.startDate,
+      endDate: window.endDate,
+      metrics,
+    };
+  });
+  const complete = normalizedWindows.every(({ metrics }) => (
+    REFERRAL_METRICS.every((metric) => Number.isFinite(metrics[metric]))
+  ));
+  const status = raw.status === 'partial' || !complete ? 'partial' : 'available';
+  return {
+    status,
+    property: null,
+    reason: status === 'available' ? null : (raw.reason ?? 'The imported analytics data is partial.'),
+    classification: structuredClone(classification),
+    windows: normalizedWindows,
+    segments,
+  };
+}
+
+function revisionFromGit() {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown-local-revision';
+  }
+}
+
+export function collectBaseline({
+  template,
+  querySet,
+  sources,
+  observedAt,
+  repositoryRevision = revisionFromGit(),
+}) {
+  invariant(template && typeof template === 'object', 'baseline template is required');
+  invariant(querySet && typeof querySet === 'object', 'query set is required');
+  invariant(sources && typeof sources === 'object', 'source manifest is required');
+  assertIsoUtcDateTime(observedAt, 'observedAt');
+
+  const baseline = structuredClone(template);
+  const googleSearchConsole = normalizeSearchExport(
+    sources.googleSearchConsole,
+    { querySet, observedAt, provider: 'Google Search Console' },
+  );
+  const bingSource = sources.bingWebmaster ?? {};
+  const bingWebmaster = normalizeSearchExport(
+    bingSource.search ?? bingSource,
+    { querySet, observedAt, provider: 'Bing Webmaster' },
+  );
+  bingWebmaster.aiPerformance = normalizeBingAiPerformance(
+    bingSource.aiPerformance ?? sources.bingAiPerformance,
+    { observedAt },
+  );
+  const referrals = normalizeReferralExport(sources.referrals, {
+    observedAt,
+    classification: template.referrals.classification,
+  });
+
+  baseline.baselineId = observedAt.slice(0, 10);
+  baseline.querySetId = querySet.querySetId;
+  baseline.querySetDigest = computeQuerySetDigest(querySet);
+  baseline.observedAt = observedAt;
+  baseline.repositoryRevision = repositoryRevision;
+  baseline.collectionContext = normalizeCollectionContext(
+    sources.collectionContext,
+    template.collectionContext,
+  );
+  baseline.search = { googleSearchConsole, bingWebmaster };
+  baseline.referrals = referrals;
+  baseline.aiSurfaces = normalizeAiSurfaces(sources.aiSurfaces, template.aiSurfaces);
+  baseline.aiObservations = normalizeAiObservations(sources.aiObservations, querySet);
+  baseline.opportunities = structuredClone(sources.opportunities ?? template.opportunities);
+  if (baseline.aiObservations.length === 0) {
+    const limitation = 'No manual AI-answer observations were supplied for this collection run.';
+    if (!baseline.collectionContext.limitations.includes(limitation)) {
+      baseline.collectionContext.limitations = [
+        ...baseline.collectionContext.limitations,
+        limitation,
+      ];
+    }
+  }
+
+  validateBaseline(baseline, querySet);
+  return baseline;
+}
+
+function parseArgs(args) {
+  const options = { check: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--check') {
+      options.check = true;
+      continue;
+    }
+    invariant(
+      ['--queries', '--template', '--sources', '--observed-at', '--output', '--repository-revision']
+        .includes(argument),
+      `unknown argument ${argument}`,
+    );
+    const value = args[index + 1];
+    invariant(isNonEmptyString(value), `${argument} requires a value`);
+    options[argument.slice(2).replaceAll('-', '_')] = value;
+    index += 1;
+  }
+  for (const required of ['queries', 'template', 'sources', 'observed_at']) {
+    invariant(options[required], `--${required.replaceAll('_', '-')} is required`);
+  }
+  if (options.check) invariant(options.output, '--check requires --output');
+  return options;
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(resolve(path), 'utf8'));
+}
+
+export async function runCli(args) {
+  const options = parseArgs(args);
+  const querySet = readJson(options.queries);
+  const template = readJson(options.template);
+  const sources = readJson(options.sources);
+  const baseline = collectBaseline({
+    template,
+    querySet,
+    sources,
+    observedAt: options.observed_at,
+    repositoryRevision: options.repository_revision ?? revisionFromGit(),
+  });
+  const serialized = `${JSON.stringify(baseline, null, 2)}\n`;
+  if (!options.output) {
+    process.stdout.write(serialized);
+    return serialized;
+  }
+  const outputPath = resolve(options.output);
+  if (options.check) {
+    invariant(
+      readFileSync(outputPath, 'utf8') === serialized,
+      `${options.output} is stale; regenerate it without --check`,
+    );
+    return serialized;
+  }
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, serialized);
+  return serialized;
+}
+
+if (isMainModule(import.meta.url, process.argv[1])) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/seo-ai-visibility-collector.mjs
+++ b/scripts/seo-ai-visibility-collector.mjs
@@ -11,14 +11,18 @@
  */
 
 import {
+  closeSync,
   mkdirSync,
+  openSync,
   readFileSync,
+  readSync,
   writeFileSync,
 } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { dirname, resolve } from 'node:path';
 
 import {
+  AI_PLATFORMS,
   PAGE_FAMILIES,
   BING_AI_METRICS,
   REFERRAL_METRICS,
@@ -33,6 +37,7 @@ import { isMainModule } from './lib/main-module.mjs';
 
 const UTC_DAY_MS = 86_400_000;
 const WINDOW_DAYS = Object.freeze({ '28d': 28, '90d': 90 });
+const AVAILABILITY_STATES = new Set(['available', 'partial', 'unavailable']);
 const REFERRER_FAMILIES = new Set([
   'chatgpt',
   'perplexity',
@@ -52,15 +57,109 @@ const EVENT_METRICS = Object.freeze({
   'sign-up': 'signUps',
   'checkout-success': 'proConversions',
   'pro-activation-exit': 'activations',
-  activation: 'activations',
-  'api-action': 'apiActions',
-  'api-key-created': 'apiActions',
-  'api-key-revoked': 'apiActions',
   'mcp-connect-success': 'mcpActions',
 });
+const API_ACTIONS = new Set(['key-created', 'key-revoked']);
+
+// These inputs are operator-provided exports. Keep the limits comfortably
+// above the reviewed fixtures while bounding work before normalization,
+// cloning, or serialization.
+const MAX_INPUT_BYTES = 4 * 1024 * 1024;
+const MAX_STRING_BYTES = 4 * 1024;
+const MAX_URL_BYTES = 8 * 1024;
+const MAX_WINDOWS = 16;
+const MAX_ROWS_PER_WINDOW = 5_000;
+const MAX_TOTAL_ROWS = 25_000;
+const MAX_ARRAY_ITEMS = 500;
+const MAX_QUERY_SET_ENTRIES = 30;
+const MAX_REFERENCE_ENTITIES = 20;
+const MAX_AI_OBSERVATIONS = 500;
+const MAX_OPPORTUNITIES = 5;
 
 function invariant(condition, message) {
   if (!condition) throw new Error(`[seo-visibility-collector] ${message}`);
+}
+
+function boundedString(value, field, maximumBytes = MAX_STRING_BYTES) {
+  invariant(typeof value === 'string', `${field} must be a string`);
+  invariant(
+    Buffer.byteLength(value, 'utf8') <= maximumBytes,
+    `${field} exceeds the ${maximumBytes}-byte limit`,
+  );
+  return value;
+}
+
+function boundedNonEmptyString(value, field, maximumBytes = MAX_STRING_BYTES) {
+  boundedString(value, field, maximumBytes);
+  invariant(isNonEmptyString(value), `${field} must be a non-empty string`);
+  return value;
+}
+
+function optionalBoundedString(value, field, maximumBytes = MAX_STRING_BYTES) {
+  if (value === undefined || value === null) return null;
+  return boundedString(value, field, maximumBytes);
+}
+
+function boundedArray(value, field, maximumLength = MAX_ARRAY_ITEMS) {
+  invariant(Array.isArray(value), `${field} must be an array`);
+  invariant(
+    value.length <= maximumLength,
+    `${field} exceeds the ${maximumLength}-item limit`,
+  );
+  return value;
+}
+
+function optionalArray(value, field, maximumLength = MAX_ARRAY_ITEMS) {
+  if (value === undefined || value === null) return [];
+  return boundedArray(value, field, maximumLength);
+}
+
+function sourceStatusValue(raw, field) {
+  if (raw?.status === undefined) return 'available';
+  const status = boundedString(raw.status, `${field}.status`, 32);
+  invariant(AVAILABILITY_STATES.has(status), `${field} must be available, partial, or unavailable`);
+  return status;
+}
+
+function sourceReason(value, fallback, field) {
+  return value === undefined || value === null
+    ? fallback
+    : boundedNonEmptyString(value, field);
+}
+
+function assertQuerySetBounds(querySet) {
+  invariant(querySet && typeof querySet === 'object', 'query set is required');
+  boundedNonEmptyString(querySet.querySetId, 'querySet.querySetId');
+  boundedNonEmptyString(querySet.reviewedAt, 'querySet.reviewedAt', 64);
+  const queries = boundedArray(
+    querySet.queries,
+    'querySet.queries',
+    MAX_QUERY_SET_ENTRIES,
+  );
+  for (const [index, query] of queries.entries()) {
+    const label = `querySet.queries[${index}]`;
+    invariant(query && typeof query === 'object', `${label} must be an object`);
+    boundedNonEmptyString(query.id, `${label}.id`);
+    boundedNonEmptyString(query.query, `${label}.query`);
+    boundedNonEmptyString(query.intent, `${label}.intent`);
+    boundedNonEmptyString(query.targetAudience, `${label}.targetAudience`);
+    boundedNonEmptyString(query.conversionGoal, `${label}.conversionGoal`);
+    invariant(query.targetPage && typeof query.targetPage === 'object', `${label}.targetPage is required`);
+    boundedNonEmptyString(query.targetPage.family, `${label}.targetPage.family`);
+    boundedNonEmptyString(query.targetPage.url, `${label}.targetPage.url`, MAX_URL_BYTES);
+    const entities = boundedArray(
+      query.referenceEntities,
+      `${label}.referenceEntities`,
+      MAX_REFERENCE_ENTITIES,
+    );
+    for (const [entityIndex, entity] of entities.entries()) {
+      const entityLabel = `${label}.referenceEntities[${entityIndex}]`;
+      invariant(entity && typeof entity === 'object', `${entityLabel} must be an object`);
+      boundedNonEmptyString(entity.role, `${entityLabel}.role`);
+      boundedNonEmptyString(entity.name, `${entityLabel}.name`);
+      boundedNonEmptyString(entity.url, `${entityLabel}.url`, MAX_URL_BYTES);
+    }
+  }
 }
 
 function isIsoCalendarDate(value) {
@@ -70,10 +169,12 @@ function isIsoCalendarDate(value) {
 }
 
 function assertIsoCalendarDate(value, field) {
+  boundedString(value, field, 64);
   invariant(isIsoCalendarDate(value), `${field} must be an ISO calendar date`);
 }
 
 function assertIsoUtcDateTime(value, field) {
+  boundedString(value, field, 64);
   invariant(
     isNonEmptyString(value)
       && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/.test(value)
@@ -189,14 +290,16 @@ function performanceMetricsAreComplete(metrics) {
 
 function canonicalWindows(rawWindows, observedAt, { requireTrailing = false } = {}) {
   const fallback = new Map(deriveTrailingWindows(observedAt).map((window) => [window.label, window]));
-  const windows = Array.isArray(rawWindows) && rawWindows.length > 0
-    ? rawWindows
+  const suppliedWindows = rawWindows === undefined || rawWindows === null
+    ? null
+    : boundedArray(rawWindows, 'windows', MAX_WINDOWS);
+  const windows = suppliedWindows && suppliedWindows.length > 0
+    ? suppliedWindows
     : [...fallback.values()];
   const labels = new Set();
   const normalized = windows.map((window, index) => {
     invariant(window && typeof window === 'object', `windows[${index}] must be an object`);
-    const label = window.label;
-    invariant(isNonEmptyString(label), `windows[${index}].label is required`);
+    const label = boundedNonEmptyString(window.label, `windows[${index}].label`);
     invariant(!labels.has(label), `duplicate window ${label}`);
     labels.add(label);
     const defaultWindow = fallback.get(label);
@@ -250,6 +353,7 @@ function unavailableBingAiPerformance(observedAt, reason) {
 }
 
 function pageRoute(value, field) {
+  boundedNonEmptyString(value, field, MAX_URL_BYTES);
   let parsed;
   try {
     parsed = new URL(value);
@@ -262,19 +366,26 @@ function pageRoute(value, field) {
 }
 
 function createQueryIndexes(querySet) {
+  assertQuerySetBounds(querySet);
   const queryById = new Map(querySet.queries.map((query) => [query.id, query]));
   const queryByText = new Map(querySet.queries.map((query) => [query.query, query]));
-  const pageFamilyByRoute = new Map();
+  const pageFamiliesByRoute = new Map();
   for (const query of querySet.queries) {
     const route = pageRoute(query.targetPage.url, `${query.id}.targetPage.url`);
-    if (!pageFamilyByRoute.has(route)) pageFamilyByRoute.set(route, query.targetPage.family);
+    const families = pageFamiliesByRoute.get(route) ?? new Set();
+    families.add(query.targetPage.family);
+    pageFamiliesByRoute.set(route, families);
   }
-  return { queryById, queryByText, pageFamilyByRoute };
+  return { queryById, queryByText, pageFamiliesByRoute };
 }
 
 function queryIdForRow(row, { queryById, queryByText }) {
-  const declaredId = row.queryId ?? null;
-  const declaredText = row.query ?? row.queryText ?? null;
+  invariant(row && typeof row === 'object', 'imported query row must be an object');
+  const declaredId = optionalBoundedString(row.queryId, 'queryId');
+  const declaredText = optionalBoundedString(
+    row.query ?? row.queryText,
+    'query',
+  );
   const query = declaredId ? queryById.get(declaredId) : queryByText.get(declaredText);
   invariant(query, 'imported row must reference an exact reviewed query text or queryId');
   if (declaredText !== null) {
@@ -286,24 +397,52 @@ function queryIdForRow(row, { queryById, queryByText }) {
   return query.id;
 }
 
-function normalizePageFamily(row, { pageFamilyByRoute }) {
+function normalizePageFamily(row, { pageFamiliesByRoute }) {
+  invariant(row && typeof row === 'object', 'page-family row must be an object');
   if (isNonEmptyString(row.pageFamily)) {
-    invariant(PAGE_FAMILIES.includes(row.pageFamily), `unknown page family ${row.pageFamily}`);
-    return row.pageFamily;
+    const pageFamily = boundedString(row.pageFamily, 'pageFamily');
+    invariant(PAGE_FAMILIES.includes(pageFamily), `unknown page family ${pageFamily}`);
+    return pageFamily;
   }
-  const page = row.page ?? row.url ?? null;
+  const page = optionalBoundedString(row.page ?? row.url, 'page', MAX_URL_BYTES);
   invariant(isNonEmptyString(page), 'page-family row requires page or pageFamily');
-  const family = pageFamilyByRoute.get(pageRoute(page, 'page'));
-  invariant(family, `page does not map to a reviewed page family: ${page}`);
-  return family;
+  const route = pageRoute(page, 'page');
+  const families = pageFamiliesByRoute.get(route);
+  invariant(families, `page does not map to a reviewed page family: ${page}`);
+  invariant(
+    families.size === 1,
+    `page maps ambiguously to reviewed page families: ${page}`,
+  );
+  return families.values().next().value;
 }
 
-function sourceStatus(raw, windows, queryRows, pageFamilyRows) {
-  if (raw?.status === 'unavailable') return 'unavailable';
-  const requested = raw?.status === 'partial' ? 'partial' : 'available';
+function hasBreakdownCoverage(rows, groupSelector, expectedGroups, windows) {
+  const groupsByWindow = new Map(windows.map(({ label }) => [label, new Set()]));
+  for (const row of rows) {
+    groupsByWindow.get(row.windowLabel)?.add(groupSelector(row));
+  }
+  return [...groupsByWindow.values()].every((groups) => (
+    [...expectedGroups].every((group) => groups.has(group))
+  ));
+}
+
+function sourceStatus(requested, windows, queryRows, pageFamilyRows, querySet) {
+  if (requested === 'unavailable') return 'unavailable';
   const complete = windows.every(({ metrics }) => metricsAreComplete(metrics))
     && queryRows.every(({ metrics }) => performanceMetricsAreComplete(metrics))
-    && pageFamilyRows.every(({ metrics }) => metricsAreComplete(metrics));
+    && pageFamilyRows.every(({ metrics }) => metricsAreComplete(metrics))
+    && hasBreakdownCoverage(
+      queryRows,
+      (row) => row.queryId,
+      querySet.queries.map((query) => query.id),
+      windows,
+    )
+    && hasBreakdownCoverage(
+      pageFamilyRows,
+      (row) => row.pageFamily,
+      PAGE_FAMILIES,
+      windows,
+    );
   return requested === 'partial' || !complete ? 'partial' : 'available';
 }
 
@@ -311,17 +450,37 @@ export function normalizeSearchExport(raw, { querySet, observedAt, provider = 's
   if (!raw || raw.status === 'unavailable') {
     return unavailableSearchSource(
       observedAt,
-      raw?.reason ?? `No supported ${provider} export was supplied.`,
+      sourceReason(
+        raw?.reason,
+        `No supported ${provider} export was supplied.`,
+        `${provider}.reason`,
+      ),
     );
   }
+  assertQuerySetBounds(querySet);
+  const requestedStatus = sourceStatusValue(raw, `${provider} status`);
   const windows = canonicalWindows(raw.windows, observedAt, { requireTrailing: true });
   const queryIndexes = createQueryIndexes(querySet);
   const queryRows = [];
   const pageFamilyRows = [];
   const normalizedWindows = [];
+  let totalRows = 0;
   for (const window of windows) {
     const rawWindow = window.raw;
-    const normalizedQueryRows = (rawWindow.queryRows ?? []).map((row) => {
+    invariant(rawWindow && typeof rawWindow === 'object', `windows.${window.label} must be an object`);
+    const rawQueryRows = optionalArray(
+      rawWindow.queryRows,
+      `windows.${window.label}.queryRows`,
+      MAX_ROWS_PER_WINDOW,
+    );
+    const rawPageRows = optionalArray(
+      rawWindow.pageFamilyRows ?? rawWindow.pageRows,
+      `windows.${window.label}.pageFamilyRows`,
+      MAX_ROWS_PER_WINDOW,
+    );
+    totalRows += rawQueryRows.length + rawPageRows.length;
+    invariant(totalRows <= MAX_TOTAL_ROWS, `search breakdown rows exceed the ${MAX_TOTAL_ROWS}-row limit`);
+    const normalizedQueryRows = rawQueryRows.map((row) => {
       const { indexedPages: _indexedPages, ...metrics } = normalizeSearchMetrics(
         row,
         { includeIndexedPages: false },
@@ -332,7 +491,7 @@ export function normalizeSearchExport(raw, { querySet, observedAt, provider = 's
         metrics,
       };
     });
-    const normalizedPageRows = (rawWindow.pageFamilyRows ?? rawWindow.pageRows ?? []).map((row) => ({
+    const normalizedPageRows = rawPageRows.map((row) => ({
       windowLabel: window.label,
       pageFamily: normalizePageFamily(row, queryIndexes),
       metrics: normalizeSearchMetrics(row, { includeIndexedPages: true }),
@@ -349,11 +508,19 @@ export function normalizeSearchExport(raw, { querySet, observedAt, provider = 's
       metrics,
     });
   }
-  const status = sourceStatus(raw, normalizedWindows, queryRows, pageFamilyRows);
+  const status = sourceStatus(
+    requestedStatus,
+    normalizedWindows,
+    queryRows,
+    pageFamilyRows,
+    querySet,
+  );
   return {
     status,
     property: null,
-    reason: status === 'available' ? null : (raw.reason ?? 'The imported provider data is partial.'),
+    reason: status === 'available'
+      ? null
+      : sourceReason(raw.reason, 'The imported provider data is partial.', `${provider}.reason`),
     windows: normalizedWindows,
     queryRows: status === 'unavailable' ? [] : queryRows,
     pageFamilyRows: status === 'unavailable' ? [] : pageFamilyRows,
@@ -361,6 +528,7 @@ export function normalizeSearchExport(raw, { querySet, observedAt, provider = 's
 }
 
 function normalizeBingAiWindow(window) {
+  invariant(window && typeof window === 'object', 'Bing AI window must be an object');
   const totalCitations = finiteNumber(
     window.totalCitations ?? window.citationTotal,
     'totalCitations',
@@ -369,28 +537,78 @@ function normalizeBingAiWindow(window) {
     window.averageCitedPages,
     'averageCitedPages',
   );
-  const groundingQueries = (window.groundingQueries ?? []).map((query, index) => ({
-    phrase: query.phrase ?? query.query ?? query.groundingQuery,
+  const groundingQueriesProvided = Array.isArray(window.groundingQueries);
+  if (
+    window.groundingQueries !== undefined
+    && window.groundingQueries !== null
+  ) {
+    invariant(groundingQueriesProvided, 'groundingQueries must be an array');
+  }
+  const groundingQueries = optionalArray(
+    window.groundingQueries,
+    'groundingQueries',
+    MAX_ROWS_PER_WINDOW,
+  ).map((query, index) => {
+    invariant(query && typeof query === 'object', `groundingQueries[${index}] must be an object`);
+    const phrase = boundedNonEmptyString(
+      query.phrase ?? query.query ?? query.groundingQuery,
+      `groundingQueries[${index}].phrase`,
+    );
+    return {
+      phrase,
     citationCount: finiteNumber(
       query.citationCount ?? query.citations ?? query.count,
       `groundingQueries[${index}].citationCount`,
     ),
-  }));
-  const citedPages = (window.citedPages ?? window.citedUrls ?? []).map((page, index) => {
-    const url = page.url ?? page.page;
-    invariant(isNonEmptyString(url), `citedPages[${index}].url is required`);
+    };
+  });
+  const citedPagesInput = Array.isArray(window.citedPages)
+    ? window.citedPages
+    : window.citedPages === undefined || window.citedPages === null
+      ? window.citedUrls
+      : null;
+  const citedPagesProvided = Array.isArray(citedPagesInput);
+  if (
+    window.citedPages !== undefined
+    && window.citedPages !== null
+  ) {
+    invariant(Array.isArray(window.citedPages), 'citedPages must be an array');
+  }
+  if (
+    window.citedUrls !== undefined
+    && window.citedUrls !== null
+    && window.citedPages === undefined
+  ) {
+    invariant(Array.isArray(window.citedUrls), 'citedUrls must be an array');
+  }
+  const citedPages = optionalArray(
+    citedPagesInput,
+    'citedPages',
+    MAX_ROWS_PER_WINDOW,
+  ).map((page, index) => {
+    invariant(page && typeof page === 'object', `citedPages[${index}] must be an object`);
+    const url = boundedNonEmptyString(
+      page.url ?? page.page,
+      `citedPages[${index}].url`,
+      MAX_URL_BYTES,
+    );
     let parsed;
     try {
       parsed = new URL(url);
     } catch {
       throw new Error(`[seo-visibility-collector] citedPages[${index}].url must be an HTTPS URL`);
     }
+    invariant(parsed.protocol === 'https:', `citedPages[${index}].url must be an HTTPS URL`);
     invariant(
-      parsed.protocol === 'https:' && isWorldMonitorUrl(url),
+      parsed.username === '' && parsed.password === '',
+      `citedPages[${index}].url must not contain credentials`,
+    );
+    invariant(
+      isWorldMonitorUrl(parsed.toString()),
       `citedPages[${index}].url must be a World Monitor HTTPS URL`,
     );
     return {
-      url,
+      url: parsed.toString(),
       citationCount: finiteNumber(
         page.citationCount ?? page.citations ?? page.count,
         `citedPages[${index}].citationCount`,
@@ -399,8 +617,10 @@ function normalizeBingAiWindow(window) {
   });
   return {
     metrics: { totalCitations, averageCitedPages },
-    groundingQueries,
-    citedPages,
+    groundingQueries: groundingQueriesProvided ? groundingQueries : null,
+    citedPages: citedPagesProvided ? citedPages : null,
+    groundingQueriesProvided,
+    citedPagesProvided,
   };
 }
 
@@ -408,24 +628,42 @@ export function normalizeBingAiPerformance(raw, { observedAt }) {
   if (!raw || raw.status === 'unavailable') {
     return unavailableBingAiPerformance(
       observedAt,
-      raw?.reason ?? 'No Bing AI Performance export was supplied.',
+      sourceReason(
+        raw?.reason,
+        'No Bing AI Performance export was supplied.',
+        'bingAiPerformance.reason',
+      ),
     );
   }
+  const requestedStatus = sourceStatusValue(raw, 'Bing AI Performance status');
   const windows = canonicalWindows(raw.windows, observedAt, { requireTrailing: true });
-  const normalizedWindows = windows.map((window) => ({
+  const normalizedWindowsWithPresence = windows.map((window) => ({
     label: window.label,
     startDate: window.startDate,
     endDate: window.endDate,
     ...normalizeBingAiWindow(window.raw),
   }));
-  const complete = normalizedWindows.every(({ metrics }) => (
-    BING_AI_METRICS.every((metric) => Number.isFinite(metrics[metric]))
+  const complete = normalizedWindowsWithPresence.every((window) => (
+    BING_AI_METRICS.every((metric) => Number.isFinite(window.metrics[metric]))
+      && window.groundingQueriesProvided
+      && window.citedPagesProvided
   ));
-  const status = raw.status === 'partial' || !complete ? 'partial' : 'available';
+  const status = requestedStatus === 'partial' || !complete
+    ? 'partial'
+    : 'available';
   return {
     status,
-    reason: status === 'available' ? null : (raw.reason ?? 'The imported Bing AI Performance data is partial.'),
-    windows: normalizedWindows,
+    reason: status === 'available'
+      ? null
+      : sourceReason(raw.reason, 'The imported Bing AI Performance data is partial.', 'bingAiPerformance.reason'),
+    windows: normalizedWindowsWithPresence.map((window) => {
+      const {
+        groundingQueriesProvided: _groundingQueriesProvided,
+        citedPagesProvided: _citedPagesProvided,
+        ...normalizedWindow
+      } = window;
+      return normalizedWindow;
+    }),
   };
 }
 
@@ -434,7 +672,7 @@ function unavailableReferralExport(observedAt, classification, reason) {
     status: 'unavailable',
     property: null,
     reason,
-    classification: structuredClone(classification),
+    classification,
     windows: deriveTrailingWindows(observedAt).map((window) => ({
       ...window,
       metrics: Object.fromEntries(REFERRAL_METRICS.map((metric) => [metric, null])),
@@ -443,28 +681,81 @@ function unavailableReferralExport(observedAt, classification, reason) {
   };
 }
 
+function normalizeReferralClassification(classification) {
+  invariant(
+    classification && typeof classification === 'object',
+    'referral classification is required',
+  );
+  const dimensions = normalizeStringArray(
+    classification.dimensions,
+    'referrals.classification.dimensions',
+  );
+  const families = boundedArray(
+    classification.families,
+    'referrals.classification.families',
+  );
+  return {
+    dimensions,
+    families: families.map((family, index) => {
+      const label = `referrals.classification.families[${index}]`;
+      invariant(family && typeof family === 'object', `${label} must be an object`);
+      return {
+        id: boundedNonEmptyString(family.id, `${label}.id`),
+        label: boundedNonEmptyString(family.label, `${label}.label`),
+        hostSuffixes: normalizeStringArray(family.hostSuffixes, `${label}.hostSuffixes`),
+        utmSources: normalizeStringArray(family.utmSources, `${label}.utmSources`),
+      };
+    }),
+  };
+}
+
 function normalizeReferrerFamily(value) {
-  const family = value ?? 'unknown_direct';
+  const family = boundedNonEmptyString(value, 'referrerFamily');
   invariant(REFERRER_FAMILIES.has(family), `unknown referrer family ${family}`);
   return family;
 }
 
 function normalizeLandingPageFamily(value) {
-  invariant(PAGE_FAMILIES.includes(value), `unknown landing page family ${value}`);
-  return value;
+  const family = boundedNonEmptyString(value, 'landingPageFamily');
+  invariant(PAGE_FAMILIES.includes(family), `unknown landing page family ${family}`);
+  return family;
 }
 
 function eventMetric(row) {
-  const event = row.event ?? row.eventName ?? null;
+  const rawEvent = row.event ?? row.eventName ?? null;
+  const event = optionalBoundedString(rawEvent, 'event');
   if (event === 'pageview') {
     if (row.landingPageFamily === 'dashboard' || row.landingPageFamily === 'homepage') {
-      return 'dashboardLaunches';
+      return { metric: 'dashboardLaunches', quarantine: false };
     }
-    if (row.landingPageFamily === 'pricing') return 'pricingViews';
-    return null;
+    if (row.landingPageFamily === 'pricing') {
+      return { metric: 'pricingViews', quarantine: false };
+    }
+    return { metric: null, quarantine: false };
   }
-  if (event === 'pro-activation-exit' && row.completion !== 'complete') return null;
-  return EVENT_METRICS[event] ?? null;
+  if (event === 'pro-activation-exit' || event === 'activation') {
+    const completion = optionalBoundedString(row.completion, 'completion');
+    return {
+      metric: completion === 'complete' ? 'activations' : null,
+      quarantine: false,
+    };
+  }
+  if (event === 'api-action') {
+    const action = optionalBoundedString(row.action ?? row.apiAction, 'api-action.action');
+    return {
+      metric: action !== null && API_ACTIONS.has(action) ? 'apiActions' : null,
+      quarantine: action === null || !API_ACTIONS.has(action),
+    };
+  }
+  if (event === 'api-key-created' || event === 'api-key-revoked') {
+    const expectedAction = event === 'api-key-created' ? 'key-created' : 'key-revoked';
+    const action = optionalBoundedString(row.action ?? row.apiAction, 'api-action.action');
+    return {
+      metric: action === null || action === expectedAction ? 'apiActions' : null,
+      quarantine: action !== null && action !== expectedAction,
+    };
+  }
+  return { metric: EVENT_METRICS[event] ?? null, quarantine: false };
 }
 
 function eventCount(row, field) {
@@ -485,8 +776,19 @@ function mergeReferralMetric(target, metric, value) {
 }
 
 function normalizeReferralRows(rows, windowLabel) {
+  const inputRows = boundedArray(rows, `windows.${windowLabel}.rows`, MAX_ROWS_PER_WINDOW);
   const segments = new Map();
-  for (const [index, row] of rows.entries()) {
+  let omittedRows = 0;
+  for (const [index, row] of inputRows.entries()) {
+    if (
+      !row
+      || typeof row !== 'object'
+      || !isNonEmptyString(row.referrerFamily)
+      || !isNonEmptyString(row.landingPageFamily)
+    ) {
+      omittedRows += 1;
+      continue;
+    }
     const referrerFamily = normalizeReferrerFamily(row.referrerFamily);
     const landingPageFamily = normalizeLandingPageFamily(row.landingPageFamily);
     const key = `${referrerFamily}:${landingPageFamily}`;
@@ -502,14 +804,21 @@ function normalizeReferralRows(rows, windowLabel) {
         mergeReferralMetric(metrics.metrics, metric, value);
       }
     } else {
-      const metric = eventMetric(row);
+      const { metric, quarantine } = eventMetric(row);
+      if (quarantine) {
+        omittedRows += 1;
+        continue;
+      }
       if (metric) mergeReferralMetric(metrics.metrics, metric, eventCount(row, `rows[${index}]`));
     }
     segments.set(key, metrics);
   }
-  return [...segments.values()].filter(({ metrics }) => (
-    REFERRAL_METRICS.some((metric) => Number.isFinite(metrics[metric]))
-  ));
+  return {
+    segments: [...segments.values()].filter(({ metrics }) => (
+      REFERRAL_METRICS.some((metric) => Number.isFinite(metrics[metric]))
+    )),
+    omittedRows,
+  };
 }
 
 function aggregateReferralSegments(segments) {
@@ -521,11 +830,10 @@ function aggregateReferralSegments(segments) {
   }));
 }
 
-function normalizeStringArray(value, field) {
-  invariant(Array.isArray(value), `${field} must be an array`);
-  return value.map((item, index) => {
-    invariant(isNonEmptyString(item), `${field}[${index}] must be a non-empty string`);
-    return item;
+function normalizeStringArray(value, field, maximumLength = MAX_ARRAY_ITEMS) {
+  const values = boundedArray(value, field, maximumLength);
+  return values.map((item, index) => {
+    return boundedNonEmptyString(item, `${field}[${index}]`);
   });
 }
 
@@ -533,68 +841,116 @@ function normalizeCollectionContext(raw, fallback) {
   const context = raw ?? fallback;
   invariant(context && typeof context === 'object', 'collection context is required');
   return {
-    geography: context.geography,
-    locale: context.locale,
+    geography: boundedNonEmptyString(context.geography, 'collectionContext.geography'),
+    locale: boundedNonEmptyString(context.locale, 'collectionContext.locale'),
     signedInStates: normalizeStringArray(context.signedInStates, 'collectionContext.signedInStates'),
-    device: context.device,
+    device: boundedNonEmptyString(context.device, 'collectionContext.device'),
     limitations: normalizeStringArray(context.limitations, 'collectionContext.limitations'),
   };
 }
 
-function normalizeAiSurfaces(raw, fallback) {
-  const surfaces = raw ?? fallback;
-  invariant(Array.isArray(surfaces), 'AI surface manifest is required');
-  return surfaces.map((surface) => ({
-    platform: surface.platform,
-    status: surface.status,
-    reason: surface.reason ?? null,
-  }));
+function normalizeAiSurfaces(raw) {
+  const surfaces = raw == null
+    ? AI_PLATFORMS.map((platform) => ({
+      platform,
+      status: 'unavailable',
+      reason: 'No current AI surface manifest was supplied.',
+    }))
+    : boundedArray(raw, 'aiSurfaces');
+  return surfaces.map((surface, index) => {
+    const label = `aiSurfaces[${index}]`;
+    invariant(surface && typeof surface === 'object', `${label} must be an object`);
+    const platform = boundedNonEmptyString(surface.platform, `${label}.platform`);
+    const status = boundedNonEmptyString(surface.status, `${label}.status`);
+    invariant(AVAILABILITY_STATES.has(status), `${label}.status must be available, partial, or unavailable`);
+    return {
+      platform,
+      status,
+      reason: optionalBoundedString(surface.reason, `${label}.reason`),
+    };
+  });
 }
 
 function normalizeAiObservations(raw, querySet) {
   if (raw == null) return [];
-  invariant(Array.isArray(raw), 'aiObservations must be an array');
+  const observations = boundedArray(raw, 'aiObservations', MAX_AI_OBSERVATIONS);
+  assertQuerySetBounds(querySet);
   const queryIds = new Set(querySet.queries.map((query) => query.id));
-  return raw.map((observation, index) => {
+  return observations.map((observation, index) => {
     invariant(observation && typeof observation === 'object', `aiObservations[${index}] must be an object`);
-    invariant(queryIds.has(observation.queryId), `aiObservations[${index}].queryId is not reviewed`);
+    const queryId = boundedNonEmptyString(observation.queryId, `aiObservations[${index}].queryId`);
+    invariant(queryIds.has(queryId), `aiObservations[${index}].queryId is not reviewed`);
     // Whitelist the reviewed artifact fields. Raw prompts, account/session ids,
     // and provider payload extensions are intentionally not copied.
     return {
-      queryId: observation.queryId,
-      platform: observation.platform,
-      observedAt: observation.observedAt,
-      geography: observation.geography,
-      locale: observation.locale,
-      signedInState: observation.signedInState,
+      queryId,
+      platform: boundedNonEmptyString(observation.platform, `aiObservations[${index}].platform`),
+      observedAt: boundedNonEmptyString(observation.observedAt, `aiObservations[${index}].observedAt`),
+      geography: boundedNonEmptyString(observation.geography, `aiObservations[${index}].geography`),
+      locale: boundedNonEmptyString(observation.locale, `aiObservations[${index}].locale`),
+      signedInState: boundedNonEmptyString(observation.signedInState, `aiObservations[${index}].signedInState`),
       brandMention: observation.brandMention,
       directCitation: observation.directCitation,
       citedUrls: normalizeStringArray(observation.citedUrls, `aiObservations[${index}].citedUrls`),
       competitorsCited: normalizeStringArray(observation.competitorsCited, `aiObservations[${index}].competitorsCited`),
-      sentiment: observation.sentiment,
-      accuracy: observation.accuracy,
-      summary: observation.summary,
+      sentiment: boundedNonEmptyString(observation.sentiment, `aiObservations[${index}].sentiment`),
+      accuracy: boundedNonEmptyString(observation.accuracy, `aiObservations[${index}].accuracy`),
+      summary: boundedNonEmptyString(observation.summary, `aiObservations[${index}].summary`),
       limitations: normalizeStringArray(observation.limitations, `aiObservations[${index}].limitations`),
     };
   });
 }
 
+function normalizeOpportunities(raw, fallback) {
+  const opportunities = raw == null ? fallback : raw;
+  const entries = boundedArray(opportunities, 'opportunities', MAX_OPPORTUNITIES);
+  return entries.map((opportunity, index) => {
+    const label = `opportunities[${index}]`;
+    invariant(opportunity && typeof opportunity === 'object', `${label} must be an object`);
+    return {
+      priority: opportunity.priority,
+      title: boundedNonEmptyString(opportunity.title, `${label}.title`),
+      evidence: boundedNonEmptyString(opportunity.evidence, `${label}.evidence`),
+      experiment: boundedNonEmptyString(opportunity.experiment, `${label}.experiment`),
+      successCriteria: boundedNonEmptyString(
+        opportunity.successCriteria,
+        `${label}.successCriteria`,
+      ),
+      queryIds: normalizeStringArray(opportunity.queryIds, `${label}.queryIds`, MAX_QUERY_SET_ENTRIES),
+    };
+  });
+}
+
 export function normalizeReferralExport(raw, { observedAt, classification }) {
-  invariant(classification && typeof classification === 'object', 'referral classification is required');
+  const normalizedClassification = normalizeReferralClassification(classification);
   if (!raw || raw.status === 'unavailable') {
     return unavailableReferralExport(
       observedAt,
-      classification,
-      raw?.reason ?? 'No aggregate analytics export was supplied.',
+      normalizedClassification,
+      sourceReason(
+        raw?.reason,
+        'No aggregate analytics export was supplied.',
+        'referrals.reason',
+      ),
     );
   }
+  const requestedStatus = sourceStatusValue(raw, 'referrals status');
   const windows = canonicalWindows(raw.windows, observedAt);
   const segments = [];
+  let omittedRows = 0;
+  let totalRows = 0;
   const normalizedWindows = windows.map((window) => {
-    const windowSegments = normalizeReferralRows(
-      window.raw.rows ?? window.raw.segments ?? [],
-      window.label,
+    invariant(window.raw && typeof window.raw === 'object', `windows.${window.label} must be an object`);
+    const rawRows = optionalArray(
+      window.raw.rows ?? window.raw.segments,
+      `windows.${window.label}.rows`,
+      MAX_ROWS_PER_WINDOW,
     );
+    totalRows += rawRows.length;
+    invariant(totalRows <= MAX_TOTAL_ROWS, `referral rows exceed the ${MAX_TOTAL_ROWS}-row limit`);
+    const normalizedRows = normalizeReferralRows(rawRows, window.label);
+    const windowSegments = normalizedRows.segments;
+    omittedRows += normalizedRows.omittedRows;
     segments.push(...windowSegments);
     const explicitMetrics = Object.fromEntries(REFERRAL_METRICS.map((metric) => [
       metric,
@@ -614,13 +970,17 @@ export function normalizeReferralExport(raw, { observedAt, classification }) {
   });
   const complete = normalizedWindows.every(({ metrics }) => (
     REFERRAL_METRICS.every((metric) => Number.isFinite(metrics[metric]))
-  ));
-  const status = raw.status === 'partial' || !complete ? 'partial' : 'available';
+  )) && omittedRows === 0;
+  const status = requestedStatus === 'partial' || !complete
+    ? 'partial'
+    : 'available';
   return {
     status,
     property: null,
-    reason: status === 'available' ? null : (raw.reason ?? 'The imported analytics data is partial.'),
-    classification: structuredClone(classification),
+    reason: status === 'available'
+      ? null
+      : sourceReason(raw.reason, 'The imported analytics data is partial.', 'referrals.reason'),
+    classification: normalizedClassification,
     windows: normalizedWindows,
     segments,
   };
@@ -630,7 +990,7 @@ function revisionFromGit() {
   try {
     return execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
   } catch {
-    return 'unknown-local-revision';
+    return null;
   }
 }
 
@@ -642,11 +1002,17 @@ export function collectBaseline({
   repositoryRevision = revisionFromGit(),
 }) {
   invariant(template && typeof template === 'object', 'baseline template is required');
-  invariant(querySet && typeof querySet === 'object', 'query set is required');
+  assertQuerySetBounds(querySet);
   invariant(sources && typeof sources === 'object', 'source manifest is required');
   assertIsoUtcDateTime(observedAt, 'observedAt');
+  invariant(
+    repositoryRevision !== null
+      && repositoryRevision !== undefined
+      && repositoryRevision !== 'unknown-local-revision',
+    'repositoryRevision must be supplied when the local git revision is unavailable',
+  );
+  const normalizedRevision = boundedNonEmptyString(repositoryRevision, 'repositoryRevision');
 
-  const baseline = structuredClone(template);
   const googleSearchConsole = normalizeSearchExport(
     sources.googleSearchConsole,
     { querySet, observedAt, provider: 'Google Search Console' },
@@ -662,28 +1028,41 @@ export function collectBaseline({
   );
   const referrals = normalizeReferralExport(sources.referrals, {
     observedAt,
-    classification: template.referrals.classification,
+    classification: template.referrals?.classification,
   });
 
-  baseline.baselineId = observedAt.slice(0, 10);
-  baseline.querySetId = querySet.querySetId;
-  baseline.querySetDigest = computeQuerySetDigest(querySet);
-  baseline.observedAt = observedAt;
-  baseline.repositoryRevision = repositoryRevision;
-  baseline.collectionContext = normalizeCollectionContext(
+  const collectionContext = normalizeCollectionContext(
     sources.collectionContext,
     template.collectionContext,
   );
-  baseline.search = { googleSearchConsole, bingWebmaster };
-  baseline.referrals = referrals;
-  baseline.aiSurfaces = normalizeAiSurfaces(sources.aiSurfaces, template.aiSurfaces);
-  baseline.aiObservations = normalizeAiObservations(sources.aiObservations, querySet);
-  baseline.opportunities = structuredClone(sources.opportunities ?? template.opportunities);
-  if (baseline.aiObservations.length === 0) {
+  const aiSurfaces = normalizeAiSurfaces(sources.aiSurfaces);
+  const aiObservations = normalizeAiObservations(sources.aiObservations, querySet);
+  const opportunities = normalizeOpportunities(sources.opportunities, template.opportunities);
+  const guardrails = normalizeStringArray(template.guardrails, 'template.guardrails');
+  const baseline = {
+    schemaVersion: template.schemaVersion,
+    baselineId: observedAt.slice(0, 10),
+    querySetId: querySet.querySetId,
+    querySetDigest: computeQuerySetDigest(querySet),
+    observedAt,
+    repositoryRevision: normalizedRevision,
+    collectionContext,
+    search: { googleSearchConsole, bingWebmaster },
+    referrals,
+    aiSurfaces,
+    aiObservations,
+    opportunities,
+    guardrails,
+  };
+  if (aiObservations.length === 0) {
     const limitation = 'No manual AI-answer observations were supplied for this collection run.';
-    if (!baseline.collectionContext.limitations.includes(limitation)) {
-      baseline.collectionContext.limitations = [
-        ...baseline.collectionContext.limitations,
+    if (!collectionContext.limitations.includes(limitation)) {
+      invariant(
+        collectionContext.limitations.length < MAX_ARRAY_ITEMS,
+        'collectionContext.limitations exceeds the item limit',
+      );
+      collectionContext.limitations = [
+        ...collectionContext.limitations,
         limitation,
       ];
     }
@@ -694,6 +1073,7 @@ export function collectBaseline({
 }
 
 function parseArgs(args) {
+  boundedArray(args, 'CLI arguments', MAX_ARRAY_ITEMS);
   const options = { check: false };
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
@@ -707,7 +1087,7 @@ function parseArgs(args) {
       `unknown argument ${argument}`,
     );
     const value = args[index + 1];
-    invariant(isNonEmptyString(value), `${argument} requires a value`);
+    boundedNonEmptyString(value, `${argument} value`, MAX_URL_BYTES);
     options[argument.slice(2).replaceAll('-', '_')] = value;
     index += 1;
   }
@@ -719,7 +1099,15 @@ function parseArgs(args) {
 }
 
 function readJson(path) {
-  return JSON.parse(readFileSync(resolve(path), 'utf8'));
+  const descriptor = openSync(resolve(path), 'r');
+  try {
+    const contents = Buffer.allocUnsafe(MAX_INPUT_BYTES + 1);
+    const bytesRead = readSync(descriptor, contents, 0, contents.length, 0);
+    invariant(bytesRead <= MAX_INPUT_BYTES, `${path} exceeds the ${MAX_INPUT_BYTES}-byte input limit`);
+    return JSON.parse(contents.subarray(0, bytesRead).toString('utf8'));
+  } finally {
+    closeSync(descriptor);
+  }
 }
 
 export async function runCli(args) {

--- a/scripts/seo-ai-visibility-scorecard.mjs
+++ b/scripts/seo-ai-visibility-scorecard.mjs
@@ -71,27 +71,32 @@ const AVAILABILITY_STATES = new Set(['available', 'partial', 'unavailable']);
 const SENTIMENTS = new Set(['positive', 'neutral', 'negative', 'mixed']);
 const ACCURACY_STATES = new Set(['accurate', 'mixed', 'inaccurate', 'unverified']);
 const REFERENCE_ROLES = new Set(['competitor', 'source']);
-const SEARCH_METRICS = Object.freeze([
+export const SEARCH_METRICS = Object.freeze([
   'indexedPages',
   'impressions',
   'clicks',
   'ctr',
   'averagePosition',
 ]);
-const SEARCH_PERFORMANCE_METRICS = Object.freeze([
+export const SEARCH_PERFORMANCE_METRICS = Object.freeze([
   'impressions',
   'clicks',
   'ctr',
   'averagePosition',
 ]);
-const REFERRAL_METRICS = Object.freeze([
+export const REFERRAL_METRICS = Object.freeze([
   'sessions',
   'dashboardLaunches',
   'pricingViews',
   'signUps',
   'proConversions',
+  'activations',
   'apiActions',
   'mcpActions',
+]);
+export const BING_AI_METRICS = Object.freeze([
+  'totalCitations',
+  'averageCitedPages',
 ]);
 
 const PLATFORM_LABELS = domainLabels(AI_PLATFORM_DOMAIN);
@@ -102,7 +107,7 @@ function invariant(condition, message) {
   if (!condition) throw new Error(`[seo-visibility] ${message}`);
 }
 
-function isNonEmptyString(value) {
+export function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
@@ -210,12 +215,15 @@ function validateWindowedSource(
   metricNames,
   label,
   latestEndDate,
+  { requireProperty = true } = {},
 ) {
   invariant(source && typeof source === 'object', `${label} is required`);
-  invariant(
-    source.property === null,
-    `${label}.property must remain null in committed artifacts`,
-  );
+  if (requireProperty || 'property' in source) {
+    invariant(
+      source.property === null,
+      `${label}.property must remain null in committed artifacts`,
+    );
+  }
   invariant(
     AVAILABILITY_STATES.has(source.status),
     `${label}.status must be available, partial, or unavailable`,
@@ -264,6 +272,60 @@ function validateWindowedSource(
       );
     }
     assertNullableMetrics(window.metrics, metricNames, windowLabel, source.status);
+  }
+}
+
+function validateBingAiPerformance(aiPerformance, label, latestEndDate) {
+  validateWindowedSource(
+    aiPerformance,
+    BING_AI_METRICS,
+    label,
+    latestEndDate,
+    { requireProperty: false },
+  );
+  for (const [index, window] of aiPerformance.windows.entries()) {
+    const windowLabel = `${label}.windows[${index}]`;
+    invariant(Array.isArray(window.groundingQueries), `${windowLabel}.groundingQueries must be an array`);
+    invariant(Array.isArray(window.citedPages), `${windowLabel}.citedPages must be an array`);
+    if (aiPerformance.status === 'unavailable') {
+      invariant(window.groundingQueries.length === 0, `${windowLabel}.groundingQueries must be empty when unavailable`);
+      invariant(window.citedPages.length === 0, `${windowLabel}.citedPages must be empty when unavailable`);
+    }
+    const groundingPhrases = new Set();
+    for (const [queryIndex, query] of window.groundingQueries.entries()) {
+      const queryLabel = `${windowLabel}.groundingQueries[${queryIndex}]`;
+      invariant(isNonEmptyString(query.phrase), `${queryLabel}.phrase is required`);
+      invariant(!groundingPhrases.has(query.phrase), `${label} has duplicate grounding phrase ${query.phrase}`);
+      groundingPhrases.add(query.phrase);
+      assertCitationCount(query.citationCount, queryLabel, aiPerformance.status);
+    }
+    const citedUrls = new Set();
+    for (const [pageIndex, page] of window.citedPages.entries()) {
+      const pageLabel = `${windowLabel}.citedPages[${pageIndex}]`;
+      invariant(
+        typeof page.url === 'string'
+          && page.url.startsWith('https://')
+          && isWorldMonitorUrl(page.url),
+        `${pageLabel}.url must be a World Monitor HTTPS URL`,
+      );
+      invariant(!citedUrls.has(page.url), `${label} has duplicate cited page ${page.url}`);
+      citedUrls.add(page.url);
+      assertCitationCount(page.citationCount, pageLabel, aiPerformance.status);
+    }
+  }
+}
+
+function assertCitationCount(value, label, status) {
+  invariant(
+    value === null
+      || (typeof value === 'number' && Number.isFinite(value) && value >= 0),
+    `${label}.citationCount must be a finite non-negative number or null`,
+  );
+  if (status === 'available') {
+    invariant(
+      typeof value === 'number' && Number.isFinite(value),
+      `${label}.citationCount must be finite when available`,
+    );
   }
 }
 
@@ -347,7 +409,7 @@ function validateReferralSegments(referrals, referrerFamilyIds) {
   }
 }
 
-function isWorldMonitorUrl(value) {
+export function isWorldMonitorUrl(value) {
   try {
     const url = new URL(value);
     return url.hostname === 'worldmonitor.app'
@@ -501,6 +563,11 @@ export function validateBaseline(baseline, querySet) {
     baseline.search.bingWebmaster,
     'search.bingWebmaster',
     queryIds,
+    baselineObservationDate,
+  );
+  validateBingAiPerformance(
+    baseline.search.bingWebmaster.aiPerformance,
+    'search.bingWebmaster.aiPerformance',
     baselineObservationDate,
   );
   validateWindowedSource(
@@ -911,6 +978,8 @@ const MEANINGFUL_ABSOLUTE_CHANGE = Object.freeze({
   indexedPages: 5,
   clicks: 10,
   impressions: 100,
+  totalCitations: 10,
+  averageCitedPages: 1,
   sessions: 10,
   dashboardLaunches: 1,
   pricingViews: 1,
@@ -1040,6 +1109,12 @@ export function compareScorecards(previous, current) {
         SEARCH_METRICS,
         'bingWebmaster',
       ),
+      bingAiPerformance: compareWindowedSource(
+        previous.search.bingWebmaster.aiPerformance,
+        current.search.bingWebmaster.aiPerformance,
+        BING_AI_METRICS,
+        'bingAiPerformance',
+      ),
     },
     referrals: compareWindowedSource(
       previous.referrals,
@@ -1102,6 +1177,13 @@ function referralMetricCell(source, metric) {
 function formatReferralRow(label, source) {
   const cells = REFERRAL_METRICS.map((metric) => referralMetricCell(source, metric));
   return `| ${label} | ${cells.join(' | ')} |`;
+}
+
+function formatBingAiPerformance(source) {
+  const noObservedRows = source.status !== 'available';
+  return source.windows.map((window) => (
+    `| ${window.label} | ${window.metrics.totalCitations ?? 'Unavailable'} | ${window.metrics.averageCitedPages ?? 'Unavailable'} | ${noObservedRows ? 'Unavailable' : window.groundingQueries.length} | ${noObservedRows ? 'Unavailable' : window.citedPages.length} |`
+  ));
 }
 
 function markdownLink(url) {
@@ -1207,6 +1289,7 @@ export function formatScorecardMarkdown(scorecard) {
     ...searchProviderRows(scorecard).map(([label, source]) => (
       `| ${label} | ${markdownCell(displayStatus(source))} | ${source.windows.map((window) => window.label).join(', ')} |`
     )),
+    `| Bing AI Performance | ${markdownCell(displayStatus(scorecard.search.bingWebmaster.aiPerformance))} | ${scorecard.search.bingWebmaster.aiPerformance.windows.map((window) => window.label).join(', ')} |`,
     '',
     '| AI surface | Status |',
     '| --- | --- |',
@@ -1215,6 +1298,14 @@ export function formatScorecardMarkdown(scorecard) {
     )),
     '',
     `Referral families: ${scorecard.referrals.classification.families.map((family) => family.label).join(', ')}.`,
+    '',
+    '## Bing AI Performance',
+    '',
+    'Citation counts describe observed source usage, not ranking, authority, or causal traffic.',
+    '',
+    '| Window | Total citations | Average cited pages | Grounding phrases | Cited pages |',
+    '| --- | ---: | ---: | ---: | ---: |',
+    ...formatBingAiPerformance(scorecard.search.bingWebmaster.aiPerformance),
     '',
     '## Query registry',
     '',
@@ -1237,14 +1328,14 @@ export function formatScorecardMarkdown(scorecard) {
     'Referral segments retain both the major referrer family and landing-page family.',
     'Unavailable aggregates remain unavailable in every slice.',
     '',
-    '| Referrer family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | API actions | MCP actions |',
-    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    '| Referrer family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | Activations | API actions | MCP actions |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
     ...scorecard.referrals.classification.families.map(({ id, label }) => (
       formatReferralRow(label, scorecard.referrals.byReferrerFamily[id])
     )),
     '',
-    '| Landing-page family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | API actions | MCP actions |',
-    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    '| Landing-page family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | Activations | API actions | MCP actions |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
     ...Object.entries(scorecard.referrals.byPageFamily).map(([family, source]) => (
       formatReferralRow(PAGE_FAMILY_LABELS[family], source)
     )),

--- a/scripts/seo-ai-visibility-scorecard.mjs
+++ b/scripts/seo-ai-visibility-scorecard.mjs
@@ -285,14 +285,38 @@ function validateBingAiPerformance(aiPerformance, label, latestEndDate) {
   );
   for (const [index, window] of aiPerformance.windows.entries()) {
     const windowLabel = `${label}.windows[${index}]`;
-    invariant(Array.isArray(window.groundingQueries), `${windowLabel}.groundingQueries must be an array`);
-    invariant(Array.isArray(window.citedPages), `${windowLabel}.citedPages must be an array`);
+    const groundingQueries = window.groundingQueries;
+    const citedPages = window.citedPages;
+    invariant(
+      groundingQueries == null || Array.isArray(groundingQueries),
+      `${windowLabel}.groundingQueries must be an array, null, or omitted`,
+    );
+    invariant(
+      citedPages == null || Array.isArray(citedPages),
+      `${windowLabel}.citedPages must be an array, null, or omitted`,
+    );
+    if (aiPerformance.status === 'available') {
+      invariant(
+        Array.isArray(groundingQueries),
+        `${windowLabel}.groundingQueries must be an array when available`,
+      );
+      invariant(
+        Array.isArray(citedPages),
+        `${windowLabel}.citedPages must be an array when available`,
+      );
+    }
     if (aiPerformance.status === 'unavailable') {
-      invariant(window.groundingQueries.length === 0, `${windowLabel}.groundingQueries must be empty when unavailable`);
-      invariant(window.citedPages.length === 0, `${windowLabel}.citedPages must be empty when unavailable`);
+      invariant(
+        groundingQueries == null || groundingQueries.length === 0,
+        `${windowLabel}.groundingQueries must be empty when unavailable`,
+      );
+      invariant(
+        citedPages == null || citedPages.length === 0,
+        `${windowLabel}.citedPages must be empty when unavailable`,
+      );
     }
     const groundingPhrases = new Set();
-    for (const [queryIndex, query] of window.groundingQueries.entries()) {
+    for (const [queryIndex, query] of (groundingQueries ?? []).entries()) {
       const queryLabel = `${windowLabel}.groundingQueries[${queryIndex}]`;
       invariant(isNonEmptyString(query.phrase), `${queryLabel}.phrase is required`);
       invariant(!groundingPhrases.has(query.phrase), `${label} has duplicate grounding phrase ${query.phrase}`);
@@ -300,7 +324,7 @@ function validateBingAiPerformance(aiPerformance, label, latestEndDate) {
       assertCitationCount(query.citationCount, queryLabel, aiPerformance.status);
     }
     const citedUrls = new Set();
-    for (const [pageIndex, page] of window.citedPages.entries()) {
+    for (const [pageIndex, page] of (citedPages ?? []).entries()) {
       const pageLabel = `${windowLabel}.citedPages[${pageIndex}]`;
       invariant(
         typeof page.url === 'string'
@@ -412,8 +436,13 @@ function validateReferralSegments(referrals, referrerFamilyIds) {
 export function isWorldMonitorUrl(value) {
   try {
     const url = new URL(value);
-    return url.hostname === 'worldmonitor.app'
-      || url.hostname.endsWith('.worldmonitor.app');
+    return url.protocol === 'https:'
+      && url.username === ''
+      && url.password === ''
+      && (
+        url.hostname === 'worldmonitor.app'
+        || url.hostname.endsWith('.worldmonitor.app')
+      );
   } catch {
     return false;
   }
@@ -1171,7 +1200,11 @@ function formatSearchPerformance(source, includeIndexedPages = false) {
 
 function referralMetricCell(source, metric) {
   const value = preferredWindow(source).metrics[metric];
-  return value === null ? 'Unavailable' : value;
+  return formatReferralMetric(value);
+}
+
+function formatReferralMetric(value) {
+  return value === null || value === undefined ? 'Unavailable' : value;
 }
 
 function formatReferralRow(label, source) {
@@ -1179,10 +1212,23 @@ function formatReferralRow(label, source) {
   return `| ${label} | ${cells.join(' | ')} |`;
 }
 
+function formatReferralAggregateRows(source) {
+  return source.windows
+    .filter(({ metrics }) => Object.values(metrics).some((value) => Number.isFinite(value)))
+    .map(({ label, metrics }) => {
+      const cells = REFERRAL_METRICS.map((metric) => formatReferralMetric(metrics[metric]));
+      return `| ${label} | ${cells.join(' | ')} |`;
+    });
+}
+
+function formatBingAiDetailCount(source, detail) {
+  if (source.status === 'unavailable' || !Array.isArray(detail)) return 'Unavailable';
+  return detail.length;
+}
+
 function formatBingAiPerformance(source) {
-  const noObservedRows = source.status !== 'available';
   return source.windows.map((window) => (
-    `| ${window.label} | ${window.metrics.totalCitations ?? 'Unavailable'} | ${window.metrics.averageCitedPages ?? 'Unavailable'} | ${noObservedRows ? 'Unavailable' : window.groundingQueries.length} | ${noObservedRows ? 'Unavailable' : window.citedPages.length} |`
+    `| ${window.label} | ${window.metrics.totalCitations ?? 'Unavailable'} | ${window.metrics.averageCitedPages ?? 'Unavailable'} | ${formatBingAiDetailCount(source, window.groundingQueries)} | ${formatBingAiDetailCount(source, window.citedPages)} |`
   ));
 }
 
@@ -1266,6 +1312,7 @@ function formatComparison(comparison) {
 }
 
 export function formatScorecardMarkdown(scorecard) {
+  const aggregateReferralRows = formatReferralAggregateRows(scorecard.referrals);
   const lines = [
     `# SEO and AI-citation visibility scorecard — ${scorecard.baselineId}`,
     '',
@@ -1327,6 +1374,16 @@ export function formatScorecardMarkdown(scorecard) {
     '',
     'Referral segments retain both the major referrer family and landing-page family.',
     'Unavailable aggregates remain unavailable in every slice.',
+    ...(aggregateReferralRows.length
+      ? [
+        '',
+        'Aggregate referral totals are shown by window; missing metrics remain unavailable.',
+        '',
+        '| Aggregate window | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | Activations | API actions | MCP actions |',
+        '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+        ...aggregateReferralRows,
+      ]
+      : []),
     '',
     '| Referrer family | Sessions | Dashboard launches | Pricing views | Sign-ups | Pro conversions | Activations | API actions | MCP actions |',
     '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -29,7 +29,7 @@ import type { PanelConfig } from '@/types';
 import { renderPreferences } from '@/services/preferences-content';
 import { renderNotificationsSettings, type NotificationsSettingsResult } from '@/services/notifications-settings';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
-import { track } from '@/services/analytics';
+import { track, trackApiAction } from '@/services/analytics';
 import { isEntitled, hasFeature, onEntitlementChange, getEntitlementState } from '@/services/entitlements';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { getSubscription, onSubscriptionChange, openBillingPortal, prereserveBillingPortalTab } from '@/services/billing';
@@ -1449,6 +1449,7 @@ export class UnifiedSettings {
     try {
       const result = await createApiKey(name);
       if (!this.isAccountRequestCurrent(request)) return;
+      trackApiAction('key-created');
       this.newlyCreatedKey = result.key;
       input.value = '';
       this.showCreatedBanner(result.key);
@@ -1480,6 +1481,7 @@ export class UnifiedSettings {
     try {
       await revokeApiKey(keyId);
       if (!this.isAccountRequestCurrent(request)) return;
+      trackApiAction('key-revoked');
       await this.loadApiKeys();
     } catch (err) {
       if (!this.isAccountRequestCurrent(request)) return;

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -121,6 +121,9 @@ const EVENTS = {
   'checkout-start': true,
   'checkout-success': true,
   'checkout-failed': true,
+  // API outcome telemetry — closed-vocabulary key lifecycle actions only;
+  // never include key names, ids, prompts, or request/user data.
+  'api-action': true,
   // Premium entitlement health — a client that believes it is Pro received a
   // server-side denial. This is trend telemetry, never an authorization signal.
   'entitlement-desync': true,
@@ -820,6 +823,15 @@ const CHECKOUT_FAILED_STATUSES = new Set(['failed', 'declined', 'cancelled', 'ca
 export function trackCheckoutFailed(rawStatus: string): void {
   const status = CHECKOUT_FAILED_STATUSES.has(rawStatus) ? rawStatus : 'other';
   track('checkout-failed', { status });
+}
+
+const API_ACTIONS = ['key-created', 'key-revoked'] as const;
+export type ApiActionName = (typeof API_ACTIONS)[number];
+
+/** Track a successful, bounded API product action without leaking key data. */
+export function trackApiAction(action: ApiActionName): void {
+  if (!API_ACTIONS.includes(action)) return;
+  track('api-action', { action });
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/funnel-analytics-policy.test.mjs
+++ b/tests/funnel-analytics-policy.test.mjs
@@ -37,9 +37,24 @@ test('UMAMI_DOMAINS covers the canonical www host', () => {
 
 test('funnel events exist in the typed catalog', () => {
   const src = read('src/services/analytics.ts');
-  for (const ev of ['checkout-start', 'checkout-success', 'checkout-failed']) {
+  for (const ev of ['checkout-start', 'checkout-success', 'checkout-failed', 'api-action']) {
     assert.ok(src.includes(`'${ev}': true`), `event '${ev}' missing from EVENTS catalog`);
   }
+});
+
+test('API outcome telemetry is bounded to successful key lifecycle actions', () => {
+  const analytics = read('src/services/analytics.ts');
+  const settings = read('src/components/UnifiedSettings.ts');
+  assert.ok(analytics.includes("['key-created', 'key-revoked'] as const"),
+    'API action vocabulary must stay closed to key lifecycle outcomes');
+  assert.ok(analytics.includes("track('api-action', { action })"),
+    'API action helper must emit only the normalized action bucket');
+  assert.ok(settings.includes("trackApiAction('key-created')"),
+    'successful API key creation no longer contributes to API outcomes');
+  assert.ok(settings.includes("trackApiAction('key-revoked')"),
+    'successful API key revocation no longer contributes to API outcomes');
+  assert.ok(!settings.includes('trackApiAction(keyId)'),
+    'API telemetry must not include a key identifier');
 });
 
 test('dashboard checkout entry fires checkout-start', () => {

--- a/tests/funnel-analytics-policy.test.mjs
+++ b/tests/funnel-analytics-policy.test.mjs
@@ -23,6 +23,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const read = (rel) => readFileSync(new URL(`../${rel}`, import.meta.url), 'utf8');
+const { trackApiAction } = await import('../src/services/analytics.ts');
 
 test('UMAMI_DOMAINS covers the canonical www host', () => {
   const src = read('src/services/analytics.ts');
@@ -55,6 +56,38 @@ test('API outcome telemetry is bounded to successful key lifecycle actions', () 
     'successful API key revocation no longer contributes to API outcomes');
   assert.ok(!settings.includes('trackApiAction(keyId)'),
     'API telemetry must not include a key identifier');
+});
+
+test('API outcome telemetry emits only the closed key lifecycle buckets at runtime', () => {
+  const calls = [];
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      umami: {
+        track: (event, data) => calls.push({ event, data }),
+      },
+    },
+  });
+
+  try {
+    trackApiAction('key-created');
+    trackApiAction('key-revoked');
+    // The TypeScript signature protects typed callers; this exercises the
+    // runtime boundary where an untyped or stale caller can still arrive.
+    trackApiAction('key-exported');
+
+    assert.deepEqual(calls, [
+      { event: 'api-action', data: { action: 'key-created' } },
+      { event: 'api-action', data: { action: 'key-revoked' } },
+    ]);
+  } finally {
+    if (previousWindow) {
+      Object.defineProperty(globalThis, 'window', previousWindow);
+    } else {
+      delete globalThis.window;
+    }
+  }
 });
 
 test('dashboard checkout entry fires checkout-start', () => {

--- a/tests/seo-ai-visibility-collector.test.mjs
+++ b/tests/seo-ai-visibility-collector.test.mjs
@@ -62,6 +62,50 @@ const searchRows = (metrics) => ({
   token: 'must never be copied',
 });
 
+const bingPerformance = ({
+  includeDetailArrays = true,
+  firstCitedUrl = 'https://www.worldmonitor.app/docs/api-reference',
+} = {}) => ({
+  status: 'available',
+  windows: [
+    {
+      label: '28d',
+      startDate: '2026-07-05',
+      endDate: '2026-08-01',
+      totalCitations: 0,
+      averageCitedPages: 0,
+      ...(includeDetailArrays ? {
+        groundingQueries: [],
+        citedPages: firstCitedUrl === null
+          ? []
+          : [{ url: firstCitedUrl, citationCount: 0 }],
+      } : {}),
+    },
+    {
+      label: '90d',
+      startDate: '2026-05-04',
+      endDate: '2026-08-01',
+      totalCitations: 0,
+      averageCitedPages: 0,
+      ...(includeDetailArrays ? {
+        groundingQueries: [],
+        citedPages: [],
+      } : {}),
+    },
+  ],
+});
+
+const completeReferralMetrics = Object.fromEntries([
+  ['sessions', 1],
+  ['dashboardLaunches', 1],
+  ['pricingViews', 1],
+  ['signUps', 1],
+  ['proConversions', 1],
+  ['activations', 1],
+  ['apiActions', 1],
+  ['mcpActions', 1],
+]);
+
 describe('SEO/AI visibility collector', () => {
   it('derives inclusive trailing 28d and 90d windows from the observation date', () => {
     assert.deepEqual(deriveTrailingWindows(observedAt), [
@@ -128,6 +172,75 @@ describe('SEO/AI visibility collector', () => {
     );
   });
 
+  it('detects target-route family collisions without overriding explicit page families', () => {
+    const ambiguousQuerySet = structuredClone(querySet);
+    ambiguousQuerySet.queries[1].targetPage.url = ambiguousQuerySet.queries[0].targetPage.url;
+    const source = searchRows({
+      indexedPages: 1,
+      impressions: 1,
+      clicks: 1,
+      ctr: 1,
+      averagePosition: 1,
+    });
+
+    assert.throws(
+      () => normalizeSearchExport(source, {
+        querySet: ambiguousQuerySet,
+        observedAt,
+        provider: 'googleSearchConsole',
+      }),
+      /maps ambiguously/,
+    );
+
+    const explicit = structuredClone(source);
+    explicit.windows[0].pageRows[0].pageFamily = 'homepage';
+    const normalized = normalizeSearchExport(explicit, {
+      querySet: ambiguousQuerySet,
+      observedAt,
+      provider: 'googleSearchConsole',
+    });
+    assert.equal(normalized.pageFamilyRows[0].pageFamily, 'homepage');
+  });
+
+  it('marks a search export partial when reviewed query or page-family breakdowns are empty', () => {
+    const source = searchRows({
+      indexedPages: 1,
+      impressions: 1,
+      clicks: 1,
+      ctr: 1,
+      averagePosition: 1,
+    });
+    for (const window of source.windows) {
+      window.queryRows = [];
+      window.pageRows = [];
+    }
+
+    const normalized = normalizeSearchExport(source, {
+      querySet,
+      observedAt,
+      provider: 'googleSearchConsole',
+    });
+    assert.equal(normalized.status, 'partial');
+  });
+
+  it('rejects unknown source statuses instead of treating them as available', () => {
+    assert.throws(
+      () => normalizeSearchExport({ status: 'mystery' }, { querySet, observedAt }),
+      /must be available, partial, or unavailable/,
+    );
+    assert.throws(
+      () => normalizeBingAiPerformance({ status: 'mystery' }, { observedAt }),
+      /must be available, partial, or unavailable/,
+    );
+    assert.throws(
+      () => normalizeReferralExport(
+        { status: 'mystery' },
+        { observedAt, classification: template.referrals.classification },
+      ),
+      /must be available, partial, or unavailable/,
+    );
+  });
+
   it('normalizes Bing AI Performance totals, cited pages, and grounding queries', () => {
     const normalized = normalizeBingAiPerformance({
       status: 'available',
@@ -169,6 +282,43 @@ describe('SEO/AI visibility collector', () => {
     ]);
   });
 
+  it('keeps omitted Bing detail arrays partial while preserving explicit empty detail as zero', () => {
+    const omitted = normalizeBingAiPerformance(
+      bingPerformance({ includeDetailArrays: false }),
+      { observedAt },
+    );
+    assert.equal(omitted.status, 'partial');
+    assert.equal(omitted.windows[0].groundingQueries, null);
+    assert.equal(omitted.windows[0].citedPages, null);
+
+    const explicitEmpty = normalizeBingAiPerformance(
+      bingPerformance({ firstCitedUrl: null }),
+      { observedAt },
+    );
+    assert.equal(explicitEmpty.status, 'available');
+    assert.deepEqual(explicitEmpty.windows[0].groundingQueries, []);
+    assert.deepEqual(explicitEmpty.windows[0].citedPages, []);
+  });
+
+  it('rejects cited URL credentials and stores canonical credential-free URLs', () => {
+    const canonical = normalizeBingAiPerformance(
+      bingPerformance({ firstCitedUrl: 'https://WWW.worldmonitor.app/docs/api-reference?view=1' }),
+      { observedAt },
+    );
+    assert.equal(
+      canonical.windows[0].citedPages[0].url,
+      'https://www.worldmonitor.app/docs/api-reference?view=1',
+    );
+
+    assert.throws(
+      () => normalizeBingAiPerformance(
+        bingPerformance({ firstCitedUrl: 'https://operator:secret@www.worldmonitor.app/docs/api-reference' }),
+        { observedAt },
+      ),
+      /must not contain credentials/,
+    );
+  });
+
   it('aggregates only bounded outcome events and keeps absent metrics null', () => {
     const normalized = normalizeReferralExport({
       status: 'available',
@@ -200,6 +350,7 @@ describe('SEO/AI visibility collector', () => {
               referrerFamily: 'chatgpt',
               landingPageFamily: 'developer_mcp',
               event: 'api-action',
+              action: 'key-created',
               count: 0,
             },
             {
@@ -237,6 +388,93 @@ describe('SEO/AI visibility collector', () => {
     assert.equal(JSON.stringify(normalized).includes('must never be copied'), false);
   });
 
+  it('omits referral rows with missing dimensions without inventing direct attribution', () => {
+    const normalized = normalizeReferralExport({
+      status: 'available',
+      windows: [
+        {
+          label: '28d',
+          startDate: '2026-07-05',
+          endDate: '2026-08-01',
+          metrics: completeReferralMetrics,
+          rows: [
+            {
+              landingPageFamily: 'homepage',
+              event: 'session',
+              count: 99,
+            },
+            {
+              referrerFamily: 'chatgpt',
+              event: 'session',
+              count: 98,
+            },
+            {
+              referrerFamily: 'unknown_direct',
+              landingPageFamily: 'homepage',
+              event: 'session',
+              count: 2,
+            },
+          ],
+        },
+        {
+          label: '90d',
+          startDate: '2026-05-04',
+          endDate: '2026-08-01',
+          metrics: completeReferralMetrics,
+          rows: [],
+        },
+      ],
+    }, { observedAt, classification: template.referrals.classification });
+
+    assert.equal(normalized.status, 'partial');
+    assert.deepEqual(normalized.segments.map(({ referrerFamily }) => referrerFamily), ['unknown_direct']);
+    assert.equal(normalized.segments[0].metrics.sessions, 2);
+  });
+
+  it('counts only completed activation aliases and quarantines unknown API actions', () => {
+    const normalized = normalizeReferralExport({
+      status: 'available',
+      windows: [{
+        label: '28d',
+        startDate: '2026-07-05',
+        endDate: '2026-08-01',
+        rows: [
+          {
+            referrerFamily: 'chatgpt',
+            landingPageFamily: 'developer_mcp',
+            event: 'activation',
+            count: 99,
+          },
+          {
+            referrerFamily: 'chatgpt',
+            landingPageFamily: 'developer_mcp',
+            event: 'activation',
+            completion: 'complete',
+            count: 2,
+          },
+          {
+            referrerFamily: 'chatgpt',
+            landingPageFamily: 'developer_mcp',
+            event: 'api-action',
+            action: 'key-revoked',
+            count: 3,
+          },
+          {
+            referrerFamily: 'chatgpt',
+            landingPageFamily: 'developer_mcp',
+            event: 'api-action',
+            action: 'key-deleted',
+            count: 100,
+          },
+        ],
+      }],
+    }, { observedAt, classification: template.referrals.classification });
+
+    assert.equal(normalized.status, 'partial');
+    assert.equal(normalized.windows[0].metrics.activations, 2);
+    assert.equal(normalized.windows[0].metrics.apiActions, 3);
+  });
+
   it('builds a validated dated baseline while leaving omitted manual AI observations empty', () => {
     const sources = {
       googleSearchConsole: searchRows({
@@ -272,6 +510,27 @@ describe('SEO/AI visibility collector', () => {
     assert.equal(JSON.stringify(baseline).includes('operator-only-property-id'), false);
   });
 
+  it('marks omitted AI surface manifests unavailable instead of inheriting template availability', () => {
+    const sources = {
+      googleSearchConsole: { status: 'unavailable', reason: 'No export.' },
+      bingWebmaster: { status: 'unavailable', reason: 'No export.' },
+      referrals: { status: 'unavailable', reason: 'No export.' },
+    };
+    const baseline = collectBaseline({
+      template,
+      querySet,
+      sources,
+      observedAt,
+      repositoryRevision: 'test-revision',
+    });
+
+    assert.deepEqual(
+      baseline.aiSurfaces.map(({ platform, status }) => ({ platform, status })),
+      template.aiSurfaces.map(({ platform }) => ({ platform, status: 'unavailable' })),
+    );
+    assert.equal(baseline.aiObservations.length, 0);
+  });
+
   it('whitelists manual observation fields before writing a baseline', () => {
     const sources = {
       googleSearchConsole: { status: 'unavailable', reason: 'No export.' },
@@ -283,6 +542,12 @@ describe('SEO/AI visibility collector', () => {
         prompt: 'must never be copied',
         userId: 'must never be copied',
       }],
+      opportunities: template.opportunities.map((opportunity) => ({
+        ...opportunity,
+        rawPrompt: 'must never be copied',
+        userId: 'must never be copied',
+        credentials: { token: 'must never be copied' },
+      })),
     };
     const baseline = collectBaseline({
       template,
@@ -294,6 +559,87 @@ describe('SEO/AI visibility collector', () => {
 
     assert.equal(JSON.stringify(baseline).includes('must never be copied'), false);
     assert.equal(baseline.aiObservations[0].queryId, 'q01');
+    assert.deepEqual(
+      Object.keys(baseline.opportunities[0]).sort(),
+      ['evidence', 'experiment', 'priority', 'queryIds', 'successCriteria', 'title'],
+    );
+  });
+
+  it('bounds imported windows, rows, and UTF-8 strings before normalization', () => {
+    const oversizedWindows = Array.from({ length: 17 }, (_, index) => ({
+      label: `${index + 1}d`,
+      startDate: '2026-08-01',
+      endDate: '2026-08-01',
+    }));
+    assert.throws(
+      () => normalizeSearchExport(
+        { status: 'available', windows: oversizedWindows },
+        { querySet, observedAt },
+      ),
+      /windows exceeds the 16-item limit/,
+    );
+
+    const oversizedReferralRows = Array.from({ length: 5_001 }, () => ({
+      referrerFamily: 'chatgpt',
+      landingPageFamily: 'homepage',
+      event: 'session',
+      count: 1,
+    }));
+    assert.throws(
+      () => normalizeReferralExport({
+        status: 'available',
+        windows: [{
+          label: '28d',
+          startDate: '2026-07-05',
+          endDate: '2026-08-01',
+          rows: oversizedReferralRows,
+        }],
+      }, { observedAt, classification: template.referrals.classification }),
+      /rows exceeds the 5000-item limit/,
+    );
+
+    assert.throws(
+      () => normalizeSearchExport(
+        { status: 'unavailable', reason: '😀'.repeat(2_049) },
+        { querySet, observedAt },
+      ),
+      /exceeds the 4096-byte limit/,
+    );
+
+    const oversizedOpportunities = structuredClone(template.opportunities);
+    oversizedOpportunities[0].title = '😀'.repeat(2_049);
+    assert.throws(
+      () => collectBaseline({
+        template,
+        querySet,
+        sources: {
+          googleSearchConsole: { status: 'unavailable', reason: 'No export.' },
+          bingWebmaster: { status: 'unavailable', reason: 'No export.' },
+          referrals: { status: 'unavailable', reason: 'No export.' },
+          opportunities: oversizedOpportunities,
+        },
+        observedAt,
+        repositoryRevision: 'test-revision',
+      }),
+      /opportunities\[0\]\.title exceeds the 4096-byte limit/,
+    );
+  });
+
+  it('fails closed when no repository revision can be resolved', () => {
+    assert.throws(
+      () => collectBaseline({
+        template,
+        querySet,
+        sources: {
+          googleSearchConsole: { status: 'unavailable', reason: 'No export.' },
+          bingWebmaster: { status: 'unavailable', reason: 'No export.' },
+          referrals: { status: 'unavailable', reason: 'No export.' },
+        },
+        observedAt,
+        repositoryRevision: 'unknown-local-revision',
+      }),
+      /local git revision is unavailable/,
+    );
   });
 
   it('reproduces the collector CLI output and its check gate', async () => {
@@ -318,6 +664,31 @@ describe('SEO/AI visibility collector', () => {
       await runCli(args);
       assert.match(readFileSync(outputPath, 'utf8'), /"baselineId": "2026-08-01"/);
       await runCli([...args, '--check']);
+      writeFileSync(outputPath, 'stale output\n');
+      await assert.rejects(
+        runCli([...args, '--check']),
+        /is stale; regenerate it without --check/,
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects oversized CLI inputs before loading the full file', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'seo-visibility-collector-'));
+    const sourcesPath = join(directory, 'oversized-sources.json');
+    writeFileSync(sourcesPath, Buffer.alloc((4 * 1024 * 1024) + 1, 0x20));
+    try {
+      await assert.rejects(
+        runCli([
+          '--queries', 'docs/research/seo-ai-visibility/query-set.json',
+          '--template', 'docs/research/seo-ai-visibility/baselines/2026-07-27.json',
+          '--sources', sourcesPath,
+          '--observed-at', observedAt,
+          '--repository-revision', 'test-revision',
+        ]),
+        /oversized-sources\.json exceeds the 4194304-byte input limit/,
+      );
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/tests/seo-ai-visibility-collector.test.mjs
+++ b/tests/seo-ai-visibility-collector.test.mjs
@@ -1,0 +1,325 @@
+import assert from 'node:assert/strict';
+import {
+  collectBaseline,
+  deriveTrailingWindows,
+  normalizeBingAiPerformance,
+  normalizeReferralExport,
+  normalizeSearchExport,
+  runCli,
+} from '../scripts/seo-ai-visibility-collector.mjs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, it } from 'node:test';
+
+const readJson = (relativePath) => JSON.parse(
+  readFileSync(new URL(`../${relativePath}`, import.meta.url), 'utf8'),
+);
+
+const querySet = readJson('docs/research/seo-ai-visibility/query-set.json');
+const template = readJson(
+  'docs/research/seo-ai-visibility/baselines/2026-07-27.json',
+);
+const observedAt = '2026-08-01T12:00:00Z';
+
+const searchRows = (metrics) => ({
+  status: 'available',
+  property: 'operator-only-property-id',
+  windows: [
+    {
+      label: '28d',
+      startDate: '2026-07-05',
+      endDate: '2026-08-01',
+      metrics,
+      queryRows: [
+        {
+          query: querySet.queries[0].query,
+          clicks: 4,
+          impressions: 20,
+          ctr: 0.2,
+          position: 8,
+        },
+      ],
+      pageRows: [
+        {
+          page: 'https://www.worldmonitor.app/',
+          clicks: 4,
+          impressions: 20,
+          ctr: 0.2,
+          position: 8,
+        },
+      ],
+    },
+    {
+      label: '90d',
+      startDate: '2026-05-04',
+      endDate: '2026-08-01',
+      metrics,
+      queryRows: [],
+      pageRows: [],
+    },
+  ],
+  token: 'must never be copied',
+});
+
+describe('SEO/AI visibility collector', () => {
+  it('derives inclusive trailing 28d and 90d windows from the observation date', () => {
+    assert.deepEqual(deriveTrailingWindows(observedAt), [
+      { label: '28d', startDate: '2026-07-05', endDate: '2026-08-01' },
+      { label: '90d', startDate: '2026-05-04', endDate: '2026-08-01' },
+    ]);
+  });
+
+  it('normalizes exact reviewed queries and page families without copying property or token data', () => {
+    const normalized = normalizeSearchExport(
+      searchRows({
+        indexedPages: 0,
+        impressions: 20,
+        clicks: 4,
+        ctr: 0.2,
+        averagePosition: 8,
+      }),
+      { querySet, observedAt, provider: 'googleSearchConsole' },
+    );
+
+    assert.equal(normalized.property, null);
+    assert.equal(normalized.status, 'partial');
+    assert.deepEqual(normalized.queryRows, [{
+      windowLabel: '28d',
+      queryId: 'q01',
+      metrics: {
+        impressions: 20,
+        clicks: 4,
+        ctr: 0.2,
+        averagePosition: 8,
+      },
+    }]);
+    assert.deepEqual(normalized.pageFamilyRows, [{
+      windowLabel: '28d',
+      pageFamily: 'homepage',
+      metrics: {
+        indexedPages: null,
+        impressions: 20,
+        clicks: 4,
+        ctr: 0.2,
+        averagePosition: 8,
+      },
+    }]);
+    assert.equal(normalized.windows[0].metrics.indexedPages, 0);
+    assert.equal('token' in normalized, false);
+  });
+
+  it('fails closed when an imported query is not an exact reviewed query', () => {
+    const source = searchRows({
+      indexedPages: 1,
+      impressions: 1,
+      clicks: 1,
+      ctr: 1,
+      averagePosition: 1,
+    });
+    source.windows[0].queryRows[0].query = 'a paraphrase that is not reviewed';
+    assert.throws(
+      () => normalizeSearchExport(source, {
+        querySet,
+        observedAt,
+        provider: 'googleSearchConsole',
+      }),
+      /exact reviewed query text/,
+    );
+  });
+
+  it('normalizes Bing AI Performance totals, cited pages, and grounding queries', () => {
+    const normalized = normalizeBingAiPerformance({
+      status: 'available',
+      windows: [
+        {
+          label: '28d',
+          startDate: '2026-07-05',
+          endDate: '2026-08-01',
+          totalCitations: 12,
+          averageCitedPages: 2.5,
+          groundingQueries: [
+            { phrase: 'geopolitical risk API', citationCount: 3 },
+          ],
+          citedPages: [
+            { url: 'https://www.worldmonitor.app/docs/api-reference', citationCount: 4 },
+          ],
+        },
+        {
+          label: '90d',
+          startDate: '2026-05-04',
+          endDate: '2026-08-01',
+          totalCitations: 20,
+          averageCitedPages: 1,
+          groundingQueries: [],
+          citedPages: [],
+        },
+      ],
+    }, { observedAt });
+
+    assert.equal(normalized.windows[0].metrics.totalCitations, 12);
+    assert.deepEqual(normalized.windows[0].groundingQueries, [
+      { phrase: 'geopolitical risk API', citationCount: 3 },
+    ]);
+    assert.deepEqual(normalized.windows[0].citedPages, [
+      {
+        url: 'https://www.worldmonitor.app/docs/api-reference',
+        citationCount: 4,
+      },
+    ]);
+  });
+
+  it('aggregates only bounded outcome events and keeps absent metrics null', () => {
+    const normalized = normalizeReferralExport({
+      status: 'available',
+      windows: [
+        {
+          label: '28d',
+          startDate: '2026-07-05',
+          endDate: '2026-08-01',
+          rows: [
+            {
+              referrerFamily: 'chatgpt',
+              landingPageFamily: 'homepage',
+              event: 'session',
+              count: 8,
+            },
+            {
+              referrerFamily: 'chatgpt',
+              landingPageFamily: 'homepage',
+              event: 'dashboard-launch',
+              count: 3,
+            },
+            {
+              referrerFamily: 'chatgpt',
+              landingPageFamily: 'pricing',
+              event: 'checkout-success',
+              count: 1,
+            },
+            {
+              referrerFamily: 'chatgpt',
+              landingPageFamily: 'developer_mcp',
+              event: 'api-action',
+              count: 0,
+            },
+            {
+              referrerFamily: 'chatgpt',
+              landingPageFamily: 'developer_mcp',
+              event: 'pro-activation-exit',
+              count: 2,
+              completion: 'complete',
+            },
+            {
+              referrerFamily: 'chatgpt',
+              landingPageFamily: 'developer_mcp',
+              event: 'mcp-connect-success',
+              count: 1,
+              prompt: 'must never be copied',
+              userId: 'must never be copied',
+            },
+          ],
+        },
+      ],
+    }, { observedAt, classification: template.referrals.classification });
+
+    assert.equal(normalized.status, 'partial');
+    assert.deepEqual(normalized.windows[0].metrics, {
+      sessions: 8,
+      dashboardLaunches: 3,
+      pricingViews: null,
+      signUps: null,
+      proConversions: 1,
+      activations: 2,
+      apiActions: 0,
+      mcpActions: 1,
+    });
+    assert.equal(normalized.segments.length, 3);
+    assert.equal(JSON.stringify(normalized).includes('must never be copied'), false);
+  });
+
+  it('builds a validated dated baseline while leaving omitted manual AI observations empty', () => {
+    const sources = {
+      googleSearchConsole: searchRows({
+        indexedPages: 1,
+        impressions: 20,
+        clicks: 4,
+        ctr: 0.2,
+        averagePosition: 8,
+      }),
+      bingWebmaster: {
+        status: 'unavailable',
+        reason: 'No supported export was supplied.',
+      },
+      referrals: {
+        status: 'unavailable',
+        reason: 'No aggregate analytics export was supplied.',
+      },
+      aiSurfaces: template.aiSurfaces,
+    };
+    const baseline = collectBaseline({
+      template,
+      querySet,
+      sources,
+      observedAt,
+      repositoryRevision: 'test-revision',
+    });
+
+    assert.equal(baseline.baselineId, '2026-08-01');
+    assert.equal(baseline.repositoryRevision, 'test-revision');
+    assert.equal(baseline.aiObservations.length, 0);
+    assert.equal(baseline.search.googleSearchConsole.windows[0].metrics.clicks, 4);
+    assert.equal(baseline.referrals.windows[0].metrics.activations, null);
+    assert.equal(JSON.stringify(baseline).includes('operator-only-property-id'), false);
+  });
+
+  it('whitelists manual observation fields before writing a baseline', () => {
+    const sources = {
+      googleSearchConsole: { status: 'unavailable', reason: 'No export.' },
+      bingWebmaster: { status: 'unavailable', reason: 'No export.' },
+      referrals: { status: 'unavailable', reason: 'No export.' },
+      aiSurfaces: template.aiSurfaces,
+      aiObservations: [{
+        ...template.aiObservations[0],
+        prompt: 'must never be copied',
+        userId: 'must never be copied',
+      }],
+    };
+    const baseline = collectBaseline({
+      template,
+      querySet,
+      sources,
+      observedAt,
+      repositoryRevision: 'test-revision',
+    });
+
+    assert.equal(JSON.stringify(baseline).includes('must never be copied'), false);
+    assert.equal(baseline.aiObservations[0].queryId, 'q01');
+  });
+
+  it('reproduces the collector CLI output and its check gate', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'seo-visibility-collector-'));
+    const sourcesPath = join(directory, 'sources.json');
+    const outputPath = join(directory, 'baseline.json');
+    writeFileSync(sourcesPath, JSON.stringify({
+      googleSearchConsole: { status: 'unavailable', reason: 'No export.' },
+      bingWebmaster: { status: 'unavailable', reason: 'No export.' },
+      referrals: { status: 'unavailable', reason: 'No export.' },
+      aiSurfaces: template.aiSurfaces,
+    }));
+    const args = [
+      '--queries', 'docs/research/seo-ai-visibility/query-set.json',
+      '--template', 'docs/research/seo-ai-visibility/baselines/2026-07-27.json',
+      '--sources', sourcesPath,
+      '--observed-at', observedAt,
+      '--repository-revision', 'test-revision',
+      '--output', outputPath,
+    ];
+    try {
+      await runCli(args);
+      assert.match(readFileSync(outputPath, 'utf8'), /"baselineId": "2026-08-01"/);
+      await runCli([...args, '--check']);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/seo-ai-visibility-scorecard.test.mjs
+++ b/tests/seo-ai-visibility-scorecard.test.mjs
@@ -168,6 +168,118 @@ describe('SEO and AI visibility baseline', () => {
     );
   });
 
+  it('rejects unavailable Bing detail, incomplete counts, and duplicate detail entries', () => {
+    const unavailable = structuredClone(baseline);
+    unavailable.search.bingWebmaster.aiPerformance.windows[0].groundingQueries = [
+      { phrase: 'geopolitical risk API', citationCount: 1 },
+    ];
+    assert.throws(
+      () => validateBaseline(unavailable, querySet),
+      /groundingQueries must be empty when unavailable/,
+    );
+
+    const unavailablePages = structuredClone(baseline);
+    unavailablePages.search.bingWebmaster.aiPerformance.windows[0].citedPages = [{
+      url: 'https://www.worldmonitor.app/docs/api-reference',
+      citationCount: 1,
+    }];
+    assert.throws(
+      () => validateBaseline(unavailablePages, querySet),
+      /citedPages must be empty when unavailable/,
+    );
+
+    const available = structuredClone(baseline);
+    available.search.bingWebmaster.aiPerformance = {
+      status: 'available',
+      reason: null,
+      windows: available.search.bingWebmaster.aiPerformance.windows.map((window) => ({
+        ...window,
+        metrics: { totalCitations: 12, averageCitedPages: 2 },
+        groundingQueries: [{ phrase: 'geopolitical risk API', citationCount: 3 }],
+        citedPages: [{
+          url: 'https://www.worldmonitor.app/docs/api-reference',
+          citationCount: 4,
+        }],
+      })),
+    };
+
+    const missingCount = structuredClone(available);
+    delete missingCount.search.bingWebmaster.aiPerformance.windows[0]
+      .groundingQueries[0].citationCount;
+    assert.throws(
+      () => validateBaseline(missingCount, querySet),
+      /citationCount must be a finite non-negative number or null/,
+    );
+
+    const nullCount = structuredClone(available);
+    nullCount.search.bingWebmaster.aiPerformance.windows[0]
+      .citedPages[0].citationCount = null;
+    assert.throws(
+      () => validateBaseline(nullCount, querySet),
+      /citationCount must be finite when available/,
+    );
+
+    const duplicatePhrase = structuredClone(available);
+    duplicatePhrase.search.bingWebmaster.aiPerformance.windows[0]
+      .groundingQueries.push({ phrase: 'geopolitical risk API', citationCount: 1 });
+    assert.throws(
+      () => validateBaseline(duplicatePhrase, querySet),
+      /duplicate grounding phrase/,
+    );
+
+    const duplicateUrl = structuredClone(available);
+    duplicateUrl.search.bingWebmaster.aiPerformance.windows[0]
+      .citedPages.push({
+        url: 'https://www.worldmonitor.app/docs/api-reference',
+        citationCount: 1,
+      });
+    assert.throws(
+      () => validateBaseline(duplicateUrl, querySet),
+      /duplicate cited page/,
+    );
+
+    const credentialUrl = structuredClone(available);
+    credentialUrl.search.bingWebmaster.aiPerformance.windows[0]
+      .citedPages[0].url = 'https://operator:secret@worldmonitor.app/docs/api-reference';
+    assert.throws(
+      () => validateBaseline(credentialUrl, querySet),
+      /World Monitor HTTPS URL/,
+    );
+  });
+
+  it('renders partial Bing detail per window and keeps missing detail unavailable', () => {
+    const measured = structuredClone(baseline);
+    measured.search.bingWebmaster.aiPerformance = {
+      status: 'partial',
+      reason: 'Detail exports were only available for one window and field.',
+      windows: [
+        {
+          label: '28d',
+          startDate: '2026-06-30',
+          endDate: '2026-07-27',
+          metrics: { totalCitations: 12, averageCitedPages: 2 },
+          groundingQueries: [{ phrase: 'geopolitical risk API', citationCount: null }],
+          citedPages: [{
+            url: 'https://www.worldmonitor.app/docs/api-reference',
+            citationCount: null,
+          }],
+        },
+        {
+          label: '90d',
+          startDate: '2026-04-29',
+          endDate: '2026-07-27',
+          metrics: { totalCitations: null, averageCitedPages: null },
+          groundingQueries: [],
+        },
+      ],
+    };
+
+    const markdown = formatScorecardMarkdown(buildScorecard(querySet, measured));
+
+    assert.match(markdown, /\| 28d \| 12 \| 2 \| 1 \| 1 \|/);
+    assert.match(markdown, /\| 90d \| Unavailable \| Unavailable \| 0 \| Unavailable \|/);
+  });
+
   it('distinguishes an AI brand mention from a direct citation', () => {
     const invalid = structuredClone(baseline);
     invalid.aiObservations[0].directCitation = true;
@@ -556,6 +668,65 @@ describe('scorecard computation', () => {
       scorecard.referrals.byPageFamily.homepage.windows[0].metrics.sessions,
       12,
     );
+  });
+
+  it('renders aggregate-only referral windows without fabricating family slices', () => {
+    const measured = structuredClone(baseline);
+    measured.referrals = {
+      ...measured.referrals,
+      status: 'available',
+      reason: null,
+      windows: [
+        {
+          label: '28d',
+          startDate: '2026-06-30',
+          endDate: '2026-07-27',
+          metrics: {
+            sessions: 100,
+            dashboardLaunches: 20,
+            pricingViews: 15,
+            signUps: 5,
+            proConversions: 2,
+            activations: 1,
+            apiActions: 3,
+            mcpActions: 4,
+          },
+        },
+        {
+          label: '90d',
+          startDate: '2026-04-29',
+          endDate: '2026-07-27',
+          metrics: {
+            sessions: 300,
+            dashboardLaunches: 50,
+            pricingViews: 40,
+            signUps: 15,
+            proConversions: 6,
+            activations: 4,
+            apiActions: 8,
+            mcpActions: 10,
+          },
+        },
+      ],
+      segments: [],
+    };
+
+    const scorecard = buildScorecard(querySet, measured);
+    assert.equal(scorecard.referrals.windows[0].metrics.sessions, 100);
+    assert.equal(
+      scorecard.referrals.byReferrerFamily.chatgpt.windows[0].metrics.sessions,
+      null,
+    );
+    assert.equal(
+      scorecard.referrals.byPageFamily.homepage.windows[0].metrics.sessions,
+      null,
+    );
+
+    const markdown = formatScorecardMarkdown(scorecard);
+    assert.match(markdown, /Aggregate referral totals are shown by window/);
+    assert.match(markdown, /\| 28d \| 100 \| 20 \| 15 \| 5 \| 2 \| 1 \| 3 \| 4 \|/);
+    assert.match(markdown, /\| 90d \| 300 \| 50 \| 40 \| 15 \| 6 \| 4 \| 8 \| 10 \|/);
+    assert.match(markdown, /\| ChatGPT \| Unavailable \| Unavailable \|/);
   });
 
   it('finds new/lost citations and meaningful search changes between periods', () => {

--- a/tests/seo-ai-visibility-scorecard.test.mjs
+++ b/tests/seo-ai-visibility-scorecard.test.mjs
@@ -137,6 +137,37 @@ describe('SEO and AI visibility baseline', () => {
     );
   });
 
+  it('validates Bing AI Performance citations as bounded first-party evidence', () => {
+    const available = structuredClone(baseline);
+    available.search.bingWebmaster.aiPerformance = {
+      status: 'available',
+      reason: null,
+      windows: available.search.bingWebmaster.aiPerformance.windows.map((window) => ({
+        ...window,
+        metrics: { totalCitations: 12, averageCitedPages: 2 },
+        groundingQueries: [{ phrase: 'geopolitical risk API', citationCount: 3 }],
+        citedPages: [{ url: 'https://www.worldmonitor.app/docs/api-reference', citationCount: 4 }],
+      })),
+    };
+    assert.doesNotThrow(() => validateBaseline(available, querySet));
+
+    const external = structuredClone(available);
+    external.search.bingWebmaster.aiPerformance.windows[0].citedPages[0].url =
+      'https://example.com/not-world-monitor';
+    assert.throws(
+      () => validateBaseline(external, querySet),
+      /must be a World Monitor HTTPS URL/,
+    );
+
+    const insecure = structuredClone(available);
+    insecure.search.bingWebmaster.aiPerformance.windows[0].citedPages[0].url =
+      'http://worldmonitor.app/docs/api-reference';
+    assert.throws(
+      () => validateBaseline(insecure, querySet),
+      /must be a World Monitor HTTPS URL/,
+    );
+  });
+
   it('distinguishes an AI brand mention from a direct citation', () => {
     const invalid = structuredClone(baseline);
     invalid.aiObservations[0].directCitation = true;
@@ -181,7 +212,7 @@ describe('SEO and AI visibility baseline', () => {
 
   it('rejects committed property IDs, malformed guardrails, and invalid priorities', () => {
     const property = structuredClone(baseline);
-    property.search.googleSearchConsole.property = 'sc-domain:worldmonitor.app';
+    property.search.googleSearchConsole.property = 'operator-only-property-id';
     assert.throws(
       () => validateBaseline(property, querySet),
       /property must remain null/,
@@ -361,6 +392,7 @@ describe('scorecard computation', () => {
       null,
     );
     assert.equal(scorecard.referrals.status, 'unavailable');
+    assert.equal(scorecard.search.bingWebmaster.aiPerformance.status, 'unavailable');
     assert.equal(Object.keys(scorecard.byIntent).length, 5);
     assert.equal(
       Object.keys(scorecard.byPageFamily).length,
@@ -454,6 +486,7 @@ describe('scorecard computation', () => {
             pricingViews: 3,
             signUps: 2,
             proConversions: 1,
+            activations: 1,
             apiActions: 1,
             mcpActions: 1,
           },
@@ -470,6 +503,7 @@ describe('scorecard computation', () => {
             pricingViews: 2,
             signUps: 1,
             proConversions: 1,
+            activations: 1,
             apiActions: 0,
             mcpActions: 0,
           },
@@ -484,6 +518,7 @@ describe('scorecard computation', () => {
             pricingViews: 1,
             signUps: 1,
             proConversions: 0,
+            activations: 0,
             apiActions: 1,
             mcpActions: 1,
           },
@@ -714,6 +749,45 @@ describe('scorecard computation', () => {
 
     assert.equal(comparison.search.googleSearchConsole.metrics.impressions.absolute, 150);
     assert.equal(comparison.search.googleSearchConsole.metrics.indexedPages, null);
+  });
+
+  it('compares and renders Bing AI Performance metrics only across advancing windows', () => {
+    const [previous, current] = buildComparableScorecards();
+    previous.search.bingWebmaster.aiPerformance = {
+      status: 'partial',
+      reason: 'Grounding phrase export is incomplete.',
+      windows: [{
+        label: '28d',
+        startDate: '2026-06-30',
+        endDate: '2026-07-27',
+        metrics: { totalCitations: 20, averageCitedPages: 2 },
+        groundingQueries: [],
+        citedPages: [],
+      }],
+    };
+    current.search.bingWebmaster.aiPerformance = {
+      status: 'partial',
+      reason: 'Grounding phrase export is incomplete.',
+      windows: [{
+        label: '28d',
+        startDate: '2026-07-31',
+        endDate: '2026-08-27',
+        metrics: { totalCitations: 35, averageCitedPages: 3.5 },
+        groundingQueries: [],
+        citedPages: [],
+      }],
+    };
+
+    const comparison = compareScorecards(previous, current);
+    assert.equal(comparison.search.bingAiPerformance.windowLabel, '28d');
+    assert.equal(comparison.search.bingAiPerformance.metrics.totalCitations.absolute, 15);
+    assert.equal(comparison.search.bingAiPerformance.metrics.totalCitations.meaningful, true);
+    assert.equal(comparison.search.bingAiPerformance.metrics.averageCitedPages.absolute, 1.5);
+    current.comparison = comparison;
+    const markdown = formatScorecardMarkdown(current);
+    assert.match(markdown, /## Bing AI Performance/);
+    assert.match(markdown, /Meaningful search changes: .*bingAiPerformance\.totalCitations/);
+    assert.match(markdown, /\| 28d \| 35 \| 3\.5 \|/);
   });
 
   it('prefers the 28d window for comparisons regardless of authored window order', () => {


### PR DESCRIPTION
## Summary

Closes #5928 by turning AI visibility review into a dated, reproducible evidence loop without adding provider credentials or raw exports to the repository.

## What changed

- Added a secure local collector for reviewed Google Search Console, Bing AI Performance, and bounded first-party referral/outcome manifests.
- Added explicit 28-day and 90-day windows, exact query/page-family reconciliation, honest unavailable/partial/null semantics, and reproducible digests.
- Added Bing AI citation totals, cited URLs, grounding-query phrases, and observation-window validation while allowing provider access to remain unavailable.
- Reconciled dashboard launches, pricing views, sign-ups, checkout success, completed Pro activation exits, API-key actions, and successful MCP actions into bounded funnel evidence.
- Added successful API-key lifecycle telemetry with a closed vocabulary and no key IDs, names, prompts, or user identifiers.
- Added dated baseline/scorecard output, prior-window comparison, prioritized experiment queue, and documentation of causal-claim limits.

## New concepts

The bounded AI-visibility evidence contract is a dated, normalized shape that joins reviewed discovery queries, page families, provider windows, referral outcomes, and manual AI observations. It is intended for reproducible decision support, not raw real-time ingestion or a claim that citation changes caused traffic or conversion uplift.

## Validation

- `npm run typecheck`
- `npm run typecheck:api`
- Focused collector, scorecard, and funnel policy tests: 56 passed
- Full pre-push gate: passed, including 240 edge tests, Unicode/boundary/safe-HTML checks, premium-fetch parity, Markdown lint, and version sync

## Post-Deploy Monitoring & Validation

- Owner: growth/analytics maintainer. Watch the first two collection runs after deploy.
- Confirm `api-action` contains only `key-created` and `key-revoked` for successful lifecycle actions, with no key IDs, names, prompts, or user identifiers.
- Compare the first two dated GSC/Bing windows, Bing AI citation/grounding/cited-page coverage, and referral outcome segments against the reviewed query contract.
- Healthy behavior is explicit `available`/`partial`/`unavailable` status, null for missing metrics, zero only when a provider reports zero, and a passing scorecard check.
- If any raw sensitive field, non-allowlisted event, stale/reversed window, or scorecard rejection appears, pause collection and revert the importer/telemetry change.

## Type of change

- [x] New feature
- [x] Documentation
- [x] Tests

## Security and privacy

- Provider properties, tokens, raw prompts, user IDs, and unapproved URLs are rejected or omitted from committed/output evidence.
- No SERP scraping, special schema/file submission, fixed citation quota, or provider credential handling is introduced.

---

![Compound Engineering](https://img.shields.io/badge/Compound%20Engineering-000000?style=flat-square&logo=github)
![Codex](https://img.shields.io/badge/MODEL_SLUG-GPT--5_Codex-000000?style=flat-square&logo=openai)