### PR TITLE
test(auth): harden Clerk expiry regression

### DIFF
--- a/tests/clerk-token-cache-expiry.test.mts
+++ b/tests/clerk-token-cache-expiry.test.mts
@@ -214,15 +214,13 @@ describe('getClerkToken', () => {
 
   it('does not return a token that expires during a failed refresh', async () => {
     const originalDateNow = Date.now;
-    let now = 1_760_000_000_000;
-    Date.now = () => now;
+    const now = 1_760_000_000_000;
+    let dateNowReads = 0;
+    Date.now = () => (dateNowReads++ < 2 ? now : now + 6_000);
     const nearExpiry = tokenExpiringAt(now + 5_000);
     const session = {
       async getToken(options: { template?: string; skipCache?: boolean } = {}) {
-        if (options.skipCache) {
-          now += 6_000;
-          throw new Error('network');
-        }
+        if (options.skipCache) throw new Error('network');
         return nearExpiry;
       },
     };


### PR DESCRIPTION
## Summary

The merged Clerk fallback path is now covered by a regression that fails if the final current-time expiry check is replaced with the earlier captured timestamp. This follow-up makes the failed-refresh test use a deterministic clock: the token is still alive at the captured fetch time but expired by the final lifetime decision.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Other: Clerk token cache tests

## Validation

- `./node_modules/.bin/tsx --test tests/clerk-token-cache-expiry.test.mts` — 18 passed
- `npm run typecheck`
- Biome check and full pre-push gates passed

Related: #5937

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-Codex-000000)
