### PR TITLE
fix(ops): sync seed-conflict-intel Railway watch paths with GDELT bulk contract registry

### DIFF
--- a/tests/railway-services-registry-coverage.test.mts
+++ b/tests/railway-services-registry-coverage.test.mts
@@ -311,12 +311,13 @@ describe('Railway service registry coverage', () => {
       (r) => r.service === 'seed-conflict-intel',
     );
     assert.ok(conflictIntel, 'seed-conflict-intel must be registered');
+    const watchPatterns = conflictIntel.watchPatterns;
     assert.ok(
-      Array.isArray((conflictIntel as any).watchPatterns),
+      Array.isArray(watchPatterns),
       'seed-conflict-intel must declare watchPatterns',
     );
     assert.ok(
-      (conflictIntel as any).watchPatterns.includes('scripts/_gdelt-bulk-contract.mjs'),
+      watchPatterns.includes('scripts/_gdelt-bulk-contract.mjs'),
       'seed-conflict-intel watchPaths must include scripts/_gdelt-bulk-contract.mjs ' +
         '(the GDELT bulk Redis key contract shared by the materializer, conflict intel, ' +
         'and unrest consumers)',

--- a/tests/railway-services-registry-coverage.test.mts
+++ b/tests/railway-services-registry-coverage.test.mts
@@ -306,6 +306,23 @@ describe('Railway service registry coverage', () => {
     }
   });
 
+  it('every nixpacks-root-scripts entry with watchPatterns lists the GDELT bulk contract for seed-conflict-intel', () => {
+    const conflictIntel = registry.find(
+      (r) => r.service === 'seed-conflict-intel',
+    );
+    assert.ok(conflictIntel, 'seed-conflict-intel must be registered');
+    assert.ok(
+      Array.isArray((conflictIntel as any).watchPatterns),
+      'seed-conflict-intel must declare watchPatterns',
+    );
+    assert.ok(
+      (conflictIntel as any).watchPatterns.includes('scripts/_gdelt-bulk-contract.mjs'),
+      'seed-conflict-intel watchPaths must include scripts/_gdelt-bulk-contract.mjs ' +
+        '(the GDELT bulk Redis key contract shared by the materializer, conflict intel, ' +
+        'and unrest consumers)',
+    );
+  });
+
   // Self-fixture: prove BOTH regex shapes match what they're supposed to.
   // Without this, a future "simplification" of either regex could silently
   // stop matching one shape, and the audit above would pass coincidentally


### PR DESCRIPTION
## Summary

The Seed Freshness Monitor scheduled workflow (`seed-freshness-monitor.yml`) has been continuously failing because the Railway production configuration for `seed-conflict-intel` was missing `scripts/_gdelt-bulk-contract.mjs` in its watch paths. The repository registry (`scripts/railway-services.json`) already listed it correctly, but the live Railway config was stale — the audit script (`scripts/audit-railway-watch-paths.mjs`) detects this drift and exits non-zero.

## Changes

- **test(seeders):** Add regression test in `tests/railway-services-registry-coverage.test.mts` asserting `seed-conflict-intel`'s watch paths include `scripts/_gdelt-bulk-contract.mjs`. This prevents silent removal of the shared GDELT Redis key contract from the deployment-triggering paths.

## Operational Fix Applied

The Railway production config was synced to match the registry:
```
node scripts/audit-railway-watch-paths.mjs --apply
```
Verified: subsequent audit passes cleanly.

## Post-Deploy Monitoring & Validation

- **What to watch:** The Seed Freshness Monitor workflow (scheduled `*/15 * * * *`) should turn green after this fix lands.
- **Expected signals:** "Railway operational-config audit passed" in workflow logs.
- **Failure signals:** If the monitor remains red, run `node scripts/audit-railway-watch-paths.mjs` locally with Railway credentials to re-check drift.
- **Validation window:** Two consecutive scheduled runs after merge.
- **Owner:** @koala73

Closes #5946 
