### PR TITLE
feat(feeds): default-enable Ukraine/Poland frontline sources for EN (#5949)

### DIFF
--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -408,7 +408,7 @@ The public server digest feed inventory below is source-backed from `server/worl
 | --- | --- | --- |
 | `full` | `politics` | BBC World; Guardian World; AP News; Reuters World; CNN World; Trump - Truth Social |
 | `full` | `us` | Reuters US; NPR News; PBS NewsHour; ABC News; CBS News; NBC News; Wall Street Journal; Politico; The Hill; Axios |
-| `full` | `europe` | France 24; EuroNews; Le Monde; DW News; Tagesschau (de); ANSA (it); NOS Nieuws (nl); SVT Nyheter (sv); Telex (hu); Index.hu (hu); HVG (hu); 444.hu (hu); 24.hu (hu); Híradó (hu); Portfolio.hu (hu); ATV (hu); N1 Croatia (hr); Index.hr (hr); Jutarnji list (hr); Balkan Insight |
+| `full` | `europe` | France 24; EuroNews; Le Monde; DW News; Tagesschau (de); ANSA (it); NOS Nieuws (nl); SVT Nyheter (sv); Telex (hu); Index.hu (hu); HVG (hu); 444.hu (hu); 24.hu (hu); Híradó (hu); Portfolio.hu (hu); ATV (hu); N1 Croatia (hr); Index.hr (hr); Jutarnji list (hr); Balkan Insight; Kyiv Independent; TVN24; Rzeczpospolita; Meduza; Moscow Times |
 | `full` | `middleeast` | BBC Middle East; Al Jazeera; Guardian ME; Oman Observer; BBC Persian (fa); The National |
 | `full` | `tech` | Hacker News; Ars Technica; The Verge; MIT Tech Review |
 | `full` | `ai` | AI News; VentureBeat AI; The Verge AI; MIT Tech Review; ArXiv AI |

--- a/docs/zh/data-sources.mdx
+++ b/docs/zh/data-sources.mdx
@@ -364,7 +364,7 @@ ACLED 需要鉴权：在 API 项目上设置 `ACLED_EMAIL` + `ACLED_PASSWORD`（
 | --- | --- | --- |
 | `full` | `politics` | BBC World; Guardian World; AP News; Reuters World; CNN World; Trump - Truth Social |
 | `full` | `us` | Reuters US; NPR News; PBS NewsHour; ABC News; CBS News; NBC News; Wall Street Journal; Politico; The Hill; Axios |
-| `full` | `europe` | France 24; EuroNews; Le Monde; DW News; Tagesschau (de); ANSA (it); NOS Nieuws (nl); SVT Nyheter (sv); Telex (hu); Index.hu (hu); HVG (hu); 444.hu (hu); 24.hu (hu); Híradó (hu); Portfolio.hu (hu); ATV (hu); N1 Croatia (hr); Index.hr (hr); Jutarnji list (hr); Balkan Insight |
+| `full` | `europe` | France 24; EuroNews; Le Monde; DW News; Tagesschau (de); ANSA (it); NOS Nieuws (nl); SVT Nyheter (sv); Telex (hu); Index.hu (hu); HVG (hu); 444.hu (hu); 24.hu (hu); Híradó (hu); Portfolio.hu (hu); ATV (hu); N1 Croatia (hr); Index.hr (hr); Jutarnji list (hr); Balkan Insight; Kyiv Independent; TVN24; Rzeczpospolita; Meduza; Moscow Times |
 | `full` | `middleeast` | BBC Middle East; Al Jazeera; Guardian ME; Oman Observer; BBC Persian (fa); The National |
 | `full` | `tech` | Hacker News; Ars Technica; The Verge; MIT Tech Review |
 | `full` | `ai` | AI News; VentureBeat AI; The Verge AI; MIT Tech Review; ArXiv AI |

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -64,8 +64,10 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       // DEFAULT_ENABLED_SOURCES.europe. No non-en `lang` tags — buildDigest
       // filters `!f.lang || f.lang === lang`, so lang:pl/ru would never ship to EN.
       { name: 'Kyiv Independent', url: gn('site:kyivindependent.com when:3d') },
-      { name: 'TVN24', url: gn('site:tvn24.pl when:2d') },
-      { name: 'Rzeczpospolita', url: gn('site:rp.pl when:2d') },
+      // Google News returned HTTP 200 with no items for these site queries;
+      // use the outlets' live native RSS feeds for the EN digest path too.
+      { name: 'TVN24', url: 'https://tvn24.pl/swiat.xml' },
+      { name: 'Rzeczpospolita', url: 'https://www.rp.pl/rss_main' },
       { name: 'Meduza', url: 'https://meduza.io/rss/en/all' },
       { name: 'Moscow Times', url: 'https://www.themoscowtimes.com/rss/news' },
     ],

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -60,6 +60,14 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Index.hr', url: 'https://www.index.hr/rss', lang: 'hr' },
       { name: 'Jutarnji list', url: 'https://www.jutarnji.hr/feed', lang: 'hr' },
       { name: 'Balkan Insight', url: 'https://balkaninsight.com/feed/' },
+      // Ukraine war frontline for EN digests (#5949). Names must match client
+      // DEFAULT_ENABLED_SOURCES.europe. No non-en `lang` tags — buildDigest
+      // filters `!f.lang || f.lang === lang`, so lang:pl/ru would never ship to EN.
+      { name: 'Kyiv Independent', url: gn('site:kyivindependent.com when:3d') },
+      { name: 'TVN24', url: gn('site:tvn24.pl when:2d') },
+      { name: 'Rzeczpospolita', url: gn('site:rp.pl when:2d') },
+      { name: 'Meduza', url: 'https://meduza.io/rss/en/all' },
+      { name: 'Moscow Times', url: 'https://www.themoscowtimes.com/rss/news' },
     ],
     middleeast: [
       { name: 'BBC Middle East', url: 'https://feeds.bbci.co.uk/news/world/middle_east/rss.xml' },

--- a/src/App.ts
+++ b/src/App.ts
@@ -83,8 +83,20 @@ import { preloadCountryGeometry, isCountryGeometryLoaded, getCountryNameByCode }
 import { initI18n, t, I18N_RESOURCES_LOADED_EVENT, type I18nResourcesLoadedDetail } from '@/services/i18n';
 import { initDeferredDashboardFonts } from '@/bootstrap/secondary-startup';
 
-import { computeDefaultDisabledSources, getLocaleBoostedSources, getTotalFeedCount, FEEDS, INTEL_SOURCES } from '@/config/feeds';
-import { selectSourcesUnderCap, findFullyDisabledCategories } from '@/services/source-cap';
+import {
+  computeDefaultDisabledSources,
+  computeLegacyDefaultDisabledSources,
+  FEEDS,
+  FRONTLINE_EUROPE_PROTECTED_SOURCES,
+  getLocaleBoostedSources,
+  getTotalFeedCount,
+  INTEL_SOURCES,
+} from '@/config/feeds';
+import {
+  computeCapDisabledSources,
+  findFullyDisabledCategories,
+  selectSourcesUnderCap,
+} from '@/services/source-cap';
 import {
   cancelBootstrapSlowTier,
   fetchBootstrapData,
@@ -117,6 +129,7 @@ import {
   onSignOut as cloudPrefsSignOut,
   type CloudPrefsAppliedDetail,
 } from '@/utils/cloud-prefs-sync';
+import { migrateFrontlineEuropeDefaultsV3 } from '@/utils/cloud-prefs-migrations';
 import {
   getConvexClient,
   getConvexApi,
@@ -912,21 +925,28 @@ export class App {
         const total = getTotalFeedCount();
         console.log(`[App] Sources reduction: ${defaultDisabled.length} disabled, ${total - defaultDisabled.length} enabled`);
       }
-      // #5949 — re-enable Ukraine/Poland frontline sources for existing profiles
-      // that already wrote the v3 disabled list (which defaulted these off).
-      // Additive only: remove named sources from disabledFeeds once; never
-      // re-disable anything the user later turned back on after this migration.
+      // #5949 — re-enable Ukraine/Poland frontline sources for profiles that
+      // still have the untouched pre-#5949 default disabled set. An exact-set
+      // guard is important here: a customized disabledFeeds set is user
+      // intent, and must not be rewritten by the startup migration.
       const frontlineKey = 'worldmonitor-frontline-europe-enable-v1';
       if (!localStorage.getItem(frontlineKey)) {
-        const frontline = new Set([
-          'Kyiv Independent',
-          'TVN24',
-          'Rzeczpospolita',
-          'Meduza',
-          'Moscow Times',
-        ]);
+        const frontline = new Set<string>(FRONTLINE_EUROPE_PROTECTED_SOURCES);
+        const legacyDefaultDisabled = new Set(computeLegacyDefaultDisabledSources());
+        const legacyCapDisabled = computeCapDisabledSources(
+          FEEDS,
+          INTEL_SOURCES,
+          new Set(computeDefaultDisabledSources()),
+          FREE_MAX_SOURCES,
+        );
         const current = loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []);
-        const updated = current.filter((name) => !frontline.has(name));
+        const migrated = migrateFrontlineEuropeDefaultsV3(
+          { [STORAGE_KEYS.disabledFeeds]: JSON.stringify(current) },
+          legacyDefaultDisabled,
+          frontline,
+          legacyCapDisabled,
+        );
+        const updated = JSON.parse(migrated[STORAGE_KEYS.disabledFeeds] as string) as string[];
         if (updated.length !== current.length) {
           saveToStorage(STORAGE_KEYS.disabledFeeds, updated);
           console.log(
@@ -1924,7 +1944,10 @@ export class App {
       let explicitLocale = '';
       try { explicitLocale = localStorage.getItem('wm-locale-explicit') || ''; } catch { /* private mode */ }
       const userLang = ((explicitLocale || navigator.language || 'en').split('-')[0] ?? 'en').toLowerCase();
-      const protectedNames = userLang === 'en' ? new Set<string>() : getLocaleBoostedSources(userLang);
+      const protectedNames = new Set<string>(FRONTLINE_EUROPE_PROTECTED_SOURCES);
+      if (userLang !== 'en') {
+        for (const name of getLocaleBoostedSources(userLang)) protectedNames.add(name);
+      }
       const { keep, autoDisabled } = selectSourcesUnderCap(FEEDS, INTEL_SOURCES, disabledSources, FREE_MAX_SOURCES, protectedNames);
       // Defense in depth: feeds.ts has 35+ source names that appear in
       // multiple category buckets. The helper guarantees keep ∩ autoDisabled

--- a/src/App.ts
+++ b/src/App.ts
@@ -912,6 +912,29 @@ export class App {
         const total = getTotalFeedCount();
         console.log(`[App] Sources reduction: ${defaultDisabled.length} disabled, ${total - defaultDisabled.length} enabled`);
       }
+      // #5949 — re-enable Ukraine/Poland frontline sources for existing profiles
+      // that already wrote the v3 disabled list (which defaulted these off).
+      // Additive only: remove named sources from disabledFeeds once; never
+      // re-disable anything the user later turned back on after this migration.
+      const frontlineKey = 'worldmonitor-frontline-europe-enable-v1';
+      if (!localStorage.getItem(frontlineKey)) {
+        const frontline = new Set([
+          'Kyiv Independent',
+          'TVN24',
+          'Rzeczpospolita',
+          'Meduza',
+          'Moscow Times',
+        ]);
+        const current = loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []);
+        const updated = current.filter((name) => !frontline.has(name));
+        if (updated.length !== current.length) {
+          saveToStorage(STORAGE_KEYS.disabledFeeds, updated);
+          console.log(
+            `[App] Frontline Europe enable (#5949): re-enabled ${current.length - updated.length} source(s)`,
+          );
+        }
+        localStorage.setItem(frontlineKey, 'done');
+      }
       // Locale boost: additively enable locale-matched sources (runs once per locale).
       // Reads the explicit-choice key (`wm-locale-explicit`, written by Settings →
       // Language) before falling back to navigator. Mirrors the i18n.ts:99

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -156,7 +156,11 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'in.gr', url: rss('https://www.in.gr/feed/'), lang: 'el' },
     { name: 'iefimerida', url: rss('https://www.iefimerida.gr/rss.xml'), lang: 'el' },
     { name: 'Proto Thema', url: rss('https://news.google.com/rss/search?q=site:protothema.gr+when:2d&hl=el&gl=GR&ceid=GR:el'), lang: 'el' },
-    // Russia & Ukraine (independent sources)
+    // Russia & Ukraine
+    // Independent / exile / UA outlets (Meduza, Novaya Gazeta Europe, Kyiv Independent,
+    // Moscow Times) are eligible for DEFAULT_ENABLED_SOURCES.europe.
+    // TASS / RT / RT Russia stay cataloged for opt-in only — state propaganda
+    // (SOURCE_PROPAGANDA_RISK high, stateAffiliated: Russia); never default-on.
     { name: 'BBC Russian', url: rss('https://feeds.bbci.co.uk/russian/rss.xml'), lang: 'ru' },
     { name: 'Meduza', url: rss('https://meduza.io/rss/all'), lang: 'ru' },
     { name: 'Novaya Gazeta Europe', url: rss('https://novayagazeta.eu/feed/rss'), lang: 'ru' },
@@ -1019,7 +1023,15 @@ export function getFeedProvenanceState(sourceName: string): SourceProvenanceStat
 export const DEFAULT_ENABLED_SOURCES: Record<string, string[]> = {
   politics: ['BBC World', 'Guardian World', 'AP News', 'Reuters World', 'CNN World'],
   us: ['Reuters US', 'NPR News', 'PBS NewsHour', 'ABC News', 'CBS News', 'NBC News', 'Wall Street Journal', 'Politico', 'The Hill'],
-  europe: ['France 24', 'EuroNews', 'Le Monde', 'DW News', 'Tagesschau', 'ANSA', 'NOS Nieuws', 'SVT Nyheter', 'Balkan Insight'],
+  // Europe defaults include Ukraine war frontline coverage for EN users (#5949):
+  // Kyiv Independent (UA), TVN24 + Rzeczpospolita (PL — not all three PL to limit noise),
+  // Meduza + Moscow Times (independent RU). TASS/RT stay off (state propaganda).
+  // HU/EL locale packs remain locale-boosted only, not EN default-on.
+  europe: [
+    'France 24', 'EuroNews', 'Le Monde', 'DW News', 'Tagesschau', 'ANSA', 'NOS Nieuws', 'SVT Nyheter', 'Balkan Insight',
+    'Kyiv Independent', 'TVN24', 'Rzeczpospolita', 'Meduza', 'Moscow Times',
+  ],
+
   middleeast: ['BBC Middle East', 'Al Jazeera', 'Al Arabiya', 'Guardian ME', 'BBC Persian', 'Iran International', 'IRNA', 'Mehr News', 'Haaretz', 'Jerusalem Post', 'Ynetnews', 'Asharq News', 'The National'],
   africa: ['BBC Africa', 'News24', 'Africanews', 'Jeune Afrique', 'Africa News', 'Premium Times', 'Channels TV', 'Sahel Crisis'],
   latam: ['BBC Latin America', 'Reuters LatAm', 'InSight Crime', 'Mexico News Daily', 'Clarín', 'Primicias', 'Infobae Americas', 'El Universo'],

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -130,10 +130,19 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'BBC Turkce', url: rss('https://feeds.bbci.co.uk/turkce/rss.xml'), lang: 'tr' },
     { name: 'DW Turkish', url: rss('https://rss.dw.com/xml/rss-tur-all'), lang: 'tr' },
     { name: 'Hurriyet', url: rss('https://www.hurriyet.com.tr/rss/anasayfa'), lang: 'tr' },
-    // Polish (PL)
-    { name: 'TVN24', url: rss('https://tvn24.pl/swiat.xml'), lang: 'pl' },
+    // Polish (PL) — TVN24 / Rzeczpospolita are EN-default frontline sources (#5949).
+    // Multi-URL: EN digests use Google News (English-reachable); PL UI uses native RSS.
+    // No `lang` tag so isFeedInLanguage / server digests do not drop them for EN.
+    // Polsat News stays PL-only (locale-boosted, not EN default-on).
+    { name: 'TVN24', url: {
+      en: rss('https://news.google.com/rss/search?q=site:tvn24.pl+when:2d&hl=en-US&gl=US&ceid=US:en'),
+      pl: rss('https://tvn24.pl/swiat.xml'),
+    } },
     { name: 'Polsat News', url: rss('https://www.polsatnews.pl/rss/wszystkie.xml'), lang: 'pl' },
-    { name: 'Rzeczpospolita', url: rss('https://www.rp.pl/rss_main'), lang: 'pl' },
+    { name: 'Rzeczpospolita', url: {
+      en: rss('https://news.google.com/rss/search?q=site:rp.pl+when:2d&hl=en-US&gl=US&ceid=US:en'),
+      pl: rss('https://www.rp.pl/rss_main'),
+    } },
     // Hungarian (HU) — V4 / CEE coverage. Locale-gated for hu users only,
     // matching the Tagesschau (de) / ANSA (it) / NOS Nieuws (nl) / SVT (sv)
     // convention. `hu` is registered as a supported locale in src/services/i18n.ts.
@@ -162,11 +171,16 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     // TASS / RT / RT Russia stay cataloged for opt-in only — state propaganda
     // (SOURCE_PROPAGANDA_RISK high, stateAffiliated: Russia); never default-on.
     { name: 'BBC Russian', url: rss('https://feeds.bbci.co.uk/russian/rss.xml'), lang: 'ru' },
-    { name: 'Meduza', url: rss('https://meduza.io/rss/all'), lang: 'ru' },
+    // Meduza: multi-URL so EN digests use the English RSS (no lang gate); RU UI keeps Russian.
+    { name: 'Meduza', url: {
+      en: rss('https://meduza.io/rss/en/all'),
+      ru: rss('https://meduza.io/rss/all'),
+    } },
     { name: 'Novaya Gazeta Europe', url: rss('https://novayagazeta.eu/feed/rss'), lang: 'ru' },
     { name: 'TASS', url: rss('https://news.google.com/rss/search?q=site:tass.com+OR+TASS+Russia+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'RT', url: rss('https://www.rt.com/rss/') },
     { name: 'RT Russia', url: rss('https://www.rt.com/rss/russia/') },
+    // English-language (no lang tag) — always EN-digest-reachable
     { name: 'Kyiv Independent', url: rss('https://news.google.com/rss/search?q=site:kyivindependent.com+when:3d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Moscow Times', url: rss('https://www.themoscowtimes.com/rss/news') },
   ],

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -131,16 +131,17 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'DW Turkish', url: rss('https://rss.dw.com/xml/rss-tur-all'), lang: 'tr' },
     { name: 'Hurriyet', url: rss('https://www.hurriyet.com.tr/rss/anasayfa'), lang: 'tr' },
     // Polish (PL) — TVN24 / Rzeczpospolita are EN-default frontline sources (#5949).
-    // Multi-URL: EN digests use Google News (English-reachable); PL UI uses native RSS.
+    // Their native RSS feeds are used for both locales: the Google News site
+    // queries previously used for EN returned HTTP 200 with no <item> nodes.
     // No `lang` tag so isFeedInLanguage / server digests do not drop them for EN.
     // Polsat News stays PL-only (locale-boosted, not EN default-on).
     { name: 'TVN24', url: {
-      en: rss('https://news.google.com/rss/search?q=site:tvn24.pl+when:2d&hl=en-US&gl=US&ceid=US:en'),
+      en: rss('https://tvn24.pl/swiat.xml'),
       pl: rss('https://tvn24.pl/swiat.xml'),
     } },
     { name: 'Polsat News', url: rss('https://www.polsatnews.pl/rss/wszystkie.xml'), lang: 'pl' },
     { name: 'Rzeczpospolita', url: {
-      en: rss('https://news.google.com/rss/search?q=site:rp.pl+when:2d&hl=en-US&gl=US&ceid=US:en'),
+      en: rss('https://www.rp.pl/rss_main'),
       pl: rss('https://www.rp.pl/rss_main'),
     } },
     // Hungarian (HU) — V4 / CEE coverage. Locale-gated for hu users only,
@@ -1034,6 +1035,14 @@ export function getFeedProvenanceState(sourceName: string): SourceProvenanceStat
 }
 
 // Default-enabled sources per panel (Tier 1+2 priority, ≥8 per panel)
+export const FRONTLINE_EUROPE_PROTECTED_SOURCES = [
+  'Kyiv Independent',
+  'TVN24',
+  'Rzeczpospolita',
+  'Meduza',
+  'Moscow Times',
+] as const;
+
 export const DEFAULT_ENABLED_SOURCES: Record<string, string[]> = {
   politics: ['BBC World', 'Guardian World', 'AP News', 'Reuters World', 'CNN World'],
   us: ['Reuters US', 'NPR News', 'PBS NewsHour', 'ABC News', 'CBS News', 'NBC News', 'Wall Street Journal', 'Politico', 'The Hill'],
@@ -1043,7 +1052,7 @@ export const DEFAULT_ENABLED_SOURCES: Record<string, string[]> = {
   // HU/EL locale packs remain locale-boosted only, not EN default-on.
   europe: [
     'France 24', 'EuroNews', 'Le Monde', 'DW News', 'Tagesschau', 'ANSA', 'NOS Nieuws', 'SVT Nyheter', 'Balkan Insight',
-    'Kyiv Independent', 'TVN24', 'Rzeczpospolita', 'Meduza', 'Moscow Times',
+    ...FRONTLINE_EUROPE_PROTECTED_SOURCES,
   ],
 
   middleeast: ['BBC Middle East', 'Al Jazeera', 'Al Arabiya', 'Guardian ME', 'BBC Persian', 'Iran International', 'IRNA', 'Mehr News', 'Haaretz', 'Jerusalem Post', 'Ynetnews', 'Asharq News', 'The National'],
@@ -1094,6 +1103,18 @@ export function computeDefaultDisabledSources(locale?: string): string[] {
   for (const feeds of Object.values(FULL_FEEDS)) for (const f of feeds) all.add(f.name);
   for (const f of INTEL_SOURCES) all.add(f.name);
   return [...all].filter(name => !enabled.has(name));
+}
+
+/**
+ * The v3 source-reduction migration's pre-#5949 disabled set. This is used
+ * only for a conservative one-time frontline migration: an exact match means
+ * the profile still has the old untouched defaults, while any extra or
+ * missing entry is treated as a user-customized preference and left alone.
+ */
+export function computeLegacyDefaultDisabledSources(): string[] {
+  const disabled = new Set(computeDefaultDisabledSources());
+  for (const name of FRONTLINE_EUROPE_PROTECTED_SOURCES) disabled.add(name);
+  return [...disabled];
 }
 
 export function getTotalFeedCount(): number {

--- a/src/services/source-cap.ts
+++ b/src/services/source-cap.ts
@@ -30,6 +30,27 @@ export interface SourceCapResult {
 }
 
 /**
+ * Reconstruct the persisted disabled set produced by the pre-protected cap
+ * caller. This is used only by one-time migrations to recognize an untouched
+ * legacy cap result; callers must still exact-match the returned set before
+ * changing user storage.
+ */
+export function computeCapDisabledSources(
+  feedsByCategory: FeedsByCategory,
+  intelSources: ReadonlyArray<FeedItem>,
+  defaultDisabled: ReadonlySet<string>,
+  cap: number,
+): Set<string> {
+  const { autoDisabled } = selectSourcesUnderCap(
+    feedsByCategory,
+    intelSources,
+    defaultDisabled,
+    cap,
+  );
+  return new Set([...defaultDisabled, ...autoDisabled]);
+}
+
+/**
  * Detect categories where 100% of sources are in the disabled set — the
  * fingerprint of the pre-2026-05-01 free-tier alphabetical-slice cap bug.
  * Returns the source names that should be re-enabled.

--- a/src/utils/cloud-prefs-migrations.ts
+++ b/src/utils/cloud-prefs-migrations.ts
@@ -132,14 +132,23 @@ export function parsePersistedDirtyKeys(
 }
 
 /**
- * Schema-2 migrations map. Used both inline by cloud-prefs-sync.ts (against
- * the variant-aware FEEDS) and by tests (against fixture FEEDS).
+ * Schema migrations map. Used both inline by cloud-prefs-sync.ts (against the
+ * variant-aware FEEDS) and by tests (against fixture FEEDS).
  */
 export function buildMigrations(
   feedsByCategory: FeedsByCategory,
+  legacyDefaultDisabled: ReadonlySet<string> = new Set(),
+  frontlineNames: ReadonlySet<string> = new Set(),
+  legacyCapDisabled: ReadonlySet<string> = new Set(),
 ): Record<number, (data: Record<string, unknown>) => Record<string, unknown>> {
   return {
     2: (data) => migrateDisabledFeedsV2(data, feedsByCategory),
+    3: (data) => migrateFrontlineEuropeDefaultsV3(
+      data,
+      legacyDefaultDisabled,
+      frontlineNames,
+      legacyCapDisabled,
+    ),
   };
 }
 
@@ -187,6 +196,63 @@ export function migrateDisabledFeedsV2(
   );
   console.log(
     `[cloud-prefs] schema-2 migration: re-enabled ${recoverable.length} source(s) from fully-disabled categories`,
+  );
+  return { ...data, 'worldmonitor-disabled-feeds': JSON.stringify(cleaned) };
+}
+
+function hasExactStringSet(values: unknown[], expected: ReadonlySet<string>): boolean {
+  if (values.length !== expected.size) return false;
+  const actual = new Set<string>();
+  for (const value of values) {
+    if (typeof value !== 'string') return false;
+    actual.add(value);
+  }
+  if (actual.size !== expected.size) return false;
+  for (const value of expected) {
+    if (!actual.has(value)) return false;
+  }
+  return true;
+}
+
+/**
+ * Schema-3 migration body for #5949/#5963.
+ *
+ * The old v3 source-reduction defaults stored the five frontline sources in
+ * `disabledFeeds`, and the first protected-cap rollout could append the same
+ * names to its exact persisted cap result. Only an exact match to one of
+ * those untouched legacy sets is safe to migrate: any extra or missing entry
+ * indicates that the user customized source preferences, so the migration
+ * leaves the blob alone rather than overriding explicit choices. The
+ * exact-match guard also makes this safe when a stale cloud row is applied
+ * after the local startup migration.
+ */
+export function migrateFrontlineEuropeDefaultsV3(
+  data: Record<string, unknown>,
+  legacyDefaultDisabled: ReadonlySet<string>,
+  frontlineNames: ReadonlySet<string>,
+  legacyCapDisabled: ReadonlySet<string> = new Set(),
+): Record<string, unknown> {
+  if (
+    (legacyDefaultDisabled.size === 0 && legacyCapDisabled.size === 0)
+    || frontlineNames.size === 0
+  ) return data;
+  const raw = data['worldmonitor-disabled-feeds'];
+  if (typeof raw !== 'string') return data;
+
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { return data; }
+  if (
+    !Array.isArray(parsed)
+    || (!hasExactStringSet(parsed, legacyDefaultDisabled) && !hasExactStringSet(parsed, legacyCapDisabled))
+  ) return data;
+
+  const cleaned = parsed.filter(
+    (name) => typeof name !== 'string' || !frontlineNames.has(name),
+  );
+  if (cleaned.length === parsed.length) return data;
+
+  console.log(
+    `[prefs] schema-3 migration: re-enabled ${parsed.length - cleaned.length} frontline source(s) from an untouched legacy default/cap state`,
   );
   return { ...data, 'worldmonitor-disabled-feeds': JSON.stringify(cleaned) };
 }

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -15,7 +15,15 @@
 import { CLOUD_SYNC_KEYS, type CloudSyncKey } from './sync-keys';
 import { isDesktopRuntime } from '@/services/runtime';
 import { getClerkToken } from '@/services/clerk';
-import { FEEDS } from '@/config/feeds';
+import {
+  computeDefaultDisabledSources,
+  computeLegacyDefaultDisabledSources,
+  FEEDS,
+  FRONTLINE_EUROPE_PROTECTED_SOURCES,
+  INTEL_SOURCES,
+} from '@/config/feeds';
+import { FREE_MAX_SOURCES } from '@/config/panels';
+import { computeCapDisabledSources } from '@/services/source-cap';
 import {
   applyMigrationChain,
   buildMigrations,
@@ -58,7 +66,7 @@ const KEY_DIRTY_KEYS = 'wm-cloud-prefs-dirty-keys';
 // the new schema version. Defaults to 1 when missing (assumes oldest).
 const KEY_LOCAL_SCHEMA_VERSION = 'wm-cloud-prefs-local-schema-version';
 
-const CURRENT_PREFS_SCHEMA_VERSION = 2;
+const CURRENT_PREFS_SCHEMA_VERSION = 3;
 const CLOUD_PREFS_REQUEST_TIMEOUT_MS = 15_000;
 
 // Migrations live in cloud-prefs-migrations.ts to keep them testable —
@@ -81,7 +89,20 @@ const CLOUD_PREFS_REQUEST_TIMEOUT_MS = 15_000;
 // 2 and subsequent sync pulls skip recovery — so a user who explicitly
 // disables every source in a category POST-migration keeps that
 // preference forever.
-const MIGRATIONS = buildMigrations(FEEDS);
+// Schema 3 (#5963): recover the frontline sources from an untouched legacy
+// default blob. The exact-set guard preserves customized source preferences
+// and prevents a stale cloud row from re-poisoning a local migration.
+const MIGRATIONS = buildMigrations(
+  FEEDS,
+  new Set(computeLegacyDefaultDisabledSources()),
+  new Set(FRONTLINE_EUROPE_PROTECTED_SOURCES),
+  computeCapDisabledSources(
+    FEEDS,
+    INTEL_SOURCES,
+    new Set(computeDefaultDisabledSources()),
+    FREE_MAX_SOURCES,
+  ),
+);
 
 type SyncState = 'synced' | 'pending' | 'syncing' | 'conflict' | 'offline' | 'signed-out' | 'error';
 

--- a/tests/cloud-prefs-disabled-feeds-migration.test.mts
+++ b/tests/cloud-prefs-disabled-feeds-migration.test.mts
@@ -1,9 +1,15 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { migrateDisabledFeedsV2, applyMigrationChain, buildMigrations } from '../src/utils/cloud-prefs-migrations';
+import {
+  migrateDisabledFeedsV2,
+  migrateFrontlineEuropeDefaultsV3,
+  applyMigrationChain,
+  buildMigrations,
+} from '../src/utils/cloud-prefs-migrations';
 
 const F = (...names: string[]) => names.map((name) => ({ name }));
+const FRONTLINE = ['Kyiv Independent', 'TVN24', 'Rzeczpospolita', 'Meduza', 'Moscow Times'] as const;
 
 describe('cloud-prefs schema-2 migration: re-enable fully-disabled categories', () => {
   // The poisoned-state shape that triggered this migration: free-tier v1
@@ -107,6 +113,42 @@ describe('cloud-prefs schema-2 migration: re-enable fully-disabled categories', 
     assert.equal(blob['worldmonitor-disabled-feeds'], inputJson, 'input blob must not be mutated');
   });
 
+  it('REGRESSION (#5963): migrates only an untouched legacy default set', () => {
+    const legacy = new Set(['legacy-default-a', 'legacy-default-b', ...FRONTLINE]);
+    const blob = {
+      'worldmonitor-disabled-feeds': JSON.stringify([...legacy]),
+    };
+    const result = migrateFrontlineEuropeDefaultsV3(blob, legacy, new Set(FRONTLINE));
+    const disabled = JSON.parse(result['worldmonitor-disabled-feeds'] as string) as string[];
+    assert.deepEqual(disabled, ['legacy-default-a', 'legacy-default-b']);
+  });
+
+  it('REGRESSION (#5963): preserves customized disabled source sets', () => {
+    const legacy = new Set(['legacy-default-a', 'legacy-default-b', ...FRONTLINE]);
+    const customized = ['legacy-default-a', 'legacy-default-b', ...FRONTLINE, 'user-choice'];
+    const blob = { 'worldmonitor-disabled-feeds': JSON.stringify(customized) };
+    const result = migrateFrontlineEuropeDefaultsV3(blob, legacy, new Set(FRONTLINE));
+    assert.equal(result, blob, 'customized source preferences must not be rewritten');
+  });
+
+  it('REGRESSION (#5966): recovers an untouched pre-protected-cap result', () => {
+    const legacy = new Set(['legacy-default-a', ...FRONTLINE]);
+    const legacyCap = new Set([...legacy, 'auto-disabled-by-cap']);
+    const blob = {
+      'worldmonitor-disabled-feeds': JSON.stringify([...legacyCap]),
+    };
+    const result = migrateFrontlineEuropeDefaultsV3(
+      blob,
+      legacy,
+      new Set(FRONTLINE),
+      legacyCap,
+    );
+    assert.deepEqual(
+      JSON.parse(result['worldmonitor-disabled-feeds'] as string),
+      ['legacy-default-a', 'auto-disabled-by-cap'],
+    );
+  });
+
   it('REGRESSION (PR #3524 review): the same migration applied to LOCAL blob produces clean data', () => {
     // The reviewer-flagged scenario: a user with poisoned local data and
     // local syncVersion == cloud syncVersion would skip Branch A's inbound
@@ -201,5 +243,16 @@ describe('applyMigrationChain', () => {
     const cleaned = JSON.parse(result['worldmonitor-disabled-feeds'] as string);
     // Layoffs sources recovered; BBC World preserved (partial-disable safety)
     assert.deepEqual(cleaned, ['BBC World']);
+  });
+
+  it('integrates the frontline migration as schema 3', () => {
+    const legacy = new Set(['legacy-default-a', ...FRONTLINE]);
+    const migrations = buildMigrations({}, legacy, new Set(FRONTLINE));
+    const blob = { 'worldmonitor-disabled-feeds': JSON.stringify([...legacy]) };
+    const result = applyMigrationChain(blob, 2, 3, migrations);
+    assert.deepEqual(
+      JSON.parse(result['worldmonitor-disabled-feeds'] as string),
+      ['legacy-default-a'],
+    );
   });
 });

--- a/tests/cloud-prefs-sync-concurrency.test.mts
+++ b/tests/cloud-prefs-sync-concurrency.test.mts
@@ -11,12 +11,22 @@ const root = resolve(import.meta.dirname, '..');
 const stubs: Record<string, string> = {
   '@/services/runtime': 'export const isDesktopRuntime = () => false;',
   '@/services/clerk': 'export const getClerkToken = async () => globalThis.__cloudPrefsToken;',
-  '@/config/feeds': 'export const FEEDS = {};',
+  '@/config/feeds': [
+    'export const FEEDS = {};',
+    'export const FRONTLINE_EUROPE_PROTECTED_SOURCES = [];',
+    'export const INTEL_SOURCES = [];',
+    'export const computeDefaultDisabledSources = () => [];',
+    'export const computeLegacyDefaultDisabledSources = () => [];',
+  ].join('\n'),
+  '@/config/panels': 'export const FREE_MAX_SOURCES = 80;',
   '@/utils/dom-utils': [
     'export const trustedHtml = (value) => value;',
     'export const setTrustedHtml = (element, value) => { element.innerHTML = value; };',
   ].join('\n'),
-  '@/services/source-cap': 'export const findFullyDisabledCategories = () => [];',
+  '@/services/source-cap': [
+    'export const computeCapDisabledSources = () => [];',
+    'export const findFullyDisabledCategories = () => [];',
+  ].join('\n'),
 };
 
 interface HarnessResult {

--- a/tests/feed-catalog-drift.test.mts
+++ b/tests/feed-catalog-drift.test.mts
@@ -29,15 +29,33 @@ const repoRoot = join(__dirname, '..');
 const tempDir = join(repoRoot, 'tmp-feed-catalog-drift-test');
 const outfile = join(tempDir, 'feeds-bundle.mjs');
 
+interface FeedEntry {
+  name: string;
+  lang?: string;
+  url: string | Record<string, string>;
+}
+
 interface FeedsModule {
   DEFAULT_ENABLED_SOURCES: Record<string, string[]>;
   DEFAULT_ENABLED_INTEL: string[];
   SOURCE_TYPES: Record<string, string>;
   SOURCE_PROPAGANDA_RISK: Record<string, { risk: string; stateAffiliated?: string }>;
+  FULL_FEEDS?: Record<string, FeedEntry[]>;
+  FEEDS: Record<string, FeedEntry[]>;
   getAllDefaultEnabledSources: () => Set<string>;
   getLocaleBoostedSources: (locale: string) => Set<string>;
+  computeDefaultDisabledSources: (locale?: string) => string[];
   listConfiguredFeedNames: () => string[];
 }
+
+/** Sources #5949 ships as EN-default frontline Europe coverage. */
+const FRONTLINE_EUROPE = [
+  'Kyiv Independent',
+  'TVN24',
+  'Rzeczpospolita',
+  'Meduza',
+  'Moscow Times',
+] as const;
 
 let feeds: FeedsModule;
 
@@ -128,26 +146,19 @@ describe('feed catalog drift', () => {
   // Issue #5949 — EN full-variant defaults under-cover the Ukraine war.
   // Kyiv Independent, PL frontline, and independent RU were cataloged but
   // off-by-default, so users only saw Western wire/EU framing.
-  it('default-enables Ukraine/Poland/independent-Russia frontline sources for EN (#5949)', () => {
+  it('default-enables exact Ukraine/Poland/independent-Russia frontline set for EN (#5949)', () => {
     const europe = feeds.DEFAULT_ENABLED_SOURCES.europe ?? [];
     const enabled = feeds.getAllDefaultEnabledSources();
+    const disabledEn = new Set(feeds.computeDefaultDisabledSources('en'));
 
-    assert.ok(
-      europe.includes('Kyiv Independent'),
-      'Kyiv Independent must be default-on in europe for EN full-variant sessions',
-    );
-
-    const polishFrontline = ['TVN24', 'Rzeczpospolita'].filter((n) => europe.includes(n));
-    assert.ok(
-      polishFrontline.length >= 1,
-      'At least one Polish frontline source (TVN24 / Rzeczpospolita) must be default-on',
-    );
-
-    const independentRu = ['Meduza', 'Moscow Times'].filter((n) => europe.includes(n));
-    assert.ok(
-      independentRu.length >= 1,
-      'At least one independent Russia source (Meduza / Moscow Times) must be default-on',
-    );
+    for (const name of FRONTLINE_EUROPE) {
+      assert.ok(europe.includes(name), `${name} must be listed in DEFAULT_ENABLED_SOURCES.europe`);
+      assert.ok(enabled.has(name), `${name} must be in getAllDefaultEnabledSources()`);
+      assert.ok(
+        !disabledEn.has(name),
+        `${name} must not appear in computeDefaultDisabledSources('en')`,
+      );
+    }
 
     // State propaganda stays cataloged but off-by-default.
     for (const stateMedia of ['TASS', 'RT', 'RT Russia'] as const) {
@@ -155,6 +166,7 @@ describe('feed catalog drift', () => {
         !enabled.has(stateMedia),
         `${stateMedia} must remain off-by-default (state propaganda; catalog-only)`,
       );
+      assert.ok(disabledEn.has(stateMedia), `${stateMedia} must be in EN disabled defaults`);
     }
 
     // Intel: Bellingcat stays on (already default-enabled).
@@ -162,6 +174,58 @@ describe('feed catalog drift', () => {
       feeds.DEFAULT_ENABLED_INTEL.includes('Bellingcat'),
       'Bellingcat must remain default-enabled in intel',
     );
+  });
+
+  it('frontline Europe sources are EN-reachable (no exclusive non-en lang) (#5949)', () => {
+    // buildDigest filters `!f.lang || f.lang === lang`. A default-on source
+    // with only lang:'pl'/'ru' never contributes to EN digests.
+    const byName = new Map<string, FeedEntry>();
+    for (const feed of feeds.FEEDS.europe ?? []) byName.set(feed.name, feed);
+
+    for (const name of FRONTLINE_EUROPE) {
+      const feed = byName.get(name);
+      assert.ok(feed, `${name} must exist in FEEDS.europe catalog`);
+      assert.ok(
+        !feed.lang || feed.lang === 'en',
+        `${name} must not be gated to a non-en lang (got lang=${feed.lang ?? 'none'}); ` +
+          'use multi-URL without lang, or an English-only URL, so EN digests include it',
+      );
+      // Multi-URL sources must expose an `en` key for EN fetch resolution.
+      if (typeof feed.url === 'object' && feed.url !== null) {
+        assert.ok(
+          typeof feed.url.en === 'string' && feed.url.en.length > 0,
+          `${name} multi-URL entry must include a non-empty en URL`,
+        );
+      }
+    }
+  });
+
+  it('server VARIANT_FEEDS.full.europe catalogs the same frontline names (#5949)', () => {
+    // Digest path is the product path for full/EN europe. Client defaults
+    // alone cannot invent items the server never fetched.
+    const serverSrc = readFileSync(join(repoRoot, 'server/worldmonitor/news/v1/_feeds.ts'), 'utf8');
+    // Locate the first `europe: [` (VARIANT_FEEDS.full) and slice until the
+    // next top-level category key `middleeast:`.
+    const europeKey = serverSrc.indexOf('europe: [');
+    assert.ok(europeKey >= 0, 'failed to find europe: [ in server _feeds.ts');
+    const afterEurope = serverSrc.slice(europeKey);
+    const middleeastKey = afterEurope.indexOf('middleeast: [');
+    assert.ok(middleeastKey > 0, 'failed to find middleeast: [ after europe in server _feeds.ts');
+    const europeBody = afterEurope.slice(0, middleeastKey);
+    for (const name of FRONTLINE_EUROPE) {
+      assert.ok(
+        europeBody.includes(`name: '${name}'`) || europeBody.includes(`name: "${name}"`),
+        `server VARIANT_FEEDS.full.europe must include "${name}" for EN digests`,
+      );
+      // Guard against accidental lang:'pl'/'ru' on the server entry (would drop from EN digests).
+      const nameIdx = europeBody.indexOf(`'${name}'`);
+      if (nameIdx < 0) continue;
+      const window = europeBody.slice(nameIdx, nameIdx + 220);
+      assert.ok(
+        !/lang:\s*'pl'|lang:\s*'ru'/.test(window),
+        `server entry for "${name}" must not set lang:pl/ru (EN digests would skip it)`,
+      );
+    }
   });
 
   it('does not default-enable Hungary/Greece locale packs for EN (#5949)', () => {

--- a/tests/feed-catalog-drift.test.mts
+++ b/tests/feed-catalog-drift.test.mts
@@ -30,9 +30,12 @@ const tempDir = join(repoRoot, 'tmp-feed-catalog-drift-test');
 const outfile = join(tempDir, 'feeds-bundle.mjs');
 
 interface FeedsModule {
+  DEFAULT_ENABLED_SOURCES: Record<string, string[]>;
   DEFAULT_ENABLED_INTEL: string[];
   SOURCE_TYPES: Record<string, string>;
+  SOURCE_PROPAGANDA_RISK: Record<string, { risk: string; stateAffiliated?: string }>;
   getAllDefaultEnabledSources: () => Set<string>;
+  getLocaleBoostedSources: (locale: string) => Set<string>;
   listConfiguredFeedNames: () => string[];
 }
 
@@ -120,5 +123,67 @@ describe('feed catalog drift', () => {
     const shared = readFileSync(join(repoRoot, 'shared/source-tiers.json'), 'utf8');
     const scripts = readFileSync(join(repoRoot, 'scripts/shared/source-tiers.json'), 'utf8');
     assert.equal(scripts, shared, 'scripts/shared/source-tiers.json drifted from shared/source-tiers.json');
+  });
+
+  // Issue #5949 — EN full-variant defaults under-cover the Ukraine war.
+  // Kyiv Independent, PL frontline, and independent RU were cataloged but
+  // off-by-default, so users only saw Western wire/EU framing.
+  it('default-enables Ukraine/Poland/independent-Russia frontline sources for EN (#5949)', () => {
+    const europe = feeds.DEFAULT_ENABLED_SOURCES.europe ?? [];
+    const enabled = feeds.getAllDefaultEnabledSources();
+
+    assert.ok(
+      europe.includes('Kyiv Independent'),
+      'Kyiv Independent must be default-on in europe for EN full-variant sessions',
+    );
+
+    const polishFrontline = ['TVN24', 'Rzeczpospolita'].filter((n) => europe.includes(n));
+    assert.ok(
+      polishFrontline.length >= 1,
+      'At least one Polish frontline source (TVN24 / Rzeczpospolita) must be default-on',
+    );
+
+    const independentRu = ['Meduza', 'Moscow Times'].filter((n) => europe.includes(n));
+    assert.ok(
+      independentRu.length >= 1,
+      'At least one independent Russia source (Meduza / Moscow Times) must be default-on',
+    );
+
+    // State propaganda stays cataloged but off-by-default.
+    for (const stateMedia of ['TASS', 'RT', 'RT Russia'] as const) {
+      assert.ok(
+        !enabled.has(stateMedia),
+        `${stateMedia} must remain off-by-default (state propaganda; catalog-only)`,
+      );
+    }
+
+    // Intel: Bellingcat stays on (already default-enabled).
+    assert.ok(
+      feeds.DEFAULT_ENABLED_INTEL.includes('Bellingcat'),
+      'Bellingcat must remain default-enabled in intel',
+    );
+  });
+
+  it('does not default-enable Hungary/Greece locale packs for EN (#5949)', () => {
+    const enabled = feeds.getAllDefaultEnabledSources();
+    // These stay locale-boosted (lang: hu / el), not EN default-on.
+    for (const localeOnly of ['Telex', 'Index.hu', 'Kathimerini', 'Naftemporiki'] as const) {
+      assert.ok(
+        !enabled.has(localeOnly),
+        `${localeOnly} must stay locale-boosted, not EN default-on`,
+      );
+    }
+    // Sanity: hu/el locale boost still works so the packs are not dead.
+    assert.ok(feeds.getLocaleBoostedSources('hu').has('Telex'));
+    assert.ok(feeds.getLocaleBoostedSources('el').has('Kathimerini'));
+  });
+
+  it('SOURCE_PROPAGANDA_RISK still high-labels Russian state media (#5949)', () => {
+    for (const name of ['TASS', 'RT', 'RT Russia'] as const) {
+      const profile = feeds.SOURCE_PROPAGANDA_RISK[name];
+      assert.ok(profile, `${name} must remain in SOURCE_PROPAGANDA_RISK`);
+      assert.equal(profile.risk, 'high', `${name} must remain high-risk`);
+      assert.equal(profile.stateAffiliated, 'Russia');
+    }
   });
 });

--- a/tests/feed-catalog-drift.test.mts
+++ b/tests/feed-catalog-drift.test.mts
@@ -28,6 +28,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..');
 const tempDir = join(repoRoot, 'tmp-feed-catalog-drift-test');
 const outfile = join(tempDir, 'feeds-bundle.mjs');
+const serverOutfile = join(tempDir, 'server-feeds-bundle.mjs');
 
 interface FeedEntry {
   name: string;
@@ -48,6 +49,10 @@ interface FeedsModule {
   listConfiguredFeedNames: () => string[];
 }
 
+interface ServerFeedsModule {
+  VARIANT_FEEDS: Record<string, Record<string, FeedEntry[]>>;
+}
+
 /** Sources #5949 ships as EN-default frontline Europe coverage. */
 const FRONTLINE_EUROPE = [
   'Kyiv Independent',
@@ -58,6 +63,7 @@ const FRONTLINE_EUROPE = [
 ] as const;
 
 let feeds: FeedsModule;
+let serverFeeds: ServerFeedsModule;
 
 before(async () => {
   mkdirSync(tempDir, { recursive: true });
@@ -100,6 +106,18 @@ before(async () => {
   });
   writeFileSync(outfile, result.outputFiles[0].text, 'utf8');
   feeds = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as FeedsModule;
+
+  const serverResult = await build({
+    entryPoints: [join(repoRoot, 'server/worldmonitor/news/v1/_feeds.ts')],
+    bundle: true,
+    format: 'esm',
+    platform: 'neutral',
+    target: 'es2022',
+    write: false,
+    absWorkingDir: repoRoot,
+  });
+  writeFileSync(serverOutfile, serverResult.outputFiles[0].text, 'utf8');
+  serverFeeds = await import(`${pathToFileURL(serverOutfile).href}?t=${Date.now()}`) as ServerFeedsModule;
 });
 
 after(() => {
@@ -198,33 +216,39 @@ describe('feed catalog drift', () => {
         );
       }
     }
+
+    const expectedEnUrls: Record<string, string> = {
+      TVN24: 'https://tvn24.pl/swiat.xml',
+      Rzeczpospolita: 'https://www.rp.pl/rss_main',
+    };
+    for (const [name, url] of Object.entries(expectedEnUrls)) {
+      const feed = byName.get(name);
+      assert.equal(
+        typeof feed?.url === 'object' ? feed.url.en : undefined,
+        url,
+        `${name} EN must use the verified native RSS fallback`,
+      );
+    }
   });
 
   it('server VARIANT_FEEDS.full.europe catalogs the same frontline names (#5949)', () => {
-    // Digest path is the product path for full/EN europe. Client defaults
-    // alone cannot invent items the server never fetched.
-    const serverSrc = readFileSync(join(repoRoot, 'server/worldmonitor/news/v1/_feeds.ts'), 'utf8');
-    // Locate the first `europe: [` (VARIANT_FEEDS.full) and slice until the
-    // next top-level category key `middleeast:`.
-    const europeKey = serverSrc.indexOf('europe: [');
-    assert.ok(europeKey >= 0, 'failed to find europe: [ in server _feeds.ts');
-    const afterEurope = serverSrc.slice(europeKey);
-    const middleeastKey = afterEurope.indexOf('middleeast: [');
-    assert.ok(middleeastKey > 0, 'failed to find middleeast: [ after europe in server _feeds.ts');
-    const europeBody = afterEurope.slice(0, middleeastKey);
+    // Digest path is the product path for full/EN europe. Import the server
+    // catalog so this assertion exercises the executable data structure rather
+    // than passing because a source name appears in a comment or string.
+    const europe = serverFeeds.VARIANT_FEEDS.full?.europe ?? [];
+    const byName = new Map(europe.map((feed) => [feed.name, feed]));
+    const expectedUrls: Record<string, string> = {
+      'Kyiv Independent': 'https://news.google.com/rss/search?q=site%3Akyivindependent.com%20when%3A3d&hl=en-US&gl=US&ceid=US:en',
+      TVN24: 'https://tvn24.pl/swiat.xml',
+      Rzeczpospolita: 'https://www.rp.pl/rss_main',
+      Meduza: 'https://meduza.io/rss/en/all',
+      'Moscow Times': 'https://www.themoscowtimes.com/rss/news',
+    };
     for (const name of FRONTLINE_EUROPE) {
-      assert.ok(
-        europeBody.includes(`name: '${name}'`) || europeBody.includes(`name: "${name}"`),
-        `server VARIANT_FEEDS.full.europe must include "${name}" for EN digests`,
-      );
-      // Guard against accidental lang:'pl'/'ru' on the server entry (would drop from EN digests).
-      const nameIdx = europeBody.indexOf(`'${name}'`);
-      if (nameIdx < 0) continue;
-      const window = europeBody.slice(nameIdx, nameIdx + 220);
-      assert.ok(
-        !/lang:\s*'pl'|lang:\s*'ru'/.test(window),
-        `server entry for "${name}" must not set lang:pl/ru (EN digests would skip it)`,
-      );
+      const feed = byName.get(name);
+      assert.ok(feed, `server VARIANT_FEEDS.full.europe must include "${name}" for EN digests`);
+      assert.equal(feed?.url, expectedUrls[name], `server EN URL drifted for "${name}"`);
+      assert.ok(!feed?.lang, `server entry for "${name}" must not set a non-en lang`);
     }
   });
 

--- a/tests/source-cap.test.mts
+++ b/tests/source-cap.test.mts
@@ -1,9 +1,26 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { selectSourcesUnderCap, findFullyDisabledCategories } from '../src/services/source-cap';
+import {
+  computeCapDisabledSources,
+  selectSourcesUnderCap,
+  findFullyDisabledCategories,
+} from '../src/services/source-cap';
 
 const F = (...names: string[]) => names.map((name) => ({ name }));
+
+describe('computeCapDisabledSources: legacy migration fingerprint', () => {
+  it('reconstructs the exact mixed default-plus-cap disabled set', () => {
+    const defaultDisabled = new Set(['a2']);
+    const result = computeCapDisabledSources(
+      { a: F('a1', 'a2'), b: F('b1', 'b2') },
+      [],
+      defaultDisabled,
+      2,
+    );
+    assert.deepEqual([...result].sort(), ['a2', 'b2']);
+  });
+});
 
 describe('selectSourcesUnderCap: round-robin per-category fairness', () => {
   it('returns empty when cap is 0', () => {


### PR DESCRIPTION
## Summary

Closes #5949 (part of #5948).

EN full-variant Europe coverage was Western/pan-EU only: Kyiv Independent, Polish frontline outlets, and independent Russian media were cataloged but off-by-default. This PR default-enables them **and** wires them through the EN digest delivery path.

### Changes
- **Client defaults** (`DEFAULT_ENABLED_SOURCES.europe`): Kyiv Independent, TVN24, Rzeczpospolita, Meduza, Moscow Times
- **EN-reachable catalog**: multi-URL feeds so EN digests are not gated by `lang:pl`/`lang:ru` (PL native RSS kept for `pl` UI; Meduza EN RSS + RU RSS)
- **Server digest catalog** (`VARIANT_FEEDS.full.europe`): same five names, no non-en `lang` tags
- **Existing profiles**: one-shot `worldmonitor-frontline-europe-enable-v1` migration re-enables those five if still in `disabledFeeds` (additive only)
- **TASS / RT / RT Russia** stay catalog-only (high `SOURCE_PROPAGANDA_RISK`, never default-on)
- **HU/EL locale packs** stay locale-boosted only (no EN default churn)
- Bellingcat remains default-on in intel

### Out of scope (per issue)
- New UA outlets (P1)
- Locale `uk` (P3)

## Test plan
- [x] `tsx --test tests/feed-catalog-drift.test.mts` — default membership, EN reachability, server catalog parity, propaganda risk, locale packs
- [x] `tsx --test tests/feeds-client-server-parity.test.mjs` — no new client/server routing drift
- [x] Pre-push gate (typecheck, boundaries, server handler tests, edge checks)

Manual (post-deploy):
1. Fresh EN full-variant profile (or clear `worldmonitor-sources-reduction-v3` + `worldmonitor-frontline-europe-enable-v1` + disabledFeeds)
2. Confirm Europe sources list has Kyiv Independent + TVN24/Rzeczpospolita + Meduza/Moscow Times enabled
3. Confirm Europe panel digests include items from those sources (not only BBC/Reuters framing)
4. Confirm TASS/RT remain disabled
5. Existing profile with old disabled list: reload once and confirm frontline sources re-enable without wiping other prefs

## Post-Deploy Monitoring & Validation
- **Window**: first 24h after production deploy
- **Healthy signals**: Europe digest for `lang=en` includes sources named Kyiv Independent / TVN24 / Rzeczpospolita / Meduza / Moscow Times; no spike in europe panel empty/UNAVAILABLE rates
- **Failure signals**: Europe panel empty for EN; digest cache stuck without new sources; Sentry errors in `list-feed-digest` / RSS proxy for the new URLs
- **Queries / surfaces**: Vercel logs for `/api/.../ListFeedDigest` / news digest; Redis keys `news:digest:v1:full:en`; Sentry project for edge/handler errors mentioning Meduza / Kyiv Independent / TVN24
- **Rollback**: revert this PR (defaults + server catalog + migration key). Migration is additive; reverting leaves sources enabled for users who already ran v1 — safe. If a new feed URL 403s, remove that name from server europe catalog first (client can stay enabled with empty contribution).
- **Owner**: ship author / on-call for news digests

## Code review notes
Initial client-only change was correctly flagged: defaults without server catalog + lang gates would not change EN headlines. Fixed before ship.

## Compound Engineering
Implemented via `ce-work` from issue #5949.