### PR TITLE
fix(insights): preserve freshness on synthesis rejection (#5947)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -403,7 +403,18 @@ const SEED_META = {
     // without treating ordinary pool-volume variation as an incident.
     minPoolCounts: PREDICTION_MARKET_MIN_POOL_COUNTS,
   },
-  newsInsights:     { key: 'seed-meta:news:insights',           maxStaleMin: 30 },
+  newsInsights:     {
+    key: 'seed-meta:news:insights',
+    maxStaleMin: 30,
+    // `fetchedAt` is deliberately held at the served LKG timestamp when a
+    // synthesis is rejected. This separate bounded contract warns before the
+    // generic 30-minute seed-age gate when repeated attempts keep failing.
+    synthesisFailure: {
+      warnAfterConsecutive: 2,
+      warnAfterAgeMin: 20,
+      warnWithoutSuccess: true,
+    },
+  },
   // #4920: daily GH Actions cadence; 2880 = 2x — one fully missed day alarms
   newsFeedHealth:   { key: 'seed-meta:news:feed-health',        maxStaleMin: 2880 },
   newsRecallBenchmark: { key: 'seed-meta:news:recall-benchmark', maxStaleMin: 2880 },
@@ -917,12 +928,12 @@ function keyHasData(redisKey, len) {
 
 function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (!seedCfg) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null, synthesisFailure: null };
   }
   // Per-command Redis errors on the GET seed-meta half of the pipeline must
   // not silently fall through to STALE_SEED — promote to REDIS_PARTIAL.
   if (keyMetaErrors.get(seedCfg.key)) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null, synthesisFailure: null };
   }
   // Unwrap through the envelope helper. Legacy seed-meta is a bare
   // `{ fetchedAt, recordCount, sourceVersion, status? }` object with no `_seed`
@@ -949,6 +960,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       poolCounts,
       contentAge: null,
       errorCode,
+      synthesisFailure: null,
     };
   }
   let seedAge = null;
@@ -1002,6 +1014,45 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       contentStale: contentAgeMin == null || isFutureDated || contentAgeMin > meta.maxContentAgeMin,
     };
   }
+  let synthesisFailure = null;
+  if (seedCfg.synthesisFailure) {
+    const consecutiveFailures = Number.isInteger(meta?.consecutiveFailures)
+      && meta.consecutiveFailures >= 0
+      ? Math.min(meta.consecutiveFailures, 100)
+      : 0;
+    const lastAttemptAt = Number.isFinite(Number(meta?.lastAttemptAt)) && Number(meta.lastAttemptAt) > 0
+      ? Number(meta.lastAttemptAt)
+      : null;
+    const lastSuccessAt = Number.isFinite(Number(meta?.lastSuccessAt)) && Number(meta.lastSuccessAt) > 0
+      ? Number(meta.lastSuccessAt)
+      : null;
+    const synthesisFailureAgeMin = lastAttemptAt == null
+      ? null
+      : Math.round((now - lastAttemptAt) / 60_000);
+    const lastSynthesisFailureCode = typeof meta?.lastSynthesisFailureCode === 'string'
+      && /^INSIGHTS_SYNTHESIS_(PARSE|GATE|MISSING_CLUSTER|PROVIDER)$/.test(meta.lastSynthesisFailureCode)
+      ? meta.lastSynthesisFailureCode
+      : null;
+    const servedGeneratedAt = typeof meta?.servedGeneratedAt === 'string'
+      && meta.servedGeneratedAt.length <= 64
+      ? meta.servedGeneratedAt
+      : null;
+    const warning = consecutiveFailures > 0 && (
+      consecutiveFailures >= seedCfg.synthesisFailure.warnAfterConsecutive
+      || (synthesisFailureAgeMin != null
+        && synthesisFailureAgeMin >= seedCfg.synthesisFailure.warnAfterAgeMin)
+      || (seedCfg.synthesisFailure.warnWithoutSuccess && lastSuccessAt == null)
+    );
+    synthesisFailure = {
+      consecutiveFailures,
+      lastAttemptAt,
+      lastSuccessAt,
+      servedGeneratedAt,
+      synthesisFailureAgeMin,
+      lastSynthesisFailureCode,
+      warning,
+    };
+  }
   return {
     hasMeta: meta != null,
     seedAge,
@@ -1014,6 +1065,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
     poolCounts,
     contentAge,
     errorCode,
+    synthesisFailure,
   };
 }
 
@@ -1060,6 +1112,7 @@ function classifyKey(name, redisKey, opts, ctx) {
     poolCounts,
     contentAge,
     errorCode,
+    synthesisFailure,
   } = meta;
 
   // When the data key is gone the meta count is meaningless; force records=0
@@ -1080,6 +1133,7 @@ function classifyKey(name, redisKey, opts, ctx) {
     status = 'SEED_ERROR';
   }
   else if (sourceBlocked && hasData && records > 0 && seedStale !== true) status = 'SOURCE_BLOCKED';
+  else if (synthesisFailure?.warning) status = 'SEED_ERROR';
   else if (seedError) status = 'SEED_ERROR';
   else if (!hasData) {
     if (cascadeCovered) status = 'OK_CASCADE';
@@ -1140,6 +1194,20 @@ function classifyKey(name, redisKey, opts, ctx) {
   if (contentAge) {
     entry.contentAgeMin = contentAge.contentAgeMin;          // null when contentMeta returned null
     entry.maxContentAgeMin = contentAge.maxContentAgeMin;
+  }
+  if (synthesisFailure) {
+    entry.consecutiveFailures = synthesisFailure.consecutiveFailures;
+    if (synthesisFailure.lastAttemptAt != null) entry.lastAttemptAt = synthesisFailure.lastAttemptAt;
+    if (synthesisFailure.lastSuccessAt != null || synthesisFailure.consecutiveFailures > 0) {
+      entry.lastSuccessAt = synthesisFailure.lastSuccessAt;
+    }
+    if (synthesisFailure.servedGeneratedAt != null) entry.servedGeneratedAt = synthesisFailure.servedGeneratedAt;
+    if (synthesisFailure.synthesisFailureAgeMin != null && synthesisFailure.consecutiveFailures > 0) {
+      entry.synthesisFailureAgeMin = synthesisFailure.synthesisFailureAgeMin;
+    }
+    if (status === 'SEED_ERROR' && synthesisFailure.lastSynthesisFailureCode) {
+      entry.lastSynthesisFailureCode = synthesisFailure.lastSynthesisFailureCode;
+    }
   }
   return entry;
 }

--- a/scripts/_insights-brief.mjs
+++ b/scripts/_insights-brief.mjs
@@ -171,10 +171,20 @@ export function composeSynthesizedBrief(rawText, topStories, opts = {}) {
   const sourceFromStory = typeof opts.sourceFromStory === 'function' ? opts.sourceFromStory : () => null;
 
   if (!Array.isArray(topStories) || topStories.length === 0) return null;
-  // Editorial gate: same bar the legacy pickBriefCluster enforced.
-  if (!topStories.some(isBriefLeadEligible)) return null;
+  // Editorial gate: same bar the legacy pickBriefCluster enforced. The caller
+  // may pass the already-selected cluster so the synthesis path does not scan
+  // the ranked list a second time.
+  const hasBriefCluster = Object.prototype.hasOwnProperty.call(opts, 'briefCluster')
+    ? opts.briefCluster != null
+    : topStories.some(isBriefLeadEligible);
+  if (!hasBriefCluster) return null;
 
-  const parsed = parseBriefSynthesis(rawText, topStories.length);
+  // The caller may also pass the parser result when it needs to classify a
+  // rejection. Keeping this seam optional preserves the pure public helper's
+  // existing behavior for direct callers and tests.
+  const parsed = Object.prototype.hasOwnProperty.call(opts, 'parsedSynthesis')
+    ? opts.parsedSynthesis
+    : parseBriefSynthesis(rawText, topStories.length);
   if (!parsed) return null;
 
   const groundingStories = topStories.map((story) => ({ headline: story.primaryTitle }));

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -2131,9 +2131,19 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       // Some rejected snapshots carry failure evidence that must survive even
       // when there is no complete last-good cohort to preserve. Keep this hook
       // in the publish phase so its persistence cannot make withRetry(fetchFn)
-      // repeat upstream source requests.
+      // repeat upstream source requests. A hook may return
+      // `{ freshnessMetaPatch }`; reserved freshness fields are stripped before
+      // the shared writer applies the patch.
+      let validationSkipResult = null;
+      let validationSkipMetaRead = false;
+      let validationSkipExistingMeta = null;
       if (!strictFailure && afterValidationSkip) {
-        await afterValidationSkip(data, validationSkipContext);
+        validationSkipExistingMeta = await readExistingSeedMeta(domain, resource);
+        validationSkipMetaRead = true;
+        validationSkipResult = await afterValidationSkip(data, {
+          ...validationSkipContext,
+          existingSeedMeta: validationSkipExistingMeta,
+        });
       }
       if (strictFailure) {
         // Strict-floor seeders (e.g. IMF-External, floor=180 countries) treat
@@ -2171,9 +2181,14 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
         // from the previous seed-meta write. The SET below replaces the whole
         // key; without this merge a validate-skip after a healthy publish wipes
         // afterPublish patches and fail-closed consumers false-alarm.
-        const preservedDiagnostics = freshnessMetaDiagnosticsPatch(
-          await readExistingSeedMeta(domain, resource),
-        );
+        const preservedDiagnostics = {
+          ...(freshnessMetaDiagnosticsPatch(
+            validationSkipMetaRead
+              ? validationSkipExistingMeta
+              : await readExistingSeedMeta(domain, resource),
+          ) || {}),
+          ...(freshnessMetaDiagnosticsPatch(validationSkipResult?.freshnessMetaPatch) || {}),
+        };
         if (canonicalMeta) {
           // Pass-through canonical's contentAge so health doesn't lose the
           // STALE_CONTENT signal exactly when last-good-with-stale-content
@@ -2184,7 +2199,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
             ttlSeconds,
             canonicalMeta.fetchedAt,
             canonicalMeta.contentAge,
-            preservedDiagnostics,
+            Object.keys(preservedDiagnostics).length > 0 ? preservedDiagnostics : null,
           );
           console.log(
             `  SKIPPED: validation failed (empty/partial fetch) — seed-meta mirrors canonical ` +

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -176,6 +176,10 @@ export function classifyInsightsSynthesisFailure({
   return INSIGHTS_SYNTHESIS_FAILURE_CODES.GATE;
 }
 
+export function resolveInsightsFallbackStatus({ synthesisFailureCode, legacyStatus }) {
+  return synthesisFailureCode ? 'degraded' : legacyStatus;
+}
+
 /**
  * Build only the diagnostic patch owned by the insights seeder. `fetchedAt`
  * remains under runSeed's control: on a rejected LKG attempt it is mirrored
@@ -765,7 +769,13 @@ async function fetchInsights() {
     briefProvider = legacy.briefProvider;
     briefModel = legacy.briefModel;
     worldBriefSources = legacy.worldBriefSources;
-    status = legacy.status;
+    // A usable L2 headline must not clear an L1 synthesis failure. Keep this
+    // run degraded so an existing LKG remains the freshness anchor and the
+    // bounded failure metadata advances until L1 publishes successfully.
+    status = resolveInsightsFallbackStatus({
+      synthesisFailureCode,
+      legacyStatus: legacy.status,
+    });
   }
 
   const multiSourceCount = clusters.filter(c => (c.sources?.length ?? 0) >= 2 || c.entityCorroboration === true).length;
@@ -866,9 +876,6 @@ async function fetchInsights() {
 
   return decorateInsightsRun(payload, {
     outcome: status === 'ok' ? INSIGHTS_RUN_OUTCOMES.PUBLISHED : INSIGHTS_RUN_OUTCOMES.DEGRADED,
-    // Keep a successful legacy fallback auditable without treating it as a
-    // failed publication. buildInsightsFreshnessMetaPatch resets the active
-    // failure streak when the fresh fallback is actually published.
     failureCode: synthesisFailureCode,
   });
 }

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -10,6 +10,7 @@ import {
   createLlmBudgetError,
   extendExistingTtl,
   isLlmBudgetError,
+  readExistingSeedMeta,
   writeExtraKey,
 } from './_seed-utils.mjs';
 import {
@@ -28,6 +29,7 @@ import {
   briefUserPrompt,
   synthesisSystemPrompt,
   synthesisUserPrompt,
+  parseBriefSynthesis,
   composeSynthesizedBrief,
 } from './_insights-brief.mjs';
 import { buildLlmCallEvent, emitLlmEvents, flushPendingLlmEvents } from './lib/llm-telemetry.cjs';
@@ -91,6 +93,129 @@ const CACHE_TTL = 10800; // 3h — 6x the 30 min cron interval. Shorter = key ex
                          // in _insights-brief.mjs), not by aging out fast.
 const MAX_HEADLINE_LEN = 500;
 const GROQ_MODEL = 'llama-3.3-70b-versatile';
+const INSIGHTS_SOURCE_VERSION = 'digest-clustering-v2-importance-diversity';
+const INSIGHTS_MAX_CONSECUTIVE_FAILURES = 100;
+const INSIGHTS_RUN_OUTCOMES = Object.freeze({
+  LKG_PRESERVED: 'lkg_preserved',
+  PUBLISHED: 'published',
+  DEGRADED: 'degraded',
+});
+
+// These codes are intentionally low-cardinality and safe to put in seed-meta,
+// health responses, and logs. Never include prompt or model output text in the
+// rejection diagnostic: the payload may contain sensitive intelligence.
+export const INSIGHTS_SYNTHESIS_FAILURE_CODES = Object.freeze({
+  PARSE: 'INSIGHTS_SYNTHESIS_PARSE',
+  GATE: 'INSIGHTS_SYNTHESIS_GATE',
+  MISSING_CLUSTER: 'INSIGHTS_SYNTHESIS_MISSING_CLUSTER',
+  PROVIDER: 'INSIGHTS_SYNTHESIS_PROVIDER',
+});
+const INSIGHTS_SYNTHESIS_FAILURE_CODE_SET = new Set(Object.values(INSIGHTS_SYNTHESIS_FAILURE_CODES));
+const INSIGHTS_RUN_META = Symbol('worldmonitor.insightsRunMeta');
+
+function normalizeInsightsFailureCode(code) {
+  return INSIGHTS_SYNTHESIS_FAILURE_CODE_SET.has(code)
+    ? code
+    : INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER;
+}
+
+function attachInsightsRunMeta(payload, runMeta) {
+  const decorated = { ...(payload || {}) };
+  Object.defineProperty(decorated, INSIGHTS_RUN_META, {
+    value: Object.freeze({ ...(runMeta || {}) }),
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+  return decorated;
+}
+
+/**
+ * Attach non-serialized run state to an insights payload. The marker lets the
+ * runSeed validation seam distinguish a true LKG preservation from a fresh
+ * payload without ever writing the marker to Redis.
+ */
+export function decorateInsightsRun(payload, runMeta) {
+  return attachInsightsRunMeta(payload, runMeta);
+}
+
+function insightsRunMeta(payload) {
+  return payload?.[INSIGHTS_RUN_META] || null;
+}
+
+/**
+ * Strip audit-only China coverage while retaining the non-serialized run
+ * marker for validation and afterPublish hooks.
+ */
+export function publishInsightsPayload(data) {
+  const { chinaNewsCoverage: _chinaNewsCoverage, ...payload } = data || {};
+  const runMeta = insightsRunMeta(data);
+  return runMeta ? attachInsightsRunMeta(payload, runMeta) : payload;
+}
+
+export function validateInsightsPayload(data) {
+  if (insightsRunMeta(data)?.outcome === INSIGHTS_RUN_OUTCOMES.LKG_PRESERVED) return false;
+  return declareRecords(data) > 0;
+}
+
+/**
+ * Keep synthesis rejection telemetry bounded and machine-actionable. The
+ * classifier deliberately accepts only stage outcomes, never raw prompt or
+ * provider text, so this value is safe for seed-meta, health, and logs.
+ */
+export function classifyInsightsSynthesisFailure({
+  hasBriefCluster = false,
+  synthesisResult = null,
+  parsedSynthesis = null,
+  composed = null,
+} = {}) {
+  if (composed) return null;
+  if (!hasBriefCluster) return INSIGHTS_SYNTHESIS_FAILURE_CODES.MISSING_CLUSTER;
+  if (!synthesisResult) return INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER;
+  if (!parsedSynthesis) return INSIGHTS_SYNTHESIS_FAILURE_CODES.PARSE;
+  return INSIGHTS_SYNTHESIS_FAILURE_CODES.GATE;
+}
+
+/**
+ * Build only the diagnostic patch owned by the insights seeder. `fetchedAt`
+ * remains under runSeed's control: on a rejected LKG attempt it is mirrored
+ * from the old canonical envelope, while a successful publish gets `now`.
+ */
+export function buildInsightsFreshnessMetaPatch({
+  previousMeta,
+  outcome,
+  failureCode = null,
+  nowMs = Date.now(),
+  servedGeneratedAt = null,
+} = {}) {
+  const previous = previousMeta && typeof previousMeta === 'object' ? previousMeta : {};
+  const now = Number.isFinite(nowMs) && nowMs > 0 ? Math.floor(nowMs) : Date.now();
+  const previousFailures = Number.isInteger(previous.consecutiveFailures) && previous.consecutiveFailures > 0
+    ? previous.consecutiveFailures
+    : 0;
+  const servedAt = typeof servedGeneratedAt === 'string' && servedGeneratedAt.length <= 64
+    ? servedGeneratedAt
+    : (typeof previous.servedGeneratedAt === 'string' ? previous.servedGeneratedAt : null);
+  const normalizedFailureCode = failureCode == null ? null : normalizeInsightsFailureCode(failureCode);
+
+  if (outcome === INSIGHTS_RUN_OUTCOMES.PUBLISHED) {
+    return {
+      lastAttemptAt: now,
+      lastSuccessAt: now,
+      servedGeneratedAt: servedAt,
+      consecutiveFailures: 0,
+      lastSynthesisFailureCode: normalizedFailureCode,
+    };
+  }
+
+  return {
+    lastAttemptAt: now,
+    lastSuccessAt: Number.isFinite(previous.lastSuccessAt) ? previous.lastSuccessAt : null,
+    servedGeneratedAt: servedAt,
+    consecutiveFailures: Math.min(INSIGHTS_MAX_CONSECUTIVE_FAILURES, previousFailures + 1),
+    lastSynthesisFailureCode: normalizedFailureCode || INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
+  };
+}
 
 const TASK_NARRATION = /^(we need to|i need to|let me|i'll |i should|i will |the task is|the instructions|according to the rules|so we need to|okay[,.]\s*(i'll|let me|so|we need|the task|i should|i will)|sure[,.]\s*(i'll|let me|so|we need|the task|i should|i will|here)|first[, ]+(i|we|let)|to summarize (the headlines|the task|this)|my task (is|was|:)|step \d)/i;
 const PROMPT_ECHO = /^(summarize the top story|summarize the key|rules:|here are the rules|the top story is likely)/i;
@@ -502,7 +627,10 @@ async function fetchInsights() {
     const existing = await readExistingInsights();
     if (existing?.topStories?.length) {
       console.log('  Digest unavailable — reusing existing insights (LKG)');
-      return existing;
+      return decorateInsightsRun(existing, {
+        outcome: INSIGHTS_RUN_OUTCOMES.LKG_PRESERVED,
+        failureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
+      });
     }
     throw new Error('No news digest found in Redis');
   }
@@ -584,21 +712,35 @@ async function fetchInsights() {
   let briefStoryLines = [];
   let worldBriefSources = [];
   let status = 'ok';
+  let synthesisFailureCode = null;
 
-  const synthesisResult = topStories.length > 0
+  const briefCluster = pickBriefCluster(topStories);
+  const hasBriefCluster = briefCluster != null;
+  const synthesisResult = hasBriefCluster
     ? await callLLM(null, {
         systemPrompt: synthesisSystemPrompt(new Date().toISOString().split('T')[0]),
         userPrompt: synthesisUserPrompt(topStories),
         maxTokens: 900,
       })
     : null;
+  const parsedSynthesis = synthesisResult
+    ? parseBriefSynthesis(synthesisResult.text, topStories.length)
+    : null;
   const composed = synthesisResult
-    ? composeSynthesizedBrief(synthesisResult.text, topStories, {
+      ? composeSynthesizedBrief(synthesisResult.text, topStories, {
         validatorMode: BRIEF_VALIDATOR_MODE,
         sanitizeTitle,
         sourceFromStory: briefSourceFromStory,
+        briefCluster,
+        parsedSynthesis,
       })
     : null;
+  synthesisFailureCode = classifyInsightsSynthesisFailure({
+    hasBriefCluster,
+    synthesisResult,
+    parsedSynthesis,
+    composed,
+  });
 
   if (composed) {
     worldBrief = composed.lead;
@@ -614,9 +756,10 @@ async function fetchInsights() {
     }
     console.log(`  Brief synthesized (top-${topStories.length}) via ${briefProvider} (${briefModel})`);
   } else {
-    if (synthesisResult) {
-      console.warn('  [brief_synthesis] composer rejected output (parse/gates) — falling back to single-headline brief');
-    }
+    console.warn(
+      `  [brief_synthesis] rejected (${synthesisFailureCode || INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER}) — `
+      + 'falling back to single-headline brief',
+    );
     const legacy = await generateLegacySingleHeadlineBrief(topStories);
     worldBrief = legacy.worldBrief;
     briefProvider = legacy.briefProvider;
@@ -711,28 +854,65 @@ async function fetchInsights() {
     const existing = await readExistingInsights();
     if (existing?.status === 'ok') {
       console.log('  LKG preservation: existing payload is "ok", skipping degraded overwrite');
-      return preserveChinaNewsCoverageInLkg(existing, chinaNewsCoverage);
+      return decorateInsightsRun(
+        preserveChinaNewsCoverageInLkg(existing, chinaNewsCoverage),
+        {
+          outcome: INSIGHTS_RUN_OUTCOMES.LKG_PRESERVED,
+          failureCode: synthesisFailureCode || INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
+        },
+      );
     }
   }
 
-  return payload;
-}
-
-function validate(data) {
-  return Array.isArray(data?.topStories) && data.topStories.length >= 1;
+  return decorateInsightsRun(payload, {
+    outcome: status === 'ok' ? INSIGHTS_RUN_OUTCOMES.PUBLISHED : INSIGHTS_RUN_OUTCOMES.DEGRADED,
+    // Keep a successful legacy fallback auditable without treating it as a
+    // failed publication. buildInsightsFreshnessMetaPatch resets the active
+    // failure streak when the fresh fallback is actually published.
+    failureCode: synthesisFailureCode,
+  });
 }
 
 export function declareRecords(data) {
   return Array.isArray(data?.topStories) ? data.topStories.length : 0;
 }
 
+async function writeInsightsChinaCoverage(data) {
+  if (!data?.chinaNewsCoverage) {
+    // LKG fallback predates the projection. Keep its timestamp honest: an
+    // extended old projection will become CONTENT_STALE rather than green.
+    await extendExistingTtl([CHINA_COVERAGE_KEY], CACHE_TTL);
+    return;
+  }
+  await writeExtraKey(CHINA_COVERAGE_KEY, data.chinaNewsCoverage, CACHE_TTL);
+}
+
+async function finalizeInsightsRun(data, outcome, { previousMeta } = {}) {
+  const [resolvedPreviousMeta] = await Promise.all([
+    previousMeta === undefined
+      ? readExistingSeedMeta('news', 'insights')
+      : Promise.resolve(previousMeta),
+    writeInsightsChinaCoverage(data),
+  ]);
+  const runMeta = insightsRunMeta(data);
+  return {
+    freshnessMetaPatch: buildInsightsFreshnessMetaPatch({
+      previousMeta: resolvedPreviousMeta,
+      outcome,
+      failureCode: runMeta?.failureCode,
+      nowMs: Date.now(),
+      servedGeneratedAt: data?.generatedAt,
+    }),
+  };
+}
+
 export { callLLM, __setInsightsLlmTransportForTests };
 
 if (_isDirectRun) {
   runSeed('news', 'insights', CANONICAL_KEY, fetchInsights, {
-    validateFn: validate,
+    validateFn: validateInsightsPayload,
     ttlSeconds: CACHE_TTL,
-    sourceVersion: 'digest-clustering-v2-importance-diversity',
+    sourceVersion: INSIGHTS_SOURCE_VERSION,
 
     declareRecords,
     schemaVersion: 1,
@@ -741,15 +921,20 @@ if (_isDirectRun) {
     // retained separately so the China audit can distinguish an unavailable
     // source from a globally outranked one without changing the public payload.
     preserveKeys: [CHINA_COVERAGE_KEY],
-    publishTransform: ({ chinaNewsCoverage: _chinaNewsCoverage, ...payload }) => payload,
+    publishTransform: publishInsightsPayload,
     afterPublish: async (data) => {
-      if (!data?.chinaNewsCoverage) {
-        // LKG fallback predates the projection. Keep its timestamp honest: an
-        // extended old projection will become CONTENT_STALE rather than green.
-        await extendExistingTtl([CHINA_COVERAGE_KEY], CACHE_TTL);
-        return;
-      }
-      await writeExtraKey(CHINA_COVERAGE_KEY, data.chinaNewsCoverage, CACHE_TTL);
+      const runMeta = insightsRunMeta(data);
+      return finalizeInsightsRun(
+        data,
+        runMeta?.outcome === INSIGHTS_RUN_OUTCOMES.PUBLISHED
+          ? INSIGHTS_RUN_OUTCOMES.PUBLISHED
+          : INSIGHTS_RUN_OUTCOMES.DEGRADED,
+      );
+    },
+    afterValidationSkip: async (data, context) => {
+      return finalizeInsightsRun(data, INSIGHTS_RUN_OUTCOMES.LKG_PRESERVED, {
+        previousMeta: context.existingSeedMeta,
+      });
     },
   }).catch(async (err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);

--- a/tests/brief-contract.test.mjs
+++ b/tests/brief-contract.test.mjs
@@ -203,6 +203,17 @@ describe('composeSynthesizedBrief (functional L1 coverage, #4928 review)', () =>
     assert.equal(out.sources[1].url, 'https://b/2');
   });
 
+  it('accepts precomputed eligibility and parser results without reparsing', () => {
+    const parsed = parseBriefSynthesis(GOOD, CORROBORATED.length);
+    const out = composeSynthesizedBrief('not parseable', CORROBORATED, {
+      ...passOpts,
+      briefCluster: CORROBORATED[0],
+      parsedSynthesis: parsed,
+    });
+    assert.ok(out);
+    assert.equal(out.lines.length, CORROBORATED.length);
+  });
+
   it('REGRESSION: a story without a usable link gets a substitute source entry, never shifting [n] mapping', () => {
     const out = composeSynthesizedBrief(GOOD, CORROBORATED, {
       ...passOpts,

--- a/tests/china-coverage-production-registration.test.mts
+++ b/tests/china-coverage-production-registration.test.mts
@@ -49,7 +49,7 @@ describe('China coverage production registration', () => {
     assert.match(insightsSeed, /\[CHINA_NEWS_DIGEST_LANGUAGE\]: await readChinaNewsDigest\(\)/);
     assert.match(insightsSeed, /digest coverage check failed/);
     assert.match(insightsSeed, /preserveKeys: \[CHINA_COVERAGE_KEY\]/);
-    assert.match(insightsSeed, /return preserveChinaNewsCoverageInLkg\(existing, chinaNewsCoverage\)/);
+    assert.match(insightsSeed, /decorateInsightsRun\(\s*preserveChinaNewsCoverageInLkg\(existing, chinaNewsCoverage\)/);
     assert.match(insightsSeed, /writeExtraKey\(CHINA_COVERAGE_KEY, data\.chinaNewsCoverage, CACHE_TTL\)/);
   });
 

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -122,6 +122,22 @@ test('classifyKey: repeated insights synthesis rejection warns while the LKG rem
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+test('classifyKey: one recent insights synthesis failure stays OK within the warning bounds', () => {
+  const entry = classifyNewsInsights({
+    fetchedAt: NOW - 5 * ONE_MIN_MS,
+    recordCount: 8,
+    lastAttemptAt: NOW - 2 * ONE_MIN_MS,
+    lastSuccessAt: NOW - 5 * ONE_MIN_MS,
+    servedGeneratedAt: '2026-08-01T08:25:39.268Z',
+    consecutiveFailures: 1,
+    lastSynthesisFailureCode: 'INSIGHTS_SYNTHESIS_GATE',
+  });
+
+  assert.equal(entry.status, 'OK');
+  assert.equal(STATUS_COUNTS[entry.status], 'ok');
+  assert.equal(entry.consecutiveFailures, 1);
+});
+
 test('classifyKey: an old single insights synthesis failure warns by age', () => {
   const entry = classifyNewsInsights({
     fetchedAt: NOW - 5 * ONE_MIN_MS,

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -44,6 +44,15 @@ function makeCtx({ strens = {}, errors = {}, metaValues = {}, metaErrors = {} } 
 }
 
 const seedMeta = (over = {}) => JSON.stringify({ fetchedAt: NOW - ONE_MIN_MS, recordCount: 5, ...over });
+const classifyNewsInsights = (over = {}) => classifyKey(
+  'newsInsights',
+  BOOTSTRAP_KEYS.newsInsights,
+  { allowOnDemand: false },
+  makeCtx({
+    strens: { [BOOTSTRAP_KEYS.newsInsights]: 4096 },
+    metaValues: { [SEED_META.newsInsights.key]: seedMeta(over) },
+  }),
+);
 
 // Mirror of the handler's overall-status computation (api/health.js ~850-859).
 // The handler computes this inline; these tests exercise the LOCAL replica —
@@ -91,6 +100,93 @@ test('classifyKey: present-but-stale seed → STALE_SEED (warn), data still pres
     }));
   assert.equal(entry.status, 'STALE_SEED');
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
+test('classifyKey: repeated insights synthesis rejection warns while the LKG remains present', () => {
+  const entry = classifyNewsInsights({
+    fetchedAt: NOW - 5 * ONE_MIN_MS,
+    recordCount: 8,
+    lastAttemptAt: NOW - 2 * ONE_MIN_MS,
+    lastSuccessAt: NOW - 45 * ONE_MIN_MS,
+    servedGeneratedAt: '2026-08-01T06:30:39.268Z',
+    consecutiveFailures: 2,
+    lastSynthesisFailureCode: 'INSIGHTS_SYNTHESIS_PARSE',
+  });
+
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.equal(entry.records, 8);
+  assert.equal(entry.consecutiveFailures, 2);
+  assert.equal(entry.lastSynthesisFailureCode, 'INSIGHTS_SYNTHESIS_PARSE');
+  assert.equal(entry.servedGeneratedAt, '2026-08-01T06:30:39.268Z');
+  assert.equal(entry.lastSuccessAt, NOW - 45 * ONE_MIN_MS);
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
+test('classifyKey: an old single insights synthesis failure warns by age', () => {
+  const entry = classifyNewsInsights({
+    fetchedAt: NOW - 5 * ONE_MIN_MS,
+    recordCount: 8,
+    lastAttemptAt: NOW - 25 * ONE_MIN_MS,
+    lastSuccessAt: NOW - 10 * ONE_MIN_MS,
+    servedGeneratedAt: '2026-08-01T06:30:39.268Z',
+    consecutiveFailures: 1,
+    lastSynthesisFailureCode: 'INSIGHTS_SYNTHESIS_GATE',
+  });
+
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.equal(entry.synthesisFailureAgeMin, 25);
+});
+
+test('classifyKey: a fresh successful insights publication clears synthesis warning state', () => {
+  const entry = classifyNewsInsights({
+    fetchedAt: NOW - ONE_MIN_MS,
+    recordCount: 8,
+    lastAttemptAt: NOW - ONE_MIN_MS,
+    lastSuccessAt: NOW - ONE_MIN_MS,
+    servedGeneratedAt: '2026-08-01T08:30:39.268Z',
+    consecutiveFailures: 0,
+    lastSynthesisFailureCode: null,
+  });
+
+  assert.equal(entry.status, 'OK');
+  assert.equal(entry.consecutiveFailures, 0);
+  assert.equal(entry.servedGeneratedAt, '2026-08-01T08:30:39.268Z');
+});
+
+test('classifyKey: no-LKG synthesis failure warns even on the first attempted publication', () => {
+  const entry = classifyNewsInsights({
+    fetchedAt: NOW - ONE_MIN_MS,
+    recordCount: 8,
+    lastAttemptAt: NOW - ONE_MIN_MS,
+    lastSuccessAt: null,
+    servedGeneratedAt: '2026-08-01T08:30:39.268Z',
+    consecutiveFailures: 1,
+    lastSynthesisFailureCode: 'INSIGHTS_SYNTHESIS_MISSING_CLUSTER',
+  });
+
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.equal(entry.consecutiveFailures, 1);
+  assert.equal(entry.lastSuccessAt, null);
+});
+
+test('compact health problem projection retains insights synthesis diagnostics', () => {
+  const snapshot = {
+    status: 'WARNING',
+    summary: { total: 1, ok: 0, warn: 1, crit: 0 },
+    checkedAt: '2026-08-01T08:31:00.000Z',
+    checks: {
+      newsInsights: {
+        status: 'SEED_ERROR',
+        records: 8,
+        maxStaleMin: 30,
+        consecutiveFailures: 2,
+        lastSynthesisFailureCode: 'INSIGHTS_SYNTHESIS_PARSE',
+        servedGeneratedAt: '2026-08-01T06:30:39.268Z',
+      },
+    },
+  };
+
+  assert.deepEqual(healthResponseBody(snapshot, true).problems.newsInsights, snapshot.checks.newsInsights);
 });
 
 test('classifyKey: riskScores partial realtime family coverage → COVERAGE_PARTIAL', () => {

--- a/tests/leads-gateway-public.test.mts
+++ b/tests/leads-gateway-public.test.mts
@@ -75,7 +75,9 @@ describe('leads gateway public access', { concurrency: 1 }, () => {
         message: 'hello',
         source: 'enterprise-contact',
         website: 'http://honeypot-filled.example',
-        turnstileToken: '',
+        // The generated request validator requires a non-empty token; the
+        // honeypot still short-circuits before the handler verifies it.
+        turnstileToken: 'test-token',
       }),
     }));
 

--- a/tests/leads-gateway-public.test.mts
+++ b/tests/leads-gateway-public.test.mts
@@ -80,8 +80,9 @@ describe('leads gateway public access', { concurrency: 1 }, () => {
     }));
 
     assert.notEqual(res.status, 401, 'gateway must not 401 anonymous contact submissions');
-    assert.equal(res.status, 200);
-    const body = await res.json() as { status?: string };
+    const bodyText = await res.text();
+    assert.equal(res.status, 200, bodyText);
+    const body = JSON.parse(bodyText) as { status?: string };
     assert.equal(body.status, 'sent');
   });
 

--- a/tests/leads-gateway-public.test.mts
+++ b/tests/leads-gateway-public.test.mts
@@ -46,7 +46,7 @@ async function loadLeadsGateway() {
   };
 }
 
-describe('leads gateway public access', () => {
+describe('leads gateway public access', { concurrency: 1 }, () => {
   it('declares both leads RPCs public-no-auth and non-premium', async () => {
     const { PUBLIC_NO_AUTH_RPC_PATHS, PREMIUM_RPC_PATHS } = await loadLeadsGateway();
     assert.equal(PUBLIC_NO_AUTH_RPC_PATHS.has('/api/leads/v1/submit-contact'), true);

--- a/tests/seed-insights-freshness.test.mjs
+++ b/tests/seed-insights-freshness.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  INSIGHTS_SYNTHESIS_FAILURE_CODES,
+  buildInsightsFreshnessMetaPatch,
+  classifyInsightsSynthesisFailure,
+  decorateInsightsRun,
+  publishInsightsPayload,
+  validateInsightsPayload,
+} from '../scripts/seed-insights.mjs';
+
+const OLD_GENERATED_AT = '2026-08-01T06:30:39.268Z';
+const NEW_GENERATED_AT = '2026-08-01T08:30:39.268Z';
+
+test('synthesis rejection codes identify missing cluster, provider, parse, and gate stages', () => {
+  assert.equal(
+    classifyInsightsSynthesisFailure({ hasBriefCluster: false }),
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.MISSING_CLUSTER,
+  );
+  assert.equal(
+    classifyInsightsSynthesisFailure({ hasBriefCluster: true }),
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
+  );
+  assert.equal(
+    classifyInsightsSynthesisFailure({ hasBriefCluster: true, synthesisResult: { text: 'raw' } }),
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.PARSE,
+  );
+  assert.equal(
+    classifyInsightsSynthesisFailure({
+      hasBriefCluster: true,
+      synthesisResult: { text: 'raw' },
+      parsedSynthesis: { lead: 'parsed' },
+    }),
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.GATE,
+  );
+  assert.equal(
+    classifyInsightsSynthesisFailure({
+      hasBriefCluster: true,
+      synthesisResult: { text: 'raw' },
+      parsedSynthesis: { lead: 'parsed' },
+      composed: { lead: 'published' },
+    }),
+    null,
+  );
+});
+
+test('LKG-preserved insights fail publication validation without leaking run metadata into JSON', () => {
+  const lkg = decorateInsightsRun(
+    {
+      status: 'ok',
+      generatedAt: OLD_GENERATED_AT,
+      topStories: [{ primaryTitle: 'The last good brief' }],
+    },
+    { outcome: 'lkg_preserved', failureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.PARSE },
+  );
+
+  const publishedShape = publishInsightsPayload(lkg);
+
+  assert.equal(validateInsightsPayload(publishedShape), false);
+  assert.equal(JSON.stringify(publishedShape).includes('lkg_preserved'), false);
+  assert.equal(publishedShape.generatedAt, OLD_GENERATED_AT);
+});
+
+test('repeated synthesis rejection advances attempt metadata but preserves LKG freshness fields', () => {
+  const patch = buildInsightsFreshnessMetaPatch({
+    previousMeta: {
+      fetchedAt: 1_754_000_000_000,
+      lastAttemptAt: 1_754_000_060_000,
+      lastSuccessAt: 1_754_000_000_000,
+      servedGeneratedAt: OLD_GENERATED_AT,
+      consecutiveFailures: 1,
+    },
+    outcome: 'lkg_preserved',
+    failureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.GATE,
+    nowMs: 1_754_000_120_000,
+    servedGeneratedAt: OLD_GENERATED_AT,
+  });
+
+  assert.equal(patch.lastAttemptAt, 1_754_000_120_000);
+  assert.equal(patch.lastSuccessAt, 1_754_000_000_000);
+  assert.equal(patch.servedGeneratedAt, OLD_GENERATED_AT);
+  assert.equal(patch.consecutiveFailures, 2);
+  assert.equal(patch.lastSynthesisFailureCode, INSIGHTS_SYNTHESIS_FAILURE_CODES.GATE);
+  assert.equal('fetchedAt' in patch, false, 'failed attempts must not re-anchor seed freshness');
+});
+
+test('a newly published payload resets synthesis failures only after publication', () => {
+  const patch = buildInsightsFreshnessMetaPatch({
+    previousMeta: {
+      fetchedAt: 1_754_000_000_000,
+      lastAttemptAt: 1_754_000_060_000,
+      lastSuccessAt: 1_754_000_000_000,
+      servedGeneratedAt: OLD_GENERATED_AT,
+      consecutiveFailures: 7,
+      lastSynthesisFailureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.PARSE,
+    },
+    outcome: 'published',
+    nowMs: 1_754_000_180_000,
+    servedGeneratedAt: NEW_GENERATED_AT,
+  });
+
+  assert.equal(patch.lastAttemptAt, 1_754_000_180_000);
+  assert.equal(patch.lastSuccessAt, 1_754_000_180_000);
+  assert.equal(patch.servedGeneratedAt, NEW_GENERATED_AT);
+  assert.equal(patch.consecutiveFailures, 0);
+  assert.equal(patch.lastSynthesisFailureCode, null);
+});

--- a/tests/seed-insights-freshness.test.mjs
+++ b/tests/seed-insights-freshness.test.mjs
@@ -7,6 +7,7 @@ import {
   classifyInsightsSynthesisFailure,
   decorateInsightsRun,
   publishInsightsPayload,
+  resolveInsightsFallbackStatus,
   validateInsightsPayload,
 } from '../scripts/seed-insights.mjs';
 
@@ -105,4 +106,18 @@ test('a newly published payload resets synthesis failures only after publication
   assert.equal(patch.servedGeneratedAt, NEW_GENERATED_AT);
   assert.equal(patch.consecutiveFailures, 0);
   assert.equal(patch.lastSynthesisFailureCode, null);
+});
+
+test('a rejected synthesized brief keeps a successful legacy fallback degraded', () => {
+  assert.equal(
+    resolveInsightsFallbackStatus({
+      synthesisFailureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.GATE,
+      legacyStatus: 'ok',
+    }),
+    'degraded',
+  );
+  assert.equal(
+    resolveInsightsFallbackStatus({ synthesisFailureCode: null, legacyStatus: 'ok' }),
+    'ok',
+  );
 });

--- a/tests/seed-utils-meta-write-degrades.test.mjs
+++ b/tests/seed-utils-meta-write-degrades.test.mjs
@@ -237,6 +237,66 @@ test('validate-skip path reports rejection when only part of the preservation co
   }
 });
 
+test('validate-skip hook diagnostics merge without re-anchoring canonical freshness', async () => {
+  const originalFetchForHook = globalThis.fetch;
+  const metaSets = [];
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url);
+    const decodedUrl = decodeURIComponent(u);
+    const body = opts?.body ? JSON.parse(opts.body) : null;
+    calls.push({ u, body });
+    if (decodedUrl.includes('/get/test:hook-diagnostics:v1')) {
+      return jsonResponse({ result: JSON.stringify(CANONICAL_ENVELOPE) });
+    }
+    if (decodedUrl.includes('/get/seed-meta:test:hook-diagnostics')) {
+      return jsonResponse({ result: JSON.stringify({
+        fetchedAt: CANONICAL_ENVELOPE._seed.fetchedAt,
+        recordCount: CANONICAL_ENVELOPE._seed.recordCount,
+        sourceVersion: 'test-v1',
+        lastAttemptAt: CANONICAL_ENVELOPE._seed.fetchedAt,
+      }) });
+    }
+    if (u.endsWith('/pipeline')) return jsonResponse(body.map(() => ({ result: 1 })));
+    if (Array.isArray(body) && body[0] === 'SET' && body[1] === 'seed-meta:test:hook-diagnostics') {
+      metaSets.push(JSON.parse(body[2]));
+    }
+    return jsonResponse({ result: 'OK' });
+  };
+
+  try {
+    const { exitCode, threw } = await runWithExitTrap(() =>
+      runSeed('test', 'hook-diagnostics', 'test:hook-diagnostics:v1',
+        async () => ({ items: [] }),
+        {
+          validateFn: () => false,
+          ttlSeconds: 3600,
+          declareRecords: () => 1,
+          sourceVersion: 'test-v1',
+          schemaVersion: 1,
+          maxStaleMin: 720,
+          afterValidationSkip: async () => ({
+            freshnessMetaPatch: {
+              lastAttemptAt: CANONICAL_ENVELOPE._seed.fetchedAt + 60_000,
+              status: 'error',
+              fetchedAt: 0,
+              recordCount: 999,
+            },
+          }),
+        }),
+    );
+
+    assert.equal(threw, null);
+    assert.equal(exitCode, 0);
+    assert.equal(metaSets.length, 1);
+    assert.equal(metaSets[0].lastAttemptAt, CANONICAL_ENVELOPE._seed.fetchedAt + 60_000);
+    assert.equal(metaSets[0].status, 'error');
+    assert.equal(metaSets[0].fetchedAt, CANONICAL_ENVELOPE._seed.fetchedAt);
+    assert.equal(metaSets[0].recordCount, CANONICAL_ENVELOPE._seed.recordCount);
+  } finally {
+    globalThis.fetch = originalFetchForHook;
+  }
+});
+
 test('publish-success path: seed-meta write exhausting retries degrades to exit 0, not FATAL', async () => {
   const { exitCode, threw } = await runWithExitTrap(() =>
     runSeed('test', 'meta-degrade-pub', 'test:meta-degrade-pub:v1',


### PR DESCRIPTION
Closes #5947. Summary: bound synthesis rejection reasons; preserve LKG generatedAt/fetchedAt while advancing lastAttemptAt, lastSuccessAt, and consecutive failure metadata; make compact health warn after bounded repeated/aged failures and clear only after a composed brief publishes; keep legacy fallback degraded after rejected L1 synthesis. Verification: focused insights/health/brief/China/LLM tests 99 passed; diff-scoped seed/health tests 107 passed; pre-push changed-test and edge gates 103 and 240 passed; typecheck, API typecheck, lint, safe-HTML, and proto freshness passed. Operational follow-up after merge/deploy: observe two consecutive production seed-insights cycles and confirm health warning/recovery behavior.