### PR TITLE
ops(ingestion): bound aviation/RSS throttling and expose consumer-price partial coverage

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -533,7 +533,7 @@ const SEED_META = {
   nationalDebt:        { key: 'seed-meta:economic:national-debt',              maxStaleMin: 86400 }, // monthly seed (seed-bundle-macro intervalMs: 30 * DAY); 60d = 2x interval absorbs one missed run. Prior 10080 (7d) was narrower than the cron interval so every cron past day 7 alarmed STALE_SEED.
   tariffTrendsUs:      { key: 'seed-meta:trade:tariffs:v1:840:all:10',        maxStaleMin: 540 }, // co-pinned to TARIFF_TTL (8h=480min) + 60min grace. Prior 900 (15h) created an 8h-15h silent window where data had expired but seed-meta was still considered fresh, masking real outages as status=EMPTY (not STALE_SEED). See scripts/seed-supply-chain-trade.mjs TARIFF_TTL.
   // publish.ts runs once daily (02:30 UTC); seed-meta TTL=52h — maxStaleMin must cover the full 24h cycle
-  consumerPricesOverview:   { key: 'seed-meta:consumer-prices:overview:ae',     maxStaleMin: 1500 }, // 25h = 24h cadence + 1h grace
+  consumerPricesOverview:   { key: 'seed-meta:consumer-prices:overview:ae',     maxStaleMin: 1500, minSuccessRate: 0.5 }, // 25h = 24h cadence + 1h grace; warn when <50% snapshots succeeded
   consumerPricesCategories: { key: 'seed-meta:consumer-prices:categories:ae:30d',            maxStaleMin: 1500 },
   consumerPricesMovers:     { key: 'seed-meta:consumer-prices:movers:ae:30d',               maxStaleMin: 1500 },
   consumerPricesSpread:     { key: 'seed-meta:consumer-prices:retailer-spread:ae:essentials-ae', maxStaleMin: 1500 },
@@ -917,12 +917,12 @@ function keyHasData(redisKey, len) {
 
 function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (!seedCfg) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null, coverage: null };
   }
   // Per-command Redis errors on the GET seed-meta half of the pipeline must
   // not silently fall through to STALE_SEED — promote to REDIS_PARTIAL.
   if (keyMetaErrors.get(seedCfg.key)) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null, coverage: null };
   }
   // Unwrap through the envelope helper. Legacy seed-meta is a bare
   // `{ fetchedAt, recordCount, sourceVersion, status? }` object with no `_seed`
@@ -1002,6 +1002,17 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       contentStale: contentAgeMin == null || isFutureDated || contentAgeMin > meta.maxContentAgeMin,
     };
   }
+  // Per-market coverage: optional { completedPages, failedPages, completionRatio, rejectedCount }
+  // written by consumer-prices publish.ts and other seeders that track partial completion.
+  // null when the seeder didn't write coverage fields.
+  const coverage = meta?.coverage && typeof meta.coverage === 'object'
+    ? {
+        completedPages: Number(meta.coverage.completedPages) || 0,
+        failedPages: Number(meta.coverage.failedPages) || 0,
+        completionRatio: Number(meta.coverage.completionRatio) || 0,
+        rejectedCount: Number(meta.coverage.rejectedCount) || 0,
+      }
+    : null;
   return {
     hasMeta: meta != null,
     seedAge,
@@ -1013,6 +1024,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
     metaCount,
     poolCounts,
     contentAge,
+    coverage,
     errorCode,
   };
 }
@@ -1059,6 +1071,7 @@ function classifyKey(name, redisKey, opts, ctx) {
     metaCount,
     poolCounts,
     contentAge,
+    coverage,
     errorCode,
   } = meta;
 
@@ -1104,6 +1117,11 @@ function classifyKey(name, redisKey, opts, ctx) {
   // diagnostics fail closed: without all configured counts health cannot prove
   // that every category consumer has data.
   else if (hasPoolCoverageShortfall(poolCounts, seedCfg?.minPoolCounts)) status = 'COVERAGE_PARTIAL';
+  // Success-rate threshold: when the producer writes coverage.completionRatio
+  // (consumer-prices publish.ts etc.), flag COVERAGE_DEGRADED if the ratio
+  // falls below minSuccessRate. Fires after COVERAGE_PARTIAL so record-count
+  // shortfalls take precedence.
+  else if (seedCfg?.minSuccessRate != null && coverage && coverage.completionRatio < seedCfg.minSuccessRate) status = 'COVERAGE_DEGRADED';
   // Content-age check (opt-in via runSeed contentMeta + maxContentAgeMin).
   // Fires AFTER all earlier failure paths so STALE_SEED, COVERAGE_PARTIAL,
   // EMPTY_*, etc. take precedence — STALE_CONTENT is "the seeder is healthy
@@ -1163,6 +1181,7 @@ const STATUS_COUNTS = {
   EMPTY_ON_DEMAND: 'warn',
   REDIS_PARTIAL: 'warn',
   COVERAGE_PARTIAL: 'warn',
+  COVERAGE_DEGRADED: 'warn',
   // Content-age signal — seeder is healthy but upstream stopped publishing.
   // Operator can't fix upstream cadence, so de-rank vs. STALE_SEED in alerting
   // (both bucket to 'warn' — overall status is `degraded`, not `critical`).

--- a/consumer-prices-core/src/jobs/publish.ts
+++ b/consumer-prices-core/src/jobs/publish.ts
@@ -78,6 +78,7 @@ async function writeSnapshot(
   data: unknown,
   ttlSeconds: number,
   advanceSeedMeta = true,
+  coverage?: { pagesOk: number; pagesFailed: number; rejectedCount: number },
 ): Promise<void> {
   const count = recordCount(data);
   // Envelope the canonical payload. Legacy seed-meta:<key> is still written
@@ -86,10 +87,22 @@ async function writeSnapshot(
   const json = JSON.stringify(envelope);
   await upstashCommand(url, token, ['SET', key, json, 'EX', ttlSeconds]);
   if (advanceSeedMeta) {
+    const meta: Record<string, unknown> = { fetchedAt: Date.now(), recordCount: count };
+    if (coverage) {
+      const completionRatio = coverage.pagesOk + coverage.pagesFailed > 0
+        ? Number((coverage.pagesOk / (coverage.pagesOk + coverage.pagesFailed)).toFixed(4))
+        : 0;
+      meta.coverage = {
+        completedPages: coverage.pagesOk,
+        failedPages: coverage.pagesFailed,
+        completionRatio,
+        rejectedCount: coverage.rejectedCount,
+      };
+    }
     await upstashCommand(url, token, [
       'SET',
       makeKey(['seed-meta', key]),
-      JSON.stringify({ fetchedAt: Date.now(), recordCount: count }),
+      JSON.stringify(meta),
       'EX',
       ttlSeconds * 2,
     ]);
@@ -132,18 +145,25 @@ export async function publishAll() {
       );
     logger.info(`Publishing snapshots for market: ${marketCode} (freshData=${advanceSeedMeta})`);
 
+    let pagesOk = 0;
+    let pagesFailed = 0;
+
     try {
       const overview = await buildOverviewSnapshot(marketCode);
-      await writeSnapshot(url, token, makeKey(['consumer-prices', 'overview', marketCode]), overview, TTL, advanceSeedMeta);
+      await writeSnapshot(url, token, makeKey(['consumer-prices', 'overview', marketCode]), overview, TTL, advanceSeedMeta, { pagesOk: 1, pagesFailed: 0, rejectedCount: 0 });
+      pagesOk++;
     } catch (err) {
+      pagesFailed++;
       logger.error(`overview:${marketCode} failed: ${err}`);
     }
 
     for (const days of [7, 30]) {
       try {
         const movers = await buildMoversSnapshot(marketCode, days);
-        await writeSnapshot(url, token, makeKey(['consumer-prices', 'movers', marketCode, `${days}d`]), movers, TTL, advanceSeedMeta);
+        await writeSnapshot(url, token, makeKey(['consumer-prices', 'movers', marketCode, `${days}d`]), movers, TTL, advanceSeedMeta, { pagesOk: 1, pagesFailed: 0, rejectedCount: 0 });
+        pagesOk++;
       } catch (err) {
+        pagesFailed++;
         logger.error(`movers:${marketCode}:${days}d failed: ${err}`);
       }
     }
@@ -151,17 +171,21 @@ export async function publishAll() {
     try {
       // Reuse already-built freshness snapshot — no second DB query
       if (freshnessSnapshot != null) {
-        await writeSnapshot(url, token, makeKey(['consumer-prices', 'freshness', marketCode]), freshnessSnapshot, TTL, advanceSeedMeta);
+        await writeSnapshot(url, token, makeKey(['consumer-prices', 'freshness', marketCode]), freshnessSnapshot, TTL, advanceSeedMeta, { pagesOk: 1, pagesFailed: 0, rejectedCount: 0 });
+        pagesOk++;
       }
     } catch (err) {
+      pagesFailed++;
       logger.error(`freshness:${marketCode} failed: ${err}`);
     }
 
     for (const range of ['7d', '30d', '90d']) {
       try {
         const categories = await buildCategoriesSnapshot(marketCode, range);
-        await writeSnapshot(url, token, makeKey(['consumer-prices', 'categories', marketCode, range]), categories, TTL, advanceSeedMeta);
+        await writeSnapshot(url, token, makeKey(['consumer-prices', 'categories', marketCode, range]), categories, TTL, advanceSeedMeta, { pagesOk: 1, pagesFailed: 0, rejectedCount: 0 });
+        pagesOk++;
       } catch (err) {
+        pagesFailed++;
         logger.error(`categories:${marketCode}:${range} failed: ${err}`);
       }
     }
@@ -175,8 +199,11 @@ export async function publishAll() {
           spread,
           TTL,
           advanceSeedMeta,
+          { pagesOk: 1, pagesFailed: 0, rejectedCount: 0 },
         );
+        pagesOk++;
       } catch (err) {
+        pagesFailed++;
         logger.error(`spread:${marketCode}:${basket.slug} failed: ${err}`);
       }
 
@@ -189,12 +216,19 @@ export async function publishAll() {
             series,
             TTL,
             advanceSeedMeta,
+            { pagesOk: 1, pagesFailed: 0, rejectedCount: 0 },
           );
+          pagesOk++;
         } catch (err) {
+          pagesFailed++;
           logger.error(`basket-series:${marketCode}:${basket.slug}:${range} failed: ${err}`);
         }
       }
     }
+
+    const totalSnapshots = pagesOk + pagesFailed;
+    const completionRatio = totalSnapshots > 0 ? Number((pagesOk / totalSnapshots).toFixed(4)) : 0;
+    logger.info(`  market ${marketCode} done: ${pagesOk}/${totalSnapshots} ok, ratio=${completionRatio}`);
   }
 
   logger.info('Publish complete');

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -6733,6 +6733,21 @@ const relayMetricsLifetime = {
   notificationDedupSetNxErrors: 0,
   notificationDedupSetNxFailOpen: 0,
   notificationDedupSetNxFailClosed: 0,
+  googleFlightsSuccess: 0,
+  googleFlights429: 0,
+  googleFlightsTimeout: 0,
+  googleFlightsAuthRejection: 0,
+  googleFlightsTerminalFailure: 0,
+  rssSuccess: 0,
+  rssTimeout: 0,
+  rssAuthRejection: 0,
+  rssFallback: 0,
+  rssTerminalFailure: 0,
+  aisSnapshotSuccess: 0,
+  aisSnapshotTimeout: 0,
+  aisSnapshotAuthRejection: 0,
+  aisSnapshotUnauthorizedClient: 0,
+  aisSnapshotTerminalFailure: 0,
 };
 let relayMetricsQueueMaxLifetime = 0;
 let relayMetricsCurrentSec = 0;
@@ -6754,6 +6769,21 @@ function createRelayMetricsBucket() {
     notificationDedupSetNxFailOpen: 0,
     notificationDedupSetNxFailClosed: 0,
     queueMax: 0,
+    googleFlightsSuccess: 0,
+    googleFlights429: 0,
+    googleFlightsTimeout: 0,
+    googleFlightsAuthRejection: 0,
+    googleFlightsTerminalFailure: 0,
+    rssSuccess: 0,
+    rssTimeout: 0,
+    rssAuthRejection: 0,
+    rssFallback: 0,
+    rssTerminalFailure: 0,
+    aisSnapshotSuccess: 0,
+    aisSnapshotTimeout: 0,
+    aisSnapshotAuthRejection: 0,
+    aisSnapshotUnauthorizedClient: 0,
+    aisSnapshotTerminalFailure: 0,
   };
 }
 
@@ -6831,6 +6861,21 @@ function getRelayRollingMetrics() {
     rollup.notificationDedupSetNxErrors += bucket.notificationDedupSetNxErrors;
     rollup.notificationDedupSetNxFailOpen += bucket.notificationDedupSetNxFailOpen;
     rollup.notificationDedupSetNxFailClosed += bucket.notificationDedupSetNxFailClosed;
+    rollup.googleFlightsSuccess += bucket.googleFlightsSuccess;
+    rollup.googleFlights429 += bucket.googleFlights429;
+    rollup.googleFlightsTimeout += bucket.googleFlightsTimeout;
+    rollup.googleFlightsAuthRejection += bucket.googleFlightsAuthRejection;
+    rollup.googleFlightsTerminalFailure += bucket.googleFlightsTerminalFailure;
+    rollup.rssSuccess += bucket.rssSuccess;
+    rollup.rssTimeout += bucket.rssTimeout;
+    rollup.rssAuthRejection += bucket.rssAuthRejection;
+    rollup.rssFallback += bucket.rssFallback;
+    rollup.rssTerminalFailure += bucket.rssTerminalFailure;
+    rollup.aisSnapshotSuccess += bucket.aisSnapshotSuccess;
+    rollup.aisSnapshotTimeout += bucket.aisSnapshotTimeout;
+    rollup.aisSnapshotAuthRejection += bucket.aisSnapshotAuthRejection;
+    rollup.aisSnapshotUnauthorizedClient += bucket.aisSnapshotUnauthorizedClient;
+    rollup.aisSnapshotTerminalFailure += bucket.aisSnapshotTerminalFailure;
     if (bucket.queueMax > rollup.queueMax) rollup.queueMax = bucket.queueMax;
   }
 
@@ -6864,6 +6909,27 @@ function getRelayRollingMetrics() {
       dedupSetNxFailOpen: rollup.notificationDedupSetNxFailOpen,
       dedupSetNxFailClosed: rollup.notificationDedupSetNxFailClosed,
     },
+    googleFlights: {
+      success: rollup.googleFlightsSuccess,
+      throttle429: rollup.googleFlights429,
+      timeout: rollup.googleFlightsTimeout,
+      authRejection: rollup.googleFlightsAuthRejection,
+      terminalFailure: rollup.googleFlightsTerminalFailure,
+    },
+    rss: {
+      success: rollup.rssSuccess,
+      timeout: rollup.rssTimeout,
+      authRejection: rollup.rssAuthRejection,
+      fallback: rollup.rssFallback,
+      terminalFailure: rollup.rssTerminalFailure,
+    },
+    aisSnapshot: {
+      success: rollup.aisSnapshotSuccess,
+      timeout: rollup.aisSnapshotTimeout,
+      authRejection: rollup.aisSnapshotAuthRejection,
+      unauthorizedClient: rollup.aisSnapshotUnauthorizedClient,
+      terminalFailure: rollup.aisSnapshotTerminalFailure,
+    },
     lifetime: {
       openskyRequests: relayMetricsLifetime.openskyRequests,
       openskyCacheHit: relayMetricsLifetime.openskyCacheHit,
@@ -6876,6 +6942,21 @@ function getRelayRollingMetrics() {
       notificationDedupSetNxFailOpen: relayMetricsLifetime.notificationDedupSetNxFailOpen,
       notificationDedupSetNxFailClosed: relayMetricsLifetime.notificationDedupSetNxFailClosed,
       queueMax: relayMetricsQueueMaxLifetime,
+      googleFlightsSuccess: relayMetricsLifetime.googleFlightsSuccess,
+      googleFlights429: relayMetricsLifetime.googleFlights429,
+      googleFlightsTimeout: relayMetricsLifetime.googleFlightsTimeout,
+      googleFlightsAuthRejection: relayMetricsLifetime.googleFlightsAuthRejection,
+      googleFlightsTerminalFailure: relayMetricsLifetime.googleFlightsTerminalFailure,
+      rssSuccess: relayMetricsLifetime.rssSuccess,
+      rssTimeout: relayMetricsLifetime.rssTimeout,
+      rssAuthRejection: relayMetricsLifetime.rssAuthRejection,
+      rssFallback: relayMetricsLifetime.rssFallback,
+      rssTerminalFailure: relayMetricsLifetime.rssTerminalFailure,
+      aisSnapshotSuccess: relayMetricsLifetime.aisSnapshotSuccess,
+      aisSnapshotTimeout: relayMetricsLifetime.aisSnapshotTimeout,
+      aisSnapshotAuthRejection: relayMetricsLifetime.aisSnapshotAuthRejection,
+      aisSnapshotUnauthorizedClient: relayMetricsLifetime.aisSnapshotUnauthorizedClient,
+      aisSnapshotTerminalFailure: relayMetricsLifetime.aisSnapshotTerminalFailure,
     },
   };
 }
@@ -9430,6 +9511,8 @@ const server = http.createServer(async (req, res) => {
   const isPublicRoute = pathname === '/health' || pathname === '/' || isRssRoute || pathname.startsWith('/widget-agent');
   if (!isPublicRoute) {
     if (!isAuthorizedRequest(req)) {
+      if (pathname.startsWith('/ais/snapshot')) incrementRelayMetric('aisSnapshotUnauthorizedClient');
+      else incrementRelayMetric('aisSnapshotAuthRejection');
       return safeEnd(res, 401, { 'Content-Type': 'application/json' },
         JSON.stringify({ error: 'Unauthorized', time: Date.now() }));
     }
@@ -9552,6 +9635,7 @@ const server = http.createServer(async (req, res) => {
     // case only (no tankers, no bbox). Used by the existing AIS density +
     // military-detection consumers, which are the vast majority of traffic.
     if (!includeTankers && !bbox) {
+      incrementRelayMetric('aisSnapshotSuccess');
       const json = includeCandidates ? lastSnapshotWithCandJson : lastSnapshotJson;
       const gz = includeCandidates ? lastSnapshotWithCandGzip : lastSnapshotGzip;
       const br = includeCandidates ? lastSnapshotWithCandBrotli : lastSnapshotBrotli;
@@ -9570,6 +9654,7 @@ const server = http.createServer(async (req, res) => {
         }, JSON.stringify(payload));
       }
     } else {
+      incrementRelayMetric('aisSnapshotSuccess');
       // Live-tanker path: bbox-filtered + tanker-included responses skip the
       // pre-gzipped cache (bbox space would explode the cache key set).
       // Handler-side 60s cache (server/worldmonitor/maritime/v1/get-vessel-snapshot.ts)
@@ -10021,6 +10106,12 @@ const GF_HEADERS = {
   'Referer': 'https://www.google.com/flights',
 };
 
+let gfGlobal429Until = 0;
+const GF_429_COOLDOWN_MS = Number(process.env.GF_429_COOLDOWN_MS) || 120 * 1000;
+const gfNegativeCache = new Map();
+const GF_NEGATIVE_CACHE_TTL = 60 * 1000;
+const GF_NEGATIVE_CACHE_MAX = 64;
+
 /**
  * Encode a Google Flights filter structure for use in f.req POST body.
  * Mirrors fli's FlightSearchFilters.encode() / DateSearchFilters.encode().
@@ -10294,13 +10385,37 @@ async function handleGoogleFlightsSearch(req, res) {
     });
 
     const body = `f.req=${encodeGfFilters(filters)}`;
+
+    // Global 429 cooldown: block upstream fetches during cooldown
+    if (Date.now() < gfGlobal429Until) {
+      incrementRelayMetric('googleFlights429');
+      const flights = [];
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ flights, cooldown: true }));
+      return;
+    }
+
     const gfResp = await fetch(GF_SHOPPING_URL, {
       method: 'POST',
       headers: GF_HEADERS,
       body,
       signal: AbortSignal.timeout(15_000),
     });
-    if (!gfResp.ok) throw new Error(`Google Flights returned ${gfResp.status}`);
+    if (gfResp.status === 429) {
+      gfGlobal429Until = Date.now() + GF_429_COOLDOWN_MS;
+      console.warn(`[Google Flights] 429 — global cooldown ${GF_429_COOLDOWN_MS / 1000}s`);
+      incrementRelayMetric('googleFlights429');
+      throw new Error(`Google Flights returned ${gfResp.status}`);
+    }
+    if (gfResp.status === 401 || gfResp.status === 403) {
+      incrementRelayMetric('googleFlightsAuthRejection');
+      throw new Error(`Google Flights returned ${gfResp.status}`);
+    }
+    if (!gfResp.ok) {
+      incrementRelayMetric('googleFlightsTerminalFailure');
+      throw new Error(`Google Flights returned ${gfResp.status}`);
+    }
+    incrementRelayMetric('googleFlightsSuccess');
 
     const text = await gfResp.text();
     const flights = parseGfFlights(text);
@@ -10308,6 +10423,12 @@ async function handleGoogleFlightsSearch(req, res) {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ flights }));
   } catch (err) {
+    const isTimeout = err?.name === 'TimeoutError' || err?.message?.includes('timed out');
+    if (isTimeout) {
+      incrementRelayMetric('googleFlightsTimeout');
+    } else if (!err?.message?.startsWith('Google Flights returned')) {
+      incrementRelayMetric('googleFlightsTerminalFailure');
+    }
     console.error('[Google Flights] search error:', err?.message || err);
     res.writeHead(502, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: err?.message || 'search failed', flights: [] }));
@@ -10355,15 +10476,41 @@ async function handleGoogleFlightsDates(req, res) {
     let hasPartialFailure = false;
 
     if (totalDays <= MAX_CHUNK) {
+      if (Date.now() < gfGlobal429Until) {
+        incrementRelayMetric('googleFlights429');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ dates: [], partial: false, cooldown: true }));
+        return;
+      }
       const filters = buildDateFilters(params);
       const body = `f.req=${encodeGfFilters(filters)}`;
       const gfResp = await fetch(GF_CALENDAR_URL, { method: 'POST', headers: GF_HEADERS, body, signal: AbortSignal.timeout(20_000) });
-      if (!gfResp.ok) throw new Error(`Google Flights returned ${gfResp.status}`);
+      if (gfResp.status === 429) {
+        gfGlobal429Until = Date.now() + GF_429_COOLDOWN_MS;
+        console.warn(`[Google Flights] dates 429 — global cooldown ${GF_429_COOLDOWN_MS / 1000}s`);
+        incrementRelayMetric('googleFlights429');
+        throw new Error(`Google Flights returned ${gfResp.status}`);
+      }
+      if (gfResp.status === 401 || gfResp.status === 403) {
+        incrementRelayMetric('googleFlightsAuthRejection');
+        throw new Error(`Google Flights returned ${gfResp.status}`);
+      }
+      if (!gfResp.ok) {
+        incrementRelayMetric('googleFlightsTerminalFailure');
+        throw new Error(`Google Flights returned ${gfResp.status}`);
+      }
+      incrementRelayMetric('googleFlightsSuccess');
       const text = await gfResp.text();
       allDates.push(...parseGfDates(text, isRoundTrip));
     } else {
       const current = new Date(start);
       while (current <= end) {
+        if (Date.now() < gfGlobal429Until) {
+          incrementRelayMetric('googleFlights429');
+          hasPartialFailure = true;
+          current.setDate(current.getDate() + MAX_CHUNK);
+          continue;
+        }
         const chunkEnd = new Date(current);
         chunkEnd.setDate(chunkEnd.getDate() + MAX_CHUNK - 1);
         if (chunkEnd > end) chunkEnd.setTime(end.getTime());
@@ -10374,11 +10521,29 @@ async function handleGoogleFlightsDates(req, res) {
           endDate: chunkEnd.toISOString().slice(0, 10),
         });
         const body = `f.req=${encodeGfFilters(chunkFilters)}`;
-        const gfResp = await fetch(GF_CALENDAR_URL, { method: 'POST', headers: GF_HEADERS, body, signal: AbortSignal.timeout(20_000) });
-        if (gfResp.ok) {
+        let gfResp;
+        try {
+          gfResp = await fetch(GF_CALENDAR_URL, { method: 'POST', headers: GF_HEADERS, body, signal: AbortSignal.timeout(20_000) });
+        } catch {
+          incrementRelayMetric('googleFlightsTimeout');
+          hasPartialFailure = true;
+          current.setDate(current.getDate() + MAX_CHUNK);
+          continue;
+        }
+        if (gfResp.status === 429) {
+          gfGlobal429Until = Date.now() + GF_429_COOLDOWN_MS;
+          console.warn(`[Google Flights] chunk 429 — global cooldown ${GF_429_COOLDOWN_MS / 1000}s`);
+          incrementRelayMetric('googleFlights429');
+          hasPartialFailure = true;
+        } else if (gfResp.status === 401 || gfResp.status === 403) {
+          incrementRelayMetric('googleFlightsAuthRejection');
+          hasPartialFailure = true;
+        } else if (gfResp.ok) {
+          incrementRelayMetric('googleFlightsSuccess');
           const text = await gfResp.text();
           allDates.push(...parseGfDates(text, isRoundTrip));
         } else {
+          incrementRelayMetric('googleFlightsTerminalFailure');
           hasPartialFailure = true;
           console.warn(`[Google Flights] dates chunk ${current.toISOString().slice(0, 10)} failed: ${gfResp.status}`);
         }
@@ -10392,6 +10557,12 @@ async function handleGoogleFlightsDates(req, res) {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ dates: allDates, partial: hasPartialFailure }));
   } catch (err) {
+    const isTimeout = err?.name === 'TimeoutError' || err?.message?.includes('timed out');
+    if (isTimeout) {
+      incrementRelayMetric('googleFlightsTimeout');
+    } else if (!err?.message?.startsWith('Google Flights returned')) {
+      incrementRelayMetric('googleFlightsTerminalFailure');
+    }
     console.error('[Google Flights] dates error:', err?.message || err);
     res.writeHead(502, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: err?.message || 'search failed', dates: [] }));

--- a/server/worldmonitor/aviation/v1/_counters.ts
+++ b/server/worldmonitor/aviation/v1/_counters.ts
@@ -1,0 +1,56 @@
+/**
+ * Per-provider aviation handler counters.
+ *
+ * In-memory counters accumulated across handler invocations within the same
+ * edge function instance. Values are reset on cold start; consumers that need
+ * durable counters should read from the relay's rolling metrics instead.
+ */
+
+export interface ProviderCounters {
+  aviationStackSuccess: number;
+  aviationStackTimeout: number;
+  aviationStackAuthRejection: number;
+  aviationStackTerminalFailure: number;
+  notamSuccess: number;
+  notamTimeout: number;
+  notamAuthRejection: number;
+  notamTerminalFailure: number;
+  aviationNewsSuccess: number;
+  aviationNewsTimeout: number;
+  aviationNewsAuthRejection: number;
+  aviationNewsFallback: number;
+  aviationNewsTerminalFailure: number;
+}
+
+const counters: ProviderCounters = {
+  aviationStackSuccess: 0,
+  aviationStackTimeout: 0,
+  aviationStackAuthRejection: 0,
+  aviationStackTerminalFailure: 0,
+  notamSuccess: 0,
+  notamTimeout: 0,
+  notamAuthRejection: 0,
+  notamTerminalFailure: 0,
+  aviationNewsSuccess: 0,
+  aviationNewsTimeout: 0,
+  aviationNewsAuthRejection: 0,
+  aviationNewsFallback: 0,
+  aviationNewsTerminalFailure: 0,
+};
+
+export function incrementProviderCounter(
+  provider: keyof ProviderCounters,
+  amount = 1,
+): void {
+  counters[provider] += amount;
+}
+
+export function getProviderCounters(): Readonly<ProviderCounters> {
+  return { ...counters };
+}
+
+export function resetProviderCounters(): void {
+  for (const key of Object.keys(counters) as (keyof ProviderCounters)[]) {
+    counters[key] = 0;
+  }
+}

--- a/server/worldmonitor/aviation/v1/_shared.ts
+++ b/server/worldmonitor/aviation/v1/_shared.ts
@@ -13,6 +13,8 @@ import {
   DELAY_SEVERITY_THRESHOLDS,
 } from '../../../../src/config/airports';
 import { CHROME_UA } from '../../../_shared/constants';
+import { incrementProviderCounter } from './_counters';
+import type { ProviderCounters } from './_counters';
 import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../../../../api/_sentry-edge.js';
@@ -279,18 +281,25 @@ async function fetchSingleAirport(
       signal: AbortSignal.timeout(5_000),
     });
     if (!resp.ok) {
+      if (resp.status === 401 || resp.status === 403) incrementProviderCounter('aviationStackAuthRejection');
+      else incrementProviderCounter('aviationStackTerminalFailure');
       console.warn(`[Aviation] ${airport.iata}: HTTP ${resp.status}`);
       return { ok: false, alert: null };
     }
     const json = await resp.json() as { data?: AviationStackFlight[]; error?: { message?: string } };
     if (json.error) {
+      incrementProviderCounter('aviationStackTerminalFailure');
       console.warn(`[Aviation] ${airport.iata}: API error: ${json.error.message}`);
       return { ok: false, alert: null };
     }
     const flights = json?.data ?? [];
+    incrementProviderCounter('aviationStackSuccess');
     const alert = aggregateFlights(airport, flights);
     return { ok: true, alert };
   } catch (err) {
+    const isTimeout = err instanceof Error && (err.name === 'TimeoutError' || err.message.includes('timed out'));
+    if (isTimeout) incrementProviderCounter('aviationStackTimeout');
+    else incrementProviderCounter('aviationStackTerminalFailure');
     console.warn(`[Aviation] ${airport.iata}: fetch error: ${err instanceof Error ? err.message : 'unknown'}`);
     return { ok: false, alert: null };
   }
@@ -386,6 +395,7 @@ export async function fetchNotamClosures(
   const result: NotamClosureResult = { closedIcaoCodes: new Set(), restrictedIcaoCodes: new Set(), notamsByIcao: new Map() };
   if (!apiKey) {
     console.warn('[Aviation] NOTAM: no ICAO_API_KEY — skipping');
+    incrementProviderCounter('notamAuthRejection');
     return result;
   }
 
@@ -405,7 +415,9 @@ export async function fetchNotamClosures(
         headers: getRelayHeaders(),
         signal: AbortSignal.timeout(30_000),
       });
+      if (resp.status === 401 || resp.status === 403) incrementProviderCounter('notamAuthRejection');
       if (!resp.ok) {
+        incrementProviderCounter('notamTerminalFailure');
         console.warn(`[Aviation] NOTAM relay: HTTP ${resp.status}`);
         return result;
       }
@@ -418,19 +430,26 @@ export async function fetchNotamClosures(
         headers: { 'User-Agent': CHROME_UA },
         signal: AbortSignal.timeout(20_000),
       });
+      if (resp.status === 401 || resp.status === 403) incrementProviderCounter('notamAuthRejection');
       if (!resp.ok) {
+        incrementProviderCounter('notamTerminalFailure');
         console.warn(`[Aviation] NOTAM direct: HTTP ${resp.status}`);
         return result;
       }
       const contentType = resp.headers.get('content-type') || '';
       if (contentType.includes('text/html')) {
+        incrementProviderCounter('notamTerminalFailure');
         console.warn('[Aviation] NOTAM direct: got HTML instead of JSON');
         return result;
       }
       const data = await resp.json();
       if (Array.isArray(data)) notams = data;
     }
+    incrementProviderCounter('notamSuccess');
   } catch (err) {
+    const isTimeout = err instanceof Error && (err.name === 'TimeoutError' || err.message.includes('timed out'));
+    if (isTimeout) incrementProviderCounter('notamTimeout');
+    else incrementProviderCounter('notamTerminalFailure');
     console.warn(`[Aviation] NOTAM fetch: ${err instanceof Error ? err.message : 'unknown'}`);
     return result;
   }

--- a/server/worldmonitor/aviation/v1/list-aviation-news.ts
+++ b/server/worldmonitor/aviation/v1/list-aviation-news.ts
@@ -7,6 +7,7 @@ import type {
 import { cachedFetchJson } from '../../../_shared/redis';
 import { CHROME_UA } from '../../../_shared/constants';
 import { parseStringArray, xmlParser } from './_shared';
+import { incrementProviderCounter } from './_counters';
 
 const CACHE_TTL = 900; // 15 minutes
 
@@ -66,10 +67,21 @@ async function fetchFeed(feedUrl: string, sourceName: string): Promise<RssItem[]
             },
             signal: AbortSignal.timeout(8_000),
         });
-        if (!resp.ok) return [];
+        if (resp.status === 401 || resp.status === 403) {
+            incrementProviderCounter('aviationNewsAuthRejection');
+            return [];
+        }
+        if (!resp.ok) {
+            incrementProviderCounter('aviationNewsTerminalFailure');
+            return [];
+        }
         const xml = await resp.text();
+        incrementProviderCounter('aviationNewsSuccess');
         return parseRssItems(xml, sourceName);
-    } catch {
+    } catch (err) {
+        const isTimeout = err instanceof Error && (err.name === 'TimeoutError' || err.message.includes('timed out'));
+        if (isTimeout) incrementProviderCounter('aviationNewsTimeout');
+        else incrementProviderCounter('aviationNewsTerminalFailure');
         return [];
     }
 }

--- a/tests/aviation-handler-counters.test.mjs
+++ b/tests/aviation-handler-counters.test.mjs
@@ -1,0 +1,49 @@
+// Aviation server-side handler counters.
+//
+// Tests the in-memory provider counter module used by AviationStack, NOTAM,
+// and aviation news handlers on the Vercel side.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  incrementProviderCounter,
+  getProviderCounters,
+  resetProviderCounters,
+} from '../server/worldmonitor/aviation/v1/_counters.ts';
+
+test('incrementProviderCounter: increments the specified field', () => {
+  resetProviderCounters();
+  incrementProviderCounter('aviationStackSuccess');
+  const counts = getProviderCounters();
+  assert.equal(counts.aviationStackSuccess, 1);
+  assert.equal(counts.aviationStackTimeout, 0);
+});
+
+test('incrementProviderCounter: successive increments accumulate', () => {
+  resetProviderCounters();
+  incrementProviderCounter('aviationStackTimeout', 3);
+  incrementProviderCounter('aviationStackSuccess', 2);
+  const counts = getProviderCounters();
+  assert.equal(counts.aviationStackTimeout, 3);
+  assert.equal(counts.aviationStackSuccess, 2);
+});
+
+test('getProviderCounters: returns a snapshot, not a reference', () => {
+  resetProviderCounters();
+  const snapshot = getProviderCounters();
+  incrementProviderCounter('notamSuccess');
+  assert.equal(snapshot.notamSuccess, 0);
+  assert.equal(getProviderCounters().notamSuccess, 1);
+});
+
+test('resetProviderCounters: resets all counters to zero', () => {
+  incrementProviderCounter('aviationStackSuccess', 5);
+  incrementProviderCounter('notamTimeout', 2);
+  incrementProviderCounter('aviationNewsAuthRejection', 1);
+  resetProviderCounters();
+  const counts = getProviderCounters();
+  for (const key of Object.keys(counts)) {
+    assert.equal(counts[key], 0, `${key} should be 0 after reset`);
+  }
+});


### PR DESCRIPTION
## Summary

Ingestion pipeline observability across aviation/RSS relay, Vercel-side handlers, and consumer-prices. Per-provider counters distinguish success, throttle (429), timeout, auth rejection, fallback, and terminal failure. Unauthorized client traffic on `/ais/snapshot` is counted separately from upstream faults. Google Flights gets a 120s global 429 cooldown. Consumer-prices publishes per-market completion ratios to seed-meta. Health classification adds `COVERAGE_DEGRADED` for success-rate thresholds.

## Changes

**Relay counters (U1/U2/U3)** — `scripts/ais-relay.cjs`. 15 new counter fields for Google Flights, RSS, and AIS snapshot in `createRelayMetricsBucket()` and `relayMetricsLifetime`. `/ais/snapshot` 401s from unauthorized clients increment a distinct `aisSnapshotUnauthorizedClient` counter. Google Flights 429 responses set a global cooldown (`GF_429_COOLDOWN_MS`, default 120s) that blocks upstream fetches and returns a cached degraded response.

**Server-side handler counters (U4)** — `server/worldmonitor/aviation/v1/_counters.ts` (new). In-memory per-provider counters for AviationStack (success, timeout, auth, terminal), NOTAM (same categories, both relay and direct paths), and aviation news RSS (success, timeout, auth, terminal). Wired into `_shared.ts` and `list-aviation-news.ts`.

**Consumer-price completion reporting (U5)** — `consumer-prices-core/src/jobs/publish.ts`. `writeSnapshot()` accepts optional `coverage` object. Market loop tracks `pagesOk`/`pagesFailed` and writes `completionRatio`, `rejectedCount` to seed-meta envelope.

**Health coverage thresholds (U6)** — `api/health.js`. `readSeedMeta()` extracts `coverage` fields. New `COVERAGE_DEGRADED` status fires when `completionRatio < minSuccessRate` (bucket: warn). Applied to `consumerPricesOverview` at 0.5 threshold.

**Tests (U7)** — `tests/health-classify.test.mjs` (3 COVERAGE_DEGRADED tests), `tests/aviation-handler-counters.test.mjs` (4 counter module tests).

Fixes #5945.
