### PR TITLE
fix(analytics): alert only on actionable collector write failures

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -52,6 +52,20 @@ An Alert Rule's optional country restriction. Empty means unscoped — every eve
 
 The country identity a notification publisher attaches to an event at publish time, normalized to ISO-3166 alpha-2 through the shared country-name map. Attribution is the publisher's job, not the dispatcher's: a publisher that knows the country must attach it, because a missing or unresolvable attribution is indistinguishable downstream from a genuinely global event. A name-normalization miss that silently omits the attribution converts "lookup failed" into "field never existed" — the failure mode that lets scoped delivery leak. See also: Country Scope.
 
+## Product Analytics Collection
+
+### Write Receipt
+
+The body the analytics collector returns for a write it actually stored, carrying the session and visit identifiers it minted for that write. The receipt — not the status code — is the delivery proof: the collector answers a success status to writes it accepts and then discards, so treating a 2xx as stored is what lets a dropped conversion look delivered. A response that carries a success status but no receipt is undelivered, and whether it is worth reporting depends on *why* the receipt is missing. See also: Bot-Filtered Write, Environment Noise.
+
+### Bot-Filtered Write
+
+A write the collector deliberately discarded because it judged the client non-human, acknowledged with a success status and a fixed sentinel body instead of a Write Receipt. It is a real delivery failure — nothing was stored, so retry policy and any durable conversion marker must treat it exactly as they treat any other missing receipt — but it is not an incident, so it must never raise an alert. That split is the load-bearing part: the distinction belongs in the *alerting* decision, never in the *delivery* classification, because collapsing them turns a silenced alert into a silenced retry. First-party crawlers and headless browsers hitting production pages land in this class, so any browser-side alarm sees the project's own monitoring traffic unless it excludes it. See also: Write Receipt, Environment Noise.
+
+### Environment Noise
+
+The class of collector failures produced by the client's own environment — a blocked request, an unanswered one — rather than by the collector. Locally indistinguishable from a total outage, because a blocked client and a dead collector both fail every write on that page; nothing computable in one browser separates them. The consequence is that the outage signal is the aggregate volume of these reports across users, not any single report, so the reporting policy gates them behind both a minimum sample and a minimum failure rate within a rolling window and admits at most one per page per window. Without the per-page bound, one heavily-blocked session outproduces the incident the gate exists to expose. Failures the origin answered — any non-success status — are outside this class and always reportable, which is what keeps a dead origin loud. See also: Write Receipt, Bot-Filtered Write, Vacuous Guard.
+
 ## Company Attribution
 
 ### Filer

--- a/docs/solutions/integration-issues/umami-answers-http-200-when-it-drops-a-bot-write.md
+++ b/docs/solutions/integration-issues/umami-answers-http-200-when-it-drops-a-bot-write.md
@@ -1,0 +1,124 @@
+---
+title: Umami answers HTTP 200 when it drops a bot write, and the alarm built on it paged on its own crawler
+date: 2026-08-01
+category: integration-issues
+module: analytics
+problem_type: integration_issue
+component: service_object
+symptoms:
+  - "Sentry issue `Umami collector write failed` at 45 events / 24 users in its first 32 minutes"
+  - "61% of the events carry `status: 200` and `failureKind: missing-receipt`"
+  - "Zero `P2002` / `session_data_pkey` events anywhere in Sentry over 14 days — the race the alarm was built for"
+  - "The CI collector monitor stays green while the browser alarm floods"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+related_components: [tooling]
+tags: [umami, analytics, sentry, alerting, alert-fatigue, bot-filter, observability]
+---
+
+# Umami answers HTTP 200 when it drops a bot write, and the alarm built on it paged on its own crawler
+
+## Problem
+
+PR #5964 added a browser-side Sentry warning for every Umami collector write failure. It fired 45 events across 24 users in its first 32 minutes and caught **zero** instances of the umami#4183 `session_data` race it was built to detect. Most of the "failures" were HTTP 200 successes, and most of those came from WorldMonitor's own crawler.
+
+## Symptoms
+
+- Sentry `Umami collector write failed`, level `warning`, first seen 6 minutes after the PR merged (12:31:13Z merge → 12:37:02Z first event).
+- Event breakdown of 44 sampled: `missing-receipt` 27 (all `status: 200`, all `requestType: event`), `network` 14, `timeout` 1, `queue-overflow` 1, `http` 1.
+- `P2002` and `session_data_pkey` return 0 results across the whole Sentry org over 14 days.
+
+## What Didn't Work
+
+- **Blaming the PR the user pointed at.** The report arrived as "after PR #5965". #5965 (`fix(insights): preserve freshness on synthesis rejection`) touches only `api/health.js`, `scripts/seed-insights.mjs`, and tests — it cannot emit a browser event. `git log -S "Umami collector write failed"` returned only #5964's commits, which is what actually settled attribution. **Merge-order adjacency is not causation; grep the message string for the introducing commit.**
+- **Assuming the receipt check was simply wrong for `event` writes.** All 27 misclassified events were `type: 'event'` and zero were `identify`, which looks conclusive. Probing production disproved it: Umami returns a full `{cache, sessionId, visitId}` receipt for *every* shape — `event` and `identify`, with and without a client `id`, with and without `x-umami-cache`.
+- **The `x-umami-cache` hypothesis.** Plausible that Umami returns a thinner body once the tracker holds a session token, and it would have explained why the CI monitor (which never sets that header) stayed green. Probed it directly: all four variants returned the same 419-byte receipt.
+- **CORS / opaque-response hypothesis.** An unreadable cross-origin body would explain an empty parse, but `OPTIONS` against the collector returns `access-control-allow-origin: *`, and an opaque response would surface as `status: 0`, not `200`.
+
+## Solution
+
+The discriminator was the User-Agent, found by replaying the exact UA strings from the Sentry events against production:
+
+```
+real Chrome      status=200 bodyLen=419 body={"cache":"eyJhbGciOi...
+HeadlessChrome   status=200 bodyLen=15  body={"beep":"boop"}
+Googlebot        status=403 (Cloudflare WAF, never reaches Umami)
+```
+
+**Umami's bot check answers `HTTP 200` with `{"beep":"boop"}` and stores nothing.** 20 of the 27 came from `Mozilla/5.0 (VISION-3.0-WorldMonitor; +https://github.com/local/vision)` — our own agent — plus 3 HeadlessChrome. The remaining `network` failures are ad-blocked clients.
+
+The fix separates *delivery classification* from *alerting*:
+
+```ts
+// shared/collector-failure-metadata.js — one definition, read by both the CI
+// monitor and the browser transport.
+export function isBotFilteredBody(body) {
+  if (typeof body !== 'string' || body.length === 0) return false;
+  try {
+    const parsed = JSON.parse(body);
+    return typeof parsed === 'object' && parsed !== null && parsed.beep === 'boop';
+  } catch {
+    return false;
+  }
+}
+```
+
+```ts
+// src/services/analytics-collector-transport.ts
+export function isAlertWorthyCollectorFailure(
+  failure: CollectorFailure,
+  window: CollectorHealthSnapshot,
+): boolean {
+  if (isKnownSessionDataConflict(failure)) return false;  // known umami#4183
+  if (failure.botFiltered) return false;                  // dropped on purpose
+  if (ENVIRONMENT_NOISE_KINDS.has(failure.kind)) {        // network | timeout
+    if (window.noiseReported) return false;               // 1 per page per window
+    if (window.writes < ENVIRONMENT_NOISE_MIN_WRITES) return false;
+    return window.failures / window.writes >= ENVIRONMENT_NOISE_MIN_FAILURE_RATE;
+  }
+  return true;  // non-2xx, unexplained receiptless 200, queue-overflow
+}
+```
+
+`botFiltered` is a **marker on `CollectorFailure`, deliberately not a new `kind`**. The write really was dropped, so `isRetryableCollectorFailure` and `isDurableMarkerResolved` must keep treating it exactly like any other receiptless 200. Promoting it to a `kind` would have turned an alert-noise fix into a conversion-accounting change.
+
+## Why This Works
+
+Three distinct facts were collapsed into one `missing-receipt` classification:
+
+1. **Umami deliberately discarded this write** (bot filter) — expected, unactionable.
+2. **The client's environment blocked the write** (ad blocker) — expected, unactionable *individually*.
+3. **The collector returned something unexplained** — actionable.
+
+Only (3) deserves an event. The alarm reported all three and suppressed the one genuinely known-bad case, so its signal-to-noise was inverted: it was quiet about umami#4183 and loud about everything expected.
+
+The rate gate matters for a reason worth stating plainly: **an ad-blocked client and a dead collector are indistinguishable from inside one browser** — both fail 100% of writes. Nothing computed on the page separates them, so the outage signal is aggregate event volume across users, not any single event. That is why the per-window cap exists; without it, crossing the rate floor makes every remaining failure in the window report, and one ad-blocked power user out-produces the incident the floor was added to expose. The common outage shape (origin dead → Cloudflare 502) is `kind: 'http'` and alerts immediately regardless.
+
+## Prevention
+
+- **An alarm must be attacked from both directions.** Reviewing "does it fire?" is half the job; the other half is "can it fire on something expected?" and "can it stay silent while the watched thing is dead?" This alarm passed the first and failed the second and third. Tests now lock all three, including that the bot-filter suppression is reachable only through a 2xx:
+
+  ```ts
+  it('cannot be muted by a non-2xx body that mimics the bot sentinel', async () => {
+    const failure = await inspectCollectorResponse(collectorResponse(false, 502, '{"beep":"boop"}'));
+    assert.equal(failure?.kind, 'http');
+    assert.ok(!failure?.botFiltered);
+  });
+  ```
+
+- **A 2xx is not a delivery receipt for any third-party collector.** Check the response body contract, and check what the vendor returns for *rejected* traffic — that path is usually undocumented and usually still a 200.
+
+- **Filter your own synthetic traffic before it reaches an alarm.** 20 of 27 events came from a first-party crawler hitting production pages. Any browser-side alarm will see monitoring traffic unless it explicitly excludes it.
+
+- **When a monitor and a client disagree about "success," the definition is duplicated.** The CI monitor and the browser transport both required `{cache, sessionId, visitId}` but only the monitor sent a browser UA, so only the browser ever saw the bot path. The sentinel now lives in `shared/collector-failure-metadata.js`, whose own header says divergence between the two surfaces is what it exists to prevent.
+
+- **Mutation-test each guard rather than trusting a green suite.** Six mutants were applied and all turned the suite red on the specific test that owns them: substring-scan detector, always-false detector, latch never set, sample floor lowered to 1, predicate not consulted, and the sentinel check leaking past the `!response.ok` branch.
+
+## Related Issues
+
+- #5973 — tracking issue for this regression
+- #5964 — the PR that introduced the alarm (and fixed the real #5715 write-path gap)
+- #5715 — collector 500s dropping checkout conversions
+- #5565 — collector dead 4 days, unnoticed; the alert-fatigue endpoint this fix exists to avoid
+- umami-software/umami#4183 — the unfixed upstream `session_data` race

--- a/scripts/check-analytics-collector.mjs
+++ b/scripts/check-analytics-collector.mjs
@@ -18,9 +18,12 @@ import { randomUUID } from 'node:crypto';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { extractCollectorFailureMetadata } from '../shared/collector-failure-metadata.js';
+import {
+  extractCollectorFailureMetadata,
+  isBotFilteredBody,
+} from '../shared/collector-failure-metadata.js';
 
-export { extractCollectorFailureMetadata };
+export { extractCollectorFailureMetadata, isBotFilteredBody };
 
 const DEFAULT_COLLECTOR_ORIGIN = 'https://abacus.worldmonitor.app';
 export const ANALYTICS_CANARY_WEBSITE_ID = '373c80a2-1109-42a7-868b-565bcf7bf168';
@@ -222,6 +225,16 @@ export function evaluateProbeResult(probe, result) {
   }
 
   if (probe.receiptFields) {
+    // Checked BEFORE the field loop so the reason names the actual condition.
+    // Umami drops a bot-detected write with 200 + `{"beep":"boop"}`; reporting
+    // that as "receipt missing non-empty string cache" points the reader at a
+    // broken write path instead of at the UA heuristic. This still counts as a
+    // probe FAILURE: the canary sends a browser User-Agent precisely so it is
+    // not filtered, so being filtered means the probe has stopped exercising
+    // the write path it exists to measure.
+    if (isBotFilteredBody(result.body)) {
+      return `HTTP ${result.status} but the write was bot-filtered by the collector (probe User-Agent now matches Umami's bot heuristic; the write path was never exercised)`;
+    }
     let receipt;
     try {
       receipt = JSON.parse(result.body);

--- a/shared/collector-failure-metadata.d.ts
+++ b/shared/collector-failure-metadata.d.ts
@@ -6,3 +6,5 @@ export interface CollectorFailureMetadata {
 export function extractCollectorFailureMetadata(body: unknown): CollectorFailureMetadata;
 
 export function isSessionDataConflict(metadata: CollectorFailureMetadata): boolean;
+
+export function isBotFilteredBody(body: unknown): boolean;

--- a/shared/collector-failure-metadata.js
+++ b/shared/collector-failure-metadata.js
@@ -102,3 +102,30 @@ export function extractCollectorFailureMetadata(body) {
 export function isSessionDataConflict(metadata) {
   return metadata.prismaCode === 'P2002' || metadata.constraint === 'session_data_pkey';
 }
+
+/**
+ * True when a 200 body is Umami's bot-filter sentinel.
+ *
+ * When Umami's User-Agent bot check rejects a write it answers `HTTP 200` with
+ * `{"beep":"boop"}` and stores nothing — an intentional silent drop, not a
+ * failure of the write path. Verified against production 2026-08-01: a
+ * HeadlessChrome UA gets this 15-byte body while a real browser UA gets the
+ * full `{cache, sessionId, visitId}` receipt.
+ *
+ * This is deliberately keyed off the PARSED `beep` property rather than a
+ * substring scan of the raw body. A receipt's field values are upstream-
+ * controlled strings, so `body.includes('beep')` would let one forge a
+ * bot-filter verdict and mute a genuine delivery failure.
+ *
+ * @param {unknown} body Raw response body text.
+ * @returns {boolean}
+ */
+export function isBotFilteredBody(body) {
+  if (typeof body !== 'string' || body.length === 0) return false;
+  try {
+    const parsed = JSON.parse(body);
+    return typeof parsed === 'object' && parsed !== null && parsed.beep === 'boop';
+  } catch {
+    return false;
+  }
+}

--- a/src/services/analytics-collector-transport.ts
+++ b/src/services/analytics-collector-transport.ts
@@ -287,6 +287,19 @@ const ENVIRONMENT_NOISE_MIN_WRITES = 5;
 const ENVIRONMENT_NOISE_MIN_FAILURE_RATE = 0.5;
 
 /**
+ * As much of the rolling health window as the alert policy reads.
+ *
+ * `noiseReported` is optional so a caller reasoning about a hypothetical window
+ * — every test in the policy suite — can omit the latch and get the
+ * first-occurrence answer.
+ */
+type CollectorHealthSnapshot = {
+  writes: number;
+  failures: number;
+  noiseReported?: boolean;
+};
+
+/**
  * Whether a failure is worth a Sentry event, as opposed to merely worth a
  * console warning.
  *
@@ -297,7 +310,7 @@ const ENVIRONMENT_NOISE_MIN_FAILURE_RATE = 0.5;
  */
 export function isAlertWorthyCollectorFailure(
   failure: CollectorFailure,
-  window: { writes: number; failures: number; noiseReported?: boolean },
+  window: CollectorHealthSnapshot,
 ): boolean {
   // Known, unfixed upstream race (umami#4183). Expected background condition.
   if (isKnownSessionDataConflict(failure)) return false;

--- a/src/services/analytics-collector-transport.ts
+++ b/src/services/analytics-collector-transport.ts
@@ -25,6 +25,7 @@
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 import {
   extractCollectorFailureMetadata,
+  isBotFilteredBody,
   isSessionDataConflict,
 } from '../../shared/collector-failure-metadata';
 
@@ -33,6 +34,17 @@ export type CollectorFailure = {
   status?: number;
   prismaCode?: string;
   constraint?: string;
+  /**
+   * The collector answered 200 with its bot-filter sentinel and stored nothing.
+   *
+   * This is a MARKER, not a `kind`, on purpose. The write really was dropped,
+   * so every delivery policy — retry, and the durable checkout marker — must
+   * keep treating it exactly like any other receiptless 200. Only the alerting
+   * decision reads this flag. Promoting it to its own `kind` would silently
+   * change `isRetryableCollectorFailure` and `isDurableMarkerResolved`, turning
+   * an alert-noise fix into a conversion-accounting change.
+   */
+  botFiltered?: boolean;
 };
 
 export type CollectorRequestType = 'event' | 'identify';
@@ -118,7 +130,7 @@ let collectorFetchWrapper: typeof window.fetch | null = null;
 let collectorUnloadFlush: (() => void) | null = null;
 let collectorVisibilityFlush: (() => void) | null = null;
 let collectorTransportGeneration = 0;
-let collectorHealthWindow = { startedAt: 0, writes: 0, failures: 0 };
+let collectorHealthWindow = { startedAt: 0, writes: 0, failures: 0, noiseReported: false };
 let pendingObservation: ObservationSlot | null = null;
 /**
  * Non-zero while this module is dispatching. If a foreign wrapper installed on
@@ -200,7 +212,13 @@ export async function inspectCollectorResponse(response: Response): Promise<Coll
   const hasReceipt = receipt !== null && WRITE_RECEIPT_FIELDS.every(
     (field) => typeof receipt?.[field] === 'string' && (receipt[field] as string).trim() !== '',
   );
-  if (!hasReceipt) return { kind: 'missing-receipt', status: response.status };
+  if (!hasReceipt) {
+    return {
+      kind: 'missing-receipt',
+      status: response.status,
+      ...(isBotFilteredBody(body) ? { botFiltered: true } : {}),
+    };
+  }
 
   return null;
 }
@@ -244,10 +262,64 @@ export function isRetryableIdentityFailure(failure: CollectorFailure): boolean {
   return failure.status !== undefined && RETRYABLE_IDENTITY_STATUSES.has(failure.status);
 }
 
+/**
+ * Failure kinds produced by the CLIENT's environment rather than the collector.
+ *
+ * A blocked request (uBlock/Brave/Pi-hole all block `abacus.`) and a dead
+ * collector are indistinguishable from inside one browser: both fail 100% of
+ * writes. Nothing computed on this page can separate them, so the outage signal
+ * is the AGGREGATE volume of these events across users, not any single one —
+ * which is exactly why each page is allowed at most one per health window
+ * below. Alerting on every occurrence buries the step change in the baseline.
+ */
+const ENVIRONMENT_NOISE_KINDS = new Set<CollectorFailure['kind']>(['network', 'timeout']);
+
+/**
+ * Minimum writes in the health window before an environment failure can alert.
+ *
+ * A page that has issued one or two writes and failed them says nothing — a
+ * single blocked beacon is the overwhelmingly common case. Requiring a real
+ * sample is what removes the ad-blocker baseline.
+ */
+const ENVIRONMENT_NOISE_MIN_WRITES = 5;
+
+/** Minimum in-window failure rate before an environment failure can alert. */
+const ENVIRONMENT_NOISE_MIN_FAILURE_RATE = 0.5;
+
+/**
+ * Whether a failure is worth a Sentry event, as opposed to merely worth a
+ * console warning.
+ *
+ * Extracted as a pure function of (failure, window) so the policy is testable
+ * without standing up the fetch gate, the deferred Sentry queue, and a real
+ * tracker — the wiring test then only has to prove this is the predicate the
+ * reporting path consults.
+ */
+export function isAlertWorthyCollectorFailure(
+  failure: CollectorFailure,
+  window: { writes: number; failures: number; noiseReported?: boolean },
+): boolean {
+  // Known, unfixed upstream race (umami#4183). Expected background condition.
+  if (isKnownSessionDataConflict(failure)) return false;
+  // The collector deliberately discarded a bot's write. Working as designed.
+  if (failure.botFiltered) return false;
+  if (ENVIRONMENT_NOISE_KINDS.has(failure.kind)) {
+    // At most one environment event per page per window. Without this, crossing
+    // the rate floor makes EVERY remaining failure in the window report, so one
+    // ad-blocked power user out-produces the incident the floor exists to show.
+    if (window.noiseReported) return false;
+    if (window.writes < ENVIRONMENT_NOISE_MIN_WRITES) return false;
+    return window.failures / window.writes >= ENVIRONMENT_NOISE_MIN_FAILURE_RATE;
+  }
+  // Everything left is actionable: a non-2xx from the origin, an unexplained
+  // receiptless 200, or a queue-overflow drop that is our own bug.
+  return true;
+}
+
 function recordCollectorOutcome(request: CollectorRequest, failure: CollectorFailure | null): void {
   const now = Date.now();
   if (collectorHealthWindow.startedAt === 0 || now - collectorHealthWindow.startedAt >= HEALTH_WINDOW_MS) {
-    collectorHealthWindow = { startedAt: now, writes: 0, failures: 0 };
+    collectorHealthWindow = { startedAt: now, writes: 0, failures: 0, noiseReported: false };
   }
   collectorHealthWindow.writes += 1;
 
@@ -272,14 +344,22 @@ function recordCollectorOutcome(request: CollectorRequest, failure: CollectorFai
     writeCount: collectorHealthWindow.writes,
     prismaCode: failure.prismaCode ?? null,
     constraint: failure.constraint ?? null,
+    // The console warning fires for suppressed failures too, so it has to say
+    // WHY a receiptless 200 happened — otherwise a developer reading devtools
+    // during a bot-filtered write starts debugging a write path that is fine.
+    botFiltered: failure.botFiltered ?? false,
   };
   console.warn('[Analytics] Umami collector write failed', diagnostics);
 
-  // A console warning in a user's devtools is not observable. The known #4183
-  // race is expected and would only add noise, but anything else is the signal
-  // this monitoring work exists to surface — route it the same way wm-session
-  // and checkout report their degraded writes so it aggregates on a dashboard.
-  if (isKnownSessionDataConflict(failure)) return;
+  // A console warning in a user's devtools is not observable, so genuine
+  // failures are routed to Sentry the same way wm-session and checkout report
+  // their degraded writes. But an alarm that fires on expected background
+  // conditions trains everyone to ignore it — the alert-fatigue path straight
+  // back to #5565, where a dead collector went unnoticed for four days. Only
+  // actionable failures get an event.
+  if (!isAlertWorthyCollectorFailure(failure, collectorHealthWindow)) return;
+  if (ENVIRONMENT_NOISE_KINDS.has(failure.kind)) collectorHealthWindow.noiseReported = true;
+
   try {
     enqueueSentryCall((s) => s.captureMessage('Umami collector write failed', {
       level: 'warning',
@@ -558,10 +638,18 @@ export function resetCollectorTransportForTesting(): void {
   collectorVisibilityFlush = null;
   collectorFetchOriginal = null;
   collectorFetchWrapper = null;
-  collectorHealthWindow = { startedAt: 0, writes: 0, failures: 0 };
+  collectorHealthWindow = { startedAt: 0, writes: 0, failures: 0, noiseReported: false };
 }
 
 /** Test-only: current rolling health window. */
-export function getCollectorHealthForTesting(): { writes: number; failures: number } {
-  return { writes: collectorHealthWindow.writes, failures: collectorHealthWindow.failures };
+export function getCollectorHealthForTesting(): {
+  writes: number;
+  failures: number;
+  noiseReported: boolean;
+} {
+  return {
+    writes: collectorHealthWindow.writes,
+    failures: collectorHealthWindow.failures,
+    noiseReported: collectorHealthWindow.noiseReported,
+  };
 }

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -216,16 +216,19 @@ function handleCollectorOutcome(outcome: CollectorOutcome): void {
   // race. Treating it as undelivered would replay the conversion on every boot
   // for the life of the tab — the duplicate the no-retry policy exists to stop.
   //
-  // The same reasoning generalises: ANY failure the retry policy refuses to
-  // re-send in-page must also be terminal for the durable marker. A 502/504 (or
-  // a 500 whose body carried no Prisma metadata to recognise) reached the origin
-  // and may have committed the row, and a receiptless 200 was accepted and
-  // discarded — none of them are retried, so leaving the marker armed would let
-  // the boot replay smuggle the event back in and duplicate the conversion that
-  // isRetryableCollectorFailure just declined to risk.
+  // The same reasoning generalises to the rest of the HTTP failures the retry
+  // policy refuses to re-send in-page: a 502/504 (or a 500 whose body carried no
+  // Prisma metadata to recognise) reached the origin and may have committed the
+  // row, so leaving the marker armed would let the boot replay smuggle the event
+  // back in and duplicate the conversion isRetryableCollectorFailure declined to
+  // risk.
   //
-  // A queue-overflow drop is the one exception: it never reached the network at
-  // all, so the marker must survive for the next boot to replay it.
+  // It does NOT generalise past that, which is why isDurableMarkerResolved keys
+  // off `kind === 'http'` and not off retryability. A queue-overflow, a network
+  // error, a timeout, and a receiptless 200 (including a bot-filtered one) all
+  // leave no row behind — never dispatched, never answered, or accepted and
+  // discarded — so for those the marker must SURVIVE and replay. That replay is
+  // a recovery, not a duplicate.
   if (!isDurableMarkerResolved(outcome.failure)) return;
 
   if (outcome.eventName === 'checkout-success') clearPendingCheckoutSuccessMarker();

--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -779,3 +779,167 @@ describe('Umami client retry policy (#5715)', () => {
     });
   });
 });
+
+const {
+  inspectCollectorResponse,
+  isRetryableCollectorFailure,
+  isRetryableIdentityFailure,
+  isAlertWorthyCollectorFailure,
+  getCollectorHealthForTesting,
+} = await import('../src/services/analytics-collector-transport.ts');
+
+/**
+ * A bot-filtered write is a REAL delivery failure — Umami stored nothing — but
+ * it is not an incident. It is the collector doing its job on traffic we do not
+ * want counted. The distinction has to live in the alerting decision, never in
+ * the delivery classification, or a suppressed alert silently becomes a
+ * suppressed retry and a cleared conversion marker.
+ */
+describe('bot-filtered collector writes (#5964 alert-noise regression)', () => {
+  const botBody = '{"beep":"boop"}';
+
+  it('flags a bot-filtered 200 without changing its delivery classification', async () => {
+    const failure = await inspectCollectorResponse(collectorResponse(true, 200, botBody));
+    assert.equal(failure?.kind, 'missing-receipt', 'the write really was dropped');
+    assert.equal(failure?.status, 200);
+    assert.equal(failure?.botFiltered, true);
+  });
+
+  it('does not flag a genuine receipt or an ordinary receiptless 200', async () => {
+    assert.equal(await inspectCollectorResponse(collectorResponse(true, 200, RECEIPT_BODY)), null);
+
+    const odd = await inspectCollectorResponse(collectorResponse(true, 200, '{"cache":"only"}'));
+    assert.equal(odd?.kind, 'missing-receipt');
+    assert.ok(!odd?.botFiltered, 'a non-sentinel receiptless 200 is still unexplained and must stay reportable');
+  });
+
+  it('leaves retry and durable-marker policy identical to a plain missing receipt', async () => {
+    const bot = (await inspectCollectorResponse(collectorResponse(true, 200, botBody)))!;
+    const plain = (await inspectCollectorResponse(collectorResponse(true, 200, '{}')))!;
+
+    // Both must stay non-retryable (a retry is filtered identically) and both
+    // must stay kind:'missing-receipt' so isDurableMarkerResolved keeps the
+    // conversion marker armed for replay. Diverging here would turn an alerting
+    // change into a conversion-accounting change.
+    assert.equal(isRetryableCollectorFailure(bot), isRetryableCollectorFailure(plain));
+    assert.equal(isRetryableIdentityFailure(bot), isRetryableIdentityFailure(plain));
+    assert.equal(isRetryableCollectorFailure(bot), false);
+    assert.equal(bot.kind, plain.kind);
+  });
+
+  it('never alerts on a bot-filtered write, at any failure rate', () => {
+    const bot = { kind: 'missing-receipt' as const, status: 200, botFiltered: true };
+    assert.equal(isAlertWorthyCollectorFailure(bot, { writes: 1, failures: 1 }), false);
+    assert.equal(isAlertWorthyCollectorFailure(bot, { writes: 500, failures: 500 }), false);
+  });
+
+  it('still alerts on an unexplained receiptless 200', () => {
+    const plain = { kind: 'missing-receipt' as const, status: 200 };
+    assert.equal(isAlertWorthyCollectorFailure(plain, { writes: 1, failures: 1 }), true);
+  });
+});
+
+describe('collector alert policy suppresses expected background conditions', () => {
+  const net = { kind: 'network' as const };
+  const timeout = { kind: 'timeout' as const };
+
+  it('stays silent for a lone blocked request — the ad-blocker baseline', () => {
+    // The overwhelmingly common shape: a page issues one or two writes and an
+    // extension blocks them. Nothing here indicates a collector problem.
+    assert.equal(isAlertWorthyCollectorFailure(net, { writes: 1, failures: 1 }), false);
+    assert.equal(isAlertWorthyCollectorFailure(net, { writes: 4, failures: 4 }), false);
+    assert.equal(isAlertWorthyCollectorFailure(timeout, { writes: 3, failures: 3 }), false);
+  });
+
+  it('reports once the window carries a real sample AND a real failure rate', () => {
+    assert.equal(isAlertWorthyCollectorFailure(net, { writes: 5, failures: 5 }), true);
+    assert.equal(isAlertWorthyCollectorFailure(timeout, { writes: 20, failures: 20 }), true);
+  });
+
+  it('stays silent when a big sample is mostly succeeding', () => {
+    // A collector that answers 80% of writes is not down; one flaky beacon in a
+    // healthy window must not page.
+    assert.equal(isAlertWorthyCollectorFailure(net, { writes: 100, failures: 20 }), false);
+    assert.equal(isAlertWorthyCollectorFailure(net, { writes: 10, failures: 4 }), false);
+    assert.equal(isAlertWorthyCollectorFailure(net, { writes: 10, failures: 5 }), true);
+  });
+
+  it('caps environment noise at one event per window', () => {
+    const saturated = { writes: 50, failures: 50 };
+    assert.equal(isAlertWorthyCollectorFailure(net, saturated), true);
+    assert.equal(
+      isAlertWorthyCollectorFailure(net, { ...saturated, noiseReported: true }),
+      false,
+      'a single ad-blocked page must not out-produce the outage it mimics',
+    );
+  });
+
+  it('always reports failures that are actionable, whatever the window', () => {
+    // These are never the client's environment: the origin answered non-2xx, or
+    // our own bounded queue dropped a write. One occurrence is worth knowing.
+    assert.equal(
+      isAlertWorthyCollectorFailure({ kind: 'http', status: 500 }, { writes: 1, failures: 1 }),
+      true,
+    );
+    assert.equal(
+      isAlertWorthyCollectorFailure({ kind: 'queue-overflow' }, { writes: 1, failures: 1 }),
+      true,
+    );
+    // ...and the cap never applies to them.
+    assert.equal(
+      isAlertWorthyCollectorFailure({ kind: 'http', status: 400 }, { writes: 50, failures: 50, noiseReported: true }),
+      true,
+    );
+  });
+
+  it('stays silent for the known umami#4183 session_data race', () => {
+    assert.equal(
+      isAlertWorthyCollectorFailure(
+        { kind: 'http', status: 500, prismaCode: 'P2002', constraint: 'session_data_pkey' },
+        { writes: 1, failures: 1 },
+      ),
+      false,
+    );
+  });
+});
+
+describe('collector alert policy is wired into the reporting path', () => {
+  beforeEach(() => {
+    resetAnalyticsForTesting();
+  });
+
+  afterEach(() => {
+    delete (globalThis.window as WinWithUmami).umami;
+  });
+
+  it('flips the once-per-window latch only after the sample floor is crossed', async () => {
+    // Drives REAL writes through the gate so this proves recordCollectorOutcome
+    // consults the predicate — a policy unit test alone would pass even if the
+    // reporting path ignored it entirely.
+    window.fetch = (() => Promise.reject(new TypeError('Failed to fetch'))) as typeof window.fetch;
+    stubFailingUmami();
+
+    // 'panel-open' is not a CRITICAL_TRACK_EVENT, so a network failure does not
+    // schedule a retry and each call is exactly one write.
+    const fire = async (n: number) => {
+      for (let i = 0; i < n; i += 1) {
+        track('panel-open' as Parameters<typeof track>[0], { i });
+        await drainPromiseHandlers();
+      }
+    };
+
+    await fire(4);
+    const below = getCollectorHealthForTesting();
+    assert.equal(below.writes, 4);
+    assert.equal(below.failures, 4);
+    assert.equal(below.noiseReported, false, 'four blocked beacons must not alert');
+
+    await fire(1);
+    assert.equal(getCollectorHealthForTesting().noiseReported, true, 'the fifth crosses the floor');
+
+    await fire(10);
+    const after = getCollectorHealthForTesting();
+    assert.equal(after.writes, 15, 'writes keep accruing');
+    assert.equal(after.noiseReported, true, 'the latch stays set — no second event this window');
+  });
+});

--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -943,3 +943,34 @@ describe('collector alert policy is wired into the reporting path', () => {
     assert.equal(after.noiseReported, true, 'the latch stays set — no second event this window');
   });
 });
+
+/**
+ * An alarm has to be attacked for the case it exists to catch: can it stay
+ * SILENT while the collector is actually dead? #5565 ran for four days unseen.
+ */
+describe('collector alert policy still fires when the collector is dead', () => {
+  it('alerts on the first 5xx, with no sample or rate floor to clear', () => {
+    // The #5565 shape: Railway origin OOM-dead, Cloudflare answers 502. This is
+    // kind:'http', so it is never subject to the environment-noise gating.
+    for (const status of [500, 502, 503, 504]) {
+      assert.equal(
+        isAlertWorthyCollectorFailure({ kind: 'http', status }, { writes: 1, failures: 1 }),
+        true,
+        `HTTP ${status} must alert immediately`,
+      );
+    }
+  });
+
+  it('alerts on a sustained total network failure once the floor is crossed', () => {
+    assert.equal(isAlertWorthyCollectorFailure({ kind: 'network' }, { writes: 5, failures: 5 }), true);
+  });
+
+  it('cannot be muted by a non-2xx body that mimics the bot sentinel', async () => {
+    // The suppression must be reachable ONLY through a 2xx. A proxy or a dead
+    // origin echoing {"beep":"boop"} with an error status is still an outage.
+    const failure = await inspectCollectorResponse(collectorResponse(false, 502, '{"beep":"boop"}'));
+    assert.equal(failure?.kind, 'http');
+    assert.ok(!failure?.botFiltered, 'a non-2xx must never be classified as bot-filtered');
+    assert.equal(isAlertWorthyCollectorFailure(failure!, { writes: 1, failures: 1 }), true);
+  });
+});

--- a/tests/analytics-collector-monitor.test.mjs
+++ b/tests/analytics-collector-monitor.test.mjs
@@ -8,6 +8,7 @@ import {
   buildProbeRequest,
   evaluateProbeResult,
   extractCollectorFailureMetadata,
+  isBotFilteredBody,
   runCollectorChecks,
   summarizeProbeFailures,
   summarizeWriteCanaryResults,
@@ -138,14 +139,38 @@ describe('scheduled analytics collector monitor', () => {
 
   it('rejects bot-filtered and malformed write-canary receipts despite HTTP 200', () => {
     const writeCanary = probeByName('write-canary-event');
+    // A bot-filtered 200 must be NAMED as such. Reporting it as a generic
+    // missing receipt blames the write path for a drop Umami made on purpose,
+    // which sends the on-call reader looking for a database fault that is not
+    // there. The canary sends a browser User-Agent, so this firing at all means
+    // the bot heuristic now matches us and the probe has stopped measuring the
+    // write path it claims to measure.
     assert.match(
       evaluateProbeResult(writeCanary, { status: 200, body: '{"beep":"boop"}' }),
-      /receipt missing non-empty string cache/,
+      /bot-filtered/,
     );
     assert.match(
       evaluateProbeResult(writeCanary, { status: 200, body: '{not json' }),
       /receipt was not valid JSON/,
     );
+  });
+
+  it('detects the Umami bot-filter sentinel without matching a real receipt', () => {
+    assert.equal(isBotFilteredBody('{"beep":"boop"}'), true);
+    assert.equal(isBotFilteredBody('  {"beep":"boop"}  '), true);
+    // A genuine receipt is never the sentinel, even if a field value happens to
+    // spell one of the sentinel's words — this must key off the parsed `beep`
+    // property, not a substring scan an upstream value could forge.
+    assert.equal(isBotFilteredBody(receiptBody), false);
+    assert.equal(
+      isBotFilteredBody(JSON.stringify({ cache: 'beep', sessionId: 'boop', visitId: 'v' })),
+      false,
+    );
+    assert.equal(isBotFilteredBody('{"beep":"something-else"}'), false);
+    assert.equal(isBotFilteredBody('{not json'), false);
+    assert.equal(isBotFilteredBody(''), false);
+    assert.equal(isBotFilteredBody(undefined), false);
+    assert.equal(isBotFilteredBody(null), false);
   });
 
   it('surfaces Prisma failure metadata without retaining the analytics payload', () => {


### PR DESCRIPTION
## Summary

The collector write alarm was paging on the collector working correctly. In its first 32 minutes in production it produced 45 Sentry warnings across 24 users, and caught zero instances of the umami#4183 `session_data` race it was built to detect. This makes it alert only on failures someone can act on.

61% of those events were HTTP **200 successes**. Umami answers a success status with a fixed sentinel body when its User-Agent bot check discards a write — the receipt check correctly saw "not stored" and the alarm incorrectly called it an incident. 23 of those 27 came from non-human traffic, 20 of them from our own VISION crawler hitting production pages. The remaining events were blocked requests from ad-blocked clients.

Analytics delivery was never affected. The regression is in signal quality, and it is the alert-fatigue path back toward a collector outage nobody notices.

## What changed

`isAlertWorthyCollectorFailure` is now the single policy the reporting path consults:

| Failure | Alerts? |
|---|---|
| Bot-filtered 200 | Never — the collector discarded it on purpose |
| Known umami#4183 race | Never (unchanged) |
| `network` / `timeout` | Only above a sample floor **and** a rate floor, capped at one per page per health window |
| Non-2xx, unexplained receiptless 200, `queue-overflow` | Always, first occurrence |

`console.warn` still fires for every failure and now carries `botFiltered`, so suppression is Sentry-only — a developer in devtools during a bot-filtered write no longer starts debugging a healthy write path.

## Design decisions worth reviewing

**`botFiltered` is a marker on `CollectorFailure`, deliberately not a new `kind`.** The write really was dropped, so `isRetryableCollectorFailure` and `isDurableMarkerResolved` must keep treating it exactly like any other receiptless 200. Promoting it to a `kind` would silently change both and turn an alerting fix into a conversion-accounting change. `onCollectorOutcome` (the durable-marker path) runs before the Sentry gate, so suppression cannot reach conversions.

**The per-window cap is load-bearing, not tidiness.** An ad-blocked client and a dead collector are indistinguishable from inside one browser — both fail 100% of writes, and nothing computable on the page separates them. So the outage signal is aggregate volume across users, not any single event. Without the cap, crossing the rate floor makes every remaining failure in that window report, and one ad-blocked power user outproduces the incident the floor exists to expose.

**The bot sentinel lives in `shared/collector-failure-metadata.js`,** whose own header says divergence between the CI monitor and the browser transport is what it exists to prevent. Both surfaces now agree on what a dropped write looks like. It keys off the parsed `beep` property rather than a substring scan — receipt field values are upstream-controlled, so `body.includes('beep')` would let one forge a bot verdict and mute a genuine failure.

**One comment correction, no behavior change.** `handleCollectorOutcome` claimed a receiptless 200 is terminal for the durable marker; `isDurableMarkerResolved` keys off `kind === 'http'` and does the opposite. The code is right — a discarded write leaves no row, so its replay is a recovery, not a duplicate — and the comment now says so.

## Validation

Root cause was confirmed by probing the production collector directly against the monitor-only canary website, not inferred. Umami returns a full receipt for every request shape (`event` and `identify`, with and without a client `id`, with and without `x-umami-cache`); only the User-Agent changes the answer:

```
real Chrome      status=200 bodyLen=419 body={"cache":"eyJhbGciOi...
HeadlessChrome   status=200 bodyLen=15  body={"beep":"boop"}
```

Three plausible alternatives were probed and disproved before landing on the UA: an `event`-vs-`identify` receipt-shape difference, a thinner body once the tracker holds an `x-umami-cache` token, and an unreadable cross-origin body.

An alarm has to be attacked from both directions, so the suite locks that it still fires when the collector is dead: a 5xx alerts on first occurrence with no floor to clear, and the bot-filter suppression is reachable only through a 2xx — a dead origin echoing the sentinel with an error status is still an outage.

Every guard was mutation-tested rather than assumed. Six mutants — substring-scan detector, always-false detector, latch never set, sample floor lowered to 1, predicate not consulted, and the sentinel check leaking past the `!response.ok` branch — each turned the suite red on the test that owns it.

Checks: `typecheck` clean; transport suite 33/33; collector monitor suite 17/17; 5 adjacent analytics/checkout suites green (45 tests); biome + safe-html clean on changed files; full pre-push tiered gate passed (240 edge tests, markdown lint, version sync).

## Post-Deploy Monitoring & Validation

- **Watch:** Sentry issue `Umami collector write failed` — both total volume and the `failureKind` / `botFiltered` breakdown, since the shape should change and not merely shrink. Confirm `P2002` / `session_data_pkey` remain absent org-wide, and that the scheduled collector-monitor job stays green.
- **Healthy:** event volume near zero in steady state, `botFiltered: true` events gone entirely, Umami event volume in the Postgres Umami DB unchanged (this touches alerting, not delivery).
- **Failure signals:** volume unchanged means the gate is not being consulted; volume at exactly zero through a known collector disruption means over-suppression — verify with a deliberate 5xx, which is ungated by design.
- **Window/owner:** a ~1h pass and a ~24h pass (the second is what catches a low-traffic false quiet), owned by whoever merges. Rollback is a plain revert; no migration, no config.
- **Re-check at 24h:** residual `network` volume is the surviving ad-blocker baseline, not a bug — but it is the number to tune the sample and rate floors against, since no baseline existed when they were chosen.

## Related

- Fixes #5973
- Related: #5964, #5715, #5565
- Upstream: umami-software/umami#4183

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
