### PR TITLE
fix(analytics): gate receiptless-200 collector alerts on aggregate floors

### DIFF
--- a/src/services/analytics-collector-transport.ts
+++ b/src/services/analytics-collector-transport.ts
@@ -267,12 +267,20 @@ export function isRetryableIdentityFailure(failure: CollectorFailure): boolean {
  *
  * A blocked request (uBlock/Brave/Pi-hole all block `abacus.`) and a dead
  * collector are indistinguishable from inside one browser: both fail 100% of
- * writes. Nothing computed on this page can separate them, so the outage signal
- * is the AGGREGATE volume of these events across users, not any single one —
- * which is exactly why each page is allowed at most one per health window
- * below. Alerting on every occurrence buries the step change in the baseline.
+ * writes. The same holds for a non-bot-filtered receiptless 200: privacy
+ * middleware that answers a faked 200 for a tracker endpoint, and a response
+ * whose body cannot be read, both look exactly like a collector that accepted
+ * and discarded the write. Verified in production 2026-08-01 (WORLDMONITOR-Y3):
+ * receiptless-200 reports arrived at ~16/hour from diverse real browsers while
+ * the Umami DB was ingesting 15-23k events/hour and every probe shape returned
+ * a full receipt. Nothing computed on this page can separate them, so the
+ * outage signal is the AGGREGATE volume of these events across users, not any
+ * single one — which is exactly why each page is allowed at most one per health
+ * window below. Alerting on every occurrence buries the step change in the
+ * baseline. (A bot-filtered 200 never reaches this set — it is suppressed
+ * outright before the gate.)
  */
-const ENVIRONMENT_NOISE_KINDS = new Set<CollectorFailure['kind']>(['network', 'timeout']);
+const ENVIRONMENT_NOISE_KINDS = new Set<CollectorFailure['kind']>(['network', 'timeout', 'missing-receipt']);
 
 /**
  * Minimum writes in the health window before an environment failure can alert.
@@ -324,8 +332,8 @@ export function isAlertWorthyCollectorFailure(
     if (window.writes < ENVIRONMENT_NOISE_MIN_WRITES) return false;
     return window.failures / window.writes >= ENVIRONMENT_NOISE_MIN_FAILURE_RATE;
   }
-  // Everything left is actionable: a non-2xx from the origin, an unexplained
-  // receiptless 200, or a queue-overflow drop that is our own bug.
+  // Everything left is actionable: a non-2xx from the origin, or a
+  // queue-overflow drop that is our own bug.
   return true;
 }
 

--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -833,9 +833,22 @@ describe('bot-filtered collector writes (#5964 alert-noise regression)', () => {
     assert.equal(isAlertWorthyCollectorFailure(bot, { writes: 500, failures: 500 }), false);
   });
 
-  it('still alerts on an unexplained receiptless 200', () => {
+  it('gates an unexplained receiptless 200 behind the aggregate floors', () => {
+    // 2026-08-01 (WORLDMONITOR-Y3): receiptless-200 reports arrived at ~16/hour
+    // from diverse real browsers while the Umami DB was ingesting 15-23k
+    // events/hour and every probe shape returned a full receipt. From inside
+    // one page, privacy middleware faking a 200 — or a body that cannot be
+    // read — is indistinguishable from a discarding collector: the same
+    // epistemics as a blocked request, so it gets the same aggregate gate.
     const plain = { kind: 'missing-receipt' as const, status: 200 };
-    assert.equal(isAlertWorthyCollectorFailure(plain, { writes: 1, failures: 1 }), true);
+    assert.equal(isAlertWorthyCollectorFailure(plain, { writes: 1, failures: 1 }), false);
+    assert.equal(isAlertWorthyCollectorFailure(plain, { writes: 100, failures: 20 }), false);
+    assert.equal(isAlertWorthyCollectorFailure(plain, { writes: 5, failures: 5 }), true);
+    assert.equal(
+      isAlertWorthyCollectorFailure(plain, { writes: 5, failures: 5, noiseReported: true }),
+      false,
+      'shares the once-per-window cap with the other environment kinds',
+    );
   });
 });
 
@@ -963,6 +976,15 @@ describe('collector alert policy still fires when the collector is dead', () => 
 
   it('alerts on a sustained total network failure once the floor is crossed', () => {
     assert.equal(isAlertWorthyCollectorFailure({ kind: 'network' }, { writes: 5, failures: 5 }), true);
+  });
+
+  it('alerts on a collector that discards every write once the floor is crossed', () => {
+    // The other way an outage can look green: Umami up and answering 200 but
+    // storing nothing (a deleted website row, an isbot update swallowing real
+    // browsers). Each affected page crosses the floor and reports once per
+    // window, so the cross-user step change stays visible in the aggregate.
+    const plain = { kind: 'missing-receipt' as const, status: 200 };
+    assert.equal(isAlertWorthyCollectorFailure(plain, { writes: 10, failures: 10 }), true);
   });
 
   it('cannot be muted by a non-2xx body that mimics the bot sentinel', async () => {


### PR DESCRIPTION
## Summary

Sentry [WORLDMONITOR-Y3](https://elie-habib.sentry.io/issues/7646416474/) kept receiving `missing-receipt` collector warnings (~6/hour, `botFiltered: false`, diverse real browsers and OSes) after #5974's noise gate went live — while the collector was provably healthy. Verified in production on 2026-08-01: the Umami DB ingested 15–23k events/hour with no dip through the alert window, and direct probes of every browser write shape (pageview, named event, with `x-umami-cache`, `identify`) returned a full `{cache, sessionId, visitId}` receipt, with the probe rows confirmed in `website_event`.

A non-bot receiptless 200 observed from a single page is therefore client-environmental — privacy middleware answering a faked 200 for a tracker endpoint, or a response body that could not be read (`inspectCollectorResponse` degrades an unreadable body to `''`, which then fails the receipt parse). From inside one browser that is indistinguishable from a discarding collector: the same epistemics the policy already applies to blocked requests. So `missing-receipt` now rides the same aggregate gate — ≥5 writes in the health window, ≥50% failure rate, one event per page per window — instead of alerting on every occurrence and burying a real step change in ambient baseline.

A collector that genuinely discards every write still alerts: each affected page crosses the floor and reports once per window, so the cross-user aggregate step change stays visible (locked by a new alarm-attack test). Bot-filter suppression, retry policy, and the durable conversion marker are untouched — this is an alerting-only change, per the `botFiltered` invariant note in the failure type.

Fixes #5978.

Related: #5964, #5974

## Validation

- New gating assertion confirmed red against the pre-fix policy, then 34/34 green in `tests/analytics-beacon-rejection.test.mts`.
- Mutation-tested: removing `'missing-receipt'` from `ENVIRONMENT_NOISE_KINDS` reds exactly the new gating test, while the discard-attack test stays green under the mutant — it bounds the blast radius rather than proving the fix.
- `tsc --noEmit` clean; full pre-push gate passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_01YFEsJigrTBSuKcRLa3qrMy
