### PR TITLE
fix(analytics): harden Umami collector write-path acceptance

### DIFF
--- a/.github/workflows/umami-storage-monitor.yml
+++ b/.github/workflows/umami-storage-monitor.yml
@@ -1,0 +1,67 @@
+name: Umami Storage Monitor
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: umami-storage-monitor
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: ingestion-acceptance-production
+      deployment: false
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+
+      - name: Install pinned Railway CLI
+        run: npm install --global @railway/cli@5.30.1
+
+      - name: Restore bounded storage history
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: .cache/umami-storage-state.json
+          key: umami-storage-${{ github.run_id }}
+          restore-keys: umami-storage-
+
+      - name: Verify Railway production context
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "$RAILWAY_TOKEN" ]; then
+            echo "::error::RAILWAY_PRODUCTION_TOKEN is required for the read-only storage monitor."
+            exit 1
+          fi
+          if [ -z "$RAILWAY_PROJECT_ID" ]; then
+            echo "::error::RAILWAY_PROJECT_ID is required for the read-only storage monitor."
+            exit 1
+          fi
+          railway status --project "$RAILWAY_PROJECT_ID" --environment production --json > /dev/null
+
+      - name: Read Umami Postgres volume usage
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+          mkdir -p .cache
+          railway volume --project "$RAILWAY_PROJECT_ID" --environment production list --json > .cache/railway-volumes.json
+
+      - name: Check capacity and projected headroom
+        env:
+          UMAMI_POSTGRES_SERVICE_NAME: Postgres Umami
+        run: node scripts/check-umami-storage.mjs --input .cache/railway-volumes.json --state .cache/umami-storage-state.json

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -372,6 +372,7 @@ Runs before every `git push`:
 | `security-audit.yml` | PR, push to main, daily cron, manual | Production dependency audits for every tracked `package-lock.json` workspace, failing on unbaselined high/critical advisories |
 | `seed-freshness-monitor.yml` | 15-minute cron, manual | Enforces production ingestion acceptance after a green scheduled main gate; fails on every actionable compact-health problem except explicitly on-demand sources without grading production before Railway deploys or runs |
 | `analytics-collector-monitor.yml` | 15-minute cron, manual | Probes the self-hosted Umami collector directly (heartbeat, tracker script, ingest route) and fails when events are being dropped — Railway reported a green deployment through the 4-day #5565 blackout, so deployment status is not trusted here |
+| `umami-storage-monitor.yml` | 15-minute cron, manual | Reads the Umami Postgres Railway volume without mutation, caches a bounded history, and fails on capacity or projected days-to-full thresholds |
 | `contributor-trust.yml` | PR | Gates untrusted first-time-contributor runs |
 | `deploy-gate.yml` | After Test/Typecheck/Security Audit complete | Aggregates required smoke-gate statuses onto the head SHA for branch protection |
 | `indexnow-submit.yml` | Successful Production deployment, manual | Submits deployment-relevant canonical URLs to IndexNow only after their host-specific ownership keys are directly reachable |

--- a/docs/analytics-collector-operations.md
+++ b/docs/analytics-collector-operations.md
@@ -1,0 +1,65 @@
+---
+title: "Analytics Collector Operations"
+description: "Operational contracts for the self-hosted Umami collector, its write canary, and its bounded Postgres retention policy."
+---
+
+# Analytics Collector Operations
+
+World Monitor sends product analytics to the separately deployed Railway
+`umami` service. Railway deployment status is not an application write-path
+health signal: a healthy deployment can still return HTTP 500 from `POST
+/api/send`.
+
+## Write-path contract
+
+- The Umami service must run an image built from upstream [commit `7c030e4`](https://github.com/umami-software/umami/commit/7c030e4) or
+  a later commit that contains both the composite `(session_id, data_key)`
+  unique index and the `ON CONFLICT` upsert for `session_data`. A version label
+  alone is insufficient; verify the deployed image/digest and schema/index.
+  The upgrade is an external Railway operation because its migration removes
+  duplicate `session_data` rows before creating the unique index.
+- The scheduled write canary sends 12 attempts per run: three synchronized
+  bursts of a pageview, a named event, and two concurrent `identify` writes
+  sharing one session-data key.
+- Every attempt must return a real Umami receipt (`cache`, `sessionId`, and
+  `visitId`). Any failed attempt, including `P2002/session_data_pkey`, fails the
+  monitor. A green heartbeat or a green Railway deployment does not override a
+  red write canary.
+- Acceptance after a server upgrade is two consecutive scheduled runs with
+  `12/12` accepted writes and zero `P2002` failures. Attach the exact deployed
+  image/digest and the bounded production log query to the issue.
+- During normal queue draining, browser writes are serialized through one
+  in-flight transport slot. `pagehide` deliberately dispatches queued writes
+  concurrently so keepalive delivery gets a chance to finish. The client does
+  not blindly retry append-only conversion events after an ambiguous 5xx;
+  identity snapshots may use their idempotent retry policy.
+
+## Retention contract
+
+The relational analytics tables retain 90 days of raw data. A controlled daily
+maintenance job runs [`scripts/umami-retention.sql`](../scripts/umami-retention.sql)
+once per tick; it never loops inside one invocation. Each delete is capped at
+10,000 rows, session-replay payloads are capped at 64 MiB per invocation, and
+oversized replay rows are left for operator handling rather than force-deleted.
+Child rows are deleted before parent rows, and a transaction-level advisory lock
+prevents overlapping jobs. The job must not use `TRUNCATE` or an unbounded
+`DELETE`.
+
+The contract preserves website configuration and saved replay definitions.
+Before enabling the job, take a database backup and verify the table names
+against the deployed Umami schema. The SQL is intentionally not called by the
+browser, the Vercel API, or the storage monitor.
+
+## Capacity alert
+
+`.github/workflows/umami-storage-monitor.yml` reads the Railway volume list
+without mutating Railway or Postgres. It caches at most 30 days of samples and
+fails the workflow when either condition is true:
+
+- current usage is at least 80% (warning) or 90% (critical); or
+- projected days to full are at most 30 (warning) or 14 (critical), once a
+  24-hour growth baseline exists.
+
+The monitor prints only volume size, growth, and projected headroom. It never
+prints Railway variables, database URLs, analytics payloads, or user identity
+fields.

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -72,9 +72,10 @@
     "seed-freshness-monitor.yml",
     "test-linux-app.yml",
     "test.yml",
-    "typecheck.yml"
+    "typecheck.yml",
+    "umami-storage-monitor.yml"
   ],
-  "workflowCount": 25,
+  "workflowCount": 26,
   "freshnessSources": 35,
   "freshnessRequiredForRisk": 2,
   "feedDefinitions": 601,

--- a/docs/solutions/integration-issues/umami-answers-http-200-when-it-drops-a-bot-write.md
+++ b/docs/solutions/integration-issues/umami-answers-http-200-when-it-drops-a-bot-write.md
@@ -19,6 +19,11 @@ tags: [umami, analytics, sentry, alerting, alert-fatigue, bot-filter, observabil
 
 # Umami answers HTTP 200 when it drops a bot write, and the alarm built on it paged on its own crawler
 
+> Historical note: this document records the bot-filter regression fixed by
+> #5964/#5974. The collector's separate `session_data_pkey` race recurred after
+> that work and reopened #5715 on 2026-08-01; the current remediation and
+> acceptance contract are in [`docs/analytics-collector-operations.md`](../../analytics-collector-operations.md).
+
 ## Problem
 
 PR #5964 added a browser-side Sentry warning for every Umami collector write failure. It fired 45 events across 24 users in its first 32 minutes and caught **zero** instances of the umami#4183 `session_data` race it was built to detect. Most of the "failures" were HTTP 200 successes, and most of those came from WorldMonitor's own crawler.
@@ -70,16 +75,20 @@ export function isAlertWorthyCollectorFailure(
   failure: CollectorFailure,
   window: CollectorHealthSnapshot,
 ): boolean {
-  if (isKnownSessionDataConflict(failure)) return false;  // known umami#4183
   if (failure.botFiltered) return false;                  // dropped on purpose
   if (ENVIRONMENT_NOISE_KINDS.has(failure.kind)) {        // network | timeout
     if (window.noiseReported) return false;               // 1 per page per window
     if (window.writes < ENVIRONMENT_NOISE_MIN_WRITES) return false;
     return window.failures / window.writes >= ENVIRONMENT_NOISE_MIN_FAILURE_RATE;
   }
-  return true;  // non-2xx, unexplained receiptless 200, queue-overflow
+  return true;  // non-2xx, P2002, unexplained 200, queue-overflow
 }
 ```
+
+The original #5964 policy also suppressed the known Umami #4183 uniqueness
+race. That suppression was intentionally removed when #5715 was reopened: the
+server-side race is now an acceptance failure until the upstream upsert fix is
+deployed and two scheduled canary windows are clean.
 
 `botFiltered` is a **marker on `CollectorFailure`, deliberately not a new `kind`**. The write really was dropped, so `isRetryableCollectorFailure` and `isDurableMarkerResolved` must keep treating it exactly like any other receiptless 200. Promoting it to a `kind` would have turned an alert-noise fix into a conversion-accounting change.
 
@@ -118,7 +127,8 @@ The rate gate matters for a reason worth stating plainly: **an ad-blocked client
 ## Related Issues
 
 - #5973 — tracking issue for this regression
-- #5964 — the PR that introduced the alarm (and fixed the real #5715 write-path gap)
+- #5964 — the PR that introduced the alarm and corrected its receipt semantics
 - #5715 — collector 500s dropping checkout conversions
 - #5565 — collector dead 4 days, unnoticed; the alert-fatigue endpoint this fix exists to avoid
-- umami-software/umami#4183 — the unfixed upstream `session_data` race
+- umami-software/umami#4183 — the upstream `session_data` race, fixed by
+  upstream commit `7c030e4` but still pending deployment and verification here

--- a/scripts/check-analytics-collector.mjs
+++ b/scripts/check-analytics-collector.mjs
@@ -15,12 +15,12 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { realpathSync } from 'node:fs';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { isMainModule } from './lib/main-module.mjs';
 
 import {
   extractCollectorFailureMetadata,
   isBotFilteredBody,
+  WRITE_RECEIPT_FIELDS,
 } from '../shared/collector-failure-metadata.js';
 
 export { extractCollectorFailureMetadata, isBotFilteredBody };
@@ -50,7 +50,6 @@ const BROWSER_USER_AGENT =
 const REQUEST_TIMEOUT_MS = 20_000;
 const ATTEMPTS = 3;
 const RETRY_DELAY_MS = 3_000;
-const WRITE_RECEIPT_FIELDS = Object.freeze(['cache', 'sessionId', 'visitId']);
 
 /**
  * Write canaries are fired as synchronized BURSTS, not through the liveness
@@ -61,18 +60,6 @@ const WRITE_RECEIPT_FIELDS = Object.freeze(['cache', 'sessionId', 'visitId']);
  */
 const WRITE_CANARY_BURSTS = 3;
 const WRITE_BURST_DELAY_MS = 3_000;
-
-/**
- * Alert threshold for the attempt-level write failure rate.
- *
- * Umami #4183 is unfixed upstream and produced a 4-8% background failure rate
- * in production, so alerting on any single failure would page on a known,
- * accepted condition and train everyone to ignore this monitor — the alert
- * fatigue path back to #5565. This sits above that band so a step change pages
- * while the known race does not. Tune once a baseline exists in the job logs;
- * the rate is printed on every run precisely so the baseline is observable.
- */
-const WRITE_FAILURE_ALERT_RATE = 0.25;
 
 const ANALYTICS_CANARY_PAYLOAD = Object.freeze({
   website: ANALYTICS_CANARY_WEBSITE_ID,
@@ -363,10 +350,12 @@ export async function runCollectorChecks({
   const livenessFailures = summarizeProbeFailures(livenessProbes, resultsByName);
   const writeSummary = summarizeWriteCanaryResults(writeRun.attempts);
 
-  // A write path that is entirely down is the #5565 class and pages regardless
-  // of the rate threshold, which exists only to tolerate the known #4183 race.
+  // The write canary is the acceptance gate for #5715: the collector must
+  // accept every realistic POST in every burst. A single P2002 or other failed
+  // write is actionable; the rate remains in the report for diagnosis, not as
+  // a tolerance band for a known database race.
   const writePathDead = writeSummary.total > 0 && writeSummary.failed === writeSummary.total;
-  const writeRateBreached = writeSummary.failureRate > WRITE_FAILURE_ALERT_RATE;
+  const hasWriteFailures = writeSummary.failed > 0;
 
   return {
     origin,
@@ -374,8 +363,8 @@ export async function runCollectorChecks({
     livenessFailures,
     writeSummary,
     writePathDead,
-    writeRateBreached,
-    alerting: livenessFailures.length > 0 || writePathDead || writeRateBreached,
+    hasWriteFailures,
+    alerting: livenessFailures.length > 0 || hasWriteFailures,
   };
 }
 
@@ -403,9 +392,9 @@ function reportCollectorChecks(report) {
   }
   if (report.writePathDead) {
     console.error('- Write path is fully down: every canary attempt failed.');
-  } else if (report.writeRateBreached) {
+  } else if (report.hasWriteFailures) {
     console.error(
-      `- Write failure rate ${writeRate} exceeds the ${(WRITE_FAILURE_ALERT_RATE * 100).toFixed(0)}% threshold (known Umami #4183 baseline is 4-8%).`,
+      `- Write canary has ${writeSummary.failed}/${writeSummary.total} failed attempts; any failed POST is actionable after #5715 remediation.`,
     );
   }
   // Deduplicate by reason so a race that hits every burst reads as one line.
@@ -426,15 +415,7 @@ async function main() {
   if (report.alerting) process.exitCode = 1;
 }
 
-// realpath BOTH sides: through a symlinked checkout Node sets import.meta.url
-// to the realpath while argv[1] keeps the symlink, and the naive comparison
-// silently no-ops the whole monitor (exit 0, nothing checked).
-const isMainModule =
-  Boolean(process.argv[1]) &&
-  pathToFileURL(realpathSync(process.argv[1])).href ===
-    pathToFileURL(realpathSync(fileURLToPath(import.meta.url))).href;
-
-if (isMainModule) {
+if (isMainModule(import.meta.url, process.argv[1])) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/scripts/check-umami-storage.mjs
+++ b/scripts/check-umami-storage.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+/**
+ * Read-only capacity and growth check for the Railway Postgres volume backing
+ * the external Umami service.
+ *
+ * Railway exposes the current volume size through `railway volume list`. The
+ * scheduled workflow supplies that JSON and caches a bounded sample history so
+ * this check can alert on projected days-to-full as well as absolute usage.
+ * It never connects to Postgres and never deletes data.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import { parseArgs as parseNodeArgs } from 'node:util';
+
+import { isMainModule } from './lib/main-module.mjs';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+export const UMAMI_STORAGE_POLICY = Object.freeze({
+  serviceName: 'Postgres Umami',
+  historyDays: 30,
+  minimumProjectionWindowMs: DAY_MS,
+  warningUsageRatio: 0.8,
+  criticalUsageRatio: 0.9,
+  warningHeadroomDays: 30,
+  criticalHeadroomDays: 14,
+});
+
+function finiteNonNegative(value) {
+  const number = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(number) && number >= 0 ? number : null;
+}
+
+function timestampMs(value) {
+  const valueMs = typeof value === 'number'
+    ? value
+    : value instanceof Date
+      ? value.getTime()
+      : Date.parse(String(value));
+  return Number.isFinite(valueMs) ? valueMs : null;
+}
+
+function volumeIdentity(volume) {
+  const identity = volume?.id ?? volume?.volumeId ?? volume?.name ?? volume?.serviceName;
+  return identity === null || identity === undefined ? null : String(identity);
+}
+
+function unwrapCollection(value) {
+  if (Array.isArray(value)) return value;
+  if (!value || typeof value !== 'object') return [];
+  if (Array.isArray(value.edges)) return value.edges.map((edge) => edge?.node ?? edge);
+  if (Array.isArray(value.nodes)) return value.nodes;
+  return [];
+}
+
+export function normalizeVolumeRows(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (!payload || typeof payload !== 'object') return [];
+  return unwrapCollection(payload.volumes ?? payload);
+}
+
+function normalizeSamples(samples, nowMs) {
+  if (!Array.isArray(samples)) return [];
+  const cutoff = nowMs - UMAMI_STORAGE_POLICY.historyDays * DAY_MS;
+  return samples
+    .map((sample) => {
+      const sampledAtMs = timestampMs(sample?.sampledAt);
+      const currentSizeMB = finiteNonNegative(sample?.currentSizeMB);
+      if (sampledAtMs === null || currentSizeMB === null) return null;
+      if (sampledAtMs < cutoff || sampledAtMs > nowMs) return null;
+      return {
+        sampledAt: new Date(sampledAtMs).toISOString(),
+        currentSizeMB,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => Date.parse(a.sampledAt) - Date.parse(b.sampledAt));
+}
+
+export function updateStorageState(previousState, volume, now = Date.now()) {
+  const nowMs = timestampMs(now);
+  if (nowMs === null) throw new Error('Storage sample time must be a valid timestamp');
+  const capacityMB = finiteNonNegative(volume?.sizeMB);
+  if (capacityMB === null || capacityMB <= 0) throw new Error('Umami volume sizeMB must be greater than zero');
+  const currentSizeMB = finiteNonNegative(volume?.currentSizeMB);
+  if (currentSizeMB === null) throw new Error('Umami volume currentSizeMB must be a non-negative number');
+  const identity = volumeIdentity(volume);
+  if (identity === null) throw new Error('Umami volume must have a stable identity');
+
+  const priorCapacityMB = finiteNonNegative(previousState?.capacityMB);
+  const sameVolume = previousState?.volumeIdentity === identity && priorCapacityMB === capacityMB;
+  const samples = (sameVolume ? normalizeSamples(previousState?.samples, nowMs) : [])
+    .filter((sample) => Date.parse(sample.sampledAt) !== nowMs);
+  samples.push({ sampledAt: new Date(nowMs).toISOString(), currentSizeMB });
+  return { version: 1, volumeIdentity: identity, capacityMB, samples };
+}
+
+export function evaluateUmamiStorage({ volume, samples = [], now = Date.now() }) {
+  const nowMs = timestampMs(now);
+  const capacityMB = finiteNonNegative(volume?.sizeMB);
+  const currentSizeMB = finiteNonNegative(volume?.currentSizeMB);
+  if (nowMs === null) throw new Error('Storage evaluation time must be a valid timestamp');
+  if (capacityMB === null || capacityMB <= 0) throw new Error('Umami volume sizeMB must be greater than zero');
+  if (currentSizeMB === null) throw new Error('Umami volume currentSizeMB must be a non-negative number');
+  if (volume.status !== 'Ready') throw new Error(`Umami volume is not ready: ${volume.status ?? 'unknown'}`);
+
+  const usageRatio = currentSizeMB / capacityMB;
+  const history = normalizeSamples(samples, nowMs);
+  const baseline = history
+    .filter((sample) => nowMs - Date.parse(sample.sampledAt) >= UMAMI_STORAGE_POLICY.minimumProjectionWindowMs)
+    .at(-1);
+
+  let growthMBPerDay = null;
+  let projectedHeadroomDays = null;
+  if (baseline) {
+    const elapsedDays = (nowMs - Date.parse(baseline.sampledAt)) / DAY_MS;
+    const growthMB = currentSizeMB - baseline.currentSizeMB;
+    if (elapsedDays > 0 && growthMB > 0) {
+      growthMBPerDay = growthMB / elapsedDays;
+      const remainingMB = Math.max(0, capacityMB - currentSizeMB);
+      projectedHeadroomDays = remainingMB / growthMBPerDay;
+    } else {
+      growthMBPerDay = 0;
+      projectedHeadroomDays = Infinity;
+    }
+  }
+
+  const critical = usageRatio >= UMAMI_STORAGE_POLICY.criticalUsageRatio
+    || (projectedHeadroomDays !== null && projectedHeadroomDays <= UMAMI_STORAGE_POLICY.criticalHeadroomDays);
+  const warning = critical || usageRatio >= UMAMI_STORAGE_POLICY.warningUsageRatio
+    || (projectedHeadroomDays !== null && projectedHeadroomDays <= UMAMI_STORAGE_POLICY.warningHeadroomDays);
+
+  return {
+    serviceName: volume.serviceName ?? null,
+    volumeName: volume.name ?? null,
+    capacityMB,
+    currentSizeMB,
+    usagePercent: usageRatio * 100,
+    growthMBPerDay,
+    projectedHeadroomDays,
+    status: critical ? 'critical' : warning ? 'warning' : 'healthy',
+    alerting: warning,
+  };
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function findUmamiVolume(rows, serviceName = UMAMI_STORAGE_POLICY.serviceName) {
+  const matches = rows.filter((row) => row?.serviceName === serviceName);
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one Railway volume for ${serviceName}, found ${matches.length}`);
+  }
+  return matches[0];
+}
+
+function writeState(path, state) {
+  mkdirSync(dirname(path), { recursive: true });
+  const temporaryPath = `${path}.tmp-${process.pid}`;
+  writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+  renameSync(temporaryPath, path);
+}
+
+function formatDays(value) {
+  return value === null ? 'unavailable' : Number.isFinite(value) ? `${value.toFixed(1)} days` : 'no growth';
+}
+
+export function parseArguments(argv) {
+  const { values } = parseNodeArgs({
+    args: argv,
+    options: {
+      input: { type: 'string' },
+      state: { type: 'string' },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  return values;
+}
+
+export function runUmamiStorageCheck({ payload, state = { version: 1, samples: [] }, now = Date.now() } = {}) {
+  const rows = normalizeVolumeRows(payload);
+  const volume = findUmamiVolume(rows, process.env.UMAMI_POSTGRES_SERVICE_NAME || UMAMI_STORAGE_POLICY.serviceName);
+  const nextState = updateStorageState(state, volume, now);
+  const result = evaluateUmamiStorage({ volume, samples: nextState.samples, now });
+  return { result, state: nextState };
+}
+
+async function main() {
+  const args = parseArguments(process.argv.slice(2));
+  const inputPath = args.input || process.env.UMAMI_STORAGE_INPUT;
+  const statePath = args.state || process.env.UMAMI_STORAGE_STATE || '.cache/umami-storage-state.json';
+  if (!inputPath) throw new Error('Provide Railway volume JSON with --input <path> or UMAMI_STORAGE_INPUT');
+
+  const payload = readJson(inputPath);
+  const previousState = existsSync(statePath) ? readJson(statePath) : { version: 1, samples: [] };
+  const { result, state } = runUmamiStorageCheck({ payload, state: previousState });
+  writeState(statePath, state);
+
+  const growth = result.growthMBPerDay === null
+    ? 'growth baseline unavailable'
+    : `${(result.growthMBPerDay / 1024).toFixed(3)} GiB/day`;
+  console.log(
+    `Umami storage ${result.status}: ${result.currentSizeMB.toFixed(1)}/${result.capacityMB.toFixed(1)} MB `
+      + `(${result.usagePercent.toFixed(1)}% used), ${growth}, `
+      + `projected headroom ${formatDays(result.projectedHeadroomDays)}.`,
+  );
+  if (result.status === 'critical') {
+    console.error('::error::Umami Postgres storage is at a critical capacity or projected-headroom threshold.');
+    process.exitCode = 1;
+  } else if (result.status === 'warning') {
+    console.error('::warning::Umami Postgres storage needs retention or capacity action before the next threshold.');
+    process.exitCode = 1;
+  }
+}
+
+const isMain = isMainModule(import.meta.url, process.argv[1]);
+if (isMain) {
+  main().catch((error) => {
+    console.error(`Umami storage monitor failed: ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/umami-retention.sql
+++ b/scripts/umami-retention.sql
@@ -1,0 +1,188 @@
+-- World Monitor Umami relational retention contract.
+--
+-- Run this file from a controlled maintenance job with the Umami Postgres
+-- DATABASE_URL. It is intentionally not invoked by the application or the
+-- GitHub storage monitor. Run it once per maintenance tick; if more rows are
+-- eligible, the next tick resumes the cleanup. Every statement is capped at
+-- 10,000 rows (and replay payloads at 64 MiB); child rows are removed before
+-- their parent rows.
+--
+-- Contract: retain 90 days of raw relational analytics. Do not TRUNCATE, use
+-- an unbounded DELETE, remove website configuration, or remove saved replays.
+
+BEGIN;
+
+-- A singleton lock prevents overlapping maintenance jobs from selecting and
+-- rescanning the same rows. The bounded lock timeout leaves collector writes
+-- unaffected when an operator accidentally starts a second job.
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '60s';
+SELECT pg_advisory_xact_lock(hashtextextended('worldmonitor.umami.retention', 0));
+
+-- Event data must be removed before the event row it references.
+WITH doomed AS MATERIALIZED (
+  SELECT data.event_data_id
+  FROM event_data AS data
+  JOIN website_event AS event ON event.event_id = data.website_event_id
+  WHERE event.created_at IS NOT NULL
+    AND event.created_at < now() - interval '90 days'
+  ORDER BY event.created_at, data.event_data_id
+  LIMIT 10000
+)
+DELETE FROM event_data AS data
+USING doomed
+WHERE data.event_data_id = doomed.event_data_id;
+
+-- Only delete an event after its event_data children are gone. Repeating this
+-- statement is safe when one event has more than one cleanup batch of data.
+WITH doomed AS MATERIALIZED (
+  SELECT event.event_id
+  FROM website_event AS event
+  WHERE event.created_at IS NOT NULL
+    AND event.created_at < now() - interval '90 days'
+    AND NOT EXISTS (
+      SELECT 1 FROM event_data AS data WHERE data.website_event_id = event.event_id
+    )
+  ORDER BY event.created_at, event.event_id
+  LIMIT 10000
+)
+DELETE FROM website_event AS event
+USING doomed
+WHERE event.event_id = doomed.event_id;
+
+WITH doomed AS MATERIALIZED (
+  SELECT revenue.revenue_id
+  FROM revenue
+  WHERE revenue.created_at IS NOT NULL
+    AND revenue.created_at < now() - interval '90 days'
+  ORDER BY revenue.website_id, revenue.created_at, revenue.revenue_id
+  LIMIT 10000
+)
+DELETE FROM revenue
+USING doomed
+WHERE revenue.revenue_id = doomed.revenue_id;
+
+WITH candidates AS MATERIALIZED (
+  SELECT replay.website_id, replay.replay_id, replay.created_at,
+    pg_column_size(replay.events) AS payload_bytes
+  FROM session_replay AS replay
+  WHERE replay.created_at IS NOT NULL
+    AND replay.created_at < now() - interval '90 days'
+    AND pg_column_size(replay.events) <= 64 * 1024 * 1024
+    AND NOT EXISTS (
+      SELECT 1
+      FROM session_replay_saved AS saved
+      WHERE saved.website_id = replay.website_id
+        AND saved.visit_id = replay.visit_id
+    )
+  ORDER BY replay.website_id, replay.created_at, replay.replay_id
+  LIMIT 10000
+), ranked AS MATERIALIZED (
+  SELECT website_id, replay_id,
+    SUM(payload_bytes) OVER (
+      ORDER BY website_id, created_at, replay_id
+      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+    ) AS cumulative_payload_bytes
+  FROM candidates
+), doomed AS MATERIALIZED (
+  SELECT replay_id
+  FROM ranked
+  WHERE cumulative_payload_bytes <= 64 * 1024 * 1024
+)
+DELETE FROM session_replay AS replay
+USING doomed
+WHERE replay.replay_id = doomed.replay_id;
+
+WITH doomed AS MATERIALIZED (
+  SELECT heatmap.heatmap_event_id
+  FROM heatmap_event AS heatmap
+  WHERE heatmap.created_at < now() - interval '90 days'
+  ORDER BY heatmap.website_id, heatmap.created_at, heatmap.heatmap_event_id
+  LIMIT 10000
+)
+DELETE FROM heatmap_event AS heatmap
+USING doomed
+WHERE heatmap.heatmap_event_id = doomed.heatmap_event_id;
+
+WITH doomed AS MATERIALIZED (
+  SELECT data.session_data_id
+  FROM session_data AS data
+  WHERE data.created_at IS NOT NULL
+    AND data.created_at < now() - interval '90 days'
+  ORDER BY data.created_at, data.session_data_id
+  LIMIT 10000
+)
+DELETE FROM session_data AS data
+USING doomed
+WHERE data.session_data_id = doomed.session_data_id;
+
+-- The fixed upstream schema includes session_link. Clean it only when the
+-- deployed schema has it, so a pre-upgrade maintenance run remains safe.
+DO $$
+BEGIN
+  IF to_regclass('public.session_link') IS NOT NULL THEN
+    EXECUTE $cleanup$
+      WITH doomed AS MATERIALIZED (
+        SELECT link.website_id, link.distinct_id, link.session_id
+        FROM session_link AS link
+        WHERE link.created_at IS NOT NULL
+          AND link.created_at < now() - interval '90 days'
+        ORDER BY link.website_id, link.created_at, link.distinct_id, link.session_id
+        LIMIT 10000
+      )
+      DELETE FROM session_link AS link
+      USING doomed
+      WHERE link.website_id = doomed.website_id
+        AND link.distinct_id = doomed.distinct_id
+        AND link.session_id = doomed.session_id
+    $cleanup$;
+  END IF;
+END $$;
+
+-- A session is safe to remove only after all relational children have gone.
+-- Saved replay definitions are deliberately not touched by this contract.
+-- If session_link exists, leave sessions with a remaining link in place.
+DO $$
+DECLARE
+  session_link_guard text := '';
+BEGIN
+  IF to_regclass('public.session_link') IS NOT NULL THEN
+    session_link_guard := $guard$
+    AND NOT EXISTS (
+      SELECT 1 FROM session_link AS link WHERE link.session_id = session.session_id
+    )
+    $guard$;
+  END IF;
+
+  EXECUTE format($cleanup$
+    WITH doomed AS MATERIALIZED (
+      SELECT session.session_id
+      FROM session
+      WHERE session.created_at IS NOT NULL
+        AND session.created_at < now() - interval '90 days'
+        AND NOT EXISTS (
+          SELECT 1 FROM website_event AS event WHERE event.session_id = session.session_id
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM session_data AS data WHERE data.session_id = session.session_id
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM revenue WHERE revenue.session_id = session.session_id
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM session_replay AS replay WHERE replay.session_id = session.session_id
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM heatmap_event AS heatmap WHERE heatmap.session_id = session.session_id
+        )
+        %s
+      ORDER BY session.created_at, session.session_id
+      LIMIT 10000
+    )
+    DELETE FROM session
+    USING doomed
+    WHERE session.session_id = doomed.session_id
+  $cleanup$, session_link_guard);
+END $$;
+
+COMMIT;

--- a/shared/collector-failure-metadata.d.ts
+++ b/shared/collector-failure-metadata.d.ts
@@ -3,6 +3,8 @@ export interface CollectorFailureMetadata {
   constraint?: string;
 }
 
+export const WRITE_RECEIPT_FIELDS: readonly string[];
+
 export function extractCollectorFailureMetadata(body: unknown): CollectorFailureMetadata;
 
 export function isSessionDataConflict(metadata: CollectorFailureMetadata): boolean;

--- a/shared/collector-failure-metadata.js
+++ b/shared/collector-failure-metadata.js
@@ -16,6 +16,9 @@
  * @typedef {{ prismaCode?: string, constraint?: string }} CollectorFailureMetadata
  */
 
+/** Fields present in a genuine Umami write receipt. */
+export const WRITE_RECEIPT_FIELDS = Object.freeze(['cache', 'sessionId', 'visitId']);
+
 /**
  * Prisma error codes are always `P` + 4 digits, so this bounds the value to 5
  * characters and cannot pass arbitrary text through.

--- a/src/services/analytics-collector-transport.ts
+++ b/src/services/analytics-collector-transport.ts
@@ -6,7 +6,7 @@
  * requests when a page issues concurrent writes for one session. This module
  * serializes our writes through a single in-flight slot so we stop generating
  * that contention ourselves, and turns the tracker's swallowed failures into an
- * observable delivery signal.
+ * observable delivery signal while the server upgrade is pending.
  *
  * Two invariants keep this from becoming a worse failure than the one it fixes:
  *
@@ -27,6 +27,7 @@ import {
   extractCollectorFailureMetadata,
   isBotFilteredBody,
   isSessionDataConflict,
+  WRITE_RECEIPT_FIELDS,
 } from '../../shared/collector-failure-metadata';
 
 export type CollectorFailure = {
@@ -98,9 +99,6 @@ const RETRYABLE_CRITICAL_EVENT_STATUSES = new Set([408, 425, 429]);
  */
 const RETRYABLE_IDENTITY_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 
-/** Fields Umami returns on a genuine write. Mirrors the CI monitor's receipt check. */
-const WRITE_RECEIPT_FIELDS = ['cache', 'sessionId', 'visitId'] as const;
-
 type CollectorRequest = {
   input: RequestInfo | URL;
   init?: RequestInit;
@@ -130,7 +128,7 @@ let collectorFetchWrapper: typeof window.fetch | null = null;
 let collectorUnloadFlush: (() => void) | null = null;
 let collectorVisibilityFlush: (() => void) | null = null;
 let collectorTransportGeneration = 0;
-let collectorHealthWindow = { startedAt: 0, writes: 0, failures: 0, noiseReported: false };
+let collectorHealthWindow = newCollectorHealthWindow();
 let pendingObservation: ObservationSlot | null = null;
 /**
  * Non-zero while this module is dispatching. If a foreign wrapper installed on
@@ -299,6 +297,25 @@ type CollectorHealthSnapshot = {
   noiseReported?: boolean;
 };
 
+type CollectorHealthWindow = CollectorHealthSnapshot & {
+  startedAt: number;
+  reportedFailureSignatures: Set<string>;
+};
+
+function newCollectorHealthWindow(startedAt = 0): CollectorHealthWindow {
+  return {
+    startedAt,
+    writes: 0,
+    failures: 0,
+    noiseReported: false,
+    reportedFailureSignatures: new Set(),
+  };
+}
+
+function collectorFailureSignature(failure: CollectorFailure): string {
+  return [failure.kind, failure.status ?? 'none', failure.prismaCode ?? 'none', failure.constraint ?? 'none'].join('|');
+}
+
 /**
  * Whether a failure is worth a Sentry event, as opposed to merely worth a
  * console warning.
@@ -312,8 +329,6 @@ export function isAlertWorthyCollectorFailure(
   failure: CollectorFailure,
   window: CollectorHealthSnapshot,
 ): boolean {
-  // Known, unfixed upstream race (umami#4183). Expected background condition.
-  if (isKnownSessionDataConflict(failure)) return false;
   // The collector deliberately discarded a bot's write. Working as designed.
   if (failure.botFiltered) return false;
   if (ENVIRONMENT_NOISE_KINDS.has(failure.kind)) {
@@ -332,7 +347,7 @@ export function isAlertWorthyCollectorFailure(
 function recordCollectorOutcome(request: CollectorRequest, failure: CollectorFailure | null): void {
   const now = Date.now();
   if (collectorHealthWindow.startedAt === 0 || now - collectorHealthWindow.startedAt >= HEALTH_WINDOW_MS) {
-    collectorHealthWindow = { startedAt: now, writes: 0, failures: 0, noiseReported: false };
+    collectorHealthWindow = newCollectorHealthWindow(now);
   }
   collectorHealthWindow.writes += 1;
 
@@ -372,6 +387,14 @@ function recordCollectorOutcome(request: CollectorRequest, failure: CollectorFai
   // actionable failures get an event.
   if (!isAlertWorthyCollectorFailure(failure, collectorHealthWindow)) return;
   if (ENVIRONMENT_NOISE_KINDS.has(failure.kind)) collectorHealthWindow.noiseReported = true;
+
+  // Keep every failure observable through the aggregate counters and console,
+  // but emit at most one Sentry event per redacted failure signature per
+  // minute. The upstream race can affect every concurrent write; one event
+  // with the live rate and Prisma identifiers is enough to page on it.
+  const signature = collectorFailureSignature(failure);
+  if (collectorHealthWindow.reportedFailureSignatures.has(signature)) return;
+  collectorHealthWindow.reportedFailureSignatures.add(signature);
 
   try {
     enqueueSentryCall((s) => s.captureMessage('Umami collector write failed', {
@@ -651,7 +674,7 @@ export function resetCollectorTransportForTesting(): void {
   collectorVisibilityFlush = null;
   collectorFetchOriginal = null;
   collectorFetchWrapper = null;
-  collectorHealthWindow = { startedAt: 0, writes: 0, failures: 0, noiseReported: false };
+  collectorHealthWindow = newCollectorHealthWindow();
 }
 
 /** Test-only: current rolling health window. */
@@ -659,10 +682,12 @@ export function getCollectorHealthForTesting(): {
   writes: number;
   failures: number;
   noiseReported: boolean;
+  reportedFailureSignatures: number;
 } {
   return {
     writes: collectorHealthWindow.writes,
     failures: collectorHealthWindow.failures,
-    noiseReported: collectorHealthWindow.noiseReported,
+    noiseReported: collectorHealthWindow.noiseReported ?? false,
+    reportedFailureSignatures: collectorHealthWindow.reportedFailureSignatures.size,
   };
 }

--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -892,13 +892,13 @@ describe('collector alert policy suppresses expected background conditions', () 
     );
   });
 
-  it('stays silent for the known umami#4183 session_data race', () => {
+  it('reports the known umami#4183 session_data race until the server is upgraded', () => {
     assert.equal(
       isAlertWorthyCollectorFailure(
         { kind: 'http', status: 500, prismaCode: 'P2002', constraint: 'session_data_pkey' },
         { writes: 1, failures: 1 },
       ),
-      false,
+      true,
     );
   });
 });
@@ -936,11 +936,13 @@ describe('collector alert policy is wired into the reporting path', () => {
 
     await fire(1);
     assert.equal(getCollectorHealthForTesting().noiseReported, true, 'the fifth crosses the floor');
+    assert.equal(getCollectorHealthForTesting().reportedFailureSignatures, 1, 'the window emits one event per signature');
 
     await fire(10);
     const after = getCollectorHealthForTesting();
     assert.equal(after.writes, 15, 'writes keep accruing');
     assert.equal(after.noiseReported, true, 'the latch stays set — no second event this window');
+    assert.equal(after.reportedFailureSignatures, 1, 'repeated failures stay latched');
   });
 });
 

--- a/tests/analytics-collector-monitor.test.mjs
+++ b/tests/analytics-collector-monitor.test.mjs
@@ -266,6 +266,7 @@ describe('scheduled analytics collector monitor', () => {
 
     assert.ok(report.writeSummary.failed > 0, 'a failed attempt must survive a later success');
     assert.ok(report.writeSummary.failureRate > 0, 'the reported rate must not be 0.0%');
+    assert.equal(report.alerting, true, 'any failed write attempt is actionable after #5715 remediation');
     assert.match(report.writeSummary.failures[0].reason, /P2002/);
   });
 
@@ -283,10 +284,10 @@ describe('scheduled analytics collector monitor', () => {
     assert.equal(report.alerting, true, 'a dead write path must alert on its own');
   });
 
-  it('tolerates the known #4183 background rate without paging', async () => {
-    // One failing attempt out of a full run sits under the alert threshold: the
-    // upstream race is unfixed and alerting on it would train everyone to
-    // ignore this monitor.
+  it('alerts on any known #4183 conflict until the upstream race is remediated', async () => {
+    // A single collision is enough to fail the acceptance contract: every
+    // canary burst must be 4/4 successful, and two consecutive scheduled runs
+    // must remain clean after the upstream upsert fix is deployed.
     let seen = 0;
     const report = await runCollectorChecks({
       sleep: async () => {},
@@ -299,8 +300,8 @@ describe('scheduled analytics collector monitor', () => {
     });
 
     assert.ok(report.writeSummary.failureRate > 0, 'the rate is still reported');
-    assert.equal(report.writeRateBreached, false);
-    assert.equal(report.alerting, false, 'the known background race must not page');
+    assert.equal(report.hasWriteFailures, true);
+    assert.equal(report.alerting, true, 'the known race must remain visible until fixed');
   });
 
   it('reports every failing probe, in probe order, and nothing else', () => {

--- a/tests/umami-storage-monitor.test.mjs
+++ b/tests/umami-storage-monitor.test.mjs
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import {
+  evaluateUmamiStorage,
+  normalizeVolumeRows,
+  parseArguments,
+  updateStorageState,
+} from '../scripts/check-umami-storage.mjs';
+
+const NOW = Date.parse('2026-08-01T12:00:00.000Z');
+
+function volume(overrides = {}) {
+  return {
+    id: 'volume-1',
+    name: 'postgres-volume',
+    serviceName: 'Postgres Umami',
+    sizeMB: 50_000,
+    currentSizeMB: 28_000,
+    status: 'Ready',
+    ...overrides,
+  };
+}
+
+describe('Umami storage monitor', () => {
+  it('normalizes Railway array and connection-shaped volume responses', () => {
+    assert.deepEqual(normalizeVolumeRows([volume()]), [volume()]);
+    assert.deepEqual(normalizeVolumeRows({ volumes: [volume()] }), [volume()]);
+    assert.deepEqual(
+      normalizeVolumeRows({ volumes: { edges: [{ node: volume() }] } }),
+      [volume()],
+    );
+  });
+
+  it('parses only the documented input and state options', () => {
+    assert.deepEqual(
+      { ...parseArguments(['--input', 'volumes.json', '--state=state.json']) },
+      { input: 'volumes.json', state: 'state.json' },
+    );
+    assert.throws(() => parseArguments(['--unknown', 'value']), /Unknown option/);
+  });
+
+  it('does not project headroom until there is a meaningful history window', () => {
+    const result = evaluateUmamiStorage({
+      volume: volume(),
+      samples: [{ sampledAt: new Date(NOW - 60 * 60 * 1000).toISOString(), currentSizeMB: 27_900 }],
+      now: NOW,
+    });
+
+    assert.equal(result.growthMBPerDay, null);
+    assert.equal(result.projectedHeadroomDays, null);
+    assert.equal(result.alerting, false);
+  });
+
+  it('alerts when projected capacity is inside the 30-day warning window', () => {
+    const result = evaluateUmamiStorage({
+      volume: volume({ currentSizeMB: 28_000 }),
+      samples: [{ sampledAt: new Date(NOW - 7 * 24 * 60 * 60 * 1000).toISOString(), currentSizeMB: 22_800 }],
+      now: NOW,
+    });
+
+    assert.equal(Math.round(result.growthMBPerDay), 743);
+    assert.equal(Math.round(result.projectedHeadroomDays), 30);
+    assert.equal(result.status, 'warning');
+    assert.equal(result.alerting, true);
+  });
+
+  it('fails closed at critical usage even when no growth baseline exists', () => {
+    const result = evaluateUmamiStorage({
+      volume: volume({ currentSizeMB: 45_000 }),
+      samples: [],
+      now: NOW,
+    });
+
+    assert.equal(result.usagePercent, 90);
+    assert.equal(result.status, 'critical');
+    assert.equal(result.alerting, true);
+  });
+
+  it('fails closed when Railway reports a non-ready volume', () => {
+    assert.throws(
+      () => evaluateUmamiStorage({ volume: volume({ status: 'Failed' }), now: NOW }),
+      /volume is not ready: Failed/,
+    );
+    assert.throws(
+      () => evaluateUmamiStorage({ volume: volume({ status: undefined }), now: NOW }),
+      /volume is not ready: unknown/,
+    );
+  });
+
+  it('keeps only bounded, valid samples in the cached state', () => {
+    const next = updateStorageState(
+      {
+        version: 1,
+        volumeIdentity: 'volume-1',
+        capacityMB: 50_000,
+        samples: [
+          { sampledAt: new Date(NOW - 31 * 24 * 60 * 60 * 1000).toISOString(), currentSizeMB: 10_000 },
+          { sampledAt: new Date(NOW - 60 * 60 * 1000).toISOString(), currentSizeMB: 20_000 },
+          { sampledAt: 'not-a-date', currentSizeMB: 30_000 },
+        ],
+      },
+      volume({ currentSizeMB: 21_000 }),
+      NOW,
+    );
+
+    assert.deepEqual(next, {
+      version: 1,
+      volumeIdentity: 'volume-1',
+      capacityMB: 50_000,
+      samples: [
+        { sampledAt: new Date(NOW - 60 * 60 * 1000).toISOString(), currentSizeMB: 20_000 },
+        { sampledAt: new Date(NOW).toISOString(), currentSizeMB: 21_000 },
+      ],
+    });
+  });
+
+  it('resets history when the volume identity or capacity changes', () => {
+    const previous = {
+      version: 1,
+      volumeIdentity: 'old-volume',
+      capacityMB: 25_000,
+      samples: [{ sampledAt: new Date(NOW - 7 * 24 * 60 * 60 * 1000).toISOString(), currentSizeMB: 10_000 }],
+    };
+    const next = updateStorageState(previous, volume({ currentSizeMB: 28_000 }), NOW);
+
+    assert.deepEqual(next, {
+      version: 1,
+      volumeIdentity: 'volume-1',
+      capacityMB: 50_000,
+      samples: [{ sampledAt: new Date(NOW).toISOString(), currentSizeMB: 28_000 }],
+    });
+  });
+
+  it('wires the read-only Railway check and bounded SQL contract', () => {
+    const workflow = readFileSync(new URL('../.github/workflows/umami-storage-monitor.yml', import.meta.url), 'utf8');
+    const sql = readFileSync(new URL('../scripts/umami-retention.sql', import.meta.url), 'utf8');
+    const executableSql = sql.replace(/^\s*--.*$/gmu, '');
+
+    assert.match(workflow, /railway volume .* list --json/);
+    assert.match(workflow, /actions\/cache@/);
+    assert.match(workflow, /check-umami-storage\.mjs/);
+    assert.match(sql, /interval '90 days'/);
+    assert.match(sql, /LIMIT 10000/);
+    assert.match(sql, /64 \* 1024 \* 1024/);
+    assert.match(sql, /pg_advisory_xact_lock/);
+    assert.doesNotMatch(executableSql, /\bTRUNCATE\b/);
+    assert.match(sql, /to_regclass\('public\.session_link'\)/);
+    assert.match(sql, /session_link/);
+    assert.match(sql, /heatmap_event/);
+    assert.match(sql, /session_replay_saved/);
+    assert.doesNotMatch(sql, /ROW_NUMBER/);
+  });
+});


### PR DESCRIPTION
## Summary

A healthy Railway deployment and heartbeat can coexist with dropped analytics writes. This change makes the write path an acceptance contract: realistic POSTs must return a real receipt, and any failure remains visible until the external collector race is remediated.

The browser transport now serializes ordinary writes, keeps bounded durable conversion delivery, and retries only outcomes that are safe to replay. A read-only storage monitor plus bounded retention contract covers the separate database-volume risk.

## What changed

- The scheduled collector monitor runs three synchronized bursts (12 pageview/event/identify writes), validates `cache`/`sessionId`/`visitId` receipts, and fails on any write failure including Prisma `P2002/session_data_pkey`.
- Collector diagnostics expose only redacted failure metadata; Sentry is latched per failure signature while counters and console diagnostics retain every failure.
- Retention is 90 days, bounded to 10,000 rows and 64 MiB replay payload per tick, protected by an advisory lock, preserving saved replays/configuration and schema-gating `session_link`.
- The Railway storage monitor reads volume usage only, retains 30 days of bounded samples, and alerts at usage/headroom thresholds.

## External deployment contract

The production Umami service must be upgraded to an image built from [upstream commit `7c030e4`](https://github.com/umami-software/umami/commit/7c030e4) or later, with the composite `session_data` unique index and `ON CONFLICT` upsert. The migration removes duplicate `session_data` rows, so backup and schema/index verification are required before applying it. This PR does not mutate Railway or run that migration.

## Tests

- `npm run test:data` — 20,033 tests, 20,027 passed, 6 skipped.
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run lint`
- `npm run docs:check`
- Focused monitor/transport tests — 59 passed.
- Pre-push gates passed, including Unicode, boundary, changed-test, and Markdown checks.
- The Vite production build passed with local secret values blanked for the subprocess. The aggregate `build:full` wrapper remains blocked by the local secret guard and missing `blog-site` `satori` dependency; neither is part of this diff.

## Post-Deploy Monitoring & Validation

Production acceptance remains pending.

1. Deploy the exact fixed Umami image/digest and apply its migration only after a database backup and schema review.
2. Verify the deployed schema has the composite `session_data(session_id, data_key)` unique index and the upsert path.
3. Observe two consecutive scheduled canary runs: `12/12` accepted writes per run, zero `P2002`/`session_data_pkey`, and zero collector HTTP 5xx in the bounded production log window.
4. Confirm the deployed image/digest, Railway health, storage monitor status, and retention/headroom trend. Do not treat deployment health alone as acceptance.
5. If schema verification fails or any write 5xx recurs, keep the monitor red, stop retention, preserve the database backup, and roll back the external image. Do not blind-retry append-only conversion events after an ambiguous 5xx.

Related: #5715

## New concepts

### Write acceptance is separate from liveness

A heartbeat answers whether a process responds; a receipt-bearing POST answers whether the write path committed. The monitor now treats these as separate gates so a green deployment cannot mask dropped conversion events.

### Bounded retention with an advisory lock

The SQL selects a small deterministic batch, deletes children before parents, caps replay bytes, and takes a transaction-scoped advisory lock. This limits lock and I/O impact while allowing the next scheduled tick to resume. Use this pattern for controlled maintenance, not emergency deletion or schema migration.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-GPT--5-000000)
