### PR TITLE
fix(analytics): aggregate collector health across users

### DIFF
--- a/api/_upstash-json.js
+++ b/api/_upstash-json.js
@@ -171,7 +171,11 @@ export async function redisPipeline(commands, timeoutMs = 5_000) {
   try {
     const resp = await fetch(`${creds.url}/pipeline`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${creds.token}`, 'Content-Type': 'application/json' },
+      headers: {
+        Authorization: `Bearer ${creds.token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'worldmonitor-edge/1.0',
+      },
       body: JSON.stringify(commands),
       signal: AbortSignal.timeout(timeoutMs),
     });

--- a/api/analytics-health.js
+++ b/api/analytics-health.js
@@ -1,0 +1,149 @@
+/**
+ * Cross-user aggregate for client-side analytics collector health.
+ *
+ * A browser cannot tell whether a receiptless collector response came from a
+ * privacy layer or from a collector outage. It reports only bounded counter
+ * deltas here; Redis supplies the cross-user denominator and Sentry receives a
+ * single warning when one request cohort crosses the existing sample/rate
+ * floors. No event payload, user id, URL, or browser fingerprint is accepted.
+ */
+
+export const config = { runtime: 'edge' };
+
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { jsonResponse } from './_json-response.js';
+import { checkRateLimit } from './_rate-limit.js';
+import { captureSilentError } from './_sentry-edge.js';
+import { redisPipeline } from './_upstash-json.js';
+
+const HEALTH_WINDOW_SECONDS = 60;
+const HEALTH_KEY_TTL_SECONDS = 120;
+const MIN_WRITES = 5;
+const MIN_FAILURE_RATE = 0.5;
+const MAX_BODY_BYTES = 1_024;
+const MAX_COUNTER_DELTA = 10_000;
+const RATE_LIMIT_SCOPE = 'analytics-health';
+const RATE_LIMIT_PER_MINUTE = 60;
+const ALLOWED_COHORTS = new Set(['event', 'critical-event', 'identify']);
+const ALLOWED_FAILURE_KINDS = new Set(['network', 'timeout', 'missing-receipt']);
+
+function redisKey(bucket, cohort, suffix) {
+  const environment = process.env.VERCEL_ENV || 'production';
+  return `analytics:collector-health:v1:${environment}:${bucket}:${cohort}:${suffix}`;
+}
+
+function finiteCounter(value) {
+  return Number.isInteger(value) && value >= 1 && value <= MAX_COUNTER_DELTA;
+}
+
+export function parseCollectorHealthReport(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const { cohort, writes, failures, failureKind } = payload;
+  if (!ALLOWED_COHORTS.has(cohort) || !ALLOWED_FAILURE_KINDS.has(failureKind)) return null;
+  if (!finiteCounter(writes) || !finiteCounter(failures) || failures > writes) return null;
+  return { cohort, writes, failures, failureKind };
+}
+
+export function shouldEmitAggregateAlert(writes, failures) {
+  return writes >= MIN_WRITES && failures / writes >= MIN_FAILURE_RATE;
+}
+
+function counterResult(entry) {
+  if (!entry || Object.prototype.hasOwnProperty.call(entry, 'error')) return null;
+  const value = typeof entry.result === 'string' ? Number(entry.result) : entry.result;
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+export async function recordCollectorHealthAggregate(
+  report,
+  bucket,
+  ctx,
+  dependencies = { redisPipeline, captureSilentError },
+) {
+  const { redisPipeline: pipeline, captureSilentError: capture } = dependencies;
+  const writesKey = redisKey(bucket, report.cohort, 'writes');
+  const failuresKey = redisKey(bucket, report.cohort, 'failures');
+  const results = await pipeline([
+    ['INCRBY', writesKey, String(report.writes)],
+    ['INCRBY', failuresKey, String(report.failures)],
+    ['EXPIRE', writesKey, String(HEALTH_KEY_TTL_SECONDS)],
+    ['EXPIRE', failuresKey, String(HEALTH_KEY_TTL_SECONDS)],
+    ['GET', writesKey],
+    ['GET', failuresKey],
+  ], 2_500);
+  if (!Array.isArray(results) || results.length < 6) return false;
+
+  const writes = counterResult(results[4]);
+  const failures = counterResult(results[5]);
+  if (writes === null || failures === null || !shouldEmitAggregateAlert(writes, failures)) return true;
+
+  // SET NX is the cross-isolate once-per-window latch. Two requests may both
+  // observe the threshold, but only one wins this claim and emits Sentry.
+  const claim = await pipeline([
+    ['SET', redisKey(bucket, report.cohort, 'reported'), '1', 'NX', 'EX', String(HEALTH_KEY_TTL_SECONDS)],
+  ], 2_000);
+  const claimEntry = claim?.[0];
+  if (!claimEntry || Object.prototype.hasOwnProperty.call(claimEntry, 'error')) return false;
+  if (!Object.prototype.hasOwnProperty.call(claimEntry, 'result')) return false;
+  if (claimEntry.result !== 'OK') return true;
+
+  capture(new Error('Umami collector environment failures crossed aggregate floor'), {
+    level: 'warning',
+    tags: {
+      component: 'analytics-collector',
+      healthCohort: report.cohort,
+      failureKind: report.failureKind,
+    },
+    fingerprint: ['analytics-collector', 'environment-noise', report.cohort],
+    extra: {
+      failureCount: failures,
+      writeCount: writes,
+      failureRate: failures / writes,
+      healthWindowSeconds: HEALTH_WINDOW_SECONDS,
+    },
+    ctx,
+  });
+  return true;
+}
+
+export default async function handler(req, ctx) {
+  if (isDisallowedOrigin(req)) return new Response('Forbidden', { status: 403 });
+
+  const cors = {
+    ...getCorsHeaders(req, 'POST, OPTIONS'),
+    'Cache-Control': 'no-store',
+  };
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+  if (req.method !== 'POST') return jsonResponse({ error: 'Method not allowed' }, 405, cors);
+
+  const limited = await checkRateLimit(req, cors, {
+    failClosed: true,
+    ctx,
+    scope: RATE_LIMIT_SCOPE,
+    limit: RATE_LIMIT_PER_MINUTE,
+    window: '60 s',
+  });
+  if (limited) return limited;
+
+  const contentLength = Number(req.headers.get('content-length') ?? 0);
+  if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+    return jsonResponse({ error: 'Payload too large' }, 413, cors);
+  }
+
+  let body;
+  try {
+    const text = await req.text();
+    if (text.length > MAX_BODY_BYTES) return jsonResponse({ error: 'Payload too large' }, 413, cors);
+    body = JSON.parse(text);
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON' }, 400, cors);
+  }
+
+  const report = parseCollectorHealthReport(body);
+  if (!report) return jsonResponse({ error: 'Invalid collector health report' }, 400, cors);
+
+  const bucket = Math.floor(Date.now() / (HEALTH_WINDOW_SECONDS * 1_000));
+  const recorded = await recordCollectorHealthAggregate(report, bucket, ctx);
+  if (!recorded) return jsonResponse({ error: 'Health aggregation unavailable' }, 503, cors);
+  return new Response(null, { status: 204, headers: cors });
+}

--- a/api/analytics-health.test.mjs
+++ b/api/analytics-health.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+const {
+  parseCollectorHealthReport,
+  shouldEmitAggregateAlert,
+  recordCollectorHealthAggregate,
+} = await import('./analytics-health.js');
+
+describe('analytics collector health aggregate', () => {
+  it('accepts only bounded allowlisted counter deltas', () => {
+    assert.deepEqual(
+      parseCollectorHealthReport({
+        cohort: 'critical-event',
+        writes: 4,
+        failures: 2,
+        failureKind: 'missing-receipt',
+      }),
+      {
+        cohort: 'critical-event',
+        writes: 4,
+        failures: 2,
+        failureKind: 'missing-receipt',
+      },
+    );
+    assert.equal(parseCollectorHealthReport({ cohort: 'event', writes: 0, failures: 0, failureKind: 'network' }), null);
+    assert.equal(parseCollectorHealthReport({ cohort: 'event', writes: 2, failures: 3, failureKind: 'network' }), null);
+    assert.equal(parseCollectorHealthReport({ cohort: 'other', writes: 5, failures: 5, failureKind: 'network' }), null);
+  });
+
+  it('requires both the sample floor and failure-rate floor', () => {
+    assert.equal(shouldEmitAggregateAlert(4, 4), false);
+    assert.equal(shouldEmitAggregateAlert(100, 49), false);
+    assert.equal(shouldEmitAggregateAlert(5, 5), true);
+  });
+
+  it('claims one aggregate Sentry event per cohort and window', async () => {
+    const pipelineCalls = [];
+    const captures = [];
+    const pipeline = async (commands) => {
+      pipelineCalls.push(commands);
+      if (commands.length === 6) {
+        return [
+          { result: 5 },
+          { result: 5 },
+          { result: 1 },
+          { result: 1 },
+          { result: '5' },
+          { result: '5' },
+        ];
+      }
+      return [{ result: 'OK' }];
+    };
+
+    const recorded = await recordCollectorHealthAggregate(
+      { cohort: 'event', writes: 1, failures: 1, failureKind: 'network' },
+      123,
+      undefined,
+      {
+        redisPipeline: pipeline,
+        captureSilentError: (error, options) => captures.push({ error, options }),
+      },
+    );
+
+    assert.equal(recorded, true);
+    assert.equal(pipelineCalls.length, 2, 'counter update and once-per-window claim are separate Redis operations');
+    assert.equal(captures.length, 1);
+    assert.equal(captures[0].options.tags.healthCohort, 'event');
+    assert.equal(captures[0].options.extra.writeCount, 5);
+    assert.equal(captures[0].options.extra.failureCount, 5);
+  });
+
+  it('fails closed when the once-per-window claim is unavailable', async () => {
+    const recorded = await recordCollectorHealthAggregate(
+      { cohort: 'event', writes: 1, failures: 1, failureKind: 'network' },
+      123,
+      undefined,
+      {
+        redisPipeline: async (commands) => commands.length === 6
+          ? [
+            { result: 5 },
+            { result: 5 },
+            { result: 1 },
+            { result: 1 },
+            { result: '5' },
+            { result: '5' },
+          ]
+          : null,
+        captureSilentError: () => {},
+      },
+    );
+
+    assert.equal(recorded, false);
+  });
+});

--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -496,6 +496,13 @@
       "removal_issue": null
     },
     {
+      "path": "api/analytics-health.js",
+      "category": "ops-admin",
+      "reason": "Anonymous, bounded analytics collector health counter ingress. It accepts no event or identity payload and aggregates operator telemetry in Redis; not a product API.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/seed-health.js",
       "category": "ops-admin",
       "reason": "Cron-triggered data-freshness check for feed seeds. Operator tool, not a user-facing API.",

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -12,7 +12,7 @@
   "variantCount": 6,
   "componentTopLevelTsFiles": 179,
   "serviceTopLevelEntries": 219,
-  "apiEndpointEntries": 89,
+  "apiEndpointEntries": 90,
   "panelClasses": 107,
   "protoFiles": 290,
   "protoServices": 35,

--- a/src/services/analytics-collector-transport.ts
+++ b/src/services/analytics-collector-transport.ts
@@ -6,7 +6,7 @@
  * requests when a page issues concurrent writes for one session. This module
  * serializes our writes through a single in-flight slot so we stop generating
  * that contention ourselves, and turns the tracker's swallowed failures into an
- * observable delivery signal while the server upgrade is pending.
+ * observable delivery signal.
  *
  * Two invariants keep this from becoming a worse failure than the one it fixes:
  *
@@ -27,7 +27,6 @@ import {
   extractCollectorFailureMetadata,
   isBotFilteredBody,
   isSessionDataConflict,
-  WRITE_RECEIPT_FIELDS,
 } from '../../shared/collector-failure-metadata';
 
 export type CollectorFailure = {
@@ -55,6 +54,17 @@ export type CollectorRequestClassification = {
   eventName?: string;
   critical: boolean;
 };
+
+export type CollectorHealthCohort = 'event' | 'critical-event' | 'identify';
+
+export type CollectorHealthReport = {
+  cohort: CollectorHealthCohort;
+  writes: number;
+  failures: number;
+  failureKind: 'network' | 'timeout' | 'missing-receipt';
+};
+
+type CollectorHealthReporter = (report: CollectorHealthReport) => Promise<boolean>;
 
 export type CollectorOutcome = {
   requestType: CollectorRequestType;
@@ -99,6 +109,9 @@ const RETRYABLE_CRITICAL_EVENT_STATUSES = new Set([408, 425, 429]);
  */
 const RETRYABLE_IDENTITY_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 
+/** Fields Umami returns on a genuine write. Mirrors the CI monitor's receipt check. */
+const WRITE_RECEIPT_FIELDS = ['cache', 'sessionId', 'visitId'] as const;
+
 type CollectorRequest = {
   input: RequestInfo | URL;
   init?: RequestInit;
@@ -120,6 +133,35 @@ type ObservationSlot = {
 let collectorEndpoint = '';
 let isCriticalEventName: (name: string) => boolean = () => false;
 let onCollectorOutcome: (outcome: CollectorOutcome) => void = () => {};
+const DEFAULT_COLLECTOR_HEALTH_ENDPOINT = '/api/analytics-health';
+const COLLECTOR_HEALTH_REPORT_TIMEOUT_MS = 2_000;
+let collectorHealthEndpoint = DEFAULT_COLLECTOR_HEALTH_ENDPOINT;
+
+async function sendCollectorHealthReport(
+  endpoint: string,
+  report: CollectorHealthReport,
+): Promise<boolean> {
+  if (typeof globalThis.fetch !== 'function') return false;
+  try {
+    const init: RequestInit = {
+      method: 'POST',
+      credentials: 'omit',
+      keepalive: true,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(report),
+    };
+    if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+      init.signal = AbortSignal.timeout(COLLECTOR_HEALTH_REPORT_TIMEOUT_MS);
+    }
+    const response = await globalThis.fetch(endpoint, init);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+let collectorHealthReporter: CollectorHealthReporter = (report) =>
+  sendCollectorHealthReport(collectorHealthEndpoint, report);
 
 const collectorRequestQueue: CollectorRequest[] = [];
 let collectorRequestInFlight = false;
@@ -128,7 +170,51 @@ let collectorFetchWrapper: typeof window.fetch | null = null;
 let collectorUnloadFlush: (() => void) | null = null;
 let collectorVisibilityFlush: (() => void) | null = null;
 let collectorTransportGeneration = 0;
-let collectorHealthWindow = newCollectorHealthWindow();
+type CollectorHealthCounters = {
+  writes: number;
+  failures: number;
+  environmentFailures: number;
+  noiseReported: boolean;
+};
+
+type CollectorHealthWindow = {
+  startedAt: number;
+  writes: number;
+  failures: number;
+  noiseReported: boolean;
+  reportedFailureSignatures: Set<string>;
+  cohorts: Record<CollectorHealthCohort, CollectorHealthCounters>;
+};
+
+function emptyCollectorHealthCounters(): CollectorHealthCounters {
+  return { writes: 0, failures: 0, environmentFailures: 0, noiseReported: false };
+}
+
+function createCollectorHealthWindow(startedAt = 0): CollectorHealthWindow {
+  return {
+    startedAt,
+    writes: 0,
+    failures: 0,
+    noiseReported: false,
+    reportedFailureSignatures: new Set(),
+    cohorts: {
+      event: emptyCollectorHealthCounters(),
+      'critical-event': emptyCollectorHealthCounters(),
+      identify: emptyCollectorHealthCounters(),
+    },
+  };
+}
+
+function collectorFailureSignature(failure: CollectorFailure): string {
+  return [failure.kind, failure.status ?? 'none', failure.prismaCode ?? 'none', failure.constraint ?? 'none'].join('|');
+}
+
+let collectorHealthWindow = createCollectorHealthWindow();
+let collectorHealthReportCursor: Record<CollectorHealthCohort, { writes: number; failures: number }> = {
+  event: { writes: 0, failures: 0 },
+  'critical-event': { writes: 0, failures: 0 },
+  identify: { writes: 0, failures: 0 },
+};
 let pendingObservation: ObservationSlot | null = null;
 /**
  * Non-zero while this module is dispatching. If a foreign wrapper installed on
@@ -142,10 +228,24 @@ export function configureCollectorTransport(options: {
   endpoint: string;
   isCriticalEvent: (name: string) => boolean;
   onOutcome: (outcome: CollectorOutcome) => void;
+  healthEndpoint?: string;
+  reportEnvironmentHealth?: CollectorHealthReporter;
 }): void {
   collectorEndpoint = options.endpoint;
   isCriticalEventName = options.isCriticalEvent;
   onCollectorOutcome = options.onOutcome;
+  collectorHealthEndpoint = options.healthEndpoint ?? DEFAULT_COLLECTOR_HEALTH_ENDPOINT;
+  collectorHealthReporter = options.reportEnvironmentHealth
+    ?? ((report) => sendCollectorHealthReport(collectorHealthEndpoint, report));
+}
+
+export function _setCollectorHealthReporterForTesting(reporter: CollectorHealthReporter): void {
+  collectorHealthReporter = reporter;
+}
+
+function getCollectorHealthCohort(request: CollectorRequest): CollectorHealthCohort {
+  if (request.requestType === 'identify') return 'identify';
+  return request.critical ? 'critical-event' : 'event';
 }
 
 export function classifyCollectorRequest(
@@ -273,12 +373,18 @@ export function isRetryableIdentityFailure(failure: CollectorFailure): boolean {
  * the Umami DB was ingesting 15-23k events/hour and every probe shape returned
  * a full receipt. Nothing computed on this page can separate them, so the
  * outage signal is the AGGREGATE volume of these events across users, not any
- * single one — which is exactly why each page is allowed at most one per health
- * window below. Alerting on every occurrence buries the step change in the
- * baseline. (A bot-filtered 200 never reaches this set — it is suppressed
- * outright before the gate.)
+ * single one. The browser sends bounded deltas to the aggregate endpoint, with
+ * a per-page floor retained as a fallback when that endpoint is unavailable.
+ * (A bot-filtered 200 never reaches this set — it is suppressed outright
+ * before the gate.)
  */
-const ENVIRONMENT_NOISE_KINDS = new Set<CollectorFailure['kind']>(['network', 'timeout', 'missing-receipt']);
+type EnvironmentNoiseKind = 'network' | 'timeout' | 'missing-receipt';
+type EnvironmentNoiseFailure = CollectorFailure & { kind: EnvironmentNoiseKind };
+const ENVIRONMENT_NOISE_KINDS = new Set<EnvironmentNoiseKind>(['network', 'timeout', 'missing-receipt']);
+
+function isEnvironmentNoiseFailure(failure: CollectorFailure): failure is EnvironmentNoiseFailure {
+  return ENVIRONMENT_NOISE_KINDS.has(failure.kind as EnvironmentNoiseKind) && !failure.botFiltered;
+}
 
 /**
  * Minimum writes in the health window before an environment failure can alert.
@@ -305,25 +411,6 @@ type CollectorHealthSnapshot = {
   noiseReported?: boolean;
 };
 
-type CollectorHealthWindow = CollectorHealthSnapshot & {
-  startedAt: number;
-  reportedFailureSignatures: Set<string>;
-};
-
-function newCollectorHealthWindow(startedAt = 0): CollectorHealthWindow {
-  return {
-    startedAt,
-    writes: 0,
-    failures: 0,
-    noiseReported: false,
-    reportedFailureSignatures: new Set(),
-  };
-}
-
-function collectorFailureSignature(failure: CollectorFailure): string {
-  return [failure.kind, failure.status ?? 'none', failure.prismaCode ?? 'none', failure.constraint ?? 'none'].join('|');
-}
-
 /**
  * Whether a failure is worth a Sentry event, as opposed to merely worth a
  * console warning.
@@ -339,10 +426,11 @@ export function isAlertWorthyCollectorFailure(
 ): boolean {
   // The collector deliberately discarded a bot's write. Working as designed.
   if (failure.botFiltered) return false;
-  if (ENVIRONMENT_NOISE_KINDS.has(failure.kind)) {
-    // At most one environment event per page per window. Without this, crossing
-    // the rate floor makes EVERY remaining failure in the window report, so one
-    // ad-blocked power user out-produces the incident the floor exists to show.
+  if (ENVIRONMENT_NOISE_KINDS.has(failure.kind as EnvironmentNoiseKind)) {
+    // The fallback emits at most one environment event per page per window.
+    // Without this, crossing the rate floor makes EVERY remaining failure in the
+    // window report, so one ad-blocked power user out-produces the incident the
+    // floor exists to show.
     if (window.noiseReported) return false;
     if (window.writes < ENVIRONMENT_NOISE_MIN_WRITES) return false;
     return window.failures / window.writes >= ENVIRONMENT_NOISE_MIN_FAILURE_RATE;
@@ -352,49 +440,43 @@ export function isAlertWorthyCollectorFailure(
   return true;
 }
 
-function recordCollectorOutcome(request: CollectorRequest, failure: CollectorFailure | null): void {
-  const now = Date.now();
-  if (collectorHealthWindow.startedAt === 0 || now - collectorHealthWindow.startedAt >= HEALTH_WINDOW_MS) {
-    collectorHealthWindow = newCollectorHealthWindow(now);
+function resetCollectorHealthWindow(startedAt: number): void {
+  collectorHealthWindow = createCollectorHealthWindow(startedAt);
+  collectorHealthReportCursor = {
+    event: { writes: 0, failures: 0 },
+    'critical-event': { writes: 0, failures: 0 },
+    identify: { writes: 0, failures: 0 },
+  };
+}
+
+function buildCollectorHealthReport(
+  cohort: CollectorHealthCohort,
+  failure: EnvironmentNoiseFailure,
+): CollectorHealthReport | null {
+  const current = collectorHealthWindow.cohorts[cohort];
+  const previous = collectorHealthReportCursor[cohort];
+  const writes = Math.max(0, current.writes - previous.writes);
+  const failures = Math.max(0, current.environmentFailures - previous.failures);
+  collectorHealthReportCursor[cohort] = {
+    writes: current.writes,
+    failures: current.environmentFailures,
+  };
+  if (writes < 1 || failures < 1) return null;
+  return { cohort, writes, failures, failureKind: failure.kind };
+}
+
+function emitCollectorFailureToSentry(
+  request: CollectorRequest,
+  failure: CollectorFailure,
+  cohort: CollectorHealthCohort,
+  diagnostics: Record<string, unknown>,
+): void {
+  if (isEnvironmentNoiseFailure(failure)) {
+    const cohortWindow = collectorHealthWindow.cohorts[cohort];
+    if (cohortWindow.noiseReported) return;
+    cohortWindow.noiseReported = true;
+    collectorHealthWindow.noiseReported = true;
   }
-  collectorHealthWindow.writes += 1;
-
-  const outcome: CollectorOutcome = {
-    requestType: request.requestType,
-    eventName: request.eventName,
-    requestBody: typeof request.init?.body === 'string' ? request.init.body : undefined,
-    failure,
-  };
-  onCollectorOutcome(outcome);
-  if (!failure) return;
-
-  collectorHealthWindow.failures += 1;
-  // Deliberately reports only delivery metadata. The event payload can contain
-  // billing or identity data and must never be copied into diagnostics.
-  const diagnostics = {
-    requestType: request.requestType,
-    status: failure.status ?? null,
-    failureKind: failure.kind,
-    failureRate: collectorHealthWindow.failures / collectorHealthWindow.writes,
-    failureCount: collectorHealthWindow.failures,
-    writeCount: collectorHealthWindow.writes,
-    prismaCode: failure.prismaCode ?? null,
-    constraint: failure.constraint ?? null,
-    // The console warning fires for suppressed failures too, so it has to say
-    // WHY a receiptless 200 happened — otherwise a developer reading devtools
-    // during a bot-filtered write starts debugging a write path that is fine.
-    botFiltered: failure.botFiltered ?? false,
-  };
-  console.warn('[Analytics] Umami collector write failed', diagnostics);
-
-  // A console warning in a user's devtools is not observable, so genuine
-  // failures are routed to Sentry the same way wm-session and checkout report
-  // their degraded writes. But an alarm that fires on expected background
-  // conditions trains everyone to ignore it — the alert-fatigue path straight
-  // back to #5565, where a dead collector went unnoticed for four days. Only
-  // actionable failures get an event.
-  if (!isAlertWorthyCollectorFailure(failure, collectorHealthWindow)) return;
-  if (ENVIRONMENT_NOISE_KINDS.has(failure.kind)) collectorHealthWindow.noiseReported = true;
 
   // Keep every failure observable through the aggregate counters and console,
   // but emit at most one Sentry event per redacted failure signature per
@@ -412,10 +494,108 @@ function recordCollectorOutcome(request: CollectorRequest, failure: CollectorFai
         failureKind: failure.kind,
         status: String(failure.status ?? 'none'),
         requestType: request.requestType,
+        healthCohort: cohort,
       },
       extra: diagnostics,
     }));
   } catch { /* best-effort telemetry */ }
+}
+
+function recordCollectorOutcome(request: CollectorRequest, failure: CollectorFailure | null): void {
+  const now = Date.now();
+  if (collectorHealthWindow.startedAt === 0 || now - collectorHealthWindow.startedAt >= HEALTH_WINDOW_MS) {
+    resetCollectorHealthWindow(now);
+  }
+  collectorHealthWindow.writes += 1;
+  const cohort = getCollectorHealthCohort(request);
+  const cohortWindow = collectorHealthWindow.cohorts[cohort];
+  cohortWindow.writes += 1;
+
+  const outcome: CollectorOutcome = {
+    requestType: request.requestType,
+    eventName: request.eventName,
+    requestBody: typeof request.init?.body === 'string' ? request.init.body : undefined,
+    failure,
+  };
+  onCollectorOutcome(outcome);
+  if (!failure) return;
+
+  collectorHealthWindow.failures += 1;
+  cohortWindow.failures += 1;
+  if (isEnvironmentNoiseFailure(failure)) cohortWindow.environmentFailures += 1;
+  if (failure.botFiltered) {
+    // Bot-filtered writes are expected drops, not evidence about the collector.
+    cohortWindow.writes -= 1;
+    cohortWindow.failures -= 1;
+  }
+  // Deliberately reports only delivery metadata. The event payload can contain
+  // billing or identity data and must never be copied into diagnostics.
+  const cohortFailureRate = cohortWindow.writes > 0
+    ? cohortWindow.failures / cohortWindow.writes
+    : 0;
+  const environmentFailureRate = cohortWindow.writes > 0
+    ? cohortWindow.environmentFailures / cohortWindow.writes
+    : 0;
+  const diagnostics = {
+    requestType: request.requestType,
+    healthCohort: cohort,
+    status: failure.status ?? null,
+    failureKind: failure.kind,
+    failureRate: cohortFailureRate,
+    environmentFailureRate,
+    failureCount: collectorHealthWindow.failures,
+    writeCount: collectorHealthWindow.writes,
+    cohortFailureCount: cohortWindow.failures,
+    cohortWriteCount: cohortWindow.writes,
+    prismaCode: failure.prismaCode ?? null,
+    constraint: failure.constraint ?? null,
+    // The console warning fires for suppressed failures too, so it has to say
+    // WHY a receiptless 200 happened — otherwise a developer reading devtools
+    // during a bot-filtered write starts debugging a write path that is fine.
+    botFiltered: failure.botFiltered ?? false,
+  };
+  console.warn('[Analytics] Umami collector write failed', diagnostics);
+
+  // A console warning in a user's devtools is not observable, so genuine
+  // failures are routed to Sentry the same way wm-session and checkout report
+  // their degraded writes. But an alarm that fires on expected background
+  // conditions trains everyone to ignore it — the alert-fatigue path straight
+  // back to #5565, where a dead collector went unnoticed for four days. Only
+  // actionable failures get an event. Environment failures first go through
+  // the cross-user aggregate. If that path is unavailable, the original
+  // per-page floor remains as a bounded fallback.
+  if (isEnvironmentNoiseFailure(failure)) {
+    const localSnapshot: CollectorHealthSnapshot = {
+      writes: cohortWindow.writes,
+      failures: cohortWindow.environmentFailures,
+      noiseReported: cohortWindow.noiseReported,
+    };
+    const report = buildCollectorHealthReport(cohort, failure);
+    if (!report) return;
+
+    let reportPromise: Promise<boolean>;
+    try {
+      reportPromise = collectorHealthReporter(report);
+    } catch {
+      reportPromise = Promise.resolve(false);
+    }
+    void reportPromise.then((accepted) => {
+      if (accepted || !isAlertWorthyCollectorFailure(failure, localSnapshot)) return;
+      emitCollectorFailureToSentry(request, failure, cohort, diagnostics);
+    }, () => {
+      if (isAlertWorthyCollectorFailure(failure, localSnapshot)) {
+        emitCollectorFailureToSentry(request, failure, cohort, diagnostics);
+      }
+    });
+    return;
+  }
+
+  if (!isAlertWorthyCollectorFailure(failure, {
+    writes: cohortWindow.writes,
+    failures: cohortWindow.failures,
+    noiseReported: cohortWindow.noiseReported,
+  })) return;
+  emitCollectorFailureToSentry(request, failure, cohort, diagnostics);
 }
 
 function withTimeout(init: RequestInit | undefined): RequestInit {
@@ -682,7 +862,9 @@ export function resetCollectorTransportForTesting(): void {
   collectorVisibilityFlush = null;
   collectorFetchOriginal = null;
   collectorFetchWrapper = null;
-  collectorHealthWindow = newCollectorHealthWindow();
+  collectorHealthEndpoint = DEFAULT_COLLECTOR_HEALTH_ENDPOINT;
+  collectorHealthReporter = (report) => sendCollectorHealthReport(collectorHealthEndpoint, report);
+  resetCollectorHealthWindow(0);
 }
 
 /** Test-only: current rolling health window. */
@@ -691,11 +873,17 @@ export function getCollectorHealthForTesting(): {
   failures: number;
   noiseReported: boolean;
   reportedFailureSignatures: number;
+  cohorts: Record<CollectorHealthCohort, CollectorHealthCounters>;
 } {
   return {
     writes: collectorHealthWindow.writes,
     failures: collectorHealthWindow.failures,
-    noiseReported: collectorHealthWindow.noiseReported ?? false,
+    noiseReported: collectorHealthWindow.noiseReported,
     reportedFailureSignatures: collectorHealthWindow.reportedFailureSignatures.size,
+    cohorts: {
+      event: { ...collectorHealthWindow.cohorts.event },
+      'critical-event': { ...collectorHealthWindow.cohorts['critical-event'] },
+      identify: { ...collectorHealthWindow.cohorts.identify },
+    },
   };
 }

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -242,6 +242,7 @@ function handleCollectorOutcome(outcome: CollectorOutcome): void {
 
 configureCollectorTransport({
   endpoint: UMAMI_COLLECTOR_ENDPOINT,
+  healthEndpoint: '/api/analytics-health',
   isCriticalEvent: (name) => CRITICAL_TRACK_EVENTS.has(name as UmamiEvent),
   onOutcome: handleCollectorOutcome,
 });

--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -786,6 +786,7 @@ const {
   isRetryableIdentityFailure,
   isAlertWorthyCollectorFailure,
   getCollectorHealthForTesting,
+  _setCollectorHealthReporterForTesting,
 } = await import('../src/services/analytics-collector-transport.ts');
 
 /**
@@ -925,10 +926,73 @@ describe('collector alert policy is wired into the reporting path', () => {
     delete (globalThis.window as WinWithUmami).umami;
   });
 
+  it('sends low-volume environment failures to the cross-user aggregate', async () => {
+    const reports: unknown[] = [];
+    _setCollectorHealthReporterForTesting(async (report) => {
+      reports.push(report);
+      return true;
+    });
+    window.fetch = (() => Promise.resolve(collectorResponse(true, 200, '{}'))) as typeof window.fetch;
+    stubFailingUmami();
+
+    for (let i = 0; i < 4; i += 1) {
+      track('panel-open' as Parameters<typeof track>[0], { i });
+      await drainPromiseHandlers();
+    }
+
+    assert.equal(reports.length, 4, 'every environment failure contributes its delta before the local floor');
+    assert.deepEqual(reports[0], {
+      cohort: 'event',
+      writes: 1,
+      failures: 1,
+      failureKind: 'missing-receipt',
+    });
+    assert.equal(
+      getCollectorHealthForTesting().noiseReported,
+      false,
+      'an accepted aggregate report does not duplicate the server-side Sentry event locally',
+    );
+  });
+
+  it('keeps critical-event health separate from successful ordinary writes', async () => {
+    const reports: unknown[] = [];
+    _setCollectorHealthReporterForTesting(async (report) => {
+      reports.push(report);
+      return true;
+    });
+    let calls = 0;
+    window.fetch = (() => {
+      calls += 1;
+      return Promise.resolve(calls <= 10 ? collectorResponse(true, 200) : collectorResponse(true, 200, '{}'));
+    }) as typeof window.fetch;
+    (globalThis.window as WinWithUmami).umami = {
+      track: (event: unknown, data?: unknown) => nativeTrackerBeacon('event', {
+        ...(data as Record<string, unknown> | undefined),
+        name: event as string,
+      }),
+      identify: (data: unknown) => nativeTrackerBeacon('identify', data as Record<string, unknown>),
+    };
+
+    for (let i = 0; i < 10; i += 1) {
+      track('panel-open' as Parameters<typeof track>[0], { i });
+      await drainPromiseHandlers();
+    }
+    track('checkout-success');
+    await drainPromiseHandlers();
+
+    assert.deepEqual(reports.at(-1), {
+      cohort: 'critical-event',
+      writes: 1,
+      failures: 1,
+      failureKind: 'missing-receipt',
+    });
+  });
+
   it('flips the once-per-window latch only after the sample floor is crossed', async () => {
     // Drives REAL writes through the gate so this proves recordCollectorOutcome
     // consults the predicate — a policy unit test alone would pass even if the
     // reporting path ignored it entirely.
+    _setCollectorHealthReporterForTesting(async () => false);
     window.fetch = (() => Promise.reject(new TypeError('Failed to fetch'))) as typeof window.fetch;
     stubFailingUmami();
 


### PR DESCRIPTION
## Summary

- Add a bounded, rate-limited Edge aggregation endpoint for collector environment-failure deltas, with Redis window counters and a once-per-window Sentry claim.
- Split health accounting into ordinary events, critical events, and identify writes so unrelated successful traffic cannot dilute a critical-event outage signal.
- Preserve the merged #5996 per-signature Sentry dedupe and session-data-race alert behavior, while keeping the per-page floor as a fail-closed fallback when aggregation is unavailable.
- Register and test the endpoint under the Edge, API-contract, rate-limit, and Sentry-coverage guardrails.

This is a follow-up to merged PR #5979. It addresses the remaining distributed low-volume and shared-denominator gaps identified during review.

## Validation

- `tsx --test tests/analytics-beacon-rejection.test.mts api/analytics-health.test.mjs` (40 passed)
- Frontend and API TypeScript checks
- `tests/edge-functions.test.mjs` (243 passed)
- Edge bundle, API contract, rate-limit, Sentry coverage, premium-fetch, safe-HTML, boundary, and Unicode checks
