### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Latest release](https://img.shields.io/github/v/release/koala73/worldmonitor?style=flat)](https://github.com/koala73/worldmonitor/releases/latest)
 [![npm: worldmonitor](https://img.shields.io/npm/v/worldmonitor?logo=npm&label=npm)](https://www.npmjs.com/package/worldmonitor)
 [![smithery badge](https://smithery.ai/badge/worldmonitor/wm-mcp)](https://smithery.ai/servers/worldmonitor/wm-mcp)
+[![MCP status](https://mcpvitals.com/badge/cd4b854b6c.svg)](https://mcpvitals.com/status/cd4b854b6c)
 [![skills.sh](https://skills.sh/b/koala73/worldmonitor)](https://skills.sh/koala73/worldmonitor)
 
 <p align="center">


### PR DESCRIPTION
Hi — worldmonitor exposes a hosted MCP endpoint with 59 tools, and there's currently no signal in the README about whether it's answering.

This adds a badge running the real handshake (`initialize` → `tools/list`) against `worldmonitor.app/mcp`, linked to a public status page with uptime and latency history. Added to the existing badge block; no other changes.

Given the size of this project I completely understand if you don't take third-party badges — close away.

---
*Disclosure: I build MCP Vitals, the service behind this badge — so I have an interest here. I also used an AI assistant to help prepare this PR. The check is real and reproducible without me: `npx @mcpvitals/cli check <your-endpoint>`. Close it freely if it isn't a fit.*