### PR TITLE
fix(ingestion): bound provider retries and expose coverage

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -26,6 +26,8 @@ RUN npm ci --prefix scripts --omit=dev --omit=optional --ignore-scripts
 
 # Relay script and shared helpers
 COPY scripts/ais-relay.cjs ./scripts/ais-relay.cjs
+# Shared ingestion outcome/cooldown helpers imported by ais-relay.cjs.
+COPY scripts/_ingestion-coverage.cjs ./scripts/_ingestion-coverage.cjs
 COPY scripts/_proxy-utils.cjs ./scripts/_proxy-utils.cjs
 # Authenticated Yahoo sector valuation client required at relay startup.
 COPY scripts/_yahoo-sector-valuations.cjs ./scripts/_yahoo-sector-valuations.cjs

--- a/api/health.js
+++ b/api/health.js
@@ -127,6 +127,7 @@ const BOOTSTRAP_KEYS = {
   consumerPricesMovers:     'consumer-prices:movers:ae:30d',
   consumerPricesSpread:     'consumer-prices:retailer-spread:ae:essentials-ae',
   consumerPricesFreshness:  'consumer-prices:freshness:ae',
+  consumerPricesCoverage:   'consumer-prices:coverage:ae',
   groceryBasket:     'economic:grocery-basket:v1',
   bigmac:            'economic:bigmac:v1',
   fuelPrices:        'economic:fuel-prices:v1',
@@ -549,6 +550,7 @@ const SEED_META = {
   consumerPricesMovers:     { key: 'seed-meta:consumer-prices:movers:ae:30d',               maxStaleMin: 1500 },
   consumerPricesSpread:     { key: 'seed-meta:consumer-prices:retailer-spread:ae:essentials-ae', maxStaleMin: 1500 },
   consumerPricesFreshness:  { key: 'seed-meta:consumer-prices:freshness:ae',    maxStaleMin: 1500 },
+  consumerPricesCoverage:   { key: 'seed-meta:consumer-prices:coverage:ae',      maxStaleMin: 1500, minSuccessRate: 0.5, requireCoverage: true },
   // defiTokens/aiTokens/otherTokens all share one seed run (seed-token-panels cron, every 30min)
   defiTokens:        { key: 'seed-meta:market:token-panels', maxStaleMin: 90 },
   aiTokens:          { key: 'seed-meta:market:token-panels', maxStaleMin: 90 },
@@ -664,6 +666,23 @@ const SEED_META = {
   intelHistoryIngestMilitaryCrossStrait: { key: 'seed-meta:intel-history:military:cross-strait-activity',  maxStaleMin: 720 }, // mirrors crossStraitActivity
   intelHistoryIngestEnergyIntelligence:  { key: 'seed-meta:intel-history:energy:intelligence',             maxStaleMin: 720 }, // mirrors energyIntelligence
 };
+
+// consumer-prices-core publishes coverage for every currently enabled market.
+// The Edge health registry cannot import the package YAML, so keep this small
+// list synchronized with consumer-prices-core/configs/retailers/*.yaml. AE keeps
+// its historical public health name; the other markets use explicit suffixes.
+const CONSUMER_PRICE_HEALTH_MARKETS = Object.freeze(['ae', 'au', 'br', 'gb', 'in', 'sa', 'sg', 'us']);
+for (const market of CONSUMER_PRICE_HEALTH_MARKETS) {
+  if (market === 'ae') continue;
+  const name = `consumerPricesCoverage${market.toUpperCase()}`;
+  BOOTSTRAP_KEYS[name] = `consumer-prices:coverage:${market}`;
+  SEED_META[name] = {
+    key: `seed-meta:consumer-prices:coverage:${market}`,
+    maxStaleMin: 1500,
+    minSuccessRate: 0.5,
+    requireCoverage: true,
+  };
+}
 
 // Iran-events sunset: when disabled (default), drop it from all health
 // classification so the deliberately-dormant manual seed can't raise
@@ -1015,15 +1034,29 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       contentStale: contentAgeMin == null || isFutureDated || contentAgeMin > meta.maxContentAgeMin,
     };
   }
-  // Per-market coverage: optional { completedPages, failedPages, completionRatio, rejectedCount }
+  // Per-market coverage: optional { status, completedPages, failedPages, completionRatio, rejectedCount, retailers }
   // written by consumer-prices publish.ts and other seeders that track partial completion.
   // null when the seeder didn't write coverage fields.
+  const coverageRetailers = Array.isArray(meta?.coverage?.retailers)
+    ? meta.coverage.retailers.slice(0, 100).map((retailer) => ({
+        slug: typeof retailer?.slug === 'string' ? retailer.slug.slice(0, 80) : null,
+        name: typeof retailer?.name === 'string' ? retailer.name.slice(0, 120) : null,
+        coverageStatus: typeof retailer?.coverageStatus === 'string' ? retailer.coverageStatus : 'unknown',
+        pagesAttempted: Number(retailer?.pagesAttempted) || 0,
+        pagesSucceeded: Number(retailer?.pagesSucceeded) || 0,
+        failedPages: Number(retailer?.failedPages) || 0,
+        rejectedCount: Number(retailer?.rejectedCount) || 0,
+        completionRatio: retailer?.completionRatio == null ? null : Number(retailer.completionRatio) || 0,
+      }))
+    : null;
   const coverage = meta?.coverage && typeof meta.coverage === 'object'
     ? {
+        status: typeof meta.coverage.status === 'string' ? meta.coverage.status : null,
         completedPages: Number(meta.coverage.completedPages) || 0,
         failedPages: Number(meta.coverage.failedPages) || 0,
         completionRatio: Number(meta.coverage.completionRatio) || 0,
         rejectedCount: Number(meta.coverage.rejectedCount) || 0,
+        retailers: coverageRetailers,
       }
     : null;
 
@@ -1177,7 +1210,16 @@ function classifyKey(name, redisKey, opts, ctx) {
   // (consumer-prices publish.ts etc.), flag COVERAGE_DEGRADED if the ratio
   // falls below minSuccessRate. Fires after COVERAGE_PARTIAL so record-count
   // shortfalls take precedence.
-  else if (seedCfg?.minSuccessRate != null && coverage && coverage.completionRatio < seedCfg.minSuccessRate) status = 'COVERAGE_DEGRADED';
+  else if (seedCfg?.requireCoverage && !coverage) status = 'COVERAGE_DEGRADED';
+  else if (
+    seedCfg?.minSuccessRate != null
+    && coverage
+    && (coverage.completionRatio < seedCfg.minSuccessRate || coverage.status === 'degraded')
+  ) status = 'COVERAGE_DEGRADED';
+  else if (
+    coverage
+    && (coverage.status === 'partial' || coverage.retailers?.some((retailer) => retailer.coverageStatus === 'failed'))
+  ) status = 'COVERAGE_PARTIAL';
   // Content-age check (opt-in via runSeed contentMeta + maxContentAgeMin).
   // Fires AFTER all earlier failure paths so STALE_SEED, COVERAGE_PARTIAL,
   // EMPTY_*, etc. take precedence — STALE_CONTENT is "the seeder is healthy
@@ -1207,6 +1249,7 @@ function classifyKey(name, redisKey, opts, ctx) {
   if (seedCfg?.minRecordCount != null) entry.minRecordCount = seedCfg.minRecordCount;
   if (seedCfg?.minPoolCounts) entry.minPoolCounts = seedCfg.minPoolCounts;
   if (poolCounts) entry.poolCounts = poolCounts;
+  if (coverage || seedCfg?.requireCoverage) entry.coverage = coverage;
   if (status === 'SEED_ERROR' && errorCode) entry.errorCode = errorCode;
   // Surface content-age fields when seeder opted in (presence of
   // meta.maxContentAgeMin). Operators can distinguish "stale content" from

--- a/api/health.js
+++ b/api/health.js
@@ -1054,7 +1054,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
         status: typeof meta.coverage.status === 'string' ? meta.coverage.status : null,
         completedPages: Number(meta.coverage.completedPages) || 0,
         failedPages: Number(meta.coverage.failedPages) || 0,
-        completionRatio: Number(meta.coverage.completionRatio) || 0,
+        completionRatio: meta.coverage.completionRatio == null ? null : Number(meta.coverage.completionRatio) || 0,
         rejectedCount: Number(meta.coverage.rejectedCount) || 0,
         retailers: coverageRetailers,
       }

--- a/consumer-prices-core/migrations/010_scrape_run_coverage.sql
+++ b/consumer-prices-core/migrations/010_scrape_run_coverage.sql
@@ -1,0 +1,12 @@
+-- Operational scrape coverage for issue #5945.
+-- Keep strict validator admission unchanged; this counter records observations
+-- rejected by the validator so partial market publication is explainable.
+
+ALTER TABLE scrape_runs
+  ADD COLUMN IF NOT EXISTS rejected_count INT NOT NULL DEFAULT 0;
+
+ALTER TABLE scrape_runs
+  DROP CONSTRAINT IF EXISTS scrape_runs_rejected_count_nonnegative;
+
+ALTER TABLE scrape_runs
+  ADD CONSTRAINT scrape_runs_rejected_count_nonnegative CHECK (rejected_count >= 0);

--- a/consumer-prices-core/src/api/routes/worldmonitor.ts
+++ b/consumer-prices-core/src/api/routes/worldmonitor.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance } from 'fastify';
+import { buildCoverageSnapshot } from '../../snapshots/coverage.js';
 import {
   buildBasketSeriesSnapshot,
   buildCategoriesSnapshot,
@@ -9,6 +10,17 @@ import {
 } from '../../snapshots/worldmonitor.js';
 
 export async function worldmonitorRoutes(fastify: FastifyInstance) {
+  fastify.get('/coverage', async (request, reply) => {
+    const { market = 'ae' } = request.query as { market?: string };
+    try {
+      const data = await buildCoverageSnapshot(market);
+      return reply.send(data);
+    } catch (err) {
+      fastify.log.error(err);
+      return reply.status(500).send({ error: 'failed to build coverage snapshot' });
+    }
+  });
+
   fastify.get('/overview', async (request, reply) => {
     const { market = 'ae' } = request.query as { market?: string };
     try {

--- a/consumer-prices-core/src/api/server.test.ts
+++ b/consumer-prices-core/src/api/server.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockHealthQuery = vi.fn().mockResolvedValue({ rows: [{ '?column?': 1 }] });
 const mockBuildOverviewSnapshot = vi.fn().mockResolvedValue({ marketCode: 'ae', coveragePct: 100 });
+const mockBuildCoverageSnapshot = vi.fn().mockResolvedValue({ marketCode: 'ke', status: 'partial', retailers: [] });
 
 vi.mock('../db/client.js', () => ({
   getPool: () => ({ query: mockHealthQuery }),
@@ -16,10 +17,15 @@ vi.mock('../snapshots/worldmonitor.js', () => ({
   buildRetailerSpreadSnapshot: vi.fn(),
 }));
 
+vi.mock('../snapshots/coverage.js', () => ({
+  buildCoverageSnapshot: mockBuildCoverageSnapshot,
+}));
+
 const { createServer, isHealthCheckPath } = await import('./server.js');
 
 beforeEach(() => {
   mockBuildOverviewSnapshot.mockClear();
+  mockBuildCoverageSnapshot.mockClear();
   mockHealthQuery.mockClear();
 });
 
@@ -75,6 +81,24 @@ describe('consumer-prices-core Fastify server', () => {
     }
   });
 
+  it('exposes per-market coverage through the authenticated snapshot API', async () => {
+    const server = createServer({ apiKey: 'secret', logger: false });
+
+    try {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/wm/consumer-prices/v1/coverage?market=ke',
+        headers: { 'x-api-key': 'secret' },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ marketCode: 'ke', status: 'partial', retailers: [] });
+      expect(mockBuildCoverageSnapshot).toHaveBeenCalledWith('ke');
+    } finally {
+      await server.close();
+    }
+  });
+
   it('rejects snapshot routes before handlers run when the API key is absent or wrong', async () => {
     const server = createServer({ apiKey: 'secret', logger: false });
 
@@ -90,7 +114,11 @@ describe('consumer-prices-core Fastify server', () => {
       });
       expect(wrong.statusCode).toBe(401);
       expect(wrong.json()).toEqual({ error: 'unauthorized' });
+      const coverage = await server.inject({ method: 'GET', url: '/wm/consumer-prices/v1/coverage?market=ke' });
+      expect(coverage.statusCode).toBe(401);
+      expect(coverage.json()).toEqual({ error: 'unauthorized' });
       expect(mockBuildOverviewSnapshot).not.toHaveBeenCalled();
+      expect(mockBuildCoverageSnapshot).not.toHaveBeenCalled();
     } finally {
       await server.close();
     }

--- a/consumer-prices-core/src/db/models.ts
+++ b/consumer-prices-core/src/db/models.ts
@@ -80,6 +80,7 @@ export interface ScrapeRun {
   pagesAttempted: number;
   pagesSucceeded: number;
   errorsCount: number;
+  rejectedCount: number;
   configVersion: string;
 }
 

--- a/consumer-prices-core/src/jobs/publish.test.ts
+++ b/consumer-prices-core/src/jobs/publish.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockBuildCoverageSnapshot = vi.fn();
+const mockBuildFreshnessSnapshot = vi.fn();
+const mockBuildOverviewSnapshot = vi.fn();
+const mockBuildMoversSnapshot = vi.fn();
+const mockBuildCategoriesSnapshot = vi.fn();
+const mockFetch = vi.fn();
+
+vi.mock('../config/loader.js', () => ({
+  loadAllRetailerConfigs: () => [{ slug: 'retailer-a', marketCode: 'ae', enabled: true }],
+  loadAllBasketConfigs: () => [],
+}));
+vi.mock('../db/client.js', () => ({ closePool: vi.fn() }));
+vi.mock('../snapshots/coverage.js', () => ({ buildCoverageSnapshot: mockBuildCoverageSnapshot }));
+vi.mock('../snapshots/worldmonitor.js', () => ({
+  buildFreshnessSnapshot: mockBuildFreshnessSnapshot,
+  buildOverviewSnapshot: mockBuildOverviewSnapshot,
+  buildMoversSnapshot: mockBuildMoversSnapshot,
+  buildCategoriesSnapshot: mockBuildCategoriesSnapshot,
+  buildBasketSeriesSnapshot: vi.fn(),
+  buildRetailerSpreadSnapshot: vi.fn(),
+}));
+
+const { publishAll } = await import('./publish.js');
+
+const coverage = {
+  marketCode: 'ae',
+  asOf: '2026-08-01T00:00:00.000Z',
+  attemptedPages: 12,
+  completedPages: 8,
+  failedPages: 4,
+  completionRatio: 0.6667,
+  rejectedCount: 3,
+  status: 'partial',
+  minimumCompletionRatio: 0.5,
+  retailers: [{ slug: 'retailer-a', name: 'Retailer A', coverageStatus: 'partial', rejectedCount: 3 }],
+  upstreamUnavailable: false,
+};
+
+function commands() {
+  return mockFetch.mock.calls.map(([, init]) => JSON.parse(init.body as string));
+}
+
+beforeEach(() => {
+  mockFetch.mockReset().mockResolvedValue({ ok: true, status: 200 });
+  mockBuildCoverageSnapshot.mockReset().mockResolvedValue(coverage);
+  mockBuildFreshnessSnapshot.mockReset().mockResolvedValue({ marketCode: 'ae', retailers: [{ freshnessMin: 10 }] });
+  mockBuildOverviewSnapshot.mockReset().mockResolvedValue({ marketCode: 'ae' });
+  mockBuildMoversSnapshot.mockReset().mockResolvedValue({ risers: [], fallers: [] });
+  mockBuildCategoriesSnapshot.mockReset().mockResolvedValue({ categories: [] });
+  vi.stubEnv('UPSTASH_REDIS_REST_URL', 'https://redis.test');
+  vi.stubEnv('UPSTASH_REDIS_REST_TOKEN', 'token');
+  globalThis.fetch = mockFetch as typeof fetch;
+});
+
+describe('consumer-price coverage publication', () => {
+  it('publishes coverage and carries market/rejection/retailer diagnostics into seed meta', async () => {
+    await publishAll();
+
+    const writes = commands();
+    const coveragePayload = writes.find((command) => command[0] === 'SET' && command[1] === 'consumer-prices:coverage:ae');
+    const coverageMeta = writes.find((command) => command[0] === 'SET' && command[1] === 'seed-meta:consumer-prices:coverage:ae');
+    expect(coveragePayload).toBeDefined();
+    expect(coverageMeta).toBeDefined();
+    expect(JSON.parse(coveragePayload[2]).data.status).toBe('partial');
+    expect(JSON.parse(coverageMeta[2]).coverage).toMatchObject({
+      status: 'partial',
+      completedPages: 8,
+      failedPages: 4,
+      completionRatio: 0.6667,
+      rejectedCount: 3,
+    });
+    expect(JSON.parse(coverageMeta[2]).coverage.retailers).toEqual(coverage.retailers);
+  });
+
+  it('keeps the last-good coverage key untouched when coverage rebuild fails, then recovers on the next run', async () => {
+    mockBuildCoverageSnapshot.mockRejectedValueOnce(new Error('coverage query unavailable'));
+    await publishAll();
+
+    let writes = commands();
+    expect(writes.some((command) => command[0] === 'DEL' && command[1] === 'consumer-prices:coverage:ae')).toBe(false);
+    expect(writes.some((command) => command[0] === 'SET' && command[1] === 'consumer-prices:overview:ae')).toBe(true);
+    expect(writes.some((command) => command[0] === 'SET' && command[1] === 'consumer-prices:coverage:ae')).toBe(false);
+
+    mockFetch.mockClear();
+    await publishAll();
+    writes = commands();
+    expect(writes.some((command) => command[0] === 'SET' && command[1] === 'consumer-prices:coverage:ae')).toBe(true);
+  });
+});

--- a/consumer-prices-core/src/jobs/publish.ts
+++ b/consumer-prices-core/src/jobs/publish.ts
@@ -11,6 +11,7 @@ import {
   buildOverviewSnapshot,
   buildRetailerSpreadSnapshot,
 } from '../snapshots/worldmonitor.js';
+import { buildCoverageSnapshot } from '../snapshots/coverage.js';
 import { loadAllBasketConfigs, loadAllRetailerConfigs } from '../config/loader.js';
 import { closePool } from '../db/client.js';
 
@@ -78,7 +79,14 @@ async function writeSnapshot(
   data: unknown,
   ttlSeconds: number,
   advanceSeedMeta = true,
-  coverage?: { pagesOk: number; pagesFailed: number; rejectedCount: number },
+  coverage?: {
+    status?: string;
+    pagesOk: number;
+    pagesFailed: number;
+    rejectedCount: number;
+    completionRatio?: number | null;
+    retailers?: unknown[];
+  },
 ): Promise<void> {
   const count = recordCount(data);
   // Envelope the canonical payload. Legacy seed-meta:<key> is still written
@@ -89,14 +97,16 @@ async function writeSnapshot(
   if (advanceSeedMeta) {
     const meta: Record<string, unknown> = { fetchedAt: Date.now(), recordCount: count };
     if (coverage) {
-      const completionRatio = coverage.pagesOk + coverage.pagesFailed > 0
+      const completionRatio = coverage.completionRatio ?? (coverage.pagesOk + coverage.pagesFailed > 0
         ? Number((coverage.pagesOk / (coverage.pagesOk + coverage.pagesFailed)).toFixed(4))
-        : 0;
+        : 0);
       meta.coverage = {
+        ...(coverage.status ? { status: coverage.status } : {}),
         completedPages: coverage.pagesOk,
         failedPages: coverage.pagesFailed,
         completionRatio,
         rejectedCount: coverage.rejectedCount,
+        ...(coverage.retailers ? { retailers: coverage.retailers } : {}),
       };
     }
     await upstashCommand(url, token, [
@@ -147,6 +157,30 @@ export async function publishAll() {
 
     let pagesOk = 0;
     let pagesFailed = 0;
+
+    try {
+      const coverage = await buildCoverageSnapshot(marketCode);
+      await writeSnapshot(
+        url,
+        token,
+        makeKey(['consumer-prices', 'coverage', marketCode]),
+        coverage,
+        TTL,
+        advanceSeedMeta,
+        {
+          pagesOk: coverage.completedPages,
+          pagesFailed: coverage.failedPages,
+          rejectedCount: coverage.rejectedCount,
+          completionRatio: coverage.completionRatio,
+          status: coverage.status,
+          retailers: coverage.retailers,
+        },
+      );
+      pagesOk++;
+    } catch (err) {
+      pagesFailed++;
+      logger.error(`coverage:${marketCode} failed: ${err}`);
+    }
 
     try {
       const overview = await buildOverviewSnapshot(marketCode);

--- a/consumer-prices-core/src/jobs/scrape-coverage.test.ts
+++ b/consumer-prices-core/src/jobs/scrape-coverage.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyValidatorOutcome,
+  createScrapeRunStatement,
+  updateScrapeRunStatement,
+} from './scrape-coverage.js';
+
+describe('scrape coverage persistence and validator admission contracts', () => {
+  it('persists rejection counts at run creation and completion', () => {
+    const create = createScrapeRunStatement('retailer-1');
+    expect(create.sql).toContain('rejected_count');
+    expect(create.params).toEqual(['retailer-1']);
+
+    const update = updateScrapeRunStatement({
+      runId: 'run-1',
+      status: 'partial',
+      pagesAttempted: 12,
+      pagesSucceeded: 8,
+      errorsCount: 4,
+      rejectedCount: 3,
+    });
+    expect(update.sql).toContain('rejected_count=$6');
+    expect(update.params).toEqual(['run-1', 'partial', 12, 8, 4, 3]);
+  });
+
+  it('skips direct-pin validator rejects but preserves search candidates as non-admitted observations', () => {
+    expect(classifyValidatorOutcome({ ok: false }, true)).toEqual({
+      rejectedCount: 1,
+      skipObservation: true,
+      errorCount: 1,
+    });
+    expect(classifyValidatorOutcome({ ok: false }, false)).toEqual({
+      rejectedCount: 1,
+      skipObservation: false,
+      errorCount: 0,
+    });
+    expect(classifyValidatorOutcome({ ok: true }, false)).toEqual({
+      rejectedCount: 0,
+      skipObservation: false,
+      errorCount: 0,
+    });
+  });
+});

--- a/consumer-prices-core/src/jobs/scrape-coverage.ts
+++ b/consumer-prices-core/src/jobs/scrape-coverage.ts
@@ -1,0 +1,52 @@
+export interface ValidatorOutcome {
+  ok: boolean;
+}
+
+export interface ScrapeRunUpdate {
+  runId: string;
+  status: string;
+  pagesAttempted: number;
+  pagesSucceeded: number;
+  errorsCount: number;
+  rejectedCount: number;
+}
+
+export function createScrapeRunStatement(retailerId: string) {
+  return {
+    sql: `INSERT INTO scrape_runs (retailer_id, started_at, status, trigger_type, pages_attempted, pages_succeeded, errors_count, rejected_count, config_version)
+     VALUES ($1, NOW(), 'running', 'scheduled', 0, 0, 0, 0, '1') RETURNING id`,
+    params: [retailerId],
+  };
+}
+
+export function updateScrapeRunStatement(update: ScrapeRunUpdate) {
+  return {
+    sql: `UPDATE scrape_runs SET status=$2, finished_at=NOW(), pages_attempted=$3, pages_succeeded=$4, errors_count=$5, rejected_count=$6 WHERE id=$1`,
+    params: [
+      update.runId,
+      update.status,
+      update.pagesAttempted,
+      update.pagesSucceeded,
+      update.errorsCount,
+      update.rejectedCount,
+    ],
+  };
+}
+
+export function classifyValidatorOutcome(
+  validator: ValidatorOutcome | undefined,
+  wasDirectHit: boolean,
+) {
+  if (!validator || validator.ok) {
+    return { rejectedCount: 0, skipObservation: false, errorCount: 0 };
+  }
+  // Direct pins are admitted only when the strict validator passes. Search
+  // discoveries remain observable as candidates for the existing recovery and
+  // review workflow; their validator rejection is counted without promoting
+  // the candidate into aggregates (scrape.ts keeps matchStatus=candidate).
+  return {
+    rejectedCount: 1,
+    skipObservation: wasDirectHit,
+    errorCount: wasDirectHit ? 1 : 0,
+  };
+}

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -17,6 +17,11 @@ import type { AdapterContext } from '../adapters/types.js';
 import { upsertCanonicalProduct } from '../db/queries/products.js';
 import { getBasketItemId, getPinnedUrlsForRetailer, getDisabledPinsForRecovery, upsertProductMatch } from '../db/queries/matches.js';
 import { AUTO_MATCH_THRESHOLD, type ValidatorResult } from '../adapters/validator.js';
+import {
+  classifyValidatorOutcome,
+  createScrapeRunStatement,
+  updateScrapeRunStatement,
+} from './scrape-coverage.js';
 
 const logger = {
   info: (msg: string, ...args: unknown[]) => console.log(`[scrape] ${msg}`, ...args),
@@ -42,11 +47,8 @@ async function getOrCreateRetailer(slug: string, config: ReturnType<typeof loadR
 }
 
 async function createScrapeRun(retailerId: string): Promise<string> {
-  const result = await query<{ id: string }>(
-    `INSERT INTO scrape_runs (retailer_id, started_at, status, trigger_type, pages_attempted, pages_succeeded, errors_count, config_version)
-     VALUES ($1, NOW(), 'running', 'scheduled', 0, 0, 0, '1') RETURNING id`,
-    [retailerId],
-  );
+  const statement = createScrapeRunStatement(retailerId);
+  const result = await query<{ id: string }>(statement.sql, statement.params);
   return result.rows[0].id;
 }
 
@@ -56,11 +58,17 @@ async function updateScrapeRun(
   pagesAttempted: number,
   pagesSucceeded: number,
   errorsCount: number,
+  rejectedCount: number,
 ) {
-  await query(
-    `UPDATE scrape_runs SET status=$2, finished_at=NOW(), pages_attempted=$3, pages_succeeded=$4, errors_count=$5 WHERE id=$1`,
-    [runId, status, pagesAttempted, pagesSucceeded, errorsCount],
-  );
+  const statement = updateScrapeRunStatement({
+    runId,
+    status,
+    pagesAttempted,
+    pagesSucceeded,
+    errorsCount,
+    rejectedCount,
+  });
+  await query(statement.sql, statement.params);
 }
 
 // Pin disable + auto-recovery helpers extracted to ./scrape-pin-recovery.ts
@@ -131,6 +139,7 @@ export async function scrapeRetailer(slug: string) {
   let pagesAttempted = 0;
   let pagesSucceeded = 0;
   let errorsCount = 0;
+  let rejectedCount = 0;
 
   const delay = config.rateLimit?.delayBetweenRequestsMs ?? 2_000;
 
@@ -165,21 +174,22 @@ export async function scrapeRetailer(slug: string) {
         // as a second opinion that specifically catches pins that have
         // drifted onto the wrong product (e.g. "White Sugar 1kg" now
         // resolving to "mango sugar baby india"). If the validator
-        // disagrees, skip the observation entirely and route this target
-        // through the existing pin-error counter so the pin soft-disables
-        // after repeated failures. Aggregates never see the bad price.
-        if (wasDirectHit) {
-          const v = product.rawPayload.validator as ValidatorResult | undefined;
-          if (v && !v.ok) {
-            logger.warn(
-              `  [${target.id}] pin validator reject — skipping observation, counting as pin error. reasons=${v.reasons.join(',')} score=${v.score.toFixed(2)} title="${product.rawTitle}"`,
-            );
-            errorsCount++;
-            if (pinnedProductId && pinnedMatchId) {
-              await handlePinError(pinnedProductId, pinnedMatchId, target.id);
-            }
-            continue;
+        // disagrees, count the rejection for coverage. Direct-pin rejects
+        // still skip the observation entirely and route this target through
+        // the existing pin-error counter so the pin soft-disables after
+        // repeated failures. Aggregates never see the bad price.
+        const validator = product.rawPayload.validator as ValidatorResult | undefined;
+        const validatorOutcome = classifyValidatorOutcome(validator, wasDirectHit);
+        rejectedCount += validatorOutcome.rejectedCount;
+        if (validatorOutcome.skipObservation) {
+          logger.warn(
+            `  [${target.id}] pin validator reject — skipping observation, counting as pin error. reasons=${validator?.reasons?.join(',') || 'unknown'} score=${validator?.score?.toFixed(2) || '0.00'} title="${product.rawTitle}"`,
+          );
+          errorsCount += validatorOutcome.errorCount;
+          if (pinnedProductId && pinnedMatchId) {
+            await handlePinError(pinnedProductId, pinnedMatchId, target.id);
           }
+          continue;
         }
 
         const productId = await upsertRetailerProduct({
@@ -295,8 +305,8 @@ export async function scrapeRetailer(slug: string) {
   }
 
   const status = errorsCount === 0 ? 'completed' : pagesSucceeded > 0 ? 'partial' : 'failed';
-  await updateScrapeRun(runId, status, pagesAttempted, pagesSucceeded, errorsCount);
-  logger.info(`Run ${runId} finished: ${status} (${pagesSucceeded}/${pagesAttempted} pages)`);
+  await updateScrapeRun(runId, status, pagesAttempted, pagesSucceeded, errorsCount, rejectedCount);
+  logger.info(`Run ${runId} finished: ${status} (${pagesSucceeded}/${pagesAttempted} pages, rejected=${rejectedCount})`);
 
   const parseSuccessRate = pagesAttempted > 0 ? (pagesSucceeded / pagesAttempted) * 100 : 0;
   const isSuccess = status === 'completed' || status === 'partial';

--- a/consumer-prices-core/src/ops/coverage.test.ts
+++ b/consumer-prices-core/src/ops/coverage.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  summarizeMarketCoverage,
+  summarizeRetailerCoverage,
+} from './coverage.js';
+
+const retailer = (overrides: Partial<Parameters<typeof summarizeRetailerCoverage>[0]> = {}) => ({
+  slug: 'retailer-a',
+  name: 'Retailer A',
+  lastRunAt: '2026-08-01T00:00:00.000Z',
+  runStatus: 'completed',
+  pagesAttempted: 12,
+  pagesSucceeded: 12,
+  errorsCount: 0,
+  rejectedCount: 0,
+  ...overrides,
+});
+
+describe('consumer-price coverage summaries', () => {
+  it('reports partial retailer coverage and preserves validator rejection counts', () => {
+    const summary = summarizeRetailerCoverage(retailer({
+      pagesSucceeded: 8,
+      errorsCount: 4,
+      rejectedCount: 3,
+      runStatus: 'partial',
+    }));
+
+    expect(summary.failedPages).toBe(4);
+    expect(summary.completionRatio).toBe(0.6667);
+    expect(summary.rejectedCount).toBe(3);
+    expect(summary.coverageStatus).toBe('partial');
+  });
+
+  it('marks a market partial when one retailer is incomplete', () => {
+    const snapshot = summarizeMarketCoverage('ae', '2026-08-01T00:00:00.000Z', [
+      retailer(),
+      retailer({ slug: 'retailer-b', name: 'Retailer B', pagesSucceeded: 8, errorsCount: 4, runStatus: 'partial' }),
+    ]);
+
+    expect(snapshot.status).toBe('partial');
+    expect(snapshot.attemptedPages).toBe(24);
+    expect(snapshot.completedPages).toBe(20);
+    expect(snapshot.failedPages).toBe(4);
+    expect(snapshot.rejectedCount).toBe(0);
+    expect(snapshot.retailers).toHaveLength(2);
+  });
+
+  it('recovers to healthy only after every observed retailer completes', () => {
+    const recovered = summarizeMarketCoverage('ae', '2026-08-01T00:00:00.000Z', [
+      retailer(),
+      retailer({ slug: 'retailer-b', name: 'Retailer B' }),
+    ]);
+
+    expect(recovered.status).toBe('healthy');
+    expect(recovered.completionRatio).toBe(1);
+    expect(recovered.failedPages).toBe(0);
+  });
+
+  it('fails closed when no retailer produced a successful page', () => {
+    const snapshot = summarizeMarketCoverage('ke', '2026-08-01T00:00:00.000Z', [
+      retailer({ pagesSucceeded: 0, errorsCount: 12, runStatus: 'failed' }),
+    ]);
+
+    expect(snapshot.status).toBe('degraded');
+    expect(snapshot.completionRatio).toBe(0);
+  });
+
+  it('degrades below the market completion floor even when one page succeeds', () => {
+    const snapshot = summarizeMarketCoverage('ke', '2026-08-01T00:00:00.000Z', [
+      retailer({ pagesAttempted: 10, pagesSucceeded: 4, errorsCount: 6, runStatus: 'partial' }),
+    ]);
+
+    expect(snapshot.completionRatio).toBe(0.4);
+    expect(snapshot.minimumCompletionRatio).toBe(0.5);
+    expect(snapshot.status).toBe('degraded');
+  });
+
+  it('keeps mixed retailer states and an empty market explicit', () => {
+    const mixed = summarizeMarketCoverage('ae', '2026-08-01T00:00:00.000Z', [
+      retailer(),
+      retailer({ slug: 'retailer-b', pagesAttempted: 0, pagesSucceeded: 0, runStatus: null }),
+      retailer({ slug: 'retailer-c', pagesAttempted: 4, pagesSucceeded: 0, errorsCount: 4, runStatus: 'failed' }),
+    ]);
+
+    expect(mixed.status).toBe('partial');
+    expect(mixed.retailers.map((entry) => entry.coverageStatus)).toEqual(['healthy', 'unknown', 'failed']);
+
+    const empty = summarizeMarketCoverage('ch', '2026-08-01T00:00:00.000Z', []);
+    expect(empty.status).toBe('unknown');
+    expect(empty.completionRatio).toBeNull();
+    expect(empty.retailers).toEqual([]);
+  });
+
+  it('does not call an in-progress scrape healthy before it finishes', () => {
+    const snapshot = summarizeMarketCoverage('ae', '2026-08-01T00:00:00.000Z', [
+      retailer({ pagesSucceeded: 12, runStatus: 'running' }),
+    ]);
+
+    expect(snapshot.status).toBe('partial');
+    expect(snapshot.retailers[0].coverageStatus).toBe('partial');
+  });
+});

--- a/consumer-prices-core/src/ops/coverage.ts
+++ b/consumer-prices-core/src/ops/coverage.ts
@@ -1,0 +1,132 @@
+/**
+ * Operational scrape coverage summaries.
+ *
+ * This module reports what each retailer run attempted, completed, rejected,
+ * and failed. It deliberately does not change validator admission rules: a
+ * rejected observation remains rejected, and the count exists so partial
+ * publication is visible. Source parsing/provider recovery remain tracked by
+ * #5445 and #5811; this is the coordination/health layer only.
+ */
+
+export const MIN_MARKET_COMPLETION_RATIO = 0.5;
+
+export type RetailerCoverageStatus = 'healthy' | 'partial' | 'failed' | 'unknown';
+export type MarketCoverageStatus = 'healthy' | 'partial' | 'degraded' | 'unknown';
+
+export interface RetailerCoverageInput {
+  slug: string;
+  name: string;
+  lastRunAt: string | null;
+  runStatus: string | null;
+  pagesAttempted: number;
+  pagesSucceeded: number;
+  errorsCount: number;
+  rejectedCount: number;
+  activeRun?: ActiveScrapeRun | null;
+}
+
+export interface ActiveScrapeRun {
+  startedAt: string;
+  pagesAttempted: number;
+  pagesSucceeded: number;
+  errorsCount: number;
+  rejectedCount: number;
+}
+
+export interface RetailerCoverage extends RetailerCoverageInput {
+  failedPages: number;
+  completionRatio: number | null;
+  coverageStatus: RetailerCoverageStatus;
+}
+
+export interface MarketCoverageSnapshot {
+  marketCode: string;
+  asOf: string;
+  attemptedPages: number;
+  completedPages: number;
+  failedPages: number;
+  completionRatio: number | null;
+  rejectedCount: number;
+  status: MarketCoverageStatus;
+  minimumCompletionRatio: number;
+  retailers: RetailerCoverage[];
+  upstreamUnavailable: false;
+}
+
+function nonNegativeInt(value: number | null | undefined): number {
+  return Math.max(0, Math.floor(Number(value) || 0));
+}
+
+export function summarizeRetailerCoverage(input: RetailerCoverageInput): RetailerCoverage {
+  const pagesAttempted = nonNegativeInt(input.pagesAttempted);
+  const pagesSucceeded = Math.min(pagesAttempted, nonNegativeInt(input.pagesSucceeded));
+  const failedPages = Math.max(0, pagesAttempted - pagesSucceeded);
+  const errorsCount = nonNegativeInt(input.errorsCount);
+  const rejectedCount = nonNegativeInt(input.rejectedCount);
+  const completionRatio = pagesAttempted > 0
+    ? Number((pagesSucceeded / pagesAttempted).toFixed(4))
+    : null;
+
+  let coverageStatus: RetailerCoverageStatus = 'unknown';
+  if (pagesAttempted > 0 && pagesSucceeded === 0) coverageStatus = 'failed';
+  else if (
+    pagesAttempted > 0 &&
+    (input.runStatus !== 'completed' || failedPages > 0 || errorsCount > 0 || rejectedCount > 0)
+  ) coverageStatus = 'partial';
+  else if (pagesAttempted > 0) coverageStatus = 'healthy';
+
+  return {
+    ...input,
+    pagesAttempted,
+    pagesSucceeded,
+    errorsCount,
+    rejectedCount,
+    failedPages,
+    completionRatio,
+    coverageStatus,
+  };
+}
+
+export function summarizeMarketCoverage(
+  marketCode: string,
+  asOf: string,
+  inputs: RetailerCoverageInput[],
+): MarketCoverageSnapshot {
+  const retailers = inputs.map(summarizeRetailerCoverage);
+  const attemptedPages = retailers.reduce((sum, retailer) => sum + retailer.pagesAttempted, 0);
+  const completedPages = retailers.reduce((sum, retailer) => sum + retailer.pagesSucceeded, 0);
+  const failedPages = retailers.reduce((sum, retailer) => sum + retailer.failedPages, 0);
+  const rejectedCount = retailers.reduce((sum, retailer) => sum + retailer.rejectedCount, 0);
+  const completionRatio = attemptedPages > 0
+    ? Number((completedPages / attemptedPages).toFixed(4))
+    : null;
+  const hasSuccessfulRetailer = retailers.some((retailer) => retailer.pagesSucceeded > 0);
+  const hasUnknownRetailer = retailers.some((retailer) => retailer.coverageStatus === 'unknown');
+  const hasPartialRetailer = retailers.some((retailer) => retailer.coverageStatus === 'partial');
+  const hasFailedRetailer = retailers.some((retailer) => retailer.coverageStatus === 'failed');
+
+  let status: MarketCoverageStatus = 'unknown';
+  if (retailers.length > 0 && hasSuccessfulRetailer && completionRatio != null && completionRatio < MIN_MARKET_COMPLETION_RATIO) {
+    status = 'degraded';
+  } else if (retailers.length > 0 && hasSuccessfulRetailer && (hasUnknownRetailer || hasPartialRetailer || hasFailedRetailer || completionRatio !== 1)) {
+    status = 'partial';
+  } else if (retailers.length > 0 && hasSuccessfulRetailer && completionRatio === 1 && !hasUnknownRetailer) {
+    status = 'healthy';
+  } else if (retailers.length > 0 && !hasSuccessfulRetailer) {
+    status = 'degraded';
+  }
+
+  return {
+    marketCode,
+    asOf,
+    attemptedPages,
+    completedPages,
+    failedPages,
+    completionRatio,
+    rejectedCount,
+    status,
+    minimumCompletionRatio: MIN_MARKET_COMPLETION_RATIO,
+    retailers,
+    upstreamUnavailable: false,
+  };
+}

--- a/consumer-prices-core/src/snapshots/coverage.test.ts
+++ b/consumer-prices-core/src/snapshots/coverage.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockQuery = vi.fn();
+vi.mock('../db/client.js', () => ({ query: mockQuery }));
+
+const { buildCoverageSnapshot } = await import('./coverage.js');
+
+beforeEach(() => mockQuery.mockReset());
+
+describe('coverage snapshot persistence contract', () => {
+  it('uses the latest terminal run for LKG coverage and exposes a running probe separately', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{
+      slug: 'retailer-a',
+      name: 'Retailer A',
+      last_run_at: new Date('2026-08-01T00:00:00.000Z'),
+      run_status: 'completed',
+      pages_attempted: '12',
+      pages_succeeded: '12',
+      errors_count: '0',
+      rejected_count: '0',
+      active_started_at: new Date('2026-08-01T01:00:00.000Z'),
+      active_pages_attempted: '4',
+      active_pages_succeeded: '2',
+      active_errors_count: '1',
+      active_rejected_count: '1',
+    }] });
+
+    const snapshot = await buildCoverageSnapshot('ae');
+    expect(snapshot.status).toBe('healthy');
+    expect(snapshot.retailers[0]).toMatchObject({
+      lastRunAt: '2026-08-01T00:00:00.000Z',
+      rejectedCount: 0,
+      activeRun: {
+        startedAt: '2026-08-01T01:00:00.000Z',
+        pagesAttempted: 4,
+        pagesSucceeded: 2,
+        errorsCount: 1,
+        rejectedCount: 1,
+      },
+    });
+
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain("status IN ('completed', 'partial', 'failed')");
+    expect(sql).toContain("status = 'running'");
+    expect(mockQuery.mock.calls[0][1]).toEqual(['ae']);
+  });
+});

--- a/consumer-prices-core/src/snapshots/coverage.ts
+++ b/consumer-prices-core/src/snapshots/coverage.ts
@@ -1,0 +1,88 @@
+import { query } from '../db/client.js';
+import {
+  summarizeMarketCoverage,
+  type MarketCoverageSnapshot,
+  type RetailerCoverageInput,
+} from '../ops/coverage.js';
+
+interface LatestScrapeRunRow {
+  slug: string;
+  name: string;
+  last_run_at: Date | string | null;
+  run_status: string | null;
+  pages_attempted: number | string | null;
+  pages_succeeded: number | string | null;
+  errors_count: number | string | null;
+  rejected_count: number | string | null;
+  active_started_at: Date | string | null;
+  active_pages_attempted: number | string | null;
+  active_pages_succeeded: number | string | null;
+  active_errors_count: number | string | null;
+  active_rejected_count: number | string | null;
+}
+
+function asCount(value: number | string | null): number {
+  return Math.max(0, Number(value) || 0);
+}
+
+function asIso(value: Date | string | null): string | null {
+  if (!value) return null;
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+export async function buildCoverageSnapshot(marketCode: string): Promise<MarketCoverageSnapshot> {
+  const result = await query<LatestScrapeRunRow>(
+    `SELECT
+       r.slug,
+       r.name,
+       latest.started_at AS last_run_at,
+       latest.status AS run_status,
+       COALESCE(latest.pages_attempted, 0) AS pages_attempted,
+       COALESCE(latest.pages_succeeded, 0) AS pages_succeeded,
+       COALESCE(latest.errors_count, 0) AS errors_count,
+       COALESCE(latest.rejected_count, 0) AS rejected_count,
+       active.started_at AS active_started_at,
+       COALESCE(active.pages_attempted, 0) AS active_pages_attempted,
+       COALESCE(active.pages_succeeded, 0) AS active_pages_succeeded,
+       COALESCE(active.errors_count, 0) AS active_errors_count,
+       COALESCE(active.rejected_count, 0) AS active_rejected_count
+     FROM retailers r
+     LEFT JOIN LATERAL (
+       SELECT started_at, status, pages_attempted, pages_succeeded, errors_count, rejected_count
+       FROM scrape_runs
+       WHERE retailer_id = r.id AND status IN ('completed', 'partial', 'failed')
+       ORDER BY started_at DESC
+       LIMIT 1
+     ) latest ON TRUE
+     LEFT JOIN LATERAL (
+       SELECT started_at, pages_attempted, pages_succeeded, errors_count, rejected_count
+       FROM scrape_runs
+       WHERE retailer_id = r.id AND status = 'running'
+       ORDER BY started_at DESC
+       LIMIT 1
+     ) active ON TRUE
+     WHERE r.market_code = $1 AND r.active = true
+     ORDER BY r.slug`,
+    [marketCode],
+  );
+
+  const inputs: RetailerCoverageInput[] = result.rows.map((row) => ({
+    slug: row.slug,
+    name: row.name,
+    lastRunAt: asIso(row.last_run_at),
+    runStatus: row.run_status,
+    pagesAttempted: asCount(row.pages_attempted),
+    pagesSucceeded: asCount(row.pages_succeeded),
+    errorsCount: asCount(row.errors_count),
+    rejectedCount: asCount(row.rejected_count),
+    activeRun: row.active_started_at ? {
+      startedAt: asIso(row.active_started_at)!,
+      pagesAttempted: asCount(row.active_pages_attempted),
+      pagesSucceeded: asCount(row.active_pages_succeeded),
+      errorsCount: asCount(row.active_errors_count),
+      rejectedCount: asCount(row.active_rejected_count),
+    } : null,
+  }));
+
+  return summarizeMarketCoverage(marketCode, String(Date.now()), inputs);
+}

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -59,6 +59,16 @@ Primary health endpoint. Checks all Redis-backed data keys and seed freshness me
 
 With `?compact=1`, the `checks` object is replaced by `problems` containing only non-OK keys.
 
+### Consumer-price source coverage
+
+The consumer-prices-core service exposes `GET /wm/consumer-prices/v1/coverage?market=ae` (the service API key is required). Its response includes attempted, completed, failed, and validator-rejected page counts for the market and each active retailer. `status` is `healthy`, `partial`, or `degraded`; a partial result remains publishable, while a rejected observation is never admitted merely to improve the coverage count. The publisher writes the same snapshot to `consumer-prices:coverage:<market>` and includes its aggregate completion ratio in `seed-meta`, so `/api/health` can distinguish a fresh partial run from a stopped producer.
+
+This operational contract complements, rather than replaces, the source-quality work in [#5445](https://github.com/koala73/worldmonitor/issues/5445) and [#5811](https://github.com/koala73/worldmonitor/issues/5811).
+
+### Relay ingestion telemetry
+
+The relay's public `GET /health` keeps the top-level `status: "ok"` contract for process-liveness probes. Its nested `ingestion.status` is the application-level verdict: it becomes `degraded` when aviation or RSS served coverage falls below its configured floor, or when AIS snapshot requests have no served snapshot. `GET /metrics` exposes the rolling-window per-route counters for success, throttle, timeout, authentication rejection, fallback, terminal failure, served coverage, cooldowns, and RSS feed backoff. AIS snapshot `unauthorizedClient` is tracked separately from upstream authentication failures so client traffic cannot be mistaken for provider health.
+
 ### Key Classifications
 
 Keys are grouped into three tiers that determine alert severity:

--- a/scripts/_ingestion-coverage.cjs
+++ b/scripts/_ingestion-coverage.cjs
@@ -1,0 +1,61 @@
+'use strict';
+
+// Shared operational contract for relay-backed ingestion routes. The relay
+// records these classes without changing the data-serving fallback behavior;
+// callers can therefore distinguish expected throttling from application
+// faults and can decide whether the served result is still usable.
+const OUTCOME_FIELDS = Object.freeze([
+  'success',
+  'throttle',
+  'timeout',
+  'authRejection',
+  'fallback',
+  'terminalFailure',
+]);
+
+const AVIATION_MIN_SERVED_COVERAGE = 0.5;
+const RSS_MIN_SERVED_COVERAGE = 0.7;
+
+function isTimeoutError(error) {
+  const message = String(error?.message || error || '').toLowerCase();
+  return error?.name === 'TimeoutError' || /timed? ?out|timeout|timed out/.test(message);
+}
+
+function classifyUpstreamOutcome({ status, error } = {}) {
+  if (status === 429) return 'throttle';
+  if (status === 401 || status === 403) return 'authRejection';
+  if (isTimeoutError(error) || status === 408 || status === 504) return 'timeout';
+  if (Number.isFinite(status) && status >= 200 && status < 300) return 'success';
+  return 'terminalFailure';
+}
+
+function nextBackoffMs(previousFailures, baseMs, maxMs) {
+  const failures = Math.max(0, Math.floor(Number(previousFailures) || 0));
+  const base = Math.max(1, Number(baseMs) || 1);
+  const cap = Math.max(base, Number(maxMs) || base);
+  return Math.min(base * (2 ** failures), cap);
+}
+
+function summarizeServedCoverage({ requests = 0, served = 0, minimum } = {}) {
+  const observed = Math.max(0, Math.floor(Number(requests) || 0));
+  const delivered = Math.max(0, Math.min(observed, Math.floor(Number(served) || 0)));
+  const minimumCoverage = Math.max(0, Math.min(1, Number(minimum) || 0));
+  const servedCoverage = observed > 0 ? Number((delivered / observed).toFixed(4)) : null;
+  return {
+    requests: observed,
+    served: delivered,
+    servedCoverage,
+    minimumCoverage,
+    status: observed === 0 ? 'not_observed' : servedCoverage < minimumCoverage ? 'degraded' : 'ok',
+  };
+}
+
+module.exports = {
+  AVIATION_MIN_SERVED_COVERAGE,
+  OUTCOME_FIELDS,
+  RSS_MIN_SERVED_COVERAGE,
+  classifyUpstreamOutcome,
+  isTimeoutError,
+  nextBackoffMs,
+  summarizeServedCoverage,
+};

--- a/scripts/_ingestion-coverage.cjs
+++ b/scripts/_ingestion-coverage.cjs
@@ -33,7 +33,11 @@ function nextBackoffMs(previousFailures, baseMs, maxMs) {
   const failures = Math.max(0, Math.floor(Number(previousFailures) || 0));
   const base = Math.max(1, Number(baseMs) || 1);
   const cap = Math.max(base, Number(maxMs) || base);
-  return Math.min(base * (2 ** failures), cap);
+  const delay = Math.min(base * (2 ** failures), cap);
+  // Add jitter (±25%) to prevent thundering herd when multiple feeds
+  // enter backoff at the same time (e.g., after a correlated failure).
+  // Jitter is bounded by the cap so repeated calls never exceed maxMs.
+  return Math.min(cap, Math.round(delay * (0.75 + Math.random() * 0.5)));
 }
 
 function summarizeServedCoverage({ requests = 0, served = 0, minimum } = {}) {

--- a/scripts/_insights-brief.mjs
+++ b/scripts/_insights-brief.mjs
@@ -8,6 +8,12 @@ import {
   verifyCitationIndexes,
 } from './shared/brief-llm-core.js';
 
+// A dotted acronym ("U.S.", "U.N.", "D.O.J.") followed by a lowercase word.
+// Sentences start with a capital, so this run is necessarily mid-clause and its
+// periods are not sentence boundaries. Deliberately narrow — see the sentence
+// split in composeSynthesizedBrief for why the ambiguous cases must not match.
+const MIDSENTENCE_DOTTED_ACRONYM = /\b[A-Z]\.(?:[A-Z]\.?)+(?=\s+\p{Ll})/gu;
+
 /**
  * Choose which clustered story to summarize for the WORLD BRIEF.
  *
@@ -200,7 +206,21 @@ export function composeSynthesizedBrief(rawText, topStories, opts = {}) {
   let strippedCitations = 0;
   const leadCheck = verifyCitationIndexes(parsed.lead, topStories.length);
   strippedCitations += leadCheck.stripped;
-  const leadSentences = leadCheck.text.split(/(?<=[.!?])\s+/).filter((sentence) => sentence.trim().length > 0);
+  // #5947: a dotted acronym mid-clause ("U.S. embassies") was read as a
+  // sentence boundary, so the fragment ending at "U.S." inherited the previous
+  // clause's citations and "us" grounded against the wrong story — rejecting
+  // otherwise-valid briefs. Collapse the dots ONLY when the acronym is followed
+  // by a lowercase word, which cannot start a sentence and is therefore
+  // provably mid-clause. A capitalized continuation stays a boundary: review of
+  // this fix showed that collapsing every acronym merged genuine sentences into
+  // one validation unit whose citation set was the UNION of both, re-opening
+  // the misattribution #4928 closed and letting an uncited sentence ride inside
+  // a cited one. Ambiguity must fail closed. Only the gate's view changes — the
+  // published lead below stays leadCheck.text, punctuation intact.
+  const leadSentences = leadCheck.text
+    .replace(MIDSENTENCE_DOTTED_ACRONYM, (acronym) => acronym.replace(/\./g, ''))
+    .split(/(?<=[.!?])\s+/)
+    .filter((sentence) => sentence.trim().length > 0);
   if (leadSentences.length === 0) return null;
   for (const sentence of leadSentences) {
     const cited = [...sentence.matchAll(/\[(\d{1,3})\]/g)]

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -946,10 +946,11 @@ export function extraKeyPayloadBytes(key, data, envelopeMeta) {
   return Buffer.byteLength(serializeExtraKeyValue(key, data, envelopeMeta), 'utf8');
 }
 
-export async function writeSeedMeta(dataKey, recordCount, metaKeyOverride, metaTtlSeconds) {
+export async function writeSeedMeta(dataKey, recordCount, metaKeyOverride, metaTtlSeconds, coverage) {
   const { url, token } = getRedisCredentials();
   const metaKey = metaKeyOverride || `seed-meta:${dataKey.replace(/:v\d+$/, '')}`;
   const meta = { fetchedAt: Date.now(), recordCount: recordCount ?? 0 };
+  if (coverage) meta.coverage = coverage;
   const metaTtl = metaTtlSeconds ?? 86400 * 7;
   const resp = await fetch(url, {
     method: 'POST',
@@ -964,9 +965,9 @@ export async function writeSeedMeta(dataKey, recordCount, metaKeyOverride, metaT
   return true;
 }
 
-export async function writeExtraKeyWithMeta(key, data, ttl, recordCount, metaKeyOverride, metaTtlSeconds) {
+export async function writeExtraKeyWithMeta(key, data, ttl, recordCount, metaKeyOverride, metaTtlSeconds, coverage) {
   await writeExtraKey(key, data, ttl);
-  return writeSeedMeta(key, recordCount, metaKeyOverride, metaTtlSeconds);
+  return writeSeedMeta(key, recordCount, metaKeyOverride, metaTtlSeconds, coverage);
 }
 
 // Detailed counterpart to extendExistingTtl. Results stay aligned to the input

--- a/scripts/ais-relay-ingestion.test.cjs
+++ b/scripts/ais-relay-ingestion.test.cjs
@@ -1,0 +1,146 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { once } = require('node:events');
+const http = require('node:http');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const test = require('node:test');
+
+function get(port, requestPath) {
+  return new Promise((resolve, reject) => {
+    const request = http.get({ hostname: '127.0.0.1', port, path: requestPath }, (response) => {
+      const chunks = [];
+      response.on('data', (chunk) => chunks.push(chunk));
+      response.on('end', () => resolve({
+        status: response.statusCode,
+        headers: response.headers,
+        body: Buffer.concat(chunks).toString(),
+      }));
+    });
+    request.on('error', reject);
+  });
+}
+
+async function stop(child) {
+  if (child.exitCode != null) return;
+  child.kill('SIGTERM');
+  await Promise.race([
+    once(child, 'exit'),
+    new Promise((resolve) => setTimeout(resolve, 2_000)),
+  ]);
+  if (child.exitCode == null) child.kill('SIGKILL');
+}
+
+test('relay handlers expose bounded Google/OpenSky cooldowns and RSS fallback metrics', async () => {
+  const preload = path.join(__dirname, 'ais-relay-test-preload.cjs');
+  const relay = path.join(__dirname, 'ais-relay.cjs');
+  const child = spawn(process.execPath, [relay], {
+    cwd: path.join(__dirname, '..'),
+    env: {
+      ...process.env,
+      PORT: '0',
+      RELAY_TEST_MODE: 'true',
+      RELAY_SHARED_SECRET: '',
+      I_UNDERSTAND_THIS_DISABLES_AUTH: 'true',
+      RELAY_RATE_LIMIT_MAX: '1000',
+      RELAY_GOOGLE_FLIGHTS_RATE_LIMIT_MAX: '1000',
+      RELAY_OPENSKY_RATE_LIMIT_MAX: '1000',
+      RELAY_RSS_RATE_LIMIT_MAX: '1000',
+      RELAY_TEST_RSS_CACHE_TTL_MS: '10',
+      GF_429_COOLDOWN_MS: '60000',
+      OPENSKY_429_COOLDOWN_MS: '60000',
+      OPENSKY_REQUEST_SPACING_MS: '1',
+      OPENSKY_CLIENT_ID: 'test-client',
+      OPENSKY_CLIENT_SECRET: 'test-secret',
+      RELAY_TEST_GOOGLE_STATUS_SEQUENCE: '429',
+      NODE_OPTIONS: `--require=${preload}`,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let output = '';
+  let port;
+  const ready = new Promise((resolve, reject) => {
+    const onData = (chunk) => {
+      output += chunk.toString();
+      const portMatch = output.match(/WebSocket relay on port (\d+)/);
+      if (portMatch) port = Number(portMatch[1]);
+      if (port && output.includes('Test mode enabled')) resolve();
+    };
+    child.stdout.on('data', onData);
+    child.stderr.on('data', (chunk) => { output += chunk.toString(); });
+    child.once('error', reject);
+    child.once('exit', (code) => {
+      if (code !== null && code !== 0) reject(new Error(`relay exited ${code}: ${output}`));
+    });
+  });
+
+  try {
+    await ready;
+
+    const googleFirst = await get(port, '/google-flights/search?origin=DXB&destination=LHR&departure_date=2026-08-03');
+    assert.equal(googleFirst.status, 502);
+    assert.match(googleFirst.body, /Google Flights returned 429/);
+
+    const googleDuringCooldown = await get(port, '/google-flights/search?origin=JFK&destination=LAX&departure_date=2026-08-04');
+    assert.equal(googleDuringCooldown.status, 200);
+    assert.equal(JSON.parse(googleDuringCooldown.body).cooldown, true);
+    assert.ok(Number(googleDuringCooldown.headers['retry-after']) >= 1);
+
+    const openskyFirst = await get(port, '/opensky/states/all?lamin=1&lomin=1&lamax=2&lomax=2');
+    assert.equal(openskyFirst.status, 429);
+    assert.ok(Number(openskyFirst.headers['retry-after']) >= 1);
+
+    const openskyDuringCooldown = await get(port, '/opensky/states/all?lamin=3&lomin=3&lamax=4&lomax=4');
+    assert.equal(openskyDuringCooldown.status, 200);
+    assert.equal(openskyDuringCooldown.headers['x-cache'], 'RATE-LIMITED');
+    assert.ok(Number(openskyDuringCooldown.headers['retry-after']) >= 1);
+
+    const noCacheFeed = 'https://feeds.bbci.co.uk/news/world/rss.xml?test=no-cache';
+    const rssFirstFailure = await get(port, `/rss?url=${encodeURIComponent(noCacheFeed)}`);
+    assert.equal(rssFirstFailure.status, 502);
+    assert.ok(Number(rssFirstFailure.headers['retry-after']) >= 1);
+    const rssBackoffFailure = await get(port, `/rss?url=${encodeURIComponent(noCacheFeed)}`);
+    assert.equal(rssBackoffFailure.status, 503);
+    assert.ok(Number(rssBackoffFailure.headers['retry-after']) >= 1);
+
+    const staleFeed = 'https://feeds.bbci.co.uk/news/world/rss.xml?test=stale';
+    const rssFresh = await get(port, `/rss?url=${encodeURIComponent(staleFeed)}`);
+    assert.equal(rssFresh.status, 200);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const rssStale = await get(port, `/rss?url=${encodeURIComponent(staleFeed)}`);
+    assert.equal(rssStale.status, 200);
+    assert.equal(rssStale.headers['x-cache'], 'STALE');
+    const rssBackoffStale = await get(port, `/rss?url=${encodeURIComponent(staleFeed)}`);
+    assert.equal(rssBackoffStale.status, 200);
+    assert.equal(rssBackoffStale.headers['x-cache'], 'BACKOFF-STALE');
+
+    const aisEmpty = await get(port, '/ais/snapshot');
+    assert.equal(aisEmpty.status, 200);
+
+    const health = JSON.parse((await get(port, '/health')).body);
+    assert.equal(health.status, 'ok');
+    assert.equal(health.ingestion.status, 'degraded');
+    assert.equal(health.ingestion.aisSnapshot.served, 0);
+    assert.equal(health.ingestion.aisSnapshot.connected, false);
+
+    const metrics = JSON.parse((await get(port, '/metrics')).body);
+    assert.equal(metrics.googleFlights.requests, 2);
+    assert.ok(metrics.googleFlights.throttle >= 2);
+    assert.equal(metrics.googleFlights.fallback, 0, 'cooldown-only empty results are not usable fallback data');
+    assert.ok(metrics.googleFlights.cooldownRemainingMs > 0);
+    assert.equal(metrics.opensky.requests, 2);
+    assert.ok(metrics.opensky.throttle >= 2);
+    assert.ok(metrics.opensky.global429CooldownRemainingMs > 0);
+    assert.ok(metrics.rss.requests >= 5);
+    assert.ok(metrics.rss.fallback >= 1);
+    assert.ok(metrics.rss.backoffActiveFeeds >= 2);
+    assert.ok(metrics.rss.maxBackoffRemainingMs > 0);
+    assert.equal(metrics.aisSnapshot.success, 0);
+    assert.equal(metrics.aisSnapshot.served, 0);
+    assert.ok(metrics.aisSnapshot.terminalFailure >= 1);
+  } finally {
+    await stop(child);
+  }
+});

--- a/scripts/ais-relay-rss.test.cjs
+++ b/scripts/ais-relay-rss.test.cjs
@@ -9,6 +9,7 @@
 const { strict: assert } = require('node:assert');
 const http = require('node:http');
 const test = require('node:test');
+const { nextBackoffMs } = require('./_ingestion-coverage.cjs');
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -443,4 +444,9 @@ test('RSS proxy: stale-on-error resolves in-flight (no hang)', async (_t) => {
   assert.equal(proxy.inFlight.size, 0, 'In-flight map should be empty after settlement');
 
   proxy.server.close();
+});
+
+test('RSS fallback exhaustion: repeated failures stop at the bounded cooldown cap', () => {
+  const delays = [0, 1, 2, 3, 4, 5].map((failures) => nextBackoffMs(failures, 60_000, 900_000));
+  assert.deepEqual(delays, [60_000, 120_000, 240_000, 480_000, 900_000, 900_000]);
 });

--- a/scripts/ais-relay-rss.test.cjs
+++ b/scripts/ais-relay-rss.test.cjs
@@ -448,5 +448,11 @@ test('RSS proxy: stale-on-error resolves in-flight (no hang)', async (_t) => {
 
 test('RSS fallback exhaustion: repeated failures stop at the bounded cooldown cap', () => {
   const delays = [0, 1, 2, 3, 4, 5].map((failures) => nextBackoffMs(failures, 60_000, 900_000));
-  assert.deepEqual(delays, [60_000, 120_000, 240_000, 480_000, 900_000, 900_000]);
+  // Each delay is deterministic-base ±25% jitter, capped at maxMs.
+  assert.ok(delays[0] >= 45_000 && delays[0] <= 75_000, `delay[0]=${delays[0]} out of range`);
+  assert.ok(delays[1] >= 90_000 && delays[1] <= 150_000, `delay[1]=${delays[1]} out of range`);
+  assert.ok(delays[2] >= 180_000 && delays[2] <= 300_000, `delay[2]=${delays[2]} out of range`);
+  assert.ok(delays[3] >= 360_000 && delays[3] <= 600_000, `delay[3]=${delays[3]} out of range`);
+  assert.ok(delays[4] >= 675_000 && delays[4] <= 900_000, `delay[4]=${delays[4]} out of range (capped)`);
+  assert.ok(delays[5] >= 675_000 && delays[5] <= 900_000, `delay[5]=${delays[5]} out of range (capped)`);
 });

--- a/scripts/ais-relay-test-preload.cjs
+++ b/scripts/ais-relay-test-preload.cjs
@@ -1,0 +1,117 @@
+'use strict';
+
+// Deterministic upstreams for ais-relay-ingestion.test.cjs. This file is only
+// loaded through NODE_OPTIONS by that test; production relay processes never
+// load it.
+const { EventEmitter } = require('node:events');
+const https = require('node:https');
+
+const googleStatuses = (process.env.RELAY_TEST_GOOGLE_STATUS_SEQUENCE || '429')
+  .split(',')
+  .map((value) => Number(value.trim()))
+  .filter(Number.isFinite);
+const rssCalls = new Map();
+
+function nextValue(values, fallback) {
+  return values.length > 0 ? values.shift() : fallback;
+}
+
+function targetUrl(input) {
+  if (typeof input === 'string') return new URL(input);
+  if (input?.href) return new URL(input.href);
+  const protocol = input?.protocol || 'https:';
+  const hostname = input?.hostname || input?.host || 'localhost';
+  const port = input?.port ? `:${input.port}` : '';
+  const path = input?.path || '/';
+  return new URL(`${protocol}//${hostname}${port}${path}`);
+}
+
+function response(statusCode, body, headers, callback) {
+  const result = new EventEmitter();
+  result.statusCode = statusCode;
+  result.headers = headers;
+  process.nextTick(() => {
+    callback(result);
+    process.nextTick(() => {
+      if (body) result.emit('data', Buffer.from(body));
+      result.emit('end');
+    });
+  });
+}
+
+function request({ callback, statusCode, body = '', headers = {}, error = null }) {
+  const req = new EventEmitter();
+  req.write = () => {};
+  req.end = () => {};
+  req.setTimeout = () => req;
+  req.destroy = () => req;
+  process.nextTick(() => {
+    if (error) {
+      const err = new Error(error);
+      err.code = 'ECONNRESET';
+      req.emit('error', err);
+      return;
+    }
+    response(statusCode, body, headers, callback);
+  });
+  return req;
+}
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = async (url) => {
+  if (String(url).includes('FlightsFrontendService')) {
+    const status = nextValue(googleStatuses, 200);
+    return {
+      status,
+      ok: status >= 200 && status < 300,
+      text: async () => '',
+    };
+  }
+  if (typeof originalFetch === 'function') return originalFetch(url);
+  throw new Error(`Unexpected test fetch: ${url}`);
+};
+
+const originalRequest = https.request;
+https.request = function patchedRequest(...args) {
+  const [input, options, callback] = args;
+  const cb = typeof options === 'function' ? options : callback;
+  const parsed = targetUrl(input);
+  if (parsed.hostname === 'auth.opensky-network.org') {
+    return request({
+      callback: cb,
+      statusCode: 200,
+      body: JSON.stringify({ access_token: 'test-opensky-token', expires_in: 3600 }),
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  return originalRequest.apply(this, args);
+};
+
+const originalGet = https.get;
+https.get = function patchedGet(...args) {
+  const [input, options, callback] = args;
+  const cb = typeof options === 'function' ? options : callback;
+  const parsed = targetUrl(input);
+  if (parsed.hostname === 'opensky-network.org') {
+    return request({
+      callback: cb,
+      statusCode: 429,
+      body: JSON.stringify({ states: [], time: Date.now() }),
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  if (parsed.hostname === 'feeds.bbci.co.uk') {
+    const key = parsed.searchParams.get('test') || parsed.pathname;
+    const callNumber = (rssCalls.get(key) || 0) + 1;
+    rssCalls.set(key, callNumber);
+    const mode = key === 'stale' && callNumber === 1 ? 'success' : 'error';
+    if (mode === 'error') return request({ callback: cb, error: 'RSS upstream reset' });
+    return request({
+      callback: cb,
+      statusCode: 200,
+      body: '<rss><channel><title>test</title></channel></rss>',
+      headers: { 'content-type': 'application/rss+xml' },
+    });
+  }
+  return originalGet.apply(this, args);
+};

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -38,6 +38,13 @@ const {
   classifySetNxResult,
   recordDedupOutcome,
 } = require('./shared/notification-dedup.cjs');
+const {
+  AVIATION_MIN_SERVED_COVERAGE,
+  RSS_MIN_SERVED_COVERAGE,
+  classifyUpstreamOutcome,
+  nextBackoffMs,
+  summarizeServedCoverage,
+} = require('./_ingestion-coverage.cjs');
 const { maintainClosedMarketEquityKeys: maintainClosedMarketEquityKeysWithDeps } = require('./shared/closed-market-equity-maintenance.cjs');
 const { getUsEquitySession, isMultiMarketEquityTradingDay } = require('./shared/market-hours.cjs');
 const { mergeLastGoodQuotes, planYahooRefresh } = require('./shared/market-quote-refresh.cjs');
@@ -60,6 +67,7 @@ console.log(`[Relay] Heap limit: ${(_heapStats.heap_size_limit / 1024 / 1024).to
 const AISSTREAM_URL = 'wss://stream.aisstream.io/v0/stream';
 const API_KEY = process.env.AISSTREAM_API_KEY || process.env.VITE_AISSTREAM_API_KEY;
 const PORT = process.env.PORT || 3004;
+const RELAY_TEST_MODE = process.env.RELAY_TEST_MODE === 'true';
 
 if (!API_KEY) {
   console.warn('[Relay] AIS disabled: AISSTREAM_API_KEY is not set (other relay and seed services remain available)');
@@ -108,6 +116,8 @@ const RELAY_OPENSKY_RATE_LIMIT_MAX = Number.isFinite(Number(process.env.RELAY_OP
   ? Number(process.env.RELAY_OPENSKY_RATE_LIMIT_MAX) : 600;
 const RELAY_RSS_RATE_LIMIT_MAX = Number.isFinite(Number(process.env.RELAY_RSS_RATE_LIMIT_MAX))
   ? Number(process.env.RELAY_RSS_RATE_LIMIT_MAX) : 300;
+const RELAY_GOOGLE_FLIGHTS_RATE_LIMIT_MAX = Number.isFinite(Number(process.env.RELAY_GOOGLE_FLIGHTS_RATE_LIMIT_MAX))
+  ? Number(process.env.RELAY_GOOGLE_FLIGHTS_RATE_LIMIT_MAX) : 60;
 const RELAY_LOG_THROTTLE_MS = Math.max(1000, Number(process.env.RELAY_LOG_THROTTLE_MS || 10000));
 const ALLOW_VERCEL_PREVIEW_ORIGINS = process.env.ALLOW_VERCEL_PREVIEW_ORIGINS === 'true';
 
@@ -675,6 +685,11 @@ async function publishNotificationEvent({ eventType, payload, severity, variant,
 }
 
 let upstreamSocket = null;
+let upstreamReconnectTimer = null;
+let upstreamReconnectFailures = 0;
+let relayShuttingDown = false;
+const AIS_RECONNECT_BASE_MS = 5_000;
+const AIS_RECONNECT_MAX_MS = 5 * 60 * 1000;
 let upstreamPaused = false;
 let upstreamQueue = [];
 let upstreamQueueReadIndex = 0;
@@ -6684,6 +6699,7 @@ function getRouteGroup(pathname) {
   if (pathname.startsWith('/wingbits/track')) return 'wingbits';
   if (pathname.startsWith('/opensky')) return 'opensky';
   if (pathname.startsWith('/rss')) return 'rss';
+  if (pathname.startsWith('/google-flights')) return 'google-flights';
   if (pathname.startsWith('/ais/snapshot')) return 'snapshot';
   if (pathname.startsWith('/worldbank')) return 'worldbank';
   if (pathname.startsWith('/polymarket')) return 'polymarket';
@@ -6698,6 +6714,7 @@ function getRouteGroup(pathname) {
 function getRateLimitForPath(pathname) {
   if (pathname.startsWith('/opensky')) return RELAY_OPENSKY_RATE_LIMIT_MAX;
   if (pathname.startsWith('/rss')) return RELAY_RSS_RATE_LIMIT_MAX;
+  if (pathname.startsWith('/google-flights')) return RELAY_GOOGLE_FLIGHTS_RATE_LIMIT_MAX;
   if (pathname.startsWith('/oref')) return RELAY_OREF_RATE_LIMIT_MAX;
   return RELAY_RATE_LIMIT_MAX;
 }
@@ -6745,24 +6762,42 @@ const relayMetricsLifetime = {
   openskyDedupEmpty: 0,
   openskyMiss: 0,
   openskyUpstreamFetches: 0,
+  openskyServed: 0,
+  openskySuccess: 0,
+  openskyThrottle: 0,
+  openskyTimeout: 0,
+  openskyAuthRejection: 0,
+  openskyFallback: 0,
+  openskyTerminalFailure: 0,
   drops: 0,
   notificationDedupSetNxErrors: 0,
   notificationDedupSetNxFailOpen: 0,
   notificationDedupSetNxFailClosed: 0,
+  googleFlightsRequests: 0,
+  googleFlightsServed: 0,
   googleFlightsSuccess: 0,
   googleFlights429: 0,
+  googleFlightsThrottle: 0,
   googleFlightsTimeout: 0,
   googleFlightsAuthRejection: 0,
+  googleFlightsFallback: 0,
   googleFlightsTerminalFailure: 0,
+  rssRequests: 0,
+  rssServed: 0,
   rssSuccess: 0,
+  rssThrottle: 0,
   rssTimeout: 0,
   rssAuthRejection: 0,
   rssFallback: 0,
   rssTerminalFailure: 0,
+  aisSnapshotRequests: 0,
+  aisSnapshotServed: 0,
   aisSnapshotSuccess: 0,
+  aisSnapshotThrottle: 0,
   aisSnapshotTimeout: 0,
   aisSnapshotAuthRejection: 0,
   aisSnapshotUnauthorizedClient: 0,
+  aisSnapshotFallback: 0,
   aisSnapshotTerminalFailure: 0,
 };
 let relayMetricsQueueMaxLifetime = 0;
@@ -6780,25 +6815,43 @@ function createRelayMetricsBucket() {
     openskyDedupEmpty: 0,
     openskyMiss: 0,
     openskyUpstreamFetches: 0,
+    openskyServed: 0,
+    openskySuccess: 0,
+    openskyThrottle: 0,
+    openskyTimeout: 0,
+    openskyAuthRejection: 0,
+    openskyFallback: 0,
+    openskyTerminalFailure: 0,
     drops: 0,
     notificationDedupSetNxErrors: 0,
     notificationDedupSetNxFailOpen: 0,
     notificationDedupSetNxFailClosed: 0,
     queueMax: 0,
+    googleFlightsRequests: 0,
+    googleFlightsServed: 0,
     googleFlightsSuccess: 0,
     googleFlights429: 0,
+    googleFlightsThrottle: 0,
     googleFlightsTimeout: 0,
     googleFlightsAuthRejection: 0,
+    googleFlightsFallback: 0,
     googleFlightsTerminalFailure: 0,
+    rssRequests: 0,
+    rssServed: 0,
     rssSuccess: 0,
+    rssThrottle: 0,
     rssTimeout: 0,
     rssAuthRejection: 0,
     rssFallback: 0,
     rssTerminalFailure: 0,
+    aisSnapshotRequests: 0,
+    aisSnapshotServed: 0,
     aisSnapshotSuccess: 0,
+    aisSnapshotThrottle: 0,
     aisSnapshotTimeout: 0,
     aisSnapshotAuthRejection: 0,
     aisSnapshotUnauthorizedClient: 0,
+    aisSnapshotFallback: 0,
     aisSnapshotTerminalFailure: 0,
   };
 }
@@ -6846,6 +6899,47 @@ function incrementRelayMetric(field, amount = 1) {
   }
 }
 
+const RELAY_OUTCOME_FIELDS = Object.freeze({
+  opensky: Object.freeze({
+    success: 'openskySuccess',
+    throttle: 'openskyThrottle',
+    timeout: 'openskyTimeout',
+    authRejection: 'openskyAuthRejection',
+    fallback: 'openskyFallback',
+    terminalFailure: 'openskyTerminalFailure',
+  }),
+  googleFlights: Object.freeze({
+    success: 'googleFlightsSuccess',
+    throttle: 'googleFlightsThrottle',
+    timeout: 'googleFlightsTimeout',
+    authRejection: 'googleFlightsAuthRejection',
+    fallback: 'googleFlightsFallback',
+    terminalFailure: 'googleFlightsTerminalFailure',
+  }),
+  rss: Object.freeze({
+    success: 'rssSuccess',
+    throttle: 'rssThrottle',
+    timeout: 'rssTimeout',
+    authRejection: 'rssAuthRejection',
+    fallback: 'rssFallback',
+    terminalFailure: 'rssTerminalFailure',
+  }),
+  aisSnapshot: Object.freeze({
+    success: 'aisSnapshotSuccess',
+    throttle: 'aisSnapshotThrottle',
+    timeout: 'aisSnapshotTimeout',
+    authRejection: 'aisSnapshotAuthRejection',
+    fallback: 'aisSnapshotFallback',
+    terminalFailure: 'aisSnapshotTerminalFailure',
+  }),
+});
+
+function recordRelayOutcome(route, outcome, amount = 1) {
+  const metricField = RELAY_OUTCOME_FIELDS[route]?.[outcome];
+  if (!metricField) return;
+  incrementRelayMetric(metricField, amount);
+}
+
 function sampleRelayQueueSize(queueSize) {
   const bucket = getRelayMetricsBucket();
   if (queueSize > bucket.queueMax) bucket.queueMax = queueSize;
@@ -6873,30 +6967,78 @@ function getRelayRollingMetrics() {
     rollup.openskyDedupEmpty += bucket.openskyDedupEmpty;
     rollup.openskyMiss += bucket.openskyMiss;
     rollup.openskyUpstreamFetches += bucket.openskyUpstreamFetches;
+    rollup.openskyServed += bucket.openskyServed;
+    rollup.openskySuccess += bucket.openskySuccess;
+    rollup.openskyThrottle += bucket.openskyThrottle;
+    rollup.openskyTimeout += bucket.openskyTimeout;
+    rollup.openskyAuthRejection += bucket.openskyAuthRejection;
+    rollup.openskyFallback += bucket.openskyFallback;
+    rollup.openskyTerminalFailure += bucket.openskyTerminalFailure;
     rollup.drops += bucket.drops;
     rollup.notificationDedupSetNxErrors += bucket.notificationDedupSetNxErrors;
     rollup.notificationDedupSetNxFailOpen += bucket.notificationDedupSetNxFailOpen;
     rollup.notificationDedupSetNxFailClosed += bucket.notificationDedupSetNxFailClosed;
+    rollup.googleFlightsRequests += bucket.googleFlightsRequests;
+    rollup.googleFlightsServed += bucket.googleFlightsServed;
     rollup.googleFlightsSuccess += bucket.googleFlightsSuccess;
     rollup.googleFlights429 += bucket.googleFlights429;
+    rollup.googleFlightsThrottle += bucket.googleFlightsThrottle;
     rollup.googleFlightsTimeout += bucket.googleFlightsTimeout;
     rollup.googleFlightsAuthRejection += bucket.googleFlightsAuthRejection;
+    rollup.googleFlightsFallback += bucket.googleFlightsFallback;
     rollup.googleFlightsTerminalFailure += bucket.googleFlightsTerminalFailure;
+    rollup.rssRequests += bucket.rssRequests;
+    rollup.rssServed += bucket.rssServed;
     rollup.rssSuccess += bucket.rssSuccess;
+    rollup.rssThrottle += bucket.rssThrottle;
     rollup.rssTimeout += bucket.rssTimeout;
     rollup.rssAuthRejection += bucket.rssAuthRejection;
     rollup.rssFallback += bucket.rssFallback;
     rollup.rssTerminalFailure += bucket.rssTerminalFailure;
+    rollup.aisSnapshotRequests += bucket.aisSnapshotRequests;
+    rollup.aisSnapshotServed += bucket.aisSnapshotServed;
     rollup.aisSnapshotSuccess += bucket.aisSnapshotSuccess;
+    rollup.aisSnapshotThrottle += bucket.aisSnapshotThrottle;
     rollup.aisSnapshotTimeout += bucket.aisSnapshotTimeout;
     rollup.aisSnapshotAuthRejection += bucket.aisSnapshotAuthRejection;
     rollup.aisSnapshotUnauthorizedClient += bucket.aisSnapshotUnauthorizedClient;
+    rollup.aisSnapshotFallback += bucket.aisSnapshotFallback;
     rollup.aisSnapshotTerminalFailure += bucket.aisSnapshotTerminalFailure;
     if (bucket.queueMax > rollup.queueMax) rollup.queueMax = bucket.queueMax;
   }
 
   const dedupCount = rollup.openskyDedup + rollup.openskyDedupNeg + rollup.openskyDedupEmpty;
   const cacheServedCount = rollup.openskyCacheHit + rollup.openskyNegativeHit + dedupCount;
+  const openskyCoverage = summarizeServedCoverage({
+    requests: rollup.openskyRequests,
+    served: rollup.openskyServed,
+    minimum: AVIATION_MIN_SERVED_COVERAGE,
+  });
+  const googleFlightsCoverage = summarizeServedCoverage({
+    requests: rollup.googleFlightsRequests,
+    served: rollup.googleFlightsServed,
+    minimum: AVIATION_MIN_SERVED_COVERAGE,
+  });
+  const aviationCoverage = summarizeServedCoverage({
+    requests: rollup.openskyRequests + rollup.googleFlightsRequests,
+    served: rollup.openskyServed + rollup.googleFlightsServed,
+    minimum: AVIATION_MIN_SERVED_COVERAGE,
+  });
+  const rssCoverage = summarizeServedCoverage({
+    requests: rollup.rssRequests,
+    served: rollup.rssServed,
+    minimum: RSS_MIN_SERVED_COVERAGE,
+  });
+  let rssBackoffActive = 0;
+  let rssMaxBackoffRemainingMs = 0;
+  const nowMs = Date.now();
+  for (const expiry of rssBackoffUntil.values()) {
+    const remaining = Math.max(0, expiry - nowMs);
+    if (remaining > 0) {
+      rssBackoffActive++;
+      rssMaxBackoffRemainingMs = Math.max(rssMaxBackoffRemainingMs, remaining);
+    }
+  }
 
   return {
     windowSeconds: METRICS_WINDOW_SECONDS,
@@ -6910,6 +7052,14 @@ function getRelayRollingMetrics() {
       dedupHits: dedupCount,
       misses: rollup.openskyMiss,
       upstreamFetches: rollup.openskyUpstreamFetches,
+      success: rollup.openskySuccess,
+      throttle: rollup.openskyThrottle,
+      timeout: rollup.openskyTimeout,
+      authRejection: rollup.openskyAuthRejection,
+      fallback: rollup.openskyFallback,
+      terminalFailure: rollup.openskyTerminalFailure,
+      served: rollup.openskyServed,
+      coverage: openskyCoverage,
       global429CooldownRemainingMs: Math.max(0, openskyGlobal429Until - Date.now()),
       requestSpacingMs: OPENSKY_REQUEST_SPACING_MS,
     },
@@ -6925,25 +7075,45 @@ function getRelayRollingMetrics() {
       dedupSetNxFailOpen: rollup.notificationDedupSetNxFailOpen,
       dedupSetNxFailClosed: rollup.notificationDedupSetNxFailClosed,
     },
+    aviation: {
+      coverage: aviationCoverage,
+      minimumServedCoverage: AVIATION_MIN_SERVED_COVERAGE,
+    },
     googleFlights: {
+      requests: rollup.googleFlightsRequests,
+      served: rollup.googleFlightsServed,
       success: rollup.googleFlightsSuccess,
       throttle429: rollup.googleFlights429,
+      throttle: rollup.googleFlightsThrottle,
       timeout: rollup.googleFlightsTimeout,
       authRejection: rollup.googleFlightsAuthRejection,
+      fallback: rollup.googleFlightsFallback,
       terminalFailure: rollup.googleFlightsTerminalFailure,
+      coverage: googleFlightsCoverage,
+      cooldownRemainingMs: Math.max(0, gfGlobal429Until - Date.now()),
     },
     rss: {
+      requests: rollup.rssRequests,
+      served: rollup.rssServed,
       success: rollup.rssSuccess,
+      throttle: rollup.rssThrottle,
       timeout: rollup.rssTimeout,
       authRejection: rollup.rssAuthRejection,
       fallback: rollup.rssFallback,
       terminalFailure: rollup.rssTerminalFailure,
+      coverage: rssCoverage,
+      backoffActiveFeeds: rssBackoffActive,
+      maxBackoffRemainingMs: rssMaxBackoffRemainingMs,
     },
     aisSnapshot: {
+      requests: rollup.aisSnapshotRequests,
+      served: rollup.aisSnapshotServed,
       success: rollup.aisSnapshotSuccess,
+      throttle: rollup.aisSnapshotThrottle,
       timeout: rollup.aisSnapshotTimeout,
       authRejection: rollup.aisSnapshotAuthRejection,
       unauthorizedClient: rollup.aisSnapshotUnauthorizedClient,
+      fallback: rollup.aisSnapshotFallback,
       terminalFailure: rollup.aisSnapshotTerminalFailure,
     },
     lifetime: {
@@ -6953,25 +7123,43 @@ function getRelayRollingMetrics() {
       openskyDedup: relayMetricsLifetime.openskyDedup + relayMetricsLifetime.openskyDedupNeg + relayMetricsLifetime.openskyDedupEmpty,
       openskyMiss: relayMetricsLifetime.openskyMiss,
       openskyUpstreamFetches: relayMetricsLifetime.openskyUpstreamFetches,
+      openskyServed: relayMetricsLifetime.openskyServed,
+      openskySuccess: relayMetricsLifetime.openskySuccess,
+      openskyThrottle: relayMetricsLifetime.openskyThrottle,
+      openskyTimeout: relayMetricsLifetime.openskyTimeout,
+      openskyAuthRejection: relayMetricsLifetime.openskyAuthRejection,
+      openskyFallback: relayMetricsLifetime.openskyFallback,
+      openskyTerminalFailure: relayMetricsLifetime.openskyTerminalFailure,
       drops: relayMetricsLifetime.drops,
       notificationDedupSetNxErrors: relayMetricsLifetime.notificationDedupSetNxErrors,
       notificationDedupSetNxFailOpen: relayMetricsLifetime.notificationDedupSetNxFailOpen,
       notificationDedupSetNxFailClosed: relayMetricsLifetime.notificationDedupSetNxFailClosed,
       queueMax: relayMetricsQueueMaxLifetime,
+      googleFlightsRequests: relayMetricsLifetime.googleFlightsRequests,
+      googleFlightsServed: relayMetricsLifetime.googleFlightsServed,
       googleFlightsSuccess: relayMetricsLifetime.googleFlightsSuccess,
       googleFlights429: relayMetricsLifetime.googleFlights429,
+      googleFlightsThrottle: relayMetricsLifetime.googleFlightsThrottle,
       googleFlightsTimeout: relayMetricsLifetime.googleFlightsTimeout,
       googleFlightsAuthRejection: relayMetricsLifetime.googleFlightsAuthRejection,
+      googleFlightsFallback: relayMetricsLifetime.googleFlightsFallback,
       googleFlightsTerminalFailure: relayMetricsLifetime.googleFlightsTerminalFailure,
+      rssRequests: relayMetricsLifetime.rssRequests,
+      rssServed: relayMetricsLifetime.rssServed,
       rssSuccess: relayMetricsLifetime.rssSuccess,
+      rssThrottle: relayMetricsLifetime.rssThrottle,
       rssTimeout: relayMetricsLifetime.rssTimeout,
       rssAuthRejection: relayMetricsLifetime.rssAuthRejection,
       rssFallback: relayMetricsLifetime.rssFallback,
       rssTerminalFailure: relayMetricsLifetime.rssTerminalFailure,
+      aisSnapshotRequests: relayMetricsLifetime.aisSnapshotRequests,
+      aisSnapshotServed: relayMetricsLifetime.aisSnapshotServed,
       aisSnapshotSuccess: relayMetricsLifetime.aisSnapshotSuccess,
+      aisSnapshotThrottle: relayMetricsLifetime.aisSnapshotThrottle,
       aisSnapshotTimeout: relayMetricsLifetime.aisSnapshotTimeout,
       aisSnapshotAuthRejection: relayMetricsLifetime.aisSnapshotAuthRejection,
       aisSnapshotUnauthorizedClient: relayMetricsLifetime.aisSnapshotUnauthorizedClient,
+      aisSnapshotFallback: relayMetricsLifetime.aisSnapshotFallback,
       aisSnapshotTerminalFailure: relayMetricsLifetime.aisSnapshotTerminalFailure,
     },
   };
@@ -7694,6 +7882,23 @@ function buildSnapshot() {
   return lastSnapshot;
 }
 
+function recordAisSnapshotAvailability(snapshot) {
+  const connected = upstreamSocket?.readyState === WebSocket.OPEN;
+  const hasData = Number(snapshot?.status?.vessels) > 0 || Number(snapshot?.status?.messages) > 0;
+  if (connected && hasData) {
+    recordRelayOutcome('aisSnapshot', 'success');
+    incrementRelayMetric('aisSnapshotServed');
+    return 'fresh';
+  }
+  if (!connected && hasData) {
+    recordRelayOutcome('aisSnapshot', 'fallback');
+    incrementRelayMetric('aisSnapshotServed');
+    return 'stale';
+  }
+  recordRelayOutcome('aisSnapshot', 'terminalFailure');
+  return 'unavailable';
+}
+
 setInterval(() => {
   if (upstreamSocket?.readyState === WebSocket.OPEN || vessels.size > 0) {
     buildSnapshot();
@@ -8095,14 +8300,14 @@ const rssResponseCache = new Map(); // key: feed URL → { data, contentType, ti
 const rssInFlight = new Map(); // key: feed URL → Promise (dedup concurrent requests)
 const rssFailureCount = new Map(); // key: feed URL → consecutive failure count (for exponential backoff)
 const rssBackoffUntil = new Map(); // key: feed URL → timestamp when backoff expires
-const RSS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 min — RSS feeds rarely update faster
+const RSS_CACHE_TTL_MS = Math.max(1, Number(process.env.RELAY_TEST_RSS_CACHE_TTL_MS) || 5 * 60 * 1000); // 5 min — RSS feeds rarely update faster
 const RSS_NEGATIVE_CACHE_TTL_MS = 60 * 1000; // 1 min base — scaled by 2^failures via backoff
 const RSS_MAX_NEGATIVE_CACHE_TTL_MS = 15 * 60 * 1000; // 15 min cap — stop hammering broken feeds
 const RSS_CACHE_MAX_ENTRIES = 200; // hard cap — ~20 allowed domains × ~5 paths max, with headroom
 
 function rssRecordFailure(feedUrl) {
   const prev = rssFailureCount.get(feedUrl) || 0;
-  const ttl = Math.min(RSS_NEGATIVE_CACHE_TTL_MS * 2 ** prev, RSS_MAX_NEGATIVE_CACHE_TTL_MS);
+  const ttl = nextBackoffMs(prev, RSS_NEGATIVE_CACHE_TTL_MS, RSS_MAX_NEGATIVE_CACHE_TTL_MS);
   rssFailureCount.set(feedUrl, prev + 1);
   rssBackoffUntil.set(feedUrl, Date.now() + ttl);
   return { failures: prev + 1, backoffSec: Math.round(ttl / 1000) };
@@ -8470,6 +8675,7 @@ async function handleOpenSkyRequest(req, res, PORT) {
     const cached = openskyResponseCache.get(cacheKey);
     if (cached && Date.now() - cached.timestamp < OPENSKY_CACHE_TTL_MS) {
       incrementRelayMetric('openskyCacheHit');
+      incrementRelayMetric('openskyServed');
       touchCacheEntry(openskyResponseCache, cacheKey, cached); // LRU
       return sendPreGzipped(req, res, 200, {
         'Content-Type': 'application/json',
@@ -8483,6 +8689,7 @@ async function handleOpenSkyRequest(req, res, PORT) {
     const negCached = openskyNegativeCache.get(cacheKey);
     if (negCached && Date.now() - negCached.timestamp < OPENSKY_NEGATIVE_CACHE_TTL_MS) {
       incrementRelayMetric('openskyNegativeHit');
+      recordRelayOutcome('opensky', classifyUpstreamOutcome({ status: negCached.status }));
       touchCacheEntry(openskyNegativeCache, cacheKey, negCached); // LRU
       return sendPreGzipped(req, res, 200, {
         'Content-Type': 'application/json',
@@ -8497,12 +8704,15 @@ async function handleOpenSkyRequest(req, res, PORT) {
     //     ALL get 429'd, and the cycle repeats forever with zero data flowing.
     if (Date.now() < openskyGlobal429Until) {
       incrementRelayMetric('openskyNegativeHit');
+      recordRelayOutcome('opensky', 'throttle');
       cacheOpenSkyNegative(cacheKey, 429);
+      const remainSec = Math.max(1, Math.ceil((openskyGlobal429Until - Date.now()) / 1000));
       return sendCompressed(req, res, 200, {
         'Content-Type': 'application/json',
         'Cache-Control': 'no-cache',
         'CDN-Cache-Control': 'no-store',
         'X-Cache': 'RATE-LIMITED',
+        'Retry-After': String(remainSec),
       }, JSON.stringify({ states: [], time: Date.now() }));
     }
 
@@ -8515,6 +8725,7 @@ async function handleOpenSkyRequest(req, res, PORT) {
       const deduped = openskyResponseCache.get(cacheKey);
       if (deduped && Date.now() - deduped.timestamp < OPENSKY_CACHE_TTL_MS) {
         incrementRelayMetric('openskyDedup');
+        incrementRelayMetric('openskyServed');
         touchCacheEntry(openskyResponseCache, cacheKey, deduped); // LRU
         return sendPreGzipped(req, res, 200, {
           'Content-Type': 'application/json',
@@ -8526,6 +8737,7 @@ async function handleOpenSkyRequest(req, res, PORT) {
       const dedupNeg = openskyNegativeCache.get(cacheKey);
       if (dedupNeg && Date.now() - dedupNeg.timestamp < OPENSKY_NEGATIVE_CACHE_TTL_MS) {
         incrementRelayMetric('openskyDedupNeg');
+        recordRelayOutcome('opensky', classifyUpstreamOutcome({ status: dedupNeg.status }));
         touchCacheEntry(openskyNegativeCache, cacheKey, dedupNeg); // LRU
         return sendPreGzipped(req, res, 200, {
           'Content-Type': 'application/json',
@@ -8536,6 +8748,7 @@ async function handleOpenSkyRequest(req, res, PORT) {
       }
       // In-flight completed but no cache entry (upstream failed) — return empty instead of thundering herd
       incrementRelayMetric('openskyDedupEmpty');
+      recordRelayOutcome('opensky', 'terminalFailure');
       return sendPreGzipped(req, res, 200, {
         'Content-Type': 'application/json',
         'Cache-Control': 'no-cache',
@@ -8563,6 +8776,7 @@ async function handleOpenSkyRequest(req, res, PORT) {
       // Only negative-cache actual upstream 429/5xx responses.
       settleFlight();
       openskyInFlight.delete(cacheKey);
+      recordRelayOutcome('opensky', 'authRejection');
       return safeEnd(res, 503, { 'Content-Type': 'application/json' },
         JSON.stringify({ error: 'OpenSky not configured or auth failed', time: Date.now(), states: [] }));
     }
@@ -8578,6 +8792,10 @@ async function handleOpenSkyRequest(req, res, PORT) {
     // Serialized fetch — queued with spacing to prevent concurrent 429 storms
     const result = await openskyQueuedFetch(openskyUrl, token);
     const upstreamStatus = result.status || 502;
+    const upstreamOutcome = result.error
+      ? classifyUpstreamOutcome({ status: upstreamStatus, error: result.error })
+      : classifyUpstreamOutcome({ status: upstreamStatus });
+    recordRelayOutcome('opensky', upstreamOutcome);
 
     if (upstreamStatus === 401) {
       openskyToken = null;
@@ -8592,6 +8810,7 @@ async function handleOpenSkyRequest(req, res, PORT) {
     if (upstreamStatus === 200 && result.data) {
       cacheOpenSkyPositive(cacheKey, result.data);
       openskyNegativeCache.delete(cacheKey);
+      incrementRelayMetric('openskyServed');
     } else if (result.error) {
       logThrottled('error', `opensky-error:${cacheKey}:${result.error.code || result.error.message}`, '[Relay] OpenSky error:', result.error.message);
       cacheOpenSkyNegative(cacheKey, upstreamStatus || 500);
@@ -8606,17 +8825,26 @@ async function handleOpenSkyRequest(req, res, PORT) {
 
     // Serve stale cache on network errors
     if (result.error && cached) {
+      incrementRelayMetric('openskyServed');
+      recordRelayOutcome('opensky', 'fallback');
       return sendPreGzipped(req, res, 200, { 'Content-Type': 'application/json', 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store', 'X-Cache': 'STALE' }, cached.data, cached.gzip, cached.brotli);
     }
 
     const responseData = result.data || JSON.stringify({ error: result.error?.message || 'upstream error', time: Date.now(), states: null });
-    return sendCompressed(req, res, upstreamStatus, {
+    const responseHeaders = {
       'Content-Type': 'application/json',
       'Cache-Control': upstreamStatus === 200 ? 'public, max-age=30' : 'no-cache',
       'CDN-Cache-Control': upstreamStatus === 200 ? 'public, max-age=15' : 'no-store',
       'X-Cache': result.rateLimited ? 'RATE-LIMITED' : 'MISS',
+    };
+    if (upstreamStatus === 429) {
+      responseHeaders['Retry-After'] = String(Math.max(1, Math.ceil((openskyGlobal429Until - Date.now()) / 1000)));
+    }
+    return sendCompressed(req, res, upstreamStatus, {
+      ...responseHeaders,
     }, responseData);
   } catch (err) {
+    recordRelayOutcome('opensky', classifyUpstreamOutcome({ error: err }));
     if (settleFlight) settleFlight();
     if (!cacheKey) {
       try {
@@ -9527,8 +9755,11 @@ const server = http.createServer(async (req, res) => {
   const isPublicRoute = pathname === '/health' || pathname === '/' || isRssRoute || pathname.startsWith('/widget-agent');
   if (!isPublicRoute) {
     if (!isAuthorizedRequest(req)) {
-      if (pathname.startsWith('/ais/snapshot')) incrementRelayMetric('aisSnapshotUnauthorizedClient');
-      else incrementRelayMetric('aisSnapshotAuthRejection');
+      const routeGroup = getRouteGroup(pathname);
+      if (routeGroup === 'snapshot') incrementRelayMetric('aisSnapshotUnauthorizedClient');
+      else if (routeGroup === 'opensky') recordRelayOutcome('opensky', 'authRejection');
+      else if (routeGroup === 'google-flights') recordRelayOutcome('googleFlights', 'authRejection');
+      else if (routeGroup === 'rss') recordRelayOutcome('rss', 'authRejection');
       return safeEnd(res, 401, { 'Content-Type': 'application/json' },
         JSON.stringify({ error: 'Unauthorized', time: Date.now() }));
     }
@@ -9537,6 +9768,20 @@ const server = http.createServer(async (req, res) => {
   if (pathname !== '/health' && pathname !== '/') {
     const rl = consumeRateLimit(req, pathname, isPublicRoute);
     if (rl.limited) {
+      const routeGroup = getRouteGroup(pathname);
+      if (routeGroup === 'opensky') {
+        incrementRelayMetric('openskyRequests');
+        recordRelayOutcome('opensky', 'throttle');
+      } else if (routeGroup === 'google-flights') {
+        incrementRelayMetric('googleFlightsRequests');
+        recordRelayOutcome('googleFlights', 'throttle');
+      } else if (routeGroup === 'rss') {
+        incrementRelayMetric('rssRequests');
+        recordRelayOutcome('rss', 'throttle');
+      } else if (routeGroup === 'snapshot') {
+        incrementRelayMetric('aisSnapshotRequests');
+        recordRelayOutcome('aisSnapshot', 'throttle');
+      }
       const retryAfterSec = Math.max(1, Math.ceil(rl.resetInMs / 1000));
       return safeEnd(res, 429, {
         'Content-Type': 'application/json',
@@ -9550,6 +9795,11 @@ const server = http.createServer(async (req, res) => {
 
   if (pathname === '/health' || pathname === '/') {
     const mem = process.memoryUsage();
+    const ingestion = getRelayRollingMetrics();
+    const aisSnapshotDegraded = ingestion.aisSnapshot.requests > 0 && ingestion.aisSnapshot.served === 0;
+    const ingestionDegraded = ingestion.aviation.coverage.status === 'degraded'
+      || ingestion.rss.coverage.status === 'degraded'
+      || aisSnapshotDegraded;
     // ⚠ SECURITY — read before adding fields to this response.
     //
     // /health is in `isPublicRoute` (no auth check). Fields here are
@@ -9581,7 +9831,19 @@ const server = http.createServer(async (req, res) => {
     // response. The `ais-relay-health-no-secret-recon` test asserts the
     // removed fields don't reappear here.
     sendCompressed(req, res, 200, { 'Content-Type': 'application/json' }, JSON.stringify({
+      // Keep the historical liveness status stable for Railway probes; the
+      // ingestion verdict is explicit below so monitors can alert without
+      // turning an application-level coverage dip into a process outage.
       status: 'ok',
+      ingestion: {
+        status: ingestionDegraded ? 'degraded' : 'ok',
+        aviation: ingestion.aviation,
+        rss: ingestion.rss,
+        aisSnapshot: {
+          ...ingestion.aisSnapshot,
+          connected: upstreamSocket?.readyState === WebSocket.OPEN,
+        },
+      },
       clients: clients.size,
       messages: messageCount,
       droppedMessages,
@@ -9639,9 +9901,10 @@ const server = http.createServer(async (req, res) => {
       'Cache-Control': 'no-store',
     }, JSON.stringify(getRelayRollingMetrics()));
   } else if (pathname.startsWith('/ais/snapshot')) {
+    incrementRelayMetric('aisSnapshotRequests');
     // Aggregated AIS snapshot for server-side fanout — serve pre-serialized + pre-gzipped
     connectUpstream();
-    buildSnapshot(); // ensures cache is warm
+    recordAisSnapshotAvailability(buildSnapshot()); // ensures cache is warm and records usable freshness
     const url = new URL(req.url, `http://localhost:${PORT}`);
     const includeCandidates = url.searchParams.get('candidates') === 'true';
     const includeTankers = url.searchParams.get('tankers') === 'true';
@@ -9651,7 +9914,6 @@ const server = http.createServer(async (req, res) => {
     // case only (no tankers, no bbox). Used by the existing AIS density +
     // military-detection consumers, which are the vast majority of traffic.
     if (!includeTankers && !bbox) {
-      incrementRelayMetric('aisSnapshotSuccess');
       const json = includeCandidates ? lastSnapshotWithCandJson : lastSnapshotJson;
       const gz = includeCandidates ? lastSnapshotWithCandGzip : lastSnapshotGzip;
       const br = includeCandidates ? lastSnapshotWithCandBrotli : lastSnapshotBrotli;
@@ -9670,7 +9932,6 @@ const server = http.createServer(async (req, res) => {
         }, JSON.stringify(payload));
       }
     } else {
-      incrementRelayMetric('aisSnapshotSuccess');
       // Live-tanker path: bbox-filtered + tanker-included responses skip the
       // pre-gzipped cache (bbox space would explode the cache key set).
       // Handler-side 60s cache (server/worldmonitor/maritime/v1/get-vessel-snapshot.ts)
@@ -9810,16 +10071,19 @@ const server = http.createServer(async (req, res) => {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         return res.end(JSON.stringify({ error: 'Missing url parameter' }));
       }
+      incrementRelayMetric('rssRequests');
 
       // Domain allowlist from shared source of truth (shared/rss-allowed-domains.js)
       const parsed = new URL(feedUrl);
       // Block deprecated/stale feed domains — stale clients still request these
       const blockedDomains = ['rsshub.app'];
       if (blockedDomains.includes(parsed.hostname)) {
+        recordRelayOutcome('rss', 'terminalFailure');
         res.writeHead(410, { 'Content-Type': 'application/json' });
         return res.end(JSON.stringify({ error: 'Feed deprecated' }));
       }
       if (!RSS_ALLOWED_DOMAINS.has(parsed.hostname)) {
+        recordRelayOutcome('rss', 'terminalFailure');
         res.writeHead(403, { 'Content-Type': 'application/json' });
         return res.end(JSON.stringify({ error: 'Domain not allowed on Railway proxy' }));
       }
@@ -9830,6 +10094,9 @@ const server = http.createServer(async (req, res) => {
       if (backoffExpiry && backoffNow < backoffExpiry) {
         const rssCachedForBackoff = rssResponseCache.get(feedUrl);
         if (rssCachedForBackoff && rssCachedForBackoff.statusCode >= 200 && rssCachedForBackoff.statusCode < 300) {
+          recordRelayOutcome('rss', 'throttle');
+          recordRelayOutcome('rss', 'fallback');
+          incrementRelayMetric('rssServed');
           return sendCompressed(req, res, 200, {
             'Content-Type': rssCachedForBackoff.contentType || 'application/xml',
             'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store',
@@ -9837,6 +10104,7 @@ const server = http.createServer(async (req, res) => {
           }, rssCachedForBackoff.data);
         }
         const remainSec = Math.max(1, Math.round((backoffExpiry - backoffNow) / 1000));
+        recordRelayOutcome('rss', 'throttle');
         res.writeHead(503, { 'Content-Type': 'application/json', 'Retry-After': String(remainSec) });
         return res.end(JSON.stringify({ error: 'Feed in backoff', retryAfterSec: remainSec }));
       }
@@ -9851,6 +10119,11 @@ const server = http.createServer(async (req, res) => {
         const ttl = (rssCached.statusCode && rssCached.statusCode >= 200 && rssCached.statusCode < 300)
           ? RSS_CACHE_TTL_MS : RSS_NEGATIVE_CACHE_TTL_MS;
         if (Date.now() - rssCached.timestamp < ttl) {
+          if (rssCached.statusCode < 200 || rssCached.statusCode >= 300) {
+            recordRelayOutcome('rss', classifyUpstreamOutcome({ status: rssCached.statusCode }));
+          } else {
+            incrementRelayMetric('rssServed');
+          }
           return sendCompressed(req, res, rssCached.statusCode || 200, {
             'Content-Type': rssCached.contentType || 'application/xml',
             'Cache-Control': rssCached.statusCode >= 200 && rssCached.statusCode < 300 ? 'public, max-age=300' : 'no-cache',
@@ -9868,6 +10141,11 @@ const server = http.createServer(async (req, res) => {
           await existing;
           const deduped = rssResponseCache.get(feedUrl);
           if (deduped) {
+            if (deduped.statusCode < 200 || deduped.statusCode >= 300) {
+              recordRelayOutcome('rss', classifyUpstreamOutcome({ status: deduped.statusCode }));
+            } else {
+              incrementRelayMetric('rssServed');
+            }
             return sendCompressed(req, res, deduped.statusCode || 200, {
               'Content-Type': deduped.contentType || 'application/xml',
               'Cache-Control': deduped.statusCode >= 200 && deduped.statusCode < 300 ? 'public, max-age=300' : 'no-cache',
@@ -9876,10 +10154,12 @@ const server = http.createServer(async (req, res) => {
             }, deduped.data);
           }
           // In-flight completed but nothing cached — serve 502 instead of cascading
+          recordRelayOutcome('rss', 'terminalFailure');
           return safeEnd(res, 502, { 'Content-Type': 'application/json' },
             JSON.stringify({ error: 'Upstream fetch completed but not cached' }));
         } catch {
           // In-flight fetch failed — serve 502 instead of starting another fetch
+          recordRelayOutcome('rss', 'terminalFailure');
           return safeEnd(res, 502, { 'Content-Type': 'application/json' },
             JSON.stringify({ error: 'Upstream fetch failed' }));
         }
@@ -9889,11 +10169,34 @@ const server = http.createServer(async (req, res) => {
 
       const fetchPromise = new Promise((resolveInFlight, rejectInFlight) => {
       let responseHandled = false;
+      let outcomeRecorded = false;
+      let failureRecorded = false;
+
+      const recordAttemptOutcome = (status, error) => {
+        if (outcomeRecorded) return;
+        outcomeRecorded = true;
+        recordRelayOutcome('rss', classifyUpstreamOutcome({ status, error }));
+      };
+
+      const recordFailure = () => {
+        if (failureRecorded) {
+          const failures = rssFailureCount.get(feedUrl) || 1;
+          const remaining = Math.max(1, Math.round(((rssBackoffUntil.get(feedUrl) || Date.now()) - Date.now()) / 1000));
+          return { failures, backoffSec: remaining };
+        }
+        failureRecorded = true;
+        return rssRecordFailure(feedUrl);
+      };
 
       const sendError = (statusCode, message) => {
         if (responseHandled || res.headersSent) return;
         responseHandled = true;
-        res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+        recordAttemptOutcome(statusCode, new Error(message));
+        const { backoffSec } = recordFailure();
+        res.writeHead(statusCode, {
+          'Content-Type': 'application/json',
+          'Retry-After': String(backoffSec),
+        });
         res.end(JSON.stringify({ error: message }));
         rejectInFlight(new Error(message));
       };
@@ -9940,6 +10243,8 @@ const server = http.createServer(async (req, res) => {
 
           if (response.statusCode === 304 && rssCached) {
             responseHandled = true;
+            recordAttemptOutcome(200);
+            incrementRelayMetric('rssServed');
             rssCached.timestamp = Date.now();
             rssResetFailure(feedUrl);
             resolveInFlight();
@@ -9976,34 +10281,43 @@ const server = http.createServer(async (req, res) => {
               etag: response.headers.etag || null,
               lastModified: response.headers['last-modified'] || null,
             });
-            if (response.statusCode >= 200 && response.statusCode < 300) {
-              rssResetFailure(feedUrl);
-            } else {
-              const { failures, backoffSec } = rssRecordFailure(feedUrl);
-              logThrottled('warn', `rss-upstream:${feedUrl}:${response.statusCode}`, `[Relay] RSS upstream ${response.statusCode} for ${feedUrl} (backoff ${backoffSec}s, failures=${failures})`);
-            }
-            resolveInFlight();
-            sendCompressed(req, res, response.statusCode, {
+            const responseHeaders = {
               'Content-Type': 'application/xml',
               'Cache-Control': response.statusCode >= 200 && response.statusCode < 300 ? 'public, max-age=300' : 'no-cache',
               'CDN-Cache-Control': response.statusCode >= 200 && response.statusCode < 300 ? 'public, max-age=600, stale-while-revalidate=300' : 'no-store',
               'X-Cache': 'MISS',
-            }, data);
+            };
+            if (response.statusCode >= 200 && response.statusCode < 300) {
+              recordAttemptOutcome(response.statusCode);
+              incrementRelayMetric('rssServed');
+              rssResetFailure(feedUrl);
+            } else {
+              recordAttemptOutcome(response.statusCode);
+              const { failures, backoffSec } = recordFailure();
+              logThrottled('warn', `rss-upstream:${feedUrl}:${response.statusCode}`, `[Relay] RSS upstream ${response.statusCode} for ${feedUrl} (backoff ${backoffSec}s, failures=${failures})`);
+              responseHeaders['Retry-After'] = String(backoffSec);
+            }
+            resolveInFlight();
+            sendCompressed(req, res, response.statusCode, responseHeaders, data);
           });
           stream.on('error', (err) => {
-            const { failures, backoffSec } = rssRecordFailure(feedUrl);
+            recordAttemptOutcome(502, err);
+            const { failures, backoffSec } = recordFailure();
             logThrottled('error', `rss-decompress:${feedUrl}:${err.code || err.message}`, `[Relay] Decompression error: ${err.message} (backoff ${backoffSec}s, failures=${failures})`);
             sendError(502, 'Decompression failed: ' + err.message);
           });
         });
 
         request.on('error', (err) => {
-          const { failures, backoffSec } = rssRecordFailure(feedUrl);
+          recordAttemptOutcome(0, err);
+          const { failures, backoffSec } = recordFailure();
           logThrottled('error', `rss-error:${feedUrl}:${err.code || err.message}`, `[Relay] RSS error: ${err.message} (backoff ${backoffSec}s, failures=${failures})`);
           // Serve stale on error (only if we have previous successful data)
           if (rssCached && rssCached.statusCode >= 200 && rssCached.statusCode < 300) {
             if (!responseHandled && !res.headersSent) {
               responseHandled = true;
+              incrementRelayMetric('rssServed');
+              recordRelayOutcome('rss', 'fallback');
               sendCompressed(req, res, 200, { 'Content-Type': 'application/xml', 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store', 'X-Cache': 'STALE' }, rssCached.data);
             }
             resolveInFlight();
@@ -10014,10 +10328,13 @@ const server = http.createServer(async (req, res) => {
 
         request.on('timeout', () => {
           request.destroy();
-          const { failures, backoffSec } = rssRecordFailure(feedUrl);
+          recordAttemptOutcome(504, new Error('timeout'));
+          const { failures, backoffSec } = recordFailure();
           logThrottled('warn', `rss-timeout:${feedUrl}`, `[Relay] RSS timeout for ${feedUrl} (backoff ${backoffSec}s, failures=${failures})`);
           if (rssCached && rssCached.statusCode >= 200 && rssCached.statusCode < 300 && !responseHandled && !res.headersSent) {
             responseHandled = true;
+            incrementRelayMetric('rssServed');
+            recordRelayOutcome('rss', 'fallback');
             sendCompressed(req, res, 200, { 'Content-Type': 'application/xml', 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store', 'X-Cache': 'STALE' }, rssCached.data);
             resolveInFlight();
             return;
@@ -10387,6 +10704,7 @@ async function handleGoogleFlightsSearch(req, res) {
       res.end(JSON.stringify({ error: 'origin, destination, departure_date required' }));
       return;
     }
+    incrementRelayMetric('googleFlightsRequests');
 
     const filters = buildFlightFilters({
       origin, destination,
@@ -10405,8 +10723,10 @@ async function handleGoogleFlightsSearch(req, res) {
     // Global 429 cooldown: block upstream fetches during cooldown
     if (Date.now() < gfGlobal429Until) {
       incrementRelayMetric('googleFlights429');
+      recordRelayOutcome('googleFlights', 'throttle');
       const flights = [];
-      res.writeHead(200, { 'Content-Type': 'application/json' });
+      const retryAfter = Math.max(1, Math.ceil((gfGlobal429Until - Date.now()) / 1000));
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) });
       res.end(JSON.stringify({ flights, cooldown: true }));
       return;
     }
@@ -10421,32 +10741,37 @@ async function handleGoogleFlightsSearch(req, res) {
       gfGlobal429Until = Date.now() + GF_429_COOLDOWN_MS;
       console.warn(`[Google Flights] 429 — global cooldown ${GF_429_COOLDOWN_MS / 1000}s`);
       incrementRelayMetric('googleFlights429');
+      recordRelayOutcome('googleFlights', 'throttle');
       throw new Error(`Google Flights returned ${gfResp.status}`);
     }
     if (gfResp.status === 401 || gfResp.status === 403) {
-      incrementRelayMetric('googleFlightsAuthRejection');
+      recordRelayOutcome('googleFlights', 'authRejection');
       throw new Error(`Google Flights returned ${gfResp.status}`);
     }
     if (!gfResp.ok) {
-      incrementRelayMetric('googleFlightsTerminalFailure');
+      recordRelayOutcome('googleFlights', 'terminalFailure');
       throw new Error(`Google Flights returned ${gfResp.status}`);
     }
-    incrementRelayMetric('googleFlightsSuccess');
-
     const text = await gfResp.text();
     const flights = parseGfFlights(text);
+    recordRelayOutcome('googleFlights', 'success');
+    incrementRelayMetric('googleFlightsServed');
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ flights }));
   } catch (err) {
     const isTimeout = err?.name === 'TimeoutError' || err?.message?.includes('timed out');
     if (isTimeout) {
-      incrementRelayMetric('googleFlightsTimeout');
+      recordRelayOutcome('googleFlights', 'timeout');
     } else if (!err?.message?.startsWith('Google Flights returned')) {
-      incrementRelayMetric('googleFlightsTerminalFailure');
+      recordRelayOutcome('googleFlights', 'terminalFailure');
     }
     console.error('[Google Flights] search error:', err?.message || err);
-    res.writeHead(502, { 'Content-Type': 'application/json' });
+    const retryAfter = Math.max(0, Math.ceil((gfGlobal429Until - Date.now()) / 1000));
+    res.writeHead(502, {
+      'Content-Type': 'application/json',
+      ...(retryAfter > 0 ? { 'Retry-After': String(retryAfter) } : {}),
+    });
     res.end(JSON.stringify({ error: err?.message || 'search failed', flights: [] }));
   }
 }
@@ -10488,13 +10813,17 @@ async function handleGoogleFlightsDates(req, res) {
     const end = new Date(endDate);
     const totalDays = Math.ceil((end - start) / 86_400_000) + 1;
     const MAX_CHUNK = 61;
+    const MAX_DATE_CHUNKS = 6;
     const allDates = [];
     let hasPartialFailure = false;
 
     if (totalDays <= MAX_CHUNK) {
+      incrementRelayMetric('googleFlightsRequests');
       if (Date.now() < gfGlobal429Until) {
         incrementRelayMetric('googleFlights429');
-        res.writeHead(200, { 'Content-Type': 'application/json' });
+        recordRelayOutcome('googleFlights', 'throttle');
+        const retryAfter = Math.max(1, Math.ceil((gfGlobal429Until - Date.now()) / 1000));
+        res.writeHead(200, { 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) });
         res.end(JSON.stringify({ dates: [], partial: false, cooldown: true }));
         return;
       }
@@ -10505,24 +10834,30 @@ async function handleGoogleFlightsDates(req, res) {
         gfGlobal429Until = Date.now() + GF_429_COOLDOWN_MS;
         console.warn(`[Google Flights] dates 429 — global cooldown ${GF_429_COOLDOWN_MS / 1000}s`);
         incrementRelayMetric('googleFlights429');
+        recordRelayOutcome('googleFlights', 'throttle');
         throw new Error(`Google Flights returned ${gfResp.status}`);
       }
       if (gfResp.status === 401 || gfResp.status === 403) {
-        incrementRelayMetric('googleFlightsAuthRejection');
+        recordRelayOutcome('googleFlights', 'authRejection');
         throw new Error(`Google Flights returned ${gfResp.status}`);
       }
       if (!gfResp.ok) {
-        incrementRelayMetric('googleFlightsTerminalFailure');
+        recordRelayOutcome('googleFlights', 'terminalFailure');
         throw new Error(`Google Flights returned ${gfResp.status}`);
       }
-      incrementRelayMetric('googleFlightsSuccess');
       const text = await gfResp.text();
       allDates.push(...parseGfDates(text, isRoundTrip));
+      recordRelayOutcome('googleFlights', 'success');
+      incrementRelayMetric('googleFlightsServed');
     } else {
       const current = new Date(start);
-      while (current <= end) {
+      let chunksAttempted = 0;
+      while (current <= end && chunksAttempted < MAX_DATE_CHUNKS) {
+        chunksAttempted++;
+        incrementRelayMetric('googleFlightsRequests');
         if (Date.now() < gfGlobal429Until) {
           incrementRelayMetric('googleFlights429');
+          recordRelayOutcome('googleFlights', 'throttle');
           hasPartialFailure = true;
           current.setDate(current.getDate() + MAX_CHUNK);
           continue;
@@ -10540,8 +10875,8 @@ async function handleGoogleFlightsDates(req, res) {
         let gfResp;
         try {
           gfResp = await fetch(GF_CALENDAR_URL, { method: 'POST', headers: GF_HEADERS, body, signal: AbortSignal.timeout(20_000) });
-        } catch {
-          incrementRelayMetric('googleFlightsTimeout');
+        } catch (err) {
+          recordRelayOutcome('googleFlights', classifyUpstreamOutcome({ error: err }));
           hasPartialFailure = true;
           current.setDate(current.getDate() + MAX_CHUNK);
           continue;
@@ -10550,37 +10885,46 @@ async function handleGoogleFlightsDates(req, res) {
           gfGlobal429Until = Date.now() + GF_429_COOLDOWN_MS;
           console.warn(`[Google Flights] chunk 429 — global cooldown ${GF_429_COOLDOWN_MS / 1000}s`);
           incrementRelayMetric('googleFlights429');
+          recordRelayOutcome('googleFlights', 'throttle');
           hasPartialFailure = true;
         } else if (gfResp.status === 401 || gfResp.status === 403) {
-          incrementRelayMetric('googleFlightsAuthRejection');
+          recordRelayOutcome('googleFlights', 'authRejection');
           hasPartialFailure = true;
         } else if (gfResp.ok) {
-          incrementRelayMetric('googleFlightsSuccess');
           const text = await gfResp.text();
           allDates.push(...parseGfDates(text, isRoundTrip));
+          recordRelayOutcome('googleFlights', 'success');
+          incrementRelayMetric('googleFlightsServed');
         } else {
-          incrementRelayMetric('googleFlightsTerminalFailure');
+          recordRelayOutcome('googleFlights', 'terminalFailure');
           hasPartialFailure = true;
           console.warn(`[Google Flights] dates chunk ${current.toISOString().slice(0, 10)} failed: ${gfResp.status}`);
         }
         current.setDate(current.getDate() + MAX_CHUNK);
       }
+      if (current <= end) hasPartialFailure = true;
     }
 
     const sortByPrice = url.searchParams.get('sort_by_price') === 'true';
     if (sortByPrice) allDates.sort((a, b) => a.price - b.price);
+
+    if (hasPartialFailure && allDates.length > 0) recordRelayOutcome('googleFlights', 'fallback');
 
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ dates: allDates, partial: hasPartialFailure }));
   } catch (err) {
     const isTimeout = err?.name === 'TimeoutError' || err?.message?.includes('timed out');
     if (isTimeout) {
-      incrementRelayMetric('googleFlightsTimeout');
+      recordRelayOutcome('googleFlights', 'timeout');
     } else if (!err?.message?.startsWith('Google Flights returned')) {
-      incrementRelayMetric('googleFlightsTerminalFailure');
+      recordRelayOutcome('googleFlights', 'terminalFailure');
     }
     console.error('[Google Flights] dates error:', err?.message || err);
-    res.writeHead(502, { 'Content-Type': 'application/json' });
+    const retryAfter = Math.max(0, Math.ceil((gfGlobal429Until - Date.now()) / 1000));
+    res.writeHead(502, {
+      'Content-Type': 'application/json',
+      ...(retryAfter > 0 ? { 'Retry-After': String(retryAfter) } : {}),
+    });
     res.end(JSON.stringify({ error: err?.message || 'search failed', dates: [] }));
   }
 }
@@ -11488,8 +11832,25 @@ function switchTab(btn, key) {
 
 // ─── End Widget Agent ────────────────────────────────────────────────────────
 
+function scheduleUpstreamReconnect() {
+  if (relayShuttingDown || upstreamReconnectTimer || !API_KEY) return;
+  const delayMs = nextBackoffMs(upstreamReconnectFailures, AIS_RECONNECT_BASE_MS, AIS_RECONNECT_MAX_MS);
+  upstreamReconnectFailures++;
+  upstreamReconnectTimer = setTimeout(() => {
+    upstreamReconnectTimer = null;
+    connectUpstream();
+  }, delayMs);
+  upstreamReconnectTimer.unref?.();
+  console.log(`[Relay] AIS reconnect scheduled in ${Math.ceil(delayMs / 1000)}s (attempt=${upstreamReconnectFailures})`);
+}
+
 function connectUpstream() {
   if (!API_KEY) return;
+
+  if (upstreamReconnectTimer) {
+    clearTimeout(upstreamReconnectTimer);
+    upstreamReconnectTimer = null;
+  }
 
   // Skip if already connected or connecting
   if (upstreamSocket?.readyState === WebSocket.OPEN ||
@@ -11549,6 +11910,7 @@ function connectUpstream() {
       return;
     }
     console.log('[Relay] Connected to aisstream.io');
+    upstreamReconnectFailures = 0;
     socket.send(JSON.stringify({
       APIKey: API_KEY,
       BoundingBoxes: [[[-90, -180], [90, 180]]],
@@ -11586,8 +11948,8 @@ function connectUpstream() {
       upstreamSocket = null;
       clearUpstreamQueue();
       upstreamPaused = false;
-      console.log('[Relay] Disconnected, reconnecting in 5s...');
-      setTimeout(connectUpstream, 5000);
+      console.log('[Relay] Disconnected');
+      scheduleUpstreamReconnect();
     }
   });
 
@@ -11599,7 +11961,12 @@ function connectUpstream() {
 const wss = new WebSocketServer({ server });
 
 server.listen(PORT, () => {
-  console.log(`[Relay] WebSocket relay on port ${PORT} (OpenSky: ${OPENSKY_PROXY_ENABLED ? 'via proxy' : 'direct'})`);
+  const listeningPort = server.address()?.port || PORT;
+  console.log(`[Relay] WebSocket relay on port ${listeningPort} (OpenSky: ${OPENSKY_PROXY_ENABLED ? 'via proxy' : 'direct'})`);
+  if (RELAY_TEST_MODE) {
+    console.log('[Relay] Test mode enabled — background seed loops are disabled');
+    return;
+  }
   startTelegramPollLoop();
   startOrefPollLoop();
   startUcdpSeedLoop();
@@ -11688,6 +12055,11 @@ setInterval(() => {
 // Railway sends SIGTERM during deploys; without this, the old container keeps
 // the Telegram session alive while the new container connects → AUTH_KEY_DUPLICATED.
 async function gracefulShutdown(signal) {
+  relayShuttingDown = true;
+  if (upstreamReconnectTimer) {
+    clearTimeout(upstreamReconnectTimer);
+    upstreamReconnectTimer = null;
+  }
   console.log(`[Relay] ${signal} received — shutting down`);
   if (telegramState.client) {
     console.log('[Relay] Disconnecting Telegram client...');

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -9760,6 +9760,7 @@ const server = http.createServer(async (req, res) => {
       else if (routeGroup === 'opensky') recordRelayOutcome('opensky', 'authRejection');
       else if (routeGroup === 'google-flights') recordRelayOutcome('googleFlights', 'authRejection');
       else if (routeGroup === 'rss') recordRelayOutcome('rss', 'authRejection');
+      else recordRelayOutcome('other', 'authRejection');
       return safeEnd(res, 401, { 'Content-Type': 'application/json' },
         JSON.stringify({ error: 'Unauthorized', time: Date.now() }));
     }

--- a/scripts/seed-consumer-prices.mjs
+++ b/scripts/seed-consumer-prices.mjs
@@ -110,7 +110,7 @@ export function coverageForSeedMeta(data) {
     status: typeof data.status === 'string' ? data.status : undefined,
     completedPages: Number(data.completedPages) || 0,
     failedPages: Number(data.failedPages) || 0,
-    completionRatio: Number(data.completionRatio) || 0,
+    completionRatio: data.completionRatio == null ? null : Number(data.completionRatio) || 0,
     rejectedCount: Number(data.rejectedCount) || 0,
     retailers: data.retailers,
   };

--- a/scripts/seed-consumer-prices.mjs
+++ b/scripts/seed-consumer-prices.mjs
@@ -17,28 +17,17 @@
  */
 
 import { loadEnvFile, CHROME_UA, writeExtraKeyWithMeta } from './_seed-utils.mjs';
+import { pathToFileURL } from 'node:url';
 
 loadEnvFile(import.meta.url);
 
 const FORCE = process.argv.includes('--force');
-if (!FORCE) {
-  console.error(
-    '[consumer-prices] ERROR: --force flag required.\n' +
-    'This script overwrites Redis keys with short TTLs (10-60 min), stomping the\n' +
-    'authoritative publish.ts 26h TTLs. Only run manually when publish.ts is broken.\n' +
-    'Usage: node scripts/seed-consumer-prices.mjs --force',
-  );
-  process.exit(1);
-}
+const IS_MAIN = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
 
 const BASE_URL = process.env.CONSUMER_PRICES_CORE_BASE_URL;
 const API_KEY = process.env.CONSUMER_PRICES_CORE_API_KEY;
 const MARKET = process.env.CONSUMER_PRICES_DEFAULT_MARKET || 'ae';
 const BASKET = 'essentials-ae';
-
-if (!BASE_URL) {
-  console.warn('[consumer-prices] CONSUMER_PRICES_CORE_BASE_URL not set — writing empty placeholders');
-}
 
 async function fetchSnapshot(path) {
   if (!BASE_URL) return null;
@@ -99,6 +88,34 @@ function emptyCategories(market, range) {
   return { marketCode: market, asOf: String(Date.now()), range, categories: [], upstreamUnavailable: true };
 }
 
+export function emptyCoverage(market) {
+  return {
+    marketCode: market,
+    asOf: String(Date.now()),
+    attemptedPages: 0,
+    completedPages: 0,
+    failedPages: 0,
+    completionRatio: null,
+    rejectedCount: 0,
+    status: 'unknown',
+    minimumCompletionRatio: 0.5,
+    retailers: [],
+    upstreamUnavailable: true,
+  };
+}
+
+export function coverageForSeedMeta(data) {
+  if (!Array.isArray(data?.retailers) || !('completedPages' in data)) return undefined;
+  return {
+    status: typeof data.status === 'string' ? data.status : undefined,
+    completedPages: Number(data.completedPages) || 0,
+    failedPages: Number(data.failedPages) || 0,
+    completionRatio: Number(data.completionRatio) || 0,
+    rejectedCount: Number(data.rejectedCount) || 0,
+    retailers: data.retailers,
+  };
+}
+
 async function run() {
   console.log(`[consumer-prices] seeding market=${MARKET} basket=${BASKET}`);
 
@@ -108,10 +125,11 @@ async function run() {
   const TTL_FRESHNESS  = 600;   // 10 min
   const TTL_SERIES     = 3600;  // 60 min
   const TTL_CATEGORIES = 1800;  // 30 min
+  const TTL_COVERAGE   = 1800;  // 30 min
 
   // Fetch all snapshots in parallel
   const [overview, movers30d, movers7d, spread, freshness, series30d, series7d, series90d,
-         categories30d, categories7d, categories90d] = await Promise.all([
+         categories30d, categories7d, categories90d, coverage] = await Promise.all([
     fetchSnapshot(`/wm/consumer-prices/v1/overview?market=${MARKET}`),
     fetchSnapshot(`/wm/consumer-prices/v1/movers?market=${MARKET}&days=30`),
     fetchSnapshot(`/wm/consumer-prices/v1/movers?market=${MARKET}&days=7`),
@@ -123,6 +141,7 @@ async function run() {
     fetchSnapshot(`/wm/consumer-prices/v1/categories?market=${MARKET}&range=30d`),
     fetchSnapshot(`/wm/consumer-prices/v1/categories?market=${MARKET}&range=7d`),
     fetchSnapshot(`/wm/consumer-prices/v1/categories?market=${MARKET}&range=90d`),
+    fetchSnapshot(`/wm/consumer-prices/v1/coverage?market=${MARKET}`),
   ]);
 
   const writes = [
@@ -192,6 +211,12 @@ async function run() {
       ttl: TTL_CATEGORIES,
       metaKey: `seed-meta:consumer-prices:categories:${MARKET}:90d`,
     },
+    {
+      key: `consumer-prices:coverage:${MARKET}`,
+      data: coverage ?? emptyCoverage(MARKET),
+      ttl: TTL_COVERAGE,
+      metaKey: `seed-meta:consumer-prices:coverage:${MARKET}`,
+    },
   ];
 
   let failed = 0;
@@ -210,7 +235,8 @@ async function run() {
       } else {
         recordCount = 1;
       }
-      await writeExtraKeyWithMeta(key, data, ttl, recordCount, metaKey);
+      const coverage = coverageForSeedMeta(data);
+      await writeExtraKeyWithMeta(key, data, ttl, recordCount, metaKey, undefined, coverage);
       console.log(`  [consumer-prices] wrote ${key} (${recordCount} records)`);
     } catch (err) {
       console.error(`  [consumer-prices] failed ${key}: ${err.message}`);
@@ -222,7 +248,21 @@ async function run() {
   process.exit(failed > 0 ? 1 : 0);
 }
 
-run().catch((err) => {
-  console.error('[consumer-prices] seed failed:', err);
-  process.exit(1);
-});
+if (IS_MAIN) {
+  if (!FORCE) {
+    console.error(
+      '[consumer-prices] ERROR: --force flag required.\n' +
+      'This script overwrites Redis keys with short TTLs (10-60 min), stomping the\n' +
+      'authoritative publish.ts 26h TTLs. Only run manually when publish.ts is broken.\n' +
+      'Usage: node scripts/seed-consumer-prices.mjs --force',
+    );
+    process.exit(1);
+  }
+  if (!BASE_URL) {
+    console.warn('[consumer-prices] CONSUMER_PRICES_CORE_BASE_URL not set — writing empty placeholders');
+  }
+  run().catch((err) => {
+    console.error('[consumer-prices] seed failed:', err);
+    process.exit(1);
+  });
+}

--- a/tests/consumer-prices-coverage-contract.test.mjs
+++ b/tests/consumer-prices-coverage-contract.test.mjs
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { coverageForSeedMeta, emptyCoverage } from '../scripts/seed-consumer-prices.mjs';
+
+const migration = readFileSync(
+  new URL('../consumer-prices-core/migrations/010_scrape_run_coverage.sql', import.meta.url),
+  'utf8',
+);
+
+test('scrape coverage migration persists a nonnegative rejection counter', () => {
+  assert.match(migration, /ADD COLUMN IF NOT EXISTS rejected_count INT NOT NULL DEFAULT 0/);
+  assert.match(migration, /CHECK \(rejected_count >= 0\)/);
+});
+
+test('manual fallback preserves partial coverage and per-retailer diagnostics in seed meta', () => {
+  const coverage = {
+    ...emptyCoverage('ke'),
+    status: 'partial',
+    completedPages: 6,
+    failedPages: 6,
+    completionRatio: 0.5,
+    rejectedCount: 3,
+    retailers: [{ slug: 'retailer-a', coverageStatus: 'partial', rejectedCount: 3 }],
+  };
+
+  assert.deepEqual(coverageForSeedMeta(coverage), {
+    status: 'partial',
+    completedPages: 6,
+    failedPages: 6,
+    completionRatio: 0.5,
+    rejectedCount: 3,
+    retailers: coverage.retailers,
+  });
+  assert.equal(coverageForSeedMeta({ upstreamUnavailable: true }), undefined);
+  assert.equal(coverageForSeedMeta(emptyCoverage('ke')).status, 'unknown');
+});

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -91,6 +91,91 @@ test('classifyKey: fresh seed + data → OK', () => {
   assert.equal(entry.status, 'OK');
 });
 
+test('classifyKey: consumer-price coverage below the declared completion floor degrades', () => {
+  const key = BOOTSTRAP_KEYS.consumerPricesCoverage;
+  const entry = classifyKey('consumerPricesCoverage', key, { allowOnDemand: false }, makeCtx({
+    strens: { [key]: 2048 },
+    metaValues: {
+      [SEED_META.consumerPricesCoverage.key]: seedMeta({
+        recordCount: 4,
+        coverage: { completedPages: 4, failedPages: 8, completionRatio: 0.3333, rejectedCount: 2 },
+      }),
+    },
+  }));
+
+  assert.equal(entry.status, 'COVERAGE_DEGRADED');
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
+test('classifyKey: consumer-price coverage at the floor remains healthy', () => {
+  const key = BOOTSTRAP_KEYS.consumerPricesCoverage;
+  const entry = classifyKey('consumerPricesCoverage', key, { allowOnDemand: false }, makeCtx({
+    strens: { [key]: 2048 },
+    metaValues: {
+      [SEED_META.consumerPricesCoverage.key]: seedMeta({
+        recordCount: 4,
+        coverage: { completedPages: 6, failedPages: 6, completionRatio: 0.5, rejectedCount: 0 },
+      }),
+    },
+  }));
+
+  assert.equal(entry.status, 'OK');
+});
+
+test('classifyKey: consumer-price coverage requires diagnostics and exposes retailer rejection state', () => {
+  const key = BOOTSTRAP_KEYS.consumerPricesCoverage;
+  const entry = classifyKey('consumerPricesCoverage', key, { allowOnDemand: false }, makeCtx({
+    strens: { [key]: 2048 },
+    metaValues: {
+      [SEED_META.consumerPricesCoverage.key]: seedMeta({
+        recordCount: 4,
+        coverage: {
+          status: 'partial',
+          completedPages: 8,
+          failedPages: 2,
+          completionRatio: 0.8,
+          rejectedCount: 3,
+          retailers: [{
+            slug: 'retailer-a',
+            name: 'Retailer A',
+            coverageStatus: 'failed',
+            pagesAttempted: 2,
+            pagesSucceeded: 0,
+            failedPages: 2,
+            rejectedCount: 1,
+            completionRatio: 0,
+          }],
+        },
+      }),
+    },
+  }));
+
+  assert.equal(entry.status, 'COVERAGE_PARTIAL');
+  assert.equal(entry.coverage.status, 'partial');
+  assert.equal(entry.coverage.rejectedCount, 3);
+  assert.equal(entry.coverage.retailers[0].coverageStatus, 'failed');
+});
+
+test('classifyKey: missing consumer-price coverage metadata fails closed', () => {
+  const key = BOOTSTRAP_KEYS.consumerPricesCoverage;
+  const entry = classifyKey('consumerPricesCoverage', key, { allowOnDemand: false }, makeCtx({
+    strens: { [key]: 2048 },
+    metaValues: { [SEED_META.consumerPricesCoverage.key]: seedMeta({ recordCount: 4 }) },
+  }));
+
+  assert.equal(entry.status, 'COVERAGE_DEGRADED');
+  assert.equal(entry.coverage, null);
+});
+
+test('health registers every currently enabled consumer-price market coverage key', () => {
+  for (const market of ['ae', 'au', 'br', 'gb', 'in', 'sa', 'sg', 'us']) {
+    const name = market === 'ae' ? 'consumerPricesCoverage' : `consumerPricesCoverage${market.toUpperCase()}`;
+    assert.equal(BOOTSTRAP_KEYS[name], `consumer-prices:coverage:${market}`);
+    assert.equal(SEED_META[name].key, `seed-meta:consumer-prices:coverage:${market}`);
+    assert.equal(SEED_META[name].requireCoverage, true);
+  }
+});
+
 test('classifyKey: present-but-stale seed → STALE_SEED (warn), data still present', () => {
   const entry = classifyKey('earthquakes', BOOTSTRAP_KEYS.earthquakes, { allowOnDemand: false },
     makeCtx({

--- a/tests/ingestion-operational-contract.test.mjs
+++ b/tests/ingestion-operational-contract.test.mjs
@@ -1,0 +1,58 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import {
+  AVIATION_MIN_SERVED_COVERAGE,
+  RSS_MIN_SERVED_COVERAGE,
+  classifyUpstreamOutcome,
+  nextBackoffMs,
+  summarizeServedCoverage,
+} from '../scripts/_ingestion-coverage.cjs';
+
+test('relay outcome classes keep throttling and auth separate from faults', () => {
+  assert.equal(classifyUpstreamOutcome({ status: 200 }), 'success');
+  assert.equal(classifyUpstreamOutcome({ status: 429 }), 'throttle');
+  assert.equal(classifyUpstreamOutcome({ status: 401 }), 'authRejection');
+  assert.equal(classifyUpstreamOutcome({ status: 504 }), 'timeout');
+  assert.equal(classifyUpstreamOutcome({ status: 502 }), 'terminalFailure');
+  assert.equal(classifyUpstreamOutcome({ error: { name: 'TimeoutError' } }), 'timeout');
+  assert.equal(classifyUpstreamOutcome({ error: new Error('socket timed out') }), 'timeout');
+  assert.equal(classifyUpstreamOutcome({ status: 204 }), 'success');
+  assert.equal(classifyUpstreamOutcome({ status: 0 }), 'terminalFailure');
+});
+
+test('served coverage degrades below the fixed aviation/RSS floors and recovers at the floor', () => {
+  assert.equal(
+    summarizeServedCoverage({ requests: 10, served: 4, minimum: AVIATION_MIN_SERVED_COVERAGE }).status,
+    'degraded',
+  );
+  assert.equal(
+    summarizeServedCoverage({ requests: 10, served: 5, minimum: AVIATION_MIN_SERVED_COVERAGE }).status,
+    'ok',
+  );
+  assert.equal(
+    summarizeServedCoverage({ requests: 10, served: 6, minimum: RSS_MIN_SERVED_COVERAGE }).status,
+    'degraded',
+  );
+  assert.equal(
+    summarizeServedCoverage({ requests: 10, served: 7, minimum: RSS_MIN_SERVED_COVERAGE }).status,
+    'ok',
+  );
+});
+
+test('RSS backoff is exponential but capped so fallback exhaustion stops retry growth', () => {
+  const delays = [0, 1, 2, 3, 4, 5].map((failures) => nextBackoffMs(failures, 60_000, 900_000));
+  assert.deepEqual(delays, [60_000, 120_000, 240_000, 480_000, 900_000, 900_000]);
+  assert.equal(nextBackoffMs(100, 60_000, 900_000), 900_000);
+});
+
+test('served coverage is bounded and remains explicit when no request was observed', () => {
+  assert.deepEqual(
+    summarizeServedCoverage({ requests: 0, served: 10, minimum: 0.5 }),
+    { requests: 0, served: 0, servedCoverage: null, minimumCoverage: 0.5, status: 'not_observed' },
+  );
+  assert.deepEqual(
+    summarizeServedCoverage({ requests: 3.9, served: 10, minimum: 2 }),
+    { requests: 3, served: 3, servedCoverage: 1, minimumCoverage: 1, status: 'ok' },
+  );
+  assert.equal(summarizeServedCoverage({ requests: 1, served: -2, minimum: 0.5 }).status, 'degraded');
+});

--- a/tests/ingestion-operational-contract.test.mjs
+++ b/tests/ingestion-operational-contract.test.mjs
@@ -39,10 +39,17 @@ test('served coverage degrades below the fixed aviation/RSS floors and recovers 
   );
 });
 
-test('RSS backoff is exponential but capped so fallback exhaustion stops retry growth', () => {
+test('RSS backoff is exponential with jitter but capped so fallback exhaustion stops retry growth', () => {
   const delays = [0, 1, 2, 3, 4, 5].map((failures) => nextBackoffMs(failures, 60_000, 900_000));
-  assert.deepEqual(delays, [60_000, 120_000, 240_000, 480_000, 900_000, 900_000]);
-  assert.equal(nextBackoffMs(100, 60_000, 900_000), 900_000);
+  // Each delay is deterministic-base ±25% jitter, capped at maxMs.
+  assert.ok(delays[0] >= 45_000 && delays[0] <= 75_000, `delay[0]=${delays[0]} out of range`);
+  assert.ok(delays[1] >= 90_000 && delays[1] <= 150_000, `delay[1]=${delays[1]} out of range`);
+  assert.ok(delays[2] >= 180_000 && delays[2] <= 300_000, `delay[2]=${delays[2]} out of range`);
+  assert.ok(delays[3] >= 360_000 && delays[3] <= 600_000, `delay[3]=${delays[3]} out of range`);
+  // Jittered values at cap may be below maxMs, but never exceed it.
+  assert.ok(delays[4] >= 675_000 && delays[4] <= 900_000, `delay[4]=${delays[4]} out of range (capped)`);
+  assert.ok(delays[5] >= 675_000 && delays[5] <= 900_000, `delay[5]=${delays[5]} out of range (capped)`);
+  assert.ok(nextBackoffMs(100, 60_000, 900_000) >= 675_000 && nextBackoffMs(100, 60_000, 900_000) <= 900_000);
 });
 
 test('served coverage is bounded and remains explicit when no request was observed', () => {

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -367,6 +367,22 @@ const EXCLUDED_FROM_MCP = new Map([
     'operational: per-collector intel-history ingest state (last successful append, last relay error, consecutive failures) published by scripts/_seed-history.mjs for /api/health + /api/seed-health (#5736). The history CONTENT it guards is already queryable through search_intel_history / get_intel_timeline / get_similar_events.'],
   ['intel-history:ingest-health:energy:intelligence:v1',
     'operational: per-collector intel-history ingest state (last successful append, last relay error, consecutive failures) published by scripts/_seed-history.mjs for /api/health + /api/seed-health (#5736). The history CONTENT it guards is already queryable through search_intel_history / get_intel_timeline / get_similar_events.'],
+  ['consumer-prices:coverage:ae',
+    'operational: consumer-price market/retailer completion and validator-rejection coverage published for /api/health; the underlying price observations are exposed through get_consumer_prices, while this health snapshot is not a queryable MCP slice (#5945).'],
+  ['consumer-prices:coverage:au',
+    'operational: consumer-price market/retailer completion and validator-rejection coverage published for /api/health; the underlying price observations are exposed through get_consumer_prices, while this health snapshot is not a queryable MCP slice (#5945).'],
+  ['consumer-prices:coverage:br',
+    'operational: consumer-price market/retailer completion and validator-rejection coverage published for /api/health; the underlying price observations are exposed through get_consumer_prices, while this health snapshot is not a queryable MCP slice (#5945).'],
+  ['consumer-prices:coverage:gb',
+    'operational: consumer-price market/retailer completion and validator-rejection coverage published for /api/health; the underlying price observations are exposed through get_consumer_prices, while this health snapshot is not a queryable MCP slice (#5945).'],
+  ['consumer-prices:coverage:in',
+    'operational: consumer-price market/retailer completion and validator-rejection coverage published for /api/health; the underlying price observations are exposed through get_consumer_prices, while this health snapshot is not a queryable MCP slice (#5945).'],
+  ['consumer-prices:coverage:sa',
+    'operational: consumer-price market/retailer completion and validator-rejection coverage published for /api/health; the underlying price observations are exposed through get_consumer_prices, while this health snapshot is not a queryable MCP slice (#5945).'],
+  ['consumer-prices:coverage:sg',
+    'operational: consumer-price market/retailer completion and validator-rejection coverage published for /api/health; the underlying price observations are exposed through get_consumer_prices, while this health snapshot is not a queryable MCP slice (#5945).'],
+  ['consumer-prices:coverage:us',
+    'operational: consumer-price market/retailer completion and validator-rejection coverage published for /api/health; the underlying price observations are exposed through get_consumer_prices, while this health snapshot is not a queryable MCP slice (#5945).'],
 ]);
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Provider throttling and partial market publication now become bounded, observable states instead of repeated error noise or a binary healthy/failed signal. The relay records route-level outcomes and served coverage, while consumer-price runs publish truthful market and retailer completion/rejection diagnostics without weakening strict validator admission.

## Design decisions

- Relay health separates process liveness from ingestion quality: `/health` preserves its top-level `status: "ok"` contract for Railway probes, while `ingestion.status` degrades below the aviation/RSS served-coverage floors or when AIS snapshot requests have no served snapshot. `/metrics` exposes the rolling counters and cooldown/backoff state.
- Google Flights and OpenSky now honor bounded global cooldowns and retry budgets; RSS uses per-feed exponential backoff, negative caching, and stale-on-error fallback. AIS reconnects use a bounded backoff, and long Google date ranges stop after six chunks instead of creating unbounded upstream work.
- The consumer-price service persists validator rejections, exposes a per-market coverage endpoint, publishes last-good coverage snapshots with recovery-safe semantics, and registers coverage health for every currently enabled market. Partial publication remains possible, but missing coverage diagnostics fail closed in health.
- The relay image explicitly copies the new shared ingestion helper, and MCP parity documents coverage snapshots as operator-only health metadata rather than pretending they are user-facing data slices.

## Related

Related: #5945, #5445, #5811

## Validation

- Full root data suite: 20,087 tests, 20,066 passed, 6 skipped. The remaining 15 failures are all `tests/prepush-hook-gate.test.mjs` fixtures blocked before their assertions by the sandbox's `/var/folders` `mktemp` permission error; no product or issue-specific test failed in that run.
- Issue-specific relay/health/MCP/Docker contract tests: 85 passed.
- Consumer-prices-core: 15 Vitest files, 123 tests passed.
- Sidecar/API suite: 307 tests passed.
- `npm run typecheck`, `npm run typecheck:api`, `npm run lint`, `npm run build:full`, and `npm run docs:check` passed.

## Production acceptance

The final acceptance gate remains operational: after deployment, capture two observation windows showing bounded relay error volume and stable served coverage from `/metrics` and the nested `ingestion` object in relay `/health`, alongside compact Edge health and the per-market consumer coverage/seed-meta records. This PR does not claim those post-deploy windows in CI.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/MODEL_SLUG-GPT_5-000000)
