### PR TITLE
fix(bootstrap): survive sandboxed iframes, match aliased fetch wrappers

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -545,8 +545,20 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // trampoline variant is WORLDMONITOR-TZ: a wallet extension's
       // `injected/hook.js` wraps `window.fetch` and the leaked rejection frame
       // surfaces as `Object.apply`, not `window.fetch`.
+      // Sentry renders a frame reached through an aliased property as
+      // `<name> [<annotation>]` — an extension that stashes the original fetch
+      // under its own property surfaces as `window.fetch [<annotation>]`. The
+      // anchored match below needs the bare name, so strip one trailing
+      // bracketed annotation first; the meaningful identity is the name BEFORE
+      // the bracket, so a frame merely stored under a fetch-ish alias still
+      // fails the match (WORLDMONITOR-Y8, same Adjust extension as SG above).
+      // NB: deliberately written without spelling out the annotation keyword —
+      // the beforeSend unit-test harness strips `<keyword> <word>` sequences to
+      // drop TypeScript assertions and would mangle a regex that contained it
+      // (same harness trap as the Floot gate above).
+      const bareFrameFunction = (fn: string) => fn.replace(/\s*\[[^\]]*\]$/, '');
       if (/^(?:TypeError: )?Failed to fetch$/.test(msg)
-          && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? '') && /^(?:(?:.*\.)?window\.|(?:window|Object)\.)?(?:fetch|apply)$/i.test(f.function ?? ''))) {
+          && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? '') && /^(?:(?:.*\.)?window\.|(?:window|Object)\.)?(?:fetch|apply)$/i.test(bareFrameFunction(f.function ?? '')))) {
         return null;
       }
       // Bare `Failed to fetch` surfacing through the DebugBear RUM collector's

--- a/src/bootstrap/sw-update.ts
+++ b/src/bootstrap/sw-update.ts
@@ -19,6 +19,30 @@ interface ServiceWorkerContainerLike {
   addEventListener: (type: string, cb: () => void) => void;
 }
 
+/**
+ * Read `navigator.serviceWorker` without letting a hostile context abort boot.
+ *
+ * `'serviceWorker' in navigator` is TRUE inside an iframe sandboxed without
+ * `allow-same-origin` — the property exists on `Navigator.prototype` — but the
+ * getter itself throws `SecurityError: Failed to read the 'serviceWorker'
+ * property from 'Navigator': Service worker is disabled because the context is
+ * sandboxed and lacks the 'allow-same-origin' flag.` So an existence check
+ * passes and the first real READ throws, which at module scope takes the rest
+ * of the entry module's top-level statements down with it (WORLDMONITOR-Y5).
+ *
+ * Returns null whenever the container is unreadable or absent, so every caller
+ * can treat "no service worker here" as one ordinary branch.
+ */
+export function readServiceWorkerContainer(
+  nav: Navigator = navigator,
+): ServiceWorkerContainerLike | null {
+  try {
+    return (nav as { serviceWorker?: ServiceWorkerContainerLike }).serviceWorker ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export interface SwUpdateHandlerOptions {
   swContainer?: ServiceWorkerContainerLike;
   document?: DocumentLike;
@@ -110,7 +134,13 @@ function appendDebugLog(entry: Record<string, unknown>): void {
  * Dismissing one version never suppresses toasts for future deploys.
  */
 export function installSwUpdateHandler(options: SwUpdateHandlerOptions = {}): void {
-  const swContainer = options.swContainer ?? navigator.serviceWorker;
+  // No readable container (sandboxed iframe, or an engine without SW support)
+  // means there is nothing to install — and reading it eagerly would throw.
+  // Rebound as a non-nullable const so the hoisted helpers below (which TS
+  // treats as callable before this guard) see the narrowed type.
+  const container = options.swContainer ?? readServiceWorkerContainer();
+  if (!container) return;
+  const swContainer: ServiceWorkerContainerLike = container;
   const doc = options.document ?? (document as unknown as DocumentLike);
   const reload = options.reload ?? (() => window.location.reload());
   const raf = options.raf ?? ((cb: () => void) => requestAnimationFrame(() => requestAnimationFrame(cb)));

--- a/src/main.ts
+++ b/src/main.ts
@@ -382,7 +382,7 @@ import { initAnalytics, trackContentHandoff } from '@/services/analytics';
 import { clearChunkReloadGuard, installChunkReloadGuard } from '@/bootstrap/chunk-reload';
 import { initDebugBearRum } from '@/bootstrap/debugbear-rum';
 import { installStaleBundleCheck } from '@/bootstrap/stale-bundle-check';
-import { installSwUpdateHandler } from '@/bootstrap/sw-update';
+import { installSwUpdateHandler, readServiceWorkerContainer } from '@/bootstrap/sw-update';
 
 // Auto-reload on stale chunk 404s after deployment (Vite fires this for modulepreload failures).
 const chunkReloadStorageKey = installChunkReloadGuard(__APP_VERSION__);
@@ -501,8 +501,12 @@ if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
   });
 }
 
-if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && 'serviceWorker' in navigator) {
-  installSwUpdateHandler({ version: __APP_VERSION__ });
+// `'serviceWorker' in navigator` is not a safe gate: in a sandboxed iframe the
+// property exists but reading it throws SecurityError (WORLDMONITOR-Y5), which
+// at module scope aborts every top-level statement below. Read it once, safely.
+const swContainer = readServiceWorkerContainer();
+if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && swContainer) {
+  installSwUpdateHandler({ version: __APP_VERSION__, swContainer });
 
   const SW_UPDATE_SUCCESS_INTERVAL_MS = 60 * 60 * 1000;
   const SW_UPDATE_FAILURE_INTERVAL_MS = 5 * 60 * 1000;

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -594,6 +594,32 @@ describe('existing beforeSend filters', () => {
     assert.equal(beforeSend(event), null, 'Extension chain-ending-in-window.fetch fetch failure should be suppressed');
   });
 
+  it('suppresses bare "Failed to fetch" when the extension fetch frame carries an alias annotation (WORLDMONITOR-Y8)', () => {
+    // Real WORLDMONITOR-Y8 stack (Adjust SDK injectScriptAdjust.js, the same
+    // extension already named in the SG gate): Sentry renders the frame whose
+    // function was reached through an alias as `<name> [<annotation>]`, so the
+    // wrapper surfaces as `window.fetch [<annotation>]`. The SG function match
+    // is anchored, so the trailing annotation made it miss and the identical
+    // wrapper class re-surfaced as a new issue.
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/assets/panel-storage-RVfx_Amx.js', lineno: 2, function: 'Ln' },
+      { filename: 'chrome-extension://bkkbcggnhapdmkeljlodobbkopceiche/injectScriptAdjust.js', lineno: 1, function: 'window.fetch [as originalFetch]' },
+      { filename: '/assets/widget-store-B60Ai24W.js', lineno: 2, function: 'window.fetch' },
+    ]);
+    assert.equal(beforeSend(event), null, 'alias-annotated extension window.fetch frame should be suppressed');
+  });
+
+  it('does NOT suppress when only the ALIAS half of an extension frame looks like fetch', () => {
+    // Precision guard for the annotation strip above: the meaningful name is the
+    // one BEFORE the bracket. An extension frame whose own function is unrelated
+    // must not qualify just because it was stored under a fetch-ish property.
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/assets/panels-wF5GXf0N.js', lineno: 100, function: 'MyApiCall' },
+      { filename: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop/inject.js', lineno: 1, function: 'trackEvent [as fetch]' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'alias-only fetch resemblance must not trigger SG suppression');
+  });
+
   it('does NOT suppress bare "Failed to fetch" with a first-party frame and a NON-fetch extension frame', () => {
     // Precision guard for WORLDMONITOR-SG: an extension frame whose function is
     // not a fetch wrapper is NOT evidence the extension owns the orphan fetch

--- a/tests/sw-update.test.mts
+++ b/tests/sw-update.test.mts
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { installSwUpdateHandler, OPEN_MODAL_SELECTOR } from '../src/bootstrap/sw-update.ts';
+import { installSwUpdateHandler, OPEN_MODAL_SELECTOR, readServiceWorkerContainer } from '../src/bootstrap/sw-update.ts';
 
 // ---------------------------------------------------------------------------
 // Fake environment
@@ -642,5 +642,46 @@ describe('installSwUpdateHandler', () => {
     env.swContainer.fireControllerChange();
     assert.equal(env.visibilityListeners.length, 1, 'still exactly one listener after N+1');
     assert.ok(env.doc._removedListeners.length > 0, 'old listener was explicitly removed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readServiceWorkerContainer — sandboxed-iframe SecurityError (WORLDMONITOR-Y5)
+// ---------------------------------------------------------------------------
+
+describe('readServiceWorkerContainer', () => {
+  it('returns null when the serviceWorker getter throws (sandboxed iframe)', () => {
+    // Chrome in an iframe sandboxed without `allow-same-origin`: the property
+    // EXISTS on Navigator.prototype (so `'serviceWorker' in navigator` is true)
+    // but reading it raises SecurityError. A plain existence check therefore
+    // passes and the first real read throws.
+    const nav = {} as Navigator;
+    Object.defineProperty(nav, 'serviceWorker', {
+      get() {
+        throw new DOMException(
+          "Failed to read the 'serviceWorker' property from 'Navigator': Service worker is disabled because the context is sandboxed and lacks the 'allow-same-origin' flag.",
+          'SecurityError',
+        );
+      },
+      configurable: true,
+    });
+    assert.ok('serviceWorker' in nav, 'precondition: the property-existence check passes');
+    assert.equal(readServiceWorkerContainer(nav), null);
+  });
+
+  it('returns null when the navigator has no serviceWorker at all', () => {
+    assert.equal(readServiceWorkerContainer({} as Navigator), null);
+  });
+
+  it('installSwUpdateHandler is an inert no-op when no container is readable', () => {
+    // The early return is the whole point of the guard: without it the handler
+    // walks on to `options.document ?? document` and dereferences a container
+    // that was never there.
+    assert.doesNotThrow(() => installSwUpdateHandler({}));
+  });
+
+  it('returns the container when it is readable', () => {
+    const container = { controller: null, addEventListener() {} };
+    assert.equal(readServiceWorkerContainer({ serviceWorker: container } as unknown as Navigator), container);
   });
 });


### PR DESCRIPTION
## Summary

Two independent fixes surfaced by a Sentry triage pass, both landing in `src/bootstrap/`.

**A sandboxed iframe threw an uncaught `SecurityError` during boot.** `'serviceWorker' in navigator` is true inside an iframe sandboxed without `allow-same-origin` — the property exists on `Navigator.prototype` — but *reading* it throws. So the existence check passed and the first real read threw at module scope. Nothing executable follows that block in `main.ts` today, so the practical damage was the error report plus the update handler never installing; the point is that the guard was one refactor away from taking real work down with it. Reads now go through `readServiceWorkerContainer()`, which returns null when the container is unreadable or absent so every caller gets one ordinary "no service worker here" branch.

**An extension's fetch wrapper was leaking bare `Failed to fetch` reports.** Sentry renders a frame reached through an aliased property as `<name> [<annotation>]`, so a wrapper stashed under the extension's own property surfaces as `window.fetch [<annotation>]`. The existing SG/TZ gate's function match is anchored, so that trailing annotation made it miss — and the very extension already named in that gate's comment came back as a brand-new issue. The match now strips one trailing bracketed annotation first. Identity still comes from the name *before* the bracket, so a frame merely stored under a fetch-ish alias keeps surfacing rather than being silently swallowed.

Both Sentry issues are already marked resolved-in-next-release: `WORLDMONITOR-Y5` and `WORLDMONITOR-Y8`.

### One line not to "simplify"

The annotation-stripping regex deliberately never spells out the alias keyword. `tests/sentry-beforesend.test.mjs` eval's the `beforeSend` body after stripping `<keyword> <word>` sequences to drop TypeScript assertions, so a regex that spelled it out would be mangled at test time — the same harness trap already documented on the Floot gate a few lines above it.

## Validation

Both fixes were written test-first and confirmed **red before the change**, then green after:

| Check | Result |
|---|---|
| `tests/sw-update.test.mts` + `tests/sentry-beforesend.test.mjs` | 264/264 pass (5 new) |
| `npx tsc --noEmit` | exit 0, no output |
| `biome lint` on the 5 changed files | clean |

The `installSwUpdateHandler` early return was separately mutation-tested: deleting just that line turns the new "inert no-op" test red, and restoring it goes green — so the guard is covered by something that can actually fail rather than passing vacuously.

Two precision guards were added alongside the suppression tests, since a filter that over-matches is worse than one that misses: an extension frame whose own function is unrelated but was *stored under* a fetch-ish alias must still surface, and the pre-existing `prefetch`/`fetchContent` guard must keep passing.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
