### PR TITLE
fix(feeds): harden geo coverage gate against silent-pass failures

### DIFF
--- a/scripts/geo-coverage-health.mjs
+++ b/scripts/geo-coverage-health.mjs
@@ -116,58 +116,73 @@ export function getEnglishDefaultEnabledSources(feeds) {
 /**
  * Load every input the audit needs.
  * @param {string} [repoRoot]
+ * @param {{ sourceGeographyPath?: string, policyPath?: string }} [paths]
+ *   Optional path overrides (used by CLI failure-path tests via env).
  */
-export async function loadGeoCoverageInputs(repoRoot = DEFAULT_REPO_ROOT) {
+export async function loadGeoCoverageInputs(repoRoot = DEFAULT_REPO_ROOT, paths = {}) {
+  const sourceGeographyPath = paths.sourceGeographyPath
+    ?? process.env.GEO_COVERAGE_SOURCE_GEOGRAPHY_PATH
+    ?? join(repoRoot, 'shared/source-geography.json');
+  const policyPath = paths.policyPath
+    ?? process.env.GEO_COVERAGE_POLICY_PATH
+    ?? join(repoRoot, 'shared/geo-coverage-policy.json');
+
   const [{ REGIONS }, sourceGeographyDoc, policy, iso2ToRegion] = await Promise.all([
     import(pathToFileURL(join(repoRoot, 'shared/geography.js')).href),
-    readJson(join(repoRoot, 'shared/source-geography.json')),
-    readJson(join(repoRoot, 'shared/geo-coverage-policy.json')),
+    readJson(sourceGeographyPath),
+    readJson(policyPath),
     readJson(join(repoRoot, 'shared/iso2-to-region.json')),
   ]);
   const { feeds, cleanup } = await bundleFeedsModule(repoRoot);
 
-  // Deduped keyCountries → owning display regions ('global' repeats strategic
-  // countries and is not itself a coverage area, so it is not listed as an owner).
-  /** @type {Map<string, string[]>} */
-  const byIso = new Map();
-  for (const region of REGIONS) {
-    if (region.id === 'global') continue;
-    for (const iso2 of region.keyCountries) {
-      const owners = byIso.get(iso2) ?? [];
-      owners.push(region.id);
-      byIso.set(iso2, owners);
-    }
-  }
-  const keyCountries = [...byIso.entries()].map(([iso2, regions]) => ({ iso2, regions }));
-
-  const sourceGeography = new Map(
-    dataEntries(sourceGeographyDoc, 'source-geography.json').map(([name, countries]) => {
-      if (!Array.isArray(countries) || countries.length === 0) {
-        throw new Error(`source-geography.json: "${name}" must map to a non-empty ISO2 array`);
+  try {
+    // Deduped keyCountries → owning display regions ('global' repeats strategic
+    // countries and is not itself a coverage area, so it is not listed as an owner).
+    /** @type {Map<string, string[]>} */
+    const byIso = new Map();
+    for (const region of REGIONS) {
+      if (region.id === 'global') continue;
+      for (const iso2 of region.keyCountries) {
+        const owners = byIso.get(iso2) ?? [];
+        owners.push(region.id);
+        byIso.set(iso2, owners);
       }
-      return [name, countries];
-    }),
-  );
+    }
+    const keyCountries = [...byIso.entries()].map(([iso2, regions]) => ({ iso2, regions }));
 
-  const catalogNames = new Set([
-    ...Object.values(feeds.FULL_FEEDS).flat().map((f) => f.name),
-    ...feeds.INTEL_SOURCES.map((f) => f.name),
-  ]);
-  const defaultEnabled = getEnglishDefaultEnabledSources(feeds);
-  const validIso2 = new Set([...Object.keys(iso2ToRegion), ...byIso.keys()]);
+    const sourceGeography = new Map(
+      dataEntries(sourceGeographyDoc, 'source-geography.json').map(([name, countries]) => {
+        if (!Array.isArray(countries) || countries.length === 0) {
+          throw new Error(`source-geography.json: "${name}" must map to a non-empty ISO2 array`);
+        }
+        return [name, countries];
+      }),
+    );
 
-  return {
-    keyCountries,
-    regions: REGIONS.filter((r) => r.id !== 'global'),
-    sourceGeography,
-    policy,
-    catalogNames,
-    defaultEnabled,
-    validIso2,
-    catalogSize: catalogNames.size,
-    defaultEnabledSize: defaultEnabled.size,
-    cleanup,
-  };
+    const catalogNames = new Set([
+      ...Object.values(feeds.FULL_FEEDS).flat().map((f) => f.name),
+      ...feeds.INTEL_SOURCES.map((f) => f.name),
+    ]);
+    const defaultEnabled = getEnglishDefaultEnabledSources(feeds);
+    const validIso2 = new Set([...Object.keys(iso2ToRegion), ...byIso.keys()]);
+
+    return {
+      keyCountries,
+      regions: REGIONS.filter((r) => r.id !== 'global'),
+      sourceGeography,
+      policy,
+      catalogNames,
+      defaultEnabled,
+      validIso2,
+      catalogSize: catalogNames.size,
+      defaultEnabledSize: defaultEnabled.size,
+      cleanup,
+    };
+  } catch (error) {
+    // Bundle succeeded but post-bundle work threw — still free the temp dir.
+    cleanup();
+    throw error;
+  }
 }
 
 /**
@@ -181,6 +196,11 @@ export function validateSourceGeography({ sourceGeography, catalogNames, validIs
       problems.push(
         `source-geography.json: "${name}" is not a configured feed source ` +
         '(rename in src/config/feeds.ts or fix the map)',
+      );
+    }
+    if (new Set(countries).size !== countries.length) {
+      problems.push(
+        `source-geography.json: "${name}" lists duplicate ISO2 codes — each country must appear once`,
       );
     }
     for (const iso2 of countries) {
@@ -216,24 +236,29 @@ export function validateGeoCoveragePolicy({ policy, keyCountries }) {
  * Row: { iso2, regions, catalogSources, defaultOnSources, floor, allowlistReason }
  */
 export function computeGeoCoverage({ keyCountries, sourceGeography, defaultEnabled, policy }) {
+  // iso2 → Set<source name> so a source counts at most once per country even if
+  // the curated map accidentally lists the same ISO2 twice (floor gaming).
+  /** @type {Map<string, Set<string>>} */
   const localByIso = new Map();
   for (const [name, countries] of sourceGeography) {
-    for (const iso2 of countries) {
-      const names = localByIso.get(iso2) ?? [];
-      names.push(name);
+    for (const iso2 of new Set(countries)) {
+      const names = localByIso.get(iso2) ?? new Set();
+      names.add(name);
       localByIso.set(iso2, names);
     }
   }
+  const floors = policy.floors ?? {};
+  const allowlist = policy.zeroDefaultOnAllowlist ?? {};
   return keyCountries.map(({ iso2, regions }) => {
-    const catalogSources = (localByIso.get(iso2) ?? []).sort((a, b) => a.localeCompare(b));
+    const catalogSources = [...(localByIso.get(iso2) ?? [])].sort((a, b) => a.localeCompare(b));
     const defaultOnSources = catalogSources.filter((name) => defaultEnabled.has(name));
     return {
       iso2,
       regions,
       catalogSources,
       defaultOnSources,
-      floor: policy.floors[iso2] ?? 0,
-      allowlistReason: policy.zeroDefaultOnAllowlist[iso2] ?? null,
+      floor: floors[iso2] ?? 0,
+      allowlistReason: allowlist[iso2] ?? null,
     };
   });
 }

--- a/tests/geo-coverage-health.test.mts
+++ b/tests/geo-coverage-health.test.mts
@@ -17,7 +17,7 @@
 import { after, before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -33,6 +33,10 @@ import {
 } from '../scripts/geo-coverage-health.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Strategic floors the epic pins — must stay in policy so CI cannot go green by emptying floors. */
+const STRATEGIC_FLOOR_ISO2 = ['UA', 'PL', 'TW', 'PK'] as const;
+const STRATEGIC_FLOOR_MIN = 1;
 
 let inputs: Awaited<ReturnType<typeof loadGeoCoverageInputs>>;
 
@@ -88,6 +92,50 @@ describe('geographic coverage health (#5957)', () => {
       'geo-coverage-policy.json: floors key "ZZ" is not a keyCountry in shared/geography.js',
       'geo-coverage-policy.json: zeroDefaultOnAllowlist key "YY" is not a keyCountry in shared/geography.js',
     ]);
+  });
+
+  it('reports unknown catalog names, unknown ISO2, and duplicate ISO2 tags', () => {
+    const malformed = {
+      ...inputs,
+      sourceGeography: new Map([
+        ['Not A Real Feed', ['US']],
+        ['BBC World', ['ZZ', 'US', 'US']],
+      ]),
+    };
+    assert.deepEqual(validateSourceGeography(malformed), [
+      'source-geography.json: "Not A Real Feed" is not a configured feed source '
+        + '(rename in src/config/feeds.ts or fix the map)',
+      'source-geography.json: "BBC World" lists duplicate ISO2 codes — each country must appear once',
+      'source-geography.json: "BBC World" tags unknown ISO2 "ZZ"',
+    ]);
+  });
+
+  it('counts each source at most once per country when ISO2 tags are duplicated', () => {
+    const rows = computeGeoCoverage({
+      keyCountries: [{ iso2: 'UA', regions: ['europe'] }],
+      sourceGeography: new Map([['Kyiv Independent', ['UA', 'UA']]]),
+      defaultEnabled: new Set(['Kyiv Independent']),
+      policy: { floors: { UA: 2 }, zeroDefaultOnAllowlist: {} },
+    });
+    assert.deepEqual(rows[0].catalogSources, ['Kyiv Independent']);
+    assert.deepEqual(rows[0].defaultOnSources, ['Kyiv Independent']);
+    assert.equal(rows[0].defaultOnSources.length, 1);
+    // Floor 2 must still fail — one source with duplicated tags cannot game it.
+    const { violations } = evaluateGeoCoverage(rows);
+    assert.equal(rows[0].status, 'FLOOR-BREACH');
+    assert.equal(violations.length, 1);
+  });
+
+  it('pins strategic floors UA/PL/TW/PK at ≥1 in policy (not just live counts)', () => {
+    const floors = inputs.policy.floors ?? {};
+    for (const iso2 of STRATEGIC_FLOOR_ISO2) {
+      const floor = floors[iso2] ?? 0;
+      assert.ok(
+        floor >= STRATEGIC_FLOOR_MIN,
+        `policy.floors must pin ${iso2} >= ${STRATEGIC_FLOOR_MIN} (got ${floor}) — `
+          + 'emptying floors must not keep CI green',
+      );
+    }
   });
 
   it('strategic floors hold (UA/PL/TW/PK ≥ 1 EN default-on local source)', () => {
@@ -185,6 +233,42 @@ describe('geographic coverage health (#5957)', () => {
       const output = JSON.parse(result.stdout);
       assert.deepEqual(output.violations, []);
       assert.deepEqual(readdirSync(tempRoot), [], 'CLI must clean its temporary bundle before exiting');
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('CLI exits 1 when policy floors are breached', () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'geo-coverage-cli-fail-'));
+    const policyPath = join(tempRoot, 'geo-coverage-policy.json');
+    try {
+      // Impossible floor forces FLOOR-BREACH while reusing the real map/catalog.
+      writeFileSync(policyPath, JSON.stringify({
+        floors: { UA: 999 },
+        zeroDefaultOnAllowlist: {},
+      }, null, 2));
+
+      const result = spawnSync(
+        process.execPath,
+        [join(repoRoot, 'scripts/geo-coverage-report.mjs'), '--json'],
+        {
+          cwd: repoRoot,
+          env: {
+            ...process.env,
+            TMPDIR: tempRoot,
+            GEO_COVERAGE_POLICY_PATH: policyPath,
+          },
+          encoding: 'utf8',
+        },
+      );
+      assert.ifError(result.error);
+      assert.equal(result.status, 1, `expected exit 1 on floor breach, got ${result.status}: ${result.stderr}`);
+      const output = JSON.parse(result.stdout);
+      assert.ok(Array.isArray(output.violations) && output.violations.length > 0);
+      assert.ok(
+        output.violations.some((v: string) => v.includes('UA') && v.includes('below floor')),
+        `expected UA floor breach in violations: ${JSON.stringify(output.violations)}`,
+      );
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

Follow-up to #5999 (merged). Addresses the structured code-review findings so the geographic coverage CI gate cannot go green while the epic contract is hollowed out.

- **Pin strategic floors** — assert `policy.floors` keeps UA/PL/TW/PK at ≥1 (not only that live counts meet whatever floors are present)
- **Dedupe ISO2 tags** — each source counts at most once per country; map validation flags duplicate ISO2 lists
- **CLI exit 1** — failure-path test via `GEO_COVERAGE_POLICY_PATH` with an impossible floor
- **Temp cleanup** — `loadGeoCoverageInputs` cleans the esbuild temp dir if post-bundle work throws

## Test plan

- [x] `tsx --test tests/geo-coverage-health.test.mts` — 14/14 pass
- [x] New cases: floors pin, duplicate ISO2 counting, map validation failures, CLI exit 1