### PR TITLE
fix(digest): tie the replay read-snapshot's lifecycle down and prove it

### DIFF
--- a/scripts/replay-digest-cooldown.mjs
+++ b/scripts/replay-digest-cooldown.mjs
@@ -52,7 +52,10 @@ const REPLAY_KEY_PREFIX = 'digest:replay-log:v1';
 const SCAN_PAGE_SIZE = 200;
 const REPLAY_REST_USER_AGENT = 'worldmonitor-digest/1.0';
 const REPLAY_REQUEST_TIMEOUT_MS = 10_000;
-const SNAPSHOT_TTL_SECONDS = 15 * 60;
+// Exported so the tests assert the real value instead of re-hardcoding it —
+// a TTL that silently drifts to 0 or a day is exactly the regression the
+// snapshot-lifecycle tests exist to catch.
+export const SNAPSHOT_TTL_SECONDS = 15 * 60;
 
 function replayRequestInit(token) {
   return {
@@ -507,6 +510,12 @@ Output:
  *     `body.result` is undefined, so the pre-2026-08-02 reader scored it
  *     as an empty list and the harness exited 2 blaming the feature flag.
  *
+ * Paging reads an atomic COPY of the day list rather than the live key, so a
+ * concurrent RPUSH/LTRIM cannot shift indices mid-read and duplicate or drop
+ * entries. The snapshot's whole lifecycle — created with a TTL in one
+ * pipeline, deleted in `finally` — is asserted by the tests; see
+ * SNAPSHOT_TTL_SECONDS.
+ *
  * @param {string} url                       Upstash REST base URL
  * @param {string} token                     Upstash REST token
  * @param {string} key                       replay-log day key
@@ -532,33 +541,58 @@ export async function readReplayListPaged(url, token, key, opts = {}) {
   /** @type {string[]} */
   const out = [];
   try {
-    const copyRes = await fetchImpl(
-      `${url}/copy/${encodeURIComponent(key)}/${encodeURIComponent(snapshotKey)}`,
-      replayRequestInit(token),
-    );
-    if (!copyRes.ok) {
-      throw new Error(`COPY ${key} -> ${snapshotKey} failed: HTTP ${copyRes.status}`);
+    // COPY and EXPIRE go out as ONE pipeline request, deliberately.
+    //
+    // Issued as two round trips, a process death between them leaves the
+    // snapshot alive with NO TTL — and the `finally` cleanup below does not
+    // run on SIGKILL, so that orphan (up to ~31MB at the current cap, and up
+    // to ~154MB for keys written under the old one) never expires. Pipelining
+    // means the server applies the TTL in the same execution as the copy, so
+    // the snapshot is never untethered regardless of what happens to us.
+    //
+    // REPLACE matters for the *diagnosis*, not for collisions: without it
+    // COPY answers 0 for BOTH "source missing" and "destination exists",
+    // and mapping that to an empty list is precisely the miss-vs-failure
+    // collapse this harness exists to avoid. With REPLACE, a 0 can only
+    // mean the source key is gone (verified against production 2026-08-02:
+    // missing source pipelines to [{result:0},{result:0}] and creates
+    // nothing), which is a genuine empty day.
+    const snapshotRes = await fetchImpl(`${url}/pipeline`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': REPLAY_REST_USER_AGENT,
+      },
+      body: JSON.stringify([
+        ['COPY', key, snapshotKey, 'REPLACE'],
+        ['EXPIRE', snapshotKey, String(SNAPSHOT_TTL_SECONDS)],
+      ]),
+      signal: AbortSignal.timeout(REPLAY_REQUEST_TIMEOUT_MS),
+    });
+    if (!snapshotRes.ok) {
+      throw new Error(`Snapshot of ${key} failed: HTTP ${snapshotRes.status}`);
     }
-    const copyBody = await copyRes.json();
-    if (copyBody?.error) {
-      throw new Error(`COPY ${key} -> ${snapshotKey} rejected by Upstash: ${copyBody.error}`);
+    const snapshotBody = await snapshotRes.json();
+    if (!Array.isArray(snapshotBody) || snapshotBody.length !== 2) {
+      throw new Error(`Snapshot of ${key} returned an unexpected pipeline shape`);
     }
-    if (copyBody?.result === 0 || copyBody?.result === '0') return out;
-    if (copyBody?.result !== 1 && copyBody?.result !== '1') {
+    const [copyCell, expireCell] = snapshotBody;
+    if (copyCell?.error) {
+      throw new Error(`COPY ${key} -> ${snapshotKey} rejected by Upstash: ${copyCell.error}`);
+    }
+    // Source key is gone (expired between SCAN and here) — a real empty day.
+    // Nothing was created, so no cleanup is owed.
+    if (copyCell?.result === 0 || copyCell?.result === '0') return out;
+    if (copyCell?.result !== 1 && copyCell?.result !== '1') {
       throw new Error(`COPY ${key} -> ${snapshotKey} returned an unexpected result`);
     }
     snapshotCreated = true;
 
-    const expireRes = await fetchImpl(
-      `${url}/expire/${encodeURIComponent(snapshotKey)}/${SNAPSHOT_TTL_SECONDS}`,
-      replayRequestInit(token),
-    );
-    if (!expireRes.ok) {
-      throw new Error(`EXPIRE ${snapshotKey} failed: HTTP ${expireRes.status}`);
-    }
-    const expireBody = await expireRes.json();
-    if (expireBody?.error || (expireBody?.result !== 1 && expireBody?.result !== '1')) {
-      throw new Error(`EXPIRE ${snapshotKey} rejected by Upstash: ${expireBody?.error ?? 'unexpected result'}`);
+    // The copy landed, so a failed EXPIRE means an untethered snapshot. Throw
+    // and let `finally` delete it rather than paging a key nothing will reap.
+    if (expireCell?.error || (expireCell?.result !== 1 && expireCell?.result !== '1')) {
+      throw new Error(`EXPIRE ${snapshotKey} rejected by Upstash: ${expireCell?.error ?? 'unexpected result'}`);
     }
 
     let start = 0;

--- a/tests/replay-digest-cooldown-harness.test.mjs
+++ b/tests/replay-digest-cooldown-harness.test.mjs
@@ -18,6 +18,7 @@ import {
   parseArgs,
   readReplayListPaged,
   renderMarkdownSummary,
+  SNAPSHOT_TTL_SECONDS,
 } from '../scripts/replay-digest-cooldown.mjs';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -467,32 +468,41 @@ describe('parseArgs', () => {
 // `res.ok` was true and `body.result` was undefined — the harness read it
 // as an empty list and exited 2 with "no records returned. Verify
 // DIGEST_DEDUP_REPLAY_LOG=1", pointing the operator at the wrong cause.
+/** Fake Upstash that serves `total` entries and records every URL hit. */
+function mockUpstash(total) {
+  const urls = [];
+  const lrangeUrls = [];
+  const requests = [];
+  const pipelines = [];
+  const dels = [];
+  return {
+    urls,
+    lrangeUrls,
+    requests,
+    pipelines,
+    dels,
+    impl: async (url, init) => {
+      urls.push(url);
+      requests.push({ url, init });
+      if (url.endsWith('/pipeline')) {
+        pipelines.push(JSON.parse(init.body));
+        return { ok: true, status: 200, json: async () => ([{ result: 1 }, { result: 1 }]) };
+      }
+      if (url.includes('/del/')) {
+        dels.push(decodeURIComponent(url.split('/del/')[1]));
+        return { ok: true, status: 200, json: async () => ({ result: 1 }) };
+      }
+      lrangeUrls.push(url);
+      const [, start, stop] = url.match(/\/lrange\/[^/]+\/(-?\d+)\/(-?\d+)$/).map(Number);
+      const from = start;
+      const to = Math.min(stop, total - 1);
+      const result = [];
+      for (let i = from; i <= to; i++) result.push(JSON.stringify({ storyHash: `h-${i}` }));
+      return { ok: true, status: 200, json: async () => ({ result }) };
+    },
+  };
+}
 describe('readReplayListPaged', () => {
-  /** Fake Upstash that serves `total` entries and records every URL hit. */
-  function mockUpstash(total) {
-    const urls = [];
-    const lrangeUrls = [];
-    const requests = [];
-    return {
-      urls,
-      lrangeUrls,
-      requests,
-      impl: async (url, init) => {
-        urls.push(url);
-        requests.push({ url, init });
-        if (url.includes('/copy/')) return { ok: true, status: 200, json: async () => ({ result: 1 }) };
-        if (url.includes('/expire/')) return { ok: true, status: 200, json: async () => ({ result: 1 }) };
-        if (url.includes('/del/')) return { ok: true, status: 200, json: async () => ({ result: 1 }) };
-        lrangeUrls.push(url);
-        const [, start, stop] = url.match(/\/lrange\/[^/]+\/(-?\d+)\/(-?\d+)$/).map(Number);
-        const from = start;
-        const to = Math.min(stop, total - 1);
-        const result = [];
-        for (let i = from; i <= to; i++) result.push(JSON.stringify({ storyHash: `h-${i}` }));
-        return { ok: true, status: 200, json: async () => ({ result }) };
-      },
-    };
-  }
 
   it('never issues an unbounded 0/-1 range', async () => {
     const up = mockUpstash(2_500);
@@ -545,12 +555,12 @@ describe('readReplayListPaged', () => {
     let live = [...original];
     let snapshot = null;
     const impl = async (url) => {
-      if (url.includes('/copy/')) {
+      if (url.endsWith('/pipeline')) {
         snapshot = [...live];
         live = [...live.slice(2), JSON.stringify({ storyHash: 'h-new-0' }), JSON.stringify({ storyHash: 'h-new-1' })];
-        return { ok: true, status: 200, json: async () => ({ result: 1 }) };
+        return { ok: true, status: 200, json: async () => ([{ result: 1 }, { result: 1 }]) };
       }
-      if (url.includes('/expire/') || url.includes('/del/')) {
+      if (url.includes('/del/')) {
         return { ok: true, status: 200, json: async () => ({ result: 1 }) };
       }
       const parts = url.split('/');
@@ -575,13 +585,21 @@ describe('readReplayListPaged', () => {
   // The load-bearing one: an HTTP 200 carrying a per-command error must
   // NOT be read as "this day had no records".
   it('throws on an HTTP-200 per-command Upstash error instead of returning []', async () => {
-    const impl = async () => ({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        error: 'ERR max request size exceeded. Limit: 52428800 bytes, Actual: 144028523 bytes',
-      }),
-    });
+    const impl = async (url) => {
+      // The snapshot succeeds; the rejection lands on the page read, which is
+      // where an oversized result actually surfaces.
+      if (url.endsWith('/pipeline')) {
+        return { ok: true, status: 200, json: async () => ([{ result: 1 }, { result: 1 }]) };
+      }
+      if (url.includes('/del/')) return { ok: true, status: 200, json: async () => ({ result: 1 }) };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          error: 'ERR max request size exceeded. Limit: 52428800 bytes, Actual: 144028523 bytes',
+        }),
+      };
+    };
     await assert.rejects(
       () => readReplayListPaged('https://u', 't', 'k', { fetchImpl: impl }),
       /max request size exceeded/,
@@ -595,6 +613,95 @@ describe('readReplayListPaged', () => {
       () => readReplayListPaged('https://u', 't', 'k', { fetchImpl: impl }),
       /HTTP 500/,
     );
+  });
+});
+
+// F1/F2/F3 — the snapshot's lifecycle is the entire safety story for reading a
+// COPY instead of the live key, and none of it was asserted: deleting the
+// `finally` cleanup, or the EXPIRE, left the whole suite green. A leaked
+// snapshot is up to ~31MB at the current cap (~154MB for keys written under
+// the old one), and without a TTL it never expires.
+describe('readReplayListPaged — snapshot lifecycle', () => {
+  it('creates the snapshot and its TTL in ONE pipeline, with REPLACE', async () => {
+    const up = mockUpstash(1);
+    await readReplayListPaged('https://u', 't', 'k', {
+      fetchImpl: up.impl, pageSize: 1_000, snapshotKey: 'snap-1',
+    });
+    assert.equal(up.pipelines.length, 1, 'snapshot must cost exactly one request');
+    const [copyCmd, expireCmd] = up.pipelines[0];
+    // Two round trips would leave a window where the snapshot exists with no
+    // TTL; a SIGKILL there orphans it permanently, since `finally` never runs.
+    assert.deepEqual(copyCmd, ['COPY', 'k', 'snap-1', 'REPLACE']);
+    assert.deepEqual(expireCmd, ['EXPIRE', 'snap-1', String(SNAPSHOT_TTL_SECONDS)]);
+    assert.ok(SNAPSHOT_TTL_SECONDS > 0, 'a zero/absent TTL is the leak this guards');
+  });
+
+  it('deletes the snapshot after a successful read', async () => {
+    const up = mockUpstash(2_500);
+    await readReplayListPaged('https://u', 't', 'k', {
+      fetchImpl: up.impl, pageSize: 1_000, snapshotKey: 'snap-2',
+    });
+    assert.deepEqual(up.dels, ['snap-2'], 'snapshot must be reaped, not left to the TTL');
+  });
+
+  it('deletes the snapshot even when paging throws mid-read', async () => {
+    const dels = [];
+    let pages = 0;
+    const impl = async (url) => {
+      if (url.endsWith('/pipeline')) {
+        return { ok: true, status: 200, json: async () => ([{ result: 1 }, { result: 1 }]) };
+      }
+      if (url.includes('/del/')) {
+        dels.push(decodeURIComponent(url.split('/del/')[1]));
+        return { ok: true, status: 200, json: async () => ({ result: 1 }) };
+      }
+      pages += 1;
+      if (pages === 2) return { ok: false, status: 500, json: async () => ({}) };
+      return { ok: true, status: 200, json: async () => ({ result: Array(1_000).fill('{}') }) };
+    };
+    await assert.rejects(
+      () => readReplayListPaged('https://u', 't', 'k', {
+        fetchImpl: impl, pageSize: 1_000, snapshotKey: 'snap-3',
+      }),
+      /HTTP 500/,
+    );
+    assert.deepEqual(dels, ['snap-3'], 'a mid-read failure must still reap the snapshot');
+  });
+
+  it('treats COPY result 0 as a genuinely empty day and creates no cleanup debt', async () => {
+    const dels = [];
+    const impl = async (url) => {
+      if (url.endsWith('/pipeline')) {
+        // With REPLACE, 0 can only mean the source key is gone.
+        return { ok: true, status: 200, json: async () => ([{ result: 0 }, { result: 0 }]) };
+      }
+      if (url.includes('/del/')) { dels.push(url); return { ok: true, status: 200, json: async () => ({ result: 1 }) }; }
+      throw new Error('must not page a snapshot that was never created: ' + url);
+    };
+    const out = await readReplayListPaged('https://u', 't', 'k', {
+      fetchImpl: impl, snapshotKey: 'snap-4',
+    });
+    assert.deepEqual(out, []);
+    assert.deepEqual(dels, [], 'nothing was created, so nothing is deleted');
+  });
+
+  it('throws (and reaps) when the copy lands but its TTL does not', async () => {
+    const dels = [];
+    const impl = async (url) => {
+      if (url.endsWith('/pipeline')) {
+        return { ok: true, status: 200, json: async () => ([{ result: 1 }, { result: 0 }]) };
+      }
+      if (url.includes('/del/')) {
+        dels.push(decodeURIComponent(url.split('/del/')[1]));
+        return { ok: true, status: 200, json: async () => ({ result: 1 }) };
+      }
+      throw new Error('must not page a snapshot with no TTL: ' + url);
+    };
+    await assert.rejects(
+      () => readReplayListPaged('https://u', 't', 'k', { fetchImpl: impl, snapshotKey: 'snap-5' }),
+      /EXPIRE snap-5 rejected/,
+    );
+    assert.deepEqual(dels, ['snap-5'], 'an untethered snapshot must be deleted, not paged');
   });
 });
 
@@ -622,21 +729,21 @@ describe('fetchRecords mixed-success path', () => {
     const goodKey = 'digest:replay-log:v1:full:en:high:2026-08-02';
     const goodRecord = { storyHash: 'good', ruleId: 'full:en:high', tsMs: Date.UTC(2026, 7, 2, 12) };
     const warnings = [];
-    const impl = async (url) => {
+    const impl = async (url, init) => {
       if (url.includes('/scan/')) {
         return { ok: true, status: 200, json: async () => ({ result: ['0', [failedKey, goodKey]] }) };
       }
-      if (url.includes('/copy/')) {
-        if (decodeURIComponent(url).includes(failedKey)) {
+      if (url.endsWith('/pipeline')) {
+        if (JSON.parse(init.body)[0][1] === failedKey) {
           return {
             ok: true,
             status: 200,
-            json: async () => ({ error: 'ERR max request size exceeded' }),
+            json: async () => ([{ error: 'ERR max request size exceeded' }, { result: 0 }]),
           };
         }
-        return { ok: true, status: 200, json: async () => ({ result: 1 }) };
+        return { ok: true, status: 200, json: async () => ([{ result: 1 }, { result: 1 }]) };
       }
-      if (url.includes('/expire/') || url.includes('/del/')) {
+      if (url.includes('/del/')) {
         return { ok: true, status: 200, json: async () => ({ result: 1 }) };
       }
       if (url.includes('/lrange/')) {


### PR DESCRIPTION
Follow-up to #6033, which merged while this was being prepared — so this targets `main` directly.

The COPY-snapshot read is the right design. It makes the page window immune to concurrent `RPUSH`/`LTRIM`, and because COPY is server-side the snapshot never crosses the wire — so it *sidesteps* the 50 MiB per-command limit rather than merely staying under it. That's better than the paging I originally wrote.

But the snapshot's lifecycle — the entire safety story for that design — was neither closed nor covered.

## F1 · The lifecycle was untested

Proven by mutation against #6033's head, not asserted:

| Mutant | Result |
|---|---|
| Delete the whole `finally` cleanup block | **43/43 pass** |
| Delete the `EXPIRE` call — snapshot never gets a TTL | **43/43 pass** |

Either regression ships a leak in total silence. The mocks *handled* `/del/` and `/expire/` but nothing asserted they were called. (The "TTL drift" test in #6033 covers the replay-log *retention* TTL — a different constant.)

Adds a snapshot-lifecycle suite: deleted after a successful read, deleted when paging throws mid-read, not created *and not deleted* on an empty day, and deleted rather than paged when its TTL fails to land.

## F2 · A permanent orphan between COPY and EXPIRE

They were two round trips:

```js
copyRes   = await fetch(copy...)    // snapshot exists, NO TTL
snapshotCreated = true;
expireRes = await fetch(expire...)  // TTL applied here
```

Process death in that window leaves the snapshot alive with no TTL, and `finally` does not run on SIGKILL — so it never self-heals. That orphan is up to ~31 MB at the current cap, ~154 MB for keys written under the old one.

Now one pipeline, so the server applies the TTL in the same execution as the copy.

## F3 · `COPY` result `0` meant two different things

Bare `COPY` answers `0` for **both** "source missing" and "destination exists", and the code mapped `0` to an empty list: precisely the miss-vs-failure collapse this harness exists to eliminate. Unreachable in production thanks to the UUID key, but reachable through the `snapshotKey` test seam.

`REPLACE` makes `0` mean only "source is gone" — a genuine empty day.

## Verified against production Upstash, not assumed

```
COPY new dst / existing dst / missing src     -> 1 / 0 / 0
["COPY",src,dst,"REPLACE"] + ["EXPIRE",...]   -> [{result:1},{result:1}], TTL set,
                                                 stale dst overwritten
missing source, same pipeline                 -> [{result:0},{result:0}], no key created
GET /del/<key with colons + uuid>             -> 1, key gone
```

## Testing

`SNAPSHOT_TTL_SECONDS` is now exported so the test asserts the real value instead of re-hardcoding it. All four new guards mutation-tested:

| Mutant | Now caught |
|---|---|
| Cleanup removed | 3 tests fail |
| `REPLACE` dropped | 1 fails |
| `EXPIRE` taken out of the pipeline | 1 fails |
| `SNAPSHOT_TTL_SECONDS` drifts to `0` | 1 fails |

```
79/79 pass  ·  biome clean
```

https://claude.ai/code/session_01EgL4oqsVDicvNxPCaWHm4A
