### PR TITLE
fix(correlation): unwrap seed envelopes in the correlation seeder's input reads

### DIFF
--- a/scripts/seed-correlation.mjs
+++ b/scripts/seed-correlation.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, runSeed, getRedisCredentials, loadSharedConfig } from './_seed-utils.mjs';
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { resolveIso2, normalizeCountryToken } from './_country-resolver.mjs';
 import {
   CORRELATION_RUNTIME_MODE_KEY,
@@ -14,7 +15,7 @@ const CACHE_TTL = 1200; // 20min — outlives maxStaleMin:15 with buffer (cron r
 const MIN_CORRELATION_CARDS = 1;
 const CORRELATION_CARD_DOMAINS = ['military', 'escalation', 'economic', 'disaster'];
 
-const INPUT_KEYS = [
+export const INPUT_KEYS = [
   'military:flights:v1',
   'military:flights:stale:v1',
   'unrest:events:v1',
@@ -26,7 +27,28 @@ const INPUT_KEYS = [
   'news:insights:v1',
 ];
 
-async function fetchInputData() {
+// Reject preserved contract envelopes past the age each source seeder itself
+// declares. runSeed extends a last-good key on an upstream failure without
+// advancing `_seed.fetchedAt` (scripts/_seed-utils.mjs), so unwrapping without
+// this gate would revive stale observations and stamp them into cards dated
+// `computedAt: Date.now()`. Every value here is that source's own
+// `maxStaleMin`, not a number chosen at this call site; the five keys shared
+// with seed-cross-source-signals.mjs carry the same budgets it uses.
+//
+// The two `military:flights` keys are absent on purpose: seed-military-flights.mjs
+// never migrated to runSeed and writes them bare, so they carry no `_seed` for
+// this gate to read.
+const SOURCE_MAX_AGE_MIN = Object.freeze({
+  'unrest:events:v1': 120,                // scripts/seed-unrest-events.mjs
+  'infra:outages:v1': 30,                 // scripts/seed-internet-outages.mjs
+  'seismology:earthquakes:v1': 30,        // scripts/seed-earthquakes.mjs
+  'market:stocks-bootstrap:v1': 30,       // scripts/seed-market-quotes.mjs
+  'market:commodities-bootstrap:v1': 30,  // scripts/seed-commodity-quotes.mjs
+  'market:crypto:v1': 30,                 // scripts/seed-crypto-quotes.mjs
+  'news:insights:v1': 30,                 // scripts/seed-insights.mjs
+});
+
+export async function fetchInputData() {
   const { url, token } = getRedisCredentials();
   const pipeline = INPUT_KEYS.map(k => ['GET', k]);
   const resp = await fetch(`${url}/pipeline`, {
@@ -40,9 +62,31 @@ async function fetchInputData() {
   const data = {};
   for (let i = 0; i < INPUT_KEYS.length; i++) {
     const raw = results[i]?.result;
-    if (raw) {
-      try { data[INPUT_KEYS[i]] = JSON.parse(raw); } catch { /* skip */ }
-    }
+    if (!raw) continue;
+    const key = INPUT_KEYS[i];
+    try {
+      // Seven of these nine keys are written by contract-mode seeders, which
+      // store `{ _seed, data }` (scripts/_seed-utils.mjs). Parsing without
+      // unwrapping handed computeCorrelation the envelope, so every
+      // `payload.<field>` read below was undefined and three of the four
+      // domains silently produced no signals at all — #5870 is the same defect
+      // one seeder over. unwrapEnvelope only unwraps when `_seed.fetchedAt` is
+      // a number, so the bare `military:flights` keys pass through unchanged.
+      //
+      // JSON.parse stays outside unwrapEnvelope on purpose: it accepts a raw
+      // string, but on a parse failure it returns that string as `data`, which
+      // would register a malformed value as a found key and defeat the
+      // "no input data" tripwire in computeCorrelation.
+      const { _seed, data: payload } = unwrapEnvelope(JSON.parse(raw));
+      if (payload == null) continue;
+      const maxAgeMin = SOURCE_MAX_AGE_MIN[key];
+      if (
+        _seed &&
+        maxAgeMin != null &&
+        Date.now() - _seed.fetchedAt > maxAgeMin * 60_000
+      ) continue;
+      data[key] = payload;
+    } catch { /* skip malformed */ }
   }
   return data;
 }

--- a/tests/correlation-envelope-reads.test.mjs
+++ b/tests/correlation-envelope-reads.test.mjs
@@ -1,0 +1,275 @@
+// Regression test for the correlation seeder's input reads.
+//
+// scripts/seed-correlation.mjs read all nine of its INPUT_KEYS with a bare
+// JSON.parse and no envelope unwrap. Seven of those keys are written by
+// contract-mode seeders, which store `{ _seed, data }` (scripts/_seed-utils.mjs),
+// so computeCorrelation's `data['<key>']?.<field>` reads were reading the
+// envelope: every one of them resolved to undefined and fell through to `[]`.
+//
+// Only the `military:flights` pair survived, because seed-military-flights.mjs
+// never migrated to runSeed and still writes bare. That left three of the four
+// correlation domains — escalation, economic, disaster — computing over empty
+// inputs while the seeder exited 0.
+//
+// It was silent by construction: the `hasAnyData` tripwire in computeCorrelation
+// tests `data[k] != null`, and an envelope object is not null, so it never fired.
+//
+// Same defect and same fix as #5870 / #5896 one seeder over, and the same shape
+// tests/regional-snapshot-envelope-unwrap.test.mjs pins a layer down.
+//
+// Every enveloped fixture below also asserts that the pre-fix shape — the raw
+// envelope handed straight to the field read — produces nothing, so the bug
+// stays pinned and cannot be reintroduced silently.
+
+import { after, before, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { INPUT_KEYS, fetchInputData } from '../scripts/seed-correlation.mjs';
+import { unwrapEnvelope } from '../scripts/_seed-envelope-source.mjs';
+
+const REDIS_URL = 'https://correlation-seeder.test.upstash.io';
+const MINUTE = 60_000;
+const now = Date.now();
+
+function seedEnvelope(data, fetchedAt = now) {
+  return {
+    _seed: {
+      fetchedAt,
+      sourceVersion: 'test-v1',
+      schemaVersion: 1,
+      recordCount: 1,
+    },
+    data,
+  };
+}
+
+// Drive a stored value through exactly what fetchInputData does to a Redis
+// string, so a fixture can never exercise a shape the reader cannot produce.
+function asReadByTheSeeder(storedValue) {
+  return unwrapEnvelope(JSON.parse(JSON.stringify(storedValue))).data;
+}
+
+// The seven contract-mode keys, each with the field computeCorrelation reads
+// off it and the writer that publishes it.
+const ENVELOPED_KEYS = [
+  {
+    key: 'unrest:events:v1',
+    field: 'events',
+    writer: 'scripts/seed-unrest-events.mjs',
+    payload: { events: [{ id: 'p1', country: 'FR', size: 5_000 }] },
+  },
+  {
+    key: 'infra:outages:v1',
+    field: 'outages',
+    writer: 'scripts/seed-internet-outages.mjs',
+    payload: { outages: [{ id: 'o1', country: 'IR', severity: 'major' }] },
+  },
+  {
+    key: 'seismology:earthquakes:v1',
+    field: 'earthquakes',
+    writer: 'scripts/seed-earthquakes.mjs',
+    payload: { earthquakes: [{ id: 'us1', magnitude: 7.1, lat: 38.1, lon: 44.2 }] },
+  },
+  {
+    key: 'market:stocks-bootstrap:v1',
+    field: 'quotes',
+    writer: 'scripts/seed-market-quotes.mjs',
+    payload: { quotes: [{ symbol: '^VIX', changePercent: 12.4 }] },
+  },
+  {
+    key: 'market:commodities-bootstrap:v1',
+    field: 'quotes',
+    writer: 'scripts/seed-commodity-quotes.mjs',
+    payload: { quotes: [{ symbol: 'CL=F', changePercent: -4.2 }] },
+  },
+  {
+    key: 'market:crypto:v1',
+    field: 'quotes',
+    writer: 'scripts/seed-crypto-quotes.mjs',
+    payload: { quotes: [{ symbol: 'BTC-USD', changePercent: 6.8 }] },
+  },
+  {
+    key: 'news:insights:v1',
+    field: 'topStories',
+    writer: 'scripts/seed-insights.mjs',
+    payload: {
+      topStories: [{ primaryTitle: 'Strait closure reported', threatLevel: 'high', lat: 26.5, lon: 56.2 }],
+      generatedAt: new Date(now).toISOString(),
+    },
+  },
+];
+
+describe('fetchInputData envelope handling', () => {
+  const originalFetch = globalThis.fetch;
+  const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+  const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  before(() => {
+    process.env.UPSTASH_REDIS_REST_URL = REDIS_URL;
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+    else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+    if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+  });
+
+  // Stub the Upstash pipeline: `byKey` maps an input key to the raw string
+  // Redis would return; anything unlisted comes back as a null result.
+  function stubPipeline(byKey) {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => INPUT_KEYS.map((key) => ({ result: byKey[key] ?? null })),
+    });
+  }
+
+  it('pins the exact key set the correlation domains are built from', () => {
+    assert.deepEqual(INPUT_KEYS, [
+      'military:flights:v1',
+      'military:flights:stale:v1',
+      'unrest:events:v1',
+      'infra:outages:v1',
+      'seismology:earthquakes:v1',
+      'market:stocks-bootstrap:v1',
+      'market:commodities-bootstrap:v1',
+      'market:crypto:v1',
+      'news:insights:v1',
+    ]);
+  });
+
+  for (const { key, field, writer, payload } of ENVELOPED_KEYS) {
+    it(`unwraps ${key} down to the payload computeCorrelation reads (${writer})`, async () => {
+      const stored = JSON.stringify(seedEnvelope(payload));
+      stubPipeline({ [key]: stored });
+
+      // Pre-fix: the bare parse stored the envelope, so the field read below —
+      // the one computeCorrelation performs — resolved to undefined and the
+      // domain fell through to an empty array.
+      assert.equal(JSON.parse(stored)[field], undefined, 'the envelope must not expose the payload field');
+
+      const data = await fetchInputData();
+      assert.deepEqual(data[key], payload);
+      assert.ok(Array.isArray(data[key][field]) && data[key][field].length > 0, `${field} must survive the read`);
+      assert.deepEqual(data[key], asReadByTheSeeder(seedEnvelope(payload)));
+    });
+  }
+
+  it('passes the bare military flights keys through unchanged', async () => {
+    // seed-military-flights.mjs writes these with a local redisSet(), not
+    // runSeed, so they carry no `_seed` and must not be touched.
+    const payload = { flights: [{ hex: 'ae1234', type: 'bomber', lat: 35.1, lon: 33.4 }] };
+    stubPipeline({
+      'military:flights:v1': JSON.stringify(payload),
+      'military:flights:stale:v1': JSON.stringify(payload),
+    });
+
+    const data = await fetchInputData();
+    assert.deepEqual(data['military:flights:v1'], payload);
+    assert.deepEqual(data['military:flights:stale:v1'], payload);
+  });
+
+  it('passes a legacy top-level array through unchanged', async () => {
+    // computeCorrelation still has an `Array.isArray(protestData)` fallback for
+    // the pre-envelope shape; unwrapping must not break it.
+    const payload = [{ id: 'p1', country: 'FR' }];
+    stubPipeline({ 'unrest:events:v1': JSON.stringify(payload) });
+
+    const data = await fetchInputData();
+    assert.deepEqual(data['unrest:events:v1'], payload);
+  });
+
+  it('skips malformed JSON instead of registering the raw string as a found key', async () => {
+    // The `hasAnyData` tripwire in computeCorrelation tests `data[k] != null`,
+    // so a raw string registered here would read as real input.
+    stubPipeline({ 'unrest:events:v1': '{"events":[' });
+
+    const data = await fetchInputData();
+    assert.equal('unrest:events:v1' in data, false);
+  });
+
+  it('skips an envelope whose payload is null', async () => {
+    stubPipeline({ 'infra:outages:v1': JSON.stringify(seedEnvelope(null)) });
+
+    const data = await fetchInputData();
+    assert.equal('infra:outages:v1' in data, false);
+  });
+});
+
+describe('fetchInputData freshness gate', () => {
+  const originalFetch = globalThis.fetch;
+  const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+  const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  before(() => {
+    process.env.UPSTASH_REDIS_REST_URL = REDIS_URL;
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  });
+
+  after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+    else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+    if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+  });
+
+  function stubPipeline(byKey) {
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => INPUT_KEYS.map((key) => ({ result: byKey[key] ?? null })),
+    });
+  }
+
+  it('drops a preserved envelope past its source freshness budget', async () => {
+    // runSeed extends a last-good key without advancing _seed.fetchedAt, so
+    // without this gate unwrapping revives stale observations into cards
+    // stamped `computedAt: Date.now()`.
+    stubPipeline({
+      'seismology:earthquakes:v1': JSON.stringify(
+        seedEnvelope({ earthquakes: [{ id: 'stale', magnitude: 7.1 }] }, now - 31 * MINUTE),
+      ),
+    });
+
+    const data = await fetchInputData();
+    assert.equal('seismology:earthquakes:v1' in data, false);
+  });
+
+  it('keeps an envelope inside its budget', async () => {
+    const payload = { earthquakes: [{ id: 'fresh', magnitude: 7.1 }] };
+    stubPipeline({
+      'seismology:earthquakes:v1': JSON.stringify(seedEnvelope(payload, now - 29 * MINUTE)),
+    });
+
+    const data = await fetchInputData();
+    assert.deepEqual(data['seismology:earthquakes:v1'], payload);
+  });
+
+  it('gives unrest the longer budget its own seeder declares', async () => {
+    // seed-unrest-events.mjs runs with maxStaleMin: 120, so a 31-minute-old
+    // envelope that would drop earthquakes must survive here.
+    const payload = { events: [{ id: 'p1', country: 'FR' }] };
+    stubPipeline({
+      'unrest:events:v1': JSON.stringify(seedEnvelope(payload, now - 31 * MINUTE)),
+    });
+
+    const data = await fetchInputData();
+    assert.deepEqual(data['unrest:events:v1'], payload);
+
+    stubPipeline({
+      'unrest:events:v1': JSON.stringify(seedEnvelope(payload, now - 121 * MINUTE)),
+    });
+    assert.equal('unrest:events:v1' in (await fetchInputData()), false);
+  });
+
+  it('never age-gates the bare flights keys', async () => {
+    // No `_seed` means no fetchedAt to judge, and these keys are the only ones
+    // still keeping the military domain alive today.
+    const payload = { flights: [{ hex: 'ae1234', type: 'bomber' }], fetchedAt: now - 48 * 60 * MINUTE };
+    stubPipeline({ 'military:flights:v1': JSON.stringify(payload) });
+
+    const data = await fetchInputData();
+    assert.deepEqual(data['military:flights:v1'], payload);
+  });
+});


### PR DESCRIPTION
## Summary

Follows #5896, whose "Out of scope" section named this file: `scripts/seed-correlation.mjs` reads its inputs with the same envelope-blind `JSON.parse` that #5870 was filed for, sits in the same Railway bundle, and registers the same `military:flights:{v1,stale:v1}` pair. There is no issue open for it.

`scripts/seed-correlation.mjs:41-46`:

```js
for (let i = 0; i < INPUT_KEYS.length; i++) {
  const raw = results[i]?.result;
  if (raw) {
    try { data[INPUT_KEYS[i]] = JSON.parse(raw); } catch { /* skip */ }
  }
}
```

**Seven of the nine `INPUT_KEYS` are written by contract-mode seeders**, which store `{ _seed, data }` (`scripts/_seed-utils.mjs`). So every field read in `computeCorrelation` (`:702-728`) was reading the envelope:

```js
const protests   = protestData?.events      ?? (Array.isArray(protestData) ? protestData : []);
const outages    = outageData?.outages      ?? (Array.isArray(outageData)  ? outageData  : []);
const earthquakes= quakeData?.earthquakes   ?? (Array.isArray(quakeData)   ? quakeData   : []);
const stockQuotes     = data['market:stocks-bootstrap:v1']?.quotes ?? [];
const commodityQuotes = data['market:commodities-bootstrap:v1']?.quotes ?? [];
const cryptoQuotes    = data['market:crypto:v1']?.quotes ?? [];
const newsClusters    = (insights?.topStories ?? []).map(...);
```

`{_seed, data}.events` is `undefined`, `Array.isArray(envelope)` is `false`, so each one fell through to `[]`.

| Key | Writer | Written as | Effect here |
|---|---|---|---|
| `military:flights:v1` | `seed-military-flights.mjs` (local `redisSet`, no `runSeed`) | bare | works |
| `military:flights:stale:v1` | `seed-military-flights.mjs` | bare | works |
| `unrest:events:v1` | `seed-unrest-events.mjs` | envelope | `protests = []` |
| `infra:outages:v1` | `seed-internet-outages.mjs` | envelope | `outages = []` |
| `seismology:earthquakes:v1` | `seed-earthquakes.mjs` | envelope | `earthquakes = []` |
| `market:stocks-bootstrap:v1` | `seed-market-quotes.mjs` | envelope | `stockQuotes = []` |
| `market:commodities-bootstrap:v1` | `seed-commodity-quotes.mjs` | envelope | `commodityQuotes = []` |
| `market:crypto:v1` | `seed-crypto-quotes.mjs` | envelope | `cryptoQuotes = []` |
| `news:insights:v1` | `seed-insights.mjs` | envelope | `newsClusters = []` |

Mapped onto the four domains (`:761-783`):

- **military** — the only surviving domain, and only because the flights pair is the one writer that never migrated to `runSeed`.
- **escalation** — `collectEscalationSignals(protests, outages, newsClusters)`, all three empty.
- **economic** — `collectEconomicSignals(allMarkets, newsClusters)`, all four empty.
- **disaster** — `collectDisasterSignals(earthquakes, outages, protests)`, all three empty.

**Why nobody saw it.** The `hasAnyData` tripwire at `:699-700` tests `data[k] != null`, and an envelope object is not null, so "No input data available in Redis" never threw. `validateFn` then failed the `MIN_CORRELATION_CARDS` floor whenever military also produced nothing, and `runSeed` resolved `contractState = 'RETRY'` (`scripts/_seed-utils.mjs:2038-2040`), which holds the previous cards alive without advancing `_seed.fetchedAt`. Exit 0, no alarm, stale cards — the same silent-degradation signature as #5870.

The irony at `:704`: the `?? data['military:flights:v1']` fallback exists to tolerate a raw-array shape. It would not have rescued an enveloped flights key either.

### The fix

The pattern #5896 established, unchanged:

- `unwrapEnvelope` from `scripts/_seed-envelope-source.mjs`. It only unwraps when `_seed.fetchedAt` is a number, so the bare flights keys pass through byte-identical, as does the legacy top-level-array shape the `Array.isArray` fallbacks still handle.
- **`JSON.parse` stays outside `unwrapEnvelope`.** It accepts a raw string, but on a parse failure returns that string as `data` — which would register a malformed value as a found key and defeat the `hasAnyData` tripwire. Same reasoning as the comment at `seed-cross-source-signals.mjs:225-235`.
- **The per-key freshness gate**, because unwrapping without one revives preserved last-good envelopes into cards stamped `computedAt: Date.now()`. Every budget is the source seeder's own declared `maxStaleMin` rather than a number chosen at this call site — and the five keys shared with `seed-cross-source-signals.mjs` come out at exactly the budgets its own table already uses, which is a useful cross-check. The two `military:flights` keys are absent from the table on purpose: written bare, they carry no `_seed` for the gate to read.

**No deploy manifest change.** `scripts/_seed-envelope-source.mjs` is already listed in `seed-bundle-derived-signals`'s `watchPatterns` in `scripts/railway-services.json`, next to `scripts/seed-correlation.mjs` itself, and is pulled in transitively by `scripts/_seed-utils.mjs:11` which this seeder already imports.

### Audit of the remaining `scripts/` readers

Since the same defect had already appeared twice, I swept every `scripts/` file that issues a Redis `GET` and parses the result, and checked each against its writer rather than trusting the key name:

| Reader | Reads | Verdict |
|---|---|---|
| `seed-correlation.mjs` | 7 cross-seeder contract-mode keys | **the defect, fixed here** |
| `seed-hs2-chokepoint-exposure.mjs:210` | `comtrade:*:v1` from `seed-comtrade-bilateral-hs4.mjs` | clean — that writer uses a plain `SET` (`:558`), not `runSeed`, so the keys are bare |
| `seed-forecast-bets.mjs:285` | `forecast:resolutions:v1`, contract-mode | clean, but only just — `collectOpenEnsembleIds` unwraps ad hoc with `Object.values(ledger.data ?? ledger)` (`:230-232`), and the feed reads handle `_seed` explicitly in `filterFreshFeeds`/`unwrapFeeds` (`:97-116`) |
| `seed-portwatch-port-activity.mjs:913` | its own previous-version keys | clean, self-written |
| `seed-wb-indicators.mjs:468-470` | keys it wrote earlier in the same run | clean, self-written, bare |
| `seed-military-bases.mjs`, `seed-webcams.mjs`, `seed-resilience-static.mjs`, `seed-comtrade-bilateral-hs4.mjs`, `lib/brief-embedding.mjs` | own state / meta / cache keys | clean, self-written |
| `seed-cross-source-signals.mjs`, `seed-regional-snapshots.mjs`, `regional-snapshot/_helpers.mjs` | cross-seeder keys | already envelope-aware |

So `seed-correlation.mjs` was the last envelope-blind cross-seeder reader in `scripts/`. `seed-forecast-bets.mjs` is worth a second look at some point — it is correct today, but its correctness lives in three separate consumers rather than at the read — and I have deliberately not touched it here.

## Design decisions for maintainer review

- **The freshness gate is included rather than deferred.** Without it this fix would, on its first bad upstream day, turn a silent-empty domain into a confidently-wrong one. The budgets are derived, but if you would rather land the unwrap alone and gate separately, the two are cleanly separable.
- **`fetchInputData` and `INPUT_KEYS` are now exported** so the test can drive the real reader instead of a copy. `computeCorrelation` is left unexported — the field reads are pinned through `fetchInputData`'s output, which is the seam the defect actually lives at.
- **The `hasAnyData` tripwire is left as-is.** With the unwrap in place it means what it says again. Making it stricter (say, requiring a minimum number of found keys) would be a behaviour change with its own alerting implications rather than a repair.
- **The legacy `Array.isArray` fallbacks in `computeCorrelation` are left in place.** They are dead for the keys that migrated, but they are what makes the read tolerant if any of these writers is ever rolled back, and removing them is not this PR's job. There is a test pinning that path.

## Verification

```
tests/correlation-envelope-reads.test.mjs        16 pass, 0 fail   (new)
+ seeder-validation-floors, correlation-runtime-mode,
  cross-source-signals-envelope-reads,
  regional-snapshot-envelope-unwrap, seed-envelope-parity
                                                105 pass, 0 fail
```

Every guard is mutation-proven:

| Mutant | Red |
|---|---|
| envelope unwrap removed (the pre-fix bare parse) | 11 |
| null-payload guard removed | 1 |
| freshness gate removed | 2 |
| `JSON.parse` folded inside `unwrapEnvelope` | 1 |
| unrest budget collapsed to the 30-minute default | 1 |
| earthquake budget widened to a day | 1 |

No survivors.

Each of the seven enveloped fixtures asserts **both** directions: that the payload field survives the read, and that the pre-fix shape does not expose that field at all — so the bug stays pinned rather than merely fixed. Fixtures are driven through an `asReadByTheSeeder()` helper built on the real `unwrapEnvelope`, so a test cannot assert against a shape the reader could not produce. `INPUT_KEYS` itself is pinned, so adding a tenth key forces a decision about its freshness budget.

The existing `tests/seeder-validation-floors.test.mjs` and `tests/correlation-runtime-mode.test.mts` never touched the read path — the first covers only `declareRecords`/`validateFn`, the second greps the source text — which is why this was invisible.

Other gates:

```
npm run typecheck        clean
npx biome check          clean (2 files)
npm run lint:boundaries  no violations
check-unicode-safety     2652 files scanned, clean
```

`npm run test:data`: **identical failure set to `origin/main`** — 47 failing test names on both, `comm` diff empty in both directions.

`scripts/audit-railway-watch-paths.mjs` needs the `railway` CLI, which I do not have locally, so I verified the bundle claim structurally instead: `scripts/_seed-envelope-source.mjs` is present in the `seed-bundle-derived-signals` `watchPatterns` array in `scripts/railway-services.json`.

## Out of scope

- **The correlation epic (#5981) and specifically #5986**, which plans to replace this seeder's hand-copied clustering with the shared contract. That work is downstream of these reads and inherits whatever they produce; today it would inherit three empty domains. This PR does not touch clustering, scoring, thresholds or runtime modes.
- **`seed-forecast-bets.mjs`'s scattered unwrapping**, described in the audit above. Correct today, structurally fragile, and its own change.
- **`seed-military-flights.mjs` not using `runSeed`.** It is the reason the military domain still works, so migrating it is a change that should be made deliberately and with this reader already envelope-aware — which it now is.
- No change to `unwrapEnvelope`, to any writer, or to the published card shape.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [x] AI Insights / World Brief — the correlation cards behind the Military/Escalation/Economic/Disaster panels
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: `scripts/seed-correlation.mjs` (Railway derived-signals bundle)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — N/A. The change is inside a Railway seeder's Redis read path; exercising it in production needs Upstash and Railway credentials I do not have. Verified through the real reader with a stubbed Upstash pipeline, and with mutation proof that each guard has teeth. The observable effect to look for after deploy is the existing `[Correlation] inputs:` line at `:735` reporting non-zero `protests`/`outages`/`markets`/`news`, and non-zero `signals` on the escalation, economic and disaster lines.
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A, no variant-specific behaviour.
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A, no feeds added.
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A — no documentation claim is published or changed. The fix restores reads that were already specified; no methodology, API/MCP contract, generated doc or example changes. Listed for completeness:

- [ ] Claim ledger attached or linked — N/A, no documented claim changes.
- [ ] All required Audit Council role signoffs attached — N/A, no methodology or contract change.
- [ ] Generated docs regenerated from proto where applicable — N/A, no proto change.
- [ ] Fixture-backed examples recomputed — N/A, no published example depends on this seeder.
- [x] Redis writers/readers enumerated for every documented key — the per-key writer table above covers all nine inputs. No key is added, removed, or written differently; the five outputs (`correlation:cards-bootstrap:v1` plus the four per-domain keys) keep their existing shape and TTL.