### PR TITLE
fix(map): hide sunset iranAttacks toggle from SVG/mobile picker

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -62,6 +62,7 @@ import {
   getLayerExplanation,
   getLayersForVariant,
   hasCuratedLayerExplanation,
+  isSunsetLayer,
   resolveLayerLabel,
   type MapVariant,
 } from '@/config/map-layer-definitions';
@@ -530,11 +531,13 @@ export class MapComponent {
       'weather', 'fires',                     // operational risk
       'economic',                             // infrastructure context
     ];
-    const layers = SITE_VARIANT === 'tech' ? techLayers
+    // Filter sunset layers (e.g. iranAttacks) so the SVG/mobile picker matches
+    // getLayersForVariant / DeckGL — otherwise a dead raw-key toggle wastes a slot (#6046).
+    const layers = (SITE_VARIANT === 'tech' ? techLayers
                  : SITE_VARIANT === 'finance' ? financeLayers
                  : SITE_VARIANT === 'happy' ? happyLayers
                  : SITE_VARIANT === 'energy' ? energyLayers
-                 : fullLayers;
+                 : fullLayers).filter((key) => !isSunsetLayer(key));
     const MAX_SVG_LAYERS = 9;
     const enforceLayerLimit = () => {
       const allBtns = Array.from(toggles.querySelectorAll<HTMLButtonElement>('.layer-toggle'));

--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -344,7 +344,8 @@ const I18N_PREFIX = 'components.deckgl.layers.';
 // see src/services/maritime/index.ts and tests/browser-bundle-secret-guard.
 const IRAN_ATTACKS_ENABLED = typeof window !== 'undefined' && import.meta.env.VITE_ENABLE_IRAN_ATTACKS === 'true';
 
-function isSunsetLayer(key: keyof MapLayers): boolean {
+/** True when a layer is feature-sunset and must not appear in any picker. */
+export function isSunsetLayer(key: keyof MapLayers): boolean {
   return !IRAN_ATTACKS_ENABLED && key === 'iranAttacks';
 }
 

--- a/tests/iran-events-sunset.test.mts
+++ b/tests/iran-events-sunset.test.mts
@@ -17,6 +17,7 @@ import {
   getLayersForVariant,
   getAllowedLayerKeys,
   isLayerExecutable,
+  isSunsetLayer,
   sanitizeLayersForVariant,
 } from '../src/config/map-layer-definitions';
 import { buildForecastInputFetchKeys } from '../scripts/seed-forecasts.mjs';
@@ -42,6 +43,25 @@ describe('iran-events sunset — frontend map layer (default OFF)', () => {
 
   it('is not executable (CMD+K / picker toggles silently skip it)', () => {
     assert.equal(isLayerExecutable('iranAttacks', 'flat', true), false);
+  });
+
+  // #6046 — SVG/mobile Map.ts hardcodes its own layer lists and used to surface
+  // a dead raw-key 'iranAttacks' toggle. Guard both the export and the filter
+  // so the SVG picker cannot drift from getLayersForVariant / DeckGL again.
+  it('exports isSunsetLayer and SVG Map.createLayerToggles filters with it', () => {
+    assert.equal(typeof isSunsetLayer, 'function');
+    assert.equal(isSunsetLayer('iranAttacks'), true);
+    assert.equal(isSunsetLayer('conflicts'), false);
+
+    const mapSrc = read('src/components/Map.ts');
+    assert.match(mapSrc, /isSunsetLayer/, 'Map.ts must import isSunsetLayer');
+    // The static lists still mention the key (for re-enable), but the picker
+    // must filter before building buttons.
+    assert.match(
+      mapSrc,
+      /\.filter\(\s*(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>\s*!isSunsetLayer\(/,
+      'createLayerToggles must filter sunset layers before rendering buttons',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Export `isSunsetLayer` and filter sunset keys out of the SVG/mobile `Map.createLayerToggles` lists so the mobile renderer no longer shows a dead raw-key `iranAttacks` button.
- Free a `MAX_SVG_LAYERS` (9) slot that the sunset layer was wasting on the default mobile renderer.
- Add a sunset-suite regression guard so the SVG picker cannot diverge from `getLayersForVariant` / DeckGL again.

Closes #6046

## Context

`iranAttacks` was feature-sunset in #4982. DeckGL/globe already filter via `getLayersForVariant` / `getAllowedLayerKeys`. The SVG map (default on mobile) hardcodes its own lists and never applied the sunset filter, so users saw a button labelled literally `iranAttacks` that could never load data.

## Test plan

- [x] Red-then-green: new test failed on missing export/filter, then passed after the fix
- [x] `tsx --test tests/iran-events-sunset.test.mts` — 14/14 pass
- [x] Pre-push gates (typecheck, boundaries, premium-fetch, changed tests, edge isolation) green
- [ ] On mobile or SVG fallback: layer picker no longer shows `iranAttacks`
- [ ] With `VITE_ENABLE_IRAN_ATTACKS=true` rebuild, toggle can reappear (re-enable path)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — client-only picker filter; no API, cache, or data-plane change. Validate on a mobile viewport or SVG-fallback session that the layer toggle list no longer includes a raw `iranAttacks` label.

## Review

Code review: no actionable findings. Surgical filter only; did not rewrite the hardcoded SVG lists onto `getLayersForVariant` (adjacent commodity-variant gap noted in the issue remains out of scope).

Made with [Compound Engineering](https://github.com/EveryInc/compound-engineering-plugin)