### PR TITLE
fix(analytics): restore umami session_data writes and gate the image on a runtime write probe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
             /^Dockerfile\.umami-retention$/ { count++ }
             /^docker\/umami\// { count++ }
             /^scripts\/umami-retention\.sql$/ { count++ }
-            /^tests\/umami-(runtime-remediation\.test|postgres-integration)\.mjs$/ { count++ }
+            /^tests\/umami-(runtime-remediation\.test|postgres-integration|runtime-write-probe)\.mjs$/ { count++ }
             /^\.github\/workflows\/test\.yml$/ { count++ }
             END { print count + 0 }
           ')
@@ -271,6 +271,10 @@ jobs:
         env:
           UMAMI_TEST_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/umami_integration
         run: node tests/umami-postgres-integration.mjs
+      - name: Probe the running image's write path (identify, concurrent upsert, event)
+        env:
+          UMAMI_TEST_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/umami_integration
+        run: node tests/umami-runtime-write-probe.mjs
 
   sidecar:
     needs: changes

--- a/Dockerfile.umami
+++ b/Dockerfile.umami
@@ -14,6 +14,7 @@ FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a55
 RUN apk add --no-cache git
 WORKDIR /upstream
 COPY docker/umami/session-data-upsert.patch /tmp/session-data-upsert.patch
+COPY docker/umami/v320-compat.patch /tmp/v320-compat.patch
 COPY docker/umami/runtime/session-data-upsert.sql /tmp/session-data-upsert.sql
 COPY docker/umami/21_update_session_data/migration.sql /tmp/21_update_session_data.sql
 COPY docker/umami/runtime/upstream-23-update-session-data.sql /tmp/upstream-23-update-session-data.sql
@@ -59,6 +60,23 @@ RUN git init \
   && test "$(git rev-parse HEAD)" = "2f6e2b5ff256862a081d9e74bed18a42ebf795e3" \
   && git apply --check /tmp/session-data-upsert.patch \
   && git apply /tmp/session-data-upsert.patch \
+  && git apply --check /tmp/v320-compat.patch \
+  && git apply /tmp/v320-compat.patch \
+  && node --input-type=module -e '\
+    import { readFileSync } from "node:fs"; \
+    const save = readFileSync("src/queries/sql/sessions/saveSessionData.ts", "utf8"); \
+    const lib = readFileSync("src/lib/prisma.ts", "utf8"); \
+    const m = save.match(/const\s*\{([^}]*)\}\s*=\s*prisma;/); \
+    if (!m) throw new Error("saveSessionData no longer destructures helpers from prisma"); \
+    const names = m[1].split(",").map((v) => v.trim()).filter(Boolean); \
+    if (!names.length) throw new Error("no prisma helpers destructured in saveSessionData"); \
+    const surface = lib.slice(lib.indexOf("export default {")); \
+    for (const n of names) { \
+      if (!new RegExp("(?:^|[\\s,{])" + n + "\\s*,").test(surface)) { \
+        throw new Error("saveSessionData calls prisma." + n + " but src/lib/prisma.ts does not export it"); \
+      } \
+    } \
+  ' \
   && node --input-type=module -e '\
     import { readFileSync } from "node:fs"; \
     const normalizeSql = (value) => value.trim().split("\n").map((line) => line.trim()).join("\n"); \

--- a/docker/umami/v320-compat.patch
+++ b/docker/umami/v320-compat.patch
@@ -1,0 +1,48 @@
+diff --git a/src/lib/prisma.ts b/src/lib/prisma.ts
+index 6cdb33c..89c418b 100644
+--- a/src/lib/prisma.ts
++++ b/src/lib/prisma.ts
+@@ -439,6 +439,37 @@ async function rawQuery(sql: string, data: Record<string, any>, name?: string):
+   return client.$queryRawUnsafe(query, ...params);
+ }
+ 
++// v3.2.0 compatibility shim. Upstream's session-data upsert fix (7c030e4c)
++// calls `prisma.writeRawQuery`, which exists on upstream's dev branch but not
++// in the v3.2.0 release this image pins. This copy is derived mechanically
++// from the file's own rawQuery above (see Dockerfile.umami) with exactly one
++// semantic change: the DATABASE_REPLICA_URL branch is removed, because a
++// write must never be routed to `$replica()`.
++async function writeRawQuery(sql: string, data: Record<string, any>, name?: string): Promise<any> {
++  if (process.env.LOG_QUERY) {
++    log('QUERY:\n', sql);
++    log('PARAMETERS:\n', data);
++    log('NAME:\n', name);
++  }
++  const params = [];
++  const schema = getSchema();
++
++  if (schema) {
++    await client.$executeRawUnsafe(`SET search_path TO "${schema}";`);
++  }
++
++  const query = sql?.replaceAll(/\{\{\s*(\w+)(::\w+)?\s*}}/g, (...args) => {
++    const [, name, type] = args;
++
++    const value = data[name];
++
++    params.push(value);
++
++    return `$${params.length}${type ?? ''}`;
++  });
++
++  return client.$queryRawUnsafe(query, ...params);
++}
+ async function pagedQuery<T>(model: string, criteria: T, filters?: QueryFilters) {
+   const { page = 1, pageSize, orderBy, sortDescending = false, search } = filters || {};
+   const size = +pageSize || DEFAULT_PAGE_SIZE;
+@@ -613,4 +644,5 @@ export default {
+   pagedRawQuery,
+   parseFilters,
+   rawQuery,
++  writeRawQuery,
+ };

--- a/tests/umami-runtime-write-probe.mjs
+++ b/tests/umami-runtime-write-probe.mjs
@@ -1,0 +1,195 @@
+// Runtime write probe for the managed Umami image.
+//
+// The sibling gate (umami-postgres-integration.mjs) proves the migration and
+// the upsert SQL at the psql layer. This probe proves the APPLICATION can
+// write: it boots the CI-built image against a disposable database, then
+// exercises the exact paths the production write canary probes — a single
+// identify, a concurrent same-key identify burst, and a named event — and
+// asserts the rows actually land.
+//
+// Why this exists (#6043): the image can build green while its write path is
+// dead. Two real shipped defects were invisible to every static check:
+//   1. the upstream patch called `prisma.writeRawQuery`, which does not exist
+//      in v3.2.0 — "patch applies" and "vitest passes" (query layer mocked)
+//      were both true of an image whose every identify returned HTTP 500;
+//   2. a corrupted compatibility shim emitted SQL placeholders as bare
+//      integers (`values (1, 2, …)` instead of `$1, $2, …`) — syntactically
+//      valid, byte-check-clean, and 100% write-fatal at runtime.
+// Only a real POST through the running app catches this class.
+//
+// Requires: docker, psql, and UMAMI_TEST_DATABASE_URL pointing at a
+// disposable PostgreSQL (the CI service container). The probe creates its own
+// database (umami_runtime_probe) so the sibling gate's schema is untouched.
+
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+const IMAGE = process.env.UMAMI_PROBE_IMAGE || 'worldmonitor/umami:ci';
+const serviceUrl = process.env.UMAMI_TEST_DATABASE_URL;
+assert.ok(
+  serviceUrl,
+  'UMAMI_TEST_DATABASE_URL is required; this probe never skips silently',
+);
+
+const serviceDbName = decodeURIComponent(new URL(serviceUrl).pathname.slice(1));
+assert.match(
+  serviceDbName,
+  /(?:^umami_integration$|_test$)/,
+  `refusing to run against non-test database ${JSON.stringify(serviceDbName)}`,
+);
+
+const PROBE_DB = 'umami_runtime_probe';
+const probeUrl = new URL(serviceUrl);
+probeUrl.pathname = `/${PROBE_DB}`;
+// The app container runs with --network host, so 127.0.0.1 inside the
+// container is the runner's loopback where the PG service port is mapped.
+const containerDbUrl = probeUrl.toString();
+
+const APP_PORT = 3000;
+const APP = `http://127.0.0.1:${APP_PORT}`;
+const CONTAINER = 'umami-runtime-probe';
+const WEBSITE_ID = '7d3e1f5a-9b2c-4d8e-a1f6-0c5b4e8d7a92';
+// A real browser UA: umami bot-filters non-browser agents, so a bare
+// node/curl UA would make every write silently vanish and fail the probe for
+// the wrong reason.
+const UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36';
+
+function psql(sql, dbUrl = containerDbUrl) {
+  return execFileSync(
+    'psql',
+    ['-X', '--set=ON_ERROR_STOP=1', '--no-align', '--tuples-only', `--dbname=${dbUrl}`, '--command', sql],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  ).trim();
+}
+
+function docker(args, opts = {}) {
+  const res = spawnSync('docker', args, { encoding: 'utf8', ...opts });
+  return res;
+}
+
+function cleanup() {
+  docker(['rm', '-f', CONTAINER]);
+}
+
+async function post(body) {
+  const res = await fetch(`${APP}/api/send`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'User-Agent': UA },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(25_000),
+  });
+  return res;
+}
+
+function identifyPayload(data) {
+  return {
+    type: 'identify',
+    payload: { website: WEBSITE_ID, hostname: 'probe.local', url: '/', data },
+  };
+}
+
+let failed = false;
+try {
+  // -- database ------------------------------------------------------------
+  psql(`DROP DATABASE IF EXISTS ${PROBE_DB};`, serviceUrl);
+  psql(`CREATE DATABASE ${PROBE_DB};`, serviceUrl);
+
+  // -- schema via the image's own migrate deploy ---------------------------
+  const mig = docker([
+    'run', '--rm', '--network', 'host',
+    '-e', `DATABASE_URL=${containerDbUrl}`,
+    '--entrypoint', 'sh', IMAGE, '-c', 'pnpm exec prisma migrate deploy',
+  ]);
+  assert.equal(mig.status, 0, `prisma migrate deploy failed:\n${mig.stdout}\n${mig.stderr}`);
+
+  // -- seed ----------------------------------------------------------------
+  psql(`
+    insert into "user" (user_id, username, password, role, created_at)
+    values ('11111111-1111-1111-1111-111111111111','probe','$2b$10$abcdefghijklmnopqrstuv','admin',now());
+    insert into website (website_id, name, domain, created_at, user_id)
+    values ('${WEBSITE_ID}','probe','probe.local',now(),'11111111-1111-1111-1111-111111111111');
+  `);
+
+  // -- boot the app --------------------------------------------------------
+  cleanup();
+  const run = docker([
+    'run', '--detach', '--name', CONTAINER, '--network', 'host',
+    '-e', `DATABASE_URL=${containerDbUrl}`,
+    '-e', 'APP_SECRET=runtime-probe-secret',
+    IMAGE,
+  ]);
+  assert.equal(run.status, 0, `container failed to start: ${run.stderr}`);
+
+  let alive = false;
+  for (let i = 0; i < 60; i++) {
+    try {
+      const res = await fetch(`${APP}/api/heartbeat`, {
+        headers: { 'User-Agent': UA },
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (res.ok) { alive = true; break; }
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+  assert.ok(alive, 'app never reached a healthy heartbeat within 120s');
+
+  // -- 1. single identify must persist -------------------------------------
+  const single = await post(identifyPayload({ probe_single: 'v1' }));
+  assert.equal(single.status, 200, `single identify returned HTTP ${single.status}`);
+  assert.equal(
+    psql('select count(*) from session_data;'),
+    '1',
+    'single identify did not land a session_data row',
+  );
+
+  // -- 2. concurrent same-key burst: atomic upsert, no P2002 ---------------
+  const burst = await Promise.all(
+    Array.from({ length: 6 }, (_, n) => post(identifyPayload({ probe_shared: `v${n}` }))),
+  );
+  for (const [n, res] of burst.entries()) {
+    assert.equal(res.status, 200, `burst identify #${n} returned HTTP ${res.status}`);
+  }
+  const dupes = psql(
+    'select count(*) - count(distinct (session_id, data_key)) from session_data;',
+  );
+  assert.equal(dupes, '0', `concurrent burst produced ${dupes} duplicate (session_id, data_key) rows`);
+  assert.equal(
+    psql("select count(*) from session_data where data_key = 'probe_shared';"),
+    '1',
+    'concurrent same-key burst must collapse to exactly one row',
+  );
+
+  // -- 3. event path must persist ------------------------------------------
+  const event = await post({
+    type: 'event',
+    payload: { website: WEBSITE_ID, hostname: 'probe.local', url: '/probe', name: 'runtime-probe' },
+  });
+  assert.equal(event.status, 200, `event returned HTTP ${event.status}`);
+  assert.equal(
+    psql('select count(*) from website_event;'),
+    '1',
+    'event did not land a website_event row',
+  );
+
+  // -- 4. the app log must be silent ---------------------------------------
+  const logs = docker(['logs', CONTAINER]);
+  const logText = `${logs.stdout}\n${logs.stderr}`;
+  for (const marker of ['P2002', 'is not a function', 'PrismaClientKnownRequestError', 'cannot cast', 'cannot be matched']) {
+    assert.ok(
+      !logText.includes(marker),
+      `app log contains "${marker}" — the write path is degraded even though HTTP said 200`,
+    );
+  }
+
+  console.log('umami runtime write probe: PASS (identify, concurrent upsert, event, clean log)');
+} catch (error) {
+  failed = true;
+  console.error(String(error?.stack || error));
+  const logs = docker(['logs', CONTAINER]);
+  console.error('--- container log tail ---');
+  console.error(`${logs.stdout}\n${logs.stderr}`.split('\n').slice(-40).join('\n'));
+} finally {
+  cleanup();
+}
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary

`session_data` writes (the identify/property path the **Analytics Collector Monitor** canary probes) have been failing 100% on the managed umami image. This PR makes them work and makes it impossible for this class of breakage to build green again.

**The missing helper.** Upstream's upsert fix calls `prisma.writeRawQuery`, which exists on upstream's dev branch but not in the v3.2.0 release the image pins — the destructured helper was `undefined` and every identify threw (`u is not a function` minified). The shim is a **byte-faithful copy of the file's own `rawQuery`**, renamed, with exactly one semantic change: the `DATABASE_REPLICA_URL` branch is removed, because a write must never route to `$replica()`.

**Why byte-derived and not hand-written.** Five prior hand-written shim generations all shipped one corruption: splicing code with `String.prototype.replace` using a replacement *string* halves `$$` to `$` (replacement-pattern escape semantics), turning the emitted SQL placeholders from `$10` into the bare integer `10`. The resulting `coalesce(10::timestamptz, now())` produced the misleading "COALESCE types integer and timestamp with time zone" error family that #6043 initially recorded as a deeper v3.2.0 incompatibility — **there is no such incompatibility**; the issue has been corrected. Postgres `log_statement=all` was the instrument that exposed the bare-integer statement on the wire. The generator now inserts only via replacer *functions* and self-verifies the placeholder emitters before diffing.

**The new gate.** Both shipped defects were invisible to every static check: the patch applied byte-identically, the in-build vitest passes with the query layer mocked, and the image builds green while every identify returns 500. Two additions close the hole:

1. **Build-time**: `Dockerfile.umami` asserts every helper `saveSessionData` destructures from `prisma` is actually exported by `src/lib/prisma.ts` — this alone would have failed the original image.
2. **CI runtime probe** (`tests/umami-runtime-write-probe.mjs`): the existing `umami-postgres` job boots the CI-built image against a disposable DB, runs its own `prisma migrate deploy`, then exercises exactly what the production write canary probes — single identify (row must land), 6-way concurrent same-key burst (must collapse to one row, the original umami#4183 race), named event — and asserts the app log is free of `P2002` / cast / `is not a function` markers so a degraded-but-200 path cannot pass.

## Validation

Full-schema PG 16.14 harness (matches production 16.14), red/green:

| Image | Result |
|---|---|
| origin/main (deployed) | identify **HTTP 500**, `session_data` delta 0, `u is not a function` |
| this PR | identify **200** + row lands · 6-way burst → **1 row, 0 duplicates** · event 200 · **0 P2002, 0 errors** |

The CI probe itself is mutation-tested: **PASS** on the fixed image, **exit 1** on the origin/main image with the real production error surfaced in the failure output. Repo gates: `umami-runtime-remediation.test.mjs` (pins Dockerfile content), `railway-watch-path-audit.test.mjs`, biome, unicode — all green locally.

## Deployment note

Merging fixes the image definition; production umami redeploys **manually** (`watchPatterns: []` — no auto-deploy on push). After merge: trigger `serviceInstanceDeployV2` on the umami service, then two consecutive green **Analytics Collector Monitor** runs complete the #6024 acceptance. The `21_update_session_data` migration is already applied in production, so the new image's startup migration is a no-op.

Fixes #6043

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
