### PR TITLE
fix(analytics): bound the umami pool's acquisition wait so overload fails fast (#6053)

### DIFF
--- a/Dockerfile.umami
+++ b/Dockerfile.umami
@@ -85,6 +85,17 @@ RUN git init \
     const match = source.match(/writeRawQuery\(\s*`([\s\S]*?)`\s*,/); \
     if (!match || normalizeSql(match[1]) !== normalizeSql(fixture)) throw new Error("session-data upsert fixture does not match the applied source"); \
   ' \
+  && node --input-type=module -e '\
+    import { readFileSync } from "node:fs"; \
+    const lib = readFileSync("src/lib/prisma.ts", "utf8"); \
+    const adapters = [...lib.matchAll(/new PrismaPg\(([\s\S]*?)\)\s*;/g)]; \
+    if (adapters.length < 2) throw new Error("expected the base and replica PrismaPg adapters in src/lib/prisma.ts"); \
+    for (const adapter of adapters) { \
+      if (!adapter[1].includes("...getPoolOptions()")) { \
+        throw new Error("a PrismaPg pool is built without getPoolOptions(); pg.Pool would default connectionTimeoutMillis to 0 and queue callers forever"); \
+      } \
+    } \
+  ' \
   && mkdir -p prisma/migrations/21_update_session_data \
   && cp /tmp/21_update_session_data.sql prisma/migrations/21_update_session_data/migration.sql
 

--- a/docker/umami/v320-compat.patch
+++ b/docker/umami/v320-compat.patch
@@ -1,5 +1,5 @@
 diff --git a/src/lib/prisma.ts b/src/lib/prisma.ts
-index 6cdb33c..89c418b 100644
+index 6cdb33c..d6bee46 100644
 --- a/src/lib/prisma.ts
 +++ b/src/lib/prisma.ts
 @@ -439,6 +439,37 @@ async function rawQuery(sql: string, data: Record<string, any>, name?: string):
@@ -40,7 +40,51 @@ index 6cdb33c..89c418b 100644
  async function pagedQuery<T>(model: string, criteria: T, filters?: QueryFilters) {
    const { page = 1, pageSize, orderBy, sortDescending = false, search } = filters || {};
    const size = +pageSize || DEFAULT_PAGE_SIZE;
-@@ -613,4 +644,5 @@ export default {
+@@ -540,6 +571,22 @@ function getSchema() {
+   return connectionUrl.searchParams.get('schema');
+ }
+ 
++// v3.2.0 operational hardening. PrismaPg forwards this options object to pg.Pool,
++// whose connectionTimeoutMillis defaults to 0, and pg-pool treats 0 as "queue the
++// caller with no timer at all". A saturated pool therefore parks callers forever
++// instead of failing them, which is how a slow database turned collector requests
++// into indefinite hangs rather than prompt errors (worldmonitor #6053). Bounding
++// the acquisition wait turns pool exhaustion back into a fast, visible failure.
++const DEFAULT_POOL_CONNECT_TIMEOUT_MS = 10000;
++
++function getPoolOptions() {
++  const configured = Number(process.env.DATABASE_CONNECT_TIMEOUT_MS);
++  const connectionTimeoutMillis =
++    Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_POOL_CONNECT_TIMEOUT_MS;
++
++  return { connectionTimeoutMillis };
++}
++
+ function getClient() {
+   const url = process.env.DATABASE_URL;
+   const replicaUrl = process.env.DATABASE_REPLICA_URL;
+@@ -551,7 +598,7 @@ function getClient() {
+ 
+   const schema = getSchema();
+ 
+-  const baseAdapter = new PrismaPg({ connectionString: url }, { schema });
++  const baseAdapter = new PrismaPg({ connectionString: url, ...getPoolOptions() }, { schema });
+ 
+   const baseClient = new PrismaClient({
+     adapter: baseAdapter,
+@@ -569,7 +616,10 @@ function getClient() {
+     return baseClient;
+   }
+ 
+-  const replicaAdapter = new PrismaPg({ connectionString: replicaUrl }, { schema });
++  const replicaAdapter = new PrismaPg(
++    { connectionString: replicaUrl, ...getPoolOptions() },
++    { schema },
++  );
+ 
+   const replicaClient = new PrismaClient({
+     adapter: replicaAdapter,
+@@ -613,4 +663,5 @@ export default {
    pagedRawQuery,
    parseFilters,
    rawQuery,

--- a/tests/umami-runtime-remediation.test.mjs
+++ b/tests/umami-runtime-remediation.test.mjs
@@ -84,6 +84,70 @@ describe('Umami runtime remediation (#6024)', () => {
     assert.doesNotMatch(addedSource, /sessionData\.create/);
   });
 
+  it('bounds pool acquisition so a saturated pool fails fast instead of queueing forever', () => {
+    const patch = read('docker/umami/v320-compat.patch');
+    const addedSource = patch
+      .split('\n')
+      .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+      .map((line) => line.slice(1))
+      .join('\n');
+
+    // pg.Pool defaults connectionTimeoutMillis to 0, and pg-pool treats 0 as
+    // "queue the caller with no timer at all" — the #6053 indefinite hang. Every
+    // adapter must therefore carry the bound, not just the one we happened to hit.
+    const adapters = [...addedSource.matchAll(/new PrismaPg\(([\s\S]*?)\)\s*;/g)];
+
+    assert.equal(adapters.length, 2, 'expected the base and replica adapters to be patched');
+    for (const adapter of adapters) {
+      assert.ok(
+        adapter[1].includes('...getPoolOptions()'),
+        `PrismaPg pool built without a bounded acquisition timeout: ${adapter[0]}`,
+      );
+    }
+
+    // Execute the helper we actually ship rather than pattern-matching its text.
+    const declaration = addedSource.indexOf('const DEFAULT_POOL_CONNECT_TIMEOUT_MS');
+    const bodyEnd = addedSource.indexOf('\n}', addedSource.indexOf('function getPoolOptions()')) + 2;
+
+    assert.ok(declaration >= 0 && bodyEnd > declaration, 'getPoolOptions() missing from the patch');
+
+    const getPoolOptions = new Function(
+      `${addedSource.slice(declaration, bodyEnd)}\nreturn getPoolOptions;`,
+    )();
+    const previous = process.env.DATABASE_CONNECT_TIMEOUT_MS;
+
+    try {
+      delete process.env.DATABASE_CONNECT_TIMEOUT_MS;
+      assert.equal(getPoolOptions().connectionTimeoutMillis, 10000);
+
+      process.env.DATABASE_CONNECT_TIMEOUT_MS = '2500';
+      assert.equal(getPoolOptions().connectionTimeoutMillis, 2500);
+
+      for (const invalid of ['0', '-1', 'abc', '']) {
+        process.env.DATABASE_CONNECT_TIMEOUT_MS = invalid;
+        assert.equal(
+          getPoolOptions().connectionTimeoutMillis,
+          10000,
+          `${JSON.stringify(invalid)} must fall back to the bounded default, never 0 (unbounded)`,
+        );
+      }
+    } finally {
+      if (previous === undefined) {
+        delete process.env.DATABASE_CONNECT_TIMEOUT_MS;
+      } else {
+        process.env.DATABASE_CONNECT_TIMEOUT_MS = previous;
+      }
+    }
+  });
+
+  it('fails the image build when a PrismaPg pool loses its acquisition bound', () => {
+    const dockerfile = read('Dockerfile.umami');
+
+    assert.match(dockerfile, /new PrismaPg\\\(\(\[\\s\\S\]\*\?\)\\\)\\s\*;/);
+    assert.match(dockerfile, /\.\.\.getPoolOptions\(\)/);
+    assert.match(dockerfile, /connectionTimeoutMillis to 0 and queue callers forever/);
+  });
+
   it('deduplicates deterministically before creating the composite unique index', () => {
     const migration = read('docker/umami/21_update_session_data/migration.sql');
 


### PR DESCRIPTION
## Summary

Bounds the umami collector's database pool acquisition wait so overload fails fast instead of hanging indefinitely.

Umami 3.2.0 runs Prisma through `@prisma/adapter-pg`, so `PrismaPg`'s first argument is a `pg.PoolConfig`. Neither adapter set `connectionTimeoutMillis`, and pg-pool treats the `0` default as *"queue the caller with no timer at all"*:

```js
// pg-pool/index.js
if (!this.options.connectionTimeoutMillis) {
  this._pendingQueue.push(new PendingItem(response.callback))
  return result        // queued, no timeout armed
}
```

A saturated pool therefore parked callers forever rather than failing them.

## Why this mattered (#6053)

With umami in `asia-southeast1` and Postgres in another region, every round trip cost **~235 ms** — measured from inside the container, on both address families. The default **10-connection** `pg.Pool` saturated, and cold-path requests queued until the Railway edge gave up at 125 s (`499 124998ms POST /api/send`).

Moving umami into the database's region removed the latency (235 ms → **2–4 ms**, verified). This removes the *unbounded wait*, so a future latency regression degrades into prompt errors instead of a silent wedge.

Diagnosis note: #6051 did not introduce a bug — it introduced **load**. Before it, identify threw instantly and consumed no pool time; after it, each identify held a connection for real round trips. That is the correlation #6053 observed but could not explain.

## Changes

- **`docker/umami/v320-compat.patch`** — adds `getPoolOptions()` and wires it into both `PrismaPg` constructions. Default 10 s, overridable via `DATABASE_CONNECT_TIMEOUT_MS`. Invalid values (`0`, negative, non-numeric, empty) fall back to the default rather than to `0`, since `0` is precisely the unbounded sentinel.
- **`Dockerfile.umami`** — build-time guard failing the image if *any* `PrismaPg` pool lacks the bound, so an upstream bump adding a third adapter cannot silently reintroduce the hang.
- **`tests/umami-runtime-remediation.test.mjs`** — extracts `getPoolOptions` from the patch and **executes it** rather than regex-matching source text.

## Verification

- Regenerated with `git diff` (not hand-edited hunk offsets); **applies clean to pristine upstream `2f6e2b5f`**, checked against a byte-exact reconstruction.
- Build guard: fails on unpatched source, passes on patched, and **fails when one adapter loses the bound while the other keeps it**.
- Both new tests mutation-tested: default `10000 → 0` red, `...getPoolOptions()` removed red, control green, patch restored byte-identical.
- 9/9 in the changed suite, 40/40 `railway-watch-path-audit`, biome clean.

## Residual

`connectionTimeoutMillis` bounds **acquisition, not execution**. A query that hangs server-side still holds its connection; the difference is that waiters now fail in 10 s instead of queueing forever. Bounding execution needs `statement_timeout` on the pool config or the role — deliberately not included here, since it also caps long dashboard queries.

Takes effect only on the next image rebuild and deploy.

Related: #6053, #6051, #6024
