### PR TITLE
fix(insights): make world brief readable

### DIFF
--- a/e2e/insights-brief-readability.spec.ts
+++ b/e2e/insights-brief-readability.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+
+const insightsFixture = {
+  worldBrief:
+    'Trump halts Iran strikes, citing a deal [1][2][3][4][5][6][8]. A deal outline is agreed upon [3].',
+  briefStoryLines: [
+    { n: 1, text: 'Trump holds off Iran strikes for a deal [1].' },
+    { n: 2, text: 'Trump calls off Iran attack for peace deal [2].' },
+    { n: 3, text: 'Trump halts Iran attack for deal outline [3].' },
+    { n: 4, text: 'Trump expects rapid deal with Iran [4].' },
+    { n: 5, text: 'Trump cancels Iran strikes for rapid deal [5].' },
+    { n: 6, text: 'Trump cancels Iran attack for deal parameters [6].' },
+    { n: 7, text: 'Poilievre calls for Iran-backed group classification [7].' },
+    { n: 8, text: 'Trump cites a deal while pausing strikes [8].' },
+  ],
+  worldBriefSources: Array.from({ length: 8 }, (_, index) => ({
+    title: `Story ${index + 1}`,
+    source: 'Example News',
+    url: `https://example.com/story-${index + 1}`,
+  })),
+  briefProvider: 'fixture',
+  status: 'ok' as const,
+  topStories: [{
+    primaryTitle: 'Trump halts Iran strikes',
+    primarySource: 'Example News',
+    primaryLink: 'https://example.com/story-1',
+    pubDate: '2026-08-02T10:00:00.000Z',
+    sourceCount: 8,
+    importanceScore: 1,
+    velocity: { level: 'normal', sourcesPerHour: 0 },
+    isAlert: false,
+    category: 'conflict',
+    threatLevel: 'high',
+    countryCode: 'IR',
+  }],
+  generatedAt: '2026-08-02T12:00:00.000Z',
+  sourceAgeRange: { newestMs: Date.now(), oldestMs: Date.now() },
+  clusterCount: 8,
+  multiSourceCount: 8,
+  fastMovingCount: 0,
+};
+
+test('server World Brief keeps the main insight concise and citations usable', async ({ page }) => {
+  await page.goto('/tests/map-harness.html', { waitUntil: 'domcontentloaded' });
+  await page.evaluate(() => document.body.replaceChildren());
+
+  const rendered = await page.evaluate(async (fixture) => {
+    const { InsightsPanel } = await import('/src/components/InsightsPanel.ts');
+    const panel = new InsightsPanel();
+    document.body.appendChild(panel.getElement());
+    (panel as any).updateGeneration = 1;
+    (panel as any).renderServerInsights(fixture, null);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+
+    const brief = panel.getElement().querySelector('.insights-brief');
+    const mainText = brief?.querySelector('.insights-brief-text');
+    const details = brief?.querySelector('.insights-brief-details');
+    const storyLineCount = brief?.querySelectorAll('.insights-brief-lines li').length ?? 0;
+    return {
+      mainCitationLinks: mainText?.querySelectorAll('a.cb-citation').length ?? 0,
+      storyLineCount,
+      visibleStoryLineCount: details?.matches(':open') ? storyLineCount : 0,
+      detailsOpen: details?.hasAttribute('open') ?? false,
+      briefText: mainText?.textContent ?? '',
+    };
+  }, insightsFixture);
+
+  expect(rendered.mainCitationLinks).toBeGreaterThan(0);
+  expect(rendered.storyLineCount).toBe(8);
+  expect(rendered.visibleStoryLineCount).toBe(0);
+  expect(rendered.detailsOpen).toBe(false);
+  expect(rendered.briefText).toContain('Trump halts Iran strikes');
+
+  const details = page.locator('.insights-brief-details');
+  await details.locator('summary').click();
+  await expect(details).toHaveAttribute('open', '');
+  await expect(details.locator('.insights-brief-lines li')).toHaveCount(8);
+});

--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -144,7 +144,7 @@ export class InsightsPanel extends Panel {
     this.setDataBadge('cached');
     this.setSafeContent(unsafeRawHtml(
       this.renderWorldBrief(this.cachedBrief, this.cachedBriefSources),
-      'renderWorldBrief escapes the cached summary (#4890 early brief paint)',
+      'renderWorldBrief formats and links the cached summary (#4890 early brief paint)',
     ));
   }
 
@@ -656,18 +656,21 @@ export class InsightsPanel extends Panel {
     `;
   }
 
-  /** #4921: cited per-story lines + staleness footer for the World Brief. */
+  /** #4921: cited per-story lines behind a disclosure + staleness footer. */
   private renderBriefExtras(insights: ServerInsights): string {
     const lines = Array.isArray(insights.briefStoryLines) ? insights.briefStoryLines : [];
     const sources = insights.worldBriefSources ?? [];
     const linesHtml = lines.length > 0
-      ? `<ol class="insights-brief-lines">${lines
-          .map((line) => `<li>${formatIntelBrief(line.text, { sources })
-            .replace(/^<div class="brief-para">/, '')
-            .replace(/<\/div>$/, '')
-            .replace(/^<p>/, '')
-            .replace(/<\/p>$/, '')}</li>`)
-          .join('')}</ol>`
+      ? `<details class="insights-brief-details">
+          <summary>${escapeHtml(t('components.insights.briefStoryDetails', { count: String(lines.length) }))}</summary>
+          <ol class="insights-brief-lines">${lines
+            .map((line) => `<li>${formatIntelBrief(line.text, { sources })
+              .replace(/^<div class="brief-para">/, '')
+              .replace(/<\/div>$/, '')
+              .replace(/^<p>/, '')
+              .replace(/<\/p>$/, '')}</li>`)
+            .join('')}</ol>
+        </details>`
       : '';
     let footer = '';
     const generatedMs = new Date(insights.generatedAt).getTime();
@@ -694,7 +697,7 @@ export class InsightsPanel extends Panel {
     return `
       <div class="insights-brief">
         <div class="insights-section-title">${heading}</div>
-        <div class="insights-brief-text">${escapeHtml(brief)}</div>
+        <div class="insights-brief-text">${formatIntelBrief(brief, { sources })}</div>
         ${extrasHtml}
         ${renderBriefSourcesFooter(sources, { className: 'insights-brief-sources', maxSources: Math.max(6, sources.length) })}
       </div>

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1321,7 +1321,8 @@
       "sources_many": "{{count}} مصدر",
       "provenanceTitle": "أصل التغطية: عدد القصص المأخوذة والمصادر المميزة التي تم اختيار هذا الملخص منها",
       "compiledFrom": "مجمّع من {{stories}} قصة عبر {{sources}} مصادر",
-      "briefFreshness": "تم الإنشاء منذ {{minutes}}د · أحدث مصدر عمره {{hours}}س"
+      "briefFreshness": "تم الإنشاء منذ {{minutes}}د · أحدث مصدر عمره {{hours}}س",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "cascade": {
       "filters": {

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -1352,7 +1352,8 @@
       "newsSignals": "{{news}} новини • {{signals}} сигнали",
       "provenanceTitle": "Произход на обхвата: колко включени истории и отделни източници е избрано от този преглед",
       "compiledFrom": "Събрано от {{stories}} истории в {{sources}} източници",
-      "briefFreshness": "Генериран преди {{minutes}}м · най-нов източник {{hours}}ч стар"
+      "briefFreshness": "Генериран преди {{minutes}}м · най-нов източник {{hours}}ч стар",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "Експорт на настройки",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -1346,7 +1346,8 @@
       "sources_many": "{{count}} zdrojů",
       "provenanceTitle": "Původ pokrytí: počet příjatých příběhů a odlišných zdrojů, ze kterých byl tento přehled vybrán",
       "compiledFrom": "Sestaveno z {{stories}} příběhů z {{sources}} zdrojů",
-      "briefFreshness": "Vygenerováno před {{minutes}}m · nejnovější zdroj starý {{hours}}h"
+      "briefFreshness": "Vygenerováno před {{minutes}}m · nejnovější zdroj starý {{hours}}h",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "cascade": {
       "filters": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1673,7 +1673,8 @@
       "newsSignals": "{{news}} Nachrichten • {{signals}} Signale",
       "provenanceTitle": "Abdeckungsherkunft: Anzahl der erfassten Stories und unterschiedlichen Quellen, aus denen dieser Brief ausgewählt wurde",
       "compiledFrom": "Zusammengestellt aus {{stories}} Geschichten über {{sources}} Quellen",
-      "briefFreshness": "Generiert vor {{minutes}}m · neueste Quelle {{hours}}h alt"
+      "briefFreshness": "Generiert vor {{minutes}}m · neueste Quelle {{hours}}h alt",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "etfFlows": {
       "unavailable": "ETF-Daten vorübergehend nicht verfügbar",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -1352,7 +1352,8 @@
       "newsSignals": "{{news}} ειδήσεις • {{signals}} σήματα",
       "provenanceTitle": "Προέλευση κάλυψης: πόσες καταχωρημένες ιστορίες και διακριτές πηγές επιλέχθησαν για αυτή τη σύνοψη",
       "compiledFrom": "Συντάχθηκε από {{stories}} ιστορίες σε {{sources}} πηγές",
-      "briefFreshness": "Δημιουργήθηκε πριν {{minutes}}λ · νεότερη πηγή {{hours}}ώ παλιά"
+      "briefFreshness": "Δημιουργήθηκε πριν {{minutes}}λ · νεότερη πηγή {{hours}}ώ παλιά",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "Εξαγωγή ρυθμίσεων",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1482,6 +1482,7 @@
       "briefCommodity": "COMMODITY BRIEF",
       "briefEnergy": "ENERGY BRIEF",
       "briefWorld": "WORLD BRIEF",
+      "briefStoryDetails": "Story details ({{count}})",
       "mlDetected": "ML DETECTED",
       "geographicConvergence": "GEOGRAPHIC CONVERGENCE",
       "focalPoints": "FOCAL POINTS",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1676,7 +1676,8 @@
       "sources_many": "{{count}} fuentes",
       "provenanceTitle": "Procedencia de cobertura: cuántas historias ingeridas y fuentes distintas se seleccionaron para este resumen",
       "compiledFrom": "Compilado de {{stories}} historias en {{sources}} fuentes",
-      "briefFreshness": "Generado hace {{minutes}}m · fuente más reciente con {{hours}}h de antigüedad"
+      "briefFreshness": "Generado hace {{minutes}}m · fuente más reciente con {{hours}}h de antigüedad",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "etfFlows": {
       "unavailable": "Datos ETF temporalmente no disponibles",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -1493,7 +1493,8 @@
       "newsSignals": "{{news}} news • {{signals}} signals",
       "compiledFrom": "گردآوری‌شده از {{stories}} خبر از {{sources}} منبع",
       "provenanceTitle": "شفافیت پوشش: این گزیده از چه تعداد خبر دریافتی و چند منبع مجزا انتخاب شده است",
-      "briefFreshness": "تولید شده {{minutes}}m پیش · جدیدترین منبع {{hours}}h قدیمی"
+      "briefFreshness": "تولید شده {{minutes}}m پیش · جدیدترین منبع {{hours}}h قدیمی",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "Export Settings",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1312,7 +1312,8 @@
       "sources_many": "{{count}} sources",
       "provenanceTitle": "Provenance de la couverture : nombre d'articles ingérés et de sources distinctes à partir desquels ce résumé a été sélectionné",
       "compiledFrom": "Compilé à partir de {{stories}} articles provenant de {{sources}} sources",
-      "briefFreshness": "Généré il y a {{minutes}}m · source la plus récente datant de {{hours}}h"
+      "briefFreshness": "Généré il y a {{minutes}}m · source la plus récente datant de {{hours}}h",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "Exporter les paramètres",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -1493,7 +1493,8 @@
       "newsSignals": "{{news}} खबरें • {{signals}} संकेत",
       "provenanceTitle": "कवरेज प्रोवेनेंस: इस ब्रीफ को कितनी अंतर्ग्रहीत कहानियों और विशिष्ट स्रोतों से चुना गया था",
       "compiledFrom": "{{stories}} कहानियों और {{sources}} स्रोतों से संकलित",
-      "briefFreshness": "{{minutes}}m पहले जनरेट किया गया · नवीनतम स्रोत {{hours}}h पुराना"
+      "briefFreshness": "{{minutes}}m पहले जनरेट किया गया · नवीनतम स्रोत {{hours}}h पुराना",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "सेटिंग्स निर्यात करें",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -1630,7 +1630,8 @@
       "sources_few": "{{count}} izvora",
       "provenanceTitle": "Pokrivanje izvora: koliko je unesenih članaka i različitih izvora odabrano za ovaj sažetak",
       "compiledFrom": "Sastavljeno od {{stories}} priča iz {{sources}} izvora",
-      "briefFreshness": "Generirano prije {{minutes}}m · najnoviji izvor star {{hours}}h"
+      "briefFreshness": "Generirano prije {{minutes}}m · najnoviji izvor star {{hours}}h",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "dataManagementLabel": "Upravljanje podacima",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -1493,7 +1493,8 @@
       "newsSignals": "{{news}} hír • {{signals}} szignál",
       "provenanceTitle": "Lefedettség eredete: hány feldolgozott történetből és különálló forrásból választotta ki ezt az összefoglalót",
       "compiledFrom": "{{stories}} történetből és {{sources}} forrásból összeállítva",
-      "briefFreshness": "Generálva {{minutes}}m idővel ezelőtt · legfrissebb forrás {{hours}}ó régi"
+      "briefFreshness": "Generálva {{minutes}}m idővel ezelőtt · legfrissebb forrás {{hours}}ó régi",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "Beállítások exportálása",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1676,7 +1676,8 @@
       "sources_many": "{{count}} fonti",
       "provenanceTitle": "Provenienza della copertura: quante storie acquisite e quante fonti distinte sono state utilizzate per selezionare questo briefing",
       "compiledFrom": "Compilato da {{stories}} storie provenienti da {{sources}} fonti",
-      "briefFreshness": "Generato {{minutes}}m fa · fonte più recente {{hours}}h fa"
+      "briefFreshness": "Generato {{minutes}}m fa · fonte più recente {{hours}}h fa",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "etfFlows": {
       "unavailable": "Dati ETF temporaneamente non disponibili",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1352,7 +1352,8 @@
       "newsSignals": "{{news}} ニュース • {{signals}} シグナル",
       "provenanceTitle": "カバレッジプロヴェナンス: このブリーフが選択された取り込まれたストーリーと個別ソースの数",
       "compiledFrom": "{{stories}}件のストーリーから{{sources}}個のソースをコンパイル",
-      "briefFreshness": "{{minutes}}m前に生成 · 最新ソース{{hours}}h前"
+      "briefFreshness": "{{minutes}}m前に生成 · 最新ソース{{hours}}h前",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "設定をエクスポート",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1352,7 +1352,8 @@
       "newsSignals": "{{news}}개 뉴스 • {{signals}}개 신호",
       "provenanceTitle": "커버리지 출처: 이 브리프가 선택된 수집 스토리 및 고유 소스의 개수",
       "compiledFrom": "{{stories}}개의 스토리와 {{sources}}개의 소스에서 컴파일됨",
-      "briefFreshness": "{{minutes}}분 전 생성됨 · 최신 소스 {{hours}}시간 전"
+      "briefFreshness": "{{minutes}}분 전 생성됨 · 최신 소스 {{hours}}시간 전",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "설정 내보내기",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1279,7 +1279,8 @@
       "newsSignals": "{{news}} nieuws • {{signals}} signalen",
       "provenanceTitle": "Dekking herkomst: hoeveel opgenomen verhalen en verschillende bronnen deze samenvatting is geselecteerd uit",
       "compiledFrom": "Samengesteld uit {{stories}} verhalen uit {{sources}} bronnen",
-      "briefFreshness": "Gegenereerd {{minutes}}m geleden · nieuwste bron {{hours}}h oud"
+      "briefFreshness": "Gegenereerd {{minutes}}m geleden · nieuwste bron {{hours}}h oud",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "techHubs": {
       "infoTooltip": "<strong>Tech Hub-activiteit</strong><br>Toont tech-hubs met de meeste nieuwsactiviteit.<br><br><em>Activiteitsniveaus:</em><br>• <span style=\"color: {{highColor}}\">Hoog</span> — Breaking news of 50+ score<br>• <span style=\"color: {{elevatedColor}}\">Verhoogd</span> — Score 20-49<br>• <span style=\"color: {{lowColor}}\">Laag</span> — Score lager dan 20<br><br>Klik op een hub om naar de locatie ervan te zoomen."

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1596,7 +1596,8 @@
       "sources_many": "{{count}} źródeł",
       "provenanceTitle": "Pochodzenie zasięgu: ile pozyskanych artykułów i odrębnych źródeł wybrano dla tego briefu",
       "compiledFrom": "Zebrane z {{stories}} artykułów z {{sources}} źródeł",
-      "briefFreshness": "Wygenerowano {{minutes}}m temu · najnowsze źródło sprzed {{hours}}h"
+      "briefFreshness": "Wygenerowano {{minutes}}m temu · najnowsze źródło sprzed {{hours}}h",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "etfFlows": {
       "unavailable": "Dane ETF tymczasowo niedostępne",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1280,7 +1280,8 @@
       "sources_many": "{{count}} fontes",
       "provenanceTitle": "Proveniência de cobertura: quantas histórias ingeridas e fontes distintas foram selecionadas para este resumo",
       "compiledFrom": "Compilado de {{stories}} histórias em {{sources}} fontes",
-      "briefFreshness": "Gerado há {{minutes}}m · fonte mais recente com {{hours}}h"
+      "briefFreshness": "Gerado há {{minutes}}m · fonte mais recente com {{hours}}h",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "techHubs": {
       "infoTooltip": "<strong>Atividade do Tech Hub</strong><br>Mostra os hubs de tecnologia com mais atividade de notícias.<br><br><em>Níveis de atividade:</em><br>• <span style=\"color: {{highColor}}\">Alto</span> — Notícias de última hora ou pontuação acima de 50<br>• <span style=\"color: {{elevatedColor}}\">Elevado</span> — Pontuação 20-49<br>• <span style=\"color: {{lowColor}}\">Baixo</span> — Pontuação abaixo de 20<br><br>Clique em um hub para ampliar sua localização."

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1355,7 +1355,8 @@
       "sources_few": "{{count}} surse",
       "provenanceTitle": "Proveniență acoperire: câte articole ingerate și surse distincte din care a fost selectat acest rezumat",
       "compiledFrom": "Compilat din {{stories}} povești din {{sources}} surse",
-      "briefFreshness": "Generat {{minutes}}m în urmă · cea mai nouă sursă {{hours}}h vechime"
+      "briefFreshness": "Generat {{minutes}}m în urmă · cea mai nouă sursă {{hours}}h vechime",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "Exportare setări",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1358,7 +1358,8 @@
       "sources_many": "{{count}} источников",
       "provenanceTitle": "Происхождение охвата: количество полученных историй и отдельных источников, из которых была выбрана эта сводка",
       "compiledFrom": "Собрано из {{stories}} историй из {{sources}} источников",
-      "briefFreshness": "Сгенерировано {{minutes}}м назад · последний источник {{hours}}ч старый"
+      "briefFreshness": "Сгенерировано {{minutes}}м назад · последний источник {{hours}}ч старый",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "Экспорт настроек",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1279,7 +1279,8 @@
       "newsSignals": "{{news}} nyheter • {{signals}} signaler",
       "provenanceTitle": "Täckningshärkomst: hur många inmatade historier och unika källor denna kortfattade sammanfattning valdes från",
       "compiledFrom": "Kompilerat från {{stories}} berättelser från {{sources}} källor",
-      "briefFreshness": "Genererad {{minutes}}m sedan · senaste källa {{hours}}h gammal"
+      "briefFreshness": "Genererad {{minutes}}m sedan · senaste källa {{hours}}h gammal",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "techHubs": {
       "infoTooltip": "<strong>Teknisk hubbaktivitet</strong><br>Visar tekniska nav med mest nyhetsaktivitet.<br><br><em>Aktivitetsnivåer:</em><br>• <span style=\"color: {{highColor}}\">Hög</span> — Nyheter från 50+ PH_• 50+ stil: {{elevatedColor}}\">Höjd</span> — Poäng 20-49<br>• <span style=\"color: {{lowColor}}\">Låg</span> — Poäng under 20<br><br>Klicka på ett nav för att zooma till dess plats."

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -1352,7 +1352,8 @@
       "newsSignals": "{{news}} ข่าว • {{signals}} สัญญาณ",
       "provenanceTitle": "ความมาของการครอบคลุม: จำนวนเรื่องข่าวที่นำเข้าและแหล่งข่าวที่แตกต่างกันที่ใช้สำหรับสรุปนี้",
       "compiledFrom": "รวบรวมจาก {{stories}} เรื่องราวจาก {{sources}} แหล่งที่มา",
-      "briefFreshness": "สร้างเมื่อ {{minutes}}m ที่แล้ว · แหล่งข้อมูลล่าสุด {{hours}}h เก่า"
+      "briefFreshness": "สร้างเมื่อ {{minutes}}m ที่แล้ว · แหล่งข้อมูลล่าสุด {{hours}}h เก่า",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "ส่งออกการตั้งค่า",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1352,7 +1352,8 @@
       "newsSignals": "{{news}} haber • {{signals}} sinyal",
       "compiledFrom": "{{stories}} hikaye ve {{sources}} kaynaktan derlenmiştir",
       "provenanceTitle": "Kapsam kaynağı: bu özet için kaç alınan hikaye ve farklı kaynaktan seçildiği",
-      "briefFreshness": "{{minutes}}m önce oluşturuldu · en yeni kaynak {{hours}}s eski"
+      "briefFreshness": "{{minutes}}m önce oluşturuldu · en yeni kaynak {{hours}}s eski",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "Ayarları Dışa Aktar",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -1493,7 +1493,8 @@
       "newsSignals": "{{news}} news • {{signals}} signals",
       "compiledFrom": "Compiled from {{stories}} stories across {{sources}} sources",
       "provenanceTitle": "Coverage provenance: how many ingested stories and distinct sources this brief was selected from",
-      "briefFreshness": "Generated {{minutes}}m ago · newest source {{hours}}h old"
+      "briefFreshness": "Generated {{minutes}}m ago · newest source {{hours}}h old",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "Export Settings",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1352,7 +1352,8 @@
       "newsSignals": "{{news}} tin tức • {{signals}} tín hiệu",
       "provenanceTitle": "Nguồn gốc bài viết: số lượng bài viết được nhập và các nguồn riêng biệt mà bài viết này được chọn từ đó",
       "compiledFrom": "Được biên soạn từ {{stories}} câu chuyện trên {{sources}} nguồn",
-      "briefFreshness": "Được tạo {{minutes}}m trước · nguồn mới nhất {{hours}}h tuổi"
+      "briefFreshness": "Được tạo {{minutes}}m trước · nguồn mới nhất {{hours}}h tuổi",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "Xuất cài đặt",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1352,7 +1352,8 @@
       "newsSignals": "{{news}} 条新闻 • {{signals}} 个信号",
       "compiledFrom": "编译自 {{stories}} 条故事和 {{sources}} 个来源",
       "provenanceTitle": "覆盖来源：此摘要选自多少条摄取的故事和不同的来源",
-      "briefFreshness": "生成于 {{minutes}}m 前 · 最新来源 {{hours}}h 前"
+      "briefFreshness": "生成于 {{minutes}}m 前 · 最新来源 {{hours}}h 前",
+      "briefStoryDetails": "Story details ({{count}})"
     },
     "settings": {
       "exportSettings": "导出设置",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -18839,7 +18839,23 @@ a.prediction-link:hover {
   flex: 1;
 }
 
-/* #4921 cited per-story brief lines + freshness footer */
+/* #4921 cited per-story brief lines stay behind a disclosure so the lead is
+   the default reading path; the evidence remains one click away. */
+.insights-brief-details {
+  margin-top: 8px;
+  border-top: 1px solid var(--border);
+  color: var(--text-dim);
+}
+.insights-brief-details summary {
+  cursor: pointer;
+  padding: 6px 0 2px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+.insights-brief-details[open] summary {
+  color: var(--text);
+}
 .insights-brief-lines {
   margin: 8px 0 4px;
   padding-left: 18px;

--- a/tests/brief-contract.test.mjs
+++ b/tests/brief-contract.test.mjs
@@ -203,10 +203,12 @@ describe('brief-contract wiring (source-textual)', () => {
     assert.match(src, /brief: citationCheck\.text/);
   });
 
-  it('panel renders story lines and the freshness footer', () => {
+  it('panel keeps cited story lines behind a disclosure and renders the freshness footer', () => {
     const src = readSrc('src/components/InsightsPanel.ts');
     assert.match(src, /renderBriefExtras/);
+    assert.match(src, /insights-brief-details/);
     assert.match(src, /insights-brief-lines/);
+    assert.match(src, /formatIntelBrief\(brief, \{ sources \}\)/);
     assert.match(src, /components\.insights\.briefFreshness/);
   });
 

--- a/tests/insights-brief-early-paint.test.mts
+++ b/tests/insights-brief-early-paint.test.mts
@@ -50,7 +50,7 @@ describe('InsightsPanel early cached-brief paint (#4890)', () => {
     assert.match(
       method,
       /this\.renderWorldBrief\(this\.cachedBrief, this\.cachedBriefSources\)/,
-      'the early paint must reuse renderWorldBrief (it escapes the cached summary)',
+      'the early paint must reuse renderWorldBrief (it formats and links the cached summary)',
     );
   });
 


### PR DESCRIPTION
## Summary

AI Insights could show a short synthesis followed by up to eight near-duplicate story restatements, making the brief difficult to scan. The World Brief now presents the concise lead first, turns inline source markers into clickable citations, and keeps the per-story evidence available behind a collapsed “Story details” disclosure.

## Validation

- `npx playwright test e2e/insights-brief-readability.spec.ts`
- `node --test tests/brief-contract.test.mjs`
- `./node_modules/.bin/tsx --test tests/insights-brief-early-paint.test.mts tests/format-intel-brief.test.mts tests/brief-sources.test.mts`
- `npm run typecheck`
- Pre-push gate: 47 changed tests and 249 edge tests passed.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-Codex-000000)
