### PR TITLE
fix(ui): normalize China dashboard panel styling

### DIFF
--- a/src/components/ChinaActivityNowcastPanel.ts
+++ b/src/components/ChinaActivityNowcastPanel.ts
@@ -4,92 +4,6 @@ import { unsafeRawHtml } from '@/utils/sanitize';
 import type { ChinaActivityNowcastResponse } from '../../shared/china-activity-nowcast';
 import { renderChinaActivityNowcastView } from './china-activity-nowcast-view';
 
-const STYLE_ID = 'china-activity-nowcast-panel-styles';
-
-function injectStyles(): void {
-  if (document.getElementById(STYLE_ID)) return;
-  const style = document.createElement('style');
-  style.id = STYLE_ID;
-  style.textContent = `
-    .china-nowcast-view { display: grid; gap: 12px; color: var(--text-primary); }
-    .china-nowcast-summary, .china-nowcast-official, .china-nowcast-method {
-      border: 1px solid var(--border-color); background: color-mix(in srgb, var(--panel-bg) 88%, transparent);
-    }
-    .china-nowcast-summary {
-      display: grid; grid-template-columns: minmax(0, 1fr) minmax(180px, .38fr);
-      gap: 14px; align-items: center; padding: 14px;
-      border-left: 3px solid var(--text-muted);
-    }
-    .china-nowcast-summary--agreement { border-left-color: var(--success-color, #45bd7d); }
-    .china-nowcast-summary--proxy_leading_divergence,
-    .china-nowcast-summary--official_leading_divergence { border-left-color: var(--warning-color, #e3a94f); }
-    .china-nowcast-summary--mixed_signals { border-left-color: #8f7bd6; }
-    .china-nowcast-summary--insufficient_data { border-left-color: var(--text-muted); }
-    .china-nowcast-eyebrow, .china-nowcast-family {
-      display: block; color: var(--text-muted); font-size: 10px; font-weight: 700;
-      letter-spacing: .11em; text-transform: uppercase;
-    }
-    .china-nowcast-summary h3, .china-nowcast-official h4,
-    .china-nowcast-contribution h4, .china-nowcast-method h4 { margin: 4px 0; }
-    .china-nowcast-summary p, .china-nowcast-official p,
-    .china-nowcast-contribution p, .china-nowcast-method p {
-      margin: 5px 0; color: var(--text-secondary); line-height: 1.45;
-    }
-    .china-nowcast-confidence { display: grid; gap: 3px; padding: 10px; background: var(--surface-hover); }
-    .china-nowcast-confidence > span {
-      width: max-content; padding: 2px 7px; border: 1px solid currentColor;
-      color: var(--text-secondary); font-size: 10px; text-transform: uppercase;
-    }
-    .china-nowcast-confidence small { color: var(--text-muted); line-height: 1.35; }
-    .china-nowcast-official { padding: 12px 14px; }
-    .china-nowcast-official dl, .china-nowcast-contribution dl { margin: 8px 0 0; }
-    .china-nowcast-official dl { display: flex; flex-wrap: wrap; gap: 8px 18px; }
-    .china-nowcast-official dl div, .china-nowcast-contribution dl div { min-width: 0; }
-    .china-nowcast-official dt, .china-nowcast-contribution dt {
-      color: var(--text-muted); font-size: 10px; text-transform: uppercase;
-    }
-    .china-nowcast-official dd, .china-nowcast-contribution dd {
-      margin: 2px 0 0; overflow-wrap: anywhere; color: var(--text-secondary);
-    }
-    .china-nowcast-contributions {
-      display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px;
-    }
-    .china-nowcast-contribution {
-      min-width: 0; padding: 11px; border: 1px solid var(--border-color);
-      background: var(--surface-bg, var(--panel-bg));
-    }
-    .china-nowcast-contribution--strengthening { border-top: 2px solid var(--success-color, #45bd7d); }
-    .china-nowcast-contribution--weakening { border-top: 2px solid var(--danger-color, #df6969); }
-    .china-nowcast-contribution--unchanged { border-top: 2px solid #8f7bd6; }
-    .china-nowcast-contribution--excluded { border-top: 2px solid var(--text-muted); opacity: .86; }
-    .china-nowcast-contribution__heading {
-      display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; align-items: start;
-    }
-    .china-nowcast-contribution__state {
-      max-width: 190px; color: var(--text-secondary); font-size: 11px; text-align: right;
-    }
-    .china-nowcast-contribution dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px 12px; }
-    .china-nowcast-contribution a { color: var(--accent-color); }
-    .china-nowcast-method summary {
-      padding: 11px 13px; cursor: pointer; font-weight: 650; color: var(--text-secondary);
-    }
-    .china-nowcast-method__grid {
-      display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 14px; padding: 0 13px 13px;
-    }
-    .china-nowcast-method ul { margin: 7px 0 0; padding-left: 18px; color: var(--text-secondary); }
-    .china-nowcast-method li { margin: 4px 0; line-height: 1.4; }
-    .china-nowcast-method li span { display: block; color: var(--text-muted); font-size: 11px; }
-    @media (max-width: 720px) {
-      .china-nowcast-summary, .china-nowcast-contributions,
-      .china-nowcast-method__grid { grid-template-columns: minmax(0, 1fr); }
-      .china-nowcast-contribution__heading { grid-template-columns: minmax(0, 1fr); }
-      .china-nowcast-contribution__state { max-width: none; text-align: left; }
-    }
-  `;
-  document.head.appendChild(style);
-}
-
 export class ChinaActivityNowcastPanel extends Panel {
   private response: ChinaActivityNowcastResponse | null = null;
 
@@ -101,7 +15,6 @@ export class ChinaActivityNowcastPanel extends Panel {
       defaultRowSpan: 2,
       infoTooltip: 'A deterministic directional comparison of revision-aware official activity and reviewed proxy families. Missing and stale inputs are excluded; this is not a replacement GDP estimate.',
     });
-    injectStyles();
   }
 
   public async fetchData(): Promise<boolean> {

--- a/src/components/ChinaCorridorPanel.ts
+++ b/src/components/ChinaCorridorPanel.ts
@@ -99,48 +99,6 @@ function conditionHtml(condition: ChinaCorridorCondition): string {
     </article>`;
 }
 
-function injectStyles(): void {
-  if (document.getElementById('china-corridor-panel-styles')) return;
-  const style = document.createElement('style');
-  style.id = 'china-corridor-panel-styles';
-  style.textContent = `
-    .china-corridor-panel { display: grid; gap: 12px; min-width: 0; }
-    .china-corridor-compare { display: grid; grid-template-columns: repeat(auto-fit,minmax(150px,1fr)); gap: 8px; }
-    .china-corridor-compare button { min-height: 64px; text-align: left; padding: 8px; color: var(--text); background: color-mix(in srgb,var(--panel-bg) 80%,transparent); border: 1px solid var(--border); border-radius: 6px; cursor: pointer; }
-    .china-corridor-compare button[aria-selected="true"] { border-color: var(--accent); box-shadow: inset 0 0 0 1px var(--accent); }
-    .china-corridor-compare strong,.china-corridor-compare small { display: block; }
-    .china-corridor-compare small { margin-top: 4px; color: var(--text-dim); }
-    .china-corridor-filters { display: flex; flex-wrap: wrap; gap: 6px; }
-    .china-corridor-filters button { min-height: 36px; padding: 5px 9px; border: 1px solid var(--border); border-radius: 999px; background: transparent; color: var(--text-dim); cursor: pointer; }
-    .china-corridor-filters button[aria-pressed="true"] { color: var(--text); border-color: var(--accent); background: color-mix(in srgb,var(--accent) 14%,transparent); }
-    .china-corridor-detail__heading { display: flex; justify-content: space-between; align-items: flex-start; gap: 10px; }
-    .china-corridor-detail__heading h3 { margin: 0; font-size: 14px; }
-    .china-corridor-description { margin: 4px 0 0; color: var(--text-dim); font-size: 11px; line-height: 1.45; }
-    .china-corridor-conditions { display: grid; grid-template-columns: repeat(auto-fit,minmax(210px,1fr)); gap: 8px; margin-top: 10px; }
-    .china-corridor-condition { min-width: 0; padding: 9px; border: 1px solid var(--border); border-radius: 6px; }
-    .china-corridor-condition header { display: flex; justify-content: space-between; gap: 8px; align-items: center; }
-    .china-corridor-condition h4 { margin: 0; font-size: 12px; }
-    .china-corridor-status { font: 700 9px/1 var(--font-mono); letter-spacing: .05em; text-transform: uppercase; }
-    .china-corridor-status--available { color: #39c77a; }
-    .china-corridor-status--partial,.china-corridor-status--stale { color: #e5a742; }
-    .china-corridor-status--unavailable { color: var(--text-dim); }
-    .china-corridor-provider { margin-top: 5px; color: var(--text-dim); font-size: 9px; overflow-wrap: anywhere; }
-    .china-corridor-sources { list-style: none; padding: 0; margin: 8px 0 0; display: grid; gap: 7px; }
-    .china-corridor-source { padding-top: 7px; border-top: 1px solid var(--border); }
-    .china-corridor-source__summary { font-size: 11px; line-height: 1.4; overflow-wrap: anywhere; }
-    .china-corridor-source__meta { display: flex; flex-wrap: wrap; gap: 3px 8px; margin-top: 5px; color: var(--text-dim); font-size: 9px; overflow-wrap: anywhere; }
-    .china-corridor-source__meta a { color: var(--accent); }
-    .china-corridor-missing { margin: 8px 0 0; color: var(--text-dim); font-size: 11px; line-height: 1.4; }
-    .china-corridor-renderer-hint { margin: 8px 0 0; color: var(--warning); font-size: 11px; line-height: 1.4; }
-    @media (max-width: 520px) {
-      .china-corridor-compare { grid-template-columns: 1fr 1fr; }
-      .china-corridor-conditions { grid-template-columns: 1fr; }
-      .china-corridor-detail__heading { display: block; }
-    }
-  `;
-  document.head.appendChild(style);
-}
-
 export class ChinaCorridorPanel extends Panel {
   private response: ChinaCorridorControlTowerResponse = { generatedAt: '', corridors: [] };
   private selectedId: ChinaLogisticsCorridorId | null = null;
@@ -156,7 +114,6 @@ export class ChinaCorridorPanel extends Panel {
       defaultRowSpan: 2,
       infoTooltip: 'Transparent control towers for four reviewed China logistics corridors. Each condition retains its own source, time, availability, and freshness; no aggregate risk score is produced.',
     });
-    injectStyles();
     this.content.addEventListener('click', (event) => this.handleClick(event));
     this.content.addEventListener('keydown', (event) => this.handleKeydown(event));
   }
@@ -251,7 +208,7 @@ export class ChinaCorridorPanel extends Panel {
       </button>`;
     }).join('');
     const filters = CHINA_CORRIDOR_SIGNAL_FAMILIES.map((family) =>
-      `<button type="button" data-family-filter="${family}" aria-pressed="${this.selectedFamilies.has(family)}">${escapeHtml(FAMILY_LABELS[family])}</button>`,
+      `<button type="button" class="panel-tab china-corridor-filter${this.selectedFamilies.has(family) ? ' active' : ''}" data-family-filter="${family}" aria-pressed="${this.selectedFamilies.has(family)}">${escapeHtml(FAMILY_LABELS[family])}</button>`,
     ).join('');
     const conditions = selected.conditions
       .filter((condition) => this.selectedFamilies.has(condition.family))
@@ -261,7 +218,7 @@ export class ChinaCorridorPanel extends Panel {
     this.setSafeContent(unsafeRawHtml(`
       <div class="china-corridor-panel">
         <div class="china-corridor-compare" role="tablist" aria-label="Compare China logistics corridors">${compare}</div>
-        <div class="china-corridor-filters" role="group" aria-label="Signal-family filters">${filters}</div>
+        <div class="panel-tabs china-corridor-filters" role="group" aria-label="Signal-family filters">${filters}</div>
         <section id="china-corridor-tabpanel" role="tabpanel" aria-labelledby="china-corridor-tab-${selected.id}">
           <div class="china-corridor-detail__heading">
             <div>

--- a/src/components/MacroTilesPanel.ts
+++ b/src/components/MacroTilesPanel.ts
@@ -68,10 +68,9 @@ function lastTwo(obs: { date: string; value: number }[]): { value: number | null
   return { value: last.value, prior: prev?.value ?? null, date: last.date };
 }
 
-function deltaColor(delta: number, lowerIsBetter: boolean, neutral: boolean): string {
-  if (neutral) return 'var(--text-dim)';
-  if (delta === 0) return 'var(--text-dim)';
-  return (lowerIsBetter ? delta < 0 : delta > 0) ? '#27ae60' : '#e74c3c';
+function deltaClass(delta: number, lowerIsBetter: boolean, neutral: boolean): string {
+  if (neutral || delta === 0) return 'neutral';
+  return (lowerIsBetter ? delta < 0 : delta > 0) ? 'positive' : 'negative';
 }
 
 function tileHtml(tile: MacroTile): string {
@@ -79,12 +78,14 @@ function tileHtml(tile: MacroTile): string {
   const delta = tile.value !== null && tile.prior !== null ? tile.value - tile.prior : null;
   const fmt = tile.deltaFormat ?? tile.format;
   const deltaStr = delta !== null ? `${delta >= 0 ? '+' : ''}${fmt(delta)} vs prior` : '';
-  const color = delta !== null ? deltaColor(delta, tile.lowerIsBetter, tile.neutral ?? false) : 'var(--text-dim)';
-  return `<div style="background:rgba(255,255,255,0.03);border:1px solid var(--border);border-radius:6px;padding:14px 12px;display:flex;flex-direction:column;gap:4px">
-    <div style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.07em">${escapeHtml(tile.label)}</div>
-    <div style="font-size:28px;font-weight:700;color:var(--text);line-height:1.1;font-variant-numeric:tabular-nums">${val}</div>
-    ${deltaStr ? `<div style="font-size:11px;color:${color}">${escapeHtml(deltaStr)}</div>` : ''}
-    <div style="font-size:10px;color:var(--text-dim)">${escapeHtml(tile.date)}</div>
+  const changeClass = delta !== null ? deltaClass(delta, tile.lowerIsBetter, tile.neutral ?? false) : 'neutral';
+  return `<div class="macro-summary-card">
+    <div class="macro-summary-head">
+      <span class="indicator-name">${escapeHtml(tile.label)}</span>
+    </div>
+    <div class="macro-summary-value">${val}</div>
+    ${deltaStr ? `<div class="macro-summary-change ${changeClass}">${escapeHtml(deltaStr)}</div>` : ''}
+    <div class="indicator-date">${escapeHtml(tile.date)}</div>
   </div>`;
 }
 
@@ -224,13 +225,13 @@ export class MacroTilesPanel extends Panel {
   private _render(afterUpdate?: () => void): void {
     const tabs = this._availableTabs();
     const labels: Record<Tab, string> = { us: 'US', eu: 'Euro Area', cn: 'China' };
-    const tabBar = `<div role="tablist" aria-label="Macro economy" style="display:flex;gap:4px;margin-bottom:10px;overflow-x:auto">
-      ${tabs.map((tab) => `<button id="macro-tiles-tab-${tab}" role="tab" aria-selected="${this._tab === tab}" aria-controls="macro-tiles-tabpanel" tabindex="${this._tab === tab ? '0' : '-1'}" class="panel-tab${this._tab === tab ? ' active' : ''}" data-tab="${tab}" style="font-size:11px;padding:6px 10px;min-height:44px">${labels[tab]}</button>`).join('')}
+    const tabBar = `<div class="panel-tabs macro-tiles-tabs" role="tablist" aria-label="Macro economy">
+      ${tabs.map((tab) => `<button type="button" id="macro-tiles-tab-${tab}" role="tab" aria-selected="${this._tab === tab}" aria-controls="macro-tiles-tabpanel" tabindex="${this._tab === tab ? '0' : '-1'}" class="panel-tab${this._tab === tab ? ' active' : ''}" data-tab="${tab}">${labels[tab]}</button>`).join('')}
     </div>`;
 
     let body: string;
     if (this._tab === 'us') {
-      body = `<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:10px">${this._usTiles.map(tileHtml).join('')}</div>`;
+      body = `<div class="macro-summary-grid">${this._usTiles.map(tileHtml).join('')}</div>`;
     } else if (this._tab === 'eu') {
       body = this._buildEuBody();
     } else {
@@ -239,7 +240,7 @@ export class MacroTilesPanel extends Panel {
 
     const labelledBy = `macro-tiles-tab-${this._tab}`;
     this.setSafeContent(
-      unsafeRawHtml(`${tabBar}<div id="macro-tiles-tabpanel" role="tabpanel" aria-labelledby="${labelledBy}">${body}</div>`, 'legacy Panel.setContent() migration'),
+      unsafeRawHtml(`${tabBar}<div id="macro-tiles-tabpanel" class="macro-tiles-tabpanel" role="tabpanel" aria-labelledby="${labelledBy}">${body}</div>`, 'legacy Panel.setContent() migration'),
       afterUpdate,
     );
   }
@@ -250,11 +251,11 @@ export class MacroTilesPanel extends Panel {
 
   private _buildChinaBody(): string {
     if (!hasChinaMacroData(this._china) || !this._china) {
-      return '<div style="padding:8px;color:var(--text-dim);font-size:12px">China macro data unavailable</div>';
+      return '<div class="macro-summary-empty">China macro data unavailable</div>';
     }
     const quality = isChinaLaunchReady(this._china)
       ? ''
-      : '<div style="margin-bottom:8px;padding:7px 9px;border:1px solid #f39c12;border-radius:5px;color:#f39c12;font-size:10px">Official China macro pulse is degraded; stale or delayed observations remain visible below.</div>';
+      : '<div class="macro-quality-note macro-quality-note--degraded" role="status">Official China macro pulse is degraded; stale or delayed observations remain visible below.</div>';
     const tiles = this._china.indicators.map(chinaTileHtml).join('');
     const today = new Date().toISOString().slice(0, 10);
     const events = this._china.releaseEvents
@@ -262,17 +263,17 @@ export class MacroTilesPanel extends Panel {
       .sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))
       .slice(0, 3);
     const calendar = events.length > 0
-      ? `<div style="margin-top:10px;border-top:1px solid var(--border);padding-top:8px">
-          <div style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.07em;margin-bottom:5px">China release calendar</div>
-          ${events.map((event) => `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;color:var(--text-dim);margin-top:3px"><span>${escapeHtml(event.event)}</span><span>${escapeHtml(event.releaseDate)} · ${escapeHtml(event.status)}</span></div>`).join('')}
-        </div>`
-      : '<div style="margin-top:8px;font-size:10px;color:var(--text-dim)">China release calendar unavailable</div>';
-    return `${quality}<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:10px">${tiles}</div>${calendar}`;
+      ? `<section class="macro-release-calendar" aria-label="China release calendar">
+          <div class="macro-release-calendar__heading">China release calendar</div>
+          ${events.map((event) => `<div class="macro-release-calendar__event"><span>${escapeHtml(event.event)}</span><span>${escapeHtml(event.releaseDate)} · ${escapeHtml(event.status)}</span></div>`).join('')}
+        </section>`
+      : '<div class="macro-release-calendar__empty">China release calendar unavailable</div>';
+    return `${quality}<div class="macro-summary-grid macro-summary-grid--china">${tiles}</div>${calendar}`;
   }
 
   private _buildEuBody(): string {
     if (!this._eurostat) {
-      return '<div style="padding:8px;color:var(--text-dim);font-size:12px">Euro Area data unavailable</div>';
+      return '<div class="macro-summary-empty">Euro Area data unavailable</div>';
     }
     const cpiAvg = euAvg(this._eurostat, 'cpi');
     const unAvg = euAvg(this._eurostat, 'unemployment');
@@ -287,10 +288,10 @@ export class MacroTilesPanel extends Panel {
     ];
 
     if (!euTiles.some(t => t.value !== null)) {
-      return '<div style="padding:8px;color:var(--text-dim);font-size:12px">Euro Area data unavailable</div>';
+      return '<div class="macro-summary-empty">Euro Area data unavailable</div>';
     }
 
-    return `<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(130px,1fr));gap:10px">${euTiles.map(tileHtml).join('')}</div>
-      <div style="margin-top:8px;font-size:9px;color:var(--text-dim)">Eurostat · ECB · avg DE, FR, IT, ES</div>`;
+    return `<div class="macro-summary-grid">${euTiles.map(tileHtml).join('')}</div>
+      <div class="economic-source macro-summary-source">Eurostat · ECB · avg DE, FR, IT, ES</div>`;
   }
 }

--- a/src/components/macro-tiles-china.ts
+++ b/src/components/macro-tiles-china.ts
@@ -23,6 +23,42 @@ function chinaValueFmt(indicator: ChinaMacroIndicator, value: number): string {
   return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}${indicator.unit ? ` ${indicator.unit}` : ''}`;
 }
 
+const CHINA_STATE_LABELS: Record<string, string> = {
+  LIVE: 'Live',
+  STALE: 'Stale',
+  UNAVAILABLE: 'Unavailable',
+  strengthening: 'Strengthening',
+  weakening: 'Weakening',
+  unchanged: 'Unchanged',
+  ROBOTS_DISALLOW: 'Source blocked',
+  TLS_CERTIFICATE_ERROR: 'Source unavailable',
+  HTTP_429: 'Rate limited',
+  HTTP_503: 'Source unavailable',
+  SCHEMA_DRIFT: 'Schema mismatch',
+  STALE_OBSERVATION: 'Observation stale',
+  TRANSPORT_STALE: 'Transport stale',
+  TRANSPORT_RECOVERING: 'Transport recovering',
+  TRANSPORT_MISSING: 'Transport unavailable',
+};
+
+function chinaStateLabel(state: string): string {
+  return CHINA_STATE_LABELS[state]
+    ?? state.toLowerCase().replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function chinaStateTone(
+  state: string,
+  available: boolean,
+  stale: boolean,
+): 'positive' | 'warning' | 'negative' | 'neutral' {
+  if (stale || state === 'STALE_OBSERVATION' || state === 'TRANSPORT_STALE') return 'warning';
+  if (!available || state === 'UNAVAILABLE' || state === 'ROBOTS_DISALLOW' || state === 'TLS_CERTIFICATE_ERROR') return 'negative';
+  if (state === 'weakening' || state === 'HTTP_429' || state === 'HTTP_503' || state === 'SCHEMA_DRIFT') return 'negative';
+  if (state === 'TRANSPORT_RECOVERING' || state === 'TRANSPORT_MISSING') return 'warning';
+  if (state === 'unchanged') return 'neutral';
+  return 'positive';
+}
+
 export function chinaTileHtml(indicator: ChinaMacroIndicator): string {
   const available = indicator.hasValue && Number.isFinite(indicator.value);
   const value = available ? escapeHtml(chinaValueFmt(indicator, indicator.value)) : 'N/A';
@@ -42,33 +78,25 @@ export function chinaTileHtml(indicator: ChinaMacroIndicator): string {
       || direction
       || (available ? 'LIVE' : 'UNAVAILABLE')
     );
-  const stateColor = indicator.stale
-    ? '#f39c12'
-    : (
-      indicator.unavailableReason
-      || indicator.transportFailureReason
-      || transportProblem
-      || !available
-      || indicator.direction === 'weakening'
-      ? '#e74c3c'
-      : indicator.direction === 'unchanged'
-        ? 'var(--text-dim)'
-        : '#27ae60'
-    );
   const observed = indicator.observationPeriod || 'No observation period';
   const released = indicator.releaseTime || 'Release time unavailable';
   const revision = indicator.revisionState || 'Revision state unavailable';
   const source = indicator.source || 'Source unavailable';
+  const stateLabel = chinaStateLabel(state);
+  const stateTone = chinaStateTone(state, available, indicator.stale);
+  const valueClass = available ? '' : ' macro-summary-value--unavailable';
 
-  return `<div style="background:rgba(255,255,255,0.03);border:1px solid var(--border);border-radius:6px;padding:14px 12px;display:flex;flex-direction:column;gap:4px;min-width:0">
-    <div style="display:flex;justify-content:space-between;gap:6px;align-items:flex-start">
-      <div style="font-size:10px;color:var(--text-dim);text-transform:uppercase;letter-spacing:0.07em">${escapeHtml(indicator.label)}</div>
-      <span style="font-size:9px;color:${stateColor};font-weight:600">${escapeHtml(state.replace(/_/g, ' '))}</span>
+  return `<div class="macro-summary-card">
+    <div class="macro-summary-head">
+      <span class="indicator-name">${escapeHtml(indicator.label)}</span>
+      <span class="macro-summary-state macro-summary-state--${stateTone}" data-state="${escapeHtml(state)}">${escapeHtml(stateLabel)}</span>
     </div>
-    <div style="font-size:28px;font-weight:700;color:var(--text);line-height:1.1;font-variant-numeric:tabular-nums">${value}</div>
-    <div style="font-size:10px;color:var(--text-dim)">Period ${escapeHtml(observed)} · ${escapeHtml(indicator.periodKind || 'period unknown').replace(/_/g, ' ')}</div>
-    <div style="font-size:10px;color:var(--text-dim)">Released ${escapeHtml(released)} · ${escapeHtml(revision).replace(/_/g, ' ')}</div>
-    <div style="font-size:9px;color:var(--text-dim);overflow-wrap:anywhere">Source: ${escapeHtml(source)}</div>
+    <div class="macro-summary-value${valueClass}">${value}</div>
+    <div class="macro-summary-meta">
+      <span>Period ${escapeHtml(observed)} · ${escapeHtml(indicator.periodKind || 'period unknown').replace(/_/g, ' ')}</span>
+      <span>Released ${escapeHtml(released)} · ${escapeHtml(revision).replace(/_/g, ' ')}</span>
+    </div>
+    <div class="macro-summary-source">Source: ${escapeHtml(source)}</div>
   </div>`;
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -10692,6 +10692,10 @@ a.prediction-link:hover {
   gap: 8px;
 }
 
+.macro-tiles-tabpanel .macro-summary-grid {
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
 .macro-summary-card,
 .energy-summary-card {
   display: flex;
@@ -10735,6 +10739,122 @@ a.prediction-link:hover {
 .macro-summary-change.neutral,
 .energy-summary-change.neutral {
   color: var(--text-dim);
+}
+
+.macro-summary-value--unavailable {
+  color: var(--text-dim);
+}
+
+.macro-summary-state {
+  flex: 0 0 auto;
+  color: var(--text-dim);
+  font: 600 9px/1.2 var(--font-mono, monospace);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  text-align: right;
+}
+
+.macro-summary-state--positive {
+  color: var(--semantic-normal);
+}
+
+.macro-summary-state--warning {
+  color: var(--semantic-elevated);
+}
+
+.macro-summary-state--negative {
+  color: var(--semantic-critical);
+}
+
+.macro-summary-state--neutral {
+  color: var(--text-dim);
+}
+
+.macro-summary-meta,
+.macro-summary-source {
+  color: var(--text-dim);
+  font-size: 9px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.macro-summary-meta {
+  display: grid;
+  gap: 2px;
+}
+
+.macro-summary-source {
+  margin-top: auto;
+}
+
+.macro-summary-empty {
+  padding: 8px;
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.macro-quality-note {
+  margin-bottom: 8px;
+  padding: 7px 9px;
+  border: 1px solid color-mix(in srgb, var(--semantic-elevated) 55%, var(--border));
+  background: color-mix(in srgb, var(--semantic-elevated) 7%, transparent);
+  color: var(--semantic-elevated);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.macro-release-calendar {
+  display: grid;
+  gap: 3px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.macro-release-calendar__heading {
+  margin-bottom: 2px;
+  color: var(--text-dim);
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.macro-release-calendar__event {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text-dim);
+  font-size: 9px;
+  line-height: 1.3;
+}
+
+.macro-release-calendar__event span:first-child {
+  color: var(--text-secondary);
+}
+
+.macro-release-calendar__empty {
+  margin-top: 8px;
+  color: var(--text-dim);
+  font-size: 9px;
+}
+
+@media (max-width: 420px) {
+  .macro-tiles-tabpanel .macro-summary-head {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .macro-summary-state {
+    max-width: none;
+    text-align: left;
+  }
+
+  .macro-release-calendar__event {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 1px;
+  }
 }
 
 .energy-unit {

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -84,6 +84,534 @@
 }
 
 /* ----------------------------------------------------------
+   China Intelligence Panels
+   Keep the China surfaces on the same compact, source-led rhythm
+   as the rest of the dashboard. The panels still expose their
+   methodology, but operational state leads the reading order.
+   ---------------------------------------------------------- */
+.china-corridor-panel,
+.china-nowcast-view {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  color: var(--text);
+}
+
+.panel-content:has(.china-corridor-panel) {
+  padding-top: 8px;
+}
+
+.panel-content > .china-corridor-panel:has(.china-corridor-filters) {
+  margin-inline: 0;
+}
+
+.china-corridor-compare {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.china-corridor-compare button {
+  display: block;
+  min-width: 0;
+  min-height: 56px;
+  padding: 8px;
+  text-align: left;
+  color: var(--text);
+  font: inherit;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition-property: background-color, border-color, box-shadow;
+  transition-duration: 150ms;
+  transition-timing-function: ease-out;
+}
+
+.china-corridor-compare button:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+}
+
+.china-corridor-compare button[aria-selected="true"] {
+  padding-left: 7px;
+  border-left: 2px solid var(--accent);
+  border-color: var(--accent);
+  background: var(--overlay-subtle);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.china-corridor-compare strong,
+.china-corridor-compare small {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.china-corridor-compare strong {
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.china-corridor-compare small {
+  margin-top: 4px;
+  color: var(--text-dim);
+  font-size: 9px;
+  line-height: 1.25;
+}
+
+.china-corridor-filters.panel-tabs {
+  min-width: 0;
+  padding: 2px 0 0;
+  background: transparent;
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
+.china-corridor-filter.panel-tab {
+  min-height: 32px;
+  padding: 6px 9px;
+  font-size: 10px;
+  transition-property: color, background-color, border-color;
+}
+
+.china-corridor-detail__heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 2px 0 7px;
+  border-bottom: 1px solid var(--border);
+}
+
+.china-corridor-detail__heading h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.china-corridor-description {
+  max-width: 72ch;
+  margin: 4px 0 0;
+  color: var(--text-dim);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.china-corridor-status {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  min-height: 18px;
+  padding: 2px 6px;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  font: 700 9px/1 var(--font-mono);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.china-corridor-status--available {
+  color: var(--semantic-normal);
+}
+
+.china-corridor-status--partial,
+.china-corridor-status--stale {
+  color: var(--semantic-elevated);
+}
+
+.china-corridor-status--unavailable {
+  color: var(--text-dim);
+}
+
+.china-corridor-renderer-hint {
+  margin: 0;
+  padding: 6px 8px;
+  color: var(--semantic-elevated);
+  font-size: 10px;
+  line-height: 1.4;
+  background: color-mix(in srgb, var(--semantic-elevated) 8%, transparent);
+  border-left: 2px solid var(--semantic-elevated);
+}
+
+.china-corridor-conditions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 6px;
+  margin-top: 7px;
+}
+
+.china-corridor-condition {
+  min-width: 0;
+  padding: 8px;
+  background: var(--overlay-subtle);
+  border: 1px solid var(--border);
+  border-left: 2px solid var(--border);
+  border-radius: 3px;
+}
+
+.china-corridor-condition[data-availability="available"] {
+  border-left-color: var(--semantic-normal);
+}
+
+.china-corridor-condition[data-availability="partial"],
+.china-corridor-condition[data-availability="stale"] {
+  border-left-color: var(--semantic-elevated);
+}
+
+.china-corridor-condition[data-availability="unavailable"] {
+  border-left-color: var(--text-dim);
+}
+
+.china-corridor-condition header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.china-corridor-condition h4 {
+  margin: 0;
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.china-corridor-provider {
+  margin-top: 5px;
+  color: var(--text-dim);
+  font-size: 9px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.china-corridor-sources {
+  display: grid;
+  gap: 6px;
+  margin: 7px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.china-corridor-source {
+  padding-top: 6px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.china-corridor-source__summary {
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.china-corridor-source__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 7px;
+  margin-top: 4px;
+  color: var(--text-dim);
+  font-size: 8px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.china-corridor-source__meta a {
+  color: var(--accent);
+}
+
+.china-corridor-missing {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: 8px;
+  color: var(--text-dim);
+  font-size: 10px;
+  line-height: 1.4;
+  background: var(--overlay-subtle);
+  border-left: 2px solid var(--border);
+}
+
+.china-nowcast-summary,
+.china-nowcast-official,
+.china-nowcast-method {
+  border: 1px solid var(--border);
+  background: var(--overlay-subtle);
+}
+
+.china-nowcast-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(170px, .38fr);
+  gap: 10px;
+  align-items: center;
+  padding: 10px 12px;
+  border-left: 3px solid var(--text-muted);
+}
+
+.china-nowcast-summary--agreement {
+  border-left-color: var(--semantic-normal);
+}
+
+.china-nowcast-summary--proxy_leading_divergence,
+.china-nowcast-summary--official_leading_divergence {
+  border-left-color: var(--semantic-elevated);
+}
+
+.china-nowcast-summary--mixed_signals {
+  border-left-color: var(--semantic-info);
+}
+
+.china-nowcast-summary--insufficient_data {
+  border-left-color: var(--text-muted);
+}
+
+.china-nowcast-eyebrow,
+.china-nowcast-family {
+  display: block;
+  color: var(--text-dim);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: .08em;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.china-nowcast-summary h3 {
+  margin: 3px 0 0;
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.china-nowcast-summary p,
+.china-nowcast-official p,
+.china-nowcast-contribution p,
+.china-nowcast-method p {
+  margin: 5px 0 0;
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.china-nowcast-confidence {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+  padding: 7px 9px;
+  background: var(--surface-hover);
+  border-left: 2px solid var(--border-strong);
+}
+
+.china-nowcast-confidence > span {
+  width: max-content;
+  padding: 2px 6px;
+  color: var(--text-secondary);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  border: 1px solid currentColor;
+}
+
+.china-nowcast-confidence strong {
+  color: var(--text);
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.china-nowcast-confidence small {
+  color: var(--text-dim);
+  font-size: 9px;
+  line-height: 1.3;
+}
+
+.china-nowcast-official {
+  padding: 9px 11px;
+  border-left: 2px solid var(--accent);
+}
+
+.china-nowcast-official h4,
+.china-nowcast-contribution h4,
+.china-nowcast-method h4 {
+  margin: 3px 0 0;
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.china-nowcast-official dl,
+.china-nowcast-contribution dl {
+  margin: 7px 0 0;
+}
+
+.china-nowcast-official dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 7px 14px;
+}
+
+.china-nowcast-official dl div,
+.china-nowcast-contribution dl div {
+  min-width: 0;
+}
+
+.china-nowcast-official dt,
+.china-nowcast-contribution dt {
+  color: var(--text-dim);
+  font-size: 8px;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.china-nowcast-official dd,
+.china-nowcast-contribution dd {
+  margin: 2px 0 0;
+  color: var(--text-secondary);
+  font-size: 9px;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.china-nowcast-contributions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.china-nowcast-contribution {
+  min-width: 0;
+  padding: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 2px solid var(--border);
+  border-radius: 3px;
+}
+
+.china-nowcast-contribution--strengthening {
+  border-left-color: var(--semantic-normal);
+}
+
+.china-nowcast-contribution--weakening {
+  border-left-color: var(--semantic-critical);
+}
+
+.china-nowcast-contribution--unchanged {
+  border-left-color: var(--semantic-info);
+}
+
+.china-nowcast-contribution--excluded {
+  border-left-color: var(--text-muted);
+  opacity: .82;
+}
+
+.china-nowcast-contribution__heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, .9fr);
+  gap: 7px;
+  align-items: start;
+}
+
+.china-nowcast-contribution__state {
+  color: var(--text-secondary);
+  font-size: 9px;
+  line-height: 1.3;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.china-nowcast-contribution dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px 10px;
+}
+
+.china-nowcast-contribution a {
+  color: var(--accent);
+}
+
+.china-nowcast-method {
+  overflow: hidden;
+}
+
+.china-nowcast-method summary {
+  padding: 8px 10px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.china-nowcast-method__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  padding: 0 10px 10px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.china-nowcast-method ul {
+  margin: 6px 0 0;
+  padding-left: 16px;
+  color: var(--text-secondary);
+  font-size: 9px;
+}
+
+.china-nowcast-method li {
+  margin: 3px 0;
+  line-height: 1.35;
+}
+
+.china-nowcast-method li span {
+  display: block;
+  color: var(--text-dim);
+  font-size: 9px;
+}
+
+@media (max-width: 900px) {
+  .china-corridor-compare {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .china-nowcast-contributions,
+  .china-nowcast-method__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .china-corridor-detail__heading {
+    display: block;
+  }
+
+  .china-corridor-detail__heading .china-corridor-status {
+    margin-top: 6px;
+  }
+
+  .china-nowcast-summary,
+  .china-nowcast-contributions,
+  .china-nowcast-method__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .china-nowcast-contribution__heading {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .china-nowcast-contribution__state {
+    text-align: left;
+  }
+
+  .china-nowcast-official dl {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+/* ----------------------------------------------------------
    Satellite Fires Panel
    ---------------------------------------------------------- */
 .fires-panel-content {

--- a/tests/macro-tiles-china-ui.test.mts
+++ b/tests/macro-tiles-china-ui.test.mts
@@ -80,7 +80,10 @@ describe('MacroTilesPanel China launch surface', () => {
     assert.match(html, /Released 2026-07-16T02:00:00\.000Z/);
     assert.match(html, /original/);
     assert.match(html, /National Bureau of Statistics of China/);
-    assert.match(html, />strengthening<\/span>/i);
+    assert.match(html, /class="macro-summary-card"/);
+    assert.match(html, /class="macro-summary-state macro-summary-state--positive"/);
+    assert.match(html, /data-state="strengthening">Strengthening<\/span>/);
+    assert.doesNotMatch(html, /style=/);
 
     const settlement = normalized.indicators.find(
       (indicator) => indicator.id === 'safe_bank_fx_settlement',
@@ -89,8 +92,8 @@ describe('MacroTilesPanel China launch surface', () => {
     assert.equal(settlement.hasValue, true);
     assert.equal(settlement.direction, 'unavailable');
     const settlementHtml = chinaTileHtml(settlement);
-    assert.match(settlementHtml, />LIVE<\/span>/);
-    assert.doesNotMatch(settlementHtml, />UNAVAILABLE<\/span>/);
+    assert.match(settlementHtml, /data-state="LIVE">Live<\/span>/);
+    assert.doesNotMatch(settlementHtml, /data-state="UNAVAILABLE"/);
 
     const unavailableHtml = chinaTileHtml({
       ...industrial,
@@ -100,7 +103,8 @@ describe('MacroTilesPanel China launch surface', () => {
       transportStatus: 'blocked',
     });
     assert.match(unavailableHtml, /N\/A/);
-    assert.match(unavailableHtml, /ROBOTS DISALLOW/);
+    assert.match(unavailableHtml, /Source blocked/);
+    assert.match(unavailableHtml, /data-state="ROBOTS_DISALLOW"/);
   });
 
   it('fails closed when current or vintage #5581 provenance is incomplete', async () => {
@@ -129,7 +133,7 @@ describe('MacroTilesPanel China launch surface', () => {
       JSON.parse(transportLate.indicators[0]?.provenanceJson ?? '').claims.transport_freshness.value.state,
       'stale',
     );
-    assert.match(chinaTileHtml(transportLate.indicators[0]!), /TRANSPORT STALE/);
+    assert.match(chinaTileHtml(transportLate.indicators[0]!), /data-state="TRANSPORT_STALE">Transport stale<\/span>/);
 
     const contentLate = normalizeHydratedChina(
       await buildOfficialChinaMacroFixture(),
@@ -254,7 +258,11 @@ describe('MacroTilesPanel China launch surface', () => {
     assert.match(panelSource, /Home/);
     assert.match(panelSource, /End/);
     assert.match(panelSource, /setSafeContent\([\s\S]*afterUpdate/);
-    assert.match(panelSource, /repeat\(auto-fit,minmax\(130px,1fr\)\)/);
+    assert.match(panelSource, /class="panel-tabs macro-tiles-tabs"/);
+    assert.match(panelSource, /class="macro-summary-grid/);
+    assert.match(panelSource, /class="macro-quality-note macro-quality-note--degraded"/);
+    assert.match(panelSource, /class="macro-release-calendar"/);
+    assert.doesNotMatch(panelSource, /style="/);
     assert.match(panelSource, /China release calendar/);
   });
 });


### PR DESCRIPTION
## Summary

China intelligence panels previously rendered with one-off injected and inline styles, making them look like a separate dashboard. They now use the same compact panel rhythm, tab primitives, semantic tokens, and responsive rules as the rest of WorldMonitor.

## What changed

- Moved Activity Nowcast and Logistics Corridors styling into shared panel CSS and reused the existing panel-tab treatment for signal filters.
- Normalized Macro Indicators across US, Euro Area, and China with shared summary grids/cards, readable state labels, and tokenized degraded/release-calendar styling.
- Added narrow-layout rules so China Macro status labels and calendar entries do not clip.
- Kept raw China transport/content state values available in `data-state`; data availability and launch-gate behavior are unchanged.

## Validation

- `npm run typecheck`
- Focused China/Macro tests: 8 passed.
- `npx impeccable --json --fast src/components/MacroTilesPanel.ts src/components/macro-tiles-china.ts`: no findings.
- China browser suites: 6 passed, including narrow layouts, keyboard navigation, renderer fallbacks, and map boundary rendering.
- Full pre-push gate passed, including changed tests (5/5), edge tests (249/249), boundary/safe-HTML/Unicode checks, and version checks.
- Manually inspected the rendered Macro Indicators panel at desktop and 390px widths.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: China intelligence dashboard panels

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant; local rendered preview verified instead.
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (not applicable).
- [x] No API keys or secrets committed.
- [x] TypeScript compiles without errors (`npm run typecheck`).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-GPT_5-000000)
