### PR TITLE
fix(webcams): fit 2x2 wall to short viewports

### DIFF
--- a/e2e/live-media-intent.spec.ts
+++ b/e2e/live-media-intent.spec.ts
@@ -103,6 +103,69 @@ test.describe('live media intent gating', () => {
     await expect.poll(() => liveNewsTransportCount(page), { timeout: 30_000 }).toBe(1);
   });
 
+  test('fits the natural webcam wall in a short desktop viewport and resizes from its two-row baseline', async ({ page }) => {
+    await page.setViewportSize({ width: 1296, height: 607 });
+    await installCleanLiveMediaPrefs(page, {
+      regionFilter: 'europe',
+      viewMode: 'grid',
+      activeFeedId: 'kyiv',
+    });
+
+    await page.goto('/dashboard?liveWebcamLayout=1', { waitUntil: 'domcontentloaded' });
+    const webcams = page.locator('.panel[data-panel="live-webcams"]');
+    // The dashboard replaces deferred shells with real panels while the page
+    // is settling. Scroll the current node directly, then wait for the real
+    // panel before taking geometry measurements so this regression test does
+    // not race that intentional shell→panel replacement.
+    await page.evaluate(() => {
+      document.querySelector('.panel[data-panel="live-webcams"]')?.scrollIntoView({ block: 'center' });
+    });
+    await page.waitForFunction(() => {
+      const panel = document.querySelector<HTMLElement>('.panel[data-panel="live-webcams"]');
+      return panel !== null && panel.dataset.deferredPanel !== 'true';
+    });
+    await page.evaluate(() => {
+      document.querySelector('.panel[data-panel="live-webcams"]')?.scrollIntoView({ block: 'center' });
+    });
+    await expect(webcams.locator('.webcam-cell')).toHaveCount(4, { timeout: 60_000 });
+
+    const layout = await webcams.evaluate((panel) => {
+      const panelRect = panel.getBoundingClientRect();
+      const grid = panel.querySelector('.webcam-grid');
+      const cells = Array.from(panel.querySelectorAll<HTMLElement>('.webcam-cell')).map((cell) => {
+        const rect = cell.getBoundingClientRect();
+        return { top: rect.top, bottom: rect.bottom, height: rect.height };
+      });
+      return {
+        viewportHeight: window.innerHeight,
+        panelBottom: panelRect.bottom,
+        panelHeight: panelRect.height,
+        gridHeight: grid?.getBoundingClientRect().height ?? 0,
+        cells,
+      };
+    });
+
+    expect(layout.panelHeight, JSON.stringify(layout)).toBeLessThanOrEqual(layout.viewportHeight);
+    expect(layout.gridHeight, JSON.stringify(layout)).toBeGreaterThan(0);
+    expect(layout.cells.every((cell) => cell.height > 0), JSON.stringify(layout)).toBe(true);
+    expect(layout.cells[3]?.bottom, JSON.stringify(layout)).toBeLessThanOrEqual(layout.panelBottom + 2);
+    expect(layout.cells[3]?.bottom, JSON.stringify(layout)).toBeLessThanOrEqual(layout.viewportHeight + 2);
+
+    const handle = webcams.locator('.panel-resize-handle');
+    await handle.evaluate((element) => element.scrollIntoView({ block: 'center' }));
+    const box = await handle.boundingBox();
+    expect(box, 'webcam resize handle should be reachable after fitting the panel').not.toBeNull();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2 + 100);
+    await page.mouse.up();
+
+    await expect(webcams).toHaveClass(/span-3/);
+    await expect(webcams).toHaveClass(/resized/);
+    const resizedHeight = await webcams.evaluate((panel) => panel.getBoundingClientRect().height);
+    expect(resizedHeight, `natural=${layout.panelHeight}, resized=${resizedHeight}`).toBeGreaterThan(layout.panelHeight + 50);
+  });
+
   test('the play-all cascade does not start media in a collapsed live panel', async ({ page }) => {
     await installCleanLiveMediaPrefs(page);
 

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -80,7 +80,12 @@ function getRowSpan(element: HTMLElement): number {
   if (element.classList.contains('span-4')) return 4;
   if (element.classList.contains('span-3')) return 3;
   if (element.classList.contains('span-2')) return 2;
-  return 1;
+  if (element.classList.contains('span-1')) return 1;
+  // A natural wide panel already occupies two dashboard rows even when it
+  // has no explicit span-N class. Treat that footprint as the resize baseline
+  // so the first vertical drag changes the visible height instead of being a
+  // no-op against the existing grid-row: span 2 rule.
+  return element.classList.contains('panel-wide') ? 2 : 1;
 }
 
 function deltaToRowSpan(startSpan: number, deltaY: number): number {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1761,11 +1761,11 @@ canvas,
   height: var(--dashboard-panel-row-max);
 }
 
-/* Offenders that are two-row by default — span-2 defaults and the 2x2
-   .panel-wide pair — get the populated two-row max (2 rows + gap) so their
-   footprint is identical loading vs populated, INCLUDING the deferred-shell
-   phase (the shell carries the same classes, so shell->panel swap is
-   shift-free). The pins apply to NATURAL footprints only: user-resized
+/* Offenders that are two-row by default — span-2 defaults and
+   the .panel-wide live-news panel — get the populated two-row max (2 rows +
+   gap) so its footprint is identical loading vs populated, INCLUDING the
+   deferred-shell phase (the shell carries the same classes, so shell->panel
+   swap is shift-free). The pins apply to NATURAL footprints only: user-resized
    panels (.resized, PR #5333 review P1) and explicit .span-N overrides keep
    the resize contract, and the #panelsGrid scope keeps panels dragged into
    the ultra-wide .map-bottom-grid (height:100%/1fr tracks) on that grid's
@@ -1775,9 +1775,22 @@ canvas,
 #panelsGrid > .panel[data-panel="energy-complex"].span-2:not(.resized),
 #panelsGrid > .panel[data-panel="strategic-posture"].span-2:not(.resized),
 #panelsGrid > .panel[data-panel="global-procurement"].span-2:not(.resized),
-#panelsGrid > .panel[data-panel="live-news"].panel-wide:not(.resized):not(.span-1):not(.span-2):not(.span-3):not(.span-4),
-#panelsGrid > .panel[data-panel="live-webcams"].panel-wide:not(.resized):not(.span-1):not(.span-2):not(.span-3):not(.span-4) {
+#panelsGrid > .panel[data-panel="live-news"].panel-wide:not(.resized):not(.span-1):not(.span-2):not(.span-3):not(.span-4) {
   height: calc(var(--dashboard-panel-row-max) * 2 + var(--dashboard-grid-gap));
+}
+
+/* The webcam wall is a 2x2 viewport surface, not a document-height panel.
+   Keep the CLS reservation on normal/tall windows, but cap the natural
+   footprint on short desktop windows so all four cells remain reachable in
+   the viewport. Explicit user-resized spans retain the normal resize
+   contract. The first-grid reservation prevents the two rows from collapsing
+   below their minimum track height on unusually short viewports. Reserve the
+   sticky dashboard chrome above the scrolled panel as well. */
+#panelsGrid > .panel[data-panel="live-webcams"].panel-wide:not(.resized):not(.span-1):not(.span-2):not(.span-3):not(.span-4) {
+  height: min(
+    calc(var(--dashboard-panel-row-max) * 2 + var(--dashboard-grid-gap)),
+    max(var(--dashboard-first-grid-reservation), calc(100dvh - 64px))
+  );
 }
 
 .panel.span-3 {

--- a/tests/panel-row-stability.test.mjs
+++ b/tests/panel-row-stability.test.mjs
@@ -23,7 +23,8 @@ const SPAN1_KEYS = [
   'live-webcams',
 ];
 const SPAN2_DEFAULT_KEYS = ['threat-timeline', 'gdelt-intel', 'energy-complex', 'strategic-posture', 'global-procurement'];
-const WIDE_KEYS = ['live-news', 'live-webcams'];
+const WIDE_KEYS = ['live-news'];
+const RESPONSIVE_WIDE_KEYS = ['live-webcams'];
 
 // The two pin blocks, extracted by their shared height declarations. Regex
 // anchors on a line START so `min-height:` can never satisfy it (review P2).
@@ -62,6 +63,20 @@ describe('always-full panel row stability (#5332)', () => {
         new RegExp(`#panelsGrid > \\.panel\\[data-panel="${key}"\\]\\.panel-wide:not\\(\\.resized\\):not\\(\\.span-1\\)`),
         `'${key}' uses .panel-wide (2x2), needs the wide pin excluding user-resized span states (review P1: a .panel-wide.span-1.resized panel must NOT stay 764px)`,
       );
+    }
+  });
+
+  it('keeps the natural webcam wall viewport-aware while preserving row minimums', () => {
+    const selector = '#panelsGrid > .panel[data-panel="live-webcams"].panel-wide:not(.resized):not(.span-1):not(.span-2):not(.span-3):not(.span-4)';
+    const start = css.indexOf(selector);
+    assert.notEqual(start, -1, 'live-webcams needs a natural-footprint selector');
+    const block = css.slice(start, css.indexOf('}', start) + 1);
+    assert.match(block, /height:\s*min\(/, 'natural webcam height must be viewport-capped');
+    assert.match(block, /100dvh/, 'webcam height must respond to the dynamic viewport');
+    assert.match(block, /max\(var\(--dashboard-first-grid-reservation\)/, 'webcam height must retain the two-row minimum');
+    for (const key of RESPONSIVE_WIDE_KEYS) {
+      assert.match(block, new RegExp(`data-panel="${key}"`), `'${key}' must use the responsive wide-panel footprint`);
+      assert.match(block, /:not\(\.resized\)/, `'${key}' must preserve explicit user-resized spans`);
     }
   });
 


### PR DESCRIPTION
## Summary

Short desktop windows could show only the top row of the Live Webcams 2×2 wall because the natural `.panel-wide` footprint was fixed at 764px; the panel’s first vertical resize step was also a no-op. The natural webcam panel now caps to the dynamic viewport while retaining a two-row minimum, so all four cells stay reachable, and natural wide panels now resize from their actual two-row baseline.

## Validation

- `npx playwright test e2e/live-media-intent.spec.ts --grep "fits the natural webcam wall"` — passed at 1296×607; verified four visible cells and successful height expansion after drag.
- `npx playwright test e2e/dashboard-cls.spec.ts` — 2 passed.
- `npm run typecheck` — passed.
- Pre-push gates — passed, including the changed tests and 249 edge-function checks.

The broader `e2e/live-media-intent.spec.ts` run still reports six separate lifecycle/media failures in this environment (deferred-shell attachment or media startup); the new layout regression is isolated and green.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-Codex-000000)
