### PR TITLE
fix(health): retire expired on-demand softenings

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -754,36 +754,9 @@ const ON_DEMAND_KEYS = new Set([
   // #scoreEnergy). Do NOT add these labels back to ON_DEMAND_KEYS
   // without revisiting that plan.
   'displacementPrev', // covered by cascade onto current-year displacement; empty most of the year
-  'fxYoy', // TRANSITIONAL (PR #3071): seed-fx-yoy Railway cron deployed manually after merge —
-           // gate as on-demand so a deploy-order race or first-cron-run failure doesn't
-           // fire a CRIT health alarm. Remove from this set after ~7 days of clean
-           // production cron runs (verify via `seed-meta:economic:fx-yoy.fetchedAt`).
-  'hyperliquidFlow', // TRANSITIONAL: seed-hyperliquid-flow runs inside seed-bundle-market-backup on
-                     // Railway; gate as on-demand so initial deploy-order race or first cold-start
-                     // snapshot doesn't CRIT. Remove after ~7 days of clean production cron runs.
-  'chokepointFlowsRelayHeartbeat', // TRANSITIONAL (PR #3133): ais-relay.cjs writes this on the
-                                   // first successful child exit after a deploy. Vercel deploys
-                                   // api/health.js instantly, but Railway rebuild + 6h initial
-                                   // loop interval means the key is absent for up to ~6h post-merge.
-                                   // Gate as on-demand so the deploy window doesn't CRIT. Remove
-                                   // after ~7 days of clean production runs (verify via
-                                   // `relay:heartbeat:chokepoint-flows.fetchedAt`).
-  'climateNewsRelayHeartbeat',     // TRANSITIONAL (PR #3133): same deploy-order rationale.
-                                   // 30min initial loop, so window is shorter but still present.
-                                   // Remove after ~7 days alongside the chokepoint-flows entry.
-  'digestNotifications',           // TRANSITIONAL (PR #4253): seed-digest-notifications.mjs writes
-                                   // `digest:last-run` on the first cron run after deploy. Vercel
-                                   // can publish this health registry before Railway's 30min cron
-                                   // ticks, so gate only the first absent-key window as WARN. Remove
-                                   // after ~7 days of clean `seed-meta:digest:last-run` writes.
-  'eiaPetroleum',                  // TRANSITIONAL: gold-standard migration of /api/eia/petroleum
-                                   // from live Vercel fetch to Redis-reader (seed-bundle-energy-sources
-                                   // daily cron). SEED_META entry above enforces 72h staleness — this
-                                   // ON_DEMAND gate only softens the absent-on-deploy case (Vercel
-                                   // deploys instantly; Railway EIA_API_KEY + first daily tick ~24h
-                                   // behind). STALE_SEED still fires if data goes stale after first seed.
-                                   // Remove from this set after ~7 days of clean cron runs so
-                                   // never-provisioned Railway promotes EMPTY_ON_DEMAND → EMPTY (CRIT).
+  // #6070 retired six expired deployment-order bridges after live producer
+  // verification. Future temporary softening needs an activation marker or an
+  // enforced wall-clock expiry; a prose-only removal reminder is not a control.
   // #5736 deployment-order bridge, activation-gated like chinaCoverage: Vercel
   // ships this registry the moment the PR merges, but the record only exists
   // after the collector's next Railway tick (up to 6h for energy/intelligence).

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -23,6 +23,7 @@ const {
   BOOTSTRAP_KEYS,
   STANDALONE_KEYS,
   SEED_META,
+  ON_DEMAND_KEYS,
 } = __testing__;
 
 const NOW = 1_700_000_000_000;
@@ -755,14 +756,34 @@ test('classifyKey: digestNotifications heartbeat goes stale when the cron stops'
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
-test('classifyKey: digestNotifications missing before first cron run is transitional warn', () => {
-  const entry = classifyKey('digestNotifications', STANDALONE_KEYS.digestNotifications, { allowOnDemand: true },
-    makeCtx({}));
+test('classifyKey: expired transitional producers fail closed when missing or empty', () => {
+  const graduatedNames = [
+    'fxYoy',
+    'hyperliquidFlow',
+    'chokepointFlowsRelayHeartbeat',
+    'climateNewsRelayHeartbeat',
+    'eiaPetroleum',
+    'digestNotifications',
+  ];
 
-  assert.equal(entry.status, 'EMPTY_ON_DEMAND');
-  assert.equal(entry.records, 0);
-  assert.equal(entry.maxStaleMin, 90);
-  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+  for (const name of graduatedNames) {
+    const dataKey = BOOTSTRAP_KEYS[name] ?? STANDALONE_KEYS[name];
+    const seedCfg = SEED_META[name];
+    assert.ok(dataKey, `${name}: data key remains registered`);
+    assert.ok(seedCfg, `${name}: freshness metadata remains registered`);
+    assert.equal(ON_DEMAND_KEYS.has(name), false, `${name}: expired softening must be retired`);
+
+    const missing = classifyKey(name, dataKey, { allowOnDemand: true }, makeCtx({}));
+    assert.equal(missing.status, 'EMPTY', `${name}: a vanished producer output is critical`);
+    assert.equal(STATUS_COUNTS[missing.status], 'crit');
+
+    const empty = classifyKey(name, dataKey, { allowOnDemand: true }, makeCtx({
+      strens: { [dataKey]: 128 },
+      metaValues: { [seedCfg.key]: seedMeta({ recordCount: 0 }) },
+    }));
+    assert.equal(empty.status, 'EMPTY_DATA', `${name}: zero records are critical`);
+    assert.equal(STATUS_COUNTS[empty.status], 'crit');
+  }
 });
 
 test('classifyKey: suppressed retailer-spread (present key, 0 records) while fresh → OK, not EMPTY_DATA', () => {


### PR DESCRIPTION
## Summary

Six warn-only health exceptions had outlived their seven-day deployment bridges by months. Their producers are now established, so missing payloads and zero-record outputs once again fail closed as critical; existing stale, seed-error, and Redis-read precedence is unchanged.

The regression contract covers all six names and prevents a future edit from silently restoring the expired softening.

## Production evidence

The authenticated detailed health probe reported every target `OK` at `2026-08-02T16:33:44.427Z`. Direct read-only seed metadata confirmed current producer writes:

| Health key | Metadata `fetchedAt` | Records |
| --- | --- | ---: |
| `fxYoy` | `2026-08-02T06:33:04.640Z` | 45 |
| `hyperliquidFlow` | `2026-08-02T16:30:14.933Z` | 14 |
| `chokepointFlowsRelayHeartbeat` | `2026-08-02T12:11:34.923Z` | 1 |
| `climateNewsRelayHeartbeat` | `2026-08-02T16:13:40.372Z` | 1 |
| `eiaPetroleum` | `2026-08-02T07:30:39.434Z` | 4 |
| `digestNotifications` | `2026-08-02T16:05:51.688Z` | 1 |

None of the six appeared in the retained 50-entry health failure history. Fleet health was independently `UNHEALTHY` for unrelated keys during the probe, so this is target-specific graduation evidence, not a general production-recovery claim.

## Validation

- Proof-first regression: the new contract failed on `fxYoy` membership before the production edit.
- `node --test tests/health-classify.test.mjs tests/health-empty-data-ok.test.mjs tests/seed-freshness-monitor.test.mjs tests/bootstrap.test.mjs` (`124/124` passed after rebase).
- `npm run typecheck:api` passed.
- `npm run lint` and the safe-HTML guard passed; Biome reported only unrelated existing warnings.
- The normal pre-push gate passed and published commit `42bb48d0a`.
- A repo-wide `npm run test:data` attempt was explicitly interrupted after 18 minutes of machine-wide contention from concurrent WorldMonitor suites; it produced no code failure before interruption. PR CI is the authoritative full-suite gate.

## Post-Deploy Monitoring & Validation

- **Logs/search terms:** query detailed `/api/health` and retained history for the six health-key names plus `EMPTY`, `EMPTY_DATA`, `EMPTY_ON_DEMAND`, `STALE_SEED`, and `SEED_ERROR`.
- **Metrics/dashboard:** watch each key's status, `seedAgeMin`, record count, and backing metadata `fetchedAt`; also watch fleet critical/warning counts without attributing unrelated incidents to this change.
- **Expected signal:** all six remain `OK`, their `fetchedAt` values advance on their established schedules, and none can report `EMPTY_ON_DEMAND`.
- **Failure signal:** any target becomes `EMPTY`, `EMPTY_DATA`, `STALE_SEED`, or `SEED_ERROR`, or its metadata misses the configured cadence.
- **Rollback trigger:** investigate the owning producer first. Revert only if a verified deployment-order race creates a false critical; any replacement bridge must use an activation marker or enforced expiry tied to an owner issue, never an unbounded prose reminder.
- **Window/owner:** PR/issue owner or on-call validates the fast producers through their next ticks and keeps the check open for 24 hours, covering the next daily `fxYoy` and `eiaPetroleum` cycles.

Fixes #6070.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5-000000)
