### PR TITLE
fix(china-nowcast): publish a directional CCFI period change so the freight proxy family can be evaluated (#6066)

### DIFF
--- a/docs/china-logistics-corridors.mdx
+++ b/docs/china-logistics-corridors.mdx
@@ -31,7 +31,7 @@ national and can apply to all four corridors.
 | `hazard` | Western Pacific cyclone sources and Hong Kong Observatory | Events inside a corridor boundary plus explicit HKO warning coverage for the Greater Bay Area |
 | `power_energy` | WorldMonitor energy spine | National China energy dependency coverage and latest source observation time |
 | `strategic_industry` | UN Comtrade | Annual strategic-product observations for reporter 156 |
-| `trade` | UN Comtrade and Shanghai Shipping Exchange CCFI | Annual reporter-156 trade observations and the current China Containerized Freight Index |
+| `trade` | UN Comtrade and Shanghai Shipping Exchange CCFI | Annual reporter-156 trade observations, the current China Containerized Freight Index, and its published period-over-period change with the prior period it was measured against |
 
 IMF PortWatch and AviationStack are node-scoped. Hazard observations are
 regional. WorldMonitor energy spine, UN Comtrade, and Shanghai Shipping

--- a/docs/zh/china-logistics-corridors.mdx
+++ b/docs/zh/china-logistics-corridors.mdx
@@ -28,7 +28,7 @@ selector 或审核地理映射到该走廊时才贡献。全国输入会明确�
 | `hazard` | 西太平洋气旋来源与 Hong Kong Observatory | 走廊边界内事件，以及大湾区明确的 HKO 警告覆盖 |
 | `power_energy` | WorldMonitor energy spine | 中国全国能源依赖覆盖与最新来源观测时间 |
 | `strategic_industry` | UN Comtrade | reporter 156 的年度战略产品观测 |
-| `trade` | UN Comtrade 与 Shanghai Shipping Exchange CCFI | reporter 156 年度贸易观测与当前中国出口集装箱运价指数 |
+| `trade` | UN Comtrade 与 Shanghai Shipping Exchange CCFI | reporter 156 年度贸易观测、当前中国出口集装箱运价指数，以及其发布的环比变化与所对比的前一期 |
 
 IMF PortWatch 和 AviationStack 是节点范围；灾害观测为区域范围；WorldMonitor
 energy spine、UN Comtrade 和 Shanghai Shipping Exchange 输入为全国范围。输出

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -141,6 +141,54 @@ async function fetchShippingRates() {
 
 // ─── Container Indices (Shanghai Shipping Exchange) ───
 
+function finiteOrNull(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+// Parse one Shanghai Shipping Exchange `currentIndex` envelope (issue #6066).
+//
+// `changePct` / `previousValue` are the legacy display fields and are DELIBERATELY
+// left fabricating (0 / the current level) so the supply-chain UI keeps rendering.
+// They must never be consumed as evidence of a period-over-period move: they cannot
+// distinguish "SSE published an unchanged week" from "SSE published no prior at all".
+//
+// `periodChangePct` is the decision-grade field and fails CLOSED — it is null unless
+// SSE itself published either its own percentage or a comparable prior-period level,
+// and `periodChangeBasis` names which of the two it came from. A single index level
+// never becomes a change.
+export function parseSseIndexResponse(json, indexId, dataItemType, displayName, unit) {
+  const lines = json?.data?.lineDataList;
+  if (!Array.isArray(lines)) return [];
+  const composite = lines.find(l => l.dataItemTypeName === dataItemType);
+  if (!composite) return [];
+  const currentValue = composite.currentContent;
+  const previousValue = composite.lastContent;
+  if (typeof currentValue !== 'number' || !Number.isFinite(currentValue)) return [];
+  const changePct = typeof composite.percentage === 'number' ? composite.percentage
+    : (previousValue > 0 ? ((currentValue - previousValue) / previousValue) * 100 : 0);
+
+  const publishedChangePct = finiteOrNull(composite.percentage);
+  const priorPeriodValue = finiteOrNull(previousValue);
+  const derivedChangePct = publishedChangePct === null && priorPeriodValue !== null
+    && priorPeriodValue !== 0
+    ? ((currentValue - priorPeriodValue) / Math.abs(priorPeriodValue)) * 100
+    : null;
+  const periodChangePct = publishedChangePct ?? derivedChangePct;
+  const periodChangeBasis = publishedChangePct !== null
+    ? 'publisher_reported'
+    : derivedChangePct !== null
+      ? 'derived_from_prior_period_level'
+      : null;
+
+  const observationDate = json.data?.currentDate || new Date().toISOString().slice(0, 10);
+  return [{
+    indexId, name: displayName, currentValue, previousValue: previousValue ?? currentValue,
+    changePct, periodChangePct, periodChangeBasis, priorPeriodValue,
+    priorPeriodDate: typeof json.data?.lastDate === 'string' ? json.data.lastDate : null,
+    unit, history: [], spikeAlert: false, _observationDate: observationDate,
+  }];
+}
+
 async function fetchSSEIndex(indexName, indexId, dataItemType, displayName, unit) {
   try {
     const resp = await fetch(`https://en.sse.net.cn/currentIndex?indexName=${indexName}`, {
@@ -149,20 +197,13 @@ async function fetchSSEIndex(indexName, indexId, dataItemType, displayName, unit
     });
     if (!resp.ok) { console.warn(`  SSE ${indexName}: HTTP ${resp.status}`); return []; }
     const json = await resp.json();
-    const lines = json?.data?.lineDataList;
-    if (!Array.isArray(lines)) { console.warn(`  SSE ${indexName}: no lineDataList`); return []; }
-    const composite = lines.find(l => l.dataItemTypeName === dataItemType);
-    if (!composite) { console.warn(`  SSE ${indexName}: ${dataItemType} not found`); return []; }
-    const currentValue = composite.currentContent;
-    const previousValue = composite.lastContent;
-    if (typeof currentValue !== 'number') return [];
-    const changePct = typeof composite.percentage === 'number' ? composite.percentage
-      : (previousValue > 0 ? ((currentValue - previousValue) / previousValue) * 100 : 0);
-    const observationDate = json.data?.currentDate || new Date().toISOString().slice(0, 10);
-    return [{
-      indexId, name: displayName, currentValue, previousValue: previousValue ?? currentValue,
-      changePct, unit, history: [], spikeAlert: false, _observationDate: observationDate,
-    }];
+    if (!Array.isArray(json?.data?.lineDataList)) {
+      console.warn(`  SSE ${indexName}: no lineDataList`);
+      return [];
+    }
+    const parsed = parseSseIndexResponse(json, indexId, dataItemType, displayName, unit);
+    if (parsed.length === 0) console.warn(`  SSE ${indexName}: ${dataItemType} not usable`);
+    return parsed;
   } catch (e) {
     console.warn(`  SSE ${indexName}: ${e.message}`);
     return [];

--- a/server/worldmonitor/economic/v1/get-china-activity-nowcast.ts
+++ b/server/worldmonitor/economic/v1/get-china-activity-nowcast.ts
@@ -244,17 +244,34 @@ function corridorProxyObservations(
     signal.selectorId === 'supply_chain:shipping:v2:CCFI'
     || signal.id.startsWith('signal:ccfi:'));
   if (ccfi) {
+    // Only the publisher's own period-over-period move counts (#6066). The
+    // current level and the legacy fabricable `changePct` are never read, so a
+    // level cannot be reinterpreted as a change or a neutral contribution.
+    const periodChange = finiteNumber(ccfi.metrics.periodChangePct);
+    // A signal that never arrived is not the same exclusion as one that arrived
+    // with a level but no comparable prior; naming the wrong one would overstate
+    // what the source actually published.
+    const exclusion = periodChange !== null
+      ? null
+      : ccfi.availability === 'available'
+        ? 'missing_comparable_prior'
+        : 'source_signal_unavailable';
     observations.push(corridorObservation({
       evaluatedAt,
       seriesId: 'ccfi_freight_rate_change',
       observationId: `ccfi-change:${corridors.generatedAt}`,
       signals: [ccfi],
-      // #5578 currently publishes the current level only. A level must not be
-      // reinterpreted as a change or a neutral contribution.
-      value: null,
+      value: periodChange,
       provenance: corridorProvenance([ccfi], {
         currentLevel: finiteNumber(ccfi.metrics.currentValue),
-        exclusion: 'period_change_not_published',
+        priorPeriodLevel: finiteNumber(ccfi.metrics.priorPeriodValue),
+        priorPeriodDate: typeof ccfi.metrics.priorPeriodDate === 'string'
+          ? ccfi.metrics.priorPeriodDate
+          : null,
+        periodChangeBasis: typeof ccfi.metrics.periodChangeBasis === 'string'
+          ? ccfi.metrics.periodChangeBasis
+          : null,
+        ...(exclusion === null ? {} : { exclusion }),
       }),
     }));
   }

--- a/server/worldmonitor/supply-chain/v1/china-corridor-source-adapters.ts
+++ b/server/worldmonitor/supply-chain/v1/china-corridor-source-adapters.ts
@@ -698,8 +698,16 @@ function adaptTrade(
       transportFreshness: transportFreshness(snapshots.shippingMeta, 420, assessedAt),
       contentFreshness: contentFreshness(observedAt, 28 * 1_440, assessedAt),
       summary: 'China Containerized Freight Index observation.',
+      // `periodChangePct` is the publisher's own period-over-period move and is
+      // absent unless the seeder proved a comparable prior (#6066). The legacy
+      // `changePct` field stays unpublished: it fabricates 0 when no prior
+      // exists, so a level would silently become a change.
       metrics: metrics([
         ['currentValue', numberValue(ccfi.currentValue)],
+        ['periodChangePct', numberValue(ccfi.periodChangePct)],
+        ['periodChangeBasis', stringValue(ccfi.periodChangeBasis)],
+        ['priorPeriodValue', numberValue(ccfi.priorPeriodValue)],
+        ['priorPeriodDate', stringValue(ccfi.priorPeriodDate)],
         ['unit', stringValue(ccfi.unit)],
       ]),
     }));

--- a/tests/china-activity-nowcast-handler.test.mts
+++ b/tests/china-activity-nowcast-handler.test.mts
@@ -150,7 +150,14 @@ function corridorSnapshot(): ChinaCorridorControlTowerResponse {
         ]),
         condition('trade', [
           {
-            ...signal('ccfi', 'trade', { currentValue: 900, unit: 'index' }),
+            ...signal('ccfi', 'trade', {
+              currentValue: 1072.16,
+              periodChangePct: 1.69,
+              periodChangeBasis: 'publisher_reported',
+              priorPeriodValue: 1054.38,
+              priorPeriodDate: '2026-07-18',
+              unit: 'index',
+            }),
             selectorId: 'supply_chain:shipping:v2:CCFI',
           },
         ]),
@@ -202,14 +209,24 @@ describe('China activity nowcast cache/API composition (#5579)', () => {
       [
         'portwatch_tanker_calls_trend',
         'aviation_hub_disruption_balance',
+        'ccfi_freight_rate_change',
         'china_input_commodity_change',
         'sse_composite_week_change',
       ],
     );
-    assert.equal(
-      inputs.proxyObservations.find((item) => item.seriesId === 'ccfi_freight_rate_change')?.value,
-      null,
-    );
+    const freight = inputs.proxyObservations
+      .find((item) => item.seriesId === 'ccfi_freight_rate_change');
+    assert.equal(freight?.value, 1.69);
+    assert.deepEqual(freight?.provenance, {
+      sourceSignalIds: ['ccfi'],
+      publishers: [{ id: 'publisher:trade', name: 'Reviewed trade publisher', type: 'official' }],
+      sourceUrls: ['https://example.test/trade'],
+      observationTimes: ['2026-07-25T10:00:00.000Z'],
+      currentLevel: 1072.16,
+      priorPeriodLevel: 1054.38,
+      priorPeriodDate: '2026-07-18',
+      periodChangeBasis: 'publisher_reported',
+    });
     assert.equal(
       inputs.proxyObservations.find((item) => item.seriesId === 'china_energy_demand_change')?.value,
       null,
@@ -236,13 +253,121 @@ describe('China activity nowcast cache/API composition (#5579)', () => {
       raw: true,
     }]);
     assert.equal(response.state, 'agreement');
-    assert.equal(response.confidence.eligibleFamilies, 4);
+    assert.equal(response.confidence.eligibleFamilies, 5);
     assert.equal(response.historicalEvaluation.available, false);
     assert.match(response.historicalEvaluation.reason, /historical proxy ledger/i);
+    // Freight is no longer structurally missing: it is included whenever the
+    // Shanghai Shipping Exchange contract publishes a period change (#6066).
     assert.deepEqual(
       response.missingInputs.map((item) => item.family),
-      ['freight', 'energy', 'corridor'],
+      ['energy', 'corridor'],
     );
+    assert.equal(
+      response.contributions.find((item) => item.family === 'freight')?.direction,
+      'strengthening',
+    );
+  });
+
+  it('excludes freight with its exact reason when only a CCFI level is published (#6066)', () => {
+    const levelOnly = corridorSnapshot();
+    const trade = levelOnly.corridors[0]!.conditions
+      .find((item) => item.family === 'trade')!;
+    trade.sourceSignals[0]!.metrics = { currentValue: 1072.16, unit: 'index' };
+
+    const inputs = buildChinaActivityNowcastInputs({
+      evaluatedAt: EVALUATED_AT,
+      macro: macroSnapshot() as never,
+      corridors: levelOnly,
+      marketValues: marketValues(),
+    });
+    const freight = inputs.proxyObservations
+      .find((item) => item.seriesId === 'ccfi_freight_rate_change');
+    assert.equal(freight?.value, null);
+    assert.equal(
+      (freight?.provenance as Record<string, unknown>).exclusion,
+      'missing_comparable_prior',
+    );
+    assert.equal((freight?.provenance as Record<string, unknown>).currentLevel, 1072.16);
+  });
+
+  it('names an unavailable CCFI signal instead of claiming a missing prior (#6066)', () => {
+    const unavailable = corridorSnapshot();
+    const signal = unavailable.corridors[0]!.conditions
+      .find((item) => item.family === 'trade')!.sourceSignals[0]!;
+    signal.availability = 'unavailable';
+    signal.metrics = {};
+
+    const freight = buildChinaActivityNowcastInputs({
+      evaluatedAt: EVALUATED_AT,
+      macro: macroSnapshot() as never,
+      corridors: unavailable,
+      marketValues: marketValues(),
+    }).proxyObservations.find((item) => item.seriesId === 'ccfi_freight_rate_change');
+    assert.equal(freight?.value, null);
+    assert.equal(
+      (freight?.provenance as Record<string, unknown>).exclusion,
+      'source_signal_unavailable',
+    );
+  });
+
+  it('never lets a CCFI level or a fabricable display change become a freight move (#6066)', () => {
+    // Each mutation is a metrics shape a weakened guard would happily read as a
+    // directional change. The published `periodChangePct` is the only input that
+    // may produce one.
+    const mutations: Array<[string, CorridorSourceSignal['metrics']]> = [
+      ['level only', { currentValue: 1072.16, unit: 'index' }],
+      ['legacy fabricated flat change', { currentValue: 1072.16, changePct: 0 }],
+      ['legacy non-flat display change', { currentValue: 1072.16, changePct: 1.69 }],
+      ['prior level without a published change', {
+        currentValue: 1072.16,
+        priorPeriodValue: 1054.38,
+      }],
+      ['basis asserted without a change', {
+        currentValue: 1072.16,
+        periodChangeBasis: 'publisher_reported',
+      }],
+      ['non-finite change', { currentValue: 1072.16, periodChangePct: Number.NaN }],
+      ['stringified change', { currentValue: 1072.16, periodChangePct: '1.69' as never }],
+      ['boolean change', { currentValue: 1072.16, periodChangePct: true }],
+    ];
+
+    for (const [label, metrics] of mutations) {
+      const mutated = corridorSnapshot();
+      mutated.corridors[0]!.conditions
+        .find((item) => item.family === 'trade')!.sourceSignals[0]!.metrics = metrics;
+      const inputs = buildChinaActivityNowcastInputs({
+        evaluatedAt: EVALUATED_AT,
+        macro: macroSnapshot() as never,
+        corridors: mutated,
+        marketValues: marketValues(),
+      });
+      const freight = inputs.proxyObservations
+        .find((item) => item.seriesId === 'ccfi_freight_rate_change');
+      assert.equal(freight?.value, null, label);
+      assert.equal(
+        (freight?.provenance as Record<string, unknown>).exclusion,
+        'missing_comparable_prior',
+        label,
+      );
+    }
+
+    // The guard is not vacuous: an explicit published zero is a real unchanged
+    // week and must survive it.
+    const flat = corridorSnapshot();
+    flat.corridors[0]!.conditions
+      .find((item) => item.family === 'trade')!.sourceSignals[0]!.metrics = {
+        currentValue: 1072.16,
+        periodChangePct: 0,
+        periodChangeBasis: 'publisher_reported',
+      };
+    const flatFreight = buildChinaActivityNowcastInputs({
+      evaluatedAt: EVALUATED_AT,
+      macro: macroSnapshot() as never,
+      corridors: flat,
+      marketValues: marketValues(),
+    }).proxyObservations.find((item) => item.seriesId === 'ccfi_freight_rate_change');
+    assert.equal(flatFreight?.value, 0);
+    assert.equal((flatFreight?.provenance as Record<string, unknown>).exclusion, undefined);
   });
 
   it('does not positively cache an insufficient response and preserves truthful degradation', async () => {

--- a/tests/china-corridor-source-adapters.test.mts
+++ b/tests/china-corridor-source-adapters.test.mts
@@ -185,5 +185,55 @@ describe('China corridor source adapters (#5578)', () => {
     assert.equal(comtrade?.contentFreshness, 'stale');
     assert.equal(ccfi?.metrics.changePct, undefined);
     assert.equal(ccfi?.metrics.currentValue, 900);
+    // The seeder published no comparable prior, so no period change is exposed
+    // even though the legacy display field fabricates a flat 0 (#6066).
+    assert.equal(ccfi?.metrics.periodChangePct, undefined);
+    assert.equal(ccfi?.metrics.periodChangeBasis, undefined);
+    assert.equal(ccfi?.metrics.priorPeriodValue, undefined);
+  });
+
+  it('exposes the published CCFI period change with its basis and prior period (#6066)', () => {
+    const signalFor = (index: Record<string, unknown>) =>
+      buildChinaCorridorSourceBundle({
+        shipping: { indices: [{ indexId: 'CCFI', unit: 'index', ...index }] },
+        shippingMeta: FRESH_META,
+      }, ASSESSED_AT).families.trade.signals.find((signal) =>
+        signal.selectorId === 'supply_chain:shipping:v2:CCFI');
+
+    const published = signalFor({
+      currentValue: 1072.16,
+      previousValue: 1054.38,
+      changePct: 1.69,
+      periodChangePct: 1.69,
+      periodChangeBasis: 'publisher_reported',
+      priorPeriodValue: 1054.38,
+      priorPeriodDate: '2026-07-11',
+      history: [{ date: '2026-07-18', value: 1072.16 }],
+    });
+    assert.equal(published?.metrics.periodChangePct, 1.69);
+    assert.equal(published?.metrics.periodChangeBasis, 'publisher_reported');
+    assert.equal(published?.metrics.priorPeriodValue, 1054.38);
+    assert.equal(published?.metrics.priorPeriodDate, '2026-07-11');
+    assert.equal(published?.metrics.changePct, undefined);
+
+    // An explicit unchanged week is a real directional observation, not a gap.
+    const flat = signalFor({
+      currentValue: 900,
+      periodChangePct: 0,
+      periodChangeBasis: 'publisher_reported',
+      history: [{ date: '2026-07-18', value: 900 }],
+    });
+    assert.equal(flat?.metrics.periodChangePct, 0);
+
+    // A non-finite change is never carried through as evidence.
+    for (const invalid of [Number.NaN, Number.POSITIVE_INFINITY, '1.69', null]) {
+      const rejected = signalFor({
+        currentValue: 900,
+        periodChangePct: invalid,
+        history: [{ date: '2026-07-18', value: 900 }],
+      });
+      assert.equal(rejected?.metrics.periodChangePct, undefined, String(invalid));
+      assert.equal(rejected?.metrics.currentValue, 900, String(invalid));
+    }
   });
 });

--- a/tests/freight-indices.test.mjs
+++ b/tests/freight-indices.test.mjs
@@ -4,6 +4,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { parseSseIndexResponse } from '../scripts/seed-supply-chain-trade.mjs';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 
@@ -58,22 +60,9 @@ function parseBDIFromHtml(html) {
   return indices;
 }
 
-// Extract SSE parser logic into a testable function
-function parseSSEResponse(json, indexId, dataItemType, displayName, unit) {
-  const lines = json?.data?.lineDataList;
-  if (!Array.isArray(lines)) return [];
-  const composite = lines.find(l => l.dataItemTypeName === dataItemType);
-  if (!composite) return [];
-  const currentValue = composite.currentContent;
-  const previousValue = composite.lastContent;
-  if (typeof currentValue !== 'number') return [];
-  const changePct = typeof composite.percentage === 'number' ? composite.percentage
-    : (previousValue > 0 ? ((currentValue - previousValue) / previousValue) * 100 : 0);
-  return [{
-    indexId, name: displayName, currentValue, previousValue: previousValue ?? currentValue,
-    changePct, unit, history: [], spikeAlert: false,
-  }];
-}
+// The SSE parser is the REAL exported seeder function, not a re-implementation —
+// a mirrored copy drifts silently from production (#6066).
+const parseSSEResponse = parseSseIndexResponse;
 
 // ─── SSE (SCFI/CCFI) parser tests with fixture data ───
 
@@ -157,6 +146,63 @@ describe('CCFI parser (functional)', () => {
     assert.equal(result[0].currentValue, 1072.16);
     assert.equal(result[0].changePct, 1.69);
     assert.equal(result[0].unit, 'index');
+  });
+});
+
+// ─── Decision-grade period change (#6066) ───
+//
+// `periodChangePct` feeds the China activity-nowcast freight family, so it must
+// fail closed: published-or-derived from SSE's own envelope, never fabricated.
+
+describe('SSE period-over-period change contract (#6066)', () => {
+  const parse = (line, data = {}) => parseSseIndexResponse(
+    { data: { lineDataList: [{ dataItemTypeName: 'CCFI_T', ...line }], ...data } },
+    'CCFI', 'CCFI_T', 'CCFI - China Container Freight', 'index',
+  )[0];
+
+  it('publishes the exchange percentage with its basis and prior period', () => {
+    const index = parseSSEResponse(CCFI_FIXTURE, 'CCFI', 'CCFI_T', 'test', 'index')[0];
+    assert.equal(index.periodChangePct, 1.69);
+    assert.equal(index.periodChangeBasis, 'publisher_reported');
+    assert.equal(index.priorPeriodValue, 1054.38);
+    assert.equal(index.priorPeriodDate, '2026-03-06');
+  });
+
+  it('derives the change from the published prior level when SSE omits its percentage', () => {
+    const index = parse({ currentContent: 110, lastContent: 100 });
+    assert.ok(Math.abs(index.periodChangePct - 10) < 1e-9, `got ${index.periodChangePct}`);
+    assert.equal(index.periodChangeBasis, 'derived_from_prior_period_level');
+    assert.equal(index.priorPeriodValue, 100);
+  });
+
+  it('keeps a published zero move directional-eligible rather than treating it as missing', () => {
+    const index = parse({ currentContent: 900, lastContent: 900, percentage: 0 });
+    assert.equal(index.periodChangePct, 0);
+    assert.equal(index.periodChangeBasis, 'publisher_reported');
+  });
+
+  it('publishes no change when SSE ships a level with no comparable prior', () => {
+    for (const line of [
+      { currentContent: 900 },
+      { currentContent: 900, lastContent: null },
+      { currentContent: 900, lastContent: 0 },
+      { currentContent: 900, lastContent: 'n/a' },
+      { currentContent: 900, percentage: 'n/a' },
+    ]) {
+      const index = parse(line);
+      assert.equal(index.periodChangePct, null, JSON.stringify(line));
+      assert.equal(index.periodChangeBasis, null, JSON.stringify(line));
+      // The legacy display field still fabricates a flat 0 — which is exactly
+      // why the decision path must not consume it.
+      assert.equal(index.changePct, 0, JSON.stringify(line));
+    }
+  });
+
+  it('reports no prior period when SSE ships a non-numeric prior level', () => {
+    for (const lastContent of [undefined, null, 'n/a', Number.NaN]) {
+      assert.equal(parse({ currentContent: 900, lastContent }).priorPeriodValue, null,
+        String(lastContent));
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

`ccfi_freight_rate_change` was structurally hardcoded to `value: null` in the corridor adapter — not a transport failure or a staleness problem. The #5578 corridor trade signal published only the current CCFI level, so the deterministic method correctly refused the whole freight family and reported `freight / ccfi_freight_rate_change: missing_directional_value`.

## Root cause

The Shanghai Shipping Exchange `currentIndex` envelope already carries a period-over-period move, but `scripts/seed-supply-chain-trade.mjs` collapsed three different provenances into one `changePct` field:

1. SSE's own published `percentage`
2. a value derived from SSE's `lastContent` (its own prior-period level)
3. a **fabricated flat `0`** when neither exists (`previousValue > 0 ? ... : 0`, plus `previousValue: previousValue ?? currentValue`)

That field cannot distinguish "SSE published an unchanged week" from "SSE published no prior at all", so consuming it would have silently turned a level into a change — exactly what the #5579 fail-closed contract forbids.

## Change

- **Seeder** — `parseSseIndexResponse` is extracted from `fetchSSEIndex` and exported. It emits `periodChangePct`, `periodChangeBasis`, `priorPeriodValue`, and `priorPeriodDate`. `periodChangePct` is `null` unless SSE published its own percentage or a comparable prior-period level, and `periodChangeBasis` names which one (`publisher_reported` / `derived_from_prior_period_level`). The legacy `changePct` / `previousValue` display fields keep their existing fabricating behaviour so the supply-chain UI is untouched — they are simply never consumed as evidence.
- **Corridor adapter** — the CCFI source signal now exposes those fields on its metrics, with its existing observation/release/retrieval times and provenance. `changePct` stays unpublished.
- **Nowcast adapter** — `buildChinaActivityNowcastInputs` reads **only** `periodChangePct`. A bare level, the legacy `changePct`, and any non-finite value all resolve to `null`.

## Non-goals (retained from #5579)

No forward fill, no interpolation, no neutral substitution. A level never becomes a change. An explicit published `0` stays a real unchanged week rather than being dropped by a truthiness check.

## Deterministic acceptance gate

- [x] The corridor trade signal exposes an explicit period-over-period CCFI change with its own provenance and observation/release/retrieval times.
- [x] `buildChinaActivityNowcastInputs` returns a finite `value` when the change is published, and `null` with reason `missing_comparable_prior` when it is not.
- [x] Unit tests assert the freight family is included and directional for a published change, and excluded with its exact reason when only a level is available.
- [x] Mutation tests prove the exclusion path fails when the guard is removed.
- [x] `tests/china-activity-nowcast-handler.test.mts` no longer lists `freight` among the structurally missing families (`missingInputs` is now `['energy', 'corridor']`, `eligibleFamilies` 4 -> 5).

## Mutation proof

Eight mutants were applied to the shipped guards and every one was killed (each reverted from a pristine file copy, hashes re-verified):

| # | Mutant | Killed by |
|---|--------|-----------|
| A | restore the hardcoded `value: null` | 3 nowcast tests |
| B | read `currentValue` (the level) as the change | 3 nowcast tests |
| C | read the legacy fabricable `changePct` | 3 nowcast tests |
| D | truthiness guard drops a published `0` | 1 nowcast test |
| E | seeder fabricates a flat `0` when no prior exists | 1 seeder test |
| F | seeder reuses the legacy `changePct` | 1 seeder test |
| G | adapter publishes `changePct` as the period change | 2 adapter tests |
| H | collapse both exclusion reasons into one | 1 nowcast test |

## Extra honesty fix found in review

A CCFI signal that never arrived is now excluded as `source_signal_unavailable` rather than claiming `missing_comparable_prior` — the latter would overstate what the source actually published. (The evaluator's own top-level `missingInputs` reason for this `signed_value` entry stays `missing_directional_value`; that arm is shared with the other signed-value families and is unchanged.)

## Test discipline

`tests/freight-indices.test.mjs` previously re-implemented the SSE parser as a copy. It now imports and exercises the **real** exported function, so the production contract can no longer drift from its test.

## Verification

- `tests/china-activity-nowcast*.test.mts`, `tests/china-corridor-*.test.mts`, `tests/china-decision-signals.test.mts`, `tests/china-strategic-trade-contract.test.mjs` — 85 pass, 0 fail
- `tests/freight-indices.test.mjs`, `tests/seed-supply-chain-trade-wto-resilience.test.mjs`, `tests/china-corridor-openapi-contract.test.mjs` — 45 pass, 0 fail
- `npm run typecheck`, `biome lint` on all changed files, `npm run lint:boundaries`, `markdownlint` on both docs, `scripts/audit-china-decision-parity.mjs`, `scripts/verify-seed-envelope-parity.mjs` — all green

## Rollout note

Until the supply-chain seeder redeploys and runs, the published payload has no `periodChangePct`, so freight stays excluded — with reason `missing_comparable_prior` instead of the old `period_change_not_published`. No regression in the interim; the family lights up on the first seeder run after deploy.

## Related

- #6060 — PortWatch content freshness and healthy-quiet decision coverage (parent)
- #5579 — deterministic China activity-nowcast contract
- #5578 — China corridor control-tower source signals

Closes #6066

https://claude.ai/code/session_01BPGvgzpLhC466aPEFS1z3Z