### PR TITLE
fix(china): accept same-publisher corridor corroboration

### DIFF
--- a/shared/china-corridor-control-towers.ts
+++ b/shared/china-corridor-control-towers.ts
@@ -409,14 +409,28 @@ function provenanceBindingMatches(
   const expectedInputIds = signals
     .filter((signal) => signal.availability !== 'unavailable')
     .map((signal) => signal.id);
-  for (const dimension of ['corroboration', 'derivation'] as const) {
-    const claim = record(claims[dimension]);
-    if (claim?.status !== 'known') continue;
-    const claimValue = record(claim.value);
-    const inputIds = dimension === 'corroboration'
-      ? claimValue?.sourceSignalIds
-      : claimValue?.inputSignalIds;
-    if (!sameStringSet(inputIds, expectedInputIds)) return false;
+  const expectedInputIdSet = new Set(expectedInputIds);
+  const corroboration = record(claims.corroboration);
+  if (corroboration?.status === 'known') {
+    const sourceSignalIds = record(corroboration.value)?.sourceSignalIds;
+    if (
+      !Array.isArray(sourceSignalIds)
+      || sourceSignalIds.length === 0
+      || !sourceSignalIds.every((id) =>
+        typeof id === 'string' && expectedInputIdSet.has(id))
+    ) {
+      return false;
+    }
+  }
+  const derivation = record(claims.derivation);
+  if (
+    derivation?.status === 'known'
+    && !sameStringSet(
+      record(derivation.value)?.inputSignalIds,
+      expectedInputIds,
+    )
+  ) {
+    return false;
   }
   return true;
 }

--- a/shared/china-corridor-control-towers.ts
+++ b/shared/china-corridor-control-towers.ts
@@ -406,18 +406,28 @@ function provenanceBindingMatches(
   }
   const claims = record(provenance.claims);
   if (claims === null) return true;
-  const expectedInputIds = signals
-    .filter((signal) => signal.availability !== 'unavailable')
-    .map((signal) => signal.id);
+  const usableSignals = signals.filter((signal) => signal.availability !== 'unavailable');
+  const expectedInputIds = usableSignals.map((signal) => signal.id);
   const expectedInputIdSet = new Set(expectedInputIds);
+  const expectedPublisherIds = new Set(usableSignals.map((signal) => signal.publisher.id));
   const corroboration = record(claims.corroboration);
   if (corroboration?.status === 'known') {
-    const sourceSignalIds = record(corroboration.value)?.sourceSignalIds;
+    const corroborationValue = record(corroboration.value);
+    const sourceSignalIds = corroborationValue?.sourceSignalIds;
+    const expectedState = expectedPublisherIds.size > 1
+      ? 'multi_source'
+      : 'single_source';
     if (
-      !Array.isArray(sourceSignalIds)
+      corroborationValue?.state !== expectedState
+      || !Array.isArray(sourceSignalIds)
       || sourceSignalIds.length === 0
       || !sourceSignalIds.every((id) =>
         typeof id === 'string' && expectedInputIdSet.has(id))
+      || (
+        expectedPublisherIds.size > 1
+          ? !sameStringSet(sourceSignalIds, expectedInputIds)
+          : sourceSignalIds.length !== 1
+      )
     ) {
       return false;
     }

--- a/tests/china-corridor-composer.test.mts
+++ b/tests/china-corridor-composer.test.mts
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import { validateDecisionSignalProvenance } from '../shared/decision-signal-provenance';
-import { validateChinaCorridorProvenanceForSurface } from '../shared/china-corridor-control-towers.ts';
+import {
+  parseChinaCorridorWirePayload,
+  validateChinaCorridorProvenanceForSurface,
+} from '../shared/china-corridor-control-towers.ts';
 import {
   composeChinaCorridorControlTowers,
   type ChinaCorridorSourceBundle,
@@ -282,6 +285,26 @@ describe('China corridor control-tower composition (#5578)', () => {
     assert.equal(corroboration?.status === 'known' ? corroboration.value.state : null, 'single_source');
     assert.equal(corroboration?.status === 'known' ? corroboration.value.sourceSignalIds.length : 0, 1);
     assert.equal(condition?.sourceSignals.length, 2);
+  });
+
+  it('keeps same-publisher multi-record payloads valid at the UI boundary', () => {
+    const bundle = sourceBundle();
+    bundle.families.port.signals.push(
+      signal({
+        id: 'signal:portwatch:ningbo-zhoushan',
+        family: 'port',
+        selectorId: 'port2027',
+      }),
+    );
+
+    const response = composeChinaCorridorControlTowers(bundle);
+    const parsed = parseChinaCorridorWirePayload(JSON.stringify(response));
+    const condition = parsed.corridors
+      .find((corridor) => corridor.id === 'china-yangtze-river-delta')
+      ?.conditions.find((item) => item.family === 'port');
+
+    assert.equal(condition?.sourceSignals.length, 2);
+    assert.equal(condition?.availability, 'available');
   });
 
   it('preserves the selected source observation precision in composed provenance', () => {

--- a/tests/china-corridor-composer.test.mts
+++ b/tests/china-corridor-composer.test.mts
@@ -124,6 +124,36 @@ function sourceBundle(): ChinaCorridorSourceBundle {
   };
 }
 
+type MutableCorroborationPayload = {
+  corridors: Array<{
+    id: string;
+    conditions: Array<{
+      family: string;
+      sourceSignals: Array<{ id: string; publisher: { id: string } }>;
+      provenance: {
+        claims: {
+          corroboration: {
+            status: string;
+            value: { state: string; sourceSignalIds: string[] };
+          };
+        };
+      } | null;
+    }>;
+  }>;
+};
+
+function cloneMutableCorroborationPayload(response: unknown): MutableCorroborationPayload {
+  return JSON.parse(JSON.stringify(response)) as MutableCorroborationPayload;
+}
+
+function yrdPortCondition(payload: MutableCorroborationPayload) {
+  const condition = payload.corridors
+    .find((corridor) => corridor.id === 'china-yangtze-river-delta')
+    ?.conditions.find((item) => item.family === 'port');
+  if (condition === undefined) throw new Error('Expected Yangtze River Delta port condition');
+  return condition;
+}
+
 describe('China corridor control-tower composition (#5578)', () => {
   it('composes reviewed selectors without producing an opaque risk score', () => {
     const response = composeChinaCorridorControlTowers(sourceBundle());
@@ -305,6 +335,84 @@ describe('China corridor control-tower composition (#5578)', () => {
 
     assert.equal(condition?.sourceSignals.length, 2);
     assert.equal(condition?.availability, 'available');
+  });
+
+  it('rejects single-source corroboration across distinct publishers', () => {
+    const bundle = sourceBundle();
+    bundle.families.port.signals.push(
+      signal({
+        id: 'signal:portwatch:ningbo-zhoushan-other',
+        family: 'port',
+        selectorId: 'port2027',
+        publisher: {
+          id: 'publisher:other-source',
+          name: 'Other source',
+          type: 'unknown',
+        },
+      }),
+    );
+
+    const response = composeChinaCorridorControlTowers(bundle);
+    const malformed = cloneMutableCorroborationPayload(response);
+    const condition = yrdPortCondition(malformed);
+    assert.equal(condition.sourceSignals.length, 2);
+    assert.deepEqual(
+      new Set(condition.sourceSignals.map((item) => item.publisher.id)),
+      new Set(['publisher:test-source', 'publisher:other-source']),
+    );
+    assert.ok(condition.provenance);
+    assert.equal(condition.provenance.claims.corroboration.status, 'known');
+    condition.provenance.claims.corroboration.value.state = 'single_source';
+    condition.provenance.claims.corroboration.value.sourceSignalIds = [
+      condition.sourceSignals[0]!.id,
+    ];
+
+    assert.throws(
+      () => parseChinaCorridorWirePayload(JSON.stringify(malformed)),
+      /Invalid China corridor control-tower response/,
+    );
+  });
+
+  it('rejects multi-source corroboration that cites one publisher only', () => {
+    const bundle = sourceBundle();
+    bundle.families.port.signals.push(
+      signal({
+        id: 'signal:portwatch:ningbo-zhoushan',
+        family: 'port',
+        selectorId: 'port2027',
+      }),
+      signal({
+        id: 'signal:portwatch:ningbo-zhoushan-other',
+        family: 'port',
+        selectorId: 'port2027',
+        publisher: {
+          id: 'publisher:other-source',
+          name: 'Other source',
+          type: 'unknown',
+        },
+      }),
+    );
+
+    const response = composeChinaCorridorControlTowers(bundle);
+    const malformed = cloneMutableCorroborationPayload(response);
+    const condition = yrdPortCondition(malformed);
+    assert.equal(condition.sourceSignals.length, 3);
+    assert.deepEqual(
+      new Set(condition.sourceSignals.map((item) => item.publisher.id)),
+      new Set(['publisher:test-source', 'publisher:other-source']),
+    );
+    assert.ok(condition.provenance);
+    assert.equal(condition.provenance.claims.corroboration.status, 'known');
+    assert.equal(condition.provenance.claims.corroboration.value.state, 'multi_source');
+    condition.provenance.claims.corroboration.value.sourceSignalIds =
+      condition.sourceSignals
+        .filter((item) => item.publisher.id === 'publisher:test-source')
+        .map((item) => item.id);
+
+    assert.throws(
+      () => parseChinaCorridorWirePayload(JSON.stringify(malformed)),
+      /Invalid China corridor control-tower response/,
+    );
   });
 
   it('preserves the selected source observation precision in composed provenance', () => {

--- a/tests/china-corridor-service.test.mts
+++ b/tests/china-corridor-service.test.mts
@@ -293,6 +293,24 @@ describe('China corridor client service', () => {
     );
   });
 
+  it('rejects corroboration signal ids outside the condition inputs', () => {
+    const example = openApiExample();
+    const malformed = JSON.parse(example.payloadJson);
+    const condition = malformed.corridors[0]!.conditions[0]!;
+    condition.provenance.claims.corroboration.value.sourceSignalIds = [
+      'signal:unrelated-source',
+    ];
+
+    assert.throws(
+      () => parseChinaCorridorResponse({
+        payloadJson: JSON.stringify(malformed),
+        generatedAt: example.generatedAt,
+        upstreamUnavailable: example.upstreamUnavailable,
+      }),
+      /Invalid China corridor control-tower response/,
+    );
+  });
+
   it('keeps the documented OpenAPI example valid at the production parser boundary', () => {
     const parsed = parseChinaCorridorResponse(openApiExample());
     assert.equal(parsed.corridors.length, 4);


### PR DESCRIPTION
## Summary

China logistics corridors no longer collapse to “Unavailable” when multiple reviewed records come from the same publisher. The client now accepts the server's single-source corroboration subset while still requiring every usable input in derivation lineage and rejecting foreign signal IDs.

The captured production response that previously threw `Invalid China corridor control-tower response` now parses into four partial corridors with their actual available and stale conditions.

Related: #5578

## Validation

- Exact captured production response: rejected before the fix, accepted after it
- Focused China corridor handler, composer, and client suites: 37 tests passed
- Pre-push gate: frontend typecheck, changed tests, Unicode safety, and version consistency passed
- `git diff --check`: passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
