### PR TITLE
fix(markets): restore ETF valuation identity for Yahoo summaries

### DIFF
--- a/scripts/_yahoo-sector-valuations.cjs
+++ b/scripts/_yahoo-sector-valuations.cjs
@@ -7,7 +7,9 @@ const YAHOO_COOKIE_URL = 'https://fc.yahoo.com';
 const YAHOO_CRUMB_URL = 'https://query1.finance.yahoo.com/v1/test/getcrumb';
 const YAHOO_SUMMARY_BASE_URL = 'https://query1.finance.yahoo.com/v10/finance/quoteSummary';
 const YAHOO_V7_QUOTE_URL = 'https://query1.finance.yahoo.com/v7/finance/quote';
-const YAHOO_SUMMARY_MODULES = 'summaryDetail,defaultKeyStatistics';
+// `price.symbol` is the identity-bearing field for ETF quoteSummary payloads;
+// the valuation modules alone return valid fields without any symbol identity.
+const YAHOO_SUMMARY_MODULES = 'price,summaryDetail,defaultKeyStatistics';
 const LAST_GOOD_KEY = 'market:sectors:valuations:last-good';
 const LAST_GOOD_TTL = 7 * 24 * 3600;
 const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;

--- a/tests/sector-valuations.test.mjs
+++ b/tests/sector-valuations.test.mjs
@@ -123,10 +123,6 @@ describe('authenticated Yahoo quoteSummary integration (static analysis)', () =>
     assert.match(valuationFetcherSrc, /v10\/finance\/quoteSummary/);
   });
 
-  it('uses summaryDetail and defaultKeyStatistics modules', () => {
-    assert.match(valuationFetcherSrc, /summaryDetail,defaultKeyStatistics/);
-  });
-
   it('extracts PE, beta, and return metrics', () => {
     for (const field of [
       'trailingPE',

--- a/tests/yahoo-sector-valuations.test.mjs
+++ b/tests/yahoo-sector-valuations.test.mjs
@@ -299,6 +299,34 @@ describe('parseQuoteSummary', () => {
 });
 
 describe('YahooQuoteSummaryClient', () => {
+  it('requests the price module so ETF quoteSummary responses carry symbol identity', async () => {
+    let summaryUrl = '';
+    const client = new YahooQuoteSummaryClient({
+      directRequest: async (url) => {
+        const kind = requestKind(url);
+        if (kind === 'cookie') return cookieResponse();
+        if (kind === 'crumb') return crumbResponse();
+        summaryUrl = url;
+        const response = valuationResponse('XLK');
+        const body = JSON.parse(response.body);
+        const result = body.quoteSummary.result[0];
+        delete result.symbol;
+        result.price = { symbol: 'XLK' };
+        return { ...response, body: JSON.stringify(body) };
+      },
+      resolveProxyString: () => '',
+      sleepFn: async () => {},
+    });
+
+    const result = await client.fetchDetailed('XLK');
+
+    assert.equal(result.kind, 'success');
+    assert.deepEqual(
+      new URL(summaryUrl).searchParams.get('modules')?.split(',').sort(),
+      ['defaultKeyStatistics', 'price', 'summaryDetail'],
+    );
+  });
+
   it('bounds direct and proxy Invalid Crumb retries, cools down, then recovers', async () => {
     let now = 1_700_000_000_000;
     let recovered = false;


### PR DESCRIPTION
## Summary

- Request Yahoo's identity-bearing `price` module together with `summaryDetail` and `defaultKeyStatistics` so ETF quoteSummary payloads expose `price.symbol` alongside their valid valuation fields.
- Preserve the existing expected-symbol guard, authentication session handling, route cooldowns, diagnostics, and degraded-coverage contract.
- Replace the brittle static module-list assertion with an end-to-end request-URL and identity regression test.

## Intent and non-goals

This addresses the valuation loss tracked in issue #5903, where the strict parser discarded valid ETF valuation fields because the requested valuation modules did not include an identity field.

Non-goals: no retry expansion, credential changes, last-good semantic changes, source-affinity changes, health-contract changes, API schema changes, or UI changes.

## Validation Matrix

- `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/yahoo-sector-valuations.test.mjs tests/sector-valuations.test.mjs tests/mcp-sector-valuation-coverage.test.mts` — 79 passed.
- `npm run typecheck:api` — passed; Convex string-call audit passed.
- `npm run lint` — passed; safe-HTML guard passed. Existing repository warnings remain, including one untouched warning in the valuation test.
- `git diff --check` — passed.
- Pre-push hook — passed all gates, including typecheck, API typecheck, changed tests (69 passed), Unicode/CJS checks, and version sync.
- Read-only authenticated Yahoo probe — all four previously missing symbols (XLK, XLV, XLY, SMH) returned matching identity and parseable valuation fields with the new module set.
- A full `npm run test:data` sweep was also attempted; unrelated timing cases passed when isolated, while the pre-push fixture cases are blocked in this sandbox by macOS `/var/folders` `mktemp` permissions. The authoritative changed-file pre-push gate passed.

## Review Gates

Correctness, maintainability, project standards, agent-native, testing, reliability, performance, adversarial, learnings, and simplification reviews found no actionable findings. The separate final outcome review passed, and the final manual diff review is clean.

## Documentation and UI Evidence

No documentation changes are needed for this internal seed-path contract. Screenshots/UI evidence are not applicable; this is a backend/seed-path fix with no rendered UI changes.

## Residual Findings and Post-Deploy Monitoring

Code findings are closed. Production acceptance remains pending: after deployment, verify two consecutive scheduled cycles with 12/12 sector valuations, including XLK, XLV, XLY, and SMH. Confirm matching Railway `ais-relay` logs and Redis `seed-meta:market:sectors` evidence show expected valuation coverage of 12, healthy/non-partial status, and independent route diagnostics. The pre-change production state was still 8/12.

Related: #5903

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-Codex-000000)