### PR TITLE
fix(navigation): keep variant links on dashboard

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -856,7 +856,7 @@ export class PanelLayoutManager implements AppModule {
               <span class="variant-label">${t('header.world')}</span>
             </a>
             <span class="variant-divider"></span>
-            <a href="${vHref('tech', 'https://tech.worldmonitor.app')}"
+            <a href="${vHref('tech', 'https://tech.worldmonitor.app/dashboard')}"
                class="variant-option ${SITE_VARIANT === 'tech' ? 'active' : ''}"
                data-variant="tech"
                ${vTarget('tech')}
@@ -865,7 +865,7 @@ export class PanelLayoutManager implements AppModule {
               <span class="variant-label">${t('header.tech')}</span>
             </a>
             <span class="variant-divider"></span>
-            <a href="${vHref('finance', 'https://finance.worldmonitor.app')}"
+            <a href="${vHref('finance', 'https://finance.worldmonitor.app/dashboard')}"
                class="variant-option ${SITE_VARIANT === 'finance' ? 'active' : ''}"
                data-variant="finance"
                ${vTarget('finance')}
@@ -874,7 +874,7 @@ export class PanelLayoutManager implements AppModule {
               <span class="variant-label">${t('header.finance')}</span>
             </a>
             <span class="variant-divider"></span>
-            <a href="${vHref('commodity', 'https://commodity.worldmonitor.app')}"
+            <a href="${vHref('commodity', 'https://commodity.worldmonitor.app/dashboard')}"
                class="variant-option ${SITE_VARIANT === 'commodity' ? 'active' : ''}"
                data-variant="commodity"
                ${vTarget('commodity')}
@@ -883,7 +883,7 @@ export class PanelLayoutManager implements AppModule {
               <span class="variant-label">${t('header.commodity')}</span>
             </a>
             <span class="variant-divider"></span>
-            <a href="${vHref('energy', 'https://energy.worldmonitor.app')}"
+            <a href="${vHref('energy', 'https://energy.worldmonitor.app/dashboard')}"
                class="variant-option ${SITE_VARIANT === 'energy' ? 'active' : ''}"
                data-variant="energy"
                ${vTarget('energy')}
@@ -892,7 +892,7 @@ export class PanelLayoutManager implements AppModule {
               <span class="variant-label">${t('header.energy')}</span>
             </a>
             <span class="variant-divider"></span>
-            <a href="${vHref('happy', 'https://happy.worldmonitor.app')}"
+            <a href="${vHref('happy', 'https://happy.worldmonitor.app/dashboard')}"
                class="variant-option ${SITE_VARIANT === 'happy' ? 'active' : ''}"
                data-variant="happy"
                ${vTarget('happy')}

--- a/tests/variant-navigation.test.mts
+++ b/tests/variant-navigation.test.mts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+const panelLayout = readFileSync(new URL('../src/app/panel-layout.ts', import.meta.url), 'utf8');
+
+describe('variant switcher navigation', () => {
+  it('keeps every production variant link on the dashboard route', () => {
+    const dashboardUrls = {
+      full: 'https://worldmonitor.app/dashboard',
+      tech: 'https://tech.worldmonitor.app/dashboard',
+      finance: 'https://finance.worldmonitor.app/dashboard',
+      commodity: 'https://commodity.worldmonitor.app/dashboard',
+      energy: 'https://energy.worldmonitor.app/dashboard',
+      happy: 'https://happy.worldmonitor.app/dashboard',
+    } as const;
+
+    for (const [variant, url] of Object.entries(dashboardUrls)) {
+      assert.match(
+        panelLayout,
+        new RegExp(`vHref\\('${variant}', '${url.replaceAll('.', '\\.')}'\\)`),
+        `${variant} switcher link must target ${url}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Clicking Tech, Finance, Commodity, Energy, or Good News from `/dashboard` now opens that monitor's dashboard directly instead of its welcome page, removing the unnecessary second click. Every production variant link is kept on the `/dashboard` route, with a regression contract covering all six targets.

## Validation

- `./node_modules/.bin/tsx --test tests/variant-navigation.test.mts`
- `npm run typecheck`
- Browser smoke check on a production-like local host: all six rendered variant links resolved to `/dashboard`.
- Full pre-push gate passed, including 249 edge tests.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/MODEL_SLUG-GPT--5-000000)
