### PR TITLE
docs(solutions): capture the parity-hardening learning from #6080

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -328,6 +328,32 @@ The upstream that actually fed a published theater-posture cycle, recorded with 
 
 Each cycle attributes exactly one winning source (or a vessels-only outcome when no flight source contributed), and per-source cycle counts accumulate for the life of the producer process. The attribution answers "who fed this record", not "which sources are healthy" — a primary source that answered healthily with zero relevant traffic is a quiet primary, not a failed one, and its health is judged from its own request counters, never from the attribution. Because the two Theater Posture producers use different vocabularies for their sources, every attribution also names its producer. See also: Theater Posture.
 
+## Seed Freshness Contracts
+
+### Transport Freshness
+
+Whether the *producer* ran recently and published enough rows — the age of its run heartbeat, plus a floor on the record count. It answers "did the pipeline execute", and it is the only freshness question most keys need. It is silent about the rows themselves: a run that publishes a complete set on schedule is transport-fresh even when every row in it is a reused copy of an old observation. See also: Content Freshness, Seed-Owned Key.
+
+### Content Freshness
+
+Whether the individual *observations* inside a published set are recent, judged per entity rather than over the set as a whole. It exists because a producer that reuses a cached entity payload while the upstream has not advanced stays transport-fresh indefinitely, so a complete, on-schedule, correctly-sized publication can still carry an entity whose data is days old.
+
+Two properties make it meaningful. The consumer pins both the entities it grades and the budget it grades them against, so a producer cannot certify its own stale observation by narrowing the set or widening the threshold. And the age is recomputed at read time rather than trusted from the producer's own count, because that count is a measurement taken when the producer ran and goes on ageing between runs. See also: Transport Freshness, Activation Marker, Content Clock.
+
+### Content Clock
+
+The timestamp content freshness is measured against: when the upstream's own data last *advanced*, not when it was last *retrieved*. The distinction is load-bearing because a producer may re-fetch an entity on a cache-expiry schedule and receive unchanged content — ageing the retrieval time would reset the clock on a frozen upstream and grade it current, which is the same substitution of transport for content that content freshness exists to end. See also: Content Freshness.
+
+### Activation Marker
+
+A durable, never-expiring marker a producer writes the first time it successfully publishes a new field, so consumers can tell "this producer has never shipped this" apart from "this producer shipped it and then stopped". It exists because consumers deploy in minutes while producers run on much slower schedules, so a newly deployed check would otherwise alarm on the absence of a field nothing has written yet.
+
+The softening it grants covers **absence only** — a field that is present is always evaluated, and once the marker exists a field that disappears fails closed. Reading the marker is a presence question, so consumers that answer it differently (by value rather than existence, or by treating an unreadable marker as a confirmed absence) will disagree about the same key. See also: Content Freshness, Grace Window.
+
+### Grace Window
+
+The bounded period in which a consumer withholds judgement because a producer has not yet had the chance to publish. A grace window must be closed by positive evidence — an activation marker that was read and found absent, or a compiled deadline — never by the mere absence of evidence, since "we could not tell" is a state that can persist forever and would silently disable the check it softens. See also: Activation Marker.
+
 ## Flagged ambiguities
 
 - *"Pool"* had been used for both a labelled market category and the complete set of markets — these are distinct. A pool is always a labelled subset; the complete set has no pool and must be requested as an explicit union.

--- a/docs/solutions/best-practices/hardening-one-side-of-a-parity-contract-reopens-the-divergence.md
+++ b/docs/solutions/best-practices/hardening-one-side-of-a-parity-contract-reopens-the-divergence.md
@@ -1,0 +1,104 @@
+---
+title: Hardening one side of a parity contract re-opens the divergence it was meant to close
+date: 2026-08-03
+category: best-practices
+module: api/mcp, api/health.js
+problem_type: best_practice
+component: testing_framework
+severity: high
+applies_when:
+  - "A change's thesis is that two surfaces must agree about the same underlying key or record"
+  - "Applying a review fix that makes one side of an agreeing pair stricter or more fail-closed"
+  - "Two consumers reach the same shared assessor through independently-written gates"
+  - "Writing tests for a contract whose correctness is a property of a pair, not of either half"
+tags:
+  - parity
+  - fail-closed
+  - cross-surface-agreement
+  - mutation-testing
+  - review-fixes
+  - health-monitoring
+  - mcp
+---
+
+# Hardening one side of a parity contract re-opens the divergence it was meant to close
+
+## Context
+
+[#6080](https://github.com/koala73/worldmonitor/issues/6080) existed because two surfaces disagreed about one seed-meta key: `/api/health` reported `STALE_CONTENT` for PortWatch port activity while the MCP freshness envelope over the same key reported `stale: false`. The fix taught MCP to evaluate the same per-country content dimension through the same shared assessor (`api/_content-freshness.js`).
+
+Review found three fail-opens in that first implementation. The most important: a failed read of the durable activation marker was swallowed to `null`, which read as "not activated", which **granted the deployment-order grace** — so a single Redis blip relabelled a real producer regression as deploy lag. The fix made MCP's activation state three-valued, requiring positive proof before granting grace (`api/mcp/freshness.ts:26`, `:73`).
+
+That fix introduced a **new** divergence in the exact dimension the PR existed to close.
+
+`/api/health` cannot distinguish a marker it failed to read from one that is genuinely absent — both land in the same bucket:
+
+```js
+// api/health.js:2026
+if (!r?.error && Number(r?.result) === 1) activatedNames.add(activationEntries[i][0]);
+```
+
+An errored read simply never enters the set, and `contentFreshnessPending` then tests `!activatedNames.has(...)`, so the grace is granted. After the hardening, for a pre-activation key whose marker read errors, health reports `OK` while MCP reports `stale: true`.
+
+## Guidance
+
+**When a change's thesis is "surfaces A and B must agree", correctness is a property of the pair. Test it as a pair, and re-ask the agreement question against every fix.**
+
+Three concrete practices:
+
+1. **Write the joint loop before hardening anything.** A test that drives the full input space through *both* surfaces and asserts they agree. Hardening one side is then what turns it red, at the moment you do it.
+
+2. **After applying any review fix to a parity-shaped change, ask literally: "which input class does my fix now treat differently from the other side?"** The strengthened guard is precisely the region where the other side's behavior was never re-examined.
+
+3. **When the surfaces must genuinely differ, encode the weaker invariant that is actually true** rather than keeping a parity claim that has become false. Here the shipped assertion is one-directional and testable:
+
+```js
+// tests/mcp-portwatch-content-freshness-parity.test.mjs:587
+it('never diverges in the unsafe direction', () => {
+  for (const activated of [true, false, null]) {
+    for (const meta of [STALE_CONTENT_META, FRESH_META, NO_BLOCK]) {
+      const healthStale = healthVerdict(meta, { activated: activated === true }).status !== 'OK';
+      if (!healthStale) continue;
+      assert.equal(mcpStale(meta, { activated }), true,
+        `MCP reported fresh where health alarmed (activated=${activated})`);
+    }
+  }
+});
+```
+
+"They cannot disagree" was false. "MCP never answers fresh where health alarms" is true, is the property that actually matters, and survives the deliberate asymmetry.
+
+## Why This Matters
+
+**Per-side verification is structurally blind to this class of bug.** The first fix passed a 14-mutant sweep and 174 tests. Every one of them compared MCP against *fixtures*; not one compared MCP against *health* on the newly-hardened input class. Mutation testing proves a guard is load-bearing within its own surface — it says nothing about whether two surfaces still answer alike.
+
+Two reviewers found it independently. Without them it would have shipped as a regression in the very dimension the PR was named for.
+
+**The direction of a divergence matters more than its existence.** Reverting MCP to match health would have restored a fail-open two other reviewers had flagged. The right resolution was to keep the safer behavior, document the asymmetry with its direction, pin it with a test, and file the alignment work as [#6095](https://github.com/koala73/worldmonitor/issues/6095) — never to leave it undocumented while the PR body claimed parity.
+
+**A grace granted on absence of evidence never expires.** "Marker missing → assume pre-activation → stay quiet" cannot tell a rollout window from an evicted key. Grace must require a positive read; unknown must fail closed.
+
+## When to Apply
+
+- Any change whose purpose is agreement between two consumers of one source of truth — health vs MCP, an alarm vs the data gate it protects, an API vs its cached projection.
+- Any review round on such a change, especially one that makes a guard *stricter*.
+- When two consumers share an assessor but reach it through independently-written gates: the shared code does not make the gates agree.
+
+## Examples
+
+Verification that would have caught it, versus verification that did not:
+
+```js
+// Did NOT catch it — asserts MCP against a fixture. Both the mutation sweep
+// and the pre-review suite were built entirely from this shape.
+assert.equal(mcpStale(NO_BLOCK_META, { activated: null }), true);
+
+// WOULD have caught it — asserts the two surfaces against each other on the
+// input class the hardening changed.
+assert.equal(healthVerdict(NO_BLOCK, { activated: false }).status, 'OK');
+assert.equal(mcpStale(NO_BLOCK, { activated: null }), true);
+// ^ these now disagree; the test forces that to be a deliberate, documented
+//   decision instead of an unnoticed regression.
+```
+
+A related trap from the same work: after switching the marker read from `GET` to `EXISTS`, a test asserting "the marker's stored *value* is irrelevant" became unfalsifiable — no code path read that value any more. It was removed rather than left as coverage theatre. See [checks-must-fail-closed-when-they-lose-their-target](./checks-must-fail-closed-when-they-lose-their-target.md).


### PR DESCRIPTION
Refs #6080, #6095. Documentation only — no runtime code.

## The learning

#6080's thesis was that two surfaces must agree about one seed-meta key: `/api/health` called PortWatch content stale while the MCP freshness envelope over the same key said `stale: false`.

Review found the first implementation swallowed a failed activation-marker read to `null`, which read as "not activated", which **granted the deployment-order grace** — one Redis blip relabelling a real producer regression as deploy lag. The fix made MCP's activation state three-valued.

**That fix created a new divergence in the exact dimension the PR existed to close.** `/api/health` cannot tell a marker it failed to read from one that is genuinely absent (`api/health.js:2026`), so it still softens. After the hardening, a pre-activation key whose marker read errors reads `OK` on health and `stale: true` on MCP.

A 14-mutant sweep and 174 passing tests were structurally blind to it — every one compared MCP against *fixtures*, never against *health* on the input class the hardening changed. Two reviewers caught it independently.

## What the doc records

Three practices that would have caught it:

1. Write the joint loop **before** hardening — so hardening one side is what turns it red.
2. After any review fix to a parity-shaped change, ask which input class the fix now treats differently from the other side.
3. When the surfaces must genuinely differ, encode the weaker invariant that is *actually true* rather than keeping a parity claim that has become false. The shipped assertion is one-directional: *MCP never answers fresh where health alarms*.

It also records why reverting to match health was the wrong call (it would restore a fail-open two other reviewers flagged), and why a grace granted on absence of evidence never expires.

## CONCEPTS.md

Seeds a **Seed Freshness Contracts** cluster for this area: Transport Freshness, Content Freshness, Content Clock, Activation Marker, Grace Window. These were in use across health, seed-health, MCP, and the seeders with no shared definition — and both the #6060 and #6080 review rounds turned on exactly the distinctions they draw (transport vs content; retrieval time vs upstream advance; absence of evidence vs evidence of absence).

## Verification

- Every cited `file:line` verified against `main` at 8875de132.
- `validate-frontmatter.py` and `validate-doc-claims.py` clean (2 paths, 1 link, 0 flags).
- `lint:md` clean across 203 files.