### PR TITLE
fix(security): bump brace-expansion past GHSA-rgw5-rvv9-x895 (#6118)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11730,9 +11730,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -14436,9 +14436,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20046,9 +20046,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -226,6 +226,8 @@
     "srvx": "^0.11.13",
     "protobufjs": "^7.6.2",
     "ws": "$ws",
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "brace-expansion@1": "^1.1.18",
+    "brace-expansion@2": "^2.1.4"
   }
 }

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -2396,9 +2396,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3757,9 +3757,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -29,7 +29,9 @@
   "overrides": {
     "esbuild": "0.28.1",
     "undici": "$undici",
-    "ws": "$ws"
+    "ws": "$ws",
+    "brace-expansion@1": "^1.1.18",
+    "brace-expansion@2": "^2.1.4"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Closes #6118. **Unblocks every open PR and `main`.**

## Why CI went red with no code change

[GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (`brace-expansion`: DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation) was published today. `main` passed at **14:15Z**; the first failure is at **18:43Z**, on a branch touching no manifest or lockfile. It fails `audit-lockfile (root)`, `audit-lockfile (scripts)`, and therefore `security-audit` and `gate`.

## The fix

Vulnerable range: `<=1.1.17 || 2.0.0 - 2.1.3 || 4.0.0 - 5.0.8`. Both affected lines are transitive only, behind pinned `minimatch` majors that will not move on their own:

```
root    prod  1.1.16   exceljs -> archiver -> archiver-utils -> glob -> minimatch@3
scripts prod  1.1.16   and  2.1.2   readdir-glob -> minimatch@5
```

So this uses the `overrides` mechanism the repo already applies to `fast-xml-parser`, `serialize-javascript`, `node-forge` and `shell-quote` — keyed **per major** (`brace-expansion@1` / `brace-expansion@2`) so 1.x consumers are not forced onto 2.x.

## Why the lockfile diff is safe to skim

Regenerated with `--package-lock-only`, so no unrelated dependency could float in alongside — a full refresh previously reded every lint PR through a biome caret-float (#5395). **Exactly five entries move, all `brace-expansion`:**

| Lockfile | Move |
|---|---|
| `package-lock.json` | 1.1.16 -> 1.1.18; 2.1.2 -> 2.1.4 (x2) |
| `scripts/package-lock.json` | 1.1.16 -> 1.1.18; 2.1.2 -> 2.1.4 |

Verified mechanically by diffing every `packages{}.version` between the old and new lockfiles: total moved = 3 and 2 respectively, nothing else.

## Verification

Ran the real gate script — `.github/scripts/audit-production-dependencies.mjs` — against **all six audited workspaces** locally, not just the two that were failing:

```
root                  exit 0   1 high+ advisories baselined or absent
scripts               exit 0   0 high+
consumer-prices-core  exit 0   0 high+
blog-site             exit 0   0 high+
pro-test              exit 0   1 high+ baselined
docker-runtime        exit 0   0 high+
```

The remaining root warning is the pre-existing **baselined** sharp/libvips advisory (`GHSA-f88m-g3jw-g9cj`), unchanged by this PR.

## Deliberately not included

- The dev-only `5.0.7` copy under `workbox-build` is untouched. The gate audits with `--omit=dev`, and bumping it would pull unrelated build tooling into a lockfile-only PR.
- The script also reports a **stale baseline entry** (`GHSA-mh99-v99m-4gvg` is baselined for both lockfiles but matches no current advisory). Real cleanup, but a separate concern from unblocking CI.

Lockfile-only: no runtime behaviour change.

https://claude.ai/code/session_01JNeFqtdXUcb7jYssWMyABt