### PR TITLE
fix(military): stop seed-military-flights crashing on every run

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -43,7 +43,7 @@
 			"correctness": {
 				"noUnusedVariables": "off",
 				"noUnusedImports": "off",
-				"noUndeclaredVariables": "off"
+				"noUndeclaredVariables": "error"
 			},
 			"suspicious": {
 				"noExplicitAny": "off",
@@ -99,7 +99,12 @@
 		}
 	},
 	"javascript": {
-		"globals": ["globalThis"]
+		"globals": [
+			"globalThis",
+			"__APP_VERSION__",
+			"__BUILD_HASH__",
+			"__CLERK_JS_VERSION__"
+		]
 	},
 	"assist": {
 		"enabled": false

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -1349,6 +1349,12 @@ async function main() {
       assessedAt,
     }));
     const posturePayload = { theaters };
+    // Derived from `theaters`, which is already in scope here, so it must NOT live inside the
+    // theater-posture lock block below: `forecastInputsPayload.stats` reads it unconditionally,
+    // including on the lock-skipped branch. #6092 wrapped the publish in `else { try { … } }` and
+    // carried this declaration in with it, leaving the consumer referencing a block-scoped const
+    // -> `PUBLISH FAILED: elevated is not defined` on 100% of runs.
+    const elevated = theaters.filter((t) => t.postureLevel !== 'normal').length;
     const theaterPostureLockResult = await acquireLockSafely('theater-posture', runId, 120_000, { label: 'theater-posture' });
     if (theaterPostureLockResult.skipped || !theaterPostureLockResult.locked) {
       console.log(`  SKIPPED: theater posture publication (${theaterPostureLockResult.skipped ? 'Redis unavailable during lock acquisition' : 'another producer in progress'})`);
@@ -1368,7 +1374,6 @@ async function main() {
         await redisSet(url, token, THEATER_POSTURE_STALE_KEY, postureEnvelope, THEATER_POSTURE_STALE_TTL);
         await redisSet(url, token, THEATER_POSTURE_BACKUP_KEY, postureEnvelope, THEATER_POSTURE_BACKUP_TTL);
         await redisSet(url, token, 'seed-meta:theater-posture', { fetchedAt: assessedAt, recordCount: theaterFlights.length, sourceVersion: source || '', producer: 'seed-military-flights', publicationId }, 604800);
-        const elevated = theaters.filter((t) => t.postureLevel !== 'normal').length;
         console.log(`  Theater posture: ${theaters.length} theaters (${elevated} elevated)`);
       } finally {
         await releaseLock('theater-posture', runId);


### PR DESCRIPTION
## Summary

Since the #6092 deploy at 2026-08-03 11:51Z, `seed-military-flights` died on **every single run** — roughly 45 consecutive ticks over 7.5h, `0` successes — with `PUBLISH FAILED: elevated is not defined`. Military surge and forecast-input data stopped advancing entirely; both payloads carry a 24h stale TTL, so they were on track to disappear rather than merely go stale.

The crash lands *after* `military:flights:v1` and `seed-meta:theater-posture` are written and verified, so the flights layer itself kept updating and every health key with a freshness budget stayed green. Nothing alarmed for the full 7.5h.

## The bug

#6092 wrapped the theater-posture publish in `else { try { … } finally { … } }` and carried `const elevated` into the new block. Its consumer stayed outside:

```js
// inside the new lock block
const elevated = theaters.filter((t) => t.postureLevel !== 'normal').length;
…
// ~40 lines below, outside it
elevatedTheaters: elevated,   // ReferenceError — no outer binding exists
```

Because `const` is block-scoped, the outer scope has **no binding at all** — this throws on every run regardless of which lock branch is taken, which is why the crash rate was 100% rather than intermittent. Fixed by hoisting the declaration beside the `theaters` it derives from; it never depended on the lock.

## Why CI merged a guaranteed crash

`correctness/noUndeclaredVariables` was explicitly disabled in `biome.json`. It catches this exactly:

```
scripts/seed-military-flights.mjs:1395:27 lint/correctness/noUndeclaredVariables
  × The elevated variable is undeclared.
  > 1395 │         elevatedTheaters: elevated,
```

Enabling it repo-wide surfaced 12 further hits, all legitimate Vite build-time defines (`__APP_VERSION__`, `__BUILD_HASH__`, `__CLERK_JS_VERSION__`). Those are already declared in `src/vite-env.d.ts`, but Biome does not read ambient TypeScript types for globals — so they are declared in `javascript.globals` instead. That is the entire cost of turning the rule on.

## Validation

- **Root cause confirmed on live infrastructure**, not inferred: identical `PUBLISH FAILED: elevated is not defined` terminal line across deployments `cbc45ef8`, `c28b6e21`, `91b98fa1`, `4963833a`, with `0` successful runs in the window.
- **Mutation-tested the new guard** — re-introducing the exact #6092 shape turns `noUndeclaredVariables` red on the consuming line; the fix is green. The rule is clean across all 3494 files and `npm run lint` passes.
- **Tests:** 154/154 pass across the five military suites (`military-surges`, `analysis-military-surge`, `military-classification`, `military-flight-classification`, `military-hex-confidence`).

Deploy-time behavior can only be confirmed once this is on `main` and the next 10-minute tick fires; the fix is a scope correction with no runtime dependency, so local test coverage plus the linter is the strongest evidence available pre-merge.

## Related

- Related: #6125 — the reason this ran 7.5h unnoticed. `military:forecast-inputs:*` and `military:surges:*` are the keys a mid-publish crash starves, and neither has a health freshness budget; `militaryForecastInputs` is explicitly excluded at `api/health.js:788`.
- Regressed by #6092.

Separately, the `diagnose-railway-seeders` skill reported this fleet as healthy throughout, because `PUBLISH FAILED:` was not in its crash-marker set — a log matching no known marker fell through to "not a crash" and was dropped. That skill lives outside this repo and was fixed alongside this work; it now classifies the service `FATAL_POSTFETCH` with `7 crash / 0 success`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
