### PR TITLE
fix(selfhost): allow Docker LLM origins through sidecar SSRF guard

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1886,22 +1886,33 @@ export async function createLocalApiServer(options = {}) {
       const boundPort = typeof address === 'object' && address?.port ? address.port : context.port;
       context.port = boundPort;
       const extraAllowedPrivateOrigins = [];
-      // Docker self-host ONLY: the Redis REST proxy (UPSTASH_REDIS_REST_URL)
-      // points at an internal private host (e.g. http://redis-rest:80 on a
-      // docker network). Without trusting it the SSRF guard blocks every Redis
-      // call and all /api/* return 503 REDIS_DOWN. Gated on mode === 'docker'
-      // so desktop/production startup never widens the SSRF boundary via env
-      // — the same containment as the cloudFallback=false docker policy above,
-      // and the programmatic allowPrivateFetchOrigins escape hatch stays
-      // env-free. On desktop UPSTASH_REDIS_REST_URL is a public Upstash https
-      // origin that already passes the SSRF check, so this path is docker-only.
-      if (context.mode === 'docker' && process.env.UPSTASH_REDIS_REST_URL) {
-        try {
-          extraAllowedPrivateOrigins.push(new URL(process.env.UPSTASH_REDIS_REST_URL).origin);
-        } catch (err) {
-          context.logger.warn(
-            `[local-api] UPSTASH_REDIS_REST_URL is not a valid URL; not added to the private-fetch allowlist (Redis calls will be SSRF-blocked): ${err.message}`,
-          );
+      if (context.mode === 'docker') {
+        const addConfiguredPrivateOrigin = (envKey, blockedService) => {
+          const rawUrl = process.env[envKey];
+          if (!rawUrl) return;
+          try {
+            extraAllowedPrivateOrigins.push(new URL(rawUrl).origin);
+          } catch (err) {
+            context.logger.warn(
+              `[local-api] ${envKey} is not a valid URL; not added to the private-fetch allowlist (${blockedService}): ${err.message}`,
+            );
+          }
+        };
+
+        // Docker self-host ONLY: the Redis REST proxy (UPSTASH_REDIS_REST_URL)
+        // points at an internal private host (e.g. http://redis-rest:80 on a
+        // docker network). Without trusting it the SSRF guard blocks every Redis
+        // call and all /api/* return 503 REDIS_DOWN. On desktop,
+        // UPSTASH_REDIS_REST_URL is a public Upstash https origin that already
+        // passes the SSRF check, so this path is docker-only.
+        addConfiguredPrivateOrigin('UPSTASH_REDIS_REST_URL', 'Redis calls will be SSRF-blocked');
+
+        // SELF_HOSTING.md documents LLM_API_URL for compose-network or LAN
+        // endpoints; OLLAMA_API_URL is the supported desktop runtime setting.
+        // Without trusting their exact configured origins, the global SSRF
+        // guard blocks every private LLM probe and silently skips the provider.
+        for (const envKey of ['LLM_API_URL', 'OLLAMA_API_URL']) {
+          addConfiguredPrivateOrigin(envKey, 'LLM calls will be SSRF-blocked');
         }
       }
       if (context.allowPrivateRemoteBase) {

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -852,6 +852,120 @@ test('allows only Docker mode to fetch configured private Redis REST origin', as
   }
 });
 
+test('allows only Docker mode to fetch configured private LLM origins', async () => {
+  const envSnapshot = {
+    LLM_API_URL: process.env.LLM_API_URL,
+    OLLAMA_API_URL: process.env.OLLAMA_API_URL,
+    UNCONFIGURED_PRIVATE_URL: process.env.UNCONFIGURED_PRIVATE_URL,
+  };
+  let handlerHits = 0;
+
+  const upstreams = [];
+  const warnings = [];
+  async function createProbeOrigin() {
+    const upstream = createServer((req, res) => {
+      if (req.headers['x-sidecar-test-probe'] === '1') handlerHits += 1;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    upstreams.push(upstream);
+    const port = await listen(upstream);
+    return `http://127.0.0.1:${port}/v1/chat/completions`;
+  }
+
+  const [privateLlmUrl, privateOllamaUrl, unconfiguredPrivateUrl] = await Promise.all([
+    createProbeOrigin(),
+    createProbeOrigin(),
+    createProbeOrigin(),
+  ]);
+
+  const localApi = await setupApiDir({
+    'llm-probe.js': `
+      export default async function handler(request) {
+        const envKey = new URL(request.url).searchParams.get('envKey');
+        const upstream = await fetch(process.env[envKey], {
+          headers: { 'x-sidecar-test-probe': '1' },
+        });
+        const payload = await upstream.text();
+        return new Response(payload, {
+          status: upstream.status,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    `,
+  });
+
+  async function runProbes(mode, envKeys) {
+    const app = await createLocalApiServer({
+      port: 0,
+      apiDir: localApi.apiDir,
+      mode,
+      logger: { log() { }, warn(message) { warnings.push(message); }, error() { } },
+    });
+    const { port } = await app.start();
+    try {
+      return await Promise.all(
+        envKeys.map((envKey) => authFetch(
+          `http://127.0.0.1:${port}/api/llm-probe?envKey=${encodeURIComponent(envKey)}`,
+        )),
+      );
+    } finally {
+      await app.close();
+    }
+  }
+
+  try {
+    process.env.LLM_API_URL = privateLlmUrl;
+    process.env.OLLAMA_API_URL = privateOllamaUrl;
+    process.env.UNCONFIGURED_PRIVATE_URL = unconfiguredPrivateUrl;
+    const envKeys = ['LLM_API_URL', 'OLLAMA_API_URL', 'UNCONFIGURED_PRIVATE_URL'];
+    const dockerResponses = await runProbes('docker', envKeys);
+    for (const [index, envKey] of envKeys.entries()) {
+      const dockerResponse = dockerResponses[index];
+      if (index < 2) {
+        assert.equal(dockerResponse.status, 200, envKey);
+        assert.deepEqual(await dockerResponse.json(), { ok: true });
+      } else {
+        assert.equal(dockerResponse.status, 502, envKey);
+        const dockerBody = await dockerResponse.json();
+        assert.equal(dockerBody.error, 'Local handler error');
+        assert.match(dockerBody.reason, /SSRF blocked/);
+      }
+    }
+
+    const desktopResponses = await runProbes('desktop-sidecar', envKeys);
+    for (const [index, envKey] of envKeys.entries()) {
+      const desktopResponse = desktopResponses[index];
+      assert.equal(desktopResponse.status, 502, envKey);
+      const desktopBody = await desktopResponse.json();
+      assert.equal(desktopBody.error, 'Local handler error');
+      assert.match(desktopBody.reason, /SSRF blocked/);
+    }
+    assert.equal(handlerHits, 2, 'only Docker handler probes should reach the upstream');
+
+    process.env.LLM_API_URL = 'not-a-url';
+    process.env.OLLAMA_API_URL = '://also-not-a-url';
+    const malformedResponses = await runProbes('docker', ['LLM_API_URL', 'OLLAMA_API_URL']);
+    for (const [index, envKey] of ['LLM_API_URL', 'OLLAMA_API_URL'].entries()) {
+      assert.equal(malformedResponses[index].status, 502, envKey);
+      const malformedBody = await malformedResponses[index].json();
+      assert.equal(malformedBody.error, 'Local handler error');
+      assert.match(malformedBody.reason, /(?:parse URL|Invalid URL)/i);
+    }
+    assert.ok(warnings.some((message) => message.includes('LLM_API_URL is not a valid URL')));
+    assert.ok(warnings.some((message) => message.includes('OLLAMA_API_URL is not a valid URL')));
+  } finally {
+    for (const [key, value] of Object.entries(envSnapshot)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await localApi.cleanup();
+    await Promise.all(upstreams.map((upstream) => new Promise((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    })));
+  }
+});
+
 test('blocks handler global fetches to non-global IPv4 special ranges', async () => {
   const originalHttpRequest = http.request;
   const blockedUrls = [


### PR DESCRIPTION
## Summary

Self-hosted Docker deployments can now reach private OpenAI-compatible endpoints configured through `LLM_API_URL` or `OLLAMA_API_URL`. Previously the sidecar SSRF guard rejected localhost, Docker-network, and LAN origins during provider health/probe fetches, so configured LLMs appeared unavailable. Docker now allowlists only the exact origins from those variables; desktop remains default-deny for private targets, and malformed or unrelated private origins stay blocked.

## Validation

- `node --test src-tauri/sidecar/local-api-server.test.mjs` — 55/55 passed.
- `node --test api/*.test.mjs src-tauri/sidecar/*.test.mjs` — 290/290 passed.
- Frontend and API TypeScript checks passed.
- Convex string-call audit passed.
- Changed-file Biome lint passed; it reports only existing unrelated diagnostics in `local-api-server.mjs`.
- Pre-push hook passed all enforced gates.

## Post-Deploy Monitoring & Validation

- Owner: WorldMonitor maintainers.
- Search sidecar logs for `[local-api] LLM health warmed`, `SSRF blocked`, `LLM_API_URL`, and `OLLAMA_API_URL`.
- Expected: in self-hosted Docker, a configured private endpoint warms successfully and requests to its exact origin do not log `SSRF blocked`; unrelated private origins remain blocked.
- Failure signal: the configured endpoint still returns 502 or logs `SSRF blocked` during health/probe requests. Roll back to the previous sidecar image/configuration and restore the prior environment values while investigating.

Fixes #6116.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-Codex-000000)
