### PR TITLE
feat(desktop): acknowledge checkout in returning browser

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -582,10 +582,14 @@ export class PanelLayoutManager implements AppModule {
       // active, retire the app-local retry/referral state here instead. This
       // is scoped to the desktop app; an anonymous or mismatched browser must
       // never clear its own unrelated local checkout state.
-      const entitlementActive = isEntitlementActive(state, Date.now());
+      // Preserve null for unavailable auth-handoff snapshots: isEntitlementActive
+      // collapses null→false, which would invent a free→pro edge and re-trigger
+      // the daypesta reload loop (see createEntitlementReloadController).
+      const entitlementActive =
+        state === null ? null : isEntitlementActive(state, Date.now());
       if (
         this.ctx.isDesktopApp &&
-        entitlementActive &&
+        entitlementActive === true &&
         loadCheckoutAttempt()
       ) {
         clearCheckoutAttempt('success');

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -51,7 +51,10 @@ import { initEntitlementSubscription, destroyEntitlementSubscription, isEntitlem
 import { createEntitlementReloadController } from '@/services/entitlement-reload-controller';
 import { initSubscriptionWatch, destroySubscriptionWatch, onSubscriptionChange } from '@/services/billing';
 import { initPaymentFailureBanner } from '@/components/payment-failure-banner';
-import { handleCheckoutReturn } from '@/services/checkout-return';
+import {
+  handleCheckoutReturn,
+  resolveCheckoutReturnRouting,
+} from '@/services/checkout-return';
 import { registerCheckoutSuccessCallback, destroyCheckoutOverlay, showCheckoutSuccess, consumePostCheckoutFlag, clearCheckoutAttempt, loadCheckoutAttempt } from '@/services/checkout';
 import {
   markProActivationPending,
@@ -414,16 +417,21 @@ export class PanelLayoutManager implements AppModule {
     // entitlement updates after purchasing (P1: newly upgraded users must
     // see their premium access without a manual page reload).
     //
-    // Two return paths need to seed the transition detector as post-checkout:
+    // Two account-bound return paths need to seed the transition detector as
+    // post-checkout:
     //   1. Full-page Dodo redirect — handleCheckoutReturn() reads
     //      subscription_id/status URL params and cleans them.
     //   2. Dodo overlay success — setTimeout(reload) with no URL params;
     //      we stash a session flag before the reload and consume it here.
     const returnResult = handleCheckoutReturn();
-    const returnedFromOverlay = consumePostCheckoutFlag();
-    const returnedFromCheckout = returnResult.kind === 'success' || returnedFromOverlay;
+    const returnedFromOverlayFlag = consumePostCheckoutFlag();
+    const {
+      returnedFromDesktopBrowser,
+      returnedFromCheckout,
+      returnedFromAccountCheckout,
+    } = resolveCheckoutReturnRouting(returnResult, returnedFromOverlayFlag);
     this.proActivationController = new ProActivationController(ctx, {
-      reloadPending: returnedFromCheckout,
+      reloadPending: returnedFromAccountCheckout,
       openAiAnalyst: () => this.revealAnalystPanel(),
       openSearch: callbacks.openSearch,
     });
@@ -431,19 +439,21 @@ export class PanelLayoutManager implements AppModule {
       // Funnel (#4931): the purchase-complete signal on the client side.
       // Queued by the analytics facade until Umami loads after first paint.
       trackCheckoutSuccess(returnResult.kind === 'success' ? 'url-return' : 'overlay-flag');
-      // Pro Activation Onboarding: capture the plan identity from the attempt
-      // record and write the durable pending-onboarding marker BEFORE the
-      // clear below wipes the attempt. Success branch only (the `failed`
-      // branch structurally cannot reach here). An overlay-only return may
-      // carry no attempt record → the marker omits productId and the boot
-      // hook falls back to the live entitlement snapshot for plan identity
-      // (never a write-time frozen fallback — see decideActivationMount).
-      const activationProductId = loadCheckoutAttempt()?.productId ?? null;
-      markProActivationPending(activationProductId);
-      // Full-page return cleared its URL params; belt-and-braces clear
-      // of the attempt record here catches the success path where the
-      // overlay handler never ran (direct Dodo redirect).
-      clearCheckoutAttempt('success');
+      if (returnedFromAccountCheckout) {
+        // Pro Activation Onboarding: capture the plan identity from the attempt
+        // record and write the durable pending-onboarding marker BEFORE the
+        // clear below wipes the attempt. Success branch only (the `failed`
+        // branch structurally cannot reach here). An overlay-only return may
+        // carry no attempt record → the marker omits productId and the boot
+        // hook falls back to the live entitlement snapshot for plan identity
+        // (never a write-time frozen fallback — see decideActivationMount).
+        const activationProductId = loadCheckoutAttempt()?.productId ?? null;
+        markProActivationPending(activationProductId);
+        // Full-page return cleared its URL params; belt-and-braces clear
+        // of the attempt record here catches the success path where the
+        // overlay handler never ran (direct Dodo redirect).
+        clearCheckoutAttempt('success');
+      }
       // waitForEntitlement: true keeps the banner mounted across the
       // entitlement-watcher reload (post-PR-4 the watcher is the single
       // reload source). If the user is already entitled on mount the
@@ -453,8 +463,13 @@ export class PanelLayoutManager implements AppModule {
       // app) and masked in the banner before rendering to keep the raw
       // address out of screenshots / screen-shares of the banner.
       showCheckoutSuccess({
-        waitForEntitlement: true,
-        email: getAuthState().user?.email ?? null,
+        // The desktop marker acknowledges payment in an arbitrary browser;
+        // it cannot prove that browser is signed into the purchasing Clerk
+        // account. Keep that path informational instead of waiting on (or
+        // displaying) another browser identity's entitlement.
+        waitForEntitlement: !returnedFromDesktopBrowser,
+        accountAgnostic: returnedFromDesktopBrowser,
+        email: returnedFromDesktopBrowser ? null : getAuthState().user?.email ?? null,
       });
     } else if (returnResult.kind === 'failed') {
       trackCheckoutFailed(returnResult.rawStatus);
@@ -554,7 +569,7 @@ export class PanelLayoutManager implements AppModule {
     // tests/entitlement-reload-controller.test.mts locks the cross-boot
     // one-navigation invariant from the daypesta customer recording.
     const entitlementReloadController = createEntitlementReloadController({
-      returnedFromCheckout,
+      returnedFromCheckout: returnedFromAccountCheckout,
       onSnapshot: () => this.updatePanelGating(getAuthState()),
       reload: () => {
         console.log('[entitlements] Subscription activated — reloading once to unlock panels');
@@ -562,8 +577,21 @@ export class PanelLayoutManager implements AppModule {
       },
     });
     this.unsubscribeEntitlementChange = onEntitlementChange((state) => {
+      // Desktop checkout is handed to the OS browser, so the app itself never
+      // receives the Dodo return URL. Once its Clerk-bound entitlement becomes
+      // active, retire the app-local retry/referral state here instead. This
+      // is scoped to the desktop app; an anonymous or mismatched browser must
+      // never clear its own unrelated local checkout state.
+      const entitlementActive = isEntitlementActive(state, Date.now());
+      if (
+        this.ctx.isDesktopApp &&
+        entitlementActive &&
+        loadCheckoutAttempt()
+      ) {
+        clearCheckoutAttempt('success');
+      }
       entitlementReloadController.handleSnapshot(
-        state === null ? null : isEntitlementActive(state, Date.now()),
+        entitlementActive,
         getAuthState().user?.id ?? null,
       );
     });

--- a/src/services/checkout-return-url.ts
+++ b/src/services/checkout-return-url.ts
@@ -10,10 +10,19 @@ const DASHBOARD_PATH = '/dashboard';
  */
 export const CHECKOUT_RETURN_PARAM = 'wm_checkout';
 export const CHECKOUT_RETURN_MARKER = 'return';
+/** Optional provenance for returns that cross the desktop WebView boundary. */
+export const CHECKOUT_SOURCE_PARAM = 'wm_src';
+export const DESKTOP_CHECKOUT_SOURCE = 'desktop';
 
-export function buildDashboardCheckoutReturnUrl(origin: string): string {
+export type CheckoutReturnSource = typeof DESKTOP_CHECKOUT_SOURCE;
+
+export function buildDashboardCheckoutReturnUrl(
+  origin: string,
+  source?: CheckoutReturnSource,
+): string {
   const url = new URL(DASHBOARD_PATH, origin);
   url.searchParams.set(CHECKOUT_RETURN_PARAM, CHECKOUT_RETURN_MARKER);
+  if (source) url.searchParams.set(CHECKOUT_SOURCE_PARAM, source);
   return url.toString();
 }
 

--- a/src/services/checkout-return.ts
+++ b/src/services/checkout-return.ts
@@ -17,25 +17,64 @@
  *   4. Dashboard full-page return bridge: `?wm_checkout=return` — set
  *      as the merchant return URL for Dodo sessions so 3DS returns land
  *      on the dashboard route instead of `/`, which is now the public
- *      welcome page. This marker only triggers the post-checkout
- *      reconciliation path when a local checkout attempt exists.
+ *      welcome page. Web returns require a local checkout attempt; desktop
+ *      returns add `wm_src=desktop` because the attempt was written in the
+ *      app WebView's separate sessionStorage.
  *
  * This module inspects those params, cleans them from the URL, and
  * returns a discriminated union so callers can branch on success vs
  * failure vs "not a checkout return at all" without sentinel-boolean
  * ambiguity. The prior boolean return silently swallowed declined
  * payments — a Dodo return with status=failed looked identical to "no
- * checkout here, render normal dashboard."
+ * checkout here, render normal dashboard." A desktop-source success is
+ * deliberately account-agnostic: it acknowledges the return but must not
+ * seed browser-local entitlement state.
  */
 
 import { loadCheckoutAttempt } from './checkout-attempt';
-import { CHECKOUT_RETURN_PARAM, CHECKOUT_RETURN_MARKER } from './checkout-return-url';
+import {
+  CHECKOUT_RETURN_PARAM,
+  CHECKOUT_RETURN_MARKER,
+  CHECKOUT_SOURCE_PARAM,
+  DESKTOP_CHECKOUT_SOURCE,
+  type CheckoutReturnSource,
+} from './checkout-return-url';
 import { applyProBannerEntitlementHint } from './pro-banner-policy';
 
 export type CheckoutReturnResult =
   | { kind: 'none' }
-  | { kind: 'success' }
+  | { kind: 'success'; source?: CheckoutReturnSource }
   | { kind: 'failed'; rawStatus: string };
+
+export interface CheckoutReturnRouting {
+  returnedFromDesktopBrowser: boolean;
+  returnedFromOverlay: boolean;
+  returnedFromCheckout: boolean;
+  returnedFromAccountCheckout: boolean;
+}
+
+/**
+ * Resolve page-level checkout signals after URL parsing and overlay-flag
+ * consumption. A URL result wins over a stale overlay flag, including a
+ * failed Dodo result that must never be promoted to success.
+ */
+export function resolveCheckoutReturnRouting(
+  result: CheckoutReturnResult,
+  overlayFlag: boolean,
+): CheckoutReturnRouting {
+  const returnedFromDesktopBrowser =
+    result.kind === 'success' && result.source === DESKTOP_CHECKOUT_SOURCE;
+  const returnedFromOverlay = result.kind === 'none' && overlayFlag;
+  const returnedFromCheckout = result.kind === 'success' || returnedFromOverlay;
+  const returnedFromAccountCheckout =
+    (result.kind === 'success' && !returnedFromDesktopBrowser) || returnedFromOverlay;
+  return {
+    returnedFromDesktopBrowser,
+    returnedFromOverlay,
+    returnedFromCheckout,
+    returnedFromAccountCheckout,
+  };
+}
 
 const SUCCESS_STATUSES = new Set(['active', 'succeeded']);
 const FAILED_STATUSES = new Set(['failed', 'declined', 'cancelled', 'canceled']);
@@ -63,11 +102,13 @@ export function handleCheckoutReturn(): CheckoutReturnResult {
   const paymentId = params.get('payment_id');
   const status = params.get('status') ?? '';
   const wmMarker = params.get(CHECKOUT_RETURN_PARAM);
+  const wmSource = params.get(CHECKOUT_SOURCE_PARAM);
 
   const hasDodoParams = Boolean(subscriptionId || paymentId);
   const hasAnyWmMarker = wmMarker !== null;
   const hasWmSuccess = wmMarker === WM_MARKER_SUCCESS;
   const hasWmReturn = wmMarker === CHECKOUT_RETURN_MARKER;
+  const isDesktopReturn = hasWmReturn && wmSource === DESKTOP_CHECKOUT_SOURCE;
 
   // Early return when nothing checkout-related is present. Note we
   // enter cleanup below when ANY wm_checkout value is present (even
@@ -89,6 +130,7 @@ export function handleCheckoutReturn(): CheckoutReturnResult {
     'email',
     'license_key',
     CHECKOUT_RETURN_PARAM,
+    CHECKOUT_SOURCE_PARAM,
   ];
   for (const key of paramsToRemove) {
     params.delete(key);
@@ -104,13 +146,17 @@ export function handleCheckoutReturn(): CheckoutReturnResult {
   //   2. WM marker as success bridge — only the exact `success` value
   //      is honored; any other wm_checkout value is dropped
   //      (defensively stripped above) without triggering success.
-  //   3. Unknown Dodo status WITH ID params → failed so the user sees
+  //   3. Desktop return marker with its exact source → acknowledgement
+  //      success without requiring browser-local attempt state.
+  //   4. Unknown Dodo status WITH ID params → failed so the user sees
   //      an actionable banner instead of silent drop.
-  //   4. Fallback → none.
+  //   5. Fallback → none.
   if (hasDodoParams) {
     if (SUCCESS_STATUSES.has(status)) {
-      markJustPaidProBannerHint();
-      return { kind: 'success' };
+      if (!isDesktopReturn) markJustPaidProBannerHint();
+      return isDesktopReturn
+        ? { kind: 'success', source: DESKTOP_CHECKOUT_SOURCE }
+        : { kind: 'success' };
     }
     if (FAILED_STATUSES.has(status)) return { kind: 'failed', rawStatus: status };
   }
@@ -118,9 +164,14 @@ export function handleCheckoutReturn(): CheckoutReturnResult {
     markJustPaidProBannerHint();
     return { kind: 'success' };
   }
-  if (!hasDodoParams && hasWmReturn && !status && loadCheckoutAttempt()) {
-    markJustPaidProBannerHint();
-    return { kind: 'success' };
+  if (!hasDodoParams && hasWmReturn && !status) {
+    if (isDesktopReturn) {
+      return { kind: 'success', source: DESKTOP_CHECKOUT_SOURCE };
+    }
+    if (loadCheckoutAttempt()) {
+      markJustPaidProBannerHint();
+      return { kind: 'success' };
+    }
   }
   if (hasDodoParams && status) return { kind: 'failed', rawStatus: status };
   return { kind: 'none' };

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -56,7 +56,11 @@ import { showDuplicateSubscriptionDialog } from './checkout-duplicate-dialog';
 import { showCheckoutPendingDialog } from './checkout-pending-dialog';
 import { resolvePlanDisplayName } from './checkout-plan-names';
 import { createEntitlementWatchdog, type EntitlementWatchdog } from './entitlement-watchdog';
-import { buildDashboardCheckoutReturnUrl, resolveCheckoutReturnOrigin } from './checkout-return-url';
+import {
+  buildDashboardCheckoutReturnUrl,
+  DESKTOP_CHECKOUT_SOURCE,
+  resolveCheckoutReturnOrigin,
+} from './checkout-return-url';
 import { WEB_APP_ORIGIN } from '@/config/web-origin';
 import { openExternalUrl } from './external-navigation';
 import { isDesktopRuntime } from './desktop-runtime';
@@ -906,6 +910,7 @@ export async function startCheckout(
     discountCode: options?.discountCode,
     startedAt: Date.now(),
   });
+  const desktopRuntime = isDesktopRuntime();
   try {
     let token = await getClerkToken();
     if (!token) {
@@ -932,7 +937,8 @@ export async function startCheckout(
         // the WebView origin serves no /dashboard route for Dodo to return
         // to (#5911).
         returnUrl: buildDashboardCheckoutReturnUrl(
-          resolveCheckoutReturnOrigin(window.location.origin, isDesktopRuntime()),
+          resolveCheckoutReturnOrigin(window.location.origin, desktopRuntime),
+          desktopRuntime ? DESKTOP_CHECKOUT_SOURCE : undefined,
         ),
         discountCode: options?.discountCode,
         referralCode: effectiveReferral,
@@ -1097,7 +1103,7 @@ export async function startCheckout(
     // event handler / watchdog) is left dormant pending removal.
     const hostedCheckoutUrl = safeHostedCheckoutUrl(result.checkout_url);
     if (hostedCheckoutUrl) {
-      if (isDesktopRuntime()) {
+      if (desktopRuntime) {
         // #5911: on desktop the same `window.location.assign` would replace
         // the entire app with Dodo's page — no tab, no back button — and run
         // 3DS/fraud inside an embedded WebView, the exact nesting #4449 moved
@@ -1305,6 +1311,11 @@ function renderCheckoutErrorSurface(
  *   - `timeout`: after 30s with no transition, swap to an explicit
  *               "Refresh if features haven't unlocked" CTA + Sentry
  *               warning. Never silently disappears.
+ *
+ * Account-agnostic mode is a short-lived classic acknowledgement for a
+ * desktop return in an arbitrary browser. It deliberately skips Clerk email
+ * hydration and entitlement waiting because this browser may belong to nobody
+ * or to a different account.
  */
 // Module-scoped cleanup for the currently-mounted success banner.
 // When `showCheckoutSuccess` is called a second time before the first
@@ -1317,7 +1328,7 @@ function renderCheckoutErrorSurface(
 let _currentBannerCleanup: (() => void) | null = null;
 
 export function showCheckoutSuccess(
-  options?: { waitForEntitlement?: boolean; email?: string | null },
+  options?: { waitForEntitlement?: boolean; email?: string | null; accountAgnostic?: boolean },
 ): void {
   _currentBannerCleanup?.();
   _currentBannerCleanup = null;
@@ -1356,7 +1367,8 @@ export function showCheckoutSuccess(
   // mutable container that later transitions can re-read, and
   // subscribe to auth-state once to update the banner text when email
   // hydrates.
-  let currentMaskedEmail = maskEmail(options?.email);
+  const accountAgnostic = options?.accountAgnostic === true;
+  let currentMaskedEmail = accountAgnostic ? null : maskEmail(options?.email);
   let unsubscribeAuth: (() => void) | null = null;
   let emailPollInterval: ReturnType<typeof setInterval> | null = null;
   let currentState: CheckoutSuccessBannerState = 'pending';
@@ -1365,7 +1377,7 @@ export function showCheckoutSuccess(
     const next = maskEmail(raw ?? null);
     if (next && next !== currentMaskedEmail) {
       currentMaskedEmail = next;
-      setBannerText(banner, currentState, currentMaskedEmail);
+      setBannerText(banner, currentState, currentMaskedEmail, accountAgnostic);
       stopEmailWatchers();
       return true;
     }
@@ -1380,7 +1392,7 @@ export function showCheckoutSuccess(
     }
   };
 
-  if (!currentMaskedEmail) {
+  if (!accountAgnostic && !currentMaskedEmail) {
     // Two fallbacks needed. (1) subscribeAuthState should fire when Clerk
     // hydrates — but auth-state.ts subscribes to clerkInstance at the
     // moment subscribeAuthState is called; if showCheckoutSuccess runs
@@ -1403,7 +1415,7 @@ export function showCheckoutSuccess(
       applyEmail(getCurrentClerkUser()?.email);
     }, POLL_MS);
   }
-  setBannerText(banner, 'pending', currentMaskedEmail);
+  setBannerText(banner, 'pending', currentMaskedEmail, accountAgnostic);
   document.body.appendChild(banner);
 
   requestAnimationFrame(() => {
@@ -1478,9 +1490,14 @@ function setBannerText(
   banner: HTMLElement,
   state: CheckoutSuccessBannerState,
   maskedEmail: string | null,
+  accountAgnostic = false,
 ): void {
   banner.setAttribute('data-entitlement-state', state);
   if (state === 'pending') {
+    if (accountAgnostic) {
+      banner.textContent = 'Payment completed in the desktop app. Pro access will update there automatically.';
+      return;
+    }
     banner.textContent = maskedEmail
       ? `Payment received! Receipt sent to ${maskedEmail}. Unlocking your premium features…`
       : 'Payment received! Unlocking your premium features…';

--- a/tests/checkout-return-discriminant.test.mts
+++ b/tests/checkout-return-discriminant.test.mts
@@ -39,6 +39,7 @@ const LAST_CHECKOUT_ATTEMPT_KEY = 'wm-last-checkout-attempt';
 let _loc: MutableLocation;
 let _history: MutableHistory;
 let _sessionStorage: MemoryStorage;
+let _localStorage: MemoryStorage;
 
 function setUrl(href: string): void {
   const url = new URL(href);
@@ -51,6 +52,7 @@ function setUrl(href: string): void {
 before(() => {
   _loc = { href: BASE_URL, pathname: '/', search: '', hash: '' };
   _sessionStorage = new MemoryStorage();
+  _localStorage = new MemoryStorage();
   _history = {
     replaceState: (_state, _unused, url) => {
       if (url !== undefined && url !== null) setUrl(new URL(String(url), _loc.href).toString());
@@ -64,6 +66,10 @@ before(() => {
     configurable: true,
     value: _sessionStorage,
   });
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: _localStorage,
+  });
 });
 
 after(() => {
@@ -71,14 +77,46 @@ after(() => {
   delete (globalThis as any).window;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (globalThis as any).sessionStorage;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (globalThis as any).localStorage;
 });
 
 beforeEach(() => {
   setUrl(BASE_URL);
   _sessionStorage.clear();
+  _localStorage.clear();
 });
 
-const { handleCheckoutReturn } = await import('../src/services/checkout-return.ts');
+const { handleCheckoutReturn, resolveCheckoutReturnRouting } = await import('../src/services/checkout-return.ts');
+
+describe('resolveCheckoutReturnRouting', () => {
+  it('keeps desktop acknowledgements account-agnostic', () => {
+    assert.deepEqual(
+      resolveCheckoutReturnRouting({ kind: 'success', source: 'desktop' }, true),
+      {
+        returnedFromDesktopBrowser: true,
+        returnedFromOverlay: false,
+        returnedFromCheckout: true,
+        returnedFromAccountCheckout: false,
+      },
+    );
+  });
+
+  it('accepts an overlay flag only when the URL had no checkout outcome', () => {
+    assert.deepEqual(resolveCheckoutReturnRouting({ kind: 'none' }, true), {
+      returnedFromDesktopBrowser: false,
+      returnedFromOverlay: true,
+      returnedFromCheckout: true,
+      returnedFromAccountCheckout: true,
+    });
+    assert.deepEqual(resolveCheckoutReturnRouting({ kind: 'failed', rawStatus: 'cancelled' }, true), {
+      returnedFromDesktopBrowser: false,
+      returnedFromOverlay: false,
+      returnedFromCheckout: false,
+      returnedFromAccountCheckout: false,
+    });
+  });
+});
 
 describe('handleCheckoutReturn', () => {
   it('returns { kind: "none" } when no checkout params present', () => {
@@ -194,6 +232,36 @@ describe('handleCheckoutReturn — /pro overlay-success marker (?wm_checkout=)',
   it('strips wm_checkout=return alone without a saved attempt but does not trigger success', () => {
     setUrl(`${BASE_URL}?wm_checkout=return`);
     assert.deepEqual(handleCheckoutReturn(), { kind: 'none' });
+    assert.equal(_loc.href, BASE_URL);
+  });
+
+  it('acknowledges a desktop return without requiring browser session storage', () => {
+    setUrl(`${BASE_URL}?wm_checkout=return&wm_src=desktop`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'success', source: 'desktop' });
+    assert.equal(_loc.href, BASE_URL);
+    assert.equal(
+      _localStorage.getItem('wm-entitlement-hint'),
+      null,
+      'an account-agnostic desktop return must not seed the browser entitlement hint',
+    );
+  });
+
+  it('keeps the desktop source and hint policy when Dodo includes a success ID', () => {
+    setUrl(`${BASE_URL}?wm_checkout=return&wm_src=desktop&subscription_id=sub_X&status=active`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'success', source: 'desktop' });
+    assert.equal(_loc.href, BASE_URL);
+    assert.equal(_localStorage.getItem('wm-entitlement-hint'), null);
+  });
+
+  it('cleans an unknown return source without acknowledging it', () => {
+    setUrl(`${BASE_URL}?wm_checkout=return&wm_src=mobile`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'none' });
+    assert.equal(_loc.href, BASE_URL);
+  });
+
+  it('preserves Dodo cancellation over the desktop acknowledgement marker', () => {
+    setUrl(`${BASE_URL}?wm_checkout=return&wm_src=desktop&payment_id=pay_X&status=cancelled`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'failed', rawStatus: 'cancelled' });
     assert.equal(_loc.href, BASE_URL);
   });
 

--- a/tests/checkout-return-url.test.mts
+++ b/tests/checkout-return-url.test.mts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   buildDashboardCheckoutReturnUrl,
+  DESKTOP_CHECKOUT_SOURCE,
   resolveCheckoutReturnOrigin,
 } from '../src/services/checkout-return-url.ts';
 
@@ -52,7 +53,17 @@ describe('resolveCheckoutReturnOrigin (#5911)', () => {
     // desktop origin here means the buyer pays and then dead-ends on a page
     // no browser can open.
     assert.equal(
-      buildDashboardCheckoutReturnUrl(resolveCheckoutReturnOrigin('tauri://localhost', true)),
+      buildDashboardCheckoutReturnUrl(
+        resolveCheckoutReturnOrigin('tauri://localhost', true),
+        DESKTOP_CHECKOUT_SOURCE,
+      ),
+      'https://worldmonitor.app/dashboard?wm_checkout=return&wm_src=desktop',
+    );
+  });
+
+  it('does not add the desktop source marker to ordinary web returns', () => {
+    assert.equal(
+      buildDashboardCheckoutReturnUrl('https://worldmonitor.app'),
       'https://worldmonitor.app/dashboard?wm_checkout=return',
     );
   });

--- a/tests/desktop-checkout-handoff.test.mts
+++ b/tests/desktop-checkout-handoff.test.mts
@@ -311,7 +311,7 @@ describe('startCheckout on desktop (#5911)', () => {
     await checkout.startCheckout('pro_monthly');
 
     const [body] = globalThis.__desktopCheckoutHarness.requestBodies;
-    assert.equal(body?.returnUrl, 'https://worldmonitor.app/dashboard?wm_checkout=return');
+    assert.equal(body?.returnUrl, 'https://worldmonitor.app/dashboard?wm_checkout=return&wm_src=desktop');
   });
 
   it('reports a checkout error instead of claiming success when nothing opened', async () => {

--- a/tests/entitlement-reload-controller.test.mts
+++ b/tests/entitlement-reload-controller.test.mts
@@ -259,8 +259,28 @@ describe('entitlement reload controller', () => {
 
     assert.match(
       panelLayout,
-      /createEntitlementReloadController\(\{\s*returnedFromCheckout,/,
+      /createEntitlementReloadController\(\{\s*returnedFromCheckout:\s*returnedFromAccountCheckout,/,
       'checkout-return seeding must flow into the guarded controller',
+    );
+    assert.match(
+      panelLayout,
+      /const returnedFromOverlayFlag = consumePostCheckoutFlag\(\)[\s\S]*?resolveCheckoutReturnRouting\(returnResult, returnedFromOverlayFlag\)/,
+      'checkout routing must consume the overlay flag through the guarded return classifier',
+    );
+    assert.match(
+      panelLayout,
+      /if\s*\(returnedFromAccountCheckout\)\s*\{[\s\S]*?markProActivationPending\([\s\S]*?clearCheckoutAttempt\('success'\)/,
+      'desktop acknowledgements must not seed onboarding or clear browser-local state',
+    );
+    assert.match(
+      panelLayout,
+      /waitForEntitlement:\s*!returnedFromDesktopBrowser,[\s\S]*?accountAgnostic:\s*returnedFromDesktopBrowser,[\s\S]*?email:\s*returnedFromDesktopBrowser\s*\?\s*null\s*:/,
+      'desktop acknowledgements must not wait on or identify an arbitrary browser account',
+    );
+    assert.match(
+      panelLayout,
+      /const entitlementActive = isEntitlementActive\(state, Date\.now\(\)\)[\s\S]*?this\.ctx\.isDesktopApp[\s\S]*?entitlementActive[\s\S]*?loadCheckoutAttempt\(\)[\s\S]*?clearCheckoutAttempt\('success'\)/,
+      'the desktop app must retire its own attempt/referral state when entitlement activates',
     );
     assert.match(
       panelLayout,
@@ -269,7 +289,7 @@ describe('entitlement reload controller', () => {
     );
     assert.match(
       panelLayout,
-      /onEntitlementChange\(\(state\) => \{\s*entitlementReloadController\.handleSnapshot\(\s*state === null \? null : isEntitlementActive\(state, Date\.now\(\)\),\s*getAuthState\(\)\.user\?\.id \?\? null,/,
+      /onEntitlementChange\(\(state\) => \{[\s\S]*?const entitlementActive = isEntitlementActive\(state, Date\.now\(\)\)[\s\S]*?entitlementReloadController\.handleSnapshot\(\s*entitlementActive,\s*getAuthState\(\)\.user\?\.id \?\? null,/,
       'the live watcher must preserve unavailable snapshots and scope the guard to the authenticated account',
     );
   });

--- a/tests/entitlement-reload-controller.test.mts
+++ b/tests/entitlement-reload-controller.test.mts
@@ -279,7 +279,7 @@ describe('entitlement reload controller', () => {
     );
     assert.match(
       panelLayout,
-      /const entitlementActive = isEntitlementActive\(state, Date\.now\(\)\)[\s\S]*?this\.ctx\.isDesktopApp[\s\S]*?entitlementActive[\s\S]*?loadCheckoutAttempt\(\)[\s\S]*?clearCheckoutAttempt\('success'\)/,
+      /const entitlementActive =\s*state === null \? null : isEntitlementActive\(state, Date\.now\(\)\)[\s\S]*?this\.ctx\.isDesktopApp[\s\S]*?entitlementActive === true[\s\S]*?loadCheckoutAttempt\(\)[\s\S]*?clearCheckoutAttempt\('success'\)/,
       'the desktop app must retire its own attempt/referral state when entitlement activates',
     );
     assert.match(
@@ -289,7 +289,7 @@ describe('entitlement reload controller', () => {
     );
     assert.match(
       panelLayout,
-      /onEntitlementChange\(\(state\) => \{[\s\S]*?const entitlementActive = isEntitlementActive\(state, Date\.now\(\)\)[\s\S]*?entitlementReloadController\.handleSnapshot\(\s*entitlementActive,\s*getAuthState\(\)\.user\?\.id \?\? null,/,
+      /onEntitlementChange\(\(state\) => \{[\s\S]*?const entitlementActive =\s*state === null \? null : isEntitlementActive\(state, Date\.now\(\)\)[\s\S]*?entitlementReloadController\.handleSnapshot\(\s*entitlementActive,\s*getAuthState\(\)\.user\?\.id \?\? null,/,
       'the live watcher must preserve unavailable snapshots and scope the guard to the authenticated account',
     );
   });


### PR DESCRIPTION
## Summary

Closes #6121.

- Mark desktop OS-browser checkout returns with `wm_checkout=return&wm_src=desktop`.
- Reconcile that marker without requiring the desktop WebView's session-local checkout attempt.
- Show an account-agnostic success state in the returning browser; keep ordinary web and overlay returns account-bound.
- Prevent stale overlay state or failed/cancelled Dodo results from overriding the parsed return outcome.

This is stacked on parent PR #6127 (`fix/desktop-billing-checkout-os-browser-5911`).

## Verification

- Focused checkout/entitlement regression tests: 72 passed, 0 failed.
- `npm run typecheck`: passed.
- `npm run lint`: passed (existing non-blocking warnings only).
- `npm run build`: passed.
- Pre-push hook contract tests: 15 passed, 0 failed with the macOS temporary-directory environment shim described in the handoff.
- `npm run test:data`: attempted; the suite reached the pre-push-hook fixture tests but exited 1 because the sandbox denied bare `mktemp` creation under `/var/folders/...` (`Operation not permitted`). It is not reported as a full-suite pass.

## Post-Deploy Monitoring & Validation

- Owner: desktop checkout/payments maintainer; window: first 48 hours after the parent and this follow-up are deployed.
- Healthy behavior: a desktop purchase returning to the OS browser shows the account-agnostic completion banner, while the desktop app receives entitlement through its existing live subscription path; ordinary web and overlay checkout returns retain account-bound behavior.
- Watch for checkout-return parsing failures, unexpected account-bound messaging in the returning browser, or entitlement mismatch between the app and purchase record.
- If the marker path regresses, revert this follow-up (the parent checkout handoff remains independently identifiable).