### PR TITLE
fix(security): clear production dependency audit failures

### DIFF
--- a/.github/scripts/audit-production-dependencies.mjs
+++ b/.github/scripts/audit-production-dependencies.mjs
@@ -21,13 +21,7 @@ export const BASELINE_ADVISORIES_BY_LOCKFILE = {
   // the browser ML worker (src/workers/ml.worker.ts) — its Node-only sharp
   // binary never executes server-side. The clean fix (sharp 0.35.x) is
   // semver-major across both chains; baselined until the parents bump.
-  // GHSA-mh99-v99m-4gvg (brace-expansion OOM from unbounded brace patterns)
-  // reaches root only through Clerk's optional Solana wallet -> react-native ->
-  // babel-jest/test-exclude tooling chain. It never executes in the Vite web
-  // bundle or API runtime. The sole patched release, brace-expansion 5.0.8,
-  // changes the CommonJS export shape and breaks this chain's minimatch 3.x;
-  // keep the advisory baselined until the upstream parents move to minimatch 10.
-  'package-lock.json': ['GHSA-f88m-g3jw-g9cj', 'GHSA-mh99-v99m-4gvg'],
+  'package-lock.json': ['GHSA-f88m-g3jw-g9cj'],
   'consumer-prices-core/package-lock.json': [],
   'blog-site/package-lock.json': [],
   // GHSA-395f-4hp3-45gv (shell-quote quadratic-complexity DoS in parse()) reaches
@@ -45,12 +39,7 @@ export const BASELINE_ADVISORIES_BY_LOCKFILE = {
   // which drags a public/pro/ bundle rebuild into a lockfile-hygiene change —
   // same trade-off as GHSA-395f below. Drop when the pin next bumps.
   'pro-test/package-lock.json': ['GHSA-qjx8-664m-686j', 'GHSA-w24r-5266-9c3c', 'GHSA-395f-4hp3-45gv', 'GHSA-r28c-9q8g-f849'],
-  // GHSA-mh99-v99m-4gvg reaches scripts only through ExcelJS's archive
-  // dependencies. ExcelJS is used by operator-run seed/backfill scripts with
-  // exact workbook paths; no request input reaches a minimatch brace pattern.
-  // Forcing brace-expansion 5.0.8 breaks minimatch 3.x/5.x's callable require,
-  // while replacing ExcelJS's archiver stack requires unrelated major upgrades.
-  'scripts/package-lock.json': ['GHSA-mh99-v99m-4gvg'],
+  'scripts/package-lock.json': [],
   'docker/runtime-package-lock.json': [],
 };
 

--- a/consumer-prices-core/package-lock.json
+++ b/consumer-prices-core/package-lock.json
@@ -1873,9 +1873,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/consumer-prices-core/package.json
+++ b/consumer-prices-core/package.json
@@ -38,6 +38,7 @@
     "vitest": "^3.2.6"
   },
   "overrides": {
+    "fast-uri": "^3.1.5",
     "ws": "8.21.0",
     "form-data": "4.0.6"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15502,9 +15502,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
     "protobufjs": "^7.6.2",
     "ws": "$ws",
     "shell-quote": "^1.8.4",
+    "ip-address": "^10.3.1",
     "brace-expansion@1": "^1.1.18",
     "brace-expansion@2": "^2.1.4"
   }

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -19,7 +19,7 @@
         "sax": "^1.6.0",
         "telegram": "^2.22.2",
         "tsx": "^4.21.0",
-        "undici": "^7.28.0",
+        "undici": "^7.29.0",
         "web-push": "^3.6.7",
         "ws": "^8.21.0",
         "yaml": "^2.8.3"
@@ -3253,9 +3253,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4068,9 +4068,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -21,7 +21,7 @@
     "sax": "^1.6.0",
     "telegram": "^2.22.2",
     "tsx": "^4.21.0",
-    "undici": "^7.28.0",
+    "undici": "^7.29.0",
     "web-push": "^3.6.7",
     "ws": "^8.21.0",
     "yaml": "^2.8.3"
@@ -30,6 +30,7 @@
     "esbuild": "0.28.1",
     "undici": "$undici",
     "ws": "$ws",
+    "ip-address": "^10.3.1",
     "brace-expansion@1": "^1.1.18",
     "brace-expansion@2": "^2.1.4"
   },


### PR DESCRIPTION
## Summary

Newly published production advisories were blocking every PR's Security Audit gate. This updates the affected production dependency resolutions and removes baseline entries that no longer match current audit data.

- Update `ip-address` from 10.2.0 to 10.4.0 in the root and scripts lockfiles.
- Update `undici` from 7.28.0 to 7.29.0 in the scripts workspace.
- Update `fast-uri` from 3.1.4 to 3.1.5 in `consumer-prices-core`.
- Remove stale brace-expansion baseline entries while preserving the active root `sharp` baseline.

## Validation

- Exact six-workspace production audit: passed; root and pro-test retain only their pre-existing baselined advisories.
- `tests/ci-workflow-coverage.test.mts`: 16 passed.
- `npm run typecheck`: passed.
- `npm run typecheck:api`: passed.
- `npm run test:data`: passed.
- `npm run lint`: passed with existing unrelated warnings.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required: this changes dependency resolution and CI audit policy only; it does not change runtime application behavior or production data paths.

---

[![Compound Engineering](https://img.shields.io/badge/Compound%20Engineering-5240E8?logo=data:image/svg%2Bxml;base64,PHN2Zy8%2B&logoColor=white)](https://every.to/compound)
![Codex](https://img.shields.io/badge/Codex-GPT--5-000000)