### PR TITLE
fix(seeders): make every Railway entry point announce that it finished

### DIFF
--- a/consumer-prices-core/src/jobs/aggregate.ts
+++ b/consumer-prices-core/src/jobs/aggregate.ts
@@ -306,5 +306,12 @@ export async function validateAndAggregateAll() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  validateAndAggregateAll().finally(() => closePool()).catch(console.error);
+  // Terminal success marker (format mirrors runSeed() in scripts/_seed-utils.mjs) so the crash
+  // diagnostic can distinguish a clean run from a silent death. Chained BEFORE .catch so a
+  // rejection — including the `N/M basket(s) failed` throw — skips it.
+  const runStartedAt = Date.now();
+  validateAndAggregateAll()
+    .then(() => console.log(`\n=== Done (${Date.now() - runStartedAt}ms) ===`))
+    .finally(() => closePool())
+    .catch(console.error);
 }

--- a/consumer-prices-core/src/jobs/publish.ts
+++ b/consumer-prices-core/src/jobs/publish.ts
@@ -305,5 +305,13 @@ export async function publishAll() {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  publishAll().finally(() => closePool()).catch(console.error);
+  // Terminal success marker (format mirrors runSeed() in scripts/_seed-utils.mjs) so the crash
+  // diagnostic can distinguish a clean run from a silent death. Chained BEFORE .catch so a
+  // rejection skips it. Plain console.log, not the logger, so the marker survives whatever
+  // transport/format the logger uses.
+  const runStartedAt = Date.now();
+  publishAll()
+    .then(() => console.log(`\n=== Done (${Date.now() - runStartedAt}ms) ===`))
+    .finally(() => closePool())
+    .catch(console.error);
 }

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -380,4 +380,15 @@ async function main() {
 // process.exit() is required to flush lingering Playwright/Chromium handles
 // that would otherwise prevent the process from exiting naturally.
 // process.exitCode preserves failure signaling set in the catch block above.
-main().catch(() => { process.exitCode = 1; }).then(() => process.exit(process.exitCode ?? 0));
+const __runStartedAt = Date.now();
+main()
+  .then(() => {
+    // Terminal success marker (format mirrors runSeed() in scripts/_seed-utils.mjs) so the crash
+    // diagnostic can tell a clean run from a silent death; without it every run reads as unknown.
+    // main() CATCHES INTERNALLY and signals failure via process.exitCode, so it resolves even when
+    // the run failed — the guard is what stops this vouching for a failed scrape. Plain console.log
+    // rather than the logger: the marker must survive whatever transport/format the logger uses.
+    if (!process.exitCode) console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`);
+  })
+  .catch(() => { process.exitCode = 1; })
+  .then(() => process.exit(process.exitCode ?? 0));

--- a/scripts/fetch-gpsjam.mjs
+++ b/scripts/fetch-gpsjam.mjs
@@ -182,14 +182,26 @@ async function main() {
   await seedRedis(output);
 }
 
-main().catch(async err => {
-  // Preserve-last-good: gpsjam.org is a daily feed; a transient fetch/parse
-  // failure must not blow away yesterday's hexes. Extend the existing TTLs and
-  // exit 0 (graceful), matching the seeder convention. seed-meta.fetchedAt is
-  // intentionally NOT refreshed, so a persistent outage still surfaces via the
-  // age-based STALE_SEED alarm (api/health.js gpsjam maxStaleMin=1440).
-  console.error(`[gpsjam] Fetch failed: ${err.message} — extending TTL on stale data`);
-  await extendExistingTtl([REDIS_KEY_V2, REDIS_KEY_V1, 'seed-meta:intelligence:gpsjam'], REDIS_TTL)
-    .catch(e => console.error(`[gpsjam] TTL extend failed: ${e.message}`));
-  process.exit(0);
-});
+// Terminal markers. Both paths here exit 0, so both must say so: this seeder's last real line was
+// `[gpsjam] Wrote seed-meta: …`, which the crash diagnostic cannot treat as proof of a clean finish
+// (the identical shape appears in runs that go on to die — that is how #6092 hid). Emitted from
+// .then()/after the recovery so a throw in between can never reach them. Format mirrors runSeed().
+const __runStartedAt = Date.now();
+
+main()
+  .then(() => console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`))
+  .catch(async err => {
+    // Preserve-last-good: gpsjam.org is a daily feed; a transient fetch/parse
+    // failure must not blow away yesterday's hexes. Extend the existing TTLs and
+    // exit 0 (graceful), matching the seeder convention. seed-meta.fetchedAt is
+    // intentionally NOT refreshed, so a persistent outage still surfaces via the
+    // age-based STALE_SEED alarm (api/health.js gpsjam maxStaleMin=1440).
+    console.error(`[gpsjam] Fetch failed: ${err.message} — extending TTL on stale data`);
+    await extendExistingTtl([REDIS_KEY_V2, REDIS_KEY_V1, 'seed-meta:intelligence:gpsjam'], REDIS_TTL)
+      .catch(e => console.error(`[gpsjam] TTL extend failed: ${e.message}`));
+    // Deliberate exit 0, not a crash — say so with the STALE PRESERVED suffix. RE_DONE_OK matches
+    // it (only `RETRY FAILED` disqualifies a `=== Done` line), so the run reads as clean rather
+    // than unknown, while the suffix keeps the log honest about what actually happened.
+    console.log(`\n=== Done (${Date.now() - __runStartedAt}ms, STALE PRESERVED) ===`);
+    process.exit(0);
+  });

--- a/scripts/process-deep-forecast-tasks.mjs
+++ b/scripts/process-deep-forecast-tasks.mjs
@@ -8,10 +8,17 @@ loadEnvFile(import.meta.url);
 const once = process.argv.includes('--once');
 const runId = process.argv.find((arg) => arg.startsWith('--run-id='))?.split('=')[1] || '';
 
+const __runStartedAt = Date.now();
+
 try {
   console.log(`[DeepForecast] Starting (once=${once}, pid=${process.pid})`);
   const result = await runDeepForecastWorker({ once, runId });
   console.log(`[DeepForecast] Exiting: ${result?.status || 'unknown'}`);
+  // Terminal success marker — see scripts/_seed-utils.mjs runSeed(). `[DeepForecast] Exiting:` is
+  // this worker's own last line, but the crash diagnostic deliberately keeps ONE small closed set
+  // of clean-finish markers rather than learning a per-entry-point vocabulary, so emit the shared
+  // one. Last statement of the try, so a throw above skips it.
+  console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`);
 } catch (err) {
   console.error(`[DeepForecast] FATAL: ${err.message}`);
   process.exit(1);

--- a/scripts/process-simulation-tasks.mjs
+++ b/scripts/process-simulation-tasks.mjs
@@ -28,10 +28,17 @@ loadEnvFile(import.meta.url);
 const once = process.argv.includes('--once');
 const runId = process.argv.find((arg) => arg.startsWith('--run-id='))?.split('=')[1] || '';
 
+const __runStartedAt = Date.now();
+
 try {
   console.log(`[Simulation] Starting (once=${once}, pid=${process.pid})`);
   const result = await runSimulationWorker({ once, runId });
   console.log(`[Simulation] Exiting: ${result?.status || 'unknown'}`);
+  // Terminal success marker — see scripts/_seed-utils.mjs runSeed(). `[Simulation] Exiting:` is
+  // this worker's own last line, but the crash diagnostic deliberately keeps ONE small closed set
+  // of clean-finish markers rather than learning a per-entry-point vocabulary, so emit the shared
+  // one. Last statement of the try, so a throw above skips it.
+  console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`);
 } catch (err) {
   console.error(`[Simulation] FATAL: ${err.message}`);
   process.exit(1);

--- a/scripts/publish-bootstrap-tiers.mjs
+++ b/scripts/publish-bootstrap-tiers.mjs
@@ -278,8 +278,16 @@ async function main() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  main().catch(error => {
-    console.error(`[bootstrap-r2] fatal: ${error?.message ?? String(error)}`);
-    process.exitCode = 1;
-  });
+  // Terminal success marker. Emitted from .then() so it can ONLY print after main() has fully
+  // resolved — a throw anywhere inside, including a late publish step, skips it. Any marker
+  // written INSIDE main() would print before later work and could vouch for a run that then
+  // died (exactly how #6092 stayed invisible). Format mirrors runSeed() so the crash
+  // diagnostic recognises it; without it a clean run is indistinguishable from a silent death.
+  const __runStartedAt = Date.now();
+  main()
+    .then(() => console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`))
+    .catch(error => {
+      console.error(`[bootstrap-r2] fatal: ${error?.message ?? String(error)}`);
+      process.exitCode = 1;
+    });
 }

--- a/scripts/seed-bundle-regional.mjs
+++ b/scripts/seed-bundle-regional.mjs
@@ -185,11 +185,19 @@ async function main() {
 
 const isMain = import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
-  main().catch(async (err) => {
-    console.error('[bundle] Fatal:', err);
-    await flushPendingLlmEvents();
-    process.exit(1);
-  });
+  // Terminal success marker. Emitted from .then() so it can ONLY print after main() has fully
+  // resolved — a throw anywhere inside, including a late publish step, skips it. Any marker
+  // written INSIDE main() would print before later work and could vouch for a run that then
+  // died (exactly how #6092 stayed invisible). Format mirrors runSeed() so the crash
+  // diagnostic recognises it; without it a clean run is indistinguishable from a silent death.
+  const __runStartedAt = Date.now();
+  main()
+    .then(() => console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`))
+    .catch(async (err) => {
+      console.error('[bundle] Fatal:', err);
+      await flushPendingLlmEvents();
+      process.exit(1);
+    });
 }
 
 export { shouldRunBriefs, BRIEF_COOLDOWN_MS, BRIEF_META_KEY };

--- a/scripts/seed-comtrade-bilateral-hs4.mjs
+++ b/scripts/seed-comtrade-bilateral-hs4.mjs
@@ -647,8 +647,16 @@ export async function main({ requestBudget = REQUEST_BUDGET } = {}) {
 
 const isMain = process.argv[1]?.endsWith('seed-comtrade-bilateral-hs4.mjs');
 if (isMain) {
-  main().catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
+  // Terminal success marker. Emitted from .then() so it can ONLY print after main() has fully
+  // resolved — a throw anywhere inside, including a late publish step, skips it. A marker written
+  // INSIDE main() would print before later work and could vouch for a run that then died (exactly
+  // how #6092 stayed invisible). Format matches the shared runner so the crash diagnostic
+  // recognises it; without it a clean run is indistinguishable from a silent death.
+  const __runStartedAt = Date.now();
+  main()
+    .then(() => console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`))
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
 }

--- a/scripts/seed-electricity-prices.mjs
+++ b/scripts/seed-electricity-prices.mjs
@@ -368,8 +368,16 @@ export async function main() {
 }
 
 if (process.argv[1]?.endsWith('seed-electricity-prices.mjs')) {
-  main().catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+  // Terminal success marker. Emitted from .then() so it can ONLY print after main() has fully
+  // resolved — a throw anywhere inside, including a late publish step, skips it. Any marker
+  // written INSIDE main() would print before later work and could vouch for a run that then
+  // died (exactly how #6092 stayed invisible). Format mirrors runSeed() so the crash
+  // diagnostic recognises it; without it a clean run is indistinguishable from a silent death.
+  const __runStartedAt = Date.now();
+  main()
+    .then(() => console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
 }

--- a/scripts/seed-ember-electricity.mjs
+++ b/scripts/seed-ember-electricity.mjs
@@ -405,8 +405,16 @@ export async function main() {
 }
 
 if (process.argv[1]?.endsWith('seed-ember-electricity.mjs')) {
-  main().catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+  // Terminal success marker. Emitted from .then() so it can ONLY print after main() has fully
+  // resolved — a throw anywhere inside, including a late publish step, skips it. Any marker
+  // written INSIDE main() would print before later work and could vouch for a run that then
+  // died (exactly how #6092 stayed invisible). Format mirrors runSeed() so the crash
+  // diagnostic recognises it; without it a clean run is indistinguishable from a silent death.
+  const __runStartedAt = Date.now();
+  main()
+    .then(() => console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`))
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
 }

--- a/scripts/seed-energy-spine.mjs
+++ b/scripts/seed-energy-spine.mjs
@@ -541,8 +541,16 @@ export async function main() {
 }
 
 if (process.argv[1]?.endsWith('seed-energy-spine.mjs')) {
-  main().catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
+  // Terminal success marker. Emitted from .then() so it can ONLY print after main() has fully
+  // resolved — a throw anywhere inside, including a late publish step, skips it. Any marker
+  // written INSIDE main() would print before later work and could vouch for a run that then
+  // died (exactly how #6092 stayed invisible). Format mirrors runSeed() so the crash
+  // diagnostic recognises it; without it a clean run is indistinguishable from a silent death.
+  const __runStartedAt = Date.now();
+  main()
+    .then(() => console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`))
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
 }

--- a/scripts/seed-forecast-bets.mjs
+++ b/scripts/seed-forecast-bets.mjs
@@ -332,8 +332,16 @@ async function main() {
 }
 
 if (DIRECT_RUN) {
-  main().catch((err) => {
-    console.error(`[bets] fatal: ${err instanceof Error ? err.stack || err.message : String(err)}`);
-    process.exit(1);
-  });
+  // Terminal success marker. Emitted from .then() so it can ONLY print after main() has fully
+  // resolved — a throw anywhere inside, including a late publish step, skips it. Any marker
+  // written INSIDE main() would print before later work and could vouch for a run that then
+  // died (exactly how #6092 stayed invisible). Format mirrors runSeed() so the crash
+  // diagnostic recognises it; without it a clean run is indistinguishable from a silent death.
+  const __runStartedAt = Date.now();
+  main()
+    .then(() => console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`))
+    .catch((err) => {
+      console.error(`[bets] fatal: ${err instanceof Error ? err.stack || err.message : String(err)}`);
+      process.exit(1);
+    });
 }

--- a/scripts/seed-hs2-chokepoint-exposure.mjs
+++ b/scripts/seed-hs2-chokepoint-exposure.mjs
@@ -360,8 +360,16 @@ export async function main() {
 
 const isMain = process.argv[1]?.endsWith('seed-hs2-chokepoint-exposure.mjs');
 if (isMain) {
-  main().catch(err => {
-    console.error(err);
-    process.exit(1);
-  });
+  // Terminal success marker. Emitted from .then() so it can ONLY print after main() has fully
+  // resolved — a throw anywhere inside, including a late publish step, skips it. Any marker
+  // written INSIDE main() would print before later work and could vouch for a run that then
+  // died (exactly how #6092 stayed invisible). Format mirrors runSeed() so the crash
+  // diagnostic recognises it; without it a clean run is indistinguishable from a silent death.
+  const __runStartedAt = Date.now();
+  main()
+    .then(() => console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`))
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
 }

--- a/scripts/seed-regulatory-actions.mjs
+++ b/scripts/seed-regulatory-actions.mjs
@@ -319,10 +319,18 @@ async function main(fetchImpl = DEFAULT_FETCH, runSeedImpl = runSeed) {
 const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isDirectRun) {
-  main().catch((err) => {
-    console.error(`FETCH FAILED: ${err.message || err}`);
-    process.exit(1);
-  });
+  // Terminal success marker. Emitted from .then() so it can ONLY print after main() has fully
+  // resolved — a throw anywhere inside, including a late publish step, skips it. Any marker
+  // written INSIDE main() would print before later work and could vouch for a run that then
+  // died (exactly how #6092 stayed invisible). Format mirrors runSeed() so the crash
+  // diagnostic recognises it; without it a clean run is indistinguishable from a silent death.
+  const __runStartedAt = Date.now();
+  main()
+    .then(() => console.log(`\n=== Done (${Date.now() - __runStartedAt}ms) ===`))
+    .catch((err) => {
+      console.error(`FETCH FAILED: ${err.message || err}`);
+      process.exit(1);
+    });
 }
 
 export {

--- a/tests/railway-entrypoint-terminal-marker.test.mts
+++ b/tests/railway-entrypoint-terminal-marker.test.mts
@@ -1,0 +1,204 @@
+/**
+ * Every Railway entry point must announce that it finished.
+ *
+ * The crash diagnostic (~/.claude/skills/diagnose-railway-seeders) reads a deployment's LOGS to
+ * decide whether a run crashed. It is fail-closed: a crash marker wins, `clean` must be positively
+ * evidenced by a terminal marker, and anything else is `unknown`. So an entry point that finishes
+ * without printing a terminal marker is permanently unvouchable — every one of its runs, healthy or
+ * dead, reads the same.
+ *
+ * That is not hypothetical. `seed-military-flights` crashed on 100% of runs for 7.5h (#6092) while
+ * the fleet reported green, and `seed-gpsjam`'s clean runs were indistinguishable from that outage
+ * because its last line, `[gpsjam] Wrote seed-meta: …`, ALSO appears in runs that go on to die.
+ *
+ * Two properties this pins:
+ *   1. Every deployable entry point emits a terminal marker.
+ *   2. The marker set stays SMALL and CLOSED. Each bespoke spelling is another thing the diagnostic
+ *      must learn, and every gap in that vocabulary is a crash reported as healthy. New entry points
+ *      should use runSeed(), or print `=== Done (Nms) ===` as their genuine last act.
+ *
+ * MARKER PLACEMENT IS THE WHOLE POINT: it must be reachable ONLY after all work succeeded —
+ * `.then()` on the top-level promise, or the last statement of the success path. A marker printed
+ * mid-run vouches for a run that may still die afterwards, which is exactly how #6092 hid.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+/**
+ * Does this source emit a terminal marker — a line that only prints once the run has finished?
+ * PURE and unit-tested by the fixtures below (not exported — biome forbids exports in tests); a bare inline grep in the assertion loop
+ * could be loosened later and still "pass" against real files that happen to match.
+ */
+/**
+ * Strip comments so prose can never satisfy the marker regexes.
+ *
+ * This is not defensive tidiness — without it this guard was VACUOUS. Each seeder fixed alongside
+ * this test carries a comment explaining the marker, and those comments say "runSeed()" and
+ * "=== Done". Deleting the actual marker left the comment behind, the predicate matched the
+ * COMMENT, and the mutation test passed with the bug fully restored.
+ *
+ * Deliberately simple: a `//` inside a string literal (a URL, say) truncates that line early. That
+ * can only DROP text, so the failure direction is a false "missing marker" — a loud test failure,
+ * never a silent pass.
+ */
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')  // block comments
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n');
+}
+
+function hasTerminalMarker(rawSrc: string): boolean {
+  const src = stripComments(rawSrc);
+  return (
+    /\brunSeed\s*\(/.test(src) ||               // shared runner prints `=== Done (Nms) ===`
+    /===\s*Done\b/.test(src) ||                  // printed directly
+    /exiting 0 \(not a crash\)/.test(src) ||     // scripts/_bundle-runner.mjs clean exit
+    /_bundle-runner/.test(src) ||                // delegates to the bundle runner
+    // A long-running service's shutdown handler. Matched on the HANDLER REGISTRATION, not on the
+    // logged text: ais-relay.cjs builds its line as `[Relay] ${signal} received`, so grepping the
+    // source for the literal "SIGTERM received" finds nothing even though the runtime output has
+    // it. Source-level guards must match what is WRITTEN, not what is printed.
+    /process\.on\(\s*['"`]SIGTERM['"`]/.test(src) ||
+    // Pre-existing bespoke markers (seed-digest-notifications, seed-webcams, seed-military-bases).
+    // Recognised because the diagnostic already knows them — but they are exactly the vocabulary
+    // sprawl this test exists to stop growing. New entry points must use `=== Done`.
+    /Cron run complete|Seeding complete|: done \(/.test(src)
+  );
+}
+
+/**
+ * Is this source executed directly by Railway, rather than only imported?
+ * Deliberately BROAD: a narrow detector that silently stops matching is how a guard goes vacuous,
+ * and a false positive here costs one `=== Done ===` line while a false negative costs an
+ * unvouchable service. `process-*-tasks.mjs` are top-level-await scripts with no guard at all, so
+ * "has no export" counts too.
+ */
+function isEntryPoint(src: string): boolean {
+  return (
+    /import\.meta\.url\s*===/.test(src) ||
+    /process\.argv\[1\]/.test(src) ||
+    /\b(isMain|DIRECT_RUN|isDirectRun)\b/.test(src) ||
+    !/^export\s/m.test(src)
+  );
+}
+
+// Deployable surface: the filesystem, NOT scripts/railway-services.json. That registry documents
+// only 41 services and omits 6 of the entry points fixed alongside this test — it is documentation
+// that drifts, so a guard built on it inherits its holes.
+const DEPLOYABLE = /^(seed-|fetch-|process-|publish-|.*-relay|.*-worker)/;
+
+/**
+ * Named like a service but NOT run by Railway — verified against live Railway `startCommand`s on
+ * 2026-08-04 (every one of these resolved to no service). Two kinds:
+ *   - bundle MEMBERS, spawned as children by scripts/_bundle-runner.mjs. The bundle is the entry
+ *     point and prints the terminal marker; a member printing its own would be a mid-run line.
+ *   - one-shot developer/data-prep utilities that never run on a schedule.
+ * Regenerate with: railway serviceInstance{startCommand} across all services (see issue #6141).
+ */
+const NOT_A_RAILWAY_SERVICE = new Set([
+  'ais-relay-test-preload.cjs',            // test harness preload
+  'fetch-country-boundary-overrides.mjs',  // one-shot data prep
+  'fetch-mirta-bases.mjs',
+  'fetch-osm-bases.mjs',
+  'fetch-pizzint-bases.mjs',
+  'seed-consumer-prices.mjs',              // superseded by consumer-prices-core/dist jobs
+  'seed-gas-storage-countries.mjs',        // bundle member
+  'seed-gdelt-intel.mjs',
+  'seed-owid-energy-mix.mjs',
+  'seed-recall-benchmark.mjs',
+  'seed-regional-briefs.mjs',
+  'seed-regional-snapshots.mjs',
+  'seed-resilience-scores.mjs',
+  'seed-resilience-static.mjs',
+]);
+
+function collectEntryPoints(): { path: string; src: string }[] {
+  const out: { path: string; src: string }[] = [];
+  const scriptsDir = join(repoRoot, 'scripts');
+  for (const name of readdirSync(scriptsDir)) {
+    if (!/\.(mjs|cjs)$/.test(name)) continue;
+    if (/\.test\.(mjs|cjs)$/.test(name)) continue;
+    if (!DEPLOYABLE.test(name)) continue;
+    if (NOT_A_RAILWAY_SERVICE.has(name)) continue;
+    const p = join(scriptsDir, name);
+    const src = readFileSync(p, 'utf8');
+    if (!isEntryPoint(src)) continue;
+    out.push({ path: `scripts/${name}`, src });
+  }
+  // The consumer-prices jobs live in their own package and are run from built dist/ output.
+  const jobsDir = join(repoRoot, 'consumer-prices-core/src/jobs');
+  if (existsSync(jobsDir)) {
+    for (const name of ['scrape.ts', 'publish.ts', 'aggregate.ts']) {
+      const p = join(jobsDir, name);
+      if (existsSync(p)) out.push({ path: `consumer-prices-core/src/jobs/${name}`, src: readFileSync(p, 'utf8') });
+    }
+  }
+  return out;
+}
+
+describe('hasTerminalMarker predicate', () => {
+  it('accepts each shape currently in use', () => {
+    assert.equal(hasTerminalMarker('await runSeed({ domain: "x" })'), true, 'runSeed');
+    assert.equal(hasTerminalMarker('console.log(`\\n=== Done (${ms}ms) ===`)'), true, 'direct');
+    assert.equal(hasTerminalMarker('[Bundle:x] 1 graceful fetch skip(s), no hard failures — exiting 0 (not a crash)'), true, 'bundle');
+    assert.equal(hasTerminalMarker("process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));"), true, 'sigterm handler');
+    assert.equal(hasTerminalMarker('console.log(`[digest] Cron run complete: ${n} sent`)'), true, 'bespoke');
+  });
+
+  it('matches the SOURCE, not the runtime output', () => {
+    // ais-relay.cjs logs `[Relay] ${signal} received — shutting down`, so the literal string
+    // "SIGTERM received" never appears in the file even though it appears in every log. Matching
+    // the interpolated output is why three real services first read as unvouchable here.
+    assert.equal(hasTerminalMarker('console.log(`[Relay] ${signal} received — shutting down`)'), false);
+  });
+
+  it('ignores markers that appear only in COMMENTS', () => {
+    // The exact false pass this guard shipped with: every seeder fixed alongside this test has a
+    // comment mentioning runSeed()/=== Done, so before stripComments() the mutation test could
+    // delete the real marker and still go green.
+    assert.equal(hasTerminalMarker('// Format mirrors runSeed() so the diagnostic recognises it'), false);
+    assert.equal(hasTerminalMarker('/* prints === Done (Nms) === at the end */'), false);
+    assert.equal(hasTerminalMarker('// exiting 0 (not a crash)'), false);
+    // …but the real thing still counts when both are present.
+    assert.equal(hasTerminalMarker('// mirrors runSeed()\nconsole.log(`\\n=== Done (${ms}ms) ===`);'), true);
+  });
+
+  it('REJECTS a mid-run line that merely looks final', () => {
+    // The seed-gpsjam trap: this was its genuine last line on a clean run, and is also present in
+    // runs that crash immediately afterwards. Accepting it would re-open the #6092 blind spot.
+    assert.equal(hasTerminalMarker('console.log(`[gpsjam] Wrote seed-meta: ${key}`)'), false);
+    assert.equal(hasTerminalMarker('console.log("  Verified: yes")'), false);
+    assert.equal(hasTerminalMarker('console.log(`  ${LIVE_KEY}: written`)'), false);
+    assert.equal(hasTerminalMarker(''), false);
+  });
+});
+
+describe('every Railway entry point emits a terminal marker', () => {
+  const entries = collectEntryPoints();
+
+  it('finds a plausible number of entry points (anti-vacuous)', () => {
+    // Without this, a broken DEPLOYABLE/isEntryPoint pair would check nothing and still go green.
+    assert.ok(entries.length >= 40, `only found ${entries.length} entry points — the collector is broken, not the fleet`);
+  });
+
+  it('has no unvouchable entry point', () => {
+    const missing = entries.filter((e) => !hasTerminalMarker(e.src)).map((e) => e.path);
+    assert.deepEqual(
+      missing,
+      [],
+      `These entry points finish without printing a terminal marker, so the crash diagnostic can ` +
+      `never tell a clean run from a silent death:\n  ${missing.join('\n  ')}\n\n` +
+      `Fix: use runSeed(), or print \`=== Done (\${Date.now() - startedAt}ms) ===\` as the genuine ` +
+      `LAST act of the success path (a .then() on the top-level promise). Do NOT print it mid-run.`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The crash diagnostic decides whether a Railway run died by reading its logs. It is fail-closed: a crash marker wins, `clean` must be **positively evidenced**, and anything else is `unknown`. **15 entry points printed no terminal marker at all**, so every one of their runs — healthy or dead — read identically, and none could ever be vouched for. On a full-fleet sweep that was 70 of 380 probed deployments the tool could not account for.

They now print `=== Done (Nms) ===`. A clean run is finally distinguishable from a silent death.

## Why this matters

This is the exact gap #6092 hid in. `seed-military-flights` crashed on 100% of runs for 7.5 hours while the fleet reported green. And `seed-gpsjam`'s **clean** runs were indistinguishable from that outage, because its final line —

```
[gpsjam] Wrote seed-meta: seed-meta:intelligence:gpsjam
```

— also appears in runs that crash immediately afterwards. There was no way to tell them apart.

## Placement is the whole point

Each marker is emitted from `.then()` on the top-level promise, so it is reachable **only** after `main()` fully resolves. A marker written *inside* `main()` prints before later work and would vouch for a run that then dies — precisely the #6092 failure mode. Runtime-verified rather than assumed:

```
success-path=true   exit=0  marker printed=true   CORRECT
success-path=false  exit=1  marker printed=false  CORRECT
```

Three entry points needed individual handling:

| entry point | why it differs |
|---|---|
| `fetch-gpsjam.mjs` | deliberately exits 0 on a graceful fetch failure after extending TTLs → that path gets `=== Done (Nms, STALE PRESERVED) ===`. `RE_DONE_OK` matches it (only `RETRY FAILED` disqualifies a `=== Done` line) while the suffix keeps the log honest. |
| `consumer-prices-core/src/jobs/scrape.ts` | catches internally and signals failure via `process.exitCode`, so it **resolves even when the run failed** — the marker is guarded on `!process.exitCode` or it would vouch for a failed scrape. |
| `publish.ts` / `aggregate.ts` | marker chained before `.catch` so a rejection skips it. |

Using the shared `runSeed()` format is deliberate: it keeps the diagnostic's clean-marker set **small and closed** rather than growing a per-seeder vocabulary. Every gap in that vocabulary is a crash reported as healthy.

## The guard, and the bug in the guard

`tests/railway-entrypoint-terminal-marker.test.mts` locks this so a new seeder cannot silently reopen the gap. It runs in CI via `npm run test:data` (`.github/workflows/test.yml:167`) — verified, since a test file's existence proves nothing about whether CI runs it.

**The guard shipped vacuous and the mutation test caught it.** Every seeder fixed here carries a comment explaining the marker, and those comments contain the words `runSeed()` and `=== Done`. Deleting the real marker left the comment behind, the predicate matched the **comment**, and the mutation test passed with the bug fully restored. Fixed with `stripComments()` before matching, then re-mutated to confirm the mutant dies and the fix is green. Stripping can only ever *drop* text, so its failure direction is a loud false "missing marker", never a silent pass.

Two further traps pinned as fixtures:

- **Match the source, not the runtime output.** `ais-relay.cjs` builds its line as `` `[Relay] ${signal} received` ``, so the literal string `SIGTERM received` never appears in the file even though every log contains it. Matching the interpolated output first reported three healthy services as unvouchable; the predicate matches the handler registration instead.
- **Reject mid-run lines that merely look final** (`Wrote seed-meta:`, `Verified: yes`, `: written`). Accepting one would shrink the unknown bucket while re-hiding the #6092 class, since those exact lines *precede* the crash.

Scope comes from the live Railway `startCommand` set, **not** `scripts/railway-services.json` — that registry lists 41 services and omits 6 of the entry points fixed here, so a guard built on it inherits its blind spots. Bundle members and one-shot utilities are excluded explicitly and documented with why. An anti-vacuous floor asserts the collector still finds ≥40 entry points, so a broken matcher fails loudly instead of quietly checking nothing.

Comment-stripping also surfaced a 15th gap my manual audit had missed for the very same reason — `seed-comtrade-bilateral-hs4.mjs`.

## Validation

- **Runtime**: marker present on the success path, absent when a late step throws (above).
- **Mutation**: removing a marker turns the guard red; restoring it turns it green.
- **Suite**: `npm run test:data` — one failure, `dashboard-critical-css`, which reads `dist/` and fails identically on clean `origin/main` with these changes stashed (2 failures there vs 1). This worktree has no build output; the diff touches no CSS, HTML, or build files.
- **Lint**: clean. The two `useDefaultParameterLast` warnings in `seed-comtrade-bilateral-hs4.mjs` are pre-existing — verified present on `origin/main` with changes stashed.

## Related

- Related: #6141 — the deploy-drift issue; its live `startCommand` survey is what scoped this change.
- The crash that exposed the class: PR #6128 / #6092.

Not addressed here: `seed-webcams`, `seed-digest-notifications`, and `seed-military-bases` keep their existing bespoke markers (`: done (`, `Cron run complete`, `Seeding complete`). They already work, so converting them is churn — but the guard accepts them explicitly as legacy, and new entry points must use `=== Done`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
