### PR TITLE
fix(review): restore the desktop handoff outcome guards dropped in the rebase (#5911, #6120)

### DIFF
--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -1106,7 +1106,11 @@ export async function startCheckout(
         // back in, because Pro arrives over the same live Convex entitlement
         // subscription the web client uses.
         const outcome = await openExternalUrl(hostedCheckoutUrl);
-        if (outcome === 'failed') {
+        // Only a confirmed NATIVE open counts. `popup` on desktop means the
+        // bridge call failed and we fell back to `window.open` inside the
+        // WebView — which is the bug this branch exists to prevent, so
+        // announcing "opened in your browser" for it would be false.
+        if (outcome !== 'native') {
           // Nothing opened. Announcing "check your browser" here would send
           // the buyer to a window that does not exist and strand a paid-for
           // session, so this takes the same shape as every other checkout

--- a/src/services/external-navigation.ts
+++ b/src/services/external-navigation.ts
@@ -79,10 +79,29 @@ function reportOpenFailure(url: string, reason: string): void {
   }));
 }
 
-function timeout(ms: number): Promise<never> {
-  return new Promise((_resolve, reject) => {
-    setTimeout(() => reject(new Error('open_url timed out')), ms);
-  });
+/** Distinguishes "the native side said no" from "it never answered". */
+class OpenUrlTimeout extends Error {}
+
+/**
+ * Race the IPC call against a CANCELLABLE timer.
+ *
+ * `Promise.race` subscribes to every promise it is given, so a losing timer
+ * rejection is already handled and never surfaces as an unhandled rejection —
+ * but an uncleared timer still keeps a 5s handle alive per call, so it is
+ * cleared on both paths.
+ */
+async function invokeOpenUrlBounded(url: string): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      invokeTauri<void>('open_url', { url }),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new OpenUrlTimeout('open_url timed out')), OPEN_URL_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 /**
@@ -169,12 +188,18 @@ export async function openExternalUrl(
     // forward over an orphaned blank WebView window.
     if (preopened && !preopened.closed) preopened.close();
     try {
-      await Promise.race([
-        invokeTauri<void>('open_url', { url: targetUrl }),
-        timeout(OPEN_URL_TIMEOUT_MS),
-      ]);
+      await invokeOpenUrlBounded(targetUrl);
       return 'native';
-    } catch {
+    } catch (err) {
+      if (err instanceof OpenUrlTimeout) {
+        // Deliberately NO window.open fallback here. The IPC call is not
+        // cancellable, so a slow-but-alive `open_url` may still complete
+        // after we gave up — falling back would open the URL twice, once in
+        // a WebView and once in the OS browser. For a payment page that is
+        // worse than a clean failure, and the caller can retry.
+        reportOpenFailure(targetUrl, 'native-open-timeout');
+        return 'failed';
+      }
       // Bridge globals are not always present at first paint, so this path is
       // reachable in production — report it, because falling back to
       // `window.open` inside Tauri reproduces the very bug this module exists

--- a/tests/desktop-checkout-handoff.test.mts
+++ b/tests/desktop-checkout-handoff.test.mts
@@ -152,7 +152,9 @@ function resetHarness(
       },
       open: (url: string) => {
         globalThis.__desktopCheckoutHarness.openedWindows.push(url);
-        return null;
+        // A non-null handle models Tauri's window.open succeeding — i.e. the
+        // fallback opened ANOTHER WEBVIEW, not the OS browser.
+        return {} as unknown;
       },
       history: { replaceState: () => {} },
       __TAURI_INTERNALS__: {
@@ -357,6 +359,20 @@ describe('startCheckout on desktop (#5911)', () => {
     assert.deepEqual(harness.invocations, [
       { command: 'open_url', payload: { url: 'https://worldmonitor.app/pro' } },
     ]);
+  });
+
+  it('does not claim the OS browser when it only fell back to a WebView window', async () => {
+    // openExternalUrl returns 'popup' here: the bridge refused and
+    // window.open succeeded INSIDE Tauri. That is the bug this branch exists
+    // to prevent, so it must not be reported to the buyer as success.
+    resetHarness(true, { invokeRejects: true });
+    const checkout = await loadCheckoutModule();
+
+    assert.equal(await checkout.startCheckout('pro_monthly'), false);
+
+    const harness = globalThis.__desktopCheckoutHarness;
+    assert.deepEqual(harness.toasts, [], 'a WebView fallback is not "opened in your browser"');
+    assert.equal(harness.errorToasts.length, 1);
   });
 
   it('tells the buyer where checkout went and that nothing redirects back', async () => {

--- a/tests/desktop-external-handoff.test.mts
+++ b/tests/desktop-external-handoff.test.mts
@@ -230,14 +230,16 @@ describe('openExternalUrl — desktop', () => {
     try {
       const pending = openExternalUrl('https://worldmonitor.app/pro');
       mock.timers.tick(5_000);
-      assert.equal(await pending, 'popup', 'the timeout must resolve the caller, not strand it');
+      assert.equal(await pending, 'failed', 'the timeout must resolve the caller, not strand it');
     } finally {
       mock.timers.reset();
     }
     assert.equal(probe.invocations.length, 1);
-    assert.deepEqual(probe.opened, [
-      ['https://worldmonitor.app/pro', '_blank', undefined],
-    ]);
+    // No window.open fallback on TIMEOUT specifically: the IPC call is not
+    // cancellable, so a slow-but-alive open_url could still complete and the
+    // user would get the page twice — once in a WebView, once in the OS
+    // browser. For a payment page a clean failure beats a double open.
+    assert.deepEqual(probe.opened, [], 'a timed-out open must not also open a WebView window');
   });
 
   it('reports failure when the native opener refuses AND the popup is blocked', async () => {
@@ -437,6 +439,33 @@ describe('openBillingPortal — desktop', () => {
       { command: 'open_url', payload: { url: 'https://customer.dodopayments.com' } },
     ]);
     assert.deepEqual(probe.assigned, []);
+  });
+});
+
+describe('openBillingPortal — desktop failure', () => {
+  it('reports open-failed rather than claiming it opened a session it did not', async () => {
+    // A portal session was just minted server-side. Reporting 'opened' for a
+    // handoff that never happened leaves the user staring at a dead button on
+    // the billing surface with a live session behind it.
+    installWindow('desktop');
+    installSignedInPortalUser();
+    probe.invokeRejects = true;
+    probe.popupBlocked = true;
+
+    assert.deepEqual(await openBillingPortal(prereserveBillingPortalTab()), {
+      outcome: 'open-failed',
+      url: PORTAL_URL,
+    });
+  });
+
+  it('still reports opened when the native handoff succeeds', async () => {
+    installWindow('desktop');
+    installSignedInPortalUser();
+
+    assert.deepEqual(await openBillingPortal(prereserveBillingPortalTab()), {
+      outcome: 'opened',
+      url: PORTAL_URL,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Targets `chore/desktop-open-external-url-6120` (the base of #6136), not `main`.

The #5911 rebase onto that branch kept round-1 and part of round-2, but `c739dfda5` rewrote the same region of `external-navigation.ts` and reverted three fixes. The **tests were reverted alongside the code**, so the branch is self-consistently green and nothing can flag it — the surviving timeout test now asserts the double-open it should forbid.

## What was lost, and is restored here

| Fix | State on `chore/...-6120` | Restored |
| --- | --- | --- |
| Timeout must not fall back to `window.open` | Reverted — bare `timeout()`, single `catch` that always falls back | Typed `OpenUrlTimeout` splits "never answered" from "refused"; timeout returns `failed` with no fallback, refusal keeps its fallback |
| Cancellable race timer | Reverted — no `clearTimeout` | Cleared on both paths |
| Desktop checkout requires a NATIVE open | Reverted — `outcome === 'failed'` | `outcome !== 'native'` |
| `openBillingPortal` reports `open-failed` | Code survived, **test did not** | Test restored |

**Why the timeout fallback is the serious one.** The IPC call is not cancellable. If the timer wins and we then `window.open`, a slow-but-alive `open_url` can still complete — opening a **payment page twice**, once in a WebView and once in the OS browser. A cancellable timer cannot prevent that (it stops our timer, not the native work); only declining to fall back can.

**Why `popup` is not success.** On desktop `popup` means the bridge failed and `window.open` opened another WebView — precisely the bug this branch exists to prevent. `outcome === 'failed'` let that path tell the buyer "Checkout opened in your browser" and return `true`.

## Preserved from `c739dfda5`

That commit is a real improvement and is kept whole: `noopener,noreferrer` makes `window.open` return `null` *while still opening the tab*, which breaks every branch that reads the handle — `openWindowWithHandle` severs `opener` manually instead. Also kept: the `sameTabFallback` opt-out and the exported `isOpenableExternalUrl` so the anchor interceptor gates on the same predicate.

## Verification

Each fix mutation-tested by reproducing the exact regression that shipped:

| Mutant | Result |
| --- | --- |
| timeout falls back to `window.open` again | fails (`a timed-out open must not also open a WebView window`) |
| checkout accepts `popup` as success again | fails (2 cases) |
| billing discards the outcome again | fails (`reports open-failed rather than claiming it opened`) |

Note on method: the first billing mutation was a **no-op** — the ported guard is a ternary, not the `if` the substitution expected — and a no-op mutant reads exactly like a surviving one. Re-run with an assertion that the substitution applied, it fails correctly. An unverified mutation is not evidence.

Local: `npm run typecheck`, `tsc -p tsconfig.dom-tests.json`, `npx biome lint src tests`, `npm run test:dom` (162 passed), full `tests/*.test.{mts,mjs}` — **20,649 passed, 0 failed**.

## Post-Deploy Monitoring & Validation

Desktop-only; web paths unchanged and covered by the existing regression cases.

- **Sentry:** `component:external-navigation action:open_url`. The new `reason:native-open-timeout` distinguishes a hung IPC from `reason:native-open-failed` (bridge refused). Expected volume: zero.
- **Sentry:** checkout errors tagged `action:desktop-handoff-failed` — now also fires for a WebView-only fallback, which previously reported success. A rise here is not a new bug; it is previously-silent failures becoming visible.
- **Rollback trigger:** sustained `desktop-handoff-failed` with no matching `open_url` failures would mean the `native`-only check is too strict — relax to accept `popup` and investigate the bridge.
- **Window / owner:** first 48h after the next desktop release, PR author.
