### PR TITLE
ci(proto): enforce breaking changes in workflow

### DIFF
--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -14,6 +14,28 @@ permissions:
   contents: read
 
 jobs:
+  proto-breaking:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        # buf compares the checked-out proto tree with the main baseline.
+        # Full history keeps that Git-backed reference from resolving vacuously.
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.26'
+          cache: false
+
+      - name: Install buf
+        run: make install-buf
+        env:
+          GOPROXY: direct
+
+      - name: Check for breaking proto changes
+        run: make breaking
+
   proto-freshness:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ generate: clean ## Generate code from proto definitions
 	@echo "Code generation complete!"
 
 breaking: ## Check for breaking changes against main
-	cd $(PROTO_DIR) && buf breaking --against '.git#branch=main,subdir=proto'
+	cd $(PROTO_DIR) && buf breaking --against '../.git#branch=origin/main,subdir=proto'
 
 format: ## Format protobuf files
 	cd $(PROTO_DIR) && buf format -w

--- a/docs/api-versioning.mdx
+++ b/docs/api-versioning.mdx
@@ -25,15 +25,18 @@ Clients should ignore response fields and enum values they do not recognize.
 The bundled [OpenAPI specification](https://www.worldmonitor.app/openapi.yaml)
 is the source of truth for the currently published contract.
 
-## Protobuf compatibility gate
+## Protobuf compatibility check
 
-The public API is JSON over HTTP. Proto changes are checked against `main` in
-CI with Buf's `FILE`, `PACKAGE`, and `WIRE_JSON` rules. `WIRE_JSON` is
+The public API is JSON over HTTP. On pull requests that touch proto paths, CI
+runs `make breaking` against `origin/main` with Buf's `FILE`, `PACKAGE`, and
+`WIRE_JSON` rules. That job fails the `proto-breaking` check-run when the
+baseline is missing or a rule is violated; it is not yet one of the deploy-gate
+required contexts that branch protection aggregates for merge. `WIRE_JSON` is
 intentional: generated JSON field names and shapes are part of the versioned
 REST contract. The repository does not currently ship binary-protobuf
 consumers, so the binary `WIRE` rule is intentionally not enabled. The CI
-workflow fetches full Git history so a missing `main` baseline fails the check
-instead of allowing a vacuous pass.
+workflow fetches full Git history so a missing `origin/main` baseline fails the
+check instead of allowing a vacuous pass.
 
 ## Deprecation timeline
 

--- a/docs/api-versioning.mdx
+++ b/docs/api-versioning.mdx
@@ -25,6 +25,16 @@ Clients should ignore response fields and enum values they do not recognize.
 The bundled [OpenAPI specification](https://www.worldmonitor.app/openapi.yaml)
 is the source of truth for the currently published contract.
 
+## Protobuf compatibility gate
+
+The public API is JSON over HTTP. Proto changes are checked against `main` in
+CI with Buf's `FILE`, `PACKAGE`, and `WIRE_JSON` rules. `WIRE_JSON` is
+intentional: generated JSON field names and shapes are part of the versioned
+REST contract. The repository does not currently ship binary-protobuf
+consumers, so the binary `WIRE` rule is intentionally not enabled. The CI
+workflow fetches full Git history so a missing `main` baseline fails the check
+instead of allowing a vacuous pass.
+
 ## Deprecation timeline
 
 When WorldMonitor replaces or retires a public REST version or operation:

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -17,6 +17,9 @@ lint:
       - worldmonitor/news/v1/service.proto
   ignore:
     - sebuf
+# Public APIs are JSON over HTTP, so WIRE_JSON protects the generated JSON
+# field/name mapping. There are currently no binary protobuf consumers, so the
+# binary WIRE rule is intentionally omitted; FILE and PACKAGE remain enforced.
 breaking:
   use:
     - FILE

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -294,7 +294,7 @@ function securityAuditMatrixLockfiles(): string[] {
 }
 
 describe('CI workflow coverage', () => {
-  it('runs the proto breaking gate against the full main history (#6114)', () => {
+  it('runs the proto breaking check against the full main history (#6114)', () => {
     const breakingJob = workflowJobBlock(protoCheckWorkflow, 'proto-breaking');
     assert.doesNotMatch(breakingJob, /^\s+if:/m, 'proto-breaking must run for fork pull requests');
     const [checkoutStep] = workflowStepBlocksByUses(breakingJob, 'actions/checkout');
@@ -310,6 +310,31 @@ describe('CI workflow coverage', () => {
       'proto-check.yml must run the canonical buf breaking target against the fetched origin/main proto baseline',
     );
     assert.doesNotMatch(breakingStep, /^\s+continue-on-error:/m);
+
+    // Pin the shared Makefile baseline. `run: make breaking` alone stays green if the
+    // recipe regresses to proto/.git#branch=main (no repo) or loses origin/main.
+    const makefile = read(resolve(root, 'Makefile'));
+    assert.match(
+      makefile,
+      /^breaking:[^\n]*\n\tcd \$\(PROTO_DIR\) && buf breaking --against '\.\.\/\.git#branch=origin\/main,subdir=proto'\s*$/m,
+      "make breaking must use '../.git#branch=origin/main,subdir=proto' from PROTO_DIR",
+    );
+
+    // Pin the documented FILE/PACKAGE/WIRE_JSON policy (binary WIRE intentionally off).
+    const bufYaml = read(resolve(root, 'proto/buf.yaml'));
+    const breakingUse = bufYaml.match(/\nbreaking:\n(?:[^\n]*\n)*?[ \t]+use:\n((?:[ \t]+-[^\n]*\n)+)/);
+    assert.ok(breakingUse, 'proto/buf.yaml must declare breaking.use');
+    const rules = [...breakingUse[1].matchAll(/^[ \t]+-[ \t]+(\S+)\s*$/gm)].map((m) => m[1]).sort();
+    assert.deepEqual(
+      rules,
+      ['FILE', 'PACKAGE', 'WIRE_JSON'].sort(),
+      'breaking.use must be exactly FILE, PACKAGE, WIRE_JSON (binary WIRE intentionally omitted)',
+    );
+
+    // Path-filtered Proto Generation Check is outside deploy-gate's aggregated
+    // workflows (#5402). A red `proto-breaking` check-run does not fail the
+    // required `gate` context until it is wired into deploy-gate (with a
+    // path-safe always-run/skip pattern) or listed in branch-protection/rulesets.
   });
 
   it('runs the public documentation boundary on docs-only pull requests', () => {

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -20,6 +20,7 @@ const testWorkflow = read(resolve(workflowsDir, 'test.yml'));
 const desktopBuildWorkflow = read(resolve(workflowsDir, 'build-desktop.yml'));
 const desktopCanaryWorkflow = read(resolve(workflowsDir, 'test-linux-app.yml'));
 const lintCodeWorkflow = read(resolve(workflowsDir, 'lint-code.yml'));
+const protoCheckWorkflow = read(resolve(workflowsDir, 'proto-check.yml'));
 const workflowText = readdirSync(workflowsDir)
   .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
   .map((name) => read(resolve(workflowsDir, name)))
@@ -143,6 +144,19 @@ function workflowStepBlock(workflow: string, stepName: string): string {
   assert.notEqual(startIndex, -1, `workflow must define step ${stepName}`);
   const nextStepIndex = workflow.indexOf('\n      - ', startIndex + marker.length);
   return workflow.slice(startIndex, nextStepIndex === -1 ? workflow.length : nextStepIndex);
+}
+
+function workflowStepBlocksByUses(workflow: string, action: string): string[] {
+  const marker = new RegExp(`\\n      - uses: ${escapeRegExp(action)}@[^\\n]+\\n`, 'g');
+  const blocks: string[] = [];
+  for (const match of workflow.matchAll(marker)) {
+    const startIndex = match.index ?? -1;
+    assert.notEqual(startIndex, -1, `workflow must define ${action}`);
+    const nextStepIndex = workflow.indexOf('\n      - ', startIndex + match[0].length);
+    blocks.push(workflow.slice(startIndex, nextStepIndex === -1 ? workflow.length : nextStepIndex));
+  }
+  assert.ok(blocks.length > 0, `workflow must define ${action}`);
+  return blocks;
 }
 
 function workflowRunScript(stepBlock: string): string {
@@ -280,6 +294,24 @@ function securityAuditMatrixLockfiles(): string[] {
 }
 
 describe('CI workflow coverage', () => {
+  it('runs the proto breaking gate against the full main history (#6114)', () => {
+    const breakingJob = workflowJobBlock(protoCheckWorkflow, 'proto-breaking');
+    assert.doesNotMatch(breakingJob, /^\s+if:/m, 'proto-breaking must run for fork pull requests');
+    const [checkoutStep] = workflowStepBlocksByUses(breakingJob, 'actions/checkout');
+    assert.match(
+      checkoutStep,
+      /\n\s+with:\n\s+fetch-depth: 0\n/,
+      'proto-breaking must fetch full history so the main baseline is available',
+    );
+    const breakingStep = workflowStepBlock(protoCheckWorkflow, 'Check for breaking proto changes');
+    assert.match(
+      breakingStep,
+      /^\s+run: make breaking\s*$/m,
+      'proto-check.yml must run the canonical buf breaking target against the fetched origin/main proto baseline',
+    );
+    assert.doesNotMatch(breakingStep, /^\s+continue-on-error:/m);
+  });
+
   it('runs the public documentation boundary on docs-only pull requests', () => {
     const publicDocsJob = workflowJobBlock(lintCodeWorkflow, 'public-docs');
 


### PR DESCRIPTION
## Summary

Proto compatibility regressions now fail on every pull request that triggers the proto workflow, including pull requests from forks. A fork-safe Buf-only job compares the checked-out proto tree with the full `origin/main` history, while the existing generation job remains guarded for its private plugin path. The local `make breaking` target and CI share one baseline command, and the repository now documents why `FILE`, `PACKAGE`, and `WIRE_JSON` are enabled while binary `WIRE` remains intentionally disabled.

Fixes #6114.

## Validation

- `./node_modules/.bin/tsx --test tests/ci-workflow-coverage.test.mts` — 18/18 passed
- YAML parse, `git diff --check`, and `make -e TMPDIR=/tmp breaking` — passed
- Deliberate enum-to-string proto mutation in a scratch Git repository — Buf failed as expected
- `npm run typecheck`, `npm run lint`, `npm run lint:md`, and `npm run docs:check` — passed
- Full `npm run test:data` reached environment-dependent pre-push fixture failures in the restricted sandbox; the focused pre-push-hook suite passed 15/15 outside the sandbox

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this change affects pull-request CI and API-versioning documentation only; it does not change deployed runtime behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/MODEL_GPT--5-000000)