### PR TITLE
fix(health): bound content freshness activation grace

### DIFF
--- a/api/_content-freshness.js
+++ b/api/_content-freshness.js
@@ -29,6 +29,59 @@ function entityList(value) {
     : [];
 }
 
+// #6111 — content-freshness activation is a deployment-order bridge, not a
+// permanent exemption. The producer publishes on a 12h Railway cron; this
+// window starts when the schema shipped and ends after the first complete cron
+// window plus six hours of scheduling slack. Keep the source timestamps here
+// so health, seed-health, and MCP cannot silently invent different deadlines.
+export const PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY =
+  'seed-activated:supply_chain:portwatch-ports:content-freshness';
+
+export const CONTENT_FRESHNESS_ROLLOUT = Object.freeze({
+  [PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY]: Object.freeze({
+    from: '2026-08-03T10:24:42Z',
+    until: '2026-08-04T06:00:00Z',
+  }),
+});
+
+const CONTENT_FRESHNESS_ROLLOUT_WINDOWS = new Map(
+  Object.entries(CONTENT_FRESHNESS_ROLLOUT).map(([key, window]) => [key, {
+    ...window,
+    fromMs: Date.parse(window.from),
+    untilMs: Date.parse(window.until),
+  }]),
+);
+
+export const CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS = Object.freeze(
+  Object.fromEntries(
+    [...CONTENT_FRESHNESS_ROLLOUT_WINDOWS.entries()]
+      .filter(([, window]) => Number.isFinite(window.untilMs))
+      .map(([key, window]) => [key, window.untilMs]),
+  ),
+);
+
+export function getContentFreshnessActivationWindow(activationKey) {
+  const window = CONTENT_FRESHNESS_ROLLOUT_WINDOWS.get(activationKey);
+  if (!window || !Number.isFinite(window.fromMs) || !Number.isFinite(window.untilMs)) return null;
+  if (window.untilMs <= window.fromMs) return null;
+  return window;
+}
+
+export function getActiveContentFreshnessActivationWindow(activationKey, activationState, now) {
+  const window = getContentFreshnessActivationWindow(activationKey);
+  return activationState === false
+    && window !== null
+    && Number.isFinite(now)
+    && now >= window.fromMs
+    && now < window.untilMs
+    ? window
+    : null;
+}
+
+export function isContentFreshnessGraceActive(activationKey, activationState, now) {
+  return getActiveContentFreshnessActivationWindow(activationKey, activationState, now) !== null;
+}
+
 // Returns a private `fieldPresent` bit in addition to the wire fields. A JSON
 // field that is present but malformed is a producer regression; only a truly
 // absent field can receive deployment-order activation grace.

--- a/api/_content-freshness.js
+++ b/api/_content-freshness.js
@@ -60,7 +60,7 @@ export const CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS = Object.freeze(
   ),
 );
 
-export function getContentFreshnessActivationWindow(activationKey) {
+function getContentFreshnessActivationWindow(activationKey) {
   const window = CONTENT_FRESHNESS_ROLLOUT_WINDOWS.get(activationKey);
   if (!window || !Number.isFinite(window.fromMs) || !Number.isFinite(window.untilMs)) return null;
   if (window.untilMs <= window.fromMs) return null;
@@ -76,10 +76,6 @@ export function getActiveContentFreshnessActivationWindow(activationKey, activat
     && now < window.untilMs
     ? window
     : null;
-}
-
-export function isContentFreshnessGraceActive(activationKey, activationState, now) {
-  return getActiveContentFreshnessActivationWindow(activationKey, activationState, now) !== null;
 }
 
 // Returns a private `fieldPresent` bit in addition to the wire fields. A JSON

--- a/api/_content-freshness.js
+++ b/api/_content-freshness.js
@@ -30,10 +30,26 @@ function entityList(value) {
 }
 
 // #6111 — content-freshness activation is a deployment-order bridge, not a
-// permanent exemption. The producer publishes on a 12h Railway cron; this
-// window starts when the schema shipped and ends after the first complete cron
-// window plus six hours of scheduling slack. Keep the source timestamps here
-// so health, seed-health, and MCP cannot silently invent different deadlines.
+// permanent exemption. The producer publishes on a 12h Railway cron; a window
+// starts when the schema shipped and ends after the first complete cron window
+// plus six hours of scheduling slack. Keep the source timestamps here so
+// health, seed-health, and MCP cannot silently invent different deadlines.
+//
+// The PortWatch entry below is SPENT: its window closed 2026-08-04T06:00:00Z,
+// and the producer has since published the block (the activation marker reads
+// EXISTS=1 in production), so the grace path is unreachable on two independent
+// grounds. It is retained as the audit record of what was granted and until
+// when. Do NOT extend it to re-open the softening — that is precisely the
+// unbounded grace #6111 exists to end, and every consumer already fails closed
+// without it. `getActiveContentFreshnessActivationWindow` therefore returns
+// null for every input today, and `contentFreshnessPendingUntil` is not
+// emitted on any surface.
+//
+// To bridge a FUTURE content schema, add a new entry keyed by its activation
+// marker with `from` = the deploy timestamp and `until` = one full producer
+// interval plus slack AFTER it. Compute both against the actual deploy time:
+// a window authored earlier in a review cycle can elapse before merge, which
+// ships a bridge that never carries anything.
 export const PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY =
   'seed-activated:supply_chain:portwatch-ports:content-freshness';
 

--- a/api/_upstash-json.d.ts
+++ b/api/_upstash-json.d.ts
@@ -31,6 +31,11 @@ export declare function getRedisCredentials(): {
   token: string;
 } | null;
 
+export declare function readExistsFlags(
+  results: unknown,
+  keys: readonly string[],
+): Map<string, boolean>;
+
 export declare function redisPipeline(
   commands: Array<Array<string | number>>,
   timeoutMs?: number,

--- a/api/_upstash-json.d.ts
+++ b/api/_upstash-json.d.ts
@@ -39,7 +39,7 @@ export declare function readExistsFlags(
 export declare function redisPipeline(
   commands: Array<Array<string | number>>,
   timeoutMs?: number,
-): Promise<Array<{ result: unknown }> | null>;
+): Promise<Array<{ result?: unknown; error?: unknown }> | null>;
 
 export declare function setCachedData(
   key: string,

--- a/api/_upstash-json.js
+++ b/api/_upstash-json.js
@@ -159,15 +159,48 @@ export function getRedisCredentials() {
 }
 
 /**
+ * Convert successful EXISTS pipeline entries into a three-valued marker map.
+ * A key is added only when its entry explicitly has a result of 0 or 1 and
+ * has no error field. Missing, malformed, null-result, and per-command-error
+ * entries remain absent from the map, which callers interpret as unknown.
+ *
+ * @param {unknown} results
+ * @param {readonly string[]} keys
+ * @returns {Map<string, boolean>}
+ */
+export function readExistsFlags(results, keys) {
+  const states = new Map();
+  if (!Array.isArray(results) || results.length !== keys.length) return states;
+
+  for (let i = 0; i < keys.length; i++) {
+    const entry = results[i];
+    if (
+      !entry
+      || typeof entry !== 'object'
+      || Array.isArray(entry)
+      || Object.prototype.hasOwnProperty.call(entry, 'error')
+      || !Object.prototype.hasOwnProperty.call(entry, 'result')
+    ) {
+      continue;
+    }
+    if (entry.result === 1 || entry.result === '1') states.set(keys[i], true);
+    else if (entry.result === 0 || entry.result === '0') states.set(keys[i], false);
+  }
+  return states;
+}
+
+/**
  * Execute a batch of Redis commands via the Upstash pipeline endpoint.
- * Returns null on missing credentials, HTTP error, or timeout.
+ * Returns null on missing credentials, HTTP error, timeout, or a response body
+ * that is not an array with exactly one entry per command.
  * @param {Array<string[]>} commands - e.g. [['GET', 'key'], ['EXPIRE', 'key', '60']]
  * @param {number} [timeoutMs=5000]
- * @returns {Promise<Array<{ result: unknown }> | null>}
+ * @returns {Promise<Array<{ result?: unknown, error?: unknown }> | null>}
  */
 export async function redisPipeline(commands, timeoutMs = 5_000) {
   const creds = getRedisCredentials();
   if (!creds) return null;
+  if (!Array.isArray(commands)) return null;
   try {
     const resp = await fetch(`${creds.url}/pipeline`, {
       method: 'POST',
@@ -180,7 +213,9 @@ export async function redisPipeline(commands, timeoutMs = 5_000) {
       signal: AbortSignal.timeout(timeoutMs),
     });
     if (!resp.ok) return null;
-    return await resp.json();
+    const entries = await resp.json();
+    if (!Array.isArray(entries) || entries.length !== commands.length) return null;
+    return entries;
   } catch {
     return null;
   }

--- a/api/health.js
+++ b/api/health.js
@@ -1785,6 +1785,58 @@ function hasExpiredRolloutPending(snapshot, now) {
 }
 
 /**
+ * The earliest activation deadline this snapshot promises, or Infinity when it
+ * promises none. A malformed deadline resolves to `now` — the same fail-closed
+ * reading isExpiredDeadline applies — so a corrupt value shortens the TTL
+ * instead of pinning a snapshot no reader will accept.
+ */
+function nearestActivationDeadlineMs(snapshot, now) {
+  let nearest = Infinity;
+  const consider = (raw) => {
+    const parsed = Date.parse(typeof raw === 'string' ? raw : '');
+    const deadline = Number.isFinite(parsed) ? parsed : now;
+    if (deadline < nearest) nearest = deadline;
+  };
+  const entries = snapshot?.checks ?? snapshot?.problems;
+  if (entries && typeof entries === 'object') {
+    for (const entry of Object.values(entries)) {
+      if (entry?.status === 'ROLLOUT_PENDING') consider(entry.rolloutPendingUntil);
+      if (Object.prototype.hasOwnProperty.call(entry ?? {}, 'contentFreshnessPendingUntil')) {
+        consider(entry.contentFreshnessPendingUntil);
+      }
+    }
+  }
+  const summaryDeadlines = snapshot?.summary?.contentFreshnessPendingUntil;
+  if (summaryDeadlines && typeof summaryDeadlines === 'object') {
+    for (const deadline of Object.values(summaryDeadlines)) consider(deadline);
+  }
+  return nearest;
+}
+
+/**
+ * Cache lifetime for a verdict snapshot: the normal 60s, SHORTENED so the entry
+ * cannot outlive any softening deadline it publishes.
+ *
+ * Without this, a snapshot written just before a deadline stays cacheable for
+ * the full minute, every reader correctly refuses it via hasExpiredActivationGrace,
+ * and — because the refresh wait budget (3s) is shorter than a ~390-command
+ * sweep — each concurrent waiter then falls through to its OWN sweep. Expiring
+ * the key AT the deadline turns that into an ordinary cache miss, which the
+ * existing lock already serialises to one sweep.
+ *
+ * Floor, never ceil: the entry must die at or before the deadline, not after.
+ * Redis EX has a 1s granularity, so a sub-second overhang remains possible —
+ * which is why hasExpiredActivationGrace stays as the read-side backstop rather
+ * than being replaced by this.
+ */
+function snapshotTtlSeconds(snapshot, now) {
+  const nearest = nearestActivationDeadlineMs(snapshot, now);
+  if (nearest === Infinity) return HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS;
+  const secondsUntilDeadline = Math.floor((nearest - now) / 1_000);
+  return Math.min(HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS, Math.max(1, secondsUntilDeadline));
+}
+
+/**
  * Bucket counts -> the endpoint's overall verdict.
  *
  * Extracted from the handler so it is reachable from tests. It used to be inline
@@ -2256,20 +2308,23 @@ export async function handleHealth(req, ctx, options = {}) {
   // live verdict just computed; the next request will retry by sweeping.
   // Both snapshots are written by the SAME sweep, in one pipeline, so the compact
   // form can never disagree with the full one or outlive it.
+  // Both keys share one TTL for the same reason they share one sweep: they
+  // carry the same deadlines, so they must stop being servable together.
+  const snapshotTtl = String(snapshotTtlSeconds(verdictSnapshot, snapshotNow()));
   const snapshotWriteResult = await redisPipeline([
     [
       'SET',
       HEALTH_VERDICT_SNAPSHOT_KEY,
       JSON.stringify(verdictSnapshot),
       'EX',
-      String(HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS),
+      snapshotTtl,
     ],
     [
       'SET',
       HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY,
       JSON.stringify(buildCompactVerdictSnapshot(verdictSnapshot)),
       'EX',
-      String(HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS),
+      snapshotTtl,
     ],
   ], 4_000).catch(() => null);
   const snapshotWriteFailed = !snapshotWriteResult
@@ -2313,6 +2368,7 @@ export const __testing__ = {
   computeOverallStatus,
   hasExpiredRolloutPending,
   hasExpiredActivationGrace,
+  snapshotTtlSeconds,
   CONSUMER_PRICE_HEALTH_MARKETS,
   consumerPriceCoverageActivationKey,
   consumerPriceCoverageHealthName,

--- a/api/health.js
+++ b/api/health.js
@@ -1777,12 +1777,11 @@ function hasExpiredActivationGrace(snapshot, now, { includeRollout = true, inclu
   return false;
 }
 
+// Retained as a named test seam: tests/consumer-prices-coverage-rollout.test.mjs
+// asserts the rollout-only half of the shared predicate. Production reads the
+// general function directly, so both graces are checked on every cache hit.
 function hasExpiredRolloutPending(snapshot, now) {
   return hasExpiredActivationGrace(snapshot, now, { includeContent: false });
-}
-
-function hasExpiredContentFreshnessPending(snapshot, now) {
-  return hasExpiredActivationGrace(snapshot, now, { includeRollout: false });
 }
 
 /**
@@ -2313,7 +2312,6 @@ export const __testing__ = {
   ROLLOUT_PENDING_FROM_MS,
   computeOverallStatus,
   hasExpiredRolloutPending,
-  hasExpiredContentFreshnessPending,
   hasExpiredActivationGrace,
   CONSUMER_PRICE_HEALTH_MARKETS,
   consumerPriceCoverageActivationKey,

--- a/api/health.js
+++ b/api/health.js
@@ -12,7 +12,7 @@ import {
 // as `.data`), so importing it is behavior-preserving.
 import { unwrapEnvelope } from './_seed-envelope.js';
 // @ts-expect-error — JS module, no declaration file
-import { redisPipeline, getRedisCredentials } from './_upstash-json.js';
+import { redisPipeline, getRedisCredentials, readExistsFlags } from './_upstash-json.js';
 import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.js';
 import { BOOTSTRAP_CACHE_KEYS } from './_bootstrap-tier-keys.js';
 import {
@@ -20,6 +20,9 @@ import {
 } from './_china-decision-health.js';
 import {
   buildContentFreshnessAssessment,
+  CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS,
+  getActiveContentFreshnessActivationWindow,
+  PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY,
   projectContentFreshnessForWire,
 } from './_content-freshness.js';
 
@@ -53,7 +56,10 @@ const CHINA_DECISION_HEALTHY_QUIET_CAUSE = 'healthy_quiet_window';
 // HTTP responses stay `no-store`, but the expensive Redis-wide verdict is
 // shared briefly at the origin. At the measured browser poll rate this turns
 // ~390 Redis commands per request into one GET, plus one sweep per minute.
-const HEALTH_VERDICT_SNAPSHOT_BASE_KEY = 'health:verdict:v1';
+// v2 invalidates pre-#6111 snapshots because they cannot carry the bounded
+// content-freshness activation deadline used to decide whether a cache hit is
+// still allowed to soften a missing producer block.
+const HEALTH_VERDICT_SNAPSHOT_BASE_KEY = 'health:verdict:v2';
 function healthVerdictRedisKey(baseKey, vercelEnv, commitSha) {
   if (!vercelEnv || vercelEnv === 'production') return baseKey;
   return `${vercelEnv}:${commitSha?.slice(0, 8) || 'dev'}:${baseKey}`;
@@ -73,7 +79,7 @@ const HEALTH_VERDICT_SNAPSHOT_KEY = healthVerdictRedisKey(
 // of Redis to render ~1 KB of it, which is ~2.2 GB/day of egress for bytes the
 // caller throws away (#5300). One sweep writes both keys, so they can never
 // disagree.
-const HEALTH_VERDICT_COMPACT_SNAPSHOT_BASE_KEY = 'health:verdict:compact:v1';
+const HEALTH_VERDICT_COMPACT_SNAPSHOT_BASE_KEY = 'health:verdict:compact:v2';
 const HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY = healthVerdictRedisKey(
   HEALTH_VERDICT_COMPACT_SNAPSHOT_BASE_KEY,
   process.env.VERCEL_ENV,
@@ -857,7 +863,7 @@ const ACTIVATION_MARKERS = {
   // on the first run that publishes a contentFreshness block, so "the producer
   // has never shipped this field" reads as pending rather than as a fault —
   // while a block that DISAPPEARS after activation still fails closed.
-  portwatchContentFreshness: 'seed-activated:supply_chain:portwatch-ports:content-freshness',
+  portwatchContentFreshness: PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY,
 };
 
 // #6059 — consumer-price coverage rollout handshake.
@@ -1367,18 +1373,20 @@ function classifyKey(name, redisKey, opts, ctx) {
   // granted on the absence of evidence never expires, so an UNREADABLE marker
   // would otherwise disable the alarm for good.
   //
-  // Scope, stated because the hazard is wider than the fix: this closes the
-  // unreadable arm ONLY. A marker that was evicted, renamed, or restored into
-  // an empty Redis returns a clean EXISTS=0 — the read-and-absent arm above —
-  // and still grants the grace indefinitely. Bounding that needs a compiled
-  // deadline the way ROLLOUT_PENDING_UNTIL_MS does; tracked in #6111.
-  const contentFreshnessPending = Boolean(
-    seedCfg?.requireContentFreshness
+  // The clean-absent arm is separately bounded by CONTENT_FRESHNESS_ROLLOUT.
+  // A marker that was evicted, renamed, or restored into an empty Redis can
+  // therefore delay strictness only until the compiled deadline (#6111).
+  const contentFreshnessActivationWindow = seedCfg?.requireContentFreshness
     && contentFreshness
     && !contentFreshness.fieldPresent
     && seedCfg.contentFreshnessActivation
-    && ctx.activationStates?.get(seedCfg.contentFreshnessActivation) === false,
-  );
+    ? getActiveContentFreshnessActivationWindow(
+      ACTIVATION_MARKERS[seedCfg.contentFreshnessActivation],
+      ctx.activationStates?.get(seedCfg.contentFreshnessActivation),
+      now,
+    )
+    : null;
+  const contentFreshnessPending = contentFreshnessActivationWindow !== null;
 
   // When the data key is gone the meta count is meaningless; force records=0
   // so we never display the contradictory "EMPTY records=N>0" pair (item 1).
@@ -1489,6 +1497,9 @@ function classifyKey(name, redisKey, opts, ctx) {
   // payload alone — an operator (and scripts/check-seed-freshness.mjs) can see
   // exactly when this key stops being excused without reading api/health.js.
   if (status === 'ROLLOUT_PENDING') entry.rolloutPendingUntil = new Date(rolloutPendingUntil).toISOString();
+  if (contentFreshnessActivationWindow) {
+    entry.contentFreshnessPendingUntil = new Date(contentFreshnessActivationWindow.untilMs).toISOString();
+  }
   // Activation is emitted for EVERY status on a rollout-registered key, not just
   // the pending one — `rolloutPendingUntil` exists precisely when the market has
   // NOT activated, so on its own it can never answer "which markets have gone
@@ -1728,22 +1739,50 @@ function isProblemStatus(status) {
 }
 
 /**
- * True when a cached verdict still carries a ROLLOUT_PENDING entry whose own
- * published deadline has already passed — i.e. the cache is about to serve a
- * softening that expired. Reads both snapshot shapes: the full one keyed by
- * `checks`, the compact one by `problems`.
+ * True when a cached verdict still carries a rollout or content-freshness
+ * softening whose published deadline has passed. Reads both snapshot shapes:
+ * the full one keyed by `checks`, the compact one by `problems`.
  */
-function hasExpiredRolloutPending(snapshot, now) {
+function isExpiredDeadline(raw, now) {
+  const until = Date.parse(typeof raw === 'string' ? raw : '');
+  // An unparseable deadline is treated as expired: a pending entry that
+  // cannot prove it is still inside its window must not be served warm.
+  return !Number.isFinite(until) || now >= until;
+}
+
+function hasExpiredActivationGrace(snapshot, now, { includeRollout = true, includeContent = true } = {}) {
   const entries = snapshot?.checks ?? snapshot?.problems;
-  if (!entries || typeof entries !== 'object') return false;
-  for (const entry of Object.values(entries)) {
-    if (entry?.status !== 'ROLLOUT_PENDING') continue;
-    const until = Date.parse(entry?.rolloutPendingUntil ?? '');
-    // An unparseable deadline is treated as expired: a ROLLOUT_PENDING entry
-    // that cannot prove it is still inside its window must not be served warm.
-    if (!Number.isFinite(until) || now >= until) return true;
+  if (entries && typeof entries === 'object') {
+    for (const entry of Object.values(entries)) {
+      if (
+        includeRollout
+        && entry?.status === 'ROLLOUT_PENDING'
+        && isExpiredDeadline(entry.rolloutPendingUntil, now)
+      ) return true;
+      if (
+        includeContent
+        && Object.prototype.hasOwnProperty.call(entry ?? {}, 'contentFreshnessPendingUntil')
+        && isExpiredDeadline(entry.contentFreshnessPendingUntil, now)
+      ) return true;
+    }
+  }
+  if (includeContent) {
+    const summaryDeadlines = snapshot?.summary?.contentFreshnessPendingUntil;
+    if (summaryDeadlines && typeof summaryDeadlines === 'object') {
+      for (const deadline of Object.values(summaryDeadlines)) {
+        if (isExpiredDeadline(deadline, now)) return true;
+      }
+    }
   }
   return false;
+}
+
+function hasExpiredRolloutPending(snapshot, now) {
+  return hasExpiredActivationGrace(snapshot, now, { includeContent: false });
+}
+
+function hasExpiredContentFreshnessPending(snapshot, now) {
+  return hasExpiredActivationGrace(snapshot, now, { includeRollout: false });
 }
 
 /**
@@ -1859,7 +1898,13 @@ function healthResponse(snapshot, compact, headers) {
   });
 }
 
-export default async function handler(req, ctx) {
+export async function handleHealth(req, ctx, options = {}) {
+  const hasInjectedClock = Object.prototype.hasOwnProperty.call(options, 'now');
+  const now = hasInjectedClock ? options.now : Date.now();
+  // The explicit clock is a deterministic test seam. Production callers keep
+  // sampling wall time after Redis I/O so a snapshot that expires in flight is
+  // not served as fresh merely because the request started before its TTL.
+  const snapshotNow = () => (hasInjectedClock ? now : Date.now());
   if (isDisallowedOrigin(req)) {
     return new Response('Forbidden', { status: 403 });
   }
@@ -1942,8 +1987,6 @@ export default async function handler(req, ctx) {
     return new Response(JSON.stringify(body, null, 2), { status: 200, headers });
   }
 
-  const now = Date.now();
-
   // A snapshot hit is one Redis command instead of the ~390-command registry
   // sweep below. A failed snapshot read is a real Redis outage, not a cache
   // miss: returning 503 preserves UptimeRobot's hard-down signal.
@@ -1958,14 +2001,12 @@ export default async function handler(req, ctx) {
     const snapshotResult = await redisPipeline([['GET', snapshotKey]], 4_000);
     if (!snapshotResult) throw new Error('Redis request failed');
     if (snapshotResult[0]?.error) throw new Error('Redis snapshot read failed');
-    const cachedSnapshot = parseHealthVerdictSnapshot(snapshotResult[0]?.result, Date.now(), { requireChecks: !compact });
-    // A rollout deadline is the one promise in this payload that is exact to the
-    // second, so the 60s verdict cache must not outlive it: a snapshot written
-    // just before a deadline would otherwise keep serving ROLLOUT_PENDING (and
-    // keep excusing the key downstream) for up to a minute after the softening
-    // was supposed to end. Sweep fresh instead — this can only fire in the one
-    // minute straddling a deadline, at most once per rollout.
-    if (cachedSnapshot && !hasExpiredRolloutPending(cachedSnapshot, Date.now())) {
+    const cachedSnapshot = parseHealthVerdictSnapshot(snapshotResult[0]?.result, snapshotNow(), { requireChecks: !compact });
+    // Activation deadlines are exact to the second, so the 60s verdict cache
+    // must not outlive either rollout grace. A snapshot written just before a
+    // deadline would otherwise keep serving a softened verdict for up to a
+    // minute after strictness was supposed to begin. Sweep fresh instead.
+    if (cachedSnapshot && !hasExpiredActivationGrace(cachedSnapshot, snapshotNow())) {
       return healthResponse(cachedSnapshot, compact, headers);
     }
 
@@ -2001,8 +2042,13 @@ export default async function handler(req, ctx) {
         const redisTimeoutMs = Math.min(4_000, remainingMs);
         const refreshedResult = await redisPipeline([['GET', snapshotKey]], redisTimeoutMs);
         if (!refreshedResult || refreshedResult[0]?.error) throw new Error('Redis snapshot wait failed');
-        const refreshedSnapshot = parseHealthVerdictSnapshot(refreshedResult[0]?.result, Date.now(), { requireChecks: !compact });
-        if (refreshedSnapshot) return healthResponse(refreshedSnapshot, compact, headers);
+        const refreshedSnapshot = parseHealthVerdictSnapshot(refreshedResult[0]?.result, snapshotNow(), { requireChecks: !compact });
+        if (
+          refreshedSnapshot
+          && !hasExpiredActivationGrace(refreshedSnapshot, snapshotNow())
+        ) {
+          return healthResponse(refreshedSnapshot, compact, headers);
+        }
 
         lockResult = await redisPipeline([[
           'SET',
@@ -2086,30 +2132,22 @@ export default async function handler(req, ctx) {
     keyMetaValues.set(allMetaKeys[i], r?.result ?? null);
   }
   // activationStates: health name -> whether its durable activation marker
-  // exists. THREE-valued on purpose (#6095, matching api/mcp/freshness.ts): an
-  // entry is present ONLY when the EXISTS command itself succeeded. `true` =
-  // read and present (the key has left ON_DEMAND softening permanently, #4927
-  // re-review P1); `false` = read and absent (the producer has demonstrably
-  // never published); a MISSING entry = the read failed, so the state is
-  // unknown. Which way "unknown" resolves is the consumer's call and the two
-  // policies differ deliberately — see classifyKey.
-  // Test the entry ITSELF, never `!r?.error` — that reads TRUE for a slot that
-  // never arrived (`undefined?.error` is undefined), so a response array
-  // shorter than the command list would record every missing marker as `false`
-  // = "read and confirmed absent" and hand back the exact grace this three-
-  // valued read exists to revoke. The EXISTS commands sit at the tail of the
-  // sweep, which is precisely where a truncated response stops short. Same
-  // guard as api/seed-health.js and api/mcp/dispatch.ts.
-  const activationStates = new Map();
-  for (let i = 0; i < activationEntries.length; i++) {
-    const r = results[allDataKeys.length + allMetaKeys.length + i];
-    if (r && !r.error) activationStates.set(activationEntries[i][0], Number(r.result) === 1);
-  }
+  // exists. `readExistsFlags` is the one shared three-valued parser for all
+  // three consumers (#6115): only an entry with an explicit result of 0 or 1
+  // enters the map. Missing, malformed, null-result, and errored entries stay
+  // unknown, so no surface can turn an absent response slot into proof of
+  // pre-activation.
+  const activationOffset = allDataKeys.length + allMetaKeys.length;
+  const activationStates = readExistsFlags(
+    results.slice(activationOffset, activationOffset + activationEntries.length),
+    activationEntries.map(([name]) => name),
+  );
   const chinaCoverageResult = results[allDataKeys.length + allMetaKeys.length + activationEntries.length];
   const chinaCoverageRaw = chinaCoverageResult?.error ? null : chinaCoverageResult?.result;
 
   const classifyCtx = { keyStrens, keyErrors, keyMetaValues, keyMetaErrors, activationStates, now };
   const checks = {};
+  const contentFreshnessPendingUntil = {};
   const counts = { ok: 0, warn: 0, onDemandWarn: 0, staleContent: 0, rolloutPending: 0, crit: 0 };
   let totalChecks = 0;
 
@@ -2125,6 +2163,9 @@ export default async function handler(req, ctx) {
         entry = composeChinaCoverageStatus(entry, chinaCoverageRaw, Boolean(chinaCoverageResult?.error));
       }
       checks[name] = entry;
+      if (typeof entry.contentFreshnessPendingUntil === 'string') {
+        contentFreshnessPendingUntil[name] = entry.contentFreshnessPendingUntil;
+      }
       const bucket = STATUS_COUNTS[entry.status] ?? 'warn';
       counts[bucket]++;
       if (entry.status === 'EMPTY_ON_DEMAND') counts.onDemandWarn++;
@@ -2202,6 +2243,9 @@ export default async function handler(req, ctx) {
       // Bounded: each entry carries a `rolloutPendingUntil` deadline, after
       // which it becomes EMPTY (crit).
       rolloutPending: counts.rolloutPending,
+      ...(Object.keys(contentFreshnessPendingUntil).length > 0
+        ? { contentFreshnessPendingUntil }
+        : {}),
       crit: critCount,
     },
     checkedAt: new Date(now).toISOString(),
@@ -2250,6 +2294,10 @@ export default async function handler(req, ctx) {
   return healthResponse(verdictSnapshot, compact, headers);
 }
 
+export default async function handler(req, ctx) {
+  return handleHealth(req, ctx);
+}
+
 // Test-only exports. Not part of the public edge handler surface — Vercel's
 // runtime invokes only `default export`. These let scoped unit tests exercise
 // the classifier without standing up the full bootstrap-keys + Redis pipeline.
@@ -2260,10 +2308,13 @@ export const __testing__ = {
   healthResponseBody,
   collectFailureLogProblems,
   ACTIVATION_MARKERS,
+  CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS,
   ROLLOUT_PENDING_UNTIL_MS,
   ROLLOUT_PENDING_FROM_MS,
   computeOverallStatus,
   hasExpiredRolloutPending,
+  hasExpiredContentFreshnessPending,
+  hasExpiredActivationGrace,
   CONSUMER_PRICE_HEALTH_MARKETS,
   consumerPriceCoverageActivationKey,
   consumerPriceCoverageHealthName,

--- a/api/health.js
+++ b/api/health.js
@@ -2163,6 +2163,12 @@ export async function handleHealth(req, ctx, options = {}) {
     }, 503, headers);
   }
 
+  // Content-freshness activation deadlines are evaluated against the clock at
+  // which the full sweep finished. A production request that crosses the
+  // deadline while awaiting Redis must not preserve its request-start grace;
+  // injected clocks stay fixed so unit tests remain deterministic.
+  const evaluationNow = snapshotNow();
+
   // keyStrens: byte length per data key (0 = missing/empty/sentinel)
   // keyErrors: per-command Redis errors so we can surface REDIS_PARTIAL
   const keyStrens = new Map();
@@ -2196,7 +2202,14 @@ export async function handleHealth(req, ctx, options = {}) {
   const chinaCoverageResult = results[allDataKeys.length + allMetaKeys.length + activationEntries.length];
   const chinaCoverageRaw = chinaCoverageResult?.error ? null : chinaCoverageResult?.result;
 
-  const classifyCtx = { keyStrens, keyErrors, keyMetaValues, keyMetaErrors, activationStates, now };
+  const classifyCtx = {
+    keyStrens,
+    keyErrors,
+    keyMetaValues,
+    keyMetaErrors,
+    activationStates,
+    now: evaluationNow,
+  };
   const checks = {};
   const contentFreshnessPendingUntil = {};
   const counts = { ok: 0, warn: 0, onDemandWarn: 0, staleContent: 0, rolloutPending: 0, crit: 0 };
@@ -2241,7 +2254,7 @@ export async function handleHealth(req, ctx, options = {}) {
     const { problemKeys, sigKeys } = collectFailureLogProblems(checks);
     console.log('[health] %s problems=[%s]', overall, problemKeys.join(', '));
     const failureLogEntry = {
-      at: new Date(now).toISOString(),
+      at: new Date(evaluationNow).toISOString(),
       status: overall,
       critCount,
       warnCount: realWarnCount,
@@ -2299,7 +2312,7 @@ export async function handleHealth(req, ctx, options = {}) {
         : {}),
       crit: critCount,
     },
-    checkedAt: new Date(now).toISOString(),
+    checkedAt: new Date(evaluationNow).toISOString(),
     checks,
   };
 

--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -39,7 +39,7 @@ import { utf8ByteLength } from './utils';
 export async function executeTool(
   tool: CacheToolDef,
   params: Record<string, unknown> = {},
-  now = Date.now(),
+  now?: number,
 ): Promise<{
   cached_at: string | null;
   stale: boolean;
@@ -84,10 +84,16 @@ export async function executeTool(
       tags: { route: 'api/mcp', step: 'activation-marker', tool: tool.name },
     });
   }
+  // Sample wall time AFTER the Redis reads, never at function entry. The same
+  // rule api/health.js applies via snapshotNow(): a request that begins inside
+  // an activation window but finishes after it must not report the grace as
+  // still live, or MCP briefly disagrees with the health surfaces at the exact
+  // instant the deadline passes. `now` stays injectable as a test seam.
+  const evaluatedAt = now ?? Date.now();
   const { cached_at, stale, contentFreshnessPendingUntil } = evaluateFreshness(
     freshnessChecks,
     metas,
-    now,
+    evaluatedAt,
     activationStates,
   );
 

--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -1,4 +1,4 @@
-import { readJsonFromUpstash, redisPipeline } from '../_upstash-json.js';
+import { readExistsFlags, readJsonFromUpstash, redisPipeline } from '../_upstash-json.js';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../_sentry-edge.js';
 import { secondsUntilUtcMidnight } from '../../server/_shared/pro-mcp-token';
@@ -39,7 +39,13 @@ import { utf8ByteLength } from './utils';
 export async function executeTool(
   tool: CacheToolDef,
   params: Record<string, unknown> = {},
-): Promise<{ cached_at: string | null; stale: boolean; data: Record<string, unknown> }> {
+  now = Date.now(),
+): Promise<{
+  cached_at: string | null;
+  stale: boolean;
+  contentFreshnessPendingUntil?: string;
+  data: Record<string, unknown>;
+}> {
   const reads = tool._cacheKeys.map(k => readJsonFromUpstash(k));
   const freshnessChecks = tool._freshnessChecks?.length
     ? tool._freshnessChecks
@@ -54,10 +60,10 @@ export async function executeTool(
       .filter((key): key is string => typeof key === 'string' && key !== ''),
   )];
   // EXISTS, not GET — the marker's meaning is presence, and both health
-  // surfaces read it that way (api/health.js: `Number(r?.result) === 1`;
-  // api/seed-health.js likewise). Reading it as JSON instead would make MCP
-  // disagree with them for any marker value that is not valid JSON, which is
-  // the same class of cross-surface divergence #6080 exists to close.
+  // surfaces read it that way through the shared `readExistsFlags` helper.
+  // Reading it as JSON instead would make MCP disagree with them for any marker
+  // value that is not valid JSON, which is the same class of cross-surface
+  // divergence #6080 exists to close.
   // redisPipeline never rejects — it returns null on any failure — so this
   // cannot turn a freshness hint into a hard tool-execution failure.
   const activationRead = activationKeys.length > 0
@@ -72,26 +78,18 @@ export async function executeTool(
   // earns the deployment-order grace. An unreadable marker stays out of the
   // map, so evaluateFreshness evaluates the block and fails closed rather than
   // granting a grace that would never expire.
-  const activationStates = new Map<string, boolean>();
-  if (activationKeys.length > 0) {
-    if (!Array.isArray(activationResults)) {
-      captureSilentError(new Error('mcp activation marker read failed'), {
-        tags: { route: 'api/mcp', step: 'activation-marker', tool: tool.name },
-      });
-    } else {
-      activationKeys.forEach((key, i) => {
-        // api/_upstash-json.d.ts declares only `result`, but Upstash reports
-        // per-command failures as `error` inside an otherwise-successful 200 —
-        // every JS consumer branches on it (api/health.js, the activationStates
-        // loop; api/seed-health.js, getSeedBatch). Cast locally
-        // rather than widening the shared declaration, which PipelineFn and
-        // api/mcp/quota.ts also depend on.
-        const entry = activationResults[i] as { result?: unknown; error?: unknown } | undefined;
-        if (entry && !entry.error) activationStates.set(key, Number(entry.result) === 1);
-      });
-    }
+  const activationStates = readExistsFlags(activationResults, activationKeys);
+  if (activationKeys.length > 0 && activationStates.size !== activationKeys.length) {
+    captureSilentError(new Error('mcp activation marker read failed'), {
+      tags: { route: 'api/mcp', step: 'activation-marker', tool: tool.name },
+    });
   }
-  const { cached_at, stale } = evaluateFreshness(freshnessChecks, metas, Date.now(), activationStates);
+  const { cached_at, stale, contentFreshnessPendingUntil } = evaluateFreshness(
+    freshnessChecks,
+    metas,
+    now,
+    activationStates,
+  );
 
   // F6: if every cache key returned null/undefined AND the tool actually
   // had keys configured, this is a degenerate-empty result (Redis transient
@@ -157,7 +155,12 @@ export async function executeTool(
   // summarises.
   if (argBool(params.summary)) result = tool._summarize ? tool._summarize(result) : summarizeData(result);
 
-  return { cached_at, stale, data: result };
+  return {
+    cached_at,
+    stale,
+    ...(contentFreshnessPendingUntil === undefined ? {} : { contentFreshnessPendingUntil }),
+    data: result,
+  };
 }
 
 export async function dispatchToolsCall(

--- a/api/mcp/filters.ts
+++ b/api/mcp/filters.ts
@@ -280,11 +280,12 @@ export function summarizeData(data: Record<string, unknown>): Record<string, unk
 //     single captured fixture (an inferred schema would freeze every observed
 //     enum value + required flag forever and reject valid future responses).
 //   - Only the envelope (`cached_at`, `stale`, `data`) is `required`. The
-//     activation-grace deadline is optional because most tools have no
-//     content-freshness rollout contract.
 //     per-label `data` properties are intentionally NOT required because any
 //     single cache key may be transiently null without tripping the
 //     `cache_all_null` guard (which fires only when ALL keys are null).
+//     `contentFreshnessPendingUntil` is likewise optional: it is advertised on
+//     every cache envelope but only a tool whose freshness check declares a
+//     `contentFreshnessActivationKey` can ever populate it.
 //   - `additionalProperties` is left implicit (true) so forward-compat fields
 //     added to a payload by a producer don't suddenly fail validation.
 //   - Per-array `items.properties` lists known top-level fields with types but

--- a/api/mcp/filters.ts
+++ b/api/mcp/filters.ts
@@ -267,7 +267,7 @@ export function summarizeData(data: Record<string, unknown>): Record<string, unk
 // ---------------------------------------------------------------------------
 // Every cache tool returns a uniform envelope from `executeTool`:
 //
-//   { cached_at: string|null, stale: boolean, data: { [label]: ... } }
+//   { cached_at: string|null, stale: boolean, contentFreshnessPendingUntil?: string, data: { [label]: ... } }
 //
 // where each `label` is derived from one of the tool's `_cacheKeys` via the
 // NON_LABEL regex in executeTool. `cacheEnvelope(dataProps)` returns the spec
@@ -280,6 +280,8 @@ export function summarizeData(data: Record<string, unknown>): Record<string, unk
 //     single captured fixture (an inferred schema would freeze every observed
 //     enum value + required flag forever and reject valid future responses).
 //   - Only the envelope (`cached_at`, `stale`, `data`) is `required`. The
+//     activation-grace deadline is optional because most tools have no
+//     content-freshness rollout contract.
 //     per-label `data` properties are intentionally NOT required because any
 //     single cache key may be transiently null without tripping the
 //     `cache_all_null` guard (which fires only when ALL keys are null).
@@ -300,6 +302,11 @@ export function cacheEnvelope(dataProperties: Record<string, object>): object {
       stale: {
         type: 'boolean',
         description: 'True when any contributing cache key is older than its per-key maxStaleMin freshness budget.',
+      },
+      contentFreshnessPendingUntil: {
+        type: 'string',
+        format: 'date-time',
+        description: 'Optional ISO-8601 deadline while a cleanly absent content-freshness block is temporarily covered by deployment-order grace.',
       },
       data: { type: 'object', properties: dataProperties },
     },

--- a/api/mcp/freshness.ts
+++ b/api/mcp/freshness.ts
@@ -1,6 +1,6 @@
 import type { FreshnessCheck } from './types';
 // @ts-expect-error — JS module, no declaration file
-import { buildContentFreshnessAssessment } from '../_content-freshness.js';
+import { buildContentFreshnessAssessment, getActiveContentFreshnessActivationWindow } from '../_content-freshness.js';
 
 function parseFiniteRecordCount(raw: unknown): number | null {
   if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null;
@@ -24,8 +24,13 @@ export function evaluateFreshness(
   metas: unknown[],
   now = Date.now(),
   activationStates?: ReadonlyMap<string, boolean>,
-): { cached_at: string | null; stale: boolean } {
+): {
+  cached_at: string | null;
+  stale: boolean;
+  contentFreshnessPendingUntil?: string;
+} {
   let stale = false;
+  let contentFreshnessPendingUntil: string | undefined;
   let oldestFetchedAt = Number.POSITIVE_INFINITY;
   let hasAnyValidMeta = false;
   let hasAllValidMeta = true;
@@ -66,12 +71,20 @@ export function evaluateFreshness(
       // Grace requires positive proof the producer has never published: the
       // marker was read AND came back absent. Anything else — unread, errored,
       // or present — evaluates the block normally.
-      const pendingActivation = Boolean(
-        assessment
-        && !assessment.fieldPresent
-        && check.contentFreshnessActivationKey
-        && activationStates?.get(check.contentFreshnessActivationKey) === false,
-      );
+      const pendingWindow = assessment && !assessment.fieldPresent && check.contentFreshnessActivationKey
+        ? getActiveContentFreshnessActivationWindow(
+          check.contentFreshnessActivationKey,
+          activationStates?.get(check.contentFreshnessActivationKey),
+          now,
+        )
+        : null;
+      const pendingActivation = pendingWindow !== null;
+      if (pendingWindow !== null) {
+        const deadline = new Date(pendingWindow.untilMs).toISOString();
+        if (contentFreshnessPendingUntil === undefined || deadline < contentFreshnessPendingUntil) {
+          contentFreshnessPendingUntil = deadline;
+        }
+      }
       if (!pendingActivation) {
         stale ||= !assessment?.usable || assessment.contentStale;
       }
@@ -81,5 +94,6 @@ export function evaluateFreshness(
   return {
     cached_at: hasAnyValidMeta && hasAllValidMeta ? new Date(oldestFetchedAt).toISOString() : null,
     stale,
+    ...(contentFreshnessPendingUntil === undefined ? {} : { contentFreshnessPendingUntil }),
   };
 }

--- a/api/mcp/quota.ts
+++ b/api/mcp/quota.ts
@@ -84,7 +84,7 @@ export async function reserveQuota(
   const key = dailyCounterKey(userId);
   if (!key) return { ok: false, reason: 'redis-unavailable' };
 
-  let pipeResult: Array<{ result: unknown }> | null;
+  let pipeResult: Array<{ result?: unknown; error?: unknown }> | null;
   try {
     pipeResult = await pipeline([
       ['INCR', key],

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -9,6 +9,8 @@ import { getSourceProvenanceState } from '../../../shared/source-provenance';
 import { CII_RISK_SCORE_CACHE_KEYS } from '../../_cii-risk-cache-keys.js';
 // @ts-expect-error — generated Edge-safe JS mirror; authored types live in shared/bootstrap-tier-keys.d.ts
 import { BOOTSTRAP_CACHE_KEYS } from '../../_bootstrap-tier-keys.js';
+// @ts-expect-error — Edge-safe JS policy shared with health and seed-health
+import { PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY } from '../../_content-freshness.js';
 import { DEFAULT_LIST_LIMIT, MARKET_FRESHNESS_CHECKS } from '../constants';
 import {
   argBool,
@@ -2103,7 +2105,7 @@ export const CACHE_TOOLS: ToolDef[] = [
         maxStaleMin: 2160, // 12h cron; 36h = 3× interval
         minRecordCount: 174,
         requireContentFreshness: { countries: ['CN', 'HK'], budgetMinutes: 2 * 72 * 60 },
-        contentFreshnessActivationKey: 'seed-activated:supply_chain:portwatch-ports:content-freshness',
+        contentFreshnessActivationKey: PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY,
       },
       { key: 'seed-meta:energy:chokepoint-baselines',      maxStaleMin: 60 * 24 * 400 },  // ~400d static registry
       { key: 'seed-meta:portwatch:chokepoints-ref',        maxStaleMin: 60 * 24 * 14 },   // weekly cron; 14d = 2× interval

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -269,7 +269,12 @@ export interface PublicToolShape {
 // ---------------------------------------------------------------------------
 // Daily-quota pipeline types
 // ---------------------------------------------------------------------------
-export type PipelineFn = (commands: Array<Array<string | number>>, timeoutMs?: number) => Promise<Array<{ result: unknown }> | null>;
+// Mirrors redisPipeline in api/_upstash-json.d.ts. `result` is OPTIONAL and
+// `error` exists because Upstash reports per-command failures inside an
+// otherwise-successful 200 — the shape readExistsFlags branches on. While this
+// omitted `error`, a consumer could not read that field without a local cast
+// (api/mcp/dispatch.ts carried one, with a comment saying so, until #6152).
+export type PipelineFn = (commands: Array<Array<string | number>>, timeoutMs?: number) => Promise<Array<{ result?: unknown; error?: unknown }> | null>;
 
 export interface QuotaReserved {
   ok: true;

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -10,10 +10,12 @@ import { unwrapEnvelope } from './_seed-envelope.js';
 import { projectChinaDecisionGroupDiagnostics } from './_china-decision-health.js';
 import {
   buildContentFreshnessAssessment,
+  getActiveContentFreshnessActivationWindow,
+  PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY,
   projectContentFreshnessForWire,
 } from './_content-freshness.js';
 // @ts-expect-error — JS module, no declaration file
-import { redisPipeline } from './_upstash-json.js';
+import { readExistsFlags, redisPipeline } from './_upstash-json.js';
 
 export const config = { runtime: 'edge' };
 
@@ -43,9 +45,6 @@ const CHINA_DECISION_SIGNAL_STATES = new Set([
 // source failure. Mirrors CHINA_DECISION_SIGNAL_COVERED_UNAVAILABLE_CAUSE in
 // scripts/seed-china-decision-signals.mjs.
 const CHINA_DECISION_HEALTHY_QUIET_CAUSE = 'healthy_quiet_window';
-const PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY =
-  'seed-activated:supply_chain:portwatch-ports:content-freshness';
-
 const SEED_DOMAINS = {
   'health:china-coverage':    { key: 'seed-meta:health:china-coverage',    intervalMin: 60, activationKey: 'seed-activated:health:china-coverage' },
   // Phase 1 — Snapshot endpoints
@@ -413,26 +412,22 @@ async function getSeedBatch(entries) {
     probeMap.set(slot.domain, data[slot.index]?.result ?? null);
   }
   // Both maps are THREE-valued (#6095, matching api/health.js and
-  // api/mcp/freshness.ts): an entry exists only when the EXISTS command itself
-  // succeeded. Upstash reports per-command failures as `error` inside an
-  // otherwise-successful 200, so a domain missing from these maps means "the
-  // read failed and the state is unknown" — distinguishable from a marker that
-  // was read and came back absent. Each consumer below decides which way
-  // unknown resolves, and they deliberately differ.
-  const activatedMap = new Map();
-  for (const slot of activationSlots) {
-    const entry = data[slot.index];
-    if (entry && !entry.error) activatedMap.set(slot.domain, Number(entry.result) === 1);
-  }
-  const contentFreshnessActivatedMap = new Map();
-  for (const slot of contentFreshnessActivationSlots) {
-    const entry = data[slot.index];
-    if (entry && !entry.error) contentFreshnessActivatedMap.set(slot.domain, Number(entry.result) === 1);
-  }
+  // api/mcp/freshness.ts): `readExistsFlags` adds a domain only when the
+  // EXISTS entry has an explicit result of 0 or 1. Per-command errors,
+  // `{}`, null results, and missing slots remain unknown, so a malformed
+  // pipeline body can never be interpreted as clean absence (#6115).
+  const activatedMap = readExistsFlags(
+    activationSlots.map((slot) => data[slot.index]),
+    activationSlots.map((slot) => slot.domain),
+  );
+  const contentFreshnessActivatedMap = readExistsFlags(
+    contentFreshnessActivationSlots.map((slot) => data[slot.index]),
+    contentFreshnessActivationSlots.map((slot) => slot.domain),
+  );
   return { metaMap, probeMap, activatedMap, contentFreshnessActivatedMap };
 }
 
-export default async function handler(req) {
+export async function handleSeedHealth(req, { now = Date.now() } = {}) {
   if (isDisallowedOrigin(req))
     return new Response('Forbidden', { status: 403 });
 
@@ -444,7 +439,6 @@ export default async function handler(req) {
   if (!apiKeyResult.valid || apiKeyResult.kind !== 'enterprise')
     return jsonResponse({ error: 'Operator API key required' }, 401, cors);
 
-  const now = Date.now();
   const entries = Object.entries(SEED_DOMAINS);
 
   let metaMap;
@@ -536,22 +530,19 @@ export default async function handler(req) {
     // absent. An unreadable marker is unknown state, not evidence of a producer
     // that never ran — the same rule api/health.js and api/mcp/freshness.ts
     // apply, so the three surfaces cannot answer differently for one input
-    // class. The opposite policy from the activation grace above, and for a
-    // reason: this one suppresses an alarm on a domain that HAS meta and IS
-    // running, and its strict verdict is 'coverage_degraded' — "cannot prove
-    // content freshness", which an unread marker makes literally true. A grace
-    // granted on the absence of evidence never expires, so an UNREADABLE marker
-    // would otherwise disable the alarm for good.
-    //
-    // Closes the unreadable arm ONLY: a marker that was evicted, renamed, or
-    // restored into an empty Redis returns a clean EXISTS=0 — the read-and-
-    // absent arm — and still grants the grace indefinitely. Tracked in #6111.
-    const contentFreshnessPending = Boolean(
-      contentFreshness
+    // class. The clean-absent arm is also bounded by the shared rollout window
+    // (#6111), so marker eviction or an empty Redis restore cannot excuse the
+    // missing block forever.
+    const contentFreshnessActivationWindow = contentFreshness
       && !contentFreshness.fieldPresent
       && cfg.contentFreshnessActivationKey
-      && contentFreshnessActivatedMap.get(domain) === false,
-    );
+      ? getActiveContentFreshnessActivationWindow(
+        cfg.contentFreshnessActivationKey,
+        contentFreshnessActivatedMap.get(domain),
+        now,
+      )
+      : null;
+    const contentFreshnessPending = contentFreshnessActivationWindow !== null;
     const contentFreshnessInvalid = Boolean(
       cfg.requireContentFreshness
       && contentFreshness
@@ -607,6 +598,11 @@ export default async function handler(req) {
     if (cfg.minPoolCounts) seeds[domain].minPoolCounts = cfg.minPoolCounts;
     if (activationUnknown) seeds[domain].activationUnknown = true;
     if (poolCounts) seeds[domain].poolCounts = poolCounts;
+    if (contentFreshnessActivationWindow) {
+      seeds[domain].contentFreshnessPendingUntil = new Date(
+        contentFreshnessActivationWindow.untilMs,
+      ).toISOString();
+    }
     if (contentFreshness && !contentFreshnessPending) {
       seeds[domain].contentFreshness = projectContentFreshnessForWire(contentFreshness);
     }
@@ -642,4 +638,8 @@ export default async function handler(req) {
     ...cors,
     'Cache-Control': 'no-cache',
   });
+}
+
+export default async function handler(req) {
+  return handleSeedHealth(req);
 }

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -427,7 +427,9 @@ async function getSeedBatch(entries) {
   return { metaMap, probeMap, activatedMap, contentFreshnessActivatedMap };
 }
 
-export async function handleSeedHealth(req, { now = Date.now() } = {}) {
+export async function handleSeedHealth(req, options = {}) {
+  const hasInjectedClock = Object.hasOwn(options, 'now');
+  const now = hasInjectedClock ? options.now : Date.now();
   if (isDisallowedOrigin(req))
     return new Response('Forbidden', { status: 403 });
 
@@ -450,6 +452,12 @@ export async function handleSeedHealth(req, { now = Date.now() } = {}) {
   } catch {
     return jsonResponse({ error: 'Redis unavailable' }, 503, cors);
   }
+
+  // Content-freshness activation deadlines are evaluated against the clock at
+  // which the Redis batch finished. A production request that crosses the
+  // deadline while awaiting Redis must not preserve its request-start grace;
+  // injected clocks stay fixed so unit tests remain deterministic.
+  const evaluationNow = hasInjectedClock ? now : Date.now();
 
   const seeds = {};
   let staleCount = 0;
@@ -492,7 +500,7 @@ export async function handleSeedHealth(req, { now = Date.now() } = {}) {
       continue;
     }
 
-    const ageMs = now - (meta.fetchedAt || 0);
+    const ageMs = evaluationNow - (meta.fetchedAt || 0);
     const recordCount = parseFiniteRecordCount(meta.recordCount);
     const poolCounts = parsePoolCounts(meta.poolCounts, cfg.minPoolCounts);
     const recordCoveragePartial = cfg.minRecordCount != null
@@ -524,7 +532,7 @@ export async function handleSeedHealth(req, { now = Date.now() } = {}) {
     const contentFreshness = buildContentFreshnessAssessment(
       meta,
       cfg.requireContentFreshness,
-      now,
+      evaluationNow,
     );
     // Grace requires POSITIVE proof (#6095): the marker was READ and came back
     // absent. An unreadable marker is unknown state, not evidence of a producer
@@ -539,7 +547,7 @@ export async function handleSeedHealth(req, { now = Date.now() } = {}) {
       ? getActiveContentFreshnessActivationWindow(
         cfg.contentFreshnessActivationKey,
         contentFreshnessActivatedMap.get(domain),
-        now,
+        evaluationNow,
       )
       : null;
     const contentFreshnessPending = contentFreshnessActivationWindow !== null;
@@ -634,7 +642,7 @@ export async function handleSeedHealth(req, { now = Date.now() } = {}) {
 
   const httpStatus = overall === 'healthy' ? 200 : overall === 'warning' ? 200 : 503;
 
-  return jsonResponse({ overall, seeds, checkedAt: now }, httpStatus, {
+  return jsonResponse({ overall, seeds, checkedAt: evaluationNow }, httpStatus, {
     ...cors,
     'Cache-Control': 'no-cache',
   });

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -245,29 +245,42 @@ never has to reconstruct the verdict from the raw counts; `expectedCriticalCount
 publishes the pinned scope alongside the declared one.
 
 Because the edge function redeploys within minutes of a merge while the producer
-is a 12-hour cron, the absent-block case has a bounded deployment-order grace.
+is a 12-hour cron, the absent-block case had a bounded deployment-order grace.
 The durable marker
-`seed-activated:supply_chain:portwatch-ports:content-freshness` may grant it
+`seed-activated:supply_chain:portwatch-ports:content-freshness` could grant it
 only inside the compiled window `2026-08-03T10:24:42Z` →
 `2026-08-04T06:00:00Z`: one complete producer interval plus six hours of
-scheduling slack after the schema shipped. The softening covers **absence only**
-— a block that is present is always evaluated, and once the marker exists a
-block that disappears fails closed. At or after the deadline, a clean
-`EXISTS=0` is no longer enough and the missing block is
-`COVERAGE_DEGRADED`.
+scheduling slack after the schema shipped.
 
-The grace needs **positive proof**, not merely the lack of a marker. The
-`EXISTS` read is three-valued: read-and-present revokes the softening,
-read-and-absent grants it while the window is open, and a read that *failed* or
-returned a malformed pipeline entry is unknown state and grants nothing. A
-pending health entry publishes `contentFreshnessPendingUntil`; compact health
-responses repeat the same per-key deadlines in
+**That window has closed, and the PortWatch grace is now permanently spent.**
+A clean `EXISTS=0` no longer softens anything: a missing PortWatch content block
+is `COVERAGE_DEGRADED`, unconditionally. The window is kept in source as the
+audit record of what was granted and until when — it is deliberately *not*
+reopened, because the producer has since published the block and re-granting the
+softening would undo exactly the bound
+[#6111](https://github.com/koala73/worldmonitor/issues/6111) asked for.
+
+In steady state, therefore, **`contentFreshnessPendingUntil` is not emitted at
+all.** It appears only while some key's window is open, which today means only
+if a NEW entry is added to `CONTENT_FRESHNESS_ROLLOUT` in
+`api/_content-freshness.js` for a newly deployed content schema. Add one there
+and the deadline is published automatically on every surface below; do not
+extend the PortWatch entry.
+
+While a window *is* open, the grace needs **positive proof**, not merely the
+lack of a marker. The `EXISTS` read is three-valued: read-and-present revokes
+the softening, read-and-absent grants it while the window is open, and a read
+that *failed* or returned a malformed pipeline entry is unknown state and grants
+nothing. A pending health entry publishes `contentFreshnessPendingUntil`;
+compact health responses repeat the same per-key deadlines in
 `summary.contentFreshnessPendingUntil`, so the bound is auditable without
 reading the implementation. `/api/seed-health` publishes the same deadline on
-its PortWatch entry, and MCP applies the same shared window to its `stale`
-boolean while exposing the optional top-level `contentFreshnessPendingUntil`
-field in cache-tool output. The cache refresh path also refuses to serve a warm
-snapshot past this deadline.
+its entry, and MCP applies the same shared window to its `stale` boolean while
+exposing the optional top-level `contentFreshnessPendingUntil` field in
+cache-tool output. The cache refresh path also refuses to serve a warm snapshot
+past this deadline. The softening covers **absence only** — a block that is
+present is always evaluated, and once the marker exists a block that disappears
+fails closed.
 
 The `cfg.activationKey` `pending-activation` path in `/api/seed-health` (and the
 matching `ON_DEMAND` policy in `/api/health`) intentionally remains separate and

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -245,22 +245,39 @@ never has to reconstruct the verdict from the raw counts; `expectedCriticalCount
 publishes the pinned scope alongside the declared one.
 
 Because the edge function redeploys within minutes of a merge while the producer
-is a 12-hour cron, the absent-block case is softened until the seeder has
-published the field at least once, tracked by the durable marker
-`seed-activated:supply_chain:portwatch-ports:content-freshness`. The softening
-covers **absence only** — a block that is present is always evaluated, and once
-the marker exists a block that disappears fails closed.
+is a 12-hour cron, the absent-block case has a bounded deployment-order grace.
+The durable marker
+`seed-activated:supply_chain:portwatch-ports:content-freshness` may grant it
+only inside the compiled window `2026-08-03T10:24:42Z` →
+`2026-08-04T06:00:00Z`: one complete producer interval plus six hours of
+scheduling slack after the schema shipped. The softening covers **absence only**
+— a block that is present is always evaluated, and once the marker exists a
+block that disappears fails closed. At or after the deadline, a clean
+`EXISTS=0` is no longer enough and the missing block is
+`COVERAGE_DEGRADED`.
 
-The grace also needs **positive proof**, not merely the lack of a marker. The
+The grace needs **positive proof**, not merely the lack of a marker. The
 `EXISTS` read is three-valued: read-and-present revokes the softening,
-read-and-absent grants it, and a read that *failed* is unknown state and grants
-nothing. A grace given on the absence of evidence would never expire, so an
-**unreadable** marker would otherwise disable this alarm permanently.
+read-and-absent grants it while the window is open, and a read that *failed* or
+returned a malformed pipeline entry is unknown state and grants nothing. A
+pending health entry publishes `contentFreshnessPendingUntil`; compact health
+responses repeat the same per-key deadlines in
+`summary.contentFreshnessPendingUntil`, so the bound is auditable without
+reading the implementation. `/api/seed-health` publishes the same deadline on
+its PortWatch entry, and MCP applies the same shared window to its `stale`
+boolean while exposing the optional top-level `contentFreshnessPendingUntil`
+field in cache-tool output. The cache refresh path also refuses to serve a warm
+snapshot past this deadline.
 
-That closes the unreadable case only. A marker that was **evicted, renamed, or
-restored into an empty Redis** returns a clean `EXISTS=0` — the read-and-absent
-case — and still grants the grace indefinitely. Bounding that needs a compiled
-deadline the way the consumer-price rollout has one, tracked in
+The `cfg.activationKey` `pending-activation` path in `/api/seed-health` (and the
+matching `ON_DEMAND` policy in `/api/health`) intentionally remains separate and
+does not reuse this PortWatch window. Those markers describe optional or
+operator-triggered producers for which “no metadata because the producer has
+never run” is the expected state, not a newly deployed data schema; there is no
+single producer cadence from which to derive a safe deadline. This path never
+softens a meta-bearing content-freshness failure. A scheduled content schema
+must use `contentFreshnessActivation` and its reviewed window instead. This
+closes the clean-absent activation gap in
 [#6111](https://github.com/koala73/worldmonitor/issues/6111).
 
 Any check whose verdict rested on an unreadable marker carries

--- a/docs/zh/health-endpoints.mdx
+++ b/docs/zh/health-endpoints.mdx
@@ -151,19 +151,29 @@ PortWatch 缓存条目，但规范国家列表和健康的 seed-meta
 `fresh_exceeds_covered`、`critical_observation_time_unusable` 等），使调用方无需从
 原始计数反推判定；`expectedCriticalCountries` 会与生产者声明的集合一并发布。
 
-由于边缘函数在合并后数分钟内即完成重新部署，而生产者是 12 小时 cron，因此在 seeder
-至少发布过一次该字段之前，"块缺失"的情形会被放宽，并由持久标记
-`seed-activated:supply_chain:portwatch-ports:content-freshness` 跟踪。该放宽**仅覆盖
-缺失**：只要块存在就一定会被评估；标记存在后，块消失将故障关闭。
+由于边缘函数在合并后数分钟内即完成重新部署，而生产者是 12 小时 cron，缺失块的情形
+只能获得有界的部署顺序放宽。持久标记
+`seed-activated:supply_chain:portwatch-ports:content-freshness` 只有在编译进代码的窗口
+`2026-08-03T10:24:42Z` → `2026-08-04T06:00:00Z` 内才能授予放宽：这代表 schema 发布后
+一个完整的生产者周期，外加六小时调度余量。该放宽**仅覆盖缺失**：只要块存在就一定会被
+评估；标记存在后，块消失将故障关闭。截止时间到达或之后，即使干净的 `EXISTS=0` 也不再
+足够，缺失块会报告为 `COVERAGE_DEGRADED`。
 
 该放宽还需要**肯定的证据**，而不仅仅是"没有标记"。`EXISTS` 读取是三值的：读到且存在
-会撤销放宽，读到且缺失才授予放宽，而读取**失败**属于未知状态，不授予任何放宽。基于
-"缺乏证据"授予的放宽永不过期，否则**无法读取**的标记就会永久停用该告警。
+会撤销放宽，读到且缺失只能在窗口内授予放宽，而读取**失败**或 pipeline 条目格式错误属于
+未知状态，不授予任何放宽。处于等待状态的健康条目会发布
+`contentFreshnessPendingUntil`；紧凑健康响应会在
+`summary.contentFreshnessPendingUntil` 中按键重复同一截止时间，因此无需阅读实现即可审计
+这一界限。`/api/seed-health` 的 PortWatch 条目也会发布同一截止时间，MCP 的 `stale` 布尔值
+使用同一共享窗口，并在缓存工具输出中通过可选顶层字段
+`contentFreshnessPendingUntil` 暴露该截止时间；缓存刷新路径也不会在截止时间之后继续提供旧快照。
 
-这只关闭了"无法读取"这一情形。被**逐出、改名或还原进空 Redis** 的标记会返回一个干净的
-`EXISTS=0` —— 即"读到且缺失"这一情形 —— 因而仍会无限期地授予放宽。要限定这一点，需要
-像消费价格 rollout 那样编译进一个截止时间，跟踪于
-[#6111](https://github.com/koala73/worldmonitor/issues/6111)。
+`/api/seed-health` 中 `cfg.activationKey` 的 `pending-activation` 路径（以及
+`/api/health` 中对应的 `ON_DEMAND` 策略）有意保持独立，不复用这个 PortWatch 窗口。这些标记
+表示可选或由运维触发的生产者；对它们而言“生产者从未运行，因此没有元数据”是预期状态，不能
+从一个统一的生产者周期推导安全的截止时间。该路径不会放宽已经存在元数据的内容新鲜度故障。
+有计划的内容 schema 必须使用 `contentFreshnessActivation` 及其经过审查的窗口。以上关闭了
+[#6111](https://github.com/koala73/worldmonitor/issues/6111) 所指出的干净缺失激活漏洞。
 
 任何判定依据来自"无法读取的标记"的检查项都会携带 `activationUnknown: true`，两个端点、
 所有状态下皆然。否则无论是标记读取失败还是生产者确实从未发布过，载荷完全相同 —— 而这

--- a/docs/zh/health-endpoints.mdx
+++ b/docs/zh/health-endpoints.mdx
@@ -152,21 +152,31 @@ PortWatch 缓存条目，但规范国家列表和健康的 seed-meta
 原始计数反推判定；`expectedCriticalCountries` 会与生产者声明的集合一并发布。
 
 由于边缘函数在合并后数分钟内即完成重新部署，而生产者是 12 小时 cron，缺失块的情形
-只能获得有界的部署顺序放宽。持久标记
+曾获得有界的部署顺序放宽。持久标记
 `seed-activated:supply_chain:portwatch-ports:content-freshness` 只有在编译进代码的窗口
 `2026-08-03T10:24:42Z` → `2026-08-04T06:00:00Z` 内才能授予放宽：这代表 schema 发布后
-一个完整的生产者周期，外加六小时调度余量。该放宽**仅覆盖缺失**：只要块存在就一定会被
-评估；标记存在后，块消失将故障关闭。截止时间到达或之后，即使干净的 `EXISTS=0` 也不再
-足够，缺失块会报告为 `COVERAGE_DEGRADED`。
+一个完整的生产者周期，外加六小时调度余量。
 
-该放宽还需要**肯定的证据**，而不仅仅是"没有标记"。`EXISTS` 读取是三值的：读到且存在
-会撤销放宽，读到且缺失只能在窗口内授予放宽，而读取**失败**或 pipeline 条目格式错误属于
-未知状态，不授予任何放宽。处于等待状态的健康条目会发布
+**该窗口已经关闭，PortWatch 的放宽已被永久用尽。** 干净的 `EXISTS=0` 不再放宽任何内容：
+缺失的 PortWatch 内容块一律报告为 `COVERAGE_DEGRADED`。该窗口保留在源码中，仅作为
+"授予了什么、到何时为止"的审计记录，并且刻意**不**重新开启：生产者此后已经发布了该块，
+重新授予放宽只会撤销
+[#6111](https://github.com/koala73/worldmonitor/issues/6111) 所要求的那道界限。
+
+因此在稳定状态下，**`contentFreshnessPendingUntil` 根本不会被发布。** 它只在某个键的窗口
+处于开启状态时出现；就今天而言，这意味着只有在 `api/_content-freshness.js` 的
+`CONTENT_FRESHNESS_ROLLOUT` 中为新部署的内容 schema 增加**新条目**时才会出现。新增条目后，
+下述各个接口都会自动发布该截止时间；不要去延长 PortWatch 那一条。
+
+当某个窗口确实开启时，该放宽仍需要**肯定的证据**，而不仅仅是"没有标记"。`EXISTS` 读取是
+三值的：读到且存在会撤销放宽，读到且缺失只能在窗口内授予放宽，而读取**失败**或 pipeline
+条目格式错误属于未知状态，不授予任何放宽。处于等待状态的健康条目会发布
 `contentFreshnessPendingUntil`；紧凑健康响应会在
 `summary.contentFreshnessPendingUntil` 中按键重复同一截止时间，因此无需阅读实现即可审计
-这一界限。`/api/seed-health` 的 PortWatch 条目也会发布同一截止时间，MCP 的 `stale` 布尔值
+这一界限。`/api/seed-health` 的对应条目也会发布同一截止时间，MCP 的 `stale` 布尔值
 使用同一共享窗口，并在缓存工具输出中通过可选顶层字段
 `contentFreshnessPendingUntil` 暴露该截止时间；缓存刷新路径也不会在截止时间之后继续提供旧快照。
+该放宽**仅覆盖缺失**：只要块存在就一定会被评估；标记存在后，块消失将故障关闭。
 
 `/api/seed-health` 中 `cfg.activationKey` 的 `pending-activation` 路径（以及
 `/api/health` 中对应的 `ON_DEMAND` 策略）有意保持独立，不复用这个 PortWatch 窗口。这些标记

--- a/tests/activation-marker-unknown-state.test.mjs
+++ b/tests/activation-marker-unknown-state.test.mjs
@@ -541,3 +541,63 @@ describe('#6095 — every activation marker is claimed by exactly one policy', (
     );
   });
 });
+
+// The read-side guard (hasExpiredActivationGrace) refuses an expired softening,
+// but refusing still costs a full ~390-command sweep per concurrent waiter,
+// because the refresh wait budget is shorter than a sweep. The write side must
+// therefore stop the snapshot from outliving the deadline in the first place,
+// so the deadline lands as an ordinary cache MISS that the refresh lock
+// serialises to one sweep.
+describe('#6152 review — the verdict cache cannot outlive the deadline it publishes', () => {
+  const DEADLINE = CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS[PORTWATCH_MARKER];
+
+  async function snapshotWritesAt(now) {
+    installHealthPipelineMock({ [PORTWATCH_MARKER]: ABSENT }, { now });
+    const inner = globalThis.fetch;
+    const sets = [];
+    globalThis.fetch = async (url, init) => {
+      for (const command of JSON.parse(init.body)) {
+        // Snapshot writes only — the refresh lock is also a `health:verdict:*`
+        // SET and carries its own unrelated TTL.
+        const key = String(command[1]);
+        if (command[0] === 'SET' && key.startsWith('health:verdict') && !key.includes('refresh-lock')) {
+          sets.push(command);
+        }
+      }
+      return inner(url, init);
+    };
+    const res = await handleHealth(new Request('https://api.worldmonitor.app/api/health', {
+      headers: { 'x-worldmonitor-key': 'test-health-admin-key' },
+    }), undefined, { now });
+    const body = await res.json();
+    return { sets, body };
+  }
+
+  it('shortens the TTL to the remaining grace, on both snapshot keys', async () => {
+    const now = DEADLINE - 30_000;
+    const { sets, body } = await snapshotWritesAt(now);
+
+    assert.equal(
+      body.summary?.contentFreshnessPendingUntil?.portwatchPortActivity,
+      new Date(DEADLINE).toISOString(),
+      'precondition: this sweep really did publish a deadline',
+    );
+    assert.equal(sets.length, 2, 'one sweep writes the full and compact snapshots together');
+    for (const command of sets) {
+      assert.deepEqual(
+        command.slice(3),
+        ['EX', '30'],
+        'a snapshot promising 30s of grace must not be cacheable for the full 60s',
+      );
+    }
+  });
+
+  it('keeps the full TTL once no deadline is published', async () => {
+    // Past the window the grace is gone, so the sweep publishes no deadline and
+    // there is nothing for the TTL to be clamped to.
+    const { sets, body } = await snapshotWritesAt(DEADLINE + 60_000);
+    assert.equal(body.summary?.contentFreshnessPendingUntil, undefined);
+    assert.equal(sets.length, 2);
+    for (const command of sets) assert.deepEqual(command.slice(3), ['EX', '60']);
+  });
+});

--- a/tests/activation-marker-unknown-state.test.mjs
+++ b/tests/activation-marker-unknown-state.test.mjs
@@ -10,11 +10,12 @@
 // one bucket, so a per-command Redis error on the marker key re-entered a grace
 // that had already been earned away.
 //
-// That is the green-while-dead shape the alarm family exists to prevent: grace
-// granted on the absence of evidence never expires. These tests drive an
-// ERRORED `EXISTS` entry (not merely a missing marker) through the real
-// handlers, because the bug lived in the pipeline-result loop that builds the
-// activation map, not in the classifier it feeds.
+// That is the green-while-dead shape the alarm family exists to prevent: an
+// unreadable marker earns no grace, and a cleanly absent marker is bounded by
+// the compiled rollout window. These tests drive an ERRORED `EXISTS` entry (not
+// merely a missing marker) through the real handlers, because the bug lived in
+// the pipeline-result loop that builds the activation map, not in the classifier
+// it feeds.
 //
 // Run: node --test tests/activation-marker-unknown-state.test.mjs
 
@@ -25,8 +26,9 @@ process.env.UPSTASH_REDIS_REST_URL = 'https://mock-upstash.test';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'mock-token';
 process.env.WORLDMONITOR_VALID_KEYS = 'test-health-admin-key';
 
-const { default: healthHandler, __testing__ } = await import('../api/health.js');
-const { default: seedHealthHandler } = await import('../api/seed-health.js');
+const { handleHealth, __testing__ } = await import('../api/health.js');
+const { handleSeedHealth } = await import('../api/seed-health.js');
+const { redisPipeline } = await import('../api/_upstash-json.js');
 
 const {
   ACTIVATION_MARKERS,
@@ -34,11 +36,16 @@ const {
   STANDALONE_KEYS,
   ON_DEMAND_KEYS,
   ROLLOUT_PENDING_UNTIL_MS,
+  CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS,
 } = __testing__;
 
 const PORTWATCH_META_KEY = SEED_META.portwatchPortActivity.key;
 const PORTWATCH_MARKER = ACTIVATION_MARKERS.portwatchContentFreshness;
 const PORTWATCH_DOMAIN = 'supply_chain:portwatch-ports';
+const TEST_NOW = Date.parse('2026-08-03T14:42:58.000Z');
+const PORTWATCH_PENDING_UNTIL = new Date(
+  CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS[PORTWATCH_MARKER],
+).toISOString();
 
 // The ON_DEMAND arm of the same shared marker read — see the last describe.
 const FEED_HEALTH_MARKER = ACTIVATION_MARKERS.newsFeedHealth;
@@ -53,6 +60,7 @@ afterEach(() => { globalThis.fetch = realFetch; });
 // only one that earns the grace.
 const PRESENT = () => ({ result: 1 });
 const ABSENT = () => ({ result: 0 });
+const EMPTY_ENTRY = () => ({});
 // Upstash reports per-command failures inside an otherwise-successful HTTP 200
 // pipeline response, so this is a live production shape, not a synthetic one.
 const ERRORED = () => ({ error: 'ERR max request size exceeded' });
@@ -61,8 +69,8 @@ const ERRORED = () => ({ error: 'ERR max request size exceeded' });
 // which it does not publish at all. Only the marker can decide whether that
 // absence is deploy lag or a producer regression — which is exactly what makes
 // it the probe for this bug.
-function blockLessPortwatchMeta() {
-  return JSON.stringify({ fetchedAt: Date.now(), recordCount: 174 });
+function blockLessPortwatchMeta(now = TEST_NOW) {
+  return JSON.stringify({ fetchedAt: now, recordCount: 174 });
 }
 
 // ── /api/health ─────────────────────────────────────────────────────────────
@@ -72,7 +80,12 @@ function blockLessPortwatchMeta() {
 // answers fresh so only the PortWatch content dimension can move the verdict.
 function installHealthPipelineMock(
   markerEntries,
-  { emptyDataKeys = [], truncateBeforeActivation = false } = {},
+  {
+    emptyDataKeys = [],
+    truncateBeforeActivation = false,
+    malformedPipelineBody,
+    now = TEST_NOW,
+  } = {},
 ) {
   const empty = new Set(emptyDataKeys);
   globalThis.fetch = async (_url, init) => {
@@ -87,10 +100,10 @@ function installHealthPipelineMock(
         // rather than as one assertion passing for the wrong reason.
         return markerEntries[key]?.() ?? { result: 0 };
       }
-      if (op === 'GET' && key === PORTWATCH_META_KEY) return { result: blockLessPortwatchMeta() };
+      if (op === 'GET' && key === PORTWATCH_META_KEY) return { result: blockLessPortwatchMeta(now) };
       // Snapshot keys included: a null GET is a cache miss, forcing the sweep.
       if (op === 'GET' && key.startsWith('health:verdict')) return { result: null };
-      if (op === 'GET') return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 10_000 }) };
+      if (op === 'GET') return { result: JSON.stringify({ fetchedAt: now, recordCount: 10_000 }) };
       return { result: 'OK' };
     });
     // A response ARRAY shorter than the command list. Upstash validates the
@@ -99,6 +112,9 @@ function installHealthPipelineMock(
     // stops short. The slots are then `undefined`: not an entry carrying an
     // error, but no entry at all.
     const firstActivation = commands.findIndex(([op]) => op === 'EXISTS');
+    if (malformedPipelineBody !== undefined && firstActivation !== -1) {
+      return new Response(JSON.stringify(malformedPipelineBody), { status: 200 });
+    }
     const body = truncateBeforeActivation && firstActivation !== -1
       ? results.slice(0, firstActivation)
       : results;
@@ -106,16 +122,21 @@ function installHealthPipelineMock(
   };
 }
 
-async function healthChecks(markerEntries, options) {
+async function healthResponseFor(markerEntries, options) {
   installHealthPipelineMock(markerEntries, options);
-  const res = await healthHandler(new Request('https://api.worldmonitor.app/api/health', {
+  const now = options?.now ?? TEST_NOW;
+  const res = await handleHealth(new Request('https://api.worldmonitor.app/api/health', {
     headers: { 'x-worldmonitor-key': 'test-health-admin-key' },
-  }));
-  return (await res.json()).checks ?? {};
+  }), undefined, { now });
+  return { res, body: await res.json() };
 }
 
-async function portwatchHealthCheck(markerEntry) {
-  const checks = await healthChecks({ [PORTWATCH_MARKER]: markerEntry });
+async function healthChecks(markerEntries, options) {
+  return (await healthResponseFor(markerEntries, options)).body.checks ?? {};
+}
+
+async function portwatchHealthCheck(markerEntry, options) {
+  const checks = await healthChecks({ [PORTWATCH_MARKER]: markerEntry }, options);
   return checks.portwatchPortActivity;
 }
 
@@ -123,6 +144,7 @@ describe('#6095 — /api/health treats an unreadable activation marker as unknow
   it('graces a block-less run only when the marker was read and came back absent', async () => {
     const entry = await portwatchHealthCheck(ABSENT);
     assert.equal(entry?.status, 'OK', 'read-absent is the deployment-order state the grace exists for');
+    assert.equal(entry?.contentFreshnessPendingUntil, PORTWATCH_PENDING_UNTIL);
   });
 
   it('fails closed once the marker proves the producer has published the block', async () => {
@@ -151,17 +173,65 @@ describe('#6095 — /api/health treats an unreadable activation marker as unknow
   // health must not be the one surface that trusts a slot it never received.
   it('does not treat a slot missing from a short pipeline response as read-absent', async () => {
     const checks = await healthChecks({}, { truncateBeforeActivation: true });
-    assert.equal(
+    assert.notEqual(
       checks.portwatchPortActivity?.status,
-      'COVERAGE_DEGRADED',
+      'OK',
       'a slot that never arrived is unknown state, not a marker read and found absent',
     );
   });
+
+  it('does not treat an empty pipeline entry as read-absent', async () => {
+    const entry = await portwatchHealthCheck(EMPTY_ENTRY);
+    assert.equal(
+      entry?.status,
+      'COVERAGE_DEGRADED',
+      'an entry without a result is unknown state, not a marker read and found absent',
+    );
+  });
+
+  for (const [label, malformedPipelineBody] of [
+    ['object', {}],
+    ['string', 'ok'],
+    ['null', null],
+    ['wrong-length array', []],
+  ]) {
+    it(`does not produce a marker verdict from a malformed ${label} pipeline body`, async () => {
+      const { res, body } = await healthResponseFor({}, { malformedPipelineBody });
+      assert.equal(res.status, 503, `${label} must fail the health request closed`);
+      assert.equal(body.status, 'REDIS_DOWN', `${label} must not produce a marker verdict`);
+    });
+  }
+});
+
+describe('#6115 — redisPipeline rejects malformed pipeline response envelopes', () => {
+  for (const [label, body] of [
+    ['object', {}],
+    ['string', 'ok'],
+    ['null', null],
+    ['wrong-length array', [{ result: 0 }]],
+  ]) {
+    it(`returns null for a ${label} response`, async () => {
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = async () => new Response(JSON.stringify(body), { status: 200 });
+      try {
+        assert.equal(
+          await redisPipeline([['EXISTS', 'marker-a'], ['EXISTS', 'marker-b']]),
+          null,
+          `${label} is not a trustworthy pipeline result envelope`,
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  }
 });
 
 // ── /api/seed-health ────────────────────────────────────────────────────────
 
-function installSeedHealthPipelineMock(markerEntries, { missingMetaKeys = [] } = {}) {
+function installSeedHealthPipelineMock(
+  markerEntries,
+  { missingMetaKeys = [], malformedPipelineBody, now = TEST_NOW } = {},
+) {
   const missing = new Set(missingMetaKeys);
   globalThis.fetch = async (_url, init) => {
     const commands = JSON.parse(init.body);
@@ -172,24 +242,30 @@ function installSeedHealthPipelineMock(markerEntries, { missingMetaKeys = [] } =
       }
       assert.equal(op, 'GET');
       if (missing.has(key)) return { result: null };
-      if (key === PORTWATCH_META_KEY) return { result: blockLessPortwatchMeta() };
+      if (key === PORTWATCH_META_KEY) return { result: blockLessPortwatchMeta(now) };
       // Keep every unrelated coverage-gated feed above its floor so only the
       // entry under test can move.
-      return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 10_000 }) };
+      return { result: JSON.stringify({ fetchedAt: now, recordCount: 10_000 }) };
     });
-    return new Response(JSON.stringify(results), {
+    const body = malformedPipelineBody === undefined ? results : malformedPipelineBody;
+    return new Response(JSON.stringify(body), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
   };
 }
 
-async function seedHealthEntries(markerEntries, options) {
+async function seedHealthResponseFor(markerEntries, options) {
   installSeedHealthPipelineMock(markerEntries, options);
-  const res = await seedHealthHandler(new Request('https://api.worldmonitor.app/api/seed-health', {
+  const now = options?.now ?? TEST_NOW;
+  const res = await handleSeedHealth(new Request('https://api.worldmonitor.app/api/seed-health', {
     headers: { 'X-WorldMonitor-Key': 'test-health-admin-key' },
-  }));
-  return (await res.json()).seeds ?? {};
+  }), { now });
+  return { res, body: await res.json() };
+}
+
+async function seedHealthEntries(markerEntries, options) {
+  return (await seedHealthResponseFor(markerEntries, options)).body.seeds ?? {};
 }
 
 async function portwatchSeedHealthEntry(markerEntry) {
@@ -203,6 +279,7 @@ describe('#6095 — /api/seed-health treats an unreadable activation marker as u
     assert.equal(entry?.status, 'ok');
     assert.equal(entry?.stale, false);
     assert.equal(entry?.contentFreshness, undefined, 'a graced block publishes no content verdict');
+    assert.equal(entry?.contentFreshnessPendingUntil, PORTWATCH_PENDING_UNTIL);
   });
 
   it('fails closed once the marker proves the producer has published the block', async () => {
@@ -231,6 +308,29 @@ describe('#6095 — /api/seed-health treats an unreadable activation marker as u
       assert.equal(entry?.activationUnknown, undefined);
     }
   });
+
+  it('does not treat an empty pipeline entry as read-absent', async () => {
+    const entry = await portwatchSeedHealthEntry(EMPTY_ENTRY);
+    assert.equal(
+      entry?.status,
+      'coverage_degraded',
+      'an entry without a result is unknown state, not a marker read and found absent',
+    );
+    assert.equal(entry?.activationUnknown, true);
+  });
+
+  for (const [label, malformedPipelineBody] of [
+    ['object', {}],
+    ['string', 'ok'],
+    ['null', null],
+    ['wrong-length array', []],
+  ]) {
+    it(`does not produce a marker verdict from a malformed ${label} pipeline body`, async () => {
+      const { res, body } = await seedHealthResponseFor({}, { malformedPipelineBody });
+      assert.equal(res.status, 503, `${label} must fail the seed-health request closed`);
+      assert.equal(body.error, 'Redis unavailable', `${label} must not produce a marker verdict`);
+    });
+  }
 });
 
 // ── The deliberate asymmetry ────────────────────────────────────────────────

--- a/tests/activation-marker-unknown-state.test.mjs
+++ b/tests/activation-marker-unknown-state.test.mjs
@@ -28,7 +28,7 @@ process.env.WORLDMONITOR_VALID_KEYS = 'test-health-admin-key';
 
 const { handleHealth, __testing__ } = await import('../api/health.js');
 const { handleSeedHealth } = await import('../api/seed-health.js');
-const { redisPipeline } = await import('../api/_upstash-json.js');
+const { readExistsFlags, redisPipeline } = await import('../api/_upstash-json.js');
 
 const {
   ACTIVATION_MARKERS,
@@ -147,6 +147,20 @@ describe('#6095 — /api/health treats an unreadable activation marker as unknow
     assert.equal(entry?.contentFreshnessPendingUntil, PORTWATCH_PENDING_UNTIL);
   });
 
+  // A graced check is OK, so it is filtered OUT of the compact `problems` map —
+  // `summary.contentFreshnessPendingUntil` is the ONLY thing carrying the
+  // deadline on the compact shape, and therefore the only thing that lets
+  // hasExpiredActivationGrace refuse an expired compact snapshot. Drive it
+  // through a real sweep; the other tests build that summary by hand.
+  it('publishes the graced deadline in the summary a live sweep produces', async () => {
+    const { body } = await healthResponseFor({ [PORTWATCH_MARKER]: ABSENT });
+    assert.equal(
+      body.summary?.contentFreshnessPendingUntil?.portwatchPortActivity,
+      PORTWATCH_PENDING_UNTIL,
+      'the sweep must accumulate per-check deadlines into the summary map',
+    );
+  });
+
   it('fails closed once the marker proves the producer has published the block', async () => {
     const entry = await portwatchHealthCheck(PRESENT);
     assert.equal(entry?.status, 'COVERAGE_DEGRADED', 'a block that disappears after activation is a regression');
@@ -165,19 +179,22 @@ describe('#6095 — /api/health treats an unreadable activation marker as unknow
   });
 
   // The same bug through a second door. "Unread" is not only an entry carrying
-  // an error — it is also a slot that never arrived. A guard written as
-  // `!r?.error` is TRUE for `r === undefined`, so a short response would record
-  // every missing activation slot as `false` ("read and confirmed absent") and
-  // hand back the very grace this issue exists to revoke. The sibling guards in
-  // api/seed-health.js and api/mcp/dispatch.ts both test the entry itself, and
-  // health must not be the one surface that trusts a slot it never received.
-  it('does not treat a slot missing from a short pipeline response as read-absent', async () => {
-    const checks = await healthChecks({}, { truncateBeforeActivation: true });
-    assert.notEqual(
-      checks.portwatchPortActivity?.status,
-      'OK',
-      'a slot that never arrived is unknown state, not a marker read and found absent',
-    );
+  // an error — it is also a slot that never arrived, and a guard written as
+  // `!r?.error` is TRUE for `r === undefined`.
+  //
+  // #6115 moved the defence one layer OUT: redisPipeline now rejects any body
+  // that is not an array of exactly commands.length entries, so a truncated
+  // response never reaches the classifier at all — the request fails closed as
+  // REDIS_DOWN instead. Assert THAT, not a status: a short response leaves no
+  // `checks` map, so the old `assert.notEqual(checks.x?.status, 'OK')` compared
+  // `undefined` and passed even with the length guard deleted. The classifier's
+  // own unknown-marker behaviour is covered by the ERRORED and EMPTY_ENTRY
+  // cases above, which do reach it.
+  it('fails a short pipeline response closed instead of classifying it', async () => {
+    const { res, body } = await healthResponseFor({}, { truncateBeforeActivation: true });
+    assert.equal(res.status, 503, 'a truncated pipeline body must not produce a verdict');
+    assert.equal(body.status, 'REDIS_DOWN');
+    assert.equal(body.checks, undefined, 'no check may be classified from a body we never fully received');
   });
 
   it('does not treat an empty pipeline entry as read-absent', async () => {
@@ -222,6 +239,61 @@ describe('#6115 — redisPipeline rejects malformed pipeline response envelopes'
       } finally {
         globalThis.fetch = originalFetch;
       }
+    });
+  }
+});
+
+// readExistsFlags is the ONE parser all three surfaces now share, so its
+// contract is asserted here directly rather than only through the handlers.
+// Every call site happens to hand it a length-matched array today, which means
+// the length clause is unreachable from them and would survive deletion — the
+// exact shape a handler-only test cannot pin.
+describe('#6115 — readExistsFlags is the shared three-valued marker parser', () => {
+  const KEYS = ['marker-a', 'marker-b'];
+
+  it('maps only an explicit 0 or 1 to a known state', () => {
+    const states = readExistsFlags([{ result: 1 }, { result: 0 }], KEYS);
+    assert.deepEqual([...states], [['marker-a', true], ['marker-b', false]]);
+  });
+
+  it('accepts the string forms Upstash may serialise', () => {
+    const states = readExistsFlags([{ result: '1' }, { result: '0' }], KEYS);
+    assert.deepEqual([...states], [['marker-a', true], ['marker-b', false]]);
+  });
+
+  // The old parser was `Number(r.result) === 1`, which coerced. Each of these
+  // became a CONFIDENT verdict under it — `{result: null}` read as "absent"
+  // (granting grace) and `{result: true}` read as "present". All must now be
+  // absent from the map, i.e. unknown.
+  for (const [label, entry] of [
+    ['a truthy non-1 result', { result: true }],
+    ['a null result', { result: null }],
+    ['an out-of-range number', { result: 2 }],
+    ['an out-of-range string', { result: '2' }],
+    ['an array result', { result: [] }],
+    ['an entry with no result at all', {}],
+    ['a per-command error', { error: 'ERR max request size exceeded' }],
+    ['a result alongside an error', { result: 0, error: 'ERR marker read' }],
+    ['a non-object entry', 'ok'],
+    ['a null entry', null],
+  ]) {
+    it(`leaves ${label} unknown`, () => {
+      const states = readExistsFlags([entry, { result: 1 }], KEYS);
+      assert.equal(states.has('marker-a'), false, `${label} must not become a verdict`);
+      assert.equal(states.get('marker-b'), true, 'the sibling slot still resolves');
+    });
+  }
+
+  // Fail-closed on the envelope itself: one short body must not let slot 0 be
+  // read as authoritative just because it happens to be well-formed.
+  for (const [label, results] of [
+    ['a short array', [{ result: 0 }]],
+    ['a long array', [{ result: 0 }, { result: 0 }, { result: 0 }]],
+    ['a non-array', { 0: { result: 0 }, 1: { result: 0 } }],
+    ['null', null],
+  ]) {
+    it(`returns an empty map for ${label}`, () => {
+      assert.equal(readExistsFlags(results, KEYS).size, 0);
     });
   }
 });

--- a/tests/activation-marker-unknown-state.test.mjs
+++ b/tests/activation-marker-unknown-state.test.mjs
@@ -54,7 +54,11 @@ const FEED_HEALTH_META_KEY = SEED_META.newsFeedHealth.key;
 const FEED_HEALTH_DOMAIN = 'news:feed-health';
 
 const realFetch = globalThis.fetch;
-afterEach(() => { globalThis.fetch = realFetch; });
+const realDateNow = Date.now;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  Date.now = realDateNow;
+});
 
 // The marker read outcomes the three surfaces must agree on. `absent` is the
 // only one that earns the grace.
@@ -85,6 +89,7 @@ function installHealthPipelineMock(
     truncateBeforeActivation = false,
     malformedPipelineBody,
     now = TEST_NOW,
+    onFetch,
   } = {},
 ) {
   const empty = new Set(emptyDataKeys);
@@ -118,6 +123,9 @@ function installHealthPipelineMock(
     const body = truncateBeforeActivation && firstActivation !== -1
       ? results.slice(0, firstActivation)
       : results;
+    if (typeof onFetch === 'function' && commands.some(([op]) => op === 'STRLEN' || op === 'LLEN')) {
+      onFetch();
+    }
     return new Response(JSON.stringify(body), { status: 200 });
   };
 }
@@ -125,9 +133,10 @@ function installHealthPipelineMock(
 async function healthResponseFor(markerEntries, options) {
   installHealthPipelineMock(markerEntries, options);
   const now = options?.now ?? TEST_NOW;
+  const handlerOptions = options?.useProductionClock ? undefined : { now };
   const res = await handleHealth(new Request('https://api.worldmonitor.app/api/health', {
     headers: { 'x-worldmonitor-key': 'test-health-admin-key' },
-  }), undefined, { now });
+  }), undefined, handlerOptions);
   return { res, body: await res.json() };
 }
 
@@ -159,6 +168,30 @@ describe('#6095 — /api/health treats an unreadable activation marker as unknow
       PORTWATCH_PENDING_UNTIL,
       'the sweep must accumulate per-check deadlines into the summary map',
     );
+  });
+
+  it('classifies against the wall clock after the live Redis sweep completes', async () => {
+    let clock = CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS[PORTWATCH_MARKER] - 1;
+    Date.now = () => clock;
+
+    const { body } = await healthResponseFor(
+      { [PORTWATCH_MARKER]: ABSENT },
+      {
+        useProductionClock: true,
+        onFetch: () => {
+          clock = CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS[PORTWATCH_MARKER] + 1;
+        },
+      },
+    );
+
+    assert.equal(
+      body.checks?.portwatchPortActivity?.status,
+      'COVERAGE_DEGRADED',
+      'a sweep that crosses the deadline must use the post-read strict verdict',
+    );
+    assert.equal(body.checks?.portwatchPortActivity?.contentFreshnessPendingUntil, undefined);
+    assert.equal(body.summary?.contentFreshnessPendingUntil, undefined);
+    assert.equal(body.checkedAt, new Date(clock).toISOString());
   });
 
   it('fails closed once the marker proves the producer has published the block', async () => {
@@ -302,7 +335,7 @@ describe('#6115 — readExistsFlags is the shared three-valued marker parser', (
 
 function installSeedHealthPipelineMock(
   markerEntries,
-  { missingMetaKeys = [], malformedPipelineBody, now = TEST_NOW } = {},
+  { missingMetaKeys = [], malformedPipelineBody, now = TEST_NOW, onFetch } = {},
 ) {
   const missing = new Set(missingMetaKeys);
   globalThis.fetch = async (_url, init) => {
@@ -320,6 +353,7 @@ function installSeedHealthPipelineMock(
       return { result: JSON.stringify({ fetchedAt: now, recordCount: 10_000 }) };
     });
     const body = malformedPipelineBody === undefined ? results : malformedPipelineBody;
+    if (typeof onFetch === 'function') onFetch();
     return new Response(JSON.stringify(body), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -330,9 +364,10 @@ function installSeedHealthPipelineMock(
 async function seedHealthResponseFor(markerEntries, options) {
   installSeedHealthPipelineMock(markerEntries, options);
   const now = options?.now ?? TEST_NOW;
+  const handlerOptions = options?.useProductionClock ? undefined : { now };
   const res = await handleSeedHealth(new Request('https://api.worldmonitor.app/api/seed-health', {
     headers: { 'X-WorldMonitor-Key': 'test-health-admin-key' },
-  }), { now });
+  }), handlerOptions);
   return { res, body: await res.json() };
 }
 
@@ -352,6 +387,31 @@ describe('#6095 — /api/seed-health treats an unreadable activation marker as u
     assert.equal(entry?.stale, false);
     assert.equal(entry?.contentFreshness, undefined, 'a graced block publishes no content verdict');
     assert.equal(entry?.contentFreshnessPendingUntil, PORTWATCH_PENDING_UNTIL);
+  });
+
+  it('classifies against the wall clock after the Redis batch completes', async () => {
+    let clock = CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS[PORTWATCH_MARKER] - 1;
+    Date.now = () => clock;
+
+    const { body } = await seedHealthResponseFor(
+      { [PORTWATCH_MARKER]: ABSENT },
+      {
+        useProductionClock: true,
+        onFetch: () => {
+          clock = CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS[PORTWATCH_MARKER] + 1;
+        },
+      },
+    );
+    const entry = body.seeds?.[PORTWATCH_DOMAIN];
+
+    assert.equal(
+      entry?.status,
+      'coverage_degraded',
+      'a batch that crosses the deadline must use the post-read strict verdict',
+    );
+    assert.equal(entry?.stale, true);
+    assert.equal(entry?.contentFreshnessPendingUntil, undefined);
+    assert.equal(body.checkedAt, clock);
   });
 
   it('fails closed once the marker proves the producer has published the block', async () => {

--- a/tests/china-decision-access-contract.test.mts
+++ b/tests/china-decision-access-contract.test.mts
@@ -12,6 +12,7 @@ import {
 const PATH = '/api/intelligence/v1/get-china-decision-signals';
 const CHINA_DATA_KEY = 'intelligence:china-decision-signals:v1';
 const CHINA_META_KEY = 'seed-meta:intelligence:china-decision-signals';
+const PORTWATCH_META_KEY = 'seed-meta:supply_chain:portwatch-ports';
 const PREDICTION_META_KEY = 'seed-meta:prediction:markets';
 const OPERATOR_KEY = 'china-decision-test-operator-key';
 const RESILIENCE_INTERVAL_PROBE_KEY = 'resilience:intervals:v9:US';
@@ -68,6 +69,27 @@ function installSeedHealthPipelineMock(chinaMeta: ChinaMeta) {
         };
       }
       if (key === CHINA_META_KEY) return { result: JSON.stringify(chinaMeta) };
+      if (key === PORTWATCH_META_KEY) {
+        return {
+          result: JSON.stringify({
+            fetchedAt: chinaMeta.fetchedAt,
+            recordCount: 174,
+            contentFreshness: {
+              coveredCount: 174,
+              freshCount: 174,
+              staleCount: 0,
+              unknownCount: 0,
+              staleCountries: [],
+              criticalCountries: ['CN', 'HK'],
+              criticalFreshCount: 2,
+              criticalStaleCountries: [],
+              criticalMissingCountries: 0,
+              criticalOldestObservedAt: chinaMeta.fetchedAt - 60_000,
+              criticalOldestObservedCountry: 'CN',
+            },
+          }),
+        };
+      }
       if (key === PREDICTION_META_KEY) {
         return {
           result: JSON.stringify({

--- a/tests/health-content-freshness.test.mjs
+++ b/tests/health-content-freshness.test.mjs
@@ -20,13 +20,17 @@ const {
   healthResponseBody,
   STATUS_COUNTS,
   SEED_META,
+  ACTIVATION_MARKERS,
+  CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS,
 } = __testing__;
 
-const NOW = Date.parse('2026-08-02T14:42:58.000Z');
+const NOW = Date.parse('2026-08-03T14:42:58.000Z');
 const MINUTE_MS = 60_000;
 const PORTWATCH_CONTENT_BUDGET_MINUTES = 2 * 72 * 60;
 const PORTWATCH_META_KEY = 'seed-meta:supply_chain:portwatch-ports';
 const PORTWATCH_DATA_KEY = 'supply_chain:portwatch-ports:v1:_countries';
+const PORTWATCH_ACTIVATION_KEY = ACTIVATION_MARKERS.portwatchContentFreshness;
+const CONTENT_FRESHNESS_ROLLOUT_UNTIL = CONTENT_FRESHNESS_ROLLOUT_UNTIL_MS[PORTWATCH_ACTIVATION_KEY];
 
 function contentFreshnessOf(overrides = {}) {
   return {
@@ -52,13 +56,13 @@ function contentFreshnessOf(overrides = {}) {
   };
 }
 
-function portwatchCtx(meta) {
+function portwatchCtx(meta, now = NOW) {
   return {
     keyStrens: new Map([[PORTWATCH_DATA_KEY, 4096]]),
     keyErrors: new Map(),
     keyMetaValues: new Map([[PORTWATCH_META_KEY, JSON.stringify(meta)]]),
     keyMetaErrors: new Map(),
-    now: NOW,
+    now,
   };
 }
 
@@ -67,13 +71,13 @@ function portwatchCtx(meta) {
 // `activated` is three-valued (#6095): true = marker read and present, false =
 // marker read and absent (the only state that earns grace), null = the marker
 // read failed, so its state is unknown and it is missing from the map entirely.
-function classifyPortwatch(meta, { activated = true } = {}) {
+function classifyPortwatch(meta, { activated = true, now = NOW } = {}) {
   return classifyKey(
     'portwatchPortActivity',
     PORTWATCH_DATA_KEY,
     {},
     {
-      ...portwatchCtx(meta),
+      ...portwatchCtx(meta, now),
       activationStates: activated === null
         ? new Map()
         : new Map([['portwatchContentFreshness', activated]]),
@@ -124,7 +128,10 @@ describe('readSeedMeta content-freshness parsing', () => {
     assert.equal(meta.contentFreshness.contentStale, true);
     assert.equal(meta.contentFreshness.staleCount, 1);
     assert.deepEqual(meta.contentFreshness.criticalStaleCountries, ['CN']);
-    assert.equal(meta.contentFreshness.criticalOldestAgeMinutes, 10_240);
+    assert.equal(
+      meta.contentFreshness.criticalOldestAgeMinutes,
+      Math.round((NOW - Date.parse('2026-07-26T12:02:43.475Z')) / MINUTE_MS),
+    );
   });
 
   it('does not alarm on fleet-wide rotation lag outside the decision-critical set', () => {
@@ -398,7 +405,10 @@ describe('portwatchPortActivity classification', () => {
       'CN',
       'operators get the stale source family, not a generic warning',
     );
-    assert.equal(entry.contentFreshness.criticalOldestAgeMinutes, 10_240);
+    assert.equal(
+      entry.contentFreshness.criticalOldestAgeMinutes,
+      Math.round((NOW - Date.parse('2026-07-26T12:02:43.475Z')) / MINUTE_MS),
+    );
   });
 
   it('alarms when a decision-critical country drops out of the run entirely', () => {
@@ -429,11 +439,10 @@ describe('portwatchPortActivity classification', () => {
     );
   });
 
-  // #6095 — the grace is earned by evidence, never by the absence of evidence.
-  // A marker health could not read says nothing about whether the producer ever
-  // published, and a grace granted on that never expires: an UNREADABLE marker
-  // would disable the content alarm permanently. (An evicted or renamed marker
-  // reads as a clean absence and still earns the grace — see #6111.)
+  // #6095/#6111 — the grace is earned by evidence, then bounded by the
+  // deployment window. A marker health could not read says nothing about
+  // whether the producer ever published; an evicted or renamed marker can only
+  // earn clean-absent grace until the compiled deadline.
   it('refuses grace when the marker state is unknown rather than read-absent', () => {
     const entry = classifyPortwatch(completeRun(undefined), { activated: null });
     assert.equal(
@@ -441,6 +450,25 @@ describe('portwatchPortActivity classification', () => {
       'COVERAGE_DEGRADED',
       'an unread marker must fail closed, not re-enter an expired grace',
     );
+  });
+
+  it('bounds clean-absent grace and publishes its deadline', () => {
+    const pending = classifyPortwatch(completeRun(undefined), {
+      activated: false,
+      now: NOW,
+    });
+    assert.equal(pending.status, 'OK');
+    assert.equal(
+      pending.contentFreshnessPendingUntil,
+      new Date(CONTENT_FRESHNESS_ROLLOUT_UNTIL).toISOString(),
+    );
+
+    const expired = classifyPortwatch(completeRun(undefined), {
+      activated: false,
+      now: CONTENT_FRESHNESS_ROLLOUT_UNTIL,
+    });
+    assert.equal(expired.status, 'COVERAGE_DEGRADED');
+    assert.ok(expired.contentFreshness, 'the expired block is evaluated and published for diagnosis');
   });
 
   it('still evaluates a block that is present before activation is observed', () => {

--- a/tests/health-verdict-compact-snapshot.test.mjs
+++ b/tests/health-verdict-compact-snapshot.test.mjs
@@ -32,7 +32,7 @@ function fullVerdict(checkCount = 228, problemCount = 5) {
 
 test('the two snapshot keys are distinct', () => {
   assert.notEqual(HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY, HEALTH_VERDICT_SNAPSHOT_KEY);
-  assert.match(HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY, /health:verdict:compact:v1$/);
+  assert.match(HEALTH_VERDICT_COMPACT_SNAPSHOT_KEY, /health:verdict:compact:v2$/);
 });
 
 // THE POINT OF THE CHANGE. ?compact=1 is the browser poll — every client, every 5

--- a/tests/health-verdict-snapshot.test.mjs
+++ b/tests/health-verdict-snapshot.test.mjs
@@ -14,6 +14,7 @@ const {
   HEALTH_VERDICT_SNAPSHOT_TTL_SECONDS,
   HEALTH_VERDICT_REFRESH_LOCK_KEY: HEALTH_REFRESH_LOCK_KEY,
   HEALTH_VERDICT_REFRESH_WAIT_MS,
+  snapshotTtlSeconds,
 } = __testing__;
 const realFetch = globalThis.fetch;
 const realSetTimeout = globalThis.setTimeout;
@@ -520,5 +521,77 @@ test('does not serve a full or compact snapshot after content-freshness grace ex
     assert.equal(response.status, 503);
     assert.equal(body.status, 'REDIS_DOWN');
     assert.ok(calls.some((commands) => commands.length > 1), 'expired cache must fall through to a fresh sweep');
+  }
+});
+
+// The verdict cache must never outlive a softening deadline it publishes.
+// Reading is already guarded (hasExpiredActivationGrace), but a guarded READ
+// still costs a full ~390-command sweep per concurrent waiter, because the
+// refresh wait budget is shorter than a sweep. Expiring the KEY at the deadline
+// converts that into an ordinary cache miss, which the refresh lock serialises.
+test('snapshot TTL is the full 60s when no deadline is published', () => {
+  const now = Date.parse('2026-08-03T12:00:00.000Z');
+  assert.equal(snapshotTtlSeconds(healthySnapshot(new Date(now).toISOString()), now), 60);
+  assert.equal(snapshotTtlSeconds({ summary: {}, checks: {} }, now), 60);
+  // A non-ROLLOUT_PENDING entry carrying a stray rolloutPendingUntil is not a
+  // published promise; only the pending status makes it one.
+  assert.equal(
+    snapshotTtlSeconds({ checks: { a: { status: 'OK', rolloutPendingUntil: new Date(now + 5_000).toISOString() } } }, now),
+    60,
+  );
+});
+
+test('snapshot TTL is clamped down to the nearest activation deadline', () => {
+  const now = Date.parse('2026-08-03T12:00:00.000Z');
+  const at = (ms) => new Date(now + ms).toISOString();
+
+  // Content deadline on a per-check entry.
+  assert.equal(snapshotTtlSeconds({ checks: { a: { status: 'OK', contentFreshnessPendingUntil: at(30_000) } } }, now), 30);
+  // Rollout deadline, which only counts on a ROLLOUT_PENDING entry.
+  assert.equal(snapshotTtlSeconds({ checks: { a: { status: 'ROLLOUT_PENDING', rolloutPendingUntil: at(10_000) } } }, now), 10);
+  // Compact shape: deadlines live under `summary`, because a graced check is OK
+  // and therefore absent from `problems` entirely.
+  assert.equal(snapshotTtlSeconds({ problems: {}, summary: { contentFreshnessPendingUntil: { a: at(25_000) } } }, now), 25);
+  // The EARLIEST wins across shapes and sources.
+  assert.equal(
+    snapshotTtlSeconds({
+      checks: { a: { status: 'ROLLOUT_PENDING', rolloutPendingUntil: at(40_000) }, b: { status: 'OK', contentFreshnessPendingUntil: at(15_000) } },
+      summary: { contentFreshnessPendingUntil: { b: at(15_000), c: at(50_000) } },
+    }, now),
+    15,
+  );
+  // Beyond the base TTL the base TTL still caps it.
+  assert.equal(snapshotTtlSeconds({ checks: { a: { status: 'OK', contentFreshnessPendingUntil: at(600_000) } } }, now), 60);
+});
+
+test('snapshot TTL floors rather than rounds, so the key dies before the deadline', () => {
+  const now = Date.parse('2026-08-03T12:00:00.000Z');
+  // 30.9s away must be 30, never 31 — a key that outlives its own deadline is
+  // the exact thing this is preventing.
+  assert.equal(
+    snapshotTtlSeconds({ checks: { a: { status: 'OK', contentFreshnessPendingUntil: new Date(now + 30_900).toISOString() } } }, now),
+    30,
+  );
+});
+
+test('a malformed or already-passed deadline collapses the TTL to its floor', () => {
+  const now = Date.parse('2026-08-03T12:00:00.000Z');
+  const cases = [
+    ['unparseable', 'not-a-date'],
+    ['non-string', 12345],
+    ['null', null],
+    ['already expired', new Date(now - 60_000).toISOString()],
+  ];
+  for (const [label, value] of cases) {
+    assert.equal(
+      snapshotTtlSeconds({ checks: { a: { status: 'OK', contentFreshnessPendingUntil: value } } }, now),
+      1,
+      `${label} must evict fast, not pin a snapshot every reader will refuse`,
+    );
+    assert.equal(
+      snapshotTtlSeconds({ summary: { contentFreshnessPendingUntil: { a: value } } }, now),
+      1,
+      `${label} must behave identically on the compact shape`,
+    );
   }
 });

--- a/tests/health-verdict-snapshot.test.mjs
+++ b/tests/health-verdict-snapshot.test.mjs
@@ -5,7 +5,7 @@ process.env.UPSTASH_REDIS_REST_URL = 'https://mock-upstash.test';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'mock-token';
 process.env.WORLDMONITOR_VALID_KEYS = 'test-health-admin-key';
 
-const { default: handler, __testing__ } = await import('../api/health.js');
+const { default: handler, handleHealth, __testing__ } = await import('../api/health.js');
 
 const {
   HEALTH_VERDICT_SNAPSHOT_KEY: HEALTH_SNAPSHOT_KEY,
@@ -35,7 +35,7 @@ function healthySnapshot(checkedAt = new Date().toISOString()) {
 }
 
 test('scopes health verdict Redis keys to non-production deployments', () => {
-  const baseKey = 'health:verdict:v1';
+  const baseKey = 'health:verdict:v2';
   const lockBaseKey = `${baseKey}:refresh-lock`;
 
   assert.equal(__testing__.healthVerdictRedisKey(baseKey, undefined, undefined), baseKey);
@@ -45,11 +45,11 @@ test('scopes health verdict Redis keys to non-production deployments', () => {
   );
   assert.equal(
     __testing__.healthVerdictRedisKey(baseKey, 'preview', '1234567890abcdef'),
-    'preview:12345678:health:verdict:v1',
+    'preview:12345678:health:verdict:v2',
   );
   assert.equal(
     __testing__.healthVerdictRedisKey(lockBaseKey, 'preview', undefined),
-    'preview:dev:health:verdict:v1:refresh-lock',
+    'preview:dev:health:verdict:v2:refresh-lock',
   );
 });
 
@@ -429,4 +429,96 @@ test('validates snapshot age after the Redis read completes', async () => {
   assert.equal(response.status, 200);
   assert.equal(sweepCount, 1, 'a snapshot that expires in flight must be recomputed');
   assert.notEqual(body.checkedAt, almostExpired.checkedAt);
+});
+
+test('serves the auditable content-freshness deadline from full and compact snapshots', async () => {
+  const now = Date.parse('2026-08-03T14:42:58.000Z');
+  const checkedAt = new Date(now - 30_000).toISOString();
+  const pendingUntil = '2026-08-04T06:00:00.000Z';
+  const snapshot = {
+    status: 'HEALTHY',
+    summary: {
+      total: 1,
+      ok: 1,
+      warn: 0,
+      onDemandWarn: 0,
+      staleContent: 0,
+      crit: 0,
+      contentFreshnessPendingUntil: { portwatchPortActivity: pendingUntil },
+    },
+    checkedAt,
+    checks: {
+      portwatchPortActivity: { status: 'OK', records: 174, contentFreshnessPendingUntil: pendingUntil },
+    },
+  };
+
+  for (const [query, key, headers] of [
+    ['?compact=1', HEALTH_COMPACT_SNAPSHOT_KEY, {}],
+    ['', HEALTH_SNAPSHOT_KEY, { 'x-worldmonitor-key': 'test-health-admin-key' }],
+  ]) {
+    globalThis.fetch = async (_url, init) => {
+      assert.deepEqual(JSON.parse(init.body), [['GET', key]]);
+      return new Response(JSON.stringify([{ result: JSON.stringify(
+        query === '?compact=1' ? buildCompactVerdictSnapshot(snapshot) : snapshot,
+      ) }]), { status: 200 });
+    };
+
+    const response = await handleHealth(new Request(`https://api.worldmonitor.app/api/health${query}`, { headers }), undefined, { now });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      body.summary.contentFreshnessPendingUntil.portwatchPortActivity,
+      pendingUntil,
+    );
+    if (query === '?compact=1') assert.equal(body.checks, undefined);
+    else assert.equal(body.checks.portwatchPortActivity.contentFreshnessPendingUntil, pendingUntil);
+  }
+});
+
+test('does not serve a full or compact snapshot after content-freshness grace expires', async () => {
+  const now = Date.parse('2026-08-04T06:00:00.000Z');
+  const pendingUntil = new Date(now).toISOString();
+  const snapshot = {
+    status: 'HEALTHY',
+    summary: {
+      total: 1,
+      ok: 1,
+      warn: 0,
+      onDemandWarn: 0,
+      staleContent: 0,
+      crit: 0,
+      contentFreshnessPendingUntil: { portwatchPortActivity: pendingUntil },
+    },
+    checkedAt: new Date(now - 30_000).toISOString(),
+    checks: {
+      portwatchPortActivity: { status: 'OK', contentFreshnessPendingUntil: pendingUntil },
+    },
+  };
+
+  for (const [query, key, headers] of [
+    ['?compact=1', HEALTH_COMPACT_SNAPSHOT_KEY, {}],
+    ['', HEALTH_SNAPSHOT_KEY, { 'x-worldmonitor-key': 'test-health-admin-key' }],
+  ]) {
+    const calls = [];
+    globalThis.fetch = async (_url, init) => {
+      const commands = JSON.parse(init.body);
+      calls.push(commands);
+      if (commands.length === 1 && commands[0][0] === 'GET' && commands[0][1] === key) {
+        const value = query === '?compact=1' ? buildCompactVerdictSnapshot(snapshot) : snapshot;
+        return new Response(JSON.stringify([{ result: JSON.stringify(value) }]), { status: 200 });
+      }
+      if (commands.length === 1 && commands[0][0] === 'SET') {
+        return new Response(JSON.stringify([{ result: 'OK' }]), { status: 200 });
+      }
+      throw new Error('stop after proving the expired snapshot was not served');
+    };
+
+    const response = await handleHealth(new Request(`https://api.worldmonitor.app/api/health${query}`, { headers }), undefined, { now });
+    const body = await response.json();
+
+    assert.equal(response.status, 503);
+    assert.equal(body.status, 'REDIS_DOWN');
+    assert.ok(calls.some((commands) => commands.length > 1), 'expired cache must fall through to a fresh sweep');
+  }
 });

--- a/tests/mcp-portwatch-content-freshness-parity.test.mjs
+++ b/tests/mcp-portwatch-content-freshness-parity.test.mjs
@@ -15,6 +15,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
+import {
+  CONTENT_FRESHNESS_ROLLOUT,
+  PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY,
+} from '../api/_content-freshness.js';
 import { __testing__ } from '../api/health.js';
 import { evaluateFreshness } from '../api/mcp/freshness.ts';
 import { executeTool } from '../api/mcp/dispatch.ts';
@@ -29,16 +33,24 @@ const SEED_HEALTH_OPERATOR_KEY = 'test-parity-operator-key';
 process.env.UPSTASH_REDIS_REST_URL ??= 'https://redis.test';
 process.env.UPSTASH_REDIS_REST_TOKEN ??= 'token';
 process.env.WORLDMONITOR_VALID_KEYS = SEED_HEALTH_OPERATOR_KEY;
-const { default: seedHealthHandler } = await import('../api/seed-health.js');
+const { handleSeedHealth } = await import('../api/seed-health.js');
 
 const { classifyKey, SEED_META, ACTIVATION_MARKERS } = __testing__;
 
-const NOW = Date.parse('2026-08-02T14:42:58.000Z');
+// #6111: the bounded content-freshness rollout window is one 12h producer
+// interval plus slack after the feature landed in PR #6073. Keep the fixture
+// inside the window so the positive pre-activation case remains testable after
+// the deadline has passed in production.
+const CONTENT_FRESHNESS_ROLLOUT_WINDOW =
+  CONTENT_FRESHNESS_ROLLOUT[PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY];
+const CONTENT_FRESHNESS_ROLLOUT_FROM = Date.parse(CONTENT_FRESHNESS_ROLLOUT_WINDOW.from);
+const CONTENT_FRESHNESS_ROLLOUT_UNTIL = Date.parse(CONTENT_FRESHNESS_ROLLOUT_WINDOW.until);
+const NOW = Date.parse('2026-08-03T14:42:58.000Z');
 const MINUTE_MS = 60_000;
 const PORTWATCH_META_KEY = 'seed-meta:supply_chain:portwatch-ports';
 const PORTWATCH_DATA_KEY = 'supply_chain:portwatch-ports:v1:_countries';
 const PORTWATCH_SEED_DOMAIN = 'supply_chain:portwatch-ports';
-const ACTIVATION_KEY = 'seed-activated:supply_chain:portwatch-ports:content-freshness';
+const ACTIVATION_KEY = PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY;
 
 // Synthetic regression shape from the #6060 audit: CN last observed more than
 // 170h before the health snapshot, therefore past the 144h content budget.
@@ -115,7 +127,7 @@ const FRESH_META = completeRun(contentFreshnessOf());
 // `activated` is three-valued and matches `mcpStale` below exactly: true =
 // marker read and present, false = marker read and absent, null = the read
 // failed, so the name is missing from the map entirely (#6095).
-function healthVerdict(meta, { activated = true } = {}) {
+function healthVerdict(meta, { activated = true, now = NOW } = {}) {
   return classifyKey(
     'portwatchPortActivity',
     PORTWATCH_DATA_KEY,
@@ -128,7 +140,7 @@ function healthVerdict(meta, { activated = true } = {}) {
       activationStates: activated === null
         ? new Map()
         : new Map([['portwatchContentFreshness', activated]]),
-      now: NOW,
+      now,
     },
   );
 }
@@ -146,11 +158,11 @@ function portwatchCheck() {
 
 // `activated: null` models "the marker was never read, or the read failed" —
 // the third state the map deliberately distinguishes from a read absence.
-function mcpStale(meta, { activated = true } = {}) {
+function mcpStale(meta, { activated = true, now = NOW } = {}) {
   return evaluateFreshness(
     [portwatchCheck()],
     [meta],
-    NOW,
+    now,
     activated === null ? new Map() : new Map([[ACTIVATION_KEY, activated]]),
   ).stale;
 }
@@ -365,6 +377,14 @@ describe('#6080 — the mirror claim in cache-tools.ts is enforced', () => {
     );
   });
 
+  it('advertises the optional activation-grace deadline on cache envelopes', () => {
+    const tool = CACHE_TOOLS.find((candidate) => candidate.name === 'get_chokepoint_status');
+    const deadline = tool?.outputSchema?.properties?.contentFreshnessPendingUntil;
+
+    assert.equal(deadline?.type, 'string');
+    assert.equal(deadline?.format, 'date-time');
+  });
+
   // Acceptance: "confirm no other tool's `stale` flips as a side effect".
   // Walks the WHOLE registry, not just CACHE_TOOLS: the RPC and analysis tools
   // build their own FreshnessCheck arrays and call evaluateFreshness without
@@ -406,7 +426,14 @@ describe('#6080 — executeTool reads the activation marker', () => {
   // markers. `markers` is the set of marker keys that exist in Redis.
   async function runWithRedis(
     stored,
-    { markers = [], failActivationRead = false, activationEntryError = false } = {},
+    {
+      markers = [],
+      failActivationRead = false,
+      activationEntryError = false,
+      activationEntryEmpty = false,
+      malformedPipelineBody,
+      now = Date.now(),
+    } = {},
   ) {
     const originalFetch = globalThis.fetch;
     const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
@@ -417,10 +444,15 @@ describe('#6080 — executeTool reads the activation marker', () => {
     globalThis.fetch = async (url, init) => {
       if (String(url).endsWith('/pipeline')) {
         if (failActivationRead) throw new TypeError('fetch failed');
+        if (malformedPipelineBody !== undefined) {
+          return new Response(JSON.stringify(malformedPipelineBody), { status: 200 });
+        }
         const commands = JSON.parse(init.body);
         return new Response(
-          JSON.stringify(commands.map(([, key]) => (activationEntryError
-            ? { error: 'ERR max request size exceeded' }
+          JSON.stringify(commands.map(([, key]) => (activationEntryEmpty
+            ? {}
+            : activationEntryError
+              ? { error: 'ERR max request size exceeded' }
             : { result: present.has(key) ? 1 : 0 }))),
           { status: 200 },
         );
@@ -430,7 +462,7 @@ describe('#6080 — executeTool reads the activation marker', () => {
       return new Response(JSON.stringify({ result: value }), { status: 200 });
     };
     try {
-      return await executeTool(CHOKEPOINT, {});
+      return await executeTool(CHOKEPOINT, {}, now);
     } finally {
       globalThis.fetch = originalFetch;
       if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
@@ -472,8 +504,8 @@ describe('#6080 — executeTool reads the activation marker', () => {
 
   // Every other key the tool reads, fresh, so only the content dimension can
   // move `stale`.
-  function baseKeys(portwatchMeta) {
-    const liveNow = Date.now();
+  function baseKeys(portwatchMeta, now = Date.now()) {
+    const liveNow = now;
     const freshMeta = JSON.stringify({ fetchedAt: liveNow - 60_000, recordCount: 10 });
     return {
       'supply_chain:transit-summaries:v1': JSON.stringify({ ok: true }),
@@ -491,8 +523,8 @@ describe('#6080 — executeTool reads the activation marker', () => {
     };
   }
 
-  const blockLessMeta = () => JSON.stringify({
-    fetchedAt: Date.now() - 60_000,
+  const blockLessMeta = (now = Date.now()) => JSON.stringify({
+    fetchedAt: now - 60_000,
     recordCount: 174,
   });
 
@@ -515,14 +547,23 @@ describe('#6080 — executeTool reads the activation marker', () => {
   // Proves the marker is actually READ, not just accepted as a parameter: the
   // identical block-less meta answers differently either side of the marker.
   it('lets the marker decide a block-less run, proving the read is wired', async () => {
-    const preActivation = await runWithRedis(baseKeys(blockLessMeta()));
+    const preActivation = await runWithRedis(
+      baseKeys(blockLessMeta(NOW), NOW),
+      { now: NOW },
+    );
     assert.equal(preActivation.stale, false, 'marker read and absent — still in grace');
+    assert.equal(
+      preActivation.contentFreshnessPendingUntil,
+      new Date(CONTENT_FRESHNESS_ROLLOUT_UNTIL).toISOString(),
+      'MCP must publish the same auditable grace deadline as the health surfaces',
+    );
 
     const postActivation = await runWithRedis(
-      baseKeys(blockLessMeta()),
-      { markers: [ACTIVATION_KEY] },
+      baseKeys(blockLessMeta(NOW), NOW),
+      { markers: [ACTIVATION_KEY], now: NOW },
     );
     assert.equal(postActivation.stale, true, 'marker present — the missing block is a fault');
+    assert.equal(postActivation.contentFreshnessPendingUntil, undefined);
   });
 
   // The marker read must not be able to take the tool down: it is a freshness
@@ -578,6 +619,34 @@ describe('#6080 — executeTool reads the activation marker', () => {
     );
   });
 
+  it('does not treat an empty pipeline entry as a read absence', async () => {
+    const result = await runWithRedis(
+      baseKeys(blockLessMeta(NOW), NOW),
+      { markers: [ACTIVATION_KEY], activationEntryEmpty: true, now: NOW },
+    );
+
+    assert.equal(
+      result.stale,
+      true,
+      'an entry without a result is unknown state, not a marker that is absent',
+    );
+  });
+
+  for (const [label, malformedPipelineBody] of [
+    ['object', {}],
+    ['string', 'ok'],
+    ['null', null],
+    ['wrong-length array', []],
+  ]) {
+    it(`does not produce a marker verdict from a malformed ${label} pipeline body`, async () => {
+      const result = await runWithRedis(
+        baseKeys(blockLessMeta(NOW), NOW),
+        { malformedPipelineBody, now: NOW },
+      );
+      assert.equal(result.stale, true, `${label} cannot earn content-freshness grace`);
+    });
+  }
+
 });
 
 // #6095 — the joint agreement loop across ALL THREE surfaces.
@@ -600,6 +669,13 @@ describe('#6095 — health, seed-health, and MCP agree on every marker outcome',
   const MARKER_OUTCOMES = {
     present: { entry: () => ({ result: 1 }), activated: true },
     absent: { entry: () => ({ result: 0 }), activated: false },
+    empty: { entry: () => ({}), activated: null },
+    invalid_number: { entry: () => ({ result: 2 }), activated: null },
+    invalid_null: { entry: () => ({ result: null }), activated: null },
+    invalid_boolean: { entry: () => ({ result: true }), activated: null },
+    invalid_string: { entry: () => ({ result: '2' }), activated: null },
+    invalid_array: { entry: () => ({ result: [] }), activated: null },
+    result_and_error: { entry: () => ({ result: 0, error: 'ERR marker read' }), activated: null },
     // Upstash reports per-command failures inside an otherwise-successful 200,
     // so this is a production shape, not a synthetic one.
     unreadable: { entry: () => ({ error: 'ERR max request size exceeded' }), activated: null },
@@ -641,10 +717,10 @@ describe('#6095 — health, seed-health, and MCP agree on every marker outcome',
   // /api/seed-health has no classifier seam, so the only way to ask it the
   // question is through the handler — which also proves the pipeline-result
   // loop that builds its activation map, not just the gate it feeds.
-  async function seedHealthStatus(build, markerEntry) {
+  async function seedHealthStatus(build, markerEntry, now = NOW) {
     const realFetch = globalThis.fetch;
     globalThis.fetch = async (_url, init) => {
-      const liveNow = Date.now();
+      const liveNow = now;
       const results = JSON.parse(init.body).map(([op, key]) => {
         if (op === 'EXISTS') return key === ACTIVATION_KEY ? markerEntry() : { result: 0 };
         if (key === PORTWATCH_META_KEY) return { result: JSON.stringify(build(liveNow)) };
@@ -655,9 +731,9 @@ describe('#6095 — health, seed-health, and MCP agree on every marker outcome',
       return new Response(JSON.stringify(results), { status: 200 });
     };
     try {
-      const res = await seedHealthHandler(new Request('https://api.worldmonitor.app/api/seed-health', {
+      const res = await handleSeedHealth(new Request('https://api.worldmonitor.app/api/seed-health', {
         headers: { 'X-WorldMonitor-Key': SEED_HEALTH_OPERATOR_KEY },
-      }));
+      }), { now });
       const entry = (await res.json()).seeds?.[PORTWATCH_SEED_DOMAIN];
       assert.ok(entry, 'seed-health must publish the PortWatch entry');
       return entry.status;
@@ -689,6 +765,92 @@ describe('#6095 — health, seed-health, and MCP agree on every marker outcome',
       });
     }
   }
+
+  it('expires cleanly absent content grace at the compiled deadline on all surfaces', async () => {
+    const beforeWindowMeta = completeRunAt(CONTENT_FRESHNESS_ROLLOUT_FROM - 1, undefined);
+    assert.equal(
+      healthVerdict(beforeWindowMeta, {
+        activated: false,
+        now: CONTENT_FRESHNESS_ROLLOUT_FROM - 1,
+      }).status,
+      'COVERAGE_DEGRADED',
+      'health must not grant clean-absent grace before the rollout window starts',
+    );
+    assert.equal(
+      mcpStale(beforeWindowMeta, {
+        activated: false,
+        now: CONTENT_FRESHNESS_ROLLOUT_FROM - 1,
+      }),
+      true,
+      'MCP must not grant clean-absent grace before the rollout window starts',
+    );
+    assert.equal(
+      await seedHealthStatus(
+        () => beforeWindowMeta,
+        () => ({ result: 0 }),
+        CONTENT_FRESHNESS_ROLLOUT_FROM - 1,
+      ),
+      'coverage_degraded',
+      'seed-health must not grant clean-absent grace before the rollout window starts',
+    );
+
+    const expiredMeta = completeRunAt(CONTENT_FRESHNESS_ROLLOUT_UNTIL, undefined);
+    const health = healthVerdict(expiredMeta, {
+      activated: false,
+      now: CONTENT_FRESHNESS_ROLLOUT_UNTIL,
+    });
+
+    assert.equal(health.status, 'COVERAGE_DEGRADED', 'health must revoke grace at the deadline');
+    assert.equal(
+      mcpStale(expiredMeta, {
+        activated: false,
+        now: CONTENT_FRESHNESS_ROLLOUT_UNTIL,
+      }),
+      true,
+      'MCP must revoke grace at the same deadline',
+    );
+    assert.equal(
+      await seedHealthStatus(
+        () => expiredMeta,
+        () => ({ result: 0 }),
+        CONTENT_FRESHNESS_ROLLOUT_UNTIL,
+      ),
+      'coverage_degraded',
+      'seed-health must revoke grace at the same deadline',
+    );
+
+    const expiredMcp = evaluateFreshness(
+      [portwatchCheck()],
+      [expiredMeta],
+      CONTENT_FRESHNESS_ROLLOUT_UNTIL,
+      new Map([[ACTIVATION_KEY, false]]),
+    );
+    assert.equal(expiredMcp.stale, true);
+    assert.equal(expiredMcp.contentFreshnessPendingUntil, undefined);
+
+    const openingMeta = completeRunAt(CONTENT_FRESHNESS_ROLLOUT_FROM, undefined);
+    const openingHealth = healthVerdict(openingMeta, {
+      activated: false,
+      now: CONTENT_FRESHNESS_ROLLOUT_FROM,
+    });
+    assert.equal(openingHealth.status, 'OK', 'health must include the exact opening boundary');
+    const openingMcp = evaluateFreshness(
+      [portwatchCheck()],
+      [openingMeta],
+      CONTENT_FRESHNESS_ROLLOUT_FROM,
+      new Map([[ACTIVATION_KEY, false]]),
+    );
+    assert.equal(openingMcp.stale, false, 'MCP must include the exact opening boundary');
+    assert.equal(
+      await seedHealthStatus(
+        () => openingMeta,
+        () => ({ result: 0 }),
+        CONTENT_FRESHNESS_ROLLOUT_FROM,
+      ),
+      'ok',
+      'seed-health must include the exact opening boundary',
+    );
+  });
 });
 
 // The assessor's fail-closed rules are shared code, but the two surfaces reach

--- a/tests/mcp-portwatch-content-freshness-parity.test.mjs
+++ b/tests/mcp-portwatch-content-freshness-parity.test.mjs
@@ -433,6 +433,11 @@ describe('#6080 — executeTool reads the activation marker', () => {
       activationEntryEmpty = false,
       malformedPipelineBody,
       now = Date.now(),
+      // Omit the explicit clock so executeTool samples its own — the only way
+      // to observe WHEN it samples. `onFetch` fires on each Redis round trip,
+      // letting a test advance a stubbed clock mid-request.
+      useInternalClock = false,
+      onFetch,
     } = {},
   ) {
     const originalFetch = globalThis.fetch;
@@ -442,6 +447,7 @@ describe('#6080 — executeTool reads the activation marker', () => {
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
     const present = new Set(markers);
     globalThis.fetch = async (url, init) => {
+      onFetch?.();
       if (String(url).endsWith('/pipeline')) {
         if (failActivationRead) throw new TypeError('fetch failed');
         if (malformedPipelineBody !== undefined) {
@@ -462,7 +468,7 @@ describe('#6080 — executeTool reads the activation marker', () => {
       return new Response(JSON.stringify({ result: value }), { status: 200 });
     };
     try {
-      return await executeTool(CHOKEPOINT, {}, now);
+      return await executeTool(CHOKEPOINT, {}, useInternalClock ? undefined : now);
     } finally {
       globalThis.fetch = originalFetch;
       if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
@@ -617,6 +623,39 @@ describe('#6080 — executeTool reads the activation marker', () => {
       true,
       'an errored EXISTS entry is unknown state, not a marker that is absent',
     );
+  });
+
+  // The deadline is exact to the second, so WHEN the clock is read decides the
+  // verdict for any request straddling it. api/health.js re-samples after its
+  // Redis I/O (snapshotNow); MCP must do the same or the two surfaces disagree
+  // for the duration of one request. Sampling at function entry — a
+  // `now = Date.now()` default parameter — reintroduces exactly that skew.
+  it('samples the freshness clock after its Redis reads, not at entry', async () => {
+    const realNow = Date.now;
+    let clock = CONTENT_FRESHNESS_ROLLOUT_UNTIL - 60_000; // inside the window
+    Date.now = () => clock;
+    try {
+      const result = await runWithRedis(
+        baseKeys(blockLessMeta(clock), clock),
+        {
+          useInternalClock: true,
+          // The grace expires while the reads are in flight.
+          onFetch: () => { clock = CONTENT_FRESHNESS_ROLLOUT_UNTIL + 60_000; },
+        },
+      );
+      assert.equal(
+        result.stale,
+        true,
+        'grace ended mid-request, so the missing block must be evaluated',
+      );
+      assert.equal(
+        result.contentFreshnessPendingUntil,
+        undefined,
+        'a window that closed during the request publishes no deadline',
+      );
+    } finally {
+      Date.now = realNow;
+    }
   });
 
   it('does not treat an empty pipeline entry as a read absence', async () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2254,6 +2254,20 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const chokepointTransitsFetchedAt = Date.now() - 8 * 60_000;
     // portwatch-ports budget=2160min (36h) → 12h old (fresh)
     const portwatchPortsFetchedAt = Date.now() - 12 * 60 * 60_000;
+    const portwatchContentFreshness = {
+      assessedAt: Date.now(),
+      coveredCount: 174,
+      freshCount: 174,
+      staleCount: 0,
+      unknownCount: 0,
+      staleCountries: [],
+      criticalCountries: ['CN', 'HK'],
+      criticalFreshCount: 2,
+      criticalStaleCountries: [],
+      criticalMissingCountries: 0,
+      criticalOldestObservedAt: Date.now() - 12 * 60 * 60_000,
+      criticalOldestObservedCountry: 'CN',
+    };
     // chokepoint-baselines budget=576000min (400d) → 60d old (fresh; SECOND-OLDEST)
     const chokepointBaselinesFetchedAt = Date.now() - 60 * 24 * 60 * 60_000;
     // portwatch:chokepoints-ref budget=20160min (14d) → 7d old (fresh)
@@ -2263,12 +2277,11 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
     globalThis.fetch = async (url, init) => {
       const u = url.toString();
-      // #6080: get_chokepoint_status also reads its content-freshness
-      // activation marker via an EXISTS pipeline. These metas predate the
-      // contentFreshness block, so answer 0 — marker absent, i.e. the producer
-      // has never published the field. That is the deployment-order grace
-      // state, which keeps these transport/cardinality assertions about
-      // transport and cardinality alone.
+      // #6080/#6111: get_chokepoint_status also reads its content-freshness
+      // activation marker via an EXISTS pipeline. This fixture includes a
+      // valid content report and answers 0 for the marker, so the test stays
+      // about transport/cardinality freshness without relying on grace after
+      // the compiled deployment-order deadline.
       if (u.endsWith('/pipeline')) {
         const commands = JSON.parse(init.body);
         return new Response(JSON.stringify(commands.map(() => ({ result: 0 }))), { status: 200, headers: { 'Content-Type': 'application/json' } });
@@ -2298,7 +2311,11 @@ describe('api/mcp.ts — PRO MCP Server', () => {
         return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: chokepointTransitsFetchedAt, recordCount: 13 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       if (u.includes(`/get/${encodeURIComponent('seed-meta:supply_chain:portwatch-ports')}`)) {
-        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: portwatchPortsFetchedAt, recordCount: 200 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        return new Response(JSON.stringify({ result: JSON.stringify({
+          fetchedAt: portwatchPortsFetchedAt,
+          recordCount: 200,
+          contentFreshness: portwatchContentFreshness,
+        }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
       }
       if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:chokepoint-baselines')}`)) {
         return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: chokepointBaselinesFetchedAt, recordCount: 13 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
@@ -2355,12 +2372,9 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
     globalThis.fetch = async (url, init) => {
       const u = url.toString();
-      // #6080: get_chokepoint_status also reads its content-freshness
-      // activation marker via an EXISTS pipeline. These metas predate the
-      // contentFreshness block, so answer 0 — marker absent, i.e. the producer
-      // has never published the field. That is the deployment-order grace
-      // state, which keeps these transport/cardinality assertions about
-      // transport and cardinality alone.
+      // #6080/#6111: the marker is read through EXISTS and answers 0, but
+      // these block-less fixtures are intentionally evaluated after the
+      // compiled grace deadline, so the missing content remains strict.
       if (u.endsWith('/pipeline')) {
         const commands = JSON.parse(init.body);
         return new Response(JSON.stringify(commands.map(() => ({ result: 0 }))), { status: 200, headers: { 'Content-Type': 'application/json' } });
@@ -2407,12 +2421,9 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
     globalThis.fetch = async (url, init) => {
       const u = url.toString();
-      // #6080: get_chokepoint_status also reads its content-freshness
-      // activation marker via an EXISTS pipeline. These metas predate the
-      // contentFreshness block, so answer 0 — marker absent, i.e. the producer
-      // has never published the field. That is the deployment-order grace
-      // state, which keeps these transport/cardinality assertions about
-      // transport and cardinality alone.
+      // #6080/#6111: the marker is read through EXISTS and answers 0, but
+      // this block-less fixture is intentionally evaluated after the compiled
+      // grace deadline, so the missing content remains strict.
       if (u.endsWith('/pipeline')) {
         const commands = JSON.parse(init.body);
         return new Response(JSON.stringify(commands.map(() => ({ result: 0 }))), { status: 200, headers: { 'Content-Type': 'application/json' } });

--- a/tests/seed-health-portwatch-port-activity.test.mjs
+++ b/tests/seed-health-portwatch-port-activity.test.mjs
@@ -16,10 +16,11 @@ process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
 process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'true';
 process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
 
-const { default: handler } = await import('../api/seed-health.js');
+const { handleSeedHealth } = await import('../api/seed-health.js');
 
 const PORTWATCH_META_KEY = 'seed-meta:supply_chain:portwatch-ports';
 const PORTWATCH_CONTENT_BUDGET_MINUTES = 2 * 72 * 60;
+const TEST_NOW = Date.parse('2026-08-03T14:42:58.000Z');
 const DECISION_META_KEY = 'seed-meta:intelligence:china-decision-signals';
 const PREDICTION_META_KEY = 'seed-meta:prediction:markets';
 const RESILIENCE_INTERVAL_PROBE_KEY = 'resilience:intervals:v9:US';
@@ -43,7 +44,12 @@ after(() => {
 
 function installSeedHealthPipelineMock(
   portwatchRecordCount,
-  { missingPortwatchMeta = false, portwatchContentFreshness, chinaDecisionMeta } = {},
+  {
+    missingPortwatchMeta = false,
+    portwatchContentFreshness,
+    chinaDecisionMeta,
+    now = TEST_NOW,
+  } = {},
 ) {
   globalThis.fetch = async (_url, init) => {
     const commands = JSON.parse(init.body);
@@ -60,7 +66,7 @@ function installSeedHealthPipelineMock(
         if (missingPortwatchMeta) return { result: null };
         return {
           result: JSON.stringify({
-            fetchedAt: Date.now(),
+            fetchedAt: now,
             recordCount: portwatchRecordCount,
             ...(portwatchContentFreshness ? { contentFreshness: portwatchContentFreshness } : {}),
           }),
@@ -72,7 +78,7 @@ function installSeedHealthPipelineMock(
       if (key === PREDICTION_META_KEY) {
         return {
           result: JSON.stringify({
-            fetchedAt: Date.now(),
+            fetchedAt: now,
             recordCount: 38,
             poolCounts: { geopolitical: 18, tech: 12, finance: 8 },
           }),
@@ -92,7 +98,7 @@ function installSeedHealthPipelineMock(
       // This fixture isolates the PortWatch entry. Keep every unrelated
       // coverage-gated feed above its floor so a new minRecordCount contract
       // cannot turn the aggregate warning for an unrelated reason.
-      return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 10_000 }) };
+      return { result: JSON.stringify({ fetchedAt: now, recordCount: 10_000 }) };
     });
     return new Response(JSON.stringify(results), {
       status: 200,
@@ -101,11 +107,11 @@ function installSeedHealthPipelineMock(
   };
 }
 
-async function readSeedHealth() {
+async function readSeedHealth(now = TEST_NOW) {
   const req = new Request('https://api.worldmonitor.app/api/seed-health', {
     headers: { 'X-WorldMonitor-Key': 'test-key' },
   });
-  const res = await handler(req);
+  const res = await handleSeedHealth(req, { now });
   const body = await res.json();
   return { res, body };
 }
@@ -167,7 +173,7 @@ test('seed-health keeps PortWatch port activity OK at the 174-country recovery f
 });
 
 test('seed-health flags stale decision-critical PortWatch content separately from heartbeat', async () => {
-  const now = Date.now();
+  const now = TEST_NOW;
   installSeedHealthPipelineMock(174, {
     portwatchContentFreshness: {
       budgetMinutes: PORTWATCH_CONTENT_BUDGET_MINUTES,
@@ -197,7 +203,7 @@ test('seed-health flags stale decision-critical PortWatch content separately fro
 test('seed-health publishes partial and stale China decision groups like /api/health', async () => {
   installSeedHealthPipelineMock(174, {
     chinaDecisionMeta: {
-      fetchedAt: Date.now(),
+      fetchedAt: TEST_NOW,
       recordCount: 3,
       groupStates: {
         macro: 'partial',

--- a/tests/seed-health-prediction-pools.test.mjs
+++ b/tests/seed-health-prediction-pools.test.mjs
@@ -19,6 +19,7 @@ process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
 const { default: handler } = await import('../api/seed-health.js');
 
 const PREDICTION_META_KEY = 'seed-meta:prediction:markets';
+const PORTWATCH_META_KEY = 'seed-meta:supply_chain:portwatch-ports';
 const RESILIENCE_INTERVAL_PROBE_KEY = 'resilience:intervals:v9:US';
 const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
 
@@ -62,6 +63,27 @@ function installSeedHealthPipelineMock(poolCounts, { fetchedAt = Date.now() } = 
             _formula: 'pc',
             methodology: RESILIENCE_INTERVAL_METHODOLOGY,
             computedAt: '2026-06-11T12:00:00.000Z',
+          }),
+        };
+      }
+      if (key === PORTWATCH_META_KEY) {
+        return {
+          result: JSON.stringify({
+            fetchedAt,
+            recordCount: 174,
+            contentFreshness: {
+              coveredCount: 174,
+              freshCount: 174,
+              staleCount: 0,
+              unknownCount: 0,
+              staleCountries: [],
+              criticalCountries: ['CN', 'HK'],
+              criticalFreshCount: 2,
+              criticalStaleCountries: [],
+              criticalMissingCountries: 0,
+              criticalOldestObservedAt: fetchedAt - 60_000,
+              criticalOldestObservedCountry: 'CN',
+            },
           }),
         };
       }

--- a/tests/seed-history-ingest-health.test.mjs
+++ b/tests/seed-history-ingest-health.test.mjs
@@ -42,6 +42,7 @@ process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
 
 const RESILIENCE_INTERVAL_PROBE_KEY = 'resilience:intervals:v9:US';
 const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
+const PORTWATCH_META_KEY = 'seed-meta:supply_chain:portwatch-ports';
 const PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY =
   'seed-activated:supply_chain:portwatch-ports:content-freshness';
 
@@ -1032,6 +1033,28 @@ describe('a prolonged relay rejection is visible in /api/seed-health', () => {
               _formula: 'pc',
               methodology: RESILIENCE_INTERVAL_METHODOLOGY,
               computedAt: '2026-06-11T12:00:00.000Z',
+            }),
+          };
+        }
+        if (key === PORTWATCH_META_KEY) {
+          const observedAt = Date.now() - 60 * 60_000;
+          return {
+            result: JSON.stringify({
+              fetchedAt: Date.now(),
+              recordCount: 174,
+              contentFreshness: {
+                coveredCount: 174,
+                freshCount: 174,
+                staleCount: 0,
+                unknownCount: 0,
+                staleCountries: [],
+                criticalCountries: ['CN', 'HK'],
+                criticalFreshCount: 2,
+                criticalStaleCountries: [],
+                criticalMissingCountries: 0,
+                criticalOldestObservedAt: observedAt,
+                criticalOldestObservedCountry: 'CN',
+              },
             }),
           };
         }


### PR DESCRIPTION
## Summary

- Closes the PortWatch content-freshness deployment grace at the compiled window `2026-08-03T10:24:42Z` through `2026-08-04T06:00:00Z`, and publishes `contentFreshnessPendingUntil` through full/compact health, seed health, and MCP cache envelopes.
- Invalidates pre-change health verdict snapshots so cached responses cannot hide the new deadline contract.
- Makes Upstash pipeline reads fail closed unless the response is an array with the exact command count, and centralizes strict three-valued EXISTS parsing across health, seed-health, and MCP.
- Adds regression coverage for malformed marker states, bounded grace boundaries, snapshot wire formats, and cross-surface parity.
- Updates the English and Chinese health endpoint documentation.

## Issues

Closes #6111
Closes #6115

## Verification

- `npm run typecheck`
- `npm run typecheck:api`
- `npm run test:sidecar` — 315/315
- Focused health/seed-health/MCP regression suite — 397/397
- MCP protocol/output suite — 230/230
- `npm run docs:check`
- `npm run lint:md`
- Pre-push gate — passed, including 508 changed/documentation tests
- `npm run test:data` remains locally limited by two unrelated environment/tree gates: the dashboard critical-CSS tests require a prior `dist/dashboard.html` build, and pre-push attestation tests intentionally reject the dirty caller worktree. The changed scoped suite is green.

## Post-Deploy Monitoring & Validation

- Verify default-branch ancestry, deployed SHA, and deployed behavior as separate checks.
- After `2026-08-04T06:00:00Z`, query `/api/health?compact=1` and `/api/seed-health`; a missing PortWatch content block must no longer be softened, must omit `contentFreshnessPendingUntil`, and must report the corresponding coverage degradation.
- With a valid published PortWatch content block, confirm the health surfaces recover and MCP `get_chokepoint_status` exposes the optional deadline only while the compiled grace is active.
- Watch logs and health aggregates for `REDIS_DOWN`, `COVERAGE_DEGRADED`, malformed marker reads, and unexpected rejection of valid pipeline responses.
- Observe at least one complete 12-hour producer rotation; investigate or roll back if valid published content degrades or valid pipeline responses are rejected unexpectedly.