### PR TITLE
fix(markets): stabilize sector valuation coverage

### DIFF
--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -302,10 +302,12 @@ export const CACHE_TOOLS: ToolDef[] = [
             properties: {
               valuationCount: { type: 'number' },
               expectedValuationCount: { type: 'number' },
+              currentValuationCount: { type: 'number' },
               sourceStatus: { type: 'string', enum: ['ok', 'partial', 'degraded'] },
               source: { type: 'string' },
               fetchedAt: { type: 'number' },
               stale: { type: 'boolean' },
+              staleValuationSymbols: { type: 'array', items: { type: 'string' } },
               unavailableSymbols: { type: 'array', items: { type: 'string' } },
               valuationDiagnostics: {
                 type: 'array',
@@ -425,6 +427,16 @@ export const CACHE_TOOLS: ToolDef[] = [
                 coverageRecord.unavailableSymbols = filteredUnavailable;
               }
             }
+            const filteredStaleValuationSymbols = Array.isArray(coverageRecord.staleValuationSymbols)
+              ? coverageRecord.staleValuationSymbols
+                .filter((symbol): symbol is string => typeof symbol === 'string')
+                .filter((symbol) => requestedSectorSymbols.includes(symbol.toLowerCase()))
+              : [];
+            if (filteredStaleValuationSymbols.length === 0) {
+              delete coverageRecord.staleValuationSymbols;
+            } else {
+              coverageRecord.staleValuationSymbols = filteredStaleValuationSymbols;
+            }
             if (coverageRecord.lastGood && typeof coverageRecord.lastGood === 'object' && !Array.isArray(coverageRecord.lastGood)) {
               const lastGoodRecord = coverageRecord.lastGood as Record<string, unknown>;
               if (Array.isArray(lastGoodRecord.symbols)) {
@@ -453,14 +465,27 @@ export const CACHE_TOOLS: ToolDef[] = [
               ? Object.keys(sector.valuations).length
               : 0;
             const expectedValuationCount = requestedSectorSymbols.length;
+            const staleValuationCount = sector.valuations && typeof sector.valuations === 'object' && !Array.isArray(sector.valuations)
+              ? filteredStaleValuationSymbols.filter((symbol) => Object.prototype.hasOwnProperty.call(sector.valuations, symbol)).length
+              : 0;
+            const hasCurrentValuationCount = typeof coverageRecord.currentValuationCount === 'number'
+              && Number.isFinite(coverageRecord.currentValuationCount);
+            const filteredCurrentValuationCount = Math.max(0, filteredValuationCount - staleValuationCount);
             coverageRecord.valuationCount = filteredValuationCount;
             coverageRecord.expectedValuationCount = expectedValuationCount;
+            if (hasCurrentValuationCount) {
+              coverageRecord.currentValuationCount = filteredCurrentValuationCount;
+            }
             // Empty request set (no sector symbols matched): complete empty view, not degraded.
             coverageRecord.sourceStatus = expectedValuationCount === 0
               ? 'ok'
               : filteredValuationCount === 0
                 ? 'degraded'
-                : filteredValuationCount < expectedValuationCount ? 'partial' : 'ok';
+                : filteredValuationCount < expectedValuationCount
+                  || filteredStaleValuationSymbols.length > 0
+                  || (hasCurrentValuationCount && filteredCurrentValuationCount < expectedValuationCount)
+                  ? 'partial'
+                  : 'ok';
           }
         }
         narrowNested(data, 'etf-flows', 'etfs', (e) => matchesCode(e.ticker, symbols));

--- a/scripts/_yahoo-sector-valuations.cjs
+++ b/scripts/_yahoo-sector-valuations.cjs
@@ -304,6 +304,55 @@ function parseV7Quote(body, expectedSymbol = null) {
   };
 }
 
+function parseV7QuoteBatch(body, expectedSymbols = []) {
+  let data;
+  try {
+    data = JSON.parse(body);
+  } catch {
+    return { kind: 'invalid_json', value: null };
+  }
+  const quoteResponse = data?.quoteResponse;
+  if (quoteResponse?.error) {
+    return { kind: 'upstream_error', value: null, failure: 'quote_response_error' };
+  }
+  const results = quoteResponse?.result;
+  if (!Array.isArray(results) || results.length === 0) {
+    return { kind: 'no_data', value: null };
+  }
+
+  const resultBySymbol = new Map(
+    results
+      .filter((result) => typeof result?.symbol === 'string')
+      .map((result) => [result.symbol.toUpperCase(), result]),
+  );
+  const valuations = {};
+  const outcomes = {};
+  for (const symbol of [...new Set(expectedSymbols)]) {
+    const result = resultBySymbol.get(String(symbol).toUpperCase());
+    if (!result) {
+      outcomes[symbol] = { kind: 'no_data', value: null };
+      continue;
+    }
+    const parsed = parseV7Quote(
+      JSON.stringify({ quoteResponse: { result: [result] } }),
+      symbol,
+    );
+    outcomes[symbol] = parsed;
+    if (parsed.kind === 'success') valuations[symbol] = parsed.value;
+  }
+
+  if (Object.keys(valuations).length > 0) {
+    return { kind: 'success', value: { valuations, outcomes } };
+  }
+  const firstOutcome = Object.values(outcomes)[0];
+  return {
+    kind: firstOutcome?.kind || 'no_data',
+    value: { valuations, outcomes },
+    ...(firstOutcome?.missingFields ? { missingFields: firstOutcome.missingFields } : {}),
+    ...(firstOutcome?.failure ? { failure: firstOutcome.failure } : {}),
+  };
+}
+
 async function fetchYahooV7QuoteDirect(symbol, { userAgent, timeoutMs = 10_000 } = {}) {
   const url = `${YAHOO_V7_QUOTE_URL}?symbols=${encodeURIComponent(symbol)}`;
   try {
@@ -381,6 +430,53 @@ async function collectV7Valuations(
     const remainingMs = deadlineAt == null ? DEFAULT_REQUEST_SPACING_MS : Math.max(0, deadlineAt - now());
     if (remainingMs > 0) await sleepFn(Math.min(DEFAULT_REQUEST_SPACING_MS, remainingMs));
   }
+
+  // Yahoo's individual v7 responses can lose valuation fields for a stable
+  // subset of ETFs even while the same authenticated endpoint returns them in
+  // one bounded batch. Use the batch shape only for symbols still uncovered;
+  // the normal per-symbol route remains the primary path and its diagnostics
+  // stay intact.
+  const batchSymbols = symbols.filter((symbol) => !freshVals[symbol]);
+  if (
+    batchSymbols.length > 0
+    && client?.fetchV7BatchDetailed
+    && (deadlineAt == null || now() < deadlineAt)
+  ) {
+    let batchResult = null;
+    try {
+      batchResult = await client.fetchV7BatchDetailed(batchSymbols, { deadlineAt });
+    } catch {
+      batchResult = null;
+    }
+    const batchValues = batchResult?.value?.valuations;
+    const batchOutcomes = batchResult?.value?.outcomes;
+    const transportDiagnostic = batchResult?.diagnostics?.[batchResult.diagnostics.length - 1]
+      || batchResult?.diagnostic;
+    for (const symbol of batchSymbols) {
+      const outcome = batchOutcomes?.[symbol];
+      const diagnostic = {
+        route: 'v7Quote',
+        ...(transportDiagnostic?.transport ? { transport: transportDiagnostic.transport } : {}),
+        ...(transportDiagnostic?.attempts != null ? { attempts: transportDiagnostic.attempts } : {}),
+        ...(transportDiagnostic?.status != null ? { status: transportDiagnostic.status } : {}),
+        responseClass: outcome?.kind || transportDiagnostic?.responseClass || batchResult?.kind || 'failed',
+        ...(outcome?.missingFields?.length ? { missingFields: outcome.missingFields } : {}),
+        ...(outcome?.failure ? { failure: boundedFailure(outcome.failure) } : {}),
+      };
+      const entry = diagnostics.find((item) => item.symbol === symbol);
+      if (entry) entry.outcomes.push(diagnostic);
+      else diagnostics.push({ symbol, outcomes: [diagnostic] });
+
+      const value = batchValues?.[symbol];
+      if (value) {
+        freshVals[symbol] = {
+          ...value,
+          ...(batchResult.value.source ? { source: batchResult.value.source } : {}),
+        };
+        if (batchResult.value.source) valuationSources.add(batchResult.value.source);
+      }
+    }
+  }
   return { valuations: freshVals, diagnostics, valuationSources: [...valuationSources] };
 }
 
@@ -405,6 +501,28 @@ function mergeReturnMetrics(freshVals, lastGoodValuations) {
       used = true;
     }
     if (used) usedSymbols.push(s);
+  }
+  return usedSymbols;
+}
+
+function hasCoreValuation(value) {
+  return Boolean(
+    value
+    && typeof value === 'object'
+    && !Array.isArray(value)
+    && (value.trailingPE != null || value.forwardPE != null),
+  );
+}
+
+function mergeLastGoodValuations(freshVals, lastGoodValuations, symbols) {
+  if (!lastGoodValuations || typeof lastGoodValuations !== 'object') return [];
+  const usedSymbols = [];
+  for (const symbol of symbols) {
+    if (freshVals[symbol]) continue;
+    const lastGood = lastGoodValuations[symbol];
+    if (!hasCoreValuation(lastGood)) continue;
+    freshVals[symbol] = { ...lastGood };
+    usedSymbols.push(symbol);
   }
   return usedSymbols;
 }
@@ -828,6 +946,19 @@ class YahooQuoteSummaryClient {
     });
   }
 
+  async fetchV7BatchDetailed(symbols, { deadlineAt = null } = {}) {
+    const requestedSymbols = [...new Set(symbols)].filter(Boolean);
+    return this._fetchRoute('v7QuoteBatch', requestedSymbols.join(','), {
+      buildUrl: (tickers, crumb) => {
+        const query = new URLSearchParams({ symbols: tickers, crumb });
+        return `${YAHOO_V7_QUOTE_URL}?${query}`;
+      },
+      parseResponse: (body) => parseV7QuoteBatch(body, requestedSymbols),
+      source: 'yahoo_v7_quote_authenticated',
+      deadlineAt,
+    });
+  }
+
   async fetchV7(symbol) {
     const result = await this.fetchV7Detailed(symbol);
     return result.kind === 'success' ? result.value : null;
@@ -843,24 +974,36 @@ function buildSectorValuationCoverage({
   valuationDiagnostics = [],
   lastGoodFetchedAt = null,
   lastGoodMetricsUsed = [],
+  currentValuationCount = null,
+  lastGoodValuationSymbols = [],
 }) {
   const count = Number.isFinite(valuationCount) ? Math.max(0, valuationCount) : 0;
   const expected = Number.isFinite(expectedCount) ? Math.max(0, expectedCount) : 0;
+  const currentCount = Number.isFinite(currentValuationCount)
+    ? Math.max(0, currentValuationCount)
+    : null;
   const orderedSources = [...new Set((sources || []).filter(Boolean))].sort();
   const source = orderedSources.length > 0
     ? orderedSources.join('+')
     : 'yahoo_quote_summary_authenticated';
   const unavailable = [...new Set(unavailableSymbols.filter(Boolean))].sort();
   const diagnostics = valuationDiagnostics.filter(Boolean);
-  const lastGood = lastGoodFetchedAt && lastGoodMetricsUsed.length > 0
+  const staleValuations = [...new Set(lastGoodValuationSymbols.filter(Boolean))].sort();
+  const lastGoodSymbols = [...new Set([
+    ...lastGoodMetricsUsed,
+    ...staleValuations,
+  ])].sort();
+  const lastGood = lastGoodFetchedAt && lastGoodSymbols.length > 0
     ? {
       fetchedAt: lastGoodFetchedAt,
       stale: true,
-      symbols: [...new Set(lastGoodMetricsUsed)].sort(),
+      symbols: lastGoodSymbols,
     }
     : null;
 
   const extras = {
+    ...(currentCount != null && currentCount !== count ? { currentValuationCount: currentCount } : {}),
+    ...(staleValuations.length > 0 ? { staleValuationSymbols: staleValuations } : {}),
     ...(unavailable.length > 0 ? { unavailableSymbols: unavailable } : {}),
     ...(diagnostics.length > 0 ? { valuationDiagnostics: diagnostics } : {}),
     ...(lastGood ? { lastGood } : {}),
@@ -879,7 +1022,7 @@ function buildSectorValuationCoverage({
       ...extras,
     };
   }
-  if (count < expected) {
+  if (count < expected || staleValuations.length > 0 || (currentCount != null && currentCount < expected)) {
     return {
       valuationCount: count,
       expectedValuationCount: expected,
@@ -944,6 +1087,7 @@ async function collectSectorValuations({
   let lastGood = null;
   let lastGoodFetchedAt = null;
   let lastGoodMetricsUsed = [];
+  let lastGoodValuationSymbols = [];
 
   // Tier 3: v10/quoteSummary for symbols v7 didn't cover
   for (const symbol of symbols) {
@@ -971,7 +1115,7 @@ async function collectSectorValuations({
     if (remainingMs > 0) await sleepFn(Math.min(DEFAULT_REQUEST_SPACING_MS, remainingMs));
   }
 
-  if (Object.keys(v7Vals).length > 0 && typeof upstashGet === 'function') {
+  if (typeof upstashGet === 'function') {
     try {
       const raw = await upstashGet(LAST_GOOD_KEY);
       if (raw && typeof raw === 'object' && raw.valuations) {
@@ -980,47 +1124,68 @@ async function collectSectorValuations({
       }
     } catch {}
   }
-  if (lastGood) lastGoodMetricsUsed = mergeReturnMetrics(v7Vals, lastGood);
+
+  const currentValuationCount = Object.keys(v7Vals).length;
+  const currentValuations = {};
+  for (const symbol of symbols) {
+    if (!v7Vals[symbol]) continue;
+    const { source: _source, ...valuation } = v7Vals[symbol];
+    currentValuations[symbol] = valuation;
+  }
+
+  if (lastGood) {
+    lastGoodValuationSymbols = mergeLastGoodValuations(v7Vals, lastGood, symbols);
+    lastGoodMetricsUsed = mergeReturnMetrics(v7Vals, lastGood);
+  }
 
   const valuations = {};
-  const unavailableSymbols = [];
+  const unavailableSymbols = symbols.filter((symbol) => !currentValuations[symbol]);
   for (const symbol of symbols) {
-    if (!v7Vals[symbol]) {
-      unavailableSymbols.push(symbol);
-      continue;
-    }
+    if (!v7Vals[symbol]) continue;
     const { source: _source, ...valuation } = v7Vals[symbol];
     valuations[symbol] = valuation;
   }
   const valuationCount = Object.keys(valuations).length;
   if (valuationCount > 0 && valuationSources.size === 0) valuationSources.add('yahoo_v7_quote');
 
-  const hasCompleteReturnMetrics = valuationCount === symbols.length
+  const hasCompleteReturnMetrics = currentValuationCount === symbols.length
     && symbols.length > 0
     && symbols.every((symbol) => {
-      const valuation = valuations[symbol];
+      const valuation = currentValuations[symbol];
       return valuation
         && valuation.ytdReturn != null
         && valuation.threeYearReturn != null
         && valuation.fiveYearReturn != null;
     });
+  const hasCompleteCoreCoverage = currentValuationCount === symbols.length
+    && symbols.length > 0
+    && symbols.every((symbol) => hasCoreValuation(currentValuations[symbol]));
+  const lastGoodCoreCount = lastGood
+    ? symbols.filter((symbol) => hasCoreValuation(lastGood[symbol])).length
+    : 0;
+  const canPersistCoreSnapshot = hasCompleteCoreCoverage
+    && !hasCompleteReturnMetrics
+    && (!lastGood || (lastGoodCoreCount > 0 && lastGoodCoreCount < symbols.length));
 
-  // Persist last-good only when the current snapshot is complete at the
-  // field level. A v7-only run intentionally leaves return metrics null, and
-  // a partial quoteSummary fallback must never replace an older complete
-  // snapshot with that incomplete shape.
-  // A partial run may borrow return metrics from the previous snapshot. Do not
-  // rewrite that snapshot with a new fetchedAt: doing so would make borrowed
-  // metrics appear fresh forever across repeated partial cycles. Also retain a
-  // full last-good snapshot until a full current run replaces it; otherwise a
-  // partial outage would discard the symbols that were healthy previously.
-  if (
-    hasCompleteReturnMetrics
-    && lastGoodMetricsUsed.length === 0
-    && typeof upstashSet === 'function'
-  ) {
+  // Persist a complete core snapshot even when a v7-only run leaves return
+  // metrics null. A partial quoteSummary fallback must never replace an older
+  // snapshot with an incomplete shape. A partial run may borrow return metrics
+  // or core valuations from the previous snapshot; do not rewrite that
+  // snapshot with a new fetchedAt because that would make borrowed data appear
+  // fresh forever across repeated partial cycles.
+  const shouldPersistLastGood = (
+    hasCompleteReturnMetrics && lastGoodMetricsUsed.length === 0
+  ) || canPersistCoreSnapshot;
+  if (shouldPersistLastGood && typeof upstashSet === 'function') {
     try {
-      const ok = await upstashSet(LAST_GOOD_KEY, { valuations, fetchedAt: now() }, LAST_GOOD_TTL);
+      const snapshotValuations = Object.fromEntries(
+        Object.entries(hasCompleteReturnMetrics ? valuations : currentValuations)
+          .map(([symbol, valuation]) => [
+            symbol,
+            Object.fromEntries(Object.entries(valuation).filter(([, value]) => value != null)),
+          ]),
+      );
+      const ok = await upstashSet(LAST_GOOD_KEY, { valuations: snapshotValuations, fetchedAt: now() }, LAST_GOOD_TTL);
       // upstashSet resolves false on disable/timeout/non-OK without throwing.
       if (!ok) {
         console.warn('[Sector] last-good valuation snapshot write failed');
@@ -1034,10 +1199,15 @@ async function collectSectorValuations({
     valuations,
     valuationSources: [...valuationSources],
     valuationCount,
+    ...(currentValuationCount !== valuationCount ? { currentValuationCount } : {}),
     ...(unavailableSymbols.length > 0 ? { unavailableSymbols } : {}),
     ...(valuationDiagnostics.length > 0 ? { valuationDiagnostics } : {}),
-    ...(lastGoodFetchedAt && lastGoodMetricsUsed.length > 0
-      ? { lastGoodFetchedAt, lastGoodMetricsUsed }
+    ...(lastGoodFetchedAt && (lastGoodMetricsUsed.length > 0 || lastGoodValuationSymbols.length > 0)
+      ? {
+        lastGoodFetchedAt,
+        ...(lastGoodMetricsUsed.length > 0 ? { lastGoodMetricsUsed } : {}),
+        ...(lastGoodValuationSymbols.length > 0 ? { lastGoodValuationSymbols } : {}),
+      }
       : {}),
   };
 }
@@ -1067,6 +1237,9 @@ function buildSectorValuationPublication({
       valuationSourceStatus: valuationCoverage.sourceStatus,
       valuationSource: valuationCoverage.source,
       sourceState: seedSourceState,
+      ...(valuationCoverage.currentValuationCount != null
+        ? { valuationCurrentRecordCount: valuationCoverage.currentValuationCount }
+        : {}),
       sourceVersion: 'market-sectors',
       ...(valuationCoverage.unavailableSymbols?.length > 0
         ? { valuationUnavailableSymbols: valuationCoverage.unavailableSymbols }
@@ -1075,6 +1248,9 @@ function buildSectorValuationPublication({
         ? { valuationDiagnostics: valuationCoverage.valuationDiagnostics }
         : {}),
       ...(valuationCoverage.lastGood ? { valuationLastGood: valuationCoverage.lastGood } : {}),
+      ...(valuationCoverage.staleValuationSymbols?.length > 0
+        ? { valuationStaleSymbols: valuationCoverage.staleValuationSymbols }
+        : {}),
       ...(errorCode ? { errorCode } : {}),
     },
   };
@@ -1104,6 +1280,7 @@ module.exports = {
   mergeReturnMetrics,
   parseCurlResponse,
   parseV7Quote,
+  parseV7QuoteBatch,
   parseQuoteSummary,
   requestHttpsText,
   requestCurlText,

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2394,8 +2394,10 @@ async function seedSectorSummary() {
     valuationCount: valCount,
     unavailableSymbols,
     valuationDiagnostics,
+    currentValuationCount,
     lastGoodFetchedAt,
     lastGoodMetricsUsed,
+    lastGoodValuationSymbols,
   } = await collectSectorValuations({
     symbols: SECTOR_SYMBOLS,
     fetchValue: fetchYahooQuoteSummary,
@@ -2416,8 +2418,10 @@ async function seedSectorSummary() {
     sources: valuationSources,
     unavailableSymbols,
     valuationDiagnostics,
+    currentValuationCount,
     lastGoodFetchedAt,
     lastGoodMetricsUsed,
+    lastGoodValuationSymbols,
   });
   const { payload, meta: sectorMeta } = buildSectorValuationPublication({
     sectors,

--- a/tests/mcp-sector-valuation-coverage.test.mts
+++ b/tests/mcp-sector-valuation-coverage.test.mts
@@ -18,12 +18,14 @@ describe('get_market_data sector valuation coverage contract', () => {
     assert.deepEqual(
       Object.keys(coverage.properties || {}).sort(),
       [
+        'currentValuationCount',
         'expectedValuationCount',
         'fetchedAt',
         'lastGood',
         'source',
         'sourceStatus',
         'stale',
+        'staleValuationSymbols',
         'unavailableSymbols',
         'valuationCount',
         'valuationDiagnostics',
@@ -163,6 +165,36 @@ describe('get_market_data sector valuation coverage contract', () => {
       data.sectors.valuationCoverage.valuationDiagnostics.map((entry) => entry.symbol),
       ['XLK', 'SMH'],
     );
+  });
+
+  it('keeps fallback-filled valuation coverage partial and preserves current count', () => {
+    const tool = CACHE_TOOLS.find((candidate) => candidate.name === 'get_market_data');
+    assert.ok(tool?._postFilter);
+    const data = {
+      sectors: {
+        sectors: [{ symbol: 'XLK' }, { symbol: 'SMH' }],
+        valuations: {
+          XLK: { trailingPE: 25 },
+          SMH: { trailingPE: 35 },
+        },
+        valuationCoverage: {
+          valuationCount: 2,
+          expectedValuationCount: 2,
+          currentValuationCount: 1,
+          sourceStatus: 'partial',
+          fetchedAt: Date.now(),
+          staleValuationSymbols: ['SMH'],
+          unavailableSymbols: ['SMH'],
+        },
+      },
+    };
+
+    tool._postFilter(data, { symbols: ['XLK', 'SMH'], limit: 0 });
+    assert.equal(data.sectors.valuationCoverage.valuationCount, 2);
+    assert.equal(data.sectors.valuationCoverage.expectedValuationCount, 2);
+    assert.equal(data.sectors.valuationCoverage.currentValuationCount, 1);
+    assert.equal(data.sectors.valuationCoverage.sourceStatus, 'partial');
+    assert.deepEqual(data.sectors.valuationCoverage.staleValuationSymbols, ['SMH']);
   });
 
   it('marks filtered coverage degraded when every requested sector symbol is unavailable', () => {

--- a/tests/sector-valuations.test.mjs
+++ b/tests/sector-valuations.test.mjs
@@ -302,6 +302,48 @@ describe('sector valuation collection', () => {
     assert.ok(result.valuations.XLE, 'should have XLE from v10 fallback');
   });
 
+  it('uses a bounded v7 batch fallback for symbols omitted from individual responses', async () => {
+    let batchCalls = 0;
+    const result = await collectSectorValuations({
+      symbols: ['XLK', 'SMH'],
+      fetchValue: async () => { throw new Error('quoteSummary must not run when batch v7 recovers'); },
+      parseValue: (raw) => raw?.value ?? null,
+      sleepFn: async () => {},
+      v7UserAgent: 'test-agent',
+      v7Client: {
+        fetchV7Detailed: async () => ({
+          kind: 'missing_fields',
+          value: null,
+          diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'missing_fields' }],
+        }),
+        fetchV7BatchDetailed: async (symbols) => {
+          batchCalls++;
+          assert.deepEqual(symbols, ['XLK', 'SMH']);
+          return {
+            kind: 'success',
+            value: {
+              source: 'yahoo_v7_quote_authenticated_direct',
+              valuations: {
+                XLK: { trailingPE: 25, forwardPE: null, beta: 1.1 },
+                SMH: { trailingPE: 37, forwardPE: null, beta: 1.2 },
+              },
+              outcomes: {
+                XLK: { kind: 'success', value: { trailingPE: 25, forwardPE: null, beta: 1.1 } },
+                SMH: { kind: 'success', value: { trailingPE: 37, forwardPE: null, beta: 1.2 } },
+              },
+            },
+            diagnostics: [{ route: 'v7Quote', transport: 'direct', attempts: 1, status: 200, responseClass: 'success' }],
+          };
+        },
+      },
+    });
+
+    assert.equal(batchCalls, 1);
+    assert.equal(result.valuationCount, 2);
+    assert.deepEqual(result.valuationSources, ['yahoo_v7_quote_authenticated_direct']);
+    assert.ok(result.valuationDiagnostics.every((entry) => entry.outcomes.some((outcome) => outcome.responseClass === 'success')));
+  });
+
   it('records authenticated v7 coverage and explicit last-good metric provenance', async () => {
     const result = await collectSectorValuations({
       symbols: ['XLK'],
@@ -343,6 +385,95 @@ describe('sector valuation collection', () => {
     assert.deepEqual(result.lastGoodMetricsUsed, ['XLK']);
     assert.equal(result.lastGoodFetchedAt, 1_700_000_000_000);
     assert.deepEqual(result.valuationSources, ['yahoo_v7_quote_authenticated_direct']);
+  });
+
+  it('persists a complete v7 valuation snapshot when return metrics are unavailable', async () => {
+    let written = null;
+    const result = await collectSectorValuations({
+      symbols: ['XLK', 'XLF'],
+      fetchValue: async () => { throw new Error('v10 must not run for a v7 success'); },
+      parseValue: (raw) => raw,
+      sleepFn: async () => {},
+      v7UserAgent: 'test-agent',
+      v7Client: {
+        fetchV7Detailed: async (symbol) => ({
+          kind: 'success',
+          value: {
+            trailingPE: symbol === 'XLK' ? 25 : 15,
+            forwardPE: symbol === 'XLK' ? 22 : 14,
+            beta: 1.1,
+            ytdReturn: null,
+            threeYearReturn: null,
+            fiveYearReturn: null,
+            source: 'yahoo_v7_quote_authenticated_direct',
+          },
+          diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'success' }],
+        }),
+      },
+      upstashGet: async () => null,
+      upstashSet: async (_key, value) => {
+        written = value;
+        return true;
+      },
+    });
+
+    assert.equal(result.valuationCount, 2);
+    assert.deepEqual(written?.valuations, {
+      XLK: { trailingPE: 25, forwardPE: 22, beta: 1.1 },
+      XLF: { trailingPE: 15, forwardPE: 14, beta: 1.1 },
+    });
+  });
+
+  it('reuses complete last-good valuations for symbols missing from both live routes', async () => {
+    const result = await collectSectorValuations({
+      symbols: ['XLK', 'XLF'],
+      fetchValue: async () => { throw new Error('v10 fallback must use the detailed route'); },
+      parseValue: (raw) => raw?.value ?? null,
+      sleepFn: async () => {},
+      v7UserAgent: 'test-agent',
+      v7Client: {
+        fetchV7Detailed: async (symbol) => symbol === 'XLK'
+          ? {
+            kind: 'success',
+            value: {
+              trailingPE: 25,
+              forwardPE: 22,
+              beta: 1.1,
+              source: 'yahoo_v7_quote_authenticated_direct',
+            },
+            diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'success' }],
+          }
+          : {
+            kind: 'missing_fields',
+            value: null,
+            diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'missing_fields' }],
+          },
+      },
+      fetchValueDetailed: async () => ({
+        kind: 'missing_fields',
+        value: null,
+        diagnostics: [{ route: 'quoteSummary', transport: 'direct', responseClass: 'missing_fields' }],
+      }),
+      upstashGet: async () => ({
+        fetchedAt: 1_700_000_000_000,
+        valuations: {
+          XLK: { trailingPE: 24, forwardPE: 21, beta: 1.05 },
+          XLF: { trailingPE: 15, forwardPE: 14, beta: 1.1 },
+        },
+      }),
+      upstashSet: async () => { throw new Error('partial run must not replace last-good'); },
+    });
+
+    assert.equal(result.valuationCount, 2);
+    assert.equal(result.currentValuationCount, 1);
+    assert.deepEqual(result.valuations.XLF, {
+      trailingPE: 15,
+      forwardPE: 14,
+      beta: 1.1,
+    });
+    assert.deepEqual(result.lastGoodValuationSymbols, ['XLF']);
+    assert.deepEqual(result.unavailableSymbols, ['XLF']);
+    assert.equal(result.lastGoodFetchedAt, 1_700_000_000_000);
   });
 
   it('does not re-date borrowed last-good metrics after a partial run', async () => {

--- a/tests/yahoo-sector-valuations.test.mjs
+++ b/tests/yahoo-sector-valuations.test.mjs
@@ -9,6 +9,7 @@ import {
   buildSectorValuationCoverage,
   buildSectorValuationPublication,
   parseV7Quote,
+  parseV7QuoteBatch,
   parseCurlResponse,
   parseQuoteSummary,
   requestCurlText,
@@ -732,6 +733,24 @@ describe('parseV7Quote', () => {
   });
 });
 
+describe('parseV7QuoteBatch', () => {
+  it('maps one authenticated batch response back to requested symbols', () => {
+    const result = parseV7QuoteBatch(JSON.stringify({
+      quoteResponse: {
+        result: [
+          { symbol: 'XLK', trailingPE: 25.3, beta: 1.05 },
+          { symbol: 'SMH', trailingPE: 37.2, beta: 1.2 },
+        ],
+      },
+    }), ['XLK', 'SMH', 'XLV']);
+
+    assert.equal(result.kind, 'success');
+    assert.equal(result.value.valuations.XLK.trailingPE, 25.3);
+    assert.equal(result.value.valuations.SMH.trailingPE, 37.2);
+    assert.equal(result.value.outcomes.XLV.kind, 'no_data');
+  });
+});
+
 describe('parseCurlResponse', () => {
   it('ignores the proxy CONNECT preamble and parses the upstream response', () => {
     const parsed = parseCurlResponse([
@@ -838,6 +857,31 @@ describe('buildSectorValuationCoverage', () => {
       fetchedAt: fetchedAt - 60_000,
       stale: true,
       symbols: ['XLF'],
+    });
+  });
+
+  it('keeps coverage partial when stale last-good records fill missing symbols', () => {
+    const coverage = buildSectorValuationCoverage({
+      valuationCount: 12,
+      expectedCount: 12,
+      currentValuationCount: 8,
+      fetchedAt,
+      sources: ['yahoo_v7_quote_authenticated_direct'],
+      unavailableSymbols: ['SMH', 'XLK', 'XLV', 'XLY'],
+      lastGoodFetchedAt: fetchedAt - 60_000,
+      lastGoodValuationSymbols: ['SMH', 'XLK', 'XLV', 'XLY'],
+    });
+
+    assert.equal(coverage.valuationCount, 12);
+    assert.equal(coverage.currentValuationCount, 8);
+    assert.equal(coverage.sourceStatus, 'partial');
+    assert.equal(coverage.seedSourceState, 'partial');
+    assert.equal(coverage.errorCode, 'SECTOR_VALUATIONS_PARTIAL');
+    assert.deepEqual(coverage.staleValuationSymbols, ['SMH', 'XLK', 'XLV', 'XLY']);
+    assert.deepEqual(coverage.lastGood, {
+      fetchedAt: fetchedAt - 60_000,
+      stale: true,
+      symbols: ['SMH', 'XLK', 'XLV', 'XLY'],
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #5903.

- Add a bounded authenticated Yahoo v7 batch fallback for symbols omitted by individual responses. The local authenticated batch probe returned all 12 sector valuations, including XLK, XLV, XLY, and SMH.
- Persist complete core valuation snapshots even when v7 return metrics are null, and reuse missing symbols only as explicit stale last-good records.
- Publish current valuation count and stale-symbol provenance separately; MCP filtering preserves partial status and current counts.
- Keep direct/proxy/field-level diagnostics and truthful SECTOR_VALUATIONS_PARTIAL semantics when stale data is used.

## Verification

- Focused Yahoo/sector/MCP tests: 85 passed.
- Health classification/verdict/history tests: 123 passed.
- npm run typecheck: passed.
- npm run typecheck:api: passed.
- npm run test:data: passed.
- Pre-push gates: passed.

Production was still reporting 8/12 before this branch was deployed. After merge/deploy, verify two consecutive five-minute production cycles at 12/12 with sourceStatus: ok before closing the issue.