### PR TITLE
fix(portwatch): retry transient ArcGIS rate limits

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -253,6 +253,12 @@ function epochToTimestamp(epochMs) {
   return `timestamp '${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}'`;
 }
 
+export function createArcgisProxyError(reason, errInfo) {
+  const error = new Error(`ArcGIS error (via proxy after ${reason}): ${errInfo}`);
+  error.refreshFailureCode = refreshFailureCode(errInfo);
+  return error;
+}
+
 // Retry an ArcGIS request through the Decodo proxy. Used as the fallback
 // path when the direct request returns 429 OR silently times out — both
 // are signals that ArcGIS is rate-limiting our seed-server IP. Returns the
@@ -274,7 +280,7 @@ async function arcgisProxyRetry(url, reason, { signal } = {}) {
     // with no message field. Fall back to code, then JSON.stringify so the
     // thrown error message stays informative on unexpected error shapes.
     const errInfo = proxied.error.message ?? proxied.error.code ?? JSON.stringify(proxied.error);
-    throw new Error(`ArcGIS error (via proxy after ${reason}): ${errInfo}`);
+    throw createArcgisProxyError(reason, errInfo);
   }
   return proxied;
 }

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -214,6 +214,12 @@ const CONCURRENCY = 6;
 // run — negligible against the 570s bundle budget.
 const BATCH_BACKOFF_MS = 5_000;
 const BATCH_LOG_EVERY = 5;
+// A country-level ArcGIS request can be rate-limited even when the run has
+// ample bundle time left. Retry that country once after a short cooldown;
+// the outer per-country timeout remains the hard ceiling for the whole retry
+// sequence, so a slow upstream cannot extend the run indefinitely.
+const RATE_LIMIT_RETRY_DELAY_MS = 2_000;
+const MAX_RATE_LIMIT_RETRIES = 1;
 // Cache hygiene: force a full refetch if the cached payload is older than 7 days
 // even when upstream maxDate is unchanged. Protects against window-shift drift
 // (cached aggregates were computed against a window that's now 7+ days offset
@@ -985,9 +991,75 @@ function refreshFailureCode(reason) {
   if (reason?.refreshFailureCode) return reason.refreshFailureCode;
   const text = `${reason?.code || ''} ${reason?.message || reason || ''}`;
   if (/invalid query parameters/i.test(text)) return 'invalid_query';
-  if (/\b429\b|rate.?limit/i.test(text)) return 'rate_limited';
+  if (/\b429\b|rate.?limit|too many requests/i.test(text)) return 'rate_limited';
   if (/timeout|timed out|abort/i.test(text)) return 'timeout';
   return 'fetch_error';
+}
+
+function waitForRetry(delayMs, signal) {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, delayMs));
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason ?? new Error('aborted'));
+      return;
+    }
+    let timer;
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      reject(signal.reason ?? new Error('aborted'));
+    };
+    const done = () => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    timer = setTimeout(done, delayMs);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+// Retry only the rate-limit failure class. Other ArcGIS errors (invalid query,
+// timeout, empty result) must retain their existing failure semantics so a
+// global upstream regression still reaches the circuit-breaker and coverage
+// gates without being hidden by a generic retry loop.
+export async function retryRateLimited(
+  operation,
+  {
+    signal,
+    delayMs = RATE_LIMIT_RETRY_DELAY_MS,
+    maxRetries = MAX_RATE_LIMIT_RETRIES,
+    sleepFn = waitForRetry,
+    label = 'country',
+  } = {},
+) {
+  let retries = 0;
+  while (true) {
+    const attemptController = new AbortController();
+    const attemptSignal = signal
+      ? AbortSignal.any([signal, attemptController.signal])
+      : attemptController.signal;
+    try {
+      return await operation(attemptSignal);
+    } catch (reason) {
+      // fetchCountryAccum runs its two windows in parallel. Abort the sibling
+      // window before retrying so one fast 429 cannot overlap a second full
+      // country attempt and amplify the upstream rate limit.
+      attemptController.abort(reason);
+      if (
+        retries >= maxRetries
+        || refreshFailureCode(reason) !== 'rate_limited'
+        || signal?.aborted
+      ) {
+        throw reason;
+      }
+      retries += 1;
+      console.warn(
+        `  [port-activity] ${label}: rate-limited — retrying ` +
+        `after ${delayMs}ms (${retries}/${maxRetries})`,
+      );
+      await sleepFn(delayMs, signal);
+    }
+  }
 }
 
 export function buildRefreshFailureState(item, reason, attemptedAt = Date.now()) {
@@ -1253,7 +1325,10 @@ export async function fetchAll(progress, { signal, expectedCountries = [] } = {}
       // Falls back to Date.now() when preflight returned null.
       const anchorEpochMs = parseMaxDateToAnchor(upstreamMaxDate);
       const p = withPerCountryTimeout(
-        (childSignal) => fetchCountryAccum(iso3, { signal: childSignal, anchorEpochMs, dateField }),
+        (childSignal) => retryRateLimited(
+          (attemptSignal) => fetchCountryAccum(iso3, { signal: attemptSignal, anchorEpochMs, dateField }),
+          { signal: childSignal, label: iso3 },
+        ),
         iso3,
       );
       // Eager error flush so a SIGTERM mid-batch captures rejections that

--- a/tests/portwatch-port-activity-recovery.test.mjs
+++ b/tests/portwatch-port-activity-recovery.test.mjs
@@ -140,11 +140,32 @@ describe('PortWatch last-good and gap reporting', () => {
     assert.equal(rateLimitedState.refreshFailure.code, 'rate_limited');
   });
 
+  it('classifies proxy errors from ArcGIS errInfo while preserving the diagnostic reason', () => {
+    const createProxyError = portwatchSeed.createArcgisProxyError;
+    assert.equal(typeof createProxyError, 'function');
+
+    const invalidQueryError = createProxyError('HTTP 429 rate-limited', 'Invalid query parameters');
+    assert.match(invalidQueryError.message, /HTTP 429 rate-limited/);
+    assert.equal(
+      portwatchSeed.buildRefreshFailureState(cachedCountry('US'), invalidQueryError, 10 * DAY)
+        .refreshFailure.code,
+      'invalid_query',
+    );
+
+    const rateLimitedError = createProxyError('direct timeout', 'Too many requests (429)');
+    assert.equal(
+      portwatchSeed.buildRefreshFailureState(cachedCountry('CY'), rateLimitedError, 10 * DAY)
+        .refreshFailure.code,
+      'rate_limited',
+    );
+  });
+
   it('retries one ArcGIS rate-limit failure when the country still has run budget', async () => {
     const retryRateLimited = portwatchSeed.retryRateLimited;
     assert.equal(typeof retryRateLimited, 'function');
     let attempts = 0;
     let firstAttemptSignal;
+    const sleepCalls = [];
 
     const result = await retryRateLimited(async (attemptSignal) => {
       attempts += 1;
@@ -154,40 +175,61 @@ describe('PortWatch last-good and gap reporting', () => {
       }
       assert.equal(firstAttemptSignal.aborted, true);
       return 'recovered';
-    }, { sleepFn: async () => {} });
+    }, {
+      sleepFn: async (delayMs) => {
+        sleepCalls.push(delayMs);
+      },
+    });
 
     assert.equal(result, 'recovered');
     assert.equal(attempts, 2);
+    assert.equal(sleepCalls.length, 1);
+    assert.equal(sleepCalls[0], 2_000);
   });
 
   it('does not retry unrelated ArcGIS failures', async () => {
     const retryRateLimited = portwatchSeed.retryRateLimited;
     let attempts = 0;
+    const sleepCalls = [];
 
     await assert.rejects(
       retryRateLimited(async () => {
         attempts += 1;
         throw new Error('ArcGIS error: Invalid query parameters');
-      }, { sleepFn: async () => {} }),
+      }, {
+        sleepFn: async (...args) => {
+          sleepCalls.push(args);
+        },
+      }),
       /Invalid query parameters/,
     );
 
     assert.equal(attempts, 1);
+    assert.equal(sleepCalls.length, 0);
   });
 
   it('bounds repeated rate-limit failures to one retry', async () => {
     const retryRateLimited = portwatchSeed.retryRateLimited;
     let attempts = 0;
+    const sleepCalls = [];
+    const delayMs = 321;
 
     await assert.rejects(
       retryRateLimited(async () => {
         attempts += 1;
         throw new Error('ArcGIS HTTP 429 rate-limited');
-      }, { sleepFn: async () => {} }),
+      }, {
+        delayMs,
+        sleepFn: async (actualDelayMs) => {
+          sleepCalls.push({ actualDelayMs });
+        },
+      }),
       /429 rate-limited/,
     );
 
     assert.equal(attempts, 2);
+    assert.equal(sleepCalls.length, 1);
+    assert.equal(sleepCalls[0].actualDelayMs, delayMs);
   });
 
   it('aborts the retry cooldown when the parent run is cancelled', async () => {

--- a/tests/portwatch-port-activity-recovery.test.mjs
+++ b/tests/portwatch-port-activity-recovery.test.mjs
@@ -139,6 +139,74 @@ describe('PortWatch last-good and gap reporting', () => {
     assert.equal(invalidQueryState.refreshFailure.code, 'invalid_query');
     assert.equal(rateLimitedState.refreshFailure.code, 'rate_limited');
   });
+
+  it('retries one ArcGIS rate-limit failure when the country still has run budget', async () => {
+    const retryRateLimited = portwatchSeed.retryRateLimited;
+    assert.equal(typeof retryRateLimited, 'function');
+    let attempts = 0;
+    let firstAttemptSignal;
+
+    const result = await retryRateLimited(async (attemptSignal) => {
+      attempts += 1;
+      if (attempts === 1) {
+        firstAttemptSignal = attemptSignal;
+        throw new Error('ArcGIS error: Unable to perform query. Too many requests.');
+      }
+      assert.equal(firstAttemptSignal.aborted, true);
+      return 'recovered';
+    }, { sleepFn: async () => {} });
+
+    assert.equal(result, 'recovered');
+    assert.equal(attempts, 2);
+  });
+
+  it('does not retry unrelated ArcGIS failures', async () => {
+    const retryRateLimited = portwatchSeed.retryRateLimited;
+    let attempts = 0;
+
+    await assert.rejects(
+      retryRateLimited(async () => {
+        attempts += 1;
+        throw new Error('ArcGIS error: Invalid query parameters');
+      }, { sleepFn: async () => {} }),
+      /Invalid query parameters/,
+    );
+
+    assert.equal(attempts, 1);
+  });
+
+  it('bounds repeated rate-limit failures to one retry', async () => {
+    const retryRateLimited = portwatchSeed.retryRateLimited;
+    let attempts = 0;
+
+    await assert.rejects(
+      retryRateLimited(async () => {
+        attempts += 1;
+        throw new Error('ArcGIS HTTP 429 rate-limited');
+      }, { sleepFn: async () => {} }),
+      /429 rate-limited/,
+    );
+
+    assert.equal(attempts, 2);
+  });
+
+  it('aborts the retry cooldown when the parent run is cancelled', async () => {
+    const retryRateLimited = portwatchSeed.retryRateLimited;
+    const controller = new AbortController();
+    let attempts = 0;
+
+    const retrying = retryRateLimited(async () => {
+      attempts += 1;
+      throw new Error('ArcGIS HTTP 429 rate-limited');
+    }, {
+      signal: controller.signal,
+      delayMs: 100,
+    });
+    setTimeout(() => controller.abort(new Error('run cancelled')), 0);
+
+    await assert.rejects(retrying, /run cancelled/);
+    assert.equal(attempts, 1);
+  });
 });
 
 describe('PortWatch canonical reference guard', () => {

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -495,8 +495,16 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /parseMaxDateToAnchor\(upstreamMaxDate\)/);
     assert.match(
       src,
-      /fetchCountryAccum\(iso3,\s*\{\s*signal:\s*childSignal,\s*anchorEpochMs,\s*dateField\s*\}\)/,
+      /retryRateLimited\(\s*\(attemptSignal\)\s*=>\s*fetchCountryAccum\(iso3,\s*\{\s*signal:\s*attemptSignal,\s*anchorEpochMs,\s*dateField\s*\}\)/,
     );
+  });
+
+  it('retries only rate-limited country fetches inside the existing timeout', () => {
+    assert.match(src, /const RATE_LIMIT_RETRY_DELAY_MS\s*=\s*2_000/);
+    assert.match(src, /const MAX_RATE_LIMIT_RETRIES\s*=\s*1/);
+    assert.match(src, /retryRateLimited\(\s*\(attemptSignal\)\s*=>/);
+    assert.match(src, /refreshFailureCode\(reason\)\s*!==\s*'rate_limited'/);
+    assert.match(src, /withPerCountryTimeout\(/);
   });
 
   it('fetchAll resolves the ArcGIS date field once at run start', () => {


### PR DESCRIPTION
## Summary

- Classify ArcGIS `Too many requests` failures as rate-limited instead of generic fetch failures.
- Retry one affected country after a 2-second cooldown, aborting the failed attempt and keeping the retry inside the existing 90-second per-country timeout.
- Preserve the hard stale-data expiry, canonical publish floor, and 174-country health target.

## Production diagnosis

The latest Railway run completed 173/174 in 32.6 seconds; Great Britain failed with `ArcGIS error: Unable to perform query. Too many requests.` The producer recorded that as `fetch_error`, so it had no transient recovery path. The attempted deployment of the #6135 scheduling/content-clock change failed before it produced a usable deployment snapshot.

## Verification

- 14 PortWatch recovery tests
- 106 producer and contract tests
- 67 content-freshness and health tests
- `npm run typecheck`
- Full pre-push gate

Production acceptance remains pending: deploy this producer change, observe successful scheduled runs, confirm CN/HK content clocks advance within the 144-hour budget, and continue #3613 cardinality acceptance separately. Railway deployment closure remains tracked by #6151.

Refs #3613 #6126 #6151