### PR TITLE
fix(consumer-prices): recover partial retailer extraction

### DIFF
--- a/consumer-prices-core/configs/retailers/carrefour_ae.yaml
+++ b/consumer-prices-core/configs/retailers/carrefour_ae.yaml
@@ -9,6 +9,10 @@ retailer:
 
   searchConfig:
     numResults: 5
+    # Pinned product URLs historically used the bare hostname while the
+    # configured base URL uses `www`; both are the same storefront.
+    allowedHosts:
+      - carrefouruae.com
 
   rateLimit:
     requestsPerMinute: 20

--- a/consumer-prices-core/configs/retailers/carrefour_sa.yaml
+++ b/consumer-prices-core/configs/retailers/carrefour_sa.yaml
@@ -9,8 +9,12 @@ retailer:
 
   searchConfig:
     numResults: 5
-    queryTemplate: "{canonicalName} carrefour saudi"
+    queryTemplate: "{canonicalName} grocery carrefour saudi {currency}"
+    allowedHosts:
+      - www.carrefourksa.com
     urlPathContains: /p/
+    extractionFallback: exa
+    requireStrictValidator: true
 
   rateLimit:
     requestsPerMinute: 10

--- a/consumer-prices-core/configs/retailers/coldstorage_sg.yaml
+++ b/consumer-prices-core/configs/retailers/coldstorage_sg.yaml
@@ -15,6 +15,10 @@ retailer:
     # result for years (logged 2026-05-09: "5 URLs from Exa, 0 passed
     # domain check" for every basket item).
     urlPathContains: /p/
+    allowedHosts:
+      - www.coldstorage.com.sg
+    extractionFallback: exa
+    requireStrictValidator: true
 
   rateLimit:
     requestsPerMinute: 10

--- a/consumer-prices-core/configs/retailers/jiomart_in.yaml
+++ b/consumer-prices-core/configs/retailers/jiomart_in.yaml
@@ -9,8 +9,15 @@ retailer:
 
   searchConfig:
     numResults: 5
-    queryTemplate: "{canonicalName} grocery {market} {currency} price"
-    urlPathContains: /p/
+    # JioMart's broad `/p/` namespace also contains home-and-kitchen pages;
+    # keep discovery on the grocery storefront and let Exa retry extraction
+    # when Firecrawl returns an empty or non-product response.
+    queryTemplate: "{canonicalName} {category} grocery food {market} {currency} price"
+    allowedHosts:
+      - www.jiomart.com
+    urlPathContains: /p/groceries/
+    extractionFallback: exa
+    requireStrictValidator: true
 
   rateLimit:
     requestsPerMinute: 10

--- a/consumer-prices-core/configs/retailers/noon_grocery_ae.yaml
+++ b/consumer-prices-core/configs/retailers/noon_grocery_ae.yaml
@@ -13,7 +13,9 @@ retailer:
     # short-lived `/now-product/` pages on minutes.noon.com.
     allowedHosts:
       - minutes.noon.com
-    urlPathContains: /uae-en/
+    urlPathContains:
+      - /p/
+      - /now-product/
     queryTemplate: "{canonicalName} grocery fresh food {currency} {market}"
     extractionFallback: exa
     requireStrictValidator: true

--- a/consumer-prices-core/configs/retailers/noon_grocery_ae.yaml
+++ b/consumer-prices-core/configs/retailers/noon_grocery_ae.yaml
@@ -16,6 +16,10 @@ retailer:
     urlPathContains:
       - /p/
       - /now-product/
+    # Mirror of noon_sa: the shared minutes.noon.com host also fronts
+    # /saudi-en/, so the AE storefront has to be pinned explicitly.
+    urlPathMustContain:
+      - /uae-en/
     queryTemplate: "{canonicalName} grocery fresh food {currency} {market}"
     extractionFallback: exa
     requireStrictValidator: true

--- a/consumer-prices-core/configs/retailers/noon_grocery_ae.yaml
+++ b/consumer-prices-core/configs/retailers/noon_grocery_ae.yaml
@@ -9,8 +9,14 @@ retailer:
 
   searchConfig:
     numResults: 5
-    urlPathContains: /p/
+    # Noon keeps grocery pages on the main `/p/` route but also exposes
+    # short-lived `/now-product/` pages on minutes.noon.com.
+    allowedHosts:
+      - minutes.noon.com
+    urlPathContains: /uae-en/
     queryTemplate: "{canonicalName} grocery fresh food {currency} {market}"
+    extractionFallback: exa
+    requireStrictValidator: true
 
   rateLimit:
     requestsPerMinute: 10

--- a/consumer-prices-core/configs/retailers/noon_sa.yaml
+++ b/consumer-prices-core/configs/retailers/noon_sa.yaml
@@ -11,6 +11,10 @@ retailer:
     numResults: 5
     queryTemplate: "{canonicalName} grocery SAR saudi noon"
     urlPathContains: /saudi-en/  # restrict to SA storefront; noon.com also serves UAE (/uae-en/) and Egypt
+    allowedHosts:
+      - minutes.noon.com
+    extractionFallback: exa
+    requireStrictValidator: true
 
   rateLimit:
     requestsPerMinute: 10

--- a/consumer-prices-core/configs/retailers/noon_sa.yaml
+++ b/consumer-prices-core/configs/retailers/noon_sa.yaml
@@ -13,6 +13,12 @@ retailer:
     urlPathContains:
       - /p/
       - /now-product/
+    # noon.com serves UAE (/uae-en/) and Egypt from the same hosts. The route
+    # filters above are an OR and cannot also pin the storefront, so the market
+    # scope is AND-ed separately — without it a UAE page is published as SAR
+    # and the outlier gate can't see it (AED:SAR is ~1:1.02).
+    urlPathMustContain:
+      - /saudi-en/
     allowedHosts:
       - minutes.noon.com
     extractionFallback: exa

--- a/consumer-prices-core/configs/retailers/noon_sa.yaml
+++ b/consumer-prices-core/configs/retailers/noon_sa.yaml
@@ -10,7 +10,9 @@ retailer:
   searchConfig:
     numResults: 5
     queryTemplate: "{canonicalName} grocery SAR saudi noon"
-    urlPathContains: /saudi-en/  # restrict to SA storefront; noon.com also serves UAE (/uae-en/) and Egypt
+    urlPathContains:
+      - /p/
+      - /now-product/
     allowedHosts:
       - minutes.noon.com
     extractionFallback: exa

--- a/consumer-prices-core/src/acquisition/exa.test.ts
+++ b/consumer-prices-core/src/acquisition/exa.test.ts
@@ -10,7 +10,8 @@ describe('ExaProvider.extract', () => {
     prompt: 'Extract the grocery price.',
     fields: {
       productName: { type: 'string' as const, description: 'Product title' },
-      price: { type: 'number' as const, description: 'Retail price' },
+      price: { type: 'number' as const, nullable: true, description: 'Retail price' },
+      inStock: { type: 'boolean' as const, required: false, description: 'Availability' },
     },
   };
 
@@ -33,10 +34,13 @@ describe('ExaProvider.extract', () => {
     expect(request.method).toBe('POST');
     expect(request.headers).toMatchObject({ 'x-api-key': 'test-key', 'User-Agent': 'worldmonitor-consumer-prices/1.0' });
     const body = JSON.parse(String(request.body)) as {
-      summary: { query: string; schema: { properties: Record<string, { type: string }>; required: string[] } };
+      summary: {
+        query: string;
+        schema: { properties: Record<string, { type: string | string[] }>; required: string[] };
+      };
     };
     expect(body.summary.query).toContain('Extract the grocery price.');
-    expect(body.summary.schema.properties.price.type).toBe('number');
+    expect(body.summary.schema.properties.price.type).toEqual(['number', 'null']);
     expect(body.summary.schema.required).toEqual(['productName', 'price']);
   });
 

--- a/consumer-prices-core/src/acquisition/exa.test.ts
+++ b/consumer-prices-core/src/acquisition/exa.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ExaProvider } from './exa.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ExaProvider.extract', () => {
+  const schema = {
+    prompt: 'Extract the grocery price.',
+    fields: {
+      productName: { type: 'string' as const, description: 'Product title' },
+      price: { type: 'number' as const, description: 'Retail price' },
+    },
+  };
+
+  it('requests structured summary output and parses the JSON summary', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          results: [{ summary: '{"productName":"White Bread","price":4.95}' }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await new ExaProvider('test-key').extract('https://retailer.example/p/bread', schema, { timeout: 1000 });
+
+    expect(result.data).toEqual({ productName: 'White Bread', price: 4.95 });
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.exa.ai/contents');
+    expect(request.method).toBe('POST');
+    expect(request.headers).toMatchObject({ 'x-api-key': 'test-key', 'User-Agent': 'worldmonitor-consumer-prices/1.0' });
+    const body = JSON.parse(String(request.body)) as {
+      summary: { query: string; schema: { properties: Record<string, { type: string }>; required: string[] } };
+    };
+    expect(body.summary.query).toContain('Extract the grocery price.');
+    expect(body.summary.schema.properties.price.type).toBe('number');
+    expect(body.summary.schema.required).toEqual(['productName', 'price']);
+  });
+
+  it('maps bounded Exa search results and forwards the host policy', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ results: [{ url: 'https://retailer.example/p/bread', title: 'White Bread', score: 0.9 }] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const results = await new ExaProvider('test-key').search('white bread', {
+      numResults: 3,
+      includeDomains: ['retailer.example'],
+      timeout: 1000,
+    });
+
+    expect(results).toEqual([{ url: 'https://retailer.example/p/bread', title: 'White Bread', score: 0.9 }]);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.exa.ai/search');
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(JSON.parse(String(request.body))).toMatchObject({
+      query: 'white bread',
+      numResults: 3,
+      includeDomains: ['retailer.example'],
+    });
+  });
+
+  it('surfaces malformed structured summaries as provider errors', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ results: [{ summary: 'not-json' }] }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(new ExaProvider('test-key').extract('https://retailer.example/p/bread', schema)).rejects.toThrow(
+      'malformed structured summary',
+    );
+  });
+
+  it('propagates the abort timeout when the Exa request does not finish', async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<never>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason));
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      new ExaProvider('test-key').extract('https://retailer.example/p/bread', schema, { timeout: 5 }),
+    ).rejects.toThrow();
+  });
+});

--- a/consumer-prices-core/src/acquisition/exa.ts
+++ b/consumer-prices-core/src/acquisition/exa.ts
@@ -4,9 +4,12 @@ import type { AcquisitionProvider, ExtractResult, ExtractSchema, FetchOptions, F
 export class ExaProvider implements AcquisitionProvider {
   readonly name = 'exa' as const;
 
+  private readonly apiKey: string;
+  private readonly baseUrl = 'https://api.exa.ai';
   private client: Exa;
 
   constructor(apiKey: string) {
+    this.apiKey = apiKey;
     this.client = new Exa(apiKey);
   }
 
@@ -31,19 +34,29 @@ export class ExaProvider implements AcquisitionProvider {
   }
 
   async search(query: string, opts: SearchOptions = {}): Promise<SearchResult[]> {
-    const result = await this.client.search(query, {
+    const result = await this.request<{
+      results?: Array<{
+        url: string;
+        title?: string;
+        text?: string;
+        highlights?: string[];
+        score?: number;
+        publishedDate?: string;
+      }>;
+    }>('/search', {
+      query,
       numResults: opts.numResults ?? 10,
       type: opts.type ?? 'neural',
       includeDomains: opts.includeDomains,
       startPublishedDate: opts.startPublishedDate,
       useAutoprompt: true,
-    });
+    }, opts.timeout);
 
-    return result.results.map((r) => ({
+    return (result.results ?? []).map((r) => ({
       url: r.url,
       title: r.title ?? '',
       text: r.text,
-      highlights: (r as Record<string, unknown>).highlights as string[] | undefined,
+      highlights: r.highlights,
       score: r.score,
       publishedDate: r.publishedDate,
     }));
@@ -52,23 +65,34 @@ export class ExaProvider implements AcquisitionProvider {
   async extract<T = Record<string, unknown>>(
     url: string,
     schema: ExtractSchema,
-    _opts: FetchOptions = {},
+    opts: FetchOptions = {},
   ): Promise<ExtractResult<T>> {
-    const prompt = `Extract the following fields from this product page: ${Object.entries(schema.fields)
+    const prompt = `${schema.prompt ? `${schema.prompt} ` : ''}Extract the following fields from this product page: ${Object.entries(schema.fields)
       .map(([k, v]) => `${k} (${v.type}): ${v.description}`)
       .join(', ')}`;
+    const outputSchema = {
+      type: 'object',
+      properties: Object.fromEntries(
+        Object.entries(schema.fields).map(([key, field]) => [key, { type: field.type, description: field.description }]),
+      ),
+      required: Object.keys(schema.fields),
+      additionalProperties: false,
+    };
 
-    const result = await this.client.getContents([url], {
-      text: { maxCharacters: 50_000 },
-      summary: { query: prompt },
-    });
-
-    const item = result.results[0];
+    // exa-js does not expose an AbortSignal for getContents, so use the API
+    // directly here to keep the opt-in fallback genuinely bounded.
+    const result = await this.request<{ results?: Array<{ summary?: unknown }> }>('/contents', {
+      urls: [url],
+      summary: { query: prompt, schema: outputSchema },
+    }, opts.timeout);
+    const item = result.results?.[0];
     if (!item) throw new Error(`Exa returned no content for ${url}`);
+    const data = parseStructuredSummary<T>(item.summary);
+    if (data === null) throw new Error(`Exa returned malformed structured summary for ${url}`);
 
     return {
       url,
-      data: (item as unknown as { summary?: T }).summary ?? ({} as T),
+      data,
       provider: this.name,
       fetchedAt: new Date(),
     };
@@ -81,5 +105,39 @@ export class ExaProvider implements AcquisitionProvider {
     } catch {
       return false;
     }
+  }
+
+  private async request<T>(endpoint: string, body: Record<string, unknown>, timeout = 30_000): Promise<T> {
+    const response = await globalThis.fetch(`${this.baseUrl}${endpoint}`, {
+      method: 'POST',
+      headers: {
+        'x-api-key': this.apiKey,
+        'Content-Type': 'application/json',
+        'User-Agent': 'worldmonitor-consumer-prices/1.0',
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeout),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(`Exa ${endpoint.slice(1)} failed HTTP ${response.status}: ${detail.slice(0, 120)}`);
+    }
+
+    return (await response.json()) as T;
+  }
+}
+
+function parseStructuredSummary<T>(summary: unknown): T | null {
+  if (summary && typeof summary === 'object') return summary as T;
+  if (typeof summary !== 'string') return null;
+
+  const trimmed = summary.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
+  if (!trimmed) return null;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return parsed && typeof parsed === 'object' ? (parsed as T) : null;
+  } catch {
+    return null;
   }
 }

--- a/consumer-prices-core/src/acquisition/exa.ts
+++ b/consumer-prices-core/src/acquisition/exa.ts
@@ -73,9 +73,17 @@ export class ExaProvider implements AcquisitionProvider {
     const outputSchema = {
       type: 'object',
       properties: Object.fromEntries(
-        Object.entries(schema.fields).map(([key, field]) => [key, { type: field.type, description: field.description }]),
+        Object.entries(schema.fields).map(([key, field]) => [
+          key,
+          {
+            type: field.nullable ? [field.type, 'null'] : field.type,
+            description: field.description,
+          },
+        ]),
       ),
-      required: Object.keys(schema.fields),
+      required: Object.entries(schema.fields)
+        .filter(([, field]) => field.required !== false)
+        .map(([key]) => key),
       additionalProperties: false,
     };
 

--- a/consumer-prices-core/src/acquisition/firecrawl.test.ts
+++ b/consumer-prices-core/src/acquisition/firecrawl.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { FirecrawlProvider } from './firecrawl.js';
+import { FirecrawlProvider, extractAbortMs } from './firecrawl.js';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -24,16 +24,54 @@ describe('FirecrawlProvider.extract', () => {
     );
   });
 
-  it('aborts a stalled extraction request', async () => {
-    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
-      new Promise<never>((_resolve, reject) => {
-        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason));
-      }),
+  // A page that uses its full server-side render budget must still be able to
+  // answer: if the client abort fires at the same deadline it always wins, the
+  // successful response is unreachable, and two such pages open the caller's
+  // Firecrawl cooldown for the rest of the scrape. `AbortSignal.timeout` uses
+  // an internal Node timer that fake timers do not drive, so the invariant is
+  // asserted on the deadline function and its wiring rather than by waiting.
+  it('gives the client abort deadline headroom over the server render budget', () => {
+    expect(extractAbortMs(30_000)).toBeGreaterThan(30_000);
+    expect(extractAbortMs(30_000)).toBe(35_000);
+    expect(extractAbortMs()).toBe(35_000);
+    expect(extractAbortMs(1_000)).toBe(6_000);
+  });
+
+  it('wires an abort signal onto the extract request', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { extract: { price: 1 } } }), { status: 200 }),
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(
-      new FirecrawlProvider('test-key').extract('https://retailer.example/p/bread', schema, { timeout: 5 }),
-    ).rejects.toThrow();
+    await new FirecrawlProvider('test-key').extract('https://retailer.example/p/bread', schema, { timeout: 1_000 });
+
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect((JSON.parse(String(init.body)) as { timeout: number }).timeout).toBe(1_000);
+  });
+
+  // A successful call that found nothing is a PAGE outcome, not an outage —
+  // returning empty lets the caller record `missing-price` and move to the next
+  // candidate URL instead of accruing a provider-outage streak.
+  it('returns empty rather than throwing when a successful response has no extract', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { metadata: {} } }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await new FirecrawlProvider('test-key').extract('https://retailer.example/p/bread', schema);
+    expect(result.data).toEqual({});
+  });
+
+  it('sends a User-Agent on extract requests', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { extract: { price: 1 } } }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await new FirecrawlProvider('test-key').extract('https://retailer.example/p/bread', schema);
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).toMatchObject({
+      'User-Agent': 'worldmonitor-consumer-prices/1.0',
+    });
   });
 });

--- a/consumer-prices-core/src/acquisition/firecrawl.test.ts
+++ b/consumer-prices-core/src/acquisition/firecrawl.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FirecrawlProvider } from './firecrawl.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const schema = {
+  fields: {
+    productName: { type: 'string' as const, description: 'Product title' },
+    price: { type: 'number' as const, description: 'Retail price' },
+  },
+};
+
+describe('FirecrawlProvider.extract', () => {
+  it('treats an unsuccessful HTTP-200 response as a provider error', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: false, error: 'extract quota exhausted' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(new FirecrawlProvider('test-key').extract('https://retailer.example/p/bread', schema)).rejects.toThrow(
+      'extract quota exhausted',
+    );
+  });
+
+  it('aborts a stalled extraction request', async () => {
+    const fetchMock = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<never>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason));
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      new FirecrawlProvider('test-key').extract('https://retailer.example/p/bread', schema, { timeout: 5 }),
+    ).rejects.toThrow();
+  });
+});

--- a/consumer-prices-core/src/acquisition/firecrawl.ts
+++ b/consumer-prices-core/src/acquisition/firecrawl.ts
@@ -24,6 +24,24 @@ interface FirecrawlExtractResponse {
   error?: string;
 }
 
+/** Transport headroom added to a server-side render budget. */
+export const ABORT_HEADROOM_MS = 5_000;
+
+/**
+ * Client abort deadline for an extraction call.
+ *
+ * Must be strictly greater than the render budget sent in the request body:
+ * the client clock starts before the request leaves the process and also
+ * covers DNS, TLS, Firecrawl's queueing and the response transfer, so with
+ * equal deadlines the client always wins. A page that uses its full render
+ * allowance would then be aborted before its successful response could
+ * arrive, Firecrawl's own timeout error would be unreachable, and two such
+ * pages open the caller's per-scrape Firecrawl cooldown.
+ */
+export function extractAbortMs(timeoutMs?: number): number {
+  return (timeoutMs ?? 30_000) + ABORT_HEADROOM_MS;
+}
+
 export class FirecrawlProvider implements AcquisitionProvider {
   readonly name = 'firecrawl' as const;
 
@@ -35,6 +53,7 @@ export class FirecrawlProvider implements AcquisitionProvider {
     return {
       Authorization: `Bearer ${this.apiKey}`,
       'Content-Type': 'application/json',
+      'User-Agent': 'worldmonitor-consumer-prices/1.0',
     };
   }
 
@@ -119,13 +138,20 @@ export class FirecrawlProvider implements AcquisitionProvider {
         extract: { schema: jsonSchema, ...(schema.prompt ? { prompt: schema.prompt } : {}) },
         timeout: opts.timeout ?? 30_000,
       }),
-      signal: AbortSignal.timeout(opts.timeout ?? 30_000),
+      signal: AbortSignal.timeout(extractAbortMs(opts.timeout)),
     });
 
     if (!resp.ok) throw new Error(`Firecrawl extract failed: HTTP ${resp.status}`);
 
     const data = (await resp.json()) as FirecrawlExtractResponse;
-    if (!data.success || !data.data || !data.data.extract) {
+    // Throw ONLY for a provider-side failure (quota exhausted, rate limited,
+    // bad request) — those are transport conditions the caller's cooldown
+    // should count. A successful call that simply found nothing to extract is
+    // a PAGE-level outcome: return empty so the caller records `missing-price`
+    // and moves to the next candidate URL without accruing an outage streak.
+    // Conflating the two lets two ordinary no-product pages disable Firecrawl
+    // for the rest of the scrape, on every retailer, not just opted-in ones.
+    if (!data.success) {
       throw new Error(`Firecrawl extract error: ${data.error ?? 'unknown'}`);
     }
 

--- a/consumer-prices-core/src/acquisition/firecrawl.ts
+++ b/consumer-prices-core/src/acquisition/firecrawl.ts
@@ -21,6 +21,7 @@ interface FirecrawlExtractResponse {
     extract?: Record<string, unknown>;
     metadata?: Record<string, unknown>;
   };
+  error?: string;
 }
 
 export class FirecrawlProvider implements AcquisitionProvider {
@@ -115,11 +116,15 @@ export class FirecrawlProvider implements AcquisitionProvider {
         extract: { schema: jsonSchema, ...(schema.prompt ? { prompt: schema.prompt } : {}) },
         timeout: opts.timeout ?? 30_000,
       }),
+      signal: AbortSignal.timeout(opts.timeout ?? 30_000),
     });
 
     if (!resp.ok) throw new Error(`Firecrawl extract failed: HTTP ${resp.status}`);
 
     const data = (await resp.json()) as FirecrawlExtractResponse;
+    if (!data.success || !data.data || !data.data.extract) {
+      throw new Error(`Firecrawl extract error: ${data.error ?? 'unknown'}`);
+    }
 
     return {
       url,

--- a/consumer-prices-core/src/acquisition/firecrawl.ts
+++ b/consumer-prices-core/src/acquisition/firecrawl.ts
@@ -102,9 +102,12 @@ export class FirecrawlProvider implements AcquisitionProvider {
       properties: Object.fromEntries(
         Object.entries(schema.fields).map(([k, v]) => [
           k,
-          { type: v.type, description: v.description },
+          { type: v.nullable ? [v.type, 'null'] : v.type, description: v.description },
         ]),
       ),
+      ...(Object.values(schema.fields).some((field) => field.required !== undefined)
+        ? { required: Object.entries(schema.fields).filter(([, field]) => field.required !== false).map(([key]) => key) }
+        : {}),
     };
 
     const resp = await fetch(`${this.baseUrl}/scrape`, {

--- a/consumer-prices-core/src/acquisition/types.ts
+++ b/consumer-prices-core/src/acquisition/types.ts
@@ -17,7 +17,15 @@ export interface SearchOptions {
 }
 
 export interface ExtractSchema {
-  fields: Record<string, { description: string; type: 'string' | 'number' | 'boolean' | 'array' }>;
+  fields: Record<
+    string,
+    {
+      description: string;
+      type: 'string' | 'number' | 'boolean' | 'array';
+      required?: boolean;
+      nullable?: boolean;
+    }
+  >;
   prompt?: string;
 }
 

--- a/consumer-prices-core/src/acquisition/types.ts
+++ b/consumer-prices-core/src/acquisition/types.ts
@@ -13,6 +13,7 @@ export interface SearchOptions {
   includeDomains?: string[];
   startPublishedDate?: string;
   type?: 'keyword' | 'neural';
+  timeout?: number;
 }
 
 export interface ExtractSchema {

--- a/consumer-prices-core/src/adapters/search.recovery.test.ts
+++ b/consumer-prices-core/src/adapters/search.recovery.test.ts
@@ -164,7 +164,10 @@ describe('SearchAdapter recovery path', () => {
     expect(firecrawl.extract).toHaveBeenCalledTimes(3);
   });
 
-  it('keeps Exa extraction cooldown independent from successful discovery', async () => {
+  // An Exa EXTRACTION cooldown must not abort the target: Exa is only the
+  // fallback there, and Firecrawl — the primary extractor — is often healthy.
+  // Aborting would turn a fallback outage into a whole-basket loss.
+  it('keeps discovery and Firecrawl running after the Exa extraction cooldown opens', async () => {
     const exa = {
       search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
       extract: vi.fn().mockRejectedValue(new Error('Exa extraction timeout')),
@@ -173,14 +176,43 @@ describe('SearchAdapter recovery path', () => {
       extract: vi.fn().mockResolvedValue({ data: {} }),
     } as unknown as FirecrawlProvider;
     const adapter = new SearchAdapter(exa, firecrawl);
-    const context = makeContext(makeConfig());
+    const context = makeContext(makeConfig({ allowedHosts: ['www.coldstorage.com.sg'] }));
 
     await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('failed extraction');
     await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('failed extraction');
-    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('extraction cooldown');
+    // Third target still runs discovery and still reaches Firecrawl; only the
+    // cooled-down fallback is skipped.
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('failed extraction');
+
+    expect(exa.search).toHaveBeenCalledTimes(3);
+    expect(firecrawl.extract).toHaveBeenCalledTimes(3);
+    expect(exa.extract).toHaveBeenCalledTimes(2);
+  });
+
+  // Exa is the ONLY discovery provider, so its discovery cooldown does abort.
+  it('still aborts the target when the Exa discovery cooldown is open', async () => {
+    const exa = {
+      search: vi.fn().mockRejectedValue(new Error('Exa search HTTP 503')),
+      extract: vi.fn(),
+    } as unknown as ExaProvider;
+    const firecrawl = { extract: vi.fn() } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const context = makeContext(makeConfig({ allowedHosts: ['www.coldstorage.com.sg'] }));
+
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('Exa search failed');
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('Exa search failed');
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('discovery cooldown');
 
     expect(exa.search).toHaveBeenCalledTimes(2);
-    expect(exa.extract).toHaveBeenCalledTimes(2);
+  });
+
+  it('carries the provider error detail into the thrown discovery message', async () => {
+    const exa = { search: vi.fn().mockRejectedValue(new Error('Exa search HTTP 401 unauthorized')) } as unknown as ExaProvider;
+    const adapter = new SearchAdapter(exa, { extract: vi.fn() } as unknown as FirecrawlProvider);
+
+    await expect(
+      adapter.fetchTarget(makeContext(makeConfig({ allowedHosts: ['www.coldstorage.com.sg'] })), makeTarget()),
+    ).rejects.toThrow('HTTP 401 unauthorized');
   });
 
   it('does not rediscover after Firecrawl cooldown when no extraction fallback is configured', async () => {
@@ -244,10 +276,41 @@ describe('SearchAdapter recovery path', () => {
 
     expect(error).toBeInstanceOf(SearchTargetError);
     expect(error).toMatchObject({ rejectedCount: 1 });
-    expect((error as SearchTargetError).failures.map(({ reason }) => reason)).toEqual([
-      'validator-rejected',
-      'validator-rejected',
-    ]);
+    // One rejection, not two: the validator judged the PAGE wrong, and both
+    // extractors read the same page, so escalating would just double the cost.
+    expect((error as SearchTargetError).failures.map(({ reason }) => reason)).toEqual(['validator-rejected']);
+    expect(exa.extract).not.toHaveBeenCalled();
+  });
+
+  // rejected_count was structurally always 0 for non-pin search targets before
+  // this adapter change, so only opted-in retailers may start reporting it.
+  it('reports rejectedCount only for retailers that opted into strict validation', async () => {
+    // Use title-mismatch: it fires for every retailer regardless of strict
+    // mode, so `requireStrictValidator` is the only variable between the two.
+    const wrongProduct = {
+      data: { productName: 'Garden Sunflower Seeds 1kg', price: 9.95, currency: 'SGD', sizeText: '400g' },
+    };
+    const build = (requireStrictValidator: boolean) => {
+      const exa = {
+        search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+        extract: vi.fn().mockResolvedValue(wrongProduct),
+      } as unknown as ExaProvider;
+      const firecrawl = { extract: vi.fn().mockResolvedValue(wrongProduct) } as unknown as FirecrawlProvider;
+      return {
+        adapter: new SearchAdapter(exa, firecrawl),
+        context: makeContext(
+          makeConfig({ allowedHosts: ['www.coldstorage.com.sg'], requireStrictValidator, extractionFallback: 'none' }),
+        ),
+      };
+    };
+
+    const strict = build(true);
+    const strictErr = await strict.adapter.fetchTarget(strict.context, makeTarget()).catch((e: unknown) => e);
+    expect((strictErr as SearchTargetError).rejectedCount).toBe(1);
+
+    const shadow = build(false);
+    const shadowErr = await shadow.adapter.fetchTarget(shadow.context, makeTarget()).catch((e: unknown) => e);
+    expect((shadowErr as SearchTargetError).rejectedCount).toBe(0);
   });
 
   it('rejects a quantity-like price when the extractor omits sizeText', async () => {
@@ -521,6 +584,96 @@ describe('SearchAdapter recovery path', () => {
   it('pins the shipped Noon market scope in YAML', () => {
     expect(loadRetailerConfig('noon_sa').searchConfig?.urlPathMustContain).toEqual(['/saudi-en/']);
     expect(loadRetailerConfig('noon_grocery_ae').searchConfig?.urlPathMustContain).toEqual(['/uae-en/']);
+  });
+
+  // The opt-in boundary itself: without this, deleting the
+  // `extractionFallback === 'exa'` guard leaves the whole suite green while
+  // every non-opted-in retailer starts paying for a second provider.
+  it('never calls the fallback extractor when extractionFallback is none', async () => {
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+      extract: vi.fn().mockResolvedValue({ data: {} }),
+    } as unknown as ExaProvider;
+    const firecrawl = { extract: vi.fn().mockResolvedValue({ data: {} }) } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const context = makeContext(makeConfig({ allowedHosts: ['www.coldstorage.com.sg'], extractionFallback: 'none' }));
+
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('failed extraction');
+
+    expect(firecrawl.extract).toHaveBeenCalledOnce();
+    expect(exa.extract).not.toHaveBeenCalled();
+  });
+
+  it('rejects a strict-mode hit whose size is missing everywhere', async () => {
+    const extracted = { data: { productName: 'Fresh Bread', price: 4.95, currency: 'SGD' } };
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+      extract: vi.fn().mockResolvedValue(extracted),
+    } as unknown as ExaProvider;
+    const firecrawl = { extract: vi.fn().mockResolvedValue(extracted) } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const target = { ...makeTarget(), metadata: { ...makeTarget().metadata, canonicalName: 'Fresh Bread' } };
+
+    const error = await adapter
+      .fetchTarget(makeContext(makeConfig({ allowedHosts: ['www.coldstorage.com.sg'] })), target)
+      .catch((err: unknown) => err);
+
+    expect((error as SearchTargetError).failures.map(({ detail }) => detail)).toContain('missing-size');
+  });
+
+  it('rejects a foreign-currency page and does not escalate to the fallback', async () => {
+    const extracted = {
+      data: { productName: 'Meadows Enriched White Bread', price: 4.95, currency: 'AED', sizeText: '400g' },
+    };
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+      extract: vi.fn().mockResolvedValue(extracted),
+    } as unknown as ExaProvider;
+    const firecrawl = { extract: vi.fn().mockResolvedValue(extracted) } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+
+    const error = await adapter
+      .fetchTarget(makeContext(makeConfig({ allowedHosts: ['www.coldstorage.com.sg'] })), makeTarget())
+      .catch((err: unknown) => err);
+
+    expect((error as SearchTargetError).failures.map(({ reason }) => reason)).toEqual(['currency-mismatch']);
+    // The page is priced in AED; a second extractor reading it cannot help.
+    expect(exa.extract).not.toHaveBeenCalled();
+  });
+
+  it('rejects a strict-mode hit whose currency the extractor omitted', async () => {
+    const extracted = { data: { productName: 'Meadows Enriched White Bread', price: 4.95, sizeText: '400g' } };
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+      extract: vi.fn().mockResolvedValue(extracted),
+    } as unknown as ExaProvider;
+    const firecrawl = { extract: vi.fn().mockResolvedValue(extracted) } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+
+    const error = await adapter
+      .fetchTarget(makeContext(makeConfig({ allowedHosts: ['www.coldstorage.com.sg'] })), makeTarget())
+      .catch((err: unknown) => err);
+
+    expect((error as SearchTargetError).failures.map(({ detail }) => detail)).toEqual([
+      'missing-currency',
+      'missing-currency',
+    ]);
+  });
+
+  it("rejects a non-grocery JioMart /p/ URL under the shipped policy", async () => {
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://www.jiomart.com/p/electronics/television-55-inch/123' }]),
+    } as unknown as ExaProvider;
+    const firecrawl = { extract: vi.fn() } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const config = loadRetailerConfig('jiomart_in');
+    const target = {
+      ...makeTarget(),
+      metadata: { ...makeTarget().metadata, domain: 'www.jiomart.com', currency: 'INR' },
+    };
+
+    await expect(adapter.fetchTarget(makeContext(config), target)).rejects.toThrow('host/path check');
+    expect(firecrawl.extract).not.toHaveBeenCalled();
   });
 
   // Pins bypass discovery entirely, so a pin stored on a foreign storefront

--- a/consumer-prices-core/src/adapters/search.recovery.test.ts
+++ b/consumer-prices-core/src/adapters/search.recovery.test.ts
@@ -443,4 +443,108 @@ describe('SearchAdapter recovery path', () => {
       expect(firecrawl.extract).not.toHaveBeenCalled();
     }
   });
+
+  // noon.com serves several storefronts from one host pair. The route filters
+  // (`/p/`, `/now-product/`) are an OR, so they cannot also express "and only
+  // the SA storefront" — `urlPathMustContain` carries that market scope.
+  // Both fixture URLs are host-allowed and route-allowed here, so the locale
+  // segment is the only thing that can reject them.
+  function noonTarget() {
+    const target = makeTarget();
+    return { ...target, metadata: { ...target.metadata, domain: 'www.noon.com' } };
+  }
+
+  function noonConfig(market: string) {
+    const config = makeConfig({
+      allowedHosts: ['minutes.noon.com'],
+      urlPathContains: ['/p/', '/now-product/'],
+      urlPathMustContain: [market],
+      extractionFallback: 'none',
+    });
+    config.baseUrl = 'https://www.noon.com';
+    return config;
+  }
+
+  it('rejects cross-storefront Noon product URLs for the configured market', async () => {
+    for (const fixture of [
+      { slug: 'noon_sa', market: '/saudi-en/', foreign: 'uae-en' },
+      { slug: 'noon_grocery_ae', market: '/uae-en/', foreign: 'saudi-en' },
+    ]) {
+      const exa = {
+        search: vi.fn().mockResolvedValue([
+          { url: `https://www.noon.com/${fixture.foreign}/fresh-milk/N123/p/` },
+          { url: `https://minutes.noon.com/${fixture.foreign}/now-product/milk-1` },
+        ]),
+      } as unknown as ExaProvider;
+      const firecrawl = { extract: vi.fn() } as unknown as FirecrawlProvider;
+      const adapter = new SearchAdapter(exa, firecrawl);
+      const config = noonConfig(fixture.market);
+      config.slug = fixture.slug;
+
+      await expect(adapter.fetchTarget(makeContext(config), noonTarget())).rejects.toThrow('host/path check');
+      expect(firecrawl.extract, fixture.slug).not.toHaveBeenCalled();
+    }
+  });
+
+  it('still admits same-storefront Noon product URLs on both hosts', async () => {
+    for (const url of [
+      'https://www.noon.com/saudi-en/fresh-milk/N123/p/',
+      'https://minutes.noon.com/saudi-en/now-product/milk-1',
+    ]) {
+      const exa = { search: vi.fn().mockResolvedValue([{ url }]) } as unknown as ExaProvider;
+      const firecrawl = {
+        extract: vi.fn().mockResolvedValue({
+          data: { productName: 'Meadows Enriched White Bread', price: 4.95, currency: 'SGD', sizeText: '400g' },
+        }),
+      } as unknown as FirecrawlProvider;
+      const adapter = new SearchAdapter(exa, firecrawl);
+
+      const result = await adapter.fetchTarget(makeContext(noonConfig('/saudi-en/')), noonTarget());
+      expect(result.url, url).toBe(url);
+    }
+  });
+
+  // A locale segment in the query string must not satisfy the market scope.
+  it('matches the market segment against the pathname, not the query string', async () => {
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://www.noon.com/uae-en/milk/N1/p/?ref=/saudi-en/' }]),
+    } as unknown as ExaProvider;
+    const firecrawl = { extract: vi.fn() } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+
+    await expect(adapter.fetchTarget(makeContext(noonConfig('/saudi-en/')), noonTarget())).rejects.toThrow(
+      'host/path check',
+    );
+    expect(firecrawl.extract).not.toHaveBeenCalled();
+  });
+
+  it('pins the shipped Noon market scope in YAML', () => {
+    expect(loadRetailerConfig('noon_sa').searchConfig?.urlPathMustContain).toEqual(['/saudi-en/']);
+    expect(loadRetailerConfig('noon_grocery_ae').searchConfig?.urlPathMustContain).toEqual(['/uae-en/']);
+  });
+
+  // Pins bypass discovery entirely, so a pin stored on a foreign storefront
+  // while the scope was missing would keep being scraped directly.
+  it('drops a stored pin that points at another storefront', async () => {
+    const adapter = new SearchAdapter({} as unknown as ExaProvider, {} as unknown as FirecrawlProvider);
+    const config = loadRetailerConfig('noon_sa');
+    const context = makeContext(config);
+    const pinKey = 'essentials-sa:Eggs Fresh 12 Pack';
+
+    const foreign = await adapter.discoverTargets({
+      ...context,
+      pinnedUrls: new Map([[pinKey, { sourceUrl: 'https://minutes.noon.com/uae-en/now-product/eggs-1', productId: 'p1', matchId: 'm1' }]]),
+    } as unknown as AdapterContext);
+    const foreignTarget = foreign.find((t) => t.metadata?.canonicalName === 'Eggs Fresh 12 Pack');
+    expect(foreignTarget?.metadata?.direct).toBe(false);
+    expect(context.logger.warn).toHaveBeenCalledWith(expect.stringContaining('market scope'));
+
+    const native = await adapter.discoverTargets({
+      ...makeContext(config),
+      pinnedUrls: new Map([[pinKey, { sourceUrl: 'https://minutes.noon.com/saudi-en/now-product/eggs-1', productId: 'p1', matchId: 'm1' }]]),
+    } as unknown as AdapterContext);
+    const nativeTarget = native.find((t) => t.metadata?.canonicalName === 'Eggs Fresh 12 Pack');
+    expect(nativeTarget?.metadata?.direct).toBe(true);
+    expect(nativeTarget?.url).toBe('https://minutes.noon.com/saudi-en/now-product/eggs-1');
+  });
 });

--- a/consumer-prices-core/src/adapters/search.recovery.test.ts
+++ b/consumer-prices-core/src/adapters/search.recovery.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SearchAdapter, SearchTargetError } from './search.js';
+import type { ExaProvider } from '../acquisition/exa.js';
+import type { FirecrawlProvider } from '../acquisition/firecrawl.js';
+import type { AdapterContext } from './types.js';
+import type { RetailerConfig } from '../config/types.js';
+import { loadRetailerConfig } from '../config/loader.js';
+
+function makeConfig(overrides: Partial<RetailerConfig['searchConfig']> = {}): RetailerConfig {
+  return {
+    slug: 'coldstorage_sg',
+    name: 'Cold Storage Singapore',
+    marketCode: 'sg',
+    currencyCode: 'SGD',
+    adapter: 'search',
+    baseUrl: 'https://coldstorage.com.sg',
+    enabled: true,
+    discovery: { mode: 'search', seeds: [], maxPages: 20 },
+    searchConfig: {
+      numResults: 3,
+      extractionFallback: 'exa',
+      requireStrictValidator: true,
+      ...overrides,
+    },
+  } as RetailerConfig;
+}
+
+function makeContext(config: RetailerConfig): AdapterContext {
+  return {
+    config,
+    runId: 'run-1',
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+}
+
+function makeTarget() {
+  return {
+    id: 'bread_white',
+    url: 'https://coldstorage.com.sg',
+    category: 'bread',
+    metadata: {
+      canonicalName: 'White Sandwich Bread 400g',
+      domain: 'coldstorage.com.sg',
+      currency: 'SGD',
+      basketSlug: 'essentials-sg',
+      itemConstraints: { baseUnit: 'g', minBaseQty: 350, maxBaseQty: 450 },
+      direct: false,
+    },
+  };
+}
+
+describe('SearchAdapter recovery path', () => {
+  it('falls back to Exa when Firecrawl confuses quantity with price', async () => {
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+      extract: vi.fn().mockResolvedValue({
+        data: {
+          productName: 'Meadows Enriched White Bread',
+          price: 4.95,
+          currency: 'SGD',
+          inStock: true,
+          sizeText: '400g',
+        },
+      }),
+    } as unknown as ExaProvider;
+    const firecrawl = {
+      extract: vi.fn().mockResolvedValue({
+        data: {
+          productName: 'Meadows Enriched White Bread',
+          price: 400,
+          currency: 'SGD',
+          inStock: true,
+          sizeText: '400g',
+        },
+      }),
+    } as unknown as FirecrawlProvider;
+
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const config = makeConfig({ allowedHosts: ['www.coldstorage.com.sg'] });
+    const context = makeContext(config);
+    const result = await adapter.fetchTarget(context, makeTarget());
+    const products = await adapter.parseListing(context, result);
+
+    expect(firecrawl.extract).toHaveBeenCalledOnce();
+    expect(exa.extract).toHaveBeenCalledOnce();
+    expect(exa.search).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ includeDomains: ['coldstorage.com.sg', 'www.coldstorage.com.sg'] }),
+    );
+    expect(products[0]?.price).toBe(4.95);
+    expect(products[0]?.rawPayload.extractionProvider).toBe('exa');
+  });
+
+  it('does not retry a failed pinned URL when Exa returns it again', async () => {
+    const duplicateUrl = 'https://coldstorage.com.sg/en/p/bread/i/1.html';
+    const replacementUrl = 'https://coldstorage.com.sg/en/p/bread/i/2.html';
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: duplicateUrl }, { url: replacementUrl }]),
+    } as unknown as ExaProvider;
+    const firecrawl = {
+      extract: vi
+        .fn()
+        .mockResolvedValueOnce({ data: {} })
+        .mockResolvedValueOnce({
+          data: {
+            productName: 'Meadows Enriched White Bread',
+            price: 4.95,
+            currency: 'SGD',
+            sizeText: '400g',
+          },
+        }),
+    } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const context = makeContext(makeConfig({ extractionFallback: 'none', requireStrictValidator: false }));
+    const target = {
+      ...makeTarget(),
+      url: duplicateUrl,
+      metadata: { ...makeTarget().metadata, direct: true },
+    };
+
+    const result = await adapter.fetchTarget(context, target);
+
+    expect(firecrawl.extract).toHaveBeenCalledTimes(2);
+    expect(result.url).toBe(replacementUrl);
+  });
+
+  it('opens a Firecrawl cooldown after repeated provider errors while keeping fallback bounded', async () => {
+    const exa = {
+      search: vi.fn().mockResolvedValue([
+        { url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' },
+        { url: 'https://coldstorage.com.sg/en/p/bread/i/2.html' },
+        { url: 'https://coldstorage.com.sg/en/p/bread/i/3.html' },
+      ]),
+      extract: vi.fn().mockResolvedValue({ data: {} }),
+    } as unknown as ExaProvider;
+    const firecrawl = {
+      extract: vi.fn().mockRejectedValue(new Error('HTTP 503')),
+    } as unknown as FirecrawlProvider;
+
+    const adapter = new SearchAdapter(exa, firecrawl);
+    await expect(adapter.fetchTarget(makeContext(makeConfig()), makeTarget())).rejects.toThrow('failed extraction');
+
+    expect(firecrawl.extract).toHaveBeenCalledTimes(2);
+    expect(exa.extract).toHaveBeenCalledTimes(3);
+  });
+
+  it('opens an Exa cooldown after repeated fallback provider errors', async () => {
+    const exa = {
+      search: vi.fn().mockResolvedValue([
+        { url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' },
+        { url: 'https://coldstorage.com.sg/en/p/bread/i/2.html' },
+        { url: 'https://coldstorage.com.sg/en/p/bread/i/3.html' },
+      ]),
+      extract: vi.fn().mockRejectedValue(new Error('Exa HTTP 503')),
+    } as unknown as ExaProvider;
+    const firecrawl = {
+      extract: vi.fn().mockResolvedValue({ data: {} }),
+    } as unknown as FirecrawlProvider;
+
+    const adapter = new SearchAdapter(exa, firecrawl);
+    await expect(adapter.fetchTarget(makeContext(makeConfig()), makeTarget())).rejects.toThrow('failed extraction');
+
+    expect(exa.extract).toHaveBeenCalledTimes(2);
+    expect(firecrawl.extract).toHaveBeenCalledTimes(3);
+  });
+
+  it('opens an Exa discovery cooldown after repeated search errors', async () => {
+    const exa = {
+      search: vi.fn().mockRejectedValue(new Error('Exa search HTTP 503')),
+    } as unknown as ExaProvider;
+    const firecrawl = { extract: vi.fn() } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const context = makeContext(makeConfig({ extractionFallback: 'none' }));
+
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toMatchObject({
+      name: 'SearchTargetError',
+      rejectedCount: 0,
+    });
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toMatchObject({
+      name: 'SearchTargetError',
+      rejectedCount: 0,
+    });
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('discovery cooldown');
+
+    expect(exa.search).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a strict final rejection once all providers return the wrong size', async () => {
+    const wrongSize = {
+      data: {
+        productName: 'Meadows Enriched White Bread',
+        price: 9.95,
+        currency: 'SGD',
+        sizeText: '2kg',
+      },
+    };
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+      extract: vi.fn().mockResolvedValue(wrongSize),
+    } as unknown as ExaProvider;
+    const firecrawl = {
+      extract: vi.fn().mockResolvedValue(wrongSize),
+    } as unknown as FirecrawlProvider;
+
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const error = await adapter.fetchTarget(makeContext(makeConfig()), makeTarget()).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(SearchTargetError);
+    expect(error).toMatchObject({ rejectedCount: 1 });
+    expect((error as SearchTargetError).failures.map(({ reason }) => reason)).toEqual([
+      'validator-rejected',
+      'validator-rejected',
+    ]);
+  });
+
+  it('keeps shadow-mode admission for an unaffected retailer when strict validation is off', async () => {
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+    } as unknown as ExaProvider;
+    const firecrawl = {
+      extract: vi.fn().mockResolvedValue({
+        data: {
+          productName: 'Meadows Enriched White Bread',
+          price: 9.95,
+          currency: 'SGD',
+          sizeText: '2kg',
+        },
+      }),
+    } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const context = makeContext(makeConfig({ extractionFallback: 'none', requireStrictValidator: false }));
+
+    const result = await adapter.fetchTarget(context, makeTarget());
+    const products = await adapter.parseListing(context, result);
+
+    expect(products[0]?.price).toBe(9.95);
+    expect(context.logger.warn).toHaveBeenCalledWith(expect.stringContaining('[search:shadow-reject]'));
+  });
+
+  it('loads the diagnosed retailer route policies from YAML', () => {
+    const recoveryPolicies = [
+      ['jiomart_in', '/p/groceries/', 'www.jiomart.com'],
+      ['noon_grocery_ae', '/uae-en/', 'minutes.noon.com'],
+      ['noon_sa', '/saudi-en/', 'minutes.noon.com'],
+      ['carrefour_sa', '/p/', 'www.carrefourksa.com'],
+      ['coldstorage_sg', '/p/', 'www.coldstorage.com.sg'],
+    ] as const;
+
+    for (const [slug, path, alias] of recoveryPolicies) {
+      const searchConfig = loadRetailerConfig(slug).searchConfig;
+      expect(searchConfig?.extractionFallback, slug).toBe('exa');
+      expect(searchConfig?.requireStrictValidator, slug).toBe(true);
+      expect(searchConfig?.urlPathContains, slug).toBe(path);
+      expect(searchConfig?.allowedHosts, slug).toContain(alias);
+    }
+
+    expect(loadRetailerConfig('carrefour_ae').searchConfig?.allowedHosts).toContain('carrefouruae.com');
+  });
+
+  it('admits representative product URLs through each diagnosed host/path policy', async () => {
+    const fixtures = [
+      {
+        slug: 'jiomart_in',
+        baseUrl: 'https://www.jiomart.com',
+        marketCode: 'in',
+        currencyCode: 'INR',
+        path: '/p/groceries/',
+        alias: 'www.jiomart.com',
+        url: 'https://www.jiomart.com/p/groceries/milk/1',
+      },
+      {
+        slug: 'noon_grocery_ae',
+        baseUrl: 'https://www.noon.com',
+        marketCode: 'ae',
+        currencyCode: 'AED',
+        path: '/uae-en/',
+        alias: 'minutes.noon.com',
+        url: 'https://minutes.noon.com/uae-en/now-product/milk-1',
+      },
+      {
+        slug: 'noon_sa',
+        baseUrl: 'https://www.noon.com/saudi-en',
+        marketCode: 'sa',
+        currencyCode: 'SAR',
+        path: '/saudi-en/',
+        alias: 'minutes.noon.com',
+        url: 'https://minutes.noon.com/saudi-en/now-product/milk-1',
+      },
+      {
+        slug: 'carrefour_sa',
+        baseUrl: 'https://www.carrefourksa.com/mafsau/en',
+        marketCode: 'sa',
+        currencyCode: 'SAR',
+        path: '/p/',
+        alias: 'www.carrefourksa.com',
+        url: 'https://www.carrefourksa.com/p/milk/1',
+      },
+      {
+        slug: 'coldstorage_sg',
+        baseUrl: 'https://coldstorage.com.sg',
+        marketCode: 'sg',
+        currencyCode: 'SGD',
+        path: '/p/',
+        alias: 'www.coldstorage.com.sg',
+        url: 'https://www.coldstorage.com.sg/en/p/milk/i/1.html',
+      },
+    ] as const;
+
+    for (const fixture of fixtures) {
+      const config = {
+        ...makeConfig(),
+        slug: fixture.slug,
+        baseUrl: fixture.baseUrl,
+        marketCode: fixture.marketCode,
+        currencyCode: fixture.currencyCode,
+        searchConfig: {
+          numResults: 1,
+          urlPathContains: fixture.path,
+          allowedHosts: [fixture.alias],
+          extractionFallback: 'none' as const,
+          requireStrictValidator: true,
+        },
+      } as RetailerConfig;
+      const exa = {
+        search: vi.fn().mockResolvedValue([{ url: fixture.url }]),
+      } as unknown as ExaProvider;
+      const firecrawl = {
+        extract: vi.fn().mockResolvedValue({
+          data: {
+            productName: 'Fresh Milk 1L',
+            price: 5.95,
+            currency: fixture.currencyCode,
+            sizeText: '1L',
+          },
+        }),
+      } as unknown as FirecrawlProvider;
+      const adapter = new SearchAdapter(exa, firecrawl);
+      const context = makeContext(config);
+      const target = {
+        ...makeTarget(),
+        url: fixture.baseUrl,
+        category: 'dairy',
+        metadata: {
+          ...makeTarget().metadata,
+          canonicalName: 'Milk 1L',
+          domain: new URL(fixture.baseUrl).hostname,
+          currency: fixture.currencyCode,
+          itemConstraints: { baseUnit: 'ml', minBaseQty: 500, maxBaseQty: 1500 },
+          direct: false,
+        },
+      };
+
+      const result = await adapter.fetchTarget(context, target);
+
+      expect(result.url, fixture.slug).toBe(fixture.url);
+    }
+  });
+});

--- a/consumer-prices-core/src/adapters/search.recovery.test.ts
+++ b/consumer-prices-core/src/adapters/search.recovery.test.ts
@@ -164,6 +164,43 @@ describe('SearchAdapter recovery path', () => {
     expect(firecrawl.extract).toHaveBeenCalledTimes(3);
   });
 
+  it('keeps Exa extraction cooldown independent from successful discovery', async () => {
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+      extract: vi.fn().mockRejectedValue(new Error('Exa extraction timeout')),
+    } as unknown as ExaProvider;
+    const firecrawl = {
+      extract: vi.fn().mockResolvedValue({ data: {} }),
+    } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const context = makeContext(makeConfig());
+
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('failed extraction');
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('failed extraction');
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('extraction cooldown');
+
+    expect(exa.search).toHaveBeenCalledTimes(2);
+    expect(exa.extract).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not rediscover after Firecrawl cooldown when no extraction fallback is configured', async () => {
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+    } as unknown as ExaProvider;
+    const firecrawl = {
+      extract: vi.fn().mockRejectedValue(new Error('Firecrawl HTTP 503')),
+    } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const context = makeContext(makeConfig({ extractionFallback: 'none' }));
+
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('failed extraction');
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('failed extraction');
+    await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('Firecrawl extraction cooldown');
+
+    expect(exa.search).toHaveBeenCalledTimes(2);
+    expect(firecrawl.extract).toHaveBeenCalledTimes(2);
+  });
+
   it('opens an Exa discovery cooldown after repeated search errors', async () => {
     const exa = {
       search: vi.fn().mockRejectedValue(new Error('Exa search HTTP 503')),

--- a/consumer-prices-core/src/adapters/search.recovery.test.ts
+++ b/consumer-prices-core/src/adapters/search.recovery.test.ts
@@ -250,6 +250,31 @@ describe('SearchAdapter recovery path', () => {
     ]);
   });
 
+  it('rejects a quantity-like price when the extractor omits sizeText', async () => {
+    const extracted = {
+      data: {
+        productName: 'Meadows Enriched White Bread',
+        price: 400,
+        currency: 'SGD',
+      },
+    };
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
+      extract: vi.fn().mockResolvedValue(extracted),
+    } as unknown as ExaProvider;
+    const firecrawl = {
+      extract: vi.fn().mockResolvedValue(extracted),
+    } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const error = await adapter.fetchTarget(makeContext(makeConfig()), makeTarget()).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(SearchTargetError);
+    expect((error as SearchTargetError).failures.map(({ reason }) => reason)).toEqual([
+      'quantity-as-price',
+      'quantity-as-price',
+    ]);
+  });
+
   it('keeps shadow-mode admission for an unaffected retailer when strict validation is off', async () => {
     const exa = {
       search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/1.html' }]),
@@ -277,8 +302,8 @@ describe('SearchAdapter recovery path', () => {
   it('loads the diagnosed retailer route policies from YAML', () => {
     const recoveryPolicies = [
       ['jiomart_in', '/p/groceries/', 'www.jiomart.com'],
-      ['noon_grocery_ae', '/uae-en/', 'minutes.noon.com'],
-      ['noon_sa', '/saudi-en/', 'minutes.noon.com'],
+      ['noon_grocery_ae', ['/p/', '/now-product/'], 'minutes.noon.com'],
+      ['noon_sa', ['/p/', '/now-product/'], 'minutes.noon.com'],
       ['carrefour_sa', '/p/', 'www.carrefourksa.com'],
       ['coldstorage_sg', '/p/', 'www.coldstorage.com.sg'],
     ] as const;
@@ -287,7 +312,7 @@ describe('SearchAdapter recovery path', () => {
       const searchConfig = loadRetailerConfig(slug).searchConfig;
       expect(searchConfig?.extractionFallback, slug).toBe('exa');
       expect(searchConfig?.requireStrictValidator, slug).toBe(true);
-      expect(searchConfig?.urlPathContains, slug).toBe(path);
+      expect(searchConfig?.urlPathContains, slug).toEqual(path);
       expect(searchConfig?.allowedHosts, slug).toContain(alias);
     }
 
@@ -310,7 +335,7 @@ describe('SearchAdapter recovery path', () => {
         baseUrl: 'https://www.noon.com',
         marketCode: 'ae',
         currencyCode: 'AED',
-        path: '/uae-en/',
+        path: ['/p/', '/now-product/'],
         alias: 'minutes.noon.com',
         url: 'https://minutes.noon.com/uae-en/now-product/milk-1',
       },
@@ -319,7 +344,7 @@ describe('SearchAdapter recovery path', () => {
         baseUrl: 'https://www.noon.com/saudi-en',
         marketCode: 'sa',
         currencyCode: 'SAR',
-        path: '/saudi-en/',
+        path: ['/p/', '/now-product/'],
         alias: 'minutes.noon.com',
         url: 'https://minutes.noon.com/saudi-en/now-product/milk-1',
       },
@@ -390,6 +415,32 @@ describe('SearchAdapter recovery path', () => {
       const result = await adapter.fetchTarget(context, target);
 
       expect(result.url, fixture.slug).toBe(fixture.url);
+    }
+  });
+
+  it('rejects Noon search and category routes before extraction', async () => {
+    for (const fixture of [
+      { slug: 'noon_grocery_ae', locale: 'uae-en' },
+      { slug: 'noon_sa', locale: 'saudi-en' },
+    ]) {
+      const exa = {
+        search: vi.fn().mockResolvedValue([
+          { url: `https://minutes.noon.com/${fixture.locale}/search?q=milk` },
+          { url: `https://minutes.noon.com/${fixture.locale}/category/grocery` },
+        ]),
+      } as unknown as ExaProvider;
+      const firecrawl = { extract: vi.fn() } as unknown as FirecrawlProvider;
+      const adapter = new SearchAdapter(exa, firecrawl);
+      const config = makeConfig({
+        allowedHosts: ['minutes.noon.com'],
+        urlPathContains: ['/p/', '/now-product/'],
+        extractionFallback: 'none',
+      });
+      config.slug = fixture.slug;
+      const context = makeContext(config);
+
+      await expect(adapter.fetchTarget(context, makeTarget())).rejects.toThrow('host/path check');
+      expect(firecrawl.extract).not.toHaveBeenCalled();
     }
   });
 });

--- a/consumer-prices-core/src/adapters/search.smoke.ts
+++ b/consumer-prices-core/src/adapters/search.smoke.ts
@@ -11,9 +11,24 @@ import type { AdapterContext } from './types.js';
 
 const RETAILERS = ['carrefour_ae', 'spinneys_ae', 'lulu_ae', 'noon_grocery_ae'];
 const ITEMS = [
-  { id: 'eggs', canonicalName: 'Eggs Fresh 12 Pack', category: 'dairy-eggs' },
-  { id: 'milk', canonicalName: 'Full Fat Fresh Milk 1L', category: 'dairy-eggs' },
-  { id: 'tomatoes', canonicalName: 'Tomatoes Fresh 1kg', category: 'produce' },
+  {
+    id: 'eggs',
+    canonicalName: 'Eggs Fresh 12 Pack',
+    category: 'dairy-eggs',
+    itemConstraints: { baseUnit: 'ct', minBaseQty: 12, maxBaseQty: 12 },
+  },
+  {
+    id: 'milk',
+    canonicalName: 'Full Fat Fresh Milk 1L',
+    category: 'dairy-eggs',
+    itemConstraints: { baseUnit: 'ml', minBaseQty: 500, maxBaseQty: 1500 },
+  },
+  {
+    id: 'tomatoes',
+    canonicalName: 'Tomatoes Fresh 1kg',
+    category: 'produce',
+    itemConstraints: { baseUnit: 'g', minBaseQty: 500, maxBaseQty: 1500 },
+  },
 ];
 
 const exaKey = (process.env.EXA_API_KEYS || process.env.EXA_API_KEY || '').split(/[\n,]+/)[0].trim();
@@ -23,8 +38,6 @@ if (!exaKey || !fcKey) {
   console.error('Missing EXA_API_KEYS or FIRECRAWL_API_KEY');
   process.exit(1);
 }
-
-const adapter = new SearchAdapter(new ExaProvider(exaKey), new FirecrawlProvider(fcKey));
 
 const logger = {
   info: (msg: string) => console.log(msg),
@@ -39,6 +52,9 @@ let failed = 0;
 for (const slug of RETAILERS) {
   const retailerCfg = loadRetailerConfig(slug);
   const domain = new URL(retailerCfg.baseUrl).hostname;
+  // Provider cooldowns are scoped to one retailer scrape. A fresh adapter
+  // keeps an outage in one retailer from suppressing another retailer's probes.
+  const adapter = new SearchAdapter(new ExaProvider(exaKey), new FirecrawlProvider(fcKey));
 
   const ctx: AdapterContext = {
     config: retailerCfg,
@@ -61,6 +77,8 @@ for (const slug of RETAILERS) {
         domain,
         basketSlug: 'essentials_ae',
         currency: retailerCfg.currencyCode,
+        itemConstraints: item.itemConstraints,
+        direct: false,
       },
     };
 

--- a/consumer-prices-core/src/adapters/search.test.ts
+++ b/consumer-prices-core/src/adapters/search.test.ts
@@ -195,4 +195,20 @@ describe('looksLikeQuantityAsPrice', () => {
     expect(looksLikeQuantityAsPrice(4.95, '500g', { baseUnit: 'g' })).toBe(false);
     expect(looksLikeQuantityAsPrice(12, '12 ct', { baseUnit: 'ct' })).toBe(false);
   });
+
+  // The canonical-name fallback must fire whenever sizeText does not PARSE,
+  // not only when it is absent — `??` would let these through.
+  it('falls back to the canonical size when sizeText is blank or unparseable', () => {
+    expect(looksLikeQuantityAsPrice(400, '', { baseUnit: 'g' }, 'White Bread 400g')).toBe(true);
+    expect(looksLikeQuantityAsPrice(400, '   ', { baseUnit: 'g' }, 'White Bread 400g')).toBe(true);
+    // `gm` and `pack` are absent from UNIT_MAP, so parseSize returns null.
+    expect(looksLikeQuantityAsPrice(400, '400 gm', { baseUnit: 'g' }, 'White Bread 400g')).toBe(true);
+    expect(looksLikeQuantityAsPrice(400, '24 pack', { baseUnit: 'g' }, 'White Bread 400g')).toBe(true);
+  });
+
+  it('still prefers a parseable sizeText over the canonical name', () => {
+    // Real 2kg pack priced 400: the page size disagrees with the price, so this
+    // is a genuine price, not an echo — the canonical 400g must not override it.
+    expect(looksLikeQuantityAsPrice(400, '2kg', { baseUnit: 'g' }, 'White Bread 400g')).toBe(false);
+  });
 });

--- a/consumer-prices-core/src/adapters/search.test.ts
+++ b/consumer-prices-core/src/adapters/search.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { isTitlePlausible, isAllowedHost, normalizePathFilters, matchesAnyPathFilter } from './search.js';
+import {
+  isTitlePlausible,
+  isAllowedHost,
+  normalizeAllowedHosts,
+  normalizePathFilters,
+  matchesAnyPathFilter,
+  looksLikeQuantityAsPrice,
+} from './search.js';
 
 describe('isAllowedHost', () => {
   it('accepts exact domain match', () => {
@@ -24,6 +31,20 @@ describe('isAllowedHost', () => {
   it('handles malformed URLs gracefully', () => {
     expect(isAllowedHost('not-a-url', 'noon.com')).toBe(false);
     expect(isAllowedHost('', 'noon.com')).toBe(false);
+  });
+
+  it('accepts only explicitly configured host aliases', () => {
+    expect(isAllowedHost('https://minutes.noon.com/uae-en/now-product/ABC', ['www.noon.com', 'minutes.noon.com'])).toBe(true);
+    expect(isAllowedHost('https://evil-noon.com/uae-en/now-product/ABC', ['www.noon.com', 'minutes.noon.com'])).toBe(false);
+  });
+});
+
+describe('normalizeAllowedHosts', () => {
+  it('keeps the base host, removes duplicates, and normalizes aliases', () => {
+    expect(normalizeAllowedHosts('www.noon.com', [' minutes.noon.com ', 'www.noon.com'])).toEqual([
+      'www.noon.com',
+      'minutes.noon.com',
+    ]);
   });
 });
 
@@ -120,5 +141,17 @@ describe('matchesAnyPathFilter', () => {
     expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/promocoes/semana', filters)).toBe(true);
     expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/pages/about', filters)).toBe(true);
     expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/popular/today', filters)).toBe(true);
+  });
+});
+
+describe('looksLikeQuantityAsPrice', () => {
+  it('rejects a quantity echoed as a price for weighted products', () => {
+    expect(looksLikeQuantityAsPrice(400, '400g', { baseUnit: 'g' })).toBe(true);
+    expect(looksLikeQuantityAsPrice(1000, '1kg', { baseUnit: 'g' })).toBe(true);
+  });
+
+  it('does not reject normal prices or count-based products', () => {
+    expect(looksLikeQuantityAsPrice(4.95, '500g', { baseUnit: 'g' })).toBe(false);
+    expect(looksLikeQuantityAsPrice(12, '12 ct', { baseUnit: 'ct' })).toBe(false);
   });
 });

--- a/consumer-prices-core/src/adapters/search.test.ts
+++ b/consumer-prices-core/src/adapters/search.test.ts
@@ -148,6 +148,7 @@ describe('looksLikeQuantityAsPrice', () => {
   it('rejects a quantity echoed as a price for weighted products', () => {
     expect(looksLikeQuantityAsPrice(400, '400g', { baseUnit: 'g' })).toBe(true);
     expect(looksLikeQuantityAsPrice(1000, '1kg', { baseUnit: 'g' })).toBe(true);
+    expect(looksLikeQuantityAsPrice(400, undefined, { baseUnit: 'g' }, 'White Bread 400g')).toBe(true);
   });
 
   it('does not reject normal prices or count-based products', () => {

--- a/consumer-prices-core/src/adapters/search.test.ts
+++ b/consumer-prices-core/src/adapters/search.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeAllowedHosts,
   normalizePathFilters,
   matchesAnyPathFilter,
+  matchesRequiredPathSegments,
   looksLikeQuantityAsPrice,
 } from './search.js';
 
@@ -141,6 +142,45 @@ describe('matchesAnyPathFilter', () => {
     expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/promocoes/semana', filters)).toBe(true);
     expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/pages/about', filters)).toBe(true);
     expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/popular/today', filters)).toBe(true);
+  });
+});
+
+describe('matchesRequiredPathSegments', () => {
+  it('passes any URL when no segments are configured', () => {
+    expect(matchesRequiredPathSegments('https://www.noon.com/uae-en/milk/N1/p/', [])).toBe(true);
+  });
+
+  it('admits the configured storefront on both noon hosts', () => {
+    expect(matchesRequiredPathSegments('https://www.noon.com/saudi-en/milk/N1/p/', ['/saudi-en/'])).toBe(true);
+    expect(matchesRequiredPathSegments('https://minutes.noon.com/saudi-en/now-product/milk-1', ['/saudi-en/'])).toBe(
+      true,
+    );
+  });
+
+  it('rejects a foreign storefront on the same hosts', () => {
+    expect(matchesRequiredPathSegments('https://www.noon.com/uae-en/milk/N1/p/', ['/saudi-en/'])).toBe(false);
+    expect(matchesRequiredPathSegments('https://minutes.noon.com/egypt-en/now-product/milk-1', ['/saudi-en/'])).toBe(
+      false,
+    );
+  });
+
+  it('matches the pathname only, so query and fragment cannot satisfy it', () => {
+    expect(matchesRequiredPathSegments('https://www.noon.com/uae-en/milk/N1/p/?ref=/saudi-en/', ['/saudi-en/'])).toBe(
+      false,
+    );
+    expect(matchesRequiredPathSegments('https://www.noon.com/uae-en/milk/N1/p/#/saudi-en/', ['/saudi-en/'])).toBe(
+      false,
+    );
+  });
+
+  it('requires every listed segment, not any', () => {
+    expect(matchesRequiredPathSegments('https://x.example/saudi-en/p/', ['/saudi-en/', '/grocery/'])).toBe(false);
+    expect(matchesRequiredPathSegments('https://x.example/saudi-en/grocery/p/', ['/saudi-en/', '/grocery/'])).toBe(true);
+  });
+
+  it('fails closed on a malformed URL', () => {
+    expect(matchesRequiredPathSegments('not-a-url', ['/saudi-en/'])).toBe(false);
+    expect(matchesRequiredPathSegments('', ['/saudi-en/'])).toBe(false);
   });
 });
 

--- a/consumer-prices-core/src/adapters/search.ts
+++ b/consumer-prices-core/src/adapters/search.ts
@@ -77,15 +77,16 @@ export function extractSizeHint(canonicalName: string): string | null {
   return `${sizeValue}${sizeUnit} (approx. ${Math.round(baseQuantity)}${baseUnit})`;
 }
 
-/**
- * Safe host boundary check. Prevents evilluluhypermarket.com from passing
- * when allowedHost is luluhypermarket.com.
- */
+/** Merge the base host with configured aliases into a deduped, lowercased allowlist. */
 export function normalizeAllowedHosts(baseHost: string | readonly string[], aliases: readonly string[] = []): string[] {
   const hosts = typeof baseHost === 'string' ? [baseHost, ...aliases] : [...baseHost, ...aliases];
   return [...new Set(hosts.map((host) => host.trim().toLowerCase()).filter(Boolean))];
 }
 
+/**
+ * Safe host boundary check. Prevents evilluluhypermarket.com from passing
+ * when allowedHost is luluhypermarket.com.
+ */
 export function isAllowedHost(url: string, allowedHost: string | readonly string[]): boolean {
   try {
     const { hostname, protocol } = new URL(url);
@@ -109,7 +110,10 @@ export function looksLikeQuantityAsPrice(
   fallbackSizeText?: string,
 ): boolean {
   if (item.baseUnit === 'ct' || !Number.isFinite(price) || price < 20) return false;
-  const parsed = parseSize(sizeText ?? fallbackSizeText);
+  // Fall back to the canonical size whenever the provider's sizeText does not
+  // PARSE, not merely when it is absent: `??` would accept `''` or `'400 gm'`
+  // (UNIT_MAP has no `gm`/`pack`) as a present size and silently skip the check.
+  const parsed = parseSize(sizeText) ?? parseSize(fallbackSizeText);
   if (!parsed || parsed.baseUnit !== item.baseUnit || parsed.baseQuantity < 100) return false;
   return Math.abs(price - parsed.baseQuantity) < 0.005;
 }
@@ -425,19 +429,37 @@ export class SearchAdapter implements RetailerAdapter {
         continue;
       }
 
-      if (data.currency && data.currency.toUpperCase() !== currency.toUpperCase()) {
-        failures.push({ provider, reason: 'currency-mismatch', detail: `${data.currency}≠${currency}` });
+      const extractedCurrency = data.currency?.trim();
+
+      // The schema marks `currency` required and non-nullable, so an omission is
+      // an off-contract response, not a normal one. Under strict mode that is a
+      // rejection rather than a pass — for a multi-market host the currency is
+      // the last market discriminator behind `urlPathMustContain`, and a silent
+      // skip here stamps the retailer's configured currency on a foreign price.
+      // The other provider may still report it, so this escalates.
+      if (strictMode && !extractedCurrency) {
+        failures.push({ provider, reason: 'currency-mismatch', detail: 'missing-currency' });
         continue;
+      }
+
+      if (extractedCurrency && extractedCurrency.toUpperCase() !== currency.toUpperCase()) {
+        failures.push({ provider, reason: 'currency-mismatch', detail: `${extractedCurrency}≠${currency}` });
+        // The PAGE is priced in another currency; a second extractor reading the
+        // same page cannot change that, so stop escalating and try the next URL.
+        break;
       }
 
       if (!isTitlePlausible(canonicalName, data.productName)) {
         failures.push({ provider, reason: 'title-mismatch', detail: data.productName ?? 'missing productName' });
+        // Escalates: an extractor can misread the title (grabbing a carousel or
+        // recommendation heading) on the correct product page.
         continue;
       }
 
       if (strictMode && !itemConstraints) {
         failures.push({ provider, reason: 'validator-rejected', detail: 'missing-item-constraints' });
-        continue;
+        // A config/plumbing gap, not an extraction problem — retrying is pointless.
+        break;
       }
 
       if (strictMode && looksLikeQuantityAsPrice(price, data.sizeText, validationConstraints, canonicalName)) {
@@ -465,7 +487,9 @@ export class SearchAdapter implements RetailerAdapter {
 
       if (strictMode && !validator.ok) {
         failures.push({ provider, reason: 'validator-rejected', detail: validator.reasons.join(',') || 'unknown' });
-        continue;
+        // The validator judged the PAGE's product/size wrong. Both extractors
+        // read the same page, so escalating just doubles the paid call.
+        break;
       }
 
       // Shadow-mode: the strict validator runs alongside the legacy boolean gate
@@ -480,7 +504,7 @@ export class SearchAdapter implements RetailerAdapter {
       // inStockFromPrice: some retailers (e.g. BigBasket) gate on delivery pincode, not product
       // availability. Firecrawl misreads the gate as out-of-stock. If price > 0, treat as in-stock.
       if (ctx.config.searchConfig?.inStockFromPrice && price > 0) {
-        ctx.logger.info(`  [search:extract] ${canonicalName}: inStockFromPrice override (price=${price})`);
+        ctx.logger.info(`  [search:extract] ${ctx.config.slug}/${canonicalName}: inStockFromPrice override (price=${price})`);
         data.inStock = true;
       }
 
@@ -510,7 +534,7 @@ export class SearchAdapter implements RetailerAdapter {
         if (attempt.result) {
           const result = attempt.result;
           ctx.logger.info(
-            `  [search:pin] ${canonicalName}: price=${result.extracted.price} ${result.extracted.currency} provider=${result.provider} from ${target.url}`,
+            `  [search:pin] ${ctx.config.slug}/${canonicalName}: price=${result.extracted.price} ${result.extracted.currency} provider=${result.provider} from ${target.url}`,
           );
           return {
             url: target.url,
@@ -532,10 +556,10 @@ export class SearchAdapter implements RetailerAdapter {
           };
         }
         ctx.logger.warn(
-          `  [search:pin] ${canonicalName}: pin extraction failed (${formatExtractionFailures(attempt.failures)}), falling back to Exa`,
+          `  [search:pin] ${ctx.config.slug}/${canonicalName}: pin extraction failed (${formatExtractionFailures(attempt.failures)}), falling back to Exa`,
         );
       } catch (err) {
-        ctx.logger.warn(`  [search:pin] ${canonicalName}: pin fetch error, falling back to Exa: ${err}`);
+        ctx.logger.warn(`  [search:pin] ${ctx.config.slug}/${canonicalName}: pin fetch error, falling back to Exa: ${err}`);
       }
     }
 
@@ -547,10 +571,17 @@ export class SearchAdapter implements RetailerAdapter {
       );
     }
 
-    if (this.exaDiscoveryCooldownOpen || this.exaExtractionCooldownOpen) {
-      const cooldownKind = this.exaDiscoveryCooldownOpen ? 'discovery' : 'extraction';
+    // Only the DISCOVERY cooldown can abort the target: Exa is the sole URL
+    // discovery provider, so without it there is nothing to extract from. An
+    // Exa *extraction* cooldown must not abort — Firecrawl is the primary
+    // extractor and is frequently healthy at that moment (its own streak resets
+    // on every success), and `_extractFromUrl` already skips the cooled-down
+    // provider per candidate. Aborting here would turn a fallback outage into
+    // a whole-basket loss, which is the COVERAGE_PARTIAL this adapter exists
+    // to prevent.
+    if (this.exaDiscoveryCooldownOpen) {
       throw new SearchTargetError(
-        `Exa ${cooldownKind} cooldown is open for "${canonicalName}"`,
+        `Exa discovery cooldown is open for "${canonicalName}"`,
         0,
         [{ provider: 'exa', reason: 'provider-cooldown' }],
       );
@@ -583,10 +614,13 @@ export class SearchAdapter implements RetailerAdapter {
       if (this.exaDiscoveryFailureStreak >= 2) {
         this.exaDiscoveryCooldownOpen = true;
         ctx.logger.warn(
-          `  [search:provider-cooldown] ${ctx.config.slug}: Exa discovery disabled for the remainder of this scrape after ${this.exaDiscoveryFailureStreak} consecutive errors`,
+          `  [search:provider-cooldown] ${ctx.config.slug}: Exa discovery disabled for the remainder of this scrape after ${this.exaDiscoveryFailureStreak} consecutive errors (last: ${detail})`,
         );
       }
-      throw new SearchTargetError(`Exa search failed for "${canonicalName}"`, 0, [
+      // Carry `detail` into the message: nothing downstream reads `.failures`,
+      // so without it the log cannot tell an auth failure from a rate limit
+      // from a timeout — the distinction the cooldown exists to surface.
+      throw new SearchTargetError(`Exa search failed for "${canonicalName}": ${detail}`, 0, [
         { provider: 'exa', reason: 'provider-error', detail },
       ]);
     }
@@ -610,7 +644,7 @@ export class SearchAdapter implements RetailerAdapter {
     const safeUrls = [...new Set(discoveredUrls)].filter((url) => !attemptedUrls.has(url));
 
     ctx.logger.info(
-      `  [search:discovery] ${canonicalName}: ${exaResults.length} URLs from Exa, ${safeUrls.length} passed host/path check`,
+      `  [search:discovery] ${ctx.config.slug}/${canonicalName}: ${exaResults.length} URLs from Exa, ${safeUrls.length} passed host/path check`,
     );
 
     if (safeUrls.length === 0) {
@@ -622,7 +656,7 @@ export class SearchAdapter implements RetailerAdapter {
       const sample = exaResults.slice(0, 5).map((r) => r.url).filter(Boolean).join(' | ');
       const excludedPinnedUrl = attemptedUrls.size > 0 && discoveredUrls.some((url) => attemptedUrls.has(url));
       ctx.logger.warn(
-        `  [search:discovery] ${canonicalName}: 0 of ${exaResults.length} URLs passed filter (hosts=${hostAllowlist.join('|')}, path=${pathFilters.length ? pathFilters.join('|') : '<none>'}${requiredSegments.length ? `, required=${requiredSegments.join('+')}` : ''}${excludedPinnedUrl ? ', pinned URL already attempted' : ''}). Rejected: ${sample}`,
+        `  [search:discovery] ${ctx.config.slug}/${canonicalName}: 0 of ${exaResults.length} URLs passed filter (hosts=${hostAllowlist.join('|')}, path=${pathFilters.length ? pathFilters.join('|') : '<none>'}${requiredSegments.length ? `, required=${requiredSegments.join('+')}` : ''}${excludedPinnedUrl ? ', pinned URL already attempted' : ''}). Rejected: ${sample}`,
       );
       if (excludedPinnedUrl) {
         throw new Error(`Exa: all ${exaResults.length} results repeated the pinned URL already attempted for "${canonicalName}"`);
@@ -649,11 +683,11 @@ export class SearchAdapter implements RetailerAdapter {
           break;
         }
         ctx.logger.warn(
-          `  [search:extract] ${canonicalName}: rejected ${url} (${formatExtractionFailures(attempt.failures)}), trying next`,
+          `  [search:extract] ${ctx.config.slug}/${canonicalName}: rejected ${url} (${formatExtractionFailures(attempt.failures)}), trying next`,
         );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        ctx.logger.warn(`  [search:extract] ${canonicalName}: extraction error on ${url}: ${msg}`);
+        ctx.logger.warn(`  [search:extract] ${ctx.config.slug}/${canonicalName}: extraction error on ${url}: ${msg}`);
         failures.push({ provider: 'firecrawl', reason: 'provider-error', detail: msg });
       }
     }
@@ -661,13 +695,22 @@ export class SearchAdapter implements RetailerAdapter {
     if (picked === null) {
       throw new SearchTargetError(
         `All ${safeUrls.length} URLs failed extraction for "${canonicalName}". Last: ${formatExtractionFailures(failures.slice(-3))}`,
-        failures.some(({ reason }) => REJECTION_FAILURES.has(reason)) ? 1 : 0,
+        // Only retailers that opted into the strict validator contribute to
+        // `rejected_count`. Before this adapter change the metric was
+        // structurally always 0 for non-pin search targets, so emitting it
+        // fleet-wide would put a step change on ~20 retailers this work does
+        // not touch — and `rejected_count` is one of the signals used to judge
+        // whether the recovery worked.
+        ctx.config.searchConfig?.requireStrictValidator === true &&
+        failures.some(({ reason }) => REJECTION_FAILURES.has(reason))
+          ? 1
+          : 0,
         failures,
       );
     }
 
     ctx.logger.info(
-      `  [search:extract] ${canonicalName}: price=${picked.extracted.price} ${picked.extracted.currency} provider=${picked.provider} from ${usedUrl}`,
+      `  [search:extract] ${ctx.config.slug}/${canonicalName}: price=${picked.extracted.price} ${picked.extracted.currency} provider=${picked.provider} from ${usedUrl}`,
     );
 
     return {

--- a/consumer-prices-core/src/adapters/search.ts
+++ b/consumer-prices-core/src/adapters/search.ts
@@ -106,9 +106,10 @@ export function looksLikeQuantityAsPrice(
   price: number,
   sizeText: string | undefined,
   item: Pick<BasketItem, 'baseUnit'>,
+  fallbackSizeText?: string,
 ): boolean {
-  if (item.baseUnit === 'ct' || !sizeText || !Number.isFinite(price) || price < 20) return false;
-  const parsed = parseSize(sizeText);
+  if (item.baseUnit === 'ct' || !Number.isFinite(price) || price < 20) return false;
+  const parsed = parseSize(sizeText ?? fallbackSizeText);
   if (!parsed || parsed.baseUnit !== item.baseUnit || parsed.baseQuantity < 100) return false;
   return Math.abs(price - parsed.baseQuantity) < 0.005;
 }
@@ -315,11 +316,24 @@ export class SearchAdapter implements RetailerAdapter {
     const extractSchema = {
       prompt: `Extract the retail price of THIS specific product from the main product section of the page.${sizeClause} The price may be displayed as two parts split across lines — like "3" and ".95" next to "${currency}" — combine them to get 3.95. ONLY extract the price shown for the main product itself. If the page shows "Out of Stock" and no price is displayed for the main product, return null for price — do NOT use prices from related products, recommendations, or carousels. Return the product name, the numeric price in ${currency} (null if not shown), the currency code, whether it is in stock, and the size or quantity shown on the page.`,
       fields: {
-        productName: { type: 'string' as const, description: 'Name or title of the product' },
-        price: { type: 'number' as const, description: `Retail price in ${currency} as a single number (e.g. 4.69)` },
-        currency: { type: 'string' as const, description: `Currency code, should be ${currency}` },
-        inStock: { type: 'boolean' as const, description: 'Whether the product is currently in stock and purchasable' },
-        sizeText: { type: 'string' as const, description: 'Size or quantity shown on the page (e.g. "32 oz", "1 gallon", "24 pack")' },
+        productName: { type: 'string' as const, required: true, description: 'Name or title of the product' },
+        price: {
+          type: 'number' as const,
+          required: true,
+          nullable: true,
+          description: `Retail price in ${currency} as a single number (e.g. 4.69)`,
+        },
+        currency: { type: 'string' as const, required: true, description: `Currency code, should be ${currency}` },
+        inStock: {
+          type: 'boolean' as const,
+          required: false,
+          description: 'Whether the product is currently in stock and purchasable',
+        },
+        sizeText: {
+          type: 'string' as const,
+          required: false,
+          description: 'Size or quantity shown on the page (e.g. "32 oz", "1 gallon", "24 pack")',
+        },
       },
     };
 
@@ -393,8 +407,19 @@ export class SearchAdapter implements RetailerAdapter {
         continue;
       }
 
-      if (strictMode && looksLikeQuantityAsPrice(price, data.sizeText, validationConstraints)) {
+      if (strictMode && looksLikeQuantityAsPrice(price, data.sizeText, validationConstraints, canonicalName)) {
         failures.push({ provider, reason: 'quantity-as-price', detail: `${price} for ${data.sizeText}` });
+        continue;
+      }
+
+      if (
+        strictMode &&
+        itemConstraints &&
+        (itemConstraints.minBaseQty != null || itemConstraints.maxBaseQty != null) &&
+        !data.sizeText?.trim() &&
+        !parseSize(canonicalName)
+      ) {
+        failures.push({ provider, reason: 'validator-rejected', detail: 'missing-size' });
         continue;
       }
 

--- a/consumer-prices-core/src/adapters/search.ts
+++ b/consumer-prices-core/src/adapters/search.ts
@@ -219,8 +219,10 @@ export class SearchAdapter implements RetailerAdapter {
   // make one bounded attempt per candidate.
   private firecrawlFailureStreak = 0;
   private firecrawlCooldownOpen = false;
-  private exaFailureStreak = 0;
-  private exaCooldownOpen = false;
+  private exaExtractionFailureStreak = 0;
+  private exaExtractionCooldownOpen = false;
+  private exaDiscoveryFailureStreak = 0;
+  private exaDiscoveryCooldownOpen = false;
 
   constructor(
     private readonly exa: ExaProvider,
@@ -236,8 +238,10 @@ export class SearchAdapter implements RetailerAdapter {
   async discoverTargets(ctx: AdapterContext): Promise<Target[]> {
     this.firecrawlFailureStreak = 0;
     this.firecrawlCooldownOpen = false;
-    this.exaFailureStreak = 0;
-    this.exaCooldownOpen = false;
+    this.exaExtractionFailureStreak = 0;
+    this.exaExtractionCooldownOpen = false;
+    this.exaDiscoveryFailureStreak = 0;
+    this.exaDiscoveryCooldownOpen = false;
 
     const baskets = loadAllBasketConfigs().filter((b) => b.marketCode === ctx.config.marketCode);
     const domain = new URL(ctx.config.baseUrl).hostname;
@@ -330,7 +334,7 @@ export class SearchAdapter implements RetailerAdapter {
         failures.push({ provider, reason: 'provider-cooldown' });
         continue;
       }
-      if (provider === 'exa' && this.exaCooldownOpen) {
+      if (provider === 'exa' && this.exaExtractionCooldownOpen) {
         failures.push({ provider, reason: 'provider-cooldown' });
         continue;
       }
@@ -343,7 +347,7 @@ export class SearchAdapter implements RetailerAdapter {
             : await this.exa.extract<ExtractedProduct>(url, extractSchema, { timeout: 30_000 });
         data = result.data ?? {};
         if (provider === 'firecrawl') this.firecrawlFailureStreak = 0;
-        if (provider === 'exa') this.exaFailureStreak = 0;
+        if (provider === 'exa') this.exaExtractionFailureStreak = 0;
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
         failures.push({ provider, reason: 'provider-error', detail });
@@ -357,11 +361,11 @@ export class SearchAdapter implements RetailerAdapter {
           }
         }
         if (provider === 'exa') {
-          this.exaFailureStreak++;
-          if (this.exaFailureStreak >= 2) {
-            this.exaCooldownOpen = true;
+          this.exaExtractionFailureStreak++;
+          if (this.exaExtractionFailureStreak >= 2) {
+            this.exaExtractionCooldownOpen = true;
             ctx.logger.warn(
-              `  [search:provider-cooldown] ${ctx.config.slug}: Exa extraction disabled for the remainder of this scrape after ${this.exaFailureStreak} consecutive errors`,
+              `  [search:provider-cooldown] ${ctx.config.slug}: Exa extraction disabled for the remainder of this scrape after ${this.exaExtractionFailureStreak} consecutive errors`,
             );
           }
         }
@@ -477,9 +481,18 @@ export class SearchAdapter implements RetailerAdapter {
       }
     }
 
-    if (this.exaCooldownOpen) {
+    if (this.firecrawlCooldownOpen && ctx.config.searchConfig?.extractionFallback !== 'exa') {
       throw new SearchTargetError(
-        `Exa discovery cooldown is open for "${canonicalName}"`,
+        `Firecrawl extraction cooldown is open for "${canonicalName}"`,
+        0,
+        [{ provider: 'firecrawl', reason: 'provider-cooldown' }],
+      );
+    }
+
+    if (this.exaDiscoveryCooldownOpen || this.exaExtractionCooldownOpen) {
+      const cooldownKind = this.exaDiscoveryCooldownOpen ? 'discovery' : 'extraction';
+      throw new SearchTargetError(
+        `Exa ${cooldownKind} cooldown is open for "${canonicalName}"`,
         0,
         [{ provider: 'exa', reason: 'provider-cooldown' }],
       );
@@ -505,14 +518,14 @@ export class SearchAdapter implements RetailerAdapter {
         includeDomains: hostAllowlist,
         timeout: 30_000,
       });
-      this.exaFailureStreak = 0;
+      this.exaDiscoveryFailureStreak = 0;
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
-      this.exaFailureStreak++;
-      if (this.exaFailureStreak >= 2) {
-        this.exaCooldownOpen = true;
+      this.exaDiscoveryFailureStreak++;
+      if (this.exaDiscoveryFailureStreak >= 2) {
+        this.exaDiscoveryCooldownOpen = true;
         ctx.logger.warn(
-          `  [search:provider-cooldown] ${ctx.config.slug}: Exa discovery disabled for the remainder of this scrape after ${this.exaFailureStreak} consecutive errors`,
+          `  [search:provider-cooldown] ${ctx.config.slug}: Exa discovery disabled for the remainder of this scrape after ${this.exaDiscoveryFailureStreak} consecutive errors`,
         );
       }
       throw new SearchTargetError(`Exa search failed for "${canonicalName}"`, 0, [

--- a/consumer-prices-core/src/adapters/search.ts
+++ b/consumer-prices-core/src/adapters/search.ts
@@ -2,11 +2,13 @@
  * SearchAdapter — two-stage grocery price pipeline.
  *
  * Stage 1 (Exa): neural search on retailer domain → ranked product page URLs
- * Stage 2 (Firecrawl): structured LLM extraction from the confirmed URL → {price, currency, inStock}
+ * Stage 2 (Firecrawl, with an opt-in bounded Exa fallback): structured LLM extraction
+ * from the confirmed URL → {price, currency, inStock}
  *
- * Pin path: if a matching pin exists in ctx.pinnedUrls, Exa is skipped and Firecrawl
- * is called directly on the stored URL. On failure, falls back to the normal Exa flow
- * in the same run so the basket item is never left uncovered.
+ * Pin path: if a matching pin exists in ctx.pinnedUrls, discovery is skipped and the
+ * configured extraction providers are called directly on the stored URL. On failure,
+ * the adapter falls back to the normal Exa discovery flow in the same run so the basket
+ * item is never left uncovered.
  *
  * Replaces ExaSearchAdapter's fragile regex-on-AI-summary approach.
  * Firecrawl renders JS so dynamic prices (Noon, etc.) are visible.
@@ -22,6 +24,7 @@ import { MARKET_NAMES } from './market-names.js';
 import { parseSize } from '../normalizers/size.js';
 import { validateSearchHit, type ValidatorResult } from './validator.js';
 import type { BasketItem } from '../config/types.js';
+import type { AcquisitionProviderName } from '../acquisition/types.js';
 
 /** Packaging/container words that are not product identity tokens. */
 const PACKAGING_WORDS = new Set(['pack', 'box', 'bag', 'container', 'bottle', 'can', 'jar', 'tin', 'set', 'kit', 'bundle']);
@@ -78,13 +81,36 @@ export function extractSizeHint(canonicalName: string): string | null {
  * Safe host boundary check. Prevents evilluluhypermarket.com from passing
  * when allowedHost is luluhypermarket.com.
  */
-export function isAllowedHost(url: string, allowedHost: string): boolean {
+export function normalizeAllowedHosts(baseHost: string | readonly string[], aliases: readonly string[] = []): string[] {
+  const hosts = typeof baseHost === 'string' ? [baseHost, ...aliases] : [...baseHost, ...aliases];
+  return [...new Set(hosts.map((host) => host.trim().toLowerCase()).filter(Boolean))];
+}
+
+export function isAllowedHost(url: string, allowedHost: string | readonly string[]): boolean {
   try {
     const { hostname, protocol } = new URL(url);
-    return (protocol === 'http:' || protocol === 'https:') && hostname === allowedHost;
+    const allowedHosts = normalizeAllowedHosts(allowedHost);
+    return (protocol === 'http:' || protocol === 'https:') && allowedHosts.includes(hostname.toLowerCase());
   } catch {
     return false;
   }
+}
+
+/**
+ * Firecrawl occasionally returns a product quantity as the retail price when
+ * a dynamic page exposes the size but not the currency-denominated price.
+ * Reject only the unambiguous weighted-unit echo; count-based products and
+ * ordinary prices remain untouched.
+ */
+export function looksLikeQuantityAsPrice(
+  price: number,
+  sizeText: string | undefined,
+  item: Pick<BasketItem, 'baseUnit'>,
+): boolean {
+  if (item.baseUnit === 'ct' || !sizeText || !Number.isFinite(price) || price < 20) return false;
+  const parsed = parseSize(sizeText);
+  if (!parsed || parsed.baseUnit !== item.baseUnit || parsed.baseQuantity < 100) return false;
+  return Math.abs(price - parsed.baseQuantity) < 0.005;
 }
 
 /**
@@ -115,6 +141,34 @@ interface ExtractedProduct {
   sizeText?: string;
 }
 
+export type ExtractionProviderName = Extract<AcquisitionProviderName, 'firecrawl' | 'exa'>;
+
+export type ExtractionFailureReason =
+  | 'provider-error'
+  | 'provider-cooldown'
+  | 'missing-price'
+  | 'title-mismatch'
+  | 'validator-rejected'
+  | 'quantity-as-price'
+  | 'currency-mismatch';
+
+export interface ExtractionFailure {
+  provider: ExtractionProviderName;
+  reason: ExtractionFailureReason;
+  detail?: string;
+}
+
+interface ExtractionSuccess {
+  extracted: ExtractedProduct;
+  validator: ValidatorResult;
+  provider: ExtractionProviderName;
+}
+
+interface ExtractionAttempt {
+  result: ExtractionSuccess | null;
+  failures: ExtractionFailure[];
+}
+
 type ItemConstraints = Pick<BasketItem, 'baseUnit' | 'minBaseQty' | 'maxBaseQty' | 'negativeTokens' | 'substitutionGroup'>;
 
 interface SearchPayload {
@@ -123,15 +177,50 @@ interface SearchPayload {
   canonicalName: string;
   basketSlug: string;
   itemCategory: string;
-  itemConstraints: ItemConstraints;
+  itemConstraints?: ItemConstraints;
   validator?: ValidatorResult;
+  extractionProvider?: ExtractionProviderName;
   direct?: boolean;
   pinnedProductId?: string;
   matchId?: string;
 }
 
+const REJECTION_FAILURES = new Set<ExtractionFailureReason>([
+  'validator-rejected',
+  'quantity-as-price',
+  'currency-mismatch',
+  'title-mismatch',
+]);
+
+export class SearchTargetError extends Error {
+  constructor(
+    message: string,
+    readonly rejectedCount: number,
+    readonly failures: readonly ExtractionFailure[] = [],
+  ) {
+    super(message);
+    this.name = 'SearchTargetError';
+  }
+}
+
+function formatExtractionFailures(failures: readonly ExtractionFailure[]): string {
+  if (failures.length === 0) return 'unknown';
+  return failures
+    .map(({ provider, reason, detail }) => `${provider}:${reason}${detail ? `(${detail})` : ''}`)
+    .join(',');
+}
+
 export class SearchAdapter implements RetailerAdapter {
   readonly key = 'search';
+
+  // A provider outage should not multiply into one failed call per candidate
+  // URL for the rest of a retailer's scrape. Two consecutive transport errors
+  // open a per-scrape cooldown; an explicitly configured fallback can still
+  // make one bounded attempt per candidate.
+  private firecrawlFailureStreak = 0;
+  private firecrawlCooldownOpen = false;
+  private exaFailureStreak = 0;
+  private exaCooldownOpen = false;
 
   constructor(
     private readonly exa: ExaProvider,
@@ -145,8 +234,14 @@ export class SearchAdapter implements RetailerAdapter {
   }
 
   async discoverTargets(ctx: AdapterContext): Promise<Target[]> {
+    this.firecrawlFailureStreak = 0;
+    this.firecrawlCooldownOpen = false;
+    this.exaFailureStreak = 0;
+    this.exaCooldownOpen = false;
+
     const baskets = loadAllBasketConfigs().filter((b) => b.marketCode === ctx.config.marketCode);
     const domain = new URL(ctx.config.baseUrl).hostname;
+    const allowedHosts = normalizeAllowedHosts(domain, ctx.config.searchConfig?.allowedHosts);
     const targets: Target[] = [];
 
     for (const basket of baskets) {
@@ -161,7 +256,7 @@ export class SearchAdapter implements RetailerAdapter {
           substitutionGroup: item.substitutionGroup,
         };
 
-        if (pinned && isAllowedHost(pinned.sourceUrl, domain)) {
+        if (pinned && isAllowedHost(pinned.sourceUrl, allowedHosts)) {
           targets.push({
             id: item.id,
             url: pinned.sourceUrl,
@@ -207,7 +302,7 @@ export class SearchAdapter implements RetailerAdapter {
     canonicalName: string,
     currency: string,
     itemConstraints?: ItemConstraints,
-  ): Promise<{ extracted: ExtractedProduct; validator: ValidatorResult } | null> {
+  ): Promise<ExtractionAttempt> {
     const sizeHint = extractSizeHint(canonicalName);
     const sizeClause = sizeHint
       ? ` You are looking for "${canonicalName}". The product MUST be ${sizeHint}. If the page shows a different size, pack count, or bulk case, return null for price.`
@@ -224,43 +319,113 @@ export class SearchAdapter implements RetailerAdapter {
       },
     };
 
-    const result = await this.firecrawl.extract<ExtractedProduct>(url, extractSchema, { timeout: 30_000 });
-    const data = result.data;
-    const price = data?.price;
+    const failures: ExtractionFailure[] = [];
+    const providers: ExtractionProviderName[] = ['firecrawl'];
+    if (ctx.config.searchConfig?.extractionFallback === 'exa') providers.push('exa');
+    const strictMode = ctx.config.searchConfig?.requireStrictValidator === true;
+    const validationConstraints: ItemConstraints = itemConstraints ?? { baseUnit: '' };
 
-    if (typeof price !== 'number' || !Number.isFinite(price) || price <= 0) {
-      return null;
+    for (const provider of providers) {
+      if (provider === 'firecrawl' && this.firecrawlCooldownOpen) {
+        failures.push({ provider, reason: 'provider-cooldown' });
+        continue;
+      }
+      if (provider === 'exa' && this.exaCooldownOpen) {
+        failures.push({ provider, reason: 'provider-cooldown' });
+        continue;
+      }
+
+      let data: ExtractedProduct;
+      try {
+        const result =
+          provider === 'firecrawl'
+            ? await this.firecrawl.extract<ExtractedProduct>(url, extractSchema, { timeout: 30_000 })
+            : await this.exa.extract<ExtractedProduct>(url, extractSchema, { timeout: 30_000 });
+        data = result.data ?? {};
+        if (provider === 'firecrawl') this.firecrawlFailureStreak = 0;
+        if (provider === 'exa') this.exaFailureStreak = 0;
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        failures.push({ provider, reason: 'provider-error', detail });
+        if (provider === 'firecrawl') {
+          this.firecrawlFailureStreak++;
+          if (this.firecrawlFailureStreak >= 2) {
+            this.firecrawlCooldownOpen = true;
+            ctx.logger.warn(
+              `  [search:provider-cooldown] ${ctx.config.slug}: Firecrawl disabled for the remainder of this scrape after ${this.firecrawlFailureStreak} consecutive errors`,
+            );
+          }
+        }
+        if (provider === 'exa') {
+          this.exaFailureStreak++;
+          if (this.exaFailureStreak >= 2) {
+            this.exaCooldownOpen = true;
+            ctx.logger.warn(
+              `  [search:provider-cooldown] ${ctx.config.slug}: Exa extraction disabled for the remainder of this scrape after ${this.exaFailureStreak} consecutive errors`,
+            );
+          }
+        }
+        continue;
+      }
+
+      const price = data.price;
+      if (typeof price !== 'number' || !Number.isFinite(price) || price <= 0) {
+        failures.push({ provider, reason: 'missing-price' });
+        continue;
+      }
+
+      if (data.currency && data.currency.toUpperCase() !== currency.toUpperCase()) {
+        failures.push({ provider, reason: 'currency-mismatch', detail: `${data.currency}≠${currency}` });
+        continue;
+      }
+
+      if (!isTitlePlausible(canonicalName, data.productName)) {
+        failures.push({ provider, reason: 'title-mismatch', detail: data.productName ?? 'missing productName' });
+        continue;
+      }
+
+      if (strictMode && !itemConstraints) {
+        failures.push({ provider, reason: 'validator-rejected', detail: 'missing-item-constraints' });
+        continue;
+      }
+
+      if (strictMode && looksLikeQuantityAsPrice(price, data.sizeText, validationConstraints)) {
+        failures.push({ provider, reason: 'quantity-as-price', detail: `${price} for ${data.sizeText}` });
+        continue;
+      }
+
+      const validator = validateSearchHit({
+        canonicalName,
+        productName: data.productName,
+        sizeText: data.sizeText,
+        item: validationConstraints,
+      });
+
+      if (strictMode && !validator.ok) {
+        failures.push({ provider, reason: 'validator-rejected', detail: validator.reasons.join(',') || 'unknown' });
+        continue;
+      }
+
+      // Shadow-mode: the strict validator runs alongside the legacy boolean gate
+      // but does NOT block a hit on its own for unaffected retailers. Priority
+      // recovery retailers opt into the hard gate above.
+      if (!validator.ok) {
+        ctx.logger.warn(
+          `  [search:shadow-reject] "${canonicalName}" would reject productName="${data.productName}" reasons=${validator.reasons.join(',')} score=${validator.score.toFixed(2)}`,
+        );
+      }
+
+      // inStockFromPrice: some retailers (e.g. BigBasket) gate on delivery pincode, not product
+      // availability. Firecrawl misreads the gate as out-of-stock. If price > 0, treat as in-stock.
+      if (ctx.config.searchConfig?.inStockFromPrice && price > 0) {
+        ctx.logger.info(`  [search:extract] ${canonicalName}: inStockFromPrice override (price=${price})`);
+        data.inStock = true;
+      }
+
+      return { result: { extracted: data, validator, provider }, failures };
     }
-    const legacyPass = isTitlePlausible(canonicalName, data.productName);
-    const validator = validateSearchHit({
-      canonicalName,
-      productName: data.productName,
-      sizeText: data.sizeText,
-      item: itemConstraints ?? { baseUnit: '' },
-    });
 
-    // Shadow-mode: the strict validator runs alongside the legacy boolean gate
-    // but does NOT block a hit on its own yet. When validator.ok=false and
-    // legacy would have accepted, log a wouldReject with reasons so the diff
-    // report can inform the rollout decision to flip the hard gate.
-    if (legacyPass && !validator.ok) {
-      ctx.logger.warn(
-        `  [search:shadow-reject] "${canonicalName}" would reject productName="${data.productName}" reasons=${validator.reasons.join(',')} score=${validator.score.toFixed(2)}`,
-      );
-    }
-
-    if (!legacyPass) {
-      return null;
-    }
-
-    // inStockFromPrice: some retailers (e.g. BigBasket) gate on delivery pincode, not product
-    // availability. Firecrawl misreads the gate as out-of-stock. If price > 0, treat as in-stock.
-    if (ctx.config.searchConfig?.inStockFromPrice && price > 0) {
-      ctx.logger.info(`  [search:extract] ${canonicalName}: inStockFromPrice override (price=${price})`);
-      data.inStock = true;
-    }
-
-    return { extracted: data, validator };
+    return { result: null, failures };
   }
 
   async fetchTarget(ctx: AdapterContext, target: Target): Promise<FetchResult> {
@@ -269,19 +434,21 @@ export class SearchAdapter implements RetailerAdapter {
       domain: string;
       currency: string;
       basketSlug: string;
-      itemConstraints: ItemConstraints;
+      itemConstraints?: ItemConstraints;
       direct: boolean;
       pinnedProductId?: string;
       matchId?: string;
     };
+    const hostAllowlist = normalizeAllowedHosts(domain, ctx.config.searchConfig?.allowedHosts);
 
-    // Direct path: skip Exa, call Firecrawl on pinned URL
+    // Direct path: skip Exa discovery, call the configured extractor on the pinned URL.
     if (direct) {
       try {
-        const result = await this._extractFromUrl(ctx, target.url, canonicalName, currency, itemConstraints);
-        if (result) {
+        const attempt = await this._extractFromUrl(ctx, target.url, canonicalName, currency, itemConstraints);
+        if (attempt.result) {
+          const result = attempt.result;
           ctx.logger.info(
-            `  [search:pin] ${canonicalName}: price=${result.extracted.price} ${result.extracted.currency} from ${target.url}`,
+            `  [search:pin] ${canonicalName}: price=${result.extracted.price} ${result.extracted.currency} provider=${result.provider} from ${target.url}`,
           );
           return {
             url: target.url,
@@ -293,6 +460,7 @@ export class SearchAdapter implements RetailerAdapter {
               itemCategory: target.category,
               itemConstraints,
               validator: result.validator,
+              extractionProvider: result.provider,
               direct: true,
               pinnedProductId,
               matchId,
@@ -301,10 +469,20 @@ export class SearchAdapter implements RetailerAdapter {
             fetchedAt: new Date(),
           };
         }
-        ctx.logger.warn(`  [search:pin] ${canonicalName}: pin extraction failed, falling back to Exa`);
+        ctx.logger.warn(
+          `  [search:pin] ${canonicalName}: pin extraction failed (${formatExtractionFailures(attempt.failures)}), falling back to Exa`,
+        );
       } catch (err) {
         ctx.logger.warn(`  [search:pin] ${canonicalName}: pin fetch error, falling back to Exa: ${err}`);
       }
+    }
+
+    if (this.exaCooldownOpen) {
+      throw new SearchTargetError(
+        `Exa discovery cooldown is open for "${canonicalName}"`,
+        0,
+        [{ provider: 'exa', reason: 'provider-cooldown' }],
+      );
     }
 
     const marketName = MARKET_NAMES[ctx.config.marketCode] ?? ctx.config.marketCode.toUpperCase();
@@ -320,22 +498,41 @@ export class SearchAdapter implements RetailerAdapter {
       : `${canonicalName} grocery ${marketName} ${currency}`.trim();
 
     // Stage 1: Exa URL discovery
-    const exaResults = await this.exa.search(searchQuery, {
-      numResults: cfg?.numResults ?? 3,
-      includeDomains: [domain],
-    });
+    let exaResults;
+    try {
+      exaResults = await this.exa.search(searchQuery, {
+        numResults: cfg?.numResults ?? 3,
+        includeDomains: hostAllowlist,
+        timeout: 30_000,
+      });
+      this.exaFailureStreak = 0;
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      this.exaFailureStreak++;
+      if (this.exaFailureStreak >= 2) {
+        this.exaCooldownOpen = true;
+        ctx.logger.warn(
+          `  [search:provider-cooldown] ${ctx.config.slug}: Exa discovery disabled for the remainder of this scrape after ${this.exaFailureStreak} consecutive errors`,
+        );
+      }
+      throw new SearchTargetError(`Exa search failed for "${canonicalName}"`, 0, [
+        { provider: 'exa', reason: 'provider-error', detail },
+      ]);
+    }
 
     if (exaResults.length === 0) {
       throw new Error(`Exa: no pages found for "${canonicalName}" on ${domain}`);
     }
 
     const pathFilters = normalizePathFilters(cfg?.urlPathContains);
-    const safeUrls = exaResults
+    const attemptedUrls = direct ? new Set([target.url]) : new Set<string>();
+    const discoveredUrls = exaResults
       .map((r) => r.url)
-      .filter((url) => !!url && isAllowedHost(url, domain) && matchesAnyPathFilter(url, pathFilters));
+      .filter((url) => !!url && isAllowedHost(url, hostAllowlist) && matchesAnyPathFilter(url, pathFilters));
+    const safeUrls = [...new Set(discoveredUrls)].filter((url) => !attemptedUrls.has(url));
 
     ctx.logger.info(
-      `  [search:discovery] ${canonicalName}: ${exaResults.length} URLs from Exa, ${safeUrls.length} passed domain check`,
+      `  [search:discovery] ${canonicalName}: ${exaResults.length} URLs from Exa, ${safeUrls.length} passed host/path check`,
     );
 
     if (safeUrls.length === 0) {
@@ -345,43 +542,54 @@ export class SearchAdapter implements RetailerAdapter {
       // run goes from "0 passed domain check" straight to a thrown error
       // with no record of what Exa actually returned.
       const sample = exaResults.slice(0, 5).map((r) => r.url).filter(Boolean).join(' | ');
+      const excludedPinnedUrl = attemptedUrls.size > 0 && discoveredUrls.some((url) => attemptedUrls.has(url));
       ctx.logger.warn(
-        `  [search:discovery] ${canonicalName}: 0 of ${exaResults.length} URLs passed filter (host=${domain}, path=${pathFilters.length ? pathFilters.join('|') : '<none>'}). Rejected: ${sample}`,
+        `  [search:discovery] ${canonicalName}: 0 of ${exaResults.length} URLs passed filter (hosts=${hostAllowlist.join('|')}, path=${pathFilters.length ? pathFilters.join('|') : '<none>'}${excludedPinnedUrl ? ', pinned URL already attempted' : ''}). Rejected: ${sample}`,
       );
+      if (excludedPinnedUrl) {
+        throw new Error(`Exa: all ${exaResults.length} results repeated the pinned URL already attempted for "${canonicalName}"`);
+      }
       throw new Error(
-        `Exa: all ${exaResults.length} results failed domain check (expected hostname: ${domain}${pathFilters.length ? `, path: *${pathFilters.join('|')}*` : ''})`,
+        `Exa: all ${exaResults.length} results failed host/path check (expected hostnames: ${hostAllowlist.join('|')}${pathFilters.length ? `, path: *${pathFilters.join('|')}*` : ''})`,
       );
     }
 
-    // Stage 2: Firecrawl structured extraction — iterate safe URLs until one yields a valid price
-    let picked: { extracted: ExtractedProduct; validator: ValidatorResult } | null = null;
+    // Stage 2: structured extraction — iterate safe URLs until one yields a valid price.
+    // _extractFromUrl keeps the provider fallback bounded per candidate and records
+    // the reason each provider/page was rejected for the scrape-run diagnostics.
+    let picked: ExtractionSuccess | null = null;
     let usedUrl = safeUrls[0];
-    const lastErrors: string[] = [];
+    const failures: ExtractionFailure[] = [];
 
     for (const url of safeUrls) {
       try {
-        const result = await this._extractFromUrl(ctx, url, canonicalName, currency, itemConstraints);
-        if (result) {
-          picked = result;
+        const attempt = await this._extractFromUrl(ctx, url, canonicalName, currency, itemConstraints);
+        failures.push(...attempt.failures);
+        if (attempt.result) {
+          picked = attempt.result;
           usedUrl = url;
           break;
         }
-        ctx.logger.warn(`  [search:extract] ${canonicalName}: no price or title mismatch at ${url}, trying next`);
+        ctx.logger.warn(
+          `  [search:extract] ${canonicalName}: rejected ${url} (${formatExtractionFailures(attempt.failures)}), trying next`,
+        );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        ctx.logger.warn(`  [search:extract] ${canonicalName}: Firecrawl error on ${url}: ${msg}`);
-        lastErrors.push(msg);
+        ctx.logger.warn(`  [search:extract] ${canonicalName}: extraction error on ${url}: ${msg}`);
+        failures.push({ provider: 'firecrawl', reason: 'provider-error', detail: msg });
       }
     }
 
     if (picked === null) {
-      throw new Error(
-        `All ${safeUrls.length} URLs failed extraction for "${canonicalName}".${lastErrors.length ? ` Last: ${lastErrors.at(-1)}` : ''}`,
+      throw new SearchTargetError(
+        `All ${safeUrls.length} URLs failed extraction for "${canonicalName}". Last: ${formatExtractionFailures(failures.slice(-3))}`,
+        failures.some(({ reason }) => REJECTION_FAILURES.has(reason)) ? 1 : 0,
+        failures,
       );
     }
 
     ctx.logger.info(
-      `  [search:extract] ${canonicalName}: price=${picked.extracted.price} ${picked.extracted.currency} from ${usedUrl}`,
+      `  [search:extract] ${canonicalName}: price=${picked.extracted.price} ${picked.extracted.currency} provider=${picked.provider} from ${usedUrl}`,
     );
 
     return {
@@ -394,6 +602,7 @@ export class SearchAdapter implements RetailerAdapter {
         itemCategory: target.category,
         itemConstraints,
         validator: picked.validator,
+        extractionProvider: picked.provider,
         direct: false,
       } satisfies SearchPayload),
       statusCode: 200,
@@ -402,7 +611,7 @@ export class SearchAdapter implements RetailerAdapter {
   }
 
   async parseListing(ctx: AdapterContext, result: FetchResult): Promise<ParsedProduct[]> {
-    const { extracted, productUrl, canonicalName, basketSlug, itemCategory, itemConstraints, validator, direct, pinnedProductId, matchId } =
+    const { extracted, productUrl, canonicalName, basketSlug, itemCategory, itemConstraints, validator, extractionProvider, direct, pinnedProductId, matchId } =
       JSON.parse(result.html) as SearchPayload;
 
     const priceResult = z.number().positive().finite().safeParse(extracted?.price);
@@ -418,10 +627,12 @@ export class SearchAdapter implements RetailerAdapter {
       return [];
     }
 
-    // Require Firecrawl to return a real product name — using canonical name as rawTitle
+    // Require the structured extractor to return a real product name — using canonical name as rawTitle
     // silently poisons the DB with unverifiable matches (e.g. extraction failures, wrong pages).
     if (!extracted.productName) {
-      ctx.logger.warn(`  [search] ${canonicalName}: no productName from Firecrawl, rejecting ${productUrl}`);
+      ctx.logger.warn(
+        `  [search] ${canonicalName}: no productName from ${extractionProvider ?? 'structured extractor'}, rejecting ${productUrl}`,
+      );
       return [];
     }
 
@@ -438,10 +649,10 @@ export class SearchAdapter implements RetailerAdapter {
         listPrice: null,
         promoPrice: null,
         promoText: null,
-        // inStock defaults to true when Firecrawl does not return the field.
+        // inStock defaults to true when the structured extractor does not return the field.
         // This is a conservative assumption — monitor for out-of-stock false positives.
         inStock: extracted.inStock ?? true,
-        rawPayload: { extracted, basketSlug, itemCategory, canonicalName, itemConstraints, validator, direct, pinnedProductId, matchId },
+        rawPayload: { extracted, basketSlug, itemCategory, canonicalName, itemConstraints, validator, extractionProvider, direct, pinnedProductId, matchId },
       },
     ];
   }

--- a/consumer-prices-core/src/adapters/search.ts
+++ b/consumer-prices-core/src/adapters/search.ts
@@ -134,6 +134,28 @@ export function matchesAnyPathFilter(url: string, filters: string[]): boolean {
   return filters.some((p) => url.includes(p));
 }
 
+/**
+ * AND-ed market scope, layered on top of `matchesAnyPathFilter`'s OR.
+ *
+ * A multi-market host serves several storefronts from one hostname — noon.com
+ * fronts /saudi-en/, /uae-en/ and Egypt on both www.noon.com and
+ * minutes.noon.com — so the host allowlist cannot separate them, and
+ * `urlPathContains` cannot either: it is an OR, and on www.noon.com the locale
+ * is the first path segment while the product route (`/p/`) is the last, so no
+ * single substring spans both. Every listed segment must appear, and matching
+ * is on `pathname` only so a locale echoed in a query string cannot satisfy it.
+ * An unparseable URL fails closed.
+ */
+export function matchesRequiredPathSegments(url: string, segments: string[]): boolean {
+  if (segments.length === 0) return true;
+  try {
+    const { pathname } = new URL(url);
+    return segments.every((segment) => pathname.includes(segment));
+  } catch {
+    return false;
+  }
+}
+
 interface ExtractedProduct {
   productName?: string;
   price?: number;
@@ -247,6 +269,10 @@ export class SearchAdapter implements RetailerAdapter {
     const baskets = loadAllBasketConfigs().filter((b) => b.marketCode === ctx.config.marketCode);
     const domain = new URL(ctx.config.baseUrl).hostname;
     const allowedHosts = normalizeAllowedHosts(domain, ctx.config.searchConfig?.allowedHosts);
+    // Pins outlive config changes, so a pin stored while a looser policy was
+    // live would keep being scraped directly and bypass discovery entirely.
+    // The market scope has to apply here too, not just to discovered URLs.
+    const requiredSegments = ctx.config.searchConfig?.urlPathMustContain ?? [];
     const targets: Target[] = [];
 
     for (const basket of baskets) {
@@ -261,7 +287,11 @@ export class SearchAdapter implements RetailerAdapter {
           substitutionGroup: item.substitutionGroup,
         };
 
-        if (pinned && isAllowedHost(pinned.sourceUrl, allowedHosts)) {
+        if (
+          pinned &&
+          isAllowedHost(pinned.sourceUrl, allowedHosts) &&
+          matchesRequiredPathSegments(pinned.sourceUrl, requiredSegments)
+        ) {
           targets.push({
             id: item.id,
             url: pinned.sourceUrl,
@@ -279,7 +309,10 @@ export class SearchAdapter implements RetailerAdapter {
           });
         } else {
           if (pinned) {
-            ctx.logger.warn(`  [pin] rejected stored URL for "${item.canonicalName}" (host mismatch): ${pinned.sourceUrl}`);
+            const pinReason = isAllowedHost(pinned.sourceUrl, allowedHosts) ? 'market scope' : 'host mismatch';
+            ctx.logger.warn(
+              `  [pin] rejected stored URL for "${item.canonicalName}" (${pinReason}): ${pinned.sourceUrl}`,
+            );
           }
           targets.push({
             id: item.id,
@@ -563,10 +596,17 @@ export class SearchAdapter implements RetailerAdapter {
     }
 
     const pathFilters = normalizePathFilters(cfg?.urlPathContains);
+    const requiredSegments = cfg?.urlPathMustContain ?? [];
     const attemptedUrls = direct ? new Set([target.url]) : new Set<string>();
     const discoveredUrls = exaResults
       .map((r) => r.url)
-      .filter((url) => !!url && isAllowedHost(url, hostAllowlist) && matchesAnyPathFilter(url, pathFilters));
+      .filter(
+        (url) =>
+          !!url &&
+          isAllowedHost(url, hostAllowlist) &&
+          matchesAnyPathFilter(url, pathFilters) &&
+          matchesRequiredPathSegments(url, requiredSegments),
+      );
     const safeUrls = [...new Set(discoveredUrls)].filter((url) => !attemptedUrls.has(url));
 
     ctx.logger.info(
@@ -582,13 +622,13 @@ export class SearchAdapter implements RetailerAdapter {
       const sample = exaResults.slice(0, 5).map((r) => r.url).filter(Boolean).join(' | ');
       const excludedPinnedUrl = attemptedUrls.size > 0 && discoveredUrls.some((url) => attemptedUrls.has(url));
       ctx.logger.warn(
-        `  [search:discovery] ${canonicalName}: 0 of ${exaResults.length} URLs passed filter (hosts=${hostAllowlist.join('|')}, path=${pathFilters.length ? pathFilters.join('|') : '<none>'}${excludedPinnedUrl ? ', pinned URL already attempted' : ''}). Rejected: ${sample}`,
+        `  [search:discovery] ${canonicalName}: 0 of ${exaResults.length} URLs passed filter (hosts=${hostAllowlist.join('|')}, path=${pathFilters.length ? pathFilters.join('|') : '<none>'}${requiredSegments.length ? `, required=${requiredSegments.join('+')}` : ''}${excludedPinnedUrl ? ', pinned URL already attempted' : ''}). Rejected: ${sample}`,
       );
       if (excludedPinnedUrl) {
         throw new Error(`Exa: all ${exaResults.length} results repeated the pinned URL already attempted for "${canonicalName}"`);
       }
       throw new Error(
-        `Exa: all ${exaResults.length} results failed host/path check (expected hostnames: ${hostAllowlist.join('|')}${pathFilters.length ? `, path: *${pathFilters.join('|')}*` : ''})`,
+        `Exa: all ${exaResults.length} results failed host/path check (expected hostnames: ${hostAllowlist.join('|')}${pathFilters.length ? `, path: *${pathFilters.join('|')}*` : ''}${requiredSegments.length ? `, required path: ${requiredSegments.join('+')}` : ''})`,
       );
     }
 

--- a/consumer-prices-core/src/config/types.ts
+++ b/consumer-prices-core/src/config/types.ts
@@ -57,7 +57,17 @@ export const SearchConfigSchema = z.object({
   // and VTEX `<slug>/p` for product pages). A URL passes if it contains ANY
   // of the listed substrings.
   urlPathContains: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
+  // Explicit storefront aliases for provider results that are still owned by
+  // the configured retailer (for example minutes.noon.com). The base URL
+  // hostname is always allowed; aliases never broaden the check implicitly.
+  allowedHosts: z.array(z.string().min(1)).min(1).optional(),
   inStockFromPrice: z.boolean().default(false),
+  // A single bounded provider fallback is opt-in per retailer. `none` keeps
+  // the historical Firecrawl-only extraction path.
+  extractionFallback: z.enum(['none', 'exa']).default('none'),
+  // Keep the strict validator opt-in while existing shadow-mode rollouts
+  // remain unchanged for unaffected retailers.
+  requireStrictValidator: z.boolean().default(false),
 });
 
 export const RetailerConfigSchema = z.object({

--- a/consumer-prices-core/src/config/types.ts
+++ b/consumer-prices-core/src/config/types.ts
@@ -57,6 +57,14 @@ export const SearchConfigSchema = z.object({
   // and VTEX `<slug>/p` for product pages). A URL passes if it contains ANY
   // of the listed substrings.
   urlPathContains: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
+  // Segment(s) that must ALL appear in the URL *pathname*, AND-ed on top of
+  // `urlPathContains`. `urlPathContains` is an OR over substrings, so it can
+  // express "is a product route" or "is this market's storefront" but never
+  // both — a multi-market host like noon.com (which serves /saudi-en/,
+  // /uae-en/ and Egypt from www.noon.com and minutes.noon.com) needs this to
+  // keep one storefront's prices out of another market's snapshot. Matched
+  // against `pathname` only, so a locale in a query string cannot satisfy it.
+  urlPathMustContain: z.array(z.string().min(1)).min(1).optional(),
   // Explicit storefront aliases for provider results that are still owned by
   // the configured retailer (for example minutes.noon.com). The base URL
   // hostname is always allowed; aliases never broaden the check implicitly.

--- a/consumer-prices-core/src/jobs/scrape-coverage.test.ts
+++ b/consumer-prices-core/src/jobs/scrape-coverage.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   classifyValidatorOutcome,
   createScrapeRunStatement,
+  DEFAULT_RUN_BUDGET_MS,
+  isRunBudgetExhausted,
+  resolveRunBudgetMs,
+  resolveRunStatus,
   updateScrapeRunStatement,
 } from './scrape-coverage.js';
 
@@ -39,5 +43,36 @@ describe('scrape coverage persistence and validator admission contracts', () => 
       skipObservation: false,
       errorCount: 0,
     });
+  });
+});
+
+describe('run budget', () => {
+  it('defaults when unset and accepts an explicit override', () => {
+    expect(resolveRunBudgetMs(undefined)).toBe(DEFAULT_RUN_BUDGET_MS);
+    expect(resolveRunBudgetMs('')).toBe(DEFAULT_RUN_BUDGET_MS);
+    expect(resolveRunBudgetMs('60000')).toBe(60_000);
+  });
+
+  // A typo'd env var must disable the ceiling, never truncate every run at
+  // target zero — that would turn a config slip into total coverage loss.
+  it('disables the ceiling on a non-numeric or non-positive value', () => {
+    expect(resolveRunBudgetMs('twenty minutes')).toBe(Number.POSITIVE_INFINITY);
+    expect(resolveRunBudgetMs('0')).toBe(Number.POSITIVE_INFINITY);
+    expect(resolveRunBudgetMs('-5')).toBe(Number.POSITIVE_INFINITY);
+    expect(isRunBudgetExhausted(0, 9_999_999, resolveRunBudgetMs('0'))).toBe(false);
+  });
+
+  it('fires only once elapsed time passes the budget', () => {
+    expect(isRunBudgetExhausted(1_000, 1_000, 500)).toBe(false);
+    expect(isRunBudgetExhausted(1_000, 1_500, 500)).toBe(false);
+    expect(isRunBudgetExhausted(1_000, 1_501, 500)).toBe(true);
+  });
+
+  it('reports a budget-truncated run as partial even with zero errors', () => {
+    expect(resolveRunStatus(0, 5, false)).toBe('completed');
+    expect(resolveRunStatus(0, 5, true)).toBe('partial');
+    expect(resolveRunStatus(3, 5, false)).toBe('partial');
+    expect(resolveRunStatus(3, 0, false)).toBe('failed');
+    expect(resolveRunStatus(0, 0, true)).toBe('failed');
   });
 });

--- a/consumer-prices-core/src/jobs/scrape-coverage.ts
+++ b/consumer-prices-core/src/jobs/scrape-coverage.ts
@@ -50,3 +50,38 @@ export function classifyValidatorOutcome(
     errorCount: wasDirectHit ? 1 : 0,
   };
 }
+
+/** Default wall-clock ceiling for one retailer's target loop. */
+export const DEFAULT_RUN_BUDGET_MS = 20 * 60_000;
+
+/**
+ * Resolve the run budget from config. A non-numeric or non-positive value
+ * disables the ceiling rather than truncating every run instantly — a typo'd
+ * env var must not silently gut coverage.
+ */
+export function resolveRunBudgetMs(raw: string | undefined): number {
+  if (raw === undefined || raw === '') return DEFAULT_RUN_BUDGET_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return Number.POSITIVE_INFINITY;
+  return parsed;
+}
+
+/** True once the target loop has spent its wall-clock budget. */
+export function isRunBudgetExhausted(startedAt: number, now: number, budgetMs: number): boolean {
+  if (!Number.isFinite(budgetMs)) return false;
+  return now - startedAt > budgetMs;
+}
+
+/**
+ * Terminal run status. A budget-truncated run is 'partial' even with zero
+ * errors: it never attempted every target, and reporting 'completed' would
+ * refresh the freshness marker while part of the basket was skipped.
+ */
+export function resolveRunStatus(
+  errorsCount: number,
+  pagesSucceeded: number,
+  budgetExhausted: boolean,
+): 'completed' | 'partial' | 'failed' {
+  if (errorsCount === 0 && !budgetExhausted) return 'completed';
+  return pagesSucceeded > 0 ? 'partial' : 'failed';
+}

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -20,6 +20,9 @@ import { AUTO_MATCH_THRESHOLD, type ValidatorResult } from '../adapters/validato
 import {
   classifyValidatorOutcome,
   createScrapeRunStatement,
+  isRunBudgetExhausted,
+  resolveRunBudgetMs,
+  resolveRunStatus,
   updateScrapeRunStatement,
 } from './scrape-coverage.js';
 
@@ -143,7 +146,27 @@ export async function scrapeRetailer(slug: string) {
 
   const delay = config.rateLimit?.delayBetweenRequestsMs ?? 2_000;
 
+  // Wall-clock ceiling for one retailer's target loop. Each candidate URL can
+  // now cost two bounded provider calls (Firecrawl, then the opt-in Exa
+  // fallback), so a provider brown-out that never trips the 2-strike cooldowns
+  // — every call slow but eventually answering — can run far past the cron
+  // slot. Without this the only stop is an external kill, which skips
+  // updateScrapeRun entirely and strands the row at status='running'; the
+  // active-run query has no age bound, so that row is served indefinitely.
+  // Stopping ourselves keeps the run's own accounting honest: whatever was
+  // scraped is committed and the status lands on 'partial'.
+  const runBudgetMs = resolveRunBudgetMs(process.env.CONSUMER_PRICES_RUN_BUDGET_MS);
+  const runStartedAt = Date.now();
+  let budgetExhausted = false;
+
   for (const target of targets) {
+    if (isRunBudgetExhausted(runStartedAt, Date.now(), runBudgetMs)) {
+      budgetExhausted = true;
+      logger.warn(
+        `  [budget] ${slug}: run budget ${runBudgetMs}ms exhausted after ${pagesAttempted}/${targets.length} targets — stopping early`,
+      );
+      break;
+    }
     pagesAttempted++;
     const isDirect = target.metadata?.direct === true;
     const pinnedProductId = target.metadata?.pinnedProductId as string | undefined;
@@ -305,7 +328,7 @@ export async function scrapeRetailer(slug: string) {
     if (pagesAttempted < targets.length) await sleep(delay);
   }
 
-  const status = errorsCount === 0 ? 'completed' : pagesSucceeded > 0 ? 'partial' : 'failed';
+  const status = resolveRunStatus(errorsCount, pagesSucceeded, budgetExhausted);
   await updateScrapeRun(runId, status, pagesAttempted, pagesSucceeded, errorsCount, rejectedCount);
   logger.info(`Run ${runId} finished: ${status} (${pagesSucceeded}/${pagesAttempted} pages, rejected=${rejectedCount})`);
 

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -10,7 +10,7 @@ import { loadAllRetailerConfigs, loadRetailerConfig } from '../config/loader.js'
 import { initProviders, teardownAll } from '../acquisition/registry.js';
 import { GenericPlaywrightAdapter } from '../adapters/generic.js';
 import { ExaSearchAdapter } from '../adapters/exa-search.js';
-import { SearchAdapter } from '../adapters/search.js';
+import { SearchAdapter, SearchTargetError } from '../adapters/search.js';
 import { ExaProvider } from '../acquisition/exa.js';
 import { FirecrawlProvider } from '../acquisition/firecrawl.js';
 import type { AdapterContext } from '../adapters/types.js';
@@ -295,6 +295,7 @@ export async function scrapeRetailer(slug: string) {
       pagesSucceeded++;
     } catch (err) {
       errorsCount++;
+      if (err instanceof SearchTargetError) rejectedCount += err.rejectedCount;
       logger.error(`  [${target.id}] failed: ${err}`);
       if (isDirect && pinnedProductId && pinnedMatchId) {
         await handlePinError(pinnedProductId, pinnedMatchId, target.id);


### PR DESCRIPTION
## Summary

Enabled consumer-price retailers could publish complete 12/12 category snapshots while losing the underlying retailer pages, leaving markets `COVERAGE_PARTIAL`. This change restores product-page discovery and bounded extraction recovery for the diagnosed host/path, provider, and quantity-as-price failures without weakening the validators or last-known-good publication contract.

## Evidence

Railway production logs identified four recoverable classes behind the current gaps: Noon results on the retailer-owned `minutes.noon.com` host, JioMart results in a broad non-grocery `/p/` namespace, Carrefour UAE pins using the bare hostname, and Cold Storage extraction echoing weights such as `400g` as prices. The adapter now emits provider, page, HTTP/result, and final rejection reasons for those paths so the next scheduled run can distinguish recovery from legitimate validator rejection.

## What changed

- Added explicit retailer-owned host aliases and product-route filters for JioMart IN, Noon AE/SA, Carrefour SA/AE, and Cold Storage SG.
- Added an opt-in, structured Exa extraction fallback for the five priority retailers, with nullable price and optional availability/size fields so missing-price results remain rejectable rather than fabricated.
- Preserved strict title, currency, size, and plausibility gates; quantity-as-price detection now falls back to the canonical basket size when the provider omits `sizeText` and rejects unknown size in strict mode when no expected size exists.
- Added per-provider failure classification, separate discovery/extraction cooldown streaks, bounded fallback attempts, and scrape-level rejection counts.
- Updated the live smoke harness to provide real item constraints and isolate provider cooldown state per retailer.

Related: #6182

## Verification

- `npm run build` in `consumer-prices-core` — passed.
- `npm test` — 18 test files, 156 tests passed.
- Focused recovery/provider suite — 4 files, 42 tests passed.
- Repository pre-push gates — passed, including Unicode safety and version sync.
- Live Exa/Firecrawl requests and production publication were not run locally because credentials and a production mutation window were unavailable; the updated smoke harness is compile-checked and is ready for the deployed validation window.

## Post-Deploy Monitoring & Validation

- Logs: Railway `seed-consumer-prices` service; search for `[search:discovery]`, `[search:extract]`, `[search:provider-cooldown]`, `provider-error`, `missing-price`, `quantity-as-price`, `validator-rejected`, and `Run .* finished`.
- Metrics/data: inspect `/api/health?compact=1` plus the per-market coverage and retailer diagnostics in seed metadata after each scheduled scrape → aggregate → publish cycle.
- Healthy signal: two consecutive scheduled cycles retain 12/12 final category snapshots, all enabled markets reach at least 90% page completion, India and Saudi Arabia reach at least 90%, no enabled retailer is below 75%, and each priority retailer reaches at least 10/12 pages or has an approved equivalent.
- Failure signal: repeated provider errors/cooldowns across all candidates, coverage below any threshold, loss of 12/12 publication, or last-known-good data being replaced by malformed observations. Keep the market `COVERAGE_PARTIAL` and last-known-good snapshot intact; revert this PR if the failure persists.
- Window/owner: the next two scheduled production runs after deployment; consumer-prices/on-call owner reviews the logs and health snapshot before considering #6182 closure.

## Known Residuals

- **P2 — `scrapeRetailer` rejection-counter integration test** (`consumer-prices-core/src/jobs/scrape.ts:298`): the `SearchTargetError.rejectedCount` handoff is covered by adapter and publication tests, but no DB-free `scrapeRetailer` harness directly exercises this catch branch. Follow-up: extract the loop/error accounting behind an injectable runner.
- **P2 — provider-side redirect host verification** (`consumer-prices-core/src/adapters/search.ts:89`): exact host checking occurs before Exa/Firecrawl fetches, but final redirect destinations are controlled by those providers and are not observable through the current interfaces. Follow-up: add resolved-URL telemetry or a provider contract that returns the final URL.

## New concepts

Per-scrape provider cooldowns are a small circuit-breaker boundary around paid or rate-limited extraction services. After repeated transport failures, the adapter stops multiplying calls across the remaining basket targets while still allowing a configured recovery provider to run once per candidate.

Why here: a normal retry loop would turn one provider outage into a long, expensive scrape and obscure the source of missing pages. This PR keeps discovery and extraction streaks separate, so successful URL search cannot hide repeated extraction failures.

```ts
// A retailer without an extraction fallback should not rediscover pages
// after Firecrawl has entered its per-scrape cooldown.
if (firecrawlCooldownOpen && extractionFallback !== 'exa') throw cooldownError;
```

Use this boundary for repeated provider/transport failures; do not cooldown on a single page-level missing price or validator rejection, which may be a legitimate product-page result.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT--5-000000)
