### PR TITLE
ops(analytics): activate the Umami 90-day retention runner (#6148)

### DIFF
--- a/docs/analytics-collector-operations.md
+++ b/docs/analytics-collector-operations.md
@@ -194,12 +194,19 @@ browser, the Vercel API, or the storage monitor.
 ## Retention runner
 
 `Dockerfile.umami-retention` packages only a digest-pinned PostgreSQL client and
-the reviewed retention SQL. Once its registry lifecycle becomes active,
-Railway runs it at minutes 7, 22, 37, and 52 of each hour. Four bounded
-10,000-row batches per hour can retire up to 960,000 eligible event rows per
-day, safely above the roughly 300,000 events/day
-observed before #6024. A once-daily 10,000-row tick would run successfully
-while permanently falling behind, so it is not an acceptable schedule.
+the reviewed retention SQL. Its registry lifecycle is active, so Railway runs it
+at minutes 7, 22, 37, and 52 of each hour. Four bounded 10,000-row batches per
+hour can retire up to 960,000 eligible event rows per day. A once-daily
+10,000-row tick would run successfully while permanently falling behind, so it
+is not an acceptable schedule.
+
+Size the schedule against the rate rows **cross** the 90-day boundary, not
+against intake. Those are different numbers whenever traffic is growing: when
+retention was activated (#6148) the collector took 591,244 events/day while only
+134,653/day aged past 90 days, because the boundary was still sweeping through
+much quieter traffic from three months earlier. Intake is the figure that
+matters for the steady state — once the boundary reaches present-day volume,
+eligibility converges on it, and 960,000/day has to stay above it.
 
 Provision the Railway `umami-retention` service from the repository root with
 `/Dockerfile.umami-retention`. Configure `PGHOST`, `PGPORT`, `PGDATABASE`,
@@ -212,13 +219,14 @@ the SQL file's transaction and statement timeouts cover work after connection.
 The image invokes `psql -X` with `ON_ERROR_STOP=1`, so a missing connection
 variable, connection timeout, or any SQL failure exits the cron non-zero.
 
-The registry deliberately marks this service as `lifecycle: planned`. Planned
-entries remain subject to static Dockerfile and registry checks, but the live
-Railway audit neither requires the service to exist nor reconciles its cron.
-Provision the service and complete the manual tick while it is planned. Only
-after the runtime migration, write canary, and manual retention gate are green
-may a separate reviewed change set `lifecycle: active`; that activation makes
-the live audit require the service and reconcile the recorded schedule.
+The registry marks this service `lifecycle: active`, so the live Railway audit
+requires it to exist and reconciles its cron. It was `planned` until #6148: a
+planned entry stays subject to the static Dockerfile and registry checks while
+the live audit neither requires the service nor reconciles its schedule, which
+is what lets the service be provisioned and manually gated before activation.
+Keep that order for any future runner — provision and complete the manual tick
+while planned, and only set `lifecycle: active` in a separate reviewed change
+once the runtime migration, write canary, and manual retention gate are green.
 
 Before enabling the recurring schedule, run one manual tick after the backup
 and record its duration, deleted-row counts, database CPU, and lock waits. Then
@@ -226,6 +234,18 @@ enable `7,22,37,52 * * * *` and observe at least four consecutive ticks. Stop
 the cron if lock waits or collector latency rise; already completed bounded
 deletes remain committed, and no further rows are touched while the cron is
 disabled.
+
+Two Railway mechanics decide whether that schedule is really running, and both
+fail quietly:
+
+- **The cron scheduler reads the active deployment's manifest, not the service
+  config.** A `serviceInstanceUpdate` that sets `cronSchedule` returns success
+  and reads back correctly from `railway environment config` while the
+  deployment keeps firing on its old schedule. Redeploy after changing it, then
+  confirm the schedule on the *deployment* manifest rather than the service.
+- **A cron tick does not create a deployment record.** It re-runs the active
+  deployment, so a tick is visible in that deployment's runtime logs and in the
+  data — never as a new row in the deployments list.
 
 The runtime-image migration and the retention runner are separate gates. Do
 not start retention until the composite-index migration has succeeded and the

--- a/docs/solutions/best-practices/retention-throughput-is-sized-against-eligibility-not-intake.md
+++ b/docs/solutions/best-practices/retention-throughput-is-sized-against-eligibility-not-intake.md
@@ -1,0 +1,101 @@
+---
+module: analytics
+date: 2026-08-04
+problem_type: best_practice
+component: background_job
+severity: medium
+applies_when: "Sizing the schedule or batch of any bounded retention, TTL, archival, or purge job that deletes rows older than a fixed age"
+tags: [retention, capacity-planning, measurement, cron, umami, postgres]
+---
+
+# Size a retention job against the eligibility rate, not against intake
+
+## Context
+
+Issue #6148 activated a 90-day retention runner whose four hourly 10,000-row
+batches retire up to 960,000 rows/day. The issue judged that margin thin by
+comparing it against **intake** — 641,713 new events/day when written, 591,244
+when measured — and concluded the backlog and the deletion contract "require
+production measurement rather than assumption." The comparison was against the
+wrong denominator, which made a comfortable 8-day drain look marginal.
+
+## Guidance
+
+A retention job that deletes rows older than N days does not race intake. It
+races the rate at which rows **cross the N-day boundary** — which is the traffic
+the system took N days ago, not today's.
+
+Measure it directly rather than deriving it:
+
+```sql
+-- rows that will become eligible in the next 24h
+SELECT count(*) FROM website_event
+WHERE created_at >= now() - interval '91 days'
+  AND created_at <  now() - interval '90 days';
+```
+
+For #6148 that returned **134,653/day** against **591,244/day** of intake — a
+4.4x difference, because the boundary was still sweeping through much quieter
+traffic from three months earlier (daily volumes either side of the cutoff ran
+71k–204k).
+
+Both numbers matter, for different questions:
+
+| Question | Denominator |
+|---|---|
+| How long to clear the existing backlog? | eligibility rate (traffic N days ago) |
+| Does the schedule hold once caught up? | intake (today's traffic) |
+
+- **Drain:** `backlog / (capacity - eligibility)` → 6,924,840 / (960,000 - 134,653) ≈ **8.4 days**
+- **Steady state:** `capacity / intake` → 960,000 / 591,244 ≈ **1.62x margin**
+
+Sizing on eligibility alone under-provisions a growing system: as the boundary
+walks forward it eventually reaches present-day volume and eligibility converges
+on intake. Sizing on intake alone over-states the backlog drain and can argue a
+healthy schedule into looking inadequate.
+
+## Why This Matters
+
+The two denominators diverge exactly when it is most tempting to guess: on a
+system whose traffic has grown. The gap is the growth ratio over the retention
+window, so a fast-growing service can show intake several times eligibility —
+and a reviewer comparing capacity to intake will read a comfortable margin as a
+knife-edge, or (in the opposite direction, on a shrinking system) approve a
+schedule that never catches up.
+
+A related trap: an eligibility rate sampled over a short window is not the daily
+average, because it inherits the *hour-of-day shape* of traffic N days ago.
+During #6148's evening observation the observed inflow was ~800/tick (≈79k/day)
+against a measured daily figure of 134,653 — the short sample would have
+overstated the drain rate by 40%. Use a full 24-hour band for the number you
+publish; use short samples only to sanity-check direction.
+
+## When to Apply
+
+Any bounded delete-by-age job: analytics retention, log/audit TTL, soft-delete
+reaping, archival sweeps, GDPR erasure batches. The rule generalizes past rows —
+anything with an age-triggered queue (files, blobs, partitions) has the same two
+denominators.
+
+## Examples
+
+Capacity claims should be stated against both, and the eligibility figure should
+be a measurement, not an inference:
+
+**Weak** — one denominator, unmeasured:
+
+> Four bounded 10,000-row batches per hour can retire up to 960,000 event rows
+> per day, safely above the roughly 300,000 events/day observed before #6024.
+
+**Strong** — both denominators, both measured:
+
+> Measured deletion throughput: 10,000 rows/tick x 4 ticks/h = 960,000/day,
+> confirmed from every tick's log. Rows become eligible at 134,653/day (measured
+> over the 90–91 day band), so the 6.89M backlog clears in ~8.3 days. Steady
+> state is governed by intake at 591,244/day, leaving a 1.62x margin.
+
+The measured-throughput half matters too: 960,000/day is a ceiling that assumes
+every tick really reaches its cap. Confirm it from the job's own output
+(`DELETE 10000` on each statement, each tick) before treating it as capacity.
+See [the runner's activation record](../../analytics-collector-operations.md)
+for the schedule this rule sized.

--- a/docs/solutions/integration-issues/railway-cron-schedule-lives-on-the-deployment-manifest.md
+++ b/docs/solutions/integration-issues/railway-cron-schedule-lives-on-the-deployment-manifest.md
@@ -1,0 +1,121 @@
+---
+module: railway-ops
+date: 2026-08-04
+problem_type: integration_issue
+component: tooling
+severity: high
+symptoms:
+  - "A cron schedule set via serviceInstanceUpdate returns true and reads back correctly, but the service keeps firing on its old schedule"
+  - "A scheduled tick produces no new row in the deployments list, so the cron looks like it never ran"
+  - "serviceInstanceUpdate with builder: DOCKERFILE fails with a bare 'Problem processing request'"
+  - "A service lands in the wrong region despite passing region to serviceInstanceUpdate"
+root_cause: config_error
+resolution_type: workflow_improvement
+related_components: [background_job, documentation]
+tags: [railway, cron, graphql, deployment, provisioning, umami]
+---
+
+# A Railway cron schedule lives on the deployment manifest, not the service config
+
+## Problem
+
+Provisioning the `umami-retention` Railway cron service for #6148, the schedule
+was set with `serviceInstanceUpdate`, the mutation returned `true`, and
+`railway environment config --json` read the new value back. The cron then did
+not fire at the scheduled minute — twice — while every surface said it was
+configured.
+
+## Symptoms
+
+- `serviceInstanceUpdate(input: {cronSchedule: "46 * * * *"})` → `{"data": {"serviceInstanceUpdate": true}}`
+- `railway environment config --json` → `"deploy": {"cronSchedule": "46 * * * *"}`
+- Minute 46 passes. No container start, no runtime logs, no data change.
+- Meanwhile the *deployment's* manifest still read `cronSchedule: "0 4 1 1 *"` —
+  the value from when the deployment was created.
+
+## What Didn't Work
+
+- **Re-reading the service config.** It kept confirming the new schedule. The
+  service config is not what the scheduler consults, so it can only ever agree
+  with itself.
+- **Watching the deployments list for a new entry.** Nothing appeared, which
+  read as "the cron never fired." That was the wrong instrument — see below.
+
+## Solution
+
+Two distinct mechanics, both of which fail quietly:
+
+**1. The scheduler reads the active deployment's manifest.** A config edit does
+not retro-apply to a running deployment. Redeploy after changing the schedule,
+then verify on the *deployment*, not the service:
+
+```graphql
+mutation($e: String!, $s: String!, $c: String!) {
+  serviceInstanceDeployV2(environmentId: $e, serviceId: $s, commitSha: $c)
+}
+```
+
+```graphql
+query($e: String!, $s: String!) {
+  deployments(first: 3, input: {environmentId: $e, serviceId: $s}) {
+    edges { node { id status createdAt meta } } }
+}
+```
+
+`meta.serviceManifest.deploy.cronSchedule` is the value that actually fires.
+Once the redeploy carried `58 * * * *`, the tick landed at 21:58 on the dot.
+
+**2. A cron tick creates no deployment record.** It re-runs the *active*
+deployment. Four scheduled ticks produced zero new rows in the deployments
+list; they were visible only in that deployment's runtime logs (one
+`Starting Container` + the job's stdout per tick) and in the data itself. Count
+ticks by grepping the active deployment's logs, never by polling for new
+deployments.
+
+Two adjacent API shapes cost time in the same session:
+
+- **`Builder` has no `DOCKERFILE` member** — the enum is
+  `HEROKU | NIXPACKS | PAKETO | RAILPACK`. Passing `builder: "DOCKERFILE"` fails
+  with an unhelpful bare `Problem processing request`. Setting `dockerfilePath`
+  is what selects the Dockerfile builder, and the config then *reads back* as
+  `builder: "DOCKERFILE"` — which is exactly why copying a read-back config
+  forward as a write payload fails.
+- **`serviceInstanceUpdate`'s `region` field does not place the instance.**
+  The service landed in `asia-southeast1-eqsg3a` (not the database's region)
+  until `multiRegionConfig: {"us-east4-eqdc4a": {"numReplicas": 1}}` was set
+  explicitly.
+
+## Why This Works
+
+A Railway deployment is an immutable snapshot: image plus the manifest that was
+current when it was created. The service config is the *template for the next*
+deployment. Everything that reads the service config — the CLI, the API, the
+dashboard — is reading the template and is therefore consistent with itself and
+useless as evidence about the running job. Only the deployment manifest is
+evidence.
+
+This is the same failure class as
+[merged-is-not-ran-long-cron-seeders.md](./merged-is-not-ran-long-cron-seeders.md)
+and the standing note that `scripts/railway-services.json` is documentation
+audited by a test, never something applied to Railway: in all three, a
+config-shaped surface agrees with your intent while production runs something
+else.
+
+## Prevention
+
+- **After changing any deploy-time field, redeploy and assert on the deployment
+  manifest.** Treat `serviceInstanceUpdate` returning `true` as "recorded for
+  next time," not "applied."
+- **Verify a cron by its effect, not by its record.** Ticks show up in runtime
+  logs and in the data. For `umami-retention` the check was
+  `railway logs -d <deployment-id> | grep -c '^COMMIT'` plus a falling row count
+  — both independent of any config surface.
+- **Provision an exit-on-completion cron service with a far-future cron pin.**
+  `0 4 1 1 *` (1 Jan 04:00) makes Railway build the image and run nothing. That
+  buys two things: a Dockerfile service whose command exits is not a
+  restart-loop candidate, and the image is proven while a pre-mutation backup is
+  still being verified. Confirm the pin held before releasing it — for #6148,
+  the deployment produced no runtime logs and the target table's row count and
+  oldest row were unchanged. Then set the real schedule and redeploy.
+- **Do not round-trip a read-back config into a write payload.** `builder` is
+  the concrete case: it is derived on read and rejected on write.

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -17,7 +17,7 @@
     "deployMode": "dockerfile",
     "dockerfile": "Dockerfile.umami-retention",
     "service": "umami-retention",
-    "lifecycle": "planned",
+    "lifecycle": "active",
     "requiredEnv": [
       "PGHOST",
       "PGPORT",

--- a/tests/umami-runtime-remediation.test.mjs
+++ b/tests/umami-runtime-remediation.test.mjs
@@ -232,7 +232,7 @@ describe('Umami runtime remediation (#6024)', () => {
       deployMode: 'dockerfile',
       dockerfile: 'Dockerfile.umami-retention',
       service: 'umami-retention',
-      lifecycle: 'planned',
+      lifecycle: 'active',
       requiredEnv: ['PGHOST', 'PGPORT', 'PGDATABASE', 'PGUSER', 'PGPASSWORD'],
       watchPatterns: [
         'scripts/umami-retention.sql',


### PR DESCRIPTION
# Issue #6148 — Umami 90-day retention activation: operational record

Project `world-monitor` / environment `production`.

## 1. Pre-flight audit (2026-08-04 ~20:27–20:35 UTC)

Read-only, via the `Postgres Umami` public TCP proxy. Server: **PostgreSQL 16.14**
(the runner image ships a psql 17 client — forward-compatible).

### Volume
| metric | value |
|---|---|
| volume instance | `8eb98704-397b-42a1-944f-3de4abec8676` (`postgres-volume`, us-east4-eqdc4a) |
| used | **32,201 / 50,000 MB = 64.4 %** |
| growth | 0.991 GiB/day |
| projected headroom | **17.5 days** |

Storage-monitor failures are the **capacity alarm firing correctly**, not a broken
monitor: run 30948231740 prints `Umami storage warning: 32201.0/50000.0 MB (64.4% used),
0.991 GiB/day, projected headroom 17.5 days.` then exits 1. Threshold hit is
`projectedHeadroomDays <= warningHeadroomDays (30)`; usage ratio 0.644 is still below
the 0.8 usage warning. Analytics Collector Monitor: **green** on every recent run.

### Relations
| table | total | heap | indexes | live | dead |
|---|---:|---:|---:|---:|---:|
| `website_event` | 25 GB | 8,432 MB | 17 GB | 19,655,465 | 0 |
| `event_data` | 3,380 MB | 1,297 MB | 2,084 MB | 11,321,074 | 15 |
| `session` | 462 MB | 87 MB | 375 MB | 739,028 | 147 |
| `session_data` | 261 MB | 17 MB | 244 MB | 61,695 | 11,615 |

`session_replay`, `heatmap_event`, `revenue` are **empty** (0 rows), so those retention
statements are no-ops. `website_event` carries 15 indexes.

### Schema vs. the retention SQL — verified
All tables and all 26 referenced columns exist **except `session_link`**, which is
absent. That is not a defect: the SQL guards both `session_link` uses with
`to_regclass('public.session_link') IS NOT NULL`, so the guard is exercised in
production exactly as designed.

Every retention scan is index-backed — confirmed with `EXPLAIN`, all plans
`LIMIT`-short-circuited:
- parent scan → `website_event_created_at_idx`
- child join/anti-join → `event_data_website_event_id_idx`
- session anti-joins → `session_created_at_idx`, `website_event_session_id_idx`,
  `session_data_session_id_idx`, `revenue_session_id_idx`,
  `session_replay_session_id_chunk_index_idx`

### Backlog and rates
Retention cutoff at audit time: 2026-05-06 20:27 UTC. Oldest event **2026-03-20
08:53:23 UTC** — 137 days, well outside the 90-day window.

| measure | website_event | event_data | session | session_data |
|---|---:|---:|---:|---:|
| rows older than 90 d | 6,924,840 | 4,237,991 | 299,192 | 12,190 |
| new in last 24 h | 591,244 | 332,565 | — | — |
| **crossing the 90 d boundary in the next 24 h** | **134,653** | **84,563** | — | — |

## 2. Throughput correction to the issue text

The issue compares the 960,000 rows/day capacity against **intake** (641,713/day at
the time, 591,244/day now) and calls the margin thin. That is the wrong denominator
for backlog drain. Rows become *eligible* at the rate traffic ran **90 days ago**,
which is **134,653 events/day** — measured, not assumed. Daily volumes either side of
the boundary run 71 k–204 k, versus 591 k today.

- Backlog drain: 960,000 − 134,653 = **825,347 events/day net** → 6.92 M / 825 k ≈ **8.4 days**.
- `event_data`: 960,000 − 84,563 → 4.24 M / 875 k ≈ **4.8 days**.
- Steady state (once the boundary reaches today's traffic, ~90 days out): eligibility
  approaches today's intake of 591 k/day against 960 k/day capacity — **1.6× margin**,
  so `7,22,37,52` holds. A once-daily tick would not.

Both figures are ceilings that assume each tick really retires a full 10,000 rows;
the manual tick measures the actual per-tick yield.

## 3. Backup (acceptance criterion 1)

**Railway volume snapshot — the restore path of record.**
- id `0ce7416e-511f-4d56-b629-c11cee9a78b6`, name `pre-retention-6148`
- created **2026-08-04T20:34:52Z**, before any mutation
- `referencedMB` 32,443 — consistent with the live volume (32,201 MB + drift)
- `expiresAt` null, and **locked** via `volumeInstanceBackupLock` so retention/GC cannot reap it
- restore path: `volumeInstanceBackupRestore(volumeInstanceId, volumeInstanceBackupId)`

Restorability cannot be proven non-destructively — a Railway restore overwrites the
live volume. So a second, independently **verifiable** artifact was taken (below).

**Logical dump.** `pg_dump -Fc -Z6` of the whole database to local disk, then restored
into a throwaway local PostgreSQL 17 cluster and compared row-for-row against
production on an immutable anchor (`created_at < 2026-08-04 20:00:00+00`, before the
dump snapshot, and before any deletion).

Production anchor counts to match:

| table | rows < anchor |
|---|---:|
| `website_event` | 19,663,055 |
| `event_data` | 11,322,101 |
| `session` | 738,611 |
| `session_data` | 61,426 |
| `website` | 2 (all) |
| `user` | 2 (all) |

## 4. Service provisioning

Service **`umami-retention`** = `ad4184fa-51d1-487f-8b2b-61ebbdd9ab4d`.

| field | value |
|---|---|
| source | `koala73/worldmonitor` @ `main`, `rootDirectory: ""` |
| build | `/Dockerfile.umami-retention` (builder resolves to `DOCKERFILE`) |
| watchPatterns | `["scripts/umami-retention.sql", "Dockerfile.umami-retention"]` — exactly the registry list |
| restartPolicyType | `NEVER` |
| region | `us-east4-eqdc4a` — same region as `umami` and `Postgres Umami` |
| variables | `PGHOST/PGPORT/PGDATABASE/PGUSER/PGPASSWORD` as `${{"Postgres Umami".VAR}}` private references — no secret value stored on this service |

Deployment `3ebec1fe-4198-49b6-a3f6-de9582cde1b4` built **SUCCESS** at main
`028ecc2296fb3e9551ef9f2abd54d0c386e41164`.

Two provisioning notes worth keeping:
- The GraphQL `Builder` enum has **no `DOCKERFILE` member** (`HEROKU|NIXPACKS|PAKETO|RAILPACK`).
  Setting `builder: "DOCKERFILE"` fails with a bare `Problem processing request`; setting
  `dockerfilePath` is what selects the Dockerfile builder, and the config then *reads back*
  as `builder: "DOCKERFILE"`.
- `serviceInstanceUpdate`'s `region` field does not place the instance. The service
  landed in `asia-southeast1-eqsg3a` until `multiRegionConfig` was set explicitly.
- The service was created with a **build-only cron pin `0 4 1 1 *`**. A Dockerfile
  service whose command exits would otherwise be a restart-loop candidate, and a real
  schedule would have fired before the backup was verified. With the pin, Railway built
  the image and ran nothing: the deployment produced **no runtime logs**, and the
  backlog/oldest-event were unchanged afterwards (6,926,976 — up 2,136 from rows aging
  in, and oldest still 2026-03-20 08:53:23+00).

## 5. Collector baseline (pre-retention)

`node scripts/check-analytics-collector.mjs` → `0/12 attempts failed`, `7 probes OK`.

Write-path latency, replaying the repo's own `/api/send` write-canary probes
(32 writes, dedicated canary website id):

| label | writes | failures | mean | p50 | p90 | max |
|---|---:|---:|---:|---:|---:|---:|
| baseline-pre-retention (20:40:39Z) | 32 | 0 | 296.8 ms | 268.3 ms | 318.2 ms | 795.1 ms |

## 6. Open risk to decide separately (issue step 9)

The monitor goes green when a 24 h window shows `growthMB <= 0` (headroom → Infinity);
usage ratio 0.644 is already under the 0.8 threshold. Bounded deletes make pages
**reusable**, not returned to the filesystem, so the volume metric should *plateau*
rather than fall — plateau is sufficient for green.

But that depends on autovacuum keeping pace, and the current settings are
`autovacuum_vacuum_scale_factor = 0.2` with `autovacuum_vacuum_threshold = 50`: on a
19.6 M-row `website_event` that is ~3.9 M dead tuples before a vacuum triggers, i.e.
roughly one vacuum every ~4 days at 960 k deletions/day. Between vacuums the table
keeps extending for new inserts while freed space sits unreclaimed. If the plateau does
not materialise, the proportionate next step is a per-table
`ALTER TABLE ... SET (autovacuum_vacuum_scale_factor = ...)` (catalog-only, non-blocking)
— **not** `VACUUM FULL` and not an index rebuild. Measure first; do not apply blind.

## 7. Manual bounded tick (the gate) — 2026-08-04 21:58 UTC

Fired through the real container, not a hand-run psql, so the image, the private
variable references and the cron path were all exercised. psql output:

```
BEGIN / SET / SET / pg_advisory_xact_lock
DELETE 10000   -- event_data (children first)
DELETE 10000   -- website_event
DELETE 0       -- revenue          (table empty)
DELETE 0       -- session_replay   (table empty)
DELETE 0       -- heatmap_event    (table empty)
DELETE 10000   -- session_data
DO             -- session_link guard: no-op, table absent
DO             -- session
COMMIT
```

| measure | pre (21:40) | post (22:01) | delta |
|---|---:|---:|---:|
| `website_event` > 90 d | 6,930,744 | 6,922,346 | −8,398 (10,000 deleted, ~1.6 k aged in) |
| `event_data` > 90 d | 4,241,484 | 4,232,447 | −9,037 |
| `session` > 90 d | 299,373 | 289,425 | −9,948 |
| `session_data` > 90 d | 12,220 | 2,230 | −9,990 |
| oldest retained event | 03-20 08:53:23 | 03-20 09:32:15 | boundary advanced |

- **Duration** ~58 s for the whole transaction; no single statement near the 60 s
  `statement_timeout`.
- **Lock waits: zero.** Sampled every 3 s for 7 minutes; `locks_waiting=0` for the
  entire retention transaction. (One unrelated 6 s `Lock:spectoken` wait appeared
  later, from the collector's own speculative-insert upsert.)
- **Collector latency: no regression.** 640 writes during the tick, 0 failures,
  p50 249.6 ms / p90 296.9 ms / mean 266.7 ms — marginally *faster* than the
  baseline p50 268.3 / p90 318.2 / mean 296.8.

## 8. Four consecutive scheduled ticks — `7,22,37,52 * * * *`

Deployment `8d3d4a5a-8c83-446f-a42d-c718684db9a7`, manifest cron
`7,22,37,52 * * * *`, region `us-east4-eqdc4a`.

| tick | `website_event` > 90 d | Δ | `event_data` > 90 d | Δ | oldest retained | volume MB |
|---|---:|---:|---:|---:|---|---:|
| 22:07 | 6,912,925 | — | 4,222,776 | — | 03-20 10:56:54 | 32,447.4 |
| 22:22 | 6,903,773 | −9,152 | 4,213,218 | −9,558 | 03-20 12:16:55 | 32,447.4 |
| 22:37 | 6,894,571 | −9,202 | 4,203,711 | −9,507 | 03-20 13:20:51 | — |
| 22:52 | 6,885,353 | −9,218 | 4,194,180 | −9,531 | 03-20 14:14:53 | 32,447.4 |

All four **COMMIT**, zero `ERROR`/`FATAL`, and every tick logged a full
`DELETE 10000` for both `website_event` and `event_data` — so the 10,000-row cap
is really being reached, not approximated. `session_data`'s backlog is now
cleared: it fell to `DELETE 2230`, then `DELETE 8`, then `DELETE 14` — the trickle
aging in. Counts decrease **monotonically** and the oldest retained event walks
forward every tick.

Per-statement timings (1 s sampling), all with `wait_event = IO:DataFileRead` and
**zero lock waiters** throughout:

| tick | `event_data` delete | `website_event` delete | session `DO` | transaction |
|---|---:|---:|---:|---:|
| 22:07 | 26 s | 12 s | ~6 s | ~44 s |
| 22:22 | ~40 s | ~10 s | ~3 s | ~53 s |
| 22:37 | ~36 s | ~10 s | ~3 s | ~50 s |
| 22:52 | ~36 s | ~10 s | ~4 s | ~49 s |

Collector after the run: `0/12 attempts failed`, `7 probes OK`.

## 9. Measured throughput and catch-up

- **Measured deletion throughput: 10,000 `website_event` rows/tick × 4 ticks/h =
  40,000/h = 960,000/day.** Confirmed from every tick's log, not assumed.
- **Rate rows become eligible: 134,653/day** (measured over the 90–91 day band).
  The observed per-tick inflow during this evening hour was lower (~800/tick,
  ≈79 k/day) because traffic 90 days ago was quieter at this hour; the day-average
  is the honest denominator.
- **Catch-up estimate: 6,885,353 ÷ (960,000 − 134,653) ≈ 8.3 days** to clear the
  `website_event` backlog; `event_data` clears sooner (4.19 M ÷ ~875 k/day ≈ 4.8 d).
- **Steady state: 960,000/day capacity vs 591,244/day intake = 1.62× margin.**
  Throughput stays above the eligibility rate both during the drain and after it.

## 10. Storage: plateau started, monitor not yet green

Volume held at **32,447.4 MB across the entire observed hour** (22:11 → 22:56),
after growing 246 MB in the 1h45m before retention started. That is the intended
behaviour — bounded deletes make pages reusable rather than returning them, so
the metric plateaus rather than falling.

**The CI Umami Storage Monitor will keep failing for now, and that is expected.**
Its baseline is the newest cached sample at least 24 h old, so the 24 h window
still contains pre-retention growth. It flips green only once a full 24 h of flat
volume accumulates (`growthMB <= 0` → headroom `Infinity`); usage ratio 0.649 is
already well under the 0.8 threshold. Do not read the current red as retention
failing — read the volume series.

The plateau depends on autovacuum keeping pace, and it is not yet proven over a
full cycle: `autovacuum_vacuum_scale_factor = 0.2` on a 19.6 M-row `website_event`
means ~3.9 M dead tuples before a vacuum triggers, roughly one vacuum every ~4
days at this deletion rate. `n_dead_tup` is climbing exactly 10,000/tick
(20,000 → 50,000 over the four ticks) with no vacuum yet. If the plateau does not
hold, the proportionate next step is a per-table
`ALTER TABLE ... SET (autovacuum_vacuum_scale_factor = ...)` — catalog-only and
non-blocking — **not** `VACUUM FULL` and not an index rebuild. That remains issue
step 9's separate decision; nothing here was applied.

---

Closes #6148

https://claude.ai/code/session_01QsJ17i4KY3FJQdRsmCa2Jp
