### PR TITLE
fix(payments): capture unattributable Dodo events instead of retry-storming

### DIFF
--- a/convex/__tests__/unattributed-payments.test.ts
+++ b/convex/__tests__/unattributed-payments.test.ts
@@ -1,0 +1,521 @@
+import { convexTest } from "convex-test";
+import { expect, test, describe } from "vitest";
+import schema from "../schema";
+import { internal } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const BASE_TIMESTAMP = new Date("2026-03-21T10:00:00Z").getTime();
+
+/**
+ * Capture-and-attribute path for Dodo events we cannot own.
+ *
+ * Origin: 2026-08-03, two enterprise buyers on a $1,596 annual bundle bought
+ * through a Dodo payment link. Payment links carry `metadata: {}` — only our
+ * checkout attaches the signed `wm_user_id` — so nothing identified the buyer.
+ * Their cards failed 3DS, which is the only reason it cost noise and not money.
+ */
+describe("unattributed Dodo events", () => {
+  function subscriptionActivePayload(overrides: Record<string, unknown> = {}) {
+    return {
+      type: "subscription.active",
+      business_id: "biz_test",
+      timestamp: "2026-03-21T10:00:00Z",
+      data: {
+        payload_type: "Subscription",
+        subscription_id: "sub_paylink_001",
+        product_id: "pdt_test_pro",
+        status: "active",
+        customer: {
+          customer_id: "cus_paylink_new",
+          email: "buyer@enterprise.example",
+          name: "Enterprise Buyer",
+        },
+        metadata: {},
+        previous_billing_date: "2026-03-21T00:00:00Z",
+        next_billing_date: "2027-03-21T00:00:00Z",
+        ...overrides,
+      },
+    };
+  }
+
+  function failedPaymentPayload(overrides: Record<string, unknown> = {}) {
+    return {
+      type: "payment.failed",
+      business_id: "biz_test",
+      timestamp: "2026-03-21T10:00:00Z",
+      data: {
+        payload_type: "Payment",
+        payment_id: "pay_paylink_3ds",
+        subscription_id: "sub_paylink_3ds",
+        total_amount: 159600,
+        currency: "USD",
+        status: "failed",
+        error_code: "AUTHENTICATION_FAILURE",
+        error_message: "The customer couldn't complete 3DS authentication.",
+        customer: {
+          customer_id: "cus_paylink_new",
+          email: "buyer@enterprise.example",
+          name: "Enterprise Buyer",
+        },
+        metadata: {},
+        ...overrides,
+      },
+    };
+  }
+
+  test("a PAID activation nobody owns is captured instead of thrown away", async () => {
+    const t = convexTest(schema, modules);
+
+    // Must not throw: throwing burned all 8 Dodo retries and lost the event.
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_paylink_active",
+      eventType: "subscription.active",
+      rawPayload: subscriptionActivePayload(),
+      timestamp: BASE_TIMESTAMP,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("unattributedPaymentEvents").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].charged).toBe(true);
+    expect(rows[0].resolved).toBe(false);
+    expect(rows[0].customerEmail).toBe("buyer@enterprise.example");
+    expect(rows[0].dodoSubscriptionId).toBe("sub_paylink_001");
+    expect(rows[0].notifiedAt).toBeDefined();
+
+    // Nothing invented: no subscription or entitlement for a user we can't name.
+    const { subs, ents } = await t.run(async (ctx) => ({
+      subs: await ctx.db.query("subscriptions").collect(),
+      ents: await ctx.db.query("entitlements").collect(),
+    }));
+    expect(subs).toHaveLength(0);
+    expect(ents).toHaveLength(0);
+  });
+
+  test("an active-status subscription.updated records its REAL envelope and counts as charged", async () => {
+    const t = convexTest(schema, modules);
+
+    // handleSubscriptionUpdated routes this to handleSubscriptionActive. The row
+    // must say `subscription.updated` — that is what replay re-dispatches — and
+    // must still be `charged`, which the event type alone cannot tell you.
+    const payload = subscriptionActivePayload();
+    payload.type = "subscription.updated";
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_paylink_updated",
+      eventType: "subscription.updated",
+      rawPayload: payload,
+      timestamp: BASE_TIMESTAMP,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("unattributedPaymentEvents").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].eventType).toBe("subscription.updated");
+    expect(rows[0].charged).toBe(true);
+    expect(rows[0].notifiedAt).toBeDefined();
+  });
+
+  test("attributing an active-status subscription.updated still grants entitlement", async () => {
+    const t = convexTest(schema, modules);
+
+    const payload = subscriptionActivePayload();
+    payload.type = "subscription.updated";
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_paylink_updated",
+      eventType: "subscription.updated",
+      rawPayload: payload,
+      timestamp: BASE_TIMESTAMP,
+    });
+    const [pending] = await t.run(async (ctx) =>
+      ctx.db.query("unattributedPaymentEvents").collect(),
+    );
+
+    await t.mutation(
+      internal.payments.webhookMutations.attributeUnattributedPayment,
+      { rowId: pending._id, userId: "user_enterprise_buyer" },
+    );
+
+    // Replay must route updated -> active and land the same fulfillment.
+    const { subs, ents } = await t.run(async (ctx) => ({
+      subs: await ctx.db.query("subscriptions").collect(),
+      ents: await ctx.db.query("entitlements").collect(),
+    }));
+    expect(subs).toHaveLength(1);
+    expect(subs[0].userId).toBe("user_enterprise_buyer");
+    expect(ents).toHaveLength(1);
+    expect(ents[0].userId).toBe("user_enterprise_buyer");
+  });
+
+  test("attributing it replays the event and grants the entitlement", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_paylink_active",
+      eventType: "subscription.active",
+      rawPayload: subscriptionActivePayload(),
+      timestamp: BASE_TIMESTAMP,
+    });
+    const [pending] = await t.run(async (ctx) =>
+      ctx.db.query("unattributedPaymentEvents").collect(),
+    );
+
+    const result = await t.mutation(
+      internal.payments.webhookMutations.attributeUnattributedPayment,
+      {
+        rowId: pending._id,
+        userId: "user_enterprise_buyer",
+        note: "5-seat deal, sold via payment link",
+      },
+    );
+    expect(result.attributedTo).toBe("user_enterprise_buyer");
+
+    const { subs, ents, customers, row } = await t.run(async (ctx) => ({
+      subs: await ctx.db.query("subscriptions").collect(),
+      ents: await ctx.db.query("entitlements").collect(),
+      customers: await ctx.db.query("customers").collect(),
+      row: await ctx.db.get(pending._id),
+    }));
+    // The buyer now holds exactly what a normal checkout would have given them.
+    expect(subs).toHaveLength(1);
+    expect(subs[0].userId).toBe("user_enterprise_buyer");
+    expect(subs[0].dodoSubscriptionId).toBe("sub_paylink_001");
+    expect(ents).toHaveLength(1);
+    expect(ents[0].userId).toBe("user_enterprise_buyer");
+    // And the identity gap is closed, so future events resolve on their own.
+    expect(customers).toHaveLength(1);
+    expect(customers[0].dodoCustomerId).toBe("cus_paylink_new");
+    expect(row?.resolved).toBe(true);
+    expect(row?.resolvedUserId).toBe("user_enterprise_buyer");
+  });
+
+  test("attributing twice is refused rather than replayed", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_paylink_active",
+      eventType: "subscription.active",
+      rawPayload: subscriptionActivePayload(),
+      timestamp: BASE_TIMESTAMP,
+    });
+    const [pending] = await t.run(async (ctx) =>
+      ctx.db.query("unattributedPaymentEvents").collect(),
+    );
+    await t.mutation(
+      internal.payments.webhookMutations.attributeUnattributedPayment,
+      { rowId: pending._id, userId: "user_enterprise_buyer" },
+    );
+
+    await expect(
+      t.mutation(
+        internal.payments.webhookMutations.attributeUnattributedPayment,
+        { rowId: pending._id, userId: "user_someone_else" },
+      ),
+    ).rejects.toThrow(/already attributed/);
+  });
+
+  test("a customer already owned by someone else is never reassigned", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: "user_rightful_owner",
+        dodoCustomerId: "cus_paylink_new",
+        email: "buyer@enterprise.example",
+        normalizedEmail: "buyer@enterprise.example",
+        createdAt: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP,
+      });
+    });
+    // With a customers row present the event resolves normally, so force the
+    // unattributed row to exist and then attempt a mismatched attribution.
+    const rowId = await t.run(async (ctx) =>
+      ctx.db.insert("unattributedPaymentEvents", {
+        webhookId: "wh_conflict",
+        eventType: "subscription.active",
+        charged: true,
+        dodoCustomerId: "cus_paylink_new",
+        rawPayload: subscriptionActivePayload(),
+        eventTimestamp: BASE_TIMESTAMP,
+        receivedAt: BASE_TIMESTAMP,
+        lastSeenAt: BASE_TIMESTAMP,
+        occurrences: 1,
+        resolved: false,
+      }),
+    );
+
+    await expect(
+      t.mutation(
+        internal.payments.webhookMutations.attributeUnattributedPayment,
+        { rowId, userId: "user_impostor" },
+      ),
+    ).rejects.toThrow(/already maps to user_rightful_owner/);
+  });
+
+  test("an uncharged failure is captured and flagged as not-charged", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_paylink_3ds",
+      eventType: "payment.failed",
+      rawPayload: failedPaymentPayload(),
+      timestamp: BASE_TIMESTAMP,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("unattributedPaymentEvents").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].charged).toBe(false);
+    expect(rows[0].errorCode).toBe("AUTHENTICATION_FAILURE");
+    expect(rows[0].amount).toBe(159600);
+    // Notified: a buyer failing to pay is a sales signal we asked to hear about.
+    expect(rows[0].notifiedAt).toBeDefined();
+  });
+
+  test("repeat uncharged attempts from one customer alert only once per day", async () => {
+    const t = convexTest(schema, modules);
+
+    for (const n of [1, 2, 3]) {
+      await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+        webhookId: `wh_burst_${n}`,
+        eventType: "payment.failed",
+        rawPayload: failedPaymentPayload({ payment_id: `pay_burst_${n}` }),
+        timestamp: BASE_TIMESTAMP,
+      });
+    }
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("unattributedPaymentEvents").collect(),
+    );
+    // Every attempt is recorded — the throttle suppresses alerts, not evidence.
+    expect(rows).toHaveLength(3);
+    expect(rows.filter((r) => r.notifiedAt !== undefined)).toHaveLength(1);
+  });
+
+  test("alerting resumes once the quiet period since the last alert has passed", async () => {
+    const t = convexTest(schema, modules);
+
+    // Seed the shape that a naive "is there a recent row" throttle gets wrong:
+    // an old ALERTED row outside the window, plus a newer THROTTLED row inside
+    // it. The next attempt must alert — 24h have passed since we last spoke up.
+    // Anchored to Date.now(), because that is the clock the throttle compares
+    // against — seeding from BASE_TIMESTAMP puts every row outside the window
+    // and makes the assertion vacuous.
+    const now = Date.now();
+    const staleAlert = now - 30 * 60 * 60 * 1000;
+    const recentSilent = now - 2 * 60 * 60 * 1000;
+    await t.run(async (ctx) => {
+      await ctx.db.insert("unattributedPaymentEvents", {
+        webhookId: "wh_old_alerted",
+        eventType: "payment.failed",
+        charged: false,
+        dodoCustomerId: "cus_paylink_new",
+        rawPayload: {},
+        eventTimestamp: staleAlert,
+        receivedAt: staleAlert,
+        lastSeenAt: staleAlert,
+        occurrences: 1,
+        notifiedAt: staleAlert,
+        resolved: false,
+      });
+      await ctx.db.insert("unattributedPaymentEvents", {
+        webhookId: "wh_recent_throttled",
+        eventType: "payment.failed",
+        charged: false,
+        dodoCustomerId: "cus_paylink_new",
+        rawPayload: {},
+        eventTimestamp: recentSilent,
+        receivedAt: recentSilent,
+        lastSeenAt: recentSilent,
+        occurrences: 1,
+        resolved: false,
+      });
+    });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_after_quiet_period",
+      eventType: "payment.failed",
+      rawPayload: failedPaymentPayload({ payment_id: "pay_after_quiet" }),
+      timestamp: BASE_TIMESTAMP,
+    });
+
+    const fresh = await t.run(async (ctx) =>
+      ctx.db
+        .query("unattributedPaymentEvents")
+        .withIndex("by_webhookId", (q) => q.eq("webhookId", "wh_after_quiet_period"))
+        .first(),
+    );
+    expect(fresh?.notifiedAt).toBeDefined();
+  });
+
+  test("the throttle honours the MOST RECENT alert, not the oldest", async () => {
+    const t = convexTest(schema, modules);
+
+    // Two alerted rows: one long outside the quiet period, one just inside it.
+    // Judging by the oldest would conclude "last alert was 30h ago, speak up"
+    // and re-alert every time an old row exists — the exact over-alerting the
+    // throttle is for.
+    const now = Date.now();
+    const staleAlert = now - 30 * 60 * 60 * 1000;
+    const freshAlert = now - 2 * 60 * 60 * 1000;
+    await t.run(async (ctx) => {
+      for (const [webhookId, at] of [
+        ["wh_alerted_stale", staleAlert],
+        ["wh_alerted_fresh", freshAlert],
+      ] as const) {
+        await ctx.db.insert("unattributedPaymentEvents", {
+          webhookId,
+          eventType: "payment.failed",
+          charged: false,
+          dodoCustomerId: "cus_paylink_new",
+          rawPayload: {},
+          eventTimestamp: at,
+          receivedAt: at,
+          lastSeenAt: at,
+          occurrences: 1,
+          notifiedAt: at,
+          resolved: false,
+        });
+      }
+    });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_within_quiet_period",
+      eventType: "payment.failed",
+      rawPayload: failedPaymentPayload({ payment_id: "pay_within_quiet" }),
+      timestamp: BASE_TIMESTAMP,
+    });
+
+    const fresh = await t.run(async (ctx) =>
+      ctx.db
+        .query("unattributedPaymentEvents")
+        .withIndex("by_webhookId", (q) =>
+          q.eq("webhookId", "wh_within_quiet_period"),
+        )
+        .first(),
+    );
+    expect(fresh).not.toBeNull();
+    expect(fresh?.notifiedAt).toBeUndefined();
+  });
+
+  test("a charged event always alerts, even behind an uncharged burst", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_burst_1",
+      eventType: "payment.failed",
+      rawPayload: failedPaymentPayload(),
+      timestamp: BASE_TIMESTAMP,
+    });
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_paid",
+      eventType: "subscription.active",
+      rawPayload: subscriptionActivePayload(),
+      timestamp: BASE_TIMESTAMP,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("unattributedPaymentEvents").collect(),
+    );
+    const charged = rows.find((r) => r.charged);
+    // Money moving must never be throttled behind a card-testing burst.
+    expect(charged?.notifiedAt).toBeDefined();
+  });
+
+  test("a redelivery of the same message does not duplicate the row or the alert", async () => {
+    const t = convexTest(schema, modules);
+
+    // Same webhookId twice. The second is skipped by the webhookEvents
+    // idempotency guard, so drive recordUnattributedEvent's own guard by
+    // clearing that record between deliveries.
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_dupe",
+      eventType: "payment.failed",
+      rawPayload: failedPaymentPayload(),
+      timestamp: BASE_TIMESTAMP,
+    });
+    await t.run(async (ctx) => {
+      for (const e of await ctx.db.query("webhookEvents").collect()) {
+        await ctx.db.delete(e._id);
+      }
+    });
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_dupe",
+      eventType: "payment.failed",
+      rawPayload: failedPaymentPayload(),
+      timestamp: BASE_TIMESTAMP,
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db.query("unattributedPaymentEvents").collect(),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].occurrences).toBe(2);
+  });
+
+  test("a known buyer's failed payment is still recorded — dunning signal intact", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: "user_known",
+        dodoCustomerId: "cus_paylink_new",
+        email: "buyer@enterprise.example",
+        normalizedEmail: "buyer@enterprise.example",
+        createdAt: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_known_failed",
+      eventType: "payment.failed",
+      rawPayload: failedPaymentPayload(),
+      timestamp: BASE_TIMESTAMP,
+    });
+
+    // The lenient unattributed path must not cost real users their dunning row.
+    const { events, rows } = await t.run(async (ctx) => ({
+      events: await ctx.db.query("paymentEvents").collect(),
+      rows: await ctx.db.query("unattributedPaymentEvents").collect(),
+    }));
+    expect(rows).toHaveLength(0);
+    expect(events).toHaveLength(1);
+    expect(events[0].userId).toBe("user_known");
+    expect(events[0].status).toBe("failed");
+  });
+
+  test("a known buyer is unaffected — no unattributed row, normal fulfillment", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: "user_known",
+        dodoCustomerId: "cus_paylink_new",
+        email: "buyer@enterprise.example",
+        normalizedEmail: "buyer@enterprise.example",
+        createdAt: BASE_TIMESTAMP,
+        updatedAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_known",
+      eventType: "subscription.active",
+      rawPayload: subscriptionActivePayload(),
+      timestamp: BASE_TIMESTAMP,
+    });
+
+    const { rows, subs } = await t.run(async (ctx) => ({
+      rows: await ctx.db.query("unattributedPaymentEvents").collect(),
+      subs: await ctx.db.query("subscriptions").collect(),
+    }));
+    expect(rows).toHaveLength(0);
+    expect(subs).toHaveLength(1);
+    expect(subs[0].userId).toBe("user_known");
+  });
+});

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -745,12 +745,14 @@ describe("webhook processWebhookEvent", () => {
     expect(paymentEvents[0].status).toBe("failed");
   });
 
-  test("payment.failed for a wholly unknown customer still fails closed, naming the inputs it tried", async () => {
+  // Previously this asserted the mutation threw. That was wrong in production:
+  // the identity lookup is deterministic, so every one of Dodo's 8 retries
+  // failed identically and a buyer abandoning 3DS raised a "delivery
+  // permanently failed" alert. No charge settled, so there is nothing to
+  // record — acknowledge it. See isChargedEventType in unattributedPayments.ts.
+  test("payment.failed for a wholly unknown customer is acknowledged, not dead-lettered", async () => {
     const t = convexTest(schema, modules);
 
-    // No customers row, no subscriptions row, unsigned metadata: genuinely
-    // unattributable, so the webhook must keep throwing (dead-letter + Dodo
-    // retry) rather than silently dropping a payment record.
     const payload = makePaymentPayload("payment.failed", {
       payment_id: "pay_unattributable",
       subscription_id: "sub_unattributable",
@@ -758,19 +760,49 @@ describe("webhook processWebhookEvent", () => {
       metadata: {},
     });
 
-    await expect(
-      t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
-        webhookId: "wh_ya_unattributable",
-        eventType: "payment.failed",
-        rawPayload: payload,
-        timestamp: BASE_TIMESTAMP,
-      }),
-    ).rejects.toThrow(/dodoCustomerId="cust_unattributable"/);
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_ya_unattributable",
+      eventType: "payment.failed",
+      rawPayload: payload,
+      timestamp: BASE_TIMESTAMP,
+    });
 
+    // Still records nothing — there is no user to attribute the row to.
     const paymentEvents = await t.run(async (ctx) => {
       return ctx.db.query("paymentEvents").collect();
     });
     expect(paymentEvents).toHaveLength(0);
+  });
+
+  test("payment.succeeded for a wholly unknown customer is captured for attribution", async () => {
+    const t = convexTest(schema, modules);
+
+    // Money moved. It must never be silently discarded — but throwing only
+    // burned Dodo's retries and lost it, so it is captured durably instead and
+    // flagged `charged` for the ops alert. See unattributed-payments.test.ts.
+    const payload = makePaymentPayload("payment.succeeded", {
+      payment_id: "pay_unattributable_paid",
+      subscription_id: "sub_unattributable_paid",
+      customer: { customer_id: "cust_unattributable", email: "nobody@example.com" },
+      metadata: {},
+    });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_ya_unattributable_paid",
+      eventType: "payment.succeeded",
+      rawPayload: payload,
+      timestamp: BASE_TIMESTAMP,
+    });
+
+    const { paymentEvents, unattributed } = await t.run(async (ctx) => ({
+      paymentEvents: await ctx.db.query("paymentEvents").collect(),
+      unattributed: await ctx.db.query("unattributedPaymentEvents").collect(),
+    }));
+    // No paymentEvents row — it requires a userId we do not have.
+    expect(paymentEvents).toHaveLength(0);
+    expect(unattributed).toHaveLength(1);
+    expect(unattributed[0].charged).toBe(true);
+    expect(unattributed[0].dodoCustomerId).toBe("cust_unattributable");
   });
 
   // #5056 — entitlement lifecycle integrity across claim, active webhook, and dispute races.

--- a/convex/__tests__/webhookFailures.test.ts
+++ b/convex/__tests__/webhookFailures.test.ts
@@ -43,6 +43,45 @@ async function signDodoPayload(
   return `v1,${btoa(String.fromCharCode(...new Uint8Array(signature)))}`;
 }
 
+/**
+ * A provider-valid `dispute.opened` for a customer we cannot attribute.
+ *
+ * Used by the HTTP-level dead-letter tests below. It replaced an unattributable
+ * `subscription.active`, which stopped throwing once unattributable payment and
+ * activation events began being captured into `unattributedPaymentEvents` and
+ * acknowledged (see unattributed-payments.test.ts). Disputes still resolve
+ * identity strictly — a dispute presupposes a settled charge, so a customers row
+ * should always exist — which keeps a genuine dead-letter path under test here.
+ */
+function makeProviderValidDisputePayload() {
+  return {
+    business_id: "biz_failure_test",
+    type: "dispute.opened",
+    timestamp: new Date(BASE_TIMESTAMP).toISOString(),
+    data: {
+      payload_type: "Dispute",
+      dispute_id: "dp_http_failure",
+      payment_id: "pay_http_failure",
+      subscription_id: "sub_http_failure",
+      business_id: "biz_failure_test",
+      amount: "1999",
+      currency: "USD",
+      dispute_stage: "pre_dispute",
+      dispute_status: "dispute_opened",
+      reason: "fraudulent",
+      created_at: new Date(BASE_TIMESTAMP).toISOString(),
+      remarks: null,
+      customer: {
+        customer_id: "cus_http_failure",
+        email: "bad@example.com",
+        name: "Unresolved Customer",
+        metadata: {},
+        phone_number: null,
+      },
+    },
+  };
+}
+
 function makeProviderValidSubscriptionPayload() {
   return {
     business_id: "biz_failure_test",
@@ -126,11 +165,11 @@ describe("Dodo webhook failure tracking", () => {
     delete process.env.DODO_PAYMENTS_WEBHOOK_SECRET;
   });
 
-  test("dead-letters an application-invalid subscription received through the HTTP handler", async () => {
+  test("dead-letters an unresolvable dispute received through the HTTP handler", async () => {
     vi.spyOn(Date, "now").mockReturnValue(BASE_TIMESTAMP);
     process.env.DODO_PAYMENTS_WEBHOOK_SECRET = DODO_WEBHOOK_SECRET;
     const t = await makeT();
-    const body = JSON.stringify(makeProviderValidSubscriptionPayload());
+    const body = JSON.stringify(makeProviderValidDisputePayload());
     const webhookId = "wh_http_failure_001";
     const timestampSeconds = String(Math.floor(BASE_TIMESTAMP / 1000));
     const signature = await signDodoPayload(body, webhookId, timestampSeconds);
@@ -153,8 +192,10 @@ describe("Dodo webhook failure tracking", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       webhookId,
-      eventType: "subscription.active",
-      dodoSubscriptionId: "sub_http_failure",
+      eventType: "dispute.opened",
+      // The SDK's Dispute schema drops `subscription_id`, so the payment id is
+      // the subscription-adjacent identifier a dispute actually carries.
+      dodoPaymentId: "pay_http_failure",
       dodoCustomerId: "cus_http_failure",
       unresolved: true,
       attemptCount: 1,
@@ -166,12 +207,12 @@ describe("Dodo webhook failure tracking", () => {
       internal.payments.webhookMutations.reportDodoWebhookFailure,
       {
         webhookId,
-        eventType: "subscription.active",
+        eventType: "dispute.opened",
         errorKind: "Error",
         errorMessage: "Cannot resolve userId",
         attemptCount: 1,
         unresolvedCount: 1,
-        eventTypes: ["subscription.active"],
+        eventTypes: ["dispute.opened"],
       },
     );
     expect(reportLog).toHaveBeenCalledWith(
@@ -186,7 +227,7 @@ describe("Dodo webhook failure tracking", () => {
       vi.spyOn(Date, "now").mockReturnValue(BASE_TIMESTAMP);
       process.env.DODO_PAYMENTS_WEBHOOK_SECRET = DODO_WEBHOOK_SECRET;
       const t = await makeT();
-      const body = JSON.stringify(makeProviderValidSubscriptionPayload());
+      const body = JSON.stringify(makeProviderValidDisputePayload());
       const webhookId = "wh_http_signal_001";
       const timestampSeconds = String(Math.floor(BASE_TIMESTAMP / 1000));
       const signature = await signDodoPayload(body, webhookId, timestampSeconds);
@@ -212,10 +253,10 @@ describe("Dodo webhook failure tracking", () => {
       expect(reportJobs[0].args).toEqual([
         expect.objectContaining({
           webhookId,
-          eventType: "subscription.active",
+          eventType: "dispute.opened",
           attemptCount: 1,
           unresolvedCount: 1,
-          eventTypes: ["subscription.active"],
+          eventTypes: ["dispute.opened"],
         }),
       ]);
     } finally {

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -51,6 +51,7 @@ import type * as payments_checkout from "../payments/checkout.js";
 import type * as payments_seedProductPlans from "../payments/seedProductPlans.js";
 import type * as payments_subscriptionEmails from "../payments/subscriptionEmails.js";
 import type * as payments_subscriptionHelpers from "../payments/subscriptionHelpers.js";
+import type * as payments_unattributedPayments from "../payments/unattributedPayments.js";
 import type * as payments_webhookHandlers from "../payments/webhookHandlers.js";
 import type * as payments_webhookMutations from "../payments/webhookMutations.js";
 import type * as registerInterest from "../registerInterest.js";
@@ -109,6 +110,7 @@ declare const fullApi: ApiFromModules<{
   "payments/seedProductPlans": typeof payments_seedProductPlans;
   "payments/subscriptionEmails": typeof payments_subscriptionEmails;
   "payments/subscriptionHelpers": typeof payments_subscriptionHelpers;
+  "payments/unattributedPayments": typeof payments_unattributedPayments;
   "payments/webhookHandlers": typeof payments_webhookHandlers;
   "payments/webhookMutations": typeof payments_webhookMutations;
   registerInterest: typeof registerInterest;

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -17,6 +17,7 @@ import {
 } from "../config/productCatalog";
 import { ANON_ID_V4_REGEX, verifyUserId } from "../lib/identitySigning";
 import { DEV_USER_ID, isDev } from "../lib/auth";
+import { isChargedEventType, recordUnattributedEvent } from "./unattributedPayments";
 
 // ---------------------------------------------------------------------------
 // Types for webhook payload data (narrowed from `any`)
@@ -650,19 +651,19 @@ export async function resolvePlanKey(
 }
 
 /**
- * Resolves a user identity from webhook data using multiple sources:
- *   1. HMAC-verified checkout metadata (wm_user_id + wm_user_id_sig)
- *   2. Customer table lookup by dodoCustomerId
- *   3. Dev-only fallback to test-user-001
+ * Attempts to resolve a user identity from webhook data, returning `null` when
+ * every source comes up empty instead of throwing.
  *
- * Only trusts metadata.wm_user_id when accompanied by a valid HMAC signature
- * created server-side by the authenticated checkout action.
+ * Split out from `resolveUserId` so callers can distinguish "unattributable" as
+ * an ordinary outcome rather than catching an exception — catching would also
+ * swallow unrelated failures (a crypto error inside `verifyUserId`, a db read
+ * error) and mislabel them as an unknown customer.
  */
-async function resolveUserId(
+async function tryResolveUserId(
   ctx: MutationCtx,
   dodoCustomerId: string,
   metadata?: Record<string, string>,
-): Promise<string> {
+): Promise<string | null> {
   // 1. HMAC-verified checkout metadata — only trust signed identity
   if (metadata?.wm_user_id && metadata?.wm_user_id_sig) {
     const isValid = await verifyUserId(metadata.wm_user_id, metadata.wm_user_id_sig);
@@ -699,20 +700,62 @@ async function resolveUserId(
     return DEV_USER_ID;
   }
 
+  return null;
+}
+
+/**
+ * Describes the identity sources that were tried, for the operator who has to
+ * triage the failure. Only *presence* is reported for the metadata fields —
+ * `wm_user_id` is our internal user id and must not be copied into a
+ * Sentry-forwarded string.
+ */
+function describeUnresolvedIdentity(
+  dodoCustomerId: string,
+  metadata?: Record<string, string>,
+): string {
+  return (
+    `(dodoCustomerId=${dodoCustomerId ? `"${dodoCustomerId}"` : "<absent>"}, ` +
+    `wm_user_id=${metadata?.wm_user_id ? "present" : "absent"}, ` +
+    `wm_user_id_sig=${metadata?.wm_user_id_sig ? "present" : "absent"}): ` +
+    `no verified metadata and no customer record.`
+  );
+}
+
+/**
+ * Resolves a user identity from webhook data using multiple sources:
+ *   1. HMAC-verified checkout metadata (wm_user_id + wm_user_id_sig)
+ *   2. Customer table lookup by dodoCustomerId
+ *   3. Dev-only fallback to test-user-001
+ *
+ * Only trusts metadata.wm_user_id when accompanied by a valid HMAC signature
+ * created server-side by the authenticated checkout action.
+ *
+ * Throws when nothing resolves, which dead-letters the delivery and has Dodo
+ * retry. Only `handleDisputeEvent` still relies on that: a dispute presupposes
+ * a settled charge, so a `customers` row should always exist and its absence is
+ * a genuine anomaly worth surfacing loudly.
+ *
+ * Payment, refund, and activation handlers use `tryResolveUserId` instead —
+ * retrying an unattributable event cannot succeed, because the lookup is
+ * deterministic. They capture it via `recordUnattributedEvent` and acknowledge.
+ */
+async function resolveUserId(
+  ctx: MutationCtx,
+  dodoCustomerId: string,
+  metadata?: Record<string, string>,
+): Promise<string> {
+  const userId = await tryResolveUserId(ctx, dodoCustomerId, metadata);
+  if (userId) return userId;
+
   // The message names the inputs that were actually tried, because it is the
   // only diagnostic an operator gets: it lands in `paymentWebhookFailures.
   // errorMessage` and is forwarded to Sentry by Convex auto-Sentry, where the
   // payload itself is deliberately absent. The prior wording asserted "no
   // dodoCustomerId" unconditionally, which sent triage down the wrong path on
-  // events that carried one (WORLDMONITOR-YA). Only presence is reported for
-  // the metadata fields — `wm_user_id` is our internal user id and must not be
-  // copied into a Sentry-forwarded string.
+  // events that carried one (WORLDMONITOR-YA).
   throw new Error(
     `[subscriptionHelpers] Cannot resolve userId ` +
-      `(dodoCustomerId=${dodoCustomerId ? `"${dodoCustomerId}"` : "<absent>"}, ` +
-      `wm_user_id=${metadata?.wm_user_id ? "present" : "absent"}, ` +
-      `wm_user_id_sig=${metadata?.wm_user_id_sig ? "present" : "absent"}): ` +
-      `no verified metadata and no customer record.`,
+      describeUnresolvedIdentity(dodoCustomerId, metadata),
   );
 }
 
@@ -789,6 +832,14 @@ export async function handleSubscriptionActive(
   ctx: MutationCtx,
   data: DodoSubscriptionData,
   eventTimestamp: number,
+  // Threaded through only for the unattributable path — see the guard below.
+  webhookId: string,
+  rawPayload: unknown,
+  // The event type as DELIVERED. Not always "subscription.active":
+  // `handleSubscriptionUpdated` routes an active-status `subscription.updated`
+  // here, and recording the envelope we actually received is what lets the
+  // replay in `attributeUnattributedPayment` re-dispatch it correctly.
+  eventType = "subscription.active",
 ): Promise<void> {
   const planKey = await resolvePlanKey(ctx, data.product_id);
 
@@ -825,7 +876,34 @@ export async function handleSubscriptionActive(
     : null;
   const resolvedUserId = existing
     ? existing.userId
-    : await resolveUserId(ctx, incomingDodoCustomerId ?? "", data.metadata);
+    : await tryResolveUserId(ctx, incomingDodoCustomerId ?? "", data.metadata);
+
+  if (!resolvedUserId) {
+    // The activation of a subscription whose first payment already settled, for
+    // a buyer we cannot name — the payment-link case. Previously this threw,
+    // which meant a paid customer got nothing and the event died after Dodo's
+    // 8 deterministic retries. Capture it for manual attribution instead.
+    await recordUnattributedEvent(ctx, {
+      webhookId,
+      eventType,
+      rawPayload,
+      data,
+      eventTimestamp,
+      // Reaching this handler at all means the subscription is active, i.e. its
+      // first payment settled — true even when the envelope was
+      // `subscription.updated`, which `isChargedEventType` cannot know.
+      charged: true,
+    });
+    // sentry-coverage-ok: recordUnattributedEvent persists the row and emails
+    // ops; this console.error is the Sentry signal for the same incident.
+    console.error(
+      `[subscriptionHelpers] Unattributable "${eventType}" ` +
+        describeUnresolvedIdentity(incomingDodoCustomerId ?? "", data.metadata) +
+        ` A settled subscription has no owner — recorded for manual attribution.`,
+    );
+    return;
+  }
+
   const userId = existing
     ? existing.userId
     : preferExistingCustomerOwner(existingCustomer?.userId, resolvedUserId);
@@ -1362,11 +1440,23 @@ export async function handleSubscriptionUpdated(
   ctx: MutationCtx,
   data: DodoSubscriptionData,
   eventTimestamp: number,
+  // Forwarded to handleSubscriptionActive so a `subscription.updated` that
+  // carries an active status reaches the same unattributable capture as a
+  // first-party `subscription.active`.
+  webhookId: string,
+  rawPayload: unknown,
 ): Promise<void> {
   const status = (data.status ?? "").toString();
   switch (status) {
     case "active":
-      return handleSubscriptionActive(ctx, data, eventTimestamp);
+      return handleSubscriptionActive(
+        ctx,
+        data,
+        eventTimestamp,
+        webhookId,
+        rawPayload,
+        "subscription.updated",
+      );
     case "on_hold":
       return handleSubscriptionOnHold(ctx, data, eventTimestamp);
     case "cancelled":
@@ -1410,6 +1500,10 @@ export async function handlePaymentOrRefundEvent(
   data: DodoPaymentData,
   eventType: string,
   eventTimestamp: number,
+  // Threaded through only for the unattributable path, which must persist the
+  // original delivery so an operator can replay it once identity is known.
+  webhookId: string,
+  rawPayload: unknown,
 ): Promise<void> {
   // Subscription-first resolution, mirroring handleDisputeEvent below over the
   // identical `DodoPaymentData` shape. Dodo's payment payloads routinely drop
@@ -1427,12 +1521,47 @@ export async function handlePaymentOrRefundEvent(
         )
         .unique()
     : null;
-  const userId = existingSubscription?.userId
-    ?? await resolveUserId(
+  const resolvedUserId = existingSubscription?.userId
+    ?? await tryResolveUserId(
       ctx,
       data.customer?.customer_id ?? "",
       data.metadata,
     );
+
+  if (!resolvedUserId) {
+    // Authenticated, intact, and unattributable. Retrying cannot help — the
+    // identity lookup is deterministic — so capture it durably, alert ops, and
+    // let the webhook acknowledge. A throw from the recorder propagates on
+    // purpose: we may only acknowledge once the row is committed.
+    await recordUnattributedEvent(ctx, {
+      webhookId,
+      eventType,
+      rawPayload,
+      data,
+      eventTimestamp,
+    });
+    // Severity comes from the same charged/uncharged call that sets the row's
+    // `charged` flag — a second list here would drift from it, and `refund.failed`
+    // (in neither list) already showed how: logged as an incident, recorded as a
+    // non-event.
+    const severity = isChargedEventType(eventType) ? "error" : "warn";
+    const message =
+      `[subscriptionHelpers] Unattributable "${eventType}" ` +
+      describeUnresolvedIdentity(
+        data.customer?.customer_id ?? "",
+        data.metadata,
+      ) +
+      (severity === "error"
+        ? ` MONEY MOVED — recorded for manual attribution and acknowledged.`
+        : ` No charge settled — recorded and acknowledged.`);
+    // sentry-coverage-ok: a settled charge with no owner is reported to Sentry
+    // via console.error AND emailed to ops by recordUnattributedEvent; an
+    // uncharged attempt is a sales signal, not a defect, so it stays a warn.
+    if (severity === "error") console.error(message);
+    else console.warn(message);
+    return;
+  }
+  const userId = resolvedUserId;
 
   const type = eventType.startsWith("refund.") ? "refund" : "charge";
   // Non-terminal payment states (processing, requires_customer_action / 3DS-SCA)

--- a/convex/payments/unattributedPayments.ts
+++ b/convex/payments/unattributedPayments.ts
@@ -1,0 +1,278 @@
+import { internalAction, internalQuery, type MutationCtx } from "../_generated/server";
+import { v } from "convex/values";
+import { internal } from "../_generated/api";
+
+const ADMIN_EMAIL = "elie@worldmonitor.app";
+
+/**
+ * Per-customer quiet period for *uncharged* events only.
+ *
+ * A settled charge always emails immediately — money is on the line and the
+ * volume is inherently tiny. Uncharged attempts are throttled because a
+ * card-testing burst hits the same customer repeatedly, and one admin email per
+ * attempt would train the recipient to ignore the alert.
+ */
+const UNCHARGED_NOTIFY_QUIET_PERIOD_MS = 24 * 60 * 60 * 1000;
+
+/** Events where money settled, so the buyer is owed fulfillment. */
+const CHARGED_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "payment.succeeded",
+  "refund.succeeded",
+  // Dodo activates a subscription only after its first payment settles.
+  "subscription.active",
+]);
+
+export function isChargedEventType(eventType: string): boolean {
+  return CHARGED_EVENT_TYPES.has(eventType);
+}
+
+type DodoCustomerLike = {
+  customer_id?: unknown;
+  email?: unknown;
+  name?: unknown;
+};
+
+type UnattributedPayloadData = {
+  customer?: DodoCustomerLike;
+  payment_id?: unknown;
+  subscription_id?: unknown;
+  product_id?: unknown;
+  total_amount?: unknown;
+  recurring_pre_tax_amount?: unknown;
+  currency?: unknown;
+  error_code?: unknown;
+  error_message?: unknown;
+};
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function num(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Durably records an authenticated-but-unattributable Dodo event and queues the
+ * ops notification.
+ *
+ * Callers MUST let a throw from here propagate: the webhook may only acknowledge
+ * (200) once this row is committed. If the write fails and we acknowledged
+ * anyway, the event would be lost outright — strictly worse than a retry storm.
+ *
+ * Returns whether a notification was queued, so tests and callers can assert the
+ * throttle without reaching into the scheduler.
+ */
+export async function recordUnattributedEvent(
+  ctx: MutationCtx,
+  args: {
+    webhookId: string;
+    eventType: string;
+    rawPayload: unknown;
+    data: UnattributedPayloadData;
+    eventTimestamp: number;
+    /**
+     * Overrides the charged/uncharged judgement for callers that know more than
+     * the envelope does. `subscription.updated` carrying an active status is a
+     * settled subscription, but its event type alone does not say so.
+     */
+    charged?: boolean;
+  },
+): Promise<{ notified: boolean }> {
+  const now = Date.now();
+  const charged = args.charged ?? isChargedEventType(args.eventType);
+  const customer = args.data.customer ?? {};
+  const dodoCustomerId = str(customer.customer_id);
+
+  // Idempotency: Dodo redelivering the same message must not create a second
+  // row or a second alert.
+  const existing = await ctx.db
+    .query("unattributedPaymentEvents")
+    .withIndex("by_webhookId", (q) => q.eq("webhookId", args.webhookId))
+    .first();
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      lastSeenAt: now,
+      occurrences: existing.occurrences + 1,
+    });
+    return { notified: false };
+  }
+
+  // Throttle uncharged alerts per customer. Charged events never throttle.
+  //
+  // The question is "did we ALERT about this customer recently", not "is there a
+  // recent row" — most rows in a burst are themselves throttled and carry no
+  // `notifiedAt`. Walk newest-first and stop at the first row we actually
+  // alerted on; `take` bounds the scan so a long burst cannot walk the table.
+  let shouldNotify = true;
+  if (!charged && dodoCustomerId) {
+    const recent = await ctx.db
+      .query("unattributedPaymentEvents")
+      .withIndex("by_dodoCustomerId_lastSeenAt", (q) =>
+        q.eq("dodoCustomerId", dodoCustomerId),
+      )
+      .order("desc")
+      .take(50);
+    const lastNotifiedAt = recent.find((r) => r.notifiedAt !== undefined)?.notifiedAt;
+    if (
+      lastNotifiedAt !== undefined &&
+      lastNotifiedAt > now - UNCHARGED_NOTIFY_QUIET_PERIOD_MS
+    ) {
+      shouldNotify = false;
+    }
+  }
+
+  const rowId = await ctx.db.insert("unattributedPaymentEvents", {
+    webhookId: args.webhookId,
+    eventType: args.eventType,
+    charged,
+    dodoCustomerId,
+    dodoPaymentId: str(args.data.payment_id),
+    dodoSubscriptionId: str(args.data.subscription_id),
+    dodoProductId: str(args.data.product_id),
+    customerEmail: str(customer.email),
+    customerName: str(customer.name),
+    amount: num(args.data.total_amount) ?? num(args.data.recurring_pre_tax_amount),
+    currency: str(args.data.currency),
+    errorCode: str(args.data.error_code),
+    errorMessage: str(args.data.error_message),
+    rawPayload: args.rawPayload,
+    eventTimestamp: args.eventTimestamp,
+    receivedAt: now,
+    lastSeenAt: now,
+    occurrences: 1,
+    notifiedAt: shouldNotify ? now : undefined,
+    resolved: false,
+  });
+
+  if (!shouldNotify) return { notified: false };
+
+  // `convex-test` cannot safely await a scheduler write started from an HTTP
+  // action's mutation, matching the existing guards in subscriptionHelpers.ts.
+  if (process.env.NODE_ENV !== "test") {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.payments.unattributedPayments.notifyUnattributedPayment,
+      { rowId },
+    );
+  }
+  return { notified: true };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function row(label: string, value: string | undefined): string {
+  if (!value) return "";
+  return `<tr><td style="color: #888; padding-right: 16px;">${escapeHtml(label)}:</td><td style="color: #fff;">${escapeHtml(value)}</td></tr>`;
+}
+
+export const getUnattributedRow = internalQuery({
+  args: { rowId: v.id("unattributedPaymentEvents") },
+  handler: async (ctx, { rowId }) => ctx.db.get(rowId),
+});
+
+/**
+ * Lists unresolved rows so an operator can see what is waiting on a human.
+ * Newest first; `charged` rows are the ones costing money.
+ */
+export const listUnresolvedUnattributed = internalQuery({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, { limit }) => {
+    const rows = await ctx.db
+      .query("unattributedPaymentEvents")
+      .withIndex("by_resolved_lastSeenAt", (q) => q.eq("resolved", false))
+      .order("desc")
+      .take(Math.min(limit ?? 50, 200));
+    // rawPayload is intentionally dropped: this is an ops listing, not an export.
+    return rows.map(({ rawPayload: _rawPayload, ...rest }) => rest);
+  },
+});
+
+/**
+ * Emails ops about an event we could not attribute.
+ *
+ * A charged row is an incident — someone paid and holds no access. An uncharged
+ * row is a sales signal: a buyer tried to pay and could not. Both are things we
+ * want to hear about; the subject line distinguishes them so neither gets lost
+ * in the other's noise.
+ */
+export const notifyUnattributedPayment = internalAction({
+  args: { rowId: v.id("unattributedPaymentEvents") },
+  handler: async (ctx, { rowId }) => {
+    const apiKey = process.env.RESEND_API_KEY;
+    if (!apiKey) {
+      console.error("[unattributedPayments] RESEND_API_KEY not set — no alert sent");
+      return;
+    }
+    const record = await ctx.runQuery(
+      internal.payments.unattributedPayments.getUnattributedRow,
+      { rowId },
+    );
+    if (!record) {
+      console.error(`[unattributedPayments] row ${rowId} vanished before notify`);
+      return;
+    }
+
+    const money = record.amount !== undefined && record.currency
+      ? `${(record.amount / 100).toFixed(2)} ${record.currency}`
+      : undefined;
+
+    const subject = record.charged
+      ? `[WM] ACTION REQUIRED — paid but unattributed (${money ?? record.eventType})`
+      : `[WM] Buyer could not pay — unattributed ${record.eventType}`;
+
+    const headline = record.charged
+      ? "Money settled and we could not attach it to a user. They have paid and hold no access."
+      : "A payment attempt failed for someone we have no account for. Nothing was charged — this is a sales signal, not an outage.";
+
+    const guidance = record.charged
+      ? `Attribute it with <code>attributeUnattributedPayment</code> (rowId + the userId who should own it). That writes the customer mapping and replays the event, granting entitlement.`
+      : `No action is required for billing. Worth a follow-up if this buyer keeps failing — repeat attempts from the same customer are throttled to one alert per 24h.`;
+
+    const html = `<div style="font-family: monospace; padding: 20px; background: #0a0a0a; color: #e0e0e0;">
+        <p style="color: ${record.charged ? "#f87171" : "#facc15"}; font-size: 16px; font-weight: bold;">${escapeHtml(record.charged ? "Unattributed PAID event" : "Unattributed failed payment")}</p>
+        <p style="font-size: 13px; color: #ccc;">${escapeHtml(headline)}</p>
+        <table style="font-size: 14px; line-height: 1.8;">
+          ${row("Event", record.eventType)}
+          ${row("Amount", money)}
+          ${row("Email", record.customerEmail)}
+          ${row("Name", record.customerName)}
+          ${row("Reason", record.errorMessage ?? record.errorCode)}
+          ${row("Customer", record.dodoCustomerId)}
+          ${row("Subscription", record.dodoSubscriptionId)}
+          ${row("Payment", record.dodoPaymentId)}
+          ${row("Product", record.dodoProductId)}
+          ${row("Row", rowId)}
+        </table>
+        <p style="font-size: 12px; color: #999; margin-top: 16px;">${guidance}</p>
+      </div>`;
+
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: "World Monitor <noreply@worldmonitor.app>",
+        to: ADMIN_EMAIL,
+        subject,
+        html,
+      }),
+    });
+    if (!response.ok) {
+      // Throwing lets Convex's action retry policy have another go; the row is
+      // already durable either way, so the record is never at risk.
+      throw new Error(
+        `[unattributedPayments] Resend failed (${response.status}) for row ${rowId}`,
+      );
+    }
+    console.log(`[unattributedPayments] alert sent for ${rowId} (charged=${record.charged})`);
+  },
+});

--- a/convex/payments/webhookMutations.ts
+++ b/convex/payments/webhookMutations.ts
@@ -384,6 +384,128 @@ export const getWebhookFailureDiagnostics = internalQuery({
 });
 
 /**
+ * Shape guards + event dispatch, shared by the live webhook path and by
+ * `attributeUnattributedPayment`'s replay.
+ *
+ * Extracted so a manually attributed event runs through EXACTLY the same
+ * handlers as a live delivery. A second copy of this switch would drift, and
+ * the replay path is precisely where a drifted copy would go unnoticed.
+ */
+async function dispatchWebhookEvent(
+  ctx: MutationCtx,
+  args: {
+    webhookId: string;
+    eventType: string;
+    rawPayload: any;
+    timestamp: number;
+  },
+): Promise<void> {
+  const data = args.rawPayload.data;
+
+  // Minimum shape guard — throw so Convex rolls back and returns 500,
+  // causing Dodo to retry instead of silently dropping the event.
+  // The HTTP action records a durable dead-letter projection after this
+  // mutation rejects, outside this transaction, so permanent schema
+  // mismatches remain repairable after Dodo exhausts its retries.
+  if (!data || typeof data !== 'object') {
+    throw new Error(
+      `[webhook] rawPayload.data is missing or not an object (eventType=${args.eventType}, webhookId=${args.webhookId})`,
+    );
+  }
+
+  const subscriptionEvents = [
+    "subscription.active", "subscription.renewed", "subscription.on_hold",
+    "subscription.cancelled", "subscription.plan_changed", "subscription.expired",
+    // PR 3 (post-launch-stabilization): Dodo's docs list `subscription.updated`
+    // as a real-time-sync event for any subscription field change. Handler
+    // dispatches by the payload's `status` field to reuse our existing
+    // lifecycle logic AND respect the paid-through-cancellation policy.
+    "subscription.updated",
+  ] as const;
+
+  if (subscriptionEvents.includes(args.eventType as typeof subscriptionEvents[number]) && !(data as Record<string, unknown>).subscription_id) {
+    throw new Error(
+      `[webhook] Missing subscription_id for subscription event (eventType=${args.eventType}, webhookId=${args.webhookId}, dataKeys=${Object.keys(data as object).join(",")})`,
+    );
+  }
+
+  switch (args.eventType) {
+    case "subscription.active":
+      await handleSubscriptionActive(
+        ctx,
+        data,
+        args.timestamp,
+        args.webhookId,
+        args.rawPayload,
+      );
+      break;
+    case "subscription.renewed":
+      await handleSubscriptionRenewed(ctx, data, args.timestamp);
+      break;
+    case "subscription.on_hold":
+      await handleSubscriptionOnHold(ctx, data, args.timestamp);
+      break;
+    case "subscription.cancelled":
+      await handleSubscriptionCancelled(ctx, data, args.timestamp);
+      break;
+    case "subscription.plan_changed":
+      await handleSubscriptionPlanChanged(ctx, data, args.timestamp);
+      break;
+    case "subscription.expired":
+      await handleSubscriptionExpired(ctx, data, args.timestamp);
+      break;
+    case "subscription.updated":
+      await handleSubscriptionUpdated(
+        ctx,
+        data,
+        args.timestamp,
+        args.webhookId,
+        args.rawPayload,
+      );
+      break;
+    case "payment.succeeded":
+    case "payment.failed":
+    // `payment.processing` is Dodo's only non-terminal payment event; its
+    // payload `data.status` carries the 3DS/SCA-pending `requires_customer_action`
+    // state. `payment.cancelled` is terminal-but-uncharged. Persisting these
+    // gives the app a pending-payment signal for duplicate-prevention (#4438)
+    // and reconciliation (#4439); previously they fell through to `default`
+    // and were dropped while the payment sat in "Requires customer action" on
+    // Dodo's dashboard. (`payment.requires_customer_action` is NOT a Dodo event
+    // type — see derivePaymentEventStatus in subscriptionHelpers.ts.)
+    case "payment.processing":
+    case "payment.cancelled":
+    case "refund.succeeded":
+    case "refund.failed":
+      await handlePaymentOrRefundEvent(
+        ctx,
+        data,
+        args.eventType,
+        args.timestamp,
+        args.webhookId,
+        args.rawPayload,
+      );
+      break;
+    case "dispute.opened":
+    case "dispute.won":
+    case "dispute.lost":
+    case "dispute.closed":
+      await handleDisputeEvent(ctx, data, args.eventType, args.timestamp);
+      break;
+    default:
+      // Loud signal for `subscription.*` additions (so a future Dodo event
+      // type doesn't silently no-op). Other unhandled events remain a warn.
+      if (typeof args.eventType === "string" && args.eventType.startsWith("subscription.")) {
+        console.error(
+          `[webhook] Unhandled subscription.* event type: ${args.eventType} — needs a dedicated handler in subscriptionHelpers.ts`,
+        );
+      } else {
+        console.warn(`[webhook] Unhandled event type: ${args.eventType}`);
+      }
+  }
+}
+
+/**
  * Idempotent webhook event processor.
  *
  * Receives parsed webhook data from the HTTP action handler,
@@ -422,90 +544,7 @@ export const processWebhookEvent = internalMutation({
     //    Errors propagate (throw) so Convex rolls back the entire transaction,
     //    preventing partial writes (e.g., subscription without entitlements).
     //    The HTTP handler catches thrown errors and returns 500 to trigger retries.
-    const data = args.rawPayload.data;
-
-    // Minimum shape guard — throw so Convex rolls back and returns 500,
-    // causing Dodo to retry instead of silently dropping the event.
-    // The HTTP action records a durable dead-letter projection after this
-    // mutation rejects, outside this transaction, so permanent schema
-    // mismatches remain repairable after Dodo exhausts its retries.
-    if (!data || typeof data !== 'object') {
-      throw new Error(
-        `[webhook] rawPayload.data is missing or not an object (eventType=${args.eventType}, webhookId=${args.webhookId})`,
-      );
-    }
-
-    const subscriptionEvents = [
-      "subscription.active", "subscription.renewed", "subscription.on_hold",
-      "subscription.cancelled", "subscription.plan_changed", "subscription.expired",
-      // PR 3 (post-launch-stabilization): Dodo's docs list `subscription.updated`
-      // as a real-time-sync event for any subscription field change. Handler
-      // dispatches by the payload's `status` field to reuse our existing
-      // lifecycle logic AND respect the paid-through-cancellation policy.
-      "subscription.updated",
-    ] as const;
-
-    if (subscriptionEvents.includes(args.eventType as typeof subscriptionEvents[number]) && !(data as Record<string, unknown>).subscription_id) {
-      throw new Error(
-        `[webhook] Missing subscription_id for subscription event (eventType=${args.eventType}, webhookId=${args.webhookId}, dataKeys=${Object.keys(data as object).join(",")})`,
-      );
-    }
-
-    switch (args.eventType) {
-      case "subscription.active":
-        await handleSubscriptionActive(ctx, data, args.timestamp);
-        break;
-      case "subscription.renewed":
-        await handleSubscriptionRenewed(ctx, data, args.timestamp);
-        break;
-      case "subscription.on_hold":
-        await handleSubscriptionOnHold(ctx, data, args.timestamp);
-        break;
-      case "subscription.cancelled":
-        await handleSubscriptionCancelled(ctx, data, args.timestamp);
-        break;
-      case "subscription.plan_changed":
-        await handleSubscriptionPlanChanged(ctx, data, args.timestamp);
-        break;
-      case "subscription.expired":
-        await handleSubscriptionExpired(ctx, data, args.timestamp);
-        break;
-      case "subscription.updated":
-        await handleSubscriptionUpdated(ctx, data, args.timestamp);
-        break;
-      case "payment.succeeded":
-      case "payment.failed":
-      // `payment.processing` is Dodo's only non-terminal payment event; its
-      // payload `data.status` carries the 3DS/SCA-pending `requires_customer_action`
-      // state. `payment.cancelled` is terminal-but-uncharged. Persisting these
-      // gives the app a pending-payment signal for duplicate-prevention (#4438)
-      // and reconciliation (#4439); previously they fell through to `default`
-      // and were dropped while the payment sat in "Requires customer action" on
-      // Dodo's dashboard. (`payment.requires_customer_action` is NOT a Dodo event
-      // type — see derivePaymentEventStatus in subscriptionHelpers.ts.)
-      case "payment.processing":
-      case "payment.cancelled":
-      case "refund.succeeded":
-      case "refund.failed":
-        await handlePaymentOrRefundEvent(ctx, data, args.eventType, args.timestamp);
-        break;
-      case "dispute.opened":
-      case "dispute.won":
-      case "dispute.lost":
-      case "dispute.closed":
-        await handleDisputeEvent(ctx, data, args.eventType, args.timestamp);
-        break;
-      default:
-        // Loud signal for `subscription.*` additions (so a future Dodo event
-        // type doesn't silently no-op). Other unhandled events remain a warn.
-        if (typeof args.eventType === "string" && args.eventType.startsWith("subscription.")) {
-          console.error(
-            `[webhook] Unhandled subscription.* event type: ${args.eventType} — needs a dedicated handler in subscriptionHelpers.ts`,
-          );
-        } else {
-          console.warn(`[webhook] Unhandled event type: ${args.eventType}`);
-        }
-    }
+    await dispatchWebhookEvent(ctx, args);
 
     // 3. Record the event AFTER successful processing.
     //    If the handler threw, we never reach here — the transaction rolls back
@@ -517,5 +556,110 @@ export const processWebhookEvent = internalMutation({
       processedAt: Date.now(),
       status: "processed",
     });
+  },
+});
+
+/**
+ * Manually attributes a captured-but-unowned Dodo event to a user, then replays
+ * it so entitlement is granted exactly as a live delivery would have.
+ *
+ * This is the repair tool for the payment-link case: a buyer purchases through a
+ * Dodo payment link (or a dashboard-created subscription), which carries no
+ * signed `wm_user_id`, so nothing tells us whose account to credit. An operator
+ * supplies that missing fact and this replays the rest.
+ *
+ * Writing the `customers` mapping first is what makes the replay succeed —
+ * `resolveUserId`'s second source is exactly that table — so the replay follows
+ * the ordinary code path rather than a privileged one that could drift from it.
+ *
+ * Run:
+ *   npx convex run payments/webhookMutations:attributeUnattributedPayment \
+ *     '{"rowId":"<id>","userId":"user_...","note":"Legendary 5-seat deal"}'
+ */
+export const attributeUnattributedPayment = internalMutation({
+  args: {
+    rowId: v.id("unattributedPaymentEvents"),
+    userId: v.string(),
+    note: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const record = await ctx.db.get(args.rowId);
+    if (!record) {
+      throw new Error(`[webhook] No unattributed event ${args.rowId}`);
+    }
+    if (record.resolved) {
+      // Replaying an already-attributed event would re-run the handlers and
+      // could re-send welcome mail or re-open a closed billing state.
+      throw new Error(
+        `[webhook] Unattributed event ${args.rowId} is already attributed to ` +
+          `${record.resolvedUserId ?? "<unknown>"} — refusing to replay.`,
+      );
+    }
+
+    // 1. Supply the missing identity so the normal resolution path works.
+    if (record.dodoCustomerId) {
+      const existingCustomer = await ctx.db
+        .query("customers")
+        .withIndex("by_dodoCustomerId", (q) =>
+          q.eq("dodoCustomerId", record.dodoCustomerId),
+        )
+        .first();
+      const email = record.customerEmail ?? existingCustomer?.email ?? "";
+      const now = Date.now();
+      if (existingCustomer) {
+        if (existingCustomer.userId !== args.userId) {
+          throw new Error(
+            `[webhook] Dodo customer ${record.dodoCustomerId} already maps to ` +
+              `${existingCustomer.userId}; refusing to reassign to ${args.userId}.`,
+          );
+        }
+      } else {
+        await ctx.db.insert("customers", {
+          userId: args.userId,
+          dodoCustomerId: record.dodoCustomerId,
+          email,
+          normalizedEmail: email.trim().toLowerCase(),
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+    }
+
+    // 2. Clear the idempotency record. The webhook acknowledged this delivery,
+    //    so `webhookEvents` holds a "processed" row that would make the replay
+    //    a no-op. Deleting it mirrors the retry path's own comment: failed
+    //    events are removed so a retry can re-process cleanly.
+    const processed = await ctx.db
+      .query("webhookEvents")
+      .withIndex("by_webhookId", (q) => q.eq("webhookId", record.webhookId))
+      .first();
+    if (processed) await ctx.db.delete(processed._id);
+
+    // 3. Replay through the identical dispatch a live delivery uses. If it
+    //    throws, the whole mutation rolls back — including the customer
+    //    mapping — so a failed repair leaves no half-applied state.
+    await dispatchWebhookEvent(ctx, {
+      webhookId: record.webhookId,
+      eventType: record.eventType,
+      rawPayload: record.rawPayload,
+      timestamp: record.eventTimestamp,
+    });
+
+    await ctx.db.insert("webhookEvents", {
+      webhookId: record.webhookId,
+      eventType: record.eventType,
+      rawPayload: record.rawPayload,
+      processedAt: Date.now(),
+      status: "processed",
+    });
+
+    await ctx.db.patch(args.rowId, {
+      resolved: true,
+      resolvedUserId: args.userId,
+      resolvedAt: Date.now(),
+      resolutionNote: args.note,
+    });
+
+    return { attributedTo: args.userId, eventType: record.eventType };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -921,6 +921,54 @@ export default defineSchema({
     updatedAt: v.number(),
   }).index("by_key", ["key"]),
 
+  // Dodo events we received and authenticated but could not attribute to a
+  // user: no signed checkout metadata and no `customers` row. The canonical
+  // source is a Dodo *payment link* / dashboard-created subscription, which
+  // carries `metadata: {}` because only our own checkout attaches the signed
+  // `wm_user_id`.
+  //
+  // These are NOT `paymentWebhookFailures`. That table means "processing broke,
+  // Dodo should retry"; retrying this never helps, because the identity lookup
+  // is deterministic — all 8 attempts fail identically (2026-08-03). This table
+  // means "received intact, needs a human to say who it belongs to", and the
+  // webhook acknowledges 200 once the row is durably committed.
+  unattributedPaymentEvents: defineTable({
+    webhookId: v.string(),
+    eventType: v.string(),
+    // Did money actually move? Drives alert severity and whether we owe the
+    // buyer fulfillment. An abandoned 3DS attempt is a sales signal; a settled
+    // charge with nobody attached is a paid customer holding no access.
+    charged: v.boolean(),
+    dodoCustomerId: v.optional(v.string()),
+    dodoPaymentId: v.optional(v.string()),
+    dodoSubscriptionId: v.optional(v.string()),
+    dodoProductId: v.optional(v.string()),
+    // Contact details come straight from the Dodo payload — they are how an
+    // operator finds the human to talk to, and the only identity signal we have.
+    customerEmail: v.optional(v.string()),
+    customerName: v.optional(v.string()),
+    amount: v.optional(v.number()),
+    currency: v.optional(v.string()),
+    errorCode: v.optional(v.string()),
+    errorMessage: v.optional(v.string()),
+    rawPayload: v.any(),
+    eventTimestamp: v.number(),
+    receivedAt: v.number(),
+    lastSeenAt: v.number(),
+    occurrences: v.number(),
+    notifiedAt: v.optional(v.number()),
+    resolved: v.boolean(),
+    resolvedUserId: v.optional(v.string()),
+    resolvedAt: v.optional(v.number()),
+    resolutionNote: v.optional(v.string()),
+  })
+    .index("by_webhookId", ["webhookId"])
+    .index("by_resolved_lastSeenAt", ["resolved", "lastSeenAt"])
+    // Powers the per-customer notification throttle: a card-testing burst must
+    // not turn into one admin email per attempt.
+    .index("by_dodoCustomerId_lastSeenAt", ["dodoCustomerId", "lastSeenAt"])
+    .index("by_dodoSubscriptionId", ["dodoSubscriptionId"]),
+
   paymentEvents: defineTable({
     userId: v.string(),
     dodoPaymentId: v.string(),


### PR DESCRIPTION
## Summary

A buyer purchasing through a Dodo **payment link** could pay and receive nothing, and we would never find out in a usable way.

Payment links and dashboard-created subscriptions arrive with `metadata: {}` — only our own checkout attaches the signed `wm_user_id` — so a first-time buyer arriving that way has no identity source at all. Identity resolution threw, which 500'd the webhook. Because that lookup is deterministic, every one of Dodo's 8 retries failed identically and the delivery permanently failed.

Both outcomes were bad in opposite directions:

| Path | Before | Now |
|---|---|---|
| Buyer paid (`payment.succeeded`, `subscription.active`) | Event thrown away after 8 retries; buyer holds no access | Captured in `unattributedPaymentEvents`, ops emailed, attributable in one command |
| Buyer failed to pay (3DS abandoned, bad card) | "Delivery permanently failed" alert that reads like an outage | Recorded and acknowledged; ops emailed once per customer per 24h |

This surfaced on 2026-08-03: two enterprise buyers on a $1,596/yr bundle both abandoned 3DS. Their cards failing is the only reason this cost noise instead of money.

## What a reviewer should check

**Returning 200 for an unattributable event is the point, not a regression.** Retrying only helps a *transient* failure. Identity resolution here is deterministic — a retry re-runs the same lookup against the same data and fails the same way. The 200 is issued strictly *after* the row commits; if the capture write fails it still throws, so Dodo retries. We never acknowledge something we did not save.

**Disputes are deliberately left strict.** A dispute presupposes a settled charge, so a missing `customers` row there is a genuine anomaly worth dead-lettering loudly. `handleDisputeEvent` still uses the throwing `resolveUserId`.

**Attribution replays through the shared dispatcher, not a copy.** `attributeUnattributedPayment` writes the customer mapping and re-dispatches through the exact switch a live delivery uses — extracted rather than duplicated, since a drifted second copy would go unnoticed precisely on the repair path.

```
npx convex run payments/webhookMutations:attributeUnattributedPayment \
  '{"rowId":"<id>","userId":"user_...","note":"5-seat deal"}'
```

Guarded against double-attribution and against reassigning a Dodo customer already owned by another user. A failed replay rolls back the mapping too, so a failed repair leaves no half-applied state.

**Alert throttling keys on the last *alert*, not the last row.** Most rows in a card-testing burst are themselves throttled and carry no `notifiedAt`, so judging by "is there a recent row" would either spam or go silent. Charged events are never throttled.

## Production reconciliation

Before changing anything, I reconciled every Dodo subscription that captured money against Convex entitlements, to confirm no existing customer was already stranded:

| Check | Result |
|---|---|
| Dodo subscriptions that captured money | 496 |
| Reconciled (subscription row + entitlement) | 493 |
| Paid but no entitlement | **0** |
| Succeeded payments (888) whose customer has no Convex row | **0** |

The 3 non-matching subscriptions are fully refunded and correctly hold no paid entitlement. No customer was affected — this closes a latent path, it does not repair existing damage.

## Test plan

- `npx vitest run --config vitest.config.mts` — 1267 pass. One unrelated pre-existing failure (`poolSelection.test.ts`, a wall-clock perf-shape test) appears only under full-suite parallelism and passes in isolation.
- Convex typecheck clean; Sentry-coverage gate clean for the changed files.
- **Mutation-tested**, each mutant confirmed to turn the suite red: cross-user reassignment guard, double-attribution guard, charged-events-never-throttled, both throttle directions, and the delivered-event-type fidelity fix.

Two existing assertions were **inverted on purpose** and are worth a look:

- `webhook.test.ts` previously asserted that an unattributable `payment.succeeded` throws. It now asserts the event is captured with `charged: true`.
- Two tests in `webhookFailures.test.ts` used an unattributable `subscription.active` purely as a way to force a throw. That fixture stopped throwing, so they now use `dispute.opened`, which still dead-letters. One assertion had to drop `dodoSubscriptionId` — the SDK's Dispute schema strips it.

## Known residuals

- `notifyUnattributedPayment` is skipped under `NODE_ENV=test` (matching the existing scheduler guards), so the email action body itself is not covered by tests.
- Unresolved rows are read via `listUnresolvedUnattributed`; there is no ops UI yet.
- Selling through payment links remains the underlying cause. This makes such a sale recoverable rather than silent; it does not make the checkout attach identity.

## New concepts

**Deterministic failures must be acknowledged, not retried.**

Webhook delivery treats a non-2xx as "try again later," which is right when the cause is *transient* — a database blip, a timeout, a deploy. It is actively harmful when the cause is *deterministic*. Identity resolution reads the same payload and the same table on every attempt, so attempt 8 fails exactly like attempt 1. The retries buy nothing and end by discarding the event, which is the worst possible outcome for a message carrying money.

This repo already dead-letters and already dedupes by webhook id, but it previously treated every handler failure as retryable. The new rule is narrower: classify the *failure*, not the event.

```mermaid
flowchart TB
    F["Handler fails"] --> Q{"Can a retry<br/>change the outcome?"}
    Q -->|"Transient<br/>db blip, timeout, deploy"| T["throw → 500<br/>provider retries<br/><i>next attempt may win</i>"]
    Q -->|"Deterministic<br/>unknown customer, bad shape"| D["capture → 200<br/>durable row + ops alert<br/><i>a retry could never win</i>"]
```

The safety condition is ordering: the acknowledgement must come *after* the capture is durable. Acknowledging first turns a retry storm into silent data loss — strictly worse than the bug being fixed. That is why `recordUnattributedEvent` is awaited and its throw deliberately propagates.

Not a licence to swallow errors: an unexpected exception is transient until proven otherwise. This applies only where you can name why a retry cannot change the outcome.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
