### PR TITLE
fix(client): keep map overlays on a faked WebGL context + name push 400s

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Agent entry point for WorldMonitor. Read this first, then follow links for depth
 
 ## What This Project Is
 
-Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 181 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
+Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 182 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
 
 ## Repository Map
 
@@ -13,7 +13,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 181
 ├── src/                    # Browser SPA (TypeScript, class-based components)
 │   ├── app/                # App orchestration (data-loader, refresh-scheduler, panel-layout)
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
-│   ├── components/         # 181 top-level TypeScript component files
+│   ├── components/         # 182 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
 │   ├── services/           # Business logic (224 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Variants share all code but differ in default panels, map layers, and RSS feeds.
 
 | Directory | Purpose |
 |---|---|
-| `src/components/` | UI components — 181 top-level TypeScript component files |
+| `src/components/` | UI components — 182 top-level TypeScript component files |
 | `src/services/` | Data fetching modules — sebuf client wrappers, AI, signal analysis |
 | `src/config/` | Static data and variant configs (feeds, geo, military, pipelines, ports) |
 | `src/generated/` | Auto-generated sebuf client + server stubs (**do not edit by hand**) |

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -16,7 +16,7 @@
     "energy": 18
   },
   "variantCount": 6,
-  "componentTopLevelTsFiles": 181,
+  "componentTopLevelTsFiles": 182,
   "serviceTopLevelEntries": 224,
   "apiEndpointEntries": 91,
   "panelClasses": 107,

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -74,6 +74,7 @@ import {
   startCountryClickGesture,
   updateCountryClickGestureDrag,
 } from './map-interaction-guard';
+import { resolveClusterGlContext } from './map-cluster-gl';
 
 
 export type TimeRange = '1h' | '6h' | '24h' | '48h' | '7d' | 'all';
@@ -1127,10 +1128,11 @@ export class MapComponent {
   }
 
   private initClusterRenderer(): void {
-    // WebGL clustering disabled - just get context for clearing canvas
-    const gl = this.clusterCanvas.getContext('webgl');
-    if (!gl) return;
-    this.clusterGl = gl;
+    // WebGL clustering disabled - just get context for clearing canvas.
+    // resolveClusterGlContext() rejects the truthy-but-method-less stub that
+    // canvas fingerprint blockers return, which used to crash the whole
+    // dynamic-layer render pass from clearClusterCanvas() (WORLDMONITOR-YG/YH).
+    this.clusterGl = resolveClusterGlContext(this.clusterCanvas);
   }
 
   private clearClusterCanvas(): void {

--- a/src/components/map-cluster-gl.ts
+++ b/src/components/map-cluster-gl.ts
@@ -1,0 +1,40 @@
+/**
+ * Cluster-canvas WebGL context acquisition for `Map.ts`.
+ *
+ * `canvas.getContext('webgl')` is specified to return `null` when WebGL is
+ * unavailable, and `if (!gl) return` was the whole guard. In production it can
+ * also return a TRUTHY object that is not a usable `WebGLRenderingContext`:
+ * canvas fingerprint-blocking extensions and hardened browsers hand back a
+ * stub/proxy that passes the null check while exposing none of the GL methods.
+ *
+ * Calling `clearColor` on that stub threw `TypeError: this.clusterGl.clearColor
+ * is not a function` out of `clearClusterCanvas()`, which sits on the
+ * synchronous render path — the throw propagated through `renderClusterLayer` →
+ * `renderDynamicLayers` → `render` and aborted the whole dynamic-layer pass, so
+ * the user lost every overlay (earthquakes, alerts, markers), not just a canvas
+ * clear that had nothing to draw anyway (WORLDMONITOR-YG/YH).
+ *
+ * Validating the exact members `clearClusterCanvas()` touches — rather than the
+ * mere presence of an object — leaves `clusterGl` null on such a device, which
+ * the existing `if (!this.clusterGl) return` already handles as a clean no-op.
+ */
+
+/** True only if `gl` exposes every member `Map.clearClusterCanvas()` uses. */
+export function isUsableClusterGlContext(gl: unknown): gl is WebGLRenderingContext {
+  if (!gl || typeof gl !== 'object') return false;
+  const ctx = gl as Partial<WebGLRenderingContext>;
+  return typeof ctx.clearColor === 'function'
+    && typeof ctx.clear === 'function'
+    && typeof ctx.COLOR_BUFFER_BIT === 'number';
+}
+
+/**
+ * Acquire the cluster canvas' GL context, or null when the browser cannot
+ * provide a usable one. Callers must treat null as "skip the GL clear".
+ */
+export function resolveClusterGlContext(
+  canvas: Pick<HTMLCanvasElement, 'getContext'>,
+): WebGLRenderingContext | null {
+  const gl = canvas.getContext('webgl');
+  return isUsableClusterGlContext(gl) ? gl : null;
+}

--- a/src/services/push-notifications.ts
+++ b/src/services/push-notifications.ts
@@ -173,6 +173,36 @@ export async function subscribeToPush(expectedUserId?: string): Promise<Subscrip
   return payload;
 }
 
+/**
+ * Shape the error thrown when `/api/notification-channels` rejects a
+ * subscription.
+ *
+ * Every rejection on that route answers with a distinct `error` code —
+ * `endpoint host is not a recognised push service`, `pro_required`,
+ * `Invalid JSON body`, `MISSING_USER_ID`, … — but the throw used to carry only
+ * the HTTP status. That made WORLDMONITOR-XR (3 events / 2 users, Chrome on
+ * macOS) permanently undiagnosable: a bare "(400)" cannot distinguish an
+ * unrecognised push host from a malformed body from an entitlement denial, and
+ * the response was already discarded by the time Sentry saw it.
+ *
+ * Only a JSON `error` string is appended, so the message stays bounded to the
+ * route's own fixed code set — a proxy/CDN HTML interstitial can't blow up
+ * Sentry's issue cardinality with one group per body.
+ */
+export async function describePushRegistrationFailure(
+  res: Pick<Response, 'status' | 'text'>,
+): Promise<string> {
+  let code = '';
+  try {
+    const parsed: unknown = JSON.parse(await res.text());
+    const error = (parsed as { error?: unknown } | null)?.error;
+    if (typeof error === 'string' && error) code = error.slice(0, 120);
+  } catch {
+    // Non-JSON body (or an unreadable stream) — the status is all we have.
+  }
+  return `Failed to register push subscription (${res.status})${code ? `: ${code}` : ''}.`;
+}
+
 async function postSubscription(
   payload: SubscriptionPayload,
   expectedUserId?: string,
@@ -182,7 +212,7 @@ async function postSubscription(
     body: JSON.stringify({ action: 'set-web-push', ...payload }),
   }, expectedUserId);
   if (!res.ok) {
-    throw new Error(`Failed to register push subscription (${res.status}).`);
+    throw new Error(await describePushRegistrationFailure(res));
   }
 }
 

--- a/tests/map-cluster-gl-context.test.mjs
+++ b/tests/map-cluster-gl-context.test.mjs
@@ -1,0 +1,121 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveClusterGlContext } from '../src/components/map-cluster-gl.ts';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const mapSrc = readFileSync(join(root, 'src', 'components', 'Map.ts'), 'utf-8');
+
+// WORLDMONITOR-YG / WORLDMONITOR-YH (11 events, production, Chrome 149/Linux):
+//
+//   TypeError: this.clusterGl.clearColor is not a function
+//     at x.clearClusterCanvas   (Map.ts clearClusterCanvas)
+//     at x.renderClusterLayer
+//     at Array.<anonymous>      (renderDynamicLayers)
+//     at x.renderDynamicLayers
+//     at x.renderWithSize / x.render
+//     at async x.renderInitialDynamicPass
+//
+// `canvas.getContext('webgl')` is specified to return `null` when WebGL is
+// unavailable, and `if (!gl) return` was the whole guard. But canvas
+// fingerprint-blocking extensions and hardened browsers hand back a TRUTHY
+// stub object that passes the null check while exposing none of the GL
+// methods. The affected session also logged "[MapContainer] Initializing SVG
+// map (globe fallback mode)" — i.e. WebGL was already degraded on that device.
+//
+// The throw is not cosmetic: `clearClusterCanvas()` sits on the synchronous
+// render path, so it aborted the entire dynamic-layer pass. That user lost
+// every overlay on the map (earthquakes, alerts, markers), not just a canvas
+// clear that had nothing to draw anyway.
+
+/** The exact shape observed in production: truthy, but not a GL context. */
+function fingerprintBlockerStub() {
+  return { canvas: null, drawingBufferWidth: 0, drawingBufferHeight: 0 };
+}
+
+/** Minimal real-shaped context exposing only what clearClusterCanvas() calls. */
+function workingGlStub() {
+  const calls = [];
+  return {
+    COLOR_BUFFER_BIT: 0x00004000,
+    clearColor(...args) { calls.push(['clearColor', ...args]); },
+    clear(...args) { calls.push(['clear', ...args]); },
+    calls,
+  };
+}
+
+function canvasReturning(context) {
+  return { getContext: (id) => (id === 'webgl' ? context : null) };
+}
+
+/** Mirror of Map.ts clearClusterCanvas(), driven by whatever the guard stored. */
+function clearClusterCanvas(clusterGl) {
+  if (!clusterGl) return;
+  clusterGl.clearColor(0, 0, 0, 0);
+  clusterGl.clear(clusterGl.COLOR_BUFFER_BIT);
+}
+
+describe('cluster canvas WebGL context guard (WORLDMONITOR-YG/YH)', () => {
+  it('rejects a truthy non-GL stub from getContext("webgl")', () => {
+    assert.equal(
+      resolveClusterGlContext(canvasReturning(fingerprintBlockerStub())),
+      null,
+      'a truthy object without GL methods must not be stored as the cluster context',
+    );
+  });
+
+  it('does not throw out of the render path when getContext returns a stub', () => {
+    const clusterGl = resolveClusterGlContext(canvasReturning(fingerprintBlockerStub()));
+    // This is the production crash: clearClusterCanvas() threw here and took
+    // the whole dynamic-layer render pass down with it.
+    assert.doesNotThrow(() => clearClusterCanvas(clusterGl));
+  });
+
+  it('still returns and drives a genuine WebGL context', () => {
+    const gl = workingGlStub();
+    const resolved = resolveClusterGlContext(canvasReturning(gl));
+    assert.equal(resolved, gl, 'a usable context must still be stored');
+    clearClusterCanvas(resolved);
+    assert.deepEqual(gl.calls, [
+      ['clearColor', 0, 0, 0, 0],
+      ['clear', 0x00004000],
+    ], 'the canvas clear must still run on a real context');
+  });
+
+  it('returns null when WebGL is genuinely unavailable', () => {
+    assert.equal(resolveClusterGlContext(canvasReturning(null)), null);
+  });
+
+  it('rejects a context missing any single member clearClusterCanvas() uses', () => {
+    const missing = [
+      ['clearColor', { clear() {}, COLOR_BUFFER_BIT: 0x4000 }],
+      ['clear', { clearColor() {}, COLOR_BUFFER_BIT: 0x4000 }],
+      ['COLOR_BUFFER_BIT', { clearColor() {}, clear() {} }],
+    ];
+    for (const [name, stub] of missing) {
+      assert.equal(
+        resolveClusterGlContext(canvasReturning(stub)),
+        null,
+        `a context without ${name} must be rejected`,
+      );
+    }
+  });
+
+  it('keeps Map.ts on the shared guard instead of a bare null check', () => {
+    // The predicate is only load-bearing if Map.ts actually routes through it.
+    const init = mapSrc.match(/private initClusterRenderer\(\): void \{[\s\S]*?\n {2}\}/);
+    assert.ok(init, 'could not locate initClusterRenderer() body');
+    assert.match(
+      init[0],
+      /resolveClusterGlContext\(/,
+      'initClusterRenderer() must acquire the context via resolveClusterGlContext()',
+    );
+    assert.doesNotMatch(
+      init[0],
+      /getContext\(/,
+      'initClusterRenderer() must not call getContext() directly — the shape check lives in resolveClusterGlContext()',
+    );
+  });
+});

--- a/tests/push-registration-failure-detail.test.mjs
+++ b/tests/push-registration-failure-detail.test.mjs
@@ -1,0 +1,106 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describePushRegistrationFailure } from '../src/services/push-notifications.ts';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const pushSrc = readFileSync(join(root, 'src', 'services', 'push-notifications.ts'), 'utf-8');
+
+// WORLDMONITOR-XR: "Error: Failed to register push subscription (400)."
+// 3 events / 2 users, Chrome on macOS, thrown from the Pro-activation push
+// step. `/api/notification-channels` rejects with a DIFFERENT `error` code for
+// every failure mode — an unrecognised push host, a non-https endpoint, a
+// missing key triple, an entitlement denial, a malformed body — but the client
+// threw only the status, so the one field naming the actual cause never
+// reached Sentry and the issue could not be diagnosed at all.
+
+/** Stand-in for the fetch Response the route actually returns. */
+function jsonResponse(status, body) {
+  return { status, text: async () => JSON.stringify(body) };
+}
+
+describe('push registration failure detail (WORLDMONITOR-XR)', () => {
+  it('names which 400 the route returned', async () => {
+    const msg = await describePushRegistrationFailure(
+      jsonResponse(400, { error: 'endpoint host is not a recognised push service' }),
+    );
+    assert.match(msg, /\(400\)/, 'status must still be present');
+    assert.match(
+      msg,
+      /endpoint host is not a recognised push service/,
+      'the server error code is the whole point — it must survive into the thrown message',
+    );
+  });
+
+  it('distinguishes the route 400s that used to collapse into one issue', async () => {
+    const codes = [
+      'endpoint, p256dh, auth required',
+      'endpoint must be https',
+      'endpoint host is not a recognised push service',
+      'invalid endpoint',
+      'Invalid JSON body',
+      'MISSING_USER_ID',
+    ];
+    const messages = await Promise.all(
+      codes.map((error) => describePushRegistrationFailure(jsonResponse(400, { error }))),
+    );
+    assert.equal(
+      new Set(messages).size,
+      codes.length,
+      'each distinct server rejection must produce a distinct message (= a distinct Sentry group)',
+    );
+  });
+
+  it('carries non-400 rejections through with their code too', async () => {
+    assert.match(
+      await describePushRegistrationFailure(jsonResponse(403, { error: 'pro_required' })),
+      /^Failed to register push subscription \(403\): pro_required\.$/,
+    );
+  });
+
+  it('falls back to the bare status when the body is not JSON', async () => {
+    const html = { status: 502, text: async () => '<!DOCTYPE html><title>Bad gateway</title>' };
+    assert.equal(
+      await describePushRegistrationFailure(html),
+      'Failed to register push subscription (502).',
+      'a proxy/CDN HTML interstitial must not leak into the message',
+    );
+  });
+
+  it('falls back to the bare status when the body cannot be read', async () => {
+    const broken = { status: 500, text: async () => { throw new Error('stream already consumed'); } };
+    assert.equal(
+      await describePushRegistrationFailure(broken),
+      'Failed to register push subscription (500).',
+      'a failed body read must not replace the registration error with its own',
+    );
+  });
+
+  it('bounds the appended code so one hostile body cannot shard Sentry groups', async () => {
+    const msg = await describePushRegistrationFailure(
+      jsonResponse(400, { error: 'x'.repeat(5000) }),
+    );
+    assert.ok(msg.length < 200, `message must stay bounded; got ${msg.length} chars`);
+  });
+
+  it('ignores a non-string error field rather than stringifying it', async () => {
+    for (const error of [{ nested: true }, ['a'], 42, null]) {
+      assert.equal(
+        await describePushRegistrationFailure(jsonResponse(400, { error })),
+        'Failed to register push subscription (400).',
+      );
+    }
+  });
+
+  it('keeps postSubscription on the shared describer', async () => {
+    const post = pushSrc.match(/async function postSubscription\([\s\S]*?\n\}/);
+    assert.ok(post, 'could not locate postSubscription()');
+    assert.match(
+      post[0],
+      /throw new Error\(await describePushRegistrationFailure\(res\)\)/,
+      'postSubscription() must throw the described failure, not a bare status',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two client-side defects found while triaging unresolved Sentry issues. Both were filed as unactionable one-liners; both were hiding something real.

**A privacy extension could silently blank the map.** On a device where a canvas fingerprint blocker fakes WebGL, `canvas.getContext('webgl')` returns a *truthy* object with none of the GL methods instead of the `null` the spec promises. `initClusterRenderer()` only checked for `null`, so the later `clearColor()` call threw. That throw lands on the **synchronous render path**: it propagated `renderClusterLayer → renderDynamicLayers → render → renderInitialDynamicPass` and aborted the entire dynamic-layer pass. The affected user got a base map with **no earthquakes, no alerts, no markers, and no visible error** — a canvas clear with nothing to draw took every overlay down with it. The context is now validated against the members it will actually be called with, so a fake one leaves `clusterGl` null and the clear becomes the no-op it was always meant to be when WebGL is absent.

**A failed push registration now says why it failed.** `/api/notification-channels` refuses a subscription with seven distinct `error` codes, but the client threw only the HTTP status and dropped the body — so `Failed to register push subscription (400).` could not distinguish an unrecognised push host from a malformed body from an entitlement denial. Each rejection now lands in its own Sentry group. **This does not fix the 400.** Its root cause is not determinable from the three captured events, every one of which discarded the deciding field; the next occurrence will be diagnosable.

## Did anything else make the same mistake?

`getContext('webgl')` is called in four places. Only one stored the context and called methods on it later:

| Call site | Status |
|---|---|
| `MapContainer.hasWebGLSupport` / `hasGlobeSupport` | Safe — `try/catch` → `false` |
| `DownloadBanner.detectPlatform` | Safe — `try/catch` |
| `ml-capabilities.checkWebGLSupport` | Safe — `try/catch`, truthiness only |
| `Map.initClusterRenderer` | **The bug** — stored it, called it one render tick later |

## Design notes

Both guards live behind a small exported function rather than inline, so the tests drive real behavior instead of asserting against source text. `map-cluster-gl.ts` is deliberately dependency-free — importing `Map.ts` in a unit test would pull in d3 and topojson for a five-line predicate.

The push describer appends only a JSON `error` string, capped at 120 characters. A proxy or CDN HTML interstitial therefore cannot shard Sentry's issue cardinality with one group per response body, and a failed body read falls back to the bare status rather than replacing the registration error with its own.

## Validation

- The map regression test was proven **red against the shipped guard first** — it reproduces the production `TypeError` by driving a mirror of `clearClusterCanvas()` with the stub shape from the Sentry stack trace, then goes green on the fix.
- Mutation-tested rather than assumed: dropping the `COLOR_BUFFER_BIT` clause, the 120-character cap, or the `typeof === 'string'` check each turns a test red.
- 14/14 new tests; 52/52 across the related map suites; `npm run typecheck` and `biome check` clean. Both files match `tests/*.test.mjs`, which CI runs via `npm run test:data` (`.github/workflows/test.yml:174`).
- **Not reproduced against a live fingerprint-blocking extension.** The stub shape is reconstructed from the Sentry stack trace and the reporting session's `globe fallback mode` breadcrumb, not captured from a real browser. The push 400 was likewise never reproduced — that is the point of the second commit.

## Related

Sentry issues, all marked resolved in next release so they auto-reopen if they recur:

- WORLDMONITOR-YG and WORLDMONITOR-YH — `TypeError: this.clusterGl.clearColor is not a function` (11 events / 1 user)
- WORLDMONITOR-XR — `Failed to register push subscription (400).` (3 events / 2 users)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
