### PR TITLE
test(prediction-markets): pin fixture expiry clock

### DIFF
--- a/scripts/_prediction-classify.mjs
+++ b/scripts/_prediction-classify.mjs
@@ -218,15 +218,15 @@ export function dedupeMarkets(markets) {
 // Returns the pools plus the pre-truncation classification counts, so the
 // seeder can log how many candidates each category actually had versus how many
 // survived the per-pool ranking cap.
-export function buildBootstrapPools(markets, { limit } = {}) {
+export function buildBootstrapPools(markets, { limit, now = Date.now() } = {}) {
   const source = Array.isArray(markets) ? markets : [];
   const deduped = dedupeMarkets(source);
   const partitioned = partitionMarkets(deduped);
   return {
     pools: {
-      geopolitical: filterAndScore(partitioned.geopolitical, null, limit),
-      tech: filterAndScore(partitioned.tech, null, limit),
-      finance: filterAndScore(partitioned.finance, null, limit),
+      geopolitical: filterAndScore(partitioned.geopolitical, null, limit, now),
+      tech: filterAndScore(partitioned.tech, null, limit, now),
+      finance: filterAndScore(partitioned.finance, null, limit, now),
     },
     classified: {
       geopolitical: partitioned.geopolitical.length,

--- a/scripts/_prediction-scoring.mjs
+++ b/scripts/_prediction-scoring.mjs
@@ -100,14 +100,14 @@ export function scoreMarket(m) {
   return (conviction * 0.5) + (Math.min(vol, 1) * 0.5);
 }
 
-export function isExpired(endDate) {
+export function isExpired(endDate, now = Date.now()) {
   if (!endDate) return false;
   const ms = Date.parse(endDate);
-  return Number.isFinite(ms) && ms < Date.now();
+  return Number.isFinite(ms) && ms < now;
 }
 
-export function filterAndScore(candidates, tagFilter, limit = 25) {
-  let filtered = candidates.filter(m => !isExpired(m.endDate));
+export function filterAndScore(candidates, tagFilter, limit = 25, now = Date.now()) {
+  let filtered = candidates.filter(m => !isExpired(m.endDate, now));
   if (tagFilter) filtered = filtered.filter(tagFilter);
 
   let result = filtered.filter(m => shouldInclude(m));

--- a/tests/prediction-market-classification.test.mjs
+++ b/tests/prediction-market-classification.test.mjs
@@ -40,14 +40,23 @@ import filterParamContracts from '../shared/openapi-filter-param-contracts.json'
 import fixture from './fixtures/prediction-markets-raw-candidates.json' with { type: 'json' };
 
 const RAW = fixture.markets;
+const FIXTURE_NOW = Date.parse('2026-08-04T00:00:00Z');
 
 // The seeder's REAL pool-building path — buildBootstrapPools is what
 // seed-prediction-markets.mjs calls, not a replica of it. This matters: an
 // earlier version of this file re-implemented the partition-then-rank wiring
 // locally, which meant reverting the seeder to the #5733 shape
 // (`filterAndScore(markets, null)` for geopolitical) left the whole suite green.
+function buildFixtureBootstrap(markets) {
+  return buildBootstrapPools(markets, { now: FIXTURE_NOW });
+}
+
 function buildPools(markets) {
-  return buildBootstrapPools(markets).pools;
+  return buildFixtureBootstrap(markets).pools;
+}
+
+function filterFixtureMarkets(tagFilter, limit = 25) {
+  return filterAndScore(RAW, tagFilter, limit, FIXTURE_NOW);
 }
 
 function titles(pool) {
@@ -62,9 +71,9 @@ describe('#5733 fixture actually exhibits the bug (guards the assertions below f
   const FINANCE_TAGS = predictionTags.finance;
 
   const legacy = {
-    geopolitical: filterAndScore(RAW, null),
-    tech: filterAndScore(RAW, (m) => m.tags?.some((t) => TECH_TAGS.includes(t))),
-    finance: filterAndScore(RAW, (m) => m.source === 'kalshi' || m.tags?.some((t) => FINANCE_TAGS.includes(t))),
+    geopolitical: filterFixtureMarkets(null),
+    tech: filterFixtureMarkets((m) => m.tags?.some((t) => TECH_TAGS.includes(t))),
+    finance: filterFixtureMarkets((m) => m.source === 'kalshi' || m.tags?.some((t) => FINANCE_TAGS.includes(t))),
   };
 
   it('the legacy geopolitical pool was an unfiltered draw from every category', () => {
@@ -336,7 +345,7 @@ describe('poolIntegrityViolations (the publish gate)', () => {
 
   it('catches the legacy unfiltered geopolitical pool wholesale', () => {
     const violations = poolIntegrityViolations({
-      geopolitical: filterAndScore(RAW, null),
+      geopolitical: filterFixtureMarkets(null),
       tech: [],
       finance: [],
     });
@@ -423,7 +432,7 @@ describe('dedupeMarkets (upstream fan-out must not freeze the feed)', () => {
     // Same url, but tags that classify differently — geo by tag vs tech by tag.
     const asGeo = { ...geo, tags: ['geopolitics'], volume: 2_000_000 };
     const asTech = { ...geo, tags: ['ai'], volume: 1_000_000 };
-    const { pools } = buildBootstrapPools([...RAW, asTech, asGeo]);
+    const { pools } = buildFixtureBootstrap([...RAW, asTech, asGeo]);
     assert.deepEqual(poolIntegrityViolations(pools), []);
     const appearances = CATEGORIES.flatMap((c) => pools[c]).filter((m) => marketIdentity(m) === marketIdentity(geo));
     assert.equal(appearances.length, 1, 'the straddling duplicate must be published exactly once');
@@ -431,8 +440,8 @@ describe('dedupeMarkets (upstream fan-out must not freeze the feed)', () => {
 
   it('reports how many duplicates it dropped so the seeder can log it', () => {
     const twin = { ...geo, volume: 1 };
-    assert.equal(buildBootstrapPools([...RAW, twin]).duplicatesDropped, 1);
-    assert.equal(buildBootstrapPools(RAW).duplicatesDropped, 0);
+    assert.equal(buildFixtureBootstrap([...RAW, twin]).duplicatesDropped, 1);
+    assert.equal(buildFixtureBootstrap(RAW).duplicatesDropped, 0);
   });
 });
 
@@ -451,7 +460,7 @@ describe('per-pool ranking: relaxation and truncation', () => {
 
   it('truncates a pool above the 25 cap, dropping the lowest-ranked entries', () => {
     // 30 tech candidates -> the published tech pool caps at 25.
-    const { pools, classified } = buildBootstrapPools(synth(30, { tag: 'ai', price: 60 }));
+    const { pools, classified } = buildFixtureBootstrap(synth(30, { tag: 'ai', price: 60 }));
     assert.equal(classified.tech, 30);
     assert.equal(pools.tech.length, 25);
     assert.deepEqual(poolIntegrityViolations(pools), []);
@@ -460,14 +469,14 @@ describe('per-pool ranking: relaxation and truncation', () => {
   it('relaxes the price band for a pool under 15, as filterAndScore intends', () => {
     // yesPrice 7 fails the strict [10,90] band but passes relaxed [5,95]; with
     // only 3 candidates the pool is under the 15 threshold so relaxation fires.
-    const { pools } = buildBootstrapPools(synth(3, { tag: 'ai', price: 7 }));
+    const { pools } = buildFixtureBootstrap(synth(3, { tag: 'ai', price: 7 }));
     assert.equal(pools.tech.length, 3, 'narrow pools relax rather than publish empty');
   });
 
   it('does NOT relax a pool that already has 15+ strict passers', () => {
     const strict = synth(20, { tag: 'ai', price: 60 });
     const edge = synth(1, { tag: 'ai', price: 7 }).map((m) => ({ ...m, url: `${m.url}-edge`, title: 'Edge at 7 percent' }));
-    const { pools } = buildBootstrapPools([...strict, ...edge]);
+    const { pools } = buildFixtureBootstrap([...strict, ...edge]);
     assert.ok(!pools.tech.some((m) => m.title === 'Edge at 7 percent'));
   });
 
@@ -475,7 +484,7 @@ describe('per-pool ranking: relaxation and truncation', () => {
     // 40 tech candidates + 2 geo: pre-fix a single ranked list would let the
     // tech flood bury both geo markets; per-pool caps keep geo addressable.
     const geoTwo = RAW.filter((m) => classifyMarket(m) === 'geopolitical').slice(0, 2);
-    const { pools } = buildBootstrapPools([...synth(40, { tag: 'ai', price: 60, volume: 90_000_000 }), ...geoTwo]);
+    const { pools } = buildFixtureBootstrap([...synth(40, { tag: 'ai', price: 60, volume: 90_000_000 }), ...geoTwo]);
     assert.equal(pools.geopolitical.length, 2);
     assert.equal(pools.tech.length, 25);
   });
@@ -545,9 +554,9 @@ describe('validateBootstrapPayload (the seeder\'s validateFn)', () => {
   it('rejects a payload whose pools are mislabeled — the #5733 regression gate', () => {
     // The exact pre-fix shape: geopolitical is an unfiltered copy of everything.
     const legacyShaped = {
-      geopolitical: filterAndScore(RAW, null),
-      tech: filterAndScore(RAW, (m) => m.tags?.some((t) => predictionTags.tech.includes(t))),
-      finance: filterAndScore(RAW, (m) => m.source === 'kalshi' || m.tags?.some((t) => predictionTags.finance.includes(t))),
+      geopolitical: filterFixtureMarkets(null),
+      tech: filterFixtureMarkets((m) => m.tags?.some((t) => predictionTags.tech.includes(t))),
+      finance: filterFixtureMarkets((m) => m.source === 'kalshi' || m.tags?.some((t) => predictionTags.finance.includes(t))),
     };
     assert.equal(validateBootstrapPayload(legacyShaped, silent), false);
   });

--- a/tests/prediction-scoring.test.mjs
+++ b/tests/prediction-scoring.test.mjs
@@ -316,6 +316,12 @@ describe('isExpired', () => {
   it('returns false for invalid date string', () => {
     assert.ok(!isExpired('not-a-date'));
   });
+
+  it('evaluates expiry against an injected clock', () => {
+    const endDate = '2026-08-05T00:00:00Z';
+    assert.ok(!isExpired(endDate, Date.parse('2026-08-04T00:00:00Z')));
+    assert.ok(isExpired(endDate, Date.parse('2026-08-05T00:00:00.001Z')));
+  });
 });
 
 describe('filterAndScore', () => {
@@ -338,6 +344,21 @@ describe('filterAndScore', () => {
     const result = filterAndScore(candidates, null);
     assert.equal(result.length, 1);
     assert.equal(result[0].title, 'ECB rate decision');
+  });
+
+  it('uses the injected clock when filtering static fixtures', () => {
+    const candidate = market('RBI policy decision', 50, 50000, {
+      endDate: '2026-08-05T00:00:00Z',
+    });
+
+    assert.equal(
+      filterAndScore([candidate], null, 25, Date.parse('2026-08-04T00:00:00Z')).length,
+      1,
+    );
+    assert.equal(
+      filterAndScore([candidate], null, 25, Date.parse('2026-08-05T00:00:00.001Z')).length,
+      0,
+    );
   });
 
   it('applies tag filter', () => {


### PR DESCRIPTION
## Summary

Prediction-market partition tests no longer expire as their static fixture ages. Expiry evaluation now accepts one optional clock snapshot and propagates it through the real pool-building path, while production callers retain the live `Date.now()` default.

Fixes #6193.

## Test plan

- `node --test tests/prediction-scoring.test.mjs tests/prediction-market-classification.test.mjs` — 127/127 passed
- `npm run typecheck`
- `npm run lint`
- pre-push gate — frontend/API type checks, changed tests, Unicode safety, version sync, and scoped guardrails passed

The full local `test:data` attempt reached the changed prediction suites green; its aggregate run was non-terminal because unrelated sandboxed integration tests could not create macOS temporary files (`mktemp: Operation not permitted`).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this only makes tests deterministic; production expiry still defaults to `Date.now()`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/GPT--5-000000)
