### PR TITLE
fix(aviation): preserve OpenSky daily credit budget

### DIFF
--- a/scripts/ais-relay-ingestion.test.cjs
+++ b/scripts/ais-relay-ingestion.test.cjs
@@ -127,6 +127,11 @@ test('relay handlers expose bounded Google/OpenSky cooldowns and RSS fallback me
     RELAY_TEST_RSS_CACHE_TTL_MS: '10',
     GF_429_COOLDOWN_MS: '60000',
     RELAY_TEST_GOOGLE_STATUS_SEQUENCE: '429',
+    RELAY_TEST_OPENSKY_STATUS_SEQUENCE: '429,200',
+    RELAY_TEST_OPENSKY_RETRY_AFTER_SECONDS: '999999',
+    RELAY_TEST_OPENSKY_REMAINING_CREDITS: '0',
+    RELAY_TEST_OPENSKY_MALFORMED_ENCODING: '1',
+    RELAY_METRICS_WINDOW_SECONDS: '10',
   });
 
   try {
@@ -141,14 +146,20 @@ test('relay handlers expose bounded Google/OpenSky cooldowns and RSS fallback me
     assert.equal(JSON.parse(googleDuringCooldown.body).cooldown, true);
     assert.ok(Number(googleDuringCooldown.headers['retry-after']) >= 1);
 
-    const openskyFirst = await get(port, '/opensky/states/all?lamin=1&lomin=1&lamax=2&lomax=2');
+    const [openskyFirst, openskyQueued] = await Promise.all([
+      get(port, '/opensky/states/all?lamin=1&lomin=1&lamax=2&lomax=2'),
+      get(port, '/opensky/states/all?lamin=3&lomin=3&lamax=4&lomax=4'),
+    ]);
     assert.equal(openskyFirst.status, 429);
-    assert.ok(Number(openskyFirst.headers['retry-after']) >= 1);
+    assert.equal(openskyQueued.headers['x-cache'], 'RATE-LIMITED', 'queued bbox must stop before a second upstream debit');
+    assert.ok(Number(openskyFirst.headers['retry-after']) >= 86_000, 'relay must honor the bounded provider reset window');
+    assert.ok(Number(openskyFirst.headers['retry-after']) <= 86_400, 'provider reset must be capped at 24 hours');
+    assert.ok(Number(openskyQueued.headers['retry-after']) >= 86_000, 'queued response must share the provider reset window');
 
-    const openskyDuringCooldown = await get(port, '/opensky/states/all?lamin=3&lomin=3&lamax=4&lomax=4');
+    const openskyDuringCooldown = await get(port, '/opensky/states/all?lamin=5&lomin=5&lamax=6&lomax=6');
     assert.equal(openskyDuringCooldown.status, 200);
     assert.equal(openskyDuringCooldown.headers['x-cache'], 'RATE-LIMITED');
-    assert.ok(Number(openskyDuringCooldown.headers['retry-after']) >= 1);
+    assert.ok(Number(openskyDuringCooldown.headers['retry-after']) >= 86_000);
 
     const noCacheFeed = 'https://feeds.bbci.co.uk/news/world/rss.xml?test=no-cache';
     const rssFirstFailure = await get(port, `/rss?url=${encodeURIComponent(noCacheFeed)}`);
@@ -184,9 +195,11 @@ test('relay handlers expose bounded Google/OpenSky cooldowns and RSS fallback me
     assert.ok(metrics.googleFlights.throttle >= 2);
     assert.equal(metrics.googleFlights.fallback, 0, 'cooldown-only empty results are not usable fallback data');
     assert.ok(metrics.googleFlights.cooldownRemainingMs > 0);
-    assert.equal(metrics.opensky.requests, 2);
-    assert.ok(metrics.opensky.throttle >= 2);
-    assert.ok(metrics.opensky.global429CooldownRemainingMs > 0);
+    assert.equal(metrics.opensky.requests, 3);
+    assert.ok(metrics.opensky.throttle >= 3);
+    assert.equal(metrics.opensky.upstreamFetches, 1, 'one upstream 429 must atomically stop queued bbox work');
+    assert.equal(metrics.opensky.rateLimitRemaining, 0);
+    assert.ok(metrics.opensky.global429CooldownRemainingMs >= 86_000_000);
     assert.ok(metrics.rss.requests >= 5);
     assert.ok(metrics.rss.fallback >= 1);
     assert.ok(metrics.rss.backoffActiveFeeds >= 2);
@@ -194,6 +207,31 @@ test('relay handlers expose bounded Google/OpenSky cooldowns and RSS fallback me
     assert.equal(metrics.aisSnapshot.success, 0);
     assert.equal(metrics.aisSnapshot.served, 0);
     assert.ok(metrics.aisSnapshot.terminalFailure >= 1);
+
+    await new Promise((resolve) => setTimeout(resolve, 11_000));
+    const agedHealth = JSON.parse((await get(port, '/health')).body);
+    assert.equal(agedHealth.ingestion.aviation.coverage.requests, 0, 'request samples must age out of the rolling window');
+    assert.equal(agedHealth.ingestion.aviation.coverage.status, 'degraded', 'active provider reset must remain visible after samples age out');
+  } finally {
+    await stop(child);
+  }
+});
+
+test('Wingbits bbox relay tiles wide viewports without silently clipping coverage', async () => {
+  const { child, ready } = spawnRelay({
+    WINGBITS_API_KEY: 'test-wingbits-key',
+    RELAY_TEST_WINGBITS_ECHO_AREAS: '1',
+  });
+
+  try {
+    const { port } = await ready;
+    const response = await get(port, '/wingbits/track?lamin=0&lomin=0&lamax=60&lomax=60');
+    assert.equal(response.status, 200, response.body);
+    const payload = JSON.parse(response.body);
+    assert.equal(payload.positions.length, 4, '60 by 60 degrees must be covered by four bounded tiles');
+    assert.ok(payload.positions.every((position) =>
+      position.lat >= 0 && position.lat <= 60 && position.lon >= 0 && position.lon <= 60
+    ));
   } finally {
     await stop(child);
   }
@@ -209,8 +247,8 @@ test('theater-posture Wingbits fallback publication is attributed to Wingbits, n
   try {
     const { port } = await ready;
 
-    // OpenSky upstream is stubbed to 429, adsb.lol to 503 — Wingbits carries
-    // the cycle. Two cycles prove the per-source counter accumulates.
+    // adsb.lol is stubbed to 503, so Wingbits carries the cycle without
+    // consulting OpenSky. Two cycles prove the per-source counter accumulates.
     for (let cycle = 1; cycle <= 2; cycle += 1) {
       const trigger = await get(port, '/__test/seed-theater-posture');
       assert.equal(trigger.status, 200, `trigger ${cycle} failed: ${trigger.body}`);
@@ -245,7 +283,8 @@ test('theater-posture Wingbits fallback publication is attributed to Wingbits, n
     // The acceptance gate itself: fallback publication must not read as OpenSky recovery.
     assert.equal(metrics.opensky.success, 0);
     assert.equal(metrics.opensky.served, 0);
-    assert.ok(metrics.opensky.throttle >= 1);
+    assert.equal(metrics.opensky.requests, 0);
+    assert.equal(metrics.opensky.upstreamFetches, 0);
   } finally {
     await stop(child);
     await upstash.close();
@@ -331,7 +370,6 @@ test('theater-posture OpenSky success is attributed to opensky, and /metrics sta
     RELAY_SHARED_SECRET: 'test-relay-secret',
     I_UNDERSTAND_THIS_DISABLES_AUTH: '',
     RELAY_TEST_OPENSKY_STATUS_SEQUENCE: '200,200',
-    WINGBITS_API_KEY: 'test-wingbits-key',
     ...upstash.env,
   });
   const auth = { 'x-relay-key': 'test-relay-secret' };
@@ -363,10 +401,10 @@ test('theater-posture OpenSky success is attributed to opensky, and /metrics sta
   }
 });
 
-test('theater-posture attributes adsb.lol wins to adsb.lol, and adsb-confirmed quiet skies to vessel-only', async () => {
+test('theater-posture uses adsb.lol, then Wingbits, without routine OpenSky debits', async () => {
   const upstash = await createUpstashMock();
   const { child, ready } = spawnRelay({
-    RELAY_TEST_ADSB_MODE_SEQUENCE: 'flight,empty',
+    RELAY_TEST_ADSB_MODE_SEQUENCE: 'flight,empty,malformed',
     WINGBITS_API_KEY: 'test-wingbits-key',
     ...upstash.env,
   });
@@ -394,12 +432,29 @@ test('theater-posture attributes adsb.lol wins to adsb.lol, and adsb-confirmed q
     assert.equal(quietMeta.sourceVersion, 'vessel-only');
     assert.equal(quietMeta.recordCount, 0);
 
+    const metricsAfterQuiet = JSON.parse((await get(port, '/metrics')).body);
+    assert.equal(
+      metricsAfterQuiet.opensky.requests,
+      0,
+      'healthy adsb.lol cycles must not debit the authenticated OpenSky budget',
+    );
+
     metrics = JSON.parse((await get(port, '/metrics')).body);
     assert.equal(metrics.theaterPosture.lastRun.source, 'vessel-only');
     // The Wingbits stub would have contributed a flight had the chain
     // consulted it: adsb.lol's authoritative empty answer stops the chain.
     assert.equal(metrics.theaterPosture.lastRun.flightCount, 0);
     assert.deepEqual(metrics.theaterPosture.sourceCountsSinceBoot, { opensky: 0, adsbLol: 1, wingbits: 0, vesselOnly: 1 });
+
+    // Cycle 3: adsb.lol returns malformed success, so Wingbits is the recovery source. OpenSky is
+    // last-resort only and must not be touched while Wingbits is usable.
+    const third = await get(port, '/__test/seed-theater-posture');
+    assert.equal(third.status, 200, `trigger 3 failed: ${third.body}`);
+    metrics = JSON.parse((await get(port, '/metrics')).body);
+    assert.equal(metrics.theaterPosture.lastRun.source, 'wingbits');
+    assert.equal(metrics.theaterPosture.lastRun.flightCount, 1);
+    assert.equal(metrics.opensky.requests, 0, 'Wingbits recovery must precede authenticated OpenSky');
+    assert.deepEqual(metrics.theaterPosture.sourceCountsSinceBoot, { opensky: 0, adsbLol: 1, wingbits: 1, vesselOnly: 1 });
   } finally {
     await stop(child);
     await upstash.close();

--- a/scripts/ais-relay-test-preload.cjs
+++ b/scripts/ais-relay-test-preload.cjs
@@ -17,6 +17,10 @@ const openskyStatuses = (process.env.RELAY_TEST_OPENSKY_STATUS_SEQUENCE || '')
   .split(',')
   .map((value) => Number(value.trim()))
   .filter((value) => Number.isFinite(value) && value > 0);
+const openskyRetryAfterSeconds = Number(process.env.RELAY_TEST_OPENSKY_RETRY_AFTER_SECONDS || 0);
+const openskyRemainingCredits = Number(process.env.RELAY_TEST_OPENSKY_REMAINING_CREDITS || 0);
+const openskyMalformedEncoding = process.env.RELAY_TEST_OPENSKY_MALFORMED_ENCODING === '1';
+const wingbitsEchoAreas = process.env.RELAY_TEST_WINGBITS_ECHO_AREAS === '1';
 // adsb.lol modes consumed per request: 'error' -> 503 (falls through to
 // Wingbits), 'empty' -> 200 with zero aircraft (authoritative quiet skies —
 // stops the fallback chain), 'flight' -> 200 with one military aircraft in
@@ -90,6 +94,9 @@ globalThis.fetch = async (url, options) => {
     if (mode === 'empty') {
       return { status: 200, ok: true, statusText: 'OK', text: async () => '', json: async () => ({ ac: [] }) };
     }
+    if (mode === 'malformed') {
+      return { status: 200, ok: true, statusText: 'OK', text: async () => '', json: async () => ({}) };
+    }
     if (mode === 'flight') {
       return {
         status: 200,
@@ -103,6 +110,19 @@ globalThis.fetch = async (url, options) => {
     return { status: 503, ok: false, statusText: 'Service Unavailable', text: async () => '', json: async () => ({}) };
   }
   if (target.includes('customer-api.wingbits.com')) {
+    if (wingbitsEchoAreas) {
+      const areas = JSON.parse(String(options?.body || '[]'));
+      return {
+        status: 200,
+        ok: true,
+        statusText: 'OK',
+        text: async () => '',
+        json: async () => areas.map((area, index) => ({
+          alias: area.alias,
+          data: [{ h: `tile${index}`, f: `TILE${index}`, la: area.la, lo: area.lo, ab: 30000 }],
+        })),
+      };
+    }
     // One military-callsign flight inside iran-theater bounds.
     return {
       status: 200,
@@ -142,11 +162,19 @@ https.get = function patchedGet(...args) {
   const parsed = targetUrl(input);
   if (parsed.hostname === 'opensky-network.org') {
     const status = nextValue(openskyStatuses, 429);
+    const headers = {
+      'content-type': 'application/json',
+      'x-rate-limit-remaining': String(openskyRemainingCredits),
+    };
+    if (status === 429 && openskyRetryAfterSeconds > 0) {
+      headers['x-rate-limit-retry-after-seconds'] = String(openskyRetryAfterSeconds);
+    }
+    if (status === 429 && openskyMalformedEncoding) headers['content-encoding'] = 'gzip';
     return request({
       callback: cb,
       statusCode: status,
       body: JSON.stringify({ states: status === 200 ? [OPENSKY_MIL_STATE] : [], time: Date.now() }),
-      headers: { 'content-type': 'application/json' },
+      headers,
     });
   }
   if (parsed.hostname === 'feeds.bbci.co.uk') {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4024,6 +4024,8 @@ function theaterDetectAircraftType(callsign) {
 }
 
 const WINGBITS_MAX_BOX_NM = 2000;
+const WINGBITS_VIEWPORT_TILE_DEGREES = 30;
+const WINGBITS_MAX_VIEWPORT_AREAS = 36;
 
 const POSTURE_THEATERS = [
   { id: 'iran-theater', bounds: { north: 42, south: 20, east: 65, west: 30 }, thresholds: { elevated: 8, critical: 20 }, strikeIndicators: { minTankers: 2, minAwacs: 1, minFighters: 5 } },
@@ -4071,6 +4073,34 @@ function wingbitsIndexLookupCallsign(callsign) {
     if (cs.includes(callsign)) results.push(position);
   }
   return results;
+}
+
+function buildWingbitsViewportAreas(south, west, north, east) {
+  const latTiles = Math.max(1, Math.ceil((north - south) / WINGBITS_VIEWPORT_TILE_DEGREES));
+  const lonTiles = Math.max(1, Math.ceil((east - west) / WINGBITS_VIEWPORT_TILE_DEGREES));
+  if (latTiles * lonTiles > WINGBITS_MAX_VIEWPORT_AREAS) return null;
+
+  const areas = [];
+  for (let latIndex = 0; latIndex < latTiles; latIndex += 1) {
+    const tileSouth = south + latIndex * WINGBITS_VIEWPORT_TILE_DEGREES;
+    const tileNorth = Math.min(north, tileSouth + WINGBITS_VIEWPORT_TILE_DEGREES);
+    for (let lonIndex = 0; lonIndex < lonTiles; lonIndex += 1) {
+      const tileWest = west + lonIndex * WINGBITS_VIEWPORT_TILE_DEGREES;
+      const tileEast = Math.min(east, tileWest + WINGBITS_VIEWPORT_TILE_DEGREES);
+      const centerLat = (tileSouth + tileNorth) / 2;
+      const centerLon = (tileWest + tileEast) / 2;
+      areas.push({
+        alias: `viewport-${latIndex}-${lonIndex}`,
+        by: 'box',
+        la: centerLat,
+        lo: centerLon,
+        w: Math.max(1, Math.min((tileEast - tileWest) * 60 * Math.cos(centerLat * Math.PI / 180), WINGBITS_MAX_BOX_NM)),
+        h: Math.max(1, Math.min((tileNorth - tileSouth) * 60, WINGBITS_MAX_BOX_NM)),
+        unit: 'nm',
+      });
+    }
+  }
+  return areas;
 }
 
 async function handleWingbitsTrackRequest(req, res) {
@@ -4183,11 +4213,17 @@ async function handleWingbitsTrackRequest(req, res) {
   const clampedLamax = Math.max(-90, Math.min(90, lamax));
   const clampedLomin = Math.max(-180, Math.min(180, lomin));
   const clampedLomax = Math.max(-180, Math.min(180, lomax));
-  const centerLat = (clampedLamin + clampedLamax) / 2;
-  const centerLon = (clampedLomin + clampedLomax) / 2;
-  const widthNm = Math.min(Math.abs(clampedLomax - clampedLomin) * 60 * Math.cos(centerLat * Math.PI / 180), WINGBITS_MAX_BOX_NM);
-  const heightNm = Math.min(Math.abs(clampedLamax - clampedLamin) * 60, WINGBITS_MAX_BOX_NM);
-  const areas = [{ alias: 'viewport', by: 'box', la: centerLat, lo: centerLon, w: widthNm, h: heightNm, unit: 'nm' }];
+  const south = Math.min(clampedLamin, clampedLamax);
+  const north = Math.max(clampedLamin, clampedLamax);
+  const west = Math.min(clampedLomin, clampedLomax);
+  const east = Math.max(clampedLomin, clampedLomax);
+  const areas = buildWingbitsViewportAreas(south, west, north, east);
+  if (!areas) {
+    return safeEnd(res, 422, { 'Content-Type': 'application/json' }, JSON.stringify({
+      error: `Viewport requires more than ${WINGBITS_MAX_VIEWPORT_AREAS} Wingbits areas`,
+      positions: [],
+    }));
+  }
 
   try {
     const resp = await fetch('https://customer-api.wingbits.com/v1/flights', {
@@ -4226,9 +4262,13 @@ async function handleWingbitsTrackRequest(req, res) {
           const cs = (f.f || f.callsign || f.flight || '').trim().toUpperCase();
           if (!cs.includes(callsignFilter)) continue;
         }
-        seenIds.add(icao24);
         const lat = f.la ?? f.latitude ?? f.lat ?? 0;
         const lon = f.lo ?? f.longitude ?? f.lon ?? f.lng ?? 0;
+        // Multi-area requests overlap at tile edges. Deduplicate and retain
+        // only positions inside the original viewport so a successful
+        // Wingbits response is complete and authoritative for that bbox.
+        if (lat < south || lat > north || lon < west || lon > east) continue;
+        seenIds.add(icao24);
         positions.push({
           icao24,
           callsign: (f.f || f.callsign || f.flight || '').trim(),
@@ -4301,7 +4341,11 @@ async function fetchTheaterFlightsFromAdsbLol() {
       return null;
     }
     const data = await resp.json();
-    const aircraft = data.ac || [];
+    if (!Array.isArray(data.ac)) {
+      console.warn('[adsb.lol] Malformed response: missing ac array');
+      return null;
+    }
+    const aircraft = data.ac;
     const flights = [];
     const seenIds = new Set();
     for (const a of aircraft) {
@@ -4463,28 +4507,29 @@ async function seedTheaterPosture() {
   const t0 = Date.now();
   let flights = [];
   let flightSource = 'vessel-only';
-  try {
-    flights = await fetchTheaterFlightsFromOpenSky();
-    if (flights.length > 0) flightSource = 'opensky';
-  } catch (e) {
-    console.warn(`[TheaterPosture] OpenSky failed: ${e?.message || e}`);
-  }
-  if (flights.length === 0) {
-    const adsbLol = await fetchTheaterFlightsFromAdsbLol();
-    if (adsbLol !== null) {
-      // null = fetch error (fall through to Wingbits); [] = success, no theater traffic (stop here)
-      flights = adsbLol;
-      if (flights.length > 0) flightSource = 'adsb.lol';
+  const adsbLol = await fetchTheaterFlightsFromAdsbLol();
+  if (adsbLol !== null) {
+    // null = fetch error (fall through); [] = success, no theater traffic (stop here).
+    // adsb.lol is the normal theater source so this background loop does not
+    // independently consume the authenticated OpenSky daily credit pool.
+    flights = adsbLol;
+    if (flights.length > 0) flightSource = 'adsb.lol';
+  } else {
+    const wb = await fetchTheaterFlightsFromWingbits();
+    if (wb && wb.length > 0) {
+      flights = wb;
+      flightSource = 'wingbits';
     } else {
-      const wb = await fetchTheaterFlightsFromWingbits();
-      if (wb && wb.length > 0) {
-        flights = wb;
-        flightSource = 'wingbits';
+      try {
+        flights = await fetchTheaterFlightsFromOpenSky();
+        if (flights.length > 0) flightSource = 'opensky';
+      } catch (e) {
+        console.warn(`[TheaterPosture] OpenSky failed: ${e?.message || e}`);
       }
     }
   }
   if (flights.length === 0) {
-    console.warn('[TheaterPosture] No military flights from OpenSky, adsb.lol, or Wingbits — continuing with vessel-only posture');
+    console.warn('[TheaterPosture] No military flights from adsb.lol, OpenSky, or Wingbits — continuing with vessel-only posture');
   }
   const theaters = calculateTheaterPostures(flights);
   const totalVessels = theaters.reduce((sum, t) => sum + t.trackedVessels, 0);
@@ -7100,21 +7145,29 @@ function getRelayRollingMetrics() {
 
   const dedupCount = rollup.openskyDedup + rollup.openskyDedupNeg + rollup.openskyDedupEmpty;
   const cacheServedCount = rollup.openskyCacheHit + rollup.openskyNegativeHit + dedupCount;
-  const openskyCoverage = summarizeServedCoverage({
+  const nowMs = Date.now();
+  const openskyProviderBlocked = nowMs < openskyGlobal429Until;
+  const observedOpenSkyCoverage = summarizeServedCoverage({
     requests: rollup.openskyRequests,
     served: rollup.openskyServed,
     minimum: AVIATION_MIN_SERVED_COVERAGE,
   });
+  const openskyCoverage = openskyProviderBlocked
+    ? { ...observedOpenSkyCoverage, status: 'degraded' }
+    : observedOpenSkyCoverage;
   const googleFlightsCoverage = summarizeServedCoverage({
     requests: rollup.googleFlightsRequests,
     served: rollup.googleFlightsServed,
     minimum: AVIATION_MIN_SERVED_COVERAGE,
   });
-  const aviationCoverage = summarizeServedCoverage({
+  const observedAviationCoverage = summarizeServedCoverage({
     requests: rollup.openskyRequests + rollup.googleFlightsRequests,
     served: rollup.openskyServed + rollup.googleFlightsServed,
     minimum: AVIATION_MIN_SERVED_COVERAGE,
   });
+  const aviationCoverage = openskyProviderBlocked
+    ? { ...observedAviationCoverage, status: 'degraded' }
+    : observedAviationCoverage;
   const rssCoverage = summarizeServedCoverage({
     requests: rollup.rssRequests,
     served: rollup.rssServed,
@@ -7122,7 +7175,6 @@ function getRelayRollingMetrics() {
   });
   let rssBackoffActive = 0;
   let rssMaxBackoffRemainingMs = 0;
-  const nowMs = Date.now();
   for (const expiry of rssBackoffUntil.values()) {
     const remaining = Math.max(0, expiry - nowMs);
     if (remaining > 0) {
@@ -7151,7 +7203,11 @@ function getRelayRollingMetrics() {
       terminalFailure: rollup.openskyTerminalFailure,
       served: rollup.openskyServed,
       coverage: openskyCoverage,
-      global429CooldownRemainingMs: Math.max(0, openskyGlobal429Until - Date.now()),
+      global429CooldownRemainingMs: Math.max(0, openskyGlobal429Until - nowMs),
+      rateLimitRemaining: openskyRateLimitRemaining,
+      rateLimitRetryAt: openskyGlobal429Until ? new Date(openskyGlobal429Until).toISOString() : null,
+      lastSuccessAt: openskyLastSuccessAt ? new Date(openskyLastSuccessAt).toISOString() : null,
+      last429At: openskyLast429At ? new Date(openskyLast429At).toISOString() : null,
       requestSpacingMs: OPENSKY_REQUEST_SPACING_MS,
     },
     ais: {
@@ -8507,9 +8563,13 @@ const OPENSKY_AUTH_COOLDOWN_MS = 60000; // 1 min cooldown after auth failure
 // Global OpenSky rate limiter — serializes upstream requests and enforces 429 cooldown
 let openskyGlobal429Until = 0; // timestamp: block ALL upstream requests until this time
 const OPENSKY_429_COOLDOWN_MS = Number(process.env.OPENSKY_429_COOLDOWN_MS) || 90 * 1000; // 90s cooldown after any 429
+const OPENSKY_MAX_429_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const OPENSKY_REQUEST_SPACING_MS = Number(process.env.OPENSKY_REQUEST_SPACING_MS) || 2000; // 2s minimum between consecutive upstream requests
 let openskyLastUpstreamTime = 0;
 let openskyUpstreamQueue = Promise.resolve(); // serial chain — only 1 upstream request at a time
+let openskyRateLimitRemaining = null;
+let openskyLastSuccessAt = 0;
+let openskyLast429At = 0;
 
 async function getOpenSkyToken() {
   const clientId = process.env.OPENSKY_CLIENT_ID;
@@ -8688,6 +8748,17 @@ function _collectDecompressed(response) {
   });
 }
 
+function _readOpenSkyRateLimitHeaders(response) {
+  const remaining = Number(response.headers['x-rate-limit-remaining']);
+  const retryAfterSeconds = Number(response.headers['x-rate-limit-retry-after-seconds']);
+  return {
+    rateLimitRemaining: Number.isFinite(remaining) && remaining >= 0 ? Math.floor(remaining) : null,
+    retryAfterSeconds: Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+      ? Math.min(Math.ceil(retryAfterSeconds), OPENSKY_MAX_429_COOLDOWN_MS / 1000)
+      : null,
+  };
+}
+
 function _openskyRawFetch(url, token) {
   const parsed = new URL(url);
   const reqHeaders = {
@@ -8710,9 +8781,10 @@ function _openskyRawFetch(url, token) {
           headers: reqHeaders,
           timeout: 15000,
         }, (response) => {
+          const rateLimit = _readOpenSkyRateLimitHeaders(response);
           _collectDecompressed(response)
-            .then(data => resolve({ status: response.statusCode || 502, data }))
-            .catch(err => resolve({ status: 0, data: null, error: err }));
+            .then(data => resolve({ status: response.statusCode || 502, data, ...rateLimit }))
+            .catch(err => resolve({ status: response.statusCode || 502, data: null, error: err, ...rateLimit }));
         });
         request.on('error', (err) => resolve({ status: 0, data: null, error: err }));
         request.on('timeout', () => { request.destroy(); resolve({ status: 504, data: null, error: new Error('timeout') }); });
@@ -8727,9 +8799,10 @@ function _openskyRawFetch(url, token) {
       agent: httpsKeepAliveAgent,
       timeout: 15000,
     }, (response) => {
+      const rateLimit = _readOpenSkyRateLimitHeaders(response);
       _collectDecompressed(response)
-        .then(data => resolve({ status: response.statusCode || 502, data }))
-        .catch(err => resolve({ status: 0, data: null, error: err }));
+        .then(data => resolve({ status: response.statusCode || 502, data, ...rateLimit }))
+        .catch(err => resolve({ status: response.statusCode || 502, data: null, error: err, ...rateLimit }));
     });
     request.on('error', (err) => resolve({ status: 0, data: null, error: err }));
     request.on('timeout', () => { request.destroy(); resolve({ status: 504, data: null, error: new Error('timeout') }); });
@@ -8749,7 +8822,28 @@ function openskyQueuedFetch(url, token) {
       return { status: 429, data: JSON.stringify({ states: [], time: Date.now() }), rateLimited: true };
     }
     openskyLastUpstreamTime = Date.now();
-    return _openskyRawFetch(url, token);
+    incrementRelayMetric('openskyUpstreamFetches');
+    const result = await _openskyRawFetch(url, token);
+    const completedAt = Date.now();
+    if (result.rateLimitRemaining != null) {
+      openskyRateLimitRemaining = result.rateLimitRemaining;
+    }
+    if (result.status >= 200 && result.status < 300) {
+      openskyLastSuccessAt = completedAt;
+    }
+    if (result.status === 429) {
+      const providerCooldownMs = result.retryAfterSeconds == null
+        ? OPENSKY_429_COOLDOWN_MS
+        : result.retryAfterSeconds * 1000;
+      const cooldownMs = Math.min(
+        OPENSKY_MAX_429_COOLDOWN_MS,
+        Math.max(OPENSKY_429_COOLDOWN_MS, providerCooldownMs),
+      );
+      openskyGlobal429Until = Math.max(openskyGlobal429Until, completedAt + cooldownMs);
+      openskyLast429At = completedAt;
+      console.warn(`[Relay] OpenSky 429 — global cooldown ${Math.ceil(cooldownMs / 1000)}s (all bbox queries blocked)`);
+    }
+    return result;
   });
   openskyUpstreamQueue = job.catch(() => {});
   return job;
@@ -8889,8 +8983,6 @@ async function handleOpenSkyRequest(req, res, PORT) {
     }
 
     logThrottled('log', `opensky-miss:${cacheKey}`, '[Relay] OpenSky request (MISS):', openskyUrl);
-    incrementRelayMetric('openskyUpstreamFetches');
-
     // Serialized fetch — queued with spacing to prevent concurrent 429 storms
     const result = await openskyQueuedFetch(openskyUrl, token);
     const upstreamStatus = result.status || 502;
@@ -8902,11 +8994,6 @@ async function handleOpenSkyRequest(req, res, PORT) {
     if (upstreamStatus === 401) {
       openskyToken = null;
       openskyTokenExpiry = 0;
-    }
-
-    if (upstreamStatus === 429 && !result.rateLimited) {
-      openskyGlobal429Until = Date.now() + OPENSKY_429_COOLDOWN_MS;
-      console.warn(`[Relay] OpenSky 429 — global cooldown ${OPENSKY_429_COOLDOWN_MS / 1000}s (all bbox queries blocked)`);
     }
 
     if (upstreamStatus === 200 && result.data) {
@@ -10064,6 +10151,9 @@ const server = http.createServer(async (req, res) => {
     openskyTokenPromise = null;
     openskyAuthCooldownUntil = 0;
     openskyGlobal429Until = 0;
+    openskyRateLimitRemaining = null;
+    openskyLastSuccessAt = 0;
+    openskyLast429At = 0;
     openskyNegativeCache.clear();
     console.log('[Relay] OpenSky auth + rate-limit state reset via /opensky-reset');
     const tokenStart = Date.now();

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -93,7 +93,8 @@ export async function readCachedJson(key: string, raw = false): Promise<CacheRea
       signal: AbortSignal.timeout(REDIS_OP_TIMEOUT_MS),
     });
     if (!resp.ok) throw new Error(`Redis HTTP ${resp.status}`);
-    const data = (await resp.json()) as { result?: string };
+    const data = (await resp.json()) as { result?: string; error?: string };
+    if (data.error) throw new Error(`Redis command error: ${data.error}`);
     if (!data.result) return { status: 'miss' };
     // Envelope-aware by default — RPC consumers get the bare payload regardless
     // of whether the writer has migrated to contract mode. Legacy shapes pass
@@ -143,7 +144,8 @@ export async function getRawJson(key: string): Promise<unknown | null> {
     signal: AbortSignal.timeout(REDIS_OP_TIMEOUT_MS),
   });
   if (!resp.ok) throw new Error(`Redis HTTP ${resp.status}`);
-  const data = (await resp.json()) as { result?: string };
+  const data = (await resp.json()) as { result?: string; error?: string };
+  if (data.error) throw new Error(`Redis command error: ${data.error}`);
   if (!data.result) return null;
   // Envelope-aware: contract-mode canonical keys are stored as {_seed, data}.
   // unwrapEnvelope is a no-op on legacy (non-envelope) shapes.

--- a/server/worldmonitor/aviation/v1/track-aircraft.ts
+++ b/server/worldmonitor/aviation/v1/track-aircraft.ts
@@ -14,6 +14,7 @@ const CACHE_TTL = 120;
 // negative hits 10s so a retry after panning into view returns fresh data quickly.
 const CALLSIGN_CACHE_TTL = 60;
 const CALLSIGN_NEGATIVE_TTL = 10;
+const BBOX_RELAY_TIMEOUT_MS = 6_000;
 
 interface OpenSkyResponse {
     states?: unknown[][];
@@ -115,37 +116,47 @@ export async function trackAircraft(
                     }
                 }
 
-                // For bbox queries: run OpenSky relay and Wingbits relay in parallel.
-                // Sequential was 10s + 6s + 15s = 31s worst-case, exceeding Vercel's 25s limit.
-                // Parallel caps at 10s and gives merged coverage from both sources.
+                // Wingbits is the normal bbox source. A successful response — including an
+                // empty one — is authoritative for that viewport, so do not also debit the
+                // shared authenticated OpenSky account. OpenSky is recovery-only when the
+                // Wingbits request itself fails.
                 if (!isCallsignOnly && relayBase && req.swLat != null && req.neLat != null) {
-                    const osUrl = `${relayBase}/opensky/states/all?lamin=${req.swLat}&lomin=${req.swLon}&lamax=${req.neLat}&lomax=${req.neLon}`;
                     const wbUrl = `${relayBase}/wingbits/track?lamin=${req.swLat}&lomin=${req.swLon}&lamax=${req.neLat}&lomax=${req.neLon}`;
-
-                    const [osResult, wbResult] = await Promise.allSettled([
-                        fetch(osUrl, { headers: getRelayHeaders({}), signal: AbortSignal.timeout(10_000) })
-                            .then(r => r.ok ? r.json() as Promise<OpenSkyResponse> : Promise.resolve(null))
-                            .then(d => d ? parseOpenSkyStates(d.states ?? []) : [])
-                            .catch(() => [] as PositionSample[]),
-                        fetch(wbUrl, { headers: getRelayHeaders({}), signal: AbortSignal.timeout(10_000) })
-                            .then(r => r.ok ? r.json() as Promise<WingbitsRelayResponse> : Promise.resolve(null))
-                            .then(d => d?.positions ?? [])
-                            .catch(() => [] as PositionSample[]),
-                    ]);
-
-                    const osPositions = osResult.status === 'fulfilled' ? osResult.value : [];
-                    const wbPositions = wbResult.status === 'fulfilled' ? wbResult.value : [];
-
-                    // Merge: Wingbits preferred for duplicates (more accurate for commercial flights).
-                    const seenIcao = new Set(wbPositions.map(p => p.icao24));
-                    const merged = [...wbPositions, ...osPositions.filter(p => !seenIcao.has(p.icao24))];
-                    if (merged.length > 0) {
-                        const source = wbPositions.length > 0 && osPositions.length > 0 ? 'wingbits'
-                            : wbPositions.length > 0 ? 'wingbits' : 'opensky';
-                        return { positions: merged, source };
+                    try {
+                        const wbResp = await fetch(wbUrl, {
+                            headers: getRelayHeaders({}),
+                            signal: AbortSignal.timeout(BBOX_RELAY_TIMEOUT_MS),
+                        });
+                        if (wbResp.ok) {
+                            const wbData = await wbResp.json() as WingbitsRelayResponse;
+                            return { positions: wbData.positions ?? [], source: 'wingbits' };
+                        }
+                    } catch (err) {
+                        // sentry-coverage-ok: provider failure is expected here and the bounded OpenSky fallback owns recovery.
+                        console.warn(`[Aviation] Wingbits bbox relay failed: ${err instanceof Error ? err.message : err}`);
                     }
 
-                    // Both relay sources empty — try OpenSky anonymous as last resort
+                    try {
+                        const osUrl = `${relayBase}/opensky/states/all?lamin=${req.swLat}&lomin=${req.swLon}&lamax=${req.neLat}&lomax=${req.neLon}`;
+                        const osResp = await fetch(osUrl, {
+                            headers: getRelayHeaders({}),
+                            signal: AbortSignal.timeout(BBOX_RELAY_TIMEOUT_MS),
+                        });
+                        if (osResp.ok) {
+                            const osData = await osResp.json() as OpenSkyResponse;
+                            const osPositions = parseOpenSkyStates(osData.states ?? []);
+                            if (osPositions.length > 0) return { positions: osPositions, source: 'opensky' };
+                        }
+                    } catch (err) {
+                        // sentry-coverage-ok: authenticated relay failure intentionally falls through to anonymous recovery.
+                        console.warn(`[Aviation] OpenSky bbox relay failed: ${err instanceof Error ? err.message : err}`);
+                    }
+
+                    // Both relay paths failed or OpenSky recovery was empty — try anonymous
+                    // OpenSky as a last resort. The 6s + 6s + 6s timeouts leave 7s of
+                    // headroom under the Vercel initial-response ceiling for cache I/O and
+                    // response serialization. Keep these sequential: parallel OpenSky
+                    // recovery would spend an authenticated credit even when anonymous wins.
                     try {
                         const directPositions = await fetchOpenSkyAnonymous(req);
                         if (directPositions.length > 0) {

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/military/v1/service_server';
 
 import { isMilitaryCallsign, isMilitaryHex, detectAircraftType, UPSTREAM_TIMEOUT_MS } from './_shared';
-import { cachedFetchJson, getRawJson } from '../../../_shared/redis';
+import { cachedFetchJson, getRawJson, readCachedJson } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 
@@ -25,6 +25,24 @@ interface RequestBounds {
   north: number;
   west: number;
   east: number;
+}
+
+// The scheduled military-flight snapshot contains exactly these two producer
+// regions (scripts/seed-military-flights.mjs QUERY_REGIONS). It is authoritative
+// only when one region fully contains the requested bbox; otherwise using it
+// would silently turn uncovered geography into an empty result.
+const LIVE_SEED_COVERAGE: readonly RequestBounds[] = [
+  { south: 10, north: 46, west: 107, east: 143 },
+  { south: 13, north: 85, west: -10, east: 57 },
+];
+
+function liveSeedCovers(bounds: RequestBounds): boolean {
+  return LIVE_SEED_COVERAGE.some((region) =>
+    region.south <= bounds.south
+    && region.north >= bounds.north
+    && region.west <= bounds.west
+    && region.east >= bounds.east
+  );
 }
 
 
@@ -126,7 +144,7 @@ const CONFIDENCE_MAP: Record<string, string> = {
   low: 'MILITARY_CONFIDENCE_LOW',
 };
 
-interface StaleFlight {
+interface SeedFlight {
   id?: string;
   callsign?: string;
   hexCode?: string;
@@ -152,8 +170,8 @@ interface StaleFlight {
   note?: string;
 }
 
-interface StalePayload {
-  flights?: StaleFlight[];
+interface SeedPayload {
+  flights?: SeedFlight[];
   fetchedAt?: number;
 }
 
@@ -164,7 +182,7 @@ interface StalePayload {
  * hexCode is canonicalized to uppercase per the invariant documented on
  * MilitaryFlight.hex_code in military_flight.proto.
  */
-function staleToProto(f: StaleFlight): ListMilitaryFlightsResponse['flights'][number] | null {
+function seedToProto(f: SeedFlight): ListMilitaryFlightsResponse['flights'][number] | null {
   if (f.lat == null || f.lon == null) return null;
   const icao = (f.hexCode || f.id || '').toUpperCase();
   if (!icao) return null;
@@ -195,6 +213,52 @@ function staleToProto(f: StaleFlight): ListMilitaryFlightsResponse['flights'][nu
   };
 }
 
+function seedPayloadToProto(raw: SeedPayload | null): ListMilitaryFlightsResponse['flights'] | null {
+  if (!raw || !Array.isArray(raw.flights)) return null;
+  if (raw.flights.length === 0) return [];
+  const flights = raw.flights
+    .map(seedToProto)
+    .filter((flight): flight is NonNullable<typeof flight> => flight != null);
+  return flights.length > 0 ? flights : null;
+}
+
+const LIVE_SEED_NEG_TTL_MS = 30_000;
+let liveSeedNegUntil = 0;
+let liveSeedNegStatus: 'miss' | 'error' = 'miss';
+type LiveSeedRead =
+  | { status: 'hit'; flights: ListMilitaryFlightsResponse['flights'] }
+  | { status: 'miss' | 'error' };
+let liveSeedReadPromise: Promise<LiveSeedRead> | null = null;
+
+async function fetchLiveSeedSnapshot(): Promise<LiveSeedRead> {
+  const now = Date.now();
+  if (now < liveSeedNegUntil) return { status: liveSeedNegStatus };
+  if (liveSeedReadPromise) return liveSeedReadPromise;
+
+  liveSeedReadPromise = (async () => {
+    const read = await readCachedJson(REDIS_CACHE_KEY, true);
+    if (read.status === 'error') {
+      liveSeedNegStatus = 'error';
+      liveSeedNegUntil = now + LIVE_SEED_NEG_TTL_MS;
+      return { status: 'error' };
+    }
+    const flights = read.status === 'hit'
+      ? seedPayloadToProto(read.value as SeedPayload)
+      : null;
+    if (flights === null) {
+      liveSeedNegStatus = 'miss';
+      liveSeedNegUntil = now + LIVE_SEED_NEG_TTL_MS;
+      return { status: 'miss' };
+    }
+    return { status: 'hit', flights };
+  })();
+  try {
+    return await liveSeedReadPromise;
+  } finally {
+    liveSeedReadPromise = null;
+  }
+}
+
 // Negative cache for the stale Redis read — mirrors the legacy
 // /api/military-flights handler's NEG_TTL=30_000ms. When the live fetch fails
 // AND the stale key is also empty/unparseable, suppress further Redis reads
@@ -207,6 +271,9 @@ let staleNegUntil = 0;
 // Test seam — exposed for unit tests that need to drive the suppression
 // window without sleeping. Not exported from the module's public API.
 export function _resetStaleNegativeCacheForTests(): void {
+  liveSeedNegUntil = 0;
+  liveSeedNegStatus = 'miss';
+  liveSeedReadPromise = null;
   staleNegUntil = 0;
 }
 
@@ -214,15 +281,9 @@ async function fetchStaleFallback(): Promise<ListMilitaryFlightsResponse['flight
   const now = Date.now();
   if (now < staleNegUntil) return null;
   try {
-    const raw = (await getRawJson(REDIS_STALE_KEY)) as StalePayload | null;
-    if (!raw || !Array.isArray(raw.flights) || raw.flights.length === 0) {
-      staleNegUntil = now + STALE_NEG_TTL_MS;
-      return null;
-    }
-    const flights = raw.flights
-      .map(staleToProto)
-      .filter((f): f is NonNullable<typeof f> => f != null);
-    if (flights.length === 0) {
+    const raw = (await getRawJson(REDIS_STALE_KEY)) as SeedPayload | null;
+    const flights = seedPayloadToProto(raw);
+    if (!flights || flights.length === 0) {
       staleNegUntil = now + STALE_NEG_TTL_MS;
       return null;
     }
@@ -259,6 +320,28 @@ export async function listMilitaryFlights(
       cacheKey,
       REDIS_CACHE_TTL,
       async () => {
+        // The scheduled seeder is the single routine authenticated OpenSky
+        // writer. Cache its unpaginated regional snapshot under the existing
+        // bbox key so every cursor reads one stable version. Requests outside
+        // the producer's declared coverage continue to request-specific
+        // recovery instead of receiving a falsely authoritative empty result.
+        // The producer deliberately preserves its last-good snapshot during an
+        // upstream outage. Keep serving that snapshot (with each flight's old
+        // lastSeenAt intact) while seed health reports the stale fetchedAt;
+        // reopening per-viewer OpenSky recovery here recreates the credit fanout.
+        if (liveSeedCovers(requestBounds)) {
+          const seeded = await fetchLiveSeedSnapshot();
+          if (seeded.status === 'hit') {
+            return { flights: seeded.flights, clusters: [], pagination: undefined };
+          }
+          if (seeded.status === 'error') {
+            // A Redis command/read failure is not proof the snapshot is
+            // missing. Throw before any provider call so cachedFetchJson's
+            // bounded negative path prevents per-bbox OpenSky amplification.
+            throw new Error('military live seed read failed');
+          }
+        }
+
         const isSidecar = (process.env.LOCAL_API_MODE || '').includes('sidecar');
         const relayBase = isSidecar ? null : getRelayBaseUrl();
         const baseUrl = isSidecar ? 'https://opensky-network.org/api/states/all' : relayBase ? relayBase + '/opensky' : null;

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1706,6 +1706,158 @@ describe('country intel brief caching behavior', { concurrency: 1 }, () => {
   });
 });
 
+describe('aviation aircraft provider priority', { concurrency: 1 }, () => {
+  async function importTrackAircraft() {
+    return importPatchedTsModule('server/worldmonitor/aviation/v1/track-aircraft.ts', {
+      './_shared': resolve(root, 'server/_shared/relay.ts'),
+      '../../../_shared/constants': resolve(root, 'server/_shared/constants.ts'),
+      '../../../_shared/redis': resolve(root, 'server/_shared/redis.ts'),
+    });
+  }
+
+  it('serves a bbox from Wingbits without spending an OpenSky request', async () => {
+    const { module, cleanup } = await importTrackAircraft();
+    const restoreEnv = withEnv({
+      WS_RELAY_URL: 'wss://relay.test',
+      UPSTASH_REDIS_REST_URL: undefined,
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let openskyCalls = 0;
+    let wingbitsCalls = 0;
+
+    globalThis.fetch = async (url) => {
+      const raw = String(url);
+      if (raw.includes('/wingbits/track')) {
+        wingbitsCalls += 1;
+        return jsonResponse({
+          positions: [{ icao24: 'abc123', callsign: 'TEST1', lat: 10.5, lon: 10.5 }],
+          source: 'wingbits',
+        });
+      }
+      if (raw.includes('/opensky') || raw.includes('opensky-network.org')) {
+        openskyCalls += 1;
+        return jsonResponse({
+          states: [['def456', 'TEST2', null, null, null, 10.6, 10.6, 1000, false, 100, 90]],
+        });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.trackAircraft({}, {
+        swLat: 10,
+        swLon: 10,
+        neLat: 11,
+        neLon: 11,
+      });
+      assert.equal(wingbitsCalls, 1);
+      assert.equal(openskyCalls, 0, 'Wingbits coverage should prevent an authenticated OpenSky debit');
+      assert.equal(result.source, 'wingbits');
+      assert.deepEqual(result.positions.map((position) => position.icao24), ['abc123']);
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('treats an empty Wingbits response as authoritative and uses OpenSky only after Wingbits fails', async () => {
+    const { module, cleanup } = await importTrackAircraft();
+    const restoreEnv = withEnv({
+      WS_RELAY_URL: 'wss://relay.test',
+      UPSTASH_REDIS_REST_URL: undefined,
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let openskyCalls = 0;
+    let wingbitsCalls = 0;
+
+    globalThis.fetch = async (url) => {
+      const raw = String(url);
+      if (raw.includes('/wingbits/track')) {
+        wingbitsCalls += 1;
+        const failed = raw.includes('lamin=20');
+        return failed ? jsonResponse({}, false) : jsonResponse({ positions: [], source: 'wingbits' });
+      }
+      if (raw.includes('/opensky')) {
+        openskyCalls += 1;
+        return jsonResponse({
+          states: [['def456', 'TEST2', null, null, null, 20.6, 20.6, 1000, false, 100, 90]],
+        });
+      }
+      if (raw.includes('opensky-network.org')) {
+        throw new Error('anonymous OpenSky should not be needed');
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const quiet = await module.trackAircraft({}, {
+        swLat: 10,
+        swLon: 10,
+        neLat: 11,
+        neLon: 11,
+      });
+      const recovered = await module.trackAircraft({}, {
+        swLat: 20,
+        swLon: 20,
+        neLat: 21,
+        neLon: 21,
+      });
+
+      assert.equal(wingbitsCalls, 2);
+      assert.equal(openskyCalls, 1, 'only the failed Wingbits request may consume OpenSky');
+      assert.deepEqual(quiet.positions, []);
+      assert.equal(quiet.source, 'wingbits');
+      assert.deepEqual(recovered.positions.map((position) => position.icao24), ['def456']);
+      assert.equal(recovered.source, 'opensky');
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('keeps the all-provider failure path inside the edge response deadline', async () => {
+    const { module, cleanup } = await importTrackAircraft();
+    const restoreEnv = withEnv({
+      WS_RELAY_URL: 'wss://relay.test',
+      UPSTASH_REDIS_REST_URL: undefined,
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const originalTimeout = AbortSignal.timeout;
+    const requestedTimeouts = [];
+
+    AbortSignal.timeout = (milliseconds) => {
+      requestedTimeouts.push(milliseconds);
+      return AbortSignal.abort(new Error('test timeout'));
+    };
+    globalThis.fetch = async (_url, init) => {
+      throw init?.signal?.reason ?? new Error('upstream failed');
+    };
+
+    try {
+      const result = await module.trackAircraft({}, {
+        swLat: 10,
+        swLon: 10,
+        neLat: 11,
+        neLon: 11,
+      });
+      assert.deepEqual(requestedTimeouts, [6_000, 6_000, 6_000]);
+      assert.equal(requestedTimeouts.reduce((sum, timeout) => sum + timeout, 0), 18_000);
+      assert.deepEqual(result.positions, []);
+      assert.equal(result.source, 'none');
+    } finally {
+      cleanup();
+      AbortSignal.timeout = originalTimeout;
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+});
+
 describe('military flights bbox behavior', { concurrency: 1 }, () => {
   async function importListMilitaryFlights() {
     return importPatchedTsModule('server/worldmonitor/military/v1/list-military-flights.ts', {
@@ -1724,6 +1876,13 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     neLon: 11,
   };
 
+  const seededRequest = {
+    swLat: 20,
+    swLon: 10,
+    neLat: 21,
+    neLon: 11,
+  };
+
   function cachedMilitaryFlight(id, latitude, longitude) {
     return {
       id,
@@ -1732,6 +1891,307 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       location: { latitude, longitude },
     };
   }
+
+  it('caches the seeded snapshot per bbox before any OpenSky fetch', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const redisKeys = [];
+    let openskyCalls = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        redisKeys.push(key);
+        if (key === 'military:flights:v1') {
+          return jsonResponse({
+            result: JSON.stringify({
+              flights: [
+                { id: 'seed-in', callsign: 'RCH301', lat: 20.2, lon: 10.2 },
+                { id: 'seed-out', callsign: 'RCH302', lat: 22.2, lon: 10.2 },
+              ],
+              fetchedAt: Date.now(),
+            }),
+          });
+        }
+        return jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (raw.includes('/opensky') || raw.includes('opensky-network.org')) {
+        openskyCalls += 1;
+        return jsonResponse({ states: [] });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.listMilitaryFlights(
+        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+        seededRequest,
+      );
+      assert.match(redisKeys[0], /^military:flights:v1:/, 'the stable bbox snapshot cache must be checked first');
+      assert.equal(redisKeys[1], 'military:flights:v1', 'a bbox cache miss must read the canonical seed');
+      assert.equal(openskyCalls, 0, 'live seed coverage should prevent an OpenSky fetch');
+      assert.deepEqual(result.flights.map((flight) => flight.id), ['SEED-IN']);
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('treats an empty live seed as authoritative instead of reopening OpenSky fanout', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const redisKeys = [];
+    let openskyCalls = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        redisKeys.push(key);
+        return jsonResponse({
+          result: key === 'military:flights:v1'
+            ? JSON.stringify({ flights: [], fetchedAt: Date.now() })
+            : null,
+        });
+      }
+      if (raw.includes('/opensky') || raw.includes('opensky-network.org')) {
+        openskyCalls += 1;
+        return jsonResponse({ states: [] });
+      }
+      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.listMilitaryFlights(
+        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+        seededRequest,
+      );
+      assert.match(redisKeys[0], /^military:flights:v1:/);
+      assert.equal(redisKeys[1], 'military:flights:v1');
+      assert.equal(openskyCalls, 0);
+      assert.deepEqual(result, { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } });
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('suppresses repeated live-seed Redis reads briefly after a miss', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: undefined,
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let liveSeedReads = 0;
+
+    let releaseLiveSeedRead;
+    const liveSeedGate = new Promise((resolveGate) => { releaseLiveSeedRead = resolveGate; });
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === 'military:flights:v1') {
+          liveSeedReads += 1;
+          await liveSeedGate;
+        }
+        return jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
+      const first = module.listMilitaryFlights(ctx, seededRequest);
+      const second = module.listMilitaryFlights(ctx, seededRequest);
+      await new Promise((resolveTick) => setImmediate(resolveTick));
+      releaseLiveSeedRead();
+      await Promise.all([first, second]);
+      await module.listMilitaryFlights(ctx, seededRequest);
+      assert.equal(liveSeedReads, 1, 'a missing root snapshot should be read at most once per suppression window');
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('does not turn a live-seed Redis command error into OpenSky fanout', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let openskyCalls = 0;
+    const redisKeys = [];
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        redisKeys.push(key);
+        return key === 'military:flights:v1'
+          ? jsonResponse({ error: 'ERR max request size exceeded' })
+          : jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (raw.includes('/opensky') || raw.includes('opensky-network.org')) {
+        openskyCalls += 1;
+        return jsonResponse({ states: [] });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.listMilitaryFlights(
+        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+        seededRequest,
+      );
+      assert.match(redisKeys[0], /^military:flights:v1:/);
+      assert.equal(redisKeys[1], 'military:flights:v1');
+      assert.equal(openskyCalls, 0, 'Redis read failure must fail closed instead of amplifying OpenSky');
+      assert.deepEqual(result, { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } });
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('keeps cursor pagination on one seeded snapshot while the root rotates', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const store = new Map();
+    let rootReads = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === 'military:flights:v1') {
+          rootReads += 1;
+          const flights = rootReads === 1
+            ? [
+              { id: 'seed-a', callsign: 'RCH501', lat: 20.2, lon: 10.2 },
+              { id: 'seed-b', callsign: 'RCH502', lat: 20.3, lon: 10.3 },
+            ]
+            : [{ id: 'seed-new', callsign: 'RCH599', lat: 20.4, lon: 10.4 }];
+          return jsonResponse({ result: JSON.stringify({ flights, fetchedAt: Date.now() }) });
+        }
+        return jsonResponse({ result: store.get(key) ?? null });
+      }
+      if (isSetRequest(url, init)) {
+        const { key, value } = parseSetRequest(url, init);
+        store.set(key, value);
+        return jsonResponse({ result: 'OK' });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
+      const first = await module.listMilitaryFlights(ctx, { ...seededRequest, pageSize: 1, cursor: '' });
+      module._resetStaleNegativeCacheForTests();
+      const second = await module.listMilitaryFlights(ctx, {
+        ...seededRequest,
+        pageSize: 1,
+        cursor: first.pagination?.nextCursor ?? '',
+      });
+      assert.deepEqual(first.flights.map((flight) => flight.id), ['SEED-A']);
+      assert.deepEqual(second.flights.map((flight) => flight.id), ['SEED-B']);
+      assert.equal(rootReads, 1, 'continuation pages must stay on the cached unpaginated snapshot');
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('uses request-specific recovery outside the seed snapshot coverage', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let liveSeedReads = 0;
+    let openskyCalls = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === 'military:flights:v1') liveSeedReads += 1;
+        return jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (raw.includes('/opensky')) {
+        openskyCalls += 1;
+        return jsonResponse({
+          states: [['outside-region', 'RCH401', null, null, null, 10.5, 10.5, 20000, false, 300, 90]],
+        });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.listMilitaryFlights(
+        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+        request,
+      );
+      assert.equal(liveSeedReads, 0, 'an uncovered bbox must not consult a partial global snapshot');
+      assert.equal(openskyCalls, 1);
+      assert.deepEqual(result.flights.map((flight) => flight.id), ['OUTSIDE-REGION']);
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
 
   it('fetches expanded quantized bbox but returns only flights inside the requested bbox', async () => {
     const { module, cleanup } = await importListMilitaryFlights();
@@ -1816,7 +2276,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
 
     try {
       const result = await module.listMilitaryFlights({}, request);
-      assert.equal(redisGetCalls, 1, 'handler should read quantized cache first');
+      assert.equal(redisGetCalls, 1, 'an uncovered bbox should read only its quantized cache');
       assert.equal(openskyCalls, 0, 'cache hit should avoid upstream fetch');
       assert.deepEqual(
         result.flights.map((flight) => flight.id),
@@ -1849,7 +2309,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       const raw = String(url);
       if (raw.includes('/get/')) {
         const key = decodeURIComponent(raw.split('/get/')[1] || '');
-        if (key.startsWith('military:flights:v1')) liveCacheKeys.push(key);
+        if (key.startsWith('military:flights:v1:')) liveCacheKeys.push(key);
         return jsonResponse({ result: store.get(key) ?? null });
       }
       if (isSetRequest(url, init)) {


### PR DESCRIPTION
## Summary

OpenSky remained 429-throttled days after the retry/cooldown fixes merged because the failure is a shared daily-credit exhaustion problem, not a propagation delay. The scheduled military seed and theater posture loops alone can consume about 3,456 of the standard account's 4,000 daily credits before viewer bbox traffic begins, while unique viewer bboxes prevent the short response cache from absorbing the remainder.

This change makes authenticated OpenSky a bounded recovery source instead of routine traffic:

- General aircraft bboxes use Wingbits first, tile wide viewports so success still means complete bbox coverage, and enter authenticated then anonymous OpenSky only after provider failure.
- Military bbox reads reuse the centralized scheduled snapshot inside its declared coverage, keep cursor pages on one cached version, coalesce root reads, and fail closed on Redis command errors rather than reopening per-viewer fanout.
- Theater posture uses `adsb.lol -> Wingbits -> OpenSky`; valid quiet skies remain authoritative, while malformed `adsb.lol` success bodies fall through.
- The relay atomically stops queued unique-bbox work after one 429, honors provider reset headers with a 24-hour cap, and exposes remaining credits, reset time, last success, and last 429. Health stays degraded while that reset is active even after rolling request samples age out.

The military seed deliberately remains a last-good snapshot during an upstream outage. Its original `fetchedAt` and each flight's `lastSeenAt` remain old so freshness monitoring stays truthful without recreating authenticated request fanout.

Related: #5945

## Validation

- `node --test scripts/ais-relay-ingestion.test.cjs` - 8/8 passed, including queued 429 suppression, malformed compression, 24-hour reset bounding, aged health, wide-viewport tiling, and zero routine theater OpenSky requests.
- `tsx --test tests/redis-caching.test.mjs` - 56/56 passed, including provider priority, the 18-second all-provider deadline, seed coverage, concurrent read coalescing, Redis error handling, and stable pagination.
- `npm run typecheck` and `npm run typecheck:api` passed.
- `npm run test:sidecar` - 316/316 passed.
- `npm run lint` passed with the repository's pre-existing warnings only.
- The full data suite exercised the repository; only its sandboxed nested pre-push fixtures were blocked from the macOS temp directory. The same fixture passed 15/15 in an authoritative unsandboxed run.
- The repository pre-push gate passed after rebasing onto current `main`.

## Post-Deploy Monitoring & Validation

**Window and owner:** release owner observes one complete 24-hour OpenSky credit cycle, then requires two consecutive 60-second healthy relay windows before accepting the fix in production.

**Logs:** search for `[Relay] OpenSky 429`, `OpenSky request (MISS)`, `[Wingbits Track]`, `[adsb.lol]`, and military-flight seed completion/failure messages. Routine healthy cycles should not log authenticated OpenSky misses from theater posture.

**Metrics and health:** watch `/metrics` fields `opensky.upstreamFetches`, `rateLimitRemaining`, `rateLimitRetryAt`, `lastSuccessAt`, `last429At`, and theater source counts, together with aviation coverage in `/health` and military seed freshness.

**Healthy signals:** theater cycles are served by adsb.lol or Wingbits; covered military requests reuse the scheduled snapshot; one 429 produces one upstream fetch followed by queue-level suppression; remaining credits survive the day; aviation coverage recovers for two windows after the reset.

**Failure signals:** OpenSky upstream fetches continue rising while adsb.lol/Wingbits are healthy, multiple unique bboxes reach upstream after one 429, credits reach zero early in the cycle, health reports OK during an active reset, or covered military requests bypass the seed.

**Mitigation/rollback:** if credit fanout persists, disable the affected authenticated consumer and retain adsb.lol/Wingbits publication while investigating. If Wingbits-first routing causes material bbox completeness loss, revert the deployment commit; the existing provider chain remains the rollback path.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
