### PR TITLE
fix(brief-gates): stop flagging a sentence-initial common noun the source already contains (#6109)

### DIFF
--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -633,6 +633,26 @@ function extractProperNounSequencesWithMeta(text) {
  * proper-noun extraction cannot, because the source may carry the same word
  * lowercase mid-sentence.
  */
+// #6109: months are excluded from the sentence-initial allowance below. For
+// every other word a capital at sentence start is pure orthography — but for a
+// month the capital is exactly what separates a CALENDAR CLAIM from an ordinary
+// word ("the march on the capital" -> "March saw heavy fighting"; "officials
+// may authorise" -> "May brought strikes"). Verified against origin/main: the
+// allowance without this newly ACCEPTED both, where the old code rejected them.
+// The date validator does not cover it either — extractNumericFacts only reads
+// a month adjacent to a day or year, so a bare "March" is not a date fact. The
+// repo has flagged this collision class before (the anchor-token note on "May":
+// Theresa May / May Day / the month all land on one token).
+//
+// Excluding a month costs nothing when the source really does name it: the
+// normal capitalized-sequence path already grounds that case. This only removes
+// the lowercase-source fallback, which for a month is never the right read.
+const SENTENCE_INITIAL_ALLOWANCE_BLOCKED = new Set([
+  'january', 'jan', 'february', 'feb', 'march', 'mar', 'april', 'apr', 'may',
+  'june', 'jun', 'july', 'jul', 'august', 'aug', 'september', 'sept', 'sep',
+  'october', 'oct', 'november', 'nov', 'december', 'dec',
+]);
+
 function groundTokenSet(text) {
   const out = new Set();
   if (typeof text !== 'string' || text.length === 0) return out;
@@ -751,7 +771,13 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
     // capital IS a deliberate signal — that is what stops a source reading
     // "apple prices" from licensing "Apple" the company. Presence in the
     // source is the definition of not-invented; case never was.
-    if (!found && sentenceInitial && summarySeq.length === 1 && headlineTokens.has(summarySeq[0])) {
+    if (
+      !found
+      && sentenceInitial
+      && summarySeq.length === 1
+      && !SENTENCE_INITIAL_ALLOWANCE_BLOCKED.has(summarySeq[0])
+      && headlineTokens.has(summarySeq[0])
+    ) {
       found = true;
     }
     if (!found) {

--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -544,9 +544,13 @@ function extractProperNounSequencesWithMeta(text) {
   const sentences = preprocessed.split(/[.!?]+\s+|\n+/);
 
   const sequences = [];
+  // #6109: which non-empty sentence are we in? Only the FIRST one can carry the
+  // sentence-initial allowance — see the `firstSentence` note at its use site.
+  let sentenceOrdinal = -1;
   for (const rawSentence of sentences) {
     const sentence = rawSentence.trim();
     if (!sentence) continue;
+    sentenceOrdinal += 1;
 
     // Tokenize: keep alphanumeric runs + apostrophes + hyphens
     // (preserves "Mar-a-Lago", "O'Brien").
@@ -555,6 +559,8 @@ function extractProperNounSequencesWithMeta(text) {
 
     let current = [];
     let currentStartedSentence = false; // #6109: did `current` open this sentence?
+    let currentAllCaps = false; // #6109: was its first token a deliberate ALL-CAPS acronym?
+    let currentFirstSentence = false; // #6109: is `current` in the FIRST sentence?
     let bridgeBuffer = []; // joiners pending — kept only if another proper noun follows
     let firstToken = true;
 
@@ -604,21 +610,31 @@ function extractProperNounSequencesWithMeta(text) {
           current.push(...bridgeBuffer);
         }
         bridgeBuffer = [];
-        if (current.length === 0) currentStartedSentence = atSentenceStart;
+        if (current.length === 0) {
+          currentStartedSentence = atSentenceStart;
+          // #6109: sentence position can force the FIRST letter to be a capital;
+          // it cannot force the interior ones. An ALL-CAPS token ("WHO", "US",
+          // "SWIFT", "ICE") is therefore a deliberate acronym, not orthography,
+          // so the sentence-initial allowance must not apply to it.
+          currentAllCaps = isAllCapsAcronym;
+          currentFirstSentence = sentenceOrdinal === 0;
+        }
         // Use the punctuation/possessive-stripped form so "Beirut's"
         // lands as "beirut", matching the headline's "Beirut".
         current.push(tokenForLookup.toLowerCase());
       } else {
         // Lowercase non-joiner — ends current sequence.
         if (current.length > 0) {
-          sequences.push({ tokens: current, sentenceInitial: currentStartedSentence });
+          sequences.push({ tokens: current, sentenceInitial: currentStartedSentence, allCaps: currentAllCaps, firstSentence: currentFirstSentence });
           current = [];
           currentStartedSentence = false;
+          currentAllCaps = false;
+          currentFirstSentence = false;
         }
         bridgeBuffer = [];
       }
     }
-    if (current.length > 0) sequences.push({ tokens: current, sentenceInitial: currentStartedSentence });
+    if (current.length > 0) sequences.push({ tokens: current, sentenceInitial: currentStartedSentence, allCaps: currentAllCaps, firstSentence: currentFirstSentence });
   }
 
   return sequences;
@@ -647,10 +663,39 @@ function extractProperNounSequencesWithMeta(text) {
 // Excluding a month costs nothing when the source really does name it: the
 // normal capitalized-sequence path already grounds that case. This only removes
 // the lowercase-source fallback, which for a month is never the right read.
+// Adversarial review widened this from months alone to the whole homograph
+// class: a token that is an ordinary lowercase word in a wire story AND a
+// distinct named entity when capitalized. Each entry below was demonstrated as
+// a live false-accept against origin/main, with a realistic newswire source:
+//   turkey  "prices for turkey soar before the holiday"   -> "Turkey rejected…"
+//   china   "tariffs on fine china"                       -> "China imposed…"
+//   bill    "the senate defense bill heads to the floor"  -> "Bill passed…"
+//   polish  "ministers race to polish the package"        -> "Poland readied…"
+//   march / may  (the original month pair)
+// These are NOT reachable via the ACRONYM/DEMONYM tables — 'china' and 'turkey'
+// are not keys there — so the source-capitalization gate in groundTokenSet
+// cannot close them; only an explicit block can.
+//
+// Scope rule for adding to this list: the word must plausibly appear LOWERCASE
+// in a geopolitical wire story while also naming a state, person, org, or date
+// when capitalized. It is deliberately short — the general amnesty is the
+// point, and every entry here is a case where capitalization carries the
+// meaning rather than mere sentence position.
 const SENTENCE_INITIAL_ALLOWANCE_BLOCKED = new Set([
+  // Months — a bare month is not a date fact to extractNumericFacts, so nothing
+  // else catches "the march on the capital" licensing "March saw fighting".
   'january', 'jan', 'february', 'feb', 'march', 'mar', 'april', 'apr', 'may',
   'june', 'jun', 'july', 'jul', 'august', 'aug', 'september', 'sept', 'sep',
   'october', 'oct', 'november', 'nov', 'december', 'dec',
+  // States and nationals that double as common words.
+  'turkey', 'china', 'chad', 'jordan', 'georgia', 'polish', 'dutch', 'thai',
+  // Person names that double as common words.
+  'bill', 'mark', 'will', 'frank', 'rose', 'grant',
+  // Brands and outlets that double as common words. Adversarial review
+  // published "Apple cut its regional orders" grounded only by "apple prices",
+  // and found Post/Guard/State/Sun still licensed across 73 live headlines.
+  'apple', 'amazon', 'shell', 'orange', 'target', 'meta', 'gap', 'visa',
+  'post', 'guard', 'state', 'sun', 'times', 'page', 'ford',
 ]);
 
 function groundTokenSet(text) {
@@ -660,7 +705,23 @@ function groundTokenSet(text) {
     if (!raw) continue;
     const stripped = raw.replace(/[.,;:'’]+$/g, '').replace(/['’]s$/i, '');
     const token = (stripped || raw).toLowerCase();
-    if (token) out.add(normalizeToken(token));
+    if (!token) continue;
+    // Do NOT let the acronym/demonym tables promote a token the source wrote in
+    // LOWERCASE. Eight ordinary English words collide with an organization or
+    // nation identity — who->WHO, us->US, sec->SEC, pentagon->DOD, and the
+    // demonyms polish->Poland, thai->Thailand, dutch->Netherlands,
+    // chinese->China. Without this, a source reading "Officials who briefed
+    // reporters…" grounds a lead reading "WHO warned…", publishing an invented
+    // attribution under the default enforce mode. Verified against origin/main:
+    // all eight flipped from reject to accept.
+    //
+    // Same reasoning as the month exclusion above, one axis wider: for these
+    // tokens the capital IS the identity, so the "case carries no signal"
+    // premise does not hold. A source that CAPITALIZES the word still gets the
+    // promotion, so "Israeli jets" -> "Israel struck" keeps working.
+    const sourceCapitalized = /^\p{Lu}/u.test(stripped || raw);
+    if (!sourceCapitalized && (ACRONYM_NORMALIZE.has(token) || DEMONYM_NORMALIZE.has(token))) continue;
+    out.add(normalizeToken(token));
   }
   return out;
 }
@@ -733,10 +794,24 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
   let summaryEntries, headlineSequences, headlineTokens;
   try {
     summaryEntries = extractProperNounSequencesWithMeta(summary)
-      .map((entry) => ({ tokens: normalizeSequence(entry.tokens), sentenceInitial: entry.sentenceInitial }));
+      .map((entry) => ({
+        tokens: normalizeSequence(entry.tokens),
+        sentenceInitial: entry.sentenceInitial,
+        allCaps: entry.allCaps,
+        firstSentence: entry.firstSentence,
+      }));
     headlineSequences = extractProperNounSequences(headline).map(normalizeSequence);
     headlineTokens = groundTokenSet(headline);
-  } catch {
+  } catch (err) {
+    // #6109: this catch fails the gate OPEN — every claim is accepted. That is
+    // the deliberate "ship the LLM output rather than fall back on confusion"
+    // stance, but it must never be SILENT: adversarial review caught a
+    // transient bad save in which the extractor threw and the validator
+    // returned ok:true for all 19 fixtures in a battery, must-reject cases
+    // included, with nothing in the log. A dead gate and a healthy gate looked
+    // identical. Warn so the difference is visible, matching the pattern used
+    // by checkLeadGrounding below.
+    console.warn(`[brief_grounding] proper-noun extraction threw (${err?.message ?? err}) — accepting unvalidated`);
     return { ok: true };
   }
 
@@ -744,7 +819,7 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
 
   // For each summary sequence, check whether at least one contiguous
   // subsequence of it appears in some headline sequence.
-  for (const { tokens: summarySeq, sentenceInitial } of summaryEntries) {
+  for (const { tokens: summarySeq, sentenceInitial, allCaps, firstSentence } of summaryEntries) {
     let found = false;
     for (const headlineSeq of headlineSequences) {
       if (containsSubsequence(headlineSeq, summarySeq)) {
@@ -774,6 +849,8 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
     if (
       !found
       && sentenceInitial
+      && firstSentence
+      && !allCaps
       && summarySeq.length === 1
       && !SENTENCE_INITIAL_ALLOWANCE_BLOCKED.has(summarySeq[0])
       && headlineTokens.has(summarySeq[0])

--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -516,6 +516,24 @@ function normalizeDottedAcronyms(text) {
 }
 
 export function extractProperNounSequences(text) {
+  return extractProperNounSequencesWithMeta(text).map((entry) => entry.tokens);
+}
+
+/**
+ * #6109: same extraction, but each sequence also reports whether it began at
+ * the FIRST token of its sentence. That distinction matters because a capital
+ * in that position is forced by orthography and therefore carries no
+ * proper-noun signal, while a capital anywhere else is a deliberate choice by
+ * the writer. `validateNoHallucinatedProperNouns` uses it to stop flagging a
+ * common noun the source already contains in lowercase.
+ *
+ * Internal on purpose — `extractProperNounSequences` keeps its `string[][]`
+ * public shape (declared in brief-llm-core.d.ts and asserted by tests).
+ *
+ * @param {string} text
+ * @returns {{ tokens: string[], sentenceInitial: boolean }[]}
+ */
+function extractProperNounSequencesWithMeta(text) {
   if (typeof text !== 'string' || text.length === 0) return [];
 
   // Normalize dotted acronyms BEFORE sentence-splitting so "U.S." isn't
@@ -536,6 +554,7 @@ export function extractProperNounSequences(text) {
     if (tokens.length === 0) continue;
 
     let current = [];
+    let currentStartedSentence = false; // #6109: did `current` open this sentence?
     let bridgeBuffer = []; // joiners pending — kept only if another proper noun follows
     let firstToken = true;
 
@@ -571,6 +590,7 @@ export function extractProperNounSequences(text) {
         firstToken = false;
         continue;
       }
+      const atSentenceStart = firstToken;
       firstToken = false;
 
       if (isJoiner) {
@@ -584,22 +604,45 @@ export function extractProperNounSequences(text) {
           current.push(...bridgeBuffer);
         }
         bridgeBuffer = [];
+        if (current.length === 0) currentStartedSentence = atSentenceStart;
         // Use the punctuation/possessive-stripped form so "Beirut's"
         // lands as "beirut", matching the headline's "Beirut".
         current.push(tokenForLookup.toLowerCase());
       } else {
         // Lowercase non-joiner — ends current sequence.
         if (current.length > 0) {
-          sequences.push(current);
+          sequences.push({ tokens: current, sentenceInitial: currentStartedSentence });
           current = [];
+          currentStartedSentence = false;
         }
         bridgeBuffer = [];
       }
     }
-    if (current.length > 0) sequences.push(current);
+    if (current.length > 0) sequences.push({ tokens: current, sentenceInitial: currentStartedSentence });
   }
 
   return sequences;
+}
+
+/**
+ * #6109: the ground text's full lowercased token set, tokenized and stripped
+ * exactly as extractProperNounSequencesWithMeta does so the two compare
+ * apples-to-apples, then acronym/demonym-normalized like a single-token
+ * sequence. Used ONLY for the sentence-initial single-token allowance below —
+ * it answers "does this word appear in the source at all?", which capitalized
+ * proper-noun extraction cannot, because the source may carry the same word
+ * lowercase mid-sentence.
+ */
+function groundTokenSet(text) {
+  const out = new Set();
+  if (typeof text !== 'string' || text.length === 0) return out;
+  for (const raw of normalizeDottedAcronyms(text).split(/[^\p{L}\p{N}'’-]+/u)) {
+    if (!raw) continue;
+    const stripped = raw.replace(/[.,;:'’]+$/g, '').replace(/['’]s$/i, '');
+    const token = (stripped || raw).toLowerCase();
+    if (token) out.add(normalizeToken(token));
+  }
+  return out;
 }
 
 /**
@@ -667,19 +710,21 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
   if (typeof summary !== 'string' || summary.length === 0) return { ok: true };
   if (typeof headline !== 'string' || headline.length === 0) return { ok: true };
 
-  let summarySequences, headlineSequences;
+  let summaryEntries, headlineSequences, headlineTokens;
   try {
-    summarySequences = extractProperNounSequences(summary).map(normalizeSequence);
+    summaryEntries = extractProperNounSequencesWithMeta(summary)
+      .map((entry) => ({ tokens: normalizeSequence(entry.tokens), sentenceInitial: entry.sentenceInitial }));
     headlineSequences = extractProperNounSequences(headline).map(normalizeSequence);
+    headlineTokens = groundTokenSet(headline);
   } catch {
     return { ok: true };
   }
 
-  if (summarySequences.length === 0) return { ok: true };
+  if (summaryEntries.length === 0) return { ok: true };
 
   // For each summary sequence, check whether at least one contiguous
   // subsequence of it appears in some headline sequence.
-  for (const summarySeq of summarySequences) {
+  for (const { tokens: summarySeq, sentenceInitial } of summaryEntries) {
     let found = false;
     for (const headlineSeq of headlineSequences) {
       if (containsSubsequence(headlineSeq, summarySeq)) {
@@ -693,6 +738,21 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
         found = true;
         break;
       }
+    }
+    // #6109: a SINGLE token that opens its sentence is capitalized by
+    // orthography, not by choice, so its capital proves nothing about
+    // proper-noun-hood. Ground it against the source's full token set, which
+    // sees the word even when the source writes it lowercase mid-sentence
+    // ("…uncertainty remains over…" -> "Uncertainty persists over…").
+    //
+    // Deliberately narrow on both axes. MULTI-token sequences keep the strict
+    // contiguous rule, so "Swat, Pakistan" against a source naming only Swat
+    // still rejects. And MID-sentence capitals keep it too, because there the
+    // capital IS a deliberate signal — that is what stops a source reading
+    // "apple prices" from licensing "Apple" the company. Presence in the
+    // source is the definition of not-invented; case never was.
+    if (!found && sentenceInitial && summarySeq.length === 1 && headlineTokens.has(summarySeq[0])) {
+      found = true;
     }
     if (!found) {
       return { ok: false, hallucinated: summarySeq };

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -633,6 +633,26 @@ function extractProperNounSequencesWithMeta(text) {
  * proper-noun extraction cannot, because the source may carry the same word
  * lowercase mid-sentence.
  */
+// #6109: months are excluded from the sentence-initial allowance below. For
+// every other word a capital at sentence start is pure orthography — but for a
+// month the capital is exactly what separates a CALENDAR CLAIM from an ordinary
+// word ("the march on the capital" -> "March saw heavy fighting"; "officials
+// may authorise" -> "May brought strikes"). Verified against origin/main: the
+// allowance without this newly ACCEPTED both, where the old code rejected them.
+// The date validator does not cover it either — extractNumericFacts only reads
+// a month adjacent to a day or year, so a bare "March" is not a date fact. The
+// repo has flagged this collision class before (the anchor-token note on "May":
+// Theresa May / May Day / the month all land on one token).
+//
+// Excluding a month costs nothing when the source really does name it: the
+// normal capitalized-sequence path already grounds that case. This only removes
+// the lowercase-source fallback, which for a month is never the right read.
+const SENTENCE_INITIAL_ALLOWANCE_BLOCKED = new Set([
+  'january', 'jan', 'february', 'feb', 'march', 'mar', 'april', 'apr', 'may',
+  'june', 'jun', 'july', 'jul', 'august', 'aug', 'september', 'sept', 'sep',
+  'october', 'oct', 'november', 'nov', 'december', 'dec',
+]);
+
 function groundTokenSet(text) {
   const out = new Set();
   if (typeof text !== 'string' || text.length === 0) return out;
@@ -751,7 +771,13 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
     // capital IS a deliberate signal — that is what stops a source reading
     // "apple prices" from licensing "Apple" the company. Presence in the
     // source is the definition of not-invented; case never was.
-    if (!found && sentenceInitial && summarySeq.length === 1 && headlineTokens.has(summarySeq[0])) {
+    if (
+      !found
+      && sentenceInitial
+      && summarySeq.length === 1
+      && !SENTENCE_INITIAL_ALLOWANCE_BLOCKED.has(summarySeq[0])
+      && headlineTokens.has(summarySeq[0])
+    ) {
       found = true;
     }
     if (!found) {

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -544,9 +544,13 @@ function extractProperNounSequencesWithMeta(text) {
   const sentences = preprocessed.split(/[.!?]+\s+|\n+/);
 
   const sequences = [];
+  // #6109: which non-empty sentence are we in? Only the FIRST one can carry the
+  // sentence-initial allowance — see the `firstSentence` note at its use site.
+  let sentenceOrdinal = -1;
   for (const rawSentence of sentences) {
     const sentence = rawSentence.trim();
     if (!sentence) continue;
+    sentenceOrdinal += 1;
 
     // Tokenize: keep alphanumeric runs + apostrophes + hyphens
     // (preserves "Mar-a-Lago", "O'Brien").
@@ -555,6 +559,8 @@ function extractProperNounSequencesWithMeta(text) {
 
     let current = [];
     let currentStartedSentence = false; // #6109: did `current` open this sentence?
+    let currentAllCaps = false; // #6109: was its first token a deliberate ALL-CAPS acronym?
+    let currentFirstSentence = false; // #6109: is `current` in the FIRST sentence?
     let bridgeBuffer = []; // joiners pending — kept only if another proper noun follows
     let firstToken = true;
 
@@ -604,21 +610,31 @@ function extractProperNounSequencesWithMeta(text) {
           current.push(...bridgeBuffer);
         }
         bridgeBuffer = [];
-        if (current.length === 0) currentStartedSentence = atSentenceStart;
+        if (current.length === 0) {
+          currentStartedSentence = atSentenceStart;
+          // #6109: sentence position can force the FIRST letter to be a capital;
+          // it cannot force the interior ones. An ALL-CAPS token ("WHO", "US",
+          // "SWIFT", "ICE") is therefore a deliberate acronym, not orthography,
+          // so the sentence-initial allowance must not apply to it.
+          currentAllCaps = isAllCapsAcronym;
+          currentFirstSentence = sentenceOrdinal === 0;
+        }
         // Use the punctuation/possessive-stripped form so "Beirut's"
         // lands as "beirut", matching the headline's "Beirut".
         current.push(tokenForLookup.toLowerCase());
       } else {
         // Lowercase non-joiner — ends current sequence.
         if (current.length > 0) {
-          sequences.push({ tokens: current, sentenceInitial: currentStartedSentence });
+          sequences.push({ tokens: current, sentenceInitial: currentStartedSentence, allCaps: currentAllCaps, firstSentence: currentFirstSentence });
           current = [];
           currentStartedSentence = false;
+          currentAllCaps = false;
+          currentFirstSentence = false;
         }
         bridgeBuffer = [];
       }
     }
-    if (current.length > 0) sequences.push({ tokens: current, sentenceInitial: currentStartedSentence });
+    if (current.length > 0) sequences.push({ tokens: current, sentenceInitial: currentStartedSentence, allCaps: currentAllCaps, firstSentence: currentFirstSentence });
   }
 
   return sequences;
@@ -647,10 +663,39 @@ function extractProperNounSequencesWithMeta(text) {
 // Excluding a month costs nothing when the source really does name it: the
 // normal capitalized-sequence path already grounds that case. This only removes
 // the lowercase-source fallback, which for a month is never the right read.
+// Adversarial review widened this from months alone to the whole homograph
+// class: a token that is an ordinary lowercase word in a wire story AND a
+// distinct named entity when capitalized. Each entry below was demonstrated as
+// a live false-accept against origin/main, with a realistic newswire source:
+//   turkey  "prices for turkey soar before the holiday"   -> "Turkey rejected…"
+//   china   "tariffs on fine china"                       -> "China imposed…"
+//   bill    "the senate defense bill heads to the floor"  -> "Bill passed…"
+//   polish  "ministers race to polish the package"        -> "Poland readied…"
+//   march / may  (the original month pair)
+// These are NOT reachable via the ACRONYM/DEMONYM tables — 'china' and 'turkey'
+// are not keys there — so the source-capitalization gate in groundTokenSet
+// cannot close them; only an explicit block can.
+//
+// Scope rule for adding to this list: the word must plausibly appear LOWERCASE
+// in a geopolitical wire story while also naming a state, person, org, or date
+// when capitalized. It is deliberately short — the general amnesty is the
+// point, and every entry here is a case where capitalization carries the
+// meaning rather than mere sentence position.
 const SENTENCE_INITIAL_ALLOWANCE_BLOCKED = new Set([
+  // Months — a bare month is not a date fact to extractNumericFacts, so nothing
+  // else catches "the march on the capital" licensing "March saw fighting".
   'january', 'jan', 'february', 'feb', 'march', 'mar', 'april', 'apr', 'may',
   'june', 'jun', 'july', 'jul', 'august', 'aug', 'september', 'sept', 'sep',
   'october', 'oct', 'november', 'nov', 'december', 'dec',
+  // States and nationals that double as common words.
+  'turkey', 'china', 'chad', 'jordan', 'georgia', 'polish', 'dutch', 'thai',
+  // Person names that double as common words.
+  'bill', 'mark', 'will', 'frank', 'rose', 'grant',
+  // Brands and outlets that double as common words. Adversarial review
+  // published "Apple cut its regional orders" grounded only by "apple prices",
+  // and found Post/Guard/State/Sun still licensed across 73 live headlines.
+  'apple', 'amazon', 'shell', 'orange', 'target', 'meta', 'gap', 'visa',
+  'post', 'guard', 'state', 'sun', 'times', 'page', 'ford',
 ]);
 
 function groundTokenSet(text) {
@@ -660,7 +705,23 @@ function groundTokenSet(text) {
     if (!raw) continue;
     const stripped = raw.replace(/[.,;:'’]+$/g, '').replace(/['’]s$/i, '');
     const token = (stripped || raw).toLowerCase();
-    if (token) out.add(normalizeToken(token));
+    if (!token) continue;
+    // Do NOT let the acronym/demonym tables promote a token the source wrote in
+    // LOWERCASE. Eight ordinary English words collide with an organization or
+    // nation identity — who->WHO, us->US, sec->SEC, pentagon->DOD, and the
+    // demonyms polish->Poland, thai->Thailand, dutch->Netherlands,
+    // chinese->China. Without this, a source reading "Officials who briefed
+    // reporters…" grounds a lead reading "WHO warned…", publishing an invented
+    // attribution under the default enforce mode. Verified against origin/main:
+    // all eight flipped from reject to accept.
+    //
+    // Same reasoning as the month exclusion above, one axis wider: for these
+    // tokens the capital IS the identity, so the "case carries no signal"
+    // premise does not hold. A source that CAPITALIZES the word still gets the
+    // promotion, so "Israeli jets" -> "Israel struck" keeps working.
+    const sourceCapitalized = /^\p{Lu}/u.test(stripped || raw);
+    if (!sourceCapitalized && (ACRONYM_NORMALIZE.has(token) || DEMONYM_NORMALIZE.has(token))) continue;
+    out.add(normalizeToken(token));
   }
   return out;
 }
@@ -733,10 +794,24 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
   let summaryEntries, headlineSequences, headlineTokens;
   try {
     summaryEntries = extractProperNounSequencesWithMeta(summary)
-      .map((entry) => ({ tokens: normalizeSequence(entry.tokens), sentenceInitial: entry.sentenceInitial }));
+      .map((entry) => ({
+        tokens: normalizeSequence(entry.tokens),
+        sentenceInitial: entry.sentenceInitial,
+        allCaps: entry.allCaps,
+        firstSentence: entry.firstSentence,
+      }));
     headlineSequences = extractProperNounSequences(headline).map(normalizeSequence);
     headlineTokens = groundTokenSet(headline);
-  } catch {
+  } catch (err) {
+    // #6109: this catch fails the gate OPEN — every claim is accepted. That is
+    // the deliberate "ship the LLM output rather than fall back on confusion"
+    // stance, but it must never be SILENT: adversarial review caught a
+    // transient bad save in which the extractor threw and the validator
+    // returned ok:true for all 19 fixtures in a battery, must-reject cases
+    // included, with nothing in the log. A dead gate and a healthy gate looked
+    // identical. Warn so the difference is visible, matching the pattern used
+    // by checkLeadGrounding below.
+    console.warn(`[brief_grounding] proper-noun extraction threw (${err?.message ?? err}) — accepting unvalidated`);
     return { ok: true };
   }
 
@@ -744,7 +819,7 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
 
   // For each summary sequence, check whether at least one contiguous
   // subsequence of it appears in some headline sequence.
-  for (const { tokens: summarySeq, sentenceInitial } of summaryEntries) {
+  for (const { tokens: summarySeq, sentenceInitial, allCaps, firstSentence } of summaryEntries) {
     let found = false;
     for (const headlineSeq of headlineSequences) {
       if (containsSubsequence(headlineSeq, summarySeq)) {
@@ -774,6 +849,8 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
     if (
       !found
       && sentenceInitial
+      && firstSentence
+      && !allCaps
       && summarySeq.length === 1
       && !SENTENCE_INITIAL_ALLOWANCE_BLOCKED.has(summarySeq[0])
       && headlineTokens.has(summarySeq[0])

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -516,6 +516,24 @@ function normalizeDottedAcronyms(text) {
 }
 
 export function extractProperNounSequences(text) {
+  return extractProperNounSequencesWithMeta(text).map((entry) => entry.tokens);
+}
+
+/**
+ * #6109: same extraction, but each sequence also reports whether it began at
+ * the FIRST token of its sentence. That distinction matters because a capital
+ * in that position is forced by orthography and therefore carries no
+ * proper-noun signal, while a capital anywhere else is a deliberate choice by
+ * the writer. `validateNoHallucinatedProperNouns` uses it to stop flagging a
+ * common noun the source already contains in lowercase.
+ *
+ * Internal on purpose — `extractProperNounSequences` keeps its `string[][]`
+ * public shape (declared in brief-llm-core.d.ts and asserted by tests).
+ *
+ * @param {string} text
+ * @returns {{ tokens: string[], sentenceInitial: boolean }[]}
+ */
+function extractProperNounSequencesWithMeta(text) {
   if (typeof text !== 'string' || text.length === 0) return [];
 
   // Normalize dotted acronyms BEFORE sentence-splitting so "U.S." isn't
@@ -536,6 +554,7 @@ export function extractProperNounSequences(text) {
     if (tokens.length === 0) continue;
 
     let current = [];
+    let currentStartedSentence = false; // #6109: did `current` open this sentence?
     let bridgeBuffer = []; // joiners pending — kept only if another proper noun follows
     let firstToken = true;
 
@@ -571,6 +590,7 @@ export function extractProperNounSequences(text) {
         firstToken = false;
         continue;
       }
+      const atSentenceStart = firstToken;
       firstToken = false;
 
       if (isJoiner) {
@@ -584,22 +604,45 @@ export function extractProperNounSequences(text) {
           current.push(...bridgeBuffer);
         }
         bridgeBuffer = [];
+        if (current.length === 0) currentStartedSentence = atSentenceStart;
         // Use the punctuation/possessive-stripped form so "Beirut's"
         // lands as "beirut", matching the headline's "Beirut".
         current.push(tokenForLookup.toLowerCase());
       } else {
         // Lowercase non-joiner — ends current sequence.
         if (current.length > 0) {
-          sequences.push(current);
+          sequences.push({ tokens: current, sentenceInitial: currentStartedSentence });
           current = [];
+          currentStartedSentence = false;
         }
         bridgeBuffer = [];
       }
     }
-    if (current.length > 0) sequences.push(current);
+    if (current.length > 0) sequences.push({ tokens: current, sentenceInitial: currentStartedSentence });
   }
 
   return sequences;
+}
+
+/**
+ * #6109: the ground text's full lowercased token set, tokenized and stripped
+ * exactly as extractProperNounSequencesWithMeta does so the two compare
+ * apples-to-apples, then acronym/demonym-normalized like a single-token
+ * sequence. Used ONLY for the sentence-initial single-token allowance below —
+ * it answers "does this word appear in the source at all?", which capitalized
+ * proper-noun extraction cannot, because the source may carry the same word
+ * lowercase mid-sentence.
+ */
+function groundTokenSet(text) {
+  const out = new Set();
+  if (typeof text !== 'string' || text.length === 0) return out;
+  for (const raw of normalizeDottedAcronyms(text).split(/[^\p{L}\p{N}'’-]+/u)) {
+    if (!raw) continue;
+    const stripped = raw.replace(/[.,;:'’]+$/g, '').replace(/['’]s$/i, '');
+    const token = (stripped || raw).toLowerCase();
+    if (token) out.add(normalizeToken(token));
+  }
+  return out;
 }
 
 /**
@@ -667,19 +710,21 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
   if (typeof summary !== 'string' || summary.length === 0) return { ok: true };
   if (typeof headline !== 'string' || headline.length === 0) return { ok: true };
 
-  let summarySequences, headlineSequences;
+  let summaryEntries, headlineSequences, headlineTokens;
   try {
-    summarySequences = extractProperNounSequences(summary).map(normalizeSequence);
+    summaryEntries = extractProperNounSequencesWithMeta(summary)
+      .map((entry) => ({ tokens: normalizeSequence(entry.tokens), sentenceInitial: entry.sentenceInitial }));
     headlineSequences = extractProperNounSequences(headline).map(normalizeSequence);
+    headlineTokens = groundTokenSet(headline);
   } catch {
     return { ok: true };
   }
 
-  if (summarySequences.length === 0) return { ok: true };
+  if (summaryEntries.length === 0) return { ok: true };
 
   // For each summary sequence, check whether at least one contiguous
   // subsequence of it appears in some headline sequence.
-  for (const summarySeq of summarySequences) {
+  for (const { tokens: summarySeq, sentenceInitial } of summaryEntries) {
     let found = false;
     for (const headlineSeq of headlineSequences) {
       if (containsSubsequence(headlineSeq, summarySeq)) {
@@ -693,6 +738,21 @@ export function validateNoHallucinatedProperNouns(summary, headline) {
         found = true;
         break;
       }
+    }
+    // #6109: a SINGLE token that opens its sentence is capitalized by
+    // orthography, not by choice, so its capital proves nothing about
+    // proper-noun-hood. Ground it against the source's full token set, which
+    // sees the word even when the source writes it lowercase mid-sentence
+    // ("…uncertainty remains over…" -> "Uncertainty persists over…").
+    //
+    // Deliberately narrow on both axes. MULTI-token sequences keep the strict
+    // contiguous rule, so "Swat, Pakistan" against a source naming only Swat
+    // still rejects. And MID-sentence capitals keep it too, because there the
+    // capital IS a deliberate signal — that is what stops a source reading
+    // "apple prices" from licensing "Apple" the company. Presence in the
+    // source is the definition of not-invented; case never was.
+    if (!found && sentenceInitial && summarySeq.length === 1 && headlineTokens.has(summarySeq[0])) {
+      found = true;
     }
     if (!found) {
       return { ok: false, hallucinated: summarySeq };

--- a/tests/brief-llm-core.test.mjs
+++ b/tests/brief-llm-core.test.mjs
@@ -573,6 +573,67 @@ describe('validateNoHallucinatedProperNouns — May 19 regression + class', () =
     assert.ok(!flat.includes('j'));
   });
 
+  // #6109: a common noun capitalized ONLY because it opens the sentence carries
+  // no proper-noun signal — orthography forced the capital. The source has the
+  // same word lowercase mid-sentence, so it is not extracted as a proper noun
+  // there and the summary's copy was flagged as invented, rejecting the whole
+  // brief. Observed live in both arms of a 40-pair A/B, so it is not a
+  // prompt artifact. SENTENCE_START_AMBIGUOUS cannot fix this by enumeration:
+  // covering every English common noun would also swallow the real proper nouns
+  // ("Trump said…", "Israel announced…") that the list deliberately lets pass.
+  it('accepts a sentence-initial common noun that appears lowercased in the source', () => {
+    const ground = 'After Donald Trump latest U-turn, uncertainty remains over the diplomatic path';
+    const summary = 'Uncertainty persists over the diplomatic path [6].';
+    assert.equal(
+      validateNoHallucinatedProperNouns(summary, ground).ok,
+      true,
+      '"uncertainty" is present in the source — capitalization is forced by sentence position',
+    );
+  });
+
+  it('still rejects a sentence-initial proper noun absent from the source', () => {
+    const ground = 'After Donald Trump latest U-turn, uncertainty remains over the diplomatic path';
+    const summary = 'Belarus escalated its posture overnight [6].';
+    assert.equal(
+      validateNoHallucinatedProperNouns(summary, ground).ok,
+      false,
+      'sentence-initial position must not become a blanket amnesty',
+    );
+  });
+
+  // The two guards below must ISOLATE the condition they pin. An earlier
+  // version of each rejected for an unrelated reason (a different ungrounded
+  // token earlier in the sentence short-circuited the loop), so both stayed
+  // green under a mutant that deleted the very narrowing they claim to protect.
+  // Each lead below is built so the token under test is the ONLY candidate.
+  it('still rejects a MID-sentence capitalized word even when the source has it lowercased', () => {
+    // The source says "apple" the fruit; the summary means Apple the company.
+    // Mid-sentence capitalization is a deliberate signal, not orthography, so
+    // the sentence-initial allowance must NOT extend here. "The" is a
+    // sentence-start stopword, so "Apple" is the only candidate in the lead.
+    const ground = 'regional apple prices rose sharply last quarter';
+    const summary = 'The Apple harvest disappointed growers [1].';
+    assert.equal(
+      validateNoHallucinatedProperNouns(summary, ground).ok,
+      false,
+      'dropping the sentence-initial narrowing would wrongly accept this',
+    );
+  });
+
+  it('does not relax multi-token sequences whose tokens are individually present', () => {
+    // Both "Swat" and "Pakistan" appear in the source, but never adjacently.
+    // The contiguous-match rule is what stops the model from fusing two
+    // separate entities into one it was never given; the single-token
+    // narrowing is what keeps that rule reachable.
+    const ground = 'Pakistan condemned the bombing near a police station in Swat';
+    const summary = 'Swat Pakistan reported 19 deaths [8].';
+    assert.equal(
+      validateNoHallucinatedProperNouns(summary, ground).ok,
+      false,
+      'dropping the single-token narrowing would wrongly accept this',
+    );
+  });
+
   it('defensive: malformed inputs return ok (do not throw)', () => {
     assert.doesNotThrow(() => validateNoHallucinatedProperNouns(undefined, "x"));
     assert.equal(validateNoHallucinatedProperNouns(undefined, "x").ok, true);

--- a/tests/brief-llm-core.test.mjs
+++ b/tests/brief-llm-core.test.mjs
@@ -620,6 +620,35 @@ describe('validateNoHallucinatedProperNouns — May 19 regression + class', () =
     );
   });
 
+  // Months are the one class where the capital is NOT mere orthography: it
+  // separates a calendar claim from an ordinary word. Caught by diffing this
+  // change against origin/main — the first version of the allowance newly
+  // ACCEPTED both of these, where the old code rejected them. The date
+  // validator does not cover a bare month (it needs an adjacent day/year).
+  it('does not let a sentence-initial month be grounded by a lowercase homograph', () => {
+    const ground = 'the march on the capital continued overnight';
+    const summary = 'March saw heavy fighting in the capital [1].';
+    assert.equal(
+      validateNoHallucinatedProperNouns(summary, ground).ok,
+      false,
+      '"march" the noun must not license "March" the month',
+    );
+  });
+
+  it('does not let a sentence-initial "May" be grounded by the modal verb', () => {
+    const ground = 'officials may authorise the strike';
+    const summary = 'May brought renewed strikes [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, false);
+  });
+
+  it('still accepts a month the source actually names', () => {
+    // The exclusion costs nothing here: the normal capitalized-sequence path
+    // grounds it, so blocking the lowercase fallback changes no real month.
+    const ground = 'March 5 offensive began at dawn';
+    const summary = 'March operations continued into the night [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, true);
+  });
+
   it('does not relax multi-token sequences whose tokens are individually present', () => {
     // Both "Swat" and "Pakistan" appear in the source, but never adjacently.
     // The contiguous-match rule is what stops the model from fusing two

--- a/tests/brief-llm-core.test.mjs
+++ b/tests/brief-llm-core.test.mjs
@@ -649,6 +649,81 @@ describe('validateNoHallucinatedProperNouns — May 19 regression + class', () =
     assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, true);
   });
 
+  // Found by adversarial review (two reviewers independently). groundTokenSet
+  // ran EVERY source word through ACRONYM_NORMALIZE / DEMONYM_NORMALIZE, so the
+  // relative pronoun "who" entered the ground set as the canonical WHO and the
+  // object pronoun "us" as US — letting the lead attribute a claim to an
+  // organization the source never mentioned. Verified as a live false-accept
+  // against origin/main. The table promotion is now refused for a token the
+  // source wrote in lowercase.
+  it('does not let the lowercase pronoun "who" ground a claim attributed to WHO', () => {
+    const ground = 'Doctors who treated cholera patients flee Sudan violence';
+    const summary = 'WHO warned of cholera spreading in Sudan [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, false);
+  });
+
+  it('does not let the lowercase pronoun "us" ground a claim about the US', () => {
+    const ground = 'they ambushed us near the border';
+    const summary = 'US forces were ambushed near the border [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, false);
+  });
+
+  it('still promotes a CAPITALIZED demonym in the source', () => {
+    // The gate is on the source's capitalization, not on the table itself.
+    const ground = 'Israeli jets struck the depot';
+    const summary = 'Israel struck the depot overnight [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, true);
+  });
+
+  it('does not promote a LOWERCASE demonym into its nation', () => {
+    // Discriminates the groundTokenSet capitalization gate specifically: the
+    // only proper-noun candidate here is "Israel", and the source writes the
+    // demonym lowercase, so the table must not promote it.
+    const ground = 'israeli jets struck the depot overnight';
+    const summary = 'Israel struck the depot overnight [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, false);
+  });
+
+  // Sentence position can force the FIRST letter to be a capital; it cannot
+  // force the interior ones. An ALL-CAPS token is a deliberate acronym, so the
+  // allowance's premise does not cover it.
+  // These two must contain NO other ungrounded proper noun, or they reject for
+  // the wrong reason and stay green with the all-caps guard deleted. A first
+  // draft used "SWIFT access for Russian banks…" and rejected on "Russian".
+  it('does not extend the allowance to an ALL-CAPS acronym at sentence start', () => {
+    const ground = 'EU vows swift response to the incident';
+    const summary = 'SWIFT curbs took effect at midnight [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, false);
+  });
+
+  it('does not let "ice storm" ground an ICE agency claim', () => {
+    const ground = 'the region was crippled by ice storm damage';
+    const summary = 'ICE raids continued through the night [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, false);
+  });
+
+  // The homograph class the month blocklist opened: a state or person name that
+  // is also an ordinary lowercase word in a wire story. Neither 'china' nor
+  // 'turkey' is in the acronym/demonym tables, so the source-capitalization
+  // gate above cannot close these — only the explicit block does.
+  it('does not let "fine china" ground a claim about China', () => {
+    const ground = 'tariffs on fine china rose sharply at auction last week';
+    const summary = 'China imposed new export controls overnight [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, false);
+  });
+
+  it('does not let "turkey" the bird ground a claim about Turkey', () => {
+    const ground = 'prices for turkey soar before the holiday';
+    const summary = 'Turkey rejected the proposal outright [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, false);
+  });
+
+  it('does not let a legislative "bill" ground a person named Bill', () => {
+    const ground = 'the senate defense bill heads to the floor';
+    const summary = 'Bill passed the chamber unopposed [1].';
+    assert.equal(validateNoHallucinatedProperNouns(summary, ground).ok, false);
+  });
+
   it('does not relax multi-token sequences whose tokens are individually present', () => {
     // Both "Swat" and "Pakistan" appear in the source, but never adjacently.
     // The contiguous-match rule is what stops the model from fusing two

--- a/tests/seed-insights-brief.test.mjs
+++ b/tests/seed-insights-brief.test.mjs
@@ -381,6 +381,56 @@ describe('composeSynthesizedBrief acronym followed by its citation (#5947)', () 
     assert.notEqual(composeSynthesizedBrief(endOfLead, topStories, { validatorMode: 'enforce' }), null);
   });
 
+  // #6109 adversarial review: the sentence-initial amnesty was reachable
+  // MID-CLAUSE by manufacturing a boundary the validator's own splitter honors
+  // but the caller's does not. The validator splits on /[.!?]+\s+|\n+/, so a
+  // bare newline (or a lowercase abbreviation like "vs.") turns an arbitrary
+  // capital into a "sentence-initial" token and hands it the amnesty. The
+  // reviewer published "Apple cut its regional orders" grounded only by
+  // "apple prices" this way — defeating the very guard the unit tests pin.
+  // Fixed by requiring the FIRST sentence, not merely a sentence start.
+  // These run through the real composer because that is where it published.
+  describe('#6109 amnesty is not reachable via a synthetic sentence boundary', () => {
+    const topStories = [
+      {
+        primaryTitle: 'Regional apple prices rose sharply in Chile last quarter, growers say',
+        primarySource: 'Reuters',
+        primaryLink: 'http://apple',
+        sources: ['Reuters', 'AP News'],
+        memberTitles: ['Regional apple prices rose sharply in Chile last quarter, growers say'],
+      },
+    ];
+    const lines = [{ n: 1, text: 'Regional apple prices rose sharply in Chile [1]' }];
+
+    it('rejects a lead smuggling a capital past a bare newline', () => {
+      const smuggled = JSON.stringify({
+        lead: 'Chile reported grower losses [1].\nApple cut its regional orders [1].',
+        lines,
+      });
+      assert.equal(
+        composeSynthesizedBrief(smuggled, topStories, { validatorMode: 'enforce' }),
+        null,
+        '"apple" the fruit must not license "Apple" the company via a newline',
+      );
+    });
+
+    it('rejects a lead smuggling a capital past a lowercase abbreviation', () => {
+      const smuggled = JSON.stringify({
+        lead: 'Chile grower losses mounted vs. Apple regional orders [1].',
+        lines,
+      });
+      assert.equal(composeSynthesizedBrief(smuggled, topStories, { validatorMode: 'enforce' }), null);
+    });
+
+    it('still composes the legitimate sentence-initial case end-to-end', () => {
+      const legit = JSON.stringify({
+        lead: 'Prices rose sharply in Chile last quarter [1].',
+        lines,
+      });
+      assert.notEqual(composeSynthesizedBrief(legit, topStories, { validatorMode: 'enforce' }), null);
+    });
+  });
+
   it('treats a bracketed year after the acronym as prose, not a citation', () => {
     // verifyCitationIndexes deliberately leaves 4-digit brackets as prose, and
     // \d{1,3} cannot match one — so "[2026]" must not license a collapse. The


### PR DESCRIPTION
Closes #6109.

With #6119 merged, this was the dominant remaining cause of `INSIGHTS_SYNTHESIS_GATE` rejections — briefs thrown away and an aging LKG served instead.

## The bug

A word capitalized only because it opens a sentence carries no proper-noun signal — orthography forced the capital. But the source writes that same word lowercase mid-sentence, so it is never extracted as a proper noun there, and the summary's copy was reported as invented:

```
source:  "After Donald Trump's latest U-turn, uncertainty remains over…"
lead:    "Uncertainty persists over the diplomatic path [6]."
verdict: { ok: false, hallucinated: ["uncertainty"] }   -> rejects the whole brief
```

Reproduced in **both arms** of a 40-pair interleaved A/B on one digest, so it is not a prompt artifact.

`SENTENCE_START_AMBIGUOUS` cannot fix this by enumeration: covering every English common noun would also swallow the real proper nouns (`Trump said…`, `Israel announced…`) the list deliberately lets through. So the check becomes grounding-aware instead of list-aware — a single-token sequence that opens the **first** sentence is grounded if the word appears in the source's own token set. Presence in the source is the definition of not-invented; case never was.

`extractProperNounSequences` keeps its public `string[][]` shape (declared in the `.d.ts`, asserted by tests); the position metadata comes from a new internal `extractProperNounSequencesWithMeta`.

## What adversarial review changed

Three reviewers — correctness, testing, and two adversarial passes on **different models** — converged on four real defects in the first cut. All were demonstrated as live false-accepts against `origin/main`; two were *published* end-to-end through `composeSynthesizedBrief` with `hallucinatedLines: 0`.

| # | Defect | Now |
|---|---|---|
| P1 | `groundTokenSet` ran every source word through `ACRONYM_NORMALIZE`/`DEMONYM_NORMALIZE`, so the pronoun `"who"` entered as canonical **WHO** and `"us"` as **US**. A reviewer published *"WHO declared a cholera emergency"* from a source reading *"Doctors who treated cholera patients"*. | Table promotion refused for a token the source wrote lowercase. A capitalized source still gets it, so `"Israeli jets"` -> `"Israel struck"` keeps working. |
| P1 | ALL-CAPS tokens (`SWIFT`, `ICE`) got the amnesty, though position can only force the *first* letter. | Excluded via new `allCaps` metadata. |
| P1 | The homograph class the month blocklist opened: `china`/`turkey`/`bill`/`apple`. Neither `china` nor `turkey` is in the normalize tables, so the fix above cannot reach them. | Explicit blocklist. |
| P2 | The extraction `catch` failed the gate **open and silent**. A reviewer watched a transient bad save make it throw; the validator then returned `ok: true` for all 19 fixtures in a battery, must-reject cases included, with nothing logged. A dead gate and a healthy gate were indistinguishable. | Warns, matching `checkLeadGrounding`. |

Also restricts the amnesty to the **first** sentence rather than any sentence start: the validator splits on `/[.!?]+\s+|\n+/`, so a lowercase abbreviation (`vs.`, `e.g.`) manufactured a boundary the caller's own split does not honor, handing a mid-clause capital the amnesty and defeating the mid-sentence guard. Both real callers pass one sentence at a time, so this costs nothing legitimate.

## Testing

Every guard is mutation-proven by a test that **isolates** it:

| Mutant | Killed by |
|---|---|
| remove the allowance entirely | the #6109 acceptance test |
| drop the sentence-initial narrowing | mid-sentence `apple`/`Apple` guard |
| drop the single-token narrowing | multi-token `Swat Pakistan` guard |
| drop the month/homograph blocklist | China, Turkey, Bill guards |
| remove the source-capitalization gate | lowercase-demonym guard |
| remove `!allCaps` | SWIFT and ICE guards |

Four drafts of these guards were **vacuous** before this landed — each rejected on an unrelated earlier token and stayed green under the mutant it claimed to catch. Every lead is now built so the token under test is the only candidate. Tests also run through `composeSynthesizedBrief`, not just the unit: that gap is precisely why the mid-sentence guard read green while the same claim published.

Suites: 108/108 core + composer, 949 across the consumer sweep (why-matters, chat-analyst, seed-insights, MCP world-brief routing, insights snapshot); biome and `tsc --noEmit` clean; both copies of `brief-llm-core.js` byte-identical (pinned by `brief-contract.test.mjs:217`). Verified from a clean extract of the commit, not the working tree.

## Known Residual

**The amnesty is a deny-list over an open class.** Measured on 150 live headlines it licenses ~5.5 tokens each — but that count is dominated by function words and common nouns with no entity twin (`and`, `for`, `says`, `war`, `oil`, `deal`). The dangerous subset is entity homographs, which the blocklist covers for every demonstrated case. New brands or place names will need adding.

The failure direction matters: not fixing #6109 loses a brief and serves a truthful LKG (fail-safe), while a wrong amnesty publishes a fabricated attribution (fail-dangerous). The blocklist is therefore the load-bearing safeguard, and `SENTENCE_INITIAL_ALLOWANCE_BLOCKED` carries a scope rule for future additions.

Not folded in, pre-existing: abbreviation-induced false boundaries in the splitter, and the ground text being the whole cluster (`primaryTitle` + all `memberTitles`), which grows the token pool with cluster size.

## Post-Deploy Monitoring & Validation

Railway service `seed-insights` (~10-minute cron).

- **Watch:** `railway logs --service seed-insights` for `Brief synthesized (top-8)` vs `[brief_synthesis] rejected (INSIGHTS_SYNTHESIS_GATE)`, and the new `[brief_grounding] proper-noun extraction threw` line — that one should never appear; if it does, the gate is passing everything unvalidated.
- **Healthy:** composed-cycle rate at or above the ~9/10 pre-merge baseline; `seed-meta:news:insights` shows `consecutiveFailures: 0` with `lastSuccessAt` advancing.
- **Extra scrutiny (this widens a hallucination gate):** spot-check several composed `worldBrief` values in `news:insights:v1` and confirm every sentence's proper nouns appear in the stories it cites — especially any sentence *starting* with a capitalized common word. A silent failure here publishes a misattributed claim rather than erroring, and it now also reaches MCP `get_world_brief` via #6134.
- **Failure signal:** a brief naming an organization or state that does not appear in its cited stories -> revert.
- **Rollback:** revert this PR; the LKG fail-safe from #5965 keeps serving the last good payload.
- **Window:** ~6 cycles (1 hour) post-deploy.

🤖 Compound Engineered with [Claude Code](https://claude.ai/code) — Opus 5, adversarial review across two model families