### PR TITLE
feat(markets): show the CBR key rate in the Central Banks tab (#6192)

### DIFF
--- a/api/_bootstrap-tier-keys.js
+++ b/api/_bootstrap-tier-keys.js
@@ -101,6 +101,7 @@ export const BOOTSTRAP_CACHE_KEYS = Object.freeze({
   crudeInventories: 'economic:crude-inventories:v1',
   natGasStorage: 'economic:nat-gas-storage:v1',
   ecbFxRates: 'economic:ecb-fx-rates:v1',
+  cbrRates: 'economic:cbr-rates:v1',
   euFsi: 'economic:fsi-eu:v1',
   shippingStress: 'supply_chain:shipping_stress:v1',
   socialVelocity: 'intelligence:social:reddit:v1',
@@ -179,6 +180,11 @@ const ON_DEMAND_KEY_NAMES = new Set([
   'cyberThreats',
   'chinaPolicyEvents', 'chinaDecisionSignals',
   'bisDsr', 'bisPropertyResidential', 'bisPropertyCommercial',
+  // One row of this feeds the Central Banks tab's policy-rate list, which BIS
+  // cannot supply for Russia. On-demand rather than tiered: the tab fetches it
+  // through the credential-less per-key URL when it renders, so the ~8KB never
+  // rides a payload every visitor downloads.
+  'cbrRates',
   'imfMacro', 'imfGrowth', 'imfLabor', 'imfExternal',
   'eurostatHousePrices', 'eurostatGovDebtQ', 'eurostatIndProd',
   'electricityPrices', 'jodiOil', 'chokepointBaselines',

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -320,7 +320,15 @@ function parseBootstrapKeyTiers(source = read('shared/bootstrap-tier-keys.js')) 
   ]) {
     const block = source.match(new RegExp(`const ${constName} = new Set\\(\\[([\\s\\S]*?)\\n\\]\\);`));
     if (!block) throw new Error(`docs-stats: could not parse ${constName} in shared/bootstrap-tier-keys.js`);
-    for (const m of block[1].matchAll(/'([^']+)'/g)) {
+    // Drop `//` comments before scanning for quoted names. The quote matcher
+    // cannot tell a key from prose, so one apostrophe in a rationale comment
+    // ("the tab's list") opens a phantom string that swallows everything up to
+    // the next apostrophe and registers it as a duplicate key — reported as
+    // `key ", " is registered in both on-demand and on-demand tiers`, which
+    // names neither the real cause nor the offending line. These Sets hold bare
+    // string literals only, so there is no `//` inside a key to protect.
+    const entries = block[1].replace(/\/\/[^\n]*/g, '');
+    for (const m of entries.matchAll(/'([^']+)'/g)) {
       // Last-write-wins would make this parser disagree with the runtime in the
       // one case that matters: tierForKey() tests fast FIRST, so a key in both
       // FAST and ON_DEMAND resolves to fast at runtime and would resolve to

--- a/shared/bootstrap-tier-keys.js
+++ b/shared/bootstrap-tier-keys.js
@@ -98,6 +98,7 @@ export const BOOTSTRAP_CACHE_KEYS = Object.freeze({
   crudeInventories: 'economic:crude-inventories:v1',
   natGasStorage: 'economic:nat-gas-storage:v1',
   ecbFxRates: 'economic:ecb-fx-rates:v1',
+  cbrRates: 'economic:cbr-rates:v1',
   euFsi: 'economic:fsi-eu:v1',
   shippingStress: 'supply_chain:shipping_stress:v1',
   socialVelocity: 'intelligence:social:reddit:v1',
@@ -176,6 +177,11 @@ const ON_DEMAND_KEY_NAMES = new Set([
   'cyberThreats',
   'chinaPolicyEvents', 'chinaDecisionSignals',
   'bisDsr', 'bisPropertyResidential', 'bisPropertyCommercial',
+  // One row of this feeds the Central Banks tab's policy-rate list, which BIS
+  // cannot supply for Russia. On-demand rather than tiered: the tab fetches it
+  // through the credential-less per-key URL when it renders, so the ~8KB never
+  // rides a payload every visitor downloads.
+  'cbrRates',
   'imfMacro', 'imfGrowth', 'imfLabor', 'imfExternal',
   'eurostatHousePrices', 'eurostatGovDebtQ', 'eurostatIndProd',
   'electricityPrices', 'jodiOil', 'chokepointBaselines',

--- a/src/services/economic/cbr-policy-rate.ts
+++ b/src/services/economic/cbr-policy-rate.ts
@@ -1,0 +1,107 @@
+import type { BisPolicyRate } from '@/generated/client/worldmonitor/economic/v1/service_client';
+
+/**
+ * Project the Bank of Russia key rate onto the BIS policy-rate row shape.
+ *
+ * BIS `WS_CBPOL` covers 12 central banks and Russia is not among them
+ * (`scripts/seed-bis-data.mjs`), so the Central Banks tab has a hole no upstream
+ * change can close — the PBoC, Banco Central do Brasil and the RBI are all
+ * there, the CBR is not. `scripts/seed-cbr-rates.mjs` (#6154) publishes the
+ * missing rate; this adapts it to the row the tab already renders.
+ *
+ * The two contracts disagree on nullability, which is the whole reason this is a
+ * function rather than an object literal at the call site. `BisPolicyRate`
+ * requires `previousRate: number` and `date: string`; the CBR payload leaves
+ * `previousRate` and `changedAt` null whenever the queried window shows no rate
+ * move. `EconomicPanel.renderCentralBanks` derives its cut/hike/hold arrow from
+ * `r.rate - r.previousRate` with no null branch, so passing those straight
+ * through would render `NaN` and an arrow that is none of the three states.
+ */
+
+const RUSSIA_ROW = {
+  countryCode: 'RU',
+  countryName: 'Russia',
+  centralBank: 'Bank of Russia',
+} as const;
+
+type CbrKeyRate = {
+  rate?: unknown;
+  observedAt?: unknown;
+  previousRate?: unknown;
+  changedAt?: unknown;
+};
+
+/** Seeded keys are written as `{_seed, data}` envelopes; readers vary on unwrapping. */
+function unwrap(payload: unknown): { keyRate?: CbrKeyRate } | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const outer = payload as { data?: unknown; keyRate?: unknown };
+  if (outer.keyRate !== undefined) return outer as { keyRate?: CbrKeyRate };
+  if (outer.data && typeof outer.data === 'object') return outer.data as { keyRate?: CbrKeyRate };
+  return null;
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === 'string' && value !== '' ? value : null;
+}
+
+/**
+ * @param payload the `economic:cbr-rates:v1` value, enveloped or not
+ * @returns a policy-rate row, or null when the payload carries no usable rate
+ */
+export function cbrKeyRateAsPolicyRate(payload: unknown): BisPolicyRate | null {
+  const keyRate = unwrap(payload)?.keyRate;
+  if (!keyRate || typeof keyRate !== 'object') return null;
+
+  const rate = finiteNumber(keyRate.rate);
+  if (rate == null) return null;
+
+  // `changedAt` is when the current rate took effect and is the more meaningful
+  // label; `observedAt` (the newest observation) is the fallback when the window
+  // shows no move. A row with neither is dropped rather than rendered undated.
+  const date = nonEmptyString(keyRate.changedAt) ?? nonEmptyString(keyRate.observedAt);
+  if (date == null) return null;
+
+  // Falling back to `rate` makes the delta exactly 0, which the tab already
+  // renders as HOLD — the honest reading of "no move inside the window we asked
+  // for". Any other default would invent a cut or a hike.
+  const previousRate = finiteNumber(keyRate.previousRate) ?? rate;
+
+  return { ...RUSSIA_ROW, rate, previousRate, date };
+}
+
+/**
+ * Append the Russia row to the BIS policy-rate list, if it belongs there.
+ *
+ * Kept here rather than inline at the call site so the two guards below are
+ * reachable by a test — they are the part of this feature most likely to be
+ * "simplified" away, and both fail silently if they are.
+ *
+ * @param bisRates rows BIS supplied, used as-is
+ * @param cbrPayload the `economic:cbr-rates:v1` value, or null/undefined
+ */
+export function mergeCbrPolicyRate(
+  bisRates: readonly BisPolicyRate[] | null | undefined,
+  cbrPayload: unknown,
+): BisPolicyRate[] {
+  const rows = [...(bisRates ?? [])];
+
+  // Guard 1 — never carry the list on Russia alone. When BIS returns nothing the
+  // tab renders a "no data" empty state; appending one row instead produces a
+  // one-bank policy-rate table, which reads as a working feed missing eleven
+  // countries rather than as an outage.
+  if (rows.length === 0) return rows;
+
+  const russia = cbrKeyRateAsPolicyRate(cbrPayload);
+  if (!russia) return rows;
+
+  // Guard 2 — BIS wins if WS_CBPOL ever adds Russia. Appending unconditionally
+  // would render two "Bank of Russia" cards with no indication which is which.
+  if (rows.some((r) => r.countryCode === russia.countryCode)) return rows;
+
+  rows.push(russia);
+  return rows;
+}

--- a/src/services/economic/index.ts
+++ b/src/services/economic/index.ts
@@ -14,7 +14,8 @@ import { createCircuitBreaker } from '@/utils';
 import { getCSSColor } from '@/utils';
 import { isFeatureAvailable } from '../runtime-config';
 import { dataFreshness } from '../data-freshness';
-import { getHydratedData } from '@/services/bootstrap';
+import { ensureHydrated, getHydratedData } from '@/services/bootstrap';
+import { mergeCbrPolicyRate } from './cbr-policy-rate';
 import { toApiUrl } from '@/services/runtime';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { EconomicServiceClient } from '@/services/generated-rpc-clients';
@@ -798,6 +799,13 @@ export async function fetchBisData(): Promise<BisData> {
   const hEer = getHydratedData('bisExchange') as GetBisExchangeRatesResponse | undefined;
   const hCredit = getHydratedData('bisCredit') as GetBisCreditResponse | undefined;
 
+  // BIS WS_CBPOL has no Russia (scripts/seed-bis-data.mjs covers 12 banks and the
+  // CBR is not one), so the key rate comes from its own seeder and is appended to
+  // the same list. Deliberately not awaited alongside the BIS calls below: this
+  // is a supplementary row, and a slow or missing CBR key must never delay or
+  // fail the twelve rows that BIS does supply.
+  const cbrPayload = ensureHydrated('cbrRates').catch(() => undefined);
+
   try {
     const [policy, eer, credit] = await Promise.all([
       hPolicy?.rates?.length ? Promise.resolve(hPolicy) : bisPolicyBreaker.execute(() => client.getBisPolicyRates({}, { signal: AbortSignal.timeout(20_000) }), emptyBisPolicyFallback, { shouldCache: (r) => (r.rates?.length ?? 0) > 0 }),
@@ -805,7 +813,7 @@ export async function fetchBisData(): Promise<BisData> {
       hCredit?.entries?.length ? Promise.resolve(hCredit) : bisCreditBreaker.execute(() => client.getBisCredit({}, { signal: AbortSignal.timeout(20_000) }), emptyBisCreditFallback, { shouldCache: (r) => (r.entries?.length ?? 0) > 0 }),
     ]);
     return {
-      policyRates: policy.rates ?? [],
+      policyRates: mergeCbrPolicyRate(policy.rates, await cbrPayload),
       exchangeRates: eer.rates ?? [],
       creditToGdp: credit.entries ?? [],
       fetchedAt: new Date(),

--- a/tests/cbr-policy-rate-row.test.mjs
+++ b/tests/cbr-policy-rate-row.test.mjs
@@ -1,0 +1,157 @@
+// CBR key rate -> BIS policy-rate row — issue #6192.
+//
+// BIS WS_CBPOL covers 12 central banks and Russia is not one of them
+// (scripts/seed-bis-data.mjs), so the Central Banks tab has a hole that cannot
+// be closed upstream. #6154 publishes the CBR key rate; this maps it onto the
+// same BisPolicyRate shape the tab already renders.
+//
+// The mapping is where the two contracts disagree, which is what these lock:
+// BisPolicyRate requires `previousRate: number` and `date: string`, while the
+// CBR payload makes both nullable — `previousRate`/`changedAt` are null whenever
+// the queried window shows no rate move. Reading those straight through would
+// render "NaN" and a cut/hike arrow computed from undefined.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { cbrKeyRateAsPolicyRate, mergeCbrPolicyRate } from '../src/services/economic/cbr-policy-rate.ts';
+
+/** The shape scripts/seed-cbr-rates.mjs publishes, as probed live 2026-08-05. */
+function cbrPayload({ keyRate: keyRateOverrides, ...rest } = {}) {
+  return {
+    quoteCurrency: 'RUB',
+    effectiveDate: '2026-08-05',
+    rates: { USD: { rate: 81.1291, nominal: 1 } },
+    ...rest,
+    keyRate: {
+      rate: 14,
+      observedAt: '2026-08-04',
+      previousRate: 14.25,
+      previousObservedAt: '2026-07-24',
+      changedAt: '2026-07-27',
+      change: -0.25,
+      observationCount: 509,
+      windowStart: { date: '2024-08-05', rate: 18 },
+      changes: [{ date: '2026-07-27', rate: 14 }],
+      ...(keyRateOverrides ?? {}),
+    },
+  };
+}
+
+test('maps the CBR key rate onto the BIS policy-rate shape', () => {
+  const row = cbrKeyRateAsPolicyRate(cbrPayload());
+  assert.deepEqual(row, {
+    countryCode: 'RU',
+    countryName: 'Russia',
+    centralBank: 'Bank of Russia',
+    rate: 14,
+    previousRate: 14.25,
+    date: '2026-07-27',
+  });
+});
+
+test('the row renders as a CUT, matching the direction the rate actually moved', () => {
+  // The tab derives its arrow from `rate - previousRate` (EconomicPanel.ts:403),
+  // so an inverted or absent previousRate silently mislabels policy direction.
+  const row = cbrKeyRateAsPolicyRate(cbrPayload());
+  assert.ok(row.rate - row.previousRate < 0, 'CBR cut 14.25 -> 14.00 on 2026-07-27');
+});
+
+test('a flat window falls back to the current rate rather than emitting NaN', () => {
+  // previousRate/changedAt are null when the queried window shows no move. The
+  // tab has no null branch: `r.rate - r.previousRate` would be NaN, and the
+  // arrow would come out as neither cut, hike, nor hold.
+  const row = cbrKeyRateAsPolicyRate(cbrPayload({
+    keyRate: { previousRate: null, previousObservedAt: null, changedAt: null, change: null },
+  }));
+  assert.equal(row.previousRate, 14, 'equal to rate => renders as HOLD');
+  assert.equal(row.rate - row.previousRate, 0);
+  assert.ok(Number.isFinite(row.rate - row.previousRate));
+});
+
+test('a flat window dates the row from the newest observation', () => {
+  // changedAt is null, but the row still needs a date string — the newest
+  // observation is the honest one: it is when we last saw this rate in force.
+  const row = cbrKeyRateAsPolicyRate(cbrPayload({
+    keyRate: { previousRate: null, changedAt: null },
+  }));
+  assert.equal(row.date, '2026-08-04');
+  assert.notEqual(row.date, '', 'an empty date would render a blank line in the tab');
+});
+
+test('returns null when the payload carries no usable key rate', () => {
+  // Every one of these must be skipped rather than rendered as a zero-rate
+  // central bank, which would sort into the tab as a real 0% policy rate.
+  for (const bad of [
+    undefined, null, {}, { keyRate: null }, { keyRate: {} },
+    { keyRate: { rate: null, observedAt: '2026-08-04' } },
+    { keyRate: { rate: Number.NaN, observedAt: '2026-08-04' } },
+    { keyRate: { rate: '14', observedAt: '2026-08-04' } },
+  ]) {
+    assert.equal(cbrKeyRateAsPolicyRate(bad), null, `expected null for ${JSON.stringify(bad)}`);
+  }
+});
+
+test('returns null when the key rate has no date at all', () => {
+  assert.equal(
+    cbrKeyRateAsPolicyRate(cbrPayload({ keyRate: { changedAt: null, observedAt: null } })),
+    null,
+    'a dateless row would render a blank date line',
+  );
+});
+
+test('tolerates the envelope wrapper the bootstrap endpoint may return', () => {
+  // Seeded keys are written as {_seed, data} envelopes; readers vary in whether
+  // they unwrap. Accepting both shapes keeps the caller from having to know.
+  const inner = cbrPayload();
+  const row = cbrKeyRateAsPolicyRate({ _seed: { fetchedAt: 1 }, data: inner });
+  assert.equal(row?.rate, 14);
+  assert.equal(row?.countryCode, 'RU');
+});
+
+// ─── merge seam ────────────────────────────────────────────────────────────────
+//
+// The mapper above is only half the feature; the decision of WHETHER to append
+// lives in mergeCbrPolicyRate. Testing only the mapper would leave both guards
+// below unreachable by the suite while every mapper test stayed green.
+
+const BIS_ROWS = Object.freeze([
+  { countryCode: 'US', countryName: 'United States', centralBank: 'Federal Reserve', rate: 4.5, previousRate: 4.75, date: '2026-06-18' },
+  { countryCode: 'BR', countryName: 'Brazil', centralBank: 'Banco Central do Brasil', rate: 15, previousRate: 15, date: '2026-07-30' },
+]);
+
+test('mergeCbrPolicyRate appends Russia to the BIS rows', () => {
+  const merged = mergeCbrPolicyRate(BIS_ROWS, cbrPayload());
+  assert.equal(merged.length, 3);
+  const ru = merged.find((r) => r.countryCode === 'RU');
+  assert.equal(ru.centralBank, 'Bank of Russia');
+  assert.equal(ru.rate, 14);
+  // The input must not be mutated — BIS_ROWS is shared frozen state here, and in
+  // production the array comes from a circuit-breaker cache that may be replayed.
+  assert.equal(BIS_ROWS.length, 2);
+});
+
+test('mergeCbrPolicyRate does NOT carry the list on Russia alone', () => {
+  // With BIS down, appending one row turns the tab's "no data" empty state into
+  // a one-bank policy-rate table — a working feed missing eleven countries,
+  // rather than a visible outage.
+  assert.deepEqual(mergeCbrPolicyRate([], cbrPayload()), []);
+  assert.deepEqual(mergeCbrPolicyRate(null, cbrPayload()), []);
+  assert.deepEqual(mergeCbrPolicyRate(undefined, cbrPayload()), []);
+});
+
+test('mergeCbrPolicyRate lets BIS win if WS_CBPOL ever adds Russia', () => {
+  // Appending unconditionally would render two "Bank of Russia" cards with
+  // nothing to tell the reader which is authoritative.
+  const withRu = [...BIS_ROWS, { countryCode: 'RU', countryName: 'Russia', centralBank: 'Bank of Russia', rate: 13.5, previousRate: 14, date: '2026-08-01' }];
+  const merged = mergeCbrPolicyRate(withRu, cbrPayload());
+  assert.equal(merged.filter((r) => r.countryCode === 'RU').length, 1);
+  assert.equal(merged.find((r) => r.countryCode === 'RU').rate, 13.5, 'BIS row survives, not ours');
+});
+
+test('mergeCbrPolicyRate returns the BIS rows untouched when CBR is unavailable', () => {
+  // ensureHydrated resolves undefined when the key is absent or the fetch failed.
+  for (const missing of [undefined, null, {}, { keyRate: null }]) {
+    assert.deepEqual(mergeCbrPolicyRate(BIS_ROWS, missing), [...BIS_ROWS]);
+  }
+});

--- a/tests/docs-stats-bootstrap-cache.test.mts
+++ b/tests/docs-stats-bootstrap-cache.test.mts
@@ -295,6 +295,25 @@ describe('parseBootstrapKeyTiers', () => {
     assert.notEqual(source, read('shared/bootstrap-tier-keys.js'), 'fixture drift: FAST_KEY_NAMES head changed');
     assert.throws(() => parseBootstrapKeyTiers(source), /registered in both fast and on-demand tiers/);
   });
+
+  // An apostrophe in a rationale comment used to open a phantom string that ran
+  // to the next apostrophe and registered as a duplicate key, failing with
+  // `key ", " is registered in both on-demand and on-demand tiers` — a message
+  // naming neither the cause nor the line. Comments are stripped before the
+  // quote scan; this keeps prose safe to write next to the key list.
+  it('ignores quotes inside comments in a tier block', () => {
+    const source = read('shared/bootstrap-tier-keys.js')
+      .replace(
+        "const ON_DEMAND_KEY_NAMES = new Set([",
+        "const ON_DEMAND_KEY_NAMES = new Set([\n  // the tab's list, which BIS cannot supply; it's on-demand",
+      );
+    assert.notEqual(source, read('shared/bootstrap-tier-keys.js'), 'fixture drift: ON_DEMAND_KEY_NAMES head changed');
+    const tiers = parseBootstrapKeyTiers(source);
+    assert.equal(tiers.cbrRates, 'on-demand', 'real keys still parse');
+    for (const name of Object.keys(tiers)) {
+      assert.match(name, /^[A-Za-z][A-Za-z0-9]*$/, `parsed a non-identifier key: ${JSON.stringify(name)}`);
+    }
+  });
 });
 
 describe('--check wiring', () => {


### PR DESCRIPTION
Closes #6192. The presentation layer for the Bank of Russia data #6154 shipped.

## Why this is a row, not a panel

`EconomicPanel.renderCentralBanks` (`src/components/EconomicPanel.ts:388`) already renders a policy-rate-by-country grid — central bank, country, rate, cut/hike/hold, date — as a tab of the `economic` panel, default-on in four variants.

Its source is `economic:bis:policy:v1`, and BIS `WS_CBPOL` covers twelve central banks (`scripts/seed-bis-data.mjs:17-30`):

```
US · GB · JP · XM · CH · SG · IN · AU · CN · CA · KR · BR
```

The PBoC is there. Banco Central do Brasil is there. The RBI is there. The CBR is not, and no upstream change can add it — BIS simply does not publish it. That is exactly the hole #6154's seeder fills, so this adds a thirteenth row rather than a panel.

## The mapping is where the contracts disagree

`BisPolicyRate` requires `previousRate: number` and `date: string`. The CBR payload nulls `previousRate` and `changedAt` whenever the queried window shows no rate move.

`renderCentralBanks:403` computes its arrow from `r.rate - r.previousRate` with **no null branch**, so passing those through renders `NaN` and an arrow that is neither cut, hike, nor hold. `cbrKeyRateAsPolicyRate` therefore:

- falls back to the current rate when `previousRate` is null — delta exactly 0, which the tab already renders as HOLD, the honest reading of "no move inside the window we asked for". Any other default invents a cut or a hike.
- dates from `changedAt`, else the newest observation; drops the row entirely if it has neither, rather than rendering a blank date line.
- returns null for a non-finite or non-numeric rate, so a malformed payload can never sort into the tab as a real 0% policy rate.

## Two guards, deliberately in the leaf module

`mergeCbrPolicyRate` owns the append decision:

- **Never carry the list on Russia alone.** With BIS down the tab renders a "no data" empty state; appending one row instead produces a one-bank policy table, which reads as a working feed missing eleven countries rather than a visible outage.
- **BIS wins if `WS_CBPOL` ever adds Russia**, instead of two "Bank of Russia" cards with nothing to distinguish them.

I first wrote both inline in `fetchBisData`. Inline, they are unreachable by any test while every mapper test stays green — the vacuous-guard shape where a suite covers each unit a change touches and still misses the seam that composes them. Moving them into the leaf makes both testable.

## Wiring

`cbrRates` joins the **on-demand** bootstrap tier, so `ensureHydrated` fetches it through the credential-less per-key URL when the tab renders and the ~8KB never rides a payload every visitor downloads. It stays in health's `STANDALONE_KEYS`, matching `bisDsr`, which preserves the activation-marker bridge added in #6154.

The CBR read is fired alongside the BIS calls but **not awaited with them** — it is a supplementary row and must never delay or fail the twelve rows BIS does supply. A rejection resolves to `undefined` and the tab renders exactly as it does today.

## Unplanned fix: `scripts/docs-stats.mjs`

The suite caught a real bug. Its bootstrap-tier parser scanned for quoted strings **including inside comments**, so one apostrophe in a rationale comment ("the tab's list") opened a phantom string that ran to the next apostrophe and registered as a duplicate key. It failed with:

```
docs-stats: bootstrap key ", " is registered in both on-demand and on-demand tiers
```

— naming neither the cause nor the offending line. Comments are now stripped before the quote scan, locked by a regression test. Fixed rather than reworded around, since it would bite the next person to write prose next to that key list.

## Verification

- Full suite green: **21,142 pass / 0 fail**; `typecheck`, `biome`, `lint:unicode`, `docs:check` all clean.
- **Mutation-proven** — reverting each of these turns a specific test red: the empty-BIS guard, the BIS-wins dedupe, the nullable `previousRate` passthrough, and the docs-stats comment strip.

## Note on gating

This inherits the Central Banks tab's existing default-on state. It is not opt-in in any meaningful sense — the alternative is hiding a single row behind a toggle nobody would find. The opt-in decision applies to the FX panel in #6199, which is where the 54-currency RUB table lives.

## Related

- #6154 / #6187 — ships the CBR data (merged).
- #6199 — the FX panel: we seed five FX datasets, render seven EUR rows in a commodities panel, and `economic:fx:yoy:v1` has no consumer at all.
- #6146 — the parent proposal.
