### PR TITLE
fix(railway): harden fleet drift fallback

### DIFF
--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -111,6 +111,7 @@ jobs:
         if: ${{ !cancelled() && steps.gate.conclusion != 'failure' }}
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
         run: |
           set -o pipefail
           # Pick up commits merged since the checkout so a service that already

--- a/scripts/railway-cli.mjs
+++ b/scripts/railway-cli.mjs
@@ -210,10 +210,10 @@ export function runRailwayApi(query, variables) {
  * made a sweep take ~7 minutes collapse to ~6 pages and ~16 seconds. That is
  * what makes running the reconciler often affordable.
  *
- * Returns `unresolved` for services the budget did not reach; the caller reads
- * those directly. This is an optimisation with a proven fallback, never a new
- * hard dependency — a project id we cannot determine, or a query that fails,
- * degrades to the per-service path rather than to a wrong answer.
+ * Returns `unresolved` for histories the stream did not prove complete; the
+ * caller reads those directly. This is an optimisation with a proven fallback,
+ * never a new hard dependency — a project id we cannot determine, or a query
+ * that fails, degrades to the per-service path rather than to a wrong answer.
  */
 export async function readFleetDeployments({
   projectId,
@@ -247,7 +247,19 @@ export async function readFleetDeployments({
     if (accumulator.done) break;
     after = connection.pageInfo.endCursor;
   }
-  return { ...accumulator.result(), pages, records };
+  const result = accumulator.result();
+  const complete = accumulator.done;
+  return {
+    ...result,
+    // Reaching the page cap without satisfying the stopping rule proves
+    // nothing about ANY service, including one that appeared with a RUNNING
+    // record. A later page may still contain its head/refusal record or a
+    // newer running record, so the caller must use the proven direct path for
+    // every partial history rather than silently accepting an incomplete one.
+    unresolved: complete ? result.unresolved : [...serviceIds],
+    pages,
+    records,
+  };
 }
 
 /**
@@ -285,15 +297,22 @@ export async function readDeploymentsForFleet({
         notBefore,
         accumulatorFactory,
       });
-      for (const [serviceId, deployments] of fleet.byService) {
-        if (fleet.unresolved.includes(serviceId)) continue;
-        // Trim to the SAME per-service window the direct read uses. The fleet
-        // stream is bounded globally, not per service, so a busy service can
-        // arrive with hundreds of records where `readDeployments` would have
-        // returned `window`. Leaving them in silently changes what the
-        // classifier sees — and every extra SKIPPED record costs a `git show`,
-        // which is what actually dominates a sweep's wall clock.
-        results.set(serviceId, { deployments: deployments.slice(0, window), error: null });
+      if (fleet.unresolved.length === byId.size) {
+        // A capped, non-exhausted stream leaves every history partial. Release
+        // those records before the direct fallback fan-out; none is safe to
+        // classify or worth retaining while the proven path reads them again.
+        fleet.byService.clear();
+      } else {
+        for (const [serviceId, deployments] of fleet.byService) {
+          if (fleet.unresolved.includes(serviceId)) continue;
+          // Trim to the SAME per-service window the direct read uses. The fleet
+          // stream is bounded globally, not per service, so a busy service can
+          // arrive with hundreds of records where `readDeployments` would have
+          // returned `window`. Leaving them in silently changes what the
+          // classifier sees — and every extra SKIPPED record costs a `git show`,
+          // which is what actually dominates a sweep's wall clock.
+          results.set(serviceId, { deployments: deployments.slice(0, window), error: null });
+        }
       }
       needDirect = fleet.unresolved.map((serviceId) => byId.get(serviceId)).filter(Boolean);
       onRoute({ route: 'fleet', pages: fleet.pages, records: fleet.records, fellBack: needDirect.length });

--- a/tests/railway-fleet-deployments.test.mjs
+++ b/tests/railway-fleet-deployments.test.mjs
@@ -122,14 +122,33 @@ describe('fleet paging', () => {
     assert.deepEqual(result.unresolved, []);
   });
 
-  it('honours the page cap and reports what it did not reach', async () => {
+  it('honours the page cap and falls back every partial history', async () => {
     const api = pager(Array.from({ length: 20 }, () => page([node('a', 'SUCCESS', '2026-08-04T11:00:00Z', 'aaa')], true)));
     const result = await readFleetDeployments({
       projectId: 'p', environmentId: 'e', serviceIds: ['a', 'b'], notBefore: HEAD_AT,
       maxPages: 3, api, accumulatorFactory: createFleetAccumulator,
     });
     assert.equal(result.pages, 3, 'must not page forever');
-    assert.deepEqual(result.unresolved, ['b'], 'the caller has to read b directly');
+    assert.deepEqual(result.unresolved, ['a', 'b'], 'the caller has to read every partial history directly');
+  });
+
+  it('treats a capped but non-exhausted stream as unresolved even when every service appeared', async () => {
+    const api = pager([
+      page([
+        node('a', 'SUCCESS', '2026-08-04T12:00:00Z', 'aaa'),
+        node('b', 'SUCCESS', '2026-08-04T12:00:00Z', 'bbb'),
+      ], true),
+    ]);
+    const result = await readFleetDeployments({
+      projectId: 'p', environmentId: 'e', serviceIds: ['a', 'b'],
+      notBefore: Date.parse('2026-08-04T11:00:00Z'),
+      maxPages: 1, api, accumulatorFactory: createFleetAccumulator,
+    });
+    assert.deepEqual(
+      result.unresolved,
+      ['a', 'b'],
+      'a capped stream is not proof that either service history is complete',
+    );
   });
 
   it('stops when the stream is exhausted', async () => {

--- a/tests/seed-freshness-workflow.test.mjs
+++ b/tests/seed-freshness-workflow.test.mjs
@@ -247,6 +247,7 @@ describe('seed freshness workflow control plane', () => {
 
     const drift = monitorSteps[driftIndex];
     assert.equal(drift.env.RAILWAY_TOKEN, '${{ secrets.RAILWAY_PRODUCTION_TOKEN }}');
+    assert.equal(drift.env.RAILWAY_PROJECT_ID, '${{ vars.RAILWAY_PROJECT_ID }}');
     assert.match(drift.run, /node scripts\/check-railway-deploy-drift\.mjs/);
     assert.match(
       drift.run,


### PR DESCRIPTION
## Summary

This follow-up makes the Railway freshness monitor use the same project-scoped fleet query as the deploy trigger, and prevents a capped GraphQL history stream from being treated as complete. A monitor run without the project ID previously fell back to the per-service fan-out; a stream that stopped at its page cap could silently skip direct reads for services it had only partially observed. Both paths now fail closed to the proven per-service history reader.

## Validation

- `node --test tests/railway-fleet-deployments.test.mjs tests/railway-deploy-trigger.test.mjs tests/railway-deploy-drift.test.mjs tests/seed-freshness-workflow.test.mjs tests/railway-deploy-trigger-workflow.test.mjs` — 118 passed.
- `npm run typecheck:all` — passed.
- `npm run lint` — passed; existing repository diagnostics only, with the safe-HTML guard passing.
- Repository pre-push hook — passed; changed-path tests, full/API typechecks, Unicode safety, and version checks all passed.
- `npm run test:data` — attempted; the sandboxed pre-push fixture cannot create `mktemp` files under macOS `/var/folders`, so the full suite could not complete in this environment.

## Related

Related: #6142, #6151

## Post-Deploy Monitoring & Validation

- On the first two scheduled `Seed Freshness Monitor` runs after deployment, inspect the `Check Railway deploy drift against main` log for `Read ... fleet page(s)` and confirm the route uses the project-scoped fleet query rather than recurring `no project/environment id available` or per-service fallback.
- Healthy signal: the monitor completes within its job budget with no `REJECTED_PUSH`, `BEHIND`, or `CLOSURE_UNKNOWN` results; direct fallback count is zero for a complete fleet stream and non-zero only when paging or query fallback is expected.
- Failure signal: repeated per-service fallback, monitor timeout, or new drift classifications. If observed, revert this PR and inspect the Railway project/environment variables and deployment query response.
- Owner/window: repository maintainers; monitor the first two scheduled runs after merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-GPT_5-000000)
