### PR TITLE
fix(seo): complete Dataset structured data

### DIFF
--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -37,6 +37,12 @@ const RESEARCH_REPORTS_INDEX_PATH = 'shared/research-reports/index.mjs';
 export const CORPUS_GENERATOR_CONTENT_VERSION = '2026-07-27';
 const COUNTRY_PAGE_CONTENT_VERSION = '2026-07-28';
 const CHOKEPOINT_PAGE_CONTENT_VERSION = '2026-07-28';
+const DATASET_SCHEMA_CONTENT_VERSION = '2026-08-05';
+const DATASET_LICENSE = {
+  '@type': 'CreativeWork',
+  name: 'World Monitor Terms of Service (27 July 2026)',
+  url: 'https://www.worldmonitor.app/docs/terms',
+};
 const CHANGELOG_PAGE_SIZE = 2;
 const MAX_TOOL_LATITUDE_SPAN = 45;
 const MAX_TOOL_LONGITUDE_SPAN = 60;
@@ -751,6 +757,7 @@ export async function loadCorpusData({ rootDir = DEFAULT_ROOT } = {}) {
     resilience.capturedAt,
     CORPUS_GENERATOR_CONTENT_VERSION,
     COUNTRY_PAGE_CONTENT_VERSION,
+    DATASET_SCHEMA_CONTENT_VERSION,
   );
   const changelogLastmod = laterDate(
     gitFileLastmod(rootDir, CHANGELOG_PATH),
@@ -773,6 +780,7 @@ export async function loadCorpusData({ rootDir = DEFAULT_ROOT } = {}) {
   const researchLastmod = laterDate(
     ...researchReports.map(({ report }) => report.dateModified),
     CORPUS_GENERATOR_CONTENT_VERSION,
+    DATASET_SCHEMA_CONTENT_VERSION,
   );
 
   return {
@@ -1063,6 +1071,12 @@ function renderCountryPage({
         '@type': 'Dataset',
         name: `World Monitor Country Resilience snapshot for ${country.name}`,
         description: `A dated World Monitor Country Resilience Index snapshot for ${country.name}, with the overall score, rank, dimension coverage, confidence classification, and scoring methodology used for this page.`,
+        creator: {
+          '@type': 'Organization',
+          name: 'World Monitor',
+          url: 'https://www.worldmonitor.app/',
+        },
+        license: DATASET_LICENSE,
         datePublished: capturedAt,
         measurementTechnique: methodologyFormula,
       },

--- a/scripts/build-research-reports.mjs
+++ b/scripts/build-research-reports.mjs
@@ -21,6 +21,12 @@ const UMAMI_SCRIPT_TAG =
   + 'data-domains="worldmonitor.app,www.worldmonitor.app,happy.worldmonitor.app" '
   + 'nonce="wm-static-bootstrap"></script>';
 
+const DATASET_LICENSE = {
+  '@type': 'CreativeWork',
+  name: 'World Monitor Terms of Service (27 July 2026)',
+  url: 'https://www.worldmonitor.app/docs/terms',
+};
+
 const CHART_WIDTH = 720;
 const LINE_CHART_HEIGHT = 260;
 const BAR_CHART_HEIGHT = 240;
@@ -864,6 +870,8 @@ ${justification}
       name: `Strait of Hormuz daily transit calls, ${focus.observationStart} to ${focus.observationEnd}`,
       description:
         'Daily AIS-observed vessel transit calls by class with deadweight-tonnage aggregates, from IMF PortWatch, frozen in a versioned snapshot.',
+      creator: { '@type': 'Organization', name: report.author.name, url: report.author.url },
+      license: DATASET_LICENSE,
       temporalCoverage: `${focus.observationStart}/${focus.observationEnd}`,
       isBasedOn: 'https://portwatch.imf.org/',
       distribution: [

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -46,7 +46,16 @@ function collectDatasets(value, datasets = []) {
   return datasets;
 }
 
-function assertDatasetDescriptions(html, route, { requireDataset = false } = {}) {
+function isAbsoluteHttpUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function assertDatasetGoogleProperties(html, route, { requireDataset = false } = {}) {
   const datasets = jsonLdObjects(html).flatMap((entry) => collectDatasets(entry));
   if (requireDataset) {
     assert.ok(datasets.length > 0, `${route} must contain a Dataset JSON-LD object`);
@@ -61,6 +70,31 @@ function assertDatasetDescriptions(html, route, { requireDataset = false } = {})
     assert.ok(
       description.length <= DATASET_DESCRIPTION_MAX_LENGTH,
       `${route} Dataset ${index + 1} description must be at most ${DATASET_DESCRIPTION_MAX_LENGTH} characters`,
+    );
+
+    const creators = Array.isArray(dataset.creator) ? dataset.creator : [dataset.creator];
+    assert.ok(
+      creators.some((creator) => (
+        creator
+        && (creator['@type'] === 'Person' || creator['@type'] === 'Organization')
+        && typeof creator.name === 'string'
+        && creator.name.trim().length > 0
+      )),
+      `${route} Dataset ${index + 1} must identify a Person or Organization creator`,
+    );
+
+    const licenses = Array.isArray(dataset.license) ? dataset.license : [dataset.license];
+    assert.ok(
+      licenses.some((license) => (
+        isAbsoluteHttpUrl(license)
+        || (
+          license?.['@type'] === 'CreativeWork'
+          && typeof license.name === 'string'
+          && license.name.trim().length > 0
+          && isAbsoluteHttpUrl(license.url)
+        )
+      )),
+      `${route} Dataset ${index + 1} must link to a specific license URL`,
     );
   }
 
@@ -266,10 +300,11 @@ describe('crawlable corpus generator', () => {
         descriptions.set(description, route);
       }
 
-      // Google requires Dataset descriptions to be 50-5000 characters. Walk
-      // every generated JSON-LD object recursively so this catches both the
-      // country snapshot Dataset and nested datasets such as research report
-      // distributions, not only one representative page.
+      // Google requires Dataset descriptions to be 50-5000 characters and
+      // recommends creator and license. Walk every generated JSON-LD object
+      // recursively so this catches both the country snapshot Dataset and
+      // nested datasets such as research report distributions, not only one
+      // representative page.
       const generatedRoutes = new Set(
         Object.values(manifest.sections)
           .filter((section) => !section.generatedBy)
@@ -281,7 +316,7 @@ describe('crawlable corpus generator', () => {
         ...manifest.sections.research.routes,
       ]);
       for (const route of generatedRoutes) {
-        assertDatasetDescriptions(
+        assertDatasetGoogleProperties(
           read(outDir, `${route.slice(1)}index.html`),
           route,
           { requireDataset: datasetRequiredRoutes.has(route) },
@@ -313,7 +348,7 @@ describe('crawlable corpus generator', () => {
       const norway = read(outDir, 'countries/norway/index.html');
       assert.match(norway, /<h1>Norway country risk and resilience<\/h1>/);
       assert.match(norway, /<link rel="canonical" href="https:\/\/www\.worldmonitor\.app\/countries\/norway\/">/);
-      assert.match(norway, /<meta name="lastmod" content="2026-07-28">/);
+      assert.match(norway, /<meta name="lastmod" content="2026-08-05">/);
       assert.match(norway, /Source: docs\/snapshots\/resilience-ranking-2026-05-28\.json/);
       assert.doesNotMatch(norway, /id="app"/, 'country page must be raw static HTML, not the SPA shell');
       assert.match(norway, /data-live-country-risk data-country-code="NO" data-country-name="Norway"/);
@@ -449,7 +484,8 @@ describe('crawlable corpus generator', () => {
     assert.equal(data.sources.countryBboxes, 'shared/country-bboxes.js');
     assert.equal(data.sources.crisisRegistry, 'shared/crawlable-crises.json');
     assert.equal(data.resilience.capturedAt, '2026-05-28');
-    assert.equal(data.lastmod.countries, '2026-07-28');
+    assert.equal(data.lastmod.countries, '2026-08-05');
+    assert.equal(data.lastmod.research, '2026-08-05');
     assert.equal(data.crises.length, 4);
     assert.ok(data.crises.some((crisis) => crisis.slug === 'ukraine-war' && crisis.coverage.some((country) => country.code === 'UA')));
     assert.ok(data.countryBounds.some((country) => country.code === 'JP' && country.bounds[0] === 31.11));

--- a/tests/research-report-corpus.test.mjs
+++ b/tests/research-report-corpus.test.mjs
@@ -92,7 +92,7 @@ describe('research report corpus (#5668)', () => {
       focus.observationEnd <= String(snapshot.capturedAt).slice(0, 10),
       'observation period must end on or before the retrieval date',
     );
-    assert.match(html, new RegExp(`<meta name="lastmod" content="${report.dateModified}">`));
+    assert.match(html, /<meta name="lastmod" content="2026-08-05">/);
     assert.match(
       html,
       new RegExp(`published <time datetime="${report.datePublished}">`),


### PR DESCRIPTION
## Summary

- add an Organization creator and dated custom-license metadata to every generated Dataset
- preserve Google's required 50-5000 character descriptions and validate creator/license recursively across country and research pages
- advance only Dataset-bearing page families' lastmod to 2026-08-05 so crawlers receive a truthful recrawl signal

## Context

Search Console exported 50 example country URLs and charted 56 affected items. The required description field from #5941 is already live; this follow-up addresses the remaining recommended creator and license warnings without mislabeling hosted data as AGPL-licensed source code.

## Validation

- node --import tsx --test tests/crawlable-corpus.test.mjs (4/4 passed)
- node --import tsx --test tests/research-report-corpus.test.mjs (12/12 passed)
- full pre-push gate: frontend/API typechecks, 16 focused tests, Unicode, version, and repository guardrails passed