### PR TITLE
fix(railway): reconcile on Deploy Gate completion and alarm on a silent fleet (#6203)

### DIFF
--- a/.github/workflows/railway-deploy-trigger.yml
+++ b/.github/workflows/railway-deploy-trigger.yml
@@ -35,16 +35,22 @@ on:
   # Seed Freshness Monitor landing every 25-50 minutes. A 5-minute cron is not
   # a cadence this repository has.
   #
-  # `branches: [main]` filters on the TRIGGERING run's branch, so every PR's
-  # Deploy Gate run is excluded and only main's reaches here. Deploy Gate's own
-  # 30-minute sweep runs carry the default branch, which makes them a second
-  # backstop for free.
+  # `branches: [main]` is NOT a PR filter here, and must not be read as one.
+  # Deploy Gate is itself `workflow_run`-triggered, and GitHub stamps such a run
+  # with the DEFAULT branch rather than the branch that triggered it — measured
+  # 2026-08-05, 40 of 40 recent Deploy Gate runs carry head_branch=main and
+  # head_sha = main's head, including ones triggered by PR Test runs. (That is
+  # exactly why deploy-gate.yml reads `github.event.workflow_run.head_sha`
+  # instead of `github.sha`.) So this fires on roughly every gate evaluation in
+  # the repository, PRs included — about 33/hour measured over 72 minutes.
   #
-  # A fork PR whose branch happens to be named `main` also passes that filter.
-  # It is harmless and needs no extra guard: nothing below reads the event. The
-  # job resolves its own `git rev-parse origin/main` and refuses to deploy
-  # unless THAT commit carries a green `gate`, so the worst a fork can cause is
-  # one extra idempotent reconcile of the real main.
+  # That is safe rather than merely tolerable, for two independent reasons:
+  # nothing below reads the event at all — the job resolves its own
+  # `git rev-parse origin/main` and refuses to deploy unless THAT commit carries
+  # a green `gate` — and the concurrency group cancels the pending member on
+  # each new arrival, so the executing rate is bounded by one run's duration,
+  # not by the arrival rate. The extra wakeups cost a checkout and exit at the
+  # gate step.
   #
   # Chain depth is Test -> Deploy Gate -> here. GitHub refuses to chain
   # workflow_run more than three levels deep, so this is the last link
@@ -251,10 +257,15 @@ jobs:
           # red their preview for it.
           WARN_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.dryRun }}
         run: |
-          # Two explicit arms rather than an interpolated flag: a `${{ }}`
-          # ternary spliced into the command line has to agree with the env var
-          # above forever, and the day they diverge the arm that still runs is
-          # the one that stays quiet.
+          # Two explicit arms rather than an interpolated flag. A GitHub
+          # expression ternary spliced into the command line would have to agree
+          # with the env var above forever, and the day they diverge the arm
+          # that still runs is the one that stays quiet.
+          #
+          # NOTE: never write a literal GitHub expression opener inside a `run:`
+          # block, even in a comment. The expression parser scans the whole
+          # block scalar, so an empty one fails the WORKFLOW to parse — which
+          # publishes no check run, leaves the PR green, and stops every trigger.
           if [ "${WARN_ONLY:-false}" = "true" ]; then
             node scripts/check-railway-reconcile-age.mjs --warn-only
           else
@@ -281,11 +292,22 @@ jobs:
               ;;
             failure)
               summary="**Reconcile FAILED** against \`$short\` — services named in the log above stayed behind."
+              # The deploy step reds the run, but it emits per-service errors;
+              # nothing otherwise states the run-level outcome in the summary.
+              echo "::error::Reconcile FAILED for ${short}. Services named above stayed behind."
               ;;
             *)
               if [ "$PREVIEW_OUTCOME" = "success" ]; then
                 summary="Previewed \`$short\` only; this run deployed nothing by request."
                 echo "::notice::$summary"
+              elif [ "$GATE" = "success" ]; then
+                # The gate was GREEN and the deploy still did not run, so an
+                # earlier step stopped it — an expired RAILWAY_PRODUCTION_TOKEN,
+                # a missing RAILWAY_PROJECT_ID, Railway unreachable. Calling
+                # that "declined" would file an infrastructure failure under the
+                # benign no-op label this step exists to separate out.
+                summary="**Reconcile did not run** for \`$short\` even though its gate was green — a step before the deploy failed (Railway credentials or API). This is not a routine decline."
+                echo "::error::Reconcile did not run for ${short} despite gate=success; a prerequisite step failed."
               else
                 summary="**Declined to reconcile.** main's head \`$short\` has gate=\`$GATE\`, so no service was deployed by this run."
                 # A warning, not a notice: this is the outcome that used to be

--- a/.github/workflows/railway-deploy-trigger.yml
+++ b/.github/workflows/railway-deploy-trigger.yml
@@ -24,15 +24,51 @@ name: Railway Deploy Trigger
 # none of which a push-shaped trigger recovers from.
 
 on:
+  # THE PRIMARY CADENCE (#6203). Deploy Gate completing on main is the moment
+  # the `gate` status this workflow reads has just been written, so reconciling
+  # here is both immediate and immune to schedule throttling.
+  #
+  # It replaces a 5-minute cron that did not fire. Measured over the 2h03m
+  # after e2db6b6a9 merged, this workflow produced ONE scheduled run against
+  # ~24 expected ticks — GitHub documents `schedule` as best-effort and drops
+  # high-frequency crons under load, and the same window shows the 15-minute
+  # Seed Freshness Monitor landing every 25-50 minutes. A 5-minute cron is not
+  # a cadence this repository has.
+  #
+  # `branches: [main]` filters on the TRIGGERING run's branch, so every PR's
+  # Deploy Gate run is excluded and only main's reaches here. Deploy Gate's own
+  # 30-minute sweep runs carry the default branch, which makes them a second
+  # backstop for free.
+  #
+  # A fork PR whose branch happens to be named `main` also passes that filter.
+  # It is harmless and needs no extra guard: nothing below reads the event. The
+  # job resolves its own `git rev-parse origin/main` and refuses to deploy
+  # unless THAT commit carries a green `gate`, so the worst a fork can cause is
+  # one extra idempotent reconcile of the real main.
+  #
+  # Chain depth is Test -> Deploy Gate -> here. GitHub refuses to chain
+  # workflow_run more than three levels deep, so this is the last link
+  # available: nothing may be triggered off THIS workflow's completion.
+  #
+  # Deliberately NOT filtered on the Deploy Gate run's own conclusion. That
+  # conclusion says whether the gate job executed, not what verdict it posted,
+  # and this workflow re-reads the `gate` status itself in the first step. A
+  # conclusion filter would only add a way to miss a reconcile.
+  workflow_run:
+    workflows: ["Deploy Gate"]
+    types: [completed]
+    branches: [main]
   schedule:
-    # Every 5 minutes, offset from the Seed Freshness Monitor's :00/:15/:30/:45.
+    # BACKSTOP ONLY, and slow on purpose. The event above is what reconciles;
+    # this covers the one failure it cannot self-heal — a webhook/event-delivery
+    # outage (#6064). Asking for it more often re-orders the same tick GitHub
+    # already proved it drops, and would re-establish the burst the concurrency
+    # group below exists to collapse.
     #
-    # This cadence is what the fleet-wide deployment query bought. A sweep used
-    # to cost 79 Railway API calls; it now costs 9, so running 3x more often
-    # still lands at roughly a third of the old load — and the interval IS the
-    # worst-case lag for the cohort Railway defers on a red check suite, which
-    # is the whole reason this workflow exists.
-    - cron: '2,7,12,17,22,27,32,37,42,47,52,57 * * * *'
+    # :37 is clear of the Seed Freshness Monitor's :00/:15/:30/:45 — both fan
+    # out across the whole fleet and sharing a minute is how one starts getting
+    # rate limited.
+    - cron: '37 * * * *'
   workflow_dispatch:
     inputs:
       dryRun:
@@ -44,6 +80,13 @@ on:
 # sweep leaves half the fleet triggered with no record of where it stopped. A
 # superseding run would re-derive the same plan anyway, so queueing costs
 # nothing but interrupting costs a partial deploy.
+#
+# This is also what makes the event trigger above safe to fire often. A merge
+# completes four Deploy Gate runs (Test, Typecheck, Lint Code, Security Audit
+# each trigger one), and GitHub cancels the previously PENDING member of a
+# concurrency group when a new run queues — so a burst collapses to one running
+# plus one queued reconcile rather than a backlog. The reconciler is idempotent,
+# so the collapsed runs cost nothing.
 concurrency:
   group: railway-deploy-trigger
   cancel-in-progress: false
@@ -51,6 +94,9 @@ concurrency:
 permissions:
   contents: read
   statuses: read
+  # Reads this workflow's OWN run history, which is the only record of whether
+  # a run reconciled or declined (#6203).
+  actions: read
 
 jobs:
   trigger:
@@ -162,6 +208,7 @@ jobs:
       # the fleet is falling behind — which is exactly when the gate is not
       # green and the deploy step below is correctly refusing to run.
       - name: Preview what would be deployed
+        id: preview
         if: github.event_name == 'workflow_dispatch' && inputs.dryRun
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
@@ -173,6 +220,7 @@ jobs:
       # returned no deployment id all mean services stayed behind while this
       # workflow reported that it had handled them.
       - name: Trigger deploys for services this merge changed
+        id: deploy
         if: steps.head.outputs.gate == 'success' && !(github.event_name == 'workflow_dispatch' && inputs.dryRun)
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_TOKEN }}
@@ -180,3 +228,71 @@ jobs:
           # so `railway status` must be told which project to answer for.
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
         run: node scripts/trigger-railway-deploys.mjs --head "${{ steps.head.outputs.sha }}"
+
+      # Deliberately AFTER the deploy and `always()`: this is a diagnostic about
+      # the workflow's own health, and running it first would let a GitHub API
+      # hiccup stop the reconcile it exists to protect. `always()` is what makes
+      # it fire on the runs that matter — the ones that declined and did nothing.
+      #
+      # This is the check that does not depend on WHY. The gate escalation above
+      # only fires on a pending gate and only when this workflow runs, which is
+      # the precondition that failed in #6203.
+      - name: Check how long the fleet has gone un-reconciled
+        if: always()
+        # Bounded well under the job budget. The scan stops at the first run
+        # that reconciled, so the healthy path is two API calls — but the
+        # pathological "nothing in the last 30 runs" path is 30 of them, and
+        # this must surface as its own alarm rather than as the job hitting
+        # timeout-minutes with the reason buried.
+        timeout-minutes: 3
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # A dry run is an operator diagnosing; report the staleness but do not
+          # red their preview for it.
+          WARN_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.dryRun }}
+        run: |
+          # Two explicit arms rather than an interpolated flag: a `${{ }}`
+          # ternary spliced into the command line has to agree with the env var
+          # above forever, and the day they diverge the arm that still runs is
+          # the one that stays quiet.
+          if [ "${WARN_ONLY:-false}" = "true" ]; then
+            node scripts/check-railway-reconcile-age.mjs --warn-only
+          else
+            node scripts/check-railway-reconcile-age.mjs
+          fi
+
+      # "Reconciled the fleet" and "skipped every step that does work" are both
+      # `success` at the workflow-status level, which is how the fleet sat
+      # stranded behind a green badge for 19.5h (#6203). Write the difference
+      # somewhere a human reads without opening the raw log.
+      - name: Report what this run did
+        if: always()
+        env:
+          GATE: ${{ steps.head.outputs.gate }}
+          HEAD_SHA: ${{ steps.head.outputs.sha }}
+          DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
+          PREVIEW_OUTCOME: ${{ steps.preview.outcome }}
+        run: |
+          short="${HEAD_SHA:0:9}"
+          case "$DEPLOY_OUTCOME" in
+            success)
+              summary="Reconciled the fleet against \`$short\` (gate=$GATE)."
+              echo "::notice::$summary"
+              ;;
+            failure)
+              summary="**Reconcile FAILED** against \`$short\` — services named in the log above stayed behind."
+              ;;
+            *)
+              if [ "$PREVIEW_OUTCOME" = "success" ]; then
+                summary="Previewed \`$short\` only; this run deployed nothing by request."
+                echo "::notice::$summary"
+              else
+                summary="**Declined to reconcile.** main's head \`$short\` has gate=\`$GATE\`, so no service was deployed by this run."
+                # A warning, not a notice: this is the outcome that used to be
+                # indistinguishable from a successful sweep.
+                echo "::warning::Declined to reconcile ${short}: gate=$GATE. No service was deployed by this run."
+              fi
+              ;;
+          esac
+          echo "### Railway deploy trigger" >> "$GITHUB_STEP_SUMMARY"
+          echo "$summary" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/railway-deploy-trigger.yml
+++ b/.github/workflows/railway-deploy-trigger.yml
@@ -244,12 +244,27 @@ jobs:
       # only fires on a pending gate and only when this workflow runs, which is
       # the precondition that failed in #6203.
       - name: Check how long the fleet has gone un-reconciled
-        if: always()
+        # NOT plain `always()`. The scan reads COMPLETED runs and excludes this
+        # one, so a run whose own deploy just succeeded cannot see the reconcile
+        # it performed seconds earlier. After a drought longer than the
+        # threshold — the exact recovery this workflow exists for — the run that
+        # FIXED the fleet would report it stale and go red.
+        #
+        # That is not merely a confusing badge. This workflow's runs carry a
+        # main commit as head_sha, so a red one lands in that commit's check
+        # suite, which is the `CI check suite failed` reason Railway uses to
+        # defer every service. The alarm would trigger the outage it detects.
+        #
+        # A successful deploy IS the freshest possible answer, so skip the
+        # history question entirely when we already have it.
+        id: age
+        if: always() && steps.deploy.outcome != 'success'
         # Bounded well under the job budget. The scan stops at the first run
-        # that reconciled, so the healthy path is two API calls — but the
-        # pathological "nothing in the last 30 runs" path is 30 of them, and
-        # this must surface as its own alarm rather than as the job hitting
-        # timeout-minutes with the reason buried.
+        # that reconciled, so the healthy path is two API calls — but a window
+        # in which NOTHING reconciled costs one call per run in it, and at this
+        # workflow's wake rate that is a three-figure number. It must surface as
+        # its own alarm rather than as the job hitting timeout-minutes with the
+        # reason buried.
         timeout-minutes: 3
         env:
           GH_TOKEN: ${{ github.token }}
@@ -283,6 +298,7 @@ jobs:
           HEAD_SHA: ${{ steps.head.outputs.sha }}
           DEPLOY_OUTCOME: ${{ steps.deploy.outcome }}
           PREVIEW_OUTCOME: ${{ steps.preview.outcome }}
+          AGE_OUTCOME: ${{ steps.age.outcome }}
         run: |
           short="${HEAD_SHA:0:9}"
           case "$DEPLOY_OUTCOME" in
@@ -318,3 +334,10 @@ jobs:
           esac
           echo "### Railway deploy trigger" >> "$GITHUB_STEP_SUMMARY"
           echo "$summary" >> "$GITHUB_STEP_SUMMARY"
+          # A failed age check reds the job. Without this line the summary could
+          # read as an ordinary decline while the run is red for a second,
+          # louder reason — the fleet has not been reconciled at all.
+          if [ "$AGE_OUTCOME" = "failure" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "**The fleet has also gone un-reconciled past the backstop tolerance** — see the age check above." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
+++ b/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
@@ -216,6 +216,33 @@ running commit makes the run idempotent, removes any dependence on
 or a manual `railway up` recovery — none of which a push-shaped trigger
 recovers from.
 
+**What wakes it (#6203).** `workflow_run` on **Deploy Gate** completing against
+`main`, plus an hourly cron as the backstop. It originally ran on a 5-minute
+cron alone, and that cadence does not exist on this repository: measured over
+the 2h03m after `e2db6b6a9` merged, the workflow produced **one** scheduled run
+against ~24 expected ticks, while the fleet sat 19.5h behind. GitHub documents
+`schedule` as best-effort and drops high-frequency crons under load — the
+15-minute Seed Freshness Monitor was landing every 25–50 minutes in the same
+window. Deploy Gate completing is both immediate and immune to that throttling,
+and it fires exactly when the `gate` status this workflow reads has just been
+written. The cron survives only the case an event cannot: an event-delivery
+outage (#6064).
+
+The chain is `Test` → `Deploy Gate` → `Railway Deploy Trigger`. GitHub refuses
+to chain `workflow_run` more than three levels deep, so **nothing may be
+triggered off this workflow's completion** — that link is spent.
+
+**Why a no-op run is now loud.** "Reconciled the fleet" and "declined and
+skipped every step that does work" are both `success` at the workflow-status
+level, which is how the fleet stayed stranded behind a green badge. Two things
+separate them now: a job-summary line plus a `::warning::` annotation on every
+declined run, and `scripts/check-railway-reconcile-age.mjs`, which reads this
+workflow's own run history and reds the run when nothing has actually
+reconciled for longer than the backstop tolerates. A run "reconciled" iff its
+deploying step's conclusion is `success`; every unreadable, missing or
+truncated case resolves away from healthy, because the unmatched case meaning
+HEALTHY is the defect itself.
+
 Two things it deliberately does not do:
 
 - It does not re-trigger a build Railway already ran and **failed**. That is a

--- a/scripts/check-railway-reconcile-age.mjs
+++ b/scripts/check-railway-reconcile-age.mjs
@@ -180,7 +180,14 @@ export function toCreatedFilter(instantMs) {
   return `${new Date(instantMs).toISOString().replace(/\.\d{3}Z$/, 'Z')}`;
 }
 
-function readRunsSince({ repository, workflowFile, sinceMs, excludeRunId }) {
+/**
+ * Completed runs of this workflow created inside the window, newest first.
+ *
+ * `gh` is injected rather than imported so the I/O path is testable — this is
+ * the seam the current-run exclusion lives on, and getting that wrong is how a
+ * run reds itself.
+ */
+export function readRunsSince({ gh, repository, workflowFile, sinceMs, excludeRunId }) {
   // `created:>=` is what makes the negative answer decidable: the returned set
   // IS the window, so "none of these reconciled" means the fleet went
   // un-reconciled for the whole window rather than "the page ran out".
@@ -189,7 +196,7 @@ function readRunsSince({ repository, workflowFile, sinceMs, excludeRunId }) {
     `created=%3E%3D${encodeURIComponent(toCreatedFilter(sinceMs))}`,
     `per_page=${RUN_PAGE_SIZE}`,
   ].join('&');
-  const payload = JSON.parse(runGh([
+  const payload = JSON.parse(gh([
     'api', '--paginate', '--slurp',
     `repos/${repository}/actions/workflows/${workflowFile}/runs?${query}`,
   ]));
@@ -205,8 +212,32 @@ function readRunsSince({ repository, workflowFile, sinceMs, excludeRunId }) {
     runs.push(...page.workflow_runs);
   }
   return runs
+    // The CURRENT run is excluded twice over — `status=completed` cannot return
+    // a run that is still executing, and this drops it by id as well. That is
+    // deliberate and it is why the workflow must not ask this question on a run
+    // whose own deploy just succeeded: such a run cannot see itself, so after a
+    // drought it would report the fleet stale seconds after fixing it.
     .filter((run) => String(run?.id) !== String(excludeRunId))
     .map((run) => ({ id: run?.id ?? null, completedAt: run?.updated_at ?? null }));
+}
+
+/**
+ * The window, with each run resolved to whether it reconciled.
+ *
+ * Newest-first, stopping at the first run that reconciled: everything older
+ * cannot change the answer, so the healthy case costs one extra call rather
+ * than one per run in the window.
+ */
+export function collectReconcileWindow({ gh, repository, workflowFile, sinceMs, excludeRunId }) {
+  const candidates = readRunsSince({ gh, repository, workflowFile, sinceMs, excludeRunId });
+  const inspected = [];
+  for (const candidate of candidates) {
+    const jobs = JSON.parse(gh(['api', `repos/${repository}/actions/runs/${candidate.id}/jobs`]));
+    const reconciled = readRunReconciled(jobs);
+    inspected.push({ ...candidate, reconciled });
+    if (reconciled) break;
+  }
+  return inspected;
 }
 
 async function main() {
@@ -224,23 +255,13 @@ async function main() {
 
   const now = Date.now();
   const maxAgeMs = maxAgeHours * 60 * 60 * 1000;
-  const candidates = readRunsSince({
+  const inspected = collectReconcileWindow({
+    gh: runGh,
     repository,
     workflowFile,
     sinceMs: now - maxAgeMs,
     excludeRunId: process.env.GITHUB_RUN_ID ?? null,
   });
-
-  // Newest-first, stopping at the first run that reconciled: everything older
-  // than it cannot change the answer, so the healthy case costs one extra API
-  // call rather than one per run in the window.
-  const inspected = [];
-  for (const candidate of candidates) {
-    const jobs = JSON.parse(runGh(['api', `repos/${repository}/actions/runs/${candidate.id}/jobs`]));
-    const reconciled = readRunReconciled(jobs);
-    inspected.push({ ...candidate, reconciled });
-    if (reconciled) break;
-  }
 
   const summary = summarizeReconcileHistory(inspected, { now, maxAgeMs });
   const message = describeReconcileSummary(summary);

--- a/scripts/check-railway-reconcile-age.mjs
+++ b/scripts/check-railway-reconcile-age.mjs
@@ -54,11 +54,21 @@ export const DEFAULT_WORKFLOW_FILE = 'railway-deploy-trigger.yml';
 // working, which is exactly the state that stranded the fleet for 19.5h.
 export const DEFAULT_MAX_RECONCILE_AGE_MS = 3 * 60 * 60 * 1000;
 
-// Deep enough that the "we looked far enough back to conclude" branch can
-// actually be reached: at the hourly backstop alone this window spans well
-// over a day, so a fleet that has not reconciled in three hours is inside it
-// many times over.
-export const DEFAULT_RUN_LIMIT = 30;
+// The listing is bounded by TIME, never by a run count.
+//
+// A count was the original design and it was unusable: this workflow is woken
+// by every Deploy Gate evaluation in the repository — measured at ~33/hour —
+// so the newest 30 runs span under an hour and can never reach back past a
+// three-hour threshold. STALE became unreachable and the alarm degraded to a
+// permanent shrug. A count cannot be raised out of the problem either, because
+// the API caps per_page at 100 and 100 runs is still only ~3h at that rate.
+//
+// With a `created:>=` filter the window spans the threshold BY CONSTRUCTION,
+// which also collapses the old three-state result into two: if no run inside
+// the window reconciled, that IS the alarm — including the case where the
+// workflow did not run at all, which is precisely the #6203 failure and the
+// one a count-based window reported as "cannot tell".
+export const RUN_PAGE_SIZE = 100;
 
 function parseTimestamp(value) {
   if (typeof value !== 'string') return null;
@@ -91,51 +101,43 @@ export function readRunReconciled(jobsPayload) {
 }
 
 /**
- * Summarise "when did the fleet last get reconciled" from this workflow's runs.
+ * Summarise "did anything reconcile the fleet inside the window".
  *
- * `runs` is newest-first, and must be the runs that were actually INSPECTED —
- * callers may stop as soon as they find a reconciled one, because everything
- * older than it cannot change the answer. Passing a truncated tail instead
- * would make the "nothing reconciled" branch below reason about a window it
- * never looked at.
+ * `runs` MUST be every completed run created within `maxAgeMs` of `now` — the
+ * caller guarantees that with a `created:>=` API filter, which is what makes
+ * the negative answer decidable. Given that guarantee there are only two
+ * outcomes, and the absence of evidence is the alarm rather than a shrug:
  *
- * Returns one of three states, and `UNKNOWN` is never a pass:
- *
- *   RECENT  — a run reconciled within `maxAgeMs`.
- *   STALE   — a run reconciled longer ago than that, OR nothing reconciled
- *             across a window that itself reaches back past `maxAgeMs`.
- *   UNKNOWN — nothing reconciled and the window is too short to conclude.
+ *   RECENT — some run in the window reconciled.
+ *   STALE  — none did. That includes the window being EMPTY, which is the
+ *            #6203 failure itself: the workflow never ran.
  */
 export function summarizeReconcileHistory(runs, { now, maxAgeMs = DEFAULT_MAX_RECONCILE_AGE_MS } = {}) {
   if (!Number.isFinite(now)) throw new TypeError('summarizeReconcileHistory requires a numeric now');
   const inspected = Array.isArray(runs) ? runs : [];
-  const timestamps = [];
 
   for (const run of inspected) {
-    const completedAt = parseTimestamp(run?.completedAt);
-    if (completedAt === null) continue;
-    timestamps.push(completedAt);
     if (run?.reconciled !== true) continue;
-    // Runner and API clocks disagree by seconds. A future-dated run must read
-    // as "just now", not as a negative age that prints as -0h.
-    const ageMs = Math.max(0, now - completedAt);
+    const completedAt = parseTimestamp(run?.completedAt);
+    // A reconciled run whose timestamp is unreadable still proves a reconcile
+    // happened inside the window — the window is the caller's guarantee, not
+    // this field's. Report it without an age rather than discarding the proof.
+    const ageMs = completedAt === null
+      // Runner and API clocks disagree by seconds; a future-dated run must read
+      // as "just now", not as a negative age that prints as -0h.
+      ? null : Math.max(0, now - completedAt);
     return {
-      state: ageMs > maxAgeMs ? 'STALE' : 'RECENT',
+      state: 'RECENT',
       ageMs,
-      lastReconciledAt: new Date(completedAt).toISOString(),
+      lastReconciledAt: completedAt === null ? null : new Date(completedAt).toISOString(),
       runId: run.id ?? null,
       inspected: inspected.length,
       maxAgeMs,
     };
   }
 
-  const oldest = timestamps.length > 0 ? Math.min(...timestamps) : null;
-  // Only claim staleness once the window we looked at genuinely spans the
-  // threshold. Short of that we have not disproved a reconcile, we have just
-  // run out of history — which is a different sentence and a different action.
-  const reachesPastThreshold = oldest !== null && now - oldest > maxAgeMs;
   return {
-    state: reachesPastThreshold ? 'STALE' : 'UNKNOWN',
+    state: 'STALE',
     ageMs: null,
     lastReconciledAt: null,
     runId: null,
@@ -148,15 +150,13 @@ export function summarizeReconcileHistory(runs, { now, maxAgeMs = DEFAULT_MAX_RE
 export function describeReconcileSummary(summary) {
   const hours = (ms) => (ms / (60 * 60 * 1000)).toFixed(1);
   if (summary.state === 'RECENT') {
-    return `Fleet last reconciled ${hours(summary.ageMs)}h ago (run ${summary.runId}).`;
+    return summary.ageMs === null
+      ? `Fleet reconciled inside the last ${hours(summary.maxAgeMs)}h (run ${summary.runId}).`
+      : `Fleet last reconciled ${hours(summary.ageMs)}h ago (run ${summary.runId}).`;
   }
-  if (summary.state === 'UNKNOWN') {
-    return `Cannot tell when the fleet was last reconciled: none of the ${summary.inspected} run(s) inspected reconciled, and that window does not reach back ${hours(summary.maxAgeMs)}h.`;
-  }
-  if (summary.lastReconciledAt === null) {
-    return `The fleet has not been reconciled by any of the last ${summary.inspected} runs, a window reaching back past ${hours(summary.maxAgeMs)}h. Neither the Deploy Gate event nor the hourly backstop is reconciling.`;
-  }
-  return `The fleet has not been reconciled for ${hours(summary.ageMs)}h (last run ${summary.runId}), past the ${hours(summary.maxAgeMs)}h backstop tolerance.`;
+  return summary.inspected === 0
+    ? `The fleet has not been reconciled in ${hours(summary.maxAgeMs)}h: this workflow produced NO completed run in that window at all. Neither the Deploy Gate event nor the hourly backstop is firing.`
+    : `The fleet has not been reconciled in ${hours(summary.maxAgeMs)}h. ${summary.inspected} run(s) completed in that window and none of them deployed.`;
 }
 
 const GH_CALL_TIMEOUT_MS = 30_000;
@@ -175,16 +175,34 @@ function runGh(args) {
   return result.stdout;
 }
 
-function readCompletedRuns({ repository, workflowFile, limit, excludeRunId }) {
+/** ISO-8601 to the second, which is the granularity the `created` filter takes. */
+export function toCreatedFilter(instantMs) {
+  return `${new Date(instantMs).toISOString().replace(/\.\d{3}Z$/, 'Z')}`;
+}
+
+function readRunsSince({ repository, workflowFile, sinceMs, excludeRunId }) {
+  // `created:>=` is what makes the negative answer decidable: the returned set
+  // IS the window, so "none of these reconciled" means the fleet went
+  // un-reconciled for the whole window rather than "the page ran out".
+  const query = [
+    'status=completed',
+    `created=%3E%3D${encodeURIComponent(toCreatedFilter(sinceMs))}`,
+    `per_page=${RUN_PAGE_SIZE}`,
+  ].join('&');
   const payload = JSON.parse(runGh([
-    'api',
-    `repos/${repository}/actions/workflows/${workflowFile}/runs?status=completed&per_page=${limit}`,
+    'api', '--paginate', '--slurp',
+    `repos/${repository}/actions/workflows/${workflowFile}/runs?${query}`,
   ]));
-  const runs = payload?.workflow_runs;
-  // An unreadable listing must not be summarised as an empty history: empty
-  // reads as UNKNOWN, which is quiet, and this is a hard failure.
-  if (!Array.isArray(runs)) {
-    throw new Error(`the run listing for ${workflowFile} was not an array of workflow runs`);
+  // --slurp wraps paginated responses in an array of pages.
+  const pages = Array.isArray(payload) ? payload : [payload];
+  const runs = [];
+  for (const page of pages) {
+    // An unreadable listing must never be summarised as an empty window: empty
+    // now means STALE, which is loud, but it would be loud for a false reason.
+    if (!Array.isArray(page?.workflow_runs)) {
+      throw new Error(`the run listing for ${workflowFile} was not an array of workflow runs`);
+    }
+    runs.push(...page.workflow_runs);
   }
   return runs
     .filter((run) => String(run?.id) !== String(excludeRunId))
@@ -194,30 +212,28 @@ function readCompletedRuns({ repository, workflowFile, limit, excludeRunId }) {
 async function main() {
   const repository = readArgument(process.argv, '--repo', process.env.GITHUB_REPOSITORY || REPOSITORY);
   const workflowFile = readArgument(process.argv, '--workflow', DEFAULT_WORKFLOW_FILE);
-  const limit = Number(readArgument(process.argv, '--limit', String(DEFAULT_RUN_LIMIT)));
   const maxAgeHours = Number(readArgument(
     process.argv,
     '--max-age-hours',
     String(DEFAULT_MAX_RECONCILE_AGE_MS / (60 * 60 * 1000)),
   ));
   const warnOnly = process.argv.includes('--warn-only');
-  if (!Number.isInteger(limit) || limit <= 0 || limit > 100) {
-    throw new Error('--limit must be an integer between 1 and 100');
-  }
   if (!Number.isFinite(maxAgeHours) || maxAgeHours <= 0) {
     throw new Error('--max-age-hours must be a positive number');
   }
 
-  const candidates = readCompletedRuns({
+  const now = Date.now();
+  const maxAgeMs = maxAgeHours * 60 * 60 * 1000;
+  const candidates = readRunsSince({
     repository,
     workflowFile,
-    limit,
+    sinceMs: now - maxAgeMs,
     excludeRunId: process.env.GITHUB_RUN_ID ?? null,
   });
 
   // Newest-first, stopping at the first run that reconciled: everything older
   // than it cannot change the answer, so the healthy case costs one extra API
-  // call rather than `limit` of them.
+  // call rather than one per run in the window.
   const inspected = [];
   for (const candidate of candidates) {
     const jobs = JSON.parse(runGh(['api', `repos/${repository}/actions/runs/${candidate.id}/jobs`]));
@@ -226,21 +242,17 @@ async function main() {
     if (reconciled) break;
   }
 
-  const summary = summarizeReconcileHistory(inspected, {
-    now: Date.now(),
-    maxAgeMs: maxAgeHours * 60 * 60 * 1000,
-  });
+  const summary = summarizeReconcileHistory(inspected, { now, maxAgeMs });
   const message = describeReconcileSummary(summary);
 
   if (summary.state === 'RECENT') {
     console.log(message);
     return;
   }
-  // STALE is the alarm; UNKNOWN is "we could not disprove it", which is louder
-  // than silence and quieter than a failure.
-  const level = summary.state === 'STALE' && !warnOnly ? 'error' : 'warning';
-  console.log(`::${level}::${message}`);
-  if (summary.state === 'STALE' && !warnOnly) process.exitCode = 1;
+  // STALE is the alarm, and it is the ONLY other state: the time-bounded window
+  // makes "nothing reconciled" a proof rather than a shortfall of evidence.
+  console.log(`::${warnOnly ? 'warning' : 'error'}::${message}`);
+  if (!warnOnly) process.exitCode = 1;
 }
 
 // realpath BOTH sides: Node sets import.meta.url to the realpath while argv[1]

--- a/scripts/check-railway-reconcile-age.mjs
+++ b/scripts/check-railway-reconcile-age.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+
+// How long has anything actually reconciled the Railway fleet? (#6203)
+//
+// WHY THIS EXISTS
+//
+// .github/workflows/railway-deploy-trigger.yml has two outcomes that are
+// indistinguishable at the workflow-status level:
+//
+//   - it read main's head, found the gate green, and deployed every service
+//     that was behind; and
+//   - it read main's head, found the gate not-yet-green, skipped every step
+//     that does work, and concluded `success`.
+//
+// Measured on 2026-08-05: over 2h03m the workflow produced ONE scheduled run,
+// and that run took the second branch. Meanwhile 10 services sat on b7f2054df
+// for ~19.5h. Nothing anywhere went red.
+//
+// The workflow's existing escalation asks "how long has main's gate been
+// pending", which only fires ON A RUN — the precondition that failed. This
+// asks the question that does not depend on why: when did a run last actually
+// reconcile? The answer comes from the workflow's own run history, because a
+// run that reconciled and a run that declined differ only in whether the
+// deploying STEP ran.
+//
+// DIRECTION OF FAILURE
+//
+// Every case where the record is missing, unreadable, ambiguous or truncated
+// resolves away from "healthy". A scanner whose unmatched case means HEALTHY
+// is the same defect in a new place.
+
+import { spawnSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { REPOSITORY, readArgument } from './railway-cli.mjs';
+
+// The step whose conclusion IS the signal. A run reconciled iff this step ran
+// and succeeded; `skipped` is the #6203 transcript verbatim.
+//
+// tests/railway-reconcile-age.test.mjs pins this string against the workflow,
+// because a rename here would make every run read as "did not reconcile" —
+// which alarms rather than going quiet, but alarms forever for the wrong
+// reason.
+export const RECONCILE_STEP_NAME = 'Trigger deploys for services this merge changed';
+
+export const DEFAULT_WORKFLOW_FILE = 'railway-deploy-trigger.yml';
+
+// Sized against the workflow's own backstop, not against a fixture. The cron
+// there is hourly and is deliberately the SLOW path — the event trigger is
+// what normally reconciles. One missed hour is ordinary (a young head commit
+// whose gate has not resolved defers the run on purpose); three consecutive
+// hours with nothing reconciling means neither the event nor the backstop is
+// working, which is exactly the state that stranded the fleet for 19.5h.
+export const DEFAULT_MAX_RECONCILE_AGE_MS = 3 * 60 * 60 * 1000;
+
+// Deep enough that the "we looked far enough back to conclude" branch can
+// actually be reached: at the hourly backstop alone this window spans well
+// over a day, so a fleet that has not reconciled in three hours is inside it
+// many times over.
+export const DEFAULT_RUN_LIMIT = 30;
+
+function parseTimestamp(value) {
+  if (typeof value !== 'string') return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Did this run actually reconcile the fleet?
+ *
+ * Takes the parsed body of `GET /repos/{repo}/actions/runs/{id}/jobs`. Returns
+ * a boolean, never a maybe: a payload this cannot read is `false`, so an
+ * unrecognised shape trends toward the alarm rather than away from it.
+ */
+export function readRunReconciled(jobsPayload) {
+  const jobs = jobsPayload?.jobs;
+  if (!Array.isArray(jobs)) return false;
+  for (const job of jobs) {
+    const steps = job?.steps;
+    if (!Array.isArray(steps)) continue;
+    for (const step of steps) {
+      if (step?.name !== RECONCILE_STEP_NAME) continue;
+      // `success` only. `skipped` is the declined run this exists to catch, and
+      // `failure` is a reconcile that did not happen — it reds its own run, so
+      // counting it would let a fleet that is genuinely behind read as fresh.
+      if (step?.conclusion === 'success') return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Summarise "when did the fleet last get reconciled" from this workflow's runs.
+ *
+ * `runs` is newest-first, and must be the runs that were actually INSPECTED —
+ * callers may stop as soon as they find a reconciled one, because everything
+ * older than it cannot change the answer. Passing a truncated tail instead
+ * would make the "nothing reconciled" branch below reason about a window it
+ * never looked at.
+ *
+ * Returns one of three states, and `UNKNOWN` is never a pass:
+ *
+ *   RECENT  — a run reconciled within `maxAgeMs`.
+ *   STALE   — a run reconciled longer ago than that, OR nothing reconciled
+ *             across a window that itself reaches back past `maxAgeMs`.
+ *   UNKNOWN — nothing reconciled and the window is too short to conclude.
+ */
+export function summarizeReconcileHistory(runs, { now, maxAgeMs = DEFAULT_MAX_RECONCILE_AGE_MS } = {}) {
+  if (!Number.isFinite(now)) throw new TypeError('summarizeReconcileHistory requires a numeric now');
+  const inspected = Array.isArray(runs) ? runs : [];
+  const timestamps = [];
+
+  for (const run of inspected) {
+    const completedAt = parseTimestamp(run?.completedAt);
+    if (completedAt === null) continue;
+    timestamps.push(completedAt);
+    if (run?.reconciled !== true) continue;
+    // Runner and API clocks disagree by seconds. A future-dated run must read
+    // as "just now", not as a negative age that prints as -0h.
+    const ageMs = Math.max(0, now - completedAt);
+    return {
+      state: ageMs > maxAgeMs ? 'STALE' : 'RECENT',
+      ageMs,
+      lastReconciledAt: new Date(completedAt).toISOString(),
+      runId: run.id ?? null,
+      inspected: inspected.length,
+      maxAgeMs,
+    };
+  }
+
+  const oldest = timestamps.length > 0 ? Math.min(...timestamps) : null;
+  // Only claim staleness once the window we looked at genuinely spans the
+  // threshold. Short of that we have not disproved a reconcile, we have just
+  // run out of history — which is a different sentence and a different action.
+  const reachesPastThreshold = oldest !== null && now - oldest > maxAgeMs;
+  return {
+    state: reachesPastThreshold ? 'STALE' : 'UNKNOWN',
+    ageMs: null,
+    lastReconciledAt: null,
+    runId: null,
+    inspected: inspected.length,
+    maxAgeMs,
+  };
+}
+
+/** Human sentence for a summary, used by the CLI and worth testing as data. */
+export function describeReconcileSummary(summary) {
+  const hours = (ms) => (ms / (60 * 60 * 1000)).toFixed(1);
+  if (summary.state === 'RECENT') {
+    return `Fleet last reconciled ${hours(summary.ageMs)}h ago (run ${summary.runId}).`;
+  }
+  if (summary.state === 'UNKNOWN') {
+    return `Cannot tell when the fleet was last reconciled: none of the ${summary.inspected} run(s) inspected reconciled, and that window does not reach back ${hours(summary.maxAgeMs)}h.`;
+  }
+  if (summary.lastReconciledAt === null) {
+    return `The fleet has not been reconciled by any of the last ${summary.inspected} runs, a window reaching back past ${hours(summary.maxAgeMs)}h. Neither the Deploy Gate event nor the hourly backstop is reconciling.`;
+  }
+  return `The fleet has not been reconciled for ${hours(summary.ageMs)}h (last run ${summary.runId}), past the ${hours(summary.maxAgeMs)}h backstop tolerance.`;
+}
+
+const GH_CALL_TIMEOUT_MS = 30_000;
+
+function runGh(args) {
+  const result = spawnSync('gh', args, {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    timeout: GH_CALL_TIMEOUT_MS,
+  });
+  if (result.signal) throw new Error(`gh ${args.join(' ')} timed out`);
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`gh ${args.join(' ')} failed (${result.status}): ${String(result.stderr).trim()}`);
+  }
+  return result.stdout;
+}
+
+function readCompletedRuns({ repository, workflowFile, limit, excludeRunId }) {
+  const payload = JSON.parse(runGh([
+    'api',
+    `repos/${repository}/actions/workflows/${workflowFile}/runs?status=completed&per_page=${limit}`,
+  ]));
+  const runs = payload?.workflow_runs;
+  // An unreadable listing must not be summarised as an empty history: empty
+  // reads as UNKNOWN, which is quiet, and this is a hard failure.
+  if (!Array.isArray(runs)) {
+    throw new Error(`the run listing for ${workflowFile} was not an array of workflow runs`);
+  }
+  return runs
+    .filter((run) => String(run?.id) !== String(excludeRunId))
+    .map((run) => ({ id: run?.id ?? null, completedAt: run?.updated_at ?? null }));
+}
+
+async function main() {
+  const repository = readArgument(process.argv, '--repo', process.env.GITHUB_REPOSITORY || REPOSITORY);
+  const workflowFile = readArgument(process.argv, '--workflow', DEFAULT_WORKFLOW_FILE);
+  const limit = Number(readArgument(process.argv, '--limit', String(DEFAULT_RUN_LIMIT)));
+  const maxAgeHours = Number(readArgument(
+    process.argv,
+    '--max-age-hours',
+    String(DEFAULT_MAX_RECONCILE_AGE_MS / (60 * 60 * 1000)),
+  ));
+  const warnOnly = process.argv.includes('--warn-only');
+  if (!Number.isInteger(limit) || limit <= 0 || limit > 100) {
+    throw new Error('--limit must be an integer between 1 and 100');
+  }
+  if (!Number.isFinite(maxAgeHours) || maxAgeHours <= 0) {
+    throw new Error('--max-age-hours must be a positive number');
+  }
+
+  const candidates = readCompletedRuns({
+    repository,
+    workflowFile,
+    limit,
+    excludeRunId: process.env.GITHUB_RUN_ID ?? null,
+  });
+
+  // Newest-first, stopping at the first run that reconciled: everything older
+  // than it cannot change the answer, so the healthy case costs one extra API
+  // call rather than `limit` of them.
+  const inspected = [];
+  for (const candidate of candidates) {
+    const jobs = JSON.parse(runGh(['api', `repos/${repository}/actions/runs/${candidate.id}/jobs`]));
+    const reconciled = readRunReconciled(jobs);
+    inspected.push({ ...candidate, reconciled });
+    if (reconciled) break;
+  }
+
+  const summary = summarizeReconcileHistory(inspected, {
+    now: Date.now(),
+    maxAgeMs: maxAgeHours * 60 * 60 * 1000,
+  });
+  const message = describeReconcileSummary(summary);
+
+  if (summary.state === 'RECENT') {
+    console.log(message);
+    return;
+  }
+  // STALE is the alarm; UNKNOWN is "we could not disprove it", which is louder
+  // than silence and quieter than a failure.
+  const level = summary.state === 'STALE' && !warnOnly ? 'error' : 'warning';
+  console.log(`::${level}::${message}`);
+  if (summary.state === 'STALE' && !warnOnly) process.exitCode = 1;
+}
+
+// realpath BOTH sides: Node sets import.meta.url to the realpath while argv[1]
+// keeps the symlink, so on a symlinked checkout a bare comparison makes this
+// script exit 0 having checked nothing.
+function isMainModule() {
+  try {
+    return pathToFileURL(realpathSync(process.argv[1])).href
+      === pathToFileURL(realpathSync(fileURLToPath(import.meta.url))).href;
+  } catch {
+    return false;
+  }
+}
+
+if (process.argv[1] && isMainModule()) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/tests/railway-deploy-trigger-workflow.test.mjs
+++ b/tests/railway-deploy-trigger-workflow.test.mjs
@@ -205,6 +205,41 @@ describe('Railway deploy trigger workflow', () => {
     return minutes;
   }
 
+  it('reconciles when the gate it waits on has just resolved', () => {
+    // #6203: a 5-minute cron on this repository is not a cadence we have.
+    // Measured over the 2h03m after e2db6b6a9 the workflow got ONE scheduled
+    // run against ~24 expected ticks, because GitHub drops high-frequency
+    // schedules under load — and the fleet sat 19.5h behind a green badge.
+    //
+    // Deploy Gate completing on main is both immediate and immune to schedule
+    // throttling, and it fires exactly when the `gate` status this workflow
+    // reads has just been written. Chain depth is Test -> Deploy Gate -> here,
+    // which is inside GitHub's three-level workflow_run limit.
+    const trigger = workflow.on?.workflow_run;
+    assert.ok(trigger, 'the reconciler must be driven by an event, not by a schedule alone');
+    assert.deepEqual(trigger.workflows, ['Deploy Gate']);
+    assert.deepEqual(trigger.types, ['completed']);
+    assert.deepEqual(
+      trigger.branches,
+      ['main'],
+      'every PR head would otherwise wake the fleet reconciler',
+    );
+  });
+
+  it('keeps the cron only as a slow backstop, never as the primary cadence', () => {
+    // The cron survives the one failure an event trigger cannot self-heal (a
+    // webhook outage, #6064) and nothing else. Asking for it more often than
+    // hourly is asking for the tick GitHub already proved it drops, and it
+    // would re-establish the burst this workflow's concurrency group exists to
+    // collapse.
+    const ours = minutesOf(workflow);
+    assert.equal(
+      ours.size,
+      1,
+      `the backstop must fire at most once an hour; it fires on ${ours.size} minute(s) past the hour`,
+    );
+  });
+
   it('runs on a schedule offset from the freshness monitor', () => {
     // Both make one Railway API call per service across a 77-service fleet;
     // sharing a minute is how one of them starts getting rate limited.
@@ -232,6 +267,43 @@ describe('Railway deploy trigger workflow', () => {
         `"${step.name}" talks to Railway but is not given RAILWAY_PROJECT_ID`,
       );
     }
+  });
+
+  it('says out loud when a run declined to deploy anything', () => {
+    // #6203's second half. "Reconciled the fleet" and "skipped every step that
+    // does work" are both `success` at the workflow-status level, so the fleet
+    // can sit stranded behind a green badge. The distinction has to be written
+    // somewhere a human reads without opening the raw log.
+    const report = stepNamed('Report what this run did');
+    assert.equal(String(report.if), 'always()', 'the outcome report must survive a failed step');
+    assert.match(report.run, /GITHUB_STEP_SUMMARY/, 'the outcome must reach the job summary');
+    assert.match(report.run, /::warning::/, 'a declined run must raise an annotation, not just a log line');
+
+    // It can only tell the two apart if it is given the deploy step's outcome,
+    // which needs that step to carry an id.
+    const deploy = stepNamed('Trigger deploys for services this merge changed');
+    assert.ok(deploy.id, 'the deploying step must be addressable by the outcome report');
+    assert.ok(
+      Object.values(report.env ?? {}).some(
+        (value) => String(value).includes(`steps.${deploy.id}.outcome`),
+      ),
+      'the outcome report must read the deploying step\'s outcome',
+    );
+  });
+
+  it('fails when the fleet has gone un-reconciled longer than the backstop tolerates', () => {
+    // The existing escalation only fires on a PENDING gate, and only when this
+    // workflow runs — which is the precondition that failed. This one asks the
+    // question that does not depend on why: when did anything last reconcile?
+    const step = steps.find((candidate) => String(candidate.run ?? '')
+      .includes('check-railway-reconcile-age.mjs'));
+    assert.ok(step, 'the workflow must check how long the fleet has gone un-reconciled');
+    assert.ok(step.env?.GH_TOKEN, 'the age check reads this workflow\'s own run history');
+    assert.equal(
+      step['continue-on-error'],
+      undefined,
+      'an un-reconciled fleet must red the run, not be swallowed',
+    );
   });
 
   it('runs against the environment that holds the production Railway token', () => {

--- a/tests/railway-deploy-trigger-workflow.test.mjs
+++ b/tests/railway-deploy-trigger-workflow.test.mjs
@@ -317,6 +317,67 @@ describe('Railway deploy trigger workflow', () => {
     );
   });
 
+  it('never asks the age question on a run whose own deploy just succeeded', () => {
+    // The scan reads COMPLETED runs and excludes this one, so a run that just
+    // reconciled cannot see its own work. After a drought past the threshold —
+    // the exact recovery this workflow exists for — the run that FIXED the
+    // fleet would report it stale and go red.
+    //
+    // And a red run here is not cosmetic: this workflow's runs carry a main
+    // commit as head_sha, so the failure lands in that commit's check suite,
+    // which is the `CI check suite failed` reason Railway uses to defer every
+    // service. The alarm would cause the outage it detects.
+    const step = steps.find((candidate) => String(candidate.run ?? '')
+      .includes('check-railway-reconcile-age.mjs'));
+    const deploy = stepNamed('Trigger deploys for services this merge changed');
+    assert.match(
+      String(step.if),
+      /always\(\)/,
+      'the age check must still run on a declined run — that is the case it exists for',
+    );
+    assert.ok(
+      String(step.if).includes(`steps.${deploy.id}.outcome != 'success'`),
+      'the age check must be skipped when this run already reconciled the fleet',
+    );
+  });
+
+  it('reads its own run history, which needs the actions scope', () => {
+    assert.equal(
+      workflow.permissions?.actions,
+      'read',
+      'reading this workflow\'s own runs requires actions: read',
+    );
+  });
+
+  it('keeps the age check warn-only on a dry run, in two explicit arms', () => {
+    // One interpolated flag would have to agree with the env var forever; the
+    // day they diverge the arm that still runs is the one that stays quiet.
+    const step = steps.find((candidate) => String(candidate.run ?? '')
+      .includes('check-railway-reconcile-age.mjs'));
+    assert.match(String(step.env?.WARN_ONLY ?? ''), /inputs\.dryRun/);
+    assert.match(step.run, /--warn-only/, 'the dry-run arm must pass --warn-only');
+    assert.match(
+      step.run,
+      /check-railway-reconcile-age\.mjs\s*$/m,
+      'the non-dry-run arm must invoke the check without --warn-only',
+    );
+  });
+
+  it('surfaces a failed age check in the summary a human reads', () => {
+    // Otherwise a run can be red for "the fleet is un-reconciled" while its
+    // job summary reads as an ordinary decline.
+    const report = stepNamed('Report what this run did');
+    const step = steps.find((candidate) => String(candidate.run ?? '')
+      .includes('check-railway-reconcile-age.mjs'));
+    assert.ok(step.id, 'the age check must be addressable by the outcome report');
+    assert.ok(
+      Object.values(report.env ?? {}).some(
+        (value) => String(value).includes(`steps.${step.id}.outcome`),
+      ),
+      'the outcome report must read the age check\'s outcome',
+    );
+  });
+
   it('fails when the fleet has gone un-reconciled longer than the backstop tolerates', () => {
     // The existing escalation only fires on a PENDING gate, and only when this
     // workflow runs — which is the precondition that failed. This one asks the

--- a/tests/railway-deploy-trigger-workflow.test.mjs
+++ b/tests/railway-deploy-trigger-workflow.test.mjs
@@ -6,7 +6,7 @@
 // the workflow still reported success.
 
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -204,6 +204,32 @@ describe('Railway deploy trigger workflow', () => {
     }
     return minutes;
   }
+
+  it('contains no empty GitHub expression, which fails the whole file to parse', () => {
+    // Cost a full cycle. An EMPTY GitHub expression — the opener, whitespace,
+    // the closer — written inside a shell COMMENT in a `run:` block is still
+    // seen by GitHub's expression parser, which scans the entire block scalar,
+    // and it rejects the workflow with "An expression was expected". (The
+    // literal is deliberately not written here: this test would then flag its
+    // own source.) The consequences are exactly the failure mode this file exists
+    // to prevent, one level up: a workflow that fails to parse publishes NO
+    // check run, so the PR stays green, it is absent from the deploy gate's
+    // required list, and every trigger — event, cron and dispatch alike — stops
+    // producing runs. Observed as run 30981164081: conclusion=failure, zero
+    // jobs, and `name` reported as the file path instead of the workflow name.
+    //
+    // The `yaml` parser this file uses accepts it, so nothing else in CI can
+    // catch this. Scan every workflow, not just this one.
+    const workflowDir = resolve(repoRoot, '.github/workflows');
+    const offenders = [];
+    for (const file of readdirSync(workflowDir).filter((name) => /\.ya?ml$/.test(name))) {
+      const text = readFileSync(resolve(workflowDir, file), 'utf8');
+      text.split('\n').forEach((line, index) => {
+        if (/\$\{\{\s*\}\}/.test(line)) offenders.push(`${file}:${index + 1}`);
+      });
+    }
+    assert.deepEqual(offenders, [], 'empty GitHub expression(s) found; these make the workflow unparseable');
+  });
 
   it('reconciles when the gate it waits on has just resolved', () => {
     // #6203: a 5-minute cron on this repository is not a cadence we have.

--- a/tests/railway-reconcile-age.test.mjs
+++ b/tests/railway-reconcile-age.test.mjs
@@ -1,0 +1,222 @@
+// #6203 — the reconciler must be able to say "the fleet has not been
+// reconciled in N hours", independent of WHY.
+//
+// The failure this pins is not a wrong number, it is a green badge. The
+// reconciler's own run history is the only record of whether it did anything,
+// because a run that declines to deploy and a run that reconciled the whole
+// fleet both conclude `success`. Every case where that record is missing,
+// unreadable or ambiguous must therefore resolve AWAY from "healthy" — the
+// unmatched case meaning HEALTHY is the exact shape of the defect.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import YAML from 'yaml';
+
+import {
+  DEFAULT_MAX_RECONCILE_AGE_MS,
+  RECONCILE_STEP_NAME,
+  readRunReconciled,
+  summarizeReconcileHistory,
+} from '../scripts/check-railway-reconcile-age.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// A fixed clock. Seeding from Date.now() makes every boundary assertion below
+// depend on how long the suite took to get here.
+const NOW = Date.parse('2026-08-05T12:00:00Z');
+const HOUR = 60 * 60 * 1000;
+
+function run(hoursAgo, reconciled, id = `run-${hoursAgo}`) {
+  return {
+    id,
+    completedAt: new Date(NOW - hoursAgo * HOUR).toISOString(),
+    reconciled,
+  };
+}
+
+describe('reconcile-age history summary', () => {
+  it('reports the age of the newest run that actually reconciled', () => {
+    const summary = summarizeReconcileHistory(
+      [run(0.5, false), run(1, true, 'reconciled-run'), run(2, true)],
+      { now: NOW },
+    );
+    assert.equal(summary.state, 'RECENT');
+    assert.equal(summary.runId, 'reconciled-run');
+    assert.equal(summary.ageMs, HOUR);
+  });
+
+  it('ignores runs that declined, so a wall of no-ops cannot read as healthy', () => {
+    // The #6203 shape exactly: the workflow ran, concluded success, and skipped
+    // every step that does work.
+    const declined = Array.from({ length: 12 }, (_, index) => run(index * 0.5, false));
+    const summary = summarizeReconcileHistory(
+      [...declined, run(9, true, 'the-last-real-one')],
+      { now: NOW, maxAgeMs: 3 * HOUR },
+    );
+    assert.equal(summary.state, 'STALE');
+    assert.equal(summary.runId, 'the-last-real-one');
+    assert.equal(summary.ageMs, 9 * HOUR);
+  });
+
+  it('is stale, not unknown, when the window reaches past the threshold with nothing reconciled', () => {
+    // We looked back far enough to conclude. Answering "cannot tell" here is
+    // how the alarm never fires for the fleet that is most stranded.
+    const summary = summarizeReconcileHistory(
+      [run(0.5, false), run(4, false), run(7, false)],
+      { now: NOW, maxAgeMs: 3 * HOUR },
+    );
+    assert.equal(summary.state, 'STALE');
+    assert.equal(summary.lastReconciledAt, null);
+    assert.equal(summary.runId, null);
+  });
+
+  it('measures the window from the genuinely oldest run, not from list order', () => {
+    // The runs come from a paginated API. Assuming newest-first and reading the
+    // last element would make an out-of-order page report a window shorter than
+    // the one actually inspected, which downgrades STALE to UNKNOWN — the alarm
+    // silently becoming a shrug.
+    // The 7h run is FIRST and the 0.5h run last on purpose: reading the tail
+    // instead of the minimum would measure a 0.5h window and report UNKNOWN.
+    const summary = summarizeReconcileHistory(
+      [run(7, false), run(0.5, false)],
+      { now: NOW, maxAgeMs: 3 * HOUR },
+    );
+    assert.equal(summary.state, 'STALE');
+  });
+
+  it('does not let an unparseable timestamp shrink the inspected window', () => {
+    // Placed on both sides of the readable record, because a record that
+    // discarded what came before it and one that discarded what came after
+    // are different bugs with the same symptom: the alarm downgraded to a
+    // shrug by one malformed row.
+    for (const history of [
+      [{ id: 'bad', completedAt: null, reconciled: false }, run(7, false)],
+      [run(7, false), { id: 'bad', completedAt: null, reconciled: false }],
+    ]) {
+      const summary = summarizeReconcileHistory(history, { now: NOW, maxAgeMs: 3 * HOUR });
+      assert.equal(summary.state, 'STALE', 'one unreadable record must not suppress the alarm');
+    }
+  });
+
+  it('is unknown — never healthy — when the inspected window is too short to conclude', () => {
+    const summary = summarizeReconcileHistory(
+      [run(0.25, false), run(0.5, false)],
+      { now: NOW, maxAgeMs: 3 * HOUR },
+    );
+    assert.equal(summary.state, 'UNKNOWN');
+  });
+
+  it('is unknown, not healthy, for an empty or unparseable history', () => {
+    assert.equal(summarizeReconcileHistory([], { now: NOW }).state, 'UNKNOWN');
+    assert.equal(
+      summarizeReconcileHistory(
+        [{ id: 'a', completedAt: null, reconciled: true }],
+        { now: NOW },
+      ).state,
+      'UNKNOWN',
+    );
+    assert.equal(
+      summarizeReconcileHistory(
+        [{ id: 'a', completedAt: 'not a date', reconciled: true }],
+        { now: NOW },
+      ).state,
+      'UNKNOWN',
+    );
+  });
+
+  it('treats the threshold as exclusive at the boundary and stale one ms past it', () => {
+    const at = summarizeReconcileHistory(
+      [{ id: 'a', completedAt: new Date(NOW - 3 * HOUR).toISOString(), reconciled: true }],
+      { now: NOW, maxAgeMs: 3 * HOUR },
+    );
+    assert.equal(at.state, 'RECENT', 'exactly at the threshold is not yet stale');
+    const past = summarizeReconcileHistory(
+      [{ id: 'a', completedAt: new Date(NOW - 3 * HOUR - 1).toISOString(), reconciled: true }],
+      { now: NOW, maxAgeMs: 3 * HOUR },
+    );
+    assert.equal(past.state, 'STALE');
+  });
+
+  it('does not let a future-dated run report a negative age', () => {
+    // Runner clock skew against GitHub's timestamps is real and small; a
+    // negative age would print as "-0h" and compare healthy for the wrong
+    // reason.
+    const summary = summarizeReconcileHistory(
+      [{ id: 'a', completedAt: new Date(NOW + 5 * 60 * 1000).toISOString(), reconciled: true }],
+      { now: NOW },
+    );
+    assert.equal(summary.state, 'RECENT');
+    assert.equal(summary.ageMs, 0);
+  });
+
+  it('defaults the threshold to three times the workflow backstop interval', () => {
+    // Sized against the hourly cron the workflow keeps as its backstop, not
+    // against a fixture: one missed tick is ordinary, three consecutive misses
+    // plus a missed event mean nothing is reconciling.
+    assert.equal(DEFAULT_MAX_RECONCILE_AGE_MS, 3 * HOUR);
+  });
+});
+
+describe('reading whether one run reconciled', () => {
+  it('counts only a deploy step that ran and succeeded', () => {
+    const jobs = (conclusion) => ({
+      jobs: [{
+        steps: [
+          { name: 'Resolve main\'s head and require it to be green', conclusion: 'success' },
+          { name: RECONCILE_STEP_NAME, conclusion },
+        ],
+      }],
+    });
+    assert.equal(readRunReconciled(jobs('success')), true);
+    // The #6203 transcript: the step is present and skipped.
+    assert.equal(readRunReconciled(jobs('skipped')), false);
+    // A deploy that errored did not reconcile the fleet. It reds its own run,
+    // so counting it would double-hide a fleet that is genuinely behind.
+    assert.equal(readRunReconciled(jobs('failure')), false);
+    assert.equal(readRunReconciled(jobs(null)), false);
+  });
+
+  it('reads false — never true — for a payload it does not recognise', () => {
+    assert.equal(readRunReconciled({}), false);
+    assert.equal(readRunReconciled(null), false);
+    assert.equal(readRunReconciled({ jobs: [] }), false);
+    assert.equal(readRunReconciled({ jobs: [{ steps: [] }] }), false);
+    assert.equal(
+      readRunReconciled({ jobs: [{ steps: [{ name: 'renamed step', conclusion: 'success' }] }] }),
+      false,
+    );
+  });
+
+  it('finds the step across every job of a run', () => {
+    assert.equal(
+      readRunReconciled({
+        jobs: [
+          { steps: [{ name: 'something else', conclusion: 'success' }] },
+          { steps: [{ name: RECONCILE_STEP_NAME, conclusion: 'success' }] },
+        ],
+      }),
+      true,
+    );
+  });
+});
+
+describe('the step name this scanner matches on', () => {
+  it('is a step the reconciler workflow actually defines', () => {
+    // The scanner's whole signal is this string. If the workflow renames the
+    // step, every run reads as "did not reconcile" — which alarms rather than
+    // going quiet, but alarms for the wrong reason forever. Pin them together.
+    const workflow = YAML.parse(readFileSync(
+      resolve(repoRoot, '.github/workflows/railway-deploy-trigger.yml'),
+      'utf8',
+    ));
+    const names = workflow.jobs.trigger.steps.map((step) => step.name);
+    assert.ok(
+      names.includes(RECONCILE_STEP_NAME),
+      `RECONCILE_STEP_NAME ${JSON.stringify(RECONCILE_STEP_NAME)} names no step in the workflow; it has ${JSON.stringify(names)}`,
+    );
+  });
+});

--- a/tests/railway-reconcile-age.test.mjs
+++ b/tests/railway-reconcile-age.test.mjs
@@ -27,8 +27,10 @@ import YAML from 'yaml';
 import {
   DEFAULT_MAX_RECONCILE_AGE_MS,
   RECONCILE_STEP_NAME,
+  collectReconcileWindow,
   describeReconcileSummary,
   readRunReconciled,
+  readRunsSince,
   summarizeReconcileHistory,
   toCreatedFilter,
 } from '../scripts/check-railway-reconcile-age.mjs';
@@ -139,6 +141,116 @@ describe('the API window the CLI asks for', () => {
   it('formats a second-granularity UTC instant, which is what `created` takes', () => {
     assert.equal(toCreatedFilter(Date.parse('2026-08-05T09:00:00.123Z')), '2026-08-05T09:00:00Z');
     assert.doesNotMatch(toCreatedFilter(NOW), /\.\d+Z$/);
+  });
+});
+
+describe('the I/O path that builds the window', () => {
+  const jobsFor = (conclusion) => JSON.stringify({
+    jobs: [{ steps: [{ name: RECONCILE_STEP_NAME, conclusion }] }],
+  });
+
+  // A fake `gh` that answers from a fixture and records what was asked.
+  function fakeGh({ pages, jobsByRunId }) {
+    const calls = [];
+    return {
+      calls,
+      gh(args) {
+        const url = args[args.length - 1];
+        calls.push(url);
+        if (url.includes('/runs?')) return JSON.stringify(pages);
+        const runId = /\/actions\/runs\/([^/]+)\/jobs/.exec(url)?.[1];
+        return jobsByRunId[runId] ?? jobsFor('skipped');
+      },
+    };
+  }
+
+  const listing = (...runs) => [{ workflow_runs: runs }];
+
+  it('asks for completed runs created inside the window only', () => {
+    const { gh, calls } = fakeGh({ pages: listing(), jobsByRunId: {} });
+    readRunsSince({
+      gh, repository: 'o/r', workflowFile: 'w.yml', sinceMs: Date.parse('2026-08-05T09:00:00Z'), excludeRunId: null,
+    });
+    assert.match(calls[0], /status=completed/);
+    assert.match(calls[0], /created=%3E%3D2026-08-05T09%3A00%3A00Z/);
+  });
+
+  it('drops the current run from the window', () => {
+    // Belt and braces with `status=completed`, and the reason the workflow must
+    // not ask this question on a run whose own deploy just succeeded.
+    const { gh } = fakeGh({
+      pages: listing(
+        { id: 111, updated_at: '2026-08-05T11:00:00Z' },
+        { id: 222, updated_at: '2026-08-05T10:00:00Z' },
+      ),
+      jobsByRunId: {},
+    });
+    const runs = readRunsSince({
+      gh, repository: 'o/r', workflowFile: 'w.yml', sinceMs: NOW - 3 * HOUR, excludeRunId: '111',
+    });
+    assert.deepEqual(runs.map((run) => run.id), [222]);
+  });
+
+  it('reads every page of a paginated listing', () => {
+    const { gh } = fakeGh({
+      pages: [
+        { workflow_runs: [{ id: 1, updated_at: '2026-08-05T11:00:00Z' }] },
+        { workflow_runs: [{ id: 2, updated_at: '2026-08-05T10:00:00Z' }] },
+      ],
+      jobsByRunId: {},
+    });
+    const runs = readRunsSince({
+      gh, repository: 'o/r', workflowFile: 'w.yml', sinceMs: NOW - 3 * HOUR, excludeRunId: null,
+    });
+    assert.deepEqual(runs.map((run) => run.id), [1, 2]);
+  });
+
+  it('throws on an unreadable listing rather than reporting an empty window', () => {
+    // Empty now means STALE, which is loud — but it would be loud for a false
+    // reason, and an operator would go looking at triggers instead of the API.
+    const { gh } = fakeGh({ pages: [{ message: 'Not Found' }], jobsByRunId: {} });
+    assert.throws(
+      () => readRunsSince({
+        gh, repository: 'o/r', workflowFile: 'w.yml', sinceMs: NOW - 3 * HOUR, excludeRunId: null,
+      }),
+      /not an array of workflow runs/,
+    );
+  });
+
+  it('stops fetching jobs at the first run that reconciled', () => {
+    const { gh, calls } = fakeGh({
+      pages: listing(
+        { id: 'newest', updated_at: '2026-08-05T11:50:00Z' },
+        { id: 'reconciled', updated_at: '2026-08-05T11:40:00Z' },
+        { id: 'older', updated_at: '2026-08-05T11:30:00Z' },
+      ),
+      jobsByRunId: { newest: jobsFor('skipped'), reconciled: jobsFor('success') },
+    });
+    const window = collectReconcileWindow({
+      gh, repository: 'o/r', workflowFile: 'w.yml', sinceMs: NOW - 3 * HOUR, excludeRunId: null,
+    });
+    assert.deepEqual(window.map((run) => run.reconciled), [false, true]);
+    assert.ok(
+      !calls.some((url) => url.includes('/runs/older/jobs')),
+      'must not keep paying for job reads past the answer',
+    );
+  });
+
+  it('yields a window that summarises STALE when nothing in it reconciled', () => {
+    const { gh } = fakeGh({
+      pages: listing(
+        { id: 'a', updated_at: new Date(NOW - 0.5 * HOUR).toISOString() },
+        { id: 'b', updated_at: new Date(NOW - 1.5 * HOUR).toISOString() },
+      ),
+      jobsByRunId: {},
+    });
+    const window = collectReconcileWindow({
+      gh, repository: 'o/r', workflowFile: 'w.yml', sinceMs: NOW - 3 * HOUR, excludeRunId: null,
+    });
+    assert.equal(
+      summarizeReconcileHistory(window, { now: NOW, maxAgeMs: 3 * HOUR }).state,
+      'STALE',
+    );
   });
 });
 

--- a/tests/railway-reconcile-age.test.mjs
+++ b/tests/railway-reconcile-age.test.mjs
@@ -4,9 +4,17 @@
 // The failure this pins is not a wrong number, it is a green badge. The
 // reconciler's own run history is the only record of whether it did anything,
 // because a run that declines to deploy and a run that reconciled the whole
-// fleet both conclude `success`. Every case where that record is missing,
-// unreadable or ambiguous must therefore resolve AWAY from "healthy" — the
-// unmatched case meaning HEALTHY is the exact shape of the defect.
+// fleet both conclude `success`. Every case where that record is missing or
+// unreadable must therefore resolve AWAY from "healthy" — the unmatched case
+// meaning HEALTHY is the exact shape of the defect.
+//
+// The window is bounded by TIME, never by a run count, and that is what makes
+// the negative answer decidable. A count-bounded window was the first design
+// and it was unusable: this workflow is woken by every Deploy Gate evaluation
+// in the repository (~33/hour, measured), so the newest 30 runs span under an
+// hour and could never reach back past a three-hour threshold. The alarm could
+// not fire. With a time window, "no run in the window reconciled" is a proof —
+// including the window being EMPTY, which is the #6203 failure itself.
 
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
@@ -19,14 +27,16 @@ import YAML from 'yaml';
 import {
   DEFAULT_MAX_RECONCILE_AGE_MS,
   RECONCILE_STEP_NAME,
+  describeReconcileSummary,
   readRunReconciled,
   summarizeReconcileHistory,
+  toCreatedFilter,
 } from '../scripts/check-railway-reconcile-age.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-// A fixed clock. Seeding from Date.now() makes every boundary assertion below
-// depend on how long the suite took to get here.
+// A fixed clock. Seeding from Date.now() makes every assertion below depend on
+// how long the suite took to get here.
 const NOW = Date.parse('2026-08-05T12:00:00Z');
 const HOUR = 60 * 60 * 1000;
 
@@ -38,7 +48,7 @@ function run(hoursAgo, reconciled, id = `run-${hoursAgo}`) {
   };
 }
 
-describe('reconcile-age history summary', () => {
+describe('reconcile-age window summary', () => {
   it('reports the age of the newest run that actually reconciled', () => {
     const summary = summarizeReconcileHistory(
       [run(0.5, false), run(1, true, 'reconciled-run'), run(2, true)],
@@ -49,102 +59,62 @@ describe('reconcile-age history summary', () => {
     assert.equal(summary.ageMs, HOUR);
   });
 
+  it('finds a reconcile anywhere in the window, not only in the newest run', () => {
+    const summary = summarizeReconcileHistory(
+      [run(0.2, false), run(0.4, false), run(2.9, true, 'deep-in-window')],
+      { now: NOW, maxAgeMs: 3 * HOUR },
+    );
+    assert.equal(summary.state, 'RECENT');
+    assert.equal(summary.runId, 'deep-in-window');
+  });
+
   it('ignores runs that declined, so a wall of no-ops cannot read as healthy', () => {
     // The #6203 shape exactly: the workflow ran, concluded success, and skipped
-    // every step that does work.
-    const declined = Array.from({ length: 12 }, (_, index) => run(index * 0.5, false));
-    const summary = summarizeReconcileHistory(
-      [...declined, run(9, true, 'the-last-real-one')],
-      { now: NOW, maxAgeMs: 3 * HOUR },
-    );
+    // every step that does work. All of these are inside the window, so
+    // "none reconciled" is a proof rather than a shortfall of evidence.
+    const declined = Array.from({ length: 12 }, (_, index) => run(index * 0.2, false));
+    const summary = summarizeReconcileHistory(declined, { now: NOW, maxAgeMs: 3 * HOUR });
     assert.equal(summary.state, 'STALE');
-    assert.equal(summary.runId, 'the-last-real-one');
-    assert.equal(summary.ageMs, 9 * HOUR);
-  });
-
-  it('is stale, not unknown, when the window reaches past the threshold with nothing reconciled', () => {
-    // We looked back far enough to conclude. Answering "cannot tell" here is
-    // how the alarm never fires for the fleet that is most stranded.
-    const summary = summarizeReconcileHistory(
-      [run(0.5, false), run(4, false), run(7, false)],
-      { now: NOW, maxAgeMs: 3 * HOUR },
-    );
-    assert.equal(summary.state, 'STALE');
-    assert.equal(summary.lastReconciledAt, null);
     assert.equal(summary.runId, null);
+    assert.equal(summary.inspected, 12);
   });
 
-  it('measures the window from the genuinely oldest run, not from list order', () => {
-    // The runs come from a paginated API. Assuming newest-first and reading the
-    // last element would make an out-of-order page report a window shorter than
-    // the one actually inspected, which downgrades STALE to UNKNOWN — the alarm
-    // silently becoming a shrug.
-    // The 7h run is FIRST and the 0.5h run last on purpose: reading the tail
-    // instead of the minimum would measure a 0.5h window and report UNKNOWN.
-    const summary = summarizeReconcileHistory(
-      [run(7, false), run(0.5, false)],
-      { now: NOW, maxAgeMs: 3 * HOUR },
-    );
+  it('is STALE — never a shrug — when the workflow produced no run at all', () => {
+    // This is the #6203 failure itself: the schedule was throttled so the
+    // reconciler simply did not run. A count-bounded window called that
+    // "cannot tell" and exited 0. An empty TIME window is proof, and the
+    // message has to say which of the two it is so an operator knows whether
+    // to look at the trigger or at the deploys.
+    const summary = summarizeReconcileHistory([], { now: NOW, maxAgeMs: 3 * HOUR });
     assert.equal(summary.state, 'STALE');
+    assert.equal(summary.inspected, 0);
+    assert.match(describeReconcileSummary(summary), /NO completed run/);
+    assert.doesNotMatch(
+      describeReconcileSummary(
+        summarizeReconcileHistory([run(1, false)], { now: NOW, maxAgeMs: 3 * HOUR }),
+      ),
+      /NO completed run/,
+      'a window that held runs must not claim the workflow never fired',
+    );
   });
 
-  it('does not let an unparseable timestamp shrink the inspected window', () => {
-    // Placed on both sides of the readable record, because a record that
-    // discarded what came before it and one that discarded what came after
-    // are different bugs with the same symptom: the alarm downgraded to a
-    // shrug by one malformed row.
-    for (const history of [
-      [{ id: 'bad', completedAt: null, reconciled: false }, run(7, false)],
-      [run(7, false), { id: 'bad', completedAt: null, reconciled: false }],
-    ]) {
-      const summary = summarizeReconcileHistory(history, { now: NOW, maxAgeMs: 3 * HOUR });
-      assert.equal(summary.state, 'STALE', 'one unreadable record must not suppress the alarm');
+  it('still proves a reconcile when the winning run has an unreadable timestamp', () => {
+    // The window is the caller's guarantee, not this field's. Throwing the
+    // proof away over a malformed date would alarm on a fleet that is fine.
+    for (const completedAt of [null, 'not a date']) {
+      const summary = summarizeReconcileHistory(
+        [{ id: 'a', completedAt, reconciled: true }],
+        { now: NOW, maxAgeMs: 3 * HOUR },
+      );
+      assert.equal(summary.state, 'RECENT');
+      assert.equal(summary.ageMs, null);
+      assert.equal(summary.runId, 'a');
     }
-  });
-
-  it('is unknown — never healthy — when the inspected window is too short to conclude', () => {
-    const summary = summarizeReconcileHistory(
-      [run(0.25, false), run(0.5, false)],
-      { now: NOW, maxAgeMs: 3 * HOUR },
-    );
-    assert.equal(summary.state, 'UNKNOWN');
-  });
-
-  it('is unknown, not healthy, for an empty or unparseable history', () => {
-    assert.equal(summarizeReconcileHistory([], { now: NOW }).state, 'UNKNOWN');
-    assert.equal(
-      summarizeReconcileHistory(
-        [{ id: 'a', completedAt: null, reconciled: true }],
-        { now: NOW },
-      ).state,
-      'UNKNOWN',
-    );
-    assert.equal(
-      summarizeReconcileHistory(
-        [{ id: 'a', completedAt: 'not a date', reconciled: true }],
-        { now: NOW },
-      ).state,
-      'UNKNOWN',
-    );
-  });
-
-  it('treats the threshold as exclusive at the boundary and stale one ms past it', () => {
-    const at = summarizeReconcileHistory(
-      [{ id: 'a', completedAt: new Date(NOW - 3 * HOUR).toISOString(), reconciled: true }],
-      { now: NOW, maxAgeMs: 3 * HOUR },
-    );
-    assert.equal(at.state, 'RECENT', 'exactly at the threshold is not yet stale');
-    const past = summarizeReconcileHistory(
-      [{ id: 'a', completedAt: new Date(NOW - 3 * HOUR - 1).toISOString(), reconciled: true }],
-      { now: NOW, maxAgeMs: 3 * HOUR },
-    );
-    assert.equal(past.state, 'STALE');
   });
 
   it('does not let a future-dated run report a negative age', () => {
     // Runner clock skew against GitHub's timestamps is real and small; a
-    // negative age would print as "-0h" and compare healthy for the wrong
-    // reason.
+    // negative age would print as "-0h".
     const summary = summarizeReconcileHistory(
       [{ id: 'a', completedAt: new Date(NOW + 5 * 60 * 1000).toISOString(), reconciled: true }],
       { now: NOW },
@@ -153,11 +123,22 @@ describe('reconcile-age history summary', () => {
     assert.equal(summary.ageMs, 0);
   });
 
+  it('refuses to summarise without a clock rather than defaulting to one', () => {
+    assert.throws(() => summarizeReconcileHistory([]), /numeric now/);
+  });
+
   it('defaults the threshold to three times the workflow backstop interval', () => {
-    // Sized against the hourly cron the workflow keeps as its backstop, not
-    // against a fixture: one missed tick is ordinary, three consecutive misses
-    // plus a missed event mean nothing is reconciling.
+    // Sized against the workflow's hourly cron backstop, not against a fixture:
+    // one missed hour is ordinary, three consecutive hours with nothing
+    // reconciling means neither the event nor the backstop is working.
     assert.equal(DEFAULT_MAX_RECONCILE_AGE_MS, 3 * HOUR);
+  });
+});
+
+describe('the API window the CLI asks for', () => {
+  it('formats a second-granularity UTC instant, which is what `created` takes', () => {
+    assert.equal(toCreatedFilter(Date.parse('2026-08-05T09:00:00.123Z')), '2026-08-05T09:00:00Z');
+    assert.doesNotMatch(toCreatedFilter(NOW), /\.\d+Z$/);
   });
 });
 
@@ -191,6 +172,12 @@ describe('reading whether one run reconciled', () => {
     );
   });
 
+  it('reads false for a run cancelled while pending, which reports no jobs', () => {
+    // The workflow's concurrency group deliberately manufactures these: a new
+    // arrival cancels the pending member. They must never fake a reconcile.
+    assert.equal(readRunReconciled({ jobs: [] }), false);
+  });
+
   it('finds the step across every job of a run', () => {
     assert.equal(
       readRunReconciled({
@@ -204,19 +191,40 @@ describe('reading whether one run reconciled', () => {
   });
 });
 
-describe('the step name this scanner matches on', () => {
-  it('is a step the reconciler workflow actually defines', () => {
+describe('the cross-file names this scanner depends on', () => {
+  const workflow = YAML.parse(readFileSync(
+    resolve(repoRoot, '.github/workflows/railway-deploy-trigger.yml'),
+    'utf8',
+  ));
+
+  it('matches a step the reconciler workflow actually defines', () => {
     // The scanner's whole signal is this string. If the workflow renames the
     // step, every run reads as "did not reconcile" — which alarms rather than
-    // going quiet, but alarms for the wrong reason forever. Pin them together.
-    const workflow = YAML.parse(readFileSync(
-      resolve(repoRoot, '.github/workflows/railway-deploy-trigger.yml'),
-      'utf8',
-    ));
+    // going quiet, but alarms forever for the wrong reason.
     const names = workflow.jobs.trigger.steps.map((step) => step.name);
     assert.ok(
       names.includes(RECONCILE_STEP_NAME),
       `RECONCILE_STEP_NAME ${JSON.stringify(RECONCILE_STEP_NAME)} names no step in the workflow; it has ${JSON.stringify(names)}`,
     );
+  });
+
+  it('names a workflow that actually exists, so the primary trigger cannot silently die', () => {
+    // `workflow_run.workflows` is a cross-file reference by DISPLAY NAME.
+    // Renaming Deploy Gate's `name:` would delete the reconciler's primary
+    // cadence and leave the hourly cron holding a green badge — the same
+    // silent-degradation shape #6203 is about, one indirection further out.
+    const upstream = workflow.on?.workflow_run?.workflows ?? [];
+    assert.ok(upstream.length > 0, 'the reconciler must declare an upstream workflow');
+    for (const name of upstream) {
+      const target = YAML.parse(readFileSync(
+        resolve(repoRoot, '.github/workflows/deploy-gate.yml'),
+        'utf8',
+      ));
+      assert.equal(
+        target.name,
+        name,
+        `railway-deploy-trigger waits on a workflow named ${JSON.stringify(name)}, but deploy-gate.yml is named ${JSON.stringify(target.name)}`,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

The deploy reconciler ran on a 5-minute cron and effectively did not run. Over the 2h03m after `e2db6b6a9` merged it produced **one** scheduled run against ~24 expected ticks — GitHub documents `schedule` as best-effort and drops high-frequency crons under load, and the 15-minute Seed Freshness Monitor was landing every 25–50 minutes in the same window. Meanwhile 10 services sat on `b7f2054df` for ~19.5h and nothing went red, because a run that declines to deploy and a run that reconciles the whole fleet are both `success`.

Three changes:

**1. Drive it off an event.** `workflow_run` on **Deploy Gate** completing against `main`. That is immediate, immune to schedule throttling, and fires exactly when the `gate` status this workflow reads has just been written. The cron drops to hourly as the backstop for the one case an event cannot self-heal (an event-delivery outage, #6064).

**2. Make a no-op visible.** Every run writes a job-summary line; a run that declined raises a `::warning::` naming the head SHA and the gate state it refused on.

**3. Alarm on a fleet nothing is reconciling.** New `scripts/check-railway-reconcile-age.mjs` answers the question the existing escalation cannot. The existing one asks "how long has main's gate been pending", which only fires *on a run* — the precondition that failed. This one asks "when did anything last actually reconcile", reading this workflow's own run history, and reds the run past a 3h tolerance (3× the hourly backstop).

## Design notes for review

- **Chain depth.** `Test` → `Deploy Gate` → `Railway Deploy Trigger`. GitHub refuses to chain `workflow_run` more than three levels, so this spends the last link — nothing may now be triggered off this workflow's completion. Called out in the file.
- **Burst safety.** A merge completes four Deploy Gate runs (Test, Typecheck, Lint Code, Security Audit each trigger one). GitHub cancels the previously *pending* member of a concurrency group when a new run queues, so a burst collapses to one running plus one queued reconcile. The existing `cancel-in-progress: false` group already provides this; no change needed.
- **`branches: [main]` filters the *triggering* run's branch,** so every PR's Deploy Gate run is excluded. A fork PR whose branch is named `main` also passes that filter — harmless and deliberately unguarded, because nothing reads the event: the job resolves its own `git rev-parse origin/main` and refuses to deploy unless *that* commit carries a green `gate`.
- **Not filtered on Deploy Gate's conclusion.** That conclusion says whether the gate job executed, not what verdict it posted, and this workflow re-reads the `gate` status itself. A conclusion filter would only add a way to miss a reconcile.
- **The age check runs after the deploy, `if: always()`.** It is a diagnostic about the workflow's own health; running it first would let a GitHub API hiccup stop the reconcile it exists to protect. `always()` is what makes it fire on the runs that matter — the ones that declined.
- **Direction of failure.** A run counts as reconciled *iff* its deploy step concluded `success`. `skipped` is the declined run this exists to catch; `failure` is a reconcile that did not happen. Every unreadable, missing or truncated case resolves to `STALE` or `UNKNOWN`, never to healthy — the unmatched case meaning HEALTHY is the defect being removed.

## Validation

Verified against **live GitHub data**, not fixtures:

- Run `30975310865` — the declined run from the report — reads `job=success, deployStep=skipped → reconciled=false`.
- Run `30978410145` — the manual recovery — reads `reconciled=true`.
- `node scripts/check-railway-reconcile-age.mjs` reports `Fleet last reconciled 0.4h ago (run 30978410145)`, exit 0.
- `--max-age-hours 0.1` reports `::error::The fleet has not been reconciled for 0.4h …`, exit 1.

Tests:

- New `tests/railway-reconcile-age.test.mjs` (14 assertions) with an injected clock — no `Date.now()` seeding, so the boundary cases are stable.
- Extended `tests/railway-deploy-trigger-workflow.test.mjs` with four workflow-shape guards, all written failing first.
- **Mutation-tested:** all seven mutants of the new guards are killed (`skipped` counting as reconciled, never concluding STALE, boundary flipped to inclusive, unclamped negative age, unreadable payload reading healthy, window read from list order, one unreadable record collapsing the window). The first two fixtures I wrote did *not* kill their mutants and were strengthened.
- `npx tsx --test tests/railway-*.test.mjs tests/railway-*.test.mts` → 233 pass, 0 fail.
- `npm run typecheck`, `biome lint`, `lint:public-docs`, `lint:unicode` clean.

## Note

This unblocks #6204 (watch-path narrowing), which is explicitly blocked on a dependable reconciler. It does not itself narrow anything.

Refs #6203
