### PR TITLE
feat(company-monitoring): add bounded portfolio onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -449,10 +449,11 @@ DODO_PAYMENTS_WEBHOOK_SECRET=
 # Generate: openssl rand -hex 32
 DODO_IDENTITY_SIGNING_SECRET=
 
-# REQUIRED before enabling Company Monitoring account onboarding in a Convex
-# deployment. Missing, blank, whitespace-padded, or malformed fence
-# configuration is logged and skips account-root synchronization; authenticated
-# entitlement writes continue.
+# REQUIRED before enabling Company Monitoring feature operations in a Convex
+# deployment. Missing, blank, whitespace-padded, or malformed owner-fence
+# configuration fails closed: Company Monitoring provisioning and terminal
+# operations throw. Entitlement writes are independent and continue because
+# they perform no Company Monitoring work.
 # HMAC key for the Company Monitoring owner fence (account tombstones).
 # Store this and DODO_IDENTITY_SIGNING_SECRET as independent secret-manager
 # entries; never reuse one value for both. The fence must stay discoverable

--- a/.env.example
+++ b/.env.example
@@ -449,21 +449,29 @@ DODO_PAYMENTS_WEBHOOK_SECRET=
 # Generate: openssl rand -hex 32
 DODO_IDENTITY_SIGNING_SECRET=
 
+# REQUIRED before enabling Company Monitoring account onboarding in a Convex
+# deployment. Missing, blank, whitespace-padded, or malformed fence
+# configuration is logged and skips account-root synchronization; authenticated
+# entitlement writes continue.
 # HMAC key for the Company Monitoring owner fence (account tombstones).
-# SEPARATE from DODO_IDENTITY_SIGNING_SECRET — never reuse the same value.
-# The fence must stay discoverable forever so a deleted owner can never be
-# re-provisioned, while the checkout-signing secret above is free to rotate;
-# sharing one key would couple those two lifetimes.
-# Read only by Convex (convex/lib/identitySigning.ts) — set it in the Convex
-# dashboard environment variables, not just here.
+# Store this and DODO_IDENTITY_SIGNING_SECRET as independent secret-manager
+# entries; never reuse one value for both. The fence must stay discoverable
+# forever so a deleted owner cannot be re-provisioned while checkout-signing
+# keys rotate independently. Read only by Convex
+# (convex/lib/identitySigning.ts) — set it in the Convex dashboard environment,
+# not just here.
 # Generate: openssl rand -hex 32
 COMPANY_MONITORING_OWNER_FENCE_SECRET=
 
-# Comma-separated retired COMPANY_MONITORING_OWNER_FENCE_SECRET values that must
-# stay discoverable. Append the CURRENT value here and deploy BEFORE rotating the
-# secret above; dropping a historical key orphans the tombstones signed with it.
-# Optional — leave unset when no rotation has happened.
-COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS=
+# Optional retired-key ring. Keep the variable ABSENT, not blank, until the first
+# rotation. Thereafter use strict comma-separated secrets: no whitespace, blank
+# entries, trailing comma, or duplicate historical entries. During pre-staging,
+# the current secret may appear once; append it only once.
+# Before rotating current: pre-stage the old key here, deploy, and verify it is
+# discoverable. Wrong order can hide a deleted-owner tombstone and allow a fresh
+# entitled root; restoring history then causes persistent
+# ACCOUNT_OWNER_FENCE_CONFLICT and requires manual data repair.
+# COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS=
 
 # Dodo Payments business ID
 # Found at: https://app.dodopayments.com/ -> Settings

--- a/.env.example
+++ b/.env.example
@@ -449,6 +449,22 @@ DODO_PAYMENTS_WEBHOOK_SECRET=
 # Generate: openssl rand -hex 32
 DODO_IDENTITY_SIGNING_SECRET=
 
+# HMAC key for the Company Monitoring owner fence (account tombstones).
+# SEPARATE from DODO_IDENTITY_SIGNING_SECRET — never reuse the same value.
+# The fence must stay discoverable forever so a deleted owner can never be
+# re-provisioned, while the checkout-signing secret above is free to rotate;
+# sharing one key would couple those two lifetimes.
+# Read only by Convex (convex/lib/identitySigning.ts) — set it in the Convex
+# dashboard environment variables, not just here.
+# Generate: openssl rand -hex 32
+COMPANY_MONITORING_OWNER_FENCE_SECRET=
+
+# Comma-separated retired COMPANY_MONITORING_OWNER_FENCE_SECRET values that must
+# stay discoverable. Append the CURRENT value here and deploy BEFORE rotating the
+# secret above; dropping a historical key orphans the tombstones signed with it.
+# Optional — leave unset when no rotation has happened.
+COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS=
+
 # Dodo Payments business ID
 # Found at: https://app.dodopayments.com/ -> Settings
 DODO_BUSINESS_ID=

--- a/api/_user-api-key.js
+++ b/api/_user-api-key.js
@@ -16,6 +16,9 @@ const RATE_LIMIT_REDIS_TIMEOUT_MS = 1_000;
 const USER_KEY_CACHE_TTL_SECONDS = 60;
 const USER_KEY_NEGATIVE_CACHE_TTL_SECONDS = 60;
 const USER_KEY_CACHE_PREFIX = 'user-api-key:';
+// Self-contained Edge entry: keep this local mirror pinned by API-key and
+// Company Monitoring contract tests rather than importing TypeScript here.
+const COMPANY_MONITORING_SCOPES = new Set(['company_monitoring:read', 'company_monitoring:write']);
 const BOOTSTRAP_USER_KEY_NEGATIVE_CACHE_PREFIX = 'bootstrap-user-api-key-invalid:';
 const ENTITLEMENT_CACHE_TTL_SECONDS = 900;
 // Mirrors server/_shared/entitlement-check.ts (this .js file cannot import the
@@ -43,6 +46,24 @@ function getServerRedisKeyPrefix() {
 
 function userApiKeyCacheKey(keyHash) {
   return `${getServerRedisKeyPrefix()}${USER_KEY_CACHE_PREFIX}${keyHash}`;
+}
+
+function isUserKeyResult(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  if (!Object.prototype.hasOwnProperty.call(value, 'userId')) return false;
+  if (typeof value.userId !== 'string' || value.userId.length === 0) return false;
+  if (value.scopes === undefined && value.companyMonitoringAccountId === undefined) return true;
+  if (!Array.isArray(value.scopes) || value.scopes.length === 0) return false;
+  if (typeof value.companyMonitoringAccountId !== 'string' || value.companyMonitoringAccountId.length === 0) {
+    return false;
+  }
+  return new Set(value.scopes).size === value.scopes.length &&
+    value.scopes.every((scope) => typeof scope === 'string' && COMPANY_MONITORING_SCOPES.has(scope));
+}
+
+// Generic bootstrap auth accepts only legacy, unscoped user API keys.
+function isGenericUserKeyResult(value) {
+  return value.scopes === undefined && value.companyMonitoringAccountId === undefined;
 }
 
 function bootstrapUserApiKeyNegativeCacheKey(keyHash) {
@@ -223,7 +244,10 @@ async function validateBootstrapUserApiKeyHash(keyHash) {
   const cacheKey = userApiKeyCacheKey(keyHash);
   const cached = await readCachedJson(cacheKey);
   if (cached.status === 'hit') {
-    if (cached.value && typeof cached.value === 'object' && typeof cached.value.userId === 'string' && cached.value.userId.length > 0) {
+    if (isUserKeyResult(cached.value)) {
+      if (!isGenericUserKeyResult(cached.value)) {
+        return { ok: false, status: 401, error: 'Invalid API key', reason: 'invalid' };
+      }
       return { ok: true, userId: cached.value.userId };
     }
   }
@@ -243,21 +267,38 @@ async function validateBootstrapUserApiKeyHash(keyHash) {
   }
 
   const value = result.value;
-  if (!value || typeof value !== 'object' || typeof value.userId !== 'string' || value.userId.length === 0) {
+  if (!isUserKeyResult(value)) {
     await writeCachedJson(negativeCacheKey, NEG_SENTINEL, USER_KEY_NEGATIVE_CACHE_TTL_SECONDS);
     return { ok: false, status: 401, error: 'Invalid API key', reason: 'invalid' };
   }
 
-  // Cache the full gateway-shared shape ({ userId, keyId, name }) so the
+  // Cache the full gateway-shared shape, including immutable Company
+  // Monitoring scope/account binding when present, so both validators see the
+  // same principal contract.
   // gateway's validateUserApiKey (server/_shared/user-api-key.ts) — which reads
   // and writes the same `user-api-key:<hash>` key typed as UserKeyResult — never
   // reads back a value with keyId/name undefined when bootstrap won the cache
   // race. Convex validateKeyByHash returns `id`, so map it to `keyId` here.
   await writeCachedJson(
     cacheKey,
-    { userId: value.userId, keyId: value.id, name: value.name },
+    {
+      userId: value.userId,
+      keyId: value.id,
+      name: value.name,
+      ...(value.scopes === undefined ? {} : { scopes: value.scopes }),
+      ...(value.companyMonitoringAccountId === undefined
+        ? {}
+        : { companyMonitoringAccountId: value.companyMonitoringAccountId }),
+    },
     USER_KEY_CACHE_TTL_SECONDS,
   );
+  // Company Monitoring keys are bound to an account and exact RPC scopes.
+  // Generic bootstrap callers do not enforce either constraint, so deny the
+  // principal after preserving its full positive cache entry for a future
+  // dedicated validator.
+  if (!isGenericUserKeyResult(value)) {
+    return { ok: false, status: 401, error: 'Invalid API key', reason: 'invalid' };
+  }
   return {
     ok: true,
     userId: value.userId,

--- a/api/_user-api-key.test.mjs
+++ b/api/_user-api-key.test.mjs
@@ -251,7 +251,7 @@ test('valid user key validation uses cached hash result without Convex', async (
   }, { redisCache: { [`user-api-key:${keyHash}`]: { userId: 'cached_owner' } } });
 });
 
-test('preview deploy user-key cache matches server Redis prefix for invalidation parity', async () => {
+test('preview deploy user-key cache matches the server Redis namespace', async () => {
   const keyHash = await sha256HexForTest(USER_KEY);
   const expectedCacheKey = `preview:abcdef12:user-api-key:${keyHash}`;
 

--- a/api/_user-api-key.test.mjs
+++ b/api/_user-api-key.test.mjs
@@ -166,6 +166,80 @@ test('valid user key validation posts only a SHA-256 hash to Convex', async () =
   });
 });
 
+test('fresh Company Monitoring key is denied generically but cached with its exact binding', async () => {
+  const scopedKey = uniqueUserKey();
+  const binding = {
+    id: 'key_company_monitoring',
+    userId: 'user_company_monitoring',
+    name: 'monitoring',
+    scopes: ['company_monitoring:read', 'company_monitoring:write'],
+    companyMonitoringAccountId: 'cm_account_01K1A2B3C4D5E6F7G8H9J0K1M2',
+  };
+  await withMockedConvex(async (calls) => {
+    const result = await validateBootstrapUserApiKey(scopedKey);
+    assert.deepEqual(result, {
+      ok: false,
+      status: 401,
+      error: 'Invalid API key',
+      reason: 'invalid',
+    });
+    const cacheWrite = calls.find((call) => call.url.startsWith('https://upstash.test') && call.body.includes('"SET"'));
+    assert.ok(cacheWrite);
+    const setCommand = JSON.parse(cacheWrite.body).find((cmd) => cmd[0] === 'SET');
+    assert.deepEqual(JSON.parse(setCommand[2]), {
+      userId: binding.userId,
+      keyId: binding.id,
+      name: binding.name,
+      scopes: binding.scopes,
+      companyMonitoringAccountId: binding.companyMonitoringAccountId,
+    });
+  }, { validateResponse: binding });
+});
+
+test('warm cached Company Monitoring principal is denied without Convex or negative-cache writes', async () => {
+  const scopedKey = uniqueUserKey();
+  const keyHash = await sha256HexForTest(scopedKey);
+  const cachedPrincipal = {
+    userId: 'user_company_monitoring',
+    keyId: 'key_company_monitoring',
+    name: 'monitoring',
+    scopes: ['company_monitoring:read', 'company_monitoring:write'],
+    companyMonitoringAccountId: 'cm_account_01K1A2B3C4D5E6F7G8H9J0K1M2',
+  };
+
+  await withMockedConvex(async (calls) => {
+    const result = await validateBootstrapUserApiKey(scopedKey);
+
+    assert.deepEqual(result, {
+      ok: false,
+      status: 401,
+      error: 'Invalid API key',
+      reason: 'invalid',
+    });
+    assert.equal(calls.some((call) => call.url.endsWith('/api/internal-validate-api-key')), false);
+    assert.equal(
+      calls.some((call) => call.url.startsWith('https://upstash.test') && call.body.includes('"SET"')),
+      false,
+    );
+  }, { redisCache: { [`user-api-key:${keyHash}`]: cachedPrincipal } });
+});
+
+test('ownerless Company Monitoring scope payload is not cached or authenticated', async () => {
+  const scopedKey = uniqueUserKey();
+  await withMockedConvex(async (calls) => {
+    const result = await validateBootstrapUserApiKey(scopedKey);
+    assert.equal(result.ok, false);
+    assert.equal(result.status, 401);
+    assert.equal(calls.some((call) => call.body.includes('"SET"') && call.body.includes('user-api-key:')), false);
+  }, {
+    validateResponse: {
+      id: 'ownerless',
+      userId: 'user_company_monitoring',
+      scopes: ['company_monitoring:read'],
+    },
+  });
+});
+
 test('valid user key validation uses cached hash result without Convex', async () => {
   const keyHash = await sha256HexForTest(USER_KEY);
   await withMockedConvex(async (calls) => {

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -2094,6 +2094,17 @@ describe("payments stuck-pending reconciliation", () => {
       /crons\.interval\(\s*"payments-stuck-pending-reconciliation",\s*\{\s*hours:\s*6\s*\}/,
     );
   });
+
+  test("registers Company Monitoring recovery crons with their exact hourly bindings", () => {
+    const source = readFileSync("convex/crons.ts", "utf8");
+
+    expect(source).toMatch(
+      /crons\.hourly\(\s*"company-monitoring-stalled-purge-reaper",\s*\{\s*minuteUTC:\s*37\s*\},\s*internal\.companyMonitoring\.accounts\.reapStalledAccountPurges,\s*\{\s*\},?\s*\);/,
+    );
+    expect(source).toMatch(
+      /crons\.hourly\(\s*"company-monitoring-entitlement-reconciler",\s*\{\s*minuteUTC:\s*47\s*\},\s*internal\.companyMonitoring\.accounts\.reconcileAccountEntitlements,\s*\{\s*\},?\s*\);/,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
+++ b/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
@@ -14,6 +14,7 @@ import {
   company,
   FUTURE,
   grant,
+  grantProvisioned,
   installCompanyMonitoringTestEnvironment,
   INTERMEDIATE_OWNER_FENCE_SECRET,
   modules,
@@ -31,56 +32,150 @@ import {
 installCompanyMonitoringTestEnvironment();
 
 describe("Company Monitoring account lifecycle", () => {
+  // #6256 acceptance criterion, proven by ablation rather than by asserting an
+  // absence: with the fence secret deleted, ANY Company Monitoring work on this
+  // path would throw. The grant succeeding is positive evidence that the
+  // entitlement write never reached Company Monitoring at all.
   test.each([
-    ["missing fence secret", () => {
-      delete process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET;
+    ["grantComplimentaryEntitlement", async (t: ReturnType<typeof convexTest>) => {
+      await grant(t, OWNER_A);
     }],
-    ["malformed fence keyring", () => {
-      process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = `${TEST_OWNER_FENCE_SECRET},`;
+    ["a Dodo subscription webhook", async (t: ReturnType<typeof convexTest>) => {
+      await t.run(async (ctx) => {
+        await ctx.db.insert("productPlans", {
+          dodoProductId: "pdt-decoupled",
+          planKey: "pro_monthly",
+          displayName: "Pro Monthly",
+          isActive: true,
+        });
+      });
+      await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+        webhookId: "wh-decoupled",
+        eventType: "subscription.active",
+        rawPayload: {
+          type: "subscription.active",
+          business_id: "biz-test",
+          timestamp: new Date(NOW).toISOString(),
+          data: {
+            payload_type: "Subscription",
+            subscription_id: "sub-decoupled",
+            product_id: "pdt-decoupled",
+            status: "active",
+            previous_billing_date: new Date(NOW - 1000).toISOString(),
+            next_billing_date: new Date(FUTURE).toISOString(),
+            customer: { customer_id: "cust-decoupled", email: "owner@example.com" },
+            // Unsigned wm_user_id is deliberately ignored by attribution, so
+            // the event would land unattributed and write no entitlement.
+            metadata: {
+              wm_user_id: OWNER_A,
+              wm_user_id_sig: await signUserId(OWNER_A),
+            },
+          },
+        },
+        timestamp: NOW,
+      });
     }],
   ])(
-    "a %s degrades Company Monitoring instead of rolling back the entitlement write",
-    async (_caseName, breakConfig) => {
+    "%s performs no Company Monitoring work for a user with no root",
+    async (_caseName, writeEntitlement) => {
       const t = convexTest(schema, modules);
-      const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-      breakConfig();
+      delete process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET;
 
-      // The entitlement write must survive: this runs inside the Dodo webhook
-      // transaction, and a config fault fails every retry identically.
-      await expect(grant(t, OWNER_A)).resolves.not.toThrow();
+      await expect(writeEntitlement(t)).resolves.not.toThrow();
 
       const state = await t.run(async (ctx) => ({
         entitlements: await ctx.db.query("entitlements").collect(),
         accounts: await ctx.db.query("companyMonitoringAccounts").collect(),
       }));
-      expect(state.entitlements).toHaveLength(1);
+      expect(state.entitlements.length).toBeGreaterThan(0);
       expect(state.accounts).toEqual([]);
-      expect(consoleError).toHaveBeenCalledWith(
-        expect.stringContaining("owner fence unavailable"),
-      );
     },
   );
 
-  test("the account root converges on the next entitlement write once config is repaired", async () => {
+  test("first authenticated use provisions the root the entitlement write did not", async () => {
     const t = convexTest(schema, modules);
-    vi.spyOn(console, "error").mockImplementation(() => undefined);
-    delete process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET;
-
     await grant(t, OWNER_A);
     expect(await accountFor(t, OWNER_A)).toBeNull();
 
-    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = TEST_OWNER_FENCE_SECRET;
-    await t.mutation(CM.accounts.syncStoredEntitlement, { userId: OWNER_A });
+    const created = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "first-use",
+      company: company("First Use", "first-use"),
+    });
+
+    expect(created.status).toBe("created");
     expect(await accountFor(t, OWNER_A)).toMatchObject({
       ownerUserId: OWNER_A,
       lifecycle: "entitled",
       lifecycleSequence: 1,
+      companyCount: 1,
+    });
+  });
+
+  test("first use cannot resurrect a deleted owner", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    await t.mutation(CM.accounts.markOwnerDeleted, { ownerUserId: OWNER_A });
+
+    // Re-entitled, then tries to use the feature: the tombstone must still win.
+    await grant(t, OWNER_A);
+    await expect(
+      t.mutation(CM.companies.createCompanyForOwner, {
+        ownerUserId: OWNER_A,
+        clientRequestId: "post-deletion",
+        company: company("Post Deletion", "post-deletion"),
+      }),
+    ).rejects.toThrow(/COMPANY_MONITORING_ACCESS_DENIED/);
+    expect(await accountFor(t, OWNER_A)).toBeNull();
+  });
+
+  test("the reconciler lapses an entitled root whose entitlement expired", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ lifecycle: "entitled" });
+
+    // Expire the entitlement WITHOUT driving the sync — exactly what happens now
+    // that billing no longer pushes into Company Monitoring.
+    await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", OWNER_A))
+        .unique();
+      await ctx.db.patch(row!._id, { planKey: "free", validUntil: NOW - 1 });
+    });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ lifecycle: "entitled" });
+
+    // The root must age past the recheck window before the reconciler sees it.
+    vi.setSystemTime(NOW + 2 * 60 * 60 * 1000);
+    const result = await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
+
+    expect(result).toMatchObject({ scanned: 1, lapsed: 1 });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitlement_lapsed",
+      purgePhase: "pending",
+    });
+  });
+
+  test("the reconciler leaves a still-entitled root alone", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const before = await accountFor(t, OWNER_A);
+
+    vi.setSystemTime(NOW + 2 * 60 * 60 * 1000);
+    const result = await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
+
+    expect(result).toMatchObject({ scanned: 1, lapsed: 0 });
+    const after = await accountFor(t, OWNER_A);
+    expect(after).toMatchObject({
+      lifecycle: "entitled",
+      lifecycleSequence: before!.lifecycleSequence,
+      purgePhase: "none",
     });
   });
 
   test("explicit owner deletion still fails loudly on a misconfigured fence", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     delete process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET;
 
     // terminalize keeps the throwing accessor: deletion is an explicit
@@ -93,7 +188,7 @@ describe("Company Monitoring account lifecycle", () => {
   test("authenticated grants create one immutable root and semantic replays do not advance sequence", async () => {
     const t = convexTest(schema, modules);
 
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const first = await accountFor(t, OWNER_A);
     expect(first).toMatchObject({
       ownerUserId: OWNER_A,
@@ -138,14 +233,26 @@ describe("Company Monitoring account lifecycle", () => {
       api.payments.billing.claimSubscription,
       { anonId, claimToken },
     );
+
+    // Claiming moves the entitlement to the real owner but provisions nothing:
+    // it is still an entitlement write (#6256). The anon id must never gain a
+    // root either, before or after the claim.
+    expect(await accountFor(t, realOwner)).toBeNull();
+    expect(await accountFor(t, anonId)).toBeNull();
+
+    // The claimed owner can then provision on first use — the anon id cannot,
+    // because ANON_ID_V4_REGEX still fences it out of the state machine.
+    await t.mutation(CM.accounts.syncStoredEntitlement, { userId: realOwner });
     expect(await accountFor(t, realOwner)).toMatchObject({
       ownerUserId: realOwner,
       lifecycle: "entitled",
       lifecycleSequence: 1,
     });
+    await t.mutation(CM.accounts.syncStoredEntitlement, { userId: anonId });
+    expect(await accountFor(t, anonId)).toBeNull();
   });
 
-  test("dispute loss recomputes the canonical root synchronously", async () => {
+  test("dispute loss lapses the root through the reconciler, not the webhook", async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {
       await ctx.db.insert("subscriptions", {
@@ -188,6 +295,16 @@ describe("Company Monitoring account lifecycle", () => {
       },
       timestamp: NOW + 1000,
     });
+
+    // The webhook revokes the entitlement but must not touch the root (#6256).
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitled",
+      lifecycleSequence: 1,
+    });
+
+    // The reconciler is what converges it.
+    vi.setSystemTime(NOW + 2 * 60 * 60 * 1000);
+    await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
     expect(await accountFor(t, OWNER_A)).toMatchObject({
       lifecycle: "entitlement_lapsed",
       lifecycleSequence: 2,
@@ -197,7 +314,7 @@ describe("Company Monitoring account lifecycle", () => {
 
   test("lapse can reactivate before destructive purge but not after owner deletion", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const original = await accountFor(t, OWNER_A);
 
     await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
@@ -256,7 +373,7 @@ describe("Company Monitoring account lifecycle", () => {
 
   test("account deletion is the same durable terminal fence", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const original = await accountFor(t, OWNER_A);
     await t.mutation(CM.accounts.markAccountDeleted, {
       ownerAccountId: original!.logicalAccountId,
@@ -278,7 +395,7 @@ describe("Company Monitoring account lifecycle", () => {
 
   test("re-entitlement during destructive purge waits for the fenced generation to finish", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     await t.mutation(CM.companies.createCompanyForOwner, {
       ownerUserId: OWNER_A,
       clientRequestId: "before-purge",
@@ -331,7 +448,7 @@ describe("Company Monitoring account lifecycle", () => {
 
   test("re-entitlement after completed destructive purge restores a clean reusable root", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const original = await accountFor(t, OWNER_A);
     const removedByPurge = await t.mutation(CM.companies.createCompanyForOwner, {
       ownerUserId: OWNER_A,
@@ -390,7 +507,7 @@ describe("Company Monitoring account lifecycle", () => {
 
   test("dense destructive purge continues across the bounded 93-company page", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const root = await accountFor(t, OWNER_A);
     await t.run(async (ctx) => {
       for (let i = 0; i < 94; i += 1) {
@@ -491,7 +608,7 @@ describe("Company Monitoring account lifecycle", () => {
   test("dedicated owner-fence rotation finds and migrates an old nonterminal root", async () => {
     const t = convexTest(schema, modules);
     process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = OLD_OWNER_FENCE_SECRET;
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const oldRoot = await accountFor(t, OWNER_A);
 
     process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = NEW_OWNER_FENCE_SECRET;
@@ -518,14 +635,14 @@ describe("Company Monitoring account lifecycle", () => {
   test("dedicated owner-fence rotation keeps two historical tombstones discoverable in candidate order", async () => {
     const t = convexTest(schema, modules);
     process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = OLD_OWNER_FENCE_SECRET;
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const oldestRoot = await accountFor(t, OWNER_A);
     const oldestFenceForOwnerA = await signCompanyMonitoringOwnerFence(OWNER_A);
     await t.mutation(CM.accounts.markOwnerDeleted, { ownerUserId: OWNER_A });
 
     process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = INTERMEDIATE_OWNER_FENCE_SECRET;
     const intermediateFenceForOwnerA = await signCompanyMonitoringOwnerFence(OWNER_A);
-    await grant(t, OWNER_B);
+    await grantProvisioned(t, OWNER_B);
     const intermediateRoot = await accountFor(t, OWNER_B);
     await t.mutation(CM.accounts.markOwnerDeleted, { ownerUserId: OWNER_B });
 
@@ -567,7 +684,7 @@ describe("Company Monitoring account lifecycle", () => {
   test("dedicated owner-fence rotation rejects split roots across current and previous keys", async () => {
     const t = convexTest(schema, modules);
     process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = OLD_OWNER_FENCE_SECRET;
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
 
     process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = NEW_OWNER_FENCE_SECRET;
     process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = OLD_OWNER_FENCE_SECRET;

--- a/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
+++ b/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
@@ -399,6 +399,64 @@ describe("Company Monitoring account lifecycle", () => {
     expect(remaining).toEqual([]);
   });
 
+  test("the reconciler reserves room for a renewed lapsed root when entitled rows fill the batch", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+
+    // Renew the canonical entitlement without pushing the change into Company
+    // Monitoring. This stale lapsed root must compete with a full old-style
+    // first bucket during the next scheduled reconciliation tick.
+    await t.run(async (ctx) => {
+      const entitlement = await ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", OWNER_A))
+        .unique();
+      await ctx.db.patch(entitlement!._id, {
+        planKey: "api_starter",
+        features: getFeaturesForPlan("api_starter"),
+        validUntil: FUTURE,
+      });
+    });
+
+    const fences = await Promise.all(
+      Array.from({ length: 50 }, (_, i) =>
+        signCompanyMonitoringOwnerFence(`user_mixed_batch_${i}`),
+      ),
+    );
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 50; i += 1) {
+        await ctx.db.insert("companyMonitoringAccounts", {
+          logicalAccountId: `cm_account_mixed_${String(i).padStart(20, "0")}`,
+          ownerUserId: `user_mixed_batch_${i}`,
+          ownerFenceHash: fences[i]!,
+          lifecycle: "entitled",
+          lifecycleSequence: 1,
+          companyCount: 0,
+          companyLimit: 500,
+          snapshotGeneration: 0,
+          purgeGeneration: 0,
+          purgePhase: "none",
+          destructivePurgeStarted: false,
+          pendingReactivation: false,
+          createdAt: NOW,
+          updatedAt: NOW,
+        });
+      }
+    });
+
+    vi.setSystemTime(NOW + 2 * 60 * 60 * 1000);
+    const result = await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
+    expect(result).toEqual({ scanned: 50, scheduled: 50 });
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
+
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitled",
+      purgePhase: "none",
+    });
+  });
+
   test("the reconciler leaves a still-entitled root alone", async () => {
     const t = convexTest(schema, modules);
     await grantProvisioned(t, OWNER_A);
@@ -877,6 +935,60 @@ describe("Company Monitoring account lifecycle", () => {
         .withIndex("by_ownerFenceHash", (q) => q.eq("ownerFenceHash", oldRoot!.ownerFenceHash))
         .unique()
     )).toBeNull();
+  });
+
+  test("scheduled sync migrates a renewed lapsed root when old fence history was dropped", async () => {
+    const t = convexTest(schema, modules);
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = OLD_OWNER_FENCE_SECRET;
+    await grantProvisioned(t, OWNER_A);
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const oldRoot = await accountFor(t, OWNER_A);
+
+    // The billing renewal only updates canonical entitlement state. Rotate the
+    // current key without retaining history before the reconciler schedules the
+    // per-owner sync.
+    await t.run(async (ctx) => {
+      const entitlement = await ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", OWNER_A))
+        .unique();
+      await ctx.db.patch(entitlement!._id, {
+        planKey: "api_starter",
+        features: getFeaturesForPlan("api_starter"),
+        validUntil: FUTURE,
+      });
+    });
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = NEW_OWNER_FENCE_SECRET;
+    delete process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS;
+    const currentFenceHash = await signCompanyMonitoringOwnerFence(OWNER_A);
+
+    vi.setSystemTime(NOW + 2 * 60 * 60 * 1000);
+    expect(await t.mutation(CM.accounts.reconcileAccountEntitlements, {}))
+      .toEqual({ scanned: 1, scheduled: 1 });
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
+
+    const state = await t.run(async (ctx) => ({
+      roots: await ctx.db.query("companyMonitoringAccounts").collect(),
+      current: await ctx.db
+        .query("companyMonitoringAccounts")
+        .withIndex("by_ownerFenceHash", (q) => q.eq("ownerFenceHash", currentFenceHash))
+        .unique(),
+      old: await ctx.db
+        .query("companyMonitoringAccounts")
+        .withIndex("by_ownerFenceHash", (q) => q.eq("ownerFenceHash", oldRoot!.ownerFenceHash))
+        .unique(),
+    }));
+    expect(state.roots).toHaveLength(1);
+    expect(state.current).toMatchObject({
+      _id: oldRoot?._id,
+      logicalAccountId: oldRoot?.logicalAccountId,
+      ownerUserId: OWNER_A,
+      ownerFenceHash: currentFenceHash,
+      lifecycle: "entitled",
+      purgePhase: "none",
+    });
+    expect(state.old).toBeNull();
   });
 
   test("dedicated owner-fence rotation keeps two historical tombstones discoverable in candidate order", async () => {

--- a/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
+++ b/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
@@ -1,0 +1,534 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import { api, internal } from "../_generated/api";
+import { getFeaturesForPlan } from "../lib/entitlements";
+import {
+  companyMonitoringOwnerFenceCandidates,
+  signAnonClaimToken,
+  signCompanyMonitoringOwnerFence,
+} from "../lib/identitySigning";
+import {
+  accountFor,
+  CM,
+  company,
+  FUTURE,
+  grant,
+  installCompanyMonitoringTestEnvironment,
+  INTERMEDIATE_SIGNING_SECRET,
+  modules,
+  NEW_SIGNING_SECRET,
+  NOW,
+  OLD_SIGNING_SECRET,
+  OWNER_A,
+  OWNER_B,
+  schema,
+  setStoredEntitlement,
+} from "./companyMonitoringTestHelpers";
+
+installCompanyMonitoringTestEnvironment();
+
+describe("Company Monitoring account lifecycle", () => {
+  test("authenticated grants create one immutable root and semantic replays do not advance sequence", async () => {
+    const t = convexTest(schema, modules);
+
+    await grant(t, OWNER_A);
+    const first = await accountFor(t, OWNER_A);
+    expect(first).toMatchObject({
+      ownerUserId: OWNER_A,
+      lifecycle: "entitled",
+      lifecycleSequence: 1,
+      companyCount: 0,
+      companyLimit: 500,
+    });
+
+    await t.mutation(CM.accounts.syncStoredEntitlement, { userId: OWNER_A });
+    const replay = await accountFor(t, OWNER_A);
+    expect(replay?._id).toBe(first?._id);
+    expect(replay?.logicalAccountId).toBe(first?.logicalAccountId);
+    expect(replay?.ownerFenceHash).toBe(first?.ownerFenceHash);
+    expect(replay?.lifecycleSequence).toBe(1);
+  });
+
+  test("anonymous entitlement rows provision nothing until a proven authenticated claim", async () => {
+    const t = convexTest(schema, modules);
+    const anonId = "11111111-1111-4111-8111-111111111111";
+    await setStoredEntitlement(t, anonId, "pro_monthly", FUTURE);
+
+    const roots = await t.run(async (ctx) => ctx.db.query("companyMonitoringAccounts").collect());
+    expect(roots).toEqual([]);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: anonId,
+        dodoSubscriptionId: "sub-company-monitoring-anon",
+        dodoProductId: "pdt-company-monitoring-anon",
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - 1000,
+        currentPeriodEnd: FUTURE,
+        rawPayload: {},
+        updatedAt: NOW,
+      });
+    });
+    const claimToken = await signAnonClaimToken(anonId);
+    const realOwner = "user_company_monitoring_claimed";
+    await t.withIdentity({ subject: realOwner, tokenIdentifier: `clerk|${realOwner}` }).mutation(
+      api.payments.billing.claimSubscription,
+      { anonId, claimToken },
+    );
+    expect(await accountFor(t, realOwner)).toMatchObject({
+      ownerUserId: realOwner,
+      lifecycle: "entitled",
+      lifecycleSequence: 1,
+    });
+  });
+
+  test("dispute loss recomputes the canonical root synchronously", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: OWNER_A,
+        dodoSubscriptionId: "sub-company-monitoring-disputed",
+        dodoProductId: "pdt-company-monitoring-disputed",
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - 1000,
+        currentPeriodEnd: FUTURE,
+        rawPayload: {},
+        updatedAt: NOW - 1000,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: OWNER_A,
+        planKey: "pro_monthly",
+        features: getFeaturesForPlan("pro_monthly"),
+        validUntil: FUTURE,
+        updatedAt: NOW - 1000,
+      });
+    });
+    await t.mutation(CM.accounts.syncStoredEntitlement, { userId: OWNER_A });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh-company-monitoring-dispute-lost",
+      eventType: "dispute.lost",
+      rawPayload: {
+        type: "dispute.lost",
+        business_id: "biz-test",
+        timestamp: new Date(NOW + 1000).toISOString(),
+        data: {
+          payload_type: "Payment",
+          payment_id: "pay-company-monitoring-disputed",
+          subscription_id: "sub-company-monitoring-disputed",
+          total_amount: 1000,
+          currency: "USD",
+          customer: { customer_id: "cust-company-monitoring", email: "owner@example.com" },
+          metadata: { wm_user_id: OWNER_A },
+        },
+      },
+      timestamp: NOW + 1000,
+    });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitlement_lapsed",
+      lifecycleSequence: 2,
+      purgePhase: "pending",
+    });
+  });
+
+  test("lapse can reactivate before destructive purge but not after owner deletion", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    const original = await accountFor(t, OWNER_A);
+
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const lapsed = await accountFor(t, OWNER_A);
+    expect(lapsed).toMatchObject({
+      lifecycle: "entitlement_lapsed",
+      lifecycleSequence: 2,
+      destructivePurgeStarted: false,
+    });
+
+    await setStoredEntitlement(t, OWNER_A, "api_starter", FUTURE, NOW - 10_000);
+    const reactivated = await accountFor(t, OWNER_A);
+    expect(reactivated).toMatchObject({
+      _id: original?._id,
+      lifecycle: "entitled",
+      lifecycleSequence: 3,
+      destructivePurgeStarted: false,
+      purgeGeneration: lapsed!.purgeGeneration + 1,
+    });
+    const stalePurge = await t.mutation(CM.accounts.advanceAccountPurge, {
+      ownerFenceHash: lapsed!.ownerFenceHash,
+      purgeGeneration: lapsed!.purgeGeneration,
+    });
+    expect(stalePurge).toEqual({ status: "stale" });
+    expect(await accountFor(t, OWNER_A)).toEqual(reactivated);
+
+    await t.mutation(CM.accounts.markOwnerDeleted, { ownerUserId: OWNER_A });
+    const terminal = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringAccounts")
+        .withIndex("by_ownerFenceHash", (q) => q.eq("ownerFenceHash", original!.ownerFenceHash))
+        .unique(),
+    );
+    expect(terminal).toMatchObject({
+      _id: original?._id,
+      lifecycle: "denied",
+      terminalReason: "owner_deleted",
+      lifecycleSequence: 4,
+    });
+    expect(terminal?.ownerUserId).toBeUndefined();
+
+    await setStoredEntitlement(t, OWNER_A, "api_starter", FUTURE + 1);
+    const afterReplay = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringAccounts")
+        .withIndex("by_ownerFenceHash", (q) => q.eq("ownerFenceHash", original!.ownerFenceHash))
+        .unique(),
+    );
+    expect(afterReplay).toMatchObject({
+      _id: original?._id,
+      lifecycle: "denied",
+      terminalReason: "owner_deleted",
+      lifecycleSequence: 4,
+    });
+  });
+
+  test("account deletion is the same durable terminal fence", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    const original = await accountFor(t, OWNER_A);
+    await t.mutation(CM.accounts.markAccountDeleted, {
+      ownerAccountId: original!.logicalAccountId,
+    });
+    await setStoredEntitlement(t, OWNER_A, "api_starter", FUTURE + 10_000);
+    const terminal = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringAccounts")
+        .withIndex("by_ownerFenceHash", (q) => q.eq("ownerFenceHash", original!.ownerFenceHash))
+        .unique(),
+    );
+    expect(terminal).toMatchObject({
+      _id: original?._id,
+      lifecycle: "denied",
+      terminalReason: "account_deleted",
+      lifecycleSequence: 2,
+    });
+  });
+
+  test("re-entitlement during destructive purge waits for the fenced generation to finish", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "before-purge",
+      company: company("Purge Me", "purge-me"),
+    });
+
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const lapsed = await accountFor(t, OWNER_A);
+    await t.mutation(CM.accounts.advanceAccountPurge, {
+      ownerFenceHash: lapsed!.ownerFenceHash,
+      purgeGeneration: lapsed!.purgeGeneration,
+    });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ destructivePurgeStarted: true });
+
+    await setStoredEntitlement(t, OWNER_A, "api_starter", FUTURE);
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitlement_lapsed",
+      pendingReactivation: true,
+    });
+
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitlement_lapsed",
+      destructivePurgeStarted: true,
+      pendingReactivation: false,
+      purgeGeneration: lapsed!.purgeGeneration,
+    });
+    await setStoredEntitlement(t, OWNER_A, "api_starter", FUTURE);
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitlement_lapsed",
+      destructivePurgeStarted: true,
+      pendingReactivation: true,
+      purgeGeneration: lapsed!.purgeGeneration,
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      await t.mutation(CM.accounts.advanceAccountPurge, {
+        ownerFenceHash: lapsed!.ownerFenceHash,
+        purgeGeneration: lapsed!.purgeGeneration,
+      });
+    }
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitled",
+      companyCount: 0,
+      pendingReactivation: false,
+      purgePhase: "none",
+    });
+  });
+
+  test("re-entitlement after completed destructive purge restores a clean reusable root", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    const original = await accountFor(t, OWNER_A);
+    const removedByPurge = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "completed-purge-old-company",
+      company: company("Completed Purge Old Company", "completed-purge-old"),
+    });
+
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const lapsed = await accountFor(t, OWNER_A);
+    const purgeArgs = {
+      ownerFenceHash: lapsed!.ownerFenceHash,
+      purgeGeneration: lapsed!.purgeGeneration,
+    };
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "started",
+    });
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "finalizing",
+    });
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "complete",
+    });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      _id: original?._id,
+      lifecycle: "entitlement_lapsed",
+      companyCount: 0,
+      purgePhase: "complete",
+      destructivePurgeStarted: true,
+    });
+
+    await setStoredEntitlement(t, OWNER_A, "api_starter", FUTURE);
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      _id: original?._id,
+      lifecycle: "entitled",
+      companyCount: 0,
+      purgePhase: "none",
+      destructivePurgeStarted: false,
+      pendingReactivation: false,
+    });
+    const replacement = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "completed-purge-new-company",
+      company: company("Completed Purge New Company", "completed-purge-new"),
+    });
+    expect(replacement.status).toBe("created");
+    expect(replacement.companyId).not.toBe(removedByPurge.companyId);
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ companyCount: 1 });
+    expect(await t.query(CM.companies.listCompaniesForOwner, { ownerUserId: OWNER_A })).toEqual([
+      expect.objectContaining({
+        companyId: replacement.companyId,
+        name: "Completed Purge New Company",
+      }),
+    ]);
+  });
+
+  test("dense destructive purge continues across the bounded 93-company page", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    const root = await accountFor(t, OWNER_A);
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 94; i += 1) {
+        const companyId = `cm_company_${String(i).padStart(26, "0")}`;
+        await ctx.db.insert("companyMonitoringCompanies", {
+          ownerAccountId: root!.logicalAccountId,
+          companyId,
+          name: `Paged ${i}`,
+          sortName: `paged ${String(i).padStart(3, "0")}`,
+          domicileCountry: "US",
+          lifecycle: "active",
+          coverageState: "awaiting_first_scan",
+          observationState: "unknown",
+          snapshotGeneration: 1,
+          purgeGeneration: 0,
+          purgePhase: "none",
+          createdAt: NOW,
+          updatedAt: NOW,
+        });
+        for (let claimOrdinal = 0; claimOrdinal < 81; claimOrdinal += 1) {
+          const claimNumber = i * 81 + claimOrdinal;
+          await ctx.db.insert("companyMonitoringClaims", {
+            ownerAccountId: root!.logicalAccountId,
+            companyId,
+            claimId: `cm_claim_${String(claimNumber).padStart(26, "0")}`,
+            type: "alias",
+            value: `Dense claim ${i}-${claimOrdinal}`,
+            provenance: "customer",
+            trustState: "unverified",
+            createdAt: NOW,
+            updatedAt: NOW,
+          });
+        }
+      }
+      await ctx.db.patch(root!._id, { companyCount: 94 });
+    });
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const lapsed = await accountFor(t, OWNER_A);
+    const purgeArgs = {
+      ownerFenceHash: lapsed!.ownerFenceHash,
+      purgeGeneration: lapsed!.purgeGeneration,
+    };
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "started",
+    });
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "companies",
+    });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      purgePhase: "companies",
+      destructivePurgeStarted: true,
+    });
+    const afterFirstPage = await t.run(async (ctx) => ({
+      companies: await ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) => q.eq("ownerAccountId", root!.logicalAccountId))
+        .collect(),
+      claims: await ctx.db.query("companyMonitoringClaims").collect(),
+    }));
+    expect(afterFirstPage.companies.filter((row) => row.purgePhase === "complete")).toHaveLength(93);
+    expect(afterFirstPage.companies.filter((row) => row.purgePhase === "none")).toHaveLength(1);
+    expect(afterFirstPage.claims).toHaveLength(81);
+
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "finalizing",
+    });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ purgePhase: "finalizing" });
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "complete",
+    });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitlement_lapsed",
+      purgePhase: "complete",
+      companyCount: 0,
+    });
+    const completed = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) => q.eq("ownerAccountId", root!.logicalAccountId))
+        .collect(),
+    );
+    expect(completed).toHaveLength(94);
+    expect(completed.every((row) => row.lifecycle === "removed" && row.purgePhase === "complete")).toBe(true);
+    expect(await t.run(async (ctx) => ctx.db.query("companyMonitoringClaims").collect())).toEqual([]);
+  }, 15_000);
+
+  test("owner-fence rotation finds and migrates an old nonterminal root", async () => {
+    const t = convexTest(schema, modules);
+    process.env.DODO_IDENTITY_SIGNING_SECRET = OLD_SIGNING_SECRET;
+    await grant(t, OWNER_A);
+    const oldRoot = await accountFor(t, OWNER_A);
+
+    process.env.DODO_IDENTITY_SIGNING_SECRET = NEW_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = OLD_SIGNING_SECRET;
+    const currentFenceHash = await signCompanyMonitoringOwnerFence(OWNER_A);
+    await t.mutation(CM.accounts.syncStoredEntitlement, { userId: OWNER_A });
+
+    const migrated = await accountFor(t, OWNER_A);
+    expect(migrated).toMatchObject({
+      _id: oldRoot?._id,
+      logicalAccountId: oldRoot?.logicalAccountId,
+      ownerFenceHash: currentFenceHash,
+      lifecycle: "entitled",
+    });
+    expect(currentFenceHash).not.toBe(oldRoot?.ownerFenceHash);
+    expect(await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringAccounts")
+        .withIndex("by_ownerFenceHash", (q) => q.eq("ownerFenceHash", oldRoot!.ownerFenceHash))
+        .unique()
+    )).toBeNull();
+  });
+
+  test("owner-fence rotation keeps two historical tombstones discoverable in candidate order", async () => {
+    const t = convexTest(schema, modules);
+    process.env.DODO_IDENTITY_SIGNING_SECRET = OLD_SIGNING_SECRET;
+    await grant(t, OWNER_A);
+    const oldestRoot = await accountFor(t, OWNER_A);
+    const oldestFenceForOwnerA = await signCompanyMonitoringOwnerFence(OWNER_A);
+    await t.mutation(CM.accounts.markOwnerDeleted, { ownerUserId: OWNER_A });
+
+    process.env.DODO_IDENTITY_SIGNING_SECRET = INTERMEDIATE_SIGNING_SECRET;
+    const intermediateFenceForOwnerA = await signCompanyMonitoringOwnerFence(OWNER_A);
+    await grant(t, OWNER_B);
+    const intermediateRoot = await accountFor(t, OWNER_B);
+    await t.mutation(CM.accounts.markOwnerDeleted, { ownerUserId: OWNER_B });
+
+    process.env.DODO_IDENTITY_SIGNING_SECRET = NEW_SIGNING_SECRET;
+    const currentFenceForOwnerA = await signCompanyMonitoringOwnerFence(OWNER_A);
+    process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS =
+      `${OLD_SIGNING_SECRET},${INTERMEDIATE_SIGNING_SECRET}`;
+    expect((await companyMonitoringOwnerFenceCandidates(OWNER_A)).all).toEqual([
+      currentFenceForOwnerA,
+      oldestFenceForOwnerA,
+      intermediateFenceForOwnerA,
+    ]);
+    await setStoredEntitlement(t, OWNER_A, "api_starter", FUTURE + 10_000);
+    await setStoredEntitlement(t, OWNER_B, "api_starter", FUTURE + 20_000);
+
+    const roots = await t.run(async (ctx) => ctx.db.query("companyMonitoringAccounts").collect());
+    expect(roots).toHaveLength(2);
+    expect(roots).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        _id: oldestRoot?._id,
+        ownerFenceHash: oldestRoot?.ownerFenceHash,
+        lifecycle: "denied",
+        terminalReason: "owner_deleted",
+      }),
+      expect.objectContaining({
+        _id: intermediateRoot?._id,
+        ownerFenceHash: intermediateRoot?.ownerFenceHash,
+        lifecycle: "denied",
+        terminalReason: "owner_deleted",
+      }),
+    ]));
+    expect(roots.every((root) => root.ownerUserId === undefined)).toBe(true);
+    expect(roots.find((root) => root._id === oldestRoot?._id)).toMatchObject({
+      lifecycle: "denied",
+      terminalReason: "owner_deleted",
+    });
+  });
+
+  test("owner-fence rotation rejects split roots across current and previous keys", async () => {
+    const t = convexTest(schema, modules);
+    process.env.DODO_IDENTITY_SIGNING_SECRET = OLD_SIGNING_SECRET;
+    await grant(t, OWNER_A);
+
+    process.env.DODO_IDENTITY_SIGNING_SECRET = NEW_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = OLD_SIGNING_SECRET;
+    const currentFenceHash = await signCompanyMonitoringOwnerFence(OWNER_A);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("companyMonitoringAccounts", {
+        logicalAccountId: "split-current-root",
+        ownerFenceHash: currentFenceHash,
+        lifecycle: "denied",
+        terminalReason: "account_deleted",
+        lifecycleSequence: 1,
+        purgeGeneration: 1,
+        purgePhase: "complete",
+        destructivePurgeStarted: true,
+        pendingReactivation: false,
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
+    });
+
+    await expect(
+      t.mutation(CM.accounts.syncStoredEntitlement, { userId: OWNER_A }),
+    ).rejects.toThrow(/ACCOUNT_OWNER_FENCE_CONFLICT/);
+  });
+
+  test.each([
+    ["empty history", ""],
+    ["blank history entry", `${OLD_SIGNING_SECRET},`],
+    ["surrounding whitespace", ` ${OLD_SIGNING_SECRET}`],
+    ["duplicate history", `${OLD_SIGNING_SECRET},${OLD_SIGNING_SECRET}`],
+    ["current key in history", `${OLD_SIGNING_SECRET},${NEW_SIGNING_SECRET}`],
+  ])("owner-fence rotation rejects %s", async (_caseName, previousSecrets) => {
+    process.env.DODO_IDENTITY_SIGNING_SECRET = NEW_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = previousSecrets;
+    await expect(signCompanyMonitoringOwnerFence(OWNER_A)).rejects.toThrow(
+      /invalid|duplicate or current key/,
+    );
+  });
+});

--- a/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
+++ b/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
@@ -64,8 +64,11 @@ describe("Company Monitoring account lifecycle", () => {
             previous_billing_date: new Date(NOW - 1000).toISOString(),
             next_billing_date: new Date(FUTURE).toISOString(),
             customer: { customer_id: "cust-decoupled", email: "owner@example.com" },
-            // Unsigned wm_user_id is deliberately ignored by attribution, so
-            // the event would land unattributed and write no entitlement.
+            // Signed so tryResolveUserId attributes the event and a REAL
+            // entitlement is written — otherwise the event lands unattributed
+            // and the assertion below would pass vacuously. The point of this
+            // case is that a genuinely attributed entitlement write still does
+            // no Company Monitoring work.
             metadata: {
               wm_user_id: OWNER_A,
               wm_user_id_sig: await signUserId(OWNER_A),
@@ -149,7 +152,9 @@ describe("Company Monitoring account lifecycle", () => {
     vi.setSystemTime(NOW + 2 * 60 * 60 * 1000);
     const result = await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
 
-    expect(result).toMatchObject({ scanned: 1, lapsed: 1 });
+    expect(result).toMatchObject({ scanned: 1, scheduled: 1 });
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
     expect(await accountFor(t, OWNER_A)).toMatchObject({
       lifecycle: "entitlement_lapsed",
       purgePhase: "pending",
@@ -207,6 +212,193 @@ describe("Company Monitoring account lifecycle", () => {
     ).rejects.toThrow();
   });
 
+  // The regression both review lenses caught. The 24h grace exists so a late
+  // renewal can land before anything is scrubbed, and its only wire into
+  // Company Monitoring was the entitlement-write call #6256 removed. Without
+  // the purge-time recheck AND the lapsed-bucket scan, a customer who paid
+  // again stays locked out and then loses their portfolio.
+  test("a renewal during the grace window restores the root and cancels the purge", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "pre-lapse",
+      company: company("Pre Lapse", "pre-lapse"),
+    });
+
+    // Renewal is late: entitlement expires and the reconciler lapses the root.
+    await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", OWNER_A))
+        .unique();
+      await ctx.db.patch(row!._id, { planKey: "free", validUntil: NOW - 1 });
+    });
+    vi.setSystemTime(NOW + 2 * 60 * 60 * 1000);
+    await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitlement_lapsed",
+      purgePhase: "pending",
+    });
+
+    // The renewal lands — a raw entitlement write, exactly as production now
+    // does it, with nothing pushing into Company Monitoring.
+    await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", OWNER_A))
+        .unique();
+      await ctx.db.patch(row!._id, {
+        planKey: "api_starter",
+        features: getFeaturesForPlan("api_starter"),
+        validUntil: NOW + 60 * 24 * 60 * 60 * 1000,
+      });
+    });
+
+    // The reconciler must restore it, not just detect lapses.
+    vi.setSystemTime(NOW + 4 * 60 * 60 * 1000);
+    await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitled",
+      purgePhase: "none",
+    });
+
+    // And the portfolio must have survived.
+    const companies = await t.query(CM.companies.listCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+    });
+    expect(companies).toHaveLength(1);
+    expect(companies[0]).toMatchObject({ name: "Pre Lapse" });
+  });
+
+  test("purge refuses to start destroying data for an owner who has paid again", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "paid-again",
+      company: company("Paid Again", "paid-again"),
+    });
+    const root = await accountFor(t, OWNER_A);
+
+    // Lapse it, then let the entitlement come back WITHOUT any reconciler run —
+    // the scheduled purge job is already armed and about to fire.
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ purgePhase: "pending" });
+    await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", OWNER_A))
+        .unique();
+      await ctx.db.patch(row!._id, {
+        planKey: "api_starter",
+        features: getFeaturesForPlan("api_starter"),
+        validUntil: NOW + 60 * 24 * 60 * 60 * 1000,
+      });
+    });
+
+    // The armed job fires after the grace deadline. It must re-derive the
+    // entitlement and refuse rather than scrub a paying customer.
+    vi.setSystemTime(NOW + 25 * 60 * 60 * 1000);
+    const lapsed = await accountFor(t, OWNER_A);
+    const result = await t.mutation(CM.accounts.advanceAccountPurge, {
+      ownerFenceHash: lapsed!.ownerFenceHash,
+      purgeGeneration: lapsed!.purgeGeneration,
+    });
+
+    expect(result).toEqual({ status: "reactivated" });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      _id: root?._id,
+      lifecycle: "entitled",
+      destructivePurgeStarted: false,
+    });
+    const surviving = await t.query(CM.companies.listCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+    });
+    expect(surviving).toHaveLength(1);
+    expect(surviving[0]).toMatchObject({ name: "Paid Again" });
+  });
+
+  test("the reconciler ignores a root that is not yet stale", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", OWNER_A))
+        .unique();
+      await ctx.db.patch(row!._id, { planKey: "free", validUntil: NOW - 1 });
+    });
+
+    // No time jump: the root was touched at NOW, so it sits inside the
+    // ENTITLED_RECHECK_AGE_MS window. Without this case, deleting the
+    // .lt("updatedAt", staleBefore) clause would leave the suite green.
+    expect(await t.mutation(CM.accounts.reconcileAccountEntitlements, {}))
+      .toMatchObject({ scanned: 0, scheduled: 0 });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ lifecycle: "entitled" });
+
+    vi.setSystemTime(NOW + 2 * 60 * 60 * 1000);
+    expect(await t.mutation(CM.accounts.reconcileAccountEntitlements, {}))
+      .toMatchObject({ scanned: 1, scheduled: 1 });
+  });
+
+  test("the reconciler caps each tick at its batch size and resumes on the next", async () => {
+    const t = convexTest(schema, modules);
+    const staleAt = NOW - 2 * 60 * 60 * 1000;
+    // 51 entitled roots with no entitlement row: every one must lapse, so the
+    // only thing bounding the first tick is the batch cap.
+    // Real fence hashes: the reconciler re-resolves each row through
+    // findAccountByOwnerFence, so a synthetic hash would make it scan the row
+    // and then silently find nothing.
+    const fences = await Promise.all(
+      Array.from({ length: 51 }, (_, i) => signCompanyMonitoringOwnerFence(`user_batch_${i}`)),
+    );
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 51; i += 1) {
+        await ctx.db.insert("companyMonitoringAccounts", {
+          logicalAccountId: `cm_account_batch_${String(i).padStart(20, "0")}`,
+          ownerUserId: `user_batch_${i}`,
+          ownerFenceHash: fences[i]!,
+          lifecycle: "entitled",
+          lifecycleSequence: 1,
+          companyCount: 0,
+          companyLimit: 500,
+          snapshotGeneration: 0,
+          purgeGeneration: 0,
+          purgePhase: "none",
+          destructivePurgeStarted: false,
+          pendingReactivation: false,
+          createdAt: staleAt,
+          updatedAt: staleAt,
+        });
+      }
+    });
+
+    const first = await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
+    expect(first).toMatchObject({ scanned: 50 });
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
+
+    // The cursor advance must let the 51st through rather than rescanning the
+    // same 50 forever.
+    const second = await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
+    expect(second.scanned).toBeGreaterThan(0);
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
+
+    const remaining = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringAccounts")
+        .withIndex("by_lifecycle_updatedAt", (q) => q.eq("lifecycle", "entitled"))
+        .collect(),
+    );
+    expect(remaining).toEqual([]);
+  });
+
   test("the reconciler leaves a still-entitled root alone", async () => {
     const t = convexTest(schema, modules);
     await grantProvisioned(t, OWNER_A);
@@ -215,7 +407,9 @@ describe("Company Monitoring account lifecycle", () => {
     vi.setSystemTime(NOW + 2 * 60 * 60 * 1000);
     const result = await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
 
-    expect(result).toMatchObject({ scanned: 1, lapsed: 0 });
+    expect(result).toMatchObject({ scanned: 1, scheduled: 1 });
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
     const after = await accountFor(t, OWNER_A);
     expect(after).toMatchObject({
       lifecycle: "entitled",
@@ -356,6 +550,8 @@ describe("Company Monitoring account lifecycle", () => {
     // The reconciler is what converges it.
     vi.setSystemTime(NOW + 2 * 60 * 60 * 1000);
     await t.mutation(CM.accounts.reconcileAccountEntitlements, {});
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
     expect(await accountFor(t, OWNER_A)).toMatchObject({
       lifecycle: "entitlement_lapsed",
       lifecycleSequence: 2,

--- a/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
+++ b/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
@@ -1,11 +1,12 @@
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { api, internal } from "../_generated/api";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import {
   companyMonitoringOwnerFenceCandidates,
   signAnonClaimToken,
   signCompanyMonitoringOwnerFence,
+  signUserId,
 } from "../lib/identitySigning";
 import {
   accountFor,
@@ -14,20 +15,36 @@ import {
   FUTURE,
   grant,
   installCompanyMonitoringTestEnvironment,
-  INTERMEDIATE_SIGNING_SECRET,
+  INTERMEDIATE_OWNER_FENCE_SECRET,
   modules,
-  NEW_SIGNING_SECRET,
+  NEW_OWNER_FENCE_SECRET,
   NOW,
-  OLD_SIGNING_SECRET,
+  OLD_OWNER_FENCE_SECRET,
   OWNER_A,
   OWNER_B,
+  ROTATED_DODO_IDENTITY_SIGNING_SECRET,
   schema,
   setStoredEntitlement,
+  TEST_OWNER_FENCE_SECRET,
 } from "./companyMonitoringTestHelpers";
 
 installCompanyMonitoringTestEnvironment();
 
 describe("Company Monitoring account lifecycle", () => {
+  test("authenticated entitlement and account-root provisioning fail atomically", async () => {
+    const t = convexTest(schema, modules);
+    delete process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET;
+
+    await expect(grant(t, OWNER_A)).rejects.toThrow(
+      /COMPANY_MONITORING_OWNER_FENCE_SECRET not set/,
+    );
+    const state = await t.run(async (ctx) => ({
+      entitlements: await ctx.db.query("entitlements").collect(),
+      accounts: await ctx.db.query("companyMonitoringAccounts").collect(),
+    }));
+    expect(state).toEqual({ entitlements: [], accounts: [] });
+  });
+
   test("authenticated grants create one immutable root and semantic replays do not advance sequence", async () => {
     const t = convexTest(schema, modules);
 
@@ -225,6 +242,7 @@ describe("Company Monitoring account lifecycle", () => {
 
     await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
     const lapsed = await accountFor(t, OWNER_A);
+    vi.setSystemTime(lapsed!.purgeAfter!);
     await t.mutation(CM.accounts.advanceAccountPurge, {
       ownerFenceHash: lapsed!.ownerFenceHash,
       purgeGeneration: lapsed!.purgeGeneration,
@@ -282,6 +300,7 @@ describe("Company Monitoring account lifecycle", () => {
       ownerFenceHash: lapsed!.ownerFenceHash,
       purgeGeneration: lapsed!.purgeGeneration,
     };
+    vi.setSystemTime(lapsed!.purgeAfter!);
     expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
       status: "started",
     });
@@ -369,6 +388,7 @@ describe("Company Monitoring account lifecycle", () => {
       ownerFenceHash: lapsed!.ownerFenceHash,
       purgeGeneration: lapsed!.purgeGeneration,
     };
+    vi.setSystemTime(lapsed!.purgeAfter!);
     expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
       status: "started",
     });
@@ -413,14 +433,24 @@ describe("Company Monitoring account lifecycle", () => {
     expect(await t.run(async (ctx) => ctx.db.query("companyMonitoringClaims").collect())).toEqual([]);
   }, 15_000);
 
-  test("owner-fence rotation finds and migrates an old nonterminal root", async () => {
+  test("Dodo identity-secret rotation cannot change a Company Monitoring owner fence", async () => {
+    const originalFence = await signCompanyMonitoringOwnerFence(OWNER_A);
+    const originalCheckoutSignature = await signUserId(OWNER_A);
+
+    process.env.DODO_IDENTITY_SIGNING_SECRET = ROTATED_DODO_IDENTITY_SIGNING_SECRET;
+
+    expect(await signCompanyMonitoringOwnerFence(OWNER_A)).toBe(originalFence);
+    expect(await signUserId(OWNER_A)).not.toBe(originalCheckoutSignature);
+  });
+
+  test("dedicated owner-fence rotation finds and migrates an old nonterminal root", async () => {
     const t = convexTest(schema, modules);
-    process.env.DODO_IDENTITY_SIGNING_SECRET = OLD_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = OLD_OWNER_FENCE_SECRET;
     await grant(t, OWNER_A);
     const oldRoot = await accountFor(t, OWNER_A);
 
-    process.env.DODO_IDENTITY_SIGNING_SECRET = NEW_SIGNING_SECRET;
-    process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = OLD_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = NEW_OWNER_FENCE_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = OLD_OWNER_FENCE_SECRET;
     const currentFenceHash = await signCompanyMonitoringOwnerFence(OWNER_A);
     await t.mutation(CM.accounts.syncStoredEntitlement, { userId: OWNER_A });
 
@@ -440,24 +470,24 @@ describe("Company Monitoring account lifecycle", () => {
     )).toBeNull();
   });
 
-  test("owner-fence rotation keeps two historical tombstones discoverable in candidate order", async () => {
+  test("dedicated owner-fence rotation keeps two historical tombstones discoverable in candidate order", async () => {
     const t = convexTest(schema, modules);
-    process.env.DODO_IDENTITY_SIGNING_SECRET = OLD_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = OLD_OWNER_FENCE_SECRET;
     await grant(t, OWNER_A);
     const oldestRoot = await accountFor(t, OWNER_A);
     const oldestFenceForOwnerA = await signCompanyMonitoringOwnerFence(OWNER_A);
     await t.mutation(CM.accounts.markOwnerDeleted, { ownerUserId: OWNER_A });
 
-    process.env.DODO_IDENTITY_SIGNING_SECRET = INTERMEDIATE_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = INTERMEDIATE_OWNER_FENCE_SECRET;
     const intermediateFenceForOwnerA = await signCompanyMonitoringOwnerFence(OWNER_A);
     await grant(t, OWNER_B);
     const intermediateRoot = await accountFor(t, OWNER_B);
     await t.mutation(CM.accounts.markOwnerDeleted, { ownerUserId: OWNER_B });
 
-    process.env.DODO_IDENTITY_SIGNING_SECRET = NEW_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = NEW_OWNER_FENCE_SECRET;
     const currentFenceForOwnerA = await signCompanyMonitoringOwnerFence(OWNER_A);
     process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS =
-      `${OLD_SIGNING_SECRET},${INTERMEDIATE_SIGNING_SECRET}`;
+      `${OLD_OWNER_FENCE_SECRET},${INTERMEDIATE_OWNER_FENCE_SECRET}`;
     expect((await companyMonitoringOwnerFenceCandidates(OWNER_A)).all).toEqual([
       currentFenceForOwnerA,
       oldestFenceForOwnerA,
@@ -489,13 +519,13 @@ describe("Company Monitoring account lifecycle", () => {
     });
   });
 
-  test("owner-fence rotation rejects split roots across current and previous keys", async () => {
+  test("dedicated owner-fence rotation rejects split roots across current and previous keys", async () => {
     const t = convexTest(schema, modules);
-    process.env.DODO_IDENTITY_SIGNING_SECRET = OLD_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = OLD_OWNER_FENCE_SECRET;
     await grant(t, OWNER_A);
 
-    process.env.DODO_IDENTITY_SIGNING_SECRET = NEW_SIGNING_SECRET;
-    process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = OLD_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = NEW_OWNER_FENCE_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = OLD_OWNER_FENCE_SECRET;
     const currentFenceHash = await signCompanyMonitoringOwnerFence(OWNER_A);
     await t.run(async (ctx) => {
       await ctx.db.insert("companyMonitoringAccounts", {
@@ -519,16 +549,39 @@ describe("Company Monitoring account lifecycle", () => {
   });
 
   test.each([
+    ["missing current secret", undefined],
+    ["empty current secret", ""],
+    ["leading whitespace", ` ${TEST_OWNER_FENCE_SECRET}`],
+    ["trailing whitespace", `${TEST_OWNER_FENCE_SECRET} `],
+  ])("dedicated owner-fence rotation rejects %s", async (_caseName, currentSecret) => {
+    if (currentSecret === undefined) delete process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET;
+    else process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = currentSecret;
+    await expect(signCompanyMonitoringOwnerFence(OWNER_A)).rejects.toThrow(
+      /COMPANY_MONITORING_OWNER_FENCE_SECRET (?:not set|is invalid)/,
+    );
+  });
+
+  test.each([
     ["empty history", ""],
-    ["blank history entry", `${OLD_SIGNING_SECRET},`],
-    ["surrounding whitespace", ` ${OLD_SIGNING_SECRET}`],
-    ["duplicate history", `${OLD_SIGNING_SECRET},${OLD_SIGNING_SECRET}`],
-    ["current key in history", `${OLD_SIGNING_SECRET},${NEW_SIGNING_SECRET}`],
+    ["blank history entry", `${OLD_OWNER_FENCE_SECRET},`],
+    ["surrounding whitespace", ` ${OLD_OWNER_FENCE_SECRET}`],
+    ["duplicate history", `${OLD_OWNER_FENCE_SECRET},${OLD_OWNER_FENCE_SECRET}`],
   ])("owner-fence rotation rejects %s", async (_caseName, previousSecrets) => {
-    process.env.DODO_IDENTITY_SIGNING_SECRET = NEW_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = NEW_OWNER_FENCE_SECRET;
     process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = previousSecrets;
     await expect(signCompanyMonitoringOwnerFence(OWNER_A)).rejects.toThrow(
-      /invalid|duplicate or current key/,
+      /invalid|duplicate key/,
     );
+  });
+
+  test("owner-fence rotation permits pre-staging the current key without duplicate candidates", async () => {
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = NEW_OWNER_FENCE_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS =
+      `${OLD_OWNER_FENCE_SECRET},${NEW_OWNER_FENCE_SECRET}`;
+
+    const candidates = await companyMonitoringOwnerFenceCandidates(OWNER_A);
+    expect(candidates.all).toHaveLength(2);
+    expect(new Set(candidates.all).size).toBe(2);
+    expect(candidates.all[0]).toBe(candidates.current);
   });
 });

--- a/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
+++ b/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
@@ -31,18 +31,63 @@ import {
 installCompanyMonitoringTestEnvironment();
 
 describe("Company Monitoring account lifecycle", () => {
-  test("authenticated entitlement and account-root provisioning fail atomically", async () => {
+  test.each([
+    ["missing fence secret", () => {
+      delete process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET;
+    }],
+    ["malformed fence keyring", () => {
+      process.env.COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS = `${TEST_OWNER_FENCE_SECRET},`;
+    }],
+  ])(
+    "a %s degrades Company Monitoring instead of rolling back the entitlement write",
+    async (_caseName, breakConfig) => {
+      const t = convexTest(schema, modules);
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      breakConfig();
+
+      // The entitlement write must survive: this runs inside the Dodo webhook
+      // transaction, and a config fault fails every retry identically.
+      await expect(grant(t, OWNER_A)).resolves.not.toThrow();
+
+      const state = await t.run(async (ctx) => ({
+        entitlements: await ctx.db.query("entitlements").collect(),
+        accounts: await ctx.db.query("companyMonitoringAccounts").collect(),
+      }));
+      expect(state.entitlements).toHaveLength(1);
+      expect(state.accounts).toEqual([]);
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining("owner fence unavailable"),
+      );
+    },
+  );
+
+  test("the account root converges on the next entitlement write once config is repaired", async () => {
     const t = convexTest(schema, modules);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
     delete process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET;
 
-    await expect(grant(t, OWNER_A)).rejects.toThrow(
-      /COMPANY_MONITORING_OWNER_FENCE_SECRET not set/,
-    );
-    const state = await t.run(async (ctx) => ({
-      entitlements: await ctx.db.query("entitlements").collect(),
-      accounts: await ctx.db.query("companyMonitoringAccounts").collect(),
-    }));
-    expect(state).toEqual({ entitlements: [], accounts: [] });
+    await grant(t, OWNER_A);
+    expect(await accountFor(t, OWNER_A)).toBeNull();
+
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = TEST_OWNER_FENCE_SECRET;
+    await t.mutation(CM.accounts.syncStoredEntitlement, { userId: OWNER_A });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      ownerUserId: OWNER_A,
+      lifecycle: "entitled",
+      lifecycleSequence: 1,
+    });
+  });
+
+  test("explicit owner deletion still fails loudly on a misconfigured fence", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    delete process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET;
+
+    // terminalize keeps the throwing accessor: deletion is an explicit
+    // operation off the billing path, so a config fault must not be swallowed.
+    await expect(
+      t.mutation(CM.accounts.markOwnerDeleted, { ownerUserId: OWNER_A }),
+    ).rejects.toThrow(/COMPANY_MONITORING_OWNER_FENCE_SECRET not set/);
   });
 
   test("authenticated grants create one immutable root and semantic replays do not advance sequence", async () => {

--- a/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
+++ b/convex/__tests__/companyMonitoringAccountLifecycle.test.ts
@@ -156,6 +156,57 @@ describe("Company Monitoring account lifecycle", () => {
     });
   });
 
+  // The safety property the whole lazy design rests on. Moving lapse detection
+  // to an hourly cron opens a window where a root still reads "entitled" after
+  // the entitlement expired. That window is only acceptable because access is
+  // re-derived from the entitlements row on every call, so it delays purge
+  // SCHEDULING and never grants access. If this test goes green while
+  // activeAccountForOwner trusts account.lifecycle, the refactor is an
+  // access-control hole.
+  test("an expired entitlement denies access immediately, before the reconciler runs", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "while-entitled",
+      company: company("While Entitled", "while-entitled"),
+    });
+
+    // Expire the entitlement without running the reconciler.
+    await t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", OWNER_A))
+        .unique();
+      await ctx.db.patch(row!._id, { planKey: "free", validUntil: NOW - 1 });
+    });
+    // The root is deliberately still stale-"entitled" at this point.
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ lifecycle: "entitled" });
+
+    // Every surface must already refuse: writes, reads, and key issuance.
+    await expect(
+      t.mutation(CM.companies.createCompanyForOwner, {
+        ownerUserId: OWNER_A,
+        clientRequestId: "after-expiry",
+        company: company("After Expiry", "after-expiry"),
+      }),
+    ).rejects.toThrow(/COMPANY_MONITORING_ACCESS_DENIED/);
+    await expect(
+      t.query(CM.companies.listCompaniesForOwner, { ownerUserId: OWNER_A }),
+    ).rejects.toThrow(/COMPANY_MONITORING_ACCESS_DENIED/);
+    await expect(
+      t.withIdentity({ subject: OWNER_A, tokenIdentifier: `clerk|${OWNER_A}` }).mutation(
+        api.apiKeys.createApiKey,
+        {
+          name: "after-expiry",
+          keyPrefix: "wm_abcde",
+          keyHash: "a".repeat(64),
+          scopes: ["company_monitoring:read"],
+        },
+      ),
+    ).rejects.toThrow();
+  });
+
   test("the reconciler leaves a still-entitled root alone", async () => {
     const t = convexTest(schema, modules);
     await grantProvisioned(t, OWNER_A);

--- a/convex/__tests__/companyMonitoringApiKeys.test.ts
+++ b/convex/__tests__/companyMonitoringApiKeys.test.ts
@@ -5,6 +5,7 @@ import {
   accountFor,
   company,
   grant,
+  grantProvisioned,
   installCompanyMonitoringTestEnvironment,
   modules,
   NOW,
@@ -18,7 +19,7 @@ installCompanyMonitoringTestEnvironment();
 describe("account-bound Company Monitoring API-key scopes", () => {
   test("scoped keys carry the exact active account binding and stale activation fails closed", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A, "api_starter");
+    await grantProvisioned(t, OWNER_A, "api_starter");
     const account = await accountFor(t, OWNER_A);
 
     const key = await t.withIdentity({ subject: OWNER_A, tokenIdentifier: `clerk|${OWNER_A}` }).mutation(
@@ -77,7 +78,7 @@ describe("account-bound Company Monitoring API-key scopes", () => {
 
   test("token-only lifecycle invalidation is scheduled and fails before fetch", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const account = await accountFor(t, OWNER_A);
     await t.run(async (ctx) => {
       await ctx.db.insert("userApiKeys", {

--- a/convex/__tests__/companyMonitoringApiKeys.test.ts
+++ b/convex/__tests__/companyMonitoringApiKeys.test.ts
@@ -1,0 +1,206 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test, vi } from "vitest";
+import { api, internal } from "../_generated/api";
+import {
+  accountFor,
+  company,
+  grant,
+  installCompanyMonitoringTestEnvironment,
+  modules,
+  NOW,
+  OWNER_A,
+  schema,
+  setStoredEntitlement,
+} from "./companyMonitoringTestHelpers";
+
+installCompanyMonitoringTestEnvironment();
+
+describe("account-bound Company Monitoring API-key scopes", () => {
+  test("scoped keys carry the exact active account binding and stale activation fails closed", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A, "api_starter");
+    const account = await accountFor(t, OWNER_A);
+
+    const key = await t.withIdentity({ subject: OWNER_A, tokenIdentifier: `clerk|${OWNER_A}` }).mutation(
+      api.apiKeys.createApiKey,
+      {
+        name: "company-monitoring",
+        keyPrefix: "wm_abcde",
+        keyHash: "a".repeat(64),
+        scopes: ["company_monitoring:read", "company_monitoring:write"],
+      },
+    );
+    const valid = await t.query(internal.apiKeys.validateKeyByHash, { keyHash: "a".repeat(64) });
+    expect(valid).toMatchObject({
+      id: key.id,
+      userId: OWNER_A,
+      scopes: ["company_monitoring:read", "company_monitoring:write"],
+      companyMonitoringAccountId: account?.logicalAccountId,
+    });
+
+    process.env.UPSTASH_REDIS_REST_URL = "https://redis.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const scheduled = await t.run(async (ctx) => ctx.db.system.query("_scheduled_functions").collect());
+    expect(scheduled.some((job) => job.name.includes("invalidateUserApiKeyCaches"))).toBe(true);
+    await expect(
+      t.query(internal.apiKeys.validateKeyByHash, { keyHash: "a".repeat(64) }),
+    ).resolves.toBeNull();
+  });
+
+  test("cache invalidation no-ops without either Redis setting", async () => {
+    const t = convexTest(schema, modules);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      t.action(internal.payments.cacheActions.invalidateUserApiKeyCaches, {
+        keyHashes: ["f".repeat(64)],
+      }),
+    ).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("URL-only cache invalidation rejects before fetch", async () => {
+    const t = convexTest(schema, modules);
+    process.env.UPSTASH_REDIS_REST_URL = "https://redis.example";
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      t.action(internal.payments.cacheActions.invalidateUserApiKeyCaches, {
+        keyHashes: ["f".repeat(64)],
+      }),
+    ).rejects.toThrow(/must be configured together/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("token-only lifecycle invalidation is scheduled and fails before fetch", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    const account = await accountFor(t, OWNER_A);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("userApiKeys", {
+        userId: OWNER_A,
+        name: "token-only-cache-key",
+        keyPrefix: "wm_fffff",
+        keyHash: "f".repeat(64),
+        scopes: ["company_monitoring:read"],
+        companyMonitoringAccountId: account!.logicalAccountId,
+        createdAt: NOW,
+      });
+    });
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+    const fetchMock = vi.fn();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const pending = await t.run(async (ctx) =>
+      ctx.db.system.query("_scheduled_functions").collect()
+    );
+    expect(pending.some((job) =>
+      job.name.includes("invalidateUserApiKeyCaches") && job.state.kind === "pending"
+    )).toBe(true);
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const completed = await t.run(async (ctx) =>
+      ctx.db.system.query("_scheduled_functions").collect()
+    );
+    expect(completed.some((job) =>
+      job.name.includes("invalidateUserApiKeyCaches") && job.state.kind === "failed"
+    )).toBe(true);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("invalidateUserApiKeyCaches"),
+      expect.objectContaining({ message: expect.stringMatching(/must be configured together/) }),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("production warm-cache invalidation sends bare keys with the required User-Agent", async () => {
+    const t = convexTest(schema, modules);
+    process.env.UPSTASH_REDIS_REST_URL = "https://redis.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+    process.env.VERCEL_ENV = "production";
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify([{ result: 1 }, { result: "0" }]),
+      { status: 200 },
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action(internal.payments.cacheActions.invalidateUserApiKeyCaches, {
+      keyHashes: ["c".repeat(64)],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://redis.example/pipeline");
+    expect(JSON.parse(String(init.body))).toEqual([
+      ["DEL", `user-api-key:${"c".repeat(64)}`],
+      ["DEL", `bootstrap-user-api-key-invalid:${"c".repeat(64)}`],
+    ]);
+    expect(init.headers).toMatchObject({
+      Authorization: "Bearer test-token",
+      "Content-Type": "application/json",
+      "User-Agent": "worldmonitor-server/1.0 (redis)",
+    });
+  });
+
+  test("preview warm-cache invalidation prefixes both keys with the deployment SHA", async () => {
+    const t = convexTest(schema, modules);
+    process.env.UPSTASH_REDIS_REST_URL = "https://redis.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+    process.env.VERCEL_ENV = "preview";
+    process.env.VERCEL_GIT_COMMIT_SHA = "abcdef1234567890";
+    const fetchMock = vi.fn(async () => new Response(
+      JSON.stringify([{ result: 1 }, { result: 1 }]),
+      { status: 200 },
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await t.action(internal.payments.cacheActions.invalidateUserApiKeyCaches, {
+      keyHashes: ["d".repeat(64)],
+    });
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual([
+      ["DEL", `preview:abcdef12:user-api-key:${"d".repeat(64)}`],
+      ["DEL", `preview:abcdef12:bootstrap-user-api-key-invalid:${"d".repeat(64)}`],
+    ]);
+  });
+
+  test.each([
+    ["per-command error", [{ result: 1 }, { error: "upstream rejected DEL" }]],
+    ["malformed command result", [{ result: 1 }, "not-an-object"]],
+    ["wrong result count", [{ result: 1 }]],
+  ])("HTTP-200 %s fails closed", async (_caseName, pipelineResults) => {
+    const t = convexTest(schema, modules);
+    process.env.UPSTASH_REDIS_REST_URL = "https://redis.example";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(
+      JSON.stringify(pipelineResults),
+      { status: 200 },
+    )));
+
+    await expect(
+      t.action(internal.payments.cacheActions.invalidateUserApiKeyCaches, {
+        keyHashes: ["e".repeat(64)],
+      }),
+    ).rejects.toThrow(/user API key cache DEL/);
+  });
+
+  test("ownerless scoped credentials fail closed", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("userApiKeys", {
+        userId: OWNER_A,
+        name: "malformed-ownerless-key",
+        keyPrefix: "wm_bbbbb",
+        keyHash: "b".repeat(64),
+        scopes: ["company_monitoring:read"],
+        createdAt: NOW,
+      });
+    });
+    await expect(
+      t.query(internal.apiKeys.validateKeyByHash, { keyHash: "b".repeat(64) }),
+    ).resolves.toBeNull();
+  });
+});

--- a/convex/__tests__/companyMonitoringApiKeys.test.ts
+++ b/convex/__tests__/companyMonitoringApiKeys.test.ts
@@ -145,7 +145,7 @@ describe("account-bound Company Monitoring API-key scopes", () => {
     });
   });
 
-  test("preview warm-cache invalidation prefixes both keys with the deployment SHA", async () => {
+  test("Convex invalidation ignores Vercel preview metadata and targets production bare keys", async () => {
     const t = convexTest(schema, modules);
     process.env.UPSTASH_REDIS_REST_URL = "https://redis.example";
     process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
@@ -162,8 +162,8 @@ describe("account-bound Company Monitoring API-key scopes", () => {
     });
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(JSON.parse(String(init.body))).toEqual([
-      ["DEL", `preview:abcdef12:user-api-key:${"d".repeat(64)}`],
-      ["DEL", `preview:abcdef12:bootstrap-user-api-key-invalid:${"d".repeat(64)}`],
+      ["DEL", `user-api-key:${"d".repeat(64)}`],
+      ["DEL", `bootstrap-user-api-key-invalid:${"d".repeat(64)}`],
     ]);
   });
 

--- a/convex/__tests__/companyMonitoringApiKeys.test.ts
+++ b/convex/__tests__/companyMonitoringApiKeys.test.ts
@@ -17,6 +17,33 @@ import {
 installCompanyMonitoringTestEnvironment();
 
 describe("account-bound Company Monitoring API-key scopes", () => {
+  test("issuing the first scoped key provisions the root, and an unscoped key does not", async () => {
+    const t = convexTest(schema, modules);
+    // Bare grant: the entitlement write no longer provisions anything (#6256).
+    await grant(t, OWNER_A, "api_starter");
+    expect(await accountFor(t, OWNER_A)).toBeNull();
+
+    // An unscoped key must stay entirely off Company Monitoring.
+    await t.withIdentity({ subject: OWNER_A, tokenIdentifier: `clerk|${OWNER_A}` }).mutation(
+      api.apiKeys.createApiKey,
+      { name: "generic", keyPrefix: "wm_ddddd", keyHash: "d".repeat(64) },
+    );
+    expect(await accountFor(t, OWNER_A)).toBeNull();
+
+    // Requesting scopes is a first-use entry point: it provisions.
+    const scoped = await t.withIdentity({ subject: OWNER_A, tokenIdentifier: `clerk|${OWNER_A}` })
+      .mutation(api.apiKeys.createApiKey, {
+        name: "company-monitoring",
+        keyPrefix: "wm_eeeee",
+        keyHash: "e".repeat(64),
+        scopes: ["company_monitoring:read"],
+      });
+
+    const account = await accountFor(t, OWNER_A);
+    expect(account).toMatchObject({ ownerUserId: OWNER_A, lifecycle: "entitled" });
+    expect(scoped.companyMonitoringAccountId).toBe(account?.logicalAccountId);
+  });
+
   test("scoped keys carry the exact active account binding and stale activation fails closed", async () => {
     const t = convexTest(schema, modules);
     await grantProvisioned(t, OWNER_A, "api_starter");

--- a/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
+++ b/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
@@ -289,6 +289,123 @@ describe("bounded onboarding and replay", () => {
     ).rejects.toThrow(/100 rows/);
   });
 
+  test("a directly created company can be recreated with the same request after purge", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const request = {
+      ownerUserId: OWNER_A,
+      clientRequestId: "direct-recreate-after-purge",
+      company: company("Direct Purge Corp", "direct-purge-corp"),
+    };
+
+    const created = await t.mutation(CM.companies.createCompanyForOwner, request);
+    expect(await t.mutation(CM.companies.createCompanyForOwner, request)).toEqual({
+      status: "replayed",
+      companyId: created.companyId,
+    });
+    await expect(
+      t.mutation(CM.companies.createCompanyForOwner, {
+        ...request,
+        company: company("Changed Direct Purge Corp", "direct-purge-corp"),
+      }),
+    ).rejects.toThrow(/REPLAY_CONFLICT/);
+
+    await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "removed",
+    });
+    const root = await accountFor(t, OWNER_A);
+    const removed = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", root!.logicalAccountId).eq("companyId", created.companyId),
+        )
+        .unique()
+    );
+    expect(await t.mutation(CM.companies.advanceCompanyPurge, {
+      ownerAccountId: root!.logicalAccountId,
+      companyId: created.companyId,
+      purgeGeneration: removed!.purgeGeneration,
+    })).toEqual({ status: "complete" });
+
+    const purged = await t.run(async (ctx) => ctx.db.get(removed!._id));
+    expect(purged?.directRequestId).toBeUndefined();
+    expect(purged?.directFingerprint).toBeUndefined();
+    expect(purged?.clientImportId).toBeUndefined();
+    expect(purged?.importOrdinal).toBeUndefined();
+    expect(purged?.importFingerprint).toBeUndefined();
+
+    const recreated = await t.mutation(CM.companies.createCompanyForOwner, request);
+    expect(recreated.status).toBe("created");
+    expect(recreated.companyId).not.toBe(created.companyId);
+    expect(await t.query(CM.companies.listCompaniesForOwner, { ownerUserId: OWNER_A })).toEqual([
+      expect.objectContaining({ companyId: recreated.companyId, lifecycle: "active" }),
+    ]);
+  });
+
+  test("an imported company can be recreated with the same tuple after purge", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const row = {
+      ...company("Import Purge Corp", "import-purge-corp"),
+      clientImportId: "import-recreate-after-purge",
+      ordinal: 0,
+    };
+    const request = { ownerUserId: OWNER_A, rows: [row] };
+
+    const imported = await t.action(CM.imports.importCompaniesForOwner, request);
+    const companyId = imported.results[0]!.companyId!;
+    expect(imported.results[0]).toMatchObject({ status: "created", companyId });
+    expect(await t.action(CM.imports.importCompaniesForOwner, request)).toMatchObject({
+      results: [{ status: "replayed", companyId }],
+    });
+    expect(await t.action(CM.imports.importCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+      rows: [{ ...row, name: "Changed Import Purge Corp" }],
+    })).toMatchObject({
+      results: [{ status: "conflict", reason: "REPLAY_CONFLICT" }],
+    });
+
+    await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId,
+      state: "removed",
+    });
+    const root = await accountFor(t, OWNER_A);
+    const removed = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", root!.logicalAccountId).eq("companyId", companyId),
+        )
+        .unique()
+    );
+    expect(await t.mutation(CM.companies.advanceCompanyPurge, {
+      ownerAccountId: root!.logicalAccountId,
+      companyId,
+      purgeGeneration: removed!.purgeGeneration,
+    })).toEqual({ status: "complete" });
+
+    const purged = await t.run(async (ctx) => ctx.db.get(removed!._id));
+    expect(purged?.directRequestId).toBeUndefined();
+    expect(purged?.directFingerprint).toBeUndefined();
+    expect(purged?.clientImportId).toBeUndefined();
+    expect(purged?.importOrdinal).toBeUndefined();
+    expect(purged?.importFingerprint).toBeUndefined();
+
+    const reimported = await t.action(CM.imports.importCompaniesForOwner, request);
+    expect(reimported.results[0]?.status).toBe("created");
+    expect(reimported.results[0]?.companyId).not.toBe(companyId);
+    expect(await t.query(CM.companies.listCompaniesForOwner, { ownerUserId: OWNER_A })).toEqual([
+      expect.objectContaining({
+        companyId: reimported.results[0]?.companyId,
+        lifecycle: "active",
+      }),
+    ]);
+  });
+
   test("removal is immediately hidden, idempotent, cleans claims, and fences cross-account IDs", async () => {
     const t = convexTest(schema, modules);
     await grantProvisioned(t, OWNER_A);

--- a/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
+++ b/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
@@ -5,6 +5,7 @@ import {
   CM,
   company,
   grant,
+  grantProvisioned,
   installCompanyMonitoringTestEnvironment,
   modules,
   NOW,
@@ -18,7 +19,7 @@ installCompanyMonitoringTestEnvironment();
 describe("bounded onboarding and replay", () => {
   test("concurrent final-slot requests admit exactly one and preserve count parity", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const root = await accountFor(t, OWNER_A);
     await t.run(async (ctx) => {
       for (let i = 0; i < 499; i += 1) {
@@ -87,7 +88,7 @@ describe("bounded onboarding and replay", () => {
 
   test("Convex validators reject unexpected fields at every Company Monitoring write boundary", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
 
     await expect(t.mutation(CM.companies.createCompanyForOwner, {
       ownerUserId: OWNER_A,
@@ -140,7 +141,7 @@ describe("bounded onboarding and replay", () => {
 
   test("a full 100-row normalized import stays ordered and replay-safe", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const rows = Array.from({ length: 100 }, (_, ordinal) => ({
       ...company(`Batch Company ${ordinal}`, `batch-${ordinal}`),
       name: `  Batch Company ${ordinal}  `,
@@ -203,7 +204,7 @@ describe("bounded onboarding and replay", () => {
 
   test("committed direct and import rows replay, changed tuples conflict, and no-ops reevaluate", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
 
     const first = await t.mutation(CM.companies.createCompanyForOwner, {
       ownerUserId: OWNER_A,
@@ -290,8 +291,8 @@ describe("bounded onboarding and replay", () => {
 
   test("removal is immediately hidden, idempotent, cleans claims, and fences cross-account IDs", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
-    await grant(t, OWNER_B);
+    await grantProvisioned(t, OWNER_A);
+    await grantProvisioned(t, OWNER_B);
     const created = await t.mutation(CM.companies.createCompanyForOwner, {
       ownerUserId: OWNER_A,
       clientRequestId: "remove-1",
@@ -382,7 +383,7 @@ describe("bounded onboarding and replay", () => {
 
   test("active-paused-active transitions advance snapshots once and self-transitions are no-ops", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const created = await t.mutation(CM.companies.createCompanyForOwner, {
       ownerUserId: OWNER_A,
       clientRequestId: "state-transitions",
@@ -448,8 +449,8 @@ describe("bounded onboarding and replay", () => {
 
   test("company updates keep claims account-bound, normalized, and budgeted", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
-    await grant(t, OWNER_B);
+    await grantProvisioned(t, OWNER_A);
+    await grantProvisioned(t, OWNER_B);
     const createdA = await t.mutation(CM.companies.createCompanyForOwner, {
       ownerUserId: OWNER_A,
       clientRequestId: "update-a",

--- a/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
+++ b/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
@@ -85,6 +85,59 @@ describe("bounded onboarding and replay", () => {
     expect(retried.status).toBe("created");
   });
 
+  test("Convex validators reject unexpected fields at every Company Monitoring write boundary", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+
+    await expect(t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "validator-create-extra",
+      company: { ...company("Validator Create", "validator-create"), unexpected: "ignored-by-v-any" },
+    } as any)).rejects.toThrow();
+
+    const created = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "validator-valid-company",
+      company: company("Validator Valid", "validator-valid"),
+    });
+    await expect(t.mutation(CM.companies.updateCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      patch: { unexpected: "ignored-by-v-any" },
+    } as any)).rejects.toThrow();
+
+    await expect(t.action(CM.imports.importCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+      rows: [{
+        ...company("Validator Import", "validator-import"),
+        clientImportId: "validator-import",
+        ordinal: 0,
+        unexpected: "ignored-by-v-any",
+      }],
+    } as any)).rejects.toThrow();
+
+    const normalizedRow = {
+      contractVersion: "cm-import-v1",
+      clientImportId: "validator-internal-import",
+      ordinal: 0,
+      name: "Validator Internal Import",
+      domicileCountry: "US",
+      aliases: [],
+      domains: [],
+      identifiers: [],
+      xHandles: [],
+      locations: [],
+      unexpected: "ignored-by-v-any",
+    };
+    await expect(t.mutation(CM.imports.importCompanyRowForOwner, {
+      ownerUserId: OWNER_A,
+      row: normalizedRow,
+      rowFingerprint: "validator-fingerprint",
+    } as any)).rejects.toThrow();
+
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ companyCount: 1 });
+  });
+
   test("a full 100-row normalized import stays ordered and replay-safe", async () => {
     const t = convexTest(schema, modules);
     await grant(t, OWNER_A);
@@ -109,27 +162,30 @@ describe("bounded onboarding and replay", () => {
     );
 
     const root = await accountFor(t, OWNER_A);
+    const firstCompanyId = imported.results[0]?.companyId;
+    expect(firstCompanyId).toBeDefined();
     const stored = await t.run(async (ctx) => ({
       companies: await ctx.db
         .query("companyMonitoringCompanies")
         .withIndex("by_account_companyId", (q) => q.eq("ownerAccountId", root!.logicalAccountId))
         .collect(),
-      firstDomain: await ctx.db
+      firstCompanyClaims: await ctx.db
         .query("companyMonitoringClaims")
-        .withIndex("by_account_type_value", (q) =>
+        .withIndex("by_account_company", (q) =>
           q
             .eq("ownerAccountId", root!.logicalAccountId)
-            .eq("type", "domain")
-            .eq("value", "batch-0.example"),
+            .eq("companyId", firstCompanyId!),
         )
-        .unique(),
+        .collect(),
     }));
     expect(stored.companies).toHaveLength(100);
     expect(stored.companies.every((row) =>
       row.name === `Batch Company ${row.importOrdinal}` &&
       row.clientImportId === "full-normalized-batch"
     )).toBe(true);
-    expect(stored.firstDomain?.value).toBe("batch-0.example");
+    expect(stored.firstCompanyClaims).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "domain", value: "batch-0.example" }),
+    ]));
 
     const replayed = await t.action(CM.imports.importCompaniesForOwner, {
       ownerUserId: OWNER_A,

--- a/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
+++ b/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
@@ -1,0 +1,483 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import {
+  accountFor,
+  CM,
+  company,
+  grant,
+  installCompanyMonitoringTestEnvironment,
+  modules,
+  NOW,
+  OWNER_A,
+  OWNER_B,
+  schema,
+} from "./companyMonitoringTestHelpers";
+
+installCompanyMonitoringTestEnvironment();
+
+describe("bounded onboarding and replay", () => {
+  test("concurrent final-slot requests admit exactly one and preserve count parity", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    const root = await accountFor(t, OWNER_A);
+    await t.run(async (ctx) => {
+      for (let i = 0; i < 499; i += 1) {
+        await ctx.db.insert("companyMonitoringCompanies", {
+          ownerAccountId: root!.logicalAccountId,
+          companyId: `cm_company_${String(i).padStart(26, "0")}`,
+          name: `Seed ${i}`,
+          sortName: `seed ${String(i).padStart(3, "0")}`,
+          domicileCountry: "US",
+          lifecycle: "active",
+          coverageState: "awaiting_first_scan",
+          observationState: "unknown",
+          snapshotGeneration: 1,
+          purgeGeneration: 0,
+          purgePhase: "none",
+          createdAt: NOW,
+          updatedAt: NOW,
+        });
+      }
+      await ctx.db.patch(root!._id, { companyCount: 499 });
+    });
+
+    const results = await Promise.allSettled([
+      t.mutation(CM.companies.createCompanyForOwner, {
+        ownerUserId: OWNER_A,
+        clientRequestId: "final-slot-a",
+        company: company("Final Slot A", "final-slot-a"),
+      }),
+      t.mutation(CM.companies.createCompanyForOwner, {
+        ownerUserId: OWNER_A,
+        clientRequestId: "final-slot-b",
+        company: company("Final Slot B", "final-slot-b"),
+      }),
+    ]);
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+
+    const parity = await t.run(async (ctx) => {
+      const account = await ctx.db.get(root!._id);
+      const active = await ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_lifecycle_sortName", (q) =>
+          q.eq("ownerAccountId", root!.logicalAccountId).eq("lifecycle", "active"),
+        )
+        .collect();
+      return { count: account?.companyCount, active: active.length };
+    });
+    expect(parity).toEqual({ count: 500, active: 500 });
+
+    const rejectedIndex = results.findIndex((result) => result.status === "rejected");
+    await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: `cm_company_${String(0).padStart(26, "0")}`,
+      state: "removed",
+    });
+    const retried = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: rejectedIndex === 0 ? "final-slot-a" : "final-slot-b",
+      company:
+        rejectedIndex === 0
+          ? company("Final Slot A", "final-slot-a")
+          : company("Final Slot B", "final-slot-b"),
+    });
+    expect(retried.status).toBe("created");
+  });
+
+  test("a full 100-row normalized import stays ordered and replay-safe", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    const rows = Array.from({ length: 100 }, (_, ordinal) => ({
+      ...company(`Batch Company ${ordinal}`, `batch-${ordinal}`),
+      name: `  Batch Company ${ordinal}  `,
+      domains: [`WWW.BATCH-${ordinal}.EXAMPLE.`],
+      clientImportId: "full-normalized-batch",
+      ordinal,
+    })).reverse();
+
+    const imported = await t.action(CM.imports.importCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+      rows,
+    });
+    expect(imported.companyCount).toBe(100);
+    expect(imported.results.map((row: any) => row.ordinal)).toEqual(
+      Array.from({ length: 100 }, (_, ordinal) => ordinal),
+    );
+    expect(imported.results.map((row: any) => row.status)).toEqual(
+      Array.from({ length: 100 }, () => "created"),
+    );
+
+    const root = await accountFor(t, OWNER_A);
+    const stored = await t.run(async (ctx) => ({
+      companies: await ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) => q.eq("ownerAccountId", root!.logicalAccountId))
+        .collect(),
+      firstDomain: await ctx.db
+        .query("companyMonitoringClaims")
+        .withIndex("by_account_type_value", (q) =>
+          q
+            .eq("ownerAccountId", root!.logicalAccountId)
+            .eq("type", "domain")
+            .eq("value", "batch-0.example"),
+        )
+        .unique(),
+    }));
+    expect(stored.companies).toHaveLength(100);
+    expect(stored.companies.every((row) =>
+      row.name === `Batch Company ${row.importOrdinal}` &&
+      row.clientImportId === "full-normalized-batch"
+    )).toBe(true);
+    expect(stored.firstDomain?.value).toBe("batch-0.example");
+
+    const replayed = await t.action(CM.imports.importCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+      rows,
+    });
+    expect(replayed.companyCount).toBe(100);
+    expect(replayed.results.map((row: any) => row.ordinal)).toEqual(
+      Array.from({ length: 100 }, (_, ordinal) => ordinal),
+    );
+    expect(replayed.results.map((row: any) => row.status)).toEqual(
+      Array.from({ length: 100 }, () => "replayed"),
+    );
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ companyCount: 100 });
+  });
+
+  test("committed direct and import rows replay, changed tuples conflict, and no-ops reevaluate", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+
+    const first = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "direct-uncertain-1",
+      company: company("Replay Corp", "replay-corp"),
+    });
+    const replay = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "direct-uncertain-1",
+      company: company("Replay Corp", "replay-corp"),
+    });
+    expect(replay).toMatchObject({ status: "replayed", companyId: first.companyId });
+    await expect(
+      t.mutation(CM.companies.createCompanyForOwner, {
+        ownerUserId: OWNER_A,
+        clientRequestId: "direct-uncertain-1",
+        company: company("Changed Corp", "replay-corp"),
+      }),
+    ).rejects.toThrow(/REPLAY_CONFLICT/);
+
+    const rows = [
+      { ...company("Replay Corp", "replay-corp"), clientImportId: "csv-1", ordinal: 0 },
+      { ...company("Fresh Corp", "fresh-corp"), clientImportId: "csv-1", ordinal: 1 },
+    ];
+    const imported = await t.action(CM.imports.importCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+      rows,
+    });
+    expect(imported.results.map((row: any) => row.status)).toEqual(["noop", "created"]);
+    const rootBeforeImportConflict = await accountFor(t, OWNER_A);
+    const committedImportRow = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_import_tuple", (q) =>
+          q
+            .eq("ownerAccountId", rootBeforeImportConflict!.logicalAccountId)
+            .eq("clientImportId", "csv-1")
+            .eq("importOrdinal", 1),
+        )
+        .unique()
+    );
+    const changedTuple = await t.action(CM.imports.importCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+      rows: [rows[0], { ...rows[1], name: "Changed Fresh Corp" }],
+    });
+    expect(changedTuple.results.map((row: any) => row.status)).toEqual(["noop", "conflict"]);
+    expect(changedTuple.results[1]).toMatchObject({ reason: "REPLAY_CONFLICT" });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      companyCount: rootBeforeImportConflict?.companyCount,
+      snapshotGeneration: rootBeforeImportConflict?.snapshotGeneration,
+    });
+    expect(await t.run(async (ctx) => ctx.db.get(committedImportRow!._id))).toEqual(
+      committedImportRow,
+    );
+
+    const replayed = await t.action(CM.imports.importCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+      rows,
+    });
+    expect(replayed.results.map((row: any) => row.status)).toEqual(["noop", "replayed"]);
+
+    await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: first.companyId,
+      state: "removed",
+    });
+    const reevaluated = await t.action(CM.imports.importCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+      rows,
+    });
+    expect(reevaluated.results.map((row: any) => row.status)).toEqual(["created", "replayed"]);
+
+    await expect(
+      t.action(CM.imports.importCompaniesForOwner, {
+        ownerUserId: OWNER_A,
+        rows: Array.from({ length: 101 }, (_, ordinal) => ({
+          ...company(`Too Many ${ordinal}`),
+          clientImportId: "oversized",
+          ordinal,
+        })),
+      }),
+    ).rejects.toThrow(/100 rows/);
+  });
+
+  test("removal is immediately hidden, idempotent, cleans claims, and fences cross-account IDs", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    await grant(t, OWNER_B);
+    const created = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "remove-1",
+      company: company("Remove Corp", "remove-corp"),
+    });
+    const before = await accountFor(t, OWNER_A);
+
+    await expect(
+      t.mutation(CM.companies.setCompanyStateForOwner, {
+        ownerUserId: OWNER_B,
+        companyId: created.companyId,
+        state: "removed",
+      }),
+    ).rejects.toThrow(/NOT_FOUND/);
+
+    const removed = await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "removed",
+    });
+    expect(removed.status).toBe("removed");
+    const again = await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "removed",
+    });
+    expect(again.status).toBe("already_removed");
+
+    const visible = await t.query(CM.companies.listCompaniesForOwner, { ownerUserId: OWNER_A });
+    expect(visible).toEqual([]);
+    const after = await accountFor(t, OWNER_A);
+    expect(after?.companyCount).toBe(0);
+    expect(after?.snapshotGeneration).toBe((before?.snapshotGeneration ?? 0) + 1);
+    const removedRow = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", before!.logicalAccountId).eq("companyId", created.companyId),
+        )
+        .unique()
+    );
+    const claims = await t.run(async (ctx) => ctx.db
+        .query("companyMonitoringClaims")
+        .withIndex("by_account_company", (q) =>
+          q.eq("ownerAccountId", before!.logicalAccountId).eq("companyId", created.companyId),
+        )
+        .collect());
+    expect(claims).toEqual([]);
+    expect(removedRow).toMatchObject({
+      lifecycle: "removed",
+      purgePhase: "payload",
+      name: "Remove Corp",
+    });
+
+    const purgeArgs = {
+      ownerAccountId: before!.logicalAccountId,
+      companyId: created.companyId,
+      purgeGeneration: removedRow!.purgeGeneration,
+    };
+    expect(await t.mutation(CM.companies.advanceCompanyPurge, purgeArgs)).toEqual({
+      status: "complete",
+    });
+    const scrubbed = await t.run(async (ctx) => ctx.db.get(removedRow!._id));
+    expect(scrubbed).toMatchObject({
+      lifecycle: "removed",
+      purgePhase: "complete",
+      purgeGeneration: removedRow?.purgeGeneration,
+    });
+    expect(scrubbed?.name).toBeUndefined();
+    expect(scrubbed?.sortName).toBeUndefined();
+    expect(scrubbed?.domicileCountry).toBeUndefined();
+    expect(scrubbed?.customerReference).toBeUndefined();
+    expect(scrubbed?.coverageState).toBeUndefined();
+    expect(scrubbed?.observationState).toBeUndefined();
+    expect(await t.mutation(CM.companies.advanceCompanyPurge, purgeArgs)).toEqual({
+      status: "complete",
+    });
+    expect(await t.run(async (ctx) => ctx.db.get(removedRow!._id))).toEqual(scrubbed);
+
+    await expect(
+      t.mutation(CM.companies.createCompanyForOwner, {
+        ownerUserId: OWNER_A,
+        clientRequestId: "invalid-domain",
+        company: { ...company("Invalid Domain"), domains: ["https://not-a-domain.example/path"] },
+      }),
+    ).rejects.toThrow(/invalid domain/);
+  });
+
+  test("active-paused-active transitions advance snapshots once and self-transitions are no-ops", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    const created = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "state-transitions",
+      company: company("State Transition Corp", "state-transition-corp"),
+    });
+    const root = await accountFor(t, OWNER_A);
+    const readState = () => t.run(async (ctx) => ({
+      account: await ctx.db.get(root!._id),
+      company: await ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", root!.logicalAccountId).eq("companyId", created.companyId),
+        )
+        .unique(),
+    }));
+    const initial = await readState();
+
+    expect(await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "active",
+    })).toMatchObject({ status: "unchanged" });
+    expect(await readState()).toEqual(initial);
+
+    expect(await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "paused",
+    })).toMatchObject({ status: "paused" });
+    const paused = await readState();
+    expect(paused.account?.snapshotGeneration).toBe((initial.account?.snapshotGeneration ?? 0) + 1);
+    expect(paused.company?.snapshotGeneration).toBe((initial.company?.snapshotGeneration ?? 0) + 1);
+    expect(paused.company?.lifecycle).toBe("paused");
+
+    expect(await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "paused",
+    })).toMatchObject({ status: "unchanged" });
+    expect(await readState()).toEqual(paused);
+
+    expect(await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "active",
+    })).toMatchObject({ status: "active" });
+    const activeAgain = await readState();
+    expect(activeAgain.account?.snapshotGeneration).toBe(
+      (initial.account?.snapshotGeneration ?? 0) + 2,
+    );
+    expect(activeAgain.company?.snapshotGeneration).toBe(
+      (initial.company?.snapshotGeneration ?? 0) + 2,
+    );
+    expect(activeAgain.company?.lifecycle).toBe("active");
+
+    expect(await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "active",
+    })).toMatchObject({ status: "unchanged" });
+    expect(await readState()).toEqual(activeAgain);
+  });
+
+  test("company updates keep claims account-bound, normalized, and budgeted", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    await grant(t, OWNER_B);
+    const createdA = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "update-a",
+      company: company("Update Corp", "update-corp"),
+    });
+    const createdB = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_B,
+      clientRequestId: "update-b",
+      company: company("Other Corp", "other-corp"),
+    });
+    const accountA = await accountFor(t, OWNER_A);
+    const accountB = await accountFor(t, OWNER_B);
+    const claims = await t.run(async (ctx) => ({
+      a: await ctx.db
+        .query("companyMonitoringClaims")
+        .withIndex("by_account_company", (q) =>
+          q.eq("ownerAccountId", accountA!.logicalAccountId).eq("companyId", createdA.companyId),
+        )
+        .collect(),
+      b: await ctx.db
+        .query("companyMonitoringClaims")
+        .withIndex("by_account_company", (q) =>
+          q.eq("ownerAccountId", accountB!.logicalAccountId).eq("companyId", createdB.companyId),
+        )
+        .collect(),
+    }));
+
+    await expect(
+      t.mutation(CM.companies.updateCompanyForOwner, {
+        ownerUserId: OWNER_A,
+        companyId: createdA.companyId,
+        patch: { removeClaimIds: [claims.b[0].claimId] },
+      }),
+    ).rejects.toThrow(/CLAIM_NOT_FOUND/);
+    await expect(
+      t.mutation(CM.companies.updateCompanyForOwner, {
+        ownerUserId: OWNER_A,
+        companyId: createdA.companyId,
+        patch: { addClaims: [{ type: "x_account_id", value: "not-numeric" }] },
+      }),
+    ).rejects.toThrow(/invalid X account ID/);
+
+    const updated = await t.mutation(CM.companies.updateCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: createdA.companyId,
+      patch: {
+        name: "Updated Corporation",
+        customerReference: "updated-corp",
+        removeClaimIds: [claims.a[0].claimId],
+        addClaims: [{ type: "x_account_id", value: "123456" }],
+      },
+    });
+    expect(updated.status).toBe("updated");
+    const after = await t.run(async (ctx) => ({
+      row: await ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", accountA!.logicalAccountId).eq("companyId", createdA.companyId),
+        )
+        .unique(),
+      claims: await ctx.db
+        .query("companyMonitoringClaims")
+        .withIndex("by_account_company", (q) =>
+          q.eq("ownerAccountId", accountA!.logicalAccountId).eq("companyId", createdA.companyId),
+        )
+        .collect(),
+    }));
+    expect(after.row).toMatchObject({
+      name: "Updated Corporation",
+      customerReference: "updated-corp",
+    });
+    expect(after.claims.some((claim) => claim.claimId === claims.a[0].claimId)).toBe(false);
+    expect(after.claims).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "x_account_id", value: "123456" }),
+      expect.objectContaining({ type: "customer_reference", value: "updated-corp" }),
+    ]));
+
+    const snapshot = (await accountFor(t, OWNER_A))!.snapshotGeneration;
+    const unchanged = await t.mutation(CM.companies.updateCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: createdA.companyId,
+      patch: {},
+    });
+    expect(unchanged.status).toBe("unchanged");
+    expect((await accountFor(t, OWNER_A))!.snapshotGeneration).toBe(snapshot);
+  });
+});

--- a/convex/__tests__/companyMonitoringPurgePersistence.test.ts
+++ b/convex/__tests__/companyMonitoringPurgePersistence.test.ts
@@ -1,0 +1,315 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test, vi } from "vitest";
+import { getFeaturesForPlan } from "../lib/entitlements";
+import {
+  accountFor,
+  CM,
+  company,
+  FUTURE,
+  grant,
+  installCompanyMonitoringTestEnvironment,
+  modules,
+  NOW,
+  OWNER_A,
+  schema,
+  setStoredEntitlement,
+} from "./companyMonitoringTestHelpers";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+installCompanyMonitoringTestEnvironment();
+
+describe("Company Monitoring purge persistence", () => {
+  test("duplicate entitlement rows use the first canonical row for sync and access", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("entitlements", {
+        userId: OWNER_A,
+        planKey: "api_starter",
+        features: getFeaturesForPlan("api_starter"),
+        validUntil: FUTURE,
+        updatedAt: NOW,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: OWNER_A,
+        planKey: "free",
+        features: getFeaturesForPlan("free"),
+        validUntil: NOW - 1,
+        updatedAt: NOW,
+      });
+    });
+
+    await expect(
+      t.mutation(CM.accounts.syncStoredEntitlement, { userId: OWNER_A }),
+    ).resolves.toMatchObject({ lifecycle: "entitled" });
+    await expect(
+      t.mutation(CM.companies.createCompanyForOwner, {
+        ownerUserId: OWNER_A,
+        clientRequestId: "duplicate-entitlement-first",
+        company: company("Duplicate Entitlement Corp", "duplicate-entitlement"),
+      }),
+    ).resolves.toMatchObject({ status: "created" });
+  });
+
+  test("ordinary lapse waits 24 hours while terminal deletion bypasses grace", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "grace-company",
+      company: company("Grace Corp", "grace-corp"),
+    });
+
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const lapsed = await accountFor(t, OWNER_A);
+    expect(lapsed).toMatchObject({
+      lifecycle: "entitlement_lapsed",
+      purgePhase: "pending",
+      purgeAfter: NOW + DAY_MS,
+      destructivePurgeStarted: false,
+    });
+    const purgeArgs = {
+      ownerFenceHash: lapsed!.ownerFenceHash,
+      purgeGeneration: lapsed!.purgeGeneration,
+    };
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "waiting",
+      purgeAfter: NOW + DAY_MS,
+    });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      purgePhase: "pending",
+      destructivePurgeStarted: false,
+    });
+
+    vi.setSystemTime(NOW + 2 * HOUR_MS);
+    expect(await t.mutation(CM.accounts.reapStalledAccountPurges, {})).toEqual({
+      scanned: 1,
+      scheduled: 0,
+      deferred: 1,
+    });
+
+    const terminal = await t.mutation(CM.accounts.markOwnerDeleted, { ownerUserId: OWNER_A });
+    expect(terminal).toMatchObject({
+      lifecycle: "denied",
+      terminalReason: "owner_deleted",
+      purgePhase: "pending",
+    });
+    expect(terminal?.purgeAfter).toBeUndefined();
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, {
+      ownerFenceHash: terminal!.ownerFenceHash,
+      purgeGeneration: terminal!.purgeGeneration,
+    })).toEqual({ status: "started" });
+  });
+
+  test("stalled-purge reaper is bounded and defers ordinary pending grace", async () => {
+    const t = convexTest(schema, modules);
+    const staleAt = NOW - 2 * HOUR_MS;
+    await t.run(async (ctx) => {
+      for (let index = 0; index < 51; index += 1) {
+        await ctx.db.insert("companyMonitoringAccounts", {
+          logicalAccountId: `reaper-account-${index}`,
+          ownerUserId: `reaper-owner-${index}`,
+          ownerFenceHash: `reaper-fence-${index}`,
+          lifecycle: "entitlement_lapsed",
+          lifecycleSequence: 1,
+          companyCount: 0,
+          companyLimit: 500,
+          snapshotGeneration: 0,
+          purgeGeneration: 1,
+          purgePhase: "finalizing",
+          destructivePurgeStarted: true,
+          pendingReactivation: false,
+          createdAt: staleAt,
+          updatedAt: staleAt,
+        });
+      }
+      await ctx.db.insert("companyMonitoringAccounts", {
+        logicalAccountId: "reaper-grace-account",
+        ownerUserId: "reaper-grace-owner",
+        ownerFenceHash: "reaper-grace-fence",
+        lifecycle: "entitlement_lapsed",
+        lifecycleSequence: 1,
+        companyCount: 0,
+        companyLimit: 500,
+        snapshotGeneration: 0,
+        purgeGeneration: 1,
+        purgePhase: "pending",
+        destructivePurgeStarted: false,
+        pendingReactivation: false,
+        purgeAfter: NOW + DAY_MS,
+        createdAt: staleAt,
+        updatedAt: staleAt,
+      });
+    });
+
+    expect(await t.mutation(CM.accounts.reapStalledAccountPurges, {})).toEqual({
+      scanned: 50,
+      scheduled: 50,
+      deferred: 0,
+    });
+    expect(await t.mutation(CM.accounts.reapStalledAccountPurges, {})).toEqual({
+      scanned: 2,
+      scheduled: 1,
+      deferred: 1,
+    });
+    let scheduled = await t.run(async (ctx) =>
+      ctx.db.system.query("_scheduled_functions").collect()
+    );
+    expect(scheduled.filter((job) => job.name.includes("advanceAccountPurge"))).toHaveLength(51);
+
+    // Leave every continuation unexecuted to model a dropped scheduler drain.
+    // Once the reaper's one-hour stale threshold elapses, the same fenced
+    // generations are enqueued again instead of remaining stuck forever.
+    vi.setSystemTime(NOW + 2 * HOUR_MS);
+    expect(await t.mutation(CM.accounts.reapStalledAccountPurges, {})).toEqual({
+      scanned: 50,
+      scheduled: 50,
+      deferred: 0,
+    });
+    scheduled = await t.run(async (ctx) =>
+      ctx.db.system.query("_scheduled_functions").collect()
+    );
+    expect(scheduled.filter((job) => job.name.includes("advanceAccountPurge"))).toHaveLength(101);
+  });
+
+  test("account purge clears replay metadata while individual removal retains it", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    const root = await accountFor(t, OWNER_A);
+    const direct = await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "replay-metadata-direct",
+      company: company("Replay Metadata Direct", "replay-metadata-direct"),
+    });
+    const imported = await t.action(CM.imports.importCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+      rows: [{
+        ...company("Replay Metadata Import", "replay-metadata-import"),
+        clientImportId: "replay-metadata-import-batch",
+        ordinal: 0,
+      }],
+    });
+    const importedBeforePurge = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q
+            .eq("ownerAccountId", root!.logicalAccountId)
+            .eq("companyId", imported.results[0]!.companyId!),
+        )
+        .unique()
+    );
+    expect(importedBeforePurge).toMatchObject({
+      clientImportId: "replay-metadata-import-batch",
+      importOrdinal: 0,
+      importFingerprint: expect.any(String),
+    });
+
+    await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: direct.companyId,
+      state: "removed",
+    });
+    const individuallyRemoved = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", root!.logicalAccountId).eq("companyId", direct.companyId),
+        )
+        .unique()
+    );
+    await t.mutation(CM.companies.advanceCompanyPurge, {
+      ownerAccountId: root!.logicalAccountId,
+      companyId: direct.companyId,
+      purgeGeneration: individuallyRemoved!.purgeGeneration,
+    });
+    expect(await t.run(async (ctx) => ctx.db.get(individuallyRemoved!._id))).toMatchObject({
+      directRequestId: "replay-metadata-direct",
+      directFingerprint: expect.any(String),
+      purgePhase: "complete",
+    });
+
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const lapsed = await accountFor(t, OWNER_A);
+    vi.setSystemTime(NOW + DAY_MS);
+    const purgeArgs = {
+      ownerFenceHash: lapsed!.ownerFenceHash,
+      purgeGeneration: lapsed!.purgeGeneration,
+    };
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "started",
+    });
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "finalizing",
+    });
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "complete",
+    });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) => q.eq("ownerAccountId", root!.logicalAccountId))
+        .collect()
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.find((row) => row.companyId === imported.results[0]?.companyId)).toBeDefined();
+    for (const row of rows) {
+      expect(row.directRequestId).toBeUndefined();
+      expect(row.directFingerprint).toBeUndefined();
+      expect(row.clientImportId).toBeUndefined();
+      expect(row.importOrdinal).toBeUndefined();
+      expect(row.importFingerprint).toBeUndefined();
+    }
+  });
+
+  test("finalization rechecks entitlement and clears stale pending reactivation", async () => {
+    const t = convexTest(schema, modules);
+    await grant(t, OWNER_A);
+    await t.mutation(CM.companies.createCompanyForOwner, {
+      ownerUserId: OWNER_A,
+      clientRequestId: "stale-reactivation-company",
+      company: company("Stale Reactivation Corp", "stale-reactivation"),
+    });
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const lapsed = await accountFor(t, OWNER_A);
+    vi.setSystemTime(NOW + DAY_MS);
+    const purgeArgs = {
+      ownerFenceHash: lapsed!.ownerFenceHash,
+      purgeGeneration: lapsed!.purgeGeneration,
+    };
+    await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs);
+
+    await setStoredEntitlement(t, OWNER_A, "api_starter", FUTURE);
+    const pending = await accountFor(t, OWNER_A);
+    expect(pending).toMatchObject({ pendingReactivation: true });
+    await t.run(async (ctx) => {
+      const entitlement = await ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", OWNER_A))
+        .first();
+      await ctx.db.patch(entitlement!._id, {
+        planKey: "free",
+        features: getFeaturesForPlan("free"),
+        validUntil: NOW - 1,
+        updatedAt: NOW + DAY_MS,
+      });
+    });
+
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "finalizing",
+    });
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, purgeArgs)).toEqual({
+      status: "complete",
+    });
+    expect(await accountFor(t, OWNER_A)).toMatchObject({
+      lifecycle: "entitlement_lapsed",
+      lifecycleSequence: pending!.lifecycleSequence + 1,
+      pendingReactivation: false,
+      destructivePurgeStarted: true,
+      purgePhase: "complete",
+    });
+    expect((await accountFor(t, OWNER_A))?.purgeAfter).toBeUndefined();
+  });
+});

--- a/convex/__tests__/companyMonitoringPurgePersistence.test.ts
+++ b/convex/__tests__/companyMonitoringPurgePersistence.test.ts
@@ -225,11 +225,10 @@ describe("Company Monitoring purge persistence", () => {
       companyId: direct.companyId,
       purgeGeneration: individuallyRemoved!.purgeGeneration,
     });
-    expect(await t.run(async (ctx) => ctx.db.get(individuallyRemoved!._id))).toMatchObject({
-      directRequestId: "replay-metadata-direct",
-      directFingerprint: expect.any(String),
-      purgePhase: "complete",
-    });
+    const individuallyPurged = await t.run(async (ctx) => ctx.db.get(individuallyRemoved!._id));
+    expect(individuallyPurged).toMatchObject({ purgePhase: "complete" });
+    expect(individuallyPurged?.directRequestId).toBeUndefined();
+    expect(individuallyPurged?.directFingerprint).toBeUndefined();
 
     await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
     const lapsed = await accountFor(t, OWNER_A);

--- a/convex/__tests__/companyMonitoringPurgePersistence.test.ts
+++ b/convex/__tests__/companyMonitoringPurgePersistence.test.ts
@@ -7,6 +7,7 @@ import {
   company,
   FUTURE,
   grant,
+  grantProvisioned,
   installCompanyMonitoringTestEnvironment,
   modules,
   NOW,
@@ -54,7 +55,7 @@ describe("Company Monitoring purge persistence", () => {
 
   test("ordinary lapse waits 24 hours while terminal deletion bypasses grace", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     await t.mutation(CM.companies.createCompanyForOwner, {
       ownerUserId: OWNER_A,
       clientRequestId: "grace-company",
@@ -175,7 +176,7 @@ describe("Company Monitoring purge persistence", () => {
 
   test("account purge clears replay metadata while individual removal retains it", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     const root = await accountFor(t, OWNER_A);
     const direct = await t.mutation(CM.companies.createCompanyForOwner, {
       ownerUserId: OWNER_A,
@@ -266,7 +267,7 @@ describe("Company Monitoring purge persistence", () => {
 
   test("finalization rechecks entitlement and clears stale pending reactivation", async () => {
     const t = convexTest(schema, modules);
-    await grant(t, OWNER_A);
+    await grantProvisioned(t, OWNER_A);
     await t.mutation(CM.companies.createCompanyForOwner, {
       ownerUserId: OWNER_A,
       clientRequestId: "stale-reactivation-company",

--- a/convex/__tests__/companyMonitoringTestHelpers.ts
+++ b/convex/__tests__/companyMonitoringTestHelpers.ts
@@ -11,13 +11,16 @@ export const FUTURE = NOW + 30 * 24 * 60 * 60 * 1000;
 export const OWNER_A = "user_company_monitoring_a";
 export const OWNER_B = "user_company_monitoring_b";
 export const CM = internal.companyMonitoring;
-export const TEST_SIGNING_SECRET = "test-company-monitoring-owner-fence-secret";
-export const OLD_SIGNING_SECRET = "old-company-monitoring-owner-fence-secret";
-export const INTERMEDIATE_SIGNING_SECRET = "intermediate-company-monitoring-owner-fence-secret";
-export const NEW_SIGNING_SECRET = "new-company-monitoring-owner-fence-secret";
+export const TEST_DODO_IDENTITY_SIGNING_SECRET = "test-dodo-identity-signing-secret";
+export const ROTATED_DODO_IDENTITY_SIGNING_SECRET = "rotated-dodo-identity-signing-secret";
+export const TEST_OWNER_FENCE_SECRET = "test-company-monitoring-owner-fence-secret";
+export const OLD_OWNER_FENCE_SECRET = "old-company-monitoring-owner-fence-secret";
+export const INTERMEDIATE_OWNER_FENCE_SECRET = "intermediate-company-monitoring-owner-fence-secret";
+export const NEW_OWNER_FENCE_SECRET = "new-company-monitoring-owner-fence-secret";
 
 const MUTATED_ENV_KEYS = [
   "DODO_IDENTITY_SIGNING_SECRET",
+  "COMPANY_MONITORING_OWNER_FENCE_SECRET",
   "COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS",
   "UPSTASH_REDIS_REST_URL",
   "UPSTASH_REDIS_REST_TOKEN",
@@ -92,7 +95,8 @@ export function installCompanyMonitoringTestEnvironment() {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
     for (const key of MUTATED_ENV_KEYS) delete process.env[key];
-    process.env.DODO_IDENTITY_SIGNING_SECRET = TEST_SIGNING_SECRET;
+    process.env.DODO_IDENTITY_SIGNING_SECRET = TEST_DODO_IDENTITY_SIGNING_SECRET;
+    process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET = TEST_OWNER_FENCE_SECRET;
   });
 
   afterEach(() => {

--- a/convex/__tests__/companyMonitoringTestHelpers.ts
+++ b/convex/__tests__/companyMonitoringTestHelpers.ts
@@ -1,0 +1,108 @@
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, vi } from "vitest";
+import { internal } from "../_generated/api";
+import { getFeaturesForPlan } from "../lib/entitlements";
+import companyMonitoringSchema from "../schema";
+
+export const modules = import.meta.glob("../**/*.ts");
+export const schema = companyMonitoringSchema;
+export const NOW = Date.parse("2026-08-05T12:00:00.000Z");
+export const FUTURE = NOW + 30 * 24 * 60 * 60 * 1000;
+export const OWNER_A = "user_company_monitoring_a";
+export const OWNER_B = "user_company_monitoring_b";
+export const CM = internal.companyMonitoring;
+export const TEST_SIGNING_SECRET = "test-company-monitoring-owner-fence-secret";
+export const OLD_SIGNING_SECRET = "old-company-monitoring-owner-fence-secret";
+export const INTERMEDIATE_SIGNING_SECRET = "intermediate-company-monitoring-owner-fence-secret";
+export const NEW_SIGNING_SECRET = "new-company-monitoring-owner-fence-secret";
+
+const MUTATED_ENV_KEYS = [
+  "DODO_IDENTITY_SIGNING_SECRET",
+  "COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS",
+  "UPSTASH_REDIS_REST_URL",
+  "UPSTASH_REDIS_REST_TOKEN",
+  "VERCEL_ENV",
+  "VERCEL_GIT_COMMIT_SHA",
+] as const;
+const ORIGINAL_ENV = Object.fromEntries(
+  MUTATED_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof MUTATED_ENV_KEYS)[number], string | undefined>;
+
+export function company(name: string, customerReference?: string) {
+  return {
+    name,
+    domicileCountry: "US",
+    aliases: [`${name} Holdings`],
+    domains: [`${name.toLowerCase().replaceAll(" ", "-")}.example`],
+    identifiers: [`lei:${name.toLowerCase().replaceAll(" ", "-")}`],
+    xHandles: [name.toLowerCase().replaceAll(" ", "_").slice(0, 15)],
+    locations: ["New York, US"],
+    ...(customerReference ? { customerReference } : {}),
+  };
+}
+
+export async function grant(
+  t: ReturnType<typeof convexTest>,
+  userId: string,
+  planKey = "api_starter",
+) {
+  return t.mutation(internal.payments.billing.grantComplimentaryEntitlement, {
+    userId,
+    planKey,
+    days: 30,
+    reason: "company monitoring onboarding test",
+  });
+}
+
+export async function setStoredEntitlement(
+  t: ReturnType<typeof convexTest>,
+  userId: string,
+  planKey: string,
+  validUntil: number,
+  updatedAt = NOW,
+) {
+  await t.run(async (ctx) => {
+    const row = await ctx.db
+      .query("entitlements")
+      .withIndex("by_userId", (q) => q.eq("userId", userId))
+      .unique();
+    const value = {
+      planKey,
+      features: getFeaturesForPlan(planKey),
+      validUntil,
+      updatedAt,
+    };
+    if (row) await ctx.db.patch(row._id, value);
+    else await ctx.db.insert("entitlements", { userId, ...value });
+  });
+  await t.mutation(CM.accounts.syncStoredEntitlement, { userId });
+}
+
+export async function accountFor(t: ReturnType<typeof convexTest>, userId: string) {
+  return t.run(async (ctx) =>
+    ctx.db
+      .query("companyMonitoringAccounts")
+      .withIndex("by_ownerUserId", (q) => q.eq("ownerUserId", userId))
+      .unique(),
+  );
+}
+
+export function installCompanyMonitoringTestEnvironment() {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    for (const key of MUTATED_ENV_KEYS) delete process.env[key];
+    process.env.DODO_IDENTITY_SIGNING_SECRET = TEST_SIGNING_SECRET;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    for (const key of MUTATED_ENV_KEYS) {
+      const original = ORIGINAL_ENV[key];
+      if (original === undefined) delete process.env[key];
+      else process.env[key] = original;
+    }
+  });
+}

--- a/convex/__tests__/companyMonitoringTestHelpers.ts
+++ b/convex/__tests__/companyMonitoringTestHelpers.ts
@@ -57,6 +57,23 @@ export async function grant(
   });
 }
 
+/**
+ * Grant an entitlement AND provision the account root.
+ *
+ * `grant` alone deliberately provisions nothing (#6256) — entitlement writes no
+ * longer touch Company Monitoring. Tests that need a root as a *precondition*
+ * use this; tests asserting the decoupling itself use bare `grant`.
+ */
+export async function grantProvisioned(
+  t: ReturnType<typeof convexTest>,
+  userId: string,
+  planKey = "api_starter",
+) {
+  const result = await grant(t, userId, planKey);
+  await t.mutation(CM.accounts.syncStoredEntitlement, { userId });
+  return result;
+}
+
 export async function setStoredEntitlement(
   t: ReturnType<typeof convexTest>,
   userId: string,

--- a/convex/__tests__/setup.ts
+++ b/convex/__tests__/setup.ts
@@ -5,4 +5,6 @@ import { beforeEach } from "vitest";
 // that production must provide; individual tests may still override it.
 beforeEach(() => {
   process.env.DODO_IDENTITY_SIGNING_SECRET ??= "test-global-dodo-identity-signing-secret";
+  process.env.COMPANY_MONITORING_OWNER_FENCE_SECRET ??=
+    "test-global-company-monitoring-owner-fence-secret";
 });

--- a/convex/__tests__/setup.ts
+++ b/convex/__tests__/setup.ts
@@ -1,0 +1,8 @@
+import { beforeEach } from "vitest";
+
+// Company Monitoring owner roots are synchronously coupled to entitlement
+// mutations. Give every Convex test the same deterministic keyed-fence setup
+// that production must provide; individual tests may still override it.
+beforeEach(() => {
+  process.env.DODO_IDENTITY_SIGNING_SECRET ??= "test-global-dodo-identity-signing-secret";
+});

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -24,6 +24,10 @@ import type * as broadcast_proLaunchEmailContent from "../broadcast/proLaunchEma
 import type * as broadcast_rampRunner from "../broadcast/rampRunner.js";
 import type * as broadcast_sendBroadcast from "../broadcast/sendBroadcast.js";
 import type * as broadcast_waveRuns from "../broadcast/waveRuns.js";
+import type * as companyMonitoring__shared from "../companyMonitoring/_shared.js";
+import type * as companyMonitoring_accounts from "../companyMonitoring/accounts.js";
+import type * as companyMonitoring_companies from "../companyMonitoring/companies.js";
+import type * as companyMonitoring_imports from "../companyMonitoring/imports.js";
 import type * as config_productCatalog from "../config/productCatalog.js";
 import type * as constants from "../constants.js";
 import type * as contactMessages from "../contactMessages.js";
@@ -83,6 +87,10 @@ declare const fullApi: ApiFromModules<{
   "broadcast/rampRunner": typeof broadcast_rampRunner;
   "broadcast/sendBroadcast": typeof broadcast_sendBroadcast;
   "broadcast/waveRuns": typeof broadcast_waveRuns;
+  "companyMonitoring/_shared": typeof companyMonitoring__shared;
+  "companyMonitoring/accounts": typeof companyMonitoring_accounts;
+  "companyMonitoring/companies": typeof companyMonitoring_companies;
+  "companyMonitoring/imports": typeof companyMonitoring_imports;
   "config/productCatalog": typeof config_productCatalog;
   constants: typeof constants;
   contactMessages: typeof contactMessages;

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -2,6 +2,7 @@ import { ConvexError, v } from "convex/values";
 import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { requireUserId, resolveUserId } from "./lib/auth";
 import { activeAccountForOwner } from "./companyMonitoring/_shared";
+import { ensureActiveAccount } from "./companyMonitoring/accounts";
 import {
   COMPANY_MONITORING_RPC_SCOPES,
   type CompanyMonitoringApiScope,
@@ -64,8 +65,10 @@ export const createApiKey = mutation({
     }
 
     const scopes = normalizeCompanyMonitoringScopes(args.scopes);
+    // Issuing a scoped key is a first-use entry point, so it provisions the
+    // root. Requesting no scopes must stay entirely off Company Monitoring.
     const companyMonitoringAccount = scopes
-      ? await activeAccountForOwner(ctx, userId, entitlement)
+      ? await ensureActiveAccount(ctx, userId, entitlement)
       : null;
     if (scopes && !companyMonitoringAccount) {
       throw new ConvexError("COMPANY_MONITORING_ACCESS_DENIED");

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -1,9 +1,28 @@
 import { ConvexError, v } from "convex/values";
 import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
 import { requireUserId, resolveUserId } from "./lib/auth";
+import { activeAccountForOwner } from "./companyMonitoring/_shared";
+import {
+  COMPANY_MONITORING_RPC_SCOPES,
+  type CompanyMonitoringApiScope,
+} from "../shared/company-monitoring-contract";
 
 /** Maximum number of active (non-revoked) API keys per user. */
 const MAX_KEYS_PER_USER = 5;
+const COMPANY_MONITORING_SCOPES = [
+  ...new Set(Object.values(COMPANY_MONITORING_RPC_SCOPES)),
+] as CompanyMonitoringApiScope[];
+
+function normalizeCompanyMonitoringScopes(scopes: string[] | undefined) {
+  if (!scopes || scopes.length === 0) return undefined;
+  if (scopes.length > COMPANY_MONITORING_SCOPES.length || new Set(scopes).size !== scopes.length) {
+    throw new ConvexError("INVALID_API_KEY_SCOPES");
+  }
+  if (scopes.some((scope) => !(COMPANY_MONITORING_SCOPES as readonly string[]).includes(scope))) {
+    throw new ConvexError("INVALID_API_KEY_SCOPES");
+  }
+  return [...scopes].sort() as CompanyMonitoringApiScope[];
+}
 
 // ---------------------------------------------------------------------------
 // Public mutations & queries (require Clerk JWT via ctx.auth)
@@ -24,6 +43,7 @@ export const createApiKey = mutation({
     name: v.string(),
     keyPrefix: v.string(),
     keyHash: v.string(),
+    scopes: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
     const userId = await requireUserId(ctx);
@@ -41,6 +61,14 @@ export const createApiKey = mutation({
       !entitlement.features.apiAccess
     ) {
       throw new ConvexError("API_ACCESS_REQUIRED");
+    }
+
+    const scopes = normalizeCompanyMonitoringScopes(args.scopes);
+    const companyMonitoringAccount = scopes
+      ? await activeAccountForOwner(ctx, userId, entitlement)
+      : null;
+    if (scopes && !companyMonitoringAccount) {
+      throw new ConvexError("COMPANY_MONITORING_ACCESS_DENIED");
     }
 
     if (!args.name.trim()) {
@@ -92,10 +120,18 @@ export const createApiKey = mutation({
       name: args.name.trim(),
       keyPrefix: args.keyPrefix,
       keyHash: args.keyHash,
+      scopes,
+      companyMonitoringAccountId: companyMonitoringAccount?.logicalAccountId,
       createdAt: Date.now(),
     });
 
-    return { id, name: args.name.trim(), keyPrefix: args.keyPrefix };
+    return {
+      id,
+      name: args.name.trim(),
+      keyPrefix: args.keyPrefix,
+      scopes,
+      companyMonitoringAccountId: companyMonitoringAccount?.logicalAccountId,
+    };
   },
 });
 
@@ -124,6 +160,8 @@ export const listApiKeys = query({
       createdAt: k.createdAt,
       lastUsedAt: k.lastUsedAt,
       revokedAt: k.revokedAt,
+      scopes: k.scopes,
+      companyMonitoringAccountId: k.companyMonitoringAccountId,
     }));
   },
 });
@@ -166,10 +204,34 @@ export const validateKeyByHash = internalQuery({
 
     if (!key || key.revokedAt) return null;
 
+    if (key.scopes && key.scopes.length > 0) {
+      let scopes: string[] | undefined;
+      try {
+        scopes = normalizeCompanyMonitoringScopes(key.scopes);
+      } catch {
+        return null;
+      }
+      const account = await activeAccountForOwner(ctx, key.userId);
+      if (
+        !scopes ||
+        !account ||
+        !key.companyMonitoringAccountId ||
+        account.logicalAccountId !== key.companyMonitoringAccountId
+      ) {
+        return null;
+      }
+    } else if (key.companyMonitoringAccountId) {
+      // A binding without issued scopes is malformed/ownerless credential
+      // state and must never authenticate through a legacy fallback.
+      return null;
+    }
+
     return {
       id: key._id,
       userId: key.userId,
       name: key.name,
+      scopes: key.scopes,
+      companyMonitoringAccountId: key.companyMonitoringAccountId,
     };
   },
 });

--- a/convex/companyMonitoring/_shared.ts
+++ b/convex/companyMonitoring/_shared.ts
@@ -1,0 +1,137 @@
+import { ConvexError } from "convex/values";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import type { Doc } from "../_generated/dataModel";
+import {
+  COMPANY_MONITORING_LIMITS,
+  type NormalizedMonitoredCompanyInput,
+} from "../../shared/company-monitoring-contract";
+
+export const COMPANY_LIMIT = COMPANY_MONITORING_LIMITS.maxCompaniesPerAccount;
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const REQUEST_CONTROL = /[\u0000-\u001f\u007f-\u009f\u00ad\u061c\u180e\u200b-\u200f\u2028-\u202e\u2060-\u206f\ufeff\ufff9-\ufffb]/u;
+
+type CompanyMonitoringCtx = MutationCtx | QueryCtx;
+
+export function normalizeRequestId(value: string, field = "clientRequestId"): string {
+  if (typeof value !== "string" || REQUEST_CONTROL.test(value)) {
+    throw new ConvexError(`INVALID_${field.toUpperCase()}`);
+  }
+  const normalized = value.normalize("NFC").trim();
+  if (!normalized || new TextEncoder().encode(normalized).byteLength > 64) {
+    throw new ConvexError(`INVALID_${field.toUpperCase()}`);
+  }
+  return normalized;
+}
+
+export async function fingerprint(value: unknown): Promise<string> {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function encodeTime(time: number): string {
+  let remaining = Math.max(0, Math.trunc(time));
+  let result = "";
+  for (let i = 0; i < 10; i += 1) {
+    result = CROCKFORD[remaining % 32] + result;
+    remaining = Math.floor(remaining / 32);
+  }
+  return result;
+}
+
+export function logicalId(kind: "account" | "company" | "claim", now = Date.now()): string {
+  const random = new Uint8Array(16);
+  crypto.getRandomValues(random);
+  const suffix = encodeTime(now) + Array.from(random, (byte) => CROCKFORD[byte & 31]).join("");
+  return `cm_${kind}_${suffix}`;
+}
+
+export async function activeAccountForOwner(
+  ctx: CompanyMonitoringCtx,
+  ownerUserId: string,
+  knownEntitlement?: Doc<"entitlements"> | null,
+) {
+  const entitlementPromise = knownEntitlement === undefined
+    ? ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", ownerUserId))
+        .unique()
+    : Promise.resolve(knownEntitlement);
+  const [account, entitlement] = await Promise.all([
+    ctx.db
+      .query("companyMonitoringAccounts")
+      .withIndex("by_ownerUserId", (q) => q.eq("ownerUserId", ownerUserId))
+      .unique(),
+    entitlementPromise,
+  ]);
+  const activeEntitlement = Boolean(
+    entitlement &&
+    entitlement.planKey !== "free" &&
+    entitlement.features.tier > 0 &&
+    entitlement.validUntil >= Date.now(),
+  );
+  if (
+    !account ||
+    !activeEntitlement ||
+    account.lifecycle !== "entitled" ||
+    account.ownerUserId !== ownerUserId ||
+    account.terminalReason
+  ) {
+    return null;
+  }
+  return account;
+}
+
+export async function requireActiveAccount(ctx: CompanyMonitoringCtx, ownerUserId: string) {
+  const account = await activeAccountForOwner(ctx, ownerUserId);
+  if (!account) throw new ConvexError("COMPANY_MONITORING_ACCESS_DENIED");
+  return account;
+}
+
+function claimsFromCompany(company: NormalizedMonitoredCompanyInput) {
+  return [
+    ...company.aliases.map((value) => ({ type: "alias" as const, value })),
+    ...company.domains.map((value) => ({ type: "domain" as const, value })),
+    ...company.identifiers.map((value) => ({ type: "legal_identifier" as const, value })),
+    ...company.xHandles.map((value) => ({ type: "x_handle" as const, value })),
+    ...company.locations.map((value) => ({ type: "location" as const, value })),
+    ...(company.customerReference
+      ? [{ type: "customer_reference" as const, value: company.customerReference }]
+      : []),
+  ];
+}
+
+export async function insertClaims(
+  ctx: MutationCtx,
+  ownerAccountId: string,
+  companyId: string,
+  company: NormalizedMonitoredCompanyInput,
+  now: number,
+) {
+  for (const claim of claimsFromCompany(company)) {
+    await ctx.db.insert("companyMonitoringClaims", {
+      ownerAccountId,
+      companyId,
+      claimId: logicalId("claim", now),
+      ...claim,
+      provenance: "customer",
+      trustState: "unverified",
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+}
+
+export async function deleteCompanyClaims(
+  ctx: MutationCtx,
+  ownerAccountId: string,
+  companyId: string,
+) {
+  const claims = await ctx.db
+    .query("companyMonitoringClaims")
+    .withIndex("by_account_company", (q) =>
+      q.eq("ownerAccountId", ownerAccountId).eq("companyId", companyId),
+    )
+    .collect();
+  for (const claim of claims) await ctx.db.delete(claim._id);
+}

--- a/convex/companyMonitoring/_shared.ts
+++ b/convex/companyMonitoring/_shared.ts
@@ -55,7 +55,7 @@ export async function activeAccountForOwner(
     ? ctx.db
         .query("entitlements")
         .withIndex("by_userId", (q) => q.eq("userId", ownerUserId))
-        .unique()
+        .first()
     : Promise.resolve(knownEntitlement);
   const [account, entitlement] = await Promise.all([
     ctx.db

--- a/convex/companyMonitoring/accounts.ts
+++ b/convex/companyMonitoring/accounts.ts
@@ -5,11 +5,16 @@ import type { Doc } from "../_generated/dataModel";
 import {
   ANON_ID_V4_REGEX,
   companyMonitoringOwnerFenceCandidates,
-  tryCompanyMonitoringOwnerFenceCandidates,
   type CompanyMonitoringOwnerFenceCandidates,
 } from "../lib/identitySigning";
 import { COMPANY_MONITORING_LIMITS } from "../../shared/company-monitoring-contract";
-import { COMPANY_LIMIT, deleteCompanyClaims, fingerprint, logicalId } from "./_shared";
+import {
+  activeAccountForOwner,
+  COMPANY_LIMIT,
+  deleteCompanyClaims,
+  fingerprint,
+  logicalId,
+} from "./_shared";
 
 const PURGE_TRANSACTION_DOCUMENT_LIMIT = 8_192;
 // Reserve room for the account read/write, the lookahead company, scheduler
@@ -28,6 +33,11 @@ const PURGE_BATCH_SIZE = Math.floor(
 const ORDINARY_LAPSE_PURGE_GRACE_MS = 24 * 60 * 60 * 1000;
 const STALLED_PURGE_AGE_MS = 60 * 60 * 1000;
 const STALLED_PURGE_REAPER_BATCH_SIZE = 50;
+// Entitled roots are re-derived from the entitlements row on this cadence.
+// Detection latency is bounded by (age + cron period) and is absorbed by the
+// 24h purgeAfter grace that already delays destructive work.
+const ENTITLED_RECHECK_AGE_MS = 60 * 60 * 1000;
+const ENTITLED_RECHECK_BATCH_SIZE = 50;
 const REAPABLE_PURGE_PHASES = ["finalizing", "companies", "pending"] as const;
 
 async function canonicalEntitlement(ctx: MutationCtx, userId: string) {
@@ -119,22 +129,13 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
   // Browser UUID purchases are deliberately invisible to Company Monitoring
   // until claimSubscription has recomputed the real authenticated owner.
   if (ANON_ID_V4_REGEX.test(userId)) return null;
-  // Resolve the fence BEFORE canonicalEntitlement, which performs this
-  // transaction's first write (its deliberate same-value serialization patch).
-  // Convex has no savepoints, so bailing out after any write would commit
-  // partial state; bailing here commits nothing. A misconfigured keyring must
-  // degrade Company Monitoring, never abort the entitlement write this runs
-  // inside — a config fault is not transient, so the caller's retry would fail
-  // identically forever. Genuine data conflicts below still throw.
-  const resolved = await tryCompanyMonitoringOwnerFenceCandidates(userId);
-  if (!resolved.ok) {
-    console.error(
-      `[companyMonitoring] owner fence unavailable; skipping account sync for ${userId}: ${resolved.reason}`,
-    );
-    return null;
-  }
+  // Throws on a misconfigured fence keyring, which is correct now that this
+  // runs only from Company Monitoring's own entry points (#6256): the caller is
+  // actively using the feature, so failing loudly beats silently skipping.
+  // The degrade path this used to need existed only because entitlement writes
+  // called in here.
   const canonical = await canonicalEntitlement(ctx, userId);
-  const ownerFence = resolved.fence;
+  const ownerFence = await companyMonitoringOwnerFenceCandidates(userId);
   const ownerFenceHash = ownerFence.current;
   const match = await findAccountByOwnerFence(ctx, ownerFence);
   let existing = match?.account ?? null;
@@ -289,11 +290,42 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
   return ctx.db.get(existing._id);
 }
 
-/** Internal repair/test seam; production entitlement writers call the helper directly. */
+/** Internal repair/test seam; nothing on the entitlement write path calls this. */
 export const syncStoredEntitlement = internalMutation({
   args: { userId: v.string() },
   handler: async (ctx, args) => syncCompanyMonitoringAccountFromEntitlement(ctx, args.userId),
 });
+
+/**
+ * Resolve the caller's account root, provisioning it on first use.
+ *
+ * This is the lazy half of #6256: entitlement writes no longer push a root at
+ * every subscriber, so the root is created the first time someone actually
+ * uses Company Monitoring. Mutation-only by construction — `activeAccountForOwner`
+ * stays the read-only resolver for query callers such as
+ * `apiKeys.validateKeyByHash`, which cannot write.
+ *
+ * Provisioning delegates to the same state machine the reaper uses, so a
+ * terminal tombstone still refuses to yield an active account: the sync returns
+ * the terminal row untouched and the re-resolve below rejects it.
+ */
+export async function ensureActiveAccount(
+  ctx: MutationCtx,
+  ownerUserId: string,
+  knownEntitlement?: Doc<"entitlements"> | null,
+) {
+  const existing = await activeAccountForOwner(ctx, ownerUserId, knownEntitlement);
+  if (existing) return existing;
+  await syncCompanyMonitoringAccountFromEntitlement(ctx, ownerUserId);
+  return activeAccountForOwner(ctx, ownerUserId, knownEntitlement);
+}
+
+/** `requireActiveAccount` for the entry points that may provision. */
+export async function requireProvisionedAccount(ctx: MutationCtx, ownerUserId: string) {
+  const account = await ensureActiveAccount(ctx, ownerUserId);
+  if (!account) throw new ConvexError("COMPANY_MONITORING_ACCESS_DENIED");
+  return account;
+}
 
 async function terminalize(
   ctx: MutationCtx,
@@ -541,5 +573,52 @@ export const reapStalledAccountPurges = internalMutation({
     }
 
     return { scanned, scheduled, deferred };
+  },
+});
+
+/**
+ * Pull-side replacement for the entitlement-write push removed in #6256.
+ *
+ * Scans entitled roots oldest-first and re-derives each owner's canonical
+ * entitlement. `syncCompanyMonitoringAccountFromEntitlement` is the same state
+ * machine first-use provisioning calls, so a lapse transitions and schedules
+ * purge here exactly as it used to when billing drove it.
+ *
+ * Scanning `companyMonitoringAccounts` rather than `entitlements` is the whole
+ * point: this table holds only owners who actually use the feature, so
+ * subscribers who never touch Company Monitoring cost nothing.
+ */
+export const reconcileAccountEntitlements = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const staleBefore = now - ENTITLED_RECHECK_AGE_MS;
+    const accounts = await ctx.db
+      .query("companyMonitoringAccounts")
+      .withIndex("by_lifecycle_updatedAt", (q) =>
+        q.eq("lifecycle", "entitled").lt("updatedAt", staleBefore),
+      )
+      .take(ENTITLED_RECHECK_BATCH_SIZE);
+
+    let scanned = 0;
+    let lapsed = 0;
+    for (const account of accounts) {
+      scanned += 1;
+      const ownerUserId = account.ownerUserId;
+      // A terminal row never carries an owner; skip rather than resurrect.
+      if (!ownerUserId || account.terminalReason) continue;
+      const before = account.lifecycle;
+      const synced = await syncCompanyMonitoringAccountFromEntitlement(ctx, ownerUserId);
+      if (synced && synced.lifecycle !== before) lapsed += 1;
+      // Always advance the cursor, including for still-entitled rows the sync
+      // left untouched — otherwise the same 50 rows are rescanned every tick
+      // and newer ones are never reached.
+      const current = await ctx.db.get(account._id);
+      if (current && current.updatedAt < now) {
+        await ctx.db.patch(account._id, { updatedAt: now });
+      }
+    }
+
+    return { scanned, lapsed };
   },
 });

--- a/convex/companyMonitoring/accounts.ts
+++ b/convex/companyMonitoring/accounts.ts
@@ -87,7 +87,7 @@ async function scheduleScopedKeyCacheInvalidation(ctx: MutationCtx, ownerUserId:
   if (keyHashes.length === 0) return;
   await ctx.scheduler.runAfter(
     0,
-    (internal as any).payments.cacheActions.invalidateUserApiKeyCaches,
+    internal.payments.cacheActions.invalidateUserApiKeyCaches,
     { keyHashes },
   );
 }
@@ -100,7 +100,7 @@ async function scheduleAccountPurge(
 ) {
   await ctx.scheduler.runAfter(
     Math.max(0, delayMs),
-    (internal as any).companyMonitoring.accounts.advanceAccountPurge,
+    internal.companyMonitoring.accounts.advanceAccountPurge,
     { ownerFenceHash, purgeGeneration },
   );
 }
@@ -124,6 +124,18 @@ async function findAccountByOwnerFence(
   return match;
 }
 
+async function findAccountByOwnerUserId(
+  ctx: MutationCtx,
+  ownerUserId: string,
+): Promise<Doc<"companyMonitoringAccounts"> | null> {
+  const accounts = await ctx.db
+    .query("companyMonitoringAccounts")
+    .withIndex("by_ownerUserId", (q) => q.eq("ownerUserId", ownerUserId))
+    .take(2);
+  if (accounts.length > 1) throw new ConvexError("ACCOUNT_OWNER_FENCE_CONFLICT");
+  return accounts[0] ?? null;
+}
+
 /** Apply the canonical stored entitlement to the single keyed account root. */
 export async function syncCompanyMonitoringAccountFromEntitlement(
   ctx: MutationCtx,
@@ -141,7 +153,14 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
   const ownerFence = await companyMonitoringOwnerFenceCandidates(userId);
   const ownerFenceHash = ownerFence.current;
   const match = await findAccountByOwnerFence(ctx, ownerFence);
-  let existing = match?.account ?? null;
+  // The owner binding is the invariant that survives an operator dropping an
+  // old fence key from history. Reconcile it before insert so a scheduled sync
+  // migrates the one nonterminal root instead of creating a duplicate root.
+  const ownerAccount = await findAccountByOwnerUserId(ctx, userId);
+  if (match && ownerAccount && match.account._id !== ownerAccount._id) {
+    throw new ConvexError("ACCOUNT_OWNER_FENCE_CONFLICT");
+  }
+  let existing = match?.account ?? ownerAccount;
 
   if (!existing) {
     if (!canonical.active) return null;
@@ -172,7 +191,7 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
   if (existing.terminalReason || existing.lifecycle === "denied") return existing;
   if (existing.ownerUserId !== userId) throw new ConvexError("ACCOUNT_OWNER_BINDING_MISMATCH");
 
-  if (match && match.matchedHash !== ownerFenceHash) {
+  if (existing.ownerFenceHash !== ownerFenceHash) {
     await ctx.db.patch(existing._id, { ownerFenceHash });
     if (existing.purgePhase !== "none" && existing.purgePhase !== "complete") {
       // Jobs scheduled before rotation still carry the old hash and will become
@@ -182,7 +201,7 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
         : 0;
       await scheduleAccountPurge(ctx, ownerFenceHash, existing.purgeGeneration, delayMs);
     }
-    existing = (await ctx.db.get(existing._id)) ?? existing;
+    existing = { ...existing, ownerFenceHash };
   }
 
   const semanticChanged = existing.entitlementDigest !== canonical.digest;
@@ -612,19 +631,17 @@ export const reconcileAccountEntitlements = internalMutation({
     let scanned = 0;
     let scheduled = 0;
 
-    // BOTH directions. Scanning only "entitled" would detect lapses and never
-    // undo one, and the entitlement write that used to restore a lapsed root is
-    // exactly what #6256 removed — a customer who re-subscribed after a late
-    // renewal would stay locked out until the purge scrubbed them.
-    for (const lifecycle of RECONCILABLE_LIFECYCLES) {
-      if (remaining === 0) break;
+    const scanLifecycle = async (
+      lifecycle: (typeof RECONCILABLE_LIFECYCLES)[number],
+      limit: number,
+    ) => {
+      if (limit === 0) return 0;
       const accounts = await ctx.db
         .query("companyMonitoringAccounts")
         .withIndex("by_lifecycle_updatedAt", (q) =>
           q.eq("lifecycle", lifecycle).lt("updatedAt", staleBefore),
         )
-        .take(remaining);
-      remaining -= accounts.length;
+        .take(limit);
 
       for (const account of accounts) {
         scanned += 1;
@@ -642,11 +659,31 @@ export const reconcileAccountEntitlements = internalMutation({
         // Same shape as reapStalledAccountPurges.
         await ctx.scheduler.runAfter(
           0,
-          (internal as any).companyMonitoring.accounts.syncStoredEntitlement,
+          internal.companyMonitoring.accounts.syncStoredEntitlement,
           { userId: ownerUserId },
         );
         scheduled += 1;
       }
+      return accounts.length;
+    };
+
+    // BOTH directions. Reserve half the shared budget for each lifecycle so a
+    // full entitled bucket cannot starve late renewals forever. The second
+    // bucket can spend unused capacity from the first; if it also has spare,
+    // the first bucket receives the remainder. Each query remains oldest-first,
+    // and scanLifecycle advances every fetched row before a later page runs.
+    const reservedPerLifecycle = Math.floor(
+      ENTITLED_RECHECK_BATCH_SIZE / RECONCILABLE_LIFECYCLES.length,
+    );
+    const firstLifecycle = RECONCILABLE_LIFECYCLES[0];
+    const secondLifecycle = RECONCILABLE_LIFECYCLES[1];
+
+    const firstScanned = await scanLifecycle(firstLifecycle, reservedPerLifecycle);
+    remaining -= firstScanned;
+    const secondScanned = await scanLifecycle(secondLifecycle, remaining);
+    remaining -= secondScanned;
+    if (remaining > 0) {
+      remaining -= await scanLifecycle(firstLifecycle, remaining);
     }
 
     return { scanned, scheduled };

--- a/convex/companyMonitoring/accounts.ts
+++ b/convex/companyMonitoring/accounts.ts
@@ -39,6 +39,9 @@ const STALLED_PURGE_REAPER_BATCH_SIZE = 50;
 const ENTITLED_RECHECK_AGE_MS = 60 * 60 * 1000;
 const ENTITLED_RECHECK_BATCH_SIZE = 50;
 const REAPABLE_PURGE_PHASES = ["finalizing", "companies", "pending"] as const;
+// Both directions: "entitled" rows may need lapsing, "entitlement_lapsed" rows
+// may need restoring after a late renewal. "denied" is terminal and excluded.
+const RECONCILABLE_LIFECYCLES = ["entitled", "entitlement_lapsed"] as const;
 
 async function canonicalEntitlement(ctx: MutationCtx, userId: string) {
   const entitlement = await ctx.db
@@ -433,6 +436,18 @@ export const advanceAccountPurge = internalMutation({
         );
         return { status: "waiting", purgeAfter };
       }
+      // Last line of defence before anything irreversible. The 24h grace exists
+      // so a late renewal can land first, and entitlement writes no longer push
+      // that restoration in (#6256) — so re-derive it here rather than trusting
+      // a lifecycle set up to a full reconciler sweep ago. The finalizing branch
+      // already does this recheck; by then the payload is gone.
+      if (isOrdinaryLapse && account.ownerUserId) {
+        const canonical = await canonicalEntitlement(ctx, account.ownerUserId);
+        if (canonical.active) {
+          await syncCompanyMonitoringAccountFromEntitlement(ctx, account.ownerUserId);
+          return { status: "reactivated" };
+        }
+      }
       await ctx.db.patch(account._id, {
         purgePhase: "companies",
         destructivePurgeStarted: true,
@@ -593,32 +608,47 @@ export const reconcileAccountEntitlements = internalMutation({
   handler: async (ctx) => {
     const now = Date.now();
     const staleBefore = now - ENTITLED_RECHECK_AGE_MS;
-    const accounts = await ctx.db
-      .query("companyMonitoringAccounts")
-      .withIndex("by_lifecycle_updatedAt", (q) =>
-        q.eq("lifecycle", "entitled").lt("updatedAt", staleBefore),
-      )
-      .take(ENTITLED_RECHECK_BATCH_SIZE);
-
+    let remaining = ENTITLED_RECHECK_BATCH_SIZE;
     let scanned = 0;
-    let lapsed = 0;
-    for (const account of accounts) {
-      scanned += 1;
-      const ownerUserId = account.ownerUserId;
-      // A terminal row never carries an owner; skip rather than resurrect.
-      if (!ownerUserId || account.terminalReason) continue;
-      const before = account.lifecycle;
-      const synced = await syncCompanyMonitoringAccountFromEntitlement(ctx, ownerUserId);
-      if (synced && synced.lifecycle !== before) lapsed += 1;
-      // Always advance the cursor, including for still-entitled rows the sync
-      // left untouched — otherwise the same 50 rows are rescanned every tick
-      // and newer ones are never reached.
-      const current = await ctx.db.get(account._id);
-      if (current && current.updatedAt < now) {
+    let scheduled = 0;
+
+    // BOTH directions. Scanning only "entitled" would detect lapses and never
+    // undo one, and the entitlement write that used to restore a lapsed root is
+    // exactly what #6256 removed — a customer who re-subscribed after a late
+    // renewal would stay locked out until the purge scrubbed them.
+    for (const lifecycle of RECONCILABLE_LIFECYCLES) {
+      if (remaining === 0) break;
+      const accounts = await ctx.db
+        .query("companyMonitoringAccounts")
+        .withIndex("by_lifecycle_updatedAt", (q) =>
+          q.eq("lifecycle", lifecycle).lt("updatedAt", staleBefore),
+        )
+        .take(remaining);
+      remaining -= accounts.length;
+
+      for (const account of accounts) {
+        scanned += 1;
+        // Advance the cursor FIRST and unconditionally, including for rows we
+        // skip — otherwise a skipped row keeps its slot at the head of the
+        // index forever and starves everything behind it.
         await ctx.db.patch(account._id, { updatedAt: now });
+        const ownerUserId = account.ownerUserId;
+        // A terminal row never carries an owner; skip rather than resurrect.
+        if (!ownerUserId || account.terminalReason) continue;
+        // Schedule rather than sync inline: this is one transaction over 50
+        // rows, so an inline throw (a fence conflict is reachable) would roll
+        // back every cursor advance and stall lapse detection fleet-wide,
+        // permanently. Per-row scheduling costs one bad row per sweep instead.
+        // Same shape as reapStalledAccountPurges.
+        await ctx.scheduler.runAfter(
+          0,
+          (internal as any).companyMonitoring.accounts.syncStoredEntitlement,
+          { userId: ownerUserId },
+        );
+        scheduled += 1;
       }
     }
 
-    return { scanned, lapsed };
+    return { scanned, scheduled };
   },
 });

--- a/convex/companyMonitoring/accounts.ts
+++ b/convex/companyMonitoring/accounts.ts
@@ -5,6 +5,7 @@ import type { Doc } from "../_generated/dataModel";
 import {
   ANON_ID_V4_REGEX,
   companyMonitoringOwnerFenceCandidates,
+  tryCompanyMonitoringOwnerFenceCandidates,
   type CompanyMonitoringOwnerFenceCandidates,
 } from "../lib/identitySigning";
 import { COMPANY_MONITORING_LIMITS } from "../../shared/company-monitoring-contract";
@@ -118,8 +119,22 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
   // Browser UUID purchases are deliberately invisible to Company Monitoring
   // until claimSubscription has recomputed the real authenticated owner.
   if (ANON_ID_V4_REGEX.test(userId)) return null;
+  // Resolve the fence BEFORE canonicalEntitlement, which performs this
+  // transaction's first write (its deliberate same-value serialization patch).
+  // Convex has no savepoints, so bailing out after any write would commit
+  // partial state; bailing here commits nothing. A misconfigured keyring must
+  // degrade Company Monitoring, never abort the entitlement write this runs
+  // inside — a config fault is not transient, so the caller's retry would fail
+  // identically forever. Genuine data conflicts below still throw.
+  const resolved = await tryCompanyMonitoringOwnerFenceCandidates(userId);
+  if (!resolved.ok) {
+    console.error(
+      `[companyMonitoring] owner fence unavailable; skipping account sync for ${userId}: ${resolved.reason}`,
+    );
+    return null;
+  }
   const canonical = await canonicalEntitlement(ctx, userId);
-  const ownerFence = await companyMonitoringOwnerFenceCandidates(userId);
+  const ownerFence = resolved.fence;
   const ownerFenceHash = ownerFence.current;
   const match = await findAccountByOwnerFence(ctx, ownerFence);
   let existing = match?.account ?? null;

--- a/convex/companyMonitoring/accounts.ts
+++ b/convex/companyMonitoring/accounts.ts
@@ -20,12 +20,20 @@ const PURGE_BATCH_SIZE = Math.floor(
   (PURGE_TRANSACTION_DOCUMENT_LIMIT - PURGE_TRANSACTION_DOCUMENT_HEADROOM) /
     PURGE_DOCUMENTS_PER_COMPANY,
 );
+// Ordinary billing lapses wait one full day before destructive work. This
+// matches the daily missed-renewal reconciliation bound: a lost successful
+// renewal webhook gets one authoritative Dodo sweep before customer data is
+// scrubbed. Explicit owner/account deletion bypasses this grace.
+const ORDINARY_LAPSE_PURGE_GRACE_MS = 24 * 60 * 60 * 1000;
+const STALLED_PURGE_AGE_MS = 60 * 60 * 1000;
+const STALLED_PURGE_REAPER_BATCH_SIZE = 50;
+const REAPABLE_PURGE_PHASES = ["finalizing", "companies", "pending"] as const;
 
 async function canonicalEntitlement(ctx: MutationCtx, userId: string) {
   const entitlement = await ctx.db
     .query("entitlements")
     .withIndex("by_userId", (q) => q.eq("userId", userId))
-    .unique();
+    .first();
   if (!entitlement) return { active: false as const, digest: await fingerprint({ active: false }) };
 
   // The entitlement row is also the pre-existing serialization document for
@@ -74,9 +82,10 @@ async function scheduleAccountPurge(
   ctx: MutationCtx,
   ownerFenceHash: string,
   purgeGeneration: number,
+  delayMs = 0,
 ) {
   await ctx.scheduler.runAfter(
-    0,
+    Math.max(0, delayMs),
     (internal as any).companyMonitoring.accounts.advanceAccountPurge,
     { ownerFenceHash, purgeGeneration },
   );
@@ -149,7 +158,10 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
     if (existing.purgePhase !== "none" && existing.purgePhase !== "complete") {
       // Jobs scheduled before rotation still carry the old hash and will become
       // stale after migration. Seed the same generation under the current key.
-      await scheduleAccountPurge(ctx, ownerFenceHash, existing.purgeGeneration);
+      const delayMs = existing.purgePhase === "pending" && existing.purgeAfter
+        ? existing.purgeAfter - Date.now()
+        : 0;
+      await scheduleAccountPurge(ctx, ownerFenceHash, existing.purgeGeneration, delayMs);
     }
     existing = (await ctx.db.get(existing._id)) ?? existing;
   }
@@ -176,6 +188,7 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
       purgePhase: "none",
       destructivePurgeStarted: false,
       pendingReactivation: false,
+      purgeAfter: undefined,
       purgeCursor: undefined,
       updatedAt: now,
     });
@@ -212,6 +225,7 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
         purgePhase: "none",
         destructivePurgeStarted: false,
         pendingReactivation: false,
+        purgeAfter: undefined,
         updatedAt: now,
       });
       await scheduleScopedKeyCacheInvalidation(ctx, userId);
@@ -237,6 +251,7 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
 
   if (semanticChanged || existing.lifecycle === "entitled") {
     const purgeGeneration = existing.purgeGeneration + 1;
+    const purgeAfter = now + ORDINARY_LAPSE_PURGE_GRACE_MS;
     await ctx.db.patch(existing._id, {
       lifecycle: "entitlement_lapsed",
       entitlementDigest: canonical.digest,
@@ -245,10 +260,16 @@ export async function syncCompanyMonitoringAccountFromEntitlement(
       purgePhase: "pending",
       destructivePurgeStarted: false,
       pendingReactivation: false,
+      purgeAfter,
       updatedAt: now,
     });
     await scheduleScopedKeyCacheInvalidation(ctx, userId);
-    await scheduleAccountPurge(ctx, ownerFenceHash, purgeGeneration);
+    await scheduleAccountPurge(
+      ctx,
+      ownerFenceHash,
+      purgeGeneration,
+      ORDINARY_LAPSE_PURGE_GRACE_MS,
+    );
   }
   return ctx.db.get(existing._id);
 }
@@ -285,6 +306,7 @@ async function terminalize(
       purgePhase: "pending",
       destructivePurgeStarted: true,
       pendingReactivation: false,
+      purgeAfter: undefined,
       createdAt: now,
       updatedAt: now,
     });
@@ -308,6 +330,7 @@ async function terminalize(
     purgePhase: "pending",
     destructivePurgeStarted: true,
     pendingReactivation: false,
+    purgeAfter: undefined,
     purgeCursor: undefined,
     updatedAt: now,
   });
@@ -347,9 +370,26 @@ export const advanceAccountPurge = internalMutation({
 
     const now = Date.now();
     if (account.purgePhase === "pending") {
+      const isOrdinaryLapse = !account.terminalReason && account.lifecycle !== "denied";
+      const purgeAfter = account.purgeAfter ?? account.updatedAt + ORDINARY_LAPSE_PURGE_GRACE_MS;
+      if (isOrdinaryLapse && account.purgeAfter === undefined) {
+        // Backfill a deadline for any pending row written before purgeAfter was
+        // introduced. Do not move updatedAt: the reaper still needs its age.
+        await ctx.db.patch(account._id, { purgeAfter });
+      }
+      if (isOrdinaryLapse && now < purgeAfter) {
+        await scheduleAccountPurge(
+          ctx,
+          args.ownerFenceHash,
+          args.purgeGeneration,
+          purgeAfter - now,
+        );
+        return { status: "waiting", purgeAfter };
+      }
       await ctx.db.patch(account._id, {
         purgePhase: "companies",
         destructivePurgeStarted: true,
+        purgeAfter: undefined,
         updatedAt: now,
       });
       await scheduleAccountPurge(ctx, args.ownerFenceHash, args.purgeGeneration);
@@ -374,6 +414,11 @@ export const advanceAccountPurge = internalMutation({
           sortName: undefined,
           domicileCountry: undefined,
           customerReference: undefined,
+          directRequestId: undefined,
+          directFingerprint: undefined,
+          clientImportId: undefined,
+          importOrdinal: undefined,
+          importFingerprint: undefined,
           lifecycle: "removed",
           coverageState: undefined,
           observationState: undefined,
@@ -395,15 +440,24 @@ export const advanceAccountPurge = internalMutation({
     }
 
     if (account.purgePhase === "finalizing") {
-      if (account.pendingReactivation && account.ownerUserId && !account.terminalReason) {
+      const canonical = account.ownerUserId && !account.terminalReason
+        ? await canonicalEntitlement(ctx, account.ownerUserId)
+        : null;
+      const canonicalChanged = Boolean(
+        canonical && account.entitlementDigest !== canonical.digest,
+      );
+      if (account.pendingReactivation && account.ownerUserId && canonical?.active) {
         await ctx.db.patch(account._id, {
           lifecycle: "entitled",
+          entitlementDigest: canonical.digest,
+          lifecycleSequence: account.lifecycleSequence + (canonicalChanged ? 1 : 0),
           companyCount: 0,
           companyLimit: COMPANY_LIMIT,
           snapshotGeneration: (account.snapshotGeneration ?? 0) + 1,
           purgePhase: "none",
           destructivePurgeStarted: false,
           pendingReactivation: false,
+          purgeAfter: undefined,
           purgeCursor: undefined,
           updatedAt: now,
         });
@@ -416,8 +470,11 @@ export const advanceAccountPurge = internalMutation({
         snapshotGeneration: account.terminalReason
           ? undefined
           : (account.snapshotGeneration ?? 0) + 1,
+        entitlementDigest: canonical?.digest ?? account.entitlementDigest,
+        lifecycleSequence: account.lifecycleSequence + (canonicalChanged ? 1 : 0),
         purgePhase: "complete",
         pendingReactivation: false,
+        purgeAfter: undefined,
         purgeCursor: undefined,
         updatedAt: now,
       });
@@ -425,5 +482,49 @@ export const advanceAccountPurge = internalMutation({
     }
 
     return { status: "complete" };
+  },
+});
+
+/** Hourly bounded recovery for purge jobs lost after their account transition. */
+export const reapStalledAccountPurges = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const staleBefore = now - STALLED_PURGE_AGE_MS;
+    let remaining = STALLED_PURGE_REAPER_BATCH_SIZE;
+    let scanned = 0;
+    let scheduled = 0;
+    let deferred = 0;
+
+    for (const purgePhase of REAPABLE_PURGE_PHASES) {
+      if (remaining === 0) break;
+      const accounts = await ctx.db
+        .query("companyMonitoringAccounts")
+        .withIndex("by_purgePhase_updatedAt", (q) =>
+          q.eq("purgePhase", purgePhase).lt("updatedAt", staleBefore),
+        )
+        .take(remaining);
+      scanned += accounts.length;
+      remaining -= accounts.length;
+
+      for (const account of accounts) {
+        if (purgePhase === "pending" && !account.terminalReason) {
+          const purgeAfter = account.purgeAfter ??
+            account.updatedAt + ORDINARY_LAPSE_PURGE_GRACE_MS;
+          if (account.purgeAfter === undefined) {
+            await ctx.db.patch(account._id, { purgeAfter });
+          }
+          if (now < purgeAfter) {
+            deferred += 1;
+            continue;
+          }
+        }
+        await ctx.db.patch(account._id, { updatedAt: now });
+        await scheduleAccountPurge(ctx, account.ownerFenceHash, account.purgeGeneration);
+        scheduled += 1;
+      }
+    }
+
+    return { scanned, scheduled, deferred };
   },
 });

--- a/convex/companyMonitoring/accounts.ts
+++ b/convex/companyMonitoring/accounts.ts
@@ -1,0 +1,429 @@
+import { ConvexError, v } from "convex/values";
+import { internal } from "../_generated/api";
+import { internalMutation, type MutationCtx } from "../_generated/server";
+import type { Doc } from "../_generated/dataModel";
+import {
+  ANON_ID_V4_REGEX,
+  companyMonitoringOwnerFenceCandidates,
+  type CompanyMonitoringOwnerFenceCandidates,
+} from "../lib/identitySigning";
+import { COMPANY_MONITORING_LIMITS } from "../../shared/company-monitoring-contract";
+import { COMPANY_LIMIT, deleteCompanyClaims, fingerprint, logicalId } from "./_shared";
+
+const PURGE_TRANSACTION_DOCUMENT_LIMIT = 8_192;
+// Reserve room for the account read/write, the lookahead company, scheduler
+// bookkeeping, and future transaction-local metadata without approaching the
+// hard bound. Each processed company can touch all 81 claims plus its row.
+const PURGE_TRANSACTION_DOCUMENT_HEADROOM = 512;
+const PURGE_DOCUMENTS_PER_COMPANY = COMPANY_MONITORING_LIMITS.maxClaimsPerCompany + 1;
+const PURGE_BATCH_SIZE = Math.floor(
+  (PURGE_TRANSACTION_DOCUMENT_LIMIT - PURGE_TRANSACTION_DOCUMENT_HEADROOM) /
+    PURGE_DOCUMENTS_PER_COMPANY,
+);
+
+async function canonicalEntitlement(ctx: MutationCtx, userId: string) {
+  const entitlement = await ctx.db
+    .query("entitlements")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .unique();
+  if (!entitlement) return { active: false as const, digest: await fingerprint({ active: false }) };
+
+  // The entitlement row is also the pre-existing serialization document for
+  // first-root creation. A same-value patch is intentional: two concurrent
+  // entitlement mutations for a new owner cannot both create roots.
+  await ctx.db.patch(entitlement._id, { updatedAt: entitlement.updatedAt });
+  const active =
+    entitlement.planKey !== "free" &&
+    entitlement.features.tier > 0 &&
+    entitlement.validUntil >= Date.now();
+  if (!active) return { active: false as const, digest: await fingerprint({ active: false }) };
+  return {
+    active: true as const,
+    digest: await fingerprint({
+      active: true,
+      planKey: entitlement.planKey,
+      validUntil: entitlement.validUntil,
+      compUntil: entitlement.compUntil ?? null,
+      features: entitlement.features,
+    }),
+  };
+}
+
+async function scheduleScopedKeyCacheInvalidation(ctx: MutationCtx, ownerUserId: string) {
+  if (!process.env.UPSTASH_REDIS_REST_URL && !process.env.UPSTASH_REDIS_REST_TOKEN) return;
+  const keys = await ctx.db
+    .query("userApiKeys")
+    .withIndex("by_userId_revokedAt", (q) =>
+      q.eq("userId", ownerUserId).eq("revokedAt", undefined),
+    )
+    .collect();
+  const keyHashes = keys
+    .filter((key) =>
+      key.scopes?.some((scope) => scope.startsWith("company_monitoring:")),
+    )
+    .map((key) => key.keyHash);
+  if (keyHashes.length === 0) return;
+  await ctx.scheduler.runAfter(
+    0,
+    (internal as any).payments.cacheActions.invalidateUserApiKeyCaches,
+    { keyHashes },
+  );
+}
+
+async function scheduleAccountPurge(
+  ctx: MutationCtx,
+  ownerFenceHash: string,
+  purgeGeneration: number,
+) {
+  await ctx.scheduler.runAfter(
+    0,
+    (internal as any).companyMonitoring.accounts.advanceAccountPurge,
+    { ownerFenceHash, purgeGeneration },
+  );
+}
+
+async function findAccountByOwnerFence(
+  ctx: MutationCtx,
+  ownerFence: CompanyMonitoringOwnerFenceCandidates,
+): Promise<{ account: Doc<"companyMonitoringAccounts">; matchedHash: string } | null> {
+  let match: { account: Doc<"companyMonitoringAccounts">; matchedHash: string } | null = null;
+  for (const ownerFenceHash of ownerFence.all) {
+    const account = await ctx.db
+      .query("companyMonitoringAccounts")
+      .withIndex("by_ownerFenceHash", (q) => q.eq("ownerFenceHash", ownerFenceHash))
+      .unique();
+    if (!account) continue;
+    if (match && match.account._id !== account._id) {
+      throw new ConvexError("ACCOUNT_OWNER_FENCE_CONFLICT");
+    }
+    match = { account, matchedHash: ownerFenceHash };
+  }
+  return match;
+}
+
+/** Apply the canonical stored entitlement to the single keyed account root. */
+export async function syncCompanyMonitoringAccountFromEntitlement(
+  ctx: MutationCtx,
+  userId: string,
+) {
+  // Browser UUID purchases are deliberately invisible to Company Monitoring
+  // until claimSubscription has recomputed the real authenticated owner.
+  if (ANON_ID_V4_REGEX.test(userId)) return null;
+  const canonical = await canonicalEntitlement(ctx, userId);
+  const ownerFence = await companyMonitoringOwnerFenceCandidates(userId);
+  const ownerFenceHash = ownerFence.current;
+  const match = await findAccountByOwnerFence(ctx, ownerFence);
+  let existing = match?.account ?? null;
+
+  if (!existing) {
+    if (!canonical.active) return null;
+    const now = Date.now();
+    const id = await ctx.db.insert("companyMonitoringAccounts", {
+      logicalAccountId: logicalId("account", now),
+      ownerUserId: userId,
+      ownerFenceHash,
+      lifecycle: "entitled",
+      entitlementDigest: canonical.digest,
+      lifecycleSequence: 1,
+      companyCount: 0,
+      companyLimit: COMPANY_LIMIT,
+      snapshotGeneration: 0,
+      purgeGeneration: 0,
+      purgePhase: "none",
+      destructivePurgeStarted: false,
+      pendingReactivation: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await scheduleScopedKeyCacheInvalidation(ctx, userId);
+    return ctx.db.get(id);
+  }
+
+  // Terminal rows intentionally retain only the keyed fence and logical id.
+  // A replayed or delayed activation can find the row, but can never mutate it.
+  if (existing.terminalReason || existing.lifecycle === "denied") return existing;
+  if (existing.ownerUserId !== userId) throw new ConvexError("ACCOUNT_OWNER_BINDING_MISMATCH");
+
+  if (match && match.matchedHash !== ownerFenceHash) {
+    await ctx.db.patch(existing._id, { ownerFenceHash });
+    if (existing.purgePhase !== "none" && existing.purgePhase !== "complete") {
+      // Jobs scheduled before rotation still carry the old hash and will become
+      // stale after migration. Seed the same generation under the current key.
+      await scheduleAccountPurge(ctx, ownerFenceHash, existing.purgeGeneration);
+    }
+    existing = (await ctx.db.get(existing._id)) ?? existing;
+  }
+
+  const semanticChanged = existing.entitlementDigest !== canonical.digest;
+  const now = Date.now();
+  // A completed generation proves every company payload and claim was scrubbed.
+  // Reuse the same nonterminal owner root as an empty portfolio; terminal roots
+  // returned above can never reach this branch. Convex OCC makes this race-safe
+  // with finalization: activation either records pending before finalization or
+  // observes the committed complete phase here.
+  if (
+    canonical.active &&
+    existing.destructivePurgeStarted &&
+    existing.purgePhase === "complete"
+  ) {
+    await ctx.db.patch(existing._id, {
+      lifecycle: "entitled",
+      entitlementDigest: canonical.digest,
+      lifecycleSequence: existing.lifecycleSequence + (semanticChanged ? 1 : 0),
+      companyCount: 0,
+      companyLimit: COMPANY_LIMIT,
+      snapshotGeneration: existing.snapshotGeneration ?? 0,
+      purgePhase: "none",
+      destructivePurgeStarted: false,
+      pendingReactivation: false,
+      purgeCursor: undefined,
+      updatedAt: now,
+    });
+    await scheduleScopedKeyCacheInvalidation(ctx, userId);
+    return ctx.db.get(existing._id);
+  }
+
+  if (canonical.active && existing.destructivePurgeStarted) {
+    if (semanticChanged || !existing.pendingReactivation) {
+      await ctx.db.patch(existing._id, {
+        entitlementDigest: canonical.digest,
+        lifecycleSequence: existing.lifecycleSequence + (semanticChanged ? 1 : 0),
+        pendingReactivation: true,
+        updatedAt: now,
+      });
+      await scheduleScopedKeyCacheInvalidation(ctx, userId);
+    }
+    return ctx.db.get(existing._id);
+  }
+
+  if (canonical.active) {
+    if (semanticChanged || existing.lifecycle !== "entitled") {
+      await ctx.db.patch(existing._id, {
+        lifecycle: "entitled",
+        entitlementDigest: canonical.digest,
+        lifecycleSequence: existing.lifecycleSequence + (semanticChanged ? 1 : 0),
+        companyCount: existing.companyCount ?? 0,
+        companyLimit: COMPANY_LIMIT,
+        snapshotGeneration: existing.snapshotGeneration ?? 0,
+        purgeGeneration:
+          existing.lifecycle === "entitlement_lapsed"
+            ? existing.purgeGeneration + 1
+            : existing.purgeGeneration,
+        purgePhase: "none",
+        destructivePurgeStarted: false,
+        pendingReactivation: false,
+        updatedAt: now,
+      });
+      await scheduleScopedKeyCacheInvalidation(ctx, userId);
+    }
+    return ctx.db.get(existing._id);
+  }
+
+  // Once a generation has crossed the destructive boundary, later semantic
+  // changes must stay on that same fence. Starting a fresh "pending" purge
+  // would let a subsequent activation revive a partially scrubbed portfolio.
+  if (existing.destructivePurgeStarted) {
+    if (semanticChanged || existing.pendingReactivation) {
+      await ctx.db.patch(existing._id, {
+        entitlementDigest: canonical.digest,
+        lifecycleSequence: existing.lifecycleSequence + (semanticChanged ? 1 : 0),
+        pendingReactivation: false,
+        updatedAt: now,
+      });
+      await scheduleScopedKeyCacheInvalidation(ctx, userId);
+    }
+    return ctx.db.get(existing._id);
+  }
+
+  if (semanticChanged || existing.lifecycle === "entitled") {
+    const purgeGeneration = existing.purgeGeneration + 1;
+    await ctx.db.patch(existing._id, {
+      lifecycle: "entitlement_lapsed",
+      entitlementDigest: canonical.digest,
+      lifecycleSequence: existing.lifecycleSequence + (semanticChanged ? 1 : 0),
+      purgeGeneration,
+      purgePhase: "pending",
+      destructivePurgeStarted: false,
+      pendingReactivation: false,
+      updatedAt: now,
+    });
+    await scheduleScopedKeyCacheInvalidation(ctx, userId);
+    await scheduleAccountPurge(ctx, ownerFenceHash, purgeGeneration);
+  }
+  return ctx.db.get(existing._id);
+}
+
+/** Internal repair/test seam; production entitlement writers call the helper directly. */
+export const syncStoredEntitlement = internalMutation({
+  args: { userId: v.string() },
+  handler: async (ctx, args) => syncCompanyMonitoringAccountFromEntitlement(ctx, args.userId),
+});
+
+async function terminalize(
+  ctx: MutationCtx,
+  ownerUserId: string,
+  terminalReason: "owner_deleted" | "account_deleted",
+  existing?: Doc<"companyMonitoringAccounts"> | null,
+) {
+  const ownerFence = await companyMonitoringOwnerFenceCandidates(ownerUserId);
+  const ownerFenceHash = ownerFence.current;
+  const match = await findAccountByOwnerFence(ctx, ownerFence);
+  if (existing && match && existing._id !== match.account._id) {
+    throw new ConvexError("ACCOUNT_OWNER_FENCE_CONFLICT");
+  }
+  const account = existing ?? match?.account ?? null;
+  const now = Date.now();
+  if (!account) {
+    const purgeGeneration = 1;
+    const id = await ctx.db.insert("companyMonitoringAccounts", {
+      logicalAccountId: logicalId("account", now),
+      ownerFenceHash,
+      lifecycle: "denied",
+      terminalReason,
+      lifecycleSequence: 1,
+      purgeGeneration,
+      purgePhase: "pending",
+      destructivePurgeStarted: true,
+      pendingReactivation: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await scheduleScopedKeyCacheInvalidation(ctx, ownerUserId);
+    await scheduleAccountPurge(ctx, ownerFenceHash, purgeGeneration);
+    return ctx.db.get(id);
+  }
+  if (account.terminalReason) return account;
+  const purgeGeneration = account.purgeGeneration + 1;
+  await ctx.db.patch(account._id, {
+    ownerUserId: undefined,
+    ownerFenceHash,
+    lifecycle: "denied",
+    terminalReason,
+    entitlementDigest: undefined,
+    lifecycleSequence: account.lifecycleSequence + 1,
+    companyCount: undefined,
+    companyLimit: undefined,
+    snapshotGeneration: undefined,
+    purgeGeneration,
+    purgePhase: "pending",
+    destructivePurgeStarted: true,
+    pendingReactivation: false,
+    purgeCursor: undefined,
+    updatedAt: now,
+  });
+  await scheduleScopedKeyCacheInvalidation(ctx, ownerUserId);
+  await scheduleAccountPurge(ctx, ownerFenceHash, purgeGeneration);
+  return ctx.db.get(account._id);
+}
+
+export const markOwnerDeleted = internalMutation({
+  args: { ownerUserId: v.string() },
+  handler: async (ctx, args) => terminalize(ctx, args.ownerUserId, "owner_deleted"),
+});
+
+export const markAccountDeleted = internalMutation({
+  args: { ownerAccountId: v.string() },
+  handler: async (ctx, args) => {
+    const account = await ctx.db
+      .query("companyMonitoringAccounts")
+      .withIndex("by_logicalAccountId", (q) => q.eq("logicalAccountId", args.ownerAccountId))
+      .unique();
+    if (!account || !account.ownerUserId) throw new ConvexError("ACCOUNT_NOT_FOUND");
+    return terminalize(ctx, account.ownerUserId, "account_deleted", account);
+  },
+});
+
+export const advanceAccountPurge = internalMutation({
+  args: { ownerFenceHash: v.string(), purgeGeneration: v.number() },
+  handler: async (ctx, args) => {
+    const account = await ctx.db
+      .query("companyMonitoringAccounts")
+      .withIndex("by_ownerFenceHash", (q) => q.eq("ownerFenceHash", args.ownerFenceHash))
+      .unique();
+    if (!account || account.purgeGeneration !== args.purgeGeneration) return { status: "stale" };
+    if (account.purgePhase === "none" || account.purgePhase === "complete") {
+      return { status: "complete" };
+    }
+
+    const now = Date.now();
+    if (account.purgePhase === "pending") {
+      await ctx.db.patch(account._id, {
+        purgePhase: "companies",
+        destructivePurgeStarted: true,
+        updatedAt: now,
+      });
+      await scheduleAccountPurge(ctx, args.ownerFenceHash, args.purgeGeneration);
+      return { status: "started" };
+    }
+
+    if (account.purgePhase === "companies") {
+      const page = await ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) => {
+          const ownerQuery = q.eq("ownerAccountId", account.logicalAccountId);
+          return account.purgeCursor
+            ? ownerQuery.gt("companyId", account.purgeCursor)
+            : ownerQuery;
+        })
+        .take(PURGE_BATCH_SIZE + 1);
+      const batch = page.slice(0, PURGE_BATCH_SIZE);
+      for (const company of batch) {
+        await deleteCompanyClaims(ctx, account.logicalAccountId, company.companyId);
+        await ctx.db.patch(company._id, {
+          name: undefined,
+          sortName: undefined,
+          domicileCountry: undefined,
+          customerReference: undefined,
+          lifecycle: "removed",
+          coverageState: undefined,
+          observationState: undefined,
+          purgeGeneration: args.purgeGeneration,
+          purgePhase: "complete",
+          removedAt: company.removedAt ?? now,
+          updatedAt: now,
+        });
+      }
+      const hasMore = page.length > PURGE_BATCH_SIZE;
+      const nextPhase = hasMore ? "companies" : "finalizing";
+      await ctx.db.patch(account._id, {
+        purgePhase: nextPhase,
+        purgeCursor: hasMore ? batch[batch.length - 1]?.companyId : undefined,
+        updatedAt: now,
+      });
+      await scheduleAccountPurge(ctx, args.ownerFenceHash, args.purgeGeneration);
+      return { status: nextPhase };
+    }
+
+    if (account.purgePhase === "finalizing") {
+      if (account.pendingReactivation && account.ownerUserId && !account.terminalReason) {
+        await ctx.db.patch(account._id, {
+          lifecycle: "entitled",
+          companyCount: 0,
+          companyLimit: COMPANY_LIMIT,
+          snapshotGeneration: (account.snapshotGeneration ?? 0) + 1,
+          purgePhase: "none",
+          destructivePurgeStarted: false,
+          pendingReactivation: false,
+          purgeCursor: undefined,
+          updatedAt: now,
+        });
+        await scheduleScopedKeyCacheInvalidation(ctx, account.ownerUserId);
+        return { status: "reactivated" };
+      }
+      await ctx.db.patch(account._id, {
+        companyCount: account.terminalReason ? undefined : 0,
+        companyLimit: account.terminalReason ? undefined : COMPANY_LIMIT,
+        snapshotGeneration: account.terminalReason
+          ? undefined
+          : (account.snapshotGeneration ?? 0) + 1,
+        purgePhase: "complete",
+        pendingReactivation: false,
+        purgeCursor: undefined,
+        updatedAt: now,
+      });
+      return { status: "complete" };
+    }
+
+    return { status: "complete" };
+  },
+});

--- a/convex/companyMonitoring/companies.ts
+++ b/convex/companyMonitoring/companies.ts
@@ -1,0 +1,414 @@
+import { ConvexError, v } from "convex/values";
+import { internal } from "../_generated/api";
+import { internalMutation, internalQuery, type MutationCtx } from "../_generated/server";
+import {
+  normalizeMonitoredCompanyInput,
+  normalizeCompanyClaimInput,
+  assertCompanyClaimBudget,
+  assertLogicalId,
+  COMPANY_MONITORING_LIMITS,
+  assertLifecycleTransition,
+  type CompanyClaimInput,
+  type MonitoredCompanyInput,
+  type NormalizedMonitoredCompanyInput,
+} from "../../shared/company-monitoring-contract";
+import {
+  deleteCompanyClaims,
+  fingerprint,
+  insertClaims,
+  logicalId,
+  normalizeRequestId,
+  requireActiveAccount,
+  COMPANY_LIMIT,
+} from "./_shared";
+
+type ReplayMetadata =
+  | { directRequestId: string; directFingerprint: string }
+  | { clientImportId: string; importOrdinal: number; importFingerprint: string };
+
+export async function insertNormalizedCompany(
+  ctx: MutationCtx,
+  account: { logicalAccountId: string; snapshotGeneration?: number },
+  company: NormalizedMonitoredCompanyInput,
+  metadata: ReplayMetadata,
+) {
+  const now = Date.now();
+  const companyId = logicalId("company", now);
+  await ctx.db.insert("companyMonitoringCompanies", {
+    ownerAccountId: account.logicalAccountId,
+    companyId,
+    name: company.name,
+    sortName: company.name.toLocaleLowerCase("en-US"),
+    domicileCountry: company.domicileCountry,
+    customerReference: company.customerReference,
+    lifecycle: "active",
+    coverageState: "awaiting_first_scan",
+    observationState: "unknown",
+    snapshotGeneration: (account.snapshotGeneration ?? 0) + 1,
+    ...metadata,
+    purgeGeneration: 0,
+    purgePhase: "none",
+    createdAt: now,
+    updatedAt: now,
+  });
+  await insertClaims(ctx, account.logicalAccountId, companyId, company, now);
+  return companyId;
+}
+
+export async function findNoopByCustomerReference(
+  ctx: MutationCtx,
+  ownerAccountId: string,
+  customerReference: string | undefined,
+) {
+  if (!customerReference) return null;
+  const [active, paused] = await Promise.all([
+    ctx.db
+      .query("companyMonitoringCompanies")
+      .withIndex("by_account_customerReference_lifecycle", (q) =>
+        q
+          .eq("ownerAccountId", ownerAccountId)
+          .eq("customerReference", customerReference)
+          .eq("lifecycle", "active"),
+      )
+      .first(),
+    ctx.db
+      .query("companyMonitoringCompanies")
+      .withIndex("by_account_customerReference_lifecycle", (q) =>
+        q
+          .eq("ownerAccountId", ownerAccountId)
+          .eq("customerReference", customerReference)
+          .eq("lifecycle", "paused"),
+      )
+      .first(),
+  ]);
+  return active ?? paused;
+}
+
+export const createCompanyForOwner = internalMutation({
+  args: {
+    ownerUserId: v.string(),
+    clientRequestId: v.string(),
+    company: v.any(),
+  },
+  handler: async (ctx, args) => {
+    const account = await requireActiveAccount(ctx, args.ownerUserId);
+    const clientRequestId = normalizeRequestId(args.clientRequestId);
+    const company = normalizeMonitoredCompanyInput(args.company as MonitoredCompanyInput);
+    const directFingerprint = await fingerprint({ version: "cm-direct-v1", company });
+
+    const replay = await ctx.db
+      .query("companyMonitoringCompanies")
+      .withIndex("by_account_directRequestId", (q) =>
+        q.eq("ownerAccountId", account.logicalAccountId).eq("directRequestId", clientRequestId),
+      )
+      .unique();
+    if (replay) {
+      if (replay.directFingerprint !== directFingerprint) {
+        throw new ConvexError("REPLAY_CONFLICT");
+      }
+      return { status: "replayed", companyId: replay.companyId };
+    }
+
+    const noop = await findNoopByCustomerReference(
+      ctx,
+      account.logicalAccountId,
+      company.customerReference,
+    );
+    if (noop) return { status: "noop", companyId: noop.companyId };
+
+    const companyCount = account.companyCount ?? 0;
+    if (companyCount >= (account.companyLimit ?? COMPANY_LIMIT)) {
+      throw new ConvexError("COMPANY_LIMIT_REACHED");
+    }
+
+    const companyId = await insertNormalizedCompany(ctx, account, company, {
+      directRequestId: clientRequestId,
+      directFingerprint,
+    });
+    await ctx.db.patch(account._id, {
+      companyCount: companyCount + 1,
+      snapshotGeneration: (account.snapshotGeneration ?? 0) + 1,
+      updatedAt: Date.now(),
+    });
+    return { status: "created", companyId };
+  },
+});
+
+export const listCompaniesForOwner = internalQuery({
+  args: { ownerUserId: v.string() },
+  handler: async (ctx, args) => {
+    const account = await requireActiveAccount(ctx, args.ownerUserId);
+    const [active, paused] = await Promise.all([
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_lifecycle_sortName", (q) =>
+          q.eq("ownerAccountId", account.logicalAccountId).eq("lifecycle", "active"),
+        )
+        .collect(),
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_lifecycle_sortName", (q) =>
+          q.eq("ownerAccountId", account.logicalAccountId).eq("lifecycle", "paused"),
+        )
+        .collect(),
+    ]);
+    return [...active, ...paused]
+      .sort((left, right) => (left.sortName ?? "").localeCompare(right.sortName ?? ""))
+      .map((row) => ({
+        companyId: row.companyId,
+        name: row.name,
+        domicileCountry: row.domicileCountry,
+        customerReference: row.customerReference,
+        lifecycle: row.lifecycle,
+      }));
+  },
+});
+
+export const updateCompanyForOwner = internalMutation({
+  args: {
+    ownerUserId: v.string(),
+    companyId: v.string(),
+    patch: v.any(),
+  },
+  handler: async (ctx, args) => {
+    const account = await requireActiveAccount(ctx, args.ownerUserId);
+    const company = await ctx.db
+      .query("companyMonitoringCompanies")
+      .withIndex("by_account_companyId", (q) =>
+        q.eq("ownerAccountId", account.logicalAccountId).eq("companyId", args.companyId),
+      )
+      .unique();
+    if (!company || company.lifecycle === "removed" || !company.name || !company.domicileCountry) {
+      throw new ConvexError("NOT_FOUND");
+    }
+    if (!args.patch || typeof args.patch !== "object" || Array.isArray(args.patch)) {
+      throw new ConvexError("INVALID_COMPANY_PATCH");
+    }
+    const patch = args.patch as Record<string, unknown>;
+    const allowedFields = new Set([
+      "name",
+      "domicileCountry",
+      "customerReference",
+      "addClaims",
+      "removeClaimIds",
+    ]);
+    if (Object.keys(patch).some((field) => !allowedFields.has(field))) {
+      throw new ConvexError("INVALID_COMPANY_PATCH");
+    }
+    const addClaimInputs = patch.addClaims ?? [];
+    const removeClaimInputs = patch.removeClaimIds ?? [];
+    if (!Array.isArray(addClaimInputs) || !Array.isArray(removeClaimInputs)) {
+      throw new ConvexError("INVALID_COMPANY_PATCH");
+    }
+    if (
+      addClaimInputs.length > COMPANY_MONITORING_LIMITS.maxClaimsPerCompany ||
+      removeClaimInputs.length > COMPANY_MONITORING_LIMITS.maxClaimsPerCompany
+    ) {
+      throw new ConvexError("INVALID_COMPANY_PATCH");
+    }
+
+    const hasName = Object.prototype.hasOwnProperty.call(patch, "name");
+    const hasDomicile = Object.prototype.hasOwnProperty.call(patch, "domicileCountry");
+    const hasCustomerReference = Object.prototype.hasOwnProperty.call(patch, "customerReference");
+    const normalizedFields = normalizeMonitoredCompanyInput({
+      name: hasName ? patch.name as string : company.name,
+      domicileCountry: hasDomicile ? patch.domicileCountry as string : company.domicileCountry,
+      customerReference: hasCustomerReference
+        ? patch.customerReference as string | undefined
+        : company.customerReference,
+    });
+    if (hasCustomerReference && normalizedFields.customerReference) {
+      const conflict = await findNoopByCustomerReference(
+        ctx,
+        account.logicalAccountId,
+        normalizedFields.customerReference,
+      );
+      if (conflict && conflict.companyId !== company.companyId) {
+        throw new ConvexError("CUSTOMER_REFERENCE_CONFLICT");
+      }
+    }
+
+    const currentClaims = await ctx.db
+      .query("companyMonitoringClaims")
+      .withIndex("by_account_company", (q) =>
+        q.eq("ownerAccountId", account.logicalAccountId).eq("companyId", company.companyId),
+      )
+      .collect();
+    const currentById = new Map(currentClaims.map((claim) => [claim.claimId, claim]));
+    const removeIds = new Set(
+      removeClaimInputs.map((claimId) => assertLogicalId("claim", String(claimId))),
+    );
+    for (const claimId of removeIds) {
+      if (!currentById.has(claimId)) throw new ConvexError("CLAIM_NOT_FOUND");
+    }
+    if (hasCustomerReference && normalizedFields.customerReference !== company.customerReference) {
+      for (const claim of currentClaims) {
+        if (claim.type === "customer_reference") removeIds.add(claim.claimId);
+      }
+    }
+
+    const remainingKeys = new Set(
+      currentClaims
+        .filter((claim) => !removeIds.has(claim.claimId))
+        .map((claim) => `${claim.type}\u0000${claim.value}`),
+    );
+    const normalizedAdditions = (addClaimInputs as CompanyClaimInput[])
+      .map(normalizeCompanyClaimInput);
+    if (hasCustomerReference && normalizedFields.customerReference) {
+      normalizedAdditions.push({
+        type: "customer_reference",
+        value: normalizedFields.customerReference,
+      });
+    }
+    const additions = normalizedAdditions.filter((claim) => {
+      const key = `${claim.type}\u0000${claim.value}`;
+      if (remainingKeys.has(key)) return false;
+      remainingKeys.add(key);
+      return true;
+    });
+    assertCompanyClaimBudget({
+      currentCount: currentClaims.length,
+      removedCount: removeIds.size,
+      addedCount: additions.length,
+    });
+
+    const fieldsChanged =
+      normalizedFields.name !== company.name ||
+      normalizedFields.domicileCountry !== company.domicileCountry ||
+      normalizedFields.customerReference !== company.customerReference;
+    if (!fieldsChanged && removeIds.size === 0 && additions.length === 0) {
+      return { status: "unchanged", companyId: company.companyId };
+    }
+
+    const now = Date.now();
+    for (const claimId of removeIds) await ctx.db.delete(currentById.get(claimId)!._id);
+    for (const claim of additions) {
+      await ctx.db.insert("companyMonitoringClaims", {
+        ownerAccountId: account.logicalAccountId,
+        companyId: company.companyId,
+        claimId: logicalId("claim", now),
+        ...claim,
+        provenance: "customer",
+        trustState: "unverified",
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+    await ctx.db.patch(company._id, {
+      name: normalizedFields.name,
+      sortName: normalizedFields.name.toLocaleLowerCase("en-US"),
+      domicileCountry: normalizedFields.domicileCountry,
+      customerReference: normalizedFields.customerReference,
+      snapshotGeneration: company.snapshotGeneration + 1,
+      updatedAt: now,
+    });
+    await ctx.db.patch(account._id, {
+      snapshotGeneration: (account.snapshotGeneration ?? 0) + 1,
+      updatedAt: now,
+    });
+    return { status: "updated", companyId: company.companyId };
+  },
+});
+
+export const setCompanyStateForOwner = internalMutation({
+  args: {
+    ownerUserId: v.string(),
+    companyId: v.string(),
+    state: v.union(v.literal("active"), v.literal("paused"), v.literal("removed")),
+  },
+  handler: async (ctx, args) => {
+    const account = await requireActiveAccount(ctx, args.ownerUserId);
+    const company = await ctx.db
+      .query("companyMonitoringCompanies")
+      .withIndex("by_account_companyId", (q) =>
+        q.eq("ownerAccountId", account.logicalAccountId).eq("companyId", args.companyId),
+      )
+      .unique();
+    if (!company) throw new ConvexError("NOT_FOUND");
+    try {
+      assertLifecycleTransition("company", company.lifecycle, args.state);
+    } catch {
+      throw new ConvexError("REMOVED_COMPANY_IS_TERMINAL");
+    }
+    if (company.lifecycle === "removed") {
+      if (args.state === "removed") return { status: "already_removed", companyId: company.companyId };
+      throw new ConvexError("REMOVED_COMPANY_IS_TERMINAL");
+    }
+    if (company.lifecycle === args.state) return { status: "unchanged", companyId: company.companyId };
+
+    const now = Date.now();
+    if (args.state !== "removed") {
+      await ctx.db.patch(company._id, {
+        lifecycle: args.state,
+        snapshotGeneration: company.snapshotGeneration + 1,
+        updatedAt: now,
+      });
+      await ctx.db.patch(account._id, {
+        snapshotGeneration: (account.snapshotGeneration ?? 0) + 1,
+        updatedAt: now,
+      });
+      return { status: args.state, companyId: company.companyId };
+    }
+
+    const purgeGeneration = company.purgeGeneration + 1;
+    await deleteCompanyClaims(ctx, account.logicalAccountId, company.companyId);
+    await ctx.db.patch(company._id, {
+      lifecycle: "removed",
+      removedAt: now,
+      purgeGeneration,
+      purgePhase: "payload",
+      snapshotGeneration: company.snapshotGeneration + 1,
+      updatedAt: now,
+    });
+    await ctx.db.patch(account._id, {
+      companyCount: Math.max(0, (account.companyCount ?? 0) - 1),
+      snapshotGeneration: (account.snapshotGeneration ?? 0) + 1,
+      updatedAt: now,
+    });
+    await ctx.scheduler.runAfter(
+      0,
+      (internal as any).companyMonitoring.companies.advanceCompanyPurge,
+      {
+        ownerAccountId: account.logicalAccountId,
+        companyId: company.companyId,
+        purgeGeneration,
+      },
+    );
+    return { status: "removed", companyId: company.companyId };
+  },
+});
+
+export const advanceCompanyPurge = internalMutation({
+  args: {
+    ownerAccountId: v.string(),
+    companyId: v.string(),
+    purgeGeneration: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const company = await ctx.db
+      .query("companyMonitoringCompanies")
+      .withIndex("by_account_companyId", (q) =>
+        q.eq("ownerAccountId", args.ownerAccountId).eq("companyId", args.companyId),
+      )
+      .unique();
+    if (
+      !company ||
+      company.lifecycle !== "removed" ||
+      company.purgeGeneration !== args.purgeGeneration
+    ) {
+      return { status: "stale" };
+    }
+    if (company.purgePhase === "complete") return { status: "complete" };
+    await ctx.db.patch(company._id, {
+      name: undefined,
+      sortName: undefined,
+      domicileCountry: undefined,
+      customerReference: undefined,
+      coverageState: undefined,
+      observationState: undefined,
+      purgePhase: "complete",
+      updatedAt: Date.now(),
+    });
+    return { status: "complete" };
+  },
+});

--- a/convex/companyMonitoring/companies.ts
+++ b/convex/companyMonitoring/companies.ts
@@ -354,7 +354,7 @@ export const setCompanyStateForOwner = internalMutation({
     });
     await ctx.scheduler.runAfter(
       0,
-      (internal as any).companyMonitoring.companies.advanceCompanyPurge,
+      internal.companyMonitoring.companies.advanceCompanyPurge,
       {
         ownerAccountId: account.logicalAccountId,
         companyId: company.companyId,
@@ -391,6 +391,11 @@ export const advanceCompanyPurge = internalMutation({
       sortName: undefined,
       domicileCountry: undefined,
       customerReference: undefined,
+      directRequestId: undefined,
+      directFingerprint: undefined,
+      clientImportId: undefined,
+      importOrdinal: undefined,
+      importFingerprint: undefined,
       coverageState: undefined,
       observationState: undefined,
       purgePhase: "complete",

--- a/convex/companyMonitoring/companies.ts
+++ b/convex/companyMonitoring/companies.ts
@@ -8,7 +8,6 @@ import {
   assertLogicalId,
   COMPANY_MONITORING_LIMITS,
   assertLifecycleTransition,
-  type CompanyClaimInput,
   type MonitoredCompanyInput,
   type NormalizedMonitoredCompanyInput,
 } from "../../shared/company-monitoring-contract";
@@ -21,6 +20,7 @@ import {
   requireActiveAccount,
   COMPANY_LIMIT,
 } from "./_shared";
+import { companyPatchValidator, monitoredCompanyInputValidator } from "./validators";
 
 type ReplayMetadata =
   | { directRequestId: string; directFingerprint: string }
@@ -88,7 +88,7 @@ export const createCompanyForOwner = internalMutation({
   args: {
     ownerUserId: v.string(),
     clientRequestId: v.string(),
-    company: v.any(),
+    company: monitoredCompanyInputValidator,
   },
   handler: async (ctx, args) => {
     const account = await requireActiveAccount(ctx, args.ownerUserId);
@@ -168,7 +168,7 @@ export const updateCompanyForOwner = internalMutation({
   args: {
     ownerUserId: v.string(),
     companyId: v.string(),
-    patch: v.any(),
+    patch: companyPatchValidator,
   },
   handler: async (ctx, args) => {
     const account = await requireActiveAccount(ctx, args.ownerUserId);
@@ -181,25 +181,9 @@ export const updateCompanyForOwner = internalMutation({
     if (!company || company.lifecycle === "removed" || !company.name || !company.domicileCountry) {
       throw new ConvexError("NOT_FOUND");
     }
-    if (!args.patch || typeof args.patch !== "object" || Array.isArray(args.patch)) {
-      throw new ConvexError("INVALID_COMPANY_PATCH");
-    }
-    const patch = args.patch as Record<string, unknown>;
-    const allowedFields = new Set([
-      "name",
-      "domicileCountry",
-      "customerReference",
-      "addClaims",
-      "removeClaimIds",
-    ]);
-    if (Object.keys(patch).some((field) => !allowedFields.has(field))) {
-      throw new ConvexError("INVALID_COMPANY_PATCH");
-    }
+    const patch = args.patch;
     const addClaimInputs = patch.addClaims ?? [];
     const removeClaimInputs = patch.removeClaimIds ?? [];
-    if (!Array.isArray(addClaimInputs) || !Array.isArray(removeClaimInputs)) {
-      throw new ConvexError("INVALID_COMPANY_PATCH");
-    }
     if (
       addClaimInputs.length > COMPANY_MONITORING_LIMITS.maxClaimsPerCompany ||
       removeClaimInputs.length > COMPANY_MONITORING_LIMITS.maxClaimsPerCompany
@@ -211,10 +195,10 @@ export const updateCompanyForOwner = internalMutation({
     const hasDomicile = Object.prototype.hasOwnProperty.call(patch, "domicileCountry");
     const hasCustomerReference = Object.prototype.hasOwnProperty.call(patch, "customerReference");
     const normalizedFields = normalizeMonitoredCompanyInput({
-      name: hasName ? patch.name as string : company.name,
-      domicileCountry: hasDomicile ? patch.domicileCountry as string : company.domicileCountry,
+      name: hasName ? patch.name! : company.name,
+      domicileCountry: hasDomicile ? patch.domicileCountry! : company.domicileCountry,
       customerReference: hasCustomerReference
-        ? patch.customerReference as string | undefined
+        ? patch.customerReference
         : company.customerReference,
     });
     if (hasCustomerReference && normalizedFields.customerReference) {
@@ -252,8 +236,7 @@ export const updateCompanyForOwner = internalMutation({
         .filter((claim) => !removeIds.has(claim.claimId))
         .map((claim) => `${claim.type}\u0000${claim.value}`),
     );
-    const normalizedAdditions = (addClaimInputs as CompanyClaimInput[])
-      .map(normalizeCompanyClaimInput);
+    const normalizedAdditions = addClaimInputs.map(normalizeCompanyClaimInput);
     if (hasCustomerReference && normalizedFields.customerReference) {
       normalizedAdditions.push({
         type: "customer_reference",

--- a/convex/companyMonitoring/companies.ts
+++ b/convex/companyMonitoring/companies.ts
@@ -20,6 +20,7 @@ import {
   requireActiveAccount,
   COMPANY_LIMIT,
 } from "./_shared";
+import { requireProvisionedAccount } from "./accounts";
 import { companyPatchValidator, monitoredCompanyInputValidator } from "./validators";
 
 type ReplayMetadata =
@@ -84,6 +85,9 @@ export async function findNoopByCustomerReference(
   return active ?? paused;
 }
 
+// Adding the first company is a first-use entry point, so it provisions the
+// root; update/setState/list resolve read-only because a company cannot exist
+// without one.
 export const createCompanyForOwner = internalMutation({
   args: {
     ownerUserId: v.string(),
@@ -91,7 +95,7 @@ export const createCompanyForOwner = internalMutation({
     company: monitoredCompanyInputValidator,
   },
   handler: async (ctx, args) => {
-    const account = await requireActiveAccount(ctx, args.ownerUserId);
+    const account = await requireProvisionedAccount(ctx, args.ownerUserId);
     const clientRequestId = normalizeRequestId(args.clientRequestId);
     const company = normalizeMonitoredCompanyInput(args.company as MonitoredCompanyInput);
     const directFingerprint = await fingerprint({ version: "cm-direct-v1", company });

--- a/convex/companyMonitoring/imports.ts
+++ b/convex/companyMonitoring/imports.ts
@@ -6,7 +6,8 @@ import {
   type CompanyImportRowInput,
   type NormalizedCompanyImportRow,
 } from "../../shared/company-monitoring-contract";
-import { COMPANY_LIMIT, fingerprint, requireActiveAccount } from "./_shared";
+import { COMPANY_LIMIT, fingerprint } from "./_shared";
+import { requireProvisionedAccount } from "./accounts";
 import { findNoopByCustomerReference, insertNormalizedCompany } from "./companies";
 import {
   companyImportRowInputValidator,
@@ -29,7 +30,7 @@ export const importCompanyRowForOwner = internalMutation({
     rowFingerprint: v.string(),
   },
   handler: async (ctx, args): Promise<ImportRowMutationResult> => {
-    const account = await requireActiveAccount(ctx, args.ownerUserId);
+    const account = await requireProvisionedAccount(ctx, args.ownerUserId);
     const row = args.row as NormalizedCompanyImportRow;
     const companyCount = account.companyCount ?? 0;
     const replay = await ctx.db

--- a/convex/companyMonitoring/imports.ts
+++ b/convex/companyMonitoring/imports.ts
@@ -114,7 +114,7 @@ export const importCompaniesForOwner = internalAction({
 
     for (const [index, row] of rows.entries()) {
       const result = await ctx.runMutation(
-        (internal as any).companyMonitoring.imports.importCompanyRowForOwner,
+        internal.companyMonitoring.imports.importCompanyRowForOwner,
         {
           ownerUserId: args.ownerUserId,
           row,

--- a/convex/companyMonitoring/imports.ts
+++ b/convex/companyMonitoring/imports.ts
@@ -1,0 +1,126 @@
+import { v } from "convex/values";
+import { internal } from "../_generated/api";
+import { internalAction, internalMutation } from "../_generated/server";
+import {
+  normalizeCompanyImportBatch,
+  type CompanyImportRowInput,
+  type NormalizedCompanyImportRow,
+} from "../../shared/company-monitoring-contract";
+import { COMPANY_LIMIT, fingerprint, requireActiveAccount } from "./_shared";
+import { findNoopByCustomerReference, insertNormalizedCompany } from "./companies";
+
+type ImportRowResult = {
+  ordinal: number;
+  status: "created" | "replayed" | "noop" | "rejected" | "conflict";
+  companyId?: string;
+  reason?: string;
+};
+
+type ImportRowMutationResult = ImportRowResult & { companyCount: number };
+
+export const importCompanyRowForOwner = internalMutation({
+  args: {
+    ownerUserId: v.string(),
+    row: v.any(),
+    rowFingerprint: v.string(),
+  },
+  handler: async (ctx, args): Promise<ImportRowMutationResult> => {
+    const account = await requireActiveAccount(ctx, args.ownerUserId);
+    const row = args.row as NormalizedCompanyImportRow;
+    const companyCount = account.companyCount ?? 0;
+    const replay = await ctx.db
+      .query("companyMonitoringCompanies")
+      .withIndex("by_account_import_tuple", (q) =>
+        q
+          .eq("ownerAccountId", account.logicalAccountId)
+          .eq("clientImportId", row.clientImportId)
+          .eq("importOrdinal", row.ordinal),
+      )
+      .unique();
+    if (replay) {
+      return replay.importFingerprint === args.rowFingerprint
+        ? {
+            ordinal: row.ordinal,
+            status: "replayed",
+            companyId: replay.companyId,
+            companyCount,
+          }
+        : {
+            ordinal: row.ordinal,
+            status: "conflict",
+            reason: "REPLAY_CONFLICT",
+            companyCount,
+          };
+    }
+
+    // No-op rows intentionally do not consume the replay tuple. Retrying
+    // must re-evaluate the current portfolio rather than replaying a stale
+    // no-op if the original matching company was removed in the meantime.
+    const noop = await findNoopByCustomerReference(
+      ctx,
+      account.logicalAccountId,
+      row.customerReference,
+    );
+    if (noop) {
+      return {
+        ordinal: row.ordinal,
+        status: "noop",
+        companyId: noop.companyId,
+        companyCount,
+      };
+    }
+
+    if (companyCount >= (account.companyLimit ?? COMPANY_LIMIT)) {
+      return {
+        ordinal: row.ordinal,
+        status: "rejected",
+        reason: "COMPANY_LIMIT_REACHED",
+        companyCount,
+      };
+    }
+
+    const companyId = await insertNormalizedCompany(ctx, account, row, {
+      clientImportId: row.clientImportId,
+      importOrdinal: row.ordinal,
+      importFingerprint: args.rowFingerprint,
+    });
+    const nextCompanyCount = companyCount + 1;
+    await ctx.db.patch(account._id, {
+      companyCount: nextCompanyCount,
+      snapshotGeneration: (account.snapshotGeneration ?? 0) + 1,
+      updatedAt: Date.now(),
+    });
+    return {
+      ordinal: row.ordinal,
+      status: "created",
+      companyId,
+      companyCount: nextCompanyCount,
+    };
+  },
+});
+
+export const importCompaniesForOwner = internalAction({
+  args: { ownerUserId: v.string(), rows: v.array(v.any()) },
+  handler: async (ctx, args) => {
+    const rows = normalizeCompanyImportBatch(args.rows as CompanyImportRowInput[]);
+    const rowFingerprints = await Promise.all(rows.map((row) => fingerprint(row)));
+    const results: ImportRowResult[] = [];
+    let companyCount = 0;
+
+    for (const [index, row] of rows.entries()) {
+      const result = await ctx.runMutation(
+        (internal as any).companyMonitoring.imports.importCompanyRowForOwner,
+        {
+          ownerUserId: args.ownerUserId,
+          row,
+          rowFingerprint: rowFingerprints[index]!,
+        },
+      ) as ImportRowMutationResult;
+      companyCount = result.companyCount;
+      const { companyCount: _companyCount, ...rowResult } = result;
+      results.push(rowResult);
+    }
+
+    return { results, companyCount };
+  },
+});

--- a/convex/companyMonitoring/imports.ts
+++ b/convex/companyMonitoring/imports.ts
@@ -8,6 +8,10 @@ import {
 } from "../../shared/company-monitoring-contract";
 import { COMPANY_LIMIT, fingerprint, requireActiveAccount } from "./_shared";
 import { findNoopByCustomerReference, insertNormalizedCompany } from "./companies";
+import {
+  companyImportRowInputValidator,
+  normalizedCompanyImportRowValidator,
+} from "./validators";
 
 type ImportRowResult = {
   ordinal: number;
@@ -21,7 +25,7 @@ type ImportRowMutationResult = ImportRowResult & { companyCount: number };
 export const importCompanyRowForOwner = internalMutation({
   args: {
     ownerUserId: v.string(),
-    row: v.any(),
+    row: normalizedCompanyImportRowValidator,
     rowFingerprint: v.string(),
   },
   handler: async (ctx, args): Promise<ImportRowMutationResult> => {
@@ -100,7 +104,7 @@ export const importCompanyRowForOwner = internalMutation({
 });
 
 export const importCompaniesForOwner = internalAction({
-  args: { ownerUserId: v.string(), rows: v.array(v.any()) },
+  args: { ownerUserId: v.string(), rows: v.array(companyImportRowInputValidator) },
   handler: async (ctx, args) => {
     const rows = normalizeCompanyImportBatch(args.rows as CompanyImportRowInput[]);
     const rowFingerprints = await Promise.all(rows.map((row) => fingerprint(row)));

--- a/convex/companyMonitoring/validators.ts
+++ b/convex/companyMonitoring/validators.ts
@@ -1,0 +1,46 @@
+import { v } from "convex/values";
+import { COMPANY_MONITORING_IMPORT_VERSION } from "../../shared/company-monitoring-contract";
+
+const monitoredCompanyInputFields = {
+  name: v.string(),
+  domicileCountry: v.string(),
+  aliases: v.optional(v.array(v.string())),
+  domains: v.optional(v.array(v.string())),
+  identifiers: v.optional(v.array(v.string())),
+  xHandles: v.optional(v.array(v.string())),
+  locations: v.optional(v.array(v.string())),
+  customerReference: v.optional(v.string()),
+};
+
+export const monitoredCompanyInputValidator = v.object(monitoredCompanyInputFields);
+
+export const companyImportRowInputValidator = v.object({
+  ...monitoredCompanyInputFields,
+  clientImportId: v.string(),
+  ordinal: v.number(),
+});
+
+export const normalizedCompanyImportRowValidator = v.object({
+  name: v.string(),
+  domicileCountry: v.union(v.literal("US"), v.literal("GB")),
+  aliases: v.array(v.string()),
+  domains: v.array(v.string()),
+  identifiers: v.array(v.string()),
+  xHandles: v.array(v.string()),
+  locations: v.array(v.string()),
+  customerReference: v.optional(v.string()),
+  contractVersion: v.literal(COMPANY_MONITORING_IMPORT_VERSION),
+  clientImportId: v.string(),
+  ordinal: v.number(),
+});
+
+export const companyPatchValidator = v.object({
+  name: v.optional(v.string()),
+  domicileCountry: v.optional(v.string()),
+  customerReference: v.optional(v.string()),
+  addClaims: v.optional(v.array(v.object({
+    type: v.string(),
+    value: v.string(),
+  }))),
+  removeClaimIds: v.optional(v.array(v.string())),
+});

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -23,6 +23,16 @@ crons.hourly(
   {},
 );
 
+// Bounded recovery for Company Monitoring purge generations whose scheduled
+// continuation was dropped. The mutation independently enforces the ordinary
+// lapse purgeAfter deadline, so an hourly wake cannot bypass the 24h grace.
+crons.hourly(
+  "company-monitoring-stalled-purge-reaper",
+  { minuteUTC: 37 },
+  internal.companyMonitoring.accounts.reapStalledAccountPurges,
+  {},
+);
+
 // PRO-launch broadcast ramp runner. Wakes once a day at 13:00 UTC
 // (~9am ET / 6am PT / 3pm CET — early enough that any kill-gate
 // trip can be triaged within US business hours, late enough that

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -33,6 +33,19 @@ crons.hourly(
   {},
 );
 
+// Company Monitoring account roots are provisioned on first use and are no
+// longer touched by entitlement writes (#6256), so lapses are pulled here
+// instead of pushed from billing. Scanning only companyMonitoringAccounts means
+// this costs nothing for the subscribers who never use the feature. The 24h
+// purgeAfter grace still applies downstream, so detection latency of one tick
+// is absorbed by a window that already exists.
+crons.hourly(
+  "company-monitoring-entitlement-reconciler",
+  { minuteUTC: 47 },
+  internal.companyMonitoring.accounts.reconcileAccountEntitlements,
+  {},
+);
+
 // PRO-launch broadcast ramp runner. Wakes once a day at 13:00 UTC
 // (~9am ET / 6am PT / 3pm CET — early enough that any kill-gate
 // trip can be triaged within US business hours, late enough that

--- a/convex/lib/identitySigning.ts
+++ b/convex/lib/identitySigning.ts
@@ -8,6 +8,10 @@
  * Uses DODO_IDENTITY_SIGNING_SECRET as the HMAC key — a dedicated secret
  * that is SEPARATE from DODO_PAYMENTS_WEBHOOK_SECRET. This ensures rotating
  * the webhook secret does not break identity verification, and vice versa.
+ *
+ * Company Monitoring owner fences use their own required
+ * COMPANY_MONITORING_OWNER_FENCE_SECRET and rotation keyring. Fence identity
+ * must remain stable when checkout/token signing keys rotate.
  */
 
 export const ANON_ID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -24,6 +28,7 @@ const MAX_ANON_CLAIM_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const BUSINESS_INVITE_TOKEN_VERSION = "v1";
 const BUSINESS_INVITE_TOKEN_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 const COMPANY_MONITORING_OWNER_FENCE_VERSION = "v1";
+const COMPANY_MONITORING_OWNER_FENCE_SECRET_ENV = "COMPANY_MONITORING_OWNER_FENCE_SECRET";
 const COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS_ENV =
   "COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS";
 
@@ -64,13 +69,30 @@ export const CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
  */
 export const CHECKOUT_LOGIN_EMAIL_CLOCK_SKEW_MS = 5 * 60 * 1000;
 
-function getSigningKey(): string {
+function getDodoIdentitySigningKey(): string {
   const key = process.env.DODO_IDENTITY_SIGNING_SECRET;
   if (!key) {
     throw new Error(
       "[identity-signing] DODO_IDENTITY_SIGNING_SECRET not set. " +
       "Set it in the Convex dashboard environment variables. " +
       "This is SEPARATE from DODO_PAYMENTS_WEBHOOK_SECRET — do not reuse."
+    );
+  }
+  return key;
+}
+
+function getCompanyMonitoringOwnerFenceKey(): string {
+  const key = process.env[COMPANY_MONITORING_OWNER_FENCE_SECRET_ENV];
+  if (!key) {
+    throw new Error(
+      `[identity-signing] ${COMPANY_MONITORING_OWNER_FENCE_SECRET_ENV} not set. ` +
+      "Set it in the Convex dashboard environment variables. " +
+      "Do not reuse DODO_IDENTITY_SIGNING_SECRET.",
+    );
+  }
+  if (key.trim() !== key) {
+    throw new Error(
+      `[identity-signing] ${COMPANY_MONITORING_OWNER_FENCE_SECRET_ENV} is invalid`,
     );
   }
   return key;
@@ -99,7 +121,7 @@ async function signPayloadWithKey(payload: string, key: string): Promise<string>
 }
 
 async function signPayload(payload: string): Promise<string> {
-  return signPayloadWithKey(payload, getSigningKey());
+  return signPayloadWithKey(payload, getDodoIdentitySigningKey());
 }
 
 function timingSafeEqualHex(expected: string, actual: string): boolean {
@@ -147,10 +169,12 @@ export interface CompanyMonitoringOwnerFenceCandidates {
  * Returns the current fence first, followed by every explicitly configured
  * predecessor that must remain discoverable.
  *
- * Rotation order is deliberate: before rotating DODO_IDENTITY_SIGNING_SECRET,
- * append its current value to the comma-separated
- * COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS keyring and deploy that
- * configuration. Then rotate the current secret. Retain every historical key
+ * Rotation order is deliberate: before rotating
+ * COMPANY_MONITORING_OWNER_FENCE_SECRET, append its current value to the
+ * comma-separated COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS keyring and
+ * deploy that configuration. The current-key duplicate is deliberately
+ * ignored during this preparation step. Then rotate the current secret.
+ * Retain every historical key
  * while tombstones created with it must remain replay-fenced: ownerless
  * terminal rows cannot be bulk migrated without retaining reversible identity.
  * Nonterminal roots are opportunistically migrated by entitlement sync.
@@ -161,10 +185,7 @@ export async function companyMonitoringOwnerFenceCandidates(
   if (!userId) {
     throw new Error("[identity-signing] Company Monitoring owner fence requires a userId");
   }
-  const currentKey = getSigningKey();
-  if (currentKey.trim() !== currentKey) {
-    throw new Error("[identity-signing] DODO_IDENTITY_SIGNING_SECRET is invalid");
-  }
+  const currentKey = getCompanyMonitoringOwnerFenceKey();
   const previousKeysRaw = process.env[COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS_ENV];
   const previousKeys = previousKeysRaw === undefined ? [] : previousKeysRaw.split(",");
   if (
@@ -177,18 +198,18 @@ export async function companyMonitoringOwnerFenceCandidates(
       `[identity-signing] ${COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS_ENV} is invalid`,
     );
   }
-  const seenKeys = new Set([currentKey]);
+  const seenPreviousKeys = new Set<string>();
   for (const previousKey of previousKeys) {
-    if (seenKeys.has(previousKey)) {
+    if (seenPreviousKeys.has(previousKey)) {
       throw new Error(
-        `[identity-signing] ${COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS_ENV} contains a duplicate or current key`,
+        `[identity-signing] ${COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS_ENV} contains a duplicate key`,
       );
     }
-    seenKeys.add(previousKey);
+    seenPreviousKeys.add(previousKey);
   }
 
   const payload = `company-monitoring-owner:${COMPANY_MONITORING_OWNER_FENCE_VERSION}:${userId}`;
-  const keys = [currentKey, ...previousKeys];
+  const keys = [currentKey, ...previousKeys.filter((key) => key !== currentKey)];
   const all = await Promise.all(keys.map((key) => signPayloadWithKey(payload, key)));
   const [current] = all;
   if (!current) {

--- a/convex/lib/identitySigning.ts
+++ b/convex/lib/identitySigning.ts
@@ -222,36 +222,6 @@ export async function signCompanyMonitoringOwnerFence(userId: string): Promise<s
   return (await companyMonitoringOwnerFenceCandidates(userId)).current;
 }
 
-export type CompanyMonitoringOwnerFenceResolution =
-  | { ok: true; fence: CompanyMonitoringOwnerFenceCandidates }
-  | { ok: false; reason: string };
-
-/**
- * Non-throwing variant for callers that must not abort their transaction when
- * the fence keyring is misconfigured.
- *
- * `companyMonitoringOwnerFenceCandidates` throws for pure configuration
- * reasons — an unset or whitespace-padded COMPANY_MONITORING_OWNER_FENCE_SECRET,
- * or a malformed COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS keyring. Its
- * one production caller runs inside the entitlement transaction, so an
- * unhandled throw there rolls back a paying customer's entitlement write and
- * keeps doing so on every Dodo retry, because a config fault is not transient.
- *
- * The try/catch lives HERE, wrapping a pure function, rather than at the call
- * site: Convex has no savepoints, so catching around code that has already
- * written would commit that partial state. Wrapping a function that never
- * touches `ctx` makes the degrade path free of that hazard.
- */
-export async function tryCompanyMonitoringOwnerFenceCandidates(
-  userId: string,
-): Promise<CompanyMonitoringOwnerFenceResolution> {
-  try {
-    return { ok: true, fence: await companyMonitoringOwnerFenceCandidates(userId) };
-  } catch (error) {
-    return { ok: false, reason: error instanceof Error ? error.message : String(error) };
-  }
-}
-
 /**
  * Verifies that a userId + signature pair is valid.
  * Returns true if the signature matches, false otherwise.

--- a/convex/lib/identitySigning.ts
+++ b/convex/lib/identitySigning.ts
@@ -222,6 +222,36 @@ export async function signCompanyMonitoringOwnerFence(userId: string): Promise<s
   return (await companyMonitoringOwnerFenceCandidates(userId)).current;
 }
 
+export type CompanyMonitoringOwnerFenceResolution =
+  | { ok: true; fence: CompanyMonitoringOwnerFenceCandidates }
+  | { ok: false; reason: string };
+
+/**
+ * Non-throwing variant for callers that must not abort their transaction when
+ * the fence keyring is misconfigured.
+ *
+ * `companyMonitoringOwnerFenceCandidates` throws for pure configuration
+ * reasons — an unset or whitespace-padded COMPANY_MONITORING_OWNER_FENCE_SECRET,
+ * or a malformed COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS keyring. Its
+ * one production caller runs inside the entitlement transaction, so an
+ * unhandled throw there rolls back a paying customer's entitlement write and
+ * keeps doing so on every Dodo retry, because a config fault is not transient.
+ *
+ * The try/catch lives HERE, wrapping a pure function, rather than at the call
+ * site: Convex has no savepoints, so catching around code that has already
+ * written would commit that partial state. Wrapping a function that never
+ * touches `ctx` makes the degrade path free of that hazard.
+ */
+export async function tryCompanyMonitoringOwnerFenceCandidates(
+  userId: string,
+): Promise<CompanyMonitoringOwnerFenceResolution> {
+  try {
+    return { ok: true, fence: await companyMonitoringOwnerFenceCandidates(userId) };
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) };
+  }
+}
+
 /**
  * Verifies that a userId + signature pair is valid.
  * Returns true if the signature matches, false otherwise.

--- a/convex/lib/identitySigning.ts
+++ b/convex/lib/identitySigning.ts
@@ -23,6 +23,9 @@ const MAX_ANON_CLAIM_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 // issuing mutation stamps (U3).
 const BUSINESS_INVITE_TOKEN_VERSION = "v1";
 const BUSINESS_INVITE_TOKEN_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+const COMPANY_MONITORING_OWNER_FENCE_VERSION = "v1";
+const COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS_ENV =
+  "COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS";
 
 // Checkout login-email tokens (#6335). Carry the Clerk login email as it was at
 // checkout time so the webhook does not have to trust `users.email`, which is
@@ -73,8 +76,7 @@ function getSigningKey(): string {
   return key;
 }
 
-async function signPayload(payload: string): Promise<string> {
-  const key = getSigningKey();
+async function signPayloadWithKey(payload: string, key: string): Promise<string> {
   const encoder = new TextEncoder();
 
   const cryptoKey = await crypto.subtle.importKey(
@@ -94,6 +96,10 @@ async function signPayload(payload: string): Promise<string> {
   return Array.from(new Uint8Array(signature))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
+}
+
+async function signPayload(payload: string): Promise<string> {
+  return signPayloadWithKey(payload, getSigningKey());
 }
 
 function timingSafeEqualHex(expected: string, actual: string): boolean {
@@ -122,6 +128,77 @@ function getAnonClaimTokenTtlMs(): number {
  */
 export async function signUserId(userId: string): Promise<string> {
   return signPayload(userId);
+}
+
+/**
+ * Stable, keyed owner fence for Company Monitoring account roots.
+ *
+ * The domain separator prevents this value being replayed as checkout
+ * metadata. Keeping the fence after owner/account deletion lets a delayed
+ * entitlement activation find the terminal tombstone without retaining the
+ * Clerk owner id on that tombstone.
+ */
+export interface CompanyMonitoringOwnerFenceCandidates {
+  current: string;
+  all: readonly string[];
+}
+
+/**
+ * Returns the current fence first, followed by every explicitly configured
+ * predecessor that must remain discoverable.
+ *
+ * Rotation order is deliberate: before rotating DODO_IDENTITY_SIGNING_SECRET,
+ * append its current value to the comma-separated
+ * COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS keyring and deploy that
+ * configuration. Then rotate the current secret. Retain every historical key
+ * while tombstones created with it must remain replay-fenced: ownerless
+ * terminal rows cannot be bulk migrated without retaining reversible identity.
+ * Nonterminal roots are opportunistically migrated by entitlement sync.
+ */
+export async function companyMonitoringOwnerFenceCandidates(
+  userId: string,
+): Promise<CompanyMonitoringOwnerFenceCandidates> {
+  if (!userId) {
+    throw new Error("[identity-signing] Company Monitoring owner fence requires a userId");
+  }
+  const currentKey = getSigningKey();
+  if (currentKey.trim() !== currentKey) {
+    throw new Error("[identity-signing] DODO_IDENTITY_SIGNING_SECRET is invalid");
+  }
+  const previousKeysRaw = process.env[COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS_ENV];
+  const previousKeys = previousKeysRaw === undefined ? [] : previousKeysRaw.split(",");
+  if (
+    previousKeysRaw !== undefined &&
+    (!previousKeysRaw ||
+      previousKeysRaw.trim() !== previousKeysRaw ||
+      previousKeys.some((key) => !key || key.trim() !== key))
+  ) {
+    throw new Error(
+      `[identity-signing] ${COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS_ENV} is invalid`,
+    );
+  }
+  const seenKeys = new Set([currentKey]);
+  for (const previousKey of previousKeys) {
+    if (seenKeys.has(previousKey)) {
+      throw new Error(
+        `[identity-signing] ${COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS_ENV} contains a duplicate or current key`,
+      );
+    }
+    seenKeys.add(previousKey);
+  }
+
+  const payload = `company-monitoring-owner:${COMPANY_MONITORING_OWNER_FENCE_VERSION}:${userId}`;
+  const keys = [currentKey, ...previousKeys];
+  const all = await Promise.all(keys.map((key) => signPayloadWithKey(payload, key)));
+  const [current] = all;
+  if (!current) {
+    throw new Error("[identity-signing] Company Monitoring owner fence keyring is empty");
+  }
+  return { current, all };
+}
+
+export async function signCompanyMonitoringOwnerFence(userId: string): Promise<string> {
+  return (await companyMonitoringOwnerFenceCandidates(userId)).current;
 }
 
 /**

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -17,6 +17,7 @@ import type { Subscription as DodoSubscription } from "dodopayments/resources/su
 import type { Doc, Id } from "../_generated/dataModel";
 import { resolveUserId, requireUserId } from "../lib/auth";
 import { getFeaturesForPlan } from "../lib/entitlements";
+import { syncCompanyMonitoringAccountFromEntitlement } from "../companyMonitoring/accounts";
 import { ANON_ID_V4_REGEX, verifyAnonClaimToken } from "../lib/identitySigning";
 import { PLAN_PRECEDENCE, PRODUCT_CATALOG, resolveProductToPlan } from "../config/productCatalog";
 import { proActivationStepIdValidator } from "../constants";
@@ -3929,6 +3930,8 @@ export const grantComplimentaryEntitlement = internalMutation({
         updatedAt: now,
       });
     }
+
+    await syncCompanyMonitoringAccountFromEntitlement(ctx, args.userId);
 
     console.log(
       `[billing] grantComplimentaryEntitlement userId=${args.userId} planKey=${args.planKey} days=${args.days} validUntil=${new Date(validUntil).toISOString()}${args.reason ? ` reason="${args.reason}"` : ""}`,

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -17,7 +17,6 @@ import type { Subscription as DodoSubscription } from "dodopayments/resources/su
 import type { Doc, Id } from "../_generated/dataModel";
 import { resolveUserId, requireUserId } from "../lib/auth";
 import { getFeaturesForPlan } from "../lib/entitlements";
-import { syncCompanyMonitoringAccountFromEntitlement } from "../companyMonitoring/accounts";
 import { ANON_ID_V4_REGEX, verifyAnonClaimToken } from "../lib/identitySigning";
 import { PLAN_PRECEDENCE, PRODUCT_CATALOG, resolveProductToPlan } from "../config/productCatalog";
 import { proActivationStepIdValidator } from "../constants";
@@ -3931,7 +3930,8 @@ export const grantComplimentaryEntitlement = internalMutation({
       });
     }
 
-    await syncCompanyMonitoringAccountFromEntitlement(ctx, args.userId);
+    // Company Monitoring is provisioned on first use, not from entitlement
+    // writes (#6256).
 
     console.log(
       `[billing] grantComplimentaryEntitlement userId=${args.userId} planKey=${args.planKey} days=${args.days} validUntil=${new Date(validUntil).toISOString()}${args.reason ? ` reason="${args.reason}"` : ""}`,

--- a/convex/payments/cacheActions.ts
+++ b/convex/payments/cacheActions.ts
@@ -27,6 +27,14 @@ function getEntitlementKey(userId: string): string {
   return `entitlements:${envPrefix}:${userId}`;
 }
 
+/** Mirrors the Vercel Redis namespace used by both user API-key validators. */
+function getServerRedisKeyPrefix(): string {
+  const env = process.env.VERCEL_ENV;
+  if (!env || env === "production") return "";
+  const sha = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 8) || "dev";
+  return `${env}:${sha}:`;
+}
+
 /**
  * Writes a user's entitlements to Redis via Upstash REST API.
  *
@@ -196,6 +204,68 @@ export const deleteEntitlementCache = internalAction({
         "[cacheActions] Redis cache delete failed:",
         err instanceof Error ? err.message : String(err),
       );
+    } finally {
+      clearTimeout(timeout);
+    }
+  },
+});
+
+/**
+ * Invalidates warm production user-key entries after an account lifecycle
+ * transition. Company Monitoring scopes are account-bound inside the cached
+ * validation payload, so a lapse/terminal fence must not wait for the 60s TTL.
+ */
+export const invalidateUserApiKeyCaches = internalAction({
+  args: { keyHashes: v.array(v.string()) },
+  handler: async (_ctx, args) => {
+    const url = process.env.UPSTASH_REDIS_REST_URL;
+    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url && !token) return;
+    if (!url || !token) {
+      throw new Error(
+        "[cacheActions] UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN must be configured together for user API key cache invalidation",
+      );
+    }
+    if (args.keyHashes.length === 0) return;
+    const keyPrefix = getServerRedisKeyPrefix();
+    const commands = args.keyHashes.flatMap((keyHash) => [
+      ["DEL", `${keyPrefix}user-api-key:${keyHash}`],
+      ["DEL", `${keyPrefix}bootstrap-user-api-key-invalid:${keyHash}`],
+    ]);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REDIS_FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetch(`${url}/pipeline`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "User-Agent": "worldmonitor-server/1.0 (redis)",
+        },
+        body: JSON.stringify(commands),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`[cacheActions] user API key cache DEL failed: HTTP ${response.status}`);
+      }
+      const results: unknown = await response.json();
+      if (!Array.isArray(results) || results.length !== commands.length) {
+        throw new Error("[cacheActions] user API key cache DEL returned malformed pipeline results");
+      }
+      for (const [index, entry] of results.entries()) {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          throw new Error(`[cacheActions] user API key cache DEL failed at pipeline index ${index}`);
+        }
+        const result = entry as Record<string, unknown>;
+        const value = result.result;
+        if (
+          Object.prototype.hasOwnProperty.call(result, "error") ||
+          !Object.prototype.hasOwnProperty.call(result, "result") ||
+          (value !== 0 && value !== 1 && value !== "0" && value !== "1")
+        ) {
+          throw new Error(`[cacheActions] user API key cache DEL failed at pipeline index ${index}`);
+        }
+      }
     } finally {
       clearTimeout(timeout);
     }

--- a/convex/payments/cacheActions.ts
+++ b/convex/payments/cacheActions.ts
@@ -27,14 +27,6 @@ function getEntitlementKey(userId: string): string {
   return `entitlements:${envPrefix}:${userId}`;
 }
 
-/** Mirrors the Vercel Redis namespace used by both user API-key validators. */
-function getServerRedisKeyPrefix(): string {
-  const env = process.env.VERCEL_ENV;
-  if (!env || env === "production") return "";
-  const sha = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 8) || "dev";
-  return `${env}:${sha}:`;
-}
-
 /**
  * Writes a user's entitlements to Redis via Upstash REST API.
  *
@@ -227,10 +219,12 @@ export const invalidateUserApiKeyCaches = internalAction({
       );
     }
     if (args.keyHashes.length === 0) return;
-    const keyPrefix = getServerRedisKeyPrefix();
+    // Convex actions do not inherit Vercel deployment metadata. Lifecycle
+    // invalidation therefore targets the production, unprefixed namespace;
+    // preview-key namespacing remains local to the Vercel validators.
     const commands = args.keyHashes.flatMap((keyHash) => [
-      ["DEL", `${keyPrefix}user-api-key:${keyHash}`],
-      ["DEL", `${keyPrefix}bootstrap-user-api-key-invalid:${keyHash}`],
+      ["DEL", `user-api-key:${keyHash}`],
+      ["DEL", `bootstrap-user-api-key-invalid:${keyHash}`],
     ]);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), REDIS_FETCH_TIMEOUT_MS);

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -22,7 +22,6 @@ import {
   verifyUserId,
 } from "../lib/identitySigning";
 import { DEV_USER_ID, isDev } from "../lib/auth";
-import { syncCompanyMonitoringAccountFromEntitlement } from "../companyMonitoring/accounts";
 import { isChargedEventType, recordUnattributedEvent } from "./unattributedPayments";
 
 // ---------------------------------------------------------------------------
@@ -196,14 +195,13 @@ export async function upsertEntitlements(
     }
   }
 
-  // Company Monitoring account state is part of the entitlement transaction: the
-  // canonical row and its one account root commit together or not at all —
-  // whenever the owner fence is resolvable. A misconfigured fence keyring
-  // degrades Company Monitoring (logged, root skipped, converges on the next
-  // entitlement write) instead of rolling back this entitlement write, because
-  // a config fault would otherwise fail every Dodo retry identically. Data
-  // conflicts inside the sync still propagate and still abort the transaction.
-  await syncCompanyMonitoringAccountFromEntitlement(ctx, userId);
+  // Company Monitoring deliberately does NOT run here (#6256). It is a
+  // segment feature, and this is the one entitlement-write path every
+  // subscriber traverses; provisioning from here charged all of them for its
+  // queries, an extra write, and 1+N HMACs, and let any fault inside it —
+  // including a config typo that fails every retry identically — roll back a
+  // paying customer's entitlement. Roots are provisioned on first authenticated
+  // use, and lapses are reconciled by the reaper cron.
 
   // ACCEPTED BOUND: cache sync runs after mutation commits. If scheduler
   // fails to enqueue, stale cache survives up to ENTITLEMENT_CACHE_TTL_SECONDS
@@ -412,7 +410,6 @@ export async function recomputeEntitlementFromAllSubs(
     console.log(
       `[subscriptionHelpers] recompute for ${userId} — comp floor active until ${new Date(entitlement.compUntil).toISOString()}, preserving entitlement`,
     );
-    await syncCompanyMonitoringAccountFromEntitlement(ctx, userId);
     return;
   }
 

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -22,6 +22,7 @@ import {
   verifyUserId,
 } from "../lib/identitySigning";
 import { DEV_USER_ID, isDev } from "../lib/auth";
+import { syncCompanyMonitoringAccountFromEntitlement } from "../companyMonitoring/accounts";
 import { isChargedEventType, recordUnattributedEvent } from "./unattributedPayments";
 
 // ---------------------------------------------------------------------------
@@ -194,6 +195,10 @@ export async function upsertEntitlements(
       });
     }
   }
+
+  // Company Monitoring account state is part of the entitlement transaction: the
+  // canonical row and its one account root commit together or not at all.
+  await syncCompanyMonitoringAccountFromEntitlement(ctx, userId);
 
   // ACCEPTED BOUND: cache sync runs after mutation commits. If scheduler
   // fails to enqueue, stale cache survives up to ENTITLEMENT_CACHE_TTL_SECONDS
@@ -402,6 +407,7 @@ export async function recomputeEntitlementFromAllSubs(
     console.log(
       `[subscriptionHelpers] recompute for ${userId} — comp floor active until ${new Date(entitlement.compUntil).toISOString()}, preserving entitlement`,
     );
+    await syncCompanyMonitoringAccountFromEntitlement(ctx, userId);
     return;
   }
 

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -197,7 +197,12 @@ export async function upsertEntitlements(
   }
 
   // Company Monitoring account state is part of the entitlement transaction: the
-  // canonical row and its one account root commit together or not at all.
+  // canonical row and its one account root commit together or not at all —
+  // whenever the owner fence is resolvable. A misconfigured fence keyring
+  // degrades Company Monitoring (logged, root skipped, converges on the next
+  // entitlement write) instead of rolling back this entitlement write, because
+  // a config fault would otherwise fail every Dodo retry identically. Data
+  // conflicts inside the sync still propagate and still abort the transaction.
   await syncCompanyMonitoringAccountFromEntitlement(ctx, userId);
 
   // ACCEPTED BOUND: cache sync runs after mutation commits. If scheduler

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1020,6 +1020,96 @@ export default defineSchema({
     .index("by_dodoProductId", ["dodoProductId"])
     .index("by_planKey", ["planKey"]),
 
+  // Company Monitoring's account root. The persistence contract deliberately keeps
+  // surface to this table plus company and claim rows: imports are replayed
+  // from company-row idempotency fields, and purge progress lives on the root.
+  companyMonitoringAccounts: defineTable({
+    logicalAccountId: v.string(),
+    ownerUserId: v.optional(v.string()),
+    ownerFenceHash: v.string(),
+    lifecycle: v.union(
+      v.literal("entitled"),
+      v.literal("entitlement_lapsed"),
+      v.literal("denied"),
+    ),
+    terminalReason: v.optional(v.union(v.literal("owner_deleted"), v.literal("account_deleted"))),
+    entitlementDigest: v.optional(v.string()),
+    lifecycleSequence: v.number(),
+    companyCount: v.optional(v.number()),
+    companyLimit: v.optional(v.number()),
+    snapshotGeneration: v.optional(v.number()),
+    purgeGeneration: v.number(),
+    purgePhase: v.union(
+      v.literal("none"),
+      v.literal("pending"),
+      v.literal("companies"),
+      v.literal("finalizing"),
+      v.literal("complete"),
+    ),
+    destructivePurgeStarted: v.boolean(),
+    pendingReactivation: v.boolean(),
+    purgeCursor: v.optional(v.string()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_logicalAccountId", ["logicalAccountId"])
+    .index("by_ownerUserId", ["ownerUserId"])
+    .index("by_ownerFenceHash", ["ownerFenceHash"])
+    .index("by_lifecycle", ["lifecycle"]),
+
+  companyMonitoringCompanies: defineTable({
+    ownerAccountId: v.string(),
+    companyId: v.string(),
+    name: v.optional(v.string()),
+    sortName: v.optional(v.string()),
+    domicileCountry: v.optional(v.union(v.literal("US"), v.literal("GB"))),
+    customerReference: v.optional(v.string()),
+    lifecycle: v.union(v.literal("active"), v.literal("paused"), v.literal("removed")),
+    coverageState: v.optional(v.literal("awaiting_first_scan")),
+    observationState: v.optional(v.literal("unknown")),
+    snapshotGeneration: v.number(),
+    directRequestId: v.optional(v.string()),
+    directFingerprint: v.optional(v.string()),
+    clientImportId: v.optional(v.string()),
+    importOrdinal: v.optional(v.number()),
+    importFingerprint: v.optional(v.string()),
+    purgeGeneration: v.number(),
+    purgePhase: v.union(v.literal("none"), v.literal("payload"), v.literal("complete")),
+    removedAt: v.optional(v.number()),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_account_companyId", ["ownerAccountId", "companyId"])
+    .index("by_account_lifecycle_sortName", ["ownerAccountId", "lifecycle", "sortName"])
+    .index("by_account_customerReference", ["ownerAccountId", "customerReference"])
+    .index("by_account_customerReference_lifecycle", ["ownerAccountId", "customerReference", "lifecycle"])
+    .index("by_account_directRequestId", ["ownerAccountId", "directRequestId"])
+    .index("by_account_import_tuple", ["ownerAccountId", "clientImportId", "importOrdinal"])
+    .index("by_account_purge", ["ownerAccountId", "purgeGeneration", "purgePhase"]),
+
+  companyMonitoringClaims: defineTable({
+    ownerAccountId: v.string(),
+    companyId: v.string(),
+    claimId: v.string(),
+    type: v.union(
+      v.literal("alias"),
+      v.literal("domain"),
+      v.literal("legal_identifier"),
+      v.literal("x_account_id"),
+      v.literal("x_handle"),
+      v.literal("location"),
+      v.literal("customer_reference"),
+    ),
+    value: v.string(),
+    provenance: v.literal("customer"),
+    trustState: v.literal("unverified"),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_account_company", ["ownerAccountId", "companyId"])
+    .index("by_account_company_claimId", ["ownerAccountId", "companyId", "claimId"])
+    .index("by_account_type_value", ["ownerAccountId", "type", "value"]),
+
   userApiKeys: defineTable({
     userId: v.string(),
     name: v.string(),
@@ -1028,8 +1118,11 @@ export default defineSchema({
     createdAt: v.number(),
     lastUsedAt: v.optional(v.number()),
     revokedAt: v.optional(v.number()),
+    scopes: v.optional(v.array(v.string())),
+    companyMonitoringAccountId: v.optional(v.string()),
   })
     .index("by_userId", ["userId"])
+    .index("by_userId_revokedAt", ["userId", "revokedAt"])
     .index("by_keyHash", ["keyHash"]),
 
   // Non-key Pro MCP identity rows. One row per OAuth grant for a Pro user.

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1056,7 +1056,11 @@ export default defineSchema({
     .index("by_logicalAccountId", ["logicalAccountId"])
     .index("by_ownerUserId", ["ownerUserId"])
     .index("by_ownerFenceHash", ["ownerFenceHash"])
-    .index("by_purgePhase_updatedAt", ["purgePhase", "updatedAt"]),
+    .index("by_purgePhase_updatedAt", ["purgePhase", "updatedAt"])
+    // Consumer: accounts.reconcileAccountEntitlements. Entitlement writes no
+    // longer push lapses (#6256), so the reconciler pulls them by scanning
+    // entitled roots oldest-first.
+    .index("by_lifecycle_updatedAt", ["lifecycle", "updatedAt"]),
 
   companyMonitoringCompanies: defineTable({
     ownerAccountId: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1048,6 +1048,7 @@ export default defineSchema({
     ),
     destructivePurgeStarted: v.boolean(),
     pendingReactivation: v.boolean(),
+    purgeAfter: v.optional(v.number()),
     purgeCursor: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),
@@ -1055,7 +1056,7 @@ export default defineSchema({
     .index("by_logicalAccountId", ["logicalAccountId"])
     .index("by_ownerUserId", ["ownerUserId"])
     .index("by_ownerFenceHash", ["ownerFenceHash"])
-    .index("by_lifecycle", ["lifecycle"]),
+    .index("by_purgePhase_updatedAt", ["purgePhase", "updatedAt"]),
 
   companyMonitoringCompanies: defineTable({
     ownerAccountId: v.string(),
@@ -1081,11 +1082,9 @@ export default defineSchema({
   })
     .index("by_account_companyId", ["ownerAccountId", "companyId"])
     .index("by_account_lifecycle_sortName", ["ownerAccountId", "lifecycle", "sortName"])
-    .index("by_account_customerReference", ["ownerAccountId", "customerReference"])
     .index("by_account_customerReference_lifecycle", ["ownerAccountId", "customerReference", "lifecycle"])
     .index("by_account_directRequestId", ["ownerAccountId", "directRequestId"])
-    .index("by_account_import_tuple", ["ownerAccountId", "clientImportId", "importOrdinal"])
-    .index("by_account_purge", ["ownerAccountId", "purgeGeneration", "purgePhase"]),
+    .index("by_account_import_tuple", ["ownerAccountId", "clientImportId", "importOrdinal"]),
 
   companyMonitoringClaims: defineTable({
     ownerAccountId: v.string(),
@@ -1106,9 +1105,7 @@ export default defineSchema({
     createdAt: v.number(),
     updatedAt: v.number(),
   })
-    .index("by_account_company", ["ownerAccountId", "companyId"])
-    .index("by_account_company_claimId", ["ownerAccountId", "companyId", "claimId"])
-    .index("by_account_type_value", ["ownerAccountId", "type", "value"]),
+    .index("by_account_company", ["ownerAccountId", "companyId"]),
 
   userApiKeys: defineTable({
     userId: v.string(),

--- a/server/__tests__/user-api-key-validation.test.ts
+++ b/server/__tests__/user-api-key-validation.test.ts
@@ -97,6 +97,33 @@ describe("Gap 2 — shapes that MUST still authenticate (fail-closed guard)", ()
   }
 });
 
+describe("Company Monitoring account-bound cache shape", () => {
+  test("generic validation rejects an exact scoped binding from the shared cache", async () => {
+    const scoped = {
+      id: "j97xyz",
+      userId: "u1",
+      name: "monitoring",
+      scopes: ["company_monitoring:read", "company_monitoring:write"],
+      companyMonitoringAccountId: "cm_account_01K1A2B3C4D5E6F7G8H9J0K1M2",
+    };
+    cachedFetchJson.mockResolvedValue(scoped);
+    await expect(validateUserApiKey(VALID_KEY)).resolves.toBeNull();
+    expect(cachedFetchJson).toHaveBeenCalledTimes(1);
+  });
+
+  for (const [label, payload] of [
+    ["scopes without account", { userId: "u1", scopes: ["company_monitoring:read"] }],
+    ["account without scopes", { userId: "u1", companyMonitoringAccountId: "cm_account_x" }],
+    ["unknown scope", { userId: "u1", scopes: ["company_monitoring:admin"], companyMonitoringAccountId: "cm_account_x" }],
+    ["duplicate scope", { userId: "u1", scopes: ["company_monitoring:read", "company_monitoring:read"], companyMonitoringAccountId: "cm_account_x" }],
+  ] as const) {
+    test(`${label} fails closed`, async () => {
+      cachedFetchJson.mockResolvedValue(payload);
+      await expect(validateUserApiKey(VALID_KEY)).resolves.toBeNull();
+    });
+  }
+});
+
 describe("Gap 3 — malformed keys are rejected without amplification", () => {
   const MALFORMED: Array<[string, string]> = [
     ["too short (wm_x)", "wm_x"],

--- a/server/_shared/user-api-key.ts
+++ b/server/_shared/user-api-key.ts
@@ -7,6 +7,12 @@
  */
 
 import { cachedFetchJson, deleteRedisKey } from './redis';
+import {
+  COMPANY_MONITORING_RPC_SCOPES,
+  type CompanyMonitoringApiScope,
+} from '../../shared/company-monitoring-contract';
+
+const COMPANY_MONITORING_SCOPES = new Set<string>(Object.values(COMPANY_MONITORING_RPC_SCOPES));
 
 interface UserKeyResult {
   userId: string;
@@ -22,6 +28,8 @@ interface UserKeyResult {
    */
   keyId?: string;
   name?: string;
+  scopes?: CompanyMonitoringApiScope[];
+  companyMonitoringAccountId?: string;
 }
 
 /**
@@ -71,7 +79,24 @@ function isUserKeyResult(value: unknown): value is UserKeyResult {
   // a bare `{}` authenticate through the prototype chain.
   if (!Object.prototype.hasOwnProperty.call(value, 'userId')) return false;
   const userId = (value as { userId?: unknown }).userId;
-  return typeof userId === 'string' && userId.length > 0;
+  if (typeof userId !== 'string' || userId.length === 0) return false;
+  const candidate = value as {
+    scopes?: unknown;
+    companyMonitoringAccountId?: unknown;
+  };
+  if (candidate.scopes === undefined && candidate.companyMonitoringAccountId === undefined) return true;
+  if (!Array.isArray(candidate.scopes) || candidate.scopes.length === 0) return false;
+  if (
+    typeof candidate.companyMonitoringAccountId !== 'string' ||
+    candidate.companyMonitoringAccountId.length === 0
+  ) return false;
+  return new Set(candidate.scopes).size === candidate.scopes.length &&
+    candidate.scopes.every((scope) => typeof scope === 'string' && COMPANY_MONITORING_SCOPES.has(scope));
+}
+
+/** Generic gateway/MCP auth accepts only legacy, unscoped user API keys. */
+function isGenericUserKeyResult(value: UserKeyResult): boolean {
+  return value.scopes === undefined && value.companyMonitoringAccountId === undefined;
 }
 
 /** SHA-256 hex digest (Web Crypto API — works in Edge Runtime). */
@@ -126,6 +151,11 @@ export async function validateUserApiKey(key: string): Promise<UserKeyResult | n
       console.warn(`[user-api-key] discarding non-conforming validation payload (type=${Array.isArray(result) ? 'array' : typeof result})`);
       return null;
     }
+    // Company Monitoring keys are bound to an account and exact RPC scopes.
+    // Generic gateway/MCP callers do not enforce either constraint, so they
+    // must not receive the principal. Keep the full positive cache entry intact
+    // for a future dedicated validator instead of replacing it with a negative.
+    if (!isGenericUserKeyResult(result)) return null;
     return result;
   } catch (err) {
     // Transient Convex/network/config errors must stay retryable. Do not

--- a/shared/company-monitoring-contract.ts
+++ b/shared/company-monitoring-contract.ts
@@ -170,7 +170,7 @@ export function normalizeCompanyClaimInput(input: CompanyClaimInput): Normalized
   if (!input || typeof input !== 'object') throw new Error('company claim is required');
   // Own-property lookup: a plain object literal inherits `__proto__`, `constructor`,
   // `toString`, etc., and a truthiness check would let those through as a "valid" type.
-  const type = Object.hasOwn(COMPANY_CLAIM_TYPE_BY_INPUT, input.type)
+  const type = Object.prototype.hasOwnProperty.call(COMPANY_CLAIM_TYPE_BY_INPUT, input.type)
     ? COMPANY_CLAIM_TYPE_BY_INPUT[input.type]
     : undefined;
   if (!type) throw new Error('company claim type is invalid');
@@ -239,7 +239,7 @@ export interface NormalizedCompanyImportRow extends NormalizedMonitoredCompanyIn
 export function normalizeMonitoredCompanyInput(input: MonitoredCompanyInput): NormalizedMonitoredCompanyInput {
   if (!input || typeof input !== 'object') throw new Error('company input is required');
   const domicileInput = String(input.domicileCountry ?? '').trim().toUpperCase();
-  const domicileCountry = Object.hasOwn(DOMICILE_COUNTRY_BY_INPUT, domicileInput)
+  const domicileCountry = Object.prototype.hasOwnProperty.call(DOMICILE_COUNTRY_BY_INPUT, domicileInput)
     ? DOMICILE_COUNTRY_BY_INPUT[domicileInput as keyof typeof DOMICILE_COUNTRY_BY_INPUT]
     : undefined;
   if (!domicileCountry) {
@@ -314,7 +314,7 @@ export function normalizeCompanyImportBatch(inputs: CompanyImportRowInput[]): No
   const normalized = inputs.map(normalizeCompanyImportRow).sort((left, right) => left.ordinal - right.ordinal);
   const importId = normalized[0]?.clientImportId;
   for (let index = 0; index < normalized.length; index += 1) {
-    const row = normalized[index];
+    const row = normalized[index]!;
     if (row.clientImportId !== importId) throw new Error('batch rows must share one clientImportId');
     if (row.ordinal !== index) throw new Error('batch ordinals must be contiguous from 0');
   }
@@ -485,10 +485,10 @@ function normalizeFilterValues(
     // Own-property lookup — see normalizeCompanyClaimInput. A truthiness check on a
     // plain object literal accepts inherited keys like `__proto__` and `constructor`
     // and returns a non-string, silently violating this function's own return type.
-    if (typeof value !== 'string' || !Object.hasOwn(vocabulary, value)) {
+    if (typeof value !== 'string' || !Object.prototype.hasOwnProperty.call(vocabulary, value)) {
       throw new Error(`${field} contains an unsupported value`);
     }
-    return vocabulary[value];
+    return vocabulary[value]!;
   });
   return [...new Set(normalized)].sort();
 }
@@ -658,7 +658,7 @@ export async function verifyOpaqueCursor<T extends CompanyMonitoringCursorClaims
   options: VerifyOpaqueCursorOptions<T>,
 ): Promise<T> {
   assertOpaqueCursorShape(cursor);
-  const [version, encodedPayload, signature] = cursor.split('.');
+  const [version, encodedPayload, signature] = cursor.split('.') as [string, string, string];
   if (!(await options.verifySignature(`${version}.${encodedPayload}`, signature))) {
     throw new Error('cursor signature is invalid');
   }

--- a/tests/company-monitoring-contract.test.mts
+++ b/tests/company-monitoring-contract.test.mts
@@ -128,6 +128,45 @@ describe('Company Monitoring RPC contract', () => {
   });
 });
 
+describe('Company Monitoring owner-fence environment contract', () => {
+  it('documents degraded provisioning and the strict rotation sequence', () => {
+    const envExample = readFileSync(resolve(root, '.env.example'), 'utf8');
+    const block = envExample.match(
+      /# REQUIRED before enabling Company Monitoring account onboarding[\s\S]+?(?=\n# Dodo Payments business ID)/,
+    )?.[0];
+    assert.ok(block, 'owner-fence environment block must remain documented');
+    const prose = block
+      .replace(/^# ?/gm, '')
+      .replace(/\s+/g, ' ');
+
+    assert.match(
+      prose,
+      /REQUIRED.+Company Monitoring account onboarding.+Convex deployment/i,
+    );
+    assert.match(
+      prose,
+      /Missing,.+blank,.+whitespace-padded,.+malformed.+logged.+skips account-root synchronization/i,
+    );
+    assert.match(prose, /authenticated entitlement writes continue/i);
+    assert.match(prose, /independent secret-manager entries/i);
+
+    assert.match(block, /^# COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS=$/m);
+    assert.doesNotMatch(block, /^COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS=/m);
+    assert.match(prose, /variable ABSENT, not blank, until the first rotation/i);
+    assert.match(
+      prose,
+      /strict comma-separated secrets:.+no whitespace,.+blank entries,.+trailing comma,.+duplicate historical entries/i,
+    );
+    assert.match(prose, /current secret may appear once; append it only once/i);
+    assert.match(
+      prose,
+      /pre-stage the old key.+deploy,.+verify it is discoverable/i,
+    );
+    assert.match(prose, /hide a deleted-owner tombstone.+allow a fresh entitled root/i);
+    assert.match(prose, /ACCOUNT_OWNER_FENCE_CONFLICT.+manual data repair/i);
+  });
+});
+
 describe('Company Monitoring limits and rollout controls', () => {
   it('publishes explicit bounded limits', () => {
     assert.deepEqual(COMPANY_MONITORING_LIMITS, {

--- a/tests/company-monitoring-contract.test.mts
+++ b/tests/company-monitoring-contract.test.mts
@@ -38,6 +38,19 @@ import {
 const root = resolve(import.meta.dirname, '..');
 
 describe('Company Monitoring RPC contract', () => {
+  it('keeps the self-contained Edge API-key scope mirror in contract parity', () => {
+    const apiKeySource = readFileSync(resolve(root, 'api/_user-api-key.js'), 'utf8');
+    const declaration = apiKeySource.match(
+      /const COMPANY_MONITORING_SCOPES = new Set\(\[([^\]]+)]\);/,
+    );
+    assert.ok(declaration, 'Edge API-key scope mirror must remain a literal Set declaration');
+    const edgeScopes = [...declaration[1]!.matchAll(/'([^']+)'/g)]
+      .map((match) => match[1])
+      .sort();
+    const contractScopes = [...new Set(Object.values(COMPANY_MONITORING_RPC_SCOPES))].sort();
+    assert.deepEqual(edgeScopes, contractScopes);
+  });
+
   it('defines the exact ten account-scoped RPCs with independent read/write scopes', () => {
     assert.deepEqual(COMPANY_MONITORING_RPC_SCOPES, {
       CreateMonitoredCompany: 'company_monitoring:write',

--- a/tests/company-monitoring-contract.test.mts
+++ b/tests/company-monitoring-contract.test.mts
@@ -129,10 +129,10 @@ describe('Company Monitoring RPC contract', () => {
 });
 
 describe('Company Monitoring owner-fence environment contract', () => {
-  it('documents degraded provisioning and the strict rotation sequence', () => {
+  it('documents fail-closed feature operations and the strict rotation sequence', () => {
     const envExample = readFileSync(resolve(root, '.env.example'), 'utf8');
     const block = envExample.match(
-      /# REQUIRED before enabling Company Monitoring account onboarding[\s\S]+?(?=\n# Dodo Payments business ID)/,
+      /# REQUIRED before enabling Company Monitoring feature operations[\s\S]+?(?=\n# Dodo Payments business ID)/,
     )?.[0];
     assert.ok(block, 'owner-fence environment block must remain documented');
     const prose = block
@@ -141,13 +141,24 @@ describe('Company Monitoring owner-fence environment contract', () => {
 
     assert.match(
       prose,
-      /REQUIRED.+Company Monitoring account onboarding.+Convex deployment/i,
+      /REQUIRED.+Company Monitoring feature operations.+Convex deployment/i,
     );
     assert.match(
       prose,
-      /Missing,.+blank,.+whitespace-padded,.+malformed.+logged.+skips account-root synchronization/i,
+      /Missing,.+blank,.+whitespace-padded,.+malformed.+fails closed/i,
     );
-    assert.match(prose, /authenticated entitlement writes continue/i);
+    assert.match(
+      prose,
+      /Company Monitoring provisioning.+terminal operations throw/i,
+    );
+    assert.match(
+      prose,
+      /Entitlement writes are independent and continue because they perform no Company Monitoring work/i,
+    );
+    assert.doesNotMatch(
+      prose,
+      /logged.+skips (?:account-root )?synchronization/i,
+    );
     assert.match(prose, /independent secret-manager entries/i);
 
     assert.match(block, /^# COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS=$/m);

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
   },
   test: {
     environment: "edge-runtime",
+    setupFiles: ["convex/__tests__/setup.ts"],
     server: { deps: { inline: ["convex-test"] } },
     include: [
       "convex/__tests__/**/*.test.ts",


### PR DESCRIPTION
## Summary

This is the account and onboarding slice after the merged viability and dark-service foundations. Company Monitoring can now maintain exactly one entitlement-bound account root and a bounded portfolio without activating any public product surface. Later corpus, scorer, provider, and runtime stages can build on durable account, company, claim, replay, removal, and purge semantics.

The implementation keeps bulk onboarding state-free. It does not add import-job or transfer state. Each normalized row is committed in its own transaction, and account-local replay metadata makes uncertain retries deterministic while rejected and no-op rows remain eligible for reevaluation.

| Guarantee | Behavior |
| --- | --- |
| Entitlement lifecycle | The first authenticated Company Monitoring feature use provisions the root from canonical entitlement state. Billing writes stay independent. An hourly bounded reconciler converges existing roots after lapses and renewals. |
| Account safety | Owner fences prevent deleted accounts from being recreated. A lapsed account receives an explicit 24-hour grace and can reactivate only before destructive purge starts. A dedicated fence secret and its previous-key ring keep terminal fences discoverable during key rotation. |
| Portfolio bounds | Direct creates and imports share one atomic 500-company cap. Imports accept at most 100 normalized rows and preserve count parity under concurrency. |
| Replay | Committed rows return their original result, changed retries conflict, and rejected or no-op rows reevaluate against current state. Individual and account purge paths scrub all five replay identity and fingerprint fields. |
| Removal and purge | Removal hides once, decrements once, clears claims, increments the snapshot once, and schedules resumable bounded payload purge work. An hourly bounded reaper recovers stalled purge phases. |
| API keys | Optional scopes and account binding are validated against the live account lifecycle. Scoped keys are rejected by unrelated generic API and MCP validators, and lifecycle changes invalidate the production cache namespace. |

All Company Monitoring feature flags and public routes remain dark. This PR does not add blind-corpus or scorer work, provider imports, runtime monitoring, import-job state, or transfer state.

Fixes #6005

Related: #6002, #6003, #6004

## Deployment gate

- Provision `COMPANY_MONITORING_OWNER_FENCE_SECRET` in the production Convex environment before merge and deployment. There is intentionally no fallback to the Dodo identity-signing secret.
- For a later rotation, pre-stage the current secret in `COMPANY_MONITORING_OWNER_FENCE_PREVIOUS_SECRETS`, deploy that keyring, then replace the current secret. Duplicate previous entries fail closed.
- Keep all Company Monitoring public feature flags dark; this persistence slice does not authorize runtime or provider activation.

## Review hardening

- Removed Company Monitoring synchronization from billing writes. Lazy feature access provisions from stored entitlement state, and the hourly reconciler converges existing roots. Owner-fence configuration errors now fail Company Monitoring operations closed without rolling back independent entitlement writes.
- Made the reconciliation budget fair across entitled and lapsed roots, and recovered the one nonterminal owner root when old fence history was dropped.
- Added the explicit 24-hour ordinary-lapse grace, terminal-deletion bypass, bounded hourly purge reaper, exact replay-metadata scrub, and a final entitlement recheck before reactivation.
- Added explicit Convex argument validators, removed five unused indexes, retained only the protected terminal owner-deletion operation, and added the single reaper index.
- Corrected Convex cache invalidation to target the production cache namespace and added parity coverage for the self-contained Edge API-key scope mirror.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Convex persistence, entitlement lifecycle, onboarding, purge, and API-key authorization

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — N/A; no public route or enabled flag exists in this slice
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A; no public route or enabled flag exists in this slice
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- [x] Claim ledger attached or linked — N/A; this PR does not publish documentation claims
- [x] All required Audit Council role signoffs attached — N/A
- [x] Generated docs regenerated from proto where applicable — N/A; no proto or generated documentation changed
- [x] Fixture-backed examples recomputed — N/A
- [x] Redis writers/readers enumerated for every documented key — N/A; no Redis key documentation changed

## Validation

- Final focused Convex verification: 5 files and 232 tests passed after the last rebase onto `origin/main`.
- Company Monitoring contract and Edge API-key verification: 82 tests passed. Server API-key validation: 33 tests passed.
- `npm run typecheck`, `npm run typecheck:api`, Convex typecheck, contract-test typecheck, and repository lint passed. Repository lint reported only pre-existing warnings outside this change.
- The final pre-push gate passed frontend, API, and Convex typechecks; architectural and policy checks; edge bundling; 107 server tests; 28 changed contract tests; 249 Edge tests; and version sync.
- Full Compound Engineering review found six in-scope lifecycle, replay, scheduling, typing, and environment-contract gaps. All six were repaired. Independent cross-model review and validator passes confirmed the material findings.

## Post-Deploy Monitoring & Validation

- Watch Convex mutation, action, and scheduled-function failures, Upstash pipeline failures, account-root cardinality, company-count parity, and purge cursors for 24 hours after deployment.
- Inspect `[subscriptionHelpers]`, `[cacheActions]`, `COMPANY_MONITORING_ACCESS_DENIED`, `REPLAY_CONFLICT`, and `COMPANY_LIMIT_REACHED` events.
- Healthy means no duplicate roots, count drift, account-binding mismatch, stale scoped-key cache entries, or stuck purge generation. Public Company Monitoring traffic must remain absent while flags stay dark.
- Duplicate roots, count drift, cross-account access, stale authorization after lifecycle change, or non-advancing purge cursors are rollback triggers. Keep all flags dark, revert the deployment, and repair affected rows before retrying.
- Validation window: 24 hours after deployment. Owner: WorldMonitor maintainers.

## Screenshots

N/A. This slice adds no public UI or enabled runtime surface.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
