### PR TITLE
fix(seed): preserve shared FX fallback provenance

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1539,6 +1539,32 @@ export async function processItemRoute({
   return { localPrice, sourceSite, routeUpdate, routeDelete };
 }
 
+// Five 8s timeouts plus four 150ms gaps take at most 40.6s, leaving ample
+// headroom inside downstream seeds' 240s fetch-phase deadline.
+const MAX_POINT_OF_USE_FX_REQUESTS = 5;
+
+async function fetchPointOfUseFxRates(fxSymbols, fallbacks = {}) {
+  const attemptedSymbols = {};
+  const deferredCurrencies = [];
+  let requestCount = 0;
+
+  for (const [currency, symbol] of Object.entries(fxSymbols)) {
+    if (currency === 'USD' || requestCount < MAX_POINT_OF_USE_FX_REQUESTS) {
+      attemptedSymbols[currency] = symbol;
+      if (currency !== 'USD') requestCount += 1;
+    } else {
+      deferredCurrencies.push(currency);
+    }
+  }
+
+  const result = await fetchYahooFxRatesWithProvenance(attemptedSymbols, fallbacks);
+  for (const currency of deferredCurrencies) {
+    result.rates[currency] = fallbacks[currency] ?? null;
+  }
+  result.fallbackCurrencies.push(...deferredCurrencies);
+  return result;
+}
+
 /**
  * Shared FX rates cache — reads from Redis `shared:fx-rates:v1` (4h TTL).
  * Falls back to fetching from Yahoo Finance if the key is missing/expired.
@@ -1556,45 +1582,87 @@ export async function getSharedFxRates(fxSymbols, fallbacks) {
     const cached = await redisGet(url, token, SHARED_KEY);
     if (cached && typeof cached === 'object' && Object.keys(cached).length > 0) {
       console.log('  FX rates: loaded from shared cache');
-      // Fill any missing currencies this seed needs using Yahoo or fallback
-      const missing = Object.keys(fxSymbols).filter(c => cached[c] == null);
+      const hasValidFallbackProvenance = (
+        Array.isArray(cached.fallbackCurrencies)
+        && cached.fallbackCurrencies.every(c => typeof c === 'string')
+      );
+      const cachedFallbacks = new Set(hasValidFallbackProvenance ? cached.fallbackCurrencies : []);
+      // The canonical seed publishes failed Yahoo quotes as null. Retry only
+      // the gaps this consumer needs, then use its fallback table at the point
+      // of use so direct readers never mistake constants for live quotes. A
+      // markerless legacy snapshot may itself contain fallback constants, so
+      // none of its requested non-USD values are trusted as live.
+      const missing = Object.keys(fxSymbols).filter(c => (
+        c !== 'USD'
+        && (!hasValidFallbackProvenance || cached[c] == null || cachedFallbacks.has(c))
+      ));
       if (missing.length === 0) return cached;
       console.log(`  FX rates: fetching ${missing.length} missing currencies from Yahoo`);
-      const extra = await fetchYahooFxRates(
+      const extra = await fetchPointOfUseFxRates(
         Object.fromEntries(missing.map(c => [c, fxSymbols[c]])),
         fallbacks,
       );
-      return { ...cached, ...extra };
+      const retried = new Set(missing);
+      const fallbackCurrencies = [
+        ...[...cachedFallbacks].filter(c => !retried.has(c)),
+        ...extra.fallbackCurrencies,
+      ];
+      return {
+        ...cached,
+        ...extra.rates,
+        fallbackCurrencies: [...new Set(fallbackCurrencies)],
+      };
     }
   } catch {
     // Cache read failed — fall through to live fetch
   }
 
   console.log('  FX rates: cache miss — fetching from Yahoo Finance');
-  return fetchYahooFxRates(fxSymbols, fallbacks);
+  const result = await fetchPointOfUseFxRates(fxSymbols, fallbacks);
+  return { ...result.rates, fallbackCurrencies: result.fallbackCurrencies };
 }
 
-export async function fetchYahooFxRates(fxSymbols, fallbacks) {
+/**
+ * Fetch USD-per-unit Yahoo FX quotes and record which currencies used the
+ * caller-provided fallback table. The provenance is based on the actual fetch
+ * outcome, never float equality with the fallback constant.
+ */
+export async function fetchYahooFxRatesWithProvenance(fxSymbols, fallbacks = {}) {
   const rates = {};
+  const fallbackCurrencies = [];
+  let requestsRemaining = Object.keys(fxSymbols).filter(currency => currency !== 'USD').length;
   for (const [currency, symbol] of Object.entries(fxSymbols)) {
     if (currency === 'USD') { rates['USD'] = 1.0; continue; }
+    let price = null;
     try {
       const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}`;
       const resp = await fetch(url, {
         headers: { 'User-Agent': CHROME_UA },
         signal: AbortSignal.timeout(8_000),
       });
-      if (!resp.ok) { rates[currency] = fallbacks[currency] ?? null; continue; }
-      const data = await resp.json();
-      const price = data?.chart?.result?.[0]?.meta?.regularMarketPrice;
-      rates[currency] = (price != null && price > 0) ? price : (fallbacks[currency] ?? null);
-    } catch {
+      if (resp.ok) {
+        const data = await resp.json();
+        price = data?.chart?.result?.[0]?.meta?.regularMarketPrice;
+      }
+    } catch {}
+    if (Number.isFinite(price) && price > 0) {
+      rates[currency] = price;
+    } else {
       rates[currency] = fallbacks[currency] ?? null;
+      fallbackCurrencies.push(currency);
     }
-    await new Promise(r => setTimeout(r, 100));
+    requestsRemaining -= 1;
+    if (requestsRemaining > 0) await sleep(150);
   }
   console.log('  FX rates fetched:', JSON.stringify(rates));
-  return rates;
+  if (fallbackCurrencies.length > 0) {
+    console.warn(`  FX rates using fallbacks (${fallbackCurrencies.length}): ${fallbackCurrencies.join(', ')}`);
+  }
+  return { rates, fallbackCurrencies };
+}
+
+export async function fetchYahooFxRates(fxSymbols, fallbacks) {
+  return (await fetchYahooFxRatesWithProvenance(fxSymbols, fallbacks)).rates;
 }
 
 /**

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -184,8 +184,9 @@ export function getBundleRunStartedAtMs() {
   return Number.isFinite(raw) && raw > 0 ? raw : null;
 }
 
-// Canonical FX fallback rates — used when Yahoo Finance returns null/zero.
-// Single source of truth shared by seed-bigmac, seed-grocery-basket, seed-fx-rates.
+// Point-of-use FX recovery constants — used by conversion seeds when Yahoo fails
+// or a gap cannot be retried in budget. Canonical seed-fx-rates must NOT fill
+// shared:fx-rates:v1 with these values (publish nulls + fallbackCurrencies instead).
 // EGP: 0.0192 is the most recently observed live rate (2026-03-21 seed run).
 export const SHARED_FX_FALLBACKS = {
   USD: 1, GBP: 1.2700, EUR: 1.0850, JPY: 0.0067, CHF: 1.1300,
@@ -1543,7 +1544,19 @@ export async function processItemRoute({
 // headroom inside downstream seeds' 240s fetch-phase deadline.
 const MAX_POINT_OF_USE_FX_REQUESTS = 5;
 
-async function fetchPointOfUseFxRates(fxSymbols, fallbacks = {}) {
+function isFinitePositiveRate(value) {
+  return Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Cap Yahoo recovery work for conversion seeds. Currencies beyond the budget are
+ * not attempted: prefer a finite prior/cache rate when present (still marked as
+ * fallback provenance — unattempted is not live), else the caller fallback table.
+ * @param {Record<string, string>} fxSymbols
+ * @param {Record<string, number>} [fallbacks]
+ * @param {Record<string, unknown>} [priorRates] rates already on hand (e.g. cache)
+ */
+async function fetchPointOfUseFxRates(fxSymbols, fallbacks = {}, priorRates = {}) {
   const attemptedSymbols = {};
   const deferredCurrencies = [];
   let requestCount = 0;
@@ -1559,7 +1572,10 @@ async function fetchPointOfUseFxRates(fxSymbols, fallbacks = {}) {
 
   const result = await fetchYahooFxRatesWithProvenance(attemptedSymbols, fallbacks);
   for (const currency of deferredCurrencies) {
-    result.rates[currency] = fallbacks[currency] ?? null;
+    const prior = priorRates[currency];
+    result.rates[currency] = isFinitePositiveRate(prior)
+      ? prior
+      : (fallbacks[currency] ?? null);
   }
   result.fallbackCurrencies.push(...deferredCurrencies);
   return result;
@@ -1601,6 +1617,7 @@ export async function getSharedFxRates(fxSymbols, fallbacks) {
       const extra = await fetchPointOfUseFxRates(
         Object.fromEntries(missing.map(c => [c, fxSymbols[c]])),
         fallbacks,
+        cached,
       );
       const retried = new Set(missing);
       const fallbackCurrencies = [
@@ -1645,7 +1662,7 @@ export async function fetchYahooFxRatesWithProvenance(fxSymbols, fallbacks = {})
         price = data?.chart?.result?.[0]?.meta?.regularMarketPrice;
       }
     } catch {}
-    if (Number.isFinite(price) && price > 0) {
+    if (isFinitePositiveRate(price)) {
       rates[currency] = price;
     } else {
       rates[currency] = fallbacks[currency] ?? null;
@@ -1659,10 +1676,6 @@ export async function fetchYahooFxRatesWithProvenance(fxSymbols, fallbacks = {})
     console.warn(`  FX rates using fallbacks (${fallbackCurrencies.length}): ${fallbackCurrencies.join(', ')}`);
   }
   return { rates, fallbackCurrencies };
-}
-
-export async function fetchYahooFxRates(fxSymbols, fallbacks) {
-  return (await fetchYahooFxRatesWithProvenance(fxSymbols, fallbacks)).rates;
 }
 
 /**

--- a/scripts/seed-fx-rates.mjs
+++ b/scripts/seed-fx-rates.mjs
@@ -11,15 +11,15 @@
  * Railway setup: rootDirectory=. startCommand="node scripts/seed-fx-rates.mjs"
  */
 
-import { loadEnvFile, runSeed, fetchYahooFxRates, SHARED_FX_FALLBACKS } from './_seed-utils.mjs';
-
-loadEnvFile(import.meta.url);
+import { loadEnvFile, runSeed, fetchYahooFxRatesWithProvenance } from './_seed-utils.mjs';
+import { isMainModule } from './lib/main-module.mjs';
 
 const CANONICAL_KEY = 'shared:fx-rates:v1';
 const CACHE_TTL = 25 * 3600; // 25 hours — covers daily cron with 1h drift buffer
+const MIN_LIVE_RATE_COUNT = 11; // Preserve the previous >10-key floor, now counting only real Yahoo quotes.
 
 // Union of all currencies used by bigmac + grocery-basket seeds
-const ALL_CURRENCIES = [
+export const ALL_CURRENCIES = [
   // Americas
   'USD', 'CAD', 'MXN', 'BRL', 'ARS', 'COP', 'CLP',
   // Europe
@@ -38,23 +38,70 @@ const FX_SYMBOLS = Object.fromEntries(
   ALL_CURRENCIES.map(c => [c, `${c}USD=X`])
 );
 
-const FX_FALLBACKS = SHARED_FX_FALLBACKS;
-
-export function declareRecords(data) {
-  return data && typeof data === 'object' ? Object.keys(data).length : 0;
+function fallbackCurrencySet(data) {
+  if (!Array.isArray(data?.fallbackCurrencies)) return null;
+  const fallbackCurrencies = data.fallbackCurrencies;
+  const fallbackSet = new Set(fallbackCurrencies);
+  if (fallbackSet.size !== fallbackCurrencies.length) return null;
+  if ([...fallbackSet].some(c => c === 'USD' || !ALL_CURRENCIES.includes(c))) return null;
+  return fallbackSet;
 }
 
-await runSeed('shared', 'fx-rates', CANONICAL_KEY, async () => {
-  // Always fetch live — this seed IS the cache writer, bypass getSharedFxRates
-  const rates = await fetchYahooFxRates(FX_SYMBOLS, FX_FALLBACKS);
-  console.log('  Fetched', Object.keys(rates).length, 'currencies');
-  return rates;
-}, {
-  ttlSeconds: CACHE_TTL,
-  validateFn: (data) => data && typeof data === 'object' && Object.keys(data).length > 10,
-  recordCount: (data) => Object.keys(data).length,
-  sourceVersion: 'yahoo-fx-shared',
-  declareRecords,
-  schemaVersion: 1,
-  maxStaleMin: 3600,
-});
+export function buildFxRatesPayload({ rates, fallbackCurrencies }) {
+  const payload = { ...rates };
+  const uniqueFallbacks = [...new Set(fallbackCurrencies)];
+  for (const currency of uniqueFallbacks) payload[currency] = null;
+  payload.fallbackCurrencies = uniqueFallbacks;
+  return payload;
+}
+
+export function declareRecords(data) {
+  const fallbackSet = fallbackCurrencySet(data);
+  if (fallbackSet === null) return 0;
+  return ALL_CURRENCIES.filter((currency) => (
+    currency !== 'USD'
+    && !fallbackSet.has(currency)
+    && Number.isFinite(data[currency])
+    && data[currency] > 0
+  )).length;
+}
+
+export function validateFxPayload(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const fallbackSet = fallbackCurrencySet(data);
+  if (fallbackSet === null) return false;
+  for (const currency of ALL_CURRENCIES) {
+    if (fallbackSet.has(currency)) {
+      if (data[currency] !== null) return false;
+    } else if (!Number.isFinite(data[currency]) || data[currency] <= 0) {
+      return false;
+    }
+  }
+  return declareRecords(data) >= MIN_LIVE_RATE_COUNT;
+}
+
+const isMain = isMainModule(import.meta.url, process.argv[1]);
+if (isMain) {
+  loadEnvFile(import.meta.url);
+  await runSeed('shared', 'fx-rates', CANONICAL_KEY, async () => {
+    // Always fetch live — this seed IS the cache writer, bypass getSharedFxRates.
+    // Pass no constants: canonical gaps stay null and provenance stays explicit.
+    const result = await fetchYahooFxRatesWithProvenance(FX_SYMBOLS, {});
+    const payload = buildFxRatesPayload(result);
+    console.log(
+      '  Fetched',
+      declareRecords(payload),
+      'live currencies;',
+      payload.fallbackCurrencies.length,
+      'unavailable',
+    );
+    return payload;
+  }, {
+    ttlSeconds: CACHE_TTL,
+    validateFn: validateFxPayload,
+    sourceVersion: 'yahoo-fx-shared-v2',
+    declareRecords,
+    schemaVersion: 2,
+    maxStaleMin: 3600,
+  });
+}

--- a/tests/fx-rates-seed.test.mjs
+++ b/tests/fx-rates-seed.test.mjs
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, test } from 'node:test';
+
+import {
+  SHARED_FX_FALLBACKS,
+  fetchYahooFxRatesWithProvenance,
+  getSharedFxRates,
+} from '../scripts/_seed-utils.mjs';
+import {
+  ALL_CURRENCIES,
+  buildFxRatesPayload,
+  declareRecords,
+  validateFxPayload,
+} from '../scripts/seed-fx-rates.mjs';
+
+const originalFetch = globalThis.fetch;
+const originalRedisUrl = process.env.UPSTASH_REDIS_REST_URL;
+const originalRedisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalRedisUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = originalRedisUrl;
+  if (originalRedisToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = originalRedisToken;
+});
+
+describe('shared FX fallback provenance', () => {
+  test('Yahoo fetches identify every quote that used a constant fallback', async () => {
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response(JSON.stringify({
+          chart: { result: [{ meta: { regularMarketPrice: 1.087654321 } }] },
+        }), { status: 200 });
+      }
+      return new Response('rate limited', { status: 429 });
+    };
+
+    const result = await fetchYahooFxRatesWithProvenance({
+      USD: 'USDUSD=X',
+      EUR: 'EURUSD=X',
+      KRW: 'KRWUSD=X',
+    }, SHARED_FX_FALLBACKS);
+
+    assert.deepEqual(result.rates, {
+      USD: 1,
+      EUR: 1.087654321,
+      KRW: SHARED_FX_FALLBACKS.KRW,
+    });
+    assert.deepEqual(result.fallbackCurrencies, ['KRW']);
+  });
+
+  test('the canonical payload nulls fallback quotes and rejects an all-fallback run', () => {
+    const rates = Object.fromEntries(ALL_CURRENCIES.map((currency) => [currency, 0.5]));
+    rates.USD = 1;
+
+    const partial = buildFxRatesPayload({
+      rates,
+      fallbackCurrencies: ['KRW', 'VND'],
+    });
+    assert.equal(partial.KRW, null);
+    assert.equal(partial.VND, null);
+    assert.deepEqual(partial.fallbackCurrencies, ['KRW', 'VND']);
+    assert.equal(declareRecords(partial), ALL_CURRENCIES.length - 3);
+    assert.equal(validateFxPayload(partial), true);
+
+    const allFallback = buildFxRatesPayload({
+      rates,
+      fallbackCurrencies: ALL_CURRENCIES.filter((currency) => currency !== 'USD'),
+    });
+    assert.equal(declareRecords(allFallback), 0);
+    assert.equal(validateFxPayload(allFallback), false);
+  });
+
+  test('the publish gate counts live quotes rather than fallback-filled keys', () => {
+    const rates = Object.fromEntries(ALL_CURRENCIES.map((currency) => [currency, 0.5]));
+    rates.USD = 1;
+    const nonUsd = ALL_CURRENCIES.filter((currency) => currency !== 'USD');
+
+    const tenLive = buildFxRatesPayload({
+      rates,
+      fallbackCurrencies: nonUsd.slice(10),
+    });
+    assert.equal(declareRecords(tenLive), 10);
+    assert.equal(validateFxPayload(tenLive), false);
+
+    const elevenLive = buildFxRatesPayload({
+      rates,
+      fallbackCurrencies: nonUsd.slice(11),
+    });
+    assert.equal(declareRecords(elevenLive), 11);
+    assert.equal(validateFxPayload(elevenLive), true);
+  });
+
+  test('conversion consumers retry canonical gaps and retain fallback provenance', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    let calls = 0;
+    globalThis.fetch = async (url) => {
+      calls += 1;
+      if (String(url).startsWith('https://redis.example/get/')) {
+        return new Response(JSON.stringify({
+          result: JSON.stringify({
+            _seed: {
+              fetchedAt: Date.now(),
+              recordCount: 1,
+              sourceVersion: 'yahoo-fx-shared',
+              schemaVersion: 2,
+              state: 'OK',
+            },
+            data: { USD: 1, KRW: null, fallbackCurrencies: ['KRW'] },
+          }),
+        }), { status: 200 });
+      }
+      return new Response('rate limited', { status: 429 });
+    };
+
+    const result = await getSharedFxRates(
+      { USD: 'USDUSD=X', KRW: 'KRWUSD=X' },
+      SHARED_FX_FALLBACKS,
+    );
+
+    assert.equal(calls, 2);
+    assert.equal(result.USD, 1);
+    assert.equal(result.KRW, SHARED_FX_FALLBACKS.KRW);
+    assert.deepEqual(result.fallbackCurrencies, ['KRW']);
+  });
+
+  test('a successful point-of-use retry clears the canonical fallback marker', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    globalThis.fetch = async (url) => {
+      if (String(url).startsWith('https://redis.example/get/')) {
+        return new Response(JSON.stringify({
+          result: JSON.stringify({ USD: 1, KRW: null, fallbackCurrencies: ['KRW'] }),
+        }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        chart: { result: [{ meta: { regularMarketPrice: 0.0007212345 } }] },
+      }), { status: 200 });
+    };
+
+    const result = await getSharedFxRates(
+      { USD: 'USDUSD=X', KRW: 'KRWUSD=X' },
+      SHARED_FX_FALLBACKS,
+    );
+
+    assert.equal(result.KRW, 0.0007212345);
+    assert.deepEqual(result.fallbackCurrencies, []);
+  });
+
+  test('point-of-use recovery caps Yahoo requests and marks unattempted gaps as fallbacks', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    const currencies = ['EUR', 'JPY', 'KRW', 'AUD', 'CAD', 'NZD', 'CNY'];
+    let yahooCalls = 0;
+    globalThis.fetch = async (url) => {
+      if (String(url).startsWith('https://redis.example/get/')) {
+        return new Response(JSON.stringify({
+          result: JSON.stringify({
+            USD: 1,
+            ...Object.fromEntries(currencies.map(currency => [currency, null])),
+            fallbackCurrencies: currencies,
+          }),
+        }), { status: 200 });
+      }
+      yahooCalls += 1;
+      return new Response(JSON.stringify({
+        chart: { result: [{ meta: { regularMarketPrice: 0.5 } }] },
+      }), { status: 200 });
+    };
+
+    const result = await getSharedFxRates(
+      Object.fromEntries(['USD', ...currencies].map(currency => [currency, `${currency}USD=X`])),
+      SHARED_FX_FALLBACKS,
+    );
+
+    assert.equal(yahooCalls, 5);
+    assert.deepEqual(result.fallbackCurrencies, ['NZD', 'CNY']);
+    assert.equal(result.EUR, 0.5);
+    assert.equal(result.NZD, SHARED_FX_FALLBACKS.NZD);
+    assert.equal(result.CNY, SHARED_FX_FALLBACKS.CNY);
+  });
+
+  test('markerless legacy cache values are retried and returned with fallback provenance', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    let yahooCalls = 0;
+    globalThis.fetch = async (url) => {
+      if (String(url).startsWith('https://redis.example/get/')) {
+        return new Response(JSON.stringify({
+          result: JSON.stringify({ USD: 1, KRW: SHARED_FX_FALLBACKS.KRW }),
+        }), { status: 200 });
+      }
+      yahooCalls += 1;
+      return new Response('rate limited', { status: 429 });
+    };
+
+    const result = await getSharedFxRates(
+      { USD: 'USDUSD=X', KRW: 'KRWUSD=X' },
+      SHARED_FX_FALLBACKS,
+    );
+
+    assert.equal(yahooCalls, 1);
+    assert.equal(result.KRW, SHARED_FX_FALLBACKS.KRW);
+    assert.deepEqual(result.fallbackCurrencies, ['KRW']);
+  });
+});

--- a/tests/fx-rates-seed.test.mjs
+++ b/tests/fx-rates-seed.test.mjs
@@ -207,4 +207,118 @@ describe('shared FX fallback provenance', () => {
     assert.equal(result.KRW, SHARED_FX_FALLBACKS.KRW);
     assert.deepEqual(result.fallbackCurrencies, ['KRW']);
   });
+
+  test('markerless cap keeps finite cached rates for deferred currencies', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    // Distinct from SHARED_FX_FALLBACKS so clobber vs retain is observable.
+    const cachedLive = {
+      EUR: 1.11, JPY: 0.0069, KRW: 0.00075, AUD: 0.66, CAD: 0.75, NZD: 0.61, CNY: 0.139,
+    };
+    let yahooCalls = 0;
+    globalThis.fetch = async (url) => {
+      if (String(url).startsWith('https://redis.example/get/')) {
+        return new Response(JSON.stringify({
+          result: JSON.stringify({ USD: 1, ...cachedLive }),
+        }), { status: 200 });
+      }
+      yahooCalls += 1;
+      return new Response(JSON.stringify({
+        chart: { result: [{ meta: { regularMarketPrice: 0.5 } }] },
+      }), { status: 200 });
+    };
+
+    const currencies = Object.keys(cachedLive);
+    const result = await getSharedFxRates(
+      Object.fromEntries(['USD', ...currencies].map((c) => [c, `${c}USD=X`])),
+      SHARED_FX_FALLBACKS,
+    );
+
+    assert.equal(yahooCalls, 5);
+    assert.deepEqual(result.fallbackCurrencies, ['NZD', 'CNY']);
+    // Attempted: live Yahoo. Deferred: retain prior cache, not SHARED_FX_FALLBACKS.
+    assert.equal(result.EUR, 0.5);
+    assert.equal(result.NZD, cachedLive.NZD);
+    assert.equal(result.CNY, cachedLive.CNY);
+    assert.notEqual(result.NZD, SHARED_FX_FALLBACKS.NZD);
+  });
+
+  test('validateFxPayload rejects provenance/value mismatches and markerless maps', () => {
+    const rates = Object.fromEntries(ALL_CURRENCIES.map((currency) => [currency, 0.5]));
+    rates.USD = 1;
+
+    const nonNullListed = buildFxRatesPayload({ rates, fallbackCurrencies: ['KRW'] });
+    nonNullListed.KRW = 0.0007;
+    assert.equal(validateFxPayload(nonNullListed), false);
+
+    const nullUnlisted = { ...rates, KRW: null, fallbackCurrencies: [] };
+    assert.equal(validateFxPayload(nullUnlisted), false);
+
+    const duplicateMarkers = { ...rates, KRW: null, fallbackCurrencies: ['KRW', 'KRW'] };
+    assert.equal(validateFxPayload(duplicateMarkers), false);
+    assert.equal(declareRecords(duplicateMarkers), 0);
+
+    const usdMarker = { ...rates, fallbackCurrencies: ['USD'] };
+    assert.equal(validateFxPayload(usdMarker), false);
+
+    const markerless = { ...rates }; // schema-v1 shape
+    assert.equal(validateFxPayload(markerless), false);
+    assert.equal(declareRecords(markerless), 0);
+
+    assert.equal(validateFxPayload(null), false);
+    assert.equal(validateFxPayload([]), false);
+  });
+
+  test('non-finite Yahoo prices mark provenance fallbacks', async () => {
+    const prices = [0, -1, Number.NaN, '1.2', null];
+    let i = 0;
+    globalThis.fetch = async () => {
+      const price = prices[i++];
+      if (price === null) {
+        return new Response(JSON.stringify({ chart: { result: [{ meta: {} }] } }), { status: 200 });
+      }
+      return new Response(JSON.stringify({
+        chart: { result: [{ meta: { regularMarketPrice: price } }] },
+      }), { status: 200 });
+    };
+
+    const symbols = {
+      USD: 'USDUSD=X',
+      A: 'AUSD=X',
+      B: 'BUSD=X',
+      C: 'CUSD=X',
+      D: 'DUSD=X',
+      E: 'EUSD=X',
+    };
+    const result = await fetchYahooFxRatesWithProvenance(symbols, { A: 1, B: 2, C: 3, D: 4, E: 5 });
+    assert.deepEqual(result.fallbackCurrencies, ['A', 'B', 'C', 'D', 'E']);
+    assert.equal(result.rates.A, 1);
+    assert.equal(result.rates.E, 5);
+  });
+
+  test('cold cache miss still caps Yahoo recovery at five requests', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    const currencies = ['EUR', 'JPY', 'KRW', 'AUD', 'CAD', 'NZD', 'CNY'];
+    let yahooCalls = 0;
+    globalThis.fetch = async (url) => {
+      if (String(url).startsWith('https://redis.example/get/')) {
+        return new Response(JSON.stringify({ result: null }), { status: 200 });
+      }
+      yahooCalls += 1;
+      return new Response(JSON.stringify({
+        chart: { result: [{ meta: { regularMarketPrice: 0.5 } }] },
+      }), { status: 200 });
+    };
+
+    const result = await getSharedFxRates(
+      Object.fromEntries(['USD', ...currencies].map((c) => [c, `${c}USD=X`])),
+      SHARED_FX_FALLBACKS,
+    );
+
+    assert.equal(yahooCalls, 5);
+    assert.deepEqual(result.fallbackCurrencies, ['NZD', 'CNY']);
+    assert.equal(result.EUR, 0.5);
+    assert.equal(result.NZD, SHARED_FX_FALLBACKS.NZD);
+  });
 });


### PR DESCRIPTION
## Summary

`shared:fx-rates:v1` no longer makes hardcoded recovery constants look like fresh Yahoo quotes. The canonical cache stays compatible with flat-map readers, but failed currencies are now `null` and listed in `fallbackCurrencies`; publication is rejected unless at least 11 non-USD quotes are genuinely live.

Conversion seeds retry only the gaps they need, attach provenance to any point-of-use fallback, distrust markerless legacy cache entries, and cap recovery at five Yahoo requests so a partial outage cannot consume the 240-second downstream seed deadline.

Fixes #6220.

## Validation

- Added proof-first coverage for mixed live/fallback quotes, all-fallback rejection, the 11-live publication floor, canonical-gap recovery, successful marker clearing, markerless legacy cache migration, and bounded point-of-use retries.
- 76 focused FX and dependent seed tests pass after the review fixes.
- `npm run typecheck`, `npm run typecheck:api`, and `npm run lint:unicode` pass.
- The repository pre-push gate passed, including change-scoped seed tests and version synchronization.
- The broad `npm run test:data` run passed its product suites; its 15 macOS temp-path hook cases were rerun outside the restricted sandbox and passed 15/15.

## Post-Deploy Monitoring & Validation

- **Window / owner:** release owner watches the first two scheduled `seed-fx-rates` Railway ticks after deployment.
- **Logs:** find `Fetched <n> live currencies; <m> unavailable`. Healthy means `n >= 11`, validation succeeds, and `shared:fx-rates:v1` plus `seed-meta:shared:fx-rates` are written without a graceful-fetch failure.
- **Health / cache:** check `/api/health?compact=1` for `sharedFxRates`, then inspect the Redis envelope for `schemaVersion: 2`, `sourceVersion: yahoo-fx-shared-v2`, exact `null`/`fallbackCurrencies` symmetry, and a live `recordCount >= 11`.
- **Failure signals:** a retained schema-v1 envelope, a numeric value listed as fallback, fewer than 11 live quotes being published, repeated validation failures, or Big Mac/grocery seed deadline exits.
- **Rollback:** stop or revert the faulty seeder deployment and restore the last known live-quote snapshot; do not republish the old constant-filled payload. Keep downstream point-of-use fallback behavior enabled while Yahoo recovers.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--Sol-000000)
