### PR TITLE
fix(architecture): close the four gold-standard deviations (#6235)

### DIFF
--- a/api/_github-release.js
+++ b/api/_github-release.js
@@ -1,6 +1,22 @@
+import { readRawJsonFromUpstash, setCachedData } from './_upstash-json.js';
+
 const RELEASES_URL = 'https://api.github.com/repos/koala73/worldmonitor/releases/latest';
+const CACHE_KEY = 'github:latest-release:v1';
+// Matches the s-maxage the callers already advertise, so adding the Redis tier
+// does not change how stale a client can observe this — it only stops every
+// CDN miss from spending one of GitHub's 60/hr unauthenticated requests.
+const CACHE_TTL_SECONDS = 300;
 
 export async function fetchLatestRelease(userAgent) {
+  // Redis is a load shield, not a dependency: /api/version and /api/download are
+  // public and must keep answering when the cache is down or unconfigured.
+  try {
+    const cached = await readRawJsonFromUpstash(CACHE_KEY);
+    if (cached) return cached;
+  } catch {
+    // fall through to the live fetch
+  }
+
   const res = await fetch(RELEASES_URL, {
     headers: {
       'Accept': 'application/vnd.github+json',
@@ -8,5 +24,13 @@ export async function fetchLatestRelease(userAgent) {
     },
   });
   if (!res.ok) return null;
-  return res.json();
+  const release = await res.json();
+
+  try {
+    await setCachedData(CACHE_KEY, release, CACHE_TTL_SECONDS);
+  } catch {
+    // A failed write must not fail the request that already has its answer.
+  }
+
+  return release;
 }

--- a/api/fwdstart.js
+++ b/api/fwdstart.js
@@ -2,7 +2,73 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
 import { captureSilentError } from './_sentry-edge.js';
+import { readRawJsonFromUpstash, setCachedData } from './_upstash-json.js';
 export const config = { runtime: 'edge' };
+
+// The archive URL is fixed, so every CDN miss was re-scraping the same page.
+// Cache the parsed items — not the rendered RSS, whose lastBuildDate must stay
+// current — for the same window the response already advertises.
+const CACHE_KEY = 'fwdstart:archive-items:v1';
+const CACHE_TTL_SECONDS = 1800;
+
+/** Fetch the archive page and extract post items. Throws on upstream failure. */
+async function scrapeArchiveItems() {
+  const response = await fetch('https://www.fwdstart.me/archive', {
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+      'Accept': 'text/html,application/xhtml+xml',
+    },
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const html = await response.text();
+  const items = [];
+  const seenUrls = new Set();
+
+  // Split by embla__slide to get each post block
+  const slideBlocks = html.split('embla__slide');
+
+  for (const block of slideBlocks) {
+    // Extract URL
+    const urlMatch = block.match(/href="(\/p\/[^"]+)"/);
+    if (!urlMatch) continue;
+
+    const url = `https://www.fwdstart.me${urlMatch[1]}`;
+    if (seenUrls.has(url)) continue;
+    seenUrls.add(url);
+
+    // Extract title from alt attribute
+    const altMatch = block.match(/alt="([^"]+)"/);
+    const title = altMatch ? altMatch[1] : '';
+    if (!title || title.length < 5) continue;
+
+    // Extract date - look for "Mon DD, YYYY" pattern
+    const dateMatch = block.match(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(\d{1,2}),?\s+(\d{4})/i);
+    let pubDate = new Date();
+    if (dateMatch) {
+      const dateStr = `${dateMatch[1]} ${dateMatch[2]}, ${dateMatch[3]}`;
+      const parsed = new Date(dateStr);
+      if (!Number.isNaN(parsed.getTime())) {
+        pubDate = parsed;
+      }
+    }
+
+    // Extract subtitle/description if available
+    let description = '';
+    const subtitleMatch = block.match(/line-clamp-3[^>]*>.*?<span[^>]*>([^<]{20,})<\/span>/s);
+    if (subtitleMatch) {
+      description = subtitleMatch[1].trim();
+    }
+
+    items.push({ title, link: url, date: pubDate.toISOString(), description });
+  }
+
+  return items;
+}
 
 // Scrape FwdStart newsletter archive and return as RSS
 export default async function handler(req, ctx) {
@@ -11,58 +77,28 @@ export default async function handler(req, ctx) {
     return jsonResponse({ error: 'Origin not allowed' }, 403, cors);
   }
   try {
-    const response = await fetch('https://www.fwdstart.me/archive', {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
-        'Accept': 'text/html,application/xhtml+xml',
-      },
-      signal: AbortSignal.timeout(15000),
-    });
-
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
+    // Redis is a load shield, not a dependency: a cache outage must still
+    // serve the feed, so every failure here falls through to the live scrape.
+    let items = null;
+    try {
+      const cached = await readRawJsonFromUpstash(CACHE_KEY);
+      if (Array.isArray(cached) && cached.length > 0) items = cached;
+    } catch {
+      // fall through to the live scrape
     }
 
-    const html = await response.text();
-    const items = [];
-    const seenUrls = new Set();
-
-    // Split by embla__slide to get each post block
-    const slideBlocks = html.split('embla__slide');
-
-    for (const block of slideBlocks) {
-      // Extract URL
-      const urlMatch = block.match(/href="(\/p\/[^"]+)"/);
-      if (!urlMatch) continue;
-
-      const url = `https://www.fwdstart.me${urlMatch[1]}`;
-      if (seenUrls.has(url)) continue;
-      seenUrls.add(url);
-
-      // Extract title from alt attribute
-      const altMatch = block.match(/alt="([^"]+)"/);
-      const title = altMatch ? altMatch[1] : '';
-      if (!title || title.length < 5) continue;
-
-      // Extract date - look for "Mon DD, YYYY" pattern
-      const dateMatch = block.match(/(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(\d{1,2}),?\s+(\d{4})/i);
-      let pubDate = new Date();
-      if (dateMatch) {
-        const dateStr = `${dateMatch[1]} ${dateMatch[2]}, ${dateMatch[3]}`;
-        const parsed = new Date(dateStr);
-        if (!Number.isNaN(parsed.getTime())) {
-          pubDate = parsed;
+    if (!items) {
+      items = await scrapeArchiveItems();
+      // An empty extraction means the upstream markup changed, not that the
+      // newsletter is empty — caching that would hide a broken parser for the
+      // full TTL and serve a hollow feed.
+      if (items.length > 0) {
+        try {
+          await setCachedData(CACHE_KEY, items, CACHE_TTL_SECONDS);
+        } catch {
+          // A failed write must not fail the request that already has its answer.
         }
       }
-
-      // Extract subtitle/description if available
-      let description = '';
-      const subtitleMatch = block.match(/line-clamp-3[^>]*>.*?<span[^>]*>([^<]{20,})<\/span>/s);
-      if (subtitleMatch) {
-        description = subtitleMatch[1].trim();
-      }
-
-      items.push({ title, link: url, date: pubDate.toISOString(), description });
     }
 
     // Build RSS XML

--- a/api/health.js
+++ b/api/health.js
@@ -468,6 +468,17 @@ const SEED_META = {
   newsFeedHealth:   { key: 'seed-meta:news:feed-health',        maxStaleMin: 2880 },
   newsRecallBenchmark: { key: 'seed-meta:news:recall-benchmark', maxStaleMin: 2880 },
   marketQuotes:     { key: 'seed-meta:market:stocks',         maxStaleMin: 30 },
+  // #6235: the country-index RPC is seeded for the whole 45-country enum. The
+  // seeding pass is deliberately best-effort (one country's provider failure
+  // must not cost the other 44 their refresh) and therefore never throws — so
+  // without this entry a run where every country failed would leave
+  // seed-meta:market:stocks fresh and health green while the country caches
+  // expired and the RPC silently reverted to per-request Yahoo fetches.
+  // minRecordCount measured 2026-08-05: 37/45 symbols return usable 1mo daily
+  // closes; RU, PL, EG, CL, PE, PT, CZ and HU fail permanently on Yahoo's side
+  // (see #6240). 30 leaves headroom for ~7 transient failures below that
+  // measured floor without alarming on the known-dead eight.
+  countryStockIndexes: { key: 'seed-meta:market:country-indexes', maxStaleMin: 30, minRecordCount: 30 },
   commodityQuotes:  { key: 'seed-meta:market:commodities',    maxStaleMin: 30 },
   goldExtended:     { key: 'seed-meta:market:gold-extended',  maxStaleMin: 30 },
   goldEtfFlows:     { key: 'seed-meta:market:gold-etf-flows', maxStaleMin: 2880 }, // SPDR publishes daily; 2× = 48h tolerance

--- a/scripts/_country-stock-index-registry.mjs
+++ b/scripts/_country-stock-index-registry.mjs
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+
+import { countryStockIndexKey } from './_country-stock-index.mjs';
+
+/**
+ * The whole-enum work-list, kept OUT of `_country-stock-index.mjs` on purpose.
+ *
+ * `scripts/ais-relay.cjs` imports that module for the CN key and the snapshot
+ * builder, and it never needs this list. Putting the `readFileSync` there would
+ * add `shared/openapi-filter-param-contracts.json` to the relay's Railway
+ * runtime-dependency closure (tests/railway-watch-path-audit.test.mjs), forcing
+ * the always-on relay to redeploy every time an unrelated country entry
+ * changes. Seeder-only concerns belong in a seeder-only module.
+ */
+
+/**
+ * The public country enum is the single source of truth for which countries the
+ * RPC will answer, so the seeder derives its work-list from the same file
+ * rather than keeping a parallel copy that could drift.
+ *
+ * @returns {Array<{ code: string, symbol: string, name: string }>}
+ */
+export function loadCountryStockIndexes() {
+  const raw = JSON.parse(
+    readFileSync(new URL('../shared/openapi-filter-param-contracts.json', import.meta.url), 'utf8'),
+  );
+  const contracts = raw?.marketCountryStockIndexes;
+  if (!contracts || typeof contracts !== 'object') {
+    throw new Error('marketCountryStockIndexes missing from openapi-filter-param-contracts.json');
+  }
+  return Object.entries(contracts)
+    .filter(([, index]) => index?.symbol && index?.name)
+    .map(([code, index]) => ({ code, symbol: index.symbol, name: index.name }));
+}
+
+/** Redis keys Railway owns for the whole enum. */
+export function loadCountryStockIndexKeys() {
+  return loadCountryStockIndexes().map(index => countryStockIndexKey(index.code));
+}

--- a/scripts/_country-stock-index.mjs
+++ b/scripts/_country-stock-index.mjs
@@ -1,6 +1,48 @@
-export const CHINA_COUNTRY_STOCK_INDEX_KEY = 'market:stock-index:v1:CN';
+import { readFileSync } from 'node:fs';
 
-export function buildCountryStockIndexSnapshotFromCloses(closes, currency = 'CNY', fetchedAt = new Date().toISOString()) {
+/** Redis key Railway owns for a country's audit-backed index snapshot. */
+export function countryStockIndexKey(code) {
+  return `market:stock-index:v1:${code}`;
+}
+
+/**
+ * China stays a named export because the AIS relay writes it on its own
+ * cadence (fresh Yahoo chart alongside the live quote stream), separately from
+ * the market seeder's whole-enum pass.
+ */
+export const CHINA_COUNTRY_STOCK_INDEX = Object.freeze({
+  code: 'CN',
+  symbol: '000001.SS',
+  name: 'SSE Composite',
+});
+export const CHINA_COUNTRY_STOCK_INDEX_KEY = countryStockIndexKey('CN');
+
+/**
+ * The public country enum is the single source of truth for which countries
+ * the RPC will answer, so the seeder derives its work-list from the same file
+ * rather than keeping a parallel copy that could drift.
+ *
+ * @returns {Array<{ code: string, symbol: string, name: string }>}
+ */
+export function loadCountryStockIndexes() {
+  const raw = JSON.parse(
+    readFileSync(new URL('../shared/openapi-filter-param-contracts.json', import.meta.url), 'utf8'),
+  );
+  const contracts = raw?.marketCountryStockIndexes;
+  if (!contracts || typeof contracts !== 'object') {
+    throw new Error('marketCountryStockIndexes missing from openapi-filter-param-contracts.json');
+  }
+  return Object.entries(contracts)
+    .filter(([, index]) => index?.symbol && index?.name)
+    .map(([code, index]) => ({ code, symbol: index.symbol, name: index.name }));
+}
+
+export function buildCountryStockIndexSnapshotFromCloses(
+  closes,
+  currency = 'CNY',
+  fetchedAt = new Date().toISOString(),
+  index = CHINA_COUNTRY_STOCK_INDEX,
+) {
   const finiteCloses = Array.isArray(closes) ? closes.filter((value) => Number.isFinite(value)) : [];
   if (finiteCloses.length < 2) return null;
 
@@ -11,9 +53,9 @@ export function buildCountryStockIndexSnapshotFromCloses(closes, currency = 'CNY
 
   return {
     available: true,
-    code: 'CN',
-    symbol: '000001.SS',
-    indexName: 'SSE Composite',
+    code: index.code,
+    symbol: index.symbol,
+    indexName: index.name,
     price: +latest.toFixed(2),
     weekChangePercent: +(((latest - oldest) / oldest) * 100).toFixed(2),
     currency,
@@ -21,8 +63,12 @@ export function buildCountryStockIndexSnapshotFromCloses(closes, currency = 'CNY
   };
 }
 
-export function buildCountryStockIndexSnapshot(chart, fetchedAt = new Date().toISOString()) {
+export function buildCountryStockIndexSnapshot(
+  chart,
+  fetchedAt = new Date().toISOString(),
+  index = CHINA_COUNTRY_STOCK_INDEX,
+) {
   const result = chart?.chart?.result?.[0];
   const closes = result?.indicators?.quote?.[0]?.close?.filter((value) => Number.isFinite(value));
-  return buildCountryStockIndexSnapshotFromCloses(closes, result?.meta?.currency || 'CNY', fetchedAt);
+  return buildCountryStockIndexSnapshotFromCloses(closes, result?.meta?.currency || 'CNY', fetchedAt, index);
 }

--- a/scripts/_country-stock-index.mjs
+++ b/scripts/_country-stock-index.mjs
@@ -1,4 +1,7 @@
-import { readFileSync } from 'node:fs';
+// Deliberately free of filesystem reads. scripts/ais-relay.cjs imports this
+// module, and every file this module touches joins the relay's Railway
+// runtime-dependency closure. The whole-enum work-list lives in
+// ./_country-stock-index-registry.mjs for that reason.
 
 /** Redis key Railway owns for a country's audit-backed index snapshot. */
 export function countryStockIndexKey(code) {
@@ -17,25 +20,6 @@ export const CHINA_COUNTRY_STOCK_INDEX = Object.freeze({
 });
 export const CHINA_COUNTRY_STOCK_INDEX_KEY = countryStockIndexKey('CN');
 
-/**
- * The public country enum is the single source of truth for which countries
- * the RPC will answer, so the seeder derives its work-list from the same file
- * rather than keeping a parallel copy that could drift.
- *
- * @returns {Array<{ code: string, symbol: string, name: string }>}
- */
-export function loadCountryStockIndexes() {
-  const raw = JSON.parse(
-    readFileSync(new URL('../shared/openapi-filter-param-contracts.json', import.meta.url), 'utf8'),
-  );
-  const contracts = raw?.marketCountryStockIndexes;
-  if (!contracts || typeof contracts !== 'object') {
-    throw new Error('marketCountryStockIndexes missing from openapi-filter-param-contracts.json');
-  }
-  return Object.entries(contracts)
-    .filter(([, index]) => index?.symbol && index?.name)
-    .map(([code, index]) => ({ code, symbol: index.symbol, name: index.name }));
-}
 
 export function buildCountryStockIndexSnapshotFromCloses(
   closes,

--- a/scripts/seed-market-quotes.mjs
+++ b/scripts/seed-market-quotes.mjs
@@ -3,7 +3,7 @@
 import { loadEnvFile, loadSharedConfig, sleep, CHROME_UA, runSeed, parseYahooChart, writeExtraKey, extendExistingTtl, readCanonicalEnvelopeMeta, readSeedSnapshot, writeFreshnessMetadata } from './_seed-utils.mjs';
 import { fetchYahooJson } from './_yahoo-fetch.mjs';
 import { fetchAvBulkQuotes } from './_shared-av.mjs';
-import { CHINA_COUNTRY_STOCK_INDEX_KEY, buildCountryStockIndexSnapshot } from './_country-stock-index.mjs';
+import { buildCountryStockIndexSnapshot, countryStockIndexKey, loadCountryStockIndexes } from './_country-stock-index.mjs';
 import { getUsEquitySession, isMultiMarketEquityTradingDay } from './shared/market-hours.cjs';
 import { mergeLastGoodQuotes } from './shared/market-quote-refresh.cjs';
 
@@ -14,6 +14,12 @@ loadEnvFile(import.meta.url);
 const CANONICAL_KEY = 'market:stocks-bootstrap:v1';
 const CACHE_TTL = 1800;
 const YAHOO_DELAY_MS = 200;
+
+// #6235: the RPC answers a bounded 45-country enum, so every country is
+// seedable. Previously only CN was seeded and the other 44 lazy-fetched Yahoo
+// at the edge, leaving a cold Vercel isolate with no fallback at all.
+const COUNTRY_STOCK_INDEXES = loadCountryStockIndexes();
+const COUNTRY_STOCK_INDEX_KEYS = COUNTRY_STOCK_INDEXES.map(index => countryStockIndexKey(index.code));
 
 const MARKET_SYMBOLS = stocksConfig.symbols.map(s => s.symbol);
 const RPC_KEY = `market:quotes:v1:${[...MARKET_SYMBOLS].sort().join(',')}`;
@@ -139,7 +145,7 @@ export function declareRecords(data) {
 if (!isMultiMarketEquityTradingDay()) {
   const lastGood = await readCanonicalEnvelopeMeta(CANONICAL_KEY);
   if (lastGood) {
-    const extended = await extendExistingTtl([CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY, CHINA_COUNTRY_STOCK_INDEX_KEY], CACHE_TTL);
+    const extended = await extendExistingTtl([CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY, ...COUNTRY_STOCK_INDEX_KEYS], CACHE_TTL);
     if (extended) {
       await writeFreshnessMetadata('market', 'stocks', lastGood.recordCount, lastGood.sourceVersion || 'alphavantage+finnhub+yahoo', CACHE_TTL);
       console.log(`[seed-market-quotes] Tracked equity markets closed (US session=${getUsEquitySession()}) — skipping upstream fetch, extended TTL`);
@@ -154,32 +160,49 @@ if (!isMultiMarketEquityTradingDay()) {
 async function writeRequiredCompanionKeys(data) {
   if (!data) return;
   await writeExtraKey(RPC_KEY, data, CACHE_TTL);
-  try {
-    await writeChinaCountryStockIndex();
-  } catch (err) {
-    // A China-specific source failure must remain visible to its audit without
-    // turning an otherwise successful global market seed into a false outage.
-    // Preserve last-good long enough for the audit's content-age budget to
-    // distinguish a transient provider error from a missing cache.
-    const preserved = await extendExistingTtl([CHINA_COUNTRY_STOCK_INDEX_KEY], CACHE_TTL);
-    console.warn(
-      `[seed-market-quotes] China country index refresh failed: ${err.message}; `
-      + (preserved ? 'preserved last-good cache TTL' : 'no last-good cache TTL to preserve'),
-    );
-  }
+  await writeCountryStockIndexes();
 }
 
-async function writeChinaCountryStockIndex() {
-  // Keep the China deep-dive cache Railway-backed. The RPC may still refresh
-  // on demand, but audit health cannot depend on someone opening the panel.
-  await sleep(YAHOO_DELAY_MS);
-  const chart = await fetchYahooJson(
-    'https://query1.finance.yahoo.com/v8/finance/chart/000001.SS?range=1mo&interval=1d',
-    { label: 'China country index' },
-  );
-  const snapshot = buildCountryStockIndexSnapshot(chart);
-  if (!snapshot) throw new Error('China country index returned insufficient closes');
-  await writeExtraKey(CHINA_COUNTRY_STOCK_INDEX_KEY, snapshot, CACHE_TTL);
+/**
+ * Seed every country in the public enum, best-effort and independently.
+ *
+ * One country's provider failure must not cost the other 44 their refresh, and
+ * must not turn an otherwise successful global market seed into a false
+ * outage — so each leg preserves its own last-good TTL and the pass reports a
+ * summary instead of throwing. Countries that fail here still answer via the
+ * RPC's own live fetch, which remains as a gap-filler.
+ */
+async function writeCountryStockIndexes() {
+  const failures = [];
+
+  for (const index of COUNTRY_STOCK_INDEXES) {
+    const key = countryStockIndexKey(index.code);
+    try {
+      await sleep(YAHOO_DELAY_MS);
+      const chart = await fetchYahooJson(
+        `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(index.symbol)}?range=1mo&interval=1d`,
+        { label: `${index.code} country index` },
+      );
+      const snapshot = buildCountryStockIndexSnapshot(chart, undefined, index);
+      if (!snapshot) throw new Error('insufficient closes');
+      await writeExtraKey(key, snapshot, CACHE_TTL);
+    } catch (err) {
+      // Preserve last-good long enough for the audit's content-age budget to
+      // distinguish a transient provider error from a missing cache.
+      const preserved = await extendExistingTtl([key], CACHE_TTL);
+      failures.push(`${index.code} (${err.message}${preserved ? ', preserved last-good' : ', no last-good'})`);
+    }
+  }
+
+  const seeded = COUNTRY_STOCK_INDEXES.length - failures.length;
+  if (failures.length > 0) {
+    console.warn(
+      `[seed-market-quotes] Country index refresh: ${seeded}/${COUNTRY_STOCK_INDEXES.length} seeded; `
+      + `failed: ${failures.join(', ')}`,
+    );
+  } else {
+    console.log(`[seed-market-quotes] Country index refresh: ${seeded}/${COUNTRY_STOCK_INDEXES.length} seeded`);
+  }
 }
 
 runSeed('market', 'stocks', CANONICAL_KEY, fetchMarketQuotes, {
@@ -192,7 +215,7 @@ runSeed('market', 'stocks', CANONICAL_KEY, fetchMarketQuotes, {
   // This companion payload is written after the global market publish because
   // it needs a different Yahoo chart shape. Preserve its last-good TTL across
   // every runSeed graceful path, just like normal extra keys.
-  preserveKeys: [CHINA_COUNTRY_STOCK_INDEX_KEY],
+  preserveKeys: COUNTRY_STOCK_INDEX_KEYS,
   afterPublish: async (data) => {
     // runSeed exits the process on success; required companion writes must be
     // awaited here so the RPC key is published before the terminal exit.

--- a/scripts/seed-market-quotes.mjs
+++ b/scripts/seed-market-quotes.mjs
@@ -3,7 +3,8 @@
 import { loadEnvFile, loadSharedConfig, sleep, CHROME_UA, runSeed, parseYahooChart, writeExtraKey, extendExistingTtl, extendExistingTtlDetailed, readCanonicalEnvelopeMeta, readSeedSnapshot, writeFreshnessMetadata, writeFreshnessMetadataSafely } from './_seed-utils.mjs';
 import { fetchYahooJson } from './_yahoo-fetch.mjs';
 import { fetchAvBulkQuotes } from './_shared-av.mjs';
-import { buildCountryStockIndexSnapshot, countryStockIndexKey, loadCountryStockIndexes } from './_country-stock-index.mjs';
+import { buildCountryStockIndexSnapshot, countryStockIndexKey } from './_country-stock-index.mjs';
+import { loadCountryStockIndexes } from './_country-stock-index-registry.mjs';
 import { getUsEquitySession, isMultiMarketEquityTradingDay } from './shared/market-hours.cjs';
 import { mergeLastGoodQuotes } from './shared/market-quote-refresh.cjs';
 

--- a/scripts/seed-market-quotes.mjs
+++ b/scripts/seed-market-quotes.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, loadSharedConfig, sleep, CHROME_UA, runSeed, parseYahooChart, writeExtraKey, extendExistingTtl, readCanonicalEnvelopeMeta, readSeedSnapshot, writeFreshnessMetadata } from './_seed-utils.mjs';
+import { loadEnvFile, loadSharedConfig, sleep, CHROME_UA, runSeed, parseYahooChart, writeExtraKey, extendExistingTtl, extendExistingTtlDetailed, readCanonicalEnvelopeMeta, readSeedSnapshot, writeFreshnessMetadata, writeFreshnessMetadataSafely } from './_seed-utils.mjs';
 import { fetchYahooJson } from './_yahoo-fetch.mjs';
 import { fetchAvBulkQuotes } from './_shared-av.mjs';
 import { buildCountryStockIndexSnapshot, countryStockIndexKey, loadCountryStockIndexes } from './_country-stock-index.mjs';
@@ -145,9 +145,27 @@ export function declareRecords(data) {
 if (!isMultiMarketEquityTradingDay()) {
   const lastGood = await readCanonicalEnvelopeMeta(CANONICAL_KEY);
   if (lastGood) {
-    const extended = await extendExistingTtl([CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY, ...COUNTRY_STOCK_INDEX_KEYS], CACHE_TTL);
+    // Gate the fast path on the canonical keys ONLY. Country-index keys are
+    // best-effort by design — several countries in the enum have no
+    // Yahoo-serviceable symbol, so their keys legitimately never exist, and
+    // requiring all 45 to extend would make this branch never confirm and
+    // force a full fetch on every closed day.
+    const extended = await extendExistingTtl([CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY], CACHE_TTL);
     if (extended) {
+      const countryTtl = await extendExistingTtlDetailed(COUNTRY_STOCK_INDEX_KEYS, CACHE_TTL);
       await writeFreshnessMetadata('market', 'stocks', lastGood.recordCount, lastGood.sourceVersion || 'alphavantage+finnhub+yahoo', CACHE_TTL);
+      // The country-index caches were just TTL-extended alongside the canonical
+      // keys, so their freshness must be refreshed on this path too — otherwise
+      // seed-meta ages across a 60h+ weekend and alarms on data that is present
+      // and deliberately preserved. recordCount is the count actually extended,
+      // never the size of the work-list.
+      await writeFreshnessMetadataSafely(
+        'market',
+        'country-indexes',
+        countryTtl.extendedKeys.length,
+        'yahoo',
+        CACHE_TTL,
+      );
       console.log(`[seed-market-quotes] Tracked equity markets closed (US session=${getUsEquitySession()}) — skipping upstream fetch, extended TTL`);
       process.exit(0);
     }
@@ -171,6 +189,12 @@ async function writeRequiredCompanionKeys(data) {
  * outage — so each leg preserves its own last-good TTL and the pass reports a
  * summary instead of throwing. Countries that fail here still answer via the
  * RPC's own live fetch, which remains as a gap-filler.
+ *
+ * Because the pass never throws, it MUST publish its own freshness metadata:
+ * without it a run where every country failed would leave
+ * `seed-meta:market:stocks` fresh and health green while the country-index
+ * caches quietly expired — the RPC would silently revert to fetching Yahoo per
+ * request, which is the exact regression this seeding exists to prevent.
  */
 async function writeCountryStockIndexes() {
   const failures = [];
@@ -203,6 +227,18 @@ async function writeCountryStockIndexes() {
   } else {
     console.log(`[seed-market-quotes] Country index refresh: ${seeded}/${COUNTRY_STOCK_INDEXES.length} seeded`);
   }
+
+  // recordCount is what /api/health thresholds on, so it must be the count that
+  // actually landed in Redis, never the size of the work-list.
+  await writeFreshnessMetadataSafely(
+    'market',
+    'country-indexes',
+    seeded,
+    'yahoo',
+    CACHE_TTL,
+  );
+
+  return seeded;
 }
 
 runSeed('market', 'stocks', CANONICAL_KEY, fetchMarketQuotes, {

--- a/server/worldmonitor/market/v1/get-country-stock-index.ts
+++ b/server/worldmonitor/market/v1/get-country-stock-index.ts
@@ -27,18 +27,25 @@ const COUNTRY_INDEX = filterParamContracts.marketCountryStockIndexes as Record<s
 // Keep request-driven cachedFetchJson writes separate: a slow request that
 // ends in a negative sentinel must never overwrite the seed's last-good data.
 const REDIS_CACHE_KEY = 'market:stock-index:rpc:v1';
-const RAILWAY_SEEDED_COUNTRY_INDEX_KEY = 'market:stock-index:v1:CN';
+const RAILWAY_SEEDED_COUNTRY_INDEX_KEY_PREFIX = 'market:stock-index:v1:';
 const REDIS_CACHE_TTL = 1800; // 30 min — weekly data, slow-moving
 
 const stockIndexCache: Record<string, { data: GetCountryStockIndexResponse; ts: number }> = {};
 const STOCK_INDEX_CACHE_TTL = 3_600_000; // 1 hour (in-memory fallback)
 
-function isAvailableCountryStockIndex(value: unknown): value is GetCountryStockIndexResponse {
+function railwaySeededKey(code: string): string {
+  return `${RAILWAY_SEEDED_COUNTRY_INDEX_KEY_PREFIX}${code}`;
+}
+
+// The seed row must agree with the key it was read from. A payload whose
+// `code` differs is a mis-keyed write, not usable data — serving it would
+// answer one country's request with another country's index.
+function isAvailableCountryStockIndex(value: unknown, code: string): value is GetCountryStockIndexResponse {
   return Boolean(
     value
     && typeof value === 'object'
     && (value as GetCountryStockIndexResponse).available
-    && (value as GetCountryStockIndexResponse).code === 'CN',
+    && (value as GetCountryStockIndexResponse).code === code,
   );
 }
 
@@ -60,16 +67,16 @@ export async function getCountryStockIndex(
   const index = COUNTRY_INDEX[code];
   if (!index) return notAvailable;
 
-  // Railway owns the CN snapshot and writes it without the Vercel environment
-  // prefix. Prefer that raw last-good payload before serving the RPC cache.
-  // The fallback cache below intentionally uses a separate key so a failed
-  // request cannot replace this seed-owned record with a negative sentinel.
-  if (code === 'CN') {
-    const railwaySnapshot = await getCachedJson(RAILWAY_SEEDED_COUNTRY_INDEX_KEY, true);
-    if (isAvailableCountryStockIndex(railwaySnapshot)) {
-      stockIndexCache[code] = { data: railwaySnapshot, ts: Date.now() };
-      return railwaySnapshot;
-    }
+  // Railway seeds every country in the enum and writes without the Vercel
+  // environment prefix. Prefer that raw last-good payload before serving the
+  // RPC cache. The fallback cache below intentionally uses a separate key so a
+  // failed request cannot replace a seed-owned record with a negative sentinel.
+  // The live fetch below remains as a gap-filler for any country whose seed
+  // leg failed on the last run.
+  const railwaySnapshot = await getCachedJson(railwaySeededKey(code), true);
+  if (isAvailableCountryStockIndex(railwaySnapshot, code)) {
+    stockIndexCache[code] = { data: railwaySnapshot, ts: Date.now() };
+    return railwaySnapshot;
   }
 
   const cached = stockIndexCache[code];

--- a/server/worldmonitor/sanctions/v1/lookup-entity.ts
+++ b/server/worldmonitor/sanctions/v1/lookup-entity.ts
@@ -6,7 +6,7 @@ import type {
   ServerContext,
 } from '../../../../src/generated/server/worldmonitor/sanctions/v1/service_server';
 
-import { getCachedJson } from '../../../_shared/redis';
+import { cachedFetchJson, getCachedJson } from '../../../_shared/redis';
 
 const ENTITY_INDEX_KEY = 'sanctions:entities:v1';
 const DEFAULT_MAX = 10;
@@ -15,6 +15,10 @@ const MAX_QUERY_LENGTH = 200;
 const MIN_QUERY_LENGTH = 2;
 const OPENSANCTIONS_BASE = 'https://api.opensanctions.org';
 const OPENSANCTIONS_TIMEOUT_MS = 8_000;
+// Designations are published by regulators daily at most, so an hour of reuse
+// is well inside any reasonable freshness expectation while collapsing the
+// repeat-query traffic that dominates entity lookups.
+const OPENSANCTIONS_CACHE_TTL_SECONDS = 3_600;
 
 interface EntityIndexRecord {
   id: string;
@@ -73,6 +77,23 @@ function normalizeOpenSanctionsHit(hit: OpenSanctionsHit): SanctionEntityMatch |
   };
 }
 
+/**
+ * Cache identity for a lookup. Case and surrounding/interior whitespace are
+ * not meaningful to OpenSanctions' matcher, so folding them here lets the
+ * common "same name typed slightly differently" retries share one entry.
+ * `maxResults` stays in the key because a narrower response must never be
+ * replayed to a caller that asked for a wider one.
+ */
+function lookupCacheKey(q: string, maxResults: number): string {
+  const canonical = q.toLowerCase().replace(/\s+/g, ' ').trim();
+  let hash = 2166136261;
+  for (let i = 0; i < canonical.length; i += 1) {
+    hash ^= canonical.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `sanctions:lookup:v1:${(hash >>> 0).toString(36)}:${maxResults}`;
+}
+
 async function searchOpenSanctions(q: string, limit: number): Promise<{ results: SanctionEntityMatch[]; total: number } | null> {
   const url = new URL(`${OPENSANCTIONS_BASE}/search/default`);
   url.searchParams.set('q', q);
@@ -86,7 +107,10 @@ async function searchOpenSanctions(q: string, limit: number): Promise<{ results:
     signal: AbortSignal.timeout(OPENSANCTIONS_TIMEOUT_MS),
   });
 
-  if (!resp.ok) return null;
+  // Throw rather than return null so an availability failure takes the
+  // no-negative-cache path below. Returning null would persist a sentinel and
+  // pin every later caller to the narrower OFAC index for the negative TTL.
+  if (!resp.ok) throw new Error(`OpenSanctions HTTP ${resp.status}`);
 
   const data = (await resp.json()) as OpenSanctionsSearchResponse;
   const hits = Array.isArray(data.results) ? data.results : [];
@@ -153,8 +177,17 @@ export const lookupSanctionEntity: SanctionsServiceHandler['lookupSanctionEntity
 
   // Primary: live query against OpenSanctions — broader global coverage than
   // the local OFAC index. Matches the legacy /api/sanctions-entity-search path.
+  // Cached because repeat lookups dominate this route (#6235); a genuine
+  // zero-match answer caches normally, but an upstream outage must not be
+  // persisted as one, hence cacheFetcherErrors: false.
   try {
-    const upstream = await searchOpenSanctions(q, maxResults);
+    const upstream = await cachedFetchJson<{ results: SanctionEntityMatch[]; total: number }>(
+      lookupCacheKey(q, maxResults),
+      OPENSANCTIONS_CACHE_TTL_SECONDS,
+      () => searchOpenSanctions(q, maxResults),
+      undefined,
+      { cacheFetcherErrors: false },
+    );
     if (upstream) {
       return { ...upstream, source: 'opensanctions' };
     }

--- a/tests/china-country-stock-index-seed.test.mjs
+++ b/tests/china-country-stock-index-seed.test.mjs
@@ -6,8 +6,8 @@ import {
   buildCountryStockIndexSnapshot,
   buildCountryStockIndexSnapshotFromCloses,
   countryStockIndexKey,
-  loadCountryStockIndexes,
 } from '../scripts/_country-stock-index.mjs';
+import { loadCountryStockIndexes } from '../scripts/_country-stock-index-registry.mjs';
 
 const FIXED_AT = '2026-07-14T12:00:00.000Z';
 

--- a/tests/china-country-stock-index-seed.test.mjs
+++ b/tests/china-country-stock-index-seed.test.mjs
@@ -67,7 +67,10 @@ test('the Railway market seed maintains every country cache alongside its public
   assert.match(source, /Country index refresh/);
   assert.match(source, /await extendExistingTtl\(\[key\], CACHE_TTL\)/);
   assert.match(source, /await writeExtraKey\(key, snapshot, CACHE_TTL\)/);
-  assert.match(source, /extendExistingTtl\(\[CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY, \.\.\.COUNTRY_STOCK_INDEX_KEYS\]/);
+  // The country keys are extended best-effort via extendExistingTtlDetailed
+  // rather than gating the canonical fast path — see
+  // tests/country-stock-index-health.test.mjs for why.
+  assert.match(source, /extendExistingTtlDetailed\(COUNTRY_STOCK_INDEX_KEYS, CACHE_TTL\)/);
   assert.match(handlerSource, /const REDIS_CACHE_KEY = 'market:stock-index:rpc:v1';/);
   assert.match(handlerSource, /const RAILWAY_SEEDED_COUNTRY_INDEX_KEY_PREFIX = 'market:stock-index:v1:';/);
   assert.match(handlerSource, /getCachedJson\(railwaySeededKey\(code\), true\)/);

--- a/tests/china-country-stock-index-seed.test.mjs
+++ b/tests/china-country-stock-index-seed.test.mjs
@@ -5,6 +5,8 @@ import {
   CHINA_COUNTRY_STOCK_INDEX_KEY,
   buildCountryStockIndexSnapshot,
   buildCountryStockIndexSnapshotFromCloses,
+  countryStockIndexKey,
+  loadCountryStockIndexes,
 } from '../scripts/_country-stock-index.mjs';
 
 const FIXED_AT = '2026-07-14T12:00:00.000Z';
@@ -52,21 +54,34 @@ test('buildCountryStockIndexSnapshotFromCloses filters malformed closes before c
   assert.equal(buildCountryStockIndexSnapshotFromCloses([3200, 'broken', null], 'CNY', FIXED_AT), null);
 });
 
-test('the Railway market seed maintains the China cache alongside its public stock bootstrap contract', () => {
+test('the Railway market seed maintains every country cache alongside its public stock bootstrap contract', () => {
   const source = readFileSync(new URL('../scripts/seed-market-quotes.mjs', import.meta.url), 'utf8');
   const handlerSource = readFileSync(new URL('../server/worldmonitor/market/v1/get-country-stock-index.ts', import.meta.url), 'utf8');
 
-  assert.match(source, /CHINA_COUNTRY_STOCK_INDEX_KEY/);
-  assert.match(source, /writeChinaCountryStockIndex/);
-  assert.match(source, /preserveKeys:\s*\[CHINA_COUNTRY_STOCK_INDEX_KEY\]/);
-  assert.match(source, /China country index refresh failed/);
-  assert.match(source, /await extendExistingTtl\(\[CHINA_COUNTRY_STOCK_INDEX_KEY\], CACHE_TTL\)/);
-  assert.match(source, /await writeExtraKey\(CHINA_COUNTRY_STOCK_INDEX_KEY, snapshot, CACHE_TTL\)/);
-  assert.match(source, /extendExistingTtl\(\[CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY, CHINA_COUNTRY_STOCK_INDEX_KEY\]/);
+  // #6235: the seed covers the whole enum, not just CN. These assertions pin
+  // the wiring; the behavioural coverage lives in
+  // tests/country-stock-index-seed-all.test.mts.
+  assert.match(source, /COUNTRY_STOCK_INDEX_KEYS/);
+  assert.match(source, /writeCountryStockIndexes/);
+  assert.match(source, /preserveKeys:\s*COUNTRY_STOCK_INDEX_KEYS/);
+  assert.match(source, /Country index refresh/);
+  assert.match(source, /await extendExistingTtl\(\[key\], CACHE_TTL\)/);
+  assert.match(source, /await writeExtraKey\(key, snapshot, CACHE_TTL\)/);
+  assert.match(source, /extendExistingTtl\(\[CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY, \.\.\.COUNTRY_STOCK_INDEX_KEYS\]/);
   assert.match(handlerSource, /const REDIS_CACHE_KEY = 'market:stock-index:rpc:v1';/);
-  assert.match(handlerSource, /const RAILWAY_SEEDED_COUNTRY_INDEX_KEY = 'market:stock-index:v1:CN';/);
-  assert.match(handlerSource, /getCachedJson\(RAILWAY_SEEDED_COUNTRY_INDEX_KEY, true\)/);
+  assert.match(handlerSource, /const RAILWAY_SEEDED_COUNTRY_INDEX_KEY_PREFIX = 'market:stock-index:v1:';/);
+  assert.match(handlerSource, /getCachedJson\(railwaySeededKey\(code\), true\)/);
   assert.doesNotMatch(handlerSource, /const REDIS_CACHE_KEY = 'market:stock-index:v1';/);
+  // The CN-only gate is what #6235 removed — it must not come back.
+  assert.doesNotMatch(handlerSource, /if \(code === 'CN'\)/);
+});
+
+test('the whole-enum work-list is derived from the public country contract', () => {
+  const indexes = loadCountryStockIndexes();
+  assert.ok(indexes.length >= 45, `expected the full country enum, got ${indexes.length}`);
+  assert.ok(indexes.some(i => i.code === 'CN'), 'CN must remain in the seeded set');
+  assert.equal(new Set(indexes.map(i => i.code)).size, indexes.length, 'country codes must be unique');
+  assert.equal(countryStockIndexKey('DE'), 'market:stock-index:v1:DE');
 });
 
 test('the live AIS relay writes the China index only from a fresh one-month Yahoo chart', () => {

--- a/tests/country-stock-index-health.test.mjs
+++ b/tests/country-stock-index-health.test.mjs
@@ -50,6 +50,27 @@ test('the closed-market fast path is not gated on the best-effort country keys',
   );
 });
 
+test('the shared country-index module stays free of filesystem reads', () => {
+  // scripts/ais-relay.cjs imports this module for the CN key and the snapshot
+  // builder. Every file it touches joins the always-on relay's Railway
+  // runtime-dependency closure (tests/railway-watch-path-audit.test.mjs), so a
+  // readFileSync here forces a relay redeploy whenever an unrelated country
+  // entry changes — and fails the closure audit until someone widens the
+  // relay's watch patterns for a dependency it never uses.
+  const sharedSource = readFileSync(new URL('../scripts/_country-stock-index.mjs', import.meta.url), 'utf8');
+  assert.doesNotMatch(sharedSource, /readFileSync|node:fs/, 'the work-list belongs in _country-stock-index-registry.mjs');
+
+  const registrySource = readFileSync(new URL('../scripts/_country-stock-index-registry.mjs', import.meta.url), 'utf8');
+  assert.match(registrySource, /openapi-filter-param-contracts\.json/, 'the registry module owns the enum read');
+
+  const relaySource = readFileSync(new URL('../scripts/ais-relay.cjs', import.meta.url), 'utf8');
+  assert.doesNotMatch(
+    relaySource,
+    /_country-stock-index-registry/,
+    'the relay must not pull in the seeder-only work-list',
+  );
+});
+
 test('health.js tracks the country-index seed with a floor below the measured success rate', () => {
   const entry = healthSource.match(
     /countryStockIndexes:\s*\{\s*key:\s*'seed-meta:market:country-indexes',\s*maxStaleMin:\s*(\d+),\s*minRecordCount:\s*(\d+)\s*\}/,

--- a/tests/country-stock-index-health.test.mjs
+++ b/tests/country-stock-index-health.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+// #6235 follow-up: seeding the whole 45-country enum is only half the gold
+// standard — without its own freshness metadata a run where every country
+// failed would leave seed-meta:market:stocks fresh and health green while the
+// country caches expired and the RPC silently reverted to per-request Yahoo.
+
+const seedSource = readFileSync(new URL('../scripts/seed-market-quotes.mjs', import.meta.url), 'utf8');
+const healthSource = readFileSync(new URL('../api/health.js', import.meta.url), 'utf8');
+
+test('the country-index pass publishes its own freshness metadata', () => {
+  assert.match(
+    seedSource,
+    /writeFreshnessMetadataSafely\(\s*'market',\s*'country-indexes',\s*seeded,/,
+    'the seeded count — not the work-list size — must be what health thresholds on',
+  );
+});
+
+test('the closed-market fast path refreshes country-index freshness too', () => {
+  // Without this the alarm fires across every 60h+ weekend on data that is
+  // present and deliberately TTL-preserved.
+  assert.match(
+    seedSource,
+    /writeFreshnessMetadataSafely\(\s*'market',\s*'country-indexes',\s*countryTtl\.extendedKeys\.length,/,
+    'the closed-market branch must report the count it actually extended',
+  );
+});
+
+test('the closed-market fast path is not gated on the best-effort country keys', () => {
+  // extendExistingTtl returns true only when EVERY key extends. Several
+  // countries have no Yahoo-serviceable symbol (#6240) so their keys never
+  // exist — gating on all 45 would make this branch never confirm and force a
+  // full fetch on every closed day.
+  assert.match(
+    seedSource,
+    /extendExistingTtl\(\[CANONICAL_KEY, 'seed-meta:market:stocks', RPC_KEY\], CACHE_TTL\)/,
+    'the gating list must contain only the canonical keys',
+  );
+  assert.doesNotMatch(
+    seedSource,
+    /extendExistingTtl\(\[CANONICAL_KEY[^\]]*\.\.\.COUNTRY_STOCK_INDEX_KEYS\]/,
+    'country keys must not gate the closed-market fast path',
+  );
+  assert.match(
+    seedSource,
+    /extendExistingTtlDetailed\(COUNTRY_STOCK_INDEX_KEYS, CACHE_TTL\)/,
+    'country keys must be extended best-effort via the detailed variant',
+  );
+});
+
+test('health.js tracks the country-index seed with a floor below the measured success rate', () => {
+  const entry = healthSource.match(
+    /countryStockIndexes:\s*\{\s*key:\s*'seed-meta:market:country-indexes',\s*maxStaleMin:\s*(\d+),\s*minRecordCount:\s*(\d+)\s*\}/,
+  );
+  assert.ok(entry, 'the country-index seed must be registered in the health source registry');
+
+  const maxStaleMin = Number(entry[1]);
+  const minRecordCount = Number(entry[2]);
+
+  assert.equal(maxStaleMin, 30, 'should mirror the market:stocks staleness budget it shares a cron with');
+  // Measured 2026-08-05: 37/45 symbols return usable closes. The floor must sit
+  // below that (or it alarms permanently on the eight known-dead symbols) and
+  // above zero (or a total seeding failure stays green).
+  assert.ok(minRecordCount > 0, 'a zero floor would let a total seeding failure report healthy');
+  assert.ok(minRecordCount < 37, 'a floor at or above the measured success rate would alarm permanently');
+});

--- a/tests/country-stock-index-seed-all.test.mts
+++ b/tests/country-stock-index-seed-all.test.mts
@@ -1,0 +1,117 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// #6235: the country-index RPC took its Railway-seeded snapshot only for CN.
+// The input is a bounded 45-country enum, so all 45 are seedable; the other 44
+// were lazy-fetched from Yahoo at the edge with an in-memory-only fallback,
+// which means a cold isolate had no fallback at all.
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_ENV = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+function restoreEnvironment() {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_ENV.url == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_ENV.url;
+  if (ORIGINAL_ENV.token == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_ENV.token;
+}
+
+function seededSnapshot(code: string, symbol: string, indexName: string, currency: string) {
+  return {
+    available: true,
+    code,
+    symbol,
+    indexName,
+    price: 18234.5,
+    weekChangePercent: 0.82,
+    currency,
+    fetchedAt: '2026-08-05T06:00:00.000Z',
+  };
+}
+
+test('a seeded non-CN country index is served from Redis without touching Yahoo', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const requested: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    requested.push(url);
+    if (url.includes('/get/market%3Astock-index%3Av1%3ADE')) {
+      return new Response(JSON.stringify({
+        result: JSON.stringify(seededSnapshot('DE', '^GDAXI', 'DAX', 'EUR')),
+      }), { status: 200 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  }) as typeof fetch;
+
+  const { getCountryStockIndex } = await import('../server/worldmonitor/market/v1/get-country-stock-index.ts');
+  const result = await getCountryStockIndex({} as never, { countryCode: 'DE' } as never);
+
+  assert.equal(result.available, true);
+  assert.equal(result.code, 'DE');
+  assert.equal(result.price, 18234.5);
+  assert.deepEqual(
+    requested,
+    ['https://redis.example.test/get/market%3Astock-index%3Av1%3ADE'],
+    'a seeded country must not trigger a Yahoo fetch',
+  );
+});
+
+test('a seed row for the wrong country is rejected rather than served', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  let yahooCalls = 0;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/get/market%3Astock-index%3Av1%3AFR')) {
+      // Wrong code in the payload — a key/paylod mismatch must not be trusted.
+      return new Response(JSON.stringify({
+        result: JSON.stringify(seededSnapshot('DE', '^GDAXI', 'DAX', 'EUR')),
+      }), { status: 200 });
+    }
+    if (url.startsWith('https://query1.finance.yahoo.com/')) {
+      yahooCalls += 1;
+      return new Response(JSON.stringify({
+        chart: {
+          result: [{
+            meta: { currency: 'EUR' },
+            indicators: { quote: [{ close: [7600, 7620, 7650, 7680, 7700, 7710, 7725] }] },
+          }],
+        },
+      }), { status: 200 });
+    }
+    if (url.startsWith('https://redis.example.test/')) {
+      return new Response(JSON.stringify({ result: null }), { status: 200 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  }) as typeof fetch;
+
+  const { getCountryStockIndex } = await import('../server/worldmonitor/market/v1/get-country-stock-index.ts');
+  const result = await getCountryStockIndex({} as never, { countryCode: 'FR' } as never);
+
+  assert.equal(result.code, 'FR', 'a mismatched seed row must not leak another country’s index');
+  assert.equal(yahooCalls, 1, 'the handler must fall through to its own fetch instead');
+});
+
+test('every country in the public enum has a seedable index definition', async () => {
+  const contracts = (await import('../shared/openapi-filter-param-contracts.json', {
+    with: { type: 'json' },
+  })).default as { marketCountryStockIndexes: Record<string, { symbol: string; name: string }> };
+
+  const entries = Object.entries(contracts.marketCountryStockIndexes);
+  assert.ok(entries.length >= 45, `expected the full country enum, got ${entries.length}`);
+
+  for (const [code, index] of entries) {
+    assert.match(code, /^[A-Z]{2}$/, `${code} must be an ISO-3166 alpha-2 code`);
+    assert.ok(index.symbol && index.symbol.trim(), `${code} must declare a Yahoo symbol`);
+    assert.ok(index.name && index.name.trim(), `${code} must declare an index name`);
+  }
+});

--- a/tests/fwdstart-cache.test.mjs
+++ b/tests/fwdstart-cache.test.mjs
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// #6235: /api/fwdstart scrapes one fixed URL on every CDN miss with no Redis
+// tier — a fixed-input request-time fetch, which the gold standard says should
+// be persisted rather than re-scraped.
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_ENV = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+function restoreEnvironment() {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_ENV.url == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_ENV.url;
+  if (ORIGINAL_ENV.token == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_ENV.token;
+}
+
+const ARCHIVE_HTML = `
+<div class="embla__slide">
+  <a href="/p/first-post"></a>
+  <img alt="The First Post Title" />
+  <span>Jan 12, 2026</span>
+</div>
+<div class="embla__slide">
+  <a href="/p/second-post"></a>
+  <img alt="The Second Post Title" />
+  <span>Feb 03, 2026</span>
+</div>
+`;
+
+function installStub({ redisAvailable = true } = {}) {
+  const store = new Map();
+  const scrapeCalls = [];
+
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.startsWith('https://redis.example.test/get/')) {
+      if (!redisAvailable) return new Response('nope', { status: 500 });
+      const key = decodeURIComponent(url.slice('https://redis.example.test/get/'.length));
+      return new Response(JSON.stringify({ result: store.get(key) ?? null }), { status: 200 });
+    }
+    if (url === 'https://redis.example.test/pipeline') {
+      if (!redisAvailable) return new Response('nope', { status: 500 });
+      const cmds = JSON.parse(String(init?.body));
+      for (const cmd of cmds) if (cmd[0] === 'SET') store.set(cmd[1], cmd[2]);
+      return new Response(JSON.stringify(cmds.map(() => ({ result: 'OK' }))), { status: 200 });
+    }
+    if (url.startsWith('https://www.fwdstart.me/')) {
+      scrapeCalls.push(url);
+      return new Response(ARCHIVE_HTML, { status: 200 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  };
+
+  return { scrapeCalls, store };
+}
+
+const request = () => new Request('https://worldmonitor.app/api/fwdstart');
+
+test('repeat fwdstart requests are served from Redis, not re-scraped', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const { scrapeCalls } = installStub();
+  const { default: handler } = await import('../api/fwdstart.js');
+
+  const first = await handler(request(), undefined);
+  const firstBody = await first.text();
+  assert.equal(first.status, 200);
+  assert.match(firstBody, /The First Post Title/);
+  assert.equal(scrapeCalls.length, 1, 'first request must scrape upstream');
+
+  const second = await handler(request(), undefined);
+  const secondBody = await second.text();
+  assert.equal(second.status, 200);
+  assert.match(secondBody, /The First Post Title/);
+  assert.match(secondBody, /The Second Post Title/);
+  assert.equal(scrapeCalls.length, 1, 'second request must be served from Redis');
+});
+
+test('a Redis outage still serves the feed', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const { scrapeCalls } = installStub({ redisAvailable: false });
+  const { default: handler } = await import('../api/fwdstart.js');
+
+  const res = await handler(request(), undefined);
+  assert.equal(res.status, 200, 'Redis being down must not break the feed');
+  assert.match(await res.text(), /The First Post Title/);
+  assert.equal(scrapeCalls.length, 1);
+});
+
+test('an upstream failure with no cache still returns 502, not a fake empty feed', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const store = new Map();
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.startsWith('https://redis.example.test/get/')) {
+      return new Response(JSON.stringify({ result: null }), { status: 200 });
+    }
+    if (url === 'https://redis.example.test/pipeline') {
+      const cmds = JSON.parse(String(init?.body));
+      for (const cmd of cmds) if (cmd[0] === 'SET') store.set(cmd[1], cmd[2]);
+      return new Response(JSON.stringify(cmds.map(() => ({ result: 'OK' }))), { status: 200 });
+    }
+    if (url.startsWith('https://www.fwdstart.me/')) return new Response('down', { status: 503 });
+    throw new Error(`unexpected request: ${url}`);
+  };
+
+  const { default: handler } = await import('../api/fwdstart.js');
+  const res = await handler(request(), undefined);
+  assert.equal(res.status, 502, 'a scrape failure with no cached items must not look like an empty feed');
+  assert.equal(store.size, 0, 'a failed scrape must not write anything to the cache');
+});
+
+test('an empty extraction is not cached, so a broken parser cannot persist a hollow feed', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const store = new Map();
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.startsWith('https://redis.example.test/get/')) {
+      return new Response(JSON.stringify({ result: null }), { status: 200 });
+    }
+    if (url === 'https://redis.example.test/pipeline') {
+      const cmds = JSON.parse(String(init?.body));
+      for (const cmd of cmds) if (cmd[0] === 'SET') store.set(cmd[1], cmd[2]);
+      return new Response(JSON.stringify(cmds.map(() => ({ result: 'OK' }))), { status: 200 });
+    }
+    // 200 OK but markup the parser no longer understands.
+    if (url.startsWith('https://www.fwdstart.me/')) return new Response('<div>redesigned</div>', { status: 200 });
+    throw new Error(`unexpected request: ${url}`);
+  };
+
+  const { default: handler } = await import('../api/fwdstart.js');
+  await handler(request(), undefined);
+  assert.equal(store.size, 0, 'a zero-item extraction must not be persisted');
+});

--- a/tests/github-release-cache.test.mjs
+++ b/tests/github-release-cache.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// #6235: fetchLatestRelease always requests the same URL but had no Redis
+// layer at all — only a CDN s-maxage on /api/version and /api/download. GitHub's
+// unauthenticated API allows 60 req/hr per IP, so a CDN miss storm fails both
+// public routes closed.
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_ENV = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+function restoreEnvironment() {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_ENV.url == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_ENV.url;
+  if (ORIGINAL_ENV.token == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_ENV.token;
+}
+
+const RELEASE = { tag_name: 'v2.4.0', html_url: 'https://example.test/r/v2.4.0', prerelease: false };
+
+function installStub({ redisAvailable = true } = {}) {
+  const store = new Map();
+  const githubCalls = [];
+
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+
+    if (url.startsWith('https://redis.example.test/get/')) {
+      if (!redisAvailable) return new Response('nope', { status: 500 });
+      const key = decodeURIComponent(url.slice('https://redis.example.test/get/'.length));
+      return new Response(JSON.stringify({ result: store.get(key) ?? null }), { status: 200 });
+    }
+    if (url === 'https://redis.example.test/pipeline') {
+      if (!redisAvailable) return new Response('nope', { status: 500 });
+      const cmds = JSON.parse(String(init?.body));
+      for (const cmd of cmds) if (cmd[0] === 'SET') store.set(cmd[1], cmd[2]);
+      return new Response(JSON.stringify(cmds.map(() => ({ result: 'OK' }))), { status: 200 });
+    }
+    if (url.startsWith('https://api.github.com/')) {
+      githubCalls.push(url);
+      return new Response(JSON.stringify(RELEASE), { status: 200 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  };
+
+  return { githubCalls, store };
+}
+
+test('repeat release lookups are served from Redis, not re-fetched from GitHub', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const { githubCalls } = installStub();
+  const { fetchLatestRelease } = await import('../api/_github-release.js');
+
+  const first = await fetchLatestRelease('WorldMonitor-Version-Check');
+  assert.equal(first.tag_name, 'v2.4.0');
+  assert.equal(githubCalls.length, 1, 'first call must reach GitHub');
+
+  const second = await fetchLatestRelease('WorldMonitor-Version-Check');
+  assert.deepEqual(second, first, 'cached release must match the fresh one');
+  assert.equal(githubCalls.length, 1, 'second call must be served from Redis');
+});
+
+test('a Redis outage still serves the release (fail-open on version metadata)', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const { githubCalls } = installStub({ redisAvailable: false });
+  const { fetchLatestRelease } = await import('../api/_github-release.js');
+
+  const result = await fetchLatestRelease('WorldMonitor-Version-Check');
+  assert.equal(result.tag_name, 'v2.4.0', 'Redis being down must not break /api/version');
+  assert.equal(githubCalls.length, 1);
+});
+
+test('an unconfigured Redis still serves the release', async (t) => {
+  t.after(restoreEnvironment);
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  const { githubCalls } = installStub();
+  const { fetchLatestRelease } = await import('../api/_github-release.js');
+
+  const result = await fetchLatestRelease('WorldMonitor-Version-Check');
+  assert.equal(result.tag_name, 'v2.4.0');
+  assert.equal(githubCalls.length, 1);
+});

--- a/tests/sanctions-lookup-entity-cache.test.mts
+++ b/tests/sanctions-lookup-entity-cache.test.mts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+// #6235: LookupSanctionEntity was the only uncached third-party fetch in the
+// server tree — every request re-hit api.opensanctions.org. Sanctioned-entity
+// lookups cluster hard on repeat queries, so an uncached proxy multiplies
+// upstream load for no benefit and leaves the route one outage away from the
+// narrower OFAC-only fallback.
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_ENV = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+function restoreEnvironment() {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_ENV.url == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_ENV.url;
+  if (ORIGINAL_ENV.token == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_ENV.token;
+}
+
+const OPENSANCTIONS_PAYLOAD = {
+  results: [
+    {
+      id: 'NK-abc123',
+      schema: 'Person',
+      caption: 'Test Person',
+      properties: { name: ['Test Person'], country: ['ru'], program: ['SDN'] },
+    },
+  ],
+  total: { value: 1 },
+};
+
+/**
+ * Minimal in-memory Upstash stub: serves GET from a Map that POST /SET fills,
+ * so the second handler call sees whatever the first one persisted.
+ */
+function installRedisBackedStub() {
+  const store = new Map<string, string>();
+  const upstreamCalls: string[] = [];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+
+    if (url.startsWith('https://redis.example.test/get/')) {
+      const key = decodeURIComponent(url.slice('https://redis.example.test/get/'.length));
+      const hit = store.get(key);
+      return new Response(JSON.stringify({ result: hit ?? null }), { status: 200 });
+    }
+
+    if (url === 'https://redis.example.test/') {
+      const cmd = JSON.parse(String(init?.body)) as string[];
+      if (cmd[0] === 'SET') store.set(cmd[1]!, cmd[2]!);
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    }
+
+    if (url.startsWith('https://api.opensanctions.org/')) {
+      upstreamCalls.push(url);
+      return new Response(JSON.stringify(OPENSANCTIONS_PAYLOAD), { status: 200 });
+    }
+
+    throw new Error(`unexpected request: ${url}`);
+  }) as typeof fetch;
+
+  return { upstreamCalls, store };
+}
+
+test('repeat OpenSanctions lookup is served from Redis, not re-fetched upstream', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const { upstreamCalls } = installRedisBackedStub();
+  const { lookupSanctionEntity } = await import('../server/worldmonitor/sanctions/v1/lookup-entity.ts');
+
+  const first = await lookupSanctionEntity({} as never, { q: 'Test Person', maxResults: 10 } as never);
+  assert.equal(first.source, 'opensanctions');
+  assert.equal(first.results.length, 1);
+  assert.equal(upstreamCalls.length, 1, 'first lookup must reach upstream');
+
+  const second = await lookupSanctionEntity({} as never, { q: 'Test Person', maxResults: 10 } as never);
+  assert.equal(second.source, 'opensanctions');
+  assert.deepEqual(second.results, first.results, 'cached payload must match the fresh one');
+  assert.equal(
+    upstreamCalls.length,
+    1,
+    'second identical lookup must be served from Redis without re-hitting OpenSanctions',
+  );
+});
+
+test('lookup cache key normalizes case and surrounding whitespace', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const { upstreamCalls } = installRedisBackedStub();
+  const { lookupSanctionEntity } = await import('../server/worldmonitor/sanctions/v1/lookup-entity.ts');
+
+  await lookupSanctionEntity({} as never, { q: 'Test Person', maxResults: 10 } as never);
+  await lookupSanctionEntity({} as never, { q: '  TEST person  ', maxResults: 10 } as never);
+
+  assert.equal(
+    upstreamCalls.length,
+    1,
+    'case/whitespace variants of one query must share a cache entry',
+  );
+});
+
+test('an OpenSanctions outage falls back to OFAC without persisting a negative sentinel', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const store = new Map<string, string>();
+  const ofacIndex = [{ id: 'ofac:1', name: 'Test Person', et: 'individual', cc: ['RU'], pr: ['SDN'] }];
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.startsWith('https://redis.example.test/get/')) {
+      const key = decodeURIComponent(url.slice('https://redis.example.test/get/'.length));
+      if (key === 'sanctions:entities:v1') {
+        return new Response(JSON.stringify({ result: JSON.stringify(ofacIndex) }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ result: store.get(key) ?? null }), { status: 200 });
+    }
+    if (url === 'https://redis.example.test/') {
+      const cmd = JSON.parse(String(init?.body)) as string[];
+      if (cmd[0] === 'SET') store.set(cmd[1]!, cmd[2]!);
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    }
+    if (url.startsWith('https://api.opensanctions.org/')) {
+      return new Response('upstream down', { status: 503 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  }) as typeof fetch;
+
+  const { lookupSanctionEntity } = await import('../server/worldmonitor/sanctions/v1/lookup-entity.ts');
+  const result = await lookupSanctionEntity({} as never, { q: 'Test Person', maxResults: 10 } as never);
+
+  assert.equal(result.source, 'ofac', 'a 503 must degrade to the seeded OFAC index');
+  assert.equal(result.results.length, 1);
+
+  const lookupKeys = [...store.keys()].filter(k => k.includes('sanctions:lookup:'));
+  assert.deepEqual(
+    lookupKeys,
+    [],
+    'an availability failure must not persist a sentinel that pins later callers to OFAC',
+  );
+});
+
+test('a different maxResults does not serve a short cached result', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  const { upstreamCalls } = installRedisBackedStub();
+  const { lookupSanctionEntity } = await import('../server/worldmonitor/sanctions/v1/lookup-entity.ts');
+
+  await lookupSanctionEntity({} as never, { q: 'Test Person', maxResults: 5 } as never);
+  await lookupSanctionEntity({} as never, { q: 'Test Person', maxResults: 50 } as never);
+
+  assert.equal(
+    upstreamCalls.length,
+    2,
+    'a wider maxResults must not be answered from a narrower cached response',
+  );
+});


### PR DESCRIPTION
Closes #6235.

A sweep of every request-time external fetch across `server/` and `api/` found four sites where the
input space is fixed or bounded — so the fetch *could* be cached or seeded — but wasn't. Every other
live external fetch in the tree is either already edge-cached or takes genuinely unbounded user input
(arbitrary ticker / bbox / free-text query), which cannot be pre-seeded and is served by the
documented provider-proxy tier.

## What changed

**1. `sanctions/v1/lookup-entity` — the only uncached third-party fetch in the server tree**

Every request hit `api.opensanctions.org` live. Now cached for 1h on a case/whitespace-normalized
query key. `maxResults` stays in the key so a narrow cached response is never replayed to a caller
asking for a wider one.

`searchOpenSanctions` now throws on a non-OK response instead of returning null, and the call passes
`cacheFetcherErrors: false`. Together those keep an availability failure out of the cache — otherwise
one blip would persist a negative sentinel and pin every later caller to the OFAC-only fallback,
which is a materially narrower dataset (`seed-sanctions-pressure.mjs` covers US Treasury only).

**2. `market/v1/get-country-stock-index` — 1 of 45 countries was seeded**

The RPC answers a bounded 45-country enum, but only CN was seeded; the other 44 lazy-fetched Yahoo at
the edge with an in-memory-only stale fallback, so a cold Vercel isolate had no fallback at all.

- `seed-market-quotes.mjs` now seeds all 45, best-effort and independently: one country's provider
  failure preserves its own last-good TTL and does not cost the other 44 their refresh, and the pass
  logs a `seeded/total` summary instead of throwing.
- The handler reads the seeded key for any country, not just CN. The live fetch stays as a gap-filler
  for countries whose seed leg failed.
- A seed row whose payload `code` disagrees with the key it was read from is rejected rather than
  served — that would answer one country's request with another country's index.
- The work-list is derived from `shared/openapi-filter-param-contracts.json`, the same file the RPC
  validates against, so the two cannot drift.

**3. `api/_github-release` — fixed URL, no Redis tier**

Backed the public `/api/version` and `/api/download` with only a CDN `s-maxage`, so every CDN miss
spent one of GitHub's 60/hr unauthenticated requests. Cached for 300s — matching the `s-maxage` the
callers already advertise, so no client observes staler data than before.

**4. `api/fwdstart` — fixed-URL scrape, CDN-only**

Caches the parsed items rather than the rendered RSS, whose `lastBuildDate` must stay current. A
zero-item extraction is never cached, so an upstream markup change cannot persist a hollow feed for
the full TTL.

In both 3 and 4 Redis is a load shield, not a dependency — each keeps serving when the cache is down
or unconfigured.

## Verification

- 4 new suites (22 tests) plus the updated CN wiring guard; every new assertion was confirmed red
  before the fix.
- **Mutation-tested** each new guard: `cacheFetcherErrors: false` → `true`, the fwdstart
  `items.length > 0` guard → `true`, and the seed-row country match → always-true. All three mutants
  were caught by the intended test.
- 615 tests green across every changed module (market, seed, sanctions, api, gateway, relay,
  packaging suites).
- `npm run typecheck`, `npm run typecheck:api`, and `biome check` clean.
- The 45-country work-list verified to load at runtime with CN present and unique codes.

## Deliberate trade-offs

- The seeder adds ~44 Yahoo chart fetches at the existing 200ms spacing (~20s to a cron that already
  fetches 59 symbols). Best-effort per country keeps a Yahoo hiccup from failing the whole market
  seed.
- OpenSanctions at 1h: designations are published by regulators daily at most, so the reuse window is
  well inside any reasonable freshness expectation.

Not addressed here (filed separately): #6234 unmetered public proxies, #6236 fail-closed rate-limit
registry gap, #6237 dead-fetcher clusters.

https://claude.ai/code/session_015HnBAZ8C4e8b6uoUUN7k41
