### PR TITLE
fix(military): one global OpenSky query per run — 86% → 43% of the daily credit quota (#6222)

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -334,13 +334,29 @@ Distinct from a *missing* translation, which has no value at all, and from an *o
 
 An aggregated military-activity assessment for a named geographic theater, derived from live military flights and tracked naval vessels inside the theater's bounds and published as a posture level per theater.
 
-Theater posture has two independent producers on different schedules — a loop inside the AIS relay and the military-flights seeder — and each acquires flights through its own ordered source chain, falling from its primary source to alternates when a tier fails or returns nothing. A cycle that publishes through an alternate source is still a healthy publication; what it must never be read as is recovery of the primary source. See also: Publication Source.
+Theater posture has two independent producers on different schedules — a loop inside the AIS relay and the military-flights seeder — and each acquires flights from its own ordered list of sources. Ordering a source list is not the same as gating it: only one producer treats its list as a true cascade, entering a lower tier solely when the tier above it failed; the other queries its lower tiers unconditionally and merges whatever they return, so a metered tier there is billed on every cycle regardless of whether the primary already succeeded (see Ungated Tier). A cycle that publishes through an alternate source is still a healthy publication; what it must never be read as is recovery of the primary source. See also: Publication Source, Ungated Tier.
 
 ### Publication Source
 
 The upstream that actually fed a published theater-posture cycle, recorded with the publication rather than inferred from which sources are configured.
 
 Each cycle attributes exactly one winning source (or a vessels-only outcome when no flight source contributed), and per-source cycle counts accumulate for the life of the producer process. The attribution answers "who fed this record", not "which sources are healthy" — a primary source that answered healthily with zero relevant traffic is a quiet primary, not a failed one, and its health is judged from its own request counters, never from the attribution. Because the two Theater Posture producers use different vocabularies for their sources, every attribution also names its producer. See also: Theater Posture.
+
+## Metered Upstreams
+
+### Credit Budget
+
+An upstream's allowance of request cost per refill period, spent down by every caller sharing the account rather than by each caller independently. Its defining property is that depletion and burst-throttling both surface as the same rejection status, while demanding opposite remediations: a depleted budget is fixed by spending less per period and is unaffected by waiting or by spacing requests, whereas a burst throttle is fixed by spacing alone and needs no reduction in total volume. The two are told apart by the wait the provider itself advertises on the rejection — a wait on the order of the refill period means the budget is gone, a wait on the order of seconds means the request rate is too high. Application-side counters cannot make this distinction, because they observe rejections rather than the balance; establishing which one is in play requires probing the provider directly with the production credentials and reading its own balance and retry headers. See also: Cost Tier, Ungated Tier.
+
+### Cost Tier
+
+The band a request falls into under an upstream's cost function, where cost is a step function of a request parameter rather than a smooth function of the data returned. The consequential case is the **flat top tier**: past some threshold the cost stops rising, so every request above that threshold — including the widest request the endpoint accepts — is billed identically. Where a top tier is flat, splitting one broad request into several narrower ones that each still exceed the threshold multiplies cost while reducing coverage, and the usual "ask for less to pay less" intuition inverts. Determining the tier boundaries before sizing a request is therefore a correctness step, not an optimization: a parameter tuned without reference to them can be adjusted at length with no effect on spend. See also: Credit Budget.
+
+### Ungated Tier
+
+A source in an ordered chain that is queried regardless of whether an earlier source already succeeded, as distinct from a fallback entered only on the failure of the tier above it. The condition is not observable from published data — the publication is fresh and correctly attributed to the primary either way — so it must be looked for in the call path rather than inferred from output.
+
+Whether it is a defect depends on what the tier does with its results. A tier whose results *replace* the primary's adds nothing when the primary succeeded, so on a metered upstream it spends budget for no marginal records and should be gated. A tier whose results *merge* into the primary's is contributing coverage, and gating it trades that coverage away — dangerously so, because a degraded-but-non-empty primary satisfies a success-gate and suppresses the merging tier precisely when its coverage matters most. For a merging tier the correct remedy is to reduce its cost rather than to stop calling it. See also: Credit Budget, Cost Tier, Theater Posture, Publication Source.
 
 ## Desktop Distribution
 

--- a/docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md
+++ b/docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md
@@ -29,10 +29,12 @@ tags:
 
 # OpenSky bills /states/all by bbox AREA with a flat top tier — two big regional boxes cost double a global query and cover less
 
-> **Status: verified diagnosis, fix pending.** The root cause below is proven against
-> production; the remediation is filed as #6222 (quota) and #6224 (keyless ADS-B
-> redundancy) and is **not** merged as of this writing. Every `file:line` citation
-> points at the current, still-unfixed tree.
+> **Status: fixed in #6244 (closes #6222).** Root cause proven against production;
+> remediation is one global `/states/all` per seeder/relay cycle (flat top tier = 4
+> credits), drop anonymous fallbacks, and global `LIVE_SEED_COVERAGE`. #6224 (keyless
+> ADS-B redundancy) remains separate. Historical `file:line` citations below describe
+> the pre-fix tree; post-fix call sites are `fetchOpenSkyAuthenticated` /
+> `fetchOpenSkyGlobal` (seeder) and `fetchTheaterFlightsFromOpenSky` (relay).
 
 ## Problem
 
@@ -144,7 +146,7 @@ for (const region of QUERY_REGIONS) {
 relay's own `seedTheaterPosture()` cascade (`ais-relay.cjs:4517-4537`) gets this right —
 adsb.lol first, Wingbits next, OpenSky only if both fail. The seeder never adopted it.
 
-### The fix (filed, unmerged)
+### The fix (landed in #6244)
 
 1. Collapse both region loops to **one global `/states/all`** — 8 credits → 4 per run, and
    coverage goes from two boxes to the planet. Filter military hex/callsign client-side as today.

--- a/docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md
+++ b/docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md
@@ -68,6 +68,26 @@ and a permanently rate-limited account, not a broken panel.
 
 ## Solution
 
+### The 4-credit global query, measured
+
+One global `/states/all?extended=1`, issued 2026-08-05 against the anonymous tier from a
+residential IP (a separate 400/day-per-IP pool, so it cost production nothing):
+
+```
+HTTP 200   X-Rate-Limit-Remaining: 396      <- 400 - 4: the flat top tier, confirmed live
+7,680 state vectors | 0.96 MB | 4.11 s wall clock
+```
+
+Two things worth keeping. First, the **4-credit price is confirmed empirically**, not just
+from the docs — a global query debited exactly 4 from a fresh 400. Second, the response is
+far smaller than a "whole planet" query sounds: **0.96 MB in 4.11 s**, which is 27% of the
+seeder's 15s `fetchJsonDirect` budget with 10.9s of headroom. Collapsing regional bboxes into
+a global query is not a payload-size trade.
+
+Measuring this needed no production credentials and no deploy. When an account is quota-locked,
+the anonymous per-IP tier from a developer machine still answers the shape questions — only
+the account-specific questions require the real credentials.
+
 ### The billing rule that makes this a bug
 
 `/states/all` is priced by **bounding-box area**, and the top tier is **flat**

--- a/docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md
+++ b/docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md
@@ -29,12 +29,10 @@ tags:
 
 # OpenSky bills /states/all by bbox AREA with a flat top tier — two big regional boxes cost double a global query and cover less
 
-> **Status: fixed in #6244 (closes #6222).** Root cause proven against production;
-> remediation is one global `/states/all` per seeder/relay cycle (flat top tier = 4
-> credits), drop anonymous fallbacks, and global `LIVE_SEED_COVERAGE`. #6224 (keyless
-> ADS-B redundancy) remains separate. Historical `file:line` citations below describe
-> the pre-fix tree; post-fix call sites are `fetchOpenSkyAuthenticated` /
-> `fetchOpenSkyGlobal` (seeder) and `fetchTheaterFlightsFromOpenSky` (relay).
+> **Status: verified diagnosis, fix pending.** The root cause below is proven against
+> production; the remediation is filed as #6222 (quota) and #6224 (keyless ADS-B
+> redundancy) and is **not** merged as of this writing. Every `file:line` citation
+> points at the current, still-unfixed tree.
 
 ## Problem
 
@@ -146,7 +144,7 @@ for (const region of QUERY_REGIONS) {
 relay's own `seedTheaterPosture()` cascade (`ais-relay.cjs:4517-4537`) gets this right —
 adsb.lol first, Wingbits next, OpenSky only if both fail. The seeder never adopted it.
 
-### The fix (landed in #6244)
+### The fix (filed, unmerged)
 
 1. Collapse both region loops to **one global `/states/all`** — 8 credits → 4 per run, and
    coverage goes from two boxes to the planet. Filter military hex/callsign client-side as today.

--- a/docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md
+++ b/docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md
@@ -1,0 +1,215 @@
+---
+title: "OpenSky bills /states/all by bbox AREA with a flat top tier — two big regional boxes cost double a global query and cover less"
+module: military-flights
+date: 2026-08-05
+category: integration-issues
+problem_type: integration_issue
+component: background_job
+severity: high
+symptoms:
+  - "OpenSky /states/all returns HTTP 429 with X-Rate-Limit-Retry-After-Seconds ~22688 (~6.3h) for the authenticated production client"
+  - "seed-meta:theater-posture reports sourceVersion: wingbits with fresh data while OpenSky contributes nothing — the quota burn is silent"
+  - "Military aircraft outside the two hardcoded query regions (Americas, Australia, most of Africa) never appear at any price"
+root_cause: wrong_api
+resolution_type: code_fix
+related_components:
+  - service_object
+tags:
+  - opensky
+  - rate-limit
+  - "429"
+  - quota
+  - api-credits
+  - bounding-box
+  - adsb
+  - seeder
+  - wingbits
+  - fallback-cascade
+---
+
+# OpenSky bills /states/all by bbox AREA with a flat top tier — two big regional boxes cost double a global query and cover less
+
+> **Status: verified diagnosis, fix pending.** The root cause below is proven against
+> production; the remediation is filed as #6222 (quota) and #6224 (keyless ADS-B
+> redundancy) and is **not** merged as of this writing. Every `file:line` citation
+> points at the current, still-unfixed tree.
+
+## Problem
+
+WorldMonitor's authenticated OpenSky account exhausts its entire 4,000 credit/day quota
+every day, so `/states/all` returns `429` for most of each day. The burn is invisible in
+normal operation because Wingbits carries the flight surface — the cost is a dead fallback
+and a permanently rate-limited account, not a broken panel.
+
+## Symptoms
+
+- Authenticating with the production `OPENSKY_CLIENT_ID` and issuing the *cheapest possible*
+  query returns `429` with `X-Rate-Limit-Retry-After-Seconds = 22688` (~6.3 hours).
+- `military:flights:v1` stays fresh (age 0.2 min) with `sourceVersion: "wingbits"` — nothing
+  in the health surface indicates OpenSky is dead.
+- Aircraft outside the two hardcoded regions are simply absent; measured against
+  `api.adsb.lol/v2/mil`, **50 of 133 positioned military aircraft (38%) fall outside them**.
+
+## What Didn't Work
+
+- **Inferring quota state from logs.** The relay tracks `openskyThrottle`, `openskyGlobal429Until`,
+  and `openskyRateLimitRemaining` (`scripts/ais-relay.cjs:8571-8579`), and the seeder has a
+  full auth-retry ladder with cooldown (`scripts/seed-military-flights.mjs:583-653`). None of
+  that distinguishes *"we hit a burst limit"* from *"we spent the day's credits."* The
+  existing 90s default cooldown (`ais-relay.cjs:8572`) is sized for the former and is
+  meaningless against the latter.
+- **Assuming smaller bounding boxes are cheaper.** They are — but only below 400 sq°. Both
+  configured regions are far above that threshold, so shrinking them changes nothing until
+  they cross a tier boundary.
+- **Assuming an anonymous fallback provides cover.** `seed-military-flights.mjs:744-746` and
+  `server/worldmonitor/aviation/v1/track-aircraft.ts:161` fall back to unauthenticated
+  OpenSky. Anonymous is 400 credits/day *per IP* on shared Railway/Vercel egress — it can
+  essentially never succeed and only adds a full timeout to every failure path.
+
+## Solution
+
+### The billing rule that makes this a bug
+
+`/states/all` is priced by **bounding-box area**, and the top tier is **flat**
+([upstream docs](https://openskynetwork.github.io/opensky-api/rest.html),
+[source](https://github.com/openskynetwork/opensky-api/blob/master/docs/free/rest.rst)):
+
+| bbox area | credits |
+|---|---|
+| ≤ 25 sq° or serial-only | 1 |
+| 25 – 100 sq° | 2 |
+| 100 – 400 sq° | 3 |
+| **> 400 sq° _or global_** | **4** |
+
+Quotas are **per endpoint** (states / tracks / flights each hold their own):
+anonymous 400/day · registered 4,000/day · active feeder (≥30% uptime/month) 8,000/day ·
+licensed 14,400/hour.
+
+**Any bbox above 400 sq° costs exactly what the whole planet costs.** So N large regional
+boxes cost N×4 while one global call costs 4 and strictly dominates on coverage.
+
+### Where the 4,000 goes
+
+`scripts/seed-military-flights.mjs:46-49` (cron `*/5`, 288 runs/day):
+
+```js
+const QUERY_REGIONS = [
+  { name: 'PACIFIC', lamin: 10, lamax: 46, lomin: 107, lomax: 143 },  // 36x36 = 1,296 sq° -> 4 credits
+  { name: 'WESTERN', lamin: 13, lamax: 85, lomin: -10, lomax:  57 },  // 72x67 = 4,824 sq° -> 4 credits
+];
+```
+
+`scripts/ais-relay.cjs:4049-4052` (theater-posture loop, 10 min, 144 runs/day) repeats the
+mistake with a second pair of oversized boxes (3,192 and 1,160 sq° — 4 credits each).
+
+| Consumer | Runs/day | Credits/run | Credits/day |
+|---|---|---|---|
+| `seed-military-flights.mjs` | 288 | 8 | **2,304** |
+| `ais-relay.cjs` theater posture | 144 | 8 | **1,152** |
+
+**3,456 of 4,000 (86%) is spent before a single user loads the map.** Per-viewer fallthrough
+in `list-military-flights.ts` and `track-aircraft.ts` finishes it.
+
+### The second, independent defect
+
+`scripts/seed-military-flights.mjs:892-894` runs the OpenSky loop **unconditionally**:
+
+```js
+for (const region of QUERY_REGIONS) {
+  await fetchOpenSkyRegion(region, { source, fetchSources, seenIds, allStates });
+}
+```
+
+`fetchWingbits()` runs first at `:876`, but its success does not short-circuit the loop. The
+relay's own `seedTheaterPosture()` cascade (`ais-relay.cjs:4517-4537`) gets this right —
+adsb.lol first, Wingbits next, OpenSky only if both fail. The seeder never adopted it.
+
+### The fix (filed, unmerged)
+
+1. Collapse both region loops to **one global `/states/all`** — 8 credits → 4 per run, and
+   coverage goes from two boxes to the planet. Filter military hex/callsign client-side as today.
+   **This step alone is sufficient**: 4×288 + 4×144 = 1,728/day, or 43% of quota, down from 86%.
+2. Delete both anonymous fallback paths — they cannot succeed and cost a timeout each.
+3. Optional: an ADS-B receiver at ≥30% monthly uptime doubles the quota to 8,000/day.
+
+**Gating OpenSky behind Wingbits success is deliberately _not_ recommended, despite being the
+obvious fix for the Ungated Tier defect.** Step 1 removes the budget pressure that motivated
+it, and gating carries a coverage cost that the budget no longer forces us to pay — see the
+caution below.
+
+### Why not simply gate the ungated tier
+
+The seeder merges OpenSky states into the result set additively, deduped by `icao24`
+(`scripts/seed-military-flights.mjs:877-882` for the Wingbits half of the same merge). So
+OpenSky is not pure waste in normal operation: it contributes aircraft Wingbits did not see.
+Gating it behind Wingbits *failure* would delete that contribution, and it fails in the exact
+way [`deduping-redundant-work-removes-the-recovery-it-was-accidentally-providing.md`](../design-patterns/deduping-redundant-work-removes-the-recovery-it-was-accidentally-providing.md)
+documents: a **degraded-but-non-empty** primary satisfies the gate. Wingbits returning a
+partial set would suppress OpenSky entirely, and the publication would look healthy because
+it is non-empty and correctly attributed.
+
+The right question from that doc — *"what would break if this ran exactly once?"* — has a real
+answer here, so the correct move is to fix the cost (step 1) and leave the redundancy in place.
+An Ungated Tier is only a defect when the tier adds nothing; here it adds coverage and, once
+the tier costs 4 credits instead of 8, the budget affords it.
+
+**The contribution is already instrumented — measure it rather than arguing about it.**
+`fetchOpenSkyRegion` receives the shared `seenIds`/`allStates` (`scripts/seed-military-flights.mjs:716`),
+dedupes and appends (`:767-769`), and then logs the net-new count per region:
+
+```js
+if (added > 0) console.log(`  [OpenSky] +${added} new from ${region.name} (total: ${allStates.length})`);
+```
+
+(`scripts/seed-military-flights.mjs:773`.) That line is the empirical answer to "what is this
+tier worth": pull `+N new` across a day of seeder logs once the quota is restored, and the
+merge's marginal value stops being a matter of opinion. Do that before entertaining any
+gating proposal — and note that while the account is quota-exhausted the number reads zero for
+reasons that have nothing to do with the merge's value.
+
+## Why This Works
+
+The billing tier is flat above 400 sq°, so the marginal cost of widening a large box to the
+whole globe is **zero**. Paying 8 credits for two boxes that exclude the Americas is strictly
+dominated by paying 4 for everything. This is counter-intuitive precisely because every other
+metered API in the fleet charges *more* for *more* data — here, past one threshold, it does not.
+
+The unconditional call is a separate axis: a metered upstream invoked behind an already-successful
+primary produces no marginal data but full marginal cost. It stays invisible because the
+publication is healthy and correctly attributed to the primary — the very attribution that
+`ais-relay.cjs:4500-4510` exists to provide (added for #5945) is what makes the waste silent.
+
+## Prevention
+
+- **Read the upstream's cost function before sizing a request, not after.** For any metered
+  API, find the tier table and check whether the parameter you are tuning actually crosses a
+  boundary. A "smaller = cheaper" intuition is wrong wherever billing is tiered and flat-topped.
+- **Notice when a metered upstream runs behind an already-successful primary — then ask what it
+  contributes before gating it.** The condition is invisible from output (the publication is
+  fresh and correctly attributed either way), so it has to be looked for deliberately. But the
+  remedy is not automatically a gate: if the tier's results *merge* into the primary's rather
+  than replacing them, gating deletes coverage, and a degraded-but-non-empty primary will
+  satisfy the gate and suppress the tier exactly when it is most needed. Establish which shape
+  it is first — replacing tier (gate it) or merging tier (make it cheaper and keep it).
+- **Probe the provider directly to establish quota state; do not infer it from your own logs.**
+  Authenticate with the production credentials, issue the cheapest possible request, and read
+  the provider's own headers. For OpenSky, `X-Rate-Limit-Retry-After-Seconds` on the order of
+  hours means daily-quota exhaustion; seconds-to-minutes means a burst limit. They demand
+  opposite remediations, and app-side counters cannot tell them apart.
+- **Treat an anonymous/unauthenticated fallback from shared serverless egress as dead code.**
+  Per-IP free tiers are consumed by every other tenant sharing that NAT pool. The fallback
+  cannot succeed and costs a timeout on every failure path.
+- **A cooldown constant must be sized to the failure it handles.** `OPENSKY_429_COOLDOWN_MS`
+  defaults to 90s (`ais-relay.cjs:8572`); a daily-quota 429 needs the provider's own
+  `retryAfterSeconds`, which the code does read (`ais-relay.cjs:8841-8849`) — but the floor
+  still applies, so verify the provider value actually wins.
+
+## Related Issues
+
+- #6222 — OpenSky quota exhaustion (the fix for this doc)
+- #6224 — keyless ADS-B redundancy (adsb.lol / airplanes.live / adsb.fi) + blind-spot regions
+- #6227 — AIS has no fallback; same class of single-provider exposure on the maritime side
+- #5945 — theater-posture source attribution, which is why the burn is silent rather than visible
+- [`railway-cron-schedule-lives-on-the-deployment-manifest.md`](./railway-cron-schedule-lives-on-the-deployment-manifest.md) — how to read the real cron cadence, needed to compute credits/day
+- [`vendor-sdk-hidden-retries-nested-retry-ladder.md`](./vendor-sdk-hidden-retries-nested-retry-ladder.md) — adjacent: request amplification against a rate-limited provider
+- [`primary-fallback-inversion-budget-transfer.md`](../design-patterns/primary-fallback-inversion-budget-transfer.md) — the same lesson on a different resource: a seeder's fallback tier carries a hidden cost against a *shared budget* (there wall-clock deadline, here API credits), and reordering or ungating the tiers silently reassigns it

--- a/scripts/ais-relay-ingestion.test.cjs
+++ b/scripts/ais-relay-ingestion.test.cjs
@@ -369,7 +369,8 @@ test('theater-posture OpenSky success is attributed to opensky, and /metrics sta
   const { child, ready } = spawnRelay({
     RELAY_SHARED_SECRET: 'test-relay-secret',
     I_UNDERSTAND_THIS_DISABLES_AUTH: '',
-    RELAY_TEST_OPENSKY_STATUS_SEQUENCE: '200,200',
+    // One 200 is all a cycle should need — the seed issues a single global query.
+    RELAY_TEST_OPENSKY_STATUS_SEQUENCE: '200',
     ...upstash.env,
   });
   const auth = { 'x-relay-key': 'test-relay-secret' };
@@ -395,6 +396,16 @@ test('theater-posture OpenSky success is attributed to opensky, and /metrics sta
     assert.equal(metrics.theaterPosture.lastRun.flightCount, 1);
     assert.deepEqual(metrics.theaterPosture.sourceCountsSinceBoot, { opensky: 1, adsbLol: 0, wingbits: 0, vesselOnly: 0 });
     assert.ok(metrics.opensky.success >= 1, 'a real OpenSky 200 must be recorded as opensky success');
+    // Credit budget (#6222): one seed cycle must debit exactly ONE upstream
+    // /states/all. Every bbox above 400 sq° costs the same 4 credits as a
+    // global query, so a per-region loop multiplies spend against the
+    // 4,000/day quota while seeing less. upstreamFetches is the credit
+    // counter — cache hits and dedup do not increment it.
+    assert.equal(
+      metrics.opensky.upstreamFetches, 1,
+      `theater-posture debited ${metrics.opensky.upstreamFetches} OpenSky upstream fetches in one ` +
+      'cycle; expected exactly 1 global query.',
+    );
   } finally {
     await stop(child);
     await upstash.close();

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4046,11 +4046,6 @@ const POSTURE_THEATERS = [
   { id: 'yemen-redsea-theater', bounds: { north: 22, south: 11, east: 54, west: 32 }, thresholds: { elevated: 4, critical: 10 }, strikeIndicators: { minTankers: 1, minAwacs: 1, minFighters: 3 } },
 ];
 
-const THEATER_QUERY_REGIONS = [
-  { name: 'WESTERN', lamin: 10, lamax: 66, lomin: 9, lomax: 66 },
-  { name: 'PACIFIC', lamin: 4, lamax: 44, lomin: 104, lomax: 133 },
-];
-
 // In-memory index of recently-seen Wingbits positions, keyed by ICAO24.
 // Populated on every successful bbox response; served for callsign-only lookups.
 // Entries expire after 5 minutes (Wingbits data is live, stale beyond that is misleading).
@@ -4305,34 +4300,49 @@ async function handleWingbitsTrackRequest(req, res) {
   }
 }
 
+// ONE global /states/all per cycle, not one query per theater region. OpenSky
+// bills by bounding-box area with a flat top tier — every bbox above 400 sq°
+// costs 4 credits, the same as a global query — so the previous WESTERN+PACIFIC
+// pair (3,192 and 1,160 sq°) spent 8 credits/cycle for less coverage than 4
+// buys. The proxy already treats a bbox-less request as a valid global query
+// (normalizeOpenSkyBbox returns the ',,,' cache key). See
+// docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md (#6222).
 async function fetchTheaterFlightsFromOpenSky() {
   const seenIds = new Set();
   const allFlights = [];
-  for (const region of THEATER_QUERY_REGIONS) {
-    const params = `lamin=${region.lamin}&lamax=${region.lamax}&lomin=${region.lomin}&lomax=${region.lomax}`;
-    const resp = await fetch(`http://localhost:${relayBoundPort}/opensky?${params}`, {
-      headers: { 'User-Agent': CHROME_UA, ...(RELAY_SHARED_SECRET ? { 'x-relay-key': RELAY_SHARED_SECRET } : {}) },
-      signal: AbortSignal.timeout(20_000),
+  const resp = await fetch(`http://localhost:${relayBoundPort}/opensky`, {
+    headers: { 'User-Agent': CHROME_UA, ...(RELAY_SHARED_SECRET ? { 'x-relay-key': RELAY_SHARED_SECRET } : {}) },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!resp.ok) throw new Error(`OpenSky proxy ${resp.status} for GLOBAL`);
+  const data = await resp.json();
+  if (!data.states) return allFlights;
+  for (const state of data.states) {
+    const [icao24, callsign, , , , lon, lat, altitude, onGround, velocity, heading] = state;
+    if (lat == null || lon == null || onGround) continue;
+    if (!theaterIsMilCallsign(callsign)) continue;
+    // Filter to theater bounds, matching fetchTheaterFlightsFromAdsbLol. The
+    // query is global now, so without this the returned count would mean
+    // "military aircraft worldwide" for this source and "military aircraft in
+    // theater" for the other two — and seedTheaterPosture attributes the cycle
+    // on `flights.length > 0`, so OpenSky would claim cycles in which it fed
+    // no theater at all.
+    const inTheater = POSTURE_THEATERS.some((t) =>
+      lat >= t.bounds.south && lat <= t.bounds.north &&
+      lon >= t.bounds.west && lon <= t.bounds.east
+    );
+    if (!inTheater) continue;
+    if (seenIds.has(icao24)) continue;
+    seenIds.add(icao24);
+    allFlights.push({
+      id: icao24,
+      callsign: (callsign || '').trim(),
+      lat, lon,
+      altitude: altitude || 0,
+      heading: heading || 0,
+      speed: velocity || 0,
+      aircraftType: theaterDetectAircraftType(callsign),
     });
-    if (!resp.ok) throw new Error(`OpenSky proxy ${resp.status} for ${region.name}`);
-    const data = await resp.json();
-    if (!data.states) continue;
-    for (const state of data.states) {
-      const [icao24, callsign, , , , lon, lat, altitude, onGround, velocity, heading] = state;
-      if (lat == null || lon == null || onGround) continue;
-      if (!theaterIsMilCallsign(callsign)) continue;
-      if (seenIds.has(icao24)) continue;
-      seenIds.add(icao24);
-      allFlights.push({
-        id: icao24,
-        callsign: (callsign || '').trim(),
-        lat, lon,
-        altitude: altitude || 0,
-        heading: heading || 0,
-        speed: velocity || 0,
-        aircraftType: theaterDetectAircraftType(callsign),
-      });
-    }
   }
   return allFlights;
 }

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -42,9 +42,7 @@ const FORECAST_REFRESH_REQUEST_TTL = 60 * 60;
 const OPENSKY_PROXY_AUTH = process.env.OPENSKY_PROXY_AUTH || process.env.PROXY_URL || '';
 const PROXY_ENABLED = !!OPENSKY_PROXY_AUTH;
 
-// ── Wingbits query regions ─────────────────────────────────
-// OpenSky is a single global /states/all (#6222). These boxes remain the
-// Wingbits multi-area POST shape only — not OpenSky bboxes.
+// ── Query Regions ──────────────────────────────────────────
 const QUERY_REGIONS = [
   { name: 'PACIFIC', lamin: 10, lamax: 46, lomin: 107, lomax: 143 },
   { name: 'WESTERN', lamin: 13, lamax: 85, lomin: -10, lomax: 57 },
@@ -558,6 +556,10 @@ function clearOpenSkyToken() {
   openskyTokenExpiry = 0;
 }
 
+function isOpenSkyRateLimitedError(error) {
+  return /HTTP 429\b/i.test(String(error?.message || error || ''));
+}
+
 function isOpenSkyUnauthorizedError(error) {
   return /HTTP 401\b/i.test(String(error?.message || error || ''));
 }
@@ -680,6 +682,14 @@ async function fetchOpenSkyAuthenticated() {
           if (attempt === 0) continue;
         }
         if (!PROXY_ENABLED) throw directError;
+        // Never retry a 429 through the proxy. The quota is per ACCOUNT, and both
+        // paths carry the same bearer token — a different egress IP cannot change
+        // the verdict, so the retry is guaranteed to fail while still costing a
+        // request, proxy bandwidth, and latency on every cycle of a multi-hour
+        // exhaustion window. It also bounds the double-spend window: a direct
+        // request that OpenSky served but that failed client-side has already
+        // debited its credits, and retrying debits them again (#6222).
+        if (isOpenSkyRateLimitedError(directError)) throw directError;
         try {
           data = await proxyFetchJson(url, { headers });
           return { states: data.states || [], status: `success:proxy` };
@@ -1296,7 +1306,23 @@ async function main() {
 
   try {
     const assessedAt = Date.now();
-    const payload = { flights, fetchedAt: assessedAt, stats: { total: flights.length, byType }, classificationAudit };
+    // Declare the snapshot's ACTUAL geographic coverage, not the producer's intent.
+    // Tier 1 (Wingbits) queries QUERY_REGIONS — the two regional boxes. Only tier 2
+    // (OpenSky) is global. So when OpenSky returns nothing, this payload covers two
+    // regions no matter what the query shape aspires to.
+    //
+    // The consumer widens its authoritative-empty guard on this field. Publishing an
+    // unconditional 'global' would make list-military-flights answer a viewport over
+    // the Americas with an authoritative empty during any OpenSky outage, instead of
+    // falling through to per-viewer recovery (#6222).
+    const openSkyContributed = fetchSources.regions.some((region) => region.statesSeen > 0);
+    const payload = {
+      flights,
+      fetchedAt: assessedAt,
+      coverage: openSkyContributed ? 'global' : 'regional',
+      stats: { total: flights.length, byType },
+      classificationAudit,
+    };
 
     await redisSet(url, token, LIVE_KEY, payload, LIVE_TTL);
     await redisSet(url, token, STALE_KEY, payload, STALE_TTL);

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -42,7 +42,9 @@ const FORECAST_REFRESH_REQUEST_TTL = 60 * 60;
 const OPENSKY_PROXY_AUTH = process.env.OPENSKY_PROXY_AUTH || process.env.PROXY_URL || '';
 const PROXY_ENABLED = !!OPENSKY_PROXY_AUTH;
 
-// ── Query Regions ──────────────────────────────────────────
+// ── Wingbits query regions ─────────────────────────────────
+// OpenSky is a single global /states/all (#6222). These boxes remain the
+// Wingbits multi-area POST shape only — not OpenSky bboxes.
 const QUERY_REGIONS = [
   { name: 'PACIFIC', lamin: 10, lamax: 46, lomin: 107, lomax: 143 },
   { name: 'WESTERN', lamin: 13, lamax: 85, lomin: -10, lomax: 57 },

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -654,9 +654,13 @@ async function getOpenSkyToken() {
   }
 }
 
-async function fetchOpenSkyAuthenticated(region) {
-  const params = `lamin=${region.lamin}&lamax=${region.lamax}&lomin=${region.lomin}&lomax=${region.lomax}&extended=1`;
-  const url = `${OPENSKY_BASE}/states/all?${params}`;
+// One GLOBAL /states/all per run. OpenSky bills this endpoint by bounding-box
+// area with a flat top tier — anything above 400 sq° costs 4 credits, exactly
+// what a global query costs — so the previous PACIFIC+WESTERN pair (1,296 and
+// 4,824 sq°) spent 8 credits/run for strictly less coverage than 4 buys. See
+// docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md (#6222).
+async function fetchOpenSkyAuthenticated() {
+  const url = `${OPENSKY_BASE}/states/all?extended=1`;
 
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const token = await getOpenSkyToken();
@@ -693,71 +697,35 @@ async function fetchOpenSkyAuthenticated(region) {
   return { states: null, status: getOpenSkyAuthStatus() };
 }
 
-async function fetchOpenSkyAnonymous(region) {
-  const params = `lamin=${region.lamin}&lamax=${region.lamax}&lomin=${region.lomin}&lomax=${region.lomax}`;
-  const url = `${OPENSKY_BASE}/states/all?${params}`;
-
-  try {
-    const data = await fetchJsonDirect(url);
-    return { states: data.states || [], status: 'success:direct' };
-  } catch (directError) {
-    if (!PROXY_ENABLED) {
-      throw new Error(`error:${redactProxy(directError.message)}`);
-    }
-    try {
-      const data = await proxyFetchJson(url);
-      return { states: data.states || [], status: 'success:proxy' };
-    } catch (proxyError) {
-      throw new Error(`error:direct=${redactProxy(directError.message)} | proxy=${redactProxy(proxyError.message)}`);
-    }
-  }
-}
-
-async function fetchOpenSkyRegion(region, { source, fetchSources, seenIds, allStates }) {
+// No anonymous fallback. OpenSky's unauthenticated tier is 400 credits/day PER
+// IP, and this seeder runs from Railway's shared egress pool alongside every
+// other tenant on that address — it can essentially never succeed, and each
+// attempt added a full timeout to the failure path (#6222).
+async function fetchOpenSkyGlobal({ source, fetchSources, seenIds, allStates }) {
   let states = null;
   const regionSource = {
-    name: region.name,
+    name: 'GLOBAL',
     authStatus: getOpenSkyAuthStatus(),
-    anonStatus: 'not_needed',
     statesSeen: 0,
     statesAdded: 0,
   };
 
   try {
-    const authResult = await fetchOpenSkyAuthenticated(region);
+    const authResult = await fetchOpenSkyAuthenticated();
     states = authResult?.states || null;
     regionSource.authStatus = authResult?.status || regionSource.authStatus;
     if (states && states.length > 0) {
       if (source.value === 'none') source.value = 'opensky-auth';
       fetchSources.openSkyAuthSuccess = true;
       regionSource.statesSeen = states.length;
-      console.log(`  [OpenSky Auth] ${region.name}: ${states.length} states`);
+      console.log(`  [OpenSky Auth] GLOBAL: ${states.length} states`);
     } else if (regionSource.authStatus.startsWith('success:')) {
       fetchSources.openSkyAuthSuccess = true;
       regionSource.authStatus = regionSource.authStatus.replace('success:', 'empty:');
     }
   } catch (e) {
     regionSource.authStatus = `error:${redactProxy(e.message)}`;
-    console.warn(`  [OpenSky Auth] ${region.name}: ${redactProxy(e.message)}`);
-  }
-
-  if (!states || states.length === 0) {
-    try {
-      const anonResult = await fetchOpenSkyAnonymous(region);
-      states = anonResult?.states || null;
-      regionSource.anonStatus = anonResult?.status || regionSource.anonStatus;
-      if (states && states.length > 0) {
-        if (source.value === 'none') source.value = 'opensky-anon';
-        fetchSources.openSkyAnonFallbackUsed = true;
-        regionSource.statesSeen = states.length;
-        console.log(`  [OpenSky Anon] ${region.name}: ${states.length} states`);
-      } else if (regionSource.anonStatus.startsWith('success:')) {
-        regionSource.anonStatus = regionSource.anonStatus.replace('success:', 'empty:');
-      }
-    } catch (e) {
-      regionSource.anonStatus = `error:${redactProxy(e.message)}`;
-      console.warn(`  [OpenSky Anon] ${region.name}: ${redactProxy(e.message)}`);
-    }
+    console.warn(`  [OpenSky Auth] GLOBAL: ${redactProxy(e.message)}`);
   }
 
   if (states) {
@@ -770,7 +738,10 @@ async function fetchOpenSkyRegion(region, { source, fetchSources, seenIds, allSt
       added++;
     }
     regionSource.statesAdded = added;
-    if (added > 0) console.log(`  [OpenSky] +${added} new from ${region.name} (total: ${allStates.length})`);
+    // `+N new` is the empirical value of this tier: aircraft Wingbits never
+    // saw. It is why OpenSky must NOT be gated behind Wingbits success — the
+    // merge is additive, not a replacement (#6222).
+    if (added > 0) console.log(`  [OpenSky] +${added} new from GLOBAL (total: ${allStates.length})`);
   }
 
   fetchSources.regions.push(regionSource);
@@ -867,7 +838,6 @@ async function fetchAllStates() {
     oauthConfigured,
     proxyEnabled: PROXY_ENABLED,
     openSkyAuthSuccess: false,
-    openSkyAnonFallbackUsed: false,
     regions: [],
   };
 
@@ -889,9 +859,11 @@ async function fetchAllStates() {
     console.warn(`  [Wingbits] ${e.message}`);
   }
 
-  for (const region of QUERY_REGIONS) {
-    await fetchOpenSkyRegion(region, { source, fetchSources, seenIds, allStates });
-  }
+  // Tier 2: OpenSky — ONE global query, always. Not gated on Wingbits success:
+  // states merge additively by icao24 above, so this contributes aircraft
+  // Wingbits never saw. Gating it would delete that coverage, and a degraded
+  // but non-empty Wingbits response would satisfy the gate (#6222).
+  await fetchOpenSkyGlobal({ source, fetchSources, seenIds, allStates });
 
   return { allStates, source: source.value, fetchSources };
 }
@@ -1280,10 +1252,10 @@ async function main() {
     if (classificationAudit) {
       console.log(`  [Audit] unknownRate=${classificationAudit.unknownTypeRate} hexOnly=${classificationAudit.hexOnlyAdmissions} rejected=${classificationAudit.rejectedFlights}`);
       console.log(
-        `  [Source] wingbits=${fetchSources.wingbitsUsed ? 'yes' : 'no'} oauthConfigured=${fetchSources.oauthConfigured ? 'yes' : 'no'} authSuccess=${fetchSources.openSkyAuthSuccess ? 'yes' : 'no'} anonFallback=${fetchSources.openSkyAnonFallbackUsed ? 'yes' : 'no'}`,
+        `  [Source] wingbits=${fetchSources.wingbitsUsed ? 'yes' : 'no'} oauthConfigured=${fetchSources.oauthConfigured ? 'yes' : 'no'} authSuccess=${fetchSources.openSkyAuthSuccess ? 'yes' : 'no'}`,
       );
       console.log(
-        `  [Source] regions=${fetchSources.regions.map((region) => `${region.name}:auth=${region.authStatus},anon=${region.anonStatus},seen=${region.statesSeen},added=${region.statesAdded}`).join(' | ')}`,
+        `  [Source] regions=${fetchSources.regions.map((region) => `${region.name}:auth=${region.authStatus},seen=${region.statesSeen},added=${region.statesAdded}`).join(' | ')}`,
       );
       console.log(
         `  [Audit] waterfall raw=${classificationAudit.stageWaterfall.rawStates} pos=${classificationAudit.stageWaterfall.positionEligible} candidate=${classificationAudit.stageWaterfall.candidateStates} admitted=${classificationAudit.stageWaterfall.admittedFlights} typed=${classificationAudit.stageWaterfall.typedFlights}`,
@@ -1457,4 +1429,9 @@ export {
   deriveOperatorFromSourceMeta,
   deriveTrustedPlaOperatorFromSourceMeta,
   filterMilitaryFlights,
+  // Test seam: the OpenSky credit budget (#6222) is a property of how many
+  // requests this function issues and with what bbox, which is unobservable
+  // from the published payload. Exported so tests can assert the request
+  // shape directly rather than grepping source text.
+  fetchAllStates,
 };

--- a/server/worldmonitor/aviation/v1/track-aircraft.ts
+++ b/server/worldmonitor/aviation/v1/track-aircraft.ts
@@ -6,7 +6,6 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
 import { cachedFetchJson } from '../../../_shared/redis';
-import { CHROME_UA } from '../../../_shared/constants';
 
 // 120s for anonymous OpenSky tier (~10 req/min limit); TODO: reduce to 10s on commercial tier
 const CACHE_TTL = 120;
@@ -45,26 +44,12 @@ function parseOpenSkyStates(states: unknown[][]): PositionSample[] {
 }
 
 
-const OPENSKY_PUBLIC_BASE = 'https://opensky-network.org/api';
-
-async function fetchOpenSkyAnonymous(req: TrackAircraftRequest): Promise<PositionSample[]> {
-    let url: string;
-    if (req.swLat != null && req.neLat != null) {
-        url = `${OPENSKY_PUBLIC_BASE}/states/all?lamin=${req.swLat}&lomin=${req.swLon}&lamax=${req.neLat}&lomax=${req.neLon}`;
-    } else if (req.icao24) {
-        url = `${OPENSKY_PUBLIC_BASE}/states/all?icao24=${req.icao24}`;
-    } else {
-        url = `${OPENSKY_PUBLIC_BASE}/states/all`;
-    }
-
-    const resp = await fetch(url, {
-        signal: AbortSignal.timeout(6_000),
-        headers: { 'Accept': 'application/json', 'User-Agent': CHROME_UA },
-    });
-    if (!resp.ok) throw new Error(`OpenSky anonymous HTTP ${resp.status}`);
-    const data = await resp.json() as OpenSkyResponse;
-    return parseOpenSkyStates(data.states ?? []);
-}
+// There is deliberately no anonymous OpenSky path here. The unauthenticated tier
+// is 400 credits/day PER IP, and these handlers run on Vercel's shared egress —
+// the quota is consumed by every other tenant on the same address, so the call
+// essentially always 429s while still costing a full 6s timeout on the very
+// request that was already failing over. Removing it also returns that 6s to
+// the response budget below (#6222).
 
 function buildCacheKey(req: TrackAircraftRequest): string {
     if (req.icao24) return `aviation:track:icao:${req.icao24}:v1`;
@@ -77,7 +62,6 @@ function buildCacheKey(req: TrackAircraftRequest): string {
 
 // Response-level source values (TrackAircraftResponse.source):
 //   'opensky'           — data from OpenSky via relay
-//   'opensky-anonymous' — data from OpenSky public API (no auth, rate-limited)
 //   'wingbits'          — data from Wingbits via relay
 //   'none'              — all real sources returned empty or failed; positions = []
 export async function trackAircraft(
@@ -148,23 +132,15 @@ export async function trackAircraft(
                             if (osPositions.length > 0) return { positions: osPositions, source: 'opensky' };
                         }
                     } catch (err) {
-                        // sentry-coverage-ok: authenticated relay failure intentionally falls through to anonymous recovery.
+                        // sentry-coverage-ok: relay failure degrades to an empty viewport by design;
+                        // there is no further provider tier that can succeed from shared egress.
                         console.warn(`[Aviation] OpenSky bbox relay failed: ${err instanceof Error ? err.message : err}`);
                     }
 
-                    // Both relay paths failed or OpenSky recovery was empty — try anonymous
-                    // OpenSky as a last resort. The 6s + 6s + 6s timeouts leave 7s of
-                    // headroom under the Vercel initial-response ceiling for cache I/O and
-                    // response serialization. Keep these sequential: parallel OpenSky
-                    // recovery would spend an authenticated credit even when anonymous wins.
-                    try {
-                        const directPositions = await fetchOpenSkyAnonymous(req);
-                        if (directPositions.length > 0) {
-                            return { positions: directPositions, source: 'opensky-anonymous' };
-                        }
-                    } catch (err) {
-                        console.warn(`[Aviation] OpenSky anonymous failed: ${err instanceof Error ? err.message : err}`);
-                    }
+                    // Both relay paths exhausted. The 6s + 6s sequential timeouts now leave
+                    // 13s of headroom under the Vercel initial-response ceiling for cache I/O
+                    // and response serialization, up from 7s before the anonymous tier was
+                    // removed (#6222).
                 }
 
                 // For icao24-only queries, try OpenSky relay then Wingbits

--- a/server/worldmonitor/aviation/v1/track-aircraft.ts
+++ b/server/worldmonitor/aviation/v1/track-aircraft.ts
@@ -7,7 +7,10 @@ import type {
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
 import { cachedFetchJson } from '../../../_shared/redis';
 
-// 120s for anonymous OpenSky tier (~10 req/min limit); TODO: reduce to 10s on commercial tier
+// 120s. This TTL was originally sized for the anonymous OpenSky tier's ~10 req/min
+// ceiling; that tier was removed in #6222, so the binding constraint is now the shared
+// authenticated credit pool the relay draws on — a shorter TTL multiplies bbox misses
+// straight into it. Revisit only alongside that budget, not on its own.
 const CACHE_TTL = 120;
 // Callsign searches hit the relay's in-memory index (5min TTL); cache positive hits 60s,
 // negative hits 10s so a retry after panning into view returns fresh data quickly.

--- a/server/worldmonitor/aviation/v1/track-aircraft.ts
+++ b/server/worldmonitor/aviation/v1/track-aircraft.ts
@@ -140,10 +140,17 @@ export async function trackAircraft(
                         console.warn(`[Aviation] OpenSky bbox relay failed: ${err instanceof Error ? err.message : err}`);
                     }
 
-                    // Both relay paths exhausted. The 6s + 6s sequential timeouts now leave
-                    // 13s of headroom under the Vercel initial-response ceiling for cache I/O
-                    // and response serialization, up from 7s before the anonymous tier was
-                    // removed (#6222).
+                    // Both relay paths exhausted. Removing the anonymous tier returns 6s to
+                    // this branch: a bbox-only request now spends at most 6s + 6s here.
+                    //
+                    // That is NOT the worst case for the handler. The generated GET decoder
+                    // coerces missing bbox params to 0 rather than leaving them null, so an
+                    // icao24 lookup also satisfies the `req.swLat != null` guard above, runs
+                    // this block against a degenerate 0,0,0,0 bbox, and then falls through to
+                    // the 8s icao24 tier below — 20s total, measured. That ladder (and the
+                    // wasted authenticated relay call on a bbox nobody asked for) predates
+                    // #6222 and is tracked separately; do not read the 12s above as the
+                    // handler's ceiling.
                 }
 
                 // For icao24-only queries, try OpenSky relay then Wingbits

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -27,14 +27,19 @@ interface RequestBounds {
   east: number;
 }
 
-// The scheduled military-flight snapshot is GLOBAL: scripts/seed-military-flights.mjs
+// The scheduled military-flight snapshot is declared GLOBAL: scripts/seed-military-flights.mjs
 // issues one bbox-less OpenSky /states/all per run (#6222), so every viewport is
-// inside the producer's declared coverage.
+// inside the producer's declared coverage and must not re-open per-viewer recovery.
 //
-// This must stay in lockstep with the producer's query shape. While the producer
-// queried two regional bboxes, this listed exactly those two, and any viewport
-// outside them fell through to per-viewer authenticated OpenSky recovery below —
-// an unbounded credit fanout on top of the seeder's own spend. Narrowing the
+// Content vs declaration: Wingbits still POSTs only PACIFIC+WESTERN areas. When
+// OpenSky fails but Wingbits succeeds, the published snapshot can be regionally
+// sparse while this list still claims planet-wide coverage — out-of-region
+// viewports then get an authoritative empty (credit-safe) rather than recovery.
+// Keep this lockstep with the OpenSky query shape, not with Wingbits boxes.
+//
+// While the producer queried two regional OpenSky bboxes, this listed exactly
+// those two, and any viewport outside them fell through to per-viewer
+// authenticated OpenSky recovery — an unbounded credit fanout. Narrowing the
 // producer again without narrowing this would silently republish that fanout.
 const LIVE_SEED_COVERAGE: readonly RequestBounds[] = [
   { south: -90, north: 90, west: -180, east: 180 },

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -437,6 +437,22 @@ export async function listMilitaryFlights(
     }
     return paginateResponse(fullResult.flights, fullResult.clusters, requestBounds, req);
   } catch {
+    // Reaching here means the live path was abandoned before any provider call —
+    // most often the deliberate 'live seed read failed' throw above, which exists
+    // to keep a Redis blip from opening per-bbox OpenSky amplification.
+    //
+    // That throw skipped the `if (!fullResult)` stale branch below, so the 24h
+    // stale key was never consulted. Reading it is another Redis GET, not a
+    // provider call, so it spends no OpenSky credit and is precisely what that
+    // key exists for. This matters much more since #6222 widened
+    // LIVE_SEED_COVERAGE to global: every viewport now routes through the
+    // live-seed read, so skipping stale here blanks the entire map rather than
+    // the two former producer regions. fetchStaleFallback swallows its own
+    // errors and returns null, so it cannot re-throw into this handler.
+    const staleFlights = await fetchStaleFallback();
+    if (staleFlights && staleFlights.length > 0) {
+      return paginateResponse(staleFlights, [], normalizeBounds(req), req);
+    }
     markNoCacheResponse(ctx.request);
     return emptyResponse();
   }

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -27,13 +27,17 @@ interface RequestBounds {
   east: number;
 }
 
-// The scheduled military-flight snapshot contains exactly these two producer
-// regions (scripts/seed-military-flights.mjs QUERY_REGIONS). It is authoritative
-// only when one region fully contains the requested bbox; otherwise using it
-// would silently turn uncovered geography into an empty result.
+// The scheduled military-flight snapshot is GLOBAL: scripts/seed-military-flights.mjs
+// issues one bbox-less OpenSky /states/all per run (#6222), so every viewport is
+// inside the producer's declared coverage.
+//
+// This must stay in lockstep with the producer's query shape. While the producer
+// queried two regional bboxes, this listed exactly those two, and any viewport
+// outside them fell through to per-viewer authenticated OpenSky recovery below —
+// an unbounded credit fanout on top of the seeder's own spend. Narrowing the
+// producer again without narrowing this would silently republish that fanout.
 const LIVE_SEED_COVERAGE: readonly RequestBounds[] = [
-  { south: 10, north: 46, west: 107, east: 143 },
-  { south: 13, north: 85, west: -10, east: 57 },
+  { south: -90, north: 90, west: -180, east: 180 },
 ];
 
 function liveSeedCovers(bounds: RequestBounds): boolean {

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -27,26 +27,34 @@ interface RequestBounds {
   east: number;
 }
 
-// The scheduled military-flight snapshot is declared GLOBAL: scripts/seed-military-flights.mjs
-// issues one bbox-less OpenSky /states/all per run (#6222), so every viewport is
-// inside the producer's declared coverage and must not re-open per-viewer recovery.
+// Coverage is a property of the SNAPSHOT, not of the producer's query shape.
 //
-// Content vs declaration: Wingbits still POSTs only PACIFIC+WESTERN areas. When
-// OpenSky fails but Wingbits succeeds, the published snapshot can be regionally
-// sparse while this list still claims planet-wide coverage — out-of-region
-// viewports then get an authoritative empty (credit-safe) rather than recovery.
-// Keep this lockstep with the OpenSky query shape, not with Wingbits boxes.
+// scripts/seed-military-flights.mjs issues one bbox-less OpenSky /states/all per
+// run (#6222), but its tier-1 source (Wingbits) still queries the two regional
+// boxes below. So a cycle where OpenSky returned nothing publishes REGIONAL data
+// however global the intent was. Treating that as global would answer a viewport
+// over the Americas with an authoritative empty for the entire duration of an
+// OpenSky outage, instead of falling through to per-viewer recovery — the exact
+// "uncovered geography becomes an empty result" failure this guard exists to stop.
 //
-// While the producer queried two regional OpenSky bboxes, this listed exactly
-// those two, and any viewport outside them fell through to per-viewer
-// authenticated OpenSky recovery — an unbounded credit fanout. Narrowing the
-// producer again without narrowing this would silently republish that fanout.
-const LIVE_SEED_COVERAGE: readonly RequestBounds[] = [
+// The producer therefore stamps its real coverage into the payload and this reads
+// it. A payload without the field predates that change and is treated as regional,
+// which is the conservative reading during rollout.
+const GLOBAL_COVERAGE: readonly RequestBounds[] = [
   { south: -90, north: 90, west: -180, east: 180 },
 ];
 
-function liveSeedCovers(bounds: RequestBounds): boolean {
-  return LIVE_SEED_COVERAGE.some((region) =>
+// The producer's tier-1 (Wingbits) query regions — mirrors QUERY_REGIONS in
+// scripts/seed-military-flights.mjs. This is what a snapshot covers when the
+// global tier contributed nothing.
+const REGIONAL_COVERAGE: readonly RequestBounds[] = [
+  { south: 10, north: 46, west: 107, east: 143 },
+  { south: 13, north: 85, west: -10, east: 57 },
+];
+
+function seedCovers(coverage: SeedCoverage, bounds: RequestBounds): boolean {
+  const regions = coverage === 'global' ? GLOBAL_COVERAGE : REGIONAL_COVERAGE;
+  return regions.some((region) =>
     region.south <= bounds.south
     && region.north >= bounds.north
     && region.west <= bounds.west
@@ -179,9 +187,13 @@ interface SeedFlight {
   note?: string;
 }
 
+/** What geography a published snapshot actually covers — see seedCovers above. */
+type SeedCoverage = 'global' | 'regional';
+
 interface SeedPayload {
   flights?: SeedFlight[];
   fetchedAt?: number;
+  coverage?: SeedCoverage;
 }
 
 /**
@@ -235,7 +247,7 @@ const LIVE_SEED_NEG_TTL_MS = 30_000;
 let liveSeedNegUntil = 0;
 let liveSeedNegStatus: 'miss' | 'error' = 'miss';
 type LiveSeedRead =
-  | { status: 'hit'; flights: ListMilitaryFlightsResponse['flights'] }
+  | { status: 'hit'; flights: ListMilitaryFlightsResponse['flights']; coverage: SeedCoverage }
   | { status: 'miss' | 'error' };
 let liveSeedReadPromise: Promise<LiveSeedRead> | null = null;
 
@@ -251,15 +263,17 @@ async function fetchLiveSeedSnapshot(): Promise<LiveSeedRead> {
       liveSeedNegUntil = now + LIVE_SEED_NEG_TTL_MS;
       return { status: 'error' };
     }
-    const flights = read.status === 'hit'
-      ? seedPayloadToProto(read.value as SeedPayload)
-      : null;
+    const payload = read.status === 'hit' ? (read.value as SeedPayload) : null;
+    const flights = payload ? seedPayloadToProto(payload) : null;
     if (flights === null) {
       liveSeedNegStatus = 'miss';
       liveSeedNegUntil = now + LIVE_SEED_NEG_TTL_MS;
       return { status: 'miss' };
     }
-    return { status: 'hit', flights };
+    // An absent field predates the producer stamping coverage; regional is the
+    // conservative reading, and it is what the payload actually covered then.
+    const coverage: SeedCoverage = payload?.coverage === 'global' ? 'global' : 'regional';
+    return { status: 'hit', flights, coverage };
   })();
   try {
     return await liveSeedReadPromise;
@@ -338,18 +352,23 @@ export async function listMilitaryFlights(
         // upstream outage. Keep serving that snapshot (with each flight's old
         // lastSeenAt intact) while seed health reports the stale fetchedAt;
         // reopening per-viewer OpenSky recovery here recreates the credit fanout.
-        if (liveSeedCovers(requestBounds)) {
-          const seeded = await fetchLiveSeedSnapshot();
-          if (seeded.status === 'hit') {
-            return { flights: seeded.flights, clusters: [], pagination: undefined };
-          }
-          if (seeded.status === 'error') {
-            // A Redis command/read failure is not proof the snapshot is
-            // missing. Throw before any provider call so cachedFetchJson's
-            // bounded negative path prevents per-bbox OpenSky amplification.
-            throw new Error('military live seed read failed');
-          }
+        // Read first, THEN judge coverage: what the snapshot covers is a property
+        // of the payload (the producer stamps it), not of this module's constants.
+        const seeded = await fetchLiveSeedSnapshot();
+        if (seeded.status === 'error') {
+          // A Redis command/read failure is not proof the snapshot is
+          // missing. Throw before any provider call so cachedFetchJson's
+          // bounded negative path prevents per-bbox OpenSky amplification.
+          // The outer catch consults the 24h stale key before giving up.
+          throw new Error('military live seed read failed');
         }
+        if (seeded.status === 'hit' && seedCovers(seeded.coverage, requestBounds)) {
+          return { flights: seeded.flights, clusters: [], pagination: undefined };
+        }
+        // A miss, or a hit whose coverage does not contain this request (a
+        // regional snapshot asked about the Americas), falls through to
+        // request-specific recovery rather than returning a falsely
+        // authoritative empty.
 
         const isSidecar = (process.env.LOCAL_API_MODE || '').includes('sidecar');
         const relayBase = isSidecar ? null : getRelayBaseUrl();

--- a/src/services/military-flights.ts
+++ b/src/services/military-flights.ts
@@ -163,9 +163,11 @@ function mapProtoFlight(pf: ProtoMilitaryFlight, nowDate: Date): MilitaryFlight 
 const MAX_REGION_PAGES = 50;
 
 async function fetchViaProto(): Promise<MilitaryFlight[]> {
-  // Iterate the same PACIFIC/WESTERN regions the server-side seed cron uses
-  // so dashboard coverage matches the analytic pipeline. The proto handler
-  // caches per-bbox, so parallel region calls warm independent cache keys.
+  // Dashboard still requests the historical PACIFIC/WESTERN viewports only
+  // (MILITARY_QUERY_REGIONS). The seeder's OpenSky path is global (#6222), so
+  // seed data outside these boxes exists for API/MCP callers but this SPA path
+  // does not enumerate it yet. Proto handler caches per-bbox, so parallel
+  // region calls warm independent cache keys.
   const results = await Promise.all(
     MILITARY_QUERY_REGIONS.map(async (region) => {
       // The server now bounds every response to a page, so follow next_cursor

--- a/src/services/military-flights.ts
+++ b/src/services/military-flights.ts
@@ -163,11 +163,9 @@ function mapProtoFlight(pf: ProtoMilitaryFlight, nowDate: Date): MilitaryFlight 
 const MAX_REGION_PAGES = 50;
 
 async function fetchViaProto(): Promise<MilitaryFlight[]> {
-  // Dashboard still requests the historical PACIFIC/WESTERN viewports only
-  // (MILITARY_QUERY_REGIONS). The seeder's OpenSky path is global (#6222), so
-  // seed data outside these boxes exists for API/MCP callers but this SPA path
-  // does not enumerate it yet. Proto handler caches per-bbox, so parallel
-  // region calls warm independent cache keys.
+  // Iterate the same PACIFIC/WESTERN regions the server-side seed cron uses
+  // so dashboard coverage matches the analytic pipeline. The proto handler
+  // caches per-bbox, so parallel region calls warm independent cache keys.
   const results = await Promise.all(
     MILITARY_QUERY_REGIONS.map(async (region) => {
       // The server now bounds every response to a page, so follow next_cursor

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -2186,6 +2186,8 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
           return jsonResponse({
             result: JSON.stringify({
               flights: [{ id: 'americas', callsign: 'RCH401', lat: 40.5, lon: -99.5 }],
+              // OpenSky contributed this cycle, so the producer stamped global.
+              coverage: 'global',
               fetchedAt: Date.now(),
             }),
           });
@@ -2216,6 +2218,66 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       );
       // Hex codes are canonicalized to uppercase on the way out.
       assert.deepEqual(result.flights.map((flight) => flight.id), ['AMERICAS']);
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('does not answer an out-of-region viewport from a REGIONAL snapshot (OpenSky tier down)', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let openskyCalls = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === 'military:flights:v1') {
+          // OpenSky contributed nothing this cycle, so the producer only had
+          // Wingbits — which queries the two regional boxes. It says so.
+          return jsonResponse({
+            result: JSON.stringify({
+              flights: [{ id: 'inregion', callsign: 'RCH301', lat: 20.2, lon: 10.2 }],
+              coverage: 'regional',
+              fetchedAt: Date.now(),
+            }),
+          });
+        }
+        return jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (raw.includes('/opensky')) {
+        openskyCalls += 1;
+        return jsonResponse({
+          states: [['recovered', 'RCH401', null, null, null, -99.5, 40.5, 20000, false, 300, 90]],
+        });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.listMilitaryFlights(
+        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+        americasRequest,
+      );
+      // A regional snapshot is NOT authoritative over North America. Answering
+      // from it would silently turn uncovered geography into an empty map for
+      // the whole duration of an OpenSky outage.
+      assert.equal(
+        openskyCalls, 1,
+        'a viewport outside a REGIONAL snapshot must fall through to request-specific recovery',
+      );
+      assert.deepEqual(result.flights.map((f) => f.id), ['RECOVERED']);
     } finally {
       cleanup();
       globalThis.fetch = originalFetch;

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -2223,6 +2223,68 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     }
   });
 
+  it('falls back to the 24h stale key when the live-seed read errors, without touching OpenSky', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let openskyCalls = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        // A Redis command failure on the LIVE key — not a miss. readCachedJson
+        // turns a thrown fetch into { status: 'error' }.
+        if (key === 'military:flights:v1') throw new Error('redis timeout');
+        if (key === 'military:flights:stale:v1') {
+          return jsonResponse({
+            result: JSON.stringify({
+              flights: [{ id: 'stale1', callsign: 'RCH777', lat: 40.5, lon: -99.5 }],
+              fetchedAt: Date.now(),
+            }),
+          });
+        }
+        return jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (raw.includes('/opensky')) {
+        openskyCalls += 1;
+        return jsonResponse({ states: [] });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.listMilitaryFlights(
+        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+        americasRequest,
+      );
+      // The live-seed read deliberately throws on a Redis error rather than
+      // calling a provider, so per-bbox OpenSky amplification stays closed.
+      // But reading the 24h stale key is another Redis GET, not a provider
+      // call — it costs no credit and is exactly what that key exists for.
+      // Since #6222 made coverage global, EVERY viewport routes through the
+      // live-seed read, so skipping stale here blanks the whole map rather
+      // than the two former regions.
+      assert.equal(openskyCalls, 0, 'a Redis error must not open a provider call');
+      assert.deepEqual(
+        result.flights.map((flight) => flight.id), ['STALE1'],
+        'a Redis error on the live key must still serve the 24h stale snapshot',
+      );
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
   it('still uses request-specific recovery when the seed snapshot is missing', async () => {
     const { module, cleanup } = await importListMilitaryFlights();
     const restoreEnv = withEnv({

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1845,8 +1845,16 @@ describe('aviation aircraft provider priority', { concurrency: 1 }, () => {
         neLat: 11,
         neLon: 11,
       });
-      assert.deepEqual(requestedTimeouts, [6_000, 6_000, 6_000]);
-      assert.equal(requestedTimeouts.reduce((sum, timeout) => sum + timeout, 0), 18_000);
+      // Two sequential 6s tiers: Wingbits bbox, then the authenticated OpenSky
+      // relay. The third tier was anonymous OpenSky, removed in #6222 — that
+      // tier is 400 credits/day PER IP on shared Vercel egress, so it could
+      // essentially never succeed while still burning 6s of the response
+      // budget on a request that had already failed over twice.
+      assert.deepEqual(requestedTimeouts, [6_000, 6_000]);
+      assert.equal(
+        requestedTimeouts.reduce((sum, timeout) => sum + timeout, 0), 12_000,
+        'worst-case provider path must stay within the edge response deadline',
+      );
       assert.deepEqual(result.positions, []);
       assert.equal(result.source, 'none');
     } finally {
@@ -2147,7 +2155,75 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     }
   });
 
-  it('uses request-specific recovery outside the seed snapshot coverage', async () => {
+  // A viewport over North America — outside BOTH of the regional bboxes the
+  // producer queried before #6222, so under the old coverage list it fell
+  // through to per-viewer authenticated OpenSky recovery.
+  const americasRequest = {
+    swLat: 40,
+    swLon: -100,
+    neLat: 41,
+    neLon: -99,
+  };
+
+  it('serves a viewport outside the old producer regions from the seed, spending no OpenSky credit', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let openskyCalls = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === 'military:flights:v1') {
+          return jsonResponse({
+            result: JSON.stringify({
+              flights: [{ id: 'americas', callsign: 'RCH401', lat: 40.5, lon: -99.5 }],
+              fetchedAt: Date.now(),
+            }),
+          });
+        }
+        return jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (raw.includes('/opensky')) {
+        openskyCalls += 1;
+        return jsonResponse({ states: [] });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.listMilitaryFlights(
+        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+        americasRequest,
+      );
+      // The producer now queries globally (#6222), so LIVE_SEED_COVERAGE is
+      // global and every viewport reads the snapshot. Before, a viewport here
+      // spent an authenticated credit PER 1-degree cell per TTL — an unbounded
+      // fanout stacked on top of the seeder's own spend.
+      assert.equal(
+        openskyCalls, 0,
+        `a viewport inside the global seed coverage spent ${openskyCalls} OpenSky request(s); ` +
+        'per-viewer recovery must not run when the snapshot covers the request.',
+      );
+      // Hex codes are canonicalized to uppercase on the way out.
+      assert.deepEqual(result.flights.map((flight) => flight.id), ['AMERICAS']);
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('still uses request-specific recovery when the seed snapshot is missing', async () => {
     const { module, cleanup } = await importListMilitaryFlights();
     const restoreEnv = withEnv({
       UPSTASH_REDIS_REST_URL: 'https://redis.test',
@@ -2183,8 +2259,11 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
         { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
         request,
       );
-      assert.equal(liveSeedReads, 0, 'an uncovered bbox must not consult a partial global snapshot');
-      assert.equal(openskyCalls, 1);
+      // Coverage is global now, so the snapshot is always consulted first —
+      // but a MISS must still fall through, or a cold seed would render the
+      // whole surface permanently empty.
+      assert.equal(liveSeedReads, 1, 'the global snapshot must be consulted before provider recovery');
+      assert.equal(openskyCalls, 1, 'a snapshot miss must still reach request-specific recovery');
       assert.deepEqual(result.flights.map((flight) => flight.id), ['OUTSIDE-REGION']);
     } finally {
       cleanup();

--- a/tests/seed-military-flights-opensky-budget.test.mjs
+++ b/tests/seed-military-flights-opensky-budget.test.mjs
@@ -127,6 +127,23 @@ test('OpenSky-only aircraft still reach the merged set when Wingbits already suc
   );
 });
 
+test('spends exactly one OpenSky request even when the authenticated call fails', async () => {
+  // The other request-count assertion runs against a SUCCEEDING fixture, so it never
+  // executes the failure branch — and the anonymity assertion below only counts
+  // requests without an Authorization header. Between them, a second *authenticated*
+  // request added on the failure path (a retry, say) would pass every other test here.
+  // Since the whole point is a credit budget, that is the most likely careless
+  // re-addition, so pin total spend on the failure path too.
+  install({ openSkyStatus: 429 });
+  await fetchAllStates();
+  const os = openSkyDataCalls();
+  assert.equal(
+    os.length, 1,
+    `A failing OpenSky call spent ${os.length} requests; expected 1. Retrying a 429 spends ` +
+    'another credit against an already-exhausted budget (#6222).',
+  );
+});
+
 test('never falls back to an unauthenticated OpenSky request', async () => {
   // Anonymous OpenSky is 400 credits/day PER IP on shared Railway/Vercel egress,
   // so it can essentially never succeed — it only adds a timeout to the failure path.

--- a/tests/seed-military-flights-opensky-budget.test.mjs
+++ b/tests/seed-military-flights-opensky-budget.test.mjs
@@ -144,6 +144,36 @@ test('spends exactly one OpenSky request even when the authenticated call fails'
   );
 });
 
+test('does not retry a 429 through the residential proxy', async () => {
+  // The quota is per ACCOUNT and both paths send the same bearer token, so a
+  // different egress IP cannot change a 429 — the retry is guaranteed futile
+  // while still costing a request, proxy bandwidth, and latency on every cycle
+  // of a multi-hour exhaustion window.
+  //
+  // Counting globalThis.fetch calls CANNOT see this: proxyFetchJson goes through
+  // _proxy-utils.cjs, which opens raw sockets and never touches globalThis.fetch.
+  // A request-count assertion here would pass with the guard removed. The
+  // observable signal is the recorded status — the proxy path stringifies BOTH
+  // errors as `direct=... | proxy=...`, so its absence proves the proxy was
+  // never attempted.
+  process.env.OPENSKY_PROXY_AUTH = 'http://user:pass@proxy.test:8080';
+  const mod = await import(`../scripts/seed-military-flights.mjs?proxy=${Date.now()}`);
+  install({ openSkyStatus: 429 });
+  try {
+    const { fetchSources } = await mod.fetchAllStates();
+    const status = fetchSources.regions[0]?.authStatus || '';
+    assert.match(status, /429/, `expected a recorded 429, got: ${status}`);
+    assert.ok(
+      !status.includes('proxy='),
+      `A 429 was retried through the residential proxy (status: ${status}). The quota is ` +
+      'per-account and both paths send the same bearer token, so a different egress IP ' +
+      'cannot change the verdict (#6222).',
+    );
+  } finally {
+    delete process.env.OPENSKY_PROXY_AUTH;
+  }
+});
+
 test('never falls back to an unauthenticated OpenSky request', async () => {
   // Anonymous OpenSky is 400 credits/day PER IP on shared Railway/Vercel egress,
   // so it can essentially never succeed — it only adds a timeout to the failure path.

--- a/tests/seed-military-flights-opensky-budget.test.mjs
+++ b/tests/seed-military-flights-opensky-budget.test.mjs
@@ -1,0 +1,145 @@
+// Regression guard for #6222 — the OpenSky credit budget of the military-flights seeder.
+//
+// OpenSky bills /states/all by bounding-box AREA with a FLAT top tier: any bbox
+// above 400 sq° costs 4 credits, exactly what a global (no-bbox) query costs.
+// The seeder used to issue TWO regional queries (1,296 and 4,824 sq°) = 8 credits
+// per run x 288 runs/day = 2,304 of the 4,000/day quota, for coverage that
+// excluded the Americas. One global query costs 4 and covers the planet.
+//
+// None of that is observable from the published payload — a run that spends 8
+// credits and a run that spends 4 publish the same shape — so these assertions
+// inspect the actual outbound requests. Source-text greps would pass with the
+// bug restored (the constants can stay while the call path changes), which is
+// why this drives fetchAllStates() and records real fetch calls.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.OPENSKY_CLIENT_ID = 'test-client';
+process.env.OPENSKY_CLIENT_SECRET = 'test-secret';
+process.env.WINGBITS_API_KEY = 'test-wingbits';
+delete process.env.OPENSKY_PROXY_AUTH;
+delete process.env.PROXY_URL;
+
+const { fetchAllStates } = await import('../scripts/seed-military-flights.mjs');
+
+const OPENSKY_HOST = 'opensky-network.org';
+const TOKEN_HOST = 'auth.opensky-network.org';
+const WINGBITS_HOST = 'customer-api.wingbits.com';
+
+const originalFetch = globalThis.fetch;
+let calls;
+
+// A state vector is a positional array; index 0 is icao24, 5 lon, 6 lat, 8 onGround.
+function state(icao24, callsign, lat, lon) {
+  const s = new Array(17).fill(null);
+  s[0] = icao24;
+  s[1] = callsign;
+  s[5] = lon;
+  s[6] = lat;
+  s[7] = 10000;
+  s[8] = false;
+  s[9] = 400;
+  s[10] = 90;
+  return s;
+}
+
+// ADF7C8-AFFFFF is the USAF hex range the seeder already recognises, so these
+// are admitted on hex alone and the assertions do not depend on callsign rules.
+const WINGBITS_ONLY = 'ae1111';
+const OPENSKY_ONLY = 'ae2222';
+
+function install({ openSkyStates = [state(OPENSKY_ONLY, 'RCH123', 40, -100)], openSkyStatus = 200 } = {}) {
+  calls = [];
+  globalThis.fetch = async (url, opts = {}) => {
+    const raw = typeof url === 'string' ? url : url.url;
+    calls.push({ url: raw, method: opts.method || 'GET', headers: opts.headers || {} });
+    const u = new URL(raw);
+
+    if (u.host === TOKEN_HOST) {
+      return new Response(JSON.stringify({ access_token: 'tok', expires_in: 1800 }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (u.host === WINGBITS_HOST) {
+      // Wingbits answers an ARRAY of per-area results, each carrying `data`;
+      // an object here is rejected by the parser's Array.isArray guard.
+      return new Response(JSON.stringify([
+        { alias: 'PACIFIC', data: [
+          { h: WINGBITS_ONLY, f: 'RCH999', la: 30, lo: 130, ab: 30000, gs: 450, th: 180, og: false },
+        ] },
+      ]), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (u.host === OPENSKY_HOST) {
+      if (openSkyStatus !== 200) {
+        return new Response('Too many requests', { status: openSkyStatus });
+      }
+      return new Response(JSON.stringify({ time: 0, states: openSkyStates }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+}
+
+const openSkyDataCalls = () => calls.filter(c => new URL(c.url).host === OPENSKY_HOST);
+
+beforeEach(() => install());
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+test('issues exactly ONE OpenSky /states/all request per run', async () => {
+  await fetchAllStates();
+  const os = openSkyDataCalls();
+  assert.equal(
+    os.length, 1,
+    `Expected 1 OpenSky states request per run, got ${os.length}: ${os.map(c => c.url).join(' , ')}. ` +
+    'Each >400 sq° bbox costs 4 credits — the same as one global query — so N regional ' +
+    'queries cost Nx4/run against a 4,000/day quota (#6222).',
+  );
+});
+
+test('the OpenSky request carries NO bounding box (global = 4 credits, widest coverage)', async () => {
+  await fetchAllStates();
+  const [os] = openSkyDataCalls();
+  assert.ok(os, 'expected an OpenSky states request');
+  const params = new URL(os.url).searchParams;
+  for (const bboxParam of ['lamin', 'lamax', 'lomin', 'lomax']) {
+    assert.equal(
+      params.get(bboxParam), null,
+      `OpenSky request still carries ${bboxParam}=${params.get(bboxParam)}. A bounded query above ` +
+      '400 sq° costs the same 4 credits as a global one but sees less; drop the bbox (#6222).',
+    );
+  }
+});
+
+test('OpenSky-only aircraft still reach the merged set when Wingbits already succeeded', async () => {
+  const { allStates } = await fetchAllStates();
+  const ids = allStates.map(s => s[0]);
+  assert.ok(
+    ids.includes(WINGBITS_ONLY),
+    'Wingbits aircraft missing from the merged set',
+  );
+  assert.ok(
+    ids.includes(OPENSKY_ONLY),
+    'OpenSky-only aircraft missing from the merged set. OpenSky merges ADDITIVELY by icao24 and ' +
+    'contributes aircraft Wingbits never saw, so it must NOT be gated behind Wingbits failure — ' +
+    'a degraded-but-non-empty Wingbits response would silently delete this coverage (#6222).',
+  );
+});
+
+test('never falls back to an unauthenticated OpenSky request', async () => {
+  // Anonymous OpenSky is 400 credits/day PER IP on shared Railway/Vercel egress,
+  // so it can essentially never succeed — it only adds a timeout to the failure path.
+  install({ openSkyStatus: 429 });
+  await fetchAllStates();
+  const anon = openSkyDataCalls().filter(c => {
+    const auth = c.headers.Authorization || c.headers.authorization;
+    return !auth;
+  });
+  assert.equal(
+    anon.length, 0,
+    `Found ${anon.length} unauthenticated OpenSky request(s) after an authenticated failure. ` +
+    'The anonymous tier is per-IP and shared across all tenants of the egress pool; it cannot ' +
+    'succeed and costs a full timeout on every failure path (#6222).',
+  );
+});


### PR DESCRIPTION
Closes #6222.

OpenSky bills `/states/all` by bounding-box **area** with a **flat top tier**: any bbox above
400 sq° costs 4 credits — exactly what a global query costs. We were issuing two large regional
bboxes in each of two services, paying 8 credits per run for coverage that excluded the
Americas, and exhausting the 4,000/day allowance every day.

| | before | after |
|---|---|---|
| `seed-military-flights` (`*/5`) | 2 bboxes x 4cr = 8/run | **1 global x 4cr** |
| `ais-relay` theater posture (10 min) | 2 bboxes x 4cr = 8/run | **1 global x 4cr** |
| per-viewer fallthrough | unbounded | **0** |
| **daily spend** | **3,456+ / 4,000 (86%)** | **1,728 / 4,000 (43%)** |

Half the cost, and coverage goes from ~9.4% of the globe to all of it.

## Measured, not assumed

One global `/states/all?extended=1`, issued against the **anonymous** tier from a residential IP
(a separate 400/day-per-IP pool, so it cost the production account nothing):

```
HTTP 200   X-Rate-Limit-Remaining: 396      <- 400 - 4: flat top tier confirmed live
7,680 state vectors | 0.96 MB | 4.11 s
```

That settles two review questions: the **4-credit price is confirmed empirically**, and 4.11s
against the seeder's 15s budget leaves **10.9s of headroom** — no timeout constant needs raising.
The global payload is under 1 MB, so this is not a payload-size trade.

## What is deliberately NOT done

**OpenSky is not gated behind Wingbits success.** Its states merge additively by `icao24`, so it
contributes aircraft Wingbits never saw; gating would delete that coverage, and a
degraded-but-non-empty Wingbits response would satisfy the gate. This was the original plan for
#6222 and was dropped after review — see the [correction on the issue](https://github.com/koala73/worldmonitor/issues/6222#issuecomment-5189069806).
Reducing the cost removes the pressure that motivated gating.

The ablation control for that decision is a test: *"OpenSky-only aircraft still reach the merged
set when Wingbits already succeeded"*. Mutation-proven — adding the gate turns it red.

## Required deploy step

**Flush `military:surges:history:v1` when this deploys.**

Three theaters extend past the old query boxes — `iran-theater` (east 65 vs lomax 57),
`south-china-sea` (south 5 / west 105 vs lamin 10 / lomin 107), and `yemen-redsea-theater`
(south 11 vs lamin 13). Their traffic was partly invisible to **both** tiers (Wingbits builds its
areas from the same `QUERY_REGIONS`), so their counts step up at deploy.

`buildMilitarySurges` compares against a 12-snapshot baseline. A theater going 4 -> 6 flights
purely from new coverage is +50% and fires a false `air_activity` surge. `normalizeSourceFamily`
cannot prevent it: `sourceVersion` stays `wingbits` across the change, so pre- and
post-widening snapshots are the same family.

Flushing the history key suppresses this entirely — `_military-surges.mjs:106` skips any theater
with fewer than `MIN_HISTORY_POINTS = 3` priors, so at `*/5` there is a **15-minute quiet window**
while the baseline rebuilds under the new coverage. No code change needed.

## Verification

- **285+ tests green** across every changed module; `typecheck`, `typecheck:api`, biome clean.
- **Five mutation proofs** — every new assertion shown to fail with its defect restored:
  gate OpenSky behind Wingbits (ablation control red) · restore the seeder per-region loop ·
  restore the anonymous fallback · restore the relay 2-region loop (`upstreamFetches` red) ·
  revert `LIVE_SEED_COVERAGE` (both coverage guards red).

## Review findings fixed in-branch

- **Redis error blanked the map.** A failed read of `military:flights:v1` threw past the
  `if (!fullResult)` branch into the bare catch, returning empty **without consulting the 24h
  stale key**. Pre-existing, but global coverage routed every viewport through it. The catch now
  reads stale first — another Redis GET, not a provider call, so the no-amplification property
  the throw protects is preserved.
- **Failure-path spend was unpinned.** The request-count assertion ran only against a succeeding
  fixture, so a second *authenticated* request on the failure path would have passed every test.
- **A comment I added was wrong.** "13s of headroom" ignored that the GET decoder coerces missing
  bbox params to `0`, so an icao24 lookup also runs the bbox block and falls through to the 8s
  tier — 20s total, measured. Corrected.

## Known residuals, filed not fixed

- #6241 — the seeder ignores `429`/`Retry-After`, re-firing ~76 doomed requests per outage. A 429
  spends no credits, so it does not affect this quota math.
- #6242 — the global snapshot is duplicated across every bbox cache key. This change made it
  universal. **The obvious one-line fix is a correctness bug** — the issue documents the trap.
- #6243 — `redisSet` checks only `resp.ok`, but Upstash returns command errors as HTTP 200.
- **Dashboard coverage unchanged.** `src/services/military-flights.ts` still iterates the two
  pre-#6222 regions, so the wider coverage currently reaches API/MCP callers, not the map. The
  credit win is unaffected. Worth a follow-up.

## Not verified

Removing the anonymous OpenSky fallback rests on the per-IP contention argument, not measurement:
`wm_api_usage` is gateway-only and does not carry the serving `source`, so there is no telemetry
to confirm the tier ever fired. It was the third tier behind two others, and this fix makes tier 2
healthy again, which reduces how often tier 3 is reached at all.

## Note on sequencing

Deploying does **not** clear the current 429 — today's credits are already spent, and this stops
future spend rather than refunding. The quota refills on its own schedule regardless. Confirm the
fix a day after it is live by checking `X-Rate-Limit-Remaining` lands near 43% rather than zero.

https://claude.ai/code/session_01WthVW8NVf8JtphhZLJotqR
