### PR TITLE
fix(docs): use MDX comments for the generated attribution markers

### DIFF
--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -647,7 +647,7 @@ WorldMonitor is grateful to the following organizations for making their data pu
 | AviationStack | International airport delay coverage | [aviationstack.com](https://aviationstack.com/) |
 
 ## Observed Upstream Inventory
-<!-- BEGIN GENERATED SOURCE ATTRIBUTION -->
+{/* BEGIN GENERATED SOURCE ATTRIBUTION */}
 This generated inventory covers **528 active upstream hosts** (**288 structured/API**, **268 feed**, and **30 operational-status** hosts). It is derived from URL literals in `scripts/`, `server/`, `api/`, and `src/`; the manifest records a license posture and the credit required for every observed host. 515 entries remain marked `terms-review` and should be confirmed before a redistribution or commercial-use claim.
 
 | Provider | Observed surface | License posture | Required attribution or exclusion reason | Status |
@@ -1301,4 +1301,4 @@ This generated inventory covers **528 active upstream hosts** (**288 structured/
 | your-app.convex.site (your-app.convex.site) | structured — scripts/import-bounced-emails.mjs:20 | Provider terms for this upstream API/dataset; verify before redistribution | Credit your-app.convex.site and link to the original upstream API/dataset. | terms-review |
 | yourstory.com (yourstory.com) | feed+structured — src/config/feeds.ts:533, src/config/variants/tech.ts:97 | Provider terms for this feed publisher; verify before redistribution | Credit yourstory.com and link to the original feed publisher. | terms-review |
 | zdf-hls-19.akamaized.net (zdf-hls-19.akamaized.net) | feed — src/components/LiveNewsPanel.ts:115, src/components/LiveNewsPanel.ts:284 | Excluded: live-video playback transport; channel/provider terms apply separately | Excluded from the external-provider count: presentation-only HLS stream, not an ingested dataset. | excluded |
-<!-- END GENERATED SOURCE ATTRIBUTION -->
+{/* END GENERATED SOURCE ATTRIBUTION */}

--- a/scripts/source-attribution.mjs
+++ b/scripts/source-attribution.mjs
@@ -21,8 +21,14 @@ import { fileURLToPath } from 'node:url';
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const MANIFEST_PATH = 'shared/source-attribution-manifest.json';
 const DOCS_PATH = 'docs/data-sources.mdx';
-const BEGIN_MARKER = '<!-- BEGIN GENERATED SOURCE ATTRIBUTION -->';
-const END_MARKER = '<!-- END GENERATED SOURCE ATTRIBUTION -->';
+// MDX comments, not HTML ones: Mintlify parses docs/data-sources.mdx as MDX v3,
+// which rejects `<!--` ("Unexpected character `!` before name") and fails the
+// whole deployment. The markers are interpolated into RegExp below, and `{`,
+// `*`, `}` are metacharacters, so every interpolation must go through
+// escapeRegExp — writing them raw silently stops the generator finding its own
+// block.
+const BEGIN_MARKER = '{/* BEGIN GENERATED SOURCE ATTRIBUTION */}';
+const END_MARKER = '{/* END GENERATED SOURCE ATTRIBUTION */}';
 const MANIFEST_STATUSES = new Set(['terms-review', 'reviewed', 'excluded']);
 const MANIFEST_KIND_RE = /^(?:structured|feed|operational-status)(?:\+(?:structured|feed|operational-status))*$/;
 const LOGICAL_KIND_RE = /^(?:candidate|structured|feed|operational-status)(?:\+(?:structured|feed|operational-status))*$/;
@@ -798,12 +804,30 @@ export function renderAttributionSection(inventory, manifest) {
   ].join('\n');
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function inventoryMarkerPattern(leadingNewline) {
+  return new RegExp(
+    `${leadingNewline ? '\\n' : ''}## (?:Audited|Observed) Upstream Inventory\\n` +
+      `${escapeRegExp(BEGIN_MARKER)}[\\s\\S]*?${escapeRegExp(END_MARKER)}`,
+  );
+}
+
+/** Single source of truth for locating the generated block, shared with the test. */
+export function matchGeneratedAttributionSection(docs) {
+  return docs.match(inventoryMarkerPattern(false))?.[0];
+}
+
 function updateDocs(rootDir, section) {
   const path = join(rootDir, DOCS_PATH);
   const current = readFileSync(path, 'utf8');
-  const markerPattern = new RegExp(`\\n## (?:Audited|Observed) Upstream Inventory\\n${BEGIN_MARKER}[\\s\\S]*?${END_MARKER}`);
+  const markerPattern = inventoryMarkerPattern(true);
   const updated = markerPattern.test(current)
-    ? current.replace(markerPattern, `\n${section}`)
+    // Function replacement: `section` is generated from manifest text that can
+    // contain `$&`/`$'`, which String.replace would otherwise expand.
+    ? current.replace(markerPattern, () => `\n${section}`)
     : `${current.trimEnd()}\n\n${section}\n`;
   writeFileSync(path, updated);
 }
@@ -838,7 +862,7 @@ function main() {
   }
   const expectedSection = renderAttributionSection(inventory, previous);
   const docs = read(ROOT, DOCS_PATH);
-  const markerPattern = new RegExp(`## (?:Audited|Observed) Upstream Inventory\\n${BEGIN_MARKER}[\\s\\S]*?${END_MARKER}`);
+  const markerPattern = inventoryMarkerPattern(false);
   const actual = docs.match(markerPattern)?.[0];
   if (actual !== expectedSection) {
     console.error('source-attribution: docs/data-sources.mdx is out of date; run node scripts/source-attribution.mjs --write');

--- a/tests/source-attribution.test.mjs
+++ b/tests/source-attribution.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import {
   loadManifest,
+  matchGeneratedAttributionSection,
   renderAttributionSection,
   scanUpstreamHosts,
   sourceAttributionStats,
@@ -20,8 +21,17 @@ test('source inventory has complete metadata and matches the generated catalog',
 
   const docs = readFileSync(join(rootDir, 'docs/data-sources.mdx'), 'utf8');
   const generated = renderAttributionSection(inventory, manifest);
-  const actual = docs.match(/## Observed Upstream Inventory\n<!-- BEGIN GENERATED SOURCE ATTRIBUTION -->[\s\S]*?<!-- END GENERATED SOURCE ATTRIBUTION -->/)?.[0];
+  const actual = matchGeneratedAttributionSection(docs);
   assert.equal(actual, generated, 'docs/data-sources.mdx must contain exactly the generated attribution section');
+
+  // Mintlify parses this page as MDX v3, which rejects `<!--` with
+  // "Unexpected character `!` (U+0021) before name" and fails the whole
+  // deployment. Nothing repo-side catches that, so pin it here.
+  assert.equal(
+    docs.includes('<!--'),
+    false,
+    'docs/data-sources.mdx must not contain HTML comments — MDX v3 rejects them; use {/* ... */}',
+  );
 
   const stats = sourceAttributionStats(inventory, manifest);
   assert.equal(stats.activeHosts, 528);


### PR DESCRIPTION
## Summary

Mintlify parses `docs/data-sources.mdx` as MDX v3, which rejects HTML comments:

> Failed to parse page content at path data-sources.mdx: Unexpected character `!` (U+0021) before name, expected a character that can start a name, such as a letter, `$`, or `_`

The generated source-attribution block is fenced with `<!-- BEGIN/END GENERATED SOURCE ATTRIBUTION -->` (added in #6250), so **every Mintlify deployment that actually runs fails** with "Encountered syntax error(s). Deployment not updated".

Main never caught it: main's Mintlify check reports `skipped — No changes to preview`, so it never parsed the page. The failure only surfaces on a PR whose deployment runs — where it looks like that PR's fault. It was first seen on #6219, which contributes no Mintlify-parsed content at all (its only docs change is under `docs/internal/`, which both `.mintignore` and `.mintlifyignore` exclude).

Not merge-blocking today — required contexts are `biome`, `typecheck`, `gate`, `unit` — but it red-flags unrelated PRs and leaves the docs site un-updated.

## Why this is more than a find-and-replace

Both marker constants are interpolated **straight into `new RegExp(...)`**:

```js
const markerPattern = new RegExp(`...${BEGIN_MARKER}[\\s\\S]*?${END_MARKER}`);
```

That works today only because `<`, `!`, `-`, `>` aren't regex metacharacters. `{/* ... */}` is nearly all metacharacters — `{` opens a quantifier, `*` is a quantifier, `}` closes one. Swapping the constants alone makes the pattern stop matching its own block, and `updateDocs` silently falls to its append branch, duplicating the whole ~650-line section instead of replacing it. (Observed directly while preparing this change.)

So the markers now go through a new `escapeRegExp`, and the pattern is built in one place — exported as `matchGeneratedAttributionSection` — shared with the test, which previously hardcoded its own copy of the regex.

Also makes `updateDocs`' replacement a function so `$&` / `$'` sequences in generated manifest text can't be expanded by `String.replace`.

## Not a content change

The regenerated block is byte-identical apart from the two marker lines. `node scripts/source-attribution.mjs` (check mode) passes against the edited doc, and the diff is 2 changed lines in `docs/data-sources.mdx`.

The doc was patched surgically rather than via `--write`: `--write` also rebuilds `shared/source-attribution-manifest.json` and produced ~158 lines of unrelated churn even though check mode passes on pristine main. That drift is pre-existing and left alone here.

## Verification

- `node --test tests/source-attribution.test.mjs` — 8/8 pass
- **Mutation:** dropping `escapeRegExp` from the pattern turns the catalog test red (`must contain exactly the generated attribution section`)
- **Mutation:** a stray `<!--` elsewhere in the doc trips *only* the new HTML-comment assertion while the section match still passes — so the new guard is isolated, not vacuous
- `biome check` on both changed JS files — clean
- Pre-push gate passed

## Regression guard

`tests/source-attribution.test.mjs` now asserts `docs/data-sources.mdx` contains no `<!--`. Nothing repo-side caught this — `mintlify-slugs`, `markdown`, and `public-docs` all pass on the broken content.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation

## Affected areas

- [x] Other: docs generation (`scripts/source-attribution.mjs`), Mintlify deployment