### PR TITLE
fix(military): persist the OpenSky 429 cooldown so the seeder stops re-firing (#6241)

### DIFF
--- a/scripts/_proxy-utils.cjs
+++ b/scripts/_proxy-utils.cjs
@@ -308,6 +308,11 @@ function proxyFetch(url, proxyConfig, {
             location: resp.headers.location || '',
             buffer,
             contentType: resp.headers['content-type'] || '',
+            // Additive: callers that only read ok/status/location/buffer/contentType
+            // are unaffected. Rate-limit headers (Retry-After and vendor variants)
+            // are lost forever otherwise, so a 429 that arrives through the tunnel
+            // cannot say how long the lockout lasts (#6241).
+            headers: resp.headers,
           }),
           rejectOnce,
         );

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, getRedisCredentials, acquireLockSafely, releaseLock, withRetry, writeFreshnessMetadata, logSeedResult, verifySeedKey, extendExistingTtl } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, getRedisCredentials, acquireLockSafely, releaseLock, withRetry, writeFreshnessMetadata, logSeedResult, verifySeedKey, extendExistingTtl, getResponseHeader } from './_seed-utils.mjs';
 import { summarizeMilitaryTheaters, buildMilitarySurges, appendMilitaryHistory } from './_military-surges.mjs';
 import { buildEnvelope, unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { pathToFileURL } from 'node:url';
 import { createRequire } from 'node:module';
+import { createHash } from 'node:crypto';
 
 loadEnvFile(import.meta.url);
 
@@ -525,6 +526,19 @@ function redactProxy(msg) {
   return String(msg || '').replace(/\/\/[^@]+@/g, '//<redacted>@');
 }
 
+// Carries the rate-limit metadata off the tunnel. Without this a 429 arriving
+// through the proxy can only ever produce the fallback cooldown, because the
+// transport used to drop every response header. Pure and exported because
+// proxyFetch runs on raw sockets and cannot be reached from a fetch mock — the
+// companion test drives proxyFetch itself to prove `result` really has this
+// shape, and this one proves the shape becomes a usable error (#6241).
+function proxyResponseError(result) {
+  return Object.assign(new Error(`HTTP ${result?.status}`), {
+    status: result?.status,
+    retryAfterSeconds: parseRetryAfterSeconds(result?.headers),
+  });
+}
+
 async function proxyFetchJson(url, { headers = {}, timeout = 15000, method = 'GET', body = null } = {}) {
   const { proxyFetch, parseProxyConfig } = createRequire(import.meta.url)('./_proxy-utils.cjs');
   const proxyConfig = parseProxyConfig(OPENSKY_PROXY_AUTH);
@@ -536,7 +550,7 @@ async function proxyFetchJson(url, { headers = {}, timeout = 15000, method = 'GE
     body,
     timeoutMs: timeout,
   });
-  if (!result.ok) throw Object.assign(new Error(`HTTP ${result.status}`), { status: result.status });
+  if (!result.ok) throw proxyResponseError(result);
   return JSON.parse(result.buffer.toString('utf8'));
 }
 
@@ -551,8 +565,11 @@ const OPENSKY_AUTH_RETRY_DELAYS = [0, 2_000, 5_000];
 // to outlive the process. Redis is the only state that does (#6241).
 const OPENSKY_COOLDOWN_KEY = 'opensky:cooldown-until:v1';
 // OpenSky omits the retry-after header on some rejections; those repeat just as
-// reliably, so a header-less 429 still parks the tier for a short window.
-const OPENSKY_429_FALLBACK_COOLDOWN_MS = 90_000;
+// reliably, so a header-less 429 still parks the tier. Sized against THIS
+// seeder's cadence, not the relay's sub-minute loop: the process is one-shot on
+// a */5 cron, so any deadline under 300s has already expired by the next tick
+// and suppresses exactly zero requests. Two ticks buys real headroom.
+const OPENSKY_429_FALLBACK_COOLDOWN_MS = 10 * 60_000;
 // Upper bound on ANY cooldown, applied on write AND on read. This guard is the
 // alarm, so a corrupt or hand-written deadline must not be able to switch a data
 // tier off permanently — anything past this window is treated as garbage.
@@ -568,6 +585,12 @@ function clearOpenSkyToken() {
 }
 
 function isOpenSkyRateLimitedError(error) {
+  // `proxyConnect` marks a rejection by the residential proxy's own gateway
+  // (its auth/quota/policy), not by OpenSky. Both collapse to status 429, and
+  // treating the proxy vendor's quota as an OpenSky lockout would park a
+  // healthy data tier for hours — _proxy-utils.cjs sets the marker for exactly
+  // this discrimination.
+  if (error?.proxyConnect) return false;
   if (Number(error?.status) === 429) return true;
   return /HTTP 429\b/i.test(String(error?.message || error || ''));
 }
@@ -583,13 +606,23 @@ function getOpenSkyAuthStatus() {
 }
 
 // OpenSky advertises how long the account is locked out for; the standard
-// Retry-After is accepted as a fallback. Values are clamped rather than
-// trusted — an upstream typo must not be able to park the tier for a week.
+// Retry-After is accepted as a fallback, in both the delta-seconds and the
+// HTTP-date form RFC 7231 permits. Reads through getResponseHeader so the same
+// parser works on a fetch `Headers` and on the plain-object header map the
+// proxy transport returns. Values are clamped rather than trusted — an upstream
+// typo must not be able to park the tier for a week.
 function parseRetryAfterSeconds(headers) {
   for (const name of ['x-rate-limit-retry-after-seconds', 'retry-after']) {
-    const seconds = Number(headers.get(name));
+    const raw = getResponseHeader(headers, name);
+    if (!raw) continue;
+    const seconds = Number(raw);
     if (Number.isFinite(seconds) && seconds > 0) {
       return Math.min(Math.ceil(seconds), OPENSKY_MAX_COOLDOWN_MS / 1000);
+    }
+    const retryAt = Date.parse(raw);
+    if (Number.isFinite(retryAt)) {
+      const delta = Math.ceil((retryAt - Date.now()) / 1000);
+      if (delta > 0) return Math.min(delta, OPENSKY_MAX_COOLDOWN_MS / 1000);
     }
   }
   return null;
@@ -615,6 +648,17 @@ async function fetchJsonDirect(url, { headers = {}, method = 'GET', body = null,
   return resp.json();
 }
 
+// The cooldown is a property of an ACCOUNT's quota, but the key is global. On a
+// credential rotation a healthy new account would otherwise inherit the old
+// one's lockout and lose coverage for its remaining window. A non-secret
+// fingerprint of the client id makes the record self-identifying; a mismatch
+// fails OPEN, same as every other unreadable record (#6241).
+function openSkyAccountFingerprint() {
+  const clientId = process.env.OPENSKY_CLIENT_ID;
+  if (!clientId) return null;
+  return createHash('sha256').update(clientId).digest('hex').slice(0, 12);
+}
+
 function getOptionalRedisCredentials() {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -632,25 +676,42 @@ function formatWait(ms) {
 // Fails OPEN on every error path. The worst case of a wrong "no cooldown" answer
 // is one wasted request; the worst case of a wrong "cooldown active" answer is
 // silently deleting a data tier for as long as Redis stays unhappy.
+//
+// The try wraps the WHOLE body, not just the Redis call. This function's own
+// parsing runs on an untrusted record, and it is called outside any caller's
+// try — so a throw here would kill the entire run, Wingbits included, on every
+// tick until someone deleted the key by hand. That is strictly worse than the
+// bug the cooldown exists to fix, so nothing in here may escape (#6241).
 async function readOpenSkyCooldown() {
   const creds = getOptionalRedisCredentials();
-  if (!creds) return { remainingMs: 0, recordPresent: false };
-  let record = null;
+  if (!creds) return { remainingMs: 0 };
   try {
-    record = await redisGet(creds.url, creds.token, OPENSKY_COOLDOWN_KEY);
-  } catch {
-    return { remainingMs: 0, recordPresent: false };
+    const record = await redisGet(creds.url, creds.token, OPENSKY_COOLDOWN_KEY);
+    const until = Number(record?.until);
+    if (!Number.isFinite(until)) return { remainingMs: 0 };
+    // A record written by different credentials describes a quota this run does
+    // not share. Records with no fingerprint predate this field, so they are
+    // also treated as not-ours rather than obeyed blindly.
+    const account = openSkyAccountFingerprint();
+    if (!record?.account || record.account !== account) {
+      console.warn('  [OpenSky Quota] ignoring cooldown recorded for a different OpenSky account');
+      return { remainingMs: 0 };
+    }
+    const remainingMs = until - Date.now();
+    // Beyond the documented maximum the record cannot have come from this code
+    // path, so obey the clock rather than the value. Logged as a raw number:
+    // `new Date(n).toISOString()` throws RangeError past ±8.64e15, and a
+    // nanosecond-scale timestamp lands there — formatting the very value this
+    // branch exists to reject would turn the guard into the outage.
+    if (remainingMs > OPENSKY_MAX_COOLDOWN_MS) {
+      console.warn(`  [OpenSky Quota] ignoring implausible cooldown deadline ${until}`);
+      return { remainingMs: 0 };
+    }
+    return { remainingMs: Math.max(0, remainingMs) };
+  } catch (err) {
+    console.warn(`  [OpenSky Quota] cooldown read failed, proceeding without it: ${err.message || err}`);
+    return { remainingMs: 0 };
   }
-  const until = Number(record?.until);
-  if (!Number.isFinite(until)) return { remainingMs: 0, recordPresent: false };
-  const remainingMs = until - Date.now();
-  // Beyond the documented maximum the record cannot have come from this code
-  // path, so obey the clock rather than the value.
-  if (remainingMs > OPENSKY_MAX_COOLDOWN_MS) {
-    console.warn(`  [OpenSky Auth] ignoring implausible cooldown deadline ${new Date(until).toISOString()}`);
-    return { remainingMs: 0, recordPresent: true };
-  }
-  return { remainingMs: Math.max(0, remainingMs), recordPresent: true };
 }
 
 async function recordOpenSkyCooldown(retryAfterSeconds) {
@@ -660,7 +721,7 @@ async function recordOpenSkyCooldown(retryAfterSeconds) {
   );
   const until = Date.now() + cooldownMs;
   console.warn(
-    `  [OpenSky Auth] 429 quota exhausted — cooldown ${formatWait(cooldownMs)} ` +
+    `  [OpenSky Quota] 429 quota exhausted — cooldown ${formatWait(cooldownMs)} ` +
     `(until ${new Date(until).toISOString()}, retryAfter=${retryAfterSeconds ?? 'absent'})`,
   );
   const creds = getOptionalRedisCredentials();
@@ -671,12 +732,18 @@ async function recordOpenSkyCooldown(retryAfterSeconds) {
     await redisSet(creds.url, creds.token, OPENSKY_COOLDOWN_KEY, {
       until,
       untilIso: new Date(until).toISOString(),
+      // Both values: the clamped one drove the deadline, the advertised one is
+      // what OpenSky actually said. Persisting only the clamp hides an
+      // implausible upstream header from whoever reads this key during an
+      // incident.
       retryAfterSeconds: retryAfterSeconds ?? null,
+      cooldownMs,
+      account: openSkyAccountFingerprint(),
       recordedAt: Date.now(),
       recordedBy: 'seed-military-flights',
     }, Math.ceil(cooldownMs / 1000) + 60);
   } catch (err) {
-    console.warn(`  [OpenSky Auth] failed to persist cooldown: ${err.message || err}`);
+    console.warn(`  [OpenSky Quota] failed to persist cooldown: ${err.message || err}`);
   }
 }
 
@@ -688,7 +755,14 @@ async function recordOpenSkyCooldown(retryAfterSeconds) {
 function combineOpenSkyFetchErrors(directError, proxyError) {
   return Object.assign(
     new Error(`direct=${redactProxy(directError?.message)} | proxy=${redactProxy(proxyError?.message)}`),
-    { status: proxyError?.status, retryAfterSeconds: proxyError?.retryAfterSeconds ?? null },
+    {
+      status: proxyError?.status,
+      retryAfterSeconds: proxyError?.retryAfterSeconds ?? null,
+      // `proxyConnect` must survive alongside `status`, or the combined error
+      // reads as a bare 429 and a proxy-vendor quota problem gets recorded as an
+      // OpenSky lockout — parking a healthy upstream on someone else's billing.
+      proxyConnect: proxyError?.proxyConnect === true,
+    },
   );
 }
 
@@ -698,7 +772,7 @@ async function clearOpenSkyCooldown() {
   try {
     await redisDel(creds.url, creds.token, OPENSKY_COOLDOWN_KEY);
   } catch (err) {
-    console.warn(`  [OpenSky Auth] failed to clear cooldown: ${err.message || err}`);
+    console.warn(`  [OpenSky Quota] failed to clear cooldown: ${err.message || err}`);
   }
 }
 
@@ -851,12 +925,12 @@ async function fetchOpenSkyGlobal({ source, fetchSources, seenIds, allStates }) 
   // seen run to 22,688s (~6.3h): ~76 doomed requests per outage (#6241).
   const cooldown = await readOpenSkyCooldown();
   if (cooldown.remainingMs > 0) {
-    regionSource.authStatus = `cooldown:${Math.ceil(cooldown.remainingMs / 1000)}s`;
+    regionSource.authStatus = `quota-cooldown:${Math.ceil(cooldown.remainingMs / 1000)}s`;
     fetchSources.openSkyCooldownRemainingMs = cooldown.remainingMs;
     // Quota exhaustion and a provider outage both look like "no OpenSky states"
     // downstream; only this line tells them apart.
     console.warn(
-      `  [OpenSky Auth] GLOBAL: SKIPPED — quota cooldown, ${formatWait(cooldown.remainingMs)} remaining. ` +
+      `  [OpenSky Quota] GLOBAL: SKIPPED — quota cooldown, ${formatWait(cooldown.remainingMs)} remaining. ` +
       'Publishing from Wingbits only.',
     );
     fetchSources.regions.push(regionSource);
@@ -869,9 +943,12 @@ async function fetchOpenSkyGlobal({ source, fetchSources, seenIds, allStates }) 
     regionSource.authStatus = authResult?.status || regionSource.authStatus;
     if (authResult?.rateLimited) {
       await recordOpenSkyCooldown(authResult.retryAfterSeconds);
-    } else if (regionSource.authStatus.startsWith('success:') && cooldown.recordPresent) {
-      // Only ever reachable for a record whose deadline has already passed —
-      // an unexpired one returns above — so this is a cleanup, not a race.
+    } else if (regionSource.authStatus.startsWith('success:')) {
+      // Unconditional on success. Gating this on "we read a record earlier"
+      // would tie the cleanup to a read that also returns empty when Redis is
+      // merely unreachable, so one GET blip would strand a dead deadline. A
+      // proven-live upstream is the authoritative signal; one DEL per healthy
+      // run is the whole cost, and it self-heals any corrupt record.
       await clearOpenSkyCooldown();
     }
     if (states && states.length > 0) {
@@ -886,6 +963,13 @@ async function fetchOpenSkyGlobal({ source, fetchSources, seenIds, allStates }) 
   } catch (e) {
     regionSource.authStatus = `error:${redactProxy(e.message)}`;
     console.warn(`  [OpenSky Auth] GLOBAL: ${redactProxy(e.message)}`);
+    // fetchOpenSkyAuthenticated has two exit contracts: it RETURNS a result
+    // carrying `rateLimited` for failures on the data call, and it THROWS for
+    // token acquisition — which runs outside its try. A 429 on the token
+    // endpoint is the same account-wide lockout and is just as doomed to
+    // repeat, but it costs three attempts and ~7s of sleeps per tick, so arm
+    // the cooldown here too rather than leaving that path un-gated (#6241).
+    if (isOpenSkyRateLimitedError(e)) await recordOpenSkyCooldown(e?.retryAfterSeconds ?? null);
   }
 
   if (states) {
@@ -998,6 +1082,7 @@ async function fetchAllStates() {
     oauthConfigured,
     proxyEnabled: PROXY_ENABLED,
     openSkyAuthSuccess: false,
+    openSkyCooldownRemainingMs: 0,
     regions: [],
   };
 
@@ -1357,7 +1442,7 @@ async function redisSet(url, token, key, value, ttl) {
 async function redisDel(url, token, key) {
   const resp = await fetch(url, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
     body: JSON.stringify(['DEL', key]),
     signal: AbortSignal.timeout(10_000),
   });
@@ -1624,4 +1709,15 @@ export {
   // touches globalThis.fetch, so the rate-limit metadata this carries onto the
   // combined error cannot be observed by driving fetchOpenSkyAuthenticated (#6241).
   combineOpenSkyFetchErrors,
+  // Test seam: this parser must work on BOTH header containers the two transports
+  // produce — a fetch `Headers` (direct) and a plain object (the proxy tunnel).
+  // Only the direct shape is reachable by driving fetchAllStates (#6241).
+  parseRetryAfterSeconds,
+  // Test seam: distinguishing an OpenSky lockout from the residential proxy's
+  // own gateway quota needs a proxy-leg failure, which raw sockets make
+  // unreachable from a fetch mock (#6241).
+  isOpenSkyRateLimitedError,
+  // Test seam: completes the proxy-leg chain — proxyFetch surfaces the headers,
+  // this turns them into an error the cooldown can read (#6241).
+  proxyResponseError,
 };

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -546,6 +546,17 @@ const WINGBITS_BASE = 'https://customer-api.wingbits.com/v1/flights';
 const OPENSKY_TOKEN_URL = 'https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token';
 const OPENSKY_AUTH_COOLDOWN_MS = 60_000;
 const OPENSKY_AUTH_RETRY_DELAYS = [0, 2_000, 5_000];
+// This seeder is a one-shot process on a */5 Railway cron, so the 429 cooldown
+// CANNOT live in a module variable the way the relay's does — the deadline has
+// to outlive the process. Redis is the only state that does (#6241).
+const OPENSKY_COOLDOWN_KEY = 'opensky:cooldown-until:v1';
+// OpenSky omits the retry-after header on some rejections; those repeat just as
+// reliably, so a header-less 429 still parks the tier for a short window.
+const OPENSKY_429_FALLBACK_COOLDOWN_MS = 90_000;
+// Upper bound on ANY cooldown, applied on write AND on read. This guard is the
+// alarm, so a corrupt or hand-written deadline must not be able to switch a data
+// tier off permanently — anything past this window is treated as garbage.
+const OPENSKY_MAX_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 let openskyToken = null;
 let openskyTokenExpiry = 0;
 let openskyTokenPromise = null;
@@ -557,6 +568,7 @@ function clearOpenSkyToken() {
 }
 
 function isOpenSkyRateLimitedError(error) {
+  if (Number(error?.status) === 429) return true;
   return /HTTP 429\b/i.test(String(error?.message || error || ''));
 }
 
@@ -570,6 +582,22 @@ function getOpenSkyAuthStatus() {
   return 'pending';
 }
 
+// OpenSky advertises how long the account is locked out for; the standard
+// Retry-After is accepted as a fallback. Values are clamped rather than
+// trusted — an upstream typo must not be able to park the tier for a week.
+function parseRetryAfterSeconds(headers) {
+  for (const name of ['x-rate-limit-retry-after-seconds', 'retry-after']) {
+    const seconds = Number(headers.get(name));
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return Math.min(Math.ceil(seconds), OPENSKY_MAX_COOLDOWN_MS / 1000);
+    }
+  }
+  return null;
+}
+
+// The status code and rate-limit headers are the only things that distinguish
+// "the quota is gone for 6 hours" from "one request failed" — throwing a bare
+// `HTTP ${status}` string discarded both before any caller could act (#6241).
 async function fetchJsonDirect(url, { headers = {}, method = 'GET', body = null, timeout = 15_000 } = {}) {
   const resp = await fetch(url, {
     method,
@@ -579,9 +607,99 @@ async function fetchJsonDirect(url, { headers = {}, method = 'GET', body = null,
   });
   if (!resp.ok) {
     const bodyText = await resp.text().catch(() => '');
-    throw new Error(`HTTP ${resp.status}: ${bodyText.substring(0, 200)}`);
+    throw Object.assign(new Error(`HTTP ${resp.status}: ${bodyText.substring(0, 200)}`), {
+      status: resp.status,
+      retryAfterSeconds: parseRetryAfterSeconds(resp.headers),
+    });
   }
   return resp.json();
+}
+
+function getOptionalRedisCredentials() {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  return url && token ? { url, token } : null;
+}
+
+function formatWait(ms) {
+  const totalSec = Math.max(0, Math.ceil(ms / 1000));
+  if (totalSec < 60) return `${totalSec}s`;
+  const hours = Math.floor(totalSec / 3600);
+  const minutes = Math.floor((totalSec % 3600) / 60);
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m ${totalSec % 60}s`;
+}
+
+// Fails OPEN on every error path. The worst case of a wrong "no cooldown" answer
+// is one wasted request; the worst case of a wrong "cooldown active" answer is
+// silently deleting a data tier for as long as Redis stays unhappy.
+async function readOpenSkyCooldown() {
+  const creds = getOptionalRedisCredentials();
+  if (!creds) return { remainingMs: 0, recordPresent: false };
+  let record = null;
+  try {
+    record = await redisGet(creds.url, creds.token, OPENSKY_COOLDOWN_KEY);
+  } catch {
+    return { remainingMs: 0, recordPresent: false };
+  }
+  const until = Number(record?.until);
+  if (!Number.isFinite(until)) return { remainingMs: 0, recordPresent: false };
+  const remainingMs = until - Date.now();
+  // Beyond the documented maximum the record cannot have come from this code
+  // path, so obey the clock rather than the value.
+  if (remainingMs > OPENSKY_MAX_COOLDOWN_MS) {
+    console.warn(`  [OpenSky Auth] ignoring implausible cooldown deadline ${new Date(until).toISOString()}`);
+    return { remainingMs: 0, recordPresent: true };
+  }
+  return { remainingMs: Math.max(0, remainingMs), recordPresent: true };
+}
+
+async function recordOpenSkyCooldown(retryAfterSeconds) {
+  const cooldownMs = Math.min(
+    OPENSKY_MAX_COOLDOWN_MS,
+    Math.max(OPENSKY_429_FALLBACK_COOLDOWN_MS, (Number(retryAfterSeconds) || 0) * 1000),
+  );
+  const until = Date.now() + cooldownMs;
+  console.warn(
+    `  [OpenSky Auth] 429 quota exhausted — cooldown ${formatWait(cooldownMs)} ` +
+    `(until ${new Date(until).toISOString()}, retryAfter=${retryAfterSeconds ?? 'absent'})`,
+  );
+  const creds = getOptionalRedisCredentials();
+  if (!creds) return;
+  try {
+    // The TTL outlives the deadline so a live key always answers the read; the
+    // successful-call path deletes it, and the TTL is only the backstop.
+    await redisSet(creds.url, creds.token, OPENSKY_COOLDOWN_KEY, {
+      until,
+      untilIso: new Date(until).toISOString(),
+      retryAfterSeconds: retryAfterSeconds ?? null,
+      recordedAt: Date.now(),
+      recordedBy: 'seed-military-flights',
+    }, Math.ceil(cooldownMs / 1000) + 60);
+  } catch (err) {
+    console.warn(`  [OpenSky Auth] failed to persist cooldown: ${err.message || err}`);
+  }
+}
+
+// A direct 429 short-circuits before the proxy is ever tried, so a 429 reaching
+// this combiner came from the PROXY leg and still describes a real account-wide
+// lockout — its retry-after must survive the re-wrap or the cooldown collapses
+// to the 90s fallback. Pure and exported because the proxy leg runs on raw
+// sockets in _proxy-utils.cjs and is unreachable from a fetch mock (#6241).
+function combineOpenSkyFetchErrors(directError, proxyError) {
+  return Object.assign(
+    new Error(`direct=${redactProxy(directError?.message)} | proxy=${redactProxy(proxyError?.message)}`),
+    { status: proxyError?.status, retryAfterSeconds: proxyError?.retryAfterSeconds ?? null },
+  );
+}
+
+async function clearOpenSkyCooldown() {
+  const creds = getOptionalRedisCredentials();
+  if (!creds) return;
+  try {
+    await redisDel(creds.url, creds.token, OPENSKY_COOLDOWN_KEY);
+  } catch (err) {
+    console.warn(`  [OpenSky Auth] failed to clear cooldown: ${err.message || err}`);
+  }
 }
 
 async function getOpenSkyToken() {
@@ -698,11 +816,16 @@ async function fetchOpenSkyAuthenticated() {
             clearOpenSkyToken();
             if (attempt === 0) continue;
           }
-          throw new Error(`direct=${redactProxy(directError.message)} | proxy=${redactProxy(proxyError.message)}`);
+          throw combineOpenSkyFetchErrors(directError, proxyError);
         }
       }
     } catch (error) {
-      return { states: null, status: `error:${redactProxy(error.message)}` };
+      return {
+        states: null,
+        status: `error:${redactProxy(error.message)}`,
+        rateLimited: isOpenSkyRateLimitedError(error),
+        retryAfterSeconds: error?.retryAfterSeconds ?? null,
+      };
     }
   }
 
@@ -722,10 +845,35 @@ async function fetchOpenSkyGlobal({ source, fetchSources, seenIds, allStates }) 
     statesAdded: 0,
   };
 
+  // A 429 spends no credits — the budget is already gone — so #6222's spend fix
+  // deliberately left this alone. What it costs is a full round-trip and its
+  // share of the run's wall clock, every 5 minutes, for a window production has
+  // seen run to 22,688s (~6.3h): ~76 doomed requests per outage (#6241).
+  const cooldown = await readOpenSkyCooldown();
+  if (cooldown.remainingMs > 0) {
+    regionSource.authStatus = `cooldown:${Math.ceil(cooldown.remainingMs / 1000)}s`;
+    fetchSources.openSkyCooldownRemainingMs = cooldown.remainingMs;
+    // Quota exhaustion and a provider outage both look like "no OpenSky states"
+    // downstream; only this line tells them apart.
+    console.warn(
+      `  [OpenSky Auth] GLOBAL: SKIPPED — quota cooldown, ${formatWait(cooldown.remainingMs)} remaining. ` +
+      'Publishing from Wingbits only.',
+    );
+    fetchSources.regions.push(regionSource);
+    return;
+  }
+
   try {
     const authResult = await fetchOpenSkyAuthenticated();
     states = authResult?.states || null;
     regionSource.authStatus = authResult?.status || regionSource.authStatus;
+    if (authResult?.rateLimited) {
+      await recordOpenSkyCooldown(authResult.retryAfterSeconds);
+    } else if (regionSource.authStatus.startsWith('success:') && cooldown.recordPresent) {
+      // Only ever reachable for a record whose deadline has already passed —
+      // an unexpired one returns above — so this is a cleanup, not a race.
+      await clearOpenSkyCooldown();
+    }
     if (states && states.length > 0) {
       if (source.value === 'none') source.value = 'opensky-auth';
       fetchSources.openSkyAuthSuccess = true;
@@ -1206,6 +1354,16 @@ async function redisSet(url, token, key, value, ttl) {
   if (!resp.ok) throw new Error(`Redis SET ${key} failed: HTTP ${resp.status}`);
 }
 
+async function redisDel(url, token, key) {
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(['DEL', key]),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!resp.ok) throw new Error(`Redis DEL ${key} failed: HTTP ${resp.status}`);
+}
+
 async function redisGet(url, token, key) {
   const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
     headers: { Authorization: `Bearer ${token}` },
@@ -1462,4 +1620,8 @@ export {
   // from the published payload. Exported so tests can assert the request
   // shape directly rather than grepping source text.
   fetchAllStates,
+  // Test seam: the proxy leg opens raw sockets in _proxy-utils.cjs and never
+  // touches globalThis.fetch, so the rate-limit metadata this carries onto the
+  // combined error cannot be observed by driving fetchOpenSkyAuthenticated (#6241).
+  combineOpenSkyFetchErrors,
 };

--- a/tests/proxy-utils.test.mjs
+++ b/tests/proxy-utils.test.mjs
@@ -172,6 +172,14 @@ describe('proxy utilities', () => {
       location: 'https://trusted.example/signed.xml',
       buffer: Buffer.from('redirect'),
       contentType: 'text/plain',
+      // The full header map rides along so callers can read headers this shape
+      // does not promote to a named field — rate-limit headers on a 429 are the
+      // motivating case, and dropping them silently downgrades an OpenSky quota
+      // cooldown from the advertised window to a short fallback (#6241).
+      headers: {
+        location: 'https://trusted.example/signed.xml',
+        'content-type': 'text/plain',
+      },
     });
     assert.equal(redirectHarness.destroyed(), 1);
 

--- a/tests/seed-military-flights-opensky-429-cooldown.test.mjs
+++ b/tests/seed-military-flights-opensky-429-cooldown.test.mjs
@@ -1,0 +1,373 @@
+// Regression guard for #6241 — the military-flights seeder must stop re-firing
+// `/states/all` while OpenSky's daily credit budget is exhausted.
+//
+// Production has seen `X-Rate-Limit-Retry-After-Seconds: 22688` (~6.3h). The
+// seeder runs as a FRESH PROCESS on every Railway `*/5` tick, so a module-level
+// cooldown cannot survive the window — the deadline has to live in Redis or the
+// seeder issues ~76 doomed authenticated requests per outage.
+//
+// The credit cost of a 429 is zero (the budget is already gone), so none of this
+// is observable from the published payload or from a credit-spend assertion —
+// which is why #6222's budget suite passes with this bug fully present. These
+// tests drive `fetchAllStates()` against a fake Upstash REST endpoint and count
+// the OUTBOUND requests a second, freshly-imported module instance makes.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.OPENSKY_CLIENT_ID = 'test-client';
+process.env.OPENSKY_CLIENT_SECRET = 'test-secret';
+process.env.WINGBITS_API_KEY = 'test-wingbits';
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'test-redis-token';
+delete process.env.OPENSKY_PROXY_AUTH;
+delete process.env.PROXY_URL;
+
+const OPENSKY_HOST = 'opensky-network.org';
+const TOKEN_HOST = 'auth.opensky-network.org';
+const WINGBITS_HOST = 'customer-api.wingbits.com';
+const REDIS_HOST = 'redis.test';
+const COOLDOWN_KEY = 'opensky:cooldown-until:v1';
+
+const originalFetch = globalThis.fetch;
+const originalLog = console.log;
+const originalWarn = console.warn;
+
+let calls;
+let redisStore;
+let logLines;
+let redisReadFails;
+
+function json(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// A state vector is a positional array; index 0 is icao24, 5 lon, 6 lat, 8 onGround.
+function state(icao24, callsign, lat, lon) {
+  const s = new Array(17).fill(null);
+  s[0] = icao24;
+  s[1] = callsign;
+  s[5] = lon;
+  s[6] = lat;
+  s[7] = 10000;
+  s[8] = false;
+  s[9] = 400;
+  s[10] = 90;
+  return s;
+}
+
+// ADF7C8-AFFFFF is the USAF hex range the seeder already recognises, so these
+// are admitted on hex alone and the assertions do not depend on callsign rules.
+const WINGBITS_ONLY = 'ae1111';
+const OPENSKY_ONLY = 'ae2222';
+
+function handleRedis(u, opts) {
+  if ((opts.method || 'GET').toUpperCase() === 'POST') {
+    const cmd = JSON.parse(opts.body);
+    const [verb, key] = cmd;
+    if (verb === 'SET') {
+      redisStore.set(key, { value: cmd[2], ttl: cmd[3] === 'EX' ? Number(cmd[4]) : null });
+      return json({ result: 'OK' });
+    }
+    if (verb === 'DEL') {
+      return json({ result: redisStore.delete(key) ? 1 : 0 });
+    }
+    return json({ result: null });
+  }
+  if (redisReadFails === 'http') return new Response('upstream unavailable', { status: 503 });
+  // A DNS/socket failure rejects the fetch outright rather than answering 503 —
+  // a different code path in the reader, and the one a Redis outage produces.
+  if (redisReadFails === 'throw') throw new TypeError('fetch failed');
+  const key = decodeURIComponent(u.pathname.replace(/^\/get\//, ''));
+  const entry = redisStore.get(key);
+  return json({ result: entry ? entry.value : null });
+}
+
+function install({ openSkyStatus = 200, retryAfterSeconds = null } = {}) {
+  calls = [];
+  logLines = [];
+  const capture = (sink) => (...args) => { logLines.push(args.join(' ')); sink(...args); };
+  console.log = capture(originalLog);
+  console.warn = capture(originalWarn);
+
+  globalThis.fetch = async (url, opts = {}) => {
+    const raw = typeof url === 'string' ? url : url.url;
+    calls.push({ url: raw, method: opts.method || 'GET', headers: opts.headers || {} });
+    const u = new URL(raw);
+
+    if (u.host === REDIS_HOST) return handleRedis(u, opts);
+
+    if (u.host === TOKEN_HOST) {
+      return json({ access_token: 'tok', expires_in: 1800 });
+    }
+    if (u.host === WINGBITS_HOST) {
+      return json([
+        { alias: 'PACIFIC', data: [
+          { h: WINGBITS_ONLY, f: 'RCH999', la: 30, lo: 130, ab: 30000, gs: 450, th: 180, og: false },
+        ] },
+      ]);
+    }
+    if (u.host === OPENSKY_HOST) {
+      if (openSkyStatus !== 200) {
+        const headers = {};
+        if (retryAfterSeconds != null) headers['X-Rate-Limit-Retry-After-Seconds'] = String(retryAfterSeconds);
+        return new Response('Too many requests', { status: openSkyStatus, headers });
+      }
+      return json({ time: 0, states: [state(OPENSKY_ONLY, 'RCH123', 40, -100)] });
+    }
+    return json({});
+  };
+}
+
+const openSkyDataCalls = () => calls.filter((c) => new URL(c.url).host === OPENSKY_HOST);
+const openSkyTokenCalls = () => calls.filter((c) => new URL(c.url).host === TOKEN_HOST);
+const readCooldownRecord = () => {
+  const entry = redisStore.get(COOLDOWN_KEY);
+  return entry ? JSON.parse(entry.value) : null;
+};
+
+// A fresh module instance is how this suite models the next cron tick. The
+// seeder is a one-shot process, so anything the fix keeps in a module-level
+// variable is gone by the time the next tick runs — only Redis survives.
+let moduleSeq = 0;
+async function freshSeeder() {
+  moduleSeq += 1;
+  return import(`../scripts/seed-military-flights.mjs?tick=${moduleSeq}`);
+}
+
+beforeEach(() => {
+  redisStore = new Map();
+  redisReadFails = false;
+  install();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.log = originalLog;
+  console.warn = originalWarn;
+});
+
+test('a 429 with a retry-after header persists a cooldown deadline to Redis', async () => {
+  const retryAfterSeconds = 22_688; // the value production actually returned
+  install({ openSkyStatus: 429, retryAfterSeconds });
+  const before = Date.now();
+  const seeder = await freshSeeder();
+  await seeder.fetchAllStates();
+
+  const record = readCooldownRecord();
+  assert.ok(
+    record,
+    `No \`${COOLDOWN_KEY}\` record after a 429. The seeder is a one-shot process on a */5 cron, ` +
+    'so a module-level cooldown cannot survive the outage — the deadline must be persisted (#6241).',
+  );
+  const expected = before + retryAfterSeconds * 1000;
+  assert.ok(
+    Math.abs(Number(record.until) - expected) < 60_000,
+    `Cooldown deadline ${record.until} does not honour X-Rate-Limit-Retry-After-Seconds=${retryAfterSeconds} ` +
+    `(expected ~${expected}). Ignoring the header re-fires ~76 doomed requests across the window (#6241).`,
+  );
+
+  const ttl = redisStore.get(COOLDOWN_KEY)?.ttl;
+  assert.ok(
+    ttl != null && ttl >= retryAfterSeconds,
+    `Cooldown key TTL is ${ttl}s but the deadline is ${retryAfterSeconds}s away — the key would ` +
+    'expire mid-outage and the seeder would resume hammering (#6241).',
+  );
+});
+
+test('the next run issues ZERO OpenSky requests while the deadline is in the future', async () => {
+  install({ openSkyStatus: 429, retryAfterSeconds: 22_688 });
+  await (await freshSeeder()).fetchAllStates();
+  assert.ok(readCooldownRecord(), 'precondition: the 429 run must have armed a cooldown');
+
+  // Second tick: a brand-new module instance, so nothing but Redis carries state.
+  install();
+  const { allStates, fetchSources } = await (await freshSeeder()).fetchAllStates();
+
+  assert.equal(
+    openSkyDataCalls().length, 0,
+    `The cooled-down run still issued ${openSkyDataCalls().length} OpenSky /states/all request(s). ` +
+    'Every one is guaranteed to 429 for the rest of the window — ~76 per outage (#6241).',
+  );
+  assert.equal(
+    openSkyTokenCalls().length, 0,
+    'The cooled-down run still fetched an OpenSky bearer token. A token is only ever used for the ' +
+    'call being skipped, so acquiring one is pure round-trip cost (#6241).',
+  );
+  assert.ok(
+    allStates.map((s) => s[0]).includes(WINGBITS_ONLY),
+    'Wingbits coverage disappeared during the OpenSky cooldown. Skipping OpenSky must degrade to ' +
+    'Wingbits-only, never to an empty publish (#6241).',
+  );
+  assert.match(
+    fetchSources.regions[0]?.authStatus || '',
+    /cooldown/i,
+    `Expected the GLOBAL region to record a cooldown status, got: ${fetchSources.regions[0]?.authStatus}`,
+  );
+});
+
+test('the skip is logged with the remaining wait', async () => {
+  install({ openSkyStatus: 429, retryAfterSeconds: 22_688 });
+  await (await freshSeeder()).fetchAllStates();
+
+  install();
+  await (await freshSeeder()).fetchAllStates();
+
+  const skipLine = logLines.find((line) => /OpenSky/i.test(line) && /cooldown/i.test(line));
+  assert.ok(
+    skipLine,
+    'The cooled-down run logged nothing about the skip. Quota exhaustion and a provider outage ' +
+    `both surface as "no OpenSky states" otherwise. Lines seen:\n${logLines.join('\n')}`,
+  );
+  assert.match(
+    skipLine,
+    /\d+\s*h/i,
+    `The skip line does not report the remaining wait: "${skipLine}". Without it a 90s blip and a ` +
+    '6-hour quota outage read identically in the logs (#6241).',
+  );
+});
+
+test('the retry-after survives the proxy-enabled branch', async () => {
+  // Production runs with OPENSKY_PROXY_AUTH set, which takes a DIFFERENT error
+  // path out of fetchOpenSkyAuthenticated than the direct-only tests above. If
+  // the header were dropped there, prod would silently arm the 90s fallback
+  // instead of the advertised 6.3h — a 250x weaker fix, invisible everywhere else.
+  process.env.OPENSKY_PROXY_AUTH = 'http://user:pass@proxy.test:8080';
+  try {
+    const retryAfterSeconds = 22_688;
+    install({ openSkyStatus: 429, retryAfterSeconds });
+    const before = Date.now();
+    await (await freshSeeder()).fetchAllStates();
+
+    const record = readCooldownRecord();
+    assert.ok(record, 'No cooldown record was written on the proxy-enabled path (#6241).');
+    assert.ok(
+      Math.abs(Number(record.until) - (before + retryAfterSeconds * 1000)) < 60_000,
+      `Proxy-enabled path armed a ${Math.round((record.until - before) / 1000)}s cooldown instead of ` +
+      `${retryAfterSeconds}s — the retry-after was lost while re-wrapping the direct error (#6241).`,
+    );
+  } finally {
+    delete process.env.OPENSKY_PROXY_AUTH;
+  }
+});
+
+test('the combined direct+proxy error keeps the proxy leg 429 metadata', async () => {
+  // The other proxy assertion covers the DIRECT-429 short-circuit. This covers
+  // the remaining shape: direct fails with something else, the proxy then 429s.
+  // Only the pure combiner is reachable here — _proxy-utils.cjs opens raw
+  // sockets, so no fetch mock can drive that leg.
+  const { combineOpenSkyFetchErrors } = await freshSeeder();
+  const combined = combineOpenSkyFetchErrors(
+    new Error('HTTP 500: upstream boom'),
+    Object.assign(new Error('HTTP 429: quota'), { status: 429, retryAfterSeconds: 22_688 }),
+  );
+
+  assert.equal(
+    combined.status, 429,
+    'The combined error dropped the proxy leg status, so the 429 is only detectable by string-matching (#6241).',
+  );
+  assert.equal(
+    combined.retryAfterSeconds, 22_688,
+    'The combined error dropped the proxy leg retry-after, collapsing a 6.3h cooldown to the 90s fallback (#6241).',
+  );
+  assert.match(combined.message, /HTTP 429\b/, 'the combined message must still carry the 429 for the string matcher');
+});
+
+test('a 429 with no retry-after header still arms a bounded cooldown', async () => {
+  install({ openSkyStatus: 429 });
+  await (await freshSeeder()).fetchAllStates();
+
+  const record = readCooldownRecord();
+  assert.ok(
+    record && Number(record.until) > Date.now(),
+    'A 429 without X-Rate-Limit-Retry-After-Seconds armed no cooldown at all. OpenSky omits the ' +
+    'header on some rejections, and those are exactly as doomed to repeat (#6241).',
+  );
+  assert.ok(
+    Number(record.until) - Date.now() <= 24 * 60 * 60 * 1000,
+    `A header-less 429 armed a ${Math.round((record.until - Date.now()) / 1000)}s cooldown; it must ` +
+    'stay bounded so an unexplained rejection cannot blackout OpenSky indefinitely (#6241).',
+  );
+});
+
+test('an expired cooldown record is cleared after the next successful call', async () => {
+  redisStore.set(COOLDOWN_KEY, {
+    value: JSON.stringify({ until: Date.now() - 1_000, retryAfterSeconds: 90 }),
+    ttl: 60,
+  });
+
+  await (await freshSeeder()).fetchAllStates();
+
+  assert.equal(
+    openSkyDataCalls().length, 1,
+    'An EXPIRED cooldown blocked the OpenSky call. The deadline is a point in time, not a latch — ' +
+    'comparing presence instead of `until` strands OpenSky until the key TTLs out (#6241).',
+  );
+  assert.equal(
+    readCooldownRecord(), null,
+    'A successful call left the stale cooldown record in place. It must be cleared so the next ' +
+    "run's read is not a wasted round-trip against a dead deadline (#6241).",
+  );
+});
+
+test('an absurd future deadline cannot blackout OpenSky forever', async () => {
+  // A corrupt or hand-written record must not be able to switch the tier off
+  // permanently — this guard IS the alarm, so it has to fail open on nonsense.
+  redisStore.set(COOLDOWN_KEY, {
+    value: JSON.stringify({ until: Date.now() + 10 * 365 * 24 * 60 * 60 * 1000 }),
+    ttl: 60,
+  });
+
+  await (await freshSeeder()).fetchAllStates();
+
+  assert.equal(
+    openSkyDataCalls().length, 1,
+    'A 10-year cooldown deadline silently disabled OpenSky. Any deadline beyond the documented ' +
+    'maximum window is corrupt and must be ignored, not obeyed (#6241).',
+  );
+});
+
+for (const mode of ['http', 'throw']) {
+  test(`a Redis read failure (${mode}) fails OPEN — the OpenSky call still runs`, async () => {
+    redisStore.set(COOLDOWN_KEY, {
+      value: JSON.stringify({ until: Date.now() + 3_600_000 }),
+      ttl: 3_600,
+    });
+    redisReadFails = mode;
+
+    await (await freshSeeder()).fetchAllStates();
+
+    assert.equal(
+      openSkyDataCalls().length, 1,
+      `An unreadable cooldown key (${mode}) suppressed the OpenSky call. A Redis blip must not ` +
+      'delete a data tier — the worst case of failing open is one wasted request (#6241).',
+    );
+  });
+}
+
+test('a Redis WRITE failure does not abort the run', async () => {
+  // The 429 already cost the run its OpenSky tier; losing Wingbits on top
+  // because the cooldown could not be persisted turns a degraded run into an
+  // empty publish.
+  install({ openSkyStatus: 429, retryAfterSeconds: 3_600 });
+  const mocked = globalThis.fetch;
+  globalThis.fetch = async (url, opts = {}) => {
+    const raw = typeof url === 'string' ? url : url.url;
+    if (new URL(raw).host === REDIS_HOST && (opts.method || 'GET').toUpperCase() === 'POST') {
+      calls.push({ url: raw, method: 'POST', headers: {} });
+      throw new TypeError('fetch failed');
+    }
+    return mocked(url, opts);
+  };
+
+  const { allStates } = await (await freshSeeder()).fetchAllStates();
+
+  assert.ok(
+    allStates.map((s) => s[0]).includes(WINGBITS_ONLY),
+    'A failed cooldown write took the whole run down with it. Persisting the deadline is best ' +
+    'effort — the publish is not (#6241).',
+  );
+});

--- a/tests/seed-military-flights-opensky-429-cooldown.test.mjs
+++ b/tests/seed-military-flights-opensky-429-cooldown.test.mjs
@@ -14,6 +14,9 @@
 
 import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { createRequire } from 'node:module';
+import { createHash } from 'node:crypto';
 
 process.env.OPENSKY_CLIENT_ID = 'test-client';
 process.env.OPENSKY_CLIENT_SECRET = 'test-secret';
@@ -86,7 +89,13 @@ function handleRedis(u, opts) {
   return json({ result: entry ? entry.value : null });
 }
 
-function install({ openSkyStatus = 200, retryAfterSeconds = null } = {}) {
+function install({
+  openSkyStatus = 200,
+  retryAfterSeconds = null,
+  retryAfterHeader = 'X-Rate-Limit-Retry-After-Seconds',
+  tokenStatus = 200,
+  tokenRetryAfterSeconds = null,
+} = {}) {
   calls = [];
   logLines = [];
   const capture = (sink) => (...args) => { logLines.push(args.join(' ')); sink(...args); };
@@ -101,6 +110,13 @@ function install({ openSkyStatus = 200, retryAfterSeconds = null } = {}) {
     if (u.host === REDIS_HOST) return handleRedis(u, opts);
 
     if (u.host === TOKEN_HOST) {
+      if (tokenStatus !== 200) {
+        const headers = {};
+        if (tokenRetryAfterSeconds != null) {
+          headers['X-Rate-Limit-Retry-After-Seconds'] = String(tokenRetryAfterSeconds);
+        }
+        return new Response('Too many requests', { status: tokenStatus, headers });
+      }
       return json({ access_token: 'tok', expires_in: 1800 });
     }
     if (u.host === WINGBITS_HOST) {
@@ -113,7 +129,7 @@ function install({ openSkyStatus = 200, retryAfterSeconds = null } = {}) {
     if (u.host === OPENSKY_HOST) {
       if (openSkyStatus !== 200) {
         const headers = {};
-        if (retryAfterSeconds != null) headers['X-Rate-Limit-Retry-After-Seconds'] = String(retryAfterSeconds);
+        if (retryAfterSeconds != null) headers[retryAfterHeader] = String(retryAfterSeconds);
         return new Response('Too many requests', { status: openSkyStatus, headers });
       }
       return json({ time: 0, states: [state(OPENSKY_ONLY, 'RCH123', 40, -100)] });
@@ -127,6 +143,14 @@ const openSkyTokenCalls = () => calls.filter((c) => new URL(c.url).host === TOKE
 const readCooldownRecord = () => {
   const entry = redisStore.get(COOLDOWN_KEY);
   return entry ? JSON.parse(entry.value) : null;
+};
+
+// The cooldown record is scoped to the OpenSky account that earned it, so any
+// hand-seeded fixture that must reach the LATER guards has to carry this
+// seeder's own fingerprint — otherwise it is rejected as another account's.
+const ACCOUNT = createHash('sha256').update('test-client').digest('hex').slice(0, 12);
+const seedCooldown = (record, ttl = 60) => {
+  redisStore.set(COOLDOWN_KEY, { value: JSON.stringify({ account: ACCOUNT, ...record }), ttl });
 };
 
 // A fresh module instance is how this suite models the next cron tick. The
@@ -254,11 +278,59 @@ test('the retry-after survives the proxy-enabled branch', async () => {
   }
 });
 
+test('the proxy transport surfaces the rate-limit headers it used to drop', async () => {
+  // The link the combiner test below depends on. `proxyFetch` opens raw sockets
+  // and never touches globalThis.fetch, but it accepts injectable connectTunnel /
+  // requestFn seams — so the REAL transport can be driven with a real 429. Before
+  // this, the resolved object carried no headers at all, which made every
+  // downstream retry-after assertion true only of a hand-built fixture.
+  const require = createRequire(import.meta.url);
+  const { proxyFetch } = require('../scripts/_proxy-utils.cjs');
+  const { parseRetryAfterSeconds } = await freshSeeder();
+
+  const fakeResponse = new EventEmitter();
+  fakeResponse.statusCode = 429;
+  fakeResponse.headers = { 'x-rate-limit-retry-after-seconds': '22688' };
+
+  const result = await proxyFetch('https://opensky-network.org/api/states/all', { host: 'p', port: 1 }, {
+    connectTunnel: async () => ({ socket: null, destroy: () => {} }),
+    requestFn: (_opts, cb) => {
+      const req = new EventEmitter();
+      req.end = () => {
+        cb(fakeResponse);
+        fakeResponse.emit('end');
+      };
+      req.write = () => {};
+      return req;
+    },
+  });
+
+  assert.equal(result.status, 429, 'expected the injected 429 to reach the caller');
+  assert.equal(
+    parseRetryAfterSeconds(result.headers), 22_688,
+    'The proxy transport still drops the rate-limit headers, so a 429 arriving through the tunnel ' +
+    'can only ever produce the fallback cooldown instead of the advertised window (#6241).',
+  );
+
+  // Second half of the chain: the SAME result object must become an error the
+  // cooldown can read. Asserting only on result.headers above would leave
+  // proxyFetchJson's own wiring unproven.
+  const { proxyResponseError } = await freshSeeder();
+  const err = proxyResponseError(result);
+  assert.equal(err.status, 429, 'the proxy error must carry the status');
+  assert.equal(
+    err.retryAfterSeconds, 22_688,
+    'proxyFetchJson built the error without reading the tunnel headers, so the advertised window ' +
+    'is discarded between the transport and the cooldown (#6241).',
+  );
+});
+
 test('the combined direct+proxy error keeps the proxy leg 429 metadata', async () => {
   // The other proxy assertion covers the DIRECT-429 short-circuit. This covers
   // the remaining shape: direct fails with something else, the proxy then 429s.
-  // Only the pure combiner is reachable here — _proxy-utils.cjs opens raw
-  // sockets, so no fetch mock can drive that leg.
+  // The proxyError fixture below is now a shape production can actually emit —
+  // the test above proves the transport surfaces the headers and proxyFetchJson
+  // parses them onto the error.
   const { combineOpenSkyFetchErrors } = await freshSeeder();
   const combined = combineOpenSkyFetchErrors(
     new Error('HTTP 500: upstream boom'),
@@ -274,6 +346,74 @@ test('the combined direct+proxy error keeps the proxy leg 429 metadata', async (
     'The combined error dropped the proxy leg retry-after, collapsing a 6.3h cooldown to the 90s fallback (#6241).',
   );
   assert.match(combined.message, /HTTP 429\b/, 'the combined message must still carry the 429 for the string matcher');
+});
+
+test('parseRetryAfterSeconds handles both header containers and the HTTP-date form', async () => {
+  // Two transports hand this parser two different container types: a fetch
+  // `Headers` (direct) and a plain object (the proxy tunnel). Driving
+  // fetchAllStates only ever exercises the first.
+  const { parseRetryAfterSeconds } = await freshSeeder();
+
+  assert.equal(
+    parseRetryAfterSeconds({ 'X-Rate-Limit-Retry-After-Seconds': '600' }), 600,
+    'Plain-object headers from the proxy tunnel must parse; `Headers.get` would have thrown on them (#6241).',
+  );
+  assert.equal(
+    parseRetryAfterSeconds(new Headers({ 'retry-after': '600' })), 600,
+    'A fetch Headers instance must still parse.',
+  );
+
+  // RFC 7231 permits Retry-After as an HTTP-date. Number() on it is NaN, so
+  // without the date arm a dated 429 silently degrades to the fallback.
+  const inTenMinutes = new Date(Date.now() + 600_000).toUTCString();
+  const parsed = parseRetryAfterSeconds({ 'retry-after': inTenMinutes });
+  assert.ok(
+    parsed > 540 && parsed <= 600,
+    `An HTTP-date Retry-After (${inTenMinutes}) parsed to ${parsed}; expected ~600s (#6241).`,
+  );
+
+  assert.equal(parseRetryAfterSeconds({}), null, 'absent header must yield null, not 0');
+  assert.equal(parseRetryAfterSeconds({ 'retry-after': '-5' }), null, 'a negative delay is not a deadline');
+  assert.equal(
+    parseRetryAfterSeconds({ 'retry-after': '604800' }), 86_400,
+    'A one-week retry-after must clamp to the 24h maximum, not park the tier for a week (#6241).',
+  );
+});
+
+test('a proxy-gateway 429 is not mistaken for an OpenSky lockout', async () => {
+  // The residential proxy's own gateway rejects with status 429 for ITS quota
+  // (Decodo traffic limits have done exactly this), carrying the `proxyConnect`
+  // marker _proxy-utils.cjs sets for this discrimination. Treating it as an
+  // OpenSky lockout would park a perfectly healthy upstream on someone else's
+  // billing problem. Unreachable from a fetch mock — the tunnel is raw sockets.
+  const { isOpenSkyRateLimitedError, combineOpenSkyFetchErrors } = await freshSeeder();
+
+  const gatewayError = Object.assign(new Error('Proxy CONNECT: HTTP/1.1 429 Too Many Requests'), {
+    status: 429,
+    proxyConnect: true,
+  });
+
+  assert.equal(
+    isOpenSkyRateLimitedError(gatewayError), false,
+    'A proxy-gateway 429 was classified as an OpenSky rate limit. Both collapse to status 429, so ' +
+    'without the proxyConnect marker the proxy vendor\'s quota parks the OpenSky tier (#6241).',
+  );
+
+  // The same must hold after the direct+proxy re-wrap, which is how this error
+  // actually reaches the classifier in production.
+  const combined = combineOpenSkyFetchErrors(new Error('HTTP 500: boom'), gatewayError);
+  assert.equal(
+    isOpenSkyRateLimitedError(combined), false,
+    'The gateway marker was dropped by the combine, so the re-wrapped error reads as a bare 429 and ' +
+    'arms an OpenSky cooldown anyway (#6241).',
+  );
+
+  // Control: an identical error WITHOUT the marker is a genuine OpenSky 429.
+  // Without this the assertions above would pass if the predicate always said false.
+  assert.equal(
+    isOpenSkyRateLimitedError(Object.assign(new Error('HTTP 429: quota'), { status: 429 })), true,
+    'A real OpenSky 429 must still be classified as rate-limited.',
+  );
 });
 
 test('a 429 with no retry-after header still arms a bounded cooldown', async () => {
@@ -294,10 +434,7 @@ test('a 429 with no retry-after header still arms a bounded cooldown', async () 
 });
 
 test('an expired cooldown record is cleared after the next successful call', async () => {
-  redisStore.set(COOLDOWN_KEY, {
-    value: JSON.stringify({ until: Date.now() - 1_000, retryAfterSeconds: 90 }),
-    ttl: 60,
-  });
+  seedCooldown({ until: Date.now() - 1_000, retryAfterSeconds: 90 });
 
   await (await freshSeeder()).fetchAllStates();
 
@@ -313,29 +450,138 @@ test('an expired cooldown record is cleared after the next successful call', asy
   );
 });
 
-test('an absurd future deadline cannot blackout OpenSky forever', async () => {
-  // A corrupt or hand-written record must not be able to switch the tier off
-  // permanently — this guard IS the alarm, so it has to fail open on nonsense.
-  redisStore.set(COOLDOWN_KEY, {
-    value: JSON.stringify({ until: Date.now() + 10 * 365 * 24 * 60 * 60 * 1000 }),
-    ttl: 60,
+// Both fixtures must be REJECTED by the implausibility guard, so each asserts the
+// guard's own log line too. Without that, `dataCalls === 1` is also what you get
+// when the record was never read at all (wrong key, unparseable envelope,
+// Number.isFinite rejecting it) — the assertion would pass for the wrong reason.
+for (const [label, until] of [
+  ['ten years out', Date.now() + 10 * 365 * 24 * 60 * 60 * 1000],
+  // Past the ECMAScript Date range (+/-8.64e15 ms). `Number.isFinite` admits it,
+  // so it reaches the guard — and a nanosecond-scale timestamp is exactly the
+  // shape a buggy writer produces.
+  ['beyond the JS Date range', 1.78e18],
+]) {
+  test(`an absurd future deadline (${label}) cannot blackout OpenSky forever`, async () => {
+    seedCooldown({ until });
+
+    const { allStates } = await (await freshSeeder()).fetchAllStates();
+
+    assert.equal(
+      openSkyDataCalls().length, 1,
+      `A cooldown deadline ${label} silently disabled OpenSky. Any deadline beyond the documented ` +
+      'maximum window is corrupt and must be ignored, not obeyed (#6241).',
+    );
+    assert.ok(
+      logLines.some((l) => /implausible cooldown deadline/.test(l)),
+      `The implausibility guard never ran for a deadline ${label} — the OpenSky call happening ` +
+      `anyway proves nothing on its own. Lines seen:\n${logLines.join('\n')}`,
+    );
+    assert.ok(
+      allStates.map((s) => s[0]).includes(WINGBITS_ONLY),
+      `A deadline ${label} killed the whole run instead of being ignored. Formatting an untrusted ` +
+      'deadline as a Date throws RangeError past 8.64e15, and this read runs outside any caller ' +
+      "try — so the guard against a corrupt record becomes a total outage, Wingbits included (#6241).",
+    );
   });
+}
+
+test("a cooldown recorded by ANOTHER OpenSky account is ignored", async () => {
+  // The quota is per-account but the key is global, so after a credential
+  // rotation a healthy new account would otherwise serve out the old account's
+  // lockout — losing coverage for up to the remaining window on a key nobody
+  // knows to delete.
+  redisStore.set(COOLDOWN_KEY, {
+    value: JSON.stringify({ until: Date.now() + 6 * 3_600_000, account: 'deadbeefcafe' }),
+    ttl: 3_600,
+  });
+
+  const { allStates } = await (await freshSeeder()).fetchAllStates();
+
+  assert.equal(
+    openSkyDataCalls().length, 1,
+    "A cooldown earned by different credentials suppressed this account's OpenSky call. The quota " +
+    'is per-account, so a rotated credential must not inherit the old lockout (#6241).',
+  );
+  assert.ok(
+    logLines.some((l) => /different OpenSky account/.test(l)),
+    `The account mismatch was not reported, so the call happening could equally mean the record was ` +
+    `never read. Lines seen:\n${logLines.join('\n')}`,
+  );
+  assert.ok(allStates.length > 0, 'the run must still publish');
+});
+
+test('a cooldown recorded by THIS account is still honoured', async () => {
+  // Control for the test above: if the fingerprint check rejected everything,
+  // that test would pass while the whole mechanism was dead.
+  seedCooldown({ until: Date.now() + 6 * 3_600_000 }, 3_600);
 
   await (await freshSeeder()).fetchAllStates();
 
   assert.equal(
-    openSkyDataCalls().length, 1,
-    'A 10-year cooldown deadline silently disabled OpenSky. Any deadline beyond the documented ' +
-    'maximum window is corrupt and must be ignored, not obeyed (#6241).',
+    openSkyDataCalls().length, 0,
+    'A cooldown carrying this account\'s own fingerprint was ignored — the account check is ' +
+    'rejecting valid records, which disables the entire mechanism (#6241).',
+  );
+});
+
+test('a 429 on the TOKEN endpoint also arms the cooldown', async () => {
+  // Token acquisition runs OUTSIDE fetchOpenSkyAuthenticated's try, so it exits
+  // by THROWING rather than by returning `rateLimited`. That path costs three
+  // attempts and ~7s of sleeps per tick, and is just as doomed to repeat.
+  install({ tokenStatus: 429, tokenRetryAfterSeconds: 22_688 });
+  const before = Date.now();
+  await (await freshSeeder()).fetchAllStates();
+
+  const record = readCooldownRecord();
+  assert.ok(
+    record,
+    'A 429 on auth.opensky-network.org armed no cooldown. It is the same account-wide lockout, and ' +
+    'the token path retries three times with ~7s of sleeps on every tick of the window (#6241).',
+  );
+  assert.ok(
+    Math.abs(Number(record.until) - (before + 22_688 * 1000)) < 60_000,
+    `Token-path cooldown honoured the wrong deadline: ${record.until}.`,
+  );
+});
+
+test('a standard `Retry-After` header is honoured when the vendor header is absent', async () => {
+  // parseRetryAfterSeconds checks two header names. Every other test sets only
+  // the vendor one, so without this case the `retry-after` arm is dead code that
+  // could be deleted with the whole suite still green.
+  install({ openSkyStatus: 429, retryAfterSeconds: 22_688, retryAfterHeader: 'Retry-After' });
+  const before = Date.now();
+  await (await freshSeeder()).fetchAllStates();
+
+  const record = readCooldownRecord();
+  assert.ok(record, 'A 429 carrying only the standard Retry-After header armed no cooldown (#6241).');
+  assert.ok(
+    Math.abs(Number(record.until) - (before + 22_688 * 1000)) < 60_000,
+    `Standard Retry-After was ignored; deadline was ${record.until}, expected ~${before + 22_688_000}. ` +
+    'The fallback header arm exists precisely because OpenSky does not always send the vendor one (#6241).',
+  );
+});
+
+test('the header-less fallback outlives one */5 cron tick', async () => {
+  // The whole mechanism is a no-op if the fallback expires before the next
+  // process starts: the seeder is one-shot on a 300s cron, so a deadline shorter
+  // than that suppresses exactly zero requests while still logging "cooldown".
+  install({ openSkyStatus: 429 });
+  const before = Date.now();
+  await (await freshSeeder()).fetchAllStates();
+
+  const record = readCooldownRecord();
+  assert.ok(record, 'precondition: a header-less 429 must arm a cooldown');
+  const cooldownMs = Number(record.until) - before;
+  assert.ok(
+    cooldownMs > 300_000,
+    `The header-less fallback armed only ${Math.round(cooldownMs / 1000)}s. The cron period is 300s, ` +
+    'so anything shorter has already expired by the next tick and prevents no requests at all (#6241).',
   );
 });
 
 for (const mode of ['http', 'throw']) {
   test(`a Redis read failure (${mode}) fails OPEN — the OpenSky call still runs`, async () => {
-    redisStore.set(COOLDOWN_KEY, {
-      value: JSON.stringify({ until: Date.now() + 3_600_000 }),
-      ttl: 3_600,
-    });
+    seedCooldown({ until: Date.now() + 3_600_000 }, 3_600);
     redisReadFails = mode;
 
     await (await freshSeeder()).fetchAllStates();
@@ -348,18 +594,69 @@ for (const mode of ['http', 'throw']) {
   });
 }
 
-test('a Redis WRITE failure does not abort the run', async () => {
-  // The 429 already cost the run its OpenSky tier; losing Wingbits on top
-  // because the cooldown could not be persisted turns a degraded run into an
-  // empty publish.
-  install({ openSkyStatus: 429, retryAfterSeconds: 3_600 });
+// Both Redis WRITE verbs must be contained. SET is reached by the 429 path; DEL
+// by the expired-record-then-success path. Each has its own catch, and a bare
+// "the run survived" assertion would stay green with either catch deleted —
+// the outer try in fetchOpenSkyGlobal swallows the throw too. So each case also
+// pins the specific warn only the inner catch emits.
+for (const [verb, setup, expectedWarn] of [
+  [
+    'SET',
+    () => install({ openSkyStatus: 429, retryAfterSeconds: 3_600 }),
+    /failed to persist cooldown/,
+  ],
+  [
+    'DEL',
+    () => {
+      install();
+      seedCooldown({ until: Date.now() - 1_000 });
+    },
+    /failed to clear cooldown/,
+  ],
+]) {
+  test(`a Redis ${verb} failure does not abort the run`, async () => {
+    setup();
+    const mocked = globalThis.fetch;
+    globalThis.fetch = async (url, opts = {}) => {
+      const raw = typeof url === 'string' ? url : url.url;
+      const isPost = (opts.method || 'GET').toUpperCase() === 'POST';
+      if (new URL(raw).host === REDIS_HOST && isPost && JSON.parse(opts.body)[0] === verb) {
+        calls.push({ url: raw, method: 'POST', headers: {} });
+        throw new TypeError('fetch failed');
+      }
+      return mocked(url, opts);
+    };
+
+    const { allStates, fetchSources } = await (await freshSeeder()).fetchAllStates();
+
+    assert.ok(
+      allStates.map((s) => s[0]).includes(WINGBITS_ONLY),
+      `A failed cooldown ${verb} took the whole run down with it. Persisting the deadline is best ` +
+      'effort — the publish is not (#6241).',
+    );
+    assert.ok(
+      logLines.some((l) => expectedWarn.test(l)),
+      `The ${verb} failure was not reported by its own handler. Without this the outer catch in ` +
+      `fetchOpenSkyGlobal would swallow it identically, so "the run survived" proves nothing. ` +
+      `Lines seen:\n${logLines.join('\n')}`,
+    );
+    assert.ok(
+      !String(fetchSources.regions[0]?.authStatus || '').includes('fetch failed'),
+      `The ${verb} failure escaped into the OpenSky status (${fetchSources.regions[0]?.authStatus}), ` +
+      'masking the real upstream outcome (#6241).',
+    );
+  });
+}
+
+test('a total Redis outage (read AND write) still publishes from Wingbits', async () => {
+  // The shape a real Upstash incident takes. Every other Redis test fails one
+  // verb; this one fails them all, which is the only case where the cooldown can
+  // be neither read nor recorded.
+  install({ openSkyStatus: 429, retryAfterSeconds: 22_688 });
   const mocked = globalThis.fetch;
   globalThis.fetch = async (url, opts = {}) => {
     const raw = typeof url === 'string' ? url : url.url;
-    if (new URL(raw).host === REDIS_HOST && (opts.method || 'GET').toUpperCase() === 'POST') {
-      calls.push({ url: raw, method: 'POST', headers: {} });
-      throw new TypeError('fetch failed');
-    }
+    if (new URL(raw).host === REDIS_HOST) throw new TypeError('fetch failed');
     return mocked(url, opts);
   };
 
@@ -367,7 +664,12 @@ test('a Redis WRITE failure does not abort the run', async () => {
 
   assert.ok(
     allStates.map((s) => s[0]).includes(WINGBITS_ONLY),
-    'A failed cooldown write took the whole run down with it. Persisting the deadline is best ' +
-    'effort — the publish is not (#6241).',
+    'A total Redis outage turned a degraded run into an empty publish. The cooldown is an ' +
+    'optimisation; losing it must never cost the data (#6241).',
+  );
+  assert.equal(
+    openSkyDataCalls().length, 1,
+    'A total Redis outage changed the OpenSky request count. With no readable deadline the run must ' +
+    'fail OPEN — exactly one attempt, same as an un-cooled run (#6241).',
   );
 });


### PR DESCRIPTION
Closes #6241.

## The problem

`scripts/seed-military-flights.mjs` never inspected OpenSky's `429` or its
`X-Rate-Limit-Retry-After-Seconds` header. Production has seen a retry-after of
**22,688s (~6.3h)**; across that window the `*/5` cron fired a fresh authenticated
`/states/all` every tick — **~76 doomed requests per outage**, each paying a full
round-trip and its share of the run's wall clock.

A 429 spends no credits, which is why #6222's credit-spend fix correctly left this
alone. The cost is latency, log noise, and a slower read on when the provider recovers.

## The fix

The seeder is a one-shot process per cron tick, so the relay's module-level
`openskyGlobal429Until` cannot work here — the deadline has to outlive the process. It
now lives in Redis under `opensky:cooldown-until:v1`, read before the authenticated call
and cleared on success.

- `fetchJsonDirect` attaches `status` and a parsed retry-after to the thrown error instead
  of discarding both behind a bare `HTTP ${status}` string.
- A 429 persists the deadline (the advertised retry-after when present, a bounded fallback
  otherwise), clamped to 24h on both write and read.
- While the deadline is in the future the seeder issues **zero** authenticated OpenSky
  requests — no token fetch either — and publishes from Wingbits, logging the remaining
  wait so quota exhaustion is distinguishable from a provider outage.

**Every path fails OPEN.** A Redis read error, a write error, a corrupt record, or a
deadline from a different account all degrade to "make the request" rather than silently
deleting a data tier. This guard is itself the alarm, so it must never be able to switch
OpenSky off permanently.

## Acceptance criteria

- [x] A `429` records a cooldown deadline that survives process exit
- [x] While the deadline is in the future, zero authenticated OpenSky requests, still publishes from Wingbits
- [x] The skip is visible in logs with the remaining wait
- [x] Regression test: a `429` + retry-after fixture makes the next run issue no OpenSky request

## Review round (second commit)

A multi-reviewer pass plus an independent cross-model review found the first cut had a
failure mode **worse than the bug**, and three paths where the cooldown silently did nothing:

- **P1 — the fail-open guard could kill the run.** It formatted an untrusted deadline with
  `new Date(until).toISOString()`, which throws `RangeError` past ±8.64e15 ms (a
  nanosecond-scale timestamp lands there). `Number.isFinite` admits it and the read runs
  outside any caller's try — so a corrupt record meant *no publish at all*, Wingbits
  included, every 5 minutes, until someone deleted the key by hand.
- **The header-less fallback was shorter than the cron period** (90s vs 300s), so it
  suppressed exactly zero requests while still logging "cooldown".
- **A 429 on the token endpoint bypassed the cooldown entirely** — token acquisition exits
  by throwing, not by returning `rateLimited`.
- **The proxy leg could never carry a retry-after**: `proxyFetch` dropped every response
  header, so that propagation defended a value nothing could produce — and its test proved
  it only by hand-building an input production cannot emit.

Also fixed: HTTP-date `Retry-After`; the residential proxy's own gateway 429 no longer
arms an OpenSky cooldown; the record is scoped to a fingerprint of the OpenSky account so
a credential rotation cannot inherit the old lockout; the clear is unconditional on
success rather than gated on a read that also returns empty when Redis is unreachable.

## Verification

- New suite: **22 tests**, all passing.
- **Mutation sweep: 26 mutants, 25 killed** — each guard reverted one at a time, each
  killed by the test that should catch it.
- Scoped sweep across every module touched by the diff: **827 tests green** (military
  seeder + theater posture + railway registration + all `_proxy-utils` consumers).
- `tests/proxy-utils.test.mjs` pins the `proxyFetch` resolve shape with `deepEqual` and
  correctly caught the new additive field; updated deliberately.

**Known gap:** the single line joining the two proven halves of the proxy path
(`throw proxyResponseError(result)` inside `proxyFetchJson`) is uncovered — that function
opens raw sockets through `createRequire` and is unreachable from a fetch mock. Both
halves it connects are tested.

## Not in scope

The OpenSky quota is per-**account** and shared with `scripts/ais-relay.cjs`, which keeps
its own in-process cooldown. Neither reads the other's state, so each still burns one
doomed request to discover the other's outage. Making the relay a reader/writer of this
same key would let either one's 429 protect both — worth a follow-up issue if you want it.

https://claude.ai/code/session_01TmaXCRoJNmiyQ1XtMmUH62