### PR TITLE
fix(military): reject Redis command errors returned with HTTP 200

### DIFF
--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -1427,16 +1427,20 @@ function calculateTheaterPostures(flights) {
 }
 
 // ── Redis Write ────────────────────────────────────────────
-async function redisSet(url, token, key, value, ttl) {
+export async function redisSet(url, token, key, value, ttl) {
   const payload = JSON.stringify(value);
   const cmd = ttl ? ['SET', key, payload, 'EX', ttl] : ['SET', key, payload];
   const resp = await fetch(url, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
     body: JSON.stringify(cmd),
     signal: AbortSignal.timeout(10_000),
   });
   if (!resp.ok) throw new Error(`Redis SET ${key} failed: HTTP ${resp.status}`);
+  const body = await resp.json();
+  if (body && typeof body === 'object' && Object.hasOwn(body, 'error')) {
+    throw new Error(`Redis SET ${key} rejected by Upstash: ${String(body.error)}`);
+  }
 }
 
 async function redisDel(url, token, key) {

--- a/tests/seed-military-flights-redis-write.test.mjs
+++ b/tests/seed-military-flights-redis-write.test.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+import { redisSet } from '../scripts/seed-military-flights.mjs';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test('redisSet rejects an Upstash command error returned with HTTP 200', async () => {
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    error: 'ERR max request size exceeded',
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  await assert.rejects(
+    redisSet('https://redis.test', 'test-token', 'military:flights:v1', { flights: [] }, 600),
+    /Redis SET military:flights:v1 rejected by Upstash: ERR max request size exceeded/,
+  );
+});
+
+test('redisSet accepts an Upstash command success response', async () => {
+  globalThis.fetch = async () => new Response(JSON.stringify({ result: 'OK' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  await redisSet('https://redis.test', 'test-token', 'military:flights:v1', { flights: [] }, 600);
+});


### PR DESCRIPTION
## Summary

Military-flight publishing no longer reports success when Upstash rejects a Redis `SET` command inside an HTTP 200 response. The rejection now reaches the seeder's existing publish-failure path before success logs or downstream freshness metadata can misrepresent the write; successful command responses remain unchanged.

The repository sweep also found pre-existing transport-only handling in `scripts/_seed-utils.mjs`, `scripts/seed-military-cii.mjs`, `scripts/seed-aviation.mjs`, and `scripts/seed-forecasts.mjs`, plus pipeline-specific helpers such as `scripts/seed-webcams.mjs`. Those paths have different retry and best-effort contracts and remain explicit follow-up audit scope rather than broadening this focused military publisher fix.

Fixes #6243.

## Validation

- Proof-first regression observed the HTTP 200 error fixture resolve successfully before the fix, then reject after it.
- `node --test tests/seed-military-flights-redis-write.test.mjs tests/seed-military-flights-opensky-429-cooldown.test.mjs` (26 passed)
- Related OpenSky budget and military classification suites (120 passed before the live-base rebase)
- `npm run typecheck`
- `npm run test:data`
- Full pre-push gate, including `typecheck:api`, changed tests, Unicode safety, and version sync

## Post-Deploy Monitoring & Validation

- **Window / owner:** release operator watches the first three scheduled `seed-military-flights` runs after deployment (about 15 minutes).
- **Logs:** search Railway logs for `=== Done`, `PUBLISH FAILED: Redis SET`, and `rejected by Upstash`. Healthy runs end with `=== Done`; any command-level rejection must be loud and exit through `PUBLISH FAILED` rather than printing write success.
- **Health:** inspect `/api/health?compact=1` for `militaryFlights`, `theaterPosture`, `militaryForecastInputs`, and `militarySurges`. They should remain present and fresh across the observation window.
- **Rollback trigger:** any new parse-related publish failure on a valid `{ "result": "OK" }` response, or three consecutive missed military publication cadences. Mitigate by reverting this commit and redeploying the military seeder while retaining the failed response body in logs for diagnosis.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
