### PR TITLE
fix(rate-limit): fail closed paid-provider market routes

### DIFF
--- a/server/__tests__/gateway-direct-llm-quota.test.ts
+++ b/server/__tests__/gateway-direct-llm-quota.test.ts
@@ -311,7 +311,7 @@ describe("gateway direct LLM quota", () => {
     );
   });
 
-  test("Pro bearer analyze-stock uses a principal-scoped global fallback bucket", async () => {
+  test("Pro bearer analyze-stock uses a principal-scoped endpoint bucket", async () => {
     const calls = { analyze: 0 };
     resolveClerkSession.mockResolvedValue({ userId: "user_pro", orgId: null, role: "pro" });
     validateApiKey.mockResolvedValue({ valid: false, required: true, error: "API key required" });
@@ -325,11 +325,13 @@ describe("gateway direct LLM quota", () => {
 
     expect(res.status).toBe(200);
     expect(calls.analyze).toBe(1);
-    expect(checkRateLimit).toHaveBeenCalledWith(
+    expect(checkEndpointRateLimit).toHaveBeenCalledWith(
       expect.any(Request),
+      ANALYZE_PATH,
       expect.any(Object),
       { principalUserId: "user_pro" },
     );
+    expect(checkRateLimit).not.toHaveBeenCalled();
   });
 
   test("active Pro freshness bearer uses a principal-scoped global fallback bucket", async () => {
@@ -402,14 +404,14 @@ describe("gateway direct LLM quota", () => {
   });
 
   test("global limiter 429s emit a distinct telemetry reason", async () => {
-    const calls = { analyze: 0 };
+    const calls = { quotes: 0 };
     resolveClerkSession.mockResolvedValue({ userId: "user_pro", orgId: null, role: "pro" });
     validateApiKey.mockResolvedValue({ valid: false, required: true, error: "API key required" });
     checkRateLimit.mockResolvedValue(json({ error: "Too many requests" }, 429));
     const recorder = makeRecordingCtx();
 
-    const res = await makeAnalyzeGateway(calls)(
-      req(`${ANALYZE_PATH}?symbol=AAPL`, {
+    const res = await makeMarketQuotesGateway(calls)(
+      req(`${MARKET_QUOTES_PATH}?symbols=AAPL`, {
         headers: { Authorization: "Bearer pro" },
       }),
       recorder.ctx,
@@ -418,11 +420,11 @@ describe("gateway direct LLM quota", () => {
 
     expect(res.status).toBe(429);
     expect(lastTelemetryReason()).toBe("rate_limit_429_global");
-    expect(calls.analyze).toBe(0);
+    expect(calls.quotes).toBe(0);
   });
 
   test("global limiter degradation keeps the degraded telemetry reason", async () => {
-    const calls = { analyze: 0 };
+    const calls = { quotes: 0 };
     resolveClerkSession.mockResolvedValue({ userId: "user_pro", orgId: null, role: "pro" });
     validateApiKey.mockResolvedValue({ valid: false, required: true, error: "API key required" });
     checkRateLimit.mockResolvedValue(new Response(
@@ -431,8 +433,8 @@ describe("gateway direct LLM quota", () => {
     ));
     const recorder = makeRecordingCtx();
 
-    const res = await makeAnalyzeGateway(calls)(
-      req(`${ANALYZE_PATH}?symbol=AAPL`, {
+    const res = await makeMarketQuotesGateway(calls)(
+      req(`${MARKET_QUOTES_PATH}?symbols=AAPL`, {
         headers: { Authorization: "Bearer pro" },
       }),
       recorder.ctx,
@@ -441,7 +443,7 @@ describe("gateway direct LLM quota", () => {
 
     expect(res.status).toBe(503);
     expect(lastTelemetryReason()).toBe("rate_limit_degraded");
-    expect(calls.analyze).toBe(0);
+    expect(calls.quotes).toBe(0);
   });
 
   test("direct LLM quota 429s emit a distinct telemetry reason", async () => {

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -272,6 +272,17 @@ export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
   '/api/intelligence/v1/get-company-enrichment': { limit: 30, window: '60 s' },
   '/api/intelligence/v1/list-company-signals': { limit: 30, window: '60 s' },
   '/api/intelligence/v1/search-sec-filings': { limit: 30, window: '60 s' },
+  // Public market/economic provider proxies (#6236): caller-controlled symbols,
+  // countries, indicators, and year ranges create unbounded cache-key
+  // cardinality, so cache misses must not inherit the global fail-open budget.
+  // analyze-stock is stricter because one miss can fan out to Finnhub plus the
+  // Exa -> Brave -> SerpAPI search ladder; the other routes make one upstream
+  // provider request per miss and use the standard 30/min proxy budget.
+  '/api/market/v1/analyze-stock': { limit: 10, window: '60 s' },
+  '/api/market/v1/backtest-stock': { limit: 30, window: '60 s' },
+  '/api/market/v1/get-insider-transactions': { limit: 30, window: '60 s' },
+  '/api/market/v1/get-country-stock-index': { limit: 30, window: '60 s' },
+  '/api/economic/v1/list-world-bank-indicators': { limit: 30, window: '60 s' },
   // Company Monitoring is contract-only and remains unrouted until #6003
   // passes, but generated mutation routes still need a fail-closed policy
   // before any later lane can wire them. Import can carry 100 rows, so keep its
@@ -365,6 +376,21 @@ export const FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED: Record<string, RateLimit
   },
   '/api/intelligence/v1/search-sec-filings': {
     reason: 'Full-text filing search proxies SEC EDGAR on cache miss with unbounded query cardinality.',
+  },
+  '/api/market/v1/analyze-stock': {
+    reason: 'Per-symbol analysis can fan out to Finnhub plus the Exa, Brave, and SerpAPI search ladder on cache miss.',
+  },
+  '/api/market/v1/backtest-stock': {
+    reason: 'Per-symbol backtests proxy scraped Yahoo Finance data with unbounded symbol cardinality.',
+  },
+  '/api/market/v1/get-insider-transactions': {
+    reason: 'Per-symbol insider lookups proxy the paid Finnhub provider on cache miss.',
+  },
+  '/api/market/v1/get-country-stock-index': {
+    reason: 'Per-country stock-index lookups proxy Yahoo Finance on cache miss.',
+  },
+  '/api/economic/v1/list-world-bank-indicators': {
+    reason: 'Caller-controlled indicator, country, and year inputs proxy World Bank on cache miss.',
   },
   '/api/company-monitoring/v1/create-monitored-company': {
     reason: 'Account-scoped portfolio mutation must not become fail-open when its dark contract is wired.',

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -23,6 +23,15 @@ export { getClientIp, hasCloudflareTransitProof, UNKNOWN_CLIENT_IP } from './cli
 // resilient default untouched. Mirrors the retry:false already shipped on the
 // MCP limiter to unblock the suite (PR #3963).
 const REDIS_TEST_RETRY_OPTS: { retry?: false } = process.env.NODE_TEST_CONTEXT ? { retry: false } : {};
+// @upstash/ratelimit v2 returns an allow-shaped result with reason="timeout"
+// when this deadline wins the Redis race. Endpoint policies inspect that
+// reason below and fail closed; keeping the SDK timeout enabled bounds the
+// outage latency instead of waiting for the platform function timeout.
+const ENDPOINT_RATE_LIMIT_TIMEOUT_MS = process.env.NODE_TEST_CONTEXT ? 25 : 5_000;
+// Abort the underlying Upstash fetch just before the SDK's availability-first
+// race expires. Without this, the SDK returns its timeout result but leaves the
+// Redis request alive in the isolate for an unbounded transport stall.
+const ENDPOINT_REDIS_ABORT_TIMEOUT_MS = process.env.NODE_TEST_CONTEXT ? 20 : 4_500;
 
 let ratelimit: Ratelimit | null = null;
 const GLOBAL_RATE_LIMIT = 600;
@@ -66,9 +75,19 @@ function rateLimitErrorLevel(stage: string, msg: string): 'warning' | 'error' {
   return 'error';
 }
 
+const RATE_LIMIT_SENTRY_DEDUP_MS = 60_000;
+const lastRateLimitSentryCaptureAt = new Map<string, number>();
+
 function logRateLimitDegraded(stage: string, err: unknown): void {
   const msg = err instanceof Error ? err.message : String(err);
   console.error(`[rate-limit] redis-error stage=${stage} msg=${msg}`);
+  // Keep every occurrence in provider logs, but emit at most one Sentry event
+  // per limiter stage per minute from this isolate. A Redis outage otherwise
+  // turns every fail-closed request into another identical ingestion event.
+  const now = Date.now();
+  const lastCaptureAt = lastRateLimitSentryCaptureAt.get(stage);
+  if (lastCaptureAt !== undefined && now - lastCaptureAt < RATE_LIMIT_SENTRY_DEDUP_MS) return;
+  lastRateLimitSentryCaptureAt.set(stage, now);
   captureSilentError(err, {
     tags: { surface: 'server', component: 'rate-limit', stage },
     fingerprint: ['rate-limit', 'redis-error', stage],
@@ -273,14 +292,16 @@ export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
   '/api/intelligence/v1/list-company-signals': { limit: 30, window: '60 s' },
   '/api/intelligence/v1/search-sec-filings': { limit: 30, window: '60 s' },
   // Public market/economic provider proxies (#6236): caller-controlled symbols,
-  // countries, indicators, and year ranges create unbounded cache-key
-  // cardinality, so cache misses must not inherit the global fail-open budget.
-  // analyze-stock is stricter because one miss can fan out to Finnhub plus the
-  // Exa -> Brave -> SerpAPI search ladder; the other routes make one upstream
-  // provider request per miss and use the standard 30/min proxy budget.
-  '/api/market/v1/analyze-stock': { limit: 10, window: '60 s' },
-  '/api/market/v1/backtest-stock': { limit: 30, window: '60 s' },
-  '/api/market/v1/get-insider-transactions': { limit: 30, window: '60 s' },
+  // indicators, and year ranges create unbounded cache-key cardinality; the
+  // country-index route is bounded to the 45-country contract but still
+  // proxies Yahoo Finance on a cache miss. None may inherit the global
+  // fail-open budget. The dashboard can legitimately fan out across 50 Pro
+  // watchlist symbols, so those three per-symbol routes admit one full load
+  // plus headroom. analyze-stock remains separately constrained by the
+  // fail-closed per-user daily direct-LLM quota.
+  '/api/market/v1/analyze-stock': { limit: 60, window: '60 s' },
+  '/api/market/v1/backtest-stock': { limit: 60, window: '60 s' },
+  '/api/market/v1/get-insider-transactions': { limit: 60, window: '60 s' },
   '/api/market/v1/get-country-stock-index': { limit: 30, window: '60 s' },
   '/api/economic/v1/list-world-bank-indicators': { limit: 30, window: '60 s' },
   // Company Monitoring is contract-only and remains unrouted until #6003
@@ -484,10 +505,16 @@ function getEndpointRatelimit(pathname: string): Ratelimit | null {
   if (!url || !token) return null;
 
   const rl = new Ratelimit({
-    redis: new Redis({ url, token, ...REDIS_TEST_RETRY_OPTS }),
+    redis: new Redis({
+      url,
+      token,
+      ...REDIS_TEST_RETRY_OPTS,
+      signal: () => AbortSignal.timeout(ENDPOINT_REDIS_ABORT_TIMEOUT_MS),
+    }),
     limiter: Ratelimit.slidingWindow(policy.limit, policy.window),
     prefix: 'rl:ep',
     analytics: false,
+    timeout: ENDPOINT_RATE_LIMIT_TIMEOUT_MS,
   });
   endpointLimiters.set(pathname, rl);
   return rl;
@@ -520,7 +547,14 @@ export async function checkEndpointRateLimit(request: Request, pathname: string,
   if (!policy) return null;
 
   try {
-    const { success, limit, reset } = await limitWithFallback(rl, `${pathname}:${identifier}`, `rl:ep:fw:${pathname}:${identifier}`, policy.limit, durationToSeconds(policy.window));
+    const result = await limitWithFallback(rl, `${pathname}:${identifier}`, `rl:ep:fw:${pathname}:${identifier}`, policy.limit, durationToSeconds(policy.window));
+    // @upstash/ratelimit v2's timeout is intentionally availability-first:
+    // it resolves { success: true, reason: 'timeout' }. Explicit endpoint
+    // policies are the abuse defence, so that result is degraded, not an allow.
+    if (result.reason === 'timeout') {
+      throw new Error('Upstash endpoint rate-limit decision timed out');
+    }
+    const { success, limit, reset } = result;
 
     if (!success) {
       return tooManyRequestsResponse(limit, reset, corsHeaders, durationToSeconds(policy.window));
@@ -635,5 +669,6 @@ export function __resetRateLimitForTest(): void {
   endpointLimiters.clear();
   scopedLimiters.clear();
   scopedMissingConfigStages.clear();
+  lastRateLimitSentryCaptureAt.clear();
   resetRateLimitFallbackForTest();
 }

--- a/src/services/premium-fetch.ts
+++ b/src/services/premium-fetch.ts
@@ -71,6 +71,10 @@ export function reportServerError(
   // widget endpoint and drowns the genuine origin-5xx canary (#5245).
   // markWmSessionDead() captures the episode once instead.
   if (res.headers.get('X-Wm-Session-Degraded') === '1') return;
+  // Fail-closed rate-limit degradation is already captured at the server
+  // decision point. Reporting every browser-visible 503 again would turn one
+  // Redis outage into a per-route, per-client Sentry flood.
+  if (res.headers.get('X-RateLimit-Mode') === 'degraded') return;
   try {
     const href = input instanceof Request ? input.url : String(input);
     const path = new URL(href, globalThis.location?.href ?? 'https://worldmonitor.app').pathname;

--- a/tests/gateway-cdn-origin-policy.test.mts
+++ b/tests/gateway-cdn-origin-policy.test.mts
@@ -55,6 +55,11 @@ function createHandler(options: { handlerCdnCacheHeader?: string; publicRouteBod
       path: '/api/market/v1/analyze-stock',
       handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
     },
+    {
+      method: 'GET',
+      path: '/api/resilience/v1/get-resilience-score',
+      handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    },
   ]);
 }
 
@@ -251,13 +256,16 @@ describe('gateway CDN origin policy', () => {
     process.env.WORLDMONITOR_VALID_KEYS = 'real-key-123';
     const handler = createHandler();
 
-    const noCreds = await handler(new Request('https://worldmonitor.app/api/market/v1/analyze-stock?symbol=AAPL', {
+    // Use a premium route without its own fail-closed provider budget. The
+    // analyze-stock limiter is covered separately by the rate-limit contract;
+    // this test is scoped to premium auth and CDN behavior with Redis absent.
+    const noCreds = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=US', {
       headers: { Origin: 'https://worldmonitor.app' },
     }));
     assert.equal(noCreds.status, 401);
     assert.equal(noCreds.headers.get('Cache-Control'), 'no-store');
 
-    const withKey = await handler(new Request('https://worldmonitor.app/api/market/v1/analyze-stock?symbol=AAPL', {
+    const withKey = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=US', {
       headers: {
         Origin: 'https://worldmonitor.app',
         'X-WorldMonitor-Key': 'real-key-123',

--- a/tests/gateway-rpc-no-store-contract.test.mts
+++ b/tests/gateway-rpc-no-store-contract.test.mts
@@ -74,7 +74,9 @@ describe('gateway RPC no-store contract', () => {
       jsonRoute('/api/scenario/v1/get-scenario-status', { status: 'pending', error: '' }),
       jsonRoute('/api/intelligence/v1/get-risk-scores', { ciiScores: [], strategicRisks: [], degraded: true, stale: true }),
       jsonRoute('/api/forecast/v1/get-forecasts', { forecasts: [], generatedAt: 0, degraded: true, stale: false, error: 'forecast_backend_unavailable' }),
-      jsonRoute('/api/market/v1/analyze-stock', { available: false, symbol: 'XYZ', error: '' }),
+      // Keep this cache-semantics test off provider-backed routes, whose
+      // fail-closed endpoint budgets intentionally require Redis to be live.
+      jsonRoute('/api/market/v1/get-stock-analysis-history', { available: false, symbol: 'XYZ', error: '' }),
       jsonRoute('/api/climate/v1/list-climate-anomalies', { anomalies: [], dataAvailable: false }),
     ]);
 
@@ -82,7 +84,7 @@ describe('gateway RPC no-store contract', () => {
       '/api/scenario/v1/get-scenario-status?jobId=scenario:1712345678901:abcdefgh',
       '/api/intelligence/v1/get-risk-scores',
       '/api/forecast/v1/get-forecasts',
-      '/api/market/v1/analyze-stock?symbol=XYZ',
+      '/api/market/v1/get-stock-analysis-history?symbol=XYZ',
       '/api/climate/v1/list-climate-anomalies',
     ]) {
       const res = await handler(request(path));

--- a/tests/premium-fetch.test.mts
+++ b/tests/premium-fetch.test.mts
@@ -469,4 +469,14 @@ describe('reportServerError', () => {
     reportServerError(res, PUBLIC_TARGET, enqueue);
     assert.equal(calls.length, 0, 'synthetic degraded 503 must not be reported as an origin 5xx');
   });
+
+  it('skips fail-closed rate-limit degradation already captured by the server', () => {
+    const { calls, enqueue } = makeSpy();
+    const res = new Response(JSON.stringify({ error: 'Rate-limit service temporarily unavailable' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json', 'X-RateLimit-Mode': 'degraded' },
+    });
+    reportServerError(res, PUBLIC_TARGET, enqueue);
+    assert.equal(calls.length, 0, 'rate-limit degradation must not be captured again by every browser');
+  });
 });

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -304,6 +304,41 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     );
   });
 
+  it('paid-provider market routes each have explicit fail-closed policies (#6236)', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await importFreshRateLimitModule();
+    const expectedPolicies = new Map([
+      ['/api/market/v1/analyze-stock', { limit: 10, window: '60 s' }],
+      ['/api/market/v1/backtest-stock', { limit: 30, window: '60 s' }],
+      ['/api/market/v1/get-insider-transactions', { limit: 30, window: '60 s' }],
+      ['/api/market/v1/get-country-stock-index', { limit: 30, window: '60 s' }],
+      ['/api/economic/v1/list-world-bank-indicators', { limit: 30, window: '60 s' }],
+    ] as const);
+
+    for (const [pathname, expectedPolicy] of expectedPolicies) {
+      assert.deepEqual(
+        ENDPOINT_RATE_POLICIES[pathname],
+        expectedPolicy,
+        `${pathname} must keep its provider-proxy budget`,
+      );
+      assert.ok(
+        pathname in FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED,
+        `${pathname} must stay in the fail-closed requirement registry`,
+      );
+
+      const res = await mod.checkEndpointRateLimit(
+        makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+        pathname,
+        {},
+      );
+
+      assert.ok(res, `${pathname} must fail closed without Redis config`);
+      assert.equal(res.status, 503);
+      assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    }
+  });
+
   it('checkEndpointRateLimit keeps unrecognised paths unguarded even with fail-closed defaults', async () => {
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -309,9 +309,9 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
     const mod = await importFreshRateLimitModule();
     const expectedPolicies = new Map([
-      ['/api/market/v1/analyze-stock', { limit: 10, window: '60 s' }],
-      ['/api/market/v1/backtest-stock', { limit: 30, window: '60 s' }],
-      ['/api/market/v1/get-insider-transactions', { limit: 30, window: '60 s' }],
+      ['/api/market/v1/analyze-stock', { limit: 60, window: '60 s' }],
+      ['/api/market/v1/backtest-stock', { limit: 60, window: '60 s' }],
+      ['/api/market/v1/get-insider-transactions', { limit: 60, window: '60 s' }],
       ['/api/market/v1/get-country-stock-index', { limit: 30, window: '60 s' }],
       ['/api/economic/v1/list-world-bank-indicators', { limit: 30, window: '60 s' }],
     ] as const);
@@ -337,6 +337,51 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
       assert.equal(res.status, 503);
       assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
     }
+  });
+
+  it('paid-provider endpoint policies fail closed when Redis ignores abort until the SDK timeout (#6236)', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+    globalThis.fetch = (() => new Promise<Response>(() => {})) as typeof fetch;
+    const mod = await importFreshRateLimitModule();
+
+    const res = await mod.checkEndpointRateLimit(
+      makeRequest({ 'x-real-ip': '203.0.113.7' }),
+      '/api/market/v1/get-insider-transactions',
+      { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+    );
+
+    assert.ok(res, 'a timed-out limiter decision must not use the SDK allow fallback');
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+  });
+
+  it('paid-provider endpoint policies abort a stalled Redis fetch before failing closed (#6236)', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+    let fetchAborted = false;
+    globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        const abort = () => {
+          fetchAborted = true;
+          reject(signal?.reason ?? new DOMException('Aborted', 'AbortError'));
+        };
+        if (signal?.aborted) abort();
+        else signal?.addEventListener('abort', abort, { once: true });
+      })) as typeof fetch;
+    const mod = await importFreshRateLimitModule();
+
+    const res = await mod.checkEndpointRateLimit(
+      makeRequest({ 'x-real-ip': '203.0.113.7' }),
+      '/api/market/v1/get-insider-transactions',
+      {},
+    );
+
+    assert.equal(fetchAborted, true, 'the Redis transport must be cancelled, not left pending');
+    assert.equal(res?.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
   });
 
   it('checkEndpointRateLimit keeps unrecognised paths unguarded even with fail-closed defaults', async () => {
@@ -384,6 +429,8 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     assert.match(src, /captureSilentError\(err,\s*\{/);
     assert.match(src, /surface:\s*'server'/);
     assert.match(src, /fingerprint:\s*\['rate-limit',\s*'redis-error',\s*stage\]/);
+    assert.match(src, /lastRateLimitSentryCaptureAt\.get\(stage\)/);
+    assert.match(src, /lastCaptureAt !== undefined && now - lastCaptureAt < RATE_LIMIT_SENTRY_DEDUP_MS/);
   });
 
   it('checkScopedRateLimit reports and captures degraded missing-config once per scope', async () => {


### PR DESCRIPTION
## Summary

Five public provider-backed market and economic RPCs no longer inherit the 600/min availability-first fallback when Redis is unavailable. The three dashboard fan-out routes (`analyze-stock`, `backtest-stock`, and `get-insider-transactions`) now allow 60/min so one legitimate 50-symbol Pro load fits with headroom; the bounded country-index and World Bank routes remain at 30/min. Stock analysis is still separately protected by the fail-closed per-user daily direct-LLM quota.

Configured-but-stalled Redis now fails closed too: the endpoint Redis transport is aborted before the Upstash SDK's availability-first timeout, and the SDK's `{ success: true, reason: "timeout" }` result is independently treated as degraded. Browser Sentry skips the resulting marked 503s, while server captures are deduplicated per limiter stage per minute.

Mutation-style coverage pins every route to its exact quota, its required fail-closed registry entry, and the degraded 503 response contract so deleting or weakening any one policy fails the suite. It also exercises both an abort-aware Redis stall and a transport that ignores abort until the SDK timeout.

Fixes #6236.

## Validation

- Mandatory pre-push gate passed after rebasing onto current `origin/main`: frontend/API typechecks, edge bundle, architecture, Sentry coverage, rate-limit policy audit, server handler tests, and changed-file tests.
- `tests/rate-limit.test.mts` + `tests/premium-fetch.test.mts`: 66 passed, including configured Redis stall, transport abort, SDK timeout, exact policy, registry, and degraded-Sentry assertions.
- Server handler suite: 107 passed.
- Edge/boundary suite: 250 passed.
- Rate-limit policy audit: 33 policies across 213 gateway routes + 114 edge exceptions; 27 fail-closed requirements validated.
- Structured correctness, reliability, adversarial, and API-contract review found no remaining actionable issues.

## Post-deploy monitoring

- Watch route-level 429/503 rates for the five RPCs and `[rate-limit] redis-error stage=checkEndpointRateLimit:` logs.
- Healthy means Redis-backed requests remain successful, Redis degradation produces bounded 503s with `X-RateLimit-Mode: degraded`, and a normal 50-symbol dashboard load does not sustain 429s.
- `get-insider-transactions` remains intentionally public and IP-scoped; multiple simultaneous users behind one NAT can still contend. Changing that requires a separate access-contract decision.
- Roll back or adjust only the affected per-route budget if healthy Redis produces unexpected 503s or normal dashboard traffic shows a sustained 429 regression.
- Owner/window: maintainer on call for the first 24 hours after deployment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
