### PR TITLE
fix(military): deliver global flight coverage to dashboard

### DIFF
--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -18,6 +18,7 @@ const REDIS_STALE_KEY = 'military:flights:stale:v1';
 
 /** Snap a coordinate to a grid step so nearby bbox values share cache entries. */
 const quantize = (v: number, step: number) => Math.round(v / step) * step;
+const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
 const BBOX_GRID_STEP = 1; // 1-degree grid (~111 km at equator)
 
 interface RequestBounds {
@@ -300,7 +301,12 @@ export function _resetStaleNegativeCacheForTests(): void {
   staleNegUntil = 0;
 }
 
-async function fetchStaleFallback(): Promise<ListMilitaryFlightsResponse['flights'] | null> {
+interface StaleSeedSnapshot {
+  flights: ListMilitaryFlightsResponse['flights'];
+  coverage: SeedCoverage;
+}
+
+async function fetchStaleFallback(): Promise<StaleSeedSnapshot | null> {
   const now = Date.now();
   if (now < staleNegUntil) return null;
   try {
@@ -310,7 +316,10 @@ async function fetchStaleFallback(): Promise<ListMilitaryFlightsResponse['flight
       staleNegUntil = now + STALE_NEG_TTL_MS;
       return null;
     }
-    return flights;
+    return {
+      flights,
+      coverage: raw?.coverage === 'global' ? 'global' : 'regional',
+    };
   } catch {
     staleNegUntil = now + STALE_NEG_TTL_MS;
     return null;
@@ -377,10 +386,10 @@ export async function listMilitaryFlights(
         if (!baseUrl) return null;
 
         const fetchBB = {
-          lamin: quantize(req.swLat, BBOX_GRID_STEP) - BBOX_GRID_STEP / 2,
-          lamax: quantize(req.neLat, BBOX_GRID_STEP) + BBOX_GRID_STEP / 2,
-          lomin: quantize(req.swLon, BBOX_GRID_STEP) - BBOX_GRID_STEP / 2,
-          lomax: quantize(req.neLon, BBOX_GRID_STEP) + BBOX_GRID_STEP / 2,
+          lamin: clamp(quantize(req.swLat, BBOX_GRID_STEP) - BBOX_GRID_STEP / 2, -90, 90),
+          lamax: clamp(quantize(req.neLat, BBOX_GRID_STEP) + BBOX_GRID_STEP / 2, -90, 90),
+          lomin: clamp(quantize(req.swLon, BBOX_GRID_STEP) - BBOX_GRID_STEP / 2, -180, 180),
+          lomax: clamp(quantize(req.neLon, BBOX_GRID_STEP) + BBOX_GRID_STEP / 2, -180, 180),
         };
         const params = new URLSearchParams();
         params.set('lamin', String(fetchBB.lamin));
@@ -452,9 +461,9 @@ export async function listMilitaryFlights(
       // The seed cron (scripts/seed-military-flights.mjs) writes both keys
       // every run; stale has a 24h TTL versus 10min live, so it's the right
       // fallback when OpenSky / the relay hiccups.
-      const staleFlights = await fetchStaleFallback();
-      if (staleFlights && staleFlights.length > 0) {
-        return paginateResponse(staleFlights, [], requestBounds, req);
+      const stale = await fetchStaleFallback();
+      if (stale && seedCovers(stale.coverage, requestBounds)) {
+        return paginateResponse(stale.flights, [], requestBounds, req);
       }
       markNoCacheResponse(ctx.request);
       return emptyResponse();
@@ -473,9 +482,10 @@ export async function listMilitaryFlights(
     // live-seed read, so skipping stale here blanks the entire map rather than
     // the two former producer regions. fetchStaleFallback swallows its own
     // errors and returns null, so it cannot re-throw into this handler.
-    const staleFlights = await fetchStaleFallback();
-    if (staleFlights && staleFlights.length > 0) {
-      return paginateResponse(staleFlights, [], normalizeBounds(req), req);
+    const requestBounds = normalizeBounds(req);
+    const stale = await fetchStaleFallback();
+    if (stale && seedCovers(stale.coverage, requestBounds)) {
+      return paginateResponse(stale.flights, [], requestBounds, req);
     }
     markNoCacheResponse(ctx.request);
     return emptyResponse();

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -8,13 +8,15 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/military/v1/service_server';
 
 import { isMilitaryCallsign, isMilitaryHex, detectAircraftType, UPSTREAM_TIMEOUT_MS } from './_shared';
-import { cachedFetchJson, getRawJson, readCachedJson } from '../../../_shared/redis';
+import { cachedFetchJson, getRawJson, readCachedJson, setCachedJson } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 
 const REDIS_CACHE_KEY = 'military:flights:v1';
 const REDIS_CACHE_TTL = 600; // 10 min — reduce upstream API pressure
 const REDIS_STALE_KEY = 'military:flights:stale:v1';
+const STALE_SNAPSHOT_CACHE_TTL = 120; // Bind a bounded cursor traversal to one snapshot.
+const STALE_SNAPSHOT_NEG_TTL = 30;
 
 /** Snap a coordinate to a grid step so nearby bbox values share cache entries. */
 const quantize = (v: number, step: number) => Math.round(v / step) * step;
@@ -109,6 +111,16 @@ function resolveOffset(cursor: string | undefined): number {
 
 function emptyResponse(): ListMilitaryFlightsResponse {
   return { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } };
+}
+
+function buildCacheKey(req: ListMilitaryFlightsRequest): string {
+  const quantizedBB = [
+    quantize(req.swLat, BBOX_GRID_STEP),
+    quantize(req.swLon, BBOX_GRID_STEP),
+    quantize(req.neLat, BBOX_GRID_STEP),
+    quantize(req.neLon, BBOX_GRID_STEP),
+  ].join(':');
+  return `${REDIS_CACHE_KEY}:${quantizedBB}:${req.operator || ''}:${req.aircraftType || ''}`;
 }
 
 // Filter the cached quantized-cell snapshot to the exact request bbox, THEN
@@ -292,6 +304,13 @@ async function fetchLiveSeedSnapshot(): Promise<LiveSeedRead> {
 const STALE_NEG_TTL_MS = 30_000;
 let staleNegUntil = 0;
 
+type StaleSnapshotCacheEntry =
+  | { status: 'hit'; result: ListMilitaryFlightsResponse; coverage: SeedCoverage }
+  | { status: 'miss' };
+
+const staleSnapshotLocalCache = new Map<string, { entry: StaleSnapshotCacheEntry; expiresAt: number }>();
+const staleSnapshotInflight = new Map<string, Promise<StaleSnapshotCacheEntry>>();
+
 // Test seam — exposed for unit tests that need to drive the suppression
 // window without sleeping. Not exported from the module's public API.
 export function _resetStaleNegativeCacheForTests(): void {
@@ -299,6 +318,8 @@ export function _resetStaleNegativeCacheForTests(): void {
   liveSeedNegStatus = 'miss';
   liveSeedReadPromise = null;
   staleNegUntil = 0;
+  staleSnapshotLocalCache.clear();
+  staleSnapshotInflight.clear();
 }
 
 interface StaleSeedSnapshot {
@@ -326,6 +347,89 @@ async function fetchStaleFallback(): Promise<StaleSeedSnapshot | null> {
   }
 }
 
+function parseStaleSnapshotCacheEntry(value: unknown): StaleSnapshotCacheEntry | null {
+  if (!value || typeof value !== 'object') return null;
+  const entry = value as Partial<StaleSnapshotCacheEntry>;
+  if (entry.status === 'miss') return { status: 'miss' };
+  if (
+    entry.status !== 'hit'
+    || !entry.result
+    || !Array.isArray(entry.result.flights)
+    || (entry.coverage !== 'global' && entry.coverage !== 'regional')
+  ) return null;
+  return { status: 'hit', result: entry.result, coverage: entry.coverage };
+}
+
+function staleResultForBounds(
+  entry: StaleSnapshotCacheEntry,
+  requestBounds: RequestBounds,
+): ListMilitaryFlightsResponse | null {
+  return entry.status === 'hit' && seedCovers(entry.coverage, requestBounds) ? entry.result : null;
+}
+
+// Stale is a mutable root key, while pagination uses numeric offsets. Cache the
+// unpaginated snapshot plus its declared coverage per bbox/filter scope so a
+// seeder write cannot make later cursor pages slice a different ordering. Every
+// cache hit still rechecks exact request bounds against that coverage. Misses use
+// the legacy 30s suppression window; snapshots live for two minutes, comfortably
+// past the bounded traversal without extending the 24h root snapshot itself.
+async function fetchStableStaleSnapshot(
+  cacheKey: string,
+  requestBounds: RequestBounds,
+): Promise<ListMilitaryFlightsResponse | null> {
+  const staleCacheKey = `${cacheKey}:stale`;
+  const now = Date.now();
+  const local = staleSnapshotLocalCache.get(staleCacheKey);
+  if (local && local.expiresAt > now) {
+    return staleResultForBounds(local.entry, requestBounds);
+  }
+  if (local) staleSnapshotLocalCache.delete(staleCacheKey);
+
+  const cached = await readCachedJson(staleCacheKey);
+  if (cached.status === 'hit') {
+    const entry = parseStaleSnapshotCacheEntry(cached.value);
+    if (entry) {
+      const ttl = entry.status === 'hit' ? STALE_SNAPSHOT_CACHE_TTL : STALE_SNAPSHOT_NEG_TTL;
+      staleSnapshotLocalCache.set(staleCacheKey, { entry, expiresAt: now + ttl * 1_000 });
+      return staleResultForBounds(entry, requestBounds);
+    }
+  }
+
+  // Another caller may have populated the isolate cache while this request
+  // awaited Redis. Recheck before starting a second root-key read.
+  const refreshedLocal = staleSnapshotLocalCache.get(staleCacheKey);
+  if (refreshedLocal && refreshedLocal.expiresAt > Date.now()) {
+    return staleResultForBounds(refreshedLocal.entry, requestBounds);
+  }
+
+  const existing = staleSnapshotInflight.get(staleCacheKey);
+  if (existing) {
+    const entry = await existing;
+    return staleResultForBounds(entry, requestBounds);
+  }
+
+  const promise = (async (): Promise<StaleSnapshotCacheEntry> => {
+    const stale = await fetchStaleFallback();
+    const entry: StaleSnapshotCacheEntry = stale
+      ? {
+        status: 'hit',
+        result: { flights: stale.flights, clusters: [], pagination: undefined },
+        coverage: stale.coverage,
+      }
+      : { status: 'miss' };
+    const ttl = entry.status === 'hit' ? STALE_SNAPSHOT_CACHE_TTL : STALE_SNAPSHOT_NEG_TTL;
+    staleSnapshotLocalCache.set(staleCacheKey, { entry, expiresAt: Date.now() + ttl * 1_000 });
+    await setCachedJson(staleCacheKey, entry, ttl);
+    return entry;
+  })().finally(() => {
+    staleSnapshotInflight.delete(staleCacheKey);
+  });
+
+  staleSnapshotInflight.set(staleCacheKey, promise);
+  const entry = await promise;
+  return staleResultForBounds(entry, requestBounds);
+}
+
 export async function listMilitaryFlights(
   ctx: ServerContext,
   req: ListMilitaryFlightsRequest,
@@ -336,17 +440,11 @@ export async function listMilitaryFlights(
 
     // Quantize bbox to a 1° grid so nearby map views share cache entries.
     // Precise coordinates caused near-zero hit rate since every pan/zoom created a unique key.
-    const quantizedBB = [
-      quantize(req.swLat, BBOX_GRID_STEP),
-      quantize(req.swLon, BBOX_GRID_STEP),
-      quantize(req.neLat, BBOX_GRID_STEP),
-      quantize(req.neLon, BBOX_GRID_STEP),
-    ].join(':');
     // Key by the quantized bbox only. The cached value is the complete
     // expanded-cell snapshot, so page size and cursor must NOT fragment it —
     // every page/cursor for the same cell shares one upstream fetch and one
     // entry, and pagination is applied per-request after retrieval.
-    const cacheKey = `${REDIS_CACHE_KEY}:${quantizedBB}:${req.operator || ''}:${req.aircraftType || ''}`;
+    const cacheKey = buildCacheKey(req);
 
     const fullResult = await cachedFetchJson<ListMilitaryFlightsResponse>(
       cacheKey,
@@ -410,8 +508,9 @@ export async function listMilitaryFlights(
 
         const flights: ListMilitaryFlightsResponse['flights'] = [];
         for (const state of data.states) {
-          const [icao24, callsign, , , , lon, lat, altitude, onGround, velocity, heading] = state as [
-            string, string, unknown, unknown, unknown, number | null, number | null, number | null, boolean, number | null, number | null,
+          const [icao24, callsign, , , , lon, lat, altitude, onGround, velocity, heading, verticalRate] = state as [
+            string, string, unknown, unknown, unknown, number | null, number | null, number | null, boolean,
+            number | null, number | null, number | null,
           ];
           if (lat == null || lon == null || onGround) continue;
           if (!isMilitaryCallsign(callsign) && !isMilitaryHex(icao24)) continue;
@@ -434,10 +533,10 @@ export async function listMilitaryFlights(
             operator: 'MILITARY_OPERATOR_OTHER',
             operatorCountry: '',
             location: { latitude: lat, longitude: lon },
-            altitude: altitude ?? 0,
+            altitude: altitude != null ? Math.round(altitude * 3.28084) : 0,
             heading: heading ?? 0,
-            speed: (velocity as number) ?? 0,
-            verticalRate: 0,
+            speed: velocity != null ? Math.round(velocity * 1.94384) : 0,
+            verticalRate: verticalRate != null ? Math.round(verticalRate * 196.85) : 0,
             onGround: false,
             squawk: '',
             origin: '',
@@ -461,9 +560,9 @@ export async function listMilitaryFlights(
       // The seed cron (scripts/seed-military-flights.mjs) writes both keys
       // every run; stale has a 24h TTL versus 10min live, so it's the right
       // fallback when OpenSky / the relay hiccups.
-      const stale = await fetchStaleFallback();
-      if (stale && seedCovers(stale.coverage, requestBounds)) {
-        return paginateResponse(stale.flights, [], requestBounds, req);
+      const staleResult = await fetchStableStaleSnapshot(cacheKey, requestBounds);
+      if (staleResult) {
+        return paginateResponse(staleResult.flights, staleResult.clusters, requestBounds, req);
       }
       markNoCacheResponse(ctx.request);
       return emptyResponse();
@@ -480,12 +579,12 @@ export async function listMilitaryFlights(
     // key exists for. This matters much more since #6222 widened
     // LIVE_SEED_COVERAGE to global: every viewport now routes through the
     // live-seed read, so skipping stale here blanks the entire map rather than
-    // the two former producer regions. fetchStaleFallback swallows its own
-    // errors and returns null, so it cannot re-throw into this handler.
+    // the two former producer regions. The accepted stale snapshot is cached
+    // unpaginated so every cursor in the bounded traversal slices one version.
     const requestBounds = normalizeBounds(req);
-    const stale = await fetchStaleFallback();
-    if (stale && seedCovers(stale.coverage, requestBounds)) {
-      return paginateResponse(stale.flights, [], requestBounds, req);
+    const staleResult = await fetchStableStaleSnapshot(buildCacheKey(req), requestBounds);
+    if (staleResult) {
+      return paginateResponse(staleResult.flights, staleResult.clusters, requestBounds, req);
     }
     markNoCacheResponse(ctx.request);
     return emptyResponse();

--- a/src/config/military.ts
+++ b/src/config/military.ts
@@ -528,8 +528,7 @@ export interface QueryRegion {
 }
 
 export const MILITARY_QUERY_REGIONS: QueryRegion[] = [
-  { name: 'PACIFIC', lamin: 10, lamax: 46, lomin: 107, lomax: 143 },
-  { name: 'WESTERN', lamin: 13, lamax: 85, lomin: -10, lomax: 57 },
+  { name: 'GLOBAL', lamin: -90, lamax: 90, lomin: -180, lomax: 180 },
 ];
 
 if (import.meta.env.DEV) {

--- a/src/services/military-flights.ts
+++ b/src/services/military-flights.ts
@@ -163,9 +163,10 @@ function mapProtoFlight(pf: ProtoMilitaryFlight, nowDate: Date): MilitaryFlight 
 const MAX_REGION_PAGES = 50;
 
 async function fetchViaProto(): Promise<MilitaryFlight[]> {
-  // Iterate the same PACIFIC/WESTERN regions the server-side seed cron uses
-  // so dashboard coverage matches the analytic pipeline. The proto handler
-  // caches per-bbox, so parallel region calls warm independent cache keys.
+  // Request one full-world region so the seed cron's global OpenSky snapshot
+  // reaches the dashboard without being clipped back to the legacy boxes. The
+  // handler falls through to request-specific recovery when a seed snapshot
+  // declares only regional coverage.
   const results = await Promise.all(
     MILITARY_QUERY_REGIONS.map(async (region) => {
       // The server now bounds every response to a page, so follow next_cursor

--- a/tests/military-flight-pagination.test.mts
+++ b/tests/military-flight-pagination.test.mts
@@ -3,9 +3,11 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { transformSync } from 'esbuild';
+import type { QueryRegion } from '../src/config/military';
 
 const root = resolve(import.meta.dirname, '..');
 const serviceSource = readFileSync(resolve(root, 'src/services/military-flights.ts'), 'utf8');
+const configSource = readFileSync(resolve(root, 'src/config/military.ts'), 'utf8');
 let moduleCounter = 0;
 
 type PageRequest = {
@@ -28,7 +30,23 @@ function replaceRequired(source: string, search: string | RegExp, replacement: s
   return patched;
 }
 
-async function loadMilitaryService(handler: (req: PageRequest) => Promise<PageResponse> | PageResponse) {
+async function loadMilitaryQueryRegions(): Promise<QueryRegion[]> {
+  const transformed = transformSync(
+    configSource.replaceAll('import.meta.env.DEV', 'false'),
+    { loader: 'ts', format: 'esm', target: 'es2022' },
+  );
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(transformed.code).toString('base64')}#config`;
+  const module = await import(dataUrl) as { MILITARY_QUERY_REGIONS: QueryRegion[] };
+  return module.MILITARY_QUERY_REGIONS;
+}
+
+async function loadMilitaryService(
+  handler: (req: PageRequest) => Promise<PageResponse> | PageResponse,
+  queryRegions: QueryRegion[] = [
+    { name: 'alpha', lamin: 0, lamax: 1, lomin: 0, lomax: 1 },
+    { name: 'bravo', lamin: 10, lamax: 11, lomin: 10, lomax: 11 },
+  ],
+) {
   const hookName = `__wmMilitaryPaginationTest${++moduleCounter}`;
   (globalThis as Record<string, unknown>)[hookName] = handler;
 
@@ -58,10 +76,7 @@ async function loadMilitaryService(handler: (req: PageRequest) => Promise<PageRe
     const isKnownMilitaryHex = () => undefined;
     const getNearbyHotspot = () => undefined;
     const MILITARY_HOTSPOTS: any[] = [];
-    const MILITARY_QUERY_REGIONS = [
-      { name: 'alpha', lamin: 0, lamax: 1, lomin: 0, lomax: 1 },
-      { name: 'bravo', lamin: 10, lamax: 11, lomin: 10, lomax: 11 },
-    ];
+    const MILITARY_QUERY_REGIONS = ${JSON.stringify(queryRegions)};
     type QueryRegion = any;`,
     'military config',
   );
@@ -170,6 +185,42 @@ function regionName(req: PageRequest): 'alpha' | 'bravo' {
 }
 
 describe('military flight application-service pagination', { concurrency: 1 }, () => {
+  it('requests one global region and renders North American flights after bounded pagination', async () => {
+    const calls: PageRequest[] = [];
+    const queryRegions = await loadMilitaryQueryRegions();
+    const { module, cleanup } = await loadMilitaryService((req) => {
+      calls.push(req);
+      const isGlobal = req.swLat === -90 && req.neLat === 90 && req.swLon === -180 && req.neLon === 180;
+      if (!isGlobal) return { flights: [] };
+      if (req.cursor === '') {
+        return {
+          flights: [protoFlight('NA0001', 40, -100)],
+          pagination: { nextCursor: '100', totalCount: 2 },
+        };
+      }
+      if (req.cursor === '100') {
+        return {
+          flights: [protoFlight('AF0001', 5, 20)],
+          pagination: { nextCursor: '', totalCount: 2 },
+        };
+      }
+      throw new Error(`unexpected cursor ${JSON.stringify(req.cursor)}`);
+    }, queryRegions);
+
+    try {
+      const result = await module.fetchMilitaryFlights();
+
+      assert.equal(calls.filter((req) => req.cursor === '').length, 1, 'the client starts exactly one region request');
+      assert.deepEqual(calls.map((req) => req.cursor), ['', '100'], 'the one global request follows its cursor to termination');
+      assert.ok(
+        result.flights.some((flight) => flight.hexCode === 'NA0001' && flight.lat === 40 && flight.lon === -100),
+        'a North American military flight from the global snapshot reaches the dashboard service result',
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
   it('follows every region page, combines rows, and preserves cross-region hex deduplication', async () => {
     const cursorsByRegion = new Map<string, string[]>();
     const { module, cleanup } = await loadMilitaryService((req) => {

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -2309,6 +2309,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
           return jsonResponse({
             result: JSON.stringify({
               flights: [{ id: 'stale1', callsign: 'RCH777', lat: 40.5, lon: -99.5 }],
+              coverage: 'global',
               fetchedAt: Date.now(),
             }),
           });
@@ -2344,6 +2345,64 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       cleanup();
       globalThis.fetch = originalFetch;
       restoreEnv();
+    }
+  });
+
+  it('rejects stale snapshots that do not cover a global request after a live Redis error', async () => {
+    for (const coverage of [undefined, 'regional']) {
+      const { module, cleanup } = await importListMilitaryFlights();
+      module._resetStaleNegativeCacheForTests();
+      const restoreEnv = withEnv({
+        UPSTASH_REDIS_REST_URL: 'https://redis.test',
+        UPSTASH_REDIS_REST_TOKEN: 'token',
+        LOCAL_API_MODE: undefined,
+        WS_RELAY_URL: 'wss://relay.test',
+        VERCEL_ENV: undefined,
+        VERCEL_GIT_COMMIT_SHA: undefined,
+      });
+      const originalFetch = globalThis.fetch;
+      let openskyCalls = 0;
+
+      globalThis.fetch = async (url, init) => {
+        const raw = String(url);
+        if (raw.includes('/get/')) {
+          const key = decodeURIComponent(raw.split('/get/')[1] || '');
+          if (key === 'military:flights:v1') throw new Error('redis timeout');
+          if (key === 'military:flights:stale:v1') {
+            return jsonResponse({
+              result: JSON.stringify({
+                flights: [{ id: 'regional-stale', callsign: 'RCH777', lat: 40.5, lon: -99.5 }],
+                ...(coverage ? { coverage } : {}),
+                fetchedAt: Date.now(),
+              }),
+            });
+          }
+          return jsonResponse({ result: null });
+        }
+        if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+        if (raw.includes('/opensky')) {
+          openskyCalls += 1;
+          return jsonResponse({ states: [] });
+        }
+        throw new Error(`Unexpected fetch URL: ${raw}`);
+      };
+
+      try {
+        const result = await module.listMilitaryFlights(
+          { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+          { swLat: -90, swLon: -180, neLat: 90, neLon: 180 },
+        );
+        assert.equal(openskyCalls, 0, `${coverage ?? 'unstamped'} stale coverage must fail closed`);
+        assert.deepEqual(
+          result,
+          { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } },
+          `${coverage ?? 'unstamped'} stale coverage is not authoritative for a global request`,
+        );
+      } finally {
+        cleanup();
+        globalThis.fetch = originalFetch;
+        restoreEnv();
+      }
     }
   });
 
@@ -2389,6 +2448,44 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       assert.equal(liveSeedReads, 1, 'the global snapshot must be consulted before provider recovery');
       assert.equal(openskyCalls, 1, 'a snapshot miss must still reach request-specific recovery');
       assert.deepEqual(result.flights.map((flight) => flight.id), ['OUTSIDE-REGION']);
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('keeps global request recovery within legal OpenSky bounds', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      LOCAL_API_MODE: 'sidecar',
+      WS_RELAY_URL: undefined,
+      UPSTASH_REDIS_REST_URL: undefined,
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let recoveryUrl;
+
+    globalThis.fetch = async (url) => {
+      recoveryUrl = new URL(String(url));
+      return jsonResponse({
+        states: [['north-america', 'RCH401', null, null, null, -99.5, 40.5, 20000, false, 300, 90]],
+      });
+    };
+
+    try {
+      const result = await module.listMilitaryFlights({}, {
+        swLat: -90,
+        swLon: -180,
+        neLat: 90,
+        neLon: 180,
+      });
+
+      assert.deepEqual(result.flights.map((flight) => flight.id), ['NORTH-AMERICA']);
+      assert.equal(recoveryUrl?.searchParams.get('lamin'), '-90');
+      assert.equal(recoveryUrl?.searchParams.get('lamax'), '90');
+      assert.equal(recoveryUrl?.searchParams.get('lomin'), '-180');
+      assert.equal(recoveryUrl?.searchParams.get('lomax'), '180');
     } finally {
       cleanup();
       globalThis.fetch = originalFetch;
@@ -2686,6 +2783,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     const originalFetch = globalThis.fetch;
 
     const stalePayload = {
+      coverage: 'global',
       flights: [
         { id: 'stale-first', callsign: 'RCH201', lat: 10.1, lon: 10.1 },
         { id: 'stale-outside', callsign: 'RCH202', lat: 9.9, lon: 10.2 },

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -2348,6 +2348,69 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     }
   });
 
+  it('keeps stale cursor pagination on one cached snapshot while the root rotates', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    module._resetStaleNegativeCacheForTests();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const store = new Map();
+    let staleRootReads = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === 'military:flights:v1') throw new Error('redis timeout');
+        if (key === 'military:flights:stale:v1') {
+          staleRootReads += 1;
+          const flights = staleRootReads === 1
+            ? [
+              { id: 'stale-a', callsign: 'RCH701', lat: 40.2, lon: -99.8 },
+              { id: 'stale-b', callsign: 'RCH702', lat: 40.3, lon: -99.7 },
+            ]
+            : [{ id: 'stale-new', callsign: 'RCH799', lat: 40.4, lon: -99.6 }];
+          return jsonResponse({
+            result: JSON.stringify({ flights, coverage: 'global', fetchedAt: Date.now() }),
+          });
+        }
+        return jsonResponse({ result: store.get(key) ?? null });
+      }
+      if (isSetRequest(url, init)) {
+        const { key, value } = parseSetRequest(url, init);
+        store.set(key, value);
+        return jsonResponse({ result: 'OK' });
+      }
+      if (raw.includes('/opensky')) throw new Error('OpenSky must stay closed on a live Redis error');
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
+      const first = await module.listMilitaryFlights(ctx, { ...americasRequest, pageSize: 1, cursor: '' });
+      module._resetStaleNegativeCacheForTests();
+      const second = await module.listMilitaryFlights(ctx, {
+        ...americasRequest,
+        pageSize: 1,
+        cursor: first.pagination?.nextCursor ?? '',
+      });
+
+      assert.deepEqual(first.flights.map((flight) => flight.id), ['STALE-A']);
+      assert.deepEqual(second.flights.map((flight) => flight.id), ['STALE-B']);
+      assert.equal(staleRootReads, 1, 'continuation pages must use the cached stale snapshot');
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
   it('rejects stale snapshots that do not cover a global request after a live Redis error', async () => {
     for (const coverage of [undefined, 'regional']) {
       const { module, cleanup } = await importListMilitaryFlights();
@@ -2393,6 +2456,64 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
           { swLat: -90, swLon: -180, neLat: 90, neLon: 180 },
         );
         assert.equal(openskyCalls, 0, `${coverage ?? 'unstamped'} stale coverage must fail closed`);
+        assert.deepEqual(
+          result,
+          { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } },
+          `${coverage ?? 'unstamped'} stale coverage is not authoritative for a global request`,
+        );
+      } finally {
+        cleanup();
+        globalThis.fetch = originalFetch;
+        restoreEnv();
+      }
+    }
+  });
+
+  it('rejects stale snapshots that do not cover a global request after non-throw recovery failure', async () => {
+    for (const coverage of [undefined, 'regional']) {
+      const { module, cleanup } = await importListMilitaryFlights();
+      module._resetStaleNegativeCacheForTests();
+      const restoreEnv = withEnv({
+        UPSTASH_REDIS_REST_URL: 'https://redis.test',
+        UPSTASH_REDIS_REST_TOKEN: 'token',
+        LOCAL_API_MODE: undefined,
+        WS_RELAY_URL: 'wss://relay.test',
+        VERCEL_ENV: undefined,
+        VERCEL_GIT_COMMIT_SHA: undefined,
+      });
+      const originalFetch = globalThis.fetch;
+      let openskyCalls = 0;
+
+      globalThis.fetch = async (url, init) => {
+        const raw = String(url);
+        if (raw.includes('/get/')) {
+          const key = decodeURIComponent(raw.split('/get/')[1] || '');
+          if (key === 'military:flights:v1') return jsonResponse({ result: null });
+          if (key === 'military:flights:stale:v1') {
+            return jsonResponse({
+              result: JSON.stringify({
+                flights: [{ id: 'regional-stale', callsign: 'RCH777', lat: 40.5, lon: -99.5 }],
+                ...(coverage ? { coverage } : {}),
+                fetchedAt: Date.now(),
+              }),
+            });
+          }
+          return jsonResponse({ result: null });
+        }
+        if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+        if (raw.includes('/opensky')) {
+          openskyCalls += 1;
+          return jsonResponse({ states: [] });
+        }
+        throw new Error(`Unexpected fetch URL: ${raw}`);
+      };
+
+      try {
+        const result = await module.listMilitaryFlights(
+          { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+          { swLat: -90, swLon: -180, neLat: 90, neLon: 180 },
+        );
+        assert.equal(openskyCalls, 1, 'a live miss must attempt one bounded provider recovery');
         assert.deepEqual(
           result,
           { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } },
@@ -2469,7 +2590,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     globalThis.fetch = async (url) => {
       recoveryUrl = new URL(String(url));
       return jsonResponse({
-        states: [['north-america', 'RCH401', null, null, null, -99.5, 40.5, 20000, false, 300, 90]],
+        states: [['north-america', 'RCH401', null, null, null, -99.5, 40.5, 10000, false, 250, 90, 5]],
       });
     };
 
@@ -2486,6 +2607,15 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       assert.equal(recoveryUrl?.searchParams.get('lamax'), '90');
       assert.equal(recoveryUrl?.searchParams.get('lomin'), '-180');
       assert.equal(recoveryUrl?.searchParams.get('lomax'), '180');
+      assert.deepEqual(
+        {
+          altitude: result.flights[0]?.altitude,
+          speed: result.flights[0]?.speed,
+          verticalRate: result.flights[0]?.verticalRate,
+        },
+        { altitude: 32808, speed: 486, verticalRate: 984 },
+        'global recovery must preserve the feet, knots, and feet/minute proto contract',
+      );
     } finally {
       cleanup();
       globalThis.fetch = originalFetch;


### PR DESCRIPTION
## Summary

Military aircraft outside the two legacy dashboard boxes now reach the map, including North America, Australia, and most of Africa. The client makes one full-world request and follows its bounded cursor chain; the handler keeps fallback requests within legal OpenSky coordinates and refuses to present regional or unstamped stale data as complete global coverage.

The focused regression suite proves one initial global request, cursor termination, and a North American flight reaching the dashboard service result. It also exercises the real handler's world-boundary recovery and fail-closed stale-coverage behavior.

## Validation

- 69 focused military pagination and Redis/handler tests passed
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run lint` (passes; existing repo-wide warnings remain outside this diff)
- `npm run test:data`
- full change-scoped pre-push gate passed, including 107 server-handler and 250 edge-function tests

## Post-deploy validation

- For the first 24 hours, monitor military-flight freshness in `/api/health?compact=1`, dashboard flight counts and geographic distribution, OpenSky 4xx/429 responses, and pagination-termination warnings.
- Expected: flights appear beyond the old PACIFIC/WESTERN boxes, each client refresh starts one global request, cursor chains terminate, and provider request volume does not multiply.
- Roll back if sustained latency or memory growth, invalid-bounds responses, pagination ceilings, or partial stale snapshots cause the military layer to fail closed.

Fixes #6245.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)