### PR TITLE
fix(china): retry transient NBS fetches so one socket blip can't stale the release calendar

### DIFF
--- a/scripts/china-macro/calendar.mjs
+++ b/scripts/china-macro/calendar.mjs
@@ -1,6 +1,16 @@
 import { decodeHtmlEntities } from '../_html-entities.mjs';
 
 export const NBS_CALENDAR_INDEX_URL = 'https://www.stats.gov.cn/english/PressRelease/ReleaseCalendar/';
+// NBS is a REQUIRED source: any failure aborts the whole run, so a single
+// transient socket error costs a full 36h refresh interval against a 4,320min
+// (= exactly 2 intervals) freshness budget. Its sibling fetcher for the same
+// host — china-macro/source-runtime.mjs `fetchText` — already retries transient
+// throws once, which is why seed-china-macro stayed healthy through the same
+// window that took this calendar stale. 3 attempts x 20s + 1.5s backoff = 61.5s
+// per URL; the two NBS URLs plus the 20s ChinaMoney call cap the fetch phase at
+// ~143s, inside both lockTtlMs (180s) and the bundle section timeout (240s).
+export const NBS_TRANSIENT_FETCH_ATTEMPTS = 3;
+const NBS_TRANSIENT_RETRY_DELAY_MS = 500;
 export const CHINAMONEY_LPR_URL = 'https://www.chinamoney.com.cn/chinese/bklpr/?tab=2';
 export const CHINAMONEY_LPR_NOTICE_API = 'https://www.chinamoney.com.cn/ags/ms/cm-s-notice-query/contentsinshorttime';
 // Official LPR market-notice channel resolved by ChinaMoney's public
@@ -148,6 +158,42 @@ async function fetchText(fetchFn, url) {
   return response.text();
 }
 
+/**
+ * A fetch that never produced a response — DNS failure, TLS reset, socket
+ * hang-up, AbortSignal timeout — is the transient class this retry exists for.
+ * A response that arrived carries the verdict in its status: 408/429/5xx are
+ * worth another attempt, every other status is a permanent client error and
+ * retrying it would only triple the load on an official government host.
+ */
+function isTransientFetchFailure(error) {
+  if (Number.isInteger(error?.status)) {
+    return error.status === 408 || error.status === 429 || (error.status >= 500 && error.status <= 599);
+  }
+  // A bad certificate chain means the connection is being intercepted, not that
+  // the network hiccuped — fail closed immediately, as the sibling fetcher does.
+  const certMessage = `${String(error?.message)} ${String(error?.cause?.message)}`;
+  if (
+    error?.code === 'SELF_SIGNED_CERT_IN_CHAIN'
+    || error?.cause?.code === 'SELF_SIGNED_CERT_IN_CHAIN'
+    || /self signed certificate|certificate chain/i.test(certMessage)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+async function fetchTextWithTransientRetry(fetchFn, url, onAttempt) {
+  for (let attempt = 1; ; attempt++) {
+    onAttempt();
+    try {
+      return await fetchText(fetchFn, url);
+    } catch (error) {
+      if (attempt >= NBS_TRANSIENT_FETCH_ATTEMPTS || !isTransientFetchFailure(error)) throw error;
+      await new Promise((resolve) => setTimeout(resolve, NBS_TRANSIENT_RETRY_DELAY_MS * attempt));
+    }
+  }
+}
+
 async function fetchChinaMoneyNotices(fetchFn) {
   const response = await fetchFn(CHINAMONEY_LPR_NOTICE_API, {
     method: 'POST',
@@ -194,12 +240,13 @@ export async function fetchChinaReleaseCalendar({
 
   let nbsEvents = [];
   let nbsRequestCount = 0;
+  // Counted per ATTEMPT, not per URL: a retry is a real request against an
+  // official host, so the audited requestCount has to include it.
+  const fetchNbsText = (url) => fetchTextWithTransientRetry(fetchFn, url, () => { nbsRequestCount += 1; });
   try {
-    nbsRequestCount += 1;
-    const indexHtml = await fetchText(fetchFn, NBS_CALENDAR_INDEX_URL);
+    const indexHtml = await fetchNbsText(NBS_CALENDAR_INDEX_URL);
     const calendarUrl = currentCalendarLink(indexHtml, year);
-    if (calendarUrl !== NBS_CALENDAR_INDEX_URL) nbsRequestCount += 1;
-    const calendarHtml = calendarUrl === NBS_CALENDAR_INDEX_URL ? indexHtml : await fetchText(fetchFn, calendarUrl);
+    const calendarHtml = calendarUrl === NBS_CALENDAR_INDEX_URL ? indexHtml : await fetchNbsText(calendarUrl);
     nbsEvents = parseNbsReleaseCalendar(calendarHtml, year, calendarUrl);
     if (nbsEvents.length === 0) {
       throw Object.assign(new Error('NO_NBS_EVENTS'), { reason: 'NO_NBS_EVENTS' });

--- a/scripts/china-macro/calendar.mjs
+++ b/scripts/china-macro/calendar.mjs
@@ -6,11 +6,19 @@ export const NBS_CALENDAR_INDEX_URL = 'https://www.stats.gov.cn/english/PressRel
 // (= exactly 2 intervals) freshness budget. Its sibling fetcher for the same
 // host — china-macro/source-runtime.mjs `fetchText` — already retries transient
 // throws once, which is why seed-china-macro stayed healthy through the same
-// window that took this calendar stale. 3 attempts x 20s + 1.5s backoff = 61.5s
-// per URL; the two NBS URLs plus the 20s ChinaMoney call cap the fetch phase at
-// ~143s, inside both lockTtlMs (180s) and the bundle section timeout (240s).
+// window that took this calendar stale.
+//
+// The retry spend is bounded by a WALL-CLOCK budget across both NBS URLs, not
+// by attempt count alone. Attempts x per-request timeout would put the ceiling
+// at 2 x 3 x 20s = 120s, which leaves too little of the seeder's 180s lockTtlMs
+// for the publish phase. In practice a transient failure fails fast (a DNS or
+// connection-refused round trip is ~500ms, so 3 attempts cost ~1.7s including
+// backoff) — the 20s ceiling only binds when the host hangs, and that is
+// exactly the case the budget caps.
 export const NBS_TRANSIENT_FETCH_ATTEMPTS = 3;
-const NBS_TRANSIENT_RETRY_DELAY_MS = 500;
+export const NBS_REQUEST_TIMEOUT_MS = 20_000;
+export const NBS_TRANSIENT_RETRY_DELAY_MS = 500;
+export const NBS_TOTAL_FETCH_BUDGET_MS = 75_000;
 export const CHINAMONEY_LPR_URL = 'https://www.chinamoney.com.cn/chinese/bklpr/?tab=2';
 export const CHINAMONEY_LPR_NOTICE_API = 'https://www.chinamoney.com.cn/ags/ms/cm-s-notice-query/contentsinshorttime';
 // Official LPR market-notice channel resolved by ChinaMoney's public
@@ -152,11 +160,29 @@ function requiredSourceError(prefix, reason) {
 async function fetchText(fetchFn, url) {
   const response = await fetchFn(url, {
     headers: { Accept: 'text/html,application/xhtml+xml', 'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)' },
-    signal: AbortSignal.timeout(20_000),
+    signal: AbortSignal.timeout(NBS_REQUEST_TIMEOUT_MS),
   });
   if (!response.ok) throw Object.assign(new Error(`HTTP_${response.status}`), { status: response.status });
   return response.text();
 }
+
+// Certificate VALIDATION failures are permanent: they mean the peer is not who
+// it claims to be (interception, or an expired/misissued cert), and retrying
+// only repeats the request against that same untrusted peer. Handshake/reset
+// errors are deliberately absent — those are ordinary transport noise.
+const PERMANENT_TLS_CODES = new Set([
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+  'UNABLE_TO_GET_ISSUER_CERT',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'CERT_HAS_EXPIRED',
+  'CERT_NOT_YET_VALID',
+  'CERT_SIGNATURE_FAILURE',
+  'CERT_UNTRUSTED',
+  'CERT_REVOKED',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+]);
 
 /**
  * A fetch that never produced a response — DNS failure, TLS reset, socket
@@ -169,27 +195,30 @@ function isTransientFetchFailure(error) {
   if (Number.isInteger(error?.status)) {
     return error.status === 408 || error.status === 429 || (error.status >= 500 && error.status <= 599);
   }
-  // A bad certificate chain means the connection is being intercepted, not that
-  // the network hiccuped — fail closed immediately, as the sibling fetcher does.
+  if (PERMANENT_TLS_CODES.has(error?.code) || PERMANENT_TLS_CODES.has(error?.cause?.code)) return false;
+  // Message backstop for runtimes that surface a cert failure without a code.
+  // Anchored alternatives only — no nested quantifiers to backtrack on.
   const certMessage = `${String(error?.message)} ${String(error?.cause?.message)}`;
-  if (
-    error?.code === 'SELF_SIGNED_CERT_IN_CHAIN'
-    || error?.cause?.code === 'SELF_SIGNED_CERT_IN_CHAIN'
-    || /self signed certificate|certificate chain/i.test(certMessage)
-  ) {
+  if (/self.signed certificate|certificate chain|certificate has expired|unable to verify|altname/i.test(certMessage)) {
     return false;
   }
   return true;
 }
 
-async function fetchTextWithTransientRetry(fetchFn, url, onAttempt) {
+async function fetchTextWithTransientRetry(fetchFn, url, onAttempt, deadlineAt) {
   for (let attempt = 1; ; attempt++) {
     onAttempt();
     try {
       return await fetchText(fetchFn, url);
     } catch (error) {
       if (attempt >= NBS_TRANSIENT_FETCH_ATTEMPTS || !isTransientFetchFailure(error)) throw error;
-      await new Promise((resolve) => setTimeout(resolve, NBS_TRANSIENT_RETRY_DELAY_MS * attempt));
+      const backoffMs = NBS_TRANSIENT_RETRY_DELAY_MS * attempt;
+      // The budget spans BOTH NBS URLs, so a host that hangs on the index
+      // cannot spend the calendar page's share and push the fetch phase into
+      // the publish half of lockTtlMs. Give up rather than start an attempt
+      // that cannot finish inside the budget.
+      if (Date.now() + backoffMs >= deadlineAt) throw error;
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
     }
   }
 }
@@ -242,7 +271,13 @@ export async function fetchChinaReleaseCalendar({
   let nbsRequestCount = 0;
   // Counted per ATTEMPT, not per URL: a retry is a real request against an
   // official host, so the audited requestCount has to include it.
-  const fetchNbsText = (url) => fetchTextWithTransientRetry(fetchFn, url, () => { nbsRequestCount += 1; });
+  const nbsDeadlineAt = Date.now() + NBS_TOTAL_FETCH_BUDGET_MS;
+  const fetchNbsText = (url) => fetchTextWithTransientRetry(
+    fetchFn,
+    url,
+    () => { nbsRequestCount += 1; },
+    nbsDeadlineAt,
+  );
   try {
     const indexHtml = await fetchNbsText(NBS_CALENDAR_INDEX_URL);
     const calendarUrl = currentCalendarLink(indexHtml, year);

--- a/scripts/china-macro/calendar.mjs
+++ b/scripts/china-macro/calendar.mjs
@@ -157,12 +157,29 @@ function requiredSourceError(prefix, reason) {
   return Object.assign(new Error(`${prefix}:${reason}`), { reason, nonRetryable: true });
 }
 
+/** `Retry-After` is either delta-seconds or an HTTP date. Null when absent or unparseable. */
+function parseRetryAfterMs(value) {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1_000);
+  const retryAt = Date.parse(value);
+  return Number.isFinite(retryAt) ? Math.max(0, retryAt - Date.now()) : null;
+}
+
 async function fetchText(fetchFn, url) {
   const response = await fetchFn(url, {
     headers: { Accept: 'text/html,application/xhtml+xml', 'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)' },
     signal: AbortSignal.timeout(NBS_REQUEST_TIMEOUT_MS),
   });
-  if (!response.ok) throw Object.assign(new Error(`HTTP_${response.status}`), { status: response.status });
+  if (!response.ok) {
+    const error = Object.assign(new Error(`HTTP_${response.status}`), { status: response.status });
+    // Carry the host's own backoff request out of the response, which is
+    // otherwise discarded here — the retry loop cannot honor a hint it never
+    // sees, and both sibling helpers (source-runtime.mjs, _seed-utils.mjs) do.
+    const retryAfterMs = parseRetryAfterMs(response.headers?.get?.('Retry-After'));
+    if (retryAfterMs != null) error.retryAfterMs = retryAfterMs;
+    throw error;
+  }
   return response.text();
 }
 
@@ -205,20 +222,23 @@ function isTransientFetchFailure(error) {
   return true;
 }
 
-async function fetchTextWithTransientRetry(fetchFn, url, onAttempt, deadlineAt) {
+async function fetchTextWithTransientRetry(fetchFn, url, { onAttempt, deadlineAt, sleepFn }) {
   for (let attempt = 1; ; attempt++) {
     onAttempt();
     try {
       return await fetchText(fetchFn, url);
     } catch (error) {
       if (attempt >= NBS_TRANSIENT_FETCH_ATTEMPTS || !isTransientFetchFailure(error)) throw error;
-      const backoffMs = NBS_TRANSIENT_RETRY_DELAY_MS * attempt;
+      // Grows with the attempt, but never undercuts an explicit Retry-After
+      // from the host. An unreasonably long hint is not slept off — it trips
+      // the deadline below and the run gives up, which is the honest outcome.
+      const backoffMs = Math.max(NBS_TRANSIENT_RETRY_DELAY_MS * attempt, error?.retryAfterMs ?? 0);
       // The budget spans BOTH NBS URLs, so a host that hangs on the index
       // cannot spend the calendar page's share and push the fetch phase into
       // the publish half of lockTtlMs. Give up rather than start an attempt
       // that cannot finish inside the budget.
       if (Date.now() + backoffMs >= deadlineAt) throw error;
-      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+      await sleepFn(backoffMs);
     }
   }
 }
@@ -260,6 +280,7 @@ export function currentCalendarLink(indexHtml, year) {
 export async function fetchChinaReleaseCalendar({
   now = Date.now(),
   fetchFn = globalThis.fetch,
+  sleepFn = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   onDecision = (entry) => console.log(JSON.stringify({ event: 'china_calendar_source_preflight', ...entry })),
 } = {}) {
   const checkedAt = new Date(now).toISOString();
@@ -272,12 +293,11 @@ export async function fetchChinaReleaseCalendar({
   // Counted per ATTEMPT, not per URL: a retry is a real request against an
   // official host, so the audited requestCount has to include it.
   const nbsDeadlineAt = Date.now() + NBS_TOTAL_FETCH_BUDGET_MS;
-  const fetchNbsText = (url) => fetchTextWithTransientRetry(
-    fetchFn,
-    url,
-    () => { nbsRequestCount += 1; },
-    nbsDeadlineAt,
-  );
+  const fetchNbsText = (url) => fetchTextWithTransientRetry(fetchFn, url, {
+    onAttempt: () => { nbsRequestCount += 1; },
+    deadlineAt: nbsDeadlineAt,
+    sleepFn,
+  });
   try {
     const indexHtml = await fetchNbsText(NBS_CALENDAR_INDEX_URL);
     const calendarUrl = currentCalendarLink(indexHtml, year);

--- a/scripts/china-macro/calendar.mjs
+++ b/scripts/china-macro/calendar.mjs
@@ -185,21 +185,51 @@ async function fetchText(fetchFn, url) {
 
 // Certificate VALIDATION failures are permanent: they mean the peer is not who
 // it claims to be (interception, or an expired/misissued cert), and retrying
-// only repeats the request against that same untrusted peer. Handshake/reset
-// errors are deliberately absent — those are ordinary transport noise.
-const PERMANENT_TLS_CODES = new Set([
+// only repeats the request against that same untrusted peer. This is OpenSSL's
+// verify-step family as Node surfaces it, plus Node's own altname code.
+// Handshake/reset/timeout codes are deliberately absent — those are ordinary
+// transport noise and are exactly what the retry exists for.
+export const PERMANENT_TLS_CODES = new Set([
   'SELF_SIGNED_CERT_IN_CHAIN',
   'DEPTH_ZERO_SELF_SIGNED_CERT',
   'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
   'UNABLE_TO_GET_ISSUER_CERT',
   'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'UNABLE_TO_GET_CRL',
+  'UNABLE_TO_DECRYPT_CERT_SIGNATURE',
+  'UNABLE_TO_DECRYPT_CRL_SIGNATURE',
+  'UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY',
   'CERT_HAS_EXPIRED',
   'CERT_NOT_YET_VALID',
   'CERT_SIGNATURE_FAILURE',
   'CERT_UNTRUSTED',
   'CERT_REVOKED',
+  'CERT_REJECTED',
+  'CERT_CHAIN_TOO_LONG',
+  'CRL_SIGNATURE_FAILURE',
+  'CRL_HAS_EXPIRED',
+  'CRL_NOT_YET_VALID',
+  'ERROR_IN_CERT_NOT_BEFORE_FIELD',
+  'ERROR_IN_CERT_NOT_AFTER_FIELD',
+  'INVALID_CA',
+  'INVALID_PURPOSE',
+  'PATH_LENGTH_EXCEEDED',
+  'HOSTNAME_MISMATCH',
   'ERR_TLS_CERT_ALTNAME_INVALID',
 ]);
+
+/** Reason recorded when the peer's certificate failed validation. */
+export const TLS_CERT_UNTRUSTED_REASON = 'TLS_CERT_UNTRUSTED';
+/** Reason recorded when the shared NBS wall-clock budget ran out mid-retry. */
+export const FETCH_BUDGET_EXHAUSTED_REASON = 'FETCH_BUDGET_EXHAUSTED';
+
+function isCertificateValidationFailure(error) {
+  if (PERMANENT_TLS_CODES.has(error?.code) || PERMANENT_TLS_CODES.has(error?.cause?.code)) return true;
+  // Message backstop for runtimes that surface a cert failure without a code.
+  // Anchored alternatives only — no nested quantifiers to backtrack on.
+  const certMessage = `${String(error?.message)} ${String(error?.cause?.message)}`;
+  return /self.signed certificate|certificate chain|certificate has expired|unable to verify|altname/i.test(certMessage);
+}
 
 /**
  * A fetch that never produced a response — DNS failure, TLS reset, socket
@@ -212,14 +242,22 @@ function isTransientFetchFailure(error) {
   if (Number.isInteger(error?.status)) {
     return error.status === 408 || error.status === 429 || (error.status >= 500 && error.status <= 599);
   }
-  if (PERMANENT_TLS_CODES.has(error?.code) || PERMANENT_TLS_CODES.has(error?.cause?.code)) return false;
-  // Message backstop for runtimes that surface a cert failure without a code.
-  // Anchored alternatives only — no nested quantifiers to backtrack on.
-  const certMessage = `${String(error?.message)} ${String(error?.cause?.message)}`;
-  if (/self.signed certificate|certificate chain|certificate has expired|unable to verify|altname/i.test(certMessage)) {
-    return false;
+  return !isCertificateValidationFailure(error);
+}
+
+/**
+ * Record WHY we stopped, so an operator can tell an intercepted connection or a
+ * spent budget from an ordinary socket blip. `reasonFor` prefers `error.reason`
+ * over its generic FETCH_FAILED fallback, and all three land in the audited
+ * `china_calendar_source_preflight` decision record.
+ */
+function tagReason(error, reason) {
+  try {
+    if (error && !error.reason) error.reason = reason;
+  } catch {
+    // A frozen error keeps the generic reason; never mask the original failure.
   }
-  return true;
+  return error;
 }
 
 async function fetchTextWithTransientRetry(fetchFn, url, { onAttempt, deadlineAt, sleepFn }) {
@@ -228,16 +266,23 @@ async function fetchTextWithTransientRetry(fetchFn, url, { onAttempt, deadlineAt
     try {
       return await fetchText(fetchFn, url);
     } catch (error) {
+      if (isCertificateValidationFailure(error)) throw tagReason(error, TLS_CERT_UNTRUSTED_REASON);
       if (attempt >= NBS_TRANSIENT_FETCH_ATTEMPTS || !isTransientFetchFailure(error)) throw error;
       // Grows with the attempt, but never undercuts an explicit Retry-After
-      // from the host. An unreasonably long hint is not slept off — it trips
-      // the deadline below and the run gives up, which is the honest outcome.
+      // from the host. An over-long hint is not slept off and is not silently
+      // shortened either — honoring it would breach the budget, so the run
+      // gives up and the next scheduled run tries again.
       const backoffMs = Math.max(NBS_TRANSIENT_RETRY_DELAY_MS * attempt, error?.retryAfterMs ?? 0);
-      // The budget spans BOTH NBS URLs, so a host that hangs on the index
-      // cannot spend the calendar page's share and push the fetch phase into
-      // the publish half of lockTtlMs. Give up rather than start an attempt
-      // that cannot finish inside the budget.
-      if (Date.now() + backoffMs >= deadlineAt) throw error;
+      // Reserve the next attempt's full timeout. Gating on the sleep's END is
+      // not enough: an attempt that merely STARTS before the deadline can run
+      // NBS_REQUEST_TIMEOUT_MS past it, and if it succeeds there, the second
+      // URL's first attempt (never gated) adds another. That path measured
+      // 134s against a claimed 115s ceiling. Reserving the timeout makes every
+      // gated attempt END inside the budget, so the ceiling is deadline + one
+      // ungated first attempt per URL.
+      if (Date.now() + backoffMs + NBS_REQUEST_TIMEOUT_MS > deadlineAt) {
+        throw tagReason(error, FETCH_BUDGET_EXHAUSTED_REASON);
+      }
       await sleepFn(backoffMs);
     }
   }

--- a/tests/china-release-calendar.test.mjs
+++ b/tests/china-release-calendar.test.mjs
@@ -212,6 +212,96 @@ describe('China official release calendar', () => {
     assert.ok(worstCaseFetchMs < BUNDLE_SECTION_TIMEOUT_MS / 2);
   });
 
+  it('shares one wall-clock budget across both NBS URLs rather than giving each a fresh one', async () => {
+    // The whole point of a shared deadline: a host that hangs on the index must
+    // not leave the calendar page a full budget. Without this the index could
+    // burn 75s and the calendar page start another 75s, doubling the ceiling
+    // the seeder's lock was sized against.
+    let calendarPageAttempts = 0;
+    const realNow = Date.now;
+    let elapsed = 0;
+    Date.now = () => realNow() + elapsed;
+    try {
+      await assert.rejects(
+        fetchChinaReleaseCalendar({
+          now: Date.parse('2026-07-13T00:00:00Z'),
+          sleepFn: async () => {},
+          fetchFn: async (url) => {
+            if (String(url) === NBS_CALENDAR_INDEX_URL) {
+              // Index succeeds, but leaves less than one backoff of budget.
+              elapsed += NBS_TOTAL_FETCH_BUDGET_MS - (NBS_TRANSIENT_RETRY_DELAY_MS - 100);
+              return new Response('<a href="calendar.html">2026 release calendar</a>');
+            }
+            calendarPageAttempts += 1;
+            throw new TypeError('fetch failed');
+          },
+          onDecision: () => {},
+        }),
+        (error) => /NBS_REQUIRED_SOURCE_UNAVAILABLE:FETCH_FAILED/.test(error.message),
+      );
+    } finally {
+      Date.now = realNow;
+    }
+    // The calendar page gets ONE attempt because the index already spent the
+    // shared budget. A per-URL budget would have handed it a fresh 75s and all
+    // NBS_TRANSIENT_FETCH_ATTEMPTS tries.
+    assert.equal(calendarPageAttempts, 1);
+    assert.ok(calendarPageAttempts < NBS_TRANSIENT_FETCH_ATTEMPTS);
+  });
+
+  it('grows the backoff with each attempt and never undercuts the host Retry-After hint', async () => {
+    const slept = [];
+    let indexAttempts = 0;
+    let pageAttempts = 0;
+    const calendar = await fetchChinaReleaseCalendar({
+      now: Date.parse('2026-07-13T00:00:00Z'),
+      sleepFn: async (ms) => { slept.push(ms); },
+      fetchFn: async (url) => {
+        if (String(url) === NBS_CALENDAR_INDEX_URL) {
+          indexAttempts += 1;
+          // Two BARE transient failures, so the growth term is observable on
+          // its own. Pairing growth with a Retry-After hint would hide it —
+          // the hint dominates the max() and a flat delay would look identical.
+          if (indexAttempts <= 2) return new Response('', { status: 503 });
+          return new Response('<a href="calendar.html">2026 release calendar</a>');
+        }
+        if (String(url).endsWith('calendar.html')) {
+          pageAttempts += 1;
+          if (pageAttempts === 1) return new Response('', { status: 503, headers: { 'Retry-After': '5' } });
+          return new Response(fixture('nbs-calendar.html'));
+        }
+        return new Response(fixture('chinamoney-lpr.json'), { headers: { 'Content-Type': 'application/json' } });
+      },
+      onDecision: () => {},
+    });
+    assert.ok(calendar.events.some((event) => event.kind === 'nbs'));
+    // 500 then 1000 proves the growth term; 5000 proves the host's hint wins
+    // over the 500ms the schedule would have used for a first retry.
+    assert.deepEqual(slept, [500, 1_000, 5_000]);
+  });
+
+  for (const status of [408, 429]) {
+    it(`retries a transient NBS ${status}`, async () => {
+      const indexRequests = [];
+      const calendar = await fetchChinaReleaseCalendar({
+        now: Date.parse('2026-07-13T00:00:00Z'),
+        sleepFn: async () => {},
+        fetchFn: async (url) => {
+          if (String(url) === NBS_CALENDAR_INDEX_URL) {
+            indexRequests.push(status);
+            if (indexRequests.length === 1) return new Response('', { status });
+            return new Response('<a href="calendar.html">2026 release calendar</a>');
+          }
+          if (String(url).endsWith('calendar.html')) return new Response(fixture('nbs-calendar.html'));
+          return new Response(fixture('chinamoney-lpr.json'), { headers: { 'Content-Type': 'application/json' } });
+        },
+        onDecision: () => {},
+      });
+      assert.ok(calendar.events.some((event) => event.kind === 'nbs'));
+      assert.equal(indexRequests.length, 2);
+    });
+  }
+
   it('stops retrying once the shared NBS wall-clock budget is spent', async () => {
     // A host that hangs must not spend the calendar page's share of the budget.
     // Simulated by advancing past the deadline rather than sleeping 75s.

--- a/tests/china-release-calendar.test.mjs
+++ b/tests/china-release-calendar.test.mjs
@@ -4,11 +4,14 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 import {
+  FETCH_BUDGET_EXHAUSTED_REASON,
   NBS_CALENDAR_INDEX_URL,
   NBS_REQUEST_TIMEOUT_MS,
   NBS_TOTAL_FETCH_BUDGET_MS,
   NBS_TRANSIENT_FETCH_ATTEMPTS,
   NBS_TRANSIENT_RETRY_DELAY_MS,
+  PERMANENT_TLS_CODES,
+  TLS_CERT_UNTRUSTED_REASON,
   buildLprCandidates,
   fetchChinaReleaseCalendar,
   mergeVerifiedLprDates,
@@ -183,33 +186,116 @@ describe('China official release calendar', () => {
     assert.equal(rejectedError.nonRetryable, true);
   });
 
-  it('bounds the worst-case NBS fetch phase well inside the seeder lock', () => {
+  // seed-china-release-calendar.mjs holds a 180s lock inside a 240s bundle
+  // section; atomicPublish makes several retried Redis round trips inside that
+  // same lock after the fetch returns, so the fetch phase must leave it room.
+  const SEEDER_LOCK_TTL_MS = 180_000;
+  const BUNDLE_SECTION_TIMEOUT_MS = 240_000;
+  const CHINAMONEY_TIMEOUT_MS = 20_000;
+  // The deadline reserves each gated attempt's full timeout, so every RETRY
+  // ends inside the budget. What can still land outside it is the one ungated
+  // first attempt per URL — hence budget + one request, then ChinaMoney.
+  const CEILING_MS = NBS_TOTAL_FETCH_BUDGET_MS + NBS_REQUEST_TIMEOUT_MS + CHINAMONEY_TIMEOUT_MS;
+
+  /**
+   * Drive a whole run on a virtual clock where every request burns its full
+   * timeout and sleeps advance time, and report the observed wall time. This is
+   * how the ceiling gets MEASURED rather than recomputed from the same
+   * constants the implementation uses.
+   */
+  const measureRun = async ({
+    retryAfterSeconds = null,
+    indexSucceedsOnAttempt = null,
+    pageSucceeds = false,
+  } = {}) => {
+    const realNow = Date.now;
+    let clock = 0;
+    let indexAttempts = 0;
+    Date.now = () => realNow() + clock;
+    try {
+      await fetchChinaReleaseCalendar({
+        sleepFn: async (ms) => { clock += ms; },
+        fetchFn: async (url) => {
+          const target = String(url);
+          // ChinaMoney runs ONLY when both NBS fetches succeeded — a failing NBS
+          // throws first. So the longest run is the SUCCESS path, which is also
+          // the only one that reaches publish and therefore the one the lock
+          // budget exists for.
+          if (target.includes('chinamoney')) {
+            clock += CHINAMONEY_TIMEOUT_MS;
+            throw new TypeError('fetch failed');
+          }
+          clock += NBS_REQUEST_TIMEOUT_MS;
+          if (target === NBS_CALENDAR_INDEX_URL) {
+            indexAttempts += 1;
+            if (indexSucceedsOnAttempt !== null && indexAttempts >= indexSucceedsOnAttempt) {
+              return new Response('<a href="calendar.html">2026 release calendar</a>');
+            }
+          } else if (pageSucceeds) {
+            return new Response(fixture('nbs-calendar.html'));
+          }
+          const headers = retryAfterSeconds === null ? undefined : { 'Retry-After': String(retryAfterSeconds) };
+          return new Response('', { status: 503, headers });
+        },
+        onDecision: () => {},
+      });
+    } catch { /* a failing run is a valid scenario too */ } finally {
+      Date.now = realNow;
+    }
+    return clock;
+  };
+
+  it('pins the constants the fetch-phase ceiling is derived from', () => {
     // Asserted against literals on purpose: every other retry test compares
     // against the imported constants, so raising one would move those
-    // assertions with it and silently widen the budget. Pinning the numbers
-    // here is what makes this test constrain the budget rather than restate it.
+    // assertions with it and silently widen the budget.
     assert.equal(NBS_TRANSIENT_FETCH_ATTEMPTS, 3);
     assert.equal(NBS_REQUEST_TIMEOUT_MS, 20_000);
     assert.equal(NBS_TRANSIENT_RETRY_DELAY_MS, 500);
     assert.equal(NBS_TOTAL_FETCH_BUDGET_MS, 75_000);
+    assert.equal(CEILING_MS, 115_000);
+    // Leave the publish phase at least a third of the lock.
+    assert.ok(CEILING_MS <= SEEDER_LOCK_TTL_MS * (2 / 3));
+    assert.ok(CEILING_MS < BUNDLE_SECTION_TIMEOUT_MS / 2);
+  });
 
-    // seed-china-release-calendar.mjs holds a 180s lock inside a 240s bundle
-    // section. The wall-clock budget spans both NBS URLs, and the deadline is
-    // checked BEFORE sleeping, so the worst case is the budget plus one
-    // already-in-flight request, then the single ChinaMoney call.
-    const SEEDER_LOCK_TTL_MS = 180_000;
-    const BUNDLE_SECTION_TIMEOUT_MS = 240_000;
-    const CHINAMONEY_TIMEOUT_MS = 20_000;
-    const worstCaseFetchMs = NBS_TOTAL_FETCH_BUDGET_MS + NBS_REQUEST_TIMEOUT_MS + CHINAMONEY_TIMEOUT_MS;
+  it('keeps the OBSERVED fetch phase inside the ceiling, including a Retry-After that fits the budget', async () => {
+    // A hint large enough to fit the deadline check but long enough to push the
+    // index's next attempt past it was the real breach: the attempt STARTED in
+    // budget, succeeded 20s outside it, and the calendar page's ungated first
+    // attempt added another 20s — 134s observed against a 115s claim. Sweeping
+    // the hint across the budget is what catches that class, not arithmetic.
+    const scenarios = [
+      { label: 'all fail, no hint' },
+      { label: 'all fail, short hint', retryAfterSeconds: 5 },
+      { label: 'index succeeds first try, page fails', indexSucceedsOnAttempt: 1 },
+      { label: 'index succeeds late, page fails', indexSucceedsOnAttempt: 2 },
+      { label: 'absurd hint', retryAfterSeconds: 3_600 },
+      { label: 'full success, no hint', indexSucceedsOnAttempt: 1, pageSucceeds: true },
+    ];
+    // Sweep at 1s granularity: the breach only appears for hints in a narrow
+    // band (large enough to push the next attempt past the deadline, small
+    // enough to still pass the check), and a 5s step steps right over it.
+    for (let hint = 1; hint <= 80; hint += 1) {
+      scenarios.push({ label: `failing run, hint ${hint}s`, retryAfterSeconds: hint });
+      scenarios.push({ label: `late index success, page fails, hint ${hint}s`, retryAfterSeconds: hint, indexSucceedsOnAttempt: 2 });
+      // The costliest shape: everything eventually SUCCEEDS but slowly, so
+      // ChinaMoney runs too and the whole fetch phase lands before publish.
+      scenarios.push({
+        label: `full success after a late retry, hint ${hint}s`,
+        retryAfterSeconds: hint,
+        indexSucceedsOnAttempt: 2,
+        pageSucceeds: true,
+      });
+    }
 
-    assert.equal(worstCaseFetchMs, 115_000);
-    // Leave the publish phase at least a third of the lock: atomicPublish makes
-    // several retried Redis round trips after the fetch returns.
-    assert.ok(
-      worstCaseFetchMs <= SEEDER_LOCK_TTL_MS * (2 / 3),
-      `worst-case fetch ${worstCaseFetchMs}ms leaves too little of the ${SEEDER_LOCK_TTL_MS}ms lock for publish`,
-    );
-    assert.ok(worstCaseFetchMs < BUNDLE_SECTION_TIMEOUT_MS / 2);
+    for (const { label, ...options } of scenarios) {
+      const observedMs = await measureRun(options);
+      assert.ok(
+        observedMs <= CEILING_MS,
+        `${label}: observed fetch phase ${observedMs}ms exceeds the ${CEILING_MS}ms ceiling`,
+      );
+    }
   });
 
   it('shares one wall-clock budget across both NBS URLs rather than giving each a fresh one', async () => {
@@ -237,7 +323,8 @@ describe('China official release calendar', () => {
           },
           onDecision: () => {},
         }),
-        (error) => /NBS_REQUIRED_SOURCE_UNAVAILABLE:FETCH_FAILED/.test(error.message),
+        // The shared budget — not the attempt count — is what stopped it.
+        (error) => error.message === `NBS_REQUIRED_SOURCE_UNAVAILABLE:${FETCH_BUDGET_EXHAUSTED_REASON}`,
       );
     } finally {
       Date.now = realNow;
@@ -306,6 +393,7 @@ describe('China official release calendar', () => {
     // A host that hangs must not spend the calendar page's share of the budget.
     // Simulated by advancing past the deadline rather than sleeping 75s.
     const requests = [];
+    const decisions = [];
     const realNow = Date.now;
     let elapsed = 0;
     Date.now = () => realNow() + elapsed;
@@ -313,18 +401,23 @@ describe('China official release calendar', () => {
       await assert.rejects(
         fetchChinaReleaseCalendar({
           now: Date.parse('2026-07-13T00:00:00Z'),
+          sleepFn: async () => {},
           fetchFn: async (url) => {
             requests.push(String(url));
             elapsed += NBS_TOTAL_FETCH_BUDGET_MS; // first attempt burns the budget
             throw new TypeError('fetch failed');
           },
-          onDecision: () => {},
+          onDecision: (decision) => decisions.push(decision),
         }),
-        (error) => /NBS_REQUIRED_SOURCE_UNAVAILABLE:FETCH_FAILED/.test(error.message),
+        // Giving up on budget and failing permanently both used to surface as a
+        // bare FETCH_FAILED, so an operator could not tell "the host is
+        // hanging" from "the host is refusing" in the preflight record.
+        (error) => error.message === `NBS_REQUIRED_SOURCE_UNAVAILABLE:${FETCH_BUDGET_EXHAUSTED_REASON}`,
       );
     } finally {
       Date.now = realNow;
     }
+    assert.equal(decisions[0]?.reason, FETCH_BUDGET_EXHAUSTED_REASON);
     // Budget exhausted after attempt 1, so attempts 2 and 3 never fire even
     // though the failure was transient and the attempt budget allowed them.
     assert.equal(requests.length, 1);
@@ -341,41 +434,52 @@ describe('China official release calendar', () => {
   const codeError = (code) => Object.assign(new TypeError('fetch failed'), {
     cause: Object.assign(new Error('connection terminated'), { code }),
   });
-  for (const [shape, makeError] of [
-    ['cause.code', () => codeError('SELF_SIGNED_CERT_IN_CHAIN')],
+  // Table-driven from the exported set so EVERY member is covered: hand-listing
+  // a few codes left the rest as undetected mutants while the suite still
+  // claimed each code was pinned. Adding a code to the set now adds its test.
+  const certFixtures = [
+    ...[...PERMANENT_TLS_CODES].map((code) => [`cause.code ${code}`, () => codeError(code)]),
     ['top-level code', () => Object.assign(new Error('fetch failed'), { code: 'SELF_SIGNED_CERT_IN_CHAIN' })],
-    // An expired or misissued cert is just as permanent as a self-signed one:
-    // the peer is not provably who it claims to be, so a retry only repeats the
-    // request against that same untrusted peer.
-    ['expired cert', () => codeError('CERT_HAS_EXPIRED')],
-    ['hostname mismatch', () => codeError('ERR_TLS_CERT_ALTNAME_INVALID')],
-    ['unverifiable leaf', () => codeError('UNABLE_TO_VERIFY_LEAF_SIGNATURE')],
     ['message backstop, no code', () => new TypeError('self signed certificate in certificate chain')],
-  ]) {
-    it(`fails closed on a certificate-chain error (${shape}) instead of retrying an intercepted connection`, async () => {
+  ];
+
+  it('covers every code in PERMANENT_TLS_CODES', () => {
+    // Guards the table above against silently shrinking.
+    assert.ok(PERMANENT_TLS_CODES.size >= 26);
+    assert.equal(certFixtures.length, PERMANENT_TLS_CODES.size + 2);
+  });
+
+  for (const [shape, makeError] of certFixtures) {
+    it(`fails closed on a certificate-validation failure (${shape}) instead of retrying an intercepted connection`, async () => {
       const requests = [];
       const decisions = [];
       await assert.rejects(
         fetchChinaReleaseCalendar({
           now: Date.parse('2026-07-13T00:00:00Z'),
+          sleepFn: async () => {},
           fetchFn: async (url) => {
             requests.push(String(url));
             throw makeError();
           },
           onDecision: (decision) => decisions.push(decision),
         }),
-        (error) => /NBS_REQUIRED_SOURCE_UNAVAILABLE:FETCH_FAILED/.test(error.message),
+        // The reason must NOT collapse into the generic FETCH_FAILED — an
+        // operator has to be able to tell interception from a socket blip.
+        (error) => error.message === `NBS_REQUIRED_SOURCE_UNAVAILABLE:${TLS_CERT_UNTRUSTED_REASON}`,
       );
       // A bad chain means interception, not a hiccup — one attempt, then stop.
       assert.deepEqual(requests, [NBS_CALENDAR_INDEX_URL]);
+      assert.equal(decisions[0]?.reason, TLS_CERT_UNTRUSTED_REASON);
       assert.equal(decisions[0]?.requestCount, 1);
     });
   }
 
-  it('still fails closed once the transient NBS retry budget is exhausted', async () => {
+  it('still fails closed once the transient NBS attempt budget is exhausted', async () => {
     const requests = [];
     const decisions = [];
     let rejectedError;
+    // The ONE test left on the real sleepFn, so the production default (a real
+    // setTimeout) stays exercised rather than only ever being stubbed out.
     await assert.rejects(
       fetchChinaReleaseCalendar({
         now: Date.parse('2026-07-13T00:00:00Z'),
@@ -390,6 +494,7 @@ describe('China official release calendar', () => {
         return /NBS_REQUIRED_SOURCE_UNAVAILABLE:FETCH_FAILED/.test(error.message);
       },
     );
+    // Attempts ran out, not the clock — so this keeps the generic reason.
     assert.equal(requests.length, NBS_TRANSIENT_FETCH_ATTEMPTS);
     assert.ok(requests.every((url) => url === NBS_CALENDAR_INDEX_URL));
     assert.equal(decisions[0]?.reason, 'FETCH_FAILED');

--- a/tests/china-release-calendar.test.mjs
+++ b/tests/china-release-calendar.test.mjs
@@ -5,7 +5,10 @@ import { resolve } from 'node:path';
 
 import {
   NBS_CALENDAR_INDEX_URL,
+  NBS_REQUEST_TIMEOUT_MS,
+  NBS_TOTAL_FETCH_BUDGET_MS,
   NBS_TRANSIENT_FETCH_ATTEMPTS,
+  NBS_TRANSIENT_RETRY_DELAY_MS,
   buildLprCandidates,
   fetchChinaReleaseCalendar,
   mergeVerifiedLprDates,
@@ -180,25 +183,84 @@ describe('China official release calendar', () => {
     assert.equal(rejectedError.nonRetryable, true);
   });
 
-  it('pins the NBS transient retry budget so the fetch phase stays inside the seeder lock', () => {
-    // Asserted as a literal on purpose: every other retry test compares against
-    // the imported constant, so raising it would move those assertions with it
-    // and silently widen the budget. seed-china-release-calendar.mjs holds a
-    // 180s lock inside a 240s bundle section, and each attempt carries its own
-    // 20s AbortSignal timeout across two independently-retried NBS URLs
-    // (2 x (3 x 20s + 1.5s backoff) + 20s ChinaMoney = ~143s). Raising this
-    // past 3 blows the lock — raise lockTtlMs first.
+  it('bounds the worst-case NBS fetch phase well inside the seeder lock', () => {
+    // Asserted against literals on purpose: every other retry test compares
+    // against the imported constants, so raising one would move those
+    // assertions with it and silently widen the budget. Pinning the numbers
+    // here is what makes this test constrain the budget rather than restate it.
     assert.equal(NBS_TRANSIENT_FETCH_ATTEMPTS, 3);
+    assert.equal(NBS_REQUEST_TIMEOUT_MS, 20_000);
+    assert.equal(NBS_TRANSIENT_RETRY_DELAY_MS, 500);
+    assert.equal(NBS_TOTAL_FETCH_BUDGET_MS, 75_000);
+
+    // seed-china-release-calendar.mjs holds a 180s lock inside a 240s bundle
+    // section. The wall-clock budget spans both NBS URLs, and the deadline is
+    // checked BEFORE sleeping, so the worst case is the budget plus one
+    // already-in-flight request, then the single ChinaMoney call.
+    const SEEDER_LOCK_TTL_MS = 180_000;
+    const BUNDLE_SECTION_TIMEOUT_MS = 240_000;
+    const CHINAMONEY_TIMEOUT_MS = 20_000;
+    const worstCaseFetchMs = NBS_TOTAL_FETCH_BUDGET_MS + NBS_REQUEST_TIMEOUT_MS + CHINAMONEY_TIMEOUT_MS;
+
+    assert.equal(worstCaseFetchMs, 115_000);
+    // Leave the publish phase at least a third of the lock: atomicPublish makes
+    // several retried Redis round trips after the fetch returns.
+    assert.ok(
+      worstCaseFetchMs <= SEEDER_LOCK_TTL_MS * (2 / 3),
+      `worst-case fetch ${worstCaseFetchMs}ms leaves too little of the ${SEEDER_LOCK_TTL_MS}ms lock for publish`,
+    );
+    assert.ok(worstCaseFetchMs < BUNDLE_SECTION_TIMEOUT_MS / 2);
+  });
+
+  it('stops retrying once the shared NBS wall-clock budget is spent', async () => {
+    // A host that hangs must not spend the calendar page's share of the budget.
+    // Simulated by advancing past the deadline rather than sleeping 75s.
+    const requests = [];
+    const realNow = Date.now;
+    let elapsed = 0;
+    Date.now = () => realNow() + elapsed;
+    try {
+      await assert.rejects(
+        fetchChinaReleaseCalendar({
+          now: Date.parse('2026-07-13T00:00:00Z'),
+          fetchFn: async (url) => {
+            requests.push(String(url));
+            elapsed += NBS_TOTAL_FETCH_BUDGET_MS; // first attempt burns the budget
+            throw new TypeError('fetch failed');
+          },
+          onDecision: () => {},
+        }),
+        (error) => /NBS_REQUIRED_SOURCE_UNAVAILABLE:FETCH_FAILED/.test(error.message),
+      );
+    } finally {
+      Date.now = realNow;
+    }
+    // Budget exhausted after attempt 1, so attempts 2 and 3 never fire even
+    // though the failure was transient and the attempt budget allowed them.
+    assert.equal(requests.length, 1);
   });
 
   // Node surfaces a bad chain either as a bare error carrying `code` or wrapped
   // in a TypeError whose `cause` carries it; both must fail closed.
+  // Each code-based fixture deliberately carries a NEUTRAL message with no
+  // certificate wording. Real Node errors do carry both, but pairing them here
+  // would let the message backstop mask the code set: dropping a code from
+  // PERMANENT_TLS_CODES would still pass. The neutral message isolates the arm
+  // under test, so each code has to earn its own place. The last fixture is the
+  // mirror image — message wording, no code — covering the backstop itself.
+  const codeError = (code) => Object.assign(new TypeError('fetch failed'), {
+    cause: Object.assign(new Error('connection terminated'), { code }),
+  });
   for (const [shape, makeError] of [
-    ['cause.code', () => Object.assign(new TypeError('fetch failed'), {
-      cause: Object.assign(new Error('unable to verify the first certificate'), { code: 'SELF_SIGNED_CERT_IN_CHAIN' }),
-    })],
+    ['cause.code', () => codeError('SELF_SIGNED_CERT_IN_CHAIN')],
     ['top-level code', () => Object.assign(new Error('fetch failed'), { code: 'SELF_SIGNED_CERT_IN_CHAIN' })],
-    ['message only', () => new TypeError('self signed certificate in certificate chain')],
+    // An expired or misissued cert is just as permanent as a self-signed one:
+    // the peer is not provably who it claims to be, so a retry only repeats the
+    // request against that same untrusted peer.
+    ['expired cert', () => codeError('CERT_HAS_EXPIRED')],
+    ['hostname mismatch', () => codeError('ERR_TLS_CERT_ALTNAME_INVALID')],
+    ['unverifiable leaf', () => codeError('UNABLE_TO_VERIFY_LEAF_SIGNATURE')],
+    ['message backstop, no code', () => new TypeError('self signed certificate in certificate chain')],
   ]) {
     it(`fails closed on a certificate-chain error (${shape}) instead of retrying an intercepted connection`, async () => {
       const requests = [];

--- a/tests/china-release-calendar.test.mjs
+++ b/tests/china-release-calendar.test.mjs
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 
 import {
   NBS_CALENDAR_INDEX_URL,
+  NBS_TRANSIENT_FETCH_ATTEMPTS,
   buildLprCandidates,
   fetchChinaReleaseCalendar,
   mergeVerifiedLprDates,
@@ -88,6 +89,159 @@ describe('China official release calendar', () => {
     assert.deepEqual(requests, [NBS_CALENDAR_INDEX_URL]);
     assert.equal(decisions[0]?.reason, 'UNTRUSTED_NBS_CALENDAR_URL');
     assert.equal(decisions[0]?.requestCount, 1);
+    assert.equal(rejectedError.nonRetryable, true);
+  });
+
+  it('recovers from a transient network failure on the NBS index', async () => {
+    const decisions = [];
+    const requests = [];
+    const calendar = await fetchChinaReleaseCalendar({
+      now: Date.parse('2026-07-13T00:00:00Z'),
+      fetchFn: async (url) => {
+        requests.push(String(url));
+        if (String(url) === NBS_CALENDAR_INDEX_URL && requests.length === 1) {
+          throw Object.assign(new TypeError('fetch failed'), { cause: { code: 'ECONNRESET' } });
+        }
+        if (String(url) === NBS_CALENDAR_INDEX_URL) return new Response('<a href="calendar.html">2026 release calendar</a>');
+        if (String(url).endsWith('calendar.html')) return new Response(fixture('nbs-calendar.html'));
+        return new Response(fixture('chinamoney-lpr.json'), { headers: { 'Content-Type': 'application/json' } });
+      },
+      onDecision: (decision) => decisions.push(decision),
+    });
+    assert.ok(calendar.events.some((event) => event.kind === 'nbs'));
+    assert.equal(decisions[0]?.status, 'accepted');
+    assert.equal(decisions[0]?.reason, 'OK');
+    // The retried attempt is a real request against an official host, so the
+    // audited request count must include it: 2 index attempts + 1 calendar page.
+    assert.equal(decisions[0]?.requestCount, 3);
+  });
+
+  it('recovers from a transient network failure on the year-specific NBS calendar page', async () => {
+    const decisions = [];
+    let calendarAttempts = 0;
+    const calendar = await fetchChinaReleaseCalendar({
+      now: Date.parse('2026-07-13T00:00:00Z'),
+      fetchFn: async (url) => {
+        if (String(url) === NBS_CALENDAR_INDEX_URL) return new Response('<a href="calendar.html">2026 release calendar</a>');
+        if (String(url).endsWith('calendar.html')) {
+          calendarAttempts += 1;
+          if (calendarAttempts === 1) throw new TypeError('fetch failed');
+          return new Response(fixture('nbs-calendar.html'));
+        }
+        return new Response(fixture('chinamoney-lpr.json'), { headers: { 'Content-Type': 'application/json' } });
+      },
+      onDecision: (decision) => decisions.push(decision),
+    });
+    assert.ok(calendar.events.some((event) => event.kind === 'nbs'));
+    assert.equal(decisions[0]?.status, 'accepted');
+    assert.equal(decisions[0]?.requestCount, 3);
+  });
+
+  it('retries a transient NBS 5xx but never a permanent 4xx', async () => {
+    const serverErrorRequests = [];
+    const recovered = await fetchChinaReleaseCalendar({
+      now: Date.parse('2026-07-13T00:00:00Z'),
+      fetchFn: async (url) => {
+        if (String(url) === NBS_CALENDAR_INDEX_URL) {
+          serverErrorRequests.push(String(url));
+          if (serverErrorRequests.length === 1) return new Response('', { status: 503 });
+          return new Response('<a href="calendar.html">2026 release calendar</a>');
+        }
+        if (String(url).endsWith('calendar.html')) return new Response(fixture('nbs-calendar.html'));
+        return new Response(fixture('chinamoney-lpr.json'), { headers: { 'Content-Type': 'application/json' } });
+      },
+      onDecision: () => {},
+    });
+    assert.ok(recovered.events.some((event) => event.kind === 'nbs'));
+    assert.equal(serverErrorRequests.length, 2);
+
+    // A permanent status must fail closed on the first response — retrying it
+    // would triple the load on an official government host for no benefit.
+    const forbiddenRequests = [];
+    const decisions = [];
+    let rejectedError;
+    await assert.rejects(
+      fetchChinaReleaseCalendar({
+        now: Date.parse('2026-07-13T00:00:00Z'),
+        fetchFn: async (url) => {
+          forbiddenRequests.push(String(url));
+          return new Response('', { status: 403 });
+        },
+        onDecision: (decision) => decisions.push(decision),
+      }),
+      (error) => {
+        rejectedError = error;
+        return /NBS_REQUIRED_SOURCE_UNAVAILABLE:HTTP_403/.test(error.message);
+      },
+    );
+    assert.deepEqual(forbiddenRequests, [NBS_CALENDAR_INDEX_URL]);
+    assert.equal(decisions[0]?.reason, 'HTTP_403');
+    assert.equal(decisions[0]?.requestCount, 1);
+    assert.equal(rejectedError.nonRetryable, true);
+  });
+
+  it('pins the NBS transient retry budget so the fetch phase stays inside the seeder lock', () => {
+    // Asserted as a literal on purpose: every other retry test compares against
+    // the imported constant, so raising it would move those assertions with it
+    // and silently widen the budget. seed-china-release-calendar.mjs holds a
+    // 180s lock inside a 240s bundle section, and each attempt carries its own
+    // 20s AbortSignal timeout across two independently-retried NBS URLs
+    // (2 x (3 x 20s + 1.5s backoff) + 20s ChinaMoney = ~143s). Raising this
+    // past 3 blows the lock — raise lockTtlMs first.
+    assert.equal(NBS_TRANSIENT_FETCH_ATTEMPTS, 3);
+  });
+
+  // Node surfaces a bad chain either as a bare error carrying `code` or wrapped
+  // in a TypeError whose `cause` carries it; both must fail closed.
+  for (const [shape, makeError] of [
+    ['cause.code', () => Object.assign(new TypeError('fetch failed'), {
+      cause: Object.assign(new Error('unable to verify the first certificate'), { code: 'SELF_SIGNED_CERT_IN_CHAIN' }),
+    })],
+    ['top-level code', () => Object.assign(new Error('fetch failed'), { code: 'SELF_SIGNED_CERT_IN_CHAIN' })],
+    ['message only', () => new TypeError('self signed certificate in certificate chain')],
+  ]) {
+    it(`fails closed on a certificate-chain error (${shape}) instead of retrying an intercepted connection`, async () => {
+      const requests = [];
+      const decisions = [];
+      await assert.rejects(
+        fetchChinaReleaseCalendar({
+          now: Date.parse('2026-07-13T00:00:00Z'),
+          fetchFn: async (url) => {
+            requests.push(String(url));
+            throw makeError();
+          },
+          onDecision: (decision) => decisions.push(decision),
+        }),
+        (error) => /NBS_REQUIRED_SOURCE_UNAVAILABLE:FETCH_FAILED/.test(error.message),
+      );
+      // A bad chain means interception, not a hiccup — one attempt, then stop.
+      assert.deepEqual(requests, [NBS_CALENDAR_INDEX_URL]);
+      assert.equal(decisions[0]?.requestCount, 1);
+    });
+  }
+
+  it('still fails closed once the transient NBS retry budget is exhausted', async () => {
+    const requests = [];
+    const decisions = [];
+    let rejectedError;
+    await assert.rejects(
+      fetchChinaReleaseCalendar({
+        now: Date.parse('2026-07-13T00:00:00Z'),
+        fetchFn: async (url) => {
+          requests.push(String(url));
+          throw new TypeError('fetch failed');
+        },
+        onDecision: (decision) => decisions.push(decision),
+      }),
+      (error) => {
+        rejectedError = error;
+        return /NBS_REQUIRED_SOURCE_UNAVAILABLE:FETCH_FAILED/.test(error.message);
+      },
+    );
+    assert.equal(requests.length, NBS_TRANSIENT_FETCH_ATTEMPTS);
+    assert.ok(requests.every((url) => url === NBS_CALENDAR_INDEX_URL));
+    assert.equal(decisions[0]?.reason, 'FETCH_FAILED');
+    assert.equal(decisions[0]?.requestCount, NBS_TRANSIENT_FETCH_ATTEMPTS);
     assert.equal(rejectedError.nonRetryable, true);
   });
 


### PR DESCRIPTION
## The fault

`economic:china-release-calendar` was **4,936 min old against a 4,320 min limit** — the only underlying fault in China's 15/16 health. Today's 08:03 UTC run failed `FETCH_FAILED`.

The source was never down. Verified against production Redis and the live host:

| Evidence | Value |
|---|---|
| Last good seed | `2026-08-02T08:03:53Z` (82.5 h ago), 154 records |
| `seed-china-macro` — **same bundle, same host** `www.stats.gov.cn` | succeeded `2026-08-04T08:01:21Z` (34.5 h ago) |
| Live probe of the NBS calendar index | `200`, 2.0 s, parses to the same 154 events |

A sibling seeder reached the same host 34.5 h ago and the host answers fine right now, so this was a per-request transient failure — not a block.

## Root cause

`fetchChinaReleaseCalendar` made **exactly one attempt** per NBS URL and tagged every failure `nonRetryable: true` — which is precisely the flag `runSeed`'s `withRetry(fetchFn)` honors to skip its retries:

```js
// scripts/_seed-utils.mjs:805
if (err?.nonRetryable) throw err;
```

So one network-level throw (DNS, TLS reset, socket hang-up) aborted the whole run. NBS is a **required** source, so that costs a full 36 h refresh interval against a budget worth exactly two of them — two such runs is all it takes to trip the alarm.

The divergence is the tell: the sibling fetcher for the same host, `china-macro/source-runtime.mjs::fetchText`, **already retries transient throws**. That is why `seed-china-macro` stayed healthy through the window that took this calendar stale.

## The fix

Transient failures (network throws, 408/429/5xx) get bounded retries; permanent ones still fail closed on the first response — 4xx, certificate-validation failures, `NO_NBS_EVENTS`, and the untrusted-calendar-link rejection.

Two things worth calling out:

- **The retry spend is capped by a wall-clock budget shared across both NBS URLs (75 s)**, not by attempt count. Attempts × timeout would have put the ceiling at 120 s, leaving too little of the seeder's 180 s `lockTtlMs` for `atomicPublish`'s retried Redis round trips. Worst case is now 115 s (budget + one in-flight request + the ChinaMoney call), leaving 65 s for publish. In practice transient failures fail *fast* — 3 attempts on a DNS failure cost ~1.7 s including backoff; the 20 s ceiling only binds when the host hangs, which is exactly what the budget caps.
- **The host's `Retry-After` is honored** on 408/429/503 — taken as `max(scheduled backoff, hint)`, matching `source-runtime.mjs` and `_seed-utils.mjs`. An unreasonably long hint isn't slept off; it trips the deadline and the run gives up.
- **Retries are counted per attempt**, so the audited official-source `requestCount` in the `china_calendar_source_preflight` decision stays honest.
- **All certificate-validation failures are permanent** (expired, misissued, unverifiable — not just self-signed): the peer isn't provably who it claims to be, so a retry only repeats the request against that same untrusted peer.

`ChinaMoney` LPR verification keeps its single attempt deliberately: it is optional by design and already degrades gracefully (dates stay `provisional` instead of `verified`). Spending the shared fetch budget on the required source is the right priority.

## Verification

Bug-fix protocol: reproduced first, exact production error, before any production code changed.

```
Error: NBS_REQUIRED_SOURCE_UNAVAILABLE:FETCH_FAILED
  reason: 'FETCH_FAILED', nonRetryable: true
```

- **22/22** focused tests; **245** across the changed-module sweep (`china-release-calendar`, `china-coverage-health`, `china-macro-seed`, `china-documentation-contract`, `china-macro-production-registration`, `macro-tiles-china-ui`, `china-macro-entity-decode`, `mcp`). Biome clean.
- **13/13 mutants killed** in the final sweeps — per-URL-instead-of-shared budget, flat backoff, dropped 408/429 arm, ignored `Retry-After`, dropped header capture, dropped deadline check, disabled TLS code set, one per individual TLS code, widened budget, widened timeout. Earlier rounds also killed no-retry, retry-everything, 5xx-as-permanent, per-URL counting, and widened attempt budget.
- **Real Node failure shapes, not just mocks.** `ENOTFOUND` and `ECONNREFUSED` each retry 3× in ~1.5 s and surface as `FETCH_FAILED` — the exact production reason; `AbortSignal` `TimeoutError` retries and surfaces as `TIMEOUT`.
- **Live end-to-end** against the real NBS + ChinaMoney hosts: 154 events in 3 requests, passing the seeder's own `validateFn` — matching production's last-good record count exactly.

### Two tests that initially had no teeth

Both were caught by mutating the shipped code and watching the suite stay green. Worth knowing about, because the failure mode is subtle in each case:

1. **The shared budget was the headline safety property and nothing verified it.** Swapping the single deadline for a fresh per-URL one passed all 18 tests — so the comment's claim that a hanging index can't spend the calendar page's share was pure assertion. Now the index consumes all but 400 ms of the budget and the calendar page gets **one** attempt instead of three.
2. **A guard's fixtures can mask the arm under test.** The cert fixtures carried both a real code *and* its real message, so the message backstop covered for the code set and deleting a TLS code still passed; they now use a **neutral** message so each code earns its own kill. The same shape bit the backoff-growth test — pairing growth with a `Retry-After` hint let the hint dominate the `max()`, making flat and growing delays indistinguishable, so growth is now exercised on two bare failures.

## Known residuals

Two **pre-existing** transport gaps in the same `fetchText`, tracked in **#6262** rather than widened into this fix. Both are already handled correctly by the sibling `source-runtime.mjs`:

1. **Off-origin redirects bypass the NBS origin allowlist.** `fetch` follows redirects before `currentCalendarLink()`'s allowlist runs. Reproduced: injected events were accepted and published stamped with the trusted `stats.gov.cn` `sourceUrl`, with `requestCount` reporting 1 for 2 hops. Bounded by requiring control of (or an open redirect on) `www.stats.gov.cn`, so not remotely exploitable today.
2. **Unbounded response bodies** — no size cap; the sibling caps at 2 MiB.

Accepted, not fixed here:

3. **The transient-status predicate now exists in three places** (`_seed-utils.mjs` `isRetryableHttpStatus`, `source-runtime.mjs` inline, and this file), and the copies have already drifted — `source-runtime.mjs`'s `status >= 500` has no upper bound. Extracting a shared zero-import leaf module is the right cleanup, but it is a wider refactor than an incident fix should carry. Raised by the maintainability review as advisory.

## Post-Deploy Monitoring & Validation

**Watch:** Railway `seed-bundle-macro`, the `China-Release-Calendar` section (36 h interval).

**Log queries**
- `china_calendar_source_preflight` — the per-run decision record. Healthy: `status: "accepted"`, `reason: "OK"`, `requestCount: 2`.
- `requestCount` of **3–6** means a retry fired and the fix did its job — that is the signal to look for, not an error.
- `NBS_REQUIRED_SOURCE_UNAVAILABLE` — a run that still failed after all attempts.

**Healthy signals**
- `seed-meta:economic:china-release-calendar` `fetchedAt` advances within each 36 h interval, `recordCount` ≈ 154.
- China coverage health returns to 16/16; `macro.china-release-calendar` age drops well under 4,320 min.

**Failure signals / rollback trigger**
- `reason: "FETCH_FAILED"` persisting across **two consecutive** runs → the failure is not transient after all; investigate an egress or host-level block rather than re-tuning the retry.
- Any `HTTP_403` / `HTTP_404` → a real block or a moved endpoint; retries correctly will *not* mask it.
- Section SIGTERM / exit 143 in the bundle → the budget math is wrong; revert.

**Validation window:** the next two scheduled runs (~72 h). Freshness should recover on the **first** successful run.
