### PR TITLE
fix(aviation): skip degenerate bbox block for icao24-only requests

### DIFF
--- a/server/worldmonitor/aviation/v1/track-aircraft.ts
+++ b/server/worldmonitor/aviation/v1/track-aircraft.ts
@@ -107,7 +107,13 @@ export async function trackAircraft(
                 // empty one — is authoritative for that viewport, so do not also debit the
                 // shared authenticated OpenSky account. OpenSky is recovery-only when the
                 // Wingbits request itself fails.
-                if (!isCallsignOnly && relayBase && req.swLat != null && req.neLat != null) {
+                //
+                // Skip a degenerate (zero-span) bbox. The generated GET decoder coerces
+                // absent query params to 0 rather than leaving them null, so an icao24-only
+                // request would otherwise issue a real authenticated bbox relay call for
+                // `lamin=0&lomin=0&lamax=0&lomax=0` before reaching its own 8s tier.
+                if (!isCallsignOnly && relayBase && req.swLat != null && req.neLat != null
+                    && (req.swLat !== req.neLat || req.swLon !== req.neLon)) {
                     const wbUrl = `${relayBase}/wingbits/track?lamin=${req.swLat}&lomin=${req.swLon}&lamax=${req.neLat}&lomax=${req.neLon}`;
                     try {
                         const wbResp = await fetch(wbUrl, {
@@ -140,17 +146,9 @@ export async function trackAircraft(
                         console.warn(`[Aviation] OpenSky bbox relay failed: ${err instanceof Error ? err.message : err}`);
                     }
 
-                    // Both relay paths exhausted. Removing the anonymous tier returns 6s to
-                    // this branch: a bbox-only request now spends at most 6s + 6s here.
-                    //
-                    // That is NOT the worst case for the handler. The generated GET decoder
-                    // coerces missing bbox params to 0 rather than leaving them null, so an
-                    // icao24 lookup also satisfies the `req.swLat != null` guard above, runs
-                    // this block against a degenerate 0,0,0,0 bbox, and then falls through to
-                    // the 8s icao24 tier below — 20s total, measured. That ladder (and the
-                    // wasted authenticated relay call on a bbox nobody asked for) predates
-                    // #6222 and is tracked separately; do not read the 12s above as the
-                    // handler's ceiling.
+                    // Both relay paths exhausted. A bbox-only request now spends at most
+                    // 6s + 6s here. An icao24-only request is also nondegenerate-bbox-gated
+                    // so it skips this block entirely and goes straight to its own 8s tier.
                 }
 
                 // For icao24-only queries, try OpenSky relay then Wingbits

--- a/server/worldmonitor/aviation/v1/track-aircraft.ts
+++ b/server/worldmonitor/aviation/v1/track-aircraft.ts
@@ -18,6 +18,10 @@ const CALLSIGN_CACHE_TTL = 60;
 const CALLSIGN_NEGATIVE_TTL = 10;
 const BBOX_RELAY_TIMEOUT_MS = 6_000;
 
+function isDegenerateBbox(req: TrackAircraftRequest): boolean {
+    return req.swLat === req.neLat && req.swLon === req.neLon;
+}
+
 interface OpenSkyResponse {
     states?: unknown[][];
 }
@@ -55,12 +59,12 @@ function parseOpenSkyStates(states: unknown[][]): PositionSample[] {
 // the response budget below (#6222).
 
 function buildCacheKey(req: TrackAircraftRequest): string {
-    if (req.icao24) return `aviation:track:icao:${req.icao24}:v1`;
-    if (req.swLat != null && req.neLat != null) {
+    if (req.icao24) return `aviation:track:icao:${req.icao24}:v2`;
+    if (req.callsign) return `aviation:track:callsign:${req.callsign.toUpperCase()}:v2`;
+    if (!isDegenerateBbox(req)) {
         return `aviation:track:bbox:${Math.floor(req.swLat)}:${Math.floor(req.swLon)}:${Math.ceil(req.neLat)}:${Math.ceil(req.neLon)}:v1`;
     }
-    if (req.callsign) return `aviation:track:callsign:${req.callsign.toUpperCase()}:v1`;
-    return 'aviation:track:all:v1';
+    return 'aviation:track:all:v2';
 }
 
 // Response-level source values (TrackAircraftResponse.source):
@@ -80,7 +84,7 @@ export async function trackAircraft(
         result = await cachedFetchJson<{ positions: PositionSample[]; source: string }>(
             cacheKey, positiveTtl, async () => {
                 const relayBase = getRelayBaseUrl();
-                const isCallsignOnly = !!req.callsign && req.swLat == null && req.icao24 == null;
+                const isCallsignOnly = !!req.callsign && !req.icao24 && isDegenerateBbox(req);
 
                 // For callsign-only searches, try Wingbits first — commercial flights like UAE20
                 // are Wingbits-exclusive and not visible in OpenSky. Trying OpenSky first wastes
@@ -112,8 +116,7 @@ export async function trackAircraft(
                 // absent query params to 0 rather than leaving them null, so an icao24-only
                 // request would otherwise issue a real authenticated bbox relay call for
                 // `lamin=0&lomin=0&lamax=0&lomax=0` before reaching its own 8s tier.
-                if (!isCallsignOnly && relayBase && req.swLat != null && req.neLat != null
-                    && (req.swLat !== req.neLat || req.swLon !== req.neLon)) {
+                if (!isCallsignOnly && relayBase && !isDegenerateBbox(req)) {
                     const wbUrl = `${relayBase}/wingbits/track?lamin=${req.swLat}&lomin=${req.swLon}&lamax=${req.neLat}&lomax=${req.neLon}`;
                     try {
                         const wbResp = await fetch(wbUrl, {
@@ -151,7 +154,7 @@ export async function trackAircraft(
                     // so it skips this block entirely and goes straight to its own 8s tier.
                 }
 
-                // For icao24-only queries, try OpenSky relay then Wingbits
+                // For icao24-only queries, try the OpenSky relay
                 if (!isCallsignOnly && relayBase && req.icao24) {
                     try {
                         const osUrl = `${relayBase}/opensky/states/all?icao24=${req.icao24}`;

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1921,6 +1921,84 @@ describe('aviation aircraft provider priority', { concurrency: 1 }, () => {
     }
   });
 
+  it('returns positions from the icao24 tier when the relay responds with data', async () => {
+    const { module, cleanup } = await importTrackAircraft();
+    const restoreEnv = withEnv({
+      WS_RELAY_URL: 'wss://relay.test',
+      UPSTASH_REDIS_REST_URL: undefined,
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+
+    globalThis.fetch = async (url) => {
+      const raw = String(url);
+      if (raw.includes('/opensky/states/all') && raw.includes('icao24=')) {
+        return jsonResponse({
+          states: [['4b1805', 'TEST1', null, null, null, 10.5, 20.5, 30000, false, 420, 180]],
+        });
+      }
+      return jsonResponse({}, false);
+    };
+
+    try {
+      const result = await module.trackAircraft({}, {
+        icao24: '4b1805',
+        swLat: 0,
+        swLon: 0,
+        neLat: 0,
+        neLon: 0,
+      });
+      assert.equal(result.source, 'opensky');
+      assert.equal(result.positions.length, 1);
+      assert.equal(result.positions[0].icao24, '4b1805');
+      assert.equal(result.positions[0].lat, 20.5);
+      assert.equal(result.positions[0].lon, 10.5);
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('treats an asymmetric bbox (equal lat, different lon) as non-degenerate', async () => {
+    const { module, cleanup } = await importTrackAircraft();
+    const restoreEnv = withEnv({
+      WS_RELAY_URL: 'wss://relay.test',
+      UPSTASH_REDIS_REST_URL: undefined,
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let wingbitsCalls = 0;
+
+    globalThis.fetch = async (url) => {
+      const raw = String(url);
+      if (raw.includes('/wingbits/track') && raw.includes('lamin=')) {
+        wingbitsCalls += 1;
+        return jsonResponse({ positions: [{ icao24: 'abc', lat: 20.5, lon: 10.5 }], source: 'wingbits' }, true);
+      }
+      return jsonResponse({}, false);
+    };
+
+    try {
+      const result = await module.trackAircraft({}, {
+        icao24: '',
+        callsign: '',
+        swLat: 10,
+        swLon: 10,
+        neLat: 10,
+        neLon: 15,
+      });
+      // Equal lat (10===10) but different lon (10!==15) → non-degenerate → bbox block runs
+      assert.equal(wingbitsCalls, 1, 'asymmetric bbox must trigger Wingbits');
+      assert.equal(result.source, 'wingbits');
+      assert.equal(result.positions.length, 1);
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
   it('keeps the all-provider failure path inside the edge response deadline', async () => {
     const { module, cleanup } = await importTrackAircraft();
     const restoreEnv = withEnv({

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1819,6 +1819,108 @@ describe('aviation aircraft provider priority', { concurrency: 1 }, () => {
     }
   });
 
+  it('issues zero bbox provider calls for an icao24-only request with absent bbox params', async () => {
+    const { module, cleanup } = await importTrackAircraft();
+    const restoreEnv = withEnv({
+      WS_RELAY_URL: 'wss://relay.test',
+      UPSTASH_REDIS_REST_URL: undefined,
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let wingbitsBboxCalls = 0;
+    let openskyBboxCalls = 0;
+    let icao24Calls = 0;
+
+    globalThis.fetch = async (url) => {
+      const raw = String(url);
+      if (raw.includes('/wingbits/track') && raw.includes('lamin=')) {
+        wingbitsBboxCalls += 1;
+        return jsonResponse({}, false);
+      }
+      if (raw.includes('/opensky/states/all') && raw.includes('lamin=')) {
+        openskyBboxCalls += 1;
+        return jsonResponse({}, false);
+      }
+      if (raw.includes('/opensky/states/all') && raw.includes('icao24=')) {
+        icao24Calls += 1;
+        return jsonResponse({}, false);
+      }
+      if (raw.includes('/wingbits/track') && raw.includes('icao24=')) {
+        icao24Calls += 1;
+        return jsonResponse({}, false);
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.trackAircraft({}, {
+        icao24: '4b1805',
+        swLat: 0,
+        swLon: 0,
+        neLat: 0,
+        neLon: 0,
+      });
+
+      assert.equal(wingbitsBboxCalls, 0, 'degenerate bbox must not trigger Wingbits');
+      assert.equal(openskyBboxCalls, 0, 'degenerate bbox must not trigger OpenSky');
+      assert.equal(icao24Calls, 1, 'icao24-only should reach the icao24 tier');
+      // The icao24 tier fires a single OpenSky fetch. It returns !ok here
+      // (jsonResponse({}, false)), so the handler returns no positions. That's
+      // acceptable — we are testing the bbox gate, not the icao24 response path.
+      assert.equal(result.source, 'none');
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('pins the worst-case timeout ladder for an icao24-only request to a single 8s tier', async () => {
+    const { module, cleanup } = await importTrackAircraft();
+    const restoreEnv = withEnv({
+      WS_RELAY_URL: 'wss://relay.test',
+      UPSTASH_REDIS_REST_URL: undefined,
+      UPSTASH_REDIS_REST_TOKEN: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const originalTimeout = AbortSignal.timeout;
+    const requestedTimeouts = [];
+
+    AbortSignal.timeout = (milliseconds) => {
+      requestedTimeouts.push(milliseconds);
+      return AbortSignal.abort(new Error('test timeout'));
+    };
+    globalThis.fetch = async (url) => {
+      const raw = String(url);
+      if (raw.includes('/opensky/states/all') && raw.includes('icao24=')) return jsonResponse({ states: [] });
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.trackAircraft({}, {
+        icao24: '4b1805',
+        swLat: 0,
+        swLon: 0,
+        neLat: 0,
+        neLon: 0,
+      });
+      // The icao24 path must not run the two 6s bbox tiers first. Before the
+      // degenerate-bbox gate, this request spent 6s + 6s + 8s = 20s; now only
+      // the single 8s icao24 tier runs.
+      assert.deepEqual(requestedTimeouts, [8_000]);
+      assert.equal(
+        requestedTimeouts.reduce((sum, timeout) => sum + timeout, 0), 8_000,
+        'icao24 must not spend time on the bbox provider ladder',
+      );
+      assert.equal(result.source, 'none');
+    } finally {
+      cleanup();
+      AbortSignal.timeout = originalTimeout;
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
   it('keeps the all-provider failure path inside the edge response deadline', async () => {
     const { module, cleanup } = await importTrackAircraft();
     const restoreEnv = withEnv({


### PR DESCRIPTION
An icao24-only lookup to `track-aircraft` ran the bbox provider block against a
degenerate `0,0,0,0` bounding box before reaching its own tier — wasting an
authenticated OpenSky relay credit on a bbox nobody asked for, and pushing the
worst-case provider ladder to 20s rather than the 8s the icao24 path alone implies.

The generated GET decoder coerces absent bbox query params to `0` instead of
leaving them absent, so null checks at three sites were broken by the same
root cause:

1. **Bbox provider gate** (the original fix) — `req.swLat != null` passed for
   icao24-only requests, issuing a real relay call for `lamin=0&lomin=0&lamax=0&lomax=0`.
2. **`isCallsignOnly`** — `req.swLat == null` was always false, making the
   callsign-only Wingbits-first path structurally dead code.
3. **`buildCacheKey`** — `req.swLat != null` was always true, so the callsign
   and "all" cache key branches were unreachable; every non-icao24 request
   collided on `aviation:track:bbox:0:0:0:0:v1`.

Fixed by extracting `isDegenerateBbox()` (`swLat === neLat && swLon === neLon`)
as a shared predicate used at all three sites:

```
Before: icao24 request → Wingbits bbox (6s) → OpenSky bbox (6s) → icao24 (8s) = 20s
After:  icao24 request → icao24 (8s) = 8s, zero bbox calls
```

## Validation

- 63 tests pass in the `aviation aircraft provider priority` suite.
- New test: zero bbox calls for icao24-only with degenerate bbox.
- New test: 8s single-tier ladder pinned via `AbortSignal.timeout`.
- New test: icao24 path returns positions when relay responds with data.
- New test: asymmetric bbox (equal lat, different lon) treated as non-degenerate.

Fixes #6247
Related: #6222, #6244

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
