### PR TITLE
fix(weather): harden the US-only disclosure guards from the #6269 review

### DIFF
--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -195,7 +195,7 @@ export const LAYER_EXPLANATIONS: Partial<Record<keyof MapLayers, LayerExplanatio
       'Low-severity GDACS alerts are filtered out to keep the map readable.',
       'EONET wildfires are freshness-filtered, so older open events may not appear as active map points.',
     ],
-    related: ['Natural Events layer popups', 'Weather Alerts', 'Country brief natural signals'],
+    related: ['Natural Events layer popups', 'US Weather Alerts (NWS)', 'Country brief natural signals'],
     evidence: ['docs/data-sources.mdx', 'docs/architecture.mdx', 'server/worldmonitor/natural/v1/list-natural-events.ts'],
   },
   weather: {

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -39,11 +39,21 @@ describe('health freshness ingestion', () => {
       }),
     });
 
+    const weatherGap = getIntelligenceGaps().find(gap => gap.source === 'weather');
+
     assert.equal(dataFreshness.getSource('weather')?.name, 'US Weather Alerts (NWS)');
-    assert.match(
-      getIntelligenceGaps().find(gap => gap.source === 'weather')?.message ?? '',
-      /US National Weather Service \(NWS\)/,
-    );
+    assert.match(weatherGap?.message ?? '', /US National Weather Service \(NWS\)/);
+
+    // The two assertions above are satisfied by DataFreshnessTracker's constructor alone:
+    // it pre-seeds every SOURCE_METADATA entry with `name` and status 'no_data', and
+    // getIntelligenceGaps() admits 'no_data' with a static per-source message. Without the
+    // two below, this test passes verbatim with the refreshDataFreshnessFromHealth() call
+    // above deleted — an inert fixture. Only a SEED_ERROR that actually routed through
+    // recordSeedHealth sets lastError, which calculateStatus turns into status 'error' and
+    // getIntelligenceGaps escalates to 'critical' (weather is requiredForRisk: false, so
+    // constructor state yields 'warning').
+    assert.equal(dataFreshness.getSource('weather')?.status, 'error');
+    assert.equal(weatherGap?.severity, 'critical');
   });
 
   it('hydrates dataFreshness from /api/health cadence metadata', async () => {

--- a/tests/layer-explanations.test.mts
+++ b/tests/layer-explanations.test.mts
@@ -239,10 +239,12 @@ describe('layer explanation metadata', () => {
       weather.limitations.some(limitation => /outside the United States/i.test(limitation)),
       'weather limitations must state that official warnings outside the United States are absent',
     );
-    assert.deepEqual(
-      weather.evidence,
-      ['scripts/ais-relay.cjs', 'api/health.js', 'src/services/weather.ts'],
-    );
+    // Require the citations this card's claims actually rest on, without pinning the array
+    // exactly — the v1 loop above already asserts every evidence path exists on disk, so a
+    // later addition stays covered instead of reddening this assertion.
+    for (const path of ['scripts/ais-relay.cjs', 'api/health.js', 'src/services/weather.ts']) {
+      assert.ok(weather.evidence.includes(path), `weather evidence must cite ${path}`);
+    }
   });
 
   test('curated explanations are not accidentally added outside the declared v1 set', () => {

--- a/tests/locale-completeness.test.mjs
+++ b/tests/locale-completeness.test.mjs
@@ -9,6 +9,42 @@ import { flattenKeys } from '../scripts/_locale-keys.mjs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LOCALES_DIR = join(__dirname, '..', 'src', 'locales');
 
+// The weather layer is fed only by the US National Weather Service, so its copy has to
+// disclose BOTH halves of that fact: the issuing agency AND the country it covers. Asserting
+// only /NWS/i would let a label keep the acronym while dropping the country — e.g. shortening
+// hu to "Időjárási riasztások (NWS)" — which restores exactly the worldwide-sounding label
+// over an empty map that this copy exists to prevent, since "NWS" carries no geographic
+// meaning to a non-US reader. Each token below is the scope marker the locale's own
+// translation actually uses; a locale with no entry fails loudly rather than going unasserted.
+const US_SCOPE_TOKENS = {
+  'ar.json': /الولايات المتحدة/,
+  'bg.json': /САЩ/,
+  'cs.json': /USA/,
+  'de.json': /USA|US-/,
+  'el.json': /ΗΠΑ/,
+  'en.json': /United States|\bUS\b/,
+  'es.json': /EE\. ?UU\./,
+  'fa.json': /ایالات متحده/,
+  'fr.json': /États-Unis/,
+  'hi.json': /अमेरिका/,
+  'hr.json': /SAD/,
+  'hu.json': /Egyesült [Áá]llamok/,
+  'it.json': /Stati Uniti/,
+  'ja.json': /米国/,
+  'ko.json': /미국/,
+  'nl.json': /\bVS\b/,
+  'pl.json': /USA/,
+  'pt.json': /EUA/,
+  'ro.json': /SUA/,
+  'ru.json': /США/,
+  'sv.json': /USA/,
+  'th.json': /สหรัฐ/,
+  'tr.json': /ABD/,
+  'uk.json': /США/,
+  'vi.json': /Hoa Kỳ/,
+  'zh.json': /美国/,
+};
+
 describe('locale completeness', () => {
   const en = JSON.parse(readFileSync(join(LOCALES_DIR, 'en.json'), 'utf8'));
   const enKeys = flattenKeys(en);
@@ -40,7 +76,7 @@ describe('locale completeness', () => {
   }
 
   for (const file of ['en.json', ...localeFiles]) {
-    it(`${file} discloses NWS coverage for every weather layer label`, () => {
+    it(`${file} discloses US NWS coverage for every weather layer label`, () => {
       const locale = JSON.parse(readFileSync(join(LOCALES_DIR, file), 'utf8'));
       const values = [
         locale.components.deckgl.layers.weatherAlerts,
@@ -48,9 +84,20 @@ describe('locale completeness', () => {
         locale.components.deckgl.layerHelp.descriptions.weatherAlertsMarket,
       ];
 
+      const scopeToken = US_SCOPE_TOKENS[file];
+      assert.ok(
+        scopeToken,
+        `${file} has no US_SCOPE_TOKENS entry — add the country marker this locale uses so its weather copy is not silently unasserted`,
+      );
+
       for (const value of values) {
         assert.equal(typeof value, 'string');
         assert.match(value, /NWS/i, `${file} weather coverage copy must identify NWS`);
+        assert.match(
+          value,
+          scopeToken,
+          `${file} weather coverage copy must name United States scope (${scopeToken}), not just the NWS acronym`,
+        );
       }
     });
   }


### PR DESCRIPTION
## Summary

Follow-up to #6269, from its code review. Four findings; only one changes anything a user sees, the rest make that PR's three new guards actually hold the line they are named for.

**Stacks on #6269.** These changes patch tests that only exist on that branch, and `natural`'s corrected cross-reference is only right once the rename lands, so this branch is based on #6269's head and should merge after it. Once #6269 merges, this PR's diff reduces to the four changes below.

### `src/config/map-layer-definitions.ts` — stale cross-reference

The `natural` card's `related[]` still named the pre-rename **"Weather Alerts"**, pointing readers at a layer that no longer appears under that name in any of the 26 locales.

### `tests/locale-completeness.test.mjs` — guard asserted the acronym, not the scope

The new weather guard asserted only `/NWS/i`. The defect #6269 fixes is a *country-scope* omission, and "NWS" carries no geographic meaning to a non-US reader — so shortening a label to the acronym-only form passed the guard while restoring exactly the worldwide-sounding label over an empty map that #6269 exists to prevent.

Now asserts a per-locale United-States token as well. Each token is derived from that catalog's own wording (`САЩ`, `EE. UU.`, `米国`, `Egyesült Államok`, …), and a locale with no table entry fails loudly rather than going silently unasserted.

Verified by mutation: shortening `hu.json` to the acronym-only form now reds the suite with `must name United States scope (/Egyesült [Áá]llamok/), not just the NWS acronym`. It passed before.

### `tests/data-freshness-health.test.mts` — inert fixture

The new weather test drove a full `SEED_ERROR` health payload, which reads as proof that a weather outage routes into the intelligence-gap surface. It proved nothing: `DataFreshnessTracker`'s constructor pre-seeds every `SOURCE_METADATA` entry with `name` and status `'no_data'`, and `getIntelligenceGaps()` admits `'no_data'` with a static per-source message — so both assertions passed with the entire `refreshDataFreshnessFromHealth()` call deleted. `__resetHealthFreshnessForTests()` only zeroes `authGateSuppressedUntilMs` and never touches the singleton.

Added `status === 'error'` and `severity === 'critical'` assertions, which only a `SEED_ERROR` that actually routed through `recordSeedHealth` can satisfy (weather is `requiredForRisk: false`, so constructor state yields `'warning'`/`'no_data'`).

Verified by mutation: removing the fixture now fails with `actual: 'no_data', expected: 'error'`.

### `tests/layer-explanations.test.mts` — over-specified assertion

`assert.deepEqual` pinned `weather.evidence` exactly — the only curated card pinned that way — so any legitimate addition would red the suite. Relaxed to membership; the v1 loop already `existsSync`-checks every evidence path.

## Verification

- `tests/locale-completeness.test.mjs`, `tests/layer-explanations.test.mts`, `tests/data-freshness-health.test.mts` — **80 pass, 0 fail**
- Both new guards mutation-tested: each goes red on the exact regression it exists to catch, and each was proven to pass before the change
- `biome check` clean on all four files; `npm run typecheck` clean

## Not included

The review's other finding — that the new card claims `confidence: 'Authoritative for active NWS alerts'` while both producers `.slice(0, 50)` after dropping `Unknown` severity (a live probe showed 68 of 118 qualifying alerts dropped) — predates #6269 and is being handled separately.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

https://claude.ai/code/session_01PGDmyDStCeqhEdqRVGCc3v