### PR TITLE
fix(railway): classify unprovisioned seeders as planned

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -845,13 +845,17 @@ entries.
 
 ## Standalone seed crons added after this snapshot
 
-> These data seeds were added **after** the 2026-04-10 inventory above and each
-> runs as its own Railway nixpacks cron service (root directory `.`, start
-> command `node scripts/<file>`, watch paths `scripts/**`, `shared/**`). They
-> are intentionally **not** part of the 100-service inventory count above and
-> are registered in `scripts/railway-services.json` with deploy mode
-> `nixpacks-root-repo`, so scripts-root packaging checks do not misclassify
-> their valid imports outside `scripts/`.
+> These data seeds were added **after** the 2026-04-10 inventory above. The rows
+> marked **planned** are registry/documentation entries for services that are
+> not provisioned in production; they remain excluded from the live audit and
+> `--apply` until an explicit lifecycle activation. The four planned rows below
+> are repository-root `nixpacks-root-repo` cron candidates (root directory
+> `.`, start command `node scripts/<file>`), so their eventual packaging can
+> include valid imports outside `scripts/`. Active rows must instead follow the
+> deploy mode and exact `watchPatterns` recorded in `scripts/railway-services.json`.
+> These rows are intentionally **not** part of the 100-service inventory count
+> above and are registered in `scripts/railway-services.json` with deploy mode
+> `nixpacks-root-repo`.
 >
 > **Cadence below is inferred from each seed's cache TTL** as a documentation
 > aid; confirm the live cron schedule and Service ID against the Railway
@@ -876,15 +880,15 @@ fetch('https://backboard.railway.com/graphql/v2',{method:'POST',
 | Service | Start command | Inferred cadence | Domain |
 |---|---|---|---|
 | seed-aaii-sentiment | `node scripts/seed-aaii-sentiment.mjs` | weekly (7d TTL) | AAII bull/bear investor sentiment survey |
-| seed-market-quotes | `node scripts/seed-market-quotes.mjs` | ~30 min (30m TTL) | Equity index / stock bootstrap quotes (Yahoo + Finnhub + Alpha Vantage) |
+| seed-market-quotes | `node scripts/seed-market-quotes.mjs` | **planned — not provisioned** | Equity index / stock bootstrap quotes (Yahoo + Finnhub + Alpha Vantage) |
 | seed-commodity-quotes | `node scripts/seed-commodity-quotes.mjs` | ~30 min (30m TTL) | Commodity + extended-gold bootstrap quotes |
-| seed-crypto-sectors | `node scripts/seed-crypto-sectors.mjs` | hourly (1h TTL) | CoinGecko crypto sector performance |
+| seed-crypto-sectors | `node scripts/seed-crypto-sectors.mjs` | **planned — not provisioned** | CoinGecko crypto sector performance |
 | seed-market-breadth | `node scripts/seed-market-breadth.mjs` | daily (30d history window) | S&P 500 breadth (% above 20/50/200-day, Barchart) |
-| seed-weather-alerts | `node scripts/seed-weather-alerts.mjs` | ~15 min (15m TTL) | NWS active weather alerts |
+| seed-weather-alerts | `node scripts/seed-weather-alerts.mjs` | **planned — not provisioned** | NWS active weather alerts |
 | seed-fx-yoy | `node scripts/seed-fx-yoy.mjs` | daily (25h TTL) | Wide-coverage FX YoY + 24m drawdown (resilience FX-stress inputs) |
 | seed-comtrade-bilateral-hs4 | `node scripts/seed-comtrade-bilateral-hs4.mjs` | **`0 6 1 * *` (monthly, verified 2026-07-27)** | UN Comtrade bilateral HS4 trade flows — only scheduled consumer of the keyed 500/mo Comtrade quota |
 | seed-hs2-chokepoint-exposure | `node scripts/seed-hs2-chokepoint-exposure.mjs` | periodic (TTL-extended) | HS2 chokepoint trade-exposure (derived) |
-| seed-service-statuses | `node scripts/seed-service-statuses.mjs` | frequent (relay-fallback) | Service-status warm-ping; primary seeder is the AIS relay loop |
+| seed-service-statuses | `node scripts/seed-service-statuses.mjs` | **planned — not provisioned** | Service-status warm-ping; primary seeder is the AIS relay loop |
 
 The bilateral HS4 cron uses `COMTRADE_API_KEYS` and a 480-request hard budget
 under the provider's 500-call monthly quota. The authenticated route requests

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -340,6 +340,7 @@
   {
     "entry": "scripts/seed-market-quotes.mjs",
     "deployMode": "nixpacks-root-repo",
+    "lifecycle": "planned",
     "service": "seed-market-quotes",
     "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
   },
@@ -367,6 +368,7 @@
   {
     "entry": "scripts/seed-crypto-sectors.mjs",
     "deployMode": "nixpacks-root-repo",
+    "lifecycle": "planned",
     "service": "seed-crypto-sectors",
     "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
   },
@@ -390,6 +392,7 @@
   {
     "entry": "scripts/seed-weather-alerts.mjs",
     "deployMode": "nixpacks-root-repo",
+    "lifecycle": "planned",
     "service": "seed-weather-alerts",
     "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
   },
@@ -458,6 +461,7 @@
   {
     "entry": "scripts/seed-service-statuses.mjs",
     "deployMode": "nixpacks-root-repo",
+    "lifecycle": "planned",
     "service": "seed-service-statuses",
     "documentedAt": "docs/railway-seed-consolidation-runbook.md#standalone-seed-crons-added-after-this-snapshot"
   },

--- a/tests/railway-watch-path-audit.test.mjs
+++ b/tests/railway-watch-path-audit.test.mjs
@@ -21,6 +21,9 @@ import {
 } from './_lib/import-graph-walk.mjs';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const RAILWAY_SERVICE_REGISTRY = JSON.parse(
+  readFileSync(resolve(repoRoot, 'scripts/railway-services.json'), 'utf8'),
+);
 
 function service({
   cronSchedule = '0 * * * *',
@@ -733,6 +736,33 @@ describe('planned Railway service lifecycle', () => {
     cronSchedule: '7,22,37,52 * * * *',
   };
 
+  it('keeps unprovisioned standalone seeders explicitly planned', () => {
+    const expectedPlannedServices = [
+      'seed-crypto-sectors',
+      'seed-market-quotes',
+      'seed-service-statuses',
+      'seed-weather-alerts',
+    ];
+    const plannedEntries = RAILWAY_SERVICE_REGISTRY.filter((entry) =>
+      expectedPlannedServices.includes(entry.service),
+    );
+
+    assert.deepEqual(
+      plannedEntries.map((entry) => entry.service).sort(),
+      expectedPlannedServices.sort(),
+    );
+    assert.ok(
+      plannedEntries.every((entry) => entry.lifecycle === 'planned'),
+      'unprovisioned standalone seeders must not be treated as active Railway services',
+    );
+    assert.deepEqual(
+      managedRailwayServices(RAILWAY_SERVICE_REGISTRY).filter((entry) =>
+        expectedPlannedServices.includes(entry.service),
+      ),
+      [],
+    );
+  });
+
   it('does not report an intentionally absent planned service', () => {
     assert.deepEqual(
       auditRailwayServiceConfig({ services: {} }, new Map(), [planned]),
@@ -1011,9 +1041,7 @@ describe('audit CLI argument parsing', () => {
 // behaviour directly, so a broken detector fails here rather than passing a
 // co-evolved comparison.
 describe('closure detection layers', () => {
-  const registry = JSON.parse(
-    readFileSync(resolve(repoRoot, 'scripts/railway-services.json'), 'utf8'),
-  );
+  const registry = RAILWAY_SERVICE_REGISTRY;
 
   describe('the container model derived from a Dockerfile', () => {
     it('detects the tsx loader and the dynamic roots the image copies in', () => {
@@ -1171,9 +1199,7 @@ describe('closure detection layers', () => {
 });
 
 describe('critical ingestion Railway registry contract', () => {
-  const registry = JSON.parse(
-    readFileSync(resolve(repoRoot, 'scripts/railway-services.json'), 'utf8'),
-  );
+  const registry = RAILWAY_SERVICE_REGISTRY;
   // Cron pins stay an explicit literal: these are production schedules and a
   // silent edit to one should fail loudly rather than be rubber-stamped by
   // reading the same file the change lives in.

--- a/tests/railway-watch-path-audit.test.mjs
+++ b/tests/railway-watch-path-audit.test.mjs
@@ -742,14 +742,15 @@ describe('planned Railway service lifecycle', () => {
       'seed-market-quotes',
       'seed-service-statuses',
       'seed-weather-alerts',
-    ];
-    const plannedEntries = RAILWAY_SERVICE_REGISTRY.filter((entry) =>
-      expectedPlannedServices.includes(entry.service),
+    ].sort();
+    const plannedEntries = RAILWAY_SERVICE_REGISTRY.filter(
+      (entry) => entry.lifecycle === 'planned',
     );
 
     assert.deepEqual(
       plannedEntries.map((entry) => entry.service).sort(),
-      expectedPlannedServices.sort(),
+      expectedPlannedServices,
+      'only unprovisioned standalone seeders may be marked planned',
     );
     assert.ok(
       plannedEntries.every((entry) => entry.lifecycle === 'planned'),


### PR DESCRIPTION
## Summary

Railway reconciliation no longer treats the four standalone seeder entries as live services before they exist, so a missing-service row cannot block every `--apply` patch. The registry now marks `seed-market-quotes`, `seed-crypto-sectors`, `seed-weather-alerts`, and `seed-service-statuses` as `lifecycle: planned`; the runbook labels them not provisioned and distinguishes planned repository-root candidates from active services' exact registry watch contracts. A regression test pins the four-service set and verifies planned entries stay outside managed audit/apply while explicit activation remains covered.

## Validation

- `node --test tests/railway-watch-path-audit.test.mjs tests/railway-deploy-closure.test.mjs` — 119 passed.
- `./node_modules/.bin/tsx --test tests/railway-services-registry-coverage.test.mts tests/scripts-railway-nixpacks-no-escape-import.test.mts` — 173 passed.
- `npm run typecheck`, Markdown lint, and the repository pre-push gate — passed.
- `npm run test:data` reached the pre-push-hook suite, whose 15 fixture cases were blocked by sandboxed macOS `mktemp` access under `/var/folders`; rerunning `node --test tests/prepush-hook-gate.test.mjs` with host filesystem access passed all 15.
- The live `node scripts/audit-railway-watch-paths.mjs --json` check could not run because this checkout has no linked Railway project; no production mutation was attempted.

## Post-Deploy Monitoring & Validation

- On the next scheduled Railway reconciliation, run `node scripts/audit-railway-watch-paths.mjs --json` from a Railway-linked operator checkout.
- Healthy: the four planned entries remain absent from managed drift and `--apply` reconciles active services without a missing-service refusal.
- Failure: any planned entry appears in live drift or reconciliation refuses on one of them; stop `--apply`, inspect lifecycle state, and revert this PR if required.
- Window/owner: the next scheduled audit plus one subsequent run; WorldMonitor ops owner.

Fixes #6238

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/MODEL_SLUG-GPT_5-000000)
