### PR TITLE
ops(railway): prune the recovered umami drift suppression and stop an empty baseline expiring (#6064)

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -234,10 +234,14 @@ different verdict than the one baselined still blocks" cannot acquire two
 meanings. It held 62 `REJECTED_PUSH` entries — every filtered service — until
 [#6142](https://github.com/koala73/worldmonitor/issues/6142) made the check
 closure-aware; those were not degradations, they were the check demanding that a
-filtered service run head. Today only `umami` at `BEHIND` against #6064 remains.
+filtered service run head. The last remaining entry — `umami` at `BEHIND` against
+[#6064](https://github.com/koala73/worldmonitor/issues/6064) — was pruned on
+2026-08-06 once the service was running head again, so the file is now empty.
 Acknowledged entries are printed on every run and do not fail it, so a green
 monitor here means "nothing new went stale", not "every service is on head". A
-service that recovers is printed as `recovered` — prune it.
+service that recovers is printed as `recovered` — prune it. The expiry does not
+fire on an empty list: it exists to stop a suppression outliving its cause, and
+with nothing suppressed there is nothing to re-review.
 
 #### Recovering a stale service
 

--- a/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
+++ b/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
@@ -310,7 +310,11 @@ baselined still blocks" from acquiring two meanings — so a baselined
 `REJECTED_PUSH` that turns into `BEHIND` still fails the run, which is the case
 where someone cleared the filter and the service went stale anyway. Every entry
 carries an owner issue and the file carries an expiry, so a suppression cannot
-outlive its cause unnoticed.
+outlive its cause unnoticed. The expiry is scoped to suppressions and does not
+fire on an empty list — the drift baseline emptied on 2026-08-06 when `umami`
+recovered, and an expiry that reddened the monitor over zero entries would be a
+finding-free failure on a check whose whole value is that its reds mean
+something.
 
 `.github/workflows/seed-freshness-monitor.yml` runs the drift check in the step
 **Check Railway deploy drift against main**, between the config audit and the

--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -117,6 +117,13 @@ export function validateAcceptanceBaseline(baseline) {
  * clear-on-recovery failure would make the monitor red on exactly the runs that
  * prove things improved. `expiresAt` is the anti-rot mechanism instead: the
  * whole baseline must be re-reviewed on a date, or the gate fails.
+ *
+ * The expiry governs SUPPRESSIONS, so a baseline that acknowledges nothing
+ * cannot expire — there is no suppression left to outlive its cause, and a
+ * date-triggered failure over an empty list is a red monitor with nothing to
+ * review. That case is reachable: pruning the last recovered entry empties the
+ * file, and this repository has already watched a permanently-red monitor hide
+ * live drift (#6087).
  */
 export function applyAcceptanceBaseline(problems, baseline, now = Date.now()) {
   validateAcceptanceBaseline(baseline);
@@ -139,7 +146,7 @@ export function applyAcceptanceBaseline(problems, baseline, now = Date.now()) {
   const cleared = baseline.acknowledged
     .filter((entry) => !seen.has(`${entry.name}:${entry.status}`))
     .map((entry) => ({ name: entry.name, status: entry.status, issue: entry.issue }));
-  const expired = Date.parse(baseline.expiresAt) < now;
+  const expired = baseline.acknowledged.length > 0 && Date.parse(baseline.expiresAt) < now;
   return { blocking, acknowledged, cleared, expired, expiresAt: baseline.expiresAt };
 }
 

--- a/scripts/railway-deploy-drift-baseline.json
+++ b/scripts/railway-deploy-drift-baseline.json
@@ -26,15 +26,18 @@
     "refused a push that DID reach the service, which is a real failure.",
     "",
     "expiresAt forces a re-review of the whole file. A stale-deploy suppression that",
-    "outlives its cause is how a fleet ends up silently a week behind."
+    "outlives its cause is how a fleet ends up silently a week behind. It does not fire",
+    "on an EMPTY list -- with nothing suppressed there is nothing to re-review, and a",
+    "red monitor with no finding behind it is how people learn to ignore this check.",
+    "",
+    "The list is empty as of 2026-08-06. It held one entry: `umami` at BEHIND against",
+    "#6064, the GitHub integration that stopped delivering pushes to the analytics",
+    "collector. The check reported it `recovered` once umami was running head again,",
+    "and the reconciler in .github/workflows/railway-deploy-trigger.yml is now what",
+    "keeps it there -- it judges each service against the commit it is RUNNING, so a",
+    "webhook that goes quiet again self-heals on the next reconcile instead of needing",
+    "an entry here."
   ],
   "expiresAt": "2026-09-04",
-  "acknowledged": [
-    {
-      "name": "umami",
-      "status": "BEHIND",
-      "issue": 6064,
-      "reason": "The analytics collector stopped receiving deployments from the GitHub integration on 2026-08-03. Its watch paths are already empty, so this is the webhook-side sibling of #6141 rather than a filter rejection -- and the failure that proves this check must not key on the filter: no SKIPPED record exists, and the service is a day behind head."
-    }
-  ]
+  "acknowledged": []
 }

--- a/tests/railway-deploy-drift.test.mjs
+++ b/tests/railway-deploy-drift.test.mjs
@@ -657,14 +657,37 @@ describe('Railway deploy drift summary', () => {
 
   // Anti-rot: a suppression that outlives its cause is how a fleet ends up
   // silently a week behind with a green monitor.
+  //
+  // `c` is acknowledged AND present in the fleet on purpose: that leaves
+  // `blocking` and `missing` both empty, so the expiry is the ONLY thing that
+  // can make this run fail. A fixture that also blocked or went missing would
+  // pass with the expiry check deleted.
   it('fails once the baseline expires, even with nothing else wrong', () => {
+    const summary = summarizeDeployDrift(
+      results.slice(0, 3),
+      baseline([{ name: 'c', status: 'REJECTED_PUSH', issue: 6141 }], '2026-08-01'),
+      NOW,
+    );
+    assert.deepEqual(summary.blocking, []);
+    assert.deepEqual(summary.missing, []);
+    assert.equal(summary.expired, true);
+    assert.equal(summary.ok, false);
+  });
+
+  // The companion to the rule above, and the reason pruning the last entry is
+  // safe: the expiry governs SUPPRESSIONS. With none left there is nothing to
+  // re-review, so a passed date must not redden a monitor whose whole fleet is
+  // on head — this file is emptied the moment the fleet recovers (#6064), and a
+  // date-triggered failure over an empty list is noise that trains people to
+  // ignore this check.
+  it('does not expire a baseline that suppresses nothing', () => {
     const summary = summarizeDeployDrift(
       results.slice(0, 2),
       baseline([], '2026-08-01'),
       NOW,
     );
-    assert.equal(summary.expired, true);
-    assert.equal(summary.ok, false);
+    assert.equal(summary.expired, false);
+    assert.equal(summary.ok, true);
   });
 });
 

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -264,6 +264,15 @@ describe('scheduled seed freshness monitor', () => {
       assert.equal(applyAcceptanceBaseline([], baseline, at('2026-08-28')).expired, true);
     });
 
+    // The expiry exists to stop a SUPPRESSION outliving its cause. Pruning the
+    // last recovered entry empties the list, and a date-triggered failure over
+    // nothing is a red monitor with nothing to review — which is how people
+    // learn to ignore the check that is supposed to page them.
+    it('does not expire once the last suppression is pruned', () => {
+      const emptied = { ...baseline, acknowledged: [] };
+      assert.equal(applyAcceptanceBaseline([], emptied, at('2026-08-28')).expired, false);
+    });
+
     it('requires an owner issue and an expiry on every entry', () => {
       assert.throws(() => validateAcceptanceBaseline({ acknowledged: [] }), /expiresAt/);
       assert.throws(


### PR DESCRIPTION
Closes #6064.

## What is left of #6064

Everything the issue proposed has shipped, in three other PRs:

| Proposed work | Where it landed |
|---|---|
| Detect commit drift | `scripts/check-railway-deploy-drift.mjs` (#6143), made closure-aware by #6151/#6142, wired at `.github/workflows/seed-freshness-monitor.yml:122` |
| Find out why the trigger stopped | Never root-caused — and no longer load-bearing (below) |
| Document the recovery recipe | `serviceInstanceDeployV2` + explicit `commitSha` is code (`scripts/trigger-railway-deploys.mjs:320-346`) and prose (`docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md:211`) |

`.github/workflows/railway-deploy-trigger.yml` is a **reconciler**, not a push
handler: it judges each service against the commit it is actually running, so a
webhook that goes quiet self-heals on the next reconcile. Its header names #6064
twice as a failure it recovers from, and the hourly `37 * * * *` cron exists
specifically as the webhook-outage backstop. That is why the unanswered "why did
the GitHub integration stop delivering" is a curiosity rather than an open risk.

The only thing still holding the issue open was a stale suppression.

## The prune

`node scripts/check-railway-deploy-drift.mjs` has been saying so on every run:

```
Railway deploy-drift check: head=01d56caf1 services=78 {"CURRENT_FOR_CLOSURE":75,"CURRENT":3}
- recovered: umami:BEHIND is running head again; remove it from scripts/railway-deploy-drift-baseline.json (#6064).
```

Verified live against production Railway: 78 services, nothing behind. While the
entry sits in the baseline the check **accepts** a `umami:BEHIND` verdict in
silence — the precise failure #6064 was filed about.

`docs/railway-seed-consolidation-runbook.md` carried the matching stale claim
("Today only `umami` at `BEHIND` against #6064 remains"); both docs are corrected.

## The trap the prune would otherwise arm

`applyAcceptanceBaseline` expired the whole file on a date whether or not it
suppressed anything. Emptying the list therefore left a baseline **guaranteed**
to fail the Seed Freshness Monitor on 2026-09-04 with nothing to review. #6087
is this repository watching a permanently-red monitor hide live drift, so a
finding-free red on the check whose entire value is that its reds mean something
is not a cost worth taking.

The expiry now governs *suppressions*: with none left, nothing can outlive its
cause. The anti-rot property is untouched for every non-empty baseline —
including `scripts/seed-freshness-baseline.json`, which has two live entries and
behaves identically today.

## Verification

- One new test per suite, each **proven red** against the pre-fix line. Mutation-
  tested by reverting the guard: 2 fail / 70 pass, so neither test is vacuous.
- The existing `fails once the baseline expires` test acknowledged nothing and a
  fixture with an empty list would pass with the expiry check deleted. Rewritten
  to acknowledge a service that is **present** in the fleet, so `blocking` and
  `missing` are both empty and the expiry is the only thing that can fail it.
- Scoped sweep across every consumer of the changed shared module
  (`scripts/check-seed-freshness.mjs`): 347 tests, 0 failures.
- `node scripts/check-railway-deploy-drift.mjs` against live Railway exits 0,
  recovered-prompt gone.
- `biome check` clean on all changed files.

## Not in this PR

#6025 (alert on umami memory) stays open and is being re-scoped separately — its
4 GB alarm band was derived from a leak #6051 eliminated, and 48h of live
`MEMORY_USAGE_GB` peaks at 0.65 GB.

https://claude.ai/code/session_01V4gDD1DzLTTii9uiDUqR9k
