### PR TITLE
ci: add generated-file drift gate for bootstrap-tier-keys

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -47,6 +47,7 @@ jobs:
       - run: npm run lint
       - run: npm run lint:boundaries
       - run: npm run lint:api-contract
+      - run: npm run sync:bootstrap-tier-keys:check
       - run: npm run lint:rate-limit-policies
       - run: npm run lint:premium-fetch
       - run: npm run security:vite-env-secrets


### PR DESCRIPTION
## Summary

Adds the existing `npm run sync:bootstrap-tier-keys:check` gate to CI so a PR that edits `shared/bootstrap-tier-keys.js` and forgets `npm run sync:bootstrap-tier-keys` is caught before merge.

**Fixes #5793**

## Background

`api/_bootstrap-tier-keys.js` is an auto-generated mirror of `shared/bootstrap-tier-keys.js` (via `scripts/sync-bootstrap-tier-keys.mjs`). The `--check` mode existed in `package.json` but was never wired anywhere — `grep -rn 'sync:bootstrap-tier-keys' .github/workflows/ .husky/` returned nothing.

A desync means `api/bootstrap.js` imports a symbol the mirror does not export, which lands as `undefined` at runtime (silent always-false predicates).

## Change

Added `- run: npm run sync:bootstrap-tier-keys:check` to the `biome` job in `.github/workflows/lint-code.yml`, alongside the other repo-consistency gates (`lint:api-contract`, `lint:rate-limit-policies`, `lint:premium-fetch`, `version:check`).

## Verification

The check passes cleanly against `origin/main` (mirror is currently in sync).