### PR TITLE
fix(mcp): attach both source failure reasons to get_airspace error (#6085)

### DIFF
--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -5,6 +5,7 @@ import { secondsUntilUtcMidnight } from '../../server/_shared/pro-mcp-token';
 import { getMcpBillingVerificationDenial } from './auth';
 import { BillingDenialError } from './billing-denial';
 import {
+  BothSourcesFailedError,
   createMcpToolExecutionContext,
   downstreamErrorTags,
 } from './downstream';
@@ -356,6 +357,7 @@ export async function dispatchToolsCall(
     const isExpectedDenial = err instanceof BillingDenialError;
     const isExpectedSourceOutage = err instanceof McpSourceUnavailableError;
     const downstreamTags = downstreamErrorTags(err);
+    const isBothFailed = err instanceof BothSourcesFailedError;
     const log = isClient4xx || isExpectedDenial || isExpectedSourceOutage ? console.warn : console.error;
     log('[mcp] tool execution error:', err);
     captureSilentError(err, {
@@ -370,6 +372,12 @@ export async function dispatchToolsCall(
         } : {}),
         ...downstreamTags,
       },
+      ...(isBothFailed ? {
+        extra: {
+          civilian_failure_detail: err.civilianFailureDetail,
+          military_failure_detail: err.militaryFailureDetail,
+        },
+      } : {}),
       ctx,
       // Split the api/mcp catch-all (WORLDMONITOR-T8) into per-tool,
       // per-status groups — see api/mcp/error-fingerprint.ts.

--- a/api/mcp/downstream.ts
+++ b/api/mcp/downstream.ts
@@ -311,7 +311,7 @@ export function classifyFailureReason(reason: unknown): string {
     if (reason.name === 'AbortError' || reason.name === 'TimeoutError') return 'timeout';
     const m = reason.message.match(/^HTTP (\d+)/);
     if (m) return `http_${m[1]}`;
-    if (/auth|secret|key|unauthorized|forbidden/i.test(reason.message)) return 'auth_error';
+    if (/\b(auth|secret|key|unauthorized|forbidden)\b/i.test(reason.message)) return 'auth_error';
     return 'error';
   }
   return reason == null ? 'unknown' : String(reason);

--- a/api/mcp/downstream.ts
+++ b/api/mcp/downstream.ts
@@ -296,6 +296,56 @@ export async function assertMcpToolFetchOk(
   );
 }
 
+/**
+ * Classify a PromiseSettledResult rejection reason into a short tag value.
+ *
+ * Returns one of:
+ *   `timeout`       — AbortSignal.timeout fired (AbortError)
+ *   `http_<status>` — upstream returned a non-ok HTTP status
+ *   `auth_error`    — buildAuthHeaders or similar auth-path failure
+ *   `error`         — generic Error subclass (message available in detail)
+ *   `unknown`       — non-Error rejection (string, undefined, etc.)
+ */
+export function classifyFailureReason(reason: unknown): string {
+  if (reason instanceof Error) {
+    if (reason.name === 'AbortError' || reason.name === 'TimeoutError') return 'timeout';
+    const m = reason.message.match(/^HTTP (\d+)/);
+    if (m) return `http_${m[1]}`;
+    if (/auth|secret|key|unauthorized|forbidden/i.test(reason.message)) return 'auth_error';
+    return 'error';
+  }
+  return reason == null ? 'unknown' : String(reason);
+}
+
+function formatErrorDetail(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  try { return JSON.stringify(err); } catch { return String(err); }
+}
+
+/**
+ * Typed error for `get_airspace` when both the civilian and military upstream
+ * sources fail. Carries the classified failure summary so dispatch can tag
+ * each side separately in Sentry and attach the full rejection reasons as
+ * extra data — distinguishing a shared-host outage (same failure on both
+ * sides) from two independent provider failures (different failures).
+ */
+export class BothSourcesFailedError extends Error {
+  readonly civilianFailure: string;
+  readonly militaryFailure: string;
+  readonly civilianFailureDetail: string;
+  readonly militaryFailureDetail: string;
+
+  constructor(civDetail: unknown, milDetail: unknown) {
+    super('Airspace data unavailable: both civilian and military sources failed');
+    this.name = 'BothSourcesFailedError';
+    this.civilianFailure = classifyFailureReason(civDetail);
+    this.militaryFailure = classifyFailureReason(milDetail);
+    this.civilianFailureDetail = formatErrorDetail(civDetail);
+    this.militaryFailureDetail = formatErrorDetail(milDetail);
+  }
+}
+
 export function downstreamErrorTags(
   error: unknown,
 ): Record<string, string> {
@@ -313,6 +363,12 @@ export function downstreamErrorTags(
       downstream_status: String(error.status),
       downstream_error_code: error.safeCode,
       downstream_response_marker: error.responseMarker,
+    };
+  }
+  if (error instanceof BothSourcesFailedError) {
+    return {
+      civilian_failure: error.civilianFailure,
+      military_failure: error.militaryFailure,
     };
   }
   return {};

--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -10,7 +10,7 @@ import { readJsonFromUpstash } from '../../_upstash-json.js';
 import { buildAuthHeaders } from '../auth';
 import { assertToolFetchOk, BillingDenialError, throwIfBillingDenial } from '../billing-denial';
 import { SUPPORTED_CONSUMER_PRICES_COUNTRIES } from '../constants';
-import { assertMcpToolFetchOk } from '../downstream';
+import { assertMcpToolFetchOk, BothSourcesFailedError } from '../downstream';
 import { evaluateFreshness } from '../freshness';
 import { McpSourceUnavailableError } from '../source-unavailable';
 import {
@@ -987,7 +987,7 @@ export const RPC_TOOLS: ToolDef[] = [
       const milOk = type === 'civilian' || milResult.status === 'fulfilled';
 
       // Both sources down — total outage, don't return misleading empty data
-      if (!civOk && !milOk) throw new Error('Airspace data unavailable: both civilian and military sources failed');
+      if (!civOk && !milOk) throw new BothSourcesFailedError(civResult.reason, milResult.reason);
 
       const civ = civResult.status === 'fulfilled' ? civResult.value : null;
       const mil = milResult.status === 'fulfilled' ? milResult.value : null;

--- a/tests/mcp-downstream-error-classification.test.mjs
+++ b/tests/mcp-downstream-error-classification.test.mjs
@@ -1,0 +1,114 @@
+// Unit tests for api/mcp/downstream.ts error-classification helpers
+// — classifyFailureReason, formatErrorDetail, BothSourcesFailedError,
+// and downstreamErrorTags BothSourcesFailedError handling.
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  classifyFailureReason,
+  BothSourcesFailedError,
+  downstreamErrorTags,
+} from '../api/mcp/downstream.ts';
+
+describe('classifyFailureReason', () => {
+  it('returns "timeout" for AbortError', () => {
+    const err = new DOMException('The operation was aborted', 'AbortError');
+    assert.equal(classifyFailureReason(err), 'timeout');
+  });
+
+  it('returns "timeout" for TimeoutError', () => {
+    const err = new Error('timed out');
+    err.name = 'TimeoutError';
+    assert.equal(classifyFailureReason(err), 'timeout');
+  });
+
+  it('returns "http_{status}" for HTTP status messages', () => {
+    assert.equal(classifyFailureReason(new Error('HTTP 500')), 'http_500');
+    assert.equal(classifyFailureReason(new Error('HTTP 404')), 'http_404');
+    assert.equal(classifyFailureReason(new Error('HTTP 503 Backend')), 'http_503');
+  });
+
+  it('returns "auth_error" for auth-related messages', () => {
+    assert.equal(classifyFailureReason(new Error('unauthorized')), 'auth_error');
+    assert.equal(classifyFailureReason(new Error('forbidden')), 'auth_error');
+    assert.equal(classifyFailureReason(new Error('invalid auth token')), 'auth_error');
+    assert.equal(classifyFailureReason(new Error('secret not found')), 'auth_error');
+    assert.equal(classifyFailureReason(new Error('API key rejected')), 'auth_error');
+  });
+
+  it('does NOT match substrings for auth keywords', () => {
+    // Word boundary anchors prevent false positives
+    assert.equal(classifyFailureReason(new Error('monkey')), 'error');
+    assert.equal(classifyFailureReason(new Error('monkey wrench')), 'error');
+  });
+
+  it('returns "error" for generic errors', () => {
+    assert.equal(classifyFailureReason(new Error('something broke')), 'error');
+    assert.equal(classifyFailureReason(new TypeError('bad type')), 'error');
+  });
+
+  it('returns "unknown" for null/undefined', () => {
+    assert.equal(classifyFailureReason(null), 'unknown');
+    assert.equal(classifyFailureReason(undefined), 'unknown');
+  });
+
+  it('returns stringified value for non-Error rejections', () => {
+    assert.equal(classifyFailureReason('just a string'), 'just a string');
+    assert.equal(classifyFailureReason(42), '42');
+  });
+});
+
+describe('BothSourcesFailedError', () => {
+  it('carries classified failure reasons from Error rejection reasons', () => {
+    const err = new BothSourcesFailedError(
+      new Error('HTTP 500'),
+      Object.assign(new Error('timed out'), { name: 'TimeoutError' }),
+    );
+    assert.equal(err.civilianFailure, 'http_500');
+    assert.equal(err.militaryFailure, 'timeout');
+    assert.equal(err.civilianFailureDetail, 'HTTP 500');
+    assert.equal(err.militaryFailureDetail, 'timed out');
+    assert.equal(err.message, 'Airspace data unavailable: both civilian and military sources failed');
+    assert.equal(err.name, 'BothSourcesFailedError');
+  });
+
+  it('carries classified failure reasons from non-Error rejections', () => {
+    const err = new BothSourcesFailedError(null, 'auth_error_string');
+    assert.equal(err.civilianFailure, 'unknown');
+    assert.equal(err.militaryFailure, 'auth_error_string');
+    assert.equal(err.civilianFailureDetail, 'null');
+    assert.equal(err.militaryFailureDetail, 'auth_error_string');
+  });
+
+  it('distinguishes same failure (shared-host outage) from different failures', () => {
+    const same = new BothSourcesFailedError(
+      new Error('HTTP 500'),
+      new Error('HTTP 500'),
+    );
+    const diff = new BothSourcesFailedError(
+      new Error('HTTP 500'),
+      new Error('timeout'),
+    );
+    assert.equal(same.civilianFailure, same.militaryFailure);
+    assert.notEqual(diff.civilianFailure, diff.militaryFailure);
+  });
+});
+
+describe('downstreamErrorTags with BothSourcesFailedError', () => {
+  it('returns civilian_failure and military_failure tags', () => {
+    const err = new BothSourcesFailedError(
+      new Error('HTTP 502'),
+      Object.assign(new Error('timed out'), { name: 'TimeoutError' }),
+    );
+    const tags = downstreamErrorTags(err);
+    assert.equal(tags.civilian_failure, 'http_502');
+    assert.equal(tags.military_failure, 'timeout');
+  });
+
+  it('does not include other error-class fields', () => {
+    const err = new BothSourcesFailedError(null, null);
+    const tags = downstreamErrorTags(err);
+    assert.equal(Object.keys(tags).length, 2);
+    assert.equal(tags.civilian_failure, 'unknown');
+    assert.equal(tags.military_failure, 'unknown');
+  });
+});


### PR DESCRIPTION
When both civilian and military upstreams fail, the thrown error now carries classified failure reasons as Sentry tags (`civilian_failure`, `military_failure` — values like `http_500`, `timeout`, `auth_error`) and full rejection details in Sentry extra, distinguishing a shared-host outage from two independent provider failures at a glance.

BillingDenialError is still rethrown ahead of this branch (unchanged).

Fixes #6085