### PR TITLE
test(build-guards): make dist-gated skip explicit via WM_EXPECT_BUILT_OUTPUT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,7 +173,7 @@ jobs:
       - run: npm ci
       - name: Build dashboard artifacts for built-output tests
         run: VITE_VARIANT=full ./node_modules/.bin/vite build
-      - run: npm run test:data
+      - run: WM_EXPECT_BUILT_OUTPUT=1 npm run test:data
       - name: Edge function bundle check
         run: |
           # JS edge entries (existing loop, unchanged).

--- a/tests/_lib/built-output-guard.mjs
+++ b/tests/_lib/built-output-guard.mjs
@@ -1,0 +1,21 @@
+import { existsSync } from 'node:fs';
+
+const EXPECT_BUILT_OUTPUT = 'WM_EXPECT_BUILT_OUTPUT';
+
+function expectsBuiltOutput() {
+  return process.env[EXPECT_BUILT_OUTPUT] === '1';
+}
+
+export function shouldSkipBuiltOutput(dashboardHtml, expectBuiltOutput = expectsBuiltOutput()) {
+  if (existsSync(dashboardHtml)) return false;
+  return !expectBuiltOutput;
+}
+
+export function guardBuiltOutput(dashboardHtml, expectBuiltOutput = expectsBuiltOutput()) {
+  if (!existsSync(dashboardHtml) && expectBuiltOutput) {
+    throw new Error(
+      'dist/dashboard.html is missing but WM_EXPECT_BUILT_OUTPUT=1 indicates CI expected a build. ' +
+      'Run VITE_VARIANT=full vite build first, or check that the build step still produces dist/dashboard.html.',
+    );
+  }
+}

--- a/tests/dashboard-build-guards.test.mjs
+++ b/tests/dashboard-build-guards.test.mjs
@@ -1,0 +1,108 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const workflowPath = resolve(repoRoot, '.github/workflows/test.yml');
+const guardModuleUrl = pathToFileURL(resolve(repoRoot, 'tests/_lib/built-output-guard.mjs')).href;
+
+const guardProbeSource = [
+  "import { describe, it } from 'node:test';",
+  "import { writeFileSync } from 'node:fs';",
+  `import { guardBuiltOutput, shouldSkipBuiltOutput } from ${JSON.stringify(guardModuleUrl)};`,
+  "const dashboardHtml = process.env.WM_DASHBOARD_GUARD_DASHBOARD;",
+  "const expectBuiltOutput = process.env.WM_EXPECT_BUILT_OUTPUT === '1';",
+  "writeFileSync(process.env.WM_DASHBOARD_GUARD_LOADED, 'loaded');",
+  "describe('built-output guard probe', { skip: shouldSkipBuiltOutput(dashboardHtml, expectBuiltOutput) }, () => {",
+  "  writeFileSync(process.env.WM_DASHBOARD_GUARD_SUITE, 'entered');",
+  "  guardBuiltOutput(dashboardHtml, expectBuiltOutput);",
+  "  it('executes the built-output assertion', () => {",
+  "    writeFileSync(process.env.WM_DASHBOARD_GUARD_ASSERTION, 'ran');",
+  "  });",
+  "});",
+].join('\n');
+
+function runGuardProbe(expectBuiltOutput) {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), 'worldmonitor-built-output-guard-'));
+  const probePath = join(fixtureRoot, 'guard-probe.test.mjs');
+  const dashboardHtml = join(fixtureRoot, 'dist', 'dashboard.html');
+  const loadedMarker = join(fixtureRoot, 'loaded');
+  const suiteMarker = join(fixtureRoot, 'suite');
+  const assertionMarker = join(fixtureRoot, 'assertion');
+
+  try {
+    writeFileSync(probePath, guardProbeSource);
+    const env = {
+      ...process.env,
+      WM_DASHBOARD_GUARD_DASHBOARD: dashboardHtml,
+      WM_DASHBOARD_GUARD_LOADED: loadedMarker,
+      WM_DASHBOARD_GUARD_SUITE: suiteMarker,
+      WM_DASHBOARD_GUARD_ASSERTION: assertionMarker,
+    };
+    delete env.NODE_OPTIONS;
+    delete env.NODE_TEST_CONTEXT;
+    if (expectBuiltOutput) env.WM_EXPECT_BUILT_OUTPUT = '1';
+    else delete env.WM_EXPECT_BUILT_OUTPUT;
+
+    const result = spawnSync(process.execPath, ['--test', probePath], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env,
+    });
+
+    return {
+      ...result,
+      output: `${result.stdout ?? ''}\n${result.stderr ?? ''}`,
+      loaded: existsSync(loadedMarker),
+      suite: existsSync(suiteMarker),
+      assertion: existsSync(assertionMarker),
+    };
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+describe('built-output guard contract', () => {
+  it('keeps the dashboard build immediately before the marker-enabled data test in CI', () => {
+    const workflow = readFileSync(workflowPath, 'utf8').replaceAll('\r\n', '\n');
+    const expectedSequence = [
+      '      - name: Build dashboard artifacts for built-output tests',
+      '        run: VITE_VARIANT=full ./node_modules/.bin/vite build',
+      '      - run: WM_EXPECT_BUILT_OUTPUT=1 npm run test:data',
+    ].join('\n');
+
+    assert.ok(
+      workflow.includes(expectedSequence),
+      'the unit job must build dashboard artifacts immediately before running test:data with WM_EXPECT_BUILT_OUTPUT=1',
+    );
+    assert.equal(
+      workflow.match(/WM_EXPECT_BUILT_OUTPUT=1 npm run test:data/g)?.length ?? 0,
+      1,
+      'the CI marker command should remain a single, explicit unit-job contract',
+    );
+  });
+
+  it('skips the built-output suite when the marker is absent and output is missing', () => {
+    const result = runGuardProbe(false);
+
+    assert.equal(result.status, 0, result.output);
+    assert.equal(result.loaded, true, 'the probe module should load');
+    assert.equal(result.suite, false, 'node:test should skip the built-output suite');
+    assert.equal(result.assertion, false, 'the built-output assertion must not run');
+  });
+
+  it('fails the built-output suite when CI expects output but it is missing', () => {
+    const result = runGuardProbe(true);
+
+    assert.notEqual(result.status, 0, result.output);
+    assert.equal(result.loaded, true, 'the probe module should load');
+    assert.equal(result.suite, true, 'the suite callback should run when CI expects built output');
+    assert.equal(result.assertion, false, 'the assertion must not run after the guard fails');
+    assert.match(result.output, /WM_EXPECT_BUILT_OUTPUT=1/);
+  });
+});

--- a/tests/dashboard-critical-css.test.mjs
+++ b/tests/dashboard-critical-css.test.mjs
@@ -4,25 +4,11 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, extname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
+import { guardBuiltOutput, shouldSkipBuiltOutput } from './_lib/built-output-guard.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const dashboardHtml = resolve(repoRoot, 'dist/dashboard.html');
-const expectBuiltOutput = process.env.WM_EXPECT_BUILT_OUTPUT === '1';
-
-function shouldSkipBuiltOutput() {
-  if (existsSync(dashboardHtml)) return false;
-  return !expectBuiltOutput;
-}
-
-function guardBuiltOutput() {
-  if (!existsSync(dashboardHtml) && expectBuiltOutput) {
-    throw new Error(
-      'dist/dashboard.html is missing but WM_EXPECT_BUILT_OUTPUT=1 indicates CI expected a build. ' +
-      'Run VITE_VARIANT=full vite build first, or check that the build step still produces dist/dashboard.html.',
-    );
-  }
-}
 
 function src(relPath) {
   return readFileSync(resolve(repoRoot, relPath), 'utf8');
@@ -322,8 +308,8 @@ describe('dashboard critical CSS graph', () => {
     );
   });
 
-  describe('built dashboard output', { skip: shouldSkipBuiltOutput() }, () => {
-    guardBuiltOutput();
+  describe('built dashboard output', { skip: shouldSkipBuiltOutput(dashboardHtml) }, () => {
+    guardBuiltOutput(dashboardHtml);
 
     it('does not link or merge the settings-only stylesheet into built dashboard.html', () => {
     const dashboardHtml = builtSrc('dist/dashboard.html');

--- a/tests/dashboard-critical-css.test.mjs
+++ b/tests/dashboard-critical-css.test.mjs
@@ -7,6 +7,22 @@ import ts from 'typescript';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
+const dashboardHtml = resolve(repoRoot, 'dist/dashboard.html');
+const expectBuiltOutput = process.env.WM_EXPECT_BUILT_OUTPUT === '1';
+
+function shouldSkipBuiltOutput() {
+  if (existsSync(dashboardHtml)) return false;
+  return !expectBuiltOutput;
+}
+
+function guardBuiltOutput() {
+  if (!existsSync(dashboardHtml) && expectBuiltOutput) {
+    throw new Error(
+      'dist/dashboard.html is missing but WM_EXPECT_BUILT_OUTPUT=1 indicates CI expected a build. ' +
+      'Run VITE_VARIANT=full vite build first, or check that the build step still produces dist/dashboard.html.',
+    );
+  }
+}
 
 function src(relPath) {
   return readFileSync(resolve(repoRoot, relPath), 'utf8');
@@ -306,7 +322,10 @@ describe('dashboard critical CSS graph', () => {
     );
   });
 
-  it('does not link or merge the settings-only stylesheet into built dashboard.html', () => {
+  describe('built dashboard output', { skip: shouldSkipBuiltOutput() }, () => {
+    guardBuiltOutput();
+
+    it('does not link or merge the settings-only stylesheet into built dashboard.html', () => {
     const dashboardHtml = builtSrc('dist/dashboard.html');
     const hrefs = stylesheetHrefs(dashboardHtml);
     const settingsStylesheets = hrefs.filter((href) =>
@@ -394,5 +413,6 @@ describe('dashboard critical CSS graph', () => {
         `Deferred dashboard stylesheet ${href} must keep a no-JS stylesheet fallback (rel=stylesheet, any attribute order).`,
       );
     }
+  });
   });
 });

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -8,6 +8,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const distDir = resolve(repoRoot, 'dist');
 const dashboardHtml = resolve(distDir, 'dashboard.html');
+const expectBuiltOutput = process.env.WM_EXPECT_BUILT_OUTPUT === '1';
+
+function shouldSkipDashboard() {
+  if (existsSync(dashboardHtml)) return false;
+  return !expectBuiltOutput;
+}
 
 // Large static config DATA TABLES intentionally kept OFF the eager dashboard
 // critical path (#4404 — main.js diet round 2). Each must (a) build as its own
@@ -15,8 +21,10 @@ const dashboardHtml = resolve(distDir, 'dashboard.html');
 // imported by the main entry chunk. A re-added @/config barrel value re-export
 // or a new eager consumer would re-eagerise the table and fail this guard.
 //
-// Dist-gated: skips when dist/dashboard.html is absent. CI builds the dashboard
-// before `npm run test:data` (the step added in #4393), so this runs in CI.
+// Dist-gated: skips when dist/dashboard.html is absent (unless
+// WM_EXPECT_BUILT_OUTPUT=1 is set, which makes it fail instead so CI cannot
+// silently skip). CI exports WM_EXPECT_BUILT_OUTPUT=1 before `npm run test:data`
+// and builds the dashboard first (the step added in #4393).
 const DEFERRED_TABLE_CHUNKS = ['tech-geo-data', 'airports-data', 'ai-datacenters-data', 'geo-map-data', 'military-bases-data'];
 const DEFERRED_SENTRY_CHUNKS = ['sentry-init', 'sentry'];
 // agent-bus-applier + shared/agent-bus-actions pull in zod (~69KB raw). They are
@@ -180,7 +188,17 @@ function registerDeferredChunkAssertions(chunks, options) {
   }
 }
 
-describe('eager chunk budget: lazy-only config data tables stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
+function guardDashboardBuild() {
+  if (!existsSync(dashboardHtml) && expectBuiltOutput) {
+    throw new Error(
+      'dist/dashboard.html is missing but WM_EXPECT_BUILT_OUTPUT=1 indicates CI expected a build. ' +
+      'Run VITE_VARIANT=full vite build first, or check that the build step still produces dist/dashboard.html.',
+    );
+  }
+}
+
+describe('eager chunk budget: lazy-only config data tables stay off the entry', { skip: shouldSkipDashboard() }, () => {
+  guardDashboardBuild();
   const html = readFileSync(dashboardHtml, 'utf-8');
   const assetsDir = resolve(distDir, 'assets');
   const assets = existsSync(assetsDir) ? readdirSync(assetsDir) : [];
@@ -250,7 +268,8 @@ describe('eager chunk budget: military base data stays behind its lazy loader', 
   });
 });
 
-describe('eager chunk budget: Sentry stays behind the deferred scheduler', { skip: !existsSync(dashboardHtml) }, () => {
+describe('eager chunk budget: Sentry stays behind the deferred scheduler', { skip: shouldSkipDashboard() }, () => {
+  guardDashboardBuild();
   const html = readFileSync(dashboardHtml, 'utf-8');
   const assetsDir = resolve(distDir, 'assets');
   const assets = existsSync(assetsDir) ? readdirSync(assetsDir) : [];
@@ -284,35 +303,40 @@ describe('eager chunk budget: Sentry stays behind the deferred scheduler', { ski
   }
 });
 
-describe('eager chunk budget: opt-in npm libs stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
+describe('eager chunk budget: opt-in npm libs stay off the entry', { skip: shouldSkipDashboard() }, () => {
+  guardDashboardBuild();
   registerDeferredChunkAssertions(DEFERRED_NPM_LIB_CHUNKS, {
     missingMessage: (chunk) => `${chunk}-*.js chunk should exist — if missing, the lib was inlined into another chunk by a static import`,
     preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — it loads on demand`,
   });
 });
 
-describe('eager chunk budget: checkout-only code stays off the dashboard entry', { skip: !existsSync(dashboardHtml) }, () => {
+describe('eager chunk budget: checkout-only code stays off the dashboard entry', { skip: shouldSkipDashboard() }, () => {
+  guardDashboardBuild();
   registerDeferredChunkAssertions(DEFERRED_CHECKOUT_CHUNKS, {
     missingMessage: (chunk) => `${chunk}-*.js chunk should exist — checkout/widget work must remain code-split`,
     preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — it loads only after checkout or widget interaction`,
   });
 });
 
-describe('eager chunk budget: agent-bus + zod stay behind the lazy chat-analyst panel', { skip: !existsSync(dashboardHtml) }, () => {
+describe('eager chunk budget: agent-bus + zod stay behind the lazy chat-analyst panel', { skip: shouldSkipDashboard() }, () => {
+  guardDashboardBuild();
   registerDeferredChunkAssertions(DEFERRED_AGENT_BUS_CHUNKS, {
     missingMessage: (chunk) => `${chunk}-*.js chunk should exist — if it was inlined into main, a static import re-eagerised agent-bus-applier (and zod)`,
     preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — agent-bus loads through the lazy chat-analyst panel`,
   });
 });
 
-describe('eager chunk budget: post-paint enrichment services stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
+describe('eager chunk budget: post-paint enrichment services stay off the entry', { skip: shouldSkipDashboard() }, () => {
+  guardDashboardBuild();
   registerDeferredChunkAssertions(DEFERRED_SERVICE_CHUNKS, {
     missingMessage: (chunk) => `${chunk}-*.js chunk should exist — if missing, a static import inlined the service into the entry (correlation-engine: App.ts; story-renderer: country-intel/StoryModal)`,
     preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — it loads post-first-paint on demand`,
   });
 });
 
-describe('eager chunk budget: generated RPC clients stay lazy', { skip: !existsSync(dashboardHtml) }, () => {
+describe('eager chunk budget: generated RPC clients stay lazy', { skip: shouldSkipDashboard() }, () => {
+  guardDashboardBuild();
   registerDeferredChunkAssertions(DEFERRED_RPC_CLIENT_CHUNKS, {
     missingMessage: (chunk) => `${chunk}-*.js chunk should exist — generated RPC constructors must load through the lazy runtime shim`,
     preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — RPC constructors load on first RPC call`,

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -3,16 +3,15 @@ import assert from 'node:assert/strict';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { guardBuiltOutput, shouldSkipBuiltOutput } from './_lib/built-output-guard.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const distDir = resolve(repoRoot, 'dist');
 const dashboardHtml = resolve(distDir, 'dashboard.html');
-const expectBuiltOutput = process.env.WM_EXPECT_BUILT_OUTPUT === '1';
 
 function shouldSkipDashboard() {
-  if (existsSync(dashboardHtml)) return false;
-  return !expectBuiltOutput;
+  return shouldSkipBuiltOutput(dashboardHtml);
 }
 
 // Large static config DATA TABLES intentionally kept OFF the eager dashboard
@@ -189,12 +188,7 @@ function registerDeferredChunkAssertions(chunks, options) {
 }
 
 function guardDashboardBuild() {
-  if (!existsSync(dashboardHtml) && expectBuiltOutput) {
-    throw new Error(
-      'dist/dashboard.html is missing but WM_EXPECT_BUILT_OUTPUT=1 indicates CI expected a build. ' +
-      'Run VITE_VARIANT=full vite build first, or check that the build step still produces dist/dashboard.html.',
-    );
-  }
+  guardBuiltOutput(dashboardHtml);
 }
 
 describe('eager chunk budget: lazy-only config data tables stay off the entry', { skip: shouldSkipDashboard() }, () => {


### PR DESCRIPTION
Fixes #6139

Two test files guard built output and disagreed on what to do when
`dist/dashboard.html` is missing:

| File | Before | After |
|---|---|---|
| `tests/dashboard-eager-chunks.test.mjs` | Silently skipped via `{ skip: !existsSync(dashboardHtml) }` — fail-open | Skips when no marker; fails with clear error when `WM_EXPECT_BUILT_OUTPUT=1` |
| `tests/dashboard-critical-css.test.mjs` | Hard-failed always via `builtSrc()` assert | Same env-marker respect: skips locally, fails in CI |

**The fix:** introduce `WM_EXPECT_BUILT_OUTPUT` env marker. Both files now:
- **Skip** when unset and artifact is missing (local dev, no build)
- **Fail** with a descriptive error when set and artifact is missing (CI)
- **Run normally** when artifact exists

CI exports `WM_EXPECT_BUILT_OUTPUT=1` before `npm run test:data` in `.github/workflows/test.yml`.

**Verification:**
- Without marker + no dist: 11 tests pass, 8 dist-gated suites correctly skip
- With `WM_EXPECT_BUILT_OUTPUT=1` + no dist: suites fail with `dist/dashboard.html is missing but WM_EXPECT_BUILT_OUTPUT=1`