### PR TITLE
fix(worktree): self-heal hooks path at push time

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,20 +5,32 @@
 # worktree's push to ANOTHER checkout's (possibly ancient) hook file — the
 # 2026-07-24 "pushes take 4 minutes and time out" incident (see
 # docs/solutions/performance-issues/git-push-timeout-stale-core-hookspath.md).
-# Bootstrap heals this too, but only when bootstrap runs; push time is the
-# moment that matters. Escape hatch for an intentional central-hook setup:
+# Bootstrap heals this too, but shared config can be poisoned again afterward.
+# At push time, reuse the same policy and hand off to this worktree's hook in
+# the same process. Escape hatch for an intentional central-hook setup:
 # WM_ALLOW_FOREIGN_HOOKS=1.
 if [ -z "${WM_ALLOW_FOREIGN_HOOKS:-}" ] && [ -n "${BASH_SOURCE[0]:-}" ]; then
   _hook_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd -P)
   _wt_root=$(cd "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null && pwd -P)
   if [ -n "$_hook_dir" ] && [ -n "$_wt_root" ] && [ "$_hook_dir" != "$_wt_root/.husky" ]; then
+    # The normalizer verifies repository ownership before rewriting a shared
+    # absolute .husky path. It leaves deliberate or unverified hook dirs alone.
+    if node "$_wt_root/scripts/bootstrap-worktree.mjs" --hooks-only --root "$_wt_root"; then
+      _resolved_hooks_path=$(git config --get core.hooksPath 2>/dev/null || true)
+      if [ "$_resolved_hooks_path" = ".husky" ]; then
+        echo "[worktree] hooksPath repaired; continuing with $_wt_root/.husky/pre-push"
+        exec bash "$_wt_root/.husky/pre-push" "$@"
+      fi
+    fi
+
     echo "============================================================"
     echo "ERROR: pre-push hook is executing from OUTSIDE this worktree:"
     echo "  running:  $_hook_dir/pre-push"
     echo "  expected: $_wt_root/.husky/pre-push"
     echo "core.hooksPath resolves to another checkout, so pushes run that"
     echo "checkout's (possibly stale) gate instead of this branch's."
-    echo "Fix (once, for all worktrees):  git config core.hooksPath .husky"
+    echo "Automatic repair could not safely normalize core.hooksPath."
+    echo "For this repository's shared .husky path, run: git config core.hooksPath .husky"
     echo "Then check for a per-worktree override:"
     echo "  git config --show-origin core.hooksPath"
     echo "  (if origin is a config.worktree file: git config --worktree --unset core.hooksPath)"

--- a/scripts/bootstrap-worktree.mjs
+++ b/scripts/bootstrap-worktree.mjs
@@ -25,6 +25,7 @@ export function parseArgs(argv = []) {
     envSource: process.env.WM_ENV_SOURCE || '',
     forceInstall: false,
     help: false,
+    hooksOnly: false,
     ignoreScripts: false,
     rootDir: process.cwd(),
     skipEnv: false,
@@ -52,6 +53,8 @@ export function parseArgs(argv = []) {
       options.skipInstall = true;
     } else if (arg === '--force-install') {
       options.forceInstall = true;
+    } else if (arg === '--hooks-only') {
+      options.hooksOnly = true;
     } else if (arg === '--ignore-scripts') {
       options.ignoreScripts = true;
     } else if (arg === '--env-source') {
@@ -87,6 +90,7 @@ Options:
   --skip-env          Do not create env symlinks.
   --skip-install      Do not run npm ci, even when installation is not verified.
   --force-install     Run npm ci even when node_modules already exists.
+  --hooks-only        Normalize core.hooksPath, then exit without other bootstrap work.
   --ignore-scripts    Pass --ignore-scripts to npm ci for docs/test-only work.
   --dry-run           Print what would happen without changing files.
   -h, --help          Show this help text.`);
@@ -425,13 +429,15 @@ export function normalizeWorktreeHooksPath({
 export function bootstrapWorktree(options = {}) {
   const rootDir = resolve(options.rootDir || process.cwd());
   const log = options.log || console.log;
-  const envSource = options.envSource
-    ? resolve(options.envSource)
-    : inferEnvSource(rootDir);
 
   assertProjectRoot(rootDir);
 
   normalizeWorktreeHooksPath({ dryRun: options.dryRun, log, rootDir });
+  if (options.hooksOnly) return;
+
+  const envSource = options.envSource
+    ? resolve(options.envSource)
+    : inferEnvSource(rootDir);
 
   if (!options.skipEnv) {
     linkEnvFiles({

--- a/tests/bootstrap-worktree.test.mjs
+++ b/tests/bootstrap-worktree.test.mjs
@@ -160,6 +160,7 @@ describe('worktree bootstrap helper', () => {
       '/tmp/source',
       '--cache=/tmp/cache',
       '--skip-install',
+      '--hooks-only',
       '--ignore-scripts',
       '--dry-run',
     ]);
@@ -167,8 +168,25 @@ describe('worktree bootstrap helper', () => {
     assert.equal(options.envSource, '/tmp/source');
     assert.equal(options.cacheDir, '/tmp/cache');
     assert.equal(options.skipInstall, true);
+    assert.equal(options.hooksOnly, true);
     assert.equal(options.ignoreScripts, true);
     assert.equal(options.dryRun, true);
+  });
+
+  it('stops after hooks normalization in hooks-only mode', () => {
+    const root = makeTempDir();
+    writeFileSync(join(root, 'package.json'), '{}');
+    writeFileSync(join(root, '.env.vercel-export'), 'MUST_NOT_BE_SCANNED=1\n');
+    const logs = [];
+
+    assert.doesNotThrow(() => bootstrapWorktree({
+      forceInstall: true,
+      hooksOnly: true,
+      log: line => logs.push(line),
+      rootDir: root,
+    }));
+    assert.deepEqual(logs, []);
+    assert.equal(existsSync(join(root, 'node_modules')), false);
   });
 
   // A stale absolute core.hooksPath makes every worktree push run ANOTHER

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -169,6 +169,99 @@ function makeFixture({ branchFiles = {}, scriptsCjs = true, failAttestMode = nul
 }
 
 /**
+ * A real linked worktree whose shared config points at the main checkout's
+ * hook. The main hook has a poisoned body after the identity tripwire, so a
+ * successful push proves the tripwire handed off to the feature worktree's
+ * hook instead of continuing in the foreign copy.
+ */
+function pushWithPoisonedSharedHooksPath() {
+  const id = fixtureCount++;
+  const base = join(WORK, `poisoned-hooks-${id}`);
+  const main = join(base, 'main');
+  const worktree = join(base, 'feature');
+  const remote = join(base, 'remote.git');
+  const { bin, log } = makeStubs(join(base, 'aux'));
+  const env = hookEnv(bin);
+  delete env.WM_ALLOW_FOREIGN_HOOKS;
+
+  // The identity repair must run the real bootstrap helper. Every later node
+  // call in the 500-line gate stays stubbed, as in makeFixture().
+  const nodeStub = join(bin, 'node');
+  writeFileSync(
+    nodeStub,
+    `#!/bin/sh\n` +
+      `case "$1" in\n` +
+      `  */scripts/bootstrap-worktree.mjs) exec ${JSON.stringify(process.execPath)} "$@" ;;\n` +
+      `esac\n` +
+      STUB_BODY('node', log).replace('#!/bin/sh\n', ''),
+  );
+  chmodSync(nodeStub, 0o755);
+
+  const git = (cwd, args) => execFileSync('git', args, { cwd, env, encoding: 'utf8' }).trim();
+  mkdirSync(main, { recursive: true });
+  execFileSync('git', ['init', '--quiet', '--bare', remote], { env });
+  git(main, ['init', '--quiet', '--initial-branch=main', '.']);
+  git(main, ['config', 'user.email', 'prepush-hook@example.invalid']);
+  git(main, ['config', 'user.name', 'Prepush Hook Fixture']);
+  git(main, ['remote', 'add', 'origin', remote]);
+
+  for (const dir of ['.husky', 'scripts', 'node_modules']) {
+    mkdirSync(join(main, dir), { recursive: true });
+  }
+  copyFileSync(HOOK, join(main, '.husky', 'pre-push'));
+  for (const script of [
+    'bootstrap-worktree.mjs',
+    'check-local-secret-dumps.mjs',
+    'prepush-attest.sh',
+    'prepush-changed-tests.sh',
+  ]) {
+    copyFileSync(join(REPO_ROOT, 'scripts', script), join(main, 'scripts', script));
+  }
+  writeFileSync(join(main, 'package.json'), '{"name":"fixture"}\n');
+  writeFileSync(join(main, 'README.md'), 'base\n');
+  git(main, ['add', '-A']);
+  git(main, ['commit', '--quiet', '-m', 'base']);
+  git(main, ['push', '--quiet', '--set-upstream', 'origin', 'main']);
+  git(main, ['worktree', 'add', '--quiet', '-b', 'feature', worktree]);
+  mkdirSync(join(worktree, 'node_modules'), { recursive: true });
+  writeFileSync(join(worktree, 'README.md'), 'feature\n');
+  git(worktree, ['add', 'README.md']);
+  git(worktree, ['commit', '--quiet', '-m', 'feature']);
+
+  const foreignHook = join(main, '.husky', 'pre-push');
+  const originalHook = readFileSync(foreignHook, 'utf8');
+  const poisonedHook = originalHook.replace(
+    '\necho "Checking for local environment dumps..."',
+    '\necho "FOREIGN HOOK BODY RAN"\nexit 97\n\necho "Checking for local environment dumps..."',
+  );
+  assert.notEqual(poisonedHook, originalHook, 'fixture must poison the foreign hook body');
+  writeFileSync(foreignHook, poisonedHook);
+  git(main, ['config', 'core.hooksPath', join(main, '.husky')]);
+
+  let status = 0;
+  let output = '';
+  try {
+    output = execFileSync('git', ['push', '--set-upstream', 'origin', 'HEAD:feature'], {
+      cwd: worktree,
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    status = error.status;
+    output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+
+  return {
+    status,
+    output,
+    hooksPath: git(worktree, ['config', '--get', 'core.hooksPath']),
+    localHead: git(worktree, ['rev-parse', 'HEAD']),
+    remoteHead: git(worktree, ['ls-remote', '--heads', 'origin', 'feature']).split(/\s+/)[0] || '',
+  };
+}
+
+/**
  * The argument list of EVERY `npx tsx --test ...` the hook issued, in order.
  * All of them, not just the first: asserting one invocation cannot see a
  * second, duplicate dispatch — which is the failure the TESTS_CHANGED dedup
@@ -187,6 +280,18 @@ function tsxRuns(invocations) {
   }
   return runs;
 }
+
+describe('a poisoned shared hooksPath self-heals at push time (#6104)', () => {
+  test('repairs the shared value and runs this worktree hook in the same push', () => {
+    const result = pushWithPoisonedSharedHooksPath();
+
+    assert.equal(result.status, 0, result.output);
+    assert.equal(result.hooksPath, '.husky');
+    assert.equal(result.remoteHead, result.localHead);
+    assert.match(result.output, /repairing shared hooksPath/);
+    assert.doesNotMatch(result.output, /FOREIGN HOOK BODY RAN/);
+  });
+});
 
 describe('a clean push runs the changed tests and attests the tree', () => {
   test('dispatches the changed test and caches HEAD^{tree}', () => {


### PR DESCRIPTION
## Summary

A poisoned shared `core.hooksPath` no longer blocks every linked-worktree push until someone repairs Git config by hand. When a repository-owned foreign `.husky` hook is detected, the push reuses the existing ownership policy to normalize the shared value and immediately hands control to the current worktree's hook; non-Husky hook directories and `WM_ALLOW_FOREIGN_HOOKS` remain untouched.

The recovery path uses a hooks-only bootstrap mode, so healing cannot expand into environment linking, secret-dump scanning, or dependency installation.

Fixes #6104.

## Validation

- Real linked-worktree regression: poisoned shared config repaired, current hook ran, and the same `git push` updated the bare remote (16/16 hook-gate tests passed).
- Bootstrap policy and hooks-only behavior: 27/27 tests passed.
- `npm run typecheck`, `npm run typecheck:api`, and `npm run lint` passed; lint retained only existing repository warnings.
- Full data suite reached 21,475 passing tests; its only two failures required a missing built dashboard artifact. After a full-variant Vite build, the affected dashboard CSS suite passed 9/9.
- The exact pushed commit passed the repository pre-push gate, including both typechecks, Unicode/version checks, and 101 changed-path/hook tests.

## Post-Deploy Monitoring & Validation

No production application monitoring is required because this only changes local developer Git-hook behavior.

- Search push output for `[worktree] repairing shared hooksPath` followed by `[worktree] hooksPath repaired`.
- Healthy: `git config --get core.hooksPath` becomes `.husky`, the current worktree's gate output follows, and the push completes.
- Failure: the outside-worktree refusal repeats, config remains absolute, or the handoff cannot start the current hook.
- Mitigation: run `git config core.hooksPath .husky`; revert this PR if recovery interferes with an intentional hook setup.
- Validation window and owner: repository maintainers should watch developer pushes and reports for seven days after merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
