### PR TITLE
fix(seeders): preserve Redis publications after rejection

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -350,16 +350,11 @@ export function getRedisCredentials() {
   return { url, token };
 }
 
-async function redisCommand(url, token, command) {
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify(command),
-    signal: AbortSignal.timeout(15_000),
-  });
+export async function parseRedisCommandResponse(resp, label = 'Redis command') {
   if (!resp.ok) {
-    const text = await resp.text().catch(() => '');
-    const err = new Error(`Redis command failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+    const text = typeof resp.text === 'function' ? await resp.text().catch(() => '') : '';
+    const detail = text ? ` — ${text.slice(0, 200)}` : '';
+    const err = new Error(`${label} failed: HTTP ${resp.status}${detail}`);
     // Tag errors so callers wrapping in withRetry know whether to back off.
     // Permanent 4xx (auth, payload-too-large, etc.) won't recover on retry —
     // mark non-retryable so withRetry exits the loop in ~10ms instead of
@@ -370,13 +365,40 @@ async function redisCommand(url, token, command) {
     if (PERMANENT_4XX_STATUSES.has(resp.status)) {
       err.nonRetryable = true;
     } else if (resp.status === 429) {
-      const retryAfterMs = parseRetryAfterMs(resp.headers.get('retry-after'));
+      const retryAfterMs = parseRetryAfterMs(getResponseHeader(resp.headers, 'Retry-After'));
       if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
     }
     err.httpStatus = resp.status;
     throw err;
   }
-  return resp.json();
+  let body;
+  try {
+    body = await resp.json();
+  } catch (cause) {
+    throw Object.assign(new Error(`${label} returned invalid JSON (HTTP ${resp.status})`), { cause });
+  }
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw new Error(`${label} returned an unexpected Upstash response`);
+  }
+  if (body.error != null) {
+    throw new Error(`${label} rejected by Upstash: ${String(body.error)}`);
+  }
+  if (!Object.hasOwn(body, 'result')) {
+    throw new Error(`${label} returned an Upstash response without a result`);
+  }
+  return body;
+}
+
+export async function redisCommand(url, token, command, options = {}) {
+  const commandName = String(command?.[0] || 'command').toUpperCase();
+  const label = options.label || `Redis ${commandName}`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
+    body: JSON.stringify(command),
+    signal: AbortSignal.timeout(options.timeoutMs ?? 15_000),
+  });
+  return parseRedisCommandResponse(resp, label);
 }
 
 async function redisGet(url, token, key) {
@@ -743,13 +765,13 @@ export async function readCanonicalEnvelopeMeta(canonicalKey) {
 // caller's request shape, not server load:
 //   400 malformed query   401 bad auth      403 forbidden
 //   404 missing path      410 permanently gone
-//   422 semantic error    451 legal block
+//   413 payload too large 422 semantic error    451 legal block
 // 408 Request Timeout and 429 Too Many Requests are deliberately excluded —
 // both are explicit "back off and retry" signals, often paired with a
 // Retry-After header. Tagging them nonRetryable would convert transient
 // rate-limits into immediate seed failures (especially under parallel
 // fetches like seed-imf-* WEO bundles).
-export const PERMANENT_4XX_STATUSES = new Set([400, 401, 403, 404, 410, 422, 451]);
+export const PERMANENT_4XX_STATUSES = new Set([400, 401, 403, 404, 410, 413, 422, 451]);
 
 // sysexits.h EX_TEMPFAIL: fetch failed, last-good TTL was extended, and the
 // bundle runner should retry/report non-OK without treating the seeder as a
@@ -973,22 +995,10 @@ export async function writeExtraKey(key, data, ttl, envelopeMeta) {
   // (auth, payload-too-large) fail fast; 429 honors Retry-After. Mirrors the
   // redisCommand / atomicPublish contract (seed-gdelt-intel PUBLISH_TIMEOUT fix).
   await withRetry(async () => {
-    const resp = await fetch(url, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
-      body: JSON.stringify(['SET', key, payload, 'EX', ttl]),
-      signal: AbortSignal.timeout(10_000),
+    await redisCommand(url, token, ['SET', key, payload, 'EX', ttl], {
+      label: `Extra key ${key}`,
+      timeoutMs: 10_000,
     });
-    if (!resp.ok) {
-      const err = new Error(`Extra key ${key}: write failed (HTTP ${resp.status})`);
-      if (PERMANENT_4XX_STATUSES.has(resp.status)) {
-        err.nonRetryable = true;
-      } else if (resp.status === 429) {
-        const retryAfterMs = parseRetryAfterMs(getResponseHeader(resp.headers, 'Retry-After'));
-        if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
-      }
-      throw err;
-    }
   }, 2, 1000);
   console.log(`  Extra key ${key}: written`);
 }

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, getRedisCredentials, acquireLockSafely, releaseLock, withRetry, writeFreshnessMetadata, logSeedResult, verifySeedKey, extendExistingTtl, getResponseHeader } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, getRedisCredentials, parseRedisCommandResponse, redisCommand, acquireLockSafely, releaseLock, withRetry, writeFreshnessMetadata, logSeedResult, verifySeedKey, extendExistingTtl, getResponseHeader } from './_seed-utils.mjs';
 import { summarizeMilitaryTheaters, buildMilitarySurges, appendMilitaryHistory } from './_military-surges.mjs';
 import { buildEnvelope, unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { pathToFileURL } from 'node:url';
@@ -1430,38 +1430,68 @@ function calculateTheaterPostures(flights) {
 export async function redisSet(url, token, key, value, ttl) {
   const payload = JSON.stringify(value);
   const cmd = ttl ? ['SET', key, payload, 'EX', ttl] : ['SET', key, payload];
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
-    body: JSON.stringify(cmd),
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!resp.ok) throw new Error(`Redis SET ${key} failed: HTTP ${resp.status}`);
-  const body = await resp.json();
-  if (body && typeof body === 'object' && Object.hasOwn(body, 'error')) {
-    throw new Error(`Redis SET ${key} rejected by Upstash: ${String(body.error)}`);
+  await withRetry(() => redisCommand(url, token, cmd, {
+    label: `Redis SET ${key}`,
+    timeoutMs: 10_000,
+  }), 2, 1000);
+}
+
+export async function redisDel(url, token, key) {
+  await withRetry(() => redisCommand(url, token, ['DEL', key], {
+    label: `Redis DEL ${key}`,
+    timeoutMs: 10_000,
+  }), 2, 1000);
+}
+
+export async function redisGet(url, token, key) {
+  const data = await withRetry(async () => {
+    const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
+      headers: { Authorization: `Bearer ${token}`, 'User-Agent': CHROME_UA },
+      signal: AbortSignal.timeout(10_000),
+    });
+    return parseRedisCommandResponse(resp, `Redis GET ${key}`);
+  }, 2, 1000);
+  if (data.result == null) return null;
+  try {
+    return unwrapEnvelope(JSON.parse(data.result)).data;
+  } catch (cause) {
+    throw Object.assign(new Error(`Redis GET ${key} returned invalid stored JSON`), { cause });
   }
 }
 
-async function redisDel(url, token, key) {
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
-    body: JSON.stringify(['DEL', key]),
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!resp.ok) throw new Error(`Redis DEL ${key} failed: HTTP ${resp.status}`);
-}
+const MILITARY_PUBLICATION_TTL_GROUPS = [
+  { keys: [LIVE_KEY, 'seed-meta:military:flights'], ttl: LIVE_TTL },
+  {
+    keys: [
+      STALE_KEY,
+      THEATER_POSTURE_STALE_KEY,
+      MILITARY_SURGES_STALE_KEY,
+      MILITARY_FORECAST_INPUTS_STALE_KEY,
+      MILITARY_CLASSIFICATION_AUDIT_STALE_KEY,
+      'seed-meta:theater-posture',
+      'seed-meta:military-forecast-inputs',
+      'seed-meta:military-surges',
+    ],
+    ttl: STALE_TTL,
+  },
+  {
+    keys: [
+      THEATER_POSTURE_LIVE_KEY,
+      MILITARY_FORECAST_INPUTS_LIVE_KEY,
+      MILITARY_CLASSIFICATION_AUDIT_LIVE_KEY,
+      MILITARY_SURGES_LIVE_KEY,
+    ],
+    ttl: THEATER_POSTURE_LIVE_TTL,
+  },
+  { keys: [THEATER_POSTURE_BACKUP_KEY, MILITARY_SURGES_HISTORY_KEY], ttl: THEATER_POSTURE_BACKUP_TTL },
+];
 
-async function redisGet(url, token, key) {
-  const resp = await fetch(`${url}/get/${encodeURIComponent(key)}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!resp.ok) return null;
-  const data = await resp.json();
-  if (!data?.result) return null;
-  try { return unwrapEnvelope(JSON.parse(data.result)).data; } catch { return null; }
+export async function preserveMilitaryPublicationTtls() {
+  const results = [];
+  for (const group of MILITARY_PUBLICATION_TTL_GROUPS) {
+    results.push(await extendExistingTtl(group.keys, group.ttl));
+  }
+  return results.every(Boolean);
 }
 
 async function requestForecastRefreshIfEnabled(runId, assessedAt, source) {
@@ -1529,23 +1559,14 @@ async function main() {
   } catch (err) {
     await releaseLock('military:flights', runId);
     console.error(`  FETCH FAILED: ${err.message || err}`);
-    await extendExistingTtl([LIVE_KEY, 'seed-meta:military:flights'], LIVE_TTL);
-    await extendExistingTtl([STALE_KEY, THEATER_POSTURE_STALE_KEY, MILITARY_SURGES_STALE_KEY, MILITARY_FORECAST_INPUTS_STALE_KEY, MILITARY_CLASSIFICATION_AUDIT_STALE_KEY], STALE_TTL);
-    await extendExistingTtl([THEATER_POSTURE_LIVE_KEY, MILITARY_FORECAST_INPUTS_LIVE_KEY, MILITARY_CLASSIFICATION_AUDIT_LIVE_KEY], THEATER_POSTURE_LIVE_TTL);
-    await extendExistingTtl([THEATER_POSTURE_BACKUP_KEY], THEATER_POSTURE_BACKUP_TTL);
-    await extendExistingTtl([MILITARY_SURGES_LIVE_KEY], MILITARY_SURGES_LIVE_TTL);
+    await preserveMilitaryPublicationTtls();
     console.log(`\n=== Failed gracefully (${Math.round(Date.now() - startMs)}ms) ===`);
     process.exit(0);
   }
 
   if (flights.length === 0) {
     console.log('  SKIPPED: 0 military flights — extending existing TTLs');
-    await extendExistingTtl([LIVE_KEY, 'seed-meta:military:flights'], LIVE_TTL);
-    await extendExistingTtl([STALE_KEY, THEATER_POSTURE_STALE_KEY, MILITARY_SURGES_STALE_KEY, MILITARY_FORECAST_INPUTS_STALE_KEY, MILITARY_CLASSIFICATION_AUDIT_STALE_KEY], STALE_TTL);
-    await extendExistingTtl([THEATER_POSTURE_LIVE_KEY, MILITARY_FORECAST_INPUTS_LIVE_KEY, MILITARY_CLASSIFICATION_AUDIT_LIVE_KEY], THEATER_POSTURE_LIVE_TTL);
-    await extendExistingTtl([THEATER_POSTURE_BACKUP_KEY], THEATER_POSTURE_BACKUP_TTL);
-    await extendExistingTtl([MILITARY_SURGES_LIVE_KEY], MILITARY_SURGES_LIVE_TTL);
-    await extendExistingTtl(['seed-meta:theater-posture', 'seed-meta:military-forecast-inputs', 'seed-meta:military-surges'], STALE_TTL);
+    await preserveMilitaryPublicationTtls();
     await releaseLock('military:flights', runId);
     lockReleased = true;
     process.exit(0);
@@ -1680,6 +1701,10 @@ async function main() {
     const durationMs = Date.now() - startMs;
     logSeedResult('military', flights.length, durationMs);
     console.log(`\n=== Done (${Math.round(durationMs)}ms) ===`);
+  } catch (err) {
+    console.warn(`  Preserving last-good military keys after publish failure: ${err.message || err}`);
+    await preserveMilitaryPublicationTtls();
+    throw err;
   } finally {
     if (!lockReleased) await releaseLock('military:flights', runId);
   }

--- a/tests/seed-military-flights-redis-write.test.mjs
+++ b/tests/seed-military-flights-redis-write.test.mjs
@@ -1,33 +1,148 @@
 import assert from 'node:assert/strict';
-import { afterEach, test } from 'node:test';
+import { afterEach, beforeEach, test } from 'node:test';
 
-import { redisSet } from '../scripts/seed-military-flights.mjs';
+import {
+  preserveMilitaryPublicationTtls,
+  redisDel,
+  redisGet,
+  redisSet,
+} from '../scripts/seed-military-flights.mjs';
 
 const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
+const originalRedisUrl = process.env.UPSTASH_REDIS_REST_URL;
+const originalRedisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+beforeEach(() => {
+  globalThis.setTimeout = (callback, _delay, ...args) => {
+    queueMicrotask(() => callback(...args));
+    return 0;
+  };
+});
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+  if (originalRedisUrl == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = originalRedisUrl;
+  if (originalRedisToken == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = originalRedisToken;
 });
 
 test('redisSet rejects an Upstash command error returned with HTTP 200', async () => {
-  globalThis.fetch = async () => new Response(JSON.stringify({
-    error: 'ERR max request size exceeded',
-  }), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  });
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response(JSON.stringify({
+      error: 'WRONGTYPE Operation against a key holding the wrong kind of value',
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
 
   await assert.rejects(
     redisSet('https://redis.test', 'test-token', 'military:flights:v1', { flights: [] }, 600),
-    /Redis SET military:flights:v1 rejected by Upstash: ERR max request size exceeded/,
+    /Redis SET military:flights:v1 rejected by Upstash: WRONGTYPE/,
   );
+  assert.equal(calls, 3, 'command-level failures use the bounded Redis retry contract');
 });
 
-test('redisSet accepts an Upstash command success response', async () => {
-  globalThis.fetch = async () => new Response(JSON.stringify({ result: 'OK' }), {
+test('redisSet accepts a successful response with a null error field', async () => {
+  globalThis.fetch = async () => new Response(JSON.stringify({ result: 'OK', error: null }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });
 
   await redisSet('https://redis.test', 'test-token', 'military:flights:v1', { flights: [] }, 600);
+});
+
+test('redisSet wraps a non-JSON HTTP 200 response with the key context', async () => {
+  globalThis.fetch = async () => new Response('temporarily unavailable', { status: 200 });
+
+  await assert.rejects(
+    redisSet('https://redis.test', 'test-token', 'military:flights:v1', { flights: [] }, 600),
+    /Redis SET military:flights:v1 returned invalid JSON \(HTTP 200\)/,
+  );
+});
+
+test('redisSet retains an HTTP failure response body in the error', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response('request payload exceeds the database limit', { status: 413 });
+  };
+
+  await assert.rejects(
+    redisSet('https://redis.test', 'test-token', 'military:flights:v1', { flights: [] }, 600),
+    /Redis SET military:flights:v1 failed: HTTP 413 — request payload exceeds the database limit/,
+  );
+  assert.equal(calls, 1, 'payload-too-large responses are permanent request failures');
+});
+
+test('redisSet retries a transient HTTP failure before succeeding', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) return new Response('overloaded', { status: 503 });
+    return new Response(JSON.stringify({ result: 'OK' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  await redisSet('https://redis.test', 'test-token', 'military:flights:v1', { flights: [] }, 600);
+  assert.equal(calls, 2);
+});
+
+test('redisGet distinguishes an Upstash rejection from a missing history key', async () => {
+  globalThis.fetch = async () => new Response(JSON.stringify({ error: 'ERR injected read failure' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  await assert.rejects(
+    redisGet('https://redis.test', 'test-token', 'military:surges:history:v1'),
+    /Redis GET military:surges:history:v1 rejected by Upstash/,
+  );
+
+  globalThis.fetch = async () => new Response(JSON.stringify({ result: null }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+  assert.equal(await redisGet('https://redis.test', 'test-token', 'military:surges:history:v1'), null);
+});
+
+test('redisDel surfaces a command rejection while clearing the OpenSky cooldown', async () => {
+  globalThis.fetch = async () => new Response(JSON.stringify({ error: 'ERR injected delete failure' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  await assert.rejects(
+    redisDel('https://redis.test', 'test-token', 'opensky:quota-cooldown:v1'),
+    /Redis DEL opensky:quota-cooldown:v1 rejected by Upstash/,
+  );
+});
+
+test('publish-failure preservation extends every military publication key at its recovery TTL', async () => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  const ttlByKey = new Map();
+  globalThis.fetch = async (_url, init) => {
+    const pipeline = JSON.parse(init.body);
+    for (const command of pipeline) ttlByKey.set(command[1], command[2]);
+    return new Response(JSON.stringify(pipeline.map(() => ({ result: 1 }))), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  assert.equal(await preserveMilitaryPublicationTtls(), true);
+  assert.equal(ttlByKey.size, 16);
+  assert.equal(ttlByKey.get('military:flights:v1'), 600);
+  assert.equal(ttlByKey.get('military:flights:stale:v1'), 86400);
+  assert.equal(ttlByKey.get('military:surges:v1'), 900);
+  assert.equal(ttlByKey.get('military:surges:history:v1'), 604800);
+  assert.equal(ttlByKey.get('seed-meta:military-surges'), 86400);
 });

--- a/tests/seed-utils-redis-read-retry.test.mjs
+++ b/tests/seed-utils-redis-read-retry.test.mjs
@@ -194,6 +194,20 @@ test('writeFreshnessMetadata: still throws after exhausting retries', async () =
   assert.equal(calls, 3, 'default retry count should be 2 (3 total attempts)');
 });
 
+test('writeFreshnessMetadata: HTTP-200 command errors retry and then throw', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return buildResponse({ body: { error: 'ERR injected metadata rejection' } });
+  };
+
+  await assert.rejects(
+    () => writeFreshnessMetadata('military', 'flights', 12, 'opensky', 600),
+    /Redis SET rejected by Upstash: ERR injected metadata rejection/,
+  );
+  assert.equal(calls, 3, 'command-level failures must not be mistaken for a successful seed-meta write');
+});
+
 // ---------- readCanonicalEnvelopeMeta (the skip-path mirror GET) ----------
 // A transient failure here is worse than a crash: the caller falls back to
 // writing recordCount=0 with fetchedAt=NOW, resetting the freshness clock and

--- a/tests/seed-utils-with-retry.test.mjs
+++ b/tests/seed-utils-with-retry.test.mjs
@@ -14,7 +14,7 @@ import {
 
 describe('PERMANENT_4XX_STATUSES classification', () => {
   it('includes the request-shape errors that retrying cannot fix', () => {
-    for (const code of [400, 401, 403, 404, 410, 422, 451]) {
+    for (const code of [400, 401, 403, 404, 410, 413, 422, 451]) {
       assert.equal(PERMANENT_4XX_STATUSES.has(code), true, `expected ${code} permanent`);
     }
   });

--- a/tests/seed-utils-write-extra-key-retry.test.mjs
+++ b/tests/seed-utils-write-extra-key-retry.test.mjs
@@ -17,9 +17,19 @@ process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
 const { writeExtraKey } = await import('../scripts/_seed-utils.mjs');
 
 const originalFetch = globalThis.fetch;
+const originalSetTimeout = globalThis.setTimeout;
 
-beforeEach(() => { globalThis.fetch = originalFetch; });
-afterEach(() => { globalThis.fetch = originalFetch; });
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = (callback, _delay, ...args) => {
+    queueMicrotask(() => callback(...args));
+    return 0;
+  };
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  globalThis.setTimeout = originalSetTimeout;
+});
 
 function buildResponse({ ok = true, status = 200, body = { result: 'OK' }, headers = {} }) {
   return { ok, status, json: async () => body, headers };
@@ -105,4 +115,18 @@ test('writeExtraKey: still throws after exhausting retries', async () => {
     /HTTP 503/,
   );
   assert.equal(calls, 3, 'default retry count should be 2 (3 total attempts)');
+});
+
+test('writeExtraKey: HTTP-200 command errors retry and then fail with the key context', async () => {
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return buildResponse({ body: { error: 'ERR injected command rejection' } });
+  };
+
+  await assert.rejects(
+    () => writeExtraKey('gdelt:intel:tone:military', { data: [] }, 600),
+    /Extra key gdelt:intel:tone:military rejected by Upstash: ERR injected command rejection/,
+  );
+  assert.equal(calls, 3, 'command-level failures must use the same bounded retry contract as HTTP failures');
 });


### PR DESCRIPTION
## Summary

- harden Upstash single-command response handling for shared freshness and extra-key writes
- retry military Redis GET, SET, and DEL operations while distinguishing a true miss from a command rejection
- preserve the full 16-key military publication cohort when any publish step fails
- correct the HTTP-200 command-error and HTTP-413 payload-limit regression fixtures

## Finding disposition

- Fixed: 43, 44, 45, 46, 47, 49, 50, 51, 52
- Refuted as a behavior change: 48. Publication remains fail-fast to avoid mixing cohort generations; the failure path now extends every last-good key.
- Refuted: 53. No-throw is the success contract, but the coverage was weak and is now strengthened with null-error, invalid-JSON, rejection, retry, and response-detail cases.
- Corrected test fidelity: 54. Command errors use WRONGTYPE with HTTP 200; oversized SET uses non-retryable HTTP 413.

## Verification

- node syntax checks
- Biome on all six changed files
- typecheck and typecheck:api
- 172 seed utility and military-flight tests
- pre-push gate: 72 changed tests, all required checks passed
- pre-push hook fixture: 16/16 outside the filesystem sandbox

## Deployment observation

After merge and deployment, observe the first three scheduled military-flight seed runs for clean completion or key-qualified Upstash rejection diagnostics.

Follow-up to merged PR #6258.