### PR TITLE
fix(military): bound stale flight recovery cache

### DIFF
--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -15,6 +15,7 @@ import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 const REDIS_CACHE_KEY = 'military:flights:v1';
 const REDIS_CACHE_TTL = 600; // 10 min — reduce upstream API pressure
 const REDIS_STALE_KEY = 'military:flights:stale:v1';
+const STABLE_STALE_CACHE_KEY = 'military:flights:stable-stale:v1';
 const STALE_SNAPSHOT_CACHE_TTL = 120; // Bind a bounded cursor traversal to one snapshot.
 const STALE_SNAPSHOT_NEG_TTL = 30;
 
@@ -308,8 +309,8 @@ type StaleSnapshotCacheEntry =
   | { status: 'hit'; result: ListMilitaryFlightsResponse; coverage: SeedCoverage }
   | { status: 'miss' };
 
-const staleSnapshotLocalCache = new Map<string, { entry: StaleSnapshotCacheEntry; expiresAt: number }>();
-const staleSnapshotInflight = new Map<string, Promise<StaleSnapshotCacheEntry>>();
+let staleSnapshotLocalCache: { entry: StaleSnapshotCacheEntry; expiresAt: number } | null = null;
+let staleSnapshotInflight: Promise<StaleSnapshotCacheEntry> | null = null;
 
 // Test seam — exposed for unit tests that need to drive the suppression
 // window without sleeping. Not exported from the module's public API.
@@ -318,8 +319,8 @@ export function _resetStaleNegativeCacheForTests(): void {
   liveSeedNegStatus = 'miss';
   liveSeedReadPromise = null;
   staleNegUntil = 0;
-  staleSnapshotLocalCache.clear();
-  staleSnapshotInflight.clear();
+  staleSnapshotLocalCache = null;
+  staleSnapshotInflight = null;
 }
 
 interface StaleSeedSnapshot {
@@ -364,51 +365,56 @@ function staleResultForBounds(
   entry: StaleSnapshotCacheEntry,
   requestBounds: RequestBounds,
 ): ListMilitaryFlightsResponse | null {
-  return entry.status === 'hit' && seedCovers(entry.coverage, requestBounds) ? entry.result : null;
+  if (entry.status !== 'hit') return null;
+  if (seedCovers(entry.coverage, requestBounds)) return entry.result;
+
+  // The dashboard deliberately asks for the full legal world. If only a
+  // regional last-good snapshot survived, serving its in-bounds rows is more
+  // useful than blanking every region. Narrow requests outside that declared
+  // coverage still fail closed, so an uncovered viewport is never presented as
+  // an authoritative empty result.
+  const isGlobalRequest = requestBounds.south === -90
+    && requestBounds.north === 90
+    && requestBounds.west === -180
+    && requestBounds.east === 180;
+  return isGlobalRequest ? entry.result : null;
 }
 
 // Stale is a mutable root key, while pagination uses numeric offsets. Cache the
-// unpaginated snapshot plus its declared coverage per bbox/filter scope so a
-// seeder write cannot make later cursor pages slice a different ordering. Every
-// cache hit still rechecks exact request bounds against that coverage. Misses use
-// the legacy 30s suppression window; snapshots live for two minutes, comfortably
-// past the bounded traversal without extending the 24h root snapshot itself.
+// unpaginated snapshot plus its declared coverage under one fixed key so a
+// seeder write cannot make later cursor pages slice a different ordering. The
+// root snapshot is bbox/filter independent; using derived public-input keys here
+// would duplicate full snapshots and make isolate state unbounded. Every cache
+// hit still rechecks exact request bounds against coverage. Misses use the legacy
+// 30s suppression window; snapshots live for two minutes, comfortably past the
+// bounded traversal without extending the 24h root snapshot itself.
 async function fetchStableStaleSnapshot(
-  cacheKey: string,
   requestBounds: RequestBounds,
 ): Promise<ListMilitaryFlightsResponse | null> {
-  const staleCacheKey = `${cacheKey}:stale`;
   const now = Date.now();
-  const local = staleSnapshotLocalCache.get(staleCacheKey);
+  const local = staleSnapshotLocalCache;
   if (local && local.expiresAt > now) {
     return staleResultForBounds(local.entry, requestBounds);
   }
-  if (local) staleSnapshotLocalCache.delete(staleCacheKey);
+  staleSnapshotLocalCache = null;
 
-  const cached = await readCachedJson(staleCacheKey);
-  if (cached.status === 'hit') {
-    const entry = parseStaleSnapshotCacheEntry(cached.value);
-    if (entry) {
-      const ttl = entry.status === 'hit' ? STALE_SNAPSHOT_CACHE_TTL : STALE_SNAPSHOT_NEG_TTL;
-      staleSnapshotLocalCache.set(staleCacheKey, { entry, expiresAt: now + ttl * 1_000 });
-      return staleResultForBounds(entry, requestBounds);
-    }
-  }
-
-  // Another caller may have populated the isolate cache while this request
-  // awaited Redis. Recheck before starting a second root-key read.
-  const refreshedLocal = staleSnapshotLocalCache.get(staleCacheKey);
-  if (refreshedLocal && refreshedLocal.expiresAt > Date.now()) {
-    return staleResultForBounds(refreshedLocal.entry, requestBounds);
-  }
-
-  const existing = staleSnapshotInflight.get(staleCacheKey);
+  const existing = staleSnapshotInflight;
   if (existing) {
     const entry = await existing;
     return staleResultForBounds(entry, requestBounds);
   }
 
   const promise = (async (): Promise<StaleSnapshotCacheEntry> => {
+    const cached = await readCachedJson(STABLE_STALE_CACHE_KEY);
+    if (cached.status === 'hit') {
+      const entry = parseStaleSnapshotCacheEntry(cached.value);
+      if (entry) {
+        const ttl = entry.status === 'hit' ? STALE_SNAPSHOT_CACHE_TTL : STALE_SNAPSHOT_NEG_TTL;
+        staleSnapshotLocalCache = { entry, expiresAt: Date.now() + ttl * 1_000 };
+        return entry;
+      }
+    }
+
     const stale = await fetchStaleFallback();
     const entry: StaleSnapshotCacheEntry = stale
       ? {
@@ -418,14 +424,14 @@ async function fetchStableStaleSnapshot(
       }
       : { status: 'miss' };
     const ttl = entry.status === 'hit' ? STALE_SNAPSHOT_CACHE_TTL : STALE_SNAPSHOT_NEG_TTL;
-    staleSnapshotLocalCache.set(staleCacheKey, { entry, expiresAt: Date.now() + ttl * 1_000 });
-    await setCachedJson(staleCacheKey, entry, ttl);
+    staleSnapshotLocalCache = { entry, expiresAt: Date.now() + ttl * 1_000 };
+    await setCachedJson(STABLE_STALE_CACHE_KEY, entry, ttl);
     return entry;
   })().finally(() => {
-    staleSnapshotInflight.delete(staleCacheKey);
+    staleSnapshotInflight = null;
   });
 
-  staleSnapshotInflight.set(staleCacheKey, promise);
+  staleSnapshotInflight = promise;
   const entry = await promise;
   return staleResultForBounds(entry, requestBounds);
 }
@@ -560,7 +566,7 @@ export async function listMilitaryFlights(
       // The seed cron (scripts/seed-military-flights.mjs) writes both keys
       // every run; stale has a 24h TTL versus 10min live, so it's the right
       // fallback when OpenSky / the relay hiccups.
-      const staleResult = await fetchStableStaleSnapshot(cacheKey, requestBounds);
+      const staleResult = await fetchStableStaleSnapshot(requestBounds);
       if (staleResult) {
         return paginateResponse(staleResult.flights, staleResult.clusters, requestBounds, req);
       }
@@ -582,7 +588,7 @@ export async function listMilitaryFlights(
     // the two former producer regions. The accepted stale snapshot is cached
     // unpaginated so every cursor in the bounded traversal slices one version.
     const requestBounds = normalizeBounds(req);
-    const staleResult = await fetchStableStaleSnapshot(buildCacheKey(req), requestBounds);
+    const staleResult = await fetchStableStaleSnapshot(requestBounds);
     if (staleResult) {
       return paginateResponse(staleResult.flights, staleResult.clusters, requestBounds, req);
     }

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -2047,6 +2047,8 @@ describe('aviation aircraft provider priority', { concurrency: 1 }, () => {
 });
 
 describe('military flights bbox behavior', { concurrency: 1 }, () => {
+  const stableStaleCacheKey = 'military:flights:stable-stale:v1';
+
   async function importListMilitaryFlights() {
     return importPatchedTsModule('server/worldmonitor/military/v1/list-military-flights.ts', {
       './_shared': resolve(root, 'server/worldmonitor/military/v1/_shared.ts'),
@@ -2591,7 +2593,223 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     }
   });
 
-  it('rejects stale snapshots that do not cover a global request after a live Redis error', async () => {
+  it('reuses one constant stale snapshot cache across bbox/filter keys and refreshes it after local expiry', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    module._resetStaleNegativeCacheForTests();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const originalNow = Date.now;
+    const store = new Map();
+    const snapshotWriteKeys = new Set();
+    let now = 1_800_000_000_000;
+    let stableCacheReads = 0;
+    let staleRootReads = 0;
+
+    Date.now = () => now;
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === stableStaleCacheKey) {
+          stableCacheReads += 1;
+          return jsonResponse({ result: store.get(key) ?? null });
+        }
+        if (key === 'military:flights:v1') throw new Error('redis timeout');
+        if (key === 'military:flights:stale:v1') {
+          staleRootReads += 1;
+          return jsonResponse({
+            result: JSON.stringify({
+              coverage: 'global',
+              flights: [
+                { id: 'first-cell', callsign: 'RCH701', lat: 10.5, lon: 10.5 },
+                { id: 'second-cell', callsign: 'RCH702', lat: 20.5, lon: 10.5 },
+              ],
+            }),
+          });
+        }
+        return jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) {
+        const { key, value } = parseSetRequest(url, init);
+        store.set(key, value);
+        const decoded = JSON.parse(value);
+        if (decoded?.status === 'hit' || decoded?.status === 'miss') snapshotWriteKeys.add(key);
+        return jsonResponse({ result: 'OK' });
+      }
+      if (raw.includes('/opensky')) throw new Error('OpenSky must stay closed on a live Redis error');
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
+      const first = await module.listMilitaryFlights(ctx, request);
+      const collisionShaped = await module.listMilitaryFlights(ctx, {
+        ...seededRequest,
+        aircraftType: ':stale',
+      });
+
+      for (let index = 0; index < 24; index += 1) {
+        await module.listMilitaryFlights(ctx, {
+          swLat: 30,
+          swLon: -170 + index * 10,
+          neLat: 31,
+          neLon: -169 + index * 10,
+          operator: `sweep-${index}`,
+        });
+      }
+
+      assert.deepEqual(first.flights.map((flight) => flight.id), ['FIRST-CELL']);
+      assert.deepEqual(collisionShaped.flights.map((flight) => flight.id), ['SECOND-CELL']);
+      assert.equal(stableCacheReads, 1, 'unexpired isolate state must bypass repeated stable-snapshot Redis reads');
+      assert.equal(staleRootReads, 1, 'bbox/filter sweeps must share one bbox-independent stale root read');
+      assert.deepEqual([...snapshotWriteKeys], [stableStaleCacheKey], 'public filter text cannot create or collide with stale snapshot keys');
+
+      now += 121_000;
+      const afterExpiry = await module.listMilitaryFlights(ctx, { ...request, operator: 'after-expiry' });
+      assert.deepEqual(afterExpiry.flights.map((flight) => flight.id), ['FIRST-CELL']);
+      assert.equal(stableCacheReads, 2, 'expired isolate state must re-read the shared Redis snapshot');
+      assert.equal(staleRootReads, 1, 'a valid shared Redis snapshot avoids another mutable-root read after local expiry');
+    } finally {
+      cleanup();
+      Date.now = originalNow;
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('deduplicates concurrent stale root reads across different bbox cache misses', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    module._resetStaleNegativeCacheForTests();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let releaseStaleRoot;
+    const staleRootGate = new Promise((resolveGate) => { releaseStaleRoot = resolveGate; });
+    let staleRootReads = 0;
+    let snapshotWrites = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === 'military:flights:v1') throw new Error('redis timeout');
+        if (key === 'military:flights:stale:v1') {
+          staleRootReads += 1;
+          await staleRootGate;
+          return jsonResponse({
+            result: JSON.stringify({
+              coverage: 'global',
+              flights: [
+                { id: 'first-cell', callsign: 'RCH801', lat: 10.5, lon: 10.5 },
+                { id: 'second-cell', callsign: 'RCH802', lat: 20.5, lon: 10.5 },
+              ],
+            }),
+          });
+        }
+        return jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) {
+        const { key } = parseSetRequest(url, init);
+        if (key === stableStaleCacheKey) snapshotWrites += 1;
+        return jsonResponse({ result: 'OK' });
+      }
+      if (raw.includes('/opensky')) throw new Error('OpenSky must stay closed on a live Redis error');
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
+      const firstPromise = module.listMilitaryFlights(ctx, request);
+      const secondPromise = module.listMilitaryFlights(ctx, seededRequest);
+      await new Promise((resolveTick) => setImmediate(resolveTick));
+      const readsBeforeRelease = staleRootReads;
+      releaseStaleRoot();
+      const [first, second] = await Promise.all([firstPromise, secondPromise]);
+
+      assert.equal(readsBeforeRelease, 1, 'different bbox callers must join one in-flight stale-root read');
+      assert.equal(staleRootReads, 1);
+      assert.equal(snapshotWrites, 1);
+      assert.deepEqual(first.flights.map((flight) => flight.id), ['FIRST-CELL']);
+      assert.deepEqual(second.flights.map((flight) => flight.id), ['SECOND-CELL']);
+    } finally {
+      cleanup();
+      releaseStaleRoot?.();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('rejects a malformed shared stale snapshot entry and rebuilds it from the root', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    module._resetStaleNegativeCacheForTests();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let stableCacheReads = 0;
+    let staleRootReads = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === stableStaleCacheKey) {
+          stableCacheReads += 1;
+          return jsonResponse({
+            result: JSON.stringify({ status: 'hit', result: { flights: 'not-an-array' }, coverage: 'global' }),
+          });
+        }
+        if (key === 'military:flights:v1') throw new Error('redis timeout');
+        if (key === 'military:flights:stale:v1') {
+          staleRootReads += 1;
+          return jsonResponse({
+            result: JSON.stringify({
+              coverage: 'global',
+              flights: [{ id: 'rebuilt', callsign: 'RCH901', lat: 10.5, lon: 10.5 }],
+            }),
+          });
+        }
+        return jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (raw.includes('/opensky')) throw new Error('OpenSky must stay closed on a live Redis error');
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.listMilitaryFlights(
+        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+        request,
+      );
+      assert.equal(stableCacheReads, 1);
+      assert.equal(staleRootReads, 1, 'malformed cached entries must not block root-snapshot recovery');
+      assert.deepEqual(result.flights.map((flight) => flight.id), ['REBUILT']);
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('serves available regional stale rows to a global request after a live Redis error', async () => {
     for (const coverage of [undefined, 'regional']) {
       const { module, cleanup } = await importListMilitaryFlights();
       module._resetStaleNegativeCacheForTests();
@@ -2614,7 +2832,10 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
           if (key === 'military:flights:stale:v1') {
             return jsonResponse({
               result: JSON.stringify({
-                flights: [{ id: 'regional-stale', callsign: 'RCH777', lat: 40.5, lon: -99.5 }],
+                flights: [
+                  { id: 'regional-stale', callsign: 'RCH777', lat: 20.5, lon: 10.5 },
+                  { id: 'outside-world', callsign: 'RCH778', lat: 91, lon: 10.5 },
+                ],
                 ...(coverage ? { coverage } : {}),
                 fetchedAt: Date.now(),
               }),
@@ -2631,15 +2852,25 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       };
 
       try {
+        const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
         const result = await module.listMilitaryFlights(
-          { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+          ctx,
           { swLat: -90, swLon: -180, neLat: 90, neLon: 180 },
         );
-        assert.equal(openskyCalls, 0, `${coverage ?? 'unstamped'} stale coverage must fail closed`);
+        const uncovered = await module.listMilitaryFlights(
+          ctx,
+          americasRequest,
+        );
         assert.deepEqual(
-          result,
+          uncovered,
           { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } },
-          `${coverage ?? 'unstamped'} stale coverage is not authoritative for a global request`,
+          `${coverage ?? 'unstamped'} regional stale data must stay fail-closed for a narrow uncovered viewport`,
+        );
+        assert.equal(openskyCalls, 0, `${coverage ?? 'unstamped'} stale recovery must not open a provider call`);
+        assert.deepEqual(
+          result.flights.map((flight) => flight.id),
+          ['REGIONAL-STALE'],
+          `${coverage ?? 'unstamped'} regional rows inside the real global bbox must survive without admitting invalid coordinates`,
         );
       } finally {
         cleanup();
@@ -2649,7 +2880,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     }
   });
 
-  it('rejects stale snapshots that do not cover a global request after non-throw recovery failure', async () => {
+  it('serves available regional stale rows to a global request after non-throw recovery failure', async () => {
     for (const coverage of [undefined, 'regional']) {
       const { module, cleanup } = await importListMilitaryFlights();
       module._resetStaleNegativeCacheForTests();
@@ -2672,7 +2903,10 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
           if (key === 'military:flights:stale:v1') {
             return jsonResponse({
               result: JSON.stringify({
-                flights: [{ id: 'regional-stale', callsign: 'RCH777', lat: 40.5, lon: -99.5 }],
+                flights: [
+                  { id: 'regional-stale', callsign: 'RCH777', lat: 20.5, lon: 10.5 },
+                  { id: 'outside-world', callsign: 'RCH778', lat: 91, lon: 10.5 },
+                ],
                 ...(coverage ? { coverage } : {}),
                 fetchedAt: Date.now(),
               }),
@@ -2695,9 +2929,9 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
         );
         assert.equal(openskyCalls, 1, 'a live miss must attempt one bounded provider recovery');
         assert.deepEqual(
-          result,
-          { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } },
-          `${coverage ?? 'unstamped'} stale coverage is not authoritative for a global request`,
+          result.flights.map((flight) => flight.id),
+          ['REGIONAL-STALE'],
+          `${coverage ?? 'unstamped'} regional fallback must keep the global map useful after provider recovery fails`,
         );
       } finally {
         cleanup();
@@ -2770,7 +3004,10 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     globalThis.fetch = async (url) => {
       recoveryUrl = new URL(String(url));
       return jsonResponse({
-        states: [['north-america', 'RCH401', null, null, null, -99.5, 40.5, 10000, false, 250, 90, 5]],
+        states: [
+          ['north-america', 'RCH401', null, null, null, -99.5, 40.5, 10000, false, 250, 90, 5],
+          ['outside-world', 'RCH402', null, null, null, 10.5, 91, 10000, false, 250, 90, 5],
+        ],
       });
     };
 
@@ -2783,6 +3020,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       });
 
       assert.deepEqual(result.flights.map((flight) => flight.id), ['NORTH-AMERICA']);
+      assert.deepEqual(result.pagination, { nextCursor: '', totalCount: 1 });
       assert.equal(recoveryUrl?.searchParams.get('lamin'), '-90');
       assert.equal(recoveryUrl?.searchParams.get('lamax'), '90');
       assert.equal(recoveryUrl?.searchParams.get('lomin'), '-180');


### PR DESCRIPTION
## Summary

Military-flight degraded recovery can no longer grow a warm Edge isolate by retaining one full global snapshot per public bbox/filter combination. All requests now share one fixed stable-snapshot key, one bounded local entry, and one in-flight promise while exact bbox filtering and pagination remain request-specific.

When live data and provider recovery are unavailable, the exact full-world dashboard request now keeps useful rows from a regional or unstamped last-good snapshot instead of blanking the entire map. Narrow requests outside that declared coverage still fail closed, and the final server bbox filter rejects coordinates outside the legal world.

## Finding disposition

| Finding | Disposition |
|---|---|
| #24 | Confirmed and fixed: the two unbounded module-level Maps are replaced by one local entry and one in-flight promise. |
| #25 | Confirmed with narrower wording and fixed: live regional data still attempts bounded provider recovery; only the failed-recovery path was blanking the global dashboard. Exact full-world fallback now preserves regional rows, while narrow uncovered requests remain empty. |
| #26 | Confirmed and fixed: stale snapshots use `military:flights:stable-stale:v1`, so free-form filter text cannot collide with a derived `:stale` key. |
| #27 | Confirmed in part and fixed at the amplification boundary: the bbox-independent snapshot is no longer fanned out across bbox/filter keys. A cold total-Redis outage can still incur bounded serial reads, but the shared 30-second miss state suppresses repeats per isolate. |
| #28-30 | Confirmed test gaps: in-flight deduplication, local hit/expiry, and malformed stable-entry rejection now have regressions. |
| #31 | Confirmed test gap: the real handler now proves global provider results are bbox-filtered before pagination, including an excluded out-of-world row. |
| #32 | Refuted as a code defect: the conversions were already correct and test-locked. This PR records them explicitly below. |

The existing OpenSky conversions remain unchanged and covered: altitude uses meters to feet (`10,000 -> 32,808`), speed uses metres/second to knots (`250 -> 486`), and vertical rate uses metres/second to feet/minute (`5 -> 984`).

Related: #6261

## Validation

- `./node_modules/.bin/tsx --test tests/redis-caching.test.mjs tests/military-flight-pagination.test.mts` - 78 passed after rebasing onto current `origin/main`.
- `npm run typecheck` - passed.
- `npm run typecheck:api` - passed, including the Convex string-call audit.
- `npm run lint` - passed; 35 existing warnings and 9 infos remain outside this diff.
- `npm run test:data` exercised the full data suite. Its only failures were 16 pre-push-hook fixture cases blocked by the filesystem sandbox's macOS `mktemp` path; the isolated suite passed 16/16 outside the sandbox.
- The actual push's mandatory pre-push gate passed, including Unicode/boundary/Sentry/rate-limit checks, edge bundling, 107 server-handler tests, and 70 changed-file tests.

## Post-Deploy Monitoring & Validation

For the first 24 hours after deployment, the release owner should:

- Search Vercel function logs for `military live seed read failed`, Redis failures involving `military:flights:stable-stale:v1`, timeouts, and isolate OOM/restart signals.
- Compare military-flight function p95/p99 duration and memory with the preceding 24-hour baseline; inspect Upstash command volume and verify stable-snapshot key cardinality remains one per deployment prefix rather than growing with bbox/filter traffic.
- Check `/api/health?compact=1` military freshness alongside dashboard flight counts and geographic distribution. Healthy behavior is normal build volume/latency, no per-bbox stale-key growth, regional rows retained during a degraded global request, and narrow uncovered requests remaining empty.
- Roll back this commit if memory or latency rises materially, Redis read/write volume spikes, cursor pages become inconsistent, or any row outside the requested bbox reaches the response. Reverting restores the prior strict regional-coverage gate while investigation continues.

Owner: release/on-call maintainer. Observation window: 24 hours after production deployment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
