### PR TITLE
fix(military): unbreak main by seeding stale-snapshot fixtures through hexCode

### DIFF
--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -2638,8 +2638,8 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
             result: JSON.stringify({
               coverage: 'global',
               flights: [
-                { id: 'first-cell', callsign: 'RCH701', lat: 10.5, lon: 10.5 },
-                { id: 'second-cell', callsign: 'RCH702', lat: 20.5, lon: 10.5 },
+                { hexCode: 'first-cell', callsign: 'RCH701', lat: 10.5, lon: 10.5 },
+                { hexCode: 'second-cell', callsign: 'RCH702', lat: 20.5, lon: 10.5 },
               ],
             }),
           });
@@ -2723,8 +2723,8 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
             result: JSON.stringify({
               coverage: 'global',
               flights: [
-                { id: 'first-cell', callsign: 'RCH801', lat: 10.5, lon: 10.5 },
-                { id: 'second-cell', callsign: 'RCH802', lat: 20.5, lon: 10.5 },
+                { hexCode: 'first-cell', callsign: 'RCH801', lat: 10.5, lon: 10.5 },
+                { hexCode: 'second-cell', callsign: 'RCH802', lat: 20.5, lon: 10.5 },
               ],
             }),
           });
@@ -2793,7 +2793,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
           return jsonResponse({
             result: JSON.stringify({
               coverage: 'global',
-              flights: [{ id: 'rebuilt', callsign: 'RCH901', lat: 10.5, lon: 10.5 }],
+              flights: [{ hexCode: 'rebuilt', callsign: 'RCH901', lat: 10.5, lon: 10.5 }],
             }),
           });
         }
@@ -2843,8 +2843,8 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
             return jsonResponse({
               result: JSON.stringify({
                 flights: [
-                  { id: 'regional-stale', callsign: 'RCH777', lat: 20.5, lon: 10.5 },
-                  { id: 'outside-world', callsign: 'RCH778', lat: 91, lon: 10.5 },
+                  { hexCode: 'regional-stale', callsign: 'RCH777', lat: 20.5, lon: 10.5 },
+                  { hexCode: 'outside-world', callsign: 'RCH778', lat: 91, lon: 10.5 },
                 ],
                 ...(coverage ? { coverage } : {}),
                 fetchedAt: Date.now(),
@@ -2914,8 +2914,8 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
             return jsonResponse({
               result: JSON.stringify({
                 flights: [
-                  { id: 'regional-stale', callsign: 'RCH777', lat: 20.5, lon: 10.5 },
-                  { id: 'outside-world', callsign: 'RCH778', lat: 91, lon: 10.5 },
+                  { hexCode: 'regional-stale', callsign: 'RCH777', lat: 20.5, lon: 10.5 },
+                  { hexCode: 'outside-world', callsign: 'RCH778', lat: 91, lon: 10.5 },
                 ],
                 ...(coverage ? { coverage } : {}),
                 fetchedAt: Date.now(),


### PR DESCRIPTION
main's Test workflow has been red since #6287 landed, so every open PR inherits a failing `unit` job through its merge commit. Five tests in the `military flights bbox behavior` block fail on a flight-ID casing mismatch. No production code is involved — the fixtures were seeding the wrong field.

| main SHA | Test workflow |
|---|---|
| `b724b2470` (before #6287) | success |
| `19956a8d3` (#6287) | **failure** |
| `9d6d62a94` (tip) | **failure** |

## What was wrong

The new tests seed pre-shaped snapshot rows as `{ id: 'first-cell', ... }`. The handler resolves the published ID as:

```ts
const icao = (f.hexCode || f.id || '').toUpperCase();
// ...
id: (f.id || icao).trim(),
```

A present `id` passes through verbatim, so the row stays `'first-cell'` while the assertion expects `'FIRST-CELL'`.

The uppercase expectation was reasonable — the sibling tests in the same file assert `'OUTSIDE-REGION'`, `'NORTH-AMERICA'`, `'FIRST'` and pass. But those exercise a **different path**: they feed raw OpenSky `states` arrays, whose `icao24` is upper-cased on the way in. The expectation was carried across two code paths that normalize differently.

## The fix

Seed `hexCode` rather than `id` in the five affected fixtures, which puts them on the normalizing path the assertions were written for. The existing expectations hold unchanged and the uppercase behavior stays covered.

The alternative — relaxing the assertions to the lowercase values the passthrough actually returns — is a smaller diff, but it would leave that normalization untested. Nine lines changed, all fixtures.

## Validation

Run against the merge base, both directions:

- fixtures as merged: **65/70**, the 5 known failures
- with this change: **70/70**

Confirmed the fix is load-bearing by stashing it and re-running — the 5 failures return, so the fixtures are not trivially satisfying the assertion.

Related: #6287

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
