### PR TITLE
fix(health): stop a producer fault from masking a vanished data key (#6263)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1464,20 +1464,21 @@ function classifyKey(name, redisKey, opts, ctx) {
   // arms so the missing-data branch below can weigh them against the absence
   // verdict instead of being pre-empted by them (#6263).
   //
-  // Left null for an unconfigured adapter, which by the NOT_CONFIGURED rule
-  // below has nothing to be degraded ABOUT — so it also publishes no cause.
+  // Skipped entirely for an unconfigured adapter, which by the NOT_CONFIGURED
+  // rule below has nothing to be degraded ABOUT — so it also publishes no cause.
   let fault = null;
-  if (sourceUnavailable) fault = null;
-  else if (sourceBlocked && name !== 'crossStraitActivityJapanMod') {
-    // Keep the fleet-wide escape hatch narrow: only the Japan MOD adapter has
-    // a reviewed-data contract and explicit two-path proof for this state.
-    fault = 'SEED_ERROR';
+  if (!sourceUnavailable) {
+    if (sourceBlocked && name !== 'crossStraitActivityJapanMod') {
+      // Keep the fleet-wide escape hatch narrow: only the Japan MOD adapter has
+      // a reviewed-data contract and explicit two-path proof for this state.
+      fault = 'SEED_ERROR';
+    }
+    else if (sourceBlocked && hasData && records > 0 && seedStale !== true) fault = 'SOURCE_BLOCKED';
+    // A producer-failure warning describes degraded-BUT-SERVING — the LKG is
+    // still on the page while generation retries.
+    else if (synthesisFailure?.warning) fault = 'SEED_ERROR';
+    else if (seedError) fault = 'SEED_ERROR';
   }
-  else if (sourceBlocked && hasData && records > 0 && seedStale !== true) fault = 'SOURCE_BLOCKED';
-  // A producer-failure warning describes degraded-BUT-SERVING — the LKG is
-  // still on the page while generation retries.
-  else if (synthesisFailure?.warning) fault = 'SEED_ERROR';
-  else if (seedError) fault = 'SEED_ERROR';
 
   let status;
   // Precedes every fault branch: an adapter this deployment never configured has

--- a/api/health.js
+++ b/api/health.js
@@ -1494,7 +1494,21 @@ function classifyKey(name, redisKey, opts, ctx) {
     // stopped is simultaneously "faulting" and "serving nothing".
     let absent;
     if (cascadeCovered) absent = 'OK_CASCADE';
-    else if (MISSING_DATA_IS_FAILURE_KEYS.has(name) && hasMeta && seedStale !== true) absent = 'EMPTY';
+    // `seedStale !== true` buys the pre-first-publish grace: before the
+    // producer's first run the payload is absent through no fault, and every
+    // key in this set is also in EMPTY_DATA_OK_KEYS, so the fallthrough reports
+    // STALE_SEED (warn) instead of a false-critical EMPTY.
+    //
+    // A REPORTED FAULT revokes that grace, because it is proof the producer did
+    // run. Without the `|| fault` clause this arm reads a fault as aging and
+    // hands the key to the EMPTY_DATA_OK arm, whose STALE_SEED merely TIES the
+    // fault — so the tie-break returns SEED_ERROR and the key reports warn.
+    // That is #6263's own headline case surviving the fix: readSeedMeta
+    // SYNTHESIZES `seedStale: true` on the `status:'error'` return as a fault
+    // marker rather than measuring it, so all eight of these keys kept the old
+    // warn on that path while the sibling `sourceState` path (where staleness
+    // IS measured) correctly reported EMPTY. One physical state, two verdicts.
+    else if (MISSING_DATA_IS_FAILURE_KEYS.has(name) && hasMeta && (seedStale !== true || fault)) absent = 'EMPTY';
     else if (EMPTY_DATA_OK_KEYS.has(name)) absent = seedStale === true ? 'STALE_SEED' : 'OK';
     else if (isOnDemand) absent = 'EMPTY_ON_DEMAND';
     // Deliberately the ONLY branch rollout softening touches: an absent data

--- a/api/health.js
+++ b/api/health.js
@@ -1458,6 +1458,27 @@ function classifyKey(name, redisKey, opts, ctx) {
   const records = hasData ? (metaCount ?? 1) : 0;
   const cascadeCovered = isCascadeCovered(name, hasData, keyStrens, keyErrors);
 
+  // Producer-fault candidates, in precedence order among themselves. Each says
+  // WHY the producer (or its upstream) is unhappy; none of them says whether
+  // anything is actually being SERVED. Resolved up front rather than as if/else
+  // arms so the missing-data branch below can weigh them against the absence
+  // verdict instead of being pre-empted by them (#6263).
+  //
+  // Left null for an unconfigured adapter, which by the NOT_CONFIGURED rule
+  // below has nothing to be degraded ABOUT — so it also publishes no cause.
+  let fault = null;
+  if (sourceUnavailable) fault = null;
+  else if (sourceBlocked && name !== 'crossStraitActivityJapanMod') {
+    // Keep the fleet-wide escape hatch narrow: only the Japan MOD adapter has
+    // a reviewed-data contract and explicit two-path proof for this state.
+    fault = 'SEED_ERROR';
+  }
+  else if (sourceBlocked && hasData && records > 0 && seedStale !== true) fault = 'SOURCE_BLOCKED';
+  // A producer-failure warning describes degraded-BUT-SERVING — the LKG is
+  // still on the page while generation retries.
+  else if (synthesisFailure?.warning) fault = 'SEED_ERROR';
+  else if (seedError) fault = 'SEED_ERROR';
+
   let status;
   // Precedes every fault branch: an adapter this deployment never configured has
   // nothing to be stale, empty, or degraded ABOUT. The producer still writes the
@@ -1465,36 +1486,46 @@ function classifyKey(name, redisKey, opts, ctx) {
   // the moment the credential lands the next run reports sourceState 'ok' and this
   // flips to OK on its own — no health-config change needed.
   if (sourceUnavailable) status = 'NOT_CONFIGURED';
-  else if (sourceBlocked && name !== 'crossStraitActivityJapanMod') {
-    // Keep the fleet-wide escape hatch narrow: only the Japan MOD adapter has
-    // a reviewed-data contract and explicit two-path proof for this state.
-    status = 'SEED_ERROR';
-  }
-  else if (sourceBlocked && hasData && records > 0 && seedStale !== true) status = 'SOURCE_BLOCKED';
-  // `hasData` guard: a producer-failure warning describes degraded-BUT-SERVING
-  // — the LKG is still on the page while generation retries. When the data key
-  // is gone there is nothing being served, and the absence verdict below
-  // (EMPTY/crit) is both stronger and more accurate. Without this guard the
-  // 7-day seed-meta outlives the shorter-lived data key, so a producer that
-  // failed once and then stopped reports warn instead of crit for the rest of
-  // the week — the exact softening the ON_DEMAND_KEYS policy block above was
-  // written to prevent for marketImplications.
-  else if (synthesisFailure?.warning && hasData) status = 'SEED_ERROR';
-  else if (seedError) status = 'SEED_ERROR';
   else if (!hasData) {
-    if (cascadeCovered) status = 'OK_CASCADE';
-    else if (MISSING_DATA_IS_FAILURE_KEYS.has(name) && hasMeta && seedStale !== true) status = 'EMPTY';
-    else if (EMPTY_DATA_OK_KEYS.has(name)) status = seedStale === true ? 'STALE_SEED' : 'OK';
-    else if (isOnDemand) status = 'EMPTY_ON_DEMAND';
+    // The absence verdict, decided on its own merits and independently of any
+    // fault above. Note the two live SIDE BY SIDE here: seed-meta outlives its
+    // data key (7 days vs. hours), so a producer that failed once and then
+    // stopped is simultaneously "faulting" and "serving nothing".
+    let absent;
+    if (cascadeCovered) absent = 'OK_CASCADE';
+    else if (MISSING_DATA_IS_FAILURE_KEYS.has(name) && hasMeta && seedStale !== true) absent = 'EMPTY';
+    else if (EMPTY_DATA_OK_KEYS.has(name)) absent = seedStale === true ? 'STALE_SEED' : 'OK';
+    else if (isOnDemand) absent = 'EMPTY_ON_DEMAND';
     // Deliberately the ONLY branch rollout softening touches: an absent data
     // key is the one state that "the producer has not run since this schema
     // deployed" actually explains. Once the key exists the producer HAS run,
     // and every downstream verdict (EMPTY_DATA, COVERAGE_DEGRADED,
     // COVERAGE_PARTIAL, STALE_SEED) describes what it produced — softening any
     // of those would hide a real first-run failure behind the rollout window.
-    else if (isRolloutPending) status = 'ROLLOUT_PENDING';
-    else status = 'EMPTY';
-  } else if (records === 0) {
+    else if (isRolloutPending) absent = 'ROLLOUT_PENDING';
+    else absent = 'EMPTY';
+
+    // The stronger of the two verdicts wins; ties go to the fault, which is the
+    // only one of the pair that carries a cause (`errorCode`,
+    // `lastSynthesisFailureCode`).
+    //
+    // Both directions matter, which is why this is NOT the one-word `&& hasData`
+    // guard the fault arms invite:
+    //   - absence is CRIT (plain EMPTY): a warn must never mask a blank panel.
+    //     A producer that errored once and then stopped otherwise reports warn
+    //     for the seed-meta's full 7-day life.
+    //   - absence is SOFTER (OK_CASCADE / OK / STALE_SEED / EMPTY_ON_DEMAND /
+    //     ROLLOUT_PENDING): the fault holds. Four key classes land here, and a
+    //     bare guard would silence or generify every one of them — most sharply
+    //     EMPTY_DATA_OK_KEYS, whose absence resolves to plain OK whenever the
+    //     fault arrived via `sourceState` (which leaves seedStale false). See
+    //     the forecastFunnel entry in that set, which documents its reliance on
+    //     a collapsed funnel surfacing as SEED_ERROR.
+    status = fault && statusSeverityRank(absent) <= statusSeverityRank(fault)
+      ? fault
+      : absent;
+  } else if (fault) status = fault;
+  else if (records === 0) {
     // hasData is true in this branch, so cascade can never apply (isCascadeCovered
     // short-circuits when hasData=true). Cascade only shields wholly absent keys.
     if (ZERO_RECORD_DATA_OK_KEYS.has(name)) status = seedStale === true ? 'STALE_SEED' : 'OK';
@@ -1591,7 +1622,12 @@ function classifyKey(name, redisKey, opts, ctx) {
   if (seedCfg?.minPoolCounts) entry.minPoolCounts = seedCfg.minPoolCounts;
   if (poolCounts) entry.poolCounts = poolCounts;
   if (coverage || seedCfg?.requireCoverage) entry.coverage = coverage;
-  if (status === 'SEED_ERROR' && errorCode) entry.errorCode = errorCode;
+  // Emitted whenever the producer recorded a cause, not only when the fault
+  // verdict WON. When a missing data key outranks the fault (#6263) the status
+  // becomes EMPTY, and gating the code on SEED_ERROR would trade the operator's
+  // "why" for the severity bump — leaving a bare crit whose explanation is
+  // sitting unread in seed-meta.
+  if (fault === 'SEED_ERROR' && errorCode) entry.errorCode = errorCode;
   // Surface content-age fields when seeder opted in (presence of
   // meta.maxContentAgeMin). Operators can distinguish "stale content" from
   // "stale seeder run" at a glance.
@@ -1616,6 +1652,12 @@ function classifyKey(name, redisKey, opts, ctx) {
     if (synthesisFailure.synthesisFailureAgeMin != null && synthesisFailure.consecutiveFailures > 0) {
       entry.synthesisFailureAgeMin = synthesisFailure.synthesisFailureAgeMin;
     }
+    // Ungated, unlike `errorCode` above: this one rides with the rest of the
+    // synthesis diagnostics, which are all published whenever the producer
+    // recorded them regardless of the verdict. Gating only the code while
+    // `consecutiveFailures` and `lastAttemptAt` publish freely would be the
+    // odd one out — and the whole point of those fields is to describe the run
+    // even when the status describes a healthy served payload.
     if (synthesisFailure.lastSynthesisFailureCode) {
       entry.lastSynthesisFailureCode = synthesisFailure.lastSynthesisFailureCode;
     }
@@ -1659,6 +1701,20 @@ const STATUS_COUNTS = {
   EMPTY: 'crit',
   EMPTY_DATA: 'crit',
 };
+
+// Orders the buckets above so classifyKey can compare two candidate verdicts
+// rather than hard-coding which statuses outrank which. Reading severity from
+// STATUS_COUNTS keeps the two in step: a status registered there becomes
+// comparable here for free.
+const STATUS_SEVERITY_RANK = { ok: 0, warn: 1, crit: 2 };
+
+// Unregistered statuses fall back to 'warn', exactly as the summary does with
+// `STATUS_COUNTS[status] ?? 'warn'`. Without the fallback an unregistered
+// status would rank `undefined`, which compares false against every other rank
+// — so it would silently LOSE every comparison rather than fail closed.
+function statusSeverityRank(status) {
+  return STATUS_SEVERITY_RANK[STATUS_COUNTS[status] ?? 'warn'];
+}
 
 function isValidChinaCoverageSummary(candidate) {
   if (

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -99,6 +99,17 @@ const SEED_DOMAINS = {
   'market:sectors':           { key: 'seed-meta:market:sectors',           intervalMin: 15 },
   'aviation:faa':             { key: 'seed-meta:aviation:faa',             intervalMin: 45 },
   'news:insights':            { key: 'seed-meta:news:insights',            intervalMin: 15 },
+  // #6263: the sibling of news:insights above, and registered on the same
+  // terms. Hourly tail LLM stage in seed-forecasts; intervalMin*2 = 120min,
+  // the api/health.js marketImplications budget. Both keys also carry a
+  // `synthesisFailure` contract in api/health.js that escalates on consecutive
+  // misses — this endpoint models neither key's streak, so within the 120min
+  // window it reports `ok` where /api/health may already report SEED_ERROR.
+  // That is the same coarse-vs-detailed split news:insights has always had,
+  // not a new divergence: the producer holds `fetchedAt` at the vintage it is
+  // still serving, so a stage that stops entirely still ages into `stale` here
+  // on exactly the budget above.
+  'intelligence:market-implications': { key: 'seed-meta:intelligence:market-implications', intervalMin: 60 },
   'positive-events:geo':      { key: 'seed-meta:positive-events:geo',      intervalMin: 30 },
   'intelligence:risk-scores': { key: 'seed-meta:intelligence:risk-scores', intervalMin: 15 }, // CII warm-ping every 8min; intervalMin*2 = 30min, aligned with api/health.js riskScores.
   'conflict:iran-events':     { key: 'seed-meta:conflict:iran-events',     intervalMin: 5040 },

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -136,10 +136,14 @@ records, and records the miss as diagnostics:
 <Warning>
 On these keys, `records` and `status` describe **what is being served**, not
 how the last run went. A key reporting `status: "OK"` with `records: 5` and
-`consecutiveFailures: 2` means five cards are on the page and the last two
-attempts to refresh them failed. Read the diagnostics above for run outcomes;
-reading `status` alone will tell you the panel is fine, which is true, and
-nothing about the producer behind it.
+`consecutiveFailures: 1` means five cards are on the page and the last attempt
+to refresh them failed. Read the diagnostics above for run outcomes; reading
+`status` alone will tell you the panel is fine, which is true, and nothing
+about the producer behind it.
+
+That independence has a ceiling. Once the streak reaches the key's
+`warnAfterConsecutive` — 2 for both keys today — the status itself becomes
+`SEED_ERROR`, so a streak of 1 is the largest one that can coexist with `OK`.
 </Warning>
 
 Each such key declares thresholds sized to its own cadence, and health reports
@@ -177,9 +181,11 @@ the pair that carries a cause. Concretely:
   none of which should be able to silence a fault the producer actually
   reported.
 
-`errorCode` and `lastSynthesisFailureCode` are published whenever the producer
-recorded one, including when the missing-data verdict wins. An escalation to
-crit never costs you the reason.
+`errorCode` and `lastSynthesisFailureCode` are published whenever a fault of the
+`SEED_ERROR` kind fired and the producer recorded a code — including when the
+missing-data verdict outranks that fault and the status ends up `EMPTY`. An
+escalation to crit never costs you the reason. (`SOURCE_BLOCKED` publishes
+neither; its cause is the status itself.)
 
 ### China Coverage Projection
 

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -112,7 +112,7 @@ Keys are grouped into three tiers that determine alert severity:
 | `SEED_ERROR` | Warn | `seed-meta` reports `status: "error"` from the last seed run, **or** a producer that serves last-known-good has failed often enough to cross its declared failure contract (see below) |
 | `REDIS_PARTIAL` | Warn | A single per-command Redis error on this key's STRLEN/GET (not a full outage) |
 | `EMPTY_ON_DEMAND` | Warn | On-demand key has no data yet (expected until first request); counted in `summary.onDemandWarn` |
-| `EMPTY` | Crit | Bootstrap or seeded standalone key has no data |
+| `EMPTY` | Crit | Bootstrap or seeded standalone key has no data. Outranks any concurrent producer fault, which would otherwise report the softer `SEED_ERROR` (see below) |
 | `EMPTY_DATA` | Crit | Key exists but contains zero records (and 0 is not a valid state for it) |
 
 ### Producers That Serve Last-Known-Good
@@ -129,20 +129,57 @@ records, and records the miss as diagnostics:
 | `consecutiveFailures` | Misses since the last successful publish; reset to 0 on success |
 | `lastAttemptAt` | When the producer last tried, successfully or not |
 | `lastSuccessAt` | When it last published |
+| `synthesisFailureAgeMin` | Minutes since `lastAttemptAt`. Emitted only while a streak is open, so it reads as "how long this failure has gone without a follow-up attempt" — a growing value means the stage has stopped running, not that it is retrying |
 | `servedGeneratedAt` | Vintage of the payload currently being served |
 | `lastSynthesisFailureCode` | Why the last attempt failed, from a closed per-key vocabulary |
+
+<Warning>
+On these keys, `records` and `status` describe **what is being served**, not
+how the last run went. A key reporting `status: "OK"` with `records: 5` and
+`consecutiveFailures: 2` means five cards are on the page and the last two
+attempts to refresh them failed. Read the diagnostics above for run outcomes;
+reading `status` alone will tell you the panel is fine, which is true, and
+nothing about the producer behind it.
+</Warning>
 
 Each such key declares thresholds sized to its own cadence, and health reports
 `SEED_ERROR` once either is crossed: `warnAfterConsecutive` misses in a row, or
 `warnAfterAgeMin` since the last attempt with a miss on record. Because
-`fetchedAt` is **not** advanced by a miss. A producer that stops after recording
-a miss therefore reports `SEED_ERROR` while retained data is still available,
-then escalates to `EMPTY` (crit) once the canonical data key disappears. A miss
-with nothing left to serve skips all of this and writes `status: "error"`
-immediately, and a failure streak never outranks a missing data key, which is
-still `EMPTY` (crit).
+`fetchedAt` is **not** advanced by a miss, the ordinary `maxStaleMin` age gate
+keeps escalating independently — a producer that stops entirely still ages into
+`STALE_SEED`. A producer that stops after recording a miss therefore reports
+`SEED_ERROR` while retained data is still available. A miss with nothing left to
+serve skips all of this and writes `status: "error"` immediately. What happens
+once the canonical data key itself disappears is not specific to this contract —
+see the fleet-wide rule below.
 
 Two keys use this contract today: `newsInsights` and `marketImplications`.
+
+### Producer Faults vs. Missing Data
+
+`seed-meta` outlives the data key it describes — 7 days against hours for most
+canonical keys — so a producer that faulted once and then stopped leaves health
+holding two true statements at the same time: *the producer is unhappy* and
+*nothing is being served*. Every fault signal is affected, not just the
+last-known-good contract above: `status: "error"`, a non-`ok` `sourceState`, a
+blocked source, and a crossed failure streak.
+
+**The stronger verdict wins, and ties go to the fault** — it is the only one of
+the pair that carries a cause. Concretely:
+
+- A blank key whose absence is critical reports `EMPTY` (crit), never
+  `SEED_ERROR` (warn). Without this rule a vanished homepage panel would report
+  a warning for the seed-meta's full 7-day life.
+- A blank key whose absence is *not* critical keeps `SEED_ERROR`. This covers
+  keys where an empty payload is a valid state (`OK`/`STALE_SEED`), keys
+  covered by a cascade sibling (`OK_CASCADE`), on-demand keys
+  (`EMPTY_ON_DEMAND`), and keys inside a rollout window (`ROLLOUT_PENDING`) —
+  none of which should be able to silence a fault the producer actually
+  reported.
+
+`errorCode` and `lastSynthesisFailureCode` are published whenever the producer
+recorded one, including when the missing-data verdict wins. An escalation to
+crit never costs you the reason.
 
 ### China Coverage Projection
 
@@ -530,7 +567,7 @@ A seed is considered stale when its age exceeds **2x the configured interval**. 
 | Predictions, military flights | 8 | 16 |
 | Market quotes, earthquakes, unrest | 15 | 30 |
 | ETF flows, stablecoins, chokepoints | 30 | 60 |
-| Service statuses, spending, wildfires | 60 | 120 |
+| Service statuses, spending, wildfires, market implications | 60 | 120 |
 | Shipping rates, satellites | 90-120 | 180-240 |
 | GPS jamming, displacement | 360 | 720 |
 | Iran events, UCDP | 210-5040 | 420-10080 |

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -181,11 +181,13 @@ the pair that carries a cause. Concretely:
   none of which should be able to silence a fault the producer actually
   reported.
 
-`errorCode` and `lastSynthesisFailureCode` are published whenever a fault of the
-`SEED_ERROR` kind fired and the producer recorded a code — including when the
-missing-data verdict outranks that fault and the status ends up `EMPTY`. An
-escalation to crit never costs you the reason. (`SOURCE_BLOCKED` publishes
-neither; its cause is the status itself.)
+`errorCode` is published whenever a fault of the `SEED_ERROR` kind fired and the
+producer recorded a code — including when the missing-data verdict outranks that
+fault and the status ends up `EMPTY`. An escalation to crit never costs you the
+reason. (`SOURCE_BLOCKED` publishes no `errorCode`; its cause is the status
+itself.) `lastSynthesisFailureCode` is broader still: like the other
+last-known-good diagnostics above, it is published on every status whenever the
+producer recorded one.
 
 ### China Coverage Projection
 

--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -112,11 +112,11 @@ export function validateAcceptanceBaseline(baseline) {
  *
  * `blocking` fails the gate. `acknowledged` is a known-degraded source with an
  * owner issue, reported but not fatal. `cleared` is a baseline entry that no
- * longer appears in health — reported as a prompt to prune, but deliberately
- * NOT fatal, because several of these sources flap between polls and a
- * clear-on-recovery failure would make the monitor red on exactly the runs that
- * prove things improved. `expiresAt` is the anti-rot mechanism instead: the
- * whole baseline must be re-reviewed on a date, or the gate fails.
+ * longer appears in health at all — reported as a prompt to prune, but
+ * deliberately NOT fatal, because several of these sources flap between polls
+ * and a clear-on-recovery failure would make the monitor red on exactly the
+ * runs that prove things improved. `expiresAt` is the anti-rot mechanism
+ * instead: the whole baseline must be re-reviewed on a date, or the gate fails.
  *
  * The expiry governs SUPPRESSIONS, so a baseline that acknowledges nothing
  * cannot expire — there is no suppression left to outlive its cause, and a
@@ -124,12 +124,23 @@ export function validateAcceptanceBaseline(baseline) {
  * review. That case is reachable: pruning the last recovered entry empties the
  * file, and this repository has already watched a permanently-red monitor hide
  * live drift (#6087).
+ *
+ * `escalated` is the third case, and it exists because the other two are not
+ * exhaustive. Acknowledgment is keyed on `name:status`, so a source that gets
+ * WORSE stops matching its entry exactly like one that recovers — and folding
+ * both into `cleared` told the operator to delete a suppression for a source
+ * that is still broken, in the same run that failed the gate on its new status.
+ * #6263 made that reachable fleet-wide: a faulting key whose data key also
+ * expires now moves SEED_ERROR -> EMPTY. The worse status still lands in
+ * `blocking` (an escalation is never suppressed); this bucket only stops the
+ * report from calling it a recovery.
  */
 export function applyAcceptanceBaseline(problems, baseline, now = Date.now()) {
   validateAcceptanceBaseline(baseline);
   const accepted = new Map(
     baseline.acknowledged.map((entry) => [`${entry.name}:${entry.status}`, entry]),
   );
+  const observedByName = new Map(problems.map((problem) => [problem.name, problem.status]));
   const seen = new Set();
   const blocking = [];
   const acknowledged = [];
@@ -143,11 +154,20 @@ export function applyAcceptanceBaseline(problems, baseline, now = Date.now()) {
       blocking.push(problem);
     }
   }
-  const cleared = baseline.acknowledged
-    .filter((entry) => !seen.has(`${entry.name}:${entry.status}`))
+  const unmatched = baseline.acknowledged.filter((entry) => !seen.has(`${entry.name}:${entry.status}`));
+  const cleared = unmatched
+    .filter((entry) => !observedByName.has(entry.name))
     .map((entry) => ({ name: entry.name, status: entry.status, issue: entry.issue }));
+  const escalated = unmatched
+    .filter((entry) => observedByName.has(entry.name))
+    .map((entry) => ({
+      name: entry.name,
+      status: entry.status,
+      observedStatus: observedByName.get(entry.name),
+      issue: entry.issue,
+    }));
   const expired = baseline.acknowledged.length > 0 && Date.parse(baseline.expiresAt) < now;
-  return { blocking, acknowledged, cleared, expired, expiresAt: baseline.expiresAt };
+  return { blocking, acknowledged, cleared, escalated, expired, expiresAt: baseline.expiresAt };
 }
 
 function readAcceptanceBaseline() {
@@ -168,11 +188,17 @@ function describeProblem(problem) {
  * list, and no assertion over the pure split functions could have seen it.
  */
 export function formatAcceptanceReport(
-  { blocking, acknowledged, cleared, expired, expiresAt },
+  { blocking, acknowledged, cleared, escalated = [], expired, expiresAt },
   checkedAt,
 ) {
   const info = [
     ...acknowledged.map((problem) => `- acknowledged (#${problem.issue}): ${describeProblem(problem)}`),
+    // Deliberately carries NO pruning advice. The suppression is still live —
+    // its source got worse, not better — and the new status is already in
+    // `blocking` above. Telling an operator to delete the entry here would
+    // retire the owner record for an active fault.
+    ...escalated.map((entry) =>
+      `- escalated (#${entry.issue}): ${entry.name} ${entry.status} -> ${entry.observedStatus}; the baselined status is no longer what this source reports. Re-review the suppression against the worse state before changing it.`),
     ...cleared.map((entry) =>
       `- recovered: ${entry.name}:${entry.status} no longer reported; remove it from scripts/seed-freshness-baseline.json (#${entry.issue}).`),
   ];

--- a/tests/consumer-prices-coverage-rollout.test.mjs
+++ b/tests/consumer-prices-coverage-rollout.test.mjs
@@ -247,6 +247,39 @@ test('deploy-before-cron: absent coverage key inside the window is ROLLOUT_PENDI
   );
 });
 
+test('a rollout-pending key still reports a producer fault it recorded (#6263)', () => {
+  // #6263 made the producer-fault verdict and the absent-data verdict compete
+  // on severity, with ties going to the fault. ROLLOUT_PENDING and SEED_ERROR
+  // are both `warn`, so this is a pure tie — and the whole point of resolving
+  // it toward the fault is that only the fault carries a cause. Softening here
+  // would say "the producer has not run yet" about a producer that ran and
+  // reported failing.
+  const entry = classifyCoverage(US, {
+    now: BEFORE_DEADLINE,
+    metaValues: {
+      [SEED_META[US].key]: {
+        fetchedAt: BEFORE_DEADLINE - 60_000,
+        recordCount: 0,
+        status: 'error',
+        errorCode: 'COVERAGE_PUBLISH_FAILED',
+      },
+    },
+  });
+
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+  assert.equal(
+    entry.errorCode,
+    'COVERAGE_PUBLISH_FAILED',
+    'the cause is the only thing separating this from ROLLOUT_PENDING — it must reach the payload',
+  );
+  assert.equal(
+    entry.rolloutPendingUntil,
+    undefined,
+    'the key is not being excused, so it must not advertise a rollout deadline',
+  );
+});
+
 // #6095 kept ROLLOUT_PENDING soft when the marker read FAILS, deliberately and
 // for a different reason than the content-freshness gate (which fails closed).
 // makeCtx models a clean sweep, so every marker gets an entry and the unknown

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -579,6 +579,27 @@ test('classifyKey: a blocked source with no data escalates like every other faul
 
   assert.equal(blockedAndAbsent('humanitarianSummary').status, 'EMPTY');
   assert.equal(blockedAndAbsent('crossStraitActivityJapanMod').status, 'EMPTY');
+
+  // Both landing on EMPTY proves they AGREE, but not that the blocked fault
+  // still fires at all — a guard that dropped it entirely would produce the
+  // same pair. Pin the other direction on the same key: with data present, the
+  // non-Japan blocked arm still yields its fault.
+  const blockedWithData = classifyKey(
+    'humanitarianSummary',
+    STANDALONE_KEYS.humanitarianSummary,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: { [STANDALONE_KEYS.humanitarianSummary]: 2048 },
+      metaValues: {
+        [SEED_META.humanitarianSummary.key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 4,
+          sourceState: 'blocked',
+        }),
+      },
+    }),
+  );
+  assert.equal(blockedWithData.status, 'SEED_ERROR');
 });
 
 test('classifyKey: a collapsed forecast funnel keeps SEED_ERROR when its payload is absent', () => {
@@ -631,7 +652,24 @@ test('classifyKey: a fresh degraded funnel source is not silently OK when its pa
   );
 
   assert.equal(entry.status, 'SEED_ERROR');
-  assert.notEqual(STATUS_COUNTS[entry.status], 'ok');
+  // The absence verdict this beat, asserted directly: with the fault removed
+  // the very same fixture resolves to a green OK, so the fault is doing all the
+  // work here and a guard that skipped it would ship a silent pass.
+  const withoutFault = classifyKey(
+    'forecastFunnel',
+    STANDALONE_KEYS.forecastFunnel,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: {},
+      metaValues: {
+        [SEED_META.forecastFunnel.key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 0,
+        }),
+      },
+    }),
+  );
+  assert.equal(withoutFault.status, 'OK');
 });
 
 test('classifyKey: cascade coverage does not hide a producer error on the covered key', () => {
@@ -657,6 +695,162 @@ test('classifyKey: cascade coverage does not hide a producer error on the covere
   );
 
   assert.equal(entry.status, 'SEED_ERROR');
+});
+
+test('classifyKey: a compact projection that must always publish is EMPTY when it errors with no payload', () => {
+  // MISSING_DATA_IS_FAILURE_KEYS members publish a canonical payload on every
+  // successful cycle, so a vanished payload is a real publish failure. The set
+  // is also a subset of EMPTY_DATA_OK_KEYS, whose absence verdict is only
+  // STALE_SEED — so if the strict arm is skipped, the fault ties the softer
+  // verdict and wins, and the key reports warn.
+  //
+  // The arm is skipped exactly when `seedStale === true`, and readSeedMeta
+  // SYNTHESIZES that on the `status:'error'` return as a fault marker rather
+  // than measuring it. Reading a fault marker as "the meta aged out" is what
+  // let #6263's own headline case — a `status:'error'` seed-meta over a
+  // vanished panel — survive on all eight of these keys.
+  const entry = classifyKey(
+    'crossStraitActivityBootstrap',
+    STANDALONE_KEYS.crossStraitActivityBootstrap,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: {},
+      metaValues: {
+        [SEED_META.crossStraitActivityBootstrap.key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 0,
+          status: 'error',
+          errorReason: 'publish_failed',
+        }),
+      },
+    }),
+  );
+
+  assert.equal(entry.status, 'EMPTY');
+  assert.equal(STATUS_COUNTS[entry.status], 'crit');
+});
+
+test('classifyKey: both fault paths agree for one physical state on a strict projection', () => {
+  // The parity that finding above turns on. `status:'error'` and a non-ok
+  // `sourceState` are two ways to say "the producer is failing", and
+  // readSeedMeta treats them differently — the first forces seedStale true, the
+  // second measures it. Same key, same absent payload, same fault: the verdict
+  // must not depend on which dialect the producer used.
+  const classifyWith = (meta) => classifyKey(
+    'wildfiresBootstrap',
+    STANDALONE_KEYS.wildfiresBootstrap,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: {},
+      metaValues: {
+        [SEED_META.wildfiresBootstrap.key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 0,
+          ...meta,
+        }),
+      },
+    }),
+  );
+
+  assert.equal(
+    classifyWith({ status: 'error', errorReason: 'publish_failed' }).status,
+    classifyWith({ sourceState: 'error' }).status,
+    'a producer reporting failure via status:error must classify like one reporting it via sourceState',
+  );
+});
+
+test('classifyKey: a strict projection that has never published keeps its STALE_SEED grace', () => {
+  // The other side of the same guard, and the reason it cannot simply be
+  // deleted: before the producer's first run the payload is absent with no
+  // fault recorded, and EMPTY (crit) would be a false alarm on a key that is
+  // merely new. Only a REPORTED fault revokes the grace — absence alone does
+  // not.
+  const entry = classifyKey(
+    'wildfiresBootstrap',
+    STANDALONE_KEYS.wildfiresBootstrap,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: {},
+      metaValues: {
+        [SEED_META.wildfiresBootstrap.key]: JSON.stringify({
+          fetchedAt: NOW - 10_000 * ONE_MIN_MS, // long past maxStaleMin
+          recordCount: 0,
+        }),
+      },
+    }),
+  );
+
+  assert.equal(entry.status, 'STALE_SEED');
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
+test('classifyKey: an unconfigured adapter publishes no fault and no cause', () => {
+  // NOT_CONFIGURED means "this deployment never opted into the adapter", so
+  // there is nothing to be degraded ABOUT — the fault is skipped entirely
+  // rather than merely losing the verdict. Without the `!sourceUnavailable`
+  // guard the fault still fires, and a green NOT_CONFIGURED entry ships
+  // diagnostic codes for a producer this deployment does not run.
+  const entry = classifyKey(
+    'marketImplications',
+    STANDALONE_KEYS.marketImplications,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: { [STANDALONE_KEYS.marketImplications]: 4096 },
+      metaValues: {
+        [SEED_META.marketImplications.key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 5,
+          sourceState: 'unavailable',
+          errorCode: 'PRODUCER_FAILED',
+          lastAttemptAt: NOW - ONE_MIN_MS,
+          lastSuccessAt: NOW - 200 * ONE_MIN_MS,
+          consecutiveFailures: 3,
+          lastSynthesisFailureCode: 'MARKET_IMPLICATIONS_LLM_NO_RESPONSE',
+        }),
+      },
+    }),
+  );
+
+  assert.equal(entry.status, 'NOT_CONFIGURED');
+  assert.equal(STATUS_COUNTS[entry.status], 'ok');
+  assert.equal(Object.hasOwn(entry, 'errorCode'), false, 'an unconfigured adapter has no fault to explain');
+  assert.equal(Object.hasOwn(entry, 'lastSynthesisFailureCode'), false);
+});
+
+test('classifyKey: a fault outranks every served-data verdict it precedes', () => {
+  // The refactor hoisted the fault arms out of the status if/else chain into a
+  // precomputed `fault`, and only the placement of `else if (fault)` keeps them
+  // ahead of the records===0 / staleness / coverage arms. Nothing else pins
+  // that ordering, so a reordering would go unnoticed — most visibly as
+  // EMPTY_DATA, which is what a mis-ordered fault arm produces for the
+  // zero-record case.
+  const withData = (over) => classifyKey(
+    'gdeltIntel',
+    BOOTSTRAP_KEYS.gdeltIntel,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.gdeltIntel]: 4096 },
+      metaValues: {
+        'seed-meta:intelligence:gdelt-intel': JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 5,
+          ...over,
+        }),
+      },
+    }),
+  );
+
+  assert.equal(withData({ status: 'error' }).status, 'SEED_ERROR', 'fault beats a healthy served payload');
+  assert.equal(
+    withData({ status: 'error', recordCount: 0 }).status,
+    'SEED_ERROR',
+    'fault beats EMPTY_DATA — a zero-record payload under a reported fault is the fault, not a separate finding',
+  );
+  assert.equal(
+    withData({ sourceState: 'error', fetchedAt: NOW - 10_000 * ONE_MIN_MS }).status,
+    'SEED_ERROR',
+    'fault beats STALE_SEED',
+  );
 });
 
 test('classifyKey: an on-demand key with an error seed-meta keeps the error verdict', () => {

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -440,6 +440,11 @@ test('classifyKey: a failure streak must not downgrade a vanished panel from EMP
 
   assert.equal(entry.status, 'EMPTY');
   assert.equal(STATUS_COUNTS[entry.status], 'crit', 'an absent homepage panel is a crit, per the ON_DEMAND_KEYS policy block');
+  assert.equal(
+    entry.lastSynthesisFailureCode,
+    'MARKET_IMPLICATIONS_LLM_NO_RESPONSE',
+    'the recorded reason survives the escalation — a bare crit with no cause makes the operator re-read seed-meta by hand',
+  );
 });
 
 test('classifyKey: an insights failure streak likewise cannot mask a vanished LKG', () => {
@@ -477,6 +482,206 @@ test('classifyKey: a market-implications run with nothing servable still errors 
 
   assert.equal(entry.status, 'SEED_ERROR');
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
+// ── Producer fault vs. missing data, fleet-wide (#6263) ──────────────────────
+// The synthesisFailure arm above learned to yield to the absence verdict. The
+// `seedError` and `sourceBlocked` arms sit on the same seam and apply to EVERY
+// SEED_META key, so the rule has to be stated once for all of them: a
+// producer-fault verdict says WHY the producer is unhappy, the absence verdict
+// says WHETHER anything is being served, and when both are true the STRONGER
+// one wins.
+//
+// That is deliberately not the one-word `&& hasData` guard the issue proposed.
+// Four key classes resolve an absent data key to something SOFTER than
+// SEED_ERROR — EMPTY_DATA_OK_KEYS (OK/STALE_SEED), cascade coverage
+// (OK_CASCADE), on-demand (EMPTY_ON_DEMAND) and rollout (ROLLOUT_PENDING) — so
+// a bare guard would demote or silence those instead of escalating them. Each
+// class gets a lock below.
+
+test('classifyKey: an error seed-meta must not downgrade a vanished panel from EMPTY to a warn', () => {
+  // The fleet-wide twin of the synthesisFailure case above. seed-meta holds 7
+  // days, the canonical key 180min, so a producer that errored once and then
+  // stopped leaves a blank homepage panel reporting warn for the rest of the
+  // week.
+  const entry = classifyKey(
+    'marketImplications',
+    STANDALONE_KEYS.marketImplications,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: {}, // canonical key expired -> panel is blank
+      metaValues: {
+        [SEED_META.marketImplications.key]: JSON.stringify({
+          fetchedAt: NOW - 190 * ONE_MIN_MS,
+          recordCount: 0,
+          status: 'error',
+          errorReason: 'llm_no_response',
+          errorCode: 'MARKET_IMPLICATIONS_LLM_NO_RESPONSE',
+        }),
+      },
+    }),
+  );
+
+  assert.equal(entry.status, 'EMPTY');
+  assert.equal(STATUS_COUNTS[entry.status], 'crit');
+  assert.equal(
+    entry.errorCode,
+    'MARKET_IMPLICATIONS_LLM_NO_RESPONSE',
+    'escalating the severity must not cost the operator the cause the producer recorded',
+  );
+});
+
+test('classifyKey: a degraded sourceState likewise cannot mask a vanished panel', () => {
+  // seedError has two producers: `status:'error'` (above) and any non-ok
+  // `sourceState` (here). The second reaches classifyKey with a FRESH
+  // fetchedAt — seedStale stays false — so it is the arm that can hide an
+  // absence behind an otherwise healthy-looking meta.
+  const entry = classifyKey(
+    'marketImplications',
+    STANDALONE_KEYS.marketImplications,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: {},
+      metaValues: {
+        [SEED_META.marketImplications.key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 5,
+          sourceState: 'error',
+        }),
+      },
+    }),
+  );
+
+  assert.equal(entry.status, 'EMPTY');
+  assert.equal(STATUS_COUNTS[entry.status], 'crit');
+});
+
+test('classifyKey: a blocked source with no data escalates like every other fault', () => {
+  // The `sourceBlocked` arm has the same shape and today produces the fleet's
+  // one self-contradiction: crossStraitActivityJapanMod is excluded from it, so
+  // that key ALREADY reports EMPTY for a blocked-and-absent state while every
+  // other key reports SEED_ERROR. One state, two verdicts. Assert both agree.
+  const blockedAndAbsent = (name) => classifyKey(
+    name,
+    STANDALONE_KEYS[name],
+    { allowOnDemand: false },
+    makeCtx({
+      strens: {},
+      metaValues: {
+        [SEED_META[name].key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 0,
+          sourceState: 'blocked',
+        }),
+      },
+    }),
+  );
+
+  assert.equal(blockedAndAbsent('humanitarianSummary').status, 'EMPTY');
+  assert.equal(blockedAndAbsent('crossStraitActivityJapanMod').status, 'EMPTY');
+});
+
+test('classifyKey: a collapsed forecast funnel keeps SEED_ERROR when its payload is absent', () => {
+  // forecastFunnel is in EMPTY_DATA_OK_KEYS, so its absence branch resolves to
+  // OK/STALE_SEED — softer than the fault. api/health.js's own comment on the
+  // set entry states the dependency: "A COLLAPSED funnel still surfaces via
+  // seed-meta status:'error' → SEED_ERROR, which classifyKey checks before this
+  // branch." A bare `&& hasData` guard would demote the collapse to a generic
+  // STALE_SEED and drop the reason.
+  const entry = classifyKey(
+    'forecastFunnel',
+    STANDALONE_KEYS.forecastFunnel,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: {},
+      metaValues: {
+        [SEED_META.forecastFunnel.key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 0,
+          status: 'error',
+          errorReason: 'funnel_collapsed',
+        }),
+      },
+    }),
+  );
+
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
+test('classifyKey: a fresh degraded funnel source is not silently OK when its payload is absent', () => {
+  // The sharpest edge of the same class: `sourceState` degradation leaves
+  // seedStale false, so EMPTY_DATA_OK_KEYS resolves the absence to plain OK. A
+  // bare `&& hasData` guard would turn a reported producer fault into a green
+  // check — the exact softening #6263 exists to remove.
+  const entry = classifyKey(
+    'forecastFunnel',
+    STANDALONE_KEYS.forecastFunnel,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: {},
+      metaValues: {
+        [SEED_META.forecastFunnel.key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 0,
+          sourceState: 'error',
+        }),
+      },
+    }),
+  );
+
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.notEqual(STATUS_COUNTS[entry.status], 'ok');
+});
+
+test('classifyKey: cascade coverage does not hide a producer error on the covered key', () => {
+  // militaryFlights cascades onto militaryFlightsStale. Cascade answers "is the
+  // panel being served from a sibling", which is true here — but the live
+  // producer still reported a fault, and OK_CASCADE would erase it. Absence
+  // resolves to `ok`, softer than the fault, so the fault holds.
+  const entry = classifyKey(
+    'militaryFlights',
+    STANDALONE_KEYS.militaryFlights,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: { [STANDALONE_KEYS.militaryFlightsStale]: 2048 },
+      metaValues: {
+        [SEED_META.militaryFlights.key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 0,
+          status: 'error',
+          errorReason: 'opensky_auth_failed',
+        }),
+      },
+    }),
+  );
+
+  assert.equal(entry.status, 'SEED_ERROR');
+});
+
+test('classifyKey: an on-demand key with an error seed-meta keeps the error verdict', () => {
+  // EMPTY_ON_DEMAND and SEED_ERROR are both warn, so severity alone does not
+  // separate them — the tie goes to the fault, which is the only one of the two
+  // that carries a cause.
+  const entry = classifyKey(
+    'macroSignals',
+    STANDALONE_KEYS.macroSignals,
+    { allowOnDemand: true },
+    makeCtx({
+      strens: {},
+      metaValues: {
+        [SEED_META.macroSignals.key]: JSON.stringify({
+          fetchedAt: NOW - ONE_MIN_MS,
+          recordCount: 0,
+          status: 'error',
+          errorReason: 'macro_publish_failed',
+        }),
+      },
+    }),
+  );
+
+  assert.equal(entry.status, 'SEED_ERROR');
+  assert.equal(entry.onDemand, true);
 });
 
 test('compact health problem projection retains insights synthesis diagnostics', () => {

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -784,12 +784,16 @@ test('classifyKey: a strict projection that has never published keeps its STALE_
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
-test('classifyKey: an unconfigured adapter publishes no fault and no cause', () => {
+test('classifyKey: an unconfigured adapter raises no fault and publishes no errorCode', () => {
   // NOT_CONFIGURED means "this deployment never opted into the adapter", so
   // there is nothing to be degraded ABOUT — the fault is skipped entirely
   // rather than merely losing the verdict. Without the `!sourceUnavailable`
-  // guard the fault still fires, and a green NOT_CONFIGURED entry ships
-  // diagnostic codes for a producer this deployment does not run.
+  // guard the fault still fires, and a green NOT_CONFIGURED entry ships an
+  // errorCode for a producer this deployment does not run.
+  //
+  // Asserted on `errorCode` only. `lastSynthesisFailureCode` is deliberately
+  // ungated upstream — it rides with consecutiveFailures/lastAttemptAt, which
+  // publish on every status — so its presence here is correct, not a leak.
   const entry = classifyKey(
     'marketImplications',
     STANDALONE_KEYS.marketImplications,
@@ -814,7 +818,6 @@ test('classifyKey: an unconfigured adapter publishes no fault and no cause', () 
   assert.equal(entry.status, 'NOT_CONFIGURED');
   assert.equal(STATUS_COUNTS[entry.status], 'ok');
   assert.equal(Object.hasOwn(entry, 'errorCode'), false, 'an unconfigured adapter has no fault to explain');
-  assert.equal(Object.hasOwn(entry, 'lastSynthesisFailureCode'), false);
 });
 
 test('classifyKey: a fault outranks every served-data verdict it precedes', () => {

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -259,6 +259,48 @@ describe('scheduled seed freshness monitor', () => {
       assert.equal(result.blocking.length, 0);
     });
 
+    it('calls a baselined source that changed status escalated, never recovered (#6263)', () => {
+      // The acknowledgment is keyed on name:status, so a source that gets WORSE
+      // stops matching exactly like one that recovers. Both then land in the
+      // same "no longer reported" bucket, and the report tells the operator to
+      // delete a suppression for a source that is still broken — while the same
+      // run fails the gate on the new status. #6263 made this reachable: a
+      // blocked source whose data key also expires moves SEED_ERROR -> EMPTY.
+      const result = applyAcceptanceBaseline(
+        [{ name: 'crossStraitActivityJapanMod', status: 'EMPTY' }],
+        baseline,
+        at('2026-08-01'),
+      );
+
+      assert.equal(
+        result.cleared.some((entry) => entry.name === 'crossStraitActivityJapanMod'),
+        false,
+        'the source is still reporting a problem, so it has not recovered',
+      );
+      assert.deepEqual(result.escalated, [
+        { name: 'crossStraitActivityJapanMod', status: 'SEED_ERROR', observedStatus: 'EMPTY', issue: 5714 },
+      ]);
+      assert.deepEqual(
+        result.blocking.map((p) => p.status),
+        ['EMPTY'],
+        'the unacknowledged worse status still blocks — escalation is reported, never suppressed',
+      );
+    });
+
+    it('still reports a genuinely recovered source as recovered', () => {
+      // The other side of the same split: absent from the problem set entirely
+      // is the only thing that counts as recovery.
+      const result = applyAcceptanceBaseline(
+        [{ name: 'gdeltIntel', status: 'SEED_ERROR' }],
+        baseline,
+        at('2026-08-01'),
+      );
+      assert.deepEqual(result.cleared, [
+        { name: 'crossStraitActivityJapanMod', status: 'SEED_ERROR', issue: 5714 },
+      ]);
+      assert.deepEqual(result.escalated, []);
+    });
+
     it('expires so the baseline cannot silently become permanent', () => {
       assert.equal(applyAcceptanceBaseline([], baseline, at('2026-08-26')).expired, false);
       assert.equal(applyAcceptanceBaseline([], baseline, at('2026-08-28')).expired, true);
@@ -354,7 +396,7 @@ describe('scheduled seed freshness monitor', () => {
       name: 'supplyChainTrade', status: 'STALE_SEED', records: 3, seedAgeMin: 900, maxStaleMin: 360,
     };
     const baselineResult = (overrides) => ({
-      blocking: [], acknowledged: [], cleared: [], expired: false, expiresAt: '2026-08-27', ...overrides,
+      blocking: [], acknowledged: [], cleared: [], escalated: [], expired: false, expiresAt: '2026-08-27', ...overrides,
     });
 
     it('names every blocking problem, not just the count', () => {
@@ -405,6 +447,30 @@ describe('scheduled seed freshness monitor', () => {
       assert.match(report.info[0], /acknowledged \(#5766\): gdeltIntel: status=SEED_ERROR records=1/);
       assert.match(report.info[1], /recovered: shippingRates:STALE_SEED/);
       assert.match(report.info[2], /acceptance passed at 2026-07-28T12:00:00Z.*\(1 acknowledged\)/);
+    });
+
+    it('never tells the operator to prune a suppression for a source that escalated', () => {
+      const report = formatAcceptanceReport(
+        baselineResult({
+          blocking: [{ name: 'crossStraitActivityJapanMod', status: 'EMPTY', records: 0 }],
+          escalated: [{
+            name: 'crossStraitActivityJapanMod',
+            status: 'SEED_ERROR',
+            observedStatus: 'EMPTY',
+            issue: 5714,
+          }],
+        }),
+        '2026-07-28T12:00:00Z',
+      );
+
+      assert.equal(report.failed, true, 'the worse status is unacknowledged and must still fail the gate');
+      const escalation = report.info.find((line) => line.includes('crossStraitActivityJapanMod'));
+      assert.match(escalation, /escalated .*SEED_ERROR -> EMPTY/);
+      assert.doesNotMatch(
+        escalation,
+        /remove it from|recovered/,
+        'pruning advice on an escalation is how a live suppression gets deleted',
+      );
     });
   });
 

--- a/tests/seed-health-market-implications-registration.test.mjs
+++ b/tests/seed-health-market-implications-registration.test.mjs
@@ -2,6 +2,11 @@
 // api/seed-health.js while its sibling `news:insights` was registered, so the
 // operator endpoint could not report the key at all.
 //
+// Not to be confused with tests/market-implications-seed-health.test.mjs,
+// which covers the PRODUCER side — scripts/seed-forecasts.mjs's failure-meta
+// contract as read by api/health.js. This file covers only the /api/seed-health
+// registration and the freshness budget that endpoint applies to the key.
+//
 // Registered on the same terms as that sibling: a coarse age view whose
 // intervalMin*2 budget must equal the api/health.js `marketImplications`
 // budget. Asserted BEHAVIORALLY — the endpoint is driven at the boundary and

--- a/tests/seed-health-market-implications.test.mjs
+++ b/tests/seed-health-market-implications.test.mjs
@@ -1,0 +1,165 @@
+// #6263 item 3: `intelligence:market-implications` was absent from
+// api/seed-health.js while its sibling `news:insights` was registered, so the
+// operator endpoint could not report the key at all.
+//
+// Registered on the same terms as that sibling: a coarse age view whose
+// intervalMin*2 budget must equal the api/health.js `marketImplications`
+// budget. Asserted BEHAVIORALLY — the endpoint is driven at the boundary and
+// one minute past it — rather than by reading the literal out of the source,
+// so a change to either side that breaks the mirror fails here.
+
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  WORLDMONITOR_VALID_KEYS: process.env.WORLDMONITOR_VALID_KEYS,
+};
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+
+const { handleSeedHealth } = await import('../api/seed-health.js');
+const { __testing__ } = await import('../api/health.js');
+
+const DOMAIN = 'intelligence:market-implications';
+const META_KEY = 'seed-meta:intelligence:market-implications';
+const PREDICTION_META_KEY = 'seed-meta:prediction:markets';
+const RESILIENCE_INTERVAL_PROBE_KEY = 'resilience:intervals:v9:US';
+const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
+const TEST_NOW = Date.parse('2026-08-06T09:00:00.000Z');
+const ONE_MIN_MS = 60_000;
+
+// The single source of truth for the budget both surfaces must agree on.
+const MAX_STALE_MIN = __testing__.SEED_META.marketImplications.maxStaleMin;
+
+before(() => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+  process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value == null) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function installPipelineMock(marketImplicationsMeta, now = TEST_NOW) {
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    const results = commands.map((command) => {
+      const [op, key] = command;
+      if (op === 'EXISTS') {
+        assert.match(String(key), /^seed-activated:/, 'EXISTS is only used for activation markers');
+        return { result: 0 };
+      }
+      assert.equal(op, 'GET');
+      if (key === META_KEY) {
+        return { result: marketImplicationsMeta == null ? null : JSON.stringify(marketImplicationsMeta) };
+      }
+      if (key === PREDICTION_META_KEY) {
+        return {
+          result: JSON.stringify({
+            fetchedAt: now,
+            recordCount: 38,
+            poolCounts: { geopolitical: 18, tech: 12, finance: 8 },
+          }),
+        };
+      }
+      if (key === RESILIENCE_INTERVAL_PROBE_KEY) {
+        return {
+          result: JSON.stringify({
+            p05: 65.2,
+            p95: 72.8,
+            _formula: 'pc',
+            methodology: RESILIENCE_INTERVAL_METHODOLOGY,
+            computedAt: '2026-06-11T12:00:00.000Z',
+          }),
+        };
+      }
+      // Isolate the entry under test: keep every unrelated coverage-gated feed
+      // comfortably above its floor so an unrelated contract cannot decide the
+      // assertions below.
+      return { result: JSON.stringify({ fetchedAt: now, recordCount: 10_000 }) };
+    });
+    return new Response(JSON.stringify(results), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+}
+
+async function readSeedHealth(now = TEST_NOW) {
+  const req = new Request('https://api.worldmonitor.app/api/seed-health', {
+    headers: { 'X-WorldMonitor-Key': 'test-key' },
+  });
+  const res = await handleSeedHealth(req, { now });
+  return (await res.json()).seeds[DOMAIN];
+}
+
+// Served vintage the producer holds `fetchedAt` at, per the failure-writer
+// contract in scripts/seed-forecasts.mjs.
+const servedMeta = (ageMin) => ({
+  fetchedAt: TEST_NOW - ageMin * ONE_MIN_MS,
+  recordCount: 5,
+  status: 'ok',
+});
+
+test('seed-health reports the market-implications key at all', async () => {
+  installPipelineMock(servedMeta(30));
+  const entry = await readSeedHealth();
+
+  assert.ok(entry, `${DOMAIN} must be registered in SEED_DOMAINS`);
+  assert.equal(entry.status, 'ok');
+  assert.equal(entry.stale, false);
+  assert.equal(entry.recordCount, 5, 'the count describes the cards actually being served');
+});
+
+test('seed-health holds market-implications healthy right up to the api/health.js budget', async () => {
+  installPipelineMock(servedMeta(MAX_STALE_MIN));
+  const entry = await readSeedHealth();
+
+  assert.equal(entry.stale, false, `${MAX_STALE_MIN}min is the boundary, not past it`);
+  assert.equal(entry.ageMinutes, MAX_STALE_MIN);
+});
+
+test('seed-health stales market-implications one minute past the api/health.js budget', async () => {
+  // The mirror that matters: intervalMin*2 here must equal maxStaleMin there,
+  // or the two surfaces disagree about when an operator should act. Because
+  // the producer holds `fetchedAt` at the served vintage rather than advancing
+  // it on a miss, a stage that stops entirely reliably reaches this state.
+  installPipelineMock(servedMeta(MAX_STALE_MIN + 1));
+  const entry = await readSeedHealth();
+
+  assert.equal(entry.stale, true);
+  assert.equal(entry.status, 'stale');
+});
+
+test('seed-health surfaces a market-implications run with nothing servable as an error', async () => {
+  // The producer's fail-closed branch: no last-good cards to hold a content
+  // clock against, so it writes the zero-record error meta.
+  installPipelineMock({
+    fetchedAt: TEST_NOW - ONE_MIN_MS,
+    recordCount: 0,
+    status: 'error',
+    errorReason: 'llm_no_response',
+  });
+  const entry = await readSeedHealth();
+
+  assert.equal(entry.status, 'error');
+  assert.equal(entry.stale, true);
+});
+
+test('seed-health reports a never-published market-implications key as missing', async () => {
+  installPipelineMock(null);
+  const entry = await readSeedHealth();
+
+  assert.equal(entry.status, 'missing');
+  assert.equal(entry.stale, true);
+});


### PR DESCRIPTION
## Summary

A homepage panel that had gone blank could report a yellow warning for a full week instead of a red critical. `/api/health` classifies ~194 keys per request, and any producer fault — `status:'error'`, a non-ok `sourceState`, a blocked source, a crossed failure streak — was evaluated *before* the check for whether the data key still existed. Because `seed-meta` lives 7 days and most data keys live hours, a producer that failed once and then stopped was simultaneously "faulting" and "serving nothing", and the fault always won. Operators saw `SEED_ERROR` (warn) where the honest answer was `EMPTY` (crit).

This makes the two verdicts compete instead of short-circuiting: both are computed, the more severe wins, and ties go to the fault — the only side carrying a machine-readable cause.

Fixes #6263. Related: #6266 (this branch was stacked on it and has since been rebased onto `main`).

## The issue's proposed fix was unsafe

#6263 suggested the same one-word `&& hasData` guard that #6266 applied to the neighbouring arm. The sweep it asked for showed why that doesn't generalise: four key classes resolve an absent data key to something **softer** than `SEED_ERROR`, so a bare guard demotes or silences them rather than escalating.

| Key class | Absence resolves to | A bare guard would |
|---|---|---|
| `EMPTY_DATA_OK_KEYS` | `STALE_SEED`, or plain **`OK`** when the fault arrived via `sourceState` | turn a reported fault green |
| cascade-covered | `OK_CASCADE` | erase a live producer's error |
| on-demand | `EMPTY_ON_DEMAND` | same severity, cause dropped |
| rollout window | `ROLLOUT_PENDING` | same severity, cause dropped |

The first row is not hypothetical — `forecastFunnel`'s own entry in that set documents the dependency: *"A COLLAPSED funnel still surfaces via seed-meta `status:'error'` → `SEED_ERROR`, which classifyKey checks before this branch."* Mutating the fix to the naive form kills exactly those four locks.

## Review found the headline case still surviving

On the eight `MISSING_DATA_IS_FAILURE_KEYS` — `cableHealth`, `notamClosures`, `positiveGeoEvents` and five bootstrap projections — a `status:'error'` meta over a vanished payload *still* reported warn after the first fix.

The arm that makes a vanished payload critical for those keys is guarded on `seedStale !== true`, and `readSeedMeta` **synthesises** `seedStale: true` on the `status:'error'` return as a fault marker rather than measuring it. The arm was skipped, the key fell through to `EMPTY_DATA_OK_KEYS`, and its `STALE_SEED` merely *tied* the fault — so the tie-break returned `SEED_ERROR`. The sibling `sourceState` path, where staleness genuinely is measured, reported `EMPTY` for the identical physical state.

```
key                            status:'error'      sourceState:'error'
crossStraitActivityBootstrap   SEED_ERROR/warn     EMPTY/crit   <-- before
crossStraitActivityBootstrap   EMPTY/crit          EMPTY/crit   <-- after
```

A reported fault now revokes that arm's grace, because it is proof the producer ran. The grace is untouched for its real purpose: a key absent before its producer's first run, with no fault recorded, is still `STALE_SEED` and not a false-critical `EMPTY`.

## Two more surfaces

**`/api/seed-health` could not report `intelligence:market-implications` at all** — it carried the `news:insights` sibling but not this one. Registered on the same terms (`intervalMin: 60`, giving the 120min budget `api/health.js` declares). Scope boundary stated in the entry: this endpoint models neither key's failure streak, so inside the window it reports `ok` where `/api/health` may already report `SEED_ERROR` — the coarse-vs-detailed split `news:insights` has always had.

**The seed-freshness monitor called an escalation a recovery.** Acknowledgments are keyed on an exact `name:status`, so a source that gets *worse* stops matching exactly like one that recovers. Both landed in `cleared`, whose report line says *"no longer reported; remove it from `seed-freshness-baseline.json`"* — so on the run where a suppressed source degraded further, the monitor failed the gate on the new status **and** told the operator to delete the owner record for the still-live fault. Unmatched entries now split on whether the source appears in the problem set at all; `escalated` reports the transition and carries no pruning advice. The worse status still blocks either way.

*Deliberately not done:* adding `EMPTY` variants to the baseline. That pre-suppresses a crit for a blank panel — a different operator impact from the "serving stale records" state actually acknowledged under #5714/#5769.

## Test plan

Every new test is mutation-verified; the mutant is named and confirmed to kill it.

| Mutant | Kills |
|---|---|
| Precedence → the naive `&& hasData` guard | the 4 anti-regression locks |
| `\|\| fault` dropped from the strict-projection arm | the 8-key escalation + two-path parity tests |
| The whole `seedStale` guard dropped | the pre-first-publish grace test |
| `if (!sourceUnavailable)` → `if (true)` | the unconfigured-adapter test |
| Fault arm reordered after `records === 0` | the served-data ordering test |
| `errorCode` re-gated on `status ===` | the escalation-keeps-its-cause test |
| `escalated` folded back into `cleared` | the escalation-vs-recovery test |
| `SEED_DOMAINS` entry removed / `intervalMin` halved | all 5 endpoint tests / the budget boundary |

**Differential harness** (built during review, over the real classifier): 156,220 cases — every registry key × data absent/present/cascade-sibling-only × 73 seed-meta shapes × 4 activation states — old code vs new. **Zero diffs wherever the data key is present**, zero softened verdicts, and `SEED_ERROR -> EMPTY` as the only transition anywhere. That is the refactor's central safety claim measured rather than argued.

446 tests across the health and monitor suites pass. `typecheck`, `lint`, `lint:api-contract`, `docs:check`, `lint:public-docs`, `lint:mintlify-slugs` clean. The budget mirror is asserted behaviourally — the real endpoint driven at the boundary and one minute past it, reading the expected value from `api/health.js`'s own `SEED_META` — so drift on either side fails.

Nine reviewers plus an independent cross-model pass (zero findings). Reviewers also empirically cleared three things the commits had only asserted: `api/mcp/freshness.ts` never consumes `classifyKey`'s status, no `SEED_ERROR -> EMPTY` transition moves a key from blocking to excused in `check-seed-freshness.mjs`, and there is no temporal-dead-zone hazard reading `STATUS_COUNTS` from a function declared above it.

## Post-Deploy Monitoring & Validation

**What changes:** only keys simultaneously faulting *and* missing their data key. Everything else classifies identically — measured, not assumed.

**Watch:** `/api/health` `summary.crit` and `overall` for the first few sweeps. Prod at time of writing is `WARNING` with `crit: 0`; `crossStraitActivityJapanMod` is `SEED_ERROR` with `records: 2`, so it does **not** escalate today.

**Healthy signal:** `summary.crit` unchanged; `forecastFunnel`, `forecastBets`, the cascade groups (`theaterPosture*`, `militaryFlights*`, `displacement*`) and the eight bootstrap projections all reporting their usual statuses.

**Failure signal / rollback trigger:** a key at `EMPTY` (crit) whose panel is demonstrably rendering — that would mean the absence verdict is beating a key that *does* have data, i.e. a `hasData` misread. Also `forecastFunnel` reporting `OK`/`STALE_SEED` while its seed-meta says `status:'error'` — the exact regression this PR exists to prevent, and evidence the precedence comparison inverted.

**Expected one-time noise:** `collectFailureLogProblems` keys its dedupe on `name:status`, so each escalating key emits one fresh failure-log entry on the first post-deploy poll. Self-clearing.

**Query:** `GET /api/health?compact=1`, diffed against a pre-deploy capture. `GET /api/seed-health` should now carry an `intelligence:market-implications` entry with `ageMinutes` tracking the served vintage.

**Window / owner:** first 2 hours (two seed-forecasts cron ticks), then the next daily health sweep.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
