### PR TITLE
fix(consumer-prices): attribute coverage loss to a bounded failure reason

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -955,6 +955,38 @@ const consumerPriceCoverageActivationKey = (market) => (
   `seed-activated:consumer-prices:coverage:v${CONSUMER_PRICE_COVERAGE_SCHEMA_VERSION}:${market}`
 );
 
+// #6182 — the terminal failure class behind a partial market's counts.
+//
+// The vocabulary is per-producer and CLOSED, like every other code health
+// echoes back to operators: anything outside this list is dropped rather than
+// relayed. Keep in lockstep with COVERAGE_FAILURE_REASONS in
+// consumer-prices-core/src/jobs/scrape-coverage.ts; tests/consumer-prices-
+// coverage-contract.test.mjs pins the two together.
+export const COVERAGE_FAILURE_REASONS = Object.freeze([
+  'provider-cooldown',
+  'provider-error',
+  'missing-price',
+  'quantity-as-price',
+  'currency-mismatch',
+  'title-mismatch',
+  'validator-rejected',
+  'parsed-zero-products',
+  'pin-validator-rejected',
+  'unknown-error',
+]);
+
+// Counts must be whole and positive: the map is a breakdown of errorsCount, so
+// a fractional or negative entry is producer drift, not a diagnostic.
+function sanitizeCoverageFailureReasons(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const clean = {};
+  for (const reason of COVERAGE_FAILURE_REASONS) {
+    const count = Number(raw[reason]);
+    if (Number.isSafeInteger(count) && count > 0) clean[reason] = count;
+  }
+  return clean;
+}
+
 // Per-market and deliberately not a shared constant: adding a ninth market
 // later must open a fresh, separately-reviewed window for THAT market only.
 // A single shared deadline would silently re-soften the eight that already
@@ -1240,7 +1272,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       unavailableGroups: decisionDiagnostics.unavailableGroups,
     }
     : null;
-  // Per-market coverage: optional { status, completedPages, failedPages, completionRatio, rejectedCount, retailers }
+  // Per-market coverage: optional { status, completedPages, failedPages, completionRatio, rejectedCount, failureReasons, retailers }
   // written by consumer-prices publish.ts and other seeders that track partial completion.
   // null when the seeder didn't write coverage fields.
   const coverageRetailers = Array.isArray(meta?.coverage?.retailers)
@@ -1253,6 +1285,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
         failedPages: Number(retailer?.failedPages) || 0,
         rejectedCount: Number(retailer?.rejectedCount) || 0,
         completionRatio: retailer?.completionRatio == null ? null : Number(retailer.completionRatio) || 0,
+        failureReasons: sanitizeCoverageFailureReasons(retailer?.failureReasons),
       }))
     : null;
   const coverage = meta?.coverage && typeof meta.coverage === 'object'
@@ -1262,6 +1295,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
         failedPages: Number(meta.coverage.failedPages) || 0,
         completionRatio: meta.coverage.completionRatio == null ? null : Number(meta.coverage.completionRatio) || 0,
         rejectedCount: Number(meta.coverage.rejectedCount) || 0,
+        failureReasons: sanitizeCoverageFailureReasons(meta.coverage.failureReasons),
         retailers: coverageRetailers,
       }
     : null;

--- a/consumer-prices-core/migrations/011_scrape_run_failure_reasons.sql
+++ b/consumer-prices-core/migrations/011_scrape_run_failure_reasons.sql
@@ -1,0 +1,25 @@
+-- Per-run failure attribution for issue #6182.
+--
+-- #5945 (migration 010) made coverage loss VISIBLE as counts; this makes it
+-- EXPLAINABLE. The adapter already classifies every failed candidate into a
+-- bounded vocabulary (provider-cooldown, provider-error, missing-price,
+-- quantity-as-price, currency-mismatch, title-mismatch, validator-rejected)
+-- plus the loop's own parsed-zero-products / pin-validator-rejected /
+-- unknown-error, and scrape.ts discarded it one line before persistence — so
+-- "why is this market COVERAGE_PARTIAL" could only be answered by grepping
+-- Railway logs, which is what both prior recovery rounds had to do.
+--
+-- One terminal reason is recorded per failure, so the map's values sum to
+-- errors_count. Validator admission is unchanged: this is reporting only.
+
+ALTER TABLE scrape_runs
+  ADD COLUMN IF NOT EXISTS failure_reasons JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE scrape_runs
+  DROP CONSTRAINT IF EXISTS scrape_runs_failure_reasons_object;
+
+-- Guards the shape the coverage snapshot reads back. A stray array or scalar
+-- would flow into seed metadata and health as an unreadable diagnostic.
+ALTER TABLE scrape_runs
+  ADD CONSTRAINT scrape_runs_failure_reasons_object
+  CHECK (jsonb_typeof(failure_reasons) = 'object');

--- a/consumer-prices-core/src/adapters/search.recovery.test.ts
+++ b/consumer-prices-core/src/adapters/search.recovery.test.ts
@@ -124,6 +124,43 @@ describe('SearchAdapter recovery path', () => {
     expect(result.url).toBe(replacementUrl);
   });
 
+  it('retains failed pin classifications when the Exa fallback also fails', async () => {
+    const exa = {
+      search: vi.fn().mockResolvedValue([{ url: 'https://coldstorage.com.sg/en/p/bread/i/2.html' }]),
+      extract: vi.fn(),
+    } as unknown as ExaProvider;
+    const firecrawl = {
+      extract: vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: {
+            productName: 'Garden Sunflower Seeds 1kg',
+            price: 9.95,
+            currency: 'SGD',
+            sizeText: '400g',
+          },
+        })
+        .mockResolvedValueOnce({ data: {} }),
+    } as unknown as FirecrawlProvider;
+    const adapter = new SearchAdapter(exa, firecrawl);
+    const context = makeContext(
+      makeConfig({ allowedHosts: ['www.coldstorage.com.sg'], extractionFallback: 'none' }),
+    );
+    const target = {
+      ...makeTarget(),
+      metadata: { ...makeTarget().metadata, direct: true },
+    };
+
+    const error = await adapter.fetchTarget(context, target).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(SearchTargetError);
+    expect((error as SearchTargetError).failures.map(({ reason }) => reason)).toEqual([
+      'title-mismatch',
+      'missing-price',
+    ]);
+    expect(exa.extract).not.toHaveBeenCalled();
+  });
+
   it('opens a Firecrawl cooldown after repeated provider errors while keeping fallback bounded', async () => {
     const exa = {
       search: vi.fn().mockResolvedValue([

--- a/consumer-prices-core/src/adapters/search.ts
+++ b/consumer-prices-core/src/adapters/search.ts
@@ -568,11 +568,13 @@ export class SearchAdapter implements RetailerAdapter {
       matchId?: string;
     };
     const hostAllowlist = normalizeAllowedHosts(domain, ctx.config.searchConfig?.allowedHosts);
+    const failures: ExtractionFailure[] = [];
 
     // Direct path: skip Exa discovery, call the configured extractor on the pinned URL.
     if (direct) {
       try {
         const attempt = await this._extractFromUrl(ctx, target.url, canonicalName, currency, itemConstraints);
+        failures.push(...attempt.failures);
         if (attempt.result) {
           const result = attempt.result;
           ctx.logger.info(
@@ -601,6 +603,8 @@ export class SearchAdapter implements RetailerAdapter {
           `  [search:pin] ${ctx.config.slug}/${canonicalName}: pin extraction failed (${formatExtractionFailures(attempt.failures)}), falling back to Exa`,
         );
       } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        failures.push({ provider: 'firecrawl', reason: 'provider-error', detail });
         ctx.logger.warn(`  [search:pin] ${ctx.config.slug}/${canonicalName}: pin fetch error, falling back to Exa: ${err}`);
       }
     }
@@ -721,7 +725,6 @@ export class SearchAdapter implements RetailerAdapter {
     // the reason each provider/page was rejected for the scrape-run diagnostics.
     let picked: ExtractionSuccess | null = null;
     let usedUrl = safeUrls[0];
-    const failures: ExtractionFailure[] = [];
 
     for (const url of safeUrls) {
       try {

--- a/consumer-prices-core/src/jobs/publish.test.ts
+++ b/consumer-prices-core/src/jobs/publish.test.ts
@@ -32,6 +32,7 @@ const coverage = {
   failedPages: 4,
   completionRatio: 0.6667,
   rejectedCount: 3,
+  failureReasons: { 'missing-price': 2, 'provider-error': 1 },
   status: 'partial',
   minimumCompletionRatio: 0.5,
   retailers: [{ slug: 'retailer-a', name: 'Retailer A', coverageStatus: 'partial', rejectedCount: 3 }],
@@ -70,6 +71,7 @@ describe('consumer-price coverage publication', () => {
       failedPages: 4,
       completionRatio: 0.6667,
       rejectedCount: 3,
+      failureReasons: { 'missing-price': 2, 'provider-error': 1 },
     });
     expect(JSON.parse(coverageMeta[2]).coverage.retailers).toEqual(coverage.retailers);
   });

--- a/consumer-prices-core/src/jobs/publish.ts
+++ b/consumer-prices-core/src/jobs/publish.ts
@@ -90,6 +90,7 @@ async function writeSnapshot(
     pagesFailed: number;
     rejectedCount: number;
     completionRatio?: number | null;
+    failureReasons?: Record<string, number>;
     retailers?: unknown[];
   },
 ): Promise<void> {
@@ -111,6 +112,7 @@ async function writeSnapshot(
         failedPages: coverage.pagesFailed,
         completionRatio,
         rejectedCount: coverage.rejectedCount,
+        ...(coverage.failureReasons ? { failureReasons: coverage.failureReasons } : {}),
         ...(coverage.retailers ? { retailers: coverage.retailers } : {}),
       };
     }
@@ -178,6 +180,7 @@ export async function publishAll() {
           rejectedCount: coverage.rejectedCount,
           completionRatio: coverage.completionRatio,
           status: coverage.status,
+          failureReasons: coverage.failureReasons,
           retailers: coverage.retailers,
         },
       );

--- a/consumer-prices-core/src/jobs/scrape-attribution.test.ts
+++ b/consumer-prices-core/src/jobs/scrape-attribution.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  loadRetailerConfig: vi.fn(),
+  loadAllRetailerConfigs: vi.fn().mockReturnValue([]),
+  discoverTargets: vi.fn(),
+  fetchTarget: vi.fn(),
+  parseListing: vi.fn(),
+  getPinnedUrlsForRetailer: vi.fn(),
+  getDisabledPinsForRecovery: vi.fn(),
+}));
+
+vi.mock('../db/client.js', () => ({
+  query: mocks.query,
+  closePool: vi.fn(),
+}));
+vi.mock('../db/queries/observations.js', () => ({ insertObservation: vi.fn() }));
+vi.mock('../db/queries/products.js', () => ({
+  upsertRetailerProduct: vi.fn(),
+  upsertCanonicalProduct: vi.fn(),
+}));
+vi.mock('../db/queries/matches.js', () => ({
+  getBasketItemId: vi.fn(),
+  getPinnedUrlsForRetailer: mocks.getPinnedUrlsForRetailer,
+  getDisabledPinsForRecovery: mocks.getDisabledPinsForRecovery,
+  upsertProductMatch: vi.fn(),
+}));
+vi.mock('../normalizers/size.js', () => ({
+  parseSize: vi.fn(),
+  unitPrice: vi.fn(),
+}));
+vi.mock('../config/loader.js', () => ({
+  loadRetailerConfig: mocks.loadRetailerConfig,
+  loadAllRetailerConfigs: mocks.loadAllRetailerConfigs,
+}));
+vi.mock('../acquisition/registry.js', () => ({
+  initProviders: vi.fn(),
+  teardownAll: vi.fn(),
+}));
+vi.mock('../acquisition/exa.js', () => ({ ExaProvider: class {} }));
+vi.mock('../acquisition/firecrawl.js', () => ({ FirecrawlProvider: class {} }));
+vi.mock('../adapters/generic.js', () => ({ GenericPlaywrightAdapter: class {} }));
+vi.mock('../adapters/exa-search.js', () => ({ ExaSearchAdapter: class {} }));
+vi.mock('../adapters/validator.js', () => ({ AUTO_MATCH_THRESHOLD: 0.9 }));
+vi.mock('./scrape-pin-recovery.js', () => ({
+  handleStaleOnInStock: vi.fn(),
+  handleStaleOnOutOfStock: vi.fn(),
+  handlePinError: vi.fn(),
+}));
+vi.mock('../adapters/search.js', () => {
+  class MockSearchTargetError extends Error {
+    readonly rejectedCount: number;
+    readonly failures: Array<{ provider: string; reason: string; detail?: string }>;
+
+    constructor(
+      message: string,
+      rejectedCount: number,
+      failures: Array<{ provider: string; reason: string; detail?: string }>,
+    ) {
+      super(message);
+      this.name = 'SearchTargetError';
+      this.rejectedCount = rejectedCount;
+      this.failures = failures;
+    }
+  }
+
+  class MockSearchAdapter {
+    discoverTargets = mocks.discoverTargets;
+    fetchTarget = mocks.fetchTarget;
+    parseListing = mocks.parseListing;
+  }
+
+  return { SearchAdapter: MockSearchAdapter, SearchTargetError: MockSearchTargetError };
+});
+
+vi.spyOn(process, 'exit').mockImplementation((code?: number | string | null) => {
+  process.exitCode = typeof code === 'number' ? code : 0;
+  return undefined as never;
+});
+
+const { scrapeRetailer } = await import('./scrape.js');
+const { SearchTargetError } = await import('../adapters/search.js');
+
+const config = {
+  slug: 'retailer-a',
+  name: 'Retailer A',
+  marketCode: 'ae',
+  countryCode: 'AE',
+  currencyCode: 'AED',
+  adapter: 'search',
+  baseUrl: 'https://retailer.test',
+  enabled: true,
+  discovery: { mode: 'search', seeds: [], maxPages: 1 },
+  searchConfig: { extractionFallback: 'none' },
+  rateLimit: { delayBetweenRequestsMs: 0 },
+};
+
+const target = {
+  id: 'bread-white',
+  url: 'https://retailer.test/bread',
+  category: 'bread',
+  metadata: { direct: false },
+};
+
+beforeEach(() => {
+  mocks.query.mockReset().mockResolvedValue({ rows: [{ id: 'retailer-run-1' }], rowCount: 1 });
+  mocks.loadRetailerConfig.mockReset().mockReturnValue(config);
+  mocks.loadAllRetailerConfigs.mockReset().mockReturnValue([]);
+  mocks.discoverTargets.mockReset().mockResolvedValue([target]);
+  mocks.fetchTarget.mockReset();
+  mocks.parseListing.mockReset().mockResolvedValue([]);
+  mocks.getPinnedUrlsForRetailer.mockReset().mockResolvedValue(new Map());
+  mocks.getDisabledPinsForRecovery.mockReset().mockResolvedValue([]);
+  vi.stubEnv('EXA_API_KEY', 'exa-test');
+  vi.stubEnv('FIRECRAWL_API_KEY', 'firecrawl-test');
+});
+
+describe('scrapeRetailer failure attribution', () => {
+  it('persists SearchTargetError reasons and a matching error count', async () => {
+    mocks.fetchTarget.mockRejectedValueOnce(
+      new SearchTargetError('all candidates failed', 0, [{ provider: 'firecrawl', reason: 'missing-price' }]),
+    );
+
+    await scrapeRetailer('retailer-a');
+
+    const updateCall = mocks.query.mock.calls.find(([sql]) => String(sql).includes('failure_reasons=$7'));
+    expect(updateCall).toBeDefined();
+    expect(updateCall?.[1]).toEqual([
+      'retailer-run-1',
+      'failed',
+      1,
+      0,
+      1,
+      0,
+      JSON.stringify({ 'missing-price': 1 }),
+    ]);
+  });
+
+  it('attributes an unexpected scrape error as unknown-error', async () => {
+    mocks.fetchTarget.mockRejectedValueOnce(new Error('adapter exploded'));
+
+    await scrapeRetailer('retailer-a');
+
+    const updateCall = mocks.query.mock.calls.find(([sql]) => String(sql).includes('failure_reasons=$7'));
+    expect(updateCall?.[1]).toEqual([
+      'retailer-run-1',
+      'failed',
+      1,
+      0,
+      1,
+      0,
+      JSON.stringify({ 'unknown-error': 1 }),
+    ]);
+  });
+});

--- a/consumer-prices-core/src/jobs/scrape-coverage.test.ts
+++ b/consumer-prices-core/src/jobs/scrape-coverage.test.ts
@@ -3,9 +3,13 @@ import {
   classifyValidatorOutcome,
   createScrapeRunStatement,
   DEFAULT_RUN_BUDGET_MS,
+  FailureReasonTally,
+  isMissingColumnError,
   isRunBudgetExhausted,
+  legacyUpdateScrapeRunStatement,
   resolveRunBudgetMs,
   resolveRunStatus,
+  terminalFailureReason,
   updateScrapeRunStatement,
 } from './scrape-coverage.js';
 
@@ -22,9 +26,63 @@ describe('scrape coverage persistence and validator admission contracts', () => 
       pagesSucceeded: 8,
       errorsCount: 4,
       rejectedCount: 3,
+      failureReasons: { 'missing-price': 3, 'provider-error': 1 },
     });
     expect(update.sql).toContain('rejected_count=$6');
-    expect(update.params).toEqual(['run-1', 'partial', 12, 8, 4, 3]);
+    expect(update.sql).toContain('failure_reasons=$7');
+    expect(update.params).toEqual([
+      'run-1',
+      'partial',
+      12,
+      8,
+      4,
+      3,
+      JSON.stringify({ 'missing-price': 3, 'provider-error': 1 }),
+    ]);
+  });
+
+  // The three consumer-price Railway services run scrape/aggregate/publish
+  // directly — none of them runs `npm run migrate`, so migration 011 is applied
+  // by hand and the new code CAN reach production first. Without a fallback the
+  // UPDATE throws, updateScrapeRun never lands, and every run row is stranded
+  // at status='running' — which the coverage query then skips entirely. That is
+  // strictly worse than the missing diagnostic this change adds.
+  it('falls back to the pre-011 column list when failure_reasons does not exist', () => {
+    const legacy = legacyUpdateScrapeRunStatement({
+      runId: 'run-3',
+      status: 'partial',
+      pagesAttempted: 12,
+      pagesSucceeded: 8,
+      errorsCount: 4,
+      rejectedCount: 3,
+      failureReasons: { 'missing-price': 4 },
+    });
+    expect(legacy.sql).not.toContain('failure_reasons');
+    expect(legacy.params).toEqual(['run-3', 'partial', 12, 8, 4, 3]);
+  });
+
+  it('recognises only the undefined-column error as the fallback trigger', () => {
+    expect(isMissingColumnError({ code: '42703' })).toBe(true);
+    // A connection drop or a constraint violation must surface, not be
+    // swallowed into a silent downgrade that hides a real database fault.
+    expect(isMissingColumnError({ code: '23514' })).toBe(false);
+    expect(isMissingColumnError(new Error('boom'))).toBe(false);
+    expect(isMissingColumnError(null)).toBe(false);
+  });
+
+  // A run with nothing to explain must still write a value: leaving the column
+  // at its previous contents would let a clean run inherit the last failing
+  // run's reasons and report a recovery as still broken.
+  it('writes an empty reason map when the run had no failures', () => {
+    const update = updateScrapeRunStatement({
+      runId: 'run-2',
+      status: 'completed',
+      pagesAttempted: 12,
+      pagesSucceeded: 12,
+      errorsCount: 0,
+      rejectedCount: 0,
+    });
+    expect(update.params[6]).toBe('{}');
   });
 
   it('skips direct-pin validator rejects but preserves search candidates as non-admitted observations', () => {
@@ -43,6 +101,80 @@ describe('scrape coverage persistence and validator admission contracts', () => 
       skipObservation: false,
       errorCount: 0,
     });
+  });
+});
+
+describe('terminal failure classification', () => {
+  // A page burns several candidate URLs and each can fail differently, so the
+  // page needs ONE terminal class or the tally stops summing to errorsCount.
+  // The class reported is the furthest stage any candidate reached: that is
+  // what tells an operator whether the page never loaded, never priced, or
+  // priced and was then refused.
+  it('reports the furthest pipeline stage any candidate reached', () => {
+    expect(
+      terminalFailureReason([
+        { provider: 'firecrawl', reason: 'provider-error' },
+        { provider: 'exa', reason: 'missing-price' },
+      ]),
+    ).toBe('missing-price');
+
+    expect(
+      terminalFailureReason([
+        { provider: 'firecrawl', reason: 'validator-rejected' },
+        { provider: 'exa', reason: 'provider-error' },
+      ]),
+    ).toBe('validator-rejected');
+
+    expect(
+      terminalFailureReason([
+        { provider: 'firecrawl', reason: 'provider-cooldown' },
+        { provider: 'exa', reason: 'provider-cooldown' },
+      ]),
+    ).toBe('provider-cooldown');
+  });
+
+  // An empty failure list is the "threw something that was not a
+  // SearchTargetError" path. It must still land in the vocabulary, otherwise
+  // the tally silently under-counts and errorsCount stops reconciling.
+  it('falls back to unknown-error when no failure was attributed', () => {
+    expect(terminalFailureReason([])).toBe('unknown-error');
+  });
+});
+
+describe('failure reason tally', () => {
+  it('counts one terminal reason per failed page and reconciles with errorsCount', () => {
+    const tally = new FailureReasonTally();
+    tally.recordPageFailure([
+      { provider: 'firecrawl', reason: 'provider-error' },
+      { provider: 'exa', reason: 'missing-price' },
+    ]);
+    tally.recordPageFailure([{ provider: 'firecrawl', reason: 'missing-price' }]);
+    tally.recordPageFailure([{ provider: 'firecrawl', reason: 'title-mismatch' }]);
+    tally.recordParsedZeroProducts();
+    tally.recordPinValidatorRejection();
+
+    expect(tally.toJSON()).toEqual({
+      'missing-price': 2,
+      'title-mismatch': 1,
+      'parsed-zero-products': 1,
+      'pin-validator-rejected': 1,
+    });
+    // Every errorsCount++ site in scrape.ts has a matching record* call, so the
+    // tally totals the run's errors exactly. A drift here means a new error
+    // path shipped without attribution.
+    expect(tally.total).toBe(5);
+  });
+
+  it('omits reasons that never fired rather than emitting zeros', () => {
+    const tally = new FailureReasonTally();
+    tally.recordPageFailure([{ provider: 'exa', reason: 'quantity-as-price' }]);
+    expect(tally.toJSON()).toEqual({ 'quantity-as-price': 1 });
+  });
+
+  it('starts empty so a clean run publishes no reasons', () => {
+    const tally = new FailureReasonTally();
+    expect(tally.toJSON()).toEqual({});
+    expect(tally.total).toBe(0);
   });
 });
 

--- a/consumer-prices-core/src/jobs/scrape-coverage.ts
+++ b/consumer-prices-core/src/jobs/scrape-coverage.ts
@@ -1,5 +1,118 @@
+import type { ExtractionFailure, ExtractionFailureReason } from '../adapters/search.js';
+
 export interface ValidatorOutcome {
   ok: boolean;
+}
+
+/**
+ * Failure classes that are not extraction outcomes: the page parsed to nothing,
+ * a direct pin was refused by the strict validator, or the target loop threw
+ * something that carried no attribution. Every `errorsCount++` site in
+ * scrape.ts maps to one of these or to an `ExtractionFailureReason`, which is
+ * what lets the tally reconcile against `errorsCount`.
+ */
+export type NonExtractionFailureReason =
+  | 'parsed-zero-products'
+  | 'pin-validator-rejected'
+  | 'unknown-error';
+
+export type CoverageFailureReason = ExtractionFailureReason | NonExtractionFailureReason;
+
+/**
+ * How far down the pipeline a candidate URL got before failing, ascending.
+ *
+ * A failed page burns several candidate URLs and each can fail differently, so
+ * the page has to collapse to ONE class or the tally stops summing to
+ * `errorsCount`. Reporting the FURTHEST stage reached is the informative
+ * choice: `provider-error` on every candidate means the pages never loaded,
+ * while `validator-rejected` means a price was extracted and then refused —
+ * opposite diagnoses that a first-failure or last-failure rule would blur.
+ *
+ * KNOWN LIMITATION, and the reason the two provider classes sit at the bottom:
+ * a page where the primary extractor answered `missing-price` AND the fallback
+ * provider errored is reported as `missing-price`, so a fallback-only outage is
+ * masked whenever the primary still runs. That is deliberate — the page's own
+ * outcome really was "never priced" — but it means this map is not a provider
+ * health signal. Provider faults surface here only when they are the whole
+ * story for a page; the `[search:provider-cooldown]` log line is what tells you
+ * a provider died mid-scrape. (Exactly this masking hid the Exa /contents 400
+ * repaired in #6270.)
+ */
+const EXTRACTION_STAGE_ORDER: readonly ExtractionFailureReason[] = [
+  'provider-cooldown',
+  'provider-error',
+  'missing-price',
+  'quantity-as-price',
+  'currency-mismatch',
+  'title-mismatch',
+  'validator-rejected',
+];
+
+/** The closed vocabulary health echoes back to operators. */
+export const COVERAGE_FAILURE_REASONS: readonly CoverageFailureReason[] = [
+  ...EXTRACTION_STAGE_ORDER,
+  'parsed-zero-products',
+  'pin-validator-rejected',
+  'unknown-error',
+];
+
+export function terminalFailureReason(
+  failures: readonly ExtractionFailure[],
+): CoverageFailureReason {
+  let furthest = -1;
+  for (const { reason } of failures) {
+    const stage = EXTRACTION_STAGE_ORDER.indexOf(reason);
+    if (stage > furthest) furthest = stage;
+  }
+  // No attributed failure at all — a non-SearchTargetError escaped the target
+  // loop. Naming it keeps the tally reconciling instead of silently short.
+  return furthest === -1 ? 'unknown-error' : EXTRACTION_STAGE_ORDER[furthest];
+}
+
+/**
+ * Per-run breakdown of WHY coverage was lost.
+ *
+ * #6182 asks for the exact failure class of every failed page. The adapter
+ * already computes that vocabulary and `scrape.ts` threw it away one line
+ * before persistence, so every diagnosis needed Railway log archaeology.
+ * This accumulates it into a bounded record that rides along to seed metadata
+ * and health next to the counts it explains.
+ *
+ * One bump per counted error, which is what makes `total` usable as the run's
+ * `errorsCount`. That is per PAGE for a failed target and for a page that
+ * parsed nothing, but per PRODUCT for a direct-pin validator rejection — a
+ * page carrying several rejected pinned products counts each one, matching
+ * the accounting `scrape.ts` has always used.
+ */
+export class FailureReasonTally {
+  private readonly counts = new Map<CoverageFailureReason, number>();
+
+  private bump(reason: CoverageFailureReason): void {
+    this.counts.set(reason, (this.counts.get(reason) ?? 0) + 1);
+  }
+
+  recordPageFailure(failures: readonly ExtractionFailure[]): void {
+    this.bump(terminalFailureReason(failures));
+  }
+
+  recordParsedZeroProducts(): void {
+    this.bump('parsed-zero-products');
+  }
+
+  recordPinValidatorRejection(): void {
+    this.bump('pin-validator-rejected');
+  }
+
+  get total(): number {
+    let sum = 0;
+    for (const count of this.counts.values()) sum += count;
+    return sum;
+  }
+
+  /** Reasons that never fired are omitted, so a clean run publishes `{}`. */
+  toJSON(): Record<string, number> {
+    return Object.fromEntries(this.counts);
+  }
 }
 
 export interface ScrapeRunUpdate {
@@ -9,6 +122,7 @@ export interface ScrapeRunUpdate {
   pagesSucceeded: number;
   errorsCount: number;
   rejectedCount: number;
+  failureReasons?: Record<string, number>;
 }
 
 export function createScrapeRunStatement(retailerId: string) {
@@ -21,6 +135,36 @@ export function createScrapeRunStatement(retailerId: string) {
 
 export function updateScrapeRunStatement(update: ScrapeRunUpdate) {
   return {
+    sql: `UPDATE scrape_runs SET status=$2, finished_at=NOW(), pages_attempted=$3, pages_succeeded=$4, errors_count=$5, rejected_count=$6, failure_reasons=$7 WHERE id=$1`,
+    params: [
+      update.runId,
+      update.status,
+      update.pagesAttempted,
+      update.pagesSucceeded,
+      update.errorsCount,
+      update.rejectedCount,
+      // Always written, never left untouched: a recovered run that skipped the
+      // column would keep serving the previous run's reasons and read as
+      // still-broken.
+      JSON.stringify(update.failureReasons ?? {}),
+    ],
+  };
+}
+
+/**
+ * Pre-migration-011 column list.
+ *
+ * None of the three consumer-price Railway services runs the migration
+ * runner, so `migrations/011_scrape_run_failure_reasons.sql` is applied by
+ * hand and this code can reach production first. Losing the whole
+ * `updateScrapeRun` to an undefined column would strand every run row at
+ * status='running' — and buildCoverageSnapshot only reads terminal runs, so
+ * the market's coverage would silently freeze at the previous day's numbers.
+ * Dropping one diagnostic field is the correct degradation; losing the run
+ * accounting is not.
+ */
+export function legacyUpdateScrapeRunStatement(update: ScrapeRunUpdate) {
+  return {
     sql: `UPDATE scrape_runs SET status=$2, finished_at=NOW(), pages_attempted=$3, pages_succeeded=$4, errors_count=$5, rejected_count=$6 WHERE id=$1`,
     params: [
       update.runId,
@@ -31,6 +175,19 @@ export function updateScrapeRunStatement(update: ScrapeRunUpdate) {
       update.rejectedCount,
     ],
   };
+}
+
+/**
+ * Postgres `undefined_column` (42703) — the ONLY error the legacy retry may
+ * swallow. Widening this to any failure would turn a connection drop or a
+ * violated constraint into a silent downgrade.
+ */
+export function isMissingColumnError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    (err as { code?: unknown }).code === '42703'
+  );
 }
 
 export function classifyValidatorOutcome(

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -20,7 +20,10 @@ import { AUTO_MATCH_THRESHOLD, type ValidatorResult } from '../adapters/validato
 import {
   classifyValidatorOutcome,
   createScrapeRunStatement,
+  FailureReasonTally,
+  isMissingColumnError,
   isRunBudgetExhausted,
+  legacyUpdateScrapeRunStatement,
   resolveRunBudgetMs,
   resolveRunStatus,
   updateScrapeRunStatement,
@@ -62,16 +65,32 @@ async function updateScrapeRun(
   pagesSucceeded: number,
   errorsCount: number,
   rejectedCount: number,
+  failureReasons: Record<string, number>,
 ) {
-  const statement = updateScrapeRunStatement({
+  const update = {
     runId,
     status,
     pagesAttempted,
     pagesSucceeded,
     errorsCount,
     rejectedCount,
-  });
-  await query(statement.sql, statement.params);
+    failureReasons,
+  };
+  const statement = updateScrapeRunStatement(update);
+  try {
+    await query(statement.sql, statement.params);
+  } catch (err) {
+    // Migration 011 has not been applied yet (no Railway service runs the
+    // migration runner). Give up the diagnostic column, never the run row —
+    // an unwritten run stays status='running' and buildCoverageSnapshot,
+    // which only reads terminal runs, would freeze the market's coverage.
+    if (!isMissingColumnError(err)) throw err;
+    logger.warn(
+      `Run ${runId}: scrape_runs.failure_reasons is missing — apply migration 011; recording counts without failure attribution`,
+    );
+    const legacy = legacyUpdateScrapeRunStatement(update);
+    await query(legacy.sql, legacy.params);
+  }
 }
 
 // Pin disable + auto-recovery helpers extracted to ./scrape-pin-recovery.ts
@@ -141,8 +160,12 @@ export async function scrapeRetailer(slug: string) {
 
   let pagesAttempted = 0;
   let pagesSucceeded = 0;
-  let errorsCount = 0;
   let rejectedCount = 0;
+  // #6182: the error count IS the tally's total. Keeping a separate
+  // `errorsCount` counter alongside it would make "every error has a recorded
+  // reason" a convention that any future `errorsCount++` could silently break;
+  // deriving it makes the two impossible to disagree.
+  const failureReasons = new FailureReasonTally();
 
   const delay = config.rateLimit?.delayBetweenRequestsMs ?? 2_000;
 
@@ -177,7 +200,7 @@ export async function scrapeRetailer(slug: string) {
 
       if (products.length === 0) {
         logger.warn(`  [${target.id}] parsed 0 products — counting as error`);
-        errorsCount++;
+        failureReasons.recordParsedZeroProducts();
         if (isDirect && pinnedProductId && pinnedMatchId) {
           await handlePinError(pinnedProductId, pinnedMatchId, target.id);
         }
@@ -208,7 +231,7 @@ export async function scrapeRetailer(slug: string) {
           logger.warn(
             `  [${target.id}] pin validator reject — skipping observation, counting as pin error. reasons=${validator?.reasons?.join(',') || 'unknown'} score=${validator?.score?.toFixed(2) || '0.00'} title="${product.rawTitle}"`,
           );
-          errorsCount += validatorOutcome.errorCount;
+          if (validatorOutcome.errorCount > 0) failureReasons.recordPinValidatorRejection();
           if (pinnedProductId && pinnedMatchId) {
             await handlePinError(pinnedProductId, pinnedMatchId, target.id);
           }
@@ -317,7 +340,11 @@ export async function scrapeRetailer(slug: string) {
 
       pagesSucceeded++;
     } catch (err) {
-      errorsCount++;
+      // `failures` carries the adapter's per-candidate classification. An error
+      // that is not a SearchTargetError has none, and recordPageFailure files
+      // it as unknown-error rather than dropping it — an unattributed page is
+      // itself a finding, and a silent drop would undercount the run's errors.
+      failureReasons.recordPageFailure(err instanceof SearchTargetError ? err.failures : []);
       if (err instanceof SearchTargetError) rejectedCount += err.rejectedCount;
       logger.error(`  [${target.id}] failed: ${err}`);
       if (isDirect && pinnedProductId && pinnedMatchId) {
@@ -328,9 +355,21 @@ export async function scrapeRetailer(slug: string) {
     if (pagesAttempted < targets.length) await sleep(delay);
   }
 
+  const errorsCount = failureReasons.total;
   const status = resolveRunStatus(errorsCount, pagesSucceeded, budgetExhausted);
-  await updateScrapeRun(runId, status, pagesAttempted, pagesSucceeded, errorsCount, rejectedCount);
-  logger.info(`Run ${runId} finished: ${status} (${pagesSucceeded}/${pagesAttempted} pages, rejected=${rejectedCount})`);
+  const failureReasonsJson = failureReasons.toJSON();
+  await updateScrapeRun(
+    runId,
+    status,
+    pagesAttempted,
+    pagesSucceeded,
+    errorsCount,
+    rejectedCount,
+    failureReasonsJson,
+  );
+  logger.info(
+    `Run ${runId} finished: ${status} (${pagesSucceeded}/${pagesAttempted} pages, rejected=${rejectedCount}, reasons=${JSON.stringify(failureReasonsJson)})`,
+  );
 
   const parseSuccessRate = pagesAttempted > 0 ? (pagesSucceeded / pagesAttempted) * 100 : 0;
   const isSuccess = status === 'completed' || status === 'partial';

--- a/consumer-prices-core/src/ops/coverage.test.ts
+++ b/consumer-prices-core/src/ops/coverage.test.ts
@@ -94,6 +94,63 @@ describe('consumer-price coverage summaries', () => {
     expect(empty.retailers).toEqual([]);
   });
 
+  // #6182: COVERAGE_PARTIAL on its own cannot distinguish "the pages never
+  // loaded" from "a price was extracted and the validator refused it" — the
+  // two need opposite fixes. The reason map is what separates them.
+  it('carries per-retailer failure reasons and rolls them up per market', () => {
+    const snapshot = summarizeMarketCoverage('sa', '2026-08-01T00:00:00.000Z', [
+      retailer({
+        slug: 'carrefour_sa',
+        pagesSucceeded: 5,
+        errorsCount: 7,
+        runStatus: 'partial',
+        failureReasons: { 'missing-price': 6, 'provider-error': 1 },
+      }),
+      retailer({
+        slug: 'noon_sa',
+        pagesSucceeded: 7,
+        errorsCount: 5,
+        runStatus: 'partial',
+        failureReasons: { 'missing-price': 2, 'title-mismatch': 3 },
+      }),
+    ]);
+
+    expect(snapshot.retailers[0].failureReasons).toEqual({ 'missing-price': 6, 'provider-error': 1 });
+    expect(snapshot.failureReasons).toEqual({
+      'missing-price': 8,
+      'provider-error': 1,
+      'title-mismatch': 3,
+    });
+  });
+
+  // The vocabulary is closed. A code the reader does not know would be echoed
+  // to operators through health as an uninterpretable diagnostic, and a
+  // negative or fractional count would corrupt the market rollup.
+  it('drops reasons outside the closed vocabulary and non-positive counts', () => {
+    const summary = summarizeRetailerCoverage(retailer({
+      pagesSucceeded: 10,
+      errorsCount: 2,
+      runStatus: 'partial',
+      failureReasons: {
+        'missing-price': 2,
+        'not-a-real-reason': 5,
+        'provider-error': 0,
+        'title-mismatch': -3,
+        'validator-rejected': 1.5,
+      } as Record<string, number>,
+    }));
+
+    expect(summary.failureReasons).toEqual({ 'missing-price': 2 });
+  });
+
+  it('reports an empty reason map when the producer wrote none', () => {
+    const summary = summarizeRetailerCoverage(retailer());
+    expect(summary.failureReasons).toEqual({});
+
+    const snapshot = summarizeMarketCoverage('ae', '2026-08-01T00:00:00.000Z', [retailer()]);
+    expect(snapshot.failureReasons).toEqual({});
+  });
+
   it('does not call an in-progress scrape healthy before it finishes', () => {
     const snapshot = summarizeMarketCoverage('ae', '2026-08-01T00:00:00.000Z', [
       retailer({ pagesSucceeded: 12, runStatus: 'running' }),

--- a/consumer-prices-core/src/ops/coverage.ts
+++ b/consumer-prices-core/src/ops/coverage.ts
@@ -8,7 +8,34 @@
  * #5445 and #5811; this is the coordination/health layer only.
  */
 
+import { COVERAGE_FAILURE_REASONS } from '../jobs/scrape-coverage.js';
+
 export const MIN_MARKET_COMPLETION_RATIO = 0.5;
+
+const KNOWN_FAILURE_REASONS = new Set<string>(COVERAGE_FAILURE_REASONS);
+
+/**
+ * Keep only whole positive counts under the producer's closed vocabulary.
+ *
+ * The map crosses a process boundary (JSONB written by the scraper, read back
+ * here, relayed to operators through health), so an unknown code or a
+ * negative/fractional count is a producer/schema drift rather than a
+ * diagnostic. Dropping it keeps the market rollup arithmetic sound and matches
+ * how health treats every other per-producer code vocabulary.
+ */
+function sanitizeFailureReasons(
+  raw: Record<string, number> | null | undefined,
+): Record<string, number> {
+  if (!raw || typeof raw !== 'object') return {};
+  const clean: Record<string, number> = {};
+  for (const [reason, value] of Object.entries(raw)) {
+    if (!KNOWN_FAILURE_REASONS.has(reason)) continue;
+    const count = Number(value);
+    if (!Number.isSafeInteger(count) || count <= 0) continue;
+    clean[reason] = count;
+  }
+  return clean;
+}
 
 /**
  * Coverage-schema activation handshake (#6059).
@@ -61,6 +88,8 @@ export interface RetailerCoverageInput {
   pagesSucceeded: number;
   errorsCount: number;
   rejectedCount: number;
+  /** Terminal failure class -> count, summing to `errorsCount` (#6182). */
+  failureReasons?: Record<string, number> | null;
   activeRun?: ActiveScrapeRun | null;
 }
 
@@ -76,6 +105,7 @@ export interface RetailerCoverage extends RetailerCoverageInput {
   failedPages: number;
   completionRatio: number | null;
   coverageStatus: RetailerCoverageStatus;
+  failureReasons: Record<string, number>;
 }
 
 export interface MarketCoverageSnapshot {
@@ -89,6 +119,7 @@ export interface MarketCoverageSnapshot {
   status: MarketCoverageStatus;
   minimumCompletionRatio: number;
   retailers: RetailerCoverage[];
+  failureReasons: Record<string, number>;
   upstreamUnavailable: false;
 }
 
@@ -120,6 +151,9 @@ export function summarizeRetailerCoverage(input: RetailerCoverageInput): Retaile
     pagesSucceeded,
     errorsCount,
     rejectedCount,
+    // Overwrites the raw value the spread copied from `input` — the spread is
+    // what would otherwise relay an unvalidated map straight to health.
+    failureReasons: sanitizeFailureReasons(input.failureReasons),
     failedPages,
     completionRatio,
     coverageStatus,
@@ -136,6 +170,12 @@ export function summarizeMarketCoverage(
   const completedPages = retailers.reduce((sum, retailer) => sum + retailer.pagesSucceeded, 0);
   const failedPages = retailers.reduce((sum, retailer) => sum + retailer.failedPages, 0);
   const rejectedCount = retailers.reduce((sum, retailer) => sum + retailer.rejectedCount, 0);
+  const failureReasons: Record<string, number> = {};
+  for (const retailer of retailers) {
+    for (const [reason, count] of Object.entries(retailer.failureReasons)) {
+      failureReasons[reason] = (failureReasons[reason] ?? 0) + count;
+    }
+  }
   const completionRatio = attemptedPages > 0
     ? Number((completedPages / attemptedPages).toFixed(4))
     : null;
@@ -166,6 +206,7 @@ export function summarizeMarketCoverage(
     status,
     minimumCompletionRatio: MIN_MARKET_COMPLETION_RATIO,
     retailers,
+    failureReasons,
     upstreamUnavailable: false,
   };
 }

--- a/consumer-prices-core/src/snapshots/coverage.test.ts
+++ b/consumer-prices-core/src/snapshots/coverage.test.ts
@@ -44,4 +44,96 @@ describe('coverage snapshot persistence contract', () => {
     expect(sql).toContain("status = 'running'");
     expect(mockQuery.mock.calls[0][1]).toEqual(['ae']);
   });
+
+  // The reason map is the whole point of #6182's diagnostics: if the query
+  // stops selecting it, coverage silently reverts to bare counts and every
+  // market reads COVERAGE_PARTIAL with no cause attached.
+  it('reads the run failure reasons through to the snapshot', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{
+      slug: 'carrefour_sa',
+      name: 'Carrefour Saudi Arabia',
+      last_run_at: new Date('2026-08-07T02:00:00.000Z'),
+      run_status: 'partial',
+      pages_attempted: '12',
+      pages_succeeded: '5',
+      errors_count: '7',
+      rejected_count: '1',
+      failure_reasons: { 'missing-price': 6, 'provider-error': 1 },
+      active_started_at: null,
+      active_pages_attempted: '0',
+      active_pages_succeeded: '0',
+      active_errors_count: '0',
+      active_rejected_count: '0',
+    }] });
+
+    const snapshot = await buildCoverageSnapshot('sa');
+    expect(mockQuery.mock.calls[0][0] as string).toContain('failure_reasons');
+    expect(snapshot.retailers[0].failureReasons).toEqual({ 'missing-price': 6, 'provider-error': 1 });
+    expect(snapshot.failureReasons).toEqual({ 'missing-price': 6, 'provider-error': 1 });
+  });
+
+  // Symmetric with the writer's fallback. This query feeds the /coverage route
+  // that publish.ts reads, so a hard failure here does not just lose the new
+  // diagnostic — it removes the market's whole coverage block from seed
+  // metadata and health. On a pre-011 database it must still answer.
+  it('retries without failure_reasons when the column does not exist yet', async () => {
+    const undefinedColumn = Object.assign(new Error('column "failure_reasons" does not exist'), {
+      code: '42703',
+    });
+    mockQuery.mockRejectedValueOnce(undefinedColumn);
+    mockQuery.mockResolvedValueOnce({ rows: [{
+      slug: 'retailer-a',
+      name: 'Retailer A',
+      last_run_at: new Date('2026-08-07T02:00:00.000Z'),
+      run_status: 'partial',
+      pages_attempted: '12',
+      pages_succeeded: '10',
+      errors_count: '2',
+      rejected_count: '1',
+      active_started_at: null,
+      active_pages_attempted: '0',
+      active_pages_succeeded: '0',
+      active_errors_count: '0',
+      active_rejected_count: '0',
+    }] });
+
+    const snapshot = await buildCoverageSnapshot('ae');
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(mockQuery.mock.calls[0][0]).toContain('failure_reasons');
+    expect(mockQuery.mock.calls[1][0]).not.toContain('failure_reasons');
+    expect(snapshot.retailers[0].pagesSucceeded).toBe(10);
+    expect(snapshot.retailers[0].failureReasons).toEqual({});
+  });
+
+  // Any other database fault must surface. Swallowing it would let a genuine
+  // outage publish a truthful-looking snapshot built from a second failed read.
+  it('does not retry on a database error other than undefined-column', async () => {
+    mockQuery.mockRejectedValueOnce(Object.assign(new Error('connection terminated'), { code: '57P01' }));
+    await expect(buildCoverageSnapshot('ae')).rejects.toThrow('connection terminated');
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  // Rows written before migration 011, and retailers that have never run, come
+  // back without the column. That must read as "no reasons recorded", not throw.
+  it('tolerates a row with no failure_reasons column', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{
+      slug: 'retailer-a',
+      name: 'Retailer A',
+      last_run_at: null,
+      run_status: null,
+      pages_attempted: '0',
+      pages_succeeded: '0',
+      errors_count: '0',
+      rejected_count: '0',
+      active_started_at: null,
+      active_pages_attempted: '0',
+      active_pages_succeeded: '0',
+      active_errors_count: '0',
+      active_rejected_count: '0',
+    }] });
+
+    const snapshot = await buildCoverageSnapshot('ae');
+    expect(snapshot.retailers[0].failureReasons).toEqual({});
+    expect(snapshot.failureReasons).toEqual({});
+  });
 });

--- a/consumer-prices-core/src/snapshots/coverage.ts
+++ b/consumer-prices-core/src/snapshots/coverage.ts
@@ -1,4 +1,5 @@
 import { query } from '../db/client.js';
+import { isMissingColumnError } from '../jobs/scrape-coverage.js';
 import {
   summarizeMarketCoverage,
   type MarketCoverageSnapshot,
@@ -14,6 +15,7 @@ interface LatestScrapeRunRow {
   pages_succeeded: number | string | null;
   errors_count: number | string | null;
   rejected_count: number | string | null;
+  failure_reasons: Record<string, number> | null;
   active_started_at: Date | string | null;
   active_pages_attempted: number | string | null;
   active_pages_succeeded: number | string | null;
@@ -30,9 +32,11 @@ function asIso(value: Date | string | null): string | null {
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
 }
 
-export async function buildCoverageSnapshot(marketCode: string): Promise<MarketCoverageSnapshot> {
-  const result = await query<LatestScrapeRunRow>(
-    `SELECT
+/**
+ * @param withFailureReasons false reproduces the pre-migration-011 column list.
+ */
+function coverageQuery(withFailureReasons: boolean): string {
+  return `SELECT
        r.slug,
        r.name,
        latest.started_at AS last_run_at,
@@ -41,6 +45,7 @@ export async function buildCoverageSnapshot(marketCode: string): Promise<MarketC
        COALESCE(latest.pages_succeeded, 0) AS pages_succeeded,
        COALESCE(latest.errors_count, 0) AS errors_count,
        COALESCE(latest.rejected_count, 0) AS rejected_count,
+       ${withFailureReasons ? "COALESCE(latest.failure_reasons, '{}'::jsonb) AS failure_reasons," : ''}
        active.started_at AS active_started_at,
        COALESCE(active.pages_attempted, 0) AS active_pages_attempted,
        COALESCE(active.pages_succeeded, 0) AS active_pages_succeeded,
@@ -48,7 +53,7 @@ export async function buildCoverageSnapshot(marketCode: string): Promise<MarketC
        COALESCE(active.rejected_count, 0) AS active_rejected_count
      FROM retailers r
      LEFT JOIN LATERAL (
-       SELECT started_at, status, pages_attempted, pages_succeeded, errors_count, rejected_count
+       SELECT started_at, status, pages_attempted, pages_succeeded, errors_count, rejected_count${withFailureReasons ? ', failure_reasons' : ''}
        FROM scrape_runs
        WHERE retailer_id = r.id AND status IN ('completed', 'partial', 'failed')
        ORDER BY started_at DESC
@@ -62,9 +67,23 @@ export async function buildCoverageSnapshot(marketCode: string): Promise<MarketC
        LIMIT 1
      ) active ON TRUE
      WHERE r.market_code = $1 AND r.active = true
-     ORDER BY r.slug`,
-    [marketCode],
-  );
+     ORDER BY r.slug`;
+}
+
+export async function buildCoverageSnapshot(marketCode: string): Promise<MarketCoverageSnapshot> {
+  let result;
+  try {
+    result = await query<LatestScrapeRunRow>(coverageQuery(true), [marketCode]);
+  } catch (err) {
+    // Mirrors the writer's fallback in scrape.ts: no Railway service runs the
+    // migration runner, so this code can reach production before migration
+    // 011. This query backs the /coverage route publish.ts reads, so failing
+    // hard would drop the market's ENTIRE coverage block from seed metadata
+    // and health — far more than the one field that is actually missing.
+    // Only undefined_column is retried; every other fault still surfaces.
+    if (!isMissingColumnError(err)) throw err;
+    result = await query<LatestScrapeRunRow>(coverageQuery(false), [marketCode]);
+  }
 
   const inputs: RetailerCoverageInput[] = result.rows.map((row) => ({
     slug: row.slug,
@@ -75,6 +94,7 @@ export async function buildCoverageSnapshot(marketCode: string): Promise<MarketC
     pagesSucceeded: asCount(row.pages_succeeded),
     errorsCount: asCount(row.errors_count),
     rejectedCount: asCount(row.rejected_count),
+    failureReasons: row.failure_reasons,
     activeRun: row.active_started_at ? {
       startedAt: asIso(row.active_started_at)!,
       pagesAttempted: asCount(row.active_pages_attempted),

--- a/scripts/seed-consumer-prices.mjs
+++ b/scripts/seed-consumer-prices.mjs
@@ -97,6 +97,7 @@ export function emptyCoverage(market) {
     failedPages: 0,
     completionRatio: null,
     rejectedCount: 0,
+    failureReasons: {},
     status: 'unknown',
     minimumCompletionRatio: 0.5,
     retailers: [],
@@ -123,6 +124,12 @@ export function coverageForSeedMeta(data) {
     failedPages: Number(data.failedPages) || 0,
     completionRatio: data.completionRatio == null ? null : Number(data.completionRatio) || 0,
     rejectedCount: Number(data.rejectedCount) || 0,
+    // #6182: the terminal failure class behind the counts. Relayed as written
+    // by consumer-prices-core, which already constrained it to the closed
+    // vocabulary; health re-filters before echoing it to operators.
+    failureReasons: data.failureReasons && typeof data.failureReasons === 'object'
+      ? data.failureReasons
+      : {},
     retailers: data.retailers,
   };
 }

--- a/tests/consumer-prices-coverage-contract.test.mjs
+++ b/tests/consumer-prices-coverage-contract.test.mjs
@@ -2,15 +2,51 @@ import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { coverageForSeedMeta, emptyCoverage } from '../scripts/seed-consumer-prices.mjs';
+// Runs under `tsx --test tests/*.test.mjs`, so the core TypeScript module is
+// importable directly and the vocabulary can be compared value-to-value rather
+// than scraped out of the source with a regex that could false-pass on a typo.
+import { COVERAGE_FAILURE_REASONS as CORE_FAILURE_REASONS } from '../consumer-prices-core/src/jobs/scrape-coverage.ts';
+import { COVERAGE_FAILURE_REASONS as HEALTH_FAILURE_REASONS } from '../api/health.js';
 
 const migration = readFileSync(
   new URL('../consumer-prices-core/migrations/010_scrape_run_coverage.sql', import.meta.url),
   'utf8',
 );
 
+const failureReasonsMigration = readFileSync(
+  new URL('../consumer-prices-core/migrations/011_scrape_run_failure_reasons.sql', import.meta.url),
+  'utf8',
+);
+
 test('scrape coverage migration persists a nonnegative rejection counter', () => {
   assert.match(migration, /ADD COLUMN IF NOT EXISTS rejected_count INT NOT NULL DEFAULT 0/);
   assert.match(migration, /CHECK \(rejected_count >= 0\)/);
+});
+
+test('failure-reason migration defaults to an empty object and rejects non-object shapes', () => {
+  assert.match(
+    failureReasonsMigration,
+    /ADD COLUMN IF NOT EXISTS failure_reasons JSONB NOT NULL DEFAULT '\{\}'::jsonb/,
+  );
+  // Without the type guard a stray array or scalar reaches health as an
+  // unreadable diagnostic instead of failing at write time.
+  assert.match(failureReasonsMigration, /CHECK \(jsonb_typeof\(failure_reasons\) = 'object'\)/);
+});
+
+// The vocabulary is duplicated because api/health.js is an Edge module that
+// cannot import the core package's TypeScript. Health DROPS anything outside
+// its own list, so a code added only to the producer would be silently deleted
+// on the way to operators — a diagnostic that vanishes exactly when a new
+// failure mode appears. Order matters too: both sides are the same contract.
+test('the failure-reason vocabulary is identical in the producer and in health', () => {
+  assert.ok(CORE_FAILURE_REASONS.length > 0, 'the producer vocabulary must not be empty');
+  assert.deepEqual(
+    [...HEALTH_FAILURE_REASONS],
+    [...CORE_FAILURE_REASONS],
+    'Add the new code to BOTH consumer-prices-core/src/jobs/scrape-coverage.ts '
+    + '(COVERAGE_FAILURE_REASONS) and api/health.js (COVERAGE_FAILURE_REASONS), '
+    + 'or health will drop it.',
+  );
 });
 
 test('manual fallback preserves partial coverage and per-retailer diagnostics in seed meta', () => {
@@ -21,6 +57,7 @@ test('manual fallback preserves partial coverage and per-retailer diagnostics in
     failedPages: 6,
     completionRatio: 0.5,
     rejectedCount: 3,
+    failureReasons: { 'missing-price': 4, 'provider-error': 2 },
     retailers: [{ slug: 'retailer-a', coverageStatus: 'partial', rejectedCount: 3 }],
   };
 
@@ -30,6 +67,7 @@ test('manual fallback preserves partial coverage and per-retailer diagnostics in
     failedPages: 6,
     completionRatio: 0.5,
     rejectedCount: 3,
+    failureReasons: { 'missing-price': 4, 'provider-error': 2 },
     retailers: coverage.retailers,
   });
   assert.equal(coverageForSeedMeta({ upstreamUnavailable: true }), undefined);

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -158,6 +158,75 @@ test('classifyKey: consumer-price coverage requires diagnostics and exposes reta
   assert.equal(entry.coverage.retailers[0].coverageStatus, 'failed');
 });
 
+// #6182: COVERAGE_PARTIAL is the same status whether the pages never loaded or
+// a price was extracted and the validator refused it, and those need opposite
+// fixes. The reason map is the only thing that separates them, so health must
+// relay it — under a closed vocabulary, like every other producer code.
+test('classifyKey: consumer-price coverage relays bounded failure reasons and drops unknown codes', () => {
+  const key = BOOTSTRAP_KEYS.consumerPricesCoverage;
+  const entry = classifyKey('consumerPricesCoverage', key, { allowOnDemand: false }, makeCtx({
+    strens: { [key]: 2048 },
+    metaValues: {
+      [SEED_META.consumerPricesCoverage.key]: seedMeta({
+        recordCount: 4,
+        coverage: {
+          status: 'partial',
+          completedPages: 8,
+          failedPages: 2,
+          completionRatio: 0.8,
+          rejectedCount: 3,
+          failureReasons: {
+            'missing-price': 2,
+            'validator-rejected': 1,
+            'not-a-real-reason': 9,
+            'provider-error': -4,
+          },
+          retailers: [{
+            slug: 'retailer-a',
+            name: 'Retailer A',
+            coverageStatus: 'failed',
+            pagesAttempted: 2,
+            pagesSucceeded: 0,
+            failedPages: 2,
+            rejectedCount: 1,
+            completionRatio: 0,
+            failureReasons: { 'missing-price': 2, 'bogus-code': 1 },
+          }],
+        },
+      }),
+    },
+  }));
+
+  assert.deepEqual(entry.coverage.failureReasons, {
+    'missing-price': 2,
+    'validator-rejected': 1,
+  });
+  assert.deepEqual(entry.coverage.retailers[0].failureReasons, { 'missing-price': 2 });
+});
+
+test('classifyKey: consumer-price coverage without failure reasons reports an empty map', () => {
+  const key = BOOTSTRAP_KEYS.consumerPricesCoverage;
+  const entry = classifyKey('consumerPricesCoverage', key, { allowOnDemand: false }, makeCtx({
+    strens: { [key]: 2048 },
+    metaValues: {
+      [SEED_META.consumerPricesCoverage.key]: seedMeta({
+        recordCount: 4,
+        coverage: {
+          status: 'partial',
+          completedPages: 8,
+          failedPages: 2,
+          completionRatio: 0.8,
+          rejectedCount: 3,
+          retailers: [{ slug: 'retailer-a', coverageStatus: 'partial' }],
+        },
+      }),
+    },
+  }));
+
+  assert.deepEqual(entry.coverage.failureReasons, {});
+  assert.deepEqual(entry.coverage.retailers[0].failureReasons, {});
+});
+
 test('classifyKey: missing consumer-price coverage metadata fails closed', () => {
   const key = BOOTSTRAP_KEYS.consumerPricesCoverage;
   const entry = classifyKey('consumerPricesCoverage', key, { allowOnDemand: false }, makeCtx({


### PR DESCRIPTION
## Summary

Every consumer-price market reports `COVERAGE_PARTIAL` (or worse), and the status alone cannot say why. A market at 100% pages with one validator rejection and a market at 39% pages with 22 failed pages produce the same string — and they need opposite fixes.

The adapter already classifies every failed candidate into a bounded vocabulary. `scrape.ts` threw it away **one line before persistence**:

```ts
} catch (err) {
  errorsCount++;
  if (err instanceof SearchTargetError) rejectedCount += err.rejectedCount;  // err.failures dropped
```

So both prior recovery rounds (#6185, #6270) had to answer "which retailer failed how" by pulling and parsing Railway logs by hand. This persists that classification on the production path.

Related: #6182

## Production diagnosis (2026-08-07T02:32Z run)

Pulled from the `seed-consumer-prices` Railway logs and classified. This is the run behind the currently-served health snapshot.

84 pages failed across the fleet; the log parser attributed 83 of them.

| Terminal class | Failed pages |
|---|---:|
| `missing-price` (extractor returned no price) | **76** |
| `title-mismatch` (extracted, validator refused) | 5 |
| `provider-error` | 2 |
| unattributed | 1 |

Three findings:

**1. The dominant failure is `firecrawl:missing-price`, on retailers neither PR touched.** AnaNinja SA fell 11/12 → 2/12 and Woolworths AU 12/12 → 4/12; both have no Exa fallback configured, so neither could have been affected by #6185's opt-in fallback or #6270's repair of it. 39 of the 76 `missing-price` pages are on retailers with **no fallback path at all**.

**2. The Exa `/contents` HTTP 400 was still live in this run** — 11 occurrences, opening the extraction cooldown on exactly the five retailers #6185 opted in (`carrefour_sa`, `coldstorage_sg`, `jiomart_in`, `noon_grocery_ae`, `noon_sa`). That is the defect #6270 fixed. #6270's own merge deployment was `SKIPPED` by the watch-paths filter at 05:14Z, but a descendant commit deployed successfully at 06:23Z, so **the fix is live now and has not yet run a scheduled cycle**. The next run is its first production exercise.

**3. Brazil's `pagesAttempted: 11` is not a defect.** `configs/baskets/essentials_br.yaml` has 11 items, not 12. Verified against the logs directly: zero `[budget]` truncation lines, and exactly two retailers logging `Discovered 11 targets` — the two BR retailers. No page is being lost there.

## What changed

- **`FailureReasonTally`** — one terminal reason per failed page. The class reported is the furthest pipeline stage any candidate reached, which is what separates "never loaded" from "priced and then refused".
- **`errorsCount` is now derived from the tally**, not a parallel counter. "Every error has a recorded reason" was initially a convention held up by three `errorsCount++` sites each sitting next to a matching `record*()` call — one future edit away from silent drift. `errorsCount = failureReasons.total` makes the two impossible to disagree, and deletes a variable.
- **Migration 011** — `failure_reasons JSONB NOT NULL DEFAULT '{}'`, with a `jsonb_typeof = 'object'` guard.
- **Threaded through** `scrape.ts` → `scrape_runs` → `buildCoverageSnapshot` → seed metadata → health, next to the counts it explains.
- **Closed vocabulary at the health boundary.** Health drops any code outside the list, matching how it treats every other per-producer code. The two copies (Edge JS cannot import the core TypeScript) are pinned value-to-value by a test.

## Deploy safety

None of the three consumer-price Railway services runs the migration runner — migration 011 is applied by hand, so this code can reach production first. Both the write and the read retry without the column on Postgres `42703` (`undefined_column`) only:

- Writer: losing `updateScrapeRun` would strand every run row at `status='running'`, and `buildCoverageSnapshot` only reads terminal runs — the market's coverage would silently freeze at the previous day's numbers.
- Reader: this query backs the `/coverage` route `publish.ts` reads, so failing hard would drop the market's entire coverage block from seed metadata and health.

Any other database error still surfaces; a test pins that a `57P01` is not swallowed.

## Known limitation (documented in the code)

One class per page means a page where the primary extractor answered `missing-price` **and** the fallback provider errored is reported as `missing-price`. A fallback-only outage is therefore masked whenever the primary still runs — which is exactly how the Exa 400 above stayed hidden. This map is a page-outcome breakdown, not a provider health signal; `[search:provider-cooldown]` remains the line that says a provider died mid-scrape.

## What this does NOT do

It does not recover coverage, and no acceptance threshold in #6182 is met by it. The evidence says the remaining lever is not in the adapter: `missing-price` at 76 of 83 attributed failures, over half of them on retailers with no fallback, is a Firecrawl extraction-quality/blocking problem. Widening the Exa fallback fleet-wide is the obvious next move but is deliberately **not** taken here — the fallback has never once completed a production cycle (#6270 shipped hours ago), and #6270's cold-start measurements showed it helping some retailers and hurting others. That decision should be made from one clean cycle of the data this PR now records.

## Verification

- `consumer-prices-core`: 22 files, 215 tests pass; `tsc --noEmit` clean.
- Root repo: 494 tests across the 29 test files that consume `api/health.js`, `scripts/seed-consumer-prices.mjs`, or the consumer-price coverage contract — all pass. Repo `typecheck`, `biome`, and `lint:api-contract` clean.
- Every new behavior was driven from an observed red first.
- The producer<->health vocabulary pin was mutation-tested: adding one code to the health list only turns it red (mutant applied, red confirmed, reverted by file copy).
- Production claims above were read from the Railway logs, not inferred.

**Not run locally:** the full `npm run test:data` sweep. It was started, ran past 30 minutes without completing, and I stopped it rather than let it race the other checks — so it is unverified here and CI is the authoritative run. The targeted 29-file batch above covers every module this diff touches.

**Review coverage:** a five-reviewer fan-out (correctness, adversarial, migration/reliability, testing, plus an independent gpt-5.5 pass) was dispatched and none returned within ~90 minutes; they were stood down without findings. The `errorsCount` derivation above came from doing that critical check directly instead — every `errorsCount` mutation site was audited by hand, then the invariant was made structural so it cannot regress. Treat this PR as having had no independent review.

## Post-deploy

1. Apply migration 011 (`npm run migrate` against the consumer-prices database) — before or after deploy; the fallbacks make the order safe, but the diagnostic is absent until it runs.
2. On the next scheduled cycle, `failureReasons` appears per retailer and per market in `/api/health?compact=1`. That run is also #6270's first production exercise.
