### PR TITLE
fix(china): retry Japan MOD empty index through proxy

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -575,8 +575,9 @@ fail-closed read and hand-off contract.
 
 The official discovery URL is the Japanese Joint Staff homepage,
 `https://www.mod.go.jp/js/`. The runtime makes one direct request and, after a
-transport failure, one request through `JAPAN_MOD_PROXY_URL` (falling back to
-`PROXY_URL`). It never downloads linked PDFs during a scheduled run.
+transport failure or an empty allowlisted index, one request through
+`JAPAN_MOD_PROXY_URL` (falling back to `PROXY_URL`). It never downloads linked
+PDFs during a scheduled run.
 
 **Japan MOD's Cloudflare rule is path-level, not egress-level.** Measured
 2026-08-01, from both direct egress and the configured Decodo path:
@@ -648,8 +649,9 @@ Recovery is accepted only when:
 2. `lastSuccessAt` is non-null, later than the deploy, and advances between
    those two successful runs;
 3. the published `_seed.sourceVersion` reads
-   `taiwan-mnd-html+japan-joint-staff-homepage-v2`, proving the new adapter is
-   the code that ran rather than a merged-but-not-deployed PR;
+   `taiwan-mnd-html+japan-joint-staff-homepage-v3`, proving the resilient
+   homepage-discovery adapter is the code that ran rather than a
+   merged-but-not-deployed PR;
 4. the source reports `transportMode: japanese_homepage_candidate_discovery`
    and at least one newly discovered candidate tied to each successful fetch —
    retained rows do not count;

--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -139,7 +139,7 @@ export const CROSS_STRAIT_SOURCE_CONTRACTS = Object.freeze({
     maxRequestsPerRun: 2,
     maxDirectRequestsPerRun: 1,
     maxProxyRequestsPerRun: 1,
-    fallbackPolicy: 'direct_then_proxy_on_transport_failure',
+    fallbackPolicy: 'direct_then_proxy_on_transport_or_empty_content',
     documentAdmission: 'manual_review_required',
     runtimePdfRequestsPerRun: 0,
     // A proxy CONNECT refusal is emitted before the tunnel reaches Japan MOD,
@@ -1539,6 +1539,12 @@ export function parseJapanModIndex(html) {
   return [...new Map(rows.map((row) => [row.sourceUrl, row])).values()];
 }
 
+function parseNonEmptyJapanModIndex(html) {
+  const rows = parseJapanModIndex(html);
+  if (rows.length === 0) throw new Error('JMOD_INDEX_EMPTY');
+  return rows;
+}
+
 function isUsableJapanEnglishIndex(html) {
   const contract = CROSS_STRAIT_SOURCE_CONTRACTS.japanMod;
   return scanHtmlAnchors(html).some((anchor) => {
@@ -1609,7 +1615,7 @@ async function fetchBoundedText(fetchFn, url, sourceContract) {
 
 function shouldProxyJapanModFailure(error) {
   const code = errorCode(error);
-  if (code === 'SOURCE_ERROR' || code === 'TIMEOUT') return true;
+  if (code === 'SOURCE_ERROR' || code === 'TIMEOUT' || code === 'JMOD_INDEX_EMPTY') return true;
   const status = Number(/^HTTP_(\d{3})$/u.exec(code)?.[1]);
   return status === 403
     || status === 408
@@ -2302,11 +2308,22 @@ async function fetchJapanIndexOutcome(fetchFn, sleepFn, {
   let transportPath = 'direct';
   let fallbackReason = null;
   let proxyResponseDetail = null;
+  let rows;
+  let directFailure = null;
   try {
     await sleepFn(REQUEST_CADENCE_MS);
     html = await fetchBoundedText(fetchFn, contract.indexUrl, contract);
-  } catch (directError) {
-    if (!proxyFetchFn || !shouldProxyJapanModFailure(directError)) {
+    rows = parseNonEmptyJapanModIndex(html);
+    // A 200 carrying no allowlisted release is a discovery failure, not a
+    // success: it is how a relocated news list or a challenge page served with
+    // a 200 would otherwise be published as fresh. Treat it like a direct
+    // transport failure so the configured proxy gets its one bounded chance.
+  } catch (error) {
+    directFailure = error;
+  }
+
+  if (directFailure) {
+    if (!proxyFetchFn || !shouldProxyJapanModFailure(directFailure)) {
       return {
         ok: false,
         requestCount,
@@ -2314,10 +2331,10 @@ async function fetchJapanIndexOutcome(fetchFn, sleepFn, {
         transportMode: contract.transportMode,
         availableDocumentUrls: [],
         candidates: [],
-        errorCodes: [errorCode(directError)],
+        errorCodes: [errorCode(directFailure)],
       };
     }
-    fallbackReason = errorCode(directError);
+    fallbackReason = errorCode(directFailure);
     requestCount += 1;
     transportPath = 'proxy';
     try {
@@ -2373,42 +2390,28 @@ async function fetchJapanIndexOutcome(fetchFn, sleepFn, {
         errorCodes: [...new Set([fallbackReason, failureCode])],
       };
     }
-  }
-
-  let rows;
-  try {
-    rows = parseJapanModIndex(html);
-    // A 200 carrying no allowlisted release is a discovery failure, not a
-    // success: it is how a relocated news list or a challenge page served with
-    // a 200 would otherwise be published as fresh.
-    if (rows.length === 0) throw new Error('JMOD_INDEX_EMPTY');
-  } catch (error) {
-    const failureCode = errorCode(error);
-    return {
-      ok: false,
-      requestCount,
-      transportPath,
-      transportMode: contract.transportMode,
-      ...(fallbackReason ? { fallbackReason } : {}),
-      ...(transportPath === 'proxy'
-        ? { proxyFailureReason: failureCode }
-        : {}),
-      ...(transportPath === 'proxy'
-        ? {
-            proxyFailureDetail: buildProxyDiagnosticDetail({
-              ...proxyResponseDetail,
-              stage: 'parse',
-              errorCode: failureCode,
-              errorMessage: error?.message,
-            }),
-          }
-        : {}),
-      availableDocumentUrls: [],
-      candidates: [],
-      errorCodes: fallbackReason
-        ? [...new Set([fallbackReason, failureCode])]
-        : [failureCode],
-    };
+    try {
+      rows = parseNonEmptyJapanModIndex(html);
+    } catch (error) {
+      const failureCode = errorCode(error);
+      return {
+        ok: false,
+        requestCount,
+        transportPath,
+        transportMode: contract.transportMode,
+        fallbackReason,
+        proxyFailureReason: failureCode,
+        proxyFailureDetail: buildProxyDiagnosticDetail({
+          ...proxyResponseDetail,
+          stage: 'parse',
+          errorCode: failureCode,
+          errorMessage: error?.message,
+        }),
+        availableDocumentUrls: [],
+        candidates: [],
+        errorCodes: [...new Set([fallbackReason, failureCode])],
+      };
+    }
   }
 
   let shadowIndexProbe;

--- a/scripts/seed-cross-strait-activity.mjs
+++ b/scripts/seed-cross-strait-activity.mjs
@@ -273,10 +273,11 @@ if (process.argv[1]?.endsWith('seed-cross-strait-activity.mjs')) {
     fetchPhaseTimeoutMs: CROSS_STRAIT_ACTIVITY_FETCH_PHASE_TIMEOUT_MS,
     validateFn: validatePublishableSnapshot,
     declareRecords: (snapshot) => snapshot.observations.length,
-    // Bumped with the #5904 discovery cutover: a merged PR is not proof the new
-    // adapter is running, and the published `_seed.sourceVersion` is what lets
-    // an operator tell a homepage-discovery run from a legacy English-index one.
-    sourceVersion: 'taiwan-mnd-html+japan-joint-staff-homepage-v2',
+    // Bumped with the #5904 discovery cutover and the bounded empty-content
+    // proxy fallback: a merged PR is not proof the new adapter is running, and
+    // the published `_seed.sourceVersion` is what lets an operator distinguish
+    // this resilient homepage-discovery run from an older deployed adapter.
+    sourceVersion: 'taiwan-mnd-html+japan-joint-staff-homepage-v3',
     schemaVersion: 1,
     maxStaleMin: CROSS_STRAIT_ACTIVITY_MAX_STALE_MIN,
     contentMeta: crossStraitActivityContentMeta,

--- a/tests/cross-strait-activity-production-registration.test.mts
+++ b/tests/cross-strait-activity-production-registration.test.mts
@@ -80,6 +80,13 @@ describe('cross-Strait activity production registration (#5575)', () => {
     );
   });
 
+  it('pins the resilient Japan MOD source-version marker used by publication health', () => {
+    assert.match(
+      read('scripts/seed-cross-strait-activity.mjs'),
+      /sourceVersion:\s*'taiwan-mnd-html\+japan-joint-staff-homepage-v3'/,
+    );
+  });
+
   it('hydrates the existing Force Posture panel without touching flight identity rules', () => {
     const panel = read('src/components/MilitaryCorrelationPanel.ts');
     const renderer = read('src/components/cross-strait-activity-summary.ts');

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -1124,7 +1124,7 @@ describe('quantified cross-Strait activity (#5575)', () => {
     );
   });
 
-  it('marks an empty or challenge-page Japan index as a transport error while retaining reviewed rows', async () => {
+  it('retries an empty or challenge-page Japan index through the proxy while retaining reviewed rows', async () => {
     let proxyCalls = 0;
     const fetchFn = async (input: string | URL | Request) => {
       const url = String(input);
@@ -1148,10 +1148,12 @@ describe('quantified cross-Strait activity (#5575)', () => {
       },
     });
     const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
-    assert.equal(japan?.transportStatus, 'error');
-    assert.deepEqual(japan?.errorCodes, ['JMOD_INDEX_EMPTY']);
-    assert.equal(proxyCalls, 0, 'valid HTTP transport with invalid content must not trigger the proxy');
-    assert.equal(snapshot.status, 'degraded');
+    assert.equal(japan?.transportStatus, 'fresh');
+    assert.equal(japan?.requestCount, 2);
+    assert.equal(japan?.transportPath, 'proxy');
+    assert.equal(japan?.fallbackReason, 'JMOD_INDEX_EMPTY');
+    assert.deepEqual(japan?.errorCodes, []);
+    assert.equal(proxyCalls, 1, 'empty direct content must trigger the bounded proxy fallback');
     assert.equal(isCrossStraitActivitySnapshot(snapshot), true);
     assert.ok(
       snapshot.observations
@@ -1211,11 +1213,66 @@ describe('quantified cross-Strait activity (#5575)', () => {
     assert.deepEqual(japan?.errorCodes, []);
     assert.equal(
       CROSS_STRAIT_SOURCE_CONTRACTS.japanMod.fallbackPolicy,
-      'direct_then_proxy_on_transport_failure',
+      'direct_then_proxy_on_transport_or_empty_content',
     );
     assert.equal(CROSS_STRAIT_SOURCE_CONTRACTS.japanMod.maxDirectRequestsPerRun, 1);
     assert.equal(CROSS_STRAIT_SOURCE_CONTRACTS.japanMod.maxProxyRequestsPerRun, 1);
     assert.doesNotMatch(JSON.stringify(japan), /proxy-user|proxy-secret/);
+  });
+
+  it('retains last-good Japan MOD data when empty direct content and the proxy both fail', async () => {
+    const previousSnapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn: crossStraitFixtureFetch(
+        () => new Response(fixture('jmod-homepage.html')),
+      ),
+      now: Date.parse(retrievedAt),
+      previousSnapshot: null,
+      sleepFn: async () => {},
+      proxyUrl: '',
+    });
+    const nextAt = '2026-07-25T11:30:00.000Z';
+    const snapshot = await fetchCrossStraitActivitySnapshot({
+      fetchFn: crossStraitFixtureFetch(
+        () => new Response('<html><body>Access denied</body></html>'),
+      ),
+      now: Date.parse(nextAt),
+      previousSnapshot,
+      sleepFn: async () => {},
+      proxyUrl: 'https://proxy-user:proxy-secret@proxy.test:443',
+      proxyRequestFn: async () => {
+        throw Object.assign(
+          new Error('Proxy CONNECT: HTTP/1.1 407 Proxy Authentication Required'),
+          { status: 407 },
+        );
+      },
+    });
+
+    const japan = snapshot.sources.find((source: { id: string }) => source.id === 'japan-mod');
+    assert.equal(japan?.transportStatus, 'error');
+    assert.equal(japan?.requestCount, 2);
+    assert.equal(japan?.transportPath, 'proxy');
+    assert.equal(japan?.fallbackReason, 'JMOD_INDEX_EMPTY');
+    assert.equal(japan?.proxyFailureReason, 'PROXY_AUTH_FAILED');
+    assert.deepEqual(japan?.errorCodes, ['JMOD_INDEX_EMPTY', 'PROXY_AUTH_FAILED']);
+    assert.equal(japan?.lastSuccessAt, retrievedAt);
+    const previousJapan = previousSnapshot.sources.find(
+      (source: { id: string }) => source.id === 'japan-mod',
+    );
+    assert.equal(
+      japan?.unreviewedCandidateCount,
+      previousJapan?.unreviewedCandidateCount,
+    );
+    const previousIndexPresence = previousSnapshot.observations
+      .filter((row: { sourceId: string }) => row.sourceId === 'japan-mod')
+      .map((row: { id: string; indexPresence?: string }) => [row.id, row.indexPresence]);
+    const currentIndexPresence = snapshot.observations
+      .filter((row: { sourceId: string }) => row.sourceId === 'japan-mod')
+      .map((row: { id: string; indexPresence?: string }) => [row.id, row.indexPresence]);
+    assert.deepEqual(
+      currentIndexPresence,
+      previousIndexPresence,
+      'an empty direct index must not be published as confirmed document absence',
+    );
   });
 
   it('retains last-good Japan MOD data and records both failures when the proxy also fails', async () => {


### PR DESCRIPTION
## Summary

Japan MOD can return an HTTP 200 challenge or relocation page with no allowlisted releases. That result was marked `JMOD_INDEX_EMPTY` without using the configured proxy, leaving the cross-Strait source degraded even though retained reviewed records were still available.

The adapter now treats that empty discovery result as a retryable direct failure, spends exactly one bounded proxy request, keeps fail-closed degradation and retained-record semantics if both attempts fail, and publishes sourceVersion v3 for deployment acceptance.

## Related

Related: #5904

## Tests

- `TMPDIR=/tmp node --import tsx --test tests/cross-strait-activity.test.mts tests/cross-strait-activity-production-registration.test.mts` — 85/85
- `TMPDIR=/tmp node --import tsx --test tests/cross-strait-activity-shipping.test.mts tests/cross-strait-entity-decode.test.mjs tests/seed-freshness-monitor.test.mjs` — 49/49
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run lint` (passes; existing unrelated Biome warnings remain)
- `npm run docs:check`
- Push preflight gates (including changed-test execution and markdown lint) — passed
- `npm run test:data` — repository-wide run reached unrelated pre-push-hook/worktree-sensitive failures and ended exit 1; targeted suites above are green.

## Post-Deploy Monitoring & Validation

- Logs: search Railway cross-Strait seeder logs for `japan-mod`, `JMOD_INDEX_EMPTY`, `transportPath`, and source-health writes after deploy.
- Metrics/health: inspect `/api/health?compact=1` and seed-health for Japan MOD `sourceState`, `lastSuccessAt`, `recordCount`, and `sourceVersion`.
- Healthy: sourceVersion `taiwan-mnd-html+japan-joint-staff-homepage-v3` is deployed, `sourceState` is fresh/OK, `lastSuccessAt` advances, and a newly fetched candidate accompanies retained rows.
- Failure/rollback: if direct and proxy attempts both fail or `SEED_ERROR` persists, leave the explicit degraded marker in place, keep retained rows, and revert or disable the rollout if the proxy path causes repeated fleet impact.
- Window/owner: monitor the first two scheduled runs after deployment (about 6 hours at the 3-hour cadence); WorldMonitor data/relay owner.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS-MODEL](https://img.shields.io/badge/MODEL_SLUG-Codex-000000)