### PR TITLE
docs(health): pin the published /api/health key count to the registry (#6300)

### DIFF
--- a/docs/api-platform.mdx
+++ b/docs/api-platform.mdx
@@ -79,13 +79,14 @@ Monitor via UptimeRobot / Better Stack with `?compact=1` — alert on any status
 ```json
 {
   "status": "HEALTHY",
-  "checkedAt": "2026-04-19T12:00:00Z",
+  "checkedAt": "2026-08-07T12:00:00Z",
   "summary": {
-    "total": 194,
-    "ok": 180,
-    "warn": 5,
-    "onDemandWarn": 9,
+    "total": 256,
+    "ok": 256,
+    "warn": 0,
+    "onDemandWarn": 0,
     "staleContent": 0,
+    "rolloutPending": 0,
     "crit": 0
   },
   "checks": {

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -297,5 +297,10 @@
     "defaultCacheControl": "public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900",
     "defaultCdnTier": "fast",
     "nonCacheable": "no-store"
+  },
+  "healthProbedKeys": {
+    "bootstrap": 109,
+    "standalone": 147,
+    "total": 256
   }
 }

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -36,14 +36,15 @@ Primary health endpoint. Checks all Redis-backed data keys and seed freshness me
 {
   "status": "HEALTHY | WARNING | DEGRADED | UNHEALTHY | REDIS_DOWN",
   "summary": {
-    "total": 194,
-    "ok": 180,
-    "warn": 5,
-    "onDemandWarn": 9,
+    "total": 256,
+    "ok": 256,
+    "warn": 0,
+    "onDemandWarn": 0,
     "staleContent": 0,
+    "rolloutPending": 0,
     "crit": 0
   },
-  "checkedAt": "2026-03-11T14:00:00.000Z",
+  "checkedAt": "2026-08-07T08:25:57.776Z",
   "checks": {
     "earthquakes": {
       "status": "OK",
@@ -55,7 +56,7 @@ Primary health endpoint. Checks all Redis-backed data keys and seed freshness me
 }
 ```
 
-`summary` fields: `total` is one entry per probed key (currently ~194 and growing as panels are added). `warn` **excludes** on-demand-empty keys — those are surfaced separately as `onDemandWarn` so they don't drive the overall verdict to `WARNING`. `staleContent` is a **subset** of `warn` (fresh seeder but the upstream feed stopped advancing), and `rolloutPending` is another **subset** of `warn` (a newly deployed schema still inside its bounded deploy-before-cron window). Only `crit` (`EMPTY`/`EMPTY_DATA`) drives `DEGRADED`/`UNHEALTHY`.
+`summary` fields: `total` is one entry per probed key, and grows as panels are added — read it from your own response rather than from this page. `warn` **excludes** on-demand-empty keys — those are surfaced separately as `onDemandWarn` so they don't drive the overall verdict to `WARNING`. `staleContent` is a **subset** of `warn` (fresh seeder but the upstream feed stopped advancing), and `rolloutPending` is another **subset** of `warn` (a newly deployed schema still inside its bounded deploy-before-cron window). Only `crit` (`EMPTY`/`EMPTY_DATA`) drives `DEGRADED`/`UNHEALTHY`.
 
 With `?compact=1`, the `checks` object is replaced by `problems` containing only non-OK keys.
 
@@ -647,4 +648,4 @@ fi
 | **Data fetched** | Full Redis values (to count records) | Only `seed-meta:*` keys |
 | **HTTP 503** | Only `REDIS_DOWN` (DEGRADED/UNHEALTHY return 200) | No (always 200 unless Redis down) |
 | **Best for** | Uptime monitoring, dashboard health | Debugging seed loop issues |
-| **Response size** | Larger (~194 keys with record counts) | Smaller (seed-meta domains only) |
+| **Response size** | Larger (one entry per probed key, with record counts) | Smaller (seed-meta domains only) |

--- a/docs/zh/api-platform.mdx
+++ b/docs/zh/api-platform.mdx
@@ -74,13 +74,14 @@ description: "World Monitor 平台基础设施端点完整参考：涵盖引导�
 ```json
 {
   "status": "HEALTHY",
-  "checkedAt": "2026-04-19T12:00:00Z",
+  "checkedAt": "2026-08-07T12:00:00Z",
   "summary": {
-    "total": 194,
-    "ok": 180,
-    "warn": 5,
-    "onDemandWarn": 9,
+    "total": 256,
+    "ok": 256,
+    "warn": 0,
+    "onDemandWarn": 0,
     "staleContent": 0,
+    "rolloutPending": 0,
     "crit": 0
   },
   "checks": {

--- a/docs/zh/health-endpoints.mdx
+++ b/docs/zh/health-endpoints.mdx
@@ -36,14 +36,15 @@ description: "World Monitor 提供两个健康检查端点用于持续监控数�
 {
   "status": "HEALTHY | WARNING | DEGRADED | UNHEALTHY | REDIS_DOWN",
   "summary": {
-    "total": 194,
-    "ok": 180,
-    "warn": 5,
-    "onDemandWarn": 9,
+    "total": 256,
+    "ok": 256,
+    "warn": 0,
+    "onDemandWarn": 0,
     "staleContent": 0,
+    "rolloutPending": 0,
     "crit": 0
   },
-  "checkedAt": "2026-03-11T14:00:00.000Z",
+  "checkedAt": "2026-08-07T08:25:57.776Z",
   "checks": {
     "earthquakes": {
       "status": "OK",
@@ -55,7 +56,7 @@ description: "World Monitor 提供两个健康检查端点用于持续监控数�
 }
 ```
 
-`summary` 字段：`total` 是每个探测键的一个条目（目前约 194 个，并随面板增加而增长）。`warn` **不包括**按需为空的键 —— 这些键作为 `onDemandWarn` 单独显示，因此它们不会将总体判定推向 `WARNING`。`staleContent` 是 `warn` 的一个**子集**（种子器新鲜但上游订阅源停止推进），`rolloutPending` 是 `warn` 的另一个**子集**（新部署的 schema 仍处于其有界的「部署先于定时任务」窗口内）。只有 `crit`（`EMPTY`/`EMPTY_DATA`）会驱动 `DEGRADED`/`UNHEALTHY`。
+`summary` 字段：`total` 是每个探测键的一个条目，并随面板增加而增长 —— 请以你自己响应中的数值为准，而非本页示例。`warn` **不包括**按需为空的键 —— 这些键作为 `onDemandWarn` 单独显示，因此它们不会将总体判定推向 `WARNING`。`staleContent` 是 `warn` 的一个**子集**（种子器新鲜但上游订阅源停止推进），`rolloutPending` 是 `warn` 的另一个**子集**（新部署的 schema 仍处于其有界的「部署先于定时任务」窗口内）。只有 `crit`（`EMPTY`/`EMPTY_DATA`）会驱动 `DEGRADED`/`UNHEALTHY`。
 
 使用 `?compact=1` 时，`checks` 对象会被 `problems` 替换，仅包含非 OK 的键。
 
@@ -435,4 +436,4 @@ fi
 | **获取的数据** | 完整 Redis 值（用于计数记录） | 仅 `seed-meta:*` 键 |
 | **HTTP 503** | 仅 `REDIS_DOWN`（DEGRADED/UNHEALTHY 返回 200） | 否（除非 Redis 宕机，否则始终为 200） |
 | **最适合** | 正常运行时间监控、仪表板健康状态 | 调试种子循环问题 |
-| **响应大小** | 较大（约 194 个键及记录计数） | 较小（仅 seed-meta 领域） |
+| **响应大小** | 较大（每个探测键一个条目，含记录计数） | 较小（仅 seed-meta 领域） |

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -368,18 +368,51 @@ function parseBootstrapKeyTiers(source = read('shared/bootstrap-tier-keys.js')) 
 // moment a third mutation lands. So every mutation site is DISCOVERED and must
 // be one this function accounts for; an unrecognized one fails the gate loudly
 // instead of quietly publishing a wrong total.
+const HEALTH_PROBED_REGISTRIES = ['BOOTSTRAP_KEYS', 'STANDALONE_KEYS'];
+
 const HEALTH_REGISTRY_MUTATION_RE = new RegExp(
   [
     // `delete BOOTSTRAP_KEYS.iranEvents;`
     String.raw`delete\s+(?:BOOTSTRAP_KEYS|STANDALONE_KEYS)\s*[.[][^\n]*`,
-    // `BOOTSTRAP_KEYS[name] = ...;` — the `=[^=]` tail keeps reads
-    // (`STANDALONE_KEYS[sibling] ?? …`) and comparisons out of the match.
-    String.raw`(?:BOOTSTRAP_KEYS|STANDALONE_KEYS)\s*(?:\[[^\]]*\]|\.\w+)\s*=[^=][^\n]*`,
-    // `Object.assign(BOOTSTRAP_KEYS, …)`
-    String.raw`Object\.assign\(\s*(?:BOOTSTRAP_KEYS|STANDALONE_KEYS)[^\n]*`,
+    // `BOOTSTRAP_KEYS[name] = ...;` — including the compound forms (`??=`,
+    // `||=`, `&&=`), which register a key just as effectively. The `[^=]` tail
+    // keeps reads (`STANDALONE_KEYS[sibling] ?? …`) and `===` out of the match.
+    String.raw`(?:BOOTSTRAP_KEYS|STANDALONE_KEYS)\s*(?:\[[^\]]*\]|\.\w+)\s*(?:\?\?|\|\||&&)?=[^=][^\n]*`,
+    // `Object.assign(BOOTSTRAP_KEYS, …)` / `Object.defineProperty(…)`
+    String.raw`Object\.(?:assign|defineProperty|defineProperties)\(\s*(?:BOOTSTRAP_KEYS|STANDALONE_KEYS)[^\n]*`,
+    // Aliasing the registry to another binding — writes through the alias are
+    // invisible to every pattern above, so the alias itself is the mutation
+    // site to flag. `\s*[;,)]` keeps ordinary indexed reads
+    // (`… ?? BOOTSTRAP_KEYS[sibling]`, followed by `[`) out of the match.
+    String.raw`=\s*(?:BOOTSTRAP_KEYS|STANDALONE_KEYS)\s*[;,)][^\n]*`,
   ].join('|'),
   'g',
 );
+
+// Comments are blanked before the mutation scan and the registry-body parse.
+// Two distinct silent failures come from reading them as code:
+//   1. A commented-out `// delete BOOTSTRAP_KEYS.iranEvents;` normalizes to the
+//      exact accounted string, satisfying the very presence check whose error
+//      message is "stale arithmetic" while the runtime registry keeps the key.
+//   2. `parseObjectBlockBody` counts raw braces, so one `}` inside a comment in
+//      a registry literal ends the block early and yields a confident short
+//      count rather than an error.
+// Blanked in place (not deleted) so line and column offsets survive — the key
+// matcher below keys on an exact two-space indent.
+//
+// LINE comments must go FIRST. api/health.js:793 contains the line comment
+// `// list synchronized with consumer-prices-core/configs/retailers/*.yaml.`,
+// whose `/*` opens a block comment that the block matcher then runs 1098 lines
+// to the next `*/` to close — blanking the consumer-price loop, the iranEvents
+// delete, and most of STANDALONE_KEYS along with it. Stripping line comments
+// first removes that text before any `/*` is looked for.
+//
+// A `/*` inside a string or regex literal would still mislead the block pass;
+// nothing in this file has one today, and the registry cross-count plus the
+// runtime-pinning test both fail loudly if that ever changes.
+const blankComments = (src) => src
+  .replace(/^([ \t]*)\/\/[^\n]*$/gm, '$1')
+  .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '));
 
 // Every mutation this function knows how to price, in `normalizeMutation` form
 // (trimmed, inner whitespace collapsed). Adding a mutation to api/health.js
@@ -398,17 +431,86 @@ const normalizeMutation = (line) => line.trim().replace(/\s+/g, ' ');
 // Depth-1 entries of a registry object literal. parseObjectBlockBody preserves
 // the original indentation, so a top-level key sits at exactly two spaces; a
 // nested object's keys would sit at four or more and are correctly excluded.
-// Comment lines start with `//` or `*` and cannot match the identifier group.
 function countRegistryEntries(source, name) {
   const body = parseObjectBlockBody(source, `const ${name}`, `${name} in api/health.js`);
+  // The literal's closing brace sits at column 0, so a correctly bounded body
+  // ends on a blank line. Anything else means the brace counter stopped early
+  // on a brace inside a string, and the short count that follows would look
+  // perfectly plausible.
+  if (!/\n[ \t]*$/.test(body)) {
+    throw new Error(`docs-stats: ${name} in api/health.js did not terminate at a top-level closing brace`);
+  }
   const keys = [...body.matchAll(/^ {2}([A-Za-z_$][\w$]*):/gm)].map((m) => m[1]);
   if (keys.length === 0) throw new Error(`docs-stats: ${name} in api/health.js yielded no keys`);
   const dupe = keys.find((k, i) => keys.indexOf(k) !== i);
   if (dupe) throw new Error(`docs-stats: ${name} in api/health.js declares "${dupe}" twice`);
+  // Whole-body conformance check. The matcher above reads exactly ONE shape —
+  // a bare identifier key at a two-space indent, one per line — and silently
+  // ignores every other legal shape: a quoted key, a computed `[CONST]` key, a
+  // `...SPREAD`, a key indented four spaces, a second key on the same line.
+  // Each of those changes `Object.entries(registry)` without changing this
+  // count, and `keys.length === 0` is far too weak an alarm for that.
+  //
+  // Both registries are uniformly flat today (every value is a string literal
+  // or an identifier, one entry per line), so demanding that EVERY non-blank
+  // line conform is a true invariant rather than a guess. A future entry shape
+  // that breaks it gets an explicit "teach the counter" failure instead of a
+  // quietly smaller number. Comments are already blanked by the caller.
+  const nonConforming = body
+    .split('\n')
+    .filter((line) => line.trim() !== '' && !/^ {2}[A-Za-z_$][\w$]*:\s*\S/.test(line));
+  if (nonConforming.length) {
+    throw new Error(
+      `docs-stats: ${name} in api/health.js has ${nonConforming.length} entr${nonConforming.length === 1 ? 'y' : 'ies'} `
+      + `this counter cannot read (it reads one identifier key per line at a two-space indent): `
+      + `${nonConforming.map((l) => l.trim()).join(' | ')}`,
+    );
+  }
+  // A second key sharing a conforming line still counts once. Every entry ends
+  // in a trailing comma, so comparing comma count to key count catches it.
+  const commas = (body.match(/,/g) || []).length;
+  if (commas !== keys.length) {
+    throw new Error(
+      `docs-stats: ${name} in api/health.js has ${commas} entry terminators but ${keys.length} readable keys `
+      + '— more than one entry on a line, or a value containing a comma.',
+    );
+  }
   return keys;
 }
 
-function parseHealthProbedKeys(source = read('api/health.js')) {
+// summary.total is one entry per key in EVERY registry the endpoint's `sources`
+// array walks — not per key in the two registries this function happens to
+// price. Adding a third registry there is the single edit that reproduces #6300
+// exactly: production grows while every gate stays pinned at the old number.
+// So read the array rather than assume it.
+function parseProbedRegistries(source) {
+  const block = source.match(/const sources = \[([\s\S]*?)\n {2}\];/);
+  if (!block) throw new Error('docs-stats: could not parse the `sources` registry array in api/health.js');
+  const listed = [...block[1].matchAll(/\[\s*([A-Za-z_$][\w$]*)\s*,/g)].map((m) => m[1]);
+  if (!sameStringSet(listed, HEALTH_PROBED_REGISTRIES)) {
+    throw new Error(
+      'docs-stats: api/health.js probes a different set of key registries than parseHealthProbedKeys prices '
+      + `(${describeSetDelta(listed, HEALTH_PROBED_REGISTRIES)}) — summary.total cannot be derived.`,
+    );
+  }
+  return listed;
+}
+
+function parseHealthProbedKeys(rawSource = read('api/health.js')) {
+  const source = blankComments(rawSource);
+  parseProbedRegistries(source);
+
+  // The registry size equals summary.total only because the endpoint counts
+  // every entry unconditionally. A `continue` or a variant/env gate inserted
+  // ahead of the increment would shrink production's total while this parse —
+  // and the unit test that pins it to `Object.keys(...).length` — stayed put.
+  if (!/for \(const \[name, redisKey\] of Object\.entries\(registry\)\) \{\s*\n\s*totalChecks\+\+;/.test(source)) {
+    throw new Error(
+      'docs-stats: api/health.js no longer counts every registry entry unconditionally, '
+      + 'so summary.total is no longer the registry size.',
+    );
+  }
+
   const found = [...source.matchAll(HEALTH_REGISTRY_MUTATION_RE)].map((m) => normalizeMutation(m[0]));
   const unaccounted = found.filter((m) => !HEALTH_REGISTRY_ACCOUNTED_MUTATIONS.includes(m));
   if (unaccounted.length) {
@@ -442,7 +544,30 @@ function parseHealthProbedKeys(source = read('api/health.js')) {
   if (!/if \(market === 'ae'\) continue;/.test(source)) {
     throw new Error("docs-stats: the consumer-price health loop no longer skips 'ae'");
   }
-  const addedMarkets = markets.filter((m) => m !== 'ae').length;
+  // Mirror of the iranEvents presence guard below. `BOOTSTRAP_KEYS[name] = …`
+  // OVERWRITES a same-named literal entry at runtime (count unchanged) while
+  // this parse would add one for it — so a market name also declared in the
+  // literal over-counts by one, exactly as a missing iranEvents would
+  // under-count by one.
+  const addedNames = markets.filter((m) => m !== 'ae').map((m) => `consumerPricesCoverage${m.toUpperCase()}`);
+  // Same overwrite semantics within the market list itself: a repeated market
+  // assigns the same property twice at runtime (count unchanged) while a naive
+  // `.length` here would add one per iteration.
+  const repeated = addedNames.find((n, i) => addedNames.indexOf(n) !== i);
+  if (repeated) {
+    throw new Error(
+      `docs-stats: CONSUMER_PRICE_HEALTH_MARKETS yields "${repeated}" more than once — `
+      + 'the runtime registers it once while this count would add it per occurrence.',
+    );
+  }
+  const collision = addedNames.find((name) => bootstrapKeys.includes(name));
+  if (collision) {
+    throw new Error(
+      `docs-stats: BOOTSTRAP_KEYS already declares "${collision}", which the consumer-price loop also `
+      + 'registers — the runtime overwrites it while this count would add it twice.',
+    );
+  }
+  const addedMarkets = addedNames.length;
 
   // -1: iran-events is sunset unless IRAN_EVENTS_ENABLED=true (default false).
   // Asserting it is present in the literal keeps the subtraction from
@@ -454,9 +579,25 @@ function parseHealthProbedKeys(source = read('api/health.js')) {
     throw new Error('docs-stats: IRAN_EVENTS_ENABLED no longer defaults to false — the documented registry size changed');
   }
 
+  // The effective registries: the literal, plus the loop's markets, minus the
+  // sunset key. Names — not just counts — so the unit test can compare SETS
+  // against the imported runtime registries; two compensating errors (one real
+  // key missed, one phantom invented) net to an identical count but not to an
+  // identical set. computeStats stores only the counts: dumping 256 key names
+  // into the committed stats.json would bury the claims it actually publishes.
+  const effectiveBootstrap = [...bootstrapKeys, ...addedNames].filter((k) => k !== 'iranEvents');
   const bootstrap = bootstrapKeys.length + addedMarkets - 1;
   const standalone = standaloneKeys.length;
-  return { bootstrap, standalone, total: bootstrap + standalone };
+  if (effectiveBootstrap.length !== bootstrap) {
+    throw new Error(`docs-stats: internal — bootstrap arithmetic (${bootstrap}) disagrees with its key list (${effectiveBootstrap.length})`);
+  }
+  return {
+    bootstrap,
+    standalone,
+    total: bootstrap + standalone,
+    bootstrapKeys: effectiveBootstrap,
+    standaloneKeys,
+  };
 }
 
 function parseJsonLdBlocks(html) {
@@ -767,7 +908,10 @@ function computeStats() {
     mcpAppUiResources: mcpApps.uiResources,
     mcpAppLinkedTools: mcpApps.linkedTools,
     bootstrapCache: parseBootstrapCacheContract(),
-    healthProbedKeys: parseHealthProbedKeys(),
+    // Counts only — see parseHealthProbedKeys on why the key names stay out.
+    healthProbedKeys: (({ bootstrap, standalone, total }) => ({ bootstrap, standalone, total }))(
+      parseHealthProbedKeys(),
+    ),
   };
 }
 
@@ -967,26 +1111,10 @@ function claims(s) {
     { file: 'blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md', re: /architecture \(\d+\s+proto files, (\d+)\s+typed services\)/, value: s.protoServices },
     { file: 'blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md', re: /using the (\d+)\s+typed API services/, value: s.protoServices },
 
-    // ---- /api/health example response bodies (#6300) ----
-    // `summary.total` is the number a reader uses to decide whether their own
-    // response looks complete, and all four pages published 194 against a live
-    // 256. Anchored on the `"summary": {` line and captured positionally, so a
-    // claim cannot be satisfied by a neighbouring count — every one of these
-    // bodies quotes several integers in a row.
-    //
-    // `ok` is pinned to the same stat on purpose: each example declares an
-    // all-OK fleet, so ok === total is what makes the body internally
-    // consistent. Pinning `total` alone would let `ok` drift back out of step
-    // with it the next time a key is added, which is the same class of silently
-    // wrong published number this gate exists to stop.
-    { file: 'docs/health-endpoints.mdx', re: /"summary":\s*\{\s*"total":\s*(\d+)/, value: s.healthProbedKeys.total },
-    { file: 'docs/health-endpoints.mdx', re: /"summary":\s*\{\s*"total":\s*\d+,\s*"ok":\s*(\d+)/, value: s.healthProbedKeys.total },
-    { file: 'docs/api-platform.mdx', re: /"summary":\s*\{\s*"total":\s*(\d+)/, value: s.healthProbedKeys.total },
-    { file: 'docs/api-platform.mdx', re: /"summary":\s*\{\s*"total":\s*\d+,\s*"ok":\s*(\d+)/, value: s.healthProbedKeys.total },
-    { file: 'docs/zh/health-endpoints.mdx', re: /"summary":\s*\{\s*"total":\s*(\d+)/, value: s.healthProbedKeys.total },
-    { file: 'docs/zh/health-endpoints.mdx', re: /"summary":\s*\{\s*"total":\s*\d+,\s*"ok":\s*(\d+)/, value: s.healthProbedKeys.total },
-    { file: 'docs/zh/api-platform.mdx', re: /"summary":\s*\{\s*"total":\s*(\d+)/, value: s.healthProbedKeys.total },
-    { file: 'docs/zh/api-platform.mdx', re: /"summary":\s*\{\s*"total":\s*\d+,\s*"ok":\s*(\d+)/, value: s.healthProbedKeys.total },
+    // /api/health `summary.total` (#6300) is pinned by validateHealthSummaryDocs
+    // rather than by claims: a claim runs `text.match()`, which reads only the
+    // FIRST match on a page, so a second example body appended below the pinned
+    // one would publish an unpinned number. The validator checks every block.
   ];
 }
 
@@ -1174,6 +1302,107 @@ function bootstrapCacheDocSources(pages = null) {
     failures.push(`${file}: known /api/bootstrap cache surface no longer publishes the contract (missing ${BOOTSTRAP_CACHE_ANCHOR})`);
   }
   return { docs, failures };
+}
+
+// ---- /api/health summary example bodies (#6300) ----
+//
+// `"onDemandWarn"` is the anchor: it is unique to this endpoint's summary
+// object, and the double quotes keep it inside JSON examples rather than the
+// surrounding prose, which names the same field in backticks.
+const HEALTH_SUMMARY_ANCHOR = '"onDemandWarn"';
+
+// The floor, for the same reason BOOTSTRAP_CACHE_DOC_FILES has one: scope is
+// DISCOVERED so a sibling page nobody remembered gets checked too, but a known
+// surface that loses its example must fail rather than drop quietly out of
+// scope. Two of these four are zh mirrors — the pages #6300 shows are exactly
+// the ones a hand-maintained list forgets.
+const HEALTH_SUMMARY_DOC_FILES = [
+  'docs/health-endpoints.mdx',
+  'docs/api-platform.mdx',
+  'docs/zh/health-endpoints.mdx',
+  'docs/zh/api-platform.mdx',
+];
+
+function healthSummaryDocSources(pages = null) {
+  const candidates = pages ?? Object.fromEntries(
+    walk('docs').filter((f) => f.endsWith('.mdx')).map((file) => [file, read(file)]),
+  );
+  const docs = {};
+  const failures = [];
+  for (const [file, text] of Object.entries(candidates)) {
+    if (text.includes(HEALTH_SUMMARY_ANCHOR)) docs[file] = text;
+  }
+  for (const file of HEALTH_SUMMARY_DOC_FILES) {
+    if (docs[file]) continue;
+    failures.push(
+      `${file}: known /api/health surface no longer publishes a summary example (missing ${HEALTH_SUMMARY_ANCHOR})`,
+    );
+  }
+  return { docs, failures };
+}
+
+// EVERY summary block on a publishing page is checked, not just the first.
+// That is the whole reason this is a validator and not a claim: `claims()` uses
+// `text.match()`, so appending a second example body below the pinned one would
+// publish a number the gate never reads — reproducing #6300 on a docs-only PR,
+// which also skips the `unit` job and so gets no other coverage at all.
+//
+// Two properties are asserted per block, and only two, so a page stays free to
+// illustrate a WARNING fleet rather than only an all-OK one:
+//   - `total` equals the registry size. True of any response, whatever its status.
+//   - the buckets sum to `total`. `summary.warn` is already net of onDemandWarn
+//     (api/health.js computes `realWarnCount = counts.warn - counts.onDemandWarn`),
+//     and staleContent/rolloutPending are documented SUBSETS of warn, so the
+//     partition is exactly ok + warn + onDemandWarn + crit. This is what caught
+//     the pre-#6300 api-platform.mdx body, which showed a concrete "HEALTHY"
+//     alongside 5 warns.
+function validateHealthSummaryDocs(stats, docs = null) {
+  const failures = [];
+  if (docs === null) {
+    const discovered = healthSummaryDocSources();
+    failures.push(...discovered.failures);
+    docs = discovered.docs;
+  }
+  const total = stats.healthProbedKeys.total;
+
+  for (const [file, text] of Object.entries(docs)) {
+    const blocks = [...text.matchAll(/"summary":\s*\{([^{}]*)\}/g)];
+    if (blocks.length === 0) {
+      failures.push(`${file}: publishes ${HEALTH_SUMMARY_ANCHOR} but no readable "summary" object`);
+      continue;
+    }
+    blocks.forEach(([, body], i) => {
+      const where = blocks.length > 1 ? `${file} (summary example ${i + 1} of ${blocks.length})` : file;
+      const field = (name) => {
+        const m = new RegExp(`"${name}":\\s*(\\d+)`).exec(body);
+        return m ? Number(m[1]) : null;
+      };
+      const counts = {};
+      for (const name of ['total', 'ok', 'warn', 'onDemandWarn', 'staleContent', 'rolloutPending', 'crit']) {
+        counts[name] = field(name);
+        if (counts[name] === null) failures.push(`${where}: /api/health summary example is missing "${name}"`);
+      }
+      if (Object.values(counts).some((v) => v === null)) return;
+
+      if (counts.total !== total) {
+        failures.push(`${where}: summary.total is ${counts.total}, but /api/health probes ${total} keys`);
+      }
+      const partition = counts.ok + counts.warn + counts.onDemandWarn + counts.crit;
+      if (partition !== counts.total) {
+        failures.push(
+          `${where}: ok + warn + onDemandWarn + crit = ${partition}, which must equal total (${counts.total})`,
+        );
+      }
+      for (const subset of ['staleContent', 'rolloutPending']) {
+        if (counts[subset] > counts.warn) {
+          failures.push(
+            `${where}: ${subset} (${counts[subset]}) is documented as a subset of warn (${counts.warn})`,
+          );
+        }
+      }
+    });
+  }
+  return failures;
 }
 
 // keyTiers is read here rather than carried in stats.json: it is validator
@@ -1440,6 +1669,7 @@ const DOC_VALIDATORS = [
   validateSupportedLanguagesRegistry,
   validateMcpAppsDocs,
   validateBootstrapCacheDocs,
+  validateHealthSummaryDocs,
   validatePlanLayerEntitlementCopy,
   validateCategoryExplainerCopy,
 ];
@@ -1516,6 +1746,11 @@ export {
   parseBootstrapCacheContract,
   parseBootstrapKeyTiers,
   parseHealthProbedKeys,
+  parseProbedRegistries,
+  validateHealthSummaryDocs,
+  healthSummaryDocSources,
+  HEALTH_SUMMARY_DOC_FILES,
+  HEALTH_SUMMARY_ANCHOR,
   validateBootstrapCacheDocs,
   bootstrapCacheDocSources,
   BOOTSTRAP_CACHE_DOC_FILES,

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -348,6 +348,117 @@ function parseBootstrapKeyTiers(source = read('shared/bootstrap-tier-keys.js')) 
   return tiers;
 }
 
+// ---- /api/health probed-key registry (api/health.js) ----
+//
+// Four published example responses quote `summary.total`, which is the single
+// number a reader uses to sanity-check whether their own response looks
+// complete. #6300: all four sat at 194 while production reported 256 — a
+// quarter of the fleet missing — and the figure had been copied forward often
+// enough (two English pages, two zh mirrors, plus a PR body quoting them) that
+// the agreement read as corroboration rather than as one stale number.
+//
+// Text-parsed rather than imported, like every other stat here: the docs-stats
+// CI job runs on bare Node with no `npm install`, and the runtime registry size
+// additionally depends on process.env.IRAN_EVENTS_ENABLED — an env-dependent
+// number must not land in the committed docs/generated/stats.json.
+//
+// The two object literals are NOT the whole registry: health.js mutates them
+// after declaration. Hardcoding that arithmetic is the same trap the docs fell
+// into — it would keep reporting a confident number that silently drifts the
+// moment a third mutation lands. So every mutation site is DISCOVERED and must
+// be one this function accounts for; an unrecognized one fails the gate loudly
+// instead of quietly publishing a wrong total.
+const HEALTH_REGISTRY_MUTATION_RE = new RegExp(
+  [
+    // `delete BOOTSTRAP_KEYS.iranEvents;`
+    String.raw`delete\s+(?:BOOTSTRAP_KEYS|STANDALONE_KEYS)\s*[.[][^\n]*`,
+    // `BOOTSTRAP_KEYS[name] = ...;` — the `=[^=]` tail keeps reads
+    // (`STANDALONE_KEYS[sibling] ?? …`) and comparisons out of the match.
+    String.raw`(?:BOOTSTRAP_KEYS|STANDALONE_KEYS)\s*(?:\[[^\]]*\]|\.\w+)\s*=[^=][^\n]*`,
+    // `Object.assign(BOOTSTRAP_KEYS, …)`
+    String.raw`Object\.assign\(\s*(?:BOOTSTRAP_KEYS|STANDALONE_KEYS)[^\n]*`,
+  ].join('|'),
+  'g',
+);
+
+// Every mutation this function knows how to price, in `normalizeMutation` form
+// (trimmed, inner whitespace collapsed). Adding a mutation to api/health.js
+// means teaching this list what it does to the count — that is the point.
+const HEALTH_REGISTRY_ACCOUNTED_MUTATIONS = [
+  // +1 per consumer-price market other than `ae` (which keeps its historical
+  // name in the BOOTSTRAP_KEYS literal).
+  'BOOTSTRAP_KEYS[name] = `consumer-prices:coverage:${market}`;',
+  // -1: the iran-events sunset drops the key unless IRAN_EVENTS_ENABLED=true,
+  // which defaults to false — so the documented (production) registry omits it.
+  'delete BOOTSTRAP_KEYS.iranEvents;',
+];
+
+const normalizeMutation = (line) => line.trim().replace(/\s+/g, ' ');
+
+// Depth-1 entries of a registry object literal. parseObjectBlockBody preserves
+// the original indentation, so a top-level key sits at exactly two spaces; a
+// nested object's keys would sit at four or more and are correctly excluded.
+// Comment lines start with `//` or `*` and cannot match the identifier group.
+function countRegistryEntries(source, name) {
+  const body = parseObjectBlockBody(source, `const ${name}`, `${name} in api/health.js`);
+  const keys = [...body.matchAll(/^ {2}([A-Za-z_$][\w$]*):/gm)].map((m) => m[1]);
+  if (keys.length === 0) throw new Error(`docs-stats: ${name} in api/health.js yielded no keys`);
+  const dupe = keys.find((k, i) => keys.indexOf(k) !== i);
+  if (dupe) throw new Error(`docs-stats: ${name} in api/health.js declares "${dupe}" twice`);
+  return keys;
+}
+
+function parseHealthProbedKeys(source = read('api/health.js')) {
+  const found = [...source.matchAll(HEALTH_REGISTRY_MUTATION_RE)].map((m) => normalizeMutation(m[0]));
+  const unaccounted = found.filter((m) => !HEALTH_REGISTRY_ACCOUNTED_MUTATIONS.includes(m));
+  if (unaccounted.length) {
+    throw new Error(
+      'docs-stats: api/health.js mutates its key registries in a way parseHealthProbedKeys does not '
+      + `account for, so summary.total cannot be derived: ${sorted(unaccounted).join(' | ')}. `
+      + 'Teach HEALTH_REGISTRY_ACCOUNTED_MUTATIONS what it does to the count.',
+    );
+  }
+  for (const expected of HEALTH_REGISTRY_ACCOUNTED_MUTATIONS) {
+    if (!found.includes(expected)) {
+      throw new Error(
+        `docs-stats: api/health.js no longer contains the accounted-for mutation \`${expected}\` — `
+        + 'summary.total would be derived from stale arithmetic.',
+      );
+    }
+  }
+
+  const bootstrapKeys = countRegistryEntries(source, 'BOOTSTRAP_KEYS');
+  const standaloneKeys = countRegistryEntries(source, 'STANDALONE_KEYS');
+
+  // +N: the consumer-price loop registers every market except `ae`.
+  const marketsBlock = source.match(/const CONSUMER_PRICE_HEALTH_MARKETS = Object\.freeze\(\[([^\]]*)\]\)/);
+  if (!marketsBlock) {
+    throw new Error('docs-stats: could not parse CONSUMER_PRICE_HEALTH_MARKETS in api/health.js');
+  }
+  const markets = [...marketsBlock[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+  if (!markets.includes('ae')) {
+    throw new Error("docs-stats: CONSUMER_PRICE_HEALTH_MARKETS no longer contains 'ae', which the loop skips");
+  }
+  if (!/if \(market === 'ae'\) continue;/.test(source)) {
+    throw new Error("docs-stats: the consumer-price health loop no longer skips 'ae'");
+  }
+  const addedMarkets = markets.filter((m) => m !== 'ae').length;
+
+  // -1: iran-events is sunset unless IRAN_EVENTS_ENABLED=true (default false).
+  // Asserting it is present in the literal keeps the subtraction from
+  // double-counting a key that was already removed from the declaration.
+  if (!bootstrapKeys.includes('iranEvents')) {
+    throw new Error('docs-stats: BOOTSTRAP_KEYS no longer declares iranEvents, so the sunset delete subtracts twice');
+  }
+  if (!/const IRAN_EVENTS_ENABLED = .*\?\? 'false'/.test(source)) {
+    throw new Error('docs-stats: IRAN_EVENTS_ENABLED no longer defaults to false — the documented registry size changed');
+  }
+
+  const bootstrap = bootstrapKeys.length + addedMarkets - 1;
+  const standalone = standaloneKeys.length;
+  return { bootstrap, standalone, total: bootstrap + standalone };
+}
+
 function parseJsonLdBlocks(html) {
   return [...html.matchAll(/<script\s+type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/g)]
     .map((m) => JSON.parse(m[1]));
@@ -656,6 +767,7 @@ function computeStats() {
     mcpAppUiResources: mcpApps.uiResources,
     mcpAppLinkedTools: mcpApps.linkedTools,
     bootstrapCache: parseBootstrapCacheContract(),
+    healthProbedKeys: parseHealthProbedKeys(),
   };
 }
 
@@ -854,6 +966,27 @@ function claims(s) {
     { file: 'blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md', re: /architecture \((\d+)\s+proto files, \d+\s+typed services\)/, value: s.protoFiles },
     { file: 'blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md', re: /architecture \(\d+\s+proto files, (\d+)\s+typed services\)/, value: s.protoServices },
     { file: 'blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md', re: /using the (\d+)\s+typed API services/, value: s.protoServices },
+
+    // ---- /api/health example response bodies (#6300) ----
+    // `summary.total` is the number a reader uses to decide whether their own
+    // response looks complete, and all four pages published 194 against a live
+    // 256. Anchored on the `"summary": {` line and captured positionally, so a
+    // claim cannot be satisfied by a neighbouring count — every one of these
+    // bodies quotes several integers in a row.
+    //
+    // `ok` is pinned to the same stat on purpose: each example declares an
+    // all-OK fleet, so ok === total is what makes the body internally
+    // consistent. Pinning `total` alone would let `ok` drift back out of step
+    // with it the next time a key is added, which is the same class of silently
+    // wrong published number this gate exists to stop.
+    { file: 'docs/health-endpoints.mdx', re: /"summary":\s*\{\s*"total":\s*(\d+)/, value: s.healthProbedKeys.total },
+    { file: 'docs/health-endpoints.mdx', re: /"summary":\s*\{\s*"total":\s*\d+,\s*"ok":\s*(\d+)/, value: s.healthProbedKeys.total },
+    { file: 'docs/api-platform.mdx', re: /"summary":\s*\{\s*"total":\s*(\d+)/, value: s.healthProbedKeys.total },
+    { file: 'docs/api-platform.mdx', re: /"summary":\s*\{\s*"total":\s*\d+,\s*"ok":\s*(\d+)/, value: s.healthProbedKeys.total },
+    { file: 'docs/zh/health-endpoints.mdx', re: /"summary":\s*\{\s*"total":\s*(\d+)/, value: s.healthProbedKeys.total },
+    { file: 'docs/zh/health-endpoints.mdx', re: /"summary":\s*\{\s*"total":\s*\d+,\s*"ok":\s*(\d+)/, value: s.healthProbedKeys.total },
+    { file: 'docs/zh/api-platform.mdx', re: /"summary":\s*\{\s*"total":\s*(\d+)/, value: s.healthProbedKeys.total },
+    { file: 'docs/zh/api-platform.mdx', re: /"summary":\s*\{\s*"total":\s*\d+,\s*"ok":\s*(\d+)/, value: s.healthProbedKeys.total },
   ];
 }
 
@@ -1382,6 +1515,7 @@ export {
   validateMcpAppsDocs,
   parseBootstrapCacheContract,
   parseBootstrapKeyTiers,
+  parseHealthProbedKeys,
   validateBootstrapCacheDocs,
   bootstrapCacheDocSources,
   BOOTSTRAP_CACHE_DOC_FILES,

--- a/tests/docs-stats-health-total.test.mts
+++ b/tests/docs-stats-health-total.test.mts
@@ -1,0 +1,176 @@
+/**
+ * The /api/health `summary.total` doc gate (#6300).
+ *
+ * Four published example bodies (two English pages, two zh mirrors) quoted
+ * `"total": 194` while production reported 256. Nothing pinned the figure, so
+ * it was copied forward until three agreeing sources read as corroboration.
+ *
+ * `parseHealthProbedKeys` derives the number from api/health.js source text —
+ * the docs-stats CI job runs on bare Node with no `npm install`, and the
+ * runtime size depends on process.env.IRAN_EVENTS_ENABLED, so it must not be
+ * imported. That makes the parser itself the thing that can silently drift, so
+ * these tests do two jobs:
+ *
+ *   1. Pin the text parse against the REAL module's runtime registry. A text
+ *      parser that agrees with itself proves nothing; one that agrees with the
+ *      object health.js actually walks proves the published number.
+ *   2. Drive every failure branch with synthetic fixtures, so "the gate would
+ *      have caught it" is executed rather than asserted.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+import { parseHealthProbedKeys } from '../scripts/docs-stats.mjs';
+import { __testing__ as healthTesting } from '../api/health.js';
+
+const root = resolve(import.meta.dirname, '..');
+const read = (path: string) => readFileSync(resolve(root, path), 'utf8');
+
+const REAL_SOURCE = read('api/health.js');
+
+const DOC_PAGES = [
+  'docs/health-endpoints.mdx',
+  'docs/api-platform.mdx',
+  'docs/zh/health-endpoints.mdx',
+  'docs/zh/api-platform.mdx',
+];
+
+/**
+ * Mutate the real api/health.js text. Throws when the anchor it targets is
+ * gone: a fixture that silently stops mutating anything turns every "this
+ * drift is caught" assertion below into a test of nothing.
+ */
+function mutate(from: string | RegExp, to: string): string {
+  const occurrences = typeof from === 'string'
+    ? REAL_SOURCE.split(from).length - 1
+    : [...REAL_SOURCE.matchAll(new RegExp(from, 'g'))].length;
+  assert.equal(occurrences, 1, `fixture drift: api/health.js must contain exactly one \`${from}\``);
+  return REAL_SOURCE.replace(from, to);
+}
+
+describe('/api/health probed-key count doc gate (#6300)', () => {
+  it('derives the same total the runtime registry actually walks', () => {
+    // api/health.js counts one check per BOOTSTRAP_KEYS + STANDALONE_KEYS entry
+    // (the `sources` loop that increments totalChecks). Importing it here is
+    // safe — only the always-on docs-stats CI job runs without node_modules.
+    const runtimeBootstrap = Object.keys(healthTesting.BOOTSTRAP_KEYS).length;
+    const runtimeStandalone = Object.keys(healthTesting.STANDALONE_KEYS).length;
+
+    const parsed = parseHealthProbedKeys(REAL_SOURCE);
+
+    assert.equal(parsed.bootstrap, runtimeBootstrap);
+    assert.equal(parsed.standalone, runtimeStandalone);
+    assert.equal(parsed.total, runtimeBootstrap + runtimeStandalone);
+  });
+
+  it('publishes that total, and an internally consistent body, on every doc page', () => {
+    const { total } = parseHealthProbedKeys(REAL_SOURCE);
+
+    for (const page of DOC_PAGES) {
+      const text = read(page);
+      const blocks = [...text.matchAll(/"summary":\s*\{/g)];
+      // The registered claims are anchored on this one block per page. A second
+      // one would let a stale duplicate hide behind the live copy — the #5791
+      // failure mode the bootstrap-cache gate was hardened against.
+      assert.equal(blocks.length, 1, `${page}: expected exactly one "summary" example block`);
+
+      const summary = /"summary":\s*\{([^}]*)\}/.exec(text)?.[1] ?? '';
+      const field = (name: string) => Number(new RegExp(`"${name}":\\s*(\\d+)`).exec(summary)?.[1]);
+
+      assert.equal(field('total'), total, `${page}: summary.total is stale`);
+      // Every example declares an all-OK fleet, so ok must equal total and the
+      // problem counters must be zero. An example that contradicts its own
+      // declared status teaches the wrong contract.
+      assert.equal(field('ok'), total, `${page}: summary.ok must equal total in an all-OK example`);
+      for (const zero of ['warn', 'onDemandWarn', 'staleContent', 'rolloutPending', 'crit']) {
+        assert.equal(field(zero), 0, `${page}: summary.${zero} must be 0 in an all-OK example`);
+      }
+    }
+  });
+
+  it('no longer hardcodes a drifting count in prose', () => {
+    // The prose figure is the half that cannot be pinned to a stat, so it must
+    // state the property instead. These pages carried "currently ~194" and
+    // "~194 keys with record counts" for long enough to go 62 keys stale.
+    assert.doesNotMatch(read('docs/health-endpoints.mdx'), /~\s*\d+\s*(?:and growing|keys with record counts)/);
+    assert.doesNotMatch(read('docs/zh/health-endpoints.mdx'), /约\s*\d+\s*个(?:，并随面板|键及记录计数)/);
+  });
+
+  it('counts a newly registered key', () => {
+    const before = parseHealthProbedKeys(REAL_SOURCE).total;
+    const source = mutate(
+      "const STANDALONE_KEYS = {\n",
+      "const STANDALONE_KEYS = {\n  brandNewPanel:      'brand:new-panel:v1',\n",
+    );
+    assert.equal(parseHealthProbedKeys(source).total, before + 1);
+  });
+
+  it('counts every consumer-price market the loop registers', () => {
+    const before = parseHealthProbedKeys(REAL_SOURCE).total;
+    const source = mutate(
+      "'ae', 'au', 'br', 'gb', 'in', 'sa', 'sg', 'us'",
+      "'ae', 'au', 'br', 'gb', 'in', 'sa', 'sg', 'us', 'zz'",
+    );
+    // The loop skips 'ae', so a ninth market is one more probed key.
+    assert.equal(parseHealthProbedKeys(source).total, before + 1);
+  });
+
+  it('subtracts the iran-events sunset exactly once', () => {
+    // The delete is why bootstrap is one smaller than its literal. Re-enabling
+    // the key by removing the delete must give the count back, not leave the
+    // subtraction stranded against a literal that still declares it.
+    const source = mutate('  delete BOOTSTRAP_KEYS.iranEvents;\n', '');
+    assert.throws(
+      () => parseHealthProbedKeys(source),
+      /no longer contains the accounted-for mutation/,
+      'dropping an accounted-for mutation must fail loudly, not silently keep subtracting',
+    );
+  });
+
+  it('refuses to publish a total when health.js mutates its registries in an unaccounted way', () => {
+    // The whole point: a third mutation must not silently shift the published
+    // number. Hardcoded arithmetic would have kept reporting the old total.
+    const source = mutate(
+      '  delete BOOTSTRAP_KEYS.iranEvents;\n',
+      "  delete BOOTSTRAP_KEYS.iranEvents;\n  STANDALONE_KEYS.someNewThing = 'some:new:thing:v1';\n",
+    );
+    assert.throws(() => parseHealthProbedKeys(source), (err: Error) => {
+      assert.match(err.message, /does not\s+account for/);
+      assert.match(err.message, /someNewThing/);
+      return true;
+    });
+  });
+
+  it('does not mistake a registry READ for a mutation', () => {
+    // `STANDALONE_KEYS[sibling] ?? BOOTSTRAP_KEYS[sibling]` in the cascade
+    // lookup is a read. A mutation matcher that catches it would fail the gate
+    // permanently, so the accounted-set check would get loosened to nothing.
+    assert.match(REAL_SOURCE, /STANDALONE_KEYS\[sibling\] \?\? BOOTSTRAP_KEYS\[sibling\]/);
+    assert.doesNotThrow(() => parseHealthProbedKeys(REAL_SOURCE));
+  });
+
+  it('fails when the iran-events default flips, changing the documented registry', () => {
+    const source = mutate("(process.env.IRAN_EVENTS_ENABLED ?? 'false')", "(process.env.IRAN_EVENTS_ENABLED ?? 'true')");
+    assert.throws(() => parseHealthProbedKeys(source), /no longer defaults to false/);
+  });
+
+  it("fails when the consumer-price loop stops skipping 'ae'", () => {
+    const source = mutate("  if (market === 'ae') continue;\n", '');
+    assert.throws(() => parseHealthProbedKeys(source), /no longer skips 'ae'/);
+  });
+
+  it('fails when a registry it counts disappears', () => {
+    const source = mutate('const STANDALONE_KEYS = {', 'const STANDALONE_KEYS_RENAMED = {');
+    assert.throws(() => parseHealthProbedKeys(source), /could not parse STANDALONE_KEYS/);
+  });
+
+  it('fails on a duplicate registry key rather than under-counting it', () => {
+    const source = mutate(
+      "const STANDALONE_KEYS = {\n",
+      "const STANDALONE_KEYS = {\n  hkoWarnings:      'weather:hko-warnings:v1',\n",
+    );
+    assert.throws(() => parseHealthProbedKeys(source), /declares "hkoWarnings" twice/);
+  });
+});

--- a/tests/docs-stats-health-total.test.mts
+++ b/tests/docs-stats-health-total.test.mts
@@ -22,7 +22,15 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 
-import { parseHealthProbedKeys } from '../scripts/docs-stats.mjs';
+import {
+  parseHealthProbedKeys,
+  parseProbedRegistries,
+  validateHealthSummaryDocs,
+  healthSummaryDocSources,
+  computeStats,
+  DOC_VALIDATORS,
+  HEALTH_SUMMARY_DOC_FILES,
+} from '../scripts/docs-stats.mjs';
 import { __testing__ as healthTesting } from '../api/health.js';
 
 const root = resolve(import.meta.dirname, '..');
@@ -50,6 +58,18 @@ function mutate(from: string | RegExp, to: string): string {
   return REAL_SOURCE.replace(from, to);
 }
 
+const REAL_STATS = computeStats();
+const REAL_TOTAL: number = REAL_STATS.healthProbedKeys.total;
+
+/** A synthetic docs page carrying one /api/health summary example. */
+function docWithSummary(fields: Record<string, number>): string {
+  const full = {
+    total: 0, ok: 0, warn: 0, onDemandWarn: 0, staleContent: 0, rolloutPending: 0, crit: 0, ...fields,
+  };
+  const body = Object.entries(full).map(([k, v]) => `    "${k}": ${v}`).join(',\n');
+  return `\n\`\`\`json\n{\n  "summary": {\n${body}\n  }\n}\n\`\`\`\n`;
+}
+
 describe('/api/health probed-key count doc gate (#6300)', () => {
   it('derives the same total the runtime registry actually walks', () => {
     // api/health.js counts one check per BOOTSTRAP_KEYS + STANDALONE_KEYS entry
@@ -63,30 +83,130 @@ describe('/api/health probed-key count doc gate (#6300)', () => {
     assert.equal(parsed.bootstrap, runtimeBootstrap);
     assert.equal(parsed.standalone, runtimeStandalone);
     assert.equal(parsed.total, runtimeBootstrap + runtimeStandalone);
+
+    // Counts alone would let a compensating pair cancel out — one real key the
+    // identifier matcher misses plus one phantom it invents net to the same
+    // number. Compare the key SETS, which cannot.
+    assert.deepEqual(
+      parsed.bootstrapKeys.slice().sort(),
+      Object.keys(healthTesting.BOOTSTRAP_KEYS).sort(),
+    );
+    assert.deepEqual(
+      parsed.standaloneKeys.slice().sort(),
+      Object.keys(healthTesting.STANDALONE_KEYS).sort(),
+    );
   });
 
-  it('publishes that total, and an internally consistent body, on every doc page', () => {
-    const { total } = parseHealthProbedKeys(REAL_SOURCE);
+  it('reads the same registries the endpoint actually probes', () => {
+    // The count above is only summary.total because these are the registries
+    // the `sources` loop walks. A third one added there is the single edit that
+    // reproduces #6300 exactly: production grows, every gate stays pinned.
+    assert.deepEqual(
+      parseProbedRegistries(REAL_SOURCE).sort(),
+      ['BOOTSTRAP_KEYS', 'STANDALONE_KEYS'],
+    );
+  });
 
-    for (const page of DOC_PAGES) {
-      const text = read(page);
-      const blocks = [...text.matchAll(/"summary":\s*\{/g)];
-      // The registered claims are anchored on this one block per page. A second
-      // one would let a stale duplicate hide behind the live copy — the #5791
-      // failure mode the bootstrap-cache gate was hardened against.
-      assert.equal(blocks.length, 1, `${page}: expected exactly one "summary" example block`);
+  it('fails when a third registry joins the endpoint\'s probe list', () => {
+    const source = mutate(
+      '    [STANDALONE_KEYS, { allowOnDemand: true }],\n',
+      '    [STANDALONE_KEYS, { allowOnDemand: true }],\n    [OPS_KEYS, { allowOnDemand: true }],\n',
+    );
+    assert.throws(() => parseHealthProbedKeys(source), /probes a different set of key registries/);
+  });
 
-      const summary = /"summary":\s*\{([^}]*)\}/.exec(text)?.[1] ?? '';
-      const field = (name: string) => Number(new RegExp(`"${name}":\\s*(\\d+)`).exec(summary)?.[1]);
+  it('fails when the endpoint stops counting every registry entry', () => {
+    // summary.total equals the registry size only while totalChecks++ is
+    // unconditional. A `continue` ahead of it shrinks production's total while
+    // both the parse and the Object.keys() cross-check above stay put.
+    const source = mutate(
+      '    for (const [name, redisKey] of Object.entries(registry)) {\n      totalChecks++;',
+      '    for (const [name, redisKey] of Object.entries(registry)) {\n      if (!shouldProbe(name)) continue;\n      totalChecks++;',
+    );
+    assert.throws(() => parseHealthProbedKeys(source), /no longer counts every registry entry unconditionally/);
+  });
 
-      assert.equal(field('total'), total, `${page}: summary.total is stale`);
-      // Every example declares an all-OK fleet, so ok must equal total and the
-      // problem counters must be zero. An example that contradicts its own
-      // declared status teaches the wrong contract.
-      assert.equal(field('ok'), total, `${page}: summary.ok must equal total in an all-OK example`);
-      for (const zero of ['warn', 'onDemandWarn', 'staleContent', 'rolloutPending', 'crit']) {
-        assert.equal(field(zero), 0, `${page}: summary.${zero} must be 0 in an all-OK example`);
-      }
+  it('discovers every publishing page, including the zh mirrors, and passes on them', () => {
+    const discovered = healthSummaryDocSources();
+    assert.deepEqual(discovered.failures, []);
+    // Discovered, not listed — the floor is a floor, not the scope. Two of the
+    // four are zh mirrors, which #6300 shows is exactly what a hand-maintained
+    // list forgets.
+    for (const page of HEALTH_SUMMARY_DOC_FILES) assert.ok(discovered.docs[page], `${page} not discovered`);
+    assert.deepEqual(Object.keys(discovered.docs).sort(), [...DOC_PAGES].sort());
+    assert.deepEqual(validateHealthSummaryDocs(REAL_STATS), []);
+  });
+
+  it('is wired into the always-on gate, not just registered', () => {
+    // A validator dropped from DOC_VALIDATORS stops running while every test
+    // that calls it directly stays green. This is the always-on job's only
+    // pin on these four pages, so the wiring is the thing to assert.
+    assert.ok(
+      DOC_VALIDATORS.includes(validateHealthSummaryDocs),
+      'validateHealthSummaryDocs must run in the --check validator set',
+    );
+  });
+
+  it('catches a stale total on any page', () => {
+    const failures = validateHealthSummaryDocs(REAL_STATS, {
+      'docs/health-endpoints.mdx': docWithSummary({ total: 194, ok: 194 }),
+    });
+    assert.ok(failures.some((f) => /summary\.total is 194/.test(f)), failures.join(' | '));
+  });
+
+  it('catches a SECOND, stale example block below the current one', () => {
+    // The hole a `claims()` entry could not close: `text.match()` reads only the
+    // first match, so an appended stale body would publish an unpinned number —
+    // and on a docs-only PR the `unit` job is skipped, leaving this validator as
+    // the only gate that runs at all.
+    const page = docWithSummary({ total: REAL_TOTAL, ok: REAL_TOTAL })
+      + docWithSummary({ total: 194, ok: 194 });
+    const failures = validateHealthSummaryDocs(REAL_STATS, { 'docs/health-endpoints.mdx': page });
+    assert.ok(
+      failures.some((f) => /summary example 2 of 2/.test(f) && /is 194/.test(f)),
+      failures.join(' | '),
+    );
+  });
+
+  it('catches a body whose buckets do not partition total', () => {
+    // The pre-#6300 api-platform.mdx body: a concrete "HEALTHY" alongside 5
+    // warns and 9 onDemandWarns. Checking the partition rather than demanding
+    // an all-OK shape leaves a page free to illustrate a WARNING fleet.
+    const failures = validateHealthSummaryDocs(REAL_STATS, {
+      'docs/health-endpoints.mdx': docWithSummary({ total: REAL_TOTAL, ok: REAL_TOTAL, warn: 5 }),
+    });
+    assert.ok(failures.some((f) => /must equal total/.test(f)), failures.join(' | '));
+
+    // ...and a truthful WARNING example still passes.
+    assert.deepEqual(
+      validateHealthSummaryDocs(REAL_STATS, {
+        'docs/health-endpoints.mdx': docWithSummary({ total: REAL_TOTAL, ok: REAL_TOTAL - 13, warn: 13 }),
+      }),
+      [],
+    );
+  });
+
+  it('catches a subset counter exceeding the warn bucket it is a subset of', () => {
+    const failures = validateHealthSummaryDocs(REAL_STATS, {
+      'docs/health-endpoints.mdx': docWithSummary({ total: REAL_TOTAL, ok: REAL_TOTAL - 2, warn: 2, staleContent: 5 }),
+    });
+    assert.ok(failures.some((f) => /staleContent \(5\) is documented as a subset/.test(f)), failures.join(' | '));
+  });
+
+  it('fails when a known page silently drops its example', () => {
+    // Scope is discovered, so a page that stops carrying the anchor would just
+    // fall out of it. The floor is what turns that into a failure — asserted
+    // through the discovery helper, since injecting `docs` bypasses discovery.
+    const discovered = healthSummaryDocSources({
+      'docs/health-endpoints.mdx': docWithSummary({ total: REAL_TOTAL, ok: REAL_TOTAL }),
+      'docs/api-platform.mdx': 'the summary example was deleted',
+    });
+    assert.deepEqual(Object.keys(discovered.docs), ['docs/health-endpoints.mdx']);
+    for (const page of HEALTH_SUMMARY_DOC_FILES.filter((p: string) => p !== 'docs/health-endpoints.mdx')) {
+      assert.ok(
+        discovered.failures.some((f: string) => f.startsWith(`${page}:`)),
+        `${page} should have failed the floor — got ${discovered.failures.join(' | ')}`,
+      );
     }
   });
 
@@ -145,10 +265,105 @@ describe('/api/health probed-key count doc gate (#6300)', () => {
 
   it('does not mistake a registry READ for a mutation', () => {
     // `STANDALONE_KEYS[sibling] ?? BOOTSTRAP_KEYS[sibling]` in the cascade
-    // lookup is a read. A mutation matcher that catches it would fail the gate
+    // lookup is a read, and `...Object.values(BOOTSTRAP_KEYS)` builds the
+    // pipeline command list. A matcher that caught either would fail the gate
     // permanently, so the accounted-set check would get loosened to nothing.
     assert.match(REAL_SOURCE, /STANDALONE_KEYS\[sibling\] \?\? BOOTSTRAP_KEYS\[sibling\]/);
+    assert.match(REAL_SOURCE, /\.\.\.Object\.values\(BOOTSTRAP_KEYS\)/);
     assert.doesNotThrow(() => parseHealthProbedKeys(REAL_SOURCE));
+  });
+
+  // Each of these registers a key at runtime. Before the mutation matcher was
+  // widened, every one returned 256 unchanged instead of throwing.
+  for (const [label, line] of [
+    ['a compound assignment', "  STANDALONE_KEYS.lateKey ??= 'late:key:v1';\n"],
+    ['Object.defineProperty', "  Object.defineProperty(STANDALONE_KEYS, 'dp', { value: 'x', enumerable: true });\n"],
+    ['an alias binding', '  const REG = STANDALONE_KEYS;\n'],
+  ] as const) {
+    it(`discovers a registry write via ${label}`, () => {
+      const source = mutate('  delete BOOTSTRAP_KEYS.iranEvents;\n', `  delete BOOTSTRAP_KEYS.iranEvents;\n${line}`);
+      assert.throws(() => parseHealthProbedKeys(source), /does not\s+account for/);
+    });
+  }
+
+  it('is not satisfied by a COMMENTED-OUT accounted mutation', () => {
+    // The presence check exists to prove health.js still performs the mutation
+    // the arithmetic prices. A commented-out delete normalizes to the exact
+    // accounted string, so before comments were blanked it satisfied the very
+    // guard whose error message is "stale arithmetic" — while the runtime
+    // registry kept the key.
+    const source = mutate('  delete BOOTSTRAP_KEYS.iranEvents;\n', '  // delete BOOTSTRAP_KEYS.iranEvents;\n');
+    assert.throws(() => parseHealthProbedKeys(source), /no longer contains the accounted-for mutation/);
+  });
+
+  it('blanks line comments before looking for block comments', () => {
+    // api/health.js carries `.../configs/retailers/*.yaml.` inside a LINE
+    // comment. Blanking block comments first lets that `/*` open a comment that
+    // runs 1098 lines to the next `*/`, erasing the consumer-price loop, the
+    // iranEvents delete, and most of STANDALONE_KEYS.
+    assert.match(REAL_SOURCE, /\/\/[^\n]*configs\/retailers\/\*\.yaml/);
+    assert.equal(parseHealthProbedKeys(REAL_SOURCE).total, REAL_TOTAL);
+  });
+
+  it('rejects a brace inside a registry comment instead of silently truncating', () => {
+    // parseObjectBlockBody counts raw braces, so one `}` in a comment ends the
+    // block early and yields a plausible short count, not an error.
+    const source = mutate(
+      "  hkoWarnings:        'weather:hko-warnings:v1',\n",
+      "  // closing an inline snippet } here\n  hkoWarnings:        'weather:hko-warnings:v1',\n",
+    );
+    assert.equal(parseHealthProbedKeys(source).total, REAL_TOTAL);
+  });
+
+  // Shapes that change Object.entries(registry) but not the identifier matcher.
+  for (const [label, line] of [
+    ['a quoted key', "  'quoted-key': 'quoted:key:v1',\n"],
+    ['a computed key', '  [SOME_CONST]: \'computed:key:v1\',\n'],
+    ['a spread', '  ...EXTRA_STANDALONE_KEYS,\n'],
+    ['a deeper-indented key', "    deepKey: 'deep:key:v1',\n"],
+  ] as const) {
+    it(`refuses to count a registry containing ${label}`, () => {
+      const source = mutate('const STANDALONE_KEYS = {\n', `const STANDALONE_KEYS = {\n${line}`);
+      assert.throws(() => parseHealthProbedKeys(source), /cannot read|entry terminators/);
+    });
+  }
+
+  it('refuses to count a non-conforming entry that carries no comma', () => {
+    // Isolates the whole-body conformance check from the comma cross-count:
+    // a trailing entry with no comma leaves the terminator count untouched, so
+    // only the conformance check can see it. Without this fixture, disabling
+    // that check leaves all other tests green.
+    const source = mutate(
+      "  intelHistoryIngestEnergyIntelligence:  'intel-history:ingest-health:energy:intelligence:v1',\n};",
+      "  intelHistoryIngestEnergyIntelligence:  'intel-history:ingest-health:energy:intelligence:v1',\n  ...EXTRA_STANDALONE_KEYS\n};",
+    );
+    assert.throws(() => parseHealthProbedKeys(source), /cannot read/);
+  });
+
+  it('refuses to count two entries sharing one line', () => {
+    const source = mutate(
+      'const STANDALONE_KEYS = {\n',
+      "const STANDALONE_KEYS = {\n  aKey: 'a:v1', bKey: 'b:v1',\n",
+    );
+    assert.throws(() => parseHealthProbedKeys(source), /entry terminators/);
+  });
+
+  it('does not double-count a market the literal already declares', () => {
+    // `BOOTSTRAP_KEYS[name] = …` overwrites a same-named literal entry, so the
+    // runtime count is unchanged while a naive +1-per-market would grow.
+    const source = mutate(
+      "  consumerPricesCoverage:   'consumer-prices:coverage:ae',\n",
+      "  consumerPricesCoverage:   'consumer-prices:coverage:ae',\n  consumerPricesCoverageUS: 'consumer-prices:coverage:us',\n",
+    );
+    assert.throws(() => parseHealthProbedKeys(source), /already declares "consumerPricesCoverageUS"/);
+  });
+
+  it('does not double-count a repeated market', () => {
+    const source = mutate(
+      "'ae', 'au', 'br', 'gb', 'in', 'sa', 'sg', 'us'",
+      "'ae', 'au', 'br', 'gb', 'in', 'sa', 'sg', 'us', 'us'",
+    );
+    assert.throws(() => parseHealthProbedKeys(source), /more than once/);
   });
 
   it('fails when the iran-events default flips, changing the documented registry', () => {

--- a/tests/docs-stats-health-total.test.mts
+++ b/tests/docs-stats-health-total.test.mts
@@ -278,6 +278,10 @@ describe('/api/health probed-key count doc gate (#6300)', () => {
   for (const [label, line] of [
     ['a compound assignment', "  STANDALONE_KEYS.lateKey ??= 'late:key:v1';\n"],
     ['Object.defineProperty', "  Object.defineProperty(STANDALONE_KEYS, 'dp', { value: 'x', enumerable: true });\n"],
+    // No Object.assign on either registry today, so this alternation is the one
+    // branch with no live example to keep it honest — a regex regression here
+    // would surface only once someone wrote health.js in that style.
+    ['Object.assign', "  Object.assign(STANDALONE_KEYS, { bulkKey: 'bulk:key:v1' });\n"],
     ['an alias binding', '  const REG = STANDALONE_KEYS;\n'],
   ] as const) {
     it(`discovers a registry write via ${label}`, () => {


### PR DESCRIPTION
Closes #6300.

## What was wrong

Four published pages documented `/api/health` as probing **194** keys. Production returns **256** — a quarter of the fleet missing.

The issue named two pages. There were **eight stale figures across four files**: the two English pages, plus both `docs/zh/` mirrors, which carried the same number in their example bodies, their prose, and a comparison table. That is the failure mode the issue describes — one stale number copied forward until the agreement between sources reads as corroboration.

## What changed

**The numbers.** All four example bodies now publish 256. They also gain `rolloutPending`, which the endpoint emits unconditionally and the prose already documented, but no example listed. The `api-platform.mdx` body was additionally self-contradictory before this: it declared a concrete `"status": "HEALTHY"` alongside 5 warns, which the endpoint's own verdict logic would never return.

**The prose.** `total` is one entry per probed key, "and grows as panels are added — read it from your own response rather than from this page." The `~194 keys with record counts` table cell lost its number the same way. A prose figure cannot be pinned to a stat, so it should not carry a count.

**The gate.** `scripts/docs-stats.mjs` gains `parseHealthProbedKeys()`, deriving the number from `api/health.js` source **text**. Not by importing it: the always-on `docs-stats` CI job runs on bare Node with no `npm install`, and the runtime size depends on `IRAN_EVENTS_ENABLED`, so an env-dependent number must not land in the committed `docs/generated/stats.json`.

The two object literals are not the whole registry — `api/health.js` mutates them after declaration. Rather than hardcode that arithmetic (the same silently-drifting-number trap the docs fell into), every mutation site is **discovered** and must be one the parser prices; an unrecognized one fails the gate loudly.

Verified three ways: text parse `256` == imported runtime registry `256` == live production probe `256` (109 bootstrap + 147 standalone).

## Review round

An adversarial pass attacked the gate as a *verification mechanism* — the risk being a guard that reports success while the published number is wrong. Two in-process reviewers plus an independent gpt-5.5 pass via Codex converged on the same top defect. Every finding below was reproduced by execution before being fixed, and each now has a fixture that fails when its guard is disabled.

| Hole | Why it stayed green |
|---|---|
| A third registry in the endpoint's `sources` array | Nothing read that array — this reproduced #6300 verbatim with all CI green |
| A `continue` added ahead of `totalChecks++` | The count pinned registry *size*, not `summary.total` |
| A **commented-out** `delete BOOTSTRAP_KEYS.iranEvents;` | Normalized to the exact accounted string, satisfying the check whose error message is literally "stale arithmetic" |
| A quoted, computed, spread, or deeper-indented key | Changed `Object.entries(registry)` without changing the count; `keys.length === 0` was the only alarm |
| `??=`, `Object.defineProperty`, an alias binding | Not seen as mutations |
| A market repeated, or also declared in the literal | Runtime overwrites; the count added one per occurrence |
| A brace inside a registry comment | Truncated the body and returned a confident short count |
| **A second, stale example block on a page** | `claims()` uses `text.match()` — first match only. On a docs-only PR the `unit` job is skipped, so this was the only gate running |

That last one is why the eight registered claims were **replaced by a discovered validator**. `validateHealthSummaryDocs` checks *every* summary block on *every* discovered page (zh mirrors included by discovery, not by list, with the four known pages as a floor) and asserts the endpoint's real invariant: `total` equals the registry size, and `ok + warn + onDemandWarn + crit` partitions it. That leaves a page free to illustrate a WARNING fleet while still catching the pre-#6300 body.

One fix bit back during implementation and is worth knowing: comment blanking **must** strip line comments first. `api/health.js:793` contains `configs/retailers/*.yaml` inside a `//` comment, and that `/*` opens a block comment the matcher runs 1098 lines to close — erasing the consumer-price loop, the `iranEvents` delete, and most of `STANDALONE_KEYS`.

## Testing

- `tests/docs-stats-health-total.test.mts` — 35 tests, all passing. The load-bearing one pins the text parse against the **imported runtime registry**, comparing key *sets* rather than counts so two compensating errors cannot cancel out.
- **Mutation-tested, 13 mutants, all killed.** Every guard has a fixture that fails when that guard alone is disabled. One mutant initially *survived* — the whole-body conformance check was redundant with the comma cross-count for all four fixtures — so a no-comma fixture was added to isolate it, and it now dies.
- `npm run docs:check` passes (150 claims). `docs/generated/stats.json` regenerates byte-identical.
- Scoped sweep green: the four sibling `docs-stats-*` suites (88), `blog-seo-contract` / `llms-txt-mcp-tools` / `docs-i18n-parity` / `docs-mcp` (274), `product:facts:check`, biome.

## Known Residuals

Accepted, not dropped. All are advisory/human-owned; the actionable queue is empty.

1. **`IRAN_EVENTS_ENABLED=true` set in the environment** moves production to 257 with no CI signal — an env flip needs no code change, so no workflow runs. The gate can only pin the source default. Mitigated by the prose now telling readers to trust their own response.
2. **A registry passed to a mutating helper** (`registerHealthKey(STANDALONE_KEYS, …)`) is still not discovered. A generic call-argument pattern was deliberately rejected because `...Object.values(BOOTSTRAP_KEYS)` is a legitimate read that would false-positive permanently. Backstopped by the key-set cross-check in `unit`.
3. **A duplicated accounted-mutation line** normalizes to an already-accounted string, so N extra registered keys pass the accounted-set check. Backstopped by the same key-set cross-check.
4. **No test drives the real `/api/health` response body.** The gate proves "the parser agrees with the registries", not "the docs agree with `summary.total`". The structural pin on `totalChecks++` is the proportionate mitigation; a stubbed-Redis handler test was judged a disproportionate lift.

Deliberately left alone: `blog-site/.../worldmonitor-is-not-palantir.md` quotes `total: 232` as an explicitly **dated** capture ("what it returned the moment this paragraph was written, July 22 2026"). Pinning or refreshing it would falsify a dated quote — recorded here so a later "grep for the stale number" sweep does not "fix" it.

## Post-Deploy Monitoring & Validation

No runtime impact — this changes documentation and a CI gate only. No handler, seeder, or Redis behavior is touched; `api/health.js` is read but not modified.

- **Watch:** the always-on `docs-stats` CI job on subsequent PRs. Expected healthy signal: `docs-stats --check OK — 150 doc claims match code.`
- **Failure signal to expect (working as intended):** the next PR that adds or removes an `/api/health` registry key will fail `docs:check` with `summary.total is N, but /api/health probes M keys`. That is the gate doing its job — update the four example bodies.
- **Failure signal that means the gate itself needs attention:** any `docs-stats:` error naming an unaccounted mutation, an unreadable entry, or a different set of probed registries. That means `api/health.js` changed shape and `parseHealthProbedKeys` must be taught the new shape rather than the docs edited.
- **Rollback trigger:** if the gate blocks a legitimate change it cannot express, revert the two commits — the doc numbers stay correct either way.
- **Window/owner:** next 2-3 PRs touching `api/health.js` or `docs/`, @koala73.
