### PR TITLE
fix(news): prioritize China feeds before digest deadline

### DIFF
--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -3,6 +3,12 @@ export interface ServerFeed {
   url: string;
   lang?: string;
   strategicDefault?: boolean;
+  /**
+   * Positive values start earlier in a cold digest build. This is a fetch
+   * scheduling hint only; it does not affect ranking, source tier, or UI
+   * default selection.
+   */
+  deadlinePriority?: number;
 }
 
 export function isServerFeedReachableForLanguage(
@@ -10,6 +16,23 @@ export function isServerFeedReachableForLanguage(
   language: string,
 ): boolean {
   return !feed.lang || feed.lang === language || !!feed.strategicDefault;
+}
+
+export function orderServerFeedEntries<T extends {
+  feed: Pick<ServerFeed, 'deadlinePriority'>;
+}>(entries: readonly T[]): T[] {
+  return entries
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => {
+      const aPriority = Number.isFinite(a.entry.feed.deadlinePriority)
+        ? a.entry.feed.deadlinePriority!
+        : 0;
+      const bPriority = Number.isFinite(b.entry.feed.deadlinePriority)
+        ? b.entry.feed.deadlinePriority!
+        : 0;
+      return bPriority - aPriority || a.index - b.index;
+    })
+    .map(({ entry }) => entry);
 }
 
 const gn = (q: string) =>
@@ -259,10 +282,13 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'South China Morning Post', url: gn('site:scmp.com when:2d') },
       { name: 'The Hindu', url: 'https://www.thehindu.com/feeder/default.rss' },
       { name: 'Asia News', url: gn('site:asianews.it when:3d') },
-      { name: 'Xinhua', url: gn('site:xinhuanet.com OR Xinhua when:1d') },
+      // China coverage feeds must start before the full digest's later
+      // batches. Otherwise a slow cold build can report timeout for an
+      // otherwise healthy source while the seed transport remains fresh.
+      { name: 'Xinhua', url: gn('site:xinhuanet.com OR Xinhua when:1d'), deadlinePriority: 100 },
       { name: 'Asahi Shimbun', url: 'https://www.asahi.com/rss/asahi/newsheadlines.rdf', lang: 'ja', strategicDefault: true },
-      { name: 'MIIT (China)', url: gnLocale('site:miit.gov.cn when:7d', 'zh-CN', 'CN', 'CN:zh-Hans'), lang: 'zh', strategicDefault: true },
-      { name: 'MOFCOM (China)', url: gnLocale('site:mofcom.gov.cn when:7d', 'zh-CN', 'CN', 'CN:zh-Hans'), lang: 'zh', strategicDefault: true },
+      { name: 'MIIT (China)', url: gnLocale('site:miit.gov.cn when:7d', 'zh-CN', 'CN', 'CN:zh-Hans'), lang: 'zh', strategicDefault: true, deadlinePriority: 100 },
+      { name: 'MOFCOM (China)', url: gnLocale('site:mofcom.gov.cn when:7d', 'zh-CN', 'CN', 'CN:zh-Hans'), lang: 'zh', strategicDefault: true, deadlinePriority: 100 },
       { name: 'Bangkok Post', url: gn('site:bangkokpost.com when:1d'), lang: 'th', strategicDefault: true },
       { name: 'VnExpress', url: 'https://vnexpress.net/rss/tin-moi-nhat.rss', lang: 'vi', strategicDefault: true },
       { name: 'Yonhap News', url: 'https://www.yonhapnewstv.co.kr/browse/feed/', lang: 'ko', strategicDefault: true },

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -14,6 +14,7 @@ import { sha256Hex } from '../../../_shared/hash';
 import { CHROME_UA } from '../../../_shared/constants';
 import {
   isServerFeedReachableForLanguage,
+  orderServerFeedEntries,
   VARIANT_FEEDS,
   INTEL_SOURCES,
   type ServerFeed,
@@ -54,6 +55,8 @@ const POST_FETCH_HEADROOM_MS = 15_000;
 const RESPONSE_GUARD_BAND_MS = 3_000;
 const OVERALL_DEADLINE_MS = VERCEL_INITIAL_RESPONSE_LIMIT_MS - POST_FETCH_HEADROOM_MS;
 const BATCH_CONCURRENCY = 20;
+
+type DigestFeedEntry = { category: string; feed: ServerFeed };
 
 // U3 — hard freshness floor (default 96h, env override NEWS_MAX_AGE_HOURS).
 // Items older than this are dropped before scoring. The 24h `recencyScore`
@@ -1278,8 +1281,36 @@ async function writeStoryTracking(items: ParsedItem[], variant: string, lang: st
   await runRedisPipeline([['EXPIRE', accKey, DIGEST_ACCUMULATOR_TTL]]);
 }
 
-async function buildDigest(variant: string, lang: string): Promise<ListFeedDigestResponse> {
+function buildDigestFeedBatches(variant: string, lang: string): {
+  allEntries: DigestFeedEntry[];
+  batches: DigestFeedEntry[][];
+} {
   const feedsByCategory = VARIANT_FEEDS[variant] ?? {};
+  const allEntries: DigestFeedEntry[] = [];
+
+  for (const [category, feeds] of Object.entries(feedsByCategory)) {
+    const filtered = feeds.filter(f => isServerFeedReachableForLanguage(f, lang));
+    for (const feed of filtered) {
+      allEntries.push({ category, feed });
+    }
+  }
+
+  if (variant === 'full') {
+    const filteredIntel = INTEL_SOURCES.filter(f => isServerFeedReachableForLanguage(f, lang));
+    for (const feed of filteredIntel) {
+      allEntries.push({ category: 'intel', feed });
+    }
+  }
+
+  const orderedEntries = orderServerFeedEntries(allEntries);
+  const batches: DigestFeedEntry[][] = [];
+  for (let i = 0; i < orderedEntries.length; i += BATCH_CONCURRENCY) {
+    batches.push(orderedEntries.slice(i, i + BATCH_CONCURRENCY));
+  }
+  return { allEntries, batches };
+}
+
+async function buildDigest(variant: string, lang: string): Promise<ListFeedDigestResponse> {
   const feedStatuses: Record<string, string> = {};
   // #4920 coverage ledger: count every silent drop gate so "how much did
   // we NOT show" is a queryable number instead of a feeling.
@@ -1290,31 +1321,16 @@ async function buildDigest(variant: string, lang: string): Promise<ListFeedDiges
   const deadlineTimeout = setTimeout(() => deadlineController.abort(), OVERALL_DEADLINE_MS);
 
   try {
-    const allEntries: Array<{ category: string; feed: ServerFeed }> = [];
-
-    for (const [category, feeds] of Object.entries(feedsByCategory)) {
-      const filtered = feeds.filter(f => isServerFeedReachableForLanguage(f, lang));
-      for (const feed of filtered) {
-        allEntries.push({ category, feed });
-      }
-    }
-
-    if (variant === 'full') {
-      const filteredIntel = INTEL_SOURCES.filter(f => isServerFeedReachableForLanguage(f, lang));
-      for (const feed of filteredIntel) {
-        allEntries.push({ category: 'intel', feed });
-      }
-    }
+    const { allEntries, batches } = buildDigestFeedBatches(variant, lang);
 
     const results = new Map<string, ParsedItem[]>();
     // Track feeds that actually completed (with or without items) so we can
     // distinguish a genuine timeout (never ran) from a successful empty fetch.
     const completedFeeds = new Set<string>();
 
-    for (let i = 0; i < allEntries.length; i += BATCH_CONCURRENCY) {
+    for (const batch of batches) {
       if (deadlineController.signal.aborted) break;
 
-      const batch = allEntries.slice(i, i + BATCH_CONCURRENCY);
       const settled = await Promise.allSettled(
         batch.map(async ({ category, feed }) => {
           const result = await fetchAndParseRss(feed, variant, deadlineController.signal);
@@ -1591,6 +1607,7 @@ async function buildDigest(variant: string, lang: string): Promise<ListFeedDiges
 
 /** Internal exports for unit tests only — do not import in production code. */
 export const __testing__ = {
+  buildDigestFeedBatches,
   parseRssXml,
   decodeXmlEntities,
   extractDescription,

--- a/tests/china-market-news-coverage.test.mts
+++ b/tests/china-market-news-coverage.test.mts
@@ -4,12 +4,17 @@ import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
-import { VARIANT_FEEDS } from '../server/worldmonitor/news/v1/_feeds.ts';
+import {
+  orderServerFeedEntries,
+  VARIANT_FEEDS,
+} from '../server/worldmonitor/news/v1/_feeds.ts';
+import { __testing__ as digestTesting } from '../server/worldmonitor/news/v1/list-feed-digest.ts';
 import { SOURCE_PROPAGANDA_RISK } from '../shared/source-provenance.ts';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const readText = (path: string) => readFileSync(resolve(root, path), 'utf8');
 const readJson = <T>(path: string): T => JSON.parse(readText(path)) as T;
+const { buildDigestFeedBatches } = digestTesting;
 
 interface StockEntry {
   symbol: string;
@@ -148,5 +153,27 @@ describe('China client/server news digest parity (#5272)', () => {
     assert.equal(readText('scripts/shared/source-tiers.json'), readText('shared/source-tiers.json'));
     assert.equal(SOURCE_PROPAGANDA_RISK.Xinhua?.risk, 'high');
     assert.equal(SOURCE_PROPAGANDA_RISK.Xinhua?.stateAffiliated, 'China');
+  });
+
+  it('starts all China coverage feeds before ordinary full-digest feeds', () => {
+    const { batches } = buildDigestFeedBatches('full', 'en');
+    const firstBatch = batches[0] ?? [];
+
+    assert.deepEqual(
+      firstBatch.slice(0, 3).map(({ feed }) => feed.name).sort(),
+      ['Xinhua', 'MIIT (China)', 'MOFCOM (China)'].sort(),
+    );
+    assert.notEqual(firstBatch[3]?.feed.name, 'Xinhua');
+    assert.notEqual(firstBatch[3]?.feed.name, 'MIIT (China)');
+    assert.notEqual(firstBatch[3]?.feed.name, 'MOFCOM (China)');
+
+    const ordinaryEntries = [
+      { category: 'test', feed: { name: 'ordinary-first', url: 'https://example.test/first' } },
+      { category: 'test', feed: { name: 'ordinary-second', url: 'https://example.test/second' } },
+    ];
+    assert.deepEqual(
+      orderServerFeedEntries([...ordinaryEntries].reverse()).map(({ feed }) => feed.name),
+      ['ordinary-second', 'ordinary-first'],
+    );
   });
 });


### PR DESCRIPTION
## Summary

China transport metadata is fresh, but cold news digest builds can spend the response deadline on earlier feeds before Xinhua, MIIT, and MOFCOM run. This change gives those three feeds a scheduling-only priority so they start in the first batch, with stable ordering for equal-priority feeds. Existing source-level timeout, freshness, and partial-coverage reporting remain unchanged, so genuine upstream failures are still visible.

## Validation

- China coverage suite: 42 passed.
- Related digest/feed contracts: 106 passed.
- Pre-push gates passed, including typecheck, API typecheck, boundary/rate-limit/edge checks, 107 server tests, and the changed China tests.
- Changed-file Biome lint and `git diff --check` passed.
- The repository-wide data suite had one timing-sensitive SIGTERM cleanup case flake once; its isolated rerun passed all 4 tests.

## Post-deploy monitoring

- Confirm fresh `seed-meta:news:insights` and inspect `news:insights:v1:CN` source statuses for at least three consecutive runs.
- Expect 3/3 when upstreams respond; retain `CHINA_COVERAGE_PARTIAL` and timeout behavior for genuine upstream failures.
- Roll back if digest response deadlines regress or source statuses become misleading.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/MODEL_SLUG-GPT_5-000000)
