### PR TITLE
fix(rss): preserve stale feeds through upstream failures

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -223,7 +223,11 @@ export default async function handler(req, ctx) {
     const data = await response.text();
     const isSuccess = response.status >= 200 && response.status < 300;
     const relayCacheState = usedRelay ? response.headers.get('x-cache') : null;
-    const isStaleRelay = relayCacheState === 'STALE' || relayCacheState?.endsWith('-STALE');
+    const relayStaleMarker = usedRelay ? response.headers.get('x-relay-stale') : null;
+    // New relays identify stale fallback explicitly. Keep the label fallback
+    // while Railway and Vercel revisions roll out independently.
+    const legacyStaleCacheLabel = relayCacheState === 'STALE' || relayCacheState?.endsWith('-STALE');
+    const isStaleRelay = relayStaleMarker === '1' || legacyStaleCacheLabel;
     const isCacheableSuccess = isSuccess && !isStaleRelay;
     // Relay-only feeds are slow-updating institutional sources — cache longer
     const cdnTtl = isRelayOnly ? 3600 : 900;
@@ -240,6 +244,7 @@ export default async function handler(req, ctx) {
         ...(isCacheableSuccess && { 'CDN-Cache-Control': `public, s-maxage=${cdnTtl}, stale-while-revalidate=${swr}, stale-if-error=${sie}` }),
         ...(isStaleRelay && { 'CDN-Cache-Control': 'no-store' }),
         ...(relayCacheState && { 'X-Cache': relayCacheState }),
+        ...(relayStaleMarker && { 'X-Relay-Stale': relayStaleMarker }),
         ...corsHeaders,
       },
     });

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -215,12 +215,16 @@ export default async function handler(req, ctx) {
         }
         if (relayResponse?.ok) {
           response = relayResponse;
+          usedRelay = true;
         }
       }
     }
 
     const data = await response.text();
     const isSuccess = response.status >= 200 && response.status < 300;
+    const relayCacheState = usedRelay ? response.headers.get('x-cache') : null;
+    const isStaleRelay = relayCacheState === 'STALE' || relayCacheState?.endsWith('-STALE');
+    const isCacheableSuccess = isSuccess && !isStaleRelay;
     // Relay-only feeds are slow-updating institutional sources — cache longer
     const cdnTtl = isRelayOnly ? 3600 : 900;
     const swr = isRelayOnly ? 7200 : 1800;
@@ -230,10 +234,12 @@ export default async function handler(req, ctx) {
       status: response.status,
       headers: {
         'Content-Type': response.headers.get('content-type') || 'application/xml',
-        'Cache-Control': isSuccess
+        'Cache-Control': isCacheableSuccess
           ? `public, max-age=${browserTtl}, s-maxage=${cdnTtl}, stale-while-revalidate=${swr}, stale-if-error=${sie}`
-          : 'public, max-age=15, s-maxage=60, stale-while-revalidate=120',
-        ...(isSuccess && { 'CDN-Cache-Control': `public, s-maxage=${cdnTtl}, stale-while-revalidate=${swr}, stale-if-error=${sie}` }),
+          : isStaleRelay ? 'no-store' : 'public, max-age=15, s-maxage=60, stale-while-revalidate=120',
+        ...(isCacheableSuccess && { 'CDN-Cache-Control': `public, s-maxage=${cdnTtl}, stale-while-revalidate=${swr}, stale-if-error=${sie}` }),
+        ...(isStaleRelay && { 'CDN-Cache-Control': 'no-store' }),
+        ...(relayCacheState && { 'X-Cache': relayCacheState }),
         ...corsHeaders,
       },
     });

--- a/api/rss-proxy.test.mjs
+++ b/api/rss-proxy.test.mjs
@@ -234,6 +234,33 @@ test('preserves Railway relay fallback for direct-fetch transport failures', asy
   assert.equal(calls[1].headers['x-relay-key'], 'relay-secret');
 });
 
+test('does not cache stale RSS bodies returned by the Railway relay', async () => {
+  process.env.WS_RELAY_URL = 'wss://relay.example.com';
+  process.env.RELAY_SHARED_SECRET = 'relay-secret';
+  const calls = [];
+
+  globalThis.fetch = async (input, init = {}) => {
+    calls.push({ url: String(input), headers: init.headers });
+    if (calls.length === 1) return new Response('Forbidden', { status: 403 });
+    return new Response('<rss><channel><title>stale</title></channel></rss>', {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/xml',
+        'X-Cache': 'BACKOFF-STALE',
+      },
+    });
+  };
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('cache-control'), 'no-store');
+  assert.equal(res.headers.get('cdn-cache-control'), 'no-store');
+  assert.equal(res.headers.get('x-cache'), 'BACKOFF-STALE');
+  assert.match(await res.text(), /stale/);
+  assert.equal(calls.length, 2);
+});
+
 test('preserves the original direct-fetch error when the relay fallback itself throws (#5398)', async () => {
   // Both legs fail, but the relay's throw must not replace directError as the
   // reported failure — the #5378 suite only ever covered relay returning

--- a/api/rss-proxy.test.mjs
+++ b/api/rss-proxy.test.mjs
@@ -247,6 +247,7 @@ test('does not cache stale RSS bodies returned by the Railway relay', async () =
       headers: {
         'Content-Type': 'application/xml',
         'X-Cache': 'BACKOFF-STALE',
+        'X-Relay-Stale': '1',
       },
     });
   };
@@ -257,7 +258,36 @@ test('does not cache stale RSS bodies returned by the Railway relay', async () =
   assert.equal(res.headers.get('cache-control'), 'no-store');
   assert.equal(res.headers.get('cdn-cache-control'), 'no-store');
   assert.equal(res.headers.get('x-cache'), 'BACKOFF-STALE');
+  assert.equal(res.headers.get('x-relay-stale'), '1');
   assert.match(await res.text(), /stale/);
+  assert.equal(calls.length, 2);
+});
+
+test('keeps legacy plain STALE relay responses non-cacheable during rollout', async () => {
+  process.env.WS_RELAY_URL = 'wss://relay.example.com';
+  process.env.RELAY_SHARED_SECRET = 'relay-secret';
+  const calls = [];
+
+  globalThis.fetch = async (input, init = {}) => {
+    calls.push({ url: String(input), headers: init.headers });
+    if (calls.length === 1) return new Response('Forbidden', { status: 403 });
+    return new Response('<rss><channel><title>legacy stale</title></channel></rss>', {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/xml',
+        'X-Cache': 'STALE',
+      },
+    });
+  };
+
+  const res = await handler(makeRequest('https://techcrunch.com/feed'));
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('cache-control'), 'no-store');
+  assert.equal(res.headers.get('cdn-cache-control'), 'no-store');
+  assert.equal(res.headers.get('x-cache'), 'STALE');
+  assert.equal(res.headers.get('x-relay-stale'), null);
+  assert.match(await res.text(), /legacy stale/);
   assert.equal(calls.length, 2);
 });
 

--- a/scripts/ais-relay-ingestion.test.cjs
+++ b/scripts/ais-relay-ingestion.test.cjs
@@ -5,6 +5,7 @@ const { once } = require('node:events');
 const http = require('node:http');
 const path = require('node:path');
 const { spawn } = require('node:child_process');
+const { setTimeout: sleep } = require('node:timers/promises');
 const test = require('node:test');
 
 function get(port, requestPath, headers) {
@@ -172,7 +173,7 @@ test('relay handlers expose bounded Google/OpenSky cooldowns and RSS fallback me
     const staleFeed = 'https://feeds.bbci.co.uk/news/world/rss.xml?test=stale';
     const rssFresh = await get(port, `/rss?url=${encodeURIComponent(staleFeed)}`);
     assert.equal(rssFresh.status, 200);
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await sleep(25);
     const rssStale = await get(port, `/rss?url=${encodeURIComponent(staleFeed)}`);
     assert.equal(rssStale.status, 200);
     assert.equal(rssStale.headers['x-cache'], 'STALE');
@@ -212,6 +213,151 @@ test('relay handlers expose bounded Google/OpenSky cooldowns and RSS fallback me
     const agedHealth = JSON.parse((await get(port, '/health')).body);
     assert.equal(agedHealth.ingestion.aviation.coverage.requests, 0, 'request samples must age out of the rolling window');
     assert.equal(agedHealth.ingestion.aviation.coverage.status, 'degraded', 'active provider reset must remain visible after samples age out');
+  } finally {
+    await stop(child);
+  }
+});
+
+test('RSS keeps serving the last good body after an upstream 403 enters backoff', async () => {
+  const { child, ready } = spawnRelay({
+    RELAY_RSS_RATE_LIMIT_MAX: '1000',
+    RELAY_TEST_RSS_CACHE_TTL_MS: '10',
+    RELAY_METRICS_WINDOW_SECONDS: '10',
+  });
+
+  try {
+    const { port } = await ready;
+    const feedUrl = 'https://feeds.bbci.co.uk/news/world/rss.xml?test=forbidden';
+    const requestPath = `/rss?url=${encodeURIComponent(feedUrl)}`;
+
+    const fresh = await get(port, requestPath);
+    assert.equal(fresh.status, 200);
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    const stale = await get(port, requestPath);
+    assert.equal(stale.status, 200, stale.body);
+    assert.equal(stale.headers['x-cache'], 'STALE');
+    assert.match(stale.body, /<rss>/);
+
+    const backoffStale = await get(port, requestPath);
+    assert.equal(backoffStale.status, 200, backoffStale.body);
+    assert.equal(backoffStale.headers['x-cache'], 'BACKOFF-STALE');
+    assert.match(backoffStale.body, /<rss>/);
+
+    const metrics = JSON.parse((await get(port, '/metrics')).body);
+    assert.ok(metrics.rss.authRejection >= 1, 'the upstream 403 must remain observable');
+    assert.ok(metrics.rss.fallback >= 2, 'both stale responses must be counted as fallback');
+    assert.equal(metrics.rss.served, 3, 'fresh plus both stale responses must be served');
+  } finally {
+    await stop(child);
+  }
+});
+
+test('RSS keeps serving the last good body after upstream 5xx and timeout failures', async () => {
+  for (const [mode, outcome] of [['server-error', 'terminalFailure'], ['timeout', 'timeout']]) {
+    const { child, ready } = spawnRelay({
+      RELAY_RSS_RATE_LIMIT_MAX: '1000',
+      RELAY_TEST_RSS_CACHE_TTL_MS: '10',
+      RELAY_METRICS_WINDOW_SECONDS: '10',
+    });
+
+    try {
+      const { port } = await ready;
+      const feedUrl = `https://feeds.bbci.co.uk/news/world/rss.xml?test=${mode}`;
+      const requestPath = `/rss?url=${encodeURIComponent(feedUrl)}`;
+
+      assert.equal((await get(port, requestPath)).status, 200);
+      await sleep(25);
+
+      const stale = await get(port, requestPath);
+      assert.equal(stale.status, 200, stale.body);
+      assert.equal(stale.headers['x-cache'], 'STALE');
+      assert.match(stale.body, /<rss>/);
+
+      const metrics = JSON.parse((await get(port, '/metrics')).body);
+      assert.ok(metrics.rss[outcome] >= 1, `${mode} must remain observable`);
+      assert.ok(metrics.rss.fallback >= 1, `${mode} must serve stale fallback`);
+    } finally {
+      await stop(child);
+    }
+  }
+});
+
+test('RSS counts concurrent stale deduplication as fallback', async () => {
+  const { child, ready } = spawnRelay({
+    RELAY_RSS_RATE_LIMIT_MAX: '1000',
+    RELAY_TEST_RSS_CACHE_TTL_MS: '10',
+    RELAY_METRICS_WINDOW_SECONDS: '10',
+  });
+
+  try {
+    const { port } = await ready;
+    const feedUrl = 'https://feeds.bbci.co.uk/news/world/rss.xml?test=dedup';
+    const requestPath = `/rss?url=${encodeURIComponent(feedUrl)}`;
+    assert.equal((await get(port, requestPath)).status, 200);
+    await sleep(25);
+
+    const responses = await Promise.all([get(port, requestPath), get(port, requestPath)]);
+    assert.ok(responses.every((response) => response.status === 200), responses.map((response) => response.body).join('\n'));
+    assert.deepEqual(new Set(responses.map((response) => response.headers['x-cache'])), new Set(['STALE', 'DEDUP-STALE']));
+
+    const metrics = JSON.parse((await get(port, '/metrics')).body);
+    assert.ok(metrics.rss.authRejection >= 2, 'leader and dedup follower must retain the upstream rejection outcome');
+    assert.ok(metrics.rss.fallback >= 2, 'leader and dedup follower must count as fallback');
+    assert.equal(metrics.rss.served, 3, 'fresh, stale leader, and stale dedup follower must be served');
+  } finally {
+    await stop(child);
+  }
+});
+
+test('RSS keeps concurrent timeout followers on the stale no-store path', async () => {
+  const { child, ready } = spawnRelay({
+    RELAY_RSS_RATE_LIMIT_MAX: '1000',
+    RELAY_TEST_RSS_CACHE_TTL_MS: '10',
+    RELAY_METRICS_WINDOW_SECONDS: '10',
+  });
+
+  try {
+    const { port } = await ready;
+    const feedUrl = 'https://feeds.bbci.co.uk/news/world/rss.xml?test=dedup-timeout';
+    const requestPath = `/rss?url=${encodeURIComponent(feedUrl)}`;
+    assert.equal((await get(port, requestPath)).status, 200);
+    await sleep(25);
+
+    const responses = await Promise.all([get(port, requestPath), get(port, requestPath)]);
+    assert.ok(responses.every((response) => response.status === 200), responses.map((response) => response.body).join('\n'));
+    assert.deepEqual(new Set(responses.map((response) => response.headers['x-cache'])), new Set(['STALE', 'DEDUP-STALE']));
+
+    const metrics = JSON.parse((await get(port, '/metrics')).body);
+    assert.ok(metrics.rss.timeout >= 2, 'leader and dedup follower must retain the timeout outcome');
+    assert.ok(metrics.rss.fallback >= 2, 'leader and dedup follower must count as fallback');
+    assert.equal(metrics.rss.served, 3, 'fresh, stale leader, and stale dedup follower must be served');
+  } finally {
+    await stop(child);
+  }
+});
+
+test('RSS retains stale bodies while cleanup runs during active backoff', async () => {
+  const { child, ready } = spawnRelay({
+    RELAY_RSS_RATE_LIMIT_MAX: '1000',
+    RELAY_TEST_RSS_CACHE_TTL_MS: '10',
+    RELAY_TEST_RSS_CACHE_CLEANUP_INTERVAL_MS: '1000',
+    RELAY_METRICS_WINDOW_SECONDS: '10',
+  });
+
+  try {
+    const { port } = await ready;
+    const feedUrl = 'https://feeds.bbci.co.uk/news/world/rss.xml?test=forbidden';
+    const requestPath = `/rss?url=${encodeURIComponent(feedUrl)}`;
+    assert.equal((await get(port, requestPath)).status, 200);
+    await sleep(25);
+    assert.equal((await get(port, requestPath)).headers['x-cache'], 'STALE');
+
+    await sleep(1200);
+    const backoffStale = await get(port, requestPath);
+    assert.equal(backoffStale.status, 200, backoffStale.body);
+    assert.equal(backoffStale.headers['x-cache'], 'BACKOFF-STALE');
   } finally {
     await stop(child);
   }

--- a/scripts/ais-relay-rss.test.cjs
+++ b/scripts/ais-relay-rss.test.cjs
@@ -85,13 +85,22 @@ function createMockUpstream() {
 
 function createTestRssProxy(upstreamPort) {
   const https = require('node:http'); // use http for testing, not https
-  const zlib = require('node:zlib');
 
   const rssResponseCache = new Map();
+  const rssNegativeCache = new Map();
   const rssInFlight = new Map();
   const RSS_CACHE_TTL_MS = 5 * 60 * 1000;
   const RSS_NEGATIVE_CACHE_TTL_MS = 60 * 1000;
   const RSS_CACHE_MAX_ENTRIES = 5; // small cap for testing
+  const RSS_NEGATIVE_CACHE_MAX_ENTRIES = 3; // failures need less headroom than feed bodies
+
+  function setBoundedCacheEntry(cache, key, value, maxEntries) {
+    if (!cache.has(key) && cache.size >= maxEntries) {
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) cache.delete(oldest);
+    }
+    cache.set(key, value);
+  }
 
   function safeEnd(res, statusCode, headers, body) {
     if (res.headersSent || res.writableEnded) return false;
@@ -111,32 +120,49 @@ function createTestRssProxy(upstreamPort) {
       return res.end(JSON.stringify({ error: 'Missing url' }));
     }
 
-    // Cache check with status-aware TTL
+    // Successful and negative responses have separate lifetimes and stores.
     const rssCached = rssResponseCache.get(feedUrl);
-    if (rssCached) {
-      const ttl = (rssCached.statusCode >= 200 && rssCached.statusCode < 300)
-        ? RSS_CACHE_TTL_MS : RSS_NEGATIVE_CACHE_TTL_MS;
-      if (Date.now() - rssCached.timestamp < ttl) {
-        res.writeHead(rssCached.statusCode, {
+    const rssNegativeCached = rssNegativeCache.get(feedUrl);
+    if (rssCached && Date.now() - rssCached.timestamp < RSS_CACHE_TTL_MS) {
+      res.writeHead(200, { 'Content-Type': 'application/xml', 'X-Cache': 'HIT' });
+      return res.end(rssCached.data);
+    }
+    if (rssNegativeCached) {
+      if (Date.now() - rssNegativeCached.timestamp < RSS_NEGATIVE_CACHE_TTL_MS) {
+        if (rssCached) {
+          res.writeHead(200, { 'Content-Type': 'application/xml', 'X-Cache': 'NEGATIVE-STALE' });
+          return res.end(rssCached.data);
+        }
+        res.writeHead(rssNegativeCached.statusCode, {
           'Content-Type': 'application/xml',
           'X-Cache': 'HIT',
         });
-        return res.end(rssCached.data);
+        return res.end(rssNegativeCached.data);
       }
+      rssNegativeCache.delete(feedUrl);
     }
 
     // In-flight dedup — cascade-resistant
     const existing = rssInFlight.get(feedUrl);
     if (existing) {
       try {
-        await existing;
+        const fetchResult = await existing;
         const deduped = rssResponseCache.get(feedUrl);
         if (deduped) {
-          res.writeHead(deduped.statusCode, {
+          const dedupedNegative = rssNegativeCache.get(feedUrl);
+          res.writeHead(200, {
+            'Content-Type': 'application/xml',
+            'X-Cache': dedupedNegative || fetchResult?.stale ? 'DEDUP-STALE' : 'DEDUP',
+          });
+          return res.end(deduped.data);
+        }
+        const dedupedNegative = rssNegativeCache.get(feedUrl);
+        if (dedupedNegative) {
+          res.writeHead(dedupedNegative.statusCode, {
             'Content-Type': 'application/xml',
             'X-Cache': 'DEDUP',
           });
-          return res.end(deduped.data);
+          return res.end(dedupedNegative.data);
         }
         return safeEnd(res, 502, { 'Content-Type': 'application/json' },
           JSON.stringify({ error: 'Upstream fetch completed but not cached' }));
@@ -158,7 +184,7 @@ function createTestRssProxy(upstreamPort) {
       }, (response) => {
         if (response.statusCode === 304 && rssCached) {
           rssCached.timestamp = Date.now();
-          resolveInFlight();
+          resolveInFlight({ stale: false });
           res.writeHead(200, {
             'Content-Type': rssCached.contentType || 'application/xml',
             'X-Cache': 'REVALIDATED',
@@ -171,18 +197,26 @@ function createTestRssProxy(upstreamPort) {
         response.on('data', (c) => chunks.push(c));
         response.on('end', () => {
           const data = Buffer.concat(chunks);
-          // FIFO eviction
-          if (rssResponseCache.size >= RSS_CACHE_MAX_ENTRIES && !rssResponseCache.has(feedUrl)) {
-            const oldest = rssResponseCache.keys().next().value;
-            if (oldest) rssResponseCache.delete(oldest);
-          }
-          rssResponseCache.set(feedUrl, {
+          const isSuccess = response.statusCode >= 200 && response.statusCode < 300;
+          const cacheEntry = {
             data, contentType: 'application/xml',
             statusCode: response.statusCode, timestamp: Date.now(),
-            etag: response.headers.etag || null,
-            lastModified: response.headers['last-modified'] || null,
-          });
-          resolveInFlight();
+          };
+          if (isSuccess) {
+            cacheEntry.etag = response.headers.etag || null;
+            cacheEntry.lastModified = response.headers['last-modified'] || null;
+            setBoundedCacheEntry(rssResponseCache, feedUrl, cacheEntry, RSS_CACHE_MAX_ENTRIES);
+            rssNegativeCache.delete(feedUrl);
+          } else {
+            setBoundedCacheEntry(rssNegativeCache, feedUrl, cacheEntry, RSS_NEGATIVE_CACHE_MAX_ENTRIES);
+          }
+          if (!isSuccess && rssCached) {
+            res.writeHead(200, { 'Content-Type': 'application/xml', 'X-Cache': 'STALE' });
+            res.end(rssCached.data);
+            resolveInFlight({ stale: true });
+            return;
+          }
+          resolveInFlight({ stale: false });
           res.writeHead(response.statusCode, {
             'Content-Type': 'application/xml',
             'X-Cache': 'MISS',
@@ -195,7 +229,7 @@ function createTestRssProxy(upstreamPort) {
         if (rssCached) {
           res.writeHead(200, { 'Content-Type': 'application/xml', 'X-Cache': 'STALE' });
           res.end(rssCached.data);
-          resolveInFlight();
+          resolveInFlight({ stale: true });
           return;
         }
         rejectInFlight(err);
@@ -208,7 +242,7 @@ function createTestRssProxy(upstreamPort) {
         if (rssCached) {
           res.writeHead(200, { 'Content-Type': 'application/xml', 'X-Cache': 'STALE' });
           res.end(rssCached.data);
-          resolveInFlight();
+          resolveInFlight({ stale: true });
           return;
         }
         rejectInFlight(new Error('timeout'));
@@ -221,7 +255,7 @@ function createTestRssProxy(upstreamPort) {
     fetchPromise.catch(() => {}).finally(() => rssInFlight.delete(feedUrl));
   });
 
-  return { server, cache: rssResponseCache, inFlight: rssInFlight };
+  return { server, cache: rssResponseCache, negativeCache: rssNegativeCache, inFlight: rssInFlight };
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
@@ -252,6 +286,104 @@ test('RSS proxy: negative caching prevents thundering herd on 429', async (_t) =
   const r3 = await fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`);
   assert.equal(r3.headers['x-cache'], 'HIT');
   assert.equal(upstream.getHitCount(), 1);
+
+  upstream.server.close();
+  proxy.server.close();
+});
+
+test('RSS proxy: upstream rejection preserves the last successful body', async (_t) => {
+  const upstream = createMockUpstream();
+  upstream.setResponse(200, '<rss><channel><title>Fresh</title></channel></rss>');
+  const upstreamPort = await listen(upstream.server);
+
+  const proxy = createTestRssProxy(upstreamPort);
+  const proxyPort = await listen(proxy.server);
+  const feedUrl = 'http://example.com/stale-403';
+
+  const fresh = await fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`);
+  assert.equal(fresh.status, 200);
+  const cached = proxy.cache.get(feedUrl);
+  cached.timestamp = Date.now() - 10 * 60 * 1000;
+
+  upstream.setResponse(403, 'Forbidden');
+  const stale = await fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`);
+  assert.equal(stale.status, 200);
+  assert.equal(stale.headers['x-cache'], 'STALE');
+  assert.match(stale.body, /Fresh/);
+  assert.equal(proxy.negativeCache.get(feedUrl).statusCode, 403);
+
+  upstream.server.close();
+  proxy.server.close();
+});
+
+test('RSS proxy: concurrent stale followers are deduplicated and served', async (_t) => {
+  const upstream = createMockUpstream();
+  upstream.setResponse(200, '<rss><channel><title>Fresh</title></channel></rss>');
+  const upstreamPort = await listen(upstream.server);
+
+  const proxy = createTestRssProxy(upstreamPort);
+  const proxyPort = await listen(proxy.server);
+  const feedUrl = 'http://example.com/stale-dedup';
+
+  await fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`);
+  proxy.cache.get(feedUrl).timestamp = Date.now() - 10 * 60 * 1000;
+  upstream.setResponse(503, 'Unavailable');
+  upstream.setDelay(100);
+
+  const responses = await Promise.all([
+    fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`),
+    fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`),
+  ]);
+  assert.ok(responses.every((response) => response.status === 200));
+  assert.deepEqual(new Set(responses.map((response) => response.headers['x-cache'])), new Set(['STALE', 'DEDUP-STALE']));
+  assert.equal(upstream.getHitCount(), 2, 'only the leader should hit upstream after the initial prime');
+
+  upstream.server.close();
+  proxy.server.close();
+});
+
+test('RSS proxy: successful recovery clears the negative cache', async (_t) => {
+  const upstream = createMockUpstream();
+  upstream.setResponse(503, 'Unavailable');
+  const upstreamPort = await listen(upstream.server);
+
+  const proxy = createTestRssProxy(upstreamPort);
+  const proxyPort = await listen(proxy.server);
+  const feedUrl = 'http://example.com/recovery';
+
+  const failed = await fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`);
+  assert.equal(failed.status, 503);
+  proxy.negativeCache.get(feedUrl).timestamp = Date.now() - 2 * 60 * 1000;
+
+  upstream.setResponse(200, '<rss><channel><title>Recovered</title></channel></rss>');
+  const recovered = await fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`);
+  assert.equal(recovered.status, 200);
+  assert.equal(recovered.headers['x-cache'], 'MISS');
+  assert.equal(proxy.negativeCache.has(feedUrl), false);
+
+  const hit = await fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`);
+  assert.equal(hit.headers['x-cache'], 'HIT');
+  assert.equal(upstream.getHitCount(), 2);
+
+  upstream.server.close();
+  proxy.server.close();
+});
+
+test('RSS proxy: negative cache has its own bounded entry cap', async (_t) => {
+  const upstream = createMockUpstream();
+  upstream.setResponse(429, 'Rate limited');
+  const upstreamPort = await listen(upstream.server);
+
+  const proxy = createTestRssProxy(upstreamPort);
+  const proxyPort = await listen(proxy.server);
+
+  for (let i = 0; i < 4; i++) {
+    const feedUrl = `http://example.com/negative-${i}`;
+    await fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`);
+  }
+
+  assert.equal(proxy.negativeCache.size, 3);
+  assert.equal(proxy.negativeCache.has('http://example.com/negative-0'), false);
 
   upstream.server.close();
   proxy.server.close();

--- a/scripts/ais-relay-rss.test.cjs
+++ b/scripts/ais-relay-rss.test.cjs
@@ -312,6 +312,13 @@ test('RSS proxy: upstream rejection preserves the last successful body', async (
   assert.match(stale.body, /Fresh/);
   assert.equal(proxy.negativeCache.get(feedUrl).statusCode, 403);
 
+  // A second request is served by the short-lived negative cache while the
+  // positive body remains available, exercising the NEGATIVE-STALE branch.
+  const negativeStale = await fetch(`http://127.0.0.1:${proxyPort}/?url=${encodeURIComponent(feedUrl)}`);
+  assert.equal(negativeStale.status, 200);
+  assert.equal(negativeStale.headers['x-cache'], 'NEGATIVE-STALE');
+  assert.match(negativeStale.body, /Fresh/);
+
   upstream.server.close();
   proxy.server.close();
 });

--- a/scripts/ais-relay-test-preload.cjs
+++ b/scripts/ais-relay-test-preload.cjs
@@ -60,13 +60,17 @@ function response(statusCode, body, headers, callback) {
   });
 }
 
-function request({ callback, statusCode, body = '', headers = {}, error = null }) {
+function request({ callback, statusCode, body = '', headers = {}, error = null, timeout = false, delayMs = 0 }) {
   const req = new EventEmitter();
   req.write = () => {};
   req.end = () => {};
   req.setTimeout = () => req;
   req.destroy = () => req;
-  process.nextTick(() => {
+  const emitResponse = () => {
+    if (timeout) {
+      req.emit('timeout');
+      return;
+    }
     if (error) {
       const err = new Error(error);
       err.code = 'ECONNRESET';
@@ -74,7 +78,9 @@ function request({ callback, statusCode, body = '', headers = {}, error = null }
       return;
     }
     response(statusCode, body, headers, callback);
-  });
+  };
+  if (delayMs > 0) setTimeout(emitResponse, delayMs);
+  else process.nextTick(emitResponse);
   return req;
 }
 
@@ -181,8 +187,39 @@ https.get = function patchedGet(...args) {
     const key = parsed.searchParams.get('test') || parsed.pathname;
     const callNumber = (rssCalls.get(key) || 0) + 1;
     rssCalls.set(key, callNumber);
-    const mode = key === 'stale' && callNumber === 1 ? 'success' : 'error';
+    let mode = 'error';
+    if ((key === 'stale' || key === 'forbidden' || key === 'server-error' || key === 'timeout' || key === 'dedup' || key === 'dedup-timeout') && callNumber === 1) {
+      mode = 'success';
+    } else if (key === 'forbidden') {
+      mode = 'forbidden';
+    } else if (key === 'server-error') {
+      mode = 'server-error';
+    } else if (key === 'timeout') {
+      mode = 'timeout';
+    } else if (key === 'dedup') {
+      mode = 'forbidden';
+    } else if (key === 'dedup-timeout') {
+      mode = 'timeout';
+    }
     if (mode === 'error') return request({ callback: cb, error: 'RSS upstream reset' });
+    if (mode === 'timeout') return request({ callback: cb, timeout: true, delayMs: key === 'dedup-timeout' ? 25 : 0 });
+    if (mode === 'server-error') {
+      return request({
+        callback: cb,
+        statusCode: 503,
+        body: 'Service unavailable',
+        headers: { 'content-type': 'text/html' },
+      });
+    }
+    if (mode === 'forbidden') {
+      return request({
+        callback: cb,
+        statusCode: 403,
+        body: 'Forbidden',
+        headers: { 'content-type': 'text/html' },
+        delayMs: key === 'dedup' ? 25 : 0,
+      });
+    }
     return request({
       callback: cb,
       statusCode: 200,

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -7638,7 +7638,7 @@ function processRawUpstreamMessage(raw) {
   messageCount++;
   if (messageCount % 5000 === 0) {
     const mem = process.memoryUsage();
-    console.log(`[Relay] ${messageCount} msgs, ${clients.size} ws-clients, ${vessels.size} vessels, queue=${getUpstreamQueueSize()}, dropped=${droppedMessages}, rss=${(mem.rss / 1024 / 1024).toFixed(0)}MB heap=${(mem.heapUsed / 1024 / 1024).toFixed(0)}MB, cache: opensky=${openskyResponseCache.size} opensky_neg=${openskyNegativeCache.size} rss_feed=${rssResponseCache.size} rss_backoff=${rssFailureCount.size}`);
+    console.log(`[Relay] ${messageCount} msgs, ${clients.size} ws-clients, ${vessels.size} vessels, queue=${getUpstreamQueueSize()}, dropped=${droppedMessages}, rss=${(mem.rss / 1024 / 1024).toFixed(0)}MB heap=${(mem.heapUsed / 1024 / 1024).toFixed(0)}MB, cache: opensky=${openskyResponseCache.size} opensky_neg=${openskyNegativeCache.size} rss_feed=${rssResponseCache.size} rss_neg=${rssNegativeCache.size} rss_backoff=${rssFailureCount.size}`);
   }
 
   let acceptedType = null;
@@ -8554,7 +8554,8 @@ const OPENSKY_BBOX_DECIMALS = OPENSKY_BBOX_QUANT_STEP > 0
 const OPENSKY_DEDUP_EMPTY_RESPONSE_JSON = JSON.stringify({ states: [], time: 0 });
 const OPENSKY_DEDUP_EMPTY_RESPONSE_GZIP = gzipSyncBuffer(OPENSKY_DEDUP_EMPTY_RESPONSE_JSON);
 const OPENSKY_DEDUP_EMPTY_RESPONSE_BROTLI = brotliSyncBuffer(OPENSKY_DEDUP_EMPTY_RESPONSE_JSON);
-const rssResponseCache = new Map(); // key: feed URL → { data, contentType, timestamp, statusCode }
+const rssResponseCache = new Map(); // key: feed URL → last successful { data, contentType, timestamp, statusCode }
+const rssNegativeCache = new Map(); // key: feed URL → short-lived last non-2xx response
 const rssInFlight = new Map(); // key: feed URL → Promise (dedup concurrent requests)
 const rssFailureCount = new Map(); // key: feed URL → consecutive failure count (for exponential backoff)
 const rssBackoffUntil = new Map(); // key: feed URL → timestamp when backoff expires
@@ -8562,6 +8563,8 @@ const RSS_CACHE_TTL_MS = Math.max(1, Number(process.env.RELAY_TEST_RSS_CACHE_TTL
 const RSS_NEGATIVE_CACHE_TTL_MS = 60 * 1000; // 1 min base — scaled by 2^failures via backoff
 const RSS_MAX_NEGATIVE_CACHE_TTL_MS = 15 * 60 * 1000; // 15 min cap — stop hammering broken feeds
 const RSS_CACHE_MAX_ENTRIES = 200; // hard cap — ~20 allowed domains × ~5 paths max, with headroom
+const RSS_NEGATIVE_CACHE_MAX_ENTRIES = 64; // short-lived failures need less headroom than feed bodies
+const RSS_CACHE_CLEANUP_INTERVAL_MS = Math.max(1, Number(process.env.RELAY_TEST_RSS_CACHE_CLEANUP_INTERVAL_MS) || 60 * 1000);
 
 function rssRecordFailure(feedUrl) {
   const prev = rssFailureCount.get(feedUrl) || 0;
@@ -9554,7 +9557,14 @@ setInterval(() => {
     if (now - entry.timestamp > OPENSKY_NEGATIVE_CACHE_TTL_MS * 2) openskyNegativeCache.delete(key);
   }
   for (const [key, entry] of rssResponseCache) {
-    if (now - entry.timestamp > RSS_CACHE_TTL_MS * 2) rssResponseCache.delete(key);
+    const backoffActive = (rssBackoffUntil.get(key) || 0) > now;
+    const negativeCacheActive = (rssNegativeCache.get(key)?.timestamp || 0) + RSS_NEGATIVE_CACHE_TTL_MS > now;
+    if (now - entry.timestamp > RSS_CACHE_TTL_MS * 2 && !backoffActive && !negativeCacheActive) {
+      rssResponseCache.delete(key);
+    }
+  }
+  for (const [key, entry] of rssNegativeCache) {
+    if (now - entry.timestamp > RSS_NEGATIVE_CACHE_TTL_MS * 2) rssNegativeCache.delete(key);
   }
   for (const [key, expiry] of rssBackoffUntil) {
     // Only clear backoff timer on expiry — preserve failureCount so
@@ -9565,7 +9575,9 @@ setInterval(() => {
   // Edge case: if cache is evicted (FIFO/age) right when backoff expires, failureCount
   // resets — next failure starts at 1min instead of re-escalating. Window is ~60s, acceptable.
   for (const key of rssFailureCount.keys()) {
-    if (!rssBackoffUntil.has(key) && !rssResponseCache.has(key)) rssFailureCount.delete(key);
+    if (!rssBackoffUntil.has(key) && !rssResponseCache.has(key) && !rssNegativeCache.has(key)) {
+      rssFailureCount.delete(key);
+    }
   }
   for (const [key, entry] of worldbankCache) {
     if (now - entry.timestamp > WORLDBANK_CACHE_TTL_MS * 2) worldbankCache.delete(key);
@@ -9582,7 +9594,7 @@ setInterval(() => {
   for (const [key, ts] of logThrottleState) {
     if (now - ts > RELAY_LOG_THROTTLE_MS * 6) logThrottleState.delete(key);
   }
-}, 60 * 1000).unref?.();
+}, RSS_CACHE_CLEANUP_INTERVAL_MS).unref?.();
 
 // ── Yahoo Finance Chart Proxy ──────────────────────────────────────
 const YAHOO_CHART_CACHE_TTL_MS = 300_000; // 5 min
@@ -10192,7 +10204,9 @@ const server = http.createServer(async (req, res) => {
       cache: {
         opensky: openskyResponseCache.size,
         opensky_neg: openskyNegativeCache.size,
-        rss: rssResponseCache.size,
+        rss: rssResponseCache.size + rssNegativeCache.size,
+        rss_positive: rssResponseCache.size,
+        rss_negative: rssNegativeCache.size,
         ucdp: ucdpCache.data ? 'warm' : 'cold',
         worldbank: worldbankCache.size,
         polymarket: polymarketCache.size,
@@ -10411,20 +10425,24 @@ const server = http.createServer(async (req, res) => {
         return res.end(JSON.stringify({ error: 'Domain not allowed on Railway proxy' }));
       }
 
+      const sendRssStale = (cacheEntry, cacheLabel = 'STALE', extraHeaders = {}) => sendCompressed(req, res, 200, {
+        'Content-Type': cacheEntry.contentType || 'application/xml',
+        'Cache-Control': 'no-store',
+        'CDN-Cache-Control': 'no-store',
+        'X-Cache': cacheLabel,
+        ...extraHeaders,
+      }, cacheEntry.data);
+
       // Backoff guard: if feed is in exponential backoff, don't hit upstream
       const backoffExpiry = rssBackoffUntil.get(feedUrl);
       const backoffNow = Date.now();
       if (backoffExpiry && backoffNow < backoffExpiry) {
         const rssCachedForBackoff = rssResponseCache.get(feedUrl);
-        if (rssCachedForBackoff && rssCachedForBackoff.statusCode >= 200 && rssCachedForBackoff.statusCode < 300) {
+        if (rssCachedForBackoff) {
           recordRelayOutcome('rss', 'throttle');
           recordRelayOutcome('rss', 'fallback');
           incrementRelayMetric('rssServed');
-          return sendCompressed(req, res, 200, {
-            'Content-Type': rssCachedForBackoff.contentType || 'application/xml',
-            'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store',
-            'X-Cache': 'BACKOFF-STALE',
-          }, rssCachedForBackoff.data);
+          return sendRssStale(rssCachedForBackoff, 'BACKOFF-STALE');
         }
         const remainSec = Math.max(1, Math.round((backoffExpiry - backoffNow) / 1000));
         recordRelayOutcome('rss', 'throttle');
@@ -10434,26 +10452,36 @@ const server = http.createServer(async (req, res) => {
 
       // Two-layer negative caching:
       // 1. Backoff guard above: exponential (1→15min) for network errors (socket hang up, timeout)
-      // 2. This cache check: flat 1min TTL for non-2xx upstream responses (429, 503, etc.)
-      // Both layers work correctly together — backoff handles persistent failures,
-      // negative cache prevents thundering herd on transient upstream errors.
+      // 2. The negative cache below: flat 1min TTL for non-2xx upstream responses (429, 503, etc.)
+      // Keep negative responses separate from the positive cache so an upstream
+      // rejection cannot erase the last body that can be served stale.
       const rssCached = rssResponseCache.get(feedUrl);
-      if (rssCached) {
-        const ttl = (rssCached.statusCode && rssCached.statusCode >= 200 && rssCached.statusCode < 300)
-          ? RSS_CACHE_TTL_MS : RSS_NEGATIVE_CACHE_TTL_MS;
-        if (Date.now() - rssCached.timestamp < ttl) {
-          if (rssCached.statusCode < 200 || rssCached.statusCode >= 300) {
-            recordRelayOutcome('rss', classifyUpstreamOutcome({ status: rssCached.statusCode }));
-          } else {
+      const rssNegativeCached = rssNegativeCache.get(feedUrl);
+      if (rssCached && Date.now() - rssCached.timestamp < RSS_CACHE_TTL_MS) {
+        incrementRelayMetric('rssServed');
+        return sendCompressed(req, res, 200, {
+          'Content-Type': rssCached.contentType || 'application/xml',
+          'Cache-Control': 'public, max-age=300',
+          'CDN-Cache-Control': 'public, max-age=600, stale-while-revalidate=300',
+          'X-Cache': 'HIT',
+        }, rssCached.data);
+      }
+      if (rssNegativeCached) {
+        if (Date.now() - rssNegativeCached.timestamp < RSS_NEGATIVE_CACHE_TTL_MS) {
+          recordRelayOutcome('rss', classifyUpstreamOutcome({ status: rssNegativeCached.statusCode }));
+          if (rssCached) {
+            recordRelayOutcome('rss', 'fallback');
             incrementRelayMetric('rssServed');
+            return sendRssStale(rssCached, 'NEGATIVE-STALE');
           }
-          return sendCompressed(req, res, rssCached.statusCode || 200, {
-            'Content-Type': rssCached.contentType || 'application/xml',
-            'Cache-Control': rssCached.statusCode >= 200 && rssCached.statusCode < 300 ? 'public, max-age=300' : 'no-cache',
-            'CDN-Cache-Control': rssCached.statusCode >= 200 && rssCached.statusCode < 300 ? 'public, max-age=600, stale-while-revalidate=300' : 'no-store',
+          return sendCompressed(req, res, rssNegativeCached.statusCode || 502, {
+            'Content-Type': rssNegativeCached.contentType || 'application/xml',
+            'Cache-Control': 'no-cache',
+            'CDN-Cache-Control': 'no-store',
             'X-Cache': 'HIT',
-          }, rssCached.data);
+          }, rssNegativeCached.data);
         }
+        rssNegativeCache.delete(feedUrl);
       }
 
       // In-flight dedup: if another request for the same feed is already fetching,
@@ -10461,20 +10489,34 @@ const server = http.createServer(async (req, res) => {
       const existing = rssInFlight.get(feedUrl);
       if (existing) {
         try {
-          await existing;
+          const fetchResult = await existing;
           const deduped = rssResponseCache.get(feedUrl);
           if (deduped) {
-            if (deduped.statusCode < 200 || deduped.statusCode >= 300) {
-              recordRelayOutcome('rss', classifyUpstreamOutcome({ status: deduped.statusCode }));
-            } else {
-              incrementRelayMetric('rssServed');
+            const dedupedNegative = rssNegativeCache.get(feedUrl);
+            incrementRelayMetric('rssServed');
+            if (dedupedNegative || fetchResult?.stale) {
+              recordRelayOutcome('rss', dedupedNegative
+                ? classifyUpstreamOutcome({ status: dedupedNegative.statusCode })
+                : fetchResult.outcome);
+              recordRelayOutcome('rss', 'fallback');
+              return sendRssStale(deduped, 'DEDUP-STALE');
             }
-            return sendCompressed(req, res, deduped.statusCode || 200, {
+            return sendCompressed(req, res, 200, {
               'Content-Type': deduped.contentType || 'application/xml',
-              'Cache-Control': deduped.statusCode >= 200 && deduped.statusCode < 300 ? 'public, max-age=300' : 'no-cache',
-              'CDN-Cache-Control': deduped.statusCode >= 200 && deduped.statusCode < 300 ? 'public, max-age=600, stale-while-revalidate=300' : 'no-store',
+              'Cache-Control': 'public, max-age=300',
+              'CDN-Cache-Control': 'public, max-age=600, stale-while-revalidate=300',
               'X-Cache': 'DEDUP',
             }, deduped.data);
+          }
+          const dedupedNegative = rssNegativeCache.get(feedUrl);
+          if (dedupedNegative) {
+            recordRelayOutcome('rss', classifyUpstreamOutcome({ status: dedupedNegative.statusCode }));
+            return sendCompressed(req, res, dedupedNegative.statusCode || 502, {
+              'Content-Type': dedupedNegative.contentType || 'application/xml',
+              'Cache-Control': 'no-cache',
+              'CDN-Cache-Control': 'no-store',
+              'X-Cache': 'DEDUP',
+            }, dedupedNegative.data);
           }
           // In-flight completed but nothing cached — serve 502 instead of cascading
           recordRelayOutcome('rss', 'terminalFailure');
@@ -10498,7 +10540,9 @@ const server = http.createServer(async (req, res) => {
       const recordAttemptOutcome = (status, error) => {
         if (outcomeRecorded) return;
         outcomeRecorded = true;
-        recordRelayOutcome('rss', classifyUpstreamOutcome({ status, error }));
+        const outcome = classifyUpstreamOutcome({ status, error });
+        recordRelayOutcome('rss', outcome);
+        return outcome;
       };
 
       const recordFailure = () => {
@@ -10566,11 +10610,11 @@ const server = http.createServer(async (req, res) => {
 
           if (response.statusCode === 304 && rssCached) {
             responseHandled = true;
-            recordAttemptOutcome(200);
+            const outcome = recordAttemptOutcome(200);
             incrementRelayMetric('rssServed');
             rssCached.timestamp = Date.now();
             rssResetFailure(feedUrl);
-            resolveInFlight();
+            resolveInFlight({ outcome });
             logThrottled('log', `rss-revalidated:${feedUrl}`, '[Relay] RSS 304 revalidated:', feedUrl);
             sendCompressed(req, res, 200, {
               'Content-Type': rssCached.contentType || 'application/xml',
@@ -10593,34 +10637,43 @@ const server = http.createServer(async (req, res) => {
             if (responseHandled || res.headersSent) return;
             responseHandled = true;
             const data = Buffer.concat(chunks);
-            // Cache all responses: 2xx with full TTL, non-2xx with short TTL (negative cache)
-            // FIFO eviction: drop oldest-inserted entry if at capacity
-            if (rssResponseCache.size >= RSS_CACHE_MAX_ENTRIES && !rssResponseCache.has(feedUrl)) {
-              const oldest = rssResponseCache.keys().next().value;
-              if (oldest) rssResponseCache.delete(oldest);
-            }
-            rssResponseCache.set(feedUrl, {
+            const isSuccess = response.statusCode >= 200 && response.statusCode < 300;
+            const cacheEntry = {
               data, contentType: 'application/xml', statusCode: response.statusCode, timestamp: Date.now(),
-              etag: response.headers.etag || null,
-              lastModified: response.headers['last-modified'] || null,
-            });
+            };
+            if (isSuccess) {
+              cacheEntry.etag = response.headers.etag || null;
+              cacheEntry.lastModified = response.headers['last-modified'] || null;
+              setBoundedCacheEntry(rssResponseCache, feedUrl, cacheEntry, RSS_CACHE_MAX_ENTRIES);
+              rssNegativeCache.delete(feedUrl);
+            } else {
+              setBoundedCacheEntry(rssNegativeCache, feedUrl, cacheEntry, RSS_NEGATIVE_CACHE_MAX_ENTRIES);
+            }
             const responseHeaders = {
               'Content-Type': 'application/xml',
-              'Cache-Control': response.statusCode >= 200 && response.statusCode < 300 ? 'public, max-age=300' : 'no-cache',
-              'CDN-Cache-Control': response.statusCode >= 200 && response.statusCode < 300 ? 'public, max-age=600, stale-while-revalidate=300' : 'no-store',
+              'Cache-Control': isSuccess ? 'public, max-age=300' : 'no-cache',
+              'CDN-Cache-Control': isSuccess ? 'public, max-age=600, stale-while-revalidate=300' : 'no-store',
               'X-Cache': 'MISS',
             };
-            if (response.statusCode >= 200 && response.statusCode < 300) {
-              recordAttemptOutcome(response.statusCode);
+            let outcome;
+            if (isSuccess) {
+              outcome = recordAttemptOutcome(response.statusCode);
               incrementRelayMetric('rssServed');
               rssResetFailure(feedUrl);
             } else {
-              recordAttemptOutcome(response.statusCode);
+              outcome = recordAttemptOutcome(response.statusCode);
               const { failures, backoffSec } = recordFailure();
               logThrottled('warn', `rss-upstream:${feedUrl}:${response.statusCode}`, `[Relay] RSS upstream ${response.statusCode} for ${feedUrl} (backoff ${backoffSec}s, failures=${failures})`);
               responseHeaders['Retry-After'] = String(backoffSec);
+              if (rssCached) {
+                incrementRelayMetric('rssServed');
+                recordRelayOutcome('rss', 'fallback');
+                resolveInFlight({ stale: true, outcome });
+                sendRssStale(rssCached, 'STALE', { 'Retry-After': String(backoffSec) });
+                return;
+              }
             }
-            resolveInFlight();
+            resolveInFlight({ outcome });
             sendCompressed(req, res, response.statusCode, responseHeaders, data);
           });
           stream.on('error', (err) => {
@@ -10632,18 +10685,18 @@ const server = http.createServer(async (req, res) => {
         });
 
         request.on('error', (err) => {
-          recordAttemptOutcome(0, err);
+          const outcome = recordAttemptOutcome(0, err);
           const { failures, backoffSec } = recordFailure();
           logThrottled('error', `rss-error:${feedUrl}:${err.code || err.message}`, `[Relay] RSS error: ${err.message} (backoff ${backoffSec}s, failures=${failures})`);
           // Serve stale on error (only if we have previous successful data)
-          if (rssCached && rssCached.statusCode >= 200 && rssCached.statusCode < 300) {
+          if (rssCached) {
             if (!responseHandled && !res.headersSent) {
               responseHandled = true;
               incrementRelayMetric('rssServed');
               recordRelayOutcome('rss', 'fallback');
-              sendCompressed(req, res, 200, { 'Content-Type': 'application/xml', 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store', 'X-Cache': 'STALE' }, rssCached.data);
+              sendRssStale(rssCached);
             }
-            resolveInFlight();
+            resolveInFlight({ stale: true, outcome });
             return;
           }
           sendError(502, err.message);
@@ -10651,15 +10704,15 @@ const server = http.createServer(async (req, res) => {
 
         request.on('timeout', () => {
           request.destroy();
-          recordAttemptOutcome(504, new Error('timeout'));
+          const outcome = recordAttemptOutcome(504, new Error('timeout'));
           const { failures, backoffSec } = recordFailure();
           logThrottled('warn', `rss-timeout:${feedUrl}`, `[Relay] RSS timeout for ${feedUrl} (backoff ${backoffSec}s, failures=${failures})`);
-          if (rssCached && rssCached.statusCode >= 200 && rssCached.statusCode < 300 && !responseHandled && !res.headersSent) {
+          if (rssCached && !responseHandled && !res.headersSent) {
             responseHandled = true;
             incrementRelayMetric('rssServed');
             recordRelayOutcome('rss', 'fallback');
-            sendCompressed(req, res, 200, { 'Content-Type': 'application/xml', 'Cache-Control': 'no-store', 'CDN-Cache-Control': 'no-store', 'X-Cache': 'STALE' }, rssCached.data);
-            resolveInFlight();
+            sendRssStale(rssCached);
+            resolveInFlight({ stale: true, outcome });
             return;
           }
           sendError(504, 'Request timeout');
@@ -12442,6 +12495,7 @@ setInterval(() => {
     openskyResponseCache.clear();
     openskyNegativeCache.clear();
     rssResponseCache.clear();
+    rssNegativeCache.clear();
     polymarketCache.clear();
     worldbankCache.clear();
     yahooChartCache.clear();

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -10431,6 +10431,7 @@ const server = http.createServer(async (req, res) => {
         'CDN-Cache-Control': 'no-store',
         'X-Cache': cacheLabel,
         ...extraHeaders,
+        'X-Relay-Stale': '1',
       }, cacheEntry.data);
 
       // Backoff guard: if feed is in exponential backoff, don't hit upstream

--- a/src/services/rss.ts
+++ b/src/services/rss.ts
@@ -1,6 +1,6 @@
 import type { Feed, NewsItem } from '@/types';
 import { SITE_VARIANT } from '@/config';
-import { chunkArray, fetchWithProxy, isMobileDevice } from '@/utils';
+import { chunkArray, fetchWithProxy, hasNoStoreCacheDirective, isMobileDevice } from '@/utils';
 import { classifyByKeyword, classifyWithAI } from './threat-classifier';
 import { inferGeoHubsFromTitle } from './geo-hub-index';
 import { getPersistentCache, setPersistentCache } from './persistent-cache';
@@ -248,6 +248,7 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
 
     const response = await fetchWithProxy(url);
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const noStoreResponse = hasNoStoreCacheDirective(response.headers);
     const text = await response.text();
     const isMobile = isMobileDevice();
     const doc = await parseFeedXml(text, isMobile);
@@ -322,8 +323,10 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
       if (isMobile && index < itemNodes.length - 1) await yieldToMain();
     }
 
-    feedCache.set(feedScope, { items: parsed, timestamp: Date.now() });
-    void setPersistentCache(getPersistentFeedKey(feedScope), toSerializable(parsed));
+    if (!noStoreResponse) {
+      feedCache.set(feedScope, { items: parsed, timestamp: Date.now() });
+      void setPersistentCache(getPersistentFeedKey(feedScope), toSerializable(parsed));
+    }
     recordFeedSuccess(feedScope);
     ingestHeadlines(parsed.map(item => ({
       title: item.title,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -186,7 +186,7 @@ export function shuffle<T>(arr: T[]): T[] {
   return a;
 }
 
-export { proxyUrl, fetchWithProxy, rssProxyUrl } from './proxy';
+export { proxyUrl, fetchWithProxy, hasNoStoreCacheDirective, rssProxyUrl } from './proxy';
 export { buildMapUrl, parseMapUrlState } from './urlState';
 export { withTimeout, TimeoutError } from './with-timeout';
 export type { ParsedMapUrlState } from './urlState';

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -49,6 +49,14 @@ type CachedResponsePayload = {
   body: string;
 };
 
+export function hasNoStoreCacheDirective(headers: HeadersInit): boolean {
+  const cacheControl = new Headers(headers).get('cache-control');
+  return cacheControl?.split(',').some((directive) => {
+    const name = directive.trim().split('=', 1)[0]?.trim().toLowerCase();
+    return name === 'no-store';
+  }) ?? false;
+}
+
 // In production browser deployments, routes are handled by Vercel serverless functions.
 // In local dev, Vite proxy handles these routes.
 // In Tauri desktop mode, route requests need an absolute remote host.
@@ -113,6 +121,7 @@ function isPersistedResponseFresh(
   cached: { updatedAt: number; data: CachedResponsePayload },
   now = Date.now(),
 ): boolean {
+  if (hasNoStoreCacheDirective(cached.data.headers)) return false;
   const ageMs = now - cached.updatedAt;
   return Number.isFinite(ageMs)
     && ageMs >= 0
@@ -121,7 +130,7 @@ function isPersistedResponseFresh(
 
 async function fetchAndPersist(url: string): Promise<Response> {
   const response = await fetch(proxyUrl(url), { cache: 'no-store' });
-  if (response.ok && shouldPersistResponse(url)) {
+  if (response.ok && shouldPersistResponse(url) && !hasNoStoreCacheDirective(response.headers)) {
     try {
       const body = await response.clone().text();
       void setPersistentCache(buildResponseCacheKey(url), toCachedPayload(url, response, body));

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -54,7 +54,7 @@ interface AllowEntry {
 const ALLOW_LIST: AllowEntry[] = [
   {
     file: 'src/services/rss.ts',
-    line: 338,
+    line: 341,
     reason: 'mlWorker.vectorStoreIngest stores pubDate as embedding metadata; not used as a freshness comparator.',
   },
   // effectivePubDateMs implementation moved to shared/news-clustering-core.js

--- a/tests/proxy-persistent-response-cache.test.mts
+++ b/tests/proxy-persistent-response-cache.test.mts
@@ -266,4 +266,21 @@ describe('fetchWithProxy persistent response freshness', () => {
 
     assert.equal(await response.text(), '<rss>current</rss>');
   });
+
+  it('does not reuse or persist responses marked no-store', async () => {
+    const state = globalThis.__wmProxyPersistentResponseCacheTestState!;
+    state.cached = cachedResponse('<rss>stale-cache</rss>', 0, 'no-store');
+    state.networkOutcomes.push(new Response('<rss>live-stale</rss>', {
+      status: 200,
+      headers: {
+        'Cache-Control': 'no-store',
+        'Content-Type': 'application/xml',
+      },
+    }));
+
+    const response = await proxyModule.fetchWithProxy(API_PATH);
+
+    assert.equal(await response.text(), '<rss>live-stale</rss>');
+    assert.equal(state.writes.length, 0, 'no-store responses must not enter the API response cache');
+  });
 });

--- a/tests/rss-mobile-yielding.test.mts
+++ b/tests/rss-mobile-yielding.test.mts
@@ -17,4 +17,12 @@ describe('RSS mobile yielding', () => {
     assert.match(rssSource, /if \(isMobile\) await yieldToMain\(\);/);
     assert.match(rssSource, /if \(isMobile && index < itemNodes\.length - 1\) await yieldToMain\(\);/);
   });
+
+  it('does not persist no-store relay responses in either feed cache', () => {
+    assert.match(rssSource, /hasNoStoreCacheDirective\(response\.headers\)/);
+    assert.match(
+      rssSource,
+      /if \(!noStoreResponse\) \{\s*feedCache\.set\(feedScope[\s\S]*?setPersistentCache\(getPersistentFeedKey\(feedScope\)/s,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

RSS requests could lose the last good feed body when an upstream 403/5xx response overwrote the same cache entry used for stale fallback. Subsequent timeouts or backoff then surfaced errors, pushing served coverage toward the floor.

Positive feed bodies and short-lived negative responses now use separate bounded caches. Failed upstream responses remain visible in auth-rejection, timeout, and terminal-failure metrics while serving the last good body with an explicit `*-STALE` marker and `no-store`; concurrent followers and cleanup during backoff preserve the same behavior. The edge proxy forwards the relay cache state and prevents browser/CDN caching of stale relay responses.

## Validation

- `npm run test:sidecar` — 326 passed.
- `npm run typecheck:api` — passed, including the Convex string-call audit.
- Pre-push gate — passed: frontend/API typecheck, CJS/Unicode/boundary/rate-limit/premium-fetch/Sentry checks, edge bundle/tests, and version sync.
- Focused coverage includes 403, 5xx, timeout, concurrent stale deduplication, cleanup during backoff, negative-cache recovery/caps, and relay stale cache headers.

## Post-Deploy Monitoring & Validation

- Observe two consecutive 10-minute windows after deployment using authenticated relay `/metrics` and `/health`.
- Confirm `ingestion.rss.coverage.servedCoverage` remains at or above `0.70`; fallback counts increase during upstream failures; auth-rejection, timeout, terminal-failure, and backoff counters remain visible; stale responses carry `X-Cache: *-STALE` and `no-store`.
- Treat served coverage below `0.70`, stale responses becoming shared-cacheable, or unexpected terminal 503s as rollback/escalation signals.
- CI and local tests do not prove Railway production acceptance; deployment health and the two observation windows remain pending.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-GPT-5-000000)
