### PR TITLE
chore(trade): remove the v1 trade-flow cutover bridge (#6315)

### DIFF
--- a/server/worldmonitor/trade/v1/get-trade-flows.ts
+++ b/server/worldmonitor/trade/v1/get-trade-flows.ts
@@ -68,33 +68,6 @@ export function tradeFlowCoverageId(reporter: string, partner: string): string {
   return `${reporter}:${partner}`;
 }
 
-/**
- * The pre-#6309 key, which baked the lookback into the key and was only ever
- * written at 10.
- *
- * This handler ships before the 6-hourly Railway seeder has written a single v2
- * key, and `reporting_country=840` with the default window answers from the v1
- * key today. Without this bridge that call would report a fault for up to one
- * cron interval — the exact failure mode this issue exists to remove — so the
- * old key is read while, and only while, the v2 manifest is absent.
- *
- * That gate is `coverage_unknown`, which is reachable at any time the manifest
- * cannot be read, not only before the first v2 run: a manifest lost to eviction
- * or to the whole fleet expiring after a prolonged seeder outage lands here too.
- * The bridge stops mattering in practice once the seeder has published (the
- * manifest is republished every run alongside the data keys), but it does not
- * become unreachable — and the v1 keys it reads carry an 8h TTL that nothing
- * refreshes any more, so it degrades to a no-op rather than to stale data.
- *
- * Remove once the first v2 run has landed — tracked in #6315, which carries the
- * production precondition to verify first.
- */
-export const LEGACY_SEEDED_YEARS = 10;
-
-export function legacyTradeFlowSeedKey(reporter: string, partner: string): string {
-  return `trade:flows:v1:${reporter}:${partner}:${LEGACY_SEEDED_YEARS}`;
-}
-
 export interface NormalizedTradeFlowRequest {
   reporter: string;
   partner: string;
@@ -224,16 +197,7 @@ export async function getTradeFlows(
 
   const seeded = read.status === 'hit' ? (read.value as GetTradeFlowsResponse | null) : null;
   const flows = Array.isArray(seeded?.flows) ? sliceFlowsToWindow(seeded.flows, years) : [];
-  if (flows.length === 0) {
-    const miss = await classifyMiss(reporter, partner);
-    if (miss.unavailableReason !== REASON.coverageUnknown) return miss;
-    const legacy = await readLegacySeed(reporter, partner, years);
-    // A failed read of the bridge key is a cache fault, not "we don't know what
-    // is covered" — collapsing the two would report a Redis outage under the
-    // wrong reason.
-    if (legacy === 'error') return unavailable(REASON.cacheUnavailable, true);
-    return legacy ?? miss;
-  }
+  if (flows.length === 0) return classifyMiss(reporter, partner);
 
   return served(flows, seeded?.fetchedAt);
 }
@@ -252,29 +216,4 @@ function served(flows: TradeFlowRecord[], fetchedAt: unknown): GetTradeFlowsResp
     coverageStartYear: first?.year ?? 0,
     coverageEndYear: last?.year ?? 0,
   };
-}
-
-/**
- * See legacyTradeFlowSeedKey. Returns the served response, `'error'` when the
- * read itself failed, or null when the old key simply has no answer.
- */
-async function readLegacySeed(
-  reporter: string,
-  partner: string,
-  years: number,
-): Promise<GetTradeFlowsResponse | 'error' | null> {
-  const key = legacyTradeFlowSeedKey(reporter, partner);
-  const read = await readCachedJson(key, true);
-  if (read.status === 'error') {
-    logReadFailure(key, read.error);
-    return 'error';
-  }
-  if (read.status !== 'hit') return null;
-  const legacy = read.value as GetTradeFlowsResponse | null;
-  if (!Array.isArray(legacy?.flows)) return null;
-  // The old key only ever held 10 years, so a wider request is answered with
-  // what exists. coverage_start_year/coverage_end_year report the real span, so
-  // the narrower window is stated rather than implied.
-  const flows = sliceFlowsToWindow(legacy.flows, years);
-  return flows.length === 0 ? null : served(flows, legacy.fetchedAt);
 }

--- a/tests/trade-flows-coverage.test.mts
+++ b/tests/trade-flows-coverage.test.mts
@@ -24,7 +24,6 @@ import {
   MAX_YEARS,
   WORLD_PARTNER_CODE,
   getTradeFlows,
-  legacyTradeFlowSeedKey,
   normalizeTradeFlowRequest,
   sliceFlowsToWindow,
   tradeFlowSeedKey,
@@ -346,25 +345,16 @@ describe('a miss is attributed to a cause, not blamed on upstream', () => {
     }
   });
 
-  test('a failed read of the bridge key is a cache fault, not unknown coverage', async () => {
-    // No manifest routes into the legacy bridge; the bridge's own read then
-    // fails. That is a Redis fault and must be named as one.
-    redisErrors.add(legacyTradeFlowSeedKey('840', '000'));
+  test('a miss reads only the pair key and the manifest', async () => {
+    // The #6309 cutover bridge (removed in #6315) used to add a third read of
+    // the old `trade:flows:v1:…` key on this path. Pin that no legacy key is
+    // consulted, so the bridge cannot be reintroduced unnoticed.
     const res = await getTradeFlows(CTX, request());
 
-    assert.equal(res.unavailableReason, R.cacheUnavailable);
-    assert.equal(res.upstreamUnavailable, true);
-  });
-
-  test('the manifest verdict wins over the legacy bridge once the seeder has run', async () => {
-    // A published manifest means the cutover happened, so a miss is a real
-    // verdict and must not be papered over by whatever v1 key still lingers.
-    seedManifest([tradeFlowCoverageId('840', '000')]);
-    redisStore.set(legacyTradeFlowSeedKey('840', '000'), seededPayload(2015, 2025));
-    const res = await getTradeFlows(CTX, request());
-
-    assert.equal(res.unavailableReason, R.seedMissing);
-    assert.ok(!redisReads.includes(legacyTradeFlowSeedKey('840', '000')));
+    assert.equal(res.unavailableReason, R.coverageUnknown);
+    assert.deepEqual(redisReads, [tradeFlowSeedKey('840', '000'), COVERAGE_KEY]);
+    assert.ok(!redisReads.some((k) => k.startsWith('trade:flows:v1:')),
+      'the v1 fleet is gone; nothing may read it');
   });
 
   test('a seeded key holding no rows still gets attributed', async () => {
@@ -376,36 +366,6 @@ describe('a miss is attributed to a cause, not blamed on upstream', () => {
   });
 });
 
-// ── Cutover bridge ────────────────────────────────────────────────────────
-
-describe('the v1 seed still answers until the first v2 run publishes', () => {
-  test('a request that works today keeps working across the deploy window', async () => {
-    // No v2 key and no manifest — the state between this deploy and the next
-    // 6-hourly seeder tick. `reporting_country=840` answers from v1 today, so
-    // reporting a fault here would be a regression introduced by the fix.
-    redisStore.set(legacyTradeFlowSeedKey('840', '000'), seededPayload(2016, 2025));
-    const res = await getTradeFlows(CTX, request());
-
-    assert.equal(res.unavailableReason, R.served);
-    assert.equal(res.upstreamUnavailable, false);
-    assert.equal(res.flows.length, 10);
-    assert.equal(res.coverageEndYear, 2025);
-  });
-
-  test('a window wider than the old key states the narrower span it actually has', async () => {
-    redisStore.set(legacyTradeFlowSeedKey('840', '000'), seededPayload(2016, 2025));
-    const res = await getTradeFlows(CTX, request({ years: 30 }));
-
-    assert.equal(res.flows.length, 10);
-    assert.equal(res.coverageStartYear, 2016,
-      'the response must report the span it has rather than imply the requested one');
-  });
-
-  test('an absent legacy key leaves the original verdict intact', async () => {
-    const res = await getTradeFlows(CTX, request());
-    assert.equal(res.unavailableReason, R.coverageUnknown);
-  });
-});
 
 // ── Request validation ────────────────────────────────────────────────────
 

--- a/tests/trade-flows-coverage.test.mts
+++ b/tests/trade-flows-coverage.test.mts
@@ -159,6 +159,24 @@ function seedManifest(pairs: string[]): void {
   redisStore.set(COVERAGE_KEY, { pairs, startYear: 1996, endYear: 2026, fetchedAt: '2026-08-07T00:00:00.000Z' });
 }
 
+/**
+ * Every miss reads exactly the pair key then the manifest — nothing else.
+ *
+ * Applied to EACH miss verdict, not just one. The #6309 cutover bridge sat on
+ * the `coverage_unknown` arm, so pinning only that arm would let the same
+ * fallback be reintroduced on `seed_missing` ("the pair is covered but its key
+ * is gone — try the old key before declaring a fault") with the suite green.
+ * Verified: that exact reintroduction passed 60/60 before this helper existed.
+ *
+ * The two reads are sequential awaits (handler, then classifyMiss), so the
+ * order is deterministic and this cannot flake. If they are ever parallelised
+ * this reddens — which is the right moment to look.
+ */
+function assertTwoReads(reporter: string, partner: string): void {
+  assert.deepEqual(redisReads, [tradeFlowSeedKey(reporter, partner), COVERAGE_KEY],
+    'a miss must read the pair key and the manifest, and nothing else');
+}
+
 // ── Contract pins: the two sides must agree without importing each other ───
 
 describe('seeder and handler agree on the cache contract', () => {
@@ -295,6 +313,7 @@ describe('a miss is attributed to a cause, not blamed on upstream', () => {
     assert.equal(res.fetchedAt, '', 'nothing was fetched, so there is no fetch time to report');
     assert.equal(res.coverageStartYear, 0);
     assert.equal(res.coverageEndYear, 0);
+    assertTwoReads('840', '156');
   });
 
   test('a covered pair whose key is gone is a fault', async () => {
@@ -303,6 +322,7 @@ describe('a miss is attributed to a cause, not blamed on upstream', () => {
 
     assert.equal(res.unavailableReason, R.seedMissing);
     assert.equal(res.upstreamUnavailable, true);
+    assertTwoReads('156', '000');
   });
 
   test('a failed read of the pair key is never reported as missing coverage', async () => {
@@ -352,9 +372,7 @@ describe('a miss is attributed to a cause, not blamed on upstream', () => {
     const res = await getTradeFlows(CTX, request());
 
     assert.equal(res.unavailableReason, R.coverageUnknown);
-    assert.deepEqual(redisReads, [tradeFlowSeedKey('840', '000'), COVERAGE_KEY]);
-    assert.ok(!redisReads.some((k) => k.startsWith('trade:flows:v1:')),
-      'the v1 fleet is gone; nothing may read it');
+    assertTwoReads('840', '000');
   });
 
   test('a seeded key holding no rows still gets attributed', async () => {
@@ -365,7 +383,6 @@ describe('a miss is attributed to a cause, not blamed on upstream', () => {
     assert.equal(res.unavailableReason, R.seedMissing);
   });
 });
-
 
 // ── Request validation ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

#6309 moved the WTO trade-flow seed to `trade:flows:v2:{reporter}:{partner}` and carried a transitional read of the old `trade:flows:v1:…:10` key, so calls that worked pre-cutover kept working until the 6-hourly Railway seeder first published. That window has closed.

## Precondition, verified against production immediately before this change

The issue required this be checked first, not assumed:

```
trade:flows:v2:*   259 pair keys, trade:flows:v2:index present
trade:flows:v1:*   0   (aged out on its 8h TTL; nothing writes it any more)
/api/health        tradeFlows OK — records 259, seedAgeMin 214,
                   maxStaleMin 420, minRecordCount 200
```

The bridge is therefore already a no-op: every read it could make returns a miss.

The live endpoint was also exercised across the contract before removing it — `years=1/10/30` all serve real rows, a non-World partner returns `NOT_COVERED`, and malformed input returns HTTP 400.

## What changed

Removes `LEGACY_SEEDED_YEARS`, `legacyTradeFlowSeedKey`, `readLegacySeed`, and the `coverage_unknown` branch that called it. A miss now returns `classifyMiss`'s verdict directly.

**Every member of the closed reason vocabulary stays reachable.** The removed function was one of two `cache_unavailable` sources, so that was the thing worth checking:

| Reason | Still reached from |
|---|---|
| `cache_unavailable` | the pair-key read, and `classifyMiss`'s manifest read |
| `coverage_unknown` | `classifyMiss` when the manifest is absent or malformed |
| `seed_missing` / `not_covered` | the manifest membership check |
| `invalid_request` | request normalization |
| `UNSPECIFIED` | the served path |

## Tests

The three bridge tests are replaced by one guard that pins the miss path to exactly `[pair key, coverage key]` and asserts no `trade:flows:v1:` key is touched — so the bridge cannot be reintroduced unnoticed.

Mutation-verified: re-adding the bridge (including its Redis read) reddens that guard.

68 trade-flow + health tests pass. `typecheck`, `typecheck:api`, and `biome` clean.

## Note on the push gate

The first push attempt was blocked because `core.hooksPath` was set to an **absolute** path into the main checkout, so every worktree's pre-push ran the main checkout's hook rather than its own branch's. Fixed locally with `git config core.hooksPath .husky` (relative) rather than bypassing via `WM_ALLOW_FOREIGN_HOOKS=1` — bypassing would have run the wrong gate. This is a local git-config change only; nothing in the repo changed.

## Related

- Closes #6315
- #6309 (added the bridge), #6316, #6323

https://claude.ai/code/session_01HtWFnQiBWN1SWtjp4AhT4C
