### PR TITLE
fix(sentry): name world-brief rejection gates, drop mutated-CSP noise

### DIFF
--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -15,7 +15,7 @@ import { evaluateFreshness } from '../freshness';
 import { McpSourceUnavailableError } from '../source-unavailable';
 import {
   collectInsightSources,
-  isAcceptedInsightsSnapshot,
+  insightsSnapshotRejection,
   normalizeInsightSource,
 } from '../../../shared/insights-snapshot.js';
 import type { FreshnessCheck, ToolDef } from '../types';
@@ -95,8 +95,18 @@ type SeededWorldBriefPayload = {
   topStories?: unknown;
 };
 
-function projectSeededWorldBrief(raw: unknown): Record<string, unknown> | null {
-  if (!isAcceptedInsightsSnapshot(raw) || !isRecord(raw)) return null;
+// Rejections carry a bounded reason so the "Seeded world brief unavailable"
+// alarm names WHICH gate fired (WORLDMONITOR-YJ) — a stale producer and a
+// schema regression need opposite responses. Bounded values only: the reason
+// lands in Sentry/log messages, never in the client-facing RPC error.
+type SeededWorldBriefProjection =
+  | { value: Record<string, unknown> }
+  | { reason: string };
+
+function projectSeededWorldBrief(raw: unknown): SeededWorldBriefProjection {
+  const snapshotRejection = insightsSnapshotRejection(raw);
+  if (snapshotRejection !== null) return { reason: snapshotRejection };
+  if (!isRecord(raw)) return { reason: 'malformed-snapshot' };
   const payload = raw as SeededWorldBriefPayload;
   const brief = typeof payload.worldBrief === 'string' ? payload.worldBrief.trim() : '';
   const generatedAt = typeof payload.generatedAt === 'string' ? payload.generatedAt : '';
@@ -106,7 +116,8 @@ function projectSeededWorldBrief(raw: unknown): Record<string, unknown> | null {
   // output requirements. Never substitute an on-demand LLM result when the
   // seeded producer has degraded: an empty or stale snapshot is safer than
   // returning an ungated brief.
-  if (!brief || payload.status !== 'ok') return null;
+  if (!brief) return { reason: 'empty-brief' };
+  if (payload.status !== 'ok') return { reason: 'status-not-ok' };
 
   const headlines: string[] = [];
   for (const story of topStories) {
@@ -116,23 +127,25 @@ function projectSeededWorldBrief(raw: unknown): Record<string, unknown> | null {
     headlines.push(headline);
     if (headlines.length >= 12) break;
   }
-  if (headlines.length === 0) return null;
+  if (headlines.length === 0) return { reason: 'no-headlines' };
 
   // The producer's sources share the brief's citation index space. Preserve
   // every record in order, including an empty URL fallback, so a malformed
   // source cannot make later [n] citations point at the wrong article.
   const sourceItems = Array.isArray(payload.worldBriefSources) ? payload.worldBriefSources : null;
-  if (!sourceItems || sourceItems.length === 0 || sourceItems.length > 12) return null;
+  if (!sourceItems || sourceItems.length === 0 || sourceItems.length > 12) return { reason: 'missing-sources' };
   const sources = sourceItems.map((item, index) => normalizeInsightSource(item, {
     fallback: topStories[index],
     urlOrder: 'url-first',
     allowEmptyUrl: true,
   }));
-  if (sources.some((source) => source === null) || !sources.some((source) => source?.url)) return null;
+  if (sources.some((source) => source === null) || !sources.some((source) => source?.url)) {
+    return { reason: 'malformed-sources' };
+  }
   const provider = typeof payload.briefProvider === 'string' ? payload.briefProvider : '';
   const model = typeof payload.briefModel === 'string' ? payload.briefModel : '';
 
-  return {
+  return { value: {
     brief,
     summary: brief,
     headlines,
@@ -140,7 +153,7 @@ function projectSeededWorldBrief(raw: unknown): Record<string, unknown> | null {
     model,
     generatedAt,
     sources: sources as McpBriefSource[],
-  };
+  } };
 }
 
 function countryBriefSearchTerms(countryCode: string): string[] {
@@ -559,14 +572,14 @@ export const RPC_TOOLS: ToolDef[] = [
         }
       }
       const result = projectSeededWorldBrief(insights);
-      if (!result) {
+      if ('reason' in result) {
         throw new McpSourceUnavailableError(
-          'Seeded world brief unavailable',
+          `Seeded world brief unavailable (${result.reason})`,
           ['news:insights:v1'],
           [],
         );
       }
-      return result;
+      return result.value;
     },
     _apiPaths: ['GET /api/infrastructure/v1/get-bootstrap-data'],
   },

--- a/shared/insights-snapshot.d.ts
+++ b/shared/insights-snapshot.d.ts
@@ -26,4 +26,15 @@ export function collectInsightSources(
   options?: InsightSourceOptions,
 ): InsightSource[];
 
+export type InsightsSnapshotRejection =
+  | 'malformed-snapshot'
+  | 'missing-generated-at'
+  | 'future-generated-at'
+  | 'stale-snapshot';
+
+export function insightsSnapshotRejection(
+  raw: unknown,
+  nowMs?: number,
+): InsightsSnapshotRejection | null;
+
 export function isAcceptedInsightsSnapshot(raw: unknown, nowMs?: number): boolean;

--- a/shared/insights-snapshot.js
+++ b/shared/insights-snapshot.js
@@ -69,11 +69,22 @@ export function collectInsightSources(candidates, maxSources = 6, options = {}) 
   return out;
 }
 
-export function isAcceptedInsightsSnapshot(raw, nowMs = Date.now()) {
-  if (!isRecord(raw) || !Array.isArray(raw.topStories) || raw.topStories.length === 0) return false;
-  if (typeof raw.generatedAt !== 'string') return false;
+/**
+ * Names WHICH acceptance gate rejects a snapshot (null = accepted). A stale
+ * producer and a schema regression need opposite responses, so alarms built
+ * on the boolean alone were undiagnosable (WORLDMONITOR-YJ). Reasons are a
+ * bounded enum — safe for Sentry messages and log grouping.
+ */
+export function insightsSnapshotRejection(raw, nowMs = Date.now()) {
+  if (!isRecord(raw) || !Array.isArray(raw.topStories) || raw.topStories.length === 0) return 'malformed-snapshot';
+  if (typeof raw.generatedAt !== 'string') return 'missing-generated-at';
   const generatedMs = Date.parse(raw.generatedAt);
-  return Number.isFinite(generatedMs)
-    && generatedMs <= nowMs
-    && nowMs - generatedMs < INSIGHTS_MAX_AGE_MS;
+  if (!Number.isFinite(generatedMs)) return 'missing-generated-at';
+  if (generatedMs > nowMs) return 'future-generated-at';
+  if (nowMs - generatedMs >= INSIGHTS_MAX_AGE_MS) return 'stale-snapshot';
+  return null;
+}
+
+export function isAcceptedInsightsSnapshot(raw, nowMs = Date.now()) {
+  return insightsSnapshotRejection(raw, nowMs) === null;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -179,6 +179,13 @@ function shouldSuppressCspViolation(
       const url = new URL(blockedURI);
       if (url.protocol === 'https:'
           && (url.hostname === 'worldmonitor.app' || url.hostname.endsWith('.worldmonitor.app'))) return true;
+      // Clerk avatar CDN (`img.clerk.com`) — the only cross-origin image host
+      // our UI loads (Clerk UserButton avatar). Explicitly allowed by our
+      // `img-src https:`, so a block here is the same mutated-policy class as
+      // the first-party rule above (WORLDMONITOR-JP round 2 — Firefox privacy
+      // extensions stripping `https:`). Exact hostname + https: only, so blocks
+      // on any other clerk.com host or a lookalike suffix still surface.
+      if (url.protocol === 'https:' && url.hostname === 'img.clerk.com') return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube IFrame API loader: explicitly allowed by our script-src

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -454,6 +454,33 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(suppress('enforce', 'img-src', 'https://tech.worldmonitor.app/favico/tech/favicon-32x32.png', '', false, FIRST_PARTY_CONVEX));
     });
 
+    // Clerk avatar CDN — the only cross-origin image host our UI loads (the
+    // Clerk UserButton avatar). Our img-src allows every https: host, so an
+    // enforced block on img.clerk.com is the same mutated-policy class as the
+    // first-party rules above (WORLDMONITOR-JP round 2, Firefox privacy
+    // extensions stripping `https:` from img-src).
+    it('suppresses img-src to img.clerk.com (Clerk avatar, WORLDMONITOR-JP)', () => {
+      assert.ok(suppress('enforce', 'img-src', 'https://img.clerk.com/eyJ0eXBlIjoicHJveHkifQ?width=200', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress http:// img-src to img.clerk.com (wrong-scheme block must surface)', () => {
+      assert.ok(!suppress('enforce', 'img-src', 'http://img.clerk.com/eyJ0eXBlIjoicHJveHkifQ', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress img-src to suffix-spoof `img.clerk.com.evil.com`', () => {
+      assert.ok(!suppress('enforce', 'img-src', 'https://img.clerk.com.evil.com/pixel.gif', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress img-src to other clerk.com hosts (rule is exact-host)', () => {
+      // Only the avatar CDN is expected; a block on any other clerk.com host
+      // is not a known injection pattern and must surface.
+      assert.ok(!suppress('enforce', 'img-src', 'https://clerk.com/logo.png', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress connect-src to img.clerk.com (rule is scoped to img-src)', () => {
+      assert.ok(!suppress('enforce', 'connect-src', 'https://img.clerk.com/avatar', '', false, FIRST_PARTY_CONVEX));
+    });
+
     it('does NOT suppress img-src to a foreign host', () => {
       // Real third-party CDN image blocks should still surface.
       assert.ok(!suppress('enforce', 'img-src', 'https://malicious.example.com/tracker.gif', '', false, FIRST_PARTY_CONVEX));

--- a/tests/insights-snapshot.test.mjs
+++ b/tests/insights-snapshot.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   INSIGHTS_MAX_AGE_MS,
   collectInsightSources,
+  insightsSnapshotRejection,
   isAcceptedInsightsSnapshot,
   normalizeInsightSource,
 } from '../shared/insights-snapshot.js';
@@ -41,6 +42,72 @@ describe('insights snapshot helpers', () => {
     assert.equal(isAcceptedInsightsSnapshot(snapshot({ generatedAt: 'not-a-timestamp' }), NOW_MS), false);
     assert.equal(isAcceptedInsightsSnapshot(snapshot({ topStories: [] }), NOW_MS), false);
     assert.equal(isAcceptedInsightsSnapshot(null, NOW_MS), false);
+  });
+
+  // WORLDMONITOR-YJ: the "Seeded world brief unavailable" alarm could not say
+  // WHICH acceptance gate rejected the snapshot (stale producer vs schema bug
+  // need opposite responses). `insightsSnapshotRejection` names the gate; the
+  // boolean acceptance MUST stay derivable from it so the two can never drift.
+  describe('insightsSnapshotRejection', () => {
+    it('returns null for an accepted snapshot', () => {
+      assert.equal(insightsSnapshotRejection(snapshot(), NOW_MS), null);
+    });
+
+    it('names malformed shapes (non-record, missing/empty topStories)', () => {
+      assert.equal(insightsSnapshotRejection(null, NOW_MS), 'malformed-snapshot');
+      assert.equal(insightsSnapshotRejection([], NOW_MS), 'malformed-snapshot');
+      assert.equal(insightsSnapshotRejection(snapshot({ topStories: [] }), NOW_MS), 'malformed-snapshot');
+      assert.equal(insightsSnapshotRejection(snapshot({ topStories: undefined }), NOW_MS), 'malformed-snapshot');
+    });
+
+    it('names a missing or unparseable generatedAt', () => {
+      assert.equal(insightsSnapshotRejection(snapshot({ generatedAt: undefined }), NOW_MS), 'missing-generated-at');
+      assert.equal(insightsSnapshotRejection(snapshot({ generatedAt: 'not-a-timestamp' }), NOW_MS), 'missing-generated-at');
+    });
+
+    it('names a future generatedAt', () => {
+      assert.equal(
+        insightsSnapshotRejection(snapshot({ generatedAt: new Date(NOW_MS + 1).toISOString() }), NOW_MS),
+        'future-generated-at',
+      );
+    });
+
+    it('names a stale snapshot at exactly the max-age boundary', () => {
+      assert.equal(
+        insightsSnapshotRejection(
+          snapshot({ generatedAt: new Date(NOW_MS - INSIGHTS_MAX_AGE_MS).toISOString() }),
+          NOW_MS,
+        ),
+        'stale-snapshot',
+      );
+      assert.equal(
+        insightsSnapshotRejection(
+          snapshot({ generatedAt: new Date(NOW_MS - INSIGHTS_MAX_AGE_MS + 1).toISOString() }),
+          NOW_MS,
+        ),
+        null,
+      );
+    });
+
+    it('stays consistent with isAcceptedInsightsSnapshot across every case', () => {
+      const cases = [
+        snapshot(),
+        null,
+        [],
+        snapshot({ topStories: [] }),
+        snapshot({ generatedAt: undefined }),
+        snapshot({ generatedAt: 'not-a-timestamp' }),
+        snapshot({ generatedAt: new Date(NOW_MS + 1).toISOString() }),
+        snapshot({ generatedAt: new Date(NOW_MS - INSIGHTS_MAX_AGE_MS).toISOString() }),
+      ];
+      for (const raw of cases) {
+        assert.equal(
+          isAcceptedInsightsSnapshot(raw, NOW_MS),
+          insightsSnapshotRejection(raw, NOW_MS) === null,
+          `acceptance and rejection drifted for ${JSON.stringify(raw)}`,
+        );
+      }
+    });
   });
 
   it('preserves citation indexes when an indexed source has no URL', () => {

--- a/tests/mcp-world-brief-routing.test.mjs
+++ b/tests/mcp-world-brief-routing.test.mjs
@@ -269,6 +269,72 @@ describe('get_world_brief seeded brief routing', () => {
     }
   });
 
+  // WORLDMONITOR-YJ: hourly scheduled agents hit "Seeded world brief
+  // unavailable" but the alarm could not say WHICH acceptance gate rejected
+  // the snapshot — a stale producer (>60min degraded seeder window) and a
+  // schema bug need opposite responses. The thrown message must name the
+  // bounded rejection reason; the client-facing RPC error stays generic.
+  it('names the rejection reason when the seeded snapshot is rejected', async () => {
+    const scenarios = [
+      {
+        name: 'stale snapshot',
+        overrides: { generatedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString() },
+        reason: 'stale-snapshot',
+      },
+      {
+        name: 'producer degraded status',
+        overrides: { status: 'degraded' },
+        reason: 'status-not-ok',
+      },
+      {
+        name: 'no headlines',
+        overrides: { topStories: [{ notATitle: true }] },
+        reason: 'no-headlines',
+      },
+    ];
+
+    const deps = makeDeps();
+    let id = 700;
+    for (const scenario of scenarios) {
+      const warned = [];
+      console.warn = (...args) => warned.push(args);
+      globalThis.fetch = async (input) => {
+        const { pathname } = new URL(String(input));
+        if (pathname === '/api/infrastructure/v1/get-bootstrap-data') {
+          return insightsResponse(scenario.overrides);
+        }
+        throw new Error(`Unexpected downstream URL: ${input}`);
+      };
+
+      const response = await mcpHandler(
+        requestFor('https://api.worldmonitor.app/api/mcp', AUTH_CASES[0].headers, id++),
+        deps,
+      );
+      assert.equal(response.status, 200, `${scenario.name}: transport status`);
+      const rpc = await response.json();
+      assert.equal(rpc.error?.code, -32003, `${scenario.name}: source-unavailable RPC code`);
+      assert.deepEqual(
+        rpc.error.data.unavailable_inputs,
+        ['news:insights:v1'],
+        `${scenario.name}: unavailable inputs`,
+      );
+      // The reason is operator-facing only — it must NOT leak into the
+      // client-facing RPC message, which stays a stable generic string.
+      assert.equal(rpc.error.message, 'Required data inputs are unavailable');
+
+      const outageWarning = warned.find((args) => (
+        args.some((arg) => arg instanceof Error && /Seeded world brief unavailable/.test(arg.message))
+      ));
+      assert.ok(outageWarning, `${scenario.name}: expected a tool-execution warning`);
+      const outageError = outageWarning.find((arg) => arg instanceof Error);
+      assert.equal(
+        outageError.message,
+        `Seeded world brief unavailable (${scenario.reason})`,
+        `${scenario.name}: reason named in the operator-facing message`,
+      );
+    }
+  });
+
   it('classifies reproduced 401/405 responses without logging response bodies', async () => {
     const scenarios = [
       {


### PR DESCRIPTION
## Summary

Sentry triage output — two observability fixes from the 2026-08-08 unresolved-issue sweep.

**World-brief alarm now names its gate (WORLDMONITOR-YJ).** When the MCP `get_world_brief` tool rejects the seeded snapshot, the operator-facing error was a bare "Seeded world brief unavailable" with five silent null gates behind it — a stale producer and a schema regression looked identical, though they need opposite responses. The thrown message now carries a bounded reason (`stale-snapshot`, `malformed-snapshot`, `missing-generated-at`, `future-generated-at`, `empty-brief`, `status-not-ok`, `no-headlines`, `missing-sources`, `malformed-sources`). The shared acceptance check `isAcceptedInsightsSnapshot()` is now derived from the reason-naming `insightsSnapshotRejection()`, so the boolean and the reason can never drift. Two invariants hold by construction and are pinned by tests: the client-facing RPC error stays the generic `Required data inputs are unavailable` (the reason is operator-only), and Sentry grouping is unchanged because the MCP fingerprint keys on the error name, not the message.

The production events behind this (hourly scheduled MCP callers landing in >60-minute stale-LKG windows) trace to the seed-insights synthesis-rejection loop; post-deploy, recurrences will self-label `stale-snapshot`, confirming that diagnosis in production.

**Clerk avatar CSP noise suppressed (WORLDMONITOR-JP).** Our dashboard `img-src` allows every `https:` host, so an enforced block on `img.clerk.com` (the Clerk UserButton avatar CDN) can only come from a proxy or privacy extension that stripped `https:` from the user's effective policy — the same mutated-policy class as the existing first-party img-src rule. The suppression is exact-hostname and `https:`-only: blocks on other `clerk.com` hosts, lookalike suffixes (`img.clerk.com.evil.com`), wrong schemes, and other directives still surface.

Related: #5947

## Validation

Both changes were built failing-test-first. The new end-to-end case drives the real `mcpHandler` through three rejection scenarios and asserts the operator message carries the exact reason while the RPC message stays generic; a parity case locks `isAcceptedInsightsSnapshot(raw) === (insightsSnapshotRejection(raw) === null)` across every rejection shape, including the exact 60-minute boundary. Full sweep scoped by changed module: csp-filter (103), insights-snapshot (10), mcp-world-brief-routing (5), insights-loader/brief-sources/error-fingerprint batch (86), and the MCP contract/parity suites (186) — all green; `tsc --noEmit` and `typecheck:api` clean.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_01M9JaHo9hL1ezzobHEQQwck
