### PR TITLE
fix(payments): send lifecycle emails to the account login email, not the checkout alias (#6330)

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -278,6 +278,14 @@ The single client-derived state that decides what a customer sees when premium a
 
 The bootstrap-time process that turns an inbound URL param into checkout attribution: `?ref=` or `?wm_referral=` on any dashboard landing is read once at app boot, stripped from the URL, persisted locally with a bounded TTL, and forwarded to the payment provider at checkout to credit the referring sharer. Because the param names are generic-looking, any other use of `ref=` on dashboard-bound links (SEO tags, campaign labels) is silently captured as a fake affiliate code — internal source attribution must use `utm_*` params, which this process ignores. See also: Entitlement.
 
+### Signed Checkout Identity
+
+The account identifier the checkout flow stamps into the payment provider's subscription and payment metadata, alongside a server-issued signature. It is the authoritative answer to "which account bought this" — independent of every email address on the payment record, because it captures who was *signed in* at the moment of purchase rather than what the buyer typed. Consumers trust it only when the signature verifies; an unsigned or tampered value falls back to matching on the provider's stored customer record. Support triage of any "paid but no access" report starts here, never from an email comparison. See also: Entitlement, Checkout Email.
+
+### Checkout Email
+
+The address a buyer types into the payment provider's checkout form. It is unauthenticated, need not match any account, and is best read as "an inbox the buyer can see," never as an identity: the same person can present one address at checkout, another as their sign-in, and a third in support threads. Any message addressed to it can therefore land in an inbox whose address owns no account — and a message that invites sign-in steers the buyer toward an address the auth provider has never seen. "Who bought" is resolved by the Signed Checkout Identity; the checkout email resolves only "where the invoice went." See also: Signed Checkout Identity, Entitlement.
+
 ## Activation & Onboarding
 
 ### Brief Loop

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -405,6 +405,265 @@ describe("webhook processWebhookEvent", () => {
     expect(welcome?.html).not.toContain("Full API Access");
   });
 
+  // #6330: lifecycle emails must target (and name) the account's login email.
+  // The checkout email is unauthenticated and may be a different alias — a
+  // welcome sent there steers the buyer into "account not known" at sign-in.
+  test("welcome email targets the account login email when checkout email differs", async () => {
+    vi.useFakeTimers();
+    process.env.RESEND_API_KEY = "re_test";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "login@example.com",
+        normalizedEmail: "login@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_login_email_divergence",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+        html: string;
+      });
+
+    // Welcome goes to the address that can actually sign in, and names it.
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["login@example.com"]);
+    expect(welcome?.html).toContain("login@example.com");
+
+    // The checkout inbox gets a sign-in pointer instead of silence — that is
+    // the inbox the buyer demonstrably watches (they typed it at checkout).
+    const pointer = sends.find((send) => send.to[0] === "checkout@example.com");
+    expect(pointer).toBeDefined();
+    expect(pointer?.html).toContain("login@example.com");
+    expect(pointer?.subject).toContain("sign in");
+
+    // Admin notification names both identities so ops can find the customer
+    // from either address.
+    const admin = sends.find((send) => send.subject.startsWith("[WM] New User Subscribed"));
+    expect(admin?.html).toContain("login@example.com");
+    expect(admin?.html).toContain("checkout@example.com");
+  });
+
+  test("welcome email flow is unchanged when login and checkout emails match", async () => {
+    vi.useFakeTimers();
+    process.env.RESEND_API_KEY = "re_test";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "test@example.com",
+        normalizedEmail: "test@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_login_email_match",
+      "subscription.active",
+      makeSubscriptionPayload(),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    // Exactly the historical pair: user welcome + admin notification. No
+    // pointer email, no duplicate sends.
+    expect(sends).toHaveLength(2);
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["test@example.com"]);
+  });
+
+  test("welcome email still sends via login email when checkout email is empty", async () => {
+    vi.useFakeTimers();
+    process.env.RESEND_API_KEY = "re_test";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "login@example.com",
+        normalizedEmail: "login@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_login_email_empty_checkout",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: { customer_id: "cust_test_001", email: "", name: "Test User" },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["login@example.com"]);
+    // No pointer send to an empty address.
+    expect(sends.every((send) => send.to.every((addr) => addr.length > 0))).toBe(true);
+  });
+
+  test("a rejected sign-in pointer send does not swallow the admin notification", async () => {
+    vi.useFakeTimers();
+    process.env.RESEND_API_KEY = "re_test";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (_url, init) => {
+        const body = JSON.parse(String((init as RequestInit).body)) as { to: string[] };
+        // The buyer-typed checkout address is one Resend rejects outright.
+        if (body.to[0] === "checkout@example.com") {
+          return new Response('{"message":"invalid to"}', { status: 422 });
+        }
+        return new Response("{}", { status: 200 });
+      });
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "login@example.com",
+        normalizedEmail: "login@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_pointer_send_rejected",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    // Welcome went out and, despite the pointer rejection, the admin
+    // notification still fired.
+    expect(sends.some((send) => send.subject.startsWith("Welcome to World Monitor"))).toBe(true);
+    expect(sends.some((send) => send.subject.startsWith("[WM] New User Subscribed"))).toBe(true);
+  });
+
+  test("reactivation email targets the account login email when checkout email differs", async () => {
+    vi.useFakeTimers();
+    process.env.RESEND_API_KEY = "re_test";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "login@example.com",
+        normalizedEmail: "login@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId: "test-user-001",
+        dodoSubscriptionId: "sub_test_001",
+        dodoProductId: "pdt_test_pro",
+        planKey: "pro_monthly",
+        status: "expired",
+        currentPeriodStart: BASE_TIMESTAMP - 31 * 86400000,
+        currentPeriodEnd: BASE_TIMESTAMP - 86400000,
+        rawPayload: {},
+        updatedAt: BASE_TIMESTAMP - 86400000,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_reactivation_login_email",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    const welcomeBack = sends.find((send) => send.subject.includes("Welcome back"));
+    expect(welcomeBack?.to).toEqual(["login@example.com"]);
+  });
+
   test.each([
     ["on_hold", BASE_TIMESTAMP + 7 * 86400000],
     ["cancelled", BASE_TIMESTAMP],

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -450,6 +450,9 @@ describe("webhook processWebhookEvent", () => {
         html: string;
       });
 
+    // Exactly three sends: welcome, pointer, admin. Pins against double-sends.
+    expect(sends).toHaveLength(3);
+
     // Welcome goes to the address that can actually sign in, and names it.
     const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
     expect(welcome?.to).toEqual(["login@example.com"]);
@@ -457,9 +460,13 @@ describe("webhook processWebhookEvent", () => {
 
     // The checkout inbox gets a sign-in pointer instead of silence — that is
     // the inbox the buyer demonstrably watches (they typed it at checkout).
+    // The login address is MASKED there: the checkout inbox is unverified
+    // (a typo'd address reaches a stranger), so it gets a recognizable hint,
+    // never the full account address.
     const pointer = sends.find((send) => send.to[0] === "checkout@example.com");
     expect(pointer).toBeDefined();
-    expect(pointer?.html).toContain("login@example.com");
+    expect(pointer?.html).toContain("l•••@example.com");
+    expect(pointer?.html).not.toContain("login@example.com");
     expect(pointer?.subject).toContain("sign in");
 
     // Admin notification names both identities so ops can find the customer
@@ -550,8 +557,9 @@ describe("webhook processWebhookEvent", () => {
 
     const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
     expect(welcome?.to).toEqual(["login@example.com"]);
-    // No pointer send to an empty address.
-    expect(sends.every((send) => send.to.every((addr) => addr.length > 0))).toBe(true);
+    // Welcome + admin only — the empty checkout email must not produce a
+    // pointer send.
+    expect(sends).toHaveLength(2);
   });
 
   test("a rejected sign-in pointer send does not swallow the admin notification", async () => {
@@ -602,8 +610,11 @@ describe("webhook processWebhookEvent", () => {
         subject: string;
       });
 
-    // Welcome went out and, despite the pointer rejection, the admin
-    // notification still fired.
+    // The pointer WAS attempted (guards against the "remove the pointer"
+    // mutant — without this, the test passes vacuously when no pointer is
+    // ever sent), and despite its rejection the welcome and the admin
+    // notification both fired.
+    expect(sends.some((send) => send.to[0] === "checkout@example.com")).toBe(true);
     expect(sends.some((send) => send.subject.startsWith("Welcome to World Monitor"))).toBe(true);
     expect(sends.some((send) => send.subject.startsWith("[WM] New User Subscribed"))).toBe(true);
   });
@@ -662,6 +673,129 @@ describe("webhook processWebhookEvent", () => {
 
     const welcomeBack = sends.find((send) => send.subject.includes("Welcome back"));
     expect(welcomeBack?.to).toEqual(["login@example.com"]);
+    // The reactivation path gets the same #6330 treatment as the first
+    // purchase: the welcome-back names the sign-in address, and the checkout
+    // inbox receives a pointer (masked login) instead of silence.
+    expect(welcomeBack?.html).toContain("login@example.com");
+    const pointer = sends.find((send) => send.to[0] === "checkout@example.com");
+    expect(pointer).toBeDefined();
+    expect(pointer?.html).toContain("l•••@example.com");
+    expect(sends).toHaveLength(2);
+  });
+
+  test("case- and whitespace-only checkout differences stay on the no-pointer path", async () => {
+    vi.useFakeTimers();
+    process.env.RESEND_API_KEY = "re_test";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "login@example.com",
+        normalizedEmail: "login@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_login_email_case_only",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: " LOGIN@Example.com ",
+          name: "Test User",
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    // Same inbox in different casing is NOT a divergence: welcome + admin
+    // only, no pointer, no third email into the user's own inbox.
+    expect(sends).toHaveLength(2);
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["login@example.com"]);
+  });
+
+  test("a users row without an email falls back to the checkout address", async () => {
+    vi.useFakeTimers();
+    process.env.RESEND_API_KEY = "re_test";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      // Phone-only signup shape: row exists, email absent.
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_users_row_no_email",
+      "subscription.active",
+      makeSubscriptionPayload(),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    expect(sends).toHaveLength(2);
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["test@example.com"]);
+  });
+
+  test("email templates escape HTML in interpolated addresses", async () => {
+    process.env.RESEND_API_KEY = "re_test";
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await t.action(internal.payments.subscriptionEmails.sendSubscriptionEmails, {
+      userEmail: 'login<script>alert(1)</script>@example.com',
+      planKey: "pro_monthly",
+      userId: "test-user-001",
+      checkoutEmail: 'checkout<img src=x>@example.com',
+    });
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        html: string;
+      });
+
+    expect(sends.length).toBeGreaterThan(0);
+    for (const send of sends) {
+      expect(send.html).not.toContain("<script>");
+      expect(send.html).not.toContain("<img src=x>");
+    }
+    expect(sends.some((send) => send.html.includes("&lt;script&gt;"))).toBe(true);
   });
 
   test.each([

--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -176,6 +176,60 @@ function escapeHtml(value: string): string {
     .replace(/'/g, "&#39;");
 }
 
+/**
+ * Mask a login address for disclosure to the UNVERIFIED checkout inbox:
+ * "login@example.com" → "l•••@example.com". Recognizable to its owner,
+ * useless to a stranger who received the pointer because the buyer typo'd
+ * the checkout address. The full address is only ever written to the login
+ * inbox itself and to the admin alert.
+ */
+function maskEmail(address: string): string {
+  const at = address.indexOf("@");
+  if (at <= 1) return address;
+  return `${address[0]}•••${address.slice(at)}`;
+}
+
+/**
+ * Best-effort sign-in pointer to the checkout inbox (#6330). The buyer typed
+ * this address at checkout and demonstrably watches it (it also receives the
+ * Dodo receipt) — without this, the only inbox they may check goes silent
+ * while the welcome lands somewhere they may not think to look. The address
+ * is buyer-typed and may be one Resend rejects outright (typo'd domain), so
+ * a failure here must never propagate — log and continue.
+ */
+async function sendSignInPointer(
+  apiKey: string,
+  checkoutEmail: string,
+  loginEmail: string,
+  planName: string,
+): Promise<void> {
+  try {
+    await sendEmail(
+      apiKey,
+      checkoutEmail,
+      `Your World Monitor subscription is active — where to sign in`,
+      `<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; background: #0a0a0a; color: #e0e0e0;">
+        <div style="background: #4ade80; height: 4px;"></div>
+        <div style="padding: 40px 32px;">
+          <p style="font-size: 22px; font-weight: 700; color: #fff; margin: 0 0 12px;">Payment received — you're all set.</p>
+          <p style="font-size: 14px; color: #999; line-height: 1.5; margin: 0 0 12px;">Your ${planName} subscription is active. This address (${escapeHtml(checkoutEmail)}) is the billing contact for the subscription.</p>
+          <p style="font-size: 14px; color: #999; line-height: 1.5; margin: 0 0 24px;">To open your dashboard, sign in with <strong style="color: #fff;">${escapeHtml(maskEmail(loginEmail))}</strong> — your sign-in code will arrive in that inbox.</p>
+          <div style="text-align: center;">
+            <a href="https://worldmonitor.app" style="display: inline-block; background: #4ade80; color: #0a0a0a; padding: 14px 36px; text-decoration: none; font-weight: 800; font-size: 13px; text-transform: uppercase; letter-spacing: 1.5px; border-radius: 2px;">Open World Monitor</a>
+          </div>
+          <p style="font-size: 11px; color: #666; text-align: center; margin: 24px 0 0;">Questions? Reply to this email or contact ${ADMIN_EMAIL}.</p>
+        </div>
+      </div>`,
+      ADMIN_EMAIL,
+    );
+    console.log(`[subscriptionEmails] Sign-in pointer sent to checkout address`);
+  } catch (err) {
+    console.error(
+      `[subscriptionEmails] Sign-in pointer to checkout address failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
 function userWelcomeHtml(planName: string, planKey: string, signInEmail?: string): string {
   const isPro = PRO_PLANS.has(planKey);
   // Pro path: headline leads with the value prop, CTA points at the brief
@@ -211,7 +265,7 @@ function userWelcomeHtml(planName: string, planKey: string, signInEmail?: string
       <p style="font-size: 14px; color: #999; margin: 0; line-height: 1.5;">Your subscription is now active. Here's what's unlocked:</p>
       ${
         signInEmail
-          ? `<p style="font-size: 13px; color: #999; margin: 12px 0 0; line-height: 1.5;">Sign in with <strong style="color: #fff;">${escapeHtml(signInEmail)}</strong> — the address you entered at checkout was used for billing only and is not a World Monitor login.</p>`
+          ? `<p style="font-size: 13px; color: #999; margin: 12px 0 0; line-height: 1.5;">Sign in with <strong style="color: #fff;">${escapeHtml(signInEmail)}</strong> — the address you entered at checkout is kept as your billing contact.</p>`
           : ""
       }
     </div>
@@ -343,53 +397,34 @@ export const sendSubscriptionEmails = internalAction({
 
     const planName = PLAN_DISPLAY[args.planKey] ?? args.planKey;
 
+    // Each of the three sends is independently guarded: a rejection or outage
+    // on any one of them must not swallow the others. A scheduled
+    // internalAction is not auto-retried, so an unguarded throw is a permanent
+    // loss of everything sequenced after it — the welcome (customer), the
+    // pointer (customer's checkout inbox), and the admin alert (the only ops
+    // signal that a paid conversion happened) each matter on their own.
+
     // 1. Welcome email to user. reply_to routes "Reply to this email" (in the
     // Pro support line) to ADMIN_EMAIL — FROM is noreply@ and Gmail honours
     // Reply-To over From when both are present.
-    await sendEmail(
-      apiKey,
-      args.userEmail,
-      `Welcome to World Monitor ${planName}`,
-      userWelcomeHtml(planName, args.planKey, args.checkoutEmail ? args.userEmail : undefined),
-      ADMIN_EMAIL,
-    );
-    console.log(`[subscriptionEmails] Welcome email sent to ${args.userEmail}`);
-
-    // 1b. Sign-in pointer to the checkout inbox. The buyer typed this address
-    // at checkout and demonstrably watches it (it also receives the Dodo
-    // receipt) — without this, the only inbox they may check goes silent
-    // while the welcome lands somewhere they may not think to look.
-    // Best-effort: the address is buyer-typed and may be one Resend rejects
-    // outright (typo'd domain), so a failure here must not swallow the admin
-    // notification below — log and continue instead of throwing.
-    if (args.checkoutEmail) {
-      try {
+    try {
       await sendEmail(
         apiKey,
-        args.checkoutEmail,
-        `Your World Monitor subscription is active — where to sign in`,
-        `<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; background: #0a0a0a; color: #e0e0e0;">
-          <div style="background: #4ade80; height: 4px;"></div>
-          <div style="padding: 40px 32px;">
-            <p style="font-size: 22px; font-weight: 700; color: #fff; margin: 0 0 12px;">Payment received — you're all set.</p>
-            <p style="font-size: 14px; color: #999; line-height: 1.5; margin: 0 0 12px;">Your ${planName} subscription is active. This address (${escapeHtml(args.checkoutEmail)}) was used for billing only — it is not a World Monitor login.</p>
-            <p style="font-size: 14px; color: #999; line-height: 1.5; margin: 0 0 24px;">Sign in with <strong style="color: #fff;">${escapeHtml(args.userEmail)}</strong> — your sign-in code will arrive in that inbox.</p>
-            <div style="text-align: center;">
-              <a href="https://worldmonitor.app" style="display: inline-block; background: #4ade80; color: #0a0a0a; padding: 14px 36px; text-decoration: none; font-weight: 800; font-size: 13px; text-transform: uppercase; letter-spacing: 1.5px; border-radius: 2px;">Open World Monitor</a>
-            </div>
-            <p style="font-size: 11px; color: #666; text-align: center; margin: 24px 0 0;">Questions? Reply to this email or contact ${ADMIN_EMAIL}.</p>
-          </div>
-        </div>`,
+        args.userEmail,
+        `Welcome to World Monitor ${planName}`,
+        userWelcomeHtml(planName, args.planKey, args.checkoutEmail ? args.userEmail : undefined),
         ADMIN_EMAIL,
       );
-      console.log(
-        `[subscriptionEmails] Sign-in pointer sent to checkout address for ${args.userEmail}`,
+      console.log(`[subscriptionEmails] Welcome email sent to ${args.userEmail}`);
+    } catch (err) {
+      console.error(
+        `[subscriptionEmails] Welcome email failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
       );
-      } catch (err) {
-        console.error(
-          `[subscriptionEmails] Sign-in pointer to checkout address failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
+    }
+
+    // 1b. Sign-in pointer to the checkout inbox (#6330) — see sendSignInPointer.
+    if (args.checkoutEmail) {
+      await sendSignInPointer(apiKey, args.checkoutEmail, args.userEmail, planName);
     }
 
     // 2. Admin notification — leads with what the user actually paid (and how
@@ -402,22 +437,28 @@ export const sendSubscriptionEmails = internalAction({
       taxInclusive: args.taxInclusive,
       discountId: args.discountId,
     });
-    await sendEmail(
-      apiKey,
-      ADMIN_EMAIL,
-      `[WM] New User Subscribed to ${planName}`,
-      `<div style="font-family: monospace; padding: 20px; background: #0a0a0a; color: #e0e0e0;">
+    try {
+      await sendEmail(
+        apiKey,
+        ADMIN_EMAIL,
+        `[WM] New User Subscribed to ${planName}`,
+        `<div style="font-family: monospace; padding: 20px; background: #0a0a0a; color: #e0e0e0;">
         <p style="color: #4ade80; font-size: 16px; font-weight: bold;">New Subscription</p>
         <table style="font-size: 14px; line-height: 1.8;">
           <tr><td style="color: #888; padding-right: 16px;">Plan:</td><td style="color: #fff;">${planName}</td></tr>
           <tr><td style="color: #888; padding-right: 16px;">Email:</td><td style="color: #fff;">${escapeHtml(args.userEmail)}</td></tr>
           ${args.checkoutEmail ? `<tr><td style="color: #888; padding-right: 16px;">Billing Email:</td><td style="color: #fff;">${escapeHtml(args.checkoutEmail)}</td></tr>` : ""}
           ${priceRows}
-          <tr><td style="color: #888; padding-right: 16px;">User ID:</td><td style="color: #fff; font-size: 12px;">${args.userId}</td></tr>
+          <tr><td style="color: #888; padding-right: 16px;">User ID:</td><td style="color: #fff; font-size: 12px;">${escapeHtml(args.userId)}</td></tr>
         </table>
       </div>`,
-    );
-    console.log(`[subscriptionEmails] Admin notification sent for ${args.userEmail}`);
+      );
+      console.log(`[subscriptionEmails] Admin notification sent for ${args.userEmail}`);
+    } catch (err) {
+      console.error(
+        `[subscriptionEmails] Admin notification failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   },
 });
 
@@ -432,6 +473,10 @@ export const sendReactivationEmail = internalAction({
   args: {
     userEmail: v.string(),
     planKey: v.string(),
+    // #6330: same contract as sendSubscriptionEmails — set only when the Dodo
+    // checkout email differs from the login email in `userEmail`. A returning
+    // checkout is exactly as capable of alias divergence as a first one.
+    checkoutEmail: v.optional(v.string()),
   },
   handler: async (_ctx, args) => {
     const apiKey = process.env.RESEND_API_KEY;
@@ -441,24 +486,40 @@ export const sendReactivationEmail = internalAction({
     }
 
     const planName = PLAN_DISPLAY[args.planKey] ?? args.planKey;
-    await sendEmail(
-      apiKey,
-      args.userEmail,
-      `Welcome back to World Monitor ${planName}`,
-      `<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; background: #0a0a0a; color: #e0e0e0;">
+    const signInLine = args.checkoutEmail
+      ? `<p style="font-size: 13px; color: #999; line-height: 1.5; margin: 0 0 24px;">Sign in with <strong style="color: #fff;">${escapeHtml(args.userEmail)}</strong> — the address you entered at checkout is kept as your billing contact.</p>`
+      : "";
+    try {
+      await sendEmail(
+        apiKey,
+        args.userEmail,
+        `Welcome back to World Monitor ${planName}`,
+        `<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; background: #0a0a0a; color: #e0e0e0;">
         <div style="background: #4ade80; height: 4px;"></div>
         <div style="padding: 40px 32px;">
           <p style="font-size: 22px; font-weight: 700; color: #fff; margin: 0 0 12px;">Welcome back.</p>
-          <p style="font-size: 14px; color: #999; line-height: 1.5; margin: 0 0 24px;">Your ${planName} subscription is active again and your premium access has been restored.</p>
+          <p style="font-size: 14px; color: #999; line-height: 1.5; margin: 0 0 ${args.checkoutEmail ? "12px" : "24px"};">Your ${planName} subscription is active again and your premium access has been restored.</p>
+          ${signInLine}
           <div style="text-align: center;">
             <a href="https://worldmonitor.app/dashboard" style="display: inline-block; background: #4ade80; color: #0a0a0a; padding: 14px 36px; text-decoration: none; font-weight: 800; font-size: 13px; text-transform: uppercase; letter-spacing: 1.5px; border-radius: 2px;">Open World Monitor</a>
           </div>
           <p style="font-size: 11px; color: #666; text-align: center; margin: 24px 0 0;">Questions? Reply to this email or contact ${ADMIN_EMAIL}.</p>
         </div>
       </div>`,
-      ADMIN_EMAIL,
-    );
-    console.log(`[subscriptionEmails] Reactivation email sent to ${args.userEmail}`);
+        ADMIN_EMAIL,
+      );
+      console.log(`[subscriptionEmails] Reactivation email sent to ${args.userEmail}`);
+    } catch (err) {
+      console.error(
+        `[subscriptionEmails] Reactivation email failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    // Sign-in pointer to the checkout inbox — same rationale as the welcome
+    // path (#6330); best-effort by construction.
+    if (args.checkoutEmail) {
+      await sendSignInPointer(apiKey, args.checkoutEmail, args.userEmail, planName);
+    }
   },
 });
 

--- a/convex/payments/subscriptionEmails.ts
+++ b/convex/payments/subscriptionEmails.ts
@@ -162,7 +162,21 @@ function featureCardsHtml(planKey: string): string {
       </tr>`;
 }
 
-function userWelcomeHtml(planName: string, planKey: string): string {
+/**
+ * Minimal HTML-escape for user-influenced strings (email addresses) that get
+ * interpolated into email markup. Addresses come from Clerk identities and
+ * buyer-typed Dodo checkout fields — treat both as untrusted display text.
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function userWelcomeHtml(planName: string, planKey: string, signInEmail?: string): string {
   const isPro = PRO_PLANS.has(planKey);
   // Pro path: headline leads with the value prop, CTA points at the brief
   // (the single highest-retention action for a new Pro). API path preserved
@@ -195,6 +209,11 @@ function userWelcomeHtml(planName: string, planKey: string): string {
     <div style="background: #111; border: 1px solid #1a1a1a; border-left: 3px solid #4ade80; padding: 20px 24px; margin-bottom: 28px;">
       <p style="font-size: 18px; font-weight: 600; color: #fff; margin: 0 0 8px;">${headline}</p>
       <p style="font-size: 14px; color: #999; margin: 0; line-height: 1.5;">Your subscription is now active. Here's what's unlocked:</p>
+      ${
+        signInEmail
+          ? `<p style="font-size: 13px; color: #999; margin: 12px 0 0; line-height: 1.5;">Sign in with <strong style="color: #fff;">${escapeHtml(signInEmail)}</strong> — the address you entered at checkout was used for billing only and is not a World Monitor login.</p>`
+          : ""
+      }
     </div>
 
     <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-bottom: 28px;">
@@ -310,6 +329,10 @@ export const sendSubscriptionEmails = internalAction({
     currency: v.optional(v.string()),
     taxInclusive: v.optional(v.boolean()),
     discountId: v.optional(v.string()),
+    // #6330: set only when the Dodo checkout email differs from the login
+    // email in `userEmail`. Adds the sign-in line to the welcome, a pointer
+    // email to the checkout inbox, and the Billing Email row for admin.
+    checkoutEmail: v.optional(v.string()),
   },
   handler: async (_ctx, args) => {
     const apiKey = process.env.RESEND_API_KEY;
@@ -327,10 +350,47 @@ export const sendSubscriptionEmails = internalAction({
       apiKey,
       args.userEmail,
       `Welcome to World Monitor ${planName}`,
-      userWelcomeHtml(planName, args.planKey),
+      userWelcomeHtml(planName, args.planKey, args.checkoutEmail ? args.userEmail : undefined),
       ADMIN_EMAIL,
     );
     console.log(`[subscriptionEmails] Welcome email sent to ${args.userEmail}`);
+
+    // 1b. Sign-in pointer to the checkout inbox. The buyer typed this address
+    // at checkout and demonstrably watches it (it also receives the Dodo
+    // receipt) — without this, the only inbox they may check goes silent
+    // while the welcome lands somewhere they may not think to look.
+    // Best-effort: the address is buyer-typed and may be one Resend rejects
+    // outright (typo'd domain), so a failure here must not swallow the admin
+    // notification below — log and continue instead of throwing.
+    if (args.checkoutEmail) {
+      try {
+      await sendEmail(
+        apiKey,
+        args.checkoutEmail,
+        `Your World Monitor subscription is active — where to sign in`,
+        `<div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; background: #0a0a0a; color: #e0e0e0;">
+          <div style="background: #4ade80; height: 4px;"></div>
+          <div style="padding: 40px 32px;">
+            <p style="font-size: 22px; font-weight: 700; color: #fff; margin: 0 0 12px;">Payment received — you're all set.</p>
+            <p style="font-size: 14px; color: #999; line-height: 1.5; margin: 0 0 12px;">Your ${planName} subscription is active. This address (${escapeHtml(args.checkoutEmail)}) was used for billing only — it is not a World Monitor login.</p>
+            <p style="font-size: 14px; color: #999; line-height: 1.5; margin: 0 0 24px;">Sign in with <strong style="color: #fff;">${escapeHtml(args.userEmail)}</strong> — your sign-in code will arrive in that inbox.</p>
+            <div style="text-align: center;">
+              <a href="https://worldmonitor.app" style="display: inline-block; background: #4ade80; color: #0a0a0a; padding: 14px 36px; text-decoration: none; font-weight: 800; font-size: 13px; text-transform: uppercase; letter-spacing: 1.5px; border-radius: 2px;">Open World Monitor</a>
+            </div>
+            <p style="font-size: 11px; color: #666; text-align: center; margin: 24px 0 0;">Questions? Reply to this email or contact ${ADMIN_EMAIL}.</p>
+          </div>
+        </div>`,
+        ADMIN_EMAIL,
+      );
+      console.log(
+        `[subscriptionEmails] Sign-in pointer sent to checkout address for ${args.userEmail}`,
+      );
+      } catch (err) {
+        console.error(
+          `[subscriptionEmails] Sign-in pointer to checkout address failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
 
     // 2. Admin notification — leads with what the user actually paid (and how
     // it compares to list price) instead of the opaque subscription_id, which
@@ -350,7 +410,8 @@ export const sendSubscriptionEmails = internalAction({
         <p style="color: #4ade80; font-size: 16px; font-weight: bold;">New Subscription</p>
         <table style="font-size: 14px; line-height: 1.8;">
           <tr><td style="color: #888; padding-right: 16px;">Plan:</td><td style="color: #fff;">${planName}</td></tr>
-          <tr><td style="color: #888; padding-right: 16px;">Email:</td><td style="color: #fff;">${args.userEmail}</td></tr>
+          <tr><td style="color: #888; padding-right: 16px;">Email:</td><td style="color: #fff;">${escapeHtml(args.userEmail)}</td></tr>
+          ${args.checkoutEmail ? `<tr><td style="color: #888; padding-right: 16px;">Billing Email:</td><td style="color: #fff;">${escapeHtml(args.checkoutEmail)}</td></tr>` : ""}
           ${priceRows}
           <tr><td style="color: #888; padding-right: 16px;">User ID:</td><td style="color: #fff; font-size: 12px;">${args.userId}</td></tr>
         </table>

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -1063,7 +1063,11 @@ export async function handleSubscriptionActive(
       await ctx.scheduler.runAfter(
         0,
         internal.payments.subscriptionEmails.sendReactivationEmail,
-        { userEmail: recipientEmail, planKey },
+        {
+          userEmail: recipientEmail,
+          planKey,
+          checkoutEmail: checkoutEmailDiffers ? email.trim() : undefined,
+        },
       );
       console.log(`[subscriptionHelpers] subscription.active: scheduled reactivation email (subscriptionId=${data.subscription_id})`);
     } else {

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -1031,19 +1031,39 @@ export async function handleSubscriptionActive(
     }
   }
 
+  // #6330: customer lifecycle emails target the account's LOGIN email, not
+  // the address typed into Dodo checkout. The two can be different aliases of
+  // the same person, and a "your subscription is active — sign in" email
+  // addressed to the checkout alias steers the buyer into "account not known"
+  // at the login screen. The users row (populated by users:ensureRecord on
+  // every authenticated session) carries the Clerk login email; fall back to
+  // the checkout email when the row or its email is absent (accounts predating
+  // the users table, phone-only signups). The customers row above deliberately
+  // keeps the checkout email — it mirrors Dodo's record for portal lookups.
+  const userRow = await ctx.db
+    .query("users")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .first();
+  const loginEmail = (userRow?.email ?? "").trim();
+  const recipientEmail = loginEmail.length > 0 ? loginEmail : email.trim();
+  const checkoutEmailDiffers =
+    loginEmail.length > 0 &&
+    normalizedEmail.length > 0 &&
+    normalizedEmail !== loginEmail.toLowerCase();
+
   // Schedule the appropriate customer email (non-blocking). Only a proven
   // post-lapse return receives the customer-only welcome-back confirmation.
   // Pre-lapse recovery and already-active replay/update paths remain silent.
-  if (!email) {
+  if (!recipientEmail) {
     console.warn(
-      `[subscriptionHelpers] subscription.active: no customer email — skipping welcome email (subscriptionId=${data.subscription_id})`,
+      `[subscriptionHelpers] subscription.active: no resolvable recipient email — skipping welcome email (subscriptionId=${data.subscription_id})`,
     );
   } else if (wasLapsed) {
     if (process.env.RESEND_API_KEY) {
       await ctx.scheduler.runAfter(
         0,
         internal.payments.subscriptionEmails.sendReactivationEmail,
-        { userEmail: email, planKey },
+        { userEmail: recipientEmail, planKey },
       );
       console.log(`[subscriptionHelpers] subscription.active: scheduled reactivation email (subscriptionId=${data.subscription_id})`);
     } else {
@@ -1058,13 +1078,17 @@ export async function handleSubscriptionActive(
       0,
       internal.payments.subscriptionEmails.sendSubscriptionEmails,
       {
-        userEmail: email,
+        userEmail: recipientEmail,
         planKey,
         userId,
         recurringPreTaxAmount: data.recurring_pre_tax_amount,
         currency: data.currency,
         taxInclusive: data.tax_inclusive,
         discountId: data.discount_id ?? undefined,
+        // Present only when the buyer typed a different address at checkout:
+        // triggers the sign-in line in the welcome, a pointer email to the
+        // checkout inbox, and the Billing Email row in the admin alert.
+        checkoutEmail: checkoutEmailDiffers ? email.trim() : undefined,
       },
     );
   }

--- a/docs/solutions/architecture-patterns/welcome-email-checkout-identity-diverges-from-clerk-login-identity.md
+++ b/docs/solutions/architecture-patterns/welcome-email-checkout-identity-diverges-from-clerk-login-identity.md
@@ -1,0 +1,150 @@
+---
+title: "Lifecycle emails addressed to the Dodo checkout email, not the Clerk login email, look like scams and failed sends"
+module: billing-identity
+date: 2026-08-08
+category: architecture-patterns
+problem_type: architecture_pattern
+component: payments
+severity: medium
+applies_when:
+  - "Triaging a \"paid but can't log in\" support ticket, especially from an email address the product has no account for"
+  - "The billing provider (Dodo Payments) and the auth provider (Clerk) can each hold a different email address for the same customer"
+  - "A lifecycle or welcome email is addressed from the payment provider's checkout email rather than the auth provider's login email"
+  - "Searching an email platform (e.g. Resend) by a customer's login email returns no results, which looks like a send failure but is actually an identity mismatch"
+  - "Confirming which account a payment reached: use the checkout session's linked user id in metadata, not any email address, as the source of truth"
+symptoms:
+  - "Customer email claims 'paid for Pro and can't log in' from an address that has no Clerk account"
+  - "Convex entitlement lookup for the correct userId already shows valid, paid coverage, contradicting the ticket"
+  - "Searching the email platform by the customer's stated login email returns zero sends, which looks like a missing welcome email"
+  - "The welcome email was delivered and clicked, but to a third address: the checkout billing email, not the login email"
+related_components:
+  - authentication
+  - email_processing
+tags:
+  - dodo-payments
+  - clerk
+  - resend
+  - entitlements
+  - identity-mismatch
+  - support-triage
+  - welcome-email
+  - checkout-vs-login-email
+---
+
+# Lifecycle emails addressed to the Dodo checkout email, not the Clerk login email, look like scams and failed sends
+
+## Context
+
+A support email arrived on 2026-08-08 with the subject energy of a chargeback: *"URGENT! Account not working after payment! … I hope this is not a scam!"* The customer had paid, and the login screen told them the account was not known.
+
+Nothing was broken. The payment succeeded, the entitlement was written correctly, and the welcome email was delivered and clicked. What failed was identity: the buyer received a "your subscription is now active" email at one address, tried to sign in with that address, and World Monitor had never heard of it. Their actual account was registered under a different address entirely.
+
+This is not a regression, and no amount of staring at the entitlement pipeline finds it — the pipeline is green the whole way through. It is a design seam between the billing provider's notion of a customer (an email typed at checkout) and Clerk's notion of a user (an email that owns a sign-in). Any user who keeps aliases — and privacy-minded users keep many — can land on the wrong side of it.
+
+The recipe below is the reusable part: it separates "our billing is broken" from "this person is signed in as someone else" in about five API calls, and it names the three ops traps that make the healthy case look like a failure.
+
+## Guidance
+
+### The diagnosis recipe for any "paid but can't log in" / "paid but no Pro" ticket
+
+Run these in order. The point of the order is that each step narrows the failure class, and by step (d) you can already tell a real regression from an identity mix-up.
+
+**(a) Resolve the Dodo customer.** Look them up by `cus_…` id if the ticket carries one, or by `?email=` using every address in the thread. Note that the billing email here is whatever the buyer typed into the checkout form — it is *not* authenticated and it is *not* an account.
+
+**(b) Read `metadata.wm_user_id` on the subscription and payment records.** This is the ground truth for "who bought this," and it is independent of any email. WorldMonitor stamps the signed Clerk identity onto the checkout session at `convex/payments/checkout.ts:201-202`:
+
+```ts
+metadata.wm_user_id = user.userId;
+metadata.wm_user_id_sig = await signUserId(user.userId);
+```
+
+The webhook side trusts it only when the HMAC verifies — `tryResolveUserId` in `convex/payments/subscriptionHelpers.ts:667-680` returns the metadata userId on a valid signature, warns and falls through on an invalid or unsigned one, and only then drops to a `customers`-table lookup by `dodoCustomerId` (`convex/payments/subscriptionHelpers.ts:682-689`). So a signed `wm_user_id` tells you exactly which Clerk account was logged in at the moment of purchase, no matter what the buyer typed.
+
+**(c) Look up that Clerk user's login email — and search Clerk for *every* address in the ticket.** Both halves matter. The first tells you where the account actually lives; the second proves whether the other addresses are accounts at all, or just inboxes. A ticket where the support-sender address, the checkout address, and the login address are three different aliases of one person is the signature of this failure mode.
+
+**(d) Query Convex entitlements for that userId** (`POST $CONVEX_SITE_URL/api/internal-entitlements` with the shared secret). Check `planKey`, `validUntil`, and `tier`. This is the decision point.
+
+**(e) List Resend sends** to see where the lifecycle email actually went, and read `last_event`. A `clicked` event on the checkout address is positive proof the buyer read the welcome mail — and therefore proof of which address they will try to sign in with.
+
+### The decision point
+
+| Entitlement for `wm_user_id` | Login email vs checkout email | Verdict |
+| --- | --- | --- |
+| Correct plan and expiry | Different addresses | Identity mix-up. Not a regression. Reply with the real login address. |
+| Missing, wrong plan, or downgraded | Any | Real pipeline defect. Escalate to the webhook/entitlement path. |
+| Correct | Same address | Look elsewhere — Clerk sign-in method, deliverability, or a genuinely different account. |
+
+Do not skip step (d) because the ticket sounds urgent. "Entitlement is correct" is what converts a possible P0 into a reply-and-close, and it is one call.
+
+### Ops traps that make a healthy system look broken
+
+Three separate false negatives, all encountered in this investigation:
+
+**Searching Resend for the login email finds nothing.** It looks exactly like a send failure. It is not — the email was addressed to the *checkout* email, which is the whole bug. Always search Resend for every alias, not just the one the account uses.
+
+**The `RESEND_API_KEY` in `.env.local` is a restricted, send-only key.** Any list/search call returns `401 restricted_api_key`, which reads like an outage or a revoked key. Use `RESEND_BROADCASTS_API_KEY` to enumerate sent emails.
+
+**Dodo's API sits behind Cloudflare and rejects default client user-agents.** A Python `urllib` default UA gets `403` with body `error code: 1010`, which looks like an auth failure against the billing provider during a billing incident. Set a browser User-Agent header.
+
+One more environment note that costs time if unknown: the Clerk secret key lives in the **Convex environment**, not in `.env.local`. Looking for it locally and failing is not evidence that Clerk access is broken.
+
+### The design seam itself (fix pending)
+
+Subscription lifecycle emails address the Dodo checkout email, never the account's login email. `convex/payments/subscriptionHelpers.ts:1011`:
+
+```ts
+// Upsert customer record so portal session creation can find dodoCustomerId
+const email = data.customer?.email ?? "";
+```
+
+That single value feeds both customer-facing sends — `sendReactivationEmail` at line 1046 and `sendSubscriptionEmails` at line 1061 — as `userEmail`, and it is also what gets written into the `customers` row (lines 1016-1031). The dunning and winback path inherits the same order of preference: `getDunningContext` in `convex/payments/subscriptionEmails.ts:479-488` reads the subscription's `rawPayload.customer.email` first and only falls back to the `customers` row for the same userId. Every lifecycle email in the system therefore addresses the checkout inbox.
+
+What lands in that inbox is an invitation to sign in. `userWelcomeHtml` renders "Your subscription is now active. Here's what's unlocked:" (`convex/payments/subscriptionEmails.ts:197`) above a CTA that for Pro plans reads "Open My Brief" and points at `https://worldmonitor.app/brief` (`convex/payments/subscriptionEmails.ts:175-176`, rendered at line 205) — an auth-gated route. A buyer who checked out under an alias reads "active," clicks through, types the address the email arrived at, and is told the account does not exist. From the buyer's seat that is indistinguishable from being scammed.
+
+Filed as issue **#6330** ("fix(payments): welcome email targets Dodo checkout email, steering alias buyers to a nonexistent login (\"account not known\")") — filed, unmerged as of this writing. Until it merges, expect this ticket class to recur, and diagnose it with the recipe above rather than re-deriving it.
+
+### A useful inference: the admin email is a receipt for the user email
+
+`sendSubscriptionEmails` sends the user welcome **first** (`convex/payments/subscriptionEmails.ts:326-333`), then the admin notification (lines 345-359), as two sequential `await`s in one action. The shared `sendEmail` helper throws on any non-OK Resend response (`convex/payments/subscriptionEmails.ts:63-68`). Therefore: **if the admin "New User Subscribed" email arrived, the user welcome was accepted by Resend** — a throw on the first send would have prevented the second from ever running. When triaging "the customer says they never got the welcome email," an admin notification in your own inbox already rules out a send failure and points you at addressing or deliverability instead.
+
+## Why This Matters
+
+The expensive failure here is misdiagnosis, in both directions.
+
+Treating it as a billing regression sends an engineer into the webhook and entitlement code for hours, where everything is correct and nothing explains the symptom. The known Dodo one-row-per-user multi-subscription hazard was explicitly checked in this case — the customer had a *failed* API Starter attempt three minutes before the successful Pro Business Yearly purchase, exactly the shape that could silently downgrade an entitlement — and it did not fire. The recompute-from-all-subs guard held. Confirming that took one entitlement query; guessing at it would have taken an afternoon.
+
+Treating it as "user error" and replying with a password-reset link is equally wrong: there is nothing to reset, because there is no account at that address. The correct reply names the actual login address and the sign-in method.
+
+And the customer-facing cost is disproportionate. This is the worst possible moment for a paying customer's first post-purchase experience to say "account not known" — they have just been charged several hundred francs by a company they do not yet trust, and the system's own welcome email is what steered them into the wall. Every hour this ticket class stays open is an hour a paying customer believes they were defrauded.
+
+## When to Apply
+
+- Any support ticket of the form "I paid but can't log in," "I paid but I don't have Pro," or "my account doesn't exist after payment."
+- Before opening a P0 on the entitlement pipeline off the back of a single customer report — run step (d) first.
+- When a customer says they never received a welcome, renewal, dunning, or winback email: check where it was actually addressed before assuming a send failure.
+- When any billing-provider record and any auth-provider record disagree about who a person is. The recipe generalizes past Dodo and Clerk: the durable move is to resolve identity from the *signed* metadata the checkout carried, never from a typed email.
+
+## Examples
+
+The 2026-08-08 case, end to end, as the recipe runs:
+
+**(a)** Dodo customer `cus_0Nkt…`, billing email `webapps_wsr@…` — an address that appears nowhere in the ticket's From header.
+
+**(b)** Two subscriptions created 2026-08-07, both carrying `wm_user_id=user_3HK…` plus a valid `wm_user_id_sig`: API Starter at 20:17 UTC whose payment **failed** (card declined, €93.49), and Pro Business Yearly at 20:20 UTC whose payment **succeeded** (408.56 CHF), status `active`, next billing 2027-08-07. The signed metadata makes the "who bought" question answerable without touching an email at all.
+
+**(c)** Clerk `user_3HK…` signs in with `crypto_wsr@…` via email code (`password_enabled` false, no OAuth). Searching Clerk for the checkout address and for the support-sender address returns **nothing** — neither is an account. Three aliases of one person, in three different roles: `wsr2021@…` sent the ticket, `webapps_wsr@…` bought the subscription, `crypto_wsr@…` owns the login.
+
+**(d)** Convex entitlement for `user_3HK…`: `planKey` `pro_business_annual`, `validUntil` ≈ 2027-08-07, tier 1. Correct — and notably *not* downgraded by the failed API Starter attempt.
+
+**(e)** Resend shows "Welcome to World Monitor Pro Business (Annual)" delivered 2026-08-07 20:21:05 to `webapps_wsr@…`, `last_event=clicked` (the Resend dashboard row is findable by recipient + subject + timestamp). The click is the missing link in the story: the buyer read the mail at the checkout alias, followed its sign-in CTA, and tried that alias at the login screen.
+
+Verdict in one line: entitlement correct + login email ≠ checkout email → identity mix-up, not a regression. The reply names `crypto_wsr@…` as the login address and explains the email-code sign-in. The product fix is issue #6330.
+
+## Related
+
+- Issue **#6330** — welcome email targets the Dodo checkout email instead of the account's login email (open, unmerged as of 2026-08-08).
+- `convex/payments/checkout.ts:201-202` — where the signed `wm_user_id` identity is stamped onto the checkout session.
+- `convex/payments/subscriptionHelpers.ts:667-689` — `tryResolveUserId` trust order: HMAC-verified metadata, then `customers` lookup.
+- `convex/payments/subscriptionHelpers.ts:1011` — the checkout email that feeds every customer-facing lifecycle send.
+- `convex/payments/subscriptionEmails.ts:479-488` — `getDunningContext`, same recipient resolution for dunning and winback.
+- The Dodo one-row-per-user multi-subscription silent-downgrade hazard (checked here, did not fire) — see the `entitlement-billing-gotchas` skill.


### PR DESCRIPTION
## Problem (#6330 — live incident 2026-08-07)

Subscription lifecycle emails addressed the **Dodo checkout email** (`data.customer.email`) — an unauthenticated, buyer-typed address that need not own any account. A real customer checked out under a different ProtonMail alias than their Clerk login email, received "your subscription is active — sign in" at that alias, clicked the CTA (Resend `last_event: clicked`), and hit **"account not known"** — then emailed support fearing a scam. The entitlement pipeline was correct end-to-end; the email's addressing manufactured the confusion.

## Fix

`handleSubscriptionActive` now resolves the customer-facing recipient from the `users` row (Clerk login email, server-derived by `users:ensureRecord`) by the already-trusted `userId`, falling back to the checkout email when the row or its email is absent. When the two addresses genuinely differ (normalized compare):

- the **welcome / welcome-back** goes to the login email and explicitly names the sign-in address;
- the **checkout inbox** receives a best-effort sign-in pointer (the buyer demonstrably watches it — it gets the Dodo receipt) with the login address **masked** (`l•••@example.com`) since that inbox is unverified;
- the **admin alert** gains a `Billing Email` row so ops can find the customer from either address (searching Resend by login email previously looked like a send failure).

Hardening from the adversarial review round: welcome, pointer, and admin sends each carry independent try/catch (a scheduled `internalAction` is never auto-retried, so one Resend rejection must not cost the other sends); reactivation gets full parity (a returning checkout is as capable of alias divergence as a first one); copy avoids the false "is not a login" claim (verified secondary Clerk emails, Gmail dot-aliases); all new interpolations are HTML-escaped.

**Deliberately unchanged:** dunning/winback recipient chain (their CTA is a portal link, not a sign-in). Follow-up filed: #6335 (stale `users.email` window — stamp the fresh login email into signed checkout metadata; plus `convex/` lint-gate gap).

## Tests

8 new/upgraded cases in `convex/__tests__/webhook.test.ts` (42/42 green): divergence routing + masking + send-count pinning, identical-address no-op parity, empty-checkout fallback via login email, case/whitespace normalization boundary, users-row-without-email fallback, rejected-pointer isolation (de-vacuated: pins that the pointer was attempted), reactivation parity, and template HTML-escaping. Red-first: the three behavior tests were observed failing against the pre-fix tree for the expected reasons. `tsc -p convex`, biome, and `audit-convex-string-calls` all pass.

Also ships the knowledge-track doc for the incident (`docs/solutions/architecture-patterns/…`) and two CONCEPTS.md entries (Signed Checkout Identity, Checkout Email).

Fixes #6330

https://claude.ai/code/session_012GMp591LtfQQ7Sypck7yqP
