### PR TITLE
fix(panels): stop the free-tier count cap being a one-way door

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -2161,10 +2161,14 @@ export class App {
   }
 
   /**
-   * Put back the custom widgets the free-tier gate hid, now that we know the
-   * user is Pro. Covers the free→pro upgrade, and heals users whose widgets
-   * were disabled by a pre-fix build (see the one-time recovery below —
-   * those entries pre-date the `proGated` marker, so they need the sweep).
+   * Put back everything the free-tier gate hid, now that we know the user is
+   * Pro: the cw-* custom widgets AND the panels the count cap clamped off past
+   * FREE_MAX_PANELS. Both now carry `proGated`, so the targeted restore covers
+   * both; only the legacy sweep below stays widget-specific.
+   *
+   * Covers the free→pro upgrade, and heals users whose widgets were disabled
+   * by a pre-fix build (see the one-time recovery below — those entries
+   * pre-date the `proGated` marker, so they need the sweep).
    */
   private restoreProGatedCustomWidgets(cloudSyncVersion?: number): boolean {
     const panelSettings = loadFromStorage<Record<string, PanelConfig>>(STORAGE_KEYS.panels, {});

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1296,8 +1296,16 @@ export function enforceFreePanelLimit(
     .sort(([ka, a], [kb, b]) => (a.priority ?? 99) - (b.priority ?? 99) || ka.localeCompare(kb))
     .map(([k]) => k);
 
+  // Stamp `proGated` for the same reason the cw-* gate above does: this is the
+  // GATE disabling the panel, not the user. Without the marker the count cap
+  // was a one-way door — App.enforceFreeTierLimits persists this map into
+  // STORAGE_KEYS.panels, and restoreProGatedPanels only re-enables what is
+  // marked, so a panel clamped during any window where the tier read as free
+  // stayed `enabled: false` forever. Going Pro never brought it back: the panel
+  // kept appearing in Cmd+K and as a checked box in settings while being absent
+  // from the dashboard.
   for (const key of enabledKeys.slice(FREE_MAX_PANELS)) {
-    next[key] = { ...next[key]!, enabled: false };
+    next[key] = { ...next[key]!, enabled: false, proGated: true };
   }
 
   return next;

--- a/tests/panel-variant-config.test.mts
+++ b/tests/panel-variant-config.test.mts
@@ -154,6 +154,57 @@ describe('variant panel config resolution', () => {
     });
   });
 
+  it('restores COUNT-CAP-disabled panels for Pro, not just custom widgets', () => {
+    // The free-tier gate disables panels two ways: cw-* widgets (stamped
+    // proGated, restored by the test above) and everything past
+    // FREE_MAX_PANELS by the count cap. Only the first is stamped, and
+    // restoreProGatedPanels restores only what is stamped — so the count cap
+    // is a ONE-WAY DOOR.
+    //
+    // Concretely: a user over the cap while free (or during any window where
+    // the tier read as free) gets `enabled: false` PERSISTED into
+    // STORAGE_KEYS.panels for their lowest-priority panels. Going Pro never
+    // puts them back. The panel stays listed in Cmd+K and checkable in
+    // settings while being absent from the dashboard — a ghost.
+    //
+    // The sort is (priority asc, key asc), so at a flat priority the
+    // alphabetically-last keys go over the cliff first — which is why
+    // late-alphabet panels are the ones that vanish.
+    const original: Record<string, { name: string; enabled: boolean; priority: number }> = {};
+    for (let i = 0; i < FREE_MAX_PANELS + 5; i += 1) {
+      const key = `p${String(i).padStart(2, '0')}`;
+      original[key] = { name: key, enabled: true, priority: 1 };
+    }
+    const overCapKeys = Object.keys(original).slice(FREE_MAX_PANELS);
+    assert.equal(overCapKeys.length, 5, 'fixture must actually exceed the cap');
+
+    const clamped = enforceFreePanelLimit(original, false);
+    for (const key of overCapKeys) {
+      assert.equal(clamped[key]?.enabled, false, `${key} should be clamped off on the free tier`);
+    }
+    assert.equal(
+      countFreePanelCapUsage(clamped), FREE_MAX_PANELS,
+      'the clamp must leave exactly the cap enabled',
+    );
+
+    const restored = restoreProGatedPanels(clamped);
+    for (const key of overCapKeys) {
+      assert.equal(
+        restored[key]?.enabled, true,
+        `${key} was disabled by the free-tier cap, not by the user — going Pro must put it back`,
+      );
+    }
+
+    // The restore must not become a blanket enable-everything: a panel the
+    // USER turned off has to stay off.
+    const userHidden = enforceFreePanelLimit(
+      { ...original, p00: { name: 'p00', enabled: false, priority: 1 } },
+      false,
+    );
+    assert.equal(restoreProGatedPanels(userHidden).p00?.enabled, false,
+      'a deliberately hidden panel must stay hidden');
+  });
+
   it('defers free-tier enforcement until both Clerk and the entitlement snapshot settle', () => {
     // Clerk still pending: always defer — a signed-in Pro user is
     // indistinguishable from an anonymous one.


### PR DESCRIPTION
## Problem

A panel disabled by the free-tier **count cap** was never restored when the user became Pro. It stayed hidden forever while still appearing in Cmd+K and as a checked box in Settings — a ghost panel.

The gate disables panels two ways, and only one was marked:

```js
// cw-* custom widgets
next[key] = { ...next[key], enabled: false, proGated: true };
// over the count cap
next[key] = { ...next[key], enabled: false };          // <- unmarked
```

`restoreProGatedPanels` re-enables only what carries `proGated`, and `App.enforceFreeTierLimits` **persists** the clamped map into `STORAGE_KEYS.panels`. So the count-cap half wrote `enabled: false` to durable storage with nothing to undo it.

`src/config/panels.ts` already named this exact shape — *"Without this the gate is a one-way door"* — but the marker was only ever applied to the widget half.

## Reachable without ever being a free user

Enforcement runs whenever the tier *reads* as free. `shouldDeferFreeTierEnforcement` bounds that window with a grace timer rather than closing it, so one slow Clerk/Convex resolve that outruns the `AUTH_SETTLE_GRACE_MS` backstop clamps a Pro session once — permanently.

The sort is `(priority asc, key asc)`, so at a flat priority the **alphabetically last** keys go over the cliff first. That is why late-alphabet panels are the ones that vanish. `trade-policy` is a real instance, which is how this was found.

## Fix

Stamp `proGated` on the count-cap disable too, so the existing targeted restore covers it.

Deliberately **not** a blanket restore: a panel the user hid themselves carries no marker and stays hidden. The test asserts both directions.

## Reproduced before fixing

The new test fails on pre-fix code with:

```
p40 was disabled by the free-tier cap, not by the user — going Pro must put it back
```

and passes after. Both mutations die:

| Mutation | Result |
|---|---|
| remove the `proGated` stamp | reddens the new test |
| restore regardless of the marker | reddens the user-hidden assertion *and* the existing cw-* test |

That second one matters — it proves the fix cannot degrade into an enable-everything.

## Verification

- 131 config / gate / entitlement tests pass
- 227 DOM tests pass (`npm run test:dom` — these are vitest, not `node:test`)
- `typecheck` and `biome` clean

## Known limitation — pre-fix damage is not healed

Entries clamped by a **pre-fix** build carry no marker at all, so the targeted restore cannot find them. Those users must re-enable the panel manually in Settings.

A one-time recovery sweep was considered and deliberately **not** included. The codebase solved the analogous widget case with an ownership set (`loadWidgets()` ids) plus a once-per-browser marker — regular panels have no equivalent discriminator. A deliberate user hide and pre-fix gate damage are both `enabled: false` with no marker, so a blanket sweep would silently un-hide panels users chose to hide, and that is not discoverable to them. Manual re-enable is the discoverable failure mode; a wrong sweep is the silent one.

If we want the sweep anyway, the least-bad fingerprint is "Pro user whose enabled counted-panel total is exactly `FREE_MAX_PANELS`", gated once per browser — but it would still misfire on a user who curated exactly 40. Worth a separate decision rather than smuggling it in here.

## Related

Found while verifying #6309's flows tab could not be observed in the UI.

https://claude.ai/code/session_01HtWFnQiBWN1SWtjp4AhT4C
