### PR TITLE
fix(panels): transfer gate ownership on every user toggle (follow-up to #6337)

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -843,7 +843,11 @@ export class App {
       const newVariantKeys = new Set(VARIANT_DEFAULTS[currentVariant] ?? []);
       for (const key of Object.keys(panelSettings)) {
         if (!newVariantKeys.has(key) && !isDynamicPanel(key) && panelSettings[key]) {
-          panelSettings[key] = { ...panelSettings[key]!, enabled: false };
+          // Variant reset asserts its own ownership over `enabled`, so drop any
+          // stale gate marker — otherwise the next Pro reconcile re-enables a
+          // panel this reset deliberately turned off.
+          const { proGated: _staleGateMarker, ...rest } = panelSettings[key]!;
+          panelSettings[key] = { ...rest, enabled: false };
         }
       }
       for (const key of newVariantKeys) {

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -18,6 +18,7 @@ import {
   FREE_MAX_SOURCES,
   countFreePanelCapUsage,
   isFreePanelCapCounted,
+  userSetPanelEnabled,
 } from '@/config/panels';
 import type { McpDataPanel } from '@/components/McpDataPanel';
 import { deleteMcpPanel, getMcpPanel, saveMcpPanel } from '@/services/mcp-store';
@@ -340,7 +341,7 @@ export class EventHandlerManager implements AppModule {
         return false;
       }
     }
-    config.enabled = true;
+    userSetPanelEnabled(config, true);
     trackPanelToggled(panelId, true);
     saveToStorage(STORAGE_KEYS.panels, this.ctx.panelSettings);
     this.applyPanelSettings();
@@ -637,7 +638,7 @@ export class EventHandlerManager implements AppModule {
 
       const config = this.ctx.panelSettings[panelId];
       if (!config) return;
-      config.enabled = false;
+      userSetPanelEnabled(config, false);
       // Live-media teardown is handled centrally by applyPanelSettings() below, which
       // calls stopLiveMediaForClose() on every now-disabled panel. Calling it here too
       // double-fired the lifecycle hook for live-news / live-webcams.
@@ -1787,10 +1788,14 @@ export class EventHandlerManager implements AppModule {
             trackPanelToggled(key, nextConfig.enabled);
             return;
           }
-          if (current.enabled !== nextConfig.enabled) {
+          const enabledChanged = current.enabled !== nextConfig.enabled;
+          if (enabledChanged) {
             trackPanelToggled(key, nextConfig.enabled);
           }
           Object.assign(current, nextConfig);
+          // Object.assign cannot DELETE a key, so a stale gate marker would
+          // survive a settings-driven toggle. Re-apply through the owner helper.
+          if (enabledChanged) userSetPanelEnabled(current, nextConfig.enabled);
         });
         saveToStorage(STORAGE_KEYS.panels, this.ctx.panelSettings);
         this.applyPanelSettings();

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -66,6 +66,7 @@ export {
   isFreePanelCapCounted,
   restoreFreeMapPanelAccess,
   restoreProGatedPanels,
+  userSetPanelEnabled,
   shouldDeferFreeTierEnforcement,
   FREE_MAX_PANELS,
   FREE_MAX_SOURCES,

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1312,6 +1312,25 @@ export function enforceFreePanelLimit(
 }
 
 /**
+ * Apply a USER-initiated enable/disable to a panel config.
+ *
+ * Every user toggle path must go through this. `proGated` means "the GATE owns
+ * this disable"; the moment the user takes a position on the panel themselves,
+ * the gate no longer owns it and the marker must go — otherwise a panel the
+ * gate once clamped keeps the marker through a user re-enable, and a LATER
+ * deliberate hide is indistinguishable from gate damage, so the next Pro
+ * reconcile resurrects a panel the user chose to hide (and cloud-syncs that to
+ * every device).
+ *
+ * Mutates in place: every call site already owns a live entry in the
+ * panelSettings map it is about to persist.
+ */
+export function userSetPanelEnabled(config: PanelConfig, enabled: boolean): void {
+  config.enabled = enabled;
+  delete config.proGated;
+}
+
+/**
  * Inverse of the cw-* half of `enforceFreePanelLimit`: re-enable the custom
  * widgets that the free-tier gate hid, and clear the marker.
  *

--- a/src/settings-window.ts
+++ b/src/settings-window.ts
@@ -12,6 +12,7 @@ import {
   isPanelEntitled,
   FREE_MAX_PANELS,
   countFreePanelCapUsage,
+  userSetPanelEnabled,
   isFreePanelCapCounted,
 } from '@/config';
 import { isProUser } from '@/services/widget-store';
@@ -94,7 +95,7 @@ export function initSettingsWindow(): void {
               const enabledCount = countFreePanelCapUsage(panelSettings);
               if (enabledCount >= FREE_MAX_PANELS) return;
             }
-            config.enabled = !config.enabled;
+            userSetPanelEnabled(config, !config.enabled);
             saveToStorage(STORAGE_KEYS.panels, panelSettings);
             render();
           }

--- a/tests/panel-variant-config.test.mts
+++ b/tests/panel-variant-config.test.mts
@@ -14,6 +14,7 @@ import {
   restoreFreeMapPanelAccess,
   restoreProGatedPanels,
   shouldDeferFreeTierEnforcement,
+  userSetPanelEnabled,
 } from '../src/config/panels.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -203,6 +204,39 @@ describe('variant panel config resolution', () => {
     );
     assert.equal(restoreProGatedPanels(userHidden).p00?.enabled, false,
       'a deliberately hidden panel must stay hidden');
+  });
+
+  it('a user toggle takes ownership: a later deliberate hide survives going Pro', () => {
+    // The marker means "the GATE owns this disable". If it survives a USER
+    // re-enable, a later deliberate hide is indistinguishable from gate damage
+    // and the next Pro reconcile resurrects a panel the user chose to hide —
+    // then cloud-syncs that resurrection to every device.
+    //
+    // The over-cap fixture above hides its panel BEFORE the clamp, so the
+    // marker is never set on it. This covers the real sequence: clamp, user
+    // re-enables, user later hides.
+    const original: Record<string, { name: string; enabled: boolean; priority: number }> = {};
+    for (let i = 0; i < FREE_MAX_PANELS + 1; i += 1) {
+      const key = `q${String(i).padStart(2, '0')}`;
+      original[key] = { name: key, enabled: true, priority: 1 };
+    }
+    const clampedKey = Object.keys(original)[FREE_MAX_PANELS]!;
+
+    const clamped = enforceFreePanelLimit(original, false);
+    assert.equal(clamped[clampedKey]?.enabled, false);
+    assert.equal(clamped[clampedKey]?.proGated, true, 'the gate owns this disable');
+
+    // 1. User re-enables it themselves (Cmd+K, settings toggle, undo-close).
+    userSetPanelEnabled(clamped[clampedKey]!, true);
+    assert.equal(clamped[clampedKey]?.proGated, undefined,
+      'a user toggle transfers ownership away from the gate — the marker must go');
+
+    // 2. Later, the user deliberately hides it.
+    userSetPanelEnabled(clamped[clampedKey]!, false);
+
+    // 3. Going Pro must NOT resurrect it.
+    assert.equal(restoreProGatedPanels(clamped)[clampedKey]?.enabled, false,
+      'a panel the user hid after re-enabling it must stay hidden');
   });
 
   it('defers free-tier enforcement until both Clerk and the entitlement snapshot settle', () => {


### PR DESCRIPTION
## Follow-up to #6337 — that fix created new exposure

#6337 stamped `proGated` on count-cap disables so the Pro restore could find them. An adversarial review of that diff found a **P1** it introduced. #6337 merged before this landed, so **main currently carries the incomplete version**.

`proGated` means *"the GATE owns this disable"* — that is the entire safety argument for restoring marked panels on upgrade. But no user-toggle path cleared it, and stamping regular panels made the marked-**enabled** state durable:

| step | state |
|---|---|
| free clamp stamps an over-cap panel | `{enabled: false, proGated: true}` |
| user re-enables it (Cmd+K / settings / undo-close) | `{enabled: true, proGated: true}` |
| user later **deliberately hides** it | `{enabled: false, proGated: true}` |
| Pro reconcile | **resurrects it**, and cloud-syncs that to every device |

Step 3 is now indistinguishable from gate damage, so the restore silently undoes a choice the user made.

**Why #6337 made this reachable.** Pre-#6337 only `cw-*` entries carried the marker, and for those the marked-enabled state is unreachable in practice: free enforcement re-disables any enabled `cw-*` on the next pass, and X-close *deletes* the entry rather than disabling it. Count-cap panels have neither escape hatch — routine toggle paths, durable state, and legitimate user hides.

**My own test missed it.** The user-hidden fixture in #6337 hides its panel *before* the clamp, so the marker was never set on it. The new test covers the real sequence: clamp → user re-enable → user hide.

## Fix

Route every user-initiated write through `userSetPanelEnabled(config, enabled)`, which clears the marker:

- `enablePanelById` (`event-handlers.ts`)
- the `wm:panel-close` handler
- the `savePanelSettings` merge — `Object.assign` **cannot delete a key**, so the marker survived a settings toggle regardless of what the UI passed back
- the settings-window toggle

Also clears the marker on the **variant-switch reset** (review F2, P3): that reset asserts its own ownership over `enabled`, so a stale marker let the next Pro reconcile re-enable a panel the reset deliberately turned off.

## Reproduced before fixing

Red first, for the right reason:

```
a user toggle transfers ownership away from the gate — the marker must go
```

Mutation: removing the `delete config.proGated` reddens it again.

## Verification

- 154 config / gate / entitlement / preset tests pass
- 227 DOM tests pass
- `typecheck` clean; the single biome warning in `src/config/index.ts:131` is pre-existing (confirmed against a stashed tree)

## Review residuals carried forward (not addressed here)

- **Pre-#6337 damage stays unhealed.** Entries clamped by an older build carry no marker, and there is no safe discriminator between that and a deliberate hide — regular panels always exist, so the widget trick (ownership set) has no analogue. Documented rather than guessed at.
- **Clamp/restore ping-pong** between a device stuck on a free verdict and a healthy Pro device. Structurally pre-existing for `cw-*`; #6337 widened the oscillating set to any >40-panel account. Bounded when tiers agree.
- **Cosmetic:** `restoreProGatedCustomWidgets` and its log line are now misnomers — they restore count-cap panels too.

https://claude.ai/code/session_01HtWFnQiBWN1SWtjp4AhT4C
