### PR TITLE
fix(entitlements): restore all free-tier-owned preferences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 183
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         # 183 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (225 service modules and domain directories)
+│   ├── services/           # Business logic (226 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)
 │   ├── embed/              # Embeddable widget loader
 │   ├── styles/             # Global CSS (layers, themes, panel styles)

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -17,7 +17,7 @@
   },
   "variantCount": 6,
   "componentTopLevelTsFiles": 183,
-  "serviceTopLevelEntries": 225,
+  "serviceTopLevelEntries": 226,
   "apiEndpointEntries": 91,
   "panelClasses": 108,
   "protoFiles": 295,

--- a/src/App.ts
+++ b/src/App.ts
@@ -16,13 +16,16 @@ import {
   enforceFreePanelLimit,
   restoreFreeMapPanelAccess,
   restoreProGatedPanels,
+  userSetPanelEnabled,
   shouldDeferFreeTierEnforcement,
   FREE_MAX_PANELS,
   FREE_MAX_SOURCES,
 } from '@/config';
 import {
   sanitizeLayersForVariant,
-  sanitizeLockedLayers,
+  sanitizeLockedLayersWithOwnership,
+  restoreGateOwnedLockedLayers,
+  mapLayerStatesEqual,
   shouldSanitizeLockedLayers,
 } from '@/config/map-layer-definitions';
 import type { MapVariant } from '@/config/map-layer-definitions';
@@ -42,7 +45,15 @@ import { isProUser, isProTierResolved, loadWidgets } from '@/services/widget-sto
 import { mlWorker } from '@/services/ml-worker';
 import { getAiFlowSettings, subscribeAiFlowChange, isHeadlineMemoryEnabled } from '@/services/ai-flow-settings';
 import { startLearning } from '@/services/country-instability';
-import { loadFromStorage, parseMapUrlState, saveToStorage, isMobileDevice, showToast } from '@/utils';
+import {
+  isMobileDevice,
+  isQuotaError,
+  loadFromStorage,
+  markStorageQuotaExceeded,
+  parseMapUrlState,
+  saveToStorage,
+  showToast,
+} from '@/utils';
 import { clearPanelSpans, invalidatePanelStorageCacheForKeys } from '@/utils/panel-storage';
 import { overlayHistory, type OverlayId } from '@/utils/overlay-history';
 import type { ParsedMapUrlState } from '@/utils';
@@ -107,8 +118,17 @@ import {
 import {
   computeCapDisabledSources,
   findFullyDisabledCategories,
+  inferExactSourceGateOwnership,
+  reconcileSourceGateOwnership,
+  restoreGateOwnedSources,
   selectSourcesUnderCap,
+  stringSetsEqual,
 } from '@/services/source-cap';
+import {
+  applyVariantPanelLayoutTransition,
+  persistGateOwnershipTransition,
+  resolveAppliedPanelLayoutVariant,
+} from '@/services/variant-panel-ownership';
 import {
   buildPreStrategicDefaultDisabledStates,
   buildRegionalFeedRolloutMigrationTargets,
@@ -142,6 +162,7 @@ import {
 } from '@/app/free-tier-gate';
 import { replaceRawI18nKeyPlaceholders } from '@/app/i18n-raw-key-healer';
 import { startAccountAuthHandoff } from '@/app/account-auth-handoff';
+import { TierPreferenceHandoff } from '@/app/tier-preference-handoff';
 import { resolveUserRegion, resolvePreciseUserCoordinates, type PreciseCoordinates } from '@/utils/user-location';
 import { showProBanner } from '@/components/ProBanner';
 import { getAuthState, initAuthState, subscribeAuthState } from '@/services/auth-state';
@@ -265,6 +286,7 @@ export class App {
   private bootstrapHydrationState: BootstrapHydrationState = getBootstrapHydrationState();
   private cachedModeBannerEl: HTMLElement | null = null;
   private pendingCloudRecoverySyncVersion: number | undefined;
+  private readonly tierPreferenceHandoff = new TierPreferenceHandoff();
   private readonly handleWmSessionDegraded = (event?: Event): void => {
     if (!this.state.isDestroyed) {
       // Pre-#5674 bundles in long-lived tabs can still dispatch a plain Event
@@ -327,6 +349,7 @@ export class App {
 
     const keySet = new Set(keys);
     let freeTierLimitsInvoked = false;
+    const tierReconciliationDeferred = this.shouldDeferTierPreferenceReconciliation();
     invalidatePanelStorageCacheForKeys(keys);
 
     if (keySet.has(STORAGE_KEYS.panels)) {
@@ -347,8 +370,10 @@ export class App {
       // Returns false while the tier is still unresolved — the fallback below
       // then just re-renders the snapshot, which is all this handler did
       // before reconciliation moved here.
-      const reconciledPanelSettings = this.enforceFreeTierLimits(cloudSyncVersion);
-      freeTierLimitsInvoked = true;
+      const reconciledPanelSettings = tierReconciliationDeferred
+        ? false
+        : this.enforceFreeTierLimits(cloudSyncVersion);
+      freeTierLimitsInvoked = !tierReconciliationDeferred;
       if (!reconciledPanelSettings) {
         this.panelLayout.applyPanelSettings();
         this.state.unifiedSettings?.refreshPanelToggles();
@@ -360,7 +385,10 @@ export class App {
       this.panelLayout.applySavedPanelOrder();
     }
 
-    if (keySet.has(STORAGE_KEYS.mapLayers) && !this.state.initialUrlState?.layers) {
+    if (
+      (keySet.has(STORAGE_KEYS.mapLayers) || keySet.has(STORAGE_KEYS.mapLayerGateOwnership))
+      && !this.state.initialUrlState?.layers
+    ) {
       let nextLayers = normalizeExclusiveChoropleths(
         sanitizeLayersForVariant(
           loadFromStorage<MapLayers>(STORAGE_KEYS.mapLayers, this.state.mapLayers),
@@ -371,11 +399,15 @@ export class App {
       // #6045 — clear locked premium layers once free-tier is settled.
       // Skip while entitlement is still resolving so Pro users don't lose
       // resilienceScore during the Clerk/Convex boot window.
-      nextLayers = this.sanitizeMapLayersForTier(nextLayers);
+      if (!tierReconciliationDeferred) {
+        nextLayers = this.sanitizeMapLayersForTier(nextLayers);
+      }
       if (!CYBER_LAYER_ENABLED) nextLayers.cyberThreats = false;
-      this.state.mapLayers = nextLayers;
-      this.state.map?.setLayers(nextLayers);
-      this.dataLoader.syncDataFreshnessWithLayers();
+      if (!mapLayerStatesEqual(this.state.mapLayers, nextLayers)) {
+        this.state.mapLayers = nextLayers;
+        this.state.map?.setLayers(nextLayers);
+        this.dataLoader.syncDataFreshnessWithLayers();
+      }
     }
 
     if (keySet.has(STORAGE_KEYS.mapMode)) {
@@ -384,11 +416,16 @@ export class App {
       else this.state.map?.switchToFlat();
     }
 
-    if (keySet.has(STORAGE_KEYS.disabledFeeds)) {
+    if (
+      keySet.has(STORAGE_KEYS.disabledFeeds)
+      || keySet.has(STORAGE_KEYS.sourceGateOwnership)
+    ) {
       // A cloud generation can contain only source preferences. Re-run the
       // cap even when no panel snapshot arrived, then reload storage because
       // enforcement may have persisted additional auto-disabled sources.
-      if (!freeTierLimitsInvoked) this.enforceFreeTierLimits(cloudSyncVersion);
+      if (!tierReconciliationDeferred && !freeTierLimitsInvoked) {
+        this.enforceFreeTierLimits(cloudSyncVersion);
+      }
       this.state.disabledSources = new Set(loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []));
     }
 
@@ -809,10 +846,19 @@ export class App {
     const isDynamicPanel = (k: string) => !ALL_PANELS[k] && (k === 'runtime-config' || k.startsWith('cw-') || k.startsWith('mcp-'));
 
     const currentVariant = SITE_VARIANT;
-    let storedVariant: string | null = null;
+    let appliedPanelLayoutVariant: string | null = null;
     let storageAvailable = true;
     try {
-      storedVariant = localStorage.getItem('worldmonitor-variant');
+      appliedPanelLayoutVariant = resolveAppliedPanelLayoutVariant({
+        appliedVariant: localStorage.getItem(STORAGE_KEYS.panelLayoutVariant),
+        legacyVariant: localStorage.getItem(STORAGE_KEYS.variant),
+        currentVariant,
+        validVariants: new Set(Object.keys(VARIANT_DEFAULTS)),
+        persistAppliedVariant: (variant) => {
+          localStorage.setItem(STORAGE_KEYS.panelLayoutVariant, variant);
+          return true;
+        },
+      });
       const probeKey = 'wm-storage-capability-probe';
       localStorage.setItem(probeKey, '1');
       localStorage.removeItem(probeKey);
@@ -827,34 +873,33 @@ export class App {
         sanitizeLayersForVariant({ ...defaultLayers }, currentVariant as MapVariant), null,
       );
       panelSettings = { ...DEFAULT_PANELS };
-    } else if (storedVariant !== currentVariant) {
+    } else if (appliedPanelLayoutVariant !== currentVariant) {
       // Variant changed - reset all settings to variant defaults.
-      console.log(`[App] Variant check: stored="${storedVariant}", current="${currentVariant}"`);
+      console.log(`[App] Variant check: applied="${appliedPanelLayoutVariant}", current="${currentVariant}"`);
       // Variant changed — seed new variant's panels, disable panels not in the new variant
       console.log('[App] Variant changed - seeding new defaults, disabling cross-variant panels');
-      localStorage.setItem('worldmonitor-variant', currentVariant);
       // Reset map layers for the new variant (map layers are not user-personalized the same way)
       localStorage.removeItem(STORAGE_KEYS.mapLayers);
+      localStorage.removeItem(STORAGE_KEYS.mapLayerGateOwnership);
       mapLayers = normalizeExclusiveChoropleths(
         sanitizeLayersForVariant({ ...defaultLayers }, currentVariant as MapVariant), null,
       );
       // Load existing panel prefs (if any), disable panels not belonging to the new variant
-      panelSettings = loadFromStorage<Record<string, PanelConfig>>(STORAGE_KEYS.panels, {});
       const newVariantKeys = new Set(VARIANT_DEFAULTS[currentVariant] ?? []);
-      for (const key of Object.keys(panelSettings)) {
-        if (!newVariantKeys.has(key) && !isDynamicPanel(key) && panelSettings[key]) {
-          // Variant reset asserts its own ownership over `enabled`, so drop any
-          // stale gate marker — otherwise the next Pro reconcile re-enables a
-          // panel this reset deliberately turned off.
-          const { proGated: _staleGateMarker, ...rest } = panelSettings[key]!;
-          panelSettings[key] = { ...rest, enabled: false };
-        }
-      }
-      for (const key of newVariantKeys) {
-        if (!(key in panelSettings)) {
-          panelSettings[key] = { ...getEffectivePanelConfig(key, currentVariant) };
-        }
-      }
+      panelSettings = applyVariantPanelLayoutTransition({
+        currentVariant,
+        panelSettings: loadFromStorage<Record<string, PanelConfig>>(STORAGE_KEYS.panels, {}),
+        variantPanelKeys: newVariantKeys,
+        isDynamicPanel,
+        getDefaultPanel: (key) => getEffectivePanelConfig(key, currentVariant),
+        // Use the throwing primitive here so the transition helper advances
+        // the applied-layout marker only after the panel blob is durable.
+        persistPanels: (next) => localStorage.setItem(STORAGE_KEYS.panels, JSON.stringify(next)),
+        persistAppliedVariant: (variant) => localStorage.setItem(STORAGE_KEYS.panelLayoutVariant, variant),
+      });
+      // Keep the legacy selected-variant key for bootstrap/theme consumers.
+      // The applied-layout marker above advances only after panels persist.
+      localStorage.setItem(STORAGE_KEYS.variant, currentVariant);
     } else {
       mapLayers = normalizeExclusiveChoropleths(
         sanitizeLayersForVariant(
@@ -942,8 +987,14 @@ export class App {
         const happyKeys = new Set(VARIANT_DEFAULTS['happy'] ?? []);
         let fixed = false;
         for (const key of Object.keys(panelSettings)) {
-          if (!happyKeys.has(key) && !isDynamicPanel(key) && panelSettings[key]?.enabled) {
-            panelSettings[key] = { ...panelSettings[key]!, enabled: false };
+          const config = panelSettings[key];
+          if (
+            !happyKeys.has(key)
+            && !isDynamicPanel(key)
+            && config
+            && (config.enabled || config.proGated)
+          ) {
+            userSetPanelEnabled(config, false);
             fixed = true;
           }
         }
@@ -1076,9 +1127,7 @@ export class App {
         const total = getTotalFeedCount();
         console.log(`[App] Sources reduction: ${defaultDisabled.length} disabled, ${total - defaultDisabled.length} enabled`);
       }
-      let explicitLocale = '';
-      try { explicitLocale = localStorage.getItem('wm-locale-explicit') || ''; } catch { /* private mode */ }
-      const userLang = ((explicitLocale || navigator.language || 'en').split('-')[0] ?? 'en').toLowerCase();
+      const userLang = this.currentSourceCapLanguage();
       // #5949 — re-enable Ukraine/Poland frontline sources for profiles that
       // still have the untouched pre-#5949 default disabled set. An exact-set
       // guard is important here: a customized disabledFeeds set is user
@@ -1726,12 +1775,10 @@ export class App {
     // watched subscribeAuthState (Clerk-only); Convex Free→Pro transitions
     // never re-fired loadTradePolicy. Same root cause as PR #3409 layer-unlock.
     const firePremiumLoaders = (): void => {
-      this.enforceFreeTierLimits();
-      // Stored dashboard-tab snapshots are clamped by their own pass at layout
-      // init, which runs inside the same unresolved-tier window. Re-heal them
-      // here so a tab the user hasn't visited yet is reconciled against the
-      // real entitlement instead of waiting for them to switch to it.
-      this.panelLayout.healStoredTabSnapshots();
+      // Account sign-in replaces anonymous/local preferences asynchronously.
+      // Entitlement callbacks may arrive first; defer every ownership mutation
+      // until cloud prefs signals success or error for this same account.
+      this.reconcileTierOwnedPreferences();
       const hadPremium = _prevHadPremium;
       const nowPremium = hasPremiumAccess();
       if (nowPremium && !hadPremium) {
@@ -1759,11 +1806,6 @@ export class App {
         // after sign-out, expiry, or downgrade.
         void this.dataLoader.clearGlobalTenders();
       }
-      // #6045 — when free-tier is settled, strip locked layers from map state
-      // (heals stuck checked+disabled checkbox from pre-gate CMD+K, and clears
-      // layers on Pro→free downgrade). The fallback deadline is an explicit
-      // settled-free signal when Clerk never resolves.
-      if (!nowPremium) this.healLockedMapLayers(this.freeTierGate.authSettleDeadlineExceeded);
       _prevHadPremium = nowPremium;
     };
     this.unsubEntitlementPremiumLoaders = onEntitlementChange(() => firePremiumLoaders());
@@ -1783,6 +1825,7 @@ export class App {
 
       if (userId !== null && userId !== _prevUserId) {
         const handoffGeneration = ++_convexWatchHandoffGeneration;
+        this.tierPreferenceHandoff.begin(userId);
 
         // Rebind Convex watches to the real Clerk userId (was bound to anon UUID at init)
         // destroyEntitlementSubscription deliberately PRESERVES the last
@@ -1807,7 +1850,21 @@ export class App {
             rebindConvexAuthForWatchHandoff,
             initEntitlementSubscription,
             initSubscriptionWatch,
-            cloudPrefsSignIn: (nextUserId) => cloudPrefsSignIn(nextUserId, SITE_VARIANT),
+            cloudPrefsSignIn: (nextUserId) => {
+              const completion = cloudPrefsSignIn(nextUserId, SITE_VARIANT);
+              const finishPreferenceHandoff = (): void => {
+                const currentUserId = getAuthState().user?.id ?? null;
+                if (this.tierPreferenceHandoff.complete(nextUserId, currentUserId)) {
+                  this.reconcileTierOwnedPreferences();
+                }
+              };
+              // Use both branches instead of `finally`: the promise returned
+              // by `finally` would mirror a rejection and become unhandled
+              // because startAccountAuthHandoff intentionally fire-and-forgets
+              // this effect.
+              void completion.then(finishPreferenceHandoff, finishPreferenceHandoff);
+              return completion;
+            },
           },
         });
 
@@ -1915,6 +1972,7 @@ export class App {
         destroySubscriptionWatch();
         cloudPrefsSignOut();
         resetEntitlementState();
+        this.tierPreferenceHandoff.clear();
       }
       _prevUserId = userId;
       // Run after account handoff/reset so this pass cannot enforce the
@@ -2112,12 +2170,38 @@ export class App {
     this.eventHandlers.setupPanelViewTracking();
   }
 
+  private shouldDeferTierPreferenceReconciliation(): boolean {
+    return this.tierPreferenceHandoff.shouldDefer(getAuthState().user?.id ?? null);
+  }
+
+  /** Reconcile all gate-owned preferences against one settled account view. */
+  private reconcileTierOwnedPreferences(): boolean {
+    if (this.shouldDeferTierPreferenceReconciliation()) return false;
+    this.enforceFreeTierLimits();
+    // Stored dashboard-tab snapshots have their own panel copies.
+    this.panelLayout.healStoredTabSnapshots();
+    this.healLockedMapLayers(this.freeTierGate.authSettleDeadlineExceeded);
+    return true;
+  }
+
+  private persistJsonStorageValue<T>(key: string, value: T): boolean {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+      return true;
+    } catch (error) {
+      if (isQuotaError(error)) markStorageQuotaExceeded();
+      else console.warn(`Failed to save ${key} to storage:`, error);
+      return false;
+    }
+  }
+
   /**
    * Grace-timer state for the free-tier gate. Lives in a collaborator so the
    * backstop can be driven by tests; App itself is not importable from the
    * node:test suites.
    */
   private readonly freeTierGate = new FreeTierGate(() => {
+    if (this.shouldDeferTierPreferenceReconciliation()) return;
     this.enforceFreeTierLimits();
     this.panelLayout.healStoredTabSnapshots();
     // Clerk can remain pending forever when its script or key is unavailable.
@@ -2134,16 +2218,56 @@ export class App {
   private sanitizeMapLayersForTier(
     layers: MapLayers,
     fallbackActive = this.freeTierGate.authSettleDeadlineExceeded,
+    options: { consumeProOwnership?: boolean } = {},
   ): MapLayers {
-    if (!shouldSanitizeLockedLayers(
-      hasPremiumAccess(),
-      isProTierResolved(),
-      fallbackActive,
-    )) return layers;
+    const consumeProOwnership = options.consumeProOwnership ?? true;
+    const premium = hasPremiumAccess();
+    const existingOwnership = new Set(
+      loadFromStorage<string[]>(STORAGE_KEYS.mapLayerGateOwnership, []),
+    );
 
-    const healed = sanitizeLockedLayers(layers, false);
-    if (healed !== layers) saveToStorage(STORAGE_KEYS.mapLayers, healed);
-    return healed;
+    if (premium) {
+      if (existingOwnership.size === 0) return layers;
+      const restored = sanitizeLayersForVariant(
+        restoreGateOwnedLockedLayers(layers, existingOwnership),
+        SITE_VARIANT as MapVariant,
+      );
+      if (!consumeProOwnership) {
+        if (restored === layers) return layers;
+        return this.persistJsonStorageValue(STORAGE_KEYS.mapLayers, restored)
+          ? restored
+          : layers;
+      }
+      const persistence = persistGateOwnershipTransition(
+        'pro',
+        () => restored === layers
+          || this.persistJsonStorageValue(STORAGE_KEYS.mapLayers, restored),
+        () => this.persistJsonStorageValue(STORAGE_KEYS.mapLayerGateOwnership, []),
+      );
+      return persistence.preferencePersisted ? restored : layers;
+    }
+
+    if (!shouldSanitizeLockedLayers(premium, isProTierResolved(), fallbackActive)) {
+      return layers;
+    }
+
+    const reconciled = sanitizeLockedLayersWithOwnership(layers, existingOwnership);
+    const ownershipChanged = !stringSetsEqual(existingOwnership, reconciled.gateOwned);
+    persistGateOwnershipTransition(
+      'free',
+      () => reconciled.layers === layers
+        || this.persistJsonStorageValue(STORAGE_KEYS.mapLayers, reconciled.layers),
+      () => !ownershipChanged
+        || this.persistJsonStorageValue(
+          STORAGE_KEYS.mapLayerGateOwnership,
+          [...reconciled.gateOwned],
+        ),
+    );
+    // Entitlement is a live safety boundary: blocked/quota-limited storage
+    // must not leave a locked layer rendered. The ordered writes above retain
+    // enough durable state to retry without ever persisting the destructive
+    // preference before ownership.
+    return reconciled.layers;
   }
 
   /** Heal the live map and persisted state after a downgrade or free fallback. */
@@ -2152,7 +2276,11 @@ export class App {
   ): void {
     const initialUrlLayers = this.state.initialUrlState?.layers;
     if (initialUrlLayers) {
-      const healedUrlLayers = this.sanitizeMapLayersForTier(initialUrlLayers, fallbackActive);
+      const healedUrlLayers = this.sanitizeMapLayersForTier(
+        initialUrlLayers,
+        fallbackActive,
+        { consumeProOwnership: false },
+      );
       if (healedUrlLayers !== initialUrlLayers && this.state.initialUrlState) {
         this.state.initialUrlState.layers = healedUrlLayers;
       }
@@ -2174,7 +2302,7 @@ export class App {
    * by a pre-fix build (see the one-time recovery below — those entries
    * pre-date the `proGated` marker, so they need the sweep).
    */
-  private restoreProGatedCustomWidgets(cloudSyncVersion?: number): boolean {
+  private restoreProGatedPanelsForTier(cloudSyncVersion?: number): boolean {
     const panelSettings = loadFromStorage<Record<string, PanelConfig>>(STORAGE_KEYS.panels, {});
     let restored = restoreProGatedPanels(panelSettings);
 
@@ -2250,6 +2378,106 @@ export class App {
     return true;
   }
 
+  private currentSourceCapLanguage(): string {
+    let explicitLocale = '';
+    try { explicitLocale = localStorage.getItem('wm-locale-explicit') || ''; } catch { /* private mode */ }
+    return ((explicitLocale || navigator.language || 'en').split('-')[0] ?? 'en').toLowerCase();
+  }
+
+  private sourceCapProtectedNames(userLang: string): Set<string> {
+    const protectedNames = new Set<string>(FREE_CAP_PROTECTED_SOURCES);
+    for (const name of getStrategicDefaultSources()) protectedNames.add(name);
+    if (userLang !== 'en') {
+      for (const name of getLocaleBoostedSources(userLang)) protectedNames.add(name);
+    }
+    return protectedNames;
+  }
+
+  /** Reconcile or restore the persisted 80-source cap without losing user intent. */
+  private reconcileSourceLimitForTier(pro: boolean): boolean {
+    let ownershipMetadataExists = false;
+    try {
+      ownershipMetadataExists = localStorage.getItem(STORAGE_KEYS.sourceGateOwnership) !== null;
+    } catch { /* optional persistence */ }
+    const persistedDisabled = new Set(
+      loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []),
+    );
+    const persistedGateOwned = new Set(
+      loadFromStorage<string[]>(STORAGE_KEYS.sourceGateOwnership, []),
+    );
+    let gateOwned = new Set(persistedGateOwned);
+    const userLang = this.currentSourceCapLanguage();
+    const protectedNames = this.sourceCapProtectedNames(userLang);
+
+    // Heal untouched profiles capped before ownership metadata existed. Exact
+    // matching preserves every customized denylist.
+    if (!ownershipMetadataExists) {
+      const defaultUserDisabled = new Set(computeDefaultDisabledSources(userLang));
+      const expectedGateOwned = selectSourcesUnderCap(
+        FEEDS,
+        INTEL_SOURCES,
+        defaultUserDisabled,
+        FREE_MAX_SOURCES,
+        protectedNames,
+      ).autoDisabled;
+      gateOwned = inferExactSourceGateOwnership(
+        persistedDisabled,
+        defaultUserDisabled,
+        expectedGateOwned,
+      ) ?? gateOwned;
+    }
+
+    let nextDisabled: Set<string>;
+    let nextGateOwned: Set<string>;
+    if (pro) {
+      nextDisabled = restoreGateOwnedSources(persistedDisabled, gateOwned);
+      nextGateOwned = new Set();
+    } else {
+      const userDisabled = restoreGateOwnedSources(persistedDisabled, gateOwned);
+      const nextAutoDisabled = selectSourcesUnderCap(
+        FEEDS,
+        INTEL_SOURCES,
+        userDisabled,
+        FREE_MAX_SOURCES,
+        protectedNames,
+      ).autoDisabled;
+      const reconciled = reconcileSourceGateOwnership(
+        userDisabled,
+        nextAutoDisabled,
+      );
+      nextDisabled = reconciled.disabled;
+      nextGateOwned = reconciled.gateOwned;
+    }
+
+    const disabledChanged = !stringSetsEqual(persistedDisabled, nextDisabled);
+    const ownershipChanged = !ownershipMetadataExists
+      || !stringSetsEqual(persistedGateOwned, nextGateOwned);
+    const persistence = persistGateOwnershipTransition(
+      pro ? 'pro' : 'free',
+      () => !disabledChanged
+        || this.persistJsonStorageValue(STORAGE_KEYS.disabledFeeds, [...nextDisabled]),
+      () => !ownershipChanged
+        || this.persistJsonStorageValue(
+          STORAGE_KEYS.sourceGateOwnership,
+          [...nextGateOwned],
+        ),
+    );
+    const disabledPersisted = disabledChanged && persistence.preferencePersisted;
+    const ownershipPersisted = ownershipChanged && persistence.ownershipPersisted;
+    if (disabledChanged) {
+      // The live entitlement boundary must not depend on localStorage health.
+      // Durable writes remain ordered/retryable above, but free users stay
+      // capped and Pro users unlock immediately even when quota is exhausted.
+      this.state.disabledSources = new Set(nextDisabled);
+    }
+    if (disabledPersisted || ownershipPersisted) {
+      console.log(pro
+        ? `[App] Pro: restored ${gateOwned.size} source(s) disabled by the free-tier gate`
+        : `[App] Free tier: reconciled ${nextGateOwned.size} gate-owned source disable(s)`);
+    }
+    return disabledPersisted || ownershipPersisted;
+  }
+
   /**
    * Enforce free-tier panel and source limits.
    * Reads current values from storage, trims if necessary, and saves back.
@@ -2288,7 +2516,9 @@ export class App {
 
     if (isProUser()) {
       this.freeTierGate.cancelFallback();
-      return this.restoreProGatedCustomWidgets(cloudSyncVersion);
+      const panelsChanged = this.restoreProGatedPanelsForTier(cloudSyncVersion);
+      this.reconcileSourceLimitForTier(true);
+      return panelsChanged;
     }
 
     // Pro/free is NOT knowable yet on an auth-enabled page load. initAuthState()
@@ -2373,63 +2603,7 @@ export class App {
       console.log(`[App] Free tier: enforced ${FREE_MAX_PANELS}-panel limit (disabled over-cap / cw-* panels)`);
     }
 
-    // --- Source limit ---
-    // Free-tier 80-source cap. Pre-2026-05-01 this used `Array.sort().slice()`
-    // which silently auto-disabled every source past alphabetical position 80,
-    // catastrophically erasing late-alphabet categories (Layoffs, Semiconductors,
-    // IPO & SPAC, Funding & VC, Product Hunt, …) and producing the "All sources
-    // disabled" red panel state on the homepage with no user explanation.
-    // Replaced with round-robin per-category distribution from `selectSourcesUnderCap`.
-    // (v1-bug recovery for stuck localStorage state is handled once at the top
-    // of this function via the schema-version migration.)
-    const disabledSources = new Set(loadFromStorage<string[]>(STORAGE_KEYS.disabledFeeds, []));
-    const totalEligible = (() => {
-      const s = new Set<string>();
-      Object.values(FEEDS).forEach((feeds) => feeds?.forEach((f) => s.add(f.name)));
-      INTEL_SOURCES.forEach((f) => s.add(f.name));
-      let count = 0;
-      for (const name of s) if (!disabledSources.has(name)) count++;
-      return count;
-    })();
-    if (totalEligible > FREE_MAX_SOURCES) {
-      // Protect locale-boosted sources from the cap. Without this, locale-
-      // tagged feeds that sit late in their category bucket (e.g. Hungarian
-      // entries in the Europe bucket, declared AFTER the existing en/de/it/
-      // nl/sv defaults) get round-robin'd out — the locale boost re-enables
-      // them, then the cap immediately auto-disables them again. Free-tier
-      // users on the boosted locale lose their locale's defaults entirely.
-      // userLang derivation mirrors the locale-boost migration (earlier in
-      // the App constructor) and the i18n.ts:99 `wmExplicit` detector:
-      // explicit Settings choice wins, navigator is the fallback. Direct
-      // localStorage read because i18next isn't initialized yet at the
-      // constructor stage where enforceFreeTierLimits also runs.
-      let explicitLocale = '';
-      try { explicitLocale = localStorage.getItem('wm-locale-explicit') || ''; } catch { /* private mode */ }
-      const userLang = ((explicitLocale || navigator.language || 'en').split('-')[0] ?? 'en').toLowerCase();
-      // Strategic defaults + locale-boosted sources (non-en) + editorially
-      // protected EN defaults. User-disabled names remain excluded by the cap
-      // helper, so strategic protection does not override explicit intent.
-      // Without frontline protection, free EN users lose Kyiv Independent / Meduza /
-      // Moscow Times to round-robin late-in-europe-bucket ordering; without the
-      // Eastern-flank additions, Daily Sabah / ERR News are also stripped (#5952).
-      const protectedNames = new Set<string>(FREE_CAP_PROTECTED_SOURCES);
-      for (const name of getStrategicDefaultSources()) protectedNames.add(name);
-      if (userLang !== 'en') {
-        for (const name of getLocaleBoostedSources(userLang)) protectedNames.add(name);
-      }
-      const { keep, autoDisabled } = selectSourcesUnderCap(FEEDS, INTEL_SOURCES, disabledSources, FREE_MAX_SOURCES, protectedNames);
-      // Defense in depth: feeds.ts has 35+ source names that appear in
-      // multiple category buckets. The helper guarantees keep ∩ autoDisabled
-      // = ∅, but a regression there would silently re-disable a kept source
-      // here. The keep.has() guard makes the cross-set invariant explicit
-      // at the caller too — if it ever fires it's a helper-bug signal.
-      for (const name of autoDisabled) {
-        if (!keep.has(name)) disabledSources.add(name);
-      }
-      saveToStorage(STORAGE_KEYS.disabledFeeds, Array.from(disabledSources));
-      this.state.disabledSources = new Set(disabledSources);
-      console.log(`[App] Free tier: round-robin disabled ${autoDisabled.size} source(s) to enforce ${FREE_MAX_SOURCES}-source limit (per-category fairness)`);
-    }
+    this.reconcileSourceLimitForTier(false);
     return panelsChanged;
   }
 

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -34,6 +34,7 @@ import type { PredictionPanel } from '@/components/PredictionPanel';
 import {
   buildMapUrl,
   debounce,
+  loadFromStorage,
   saveToStorage,
   getCurrentTheme,
   showToast,
@@ -108,6 +109,8 @@ import { buildEmbedIframeSnippet, buildEmbedMapUrl, type EmbedVariant } from '@/
 import { createSettingsButton } from '@/components/settings-button';
 import { overlayHistory, type OverlayId } from '@/utils/overlay-history';
 import { MobilePrimaryNav } from '@/app/mobile-primary-nav';
+import { stageVariantSelection } from '@/services/variant-panel-ownership';
+import { transferSourceGateOwnershipToUser as releaseSourceGateOwnership } from '@/services/source-cap';
 
 function readStorageValue(key: string): string | null {
   try {
@@ -117,11 +120,13 @@ function readStorageValue(key: string): string | null {
   }
 }
 
-function writeStorageValue(key: string, value: string): void {
+function writeStorageValue(key: string, value: string): boolean {
   try {
     localStorage.setItem(key, value);
+    return true;
   } catch {
     // UI preferences remain in memory for the current page.
+    return false;
   }
 }
 
@@ -1532,8 +1537,9 @@ export class EventHandlerManager implements AppModule {
     await this.exitFullscreenForNavigation();
 
     if (this.ctx.isDesktopApp || options.isLocalDev) {
-      writeStorageValue('worldmonitor-variant', variant);
-      window.location.reload();
+      if (stageVariantSelection(SITE_VARIANT, variant, writeStorageValue)) {
+        window.location.reload();
+      }
       return;
     }
 
@@ -1817,7 +1823,9 @@ export class EventHandlerManager implements AppModule {
         } else {
           this.ctx.disabledSources.add(name);
         }
-        saveToStorage(STORAGE_KEYS.disabledFeeds, Array.from(this.ctx.disabledSources));
+        if (this.transferSourceGateOwnershipToUser([name])) {
+          saveToStorage(STORAGE_KEYS.disabledFeeds, Array.from(this.ctx.disabledSources));
+        }
       },
       setSourcesEnabled: (names: string[], enabled: boolean) => {
         if (enabled && !isProUser()) {
@@ -1833,7 +1841,9 @@ export class EventHandlerManager implements AppModule {
           if (enabled) this.ctx.disabledSources.delete(name);
           else this.ctx.disabledSources.add(name);
         }
-        saveToStorage(STORAGE_KEYS.disabledFeeds, Array.from(this.ctx.disabledSources));
+        if (this.transferSourceGateOwnershipToUser(names)) {
+          saveToStorage(STORAGE_KEYS.disabledFeeds, Array.from(this.ctx.disabledSources));
+        }
       },
       getAllSourceNames: () => this.getAllSourceNames(),
       getLocalizedPanelName: (key: string, fallback: string) => this.getLocalizedPanelName(key, fallback),
@@ -2306,6 +2316,21 @@ export class EventHandlerManager implements AppModule {
     const lookup = `panels.${key}`;
     const localized = t(lookup);
     return localized === lookup ? fallback : localized;
+  }
+
+  private transferSourceGateOwnershipToUser(names: Iterable<string>): boolean {
+    const gateOwned = new Set(
+      loadFromStorage<string[]>(STORAGE_KEYS.sourceGateOwnership, []),
+    );
+    const nextGateOwned = releaseSourceGateOwnership(gateOwned, names);
+    if (nextGateOwned.size === gateOwned.size) return true;
+    // A deliberate source preference can only outlive the gate safely after
+    // ownership transfers. If this sidecar write fails, keep the live toggle
+    // for the session but do not persist a preference Pro could later undo.
+    return writeStorageValue(
+      STORAGE_KEYS.sourceGateOwnership,
+      JSON.stringify([...nextGateOwned]),
+    );
   }
 
   getAllSourceNames(): string[] {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1354,8 +1354,8 @@ export class PanelLayoutManager implements AppModule {
       name: t('dashboardTabs.newTabName'),
       // Same unresolved-tier caveat as applyTabPanelState: clamping a new tab
       // before the entitlement is known bakes a free-tier layout into a Pro
-      // user's workspace, and the count clamp carries no marker to undo. Once
-      // the bounded fallback fires, the tier is settled enough to clamp.
+      // user's workspace before its ownership marker can be safely reconciled.
+      // Once the bounded fallback fires, the tier is settled enough to clamp.
       panelSettings: this.isProTierResolvedOrFallback()
         ? enforceFreePanelLimit(defaults.panelSettings, isProUser())
         : defaults.panelSettings,

--- a/src/app/tier-preference-handoff.ts
+++ b/src/app/tier-preference-handoff.ts
@@ -1,0 +1,27 @@
+/**
+ * Tracks the account whose cloud preferences are replacing anonymous/local
+ * state. Tier reconciliation must not mutate that state until the handoff's
+ * success/error completion signal arrives.
+ */
+export class TierPreferenceHandoff {
+  private activeUserId: string | null = null;
+
+  begin(userId: string): void {
+    this.activeUserId = userId;
+  }
+
+  shouldDefer(currentUserId: string | null): boolean {
+    return currentUserId !== null && this.activeUserId === currentUserId;
+  }
+
+  /** Return true only when this completion still belongs to the active account. */
+  complete(userId: string, currentUserId: string | null): boolean {
+    if (this.activeUserId !== userId) return false;
+    this.activeUserId = null;
+    return currentUserId === userId;
+  }
+
+  clear(): void {
+    this.activeUserId = null;
+  }
+}

--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -502,6 +502,61 @@ export function sanitizeLockedLayers(
   return changed ? sanitized : layers;
 }
 
+export interface LockedLayerOwnershipResult {
+  layers: MapLayers;
+  gateOwned: Set<string>;
+}
+
+export function mapLayerStatesEqual(a: MapLayers, b: MapLayers): boolean {
+  const keys = Object.keys(a) as Array<keyof MapLayers>;
+  return keys.length === Object.keys(b).length && keys.every((key) => a[key] === b[key]);
+}
+
+/**
+ * Sanitize locked layers while remembering which enabled preferences the
+ * free-tier gate forced off. Existing ownership is retained across idempotent
+ * reconciliation passes where the persisted layer is already false.
+ */
+export function sanitizeLockedLayersWithOwnership(
+  layers: MapLayers,
+  existingGateOwned: ReadonlySet<string>,
+): LockedLayerOwnershipResult {
+  const gateOwned = new Set(
+    [...existingGateOwned].filter((key) => (
+      LAYER_REGISTRY[key as keyof MapLayers]?.premium === 'locked'
+    )),
+  );
+  for (const key of Object.keys(layers) as Array<keyof MapLayers>) {
+    if (layers[key] && LAYER_REGISTRY[key]?.premium === 'locked') {
+      gateOwned.add(key);
+    }
+  }
+  return {
+    layers: sanitizeLockedLayers(layers, false),
+    gateOwned,
+  };
+}
+
+/** Restore only valid premium layers previously disabled by the free gate. */
+export function restoreGateOwnedLockedLayers(
+  layers: MapLayers,
+  gateOwned: ReadonlySet<string>,
+): MapLayers {
+  let changed = false;
+  const restored = { ...layers };
+  for (const rawKey of gateOwned) {
+    const key = rawKey as keyof MapLayers;
+    // CII and resilience are mutually exclusive choropleths. Ownership can
+    // outlive a later user choice to enable CII while free; that stale marker
+    // must be consumed without overriding the newer CII preference.
+    if (key === 'resilienceScore' && restored.ciiChoropleth === true) continue;
+    if (LAYER_REGISTRY[key]?.premium !== 'locked' || restored[key] === true) continue;
+    restored[key] = true;
+    changed = true;
+  }
+  return changed ? restored : layers;
+}
+
 export const LAYER_SYNONYMS: Record<string, Array<keyof MapLayers>> = {
   aviation: ['flights'],
   flight: ['flights'],

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1331,8 +1331,8 @@ export function userSetPanelEnabled(config: PanelConfig, enabled: boolean): void
 }
 
 /**
- * Inverse of the cw-* half of `enforceFreePanelLimit`: re-enable the custom
- * widgets that the free-tier gate hid, and clear the marker.
+ * Inverse of `enforceFreePanelLimit`: re-enable panels the free-tier gate hid
+ * (custom widgets or count-cap overflow), and clear the marker.
  *
  * Without this the gate is a one-way door. `enforceFreePanelLimit` writes
  * straight into STORAGE_KEYS.panels, so once a widget is disabled nothing
@@ -1341,8 +1341,8 @@ export function userSetPanelEnabled(config: PanelConfig, enabled: boolean): void
  * widgets permanently missing from the dashboard even though the specs are
  * still in wm-custom-widgets.
  *
- * Only panels carrying `proGated` are touched, so a widget the user hid
- * deliberately via the settings toggle stays hidden.
+ * Only panels carrying `proGated` are touched, so a panel the user hid
+ * deliberately via settings stays hidden.
  */
 export function restoreProGatedPanels(
   panelSettings: Record<string, PanelConfig>,

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -99,10 +99,14 @@ export const MONITOR_COLORS = [
 
 // Storage keys - shared
 export const STORAGE_KEYS = {
+  variant: 'worldmonitor-variant',
   panels: 'worldmonitor-panels',
   monitors: 'worldmonitor-monitors',
   mapLayers: 'worldmonitor-layers',
   disabledFeeds: 'worldmonitor-disabled-feeds',
+  sourceGateOwnership: 'worldmonitor-free-tier-source-ownership',
+  mapLayerGateOwnership: 'worldmonitor-free-tier-layer-ownership',
+  panelLayoutVariant: 'worldmonitor-panel-layout-variant',
   // Schema version for the disabledFeeds set. Bumped on each migration that
   // mutates the set in a backwards-incompatible way. Currently:
   //   missing/0 → pre-2026-05-01 alphabetical-cap state. Eligible for

--- a/src/services/source-cap.ts
+++ b/src/services/source-cap.ts
@@ -29,6 +29,13 @@ export interface SourceCapResult {
   autoDisabled: Set<string>;
 }
 
+export interface SourceGateOwnershipResult {
+  /** Sources disabled by the current cap calculation. */
+  gateOwned: Set<string>;
+  /** Persisted denylist containing both user and gate-owned disables. */
+  disabled: Set<string>;
+}
+
 export interface SourceCapRolloutStage {
   /** Source names that first became configured in this release stage. */
   introducedNames: ReadonlySet<string>;
@@ -38,6 +45,63 @@ export interface SourceCapRolloutStage {
 
 export function canonicalStringSet(values: ReadonlySet<string>): string {
   return JSON.stringify([...values].sort());
+}
+
+export function stringSetsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const value of a) if (!b.has(value)) return false;
+  return true;
+}
+
+/**
+ * Replace the previous free-tier cap selection without confusing it with the
+ * user's own denylist. This makes repeated enforcement responsive to catalog,
+ * locale, and protection changes instead of permanently baking in the first
+ * 80-source selection.
+ */
+export function reconcileSourceGateOwnership(
+  userDisabled: ReadonlySet<string>,
+  nextGateOwned: ReadonlySet<string>,
+): SourceGateOwnershipResult {
+  const gateOwned = new Set(nextGateOwned);
+  return {
+    gateOwned,
+    disabled: new Set([...userDisabled, ...gateOwned]),
+  };
+}
+
+/** Restore only the source disables that the free-tier cap owned. */
+export function restoreGateOwnedSources(
+  persistedDisabled: ReadonlySet<string>,
+  gateOwned: ReadonlySet<string>,
+): Set<string> {
+  return new Set([...persistedDisabled].filter((name) => !gateOwned.has(name)));
+}
+
+/** A direct user source toggle transfers those names out of gate ownership. */
+export function transferSourceGateOwnershipToUser(
+  gateOwned: ReadonlySet<string>,
+  names: Iterable<string>,
+): Set<string> {
+  const next = new Set(gateOwned);
+  for (const name of names) next.delete(name);
+  return next;
+}
+
+/**
+ * Conservatively recover ownership for profiles capped before ownership was
+ * stored. Exact equality is required: one customized source leaves the blob
+ * untouched rather than guessing about user intent.
+ */
+export function inferExactSourceGateOwnership(
+  persistedDisabled: ReadonlySet<string>,
+  defaultUserDisabled: ReadonlySet<string>,
+  expectedGateOwned: ReadonlySet<string>,
+): Set<string> | null {
+  const expectedPersisted = new Set([...defaultUserDisabled, ...expectedGateOwned]);
+  return stringSetsEqual(persistedDisabled, expectedPersisted)
+    ? new Set(expectedGateOwned)
+    : null;
 }
 
 function filterFeedsToAvailable(

--- a/src/services/variant-panel-ownership.ts
+++ b/src/services/variant-panel-ownership.ts
@@ -1,0 +1,140 @@
+import type { PanelConfig } from '@/types';
+import { userSetPanelEnabled } from '@/config/panels';
+import { STORAGE_KEYS } from '@/config/variants/base';
+
+type StorageWriter = (key: string, value: string) => boolean | void;
+type PersistenceStep = () => boolean | void;
+
+export interface GateOwnershipPersistenceResult {
+  preferencePersisted: boolean;
+  ownershipPersisted: boolean;
+  complete: boolean;
+}
+
+function runPersistenceStep(step: PersistenceStep): boolean {
+  try {
+    return step() !== false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Persist a preference and its gate-ownership sidecar in the only safe order.
+ * Free enforcement records ownership before a destructive preference write;
+ * Pro restoration records the restored preference before consuming ownership.
+ */
+export function persistGateOwnershipTransition(
+  mode: 'free' | 'pro',
+  persistPreference: PersistenceStep,
+  persistOwnership: PersistenceStep,
+): GateOwnershipPersistenceResult {
+  if (mode === 'free') {
+    const ownershipPersisted = runPersistenceStep(persistOwnership);
+    if (!ownershipPersisted) {
+      return { preferencePersisted: false, ownershipPersisted, complete: false };
+    }
+    const preferencePersisted = runPersistenceStep(persistPreference);
+    return {
+      preferencePersisted,
+      ownershipPersisted,
+      complete: preferencePersisted,
+    };
+  }
+
+  const preferencePersisted = runPersistenceStep(persistPreference);
+  if (!preferencePersisted) {
+    return { preferencePersisted, ownershipPersisted: false, complete: false };
+  }
+  const ownershipPersisted = runPersistenceStep(persistOwnership);
+  return {
+    preferencePersisted,
+    ownershipPersisted,
+    complete: ownershipPersisted,
+  };
+}
+
+interface ResolveAppliedPanelLayoutVariantOptions {
+  appliedVariant: string | null;
+  legacyVariant: string | null;
+  currentVariant: string;
+  validVariants: ReadonlySet<string>;
+  persistAppliedVariant: (variant: string) => boolean | void;
+}
+
+/**
+ * Prefer the crash-safe applied-layout marker, but preserve legacy profiles
+ * that pre-date it. A stable legacy profile seeds the marker without making a
+ * destructive variant transition; a staged switch keeps the existing marker
+ * and is therefore still detected on the next boot.
+ */
+export function resolveAppliedPanelLayoutVariant(
+  options: ResolveAppliedPanelLayoutVariantOptions,
+): string | null {
+  if (options.appliedVariant !== null) return options.appliedVariant;
+  if (
+    options.legacyVariant === null
+    || !options.validVariants.has(options.legacyVariant)
+  ) return null;
+
+  if (options.legacyVariant === options.currentVariant) {
+    try {
+      options.persistAppliedVariant(options.currentVariant);
+    } catch {
+      // The valid legacy identity remains safe for this session. A future boot
+      // can retry seeding the crash-safe marker.
+    }
+  }
+  return options.legacyVariant;
+}
+
+/** Stage a same-origin desktop/local switch without erasing the old layout identity. */
+export function stageVariantSelection(
+  currentVariant: string,
+  nextVariant: string,
+  write: StorageWriter,
+): boolean {
+  if (write(STORAGE_KEYS.panelLayoutVariant, currentVariant) === false) return false;
+  return write(STORAGE_KEYS.variant, nextVariant) !== false;
+}
+
+interface ApplyVariantPanelLayoutTransitionOptions {
+  currentVariant: string;
+  panelSettings: Record<string, PanelConfig>;
+  variantPanelKeys: ReadonlySet<string>;
+  isDynamicPanel: (key: string) => boolean;
+  getDefaultPanel: (key: string) => PanelConfig;
+  persistPanels: (panels: Record<string, PanelConfig>) => void;
+  persistAppliedVariant: (variant: string) => void;
+}
+
+/**
+ * Transfer ownership of cross-variant disables and persist them before the
+ * applied-layout marker advances. A crash can therefore retry the reset; it
+ * can never claim an unapplied layout is current.
+ */
+export function applyVariantPanelLayoutTransition(
+  options: ApplyVariantPanelLayoutTransitionOptions,
+): Record<string, PanelConfig> {
+  const next = Object.fromEntries(
+    Object.entries(options.panelSettings).map(([key, config]) => [key, { ...config }]),
+  );
+
+  for (const [key, config] of Object.entries(next)) {
+    if (!options.variantPanelKeys.has(key) && !options.isDynamicPanel(key)) {
+      userSetPanelEnabled(config, false);
+    }
+  }
+  for (const key of options.variantPanelKeys) {
+    if (!(key in next)) next[key] = { ...options.getDefaultPanel(key) };
+  }
+
+  try {
+    options.persistPanels(next);
+    options.persistAppliedVariant(options.currentVariant);
+  } catch {
+    // The in-memory reset is still safe to use for this session. Leaving the
+    // applied marker unchanged makes the durable transition retry next boot.
+  }
+  return next;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -632,7 +632,8 @@ export interface PanelConfig {
    * Set by `enforceFreePanelLimit` when the free-tier pro gate — not the user —
    * is what turned this panel off. Distinguishes "hidden because you aren't Pro"
    * from "you hid it in settings", so the gate can be reversed on upgrade
-   * without overriding a deliberate choice. Only ever set on `cw-*` panels.
+   * without overriding a deliberate choice. Used for both `cw-*` panels and
+   * ordinary panels disabled by the free panel-count cap.
    */
   proGated?: boolean;
 }

--- a/src/utils/sync-keys.ts
+++ b/src/utils/sync-keys.ts
@@ -3,6 +3,8 @@ export const CLOUD_SYNC_KEYS = [
   'worldmonitor-monitors',
   'worldmonitor-layers',
   'worldmonitor-disabled-feeds',
+  'worldmonitor-free-tier-source-ownership',
+  'worldmonitor-free-tier-layer-ownership',
   'worldmonitor-panel-spans',
   'worldmonitor-panel-col-spans',
   'panel-order',

--- a/tests/blocked-storage-event-handlers.test.mjs
+++ b/tests/blocked-storage-event-handlers.test.mjs
@@ -20,7 +20,7 @@ describe('blocked-storage event handlers', () => {
   it('reloads local variant navigation after a guarded storage write', () => {
     assert.match(
       eventHandlersSrc,
-      /if \(this\.ctx\.isDesktopApp \|\| options\.isLocalDev\) \{\s*writeStorageValue\('worldmonitor-variant', variant\);\s*window\.location\.reload\(\);/,
+      /if \(this\.ctx\.isDesktopApp \|\| options\.isLocalDev\) \{\s*if \(stageVariantSelection\(SITE_VARIANT, variant, writeStorageValue\)\) \{\s*window\.location\.reload\(\);/,
     );
   });
 

--- a/tests/cloud-prefs-panel-sync-guard.test.mjs
+++ b/tests/cloud-prefs-panel-sync-guard.test.mjs
@@ -93,8 +93,8 @@ describe('cloud prefs panel sync guardrails', () => {
     const cloudApplyBlock = appSrc.slice(cloudApplyStart, cloudApplyEnd);
     assert.match(
       cloudApplyBlock,
-      /const reconciledPanelSettings = this\.enforceFreeTierLimits\(cloudSyncVersion\);/,
-      'cloud panel snapshots must re-run entitlement reconciliation',
+      /const reconciledPanelSettings = tierReconciliationDeferred\s*\? false\s*: this\.enforceFreeTierLimits\(cloudSyncVersion\);/,
+      'cloud panel snapshots must reconcile only after account preference handoff',
     );
     assert.match(
       cloudApplyBlock,
@@ -107,8 +107,8 @@ describe('cloud prefs panel sync guardrails', () => {
     );
     assert.match(
       cloudApplyHandler,
-      /if \(!freeTierLimitsInvoked\) this\.enforceFreeTierLimits\(cloudSyncVersion\);[\s\S]*?this\.state\.disabledSources = new Set\(loadFromStorage<string\[\]>\(STORAGE_KEYS\.disabledFeeds, \[\]\)\);/,
-      'a disabled-feeds-only cloud generation must re-run the free source cap and then reload the enforced state',
+      /if \(!tierReconciliationDeferred && !freeTierLimitsInvoked\) \{\s*this\.enforceFreeTierLimits\(cloudSyncVersion\);\s*\}[\s\S]*?this\.state\.disabledSources = new Set\(loadFromStorage<string\[\]>\(STORAGE_KEYS\.disabledFeeds, \[\]\)\);/,
+      'a disabled-feeds-only cloud generation must defer during handoff or re-run the cap before reloading state',
     );
     // The legacy sweep must stay one-shot per browser: it cannot tell pre-marker
     // gate damage from a deliberate hide, so re-arming it on cloud snapshots
@@ -144,7 +144,7 @@ describe('cloud prefs panel sync guardrails', () => {
   it('reapplies delayed free-tier panel clamps to the mounted dashboard', () => {
     const appSrc = readSrc('src/App.ts');
     const clampStart = appSrc.indexOf('if (panelsChanged) {');
-    const clampEnd = appSrc.indexOf('// --- Source limit ---', clampStart);
+    const clampEnd = appSrc.indexOf('this.reconcileSourceLimitForTier(false);', clampStart);
     assert.ok(clampStart >= 0 && clampEnd > clampStart, 'free-tier panel clamp block must exist');
     const clampBlock = appSrc.slice(clampStart, clampEnd);
 
@@ -162,15 +162,20 @@ describe('cloud prefs panel sync guardrails', () => {
 
   it('updates the live disabled-source set when a delayed cap persists changes', () => {
     const appSrc = readSrc('src/App.ts');
-    const capStart = appSrc.indexOf('if (totalEligible > FREE_MAX_SOURCES) {');
-    const capEnd = appSrc.indexOf('return panelsChanged;', capStart);
-    assert.ok(capStart >= 0 && capEnd > capStart, 'free-tier source-cap block must exist');
+    const capStart = appSrc.indexOf('private reconcileSourceLimitForTier(');
+    const capEnd = appSrc.indexOf('/**\n   * Enforce free-tier panel', capStart);
+    assert.ok(capStart >= 0 && capEnd > capStart, 'owned free-tier source-cap helper must exist');
     const capBlock = appSrc.slice(capStart, capEnd);
 
     assert.match(
       capBlock,
-      /saveToStorage\(STORAGE_KEYS\.disabledFeeds, Array\.from\(disabledSources\)\);\s*this\.state\.disabledSources = new Set\(disabledSources\);/,
+      /persistJsonStorageValue\(STORAGE_KEYS\.disabledFeeds, \[\.\.\.nextDisabled\]\)[\s\S]*?if \(disabledChanged\) \{[\s\S]*?this\.state\.disabledSources = new Set\(nextDisabled\);/,
       'a cap reached from delayed auth or entitlement settlement must update the running app state',
+    );
+    assert.match(
+      capBlock,
+      /persistJsonStorageValue\(\s*STORAGE_KEYS\.sourceGateOwnership,\s*\[\.\.\.nextGateOwned\],\s*\)/,
+      'the source cap must explicitly confirm persisted ownership',
     );
   });
 

--- a/tests/free-tier-ownership-wiring.test.mjs
+++ b/tests/free-tier-ownership-wiring.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+const app = readFileSync(new URL('../src/App.ts', import.meta.url), 'utf8');
+const handlers = readFileSync(new URL('../src/app/event-handlers.ts', import.meta.url), 'utf8');
+const settingsWindow = readFileSync(new URL('../src/settings-window.ts', import.meta.url), 'utf8');
+const syncKeys = readFileSync(new URL('../src/utils/sync-keys.ts', import.meta.url), 'utf8');
+
+describe('free-tier ownership production wiring', () => {
+  it('routes every persistent human panel toggle through the ownership helper', () => {
+    assert.match(handlers, /enablePanelById\(panelId: string\): boolean[\s\S]*?userSetPanelEnabled\(config, true\)/);
+    assert.match(handlers, /boundPanelCloseHandler[\s\S]*?userSetPanelEnabled\(config, false\)/);
+    assert.match(handlers, /savePanelSettings:[\s\S]*?userSetPanelEnabled\(current, nextConfig\.enabled\)/);
+    assert.match(settingsWindow, /userSetPanelEnabled\(config, !config\.enabled\)/);
+  });
+
+  it('stages desktop variant selection and applies the durable panel transition', () => {
+    assert.match(handlers, /stageVariantSelection\(SITE_VARIANT, variant, writeStorageValue\)/);
+    assert.match(app, /applyVariantPanelLayoutTransition\(\{/);
+  });
+
+  it('restores source and map ownership on Pro and syncs ownership metadata', () => {
+    assert.match(app, /reconcileSourceLimitForTier\(true\)/);
+    assert.match(app, /restoreGateOwnedLockedLayers\(/);
+    assert.match(app, /if \(!ownershipMetadataExists\) \{/);
+    assert.match(app, /const ownershipChanged = !ownershipMetadataExists\s*\|\|/);
+    assert.match(app, /if \(!mapLayerStatesEqual\(this\.state\.mapLayers, nextLayers\)\) \{/);
+    assert.match(app, /persistGateOwnershipTransition\(\s*'pro'/);
+    assert.match(app, /persistGateOwnershipTransition\(\s*'free'/);
+    assert.match(app, /persistJsonStorageValue\(\s*STORAGE_KEYS\.disabledFeeds/);
+    assert.match(app, /persistJsonStorageValue\(\s*STORAGE_KEYS\.sourceGateOwnership/);
+    assert.match(syncKeys, /worldmonitor-free-tier-source-ownership/);
+    assert.match(syncKeys, /worldmonitor-free-tier-layer-ownership/);
+  });
+
+  it('transfers single and bulk source toggles out of gate ownership', () => {
+    assert.match(handlers, /toggleSource:[\s\S]*?if \(this\.transferSourceGateOwnershipToUser\(\[name\]\)\) \{\s*saveToStorage\(STORAGE_KEYS\.disabledFeeds/);
+    assert.match(handlers, /setSourcesEnabled:[\s\S]*?if \(this\.transferSourceGateOwnershipToUser\(names\)\) \{\s*saveToStorage\(STORAGE_KEYS\.disabledFeeds/);
+    assert.match(handlers, /transferSourceGateOwnershipToUser\(names: Iterable<string>\): boolean[\s\S]*?return writeStorageValue\([\s\S]*?STORAGE_KEYS\.sourceGateOwnership/);
+  });
+
+  it('defers ownership reconciliation until cloud prefs completes for the current account', () => {
+    assert.match(app, /this\.tierPreferenceHandoff\.begin\(userId\)/);
+    assert.match(app, /const tierReconciliationDeferred = this\.shouldDeferTierPreferenceReconciliation\(\)/);
+    assert.match(app, /onEntitlementChange\(\(\) => firePremiumLoaders\(\)\)/);
+    assert.match(app, /const firePremiumLoaders = \(\): void => \{[\s\S]*?this\.reconcileTierOwnedPreferences\(\)/);
+    assert.match(app, /const completion = cloudPrefsSignIn\(nextUserId, SITE_VARIANT\)[\s\S]*?tierPreferenceHandoff\.complete\(nextUserId, currentUserId\)[\s\S]*?reconcileTierOwnedPreferences\(\)[\s\S]*?completion\.then\(finishPreferenceHandoff, finishPreferenceHandoff\)/);
+  });
+});

--- a/tests/map-layer-executable.test.mts
+++ b/tests/map-layer-executable.test.mts
@@ -15,6 +15,8 @@
 
 import { strict as assert } from 'node:assert';
 import { test, describe } from 'node:test';
+import type { MapLayers } from '../src/types';
+import { persistGateOwnershipTransition } from '../src/services/variant-panel-ownership';
 import {
   LAYER_REGISTRY,
   isLayerCommandAllowed,
@@ -22,6 +24,9 @@ import {
   isLayerEntitled,
   isLayerToggleAllowed,
   sanitizeLockedLayers,
+  sanitizeLockedLayersWithOwnership,
+  restoreGateOwnedLockedLayers,
+  mapLayerStatesEqual,
   shouldSanitizeLockedLayers,
 } from '../src/config/map-layer-definitions';
 
@@ -176,6 +181,115 @@ describe('sanitizeLockedLayers — free-user stuck-state heal', () => {
     const out = sanitizeLockedLayers(input, true);
     assert.equal(out.resilienceScore, true);
     assert.equal(out.conflicts, true);
+  });
+});
+
+describe('locked map-layer ownership', () => {
+  test('compares layer snapshots semantically instead of by object identity', () => {
+    const layers = { conflicts: true, resilienceScore: false } as unknown as MapLayers;
+    assert.equal(mapLayerStatesEqual(layers, { ...layers }), true);
+    assert.equal(
+      mapLayerStatesEqual(layers, { ...layers, resilienceScore: true }),
+      false,
+    );
+  });
+
+  test('records a locked layer forced off for a free user and keeps ownership across reruns', () => {
+    const input = {
+      resilienceScore: true,
+      conflicts: true,
+    } as unknown as MapLayers;
+
+    const first = sanitizeLockedLayersWithOwnership(input, new Set());
+    assert.equal(first.layers.resilienceScore, false);
+    assert.equal(first.layers.conflicts, true);
+    assert.deepEqual(first.gateOwned, new Set(['resilienceScore']));
+
+    const second = sanitizeLockedLayersWithOwnership(first.layers, first.gateOwned);
+    assert.equal(second.layers.resilienceScore, false);
+    assert.deepEqual(second.gateOwned, new Set(['resilienceScore']));
+  });
+
+  test('keeps the live free gate sanitized when ownership persistence fails', () => {
+    const durableLayers = {
+      resilienceScore: true,
+      conflicts: true,
+    } as unknown as MapLayers;
+    const reconciled = sanitizeLockedLayersWithOwnership(durableLayers, new Set());
+    const writes: string[] = [];
+
+    const persistence = persistGateOwnershipTransition(
+      'free',
+      () => { writes.push('layers'); },
+      () => { writes.push('ownership'); return false; },
+    );
+
+    assert.equal(reconciled.layers.resilienceScore, false, 'live state remains safely gated');
+    assert.equal(durableLayers.resilienceScore, true, 'durable preference remains retryable');
+    assert.deepEqual(writes, ['ownership'], 'destructive durable write is blocked');
+    assert.equal(persistence.complete, false);
+  });
+
+  test('restores only valid locked layers owned by the gate', () => {
+    const restored = restoreGateOwnedLockedLayers(
+      {
+        resilienceScore: false,
+        conflicts: false,
+      } as unknown as MapLayers,
+      new Set(['resilienceScore', 'conflicts', 'removed-layer']),
+    );
+
+    assert.equal(restored.resilienceScore, true);
+    assert.equal(restored.conflicts, false, 'ordinary user-disabled layers stay disabled');
+    assert.equal('removed-layer' in restored, false, 'unknown historical keys are ignored');
+  });
+
+  test('does not let stale resilience ownership override an enabled CII choropleth', () => {
+    const restored = restoreGateOwnedLockedLayers(
+      {
+        resilienceScore: false,
+        ciiChoropleth: true,
+      } as unknown as MapLayers,
+      new Set(['resilienceScore']),
+    );
+
+    assert.equal(restored.resilienceScore, false);
+    assert.equal(restored.ciiChoropleth, true);
+  });
+
+  test('consumes stale resilience ownership after a free-to-Pro CII sequence', () => {
+    const free = sanitizeLockedLayersWithOwnership(
+      {
+        resilienceScore: true,
+        ciiChoropleth: false,
+      } as unknown as MapLayers,
+      new Set(),
+    );
+    const ciiSelectedWhileFree = {
+      ...free.layers,
+      ciiChoropleth: true,
+    };
+    const restored = restoreGateOwnedLockedLayers(
+      ciiSelectedWhileFree,
+      free.gateOwned,
+    );
+    let durableOwnership = new Set(free.gateOwned);
+
+    const persistence = persistGateOwnershipTransition(
+      'pro',
+      () => true,
+      () => { durableOwnership = new Set(); },
+    );
+
+    assert.equal(restored.resilienceScore, false);
+    assert.equal(restored.ciiChoropleth, true);
+    assert.equal(persistence.complete, true);
+    assert.deepEqual(durableOwnership, new Set());
+    assert.equal(
+      restoreGateOwnedLockedLayers(restored, durableOwnership),
+      restored,
+      'later reconciliations have no stale resilience ownership to replay',
+    );
   });
 });
 

--- a/tests/source-cap.test.mts
+++ b/tests/source-cap.test.mts
@@ -4,11 +4,67 @@ import assert from 'node:assert/strict';
 import {
   computeRolloutLegacyDisabledStates,
   computeCapDisabledSources,
+  inferExactSourceGateOwnership,
+  reconcileSourceGateOwnership,
+  restoreGateOwnedSources,
+  transferSourceGateOwnershipToUser,
   selectSourcesUnderCap,
   findFullyDisabledCategories,
 } from '../src/services/source-cap';
 
 const F = (...names: string[]) => names.map((name) => ({ name }));
+
+describe('source-cap ownership', () => {
+  it('recomputes the cap from user-owned disables instead of preserving the old cap selection', () => {
+    const reconciled = reconcileSourceGateOwnership(
+      new Set(['user-off']),
+      new Set(['new-cap-b', 'new-cap-c']),
+    );
+
+    assert.deepEqual(reconciled.gateOwned, new Set(['new-cap-b', 'new-cap-c']));
+    assert.deepEqual(reconciled.disabled, new Set(['user-off', 'new-cap-b', 'new-cap-c']));
+  });
+
+  it('restores only sources disabled by the gate on upgrade', () => {
+    assert.deepEqual(
+      restoreGateOwnedSources(
+        new Set(['user-off', 'cap-a', 'cap-b']),
+        new Set(['cap-a', 'cap-b']),
+      ),
+      new Set(['user-off']),
+    );
+  });
+
+  it('transfers directly toggled source names from gate ownership to the user', () => {
+    assert.deepEqual(
+      transferSourceGateOwnershipToUser(
+        new Set(['cap-owned', 'still-cap-owned']),
+        ['cap-owned', 'already-user-owned'],
+      ),
+      new Set(['still-cap-owned']),
+    );
+  });
+
+  it('infers ownership only for an exact untouched legacy cap fingerprint', () => {
+    assert.deepEqual(
+      inferExactSourceGateOwnership(
+        new Set(['user-off', 'cap-a']),
+        new Set(['user-off']),
+        new Set(['cap-a']),
+      ),
+      new Set(['cap-a']),
+    );
+    assert.equal(
+      inferExactSourceGateOwnership(
+        new Set(['user-off', 'cap-a', 'custom-off']),
+        new Set(['user-off']),
+        new Set(['cap-a']),
+      ),
+      null,
+      'a customized denylist must never be guessed back into gate ownership',
+    );
+  });
+});
 
 describe('computeCapDisabledSources: legacy migration fingerprint', () => {
   it('reconstructs the exact mixed default-plus-cap disabled set', () => {

--- a/tests/tier-preference-handoff.test.mts
+++ b/tests/tier-preference-handoff.test.mts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { TierPreferenceHandoff } from '../src/app/tier-preference-handoff';
+
+describe('tier preference account handoff', () => {
+  it('defers only the signing-in account until its cloud completion signal', () => {
+    const handoff = new TierPreferenceHandoff();
+    handoff.begin('account-b');
+
+    assert.equal(handoff.shouldDefer('account-b'), true);
+    assert.equal(handoff.shouldDefer('account-a'), false);
+    assert.equal(handoff.complete('account-b', 'account-b'), true);
+    assert.equal(handoff.shouldDefer('account-b'), false);
+  });
+
+  it('does not let a stale completion clear a newer account handoff', () => {
+    const handoff = new TierPreferenceHandoff();
+    handoff.begin('account-a');
+    handoff.begin('account-b');
+
+    assert.equal(handoff.complete('account-a', 'account-b'), false);
+    assert.equal(handoff.shouldDefer('account-b'), true);
+    assert.equal(handoff.complete('account-b', null), false);
+    assert.equal(handoff.shouldDefer('account-b'), false);
+  });
+});

--- a/tests/variant-panel-ownership.test.mts
+++ b/tests/variant-panel-ownership.test.mts
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import type { PanelConfig } from '../src/types';
+import {
+  applyVariantPanelLayoutTransition,
+  persistGateOwnershipTransition,
+  resolveAppliedPanelLayoutVariant,
+  stageVariantSelection,
+} from '../src/services/variant-panel-ownership';
+
+describe('variant panel ownership', () => {
+  it('persists free ownership before a destructive preference and stops on failure', () => {
+    const events: string[] = [];
+    const failed = persistGateOwnershipTransition(
+      'free',
+      () => { events.push('preference'); },
+      () => { events.push('ownership'); return false; },
+    );
+
+    assert.deepEqual(events, ['ownership']);
+    assert.deepEqual(failed, {
+      preferencePersisted: false,
+      ownershipPersisted: false,
+      complete: false,
+    });
+  });
+
+  it('persists a Pro restoration before clearing ownership and retains it on failure', () => {
+    const events: string[] = [];
+    const failed = persistGateOwnershipTransition(
+      'pro',
+      () => { events.push('preference'); return false; },
+      () => { events.push('ownership'); },
+    );
+
+    assert.deepEqual(events, ['preference']);
+    assert.deepEqual(failed, {
+      preferencePersisted: false,
+      ownershipPersisted: false,
+      complete: false,
+    });
+  });
+
+  it('reports a durable Pro preference even when ownership clearing must retry', () => {
+    const events: string[] = [];
+    const result = persistGateOwnershipTransition(
+      'pro',
+      () => { events.push('preference'); },
+      () => { events.push('ownership'); throw new Error('quota'); },
+    );
+
+    assert.deepEqual(events, ['preference', 'ownership']);
+    assert.deepEqual(result, {
+      preferencePersisted: true,
+      ownershipPersisted: false,
+      complete: false,
+    });
+  });
+
+  it('seeds a stable valid legacy profile without treating it as a variant switch', () => {
+    const seeded: string[] = [];
+    const applied = resolveAppliedPanelLayoutVariant({
+      appliedVariant: null,
+      legacyVariant: 'full',
+      currentVariant: 'full',
+      validVariants: new Set(['full', 'tech']),
+      persistAppliedVariant: (variant) => { seeded.push(variant); },
+    });
+
+    assert.equal(applied, 'full');
+    assert.deepEqual(seeded, ['full']);
+  });
+
+  it('keeps an existing applied marker authoritative during a staged switch', () => {
+    const seeded: string[] = [];
+    const applied = resolveAppliedPanelLayoutVariant({
+      appliedVariant: 'full',
+      legacyVariant: 'tech',
+      currentVariant: 'tech',
+      validVariants: new Set(['full', 'tech']),
+      persistAppliedVariant: (variant) => { seeded.push(variant); },
+    });
+
+    assert.equal(applied, 'full');
+    assert.deepEqual(seeded, []);
+  });
+
+  it('ignores an invalid legacy variant when the applied marker is missing', () => {
+    const applied = resolveAppliedPanelLayoutVariant({
+      appliedVariant: null,
+      legacyVariant: 'removed-variant',
+      currentVariant: 'full',
+      validVariants: new Set(['full', 'tech']),
+      persistAppliedVariant: () => { throw new Error('must not seed'); },
+    });
+
+    assert.equal(applied, null);
+  });
+
+  it('keeps the selected and applied layout variants distinct across a reload', () => {
+    const writes: Array<[string, string]> = [];
+    assert.equal(
+      stageVariantSelection('full', 'tech', (key, value) => {
+        writes.push([key, value]);
+      }),
+      true,
+    );
+    assert.deepEqual(writes, [
+      ['worldmonitor-panel-layout-variant', 'full'],
+      ['worldmonitor-variant', 'tech'],
+    ]);
+  });
+
+  it('does not overwrite the selected variant when the applied marker cannot persist', () => {
+    const writes: string[] = [];
+    const staged = stageVariantSelection('full', 'tech', (key) => {
+      writes.push(key);
+      return false;
+    });
+
+    assert.equal(staged, false);
+    assert.deepEqual(writes, ['worldmonitor-panel-layout-variant']);
+  });
+
+  it('persists the marker-free panel reset before marking the new layout applied', () => {
+    const panels: Record<string, PanelConfig> = {
+      keep: { name: 'Keep', enabled: true },
+      outsideEnabled: { name: 'Outside enabled', enabled: true, proGated: true },
+      outsideHidden: { name: 'Outside hidden', enabled: false, proGated: true },
+      'cw-user': { name: 'Widget', enabled: false, proGated: true },
+    };
+    const events: string[] = [];
+    let persisted: Record<string, PanelConfig> | null = null;
+
+    const result = applyVariantPanelLayoutTransition({
+      currentVariant: 'tech',
+      panelSettings: panels,
+      variantPanelKeys: new Set(['keep', 'new-default']),
+      isDynamicPanel: (key) => key.startsWith('cw-'),
+      getDefaultPanel: (key) => ({ name: key, enabled: true }),
+      persistPanels: (next) => {
+        events.push('panels');
+        persisted = structuredClone(next);
+      },
+      persistAppliedVariant: (variant) => events.push(`variant:${variant}`),
+    });
+
+    assert.deepEqual(events, ['panels', 'variant:tech']);
+    assert.equal(result.outsideEnabled?.enabled, false);
+    assert.equal(result.outsideEnabled?.proGated, undefined);
+    assert.equal(result.outsideHidden?.enabled, false);
+    assert.equal(result.outsideHidden?.proGated, undefined);
+    assert.equal(result['cw-user']?.proGated, true, 'dynamic panel state survives variant resets');
+    assert.equal(result['new-default']?.enabled, true);
+    assert.deepEqual(persisted, result);
+  });
+
+  it('does not advance the applied marker when panel persistence fails', () => {
+    const events: string[] = [];
+    const result = applyVariantPanelLayoutTransition({
+      currentVariant: 'tech',
+      panelSettings: { outside: { name: 'Outside', enabled: true, proGated: true } },
+      variantPanelKeys: new Set(),
+      isDynamicPanel: () => false,
+      getDefaultPanel: (key) => ({ name: key, enabled: true }),
+      persistPanels: () => {
+        events.push('panels');
+        throw new Error('quota exceeded');
+      },
+      persistAppliedVariant: () => events.push('variant'),
+    });
+
+    assert.deepEqual(events, ['panels']);
+    assert.equal(result.outside?.enabled, false, 'the safe in-memory transition still applies');
+    assert.equal(result.outside?.proGated, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Upgrading to Pro now reverses every free-tier restriction that mutates saved dashboard preferences, without resurrecting choices the user explicitly disabled. This expands the panel ownership fix from #6338 to the 80-source cap, locked premium map layers, and variant-driven layout resets.

The broader limit audit found three persisted destructive gates: panels, source disables, and locked map layers. Dashboard tabs and followed countries reject new additions without trimming existing signed-in state, while stock-analysis targets and server-side quotas are derived from the live entitlement, so those surfaces have no persisted free-tier state to undo.

## Design decisions

| Risk | Behavior after this change |
|---|---|
| Free-tier enforcement is mistaken for user intent | Gate-owned panel, source, and layer changes carry ownership that a later Pro reconciliation can safely reverse. |
| Storage fails between preference and ownership writes | Free enforcement records ownership first; Pro restoration persists the restored preference before consuming ownership, leaving every partial state retryable. |
| Sign-in races cloud preference hydration | Tier reconciliation waits for the current account's cloud handoff before mutating or uploading local gate state. |
| A legacy profile lacks the new variant marker | The existing valid variant identity is adopted without resetting saved panels or map layers. |
| Stale Resilience ownership conflicts with a newer CII choice | CII remains enabled and the stale Resilience ownership is consumed instead of replayed. |

Creation-only free caps remain non-destructive; this PR does not remove the distinct limits intentionally attached to paid plans.

Related: #6338

## Validation

- Focused ownership and transition suite: 137/137 passed.
- `npm run typecheck` passed after rebasing onto the latest `origin/main`.
- `npm run lint` passed; Biome reported only the repository's existing warnings and the safe-HTML guard passed.
- The repository pre-push gate passed, including changed tests, architectural boundaries, premium-fetch parity, edge-function tests, and version checks.
- The pre-push hook's isolated fixture suite passed 16/16 with a sandbox-safe GNU `mktemp` shim.

## Post-Deploy Monitoring & Validation

- Window: first 24 hours after the web deployment.
- Validate a free-to-Pro transition with over-cap panels/sources and an enabled locked layer; only gate-owned changes should restore.
- Validate cloud sign-in on a second browser before entitlement settlement; the hydrated account preferences must win before ownership reconciliation.
- Watch client errors and console/Sentry reports for storage-write failures, repeated `Free tier: reconciled` / `Pro: restored` churn, or preference-sync conflicts.
- Roll back if explicit panel/source disables are re-enabled, CII is displaced by Resilience, or a stable same-variant profile resets its layout.
- Owner: WorldMonitor maintainer handling the deployment.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
