### PR TITLE
fix(entitlements): repair the free-tier ownership model shipped in #6345

### DIFF
--- a/convex/__tests__/userPreferences.test.ts
+++ b/convex/__tests__/userPreferences.test.ts
@@ -220,4 +220,63 @@ describe("userPreferences.setPreferences write rate limit", () => {
 
     await expectRateLimited(writePref(t, USER_A, 0));
   });
+
+  test("preserves ownership sidecars omitted by an older writer", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = makeT();
+    const sourceOwnership = "worldmonitor-free-tier-source-ownership";
+    const layerOwnership = "worldmonitor-free-tier-layer-ownership";
+
+    await expect(
+      t.withIdentity(USER_A).mutation(api.userPreferences.setPreferences, {
+        variant: "full",
+        data: {
+          theme: "dark",
+          [sourceOwnership]: '["source-a"]',
+          [layerOwnership]: '["resilienceScore"]',
+        },
+        expectedSyncVersion: 0,
+        schemaVersion: 6,
+      }),
+    ).resolves.toEqual({ ok: true, syncVersion: 1 });
+
+    await expect(
+      t.withIdentity(USER_A).mutation(api.userPreferences.setPreferences, {
+        variant: "full",
+        data: { theme: "light" },
+        expectedSyncVersion: 1,
+        schemaVersion: 6,
+      }),
+    ).resolves.toEqual({ ok: true, syncVersion: 2 });
+
+    const preserved = await t.withIdentity(USER_A).query(api.userPreferences.getPreferences, {
+      variant: "full",
+    });
+    expect(preserved?.data).toEqual({
+      theme: "light",
+      [sourceOwnership]: '["source-a"]',
+      [layerOwnership]: '["resilienceScore"]',
+    });
+
+    await expect(
+      t.withIdentity(USER_A).mutation(api.userPreferences.setPreferences, {
+        variant: "full",
+        data: {
+          theme: "light",
+          [sourceOwnership]: "[]",
+          [layerOwnership]: "[]",
+        },
+        expectedSyncVersion: 2,
+        schemaVersion: 6,
+      }),
+    ).resolves.toEqual({ ok: true, syncVersion: 3 });
+
+    const cleared = await t.withIdentity(USER_A).query(api.userPreferences.getPreferences, {
+      variant: "full",
+    });
+    expect(cleared?.data).toMatchObject({
+      [sourceOwnership]: "[]",
+      [layerOwnership]: "[]",
+    });
+  });
 });

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -58,6 +58,38 @@ type UserPrefsWriteRateLimitResult =
 
 const RATE_LIMIT_COUNTER_SCAN_LIMIT = USER_PREFS_WRITE_RATE_LIMIT + 1;
 const RATE_LIMIT_STALE_CLEANUP_LIMIT = 5;
+const FREE_TIER_OWNERSHIP_KEYS = [
+  "worldmonitor-free-tier-source-ownership",
+  "worldmonitor-free-tier-layer-ownership",
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Older clients replace the complete preference blob without the ownership
+ * sidecars. Preserve only those omitted fields from an existing row; an
+ * explicit value, including the string "[]", remains authoritative.
+ */
+export function preserveOmittedFreeTierOwnership(
+  existingData: unknown,
+  incomingData: unknown,
+): unknown {
+  if (!isRecord(existingData) || !isRecord(incomingData)) return incomingData;
+
+  let merged: Record<string, unknown> | null = null;
+  for (const key of FREE_TIER_OWNERSHIP_KEYS) {
+    if (
+      !Object.prototype.hasOwnProperty.call(incomingData, key)
+      && typeof existingData[key] === "string"
+    ) {
+      merged ??= { ...incomingData };
+      merged[key] = existingData[key];
+    }
+  }
+  return merged ?? incomingData;
+}
 
 async function checkUserPrefsWriteRateLimit(
   ctx: MutationCtx,
@@ -143,7 +175,15 @@ export const setPreferences = mutation({
     const rateLimit = await checkUserPrefsWriteRateLimit(ctx, userId);
     if (!rateLimit.ok) return rateLimit;
 
-    const blobSize = JSON.stringify(args.data).length;
+    const existing = await ctx.db
+      .query("userPreferences")
+      .withIndex("by_user_variant", (q) =>
+        q.eq("userId", userId).eq("variant", args.variant),
+      )
+      .unique();
+
+    const data = preserveOmittedFreeTierOwnership(existing?.data, args.data);
+    const blobSize = JSON.stringify(data).length;
     if (blobSize > MAX_PREFS_BLOB_SIZE) {
       return {
         ok: false,
@@ -152,13 +192,6 @@ export const setPreferences = mutation({
         max: MAX_PREFS_BLOB_SIZE,
       };
     }
-
-    const existing = await ctx.db
-      .query("userPreferences")
-      .withIndex("by_user_variant", (q) =>
-        q.eq("userId", userId).eq("variant", args.variant),
-      )
-      .unique();
 
     if (existing && existing.syncVersion !== args.expectedSyncVersion) {
       // CAS-guard "no-op". Returns rather than throws — see SetPreferencesResult
@@ -176,7 +209,7 @@ export const setPreferences = mutation({
 
     if (existing) {
       await ctx.db.patch(existing._id, {
-        data: args.data,
+        data,
         schemaVersion,
         updatedAt: Date.now(),
         syncVersion: nextSyncVersion,
@@ -185,7 +218,7 @@ export const setPreferences = mutation({
       await ctx.db.insert("userPreferences", {
         userId,
         variant: args.variant,
-        data: args.data,
+        data,
         schemaVersion,
         updatedAt: Date.now(),
         syncVersion: nextSyncVersion,

--- a/src/App.ts
+++ b/src/App.ts
@@ -23,6 +23,7 @@ import {
 } from '@/config';
 import {
   sanitizeLayersForVariant,
+  sanitizeLockedLayers,
   sanitizeLockedLayersWithOwnership,
   restoreGateOwnedLockedLayers,
   mapLayerStatesEqual,
@@ -169,6 +170,7 @@ import { getAuthState, initAuthState, subscribeAuthState } from '@/services/auth
 import {
   CLOUD_PREFS_APPLIED_EVENT,
   getSyncVersion,
+  hasPendingCloudPrefsRetry,
   install as installCloudPrefsSync,
   onSignIn as cloudPrefsSignIn,
   onSignOut as cloudPrefsSignOut,
@@ -880,7 +882,11 @@ export class App {
       console.log('[App] Variant changed - seeding new defaults, disabling cross-variant panels');
       // Reset map layers for the new variant (map layers are not user-personalized the same way)
       localStorage.removeItem(STORAGE_KEYS.mapLayers);
-      localStorage.removeItem(STORAGE_KEYS.mapLayerGateOwnership);
+      // Write an explicit empty set rather than removing the key: cloud sync
+      // now tolerates an ABSENT ownership sidecar (a row that predates it must
+      // not delete local ownership), so a genuine variant-reset clear only
+      // propagates cross-device when it is an explicit value.
+      localStorage.setItem(STORAGE_KEYS.mapLayerGateOwnership, '[]');
       mapLayers = normalizeExclusiveChoropleths(
         sanitizeLayersForVariant({ ...defaultLayers }, currentVariant as MapVariant), null,
       );
@@ -895,11 +901,21 @@ export class App {
         // Use the throwing primitive here so the transition helper advances
         // the applied-layout marker only after the panel blob is durable.
         persistPanels: (next) => localStorage.setItem(STORAGE_KEYS.panels, JSON.stringify(next)),
-        persistAppliedVariant: (variant) => localStorage.setItem(STORAGE_KEYS.panelLayoutVariant, variant),
+        persistAppliedVariant: (variant) => {
+          // Both markers advance HERE, inside the helper's success path, and
+          // never after a failed panel write. Advancing the legacy key
+          // unconditionally used to erase the retry: on the next boot
+          // resolveAppliedPanelLayoutVariant would see a null applied marker
+          // beside a legacy key already equal to the current variant, take its
+          // SEEDING branch, and silently record the failed reset as applied.
+          //
+          // Order is load-bearing: the legacy key (read by bootstrap/theme and
+          // by SITE_VARIANT on desktop) goes first, and the applied-layout
+          // marker — the "this layout is durable" flag — goes last.
+          localStorage.setItem(STORAGE_KEYS.variant, variant);
+          localStorage.setItem(STORAGE_KEYS.panelLayoutVariant, variant);
+        },
       });
-      // Keep the legacy selected-variant key for bootstrap/theme consumers.
-      // The applied-layout marker above advances only after panels persist.
-      localStorage.setItem(STORAGE_KEYS.variant, currentVariant);
     } else {
       mapLayers = normalizeExclusiveChoropleths(
         sanitizeLayersForVariant(
@@ -1111,7 +1127,9 @@ export class App {
         sanitizeLayersForVariant(initialUrlState.layers, currentVariant as MapVariant), null,
       );
       // #6045 — URL layer deep-links also cannot force locked layers on for free users.
-      mapLayers = this.sanitizeMapLayersForTier(mapLayers);
+      // Ephemeral: the link is a view, so it must not overwrite the stored
+      // preference or touch gate ownership in either direction.
+      mapLayers = this.sanitizeMapLayersForTier(mapLayers, undefined, { ephemeralSnapshot: true });
       initialUrlState.layers = mapLayers;
     }
     if (!CYBER_LAYER_ENABLED) {
@@ -1825,7 +1843,15 @@ export class App {
 
       if (userId !== null && userId !== _prevUserId) {
         const handoffGeneration = ++_convexWatchHandoffGeneration;
-        this.tierPreferenceHandoff.begin(userId);
+        // The token fences a LATE completion from a previous attempt for the
+        // same account (sign-in A -> sign-out -> sign-in A): the queue settles
+        // that stale attempt before this one runs, and an id-only guard would
+        // let it release a handoff it does not own. The expiry callback is the
+        // backstop for an attempt that never reaches a terminal outcome.
+        const preferenceHandoffGeneration = this.tierPreferenceHandoff.begin(
+          userId,
+          () => { this.reconcileTierOwnedPreferences(); },
+        );
 
         // Rebind Convex watches to the real Clerk userId (was bound to anon UUID at init)
         // destroyEntitlementSubscription deliberately PRESERVES the last
@@ -1853,8 +1879,19 @@ export class App {
             cloudPrefsSignIn: (nextUserId) => {
               const completion = cloudPrefsSignIn(nextUserId, SITE_VARIANT);
               const finishPreferenceHandoff = (): void => {
+                // A 503 resolves this promise as soon as the RETRY IS ARMED,
+                // before any cloud blob is applied. Completing here would
+                // reconcile — and upload — pre-cloud local state. Leave the
+                // handoff armed: its bounded expiry still guarantees a pass,
+                // and the retry's own applyCloudBlob re-reconciles via
+                // CLOUD_PREFS_APPLIED_EVENT.
+                if (hasPendingCloudPrefsRetry()) return;
                 const currentUserId = getAuthState().user?.id ?? null;
-                if (this.tierPreferenceHandoff.complete(nextUserId, currentUserId)) {
+                if (this.tierPreferenceHandoff.complete(
+                  preferenceHandoffGeneration,
+                  nextUserId,
+                  currentUserId,
+                )) {
                   this.reconcileTierOwnedPreferences();
                 }
               };
@@ -2218,9 +2255,14 @@ export class App {
   private sanitizeMapLayersForTier(
     layers: MapLayers,
     fallbackActive = this.freeTierGate.authSettleDeadlineExceeded,
-    options: { consumeProOwnership?: boolean } = {},
+    options: { ephemeralSnapshot?: boolean } = {},
   ): MapLayers {
-    const consumeProOwnership = options.consumeProOwnership ?? true;
+    // A `?layers=` deep link is a VIEW, not the user's saved preference:
+    // parseMapUrlState rebuilds every LAYER_KEYS entry from the query string.
+    // Treating it as durable state let a shared link overwrite the stored
+    // (and cloud-synced) preference and seed gate ownership the user never
+    // chose, so an ephemeral snapshot is sanitized for display only.
+    const ephemeral = options.ephemeralSnapshot ?? false;
     const premium = hasPremiumAccess();
     const existingOwnership = new Set(
       loadFromStorage<string[]>(STORAGE_KEYS.mapLayerGateOwnership, []),
@@ -2232,15 +2274,14 @@ export class App {
         restoreGateOwnedLockedLayers(layers, existingOwnership),
         SITE_VARIANT as MapVariant,
       );
-      if (!consumeProOwnership) {
-        if (restored === layers) return layers;
-        return this.persistJsonStorageValue(STORAGE_KEYS.mapLayers, restored)
-          ? restored
-          : layers;
-      }
+      // sanitizeLayersForVariant always returns a fresh object, so `restored
+      // === layers` is never true — an identity check here silently persisted
+      // on every pass. Compare by value.
+      const unchanged = mapLayerStatesEqual(layers, restored);
+      if (ephemeral) return unchanged ? layers : restored;
       const persistence = persistGateOwnershipTransition(
         'pro',
-        () => restored === layers
+        () => unchanged
           || this.persistJsonStorageValue(STORAGE_KEYS.mapLayers, restored),
         () => this.persistJsonStorageValue(STORAGE_KEYS.mapLayerGateOwnership, []),
       );
@@ -2250,6 +2291,11 @@ export class App {
     if (!shouldSanitizeLockedLayers(premium, isProTierResolved(), fallbackActive)) {
       return layers;
     }
+
+    // Strip locked layers from the view without recording ownership: a shared
+    // link naming a locked layer must not make that layer auto-enable if the
+    // user later subscribes.
+    if (ephemeral) return sanitizeLockedLayers(layers, false);
 
     const reconciled = sanitizeLockedLayersWithOwnership(layers, existingOwnership);
     const ownershipChanged = !stringSetsEqual(existingOwnership, reconciled.gateOwned);
@@ -2279,7 +2325,7 @@ export class App {
       const healedUrlLayers = this.sanitizeMapLayersForTier(
         initialUrlLayers,
         fallbackActive,
-        { consumeProOwnership: false },
+        { ephemeralSnapshot: true },
       );
       if (healedUrlLayers !== initialUrlLayers && this.state.initialUrlState) {
         this.state.initialUrlState.layers = healedUrlLayers;

--- a/src/App.ts
+++ b/src/App.ts
@@ -288,6 +288,8 @@ export class App {
   private bootstrapHydrationState: BootstrapHydrationState = getBootstrapHydrationState();
   private cachedModeBannerEl: HTMLElement | null = null;
   private pendingCloudRecoverySyncVersion: number | undefined;
+  /** Token of the in-flight preference handoff, so the cloud-applied event can release it. */
+  private pendingPreferenceHandoffGeneration: number | undefined;
   private readonly tierPreferenceHandoff = new TierPreferenceHandoff();
   private readonly handleWmSessionDegraded = (event?: Event): void => {
     if (!this.state.isDestroyed) {
@@ -351,6 +353,13 @@ export class App {
 
     const keySet = new Set(keys);
     let freeTierLimitsInvoked = false;
+    // This event fires from applyCloudBlob, so reaching it means the signing-in
+    // account's cloud preferences have ACTUALLY landed — the terminal signal the
+    // handoff is waiting for. Releasing it here (rather than when the sign-in
+    // promise settles, which a 503 resolves the moment a retry is merely armed)
+    // is what lets the reconciliation below run against cloud state instead of
+    // the local state it is replacing.
+    this.releasePreferenceHandoffOnCloudApply();
     const tierReconciliationDeferred = this.shouldDeferTierPreferenceReconciliation();
     invalidatePanelStorageCacheForKeys(keys);
 
@@ -1851,7 +1860,13 @@ export class App {
         const preferenceHandoffGeneration = this.tierPreferenceHandoff.begin(
           userId,
           () => { this.reconcileTierOwnedPreferences(); },
+          // A 503 keeps the sign-in legitimately in flight for up to
+          // Retry-After, which can outlast one grace window. Waiting beats
+          // reconciling against pre-cloud state; the handoff's own ceiling
+          // stops that wait from becoming indefinite.
+          () => hasPendingCloudPrefsRetry(),
         );
+        this.pendingPreferenceHandoffGeneration = preferenceHandoffGeneration;
 
         // Rebind Convex watches to the real Clerk userId (was bound to anon UUID at init)
         // destroyEntitlementSubscription deliberately PRESERVES the last
@@ -1881,10 +1896,13 @@ export class App {
               const finishPreferenceHandoff = (): void => {
                 // A 503 resolves this promise as soon as the RETRY IS ARMED,
                 // before any cloud blob is applied. Completing here would
-                // reconcile — and upload — pre-cloud local state. Leave the
-                // handoff armed: its bounded expiry still guarantees a pass,
-                // and the retry's own applyCloudBlob re-reconciles via
-                // CLOUD_PREFS_APPLIED_EVENT.
+                // reconcile — and upload — pre-cloud local state.
+                //
+                // Leave the handoff armed instead. The retry re-enters
+                // onSignIn inside cloud-prefs-sync and never comes back
+                // through this wrapper, so the release comes from
+                // applyCloudSyncedPrefsToRuntime when the blob actually lands,
+                // and from the handoff's bounded expiry if it never does.
                 if (hasPendingCloudPrefsRetry()) return;
                 const currentUserId = getAuthState().user?.id ?? null;
                 if (this.tierPreferenceHandoff.complete(
@@ -2211,6 +2229,22 @@ export class App {
     return this.tierPreferenceHandoff.shouldDefer(getAuthState().user?.id ?? null);
   }
 
+  /**
+   * Release the handoff because the account's cloud blob just landed.
+   *
+   * The caller then reconciles inline, so this deliberately does NOT reconcile
+   * itself — doing both would run the pass twice per applied generation.
+   */
+  private releasePreferenceHandoffOnCloudApply(): void {
+    const generation = this.pendingPreferenceHandoffGeneration;
+    if (generation === undefined) return;
+    const currentUserId = getAuthState().user?.id ?? null;
+    if (currentUserId === null) return;
+    if (this.tierPreferenceHandoff.complete(generation, currentUserId, currentUserId)) {
+      this.pendingPreferenceHandoffGeneration = undefined;
+    }
+  }
+
   /** Reconcile all gate-owned preferences against one settled account view. */
   private reconcileTierOwnedPreferences(): boolean {
     if (this.shouldDeferTierPreferenceReconciliation()) return false;
@@ -2331,7 +2365,18 @@ export class App {
         this.state.initialUrlState.layers = healedUrlLayers;
       }
     }
-    const healed = this.sanitizeMapLayersForTier(this.state.mapLayers, fallbackActive);
+    // When the session booted from a `?layers=` link, state.mapLayers IS that
+    // URL-derived view (seeded from the same local in the constructor), so this
+    // heal must stay ephemeral too. The boot-time ephemeral pass usually
+    // no-ops — shouldSanitizeLockedLayers is false while the tier is still
+    // unresolved — which makes THIS the call that actually acts, and a
+    // non-ephemeral run here would seed gate ownership from the link and write
+    // it to the stored preference, undoing the deep-link fix entirely.
+    const healed = this.sanitizeMapLayersForTier(
+      this.state.mapLayers,
+      fallbackActive,
+      initialUrlLayers ? { ephemeralSnapshot: true } : {},
+    );
     if (healed === this.state.mapLayers) return;
     this.state.mapLayers = healed;
     this.state.map?.setLayers(healed);

--- a/src/App.ts
+++ b/src/App.ts
@@ -169,12 +169,14 @@ import { showProBanner } from '@/components/ProBanner';
 import { getAuthState, initAuthState, subscribeAuthState } from '@/services/auth-state';
 import {
   CLOUD_PREFS_APPLIED_EVENT,
+  CLOUD_PREFS_SIGN_IN_TERMINAL_EVENT,
   getSyncVersion,
   hasPendingCloudPrefsRetry,
   install as installCloudPrefsSync,
   onSignIn as cloudPrefsSignIn,
   onSignOut as cloudPrefsSignOut,
   type CloudPrefsAppliedDetail,
+  type CloudPrefsSignInTerminalDetail,
 } from '@/utils/cloud-prefs-sync';
 import {
   migrateFrontlineEuropeDefaultsV3,
@@ -347,19 +349,35 @@ export class App {
     const detail = (ev as CustomEvent<CloudPrefsAppliedDetail>).detail;
     this.applyCloudSyncedPrefsToRuntime(detail?.keys ?? [], detail?.syncVersion);
   };
+  private readonly handleCloudPrefsSignInTerminal = (ev: Event): void => {
+    const detail = (ev as CustomEvent<CloudPrefsSignInTerminalDetail>).detail;
+    const pendingGeneration = this.pendingPreferenceHandoffGeneration;
+    if (
+      detail?.origin !== 'sign-in'
+      || pendingGeneration === undefined
+      || detail.handoffGeneration !== pendingGeneration
+    ) {
+      return;
+    }
+
+    const currentUserId = getAuthState().user?.id ?? null;
+    if (this.tierPreferenceHandoff.complete(
+      pendingGeneration,
+      detail.accountId,
+      currentUserId,
+    )) {
+      this.pendingPreferenceHandoffGeneration = undefined;
+      // A terminal sign-in attempt is the only handoff release signal. Run
+      // one complete pass even when the cloud blob changed no local keys.
+      this.reconcileTierOwnedPreferences();
+    }
+  };
 
   private applyCloudSyncedPrefsToRuntime(keys: readonly string[], cloudSyncVersion?: number): void {
     if (keys.length === 0) return;
 
     const keySet = new Set(keys);
     let freeTierLimitsInvoked = false;
-    // This event fires from applyCloudBlob, so reaching it means the signing-in
-    // account's cloud preferences have ACTUALLY landed — the terminal signal the
-    // handoff is waiting for. Releasing it here (rather than when the sign-in
-    // promise settles, which a 503 resolves the moment a retry is merely armed)
-    // is what lets the reconciliation below run against cloud state instead of
-    // the local state it is replacing.
-    this.releasePreferenceHandoffOnCloudApply();
     const tierReconciliationDeferred = this.shouldDeferTierPreferenceReconciliation();
     invalidatePanelStorageCacheForKeys(keys);
 
@@ -1779,6 +1797,10 @@ export class App {
     initAuthAnalytics();
     installCloudPrefsSync(SITE_VARIANT);
     window.addEventListener(CLOUD_PREFS_APPLIED_EVENT, this.handleCloudPrefsApplied);
+    window.addEventListener(
+      CLOUD_PREFS_SIGN_IN_TERMINAL_EVENT,
+      this.handleCloudPrefsSignInTerminal,
+    );
     // Install the followed-countries auth listener once. Drives the
     // anon→signed-in handoff (mergeAnonymousLocal mutation) and sign-out
     // cleanup. Idempotent.
@@ -1892,33 +1914,9 @@ export class App {
             initEntitlementSubscription,
             initSubscriptionWatch,
             cloudPrefsSignIn: (nextUserId) => {
-              const completion = cloudPrefsSignIn(nextUserId, SITE_VARIANT);
-              const finishPreferenceHandoff = (): void => {
-                // A 503 resolves this promise as soon as the RETRY IS ARMED,
-                // before any cloud blob is applied. Completing here would
-                // reconcile — and upload — pre-cloud local state.
-                //
-                // Leave the handoff armed instead. The retry re-enters
-                // onSignIn inside cloud-prefs-sync and never comes back
-                // through this wrapper, so the release comes from
-                // applyCloudSyncedPrefsToRuntime when the blob actually lands,
-                // and from the handoff's bounded expiry if it never does.
-                if (hasPendingCloudPrefsRetry()) return;
-                const currentUserId = getAuthState().user?.id ?? null;
-                if (this.tierPreferenceHandoff.complete(
-                  preferenceHandoffGeneration,
-                  nextUserId,
-                  currentUserId,
-                )) {
-                  this.reconcileTierOwnedPreferences();
-                }
-              };
-              // Use both branches instead of `finally`: the promise returned
-              // by `finally` would mirror a rejection and become unhandled
-              // because startAccountAuthHandoff intentionally fire-and-forgets
-              // this effect.
-              void completion.then(finishPreferenceHandoff, finishPreferenceHandoff);
-              return completion;
+              return cloudPrefsSignIn(nextUserId, SITE_VARIANT, {
+                handoffGeneration: preferenceHandoffGeneration,
+              });
             },
           },
         });
@@ -2028,6 +2026,7 @@ export class App {
         cloudPrefsSignOut();
         resetEntitlementState();
         this.tierPreferenceHandoff.clear();
+        this.pendingPreferenceHandoffGeneration = undefined;
       }
       _prevUserId = userId;
       // Run after account handoff/reset so this pass cannot enforce the
@@ -2229,22 +2228,6 @@ export class App {
     return this.tierPreferenceHandoff.shouldDefer(getAuthState().user?.id ?? null);
   }
 
-  /**
-   * Release the handoff because the account's cloud blob just landed.
-   *
-   * The caller then reconciles inline, so this deliberately does NOT reconcile
-   * itself — doing both would run the pass twice per applied generation.
-   */
-  private releasePreferenceHandoffOnCloudApply(): void {
-    const generation = this.pendingPreferenceHandoffGeneration;
-    if (generation === undefined) return;
-    const currentUserId = getAuthState().user?.id ?? null;
-    if (currentUserId === null) return;
-    if (this.tierPreferenceHandoff.complete(generation, currentUserId, currentUserId)) {
-      this.pendingPreferenceHandoffGeneration = undefined;
-    }
-  }
-
   /** Reconcile all gate-owned preferences against one settled account view. */
   private reconcileTierOwnedPreferences(): boolean {
     if (this.shouldDeferTierPreferenceReconciliation()) return false;
@@ -2298,6 +2281,11 @@ export class App {
     // chose, so an ephemeral snapshot is sanitized for display only.
     const ephemeral = options.ephemeralSnapshot ?? false;
     const premium = hasPremiumAccess();
+    // A Pro deep link is already entitled. Preserve the exact URL-derived
+    // display snapshot and do not even read durable gate ownership: restoring
+    // it here would enable layers the shared link deliberately omitted.
+    if (premium && ephemeral) return layers;
+
     const existingOwnership = new Set(
       loadFromStorage<string[]>(STORAGE_KEYS.mapLayerGateOwnership, []),
     );
@@ -2312,7 +2300,6 @@ export class App {
       // === layers` is never true — an identity check here silently persisted
       // on every pass. Compare by value.
       const unchanged = mapLayerStatesEqual(layers, restored);
-      if (ephemeral) return unchanged ? layers : restored;
       const persistence = persistGateOwnershipTransition(
         'pro',
         () => unchanged
@@ -2700,6 +2687,8 @@ export class App {
 
   public destroy(): void {
     this.state.isDestroyed = true;
+    this.tierPreferenceHandoff.clear();
+    this.pendingPreferenceHandoffGeneration = undefined;
     this.viewportHydrationReady = false;
     cancelBootstrapSlowTier();
     window.removeEventListener('scroll', this.handleViewportPrime, { capture: true });
@@ -2709,6 +2698,10 @@ export class App {
     window.removeEventListener(I18N_RESOURCES_LOADED_EVENT, this.handleI18nResourcesLoaded);
     window.removeEventListener(WM_FOLLOWED_COUNTRIES_CAP_DROP, this.handleFollowedCountriesCapDrop);
     window.removeEventListener(CLOUD_PREFS_APPLIED_EVENT, this.handleCloudPrefsApplied);
+    window.removeEventListener(
+      CLOUD_PREFS_SIGN_IN_TERMINAL_EVENT,
+      this.handleCloudPrefsSignInTerminal,
+    );
     if (this.visiblePanelPrimeRaf !== null) {
       window.cancelAnimationFrame(this.visiblePanelPrimeRaf);
       this.visiblePanelPrimeRaf = null;

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -2926,10 +2926,9 @@ export class PanelLayoutManager implements AppModule {
         normalized = { ...normalized, resilienceScore: false };
       }
       // MapContainer also sanitizes at the renderer boundary, but update the
-      // context and persisted URL preference with the effective state first.
-      // Otherwise a settled-free user can have the locked layer stripped from
-      // the renderer while ctx.mapLayers/localStorage retain the stale `true`
-      // value and a later preference/URL reapplication resurrects it (#6045).
+      // URL-derived context with the effective display state first. A shared
+      // link is not a user preference, so it must never overwrite the saved
+      // (and cloud-synced) map-layer selection.
       if (shouldSanitizeLockedLayers(
         hasPremiumAccess(getAuthState()),
         isProTierResolved(),
@@ -2939,7 +2938,6 @@ export class PanelLayoutManager implements AppModule {
       }
       this.ctx.initialUrlState.layers = normalized;
       this.ctx.mapLayers = normalized;
-      saveToStorage(STORAGE_KEYS.mapLayers, normalized);
       this.ctx.map.setLayers(normalized);
     }
 

--- a/src/app/tier-preference-handoff.ts
+++ b/src/app/tier-preference-handoff.ts
@@ -1,27 +1,95 @@
+import { AUTH_SETTLE_GRACE_MS } from '@/app/free-tier-gate';
+
+interface TierPreferenceHandoffOptions {
+  /** Upper bound on how long reconciliation may be deferred. */
+  graceMs?: number;
+  /** Injected so boundary behaviour is testable without a live clock. */
+  schedule?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  cancel?: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
 /**
  * Tracks the account whose cloud preferences are replacing anonymous/local
- * state. Tier reconciliation must not mutate that state until the handoff's
- * success/error completion signal arrives.
+ * state. Tier reconciliation must not mutate that state until the handoff
+ * signals a TERMINAL outcome for that same account.
+ *
+ * Two hazards this guards, both found reviewing #6345:
+ *
+ *  - A stale completion. Keying only on account id is not enough: on
+ *    sign-in A -> sign-out -> sign-in A, the first attempt's late completion
+ *    carries a matching id, and SerializedAsyncQueue guarantees it settles
+ *    BEFORE the second attempt runs — so it deterministically released a
+ *    handoff it did not own. Callers now present the token `begin` returned.
+ *
+ *  - An unbounded deferral. The deferral suspends the live entitlement
+ *    boundary, so it must never outlive the free-tier gate's own grace
+ *    window. `begin` arms an expiry that releases the latch and runs the
+ *    pending reconciliation itself, so a sign-in that never reaches a
+ *    terminal outcome (a 503 whose retry never lands, a stalled token) can
+ *    delay enforcement but never cancel it.
  */
 export class TierPreferenceHandoff {
   private activeUserId: string | null = null;
+  private generation = 0;
+  private expiryTimer: ReturnType<typeof setTimeout> | null = null;
+  private onExpire: (() => void) | null = null;
 
-  begin(userId: string): void {
+  private readonly graceMs: number;
+  private readonly schedule: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly cancel: (handle: ReturnType<typeof setTimeout>) => void;
+
+  constructor(options: TierPreferenceHandoffOptions = {}) {
+    this.graceMs = options.graceMs ?? AUTH_SETTLE_GRACE_MS;
+    this.schedule = options.schedule ?? ((fn, ms) => setTimeout(fn, ms));
+    this.cancel = options.cancel ?? ((handle) => clearTimeout(handle));
+  }
+
+  /**
+   * Arm the deferral for `userId`. Returns the token that may later complete
+   * it; `onExpire` runs if no terminal outcome arrives within the grace window.
+   */
+  begin(userId: string, onExpire?: () => void): number {
+    this.disarmExpiry();
     this.activeUserId = userId;
+    this.onExpire = onExpire ?? null;
+    const generation = ++this.generation;
+    this.expiryTimer = this.schedule(() => {
+      this.expiryTimer = null;
+      if (this.generation !== generation || this.activeUserId !== userId) return;
+      this.activeUserId = null;
+      const expired = this.onExpire;
+      this.onExpire = null;
+      expired?.();
+    }, this.graceMs);
+    return generation;
   }
 
   shouldDefer(currentUserId: string | null): boolean {
     return currentUserId !== null && this.activeUserId === currentUserId;
   }
 
-  /** Return true only when this completion still belongs to the active account. */
-  complete(userId: string, currentUserId: string | null): boolean {
-    if (this.activeUserId !== userId) return false;
+  /**
+   * Release the handoff. Returns true only when this completion still owns the
+   * active handoff AND that account is still signed in — i.e. when the caller
+   * should now reconcile.
+   */
+  complete(generation: number, userId: string, currentUserId: string | null): boolean {
+    if (generation !== this.generation || this.activeUserId !== userId) return false;
+    this.disarmExpiry();
     this.activeUserId = null;
+    this.onExpire = null;
     return currentUserId === userId;
   }
 
   clear(): void {
+    this.disarmExpiry();
     this.activeUserId = null;
+    this.onExpire = null;
+  }
+
+  private disarmExpiry(): void {
+    if (this.expiryTimer === null) return;
+    this.cancel(this.expiryTimer);
+    this.expiryTimer = null;
   }
 }

--- a/src/app/tier-preference-handoff.ts
+++ b/src/app/tier-preference-handoff.ts
@@ -1,8 +1,20 @@
 import { AUTH_SETTLE_GRACE_MS } from '@/app/free-tier-gate';
+import { RETRY_AFTER_MAX_SEC } from '@/utils/cloud-prefs-retry';
+
+/**
+ * Hard ceiling on the deferral. A sign-in that hit a 503 may legitimately be
+ * waiting out a `Retry-After` longer than one grace window, so the expiry
+ * postpones itself while that retry is genuinely pending — but never past the
+ * longest delay the retry scheduler will ever honour, after which enforcement
+ * wins over waiting.
+ */
+const MAX_TOTAL_DEFERRAL_MS = AUTH_SETTLE_GRACE_MS + RETRY_AFTER_MAX_SEC * 1000;
 
 interface TierPreferenceHandoffOptions {
-  /** Upper bound on how long reconciliation may be deferred. */
+  /** How long one deferral window lasts before the expiry is considered. */
   graceMs?: number;
+  /** Absolute ceiling across all postponements. */
+  maxTotalDeferralMs?: number;
   /** Injected so boundary behaviour is testable without a live clock. */
   schedule?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
   cancel?: (handle: ReturnType<typeof setTimeout>) => void;
@@ -34,33 +46,58 @@ export class TierPreferenceHandoff {
   private expiryTimer: ReturnType<typeof setTimeout> | null = null;
   private onExpire: (() => void) | null = null;
 
+  private onPostponeCheck: (() => boolean) | null = null;
+  private postponementsRemaining = 0;
+
   private readonly graceMs: number;
+  private readonly maxTotalDeferralMs: number;
   private readonly schedule: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
   private readonly cancel: (handle: ReturnType<typeof setTimeout>) => void;
 
   constructor(options: TierPreferenceHandoffOptions = {}) {
     this.graceMs = options.graceMs ?? AUTH_SETTLE_GRACE_MS;
+    this.maxTotalDeferralMs = options.maxTotalDeferralMs ?? MAX_TOTAL_DEFERRAL_MS;
     this.schedule = options.schedule ?? ((fn, ms) => setTimeout(fn, ms));
     this.cancel = options.cancel ?? ((handle) => clearTimeout(handle));
   }
 
   /**
    * Arm the deferral for `userId`. Returns the token that may later complete
-   * it; `onExpire` runs if no terminal outcome arrives within the grace window.
+   * it.
+   *
+   * `onExpire` runs once the deferral gives up waiting. `shouldPostpone` lets
+   * the caller say "the cloud sign-in is still legitimately in flight" — a 503
+   * whose `Retry-After` outlasts one grace window. Postponing is bounded by
+   * `maxTotalDeferralMs`, so a permanently failing sync delays enforcement but
+   * can never cancel it.
    */
-  begin(userId: string, onExpire?: () => void): number {
+  begin(userId: string, onExpire?: () => void, shouldPostpone?: () => boolean): number {
     this.disarmExpiry();
     this.activeUserId = userId;
     this.onExpire = onExpire ?? null;
+    this.onPostponeCheck = shouldPostpone ?? null;
+    this.postponementsRemaining = Math.max(
+      0,
+      Math.ceil(this.maxTotalDeferralMs / this.graceMs) - 1,
+    );
     const generation = ++this.generation;
-    this.expiryTimer = this.schedule(() => {
-      this.expiryTimer = null;
-      if (this.generation !== generation || this.activeUserId !== userId) return;
-      this.activeUserId = null;
-      const expired = this.onExpire;
-      this.onExpire = null;
-      expired?.();
-    }, this.graceMs);
+    const armExpiry = (): void => {
+      this.expiryTimer = this.schedule(() => {
+        this.expiryTimer = null;
+        if (this.generation !== generation || this.activeUserId !== userId) return;
+        if (this.postponementsRemaining > 0 && this.onPostponeCheck?.() === true) {
+          this.postponementsRemaining -= 1;
+          armExpiry();
+          return;
+        }
+        this.activeUserId = null;
+        const expired = this.onExpire;
+        this.onExpire = null;
+        this.onPostponeCheck = null;
+        expired?.();
+      }, this.graceMs);
+    };
+    armExpiry();
     return generation;
   }
 
@@ -78,6 +115,7 @@ export class TierPreferenceHandoff {
     this.disarmExpiry();
     this.activeUserId = null;
     this.onExpire = null;
+    this.onPostponeCheck = null;
     return currentUserId === userId;
   }
 
@@ -85,6 +123,7 @@ export class TierPreferenceHandoff {
     this.disarmExpiry();
     this.activeUserId = null;
     this.onExpire = null;
+    this.onPostponeCheck = null;
   }
 
   private disarmExpiry(): void {

--- a/src/utils/cloud-prefs-retry.ts
+++ b/src/utils/cloud-prefs-retry.ts
@@ -1,5 +1,10 @@
 const RETRY_AFTER_MIN_SEC = 1;
-const RETRY_AFTER_MAX_SEC = 60;
+/**
+ * Upper clamp on a honoured `Retry-After`. Exported so callers that must wait
+ * out a pending retry can size their own deadline against the longest delay
+ * this module will ever schedule, instead of guessing a magic number.
+ */
+export const RETRY_AFTER_MAX_SEC = 60;
 const RETRY_AFTER_DEFAULT_SEC = 5;
 
 export function isTemporaryCloudPrefsStatus(status: number): boolean {

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -12,7 +12,7 @@
  * Desktop guard: isDesktopRuntime() always skips sync.
  */
 
-import { CLOUD_SYNC_KEYS, type CloudSyncKey } from './sync-keys';
+import { CLOUD_SYNC_KEYS, resolveCloudBlobKeyAction, type CloudSyncKey } from './sync-keys';
 import { isDesktopRuntime } from '@/services/runtime';
 import { getClerkToken } from '@/services/clerk';
 import {
@@ -242,6 +242,21 @@ function clearRetryTimer(): void {
   }
 }
 
+/**
+ * Whether a sign-in sync is waiting on a scheduled 503 retry.
+ *
+ * `onSignIn`'s promise resolves as soon as the retry is ARMED, not when the
+ * cloud blob is finally applied — the catch schedules the timer and returns
+ * without awaiting it. A caller that treats that resolution as "the account's
+ * preferences have landed" acts on pre-cloud local state (see
+ * TierPreferenceHandoff). The 503 branch assigns `_retryTimer` before the
+ * queued task returns, so this is already true by the time the promise's
+ * `.then` runs.
+ */
+export function hasPendingCloudPrefsRetry(): boolean {
+  return _retryTimer !== null;
+}
+
 // ── Guards ────────────────────────────────────────────────────────────────────
 
 function isEnabled(): boolean {
@@ -290,11 +305,16 @@ function applyCloudBlob(data: Record<string, unknown>, syncVersion?: number): vo
   _suppressPatch = true;
   try {
     for (const key of CLOUD_SYNC_KEYS) {
-      const val = data[key];
-      if (typeof val === 'string') {
-        if (localStorage.getItem(key) !== val) changedKeys.push(key);
-        localStorage.setItem(key, val);
-      } else if (!(key in data)) {
+      // An omitted key normally means the user cleared it. For the free-tier
+      // ownership sidecars it instead means the row predates them (or an older
+      // tab uploaded), and deleting them strands the gate's own disables as
+      // user intent forever. See resolveCloudBlobKeyAction.
+      const action = resolveCloudBlobKeyAction(key, data);
+      if (action.kind === 'keep') continue;
+      if (action.kind === 'set') {
+        if (localStorage.getItem(key) !== action.value) changedKeys.push(key);
+        localStorage.setItem(key, action.value);
+      } else {
         if (localStorage.getItem(key) !== null) changedKeys.push(key);
         localStorage.removeItem(key);
       }

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -12,7 +12,12 @@
  * Desktop guard: isDesktopRuntime() always skips sync.
  */
 
-import { CLOUD_SYNC_KEYS, resolveCloudBlobKeyAction, type CloudSyncKey } from './sync-keys';
+import {
+  ABSENCE_TOLERANT_SYNC_KEYS,
+  CLOUD_SYNC_KEYS,
+  resolveCloudBlobKeyAction,
+  type CloudSyncKey,
+} from './sync-keys';
 import { isDesktopRuntime } from '@/services/runtime';
 import { getClerkToken } from '@/services/clerk';
 import {
@@ -53,10 +58,23 @@ export { isTemporaryCloudPrefsStatus, parseRetryAfterSeconds } from './cloud-pre
 
 const ENABLED = import.meta.env.VITE_CLOUD_PREFS_ENABLED === 'true';
 export const CLOUD_PREFS_APPLIED_EVENT = 'wm:cloud-prefs-applied';
+export const CLOUD_PREFS_SIGN_IN_TERMINAL_EVENT = 'wm:cloud-prefs-sign-in-terminal';
 
 export interface CloudPrefsAppliedDetail {
   keys: CloudSyncKey[];
   syncVersion?: number;
+}
+
+export interface CloudPrefsSignInTerminalDetail {
+  accountId: string;
+  authGeneration: number;
+  handoffGeneration: number;
+  origin: 'sign-in';
+  outcome: 'synced' | 'error' | 'skipped';
+}
+
+export interface CloudPrefsSignInOptions {
+  handoffGeneration?: number;
 }
 
 // localStorage state keys — never uploaded to cloud
@@ -230,6 +248,8 @@ function clearSettledDirtyKeys(postedBlob: Record<string, string>): void {
 // produce a misleading sync attempt and pollute Sentry with confused errors.
 
 let _retryTimer: ReturnType<typeof setTimeout> | null = null;
+let _signInRetryTimer: ReturnType<typeof setTimeout> | null = null;
+let _pendingSignInRetryGeneration: number | null = null;
 let _authGeneration = 0;
 const _syncOperations = new SerializedAsyncQueue();
 let _activeUploadPromise: Promise<void> | null = null;
@@ -240,6 +260,14 @@ function clearRetryTimer(): void {
     clearTimeout(_retryTimer);
     _retryTimer = null;
   }
+}
+
+function clearSignInRetry(): void {
+  if (_signInRetryTimer !== null) {
+    clearTimeout(_signInRetryTimer);
+    _signInRetryTimer = null;
+  }
+  _pendingSignInRetryGeneration = null;
 }
 
 /**
@@ -254,7 +282,7 @@ function clearRetryTimer(): void {
  * `.then` runs.
  */
 export function hasPendingCloudPrefsRetry(): boolean {
-  return _retryTimer !== null;
+  return _pendingSignInRetryGeneration === _authGeneration;
 }
 
 // ── Guards ────────────────────────────────────────────────────────────────────
@@ -298,6 +326,40 @@ function dispatchCloudPrefsApplied(keys: CloudSyncKey[], syncVersion?: number): 
   window.dispatchEvent(new CustomEvent<CloudPrefsAppliedDetail>(CLOUD_PREFS_APPLIED_EVENT, {
     detail: { keys, ...(syncVersion === undefined ? {} : { syncVersion }) },
   }));
+}
+
+function dispatchCloudPrefsSignInTerminal(
+  accountId: string,
+  authGeneration: number,
+  handoffGeneration: number | undefined,
+  outcome: CloudPrefsSignInTerminalDetail['outcome'],
+): void {
+  if (handoffGeneration === undefined || typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent<CloudPrefsSignInTerminalDetail>(
+    CLOUD_PREFS_SIGN_IN_TERMINAL_EVENT,
+    {
+      detail: {
+        accountId,
+        authGeneration,
+        handoffGeneration,
+        origin: 'sign-in',
+        outcome,
+      },
+    },
+  ));
+}
+
+function clearForeignOwnershipSidecars(userId: string): void {
+  const lastSignedInAs = localStorage.getItem(KEY_LAST_SIGNED_IN_AS);
+  if (lastSignedInAs === null || lastSignedInAs === userId) return;
+
+  // Preferences intentionally survive sign-out, but ownership sidecars are
+  // account provenance. If the next account has a legacy row that omits them,
+  // keeping the prior account's local values attributes A's gate decisions to
+  // B. B's explicit cloud values will still be applied later in this attempt.
+  for (const key of ABSENCE_TOLERANT_SYNC_KEYS) {
+    Storage.prototype.removeItem.call(localStorage, key);
+  }
 }
 
 function applyCloudBlob(data: Record<string, unknown>, syncVersion?: number): void {
@@ -583,21 +645,35 @@ async function resolveConflictWithMerge(token: string, variant: string, callerGe
   return true;
 }
 
-export function onSignIn(userId: string, variant: string): Promise<void> {
-  if (!isEnabled()) return Promise.resolve();
+interface SignInAttempt {
+  userId: string;
+  variant: string;
+  authGeneration: number;
+  handoffGeneration?: number;
+}
 
-  // New onSignIn entry — invalidate any pending 503 retry so a stale
-  // closure can't fire mid-flight, and bump generation so any timer that
-  // was already scheduled (and not yet caught by clearRetryTimer) bails
-  // when it fires.
-  clearRetryTimer();
-  _authGeneration += 1;
-  const myGeneration = _authGeneration;
-  // Establish dirty-key ownership synchronously. Preference writes may happen
-  // while this sign-in waits behind an older queued writer; hydrating inside
-  // the queued callback would then clear those new edits or attribute them to
-  // the previous account.
-  hydrateDirtyKeysFromStorage(userId);
+function completeSignInAttempt(
+  attempt: SignInAttempt,
+  outcome: CloudPrefsSignInTerminalDetail['outcome'],
+): void {
+  if (_authGeneration !== attempt.authGeneration) return;
+  if (_pendingSignInRetryGeneration === attempt.authGeneration) {
+    _pendingSignInRetryGeneration = null;
+  }
+  dispatchCloudPrefsSignInTerminal(
+    attempt.userId,
+    attempt.authGeneration,
+    attempt.handoffGeneration,
+    outcome,
+  );
+}
+
+function runSignInAttempt(attempt: SignInAttempt): Promise<void> {
+  const {
+    userId,
+    variant,
+    authGeneration: myGeneration,
+  } = attempt;
 
   return _syncOperations.run(async () => {
     if (_authGeneration !== myGeneration) return;
@@ -608,7 +684,11 @@ export function onSignIn(userId: string, variant: string): Promise<void> {
     try {
       const token = await getCloudPrefsToken();
       if (_authGeneration !== myGeneration) return;
-      if (!token) { setState('error'); return; }
+      if (!token) {
+        setState('error');
+        completeSignInAttempt(attempt, 'error');
+        return;
+      }
       _cachedToken = token;
 
       const cloud = await fetchCloudPrefs(token, variant);
@@ -665,7 +745,10 @@ export function onSignIn(userId: string, variant: string): Promise<void> {
           // Merge instead of clobber — see resolveConflictWithMerge. The old
           // path here applied the cloud blob over localStorage and stopped,
           // discarding the local edits this branch was trying to upload.
-          await resolveConflictWithMerge(token, variant, myGeneration);
+          if (!await resolveConflictWithMerge(token, variant, myGeneration)) {
+            completeSignInAttempt(attempt, 'error');
+            return;
+          }
         } else {
           setSyncVersion(result.syncVersion);
           clearSettledDirtyKeys(prepared.data);
@@ -676,6 +759,7 @@ export function onSignIn(userId: string, variant: string): Promise<void> {
 
       if (_authGeneration === myGeneration) {
         Storage.prototype.setItem.call(localStorage, KEY_LAST_SIGNED_IN_AS, userId);
+        completeSignInAttempt(attempt, 'synced');
       }
     } catch (err) {
       if (_authGeneration !== myGeneration) return;
@@ -687,25 +771,77 @@ export function onSignIn(userId: string, variant: string): Promise<void> {
         // 'error' and the user's prefs would silently not sync until they
         // reload.
         //
-        // Generation guard: cancel any prior pending retry, then schedule a
-        // new one whose callback bails if `_authGeneration` has advanced
-        // (sign-out, user-switch, or another onSignIn invocation since this
-        // attempt began). Without the guard, a 5s delayed retry from user A
-        // could fire after sign-out (no token) or after user B signed in
-        // (wrong token in cache).
+        // Keep this attempt logically pending through both the scheduled wait
+        // and the recursively invoked request. The handoff expiry consults
+        // this generation-scoped marker, so firing the timer must not create
+        // an 8-15 second gap where the request is active but looks idle.
         console.warn(`[cloud-prefs] onSignIn ${err.status}; retrying in ${err.retryAfterSec}s`);
         setState('pending');
-        clearRetryTimer();
-        _retryTimer = setTimeout(() => {
-          _retryTimer = null;
-          if (_authGeneration !== myGeneration) return;
-          void onSignIn(userId, variant);
+        clearSignInRetry();
+        _pendingSignInRetryGeneration = myGeneration;
+        _signInRetryTimer = setTimeout(() => {
+          _signInRetryTimer = null;
+          if (_authGeneration !== myGeneration) {
+            if (_pendingSignInRetryGeneration === myGeneration) {
+              _pendingSignInRetryGeneration = null;
+            }
+            return;
+          }
+          void runSignInAttempt(attempt);
         }, err.retryAfterSec * 1000);
         return;
       }
       console.warn('[cloud-prefs] onSignIn failed:', err);
       setState(!navigator.onLine || (err instanceof TypeError && err.message.includes('fetch')) ? 'offline' : 'error');
+      completeSignInAttempt(attempt, 'error');
     }
+  });
+}
+
+export function onSignIn(
+  userId: string,
+  variant: string,
+  options: CloudPrefsSignInOptions = {},
+): Promise<void> {
+  if (!isEnabled()) {
+    // The account handoff still needs a real terminal signal when cloud sync
+    // is feature-disabled or unavailable in the desktop runtime. Without it,
+    // tier-owned preferences remain deferred until the expiry timer fires.
+    dispatchCloudPrefsSignInTerminal(
+      userId,
+      _authGeneration,
+      options.handoffGeneration,
+      'skipped',
+    );
+    return Promise.resolve();
+  }
+
+  // New onSignIn entry invalidates both upload and sign-in retry closures.
+  // Recursive sign-in retries use runSignInAttempt directly, preserving this
+  // generation until they reach a real terminal outcome.
+  clearRetryTimer();
+  clearSignInRetry();
+  _authGeneration += 1;
+  const myGeneration = _authGeneration;
+
+  // Ownership sidecars describe which changes a particular account's gate
+  // produced. Preserve them for a same-account legacy cloud row, but never
+  // carry them across an observed account transition.
+  clearForeignOwnershipSidecars(userId);
+
+  // Establish dirty-key ownership synchronously. Preference writes may happen
+  // while this sign-in waits behind an older queued writer; hydrating inside
+  // the queued callback would then clear those new edits or attribute them to
+  // the previous account.
+  hydrateDirtyKeysFromStorage(userId);
+
+  return runSignInAttempt({
+    userId,
+    variant,
+    authGeneration: myGeneration,
+    ...(options.handoffGeneration === undefined
+      ? {}
+      : { handoffGeneration: options.handoffGeneration }),
   });
 }
 
@@ -743,6 +879,7 @@ export function onSignOut(): void {
   // onSignIn / uploadNow against the now-empty token cache or, worse, against
   // a different user's token after a fast user switch.
   clearRetryTimer();
+  clearSignInRetry();
   _authGeneration += 1;
   _cachedToken = null;
   // Dirty-key tracking is user-scoped. Clear the in-memory owner on sign-out,

--- a/src/utils/sync-keys.ts
+++ b/src/utils/sync-keys.ts
@@ -46,3 +46,47 @@ export const CLOUD_SYNC_KEYS = [
 ] as const;
 
 export type CloudSyncKey = (typeof CLOUD_SYNC_KEYS)[number];
+
+/**
+ * Keys whose ABSENCE from a cloud row must not be read as "the user cleared
+ * this". `applyCloudBlob` deletes any synced key the incoming row omits, which
+ * is correct for a preference the user can reset but wrong for the free-tier
+ * gate's ownership sidecars: every row written before #6345 lacks them, as does
+ * every upload from an older tab still running a pre-#6345 bundle.
+ *
+ * Deleting them locally is not a cosmetic loss. Without the sidecar,
+ * `reconcileSourceLimitForTier` sees no ownership metadata,
+ * `inferExactSourceGateOwnership` declines to guess for any customized profile,
+ * and the gate's own disables become indistinguishable from deliberate user
+ * choices — so a later Pro upgrade can never reverse them. That is precisely
+ * the bug #6345 exists to fix, reintroduced through the cloud path.
+ *
+ * Tolerating absence loses nothing, because an intentional clear is always an
+ * explicit empty-array write (see `persistGateOwnershipTransition`'s Pro path
+ * and the variant reset in App.ts), never an omission.
+ */
+export const ABSENCE_TOLERANT_SYNC_KEYS: ReadonlySet<CloudSyncKey> = new Set([
+  'worldmonitor-free-tier-source-ownership',
+  'worldmonitor-free-tier-layer-ownership',
+] satisfies CloudSyncKey[]);
+
+export type CloudBlobKeyAction =
+  | { kind: 'set'; value: string }
+  | { kind: 'remove' }
+  | { kind: 'keep' };
+
+/**
+ * What applying an incoming cloud row should do to one local key.
+ *
+ * Extracted as a pure decision so the absence rule is testable against real
+ * key names rather than asserted by grepping the applier's source text.
+ */
+export function resolveCloudBlobKeyAction(
+  key: CloudSyncKey,
+  data: Record<string, unknown>,
+): CloudBlobKeyAction {
+  const value = data[key];
+  if (typeof value === 'string') return { kind: 'set', value };
+  if (!(key in data) && !ABSENCE_TOLERANT_SYNC_KEYS.has(key)) return { kind: 'remove' };
+  return { kind: 'keep' };
+}

--- a/tests/cloud-prefs-absent-key-tolerance.test.mts
+++ b/tests/cloud-prefs-absent-key-tolerance.test.mts
@@ -1,0 +1,104 @@
+// A cloud row that OMITS a synced key normally means "the user cleared it",
+// and applyCloudBlob deletes the local value. That rule is wrong for the
+// free-tier gate's ownership sidecars (#6345 follow-up): every row written
+// before they existed lacks them, as does every upload from an older tab.
+//
+// Deleting them is not cosmetic. Without the sidecar,
+// reconcileSourceLimitForTier sees no ownership metadata,
+// inferExactSourceGateOwnership declines to guess for any customized profile,
+// and the gate's own disables become indistinguishable from deliberate user
+// choices — so a later Pro upgrade can never reverse them. That is exactly the
+// bug #6345 shipped to fix, reintroduced through the cloud path.
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  ABSENCE_TOLERANT_SYNC_KEYS,
+  CLOUD_SYNC_KEYS,
+  resolveCloudBlobKeyAction,
+} from '../src/utils/sync-keys.ts';
+
+const SOURCE_OWNERSHIP = 'worldmonitor-free-tier-source-ownership';
+const LAYER_OWNERSHIP = 'worldmonitor-free-tier-layer-ownership';
+
+describe('cloud blob absent-key tolerance', () => {
+  it('keeps both ownership sidecars when the row predates them', () => {
+    // A pre-#6345 row: real preferences, no ownership keys at all.
+    const legacyRow = {
+      'worldmonitor-disabled-feeds': '["Some Source"]',
+      'worldmonitor-layers': '{"conflicts":true}',
+    };
+
+    assert.deepEqual(
+      resolveCloudBlobKeyAction(SOURCE_OWNERSHIP, legacyRow),
+      { kind: 'keep' },
+      'a row without the source sidecar must not delete local ownership',
+    );
+    assert.deepEqual(
+      resolveCloudBlobKeyAction(LAYER_OWNERSHIP, legacyRow),
+      { kind: 'keep' },
+      'a row without the layer sidecar must not delete local ownership',
+    );
+  });
+
+  it('still deletes an ordinary preference the row omits', () => {
+    // The absence rule must stay intact for keys the user can genuinely clear,
+    // otherwise a cleared preference would resurrect on every sign-in.
+    assert.deepEqual(
+      resolveCloudBlobKeyAction('worldmonitor-monitors', {}),
+      { kind: 'remove' },
+    );
+    assert.deepEqual(
+      resolveCloudBlobKeyAction('worldmonitor-disabled-feeds', {}),
+      { kind: 'remove' },
+    );
+  });
+
+  it('applies an explicit empty ownership set, so a real clear still propagates', () => {
+    // Tolerating ABSENCE only works because an intentional clear is written as
+    // an explicit empty array (the Pro restore path and the variant reset both
+    // do this). If that stopped being true, ownership could never be cleared
+    // cross-device.
+    assert.deepEqual(
+      resolveCloudBlobKeyAction(SOURCE_OWNERSHIP, { [SOURCE_OWNERSHIP]: '[]' }),
+      { kind: 'set', value: '[]' },
+    );
+    assert.deepEqual(
+      resolveCloudBlobKeyAction(LAYER_OWNERSHIP, { [LAYER_OWNERSHIP]: '[]' }),
+      { kind: 'set', value: '[]' },
+    );
+  });
+
+  it('applies a populated ownership set like any other value', () => {
+    assert.deepEqual(
+      resolveCloudBlobKeyAction(SOURCE_OWNERSHIP, { [SOURCE_OWNERSHIP]: '["A","B"]' }),
+      { kind: 'set', value: '["A","B"]' },
+    );
+  });
+
+  it('tolerates absence for exactly the two ownership sidecars', () => {
+    // Pins the blast radius: widening this set silently makes some other
+    // preference impossible to clear from another device.
+    assert.deepEqual(
+      [...ABSENCE_TOLERANT_SYNC_KEYS].sort(),
+      [LAYER_OWNERSHIP, SOURCE_OWNERSHIP].sort(),
+    );
+    for (const key of ABSENCE_TOLERANT_SYNC_KEYS) {
+      assert.ok(
+        CLOUD_SYNC_KEYS.includes(key),
+        `${key} must be a real cloud-sync key`,
+      );
+    }
+  });
+
+  it('leaves every other synced key deletable on absence', () => {
+    const notDeletable = CLOUD_SYNC_KEYS.filter(
+      (key) => resolveCloudBlobKeyAction(key, {}).kind !== 'remove',
+    );
+    assert.deepEqual(
+      notDeletable.sort(),
+      [LAYER_OWNERSHIP, SOURCE_OWNERSHIP].sort(),
+    );
+  });
+});

--- a/tests/cloud-prefs-sync-concurrency.test.mts
+++ b/tests/cloud-prefs-sync-concurrency.test.mts
@@ -55,6 +55,10 @@ interface HeldRequest {
 
 interface HarnessControls {
   dispatchHidden: () => void;
+  events: Array<{ detail: unknown; type: string }>;
+  failNextGetTemporarily: () => void;
+  fireSignInRetry: () => void;
+  holdNextGet: () => HeldRequest;
   holdNextPost: () => HeldRequest;
   seedRow: (token: string, data: Record<string, string>, syncVersion: number, schemaVersion?: number) => void;
   setToken: (token: string) => void;
@@ -63,14 +67,17 @@ interface HarnessControls {
 }
 
 let harnessSequence = 0;
-let bundledSourcePromise: Promise<string> | null = null;
+const bundledSourcePromises = new Map<boolean, Promise<string>>();
 
 after(() => {
   stop();
 });
 
-async function getBundledSource(): Promise<string> {
-  bundledSourcePromise ??= build({
+async function getBundledSource(enabled = true): Promise<string> {
+  let bundledSourcePromise = bundledSourcePromises.get(enabled);
+  if (bundledSourcePromise) return bundledSourcePromise;
+
+  bundledSourcePromise = build({
     absWorkingDir: root,
     entryPoints: ['src/utils/cloud-prefs-sync.ts'],
     bundle: true,
@@ -78,7 +85,7 @@ async function getBundledSource(): Promise<string> {
     platform: 'browser',
     write: false,
     define: {
-      'import.meta.env.VITE_CLOUD_PREFS_ENABLED': '"true"',
+      'import.meta.env.VITE_CLOUD_PREFS_ENABLED': enabled ? '"true"' : '"false"',
     },
     plugins: [{
       name: 'cloud-prefs-test-stubs',
@@ -98,11 +105,12 @@ async function getBundledSource(): Promise<string> {
       },
     }],
   }).then((bundled) => bundled.outputFiles[0]!.text);
+  bundledSourcePromises.set(enabled, bundledSourcePromise);
   return bundledSourcePromise;
 }
 
-async function loadCloudPrefsModule() {
-  const source = await getBundledSource();
+async function loadCloudPrefsModule(enabled = true) {
+  const source = await getBundledSource(enabled);
   const encoded = Buffer.from(source).toString('base64');
   harnessSequence += 1;
   return import(`data:text/javascript;base64,${encoded}#harness-${harnessSequence}`);
@@ -113,6 +121,7 @@ async function runHarness(
     cloudPrefs: Awaited<ReturnType<typeof loadCloudPrefsModule>>,
     controls: HarnessControls,
   ) => Promise<void>,
+  { enabled = true }: { enabled?: boolean } = {},
 ): Promise<HarnessResult> {
   const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
   const originalCloudPrefsToken = Object.getOwnPropertyDescriptor(globalThis, '__cloudPrefsToken');
@@ -125,7 +134,9 @@ async function runHarness(
     localStorage: globalThis.localStorage,
     window: globalThis.window,
   };
+  const originalSetTimeout = globalThis.setTimeout;
   const stateHistory: string[] = [];
+  const events: Array<{ detail: unknown; type: string }> = [];
   class TestStorage extends MiniStorage {
     override setItem(key: string, value: string): void {
       super.setItem(key, value);
@@ -172,7 +183,14 @@ async function runHarness(
 
   Object.assign(globalThis, {
     __cloudPrefsToken: 'test-token',
-    CustomEvent: class TestCustomEvent {},
+    CustomEvent: class TestCustomEvent {
+      detail: unknown;
+      type: string;
+      constructor(type: string, init?: { detail?: unknown }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    },
     Storage: TestStorage,
     document: documentStub,
     localStorage: storage,
@@ -182,7 +200,12 @@ async function runHarness(
         listeners.push(listener);
         windowListeners.set(type, listeners);
       },
-      dispatchEvent() {},
+      dispatchEvent(event: { detail?: unknown; type?: string }) {
+        const type = event.type ?? '';
+        events.push({ type, detail: event.detail });
+        for (const listener of windowListeners.get(type) ?? []) listener();
+        return true;
+      },
     },
   });
   Object.defineProperty(globalThis, 'navigator', {
@@ -205,6 +228,25 @@ async function runHarness(
     resolveStarted: () => void;
   } | null = null;
   let timeoutNextRequest = false;
+  let failNextGetTemporarily = false;
+  let captureSignInRetryTimer = false;
+  let pendingSignInRetry: (() => void) | null = null;
+  let pendingGetHold: {
+    releasePromise: Promise<void>;
+    resolveRelease: () => void;
+    resolveStarted: () => void;
+  } | null = null;
+
+  globalThis.setTimeout = ((callback: TimerHandler, delay?: number, ...args: unknown[]) => {
+    if (captureSignInRetryTimer && (delay ?? 0) >= 1000) {
+      captureSignInRetryTimer = false;
+      pendingSignInRetry = () => {
+        if (typeof callback === 'function') callback(...args);
+      };
+      return 987_654 as unknown as ReturnType<typeof setTimeout>;
+    }
+    return originalSetTimeout(callback, delay, ...args);
+  }) as typeof setTimeout;
 
   AbortSignal.timeout = ((_delay: number) => {
     const controller = new AbortController();
@@ -223,6 +265,20 @@ async function runHarness(
     const token = authorization.replace(/^Bearer\s+/, '') || 'anonymous';
     const row = rows.get(token) ?? { data: {}, schemaVersion: 2, syncVersion: 0 };
     if (method === 'GET') {
+      if (failNextGetTemporarily) {
+        failNextGetTemporarily = false;
+        captureSignInRetryTimer = true;
+        return Response.json(
+          { error: 'SERVICE_UNAVAILABLE' },
+          { status: 503, headers: { 'Retry-After': '1' } },
+        );
+      }
+      const held = pendingGetHold;
+      if (held) {
+        pendingGetHold = null;
+        held.resolveStarted();
+        await held.releasePromise;
+      }
       return Response.json({
         data: row.data,
         schemaVersion: row.schemaVersion,
@@ -241,7 +297,7 @@ async function runHarness(
     }
 
     await new Promise<void>((resolveDelay, rejectDelay) => {
-      const timer = setTimeout(resolveDelay, 5);
+      const timer = originalSetTimeout(resolveDelay, 5);
       const signal = init.signal;
       signal?.addEventListener('abort', () => {
         clearTimeout(timer);
@@ -274,6 +330,28 @@ async function runHarness(
       documentStub.visibilityState = 'hidden';
       for (const listener of documentListeners.get('visibilitychange') ?? []) listener();
     },
+    events,
+    failNextGetTemporarily: () => {
+      failNextGetTemporarily = true;
+    },
+    fireSignInRetry: () => {
+      const retry = pendingSignInRetry;
+      pendingSignInRetry = null;
+      if (!retry) throw new Error('no sign-in retry is pending');
+      retry();
+    },
+    holdNextGet: () => {
+      let resolveRelease!: () => void;
+      let resolveStarted!: () => void;
+      const releasePromise = new Promise<void>((resolveReleasePromise) => {
+        resolveRelease = resolveReleasePromise;
+      });
+      const started = new Promise<void>((resolveStartedPromise) => {
+        resolveStarted = resolveStartedPromise;
+      });
+      pendingGetHold = { releasePromise, resolveRelease, resolveStarted };
+      return { release: resolveRelease, started };
+    },
     holdNextPost: () => {
       let resolveRelease!: () => void;
       let resolveStarted!: () => void;
@@ -299,7 +377,7 @@ async function runHarness(
   };
 
   try {
-    const cloudPrefs = await loadCloudPrefsModule();
+    const cloudPrefs = await loadCloudPrefsModule(enabled);
     await invoke(cloudPrefs, controls);
     const activeToken = String(Reflect.get(globalThis, '__cloudPrefsToken'));
     const activeRow = rows.get(activeToken) ?? { data: {}, schemaVersion: 2, syncVersion: 0 };
@@ -320,6 +398,7 @@ async function runHarness(
     };
   } finally {
     globalThis.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
     AbortSignal.timeout = originalAbortSignalTimeout;
     Object.assign(globalThis, originals);
     if (originalNavigator) {
@@ -480,5 +559,109 @@ describe('cloud preference write serialization', () => {
     assert.equal(result.conflictCount, 0);
     assert.equal(result.postCount, 2);
     assert.equal(result.serverSyncVersion, 1);
+  });
+
+  it('keeps a sign-in retry pending after its timer fires until the request settles', async () => {
+    await runHarness(async (cloudPrefs, controls) => {
+      controls.seedRow('test-token', {}, 1, 6);
+      controls.failNextGetTemporarily();
+
+      await cloudPrefs.onSignIn('user-1', 'full', { handoffGeneration: 41 });
+      assert.equal(cloudPrefs.hasPendingCloudPrefsRetry(), true);
+
+      const heldGet = controls.holdNextGet();
+      controls.fireSignInRetry();
+      await heldGet.started;
+      assert.equal(
+        cloudPrefs.hasPendingCloudPrefsRetry(),
+        true,
+        'firing the timer must not expose an idle gap while the retry fetch is unresolved',
+      );
+      assert.equal(
+        controls.events.filter((event) => event.type === cloudPrefs.CLOUD_PREFS_SIGN_IN_TERMINAL_EVENT).length,
+        0,
+      );
+
+      heldGet.release();
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 20));
+      assert.equal(cloudPrefs.hasPendingCloudPrefsRetry(), false);
+      const terminalEvents = controls.events.filter(
+        (event) => event.type === cloudPrefs.CLOUD_PREFS_SIGN_IN_TERMINAL_EVENT,
+      );
+      assert.deepEqual(terminalEvents.map((event) => event.detail), [{
+        accountId: 'user-1',
+        authGeneration: 1,
+        handoffGeneration: 41,
+        origin: 'sign-in',
+        outcome: 'synced',
+      }]);
+    });
+  });
+
+  it('emits a scoped terminal event even when cloud apply changes no keys', async () => {
+    await runHarness(async (cloudPrefs, controls) => {
+      controls.seedRow('test-token', {}, 1, 6);
+      await cloudPrefs.onSignIn('user-1', 'full', { handoffGeneration: 73 });
+
+      assert.equal(
+        controls.events.filter((event) => event.type === cloudPrefs.CLOUD_PREFS_APPLIED_EVENT).length,
+        0,
+        'unchanged apply has no generic change event',
+      );
+      const terminal = controls.events.find(
+        (event) => event.type === cloudPrefs.CLOUD_PREFS_SIGN_IN_TERMINAL_EVENT,
+      );
+      assert.deepEqual(terminal?.detail, {
+        accountId: 'user-1',
+        authGeneration: 1,
+        handoffGeneration: 73,
+        origin: 'sign-in',
+        outcome: 'synced',
+      });
+    });
+  });
+
+  it('releases the scoped handoff immediately when cloud sync is disabled', async () => {
+    const result = await runHarness(async (cloudPrefs, controls) => {
+      await cloudPrefs.onSignIn('user-1', 'full', { handoffGeneration: 89 });
+
+      const terminal = controls.events.find(
+        (event) => event.type === cloudPrefs.CLOUD_PREFS_SIGN_IN_TERMINAL_EVENT,
+      );
+      assert.deepEqual(terminal?.detail, {
+        accountId: 'user-1',
+        authGeneration: 0,
+        handoffGeneration: 89,
+        origin: 'sign-in',
+        outcome: 'skipped',
+      });
+    }, { enabled: false });
+
+    assert.equal(result.postCount, 0);
+    assert.equal(result.state, null);
+  });
+
+  it('does not retain account A ownership for account B legacy cloud rows', async () => {
+    await runHarness(async (cloudPrefs, controls) => {
+      const sourceOwnership = 'worldmonitor-free-tier-source-ownership';
+      const layerOwnership = 'worldmonitor-free-tier-layer-ownership';
+      controls.seedRow('user-a-token', {
+        [sourceOwnership]: '["source-a"]',
+        [layerOwnership]: '["resilienceScore"]',
+      }, 1, 6);
+      controls.setToken('user-a-token');
+      await cloudPrefs.onSignIn('user-a', 'full');
+      assert.equal(localStorage.getItem(sourceOwnership), '["source-a"]');
+      assert.equal(localStorage.getItem(layerOwnership), '["resilienceScore"]');
+
+      cloudPrefs.onSignOut();
+      controls.seedRow('user-b-token', { 'worldmonitor-theme': 'light' }, 1, 6);
+      controls.setToken('user-b-token');
+      await cloudPrefs.onSignIn('user-b', 'full');
+
+      assert.equal(localStorage.getItem(sourceOwnership), null);
+      assert.equal(localStorage.getItem(layerOwnership), null);
+      assert.equal(localStorage.getItem('worldmonitor-theme'), 'light');
+    });
   });
 });

--- a/tests/free-tier-ownership-wiring.test.mjs
+++ b/tests/free-tier-ownership-wiring.test.mjs
@@ -114,9 +114,47 @@ describe('free-tier ownership production wiring', () => {
     // ownership: a shared link overwrote the cloud-synced layer preference and
     // seeded gate ownership the user never chose.
     const urlCallSites = app.match(
-      /sanitizeMapLayersForTier\([\s\S]{0,160}?ephemeralSnapshot: true/g,
+      /sanitizeMapLayersForTier\([\s\S]{0,220}?ephemeralSnapshot: true/g,
     ) ?? [];
-    assert.equal(urlCallSites.length, 2, 'both URL layer paths must pass ephemeralSnapshot');
+    assert.equal(urlCallSites.length, 3, 'every URL-derived layer path must pass ephemeralSnapshot');
     assert.doesNotMatch(app, /consumeProOwnership/, 'the superseded option must be gone');
+
+    // state.mapLayers IS the URL snapshot when the session booted from a deep
+    // link, and the boot-time ephemeral pass no-ops while the tier is
+    // unresolved — so THIS heal is the one that actually acts. Running it
+    // non-ephemerally seeded ownership from the link and persisted it.
+    const healStart = app.indexOf('private healLockedMapLayers(');
+    const healEnd = app.indexOf('syncDataFreshnessWithLayers();', healStart);
+    assert.ok(healStart >= 0 && healEnd > healStart, 'healLockedMapLayers must exist');
+    const healBody = app.slice(healStart, healEnd);
+    assert.match(
+      healBody,
+      /this\.sanitizeMapLayersForTier\(\s*this\.state\.mapLayers,\s*fallbackActive,\s*initialUrlLayers \? \{ ephemeralSnapshot: true \} : \{\},?\s*\)/,
+      'the live-layer heal must stay ephemeral for a deep-linked session',
+    );
+  });
+
+  it('releases the handoff when the cloud blob actually lands, not when a retry is armed', () => {
+    // The 503 retry re-enters onSignIn inside cloud-prefs-sync and never comes
+    // back through App's wrapper, so without this release the only path out was
+    // the expiry — which fired at 8s against pre-cloud state while Retry-After
+    // can legitimately run to 60s.
+    const applyStart = app.indexOf('private applyCloudSyncedPrefsToRuntime(');
+    const applyEnd = app.indexOf('invalidatePanelStorageCacheForKeys(keys);', applyStart);
+    assert.ok(applyStart >= 0 && applyEnd > applyStart, 'cloud apply handler must exist');
+    const applyHead = app.slice(applyStart, applyEnd);
+    assert.match(
+      applyHead,
+      /this\.releasePreferenceHandoffOnCloudApply\(\);/,
+      'the applied-blob event must release the handoff',
+    );
+    // Order matters: releasing after the deferral is read would leave this
+    // generation deferred and defeat the fix.
+    assert.ok(
+      applyHead.indexOf('releasePreferenceHandoffOnCloudApply')
+        < applyHead.indexOf('const tierReconciliationDeferred'),
+      'the release must happen before the deferral is evaluated',
+    );
+    assert.match(app, /\(\) => hasPendingCloudPrefsRetry\(\),/, 'expiry must postpone on a pending retry');
   });
 });

--- a/tests/free-tier-ownership-wiring.test.mjs
+++ b/tests/free-tier-ownership-wiring.test.mjs
@@ -62,26 +62,15 @@ describe('free-tier ownership production wiring', () => {
     );
 
     const handoffStart = app.indexOf('cloudPrefsSignIn: (nextUserId) => {');
-    const handoffEnd = app.indexOf('return completion;', handoffStart);
+    const handoffEnd = app.indexOf('},\n          },', handoffStart);
     assert.ok(handoffStart >= 0 && handoffEnd > handoffStart, 'cloudPrefsSignIn wrapper must exist');
     const handoffBody = app.slice(handoffStart, handoffEnd);
-    assert.match(handoffBody, /const completion = cloudPrefsSignIn\(nextUserId, SITE_VARIANT\)/);
-    // A 503 resolves the sign-in promise as soon as the retry is armed, before
-    // any cloud blob is applied; completing then reconciles pre-cloud state.
     assert.match(
       handoffBody,
-      /if \(hasPendingCloudPrefsRetry\(\)\) return;/,
-      'a pending 503 retry must not be treated as a settled handoff',
+      /cloudPrefsSignIn\(nextUserId, SITE_VARIANT, \{\s*handoffGeneration: preferenceHandoffGeneration,/,
+      'the sign-in attempt must carry its caller-owned handoff generation',
     );
-    // The generation token fences a late completion from a previous attempt
-    // for the SAME account id.
-    assert.match(
-      handoffBody,
-      /tierPreferenceHandoff\.complete\(\s*preferenceHandoffGeneration,\s*nextUserId,\s*currentUserId,?\s*\)/,
-      'completion must present the generation token, not the id alone',
-    );
-    assert.match(handoffBody, /reconcileTierOwnedPreferences\(\)/);
-    assert.match(handoffBody, /completion\.then\(finishPreferenceHandoff, finishPreferenceHandoff\)/);
+    assert.doesNotMatch(handoffBody, /\.then\(/, 'promise settlement is not a terminal cloud signal');
   });
 
   it('never advances the legacy variant key outside the durable transition', () => {
@@ -134,27 +123,43 @@ describe('free-tier ownership production wiring', () => {
     );
   });
 
-  it('releases the handoff when the cloud blob actually lands, not when a retry is armed', () => {
-    // The 503 retry re-enters onSignIn inside cloud-prefs-sync and never comes
-    // back through App's wrapper, so without this release the only path out was
-    // the expiry — which fired at 8s against pre-cloud state while Retry-After
-    // can legitimately run to 60s.
+  it('releases the handoff only from a matching scoped sign-in terminal event', () => {
     const applyStart = app.indexOf('private applyCloudSyncedPrefsToRuntime(');
     const applyEnd = app.indexOf('invalidatePanelStorageCacheForKeys(keys);', applyStart);
     assert.ok(applyStart >= 0 && applyEnd > applyStart, 'cloud apply handler must exist');
     const applyHead = app.slice(applyStart, applyEnd);
-    assert.match(
-      applyHead,
-      /this\.releasePreferenceHandoffOnCloudApply\(\);/,
-      'the applied-blob event must release the handoff',
-    );
-    // Order matters: releasing after the deferral is read would leave this
-    // generation deferred and defeat the fix.
-    assert.ok(
-      applyHead.indexOf('releasePreferenceHandoffOnCloudApply')
-        < applyHead.indexOf('const tierReconciliationDeferred'),
-      'the release must happen before the deferral is evaluated',
+    assert.doesNotMatch(applyHead, /tierPreferenceHandoff\.complete/,
+      'generic apply events, including local migrations, must not release the handoff');
+
+    const terminalStart = app.indexOf('private readonly handleCloudPrefsSignInTerminal');
+    const terminalEnd = app.indexOf('private applyCloudSyncedPrefsToRuntime', terminalStart);
+    assert.ok(terminalStart >= 0 && terminalEnd > terminalStart, 'terminal handler must exist');
+    const terminalBody = app.slice(terminalStart, terminalEnd);
+    assert.match(terminalBody, /detail\?\.origin !== 'sign-in'/);
+    assert.match(terminalBody, /detail\.handoffGeneration !== pendingGeneration/);
+    assert.match(terminalBody, /detail\.accountId,\s*currentUserId/);
+    assert.equal(
+      (terminalBody.match(/this\.reconcileTierOwnedPreferences\(\)/g) ?? []).length,
+      1,
+      'a matching terminal event must run one full reconciliation pass',
     );
     assert.match(app, /\(\) => hasPendingCloudPrefsRetry\(\),/, 'expiry must postpone on a pending retry');
+  });
+
+  it('disarms an armed preference handoff before App module teardown', () => {
+    const destroyStart = app.indexOf('public destroy(): void {');
+    const destroyEnd = app.indexOf('private async initFindingsBadge', destroyStart);
+    assert.ok(destroyStart >= 0 && destroyEnd > destroyStart, 'App.destroy must exist');
+    const destroyBody = app.slice(destroyStart, destroyEnd);
+    const clearIndex = destroyBody.indexOf('this.tierPreferenceHandoff.clear();');
+    const generationIndex = destroyBody.indexOf('this.pendingPreferenceHandoffGeneration = undefined;');
+    const moduleTeardownIndex = destroyBody.indexOf('// Destroy all modules in reverse order');
+
+    assert.ok(clearIndex >= 0, 'destroy must cancel the armed handoff expiry');
+    assert.ok(generationIndex > clearIndex, 'destroy must invalidate the pending generation');
+    assert.ok(
+      moduleTeardownIndex > generationIndex,
+      'handoff teardown must finish before module teardown can trigger late effects',
+    );
   });
 });

--- a/tests/free-tier-ownership-wiring.test.mjs
+++ b/tests/free-tier-ownership-wiring.test.mjs
@@ -41,10 +41,82 @@ describe('free-tier ownership production wiring', () => {
   });
 
   it('defers ownership reconciliation until cloud prefs completes for the current account', () => {
-    assert.match(app, /this\.tierPreferenceHandoff\.begin\(userId\)/);
+    assert.match(app, /this\.tierPreferenceHandoff\.begin\(\s*userId,/);
     assert.match(app, /const tierReconciliationDeferred = this\.shouldDeferTierPreferenceReconciliation\(\)/);
     assert.match(app, /onEntitlementChange\(\(\) => firePremiumLoaders\(\)\)/);
-    assert.match(app, /const firePremiumLoaders = \(\): void => \{[\s\S]*?this\.reconcileTierOwnedPreferences\(\)/);
-    assert.match(app, /const completion = cloudPrefsSignIn\(nextUserId, SITE_VARIANT\)[\s\S]*?tierPreferenceHandoff\.complete\(nextUserId, currentUserId\)[\s\S]*?reconcileTierOwnedPreferences\(\)[\s\S]*?completion\.then\(finishPreferenceHandoff, finishPreferenceHandoff\)/);
+
+    // Bounded to the function body. An unbounded `[\s\S]*?` here matched the
+    // NEXT `reconcileTierOwnedPreferences()` call 81 lines below, so deleting
+    // the call this assertion names left the test green (verified by mutation).
+    // Same slice technique as tests/cloud-prefs-panel-sync-guard.test.mjs.
+    const firePremiumStart = app.indexOf('const firePremiumLoaders = (): void => {');
+    const firePremiumEnd = app.indexOf('this.unsubEntitlementPremiumLoaders', firePremiumStart);
+    assert.ok(
+      firePremiumStart >= 0 && firePremiumEnd > firePremiumStart,
+      'firePremiumLoaders body must exist',
+    );
+    assert.match(
+      app.slice(firePremiumStart, firePremiumEnd),
+      /this\.reconcileTierOwnedPreferences\(\)/,
+      'entitlement changes must reconcile tier-owned preferences',
+    );
+
+    const handoffStart = app.indexOf('cloudPrefsSignIn: (nextUserId) => {');
+    const handoffEnd = app.indexOf('return completion;', handoffStart);
+    assert.ok(handoffStart >= 0 && handoffEnd > handoffStart, 'cloudPrefsSignIn wrapper must exist');
+    const handoffBody = app.slice(handoffStart, handoffEnd);
+    assert.match(handoffBody, /const completion = cloudPrefsSignIn\(nextUserId, SITE_VARIANT\)/);
+    // A 503 resolves the sign-in promise as soon as the retry is armed, before
+    // any cloud blob is applied; completing then reconciles pre-cloud state.
+    assert.match(
+      handoffBody,
+      /if \(hasPendingCloudPrefsRetry\(\)\) return;/,
+      'a pending 503 retry must not be treated as a settled handoff',
+    );
+    // The generation token fences a late completion from a previous attempt
+    // for the SAME account id.
+    assert.match(
+      handoffBody,
+      /tierPreferenceHandoff\.complete\(\s*preferenceHandoffGeneration,\s*nextUserId,\s*currentUserId,?\s*\)/,
+      'completion must present the generation token, not the id alone',
+    );
+    assert.match(handoffBody, /reconcileTierOwnedPreferences\(\)/);
+    assert.match(handoffBody, /completion\.then\(finishPreferenceHandoff, finishPreferenceHandoff\)/);
+  });
+
+  it('never advances the legacy variant key outside the durable transition', () => {
+    // Advancing it unconditionally after applyVariantPanelLayoutTransition
+    // erased the retry for a failed reset: the next boot saw a null applied
+    // marker beside a matching legacy key and seeded it as already-applied.
+    const transitionStart = app.indexOf('panelSettings = applyVariantPanelLayoutTransition({');
+    const transitionEnd = app.indexOf('} else {', transitionStart);
+    assert.ok(
+      transitionStart >= 0 && transitionEnd > transitionStart,
+      'variant transition block must exist',
+    );
+    const block = app.slice(transitionStart, transitionEnd);
+    const legacyWrites = block.match(/localStorage\.setItem\(STORAGE_KEYS\.variant,/g) ?? [];
+    assert.equal(
+      legacyWrites.length,
+      1,
+      'the legacy variant key must be written exactly once, inside persistAppliedVariant',
+    );
+    const persistStart = block.indexOf('persistAppliedVariant: (variant) => {');
+    assert.ok(persistStart >= 0, 'persistAppliedVariant must be a block body');
+    assert.ok(
+      block.indexOf('localStorage.setItem(STORAGE_KEYS.variant,') > persistStart,
+      'the legacy variant write must live inside persistAppliedVariant, not after the transition',
+    );
+  });
+
+  it('treats a ?layers= deep link as an ephemeral view, not a saved preference', () => {
+    // Both URL-derived call sites must opt out of persistence AND of
+    // ownership: a shared link overwrote the cloud-synced layer preference and
+    // seeded gate ownership the user never chose.
+    const urlCallSites = app.match(
+      /sanitizeMapLayersForTier\([\s\S]{0,160}?ephemeralSnapshot: true/g,
+    ) ?? [];
+    assert.equal(urlCallSites.length, 2, 'both URL layer paths must pass ephemeralSnapshot');
+    assert.doesNotMatch(app, /consumeProOwnership/, 'the superseded option must be gone');
   });
 });

--- a/tests/map-layer-executable.test.mts
+++ b/tests/map-layer-executable.test.mts
@@ -23,6 +23,7 @@ import {
   isLayerExecutable,
   isLayerEntitled,
   isLayerToggleAllowed,
+  sanitizeLayersForVariant,
   sanitizeLockedLayers,
   sanitizeLockedLayersWithOwnership,
   restoreGateOwnedLockedLayers,
@@ -185,6 +186,32 @@ describe('sanitizeLockedLayers — free-user stuck-state heal', () => {
 });
 
 describe('locked map-layer ownership', () => {
+  // Regression: App.sanitizeMapLayersForTier's premium branch guarded its
+  // storage write with `restored === layers`, where `restored` came out of
+  // sanitizeLayersForVariant. That helper spreads its input, so the identity
+  // check was ALWAYS false and the branch persisted on every pass — which is
+  // how a `?layers=` deep link came to overwrite the saved (cloud-synced)
+  // layer preference. Value comparison is the only correct check here.
+  test('sanitizeLayersForVariant never returns its input, so identity guards are dead', () => {
+    const layers = {
+      conflicts: true,
+      resilienceScore: false,
+    } as unknown as MapLayers;
+
+    const out = sanitizeLayersForVariant(layers, 'full');
+
+    assert.notEqual(
+      out,
+      layers,
+      'a fresh object means `out === layers` can never short-circuit a write',
+    );
+    assert.equal(
+      mapLayerStatesEqual(out, layers),
+      true,
+      'mapLayerStatesEqual is the comparison that actually detects "nothing changed"',
+    );
+  });
+
   test('compares layer snapshots semantically instead of by object identity', () => {
     const layers = { conflicts: true, resilienceScore: false } as unknown as MapLayers;
     assert.equal(mapLayerStatesEqual(layers, { ...layers }), true);

--- a/tests/map-layer-initial-url-gate.test.mts
+++ b/tests/map-layer-initial-url-gate.test.mts
@@ -11,8 +11,18 @@ import { normalizeExclusiveChoropleths } from '../src/components/resilience-chor
 import type { MapLayers } from '../src/types';
 
 const panelLayoutSrc = readFileSync(new URL('../src/app/panel-layout.ts', import.meta.url), 'utf8');
+const appSrc = readFileSync(new URL('../src/App.ts', import.meta.url), 'utf8');
 const tier = { premium: false, resolved: true, fallback: false };
-const restoreProbe: { persisted: MapLayers | null } = { persisted: null };
+let gateOwnershipReads = 0;
+const savedPreference = {
+  resilienceScore: true,
+  ciiChoropleth: false,
+  conflicts: false,
+} as unknown as MapLayers;
+const restoreProbe: { persisted: MapLayers; writes: number } = {
+  persisted: { ...savedPreference },
+  writes: 0,
+};
 
 function extractApplyInitialUrlState(): new () => {
   ctx: any;
@@ -56,7 +66,10 @@ function extractApplyInitialUrlState(): new () => {
     () => ({}),
     () => tier.resolved,
     { mapLayers: 'mapLayers' },
-    (_key: string, layers: MapLayers) => { restoreProbe.persisted = { ...layers }; },
+    (_key: string, layers: MapLayers) => {
+      restoreProbe.persisted = { ...layers };
+      restoreProbe.writes += 1;
+    },
   ) as new () => {
     ctx: any;
     callbacks: any;
@@ -66,6 +79,57 @@ function extractApplyInitialUrlState(): new () => {
 
 const PanelLayoutHarness = extractApplyInitialUrlState();
 
+function extractSanitizeMapLayersForTier(): new () => {
+  freeTierGate: { authSettleDeadlineExceeded: boolean };
+  sanitizeMapLayersForTier(
+    layers: MapLayers,
+    fallbackActive?: boolean,
+    options?: { ephemeralSnapshot?: boolean },
+  ): MapLayers;
+} {
+  const signature = 'private sanitizeMapLayersForTier(';
+  const start = appSrc.indexOf(signature);
+  assert.ok(start >= 0, 'App.sanitizeMapLayersForTier must remain in the source');
+  const bodyMarker = appSrc.indexOf('): MapLayers {', start);
+  assert.ok(bodyMarker > start, 'App.sanitizeMapLayersForTier must keep its return type');
+  const braceStart = appSrc.indexOf('{', bodyMarker);
+  let depth = 0;
+  let end = -1;
+  for (let i = braceStart; i < appSrc.length; i++) {
+    if (appSrc[i] === '{') depth++;
+    else if (appSrc[i] === '}' && --depth === 0) {
+      end = i + 1;
+      break;
+    }
+  }
+  assert.ok(end > braceStart, 'App.sanitizeMapLayersForTier must have balanced braces');
+  const method = appSrc.slice(start, end).replace(/^private\s+/, '');
+  const js = ts.transpileModule(
+    `class AppHarness { ${method} }`,
+    { compilerOptions: { target: ts.ScriptTarget.ES2020, module: ts.ModuleKind.None } },
+  ).outputText;
+  return new Function(
+    'hasPremiumAccess',
+    'loadFromStorage',
+    `${js}\nreturn AppHarness;`,
+  )(
+    () => true,
+    () => {
+      gateOwnershipReads += 1;
+      return ['resilienceScore'];
+    },
+  ) as new () => {
+    freeTierGate: { authSettleDeadlineExceeded: boolean };
+    sanitizeMapLayersForTier(
+      layers: MapLayers,
+      fallbackActive?: boolean,
+      options?: { ephemeralSnapshot?: boolean },
+    ): MapLayers;
+  };
+}
+
+const AppSanitizeHarness = extractSanitizeMapLayersForTier();
+
 function runInitialUrlRestore({
   premium = false,
   resolved = true,
@@ -74,7 +138,8 @@ function runInitialUrlRestore({
   tier.premium = premium;
   tier.resolved = resolved;
   tier.fallback = fallback;
-  restoreProbe.persisted = null;
+  restoreProbe.persisted = { ...savedPreference };
+  restoreProbe.writes = 0;
   const sourceLayers = { resilienceScore: true, ciiChoropleth: false, conflicts: true } as unknown as MapLayers;
   let rendered: MapLayers | null = null;
   const initialUrlState = { layers: sourceLayers };
@@ -93,16 +158,22 @@ function runInitialUrlRestore({
 
   Harness.applyInitialUrlState();
 
-  return { ctx, rendered, persisted: restoreProbe.persisted };
+  return {
+    ctx,
+    rendered,
+    persisted: restoreProbe.persisted,
+    persistenceWrites: restoreProbe.writes,
+  };
 }
 
 describe('initial URL map-layer entitlement healing (#6045)', () => {
-  it('persists and reuses sanitized locked layers when auth settled free', () => {
+  it('sanitizes the rendered URL snapshot without changing saved preferences', () => {
     const result = runInitialUrlRestore({ premium: false, resolved: true });
     assert.equal(result.ctx.mapLayers.resilienceScore, false);
     assert.equal(result.ctx.initialUrlState.layers.resilienceScore, false);
     assert.equal(result.rendered?.resilienceScore, false);
-    assert.equal(result.persisted?.resilienceScore, false);
+    assert.equal(result.persistenceWrites, 0, 'URL application must not persist map layers');
+    assert.deepEqual(result.persisted, savedPreference, 'saved preferences remain untouched');
   });
 
   it('does not clamp a pending tier before the bounded fallback', () => {
@@ -115,5 +186,26 @@ describe('initial URL map-layer entitlement healing (#6045)', () => {
     const result = runInitialUrlRestore({ premium: false, resolved: false, fallback: true });
     assert.equal(result.ctx.mapLayers.resilienceScore, false);
     assert.equal(result.ctx.initialUrlState.layers.resilienceScore, false);
+  });
+
+  it('keeps a premium URL snapshot exact without consuming durable gate ownership', () => {
+    gateOwnershipReads = 0;
+    const sourceLayers = {
+      conflicts: true,
+      resilienceScore: false,
+    } as unknown as MapLayers;
+    const Harness = new AppSanitizeHarness();
+    Harness.freeTierGate = { authSettleDeadlineExceeded: false };
+
+    const result = Harness.sanitizeMapLayersForTier(
+      sourceLayers,
+      false,
+      { ephemeralSnapshot: true },
+    );
+
+    assert.equal(result, sourceLayers, 'the exact URL-derived snapshot is preserved');
+    assert.equal(result.conflicts, true);
+    assert.equal(result.resilienceScore, false, 'durable ownership must not enable an omitted layer');
+    assert.equal(gateOwnershipReads, 0, 'ephemeral Pro views must not consume ownership metadata');
   });
 });

--- a/tests/tier-preference-handoff.test.mts
+++ b/tests/tier-preference-handoff.test.mts
@@ -3,25 +3,131 @@ import { describe, it } from 'node:test';
 
 import { TierPreferenceHandoff } from '../src/app/tier-preference-handoff';
 
+/**
+ * Deterministic timer seam. The expiry is a real setTimeout in production, so
+ * the tests drive it explicitly rather than sleeping — a live clock would make
+ * the boundary cases untestable.
+ */
+function manualTimers() {
+  const pending = new Map<number, () => void>();
+  let nextId = 1;
+  return {
+    schedule: (fn: () => void) => {
+      const id = nextId++;
+      pending.set(id, fn);
+      return id as unknown as ReturnType<typeof setTimeout>;
+    },
+    cancel: (handle: ReturnType<typeof setTimeout>) => {
+      pending.delete(handle as unknown as number);
+    },
+    get armed() { return pending.size; },
+    fireAll() {
+      for (const fn of [...pending.values()]) fn();
+      pending.clear();
+    },
+  };
+}
+
+const make = (timers: ReturnType<typeof manualTimers>) =>
+  new TierPreferenceHandoff({ schedule: timers.schedule, cancel: timers.cancel });
+
 describe('tier preference account handoff', () => {
   it('defers only the signing-in account until its cloud completion signal', () => {
-    const handoff = new TierPreferenceHandoff();
-    handoff.begin('account-b');
+    const timers = manualTimers();
+    const handoff = make(timers);
+    const generation = handoff.begin('account-b');
 
     assert.equal(handoff.shouldDefer('account-b'), true);
     assert.equal(handoff.shouldDefer('account-a'), false);
-    assert.equal(handoff.complete('account-b', 'account-b'), true);
+    assert.equal(handoff.complete(generation, 'account-b', 'account-b'), true);
     assert.equal(handoff.shouldDefer('account-b'), false);
   });
 
   it('does not let a stale completion clear a newer account handoff', () => {
-    const handoff = new TierPreferenceHandoff();
-    handoff.begin('account-a');
-    handoff.begin('account-b');
+    const timers = manualTimers();
+    const handoff = make(timers);
+    const first = handoff.begin('account-a');
+    const second = handoff.begin('account-b');
 
-    assert.equal(handoff.complete('account-a', 'account-b'), false);
+    assert.equal(handoff.complete(first, 'account-a', 'account-b'), false);
     assert.equal(handoff.shouldDefer('account-b'), true);
-    assert.equal(handoff.complete('account-b', null), false);
+    assert.equal(handoff.complete(second, 'account-b', null), false);
     assert.equal(handoff.shouldDefer('account-b'), false);
+  });
+
+  // Regression: an id-only guard passed here, because the ids match. The queue
+  // settles the superseded attempt BEFORE the new one runs, so this ordering is
+  // deterministic rather than a narrow race.
+  it('rejects a stale completion for the same account after sign-out and back in', () => {
+    const timers = manualTimers();
+    const handoff = make(timers);
+    const firstAttempt = handoff.begin('account-a');
+    handoff.clear();
+    const secondAttempt = handoff.begin('account-a');
+
+    assert.notEqual(firstAttempt, secondAttempt);
+    assert.equal(
+      handoff.complete(firstAttempt, 'account-a', 'account-a'),
+      false,
+      'the superseded attempt must not release the live handoff',
+    );
+    assert.equal(
+      handoff.shouldDefer('account-a'),
+      true,
+      'the second sign-in is still waiting for its own cloud prefs',
+    );
+    assert.equal(handoff.complete(secondAttempt, 'account-a', 'account-a'), true);
+  });
+
+  it('releases the deferral and reconciles when no terminal outcome arrives', () => {
+    const timers = manualTimers();
+    const handoff = make(timers);
+    let reconciled = 0;
+    handoff.begin('account-a', () => { reconciled += 1; });
+
+    assert.equal(handoff.shouldDefer('account-a'), true);
+    timers.fireAll();
+
+    assert.equal(reconciled, 1, 'expiry must run the reconciliation itself');
+    assert.equal(
+      handoff.shouldDefer('account-a'),
+      false,
+      'a stalled sign-in may delay enforcement but must never cancel it',
+    );
+  });
+
+  it('disarms the expiry once a terminal outcome arrives', () => {
+    const timers = manualTimers();
+    const handoff = make(timers);
+    let reconciled = 0;
+    const generation = handoff.begin('account-a', () => { reconciled += 1; });
+
+    assert.equal(handoff.complete(generation, 'account-a', 'account-a'), true);
+    assert.equal(timers.armed, 0, 'completion must cancel the pending expiry');
+    timers.fireAll();
+    assert.equal(reconciled, 0, 'a completed handoff must not also fire its expiry');
+  });
+
+  it('disarms the expiry on sign-out', () => {
+    const timers = manualTimers();
+    const handoff = make(timers);
+    let reconciled = 0;
+    handoff.begin('account-a', () => { reconciled += 1; });
+    handoff.clear();
+
+    assert.equal(timers.armed, 0);
+    timers.fireAll();
+    assert.equal(reconciled, 0, 'a signed-out handoff must not reconcile');
+  });
+
+  it('supersedes a previous expiry when a new handoff begins', () => {
+    const timers = manualTimers();
+    const handoff = make(timers);
+    const fired: string[] = [];
+    handoff.begin('account-a', () => fired.push('a'));
+    handoff.begin('account-b', () => fired.push('b'));
+
+    timers.fireAll();
+    assert.deepEqual(fired, ['b'], 'only the live handoff may expire');
   });
 });

--- a/tests/tier-preference-handoff.test.mts
+++ b/tests/tier-preference-handoff.test.mts
@@ -21,9 +21,16 @@ function manualTimers() {
       pending.delete(handle as unknown as number);
     },
     get armed() { return pending.size; },
+    /**
+     * Fire exactly the timers armed at entry. Each is removed BEFORE it runs,
+     * so a callback that re-arms (the expiry postponing itself) leaves a live
+     * timer behind instead of having it cleared out from under it.
+     */
     fireAll() {
-      for (const fn of [...pending.values()]) fn();
-      pending.clear();
+      for (const [id, fn] of [...pending.entries()]) {
+        pending.delete(id);
+        fn();
+      }
     },
   };
 }
@@ -118,6 +125,55 @@ describe('tier preference account handoff', () => {
     assert.equal(timers.armed, 0);
     timers.fireAll();
     assert.equal(reconciled, 0, 'a signed-out handoff must not reconcile');
+  });
+
+  // Regression: withholding completion while a 503 retry is pending is only
+  // safe if the expiry does not then reconcile against the same pre-cloud
+  // state. Retry-After is clamped to 60s but one grace window is 8s, so the
+  // expiry must wait the retry out rather than fire through it.
+  it('postpones expiry while a cloud retry is still pending', () => {
+    const timers = manualTimers();
+    let retryPending = true;
+    const handoff = new TierPreferenceHandoff({
+      schedule: timers.schedule,
+      cancel: timers.cancel,
+      graceMs: 10,
+      maxTotalDeferralMs: 100,
+    });
+    let reconciled = 0;
+    handoff.begin('account-a', () => { reconciled += 1; }, () => retryPending);
+
+    timers.fireAll();
+    assert.equal(reconciled, 0, 'must not reconcile while the retry is in flight');
+    assert.equal(handoff.shouldDefer('account-a'), true, 'handoff stays armed');
+
+    // The retry lands; the next window may now give up waiting.
+    retryPending = false;
+    timers.fireAll();
+    assert.equal(reconciled, 1);
+    assert.equal(handoff.shouldDefer('account-a'), false);
+  });
+
+  it('stops postponing at the ceiling so a stuck retry cannot defer forever', () => {
+    const timers = manualTimers();
+    const handoff = new TierPreferenceHandoff({
+      schedule: timers.schedule,
+      cancel: timers.cancel,
+      graceMs: 10,
+      maxTotalDeferralMs: 30,
+    });
+    let reconciled = 0;
+    // A retry that never clears — the pathological case.
+    handoff.begin('account-a', () => { reconciled += 1; }, () => true);
+
+    for (let i = 0; i < 10; i += 1) timers.fireAll();
+
+    assert.equal(reconciled, 1, 'enforcement must win once the ceiling is reached');
+    assert.equal(
+      handoff.shouldDefer('account-a'),
+      false,
+      'a permanently failing sync delays enforcement but must never cancel it',
+    );
   });
 
   it('supersedes a previous expiry when a new handoff begins', () => {


### PR DESCRIPTION
## Summary

Post-merge review of #6345 surfaced six P1 defects. Three each defeat a specific safety claim that PR's own description makes, and one is silently losing ownership metadata for existing users today.

The pure helpers #6345 extracted (`source-cap.ts`, `variant-panel-ownership.ts`, the map-layer ownership functions) are sound and well covered. Every defect here lives in the `App.ts` orchestration that composes them — which is exactly the layer the node:test suites cannot import, and which the PR's wiring guard could not actually fail on.

## What was wrong

| Defect | Claim it defeated | Effect |
|---|---|---|
| Cloud rows lacking the ownership keys **deleted** them locally | "ownership a later Pro reconciliation can safely reverse" | Every pre-#6345 row (i.e. every existing user) strands the gate's disables as user intent — never restored on upgrade |
| Premium branch's `restored === layers` guard is always false | — | A shared `?layers=` link overwrote the stored, cloud-synced map-layer preference |
| Handoff keyed on account id alone | "waits for the current account's cloud handoff" | A superseded attempt released a live handoff, deterministically |
| `onSignIn` resolves when a 503 retry is *armed* | same | Reconciled and uploaded pre-cloud local state |
| Legacy variant key advanced unconditionally | "a crash can retry the reset" | A failed reset recorded itself as durable and never retried |
| Wiring guard used an unbounded `[\s\S]*?` | — | Deleting the call it names left the test green |

## Design decisions

**Ownership must stay cloud-synced.** The obvious alternative — drop both sidecars from `CLOUD_SYNC_KEYS` and keep ownership device-local — is incoherent: the denylist they annotate (`worldmonitor-disabled-feeds`) *is* synced, so device B would receive A's gate-disabled sources with no ownership and treat them as user intent. That is the same bug. So the keys stay synced and are protected on the way in, via `ABSENCE_TOLERANT_SYNC_KEYS`. This is safe only because an intentional clear is always an explicit `[]` write — the Pro restore path and the variant reset both already do that, and the variant reset moved from `removeItem` to `'[]'` so a real clear still propagates.

**`ephemeralSnapshot` replaces `consumeProOwnership`.** The old flag named a mechanism; the new one names the fact that actually matters — a `?layers=` view is not the durable preference. One concept now covers all three consequences: don't persist it, don't seed ownership from it, don't consume ownership with it.

**Withholding completion on a 503 required a bounded expiry.** Not completing while a retry is pending would otherwise defer reconciliation forever, which is strictly worse than the bug. `TierPreferenceHandoff` now owns an expiry that releases the latch and runs the reconciliation itself, so a stalled sign-in delays enforcement but can never cancel it.

## Validation

- `npm run test:data`: **22005 pass / 0 fail** (6 skipped).
- `npm run typecheck` clean; `biome check` clean on all changed files.
- Repository pre-push gate passed.
- **Every new guard was mutation-tested** — reverted the fix, confirmed red, restored by file copy:
  - absence rule removed -> 2 tests red
  - generation guard removed -> the same-account staleness test red
  - expiry backstop removed -> 2 tests red
  - reconcile call deleted from `firePremiumLoaders` -> the rewritten wiring guard red (the original survived this exact mutant)

## Deliberately not in scope

Two P2s from the same review, both worth their own PR:

- Layer gate ownership is never transferred on any user toggle — `mapLayerGateOwnership` is referenced only in `variants/base.ts` and `App.ts`, while 14 paths write `STORAGE_KEYS.mapLayers`. This is the same class of bug #6338 fixed for panels.
- `LAYER_REGISTRY`'s `premium` flag is desktop-conditional (`_desktop ? 'locked' : undefined`), so opening the web app prunes desktop-acquired ownership and cloud-syncs the loss.

## Post-deploy monitoring

Worth noting the gap this PR does not close: #6345's own monitoring plan asked operators to watch for `Free tier: reconciled` / `Pro: restored` churn, but those are `console.log` in the end user's browser with no Sentry or analytics path, so that plan is not executable. `trackEvent` is already imported in `App.ts`. Adding telemetry to the ownership mutations is a sensible follow-up.

Related: #6345, #6338

https://claude.ai/code/session_01C6yvWYSo4yprxAWbARYEsx
