### PR TITLE
fix(observability): stop two non-errors paging at Sentry error level

### DIFF
--- a/api/_rate-limit.js
+++ b/api/_rate-limit.js
@@ -69,10 +69,23 @@ function getRatelimit(policy) {
 // SERVICE_UNAVAILABLE `level: 'warning'` precedent in api/user-prefs.ts). A
 // `missing-config` stage is a real deploy misconfiguration and any novel error
 // is unclassified — both stay at `error` so on-call still sees them.
+//
+// `aborted due to timeout` / `TimeoutError` is our OWN deadline reporting in:
+// getEndpointRatelimit arms `AbortSignal.timeout(ENDPOINT_REDIS_ABORT_TIMEOUT_MS)`
+// on the Upstash client, so a stalled transport rejects with a DOMException
+// phrased "The operation was aborted due to timeout" — no `timed out`, no
+// `network`, so the pre-existing alternation scored it `error`. That split the
+// one condition in two: the SDK-race arm throws `Upstash endpoint rate-limit
+// decision timed out` (already `warning`) while the abort arm paged
+// (WORLDMONITOR-VM). Both are absorbed by the same fail-closed 503.
 // Mirrored verbatim in server/_shared/rate-limit.ts.
-function rateLimitErrorLevel(stage, msg) {
+//
+// Exported purely as a test seam: the classification is only observable through
+// a Sentry capture otherwise, and a source-regex assertion would false-pass on
+// the mirror drifting. tests/rate-limit.test.mts calls both copies directly.
+export function rateLimitErrorLevel(stage, msg) {
   if (stage.includes('missing-config')) return 'error';
-  if (/Error running script|execution timed out|Command failed|ETIMEDOUT|ECONNRESET|ENOTFOUND|fetch failed|network|timed out|socket hang up|Redis unavailable|Redis unreachable/i.test(msg)) {
+  if (/Error running script|execution timed out|Command failed|ETIMEDOUT|ECONNRESET|ENOTFOUND|fetch failed|network|timed out|aborted due to timeout|TimeoutError|socket hang up|Redis unavailable|Redis unreachable/i.test(msg)) {
     return 'warning';
   }
   return 'error';

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -66,10 +66,23 @@ function getRatelimit(): Ratelimit | null {
 // SERVICE_UNAVAILABLE `level: 'warning'` precedent in api/user-prefs.ts). A
 // `missing-config` stage is a real deploy misconfiguration and any novel error
 // is unclassified — both stay at `error` so on-call still sees them.
+//
+// `aborted due to timeout` / `TimeoutError` is our OWN deadline reporting in:
+// getEndpointRatelimit arms `AbortSignal.timeout(ENDPOINT_REDIS_ABORT_TIMEOUT_MS)`
+// on the Upstash client, so a stalled transport rejects with a DOMException
+// phrased "The operation was aborted due to timeout" — no `timed out`, no
+// `network`, so the pre-existing alternation scored it `error`. That split the
+// one condition in two: the SDK-race arm throws `Upstash endpoint rate-limit
+// decision timed out` (already `warning`) while the abort arm paged
+// (WORLDMONITOR-VM). Both are absorbed by the same fail-closed 503.
 // Mirrored verbatim in api/_rate-limit.js.
-function rateLimitErrorLevel(stage: string, msg: string): 'warning' | 'error' {
+//
+// Exported purely as a test seam: the classification is only observable through
+// a Sentry capture otherwise, and a source-regex assertion would false-pass on
+// the mirror drifting. tests/rate-limit.test.mts calls both copies directly.
+export function rateLimitErrorLevel(stage: string, msg: string): 'warning' | 'error' {
   if (stage.includes('missing-config')) return 'error';
-  if (/Error running script|execution timed out|Command failed|ETIMEDOUT|ECONNRESET|ENOTFOUND|fetch failed|network|timed out|socket hang up|Redis unavailable|Redis unreachable/i.test(msg)) {
+  if (/Error running script|execution timed out|Command failed|ETIMEDOUT|ECONNRESET|ENOTFOUND|fetch failed|network|timed out|aborted due to timeout|TimeoutError|socket hang up|Redis unavailable|Redis unreachable/i.test(msg)) {
     return 'warning';
   }
   return 'error';

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -189,7 +189,6 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /Se requiere plan premium/,
       /hybridExecute is not defined/,
       /reading 'postMessage'/,
-      /appendChild.*Unexpected token/,
       /\bmag is not defined\b/,
       /evaluating '[^']*\.luma/,
       /translateNotifyError/,
@@ -839,6 +838,22 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
           // This is the WebKit phrasing; the V8 `reading 'postMessage'` variant is
           // already suppressed via the ignoreErrors entry above.
           || /null is not an object \(evaluating '[^']*\.postMessage'\)/.test(msg)
+          // Chrome composes `Failed to execute 'appendChild' on 'Node': <parse
+          // error>` when a script element is inserted and its source fails to
+          // parse synchronously. The DOM-API prefix means SOME caller passed
+          // unparseable script text — and we do have first-party callers that
+          // append third-party scripts (analytics.ts → abacus, debugbear-rum.ts,
+          // clerk.ts, LiveNewsPanel.ts embeds). Those keep a source-mapped .ts
+          // frame, so `!hasFirstParty` is what separates them from an injected
+          // page script inserting its own broken source with only `<anonymous>`
+          // frames. This supersedes the ungated `/appendChild.*Unexpected token/`
+          // ignoreErrors entry, which both missed the `Unexpected identifier`
+          // phrasing and — having no access to frames — would have swallowed a
+          // parse failure attributable to one of those first-party loaders
+          // (WORLDMONITOR-YW: Chrome 150 on Chrome OS, two `<anonymous>:1`
+          // frames). Left deliberately phrasing-agnostic after `Unexpected ` so
+          // every engine's token/identifier/keyword/EOF wording is covered.
+          || /appendChild.*Unexpected /.test(msg)
         )
       ) return null;
       if (hasAnyStack && !hasFirstParty && (

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -22,7 +22,10 @@ import {
   checkRateLimit,
   checkScopedRateLimit,
   getClientIp,
+  rateLimitErrorLevel,
 } from '../server/_shared/rate-limit.ts';
+// @ts-expect-error — JS module, no declaration file
+import { rateLimitErrorLevel as apiRateLimitErrorLevel } from '../api/_rate-limit.js';
 
 const originalFetch = globalThis.fetch;
 const originalEnv = { ...process.env };
@@ -570,6 +573,55 @@ describe('rate-limit constants', () => {
   it('UNKNOWN_CLIENT_IP is the literal "unknown" so the api/ mirror stays string-equal', () => {
     assert.equal(UNKNOWN_CLIENT_IP, 'unknown');
   });
+});
+
+describe('rateLimitErrorLevel — Sentry severity for a degraded limiter (WORLDMONITOR-VM)', () => {
+  // Both copies must agree; api/_rate-limit.js is the byte-mirror of the .ts one.
+  const IMPLS: Array<[string, (stage: string, msg: string) => string]> = [
+    ['server/_shared/rate-limit.ts', rateLimitErrorLevel],
+    ['api/_rate-limit.js', apiRateLimitErrorLevel],
+  ];
+
+  for (const [surface, classify] of IMPLS) {
+    it(`${surface}: the endpoint limiter's own abort deadline is a transient, not an error`, () => {
+      // getEndpointRatelimit arms `AbortSignal.timeout(ENDPOINT_REDIS_ABORT_TIMEOUT_MS)`
+      // on the Upstash client. When that deadline wins, the SDK rejects with a
+      // DOMException whose message is this exact phrase, checkEndpointRateLimit
+      // absorbs it into the fail-closed 503, and the capture must not page.
+      assert.equal(
+        classify(
+          'checkEndpointRateLimit:/api/military/v1/get-aircraft-details-batch',
+          'The operation was aborted due to timeout',
+        ),
+        'warning',
+      );
+    });
+
+    it(`${surface}: both arms of the same limiter timeout classify alike`, () => {
+      // The SDK-race arm throws this literal from checkEndpointRateLimit; it and
+      // the abort arm above are one condition, so they must not split severity.
+      assert.equal(
+        classify('checkEndpointRateLimit:/api/ask', 'Upstash endpoint rate-limit decision timed out'),
+        'warning',
+      );
+      assert.equal(
+        classify('checkRateLimit', 'ERR Error running script: execution timed out'),
+        'warning',
+      );
+    });
+
+    it(`${surface}: a missing-config stage and an unclassified error still page`, () => {
+      assert.equal(
+        classify('checkEndpointRateLimit:/api/ask:missing-config', 'The operation was aborted due to timeout'),
+        'error',
+        'a deploy misconfiguration outranks any transient phrasing in the message',
+      );
+      assert.equal(
+        classify('checkRateLimit', 'WRONGTYPE Operation against a key holding the wrong kind of value'),
+        'error',
+      );
+    });
+  }
 });
 
 describe('EVALSHA-unsupported fallback (#7c — self-hosted redis-rest proxy blocks Lua)', () => {

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -397,6 +397,15 @@ describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DO
     // value shapes are matched.
     ['NetworkError when attempting to fetch resource.', 'TypeError'],
     ['TypeError: NetworkError when attempting to fetch resource.', 'TypeError'],
+    // Injected page script inserting its own unparseable source
+    // (WORLDMONITOR-YW). Chrome prefixes the parse error with the DOM API that
+    // triggered it. Our own script-appending call sites (analytics, DebugBear,
+    // Clerk, news embeds) keep a source-mapped .ts frame, so the first-party
+    // case is asserted "lets through" by this same loop — the coverage the
+    // superseded ungated ignoreErrors entry could not provide.
+    ["Failed to execute 'appendChild' on 'Node': Unexpected identifier 'x'", 'SyntaxError'],
+    ["Failed to execute 'appendChild' on 'Node': Unexpected token '}'", 'SyntaxError'],
+    ["SyntaxError: Failed to execute 'appendChild' on 'Node': Unexpected end of input", 'SyntaxError'],
   ];
 
   for (const [msg, type] of zeroFrameErrors) {
@@ -415,6 +424,32 @@ describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DO
       assert.ok(beforeSend(event) !== null, `"${msg}" with first-party stack should NOT be suppressed`);
     });
   }
+
+  // The shape WORLDMONITOR-YW actually arrived in: an injected script's parse
+  // failure carries only `<anonymous>` frames, which nonInfraFrames strips —
+  // so neither the empty-stack nor the extension-URL case above reproduces it.
+  it("suppresses the injected-script appendChild parse failure with only <anonymous> frames", () => {
+    const event = makeEvent(
+      "Failed to execute 'appendChild' on 'Node': Unexpected identifier 'x'",
+      'SyntaxError',
+      [{ filename: '<anonymous>', lineno: 1 }, { filename: '<anonymous>', lineno: 1 }],
+    );
+    assert.equal(beforeSend(event), null);
+  });
+
+  it('lets through an appendChild parse failure attributed to a first-party script loader', () => {
+    // analytics.ts / debugbear-rum.ts / clerk.ts / LiveNewsPanel.ts all append a
+    // third-party <script>; if one of those inserts unparseable source the frame
+    // is ours and the event must still reach the dashboard. The superseded
+    // ignoreErrors entry had no frames to check and dropped this case.
+    const event = makeEvent(
+      "Failed to execute 'appendChild' on 'Node': Unexpected identifier 'x'",
+      'SyntaxError',
+      [{ filename: 'src/services/analytics.ts', lineno: 494, function: 'loadUmamiScript' },
+        { filename: '<anonymous>', lineno: 1 }],
+    );
+    assert.ok(beforeSend(event) !== null);
+  });
 });
 
 // ─── All ambiguous errors require confirmed third-party stack ────────────


### PR DESCRIPTION
## Summary

Two Sentry issues were paging at `error` level for conditions that are not errors. One of them was also being suppressed by a filter that could just as easily have hidden a real bug.

**WORLDMONITOR-VM is our own deadline reporting in.** `getEndpointRatelimit` arms `AbortSignal.timeout(ENDPOINT_REDIS_ABORT_TIMEOUT_MS)` on the Upstash client, so a stalled transport rejects with `DOMException: The operation was aborted due to timeout`. That message carries no `timed out`, no `network`, and no errno, so `rateLimitErrorLevel` fell through to `error`. What makes this a bug rather than a judgement call is the asymmetry it produced: the SDK-race arm of the very same timeout throws `Upstash endpoint rate-limit decision timed out` and already scored `warning`. One condition, two severities, and both arms end in the same fail-closed 503 — the exact disposition the function's own comment reserves for `warning`.

**WORLDMONITOR-YW is an injected page script inserting unparseable source.** Chrome composes `Failed to execute 'appendChild' on 'Node': Unexpected identifier 'as'`, here from two `<anonymous>:1` frames on Chrome 150 / Chrome OS. The pre-existing `/appendChild.*Unexpected token/` pattern lived in `ignoreErrors`, which has no access to stack frames, so it was wrong in both directions: it missed the `identifier` phrasing entirely, and it would have blind-dropped the same message arriving from one of our *own* script loaders — `analytics.ts`, `debugbear-rum.ts`, `clerk.ts`, and `LiveNewsPanel.ts` all append a third-party `<script>`. Moving it into `beforeSend` behind `!hasFirstParty` both widens the phrasing coverage and adds the frame check the old entry structurally could not perform.

## Test seam

`rateLimitErrorLevel` was module-private in both mirrors and observable only through a Sentry capture, so a source-regex assertion would have false-passed the moment the two copies drifted apart. It is now exported from `server/_shared/rate-limit.ts` and `api/_rate-limit.js`, and `tests/rate-limit.test.mts` drives each copy through the same assertion table.

## Validation

- Both new test groups were confirmed **red before the fix** — both mirrors returned `error` where `warning` was required.
- The `beforeSend` gate was mutation-checked: breaking the pattern turns 4 tests red, including the `<anonymous>`-frames-only shape the issue actually arrived in. Neither the empty-stack nor the extension-URL case reproduces that shape, because `nonInfraFrames` strips `<anonymous>`.
- Sweep scoped by changed module, run sequentially: `tests/rate-limit.test.mts` 44/44, `tests/sentry-beforesend.test.mjs` 250/250, rate-limit consumers 187/187, Sentry consumers 276/276, gateway/MCP/turnstile consumers 221/221. Zero failures.
- `npx tsc --noEmit`, `npm run typecheck:api`, and Biome all pass.

No screenshots — neither change has a rendered surface.

## Related

- Sentry WORLDMONITOR-VM — https://elie-habib.sentry.io/issues/7598472178/
- Sentry WORLDMONITOR-YW — https://elie-habib.sentry.io/issues/7661408861/

Both are marked resolved-in-next-release, so they reopen automatically if either fix misses. VM will reopen **by design** on the next abort deadline — now at `warning`, joining its `route=api/user-prefs` sibling WORLDMONITOR-R2, which carries the identical message at that level today. This change reclassifies the capture; it does not stop the timeouts.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
