### PR TITLE
fix(analytics): unblock Umami storage monitor

### DIFF
--- a/.github/workflows/umami-storage-monitor.yml
+++ b/.github/workflows/umami-storage-monitor.yml
@@ -6,8 +6,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: umami-storage-monitor
-  cancel-in-progress: false
+  group: umami-storage-monitor-${{ github.ref }}
+  # This is a read-only point-in-time probe. A newer sample is more useful than
+  # a stale runner-less job, which would otherwise own the group indefinitely.
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/tests/umami-storage-monitor.test.mjs
+++ b/tests/umami-storage-monitor.test.mjs
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 
+import YAML from 'yaml';
+
 import {
   evaluateUmamiStorage,
   normalizeVolumeRows,
@@ -10,6 +12,11 @@ import {
 } from '../scripts/check-umami-storage.mjs';
 
 const NOW = Date.parse('2026-08-01T12:00:00.000Z');
+const workflowSource = readFileSync(
+  new URL('../.github/workflows/umami-storage-monitor.yml', import.meta.url),
+  'utf8',
+);
+const workflow = YAML.parse(workflowSource);
 
 function volume(overrides = {}) {
   return {
@@ -134,13 +141,12 @@ describe('Umami storage monitor', () => {
   });
 
   it('wires the read-only Railway check and bounded SQL contract', () => {
-    const workflow = readFileSync(new URL('../.github/workflows/umami-storage-monitor.yml', import.meta.url), 'utf8');
     const sql = readFileSync(new URL('../scripts/umami-retention.sql', import.meta.url), 'utf8');
     const executableSql = sql.replace(/^\s*--.*$/gmu, '');
 
-    assert.match(workflow, /railway volume .* list --json/);
-    assert.match(workflow, /actions\/cache@/);
-    assert.match(workflow, /check-umami-storage\.mjs/);
+    assert.match(workflowSource, /railway volume .* list --json/);
+    assert.match(workflowSource, /actions\/cache@/);
+    assert.match(workflowSource, /check-umami-storage\.mjs/);
     assert.match(sql, /interval '90 days'/);
     assert.match(sql, /LIMIT 10000/);
     assert.match(sql, /64 \* 1024 \* 1024/);
@@ -151,5 +157,25 @@ describe('Umami storage monitor', () => {
     assert.match(sql, /heatmap_event/);
     assert.match(sql, /session_replay_saved/);
     assert.doesNotMatch(sql, /ROW_NUMBER/);
+  });
+
+  it('supersedes stale probes without broadening production credential access', () => {
+    assert.deepEqual(
+      workflow.concurrency,
+      {
+        group: 'umami-storage-monitor-${{ github.ref }}',
+        'cancel-in-progress': true,
+      },
+      'the newest same-ref sample must replace a runner-less owner without cancelling main from another ref',
+    );
+    assert.deepEqual(
+      workflow.jobs.monitor.environment,
+      {
+        name: 'ingestion-acceptance-production',
+        deployment: false,
+      },
+      'the Railway token must stay in the main-only environment without deployment tracking',
+    );
+    assert.equal(workflow.jobs.monitor['timeout-minutes'], 5);
   });
 });


### PR DESCRIPTION
## Summary

Scheduled Umami storage checks can no longer remain blocked behind a runner-less probe indefinitely: each new sample replaces an older probe on the same ref. Ref-scoped concurrency keeps a manual run from another branch from cancelling the production `main` monitor, while the existing main-only environment, Railway credential boundary, warning thresholds, and five-minute timeout stay unchanged.

The live stale owner (`31125595042`) was cancelled during diagnosis. Its queued replacement then reached a runner and produced a real storage result: 68.8% used, 0.661 GiB/day growth, and 23.0 days projected headroom. That warning is the retained capacity policy working after scheduler recovery; sustained capacity action is separate from this control-plane fix.

Related: #6348

## Validation

- Test-first contract: the new assertion failed against `cancel-in-progress: false`, then passed after the workflow change.
- `node --test tests/umami-storage-monitor.test.mjs` — 10/10 passed.
- `npm run typecheck` and `npm run lint` passed; lint reported only existing warnings outside this change.
- `npm run test:data` exercised the repository suite. Its only failures were the sandbox denying macOS `mktemp` under `/var/folders`; the exact failing `tests/prepush-hook-gate.test.mjs` suite passed 16/16 outside the sandbox.
- The pre-push gate passed, including typecheck, Unicode safety, the focused workflow contract, version sync, and scoped repository checks.

## Post-Deploy Monitoring & Validation

- Validation window: observe four consecutive natural `*/15` runs on `main` after merge, about one hour. Owner: @koala73.
- Success: every run leaves `waiting`/`pending`, gets a runner, reads the protected Railway volume, and emits usage, growth, and headroom within five minutes. Alert-policy failures are valid monitor results; scheduler or credential failures are not.
- Check: use the Umami Storage Monitor Actions history and inspect each run's runner assignment, environment step, and `Postgres Umami` output. Confirm that no non-main dispatch cancels a `main` run.
- Failure: any run remains runner-less, is concurrency-cancelled by another ref, cannot access the production environment token, omits capacity metrics, or exceeds five minutes.
- Mitigation: cancel any stale group owner before dispatching a replacement. Revert this commit only if ref-scoped cancellation causes cross-run interference, then keep manual stale-owner cleanup in place while the scheduler policy is corrected.
- Capacity follow-up: if consecutive restored samples continue to cross the existing 30-day warning contract, open separate capacity work with those samples as evidence.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT_5-000000)
