### PR TITLE
ops(monitor): acknowledge the eight consumer-price coverage partials against owner issues

### DIFF
--- a/scripts/seed-freshness-baseline.json
+++ b/scripts/seed-freshness-baseline.json
@@ -24,6 +24,54 @@
       "status": "SEED_ERROR",
       "issue": 5714,
       "reason": "Japan MOD route returns proxy CONNECT 403; candidate country-specific routes return 407. Second cause independent of the #5689 Decodo exhaustion. No verified replacement endpoint installed."
+    },
+    {
+      "name": "consumerPricesCoverage",
+      "status": "COVERAGE_PARTIAL",
+      "issue": 6355,
+      "reason": "AE aggregate: records match the enabled retailer roster (4) and coverage age stays inside maxStaleMin. summarizeMarketCoverage grades any retailer dirty scrape run as market-wide partial, which fires nearly every day, so the monitor has been red on every scheduled run since #5970 exposed these keys on 2026-07-30. Producer-side tolerance or a warn-level mapping is tracked in the issue."
+    },
+    {
+      "name": "consumerPricesCoverageAU",
+      "status": "COVERAGE_PARTIAL",
+      "issue": 6356,
+      "reason": "AU: records match the enabled retailer roster (2), age fresh. Same daily dirty-scrape-run partial grading as consumerPricesCoverage; parent evidence in #6355."
+    },
+    {
+      "name": "consumerPricesCoverageBR",
+      "status": "COVERAGE_PARTIAL",
+      "issue": 6357,
+      "reason": "BR: records match the enabled retailer roster (2), age fresh. Same daily dirty-scrape-run partial grading as consumerPricesCoverage; parent evidence in #6355."
+    },
+    {
+      "name": "consumerPricesCoverageGB",
+      "status": "COVERAGE_PARTIAL",
+      "issue": 6358,
+      "reason": "GB: records match the enabled retailer roster (2), age fresh. Same daily dirty-scrape-run partial grading as consumerPricesCoverage; parent evidence in #6355."
+    },
+    {
+      "name": "consumerPricesCoverageIN",
+      "status": "COVERAGE_PARTIAL",
+      "issue": 6359,
+      "reason": "IN: records match the enabled retailer roster (2), age fresh. Same daily dirty-scrape-run partial grading as consumerPricesCoverage; parent evidence in #6355."
+    },
+    {
+      "name": "consumerPricesCoverageSA",
+      "status": "COVERAGE_PARTIAL",
+      "issue": 6360,
+      "reason": "SA: records match the enabled retailer roster (3), age fresh. Same daily dirty-scrape-run partial grading as consumerPricesCoverage; parent evidence in #6355."
+    },
+    {
+      "name": "consumerPricesCoverageSG",
+      "status": "COVERAGE_PARTIAL",
+      "issue": 6361,
+      "reason": "SG: records match the enabled retailer roster (2), age fresh. Same daily dirty-scrape-run partial grading as consumerPricesCoverage; parent evidence in #6355."
+    },
+    {
+      "name": "consumerPricesCoverageUS",
+      "status": "COVERAGE_PARTIAL",
+      "issue": 6362,
+      "reason": "US: records match the enabled retailer roster (2), age fresh. Same daily dirty-scrape-run partial grading as consumerPricesCoverage; parent evidence in #6355."
     }
   ]
 }


### PR DESCRIPTION
## What

Adds the eight `consumerPricesCoverage*:COVERAGE_PARTIAL` pairs to `scripts/seed-freshness-baseline.json`, each against its own tracking issue (#6355 parent + #6356–#6362 per market), so the Seed Freshness Monitor can pass again and catch new regressions.

## Why

The monitor has failed **every scheduled run since 2026-07-30T13:04Z** — the same day #5970 exposed these keys to health. Every one of those failures blocks on the same 8 keys and nothing else:

```
- consumerPricesCoverage: status=COVERAGE_PARTIAL records=4 age=134m max=1500m
- consumerPricesCoverageAU..US: status=COVERAGE_PARTIAL records=2-3, age fresh
```

Records match the enabled retailer roster exactly for every market; age is well inside `maxStaleMin`. The partial grade comes from `summarizeMarketCoverage` (`consumer-prices-core/src/ops/coverage.ts:129-171`) treating any retailer's dirty scrape run as market-wide partial, which fires nearly every day. Root cause and two candidate fixes (producer-side tolerance, or warn-level mapping when records == roster) are written up in #6355 — this PR only restores the gate's signal until one of those lands.

## Test plan

- [x] `node --test tests/seed-freshness-monitor.test.mjs` — 23 pass, 0 fail (including the distinct-owner-issue and substantive-reason assertions)
- [x] `node --test tests/seed-freshness-workflow.test.mjs` — 3 pass
- [x] `node scripts/check-seed-freshness.mjs` against live `api.worldmonitor.app` — exit 0, "no unacknowledged health problems (8 acknowledged)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sD2H1oDsXVRUQwdKpvujJ