### PR TITLE
fix(payments): send the welcome email to the account's current login address (#6335)

### DIFF
--- a/convex/__tests__/checkoutLoginEmailMetadata.test.ts
+++ b/convex/__tests__/checkoutLoginEmailMetadata.test.ts
@@ -1,0 +1,198 @@
+/**
+ * #6335 — the checkout stamps the authenticated login email into signed
+ * metadata, so the activation webhook does not have to trust `users.email`
+ * (refreshed only once per page load per userId).
+ *
+ * Lives in its own file because it mocks `../lib/dodo`: the sibling
+ * checkout.test.ts deliberately runs with DODO_API_KEY unset so that reaching
+ * the provider is itself an assertion, and a module-level mock there would
+ * silently defeat that.
+ */
+import { convexTest } from "convex-test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { api, internal } from "../_generated/api";
+import { createDodoCheckoutSession } from "../lib/dodo";
+import {
+  CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS,
+  verifyCheckoutLoginEmail,
+  verifyUserId,
+} from "../lib/identitySigning";
+import schema from "../schema";
+
+vi.mock("../lib/dodo", () => ({
+  CHECKOUT_PROVIDER_ATTEMPT_TIMEOUT_MS: 3_500,
+  createDodoCheckoutSession: vi.fn(),
+}));
+
+const modules = import.meta.glob("../**/*.ts");
+const SIGNING_SECRET = "checkout-login-email-test-signing-secret";
+const PRODUCT_ID = "pdt_login_email_metadata";
+const CLERK_USER = {
+  subject: "user_login_email_metadata",
+  tokenIdentifier: "clerk|user_login_email_metadata",
+  email: "Fresh.Login@Example.com",
+};
+
+type StampedMetadata = Record<string, string>;
+
+/** The metadata dictionary the action actually handed to the provider. */
+function capturedMetadata(): StampedMetadata {
+  expect(createDodoCheckoutSession).toHaveBeenCalledTimes(1);
+  const payload = vi.mocked(createDodoCheckoutSession).mock.calls[0][0] as {
+    metadata?: StampedMetadata;
+  };
+  return payload.metadata ?? {};
+}
+
+beforeEach(() => {
+  process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+  vi.mocked(createDodoCheckoutSession).mockResolvedValue({
+    checkout_url: "https://checkout.example/session",
+  });
+});
+
+afterEach(() => {
+  vi.mocked(createDodoCheckoutSession).mockReset();
+  vi.restoreAllMocks();
+  delete process.env.DODO_IDENTITY_SIGNING_SECRET;
+});
+
+describe("checkout stamps a signed login email (#6335)", () => {
+  test("the authenticated action stamps a verifiable login email alongside the userId", async () => {
+    const t = convexTest(schema, modules);
+
+    await t
+      .withIdentity(CLERK_USER)
+      .action(api.payments.checkout.createCheckout, { productId: PRODUCT_ID });
+
+    const metadata = capturedMetadata();
+    // Case is preserved: the signature covers the exact bytes, and the local
+    // part of an address is case-sensitive per RFC 5321.
+    expect(metadata.wm_login_email).toBe("Fresh.Login@Example.com");
+    expect(
+      await verifyCheckoutLoginEmail(
+        CLERK_USER.subject,
+        metadata.wm_login_email,
+        metadata.wm_login_email_sig,
+        Date.now(),
+      ),
+    ).toBe("valid");
+    // The pre-existing identity signature is untouched — folding the email into
+    // it would strand every checkout session created before this deploy.
+    expect(await verifyUserId(CLERK_USER.subject, metadata.wm_user_id_sig)).toBe(true);
+  });
+
+  test("the stamped token expires on the documented window, not never", async () => {
+    const t = convexTest(schema, modules);
+
+    await t
+      .withIdentity(CLERK_USER)
+      .action(api.payments.checkout.createCheckout, { productId: PRODUCT_ID });
+
+    const metadata = capturedMetadata();
+    const wellPastTheWindow = Date.now() + CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS + 60_000;
+    expect(
+      await verifyCheckoutLoginEmail(
+        CLERK_USER.subject,
+        metadata.wm_login_email,
+        metadata.wm_login_email_sig,
+        wellPastTheWindow,
+      ),
+    ).toBe("expired");
+  });
+
+  // The production shape for a phone-only signup, or any session whose Clerk
+  // JWT template omits the `email` claim. Driven through the PUBLIC action so
+  // the `identity?.email` path itself is exercised, not just the relay's
+  // explicit argument.
+  test("the authenticated action stamps nothing when the identity carries no email", async () => {
+    const t = convexTest(schema, modules);
+
+    await t
+      .withIdentity({
+        subject: "user_no_email_claim",
+        tokenIdentifier: "clerk|user_no_email_claim",
+      })
+      .action(api.payments.checkout.createCheckout, { productId: PRODUCT_ID });
+
+    const metadata = capturedMetadata();
+    expect(metadata.wm_login_email).toBeUndefined();
+    expect(metadata.wm_login_email_sig).toBeUndefined();
+    // Attribution is unaffected — the webhook still resolves the buyer.
+    expect(metadata.wm_user_id).toBe("user_no_email_claim");
+    expect(await verifyUserId("user_no_email_claim", metadata.wm_user_id_sig)).toBe(true);
+  });
+
+  test("the relay path stamps the email the edge gateway verified", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.action(internal.payments.checkout.internalCreateCheckout, {
+      userId: "user_relay_login_email",
+      email: "  relay@example.com  ",
+      productId: PRODUCT_ID,
+    });
+
+    const metadata = capturedMetadata();
+    // Surrounding whitespace is stripped BEFORE signing, so the stamped value
+    // and the signed value are the same bytes.
+    expect(metadata.wm_login_email).toBe("relay@example.com");
+    expect(
+      await verifyCheckoutLoginEmail(
+        "user_relay_login_email",
+        metadata.wm_login_email,
+        metadata.wm_login_email_sig,
+        Date.now(),
+      ),
+    ).toBe("valid");
+  });
+
+  // The rejection case in the table below is 262 chars — far enough past the
+  // 254 cap that `>` and `>=` are indistinguishable. These two pin the exact
+  // edge so an off-by-one turns something red.
+  test.each([
+    ["exactly at the 254-char cap", 242, true],
+    ["one char over the cap", 243, false],
+  ])("a login email %s is stamped=%s", async (_label, localLength, shouldStamp) => {
+    const email = `${"a".repeat(localLength)}@example.com`;
+    expect(email.length).toBe(shouldStamp ? 254 : 255);
+    const t = convexTest(schema, modules);
+
+    await t.action(internal.payments.checkout.internalCreateCheckout, {
+      userId: "user_login_email_length_edge",
+      email,
+      productId: PRODUCT_ID,
+    });
+
+    const metadata = capturedMetadata();
+    expect(metadata.wm_login_email).toBe(shouldStamp ? email : undefined);
+  });
+
+  test.each([
+    ["absent", undefined],
+    ["blank", "   "],
+    ["missing an @", "not-an-email"],
+    ["double-@", "a@b@example.com"],
+    ["missing a domain", "trailing@"],
+    ["missing a local part", "@example.com"],
+    ["whitespace-infixed", "spaced out@example.com"],
+    ["over the RFC 5321 length cap", `${"a".repeat(250)}@example.com`],
+  ])("an %s login email stamps nothing at all", async (_label, email) => {
+    const t = convexTest(schema, modules);
+
+    await t.action(internal.payments.checkout.internalCreateCheckout, {
+      userId: "user_unusable_login_email",
+      ...(email === undefined ? {} : { email }),
+      productId: PRODUCT_ID,
+    });
+
+    const metadata = capturedMetadata();
+    // Neither half: a bare email with no signature would be ignored by the
+    // webhook anyway, but stamping it would put an unusable address on the
+    // provider record for no benefit.
+    expect(metadata.wm_login_email).toBeUndefined();
+    expect(metadata.wm_login_email_sig).toBeUndefined();
+    // The identity metadata the webhook actually attributes on is unaffected.
+    expect(metadata.wm_user_id).toBe("user_unusable_login_email");
+  });
+});

--- a/convex/__tests__/identitySigning.test.ts
+++ b/convex/__tests__/identitySigning.test.ts
@@ -1,13 +1,20 @@
 /**
- * Tests for convex/lib/identitySigning.ts business-invite token helpers.
+ * Tests for convex/lib/identitySigning.ts business-invite and checkout
+ * login-email token helpers.
  *
  * These are pure crypto tests; they do not need the Convex runtime because
  * the helpers have no Convex imports.
  */
 import { beforeEach, describe, expect, test } from "vitest";
 import {
+  CHECKOUT_LOGIN_EMAIL_CLOCK_SKEW_MS,
+  CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS,
   signBusinessInviteToken,
+  signCheckoutLoginEmail,
+  signUserId,
   verifyBusinessInviteToken,
+  verifyCheckoutLoginEmail,
+  verifyUserId,
 } from "../lib/identitySigning";
 
 const TEST_SECRET = "test-business-invite-secret-minimum-32-bytes-long";
@@ -102,5 +109,255 @@ describe("business invite token signing/verification", () => {
     await expect(signBusinessInviteToken("grant.with.dots")).rejects.toThrow(
       /business invite grantId must not contain/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #6335 — checkout login-email token. Both the issuing and the verifying clock
+// are parameters, never Date.now(), so every boundary below is exercisable.
+// ---------------------------------------------------------------------------
+
+describe("checkout login-email token signing/verification", () => {
+  const USER = "user_login_email_001";
+  const EMAIL = "login@example.com";
+  const ISSUED_AT = new Date("2026-03-21T10:00:00Z").getTime();
+
+  beforeEach(() => {
+    process.env.DODO_IDENTITY_SIGNING_SECRET = TEST_SECRET;
+  });
+
+  test("round-trips the exact userId + email that were signed", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    expect(await verifyCheckoutLoginEmail(USER, EMAIL, token, ISSUED_AT)).toBe("valid");
+  });
+
+  test("rejects the same email under a different userId", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    expect(
+      await verifyCheckoutLoginEmail("user_other_002", EMAIL, token, ISSUED_AT),
+    ).toBe("invalid");
+  });
+
+  test("rejects a swapped email under the signed userId", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    expect(
+      await verifyCheckoutLoginEmail(USER, "attacker@example.com", token, ISSUED_AT),
+    ).toBe("invalid");
+  });
+
+  test("rejects a case-changed email — the signature covers the exact bytes", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    expect(
+      await verifyCheckoutLoginEmail(USER, "Login@example.com", token, ISSUED_AT),
+    ).toBe("invalid");
+  });
+
+  // The field boundary is length-prefixed, so no (userId, email) pair can be
+  // re-cut into another pair with the same signing payload.
+  //
+  // The inputs below are chosen so that WITHOUT the length prefix the two pairs
+  // would produce a byte-identical payload — `user:a` + ":" + `b@example.com`
+  // and `user` + ":" + `a:b@example.com` both concatenate to
+  // `user:a:b@example.com`. A userId containing the separator is what makes the
+  // collision constructible at all; a colon-free userId (every real Clerk id)
+  // cannot collide even unprefixed, so testing with one would assert nothing
+  // about this guard. Verified by mutation: dropping `${userId.length}:` from
+  // the payload turns this test red.
+  test("rejects a userId/email split moved across the field boundary", async () => {
+    const token = await signCheckoutLoginEmail("user:a", "b@example.com", ISSUED_AT);
+    expect(
+      await verifyCheckoutLoginEmail("user:a", "b@example.com", token, ISSUED_AT),
+    ).toBe("valid");
+    expect(
+      await verifyCheckoutLoginEmail("user", "a:b@example.com", token, ISSUED_AT),
+    ).toBe("invalid");
+  });
+
+  // Aging out is `expired`, NOT `invalid` — the caller logs the two at
+  // different volumes because a mature subscription produces the former on
+  // every `subscription.updated`, by design.
+  test("accepts a token at the exact max-age boundary and expires one past it", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    expect(
+      await verifyCheckoutLoginEmail(
+        USER,
+        EMAIL,
+        token,
+        ISSUED_AT + CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS,
+      ),
+    ).toBe("valid");
+    expect(
+      await verifyCheckoutLoginEmail(
+        USER,
+        EMAIL,
+        token,
+        ISSUED_AT + CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS + 1,
+      ),
+    ).toBe("expired");
+  });
+
+  // An implausibly future-dated token could only have come from our own signer,
+  // so it is a clock anomaly worth a warning — `invalid`, not `expired`.
+  test("tolerates reverse clock skew up to the allowance and no further", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    expect(
+      await verifyCheckoutLoginEmail(
+        USER,
+        EMAIL,
+        token,
+        ISSUED_AT - CHECKOUT_LOGIN_EMAIL_CLOCK_SKEW_MS,
+      ),
+    ).toBe("valid");
+    expect(
+      await verifyCheckoutLoginEmail(
+        USER,
+        EMAIL,
+        token,
+        ISSUED_AT - CHECKOUT_LOGIN_EMAIL_CLOCK_SKEW_MS - 1,
+      ),
+    ).toBe("invalid");
+  });
+
+  // The signature is checked BEFORE the age window, so a forged token cannot
+  // launder itself into the quiet `expired` bucket by carrying an old issuedAt.
+  // Without that ordering this returns "expired" and the tamper warning is lost.
+  test("a forged old token is invalid, never merely expired", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    const [version, issuedAtRaw] = token.split(".");
+    const forged = `${version}.${issuedAtRaw}.${"0".repeat(64)}`;
+    expect(
+      await verifyCheckoutLoginEmail(
+        USER,
+        EMAIL,
+        forged,
+        ISSUED_AT + CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS + 1,
+      ),
+    ).toBe("invalid");
+    // Same for a real signature replayed onto a different account past the window.
+    expect(
+      await verifyCheckoutLoginEmail(
+        "user_other_002",
+        EMAIL,
+        token,
+        ISSUED_AT + CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS + 1,
+      ),
+    ).toBe("invalid");
+  });
+
+  test("rejects a tampered issuedAt segment", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    const parts = token.split(".");
+    expect(parts).toHaveLength(3);
+    parts[1] = String(ISSUED_AT + 60_000);
+    expect(
+      await verifyCheckoutLoginEmail(USER, EMAIL, parts.join("."), ISSUED_AT),
+    ).toBe("invalid");
+  });
+
+  // `Number("+1774087200000")` parses fine and is a safe integer, so the later
+  // `Number.isSafeInteger` backstop accepts it — only the `^\d+$` test rejects
+  // the non-canonical spelling. Because verification re-signs over the PARSED
+  // number, the original signature still matches, so this token would verify
+  // without the digits-only guard. The generic "not-a-number" case below cannot
+  // show that: NaN is caught by the backstop, giving two paths to one verdict.
+  test("rejects a non-canonical numeric issuedAt that still parses and verifies", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    const [version, issuedAtRaw, signature] = token.split(".");
+    expect(Number(`+${issuedAtRaw}`)).toBe(ISSUED_AT);
+    expect(
+      await verifyCheckoutLoginEmail(
+        USER,
+        EMAIL,
+        `${version}.+${issuedAtRaw}.${signature}`,
+        ISSUED_AT,
+      ),
+    ).toBe("invalid");
+  });
+
+  test.each([
+    ["a wrong version label", (parts: string[]) => { parts[0] = "v0"; }],
+    ["a foreign version label", (parts: string[]) => { parts[0] = "v1-claim"; }],
+    ["a non-numeric issuedAt", (parts: string[]) => { parts[1] = "not-a-number"; }],
+    ["an empty signature", (parts: string[]) => { parts[2] = ""; }],
+    ["an extra segment", (parts: string[]) => { parts.push("extra"); }],
+  ])("rejects %s", async (_label, mutate) => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    const parts = token.split(".");
+    mutate(parts);
+    expect(
+      await verifyCheckoutLoginEmail(USER, EMAIL, parts.join("."), ISSUED_AT),
+    ).toBe("invalid");
+  });
+
+  test.each([
+    ["a malformed token", "not-a-token"],
+    ["an empty token", ""],
+    ["an undefined token", undefined],
+  ])("rejects %s", async (_label, token) => {
+    expect(await verifyCheckoutLoginEmail(USER, EMAIL, token, ISSUED_AT)).toBe("invalid");
+  });
+
+  // Without the `Number.isFinite(nowMs)` guard this is a silent bypass, not a
+  // crash: `NaN - issuedAt` is NaN, and both `NaN > MAX_AGE` and
+  // `NaN < -SKEW` are false, so an ancient token would sail through the age
+  // window entirely. The guard is the only thing that makes it fail closed.
+  test.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["-Infinity", Number.NEGATIVE_INFINITY],
+  ])("rejects a non-finite verifying clock (%s)", async (_label, clock) => {
+    const ancient = await signCheckoutLoginEmail(
+      USER,
+      EMAIL,
+      ISSUED_AT - CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS * 52,
+    );
+    expect(await verifyCheckoutLoginEmail(USER, EMAIL, ancient, clock)).toBe("invalid");
+  });
+
+  test("rejects an empty userId or email", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    expect(await verifyCheckoutLoginEmail("", EMAIL, token, ISSUED_AT)).toBe("invalid");
+    expect(await verifyCheckoutLoginEmail(USER, "", token, ISSUED_AT)).toBe("invalid");
+  });
+
+  // Domain separation: a wm_user_id_sig is a bare hex HMAC, so it must not
+  // parse as — nor be replayable as — a login-email token, and vice versa.
+  test("does not accept a wm_user_id signature as a login-email token", async () => {
+    const userSig = await signUserId(USER);
+    expect(await verifyCheckoutLoginEmail(USER, EMAIL, userSig, ISSUED_AT)).toBe("invalid");
+    expect(
+      await verifyCheckoutLoginEmail(USER, EMAIL, `v1.${ISSUED_AT}.${userSig}`, ISSUED_AT),
+    ).toBe("invalid");
+  });
+
+  // The other direction. Both tokens share one signing secret, so a login-email
+  // signature reaching the identity bridge as `wm_user_id_sig` would let a
+  // buyer's own token stand in for the identity proof the webhook attributes on.
+  test("a login-email signature is not accepted as a wm_user_id signature", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    const [, , loginEmailSig] = token.split(".");
+    expect(await verifyUserId(USER, loginEmailSig)).toBe(false);
+    expect(await verifyUserId(USER, token)).toBe(false);
+  });
+
+  test("throws when signing without an email or userId", async () => {
+    await expect(signCheckoutLoginEmail("", EMAIL, ISSUED_AT)).rejects.toThrow(
+      /requires a non-empty userId/,
+    );
+    await expect(signCheckoutLoginEmail(USER, "", ISSUED_AT)).rejects.toThrow(
+      /requires a non-empty email/,
+    );
+  });
+
+  test("throws when signing with a non-integer issuedAt", async () => {
+    await expect(signCheckoutLoginEmail(USER, EMAIL, Number.NaN)).rejects.toThrow(
+      /requires an integer issuedAt/,
+    );
+  });
+
+  test("fails closed when the signing secret is absent", async () => {
+    const token = await signCheckoutLoginEmail(USER, EMAIL, ISSUED_AT);
+    delete process.env.DODO_IDENTITY_SIGNING_SECRET;
+    expect(await verifyCheckoutLoginEmail(USER, EMAIL, token, ISSUED_AT)).toBe("invalid");
   });
 });

--- a/convex/__tests__/identitySigning.test.ts
+++ b/convex/__tests__/identitySigning.test.ts
@@ -351,7 +351,19 @@ describe("checkout login-email token signing/verification", () => {
 
   test("throws when signing with a non-integer issuedAt", async () => {
     await expect(signCheckoutLoginEmail(USER, EMAIL, Number.NaN)).rejects.toThrow(
-      /requires an integer issuedAt/,
+      /requires a non-negative integer issuedAt/,
+    );
+    await expect(signCheckoutLoginEmail(USER, EMAIL, 1.5)).rejects.toThrow(
+      /requires a non-negative integer issuedAt/,
+    );
+  });
+
+  // The verifier parses issuedAt with `^\d+$`, which has no sign — so a signer
+  // that accepted a negative value could mint a token this module's own
+  // verifier always calls invalid.
+  test("throws rather than minting a token its own verifier would reject", async () => {
+    await expect(signCheckoutLoginEmail(USER, EMAIL, -1)).rejects.toThrow(
+      /requires a non-negative integer issuedAt/,
     );
   });
 

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -1,7 +1,11 @@
 import { convexTest } from "convex-test";
 import { afterEach, expect, test, describe, vi } from "vitest";
 import { getFeaturesForPlan } from "../lib/entitlements";
-import { signUserId } from "../lib/identitySigning";
+import {
+  CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS,
+  signCheckoutLoginEmail,
+  signUserId,
+} from "../lib/identitySigning";
 import schema from "../schema";
 import { internal } from "../_generated/api";
 
@@ -768,6 +772,796 @@ describe("webhook processWebhookEvent", () => {
     expect(sends).toHaveLength(2);
     const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
     expect(welcome?.to).toEqual(["test@example.com"]);
+  });
+
+  // #6335: the users row is refreshed once per page load per userId
+  // (src/services/convex-client.ts short-circuits on a module-level
+  // lastEnsuredUserId), so a user who changes their primary email in the Clerk
+  // portal and subscribes in the same long-lived tab leaves a STALE
+  // users.email. The checkout carries the login email as it was at checkout
+  // time, HMAC-signed — that is the fresher of the two, so it wins.
+  test("a signed checkout login email outranks a stale users row", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      // The address the user abandoned in the Clerk portal, mirrored here by
+      // the last ensureRecord call before the change.
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "stale@example.com",
+        normalizedEmail: "stale@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP - 86400000,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_signed_login_email_fresh",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          wm_login_email: "fresh@example.com",
+          wm_login_email_sig: await signCheckoutLoginEmail(
+            "test-user-001",
+            "fresh@example.com",
+            BASE_TIMESTAMP - 60_000,
+          ),
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+        html: string;
+      });
+
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["fresh@example.com"]);
+    expect(welcome?.html).toContain("fresh@example.com");
+    // The abandoned address receives nothing at all.
+    expect(sends.every((send) => send.to[0] !== "stale@example.com")).toBe(true);
+    // The checkout inbox still gets the pointer, and it names the FRESH login
+    // address (masked) — pointing at the stale one is the same dead end.
+    const pointer = sends.find((send) => send.to[0] === "checkout@example.com");
+    expect(pointer?.html).toContain("f•••@example.com");
+    expect(pointer?.html).not.toContain("s•••@example.com");
+  });
+
+  test("a signed login email equal to the checkout address suppresses the pointer", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      // Stale row that DIVERGES from the checkout address: without the signed
+      // value the run would emit a pointer, so this pins that the divergence
+      // verdict is recomputed against the signed email, not just the recipient.
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "stale@example.com",
+        normalizedEmail: "stale@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP - 86400000,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_signed_login_email_matches_checkout",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          wm_login_email: "checkout@example.com",
+          wm_login_email_sig: await signCheckoutLoginEmail(
+            "test-user-001",
+            "checkout@example.com",
+            BASE_TIMESTAMP - 60_000,
+          ),
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    // Welcome + admin only — one inbox, so no sign-in pointer.
+    expect(sends).toHaveLength(2);
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["checkout@example.com"]);
+  });
+
+  test.each([
+    [
+      "a signature minted for a different account",
+      async () => ({
+        wm_login_email: "attacker@example.com",
+        wm_login_email_sig: await signCheckoutLoginEmail(
+          "user_someone_else",
+          "attacker@example.com",
+          BASE_TIMESTAMP - 60_000,
+        ),
+      }),
+    ],
+    [
+      "an email swapped after signing",
+      async () => ({
+        wm_login_email: "attacker@example.com",
+        wm_login_email_sig: await signCheckoutLoginEmail(
+          "test-user-001",
+          "fresh@example.com",
+          BASE_TIMESTAMP - 60_000,
+        ),
+      }),
+    ],
+    [
+      "a token older than the checkout window",
+      async () => ({
+        wm_login_email: "expired@example.com",
+        wm_login_email_sig: await signCheckoutLoginEmail(
+          "test-user-001",
+          "expired@example.com",
+          BASE_TIMESTAMP - CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS - 1,
+        ),
+      }),
+    ],
+    [
+      "an unsigned login email",
+      async () => ({ wm_login_email: "unsigned@example.com" }),
+    ],
+    [
+      // Producible only by hand: the stamping side trims before signing. The
+      // signature here genuinely covers the padding, so this is the one shape
+      // where "verify then trim" would have sent to bytes nobody proved.
+      "a padded login email whose signature covers the padding",
+      async () => ({
+        wm_login_email: "  padded@example.com  ",
+        wm_login_email_sig: await signCheckoutLoginEmail(
+          "test-user-001",
+          "  padded@example.com  ",
+          BASE_TIMESTAMP - 60_000,
+        ),
+      }),
+    ],
+    [
+      // The mirror tamper shape: strip the address, keep the signature. Both
+      // halves are stamped together, so either half alone is an anomaly.
+      "a signature with the address stripped",
+      async () => ({
+        wm_login_email_sig: await signCheckoutLoginEmail(
+          "test-user-001",
+          "stripped@example.com",
+          BASE_TIMESTAMP - 60_000,
+        ),
+      }),
+    ],
+  ])("%s never displaces the users row", async (_label, buildMetadata) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "login@example.com",
+        normalizedEmail: "login@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await processEvent(
+      t,
+      `wh_login_email_rejected_${_label.replace(/\W+/g, "_")}`,
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          ...(await buildMetadata()),
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["login@example.com"]);
+    // Whitelist rather than blacklist: every recipient must be one of the three
+    // legitimate inboxes (login, checkout pointer, admin alert), so no
+    // unverifiable metadata value can reach ANY send regardless of the shape it
+    // arrived in (padding included).
+    expect([...new Set(sends.map((send) => send.to[0]))].sort()).toEqual([
+      "checkout@example.com",
+      "elie@worldmonitor.app",
+      "login@example.com",
+    ]);
+  });
+
+  // The steady state, not an anomaly: Dodo re-delivers the ORIGINAL checkout's
+  // metadata on every later `subscription.updated`, so a mature subscription
+  // ages its stamped token out on each one. That must be quiet (console.log)
+  // and must not spend the tamper warning, which is reserved for a token that
+  // did not come from us.
+  test("an aged-out replay on a mature subscription falls back without a warning", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "current@example.com",
+        normalizedEmail: "current@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 400 * 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_mature_sub_aged_replay",
+      "subscription.updated",
+      makeSubscriptionPayload({
+        status: "active",
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          wm_login_email: "year-old@example.com",
+          wm_login_email_sig: await signCheckoutLoginEmail(
+            "test-user-001",
+            "year-old@example.com",
+            BASE_TIMESTAMP - 365 * 86400000,
+          ),
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // The year-old stamped address loses to the users row, which a page load
+    // has refreshed many times since that checkout.
+    const sends = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls
+      .filter(([url]: [unknown]) => String(url).includes("api.resend.com"))
+      .map(([, init]: [unknown, RequestInit]) => JSON.parse(String(init.body)) as {
+        to: string[];
+        subject: string;
+      });
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["current@example.com"]);
+
+    // And it did so silently. Pinning the ABSENCE of the tamper warning is the
+    // point: without the expired/invalid split this fires on every mature
+    // subscription and the real signal drowns.
+    const loginEmailWarnings = warn.mock.calls
+      .map((call) => String(call[0]))
+      .filter((line) => line.includes("wm_login_email"));
+    expect(loginEmailWarnings).toEqual([]);
+  });
+
+  // Rotating DODO_IDENTITY_SIGNING_SECRET invalidates every in-flight stamped
+  // token at once. The recipient must degrade to the users row rather than the
+  // send failing or addressing an unverified value.
+  test("a rotated signing secret degrades to the users row, it does not break the send", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "login@example.com",
+        normalizedEmail: "login@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    // Stamped under the old secret...
+    const metadata = {
+      wm_user_id: "test-user-001",
+      wm_user_id_sig: await signUserId("test-user-001"),
+      wm_login_email: "fresh@example.com",
+      wm_login_email_sig: await signCheckoutLoginEmail(
+        "test-user-001",
+        "fresh@example.com",
+        BASE_TIMESTAMP - 60_000,
+      ),
+    };
+    // ...delivered after the rotation. `wm_user_id_sig` is rotated in lockstep,
+    // so attribution falls through to the customers row seeded by processEvent.
+    process.env.DODO_IDENTITY_SIGNING_SECRET = "rotated-secret-value";
+
+    await processEvent(
+      t,
+      "wh_rotated_secret",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata,
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["login@example.com"]);
+  });
+
+  test("a rejected signature on the reactivation path still reaches the users row", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "login@example.com",
+        normalizedEmail: "login@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId: "test-user-001",
+        dodoSubscriptionId: "sub_prior_lapsed_reject",
+        dodoProductId: "pdt_test_pro",
+        planKey: "pro_monthly",
+        status: "expired",
+        currentPeriodStart: BASE_TIMESTAMP - 31 * 86400000,
+        currentPeriodEnd: BASE_TIMESTAMP - 86400000,
+        rawPayload: {},
+        updatedAt: BASE_TIMESTAMP - 86400000,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_reactivation_rejected_sig",
+      "subscription.active",
+      makeSubscriptionPayload({
+        subscription_id: "sub_returning_reject",
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          wm_login_email: "attacker@example.com",
+          wm_login_email_sig: await signCheckoutLoginEmail(
+            "test-user-001",
+            "somethingelse@example.com",
+            BASE_TIMESTAMP - 60_000,
+          ),
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    // The reactivation path gets the same fallback as the first-purchase path.
+    const welcomeBack = sends.find((send) => send.subject.includes("Welcome back"));
+    expect(welcomeBack?.to).toEqual(["login@example.com"]);
+    expect(sends.every((send) => send.to[0] !== "attacker@example.com")).toBe(true);
+  });
+
+  test("a tampered login email still spends the warning", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "login@example.com",
+        normalizedEmail: "login@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_tampered_login_email_warns",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          wm_login_email: "attacker@example.com",
+          wm_login_email_sig: await signCheckoutLoginEmail(
+            "test-user-001",
+            "fresh@example.com",
+            BASE_TIMESTAMP - 60_000,
+          ),
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const loginEmailWarnings = warn.mock.calls
+      .map((call) => String(call[0]))
+      .filter((line) => line.includes("wm_login_email"));
+    expect(loginEmailWarnings).toHaveLength(1);
+    expect(loginEmailWarnings[0]).toContain("failed signature verification");
+  });
+
+  // Both halves are stamped together, so either half alone is an anomaly — and
+  // it must warn in EITHER direction. Reported by presence only: the address
+  // must never reach a Sentry-forwarded string.
+  test.each([
+    [
+      "the signature stripped",
+      { wm_login_email: "half@example.com" },
+      "email=present, signature=absent",
+    ],
+    [
+      "the address stripped",
+      { wm_login_email_sig: "v1.1.deadbeef" },
+      "email=absent, signature=present",
+    ],
+  ])("a half-present pair with %s warns", async (_label, half, expectedShape) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "login@example.com",
+        normalizedEmail: "login@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await processEvent(
+      t,
+      `wh_half_present_${expectedShape.replace(/\W+/g, "_")}`,
+      "subscription.active",
+      makeSubscriptionPayload({
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          ...half,
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const loginEmailWarnings = warn.mock.calls
+      .map((call) => String(call[0]))
+      .filter((line) => line.includes("wm_login_email"));
+    expect(loginEmailWarnings).toHaveLength(1);
+    expect(loginEmailWarnings[0]).toContain("Half-present");
+    expect(loginEmailWarnings[0]).toContain(expectedShape);
+    // Presence only — the address itself never reaches the log line.
+    expect(loginEmailWarnings[0]).not.toContain("@example.com");
+  });
+
+  // resolveSignedCheckoutLoginEmail's docstring claims the signature is checked
+  // against the userId the handler ACTUALLY resolved, not the one the metadata
+  // claims — so a token minted for an anonymous checkout id cannot follow the
+  // subscription after preferExistingCustomerOwner reassigns it to the real
+  // account that owns the Dodo customer. Nothing tested that claim.
+  test("an anon-signed login email does not survive owner reassignment", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    const anonId = "33333333-3333-4333-8333-333333333333";
+    const realUserId = "user_real_owner_6335";
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      // The Dodo customer already belongs to a real account...
+      await ctx.db.insert("customers", {
+        userId: realUserId,
+        dodoCustomerId: "cust_reassign_6335",
+        email: "checkout@example.com",
+        normalizedEmail: "checkout@example.com",
+        createdAt: BASE_TIMESTAMP - 86400000,
+        updatedAt: BASE_TIMESTAMP - 86400000,
+      });
+      // ...whose users row carries the address that must win.
+      await ctx.db.insert("users", {
+        userId: realUserId,
+        email: "realowner@example.com",
+        normalizedEmail: "realowner@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP,
+      });
+    });
+
+    await t.mutation(internal.payments.webhookMutations.processWebhookEvent, {
+      webhookId: "wh_anon_signed_reassigned",
+      eventType: "subscription.active",
+      rawPayload: makeSubscriptionPayload({
+        subscription_id: "sub_reassign_6335",
+        customer: {
+          customer_id: "cust_reassign_6335",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        // Signed correctly — but for the ANONYMOUS id, which
+        // preferExistingCustomerOwner discards in favour of the real owner.
+        metadata: {
+          wm_user_id: anonId,
+          wm_user_id_sig: await signUserId(anonId),
+          wm_login_email: "anon-typed@example.com",
+          wm_login_email_sig: await signCheckoutLoginEmail(
+            anonId,
+            "anon-typed@example.com",
+            BASE_TIMESTAMP - 60_000,
+          ),
+        },
+      }),
+      timestamp: BASE_TIMESTAMP,
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // The subscription landed on the real owner...
+    const sub = await t.run(async (ctx) =>
+      ctx.db
+        .query("subscriptions")
+        .withIndex("by_dodoSubscriptionId", (q) =>
+          q.eq("dodoSubscriptionId", "sub_reassign_6335"),
+        )
+        .unique(),
+    );
+    expect(sub?.userId).toBe(realUserId);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    // ...and so did the welcome. The anon-signed address never verifies against
+    // the reassigned userId, so it cannot redirect a real account's mail.
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["realowner@example.com"]);
+    expect(sends.every((send) => send.to[0] !== "anon-typed@example.com")).toBe(true);
+  });
+
+  test("a signed login email is used even when no users row exists", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+
+    await processEvent(
+      t,
+      "wh_signed_login_email_no_users_row",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          wm_login_email: "fresh@example.com",
+          wm_login_email_sig: await signCheckoutLoginEmail(
+            "test-user-001",
+            "fresh@example.com",
+            BASE_TIMESTAMP - 60_000,
+          ),
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["fresh@example.com"]);
+  });
+
+  test("reactivation targets the signed login email over a stale users row", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "stale@example.com",
+        normalizedEmail: "stale@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: BASE_TIMESTAMP - 86400000,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId: "test-user-001",
+        dodoSubscriptionId: "sub_prior_lapsed",
+        dodoProductId: "pdt_test_pro",
+        planKey: "pro_monthly",
+        status: "expired",
+        currentPeriodStart: BASE_TIMESTAMP - 31 * 86400000,
+        currentPeriodEnd: BASE_TIMESTAMP - 86400000,
+        rawPayload: {},
+        updatedAt: BASE_TIMESTAMP - 86400000,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_reactivation_signed_login_email",
+      "subscription.active",
+      makeSubscriptionPayload({
+        subscription_id: "sub_returning_001",
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          wm_login_email: "fresh@example.com",
+          wm_login_email_sig: await signCheckoutLoginEmail(
+            "test-user-001",
+            "fresh@example.com",
+            BASE_TIMESTAMP - 60_000,
+          ),
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+        html: string;
+      });
+
+    const welcomeBack = sends.find((send) => send.subject.includes("Welcome back"));
+    expect(welcomeBack?.to).toEqual(["fresh@example.com"]);
+    expect(welcomeBack?.html).toContain("fresh@example.com");
   });
 
   test("email templates escape HTML in interpolated addresses", async () => {

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -848,6 +848,137 @@ describe("webhook processWebhookEvent", () => {
     expect(pointer?.html).not.toContain("s•••@example.com");
   });
 
+  // The inverse of the #6335 bug, and just as real: change the email AFTER
+  // checking out, then load a page (refreshing the users row) before the
+  // activation webhook lands. Now the STAMP is the stale one. A fixed
+  // "stamp wins" rule would send to the abandoned address — the very failure
+  // #6335 set out to fix, with the two sources swapped.
+  test("a users row refreshed after checkout outranks the stamped email", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    const checkoutIssuedAt = BASE_TIMESTAMP - 3600_000;
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        // Confirmed against Clerk AFTER the checkout was stamped.
+        email: "newest@example.com",
+        normalizedEmail: "newest@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: checkoutIssuedAt + 60_000,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_users_row_fresher_than_stamp",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          // Valid signature, inside the age window — but superseded.
+          wm_login_email: "abandoned@example.com",
+          wm_login_email_sig: await signCheckoutLoginEmail(
+            "test-user-001",
+            "abandoned@example.com",
+            checkoutIssuedAt,
+          ),
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["newest@example.com"]);
+    expect(sends.every((send) => send.to[0] !== "abandoned@example.com")).toBe(true);
+  });
+
+  // The boundary between the two rules: a users row last confirmed BEFORE the
+  // checkout is the stale one, so the stamp wins. Same fixture as above with
+  // only the timestamps' order flipped, which is what makes the comparison
+  // itself — not some other difference — the thing under test.
+  test("a users row last confirmed before checkout loses to the stamped email", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(BASE_TIMESTAMP);
+    process.env.RESEND_API_KEY = "re_test";
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("{}", { status: 200 }));
+    const t = convexTest(schema, modules);
+
+    const checkoutIssuedAt = BASE_TIMESTAMP - 3600_000;
+
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", {
+        userId: "test-user-001",
+        email: "abandoned@example.com",
+        normalizedEmail: "abandoned@example.com",
+        firstSeenAt: BASE_TIMESTAMP - 86400000,
+        lastSeenAt: checkoutIssuedAt - 60_000,
+      });
+    });
+
+    await processEvent(
+      t,
+      "wh_users_row_older_than_stamp",
+      "subscription.active",
+      makeSubscriptionPayload({
+        customer: {
+          customer_id: "cust_test_001",
+          email: "checkout@example.com",
+          name: "Test User",
+        },
+        metadata: {
+          wm_user_id: "test-user-001",
+          wm_user_id_sig: await signUserId("test-user-001"),
+          wm_login_email: "newest@example.com",
+          wm_login_email_sig: await signCheckoutLoginEmail(
+            "test-user-001",
+            "newest@example.com",
+            checkoutIssuedAt,
+          ),
+        },
+      }),
+      BASE_TIMESTAMP,
+    );
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const sends = fetchMock.mock.calls
+      .filter(([url]) => String(url).includes("api.resend.com"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as {
+        to: string[];
+        subject: string;
+      });
+
+    const welcome = sends.find((send) => send.subject.startsWith("Welcome to World Monitor"));
+    expect(welcome?.to).toEqual(["newest@example.com"]);
+    expect(sends.every((send) => send.to[0] !== "abandoned@example.com")).toBe(true);
+  });
+
   test("a signed login email equal to the checkout address suppresses the pointer", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(BASE_TIMESTAMP);
@@ -1295,21 +1426,32 @@ describe("webhook processWebhookEvent", () => {
     expect(loginEmailWarnings[0]).toContain("failed signature verification");
   });
 
-  // Both halves are stamped together, so either half alone is an anomaly — and
-  // it must warn in EITHER direction. Reported by presence only: the address
-  // must never reach a Sentry-forwarded string.
+  // Every metadata shape that CANNOT have come from our own stamping side is an
+  // anomaly and must warn — otherwise a corruption or tampering signal is
+  // invisible. Reported by presence only: the address must never reach a
+  // Sentry-forwarded string.
   test.each([
     [
-      "the signature stripped",
+      "a pair with the signature stripped",
       { wm_login_email: "half@example.com" },
       "email=present, signature=absent",
     ],
     [
-      "the address stripped",
+      "a pair with the address stripped",
       { wm_login_email_sig: "v1.1.deadbeef" },
       "email=absent, signature=present",
     ],
-  ])("a half-present pair with %s warns", async (_label, half, expectedShape) => {
+    [
+      // The stamping side always trims before signing, so padding here is
+      // corruption or tampering even though the fallback is graceful.
+      "a padded address",
+      {
+        wm_login_email: "  padded@example.com  ",
+        wm_login_email_sig: "v1.1.deadbeef",
+      },
+      "Padded wm_login_email",
+    ],
+  ])("%s warns", async (_label, half, expectedShape) => {
     vi.useFakeTimers();
     vi.setSystemTime(BASE_TIMESTAMP);
     process.env.RESEND_API_KEY = "re_test";
@@ -1348,7 +1490,6 @@ describe("webhook processWebhookEvent", () => {
       .map((call) => String(call[0]))
       .filter((line) => line.includes("wm_login_email"));
     expect(loginEmailWarnings).toHaveLength(1);
-    expect(loginEmailWarnings[0]).toContain("Half-present");
     expect(loginEmailWarnings[0]).toContain(expectedShape);
     // Presence only — the address itself never reaches the log line.
     expect(loginEmailWarnings[0]).not.toContain("@example.com");

--- a/convex/lib/emailDomain.ts
+++ b/convex/lib/emailDomain.ts
@@ -1,4 +1,10 @@
 import { isValid as mailcheckerIsValid } from "mailchecker";
+import { extractDomain } from "./emailShape";
+
+// Re-exported so this module stays the address-semantics entry point for
+// existing callers, while the pure shape parse lives in a dependency-free
+// module the checkout path can import without pulling in `mailchecker` (#6335).
+export { extractDomain };
 
 // Free / consumer email providers. A "corporate" domain is, by definition, NOT
 // one of these. Kept as the single convex-side source of truth for the
@@ -22,27 +28,6 @@ export const FREE_EMAIL_DOMAINS = new Set<string>([
   "wanadoo.fr", "free.fr", "laposte.net", "orange.fr", "sfr.fr",
   "t-online.de", "libero.it", "virgilio.it",
 ]);
-
-/**
- * Return the lowercased domain part of an email address, or `null` when the
- * address is malformed. "Malformed" here means: not a string, no `@`, an empty
- * local part, more than one `@`, an empty domain, or whitespace in the domain.
- * Does NOT require a dot in the domain — that is only enforced by
- * {@link isCorporateDomain}.
- */
-export function extractDomain(email: string): string | null {
-  if (typeof email !== "string") return null;
-  const trimmed = email.trim();
-  const at = trimmed.indexOf("@");
-  // `at <= 0` rejects both "no @" (-1) and an empty local part ("@b.com" -> 0).
-  if (at <= 0) return null;
-  // Reject a second `@` — "a@b@c" is not a single address.
-  if (trimmed.indexOf("@", at + 1) !== -1) return null;
-  const domain = trimmed.slice(at + 1).toLowerCase();
-  if (domain.length === 0) return null;
-  if (/\s/.test(domain)) return null;
-  return domain;
-}
 
 /**
  * Case-insensitive equality of the two addresses' domains. Returns `false` if

--- a/convex/lib/emailShape.ts
+++ b/convex/lib/emailShape.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure address-shape parsing, with NO dependencies.
+ *
+ * Split out of `emailDomain.ts` (#6335) so the checkout hot path can reuse the
+ * one definition of "well-formed address" without importing that module's
+ * `mailchecker` dependency — a ~1MB disposable-domain list that builds a Set at
+ * module load and has no business on a paying customer's checkout request.
+ * `emailDomain.ts` re-exports `extractDomain` from here, so every existing
+ * caller and its tests are unaffected.
+ */
+
+/**
+ * Return the lowercased domain part of an email address, or `null` when the
+ * address is malformed. "Malformed" here means: not a string, no `@`, an empty
+ * local part, more than one `@`, an empty domain, or whitespace in the domain.
+ * Does NOT require a dot in the domain — that is only enforced by
+ * `isCorporateDomain` in `emailDomain.ts`.
+ */
+export function extractDomain(email: string): string | null {
+  if (typeof email !== "string") return null;
+  const trimmed = email.trim();
+  const at = trimmed.indexOf("@");
+  // `at <= 0` rejects both "no @" (-1) and an empty local part ("@b.com" -> 0).
+  if (at <= 0) return null;
+  // Reject a second `@` — "a@b@c" is not a single address.
+  if (trimmed.indexOf("@", at + 1) !== -1) return null;
+  const domain = trimmed.slice(at + 1).toLowerCase();
+  if (domain.length === 0) return null;
+  if (/\s/.test(domain)) return null;
+  return domain;
+}

--- a/convex/lib/identitySigning.ts
+++ b/convex/lib/identitySigning.ts
@@ -273,8 +273,12 @@ export async function signCheckoutLoginEmail(
   if (!email) {
     throw new Error("[identity-signing] checkout login-email token requires a non-empty email");
   }
-  if (!Number.isSafeInteger(issuedAt)) {
-    throw new Error("[identity-signing] checkout login-email token requires an integer issuedAt");
+  // Negative is rejected as well as non-integer: the verifier's `^\d+$` parse
+  // has no sign, so a negative issuedAt would mint a token this module's own
+  // verifier always calls invalid. Unreachable from `Date.now()`, but a signer
+  // that can emit a token its verifier rejects is a trap worth closing here.
+  if (!Number.isSafeInteger(issuedAt) || issuedAt < 0) {
+    throw new Error("[identity-signing] checkout login-email token requires a non-negative integer issuedAt");
   }
   const signature = await signPayload(
     checkoutLoginEmailPayload(userId, email, issuedAt),
@@ -295,6 +299,28 @@ export async function signCheckoutLoginEmail(
  * Logging both at the same volume would bury the second in the first.
  */
 export type CheckoutLoginEmailVerdict = "valid" | "expired" | "invalid";
+
+/**
+ * Structural parse of a login-email token — shape only, no authenticity claim.
+ *
+ * Exported so a caller that needs the token's `issuedAt` (to compare the
+ * stamped address's age against another source's) reads it through the SAME
+ * parser `verifyCheckoutLoginEmail` uses, rather than re-splitting the string
+ * and risking a divergent reading. Callers must treat the result as untrusted
+ * until `verifyCheckoutLoginEmail` returns `valid` for the same token.
+ */
+export function parseCheckoutLoginEmailToken(
+  token: string | undefined,
+): { issuedAt: number; signature: string } | null {
+  if (!token) return null;
+  const [version, issuedAtRaw, signature, ...extra] = token.split(".");
+  if (version !== CHECKOUT_LOGIN_EMAIL_TOKEN_VERSION || extra.length > 0) return null;
+  if (typeof issuedAtRaw !== "string" || typeof signature !== "string") return null;
+  if (!/^\d+$/.test(issuedAtRaw) || !signature) return null;
+  const issuedAt = Number(issuedAtRaw);
+  if (!Number.isSafeInteger(issuedAt)) return null;
+  return { issuedAt, signature };
+}
 
 /**
  * Verifies a stamped login email against the userId the webhook actually
@@ -319,12 +345,9 @@ export async function verifyCheckoutLoginEmail(
 ): Promise<CheckoutLoginEmailVerdict> {
   if (!token || !userId || !email) return "invalid";
   if (!Number.isFinite(nowMs)) return "invalid";
-  const [version, issuedAtRaw, signature, ...extra] = token.split(".");
-  if (version !== CHECKOUT_LOGIN_EMAIL_TOKEN_VERSION || extra.length > 0) return "invalid";
-  if (typeof issuedAtRaw !== "string" || typeof signature !== "string") return "invalid";
-  if (!/^\d+$/.test(issuedAtRaw) || !signature) return "invalid";
-  const issuedAt = Number(issuedAtRaw);
-  if (!Number.isSafeInteger(issuedAt)) return "invalid";
+  const parsed = parseCheckoutLoginEmailToken(token);
+  if (!parsed) return "invalid";
+  const { issuedAt, signature } = parsed;
   try {
     const expected = await signPayload(
       checkoutLoginEmailPayload(userId, email, issuedAt),

--- a/convex/lib/identitySigning.ts
+++ b/convex/lib/identitySigning.ts
@@ -24,6 +24,43 @@ const MAX_ANON_CLAIM_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const BUSINESS_INVITE_TOKEN_VERSION = "v1";
 const BUSINESS_INVITE_TOKEN_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 
+// Checkout login-email tokens (#6335). Carry the Clerk login email as it was at
+// checkout time so the webhook does not have to trust `users.email`, which is
+// only refreshed once per page load per userId.
+const CHECKOUT_LOGIN_EMAIL_TOKEN_VERSION = "v1";
+
+/**
+ * How long a stamped login email stays authoritative, measured from the moment
+ * the checkout session was created to the moment the activation webhook is
+ * processed.
+ *
+ * Sized to cover the slowest legitimate checkout→activation path: a Dodo
+ * checkout session's life plus a pending 3DS/SCA settlement.
+ *
+ * The upper bound is what keeps a REPLAY of old checkout metadata from
+ * outranking the `users` row. Note what does NOT bound it: a
+ * `subscription.updated`→active is Dodo's catch-all "any field changed" sync
+ * event and can arrive minutes after checkout, re-delivering the original
+ * metadata for the life of the subscription. What bounds it is that such an
+ * event on an existing NON-LAPSED subscription sends no lifecycle email at all
+ * (see the `else if (existing)` arm of handleSubscriptionActive). The only
+ * replay that can actually address a customer is one on an existing LAPSED row,
+ * and lapsing requires the paid period to have run out — at least one billing
+ * period after checkout. Seven days sits comfortably inside that gap.
+ *
+ * Past this window the `users` row is the better guess, because it is rewritten
+ * on every authenticated page load and the stamped value never is.
+ */
+export const CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Reverse-skew allowance. The issuing clock is a Convex action host and the
+ * verifying clock is the Dodo event timestamp, so a fresh token can legitimately
+ * look very slightly future-dated. Mirrors Dodo's own ±5 minute webhook
+ * signature tolerance (payments/webhookHandlers.ts).
+ */
+export const CHECKOUT_LOGIN_EMAIL_CLOCK_SKEW_MS = 5 * 60 * 1000;
+
 function getSigningKey(): string {
   const key = process.env.DODO_IDENTITY_SIGNING_SECRET;
   if (!key) {
@@ -188,4 +225,118 @@ export async function verifyBusinessInviteToken(
   } catch {
     return false;
   }
+}
+
+/**
+ * The signing payload for a checkout login-email token.
+ *
+ * Domain-separated by the `checkout-email:` prefix (so it can never be replayed
+ * as `wm_user_id_sig`, an anon-claim, or a business invite) and LENGTH-PREFIXED
+ * on the userId, so no (userId, email) pair can be re-cut into a different pair
+ * that hashes identically.
+ *
+ * The collision the length prefix closes needs a userId containing the `:`
+ * separator: unprefixed, `("user:a", "b@x")` and `("user", "a:b@x")` both
+ * concatenate to `user:a:b@x`. Every real Clerk id and anon UUID is colon-free,
+ * so this is defense against a future id format rather than a live hole — which
+ * is exactly why it is cheaper to encode unambiguously now than to audit id
+ * formats forever. The email is last and unbounded, which is what makes a length
+ * prefix on the preceding field sufficient.
+ */
+function checkoutLoginEmailPayload(
+  userId: string,
+  email: string,
+  issuedAt: number,
+): string {
+  return `checkout-email:${CHECKOUT_LOGIN_EMAIL_TOKEN_VERSION}:${issuedAt}:${userId.length}:${userId}:${email}`;
+}
+
+/**
+ * Signs the Clerk login email that was authenticated at checkout time, bound to
+ * the buyer's userId (#6335).
+ *
+ * `issuedAt` is a REQUIRED parameter rather than an internal `Date.now()`: the
+ * verifier ages the token against the webhook's own event clock, and a helper
+ * that reads a live clock would make every boundary in that comparison
+ * untestable. Callers pass `Date.now()`.
+ *
+ * @throws If userId or email is empty, or issuedAt is not an integer.
+ */
+export async function signCheckoutLoginEmail(
+  userId: string,
+  email: string,
+  issuedAt: number,
+): Promise<string> {
+  if (!userId) {
+    throw new Error("[identity-signing] checkout login-email token requires a non-empty userId");
+  }
+  if (!email) {
+    throw new Error("[identity-signing] checkout login-email token requires a non-empty email");
+  }
+  if (!Number.isSafeInteger(issuedAt)) {
+    throw new Error("[identity-signing] checkout login-email token requires an integer issuedAt");
+  }
+  const signature = await signPayload(
+    checkoutLoginEmailPayload(userId, email, issuedAt),
+  );
+  return `${CHECKOUT_LOGIN_EMAIL_TOKEN_VERSION}.${issuedAt}.${signature}`;
+}
+
+/**
+ * Why a stamped login email was not usable.
+ *
+ * `expired` and `invalid` are split because they mean opposite things to an
+ * operator. `expired` is the STEADY STATE for any mature subscription: a
+ * `subscription.updated`→active re-delivers the original checkout's metadata
+ * for the life of the subscription (subscriptionHelpers:handleSubscriptionUpdated),
+ * so every such event on a subscription older than the window ages out by
+ * design. `invalid` means the token did not come from us for this
+ * (userId, email) — a forgery, a corrupted payload, or a stamping regression.
+ * Logging both at the same volume would bury the second in the first.
+ */
+export type CheckoutLoginEmailVerdict = "valid" | "expired" | "invalid";
+
+/**
+ * Verifies a stamped login email against the userId the webhook actually
+ * resolved and the event's own clock. Anything other than `valid` fails closed —
+ * the caller falls back to the `users` row, so a rejection costs freshness,
+ * never delivery.
+ *
+ * The signature is checked BEFORE the age window, which costs one HMAC on
+ * tokens the window would have rejected anyway. That ordering is what makes the
+ * `expired` verdict worth trusting: it can only be returned for a token we
+ * genuinely signed for this exact (userId, email), so a forged token can never
+ * launder itself into the quiet bucket by carrying an old issuedAt.
+ *
+ * `email` must be the value EXACTLY as stamped (the signature covers those
+ * bytes, including case and surrounding whitespace).
+ */
+export async function verifyCheckoutLoginEmail(
+  userId: string,
+  email: string,
+  token: string | undefined,
+  nowMs: number,
+): Promise<CheckoutLoginEmailVerdict> {
+  if (!token || !userId || !email) return "invalid";
+  if (!Number.isFinite(nowMs)) return "invalid";
+  const [version, issuedAtRaw, signature, ...extra] = token.split(".");
+  if (version !== CHECKOUT_LOGIN_EMAIL_TOKEN_VERSION || extra.length > 0) return "invalid";
+  if (typeof issuedAtRaw !== "string" || typeof signature !== "string") return "invalid";
+  if (!/^\d+$/.test(issuedAtRaw) || !signature) return "invalid";
+  const issuedAt = Number(issuedAtRaw);
+  if (!Number.isSafeInteger(issuedAt)) return "invalid";
+  try {
+    const expected = await signPayload(
+      checkoutLoginEmailPayload(userId, email, issuedAt),
+    );
+    if (!timingSafeEqualHex(expected, signature)) return "invalid";
+  } catch {
+    return "invalid";
+  }
+  const age = nowMs - issuedAt;
+  if (age > CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS) return "expired";
+  // Implausibly future-dated: only our own signer could have produced this, so
+  // it is a clock problem worth surfacing rather than an ordinary expiry.
+  if (age < -CHECKOUT_LOGIN_EMAIL_CLOCK_SKEW_MS) return "invalid";
+  return "valid";
 }

--- a/convex/payments/checkout.ts
+++ b/convex/payments/checkout.ts
@@ -17,7 +17,13 @@ import {
   createDodoCheckoutSession,
 } from "../lib/dodo";
 import { requireUserId, resolveUserIdentity } from "../lib/auth";
-import { ANON_ID_V4_REGEX, signAnonClaimToken, signUserId } from "../lib/identitySigning";
+import { extractDomain } from "../lib/emailShape";
+import {
+  ANON_ID_V4_REGEX,
+  signAnonClaimToken,
+  signCheckoutLoginEmail,
+  signUserId,
+} from "../lib/identitySigning";
 import { resolveProductToPlan } from "../config/productCatalog";
 import {
   CHECKOUT_RATE_LIMITED,
@@ -28,6 +34,45 @@ import {
 
 const ACTIVE_SUBSCRIPTION_EXISTS = "ACTIVE_SUBSCRIPTION_EXISTS";
 const PAYMENT_IN_PROGRESS = "PAYMENT_IN_PROGRESS";
+
+// RFC 5321 maximum forward-path length. A value beyond it is not an address we
+// could deliver to anyway, and it keeps the stamped metadata value small.
+const MAX_LOGIN_EMAIL_LENGTH = 254;
+
+/**
+ * Normalizes the authenticated login email for stamping into checkout metadata
+ * (#6335).
+ *
+ * This is a shape guard, not a trust boundary — it keeps an unusable value out
+ * of a field the webhook later hands to Resend as a recipient. What makes that
+ * the right level: `createCheckout` reads the email from the Clerk JWT `email`
+ * claim via `resolveUserIdentity`, and `internalCreateCheckout` receives it from
+ * `/relay/create-checkout`, whose only caller (`api/create-checkout.ts`) derives
+ * it from a JWKS-verified bearer token. Note the relay itself authenticates by
+ * shared secret and does NOT re-derive the claim, so "the value is a verified
+ * credential" is a property of that caller rather than one enforced here.
+ * Downstream this stays safe regardless: the webhook trusts the value only
+ * through the HMAC, and the email templates escape it.
+ *
+ * Case is PRESERVED (the local part is case-sensitive per RFC 5321, and
+ * `users.email` is stored the same way).
+ *
+ * Returns null when there is nothing usable to stamp, in which case the
+ * webhook's existing `users.email` → checkout-email ladder is unchanged.
+ */
+function normalizeCheckoutLoginEmail(raw: string | undefined): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_LOGIN_EMAIL_LENGTH) return null;
+  // `extractDomain` owns the @-shape rules (no @, empty local part, a second @,
+  // empty domain). Imported from `emailShape` rather than `emailDomain` so the
+  // checkout path does not pull in that module's `mailchecker` dependency.
+  if (extractDomain(trimmed) === null) return null;
+  // Stricter than extractDomain, which only rejects whitespace in the domain
+  // half: an address bound for an email `to:` header must have none anywhere.
+  if (/\s/.test(trimmed)) return null;
+  return trimmed;
+}
 
 // ---------------------------------------------------------------------------
 // Shared checkout session creation logic
@@ -205,6 +250,26 @@ async function _createCheckoutSession(
     : null;
   if (anonymousClaimToken) {
     metadata.wm_anon_claim = "v2";
+  }
+  // #6335: carry the login email that was authenticated FOR THIS CHECKOUT, so
+  // the activation webhook can address lifecycle mail without depending on the
+  // `users` row — that row is refreshed once per page load per userId
+  // (src/services/convex-client.ts short-circuits on a module-level
+  // lastEnsuredUserId), so a portal email change made in a long-lived tab
+  // leaves it stale and the welcome lands at the abandoned address.
+  //
+  // Signed as a SEPARATE field rather than folded into `wm_user_id_sig`: that
+  // signature's payload must stay `userId` alone, or every checkout session
+  // created before this deploy stops verifying at the webhook and its buyer
+  // becomes unattributable.
+  const loginEmail = normalizeCheckoutLoginEmail(user.email);
+  if (loginEmail) {
+    metadata.wm_login_email = loginEmail;
+    metadata.wm_login_email_sig = await signCheckoutLoginEmail(
+      user.userId,
+      loginEmail,
+      Date.now(),
+    );
   }
   // Tier-group bridge for the duplicate-payment guard (#4438): the pending
   // `payment.processing` webhook echoes `data.metadata.wm_plan_key` and persists

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -17,6 +17,7 @@ import {
 } from "../config/productCatalog";
 import {
   ANON_ID_V4_REGEX,
+  parseCheckoutLoginEmailToken,
   verifyCheckoutLoginEmail,
   verifyUserId,
 } from "../lib/identitySigning";
@@ -814,14 +815,20 @@ function mergeDodoCustomerId(
 }
 
 /**
- * Returns the login email the checkout stamped into its metadata, or null when
- * there is nothing trustworthy to use (#6335).
+ * Returns the login email the checkout stamped into its metadata together with
+ * the moment it was stamped, or null when there is nothing trustworthy to use
+ * (#6335).
  *
  * Verified against the userId this handler ACTUALLY resolved — not the one in
  * the metadata — so a signature minted for a different account (or replayed
  * onto a subscription whose ownership `preferExistingCustomerOwner` reassigned)
  * is rejected, and against the event's own clock, so a year-old checkout's
  * metadata replayed by a `subscription.updated` cannot outrank the `users` row.
+ *
+ * `issuedAt` comes back because "is the stamp fresher than the users row?" is
+ * the caller's actual question — see the recipient selection in
+ * `handleSubscriptionActive`. It is read through the shared token parser and is
+ * only returned once the signature over it has verified.
  *
  * Every rejection is a fallback, never a failure: the caller drops to
  * `users.email` and then to the checkout email exactly as before.
@@ -831,7 +838,7 @@ async function resolveSignedCheckoutLoginEmail(
   metadata: Record<string, string> | undefined,
   eventTimestamp: number,
   subscriptionId: string,
-): Promise<string | null> {
+): Promise<{ email: string; issuedAt: number } | null> {
   const stamped = metadata?.wm_login_email;
   const signature = metadata?.wm_login_email_sig;
   const hasStamped = typeof stamped === "string" && stamped.length > 0;
@@ -855,8 +862,15 @@ async function resolveSignedCheckoutLoginEmail(
   // signature covers the exact bytes INCLUDING surrounding whitespace, so
   // trimming post-verification would mean the value we send is not the value we
   // proved authentic. The stamping side always trims before signing
-  // (normalizeCheckoutLoginEmail), so no producible token is rejected here.
-  if (stamped !== stamped.trim()) return null;
+  // (normalizeCheckoutLoginEmail), so no producible token is rejected here —
+  // which is exactly why it warns: a padded value is corruption or tampering,
+  // and returning silently would make that anomaly invisible.
+  if (stamped !== stamped.trim()) {
+    console.warn(
+      `[subscriptionHelpers] Padded wm_login_email in checkout metadata — ignoring (subscriptionId=${subscriptionId})`,
+    );
+    return null;
+  }
   // Verify the value EXACTLY as stamped; the signature covers those bytes.
   const verdict = await verifyCheckoutLoginEmail(
     userId,
@@ -884,8 +898,11 @@ async function resolveSignedCheckoutLoginEmail(
     );
     return null;
   }
+  // Safe to read now: the signature over this exact issuedAt has verified.
+  const parsed = parseCheckoutLoginEmailToken(signature);
+  if (!parsed) return null;
   // Byte-identical to what the signature covers — see the padding guard above.
-  return stamped;
+  return { email: stamped, issuedAt: parsed.issuedAt };
 }
 
 function preferExistingCustomerOwner(
@@ -1117,26 +1134,46 @@ export async function handleSubscriptionActive(
   // at the login screen. The customers row above deliberately keeps the
   // checkout email — it mirrors Dodo's record for portal lookups.
   //
-  // #6335: prefer the login email the CHECKOUT stamped and signed. The users
-  // row (populated by users:ensureRecord) is only as fresh as the buyer's last
-  // page load for that userId, so a Clerk portal email change made in a
-  // long-lived tab leaves it pointing at the abandoned address. The stamped
-  // value is as fresh as the checkout itself. Fall through to the users row,
-  // then to the checkout email, when it is absent or unverifiable (pre-#6335
-  // sessions, phone-only signups, accounts predating the users table).
+  // #6335: two sources can hold the account's login email, and NEITHER is
+  // reliably the fresher one — so pick by which was last confirmed against
+  // Clerk rather than by a fixed precedence.
+  //
+  //   - The stamped value was the login email at `issuedAt` (checkout time).
+  //   - The `users` row's address was last refreshed at `lastSeenAt`:
+  //     `users:ensureRecord` rewrites `email` and stamps `lastSeenAt` in the
+  //     same patch (convex/users.ts), so that timestamp dates the address.
+  //
+  // The original bug is the row being stale: it is only rewritten once per page
+  // load per userId (`src/services/convex-client.ts` short-circuits on a
+  // module-level `lastEnsuredUserId`), so an email change made in a long-lived
+  // tab leaves it pointing at the abandoned address. But the inverse is just as
+  // real — change the email AFTER checking out, then load a page before the
+  // activation webhook arrives, and the STAMP is the stale one. Comparing the
+  // two clocks is correct in both directions; a fixed "stamp wins" rule is only
+  // correct in one.
+  //
+  // Falls through to the checkout email when neither source yields an address
+  // (pre-#6335 sessions, phone-only signups, accounts predating the users row).
   const signedLoginEmail = await resolveSignedCheckoutLoginEmail(
     userId,
     data.metadata,
     eventTimestamp,
     data.subscription_id,
   );
-  const userRow = signedLoginEmail
-    ? null
-    : await ctx.db
-        .query("users")
-        .withIndex("by_userId", (q) => q.eq("userId", userId))
-        .first();
-  const loginEmail = signedLoginEmail ?? (userRow?.email ?? "").trim();
+  const userRow = await ctx.db
+    .query("users")
+    .withIndex("by_userId", (q) => q.eq("userId", userId))
+    .first();
+  const userRowEmail = (userRow?.email ?? "").trim();
+  const userRowIsFresher =
+    userRow !== null &&
+    userRowEmail.length > 0 &&
+    signedLoginEmail !== null &&
+    userRow.lastSeenAt > signedLoginEmail.issuedAt;
+  const loginEmail =
+    signedLoginEmail !== null && !userRowIsFresher
+      ? signedLoginEmail.email
+      : userRowEmail;
   const recipientEmail = loginEmail.length > 0 ? loginEmail : email.trim();
   const checkoutEmailDiffers =
     loginEmail.length > 0 &&

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -15,7 +15,11 @@ import {
   LEGACY_PRODUCT_ALIASES,
   resolveProductToPlan,
 } from "../config/productCatalog";
-import { ANON_ID_V4_REGEX, verifyUserId } from "../lib/identitySigning";
+import {
+  ANON_ID_V4_REGEX,
+  verifyCheckoutLoginEmail,
+  verifyUserId,
+} from "../lib/identitySigning";
 import { DEV_USER_ID, isDev } from "../lib/auth";
 import { isChargedEventType, recordUnattributedEvent } from "./unattributedPayments";
 
@@ -809,6 +813,81 @@ function mergeDodoCustomerId(
   return existing.dodoCustomerId;
 }
 
+/**
+ * Returns the login email the checkout stamped into its metadata, or null when
+ * there is nothing trustworthy to use (#6335).
+ *
+ * Verified against the userId this handler ACTUALLY resolved — not the one in
+ * the metadata — so a signature minted for a different account (or replayed
+ * onto a subscription whose ownership `preferExistingCustomerOwner` reassigned)
+ * is rejected, and against the event's own clock, so a year-old checkout's
+ * metadata replayed by a `subscription.updated` cannot outrank the `users` row.
+ *
+ * Every rejection is a fallback, never a failure: the caller drops to
+ * `users.email` and then to the checkout email exactly as before.
+ */
+async function resolveSignedCheckoutLoginEmail(
+  userId: string,
+  metadata: Record<string, string> | undefined,
+  eventTimestamp: number,
+  subscriptionId: string,
+): Promise<string | null> {
+  const stamped = metadata?.wm_login_email;
+  const signature = metadata?.wm_login_email_sig;
+  const hasStamped = typeof stamped === "string" && stamped.length > 0;
+  const hasSignature = typeof signature === "string" && signature.length > 0;
+  // Neither field: an ordinary pre-#6335 checkout session. Silent by design —
+  // this is the majority shape until every in-flight session has turned over.
+  if (!hasStamped && !hasSignature) return null;
+  // Exactly one of the pair. Both halves are stamped together or not at all
+  // (checkout.ts), so a half-present pair is tampering or a stamping-side
+  // regression — warned in EITHER direction, and reporting only presence,
+  // matching the `describeUnresolvedIdentity` convention for Sentry-bound text.
+  if (!hasStamped || !hasSignature) {
+    console.warn(
+      `[subscriptionHelpers] Half-present wm_login_email pair in checkout metadata — ignoring ` +
+        `(email=${hasStamped ? "present" : "absent"}, signature=${hasSignature ? "present" : "absent"}, ` +
+        `subscriptionId=${subscriptionId})`,
+    );
+    return null;
+  }
+  // Fail closed on padding rather than normalizing it away afterwards. The
+  // signature covers the exact bytes INCLUDING surrounding whitespace, so
+  // trimming post-verification would mean the value we send is not the value we
+  // proved authentic. The stamping side always trims before signing
+  // (normalizeCheckoutLoginEmail), so no producible token is rejected here.
+  if (stamped !== stamped.trim()) return null;
+  // Verify the value EXACTLY as stamped; the signature covers those bytes.
+  const verdict = await verifyCheckoutLoginEmail(
+    userId,
+    stamped,
+    signature,
+    eventTimestamp,
+  );
+  if (verdict === "expired") {
+    // Routine, not anomalous. A `subscription.updated`→active re-delivers the
+    // original checkout's metadata for the whole life of the subscription, so
+    // every such event past the window lands here by design. Logged at
+    // console.log so it cannot dilute the tamper signal below.
+    console.log(
+      `[subscriptionHelpers] wm_login_email aged out of the checkout window — using the users row (subscriptionId=${subscriptionId})`,
+    );
+    return null;
+  }
+  if (verdict !== "valid") {
+    // Genuinely did not come from us for this (userId, email). The address
+    // itself is deliberately absent: this string reaches Sentry via Convex
+    // auto-Sentry, and a login email is exactly the PII the sibling identity
+    // diagnostics (describeUnresolvedIdentity) keep out of it.
+    console.warn(
+      `[subscriptionHelpers] wm_login_email failed signature verification — falling back to the users row (subscriptionId=${subscriptionId})`,
+    );
+    return null;
+  }
+  // Byte-identical to what the signature covers — see the padding guard above.
+  return stamped;
+}
+
 function preferExistingCustomerOwner(
   existingCustomerUserId: string | undefined,
   resolvedUserId: string,
@@ -1035,16 +1114,29 @@ export async function handleSubscriptionActive(
   // the address typed into Dodo checkout. The two can be different aliases of
   // the same person, and a "your subscription is active — sign in" email
   // addressed to the checkout alias steers the buyer into "account not known"
-  // at the login screen. The users row (populated by users:ensureRecord on
-  // every authenticated session) carries the Clerk login email; fall back to
-  // the checkout email when the row or its email is absent (accounts predating
-  // the users table, phone-only signups). The customers row above deliberately
-  // keeps the checkout email — it mirrors Dodo's record for portal lookups.
-  const userRow = await ctx.db
-    .query("users")
-    .withIndex("by_userId", (q) => q.eq("userId", userId))
-    .first();
-  const loginEmail = (userRow?.email ?? "").trim();
+  // at the login screen. The customers row above deliberately keeps the
+  // checkout email — it mirrors Dodo's record for portal lookups.
+  //
+  // #6335: prefer the login email the CHECKOUT stamped and signed. The users
+  // row (populated by users:ensureRecord) is only as fresh as the buyer's last
+  // page load for that userId, so a Clerk portal email change made in a
+  // long-lived tab leaves it pointing at the abandoned address. The stamped
+  // value is as fresh as the checkout itself. Fall through to the users row,
+  // then to the checkout email, when it is absent or unverifiable (pre-#6335
+  // sessions, phone-only signups, accounts predating the users table).
+  const signedLoginEmail = await resolveSignedCheckoutLoginEmail(
+    userId,
+    data.metadata,
+    eventTimestamp,
+    data.subscription_id,
+  );
+  const userRow = signedLoginEmail
+    ? null
+    : await ctx.db
+        .query("users")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .first();
+  const loginEmail = signedLoginEmail ?? (userRow?.email ?? "").trim();
   const recipientEmail = loginEmail.length > 0 ? loginEmail : email.trim();
   const checkoutEmailDiffers =
     loginEmail.length > 0 &&

--- a/docs/architecture/pro-monetization.md
+++ b/docs/architecture/pro-monetization.md
@@ -50,7 +50,7 @@ Two Convex actions at `convex/payments/checkout.ts`:
 Both share `_createCheckoutSession()` which:
 
 1. Validates `returnUrl` against an allow-listed set of worldmonitor.app origins.
-2. Builds metadata: `wm_user_id` (HMAC-signed via `convex/lib/identitySigning.ts`) + optional `affonso_referral`.
+2. Builds metadata: `wm_user_id` (HMAC-signed via `convex/lib/identitySigning.ts`), `wm_login_email` + `wm_login_email_sig` (the Clerk login email authenticated for this checkout, signed as a **separate** field so the `wm_user_id_sig` payload stays `userId` alone and pre-existing sessions keep verifying), + optional `affonso_referral`.
 3. Calls `checkout()` from `convex/lib/dodo.ts`.
 4. Returns `{ checkout_url }` for overlay open or full-page redirect.
 
@@ -66,6 +66,8 @@ Before creating a session, `getCheckoutBlockingSubscription` checks for active/o
 ### Webhook → subscription lifecycle
 
 `convex/payments/subscriptionHelpers.ts` handles Dodo webhook events (`subscription.active`, `subscription.renewed`, `subscription.updated`, `payment.succeeded`, refunds). On first `subscription.active`, writes `subscriptions` row, recomputes `entitlements`, and credits referral attribution if `metadata.affonso_referral` matches a `userReferralCodes` row.
+
+**Lifecycle-email recipient** (`subscription.active` only). Resolved in this order: the signed `wm_login_email` from checkout metadata, verified against the finally-resolved `userId` and aged against the event clock (`CHECKOUT_LOGIN_EMAIL_MAX_AGE_MS`, 7 days); then `users.email`; then the Dodo checkout email. The `users` row is only as fresh as the buyer's last page load for that userId, so a Clerk portal email change made in a long-lived tab leaves it stale — the stamped value is as fresh as the checkout itself. Every rejection at the first rung is a silent fall-through to the next, never a failure to send. The `customers` row keeps the checkout email regardless; it mirrors Dodo's record for portal lookups.
 
 ## Entitlements — Convex
 


### PR DESCRIPTION
## Summary

A customer who changed their primary email in the Clerk portal and then subscribed in the same long-lived browser tab received the "your subscription is active — sign in" email at the address they had just abandoned. Following it led to "account not known" at the login screen. That is the #6330 symptom reaching users again through a different cause, and it is the worst possible first post-purchase experience: the buyer has just been charged, and the product's own welcome mail walks them into a wall.

The recipient was read from the `users` row, which is only rewritten once per page load per userId (`src/services/convex-client.ts` short-circuits on a module-level `lastEnsuredUserId`). The checkout already authenticates a login email and was throwing it away. Now it stamps that value into the Dodo checkout metadata, HMAC-signed, and the activation webhook considers it alongside the `users` row.

Fixes #6335

## Choosing between two sources

Neither source is reliably the fresher one, so the handler no longer applies a fixed precedence — it compares timestamps and takes the later:

| Source | Dated by | Goes stale when |
| --- | --- | --- |
| Stamped checkout email | the token's `issuedAt` | the buyer changes their email *after* checking out |
| `users.email` | `lastSeenAt`, which `ensureRecord` stamps in the same patch that rewrites `email` | the buyer changes their email *before* checking out, in a long-lived tab |

The first commit preferred the stamp whenever it verified. Independent cross-model review (Codex) and the adversarial reviewer both caught that this is only correct in one direction: change your email *after* checkout, then load a page before the webhook lands, and the stamp is the stale one — reproducing the original bug with the two sources swapped. The second commit replaces the precedence rule with the comparison above.

## Design decisions a reviewer should weigh

**The email is a separate signed field, not part of `wm_user_id_sig`.** That signature's payload has to stay `userId` alone. Folding the email in would mean every checkout session created before this deploy stops verifying at the webhook, and its buyer becomes unattributable — a payment that lands with no owner.

**The signature is checked before the age window.** This costs one HMAC on tokens the window would reject anyway, and it is what makes the `expired` verdict trustworthy: it can only be returned for a token we genuinely signed, so a forged token cannot launder itself into the quiet bucket by carrying an old `issuedAt`.

**`expired` and `invalid` are logged at different volumes.** Dodo re-delivers the original checkout metadata on every later `subscription.updated`, so *every* mature subscription ages its token out. Logging that at the same volume as a forged signature would bury the real signal under ordinary traffic.

**Verification uses the finally-resolved `userId`, not the metadata's claim.** A token minted for an anonymous checkout cannot follow a subscription that `preferExistingCustomerOwner` reassigns to a real account.

Every rejection falls through to the existing ladder, so a bad token costs freshness, never delivery.

## Validation

`npm run test:convex` — 1338 passing. `typecheck`, `typecheck:api`, and the `convex/tsconfig.json` check CI runs are clean.

Because passing tests only prove the suite is green, each guard was also mutation-tested: 26 mutants across four rounds, every one killed. That included one mutant per guard in the verifier, one per direction of the freshness comparison, and one reinstating each fixed-precedence rule. The exercise earned its cost — it caught two assertions that were passing for the wrong reason (a field-boundary test whose inputs could not collide, and a parse guard shadowed by a later backstop) and one guard with no assertion at all.

One caveat on the test run: a perf-shape test in an unrelated file timed out during a full-suite run under a load average of 45 caused by a concurrent job. It passes in isolation and passes in the full suite with the timeout raised.

## Residual risk

Dodo does not document a per-object metadata size cap, and this adds two keys (~336 bytes). If such a cap exists and we are near it, checkout session creation would throw. I could not verify the limit offline.

Codex also flagged `isLapsedAt`'s `<` vs `<=` boundary at `convex/payments/subscriptionHelpers.ts:269` — plausible, but pre-existing code whose semantics reach across entitlements. It does not belong in a lifecycle-email fix and wants its own issue.

## New concepts

### Length-prefixed fields in a MAC payload

When you sign a concatenation of variable-length fields, the separator alone does not tell the verifier where one field ended and the next began. Two different field pairs can produce the same byte string, so one valid signature authenticates both — a canonicalization bug, not a crypto bug. Prefixing a field with its length makes the encoding unambiguous.

Every existing token in `convex/lib/identitySigning.ts` joins with a bare `:`, and that is safe because each field is constrained: `anonId` is a UUID, and `grantId` is explicitly rejected if it contains the delimiter. This token's last field is an **email**, which is unbounded and attacker-adjacent, so the same shape would not be safe:

```ts
// Unprefixed, these two pairs sign the SAME bytes — one signature, two meanings:
//   ("user:a", "b@x.com")  ->  checkout-email:v1:<t>:user:a:b@x.com
//   ("user",   "a:b@x.com")  ->  checkout-email:v1:<t>:user:a:b@x.com
return `checkout-email:${VERSION}:${issuedAt}:${userId.length}:${userId}:${email}`;
```

With the length prefix the verifier reads exactly `userId.length` units for the userId, so the remainder is unambiguously the email. Real Clerk ids contain no colon, so this is defense against a future id format rather than a live hole — but encoding unambiguously once is cheaper than auditing every id format forever.

Reach for it whenever a signed payload concatenates fields whose contents you do not fully control. Skip it when every field is fixed-width or provably delimiter-free, as the sibling tokens here already are.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
