### PR TITLE
fix: unblock checkout on the API host and revive two dead iOS filters

### DIFF
--- a/convex/payments/checkout.ts
+++ b/convex/payments/checkout.ts
@@ -19,6 +19,7 @@ import {
 import { requireUserId, resolveUserIdentity } from "../lib/auth";
 import { ANON_ID_V4_REGEX, signAnonClaimToken, signUserId } from "../lib/identitySigning";
 import { resolveProductToPlan } from "../config/productCatalog";
+import { isTrustedReturnUrlOrigin } from "./returnUrlOrigin";
 import {
   CHECKOUT_RATE_LIMITED,
   CHECKOUT_RATE_LIMIT_MAX_ATTEMPTS,
@@ -177,18 +178,7 @@ async function _createCheckoutSession(
       throw new ConvexError("Invalid returnUrl: must be a valid absolute URL");
     }
 
-    const allowedOrigins = new Set([
-      "https://worldmonitor.app",
-      "https://www.worldmonitor.app",
-      "https://app.worldmonitor.app",
-      "https://tech.worldmonitor.app",
-      "https://finance.worldmonitor.app",
-      "https://commodity.worldmonitor.app",
-      "https://happy.worldmonitor.app",
-      "https://energy.worldmonitor.app",
-      new URL(siteUrl).origin,
-    ]);
-    if (!allowedOrigins.has(parsedReturnUrl.origin)) {
+    if (!isTrustedReturnUrlOrigin(parsedReturnUrl.origin, new URL(siteUrl).origin)) {
       throw new ConvexError(
         "Invalid returnUrl: must use a trusted worldmonitor.app origin",
       );

--- a/convex/payments/returnUrlOrigin.ts
+++ b/convex/payments/returnUrlOrigin.ts
@@ -1,0 +1,43 @@
+/**
+ * Which origins may receive a post-payment `returnUrl` redirect.
+ *
+ * Vercel serves the deployment on EVERY attached domain, so any host pointed at the
+ * project renders the full app — `https://api.worldmonitor.app/dashboard` returns the
+ * real dashboard, not a 404. The allowlist therefore has to track "hosts that serve
+ * the app", and it silently drifted: `api.worldmonitor.app` was missing, so 12 distinct
+ * signed-in users who opened the dashboard on the API host got a 500 from
+ * /api/create-checkout instead of a checkout page (WORLDMONITOR-K7 / -Q4).
+ *
+ * Deliberately NOT a `*.worldmonitor.app` suffix match. The guard's job is blocking
+ * open redirects, and several worldmonitor.app subdomains are vendor-owned CNAMEs
+ * (`clerk.` → Clerk, `abacus.` → Umami). A suffix rule would quietly promote every
+ * current and future vendor subdomain to a valid post-payment redirect target, so the
+ * list stays enumerated and `tests/checkout-return-url-origin.test.mts` pins both
+ * directions.
+ */
+
+/** App-serving origins trusted as post-payment return targets. */
+export const TRUSTED_RETURN_URL_ORIGINS: readonly string[] = [
+  "https://worldmonitor.app",
+  "https://www.worldmonitor.app",
+  "https://app.worldmonitor.app",
+  "https://api.worldmonitor.app",
+  "https://tech.worldmonitor.app",
+  "https://finance.worldmonitor.app",
+  "https://commodity.worldmonitor.app",
+  "https://happy.worldmonitor.app",
+  "https://energy.worldmonitor.app",
+];
+
+/**
+ * True when `origin` is an exact-match trusted origin. `extraOrigin` carries the
+ * deployment's own `SITE_URL` origin so preview/self-hosted deploys keep working.
+ *
+ * Compares full origin strings (scheme + host + port), so `http://worldmonitor.app`,
+ * `https://worldmonitor.app:8443` and `https://worldmonitor.app.evil.com` all fail.
+ */
+export function isTrustedReturnUrlOrigin(origin: string, extraOrigin?: string): boolean {
+  if (!origin) return false;
+  if (TRUSTED_RETURN_URL_ORIGINS.includes(origin)) return true;
+  return Boolean(extraOrigin) && origin === extraOrigin;
+}

--- a/src/bootstrap/platform-ua.ts
+++ b/src/bootstrap/platform-ua.ts
@@ -1,0 +1,35 @@
+/**
+ * Client-side platform detection for `beforeSend` filters.
+ *
+ * `event.contexts.os` is NOT available inside `beforeSend`. @sentry/browser 10.x
+ * populates neither `contexts.os` nor `contexts.browser` — Sentry's ingest pipeline
+ * derives both from the User-Agent header AFTER the event leaves the browser. Two
+ * platform-gated filters read `event.contexts.os.name` anyway, so they compared
+ * `''` against `/^(iOS|iPadOS)$/` and could never fire: WORLDMONITOR-WK kept
+ * reporting across seven post-fix build SHAs (44 events, 100% iOS, all zero-frame
+ * RangeErrors that the gate was written to drop). Their unit tests passed only
+ * because the fixtures fabricated `contexts: { os: { name: 'iOS' } }` — a field
+ * production never supplies.
+ *
+ * Sniff the User-Agent directly instead: it is the same string Sentry's backend
+ * parses, and it is available synchronously in `beforeSend`.
+ */
+
+/**
+ * True for iOS/iPadOS. `ua` is `navigator.userAgent`; `maxTouchPoints` is
+ * `navigator.maxTouchPoints`.
+ *
+ * iPhone/iPad/iPod appear verbatim in every mobile-mode iOS UA, including in-app
+ * WebViews (Google app, Chrome iOS, Facebook). iPadOS 13+ in desktop mode reports a
+ * `Macintosh` UA instead, which is only separable from a real Mac by touch support —
+ * genuine macOS reports `maxTouchPoints === 0`.
+ *
+ * Kept deliberately narrow: these filters SUPPRESS events, so a false negative just
+ * lets an event through (safe) while a false positive would hide a real desktop
+ * regression.
+ */
+export function isIosLikeUserAgent(ua: string, maxTouchPoints = 0): boolean {
+  if (!ua) return false;
+  if (/(iPhone|iPad|iPod)/.test(ua)) return true;
+  return /Macintosh/.test(ua) && maxTouchPoints > 1;
+}

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -7,6 +7,7 @@
  */
 
 import { isDebugBearRumScriptFrame } from './debugbear-rum';
+import { isIosLikeUserAgent } from './platform-ua';
 import { getSentryBuildMetadata } from './sentry-build-metadata';
 
 type SentryNs = typeof import('@sentry/browser');
@@ -348,6 +349,14 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       const nonInfraFrames = frames.filter(f => f.filename && f.filename !== '<anonymous>' && f.filename !== '[native code]' && !/\/sentry-[A-Za-z0-9_-]+\.js/.test(f.filename));
       const hasFirstParty = nonInfraFrames.some(f => firstPartyFile(f.filename ?? ''));
       const hasAnyStack = nonInfraFrames.length > 0;
+      // Platform gate for the two iOS-scoped filters below. MUST come from the
+      // User-Agent, not `event.contexts.os` — the browser SDK never populates that
+      // context; Sentry derives it at ingest, long after beforeSend runs. Reading it
+      // here always yielded '' and left both filters unreachable (see platform-ua.ts).
+      const isIosLike = isIosLikeUserAgent(
+        typeof navigator === 'undefined' ? '' : navigator.userAgent ?? '',
+        typeof navigator === 'undefined' ? 0 : navigator.maxTouchPoints ?? 0,
+      );
       // Suppress maplibre internal null-access crashes (light, placement) only when stack is in map chunk
       if (/this\.style\._layers|reading '_layers'|this\.(light|sky) is null|can't access property "(id|type|setFilter|bind)"[,] ?[\w.]+ is (null|undefined)|can't access property "(id|type)" of null|Cannot read properties of null \(reading '(id|type|setFilter|_layers)'\)|null is not an object \(evaluating '\w{1,3}\.(id|style)|^\w{1,2} is null$/.test(msg)) {
         if (frames.some(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
@@ -426,8 +435,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // so a real `t.x` regression elsewhere on desktop still surfaces.
       if (/undefined is not an object \(evaluating 't\.x'\)|Cannot read properties of undefined \(reading 'x'\)/.test(msg)) {
         if (!hasFirstParty || frames.some(f => /\b_handleTouch\w*Dolly|OrbitControls/.test(f.function ?? ''))) return null;
-        const osName = ((event.contexts as any)?.os?.name as string) ?? '';
-        const isTouchOs = /^(iOS|iPadOS)$/.test(osName);
+        const isTouchOs = isIosLike;
         const mainBundleFrames = nonInfraFrames.filter(f => /\/(main|index)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''));
         if (isTouchOs && mainBundleFrames.length === 1 && nonInfraFrames.length === mainBundleFrames.length) return null;
       }
@@ -637,9 +645,12 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // `Maximum call stack size exceeded` with a COMPLETELY empty stack, only on
       // iOS. A blown stack is exactly the case where the SDK cannot collect
       // frames, so zero frames alone proves nothing — the platform census is what
-      // does. WORLDMONITOR-WK is 23 events across 20 users and 100% iOS, 21 of
-      // them inside the Google app's in-app WebView (the rest Chrome iOS); zero
-      // desktop, zero Android, one release. Our own bundle is the same code on
+      // does. WORLDMONITOR-WK re-censused 2026-08-09 at 44 events / 37 users: 100%
+      // iOS, 100% zero-frame RangeError, overwhelmingly the Google app's in-app
+      // WebView; zero desktop, zero Android. (It reached 44 because this gate read
+      // the ingest-only `contexts.os` and could never fire — see platform-ua.ts. The
+      // census below is why the platform half is load-bearing, not why it was dead.)
+      // Our own bundle is the same code on
       // every platform, so a genuine first-party recursion cannot be confined to
       // one iOS WebView family — these are the host app's injected scripts
       // recursing (the Fireglass gate above is the same class, caught by name).
@@ -649,7 +660,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
           && frames.length === 0
           && !hasFirstParty
           && /^Maximum call stack size exceeded\.?$/.test(msg)
-          && /^(iOS|iPadOS)$/.test(((event.contexts as any)?.os?.name as string) ?? '')) return null;
+          && isIosLike) return null;
       // Suppress Chrome Mobile WebView 105+ Request constructor quirk ONLY when
       // the Dodo checkout lazy chunk is in the stack (WORLDMONITOR-MH). The
       // exact message is unique to the Fetch § Request() duplex requirement, but

--- a/tests/checkout-return-url-origin.test.mts
+++ b/tests/checkout-return-url-origin.test.mts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { isTrustedReturnUrlOrigin } from '../convex/payments/returnUrlOrigin.ts';
+
+/**
+ * WORLDMONITOR-K7 / -Q4: `_createCheckoutSession()` enumerated the origins allowed
+ * as a post-payment `returnUrl`, but the list drifted from the set of hosts that
+ * actually serve the app. Vercel serves the deployment on EVERY attached domain, so
+ * `https://api.worldmonitor.app/dashboard` returns the real dashboard (verified HTTP
+ * 200, `<title>World Monitor - Real-Time Global Intelligence Dashboard</title>`)
+ * while `api.worldmonitor.app` was absent from the allowlist. 12 distinct signed-in
+ * users were handed a 500 from /api/create-checkout instead of a Dodo checkout page.
+ *
+ * The guard exists to stop open redirects, so widening it to a blanket
+ * `*.worldmonitor.app` suffix match is NOT safe: several subdomains are vendor-owned
+ * CNAMEs (clerk., abacus.) and must never be post-payment redirect targets. The list
+ * stays enumerated; these tests pin both directions.
+ */
+
+describe('checkout returnUrl origin allowlist', () => {
+  it('accepts the API host, which serves the app on every Vercel-attached domain', () => {
+    // Red before the fix: api.worldmonitor.app was missing from allowedOrigins.
+    assert.equal(isTrustedReturnUrlOrigin('https://api.worldmonitor.app'), true);
+  });
+
+  it('accepts the apex, www, app and every variant host', () => {
+    for (const origin of [
+      'https://worldmonitor.app',
+      'https://www.worldmonitor.app',
+      'https://app.worldmonitor.app',
+      'https://tech.worldmonitor.app',
+      'https://finance.worldmonitor.app',
+      'https://commodity.worldmonitor.app',
+      'https://happy.worldmonitor.app',
+      'https://energy.worldmonitor.app',
+    ]) {
+      assert.equal(isTrustedReturnUrlOrigin(origin), true, `expected trusted: ${origin}`);
+    }
+  });
+
+  it('rejects vendor-owned worldmonitor.app subdomains', () => {
+    // These resolve to third-party infrastructure (Clerk, Umami). A suffix-based
+    // widening would silently make them valid redirect targets.
+    for (const origin of [
+      'https://clerk.worldmonitor.app',
+      'https://abacus.worldmonitor.app',
+    ]) {
+      assert.equal(isTrustedReturnUrlOrigin(origin), false, `expected rejected: ${origin}`);
+    }
+  });
+
+  it('rejects look-alike and hostile origins', () => {
+    for (const origin of [
+      'https://evilworldmonitor.app',
+      'https://worldmonitor.app.evil.com',
+      'https://www.worldmonitor.app.evil.com',
+      'http://worldmonitor.app',
+      'https://attacker.example.com',
+      'https://worldmonitor.app:8443',
+      '',
+    ]) {
+      assert.equal(isTrustedReturnUrlOrigin(origin), false, `expected rejected: ${origin}`);
+    }
+  });
+});

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isDebugBearRumScriptFrame } from '../src/bootstrap/debugbear-rum.ts';
+import { isIosLikeUserAgent } from '../src/bootstrap/platform-ua.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -40,9 +41,24 @@ assert.ok(tpMatch, 'THIRD_PARTY_FETCH_HOST_ALLOWLIST must be defined in src/boot
 
 // Build a callable version. Input: a Sentry-shaped event object. Returns event or null.
 // eslint-disable-next-line no-new-func
-const rawBeforeSend = new Function('event', 'isDebugBearRumScriptFrame', `${tpMatch[0]}\n${fnBody}`);
-function beforeSend(event) {
-  return rawBeforeSend(event, isDebugBearRumScriptFrame);
+const rawBeforeSend = new Function(
+  'event', 'isDebugBearRumScriptFrame', 'isIosLikeUserAgent', 'navigator',
+  `${tpMatch[0]}\n${fnBody}`,
+);
+
+// User-Agent strings, because beforeSend's platform gates read `navigator.userAgent`
+// — NOT `event.contexts.os`, which the browser SDK never populates (see
+// src/bootstrap/platform-ua.ts). `navigator` is passed as a Function parameter so it
+// shadows Node's global and each test can state the platform explicitly.
+const MAC_DESKTOP_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36';
+const IOS_GOOGLE_APP_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/432.9.954074404 Mobile/15E148 Safari/604.1';
+const DESKTOP_NAVIGATOR = { userAgent: MAC_DESKTOP_UA, maxTouchPoints: 0 };
+const IOS_NAVIGATOR = { userAgent: IOS_GOOGLE_APP_UA, maxTouchPoints: 5 };
+/** iPadOS 13+ desktop mode: Macintosh UA, but touch-capable. */
+const IPADOS_NAVIGATOR = { userAgent: MAC_DESKTOP_UA, maxTouchPoints: 5 };
+
+function beforeSend(event, navigatorStub = DESKTOP_NAVIGATOR) {
+  return rawBeforeSend(event, isDebugBearRumScriptFrame, isIosLikeUserAgent, navigatorStub);
 }
 
 // Extract the `ignoreErrors` array literal so tests can assert which messages
@@ -1457,28 +1473,49 @@ describe('sentry beforeSend — Y4 bare minified trampoline hop', () => {
 // A blown stack is exactly when the SDK cannot collect frames, so zero frames
 // alone proves nothing — the OS gate is the load-bearing half.
 describe('sentry beforeSend — WK iOS zero-frame call-stack overflow', () => {
-  const withOs = (event, name) => ({ ...event, contexts: { os: { name } } });
-
   it('suppresses the exact WK shape on iOS', () => {
-    const event = withOs(makeEvent('Maximum call stack size exceeded.', 'RangeError', []), 'iOS');
-    assert.equal(beforeSend(event), null, 'iOS in-app WebView recursion is not our bundle');
+    const event = makeEvent('Maximum call stack size exceeded.', 'RangeError', []);
+    assert.equal(beforeSend(event, IOS_NAVIGATOR), null, 'iOS in-app WebView recursion is not our bundle');
+  });
+
+  it('suppresses the WK shape on iPadOS desktop-mode (Macintosh UA + touch)', () => {
+    const event = makeEvent('Maximum call stack size exceeded.', 'RangeError', []);
+    assert.equal(beforeSend(event, IPADOS_NAVIGATOR), null, 'iPadOS is the same WebView family');
   });
 
   it('does NOT suppress the same message on a desktop OS', () => {
-    const event = withOs(makeEvent('Maximum call stack size exceeded.', 'RangeError', []), 'Mac OS X');
-    assert.ok(beforeSend(event) !== null, 'a real recursion regression must still reach Sentry');
+    const event = makeEvent('Maximum call stack size exceeded.', 'RangeError', []);
+    assert.ok(beforeSend(event, DESKTOP_NAVIGATOR) !== null, 'a real recursion regression must still reach Sentry');
   });
 
   it('does NOT suppress an iOS call-stack overflow that carries a first-party frame', () => {
-    const event = withOs(
-      makeEvent('Maximum call stack size exceeded.', 'RangeError', [firstPartyFrame()]),
-      'iOS',
-    );
-    assert.ok(beforeSend(event) !== null, 'an attributable recursion is signal, not noise');
+    const event = makeEvent('Maximum call stack size exceeded.', 'RangeError', [firstPartyFrame()]);
+    assert.ok(beforeSend(event, IOS_NAVIGATOR) !== null, 'an attributable recursion is signal, not noise');
   });
 
   it('does NOT suppress an unrelated zero-frame iOS RangeError', () => {
-    const event = withOs(makeEvent('Invalid array length', 'RangeError', []), 'iOS');
-    assert.ok(beforeSend(event) !== null, 'the gate is scoped to the call-stack message');
+    const event = makeEvent('Invalid array length', 'RangeError', []);
+    assert.ok(beforeSend(event, IOS_NAVIGATOR) !== null, 'the gate is scoped to the call-stack message');
+  });
+
+  // The regression that let WORLDMONITOR-WK run for 44 events across seven builds:
+  // the gate read `event.contexts.os.name`, which the browser SDK never sets, and the
+  // old fixtures fabricated it. Pin BOTH directions so no future gate can pass a test
+  // via a field production does not supply.
+  it('ignores event.contexts.os entirely — a fabricated iOS context cannot suppress', () => {
+    const event = {
+      ...makeEvent('Maximum call stack size exceeded.', 'RangeError', []),
+      contexts: { os: { name: 'iOS', version: '18.0.0' } },
+    };
+    assert.ok(
+      beforeSend(event, DESKTOP_NAVIGATOR) !== null,
+      'contexts.os is ingest-derived and absent in beforeSend; it must not drive the gate',
+    );
+  });
+
+  it('suppresses on an iOS UA even with no contexts at all (the real production shape)', () => {
+    const event = makeEvent('Maximum call stack size exceeded.', 'RangeError', []);
+    assert.equal(event.contexts, undefined, 'production events reach beforeSend without an os context');
+    assert.equal(beforeSend(event, IOS_NAVIGATOR), null, 'the UA is the only platform signal available');
   });
 });


### PR DESCRIPTION
## Summary

Two production bugs surfaced by a Sentry triage sweep, each fixed together with the test that would have caught it.

**Checkout returned a 500 instead of a payment page.** A signed-in user who opened the dashboard on `api.worldmonitor.app` and clicked upgrade got a generic checkout failure — 12 distinct users over three weeks (Sentry `WORLDMONITOR-K7`, 142 events; `WORLDMONITOR-Q4` carries the client-side view of the same throw). Vercel serves the deployment on *every* attached domain, so that host renders the real app — verified HTTP 200 with the production `<title>` — but it was absent from checkout's `returnUrl` origin allowlist. Those users can now pay.

**Two iOS crash filters had never once fired.** `WORLDMONITOR-WK` kept paging at error level across seven build SHAs deployed *after* the filter written to drop it shipped in #6129 — 44 events, 37 users, 100% iOS, 100% zero-frame `RangeError`, every one satisfying the filter's other four conditions. The fifth condition required `event.contexts.os.name` to match `/^(iOS|iPadOS)$/`, and that field does not exist where the filter runs. The same trap silently killed the unsymbolicated OrbitControls `t.x` arm (`WORLDMONITOR-P7`).

## Why the allowlist stayed enumerated

The obvious fix — accept any `*.worldmonitor.app` — would be wrong in two directions, so the list stays exact-match and is now pinned by tests:

| Origin | Suffix match | Correct |
|---|---|---|
| `https://worldmonitor.app` (apex) | rejected — no leading dot | accepted |
| `https://clerk.worldmonitor.app` (Clerk CNAME) | accepted | rejected |
| `https://abacus.worldmonitor.app` (Umami CNAME) | accepted | rejected |

The guard exists to stop open redirects; a suffix rule would promote every current and future vendor-owned subdomain to a valid post-payment redirect target.

## New concepts

**Ingest-derived event fields are invisible to client-side filters.**

A telemetry SDK sends a thin event; the vendor's ingest pipeline *enriches* it afterwards — parsing the User-Agent into `contexts.os` and `contexts.browser`, resolving IP to geo, symbolicating stacks. Everything you read in the dashboard looks like one object, so it is natural to assume a client-side hook sees that same object. It does not: `beforeSend` runs strictly before the event leaves the browser.

| Field | Present in `beforeSend` | Present in the dashboard |
|---|---|---|
| `exception.values[].value`, `stacktrace.frames` | yes | yes |
| `tags` / `contexts` you set yourself | yes | yes |
| `contexts.os`, `contexts.browser` | **no** | yes (ingest-derived) |
| `user.geo`, symbolicated frames | no | yes |

Why it bit here instead of throwing: the read was optional-chained to a default, so the filter degraded to a silent always-false rather than an error.

```js
// Dead: contexts.os is ingest-derived, so this is always /iOS/.test('') === false
&& /^(iOS|iPadOS)$/.test(event.contexts?.os?.name ?? '')

// Live: the UA is the same string the backend parses, and it is available now
&& isIosLikeUserAgent(navigator.userAgent, navigator.maxTouchPoints)
```

The generalization: a predicate must be gated on data available at the point it is evaluated, and a `?? ''` fallback on an absent field turns a filter into a no-op instead of a crash. The boundary — anything the SDK or your own code sets before send *is* readable in `beforeSend`, and this caution does not apply to those fields.

Verified against the installed SDK rather than assumed: `@sentry/browser` 10.46.0 contains zero occurrences of `contexts.os`.

## How a passing test hid a dead filter

The existing unit test for `WORLDMONITOR-WK` passed the entire time, because its fixture built the event with `contexts: { os: { name: 'iOS' } }` — a field production never supplies. The fixture, not the code, was satisfying the condition.

The harness now drives `navigator` instead, and two regression tests pin both directions: a fabricated iOS context must **not** suppress, and an iOS UA with no `contexts` at all — the real production shape — must.

## Validation

- `tests/checkout-return-url-origin.test.mts` (new, 4 tests) went red first with `ERR_MODULE_NOT_FOUND`, then green.
- Mutation-tested both fixes, reverting by file copy. Dropping the `api.` origin kills exactly one test; swapping exact-match for suffix-match kills the vendor-subdomain *and* apex tests; restoring the old `contexts.os` read turns 4 tests red — so the old production code fails the new suite.
- 257 tests pass across the two changed test files; 234 checkout tests and 260 Sentry-layer tests pass. `tsc --noEmit`, `typecheck:api` (incl. the Convex string-call audit), and biome are clean.
- `https://api.worldmonitor.app/dashboard` probed directly: HTTP 200, production `<title>` — this is what makes the missing origin a bug rather than a hardened rejection.

Not verified, and deliberately called out: no real Dodo checkout was completed from `api.worldmonitor.app` (that needs a live payment session), and the `WORLDMONITOR-WK` suppression can only be confirmed after deploy by watching that issue's event volume go flat. Both Sentry issues are intentionally left unresolved until then.

Related: #6129 (where the iOS filter shipped dead).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
