### PR TITLE
fix(sentry): filter the CSP injectors behind TR/J0 and clear 76 unreopenable release pins (#6367)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -228,6 +228,13 @@ function shouldSuppressCspViolation(
       // match like the vendor rules above so lookalikes still surface
       // (WORLDMONITOR-HT long tail — 5.8k events / 1.2k users since March).
       if (frameHost === 'h5player.anzz.site') return true;
+      // `div.show` — an origin-only frame (no path) that appears nowhere in our
+      // source, repeated across many users over months. The injector is not
+      // identified, but it does not need to be: our frame-src is an explicit
+      // allowlist of every host we embed, so a host we never reference can only
+      // have been framed into the page from outside. Exact host, so the
+      // rotating merchant-domain tail below stays surfaced (WORLDMONITOR-HT).
+      if (frameHost === 'div.show') return true;
     } catch { /* scheme-only values fall through */ }
   }
   // Browser extensions or injected scripts. `ms-browser-extension://` is Edge's
@@ -249,12 +256,18 @@ function shouldSuppressCspViolation(
   if (/gstatic\.com\/_\/translate/.test(blockedURI) || /facebook\.net/.test(blockedURI)) return true;
   // Google Fonts font files from stale or injected stylesheets. The dashboard now
   // self-hosts its own fonts and the deploy/config tests keep Google Fonts out of
-  // dashboard CSP/source surfaces; if a user's browser still tries
-  // fonts.gstatic.com/s/*.woff2, the strict font-src block is expected noise.
+  // dashboard CSP/source surfaces; if a user's browser still tries a
+  // fonts.gstatic.com/s/* font file, the strict font-src block is expected noise.
   if (directive === 'font-src') {
+    // An @font-face `src:` list names the same face in several formats, and the
+    // browser reports a CSP block for each one it tries. Every host rule below
+    // therefore matches the whole fallback chain — pinning one extension leaks
+    // the rest, which is how a Doubao `.otf` and a gstatic `.ttf` kept firing
+    // after their rules shipped (WORLDMONITOR-TR round 3).
+    const fontFile = /\.(?:woff2?|ttf|otf)$/;
     try {
       const url = new URL(blockedURI);
-      if (url.protocol === 'https:' && url.hostname === 'fonts.gstatic.com' && /^\/s\/.+\.woff2$/.test(url.pathname)) return true;
+      if (url.protocol === 'https:' && url.hostname === 'fonts.gstatic.com' && /^\/s\/.+/.test(url.pathname) && fontFile.test(url.pathname)) return true;
       // Perplexity's Comet browser / extension injects its own UI webfont
       // (frontend-cdn.perplexity.ai/_agi_assets/fonts/*.woff2) into every page.
       // We never load it; the block is the overlay's font failing regardless of
@@ -268,7 +281,24 @@ function shouldSuppressCspViolation(
       // appear. We never load it; exact host + font-file path like the rules
       // above, NOT a blanket third-party suppression (WORLDMONITOR-TR round 2:
       // 310k events / 308 users in 11 days).
-      if (url.protocol === 'https:' && url.hostname === 'lf-flow-web-cdn.doubao.com' && /\.(?:woff2?|ttf)$/.test(url.pathname)) return true;
+      if (url.protocol === 'https:' && url.hostname === 'lf-flow-web-cdn.doubao.com' && fontFile.test(url.pathname)) return true;
+      // Migaku language-learning browser extension injects a subsetted Chiron
+      // Hei HK webfont as many numbered chunks (fonts/chiron-hei-hk-webfont-*/
+      // cw_N.woff2, kx_N.woff2) into every page. 38 distinct URLs in a 14-day
+      // sample and 69% of this issue's current volume — the single largest
+      // contributor. We never load it; exact host + font-file path like the
+      // rules above, so any other migaku path still surfaces.
+      if (url.protocol === 'https:' && url.hostname === 'migaku-public-data.migaku.com' && fontFile.test(url.pathname)) return true;
+      // Alibaba iconfont.cn project CDN (at.alicdn.com/t/c/font_<id>.<ext>).
+      // One injected icon font requested in all three formats. `alicdn.com` is
+      // a general Alibaba CDN, so this is pinned to the exact `at.` host and a
+      // font-file path — other alicdn hosts and non-font assets still surface.
+      if (url.protocol === 'https:' && url.hostname === 'at.alicdn.com' && fontFile.test(url.pathname)) return true;
+      // slant.co overlay webfont (Plus Jakarta Display, 3 weights x 2 formats)
+      // served from the injecting extension's own origin. Our font-src is
+      // `'self' data:` — we ship no cross-origin webfonts at all, so a block
+      // here can never be a first-party regression.
+      if (url.protocol === 'https:' && url.hostname === 'www.slant.co' && fontFile.test(url.pathname)) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube live stream manifests.
@@ -300,6 +330,20 @@ function shouldSuppressCspViolation(
       // (www.6ppn.com/ext/assets/style.<hash>.css — the /ext/ path is the
       // extension's own asset root). Exact host + .css path (WORLDMONITOR-J0).
       if (url.protocol === 'https:' && url.hostname === 'www.6ppn.com' && /\.css$/.test(url.pathname)) return true;
+      // FontAwesome public CDN. The injected sheet is v4.7.0 — a 2016 release
+      // this app never shipped — and our style-src is `'self' 'unsafe-inline'`
+      // with no cross-origin host at all, so any use.fontawesome.com stylesheet
+      // is third-party by construction (WORLDMONITOR-J0 round 3: 80% of the
+      // issue's current volume). Exact host + .css path; their JS bundle under
+      // script-src still surfaces.
+      if (url.protocol === 'https:' && url.hostname === 'use.fontawesome.com' && /\.css$/.test(url.pathname)) return true;
+      // Adobe Typekit / Adobe Fonts kit CSS, from both hosts it serves:
+      // `use.typekit.net/<kit>.css` and the `p.typekit.net/p.css?...` tracking
+      // sheet. We self-host every font and reference no kit id, so these are
+      // injected by a theme extension or the user's own stylesheet manager.
+      if (url.protocol === 'https:'
+          && (url.hostname === 'use.typekit.net' || url.hostname === 'p.typekit.net')
+          && /\.css$/.test(url.pathname)) return true;
     } catch { /* unparseable values fall through */ }
     // Extension bug: a literal unsubstituted `[email]` template placeholder as
     // the stylesheet URL. Not a parseable host; can never be first-party.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -221,8 +221,13 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(suppress('enforce', 'font-src', 'https://fonts.gstatic.com/s/mulish/v18/1Ptvg83HX_SGhgqk2wotcqA.woff2?display=swap', '', false));
     });
 
-    it('does NOT suppress non-woff2 Google Fonts paths with woff2 query values', () => {
-      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.gstatic.com/s/mulish/v18/font.woff?kit=abc.woff2', '', false));
+    it('does NOT let a font extension in the QUERY STRING trigger the Google Fonts rule', () => {
+      // The rule anchors on `url.pathname`, which excludes the query, so a
+      // font-looking query value cannot satisfy it. The fixture uses a non-font
+      // pathname because the rule now covers the whole woff2/woff/ttf/otf
+      // fallback chain (WORLDMONITOR-TR round 3) — a `.woff` PATH is suppressed
+      // on purpose now, so it can no longer carry this assertion.
+      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.gstatic.com/s/mulish/v18/font.css?kit=abc.woff2', '', false));
     });
 
     it('does NOT suppress arbitrary third-party font-src hosts', () => {
@@ -250,6 +255,56 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     it('does NOT suppress a doubao.com lookalike host or non-font path', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://lf-flow-web-cdn.doubao.com.evil.com/x.woff2', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'https://lf-flow-web-cdn.doubao.com/obj/flow-doubao/app.js', '', false));
+    });
+
+    it('suppresses the Doubao .otf fallback the woff2/woff/ttf rule missed (WORLDMONITOR-TR round 3)', () => {
+      // The observed escape: an .otf face is part of the same @font-face
+      // fallback chain, so restricting the rule to woff2?/ttf leaked it.
+      assert.ok(suppress('enforce', 'font-src', 'https://lf-flow-web-cdn.doubao.com/obj/flow-doubao/flow-ext-doubao/cdn-media-assets/Montserrat-SemiBold.c57269b8.otf', '', false));
+    });
+
+    it('suppresses Google Fonts faces in every format, not just woff2 (WORLDMONITOR-TR round 3)', () => {
+      // Observed escape: fonts.gstatic.com/s/poppins/v24/*.ttf. Legacy browsers
+      // and stale injected stylesheets request ttf/woff from the same /s/ path.
+      assert.ok(suppress('enforce', 'font-src', 'https://fonts.gstatic.com/s/poppins/v24/pxiEyp8kv8JHgFVrJJfedw.ttf', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://fonts.gstatic.com/s/mulish/v18/1Ptvg83HX_SGhgqk2wotcqA.woff', '', false));
+    });
+
+    it('suppresses Migaku language-extension webfont injection (WORLDMONITOR-TR round 3)', () => {
+      // Migaku injects a subsetted Chiron Hei HK webfont as many numbered
+      // chunks; 38 distinct URLs in a 14-day sample, 69% of the issue's volume.
+      assert.ok(suppress('enforce', 'font-src', 'https://migaku-public-data.migaku.com/fonts/chiron-hei-hk-webfont-2.6.7/cw_0.woff2', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://migaku-public-data.migaku.com/fonts/chiron-hei-hk-webfont-2.6.7/kx_12.woff2', '', false));
+    });
+
+    it('does NOT suppress a migaku.com lookalike host or non-font path', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://migaku-public-data.migaku.com.evil.com/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://migaku-public-data.migaku.com/fonts/app.js', '', false));
+    });
+
+    it('suppresses Alibaba iconfont CDN injection (WORLDMONITOR-TR round 3)', () => {
+      // at.alicdn.com/t/c/font_* is iconfont.cn's project CDN. One icon font
+      // requested in all three formats by an injected @font-face chain.
+      assert.ok(suppress('enforce', 'font-src', 'https://at.alicdn.com/t/c/font_1011144_jmo4009ffif.woff?t=1719821135173', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://at.alicdn.com/t/c/font_1011144_jmo4009ffif.woff2?t=1719821135173', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://at.alicdn.com/t/c/font_1011144_jmo4009ffif.ttf?t=1719821135173', '', false));
+    });
+
+    it('does NOT suppress an alicdn lookalike host or non-font path', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://at.alicdn.com.evil.com/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://at.alicdn.com/t/c/loader.js', '', false));
+    });
+
+    it('suppresses slant.co overlay webfont injection (WORLDMONITOR-TR round 3)', () => {
+      // Plus Jakarta Display in 3 weights x 2 formats, served from the
+      // injecting extension's own origin. We ship no cross-origin webfonts.
+      assert.ok(suppress('enforce', 'font-src', 'https://www.slant.co/fonts/plus-jakarta/Display-Bold.woff2', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://www.slant.co/fonts/plus-jakarta/Display-Regular.woff', '', false));
+    });
+
+    it('does NOT suppress a slant.co lookalike host or non-font path', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://www.slant.co.evil.com/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://www.slant.co/fonts/loader.js', '', false));
     });
 
     it('does NOT suppress Google Fonts under unrelated directives', () => {
@@ -312,6 +367,29 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
 
     it('suppresses literal [email] placeholder stylesheet URL from a broken extension template', () => {
       assert.ok(suppress('enforce', 'style-src-elem', 'https://[email]', '', false));
+    });
+
+    it('suppresses FontAwesome CDN stylesheet injection (WORLDMONITOR-J0 round 3)', () => {
+      // FontAwesome 4.7.0 (a 2016 release we never shipped) loaded from the
+      // public CDN — 80% of the issue's current volume.
+      assert.ok(suppress('enforce', 'style-src-elem', 'https://use.fontawesome.com/releases/v4.7.0/css/font-awesome-css.min.css', '', false));
+    });
+
+    it('does NOT suppress a fontawesome lookalike host or non-css path', () => {
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://use.fontawesome.com.evil.com/releases/v4.7.0/css/x.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://use.fontawesome.com/releases/v4.7.0/js/all.js', '', false));
+    });
+
+    it('suppresses Adobe Typekit stylesheet injection (WORLDMONITOR-J0 round 3)', () => {
+      // Typekit kit css from both of its hosts; we self-host every font and
+      // reference no Adobe Fonts kit.
+      assert.ok(suppress('enforce', 'style-src-elem', 'https://use.typekit.net/izn6gyh.css', '', false));
+      assert.ok(suppress('enforce', 'style-src-elem', 'https://p.typekit.net/p.css?s=1&k=izn6gyh&ht=tk&f=16927.17005.17006&a=5344842&app=typekit&e=css', '', false));
+    });
+
+    it('does NOT suppress a typekit lookalike host or non-css path', () => {
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://use.typekit.net.evil.com/izn6gyh.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://use.typekit.net/kit.js', '', false));
     });
 
     it('does NOT suppress arbitrary third-party style-src hosts', () => {
@@ -412,10 +490,18 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(suppress('enforce', 'frame-src', 'https://h5player.anzz.site', '', false, FIRST_PARTY_CONVEX));
     });
 
+    it('suppresses frame-src for the div.show injected frame (WORLDMONITOR-HT)', () => {
+      // Origin-only frame to a host that appears nowhere in our source, seen
+      // repeatedly across many users — the stable head of HT, unlike its
+      // rotating merchant-domain tail below.
+      assert.ok(suppress('enforce', 'frame-src', 'https://div.show', '', false, FIRST_PARTY_CONVEX));
+    });
+
     it('does NOT suppress frame-src for lookalike filter-vendor hosts', () => {
       assert.ok(!suppress('enforce', 'frame-src', 'https://netstar-inc.com.evil.com', '', false, FIRST_PARTY_CONVEX));
       assert.ok(!suppress('enforce', 'frame-src', 'https://clients6.google.com.evil.com', '', false, FIRST_PARTY_CONVEX));
       assert.ok(!suppress('enforce', 'frame-src', 'https://h5player.anzz.site.evil.com', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(!suppress('enforce', 'frame-src', 'https://div.show.evil.com', '', false, FIRST_PARTY_CONVEX));
     });
 
     it('does NOT suppress frame-src for arbitrary third-party hosts (rotating extension long tail stays surfaced)', () => {


### PR DESCRIPTION
Closes #6367.

Two halves: a code change (this diff) and a Sentry state repair (already applied, described below).

## The measurement that drove the code

The three CSP issues #6367 names were pinned shut by an `inNextRelease` resolve, so nobody had re-read what they actually contain. Measured over an explicit 14-day window:

| Issue | Composition now |
|---|---|
| **TR** | migaku 69%, at.alicdn.com 15%, www.slant.co 12%, doubao 3%, gstatic 1% |
| **J0** | use.fontawesome.com 80%, typekit 17%, other 2% |
| **HT** | no dominant host — Google account hosts 24%, div.show 9%, long rotating tail |

The issue's headline host for TR (`at.alicdn.com`) is **not** the dominant one; Migaku is, by 4.6x.

A methodology note worth keeping: `GET /issues/{id}/events/` does **not** honour a recent window. For an issue last seen Aug 7 it returned a Jul 5-20 slice, which made already-filtered hosts look like they were still escaping. Anything of the form "what is still firing?" has to go through `/organizations/{org}/events/` with `statsPeriod`.

## Code change

New host-pinned rules in `shouldSuppressCspViolation`:

- `font-src` — `migaku-public-data.migaku.com`, `at.alicdn.com`, `www.slant.co`
- `style-src*` — `use.fontawesome.com`, `use.typekit.net`, `p.typekit.net`
- `frame-src` — `div.show`

All exact-host + asset-path, so lookalike registrable domains and HT's rotating merchant tail still surface. Our CSP makes the safety argument easy: `font-src 'self' data:` and `style-src 'self' 'unsafe-inline'` name no cross-origin host at all, and `frame-src` is an explicit allowlist — so a block on any of these can never be a first-party regression.

**Two gaps closed in existing rules**, both found by reading real escapes rather than by inspection: a Doubao `.otf` and a gstatic `.ttf` were still firing because those rules pinned a subset of the `@font-face` fallback chain. Font rules now share one `woff2/woff/ttf/otf` matcher.

**One existing test changed contract.** It asserted a gstatic `.woff` *path* is not suppressed — which is exactly the narrowness being fixed. Its real guard (a font extension in the **query string** must not trigger the rule) is preserved with a non-font pathname fixture.

## Sentry state repair (applied, not in this diff)

#6367 counted 21 pinned issues. The true number was **76** — the earlier count came from an unpaginated sweep capped at one page of 100. All 76 are now un-pinned and verified.

The mechanism matters for anyone repeating this: **a plain `PUT {"status":"resolved"}` on an already-resolved issue is a no-op — the stale `inRelease` pin survives it.** The pin only clears on a real status transition, so each one went `unresolved` -> `resolved`. The first pass reported success while leaving 39 pins intact; the read-back caught it.

Per-issue outcomes for the six #6367 listed:

| Issue | Outcome | Why |
|---|---|---|
| TR | unresolved | filter written but not deployed; resolving now would page on stale bundles, and leaving it visible is how the post-deploy drop gets confirmed |
| J0 | unresolved | same |
| WG | unresolved | intentional session-blackout monitor (#5245) — belongs in the queue |
| XP | unresolved | intentional per-route monitor, `info` level |
| HT | archived until 100 events/hour | un-filterable by design: its largest slice is the Google account hosts we deliberately keep surfaced. Unlike the `inNextRelease` pin, this can still reopen |
| P4 | resolved, no pin | 297 events / 178 users, ~6 in 14 days. Pages on recurrence; tracked separately |

Every other pinned issue got a plain resolve, so recurrence pages.

**Verification.** An all-time `is:resolved` sweep now reports 301 resolved issues and **zero** carrying a release pin — acceptance criterion 2. Un-resolving returned `substatus=regressed` on each live one, confirming Sentry had been holding them shut.

## Tests

`tests/csp-filter.test.mjs` 116/116. Full sweep of every test touching `src/main.ts` — 11 files, 639/639. `typecheck` and `biome` clean. The 8 new positive cases were observed red before the implementation landed.
