### PR TITLE
fix(sentry): narrow the CSP rules to observed signatures and repair a vacuous guard (follow-up to #6369)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -204,7 +204,8 @@ function shouldSuppressCspViolation(
   // surrounding signal filters.
   if (directive === 'frame-src') {
     try {
-      const frameHost = new URL(blockedURI).hostname;
+      const frameUrl = new URL(blockedURI);
+      const frameHost = frameUrl.hostname;
       if (frameHost === 'gateway.zscloud.net') return true;
       // Same class, other vendors (WORLDMONITOR-HT long tail): NetSTAR inSITE
       // (gw-*.iss.netstar-inc.com), Techloq (filter.techloq.com — kosher
@@ -230,11 +231,24 @@ function shouldSuppressCspViolation(
       if (frameHost === 'h5player.anzz.site') return true;
       // `div.show` — an origin-only frame (no path) that appears nowhere in our
       // source, repeated across many users over months. The injector is not
-      // identified, but it does not need to be: our frame-src is an explicit
-      // allowlist of every host we embed, so a host we never reference can only
-      // have been framed into the page from outside. Exact host, so the
+      // identified, but it does not need to be: frame-src is a BOUNDED
+      // allowlist — named hosts plus five vendor wildcard subdomains
+      // (*.clerk.accounts.dev, *.vercel.app, *.dodopayments.com and two more) —
+      // and div.show falls under none of them, so it can only have been framed
+      // into the page from outside. That safety argument depends on frame-src
+      // staying bounded — pinned by "CSP frame-src stays a bounded host
+      // allowlist" in tests/deploy-config.test.mjs.
+      // Sizing, unlike the font/style rules above: this is ~9% of the issue and
+      // NOT its dominant slice. WORLDMONITOR-HT has no dominant host, and its
+      // largest share is the Google account hosts we deliberately keep
+      // surfaced, so no rule here can quiet it — this one is added because it
+      // is cleanly identifiable, not because it fixes HT. Exact host, so the
       // rotating merchant-domain tail below stays surfaced (WORLDMONITOR-HT).
-      if (frameHost === 'div.show') return true;
+      // Narrowed to the exact observed shape — https, origin-only, no path —
+      // rather than the whole host, because a destination match alone does not
+      // establish that the frame was injected. Anything else on this host still
+      // reports.
+      if (frameUrl.protocol === 'https:' && frameHost === 'div.show' && frameUrl.pathname === '/') return true;
     } catch { /* scheme-only values fall through */ }
   }
   // Browser extensions or injected scripts. `ms-browser-extension://` is Edge's
@@ -274,31 +288,38 @@ function shouldSuppressCspViolation(
       // our code. Allowlisted by exact host like gstatic above — NOT a blanket
       // third-party suppression, so an unexpected font injection from any other
       // host still surfaces (WORLDMONITOR-TR: 1065 events / 83 users).
-      if (url.protocol === 'https:' && url.hostname === 'frontend-cdn.perplexity.ai' && /\.woff2?$/.test(url.pathname)) return true;
+      if (url.protocol === 'https:' && url.hostname === 'frontend-cdn.perplexity.ai'
+          && url.pathname.startsWith('/_agi_assets/') && fontFile.test(url.pathname)) return true;
       // ByteDance's Doubao AI-assistant browser/extension injects its overlay's
       // KaTeX math fonts (lf-flow-web-cdn.doubao.com/obj/flow-doubao/...) into
       // every page — .woff2/.woff/.ttf fallback chain, so all three extensions
       // appear. We never load it; exact host + font-file path like the rules
       // above, NOT a blanket third-party suppression (WORLDMONITOR-TR round 2:
       // 310k events / 308 users in 11 days).
-      if (url.protocol === 'https:' && url.hostname === 'lf-flow-web-cdn.doubao.com' && fontFile.test(url.pathname)) return true;
+      if (url.protocol === 'https:' && url.hostname === 'lf-flow-web-cdn.doubao.com'
+          && url.pathname.startsWith('/obj/flow-doubao/') && fontFile.test(url.pathname)) return true;
       // Migaku language-learning browser extension injects a subsetted Chiron
       // Hei HK webfont as many numbered chunks (fonts/chiron-hei-hk-webfont-*/
       // cw_N.woff2, kx_N.woff2) into every page. 38 distinct URLs in a 14-day
       // sample and 69% of this issue's current volume — the single largest
       // contributor. We never load it; exact host + font-file path like the
       // rules above, so any other migaku path still surfaces.
-      if (url.protocol === 'https:' && url.hostname === 'migaku-public-data.migaku.com' && fontFile.test(url.pathname)) return true;
+      if (url.protocol === 'https:' && url.hostname === 'migaku-public-data.migaku.com'
+          && url.pathname.startsWith('/fonts/') && fontFile.test(url.pathname)) return true;
       // Alibaba iconfont.cn project CDN (at.alicdn.com/t/c/font_<id>.<ext>).
-      // One injected icon font requested in all three formats. `alicdn.com` is
-      // a general Alibaba CDN, so this is pinned to the exact `at.` host and a
-      // font-file path — other alicdn hosts and non-font assets still surface.
-      if (url.protocol === 'https:' && url.hostname === 'at.alicdn.com' && fontFile.test(url.pathname)) return true;
+      // One injected icon font requested in all three formats — 15% of this
+      // issue's current volume. `alicdn.com` is a general Alibaba CDN, so this
+      // is pinned to the exact `at.` host and a font-file path — other alicdn
+      // hosts and non-font assets still surface.
+      if (url.protocol === 'https:' && url.hostname === 'at.alicdn.com'
+          && url.pathname.startsWith('/t/c/') && fontFile.test(url.pathname)) return true;
       // slant.co overlay webfont (Plus Jakarta Display, 3 weights x 2 formats)
-      // served from the injecting extension's own origin. Our font-src is
-      // `'self' data:` — we ship no cross-origin webfonts at all, so a block
-      // here can never be a first-party regression.
-      if (url.protocol === 'https:' && url.hostname === 'www.slant.co' && fontFile.test(url.pathname)) return true;
+      // served from the injecting extension's own origin — 12% of this issue's
+      // current volume. Our font-src is `'self' data:` — we ship no
+      // cross-origin webfonts at all, so a block here can never be a
+      // first-party regression.
+      if (url.protocol === 'https:' && url.hostname === 'www.slant.co'
+          && url.pathname.startsWith('/fonts/') && fontFile.test(url.pathname)) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube live stream manifests.
@@ -323,27 +344,34 @@ function shouldSuppressCspViolation(
   // fonts.gstatic.com font-src rule above (WORLDMONITOR-J0 round 2). Exact
   // host + /css path; Google Fonts under any other directive still surfaces.
   if (/^style-src(-elem)?$/.test(directive)) {
+    // Same reason as `fontFile` above: the plain suffix rules below would
+    // otherwise re-type this per host, which is how such rules drift apart.
+    // Two rules deliberately do NOT use it: Google Fonts matches a path PREFIX
+    // (`/css`, `/css2`), and Typekit pins an exact path shape per host.
+    const cssFile = /\.css$/;
     try {
       const url = new URL(blockedURI);
       if (url.protocol === 'https:' && url.hostname === 'fonts.googleapis.com' && /^\/css2?$/.test(url.pathname)) return true;
       // Chinese-market extension CDN injecting its overlay stylesheet
       // (www.6ppn.com/ext/assets/style.<hash>.css — the /ext/ path is the
       // extension's own asset root). Exact host + .css path (WORLDMONITOR-J0).
-      if (url.protocol === 'https:' && url.hostname === 'www.6ppn.com' && /\.css$/.test(url.pathname)) return true;
+      if (url.protocol === 'https:' && url.hostname === 'www.6ppn.com' && cssFile.test(url.pathname)) return true;
       // FontAwesome public CDN. The injected sheet is v4.7.0 — a 2016 release
       // this app never shipped — and our style-src is `'self' 'unsafe-inline'`
       // with no cross-origin host at all, so any use.fontawesome.com stylesheet
       // is third-party by construction (WORLDMONITOR-J0 round 3: 80% of the
       // issue's current volume). Exact host + .css path; their JS bundle under
       // script-src still surfaces.
-      if (url.protocol === 'https:' && url.hostname === 'use.fontawesome.com' && /\.css$/.test(url.pathname)) return true;
+      if (url.protocol === 'https:' && url.hostname === 'use.fontawesome.com'
+          && url.pathname.startsWith('/releases/') && cssFile.test(url.pathname)) return true;
       // Adobe Typekit / Adobe Fonts kit CSS, from both hosts it serves:
       // `use.typekit.net/<kit>.css` and the `p.typekit.net/p.css?...` tracking
-      // sheet. We self-host every font and reference no kit id, so these are
-      // injected by a theme extension or the user's own stylesheet manager.
+      // sheet — together 17% of this issue's current volume. We self-host every
+      // font and reference no kit id, so these are injected by a theme
+      // extension or the user's own stylesheet manager.
       if (url.protocol === 'https:'
-          && (url.hostname === 'use.typekit.net' || url.hostname === 'p.typekit.net')
-          && /\.css$/.test(url.pathname)) return true;
+          && ((url.hostname === 'use.typekit.net' && /^\/[^/]+\.css$/.test(url.pathname))
+            || (url.hostname === 'p.typekit.net' && url.pathname === '/p.css'))) return true;
     } catch { /* unparseable values fall through */ }
     // Extension bug: a literal unsubstituted `[email]` template placeholder as
     // the stylesheet URL. Not a parseable host; can never be first-party.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -230,6 +230,70 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://fonts.gstatic.com/s/mulish/v18/font.css?kit=abc.woff2', '', false));
     });
 
+    it('does NOT suppress a Google Fonts lookalike host', () => {
+      // Every other font-src host rule has this; gstatic did not, so a host
+      // widening there was the one such mutation the suite could not catch.
+      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.gstatic.com.evil.com/s/mulish/v18/x.woff2', '', false));
+    });
+
+    it('does NOT suppress Google Fonts files outside the /s/ path', () => {
+      // Pins the `/^\/s\/.+/` conjunct — without this, deleting that conjunct
+      // leaves the whole suite green.
+      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.gstatic.com/x/a/b.woff2', '', false));
+    });
+
+    it('does NOT suppress http: font-src on the injected-webfont hosts', () => {
+      // Pins the `url.protocol === 'https:'` conjunct the new rules share; the
+      // other new negatives only cover lookalike host and non-font path.
+      assert.ok(!suppress('enforce', 'font-src', 'http://migaku-public-data.migaku.com/fonts/x/cw_0.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'http://at.alicdn.com/t/c/font_1011144_jmo4009ffif.woff', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'http://www.slant.co/fonts/plus-jakarta/Display-Bold.woff2', '', false));
+    });
+
+    it('does NOT suppress a SIBLING registrable domain of a pinned font host', () => {
+      // The `<host>.evil.com` fixtures elsewhere are rejected by ANY hostname
+      // check, including a suffix match, so they cannot prove exactness. These
+      // do: each is a domain an attacker can register that a naive
+      // `endsWith('alicdn.com')` style refactor would start swallowing.
+      assert.ok(!suppress('enforce', 'font-src', 'https://evilalicdn.com/t/c/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://evil-at.alicdn.com/t/c/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://myslant.co/fonts/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://notmigaku.com/fonts/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://evil-fonts.gstatic.com/s/a/b.woff2', '', false));
+    });
+
+    it('does NOT suppress http: font-src on gstatic', () => {
+      // The other http: negative covers migaku/alicdn/slant; without this one,
+      // dropping gstatic's https gate leaves the whole suite green.
+      assert.ok(!suppress('enforce', 'font-src', 'http://fonts.gstatic.com/s/a/b.woff2', '', false));
+    });
+
+    it('does NOT suppress an unrelated path on an injected-webfont host', () => {
+      // A destination match alone does not prove injection: the same host could
+      // serve a font our own code someday references. Each rule is pinned to the
+      // path prefix actually observed from the injector, so an off-signature
+      // path on the same host keeps reporting.
+      assert.ok(!suppress('enforce', 'font-src', 'https://migaku-public-data.migaku.com/unrelated/regression.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://at.alicdn.com/other/regression.woff', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://www.slant.co/assets/regression.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://frontend-cdn.perplexity.ai/unrelated/regression.ttf', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://lf-flow-web-cdn.doubao.com/unrelated/regression.otf', '', false));
+    });
+
+    it('does NOT suppress a SIBLING registrable domain, or http:, on a pinned stylesheet host', () => {
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://notfontawesome.com/releases/x.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://faketypekit.net/x.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'http://use.fontawesome.com/releases/x.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'http://use.typekit.net/x.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'http://p.typekit.net/p.css', '', false));
+    });
+
+    it('does NOT suppress an unrelated path on an injected-stylesheet host', () => {
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://use.fontawesome.com/unrelated/regression.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://use.typekit.net/nested/regression.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://p.typekit.net/regression.css', '', false));
+    });
+
     it('does NOT suppress arbitrary third-party font-src hosts', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://fonts.evil.example/s/mulish/v18/font.woff2', '', false));
     });
@@ -237,6 +301,9 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     it('suppresses Perplexity Comet overlay webfont injection (WORLDMONITOR-TR)', () => {
       assert.ok(suppress('enforce', 'font-src', 'https://frontend-cdn.perplexity.ai/_agi_assets/fonts/FKGroteskNeue.woff2', '', false));
       assert.ok(suppress('enforce', 'font-src', 'https://frontend-cdn.perplexity.ai/_agi_assets/fonts/FKGroteskNeue.woff', '', false));
+      // Shares the whole-chain matcher with the other font-src hosts, so the
+      // block header's "every host rule below" claim is literally true.
+      assert.ok(suppress('enforce', 'font-src', 'https://frontend-cdn.perplexity.ai/_agi_assets/fonts/FKGroteskNeue.ttf', '', false));
     });
 
     it('does NOT suppress a perplexity.ai lookalike host or non-font path', () => {
@@ -388,8 +455,13 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     });
 
     it('does NOT suppress a typekit lookalike host or non-css path', () => {
+      // BOTH arms of the hostname OR need lookalike cover — a mutation that
+      // widened only the p.typekit.net side left every use.typekit.net
+      // assertion green, so testing one arm proves nothing about the other.
       assert.ok(!suppress('enforce', 'style-src-elem', 'https://use.typekit.net.evil.com/izn6gyh.css', '', false));
       assert.ok(!suppress('enforce', 'style-src-elem', 'https://use.typekit.net/kit.js', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://p.typekit.net.evil.com/p.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://p.typekit.net/kit.js', '', false));
     });
 
     it('does NOT suppress arbitrary third-party style-src hosts', () => {
@@ -502,6 +574,14 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'frame-src', 'https://clients6.google.com.evil.com', '', false, FIRST_PARTY_CONVEX));
       assert.ok(!suppress('enforce', 'frame-src', 'https://h5player.anzz.site.evil.com', '', false, FIRST_PARTY_CONVEX));
       assert.ok(!suppress('enforce', 'frame-src', 'https://div.show.evil.com', '', false, FIRST_PARTY_CONVEX));
+      // Pinned to the exact observed shape, so a pathful or http: frame on the
+      // same host still reports — a destination match alone is not provenance.
+      assert.ok(!suppress('enforce', 'frame-src', 'https://div.show/embed', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(!suppress('enforce', 'frame-src', 'http://div.show', '', false, FIRST_PARTY_CONVEX));
+      // Sibling registrable domain + subdomain: a suffix-match refactor would
+      // swallow both, and `div.show.evil.com` alone would not catch it.
+      assert.ok(!suppress('enforce', 'frame-src', 'https://xdiv.show', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(!suppress('enforce', 'frame-src', 'https://sub.div.show', '', false, FIRST_PARTY_CONVEX));
     });
 
     it('does NOT suppress frame-src for arbitrary third-party hosts (rotating extension long tail stays surfaced)', () => {

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -260,6 +260,17 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://myslant.co/fonts/x.woff2', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'https://notmigaku.com/fonts/x.woff2', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'https://evil-fonts.gstatic.com/s/a/b.woff2', '', false));
+      // Sibling SUBDOMAINS too — these kill an `endsWith('.migaku.com')` style
+      // mutant that a sibling registrable domain alone leaves alive.
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.migaku.com/fonts/chiron-hei-hk-webfont-2.6.7/cw_0.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.doubao.com/obj/flow-doubao/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.perplexity.ai/_agi_assets/fonts/x.woff2', '', false));
+    });
+
+    it('pins the end-anchor on the shared font matcher', () => {
+      // Without the `$`, `/\.(?:woff2?|ttf|otf)/` matches mid-path and a
+      // sourcemap alongside the font would be swallowed.
+      assert.ok(!suppress('enforce', 'font-src', 'https://at.alicdn.com/t/c/font_1011144.woff2.map', '', false));
     });
 
     it('does NOT suppress http: font-src on gstatic', () => {
@@ -286,6 +297,12 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'style-src-elem', 'http://use.fontawesome.com/releases/x.css', '', false));
       assert.ok(!suppress('enforce', 'style-src-elem', 'http://use.typekit.net/x.css', '', false));
       assert.ok(!suppress('enforce', 'style-src-elem', 'http://p.typekit.net/p.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://cdn.fontawesome.com/releases/v4.7.0/css/x.css', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://cdn.6ppn.com/ext/assets/style.abc.css', '', false));
+    });
+
+    it('pins the end-anchor on the shared stylesheet matcher', () => {
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://www.6ppn.com/ext/assets/style.abc.css.map', '', false));
     });
 
     it('does NOT suppress an unrelated path on an injected-stylesheet host', () => {
@@ -582,6 +599,7 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       // swallow both, and `div.show.evil.com` alone would not catch it.
       assert.ok(!suppress('enforce', 'frame-src', 'https://xdiv.show', '', false, FIRST_PARTY_CONVEX));
       assert.ok(!suppress('enforce', 'frame-src', 'https://sub.div.show', '', false, FIRST_PARTY_CONVEX));
+      assert.ok(!suppress('enforce', 'frame-src', 'https://cdn.anzz.site', '', false, FIRST_PARTY_CONVEX));
     });
 
     it('does NOT suppress frame-src for arbitrary third-party hosts (rotating extension long tail stays surfaced)', () => {

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -130,6 +130,27 @@ const getCspDirectiveTokens = (csp, directive) => {
   return [...new Set(tokens)].sort();
 };
 
+// frame-src is a BOUNDED allowlist, not a closed host list: it legitimately
+// carries vendor wildcard subdomains. Pin them, so a NEW wildcard or any
+// scheme-wide source is flagged while the known ones stay quiet.
+const KNOWN_FRAME_WILDCARDS = [
+  'https://*.clerk.accounts.dev',
+  'https://*.vercel.app',
+  'https://*.dodopayments.com',
+  'https://*.hs.dodopayments.com',
+  'https://*.custom.hs.dodopayments.com',
+];
+const OPEN_CSP_SOURCES = ['*', 'https:', 'http:', 'data:', 'blob:'];
+// Exported-by-hoisting so the guard's own negative test can drive it directly
+// rather than asserting through the real config, which cannot show a widening.
+const findOpenFrameSources = (tokens) => tokens.filter((token) => {
+  if (KNOWN_FRAME_WILDCARDS.includes(token)) return false;
+  // Tokens keep their scheme (`https://*.vercel.app`), so the wildcard test has
+  // to run on the host part or it matches nothing at all.
+  const host = token.replace(/^[a-z][a-z0-9+.-]*:\/\//i, '');
+  return OPEN_CSP_SOURCES.includes(token) || host === '*' || host.startsWith('*.');
+});
+
 const hasTrustedStaticNonce = (attributes) => (
   new RegExp(`\\bnonce=["']${STATIC_SCRIPT_NONCE}["']`).test(attributes)
 );
@@ -1275,6 +1296,53 @@ describe('security header guardrails', () => {
         `${directive} tokens in nginx-security-headers.conf but missing from vercel.json: ${onlyNginx.join(', ')}. ` +
         'Payment/auth iframe and form targets must stay deploy-surface identical.');
     }
+  });
+
+  it('CSP frame-src stays a bounded host allowlist (load-bearing for a Sentry suppression rule)', () => {
+    // `shouldSuppressCspViolation` in src/main.ts discards frame-src violation
+    // reports for `div.show` on the argument that frame-src enumerates every
+    // host we embed, so a host we never reference can only have been injected
+    // from outside. That argument holds only while the directive stays a closed
+    // allowlist -- adding a scheme-wide or wildcard source would make foreign
+    // frames legal, and the suppression would then be hiding a real policy
+    // change rather than third-party noise. The existing frame-src tests pin
+    // that Clerk is PRESENT and that the deploy surfaces agree; neither would
+    // fail on a widening, so this pins the property the suppression depends on.
+    for (const [label, csp] of [
+      ['vercel.json', getHeaderValue('Content-Security-Policy')],
+      ['docker/nginx', getNginxHeaderValue('Content-Security-Policy')],
+    ]) {
+      assert.ok(csp, `${label} must have a Content-Security-Policy header`);
+      const tokens = getCspDirectiveTokens(csp, 'frame-src');
+      assert.ok(tokens.length > 0, `${label} must declare an explicit frame-src`);
+      const open = findOpenFrameSources(tokens);
+      assert.deepEqual(open, [],
+        `${label} frame-src must stay a bounded host allowlist; found open source(s): ${open.join(', ')}. ` +
+        'The div.show suppression in src/main.ts assumes any non-allowlisted frame is third-party injection.');
+    }
+  });
+
+  it('the frame-src allowlist guard actually fires on a widening', () => {
+    // The first version of this guard tested `token.startsWith('*.')`, which can
+    // never match: getCspDirectiveTokens returns tokens WITH their scheme
+    // (`https://*.vercel.app`). It therefore passed while dead. Drive the
+    // predicate directly against widenings written the way they'd really appear.
+    for (const widened of [
+      'https://*.evil.com',   // a new vendor wildcard
+      'https://*',            // scheme-wide with a wildcard host
+      'http://*.evil.com',
+      '*',
+      'https:',
+      '*.evil.com',           // scheme-less
+    ]) {
+      assert.deepEqual(findOpenFrameSources([widened]), [widened],
+        `guard must flag ${widened} as an open frame-src source`);
+    }
+    // ...and must stay quiet on the bounded sources the policy legitimately has.
+    assert.deepEqual(
+      findOpenFrameSources(["'self'", 'https://www.worldmonitor.app', ...KNOWN_FRAME_WILDCARDS]),
+      []
+    );
   });
 
   it('security.txt exists in public/.well-known/', () => {


### PR DESCRIPTION
Follow-up to #6369, which merged before its review finished. The review — six reviewers plus an independent cross-model pass — found real defects in what shipped. This fixes them. Every claim below was verified by mutation, not by reading.

## 1. Destination alone is not provenance

#6369's rules matched **host + extension**, so any path on those hosts was discarded. The repo's own guidance in `docs/solutions/best-practices/sentry-noise-filtering-with-stack-gating-and-signature-matching.md` says to use *"the narrowest stable evidence available"* — and the measurement behind #6369 already had that evidence, it just wasn't used.

Each rule now pins the observed path signature:

| Host | Signature |
|---|---|
| `migaku-public-data.migaku.com` | `/fonts/` |
| `at.alicdn.com` | `/t/c/` |
| `www.slant.co` | `/fonts/` |
| `frontend-cdn.perplexity.ai` | `/_agi_assets/` |
| `lf-flow-web-cdn.doubao.com` | `/obj/flow-doubao/` |
| `use.fontawesome.com` | `/releases/` |
| `use.typekit.net` / `p.typekit.net` | root-level `.css` / exactly `/p.css` |

An off-signature path on the same host reports again. The originally observed URLs still suppress — the positive tests cover them, and they still pass.

## 2. The guard #6369 added was vacuous

#6369 added a `frame-src` allowlist guard because the `div.show` rule's safety argument depends on that directive staying bounded. The guard's wildcard clause was:

```js
tokens.filter((token) => OPEN_SOURCES.includes(token) || token.startsWith('*.'))
```

`getCspDirectiveTokens` returns tokens **with their scheme** (`https://*.vercel.app`), so `startsWith('*.')` matches nothing that can appear in the directive. And `frame-src` already ships five vendor wildcards today, which the guard reported as zero open sources.

It passed while dead — precisely the failure it was written to prevent. I mutation-tested the `https:` clause when I added it and never tested the wildcard clause, which is how it got through.

The predicate is now extracted and driven **directly** by its own negative test over six widening forms, including `https://*.evil.com`, which the dead version missed. The five legitimate wildcards are pinned so a *new* one fails.

## 3. The lookalike fixtures proved nothing

Every rule's comment claims exact-host matching, but the negatives all used `<host>.evil.com` — a shape rejected by *any* hostname check, including a suffix match. So `url.hostname === 'at.alicdn.com'` -> `url.hostname.endsWith('alicdn.com')` **survived** on all six hosts.

That mutant is not academic: `'evilalicdn.com'.endsWith('alicdn.com')` is `true`, and the same holds for `notfontawesome.com`, `faketypekit.net`, `myslant.co`, `xdiv.show`. A future refactor to suffix matching would have started silently swallowing CSP blocks from attacker-registrable domains with the whole suite green.

Added sibling-registrable-domain negatives per host, and confirmed the mutants now die. Also added the missing `http:` negatives for gstatic, fontawesome and typekit, whose https gate was equally unpinned.

## 4. `div.show` was unbounded

Any scheme, any path. Now pinned to the shape actually observed: https, origin-only, no path.

## 5. Two comments that weren't true

- `frame-src` is a **bounded** allowlist — named hosts plus five vendor wildcards — not "an explicit allowlist of every host we embed". The wildcards include `https://*.vercel.app`, which admits any Vercel preview deployment. The `div.show` conclusion survives (it falls under none of them), but the general claim was false in both the comment and the test name.
- `cssFile` serves the plain suffix rules only; Google Fonts matches a path prefix and Typekit an exact shape.

## Tests

`csp-filter` 125/125, `deploy-config` 171/171, typecheck and biome clean. The new guards were each verified to go red when the conjunct they pin is removed.

## Note on sequencing

#6369 merged while its review was still running, so these findings arrived against already-shipped code. Nothing here is a production incident — the shipped rules are over-broad and the guard is inert, not actively harmful — but the over-broad window is open until this lands.
