### PR TITLE
fix(sentry): filter the two extension webfonts still dominating TR (follow-up to #6371)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -320,6 +320,19 @@ function shouldSuppressCspViolation(
       // first-party regression.
       if (url.protocol === 'https:' && url.hostname === 'www.slant.co'
           && url.pathname.startsWith('/fonts/') && fontFile.test(url.pathname)) return true;
+      // ShopBack cashback extension injects its own UI face (ShopBackSans, 8
+      // weight/style combinations) from its static origin. Sized on the window
+      // AFTER the rules above deployed: every host named there went silent and
+      // this one was 100% of what remained, which is why the issue regressed
+      // minutes after being resolved. Exact host + font-file path like the
+      // rules above, so other shopback assets still surface.
+      if (url.protocol === 'https:' && url.hostname === 'static.shopback.com'
+          && url.pathname.startsWith('/fonts/') && fontFile.test(url.pathname)) return true;
+      // SimplyCodes coupon extension injects three overlay families (Circular
+      // XX, Neue Haas Grotesk, Degular) under one /fonts/ root — 10 distinct
+      // URLs, the second-largest remaining slice. Same exact-host shape.
+      if (url.protocol === 'https:' && url.hostname === 'images.simplycodes.com'
+          && url.pathname.startsWith('/fonts/') && fontFile.test(url.pathname)) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube live stream manifests.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -248,6 +248,8 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'font-src', 'http://migaku-public-data.migaku.com/fonts/x/cw_0.woff2', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'http://at.alicdn.com/t/c/font_1011144_jmo4009ffif.woff', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'http://www.slant.co/fonts/plus-jakarta/Display-Bold.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'http://static.shopback.com/fonts/ShopBackSans-Bold.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'http://images.simplycodes.com/fonts/simply-circular/CircularXXWeb-Regular.woff2', '', false));
     });
 
     it('does NOT suppress a SIBLING registrable domain of a pinned font host', () => {
@@ -265,6 +267,8 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://cdn.migaku.com/fonts/chiron-hei-hk-webfont-2.6.7/cw_0.woff2', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'https://cdn.doubao.com/obj/flow-doubao/x.woff2', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'https://cdn.perplexity.ai/_agi_assets/fonts/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.shopback.com/fonts/ShopBackSans-Bold.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.simplycodes.com/fonts/simply-circular/CircularXXWeb-Regular.woff2', '', false));
     });
 
     it('pins the end-anchor on the shared font matcher', () => {
@@ -289,6 +293,8 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://www.slant.co/assets/regression.woff2', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'https://frontend-cdn.perplexity.ai/unrelated/regression.ttf', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'https://lf-flow-web-cdn.doubao.com/unrelated/regression.otf', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://static.shopback.com/unrelated/regression.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://images.simplycodes.com/unrelated/regression.woff2', '', false));
     });
 
     it('does NOT suppress a SIBLING registrable domain, or http:, on a pinned stylesheet host', () => {
@@ -389,6 +395,32 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     it('does NOT suppress a slant.co lookalike host or non-font path', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://www.slant.co.evil.com/x.woff2', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'https://www.slant.co/fonts/loader.js', '', false));
+    });
+
+    it('suppresses ShopBack cashback-extension webfont injection (WORLDMONITOR-TR round 4)', () => {
+      // ShopBackSans in 8 weight/style combinations from the extension's own
+      // static origin. 100% of the issue's volume in the window after the
+      // round-3 rules deployed — every host named there went silent, this one
+      // did not, which is what regressed the issue minutes after a resolve.
+      assert.ok(suppress('enforce', 'font-src', 'https://static.shopback.com/fonts/ShopBackSans-Bold.woff2', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://static.shopback.com/fonts/ShopBackSans-BlackItalic.woff2', '', false));
+    });
+
+    it('does NOT suppress a shopback lookalike host or non-font path', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://static.shopback.com.evil.com/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://static.shopback.com/fonts/loader.js', '', false));
+    });
+
+    it('suppresses SimplyCodes coupon-extension webfont injection (WORLDMONITOR-TR round 4)', () => {
+      // Three families (Circular XX, Neue Haas Grotesk, Degular) under one
+      // /fonts/ root — 10 distinct URLs, the second-largest remaining slice.
+      assert.ok(suppress('enforce', 'font-src', 'https://images.simplycodes.com/fonts/simply-circular/CircularXXWeb-Regular.woff2', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://images.simplycodes.com/fonts/neue-haas-grotesk/NHaasGroteskDSPro-55Rg.woff2', '', false));
+    });
+
+    it('does NOT suppress a simplycodes lookalike host or non-font path', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://images.simplycodes.com.evil.com/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://images.simplycodes.com/fonts/loader.js', '', false));
     });
 
     it('does NOT suppress Google Fonts under unrelated directives', () => {


### PR DESCRIPTION
## Summary

WORLDMONITOR-TR was resolved during triage and **regressed within minutes** — one uncovered injector was still generating the entire remaining stream. This adds the rule for it, plus the next-largest one.

The useful part is the measurement window. Censusing TR over 7 days blends pre- and post-fix traffic and still shows migaku at 53%, which reads as "the last round didn't work." Censusing only the window *after* #6369/#6371 reached production — confirmed by reading `build_sha` off a live event rather than assuming merge means deployed — shows the opposite: every host those rounds named has gone silent, and what remains is one host they never covered.

| Host | 7-day share | Share after #6371 shipped | Rule |
|---|---|---|---|
| `static.shopback.com` | 14.3% | **100%** | added here |
| `images.simplycodes.com` | 6.7% | 0% observed | added here |
| migaku / slant / typekit / alicdn / gstatic / doubao | 76% | **0%** | already covered — confirmed working |
| scite.ai, mindverse.ai, marmot-cloud | 2.7% (53 events) | 0% observed | deliberately left surfaced |

ShopBack is a cashback extension injecting ShopBackSans in 8 weight/style combinations; SimplyCodes is a coupon extension injecting three overlay families under one `/fonts/` root. Both follow the exact-host + `/fonts/` prefix + font-extension shape #6371 settled on, so any other asset on either host still reports. Our `font-src` is `'self' data:` — we ship no cross-origin webfonts at all, so a cross-origin `font-src` block cannot be a first-party regression.

The 2.7% tail is left reporting on purpose. One rule per long-tail injector is how this filter rots into an unauditable allowlist; these three aren't worth that cost yet.

## Validation

`tests/csp-filter.test.mjs` + `tests/deploy-config.test.mjs`: 301 pass, 0 fail. `npm run typecheck` clean. Both re-run after rebasing onto `f8c9d016b`.

Both new positives were proven red before the rules landed. A mutation sweep over the two new rules kills all four conjunct mutants:

| Mutant | Result |
|---|---|
| `https:` protocol gate removed | killed |
| exact host widened to `endsWith` | killed |
| font-extension check removed | killed |
| `/fonts/` prefix removed | **initially SURVIVED** |

That last one matters: the first version of these tests passed 130/130 against a mutant where `startsWith('/fonts/')` was deleted from both rules — the guard would have silently widened to every font-extension asset on those hosts with no test objecting. The two unrelated-path negatives that kill it were added rather than shipping a vacuous guard.

Not verified: that the suppression holds in production. That needs the deploy, and TR is deliberately left **unresolved** in Sentry until then — resolving now would just regress again against a build that lacks the rule.

Related: #6371, #6369

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
