### PR TITLE
fix(dashboard): apply panel settings without a reload (#6379)

### DIFF
--- a/e2e/settings-panel-live-apply.spec.ts
+++ b/e2e/settings-panel-live-apply.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * The Settings modal must apply a panel toggle to the LIVE dashboard on Save.
+ *
+ * Regression guard for the split-brain `applyPanelSettings()`: the settings
+ * save path (EventHandlerManager) had its own copy that only re-toggled panels
+ * already mounted in `ctx.panels`, while the deferred-mount bookkeeping added
+ * in #4367 lives in PanelLayoutManager's copy. A panel that boots disabled is
+ * parked in `deferredPanelMounts` with no shell and no IntersectionObserver, so
+ * the settings copy had nothing to toggle — enabling it did nothing until a
+ * page reload re-ran createPanels().
+ */
+
+/** A full-variant panel, seeded disabled below so it boots into deferredPanelMounts. */
+const PANEL_KEY = 'threat-timeline';
+const PANEL_SELECTOR = `.panel[data-panel="${PANEL_KEY}"]`;
+
+async function seedDashboard(page: Page): Promise<void> {
+  await page.addInitScript((panelKey) => {
+    // Seed once per tab: addInitScript re-runs on every navigation, and a
+    // re-seed on reload would wipe the very preference under test.
+    if (sessionStorage.getItem('__settings_live_apply_seeded__')) return;
+    localStorage.clear();
+    sessionStorage.clear();
+    sessionStorage.setItem('__settings_live_apply_seeded__', '1');
+    localStorage.setItem('worldmonitor-variant', 'full');
+    // Pro: the free tier clamps to FREE_MAX_PANELS (40) and the full variant
+    // already defaults over that, so a free profile has zero headroom and the
+    // modal would refuse the toggle with a cap toast before reaching the bug.
+    localStorage.setItem('wm-pro-key', 'e2e-live-apply');
+    // Overlays that would otherwise steal the click target.
+    localStorage.setItem('wm-layer-warning-dismissed', 'true');
+    localStorage.setItem('wm-pro-banner-launched-dismissed', String(Date.now()));
+    localStorage.setItem('worldmonitor-mission-preset-dismissed-v1', '1');
+    // Partial map: App merges every other ALL_PANELS key at its variant default.
+    localStorage.setItem('worldmonitor-panels', JSON.stringify({
+      [panelKey]: { name: 'Threat Timeline', enabled: false, priority: 1 },
+    }));
+  }, PANEL_KEY);
+}
+
+test('enabling a panel in Settings shows it on the dashboard without a reload', async ({ page }) => {
+  await seedDashboard(page);
+  await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+
+  const settingsBtn = page.locator('#unifiedSettingsBtn');
+  await expect(settingsBtn).toBeVisible({ timeout: 60_000 });
+  // Boot is far enough along that the grid has real panels, so a later absence
+  // of PANEL_SELECTOR means "disabled", not "not created yet".
+  await expect(page.locator('#panelsGrid .panel').first()).toBeVisible({ timeout: 60_000 });
+  await expect(page.locator(PANEL_SELECTOR)).toHaveCount(0);
+
+  await settingsBtn.click();
+  await page.locator('#us-tab-panels').click();
+
+  const toggle = page.locator(`#usPanelToggles .panel-toggle-item[data-panel="${PANEL_KEY}"]`);
+  await expect(toggle).toBeVisible({ timeout: 15_000 });
+  await expect(toggle).not.toHaveClass(/\bactive\b/);
+  await toggle.click();
+  await expect(toggle).toHaveClass(/\bactive\b/);
+
+  const save = page.locator('.panels-save-layout');
+  await expect(save).toBeEnabled();
+  await save.click();
+  await page.locator('.unified-settings-close').click();
+
+  // No reload between the Save click and this assertion.
+  await expect(page.locator(PANEL_SELECTOR)).toBeVisible({ timeout: 30_000 });
+});

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "test:e2e:runtime": "cross-env VITE_VARIANT=full playwright test e2e/runtime-fetch.spec.ts",
     "test:e2e:mcp-grant": "cross-env VITE_VARIANT=full playwright test e2e/mcp-grant-consent.spec.ts",
     "test:e2e:news-budget": "cross-env VITE_VARIANT=full playwright test e2e/dashboard-news-request-budget.spec.ts",
-    "test:e2e:ci-smoke": "cross-env VITE_VARIANT=full playwright test e2e/variant-live-smoke.spec.ts e2e/mcp-grant-consent.spec.ts e2e/dashboard-news-request-budget.spec.ts",
+    "test:e2e:ci-smoke": "cross-env VITE_VARIANT=full playwright test e2e/variant-live-smoke.spec.ts e2e/mcp-grant-consent.spec.ts e2e/dashboard-news-request-budget.spec.ts e2e/settings-panel-live-apply.spec.ts",
     "test:e2e:variant-smoke:full": "cross-env VITE_VARIANT=full playwright test e2e/variant-live-smoke.spec.ts",
     "test:e2e:variant-smoke:tech": "cross-env VITE_VARIANT=tech playwright test e2e/variant-live-smoke.spec.ts",
     "test:e2e:variant-smoke:finance": "cross-env VITE_VARIANT=finance playwright test e2e/variant-live-smoke.spec.ts",

--- a/src/App.ts
+++ b/src/App.ts
@@ -1407,7 +1407,7 @@ export class App {
       loadDataForLayer: (layer) => { void this.dataLoader.loadDataForLayer(layer as keyof MapLayers); },
       waitForAisData: () => this.dataLoader.waitForAisData(),
       syncDataFreshnessWithLayers: () => this.dataLoader.syncDataFreshnessWithLayers(),
-      ensureCorrectZones: () => this.panelLayout.ensureCorrectZones(),
+      applyPanelSettings: () => this.panelLayout.applyPanelSettings(),
       applySavedPanelOrder: (panelOrder?: string[]) => this.panelLayout.applySavedPanelOrder(panelOrder),
       stopLayerActivity: (layer) => this.dataLoader.stopLayerActivity(layer),
       mountLiveNewsIfReady: () => this.panelLayout.mountLiveNewsIfReady(),

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -238,7 +238,13 @@ export interface EventHandlerCallbacks {
   loadDataForLayer: (layer: string) => void;
   waitForAisData: () => void;
   syncDataFreshnessWithLayers: () => void;
-  ensureCorrectZones: () => void;
+  /**
+   * Push `ctx.panelSettings` onto the live dashboard. Must route to
+   * PanelLayoutManager.applyPanelSettings — it owns the deferred-mount
+   * bookkeeping a panel needs to appear without a reload, and the map-zone
+   * reconciliation the `map` key needs.
+   */
+  applyPanelSettings: () => void;
   applySavedPanelOrder?: (panelOrder?: string[]) => void;
   stopLayerActivity?: (layer: keyof MapLayers) => void;
   mountLiveNewsIfReady?: () => void;
@@ -2332,29 +2338,19 @@ export class EventHandlerManager implements AppModule {
     return Array.from(sources).sort((a, b) => a.localeCompare(b));
   }
 
+  /**
+   * Delegates to PanelLayoutManager, which owns panel visibility.
+   *
+   * This class used to carry its own copy of the toggle loop. That copy could
+   * only re-toggle panels already present in `ctx.panels`, and since #4367 a
+   * panel that boots disabled has no DOM node at all — just an unobserved,
+   * shell-less entry in `deferredPanelMounts`. So every caller here that
+   * ENABLES a panel (settings save, CMD+K add, undo-restore, mission preset,
+   * cross-tab storage sync) silently did nothing until the next reload
+   * re-ran createPanels(). The layout manager's version mounts the deferred
+   * panel and refreshes the mobile panel nav.
+   */
   applyPanelSettings(): void {
-    Object.entries(this.ctx.panelSettings).forEach(([key, config]) => {
-      if (key === 'map') {
-        const mapSection = document.getElementById('mapSection');
-        if (mapSection) {
-          mapSection.classList.toggle('hidden', !config.enabled);
-          const mainContent = document.querySelector('.main-content');
-          if (mainContent) {
-            mainContent.classList.toggle('map-hidden', !config.enabled);
-          }
-          this.callbacks.ensureCorrectZones();
-        }
-        return;
-      }
-      const panel = this.ctx.panels[key];
-      const liveMediaPanel = panel as { stopLiveMediaForClose?: () => void; resumeLiveMediaForShow?: () => void } | undefined;
-      if (!config.enabled) {
-        liveMediaPanel?.stopLiveMediaForClose?.();
-      }
-      panel?.toggle(config.enabled);
-      if (config.enabled) {
-        liveMediaPanel?.resumeLiveMediaForShow?.();
-      }
-    });
+    this.callbacks.applyPanelSettings();
   }
 }

--- a/tests/mission-presets.test.mts
+++ b/tests/mission-presets.test.mts
@@ -941,6 +941,7 @@ type MissionTestCallbacks = {
   syncDataFreshnessCalls: number;
   mountLiveNewsCalls: number;
   waitForAisCalls: number;
+  applyPanelSettingsCalls: number;
 };
 
 type MissionHarness = {
@@ -1049,6 +1050,7 @@ function createMissionHarness(options: {
     syncDataFreshnessCalls: 0,
     mountLiveNewsCalls: 0,
     waitForAisCalls: 0,
+    applyPanelSettingsCalls: 0,
   };
   const unifiedSettings = {
     refreshes: 0,
@@ -1121,7 +1123,7 @@ function createMissionHarness(options: {
     loadDataForLayer: (layer: string) => callbacks.loadDataForLayer.push(layer),
     waitForAisData: () => { callbacks.waitForAisCalls += 1; },
     syncDataFreshnessWithLayers: () => { callbacks.syncDataFreshnessCalls += 1; },
-    ensureCorrectZones() {},
+    applyPanelSettings: () => { callbacks.applyPanelSettingsCalls += 1; },
     applySavedPanelOrder: (panelOrder?: string[]) => callbacks.appliedOrders.push([...(panelOrder ?? [])]),
     stopLayerActivity: (layer: keyof MapLayers) => callbacks.stopLayerActivity.push(String(layer)),
     mountLiveNewsIfReady: () => { callbacks.mountLiveNewsCalls += 1; },
@@ -1169,6 +1171,10 @@ describe('mission preset shell integration', () => {
     assert.deepEqual(ctx.map.calls.setView.at(-1), { view: 'global', zoom: 2.3 });
     assert.equal(ctx.map.calls.setTimeRange.at(-1), '7d');
     assert.equal(callbacks.waitForAisCalls, 1, 'AIS layer enable should initialize the AIS stream path');
+    assert.ok(
+      callbacks.applyPanelSettingsCalls >= 1,
+      'a preset that flips panels must push them onto the live dashboard, not just persist them (#6379)',
+    );
     assert.ok(callbacks.loadDataForLayer.includes('tradeRoutes'), 'newly enabled non-AIS layers should load data');
     assert.ok(
       ((globalThis as { __missionAnalytics?: Array<{ name: string; args: unknown[] }> }).__missionAnalytics ?? [])


### PR DESCRIPTION
## Summary

Enabling a panel in Settings → PANELS and pressing Save did nothing — the dashboard stayed exactly as it was until you reloaded the page. The panel now appears immediately, already hydrating its data.

`applyPanelSettings()` existed in two places and the Settings save path called the wrong one. `PanelLayoutManager`'s version mounts panels parked in `deferredPanelMounts`; the copy inside `EventHandlerManager` only re-toggled panels already present in `ctx.panels`. A panel that boots **disabled** has no DOM node at all — no placeholder shell, no IntersectionObserver, and for lazily registered panels not even an entry in `ctx.panels` — so the copy was calling `toggle(true)` on `undefined`. The preference was persisted correctly all along, which is why a reload appeared to "work": `createPanels()` re-ran and mounted it.

The duplicate is deleted and `EventHandlerManager` now delegates through an `applyPanelSettings` callback, so the two cannot drift again. That also restores two behaviours the copy silently dropped: data-hydration priming for the newly mounted panel, and the mobile panel-nav refresh.

The bug reached further than the Settings modal. Every caller of the stale copy was a no-op when **enabling** a panel that was not already mounted:

| Path | Before | After |
|---|---|---|
| Settings → PANELS → Save | no visible change until reload | panel mounts immediately |
| CMD+K "Add panel" | silently did nothing | panel mounts |
| Undo of a closed panel | panel stayed gone | panel returns |
| Mission preset apply / reset | preset's newly enabled panels missing | all preset panels mount |
| Cross-tab settings sync | other tab never updated | other tab updates live |

Disabling always looked fine, because that panel was already in the DOM.

Regression window: #4367 added the deferred-mount handling to the layout manager's copy only.

## Validation

`e2e/settings-panel-live-apply.spec.ts` boots the dashboard with `threat-timeline` disabled, then drives the real modal — gear → PANELS → toggle → Save — and asserts the panel is visible with no reload in between.

- On the pre-fix code it fails with `element(s) not found` after 30s; a temporary probe that reloaded at the end passed, reproducing "I have to refresh for the settings to work" exactly.
- On this branch it passes in 5–14s, repeatably.

The spec is named in `test:e2e:ci-smoke` on purpose: nothing in CI runs the `e2e/` glob, so an unnamed guard would report green while the regression ships.

Also run: `npm run typecheck` clean, `npm run test:dom` 246/246, ~450 related unit tests green, biome clean. `e2e/live-media-intent.spec.ts` covers the *disable* path — it fails identically with and without this change (6 failures on baseline, 5 here); those tests need live YouTube/webcam access from the runner.

The new mission-preset assertion was mutation-checked: removing the `applyPanelSettings()` call from `applyMissionPreset` turns it red.

Fixes #6379

Related: #6380 — the SOURCES tab has a different cause for the same complaint (a source toggle is persisted but nothing triggers a refetch, so it lands at the next 20-minute feed tick). Deliberately not folded in here: the fix needs a debounced refetch to stay inside the news request budget guarded by #5376.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
