### PR TITLE
fix(analytics): keep Umami storage warnings non-fatal

### DIFF
--- a/docs/analytics-collector-operations.md
+++ b/docs/analytics-collector-operations.md
@@ -255,11 +255,16 @@ write canary is green.
 
 `.github/workflows/umami-storage-monitor.yml` reads the Railway volume list
 without mutating Railway or Postgres. It caches at most 30 days of samples and
-fails the workflow when either condition is true:
+reports the following capacity conditions:
 
 - current usage is at least 80% (warning) or 90% (critical); or
 - projected days to full are at most 30 (warning) or 14 (critical), once a
   24-hour growth baseline exists.
+
+A warning emits a GitHub annotation but leaves the scheduled workflow green so
+the 15-minute probe does not send repeated failed-run alerts during a bounded
+retention drain. A critical condition fails the workflow. Input, Railway, or
+state-processing errors also fail closed.
 
 The monitor prints only volume size, growth, and projected headroom. It never
 prints Railway variables, database URLs, analytics payloads, or user identity

--- a/scripts/check-umami-storage.mjs
+++ b/scripts/check-umami-storage.mjs
@@ -220,7 +220,6 @@ async function main() {
     process.exitCode = 1;
   } else if (result.status === 'warning') {
     console.error('::warning::Umami Postgres storage needs retention or capacity action before the next threshold.');
-    process.exitCode = 1;
   }
 }
 

--- a/tests/umami-storage-monitor.test.mjs
+++ b/tests/umami-storage-monitor.test.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import YAML from 'yaml';
 
@@ -12,6 +16,10 @@ import {
 } from '../scripts/check-umami-storage.mjs';
 
 const NOW = Date.parse('2026-08-01T12:00:00.000Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+const storageCheckScript = fileURLToPath(
+  new URL('../scripts/check-umami-storage.mjs', import.meta.url),
+);
 const workflowSource = readFileSync(
   new URL('../.github/workflows/umami-storage-monitor.yml', import.meta.url),
   'utf8',
@@ -28,6 +36,32 @@ function volume(overrides = {}) {
     status: 'Ready',
     ...overrides,
   };
+}
+
+function runStorageCheckCli({ currentSizeMB, samples = [], volumeOverrides = {} }) {
+  const directory = mkdtempSync(join(tmpdir(), 'wm-umami-storage-monitor-'));
+  const inputPath = join(directory, 'volumes.json');
+  const statePath = join(directory, 'state.json');
+
+  try {
+    writeFileSync(inputPath, JSON.stringify([volume({ currentSizeMB, ...volumeOverrides })]));
+    writeFileSync(statePath, JSON.stringify({
+      version: 1,
+      volumeIdentity: 'volume-1',
+      capacityMB: 50_000,
+      samples,
+    }));
+    return spawnSync(
+      process.execPath,
+      [storageCheckScript, '--input', inputPath, '--state', statePath],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, UMAMI_POSTGRES_SERVICE_NAME: 'Postgres Umami' },
+      },
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 }
 
 describe('Umami storage monitor', () => {
@@ -83,6 +117,38 @@ describe('Umami storage monitor', () => {
     assert.equal(result.usagePercent, 90);
     assert.equal(result.status, 'critical');
     assert.equal(result.alerting, true);
+  });
+
+  it('reports a capacity warning without failing the scheduled workflow', () => {
+    const run = runStorageCheckCli({
+      currentSizeMB: 28_000,
+      samples: [{
+        sampledAt: new Date(Date.now() - 7 * DAY_MS).toISOString(),
+        currentSizeMB: 22_800,
+      }],
+    });
+
+    assert.equal(run.status, 0, run.stderr);
+    assert.match(run.stdout, /Umami storage warning:/);
+    assert.match(run.stderr, /::warning::Umami Postgres storage needs retention or capacity action/);
+  });
+
+  it('fails the scheduled workflow at critical capacity', () => {
+    const run = runStorageCheckCli({ currentSizeMB: 45_000 });
+
+    assert.equal(run.status, 1);
+    assert.match(run.stdout, /Umami storage critical:/);
+    assert.match(run.stderr, /::error::Umami Postgres storage is at a critical capacity/);
+  });
+
+  it('fails the scheduled workflow when Railway volume processing fails', () => {
+    const run = runStorageCheckCli({
+      currentSizeMB: 28_000,
+      volumeOverrides: { status: 'Failed' },
+    });
+
+    assert.equal(run.status, 1);
+    assert.match(run.stderr, /Umami storage monitor failed: Umami volume is not ready: Failed/);
   });
 
   it('fails closed when Railway reports a non-ready volume', () => {


### PR DESCRIPTION
## Summary

The Umami storage monitor no longer sends failed-run alerts for a valid warning state during a known retention drain. The warning stays visible as a GitHub annotation, while critical capacity and evaluation failures still fail the job.

## Validation

- Exercised the production CLI boundary: warning exits 0; critical capacity and Railway volume-processing failures exit 1.
- `tests/umami-storage-monitor.test.mjs`: 13 passed.
- `npm run typecheck` and the repository pre-push gate passed.
- `npm run lint` passed with the repository's existing warnings outside this diff.

## Post-Deploy Monitoring & Validation

- Observe at least two scheduled 15-minute monitor runs after deployment.
- Expected: a warning run is green, retains its `::warning::` annotation, and saves the updated cache state.
- Failure signal: a warning run is red, its annotation disappears, or the cache state stops advancing. Critical capacity or evaluation errors must remain red.
- Rollback: revert this commit if warning visibility or fail-closed critical/error behavior regresses.
- Owner: WorldMonitor operations.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
