### PR TITLE
feat(company-monitoring): add durable scan orchestration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -423,6 +423,13 @@ CONVEX_SITE_URL=
 # environment together (a one-sided rotation breaks the fallback for live users).
 CONVEX_SERVER_SHARED_SECRET=
 
+# Shared secret for the always-on Railway Company Monitoring scan worker.
+# Set the same value as COMPANY_MONITORING_WORKER_SECRET in the Convex
+# deployment. The worker uses it only for targetless claim/finalize mutations;
+# never expose it to Vite or log it.
+# Generate: openssl rand -hex 32
+COMPANY_MONITORING_WORKER_SECRET=
+
 # Vite-exposed Convex URL for frontend entitlement service (VITE_ prefix required for client-side access)
 VITE_CONVEX_URL=
 

--- a/api/health.js
+++ b/api/health.js
@@ -220,6 +220,9 @@ const BOOTSTRAP_KEYS = {
 
 const STANDALONE_KEYS = {
   chinaCoverage:      CHINA_COVERAGE_SUMMARY_KEY,
+  // Control-plane heartbeat only. Convex owns every durable scan lease,
+  // checkpoint, receipt, and replay decision; this Redis value is disposable.
+  companyMonitoringWorker: 'company-monitoring:worker-health:v1',
   // Seeded and health-monitored; no dashboard consumer yet (#6155 is the
   // data layer only), so it is standalone rather than bootstrap-tiered.
   chinaStockConnect:  'market:china:stock-connect:v1',
@@ -429,6 +432,9 @@ const SEED_META = {
   // a full hour below the 6h data-expiry floor.
   humanitarianSummary: { key: 'seed-meta:conflict:humanitarian',  maxStaleMin: 300, minRecordCount: 23 },
   chinaCoverage:   { key: 'seed-meta:health:china-coverage',   maxStaleMin: 180 },
+  // Always-on loop publishes every few seconds. Five minutes tolerates deploy
+  // churn while still detecting a stopped worker well before leases age out.
+  companyMonitoringWorker: { key: 'seed-meta:company-monitoring:worker', maxStaleMin: 5, workerControl: true },
   earthquakes:      { key: 'seed-meta:seismology:earthquakes',  maxStaleMin: 30 },
   wildfires:        { key: 'seed-meta:wildfire:fires',          maxStaleMin: 360 }, // FIRMS NRT resets at midnight UTC; new-day data takes 3-6h to accumulate
   wildfiresBootstrap: { key: 'seed-meta:wildfire:fires-bootstrap', maxStaleMin: 360 }, // Compact CDN payload is a distinct publish target; monitor it so canonical fallback cannot hide transform/write failures.
@@ -878,6 +884,9 @@ const ON_DEMAND_KEYS = new Set([
   // activation marker after its first successful publish; after that, a
   // missing/stale summary is strict forever.
   'chinaCoverage',
+  // Deployment-order bridge. The worker writes a permanent activation marker
+  // on its first healthy loop report; absence becomes strict immediately after.
+  'companyMonitoringWorker',
   // Same deployment-order bridge as chinaCoverage: Vercel can ship this reader
   // before seed-bundle-macro's next 08:00 UTC tick publishes the first CBR
   // table, and the every-15-minute freshness monitor would otherwise report an
@@ -947,6 +956,7 @@ const ON_DEMAND_KEYS = new Set([
 // normal EMPTY/STALE_SEED rules apply.
 const ACTIVATION_MARKERS = {
   chinaCoverage: 'seed-activated:health:china-coverage',
+  companyMonitoringWorker: 'seed-activated:company-monitoring:worker',
   // Written by scripts/seed-cbr-rates.mjs (CBR_ACTIVATION_KEY) in runSeed's
   // afterPublish hook, so it exists only once a real table has been published.
   cbrRates: 'seed-activated:economic:cbr-rates',
@@ -1201,14 +1211,37 @@ const TRADE_FLOW_DOMINANT_FAILURE_MODES = new Set([
   'run-failed', 'upstream', 'empty', 'incomplete-years', 'mixed', 'none',
 ]);
 
+const COMPANY_MONITORING_WORKER_STATUSES = new Set(['ok', 'error']);
+const COMPANY_MONITORING_WORKER_OUTCOMES = new Set([
+  'starting', 'disabled', 'idle', 'completed', 'non_reassuring', 'fenced',
+  'replayed', 'claim_error', 'finalize_error',
+]);
+const COMPANY_MONITORING_WORKER_COUNTERS = Object.freeze([
+  'loops', 'claims', 'completed', 'nonReassuring', 'fenced', 'replayed',
+  'executorErrors', 'claimErrors', 'finalizeErrors',
+]);
+
+function projectCompanyMonitoringWorkerControl(meta, enabled) {
+  if (!enabled || !COMPANY_MONITORING_WORKER_STATUSES.has(meta?.status)
+    || !COMPANY_MONITORING_WORKER_OUTCOMES.has(meta?.outcome)) return null;
+  const counters = {};
+  for (const name of COMPANY_MONITORING_WORKER_COUNTERS) {
+    const value = meta?.counters?.[name];
+    counters[name] = Number.isSafeInteger(value) && value >= 0
+      ? Math.min(value, 9_999_999_999)
+      : 0;
+  }
+  return { status: meta.status, outcome: meta.outcome, counters };
+}
+
 function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (!seedCfg) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null, coverage: null, synthesisFailure: null, dominantFailureMode: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null, coverage: null, synthesisFailure: null, dominantFailureMode: null, workerControl: null };
   }
   // Per-command Redis errors on the GET seed-meta half of the pipeline must
   // not silently fall through to STALE_SEED — promote to REDIS_PARTIAL.
   if (keyMetaErrors.get(seedCfg.key)) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null, coverage: null, synthesisFailure: null, dominantFailureMode: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null, coverage: null, synthesisFailure: null, dominantFailureMode: null, workerControl: null };
   }
   // Unwrap through the envelope helper. Legacy seed-meta is a bare
   // `{ fetchedAt, recordCount, sourceVersion, status? }` object with no `_seed`
@@ -1222,6 +1255,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
     && /^[A-Z0-9_]{1,64}$/.test(meta.errorCode)
     ? meta.errorCode
     : null;
+  const workerControl = projectCompanyMonitoringWorkerControl(meta, seedCfg.workerControl);
   if (meta?.status === 'error') {
     return {
       hasMeta: true,
@@ -1240,6 +1274,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       errorCode,
       synthesisFailure: null,
       dominantFailureMode: null,
+      workerControl,
     };
   }
   let seedAge = null;
@@ -1418,6 +1453,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
     errorCode,
     synthesisFailure,
     dominantFailureMode,
+    workerControl,
   };
 }
 
@@ -1513,6 +1549,7 @@ function classifyKey(name, redisKey, opts, ctx) {
     errorCode,
     synthesisFailure,
     dominantFailureMode,
+    workerControl,
   } = meta;
 
   // Pending activation: the producer has never published a contentFreshness
@@ -1742,6 +1779,9 @@ function classifyKey(name, redisKey, opts, ctx) {
   // it on the fault verdict would hide exactly the "healthy-looking partial"
   // case. Mirrors the ungated synthesisFailure emission below.
   if (dominantFailureMode) entry.dominantFailureMode = dominantFailureMode;
+  // Closed, bounded projection from the worker's seed-meta. It contains only
+  // control-loop state and counters, never work or customer identifiers.
+  if (workerControl) entry.workerControl = workerControl;
   // Surface content-age fields when seeder opted in (presence of
   // meta.maxContentAgeMin). Operators can distinguish "stale content" from
   // "stale seeder run" at a glance.

--- a/convex/__tests__/companyMonitoringLifecycleOrchestration.test.ts
+++ b/convex/__tests__/companyMonitoringLifecycleOrchestration.test.ts
@@ -11,7 +11,7 @@ import {
   OWNER_A,
   schema,
   setStoredEntitlement,
-} from "./companyMonitoringTestHelpers";
+} from "./companyMonitoring.helpers";
 
 const ORCHESTRATION = (CM as any).orchestration;
 const DAY_MS = 24 * 60 * 60 * 1000;

--- a/convex/__tests__/companyMonitoringLifecycleOrchestration.test.ts
+++ b/convex/__tests__/companyMonitoringLifecycleOrchestration.test.ts
@@ -1,0 +1,199 @@
+import { convexTest } from "convex-test";
+import { describe, expect, test, vi } from "vitest";
+import {
+  accountFor,
+  CM,
+  company,
+  grantProvisioned,
+  installCompanyMonitoringTestEnvironment,
+  modules,
+  NOW,
+  OWNER_A,
+  schema,
+  setStoredEntitlement,
+} from "./companyMonitoringTestHelpers";
+
+const ORCHESTRATION = (CM as any).orchestration;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+installCompanyMonitoringTestEnvironment();
+
+async function createCompany(t: ReturnType<typeof convexTest>, name: string) {
+  const created = await t.mutation(CM.companies.createCompanyForOwner, {
+    ownerUserId: OWNER_A,
+    clientRequestId: `request-${name}`,
+    company: company(name, `customer-${name}`),
+  });
+  const account = await accountFor(t, OWNER_A);
+  return { account: account!, companyId: created.companyId };
+}
+
+async function scanRows(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => ({
+    obligations: await ctx.db.query("companyMonitoringScanObligations").collect(),
+    work: await ctx.db.query("companyMonitoringScanWorkItems").collect(),
+  }));
+}
+
+describe("Company Monitoring lifecycle scan integration", () => {
+  test("creation materializes trusted source scheduling while public provider flags remain dark", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const created = await createCompany(t, "Lifecycle Queue");
+
+    expect(await t.mutation(ORCHESTRATION.scheduleCompanySources, {
+      ownerAccountId: created.account.logicalAccountId,
+      companyId: created.companyId,
+    })).toEqual({ status: "replayed", sources: 2 });
+    const rows = await scanRows(t);
+    expect(rows.obligations).toHaveLength(2);
+    expect(rows.obligations.every((row) => row.state === "due")).toBe(true);
+    expect(rows.work).toHaveLength(2);
+  });
+
+  test("removal immediately cancels due and leased work, fences stale holders, and purges scan state first", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const created = await createCompany(t, "Lease Removal");
+    await t.mutation(ORCHESTRATION.scheduleCompanySources, {
+      ownerAccountId: created.account.logicalAccountId,
+      companyId: created.companyId,
+    });
+    const claim = await t.mutation(ORCHESTRATION.claimNextWorkForTest, {
+      workerId: "lifecycle-worker",
+    });
+    expect(claim.status).toBe("claimed");
+
+    await expect(t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "removed",
+    })).resolves.toMatchObject({ status: "removed" });
+
+    const removed = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q
+            .eq("ownerAccountId", created.account.logicalAccountId)
+            .eq("companyId", created.companyId),
+        )
+        .unique()
+    );
+    expect(removed).toMatchObject({ lifecycle: "removed", purgePhase: "scan" });
+    const cancelled = await scanRows(t);
+    expect(cancelled.work.every((row) => row.state === "cancelled")).toBe(true);
+    expect(cancelled.obligations.every((row) =>
+      row.state === "cancelled" && row.reason === "company_removed"
+    )).toBe(true);
+    expect(await t.mutation(ORCHESTRATION.finalizeWorkForTest, {
+      workerId: "lifecycle-worker",
+      workId: claim.work.workId,
+      leaseToken: claim.work.leaseToken,
+      result: {
+        type: "provider_error",
+        reason: "timeout",
+        costUsdMicros: 0,
+      },
+    })).toEqual({ status: "fenced" });
+
+    expect(await t.mutation(CM.companies.advanceCompanyPurge, {
+      ownerAccountId: created.account.logicalAccountId,
+      companyId: created.companyId,
+      purgeGeneration: removed!.purgeGeneration,
+    })).toEqual({ status: "complete" });
+    expect(await scanRows(t)).toEqual({ obligations: [], work: [] });
+    const purged = await t.run(async (ctx) => ctx.db.get(removed!._id));
+    expect(purged).toMatchObject({ purgePhase: "complete" });
+    expect(purged?.name).toBeUndefined();
+  });
+
+  test("removing one company cancels its shared cohort but preserves and requeues the active peer", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const first = await createCompany(t, "Shared First");
+    const second = await createCompany(t, "Shared Second");
+    await t.run(async (ctx) => {
+      for (const row of await ctx.db.query("companyMonitoringScanObligations").collect()) {
+        await ctx.db.delete(row._id);
+      }
+      for (const row of await ctx.db.query("companyMonitoringScanWorkItems").collect()) {
+        await ctx.db.delete(row._id);
+      }
+      await ctx.db.patch(first.account._id, {
+        nextScanDueAt: undefined,
+        nextExaScanDueAt: undefined,
+        nextXScanDueAt: undefined,
+      });
+    });
+    await t.mutation(ORCHESTRATION.scheduleAccountWork, {
+      ownerAccountId: first.account.logicalAccountId,
+      source: "exa",
+      companyIds: [first.companyId, second.companyId],
+    });
+
+    await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: first.companyId,
+      state: "removed",
+    });
+    const beforeRequeue = await scanRows(t);
+    expect(beforeRequeue.work).toHaveLength(1);
+    expect(beforeRequeue.work[0]).toMatchObject({ state: "cancelled" });
+    expect(beforeRequeue.obligations.find((row) => row.companyId === second.companyId))
+      .toMatchObject({ state: "cancelled", reason: "superseded" });
+
+    await t.mutation(ORCHESTRATION.scheduleCompanySources, {
+      ownerAccountId: first.account.logicalAccountId,
+      companyId: second.companyId,
+    });
+    const afterRequeue = await scanRows(t);
+    expect(afterRequeue.obligations.find((row) =>
+      row.companyId === second.companyId && row.source === "exa"
+    )).toMatchObject({ state: "due" });
+    const secondRow = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", first.account.logicalAccountId).eq("companyId", second.companyId),
+        )
+        .unique()
+    );
+    expect(secondRow).toMatchObject({ lifecycle: "active", name: "Shared Second" });
+  });
+
+  test("account destructive purge clears durable scan state before company payloads", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const created = await createCompany(t, "Account Scan Purge");
+    for (let index = 1; index < 5; index += 1) {
+      await createCompany(t, `Account Scan Purge ${index}`);
+    }
+    expect((await scanRows(t)).work).toHaveLength(10);
+
+    await setStoredEntitlement(t, OWNER_A, "free", NOW - 1);
+    const lapsed = await accountFor(t, OWNER_A);
+    vi.setSystemTime(NOW + DAY_MS);
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, {
+      ownerFenceHash: lapsed!.ownerFenceHash,
+      purgeGeneration: lapsed!.purgeGeneration,
+    })).toEqual({ status: "started" });
+
+    expect(await accountFor(t, OWNER_A)).toMatchObject({ purgePhase: "scan" });
+    expect((await scanRows(t)).work).toHaveLength(2);
+    expect(await t.mutation(CM.accounts.advanceAccountPurge, {
+      ownerFenceHash: lapsed!.ownerFenceHash,
+      purgeGeneration: lapsed!.purgeGeneration,
+    })).toEqual({ status: "companies" });
+    expect(await scanRows(t)).toEqual({ obligations: [], work: [] });
+    const companyBeforePayload = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", created.account.logicalAccountId).eq("companyId", created.companyId),
+        )
+        .unique()
+    );
+    expect(companyBeforePayload).toMatchObject({ name: "Account Scan Purge", purgePhase: "none" });
+  });
+});

--- a/convex/__tests__/companyMonitoringLifecycleOrchestration.test.ts
+++ b/convex/__tests__/companyMonitoringLifecycleOrchestration.test.ts
@@ -76,6 +76,58 @@ describe("Company Monitoring lifecycle scan integration", () => {
     expect(rows.work).toHaveLength(2);
   });
 
+  test.each([
+    ["complete", "completed"],
+    ["non_reassuring", "non_reassuring"],
+  ] as const)("same-hour reactivation replaces a %s terminal work-key collision", async (
+    terminalState,
+    expectedStatus,
+  ) => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const created = await createCompany(
+      t,
+      `Same Hour Reactivation ${terminalState.replace("_", " ")}`,
+    );
+
+    const firstClaim = await t.mutation(ORCHESTRATION.claimNextWorkForTest, {
+      workerId: "lifecycle-worker",
+    });
+    expect(firstClaim).toMatchObject({ status: "claimed", work: { source: "exa" } });
+    const finalized = terminalState === "complete"
+      ? await finalizeComplete(t, firstClaim)
+      : await t.mutation(ORCHESTRATION.finalizeWorkForTest, {
+        workerId: "lifecycle-worker",
+        workId: firstClaim.work.workId,
+        leaseToken: firstClaim.work.leaseToken,
+        result: { type: "provider_error", reason: "timeout", costUsdMicros: 10 },
+      });
+    expect(finalized).toMatchObject({ status: expectedStatus });
+
+    expect(await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "paused",
+    })).toMatchObject({ status: "paused" });
+    expect(await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "active",
+    })).toMatchObject({ status: "active" });
+    await t.mutation(ORCHESTRATION.scheduleCompanySources, {
+      ownerAccountId: created.account.logicalAccountId,
+      companyId: created.companyId,
+    });
+
+    const rows = await scanRows(t);
+    const exaObligation = rows.obligations.find((row) => row.source === "exa");
+    expect(exaObligation).toMatchObject({ state: "due" });
+    expect(exaObligation?.workId).not.toBe(firstClaim.work.workId);
+    expect(await t.mutation(ORCHESTRATION.claimNextWorkForTest, {
+      workerId: "lifecycle-worker",
+    })).toMatchObject({ status: "claimed", work: { source: "exa" } });
+  });
+
   test("removal immediately cancels due and leased work, fences stale holders, and purges scan state first", async () => {
     const t = convexTest(schema, modules);
     await grantProvisioned(t, OWNER_A);
@@ -222,6 +274,52 @@ describe("Company Monitoring lifecycle scan integration", () => {
     })).toEqual({ status: "complete" });
     expect(await scanRows(t)).toEqual({ obligations: [], work: [] });
     expect(await receiptLinks(t)).toEqual([]);
+  });
+
+  test("company purge resumes after a full terminal receipt-link page", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const created = await createCompany(t, "Paged Receipt Purge");
+
+    for (let scan = 0; scan < 17; scan += 1) {
+      vi.setSystemTime(NOW + scan * DAY_MS);
+      const claim = await t.mutation(ORCHESTRATION.claimNextWorkForTest, {
+        workerId: "lifecycle-worker",
+      });
+      expect(claim).toMatchObject({ status: "claimed", work: { source: "exa" } });
+      expect(await finalizeComplete(t, claim)).toMatchObject({ status: "completed" });
+    }
+    expect(await receiptLinks(t)).toHaveLength(17);
+
+    await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "removed",
+    });
+    const removed = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q
+            .eq("ownerAccountId", created.account.logicalAccountId)
+            .eq("companyId", created.companyId),
+        )
+        .unique()
+    );
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
+    expect(await t.run(async (ctx) => ctx.db.get(removed!._id)))
+      .toMatchObject({ name: "Paged Receipt Purge", purgePhase: "scan" });
+    expect(await receiptLinks(t)).toHaveLength(1);
+
+    vi.advanceTimersByTime(1);
+    await t.finishInProgressScheduledFunctions();
+
+    const purged = await t.run(async (ctx) => ctx.db.get(removed!._id));
+    expect(purged).toMatchObject({ purgePhase: "complete" });
+    expect(purged?.name).toBeUndefined();
+    expect(await receiptLinks(t)).toEqual([]);
+    expect(await scanRows(t)).toEqual({ obligations: [], work: [] });
   });
 
   test("shared terminal receipt survives one member purge and leaves with its final member", async () => {

--- a/convex/__tests__/companyMonitoringLifecycleOrchestration.test.ts
+++ b/convex/__tests__/companyMonitoringLifecycleOrchestration.test.ts
@@ -186,6 +186,10 @@ describe("Company Monitoring lifecycle scan integration", () => {
       purgeGeneration: lapsed!.purgeGeneration,
     })).toEqual({ status: "companies" });
     expect(await scanRows(t)).toEqual({ obligations: [], work: [] });
+    const scanClearedAccount = await accountFor(t, OWNER_A);
+    expect(scanClearedAccount?.nextScanDueAt).toBeUndefined();
+    expect(scanClearedAccount?.nextExaScanDueAt).toBeUndefined();
+    expect(scanClearedAccount?.nextXScanDueAt).toBeUndefined();
     const companyBeforePayload = await t.run(async (ctx) =>
       ctx.db
         .query("companyMonitoringCompanies")

--- a/convex/__tests__/companyMonitoringLifecycleOrchestration.test.ts
+++ b/convex/__tests__/companyMonitoringLifecycleOrchestration.test.ts
@@ -35,6 +35,31 @@ async function scanRows(t: ReturnType<typeof convexTest>) {
   }));
 }
 
+async function receiptLinks(t: ReturnType<typeof convexTest>) {
+  return t.run(async (ctx) => ctx.db.query("companyMonitoringScanReceiptLinks").collect());
+}
+
+async function finalizeComplete(t: ReturnType<typeof convexTest>, claim: any) {
+  return t.mutation(ORCHESTRATION.finalizeWorkForTest, {
+    workerId: "lifecycle-worker",
+    workId: claim.work.workId,
+    leaseToken: claim.work.leaseToken,
+    result: {
+      type: "result",
+      itemCount: 1,
+      hasMore: false,
+      coverage: "complete",
+      returnedRange: {
+        startAt: claim.work.windowStart,
+        endAt: claim.work.windowEnd,
+      },
+      checkpoint: `checkpoint-${claim.work.workId}`,
+      emptyValidated: false,
+      costUsdMicros: 10,
+    },
+  });
+}
+
 describe("Company Monitoring lifecycle scan integration", () => {
   test("creation materializes trusted source scheduling while public provider flags remain dark", async () => {
     const t = convexTest(schema, modules);
@@ -121,7 +146,6 @@ describe("Company Monitoring lifecycle scan integration", () => {
         await ctx.db.delete(row._id);
       }
       await ctx.db.patch(first.account._id, {
-        nextScanDueAt: undefined,
         nextExaScanDueAt: undefined,
         nextXScanDueAt: undefined,
       });
@@ -162,6 +186,123 @@ describe("Company Monitoring lifecycle scan integration", () => {
     expect(secondRow).toMatchObject({ lifecycle: "active", name: "Shared Second" });
   });
 
+  test("company purge removes current scan state and its retained terminal receipts", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const created = await createCompany(t, "Receipt Purge");
+    await t.mutation(ORCHESTRATION.scheduleCompanySources, {
+      ownerAccountId: created.account.logicalAccountId,
+      companyId: created.companyId,
+    });
+    const claim = await t.mutation(ORCHESTRATION.claimNextWorkForTest, {
+      workerId: "lifecycle-worker",
+    });
+    expect(await finalizeComplete(t, claim)).toMatchObject({ status: "completed" });
+    expect(await receiptLinks(t)).toHaveLength(1);
+
+    await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: created.companyId,
+      state: "removed",
+    });
+    const removed = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q
+            .eq("ownerAccountId", created.account.logicalAccountId)
+            .eq("companyId", created.companyId),
+        )
+        .unique()
+    );
+    expect(await t.mutation(CM.companies.advanceCompanyPurge, {
+      ownerAccountId: created.account.logicalAccountId,
+      companyId: created.companyId,
+      purgeGeneration: removed!.purgeGeneration,
+    })).toEqual({ status: "complete" });
+    expect(await scanRows(t)).toEqual({ obligations: [], work: [] });
+    expect(await receiptLinks(t)).toEqual([]);
+  });
+
+  test("shared terminal receipt survives one member purge and leaves with its final member", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const first = await createCompany(t, "Receipt Shared First");
+    const second = await createCompany(t, "Receipt Shared Second");
+    await t.run(async (ctx) => {
+      for (const row of await ctx.db.query("companyMonitoringScanObligations").collect()) {
+        await ctx.db.delete(row._id);
+      }
+      for (const row of await ctx.db.query("companyMonitoringScanWorkItems").collect()) {
+        await ctx.db.delete(row._id);
+      }
+      await ctx.db.patch(first.account._id, {
+        nextExaScanDueAt: undefined,
+        nextXScanDueAt: undefined,
+      });
+    });
+    await t.mutation(ORCHESTRATION.scheduleAccountWork, {
+      ownerAccountId: first.account.logicalAccountId,
+      source: "exa",
+      companyIds: [first.companyId, second.companyId],
+    });
+    const claim = await t.mutation(ORCHESTRATION.claimNextWorkForTest, {
+      workerId: "lifecycle-worker",
+    });
+    expect(await finalizeComplete(t, claim)).toMatchObject({ status: "completed" });
+    expect(await receiptLinks(t)).toHaveLength(2);
+
+    await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: first.companyId,
+      state: "removed",
+    });
+    const removedFirst = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", first.account.logicalAccountId).eq("companyId", first.companyId),
+        )
+        .unique()
+    );
+    expect(await t.mutation(CM.companies.advanceCompanyPurge, {
+      ownerAccountId: first.account.logicalAccountId,
+      companyId: first.companyId,
+      purgeGeneration: removedFirst!.purgeGeneration,
+    })).toEqual({ status: "complete" });
+    expect(await receiptLinks(t)).toMatchObject([{
+      companyId: second.companyId,
+      workId: claim.work.workId,
+    }]);
+    expect(await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringScanWorkItems")
+        .withIndex("by_workId", (q) => q.eq("workId", claim.work.workId))
+        .unique()
+    )).toMatchObject({ state: "complete" });
+
+    await t.mutation(CM.companies.setCompanyStateForOwner, {
+      ownerUserId: OWNER_A,
+      companyId: second.companyId,
+      state: "removed",
+    });
+    const removedSecond = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", first.account.logicalAccountId).eq("companyId", second.companyId),
+        )
+        .unique()
+    );
+    expect(await t.mutation(CM.companies.advanceCompanyPurge, {
+      ownerAccountId: first.account.logicalAccountId,
+      companyId: second.companyId,
+      purgeGeneration: removedSecond!.purgeGeneration,
+    })).toEqual({ status: "complete" });
+    expect(await receiptLinks(t)).toEqual([]);
+    expect(await scanRows(t)).toEqual({ obligations: [], work: [] });
+  });
+
   test("account destructive purge clears durable scan state before company payloads", async () => {
     const t = convexTest(schema, modules);
     await grantProvisioned(t, OWNER_A);
@@ -187,7 +328,6 @@ describe("Company Monitoring lifecycle scan integration", () => {
     })).toEqual({ status: "companies" });
     expect(await scanRows(t)).toEqual({ obligations: [], work: [] });
     const scanClearedAccount = await accountFor(t, OWNER_A);
-    expect(scanClearedAccount?.nextScanDueAt).toBeUndefined();
     expect(scanClearedAccount?.nextExaScanDueAt).toBeUndefined();
     expect(scanClearedAccount?.nextXScanDueAt).toBeUndefined();
     const companyBeforePayload = await t.run(async (ctx) =>

--- a/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
+++ b/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
@@ -1,5 +1,7 @@
 import { convexTest } from "convex-test";
 import { describe, expect, test } from "vitest";
+import { normalizeCompanyImportBatch } from "../../shared/company-monitoring-contract";
+import { fingerprint } from "../companyMonitoring/_shared";
 import {
   accountFor,
   CM,
@@ -178,6 +180,18 @@ describe("bounded onboarding and replay", () => {
             .eq("companyId", firstCompanyId!),
         )
         .collect(),
+      obligations: await ctx.db
+        .query("companyMonitoringScanObligations")
+        .withIndex("by_account_company_source", (q) =>
+          q.eq("ownerAccountId", root!.logicalAccountId),
+        )
+        .collect(),
+      work: await ctx.db
+        .query("companyMonitoringScanWorkItems")
+        .withIndex("by_account_state_selectionDueAt", (q) =>
+          q.eq("ownerAccountId", root!.logicalAccountId).eq("state", "due"),
+        )
+        .collect(),
     }));
     expect(stored.companies).toHaveLength(100);
     expect(stored.companies.every((row) =>
@@ -187,6 +201,8 @@ describe("bounded onboarding and replay", () => {
     expect(stored.firstCompanyClaims).toEqual(expect.arrayContaining([
       expect.objectContaining({ type: "domain", value: "batch-0.example" }),
     ]));
+    expect(stored.obligations).toHaveLength(200);
+    expect(stored.work).toHaveLength(8);
 
     const replayed = await t.action(CM.imports.importCompaniesForOwner, {
       ownerUserId: OWNER_A,
@@ -200,6 +216,49 @@ describe("bounded onboarding and replay", () => {
       Array.from({ length: 100 }, () => "replayed"),
     );
     expect(await accountFor(t, OWNER_A)).toMatchObject({ companyCount: 100 });
+    expect(await t.run(async (ctx) => ({
+      obligations: (await ctx.db.query("companyMonitoringScanObligations").collect()).length,
+      work: (await ctx.db.query("companyMonitoringScanWorkItems").collect()).length,
+    }))).toEqual({ obligations: 200, work: 8 });
+  });
+
+  test("an import retry heals rows committed before scan scheduling without duplicates", async () => {
+    const t = convexTest(schema, modules);
+    await grantProvisioned(t, OWNER_A);
+    const rows = [0, 1].map((ordinal) => ({
+      ...company(`Interrupted Batch ${ordinal}`, `interrupted-${ordinal}`),
+      clientImportId: "interrupted-scan-batch",
+      ordinal,
+    }));
+    const normalizedRows = normalizeCompanyImportBatch(rows);
+    for (const row of normalizedRows) {
+      await t.mutation(CM.imports.importCompanyRowForOwner, {
+        ownerUserId: OWNER_A,
+        row,
+        rowFingerprint: await fingerprint(row),
+      });
+    }
+    expect(await t.run(async (ctx) => ({
+      obligations: (await ctx.db.query("companyMonitoringScanObligations").collect()).length,
+      work: (await ctx.db.query("companyMonitoringScanWorkItems").collect()).length,
+    }))).toEqual({ obligations: 0, work: 0 });
+
+    const retry = await t.action(CM.imports.importCompaniesForOwner, {
+      ownerUserId: OWNER_A,
+      rows,
+    });
+    expect(retry.results.map((row: any) => row.status)).toEqual(["replayed", "replayed"]);
+    const healed = await t.run(async (ctx) => ({
+      obligations: (await ctx.db.query("companyMonitoringScanObligations").collect()).length,
+      work: (await ctx.db.query("companyMonitoringScanWorkItems").collect()).length,
+    }));
+    expect(healed).toEqual({ obligations: 4, work: 2 });
+
+    await t.action(CM.imports.importCompaniesForOwner, { ownerUserId: OWNER_A, rows });
+    expect(await t.run(async (ctx) => ({
+      obligations: (await ctx.db.query("companyMonitoringScanObligations").collect()).length,
+      work: (await ctx.db.query("companyMonitoringScanWorkItems").collect()).length,
+    }))).toEqual(healed);
   });
 
   test("committed direct and import rows replay, changed tuples conflict, and no-ops reevaluate", async () => {
@@ -460,7 +519,7 @@ describe("bounded onboarding and replay", () => {
     expect(claims).toEqual([]);
     expect(removedRow).toMatchObject({
       lifecycle: "removed",
-      purgePhase: "payload",
+      purgePhase: "scan",
       name: "Remove Corp",
     });
 

--- a/convex/__tests__/companyMonitoringOrchestration.test.ts
+++ b/convex/__tests__/companyMonitoringOrchestration.test.ts
@@ -12,6 +12,8 @@ const ORCHESTRATION = (internal as any).companyMonitoring.orchestration;
 const PUBLIC_ORCHESTRATION = (api as any).companyMonitoring.orchestration;
 const WORKER_SECRET = "test-company-monitoring-worker-secret";
 const LEASE_MS = 5 * 60 * 1000;
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+const WINDOW_BUCKET_MS = 60 * 60 * 1000;
 const ORIGINAL_WORKER_SECRET = process.env.COMPANY_MONITORING_WORKER_SECRET;
 
 installCompanyMonitoringTestEnvironment();
@@ -116,7 +118,7 @@ async function finalizeComplete(
 }
 
 describe("Company Monitoring durable scan orchestration", () => {
-  test("claims server-shaped work and advances checkpoints only after a valid complete result", async () => {
+  test("claims server-shaped work, advances checkpoints, and durably rearms the next scan", async () => {
     const t = convexTest(schema, modules);
     const seeded = await seedAccountWithCompany(t, "happy", {
       initialCheckpoint: "checkpoint-before",
@@ -154,7 +156,21 @@ describe("Company Monitoring durable scan orchestration", () => {
             .eq("source", "exa"),
         )
         .unique();
-      return { work, obligation };
+      const nextWork = obligation?.workId
+        ? await ctx.db
+          .query("companyMonitoringScanWorkItems")
+          .withIndex("by_workId", (q) => q.eq("workId", obligation.workId!))
+          .unique()
+        : null;
+      const account = await ctx.db
+        .query("companyMonitoringAccounts")
+        .withIndex("by_logicalAccountId", (q) => q.eq("logicalAccountId", seeded.ownerAccountId))
+        .unique();
+      const receiptLinks = await ctx.db
+        .query("companyMonitoringScanReceiptLinks")
+        .withIndex("by_workId", (q) => q.eq("workId", claim.work.workId))
+        .collect();
+      return { work, obligation, nextWork, account, receiptLinks };
     });
     expect(state.work).toMatchObject({
       state: "complete",
@@ -166,20 +182,85 @@ describe("Company Monitoring durable scan orchestration", () => {
       },
     });
     expect(state.obligation).toMatchObject({
-      state: "complete",
+      state: "due",
+      dueAt: NOW + WINDOW_MS,
       checkpoint: `checkpoint-${claim.work.workId}`,
     });
+    expect(state.nextWork).toMatchObject({
+      state: "due",
+      scheduledDueAt: NOW + WINDOW_MS,
+      selectionDueAt: NOW + WINDOW_MS,
+    });
+    expect(state.nextWork?.workId).not.toBe(claim.work.workId);
+    expect(state.account?.nextExaScanDueAt).toBe(NOW + WINDOW_MS);
+    expect(state.receiptLinks).toMatchObject([{
+      ownerAccountId: seeded.ownerAccountId,
+      companyId: seeded.companyId,
+      workId: claim.work.workId,
+    }]);
 
     vi.setSystemTime(NOW + 1_000);
-    expect(await t.mutation(ORCHESTRATION.scheduleAccountWork, {
+    await expect(t.mutation(ORCHESTRATION.scheduleAccountWork, {
       ownerAccountId: seeded.ownerAccountId,
       source: "exa",
       companyIds: [seeded.companyId],
-    })).toEqual({ status: "replayed", workId: claim.work.workId });
+    })).rejects.toThrow(/COMPANY_MONITORING_OBLIGATION_ALREADY_ACTIVE/);
     expect(await t.run(async (ctx) => ({
       workItems: (await ctx.db.query("companyMonitoringScanWorkItems").collect()).length,
       obligations: (await ctx.db.query("companyMonitoringScanObligations").collect()).length,
-    }))).toEqual({ workItems: 1, obligations: 1 });
+    }))).toEqual({ workItems: 2, obligations: 1 });
+  });
+
+  test("rebinds materially old due work to the claim-time scan window", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAccountWithCompany(t, "old_due");
+    const claimAt = NOW + (3 * WINDOW_MS) + (17 * 60 * 1000);
+    vi.setSystemTime(claimAt);
+
+    const claim = await claimForTest(t);
+    const expectedWindowEnd = Math.floor(claimAt / WINDOW_BUCKET_MS) * WINDOW_BUCKET_MS;
+    expect(claim).toMatchObject({
+      status: "claimed",
+      work: {
+        ownerAccountId: seeded.ownerAccountId,
+        windowStart: expectedWindowEnd - WINDOW_MS,
+        windowEnd: expectedWindowEnd,
+      },
+    });
+    const persisted = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringScanWorkItems")
+        .withIndex("by_workId", (q) => q.eq("workId", claim.work.workId))
+        .unique()
+    );
+    expect(persisted).toMatchObject({
+      state: "leased",
+      windowStart: expectedWindowEnd - WINDOW_MS,
+      windowEnd: expectedWindowEnd,
+    });
+  });
+
+  test("duplicate lifecycle scheduling is replay-safe while explicit scheduling stays strict", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAccountWithCompany(t, "lifecycle_replay");
+
+    expect(await t.mutation(ORCHESTRATION.scheduleCompanySources, {
+      ownerAccountId: seeded.ownerAccountId,
+      companyId: seeded.companyId,
+    })).toEqual({ status: "scheduled", sources: 2 });
+    expect(await t.mutation(ORCHESTRATION.scheduleCompanySources, {
+      ownerAccountId: seeded.ownerAccountId,
+      companyId: seeded.companyId,
+    })).toEqual({ status: "replayed", sources: 2 });
+    await expect(t.mutation(ORCHESTRATION.scheduleAccountWork, {
+      ownerAccountId: seeded.ownerAccountId,
+      source: "exa",
+      companyIds: [seeded.companyId],
+    })).rejects.toThrow(/COMPANY_MONITORING_OBLIGATION_ALREADY_ACTIVE/);
+    expect(await t.run(async (ctx) => ({
+      obligations: (await ctx.db.query("companyMonitoringScanObligations").collect()).length,
+      work: (await ctx.db.query("companyMonitoringScanWorkItems").collect()).length,
+    }))).toEqual({ obligations: 2, work: 2 });
   });
 
   test("starts from the indexed account due page and stays bounded beyond 5,000 rows", async () => {
@@ -202,7 +283,6 @@ describe("Company Monitoring durable scan orchestration", () => {
             purgePhase: "none",
             destructivePurgeStarted: false,
             pendingReactivation: false,
-            nextScanDueAt: NOW,
             nextExaScanDueAt: NOW,
             createdAt: NOW + index,
             updatedAt: NOW,
@@ -286,6 +366,12 @@ describe("Company Monitoring durable scan orchestration", () => {
       status: "replayed",
       reason: "complete",
     });
+    expect(await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringScanReceiptLinks")
+        .withIndex("by_workId", (q) => q.eq("workId", replay.work.workId))
+        .collect()
+    )).toHaveLength(1);
   });
 
   test.each([
@@ -304,8 +390,8 @@ describe("Company Monitoring durable scan orchestration", () => {
       status: "non_reassuring",
       reason,
     });
-    const obligation = await t.run(async (ctx) =>
-      ctx.db
+    const state = await t.run(async (ctx) => ({
+      obligation: await ctx.db
         .query("companyMonitoringScanObligations")
         .withIndex("by_account_company_source", (q) =>
           q
@@ -314,11 +400,98 @@ describe("Company Monitoring durable scan orchestration", () => {
             .eq("source", "exa"),
         )
         .unique(),
-    );
-    expect(obligation).toMatchObject({
-      state: "non_reassuring",
-      reason,
+      terminalWork: await ctx.db
+        .query("companyMonitoringScanWorkItems")
+        .withIndex("by_workId", (q) => q.eq("workId", claim.work.workId))
+        .unique(),
+    }));
+    expect(state.obligation).toMatchObject({
+      state: "due",
+      dueAt: NOW + WINDOW_MS,
       checkpoint: "checkpoint-before",
+    });
+    expect(state.terminalWork).toMatchObject({
+      state: "non_reassuring",
+      terminalReceipt: { reason },
+    });
+  });
+
+  test.each([
+    ["blank checkpoint", "   "],
+    ["checkpoint over 512 UTF-8 bytes", "😀".repeat(129)],
+  ])("%s is malformed, preserves the prior checkpoint, and keeps valid receipt cost", async (_label, checkpoint) => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAccountWithCompany(t, `malformed_checkpoint_${checkpoint.length}`, {
+      initialCheckpoint: "checkpoint-before",
+    });
+    const claim = await claimForTest(t);
+
+    expect(await finalizeComplete(t, claim, { checkpoint })).toMatchObject({
+      status: "non_reassuring",
+      reason: "malformed",
+    });
+    const state = await t.run(async (ctx) => ({
+      obligation: await ctx.db
+        .query("companyMonitoringScanObligations")
+        .withIndex("by_account_company_source", (q) =>
+          q
+            .eq("ownerAccountId", seeded.ownerAccountId)
+            .eq("companyId", seeded.companyId)
+            .eq("source", "exa"),
+        )
+        .unique(),
+      terminalWork: await ctx.db
+        .query("companyMonitoringScanWorkItems")
+        .withIndex("by_workId", (q) => q.eq("workId", claim.work.workId))
+        .unique(),
+    }));
+    expect(state.obligation).toMatchObject({
+      state: "due",
+      checkpoint: "checkpoint-before",
+    });
+    expect(state.terminalWork).toMatchObject({
+      state: "non_reassuring",
+      terminalReceipt: { reason: "malformed", costUsdMicros: 125 },
+    });
+  });
+
+  test.each([
+    ["negative", -1],
+    ["above maximum", 1_000_000_000_001],
+  ])("%s cost is malformed, preserves the prior checkpoint, and records zero cost", async (_label, costUsdMicros) => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAccountWithCompany(t, `invalid_cost_${String(costUsdMicros)}`, {
+      initialCheckpoint: "checkpoint-before",
+    });
+    const claim = await claimForTest(t);
+
+    expect(await finalizeComplete(t, claim, { costUsdMicros })).toMatchObject({
+      status: "non_reassuring",
+      reason: "malformed",
+      receipt: { costUsdMicros: 0 },
+    });
+    const state = await t.run(async (ctx) => ({
+      obligation: await ctx.db
+        .query("companyMonitoringScanObligations")
+        .withIndex("by_account_company_source", (q) =>
+          q
+            .eq("ownerAccountId", seeded.ownerAccountId)
+            .eq("companyId", seeded.companyId)
+            .eq("source", "exa"),
+        )
+        .unique(),
+      terminalWork: await ctx.db
+        .query("companyMonitoringScanWorkItems")
+        .withIndex("by_workId", (q) => q.eq("workId", claim.work.workId))
+        .unique(),
+    }));
+    expect(state.obligation).toMatchObject({
+      state: "due",
+      checkpoint: "checkpoint-before",
+    });
+    expect(state.terminalWork).toMatchObject({
+      state: "non_reassuring",
+      terminalReceipt: { reason: "malformed", costUsdMicros: 0 },
     });
   });
 
@@ -347,8 +520,7 @@ describe("Company Monitoring durable scan orchestration", () => {
         .unique(),
     );
     expect(obligation).toMatchObject({
-      state: "non_reassuring",
-      reason: "provider_error",
+      state: "due",
       checkpoint: "checkpoint-before",
     });
   });

--- a/convex/__tests__/companyMonitoringOrchestration.test.ts
+++ b/convex/__tests__/companyMonitoringOrchestration.test.ts
@@ -6,7 +6,7 @@ import {
   modules,
   NOW,
   schema,
-} from "./companyMonitoringTestHelpers";
+} from "./companyMonitoring.helpers";
 
 const ORCHESTRATION = (internal as any).companyMonitoring.orchestration;
 const PUBLIC_ORCHESTRATION = (api as any).companyMonitoring.orchestration;

--- a/convex/__tests__/companyMonitoringOrchestration.test.ts
+++ b/convex/__tests__/companyMonitoringOrchestration.test.ts
@@ -1,0 +1,355 @@
+import { convexTest } from "convex-test";
+import { api, internal } from "../_generated/api";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  installCompanyMonitoringTestEnvironment,
+  modules,
+  NOW,
+  schema,
+} from "./companyMonitoringTestHelpers";
+
+const ORCHESTRATION = (internal as any).companyMonitoring.orchestration;
+const PUBLIC_ORCHESTRATION = (api as any).companyMonitoring.orchestration;
+const WORKER_SECRET = "test-company-monitoring-worker-secret";
+const LEASE_MS = 5 * 60 * 1000;
+const ORIGINAL_WORKER_SECRET = process.env.COMPANY_MONITORING_WORKER_SECRET;
+
+installCompanyMonitoringTestEnvironment();
+
+beforeEach(() => {
+  process.env.COMPANY_MONITORING_WORKER_SECRET = WORKER_SECRET;
+});
+
+afterEach(() => {
+  if (ORIGINAL_WORKER_SECRET === undefined) delete process.env.COMPANY_MONITORING_WORKER_SECRET;
+  else process.env.COMPANY_MONITORING_WORKER_SECRET = ORIGINAL_WORKER_SECRET;
+});
+
+async function seedAccountWithCompany(
+  t: ReturnType<typeof convexTest>,
+  suffix: string,
+  options: { initialCheckpoint?: string } = {},
+) {
+  const ownerAccountId = `cm_account_${suffix}`;
+  const companyId = `cm_company_${suffix.padStart(26, "0").slice(-26)}`;
+  await t.run(async (ctx) => {
+    await ctx.db.insert("companyMonitoringAccounts", {
+      logicalAccountId: ownerAccountId,
+      ownerUserId: `user_${suffix}`,
+      ownerFenceHash: `fence_${suffix}`,
+      lifecycle: "entitled",
+      lifecycleSequence: 1,
+      companyCount: 1,
+      companyLimit: 500,
+      snapshotGeneration: 1,
+      purgeGeneration: 0,
+      purgePhase: "none",
+      destructivePurgeStarted: false,
+      pendingReactivation: false,
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+    await ctx.db.insert("companyMonitoringCompanies", {
+      ownerAccountId,
+      companyId,
+      name: `Company ${suffix}`,
+      sortName: `company ${suffix}`,
+      domicileCountry: "US",
+      lifecycle: "active",
+      coverageState: "awaiting_first_scan",
+      observationState: "unknown",
+      snapshotGeneration: 1,
+      purgeGeneration: 0,
+      purgePhase: "none",
+      createdAt: NOW,
+      updatedAt: NOW,
+    });
+  });
+
+  const scheduled = await t.mutation(ORCHESTRATION.scheduleAccountWork, {
+    ownerAccountId,
+    source: "exa",
+    companyIds: [companyId],
+  });
+  if (options.initialCheckpoint) {
+    await t.run(async (ctx) => {
+      const obligation = await ctx.db
+        .query("companyMonitoringScanObligations")
+        .withIndex("by_account_company_source", (q) =>
+          q.eq("ownerAccountId", ownerAccountId).eq("companyId", companyId).eq("source", "exa"),
+        )
+        .unique();
+      await ctx.db.patch(obligation!._id, { checkpoint: options.initialCheckpoint });
+    });
+  }
+  return { ownerAccountId, companyId, ...scheduled };
+}
+
+async function claimForTest(t: ReturnType<typeof convexTest>, workerId = "worker-a") {
+  return t.mutation(ORCHESTRATION.claimNextWorkForTest, { workerId });
+}
+
+async function finalizeComplete(
+  t: ReturnType<typeof convexTest>,
+  claim: any,
+  overrides: Record<string, unknown> = {},
+) {
+  return t.mutation(ORCHESTRATION.finalizeWorkForTest, {
+    workerId: "worker-a",
+    workId: claim.work.workId,
+    leaseToken: claim.work.leaseToken,
+    result: {
+      type: "result",
+      itemCount: 1,
+      hasMore: false,
+      coverage: "complete",
+      returnedRange: {
+        startAt: claim.work.windowStart,
+        endAt: claim.work.windowEnd,
+      },
+      checkpoint: `checkpoint-${claim.work.workId}`,
+      emptyValidated: false,
+      costUsdMicros: 125,
+      ...overrides,
+    },
+  });
+}
+
+describe("Company Monitoring durable scan orchestration", () => {
+  test("claims server-shaped work and advances checkpoints only after a valid complete result", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAccountWithCompany(t, "happy", {
+      initialCheckpoint: "checkpoint-before",
+    });
+
+    const claim = await claimForTest(t);
+    expect(claim).toMatchObject({
+      status: "claimed",
+      accountsExamined: 1,
+      work: {
+        ownerAccountId: seeded.ownerAccountId,
+        source: "exa",
+        queryVersion: "exa-company-discovery-v1",
+        resultCap: 100,
+        attempt: 1,
+        obligations: [{ companyId: seeded.companyId, checkpoint: "checkpoint-before" }],
+      },
+    });
+    expect(claim.work.leaseToken).toMatch(/^[a-f0-9]{64}$/);
+    expect(claim.work.leaseExpiresAt).toBe(NOW + LEASE_MS);
+
+    const finalized = await finalizeComplete(t, claim);
+    expect(finalized).toMatchObject({ status: "completed", reason: "complete" });
+    const state = await t.run(async (ctx) => {
+      const work = await ctx.db
+        .query("companyMonitoringScanWorkItems")
+        .withIndex("by_workId", (q) => q.eq("workId", claim.work.workId))
+        .unique();
+      const obligation = await ctx.db
+        .query("companyMonitoringScanObligations")
+        .withIndex("by_account_company_source", (q) =>
+          q
+            .eq("ownerAccountId", seeded.ownerAccountId)
+            .eq("companyId", seeded.companyId)
+            .eq("source", "exa"),
+        )
+        .unique();
+      return { work, obligation };
+    });
+    expect(state.work).toMatchObject({
+      state: "complete",
+      terminalReceipt: {
+        reason: "complete",
+        costUsdMicros: 125,
+        sourceCoverage: "complete",
+        returnedRange: { startAt: claim.work.windowStart, endAt: claim.work.windowEnd },
+      },
+    });
+    expect(state.obligation).toMatchObject({
+      state: "complete",
+      checkpoint: `checkpoint-${claim.work.workId}`,
+    });
+
+    vi.setSystemTime(NOW + 1_000);
+    expect(await t.mutation(ORCHESTRATION.scheduleAccountWork, {
+      ownerAccountId: seeded.ownerAccountId,
+      source: "exa",
+      companyIds: [seeded.companyId],
+    })).toEqual({ status: "replayed", workId: claim.work.workId });
+    expect(await t.run(async (ctx) => ({
+      workItems: (await ctx.db.query("companyMonitoringScanWorkItems").collect()).length,
+      obligations: (await ctx.db.query("companyMonitoringScanObligations").collect()).length,
+    }))).toEqual({ workItems: 1, obligations: 1 });
+  });
+
+  test("starts from the indexed account due page and stays bounded beyond 5,000 rows", async () => {
+    const t = convexTest(schema, modules);
+    const totalAccounts = 5_005;
+    const targetIndex = 31;
+    for (let start = 0; start < totalAccounts; start += 250) {
+      const end = Math.min(totalAccounts, start + 250);
+      await t.run(async (ctx) => {
+        for (let index = start; index < end; index += 1) {
+          await ctx.db.insert("companyMonitoringAccounts", {
+            logicalAccountId: `cm_account_scale_${String(index).padStart(5, "0")}`,
+            ownerFenceHash: `fence_scale_${index}`,
+            lifecycle: "entitled",
+            lifecycleSequence: 1,
+            companyCount: index === targetIndex ? 1 : 0,
+            companyLimit: 500,
+            snapshotGeneration: 1,
+            purgeGeneration: 0,
+            purgePhase: "none",
+            destructivePurgeStarted: false,
+            pendingReactivation: false,
+            nextScanDueAt: NOW,
+            nextExaScanDueAt: NOW,
+            createdAt: NOW + index,
+            updatedAt: NOW,
+          });
+        }
+      });
+    }
+    const ownerAccountId = `cm_account_scale_${String(targetIndex).padStart(5, "0")}`;
+    const companyId = `cm_company_${String(targetIndex).padStart(26, "0")}`;
+    await t.run(async (ctx) => {
+      await ctx.db.insert("companyMonitoringCompanies", {
+        ownerAccountId,
+        companyId,
+        name: "Scale Target",
+        sortName: "scale target",
+        domicileCountry: "US",
+        lifecycle: "active",
+        coverageState: "awaiting_first_scan",
+        observationState: "unknown",
+        snapshotGeneration: 1,
+        purgeGeneration: 0,
+        purgePhase: "none",
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
+    });
+    await t.mutation(ORCHESTRATION.scheduleAccountWork, {
+      ownerAccountId,
+      source: "exa",
+      companyIds: [companyId],
+    });
+
+    const claim = await claimForTest(t, "scale-worker");
+    expect(claim.status).toBe("claimed");
+    expect(claim.work.ownerAccountId).toBe(ownerAccountId);
+    expect(claim.accountsExamined).toBeLessThanOrEqual(32);
+  }, 20_000);
+
+  test("public claims and finalization are secret-gated, targetless, and dark by provider flag", async () => {
+    const t = convexTest(schema, modules);
+    await seedAccountWithCompany(t, "auth");
+
+    await expect(t.mutation(PUBLIC_ORCHESTRATION.claimNextWork, {
+      secret: "wrong-secret",
+      workerId: "worker-a",
+    })).rejects.toThrow(/COMPANY_MONITORING_WORKER_UNAUTHORIZED/);
+    await expect(t.mutation(PUBLIC_ORCHESTRATION.claimNextWork, {
+      secret: WORKER_SECRET,
+      workerId: "worker-a",
+      ownerAccountId: "cm_account_attacker_selected",
+    } as any)).rejects.toThrow();
+    await expect(t.mutation(PUBLIC_ORCHESTRATION.finalizeWork, {
+      secret: "wrong-secret",
+      workerId: "worker-a",
+      workId: "cm_work_unknown",
+      leaseToken: "a".repeat(64),
+      result: { type: "provider_error", reason: "timeout", costUsdMicros: 0 },
+    })).rejects.toThrow(/COMPANY_MONITORING_WORKER_UNAUTHORIZED/);
+
+    expect(await t.mutation(PUBLIC_ORCHESTRATION.claimNextWork, {
+      secret: WORKER_SECRET,
+      workerId: "worker-a",
+    })).toEqual({ status: "disabled" });
+  });
+
+  test("expired claims replay with a fresh fence; stale holders cannot commit; same-lease terminal retries replay", async () => {
+    const t = convexTest(schema, modules);
+    await seedAccountWithCompany(t, "lease");
+    const first = await claimForTest(t);
+
+    vi.setSystemTime(NOW + LEASE_MS + 1);
+    const replay = await claimForTest(t);
+    expect(replay).toMatchObject({ status: "claimed", work: { attempt: 2 } });
+    expect(replay.work.workId).toBe(first.work.workId);
+    expect(replay.work.leaseToken).not.toBe(first.work.leaseToken);
+
+    expect(await finalizeComplete(t, first)).toEqual({ status: "fenced" });
+    const completed = await finalizeComplete(t, replay);
+    expect(completed).toMatchObject({ status: "completed", reason: "complete" });
+    expect(await finalizeComplete(t, replay)).toMatchObject({
+      status: "replayed",
+      reason: "complete",
+    });
+  });
+
+  test.each([
+    ["capped", { itemCount: 100, hasMore: false }, "capped"],
+    ["partial", { coverage: "partial" }, "partial"],
+    ["malformed range", { returnedRange: { startAt: NOW, endAt: NOW - 1 } }, "malformed"],
+    ["invalid empty", { itemCount: 0, emptyValidated: false }, "invalid_empty"],
+  ])("%s results preserve the previous checkpoint and remain non-reassuring", async (_label, overrides, reason) => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAccountWithCompany(t, `preserve_${reason}`, {
+      initialCheckpoint: "checkpoint-before",
+    });
+    const claim = await claimForTest(t);
+
+    expect(await finalizeComplete(t, claim, overrides)).toMatchObject({
+      status: "non_reassuring",
+      reason,
+    });
+    const obligation = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringScanObligations")
+        .withIndex("by_account_company_source", (q) =>
+          q
+            .eq("ownerAccountId", seeded.ownerAccountId)
+            .eq("companyId", seeded.companyId)
+            .eq("source", "exa"),
+        )
+        .unique(),
+    );
+    expect(obligation).toMatchObject({
+      state: "non_reassuring",
+      reason,
+      checkpoint: "checkpoint-before",
+    });
+  });
+
+  test("provider errors preserve checkpoints with a closed reason code", async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await seedAccountWithCompany(t, "provider_error", {
+      initialCheckpoint: "checkpoint-before",
+    });
+    const claim = await claimForTest(t);
+    const result = await t.mutation(ORCHESTRATION.finalizeWorkForTest, {
+      workerId: "worker-a",
+      workId: claim.work.workId,
+      leaseToken: claim.work.leaseToken,
+      result: { type: "provider_error", reason: "timeout", costUsdMicros: 25 },
+    });
+    expect(result).toMatchObject({ status: "non_reassuring", reason: "provider_error" });
+    const obligation = await t.run(async (ctx) =>
+      ctx.db
+        .query("companyMonitoringScanObligations")
+        .withIndex("by_account_company_source", (q) =>
+          q
+            .eq("ownerAccountId", seeded.ownerAccountId)
+            .eq("companyId", seeded.companyId)
+            .eq("source", "exa"),
+        )
+        .unique(),
+    );
+    expect(obligation).toMatchObject({
+      state: "non_reassuring",
+      reason: "provider_error",
+      checkpoint: "checkpoint-before",
+    });
+  });
+});

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -28,6 +28,7 @@ import type * as companyMonitoring__shared from "../companyMonitoring/_shared.js
 import type * as companyMonitoring_accounts from "../companyMonitoring/accounts.js";
 import type * as companyMonitoring_companies from "../companyMonitoring/companies.js";
 import type * as companyMonitoring_imports from "../companyMonitoring/imports.js";
+import type * as companyMonitoring_orchestration from "../companyMonitoring/orchestration.js";
 import type * as config_productCatalog from "../config/productCatalog.js";
 import type * as constants from "../constants.js";
 import type * as contactMessages from "../contactMessages.js";
@@ -91,6 +92,7 @@ declare const fullApi: ApiFromModules<{
   "companyMonitoring/accounts": typeof companyMonitoring_accounts;
   "companyMonitoring/companies": typeof companyMonitoring_companies;
   "companyMonitoring/imports": typeof companyMonitoring_imports;
+  "companyMonitoring/orchestration": typeof companyMonitoring_orchestration;
   "config/productCatalog": typeof config_productCatalog;
   constants: typeof constants;
   contactMessages: typeof contactMessages;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as companyMonitoring_accounts from "../companyMonitoring/accounts.
 import type * as companyMonitoring_companies from "../companyMonitoring/companies.js";
 import type * as companyMonitoring_imports from "../companyMonitoring/imports.js";
 import type * as companyMonitoring_orchestration from "../companyMonitoring/orchestration.js";
+import type * as companyMonitoring_validators from "../companyMonitoring/validators.js";
 import type * as config_productCatalog from "../config/productCatalog.js";
 import type * as constants from "../constants.js";
 import type * as contactMessages from "../contactMessages.js";
@@ -41,6 +42,7 @@ import type * as intelHistory from "../intelHistory.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_dodo from "../lib/dodo.js";
 import type * as lib_emailDomain from "../lib/emailDomain.js";
+import type * as lib_emailShape from "../lib/emailShape.js";
 import type * as lib_entitlements from "../lib/entitlements.js";
 import type * as lib_env from "../lib/env.js";
 import type * as lib_identitySigning from "../lib/identitySigning.js";
@@ -53,6 +55,8 @@ import type * as payments_billing from "../payments/billing.js";
 import type * as payments_businessSeats from "../payments/businessSeats.js";
 import type * as payments_cacheActions from "../payments/cacheActions.js";
 import type * as payments_checkout from "../payments/checkout.js";
+import type * as payments_checkoutRateLimit from "../payments/checkoutRateLimit.js";
+import type * as payments_returnUrlOrigin from "../payments/returnUrlOrigin.js";
 import type * as payments_seedProductPlans from "../payments/seedProductPlans.js";
 import type * as payments_subscriptionEmails from "../payments/subscriptionEmails.js";
 import type * as payments_subscriptionHelpers from "../payments/subscriptionHelpers.js";
@@ -93,6 +97,7 @@ declare const fullApi: ApiFromModules<{
   "companyMonitoring/companies": typeof companyMonitoring_companies;
   "companyMonitoring/imports": typeof companyMonitoring_imports;
   "companyMonitoring/orchestration": typeof companyMonitoring_orchestration;
+  "companyMonitoring/validators": typeof companyMonitoring_validators;
   "config/productCatalog": typeof config_productCatalog;
   constants: typeof constants;
   contactMessages: typeof contactMessages;
@@ -105,6 +110,7 @@ declare const fullApi: ApiFromModules<{
   "lib/auth": typeof lib_auth;
   "lib/dodo": typeof lib_dodo;
   "lib/emailDomain": typeof lib_emailDomain;
+  "lib/emailShape": typeof lib_emailShape;
   "lib/entitlements": typeof lib_entitlements;
   "lib/env": typeof lib_env;
   "lib/identitySigning": typeof lib_identitySigning;
@@ -117,6 +123,8 @@ declare const fullApi: ApiFromModules<{
   "payments/businessSeats": typeof payments_businessSeats;
   "payments/cacheActions": typeof payments_cacheActions;
   "payments/checkout": typeof payments_checkout;
+  "payments/checkoutRateLimit": typeof payments_checkoutRateLimit;
+  "payments/returnUrlOrigin": typeof payments_returnUrlOrigin;
   "payments/seedProductPlans": typeof payments_seedProductPlans;
   "payments/subscriptionEmails": typeof payments_subscriptionEmails;
   "payments/subscriptionHelpers": typeof payments_subscriptionHelpers;
@@ -157,77 +165,5 @@ export declare const internal: FilterApi<
 >;
 
 export declare const components: {
-  dodopayments: {
-    lib: {
-      checkout: FunctionReference<
-        "action",
-        "internal",
-        {
-          apiKey: string;
-          environment: "test_mode" | "live_mode";
-          payload: {
-            allowed_payment_method_types?: Array<string>;
-            billing_address?: {
-              city?: string;
-              country: string;
-              state?: string;
-              street?: string;
-              zipcode?: string;
-            };
-            billing_currency?: string;
-            confirm?: boolean;
-            customer?:
-              | { email: string; name?: string; phone_number?: string }
-              | { customer_id: string };
-            customization?: {
-              force_language?: string;
-              show_on_demand_tag?: boolean;
-              show_order_details?: boolean;
-              theme?: string;
-            };
-            discount_code?: string;
-            feature_flags?: {
-              allow_currency_selection?: boolean;
-              allow_discount_code?: boolean;
-              allow_phone_number_collection?: boolean;
-              allow_tax_id?: boolean;
-              always_create_new_customer?: boolean;
-            };
-            force_3ds?: boolean;
-            metadata?: Record<string, string>;
-            product_cart: Array<{
-              addons?: Array<{ addon_id: string; quantity: number }>;
-              amount?: number;
-              product_id: string;
-              quantity: number;
-            }>;
-            return_url?: string;
-            show_saved_payment_methods?: boolean;
-            subscription_data?: {
-              on_demand?: {
-                adaptive_currency_fees_inclusive?: boolean;
-                mandate_only: boolean;
-                product_currency?: string;
-                product_description?: string;
-                product_price?: number;
-              };
-              trial_period_days?: number;
-            };
-          };
-        },
-        { checkout_url: string }
-      >;
-      customerPortal: FunctionReference<
-        "action",
-        "internal",
-        {
-          apiKey: string;
-          dodoCustomerId: string;
-          environment: "test_mode" | "live_mode";
-          send_email?: boolean;
-        },
-        { portal_url: string }
-      >;
-    };
-  };
+  dodopayments: import("@dodopayments/convex/_generated/component.js").ComponentApi<"dodopayments">;
 };

--- a/convex/companyMonitoring/accounts.ts
+++ b/convex/companyMonitoring/accounts.ts
@@ -15,6 +15,7 @@ import {
   fingerprint,
   logicalId,
 } from "./_shared";
+import { purgeAccountScanStateBatch } from "./orchestration";
 
 const PURGE_TRANSACTION_DOCUMENT_LIMIT = 8_192;
 // Reserve room for the account read/write, the lookahead company, scheduler
@@ -38,7 +39,7 @@ const STALLED_PURGE_REAPER_BATCH_SIZE = 50;
 // 24h purgeAfter grace that already delays destructive work.
 const ENTITLED_RECHECK_AGE_MS = 60 * 60 * 1000;
 const ENTITLED_RECHECK_BATCH_SIZE = 50;
-const REAPABLE_PURGE_PHASES = ["finalizing", "companies", "pending"] as const;
+const REAPABLE_PURGE_PHASES = ["finalizing", "companies", "scan", "pending"] as const;
 // Both directions: "entitled" rows may need lapsing, "entitlement_lapsed" rows
 // may need restoring after a late renewal. "denied" is terminal and excluded.
 const RECONCILABLE_LIFECYCLES = ["entitled", "entitlement_lapsed"] as const;
@@ -467,14 +468,27 @@ export const advanceAccountPurge = internalMutation({
           return { status: "reactivated" };
         }
       }
+      const scanPurge = await purgeAccountScanStateBatch(ctx, account.logicalAccountId);
       await ctx.db.patch(account._id, {
-        purgePhase: "companies",
+        purgePhase: scanPurge.complete ? "companies" : "scan",
         destructivePurgeStarted: true,
         purgeAfter: undefined,
         updatedAt: now,
       });
       await scheduleAccountPurge(ctx, args.ownerFenceHash, args.purgeGeneration);
       return { status: "started" };
+    }
+
+    if (account.purgePhase === "scan") {
+      const scanPurge = await purgeAccountScanStateBatch(ctx, account.logicalAccountId);
+      if (!scanPurge.complete) {
+        await ctx.db.patch(account._id, { updatedAt: now });
+        await scheduleAccountPurge(ctx, args.ownerFenceHash, args.purgeGeneration);
+        return { status: "scan" };
+      }
+      await ctx.db.patch(account._id, { purgePhase: "companies", updatedAt: now });
+      await scheduleAccountPurge(ctx, args.ownerFenceHash, args.purgeGeneration);
+      return { status: "companies" };
     }
 
     if (account.purgePhase === "companies") {

--- a/convex/companyMonitoring/companies.ts
+++ b/convex/companyMonitoring/companies.ts
@@ -38,7 +38,6 @@ export async function insertNormalizedCompany(
   account: { logicalAccountId: string; snapshotGeneration?: number },
   company: NormalizedMonitoredCompanyInput,
   metadata: ReplayMetadata,
-  options: { scheduleScans?: boolean } = {},
 ) {
   const now = Date.now();
   const companyId = logicalId("company", now);
@@ -60,15 +59,6 @@ export async function insertNormalizedCompany(
     updatedAt: now,
   });
   await insertClaims(ctx, account.logicalAccountId, companyId, company, now);
-  // Import rows are already isolated one mutation at a time. Materializing
-  // both sources here avoids a scheduler fan-out for a 100-row import while
-  // keeping the durable ledger atomic with company creation.
-  if (options.scheduleScans !== false) {
-    await scheduleCompanySourcesHandler(ctx, {
-      ownerAccountId: account.logicalAccountId,
-      companyId,
-    });
-  }
   return companyId;
 }
 
@@ -144,6 +134,10 @@ export const createCompanyForOwner = internalMutation({
     const companyId = await insertNormalizedCompany(ctx, account, company, {
       directRequestId: clientRequestId,
       directFingerprint,
+    });
+    await scheduleCompanySourcesHandler(ctx, {
+      ownerAccountId: account.logicalAccountId,
+      companyId,
     });
     await ctx.db.patch(account._id, {
       companyCount: companyCount + 1,

--- a/convex/companyMonitoring/companies.ts
+++ b/convex/companyMonitoring/companies.ts
@@ -21,6 +21,12 @@ import {
   COMPANY_LIMIT,
 } from "./_shared";
 import { requireProvisionedAccount } from "./accounts";
+import {
+  cancelCompanyScanWork,
+  purgeCompanyScanStateBatch,
+  queueCompanySources,
+  scheduleCompanySourcesHandler,
+} from "./orchestration";
 import { companyPatchValidator, monitoredCompanyInputValidator } from "./validators";
 
 type ReplayMetadata =
@@ -32,6 +38,7 @@ export async function insertNormalizedCompany(
   account: { logicalAccountId: string; snapshotGeneration?: number },
   company: NormalizedMonitoredCompanyInput,
   metadata: ReplayMetadata,
+  options: { scheduleScans?: boolean } = {},
 ) {
   const now = Date.now();
   const companyId = logicalId("company", now);
@@ -53,6 +60,15 @@ export async function insertNormalizedCompany(
     updatedAt: now,
   });
   await insertClaims(ctx, account.logicalAccountId, companyId, company, now);
+  // Import rows are already isolated one mutation at a time. Materializing
+  // both sources here avoids a scheduler fan-out for a 100-row import while
+  // keeping the durable ledger atomic with company creation.
+  if (options.scheduleScans !== false) {
+    await scheduleCompanySourcesHandler(ctx, {
+      ownerAccountId: account.logicalAccountId,
+      companyId,
+    });
+  }
   return companyId;
 }
 
@@ -293,6 +309,14 @@ export const updateCompanyForOwner = internalMutation({
       snapshotGeneration: (account.snapshotGeneration ?? 0) + 1,
       updatedAt: now,
     });
+    if (company.lifecycle === "active") {
+      await cancelCompanyScanWork(ctx, {
+        ownerAccountId: account.logicalAccountId,
+        companyId: company.companyId,
+        reason: "superseded",
+      });
+      await queueCompanySources(ctx, account.logicalAccountId, company.companyId);
+    }
     return { status: "updated", companyId: company.companyId };
   },
 });
@@ -325,6 +349,13 @@ export const setCompanyStateForOwner = internalMutation({
 
     const now = Date.now();
     if (args.state !== "removed") {
+      if (args.state === "paused") {
+        await cancelCompanyScanWork(ctx, {
+          ownerAccountId: account.logicalAccountId,
+          companyId: company.companyId,
+          reason: "superseded",
+        });
+      }
       await ctx.db.patch(company._id, {
         lifecycle: args.state,
         snapshotGeneration: company.snapshotGeneration + 1,
@@ -334,16 +365,24 @@ export const setCompanyStateForOwner = internalMutation({
         snapshotGeneration: (account.snapshotGeneration ?? 0) + 1,
         updatedAt: now,
       });
+      if (args.state === "active") {
+        await queueCompanySources(ctx, account.logicalAccountId, company.companyId);
+      }
       return { status: args.state, companyId: company.companyId };
     }
 
     const purgeGeneration = company.purgeGeneration + 1;
+    await cancelCompanyScanWork(ctx, {
+      ownerAccountId: account.logicalAccountId,
+      companyId: company.companyId,
+      reason: "company_removed",
+    });
     await deleteCompanyClaims(ctx, account.logicalAccountId, company.companyId);
     await ctx.db.patch(company._id, {
       lifecycle: "removed",
       removedAt: now,
       purgeGeneration,
-      purgePhase: "payload",
+      purgePhase: "scan",
       snapshotGeneration: company.snapshotGeneration + 1,
       updatedAt: now,
     });
@@ -386,6 +425,22 @@ export const advanceCompanyPurge = internalMutation({
       return { status: "stale" };
     }
     if (company.purgePhase === "complete") return { status: "complete" };
+    if (company.purgePhase === "scan") {
+      const scanPurge = await purgeCompanyScanStateBatch(
+        ctx,
+        args.ownerAccountId,
+        args.companyId,
+      );
+      if (!scanPurge.complete) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.companyMonitoring.companies.advanceCompanyPurge,
+          args,
+        );
+        return { status: "scan" };
+      }
+      await ctx.db.patch(company._id, { purgePhase: "payload", updatedAt: Date.now() });
+    }
     await ctx.db.patch(company._id, {
       name: undefined,
       sortName: undefined,

--- a/convex/companyMonitoring/imports.ts
+++ b/convex/companyMonitoring/imports.ts
@@ -22,6 +22,7 @@ type ImportRowResult = {
 };
 
 type ImportRowMutationResult = ImportRowResult & { companyCount: number };
+type InternalImportRowMutationResult = ImportRowMutationResult & { ownerAccountId: string };
 
 export const importCompanyRowForOwner = internalMutation({
   args: {
@@ -29,7 +30,7 @@ export const importCompanyRowForOwner = internalMutation({
     row: normalizedCompanyImportRowValidator,
     rowFingerprint: v.string(),
   },
-  handler: async (ctx, args): Promise<ImportRowMutationResult> => {
+  handler: async (ctx, args): Promise<InternalImportRowMutationResult> => {
     const account = await requireProvisionedAccount(ctx, args.ownerUserId);
     const row = args.row as NormalizedCompanyImportRow;
     const companyCount = account.companyCount ?? 0;
@@ -49,12 +50,14 @@ export const importCompanyRowForOwner = internalMutation({
             status: "replayed",
             companyId: replay.companyId,
             companyCount,
+            ownerAccountId: account.logicalAccountId,
           }
         : {
             ordinal: row.ordinal,
             status: "conflict",
             reason: "REPLAY_CONFLICT",
             companyCount,
+            ownerAccountId: account.logicalAccountId,
           };
     }
 
@@ -72,6 +75,7 @@ export const importCompanyRowForOwner = internalMutation({
         status: "noop",
         companyId: noop.companyId,
         companyCount,
+        ownerAccountId: account.logicalAccountId,
       };
     }
 
@@ -81,6 +85,7 @@ export const importCompanyRowForOwner = internalMutation({
         status: "rejected",
         reason: "COMPANY_LIMIT_REACHED",
         companyCount,
+        ownerAccountId: account.logicalAccountId,
       };
     }
 
@@ -88,7 +93,7 @@ export const importCompanyRowForOwner = internalMutation({
       clientImportId: row.clientImportId,
       importOrdinal: row.ordinal,
       importFingerprint: args.rowFingerprint,
-    });
+    }, { scheduleScans: false });
     const nextCompanyCount = companyCount + 1;
     await ctx.db.patch(account._id, {
       companyCount: nextCompanyCount,
@@ -100,6 +105,7 @@ export const importCompanyRowForOwner = internalMutation({
       status: "created",
       companyId,
       companyCount: nextCompanyCount,
+      ownerAccountId: account.logicalAccountId,
     };
   },
 });
@@ -110,6 +116,8 @@ export const importCompaniesForOwner = internalAction({
     const rows = normalizeCompanyImportBatch(args.rows as CompanyImportRowInput[]);
     const rowFingerprints = await Promise.all(rows.map((row) => fingerprint(row)));
     const results: ImportRowResult[] = [];
+    const schedulableCompanyIds: string[] = [];
+    let ownerAccountId: string | undefined;
     let companyCount = 0;
 
     for (const [index, row] of rows.entries()) {
@@ -120,10 +128,38 @@ export const importCompaniesForOwner = internalAction({
           row,
           rowFingerprint: rowFingerprints[index]!,
         },
-      ) as ImportRowMutationResult;
+      ) as InternalImportRowMutationResult;
       companyCount = result.companyCount;
-      const { companyCount: _companyCount, ...rowResult } = result;
+      ownerAccountId = result.ownerAccountId;
+      if (
+        (result.status === "created" || result.status === "replayed") &&
+        result.companyId
+      ) {
+        schedulableCompanyIds.push(result.companyId);
+      }
+      const {
+        companyCount: _companyCount,
+        ownerAccountId: _ownerAccountId,
+        ...rowResult
+      } = result;
       results.push(rowResult);
+    }
+
+    // Imports already run one mutation per normalized row. Cohort created and
+    // replayed rows into at most 25 IDs, then materialize two source work
+    // items per cohort. Work-key replay heals an action interrupted after row
+    // commits without duplicating work; no-op rows never join the cohort.
+    if (ownerAccountId) {
+      for (let offset = 0; offset < schedulableCompanyIds.length; offset += 25) {
+        const companyIds = schedulableCompanyIds.slice(offset, offset + 25);
+        for (const source of ["exa", "x"] as const) {
+          await ctx.runMutation(internal.companyMonitoring.orchestration.ensureAccountWork, {
+            ownerAccountId,
+            source,
+            companyIds,
+          });
+        }
+      }
     }
 
     return { results, companyCount };

--- a/convex/companyMonitoring/imports.ts
+++ b/convex/companyMonitoring/imports.ts
@@ -9,6 +9,7 @@ import {
 import { COMPANY_LIMIT, fingerprint } from "./_shared";
 import { requireProvisionedAccount } from "./accounts";
 import { findNoopByCustomerReference, insertNormalizedCompany } from "./companies";
+import { COMPANY_MONITORING_SCAN_COHORT_LIMIT } from "./orchestration";
 import {
   companyImportRowInputValidator,
   normalizedCompanyImportRowValidator,
@@ -93,7 +94,7 @@ export const importCompanyRowForOwner = internalMutation({
       clientImportId: row.clientImportId,
       importOrdinal: row.ordinal,
       importFingerprint: args.rowFingerprint,
-    }, { scheduleScans: false });
+    });
     const nextCompanyCount = companyCount + 1;
     await ctx.db.patch(account._id, {
       companyCount: nextCompanyCount,
@@ -150,8 +151,15 @@ export const importCompaniesForOwner = internalAction({
     // items per cohort. Work-key replay heals an action interrupted after row
     // commits without duplicating work; no-op rows never join the cohort.
     if (ownerAccountId) {
-      for (let offset = 0; offset < schedulableCompanyIds.length; offset += 25) {
-        const companyIds = schedulableCompanyIds.slice(offset, offset + 25);
+      for (
+        let offset = 0;
+        offset < schedulableCompanyIds.length;
+        offset += COMPANY_MONITORING_SCAN_COHORT_LIMIT
+      ) {
+        const companyIds = schedulableCompanyIds.slice(
+          offset,
+          offset + COMPANY_MONITORING_SCAN_COHORT_LIMIT,
+        );
         for (const source of ["exa", "x"] as const) {
           await ctx.runMutation(internal.companyMonitoring.orchestration.ensureAccountWork, {
             ownerAccountId,

--- a/convex/companyMonitoring/orchestration.ts
+++ b/convex/companyMonitoring/orchestration.ts
@@ -232,7 +232,7 @@ async function scheduleAccountWorkHandler(
   const { windowStart, windowEnd } = scanWindowAt(now);
   const queryVersion = QUERY_VERSION[args.source];
   const cohortKey = await fingerprint({ version: "cm-cohort-v1", companyIds });
-  const workKey = await scanWorkKey({
+  let workKey = await scanWorkKey({
     ownerAccountId: args.ownerAccountId,
     cohortKey,
     source: args.source,
@@ -246,22 +246,40 @@ async function scheduleAccountWorkHandler(
     }
   }
 
-  const existing = await ctx.db
+  const priorWorkIds = new Set<string>();
+  for (const { obligation } of selectedRows) {
+    if (obligation?.workId) priorWorkIds.add(obligation.workId);
+  }
+
+  let existing = await ctx.db
     .query("companyMonitoringScanWorkItems")
     .withIndex("by_workKey", (q) => q.eq("workKey", workKey))
     .unique();
+  if (
+    mode === "missing_only" &&
+    existing &&
+    (existing.state === "complete" || existing.state === "non_reassuring")
+  ) {
+    // The hourly key is also the immutable identity of the terminal receipt.
+    // A same-hour lifecycle change must preserve that receipt while creating
+    // a new scheduled occurrence for the cancelled obligation.
+    workKey = await fingerprint({
+      version: "cm-lifecycle-reschedule-v1",
+      originalWorkKey: workKey,
+      supersededWorkIds: [...priorWorkIds].sort(),
+    });
+    existing = await ctx.db
+      .query("companyMonitoringScanWorkItems")
+      .withIndex("by_workKey", (q) => q.eq("workKey", workKey))
+      .unique();
+  }
   if (existing && existing.state !== "cancelled") {
     await updateAccountDueFromWork(ctx, args.ownerAccountId);
     return { status: "replayed" as const, workId: existing.workId };
   }
 
   const workId = existing?.workId ?? `cm_work_${workKey.slice(0, 40)}`;
-  const priorWorkIds = new Set<string>();
-  for (const { obligation } of selectedRows) {
-    if (obligation?.workId && obligation.workId !== workId) {
-      priorWorkIds.add(obligation.workId);
-    }
-  }
+  priorWorkIds.delete(workId);
 
   const dueWork = {
     workId,

--- a/convex/companyMonitoring/orchestration.ts
+++ b/convex/companyMonitoring/orchestration.ts
@@ -1,0 +1,695 @@
+import { ConvexError, type Infer, v } from "convex/values";
+import type { Doc } from "../_generated/dataModel";
+import {
+  internalMutation,
+  mutation,
+  type MutationCtx,
+} from "../_generated/server";
+import { COMPANY_MONITORING_ROLLOUT_FLAGS } from "../config/productCatalog";
+import { fingerprint } from "./_shared";
+import {
+  companyMonitoringFinalizeResultValidator,
+  companyMonitoringNonReassuringReasonValidator,
+  companyMonitoringProviderErrorReasonValidator,
+  companyMonitoringScanSourceValidator,
+} from "./validators";
+
+type Source = Infer<typeof companyMonitoringScanSourceValidator>;
+type FinalizeResult = Infer<typeof companyMonitoringFinalizeResultValidator>;
+type NonReassuringReason = Infer<typeof companyMonitoringNonReassuringReasonValidator>;
+type ProviderErrorReason = Infer<typeof companyMonitoringProviderErrorReasonValidator>;
+type Work = Doc<"companyMonitoringScanWorkItems">;
+type Obligation = Doc<"companyMonitoringScanObligations">;
+
+const ACCOUNT_DUE_PAGE_SIZE = 32;
+const ACCOUNT_WORK_PAGE_SIZE = 8;
+const MAX_COHORT_COMPANIES = 25;
+const LEASE_MS = 5 * 60 * 1000;
+const WINDOW_MS = 24 * 60 * 60 * 1000;
+const WINDOW_BUCKET_MS = 60 * 60 * 1000;
+const MAX_CHECKPOINT_BYTES = 512;
+const MAX_COST_USD_MICROS = 1_000_000_000_000;
+const WORKER_ID = /^[A-Za-z0-9._:-]{1,64}$/;
+
+const QUERY_VERSION: Record<Source, string> = {
+  exa: "exa-company-discovery-v1",
+  x: "x-company-discovery-v1",
+};
+
+// Provider limits are Convex-owned. A worker receives the selected value in a
+// lease and cannot raise it in claim or finalize arguments.
+const RESULT_CAP: Record<Source, number> = { exa: 100, x: 100 };
+
+function workIdentity(work: Work) {
+  return {
+    workId: work.workId,
+    workKey: work.workKey,
+    ownerAccountId: work.ownerAccountId,
+    cohortKey: work.cohortKey,
+    source: work.source,
+    windowStart: work.windowStart,
+    windowEnd: work.windowEnd,
+    queryVersion: work.queryVersion,
+    scheduledDueAt: work.scheduledDueAt,
+    selectionDueAt: work.selectionDueAt,
+    resultCap: work.resultCap,
+    attemptCount: work.attemptCount,
+    createdAt: work.createdAt,
+    updatedAt: work.updatedAt,
+  };
+}
+
+function obligationIdentity(obligation: Obligation) {
+  return {
+    obligationId: obligation.obligationId,
+    ownerAccountId: obligation.ownerAccountId,
+    companyId: obligation.companyId,
+    source: obligation.source,
+    queryVersion: obligation.queryVersion,
+    dueAt: obligation.dueAt,
+    checkpoint: obligation.checkpoint,
+    createdAt: obligation.createdAt,
+    updatedAt: obligation.updatedAt,
+  };
+}
+
+function normalizeWorkerId(workerId: string): string {
+  if (!WORKER_ID.test(workerId)) {
+    throw new ConvexError("INVALID_COMPANY_MONITORING_WORKER_ID");
+  }
+  return workerId;
+}
+
+async function timingSafeEqualStrings(left: string, right: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const [leftDigest, rightDigest] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(left)),
+    crypto.subtle.digest("SHA-256", encoder.encode(right)),
+  ]);
+  const leftBytes = new Uint8Array(leftDigest);
+  const rightBytes = new Uint8Array(rightDigest);
+  let mismatch = 0;
+  for (let index = 0; index < leftBytes.length; index += 1) {
+    mismatch |= leftBytes[index] ^ rightBytes[index];
+  }
+  return mismatch === 0;
+}
+
+async function requireWorkerSecret(secret: string): Promise<void> {
+  const expected = process.env.COMPANY_MONITORING_WORKER_SECRET ?? "";
+  if (!expected || !(await timingSafeEqualStrings(secret, expected))) {
+    throw new ConvexError("COMPANY_MONITORING_WORKER_UNAUTHORIZED");
+  }
+}
+
+function randomFence(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function enabledSources(): Source[] {
+  const flags: Record<Source, boolean> = {
+    exa: COMPANY_MONITORING_ROLLOUT_FLAGS.exaProvider,
+    x: COMPANY_MONITORING_ROLLOUT_FLAGS.xProvider,
+  };
+  return (Object.keys(flags) as Source[]).filter((source) => flags[source]);
+}
+
+async function updateAccountDueFromWork(ctx: MutationCtx, ownerAccountId: string) {
+  const account = await ctx.db
+    .query("companyMonitoringAccounts")
+    .withIndex("by_logicalAccountId", (q) => q.eq("logicalAccountId", ownerAccountId))
+    .unique();
+  if (!account) return;
+  const nextForSource = async (source: Source) => {
+    const [due, leased] = await Promise.all([
+      ctx.db
+        .query("companyMonitoringScanWorkItems")
+        .withIndex("by_account_source_state_selectionDueAt", (q) =>
+          q.eq("ownerAccountId", ownerAccountId).eq("source", source).eq("state", "due"),
+        )
+        .first(),
+      ctx.db
+        .query("companyMonitoringScanWorkItems")
+        .withIndex("by_account_source_state_selectionDueAt", (q) =>
+          q.eq("ownerAccountId", ownerAccountId).eq("source", source).eq("state", "leased"),
+        )
+        .first(),
+    ]);
+    if (due && leased) return Math.min(due.selectionDueAt, leased.selectionDueAt);
+    return due?.selectionDueAt ?? leased?.selectionDueAt;
+  };
+  const [nextExaScanDueAt, nextXScanDueAt] = await Promise.all([
+    nextForSource("exa"),
+    nextForSource("x"),
+  ]);
+  const nextScanDueAt = nextExaScanDueAt === undefined
+    ? nextXScanDueAt
+    : nextXScanDueAt === undefined
+      ? nextExaScanDueAt
+      : Math.min(nextExaScanDueAt, nextXScanDueAt);
+  await ctx.db.patch(account._id, {
+    nextScanDueAt,
+    nextExaScanDueAt,
+    nextXScanDueAt,
+    updatedAt: Date.now(),
+  });
+}
+
+async function scheduleAccountWorkHandler(
+  ctx: MutationCtx,
+  args: { ownerAccountId: string; source: Source; companyIds: string[] },
+) {
+  const now = Date.now();
+  const account = await ctx.db
+    .query("companyMonitoringAccounts")
+    .withIndex("by_logicalAccountId", (q) => q.eq("logicalAccountId", args.ownerAccountId))
+    .unique();
+  if (!account || account.lifecycle !== "entitled" || account.terminalReason) {
+    throw new ConvexError("COMPANY_MONITORING_ACCOUNT_INACTIVE");
+  }
+
+  const companyIds = [...new Set(args.companyIds)].sort();
+  if (companyIds.length === 0 || companyIds.length > MAX_COHORT_COMPANIES) {
+    throw new ConvexError("INVALID_COMPANY_MONITORING_COHORT");
+  }
+  for (const companyId of companyIds) {
+    const company = await ctx.db
+      .query("companyMonitoringCompanies")
+      .withIndex("by_account_companyId", (q) =>
+        q.eq("ownerAccountId", args.ownerAccountId).eq("companyId", companyId),
+      )
+      .unique();
+    if (!company || company.lifecycle !== "active") {
+      throw new ConvexError("COMPANY_MONITORING_COMPANY_NOT_ACTIVE");
+    }
+  }
+
+  const windowEnd = Math.floor(now / WINDOW_BUCKET_MS) * WINDOW_BUCKET_MS;
+  const windowStart = windowEnd - WINDOW_MS;
+  const queryVersion = QUERY_VERSION[args.source];
+  const cohortKey = await fingerprint({ version: "cm-cohort-v1", companyIds });
+  const workKey = await fingerprint({
+    version: "cm-work-v1",
+    ownerAccountId: args.ownerAccountId,
+    cohortKey,
+    source: args.source,
+    windowStart,
+    windowEnd,
+    queryVersion,
+  });
+  const existing = await ctx.db
+    .query("companyMonitoringScanWorkItems")
+    .withIndex("by_workKey", (q) => q.eq("workKey", workKey))
+    .unique();
+  if (existing) {
+    await updateAccountDueFromWork(ctx, args.ownerAccountId);
+    return { status: "replayed" as const, workId: existing.workId };
+  }
+
+  const workId = `cm_work_${workKey.slice(0, 40)}`;
+  for (const companyId of companyIds) {
+    const obligation = await ctx.db
+      .query("companyMonitoringScanObligations")
+      .withIndex("by_account_company_source", (q) =>
+        q
+          .eq("ownerAccountId", args.ownerAccountId)
+          .eq("companyId", companyId)
+          .eq("source", args.source),
+      )
+      .unique();
+    if (obligation && (obligation.state === "due" || obligation.state === "leased")) {
+      throw new ConvexError("COMPANY_MONITORING_OBLIGATION_ALREADY_ACTIVE");
+    }
+  }
+
+  await ctx.db.insert("companyMonitoringScanWorkItems", {
+    workId,
+    workKey,
+    ownerAccountId: args.ownerAccountId,
+    cohortKey,
+    source: args.source,
+    windowStart,
+    windowEnd,
+    queryVersion,
+    scheduledDueAt: now,
+    selectionDueAt: now,
+    resultCap: RESULT_CAP[args.source],
+    attemptCount: 0,
+    state: "due",
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  for (const companyId of companyIds) {
+    const obligation = await ctx.db
+      .query("companyMonitoringScanObligations")
+      .withIndex("by_account_company_source", (q) =>
+        q
+          .eq("ownerAccountId", args.ownerAccountId)
+          .eq("companyId", companyId)
+          .eq("source", args.source),
+      )
+      .unique();
+    if (obligation) {
+      await ctx.db.replace(obligation._id, {
+        ...obligationIdentity(obligation),
+        queryVersion,
+        dueAt: now,
+        state: "due",
+        workId,
+        updatedAt: now,
+      });
+    } else {
+      const obligationHash = await fingerprint({
+        version: "cm-obligation-v1",
+        ownerAccountId: args.ownerAccountId,
+        companyId,
+        source: args.source,
+      });
+      await ctx.db.insert("companyMonitoringScanObligations", {
+        obligationId: `cm_obligation_${obligationHash.slice(0, 40)}`,
+        ownerAccountId: args.ownerAccountId,
+        companyId,
+        source: args.source,
+        queryVersion,
+        dueAt: now,
+        state: "due",
+        workId,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+  }
+
+  const currentDue = account.nextScanDueAt;
+  const sourceDueField = args.source === "exa" ? "nextExaScanDueAt" : "nextXScanDueAt";
+  const currentSourceDue = account[sourceDueField];
+  await ctx.db.patch(account._id, {
+    nextScanDueAt: currentDue === undefined ? now : Math.min(currentDue, now),
+    [sourceDueField]: currentSourceDue === undefined ? now : Math.min(currentSourceDue, now),
+    updatedAt: now,
+  });
+  return { status: "scheduled" as const, workId };
+}
+
+async function dueWorkForAccount(
+  ctx: MutationCtx,
+  ownerAccountId: string,
+  now: number,
+  source: Source,
+) {
+  for (const state of ["leased", "due"] as const) {
+    const page = await ctx.db
+      .query("companyMonitoringScanWorkItems")
+      .withIndex("by_account_source_state_selectionDueAt", (q) =>
+        q
+          .eq("ownerAccountId", ownerAccountId)
+          .eq("source", source)
+          .eq("state", state)
+          .lte("selectionDueAt", now),
+      )
+      .take(ACCOUNT_WORK_PAGE_SIZE);
+    if (page[0]) return page[0];
+  }
+  return null;
+}
+
+async function claimSelectedWork(
+  ctx: MutationCtx,
+  work: Extract<Work, { state: "due" | "leased" }>,
+  workerId: string,
+  now: number,
+) {
+  const leaseToken = randomFence();
+  const leaseExpiresAt = now + LEASE_MS;
+  const attemptCount = work.attemptCount + 1;
+  const obligations = await ctx.db
+    .query("companyMonitoringScanObligations")
+    .withIndex("by_workId", (q) => q.eq("workId", work.workId))
+    .collect();
+  if (obligations.length === 0 || obligations.length > MAX_COHORT_COMPANIES) {
+    throw new ConvexError("COMPANY_MONITORING_WORK_OBLIGATIONS_INVALID");
+  }
+  for (const obligation of obligations) {
+    if (
+      obligation.workId !== work.workId ||
+      (obligation.state !== "due" && obligation.state !== "leased")
+    ) {
+      throw new ConvexError("COMPANY_MONITORING_WORK_OBLIGATIONS_INVALID");
+    }
+  }
+
+  await ctx.db.replace(work._id, {
+    ...workIdentity(work),
+    state: "leased",
+    selectionDueAt: leaseExpiresAt,
+    attemptCount,
+    leaseToken,
+    leaseExpiresAt,
+    workerId,
+    updatedAt: now,
+  });
+  for (const obligation of obligations) {
+    await ctx.db.replace(obligation._id, {
+      ...obligationIdentity(obligation),
+      state: "leased",
+      workId: work.workId,
+      leaseToken,
+      leaseExpiresAt,
+      workerId,
+      updatedAt: now,
+    });
+  }
+
+  const account = await ctx.db
+    .query("companyMonitoringAccounts")
+    .withIndex("by_logicalAccountId", (q) => q.eq("logicalAccountId", work.ownerAccountId))
+    .unique();
+  if (!account || account.lifecycle !== "entitled" || account.terminalReason) {
+    throw new ConvexError("COMPANY_MONITORING_ACCOUNT_INACTIVE");
+  }
+  const sourceDueField = work.source === "exa" ? "nextExaScanDueAt" : "nextXScanDueAt";
+  const otherDue = work.source === "exa" ? account.nextXScanDueAt : account.nextExaScanDueAt;
+  await ctx.db.patch(account._id, {
+    nextScanDueAt: otherDue === undefined ? leaseExpiresAt : Math.min(leaseExpiresAt, otherDue),
+    [sourceDueField]: leaseExpiresAt,
+    updatedAt: now,
+  });
+
+  return {
+    ownerAccountId: work.ownerAccountId,
+    workId: work.workId,
+    cohortKey: work.cohortKey,
+    source: work.source,
+    windowStart: work.windowStart,
+    windowEnd: work.windowEnd,
+    queryVersion: work.queryVersion,
+    resultCap: work.resultCap,
+    attempt: attemptCount,
+    leaseToken,
+    leaseExpiresAt,
+    obligations: obligations.map((obligation) => ({
+      companyId: obligation.companyId,
+      ...(obligation.checkpoint ? { checkpoint: obligation.checkpoint } : {}),
+    })),
+  };
+}
+
+async function claimNextWorkHandler(
+  ctx: MutationCtx,
+  workerIdInput: string,
+  sources: readonly Source[],
+) {
+  const workerId = normalizeWorkerId(workerIdInput);
+  const now = Date.now();
+  let accountsExamined = 0;
+  for (const source of sources) {
+    const index = source === "exa"
+      ? "by_lifecycle_nextExaScanDueAt" as const
+      : "by_lifecycle_nextXScanDueAt" as const;
+    const dueField = source === "exa" ? "nextExaScanDueAt" as const : "nextXScanDueAt" as const;
+    const accounts = await ctx.db
+      .query("companyMonitoringAccounts")
+      .withIndex(index, (q) =>
+        q
+          .eq("lifecycle", "entitled")
+          .gte(dueField, 0)
+          .lte(dueField, now),
+      )
+      .take(ACCOUNT_DUE_PAGE_SIZE);
+
+    for (const account of accounts) {
+      accountsExamined += 1;
+      if (account.terminalReason) continue;
+      const work = await dueWorkForAccount(ctx, account.logicalAccountId, now, source);
+      if (!work) {
+        await updateAccountDueFromWork(ctx, account.logicalAccountId);
+        continue;
+      }
+      const claimed = await claimSelectedWork(ctx, work, workerId, now);
+      return { status: "claimed" as const, accountsExamined, work: claimed };
+    }
+  }
+  return { status: "idle" as const, accountsExamined };
+}
+
+function validCost(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 0 && value <= MAX_COST_USD_MICROS;
+}
+
+function validRange(
+  range: { startAt: number; endAt: number } | undefined,
+  work: Work,
+): range is { startAt: number; endAt: number } {
+  return Boolean(
+    range &&
+    Number.isSafeInteger(range.startAt) &&
+    Number.isSafeInteger(range.endAt) &&
+    range.startAt === work.windowStart &&
+    range.endAt === work.windowEnd,
+  );
+}
+
+function validCheckpoint(value: string | undefined): value is string {
+  if (!value || value !== value.trim()) return false;
+  return new TextEncoder().encode(value).byteLength <= MAX_CHECKPOINT_BYTES;
+}
+
+function nonReassuringReceipt(
+  reason: NonReassuringReason,
+  now: number,
+  result: FinalizeResult,
+  work: Work,
+) {
+  const range = result.type === "result" && validRange(result.returnedRange, work)
+    ? result.returnedRange
+    : undefined;
+  const itemCount = result.type === "result" && Number.isSafeInteger(result.itemCount) && result.itemCount >= 0
+    ? result.itemCount
+    : undefined;
+  const providerReason: ProviderErrorReason | undefined = result.type === "provider_error"
+    ? result.reason
+    : undefined;
+  const sourceCoverage = result.type === "provider_error"
+    ? "failed" as const
+    : result.coverage === "partial"
+      ? "partial" as const
+      : "unknown" as const;
+  return {
+    kind: "non_reassuring" as const,
+    reason,
+    ...(providerReason ? { providerReason } : {}),
+    completedAt: now,
+    ...(range ? { returnedRange: range } : {}),
+    ...(itemCount !== undefined ? { itemCount } : {}),
+    costUsdMicros: validCost(result.costUsdMicros) ? result.costUsdMicros : 0,
+    sourceCoverage,
+  };
+}
+
+function classifyResult(result: FinalizeResult, work: Work, now: number) {
+  if (!validCost(result.costUsdMicros)) {
+    return nonReassuringReceipt("malformed", now, result, work);
+  }
+  if (result.type === "provider_error") {
+    return nonReassuringReceipt("provider_error", now, result, work);
+  }
+  if (
+    !Number.isSafeInteger(result.itemCount) ||
+    result.itemCount < 0 ||
+    result.itemCount > work.resultCap ||
+    !validRange(result.returnedRange, work) ||
+    !validCheckpoint(result.checkpoint)
+  ) {
+    return nonReassuringReceipt("malformed", now, result, work);
+  }
+  if (result.hasMore || result.itemCount === work.resultCap) {
+    return nonReassuringReceipt("capped", now, result, work);
+  }
+  if (result.coverage === "partial") {
+    return nonReassuringReceipt("partial", now, result, work);
+  }
+  if (result.itemCount === 0 && !result.emptyValidated) {
+    return nonReassuringReceipt("invalid_empty", now, result, work);
+  }
+  return {
+    kind: "complete" as const,
+    reason: "complete" as const,
+    completedAt: now,
+    returnedRange: result.returnedRange,
+    itemCount: result.itemCount,
+    costUsdMicros: result.costUsdMicros,
+    sourceCoverage: "complete" as const,
+    checkpointAfter: result.checkpoint,
+  };
+}
+
+async function finalizeWorkHandler(
+  ctx: MutationCtx,
+  args: {
+    workerId: string;
+    workId: string;
+    leaseToken: string;
+    result: FinalizeResult;
+  },
+) {
+  const workerId = normalizeWorkerId(args.workerId);
+  const work = await ctx.db
+    .query("companyMonitoringScanWorkItems")
+    .withIndex("by_workId", (q) => q.eq("workId", args.workId))
+    .unique();
+  if (!work) return { status: "fenced" as const };
+  if (work.state === "complete" || work.state === "non_reassuring") {
+    if (work.terminalLeaseToken !== args.leaseToken || work.terminalWorkerId !== workerId) {
+      return { status: "fenced" as const };
+    }
+    return {
+      status: "replayed" as const,
+      reason: work.terminalReceipt.reason,
+      receipt: work.terminalReceipt,
+    };
+  }
+  const now = Date.now();
+  if (
+    work.state !== "leased" ||
+    work.leaseToken !== args.leaseToken ||
+    work.workerId !== workerId ||
+    work.leaseExpiresAt <= now
+  ) {
+    return { status: "fenced" as const };
+  }
+
+  const account = await ctx.db
+    .query("companyMonitoringAccounts")
+    .withIndex("by_logicalAccountId", (q) => q.eq("logicalAccountId", work.ownerAccountId))
+    .unique();
+  if (!account || account.lifecycle !== "entitled" || account.terminalReason) {
+    return { status: "fenced" as const };
+  }
+
+  const obligations = await ctx.db
+    .query("companyMonitoringScanObligations")
+    .withIndex("by_workId", (q) => q.eq("workId", work.workId))
+    .collect();
+  if (
+    obligations.length === 0 ||
+    obligations.some((obligation) =>
+      obligation.state !== "leased" ||
+      obligation.leaseToken !== args.leaseToken ||
+      obligation.workerId !== workerId,
+    )
+  ) {
+    return { status: "fenced" as const };
+  }
+
+  const receipt = classifyResult(args.result, work, now);
+  if (receipt.kind === "complete") {
+    await ctx.db.replace(work._id, {
+      ...workIdentity(work),
+      state: "complete",
+      selectionDueAt: now,
+      terminalLeaseToken: args.leaseToken,
+      terminalWorkerId: workerId,
+      terminalReceipt: receipt,
+      updatedAt: now,
+    });
+    for (const obligation of obligations) {
+      await ctx.db.replace(obligation._id, {
+        ...obligationIdentity(obligation),
+        state: "complete",
+        workId: work.workId,
+        checkpoint: receipt.checkpointAfter,
+        terminalReceiptId: work.workId,
+        completedAt: now,
+        updatedAt: now,
+      });
+    }
+  } else {
+    await ctx.db.replace(work._id, {
+      ...workIdentity(work),
+      state: "non_reassuring",
+      selectionDueAt: now,
+      terminalLeaseToken: args.leaseToken,
+      terminalWorkerId: workerId,
+      terminalReceipt: receipt,
+      updatedAt: now,
+    });
+    for (const obligation of obligations) {
+      await ctx.db.replace(obligation._id, {
+        ...obligationIdentity(obligation),
+        state: "non_reassuring",
+        workId: work.workId,
+        terminalReceiptId: work.workId,
+        completedAt: now,
+        reason: receipt.reason,
+        updatedAt: now,
+      });
+    }
+  }
+  await updateAccountDueFromWork(ctx, work.ownerAccountId);
+  return {
+    status: receipt.kind === "complete" ? "completed" as const : "non_reassuring" as const,
+    reason: receipt.reason,
+    receipt,
+  };
+}
+
+// Internal scheduling is the trusted seam for lifecycle/cron integration. It
+// accepts an account cohort, but creates the due time, time window, query
+// version, cap, uniqueness key, and durable obligations inside Convex.
+export const scheduleAccountWork = internalMutation({
+  args: {
+    ownerAccountId: v.string(),
+    source: companyMonitoringScanSourceValidator,
+    companyIds: v.array(v.string()),
+  },
+  handler: scheduleAccountWorkHandler,
+});
+
+// Public worker claims are intentionally targetless. The worker can identify
+// only itself; Convex selects the account and work from the bounded due index.
+export const claimNextWork = mutation({
+  args: { secret: v.string(), workerId: v.string() },
+  handler: async (ctx, args) => {
+    await requireWorkerSecret(args.secret);
+    const sources = enabledSources();
+    if (sources.length === 0) return { status: "disabled" as const };
+    const result = await claimNextWorkHandler(ctx, args.workerId, sources);
+    if (result.status === "claimed") return { status: result.status, work: result.work };
+    return { status: result.status };
+  },
+});
+
+export const finalizeWork = mutation({
+  args: {
+    secret: v.string(),
+    workerId: v.string(),
+    workId: v.string(),
+    leaseToken: v.string(),
+    result: companyMonitoringFinalizeResultValidator,
+  },
+  handler: async (ctx, args) => {
+    await requireWorkerSecret(args.secret);
+    return finalizeWorkHandler(ctx, args);
+  },
+});
+
+// Convex-test cannot override compile-time-dark provider flags. These internal
+// seams exercise the exact selection/finalization handlers without widening
+// the worker API or introducing an environment bypass in production.
+export const claimNextWorkForTest = internalMutation({
+  args: { workerId: v.string() },
+  handler: (ctx, args) => claimNextWorkHandler(ctx, args.workerId, ["exa", "x"]),
+});
+
+export const finalizeWorkForTest = internalMutation({
+  args: {
+    workerId: v.string(),
+    workId: v.string(),
+    leaseToken: v.string(),
+    result: companyMonitoringFinalizeResultValidator,
+  },
+  handler: finalizeWorkHandler,
+});

--- a/convex/companyMonitoring/orchestration.ts
+++ b/convex/companyMonitoring/orchestration.ts
@@ -24,9 +24,10 @@ type Obligation = Doc<"companyMonitoringScanObligations">;
 
 const ACCOUNT_DUE_PAGE_SIZE = 32;
 const ACCOUNT_WORK_PAGE_SIZE = 8;
-const MAX_COHORT_COMPANIES = 25;
+export const COMPANY_MONITORING_SCAN_COHORT_LIMIT = 25;
 const SCAN_PURGE_WORK_BATCH_SIZE = 8;
 const SCAN_PURGE_OBLIGATION_BATCH_SIZE = 16;
+const SCAN_PURGE_RECEIPT_LINK_BATCH_SIZE = 16;
 const LEASE_MS = 5 * 60 * 1000;
 const WINDOW_MS = 24 * 60 * 60 * 1000;
 const WINDOW_BUCKET_MS = 60 * 60 * 1000;
@@ -76,6 +77,22 @@ function obligationIdentity(obligation: Obligation) {
   };
 }
 
+function scanWindowAt(timestamp: number) {
+  const windowEnd = Math.floor(timestamp / WINDOW_BUCKET_MS) * WINDOW_BUCKET_MS;
+  return { windowStart: windowEnd - WINDOW_MS, windowEnd };
+}
+
+async function scanWorkKey(args: {
+  ownerAccountId: string;
+  cohortKey: string;
+  source: Source;
+  windowStart: number;
+  windowEnd: number;
+  queryVersion: string;
+}) {
+  return fingerprint({ version: "cm-work-v1", ...args });
+}
+
 function normalizeWorkerId(workerId: string): string {
   if (!WORKER_ID.test(workerId)) {
     throw new ConvexError("INVALID_COMPANY_MONITORING_WORKER_ID");
@@ -93,7 +110,7 @@ async function timingSafeEqualStrings(left: string, right: string): Promise<bool
   const rightBytes = new Uint8Array(rightDigest);
   let mismatch = 0;
   for (let index = 0; index < leftBytes.length; index += 1) {
-    mismatch |= leftBytes[index] ^ rightBytes[index];
+    mismatch |= leftBytes[index]! ^ rightBytes[index]!;
   }
   return mismatch === 0;
 }
@@ -147,13 +164,7 @@ async function updateAccountDueFromWork(ctx: MutationCtx, ownerAccountId: string
     nextForSource("exa"),
     nextForSource("x"),
   ]);
-  const nextScanDueAt = nextExaScanDueAt === undefined
-    ? nextXScanDueAt
-    : nextXScanDueAt === undefined
-      ? nextExaScanDueAt
-      : Math.min(nextExaScanDueAt, nextXScanDueAt);
   await ctx.db.patch(account._id, {
-    nextScanDueAt,
     nextExaScanDueAt,
     nextXScanDueAt,
     updatedAt: Date.now(),
@@ -163,6 +174,7 @@ async function updateAccountDueFromWork(ctx: MutationCtx, ownerAccountId: string
 async function scheduleAccountWorkHandler(
   ctx: MutationCtx,
   args: { ownerAccountId: string; source: Source; companyIds: string[] },
+  mode: "strict" | "missing_only" = "strict",
 ) {
   const now = Date.now();
   const account = await ctx.db
@@ -173,28 +185,54 @@ async function scheduleAccountWorkHandler(
     throw new ConvexError("COMPANY_MONITORING_ACCOUNT_INACTIVE");
   }
 
-  const companyIds = [...new Set(args.companyIds)].sort();
-  if (companyIds.length === 0 || companyIds.length > MAX_COHORT_COMPANIES) {
+  const requestedCompanyIds = [...new Set(args.companyIds)].sort();
+  if (
+    requestedCompanyIds.length === 0 ||
+    requestedCompanyIds.length > COMPANY_MONITORING_SCAN_COHORT_LIMIT
+  ) {
     throw new ConvexError("INVALID_COMPANY_MONITORING_COHORT");
   }
-  for (const companyId of companyIds) {
-    const company = await ctx.db
-      .query("companyMonitoringCompanies")
-      .withIndex("by_account_companyId", (q) =>
-        q.eq("ownerAccountId", args.ownerAccountId).eq("companyId", companyId),
-      )
-      .unique();
-    if (!company || company.lifecycle !== "active") {
-      throw new ConvexError("COMPANY_MONITORING_COMPANY_NOT_ACTIVE");
-    }
-  }
 
-  const windowEnd = Math.floor(now / WINDOW_BUCKET_MS) * WINDOW_BUCKET_MS;
-  const windowStart = windowEnd - WINDOW_MS;
+  const rows = await Promise.all(requestedCompanyIds.map(async (companyId) => {
+    const [company, obligation] = await Promise.all([
+      ctx.db
+        .query("companyMonitoringCompanies")
+        .withIndex("by_account_companyId", (q) =>
+          q.eq("ownerAccountId", args.ownerAccountId).eq("companyId", companyId),
+        )
+        .unique(),
+      ctx.db
+        .query("companyMonitoringScanObligations")
+        .withIndex("by_account_company_source", (q) =>
+          q
+            .eq("ownerAccountId", args.ownerAccountId)
+            .eq("companyId", companyId)
+            .eq("source", args.source),
+        )
+        .unique(),
+    ]);
+    return { companyId, company, obligation };
+  }));
+
+  if (
+    mode === "strict" &&
+    rows.some(({ company }) => !company || company.lifecycle !== "active")
+  ) {
+    throw new ConvexError("COMPANY_MONITORING_COMPANY_NOT_ACTIVE");
+  }
+  const selectedRows = mode === "strict"
+    ? rows
+    : rows.filter(({ company, obligation }) =>
+      company?.lifecycle === "active" &&
+      (!obligation || obligation.state === "cancelled")
+    );
+  if (selectedRows.length === 0) return { status: "replayed" as const };
+  const companyIds = selectedRows.map(({ companyId }) => companyId);
+
+  const { windowStart, windowEnd } = scanWindowAt(now);
   const queryVersion = QUERY_VERSION[args.source];
   const cohortKey = await fingerprint({ version: "cm-cohort-v1", companyIds });
-  const workKey = await fingerprint({
-    version: "cm-work-v1",
+  const workKey = await scanWorkKey({
     ownerAccountId: args.ownerAccountId,
     cohortKey,
     source: args.source,
@@ -202,6 +240,12 @@ async function scheduleAccountWorkHandler(
     windowEnd,
     queryVersion,
   });
+  for (const { obligation } of selectedRows) {
+    if (obligation && (obligation.state === "due" || obligation.state === "leased")) {
+      throw new ConvexError("COMPANY_MONITORING_OBLIGATION_ALREADY_ACTIVE");
+    }
+  }
+
   const existing = await ctx.db
     .query("companyMonitoringScanWorkItems")
     .withIndex("by_workKey", (q) => q.eq("workKey", workKey))
@@ -213,19 +257,7 @@ async function scheduleAccountWorkHandler(
 
   const workId = existing?.workId ?? `cm_work_${workKey.slice(0, 40)}`;
   const priorWorkIds = new Set<string>();
-  for (const companyId of companyIds) {
-    const obligation = await ctx.db
-      .query("companyMonitoringScanObligations")
-      .withIndex("by_account_company_source", (q) =>
-        q
-          .eq("ownerAccountId", args.ownerAccountId)
-          .eq("companyId", companyId)
-          .eq("source", args.source),
-      )
-      .unique();
-    if (obligation && (obligation.state === "due" || obligation.state === "leased")) {
-      throw new ConvexError("COMPANY_MONITORING_OBLIGATION_ALREADY_ACTIVE");
-    }
+  for (const { obligation } of selectedRows) {
     if (obligation?.workId && obligation.workId !== workId) {
       priorWorkIds.add(obligation.workId);
     }
@@ -251,16 +283,7 @@ async function scheduleAccountWorkHandler(
   if (existing) await ctx.db.replace(existing._id, dueWork);
   else await ctx.db.insert("companyMonitoringScanWorkItems", dueWork);
 
-  for (const companyId of companyIds) {
-    const obligation = await ctx.db
-      .query("companyMonitoringScanObligations")
-      .withIndex("by_account_company_source", (q) =>
-        q
-          .eq("ownerAccountId", args.ownerAccountId)
-          .eq("companyId", companyId)
-          .eq("source", args.source),
-      )
-      .unique();
+  for (const { companyId, obligation } of selectedRows) {
     if (obligation) {
       await ctx.db.replace(obligation._id, {
         ...obligationIdentity(obligation),
@@ -293,8 +316,9 @@ async function scheduleAccountWorkHandler(
   }
 
   // Re-scheduling after a cohort cancellation moves every surviving
-  // obligation to fresh work. Remove the old work only after its last durable
-  // obligation has moved, so another company in the cohort is never stranded.
+  // obligation to fresh work. Remove only unreferenced cancelled work. A
+  // terminal work row is an immutable receipt and remains available for audit
+  // and same-lease replay after its obligations move to the next scan.
   for (const priorWorkId of priorWorkIds) {
     const remaining = await ctx.db
       .query("companyMonitoringScanObligations")
@@ -305,14 +329,12 @@ async function scheduleAccountWorkHandler(
       .query("companyMonitoringScanWorkItems")
       .withIndex("by_workId", (q) => q.eq("workId", priorWorkId))
       .unique();
-    if (priorWork) await ctx.db.delete(priorWork._id);
+    if (priorWork?.state === "cancelled") await ctx.db.delete(priorWork._id);
   }
 
-  const currentDue = account.nextScanDueAt;
   const sourceDueField = args.source === "exa" ? "nextExaScanDueAt" : "nextXScanDueAt";
   const currentSourceDue = account[sourceDueField];
   await ctx.db.patch(account._id, {
-    nextScanDueAt: currentDue === undefined ? now : Math.min(currentDue, now),
     [sourceDueField]: currentSourceDue === undefined ? now : Math.min(currentSourceDue, now),
     updatedAt: now,
   });
@@ -329,6 +351,19 @@ export async function queueCompanySources(
     0,
     internal.companyMonitoring.orchestration.scheduleCompanySources,
     { ownerAccountId, companyId },
+  );
+}
+
+async function queueAccountSourceWork(
+  ctx: MutationCtx,
+  ownerAccountId: string,
+  source: Source,
+  companyIds: string[],
+) {
+  await ctx.scheduler.runAfter(
+    0,
+    internal.companyMonitoring.orchestration.ensureAccountWork,
+    { ownerAccountId, source, companyIds },
   );
 }
 
@@ -372,7 +407,10 @@ export async function cancelCompanyScanWork(
 
   const now = Date.now();
   const handledWorkIds = new Set<string>();
-  const peerCompanyIds = new Set<string>();
+  const peerCandidates: Record<Source, Set<string>> = {
+    exa: new Set<string>(),
+    x: new Set<string>(),
+  };
   for (const companyObligation of companyObligations) {
     if (!companyObligation.workId || handledWorkIds.has(companyObligation.workId)) continue;
     handledWorkIds.add(companyObligation.workId);
@@ -385,8 +423,8 @@ export async function cancelCompanyScanWork(
     const cohortObligations = await ctx.db
       .query("companyMonitoringScanObligations")
       .withIndex("by_workId", (q) => q.eq("workId", work.workId))
-      .take(MAX_COHORT_COMPANIES + 1);
-    if (cohortObligations.length > MAX_COHORT_COMPANIES) {
+      .take(COMPANY_MONITORING_SCAN_COHORT_LIMIT + 1);
+    if (cohortObligations.length > COMPANY_MONITORING_SCAN_COHORT_LIMIT) {
       throw new ConvexError("COMPANY_MONITORING_WORK_OBLIGATIONS_INVALID");
     }
     await ctx.db.replace(work._id, {
@@ -407,17 +445,57 @@ export async function cancelCompanyScanWork(
         reason: isTarget ? args.reason : "superseded",
         updatedAt: now,
       });
-      if (!isTarget && await activeCompany(ctx, args.ownerAccountId, obligation.companyId)) {
-        peerCompanyIds.add(obligation.companyId);
-      }
+      if (!isTarget) peerCandidates[work.source].add(obligation.companyId);
     }
   }
 
-  for (const peerCompanyId of peerCompanyIds) {
-    await queueCompanySources(ctx, args.ownerAccountId, peerCompanyId);
+  const requeuedPeers = new Set<string>();
+  for (const source of ["exa", "x"] as const) {
+    const candidates = [...peerCandidates[source]].sort();
+    const activePeers = (await Promise.all(candidates.map(async (companyId) => ({
+      companyId,
+      active: Boolean(await activeCompany(ctx, args.ownerAccountId, companyId)),
+    })))).filter(({ active }) => active).map(({ companyId }) => companyId);
+    for (
+      let offset = 0;
+      offset < activePeers.length;
+      offset += COMPANY_MONITORING_SCAN_COHORT_LIMIT
+    ) {
+      const cohort = activePeers.slice(
+        offset,
+        offset + COMPANY_MONITORING_SCAN_COHORT_LIMIT,
+      );
+      await queueAccountSourceWork(ctx, args.ownerAccountId, source, cohort);
+      for (const companyId of cohort) requeuedPeers.add(companyId);
+    }
   }
   await updateAccountDueFromWork(ctx, args.ownerAccountId);
-  return { cancelledWork: handledWorkIds.size, requeuedPeers: peerCompanyIds.size };
+  return { cancelledWork: handledWorkIds.size, requeuedPeers: requeuedPeers.size };
+}
+
+async function deleteTerminalReceiptLink(
+  ctx: MutationCtx,
+  link: Doc<"companyMonitoringScanReceiptLinks">,
+) {
+  await ctx.db.delete(link._id);
+  const [remainingLink, remainingObligation] = await Promise.all([
+    ctx.db
+      .query("companyMonitoringScanReceiptLinks")
+      .withIndex("by_workId", (q) => q.eq("workId", link.workId))
+      .first(),
+    ctx.db
+      .query("companyMonitoringScanObligations")
+      .withIndex("by_workId", (q) => q.eq("workId", link.workId))
+      .first(),
+  ]);
+  if (remainingLink || remainingObligation) return;
+  const work = await ctx.db
+    .query("companyMonitoringScanWorkItems")
+    .withIndex("by_workId", (q) => q.eq("workId", link.workId))
+    .unique();
+  if (work && (work.state === "complete" || work.state === "non_reassuring")) {
+    await ctx.db.delete(work._id);
+  }
 }
 
 /** Delete one bounded page of scan state associated with a removed company. */
@@ -442,14 +520,32 @@ export async function purgeCompanyScanStateBatch(
       .withIndex("by_workId", (q) => q.eq("workId", workId))
       .first();
     if (remaining) continue;
+    const receiptLink = await ctx.db
+      .query("companyMonitoringScanReceiptLinks")
+      .withIndex("by_workId", (q) => q.eq("workId", workId))
+      .first();
+    if (receiptLink) continue;
     const work = await ctx.db
       .query("companyMonitoringScanWorkItems")
       .withIndex("by_workId", (q) => q.eq("workId", workId))
       .unique();
     if (work) await ctx.db.delete(work._id);
   }
+  const receiptLinkPage = await ctx.db
+    .query("companyMonitoringScanReceiptLinks")
+    .withIndex("by_account_company", (q) =>
+      q.eq("ownerAccountId", ownerAccountId).eq("companyId", companyId),
+    )
+    .take(SCAN_PURGE_RECEIPT_LINK_BATCH_SIZE + 1);
+  for (const link of receiptLinkPage.slice(0, SCAN_PURGE_RECEIPT_LINK_BATCH_SIZE)) {
+    await deleteTerminalReceiptLink(ctx, link);
+  }
   await updateAccountDueFromWork(ctx, ownerAccountId);
-  return { complete: page.length <= SCAN_PURGE_OBLIGATION_BATCH_SIZE };
+  return {
+    complete:
+      page.length <= SCAN_PURGE_OBLIGATION_BATCH_SIZE &&
+      receiptLinkPage.length <= SCAN_PURGE_RECEIPT_LINK_BATCH_SIZE,
+  };
 }
 
 /** Delete one bounded, account-leading page during destructive account purge. */
@@ -474,11 +570,19 @@ export async function purgeAccountScanStateBatch(
     const obligations = await ctx.db
       .query("companyMonitoringScanObligations")
       .withIndex("by_workId", (q) => q.eq("workId", work.workId))
-      .take(MAX_COHORT_COMPANIES + 1);
-    if (obligations.length > MAX_COHORT_COMPANIES) {
+      .take(COMPANY_MONITORING_SCAN_COHORT_LIMIT + 1);
+    if (obligations.length > COMPANY_MONITORING_SCAN_COHORT_LIMIT) {
       throw new ConvexError("COMPANY_MONITORING_WORK_OBLIGATIONS_INVALID");
     }
+    const receiptLinks = await ctx.db
+      .query("companyMonitoringScanReceiptLinks")
+      .withIndex("by_workId", (q) => q.eq("workId", work.workId))
+      .take(COMPANY_MONITORING_SCAN_COHORT_LIMIT + 1);
+    if (receiptLinks.length > COMPANY_MONITORING_SCAN_COHORT_LIMIT) {
+      throw new ConvexError("COMPANY_MONITORING_WORK_RECEIPT_LINKS_INVALID");
+    }
     for (const obligation of obligations) await ctx.db.delete(obligation._id);
+    for (const link of receiptLinks) await ctx.db.delete(link._id);
     await ctx.db.delete(work._id);
   }
   if (works.length > SCAN_PURGE_WORK_BATCH_SIZE) {
@@ -493,8 +597,19 @@ export async function purgeAccountScanStateBatch(
   for (const obligation of obligationPage.slice(0, SCAN_PURGE_OBLIGATION_BATCH_SIZE)) {
     await ctx.db.delete(obligation._id);
   }
+  const receiptLinkPage = await ctx.db
+    .query("companyMonitoringScanReceiptLinks")
+    .withIndex("by_account_company", (q) => q.eq("ownerAccountId", ownerAccountId))
+    .take(SCAN_PURGE_RECEIPT_LINK_BATCH_SIZE + 1);
+  for (const link of receiptLinkPage.slice(0, SCAN_PURGE_RECEIPT_LINK_BATCH_SIZE)) {
+    await deleteTerminalReceiptLink(ctx, link);
+  }
   await updateAccountDueFromWork(ctx, ownerAccountId);
-  return { complete: obligationPage.length <= SCAN_PURGE_OBLIGATION_BATCH_SIZE };
+  return {
+    complete:
+      obligationPage.length <= SCAN_PURGE_OBLIGATION_BATCH_SIZE &&
+      receiptLinkPage.length <= SCAN_PURGE_RECEIPT_LINK_BATCH_SIZE,
+  };
 }
 
 async function dueWorkForAccount(
@@ -514,7 +629,8 @@ async function dueWorkForAccount(
           .lte("selectionDueAt", now),
       )
       .take(ACCOUNT_WORK_PAGE_SIZE);
-    if (page[0]) return page[0];
+    const work = page[0];
+    if (work && (work.state === "due" || work.state === "leased")) return work;
   }
   return null;
 }
@@ -528,11 +644,19 @@ async function claimSelectedWork(
   const leaseToken = randomFence();
   const leaseExpiresAt = now + LEASE_MS;
   const attemptCount = work.attemptCount + 1;
+  // A due row can wait while a provider rollout flag is dark. Bind the
+  // execution range when a worker actually claims it, not when lifecycle code
+  // first scheduled it. The stable work id/key still fence retries of this
+  // scheduled occurrence while the persisted range governs finalization.
+  const { windowStart, windowEnd } = scanWindowAt(now);
   const obligations = await ctx.db
     .query("companyMonitoringScanObligations")
     .withIndex("by_workId", (q) => q.eq("workId", work.workId))
-    .collect();
-  if (obligations.length === 0 || obligations.length > MAX_COHORT_COMPANIES) {
+    .take(COMPANY_MONITORING_SCAN_COHORT_LIMIT + 1);
+  if (
+    obligations.length === 0 ||
+    obligations.length > COMPANY_MONITORING_SCAN_COHORT_LIMIT
+  ) {
     throw new ConvexError("COMPANY_MONITORING_WORK_OBLIGATIONS_INVALID");
   }
   for (const obligation of obligations) {
@@ -546,6 +670,8 @@ async function claimSelectedWork(
 
   await ctx.db.replace(work._id, {
     ...workIdentity(work),
+    windowStart,
+    windowEnd,
     state: "leased",
     selectionDueAt: leaseExpiresAt,
     attemptCount,
@@ -574,9 +700,7 @@ async function claimSelectedWork(
     throw new ConvexError("COMPANY_MONITORING_ACCOUNT_INACTIVE");
   }
   const sourceDueField = work.source === "exa" ? "nextExaScanDueAt" : "nextXScanDueAt";
-  const otherDue = work.source === "exa" ? account.nextXScanDueAt : account.nextExaScanDueAt;
   await ctx.db.patch(account._id, {
-    nextScanDueAt: otherDue === undefined ? leaseExpiresAt : Math.min(leaseExpiresAt, otherDue),
     [sourceDueField]: leaseExpiresAt,
     updatedAt: now,
   });
@@ -586,8 +710,8 @@ async function claimSelectedWork(
     workId: work.workId,
     cohortKey: work.cohortKey,
     source: work.source,
-    windowStart: work.windowStart,
-    windowEnd: work.windowEnd,
+    windowStart,
+    windowEnd,
     queryVersion: work.queryVersion,
     resultCap: work.resultCap,
     attempt: attemptCount,
@@ -598,6 +722,95 @@ async function claimSelectedWork(
       ...(obligation.checkpoint ? { checkpoint: obligation.checkpoint } : {}),
     })),
   };
+}
+
+async function rearmNextScan(
+  ctx: MutationCtx,
+  work: Work,
+  obligations: Obligation[],
+  now: number,
+  checkpointAfter?: string,
+) {
+  const nextDueAt = now + WINDOW_MS;
+  const companyIds = obligations.map((obligation) => obligation.companyId).sort();
+  const cohortKey = await fingerprint({ version: "cm-cohort-v1", companyIds });
+  const queryVersion = QUERY_VERSION[work.source];
+  const { windowStart, windowEnd } = scanWindowAt(nextDueAt);
+  // Recurring work keys identify a durable scheduled occurrence. Its window
+  // is provisional until claim time, when Convex atomically binds the actual
+  // execution range without changing the replay/fencing identity.
+  const workKey = await fingerprint({
+    version: "cm-recurring-work-v1",
+    ownerAccountId: work.ownerAccountId,
+    cohortKey,
+    source: work.source,
+    scheduledDueAt: nextDueAt,
+    queryVersion,
+  });
+  const nextWorkId = `cm_work_${workKey.slice(0, 40)}`;
+  const existing = await ctx.db
+    .query("companyMonitoringScanWorkItems")
+    .withIndex("by_workKey", (q) => q.eq("workKey", workKey))
+    .unique();
+  if (!existing) {
+    await ctx.db.insert("companyMonitoringScanWorkItems", {
+      workId: nextWorkId,
+      workKey,
+      ownerAccountId: work.ownerAccountId,
+      cohortKey,
+      source: work.source,
+      windowStart,
+      windowEnd,
+      queryVersion,
+      scheduledDueAt: nextDueAt,
+      selectionDueAt: nextDueAt,
+      resultCap: RESULT_CAP[work.source],
+      attemptCount: 0,
+      state: "due",
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  // Finalization and rearming share one Convex transaction, so a retry sees
+  // the terminal work and replays before reaching this point. The guard also
+  // makes the helper safe if that invariant is relaxed later.
+  const durableNextWorkId = existing?.workId ?? nextWorkId;
+  for (const obligation of obligations) {
+    if (obligation.workId === durableNextWorkId && obligation.state === "due") continue;
+    await ctx.db.replace(obligation._id, {
+      ...obligationIdentity(obligation),
+      queryVersion,
+      dueAt: nextDueAt,
+      ...(checkpointAfter ? { checkpoint: checkpointAfter } : {}),
+      state: "due",
+      workId: durableNextWorkId,
+      updatedAt: now,
+    });
+  }
+}
+
+async function linkTerminalReceipt(
+  ctx: MutationCtx,
+  work: Work,
+  obligations: Obligation[],
+  now: number,
+) {
+  for (const obligation of obligations) {
+    const existing = await ctx.db
+      .query("companyMonitoringScanReceiptLinks")
+      .withIndex("by_workId_company", (q) =>
+        q.eq("workId", work.workId).eq("companyId", obligation.companyId),
+      )
+      .unique();
+    if (existing) continue;
+    await ctx.db.insert("companyMonitoringScanReceiptLinks", {
+      ownerAccountId: work.ownerAccountId,
+      companyId: obligation.companyId,
+      workId: work.workId,
+      createdAt: now,
+    });
+  }
 }
 
 async function claimNextWorkHandler(
@@ -660,6 +873,12 @@ function validCheckpoint(value: string | undefined): value is string {
   return new TextEncoder().encode(value).byteLength <= MAX_CHECKPOINT_BYTES;
 }
 
+function nonReassuringSourceCoverage(result: FinalizeResult) {
+  if (result.type === "provider_error") return "failed" as const;
+  if (result.coverage === "partial") return "partial" as const;
+  return "unknown" as const;
+}
+
 function nonReassuringReceipt(
   reason: NonReassuringReason,
   now: number,
@@ -675,11 +894,6 @@ function nonReassuringReceipt(
   const providerReason: ProviderErrorReason | undefined = result.type === "provider_error"
     ? result.reason
     : undefined;
-  const sourceCoverage = result.type === "provider_error"
-    ? "failed" as const
-    : result.coverage === "partial"
-      ? "partial" as const
-      : "unknown" as const;
   return {
     kind: "non_reassuring" as const,
     reason,
@@ -688,7 +902,7 @@ function nonReassuringReceipt(
     ...(range ? { returnedRange: range } : {}),
     ...(itemCount !== undefined ? { itemCount } : {}),
     costUsdMicros: validCost(result.costUsdMicros) ? result.costUsdMicros : 0,
-    sourceCoverage,
+    sourceCoverage: nonReassuringSourceCoverage(result),
   };
 }
 
@@ -775,9 +989,10 @@ async function finalizeWorkHandler(
   const obligations = await ctx.db
     .query("companyMonitoringScanObligations")
     .withIndex("by_workId", (q) => q.eq("workId", work.workId))
-    .collect();
+    .take(COMPANY_MONITORING_SCAN_COHORT_LIMIT + 1);
   if (
     obligations.length === 0 ||
+    obligations.length > COMPANY_MONITORING_SCAN_COHORT_LIMIT ||
     obligations.some((obligation) =>
       obligation.state !== "leased" ||
       obligation.leaseToken !== args.leaseToken ||
@@ -798,17 +1013,8 @@ async function finalizeWorkHandler(
       terminalReceipt: receipt,
       updatedAt: now,
     });
-    for (const obligation of obligations) {
-      await ctx.db.replace(obligation._id, {
-        ...obligationIdentity(obligation),
-        state: "complete",
-        workId: work.workId,
-        checkpoint: receipt.checkpointAfter,
-        terminalReceiptId: work.workId,
-        completedAt: now,
-        updatedAt: now,
-      });
-    }
+    await linkTerminalReceipt(ctx, work, obligations, now);
+    await rearmNextScan(ctx, work, obligations, now, receipt.checkpointAfter);
   } else {
     await ctx.db.replace(work._id, {
       ...workIdentity(work),
@@ -819,17 +1025,8 @@ async function finalizeWorkHandler(
       terminalReceipt: receipt,
       updatedAt: now,
     });
-    for (const obligation of obligations) {
-      await ctx.db.replace(obligation._id, {
-        ...obligationIdentity(obligation),
-        state: "non_reassuring",
-        workId: work.workId,
-        terminalReceiptId: work.workId,
-        completedAt: now,
-        reason: receipt.reason,
-        updatedAt: now,
-      });
-    }
+    await linkTerminalReceipt(ctx, work, obligations, now);
+    await rearmNextScan(ctx, work, obligations, now);
   }
   await updateAccountDueFromWork(ctx, work.ownerAccountId);
   return {
@@ -861,32 +1058,7 @@ export const ensureAccountWork = internalMutation({
     source: companyMonitoringScanSourceValidator,
     companyIds: v.array(v.string()),
   },
-  handler: async (ctx, args) => {
-    const companyIds = [...new Set(args.companyIds)].sort();
-    if (companyIds.length === 0 || companyIds.length > MAX_COHORT_COMPANIES) {
-      throw new ConvexError("INVALID_COMPANY_MONITORING_COHORT");
-    }
-    const missing: string[] = [];
-    for (const companyId of companyIds) {
-      if (!await activeCompany(ctx, args.ownerAccountId, companyId)) continue;
-      const obligation = await ctx.db
-        .query("companyMonitoringScanObligations")
-        .withIndex("by_account_company_source", (q) =>
-          q
-            .eq("ownerAccountId", args.ownerAccountId)
-            .eq("companyId", companyId)
-            .eq("source", args.source),
-        )
-        .unique();
-      if (!obligation || obligation.state === "cancelled") missing.push(companyId);
-    }
-    if (missing.length === 0) return { status: "replayed" as const };
-    return scheduleAccountWorkHandler(ctx, {
-      ownerAccountId: args.ownerAccountId,
-      source: args.source,
-      companyIds: missing,
-    });
-  },
+  handler: (ctx, args) => scheduleAccountWorkHandler(ctx, args, "missing_only"),
 });
 
 export async function scheduleCompanySourcesHandler(
@@ -902,7 +1074,7 @@ export async function scheduleCompanySourcesHandler(
       ownerAccountId: args.ownerAccountId,
       source,
       companyIds: [args.companyId],
-    }));
+    }, "missing_only"));
   }
   return {
     status: results.some((result) => result.status === "scheduled")

--- a/convex/companyMonitoring/orchestration.ts
+++ b/convex/companyMonitoring/orchestration.ts
@@ -1,5 +1,6 @@
 import { ConvexError, type Infer, v } from "convex/values";
 import type { Doc } from "../_generated/dataModel";
+import { internal } from "../_generated/api";
 import {
   internalMutation,
   mutation,
@@ -24,6 +25,8 @@ type Obligation = Doc<"companyMonitoringScanObligations">;
 const ACCOUNT_DUE_PAGE_SIZE = 32;
 const ACCOUNT_WORK_PAGE_SIZE = 8;
 const MAX_COHORT_COMPANIES = 25;
+const SCAN_PURGE_WORK_BATCH_SIZE = 8;
+const SCAN_PURGE_OBLIGATION_BATCH_SIZE = 16;
 const LEASE_MS = 5 * 60 * 1000;
 const WINDOW_MS = 24 * 60 * 60 * 1000;
 const WINDOW_BUCKET_MS = 60 * 60 * 1000;
@@ -203,12 +206,13 @@ async function scheduleAccountWorkHandler(
     .query("companyMonitoringScanWorkItems")
     .withIndex("by_workKey", (q) => q.eq("workKey", workKey))
     .unique();
-  if (existing) {
+  if (existing && existing.state !== "cancelled") {
     await updateAccountDueFromWork(ctx, args.ownerAccountId);
     return { status: "replayed" as const, workId: existing.workId };
   }
 
-  const workId = `cm_work_${workKey.slice(0, 40)}`;
+  const workId = existing?.workId ?? `cm_work_${workKey.slice(0, 40)}`;
+  const priorWorkIds = new Set<string>();
   for (const companyId of companyIds) {
     const obligation = await ctx.db
       .query("companyMonitoringScanObligations")
@@ -222,9 +226,12 @@ async function scheduleAccountWorkHandler(
     if (obligation && (obligation.state === "due" || obligation.state === "leased")) {
       throw new ConvexError("COMPANY_MONITORING_OBLIGATION_ALREADY_ACTIVE");
     }
+    if (obligation?.workId && obligation.workId !== workId) {
+      priorWorkIds.add(obligation.workId);
+    }
   }
 
-  await ctx.db.insert("companyMonitoringScanWorkItems", {
+  const dueWork = {
     workId,
     workKey,
     ownerAccountId: args.ownerAccountId,
@@ -236,11 +243,13 @@ async function scheduleAccountWorkHandler(
     scheduledDueAt: now,
     selectionDueAt: now,
     resultCap: RESULT_CAP[args.source],
-    attemptCount: 0,
-    state: "due",
-    createdAt: now,
+    attemptCount: existing?.attemptCount ?? 0,
+    state: "due" as const,
+    createdAt: existing?.createdAt ?? now,
     updatedAt: now,
-  });
+  };
+  if (existing) await ctx.db.replace(existing._id, dueWork);
+  else await ctx.db.insert("companyMonitoringScanWorkItems", dueWork);
 
   for (const companyId of companyIds) {
     const obligation = await ctx.db
@@ -283,6 +292,22 @@ async function scheduleAccountWorkHandler(
     }
   }
 
+  // Re-scheduling after a cohort cancellation moves every surviving
+  // obligation to fresh work. Remove the old work only after its last durable
+  // obligation has moved, so another company in the cohort is never stranded.
+  for (const priorWorkId of priorWorkIds) {
+    const remaining = await ctx.db
+      .query("companyMonitoringScanObligations")
+      .withIndex("by_workId", (q) => q.eq("workId", priorWorkId))
+      .first();
+    if (remaining) continue;
+    const priorWork = await ctx.db
+      .query("companyMonitoringScanWorkItems")
+      .withIndex("by_workId", (q) => q.eq("workId", priorWorkId))
+      .unique();
+    if (priorWork) await ctx.db.delete(priorWork._id);
+  }
+
   const currentDue = account.nextScanDueAt;
   const sourceDueField = args.source === "exa" ? "nextExaScanDueAt" : "nextXScanDueAt";
   const currentSourceDue = account[sourceDueField];
@@ -292,6 +317,180 @@ async function scheduleAccountWorkHandler(
     updatedAt: now,
   });
   return { status: "scheduled" as const, workId };
+}
+
+/** Queue one bounded mutation that materializes both source obligations. */
+export async function queueCompanySources(
+  ctx: MutationCtx,
+  ownerAccountId: string,
+  companyId: string,
+) {
+  await ctx.scheduler.runAfter(
+    0,
+    internal.companyMonitoring.orchestration.scheduleCompanySources,
+    { ownerAccountId, companyId },
+  );
+}
+
+async function activeCompany(
+  ctx: MutationCtx,
+  ownerAccountId: string,
+  companyId: string,
+) {
+  const company = await ctx.db
+    .query("companyMonitoringCompanies")
+    .withIndex("by_account_companyId", (q) =>
+      q.eq("ownerAccountId", ownerAccountId).eq("companyId", companyId),
+    )
+    .unique();
+  return company?.lifecycle === "active" ? company : null;
+}
+
+/**
+ * Fence every active cohort that contains this company. Surviving peers keep
+ * cancelled obligations until a trusted queued mutation moves them to fresh
+ * server-shaped work, so no peer can disappear between cancellation and
+ * re-scheduling.
+ */
+export async function cancelCompanyScanWork(
+  ctx: MutationCtx,
+  args: {
+    ownerAccountId: string;
+    companyId: string;
+    reason: "company_removed" | "superseded";
+  },
+) {
+  const companyObligations = await ctx.db
+    .query("companyMonitoringScanObligations")
+    .withIndex("by_account_company_source", (q) =>
+      q.eq("ownerAccountId", args.ownerAccountId).eq("companyId", args.companyId),
+    )
+    .take(3);
+  if (companyObligations.length > 2) {
+    throw new ConvexError("COMPANY_MONITORING_COMPANY_OBLIGATIONS_INVALID");
+  }
+
+  const now = Date.now();
+  const handledWorkIds = new Set<string>();
+  const peerCompanyIds = new Set<string>();
+  for (const companyObligation of companyObligations) {
+    if (!companyObligation.workId || handledWorkIds.has(companyObligation.workId)) continue;
+    handledWorkIds.add(companyObligation.workId);
+    const work = await ctx.db
+      .query("companyMonitoringScanWorkItems")
+      .withIndex("by_workId", (q) => q.eq("workId", companyObligation.workId!))
+      .unique();
+    if (!work || (work.state !== "due" && work.state !== "leased")) continue;
+
+    const cohortObligations = await ctx.db
+      .query("companyMonitoringScanObligations")
+      .withIndex("by_workId", (q) => q.eq("workId", work.workId))
+      .take(MAX_COHORT_COMPANIES + 1);
+    if (cohortObligations.length > MAX_COHORT_COMPANIES) {
+      throw new ConvexError("COMPANY_MONITORING_WORK_OBLIGATIONS_INVALID");
+    }
+    await ctx.db.replace(work._id, {
+      ...workIdentity(work),
+      state: "cancelled",
+      cancelledAt: now,
+      cancelReason: args.reason,
+      updatedAt: now,
+    });
+    for (const obligation of cohortObligations) {
+      if (obligation.state !== "due" && obligation.state !== "leased") continue;
+      const isTarget = obligation.companyId === args.companyId;
+      await ctx.db.replace(obligation._id, {
+        ...obligationIdentity(obligation),
+        state: "cancelled",
+        workId: work.workId,
+        cancelledAt: now,
+        reason: isTarget ? args.reason : "superseded",
+        updatedAt: now,
+      });
+      if (!isTarget && await activeCompany(ctx, args.ownerAccountId, obligation.companyId)) {
+        peerCompanyIds.add(obligation.companyId);
+      }
+    }
+  }
+
+  for (const peerCompanyId of peerCompanyIds) {
+    await queueCompanySources(ctx, args.ownerAccountId, peerCompanyId);
+  }
+  await updateAccountDueFromWork(ctx, args.ownerAccountId);
+  return { cancelledWork: handledWorkIds.size, requeuedPeers: peerCompanyIds.size };
+}
+
+/** Delete one bounded page of scan state associated with a removed company. */
+export async function purgeCompanyScanStateBatch(
+  ctx: MutationCtx,
+  ownerAccountId: string,
+  companyId: string,
+) {
+  const page = await ctx.db
+    .query("companyMonitoringScanObligations")
+    .withIndex("by_account_company_source", (q) =>
+      q.eq("ownerAccountId", ownerAccountId).eq("companyId", companyId),
+    )
+    .take(SCAN_PURGE_OBLIGATION_BATCH_SIZE + 1);
+  const batch = page.slice(0, SCAN_PURGE_OBLIGATION_BATCH_SIZE);
+  for (const obligation of batch) {
+    const workId = obligation.workId;
+    await ctx.db.delete(obligation._id);
+    if (!workId) continue;
+    const remaining = await ctx.db
+      .query("companyMonitoringScanObligations")
+      .withIndex("by_workId", (q) => q.eq("workId", workId))
+      .first();
+    if (remaining) continue;
+    const work = await ctx.db
+      .query("companyMonitoringScanWorkItems")
+      .withIndex("by_workId", (q) => q.eq("workId", workId))
+      .unique();
+    if (work) await ctx.db.delete(work._id);
+  }
+  await updateAccountDueFromWork(ctx, ownerAccountId);
+  return { complete: page.length <= SCAN_PURGE_OBLIGATION_BATCH_SIZE };
+}
+
+/** Delete one bounded, account-leading page during destructive account purge. */
+export async function purgeAccountScanStateBatch(
+  ctx: MutationCtx,
+  ownerAccountId: string,
+) {
+  const states = ["due", "leased", "complete", "non_reassuring", "cancelled"] as const;
+  const works: Work[] = [];
+  for (const state of states) {
+    const remaining = SCAN_PURGE_WORK_BATCH_SIZE + 1 - works.length;
+    if (remaining <= 0) break;
+    works.push(...await ctx.db
+      .query("companyMonitoringScanWorkItems")
+      .withIndex("by_account_state_selectionDueAt", (q) =>
+        q.eq("ownerAccountId", ownerAccountId).eq("state", state),
+      )
+      .take(remaining));
+  }
+  const workBatch = works.slice(0, SCAN_PURGE_WORK_BATCH_SIZE);
+  for (const work of workBatch) {
+    const obligations = await ctx.db
+      .query("companyMonitoringScanObligations")
+      .withIndex("by_workId", (q) => q.eq("workId", work.workId))
+      .take(MAX_COHORT_COMPANIES + 1);
+    if (obligations.length > MAX_COHORT_COMPANIES) {
+      throw new ConvexError("COMPANY_MONITORING_WORK_OBLIGATIONS_INVALID");
+    }
+    for (const obligation of obligations) await ctx.db.delete(obligation._id);
+    await ctx.db.delete(work._id);
+  }
+  if (works.length > SCAN_PURGE_WORK_BATCH_SIZE) return { complete: false };
+
+  const obligationPage = await ctx.db
+    .query("companyMonitoringScanObligations")
+    .withIndex("by_account_company_source", (q) => q.eq("ownerAccountId", ownerAccountId))
+    .take(SCAN_PURGE_OBLIGATION_BATCH_SIZE + 1);
+  for (const obligation of obligationPage.slice(0, SCAN_PURGE_OBLIGATION_BATCH_SIZE)) {
+    await ctx.db.delete(obligation._id);
+  }
+  return { complete: obligationPage.length <= SCAN_PURGE_OBLIGATION_BATCH_SIZE };
 }
 
 async function dueWorkForAccount(
@@ -646,6 +845,72 @@ export const scheduleAccountWork = internalMutation({
     companyIds: v.array(v.string()),
   },
   handler: scheduleAccountWorkHandler,
+});
+
+// Import actions can be retried after row mutations committed but before all
+// cohort scheduling finished. Filter each fixed-size cohort in Convex so only
+// companies missing this source join new work; already durable obligations are
+// left untouched even when created and replayed rows are mixed.
+export const ensureAccountWork = internalMutation({
+  args: {
+    ownerAccountId: v.string(),
+    source: companyMonitoringScanSourceValidator,
+    companyIds: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const companyIds = [...new Set(args.companyIds)].sort();
+    if (companyIds.length === 0 || companyIds.length > MAX_COHORT_COMPANIES) {
+      throw new ConvexError("INVALID_COMPANY_MONITORING_COHORT");
+    }
+    const missing: string[] = [];
+    for (const companyId of companyIds) {
+      if (!await activeCompany(ctx, args.ownerAccountId, companyId)) continue;
+      const obligation = await ctx.db
+        .query("companyMonitoringScanObligations")
+        .withIndex("by_account_company_source", (q) =>
+          q
+            .eq("ownerAccountId", args.ownerAccountId)
+            .eq("companyId", companyId)
+            .eq("source", args.source),
+        )
+        .unique();
+      if (!obligation || obligation.state === "cancelled") missing.push(companyId);
+    }
+    if (missing.length === 0) return { status: "replayed" as const };
+    return scheduleAccountWorkHandler(ctx, {
+      ownerAccountId: args.ownerAccountId,
+      source: args.source,
+      companyIds: missing,
+    });
+  },
+});
+
+export async function scheduleCompanySourcesHandler(
+  ctx: MutationCtx,
+  args: { ownerAccountId: string; companyId: string },
+) {
+  if (!await activeCompany(ctx, args.ownerAccountId, args.companyId)) {
+    return { status: "inactive" as const, sources: 0 };
+  }
+  const results = [];
+  for (const source of ["exa", "x"] as const) {
+    results.push(await scheduleAccountWorkHandler(ctx, {
+      ownerAccountId: args.ownerAccountId,
+      source,
+      companyIds: [args.companyId],
+    }));
+  }
+  return {
+    status: results.some((result) => result.status === "scheduled")
+      ? "scheduled" as const
+      : "replayed" as const,
+    sources: results.length,
+  };
+}
+
+export const scheduleCompanySources = internalMutation({
+  args: { ownerAccountId: v.string(), companyId: v.string() },
+  handler: scheduleCompanySourcesHandler,
 });
 
 // Public worker claims are intentionally targetless. The worker can identify

--- a/convex/companyMonitoring/orchestration.ts
+++ b/convex/companyMonitoring/orchestration.ts
@@ -481,7 +481,10 @@ export async function purgeAccountScanStateBatch(
     for (const obligation of obligations) await ctx.db.delete(obligation._id);
     await ctx.db.delete(work._id);
   }
-  if (works.length > SCAN_PURGE_WORK_BATCH_SIZE) return { complete: false };
+  if (works.length > SCAN_PURGE_WORK_BATCH_SIZE) {
+    await updateAccountDueFromWork(ctx, ownerAccountId);
+    return { complete: false };
+  }
 
   const obligationPage = await ctx.db
     .query("companyMonitoringScanObligations")
@@ -490,6 +493,7 @@ export async function purgeAccountScanStateBatch(
   for (const obligation of obligationPage.slice(0, SCAN_PURGE_OBLIGATION_BATCH_SIZE)) {
     await ctx.db.delete(obligation._id);
   }
+  await updateAccountDueFromWork(ctx, ownerAccountId);
   return { complete: obligationPage.length <= SCAN_PURGE_OBLIGATION_BATCH_SIZE };
 }
 

--- a/convex/companyMonitoring/validators.ts
+++ b/convex/companyMonitoring/validators.ts
@@ -44,3 +44,73 @@ export const companyPatchValidator = v.object({
   }))),
   removeClaimIds: v.optional(v.array(v.string())),
 });
+
+export const companyMonitoringScanSourceValidator = v.union(
+  v.literal("exa"),
+  v.literal("x"),
+);
+
+export const companyMonitoringProviderErrorReasonValidator = v.union(
+  v.literal("timeout"),
+  v.literal("rate_limited"),
+  v.literal("authentication_failed"),
+  v.literal("provider_unavailable"),
+  v.literal("request_rejected"),
+);
+
+export const companyMonitoringNonReassuringReasonValidator = v.union(
+  v.literal("capped"),
+  v.literal("partial"),
+  v.literal("malformed"),
+  v.literal("invalid_empty"),
+  v.literal("provider_error"),
+);
+
+export const companyMonitoringReturnedRangeValidator = v.object({
+  startAt: v.number(),
+  endAt: v.number(),
+});
+
+export const companyMonitoringFinalizeResultValidator = v.union(
+  v.object({
+    type: v.literal("result"),
+    itemCount: v.number(),
+    hasMore: v.boolean(),
+    coverage: v.union(v.literal("complete"), v.literal("partial")),
+    returnedRange: v.optional(companyMonitoringReturnedRangeValidator),
+    checkpoint: v.optional(v.string()),
+    emptyValidated: v.boolean(),
+    costUsdMicros: v.number(),
+  }),
+  v.object({
+    type: v.literal("provider_error"),
+    reason: companyMonitoringProviderErrorReasonValidator,
+    costUsdMicros: v.number(),
+  }),
+);
+
+export const companyMonitoringCompleteReceiptValidator = v.object({
+  kind: v.literal("complete"),
+  reason: v.literal("complete"),
+  completedAt: v.number(),
+  returnedRange: companyMonitoringReturnedRangeValidator,
+  itemCount: v.number(),
+  costUsdMicros: v.number(),
+  sourceCoverage: v.literal("complete"),
+  checkpointAfter: v.string(),
+});
+
+export const companyMonitoringNonReassuringReceiptValidator = v.object({
+  kind: v.literal("non_reassuring"),
+  reason: companyMonitoringNonReassuringReasonValidator,
+  providerReason: v.optional(companyMonitoringProviderErrorReasonValidator),
+  completedAt: v.number(),
+  returnedRange: v.optional(companyMonitoringReturnedRangeValidator),
+  itemCount: v.optional(v.number()),
+  costUsdMicros: v.number(),
+  sourceCoverage: v.union(
+    v.literal("partial"),
+    v.literal("failed"),
+    v.literal("unknown"),
+  ),
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1077,6 +1077,7 @@ export default defineSchema({
     purgePhase: v.union(
       v.literal("none"),
       v.literal("pending"),
+      v.literal("scan"),
       v.literal("companies"),
       v.literal("finalizing"),
       v.literal("complete"),
@@ -1123,7 +1124,12 @@ export default defineSchema({
     importOrdinal: v.optional(v.number()),
     importFingerprint: v.optional(v.string()),
     purgeGeneration: v.number(),
-    purgePhase: v.union(v.literal("none"), v.literal("payload"), v.literal("complete")),
+    purgePhase: v.union(
+      v.literal("none"),
+      v.literal("scan"),
+      v.literal("payload"),
+      v.literal("complete"),
+    ),
     removedAt: v.optional(v.number()),
     createdAt: v.number(),
     updatedAt: v.number(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,6 +7,12 @@ import {
   quietHoursOverrideValidator,
   sensitivityValidator,
 } from "./constants";
+import {
+  companyMonitoringCompleteReceiptValidator,
+  companyMonitoringNonReassuringReasonValidator,
+  companyMonitoringNonReassuringReceiptValidator,
+  companyMonitoringScanSourceValidator,
+} from "./companyMonitoring/validators";
 
 // Subscription status enum — maps Dodo statuses to our internal set
 const subscriptionStatus = v.union(
@@ -60,6 +66,35 @@ const apiPlanLimitCtaKind = v.union(
   v.literal("contact_support"),
   v.literal("none"),
 );
+
+const companyMonitoringObligationIdentity = {
+  obligationId: v.string(),
+  ownerAccountId: v.string(),
+  companyId: v.string(),
+  source: companyMonitoringScanSourceValidator,
+  queryVersion: v.string(),
+  dueAt: v.number(),
+  checkpoint: v.optional(v.string()),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+};
+
+const companyMonitoringWorkIdentity = {
+  workId: v.string(),
+  workKey: v.string(),
+  ownerAccountId: v.string(),
+  cohortKey: v.string(),
+  source: companyMonitoringScanSourceValidator,
+  windowStart: v.number(),
+  windowEnd: v.number(),
+  queryVersion: v.string(),
+  scheduledDueAt: v.number(),
+  selectionDueAt: v.number(),
+  resultCap: v.number(),
+  attemptCount: v.number(),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+};
 
 export default defineSchema({
   userPreferences: defineTable({
@@ -1048,6 +1083,12 @@ export default defineSchema({
     ),
     destructivePurgeStarted: v.boolean(),
     pendingReactivation: v.boolean(),
+    // Durable orchestration cursor. Claims always begin from this indexed
+    // account field and read only a fixed page; work/company tables are never
+    // scanned globally to discover due customer work.
+    nextScanDueAt: v.optional(v.number()),
+    nextExaScanDueAt: v.optional(v.number()),
+    nextXScanDueAt: v.optional(v.number()),
     purgeAfter: v.optional(v.number()),
     purgeCursor: v.optional(v.string()),
     createdAt: v.number(),
@@ -1060,7 +1101,10 @@ export default defineSchema({
     // Consumer: accounts.reconcileAccountEntitlements. Entitlement writes no
     // longer push lapses (#6256), so the reconciler pulls them by scanning
     // entitled roots oldest-first.
-    .index("by_lifecycle_updatedAt", ["lifecycle", "updatedAt"]),
+    .index("by_lifecycle_updatedAt", ["lifecycle", "updatedAt"])
+    .index("by_lifecycle_nextScanDueAt", ["lifecycle", "nextScanDueAt"])
+    .index("by_lifecycle_nextExaScanDueAt", ["lifecycle", "nextExaScanDueAt"])
+    .index("by_lifecycle_nextXScanDueAt", ["lifecycle", "nextXScanDueAt"]),
 
   companyMonitoringCompanies: defineTable({
     ownerAccountId: v.string(),
@@ -1110,6 +1154,101 @@ export default defineSchema({
     updatedAt: v.number(),
   })
     .index("by_account_company", ["ownerAccountId", "companyId"]),
+
+  // One durable company/source obligation. The closed state variants keep a
+  // single uniqueness row while a work item's terminal receipt preserves the
+  // history for every completed window. A failed/non-reassuring attempt never
+  // changes `checkpoint`; a later window reuses that exact value.
+  companyMonitoringScanObligations: defineTable(v.union(
+    v.object({
+      ...companyMonitoringObligationIdentity,
+      state: v.literal("due"),
+      workId: v.string(),
+    }),
+    v.object({
+      ...companyMonitoringObligationIdentity,
+      state: v.literal("leased"),
+      workId: v.string(),
+      leaseToken: v.string(),
+      leaseExpiresAt: v.number(),
+      workerId: v.string(),
+    }),
+    v.object({
+      ...companyMonitoringObligationIdentity,
+      state: v.literal("complete"),
+      workId: v.string(),
+      terminalReceiptId: v.string(),
+      completedAt: v.number(),
+    }),
+    v.object({
+      ...companyMonitoringObligationIdentity,
+      state: v.literal("non_reassuring"),
+      workId: v.string(),
+      terminalReceiptId: v.string(),
+      completedAt: v.number(),
+      reason: companyMonitoringNonReassuringReasonValidator,
+    }),
+    v.object({
+      ...companyMonitoringObligationIdentity,
+      state: v.literal("cancelled"),
+      workId: v.optional(v.string()),
+      cancelledAt: v.number(),
+      reason: v.union(
+        v.literal("company_removed"),
+        v.literal("account_inactive"),
+        v.literal("superseded"),
+      ),
+    }),
+  ))
+    .index("by_obligationId", ["obligationId"])
+    .index("by_account_company_source", ["ownerAccountId", "companyId", "source"])
+    .index("by_workId", ["workId"]),
+
+  // Cohort/source/window work is the sole lease and terminal-receipt
+  // authority. `selectionDueAt` is `scheduledDueAt` while due and the lease
+  // expiry while leased, so crash replay remains an indexed bounded lookup.
+  companyMonitoringScanWorkItems: defineTable(v.union(
+    v.object({
+      ...companyMonitoringWorkIdentity,
+      state: v.literal("due"),
+    }),
+    v.object({
+      ...companyMonitoringWorkIdentity,
+      state: v.literal("leased"),
+      leaseToken: v.string(),
+      leaseExpiresAt: v.number(),
+      workerId: v.string(),
+    }),
+    v.object({
+      ...companyMonitoringWorkIdentity,
+      state: v.literal("complete"),
+      terminalLeaseToken: v.string(),
+      terminalWorkerId: v.string(),
+      terminalReceipt: companyMonitoringCompleteReceiptValidator,
+    }),
+    v.object({
+      ...companyMonitoringWorkIdentity,
+      state: v.literal("non_reassuring"),
+      terminalLeaseToken: v.string(),
+      terminalWorkerId: v.string(),
+      terminalReceipt: companyMonitoringNonReassuringReceiptValidator,
+    }),
+    v.object({
+      ...companyMonitoringWorkIdentity,
+      state: v.literal("cancelled"),
+      cancelledAt: v.number(),
+      cancelReason: v.union(
+        v.literal("company_removed"),
+        v.literal("account_inactive"),
+        v.literal("superseded"),
+      ),
+    }),
+  ))
+    .index("by_workId", ["workId"])
+    .index("by_workKey", ["workKey"])
+    .index("by_account_state_selectionDueAt", ["ownerAccountId", "state", "selectionDueAt"])
+    .index("by_account_source_state_selectionDueAt", ["ownerAccountId", "source", "state", "selectionDueAt"])
+    .index("by_state_selectionDueAt", ["state", "selectionDueAt"]),
 
   userApiKeys: defineTable({
     userId: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1084,10 +1084,9 @@ export default defineSchema({
     ),
     destructivePurgeStarted: v.boolean(),
     pendingReactivation: v.boolean(),
-    // Durable orchestration cursor. Claims always begin from this indexed
-    // account field and read only a fixed page; work/company tables are never
+    // Durable orchestration cursors. Claims always begin from these indexed
+    // account fields and read only a fixed page; work/company tables are never
     // scanned globally to discover due customer work.
-    nextScanDueAt: v.optional(v.number()),
     nextExaScanDueAt: v.optional(v.number()),
     nextXScanDueAt: v.optional(v.number()),
     purgeAfter: v.optional(v.number()),
@@ -1103,7 +1102,6 @@ export default defineSchema({
     // longer push lapses (#6256), so the reconciler pulls them by scanning
     // entitled roots oldest-first.
     .index("by_lifecycle_updatedAt", ["lifecycle", "updatedAt"])
-    .index("by_lifecycle_nextScanDueAt", ["lifecycle", "nextScanDueAt"])
     .index("by_lifecycle_nextExaScanDueAt", ["lifecycle", "nextExaScanDueAt"])
     .index("by_lifecycle_nextXScanDueAt", ["lifecycle", "nextXScanDueAt"]),
 
@@ -1206,9 +1204,23 @@ export default defineSchema({
       ),
     }),
   ))
-    .index("by_obligationId", ["obligationId"])
     .index("by_account_company_source", ["ownerAccountId", "companyId", "source"])
     .index("by_workId", ["workId"]),
+
+  // Durable cohort membership for terminal receipts. Live obligations move
+  // to the next due work item, while these bounded links retain which
+  // companies the immutable terminal work receipt covered. Company purge
+  // removes its links page-by-page and deletes a receipt only after the final
+  // cohort member link is gone.
+  companyMonitoringScanReceiptLinks: defineTable({
+    ownerAccountId: v.string(),
+    companyId: v.string(),
+    workId: v.string(),
+    createdAt: v.number(),
+  })
+    .index("by_account_company", ["ownerAccountId", "companyId"])
+    .index("by_workId", ["workId"])
+    .index("by_workId_company", ["workId", "companyId"]),
 
   // Cohort/source/window work is the sole lease and terminal-receipt
   // authority. `selectionDueAt` is `scheduledDueAt` while due and the lease
@@ -1253,8 +1265,7 @@ export default defineSchema({
     .index("by_workId", ["workId"])
     .index("by_workKey", ["workKey"])
     .index("by_account_state_selectionDueAt", ["ownerAccountId", "state", "selectionDueAt"])
-    .index("by_account_source_state_selectionDueAt", ["ownerAccountId", "source", "state", "selectionDueAt"])
-    .index("by_state_selectionDueAt", ["state", "selectionDueAt"]),
+    .index("by_account_source_state_selectionDueAt", ["ownerAccountId", "source", "state", "selectionDueAt"]),
 
   userApiKeys: defineTable({
     userId: v.string(),

--- a/docs/api-platform.mdx
+++ b/docs/api-platform.mdx
@@ -81,8 +81,8 @@ Monitor via UptimeRobot / Better Stack with `?compact=1` — alert on any status
   "status": "HEALTHY",
   "checkedAt": "2026-08-07T12:00:00Z",
   "summary": {
-    "total": 257,
-    "ok": 257,
+    "total": 258,
+    "ok": 258,
     "warn": 0,
     "onDemandWarn": 0,
     "staleContent": 0,

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -303,7 +303,7 @@
   },
   "healthProbedKeys": {
     "bootstrap": 109,
-    "standalone": 148,
-    "total": 257
+    "standalone": 149,
+    "total": 258
   }
 }

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -36,8 +36,8 @@ Primary health endpoint. Checks all Redis-backed data keys and seed freshness me
 {
   "status": "HEALTHY | WARNING | DEGRADED | UNHEALTHY | REDIS_DOWN",
   "summary": {
-    "total": 257,
-    "ok": 257,
+    "total": 258,
+    "ok": 258,
     "warn": 0,
     "onDemandWarn": 0,
     "staleContent": 0,

--- a/docs/zh/api-platform.mdx
+++ b/docs/zh/api-platform.mdx
@@ -76,8 +76,8 @@ description: "World Monitor 平台基础设施端点完整参考：涵盖引导�
   "status": "HEALTHY",
   "checkedAt": "2026-08-07T12:00:00Z",
   "summary": {
-    "total": 257,
-    "ok": 257,
+    "total": 258,
+    "ok": 258,
     "warn": 0,
     "onDemandWarn": 0,
     "staleContent": 0,

--- a/docs/zh/health-endpoints.mdx
+++ b/docs/zh/health-endpoints.mdx
@@ -36,8 +36,8 @@ description: "World Monitor 提供两个健康检查端点用于持续监控数�
 {
   "status": "HEALTHY | WARNING | DEGRADED | UNHEALTHY | REDIS_DOWN",
   "summary": {
-    "total": 257,
-    "ok": 257,
+    "total": 258,
+    "ok": 258,
     "warn": 0,
     "onDemandWarn": 0,
     "staleContent": 0,

--- a/scripts/company-monitoring-worker.mjs
+++ b/scripts/company-monitoring-worker.mjs
@@ -15,11 +15,11 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { pathToFileURL } from 'node:url';
 import { ConvexHttpClient } from 'convex/browser';
 import { anyApi } from 'convex/server';
 
 import { loadEnvFile } from './_seed-utils.mjs';
+import { isMainModule } from './lib/main-module.mjs';
 
 export const COMPANY_MONITORING_WORKER_HEALTH_KEY = 'company-monitoring:worker-health:v1';
 export const COMPANY_MONITORING_WORKER_META_KEY = 'seed-meta:company-monitoring:worker';
@@ -52,6 +52,12 @@ const HEALTH_OUTCOMES = new Set([
   'claim_error',
   'finalize_error',
 ]);
+const HEALTHY_OUTCOMES = new Set([
+  'disabled',
+  'idle',
+  'completed',
+  'replayed',
+]);
 
 /** @typedef {'ok' | 'error'} WorkerHealthStatus */
 /** @typedef {'starting' | 'disabled' | 'idle' | 'completed' | 'non_reassuring' | 'fenced' | 'replayed' | 'claim_error' | 'finalize_error'} WorkerOutcome */
@@ -64,19 +70,21 @@ function projectCounters(value) {
   return Object.fromEntries(COUNTER_NAMES.map((name) => [name, boundedCounter(value?.[name])]));
 }
 
+function providerCoverage(outcome) {
+  if (outcome === 'completed') return 'complete';
+  if (outcome === 'non_reassuring') return 'non_reassuring';
+  return 'not_evaluated';
+}
+
 function workerHealthPayload(input, now) {
-  const status = input?.status === 'error' ? 'error' : 'ok';
   const outcome = HEALTH_OUTCOMES.has(input?.outcome) ? input.outcome : 'starting';
+  const status = input?.status === 'ok' && HEALTHY_OUTCOMES.has(outcome) ? 'ok' : 'error';
   return {
     version: 1,
     status,
     outcome,
     observedAt: now,
-    providerCoverage: outcome === 'completed'
-      ? 'complete'
-      : outcome === 'non_reassuring'
-        ? 'non_reassuring'
-        : 'not_evaluated',
+    providerCoverage: providerCoverage(outcome),
     counters: projectCounters(input?.counters),
   };
 }
@@ -119,6 +127,7 @@ export function createRedisHealthPublisher(options = {}) {
         'SET',
         COMPANY_MONITORING_WORKER_ACTIVATION_KEY,
         JSON.stringify({ version: 1, activatedAt: observedAt }),
+        'NX',
       ]);
     }
 
@@ -154,10 +163,6 @@ async function unavailableExecutor() {
   };
 }
 
-function delay(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 /**
  * ConvexHttpClient has no default request timeout. Keep every control-plane
  * request inside the lease budget and identify this server-side caller.
@@ -189,7 +194,6 @@ export function createConvexFetch(fetchImpl = globalThis.fetch) {
  * @param {(work: Record<string, unknown>) => Promise<Record<string, unknown>>} [options.executeClaim]
  * @param {(result: Record<string, unknown>, work: Record<string, unknown>) => Promise<void>} [options.afterExecute]
  * @param {(payload: Record<string, unknown>) => Promise<unknown>} [options.publishHealth]
- * @param {(ms: number) => Promise<void>} [options.sleep]
  * @param {number} [options.pollIntervalMs]
  * @param {{ warn?: (...args: unknown[]) => void }} [options.logger]
  */
@@ -201,7 +205,6 @@ export function createCompanyMonitoringWorker(options) {
     executeClaim = unavailableExecutor,
     afterExecute,
     publishHealth = async () => false,
-    sleep = delay,
     pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
     logger = console,
   } = options;
@@ -211,7 +214,8 @@ export function createCompanyMonitoringWorker(options) {
 
   let stopping = false;
   let stopSignal = null;
-  let wakeSleep = null;
+  let pollTimer = null;
+  let finishPoll = null;
   let inFlight = false;
   const counters = projectCounters({});
 
@@ -293,14 +297,23 @@ export function createCompanyMonitoringWorker(options) {
       await safePublish('error', 'finalize_error');
       return 'finalize_error';
     }
-    await safePublish('ok', outcome);
+    await safePublish(HEALTHY_OUTCOMES.has(outcome) ? 'ok' : 'error', outcome);
     return outcome;
   };
 
-  const waitForNextPoll = () => Promise.race([
-    sleep(Math.max(0, pollIntervalMs)),
-    new Promise((resolve) => { wakeSleep = resolve; }),
-  ]).finally(() => { wakeSleep = null; });
+  const waitForNextPoll = () => new Promise((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      if (pollTimer !== null) clearTimeout(pollTimer);
+      pollTimer = null;
+      finishPoll = null;
+      resolve();
+    };
+    finishPoll = finish;
+    pollTimer = setTimeout(finish, Math.max(0, pollIntervalMs));
+  });
 
   return {
     tick,
@@ -313,7 +326,7 @@ export function createCompanyMonitoringWorker(options) {
     requestStop(signal = 'SIGTERM') {
       stopping = true;
       stopSignal = signal;
-      wakeSleep?.();
+      finishPoll?.();
     },
     snapshot() {
       return {
@@ -363,8 +376,7 @@ async function main() {
   console.log(`[company-monitoring-worker] shutdown complete (${shutdownSignal} received)`);
 }
 
-const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
-if (isMain) {
+if (isMainModule(import.meta.url, process.argv[1])) {
   main().catch((error) => {
     console.error('[company-monitoring-worker] fatal:', error?.message ?? String(error));
     process.exitCode = 1;

--- a/scripts/company-monitoring-worker.mjs
+++ b/scripts/company-monitoring-worker.mjs
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Company Monitoring scan worker — always-on Railway service.
+ *
+ * Railway config:
+ *   - Service name: company-monitoring-worker
+ *   rootDirectory: scripts
+ *   startCommand: node company-monitoring-worker.mjs
+ *   cronSchedule: <none> (always-on long-running process)
+ *
+ * Convex owns work selection, leases, replay, checkpoints, and receipts. This
+ * process accepts no tenant target. Redis receives only disposable, bounded
+ * control-plane health metadata and is never part of the work protocol.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+import { ConvexHttpClient } from 'convex/browser';
+import { anyApi } from 'convex/server';
+
+import { loadEnvFile } from './_seed-utils.mjs';
+
+export const COMPANY_MONITORING_WORKER_HEALTH_KEY = 'company-monitoring:worker-health:v1';
+export const COMPANY_MONITORING_WORKER_META_KEY = 'seed-meta:company-monitoring:worker';
+export const COMPANY_MONITORING_WORKER_ACTIVATION_KEY = 'seed-activated:company-monitoring:worker';
+
+const HEALTH_TTL_SECONDS = 900;
+const META_TTL_SECONDS = 86_400;
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const CONVEX_TIMEOUT_MS = 15_000;
+const REDIS_TIMEOUT_MS = 5_000;
+const COUNTER_NAMES = Object.freeze([
+  'loops',
+  'claims',
+  'completed',
+  'nonReassuring',
+  'fenced',
+  'replayed',
+  'executorErrors',
+  'claimErrors',
+  'finalizeErrors',
+]);
+const HEALTH_OUTCOMES = new Set([
+  'starting',
+  'disabled',
+  'idle',
+  'completed',
+  'non_reassuring',
+  'fenced',
+  'replayed',
+  'claim_error',
+  'finalize_error',
+]);
+
+/** @typedef {'ok' | 'error'} WorkerHealthStatus */
+/** @typedef {'starting' | 'disabled' | 'idle' | 'completed' | 'non_reassuring' | 'fenced' | 'replayed' | 'claim_error' | 'finalize_error'} WorkerOutcome */
+
+function boundedCounter(value) {
+  return Number.isSafeInteger(value) && value >= 0 ? Math.min(value, 9_999_999_999) : 0;
+}
+
+function projectCounters(value) {
+  return Object.fromEntries(COUNTER_NAMES.map((name) => [name, boundedCounter(value?.[name])]));
+}
+
+function workerHealthPayload(input, now) {
+  const status = input?.status === 'error' ? 'error' : 'ok';
+  const outcome = HEALTH_OUTCOMES.has(input?.outcome) ? input.outcome : 'starting';
+  return {
+    version: 1,
+    status,
+    outcome,
+    observedAt: now,
+    providerCoverage: outcome === 'completed'
+      ? 'complete'
+      : outcome === 'non_reassuring'
+        ? 'non_reassuring'
+        : 'not_evaluated',
+    counters: projectCounters(input?.counters),
+  };
+}
+
+/**
+ * Create a best-effort Redis publisher. Failure is returned as `false`; it is
+ * never allowed to change claim/finalize behavior.
+ *
+ * @param {object} [options]
+ * @param {Record<string, string | undefined>} [options.env]
+ * @param {typeof fetch} [options.fetchImpl]
+ * @param {() => number} [options.now]
+ * @param {{ warn?: (...args: unknown[]) => void }} [options.logger]
+ */
+export function createRedisHealthPublisher(options = {}) {
+  const env = options.env ?? process.env;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? Date.now;
+  const logger = options.logger ?? console;
+
+  return async (input) => {
+    const url = env.UPSTASH_REDIS_REST_URL?.replace(/\/+$/, '');
+    const token = env.UPSTASH_REDIS_REST_TOKEN;
+    if (!url || !token) return false;
+
+    const observedAt = now();
+    const canonical = workerHealthPayload(input, observedAt);
+    const meta = {
+      ...canonical,
+      fetchedAt: observedAt,
+      recordCount: 1,
+      sourceState: canonical.status === 'ok' ? 'ok' : 'error',
+    };
+    const commands = [
+      ['SET', COMPANY_MONITORING_WORKER_HEALTH_KEY, JSON.stringify(canonical), 'EX', String(HEALTH_TTL_SECONDS)],
+      ['SET', COMPANY_MONITORING_WORKER_META_KEY, JSON.stringify(meta), 'EX', String(META_TTL_SECONDS)],
+    ];
+    if (canonical.status === 'ok') {
+      commands.push([
+        'SET',
+        COMPANY_MONITORING_WORKER_ACTIVATION_KEY,
+        JSON.stringify({ version: 1, activatedAt: observedAt }),
+      ]);
+    }
+
+    try {
+      const response = await fetchImpl(`${url}/pipeline`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'worldmonitor-company-monitoring-worker/1.0',
+        },
+        body: JSON.stringify(commands),
+        signal: AbortSignal.timeout(REDIS_TIMEOUT_MS),
+      });
+      if (!response.ok) throw new Error(`Redis health HTTP ${response.status}`);
+      const results = await response.json();
+      if (!Array.isArray(results) || results.some((result) => result?.error)) {
+        throw new Error('Redis health pipeline rejected a command');
+      }
+      return true;
+    } catch (error) {
+      logger.warn?.('[company-monitoring-worker] health publish unavailable:', error?.message ?? String(error));
+      return false;
+    }
+  };
+}
+
+async function unavailableExecutor() {
+  return {
+    type: 'provider_error',
+    reason: 'provider_unavailable',
+    costUsdMicros: 0,
+  };
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * ConvexHttpClient has no default request timeout. Keep every control-plane
+ * request inside the lease budget and identify this server-side caller.
+ *
+ * @param {typeof fetch} [fetchImpl]
+ * @returns {typeof fetch}
+ */
+export function createConvexFetch(fetchImpl = globalThis.fetch) {
+  return (input, init = {}) => {
+    const headers = new Headers(init.headers);
+    headers.set('User-Agent', 'worldmonitor-company-monitoring-worker/1.0');
+    return fetchImpl(input, {
+      ...init,
+      headers,
+      signal: init.signal ?? AbortSignal.timeout(CONVEX_TIMEOUT_MS),
+    });
+  };
+}
+
+/**
+ * Create the control loop with explicit seams for local replay and shutdown
+ * tests. `afterExecute` models the exact crash point after provider fetch and
+ * before finalize; production leaves it unset.
+ *
+ * @param {object} options
+ * @param {{ mutation: (fn: unknown, args: Record<string, unknown>) => Promise<any> }} options.client
+ * @param {string} options.secret
+ * @param {string} options.workerId
+ * @param {(work: Record<string, unknown>) => Promise<Record<string, unknown>>} [options.executeClaim]
+ * @param {(result: Record<string, unknown>, work: Record<string, unknown>) => Promise<void>} [options.afterExecute]
+ * @param {(payload: Record<string, unknown>) => Promise<unknown>} [options.publishHealth]
+ * @param {(ms: number) => Promise<void>} [options.sleep]
+ * @param {number} [options.pollIntervalMs]
+ * @param {{ warn?: (...args: unknown[]) => void }} [options.logger]
+ */
+export function createCompanyMonitoringWorker(options) {
+  const {
+    client,
+    secret,
+    workerId,
+    executeClaim = unavailableExecutor,
+    afterExecute,
+    publishHealth = async () => false,
+    sleep = delay,
+    pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+    logger = console,
+  } = options;
+  if (!client || typeof client.mutation !== 'function') throw new Error('Convex client is required');
+  if (!secret) throw new Error('COMPANY_MONITORING_WORKER_SECRET is required');
+  if (!workerId) throw new Error('workerId is required');
+
+  let stopping = false;
+  let stopSignal = null;
+  let wakeSleep = null;
+  let inFlight = false;
+  const counters = projectCounters({});
+
+  const safePublish = async (status, outcome) => {
+    try {
+      await publishHealth({ status, outcome, counters: projectCounters(counters) });
+    } catch (error) {
+      logger.warn?.('[company-monitoring-worker] health publisher failed:', error?.message ?? String(error));
+    }
+  };
+
+  const tick = async () => {
+    if (stopping) return 'stopping';
+    counters.loops += 1;
+    let claim;
+    try {
+      claim = await client.mutation(
+        anyApi.companyMonitoring.orchestration.claimNextWork,
+        { secret, workerId },
+      );
+    } catch {
+      counters.claimErrors += 1;
+      await safePublish('error', 'claim_error');
+      return 'claim_error';
+    }
+
+    if (claim?.status === 'disabled' || claim?.status === 'idle') {
+      await safePublish('ok', claim.status);
+      return claim.status;
+    }
+    if (claim?.status !== 'claimed' || !claim.work) {
+      counters.claimErrors += 1;
+      await safePublish('error', 'claim_error');
+      return 'claim_error';
+    }
+
+    counters.claims += 1;
+    inFlight = true;
+    let result;
+    try {
+      result = await executeClaim(claim.work);
+    } catch {
+      counters.executorErrors += 1;
+      result = await unavailableExecutor();
+    }
+
+    // This test-only hook deliberately remains outside the executor catch. A
+    // throw models abrupt process death: no finalize is attempted, so Convex
+    // alone decides when the expired lease can be replayed with a fresh fence.
+    if (afterExecute) await afterExecute(result, claim.work);
+
+    let finalized;
+    try {
+      finalized = await client.mutation(
+        anyApi.companyMonitoring.orchestration.finalizeWork,
+        {
+          secret,
+          workerId,
+          workId: claim.work.workId,
+          leaseToken: claim.work.leaseToken,
+          result,
+        },
+      );
+    } catch {
+      inFlight = false;
+      counters.finalizeErrors += 1;
+      await safePublish('error', 'finalize_error');
+      return 'finalize_error';
+    }
+    inFlight = false;
+
+    const outcome = finalized?.status;
+    if (outcome === 'completed') counters.completed += 1;
+    else if (outcome === 'non_reassuring') counters.nonReassuring += 1;
+    else if (outcome === 'fenced') counters.fenced += 1;
+    else if (outcome === 'replayed') counters.replayed += 1;
+    else {
+      counters.finalizeErrors += 1;
+      await safePublish('error', 'finalize_error');
+      return 'finalize_error';
+    }
+    await safePublish('ok', outcome);
+    return outcome;
+  };
+
+  const waitForNextPoll = () => Promise.race([
+    sleep(Math.max(0, pollIntervalMs)),
+    new Promise((resolve) => { wakeSleep = resolve; }),
+  ]).finally(() => { wakeSleep = null; });
+
+  return {
+    tick,
+    async run() {
+      while (!stopping) {
+        await tick();
+        if (!stopping) await waitForNextPoll();
+      }
+    },
+    requestStop(signal = 'SIGTERM') {
+      stopping = true;
+      stopSignal = signal;
+      wakeSleep?.();
+    },
+    snapshot() {
+      return {
+        stopping,
+        stopSignal,
+        inFlight,
+        counters: projectCounters(counters),
+      };
+    },
+  };
+}
+
+async function main() {
+  loadEnvFile(import.meta.url, {
+    only: [
+      'CONVEX_URL',
+      'COMPANY_MONITORING_WORKER_SECRET',
+      'UPSTASH_REDIS_REST_URL',
+      'UPSTASH_REDIS_REST_TOKEN',
+    ],
+  });
+  const convexUrl = process.env.CONVEX_URL;
+  const secret = process.env.COMPANY_MONITORING_WORKER_SECRET;
+  if (!convexUrl || !secret) {
+    throw new Error('CONVEX_URL and COMPANY_MONITORING_WORKER_SECRET are required');
+  }
+
+  const client = new ConvexHttpClient(convexUrl, { fetch: createConvexFetch() });
+  const worker = createCompanyMonitoringWorker({
+    client,
+    secret,
+    workerId: `railway-${process.pid}-${randomUUID()}`,
+    publishHealth: createRedisHealthPublisher(),
+  });
+  let shutdownSignal = 'SIGTERM';
+  process.on('SIGTERM', () => {
+    shutdownSignal = 'SIGTERM';
+    worker.requestStop(shutdownSignal);
+  });
+  process.on('SIGINT', () => {
+    shutdownSignal = 'SIGINT';
+    worker.requestStop(shutdownSignal);
+  });
+
+  console.log('[company-monitoring-worker] control loop started');
+  await worker.run();
+  console.log(`[company-monitoring-worker] shutdown complete (${shutdownSignal} received)`);
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main().catch((error) => {
+    console.error('[company-monitoring-worker] fatal:', error?.message ?? String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1168,6 +1168,7 @@
       "scripts/_seed-utils.mjs",
       "scripts/company-monitoring-worker.mjs",
       "scripts/lib/llm-telemetry.cjs",
+      "scripts/lib/main-module.mjs",
       "scripts/nixpacks.toml",
       "scripts/package-lock.json",
       "scripts/package.json"

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1151,6 +1151,31 @@
     "documentedAt": "docs/railway-seed-consolidation-runbook.md#bundle-11-seed-bundle-relay-backup"
   },
   {
+    "entry": "scripts/company-monitoring-worker.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "company-monitoring-worker",
+    "startCommand": "node company-monitoring-worker.mjs",
+    "requiredEnv": [
+      "CONVEX_URL",
+      "COMPANY_MONITORING_WORKER_SECRET",
+      "UPSTASH_REDIS_REST_URL",
+      "UPSTASH_REDIS_REST_TOKEN"
+    ],
+    "watchPatterns": [
+      "scripts/_proxy-utils.cjs",
+      "scripts/_seed-contract.mjs",
+      "scripts/_seed-envelope-source.mjs",
+      "scripts/_seed-utils.mjs",
+      "scripts/company-monitoring-worker.mjs",
+      "scripts/lib/llm-telemetry.cjs",
+      "scripts/nixpacks.toml",
+      "scripts/package-lock.json",
+      "scripts/package.json"
+    ],
+    "cronSchedule": null,
+    "documentedAt": "scripts/company-monitoring-worker.mjs (header docblock declares rootDirectory: scripts)"
+  },
+  {
     "entry": "scripts/scenario-worker.mjs",
     "deployMode": "nixpacks-root-scripts",
     "service": "scenario-worker",

--- a/tests/company-monitoring-worker-registration.test.mjs
+++ b/tests/company-monitoring-worker-registration.test.mjs
@@ -30,6 +30,7 @@ describe('company monitoring worker deployment registration', () => {
       'scripts/_seed-contract.mjs',
       'scripts/_seed-envelope-source.mjs',
       'scripts/lib/llm-telemetry.cjs',
+      'scripts/lib/main-module.mjs',
       'scripts/nixpacks.toml',
       'scripts/package.json',
       'scripts/package-lock.json',

--- a/tests/company-monitoring-worker-registration.test.mjs
+++ b/tests/company-monitoring-worker-registration.test.mjs
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+import { __testing__ as health } from '../api/health.js';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const registry = JSON.parse(readFileSync(resolve(repoRoot, 'scripts/railway-services.json'), 'utf8'));
+
+describe('company monitoring worker deployment registration', () => {
+  it('registers an always-on scripts-root Railway service with its full dependency closure', () => {
+    const service = registry.find((entry) => entry.service === 'company-monitoring-worker');
+    assert.ok(service);
+    assert.equal(service.entry, 'scripts/company-monitoring-worker.mjs');
+    assert.equal(service.deployMode, 'nixpacks-root-scripts');
+    assert.equal(service.startCommand, 'node company-monitoring-worker.mjs');
+    assert.equal(service.cronSchedule, null);
+    assert.deepEqual(service.requiredEnv, [
+      'CONVEX_URL',
+      'COMPANY_MONITORING_WORKER_SECRET',
+      'UPSTASH_REDIS_REST_URL',
+      'UPSTASH_REDIS_REST_TOKEN',
+    ]);
+    for (const dependency of [
+      'scripts/company-monitoring-worker.mjs',
+      'scripts/_proxy-utils.cjs',
+      'scripts/_seed-utils.mjs',
+      'scripts/_seed-contract.mjs',
+      'scripts/_seed-envelope-source.mjs',
+      'scripts/lib/llm-telemetry.cjs',
+      'scripts/nixpacks.toml',
+      'scripts/package.json',
+      'scripts/package-lock.json',
+    ]) {
+      assert.ok(service.watchPatterns.includes(dependency), `${dependency} must trigger a deploy`);
+    }
+  });
+
+  it('softens only the pre-activation window and registers strict worker freshness', () => {
+    assert.equal(health.STANDALONE_KEYS.companyMonitoringWorker, 'company-monitoring:worker-health:v1');
+    assert.deepEqual(health.SEED_META.companyMonitoringWorker, {
+      key: 'seed-meta:company-monitoring:worker',
+      maxStaleMin: 5,
+      workerControl: true,
+    });
+    assert.equal(health.ON_DEMAND_KEYS.has('companyMonitoringWorker'), true);
+    assert.equal(
+      health.ACTIVATION_MARKERS.companyMonitoringWorker,
+      'seed-activated:company-monitoring:worker',
+    );
+
+    const base = {
+      keyStrens: new Map([['company-monitoring:worker-health:v1', 0]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map([['seed-meta:company-monitoring:worker', null]]),
+      keyMetaErrors: new Map(),
+      now: 1_800_000_000_000,
+    };
+    assert.equal(health.classifyKey(
+      'companyMonitoringWorker',
+      'company-monitoring:worker-health:v1',
+      { allowOnDemand: true },
+      { ...base, activationStates: new Map([['companyMonitoringWorker', false]]) },
+    ).status, 'EMPTY_ON_DEMAND');
+    assert.equal(health.classifyKey(
+      'companyMonitoringWorker',
+      'company-monitoring:worker-health:v1',
+      { allowOnDemand: true },
+      { ...base, activationStates: new Map([['companyMonitoringWorker', true]]) },
+    ).status, 'EMPTY');
+  });
+
+  it('projects only the closed worker control-plane status, outcome, and counters', () => {
+    const redisKey = 'company-monitoring:worker-health:v1';
+    const metaKey = 'seed-meta:company-monitoring:worker';
+    const entry = health.classifyKey(
+      'companyMonitoringWorker',
+      redisKey,
+      { allowOnDemand: true },
+      {
+        keyStrens: new Map([[redisKey, 120]]),
+        keyErrors: new Map(),
+        keyMetaValues: new Map([[metaKey, JSON.stringify({
+          fetchedAt: 1_800_000_000_000,
+          recordCount: 1,
+          sourceState: 'ok',
+          status: 'ok',
+          outcome: 'disabled',
+          counters: { loops: 2, claims: 0, unexpected: 99 },
+          secret: 'must-not-project',
+        })]]),
+        keyMetaErrors: new Map(),
+        activationStates: new Map([['companyMonitoringWorker', true]]),
+        now: 1_800_000_000_000,
+      },
+    );
+
+    assert.equal(entry.status, 'OK');
+    assert.deepEqual(entry.workerControl, {
+      status: 'ok',
+      outcome: 'disabled',
+      counters: {
+        loops: 2,
+        claims: 0,
+        completed: 0,
+        nonReassuring: 0,
+        fenced: 0,
+        replayed: 0,
+        executorErrors: 0,
+        claimErrors: 0,
+        finalizeErrors: 0,
+      },
+    });
+    assert.equal(JSON.stringify(entry).includes('must-not-project'), false);
+  });
+});

--- a/tests/company-monitoring-worker.test.mjs
+++ b/tests/company-monitoring-worker.test.mjs
@@ -105,6 +105,7 @@ describe('company monitoring Railway worker', () => {
 
   it('fails closed with provider_unavailable when no provider adapter is installed', async () => {
     const calls = [];
+    const health = [];
     const client = convexClient([
       CLAIM,
       { status: 'non_reassuring', reason: 'provider_error', receipt: {} },
@@ -113,7 +114,7 @@ describe('company monitoring Railway worker', () => {
       client,
       secret: 'worker-secret',
       workerId: 'worker-a',
-      publishHealth: async () => true,
+      publishHealth: async (payload) => { health.push(payload); },
     });
 
     assert.equal(await worker.tick(), 'non_reassuring');
@@ -122,6 +123,8 @@ describe('company monitoring Railway worker', () => {
       reason: 'provider_unavailable',
       costUsdMicros: 0,
     });
+    assert.equal(health.at(-1).status, 'error');
+    assert.equal(health.at(-1).outcome, 'non_reassuring');
   });
 
   it('leaves a fetched result unfinalized on a hard crash and safely finalizes the replayed work', async () => {
@@ -172,6 +175,7 @@ describe('company monitoring Railway worker', () => {
 
     assert.equal(await worker.tick(), 'fenced');
     assert.equal(calls.length, 2);
+    assert.equal(health.at(-1).status, 'error');
     assert.equal(health.at(-1).outcome, 'fenced');
     assert.equal(health.at(-1).counters.fenced, 1);
   });
@@ -194,7 +198,6 @@ describe('company monitoring Railway worker', () => {
         return COMPLETE_RESULT;
       },
       publishHealth: async () => true,
-      sleep: async () => {},
     });
 
     const running = worker.run();
@@ -204,6 +207,25 @@ describe('company monitoring Railway worker', () => {
     await running;
 
     assert.equal(calls.length, 2, 'one claim and its finalize; no second claim');
+    assert.equal(worker.snapshot().stopping, true);
+  });
+
+  it('cancels the pending poll timer on SIGTERM instead of delaying shutdown', async () => {
+    const published = deferred();
+    const client = convexClient([{ status: 'idle' }]);
+    const worker = createCompanyMonitoringWorker({
+      client,
+      secret: 'worker-secret',
+      workerId: 'worker-a',
+      pollIntervalMs: 60_000,
+      publishHealth: async () => { published.resolve(); },
+    });
+
+    const running = worker.run();
+    await published.promise;
+    worker.requestStop('SIGTERM');
+    await running;
+
     assert.equal(worker.snapshot().stopping, true);
   });
 });
@@ -234,6 +256,7 @@ describe('company monitoring worker health projection', () => {
     assert.equal(commands[0][1], COMPANY_MONITORING_WORKER_HEALTH_KEY);
     assert.equal(commands[1][1], COMPANY_MONITORING_WORKER_META_KEY);
     assert.deepEqual(commands[2].slice(0, 2), ['SET', COMPANY_MONITORING_WORKER_ACTIVATION_KEY]);
+    assert.equal(commands[2].at(-1), 'NX');
     assert.equal(commands[2].includes('EX'), false, 'activation marker must have no TTL');
     const canonical = JSON.parse(commands[0][2]);
     const meta = JSON.parse(commands[1][2]);
@@ -244,7 +267,7 @@ describe('company monitoring worker health projection', () => {
     assert.equal(JSON.stringify(canonical).includes('account-private'), false);
   });
 
-  it('does not write an activation marker for an unhealthy control-loop result', async () => {
+  it('does not write an activation marker for unhealthy control-loop results', async () => {
     const bodies = [];
     const publisher = createRedisHealthPublisher({
       env: {
@@ -258,11 +281,16 @@ describe('company monitoring worker health projection', () => {
       now: () => 1_800_000_000_000,
     });
 
-    assert.equal(await publisher({
-      status: 'error',
-      outcome: 'claim_error',
-      counters: { loops: 1, claims: 0, completed: 0, nonReassuring: 0, fenced: 0, replayed: 0, executorErrors: 0, claimErrors: 1, finalizeErrors: 0 },
-    }), true);
-    assert.equal(bodies[0].some((command) => command[1] === COMPANY_MONITORING_WORKER_ACTIVATION_KEY), false);
+    for (const outcome of ['claim_error', 'non_reassuring', 'fenced']) {
+      assert.equal(await publisher({
+        status: outcome === 'claim_error' ? 'error' : 'ok',
+        outcome,
+        counters: { loops: 1, claims: 0, completed: 0, nonReassuring: 0, fenced: 0, replayed: 0, executorErrors: 0, claimErrors: 1, finalizeErrors: 0 },
+      }), true);
+    }
+
+    for (const body of bodies) {
+      assert.equal(body.some((command) => command[1] === COMPANY_MONITORING_WORKER_ACTIVATION_KEY), false);
+    }
   });
 });

--- a/tests/company-monitoring-worker.test.mjs
+++ b/tests/company-monitoring-worker.test.mjs
@@ -1,0 +1,268 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  COMPANY_MONITORING_WORKER_ACTIVATION_KEY,
+  COMPANY_MONITORING_WORKER_HEALTH_KEY,
+  COMPANY_MONITORING_WORKER_META_KEY,
+  createCompanyMonitoringWorker,
+  createConvexFetch,
+  createRedisHealthPublisher,
+} from '../scripts/company-monitoring-worker.mjs';
+
+const CLAIM = {
+  status: 'claimed',
+  work: {
+    ownerAccountId: 'account-private',
+    workId: 'work-1',
+    cohortKey: 'cohort-private',
+    source: 'exa',
+    windowStart: 100,
+    windowEnd: 200,
+    queryVersion: 1,
+    resultCap: 50,
+    attempt: 1,
+    leaseToken: 'lease-1',
+    leaseExpiresAt: 500,
+    obligations: [{ companyId: 'company-private' }],
+  },
+};
+
+const COMPLETE_RESULT = {
+  type: 'result',
+  returnedRange: { startAt: 100, endAt: 200 },
+  itemCount: 1,
+  hasMore: false,
+  coverage: 'complete',
+  emptyValidated: false,
+  checkpoint: 'checkpoint-1',
+  costUsdMicros: 12,
+};
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
+function convexClient(responses, calls = []) {
+  return {
+    async mutation(_fn, args) {
+      calls.push(args);
+      const next = responses.shift();
+      if (next instanceof Error) throw next;
+      return typeof next === 'function' ? next(args) : next;
+    },
+  };
+}
+
+describe('company monitoring Railway worker', () => {
+  it('bounds Convex requests and identifies the server-side worker', async () => {
+    let captured;
+    const guardedFetch = createConvexFetch(async (_input, init) => {
+      captured = init;
+      return new Response('{}', { status: 200 });
+    });
+
+    await guardedFetch('https://convex.example/api/mutation', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    assert.equal(captured.headers.get('User-Agent'), 'worldmonitor-company-monitoring-worker/1.0');
+    assert.ok(captured.signal instanceof AbortSignal);
+  });
+
+  it('claims without accepting a tenant target and continues when Redis health is down', async () => {
+    const calls = [];
+    const client = convexClient([
+      CLAIM,
+      { status: 'completed', reason: 'complete', receipt: {} },
+    ], calls);
+    const worker = createCompanyMonitoringWorker({
+      client,
+      secret: 'worker-secret',
+      workerId: 'worker-a',
+      executeClaim: async () => COMPLETE_RESULT,
+      publishHealth: async () => { throw new Error('redis unavailable'); },
+    });
+
+    const outcome = await worker.tick();
+
+    assert.equal(outcome, 'completed');
+    assert.deepEqual(calls[0], { secret: 'worker-secret', workerId: 'worker-a' });
+    assert.deepEqual(calls[1], {
+      secret: 'worker-secret',
+      workerId: 'worker-a',
+      workId: 'work-1',
+      leaseToken: 'lease-1',
+      result: COMPLETE_RESULT,
+    });
+    assert.equal('accountId' in calls[0], false);
+    assert.equal('companyId' in calls[0], false);
+    assert.equal('portfolioId' in calls[0], false);
+  });
+
+  it('fails closed with provider_unavailable when no provider adapter is installed', async () => {
+    const calls = [];
+    const client = convexClient([
+      CLAIM,
+      { status: 'non_reassuring', reason: 'provider_error', receipt: {} },
+    ], calls);
+    const worker = createCompanyMonitoringWorker({
+      client,
+      secret: 'worker-secret',
+      workerId: 'worker-a',
+      publishHealth: async () => true,
+    });
+
+    assert.equal(await worker.tick(), 'non_reassuring');
+    assert.deepEqual(calls[1].result, {
+      type: 'provider_error',
+      reason: 'provider_unavailable',
+      costUsdMicros: 0,
+    });
+  });
+
+  it('leaves a fetched result unfinalized on a hard crash and safely finalizes the replayed work', async () => {
+    const firstCalls = [];
+    const firstWorker = createCompanyMonitoringWorker({
+      client: convexClient([CLAIM], firstCalls),
+      secret: 'worker-secret',
+      workerId: 'worker-a',
+      executeClaim: async () => COMPLETE_RESULT,
+      afterExecute: async () => { throw new Error('simulated process crash'); },
+      publishHealth: async () => true,
+    });
+
+    await assert.rejects(firstWorker.tick(), /simulated process crash/);
+    assert.equal(firstCalls.length, 1, 'the crashing attempt must not finalize');
+
+    const replayCalls = [];
+    const replayClaim = {
+      ...CLAIM,
+      work: { ...CLAIM.work, attempt: 2, leaseToken: 'lease-2', leaseExpiresAt: 900 },
+    };
+    const replayWorker = createCompanyMonitoringWorker({
+      client: convexClient([
+        replayClaim,
+        { status: 'completed', reason: 'complete', receipt: {} },
+      ], replayCalls),
+      secret: 'worker-secret',
+      workerId: 'worker-b',
+      executeClaim: async () => COMPLETE_RESULT,
+      publishHealth: async () => true,
+    });
+
+    assert.equal(await replayWorker.tick(), 'completed');
+    assert.equal(replayCalls[1].leaseToken, 'lease-2');
+    assert.equal(replayCalls[1].workerId, 'worker-b');
+  });
+
+  it('accepts a fenced finalize as authoritative and does not retry it', async () => {
+    const calls = [];
+    const health = [];
+    const worker = createCompanyMonitoringWorker({
+      client: convexClient([CLAIM, { status: 'fenced' }], calls),
+      secret: 'worker-secret',
+      workerId: 'worker-a',
+      executeClaim: async () => COMPLETE_RESULT,
+      publishHealth: async (payload) => { health.push(payload); },
+    });
+
+    assert.equal(await worker.tick(), 'fenced');
+    assert.equal(calls.length, 2);
+    assert.equal(health.at(-1).outcome, 'fenced');
+    assert.equal(health.at(-1).counters.fenced, 1);
+  });
+
+  it('stops new claims on SIGTERM intent and lets the current finalize finish', async () => {
+    const calls = [];
+    const started = deferred();
+    const release = deferred();
+    const client = convexClient([
+      CLAIM,
+      { status: 'completed', reason: 'complete', receipt: {} },
+    ], calls);
+    const worker = createCompanyMonitoringWorker({
+      client,
+      secret: 'worker-secret',
+      workerId: 'worker-a',
+      executeClaim: async () => {
+        started.resolve();
+        await release.promise;
+        return COMPLETE_RESULT;
+      },
+      publishHealth: async () => true,
+      sleep: async () => {},
+    });
+
+    const running = worker.run();
+    await started.promise;
+    worker.requestStop('SIGTERM');
+    release.resolve();
+    await running;
+
+    assert.equal(calls.length, 2, 'one claim and its finalize; no second claim');
+    assert.equal(worker.snapshot().stopping, true);
+  });
+});
+
+describe('company monitoring worker health projection', () => {
+  it('writes bounded matching canonical/meta payloads and a no-TTL activation marker', async () => {
+    const requests = [];
+    const publisher = createRedisHealthPublisher({
+      env: {
+        UPSTASH_REDIS_REST_URL: 'https://redis.example',
+        UPSTASH_REDIS_REST_TOKEN: 'redis-token',
+      },
+      fetchImpl: async (url, init) => {
+        requests.push({ url, init });
+        return { ok: true, json: async () => [{ result: 'OK' }, { result: 'OK' }, { result: 'OK' }] };
+      },
+      now: () => 1_800_000_000_000,
+    });
+
+    const ok = await publisher({
+      status: 'ok',
+      outcome: 'idle',
+      counters: { loops: 1, claims: 0, completed: 0, nonReassuring: 0, fenced: 0, replayed: 0, executorErrors: 0, claimErrors: 0, finalizeErrors: 0 },
+    });
+
+    assert.equal(ok, true);
+    const commands = JSON.parse(requests[0].init.body);
+    assert.equal(commands[0][1], COMPANY_MONITORING_WORKER_HEALTH_KEY);
+    assert.equal(commands[1][1], COMPANY_MONITORING_WORKER_META_KEY);
+    assert.deepEqual(commands[2].slice(0, 2), ['SET', COMPANY_MONITORING_WORKER_ACTIVATION_KEY]);
+    assert.equal(commands[2].includes('EX'), false, 'activation marker must have no TTL');
+    const canonical = JSON.parse(commands[0][2]);
+    const meta = JSON.parse(commands[1][2]);
+    assert.equal(canonical.status, meta.status);
+    assert.equal(canonical.outcome, meta.outcome);
+    assert.deepEqual(canonical.counters, meta.counters);
+    assert.equal(JSON.stringify(canonical).includes('worker-secret'), false);
+    assert.equal(JSON.stringify(canonical).includes('account-private'), false);
+  });
+
+  it('does not write an activation marker for an unhealthy control-loop result', async () => {
+    const bodies = [];
+    const publisher = createRedisHealthPublisher({
+      env: {
+        UPSTASH_REDIS_REST_URL: 'https://redis.example',
+        UPSTASH_REDIS_REST_TOKEN: 'redis-token',
+      },
+      fetchImpl: async (_url, init) => {
+        bodies.push(JSON.parse(init.body));
+        return { ok: true, json: async () => [{ result: 'OK' }, { result: 'OK' }] };
+      },
+      now: () => 1_800_000_000_000,
+    });
+
+    assert.equal(await publisher({
+      status: 'error',
+      outcome: 'claim_error',
+      counters: { loops: 1, claims: 0, completed: 0, nonReassuring: 0, fenced: 0, replayed: 0, executorErrors: 0, claimErrors: 1, finalizeErrors: 0 },
+    }), true);
+    assert.equal(bodies[0].some((command) => command[1] === COMPANY_MONITORING_WORKER_ACTIVATION_KEY), false);
+  });
+});

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -47,6 +47,8 @@ const EXCLUDED_FROM_MCP = new Map([
     'ops surface: daily GDELT recall percentage + missed headlines for coverage monitoring; consumed by api/health.js + operators, not a queryable news slice (#4920).'],
   ['health:china-coverage:v1',
     'operational: bounded China coverage verdict and reason codes consumed by api/health.js and the read-only operator audit; source content remains available through its domain tools, so this summary is not a queryable MCP slice (#5271).'],
+  ['company-monitoring:worker-health:v1',
+    'operational: bounded Company Monitoring worker control-plane heartbeat, outcome, and counters consumed by api/health.js and operators; durable scan state remains in Convex and provider/product query surfaces are deferred beyond #6007.'],
   ['economic:global-tenders:v1:source:sam',
     'ops surface: per-source procurement availability, freshness, and record count; consumed by api/health.js while tender content is exposed through the bounded MCP procurement tool, which proxies the paginated economic RPC.'],
   ['economic:global-tenders:v1:source:ted',


### PR DESCRIPTION
## Summary

Issue #6007 is the durable execution layer for the Company Monitoring program in #6002. The account roots, entitlements, and bounded onboarding contracts from #6003, #6004, and #6005 are already on `main`; this change adds the Convex orchestration and Railway control loop that can safely resume bounded scans. Provider adapters and user-facing scan results remain in #6008 and later slices.

- Make Convex the only durable authority for obligations, work, leases, checkpoints, receipts, cost, coverage, and reason codes.
- Select due work through account-leading indexes and let the server choose claims; workers cannot nominate arbitrary accounts or companies.
- Fence leases and terminal writes so expired holders cannot mutate current work, while crash replay preserves bounded progress.
- Preserve capped, partial, malformed, and invalid-empty checkpoints and receipts; rearm completed obligations without losing terminal history.
- Connect company lifecycle actions and resumable account/company purge to orchestration cleanup.
- Register an always-on Railway worker with bounded control-loop calls, payload-aware health metadata, disposable Redis health hints, and SIGTERM/SIGINT recovery.
- Keep all provider and product feature flags dark. This PR does not implement #6008 or later provider/product slices.

Fixes #6007

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [x] Config / Settings
- [x] Other: Convex Company Monitoring orchestration and Railway worker

## Design decisions

| Concern | Decision |
|---|---|
| Durable authority | Convex owns obligations, work, leases, checkpoints, receipts, and purge state. Redis contains health projections only. |
| Due selection | Account-leading indexes bound the scan, and the server selects the claim target. |
| Fencing and replay | Each claim has an expiring lease token. Mutations validate the active token and expiry; expired work becomes claimable again. |
| Partial outcomes | Capped, partial, malformed, and invalid-empty outcomes retain explicit reason, coverage, cost, checkpoint, and receipt data. |
| Shared results | Durable per-company receipt links preserve cohort history until the last linked company is purged. |
| Lifecycle cleanup | Create, import, pause, removal, and resumable purge update or remove orchestration state without unbounded scans. |
| Worker operations | The Railway loop uses bounded Convex calls, writes payload-aware health metadata, activates only after a healthy result, and drains on termination signals. |

## Acceptance proof ledger

| Acceptance surface | Implementation evidence | Verification evidence |
|---|---|---|
| Closed obligations and work states | Convex validators, schema, and orchestration mutations | Company Monitoring orchestration tests |
| Bounded indexed selection and server claims | Account-leading due index and targetless claim mutation | Claim ordering, duplicate work, and stale-window tests |
| Lease fencing and crash replay | Lease token/expiry checks and expired-work reclaim | Stale-holder and replay tests |
| Checkpoints, receipts, cost, coverage, reasons | Durable work, receipt, and link records | Capped, partial, malformed, invalid-empty, and invalid-cost tests |
| Resumable cleanup | Company lifecycle integration plus purge cursors | Lifecycle and onboarding replay tests |
| Railway service and health | Service registry, worker loop, health projection, activation marker | Worker, registry, deployment-closure, and health tests |

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant - N/A: no browser or variant surface changes
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) - N/A: no browser or variant surface changes
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) - N/A: no RSS feeds
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- [x] Claim ledger attached or linked - acceptance proof ledger above
- [ ] All required Audit Council role signoffs attached - N/A: this change does not publish a methodology or policy claim
- [ ] Generated docs regenerated from proto where applicable - N/A: no proto contract changed
- [ ] Fixture-backed examples recomputed - N/A: no published fixture example changed
- [x] Redis writers/readers enumerated for every documented key

Redis ownership:

- `scripts/company-monitoring-worker.mjs` writes disposable `company-monitoring:worker-health:v1`, `seed-meta:company-monitoring:worker`, and the durable rollout marker `seed-activated:company-monitoring:worker` only after a healthy loop result.
- `api/health.js` reads those keys for the detailed and compact health projections.
- No scan obligation, lease, checkpoint, receipt, cost, coverage, or purge state is stored in Redis.

## Screenshots

N/A. This is internal orchestration and worker infrastructure with no visual surface change.

## Verification

- `npm run test:data`: 22,306 passed, 6 skipped, 0 failed
- `npm run test:convex`: 1,426 passed, 0 failed
- Railway registration/deployment closure suite: 787 passed, 0 failed
- Company Monitoring worker tests: 12 passed, 0 failed
- Focused Convex orchestration/lifecycle/replay tests: 31 passed, 0 failed
- `npm run typecheck`: passed
- `npm run typecheck:api`: passed, including the Convex string-call audit
- `npm run lint`: passed; existing unrelated warnings remain unchanged
- Full repository pre-push gate: passed

## Post-deploy monitoring and validation

**Logs**

- Watch Railway logs for `company-monitoring-worker control loop started`, `claim_error`, `finalize_error`, `health publisher failed`, `fatal`, and `shutdown complete`.
- Confirm termination produces the bounded shutdown path and does not leave repeated fatal/restart messages.

**Metrics and health**

- Inspect `/api/health?compact=1` and the detailed health entry for `companyMonitoringWorker`.
- Inspect Railway CPU, memory, restart count, and deployment state.
- Inspect Convex counts for due work, active/expired leases, and non-reassuring outcomes.

**Healthy state**

- While provider flags remain dark, the worker reports a disabled/idle outcome with a heartbeat younger than five minutes and no claim/finalize errors.
- After a later provider activation, claims finalize or replay under the fencing contract without a growing expired-lease backlog.

**Failure state**

- `EMPTY`, `STALE_SEED`, or `SEED_ERROR` health; increasing due or expired-lease counts; Railway crash loops; repeated non-reassuring outcomes after activation; or missing graceful-shutdown logs.

**Rollback**

- Keep or restore provider flags to disabled, stop or roll back the Railway worker deployment, and retain Convex obligations/checkpoints for later replay. Do not delete durable orchestration state as part of rollback.

**Window and owner**

- Observe for 24 hours after deployment and again for 24 hours after a later provider activation. WorldMonitor operations owns this gate.

## New concepts

- **Fenced durable work lease**: a server-issued, expiring claim token that must still be current when a worker checkpoints or finalizes work. This prevents a stale worker from overwriting a replacement claim while keeping abandoned work replayable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
