### PR TITLE
fix(ci): keep the deploy gate posting a status when the required list is long (#6389)

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -34,6 +34,26 @@ jobs:
           SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -o pipefail
+          # A commit-status description is capped at 140 characters and GitHub
+          # answers 422 past it. Splicing the whole required-name list in made
+          # this job CRASH instead of posting its status once enough names were
+          # in the list — about seven (#6389, run 31357392032, all 20 pending).
+          # The failure arm is the dangerous one: no `gate` status posted at all
+          # reads as "missing", not "failure", to branch protection, to
+          # check-railway-deploy-drift.mjs and to the Seed Freshness Monitor.
+          # Keep the state and the COUNT, which survive truncation; the full
+          # list is already in this log.
+          gate_description() {
+            text="$1"
+            if [ "${#text}" -le 140 ]; then
+              printf '%s' "$text"
+            else
+              printf '%s...' "${text:0:137}"
+            fi
+          }
+          name_count() {
+            printf '%s\n' "$1" | tr ',' '\n' | wc -l | tr -d ' '
+          }
           # Every job of every workflow named in the workflow_run trigger above.
           # A job missing here is never inspected, so it reports red on the PR
           # while this gate still posts success — CI theatre, not a gate (#5402).
@@ -135,7 +155,7 @@ jobs:
             gh api "repos/$REPO/statuses/$SHA" --method POST \
               --field state="pending" \
               --field context="gate" \
-              --field description="Waiting for required PR gates: $pending"
+              --field description="$(gate_description "Waiting for required PR gates ($(name_count "$pending")): $pending")"
             continue
           fi
 
@@ -144,7 +164,7 @@ jobs:
             gh api "repos/$REPO/statuses/$SHA" --method POST \
               --field state="failure" \
               --field context="gate" \
-              --field description="Required PR gates did not pass: $failed"
+              --field description="$(gate_description "Required PR gates did not pass ($(name_count "$failed")): $failed")"
             continue
           fi
 

--- a/scripts/seed-freshness-baseline.json
+++ b/scripts/seed-freshness-baseline.json
@@ -20,12 +20,6 @@
   "expiresAt": "2026-08-27",
   "acknowledged": [
     {
-      "name": "crossStraitActivityJapanMod",
-      "status": "SEED_ERROR",
-      "issue": 5714,
-      "reason": "Japan MOD route returns proxy CONNECT 403; candidate country-specific routes return 407. Second cause independent of the #5689 Decodo exhaustion. No verified replacement endpoint installed."
-    },
-    {
       "name": "consumerPricesCoverage",
       "status": "COVERAGE_PARTIAL",
       "issue": 6355,

--- a/tests/deploy-gate-status-description.test.mjs
+++ b/tests/deploy-gate-status-description.test.mjs
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import YAML from 'yaml';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workflowPath = resolve(repoRoot, '.github/workflows/deploy-gate.yml');
+const workflow = YAML.parse(readFileSync(workflowPath, 'utf8'));
+const gateStep = workflow.jobs.gate.steps.find(
+  (step) => step.name === 'Check required PR gates passed for this SHA',
+);
+const SHA = 'fedcba9876543210fedcba9876543210fedcba98';
+
+// The whole required list, read from the workflow so the test cannot pass by
+// pinning a shorter list than production actually gates on.
+const REQUIRED = JSON.parse(gateStep.run.match(/required='(\[[^']*\])'/)[1]);
+
+/**
+ * Run the gate step against a fabricated check-runs answer.
+ *
+ * `conclusions` maps a required check name to its conclusion; a name left out
+ * is absent from the API response, which the step reads as pending.
+ */
+function runGate(conclusions) {
+  const tempDir = mkdtempSync(join(repoRoot, '.tmp-deploy-gate-'));
+  const fakeBin = join(tempDir, 'bin');
+  const runsFile = join(tempDir, 'check-runs.json');
+  const postedFile = join(tempDir, 'posted');
+  const rejectedFile = join(tempDir, 'rejected');
+
+  try {
+    mkdirSync(fakeBin);
+    writeFileSync(postedFile, '');
+    writeFileSync(rejectedFile, '');
+    writeFileSync(
+      runsFile,
+      JSON.stringify(
+        Object.entries(conclusions).map(([name, conclusion]) => ({
+          name,
+          conclusion,
+          completed_at: '2026-08-10T05:00:00Z',
+        })),
+      ),
+    );
+
+    // Two behaviours matter. The check-runs read returns the already-projected
+    // array the step's own --jq would produce. The status POST enforces the
+    // real 140-character cap the same way the API does — a 422 and a non-zero
+    // exit — so this harness reproduces #6389 rather than describing it.
+    writeFileSync(
+      join(fakeBin, 'gh'),
+      [
+        '#!/bin/sh',
+        'case "$*" in',
+        '  *"/check-runs"*)',
+        '    cat "$FAKE_CHECK_RUNS"',
+        '    exit 0',
+        '    ;;',
+        '  *"/statuses/"*)',
+        '    state=""',
+        '    description=""',
+        '    for arg in "$@"; do',
+        '      case "$arg" in',
+        '        state=*) state=${arg#state=} ;;',
+        '        description=*) description=${arg#description=} ;;',
+        '      esac',
+        '    done',
+        '    if [ "${#description}" -gt 140 ]; then',
+        '      printf \'%s|%s\\n\' "$state" "$description" >> "$FAKE_REJECTED"',
+        '      echo "gh: Validation failed: Description is too long (maximum is 140 characters) (Validation Failed)" >&2',
+        '      exit 1',
+        '    fi',
+        '    printf \'%s|%s\\n\' "$state" "$description" >> "$FAKE_POSTED"',
+        '    exit 0',
+        '    ;;',
+        'esac',
+        'exit 90',
+        '',
+      ].join('\n'),
+    );
+    // The step sleeps 30s between poll attempts; four of those would make this
+    // suite take two minutes to learn nothing.
+    writeFileSync(join(fakeBin, 'sleep'), ['#!/bin/sh', 'exit 0', ''].join('\n'));
+    for (const command of ['gh', 'sleep']) chmodSync(join(fakeBin, command), 0o755);
+
+    const result = spawnSync('bash', ['-e', '-c', gateStep.run], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FAKE_CHECK_RUNS: runsFile,
+        FAKE_POSTED: postedFile,
+        FAKE_REJECTED: rejectedFile,
+        GH_TOKEN: 'test-token',
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        REPO: 'koala73/worldmonitor',
+        SHA,
+      },
+    });
+
+    const parse = (file) => readFileSync(file, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf('|');
+        return { state: line.slice(0, separator), description: line.slice(separator + 1) };
+      });
+
+    return { ...result, posted: parse(postedFile), rejected: parse(rejectedFile) };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+const conclusionsFor = (value) => Object.fromEntries(REQUIRED.map((name) => [name, value]));
+
+describe('deploy gate commit-status description', () => {
+  it('gates on enough checks for the cap to be reachable', () => {
+    // Anti-vacuity: with three required names the untruncated description fits
+    // and every assertion below would pass against the broken step too.
+    assert.ok(REQUIRED.length >= 10, `expected the full required list, found ${REQUIRED.length}`);
+    assert.ok(
+      `Waiting for required PR gates (${REQUIRED.length}): ${REQUIRED.join(',')}`.length > 140,
+      'the fabricated worst case must actually exceed the API cap',
+    );
+  });
+
+  it('posts a pending status when every required check is pending', () => {
+    // #6389 reproduced: 20 pending names is ~300 characters, and the step used
+    // to die on the 422 instead of posting anything.
+    const result = runGate({});
+
+    assert.deepEqual(result.rejected, [], `the API rejected a description: ${result.stderr}`);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.posted.length, 1);
+    assert.equal(result.posted[0].state, 'pending');
+    assert.ok(result.posted[0].description.length <= 140);
+    assert.match(result.posted[0].description, new RegExp(`Waiting for required PR gates \\(${REQUIRED.length}\\):`));
+    assert.match(result.posted[0].description, /\.\.\.$/, 'a truncated description must say it was cut');
+  });
+
+  it('posts a failure status when every required check failed', () => {
+    // The arm that matters most: crashing here left NO gate status, and every
+    // consumer reads a missing status as undecided rather than failed.
+    const result = runGate(conclusionsFor('failure'));
+
+    assert.deepEqual(result.rejected, [], `the API rejected a description: ${result.stderr}`);
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.posted.length, 1);
+    assert.equal(result.posted[0].state, 'failure');
+    assert.ok(result.posted[0].description.length <= 140);
+    assert.match(result.posted[0].description, new RegExp(`Required PR gates did not pass \\(${REQUIRED.length}\\):`));
+  });
+
+  it('keeps the whole list when it fits', () => {
+    const conclusions = conclusionsFor('success');
+    delete conclusions.unit;
+    delete conclusions.biome;
+    const result = runGate(conclusions);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.posted[0].state, 'pending');
+    assert.equal(result.posted[0].description, 'Waiting for required PR gates (2): unit,biome');
+    assert.doesNotMatch(result.posted[0].description, /\.\.\.$/, 'a description that fits must not be cut');
+  });
+
+  it('still posts success when everything passed or skipped', () => {
+    const conclusions = conclusionsFor('success');
+    conclusions['desktop-rust'] = 'skipped';
+    const result = runGate(conclusions);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.posted, [{ state: 'success', description: 'All required PR gates passed' }]);
+  });
+});

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -348,6 +348,22 @@ describe('scheduled seed freshness monitor', () => {
         false,
         'humanitarianSummary recovered; do not suppress a future recurrence',
       );
+      assert.equal(
+        committed.acknowledged.some((entry) => entry.name === 'crossStraitActivityJapanMod'),
+        false,
+        'crossStraitActivityJapanMod stopped reporting SEED_ERROR and compact health now counts it OK; do not suppress a future recurrence',
+      );
+      const japanModFailure = applyAcceptanceBaseline(
+        [{ name: 'crossStraitActivityJapanMod', status: 'SEED_ERROR' }],
+        committed,
+        Date.parse('2026-08-10'),
+      );
+      assert.deepEqual(
+        japanModFailure.blocking.map((problem) => problem.name),
+        ['crossStraitActivityJapanMod'],
+        'a returning Japan MOD proxy block must reach the gate, not the suppression it used to carry (#5714)',
+      );
+      assert.deepEqual(japanModFailure.acknowledged, []);
       const humanitarianFailure = applyAcceptanceBaseline(
         [{ name: 'humanitarianSummary', status: 'SEED_ERROR' }],
         committed,


### PR DESCRIPTION
Two independent leftovers from yesterday's monitor work. Closes #6389.

## 1. The deploy gate crashed instead of posting its status (#6389)

A commit-status description is capped at 140 characters and GitHub answers 422 past it.
The gate spliced the whole required-name list in. [Run 31357392032](https://github.com/koala73/worldmonitor/actions/runs/31357392032)
read all 20 contexts as pending, built a ~300-character description and died:

```
gh: Validation failed: Description is too long (maximum is 140 characters) (Validation Failed)
##[error]Process completed with exit code 1.
```

The threshold is about **seven** names, so the pending arm was one slow morning away from
this at any time.

**The failure arm is the dangerous one.** When many required checks genuinely fail, the
crash leaves **no `gate` status at all** — and every consumer reads a missing status as
undecided rather than failed: branch protection, `check-railway-deploy-drift.mjs`, and the
Seed Freshness Monitor gate step, which since #6374 walks back to an older gated revision
on `missing`. That walk-back was compensating for a status that should have existed.

Both descriptions now carry the count and are truncated to fit:

```
Waiting for required PR gates (20): changes,typecheck-changes,lint-changes,...
Required PR gates did not pass (20): changes,typecheck-changes,...
```

The count is what survives truncation; the full list is already in the job log. The success
description is untouched, so the existing assertion in `ci-workflow-coverage.test.mts` still
holds.

## 2. Prune the recovered baseline entry

`crossStraitActivityJapanMod:SEED_ERROR` stopped being reported, so the monitor printed a
prune request on every run. Before removing it I checked it was a real recovery and not a
key that quietly left the health config:

- Still probed: `api/health.js:295` (data key) and `:517` (seed-meta, `maxStaleMin: 720`).
- Compact health counts it OK: `total 257 = ok 249 + warn 8`, and the eight warns are the
  consumer-price keys.
- The narrow escape hatch at `health.js:1564` (`sourceBlocked && name !== 'crossStraitActivityJapanMod'`)
  landed in #5718 at 09:30, **eleven hours before** the baseline entry in #5756 at 20:26, so
  the classification change does not explain the disappearance either.

Removal follows the `shippingRates` / `gdeltIntel` / `humanitarianSummary` pattern already in
`tests/seed-freshness-monitor.test.mjs`: the entry must not come back, and a future
`SEED_ERROR` must reach the gate rather than the suppression it used to carry. #5714 stays
open as the owner.

## Verification

- `tests/deploy-gate-status-description.test.mjs` executes the **real** gate step with a fake
  `gh` that enforces the 140-character cap the way the API does — it reproduces the 422
  rather than describing it. A first case asserts the required list is long enough for the
  cap to be reachable, so the others cannot pass vacuously.
- Three of its five cases proven **red** against the previous step (reverted by file copy,
  restored the same way); the two that stay green encode behaviour that did not change.
- `tests/seed-freshness-monitor.test.mjs`: 23 pass.
- `ci-workflow-coverage`, `railway-reconcile-age`, `umami-runtime-remediation`,
  `seed-freshness-workflow`: 62 pass.
- Live `node scripts/check-seed-freshness.mjs` no longer prints the prune advisory. The only
  blocker left is `consumerPricesCoverageGB`, which escalated to `COVERAGE_DEGRADED` because
  `tesco_gb` now fetches 0 of 12 pages — owned by #6358, not this PR.

https://claude.ai/code/session_014iaXRJN9n59i1ZDTd3JLy2
