### PR TITLE
fix(ci): paginate the deploy gate's check-runs read (root cause of #6389)

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -99,9 +99,22 @@ jobs:
           echo "── evaluating $SHA"
 
           # Poll check-runs for this SHA and find the latest result for each required job.
-          # Project to just the three fields the gate logic reads. A SHA can
-          # accumulate dozens of full check-run objects across re-runs; passing
-          # the un-projected JSON to python3 via the RUNS_JSON env var overflowed
+          #
+          # PAGINATE. `filter=latest` still returns one entry per check-run NAME,
+          # and a push to main now carries more than 100 of them (153 on
+          # d38195c86, 161 on 704537706) — Convex Deploy, the Railway trigger,
+          # IndexNow and the monitors all publish here, not just the gated
+          # workflows. A single un-paginated page held ZERO of the 20 required
+          # names on d38195c86, so the gate read "everything pending" from a page
+          # that did not contain the answer: it posted a stuck `pending` on main
+          # head, and before #6390 it built a ~300-character description from all
+          # 20 names and died on the API's 140-character cap. That 422 was the
+          # symptom; this truncation is the cause (#6389).
+          #
+          # `--slurp` cannot be combined with gh's own `--jq`, so pipe to jq the
+          # way the sweep above already does. Project to just the three fields
+          # the gate logic reads — more pages means more bytes, and passing the
+          # un-projected JSON to python3 via the RUNS_JSON env var overflowed
           # Linux's 128KB-per-arg/env limit (MAX_ARG_STRLEN) once it crossed
           # ~131KB, failing the gate with "Argument list too long" (exit 126).
           #
@@ -115,8 +128,8 @@ jobs:
           # NOTE: the python3 -c body must stay at column 0 of the block scalar —
           # indenting it with the loops would be a Python IndentationError.
           for attempt in 1 2 3 4 5; do
-            runs=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
-              --jq ".check_runs | map(select(.name as \$name | $required | index(\$name)) | {name, conclusion, completed_at})")
+            runs=$(gh api --paginate --slurp "repos/$REPO/commits/$SHA/check-runs?per_page=100" |
+              jq -c "[.[].check_runs[]] | map(select(.name as \$name | $required | index(\$name)) | {name, conclusion, completed_at})")
 
             status=$(RUNS_JSON="$runs" REQUIRED_JOBS="$required" python3 -c "
           import json

--- a/tests/deploy-gate-status-description.test.mjs
+++ b/tests/deploy-gate-status-description.test.mjs
@@ -31,8 +31,13 @@ const REQUIRED = JSON.parse(gateStep.run.match(/required='(\[[^']*\])'/)[1]);
  *
  * `conclusions` maps a required check name to its conclusion; a name left out
  * is absent from the API response, which the step reads as pending.
+ *
+ * `fillerFirstPage` reproduces production: `filter=latest` returns one entry
+ * per check-run NAME, a push to main carries more than 100 of them, and on
+ * d38195c86 page one held ZERO of the 20 required names. Pass it to put the
+ * required entries on page two, where only a paginated read can see them.
  */
-function runGate(conclusions) {
+function runGate(conclusions, { fillerFirstPage = 0 } = {}) {
   const tempDir = mkdtempSync(join(repoRoot, '.tmp-deploy-gate-'));
   const fakeBin = join(tempDir, 'bin');
   const runsFile = join(tempDir, 'check-runs.json');
@@ -43,28 +48,64 @@ function runGate(conclusions) {
     mkdirSync(fakeBin);
     writeFileSync(postedFile, '');
     writeFileSync(rejectedFile, '');
+    const required = Object.entries(conclusions).map(([name, conclusion]) => ({
+      name,
+      conclusion,
+      completed_at: '2026-08-10T05:00:00Z',
+    }));
+    const filler = Array.from({ length: fillerFirstPage }, (_, index) => ({
+      name: `indexnow-submit-${index}`,
+      conclusion: 'skipped',
+      completed_at: '2026-08-10T05:00:00Z',
+    }));
+    // The shape gh returns: one object per page, and `--slurp` wraps them in an
+    // array. Without pagination the caller sees page one and nothing else.
     writeFileSync(
       runsFile,
       JSON.stringify(
-        Object.entries(conclusions).map(([name, conclusion]) => ({
-          name,
-          conclusion,
-          completed_at: '2026-08-10T05:00:00Z',
-        })),
+        fillerFirstPage > 0
+          ? [{ check_runs: filler }, { check_runs: required }]
+          : [{ check_runs: required }],
       ),
     );
 
-    // Two behaviours matter. The check-runs read returns the already-projected
-    // array the step's own --jq would produce. The status POST enforces the
-    // real 140-character cap the same way the API does — a 422 and a non-zero
-    // exit — so this harness reproduces #6389 rather than describing it.
+    // Three behaviours matter, and each is a real API behaviour rather than a
+    // convenience. The check-runs read serves ONLY page one unless --paginate
+    // is passed, and applies a --jq filter itself when given one, so a step
+    // that forgets to paginate sees exactly what production saw. The status
+    // POST enforces the real 140-character cap the way the API does — a 422 and
+    // a non-zero exit — so this harness reproduces #6389 rather than describing
+    // it.
     writeFileSync(
       join(fakeBin, 'gh'),
       [
         '#!/bin/sh',
         'case "$*" in',
         '  *"/check-runs"*)',
-        '    cat "$FAKE_CHECK_RUNS"',
+        '    filter=""',
+        '    take_next=0',
+        '    paginate=0',
+        '    for arg in "$@"; do',
+        '      if [ "$take_next" = "1" ]; then filter="$arg"; take_next=0; continue; fi',
+        '      case "$arg" in',
+        '        --jq|-q) take_next=1 ;;',
+        '        --paginate) paginate=1 ;;',
+        '      esac',
+        '    done',
+        '    if [ "$paginate" = "1" ]; then',
+        // gh refuses --slurp together with --jq, and without --slurp a paginated
+        // read emits bare concatenated page bodies rather than the array the
+        // filter indexes. Half a pagination fix must not pass here.
+        '      case " $* " in *" --slurp "*) ;; *) exit 96 ;; esac',
+        '      body=$(cat "$FAKE_CHECK_RUNS")',
+        '    else',
+        '      body=$(jq -c \'.[0]\' "$FAKE_CHECK_RUNS")',
+        '    fi',
+        '    if [ -n "$filter" ]; then',
+        '      printf \'%s\' "$body" | jq -c "$filter"',
+        '    else',
+        '      printf \'%s\' "$body"',
+        '    fi',
         '    exit 0',
         '    ;;',
         '  *"/statuses/"*)',
@@ -173,6 +214,23 @@ describe('deploy gate commit-status description', () => {
     assert.equal(result.posted[0].state, 'pending');
     assert.equal(result.posted[0].description, 'Waiting for required PR gates (2): unit,biome');
     assert.doesNotMatch(result.posted[0].description, /\.\.\.$/, 'a description that fits must not be cut');
+  });
+
+  it('reads every page, so a required check on page two is not read as pending', () => {
+    // What actually happened on d38195c86: 153 check runs, and an un-paginated
+    // read of the first 100 held ZERO of the 20 required names. The gate posted
+    // `Waiting for required PR gates (6): …` over six checks that had already
+    // passed, and nothing re-evaluates a main commit — the self-healing sweep
+    // walks open PR heads only. Before #6390 the same misread produced all 20
+    // names, a ~300-character description and a 422 that posted nothing at all.
+    const result = runGate(conclusionsFor('success'), { fillerFirstPage: 100 });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(
+      result.posted,
+      [{ state: 'success', description: 'All required PR gates passed' }],
+      'every required check passed on page two; a gate that cannot see page two invents a pending verdict',
+    );
   });
 
   it('still posts success when everything passed or skipped', () => {


### PR DESCRIPTION
#6390 stopped the gate crashing on a long status description. This fixes the misread that
produced the long description in the first place. Closes the root cause of #6389.

## The measurement

`check-runs?per_page=100` was called without `--paginate`. `filter=latest` still returns one
entry per check-run **name**, and a push to `main` now carries more than 100 of them — 153 on
`d38195c86`, 161 on `704537706` — because Convex Deploy, the Railway trigger, IndexNow and the
monitors all publish check runs there, not just the four gated workflows.

Measured against the merge commit of #6390:

```
un-paginated (what the gate read):   0 of 20 required checks found
paginated (the truth):              20 of 20, every one success
total check runs on the commit:    153
```

The gate concluded "everything pending" from a page that did not contain the answer.

## Two symptoms, one cause

| commit | check runs | what happened |
|---|---|---|
| `e79546a44` | 103 | `gate` → `success`, normal |
| `704537706` | 161 | ~300-char description from all 20 names → 422 → **no `gate` status at all** |
| `d38195c86` | 153 | posted `Waiting for required PR gates (6): …` over six checks that had **already passed** — and it is still pending |

The stuck `pending` does not self-heal: the 30-minute sweep walks **open PR heads** only, so a
main commit is never re-evaluated. Open PRs are not affected today only because a PR head
carries fewer check runs than a main merge commit — that margin is shrinking.

## The change

```diff
-  runs=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
-    --jq ".check_runs | map(select(…) | {name, conclusion, completed_at})")
+  runs=$(gh api --paginate --slurp "repos/$REPO/commits/$SHA/check-runs?per_page=100" |
+    jq -c "[.[].check_runs[]] | map(select(…) | {name, conclusion, completed_at})")
```

`--slurp` cannot be combined with gh's own `--jq`, so this pipes to `jq` the way the sweep in
the same step already does (`deploy-gate.yml:84`). The projection stays: more pages means more
bytes through the `RUNS_JSON` env var, which has the 128KB limit the existing comment records.

## The harness now models the API instead of standing in for it

The fake `gh` serves **only page one** unless `--paginate` is passed, applies a `--jq` filter
itself when given one, and rejects `--paginate` without `--slurp` so half a fix cannot pass.
The new case puts all 20 required checks on page two behind 100 filler entries — the production
shape.

Against the previous step it reproduces the production symptom exactly:

```
+ description: 'Waiting for required PR gates (20): changes,typecheck-changes,lint-changes,...'
+ state: 'pending'
- description: 'All required PR gates passed'
- state: 'success'
```

The other five cases stay green across the change, because they pin description behaviour
rather than pagination — reverted by file copy and restored the same way.

## Verification

- `tests/deploy-gate-status-description.test.mjs`: 6/6 pass; the new case proven red against
  the merged pre-pagination step.
- `ci-workflow-coverage`, `railway-reconcile-age`, `umami-runtime-remediation`: 53/53 pass.
- The paginated command was run against `d38195c86` in this repo before it was written into
  the workflow — it returns all 20 required checks, all `success`.
- `npx biome check` clean; the step script passes `bash -n`.

https://claude.ai/code/session_014iaXRJN9n59i1ZDTd3JLy2
