### PR TITLE
fix(energy): stop one absent country from withholding the JODI dataset (#6395)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -756,12 +756,19 @@ const SEED_META = {
   electricityPrices:    { key: 'seed-meta:energy:electricity-prices',   maxStaleMin: 2880 }, // daily cron (14:00 UTC); 2880min = 48h = 2x interval
   gasStorageCountries:  { key: 'seed-meta:energy:gas-storage-countries', maxStaleMin: 2880 }, // daily cron at 10:30 UTC; 2880min = 48h = 2x interval
   energyIntelligence:   { key: 'seed-meta:energy:intelligence',          maxStaleMin: 720 }, // 6h cron; 720min = 2x interval
-  jodiOil:              { key: 'seed-meta:energy:jodi-oil',               maxStaleMin: 60 * 24 * 40 }, // monthly cron on 25th; 40d threshold matches 35d TTL + 5d buffer
+  // `chinaCoverage` opts these three into the producer diagnostic below. An
+  // unusable China row no longer withholds the JODI publish (#6395), so the
+  // freshness verdict now describes the 51-63 countries that DID publish and
+  // the China gap rides alongside it, named, instead of surfacing 40 days
+  // later as a generic STALE_SEED. Content age is producer-declared
+  // (newestItemAt/maxContentAgeMin in seed-meta) — a frozen upstream file
+  // reads STALE_CONTENT rather than passing as fresh.
+  jodiOil:              { key: 'seed-meta:energy:jodi-oil',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // monthly cron on 25th; 40d threshold matches 35d TTL + 5d buffer
   ieaOilStocks:         { key: 'seed-meta:energy:iea-oil-stocks',        maxStaleMin: 60 * 24 * 40 }, // monthly cron on 15th; 40d threshold = TTL_SECONDS
   oilStocksAnalysis:    { key: 'seed-meta:energy:oil-stocks-analysis',   maxStaleMin: 60 * 24 * 50 }, // afterPublish of ieaOilStocks; 50d = matches seed-meta TTL (exceeds 40d data TTL)
   eiaPetroleum:         { key: 'seed-meta:energy:eia-petroleum',         maxStaleMin: 4320 }, // daily bundle cron (seed-bundle-energy-sources); 72h = 3× interval, well under 7d data TTL
-  jodiGas:              { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40 }, // monthly cron on 25th; 40d threshold matches 35d TTL + 5d buffer
-  lngVulnerability:     { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40 }, // written by jodi-gas seeder afterPublish; shares seed-meta key
+  jodiGas:              { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // monthly cron on 25th; 40d threshold matches 35d TTL + 5d buffer
+  lngVulnerability:     { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // written by jodi-gas seeder afterPublish; shares seed-meta key
   chokepointBaselines:  { key: 'seed-meta:energy:chokepoint-baselines', maxStaleMin: 60 * 24 * 400 }, // 400 days
   sprPolicies:          { key: 'seed-meta:energy:spr-policies',         maxStaleMin: 60 * 24 * 400 }, // 400 days; static registry, same cadence as chokepoint baselines
   pipelinesGas:         { key: 'seed-meta:energy:pipelines-gas',        maxStaleMin: 20_160 }, // 14d — weekly cron (7d) × 2 headroom
@@ -1234,14 +1241,62 @@ function projectCompanyMonitoringWorkerControl(meta, enabled) {
   return { status: meta.status, outcome: meta.outcome, counters };
 }
 
+// A JODI producer's China record, projected for the wire. Opt-in per key via
+// the SEED_META entry declaring `chinaRow: true` so no other seed-meta reader
+// changes. Deliberately NOT named `chinaCoverage`: that is the top-level check
+// projecting the hourly China coverage summary, and one country's row inside
+// one source is a different, smaller claim.
+//
+// Purely informational — it never moves a status. China's rows going unusable
+// is an upstream fact the operator can neither clear nor retry (the China
+// coverage manifest already carries JODI as `blocked` for the same reason), so
+// grading it would be an eternal warn. What it must not be is invisible: since
+// #6395 the dataset publishes without China, and this block is what says which
+// country dropped out and how long ago.
+//
+// `reason` is a closed vocabulary — health would otherwise relay arbitrary
+// producer free-text onto a public endpoint.
+const JODI_CHINA_ROW_REASONS = new Set([
+  'china-missing',
+  'china-invalid-month',
+  'china-stale',
+  'china-no-measurements',
+]);
+
+function projectJodiChinaRow(meta, enabled) {
+  if (!enabled) return null;
+  const raw = meta?.chinaRow;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+
+  const ok = raw.ok === true;
+  // Read the raw types rather than coercing: `Number(null)` is 0, which would
+  // publish "China's data is 0 months old" for a China record that is absent
+  // and has no data month at all.
+  const ageMonths = typeof raw.ageMonths === 'number' ? raw.ageMonths : NaN;
+  const unavailableSince = typeof raw.unavailableSince === 'number' ? raw.unavailableSince : NaN;
+  return {
+    ok,
+    reason: !ok && typeof raw.reason === 'string' && JODI_CHINA_ROW_REASONS.has(raw.reason)
+      ? raw.reason
+      : null,
+    dataMonth: typeof raw.dataMonth === 'string' && /^\d{4}-\d{2}$/.test(raw.dataMonth)
+      ? raw.dataMonth
+      : null,
+    ageMonths: Number.isSafeInteger(ageMonths) && ageMonths >= 0 ? ageMonths : null,
+    unavailableSince: !ok && Number.isFinite(unavailableSince) && unavailableSince > 0
+      ? unavailableSince
+      : null,
+  };
+}
+
 function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (!seedCfg) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null, coverage: null, synthesisFailure: null, dominantFailureMode: null, workerControl: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: false, metaCount: null, contentAge: null, coverage: null, synthesisFailure: null, dominantFailureMode: null, chinaRow: null, workerControl: null };
   }
   // Per-command Redis errors on the GET seed-meta half of the pipeline must
   // not silently fall through to STALE_SEED — promote to REDIS_PARTIAL.
   if (keyMetaErrors.get(seedCfg.key)) {
-    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null, coverage: null, synthesisFailure: null, dominantFailureMode: null, workerControl: null };
+    return { hasMeta: false, seedAge: null, seedStale: null, seedError: false, sourceUnavailable: false, sourceBlocked: false, metaReadFailed: true, metaCount: null, contentAge: null, coverage: null, synthesisFailure: null, dominantFailureMode: null, chinaRow: null, workerControl: null };
   }
   // Unwrap through the envelope helper. Legacy seed-meta is a bare
   // `{ fetchedAt, recordCount, sourceVersion, status? }` object with no `_seed`
@@ -1274,6 +1329,10 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
       errorCode,
       synthesisFailure: null,
       dominantFailureMode: null,
+      // A producer that reported `status: 'error'` never got far enough to
+      // assess China this run; relaying the previous run's verdict here would
+      // read as current.
+      chinaRow: null,
       workerControl,
     };
   }
@@ -1436,6 +1495,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
     && TRADE_FLOW_DOMINANT_FAILURE_MODES.has(meta.dominantFailureMode)) {
     dominantFailureMode = meta.dominantFailureMode;
   }
+  const chinaRow = projectJodiChinaRow(meta, seedCfg?.chinaRow);
   return {
     hasMeta: meta != null,
     seedAge,
@@ -1453,6 +1513,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
     errorCode,
     synthesisFailure,
     dominantFailureMode,
+    chinaRow,
     workerControl,
   };
 }
@@ -1549,6 +1610,7 @@ function classifyKey(name, redisKey, opts, ctx) {
     errorCode,
     synthesisFailure,
     dominantFailureMode,
+    chinaRow,
     workerControl,
   } = meta;
 
@@ -1782,6 +1844,11 @@ function classifyKey(name, redisKey, opts, ctx) {
   // it on the fault verdict would hide exactly the "healthy-looking partial"
   // case. Mirrors the ungated synthesisFailure emission below.
   if (dominantFailureMode) entry.dominantFailureMode = dominantFailureMode;
+  // Ungated for the same reason as dominantFailureMode: the point of #6395 is
+  // that "China dropped out of JODI" is legible from /api/health on a dataset
+  // that is otherwise publishing normally. Gating it on a fault verdict would
+  // hide exactly the healthy-looking-partial case it exists to describe.
+  if (chinaRow) entry.chinaRow = chinaRow;
   // Closed, bounded projection from the worker's seed-meta. It contains only
   // control-loop state and counters, never work or customer identifiers.
   if (workerControl) entry.workerControl = workerControl;
@@ -2198,11 +2265,20 @@ function healthResponseBody(snapshot, compact) {
   // STATUS is public, but its named entities are operator-only. `staleCountries`
   // and the decision-group breakdown identify WHICH source is degraded, which
   // is exactly what the chinaDecisionSignals carve-out above exists to
-  // withhold. Runs on both shapes so a cached compact snapshot written before
-  // this rule is scrubbed on the way out too.
+  // withhold. `chinaRow` (#6395) names a country and says which part of a JODI
+  // source is unusable, so it falls under the same rule. Runs on both shapes so
+  // a cached compact snapshot written before this rule is scrubbed on the way
+  // out too.
   for (const [name, check] of Object.entries(problems)) {
-    if (check?.contentFreshness === undefined && check?.decisionGroups === undefined) continue;
-    const { contentFreshness: _detail, decisionGroups: _groups, ...publicFields } = check;
+    if (check?.contentFreshness === undefined
+      && check?.decisionGroups === undefined
+      && check?.chinaRow === undefined) continue;
+    const {
+      contentFreshness: _detail,
+      decisionGroups: _groups,
+      chinaRow: _chinaRow,
+      ...publicFields
+    } = check;
     problems[name] = publicFields;
   }
   if (Object.keys(problems).length > 0) body.problems = problems;

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -190,6 +190,46 @@ itself.) `lastSynthesisFailureCode` is broader still: like the other
 last-known-good diagnostics above, it is published on every status whenever the
 producer recorded one.
 
+### JODI China Row
+
+`jodiOil`, `jodiGas` and `lngVulnerability` publish an extra `chinaRow` block
+whenever their producer recorded one:
+
+| Field | Meaning |
+|-------|---------|
+| `ok` | Whether China parsed into a usable record this run |
+| `reason` | Why it did not, from a closed vocabulary: `china-missing`, `china-invalid-month`, `china-stale`, `china-no-measurements` |
+| `dataMonth` | China's observation month, when it has one |
+| `ageMonths` | How many months behind the run that observation month is |
+| `unavailableSince` | Epoch milliseconds of the first run that **recorded** the gap, carried forward across runs. Best-effort: a run that cannot read the previous `seed-meta` (Redis blip, first run after deploy) re-dates it to that run. Read it as "first run that recorded this gap", never as a measured outage start |
+
+The block never moves the status. China's rows going unusable is an upstream
+fact no retry clears — every China row in both JODI files has carried
+`ASSESSMENT_CODE 3` ("null/uncertain") since at least 2026-08 — so grading it
+would be a warning nobody can act on. What it must not be is silent: the
+seeders publish the other 50-57 countries regardless of China, and this block
+is what names the country that dropped out.
+
+It describes the producer's **last completed publish**, like every other
+`seed-meta`-derived field: on a run that refused or failed, the previous
+block stays in place and ages alongside `seedAgeMin`. A producer that reported
+`status: "error"` publishes no block at all rather than relaying a verdict it
+never reached this run. The block is also **operator-only** — it names a
+country, so `?compact=1` strips it under the same rule as `contentFreshness`
+and the decision-group breakdown.
+
+Whether the *dataset* is still advancing is a separate, graded signal: both
+seeders declare `newestItemAt`/`maxContentAgeMin` from the newest month a
+quorum of countries reports a measurement for, so a JODI file that stops
+publishing reads `STALE_CONTENT` rather than passing as fresh, and one
+fast-reporting country cannot vouch for a frozen file. Countries whose every
+field parsed to null are not published at all, so the seeders' country floors
+count coverage rather than rows.
+
+Do not confuse `checks.jodiGas.chinaRow` with the `checks.chinaCoverage` entry
+below: the first is one country's row inside one source, the second is the
+fleet-wide China coverage summary.
+
 ### China Coverage Projection
 
 `chinaCoverage` projects the hourly Railway summary at

--- a/scripts/seed-jodi-gas.mjs
+++ b/scripts/seed-jodi-gas.mjs
@@ -9,12 +9,14 @@ import {
   CHROME_UA,
   runSeed,
   writeExtraKey,
-  readSeedSnapshot,
-  extendExistingTtl,
+  readExistingSeedMeta,
 } from './_seed-utils.mjs';
 import {
+  MAX_JODI_CONTENT_AGE_MIN,
   assessChinaJodiCoverage,
+  buildChinaRowDiagnostic,
   hasFiniteMeasurementAtPaths,
+  jodiDatasetContentMeta,
 } from './shared/jodi-content-age.mjs';
 
 loadEnvFile(import.meta.url);
@@ -156,39 +158,69 @@ export function assessChinaGasCoverage(records, now = new Date()) {
 }
 
 /**
- * Reject unusable China coverage without letting the prior per-country
- * snapshot expire behind the still-preserved canonical country list.
+ * Content age of the published gas snapshot, for runSeed's content-age
+ * contract. This is the staleness guard that used to ride on China's data
+ * month: when the world file stops advancing, health says STALE_CONTENT
+ * instead of serving a frozen vintage as if it were current.
  *
  * @param {Parameters<typeof assessChinaGasCoverage>[0]} records
  * @param {Date} now
- * @param {{
- *   readSnapshot?: (key: string) => Promise<unknown>,
- *   extendTtl?: (keys: string[], ttlSeconds: number) => Promise<unknown>,
- * }} deps
  */
-export async function enforceChinaGasCoverage(records, now = new Date(), deps = {}) {
-  const chinaCoverage = assessChinaGasCoverage(records, now);
-  if (chinaCoverage.ok) return chinaCoverage;
+export function gasContentMeta(records, now = new Date()) {
+  return jodiDatasetContentMeta(records, hasGasMeasurements, now);
+}
 
-  const readSnapshot = deps.readSnapshot ?? readSeedSnapshot;
-  const extendTtl = deps.extendTtl ?? extendExistingTtl;
-  const previousIso2List = await readSnapshot(CANONICAL_KEY).catch(() => null);
-  const previousCountryKeys = Array.isArray(previousIso2List)
-    ? previousIso2List
-      .filter((iso2) => typeof iso2 === 'string' && /^[A-Z]{2}$/.test(iso2))
-      .map((iso2) => `${KEY_PREFIX}${iso2}`)
-    : [];
+/**
+ * Record — never enforce — China's state for seed-meta.
+ *
+ * Until #6395 an unusable China row threw here and discarded all 63 parsed
+ * countries, so the whole dataset froze for 40 days behind one absent record.
+ * The publish now proceeds on the country floor alone (runSeed `validateFn`),
+ * and this diagnostic is what keeps the gap visible on /api/health.
+ *
+ * @param {Parameters<typeof assessChinaGasCoverage>[0]} records
+ * @param {Date} now
+ * @param {{ readPreviousMeta?: () => Promise<any> }} deps
+ */
+export async function buildGasChinaRowDiagnostic(records, now = new Date(), deps = {}) {
+  const readPreviousMeta = deps.readPreviousMeta ?? (() => readExistingSeedMeta('energy', 'jodi-gas'));
+  const previousMeta = await readPreviousMeta();
+  return buildChinaRowDiagnostic(
+    assessChinaGasCoverage(records, now),
+    previousMeta?.chinaRow ?? null,
+    now.getTime(),
+  );
+}
 
-  if (previousCountryKeys.length > 0) {
-    await extendTtl(previousCountryKeys, GAS_TTL).catch(() => {});
-  }
+/**
+ * Parse a downloaded world file into country records and say, once, what
+ * happened to China. Separated from the download so the no-China path is
+ * exercisable without a network round trip.
+ *
+ * @param {string} csvText
+ * @param {Date} now
+ */
+export function buildGasRecordsFromCsv(csvText, now = new Date()) {
+  const rows = parseCsvRows(csvText);
+  console.log(`  Rows after TJ/flow/assessment filter: ${rows.length}`);
+  const parsed = buildCountryRecords(rows);
 
-  const error = new Error(`China JODI gas coverage failed: ${chinaCoverage.reason} (dataMonth=${chinaCoverage.dataMonth ?? 'missing'})`);
-  // The coverage result is deterministic for the downloaded snapshot. Tell
-  // runSeed's outer withRetry loop not to download and parse the same ZIP
-  // again after last-good country TTLs have already been preserved.
-  error.nonRetryable = true;
-  throw error;
+  const chinaCoverage = assessChinaGasCoverage(parsed, now);
+
+  // A country whose every field parsed to null is not coverage: it would count
+  // toward MIN_COUNTRIES while serving no measurement to anyone. With no
+  // single-country gate standing behind that floor any more (#6395), the floor
+  // has to mean what it says, so only measurement-bearing countries are
+  // published. It also stops a null-only month from overwriting a country's
+  // last-good record — the key simply is not rewritten and ages out instead.
+  const records = parsed.filter(hasGasMeasurements);
+  console.log(`  Countries with gas data: ${records.length} of ${parsed.length} parsed`);
+  console.log(chinaCoverage.ok
+    ? `  China gas coverage: ok (dataMonth=${chinaCoverage.dataMonth})`
+    : `  China gas coverage: ${chinaCoverage.reason} (dataMonth=${chinaCoverage.dataMonth ?? 'missing'})`
+      + ` — publishing the other ${records.length} countries anyway`);
+
+  return records;
 }
 
 function findZipEntry(buf, filename) {
@@ -254,12 +286,7 @@ async function fetchAndParseCsv() {
 async function fetchJodiGas() {
   const csvText = await fetchAndParseCsv();
   console.log('  Parsing CSV rows...');
-  const rows = parseCsvRows(csvText);
-  console.log(`  Rows after TJ/flow/assessment filter: ${rows.length}`);
-  const records = buildCountryRecords(rows);
-  console.log(`  Countries with gas data: ${records.length}`);
-  await enforceChinaGasCoverage(records);
-  return records;
+  return buildGasRecordsFromCsv(csvText);
 }
 
 /**
@@ -331,8 +358,11 @@ if (isMain) {
         await writeExtraKey(`${KEY_PREFIX}${record.iso2}`, record, GAS_TTL);
       }
       // LNG vulnerability index is now written via extraKeys (gets TTL-preserved on failure)
+      return { freshnessMetaPatch: { chinaRow: await buildGasChinaRowDiagnostic(records) } };
     },
-  
+    contentMeta: gasContentMeta,
+    maxContentAgeMin: MAX_JODI_CONTENT_AGE_MIN,
+
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 57600,

--- a/scripts/seed-jodi-gas.mjs
+++ b/scripts/seed-jodi-gas.mjs
@@ -185,6 +185,12 @@ export function gasContentMeta(records, now = new Date()) {
 export async function buildGasChinaRowDiagnostic(records, now = new Date(), deps = {}) {
   const readPreviousMeta = deps.readPreviousMeta ?? (() => readExistingSeedMeta('energy', 'jodi-gas'));
   const previousMeta = await readPreviousMeta();
+  if (previousMeta?.chinaRow == null) {
+    // readExistingSeedMeta collapses "no prior record" and "read failed" into
+    // one null, so an ongoing gap re-dates to this run. Say so, or the reset is
+    // indistinguishable from a genuine new outage in the log.
+    console.warn('  China gas row: no previous record readable — dating any gap from this run');
+  }
   return buildChinaRowDiagnostic(
     assessChinaGasCoverage(records, now),
     previousMeta?.chinaRow ?? null,

--- a/scripts/seed-jodi-oil.mjs
+++ b/scripts/seed-jodi-oil.mjs
@@ -486,9 +486,16 @@ async function main() {
 
     console.log(`  Parsed ${allRows.length} KBD rows`);
 
+    const previousMeta = await readExistingSeedMeta('energy', 'jodi-oil');
+    if (previousMeta?.chinaRow == null) {
+      // readExistingSeedMeta collapses "no prior record" and "read failed" into
+      // one null, so an ongoing gap re-dates to this run. Say so, or the reset
+      // is indistinguishable from a genuine new outage in the log.
+      console.warn('  China oil row: no previous record readable — dating any gap from this run');
+    }
     const { countries, parsedCount, chinaCoverage, refusalReason, metaPayload } = prepareOilPublish({
       allRows,
-      previousMeta: await readExistingSeedMeta('energy', 'jodi-oil'),
+      previousMeta,
     });
     console.log(`  Built ${countries.length} country payloads of ${parsedCount} parsed`);
 

--- a/scripts/seed-jodi-oil.mjs
+++ b/scripts/seed-jodi-oil.mjs
@@ -12,10 +12,14 @@ import {
   logSeedResult,
   withRetry,
   readSeedSnapshot,
+  readExistingSeedMeta,
 } from './_seed-utils.mjs';
 import {
+  MAX_JODI_CONTENT_AGE_MIN,
   assessChinaJodiCoverage,
+  buildChinaRowDiagnostic,
   hasFiniteMeasurementAtPaths,
+  jodiDatasetContentMeta,
 } from './shared/jodi-content-age.mjs';
 import {
   DEMAND_CHANGE_BASIS,
@@ -402,15 +406,59 @@ async function redisPipeline(commands) {
   return resp.json();
 }
 
-export function formatCoverageFailureReason({ hasGlobalCoverage, countryCount, chinaCoverage }) {
-  const reasons = [];
-  if (!hasGlobalCoverage) {
-    reasons.push(`only ${countryCount} countries, need >=${MIN_VALID_COUNTRIES}`);
-  }
-  if (!chinaCoverage.ok) {
-    reasons.push(`China JODI oil coverage failed: ${chinaCoverage.reason} (dataMonth=${chinaCoverage.dataMonth ?? 'missing'})`);
-  }
-  return reasons.join('; ');
+/**
+ * The only condition that may withhold an oil publish: too few countries
+ * carry a usable measurement to trust the file at all. A single country —
+ * China included — is reported, never enforced (issue #6395).
+ */
+export function formatCoverageFailureReason({ countryCount }) {
+  return `only ${countryCount} countries with usable measurements, need >=${MIN_VALID_COUNTRIES}`;
+}
+
+/**
+ * Everything main() decides about a parsed snapshot, in one testable place:
+ * whether it may publish, what China looks like, and the seed-meta record that
+ * carries both to /api/health.
+ *
+ * @param {{ allRows: any[], previousMeta?: any, now?: Date }} input
+ */
+export function prepareOilPublish({ allRows, previousMeta = null, now = new Date() }) {
+  const parsed = buildAllCountries(allRows);
+  const chinaCoverage = assessChinaOilCoverage(parsed, now);
+
+  // A country whose every field parsed to null is not coverage: it would count
+  // toward MIN_VALID_COUNTRIES while serving no measurement to anyone. With no
+  // single-country gate standing behind that floor any more (#6395), the floor
+  // has to mean what it says, so only measurement-bearing countries are
+  // published. It also stops a null-only month from overwriting a country's
+  // last-good record — the key simply is not rewritten and ages out instead.
+  const countries = parsed.filter(hasOilMeasurements);
+  const refusalReason = validateCoverage(countries)
+    ? null
+    : formatCoverageFailureReason({ countryCount: countries.length });
+
+  const contentMeta = jodiDatasetContentMeta(countries, hasOilMeasurements, now);
+  return {
+    parsedCount: parsed.length,
+    countries,
+    chinaCoverage,
+    refusalReason,
+    metaPayload: {
+      fetchedAt: now.getTime(),
+      recordCount: countries.length,
+      chinaDataMonth: chinaCoverage.dataMonth,
+      chinaRow: buildChinaRowDiagnostic(
+        chinaCoverage,
+        previousMeta?.chinaRow ?? null,
+        now.getTime(),
+      ),
+      // Content-age trio: without it a JODI file that stopped advancing would
+      // publish forever as fresh now that no per-country gate refuses it.
+      newestItemAt: contentMeta?.newestItemAt ?? null,
+      oldestItemAt: contentMeta?.oldestItemAt ?? null,
+      maxContentAgeMin: MAX_JODI_CONTENT_AGE_MIN,
+    },
+  };
 }
 
 async function main() {
@@ -438,18 +486,14 @@ async function main() {
 
     console.log(`  Parsed ${allRows.length} KBD rows`);
 
-    const countries = buildAllCountries(allRows);
-    console.log(`  Built ${countries.length} country payloads`);
+    const { countries, parsedCount, chinaCoverage, refusalReason, metaPayload } = prepareOilPublish({
+      allRows,
+      previousMeta: await readExistingSeedMeta('energy', 'jodi-oil'),
+    });
+    console.log(`  Built ${countries.length} country payloads of ${parsedCount} parsed`);
 
-    const chinaCoverage = assessChinaOilCoverage(countries);
-    const hasGlobalCoverage = validateCoverage(countries);
-    if (!hasGlobalCoverage || !chinaCoverage.ok) {
-      const reason = formatCoverageFailureReason({
-        hasGlobalCoverage,
-        countryCount: countries.length,
-        chinaCoverage,
-      });
-      console.error(`  COVERAGE GATE FAILED: ${reason}`);
+    if (refusalReason) {
+      console.error(`  COVERAGE GATE FAILED: ${refusalReason}`);
       const prevIso2List = await readSeedSnapshot(CANONICAL_KEY, { strict: true });
       if (Array.isArray(prevIso2List) && prevIso2List.length > 0) {
         const prevCountryKeys = prevIso2List.map(iso2 => `${COUNTRY_KEY_PREFIX}${iso2}`);
@@ -465,6 +509,11 @@ async function main() {
       }
       return;
     }
+
+    console.log(chinaCoverage.ok
+      ? `  China oil coverage: ok (dataMonth=${chinaCoverage.dataMonth})`
+      : `  China oil coverage: ${chinaCoverage.reason} (dataMonth=${chinaCoverage.dataMonth ?? 'missing'})`
+        + ` — publishing the other ${countries.length} countries anyway`);
 
     // Every guard in this chain refuses by returning null, so a refused change
     // is otherwise indistinguishable from an upstream that simply has not
@@ -482,7 +531,6 @@ async function main() {
         + `(${chinaDemandAssessment.reason ?? 'no comparable basket'})`);
 
     const iso2List = countries.map(c => c.iso2);
-    const metaPayload = { fetchedAt: Date.now(), recordCount: countries.length, chinaDataMonth: chinaCoverage.dataMonth };
 
     const commands = [];
     for (const payload of countries) {

--- a/scripts/shared/jodi-content-age.mjs
+++ b/scripts/shared/jodi-content-age.mjs
@@ -96,6 +96,20 @@ export function assessChinaJodiCoverage(records, now, hasMeasurements) {
  * for the freshness of the whole file. For the same reason the newest month
  * must clear `minCountries` — see MIN_JODI_CONTENT_AGE_COUNTRIES.
  *
+ * This reduces with max-over-quorum, NOT the min() that
+ * `docs/solutions/design-patterns/multi-source-freshness-clock-must-reduce-with-min.md`
+ * requires. That rule governs one canonical key fed by several independently
+ * failing UPSTREAMS, where the live one hides the dead one. JODI is a single
+ * upstream — one file per fuel — whose countries are series inside it, and
+ * whose reporting lag is heterogeneous by design: the live files carry a tail
+ * back to 2014-03, so min() would report twelve years stale forever and could
+ * never go green. Gating the whole file on one country is also the exact
+ * defect issue #6395 removes. The quorum is what keeps max() honest here:
+ * a file that stops advancing cannot keep three countries moving, so the
+ * doc's own diagnostic — "which single upstream can stop publishing without
+ * changing newestItemAt?" — answers "none" at the granularity that has an
+ * upstream.
+ *
  * @param {unknown} records
  * @param {(record: any) => boolean} hasMeasurements
  * @param {Date} now

--- a/scripts/shared/jodi-content-age.mjs
+++ b/scripts/shared/jodi-content-age.mjs
@@ -1,6 +1,27 @@
-import { monthIndex } from './jodi-demand-change.mjs';
+import { monthIndex, monthPeriodEnd } from './jodi-demand-change.mjs';
 
 export const MAX_JODI_CONTENT_AGE_MONTHS = 6;
+
+/**
+ * Whole-dataset content budget, in minutes, for the runSeed content-age
+ * contract. JODI publishes monthly with a two-to-three month reporting lag, so
+ * this is the same six months the per-country assessment allows, measured in
+ * 31-day months so a snapshot can never alarm purely because the span it
+ * covered happened to cross short ones.
+ */
+export const MAX_JODI_CONTENT_AGE_MIN = MAX_JODI_CONTENT_AGE_MONTHS * 31 * 24 * 60;
+
+/**
+ * How many countries must report a month before it can date the whole file.
+ *
+ * A JODI file carries a long reporting tail — one country can sit years behind
+ * while the leading cohort is current. Taking the plain maximum would let a
+ * single fast reporter vouch for a file everyone else had stopped updating, so
+ * the dataset's date is the newest month a quorum agrees on. Measured against
+ * the live files on 2026-08-10 the leading cohort was 35 of 57 usable gas
+ * countries and 43 of 50 oil countries, so a quorum of three has wide margin.
+ */
+export const MIN_JODI_CONTENT_AGE_COUNTRIES = 3;
 
 function readPath(value, path) {
   return path.split('.').reduce((current, part) => {
@@ -21,8 +42,13 @@ export function hasFiniteMeasurementAtPaths(value, paths) {
 }
 
 /**
- * Validate China presence, source month, and usable measurements independently
+ * Report China presence, source month, and usable measurements independently
  * of the seeder fetch timestamp. Zero is a valid measurement.
+ *
+ * This is a diagnostic, never a publish gate: China stopping does not make the
+ * other fifty-plus countries in the same file wrong (issue #6395). Callers
+ * record the verdict through {@link buildChinaRowDiagnostic} and publish
+ * whatever else parsed.
  */
 export function assessChinaJodiCoverage(records, now, hasMeasurements) {
   const china = Array.isArray(records) ? records.find((record) => record?.iso2 === 'CN') : null;
@@ -47,4 +73,99 @@ export function assessChinaJodiCoverage(records, now, hasMeasurements) {
   }
 
   return { ok: true, reason: null, dataMonth: china.dataMonth, ageMonths };
+}
+
+/**
+ * Newest and oldest usable observation in a JODI snapshot, as epoch
+ * milliseconds anchored to the END of each record's data month.
+ *
+ * With China demoted to a diagnostic, this is what keeps a frozen upstream file
+ * from publishing as if it were fresh: the seeder feeds it to runSeed's
+ * content-age contract, and /api/health reports STALE_CONTENT once the whole
+ * dataset falls behind MAX_JODI_CONTENT_AGE_MIN.
+ *
+ * Only records that carry a real measurement count. A country row that parsed
+ * into nothing but nulls proves the download happened, never that the file
+ * still holds current observations. Returns null when no record qualifies,
+ * which both runSeed and health read as "content age unknown" — STALE_CONTENT,
+ * not OK.
+ *
+ * Months that have not finished yet are skipped for the same reason
+ * `assessChinaJodiCoverage` rejects them: an observation cannot be reported
+ * before its period ends, so one mis-dated country must not be able to vouch
+ * for the freshness of the whole file. For the same reason the newest month
+ * must clear `minCountries` — see MIN_JODI_CONTENT_AGE_COUNTRIES.
+ *
+ * @param {unknown} records
+ * @param {(record: any) => boolean} hasMeasurements
+ * @param {Date} now
+ * @param {number} minCountries
+ * @returns {{ newestItemAt: number, oldestItemAt: number } | null}
+ */
+export function jodiDatasetContentMeta(
+  records,
+  hasMeasurements,
+  now = new Date(),
+  minCountries = MIN_JODI_CONTENT_AGE_COUNTRIES,
+) {
+  if (!Array.isArray(records)) return null;
+  const nowMs = now instanceof Date && Number.isFinite(now.getTime()) ? now.getTime() : null;
+  if (nowMs === null) return null;
+
+  /** @type {Map<number, number>} */
+  const countriesByMonthEnd = new Map();
+  let oldestItemAt = null;
+  for (const record of records) {
+    if (!hasMeasurements(record)) continue;
+    const periodEnd = monthPeriodEnd(record?.dataMonth);
+    if (periodEnd === null) continue;
+    const observedAt = Date.parse(periodEnd);
+    if (!Number.isFinite(observedAt) || observedAt > nowMs) continue;
+    countriesByMonthEnd.set(observedAt, (countriesByMonthEnd.get(observedAt) ?? 0) + 1);
+    if (oldestItemAt === null || observedAt < oldestItemAt) oldestItemAt = observedAt;
+  }
+
+  let newestItemAt = null;
+  for (const [observedAt, countries] of countriesByMonthEnd) {
+    if (countries < minCountries) continue;
+    if (newestItemAt === null || observedAt > newestItemAt) newestItemAt = observedAt;
+  }
+
+  return newestItemAt === null ? null : { newestItemAt, oldestItemAt };
+}
+
+/**
+ * The bounded, public-safe China record the seeders write into seed-meta.
+ *
+ * Since an unusable China row no longer withholds the publish, this block is
+ * the only live statement of the gap — /api/health relays it verbatim so an
+ * operator reads "china-missing since <date>" beside an otherwise healthy
+ * dataset instead of inferring it from a generic staleness verdict 40 days
+ * later. `unavailableSince` is carried forward from the previous run so the
+ * gap reports its true age rather than looking new on every tick. It is
+ * best-effort by construction: a run that cannot read the previous seed-meta
+ * (Redis blip, first run after deploy) has no evidence the gap is older, so it
+ * re-dates to now. Read it as "first run that recorded this gap", never as a
+ * measured outage start.
+ *
+ * @param {{ ok: boolean, reason: string|null, dataMonth: string|null, ageMonths: number|null }} assessment
+ * @param {{ ok?: unknown, unavailableSince?: unknown }|null|undefined} previous
+ * @param {number} nowMs
+ */
+export function buildChinaRowDiagnostic(assessment, previous, nowMs) {
+  const ok = assessment?.ok === true;
+  const diagnostic = {
+    ok,
+    reason: ok ? null : (assessment?.reason ?? null),
+    dataMonth: assessment?.dataMonth ?? null,
+    ageMonths: assessment?.ageMonths ?? null,
+    unavailableSince: null,
+  };
+  if (ok) return diagnostic;
+
+  const carried = Number(previous?.unavailableSince);
+  diagnostic.unavailableSince = previous?.ok === false && Number.isFinite(carried) && carried > 0
+    ? carried
+    : nowMs;
+  return diagnostic;
 }

--- a/tests/china-energy-coverage.test.mjs
+++ b/tests/china-energy-coverage.test.mjs
@@ -3,7 +3,14 @@ import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
 
 import { buildSpineEntry } from '../scripts/seed-energy-spine.mjs';
-import { withRetry } from '../scripts/_seed-utils.mjs';
+import {
+  MAX_JODI_CONTENT_AGE_MIN,
+  MIN_JODI_CONTENT_AGE_COUNTRIES,
+  buildChinaRowDiagnostic,
+  jodiDatasetContentMeta,
+} from '../scripts/shared/jodi-content-age.mjs';
+import { monthPeriodEnd } from '../scripts/shared/jodi-demand-change.mjs';
+import { __testing__ as healthTesting } from '../api/health.js';
 import {
   buildResponseFromSpine,
   getObservedJodiGasMeasurements,
@@ -135,49 +142,397 @@ describe('China JODI content validation', () => {
     );
   });
 
-  it('reports global and China oil coverage failures together', () => {
-    const reason = oilModule.formatCoverageFailureReason({
-      hasGlobalCoverage: false,
-      countryCount: 50,
-      chinaCoverage: { ok: false, reason: 'china-stale', dataMonth: '2025-12' },
-    });
+  it('reports the country-floor shortfall that is the only oil publish refusal', () => {
+    const reason = oilModule.formatCoverageFailureReason({ countryCount: 39 });
 
-    assert.match(reason, /only 50 countries, need >=40/);
-    assert.match(reason, /China JODI oil coverage failed: china-stale \(dataMonth=2025-12\)/);
+    assert.match(reason, /only 39 countries with usable measurements, need >=40/);
+    assert.doesNotMatch(reason, /China/i, 'China must never appear in a publish refusal');
+  });
+});
+
+// Issue #6395. On 2026-08-10 both JODI files still carried China, but every
+// China row was ASSESSMENT_CODE 3 ("null/uncertain"), which both parsers
+// correctly discard — so China resolved to `china-missing` and the China gate
+// discarded 51 oil and 63 gas country payloads that had parsed cleanly. One
+// country must never withhold the rest of the dataset.
+describe('JODI publishes the rest of the world without China (#6395)', () => {
+  const NOW = new Date('2026-08-10T00:00:00.000Z');
+  const GAS_CSV_HEADER = 'REF_AREA,TIME_PERIOD,ENERGY_PRODUCT,FLOW_BREAKDOWN,UNIT_MEASURE,OBS_VALUE,ASSESSMENT_CODE';
+
+  /** A world file where China reports only unusable (code 3) rows. */
+  function gasCsvWithChinaCode3(countryCount) {
+    const lines = [GAS_CSV_HEADER];
+    for (let index = 0; index < countryCount; index++) {
+      const iso2 = `X${String(index).padStart(2, '0')}`;
+      lines.push(`${iso2},2026-05,NATGAS,IMPLNG,TJ,95000,1`);
+      lines.push(`${iso2},2026-05,NATGAS,TOTIMPSB,TJ,380000,1`);
+    }
+    for (const flow of ['IMPLNG', 'TOTIMPSB', 'TOTDEMO']) {
+      lines.push(`CN,2026-05,NATGAS,${flow},TJ,1200000,3`);
+    }
+    return lines.join('\n');
+  }
+
+  function oilRowsWithChinaCode3(countryCount) {
+    const rows = [];
+    for (let index = 0; index < countryCount; index++) {
+      rows.push({
+        REF_AREA: `X${String(index).padStart(2, '0')}`,
+        TIME_PERIOD: '2026-05',
+        ENERGY_PRODUCT: 'GASDIES',
+        FLOW_BREAKDOWN: 'TOTDEMO',
+        UNIT_MEASURE: 'KBD',
+        OBS_VALUE: '894.4',
+        ASSESSMENT_CODE: '1',
+      });
+    }
+    for (const product of ['GASDIES', 'GASOLINE', 'JETKERO']) {
+      rows.push({
+        REF_AREA: 'CN',
+        TIME_PERIOD: '2026-05',
+        ENERGY_PRODUCT: product,
+        FLOW_BREAKDOWN: 'TOTDEMO',
+        UNIT_MEASURE: 'KBD',
+        OBS_VALUE: '3200',
+        ASSESSMENT_CODE: '3',
+      });
+    }
+    return rows;
+  }
+
+  it('gas: keeps every other country when China parses to nothing usable', () => {
+    const records = gasModule.buildGasRecordsFromCsv(gasCsvWithChinaCode3(63), NOW);
+
+    assert.equal(records.length, 63, 'the 63 parsed countries must survive the run');
+    assert.equal(records.some((record) => record.iso2 === 'CN'), false);
+    assert.equal(
+      gasModule.validateGasCountries(records.map((record) => record.iso2)),
+      true,
+      'runSeed validateFn is the only gas publish gate and it must pass',
+    );
+    assert.equal(gasModule.assessChinaGasCoverage(records, NOW).reason, 'china-missing');
   });
 
-  it('preserves prior gas country keys and does not retry deterministic China rejection', async () => {
-    const ttlExtensions = [];
-    let attempts = 0;
+  it('oil: publishes when China is unusable and refuses only below the country floor', () => {
+    const publishable = oilModule.prepareOilPublish({
+      allRows: oilRowsWithChinaCode3(45),
+      previousMeta: null,
+      now: NOW,
+    });
 
-    await assert.rejects(
-      () => withRetry(
-        async () => {
-          attempts++;
-          return gasModule.enforceChinaGasCoverage(
-            [gasRecord({ iso2: 'US' })],
-            new Date('2026-07-13T00:00:00.000Z'),
-            {
-              readSnapshot: async () => ['US', 'CN', 'invalid'],
-              extendTtl: async (keys, ttlSeconds) => { ttlExtensions.push({ keys, ttlSeconds }); },
-            },
-          );
+    assert.equal(publishable.refusalReason, null, 'an unusable China row must not refuse the publish');
+    assert.equal(publishable.countries.length, 45);
+    assert.equal(publishable.chinaCoverage.reason, 'china-missing');
+    assert.equal(publishable.metaPayload.recordCount, 45);
+    assert.equal(publishable.metaPayload.chinaRow.ok, false);
+
+    const refused = oilModule.prepareOilPublish({
+      allRows: oilRowsWithChinaCode3(39),
+      previousMeta: null,
+      now: NOW,
+    });
+
+    assert.match(refused.refusalReason, /only 39 countries with usable measurements, need >=40/);
+    assert.doesNotMatch(refused.refusalReason, /China/i);
+  });
+
+  it('oil: records the content-age trio the replacement staleness alarm reads', () => {
+    const { metaPayload } = oilModule.prepareOilPublish({
+      allRows: oilRowsWithChinaCode3(45),
+      previousMeta: null,
+      now: NOW,
+    });
+
+    assert.equal(metaPayload.newestItemAt, Date.parse(monthPeriodEnd('2026-05')));
+    assert.equal(metaPayload.oldestItemAt, Date.parse(monthPeriodEnd('2026-05')));
+    assert.equal(metaPayload.maxContentAgeMin, MAX_JODI_CONTENT_AGE_MIN);
+  });
+
+  it('the country floor counts countries that carry a measurement, not rows that parsed', () => {
+    // 45 countries reach the file, but only 39 report a usable value. Before
+    // #6395 an unusable China row was the incidental canary for this; the floor
+    // itself has to catch it now.
+    const rows = oilRowsWithChinaCode3(39);
+    for (let index = 0; index < 6; index++) {
+      rows.push({
+        REF_AREA: `E${String(index).padStart(2, '0')}`,
+        TIME_PERIOD: '2026-05',
+        ENERGY_PRODUCT: 'GASDIES',
+        FLOW_BREAKDOWN: 'TOTDEMO',
+        UNIT_MEASURE: 'KBD',
+        OBS_VALUE: '-',
+        ASSESSMENT_CODE: '1',
+      });
+    }
+
+    const refused = oilModule.prepareOilPublish({ allRows: rows, previousMeta: null, now: NOW });
+    assert.equal(refused.parsedCount, 45, 'all 45 countries still parse');
+    assert.match(refused.refusalReason, /only 39 countries with usable measurements/);
+    assert.equal(refused.countries.some((country) => country.iso2.startsWith('E')), false);
+
+    // Gas drops the same shape rather than publishing an all-null record over
+    // that country's last-good key.
+    const gasCsv = [
+      GAS_CSV_HEADER,
+      ...Array.from({ length: 55 }, (_, index) => {
+        const iso2 = `X${String(index).padStart(2, '0')}`;
+        return `${iso2},2026-05,NATGAS,IMPLNG,TJ,95000,1`;
+      }),
+      // Reports a flow, but with no readable value — a row, not coverage.
+      'ZZ,2026-05,NATGAS,IMPLNG,TJ,-,1',
+    ].join('\n');
+    const gasRecords = gasModule.buildGasRecordsFromCsv(gasCsv, NOW);
+    assert.equal(gasRecords.length, 55);
+    assert.equal(gasRecords.some((record) => record.iso2 === 'ZZ'), false);
+  });
+
+  it('dates the China gap once and carries that date across later runs', () => {
+    const firstSeen = Date.UTC(2026, 5, 1);
+    const absent = { ok: false, reason: 'china-missing', dataMonth: null, ageMonths: null };
+
+    const first = buildChinaRowDiagnostic(absent, null, firstSeen);
+    assert.deepEqual(first, {
+      ok: false,
+      reason: 'china-missing',
+      dataMonth: null,
+      ageMonths: null,
+      unavailableSince: firstSeen,
+    });
+
+    const later = buildChinaRowDiagnostic(absent, first, Date.UTC(2026, 7, 10));
+    assert.equal(later.unavailableSince, firstSeen, 'the gap must not look new on every tick');
+
+    const recovered = buildChinaRowDiagnostic(
+      { ok: true, reason: null, dataMonth: '2026-06', ageMonths: 2 },
+      later,
+      Date.UTC(2026, 8, 10),
+    );
+    assert.deepEqual(recovered, {
+      ok: true,
+      reason: null,
+      dataMonth: '2026-06',
+      ageMonths: 2,
+      unavailableSince: null,
+    });
+  });
+
+  const hasMeasurement = (record) => record.usable === true;
+  const reporters = (dataMonth, count, usable = true) =>
+    Array.from({ length: count }, () => ({ dataMonth, usable }));
+
+  it('dates dataset content age from the newest month that carries a measurement', () => {
+    const contentMeta = jodiDatasetContentMeta([
+      ...reporters('2026-01', 3),
+      ...reporters('2025-11', 3),
+      // A newer month whose every field parsed to null proves the download
+      // happened, never that the file still holds current observations.
+      ...reporters('2026-05', 5, false),
+      ...reporters('not-a-month', 5),
+      // Mis-dated countries must not vouch for the whole file's freshness.
+      ...reporters('2027-03', 5),
+    ], hasMeasurement, NOW);
+
+    assert.deepEqual(contentMeta, {
+      newestItemAt: Date.parse(monthPeriodEnd('2026-01')),
+      oldestItemAt: Date.parse(monthPeriodEnd('2025-11')),
+    });
+    assert.equal(jodiDatasetContentMeta(reporters('2026-01', 5, false), hasMeasurement, NOW), null);
+    assert.equal(jodiDatasetContentMeta(reporters('2027-03', 5), hasMeasurement, NOW), null);
+    assert.equal(jodiDatasetContentMeta(null, hasMeasurement, NOW), null);
+  });
+
+  it('one fast reporter cannot date a file everyone else stopped updating', () => {
+    // JODI carries a long reporting tail — a single country sitting on a
+    // current month while the leading cohort is frozen must not read as fresh.
+    const frozenFileWithOneLeader = [
+      ...reporters('2026-06', MIN_JODI_CONTENT_AGE_COUNTRIES - 1),
+      ...reporters('2025-09', 40),
+    ];
+
+    assert.equal(
+      jodiDatasetContentMeta(frozenFileWithOneLeader, hasMeasurement, NOW).newestItemAt,
+      Date.parse(monthPeriodEnd('2025-09')),
+      'the quorum month dates the file, not the leader',
+    );
+    assert.equal(
+      jodiDatasetContentMeta(
+        [...reporters('2026-06', MIN_JODI_CONTENT_AGE_COUNTRIES), ...reporters('2025-09', 40)],
+        hasMeasurement,
+        NOW,
+      ).newestItemAt,
+      Date.parse(monthPeriodEnd('2026-06')),
+      'once a quorum reports the newer month, the file is dated by it',
+    );
+  });
+
+  it('gas reads its previous run to age the gap, and re-dates it when it cannot', async () => {
+    const records = gasModule.buildGasRecordsFromCsv(gasCsvWithChinaCode3(63), NOW);
+    const firstSeen = Date.parse('2026-06-01T00:00:00.000Z');
+
+    const carried = await gasModule.buildGasChinaRowDiagnostic(records, NOW, {
+      readPreviousMeta: async () => ({
+        chinaRow: { ok: false, reason: 'china-missing', unavailableSince: firstSeen },
+      }),
+    });
+    assert.equal(carried.reason, 'china-missing');
+    assert.equal(carried.unavailableSince, firstSeen);
+
+    // Documented best-effort behaviour: with no readable previous record the
+    // gap can only be dated from this run.
+    const unreadable = await gasModule.buildGasChinaRowDiagnostic(records, NOW, {
+      readPreviousMeta: async () => null,
+    });
+    assert.equal(unreadable.unavailableSince, NOW.getTime());
+  });
+
+  it('a frozen upstream file reads STALE_CONTENT instead of publishing silently', () => {
+    const { classifyKey, STANDALONE_KEYS, SEED_META } = healthTesting;
+    const now = Date.parse('2026-08-10T00:00:00.000Z');
+    const key = STANDALONE_KEYS.jodiGas;
+    const metaKey = SEED_META.jodiGas.key;
+
+    const classify = (newestMonth) => classifyKey('jodiGas', key, {}, {
+      keyStrens: new Map([[key, 4096]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map([[metaKey, JSON.stringify({
+        fetchedAt: now - 60_000,
+        recordCount: 63,
+        newestItemAt: Date.parse(monthPeriodEnd(newestMonth)),
+        oldestItemAt: Date.parse(monthPeriodEnd('2024-01')),
+        maxContentAgeMin: MAX_JODI_CONTENT_AGE_MIN,
+        chinaRow: {
+          ok: false,
+          reason: 'china-missing',
+          dataMonth: null,
+          ageMonths: null,
+          unavailableSince: Date.parse('2026-06-01T00:00:00.000Z'),
         },
-        3,
-        0,
-      ),
-      (error) => {
-        assert.match(error.message, /China JODI gas coverage failed: china-missing/);
-        assert.equal(error.nonRetryable, true);
-        return true;
+      })]]),
+      keyMetaErrors: new Map(),
+      now,
+    });
+
+    // The observed 2026-08-10 state: gas has not moved past 2026-01.
+    const frozen = classify('2026-01');
+    assert.equal(frozen.status, 'STALE_CONTENT');
+    // The China gap rides along on every verdict, named, so an operator never
+    // has to read Railway logs to learn which country dropped out.
+    assert.deepEqual(frozen.chinaRow, {
+      ok: false,
+      reason: 'china-missing',
+      dataMonth: null,
+      ageMonths: null,
+      unavailableSince: Date.parse('2026-06-01T00:00:00.000Z'),
+    });
+
+    // ...and a live upstream stays OK: an absent China alone never warns.
+    const current = classify('2026-06');
+    assert.equal(current.status, 'OK');
+    assert.equal(current.chinaRow.reason, 'china-missing');
+  });
+
+  it('bounds the chinaRow relay so a producer cannot put arbitrary values on a public endpoint', () => {
+    const { classifyKey, STANDALONE_KEYS, SEED_META } = healthTesting;
+    const now = Date.parse('2026-08-10T00:00:00.000Z');
+    const key = STANDALONE_KEYS.jodiGas;
+    const metaKey = SEED_META.jodiGas.key;
+
+    const classifyWith = (meta, name = 'jodiGas', dataKey = key, metaK = metaKey) =>
+      classifyKey(name, dataKey, {}, {
+        keyStrens: new Map([[dataKey, 4096]]),
+        keyErrors: new Map(),
+        keyMetaValues: new Map([[metaK, JSON.stringify({
+          fetchedAt: now - 60_000,
+          recordCount: 63,
+          newestItemAt: Date.parse(monthPeriodEnd('2026-06')),
+          oldestItemAt: Date.parse(monthPeriodEnd('2024-01')),
+          maxContentAgeMin: MAX_JODI_CONTENT_AGE_MIN,
+          ...meta,
+        })]]),
+        keyMetaErrors: new Map(),
+        now,
+      });
+
+    // Free-text reason, junk month, non-numeric age, and a string timestamp all
+    // collapse to null rather than reaching the wire.
+    const junk = classifyWith({
+      chinaRow: {
+        ok: false,
+        reason: 'whatever the producer felt like writing',
+        dataMonth: 'not-a-month',
+        ageMonths: 'lots',
+        unavailableSince: 'yesterday',
       },
+    });
+    assert.deepEqual(junk.chinaRow, {
+      ok: false,
+      reason: null,
+      dataMonth: null,
+      ageMonths: null,
+      unavailableSince: null,
+    });
+
+    // A healthy China row never carries an outage start date.
+    const healthy = classifyWith({
+      chinaRow: {
+        ok: true,
+        reason: null,
+        dataMonth: '2026-05',
+        ageMonths: 3,
+        unavailableSince: Date.parse('2026-06-01T00:00:00.000Z'),
+      },
+    });
+    assert.deepEqual(healthy.chinaRow, {
+      ok: true,
+      reason: null,
+      dataMonth: '2026-05',
+      ageMonths: 3,
+      unavailableSince: null,
+    });
+
+    // A non-object block, and a key that never opted in, publish nothing.
+    assert.equal(classifyWith({ chinaRow: 'china-missing' }).chinaRow, undefined);
+    assert.equal(classifyWith({}).chinaRow, undefined);
+    assert.equal(
+      classifyWith(
+        { chinaRow: { ok: false, reason: 'china-missing' } },
+        'eiaPetroleum',
+        STANDALONE_KEYS.eiaPetroleum,
+        SEED_META.eiaPetroleum.key,
+      ).chinaRow,
+      undefined,
+      'only the three JODI-backed checks opt in',
     );
 
-    assert.equal(attempts, 1, 'deterministic coverage rejection must not redownload the JODI ZIP');
-    assert.deepEqual(ttlExtensions, [{
-      keys: ['energy:jodi-gas:v1:US', 'energy:jodi-gas:v1:CN'],
-      ttlSeconds: gasModule.GAS_TTL,
-    }]);
+    // A producer that reported status:'error' never got as far as assessing
+    // China; last run's verdict must not be relayed as this run's.
+    const errored = classifyWith({ status: 'error', chinaRow: { ok: false, reason: 'china-missing' } });
+    assert.equal(errored.chinaRow, undefined);
+  });
+
+  it('keeps the named China gap out of the anonymous compact body', () => {
+    const { healthResponseBody } = healthTesting;
+    const chinaRow = { ok: false, reason: 'china-missing', dataMonth: null, ageMonths: null, unavailableSince: 1 };
+    const snapshot = {
+      status: 'DEGRADED',
+      summary: {},
+      checkedAt: '2026-08-10T00:00:00.000Z',
+      checks: { jodiGas: { status: 'STALE_CONTENT', records: 57, chinaRow } },
+    };
+
+    // Same rule the contentFreshness/decisionGroups scrub follows: the STATUS
+    // is public, the named entity behind it is operator-only.
+    const compact = healthResponseBody(snapshot, true);
+    assert.equal(compact.problems.jodiGas.status, 'STALE_CONTENT');
+    assert.equal(compact.problems.jodiGas.chinaRow, undefined);
+    // ...and a cached compact snapshot written before the rule is scrubbed too.
+    assert.equal(
+      healthResponseBody({ ...snapshot, checks: undefined, problems: { jodiGas: { status: 'STALE_CONTENT', chinaRow } } }, true)
+        .problems.jodiGas.chinaRow,
+      undefined,
+    );
+    // The operator view keeps it.
+    assert.deepEqual(healthResponseBody(snapshot, false).checks.jodiGas.chinaRow, chinaRow);
   });
 });
 

--- a/tests/seeder-content-age-coverage.test.mjs
+++ b/tests/seeder-content-age-coverage.test.mjs
@@ -37,6 +37,13 @@ const FREEZE_PRONE_MARKERS = [
   /api\.worldbank\.org/,         // World Bank
   /open-meteo-archive/,          // Open-Meteo ERA5 archive
   /lastNObservations=/,          // SDMX windowed-fetch query param
+  // JODI — froze in #6395: the gas world file stopped advancing past 2026-01
+  // and no 2026 oil annual file was ever published, while both downloads kept
+  // returning HTTP 200. Content-age is now the ONLY thing standing between a
+  // frozen JODI file and an OK health verdict, because the per-country China
+  // gate that incidentally caught it was removed in the same issue. This
+  // marker is what keeps that opt-in from being deleted silently.
+  /jodidata\.org/,
 ];
 
 // Seeders that match the heuristic but do NOT wire content-age. Every entry


### PR DESCRIPTION
Closes #6395.

## What was actually wrong

The seeders were not mis-scheduled and were not failing. They ran daily, parsed cleanly, and then refused to publish: `assessChinaJodiCoverage` returned `china-missing`, and both seeders treated that as a hard gate — discarding 51 oil and 63 gas country payloads because one country was unusable. `seed-meta` was never written, so the freshness clock kept running until the 40-day budget tripped on 2026-08-10.

**Verified against the live upstream files on 2026-08-10** (not inferred from logs):

- China **is** present in both JODI files — but every China row carries `ASSESSMENT_CODE 3` ("null/uncertain"), which both parsers correctly discard. 1080 of 1080 China oil KBD rows and 977 of 977 China gas TJ rows are code 3, so China resolves to `china-missing`.
- Both files are themselves frozen. The gas world file stops at `2026-01` (zip entry dated 2026-03-16). JODI's oil downloads page lists annual CSVs only through `2025.csv` — `primary/2026.csv` and `secondary/2026.csv` return 404 because **no 2026 oil file exists**, so the newest oil month is `2025-12`.

Neither fact was visible, because the China gate was suppressing the publish that would have exposed them.

## The decision

One country does not get to withhold the dataset. China is now reported, never enforced.

1. **The only publish refusal left is the country floor** — and it now counts countries that carry a measurement rather than rows that parsed. A country whose every field is null was never coverage; counting it padded the floor, and publishing it overwrote that country's last-good record with nulls. Against the live files that is 57 of 63 gas countries and 50 of 50 oil.

2. **The staleness protection the China gate incidentally provided is replaced, not dropped.** The old gate bounded the dataset's content age via China's `dataMonth`; removing it without a replacement would have let a frozen file publish as fresh forever. Both seeders now declare `newestItemAt`/`oldestItemAt`/`maxContentAgeMin` in `seed-meta`, dated from the newest month a **quorum** of countries reports (JODI has a long reporting tail — one country sat on `2014-03` — so a plain maximum would let a single fast reporter vouch for a dead file). `jodidata.org` joins `FREEZE_PRONE_MARKERS` so that opt-in cannot be deleted silently; the guard was mutation-proven (removing `maxContentAgeMin` from the gas seeder turns `tests/seeder-content-age-coverage.test.mjs` red).

   *On the reduction:* `docs/solutions/design-patterns/multi-source-freshness-clock-must-reduce-with-min.md` requires `min()` so a live source cannot hide a dead sibling. This clock reduces with max-over-quorum, deliberately, and the code now says why. That rule governs one key fed by several independently failing **upstreams**; JODI is a single upstream per fuel whose countries are series inside one file, with heterogeneous lag by design — the live files carry a tail back to `2014-03`, so `min()` would report twelve years stale forever and could never go green. Gating the file on one lagging country is also the exact defect this issue removes. The quorum is what keeps `max()` honest: a file that stops advancing cannot keep three countries moving, so the doc's own diagnostic ("which single upstream can stop publishing without changing `newestItemAt`?") answers "none" at the granularity that has an upstream.

3. **`/api/health` relays a bounded `chinaRow` diagnostic** on `jodiOil` / `jodiGas` / `lngVulnerability`: `{ok, reason, dataMonth, ageMonths, unavailableSince}`, closed reason vocabulary, operator-only (stripped from `?compact=1` under the same rule as `contentFreshness`). It **never moves a status** — China's rows going unusable is an upstream fact no retry clears, and `scripts/china-coverage-manifest.mjs` already carries both JODI entries as `launchStatus: 'blocked'` with `CHINA_UPSTREAM_ROW_UNAVAILABLE` for exactly that reason. Grading it would be an eternal warn nobody can clear; leaving it silent would be worse.

## Acceptance criteria

- [x] `jodiGas`, `jodiOil` and `lngVulnerability` stop reporting a generic staleness verdict. They publish, and report `STALE_CONTENT` — the specific, true statement that the *upstream content* is frozen — alongside a `chinaRow` block that names China. When JODI resumes, both clear to `OK` with no further change.
- [x] The chosen behaviour is covered by tests driving `assessChinaJodiCoverage` with an absent `CN` record (`tests/china-energy-coverage.test.mjs`).
- [x] Item 3 of the issue (confirm with JODI whether China's submission stopped or the layout moved) is **answered**: the layout did not move; China's submissions are present but flagged unusable, and JODI has stopped publishing new oil annual files entirely. Worth raising with JODI, but nothing in this repo can fix it.

## Verification

Real upstream files, real seeder code paths, `now = 2026-08-10`:

```
GAS  63 parsed -> 57 published (>= 50 floor)   china: china-missing   content: 2026-01-31 (190d old)
OIL  50 parsed -> 50 published (>= 40 floor)   china: china-missing   content: 2025-12-31 (221d old)
     budget 267840 min (186d) -> both read STALE_CONTENT, neither refuses
```

Before this change both published **nothing**.

Tests: `tests/china-energy-coverage.test.mjs` 24/24; plus green on `jodi-gas-seed`, `jodi-oil-seed`, `seeder-content-age-coverage`, `china-energy-demand-change-parity`, `energy-spine-seed`, `health-classify`, `health-content-age`, `health-verdict-snapshot`, `health-verdict-compact-snapshot`, `health-compact-cdn-cache`, `health-content-freshness`, `seed-ttl-outlives-staleness-fleet`, `seeder-canonical-ttl-vs-cron`, `seed-extra-key-leak-guard`, `china-coverage-health`, `mcp-bootstrap-parity`. Biome clean.

Reviewed by a 10-reviewer roster plus an independent cross-model adversarial pass; the floor-counts-rows finding, the compact-body leak, the content-age anchor, and the quorum weakness all came from that review and are fixed here.

## Known residuals

- **`energy:jodi-*:v1:CN` lingers up to 35 days.** A no-China publish stops refreshing the CN per-country key rather than deleting it, so a direct reader can serve the old China record until its TTL expires while the canonical list already excludes it. This is strictly better than the previous behaviour, where the gate *extended* that key's TTL on every failed run and pinned the stale record indefinitely. Consumers already degrade correctly (`hasJodiOil`/`hasJodiGas` read false), and the China coverage manifest already reports JODI as blocked.
- **`chinaRow.unavailableSince` is best-effort.** A run that cannot read the previous `seed-meta` re-dates the gap to that run. Documented as "first run that recorded this gap", never as a measured outage start.
- **Worth a `docs/solutions` entry after this lands.** The min-reduction rule now has a documented boundary case (one upstream, many heterogeneous series inside it, quorum instead of min) that is not captured anywhere.
- **Content-age is producer-declared fleet-wide.** Health treats a missing `maxContentAgeMin` as a legacy opt-out rather than failing closed. The static anchor added here closes the source-level path; a health-side `requireContentAge` would need a rollout window on 35-day-cadence producers and belongs to the fleet, not this fix.

## Post-Deploy Monitoring & Validation

- **Trigger:** `seed-bundle-energy-sources` (cron `30 7 * * *`). Both JODI members are past their 35-day self-throttle, so they run on the next tick.
- **Railway logs to search** (`seed-bundle-energy-sources`): `Countries with gas data:` should read `57 of 63 parsed`; `Built N country payloads of M parsed` for oil; `China gas coverage: china-missing … publishing the other 57 countries anyway`. `section=JODI-Gas status=GRACEFUL_FAIL` and `COVERAGE GATE FAILED` must **not** appear.
- **Healthy signal:** `GET /api/health` -> `checks.jodiGas` and `checks.jodiOil` have `seedAgeMin` < 1440 and `status: "STALE_CONTENT"` with `contentAgeMin` ~190d / ~221d and a `chinaRow` naming `china-missing`. `lngVulnerability` follows `jodiGas`.
- **Failure signal / rollback trigger:** either check still `STALE_SEED` after the next successful bundle run (the publish did not happen), or `records` below 50 gas / 40 oil (the usable-country filter cut too deep). Rollback is a revert of this commit — the seeders' last-good keys are untouched by it.
- **Watch for the recovery case:** when JODI resumes publishing, `STALE_CONTENT` should clear to `OK` on its own with no code change. If it does not, the quorum or the 186-day budget needs revisiting.
- **Window/owner:** next two bundle runs (~48h), @koala73.
