### PR TITLE
ops(railway): mark company-monitoring-worker planned so the post-#6397 apply can run (#6402)

### DIFF
--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1186,6 +1186,7 @@
   {
     "entry": "scripts/company-monitoring-worker.mjs",
     "deployMode": "nixpacks-root-scripts",
+    "lifecycle": "planned",
     "service": "company-monitoring-worker",
     "startCommand": "node company-monitoring-worker.mjs",
     "requiredEnv": [
@@ -1207,7 +1208,7 @@
       "scripts/package.json"
     ],
     "cronSchedule": null,
-    "documentedAt": "scripts/company-monitoring-worker.mjs (header docblock declares rootDirectory: scripts)"
+    "documentedAt": "scripts/company-monitoring-worker.mjs (header docblock declares rootDirectory: scripts); lifecycle planned 2026-08-10 pending provisioning — see #6402"
   },
   {
     "entry": "scripts/scenario-worker.mjs",

--- a/tests/railway-watch-path-audit.test.mjs
+++ b/tests/railway-watch-path-audit.test.mjs
@@ -748,7 +748,22 @@ describe('planned Railway service lifecycle', () => {
   };
 
   it('keeps unprovisioned standalone seeders explicitly planned', () => {
+    // An exact list, not a predicate: `planned` removes an entry from the live
+    // audit AND from `--apply`, so every addition has to be a decision somebody
+    // made rather than a way to quiet a red gate.
+    //
+    // company-monitoring-worker (2026-08-10, #6402): #6386 shipped the module and
+    // this registry entry, but no Railway service, no COMPANY_MONITORING_WORKER_SECRET
+    // in any of the 92 shared variables, and nothing else provisioned. Left
+    // unmarked it read as `service is missing from Railway production`, which made
+    // buildRailwayServiceConfigPatch refuse the apply for six OTHER services —
+    // stranding #6397's widened watch paths, including the exact build-input
+    // closure `umami` needs to stop being BEHIND (#6381). Unlike the seeders above,
+    // its own module header says "always-on Railway service" and health polls it on
+    // a 5-minute budget, so this entry is a deliberate PAUSE, not a staging state:
+    // provisioning it (#6402) must remove it from this list again.
     const expectedPlannedServices = [
+      'company-monitoring-worker',
       'seed-crypto-sectors',
       'seed-market-quotes',
       'seed-service-statuses',


### PR DESCRIPTION
Unblocks the post-#6397 watch-path apply, which is **already applied to production** — see
Verification. Refs #6402, #6381.

## Why the apply was stuck

#6397 widened the registry (`.dockerignore`, direct Dockerfile `COPY` inputs, `.d.ts` files,
tsconfigs). A merged registry change is not Railway truth: only
`audit-railway-watch-paths.mjs --apply` pushes it, and that apply was refusing outright:

```
$ node scripts/audit-railway-watch-paths.mjs --apply
company-monitoring-worker not present in Railway production; refusing a partial config apply
```

#6386 shipped `scripts/company-monitoring-worker.mjs` and its registry entry with nothing
provisioned — no Railway service, and no `COMPANY_MONITORING_WORKER_SECRET` in the local env
file or in any of Railway's 92 shared variables. Unmarked, the entry reads as a missing
service, and `buildRailwayServiceConfigPatch` refuses a partial apply. So one unprovisioned
entry stranded #6397's watch paths for **six other services** — including the exact
build-input closure `umami` needs to stop being `BEHIND` since 2026-08-09 16:23 (#6381).

## The change

`lifecycle: "planned"` is the registry's own mechanism for declared-but-unprovisioned
(`audit-railway-watch-paths.mjs:143`); four seeders already use it.

Applied here as a deliberate **pause**, not a staging state. Unlike those seeders, this
module's header says *"always-on Railway service"* and `api/health.js` polls it on a 5-minute
budget — the gate was correctly reporting a real provisioning gap. Provisioning it (#6402)
must take it back off the list, and the test comment says so.

The allow-list in `tests/railway-watch-path-audit.test.mjs` is exact on purpose: `planned`
removes an entry from both the live audit and `--apply`, so every addition has to be a
decision somebody made rather than a way to quiet a red gate. Updated with the reasoning and
the condition that reverses it.

## Verification

Applied to production with the registry read from this tree — the applied config equals what
`main` declares for those six services; this change only excludes the unprovisioned entry from
the patch:

```
Applied and verified registry-managed config for 6 Railway service(s) in production.
  ais-relay, digest-notifications, seed-bundle-portwatch-port-activity,
  seed-bundle-resilience-validation, umami, umami-retention

$ node scripts/audit-railway-watch-paths.mjs
Railway operational-config audit passed: registry-managed Dockerfile paths, cron schedules,
and watch paths match production …   (exit 0)
```

`main()` re-reads the environment after patching and fails if drift remains, so the apply
proves itself.

- 99 registry tests pass (`railway-watch-path-audit`, `railway-services-registry-coverage`,
  `railway-watch-path-drift-regression`, `dockerfile-digest-notifications-imports`).
- 154 sibling Railway/monitor tests pass.
- `npx biome check` clean.

The `Audit Railway ingestion deployment controls` step of the Seed Freshness Monitor should go
green on the next scheduled run.

https://claude.ai/code/session_014iaXRJN9n59i1ZDTd3JLy2
