### PR TITLE
fix(sentry): repair the alicdn font rule and filter the round-5 TR injectors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -278,7 +278,13 @@ function shouldSuppressCspViolation(
     // therefore matches the whole fallback chain — pinning one extension leaks
     // the rest, which is how a Doubao `.otf` and a gstatic `.ttf` kept firing
     // after their rules shipped (WORLDMONITOR-TR round 3).
-    const fontFile = /\.(?:woff2?|ttf|otf)$/;
+    // `.eot`/`.svg` are here for the same reason: iconfont.cn emits the classic
+    // five-format chain (eot -> woff2 -> woff -> ttf -> svg), so the alicdn rule
+    // below kept leaking its `.svg` member — 224 of that host's 776 events in the
+    // 14d window to 2026-08-10 (WORLDMONITOR-TR round 5). Both are font formats
+    // only; every rule below stays host- and path-pinned, so widening the format
+    // set cannot widen which hosts are suppressed.
+    const fontFile = /\.(?:woff2?|ttf|otf|eot|svg)$/;
     try {
       const url = new URL(blockedURI);
       if (url.protocol === 'https:' && url.hostname === 'fonts.gstatic.com' && /^\/s\/.+/.test(url.pathname) && fontFile.test(url.pathname)) return true;
@@ -306,13 +312,19 @@ function shouldSuppressCspViolation(
       // rules above, so any other migaku path still surfaces.
       if (url.protocol === 'https:' && url.hostname === 'migaku-public-data.migaku.com'
           && url.pathname.startsWith('/fonts/') && fontFile.test(url.pathname)) return true;
-      // Alibaba iconfont.cn project CDN (at.alicdn.com/t/c/font_<id>.<ext>).
-      // One injected icon font requested in all three formats — 15% of this
-      // issue's current volume. `alicdn.com` is a general Alibaba CDN, so this
-      // is pinned to the exact `at.` host and a font-file path — other alicdn
-      // hosts and non-font assets still surface.
+      // Alibaba iconfont.cn project CDN. `alicdn.com` is a general Alibaba CDN,
+      // so this is pinned to the exact `at.` host and a font-file path — other
+      // alicdn hosts and non-font assets still surface.
+      //
+      // The prefix is `/t/`, NOT `/t/c/`: iconfont.cn serves projects under both
+      // the legacy `/t/font_<id>.<ext>` and the newer `/t/c/font_<id>.<ext>`, and
+      // the original `/t/c/` rule matched only the newer one. Measured over the
+      // 14d window to 2026-08-10, 755 of this host's 776 events (97%) used the
+      // legacy `/t/` path, so the rule shipped in #6369 suppressed almost none of
+      // what it was written for (WORLDMONITOR-TR round 5). `/t/` is still a
+      // path prefix on a pinned host, so `/other/...` assets keep surfacing.
       if (url.protocol === 'https:' && url.hostname === 'at.alicdn.com'
-          && url.pathname.startsWith('/t/c/') && fontFile.test(url.pathname)) return true;
+          && url.pathname.startsWith('/t/') && fontFile.test(url.pathname)) return true;
       // slant.co overlay webfont (Plus Jakarta Display, 3 weights x 2 formats)
       // served from the injecting extension's own origin — 12% of this issue's
       // current volume. Our font-src is `'self' data:` — we ship no
@@ -333,6 +345,48 @@ function shouldSuppressCspViolation(
       // URLs, the second-largest remaining slice. Same exact-host shape.
       if (url.protocol === 'https:' && url.hostname === 'images.simplycodes.com'
           && url.pathname.startsWith('/fonts/') && fontFile.test(url.pathname)) return true;
+      // ---- Round 5 hosts. Sized on 2026-07-27..2026-08-10 (14d, 6353 events),
+      // and re-sized on the 22h window strictly AFTER the round-4 rules were
+      // live (2026-08-09T16:00Z, commit b2f1473) so drain from stale clients on
+      // pre-rule bundles is not mistaken for a rule that does not work. That
+      // distinction matters: shopback looked like it was still escaping its
+      // brand-new rule until its events were grouped by `build_sha` and every
+      // one turned out to predate the rule's own commit.
+      //
+      // scite.ai citation-badge extension injects its icon font on every page.
+      // The ONLY host still firing at the head of that post-deploy window (25 of
+      // 61 events, 41%, latest 2026-08-10T13:18Z) — i.e. the host that keeps
+      // regressing this issue. `scite` appears nowhere in src.
+      if (url.protocol === 'https:' && url.hostname === 'cdn.scite.ai'
+          && url.pathname.startsWith('/assets/fonts/') && fontFile.test(url.pathname)) return true;
+      // Adobe Fonts (Typekit) kit webfonts — 1137 events / 14d, the largest
+      // remaining slice after migaku. This is the font-src counterpart of the
+      // existing use.typekit.net STYLE-src rule below: that one matches the kit
+      // `.css`, this one matches the font binaries the kit then requests. They
+      // need separate rules because Typekit serves fonts from extensionless
+      // paths (`/af/<hex>/<hex>/<n>/<a|d|l>`, where the last segment is the
+      // format code), so `fontFile` cannot match them. Pinned to that exact
+      // path shape, so any other typekit path still surfaces.
+      if (url.protocol === 'https:' && url.hostname === 'use.typekit.net'
+          && /^\/af\/[0-9a-f]+\/[0-9a-f]+\/\d+\/[adl]$/.test(url.pathname)) return true;
+      // FontAwesome public CDN, font-src counterpart of the style-src rule
+      // below. Same argument: the injected release is v4.7.0, a 2016 version
+      // this app never shipped, and our font-src is `'self' data:` with no
+      // cross-origin host at all (39 events / 14d).
+      if (url.protocol === 'https:' && url.hostname === 'use.fontawesome.com'
+          && url.pathname.startsWith('/releases/') && fontFile.test(url.pathname)) return true;
+      // MerciApp French writing-assistant extension — its overlay ships Inter +
+      // Tropiline from its own asset origin (11 events / 14d, 18% of the
+      // post-deploy window). Exact host + /fonts/ path.
+      if (url.protocol === 'https:' && url.hostname === 'assets.merci-app.com'
+          && url.pathname.startsWith('/fonts/') && fontFile.test(url.pathname)) return true;
+      // Yiban extension overlay font (AlimamaShuHeiTi, 64 events / 14d).
+      if (url.protocol === 'https:' && url.hostname === 'cdn.yiban.io'
+          && url.pathname.startsWith('/fonts/') && fontFile.test(url.pathname)) return true;
+      // Alipay/antbank "marmot" asset CDN injecting Inter-Regular (34 events /
+      // 14d). Exact host + /file/ asset-root path.
+      if (url.protocol === 'https:' && url.hostname === 'antbank-cdn.marmot-cloud.com'
+          && url.pathname.startsWith('/file/') && fontFile.test(url.pathname)) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube live stream manifests.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -383,6 +383,22 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     it('does NOT suppress an alicdn lookalike host or non-font path', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://at.alicdn.com.evil.com/x.woff2', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'https://at.alicdn.com/t/c/loader.js', '', false));
+      // The legacy `/t/` widening must not swallow the whole host.
+      assert.ok(!suppress('enforce', 'font-src', 'https://at.alicdn.com/t/loader.js', '', false));
+    });
+
+    it('suppresses the LEGACY alicdn /t/ path and its eot/svg chain members (WORLDMONITOR-TR round 5)', () => {
+      // iconfont.cn serves projects under both `/t/c/font_*` and the legacy
+      // `/t/font_*`. The round-3 rule pinned `/t/c/` only, so it matched almost
+      // nothing: 755 of this host's 776 events over 14d used `/t/`. These
+      // fixtures are the exact URLs observed in Sentry.
+      assert.ok(suppress('enforce', 'font-src', 'https://at.alicdn.com/t/font_792691_ptvyboo0bno.woff?t=1574048839056', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://at.alicdn.com/t/font_792691_ptvyboo0bno.ttf?t=1574048839056', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://at.alicdn.com/t/font_1334179_yeeyzhmgwya.woff?t=1', '', false));
+      // The five-format chain: 223 of those 776 events were `.svg` and 1 was
+      // `.eot`; neither format was in the shared matcher before round 5.
+      assert.ok(suppress('enforce', 'font-src', 'https://at.alicdn.com/t/font_792691_ptvyboo0bno.svg?t=1574048839056', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://at.alicdn.com/t/font_792691_ptvyboo0bno.eot?t=1574048839056', '', false));
     });
 
     it('suppresses slant.co overlay webfont injection (WORLDMONITOR-TR round 3)', () => {
@@ -421,6 +437,88 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     it('does NOT suppress a simplycodes lookalike host or non-font path', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://images.simplycodes.com.evil.com/x.woff2', '', false));
       assert.ok(!suppress('enforce', 'font-src', 'https://images.simplycodes.com/fonts/loader.js', '', false));
+    });
+
+    it('suppresses scite.ai citation-badge webfont injection (WORLDMONITOR-TR round 5)', () => {
+      // The only host still firing at the head of the window measured strictly
+      // after the round-4 rules were live (25 of 61 events, latest
+      // 2026-08-10T13:18Z) — i.e. the one that keeps regressing this issue.
+      // `scite` appears nowhere in src.
+      assert.ok(suppress('enforce', 'font-src', 'https://cdn.scite.ai/assets/fonts/scite-icons/scite-icons.woff2?v=5', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://cdn.scite.ai/assets/fonts/scite-icons/scite-icons.woff?v=5', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://cdn.scite.ai/assets/fonts/scite-icons/scite-icons.ttf?v=5', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://cdn.scite.ai/assets/fonts/scite-icons/scite-icons.svg?v=5', '', false));
+    });
+
+    it('does NOT suppress a scite.ai lookalike host, sibling subdomain, http:, or non-font path', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.scite.ai.evil.com/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://assets.scite.ai/assets/fonts/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'http://cdn.scite.ai/assets/fonts/scite-icons/scite-icons.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.scite.ai/assets/fonts/loader.js', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.scite.ai/unrelated/regression.woff2', '', false));
+    });
+
+    it('suppresses Adobe Typekit kit FONTS under font-src (WORLDMONITOR-TR round 5)', () => {
+      // Typekit serves font binaries from EXTENSIONLESS paths
+      // (/af/<hex>/<hex>/<n>/<a|d|l>), so the shared `fontFile` matcher cannot
+      // reach them and the existing style-src `.css` rule does not either. 1137
+      // events / 14d — the largest slice after migaku.
+      assert.ok(suppress('enforce', 'font-src', 'https://use.typekit.net/af/bcdde2/00000000000000003b9af1d8/27/a?primer=7cdcb44be4a7', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://use.typekit.net/af/173a8e/00000000000000003b9af1d9/27/d?primer=7cdcb44be4a7', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://use.typekit.net/af/5424c6/00000000000000003b9af1de/30/l?primer=7cdcb44be4a7', '', false));
+    });
+
+    it('does NOT suppress off-shape Typekit paths, a lookalike host, or http:', () => {
+      // Pins each conjunct of the path regex: the `/af/` root, both hex
+      // segments, the numeric segment, and the {a,d,l} format code.
+      assert.ok(!suppress('enforce', 'font-src', 'https://use.typekit.net/af/bcdde2/00000000000000003b9af1d8/27/z', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://use.typekit.net/other/bcdde2/00000000000000003b9af1d8/27/a', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://use.typekit.net/af/nothex/00000000000000003b9af1d8/27/a', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://use.typekit.net/af/bcdde2/00000000000000003b9af1d8/xx/a', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://use.typekit.net/af/bcdde2/00000000000000003b9af1d8/27/a/extra', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://use.typekit.net.evil.com/af/a/b/27/a', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'http://use.typekit.net/af/bcdde2/00000000000000003b9af1d8/27/a', '', false));
+    });
+
+    it('suppresses FontAwesome CDN webfonts under font-src (WORLDMONITOR-TR round 5)', () => {
+      // font-src counterpart of the existing style-src rule: the injected
+      // release is v4.7.0, a 2016 version this app never shipped.
+      assert.ok(suppress('enforce', 'font-src', 'https://use.fontawesome.com/releases/v4.7.0/fonts/fontawesome-webfont.woff2', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://use.fontawesome.com/releases/v4.7.0/fonts/fontawesome-webfont.ttf', '', false));
+    });
+
+    it('does NOT suppress a fontawesome lookalike host or non-font path', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://use.fontawesome.com.evil.com/releases/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://use.fontawesome.com/releases/v4.7.0/js/loader.js', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://use.fontawesome.com/other/x.woff2', '', false));
+    });
+
+    it('suppresses MerciApp, Yiban and marmot-cloud overlay webfonts (WORLDMONITOR-TR round 5)', () => {
+      assert.ok(suppress('enforce', 'font-src', 'https://assets.merci-app.com/fonts/Inter-Bold.woff2', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://assets.merci-app.com/fonts/Tropiline-Bold.woff', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://cdn.yiban.io/fonts/AlimamaShuHeiTi/AlimamaShuHeiTi-Bold.woff2', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://antbank-cdn.marmot-cloud.com/file/ee7a463b/Inter-Regular.ttf', '', false));
+    });
+
+    it('does NOT suppress lookalike hosts or non-font paths for the round-5 overlay hosts', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://assets.merci-app.com.evil.com/fonts/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.merci-app.com/fonts/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://assets.merci-app.com/other/regression.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.yiban.io.evil.com/fonts/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.yiban.io/fonts/loader.js', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://antbank-cdn.marmot-cloud.com.evil.com/file/x.ttf', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://antbank-cdn.marmot-cloud.com/other/regression.ttf', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'http://assets.merci-app.com/fonts/Inter-Bold.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'http://cdn.yiban.io/fonts/AlimamaShuHeiTi/AlimamaShuHeiTi-Bold.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'http://antbank-cdn.marmot-cloud.com/file/ee7a463b/Inter-Regular.ttf', '', false));
+    });
+
+    it('keeps the widened eot/svg formats host- and path-pinned', () => {
+      // Widening the shared matcher to the full five-format chain must not make
+      // an unpinned host suppressible in a format it previously escaped in.
+      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.evil.example/fonts/x.svg', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.evil.example/fonts/x.eot', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://migaku-public-data.migaku.com/unrelated/regression.svg', '', false));
     });
 
     it('does NOT suppress Google Fonts under unrelated directives', () => {


### PR DESCRIPTION
## Summary

`WORLDMONITOR-TR` has regressed after every round of font-src filtering, and the Sentry view of why is misleading. Over a 14-day window, four hosts that already have rules still appear to be firing — which reads as "the rules do not work." They do. Grouping each event by its `build_sha` and testing that SHA against its own rule's commit shows every event from an already-filtered host came from a bundle built *before* that host's rule existed. That residue is stale clients draining, not escape. Sizing this issue on any window that straddles a deploy will keep producing that false signal.

With the drain separated out, two real defects remain.

**The alicdn rule never matched what it was written for.** It requires the path prefix `/t/c/`, but iconfont.cn also serves the legacy `/t/font_<id>.<ext>` form, and 755 of that host's 776 events over 14 days (97%) use the legacy path. The rule shipped in #6369 and suppressed almost nothing.

**The shared format matcher missed two members of the fallback chain.** An `@font-face` `src:` list names one face in several formats and the browser reports a block for each, so a rule that misses one format leaks the rest. iconfont.cn emits the classic five (`eot`, `woff2`, `woff`, `ttf`, `svg`); 223 `.svg` and 1 `.eot` events escaped every host rule.

## Hosts added

Each was sized twice: over 14 days, and again over a 22-hour window starting strictly after the round-4 rules went live, so drain is not counted as escape.

| Host | 14d events | Note |
|---|---:|---|
| `use.typekit.net` | 1137 | Largest remaining slice. Needs its own rule — Typekit serves fonts from extensionless paths (`/af/<hex>/<hex>/<n>/<a\|d\|l>`) that the shared matcher cannot reach, so the existing style-src `.css` rule does not cover them |
| `cdn.scite.ai` | 193 | The **only** host still firing at the head of the post-deploy window (41%), i.e. the one currently regressing the issue |
| `cdn.yiban.io` | 64 | |
| `use.fontawesome.com` | 39 | font-src counterpart of the existing style-src rule; injected release is v4.7.0, a 2016 version this app never shipped |
| `antbank-cdn.marmot-cloud.com` | 34 | |
| `assets.merci-app.com` | 11 | 18% of the post-deploy window |

## Why suppressing these is safe

The dashboard policy is `font-src 'self' data:` — no cross-origin source at all — so we ship no cross-origin webfont and a block on one of these hosts can never be a first-party regression. Every rule stays pinned to an exact hostname, a path prefix, and `https:`, so a lookalike domain, a sibling subdomain, an off-signature path, or an `http:` block all keep reporting. Widening the format set does not widen which hosts are suppressed.

This is round 5 of a host-by-host allowlist, and it will need a round 6. Because `font-src` admits no cross-origin source, a single "suppress any cross-origin font-src block" rule would end this permanently, at the cost of one blind spot: a developer who ships a cross-origin font and forgets the CSP. I kept the existing host-pinned convention rather than make that call here.

## Validation

- `csp-filter` 140 pass, `deploy-config` 171 pass, `secondary-startup` + `csp-filter` 153 pass. `tsc --noEmit` clean.
- **Mutation sweep: 8 of 8 mutants killed.** Each new rule was reverted one at a time, by file copy, and the suite went red every time — so none of the new tests are vacuous. The file restored byte-identical afterward.

The Sentry issue is deliberately **not** resolved yet. Resolving before this deploys and stale clients drain would regress it within minutes, which is what happened on the previous round.

Related: #6369, #6372

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
