### PR TITLE
fix(sentry): split Cloudflare edge 5xx from origin 5xx by fingerprint (#6370)

### DIFF
--- a/src/services/premium-fetch.ts
+++ b/src/services/premium-fetch.ts
@@ -86,7 +86,20 @@ export function reportServerError(
     const isCloudflareEdgeError = res.status >= 520 && res.status <= 527;
     const message = `API ${res.status}: ${path}`;
     const level: 'warning' | 'error' = isCloudflareEdgeError ? 'warning' : 'error';
-    const tags = { kind: isCloudflareEdgeError ? 'api_cf_5xx' : 'api_5xx' };
+    // `status` is a tag, not just an `extra`: `extra` is not indexed, so a
+    // status that is only there can be read one event at a time but never
+    // aggregated. Both sibling fingerprint sites mirror every grouping
+    // dimension into tags for that reason — analytics-collector-transport.ts
+    // tags `status` beside its fingerprint, and api/user-prefs.ts promotes
+    // fields out of `extra` explicitly to make them searchable. Without it
+    // `kind:api_cf_5xx` is queryable but `status:503` is not, so triage cannot
+    // ask "every 503 this week, across all routes" — the exact question that
+    // separated this issue's 503s from its 520s. Cardinality is the bounded
+    // 5xx set, same as the fingerprint's.
+    const tags = {
+      kind: isCloudflareEdgeError ? 'api_cf_5xx' : 'api_5xx',
+      status: String(res.status),
+    };
     const extra = { path, status: res.status };
     // Group explicitly rather than letting Sentry infer it. These are
     // message-only events — `attachStacktrace` defaults to false and is never

--- a/src/services/premium-fetch.ts
+++ b/src/services/premium-fetch.ts
@@ -88,7 +88,31 @@ export function reportServerError(
     const level: 'warning' | 'error' = isCloudflareEdgeError ? 'warning' : 'error';
     const tags = { kind: isCloudflareEdgeError ? 'api_cf_5xx' : 'api_5xx' };
     const extra = { path, status: res.status };
-    enqueue((s) => s.captureMessage(message, { level, tags, extra }));
+    // Group explicitly rather than letting Sentry infer it. These are
+    // message-only events — `attachStacktrace` defaults to false and is never
+    // set in sentry-init.ts — so Sentry groups them by message, and its
+    // server-side parameterization normalizes the embedded status integer:
+    // `API 520: /x` and `API 503: /x` collapse to the same grouping message.
+    // WORLDMONITOR-P4 ("API 520: /api/economic/v1/get-fred-series-batch") held
+    // 256 api_5xx events beside 25 api_cf_5xx ones that way — 92 of its last
+    // 100 were the 2026-07-12 origin 503s, not the 520 it is named for. That
+    // inflates the headline count, voids the level split above (one issue
+    // carries one level), and makes an unpinned resolve reopen and page on any
+    // origin 5xx for the path.
+    //
+    // `path` and the status are the two grouping axes. The leading token is a
+    // readable class label in the style of analytics-collector-transport.ts's
+    // fingerprint namespace, but it is derived from the status, so it splits
+    // nothing on its own — do not read it as a third axis.
+    // Cardinality stays bounded at the RPC path set x the 5xx status set —
+    // `path` is a pathname, so query strings never enter the key. Keep it that
+    // way: a path-parameterized caller would mint one Sentry issue per URL.
+    const fingerprint = [
+      isCloudflareEdgeError ? 'api-cf-5xx' : 'api-5xx',
+      path,
+      String(res.status),
+    ];
+    enqueue((s) => s.captureMessage(message, { level, tags, extra, fingerprint }));
   } catch { /* ignore URL parse errors */ }
 }
 

--- a/tests/premium-fetch.test.mts
+++ b/tests/premium-fetch.test.mts
@@ -432,12 +432,21 @@ describe('premiumFetch', () => {
 // reportServerError — the Sentry origin-5xx surface.
 // ---------------------------------------------------------------------------
 describe('reportServerError', () => {
+  type CaptureCtx = { level: string; tags: Record<string, string>; fingerprint?: string[] };
   function makeSpy() {
-    const calls: Array<{ msg: string; ctx: { level: string; tags: Record<string, string> } }> = [];
+    const calls: Array<{ msg: string; ctx: CaptureCtx }> = [];
     const enqueue = ((fn: (s: unknown) => void) => {
-      fn({ captureMessage: (msg: string, ctx: { level: string; tags: Record<string, string> }) => { calls.push({ msg, ctx }); } });
+      fn({ captureMessage: (msg: string, ctx: CaptureCtx) => { calls.push({ msg, ctx }); } });
     }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
     return { calls, enqueue };
+  }
+
+  /** Capture one response and return the fingerprint Sentry would group on. */
+  function fingerprintOf(res: Response, target: string = PUBLIC_TARGET): string[] | undefined {
+    const { calls, enqueue } = makeSpy();
+    reportServerError(res, target, enqueue);
+    assert.equal(calls.length, 1, 'expected exactly one capture');
+    return calls[0].ctx.fingerprint;
   }
 
   it('captures a genuine origin 503 at error level with kind api_5xx', () => {
@@ -478,5 +487,127 @@ describe('reportServerError', () => {
     });
     reportServerError(res, PUBLIC_TARGET, enqueue);
     assert.equal(calls.length, 0, 'rate-limit degradation must not be captured again by every browser');
+  });
+
+  // -------------------------------------------------------------------------
+  // Grouping — WORLDMONITOR-P4.
+  //
+  // `captureMessage` varies the message per status (`API 520: …` vs
+  // `API 503: …`), but these are message-only events (`attachStacktrace`
+  // defaults to false and is never set), so Sentry groups them by message and
+  // its server-side parameterization normalizes the status integer — both
+  // collapse to one grouping message. Without an explicit fingerprint every
+  // status for a path folds into ONE issue, titled by whichever fired first.
+  //
+  // Measured on WORLDMONITOR-P4 ("API 520: /api/economic/v1/get-fred-series-batch",
+  // 2026-08-10): the group held `kind` = api_5xx x256 and api_cf_5xx x25, and
+  // 92 of its last 100 events were status 503 from the 2026-07-12 origin
+  // incident — only 8 were the 520 in the title. Three consequences:
+  //   1. the headline count overstates the 520 population by ~11x;
+  //   2. #3854's warning-vs-error split is void, because one issue carries one
+  //      level — the warning 520s inherit the error 503s' grouping;
+  //   3. an issue resolved with no release pin reopens and pages on ANY origin
+  //      5xx for that path, not on the Cloudflare edge error it is named for.
+  // -------------------------------------------------------------------------
+  it('does not group a Cloudflare 520 with an origin 503 on the same path', () => {
+    const cf = fingerprintOf(new Response('cf', { status: 520 }));
+    const origin = fingerprintOf(new Response('oops', { status: 503 }));
+    assert.ok(cf, 'Cloudflare edge capture must carry an explicit fingerprint');
+    assert.ok(origin, 'origin 5xx capture must carry an explicit fingerprint');
+    assert.notDeepEqual(
+      cf, origin,
+      'a CDN-transport 520 and an origin 503 are different failures and must not share a Sentry issue',
+    );
+  });
+
+  it('keeps repeat events of the same status and path in one group', () => {
+    // The fix must split by cause, not fragment per event — otherwise volume
+    // stops being readable and every blip mints a fresh issue.
+    const first = fingerprintOf(new Response('cf', { status: 520 }));
+    const second = fingerprintOf(new Response('cf again', { status: 520 }));
+    // Assert presence explicitly: two absent fingerprints are deep-equal, so
+    // without this the case would pass vacuously against the unfixed code.
+    assert.ok(first, 'fingerprint must be set');
+    assert.deepEqual(first, second, 'two 520s on one path must stay a single issue');
+  });
+
+  it('separates two different origin 5xx statuses on the same path', () => {
+    // The 520-vs-503 case above is also satisfied by grouping on the
+    // Cloudflare-vs-origin class alone, which would leave every origin status
+    // for a path folded together — the same defect one level down (a 500 from
+    // a handler throw sharing an issue with a 503 from a dependency outage).
+    assert.notDeepEqual(
+      fingerprintOf(new Response('boom', { status: 500 })),
+      fingerprintOf(new Response('down', { status: 503 })),
+      'a 500 and a 503 are different origin failures and must not share a Sentry issue',
+    );
+  });
+
+  it('separates the same status across different paths', () => {
+    assert.notDeepEqual(
+      fingerprintOf(new Response('cf', { status: 520 }), PUBLIC_TARGET),
+      fingerprintOf(new Response('cf', { status: 520 }), 'https://www.worldmonitor.app/api/news/v1/summarize-article'),
+      'per-path grouping is what makes the issue title actionable',
+    );
+  });
+
+  it('pins the exact fingerprint tuple', () => {
+    // Every other case here is relational (equal / not-equal), so a refactor
+    // that reorders the tuple or renames a token keeps them green while
+    // silently re-splitting every live Sentry issue — the groups are identified
+    // by these literal strings, so the identity itself needs a test.
+    assert.deepEqual(
+      fingerprintOf(new Response('cf', { status: 520 })),
+      ['api-cf-5xx', '/api/economic/v1/get-fred-series-batch', '520'],
+    );
+    assert.deepEqual(
+      fingerprintOf(new Response('down', { status: 503 })),
+      ['api-5xx', '/api/economic/v1/get-fred-series-batch', '503'],
+    );
+  });
+
+  it('excludes the query string from the grouping key', () => {
+    // `path` is `new URL(...).pathname`, which drops the query. Switching it to
+    // `pathname + search` would mint one Sentry issue per distinct URL — the
+    // cardinality blow-up the bounded-key claim rules out — and real callers do
+    // send per-request query strings through premiumFetch (McpConnectModal
+    // posts `/api/mcp-proxy?<qs>`). Two calls differing only in query must group
+    // together, and no query value may reach the key.
+    const withQuery = fingerprintOf(
+      new Response('cf', { status: 520 }),
+      `${PUBLIC_TARGET}?token=SECRET&cursor=abc`,
+    );
+    assert.deepEqual(withQuery, fingerprintOf(new Response('cf', { status: 520 })));
+    assert.ok(
+      !withQuery?.some((part) => part.includes('SECRET')),
+      'no query-string value may enter the Sentry grouping key',
+    );
+  });
+
+  it('groups a Request input with the equivalent string URL', () => {
+    // reportServerError normalizes via `input instanceof Request ? input.url :
+    // String(input)`. Callers pass both shapes, and one endpoint must stay one
+    // issue regardless of which the caller used.
+    assert.deepEqual(
+      fingerprintOf(new Response('cf', { status: 520 }), PUBLIC_TARGET),
+      (() => {
+        const { calls, enqueue } = makeSpy();
+        reportServerError(new Response('cf', { status: 520 }), new Request(PUBLIC_TARGET), enqueue);
+        return calls[0].ctx.fingerprint;
+      })(),
+    );
+  });
+
+  it('classifies the Cloudflare range at its exact boundaries', () => {
+    // The 520-527 window now feeds the grouping key, not just the level and
+    // tag, so an off-by-one here would re-split live issues rather than only
+    // mislabel them. 530 is a real Cloudflare status that sits OUTSIDE the
+    // window by design and must stay on the origin class.
+    const classOf = (status: number) => fingerprintOf(new Response('x', { status }))?.[0];
+    assert.equal(classOf(519), 'api-5xx', '519 is below the Cloudflare window');
+    assert.equal(classOf(520), 'api-cf-5xx', '520 is the first Cloudflare code');
+    assert.equal(classOf(527), 'api-cf-5xx', '527 is the last Cloudflare code');
+    assert.equal(classOf(528), 'api-5xx', '528 is above the Cloudflare window');
+    assert.equal(classOf(530), 'api-5xx', 'CF 530 is deliberately outside the transient-transport window');
   });
 });

--- a/tests/premium-fetch.test.mts
+++ b/tests/premium-fetch.test.mts
@@ -598,6 +598,21 @@ describe('reportServerError', () => {
     );
   });
 
+  it('exposes status as a searchable tag, not only in extra', () => {
+    // Sentry does not index `extra`, so a status that lives only there is
+    // readable per event but never aggregable. Both sibling fingerprint sites
+    // mirror their grouping dimensions into tags; this pins that parity so a
+    // triage query like `kind:api_5xx status:503` keeps working.
+    const tagsFor = (status: number) => {
+      const { calls, enqueue } = makeSpy();
+      reportServerError(new Response('x', { status }), PUBLIC_TARGET, enqueue);
+      return calls[0].ctx.tags;
+    };
+    assert.equal(tagsFor(503).status, '503');
+    assert.equal(tagsFor(520).status, '520');
+    assert.equal(tagsFor(520).kind, 'api_cf_5xx', 'kind must survive alongside status');
+  });
+
   it('classifies the Cloudflare range at its exact boundaries', () => {
     // The 520-527 window now feeds the grouping key, not just the level and
     // tag, so an off-by-one here would re-split live issues rather than only


### PR DESCRIPTION
Diagnoses #6370 and fixes the one part of it that is ours to fix. Closes the half of #3854 that was left open.

## What P4 actually is

`WORLDMONITOR-P4` is titled `API 520: /api/economic/v1/get-fred-series-batch`, but only **25 of its 281 events are Cloudflare 520-527**. The other 256 are origin 5xx, and 92 of its last 100 events were status **503** from the 2026-07-12 origin incident that also dominates its four sibling issues (`-PE`, `-V5`, `-V7`, `-PV`, all last-seen that same day).

`reportServerError` captures **message-only** events — `attachStacktrace` is `@default false` in the SDK and never set in `sentry-init.ts` — so Sentry groups them by message, and its server-side parameterization normalizes the embedded status integer. `API 520: /x` and `API 503: /x` collapse into one group, titled by whichever fired first.

Three consequences:

1. the headline count overstates the 520 population by ~11x;
2. #3854's warning-vs-error split is void — a Sentry issue carries **one** level, so the warning 520s inherit the error 503s' grouping. #3854 split `level` and `tags` but never added a fingerprint, so the split it introduced was silently voidable from the day it landed;
3. an issue resolved with **no** release pin reopens and pages on *any* origin 5xx for that path, not on the Cloudflare error it is named for. That is exactly the state #6370's **State** section describes.

## The change

Two commits:

1. **Explicit `fingerprint`** of (class label, path, status). Grouping is bounded by the RPC path set x the 5xx status set; `path` is a pathname, so query strings never enter the key.
2. **`status` promoted from `extra` to `tags`.** It was a grouping dimension but lived only in `extra`, which Sentry does not index — so `kind:api_cf_5xx` was queryable and `status:503` was not. Triage could not ask "every 503 this week across all routes", which is the exact question that separated this issue's 503s from its 520s during the diagnosis. Both sibling fingerprint sites already do this (`analytics-collector-transport.ts:553`; `api/user-prefs.ts:587` has an explicit comment about promoting a field out of `extra` for searchability). Tags do not split issues, so grouping is unchanged.

## What this does *not* fix

The 520s themselves. They are a Cloudflare<->Vercel transport failure that never reaches the origin — 7 days of Axiom on this route shows **36,938 requests with statuses 200/401/429/403/405 and zero 5xx**. Rate is ~1 per 17,000 requests; site-wide there are 41 CF 52x events across 10 routes in 90 days. FRED batch leads only because it is the busiest economic route (36,938 req/7d vs 18-27k for siblings; 3-4 client call sites per dashboard load).

The issue's three hypotheses are all disproven with measurements in the #6370 comment. The unexplained residue — an hourly **`:30`** clustering (14 of 25 on this route, 16 of 41 site-wide, against uniform arrivals and flat origin latency) — is tracked separately in #6410; chasing it needs Cloudflare-side Logpush data.

No retry was added. It is defensible, but at this rate with the circuit breaker already serving cached data it is a request-path behavior change for negligible user impact. #6410 records it as the fallback if the `:30` cause turns out to be unfixable upstream.

## Operational notes for whoever triages after this lands

- **P4 is not retro-split.** It keeps its 281 historical events and its `520` title, then goes permanently silent. Each live (path, status) pair mints a new issue on first occurrence after release. Anything pinned to P4 or its siblings — saved searches, assignees, ignore/resolve state — needs re-pointing. The project's only alert rule is issue-priority based (`NewHighPriorityIssue` / `ExistingHighPriorityIssue`, zero metric alert rules), so expect a one-time, self-limiting new-issue burst rather than sustained noise.
- **Resolve the new issues plain — never `inNextRelease`.** On WM, `inNextRelease` permanently mutes browser issues because of how `worldmonitor@<semver>` release ordering resolves, which is how WORLDMONITOR-TR ended up with issues stuck resolved-but-firing (one at 357k events). This PR's whole "page again on any real recurrence" guarantee depends on plain `{"status":"resolved"}`.

## Verification

- `tests/premium-fetch.test.mts`: **37 pass**. 13 cases now cover `reportServerError`, including a literal fingerprint-tuple pin, a query-string exclusion guard, Request-vs-string grouping stability, the tag/fingerprint status parity, and the 520-527 boundary (519/520/527/528/530).
- **Mutation swept: 11/11 killed** — drop/reorder/rename each tuple token, drop the fingerprint entirely, `pathname`->`href`, both CF-window off-by-ones, drop the new status tag, and drop `kind` from the widened tags object.
- `npm run typecheck` clean; `biome check` clean; `npm run lint:premium-fetch` clean.
- Scoped suite (6 premium-fetch/wm-session files): **113 pass**.
- The `fingerprint` key is genuinely type-checked, not swallowed by `any`: a deliberate typo (`fingerprintt`) fails `tsc` with TS2353 against `Partial<ScopeContext>`.

Reviewed by 8 reviewers plus an independent cross-model adversarial pass. Three findings applied: the original comment named the wrong grouping mechanism (stack frame rather than message parameterization, verified against the SDK), the test suite was relational-only so a tuple refactor could have silently re-split every live issue, and `status` was not tag-searchable. One P1 from the cross-model pass was rejected on evidence: it warned that per-status grouping could keep an incident under a paging threshold, which requires a per-issue volume rule — this project has none.

Closes #6370

https://claude.ai/code/session_0111uUyRB1ZoNCr2sYLCaUiw
