### PR TITLE
fix(session): stop one dropped mint request blacking out anonymous browsing

### DIFF
--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -273,7 +273,11 @@ function addSessionBreadcrumb(message: string, data: Record<string, string>): vo
   } catch { /* best-effort telemetry */ }
 }
 
-function markWmSessionDead(reason: WmSessionDeadReason, rawPath: string): void {
+function markWmSessionDead(
+  reason: WmSessionDeadReason,
+  rawPath: string,
+  cause: MintFailureCause | null = null,
+): void {
   const alreadyDead = isWmSessionDead();
   sessionDeadUntil = Date.now() + SESSION_DEAD_COOLDOWN_MS;
   if (!alreadyDead) sessionDeadReason = reason;
@@ -311,11 +315,23 @@ function markWmSessionDead(reason: WmSessionDeadReason, rawPath: string): void {
   // so whichever route happened to be in flight is a bystander — tagging it
   // would seed the census with innocent endpoints.
   const routeTag = reason === 'retry_401' ? blockedTag : '/api/wm-session';
-  addSessionBreadcrumb('wm-session recovery failed', { route: routeTag, blocked: blockedTag, reason });
+  // `reason` names the CATEGORY of failure; `mint_cause` names the actual one.
+  // Without it every mint_failed event looked identical, so WORLDMONITOR-WG
+  // could not be told apart from a server outage, a rate-limit, a CORS block or
+  // a dropped connection — and each of those needs a different fix. This is the
+  // same aggregability argument that added the `route` tag in #5674.
+  const tags: Record<string, string> = { kind: 'wm_session_dead', reason, route: routeTag };
+  if (cause) tags.mint_cause = cause;
+  addSessionBreadcrumb('wm-session recovery failed', {
+    route: routeTag,
+    blocked: blockedTag,
+    reason,
+    ...(cause ? { mint_cause: cause } : {}),
+  });
   try {
     sentryEnqueue((s) => s.captureMessage(
       'wm-session dead: anonymous API calls suppressed',
-      { level: 'warning', tags: { kind: 'wm_session_dead', reason, route: routeTag } },
+      { level: 'warning', tags },
     ));
   } catch { /* best-effort telemetry */ }
   if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
@@ -350,23 +366,47 @@ function reportRouteRecoveryFailure(rawPath: string): void {
 /**
  * Decide how far a failed recovery should reach.
  *
- * `mint_failed` is session-wide by construction — /api/wm-session itself did
- * not hand back a cookie, so no route can succeed. It trips the global
- * cooldown immediately, exactly as before.
+ * `mint_failed` is session-wide only when the SERVER produced the failure —
+ * `refused` (it answered non-2xx) or `malformed` (it answered something
+ * unusable). Those still trip the global cooldown immediately, because no route
+ * can succeed against an endpoint that will not issue a token.
+ *
+ * A `timeout` or `network` mint failure is NOT session-wide. The request never
+ * completed, so the server rendered no verdict, and the original
+ * "session-wide by construction" reading turned one dropped request into a
+ * 15-minute blackout. It is retried once and then needs the same corroboration
+ * as `retry_401` (WORLDMONITOR-WG).
  *
  * `retry_401` only implicates the one route that was replayed, so it needs
  * SESSION_DEAD_ROUTE_QUORUM distinct routes before it may black out the tab.
  */
-function noteRecoveryFailure(reason: WmSessionDeadReason, rawPath: string): void {
-  if (reason === 'mint_failed') {
-    markWmSessionDead(reason, rawPath);
+function noteRecoveryFailure(
+  reason: WmSessionDeadReason,
+  rawPath: string,
+  cause: MintFailureCause | null = null,
+): void {
+  // A mint the SERVER refused (or answered unusably) is session-wide by
+  // construction, exactly as before: no route can succeed against an endpoint
+  // that will not issue a token, so this still skips the quorum.
+  if (reason === 'mint_failed' && !mintCauseIsTransport(cause)) {
+    markWmSessionDead(reason, rawPath, cause);
     return;
   }
+  // Everything else needs corroboration from a second distinct route before it
+  // may black out the tab. For retry_401 that is the original #5674 rule. For a
+  // transport-level mint failure it is new: the attempt already burned its one
+  // retry, and a single client-side blip is not evidence that the session is
+  // unusable — production shows the server minting normally for everyone else
+  // at that moment (WORLDMONITOR-WG).
   if (recordRouteStrike(rawPath) >= SESSION_DEAD_ROUTE_QUORUM) {
-    markWmSessionDead(reason, rawPath);
+    markWmSessionDead(reason, rawPath, cause);
     return;
   }
-  reportRouteRecoveryFailure(rawPath);
+  // Below quorum, a transport mint failure gets no captureMessage. WG is the
+  // blackout counter (#5245) and no blackout happened; XP counts routes that
+  // reject a demonstrably fresh cookie, which this route did not do — the
+  // cookie never arrived. The breadcrumb from the eventual episode carries it.
+  if (reason === 'retry_401') reportRouteRecoveryFailure(rawPath);
 }
 
 function sessionDegradedResponse(): Response {
@@ -433,7 +473,50 @@ function noteMintCookieEvidence(hadSession: boolean, aCookieExistedWhenSent: boo
   useAnonymousSessionHeader = anonymousSessionHeaderToken !== null;
 }
 
+/**
+ * Why a mint attempt did not produce a session.
+ *
+ * `refused` and `malformed` are verdicts FROM the server: it answered, and the
+ * answer was unusable. Those really are session-wide — no route can succeed
+ * against a session endpoint that will not issue a token.
+ *
+ * `timeout` and `network` are failures of our own transport: the request never
+ * completed, so the server never rendered a verdict at all. They say nothing
+ * about whether the next attempt will work, and must not be read as one
+ * (WORLDMONITOR-WG — see mintCauseIsTransport).
+ */
+type MintFailureCause = 'refused' | 'malformed' | 'timeout' | 'network';
+type MintOutcome =
+  | { ok: true; session: StoredSession }
+  | { ok: false; cause: MintFailureCause };
+
+/**
+ * A transport cause is evidence about this ATTEMPT, not about the session.
+ *
+ * Production disproved the original "a failed mint is session-wide by
+ * construction" premise: for 5 of the 7 most recent mint_failed events, server
+ * telemetry showed 121-216 successful /api/wm-session mints in a +/-2.5 minute
+ * window around the event and ZERO rejections. The server was healthy and
+ * minting for everyone else while one client declared the whole session dead
+ * and suppressed its own anonymous calls for 15 minutes.
+ */
+function mintCauseIsTransport(cause: MintFailureCause | null): boolean {
+  return cause === 'timeout' || cause === 'network';
+}
+
+// The cause of the most recent failed mint, for the recovery path to read.
+// Module-scoped rather than threaded through ensureWmSession's boolean return
+// because that boolean is part of this module's public surface and is consumed
+// by callers (periodic refresh, page boot) that have no use for the cause.
+let lastMintFailureCause: MintFailureCause | null = null;
+
 async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): Promise<StoredSession | null> {
+  const outcome = await mintSession(body);
+  lastMintFailureCause = outcome.ok ? null : outcome.cause;
+  return outcome.ok ? outcome.session : null;
+}
+
+async function mintSession(body?: { widgetKey?: string; proKey?: string }): Promise<MintOutcome> {
   // Sampled BEFORE the request leaves, not when it returns: concurrent mints
   // would otherwise let the first response to land make the others look like
   // follow-up mints that came back empty. See noteMintCookieEvidence.
@@ -444,8 +527,12 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
   // before fetch is dispatched and looks exactly like a server-side
   // mint_failed episode. AbortController has materially wider support.
   const timeoutController = new AbortController();
+  // Set by our own timer, so an AbortError can be attributed to the budget
+  // rather than guessed at from the error name — a caller-supplied abort or a
+  // browser-issued one would otherwise be misreported as `timeout`.
+  let timedOut = false;
   const timeoutId = setTimeout(
-    () => timeoutController.abort(),
+    () => { timedOut = true; timeoutController.abort(); },
     fetchNewSessionTimeoutMs,
   );
   try {
@@ -457,9 +544,18 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
       body: body ? JSON.stringify(body) : undefined,
       signal: timeoutController.signal,
     });
-    if (!resp.ok) return null;
-    const data = await resp.json() as { exp?: unknown; hadSession?: unknown; token?: unknown };
-    if (typeof data?.exp !== 'number') return null;
+    // The server answered and said no. That IS a session-wide verdict.
+    if (!resp.ok) return { ok: false, cause: 'refused' };
+    // A body we cannot parse or that carries no usable expiry is the server
+    // answering with something unusable — also session-wide, and NOT a
+    // transport failure, so it must not inherit the retry below.
+    let data: { exp?: unknown; hadSession?: unknown; token?: unknown };
+    try {
+      data = await resp.json() as { exp?: unknown; hadSession?: unknown; token?: unknown };
+    } catch {
+      return { ok: false, cause: 'malformed' };
+    }
+    if (typeof data?.exp !== 'number') return { ok: false, cause: 'malformed' };
     if (
       sessionIdentityGeneration === identityGenerationWhenSent &&
       typeof data.token === 'string' &&
@@ -472,9 +568,10 @@ async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): 
     if (typeof data.hadSession === 'boolean') {
       noteMintCookieEvidence(data.hadSession, aCookieExistedWhenSent);
     }
-    return { exp: data.exp };
+    return { ok: true, session: { exp: data.exp } };
   } catch {
-    return null;
+    // The request never completed. Nothing here is evidence about the session.
+    return { ok: false, cause: timedOut ? 'timeout' : 'network' };
   } finally {
     clearTimeout(timeoutId);
   }
@@ -575,6 +672,7 @@ export function __resetWmSessionForTests(): void {
   cookiePersistenceBroken = false;
   anonymousSessionHeaderToken = null;
   useAnonymousSessionHeader = false;
+  lastMintFailureCause = null;
   sentryEnqueue = enqueueSentryCall;
   fetchNewSessionTimeoutMs = 10_000;
 }
@@ -871,9 +969,19 @@ export function installWmSessionFetchInterceptor(): void {
     // for that result instead of each multiplying the failed retry.
     if (!recoveryInFlight) {
       const recovery = (async (): Promise<Response | null> => {
-        const fresh = await ensureWmSession().catch(() => false);
+        let fresh = await ensureWmSession().catch(() => false);
+        // A transport failure is the one cause worth immediately re-attempting:
+        // the server never answered, so a second try costs one request and may
+        // simply succeed. Bounded to a single retry, and only for a transport
+        // cause — a refusal is not retried, because the server already answered
+        // and would answer the same way (WORLDMONITOR-WG).
+        if (!fresh && mintCauseIsTransport(lastMintFailureCause)) {
+          fresh = await ensureWmSession().catch(() => false);
+        }
         if (!fresh) {
-          if (isCurrentSessionIdentity()) noteRecoveryFailure('mint_failed', path);
+          if (isCurrentSessionIdentity()) {
+            noteRecoveryFailure('mint_failed', path, lastMintFailureCause);
+          }
           return null;
         }
         // Recovery already has stronger evidence than a page-boot mint: the

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -1907,6 +1907,273 @@ describe('wm-session route-scoped recovery failures (#5674)', () => {
 // the cookie we just set never came back.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Layer 4 — a failed mint is not automatically a dead session (WORLDMONITOR-WG).
+//
+// `fetchNewSession` used to collapse five outcomes into a bare `null`: a non-2xx
+// status, a 200 with a malformed body, a network error, a CORS block, and its own
+// 10s timeout. `mint_failed` then skipped the route quorum and blacked out every
+// anonymous call for 15 minutes, justified by "the mint itself did not hand back
+// a cookie, so no route can succeed".
+//
+// Production disproved that premise. For 5 of the 7 most recent mint_failed
+// events, Axiom shows the server handled 121-216 /api/wm-session requests in a
+// +/-2.5 minute window around the event with ZERO rejections; the two others saw
+// only origin_403 from unrelated clients. The server never refused. The failure
+// was in the client's own transport, and one dropped request cost that user a
+// 15-minute blackout.
+//
+// So the verdict now depends on WHICH failure happened: a server refusal is still
+// session-wide, a transport failure is retried once and must corroborate across
+// two routes before it may black out the tab.
+// ---------------------------------------------------------------------------
+
+describe('wm-session mint failure cause (WORLDMONITOR-WG)', () => {
+  function captureSink() {
+    const captures: Array<{ msg: string; ctx: { level?: string; tags?: Record<string, string> } }> = [];
+    mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
+      fn({
+        captureMessage: (msg: string, ctx: { level?: string; tags?: Record<string, string> }) => {
+          captures.push({ msg, ctx });
+        },
+        addBreadcrumb: () => {},
+      });
+    }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
+    return captures;
+  }
+
+  function isDegraded(resp: Response): boolean {
+    return resp.status === 503 && resp.headers.get('X-Wm-Session-Degraded') === '1';
+  }
+
+  it('does NOT black out the session when a single mint fails at the transport level', async () => {
+    // The whole bug in one assertion: one network blip on one route must not
+    // suppress every anonymous API call for 15 minutes.
+    memoryStorage.clear();
+    const captures = captureSink();
+
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) return Promise.reject(new TypeError('Failed to fetch'));
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    // Assert on the blackout itself, not on a follow-up route's status: a second
+    // route would corroborate and trip the quorum, so its response would be a
+    // plain 401 either way and could not tell the two behaviours apart.
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(
+      dead.length,
+      0,
+      'one transport-level mint failure must not start a 15-minute degraded episode',
+    );
+    // And the session must genuinely still be usable, not merely unreported.
+    const publicRead = await wrappedFetch('https://api.worldmonitor.app/api/health?compact=1');
+    assert.equal(isDegraded(publicRead), false, 'anonymous calls must not be suppressed yet');
+  });
+
+  it('retries the mint once when the failure is transport-level', async () => {
+    memoryStorage.clear();
+    captureSink();
+
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.reject(new TypeError('Failed to fetch'));
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    // preflight mint + recovery mint + ONE transport retry.
+    assert.equal(mintCalls, 3, 'a transport failure earns exactly one retry, not zero and not a loop');
+  });
+
+  it('still blacks out immediately when the SERVER refuses to mint', async () => {
+    // Regression guard for the case the original design was written for: a real
+    // server refusal IS session-wide, and must keep skipping the quorum.
+    memoryStorage.clear();
+    const captures = captureSink();
+
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response('mint unavailable', { status: 503 }));
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+      const other = await wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series');
+      assert.equal(isDegraded(other), true, 'a server refusal still suppresses anonymous calls');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(mintCalls, 2, 'a refusal is NOT retried — the server answered, it just said no');
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1);
+    assert.equal(dead[0].ctx.tags?.reason, 'mint_failed');
+    assert.equal(dead[0].ctx.tags?.mint_cause, 'refused', 'the discriminator that makes WG diagnosable');
+  });
+
+  it('treats a 200 with an unusable body as a SERVER verdict, not a transport failure', async () => {
+    // The server answered — it just answered with something we cannot use. That
+    // is session-wide like a refusal, so it must skip the quorum AND skip the
+    // retry: re-asking an endpoint that just replied nonsense gets more nonsense.
+    // Without this test the malformed/network classification is interchangeable.
+    memoryStorage.clear();
+    const captures = captureSink();
+
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        // 200, valid JSON, but no usable expiry.
+        return Promise.resolve(new Response(JSON.stringify({ hadSession: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+      const other = await wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series');
+      assert.equal(isDegraded(other), true, 'an unusable mint body is session-wide');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(mintCalls, 2, 'a malformed body is NOT retried — the server already answered');
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1);
+    assert.equal(dead[0].ctx.tags?.mint_cause, 'malformed');
+  });
+
+  it('classifies an unparseable mint body as malformed, not network', async () => {
+    // A body that is not JSON at all throws inside resp.json(). That throw lands
+    // in the same catch as a dropped connection, so without an inner guard it
+    // would be reported as `network` and wrongly earn a retry.
+    memoryStorage.clear();
+    const captures = captureSink();
+
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response('<html>gateway error</html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        }));
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.equal(mintCalls, 2, 'an unparseable body is not a transport failure, so it is not retried');
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1, 'and it is session-wide immediately');
+    assert.equal(dead[0].ctx.tags?.mint_cause, 'malformed');
+  });
+
+  it('blacks out on a transport failure only once TWO routes corroborate', async () => {
+    memoryStorage.clear();
+    const captures = captureSink();
+
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) return Promise.reject(new TypeError('Failed to fetch'));
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+      await wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health');
+      const third = await wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series');
+      assert.equal(isDegraded(third), true, 'two corroborating routes DO justify the blackout');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1, 'exactly one capture per degraded episode');
+    assert.equal(dead[0].ctx.tags?.reason, 'mint_failed');
+    assert.equal(dead[0].ctx.tags?.mint_cause, 'network');
+    assert.equal(dead[0].ctx.tags?.route, '/api/wm-session', 'the mint is implicated, not a bystander route');
+  });
+
+  it('distinguishes a timeout from a network error', async () => {
+    // These need different remedies — a timeout points at our own budget, a
+    // network error points at the user's connectivity — so one tag must not
+    // stand for both.
+    memoryStorage.clear();
+    const captures = captureSink();
+    mod.__setWmSessionFetchTimeoutForTests(20);
+
+    currentFetchHandler = (input, init) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        // Never settles on its own — only the abort signal ends it, which is
+        // exactly how a hung mint behaves against the production budget.
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+        });
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+      await wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1);
+    assert.equal(dead[0].ctx.tags?.mint_cause, 'timeout', 'an aborted mint is a timeout, not a network error');
+  });
+});
+
 describe('wm-session cookie-persistence detection (Layer 3)', () => {
   it('mints on browsers that do not implement AbortSignal.timeout', async () => {
     memoryStorage.clear();


### PR DESCRIPTION
## Summary

A user whose single mint request dropped lost **15 minutes of anonymous browsing**. `WORLDMONITOR-WG` has 35,080 affected users and still fires on current builds.

`fetchNewSession` collapsed five outcomes into a bare `null` — a non-2xx status, a 200 with an unusable body, a network error, a CORS block, and its own 10s timeout. `noteRecoveryFailure` escalated all five straight to a session-wide blackout, skipping the route quorum on this reasoning:

> `mint_failed` is session-wide by construction — /api/wm-session itself did not hand back a cookie, so no route can succeed.

That premise does not hold in production.

## The evidence

Each of the 7 most recent `mint_failed` events, checked against Axiom `wm_api_usage` in a ±2.5-minute window:

| WG event (UTC) | server 200 | server non-200 |
|---|---:|---|
| 08-10 13:06:34 | 192 | **0** |
| 08-10 12:42:20 | 216 | **0** |
| 08-10 10:53:00 | 177 | **0** |
| 08-10 05:00:51 | 121 | **0** |
| 08-10 03:54:09 | 124 | **0** |
| 08-09 19:45:57 | 143 | 14 — `origin_403`, unrelated clients |
| 08-09 19:28:10 | 141 | 1 — `origin_403`, unrelated client |

The server was healthy and minting 121–216 sessions per window while the client declared its own session dead.

The reverse check agrees: the four largest server-rejection hours (289, 240, 236, 220 rejects) produced **zero** WG events. 61% of all 429s come from a single AWS /24 that is being correctly rate-limited, and bots do not run our JS.

So `mint_failed` is dominated by client-side transport failure, not by the server refusing.

## What changed

The mint now reports *why* it failed, and the verdict follows the cause:

| cause | meaning | behaviour |
|---|---|---|
| `refused` | server answered non-2xx | immediate session-wide blackout — **unchanged** |
| `malformed` | server answered something unusable | immediate session-wide blackout — **unchanged** |
| `timeout` | our own 10s budget aborted it | one retry, then needs a 2nd route to corroborate |
| `network` | request never completed | one retry, then needs a 2nd route to corroborate |

A `resp.json()` throw is classified `malformed`, not `network`, so an HTML error page is not retried as though the connection dropped.

## The risk a reviewer should weigh

This relaxes a guard that exists for a reason. #5219 added the immediate cooldown to stop mint-on-every-poll amplification, so the question is whether a genuinely offline client can now spin.

It cannot. The retry is a single bounded `if` — not a loop — and the quorum still ends in the same 15-minute blackout. Worst case for a fully offline client goes from 2 mints to 6 before the blackout engages, after which every anonymous call is suppressed exactly as before. `isRouteStruck` still short-circuits a repeated route. The amplification ceiling is per-episode, not per-poll.

The mutation sweep pins this: turning the retry into a `while` loop makes the suite hang rather than pass.

## Diagnosability

The cause also ships as a `mint_cause` Sentry tag. Every `mint_failed` event was previously identical, so WG could not separate an outage from a rate-limit from a CORS block from a dropped connection — and each needs a different fix. Same aggregability argument that added the `route` tag in #5674.

## Validation

- 134 tests pass across the module's suites (`wm-session-*`, `premium-fetch`, `auth-resource-timeout`, `api/wm-session`). `tsc --noEmit` clean.
- 7 new tests, each confirmed **red against the pre-fix code** before the implementation was written.
- **Mutation sweep: 8 of 8 mutants killed**, source restored byte-identical.

Worth flagging: the first sweep had a **survivor** — misclassifying a malformed body as transport changed behaviour with no test failing. Two tests were added to cover that classification and the sweep re-run to 8/8. Without the sweep that gap would have shipped looking fully covered.

Related: #5674, #5677, #6411

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
