### PR TITLE
fix(settings): keep plan verification pending through auth retries

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -197,7 +197,16 @@ import {
   settleAccountOperation,
 } from '@/services/account-operation';
 import type { Id } from '../convex/_generated/dataModel';
-import { initEntitlementSubscription, destroyEntitlementSubscription, resetEntitlementState, onEntitlementChange, getEntitlementState } from '@/services/entitlements';
+import {
+  beginEntitlementVerification,
+  destroyEntitlementSubscription,
+  getEntitlementState,
+  initEntitlementSubscription,
+  markEntitlementVerificationUnavailable,
+  onEntitlementChange,
+  resetEntitlementState,
+  resetEntitlementVerification,
+} from '@/services/entitlements';
 import { initSubscriptionWatch, destroySubscriptionWatch } from '@/services/billing';
 import {
   FREE_TIER_FOLLOW_LIMIT,
@@ -1907,7 +1916,9 @@ export class App {
           ),
           effects: {
             destroyEntitlementSubscription,
+            beginEntitlementVerification,
             resetEntitlementState,
+            markEntitlementVerificationUnavailable,
             destroySubscriptionWatch,
             rebindConvexAuthForWatchHandoff,
             initEntitlementSubscription,
@@ -2024,6 +2035,7 @@ export class App {
         destroySubscriptionWatch();
         cloudPrefsSignOut();
         resetEntitlementState();
+        resetEntitlementVerification();
         this.tierPreferenceHandoff.clear();
         this.pendingPreferenceHandoffGeneration = undefined;
       }

--- a/src/app/account-auth-handoff.ts
+++ b/src/app/account-auth-handoff.ts
@@ -1,6 +1,8 @@
 export interface AccountAuthHandoffEffects {
   destroyEntitlementSubscription: () => void;
+  beginEntitlementVerification: () => void;
   resetEntitlementState: () => void;
+  markEntitlementVerificationUnavailable: () => void;
   destroySubscriptionWatch: () => void;
   rebindConvexAuthForWatchHandoff: (
     isCurrent: () => boolean,
@@ -33,6 +35,10 @@ export function startAccountAuthHandoff(input: {
   const { userId, isCurrent, effects } = input;
 
   effects.destroyEntitlementSubscription();
+  // Publish `pending` before the null snapshot. Settings can receive the
+  // reset synchronously, and must never interpret that account-transition
+  // emission as a terminal lookup failure.
+  effects.beginEntitlementVerification();
   effects.resetEntitlementState();
   effects.destroySubscriptionWatch();
 
@@ -44,5 +50,10 @@ export function startAccountAuthHandoff(input: {
     },
   );
   void effects.cloudPrefsSignIn(userId);
-  return handoff;
+  return handoff.then((ready) => {
+    if (!ready && isCurrent()) {
+      effects.markEntitlementVerificationUnavailable();
+    }
+    return ready;
+  });
 }

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -33,7 +33,14 @@ import { renderPreferences } from '@/services/preferences-content';
 import { renderNotificationsSettings, type NotificationsSettingsResult } from '@/services/notifications-settings';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { track, trackApiAction } from '@/services/analytics';
-import { isEntitled, hasFeature, onEntitlementChange, getEntitlementState } from '@/services/entitlements';
+import {
+  getEntitlementState,
+  getEntitlementVerificationStatus,
+  hasFeature,
+  isEntitled,
+  onEntitlementChange,
+  onEntitlementVerificationChange,
+} from '@/services/entitlements';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { getSubscription, onSubscriptionChange, openBillingPortal, prereserveBillingPortalTab } from '@/services/billing';
 import { BusinessSeatsSection } from '@/components/BusinessSeatsSection';
@@ -143,15 +150,8 @@ export class UnifiedSettings {
   private accountEntitlementRefreshPending = false;
   private unsubscribeAuth: (() => void) | null = null;
   private unsubscribeEntitlement: (() => void) | null = null;
+  private unsubscribeEntitlementVerification: (() => void) | null = null;
   private unsubscribeSubscription: (() => void) | null = null;
-  // Bounded "entitlement snapshot might still arrive" window. Starts false
-  // on open() when currentState is null, flips true on first snapshot OR
-  // after a fallback timeout so signed-in free users aren't stranded on an
-  // empty placeholder when Convex is disabled / auth times out / init
-  // silently fails (all of which leave currentState === null forever — see
-  // src/services/entitlements.ts:41,47,58,78).
-  private entitlementReady = false;
-  private entitlementReadyTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(config: UnifiedSettingsConfig) {
     this.config = config;
@@ -184,6 +184,11 @@ export class UnifiedSettings {
 
       if (target.closest('.upgrade-pro-cta')) {
         this.handleUpgradeClick();
+        return;
+      }
+
+      if (target.closest('.retry-plan-status-btn')) {
+        window.location.reload();
         return;
       }
 
@@ -451,7 +456,6 @@ export class UnifiedSettings {
     // Replace any rendered A-owned plaintext/list data synchronously. Account
     // loaders stay suppressed until the new entitlement snapshot rerenders.
     if (this.overlay.classList.contains('active')) {
-      this.entitlementReady = false;
       this.render(false);
     }
   }
@@ -482,10 +486,6 @@ export class UnifiedSettings {
     if (this.sourceSelectionBaseline === null) {
       this.sourceSelectionBaseline = this.sourceSelectionSignature();
     }
-    // Seed entitlementReady BEFORE render() so the first paint of
-    // renderUpgradeSection branches on the current snapshot state, not the
-    // stale value left over from a previous open/close cycle.
-    this.entitlementReady = getEntitlementState() !== null;
     this.render();
     this.overlay.classList.add('active');
     if (isMobileDevice()) {
@@ -504,7 +504,6 @@ export class UnifiedSettings {
     // delivers data, so a paid API Starter user sees the upgrade CTA briefly).
     this.unsubscribeEntitlement?.();
     this.unsubscribeEntitlement = onEntitlementChange((state) => {
-      this.entitlementReady = true;
       if (this.accountEntitlementRefreshPending) {
         // Entitlements are account-scoped. Rebuild every account surface so a
         // direct A→B handoff removes/adds MCP and API tabs using B's snapshot.
@@ -534,6 +533,10 @@ export class UnifiedSettings {
       }
       this.replaceUpgradeSection();
     });
+    this.unsubscribeEntitlementVerification?.();
+    this.unsubscribeEntitlementVerification = onEntitlementVerificationChange(() => {
+      this.replaceUpgradeSection();
+    });
     this.unsubscribeSubscription?.();
     this.unsubscribeSubscription = onSubscriptionChange(() => {
       this.replaceUpgradeSection();
@@ -545,23 +548,6 @@ export class UnifiedSettings {
     const sub = getSubscription();
     if (sub?.planKey === 'api_business' && sub?.status === 'active') {
       void this.businessSeatsSection.load();
-    }
-    // Bounded fallback: the entitlement listener can legitimately never
-    // fire (no VITE_CONVEX_URL, Convex API fails to load, waitForConvexAuth
-    // times out at 10s, or init throws — see entitlements.ts:41,47,58,78).
-    // Without this timer, the signed-in-free branch of renderUpgradeSection
-    // would show a blank placeholder for the entire session. 12s > the 10s
-    // auth timeout so the healthy-but-slow path lands on the real state;
-    // any later path falls back to "Upgrade to Pro" with handleUpgradeClick
-    // defensively re-checking isEntitled() at click time.
-    if (this.entitlementReadyTimer) clearTimeout(this.entitlementReadyTimer);
-    if (!this.entitlementReady) {
-      this.entitlementReadyTimer = setTimeout(() => {
-        this.entitlementReadyTimer = null;
-        if (this.entitlementReady) return;
-        this.entitlementReady = true;
-        this.replaceUpgradeSection();
-      }, 12_000);
     }
   }
 
@@ -616,12 +602,10 @@ export class UnifiedSettings {
     this.pendingNotifs = null;
     this.unsubscribeEntitlement?.();
     this.unsubscribeEntitlement = null;
+    this.unsubscribeEntitlementVerification?.();
+    this.unsubscribeEntitlementVerification = null;
     this.unsubscribeSubscription?.();
     this.unsubscribeSubscription = null;
-    if (this.entitlementReadyTimer) {
-      clearTimeout(this.entitlementReadyTimer);
-      this.entitlementReadyTimer = null;
-    }
     this.stopMcpQuotaPolling();
     this.resetPanelDraft();
     localStorage.removeItem('wm-settings-open');
@@ -680,19 +664,12 @@ export class UnifiedSettings {
     this.pendingNotifs = null;
     this.unsubscribeEntitlement?.();
     this.unsubscribeEntitlement = null;
+    this.unsubscribeEntitlementVerification?.();
+    this.unsubscribeEntitlementVerification = null;
     this.unsubscribeSubscription?.();
     this.unsubscribeSubscription = null;
     this.unsubscribeAuth?.();
     this.unsubscribeAuth = null;
-    // Mirror close() — without this, a destroy() during the 12s fallback
-    // window leaves the timer live; it fires after teardown and calls
-    // replaceUpgradeSection() against a detached overlay (no-op via the
-    // querySelector early return, but a stray async callback + DOM
-    // reference alive longer than intended).
-    if (this.entitlementReadyTimer) {
-      clearTimeout(this.entitlementReadyTimer);
-      this.entitlementReadyTimer = null;
-    }
     this.stopMcpQuotaPolling();
     document.removeEventListener('keydown', this.escapeHandler);
     this.overlay.remove();
@@ -928,17 +905,19 @@ export class UnifiedSettings {
         </div>
       `;
     }
-    // Signed-in user whose Convex entitlement snapshot has not arrived yet
-    // AND whose bounded-wait window has not expired. Rendering "Upgrade to
-    // Pro" in this window is how paying users click through to
+    // Signed-in user whose Convex entitlement snapshot has not arrived yet.
+    // Rendering "Upgrade to Pro" in this window is how paying users click through to
     // /api/create-checkout and hit 409 duplicate_subscription — same race
     // as the 2026-04-17/18 panel-overlay incident fixed in panel-gating.ts,
-    // different surface. The entitlementReady flag is flipped either by
-    // the onEntitlementChange listener (healthy path) or by a 12s fallback
-    // timer in open() (Convex-disabled / auth-timeout / init-fail paths
-    // where currentState would otherwise stay null forever and strand a
-    // signed-in free user on an empty placeholder).
-    if (!this.entitlementReady && getAuthState().user && getEntitlementState() === null) {
+    // different surface. The verification service stays pending across the
+    // complete Clerk/Convex retry schedule and publishes unavailable only
+    // after a terminal handoff or subscription failure.
+    const verificationStatus = getEntitlementVerificationStatus();
+    if (
+      getAuthState().user
+      && getEntitlementState() === null
+      && (verificationStatus === 'idle' || verificationStatus === 'pending')
+    ) {
       return `
         <div class="upgrade-pro-section upgrade-pro-loading" role="status" aria-live="polite">
           <div class="upgrade-pro-title">Checking your plan…</div>
@@ -996,22 +975,15 @@ export class UnifiedSettings {
       `;
     }
 
-    // Fallback branch: 12s timer fired but Convex never delivered a
-    // snapshot. entitlementReady===true does NOT prove the user is free —
-    // it just means we've given up waiting. A paying user whose auth/query
-    // is simply very slow (beyond the 10s waitForConvexAuth timeout) would
-    // otherwise race into in-modal startCheckout here and reproduce the
-    // 409 duplicate_subscription cascade this PR exists to eliminate.
-    // Render the card with a plain anchor to /pro instead: /pro has its
-    // own entitlement gating on fresh page load, and navigating away is a
-    // no-op for backend subscription state. The `upgrade-pro-cta-link`
-    // class does NOT match the `.upgrade-pro-cta` delegated click handler
-    // (line ~95), so the browser handles the navigation natively.
+    // A terminal auth/subscription failure still does not prove the user is
+    // free. Keep checkout unavailable, offer a fresh verification attempt,
+    // and retain the safe /pro link in a separate tab.
     if (getAuthState().user && getEntitlementState() === null) {
       return `
         <div class="upgrade-pro-section upgrade-pro-fallback">
           <div class="upgrade-pro-title">Plan status unavailable</div>
-          <div class="upgrade-pro-desc">We could not verify your current plan. View plans in a new tab or try again later.</div>
+          <div class="upgrade-pro-desc">We could not verify your current plan. Try again or view plans in a new tab.</div>
+          <button class="manage-billing-btn retry-plan-status-btn" style="margin-bottom:8px;">Try again</button>
           <a class="upgrade-pro-cta-link" href="/pro" target="_blank" rel="noopener">View plans →</a>
         </div>
       `;
@@ -1030,14 +1002,9 @@ export class UnifiedSettings {
   // BusinessSeatsSection — see this.businessSeatsSection.
 
   private handleUpgradeClick(): void {
-    // Defense in depth: the upgrade CTA can only be clicked when either (a)
-    // the user is genuinely free-tier, or (b) the 12s fallback timer fired
-    // before the Convex snapshot arrived. In (b), the snapshot might land
-    // AFTER the timer but BEFORE the click — re-check isEntitled() here so
-    // a late-arriving "you're a paying user" state routes to the billing
-    // portal instead of triggering /api/create-checkout against an active
-    // subscription (which would 409 and re-enter the duplicate_subscription
-    // → getCustomerPortalUrl cascade this PR is trying to eliminate).
+    // Defense in depth: re-check at click time so a late-arriving "you're a
+    // paying user" snapshot routes to the billing portal instead of creating
+    // a second checkout against an active subscription.
     if (isEntitled()) {
       this.close();
       const reservedWin = prereserveBillingPortalTab();

--- a/src/services/entitlements.ts
+++ b/src/services/entitlements.ts
@@ -53,11 +53,51 @@ export interface EntitlementState {
   validUntil: number;
 }
 
+/**
+ * Account-scoped progress for resolving the current entitlement snapshot.
+ *
+ * `currentState === null` alone is ambiguous: it can mean that a signed-in
+ * account is still moving through the bounded Clerk/Convex auth retries, or
+ * that the handoff reached a terminal failure. Keep that distinction explicit
+ * so billing UI never converts an in-flight retry into a failure message.
+ */
+export type EntitlementVerificationStatus =
+  | 'idle'
+  | 'pending'
+  | 'ready'
+  | 'unavailable';
+
 // Module-level state
 let currentState: EntitlementState | null = null;
 const listeners = new Set<(state: EntitlementState | null) => void>();
+let verificationStatus: EntitlementVerificationStatus = 'idle';
+const verificationListeners = new Set<(status: EntitlementVerificationStatus) => void>();
 let initialized = false;
 let unsubscribeFn: (() => void) | null = null;
+
+function setEntitlementVerificationStatus(status: EntitlementVerificationStatus): void {
+  if (verificationStatus === status) return;
+  verificationStatus = status;
+  for (const cb of verificationListeners) {
+    try {
+      cb(status);
+    } catch (err) {
+      console.warn('[entitlements] verification listener threw; continuing fan-out:', err);
+    }
+  }
+}
+
+export function beginEntitlementVerification(): void {
+  setEntitlementVerificationStatus('pending');
+}
+
+export function markEntitlementVerificationUnavailable(): void {
+  if (currentState === null) setEntitlementVerificationStatus('unavailable');
+}
+
+export function resetEntitlementVerification(): void {
+  setEntitlementVerificationStatus('idle');
+}
 
 /**
  * Fan a new snapshot out to every subscriber, isolating failures.
@@ -92,17 +132,20 @@ export async function initEntitlementSubscription(
     isCurrent() && (_userId === undefined || getCurrentClerkUser()?.id === _userId)
   );
   if (initialized || !isExpectedAccount()) return;
+  if (currentState === null) beginEntitlementVerification();
 
   try {
     const client = await getConvexClient();
     if (!client) {
       console.log('[entitlements] No VITE_CONVEX_URL — skipping Convex subscription');
+      if (isExpectedAccount()) markEntitlementVerificationUnavailable();
       return;
     }
 
     const api = await getConvexApi();
     if (!api) {
       console.log('[entitlements] Could not load Convex API — skipping subscription');
+      if (isExpectedAccount()) markEntitlementVerificationUnavailable();
       return;
     }
 
@@ -117,6 +160,7 @@ export async function initEntitlementSubscription(
       : await waitForConvexAuth(10_000);
     if (!authed) {
       console.log('[entitlements] Convex auth not established — skipping subscription');
+      if (isExpectedAccount()) markEntitlementVerificationUnavailable();
       return;
     }
     if (!isExpectedAccount()) return;
@@ -127,11 +171,13 @@ export async function initEntitlementSubscription(
       (result: EntitlementState | null) => {
         if (!isExpectedAccount()) return;
         currentState = result;
+        setEntitlementVerificationStatus('ready');
         notifyListeners(result);
       },
       (err: Error) => {
         if (!isExpectedAccount()) return;
         console.warn('[entitlements] Subscription query error:', err.message);
+        markEntitlementVerificationUnavailable();
       },
     );
 
@@ -139,6 +185,7 @@ export async function initEntitlementSubscription(
     initialized = true;
   } catch (err) {
     console.error('[entitlements] Failed to initialize Convex subscription:', err);
+    if (isExpectedAccount()) markEntitlementVerificationUnavailable();
     // Do not rethrow — entitlement service failure must not break the dashboard
   }
 }
@@ -193,6 +240,25 @@ export function onEntitlementChange(
   return () => {
     listeners.delete(cb);
   };
+}
+
+/**
+ * Register a callback for entitlement-verification progress.
+ * The current status is replayed immediately so late UI subscribers cannot
+ * recreate a local timeout with a different lifecycle.
+ */
+export function onEntitlementVerificationChange(
+  cb: (status: EntitlementVerificationStatus) => void,
+): () => void {
+  verificationListeners.add(cb);
+  cb(verificationStatus);
+  return () => {
+    verificationListeners.delete(cb);
+  };
+}
+
+export function getEntitlementVerificationStatus(): EntitlementVerificationStatus {
+  return verificationStatus;
 }
 
 /**

--- a/tests/convex-auth-handoff.test.mts
+++ b/tests/convex-auth-handoff.test.mts
@@ -744,7 +744,9 @@ describe('App account-switch controller', () => {
       isCurrent: () => true,
       effects: {
         destroyEntitlementSubscription: () => events.push('destroy-entitlement'),
+        beginEntitlementVerification: () => events.push('begin-entitlement-verification'),
         resetEntitlementState: () => events.push('reset-entitlement'),
+        markEntitlementVerificationUnavailable: () => events.push('unavailable-entitlement-verification'),
         destroySubscriptionWatch: () => events.push('destroy-billing'),
         rebindConvexAuthForWatchHandoff: (isCurrent, attach) => {
           events.push('rebind');
@@ -766,6 +768,7 @@ describe('App account-switch controller', () => {
 
     assert.deepEqual(events, [
       'destroy-entitlement',
+      'begin-entitlement-verification',
       'reset-entitlement',
       'destroy-billing',
       'rebind',
@@ -781,6 +784,52 @@ describe('App account-switch controller', () => {
 
     completion.resolve(true);
     assert.equal(await handoff, true);
+    assert.equal(events.includes('unavailable-entitlement-verification'), false);
+  });
+
+  it('publishes unavailable only when the current account handoff exhausts retries', async () => {
+    const events: string[] = [];
+    let current = true;
+
+    const handoff = startAccountAuthHandoff({
+      userId: 'B',
+      isCurrent: () => current,
+      effects: {
+        destroyEntitlementSubscription: () => {},
+        beginEntitlementVerification: () => events.push('pending'),
+        resetEntitlementState: () => {},
+        markEntitlementVerificationUnavailable: () => events.push('unavailable'),
+        destroySubscriptionWatch: () => {},
+        rebindConvexAuthForWatchHandoff: async () => false,
+        initEntitlementSubscription: () => {},
+        initSubscriptionWatch: () => {},
+        cloudPrefsSignIn: () => {},
+      },
+    });
+
+    assert.equal(await handoff, false);
+    assert.deepEqual(events, ['pending', 'unavailable']);
+
+    current = false;
+    events.length = 0;
+    const staleHandoff = startAccountAuthHandoff({
+      userId: 'B',
+      isCurrent: () => current,
+      effects: {
+        destroyEntitlementSubscription: () => {},
+        beginEntitlementVerification: () => events.push('pending'),
+        resetEntitlementState: () => {},
+        markEntitlementVerificationUnavailable: () => events.push('unavailable'),
+        destroySubscriptionWatch: () => {},
+        rebindConvexAuthForWatchHandoff: async () => false,
+        initEntitlementSubscription: () => {},
+        initSubscriptionWatch: () => {},
+        cloudPrefsSignIn: () => {},
+      },
+    });
+
+    assert.equal(await staleHandoff, false);
+    assert.deepEqual(events, ['pending']);
   });
 
   it('wires App through the tested account-handoff controller', async () => {

--- a/tests/dom/pro-banner-premium-stability.test.mts
+++ b/tests/dom/pro-banner-premium-stability.test.mts
@@ -180,11 +180,13 @@ function installAppEntitlementResetListener(
         isCurrent: () => session.user?.id === userId,
         effects: {
           destroyEntitlementSubscription: () => {},
+          beginEntitlementVerification: () => {},
           resetEntitlementState: () => {
             entitlementSnapshot = null;
             const state = entitlement();
             for (const listener of entitlementListeners) listener(state);
           },
+          markEntitlementVerificationUnavailable: () => {},
           destroySubscriptionWatch: () => {},
           rebindConvexAuthForWatchHandoff: async () => false,
           initEntitlementSubscription: () => {},

--- a/tests/dom/unified-settings-account-handoff.test.mts
+++ b/tests/dom/unified-settings-account-handoff.test.mts
@@ -10,7 +10,10 @@ import type { UnifiedSettingsConfig } from '@/components/UnifiedSettings';
 import type { ApiKeyInfo, CreateApiKeyResult } from '@/services/api-keys';
 import type { ApiPlanLimitNotice } from '@/services/api-plan-limit-notices';
 import type { AuthSession } from '@/services/auth-state';
-import type { EntitlementState } from '@/services/entitlements';
+import type {
+  EntitlementState,
+  EntitlementVerificationStatus,
+} from '@/services/entitlements';
 import type { McpClientInfo, McpQuota } from '@/services/mcp-clients';
 
 let session: AuthSession = signedIn('A');
@@ -33,6 +36,11 @@ const mcpMocks = vi.hoisted(() => ({
 const entitlementMocks = vi.hoisted(() => ({
   state: null as EntitlementState | null,
   listeners: [] as Array<(state: EntitlementState | null) => void>,
+  verificationStatus: 'idle' as EntitlementVerificationStatus,
+  verificationListeners: [] as Array<(status: EntitlementVerificationStatus) => void>,
+}));
+const panelGatingMocks = vi.hoisted(() => ({
+  hasPremiumAccess: true,
 }));
 const storageValues = new Map<string, string>();
 const storage: Storage = {
@@ -59,6 +67,7 @@ vi.mock('@/services/auth-state', async (importOriginal) => ({
 
 vi.mock('@/services/entitlements', () => ({
   getEntitlementState: () => entitlementMocks.state,
+  getEntitlementVerificationStatus: () => entitlementMocks.verificationStatus,
   hasFeature: (feature: string) => Boolean(
     (entitlementMocks.state?.features as Record<string, unknown> | undefined)?.[feature],
   ),
@@ -74,10 +83,20 @@ vi.mock('@/services/entitlements', () => ({
       if (index >= 0) entitlementMocks.listeners.splice(index, 1);
     };
   },
+  onEntitlementVerificationChange: (
+    listener: (status: EntitlementVerificationStatus) => void,
+  ) => {
+    entitlementMocks.verificationListeners.push(listener);
+    listener(entitlementMocks.verificationStatus);
+    return () => {
+      const index = entitlementMocks.verificationListeners.indexOf(listener);
+      if (index >= 0) entitlementMocks.verificationListeners.splice(index, 1);
+    };
+  },
 }));
 
 vi.mock('@/services/panel-gating', () => ({
-  hasPremiumAccess: () => true,
+  hasPremiumAccess: () => panelGatingMocks.hasPremiumAccess,
 }));
 
 vi.mock('@/services/widget-store', () => ({
@@ -248,6 +267,11 @@ function emitEntitlement(state: EntitlementState | null): void {
   for (const listener of [...entitlementMocks.listeners]) listener(state);
 }
 
+function emitEntitlementVerification(status: EntitlementVerificationStatus): void {
+  entitlementMocks.verificationStatus = status;
+  for (const listener of [...entitlementMocks.verificationListeners]) listener(status);
+}
+
 function apiKey(id = 'key-a'): ApiKeyInfo {
   return {
     id,
@@ -303,11 +327,14 @@ beforeEach(() => {
   document.body.replaceChildren();
   authListeners.length = 0;
   entitlementMocks.listeners.length = 0;
+  entitlementMocks.verificationListeners.length = 0;
   entitlementMocks.state = entitlement({
     planKey: 'api_business',
     apiAccess: true,
     mcpAccess: true,
   });
+  entitlementMocks.verificationStatus = 'ready';
+  panelGatingMocks.hasPremiumAccess = true;
   storageValues.clear();
   vi.stubGlobal('localStorage', storage);
   session = signedIn('A');
@@ -342,6 +369,40 @@ afterEach(() => {
 });
 
 describe('UnifiedSettings real auth-subscription handoff', () => {
+  it('keeps checking past 12 seconds while entitlement verification is still in flight', () => {
+    vi.useFakeTimers();
+    panelGatingMocks.hasPremiumAccess = false;
+    entitlementMocks.state = null;
+    entitlementMocks.verificationStatus = 'pending';
+
+    try {
+      settings.open('billing');
+      expect(internal.overlay.textContent).toContain('Checking your plan');
+
+      vi.advanceTimersByTime(12_000);
+
+      expect(internal.overlay.textContent).toContain('Checking your plan');
+      expect(internal.overlay.textContent).not.toContain('Plan status unavailable');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows retry only after entitlement verification becomes unavailable', () => {
+    panelGatingMocks.hasPremiumAccess = false;
+    entitlementMocks.state = null;
+    entitlementMocks.verificationStatus = 'pending';
+    settings.open('billing');
+
+    expect(internal.overlay.textContent).toContain('Checking your plan');
+    expect(internal.overlay.querySelector('.retry-plan-status-btn')).toBeNull();
+
+    emitEntitlementVerification('unavailable');
+
+    expect(internal.overlay.textContent).toContain('Plan status unavailable');
+    expect(internal.overlay.querySelector('.retry-plan-status-btn')).not.toBeNull();
+  });
+
   it('synchronously purges A plaintext and rendered account lists when auth emits B', () => {
     internal.apiKeys = [apiKey()];
     internal.planLimitNotices = [notice()];

--- a/tests/dom/unified-settings-sources-live-apply.test.mts
+++ b/tests/dom/unified-settings-sources-live-apply.test.mts
@@ -69,9 +69,11 @@ vi.mock('@/services/auth-state', async (importOriginal) => ({
 
 vi.mock('@/services/entitlements', () => ({
   getEntitlementState: () => entitlementState,
+  getEntitlementVerificationStatus: () => 'ready',
   hasFeature: () => true,
   isEntitled: () => true,
   onEntitlementChange: () => () => {},
+  onEntitlementVerificationChange: () => () => {},
 }));
 
 vi.mock('@/services/panel-gating', () => ({

--- a/tests/dom/unified-settings-theater-presets.test.mts
+++ b/tests/dom/unified-settings-theater-presets.test.mts
@@ -60,9 +60,11 @@ vi.mock('@/services/auth-state', async (importOriginal) => ({
 
 vi.mock('@/services/entitlements', () => ({
   getEntitlementState: () => entitlementState,
+  getEntitlementVerificationStatus: () => 'ready',
   hasFeature: () => true,
   isEntitled: () => true,
   onEntitlementChange: () => () => {},
+  onEntitlementVerificationChange: () => () => {},
 }));
 
 vi.mock('@/services/panel-gating', () => ({

--- a/tests/dom/unified-settings-upgrade-click-runtime.test.mts
+++ b/tests/dom/unified-settings-upgrade-click-runtime.test.mts
@@ -53,10 +53,12 @@ vi.mock('@/services/auth-state', async (importOriginal) => ({
 
 vi.mock('@/services/entitlements', () => ({
   getEntitlementState: () => null,
+  getEntitlementVerificationStatus: () => 'ready',
   hasFeature: () => false,
   // Free tier: the upgrade branch, not the manage-billing branch.
   isEntitled: () => false,
   onEntitlementChange: () => () => {},
+  onEntitlementVerificationChange: () => () => {},
 }));
 
 vi.mock('@/services/panel-gating', () => ({

--- a/tests/entitlement-listener-fanout.test.mts
+++ b/tests/entitlement-listener-fanout.test.mts
@@ -17,7 +17,15 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { onEntitlementChange, resetEntitlementState } from '@/services/entitlements';
+import {
+  beginEntitlementVerification,
+  markEntitlementVerificationUnavailable,
+  onEntitlementChange,
+  onEntitlementVerificationChange,
+  resetEntitlementState,
+  resetEntitlementVerification,
+  type EntitlementVerificationStatus,
+} from '@/services/entitlements';
 
 /** Unsubscribers for every listener a test registers. */
 let cleanup: Array<() => void> = [];
@@ -33,6 +41,7 @@ beforeEach(() => {
 afterEach(() => {
   for (const off of cleanup) off();
   cleanup = [];
+  resetEntitlementVerification();
 });
 
 describe('entitlement listener fan-out', () => {
@@ -98,5 +107,19 @@ describe('entitlement listener fan-out', () => {
     resetEntitlementState();
 
     assert.equal(healthy, 2);
+  });
+});
+
+describe('entitlement verification lifecycle', () => {
+  it('publishes pending and unavailable as distinct account-resolution states', () => {
+    resetEntitlementState();
+    resetEntitlementVerification();
+    const statuses: EntitlementVerificationStatus[] = [];
+    cleanup.push(onEntitlementVerificationChange((status) => statuses.push(status)));
+
+    beginEntitlementVerification();
+    markEntitlementVerificationUnavailable();
+
+    assert.deepEqual(statuses, ['idle', 'pending', 'unavailable']);
   });
 });

--- a/tests/unified-settings-account-handoff.test.mjs
+++ b/tests/unified-settings-account-handoff.test.mjs
@@ -86,7 +86,6 @@ describe('UnifiedSettings account handoff', () => {
       },
     };
     instance.overlay = { classList: { contains: () => true } };
-    instance.entitlementReady = true;
     instance.render = (loadAccountData) => renders.push(loadAccountData);
     let listRenders = 0;
     instance.renderApiKeysList = () => {
@@ -113,7 +112,6 @@ describe('UnifiedSettings account handoff', () => {
     assert.equal(instance.mcpClientsError, '');
     assert.equal(instance.mcpQuota, null);
     assert.equal(seatsReset, 1);
-    assert.equal(instance.entitlementReady, false);
     assert.deepEqual(renders, [false], 'the synchronous rerender must suppress account loads');
     assert.equal(listRenders, 1, 'A settlement must not render after B clears the surface');
     assert.equal(instance.isAccountRequestCurrent(requestA), false);

--- a/tests/unified-settings-active-tab.test.mjs
+++ b/tests/unified-settings-active-tab.test.mjs
@@ -65,8 +65,10 @@ function extractOpen() {
   // eslint-disable-next-line no-new-func
   return new Function(
     'getEntitlementState',
+    'getEntitlementVerificationStatus',
     'hasFeature',
     'onEntitlementChange',
+    'onEntitlementVerificationChange',
     'onSubscriptionChange',
     'getSubscription',
     'getAuthState',
@@ -82,7 +84,9 @@ function extractOpen() {
 let mcpAccess = false;
 const Harness = extractOpen()(
   () => ({ planKey: mcpAccess ? 'pro_monthly' : 'free' }),
+  () => 'ready',
   (feature) => feature === 'mcpAccess' && mcpAccess,
+  () => () => {},
   () => () => {},
   () => () => {},
   () => null,
@@ -121,9 +125,8 @@ function makeInstance(initialTab = 'settings') {
   };
   instance.escapeHandler = () => {};
   instance.unsubscribeEntitlement = null;
+  instance.unsubscribeEntitlementVerification = null;
   instance.unsubscribeSubscription = null;
-  instance.entitlementReady = false;
-  instance.entitlementReadyTimer = null;
   instance.businessSeatsSection = { load() {} };
   return instance;
 }


### PR DESCRIPTION
## Summary

Plan & billing no longer reports “Plan status unavailable” at 12 seconds while Clerk/Convex authentication is still retrying. It stays on “Checking your plan…” until verification produces a snapshot or a terminal failure. A terminal failure remains fail-safe for checkout, includes a Try again action, and is generation-scoped so an old account handoff cannot overwrite the active account.

## Validation

- `npm run typecheck`
- `npm run test:dom` — 29 files and 256 tests; the regression covers the 12-second pending window and terminal retry UI
- Focused auth and settings suite — 40 tests covering current-account failure, stale handoffs, listener state, and account switching
- Repository pre-push gate — typecheck, architectural boundaries, safe HTML, premium-fetch parity, changed tests, DOM tests, Edge isolation, and version sync

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
