### PR TITLE
fix(rate-limit): confirm CF edge-proof covers /api/* and warn when it stops

### DIFF
--- a/api/_client-ip.js
+++ b/api/_client-ip.js
@@ -12,6 +12,112 @@ export const RATE_LIMIT_DEGRADED_HEADERS = Object.freeze({
 // the request actually transited CF. Keep in sync with server/_shared/client-ip.ts.
 const CF_EDGE_PROOF_HEADER = 'x-wm-edge-proof';
 
+// Vercel's x-real-ip is its direct peer. Only a peer in Cloudflare's published
+// proxy ranges proves that an unproven cf-connecting-ip came from a genuine
+// Cloudflare hop rather than a direct-origin spoof. Sources:
+// https://www.cloudflare.com/ips-v4/ and https://www.cloudflare.com/ips-v6/
+// Keep in sync with server/_shared/client-ip.ts.
+const CLOUDFLARE_IPV4_CIDRS = Object.freeze([
+  '173.245.48.0/20',
+  '103.21.244.0/22',
+  '103.22.200.0/22',
+  '103.31.4.0/22',
+  '141.101.64.0/18',
+  '108.162.192.0/18',
+  '190.93.240.0/20',
+  '188.114.96.0/20',
+  '197.234.240.0/22',
+  '198.41.128.0/17',
+  '162.158.0.0/15',
+  '104.16.0.0/13',
+  '104.24.0.0/14',
+  '172.64.0.0/13',
+  '131.0.72.0/22',
+]);
+
+const CLOUDFLARE_IPV6_CIDRS = Object.freeze([
+  '2400:cb00::/32',
+  '2606:4700::/32',
+  '2803:f800::/32',
+  '2405:b500::/32',
+  '2405:8100::/32',
+  '2a06:98c0::/29',
+  '2c0f:f248::/32',
+]);
+
+function parseIpv4(value) {
+  const parts = value.split('.');
+  if (parts.length !== 4) return null;
+  let address = 0;
+  for (const part of parts) {
+    if (!/^(?:0|[1-9]\d{0,2})$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    address = (address * 256) + octet;
+  }
+  return address >>> 0;
+}
+
+function parseIpv6(value) {
+  if (!value || value.includes('.') || value.includes('%')) return null;
+  const halves = value.split('::');
+  if (halves.length > 2) return null;
+
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  if (halves.length === 1 && head.length !== 8) return null;
+  if (halves.length === 2 && head.length + tail.length >= 8) return null;
+
+  const groups = halves.length === 2
+    ? [...head, ...Array(8 - head.length - tail.length).fill('0'), ...tail]
+    : head;
+  if (groups.some((group) => !/^[0-9a-f]{1,4}$/i.test(group))) return null;
+  return groups.map((group) => Number.parseInt(group, 16));
+}
+
+function parseIpv4Cidr(cidr) {
+  const [networkText, prefixText] = cidr.split('/');
+  const network = parseIpv4(networkText);
+  if (network === null) throw new Error(`Invalid Cloudflare IPv4 CIDR: ${cidr}`);
+  return [network, Number(prefixText)];
+}
+
+function parseIpv6Cidr(cidr) {
+  const [networkText, prefixText] = cidr.split('/');
+  const network = parseIpv6(networkText);
+  if (network === null) throw new Error(`Invalid Cloudflare IPv6 CIDR: ${cidr}`);
+  return [network, Number(prefixText)];
+}
+
+const CLOUDFLARE_IPV4_RANGES = Object.freeze(CLOUDFLARE_IPV4_CIDRS.map(parseIpv4Cidr));
+const CLOUDFLARE_IPV6_RANGES = Object.freeze(CLOUDFLARE_IPV6_CIDRS.map(parseIpv6Cidr));
+
+function isInIpv4Range(address, network, prefixLength) {
+  const mask = (0xffffffff << (32 - prefixLength)) >>> 0;
+  return ((address & mask) >>> 0) === ((network & mask) >>> 0);
+}
+
+function isInIpv6Range(address, network, prefixLength) {
+  const fullGroups = Math.floor(prefixLength / 16);
+  for (let i = 0; i < fullGroups; i += 1) {
+    if (address[i] !== network[i]) return false;
+  }
+  const remainingBits = prefixLength % 16;
+  if (remainingBits === 0) return true;
+  const mask = (0xffff << (16 - remainingBits)) & 0xffff;
+  return (address[fullGroups] & mask) === (network[fullGroups] & mask);
+}
+
+function isCloudflareProxyIp(value) {
+  const ipv4 = parseIpv4(value);
+  if (ipv4 !== null) {
+    return CLOUDFLARE_IPV4_RANGES.some(([network, prefix]) => isInIpv4Range(ipv4, network, prefix));
+  }
+  const ipv6 = parseIpv6(value);
+  return ipv6 !== null
+    && CLOUDFLARE_IPV6_RANGES.some(([network, prefix]) => isInIpv6Range(ipv6, network, prefix));
+}
+
 // Compare the edge-proof secret without an early exit on length mismatch.
 // Synchronous so getClientIp stays sync (it's on the per-request rate-limit hot
 // path with several callers that invoke it without await). Keep in sync with
@@ -37,16 +143,27 @@ export function hasCloudflareTransitProof(request) {
 // One-per-isolate warning that the edge-proof is not matching, so a missing
 // CF_EDGE_PROOF_SECRET or a Cloudflare rule that stopped covering this route
 // cannot regress silently. The dangerous state is cf-connecting-ip PRESENT
-// (the request really did transit Cloudflare) but the x-wm-edge-proof header
-// absent or mismatched: getClientIp then falls back to x-real-ip, which
-// Vercel sets to its peer — the Cloudflare PoP — so every user behind that
-// PoP shares one rate-limit bucket and per-IP budgets look enforced but are
-// not (issue #6431). Keep this dependency-free and in sync with
-// server/_shared/client-ip.ts.
-let edgeProofMismatchWarned = false;
+// and x-real-ip in Cloudflare's proxy ranges, but the x-wm-edge-proof header
+// absent or mismatched. Direct-origin spoofs with non-CF peers must not warn
+// or consume the latch. Keep this dependency-free and in sync with
+// server/_shared/client-ip.ts. Symbol.for gives both mirror modules one
+// collision-resistant, isolate-wide latch even when both are loaded together.
+const EDGE_PROOF_MISMATCH_LATCH = Symbol.for(
+  'worldmonitor.client-ip.edge-proof-mismatch-warning.v1',
+);
+
+function getEdgeProofMismatchLatch() {
+  const existing = Reflect.get(globalThis, EDGE_PROOF_MISMATCH_LATCH);
+  if (existing) return existing;
+  const latch = { warned: false };
+  Reflect.set(globalThis, EDGE_PROOF_MISMATCH_LATCH, latch);
+  return latch;
+}
+
 export function warnEdgeProofNotProving() {
-  if (edgeProofMismatchWarned) return;
-  edgeProofMismatchWarned = true;
+  const latch = getEdgeProofMismatchLatch();
+  if (latch.warned) return;
+  latch.warned = true;
   // One line, greppable in Vercel logs; not a per-request log. Follows the
   // rate-limit degraded-mode console.error precedent (api/_rate-limit.js).
   console.warn(
@@ -54,13 +171,11 @@ export function warnEdgeProofNotProving() {
   );
 }
 
-// Test seam: the warn-once flag is module state, so a suite that exercises the
-// warning in one test must be able to reset it for the next. Real isolates
-// never call this — a fresh isolate starts with the flag clear, which is
-// exactly what the once-per-isolate contract needs. Mirrors the
+// Test seam for the shared isolate-wide latch. Real isolates never call this;
+// a fresh isolate starts with the latch clear. Mirrors the
 // resetRateLimitFallbackForTest pattern.
 export function resetEdgeProofMismatchWarnedForTest() {
-  edgeProofMismatchWarned = false;
+  getEdgeProofMismatchLatch().warned = false;
 }
 
 export function getClientIp(request) {
@@ -75,11 +190,10 @@ export function getClientIp(request) {
   // and the client-settable x-forwarded-for (#3531) are deliberately NOT
   // fallbacks here.
   if (cf && hasCloudflareTransitProof(request)) return cf;
-  // The precise "looks enforced but is shared" state (#6431): the request
-  // really did transit Cloudflare (cf-connecting-ip present and real) but
-  // proof of CF transit is missing, so the user just joined the PoP-shared
-  // x-real-ip bucket. Warn once per isolate so a rule/secret regression
-  // surfaces in logs without spamming them.
-  if (cf) warnEdgeProofNotProving();
+  // The precise "looks enforced but is shared" state (#6431): an unproven
+  // cf-connecting-ip arrived from a Cloudflare peer, so the user just joined
+  // the PoP-shared x-real-ip bucket. A non-CF peer is a direct-origin spoof;
+  // it must neither warn nor consume the shared latch.
+  if (cf && isCloudflareProxyIp(xr)) warnEdgeProofNotProving();
   return xr || UNKNOWN_CLIENT_IP;
 }

--- a/api/_client-ip.js
+++ b/api/_client-ip.js
@@ -34,6 +34,35 @@ export function hasCloudflareTransitProof(request) {
   return constantTimeEqual((request.headers.get(CF_EDGE_PROOF_HEADER) ?? '').trim(), secret);
 }
 
+// One-per-isolate warning that the edge-proof is not matching, so a missing
+// CF_EDGE_PROOF_SECRET or a Cloudflare rule that stopped covering this route
+// cannot regress silently. The dangerous state is cf-connecting-ip PRESENT
+// (the request really did transit Cloudflare) but the x-wm-edge-proof header
+// absent or mismatched: getClientIp then falls back to x-real-ip, which
+// Vercel sets to its peer — the Cloudflare PoP — so every user behind that
+// PoP shares one rate-limit bucket and per-IP budgets look enforced but are
+// not (issue #6431). Keep this dependency-free and in sync with
+// server/_shared/client-ip.ts.
+let edgeProofMismatchWarned = false;
+export function warnEdgeProofNotProving() {
+  if (edgeProofMismatchWarned) return;
+  edgeProofMismatchWarned = true;
+  // One line, greppable in Vercel logs; not a per-request log. Follows the
+  // rate-limit degraded-mode console.error precedent (api/_rate-limit.js).
+  console.warn(
+    '[client-ip] cf-connecting-ip present but x-wm-edge-proof missing/mismatched — rate-limit buckets keyed by Cloudflare PoP (x-real-ip), not per user. Fix CF_EDGE_PROOF_SECRET or the Cloudflare header transform rule. Issue #6431',
+  );
+}
+
+// Test seam: the warn-once flag is module state, so a suite that exercises the
+// warning in one test must be able to reset it for the next. Real isolates
+// never call this — a fresh isolate starts with the flag clear, which is
+// exactly what the once-per-isolate contract needs. Mirrors the
+// resetRateLimitFallbackForTest pattern.
+export function resetEdgeProofMismatchWarnedForTest() {
+  edgeProofMismatchWarned = false;
+}
+
 export function getClientIp(request) {
   const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
   const xr = (request.headers.get('x-real-ip') ?? '').trim();
@@ -46,5 +75,11 @@ export function getClientIp(request) {
   // and the client-settable x-forwarded-for (#3531) are deliberately NOT
   // fallbacks here.
   if (cf && hasCloudflareTransitProof(request)) return cf;
+  // The precise "looks enforced but is shared" state (#6431): the request
+  // really did transit Cloudflare (cf-connecting-ip present and real) but
+  // proof of CF transit is missing, so the user just joined the PoP-shared
+  // x-real-ip bucket. Warn once per isolate so a rule/secret regression
+  // surfaces in logs without spamming them.
+  if (cf) warnEdgeProofNotProving();
   return xr || UNKNOWN_CLIENT_IP;
 }

--- a/server/_shared/client-ip.ts
+++ b/server/_shared/client-ip.ts
@@ -21,6 +21,116 @@ export const UNKNOWN_CLIENT_IP = 'unknown';
 // the request actually transited CF. Keep in sync with api/_client-ip.js.
 const CF_EDGE_PROOF_HEADER = 'x-wm-edge-proof';
 
+// Vercel's x-real-ip is its direct peer. Only a peer in Cloudflare's published
+// proxy ranges proves that an unproven cf-connecting-ip came from a genuine
+// Cloudflare hop rather than a direct-origin spoof. Sources:
+// https://www.cloudflare.com/ips-v4/ and https://www.cloudflare.com/ips-v6/
+// Keep in sync with api/_client-ip.js.
+const CLOUDFLARE_IPV4_CIDRS = Object.freeze([
+  '173.245.48.0/20',
+  '103.21.244.0/22',
+  '103.22.200.0/22',
+  '103.31.4.0/22',
+  '141.101.64.0/18',
+  '108.162.192.0/18',
+  '190.93.240.0/20',
+  '188.114.96.0/20',
+  '197.234.240.0/22',
+  '198.41.128.0/17',
+  '162.158.0.0/15',
+  '104.16.0.0/13',
+  '104.24.0.0/14',
+  '172.64.0.0/13',
+  '131.0.72.0/22',
+]);
+
+const CLOUDFLARE_IPV6_CIDRS = Object.freeze([
+  '2400:cb00::/32',
+  '2606:4700::/32',
+  '2803:f800::/32',
+  '2405:b500::/32',
+  '2405:8100::/32',
+  '2a06:98c0::/29',
+  '2c0f:f248::/32',
+]);
+
+function parseIpv4(value: string): number | null {
+  const parts = value.split('.');
+  if (parts.length !== 4) return null;
+  let address = 0;
+  for (const part of parts) {
+    if (!/^(?:0|[1-9]\d{0,2})$/.test(part)) return null;
+    const octet = Number(part);
+    if (octet > 255) return null;
+    address = (address * 256) + octet;
+  }
+  return address >>> 0;
+}
+
+function parseIpv6(value: string): number[] | null {
+  if (!value || value.includes('.') || value.includes('%')) return null;
+  const halves = value.split('::');
+  if (halves.length > 2) return null;
+
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  if (halves.length === 1 && head.length !== 8) return null;
+  if (halves.length === 2 && head.length + tail.length >= 8) return null;
+
+  const groups = halves.length === 2
+    ? [...head, ...Array(8 - head.length - tail.length).fill('0'), ...tail]
+    : head;
+  if (groups.some((group) => !/^[0-9a-f]{1,4}$/i.test(group))) return null;
+  return groups.map((group) => Number.parseInt(group, 16));
+}
+
+function parseIpv4Cidr(cidr: string): [number, number] {
+  const [networkText = '', prefixText = ''] = cidr.split('/');
+  const network = parseIpv4(networkText);
+  if (network === null) throw new Error(`Invalid Cloudflare IPv4 CIDR: ${cidr}`);
+  return [network, Number(prefixText)];
+}
+
+function parseIpv6Cidr(cidr: string): [number[], number] {
+  const [networkText = '', prefixText = ''] = cidr.split('/');
+  const network = parseIpv6(networkText);
+  if (network === null) throw new Error(`Invalid Cloudflare IPv6 CIDR: ${cidr}`);
+  return [network, Number(prefixText)];
+}
+
+const CLOUDFLARE_IPV4_RANGES = Object.freeze(CLOUDFLARE_IPV4_CIDRS.map(parseIpv4Cidr));
+const CLOUDFLARE_IPV6_RANGES = Object.freeze(CLOUDFLARE_IPV6_CIDRS.map(parseIpv6Cidr));
+
+function isInIpv4Range(address: number, network: number, prefixLength: number): boolean {
+  const mask = (0xffffffff << (32 - prefixLength)) >>> 0;
+  return ((address & mask) >>> 0) === ((network & mask) >>> 0);
+}
+
+function isInIpv6Range(
+  address: number[],
+  network: number[],
+  prefixLength: number,
+): boolean {
+  const fullGroups = Math.floor(prefixLength / 16);
+  for (let i = 0; i < fullGroups; i += 1) {
+    if (address[i]! !== network[i]!) return false;
+  }
+  const remainingBits = prefixLength % 16;
+  if (remainingBits === 0) return true;
+  const mask = (0xffff << (16 - remainingBits)) & 0xffff;
+  return (address[fullGroups]! & mask) === (network[fullGroups]! & mask);
+}
+
+function isCloudflareProxyIp(value: string): boolean {
+  const ipv4 = parseIpv4(value);
+  if (ipv4 !== null) {
+    return CLOUDFLARE_IPV4_RANGES.some(([network, prefix]) => isInIpv4Range(ipv4, network, prefix));
+  }
+  const ipv6 = parseIpv6(value);
+  return ipv6 !== null
+    && CLOUDFLARE_IPV6_RANGES.some(([network, prefix]) => isInIpv6Range(ipv6, network, prefix));
+}
+
 // Compare the edge-proof secret without an early exit on length mismatch.
 // Synchronous so getClientIp stays sync (per-request rate-limit hot path,
 // several non-awaiting callers). Keep in sync with api/_client-ip.js.
@@ -44,17 +154,35 @@ export function hasCloudflareTransitProof(request: Request): boolean {
 // One-per-isolate warning that the edge-proof is not matching, so a missing
 // CF_EDGE_PROOF_SECRET or a Cloudflare rule that stopped covering this route
 // cannot regress silently. The dangerous state is cf-connecting-ip PRESENT
-// (the request really did transit Cloudflare) but the x-wm-edge-proof header
-// absent or mismatched: getClientIp then falls back to x-real-ip, which
-// Vercel sets to its peer — the Cloudflare PoP — so every user behind that
-// PoP shares one rate-limit bucket and per-IP budgets look enforced but are
-// not (issue #6431). Keep this dependency-free: this module is in the static
-// import closure of Railway seeders that install no npm packages (#5229), so
-// no Sentry/logger import and no npm specifier may be added here.
-let edgeProofMismatchWarned = false;
+// and x-real-ip in Cloudflare's proxy ranges, but the x-wm-edge-proof header
+// absent or mismatched. Direct-origin spoofs with non-CF peers must not warn
+// or consume the latch. Keep this dependency-free: this module is in the
+// static import closure of Railway seeders that install no npm packages
+// (#5229), so no Sentry/logger import and no npm specifier may be added here.
+// Symbol.for gives both mirror modules one collision-resistant, isolate-wide
+// latch even when both are loaded together.
+const EDGE_PROOF_MISMATCH_LATCH = Symbol.for(
+  'worldmonitor.client-ip.edge-proof-mismatch-warning.v1',
+);
+
+interface EdgeProofMismatchLatch {
+  warned: boolean;
+}
+
+function getEdgeProofMismatchLatch(): EdgeProofMismatchLatch {
+  const existing = Reflect.get(globalThis, EDGE_PROOF_MISMATCH_LATCH) as
+    | EdgeProofMismatchLatch
+    | undefined;
+  if (existing) return existing;
+  const latch = { warned: false };
+  Reflect.set(globalThis, EDGE_PROOF_MISMATCH_LATCH, latch);
+  return latch;
+}
+
 export function warnEdgeProofNotProving(): void {
-  if (edgeProofMismatchWarned) return;
-  edgeProofMismatchWarned = true;
+  const latch = getEdgeProofMismatchLatch();
+  if (latch.warned) return;
+  latch.warned = true;
   // One line, greppable in Vercel logs; not a per-request log. Follows the
   // rate-limit degraded-mode console.error precedent (server/_shared/rate-limit.ts).
   console.warn(
@@ -62,13 +190,11 @@ export function warnEdgeProofNotProving(): void {
   );
 }
 
-// Test seam: the warn-once flag is module state, so a suite that exercises the
-// warning in one test must be able to reset it for the next. Real isolates
-// never call this — a fresh isolate starts with the flag clear, which is
-// exactly what the once-per-isolate contract needs. Mirrors the
+// Test seam for the shared isolate-wide latch. Real isolates never call this;
+// a fresh isolate starts with the latch clear. Mirrors the
 // resetRateLimitFallbackForTest pattern.
 export function resetEdgeProofMismatchWarnedForTest(): void {
-  edgeProofMismatchWarned = false;
+  getEdgeProofMismatchLatch().warned = false;
 }
 
 export function getClientIp(request: Request): string {
@@ -86,11 +212,10 @@ export function getClientIp(request: Request): string {
   const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
   const xr = (request.headers.get('x-real-ip') ?? '').trim();
   if (cf && hasCloudflareTransitProof(request)) return cf;
-  // The precise "looks enforced but is shared" state (#6431): the request
-  // really did transit Cloudflare (cf-connecting-ip present and real) but
-  // proof of CF transit is missing, so the user just joined the PoP-shared
-  // x-real-ip bucket. Warn once per isolate so a rule/secret regression
-  // surfaces in logs without spamming them.
-  if (cf) warnEdgeProofNotProving();
+  // The precise "looks enforced but is shared" state (#6431): an unproven
+  // cf-connecting-ip arrived from a Cloudflare peer, so the user just joined
+  // the PoP-shared x-real-ip bucket. A non-CF peer is a direct-origin spoof;
+  // it must neither warn nor consume the shared latch.
+  if (cf && isCloudflareProxyIp(xr)) warnEdgeProofNotProving();
   return xr || UNKNOWN_CLIENT_IP;
 }

--- a/server/_shared/client-ip.ts
+++ b/server/_shared/client-ip.ts
@@ -41,6 +41,36 @@ export function hasCloudflareTransitProof(request: Request): boolean {
   return constantTimeEqual((request.headers.get(CF_EDGE_PROOF_HEADER) ?? '').trim(), secret);
 }
 
+// One-per-isolate warning that the edge-proof is not matching, so a missing
+// CF_EDGE_PROOF_SECRET or a Cloudflare rule that stopped covering this route
+// cannot regress silently. The dangerous state is cf-connecting-ip PRESENT
+// (the request really did transit Cloudflare) but the x-wm-edge-proof header
+// absent or mismatched: getClientIp then falls back to x-real-ip, which
+// Vercel sets to its peer — the Cloudflare PoP — so every user behind that
+// PoP shares one rate-limit bucket and per-IP budgets look enforced but are
+// not (issue #6431). Keep this dependency-free: this module is in the static
+// import closure of Railway seeders that install no npm packages (#5229), so
+// no Sentry/logger import and no npm specifier may be added here.
+let edgeProofMismatchWarned = false;
+export function warnEdgeProofNotProving(): void {
+  if (edgeProofMismatchWarned) return;
+  edgeProofMismatchWarned = true;
+  // One line, greppable in Vercel logs; not a per-request log. Follows the
+  // rate-limit degraded-mode console.error precedent (server/_shared/rate-limit.ts).
+  console.warn(
+    '[client-ip] cf-connecting-ip present but x-wm-edge-proof missing/mismatched — rate-limit buckets keyed by Cloudflare PoP (x-real-ip), not per user. Fix CF_EDGE_PROOF_SECRET or the Cloudflare header transform rule. Issue #6431',
+  );
+}
+
+// Test seam: the warn-once flag is module state, so a suite that exercises the
+// warning in one test must be able to reset it for the next. Real isolates
+// never call this — a fresh isolate starts with the flag clear, which is
+// exactly what the once-per-isolate contract needs. Mirrors the
+// resetRateLimitFallbackForTest pattern.
+export function resetEdgeProofMismatchWarnedForTest(): void {
+  edgeProofMismatchWarned = false;
+}
+
 export function getClientIp(request: Request): string {
   // cf-connecting-ip is only unforgeable for traffic that actually transited
   // Cloudflare (x-real-ip is then the CF edge IP, shared across users). On a
@@ -56,5 +86,11 @@ export function getClientIp(request: Request): string {
   const cf = (request.headers.get('cf-connecting-ip') ?? '').trim();
   const xr = (request.headers.get('x-real-ip') ?? '').trim();
   if (cf && hasCloudflareTransitProof(request)) return cf;
+  // The precise "looks enforced but is shared" state (#6431): the request
+  // really did transit Cloudflare (cf-connecting-ip present and real) but
+  // proof of CF transit is missing, so the user just joined the PoP-shared
+  // x-real-ip bucket. Warn once per isolate so a rule/secret regression
+  // surfaces in logs without spamming them.
+  if (cf) warnEdgeProofNotProving();
   return xr || UNKNOWN_CLIENT_IP;
 }

--- a/tests/client-ip.test.mts
+++ b/tests/client-ip.test.mts
@@ -1,8 +1,24 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { describe, it, afterEach } from 'node:test';
 
-import { getClientIp as getServerClientIp } from '../server/_shared/client-ip.ts';
-import { getClientIp as getApiClientIp } from '../api/_client-ip.js';
+import {
+  getClientIp as getServerClientIp,
+  resetEdgeProofMismatchWarnedForTest as resetServer,
+} from '../server/_shared/client-ip.ts';
+import {
+  getClientIp as getApiClientIp,
+  resetEdgeProofMismatchWarnedForTest as resetApi,
+} from '../api/_client-ip.js';
+
+let originalWarn: typeof console.warn | null = null;
+
+afterEach(() => {
+  if (originalWarn !== null) {
+    console.warn = originalWarn;
+    originalWarn = null;
+  }
+  delete process.env.CF_EDGE_PROOF_SECRET;
+});
 
 function makeRequest(proof: string): Request {
   return new Request('https://worldmonitor.app/api/test', {
@@ -74,6 +90,56 @@ describe('client-IP edge-proof comparison (#5239)', () => {
     } finally {
       if (originalSecret == null) delete process.env.CF_EDGE_PROOF_SECRET;
       else process.env.CF_EDGE_PROOF_SECRET = originalSecret;
+    }
+  });
+});
+
+describe('client-IP proof-mismatch canary (#6431)', () => {
+  it('warns once per isolate when cf-connecting-ip is present but the proof is absent or mismatched', () => {
+    for (const { getClientIp, reset } of [
+      { getClientIp: getServerClientIp, reset: resetServer },
+      { getClientIp: getApiClientIp, reset: resetApi },
+    ]) {
+      let warnings = 0;
+      originalWarn = console.warn;
+      console.warn = () => { warnings += 1; };
+      try {
+        reset();
+        process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+        // Miss: secret configured, header absent.
+        getClientIp(makeRequest(''));
+        assert.ok(warnings >= 1, 'must warn when proof header is absent');
+        // Miss: secret configured, header mismatched.
+        getClientIp(makeRequest('wrong'));
+        getClientIp(makeRequest('edge-secret-xyz-with-extra'));
+        // warn-once: still exactly one warning for the whole isolate.
+        assert.equal(warnings, 1, 'must warn exactly once per isolate');
+      } finally {
+        console.warn = originalWarn;
+        originalWarn = null;
+        delete process.env.CF_EDGE_PROOF_SECRET;
+      }
+    }
+  });
+
+  it('does not warn when the proof matches (normal transit)', () => {
+    for (const { getClientIp, reset } of [
+      { getClientIp: getServerClientIp, reset: resetServer },
+      { getClientIp: getApiClientIp, reset: resetApi },
+    ]) {
+      let warnings = 0;
+      originalWarn = console.warn;
+      console.warn = () => { warnings += 1; };
+      try {
+        reset();
+        process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+        getClientIp(makeRequest('edge-secret-xyz'));
+        assert.equal(warnings, 0, 'must not warn when proof matches');
+      } finally {
+        console.warn = originalWarn;
+        originalWarn = null;
+        delete process.env.CF_EDGE_PROOF_SECRET;
+      }
     }
   });
 });

--- a/tests/client-ip.test.mts
+++ b/tests/client-ip.test.mts
@@ -20,11 +20,11 @@ afterEach(() => {
   delete process.env.CF_EDGE_PROOF_SECRET;
 });
 
-function makeRequest(proof: string): Request {
+function makeRequest(proof: string, xRealIp = '192.0.2.5'): Request {
   return new Request('https://worldmonitor.app/api/test', {
     headers: {
       'cf-connecting-ip': '203.0.113.7',
-      'x-real-ip': '192.0.2.5',
+      'x-real-ip': xRealIp,
       'x-wm-edge-proof': proof,
     },
   });
@@ -95,31 +95,66 @@ describe('client-IP edge-proof comparison (#5239)', () => {
 });
 
 describe('client-IP proof-mismatch canary (#6431)', () => {
-  it('warns once per isolate when cf-connecting-ip is present but the proof is absent or mismatched', () => {
-    for (const { getClientIp, reset } of [
-      { getClientIp: getServerClientIp, reset: resetServer },
-      { getClientIp: getApiClientIp, reset: resetApi },
-    ]) {
-      let warnings = 0;
-      originalWarn = console.warn;
-      console.warn = () => { warnings += 1; };
-      try {
-        reset();
-        process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
-        // Miss: secret configured, header absent.
-        getClientIp(makeRequest(''));
-        assert.ok(warnings >= 1, 'must warn when proof header is absent');
-        // Miss: secret configured, header mismatched.
-        getClientIp(makeRequest('wrong'));
-        getClientIp(makeRequest('edge-secret-xyz-with-extra'));
-        // warn-once: still exactly one warning for the whole isolate.
-        assert.equal(warnings, 1, 'must warn exactly once per isolate');
-      } finally {
-        console.warn = originalWarn;
-        originalWarn = null;
-        delete process.env.CF_EDGE_PROOF_SECRET;
+  it('does not warn or consume the latch for a direct-origin spoof', () => {
+    let warnings = 0;
+    originalWarn = console.warn;
+    console.warn = () => { warnings += 1; };
+    resetServer();
+    process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+
+    assert.equal(getServerClientIp(makeRequest('wrong')), '192.0.2.5');
+    assert.equal(getApiClientIp(makeRequest('', '203.0.113.10')), '203.0.113.10');
+    assert.equal(warnings, 0, 'a non-Cloudflare peer must not warn');
+
+    assert.equal(getApiClientIp(makeRequest('wrong', '173.245.48.1')), '173.245.48.1');
+    assert.equal(warnings, 1, 'a later Cloudflare peer mismatch must still warn');
+  });
+
+  it('recognizes official Cloudflare IPv4 and IPv6 peers in both mirrors', () => {
+    let warnings = 0;
+    originalWarn = console.warn;
+    console.warn = () => { warnings += 1; };
+    process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+
+    for (const getClientIp of [getServerClientIp, getApiClientIp]) {
+      for (const peerIp of ['173.245.48.1', '2606:4700::1111']) {
+        resetServer();
+        assert.equal(getClientIp(makeRequest('wrong', peerIp)), peerIp);
+        assert.equal(warnings, 1, `${peerIp} must trigger the mismatch canary`);
+        warnings = 0;
       }
     }
+  });
+
+  it('warns for a Cloudflare peer when the proof secret is unset', () => {
+    let warnings = 0;
+    originalWarn = console.warn;
+    console.warn = () => { warnings += 1; };
+    resetServer();
+    delete process.env.CF_EDGE_PROOF_SECRET;
+
+    assert.equal(getApiClientIp(makeRequest('', '173.245.48.1')), '173.245.48.1');
+    assert.equal(warnings, 1, 'an unset deployment secret must trigger the canary');
+  });
+
+  it('shares one warning latch and reset seam across both mirrors', () => {
+    let warnings = 0;
+    originalWarn = console.warn;
+    console.warn = () => { warnings += 1; };
+    process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
+
+    resetServer();
+    getServerClientIp(makeRequest('', '173.245.48.1'));
+    getApiClientIp(makeRequest('wrong', '173.245.48.2'));
+    assert.equal(warnings, 1, 'both mirrors must share one isolate-wide warning');
+
+    resetApi();
+    getServerClientIp(makeRequest('wrong', '173.245.48.3'));
+    assert.equal(warnings, 2, 'the API reset seam must reset the shared latch');
+
+    resetServer();
+    getApiClientIp(makeRequest('wrong', '173.245.48.4'));
+    assert.equal(warnings, 3, 'the server reset seam must reset the shared latch');
   });
 
   it('does not warn when the proof matches (normal transit)', () => {


### PR DESCRIPTION
## Closes #6431

Follow-up to #6412 (merged), which narrowed three public proxies to strict per-IP budgets (30/60 per minute). Those budgets are only per-*user* if `getClientIp` resolves the real client IP — which requires the Cloudflare edge-proof to be in place.

### Verification (dashboard evidence, not repo-inferable)

**1. `CF_EDGE_PROOF_SECRET` is set in Vercel** — `vercel env ls` on `eliewm/worldmonitor`: **Encrypted, Production AND Preview**, created 37d ago (spans #6412).

**2. Cloudflare Transform Rule covers `/api/*`** — zone `worldmonitor.app`, ruleset `http_request_late_transform`:
- Action `rewrite` sets `x-wm-edge-proof` to the secret
- Expression `"true"` (matches ALL paths incl. every `/api/*`) — broader than needed but safe
- Enabled, last updated 2026-07-04

**3. Proof is matching in production** — Axiom `wm_api_usage`: `deriveCountry` uses `cf-ipcountry` only when `hasCloudflareTransitProof` is true, and the affected routes show genuinely diverse real-user countries (13 distinct on reverse-geocode, 11 on youtube-live): NL, DE, IR, MR, US, FR, PL, BR, TR, JP, UG... That diversity is impossible under PoP-keyed buckets. **The 30/60 budgets are shared per user, not per PoP.**

### Change: runtime canary (acceptance item 4)

One-per-isolate `console.warn` in both mirrors (`server/_shared/client-ip.ts`, `api/_client-ip.js`) firing in the exact "looks enforced but is shared" state: `cf-connecting-ip` present but `x-wm-edge-proof` missing/mismatched → `getClientIp` falls back to `x-real-ip` (Vercel's peer = the Cloudflare PoP) → every user behind that PoP shares one bucket. Greppable in Vercel logs so a missing secret or a rule that stopped covering a route can no longer regress silently.

- **Dependency-free by design**: `client-ip.ts` is in the Railway seeder static import closure (#5229), enforced by `tests/resilience-validation-import-graph.test.mjs` — plain `console.warn`, no Sentry/logger import.
- Test reset seam (`resetEdgeProofMismatchWarnedForTest`) because the warn-once flag is module state.
- Tests: warn-once on absent/mismatched proof + no-warn on match, both copies.

### Validation
- `tests/client-ip.test.mts` (4 pass), `rate-limit`, `turnstile`, `usage-telemetry-emission`, `resilience-validation-import-graph` (72 + 24 + 20 pass)
- `npm run typecheck`, `typecheck:api` clean
- `node scripts/check-edge-function-bundles.mjs` — 49 entrypoints OK
- Pre-push gate: 250 tests, full checks green