### PR TITLE
fix(ingestion): rebuild GB consumer-price roster around scrapeable retailers (#6358)

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -330,7 +330,7 @@ Two properties keep the soft path from becoming a hole. It may fire only when th
 
 A dependency advisory the security gate knowingly tolerates, recorded per-lockfile with written reasoning for why the vulnerable path is unreachable in this project — typically a build-time-only or dev-tooling chain, or a fix that is semver-major on a parent the project cannot yet move.
 
-The baseline is an exemption list, not a suppression: an advisory outside it fails the gate for every branch at once, which is why a newly published advisory blocks the whole repository until someone either patches or baselines it. Each entry carries its justification inline so a later reader can re-evaluate rather than inherit a bare allowlist, and an entry that no longer matches any live advisory is surfaced as stale so the list does not accrete dead exemptions. See also: Third-Party Rot.
+The baseline is an exemption list, not a suppression: an advisory outside it fails the gate for every branch at once, which is why a newly published advisory blocks the whole repository until someone either patches or baselines it. Each entry carries its justification inline so a later reader can re-evaluate rather than inherit a bare allowlist, and an entry that no longer matches any live advisory is surfaced as stale so the list does not accrete dead exemptions. See also: Third-Party Rot, Acceptance Baseline.
 
 ## Localization & First Paint
 
@@ -379,6 +379,36 @@ The band a request falls into under an upstream's cost function, where cost is a
 A source in an ordered chain that is queried regardless of whether an earlier source already succeeded, as distinct from a fallback entered only on the failure of the tier above it. The condition is not observable from published data — the publication is fresh and correctly attributed to the primary either way — so it must be looked for in the call path rather than inferred from output.
 
 Whether it is a defect depends on what the tier does with its results. A tier whose results *replace* the primary's adds nothing when the primary succeeded, so on a metered upstream it spends budget for no marginal records and should be gated. A tier whose results *merge* into the primary's is contributing coverage, and gating it trades that coverage away — dangerously so, because a degraded-but-non-empty primary satisfies a success-gate and suppresses the merging tier precisely when its coverage matters most. For a merging tier the correct remedy is to reduce its cost rather than to stop calling it. See also: Credit Budget, Cost Tier, Theater Posture, Publication Source.
+
+## Consumer Prices Ingestion
+
+### Retailer Roster
+
+The set of enabled retailer configurations for one market. The market's coverage denominator is the pages its roster plans, so roster membership — not scrape tuning — is the operational lever when a retailer's domain becomes unscrapeable to every acquisition provider.
+
+A retailer enters or leaves the roster by flipping its declared enablement; a disabled retailer keeps its configuration and its recorded disable evidence so re-admission starts from the prior verdict rather than a fresh diagnosis (and that evidence goes stale — re-probe before trusting it). Onboarding requires probing every acquisition provider against the retailer's domain first: a retailer only one provider can reach carries a single point of failure from day one. See also: Market Completion Floor.
+
+### Market Completion Floor
+
+The declared minimum share of planned pages a market's scrape must complete for the market to stay operationally healthy; below the floor the market grades degraded rather than merely noisy.
+
+The floor governs the market aggregate, not individual retailers — one retailer can fail outright without degrading the market so long as the remaining roster keeps the completion ratio above the floor. Roster size is therefore floor headroom: the roster should survive the outright loss of any single retailer. See also: Retailer Roster.
+
+### Auto Match
+
+A scraped product accepted for aggregation: validation bound the retailer product to a basket item confidently enough that its price is aggregate-eligible without review.
+
+### Candidate Match
+
+A scraped product admitted with doubt: recorded for later review but excluded from aggregates. A page can scrape successfully yet yield only a candidate match, so page-level success and aggregate eligibility diverge — coverage built on page counts alone can read healthy while contributing no usable prices. Strict validation closes the gap by rejecting the doubtful product and trying the next candidate page instead of admitting the doubt. See also: Auto Match, Market Completion Floor.
+
+## Ingestion Acceptance
+
+### Acceptance Baseline
+
+The accepted-problem list the ingestion acceptance gate consults: each entry acknowledges one known degradation, identified by exactly its source and status, and owned by an open tracking issue.
+
+Matching is exact by design. A source that recovers surfaces its entry as a prune prompt; a source that worsens to a different status escalates and blocks, because a suppression written for a lesser state must not cover a worse one. The list as a whole carries an expiry that forces re-review, and an acknowledgement is never added for a status whose remediation is still in flight — the gate exists to verify the remediation, not to trust it. See also: Baselined Advisory.
 
 ## Desktop Distribution
 

--- a/consumer-prices-core/configs/retailers/morrisons_gb.yaml
+++ b/consumer-prices-core/configs/retailers/morrisons_gb.yaml
@@ -1,0 +1,31 @@
+retailer:
+  slug: morrisons_gb
+  name: Morrisons UK
+  marketCode: gb
+  currencyCode: GBP
+  adapter: search
+  # added 2026-08-10 (#6358) replacing the anti-bot-blocked tesco_gb. Probed live:
+  # Exa discovery ranks exact-match /products/ pages first and Firecrawl extraction
+  # returns priced, in-stock renders (~13k chars markdown).
+  baseUrl: https://groceries.morrisons.com
+  enabled: true
+
+  searchConfig:
+    numResults: 5
+    urlPathContains: /products/
+    queryTemplate: "{canonicalName} grocery {market} {currency} price"
+    # Strict from day one (like jiomart_in): the 2026-08-10 shadow-mode probe
+    # accepted Kohinoor 10kg basmati for the 1kg item and 2L oil for 1L —
+    # counted as succeeded pages while their candidate matches never enter
+    # aggregates. Strict rejects wrong sizes and tries the next candidate URL.
+    requireStrictValidator: true
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []

--- a/consumer-prices-core/configs/retailers/tesco_gb.yaml
+++ b/consumer-prices-core/configs/retailers/tesco_gb.yaml
@@ -5,7 +5,15 @@ retailer:
   currencyCode: GBP
   adapter: search
   baseUrl: https://www.tesco.com
-  enabled: true
+  # disabled 2026-08-10 (#6358): tesco.com blocks every acquisition route we have.
+  # Firecrawl /v1/scrape returns HTTP 500 SCRAPE_ALL_ENGINES_FAILED on every engine
+  # (index, chrome-cdp, retry — and the stealth proxy tier, probed live 2026-08-10),
+  # and Exa's crawler stores no page content for tesco.com product URLs (163-char
+  # shells, price=null), so the exa extraction fallback cannot help either.
+  # Production runs: 1/12 pages on 2026-08-09, 0/12 on 2026-08-10 — the retailer
+  # dragged GB below the 0.5 market completion floor (COVERAGE_DEGRADED).
+  # Replaced by morrisons_gb + waitrose_gb. Re-probe both providers before re-enabling.
+  enabled: false
 
   searchConfig:
     numResults: 5

--- a/consumer-prices-core/configs/retailers/waitrose_gb.yaml
+++ b/consumer-prices-core/configs/retailers/waitrose_gb.yaml
@@ -1,0 +1,43 @@
+retailer:
+  slug: waitrose_gb
+  name: Waitrose UK
+  marketCode: gb
+  currencyCode: GBP
+  adapter: search
+  # added 2026-08-10 (#6358) replacing the anti-bot-blocked tesco_gb. Probed live:
+  # Exa discovery ranks exact-match /ecom/products/ pages first and Firecrawl
+  # extraction returns priced, in-stock renders. Third roster member adds
+  # single-retailer-loss headroom: on the 2026-08-10 measured baselines
+  # (ocado 11/12, morrisons 11/12, waitrose 8/12) losing one retailer outright
+  # leaves 19/36 = 0.53 -- above the 0.5 floor, but thinly; treat a second
+  # simultaneously-degraded retailer as a page-worthy event, not noise.
+  baseUrl: https://www.waitrose.com
+  enabled: true
+
+  searchConfig:
+    # Exa's neural ranking on waitrose.com drifts to adjacent products (sugar →
+    # bread flour, eggs → pork mince; 6/12 pages on the 2026-08-10 baseline run)
+    # while keyword search returns the exact product for the same queries
+    # (sugar/eggs/oil/cheddar all recovered, probed 2026-08-10). Same failure
+    # shape and fix as jiomart_in. Search wide, extract from at most 4.
+    numResults: 10
+    searchType: keyword
+    maxExtractionCandidates: 4
+    urlPathContains: /ecom/products/
+    queryTemplate: "{canonicalName} grocery {market} {currency} price"
+    # Strict from day one (like jiomart_in): shadow mode counts a wrong-size
+    # accept (Evian 12x330ml for "Still Water 6x1.5L" on the 2026-08-10 probe)
+    # toward pagesSucceeded while aggregate.ts excludes its candidate match —
+    # coverage would read healthy without adding usable prices. Strict rejects
+    # it and escalates to the next candidate URL instead.
+    requireStrictValidator: true
+
+  rateLimit:
+    requestsPerMinute: 10
+    maxConcurrency: 1
+    delayBetweenRequestsMs: 6000
+
+  discovery:
+    mode: search
+    maxPages: 20
+    seeds: []

--- a/consumer-prices-core/src/config/loader.test.ts
+++ b/consumer-prices-core/src/config/loader.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Real-config parse gate (#6358 review).
+ *
+ * Every other test that touches the config layer mocks loadAllRetailerConfigs,
+ * so before this file nothing in CI parsed the actual configs/retailers/*.yaml
+ * directory through the zod schema. scrape.ts and publish.ts call the real
+ * loader with no try/catch around it — a config that fails to parse would pass
+ * CI green and then crash the whole scrape/publish job for all markets in
+ * production. This suite pins only structural loadability; every ops-tunable
+ * value (numResults, delays, queryTemplate, searchType, enabled) stays free.
+ */
+import { describe, expect, it } from 'vitest';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { loadAllBasketConfigs, loadAllRetailerConfigs } from './loader.js';
+
+const RETAILERS_DIR = join(import.meta.dirname, '..', '..', 'configs', 'retailers');
+
+describe('retailer config directory', () => {
+  it('parses every configs/retailers/*.yaml through the schema without throwing', () => {
+    const configs = loadAllRetailerConfigs();
+    const yamlFiles = readdirSync(RETAILERS_DIR).filter((f) => f.endsWith('.yaml'));
+    expect(configs.length).toBe(yamlFiles.length);
+  });
+
+  it('gives every config a slug matching its filename', () => {
+    for (const config of loadAllRetailerConfigs()) {
+      // panda_sa.yaml must declare slug panda_sa — a copy-paste slug points
+      // pins, coverage rows, and scrape-run attribution at the wrong retailer.
+      expect(`${config.slug}.yaml`).toBe(
+        readdirSync(RETAILERS_DIR).find((f) => f === `${config.slug}.yaml`),
+      );
+    }
+  });
+
+  it('has no duplicate slugs', () => {
+    const slugs = loadAllRetailerConfigs().map((c) => c.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('parses every basket config and keeps each market non-empty for enabled retailers', () => {
+    const baskets = loadAllBasketConfigs();
+    expect(baskets.length).toBeGreaterThan(0);
+    // Every market with at least one ENABLED retailer must have a basket to
+    // scrape — an enabled retailer with no basket silently yields 0 targets.
+    const basketMarkets = new Set(baskets.map((b) => b.marketCode));
+    for (const config of loadAllRetailerConfigs().filter((c) => c.enabled)) {
+      expect(basketMarkets, `enabled retailer ${config.slug} has no basket for market ${config.marketCode}`).toContain(
+        config.marketCode,
+      );
+    }
+  });
+});

--- a/docs/solutions/integration-issues/gb-tesco-anti-bot-blocked-both-scrape-and-fallback-providers.md
+++ b/docs/solutions/integration-issues/gb-tesco-anti-bot-blocked-both-scrape-and-fallback-providers.md
@@ -1,0 +1,98 @@
+---
+title: "tesco.com anti-bot block starves GB consumer-prices coverage — fix the roster, not the configs"
+module: consumer-prices-core ingestion
+date: 2026-08-10
+category: integration-issues
+problem_type: integration_issue
+component: background_job
+severity: high
+symptoms:
+  - "GB consumer-price coverage dropped to COVERAGE_DEGRADED: tesco_gb read 1/12 pages on 2026-08-09 and 0/12 on 2026-08-10, failure reasons {provider-cooldown: 9, provider-error: 3}"
+  - "Firecrawl /v1/scrape returned HTTP 500 SCRAPE_ALL_ENGINES_FAILED on every engine (index, chrome-cdp, retry, stealth proxy) for tesco.com"
+  - "Exa's crawler stored no page content for tesco.com product URLs — 163-char shells with price null — so the exa extraction fallback was equally dead"
+  - "ocado_gb stayed healthy in the same runs, proving the provider accounts were fine and the blockage was domain-specific to tesco.com"
+root_cause: missing_validation
+resolution_type: seed_data_update
+related_components: [service_object, testing_framework]
+tags: [consumer-prices, retailer-roster, firecrawl, exa, anti-bot, fallback-independence, coverage-degraded, coverage-floor, seed-freshness, gb]
+---
+
+# tesco.com anti-bot block starves GB consumer-prices coverage — fix the roster, not the configs
+
+## Problem
+
+The GB consumer-prices market fell below its coverage floor and blocked the ingestion acceptance gate: `consumerPricesCoverageGB` escalated from its baselined `COVERAGE_PARTIAL` to `COVERAGE_DEGRADED` (records=2), because tesco.com had started blocking every acquisition route we have — both Firecrawl and Exa — so the tesco_gb retailer contributed nothing while still occupying a third of the GB roster's page budget. The fix was roster surgery (disable tesco_gb, onboard probed replacements morrisons_gb and waitrose_gb), shipped in PR #6442 (issue #6358; the PR is open, not yet merged, as of this writing).
+
+## Symptoms
+
+- Seed Freshness Monitor / ingestion acceptance gate red on `consumerPricesCoverageGB=COVERAGE_DEGRADED`, an escalation past the baselined `COVERAGE_PARTIAL` entry (`scripts/seed-freshness-baseline.json:40-45`). The health classifier grades a market degraded when its completion ratio drops below the floor (`api/health.js:1796-1812`), `MIN_MARKET_COMPLETION_RATIO = 0.5` (`consumer-prices-core/src/ops/coverage.ts:13`).
+- tesco_gb page counts: 1/12 on 2026-08-09, then 0/12 on 2026-08-10, with failure reasons `{provider-cooldown: 9, provider-error: 3}`.
+- Railway scrape logs: every `provider-error` detail was `Firecrawl extract failed: HTTP 500` (the thrown non-OK path in `consumer-prices-core/src/acquisition/firecrawl.ts:157`) for tesco.com URLs across both days, on both the pin path and the discovery path — while ocado_gb extractions in the SAME runs succeeded. Account healthy; block is domain-specific.
+- The 9 `provider-cooldown` entries were not a client bug (the issue's initial hypothesis was a client-side backoff defect). They are the half-open cooldown gate doing its job against a hard-down route: two consecutive transport failures open the gate, the next 4 attempts are skipped without a network call, then one probe is allowed through (`consumer-prices-core/src/adapters/provider-cooldown.ts:21-67`); each skipped attempt is recorded as a `provider-cooldown` failure (`consumer-prices-core/src/adapters/search.ts:440-443`).
+
+## What Didn't Work
+
+- **`extractionFallback: exa`** — probed *before* configuring it, and correctly rejected. Exa's crawl of tesco.com has no page content (see the live probe below): the fallback would only convert `provider-error` into `missing-price`, because the fallback shares the blocked resource — the target site itself, not the provider — with the primary. This is the standing "a fallback sharing an upstream is not a fallback" lesson, instantiated: `search.ts:434-435` would happily push `exa` as a second provider, and it would fail for the same upstream reason every time.
+- **Firecrawl's stealth proxy tier** — probed live with `proxy: "stealth"` and again with `proxy` + `location: GB`: same HTTP 500 `SCRAPE_ALL_ENGINES_FAILED`, now through `fire-engine;chrome-cdp;stealth`. The block outranks Firecrawl's best evasion tier.
+- **Re-enabling sainsburys_gb** — its disable note ("disabled 2026-03: Exa returns 'no pages found'", `consumer-prices-core/configs/retailers/sainsburys_gb.yaml:8`) is stale: discovery NOW works. But Firecrawl extraction still returns an empty ~2.5k-char shell (no product name, no price), so it cannot rejoin the roster. Stale disable notes cut both ways: the recorded reason was wrong, and yet the disable was still correct for a different reason.
+
+## Solution
+
+**1. Fingerprint the block with live probes that mirror the production request bodies.** Both probes reuse the exact shapes the adapters send, so the verdict is the seeder's verdict, not a reimplementation's:
+
+```
+# Firecrawl — mirrors FirecrawlProvider.extract() (firecrawl.ts:140-155)
+POST https://api.firecrawl.dev/v1/scrape
+{ "url": "<tesco.com product URL>", "formats": ["extract","markdown"],
+  "extract": { "schema": ..., "prompt": ... }, "timeout": 30000 }
+-> HTTP 500 SCRAPE_ALL_ENGINES_FAILED, engines tried [index, chrome-cdp, retry]
+-> retried with "proxy": "stealth" (and proxy + GB location): same, via fire-engine;chrome-cdp;stealth
+
+# Exa — mirrors ExaProvider.extract() (exa.ts:99-103)
+POST https://api.exa.ai/contents
+{ "urls": ["<same tesco.com URL>"], "summary": { "query": ..., "schema": ... },
+  "text": { "maxCharacters": 30000 } }
+-> HTTP 200, but 163 chars of stored text, price null (Exa's crawler has no content for the domain)
+
+# Control — Firecrawl on an ocado.com product URL -> HTTP 200
+```
+
+That trio — Firecrawl `SCRAPE_ALL_ENGINES_FAILED` including stealth, Exa `/contents` returning an empty text shell, a healthy control domain on the same account — is the fingerprint of an unscrapeable domain. No retailer-config tuning can fix it.
+
+**2. Roster surgery, probe-then-onboard.** For each GB grocer candidate, ran domain-restricted Exa discovery AND a Firecrawl extract on a discovered URL before writing any config: morrisons clean on both; waitrose clean; asda/iceland extraction OK but discovery noisy; sainsburys still extraction-blocked. Config diffs:
+
+- `consumer-prices-core/configs/retailers/tesco_gb.yaml` — `enabled: false`, with the evidence and re-probe instructions in the comment (lines 8-16) so a future session doesn't re-diagnose from scratch or blindly re-enable.
+- `consumer-prices-core/configs/retailers/morrisons_gb.yaml` — new, `requireStrictValidator: true` from day one.
+- `consumer-prices-core/configs/retailers/waitrose_gb.yaml` — new, `requireStrictValidator: true` plus `searchType: keyword` with `numResults: 10` / `maxExtractionCandidates: 4`: Exa's neural ranking drifts to adjacent products on waitrose.com (sugar query -> bread flour, eggs -> pork mince) while keyword search returns the exact product — the same failure shape and fix as `jiomart_in.yaml:19`.
+
+**3. Verified with the repo's own full-pipeline diagnostic** (`consumer-prices-core/src/adapters/extraction.diag.ts`, run with real creds per its header: `EXA_API_KEYS=... FIRECRAWL_API_KEY=... npx tsx src/adapters/extraction.diag.ts <slug>` — it drives the real SearchAdapter, so its verdict is the seeder's): morrisons 11/12 pages; waitrose 6/12 under neural -> 8/12 under keyword.
+
+**4. Review-round hardening (cross-model reviewers):**
+
+- **Strict validator on BOTH new retailers.** In shadow (non-strict) mode a wrong-size accept — Kohinoor 10kg basmati accepted for the 1kg item, Evian 12x330ml for "Still Water 6x1.5L" — still increments `pagesSucceeded` (`consumer-prices-core/src/jobs/scrape.ts:341`) while its match is stored `matchStatus: 'candidate'` (`scrape.ts:316-317,331`), which the aggregate query excludes (`match_status IN ('auto','approved')`, `consumer-prices-core/src/jobs/aggregate.ts:52`). Market coverage can therefore read healthy while contributing zero aggregate-eligible prices. Strict mode rejects the wrong size and escalates to the next candidate URL (the per-target loop at `search.ts:807`). Re-run diagnostics kept the same page counts with the wrong products self-correcting (10kg basmati -> Morrisons 1kg @ 1.79).
+- **Deliberately did NOT acknowledge COVERAGE_DEGRADED in `scripts/seed-freshness-baseline.json`.** Three independent reviewers of PR #6442 (cross-model Codex adversarial, in-process adversarial, correctness) converged on the same reasoning: acknowledging DEGRADED would keep the gate green even if this remediation failed (until the global `expiresAt`), while dropping the existing PARTIAL entry would re-red the monitor on mere transition noise. Keeping main's PARTIAL-only entry (`seed-freshness-baseline.json:40-45`) means DEGRADED keeps blocking until recovery is actually observed in production.
+- **New real-config parse gate** (`consumer-prices-core/src/config/loader.test.ts:20-52`): every other config-layer test mocks the loader, yet `scrape.ts`/`publish.ts` call the real one uncaught — before this test, a malformed retailer YAML would pass CI green and crash the whole scrape/publish job for all markets. The suite parses the actual `configs/retailers/*.yaml` directory through the zod schema, pins slug-filename agreement, and checks every enabled retailer's market has a basket.
+
+**5. Roster math.** Measured baselines: ocado 11/12 + morrisons 11/12 + waitrose 8/12 = 30/36 = 0.83, comfortably above the 0.5 floor (`coverage.ts:13`). Worst-case single-retailer death: 19/36 = 0.53 — survivable but thin, which is why GB now carries three retailers instead of two, and why a second simultaneously-degraded GB retailer should be treated as a page-worthy event.
+
+## Why This Works
+
+The root cause was never in our client: tesco.com blocks the fetch infrastructure of *both* acquisition providers at the domain level, so every code-side lever — retry shape, cooldown tuning, extraction fallback, proxy tier — either re-asks the same blocked upstream or converts one failure label into another. The cooldown gate behaved exactly as designed for a hard-down route; the `extractionFallback` could not help because Exa and Firecrawl are different *fetchers* of the same blocked *site*, i.e. the fallback shares the failed upstream. The only variable actually under our control is which domains sit in the roster, so the durable fix is substituting scrapeable retailers — validated by probing both providers per domain *before* enabling the config, and measured through the production adapter path.
+
+The hardening makes the recovery honest rather than cosmetic: strict validation closes the gap where `pagesSucceeded` (the coverage numerator) and aggregate eligibility (`match_status IN ('auto','approved')`) can diverge, and leaving the DEGRADED status un-baselined means the gate only goes green when production runs prove the new roster works — the gate verifies the remediation instead of trusting it.
+
+## Prevention
+
+- **Learn the unscrapeable-domain fingerprint** and check it before onboarding or diagnosing any retailer: Firecrawl `SCRAPE_ALL_ENGINES_FAILED` including the stealth tier + Exa `/contents` returning empty text for the domain (with a healthy same-account control domain) = the domain is blocked. Fix the roster; do not tune configs.
+- **Probe BOTH providers per domain before enabling a retailer config** — domain-restricted Exa discovery and a Firecrawl extract on a discovered URL. A retailer that passes only one provider inherits a single point of failure on day one.
+- **`requireStrictValidator: true` from day one for new search-adapter retailers.** Shadow mode lets wrong-size accepts inflate `pagesSucceeded` while their candidate matches never reach aggregates — coverage that looks healthy and feeds nothing.
+- **Disable notes on retailer configs go stale — re-probe before trusting them** (sainsburys' 2026-03 note cited a discovery failure that no longer exists, while a different blocker did). Write disable notes with the evidence and explicit re-probe instructions, as done in `tesco_gb.yaml:8-16`.
+- **Never rebaseline a degraded status to clear a gate while its remediation is in flight.** Keep the pre-incident baseline entry; let the escalated status block until recovery is observed in production.
+- A structurally related exposure was flagged during the #6182 review round (session history): a fleet-wide loss of provider page content silently disables the anti-fabrication evidence gate while health stays green — the "no-content abstention" path. The tesco.com block is the single-domain version of that scenario; if a whole provider ever goes content-less, expect the same green-while-blind shape at fleet scale.
+
+## Related Issues
+
+- Issue #6358 (GB coverage degraded); fixed by PR #6442 (open, unmerged at the time of writing). Parent: #6355.
+- #6182 / #6185 — the half-open provider cooldown whose skip entries were initially misread as a client backoff bug (`consumer-prices-core/src/adapters/provider-cooldown.ts:1-19`), and the evidence-gate era of the same acquisition layer: `docs/solutions/design-patterns/evidence-gate-llm-extracted-values-bypass-classes.md` (prior chapter of this saga — internal fabrication defense vs this doc's external blocking).
+- Standing lesson: "a fallback sharing an upstream is not a fallback" — this incident is the canonical acquisition-provider instance.
+- `consumer-prices-core/configs/retailers/jiomart_in.yaml:11-26` — the searchType keyword precedent for Exa neural index drift.


### PR DESCRIPTION
## Summary

GB consumer-price coverage is the last blocker on the ingestion acceptance gate (#6358): `tesco_gb` scraped 0/12 pages on 2026-08-10 (1/12 on 2026-08-09), dragging GB to `COVERAGE_DEGRADED` (0.4583 < the 0.5 floor). Live probes confirm tesco.com now blocks **every acquisition route we have**: Firecrawl `/v1/scrape` returns HTTP 500 `SCRAPE_ALL_ENGINES_FAILED` on every engine — including the stealth proxy tier — and Exa's crawler stores no page content for tesco.com product URLs (163-char shells, `price: null`), so the `extractionFallback: exa` path cannot recover it either.

This PR rebuilds the GB roster around retailers that are actually scrapeable:

- **`tesco_gb` disabled** with the probe evidence and re-probe instructions in the config comment.
- **`morrisons_gb` added** — full-pipeline diagnostic (`extraction.diag.ts`, real credentials): **11/12 pages**, size-correct products.
- **`waitrose_gb` added** with `searchType: keyword` (Exa neural ranking drifts to adjacent products on waitrose.com — sugar → bread flour, eggs → pork mince; same failure shape and fix as `jiomart_in`) — diagnostic: **8/12 pages**.
- **`requireStrictValidator: true` on both new retailers** (review finding, cross-model corroborated): in shadow mode a wrong-size accept (10kg rice for the 1kg item, 12×330ml water for 6×1.5L) increments `pagesSucceeded` while its `candidate` match never enters aggregates — coverage could go green without adding usable prices. Strict rejects those and escalates to the next candidate URL; the re-run diagnostics confirmed the same page counts with wrong-size accepts self-correcting (Basmati 10kg → Morrisons 1kg @ 1.79, oil 2L → Flora 1L).
- **New `loader.test.ts`** (review finding, independently corroborated by two reviewers): nothing in CI parsed the real `configs/retailers/*.yaml` through the zod schema (every test mocks the loader), while `scrape.ts`/`publish.ts` call it uncaught — a malformed config would pass CI and crash every market's scrape in production. The test pins structural loadability only; ops-tunable values stay free.

**The seed-freshness baseline is deliberately untouched.** Three reviewers (cross-model Codex adversarial + in-process adversarial + correctness) converged on keeping main's `COVERAGE_PARTIAL` acknowledgement exactly as-is: acknowledging `COVERAGE_DEGRADED` would keep the gate green if this remediation itself fails (a 17-day blind window until the global `expiresAt`), while dropping the PARTIAL entry would re-red the monitor on ordinary transition noise. GB therefore keeps blocking the gate until the first post-deploy scrape proves recovery — matching #6358's own instruction: "Do not rebaseline COVERAGE_DEGRADED to clear the gate."

Roster math on measured baselines (ocado 11/12 + morrisons 11/12 + waitrose 8/12 = 30/36 = 0.83): GB grades healthy; losing any one retailer outright leaves 19/36 = 0.53, still above the floor — the single-retailer-death mode that caused this incident becomes survivable, though thinly (documented in the config comment).

## Validation

- Live provider probes (2026-08-10): Firecrawl 500 on tesco.com (all engines + stealth); Firecrawl 200 on ocado/morrisons/asda/waitrose/iceland; Exa `/contents` empty for tesco.com. Sainsbury's re-probed: discovery now works but extraction still returns an empty shell (config stays disabled).
- Full-pipeline diagnostics via the repo's `extraction.diag.ts` with production credentials, before and after strict mode: morrisons 11/12 → 11/12 (products improved), waitrose 6/12 (neural) → 8/12 (keyword, strict).
- `consumer-prices-core` suite: **264/264** (4 new).
- `tests/seed-freshness-monitor.test.mjs`: **23/23**; `tests/consumer-prices-coverage-rollout.test.mjs` + `tests/health-classify.test.mjs`: **130/130**.
- All 29 retailer configs parse through the real loader; GB enabled roster = `morrisons_gb, ocado_gb, waitrose_gb`.
- Live acceptance-gate run against production health with this tree: GB behaves as intended (blocking until recovery; note the gate currently also blocks on unrelated `jodiGas`/`jodiOil`/`lngVulnerability` STALE_SEED, tracked separately).
- Code review: 7-persona fleet + cross-model Codex adversarial pass. 2 P1 + 2 P2 findings, all applied and re-verified (strict validator, baseline revert, loader test); 3 duplicate/converging baseline findings resolved by the keep-main's-PARTIAL decision.

## Post-Deploy Monitoring & Validation

- **Logs (Railway `seed-consumer-prices`):** next canonical scrape (~02:10Z daily) — `[scrape] Run ... started for morrisons_gb`, `for waitrose_gb`; expect `[search:extract] ... price=` lines and no `[search:provider-cooldown]` streaks. `[scrape] ... finished: completed` (or `partial` with small counts) for both new retailers; `tesco_gb` must be absent.
- **Health:** `/api/health?compact=1` — `consumerPricesCoverageGB` should leave `problems` after the first post-deploy scrape/publish cycle (records=3). Full authenticated response: three GB retailers with per-retailer statuses; strict-mode `rejected_count` present but bounded.
- **Acceptance gate:** `node scripts/check-seed-freshness.mjs` — GB escalation line disappears; the `consumerPricesCoverageGB:COVERAGE_PARTIAL` baseline entry reports `recovered — prune it` once GB goes healthy: prune it and close #6358 then.
- **Expected healthy signal:** GB `completionRatio ≥ 0.75` with 3 retailers; aggregate publishes GBP prices from at least 2 retailers per basket item majority.
- **Failure signal / rollback trigger:** GB still `COVERAGE_DEGRADED` after two canonical cycles (roster fix failed — investigate morrisons/waitrose logs before considering revert); or `rejected_count` spikes to a majority of pages on either new retailer (strict validator too aggressive for a page shape — relax to shadow for that retailer only, with evidence).
- **Window and owner:** ingestion on-call through the next two scheduled freshness-monitor runs after the first post-deploy scrape.

## Known Residuals

- Title-plausibility can still pass a semantically wrong same-size product (observed once: a 400g "Mature Cheddar" *quiche* accepted for the 400g cheddar item on one Waitrose draw). Token+size validation cannot catch category errors; consider `negativeTokens: [quiche]` if it recurs in production.
- One-retailer-loss margin is thin (0.53 vs 0.5 floor) — documented in `waitrose_gb.yaml`; a second simultaneously-degraded retailer is a page-worthy event.
- `scripts/shared/grocery-basket.json` (separate legacy `seed-grocery-basket.mjs` pipeline) still lists `tesco.com` as a GB site — pre-existing, different health key; this PR's probe evidence suggests it contributes nothing there. Follow-up candidate.
- Provider behavior is probe-day truth: Exa ranking and Firecrawl fetchability can drift; the coverage alarm this PR answers is the designed detection for that.

Refs #6358

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Opus](https://img.shields.io/badge/Claude_Opus-D97757)

https://claude.ai/code/session_01NhYVgTRWCXmj7XXvnvBxjp
