### PR TITLE
fix(rate-limit): meter the gateway reverse-geocode RPC at 60/min

### DIFF
--- a/api/reverse-geocode.js
+++ b/api/reverse-geocode.js
@@ -76,15 +76,22 @@ export default async function handler(req, ctx) {
     }
 
     const data = await resp.json();
-    const country = data.address?.country;
-    const code = data.address?.country_code?.toUpperCase();
+    const country = data.address?.country || '';
+    const code = (data.address?.country_code || '').toUpperCase();
+    const displayName = data.display_name || country || '';
 
-    const result = { country: country || null, code: code || null, displayName: data.display_name || country || '' };
+    // Write unconditionally, matching the gateway RPC
+    // (server/worldmonitor/infrastructure/v1/reverse-geocode.ts): ocean and
+    // Antarctic cells must populate the shared geocode: cache, and a sweep of
+    // those cells is currently 100% Nominatim passthrough. The entry uses the
+    // RPC's exact shape ({country, code, displayName, error} as strings) —
+    // both handlers read the same 0.1-degree grid namespace (`geocode:lat,lon`,
+    // 604800 s TTL), so either may serve the other and a normalized `''` is
+    // indistinguishable from an ocean lookup either way. (#6432)
+    const result = { country, code, displayName, error: '' };
     const body = JSON.stringify(result);
 
-    if (country && code) {
-      ctx.waitUntil(setCachedData(cacheKey, result, 604800));
-    }
+    ctx.waitUntil(setCachedData(cacheKey, result, 604800));
 
     return new Response(body, {
       status: 200,

--- a/api/reverse-geocode.js
+++ b/api/reverse-geocode.js
@@ -16,6 +16,23 @@ const CHROME_UA = 'WorldMonitor/2.0 (https://worldmonitor.app)';
 const RATE_LIMIT_SCOPE = 'reverse-geocode';
 const RATE_LIMIT_PER_MINUTE = 60;
 
+function normalizeCacheEntry(entry) {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return null;
+  return {
+    country: typeof entry.country === 'string' ? entry.country : '',
+    code: typeof entry.code === 'string' ? entry.code : '',
+    displayName: typeof entry.displayName === 'string' ? entry.displayName : '',
+    error: '',
+  };
+}
+
+function getCacheKeyPrefix() {
+  const env = process.env.VERCEL_ENV;
+  if (!env || env === 'production') return '';
+  const sha = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 8) || 'dev';
+  return `${env}:${sha}:`;
+}
+
 export default async function handler(req, ctx) {
   if (isDisallowedOrigin(req))
     return new Response('Forbidden', { status: 403 });
@@ -48,9 +65,9 @@ export default async function handler(req, ctx) {
     return jsonResponse({ error: 'valid lat (-90..90) and lon (-180..180) required' }, 400, cors);
   }
 
-  const cacheKey = `geocode:${latN.toFixed(1)},${lonN.toFixed(1)}`;
+  const cacheKey = `${getCacheKeyPrefix()}geocode:${latN.toFixed(1)},${lonN.toFixed(1)}`;
 
-  const cached = await readJsonFromUpstash(cacheKey, 1500);
+  const cached = normalizeCacheEntry(await readJsonFromUpstash(cacheKey, 1500));
   if (cached) {
     return new Response(JSON.stringify(cached), {
       status: 200,
@@ -85,9 +102,10 @@ export default async function handler(req, ctx) {
     // Antarctic cells must populate the shared geocode: cache, and a sweep of
     // those cells is currently 100% Nominatim passthrough. The entry uses the
     // RPC's exact shape ({country, code, displayName, error} as strings) —
-    // both handlers read the same 0.1-degree grid namespace (`geocode:lat,lon`,
-    // 604800 s TTL), so either may serve the other and a normalized `''` is
-    // indistinguishable from an ocean lookup either way. (#6432)
+    // both handlers read the same deployment-scoped 0.1-degree grid namespace
+    // (`geocode:lat,lon`, 604800 s TTL), so either may serve the other and a
+    // normalized `''` is indistinguishable from an ocean lookup either way.
+    // (#6432)
     const result = { country, code, displayName, error: '' };
     const body = JSON.stringify(result);
 

--- a/docs/usage-rate-limits.mdx
+++ b/docs/usage-rate-limits.mdx
@@ -76,8 +76,9 @@ Routes that fetch a third-party host on our behalf carry their own per-IP budget
 | `POST /api/skills/fetch-agentskills` | 30 | 60 s | Per IP |
 | `GET /api/youtube/live` | 30 | 60 s | Per IP |
 | `GET /api/reverse-geocode` | 60 | 60 s | Per IP |
+| `GET /api/infrastructure/v1/reverse-geocode` | 60 | 60 s | Per IP |
 
-All three are declared in `ENDPOINT_RATE_POLICIES` (`server/_shared/rate-limit.ts`) and enforced inside the handler, because none of them is routed through the gateway. `/api/reverse-geocode` reaches Nominatim, whose usage policy is the strictest of any provider in the stack and whose enforcement is an egress-IP ban, so treat that budget as a ceiling rather than a target.
+The two edge handlers (`/api/skills/fetch-agentskills`, `/api/youtube/live`) enforce their budgets in-handler via `checkScopedRateLimit`/`checkRateLimit`; `/api/reverse-geocode` mirrors its budget as a literal constant per `api/*.js` constraints. `/api/infrastructure/v1/reverse-geocode` is a gateway RPC, so the gateway enforces it via `checkEndpointRateLimit` (fail-closed on Redis outage). Both reverse-geocode routes reach Nominatim, whose usage policy is the strictest of any provider in the stack and whose enforcement is an egress-IP ban — treat those budgets as a ceiling rather than a target; a global (aggregate) companion budget is tracked in #6431.
 
 ## Write endpoints
 

--- a/docs/usage-rate-limits.mdx
+++ b/docs/usage-rate-limits.mdx
@@ -78,7 +78,7 @@ Routes that fetch a third-party host on our behalf carry their own per-IP budget
 | `GET /api/reverse-geocode` | 60 | 60 s | Per IP |
 | `GET /api/infrastructure/v1/reverse-geocode` | 60 | 60 s | Per IP |
 
-The two edge handlers (`/api/skills/fetch-agentskills`, `/api/youtube/live`) enforce their budgets in-handler via `checkScopedRateLimit`/`checkRateLimit`; `/api/reverse-geocode` mirrors its budget as a literal constant per `api/*.js` constraints. `/api/infrastructure/v1/reverse-geocode` is a gateway RPC, so the gateway enforces it via `checkEndpointRateLimit` (fail-closed on Redis outage). Both reverse-geocode routes reach Nominatim, whose usage policy is the strictest of any provider in the stack and whose enforcement is an egress-IP ban — treat those budgets as a ceiling rather than a target; a global (aggregate) companion budget is tracked in #6431.
+The two edge handlers (`/api/skills/fetch-agentskills`, `/api/youtube/live`) enforce their budgets in-handler via `checkScopedRateLimit`/`checkRateLimit`; `/api/reverse-geocode` mirrors its budget as a literal constant per `api/*.js` constraints. `/api/infrastructure/v1/reverse-geocode` is a gateway RPC, so the gateway enforces it via `checkEndpointRateLimit` (fail-closed on Redis outage). Both reverse-geocode routes reach Nominatim, whose usage policy is the strictest of any provider in the stack and whose enforcement is an egress-IP ban — treat those budgets as a ceiling rather than a target; a global (aggregate) companion budget is still required and is not implemented by this change.
 
 ## Write endpoints
 

--- a/docs/zh/usage-rate-limits.mdx
+++ b/docs/zh/usage-rate-limits.mdx
@@ -76,8 +76,9 @@ Free 与未登录的仪表盘用户在信息流增强上仍可使用常规的关
 | `POST /api/skills/fetch-agentskills` | 30 | 60 秒 | 按 IP |
 | `GET /api/youtube/live` | 30 | 60 秒 | 按 IP |
 | `GET /api/reverse-geocode` | 60 | 60 秒 | 按 IP |
+| `GET /api/infrastructure/v1/reverse-geocode` | 60 | 60 秒 | 按 IP |
 
-这三个路由都在 `ENDPOINT_RATE_POLICIES`（`server/_shared/rate-limit.ts`）中声明并在处理函数内部强制执行，因为它们都不经过网关。`/api/reverse-geocode` 会访问 Nominatim，其使用政策是本技术栈中最严格的，且以封禁出口 IP 的方式执行，因此应将该额度视为上限而非目标。
+两个边缘处理函数（`/api/skills/fetch-agentskills`、`/api/youtube/live`）通过 `checkScopedRateLimit`/`checkRateLimit` 在处理函数内部执行其额度；`/api/reverse-geocode` 根据 `api/*.js` 约束将其额度镜像为字面常量；`/api/infrastructure/v1/reverse-geocode` 是网关 RPC，由网关通过 `checkEndpointRateLimit` 执行（Redis 故障时默认失败关闭）。两条 reverse-geocode 路由都会访问 Nominatim，其使用政策是本技术栈中最严格的，且以封禁出口 IP 的方式执行，因此应将这些额度视为上限而非目标；聚合总量配套额度见 #6431。
 
 ## 写入端点
 

--- a/docs/zh/usage-rate-limits.mdx
+++ b/docs/zh/usage-rate-limits.mdx
@@ -78,7 +78,7 @@ Free 与未登录的仪表盘用户在信息流增强上仍可使用常规的关
 | `GET /api/reverse-geocode` | 60 | 60 秒 | 按 IP |
 | `GET /api/infrastructure/v1/reverse-geocode` | 60 | 60 秒 | 按 IP |
 
-两个边缘处理函数（`/api/skills/fetch-agentskills`、`/api/youtube/live`）通过 `checkScopedRateLimit`/`checkRateLimit` 在处理函数内部执行其额度；`/api/reverse-geocode` 根据 `api/*.js` 约束将其额度镜像为字面常量；`/api/infrastructure/v1/reverse-geocode` 是网关 RPC，由网关通过 `checkEndpointRateLimit` 执行（Redis 故障时默认失败关闭）。两条 reverse-geocode 路由都会访问 Nominatim，其使用政策是本技术栈中最严格的，且以封禁出口 IP 的方式执行，因此应将这些额度视为上限而非目标；聚合总量配套额度见 #6431。
+两个边缘处理函数（`/api/skills/fetch-agentskills`、`/api/youtube/live`）通过 `checkScopedRateLimit`/`checkRateLimit` 在处理函数内部执行其额度；`/api/reverse-geocode` 根据 `api/*.js` 约束将其额度镜像为字面常量；`/api/infrastructure/v1/reverse-geocode` 是网关 RPC，由网关通过 `checkEndpointRateLimit` 执行（Redis 故障时默认失败关闭）。两条 reverse-geocode 路由都会访问 Nominatim，其使用政策是本技术栈中最严格的，且以封禁出口 IP 的方式执行，因此应将这些额度视为上限而非目标；本次变更未实现聚合总量配套额度，后续仍需补充。
 
 ## 写入端点
 

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -462,7 +462,8 @@ export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
   // per-IP budgets, so they bound any one caller but do not cap aggregate
   // egress to Nominatim (60/min from a single IP is Nominatim's whole
   // documented allowance for the application); a global companion budget
-  // keyed on 'reverse-geocode:global' is tracked in #6431. Fail-closed on
+  // keyed on 'reverse-geocode:global' is still required but is out of scope
+  // for this change. Fail-closed on
   // Redis outage (default) — Nominatim's enforcement is an egress-IP ban, so
   // a degraded limiter must 503 rather than inherit the fail-open fallback.
   '/api/infrastructure/v1/reverse-geocode': { limit: 60, window: '60 s' },

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -448,10 +448,24 @@ export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
   // per cell in the browser (src/utils/reverse-geocode.ts), so 60/min is a
   // floor against scripted coordinate sweeps rather than a throttle on real
   // map use. Nominatim's usage policy is the strictest in our stack and is
-  // enforced by egress-IP ban, and we have a second caller
-  // (server/worldmonitor/infrastructure/v1/reverse-geocode.ts), so the
-  // unmetered path is the one worth closing first.
+  // enforced by egress-IP ban, and there are two callers sharing one egress:
+  // the legacy `api/reverse-geocode.js` edge function (which carries these
+  // same numbers as literal constants and enforces them in-handler via
+  // checkRateLimit — api/*.js cannot import ../server/) and the gateway RPC
+  // below. Both use the shared `geocode:` cache namespace (604800 s TTL), so
+  // a hit on either serves the other and the budget is a floor against
+  // scripted sweeps, not a throttle on real map use. (#6234, #6432)
   '/api/reverse-geocode': { limit: 60, window: '60 s' },
+  // Gateway reverse-geocode RPC (#6432): the second Nominatim caller. Same
+  // provider, same shared 0.1-degree grid cache, same egress IPs — must carry
+  // the same 60/min budget as the legacy edge route, and it now does. Both are
+  // per-IP budgets, so they bound any one caller but do not cap aggregate
+  // egress to Nominatim (60/min from a single IP is Nominatim's whole
+  // documented allowance for the application); a global companion budget
+  // keyed on 'reverse-geocode:global' is tracked in #6431. Fail-closed on
+  // Redis outage (default) — Nominatim's enforcement is an egress-IP ban, so
+  // a degraded limiter must 503 rather than inherit the fail-open fallback.
+  '/api/infrastructure/v1/reverse-geocode': { limit: 60, window: '60 s' },
 };
 
 interface RateLimitPolicyDecision {
@@ -548,6 +562,9 @@ export const FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED: Record<string, RateLimit
   },
   '/api/resilience/v1/get-resilience-ranking': {
     reason: 'Cold/stale cache paths can synchronously warm the full country table.',
+  },
+  '/api/infrastructure/v1/reverse-geocode': {
+    reason: 'Proxies Nominatim (egress-IP ban enforcement), same provider and egress IPs as the legacy edge route. Must fail closed on a Redis outage rather than inherit the fail-open 600/min fallback.',
   },
 };
 

--- a/server/worldmonitor/infrastructure/v1/reverse-geocode.ts
+++ b/server/worldmonitor/infrastructure/v1/reverse-geocode.ts
@@ -13,6 +13,7 @@ interface ReverseCacheEntry {
   country?: string;
   code?: string;
   displayName?: string;
+  error?: string;
 }
 
 interface NominatimResponse {
@@ -85,7 +86,7 @@ export const reverseGeocode: InfrastructureServiceHandler['reverseGeocode'] = as
     const code = (data.address?.country_code || '').toUpperCase();
     const displayName = data.display_name || country || '';
 
-    const result: ReverseCacheEntry = { country, code, displayName };
+    const result: ReverseCacheEntry = { country, code, displayName, error: '' };
     await setCachedJson(cacheKey, result, 604800);
 
     return { country, code, displayName, error: '' };

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -336,6 +336,33 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     assert.ok(res, 'expected reverse-geocode RPC policy to fail closed without Redis config');
     assert.equal(res.status, 503);
     assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+
+    process.env.WORLDMONITOR_VALID_KEYS = 'reverse-geocode-gateway-test-key';
+    __resetRateLimitForTest();
+    const { createDomainGateway } = await import('../server/gateway.ts');
+    let handlerCalls = 0;
+    const gateway = createDomainGateway([{
+      method: 'GET',
+      path: pathname,
+      handler: async () => {
+        handlerCalls += 1;
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    }]);
+    const gatewayRes = await gateway(new Request(
+      `https://worldmonitor.app${pathname}?lat=40.7&lon=-74.0`,
+      {
+        headers: {
+          Origin: 'https://worldmonitor.app',
+          'X-WorldMonitor-Key': 'reverse-geocode-gateway-test-key',
+          'x-real-ip': '203.0.113.7',
+        },
+      },
+    ));
+
+    assert.equal(gatewayRes.status, 503);
+    assert.equal(gatewayRes.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.equal(handlerCalls, 0, 'the gateway must reject before route execution');
   });
 
   it('paid-provider market routes each have explicit fail-closed policies (#6236)', async () => {

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -308,6 +308,36 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     );
   });
 
+  it('gateway reverse-geocode RPC is a Nominatim provider route with a matched 60/min fail-closed policy (#6432)', async () => {
+    // #6432 — the second Nominatim caller. The legacy edge route carries a
+    // per-IP 60/min budget (#6234); this RPC must carry the same policy or it
+    // silently inherits the gateway's 600/min availability-first fallback,
+    // leaving half the egress exposure open. Since the RPC has no handler --
+    // checkEndpointRateLimit runs in the gateway before any route logic -- the
+    // policy is the whole metering, so assert it stays registered, stays in
+    // the fail-closed requirement, and degrades to 503.
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await importFreshRateLimitModule();
+    const pathname = '/api/infrastructure/v1/reverse-geocode';
+
+    assert.deepEqual(ENDPOINT_RATE_POLICIES[pathname], { limit: 60, window: '60 s' });
+    assert.ok(
+      pathname in FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED,
+      'reverse-geocode RPC must stay in the fail-closed requirement registry — a Redis outage must 503, not inherit the fail-open 600/min fallback',
+    );
+
+    const res = await mod.checkEndpointRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      pathname,
+      { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+    );
+
+    assert.ok(res, 'expected reverse-geocode RPC policy to fail closed without Redis config');
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+  });
+
   it('paid-provider market routes each have explicit fail-closed policies (#6236)', async () => {
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;

--- a/tests/reverse-geocode-cache-contract.test.mts
+++ b/tests/reverse-geocode-cache-contract.test.mts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import type { ServerContext } from '../src/generated/server/worldmonitor/infrastructure/v1/service_server.ts';
+import { __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
+import { reverseGeocode } from '../server/worldmonitor/infrastructure/v1/reverse-geocode.ts';
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+const context = {} as ServerContext;
+
+function restoreEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+function json(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function configurePreviewRedis(): void {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  process.env.VERCEL_ENV = 'preview';
+  process.env.VERCEL_GIT_COMMIT_SHA = 'deadbeefcafebabe';
+  delete process.env.LOCAL_API_MODE;
+  __resetKeyPrefixCacheForTests();
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreEnv();
+  __resetKeyPrefixCacheForTests();
+});
+
+describe('reverse-geocode shared cache contract', () => {
+  it('reads the edge route deployment-scoped key in preview and normalizes its value', async () => {
+    configurePreviewRedis();
+    const urls: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      urls.push(url);
+      assert.equal(
+        url,
+        'https://redis.example.test/get/preview%3Adeadbeef%3Ageocode%3A40.7%2C-74.0',
+        'the gateway RPC must read the same preview key as the edge route',
+      );
+      return json({ result: JSON.stringify({
+        country: 'United States',
+        code: 'US',
+        displayName: 'New York, United States',
+        error: '',
+      }) });
+    }) as typeof fetch;
+
+    const result = await reverseGeocode(context, { lat: 40.7, lon: -74.0 });
+
+    assert.deepEqual(result, {
+      country: 'United States',
+      code: 'US',
+      displayName: 'New York, United States',
+      error: '',
+    });
+    assert.equal(urls.length, 1, 'a shared cache hit must not reach Nominatim');
+  });
+
+  it('writes the complete shared value to the deployment-scoped key in preview', async () => {
+    configurePreviewRedis();
+    const redisCommands: unknown[] = [];
+    let nominatimCalls = 0;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.startsWith('https://redis.example.test/get/')) {
+        assert.equal(url, 'https://redis.example.test/get/preview%3Adeadbeef%3Ageocode%3A0.0%2C-150.0');
+        return json({ result: null });
+      }
+      if (url === 'https://redis.example.test/') {
+        redisCommands.push(JSON.parse(String(init?.body)));
+        return json({ result: 'OK' });
+      }
+      assert.match(url, /^https:\/\/nominatim\.openstreetmap\.org\/reverse\?/);
+      nominatimCalls += 1;
+      return json({ display_name: '' });
+    }) as typeof fetch;
+
+    const result = await reverseGeocode(context, { lat: 0, lon: -150 });
+
+    assert.deepEqual(result, { country: '', code: '', displayName: '', error: '' });
+    assert.equal(nominatimCalls, 1);
+    assert.deepEqual(redisCommands, [[
+      'SET',
+      'preview:deadbeef:geocode:0.0,-150.0',
+      JSON.stringify({ country: '', code: '', displayName: '', error: '' }),
+      'EX',
+      '604800',
+    ]]);
+  });
+});

--- a/tests/reverse-geocode-rate-limit.test.mjs
+++ b/tests/reverse-geocode-rate-limit.test.mjs
@@ -148,6 +148,48 @@ test('allows the request through when the limiter reports headroom', async () =>
   );
 });
 
+test('caches ocean and Antarctic results too — a sweep of empty cells must not be 100% passthrough (#6432)', async () => {
+  // #6412 deliberately left the cache write conditional on a resolved country,
+  // so ocean/Antarctic cells returned Nominatim's "no place" answer on every
+  // request. The parallel gateway RPC writes those cells unconditionally and
+  // both share the geocode: namespace, so this route must too. The mutation
+  // is one line: no `if (country && code)` around the write.
+  const calls = spyFetch((url) => {
+    if (url.includes('/get/')) {
+      // First request is a cache miss; the write is fire-and-forget so no
+      // read-back occurs.
+      return new Response(JSON.stringify({ result: null }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    // Ocean in the middle of the Pacific — Nominatim returns no address.
+    return new Response(JSON.stringify({
+      display_name: '',
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  });
+  const { ctx, waited } = makeCtx();
+  const res = await handler(makeRequest('lat=0&lon=-150', uniqueCallerIp()), ctx);
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).country, '');
+  assert.equal(nominatimCalls(calls).length, 1);
+  // The cache write is fire-and-forget; flush it.
+  await Promise.all(waited);
+  const writes = calls.filter((c) => c.url.includes('fake-upstash'));
+  assert.ok(writes.length > 0, 'an ocean-resolved response must be written to the shared geocode: cache');
+  assert.ok(
+    writes.some((c) => {
+      try {
+        const entries = JSON.parse(String(c.init.body));
+        const hasSet = Array.isArray(entries)
+          ? entries.some((e) => Array.isArray(e) && String(e[0]).toLowerCase() === 'set')
+          : String(entries[0]).toLowerCase() === 'set';
+        return hasSet && JSON.stringify(entries).includes('geocode:0.0,-150.0');
+      } catch { return false; }
+    }),
+    'the cache write must target the shared geocode:0.0,-150.0 key (lat=0 → 0.0, lon=-150 → -150.0)',
+  );
+});
+
 test('stays available when Upstash is unconfigured', async () => {
   // Availability-first: the map degrades to an unlabelled country rather than
   // failing, so a missing/blipping Redis must not black-hole the route.

--- a/tests/reverse-geocode-rate-limit.test.mjs
+++ b/tests/reverse-geocode-rate-limit.test.mjs
@@ -1,10 +1,9 @@
 // Rate-limit coverage for api/reverse-geocode.js (#6234).
 //
 // The route reaches Nominatim, whose usage policy is the strictest in our
-// stack and whose enforcement is an egress-IP ban. It is Upstash-cached on a
-// 0.1-degree grid, but the cache write is conditional on a resolved country
-// (api/reverse-geocode.js), so ocean and Antarctic coordinates never populate
-// it — a scripted sweep of those cells was 100% passthrough with no meter.
+// stack and whose enforcement is an egress-IP ban. It shares an Upstash-backed
+// 0.1-degree grid with the gateway RPC and caches normalized empty results, so
+// repeated ocean and Antarctic lookups do not remain provider passthrough.
 
 import { afterEach, beforeEach, test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -148,6 +147,40 @@ test('allows the request through when the limiter reports headroom', async () =>
   );
 });
 
+test('normalizes an RPC-shaped shared cache hit in the same preview namespace', async () => {
+  process.env.VERCEL_ENV = 'preview';
+  process.env.VERCEL_GIT_COMMIT_SHA = 'deadbeefcafebabe';
+  const calls = spyFetch((url) => {
+    if (url.includes('/get/')) {
+      return new Response(JSON.stringify({
+        result: JSON.stringify({
+          country: 'United States',
+          code: 'US',
+          displayName: 'New York, United States',
+        }),
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (url.includes('fake-upstash')) return upstashReply(59, 60);
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  const { ctx } = makeCtx();
+
+  const res = await handler(makeRequest('lat=40.7&lon=-74.0', uniqueCallerIp()), ctx);
+
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), {
+    country: 'United States',
+    code: 'US',
+    displayName: 'New York, United States',
+    error: '',
+  });
+  assert.equal(nominatimCalls(calls).length, 0, 'a shared cache hit must not reach Nominatim');
+  assert.ok(
+    calls.some((call) => call.url === 'https://fake-upstash.example/get/preview%3Adeadbeef%3Ageocode%3A40.7%2C-74.0'),
+    'the edge route must read the same deployment-prefixed key as the gateway RPC',
+  );
+});
+
 test('caches ocean and Antarctic results too — a sweep of empty cells must not be 100% passthrough (#6432)', async () => {
   // #6412 deliberately left the cache write conditional on a resolved country,
   // so ocean/Antarctic cells returned Nominatim's "no place" answer on every
@@ -176,18 +209,22 @@ test('caches ocean and Antarctic results too — a sweep of empty cells must not
   await Promise.all(waited);
   const writes = calls.filter((c) => c.url.includes('fake-upstash'));
   assert.ok(writes.length > 0, 'an ocean-resolved response must be written to the shared geocode: cache');
-  assert.ok(
-    writes.some((c) => {
-      try {
-        const entries = JSON.parse(String(c.init.body));
-        const hasSet = Array.isArray(entries)
-          ? entries.some((e) => Array.isArray(e) && String(e[0]).toLowerCase() === 'set')
-          : String(entries[0]).toLowerCase() === 'set';
-        return hasSet && JSON.stringify(entries).includes('geocode:0.0,-150.0');
-      } catch { return false; }
-    }),
-    'the cache write must target the shared geocode:0.0,-150.0 key (lat=0 → 0.0, lon=-150 → -150.0)',
-  );
+  const cacheWrite = writes.map((c) => {
+    try { return JSON.parse(String(c.init.body)); } catch { return null; }
+  }).find((entries) => Array.isArray(entries)
+    && entries.some((entry) => Array.isArray(entry)
+      && String(entry[0]).toLowerCase() === 'set'
+      && entry[1] === 'geocode:0.0,-150.0'));
+  assert.ok(cacheWrite, 'the cache write must target the shared geocode:0.0,-150.0 key');
+  const setCommand = cacheWrite.find((entry) => Array.isArray(entry)
+    && String(entry[0]).toLowerCase() === 'set');
+  assert.deepEqual(setCommand, [
+    'SET',
+    'geocode:0.0,-150.0',
+    JSON.stringify({ country: '', code: '', displayName: '', error: '' }),
+    'EX',
+    '604800',
+  ]);
 });
 
 test('stays available when Upstash is unconfigured', async () => {


### PR DESCRIPTION
## Summary

`GET /api/infrastructure/v1/reverse-geocode` reaches Nominatim on a cache miss, but it had no `ENDPOINT_RATE_POLICIES` entry, so it silently inherited the gateway's 600/min availability-first fallback. That is 10x the 60/min budget #6412 set on the sibling `api/reverse-geocode.js` edge route - from the same provider, the same egress IPs, against a provider that bans egress IPs. Half the exposure #6412 closed was still open.

This closes it: the RPC is now registered at the same 60/min, and the edge route's cache no longer leaves ocean/Antarctic cells as unmetered passthrough.

### What changed

- **Metered the RPC.** `'/api/infrastructure/v1/reverse-geocode': { limit: 60, window: '60 s' }` in `ENDPOINT_RATE_POLICIES` (`server/_shared/rate-limit.ts`). The gateway already runs `checkEndpointRateLimit` for every route before consulting the registry, so the entry is the whole metering - no handler change needed. Because Nominatim enforces by egress-IP ban, it also goes into `FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED`, so a Redis outage returns 503 rather than inheriting the fail-open fallback.
- **Cache-write parity (#6412 follow-up).** `api/reverse-geocode.js` wrote the shared `geocode:` cache only when a country resolved, so ocean and Antarctic coordinates were 100% Nominatim passthrough with no meter. The write is now unconditional and uses the RPC's complete entry shape `{country, code, displayName, error}`. Both routes use the same deployment-scoped 0.1-degree grid namespace, so either reader can serve the other without mixing preview and production entries.
- **Cache-read parity.** The edge route normalizes legacy RPC cache values before returning them, so fresh and cached success responses have the same four fields.
- **Docs.** The provider-proxies table in `docs/usage-rate-limits.mdx` and its Chinese translation gains the RPC row and corrects the now-false "none of them is routed through the gateway" claim.

### Residual

Both budgets are per-IP, so they bound any single caller but not aggregate egress to Nominatim. A global companion budget is still required and is not implemented by this PR.

## Verification

- `tests/rate-limit.test.mts`: 50/50 pass, including the 60/min registry contract, fail-closed Redis behavior, and the real gateway rejection path.
- `tests/reverse-geocode-rate-limit.test.mjs`: 6/6 pass, including preview-key interoperability, response normalization, and the complete seven-day negative-cache payload.
- `tests/reverse-geocode-cache-contract.test.mts`: 2/2 pass for preview reads and writes across the shared cache contract.
- `tests/edge-functions.test.mjs`: 252/252 pass.
- `typecheck:api`, `enforce-rate-limit-policies`, Biome, and Markdown lint pass.

Fixes #6432
