### PR TITLE
fix(feeds): drop the dead YC Blog publisher-family label

### DIFF
--- a/scripts/shared/publisher-families.js
+++ b/scripts/shared/publisher-families.js
@@ -163,7 +163,7 @@ const PUBLISHER_FAMILY_DATA = {
   },
   'venturebeat': { publisher: "VentureBeat", labels: ["VentureBeat", "VentureBeat AI"] },
   'white-house': { publisher: "The White House", labels: ["White House", "White House Actions"] },
-  'y-combinator': { publisher: "Y Combinator", labels: ["YC Blog", "YC Launches", "Y Combinator Blog"] },
+  'y-combinator': { publisher: "Y Combinator", labels: ["YC Launches", "Y Combinator Blog"] },
   'yahoo-finance': { publisher: "Yahoo Finance", labels: ["Yahoo Finance", "Yahoo Finance Commodities"] },
 };
 

--- a/shared/publisher-families.js
+++ b/shared/publisher-families.js
@@ -163,7 +163,7 @@ const PUBLISHER_FAMILY_DATA = {
   },
   'venturebeat': { publisher: "VentureBeat", labels: ["VentureBeat", "VentureBeat AI"] },
   'white-house': { publisher: "The White House", labels: ["White House", "White House Actions"] },
-  'y-combinator': { publisher: "Y Combinator", labels: ["YC Blog", "YC Launches", "Y Combinator Blog"] },
+  'y-combinator': { publisher: "Y Combinator", labels: ["YC Launches", "Y Combinator Blog"] },
   'yahoo-finance': { publisher: "Yahoo Finance", labels: ["Yahoo Finance", "Yahoo Finance Commodities"] },
 };
 


### PR DESCRIPTION
## Summary

`#6444` removed the `YC Blog` feed but left its label mapped in the `y-combinator` publisher family. `publisher-families.test.mjs` fails closed on exactly that condition — *"a renamed or removed feed leaves a dead entry"* — so main's `unit` check is red.

**This is currently blocking every Railway seeder deploy.** `Railway Deploy Trigger`'s admission job gates on main's check suite and has been logging:

```
Current main gate is failure; this admission performs no production work.
```

so its `leased production mutation` job is skipped on every run. The seeder fleet cannot deploy until main is green again.

## Root cause

`#6444` (`3ee808efd`) deleted the feed from both declaring configs:

- `src/config/variants/tech.ts` — `- { name: 'YC Blog', url: rss('https://www.ycombinator.com/blog/rss/') }`
- `server/worldmonitor/news/v1/_feeds.ts` — `- 'YC Blog'`

but `shared/publisher-families.js` still listed it:

```js
'y-combinator': { publisher: "Y Combinator", labels: ["YC Blog", "YC Launches", "Y Combinator Blog"] },
```

`#6444` never ran `unit` on main, so the breakage landed unobserved; the next merge is simply where the check first executed and caught it.

## Why dropping the label is safe

No coverage is lost. `Y Combinator Blog` already carries the **same** `https://www.ycombinator.com/blog/rss/` URL that `YC Blog` pointed at, and `YC Launches` remains declared. The family still groups every live YC feed under one publisher, so corroboration counting is unchanged — a story reprinted across YC feeds still cannot clear a "two independent sources" gate on its own.

Both copies of the mirrored module are updated together so `scripts-shared-mirror` parity holds.

## Validation

Reproduced first, then fixed:

```
# before
✖ maps only labels that a feed config or the tier table declares
    actual: [ 'y-combinator -> "YC Blog"' ], expected: []

# after — publisher-families + scripts-shared-mirror + corroboration-publisher-count
ℹ pass 39   ℹ fail 0
```

Swept the changed module's full consumer surface (clustering, dedup, digest, keyword/trending, brief, insights, feeds):

```
ℹ tests 1922   ℹ pass 1922   ℹ fail 0
```

## Note on the other main failure

Main's `unit` run also failed `tests/market-quotes-seed-first.test.mts` — *"enforces one wall-clock deadline across an in-window stalled lookup"* (`PROVIDER_ERROR` vs `UPSTREAM_BUDGET_EXHAUSTED`). That one passes locally in 32ms and failed at 80ms under CI's `--test-concurrency=16`; it is a wall-clock timing flake, not a defect this PR addresses. Flagging it separately rather than folding it in.
