### PR TITLE
fix(sidecar): pin IPv6-only RSS fetches

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -906,12 +906,24 @@ function makeCorsHeaders(req) {
 }
 
 async function fetchWithTimeout(url, options = {}, timeoutMs = 12000) {
-  // Use node:https with IPv4 forced — Node.js built-in fetch (undici) tries IPv6
-  // first and some servers (EIA, NASA FIRMS) have broken IPv6 causing ETIMEDOUT.
+  // Use node:https with IPv4 by default — Node.js built-in fetch (undici) tries
+  // IPv6 first and some servers (EIA, NASA FIRMS) have broken IPv6. Callers
+  // with a validated address can instead pin its detected family below.
   const u = new URL(url);
   const allowPrivateNetwork = options.allowPrivateNetwork === true;
   const fetchOptions = { ...options };
   delete fetchOptions.allowPrivateNetwork;
+  const resolvedAddress = fetchOptions.resolvedAddress;
+  const requestedFamily = fetchOptions.resolvedFamily;
+  delete fetchOptions.resolvedAddress;
+  delete fetchOptions.resolvedFamily;
+  const resolvedFamily = resolvedAddress ? isIP(resolvedAddress) : 0;
+  if (resolvedAddress && resolvedFamily === 0) {
+    throw new TypeError('resolvedAddress must be an IPv4 or IPv6 address');
+  }
+  if (requestedFamily != null && requestedFamily !== resolvedFamily) {
+    throw new TypeError('resolvedFamily must match resolvedAddress');
+  }
   if (u.protocol === 'https:') {
     return new Promise((resolve, reject) => {
       const reqOpts = {
@@ -920,12 +932,12 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = 12000) {
         path: u.pathname + u.search,
         method: fetchOptions.method || 'GET',
         headers: fetchOptions.headers || {},
-        family: 4,
+        family: resolvedFamily || 4,
       };
       // Pin to a pre-resolved IP to prevent TOCTOU DNS rebinding.
       // The hostname is kept for SNI / TLS certificate validation.
-      if (fetchOptions.resolvedAddress) {
-        reqOpts.lookup = makePinnedLookup(fetchOptions.resolvedAddress, 4);
+      if (resolvedAddress) {
+        reqOpts.lookup = makePinnedLookup(resolvedAddress, resolvedFamily);
       }
       const req = https.request(reqOpts, (res) => {
         const chunks = [];
@@ -957,10 +969,10 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = 12000) {
   // validated IP and set the Host header so virtual-host routing still works.
   let fetchUrl = url;
   const fetchHeaders = { ...(fetchOptions.headers || {}) };
-  if (fetchOptions.resolvedAddress && u.protocol === 'http:') {
+  if (resolvedAddress && u.protocol === 'http:') {
     const pinned = new URL(url);
     fetchHeaders['Host'] = pinned.host;
-    pinned.hostname = fetchOptions.resolvedAddress;
+    pinned.hostname = resolvedFamily === 6 ? `[${resolvedAddress}]` : resolvedAddress;
     fetchUrl = pinned.toString();
   }
   const controller = new AbortController();
@@ -1611,17 +1623,22 @@ async function dispatch(requestUrl, req, routes, context) {
 
     try {
       const parsed = new URL(feedUrl);
-      // Pin to the first IPv4 address validated by isSafeUrl() so the
-      // actual TCP connection goes to the same IP we checked, closing
-      // the TOCTOU DNS-rebinding window.
-      const pinnedV4 = safety.resolvedAddresses?.find(a => a.includes('.'));
+      // Pin to an address validated by isSafeUrl() so the actual TCP
+      // connection goes to the same IP and family we checked, closing
+      // the TOCTOU DNS-rebinding window for IPv4 and IPv6-only feeds.
+      const pinned = pickPinnedAddress(safety.resolvedAddresses);
+      if (!pinned) {
+        context.logger.warn(`[local-api] rss-proxy SSRF blocked: no validated address (url=${feedUrl})`);
+        return json({ error: 'Could not resolve hostname' }, 403);
+      }
       const response = await fetchWithTimeout(feedUrl, {
         headers: {
           'User-Agent': CHROME_UA,
           'Accept': 'application/rss+xml, application/xml, text/xml, */*',
           'Accept-Language': 'en-US,en;q=0.9',
         },
-        ...(pinnedV4 ? { resolvedAddress: pinnedV4 } : {}),
+        resolvedAddress: pinned.address,
+        resolvedFamily: pinned.family,
       }, parsed.hostname.includes('news.google.com') ? 20000 : 12000);
       const contentType = response.headers?.get?.('content-type') || 'application/xml';
       const rssBody = await response.text();

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -3,6 +3,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import http, { createServer, request as httpRequest } from 'node:http';
 import https from 'node:https';
 import { createHmac } from 'node:crypto';
+import dns from 'node:dns/promises';
 import { EventEmitter } from 'node:events';
 import net from 'node:net';
 import { brotliDecompressSync, gunzipSync } from 'node:zlib';
@@ -2161,6 +2162,114 @@ test('default-deny: rejects every authenticated route when LOCAL_API_TOKEN is un
     if (originalToken !== undefined) {
       process.env.LOCAL_API_TOKEN = originalToken;
     }
+    await app.close();
+    await localApi.cleanup();
+  }
+});
+
+test('rss-proxy pins an IPv6-only hostname to the validated address', async () => {
+  const localApi = await setupApiDir({});
+  const originalResolve4 = dns.resolve4;
+  const originalResolve6 = dns.resolve6;
+  const originalHttpsRequest = https.request;
+  const publicIpv6 = '2606:4700:4700::1111';
+  let outboundOptions = null;
+  let pinnedLookup = null;
+
+  dns.resolve4 = async () => {
+    const error = new Error('No A records');
+    error.code = 'ENODATA';
+    throw error;
+  };
+  dns.resolve6 = async (hostname) => {
+    assert.equal(hostname, 'ipv6-only.example');
+    return [publicIpv6];
+  };
+  https.request = (options, onResponse) => {
+    outboundOptions = options;
+    if (typeof options.lookup === 'function') {
+      options.lookup(options.hostname, { family: options.family }, (error, address, family) => {
+        assert.ifError(error);
+        pinnedLookup = { address, family };
+      });
+    }
+
+    const req = new EventEmitter();
+    req.setTimeout = () => {};
+    req.write = () => {};
+    req.destroy = (error) => {
+      if (error) req.emit('error', error);
+    };
+    req.end = () => {
+      queueMicrotask(() => {
+        const res = new EventEmitter();
+        res.statusCode = 200;
+        res.statusMessage = 'OK';
+        res.headers = { 'content-type': 'application/rss+xml' };
+        onResponse(res);
+        res.emit('data', Buffer.from('<rss />'));
+        res.emit('end');
+      });
+    };
+    return req;
+  };
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() {}, warn() {}, error() {} },
+  });
+  const { port } = await app.start();
+
+  try {
+    const feedUrl = encodeURIComponent('https://ipv6-only.example/feed.xml');
+    const response = await authFetch(`http://127.0.0.1:${port}/api/rss-proxy?url=${feedUrl}`);
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), '<rss />');
+    assert.equal(outboundOptions?.hostname, 'ipv6-only.example');
+    assert.equal(outboundOptions?.family, 6);
+    assert.deepEqual(pinnedLookup, { address: publicIpv6, family: 6 });
+  } finally {
+    dns.resolve4 = originalResolve4;
+    dns.resolve6 = originalResolve6;
+    https.request = originalHttpsRequest;
+    await app.close();
+    await localApi.cleanup();
+  }
+});
+
+test('rss-proxy rejects a hostname with mixed public and private DNS answers', async () => {
+  const localApi = await setupApiDir({});
+  const originalResolve4 = dns.resolve4;
+  const originalResolve6 = dns.resolve6;
+  const originalHttpsRequest = https.request;
+  let outboundCalls = 0;
+
+  dns.resolve4 = async () => ['93.184.216.34'];
+  dns.resolve6 = async () => ['fd00::1'];
+  https.request = () => {
+    outboundCalls += 1;
+    throw new Error('blocked DNS result must not reach the network');
+  };
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() {}, warn() {}, error() {} },
+  });
+  const { port } = await app.start();
+
+  try {
+    const feedUrl = encodeURIComponent('https://mixed-dns.example/feed.xml');
+    const response = await authFetch(`http://127.0.0.1:${port}/api/rss-proxy?url=${feedUrl}`);
+    assert.equal(response.status, 403);
+    const body = await response.json();
+    assert.match(body.error, /private\/reserved/);
+    assert.equal(outboundCalls, 0);
+  } finally {
+    dns.resolve4 = originalResolve4;
+    dns.resolve6 = originalResolve6;
+    https.request = originalHttpsRequest;
     await app.close();
     await localApi.cleanup();
   }


### PR DESCRIPTION
## Summary

- keep the validated RSS DNS address pinned for IPv6-only hostnames
- derive and validate the outbound address family before the request
- preserve fail-closed rejection for mixed public and private DNS answers

## Verification

- TMPDIR=/private/tmp node --test src-tauri/sidecar/local-api-server.test.mjs (59/59)
- TMPDIR=/private/tmp npm run test:sidecar (370/370)

Fixes #5921