### PR TITLE
fix(ingestion): publish Military-Bases seed metadata

### DIFF
--- a/scripts/seed-military-bases.mjs
+++ b/scripts/seed-military-bases.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join } from 'node:path';
 import { loadEnvFile } from './_seed-utils.mjs';
 
@@ -136,17 +136,17 @@ async function validate(url, token, prefix, version, expectedCount) {
     ['HLEN', metaKey],
   ]);
 
-  const geoCount = zcardResult.result;
-  const metaCount = hlenResult.result;
+  const geoCount = Number(zcardResult.result);
+  const metaCount = Number(hlenResult.result);
 
   console.log(`  ZCARD ${geoKey} = ${geoCount} (expected >= ${expectedCount})`);
   console.log(`  HLEN  ${metaKey} = ${metaCount} (expected == ZCARD)`);
 
-  if (geoCount < expectedCount) {
+  if (!Number.isSafeInteger(geoCount) || geoCount < expectedCount) {
     throw new Error(`GEO count ${geoCount} < expected ${expectedCount}`);
   }
 
-  if (metaCount !== geoCount) {
+  if (!Number.isSafeInteger(metaCount) || metaCount !== geoCount) {
     throw new Error(`META count ${metaCount} != GEO count ${geoCount}`);
   }
 
@@ -179,12 +179,75 @@ async function validate(url, token, prefix, version, expectedCount) {
 
   console.log(`  Sampled ${parseOk}/${sampleIds.length} entries — all valid JSON`);
   console.log('  Validation passed.');
+  return geoCount;
 }
 
-async function atomicSwitch(url, token, prefix, version) {
+function buildSeedMetaCommand(prefix, version, recordCount, fetchedAt) {
+  const seedMetaKey = `${prefix}seed-meta:military:bases`;
+  return ['SET', seedMetaKey, JSON.stringify({
+    fetchedAt,
+    recordCount,
+    sourceVersion: String(version),
+  })];
+}
+
+function buildAtomicSwitchCommands(prefix, version, recordCount, fetchedAt) {
   const activeKey = `${prefix}military:bases:active`;
-  await pipelineRequest(url, token, [['SET', activeKey, String(version)]]);
+  return [
+    ['SET', activeKey, String(version)],
+    buildSeedMetaCommand(prefix, version, recordCount, fetchedAt),
+  ];
+}
+
+export async function atomicSwitch(
+  url,
+  token,
+  prefix,
+  version,
+  recordCount,
+  fetchedAt = Date.now(),
+) {
+  const activeKey = `${prefix}military:bases:active`;
+  const seedMetaKey = `${prefix}seed-meta:military:bases`;
+  await pipelineRequest(
+    url,
+    token,
+    buildAtomicSwitchCommands(prefix, version, recordCount, fetchedAt),
+  );
   console.log(`\nAtomic switch: SET ${activeKey} = ${version}`);
+  console.log(`Freshness meta: SET ${seedMetaKey}`);
+}
+
+export async function backfillSeedMetaFromActiveVersion(url, token, prefix) {
+  const activeKey = `${prefix}military:bases:active`;
+  const activeResult = await pipelineRequest(url, token, [['GET', activeKey]]);
+  const rawVersion = activeResult[0]?.result;
+  if (rawVersion == null || rawVersion === '') {
+    throw new Error('Data file not found locally or on R2, and no existing active version in Redis');
+  }
+
+  const version = String(rawVersion);
+  const fetchedAt = Number(version);
+  if (!/^\d+$/.test(version) || !Number.isSafeInteger(fetchedAt) || fetchedAt <= 0) {
+    throw new Error(`Active version "${version}" is not a valid millisecond timestamp`);
+  }
+
+  const recordCount = await validate(url, token, prefix, version, 1);
+
+  // Do not publish metadata for a version that stopped being active while its
+  // versioned GEO/META keys were being validated.
+  const currentResult = await pipelineRequest(url, token, [['GET', activeKey]]);
+  const currentVersion = currentResult[0]?.result;
+  if (String(currentVersion ?? '') !== version) {
+    throw new Error(`Active version changed during validation (${version} -> ${currentVersion ?? 'missing'})`);
+  }
+
+  const seedMetaKey = `${prefix}seed-meta:military:bases`;
+  await pipelineRequest(url, token, [
+    buildSeedMetaCommand(prefix, version, recordCount, fetchedAt),
+  ]);
+  console.log(`No data file found — restored ${seedMetaKey} from active version ${version} (${recordCount} records).`);
+  return { version, fetchedAt, recordCount };
 }
 
 async function cleanupOldVersion(url, token, prefix, newVersion) {
@@ -252,15 +315,8 @@ async function main() {
   }
 
   if (!dataPath) {
-    const activeKey = `${prefix}military:bases:active`;
-    const check = await pipelineRequest(redisUrl, redisToken, [['GET', activeKey]]);
-    const existing = check[0]?.result;
-    if (existing) {
-      console.log(`No data file found — Redis already has active version ${existing}, skipping.`);
-      process.exit(0);
-    }
-    console.error(`Data file not found locally or on R2, and no existing data in Redis.`);
-    process.exit(1);
+    await backfillSeedMetaFromActiveVersion(redisUrl, redisToken, prefix);
+    return;
   }
 
   const raw = readFileSync(dataPath, 'utf8');
@@ -312,7 +368,7 @@ async function main() {
 
   await validate(redisUrl, redisToken, prefix, version, entries.length);
 
-  await atomicSwitch(redisUrl, redisToken, prefix, version);
+  await atomicSwitch(redisUrl, redisToken, prefix, version, entries.length);
 
   if (oldInfo) {
     console.log(`\nScheduling cleanup of old version ${oldInfo.oldVersion} in ${GRACE_PERIOD_MS / 1000}s...`);
@@ -332,7 +388,10 @@ async function main() {
   console.log(`  Total entries:  ${entries.length.toLocaleString()}`);
 }
 
-main().catch(err => {
-  console.error('\nFATAL:', err.message || err);
-  process.exit(1);
-});
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main().catch(err => {
+    console.error('\nFATAL:', err.message || err);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-military-bases.mjs
+++ b/scripts/seed-military-bases.mjs
@@ -13,7 +13,23 @@ const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
 const PROGRESS_INTERVAL = 5000;
 const GRACE_PERIOD_MS = 5 * 60 * 1000;
-const VALIDATION_SAMPLE_SIZE = 10;
+const VALIDATION_BATCH_SIZE = 500;
+const USER_AGENT = 'worldmonitor-military-bases-seeder/1.0';
+
+const PUBLISH_ACTIVE_AND_META_SCRIPT = `
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('SET', KEYS[2], ARGV[2])
+return ARGV[1]
+`.trim();
+
+const BACKFILL_META_IF_ACTIVE_SCRIPT = `
+local current = redis.call('GET', KEYS[1])
+if current ~= ARGV[1] then
+  return {0, current or ''}
+end
+redis.call('SET', KEYS[2], ARGV[2])
+return {1, current}
+`.trim();
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -55,15 +71,15 @@ function maskToken(token) {
   return token.slice(0, 4) + '***' + token.slice(-4);
 }
 
-async function pipelineRequest(url, token, commands, attempt = 1) {
-  const body = JSON.stringify(commands);
-  const resp = await fetch(`${url}/pipeline`, {
+async function redisRequest(url, token, path, body, label, attempt = 1) {
+  const resp = await fetch(`${url}${path}`, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
+      'User-Agent': USER_AGENT,
     },
-    body,
+    body: JSON.stringify(body),
     signal: AbortSignal.timeout(30_000),
   });
 
@@ -71,14 +87,50 @@ async function pipelineRequest(url, token, commands, attempt = 1) {
     const text = await resp.text().catch(() => '');
     if (attempt < MAX_RETRIES) {
       const delay = RETRY_BASE_MS * 2 ** (attempt - 1);
-      console.warn(`  Pipeline failed (HTTP ${resp.status}), retry ${attempt}/${MAX_RETRIES} in ${delay}ms...`);
+      console.warn(`  ${label} failed (HTTP ${resp.status}), retry ${attempt}/${MAX_RETRIES} in ${delay}ms...`);
       await sleep(delay);
-      return pipelineRequest(url, token, commands, attempt + 1);
+      return redisRequest(url, token, path, body, label, attempt + 1);
     }
-    throw new Error(`Pipeline failed after ${MAX_RETRIES} attempts: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+    throw new Error(`${label} failed after ${MAX_RETRIES} attempts: HTTP ${resp.status} — ${text.slice(0, 200)}`);
   }
 
-  return resp.json();
+  try {
+    return await resp.json();
+  } catch (err) {
+    throw new Error(`${label} returned invalid JSON: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+function commandFailure(result) {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return 'invalid response cell';
+  if (result.error != null) return String(result.error);
+  if (!Object.hasOwn(result, 'result')) return 'missing result field';
+  if (result.result === 'ERR') return 'ERR';
+  return null;
+}
+
+async function pipelineRequest(url, token, commands) {
+  const results = await redisRequest(url, token, '/pipeline', commands, 'Pipeline');
+  if (!Array.isArray(results) || results.length !== commands.length) {
+    throw new Error(`Pipeline returned ${Array.isArray(results) ? results.length : 'an invalid response'} for ${commands.length} commands`);
+  }
+
+  for (let i = 0; i < results.length; i++) {
+    const failure = commandFailure(results[i]);
+    if (failure) {
+      throw new Error(`Pipeline command ${i + 1}/${commands.length} ${commands[i]?.[0] || 'UNKNOWN'} failed: ${failure}`);
+    }
+  }
+  return results;
+}
+
+async function commandRequest(url, token, command) {
+  const response = await redisRequest(url, token, '/', command, 'Redis command');
+  const failure = commandFailure(response);
+  if (failure) {
+    throw new Error(`Redis command ${command[0] || 'UNKNOWN'} failed: ${failure}`);
+  }
+  return response.result;
 }
 
 function sleep(ms) {
@@ -150,53 +202,58 @@ async function validate(url, token, prefix, version, expectedCount) {
     throw new Error(`META count ${metaCount} != GEO count ${geoCount}`);
   }
 
-  const membersResult = await pipelineRequest(url, token, [
-    ['ZRANDMEMBER', geoKey, String(VALIDATION_SAMPLE_SIZE)],
-  ]);
+  let validatedCount = 0;
+  for (let offset = 0; offset < geoCount; offset += VALIDATION_BATCH_SIZE) {
+    const end = Math.min(offset + VALIDATION_BATCH_SIZE, geoCount) - 1;
+    const membersResult = await pipelineRequest(url, token, [
+      ['ZRANGE', geoKey, String(offset), String(end)],
+    ]);
+    const memberIds = membersResult[0].result;
+    const expectedBatchSize = end - offset + 1;
+    if (!Array.isArray(memberIds) || memberIds.length !== expectedBatchSize) {
+      throw new Error(`ZRANGE returned ${Array.isArray(memberIds) ? memberIds.length : 'an invalid response'} members for range ${offset}-${end}`);
+    }
 
-  const sampleIds = membersResult[0].result;
-  if (!sampleIds || sampleIds.length === 0) {
-    throw new Error('ZRANDMEMBER returned no members');
+    const hmgetResult = await pipelineRequest(url, token, [
+      ['HMGET', metaKey, ...memberIds],
+    ]);
+    const values = hmgetResult[0].result;
+    if (!Array.isArray(values) || values.length !== memberIds.length) {
+      throw new Error(`HMGET returned ${Array.isArray(values) ? values.length : 'an invalid response'} values for ${memberIds.length} members`);
+    }
+
+    for (let i = 0; i < values.length; i++) {
+      if (!values[i]) {
+        throw new Error(`ID "${memberIds[i]}" missing from META hash`);
+      }
+      try {
+        JSON.parse(values[i]);
+      } catch {
+        throw new Error(`ID "${memberIds[i]}" has invalid JSON in META hash`);
+      }
+    }
+    validatedCount += memberIds.length;
   }
 
-  const hmgetResult = await pipelineRequest(url, token, [
-    ['HMGET', metaKey, ...sampleIds],
+  const [finalZcardResult, finalHlenResult] = await pipelineRequest(url, token, [
+    ['ZCARD', geoKey],
+    ['HLEN', metaKey],
   ]);
-
-  const values = hmgetResult[0].result;
-  let parseOk = 0;
-  for (let i = 0; i < values.length; i++) {
-    if (!values[i]) {
-      throw new Error(`Sample ID "${sampleIds[i]}" missing from META hash`);
-    }
-    try {
-      JSON.parse(values[i]);
-      parseOk++;
-    } catch {
-      throw new Error(`Sample ID "${sampleIds[i]}" has invalid JSON in META hash`);
-    }
+  if (Number(finalZcardResult.result) !== geoCount || Number(finalHlenResult.result) !== metaCount) {
+    throw new Error('GEO or META counts changed during validation');
   }
 
-  console.log(`  Sampled ${parseOk}/${sampleIds.length} entries — all valid JSON`);
+  console.log(`  Validated ${validatedCount}/${geoCount} entries — all present with valid JSON`);
   console.log('  Validation passed.');
   return geoCount;
 }
 
-function buildSeedMetaCommand(prefix, version, recordCount, fetchedAt) {
-  const seedMetaKey = `${prefix}seed-meta:military:bases`;
-  return ['SET', seedMetaKey, JSON.stringify({
+function buildSeedMetaPayload(version, recordCount, fetchedAt) {
+  return JSON.stringify({
     fetchedAt,
     recordCount,
     sourceVersion: String(version),
-  })];
-}
-
-function buildAtomicSwitchCommands(prefix, version, recordCount, fetchedAt) {
-  const activeKey = `${prefix}military:bases:active`;
-  return [
-    ['SET', activeKey, String(version)],
-    buildSeedMetaCommand(prefix, version, recordCount, fetchedAt),
-  ];
+  });
 }
 
 export async function atomicSwitch(
@@ -209,11 +266,18 @@ export async function atomicSwitch(
 ) {
   const activeKey = `${prefix}military:bases:active`;
   const seedMetaKey = `${prefix}seed-meta:military:bases`;
-  await pipelineRequest(
-    url,
-    token,
-    buildAtomicSwitchCommands(prefix, version, recordCount, fetchedAt),
-  );
+  const publishedVersion = await commandRequest(url, token, [
+    'EVAL',
+    PUBLISH_ACTIVE_AND_META_SCRIPT,
+    '2',
+    activeKey,
+    seedMetaKey,
+    String(version),
+    buildSeedMetaPayload(version, recordCount, fetchedAt),
+  ]);
+  if (String(publishedVersion) !== String(version)) {
+    throw new Error(`Atomic switch returned unexpected version "${publishedVersion}"`);
+  }
   console.log(`\nAtomic switch: SET ${activeKey} = ${version}`);
   console.log(`Freshness meta: SET ${seedMetaKey}`);
 }
@@ -234,18 +298,20 @@ export async function backfillSeedMetaFromActiveVersion(url, token, prefix) {
 
   const recordCount = await validate(url, token, prefix, version, 1);
 
-  // Do not publish metadata for a version that stopped being active while its
-  // versioned GEO/META keys were being validated.
-  const currentResult = await pipelineRequest(url, token, [['GET', activeKey]]);
-  const currentVersion = currentResult[0]?.result;
-  if (String(currentVersion ?? '') !== version) {
-    throw new Error(`Active version changed during validation (${version} -> ${currentVersion ?? 'missing'})`);
-  }
-
   const seedMetaKey = `${prefix}seed-meta:military:bases`;
-  await pipelineRequest(url, token, [
-    buildSeedMetaCommand(prefix, version, recordCount, fetchedAt),
+  const writeResult = await commandRequest(url, token, [
+    'EVAL',
+    BACKFILL_META_IF_ACTIVE_SCRIPT,
+    '2',
+    activeKey,
+    seedMetaKey,
+    version,
+    buildSeedMetaPayload(version, recordCount, fetchedAt),
   ]);
+  if (!Array.isArray(writeResult) || Number(writeResult[0]) !== 1) {
+    const currentVersion = Array.isArray(writeResult) ? writeResult[1] : null;
+    throw new Error(`Active version changed during validation (${version} -> ${currentVersion || 'missing'})`);
+  }
   console.log(`No data file found — restored ${seedMetaKey} from active version ${version} (${recordCount} records).`);
   return { version, fetchedAt, recordCount };
 }

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -9,10 +9,15 @@ import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
+import { createServer } from 'node:http';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { GRACEFUL_FETCH_FAILURE_EXIT_CODE } from '../scripts/_seed-utils.mjs';
-import { readSectionFreshness } from '../scripts/_bundle-runner.mjs';
+import { DAY, readSectionFreshness } from '../scripts/_bundle-runner.mjs';
+import {
+  atomicSwitch,
+  backfillSeedMetaFromActiveVersion,
+} from '../scripts/seed-military-bases.mjs';
 
 const SCRIPTS_DIR = fileURLToPath(new URL('../scripts/', import.meta.url));
 const FIXTURES_DIR = join(SCRIPTS_DIR, 'fixtures');
@@ -175,6 +180,195 @@ function writeFixture(name, body) {
   writeFileSync(path, body);
   return () => { try { unlinkSync(path); } catch {} };
 }
+
+async function startFakeUpstash({
+  strings = new Map(),
+  geoMembers = new Map(),
+  hashes = new Map(),
+} = {}) {
+  const pipelines = [];
+  const reads = [];
+  const runCommand = (command) => {
+    const [operation, key, ...args] = command;
+    if (operation === 'GET') return { result: strings.get(key) ?? null };
+    if (operation === 'SET') {
+      strings.set(key, args[0]);
+      return { result: 'OK' };
+    }
+    if (operation === 'ZCARD') return { result: geoMembers.get(key)?.length ?? 0 };
+    if (operation === 'HLEN') return { result: hashes.get(key)?.size ?? 0 };
+    if (operation === 'ZRANDMEMBER') {
+      return { result: (geoMembers.get(key) ?? []).slice(0, Number(args[0])) };
+    }
+    if (operation === 'HMGET') {
+      const hash = hashes.get(key);
+      return { result: args.map(id => hash?.get(id) ?? null) };
+    }
+    return { error: `Unsupported fake command: ${operation}` };
+  };
+
+  const redis = createServer((req, res) => {
+    if (req.method === 'GET' && req.url?.startsWith('/get/')) {
+      const key = decodeURIComponent(req.url.slice('/get/'.length));
+      reads.push(key);
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ result: strings.get(key) ?? null }));
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/pipeline') {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', chunk => { body += chunk; });
+      req.on('end', () => {
+        try {
+          const commands = JSON.parse(body);
+          pipelines.push(commands);
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify(commands.map(runCommand)));
+        } catch (err) {
+          res.statusCode = 500;
+          res.end(String(err?.message || err));
+        }
+      });
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  await new Promise((resolve, reject) => {
+    const onError = err => reject(err);
+    redis.once('error', onError);
+    redis.listen(0, '127.0.0.1', () => {
+      redis.off('error', onError);
+      resolve();
+    });
+  });
+  const address = redis.address();
+  assert.ok(address && typeof address === 'object');
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    token: 'isolated-test-token',
+    strings,
+    pipelines,
+    reads,
+    close: () => new Promise((resolve, reject) => {
+      redis.close(err => err ? reject(err) : resolve());
+    }),
+  };
+}
+
+async function runMilitaryGate(fakeRedis) {
+  const fixtureName = `_bundle-fixture-military-bases-must-not-run-${randomUUID()}.mjs`;
+  const cleanup = writeFixture(
+    fixtureName,
+    `console.log('military-bases-ran');\n`,
+  );
+  try {
+    return await runBundleWith([
+      {
+        label: 'Military-Bases',
+        script: fixtureName,
+        seedMetaKey: 'military:bases',
+        intervalMs: 30 * DAY,
+        timeoutMs: 5000,
+      },
+    ], {}, {
+      UPSTASH_REDIS_REST_URL: fakeRedis.url,
+      UPSTASH_REDIS_REST_TOKEN: fakeRedis.token,
+    });
+  } finally {
+    cleanup();
+  }
+}
+
+test('Military-Bases normal publication writes metadata through the real pipeline and gates', async () => {
+  const redis = await startFakeUpstash();
+  const version = Date.now();
+  const fetchedAt = version - 60_000;
+  try {
+    await atomicSwitch(redis.url, redis.token, '', version, 42, fetchedAt);
+    assert.deepEqual(redis.pipelines, [[
+      ['SET', 'military:bases:active', String(version)],
+      ['SET', 'seed-meta:military:bases', JSON.stringify({
+        fetchedAt,
+        recordCount: 42,
+        sourceVersion: String(version),
+      })],
+    ]]);
+
+    const { code, stdout, stderr } = await runMilitaryGate(redis);
+
+    assert.equal(code, 0, stderr);
+    assert.match(stdout, /\[Military-Bases\] Skipped, last seeded \d+min ago \(interval: 43200min\)/);
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:1/);
+    assert.doesNotMatch(stdout, /military-bases-ran/);
+    assert.deepEqual(redis.reads, ['seed-meta:military:bases']);
+  } finally {
+    await redis.close();
+  }
+});
+
+test('Military-Bases backfills metadata from validated active data without refreshing its age', async () => {
+  const version = String(Date.now() - 60_000);
+  const ids = ['base-a', 'base-b', 'base-c'];
+  const redis = await startFakeUpstash({
+    strings: new Map([['military:bases:active', version]]),
+    geoMembers: new Map([[`military:bases:geo:${version}`, ids]]),
+    hashes: new Map([[
+      `military:bases:meta:${version}`,
+      new Map(ids.map(id => [id, JSON.stringify({ name: id })])),
+    ]]),
+  });
+  try {
+    const result = await backfillSeedMetaFromActiveVersion(redis.url, redis.token, '');
+    assert.deepEqual(result, {
+      version,
+      fetchedAt: Number(version),
+      recordCount: ids.length,
+    });
+    assert.deepEqual(JSON.parse(redis.strings.get('seed-meta:military:bases')), {
+      fetchedAt: Number(version),
+      recordCount: ids.length,
+      sourceVersion: version,
+    });
+    assert.equal(
+      redis.pipelines.flat().some(command => command[0] === 'SET' && command[1] === 'military:bases:active'),
+      false,
+      'backfill must not rewrite or race the active pointer',
+    );
+
+    const { code, stdout, stderr } = await runMilitaryGate(redis);
+    assert.equal(code, 0, stderr);
+    assert.match(stdout, /\[Military-Bases\] Skipped/);
+    assert.doesNotMatch(stdout, /military-bases-ran/);
+  } finally {
+    await redis.close();
+  }
+});
+
+test('Military-Bases backfill fails closed when active GEO and META counts disagree', async () => {
+  const version = String(Date.now() - 60_000);
+  const redis = await startFakeUpstash({
+    strings: new Map([['military:bases:active', version]]),
+    geoMembers: new Map([[`military:bases:geo:${version}`, ['base-a', 'base-b']]]),
+    hashes: new Map([[
+      `military:bases:meta:${version}`,
+      new Map([['base-a', JSON.stringify({ name: 'base-a' })]]),
+    ]]),
+  });
+  try {
+    await assert.rejects(
+      backfillSeedMetaFromActiveVersion(redis.url, redis.token, ''),
+      /META count 1 != GEO count 2/,
+    );
+    assert.equal(redis.strings.has('seed-meta:military:bases'), false);
+    assert.equal(
+      redis.pipelines.flat().some(command => command[0] === 'SET' && command[1] === 'seed-meta:military:bases'),
+      false,
+    );
+  } finally {
+    await redis.close();
+  }
+});
 
 test('streams child stdout live and reports Done on success', async () => {
   const cleanup = writeFixture(

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -185,10 +185,16 @@ async function startFakeUpstash({
   strings = new Map(),
   geoMembers = new Map(),
   hashes = new Map(),
+  beforeCommand,
+  failCommand,
 } = {}) {
   const pipelines = [];
+  const commands = [];
   const reads = [];
-  const runCommand = (command) => {
+  const runCommand = (command, path) => {
+    const forcedFailure = failCommand?.({ command, path, strings, geoMembers, hashes });
+    if (forcedFailure) return { error: forcedFailure };
+
     const [operation, key, ...args] = command;
     if (operation === 'GET') return { result: strings.get(key) ?? null };
     if (operation === 'SET') {
@@ -197,12 +203,34 @@ async function startFakeUpstash({
     }
     if (operation === 'ZCARD') return { result: geoMembers.get(key)?.length ?? 0 };
     if (operation === 'HLEN') return { result: hashes.get(key)?.size ?? 0 };
-    if (operation === 'ZRANDMEMBER') {
-      return { result: (geoMembers.get(key) ?? []).slice(0, Number(args[0])) };
+    if (operation === 'ZRANGE') {
+      const members = geoMembers.get(key) ?? [];
+      const start = Number(args[0]);
+      const rawEnd = Number(args[1]);
+      const end = rawEnd < 0 ? members.length + rawEnd : rawEnd;
+      return { result: members.slice(start, end + 1) };
     }
     if (operation === 'HMGET') {
       const hash = hashes.get(key);
       return { result: args.map(id => hash?.get(id) ?? null) };
+    }
+    if (operation === 'EVAL') {
+      const script = key;
+      const keyCount = Number(args[0]);
+      const keys = args.slice(1, 1 + keyCount);
+      const argv = args.slice(1 + keyCount);
+
+      if (script.includes("return {0, current or ''}")) {
+        const current = strings.get(keys[0]) ?? '';
+        if (current !== argv[0]) return { result: [0, current] };
+        strings.set(keys[1], argv[1]);
+        return { result: [1, current] };
+      }
+      if (script.includes('return ARGV[1]')) {
+        strings.set(keys[0], argv[0]);
+        strings.set(keys[1], argv[1]);
+        return { result: argv[0] };
+      }
     }
     return { error: `Unsupported fake command: ${operation}` };
   };
@@ -219,12 +247,33 @@ async function startFakeUpstash({
       let body = '';
       req.setEncoding('utf8');
       req.on('data', chunk => { body += chunk; });
-      req.on('end', () => {
+      req.on('end', async () => {
         try {
-          const commands = JSON.parse(body);
-          pipelines.push(commands);
+          const requestCommands = JSON.parse(body);
+          pipelines.push(requestCommands);
+          for (const command of requestCommands) {
+            await beforeCommand?.({ command, path: '/pipeline', strings, geoMembers, hashes });
+          }
           res.setHeader('Content-Type', 'application/json');
-          res.end(JSON.stringify(commands.map(runCommand)));
+          res.end(JSON.stringify(requestCommands.map(command => runCommand(command, '/pipeline'))));
+        } catch (err) {
+          res.statusCode = 500;
+          res.end(String(err?.message || err));
+        }
+      });
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/') {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', chunk => { body += chunk; });
+      req.on('end', async () => {
+        try {
+          const command = JSON.parse(body);
+          commands.push(command);
+          await beforeCommand?.({ command, path: '/', strings, geoMembers, hashes });
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify(runCommand(command, '/')));
         } catch (err) {
           res.statusCode = 500;
           res.end(String(err?.message || err));
@@ -249,6 +298,7 @@ async function startFakeUpstash({
     token: 'isolated-test-token',
     strings,
     pipelines,
+    commands,
     reads,
     close: () => new Promise((resolve, reject) => {
       redis.close(err => err ? reject(err) : resolve());
@@ -280,20 +330,27 @@ async function runMilitaryGate(fakeRedis) {
   }
 }
 
-test('Military-Bases normal publication writes metadata through the real pipeline and gates', async () => {
+test('Military-Bases normal publication atomically writes metadata and gates', async () => {
   const redis = await startFakeUpstash();
   const version = Date.now();
   const fetchedAt = version - 60_000;
   try {
     await atomicSwitch(redis.url, redis.token, '', version, 42, fetchedAt);
-    assert.deepEqual(redis.pipelines, [[
-      ['SET', 'military:bases:active', String(version)],
-      ['SET', 'seed-meta:military:bases', JSON.stringify({
-        fetchedAt,
-        recordCount: 42,
-        sourceVersion: String(version),
-      })],
-    ]]);
+    assert.equal(redis.commands.length, 1);
+    const [operation, script, keyCount, activeKey, seedMetaKey, publishedVersion, payload] = redis.commands[0];
+    assert.equal(operation, 'EVAL');
+    assert.match(script, /redis\.call\('SET', KEYS\[1\]/);
+    assert.equal(keyCount, '2');
+    assert.equal(activeKey, 'military:bases:active');
+    assert.equal(seedMetaKey, 'seed-meta:military:bases');
+    assert.equal(publishedVersion, String(version));
+    assert.deepEqual(JSON.parse(payload), {
+      fetchedAt,
+      recordCount: 42,
+      sourceVersion: String(version),
+    });
+    assert.equal(redis.strings.get(activeKey), String(version));
+    assert.equal(redis.strings.get(seedMetaKey), payload);
 
     const { code, stdout, stderr } = await runMilitaryGate(redis);
 
@@ -335,6 +392,8 @@ test('Military-Bases backfills metadata from validated active data without refre
       false,
       'backfill must not rewrite or race the active pointer',
     );
+    assert.equal(redis.pipelines.flat().some(command => command[0] === 'ZRANDMEMBER'), false);
+    assert.equal(redis.pipelines.flat().some(command => command[0] === 'ZRANGE'), true);
 
     const { code, stdout, stderr } = await runMilitaryGate(redis);
     assert.equal(code, 0, stderr);
@@ -365,6 +424,97 @@ test('Military-Bases backfill fails closed when active GEO and META counts disag
       redis.pipelines.flat().some(command => command[0] === 'SET' && command[1] === 'seed-meta:military:bases'),
       false,
     );
+  } finally {
+    await redis.close();
+  }
+});
+
+test('Military-Bases publication rejects an HTTP-200 Redis command error', async () => {
+  const redis = await startFakeUpstash({
+    failCommand: ({ command }) => command[0] === 'EVAL' ? 'forced command failure' : null,
+  });
+  try {
+    await assert.rejects(
+      atomicSwitch(redis.url, redis.token, '', Date.now(), 42),
+      /Redis command EVAL failed: forced command failure/,
+    );
+    assert.equal(redis.strings.has('military:bases:active'), false);
+    assert.equal(redis.strings.has('seed-meta:military:bases'), false);
+  } finally {
+    await redis.close();
+  }
+});
+
+test('Military-Bases backfill rejects an HTTP-200 pipeline command error', async () => {
+  const version = String(Date.now() - 60_000);
+  const redis = await startFakeUpstash({
+    strings: new Map([['military:bases:active', version]]),
+    failCommand: ({ command }) => command[0] === 'ZCARD' ? 'forced command failure' : null,
+  });
+  try {
+    await assert.rejects(
+      backfillSeedMetaFromActiveVersion(redis.url, redis.token, ''),
+      /Pipeline command 1\/2 ZCARD failed: forced command failure/,
+    );
+    assert.equal(redis.strings.has('seed-meta:military:bases'), false);
+  } finally {
+    await redis.close();
+  }
+});
+
+test('Military-Bases backfill cannot overwrite metadata for a newer active version', async () => {
+  const oldVersion = String(Date.now() - 120_000);
+  const newVersion = String(Date.now() - 60_000);
+  const ids = ['base-a', 'base-b'];
+  const newMeta = JSON.stringify({
+    fetchedAt: Number(newVersion),
+    recordCount: 1,
+    sourceVersion: newVersion,
+  });
+  let switched = false;
+  const redis = await startFakeUpstash({
+    strings: new Map([['military:bases:active', oldVersion]]),
+    geoMembers: new Map([[`military:bases:geo:${oldVersion}`, ids]]),
+    hashes: new Map([[
+      `military:bases:meta:${oldVersion}`,
+      new Map(ids.map(id => [id, JSON.stringify({ name: id })])),
+    ]]),
+    beforeCommand: ({ command, path, strings }) => {
+      if (!switched && path === '/' && command[0] === 'EVAL' && command[1].includes("return {0, current or ''}")) {
+        switched = true;
+        strings.set('military:bases:active', newVersion);
+        strings.set('seed-meta:military:bases', newMeta);
+      }
+    },
+  });
+  try {
+    await assert.rejects(
+      backfillSeedMetaFromActiveVersion(redis.url, redis.token, ''),
+      new RegExp(`Active version changed during validation \\(${oldVersion} -> ${newVersion}\\)`),
+    );
+    assert.equal(redis.strings.get('military:bases:active'), newVersion);
+    assert.equal(redis.strings.get('seed-meta:military:bases'), newMeta);
+  } finally {
+    await redis.close();
+  }
+});
+
+test('Military-Bases backfill validates every active record', async () => {
+  const version = String(Date.now() - 60_000);
+  const ids = Array.from({ length: 11 }, (_, index) => `base-${index + 1}`);
+  const metadata = new Map(ids.map(id => [id, JSON.stringify({ name: id })]));
+  metadata.set(ids.at(-1), '{invalid-json');
+  const redis = await startFakeUpstash({
+    strings: new Map([['military:bases:active', version]]),
+    geoMembers: new Map([[`military:bases:geo:${version}`, ids]]),
+    hashes: new Map([[`military:bases:meta:${version}`, metadata]]),
+  });
+  try {
+    await assert.rejects(
+      backfillSeedMetaFromActiveVersion(redis.url, redis.token, ''),
+      /ID "base-11" has invalid JSON in META hash/,
+    );
+    assert.equal(redis.strings.has('seed-meta:military:bases'), false);
   } finally {
     await redis.close();
   }


### PR DESCRIPTION
## Summary

- publish `seed-meta:military:bases` in the same Redis pipeline as the active-version switch
- safely backfill missing metadata from a validated active version when the source file is unavailable
- preserve the active version timestamp during backfill so recovery cannot fabricate freshness
- fail closed on missing, malformed, mismatched, or concurrently changed active data
- add fake-Upstash regressions proving the 30-day bundle gate skips without spawning the seeder

Closes #6398

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: ingestion seeder and bundle freshness gate

## Testing

- `node --test --test-name-pattern="Military-Bases" tests/bundle-runner.test.mjs` (3 passed)
- `node --test tests/bundle-runner.test.mjs` (24 passed)
- `npm run typecheck`
- `npx biome lint scripts/seed-military-bases.mjs tests/bundle-runner.test.mjs`
- `npm run lint` (exit 0; existing diagnostics only)

## Checklist

- [ ] Tested on worldmonitor.app variant (not applicable: backend seeder only)
- [ ] Tested on tech.worldmonitor.app variant (not applicable)
- [ ] New RSS feed domains added to allowlist (not applicable)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] Health-probe Railway pre-seed acknowledgement (not applicable: no probe was added or repointed)

## Redis key contract

- Writer: `scripts/seed-military-bases.mjs`
- Declared bundle target: `scripts/seed-bundle-static-ref.mjs`
- Reader: `scripts/_bundle-runner.mjs`
- Key: `seed-meta:military:bases`
- Shape: `{ fetchedAt, recordCount, sourceVersion }`

## Documentation alignment

- Evidence/claim record: #6398
- Audit Council signoff: not applicable; no published methodology or API claim changes
- Generated docs: not applicable
- Fixture-backed behavior: recomputed by the fake-Upstash bundle-runner tests above
- Redis writer and readers are enumerated in this description

## AI assistance

OpenAI Codex assisted with investigation, implementation, tests, and code review.

## Screenshots

Not applicable.