### PR TITLE
docs(resilience): record education probe acceptance and its two read traps

### DIFF
--- a/docs/methodology/education-flag-flip-runbook.md
+++ b/docs/methodology/education-flag-flip-runbook.md
@@ -45,9 +45,8 @@ All must be green before flipping:
    176–179 would pass a laxer runbook check and then fail CI inside the
    publication PR. The gate and the invariant must be the same number.
 
-2. **Register the health probe, then confirm it green.** Implementation is ready in
-   #6452 (2026-08-11); post-deploy acceptance is pending. The probe was deliberately
-   **not** registered in the scaffold PR,
+2. **Register the health probe, then confirm it green.** ✅ **Done and accepted in #6452**
+   (2026-08-11). The probe was deliberately **not** registered in the scaffold PR,
    because `scripts/check-health-probe-cutovers.mts` requires a new strict probe to
    carry machine-readable pre-seed evidence, or an acknowledgement expiring by the
    producer's first scheduled run within 24 hours — neither is obtainable before the
@@ -58,10 +57,30 @@ All must be green before flipping:
    service, `probeKey`, a real `compactHealthStatus: OK`, and an HTTPS reference →
    then confirm `/api/health` reports OK.
 
-   **Do not mark this step done or close #6452 until post-deploy acceptance proves all
-   three conditions:** the deployed Vercel SHA includes the registration change,
-   `/api/health?compact=1` reports a total of **260** probes, and
-   `educationAttainment` reports status **OK**.
+   Post-deploy acceptance proved all three conditions on production:
+
+   ```
+   checks.educationAttainment = { "status": "OK", "records": 189,
+                                  "seedAgeMin": 338, "maxStaleMin": 11520 }
+   summary = { "total": 260, ..., "crit": 0 }
+   ```
+
+   **Keep these three conditions as the standard for the next probe** — the deployed SHA
+   carries the registration, the probed-key total moved to its new value, and the probe
+   itself reports `OK`. Two traps sit on that check, and they fail in **opposite**
+   directions, so neither one covers the other:
+
+   - **A stale CDN read looks like a failure that is not real.** `/api/health?compact=1`
+     served the *old* `total: 259` for several minutes after the deploy had completed; a
+     cache-busted request returned `260` with `x-vercel-cache: MISS`. Use the endpoint's
+     own registry size as the deploy signal rather than the Vercel commit status, and
+     bust the cache — otherwise you read a pre-deploy snapshot and conclude a landed
+     registration never landed.
+   - **A compact-only read looks like a pass that is not real.** The compact surface
+     carries `problems`, not a per-check map, so a probe is absent from it both when it
+     is healthy *and when it was never registered at all*. Confirming `OK` from absence
+     would green-light a probe that does not exist. Read the explicit
+     `checks.<probe>.status` on the operator surface.
 
    **The publish did not happen on its own.** Railway refused the #6450 merge commit
    because its post-merge check suite was red on two unrelated tests, so the service


### PR DESCRIPTION
## Summary

Docs only. Pre-flip step 2 of the education flag-flip runbook still said **"post-deploy
acceptance is pending"** and instructed the reader not to close #6452 until three
conditions were proven. All three were proven on production before #6467 merged, and
#6452 is closed.

A pre-flip checklist that calls a finished step pending is not a harmless lag — the next
actor either redoes the work or treats the flip as blocked on something that already
happened.

## What was actually proven

```
checks.educationAttainment = { "status": "OK", "records": 189,
                               "seedAgeMin": 338, "maxStaleMin": 11520 }
summary = { "total": 260, ..., "crit": 0 }
```

## The part worth keeping

The three conditions stay as the standard for the next probe, now with the two traps that
made verifying them harder than it looks. They fail in **opposite** directions, which is
why neither substitutes for the other:

| Trap | Failure direction |
|---|---|
| Stale CDN read of `?compact=1` | **False alarm** — served the old `total: 259` for minutes after the deploy finished; a cache-busted request returned `260` with `x-vercel-cache: MISS` |
| Confirming `OK` from the compact surface alone | **False pass** — it carries `problems`, not a per-check map, so a probe is absent both when healthy *and when never registered* |

The second is the dangerous one: concluding `OK` from absence would green-light a probe
that does not exist.

## Verification

Both `docs-stats` steps run, not just `--check` — the regeneration step is the one that
catches a stale `docs/generated/stats.json`, which is how the snapshot went stale in
#6467.

| Check | Result |
|---|---|
| `docs-stats.mjs` (regenerate) | no diff |
| `docs-stats.mjs --check` | 150/150 doc claims match code |
| methodology-lint + doc-parity + markdown-links | 51/51 |

No code or behavior change.

Refs #6452, #6460

https://claude.ai/code/session_012Ywf81PKWq1kETqJuHoVFe
