### PR TITLE
docs(railway): correct three claims that shipped with the pagination fix (#6474)

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -144,9 +144,12 @@ rejects every other host even if a workflow variable is misconfigured.
 |---|---|
 | `railway-reconcile-control-production` | Cloudflare deploy token, account ID, fixed control scope, and all four pairwise-distinct HMAC values |
 | `ingestion-acceptance-production-watchdog` | Watchdog HMAC only; no Railway credential |
-| `ingestion-acceptance-production` | Mutation HMAC, the deploy-scoped `RAILWAY_RECONCILE_DEPLOY_TOKEN_V2`, and project ID |
-| `ingestion-acceptance-production-verification` | Verifier HMAC, read-only Railway Viewer token, project ID, and GitHub read evidence |
-| `ingestion-acceptance-production-breakglass` | Operator HMAC plus the same Viewer-only Railway access; required reviewers gate the resolve job |
+| `ingestion-acceptance-production` | Mutation HMAC, `RAILWAY_RECONCILE_DEPLOY_TOKEN_V2`, and project ID |
+| `ingestion-acceptance-production-verification` | Verifier HMAC, `RAILWAY_RECONCILE_VIEWER_TOKEN`, project ID, and GitHub read evidence |
+| `ingestion-acceptance-production-breakglass` | Operator HMAC plus the same `RAILWAY_RECONCILE_VIEWER_TOKEN`; required reviewers gate the resolve job |
+
+Both Railway tokens are distinct project tokens with identical capability; the
+names record intended use, not an enforced boundary. See the scope note below.
 
 The ordinary lease-aware mutation and verifier jobs receive only their own
 HMAC roles in their separately protected environments.

--- a/scripts/dispatch-stale-railway-reconcile.mjs
+++ b/scripts/dispatch-stale-railway-reconcile.mjs
@@ -372,11 +372,18 @@ export class GitHubWatchdogClient {
       items.push(...pageItems);
       // GitHub answers every paginated read with a `next` link on the numeric
       // repository-ID path (`/repositories/<id>/statuses/<sha>`), not the
-      // `/repos/<owner>/<repo>/...` path that was requested. Treat the link as
-      // nothing but a boolean "another page exists" and synthesize the next
-      // request from our own allowlisted path, so the origin never routes a
-      // watchdog request. Completeness stays enforced below by the frozen
-      // total_count, duplicate-id, and truncation invariants.
+      // `/repos/<owner>/<repo>/...` path that was requested, so comparing the
+      // two never matches. Treat the link as nothing but a boolean "another
+      // page exists" and synthesize the next request from our own path.
+      //
+      // Completeness is proven per collection, NOT uniformly: the frozen
+      // total_count, duplicate-id, and truncation checks below all sit behind
+      // `frozenTotalCount !== null`, so they are inert for any caller that
+      // passes no readTotalCount. readNewestGate is exactly that caller — and
+      // the only one that paginates in production. Its walk is bounded solely
+      // by WATCHDOG_MAX_PAGES, and a short or Link-less response yields a
+      // partial prefix that surfaces as a fail-closed `state: 'missing'`
+      // (DEFERRED_NON_GREEN_MAIN), never as a dispatch. See #6474.
       const hasNextPage = parseNextLink(response.headers.get('link')) !== null;
       let nextPage = null;
       if (hasNextPage) {


### PR DESCRIPTION
Comment-only and prose-only. No behavior change; 51/51 tests pass unchanged.

These are the three P3 accuracy findings from the #6469 review, split out so the substantive P1 work in #6474 isn't blocked behind them.

## 1. The comment claimed invariants that are inert where it matters

`scripts/dispatch-stale-railway-reconcile.mjs` asserted:

> Completeness stays enforced below by the frozen total_count, duplicate-id, and truncation invariants.

All three checks sit behind `frozenTotalCount !== null`, so they are skipped for any caller passing no `readTotalCount`. `readNewestGate` is exactly that caller — and the only one that paginates in production. A security pass proved it rather than reasoned it: **a duplicated statuses page is accepted silently, while the same duplication throws for workflow runs.**

The comment now names what actually bounds that walk (`WATCHDOG_MAX_PAGES`) and where a truncated read surfaces (fail-closed `state: 'missing'` -> `DEFERRED_NON_GREEN_MAIN`, never a dispatch), and points at #6474 for the fix.

## 2. The security framing was overstated

The same comment said the synthesis means "the origin never routes a watchdog request," and #6469's PR body made the same claim. A security pass probed 13 off-allowlist payloads: `#authorize` blocked every one on its own, and the deleted Link-header check pinned pathname and page arithmetic on top of that. The pre-fix code gave the origin zero routing freedom, so there was no exposure to remove.

The synthesis is still the right design — it collapses two layers into one with the same guarantee and removes a false-positive `GITHUB_READ_FAILED`. It is a correctness fix and now reads as one.

## 3. The provisioning table contradicted its own paragraph

`docs/railway-seed-consolidation-runbook.md` called `RAILWAY_RECONCILE_DEPLOY_TOKEN_V2` "deploy-scoped" and the Viewer token "read-only" — seven lines above the paragraph added in the *same* PR establishing that Railway issues no scoped token at all (`apiTokenCreate` takes only `{name, workspaceId}`; `projectTokenCreate` only `{projectId, environmentId, name}`; `VIEWER` is a project-*member* role, not a token role).

Both secrets are now named without a capability adjective, plus one line making the situation explicit:

> Both Railway tokens are distinct project tokens with identical capability; the names record intended use, not an enforced boundary.

Deliberately avoided "Viewer-role" / "deploy-role" — that would have replaced one false capability claim with another, since Railway has no role on tokens either.

## Verification

- `node --test tests/railway-stale-reconcile-dispatch.test.mjs` -> 51/51 pass
- `npx markdownlint-cli2 docs/railway-seed-consolidation-runbook.md` -> 0 errors
- `npx biome check scripts/dispatch-stale-railway-reconcile.mjs` -> clean

Refs #6474, #6469, #6378

https://claude.ai/code/session_01GYUZ5eKm69sim6cEHpGJRh
