### PR TITLE
fix(railway): let the watchdog go red, retry the read path, and stop the gate walk early (#6474)

### DIFF
--- a/.github/workflows/railway-deploy-trigger-watchdog.yml
+++ b/.github/workflows/railway-deploy-trigger-watchdog.yml
@@ -49,6 +49,8 @@ jobs:
       recovery_attempt_id: ${{ steps.controller.outputs.recovery_attempt_id }}
       prior_id: ${{ steps.controller.outputs.prior_id }}
       outcome: ${{ steps.controller.outputs.outcome }}
+      read_failure: ${{ steps.controller.outputs.read_failure }}
+      read_failure_code: ${{ steps.controller.outputs.read_failure_code }}
     steps:
       - name: Check out the watchdog classifier
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -68,6 +70,22 @@ jobs:
           node scripts/dispatch-stale-railway-reconcile.mjs
           --phase "$WATCHDOG_PHASE"
           --auto-recovery-enabled "$AUTO_RECOVERY_ENABLED"
+
+      # This step is the durable record of a blind run: a later classify run
+      # reads its own recent scheduled history and counts how many consecutive
+      # runs ran it. Success means this run could not read GitHub; skipped
+      # means it could. The step name is the contract — it must stay identical
+      # to WATCHDOG_READ_FAILURE_STEP_NAME in the controller, which the test
+      # suite pins. The controller itself fails the job once the streak holds.
+      # `always()` is load-bearing: the run that first trips the streak fails
+      # the controller step, and a default `success()` guard would skip its own
+      # marker. The streak would then reset and the job would only go red every
+      # third run instead of staying red until reads recover.
+      - name: Record watchdog read-path failure
+        if: always() && steps.controller.outputs.read_failure == 'true'
+        env:
+          READ_FAILURE_CODE: ${{ steps.controller.outputs.read_failure_code }}
+        run: echo "::warning::The watchdog could not read GitHub ($READ_FAILURE_CODE)."
 
   dispatch:
     name: Dispatch authorized recovery

--- a/scripts/dispatch-stale-railway-reconcile.mjs
+++ b/scripts/dispatch-stale-railway-reconcile.mjs
@@ -17,10 +17,24 @@ export const WATCHDOG_HISTORY_WINDOW_MS = 24 * 60 * 60_000;
 export const WATCHDOG_MAX_PAGES = 10;
 export const WATCHDOG_MAX_API_REQUESTS = 250;
 export const WATCHDOG_REQUEST_TIMEOUT_MS = 10_000;
+export const WATCHDOG_READ_RETRY_ATTEMPTS = 2;
+export const WATCHDOG_READ_RETRY_BASE_MS = 500;
+export const WATCHDOG_READ_RETRY_MAX_MS = 8_000;
 export const WATCHDOG_JOB_READ_CONCURRENCY = 6;
 export const DISPATCH_CORRELATION_ATTEMPTS = 3;
 export const DISPATCH_CORRELATION_POLL_MS = 1_000;
 export const WATCHDOG_SOURCE_WORKFLOW_FILE = 'railway-deploy-trigger-watchdog.yml';
+// The classify job cannot report a read-path failure by failing, because one
+// transient failure is not worth paging on. It reports by *running* a named
+// step instead: present-and-successful means this run was blind, skipped means
+// it read GitHub fine. A later run counts those step conclusions across its own
+// recent history and fails the job once the blindness is sustained.
+export const WATCHDOG_CLASSIFY_JOB_NAME = 'classify';
+export const WATCHDOG_READ_FAILURE_STEP_NAME = 'Record watchdog read-path failure';
+export const WATCHDOG_READ_FAILURE_STREAK_LIMIT = 3;
+export const WATCHDOG_READ_FAILURE_STREAK_WINDOW_MS = 2 * 60 * 60_000;
+export const WATCHDOG_STREAK_PAGE_SIZE = 5;
+export const WATCHDOG_STREAK_API_RESERVE = 5;
 export const MANUAL_RECOVERY_SOURCE_WORKFLOW_FILE = 'railway-reconcile-manual-recovery.yml';
 export const WATCHDOG_DISPATCH_JOB_NAME = 'Dispatch authorized recovery';
 export const WATCHDOG_DISPATCH_STEP_NAME = 'Dispatch exact Railway deploy-trigger run';
@@ -73,13 +87,59 @@ const SOURCE_WORKFLOW_SPECS = Object.freeze([
 ]);
 
 export class GitHubWatchdogError extends Error {
-  constructor(code, message, { status = null, ambiguous = false, cause = undefined } = {}) {
+  constructor(code, message, {
+    status = null,
+    ambiguous = false,
+    retryAfterMs = null,
+    cause = undefined,
+  } = {}) {
     super(message, { cause });
     this.name = 'GitHubWatchdogError';
     this.code = code;
     this.status = status;
     this.ambiguous = ambiguous;
+    this.retryAfterMs = retryAfterMs;
   }
+}
+
+// GitHub answers a secondary-rate-limit or abuse throttle with 403, and a
+// concurrent-update race with 409. Both are transient despite being 4xx, which
+// is why the dispatch path already refuses to call them definitive. Reads use
+// the same predicate so the two paths cannot drift apart.
+function isRetryableGitHubStatus(status) {
+  return [403, 408, 409, 429].includes(status) || (status >= 500 && status < 600);
+}
+
+// Only a GitHub read failure marks the run blind. A control-plane outage or an
+// ambiguous classification is a different tier that stays warning-green, which
+// is why the streak keys on the code rather than on DEFERRED_AMBIGUOUS itself.
+function readFailureCodeOf(error) {
+  return error instanceof GitHubWatchdogError && error.code.startsWith('GITHUB_READ_')
+    ? error.code
+    : null;
+}
+
+// Exactly-once dispatch is guarded twice, on purpose. This is the outer guard:
+// a POST gets one attempt whatever the error classifier later decides, so a
+// future retryable POST classification cannot quietly turn into a second
+// Railway deploy. `isRetryableRead` below is the inner one. Exported because a
+// guard whose only proof is a second guard is a guard nobody can test.
+export function retryAttemptsFor(method, readRetryAttempts) {
+  return method === 'GET' ? readRetryAttempts + 1 : 1;
+}
+
+// A read worth retrying either never reached GitHub or came back on a
+// transient status. Budget exhaustion and allowlist rejection are terminal by
+// construction, and a malformed 2xx body is a contract break rather than a
+// throttle — retrying any of those only burns the remaining budget.
+function isRetryableRead(error) {
+  if (!(error instanceof GitHubWatchdogError)) return false;
+  // GITHUB_READ_TIMEOUT is deliberately absent. Every attempt burns the full
+  // request timeout, and the snapshot issues ~90 reads six at a time, so a
+  // retried timeout ladder would spend the classify job's own budget waiting on
+  // an origin that already proved it is not answering.
+  if (error.code !== 'GITHUB_READ_FAILED') return false;
+  return error.status === null || isRetryableGitHubStatus(error.status);
 }
 
 function exactQuery(url, expected) {
@@ -139,6 +199,9 @@ export class GitHubWatchdogClient {
     now = Date.now,
     maxRequests = WATCHDOG_MAX_API_REQUESTS,
     requestTimeoutMs = WATCHDOG_REQUEST_TIMEOUT_MS,
+    readRetryAttempts = WATCHDOG_READ_RETRY_ATTEMPTS,
+    sleep = defaultSleep,
+    random = Math.random,
   }) {
     if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository ?? '')) {
       throw new TypeError('repository must be owner/name');
@@ -152,6 +215,13 @@ export class GitHubWatchdogClient {
     if (!Number.isInteger(requestTimeoutMs) || requestTimeoutMs < 1 || requestTimeoutMs > 30_000) {
       throw new TypeError('GitHub request timeout must be an integer from 1 to 30000ms');
     }
+    if (!Number.isInteger(readRetryAttempts)
+      || readRetryAttempts < 0
+      || readRetryAttempts > WATCHDOG_READ_RETRY_ATTEMPTS) {
+      throw new TypeError(`GitHub read retries must be an integer from 0 to ${WATCHDOG_READ_RETRY_ATTEMPTS}`);
+    }
+    if (typeof sleep !== 'function') throw new TypeError('sleep must be a function');
+    if (typeof random !== 'function') throw new TypeError('random must be a function');
     const base = new URL(apiBase);
     if (base.protocol !== 'https:' || base.username || base.password || base.pathname !== '/') {
       throw new TypeError('GitHub API base must be one credential-free HTTPS origin');
@@ -163,6 +233,9 @@ export class GitHubWatchdogClient {
     this.maxRequests = maxRequests;
     this.requestCount = 0;
     this.requestTimeoutMs = requestTimeoutMs;
+    this.readRetryAttempts = readRetryAttempts;
+    this.sleep = sleep;
+    this.random = random;
     this.apiBase = base.origin;
     this.repoPath = `/repos/${repository}`;
     this.repoPathPattern = this.repoPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -198,6 +271,14 @@ export class GitHubWatchdogClient {
           }))
       );
     }
+    if (method === 'GET' && url.pathname === `${this.repoPath}/actions/workflows/${WATCHDOG_SOURCE_WORKFLOW_FILE}/runs`) {
+      return exactQuery(url, {
+        event: 'schedule',
+        status: 'completed',
+        per_page: String(WATCHDOG_STREAK_PAGE_SIZE),
+        page: '1',
+      });
+    }
     if (method === 'GET' && new RegExp(`^${this.repoPathPattern}/actions/runs/\\d+/attempts/\\d+/jobs$`).test(url.pathname)) {
       return paginated && exactQuery(url, { per_page: String(GITHUB_PAGE_SIZE), page });
     }
@@ -216,6 +297,10 @@ export class GitHubWatchdogClient {
     return false;
   }
 
+  // Only reads retry. A dispatch POST may already have created a run, so a
+  // resend would be a second Railway deploy: its transient statuses stay
+  // GITHUB_DISPATCH_AMBIGUOUS and the durable hold decides, never a resend.
+  // See retryAttemptsFor for why that rule is enforced in two places.
   async request(method, path, { body = undefined } = {}) {
     const url = new URL(path, this.apiBase);
     if (!this.#authorize(method, url, body)) {
@@ -224,6 +309,46 @@ export class GitHubWatchdogClient {
         `${method} ${url.pathname} is outside the watchdog allowlist`,
       );
     }
+    const attempts = retryAttemptsFor(method, this.readRetryAttempts);
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        return await this.#requestOnce(method, url, body);
+      } catch (error) {
+        if (attempt >= attempts - 1 || !isRetryableRead(error)) throw error;
+        await this.sleep(this.#retryDelayMs(attempt, error));
+      }
+    }
+  }
+
+  #retryDelayMs(attempt, error) {
+    if (Number.isFinite(error.retryAfterMs) && error.retryAfterMs >= 0) {
+      // A secondary-limit window can be minutes long. Sleeping it out would
+      // blow the classify job's own timeout, so clamp and let the third
+      // failure escalate through the read-failure streak instead.
+      return Math.min(error.retryAfterMs, WATCHDOG_READ_RETRY_MAX_MS);
+    }
+    // Full jitter: pick uniformly below the exponential ceiling so the six
+    // concurrent job reads do not re-collide on one backoff boundary.
+    const ceiling = Math.min(WATCHDOG_READ_RETRY_BASE_MS * (2 ** attempt), WATCHDOG_READ_RETRY_MAX_MS);
+    return Math.round(this.random() * ceiling);
+  }
+
+  #retryAfterMs(headers) {
+    const retryAfter = headers.get('retry-after');
+    if (retryAfter !== null && retryAfter.trim() !== '') {
+      const seconds = Number(retryAfter);
+      if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1_000;
+      const at = Date.parse(retryAfter);
+      if (Number.isFinite(at)) return Math.max(0, at - this.now());
+    }
+    if (headers.get('x-ratelimit-remaining') === '0') {
+      const reset = Number(headers.get('x-ratelimit-reset'));
+      if (Number.isSafeInteger(reset) && reset > 0) return Math.max(0, reset * 1_000 - this.now());
+    }
+    return null;
+  }
+
+  async #requestOnce(method, url, body) {
     this.requestCount += 1;
     if (this.requestCount > this.maxRequests) {
       throw new GitHubWatchdogError(
@@ -259,16 +384,20 @@ export class GitHubWatchdogClient {
         );
       }
       if (!response.ok) {
+        // A transient status keeps the durable hold on the dispatch path until
+        // correlation proves whether a run exists, and earns a backoff retry
+        // on the read path.
         const definitive = method === 'POST'
           && response.status >= 400 && response.status < 500
-          // GitHub uses 403 for secondary-rate-limit and abuse throttles. The
-          // response is transient even though it is in the 4xx range, so keep
-          // the durable hold until correlation proves whether a run exists.
-          && ![403, 408, 409, 429].includes(response.status);
+          && !isRetryableGitHubStatus(response.status);
         throw new GitHubWatchdogError(
           definitive ? 'GITHUB_DISPATCH_REJECTED' : method === 'POST' ? 'GITHUB_DISPATCH_AMBIGUOUS' : 'GITHUB_READ_FAILED',
           `GitHub returned HTTP ${response.status}`,
-          { status: response.status, ambiguous: method === 'POST' && !definitive },
+          {
+            status: response.status,
+            ambiguous: method === 'POST' && !definitive,
+            retryAfterMs: this.#retryAfterMs(response.headers),
+          },
         );
       }
       if (method === 'POST') {
@@ -332,12 +461,15 @@ export class GitHubWatchdogClient {
     readTotalCount = null,
     readItemId = null,
     collectionName = 'GitHub collection',
+    stopWhen = null,
+    requireShortFinalPage = false,
   } = {}) {
     const items = [];
     const itemIds = new Set();
     let next = firstPath;
     let pages = 0;
     let frozenTotalCount = null;
+    let finalPageLength = 0;
     while (next) {
       pages += 1;
       if (pages > WATCHDOG_MAX_PAGES) {
@@ -370,29 +502,37 @@ export class GitHubWatchdogClient {
         }
       }
       items.push(...pageItems);
+      finalPageLength = pageItems.length;
+      // A caller that only needs a prefix of a newest-first collection stops
+      // here, before the link is even parsed, and pays for no page behind the
+      // item it was looking for.
+      if (stopWhen !== null && stopWhen(items)) return items;
       // GitHub answers every paginated read with a `next` link on the numeric
       // repository-ID path (`/repositories/<id>/statuses/<sha>`), not the
       // `/repos/<owner>/<repo>/...` path that was requested, so comparing the
-      // two never matches. Treat the link as nothing but a boolean "another
-      // page exists" and synthesize the next request from our own path.
+      // two never matches. Following that link put every page after the first
+      // outside the allowlist, so the walk aborted and the watchdog deferred
+      // forever. Treat the link as nothing but a boolean "another page exists"
+      // and synthesize the next request from our own path. `#authorize`
+      // already rejected the rewritten path on its own, so this is a
+      // correctness fix, not a routing-exposure one.
       //
       // Completeness is proven per collection, NOT uniformly: the frozen
       // total_count, duplicate-id, and truncation checks below all sit behind
       // `frozenTotalCount !== null`, so they are inert for any caller that
       // passes no readTotalCount. readNewestGate is exactly that caller — and
-      // the only one that paginates in production. Its walk is bounded solely
-      // by WATCHDOG_MAX_PAGES, and a short or Link-less response yields a
-      // partial prefix that surfaces as a fail-closed `state: 'missing'`
-      // (DEFERRED_NON_GREEN_MAIN), never as a dispatch. See #6474.
+      // the only one that paginates in production — which is why it opts into
+      // `stopWhen` and `requireShortFinalPage` instead. See the rule at the
+      // end of this walk.
+      //
+      // Nothing validates the page cursor here because nothing can move it off
+      // the arithmetic: every caller starts at a literal `page=1`, the loop is
+      // the only writer, and WATCHDOG_MAX_PAGES caps the increment.
       const hasNextPage = parseNextLink(response.headers.get('link')) !== null;
       let nextPage = null;
       if (hasNextPage) {
         const synthesized = new URL(next, this.apiBase);
-        const currentPage = Number(synthesized.searchParams.get('page'));
-        if (!Number.isSafeInteger(currentPage) || currentPage < 1) {
-          throw new GitHubWatchdogError('GITHUB_READ_FAILED', `${collectionName} page cursor was not exact`);
-        }
-        synthesized.searchParams.set('page', String(currentPage + 1));
+        synthesized.searchParams.set('page', String(Number(synthesized.searchParams.get('page')) + 1));
         nextPage = `${synthesized.pathname}${synthesized.search}`;
       }
       if (frozenTotalCount !== null) {
@@ -411,6 +551,19 @@ export class GitHubWatchdogClient {
     if (frozenTotalCount !== null && items.length !== frozenTotalCount) {
       throw new GitHubWatchdogError('GITHUB_READ_FAILED', `${collectionName} did not match total_count`);
     }
+    // Completeness is proven per caller. The three collections that carry
+    // `total_count` use the frozen-total, duplicate-id, and truncation
+    // invariants above. A collection without one cannot tell a short last page
+    // apart from a silently truncated full one, so it opts into this rule: a
+    // walk that drained the collection without `stopWhen` firing, yet ended on
+    // a page exactly GITHUB_PAGE_SIZE long and carrying no `next`, read a
+    // prefix — not the whole thing.
+    if (requireShortFinalPage && finalPageLength >= GITHUB_PAGE_SIZE) {
+      throw new GitHubWatchdogError(
+        'GITHUB_READ_FAILED',
+        `${collectionName} ended on a full page with no next link`,
+      );
+    }
     return items;
   }
 
@@ -422,9 +575,18 @@ export class GitHubWatchdogClient {
   }
 
   async readNewestGate(headSha) {
+    // Commit statuses come back newest-first, so the first `gate` is the
+    // newest one and every page behind it is dead weight. The gate currently
+    // sits near the end of page one on this repository, so this both stops the
+    // walk early and removes a page of I/O per snapshot.
     const statuses = await this.#paginate(
       `${this.repoPath}/commits/${headSha}/statuses?per_page=${GITHUB_PAGE_SIZE}&page=1`,
       (data) => data,
+      {
+        collectionName: 'commit statuses',
+        stopWhen: (items) => items.some((status) => status?.context === 'gate'),
+        requireShortFinalPage: true,
+      },
     );
     const gate = statuses.find((status) => status?.context === 'gate');
     const state = gate?.state ?? 'missing';
@@ -581,6 +743,54 @@ export class GitHubWatchdogClient {
     return history.find((run) => (
       displayTitleHasIdentifier(run.displayTitle, recoveryAttemptId)
     )) ?? null;
+  }
+
+  // Counts how many of the watchdog's own most recent scheduled runs recorded a
+  // read-path failure, newest first, stopping at the first run that did not.
+  // Only the newest page is read and the walk is capped at the streak limit, so
+  // this costs at most one runs read plus one job read per counted run.
+  //
+  // A run whose marker step is absent — cancelled before it ran, or a schedule
+  // gap wider than the window — carries no evidence either way and ends the
+  // count. That delays detection by one cycle at worst: a read path that is
+  // still broken re-accumulates on the very next run.
+  async readReadFailureStreak({ excludeRunId = null } = {}) {
+    const now = this.now();
+    if (!Number.isFinite(now)) throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'watchdog clock was invalid');
+    const query = new URLSearchParams({
+      event: 'schedule',
+      status: 'completed',
+      per_page: String(WATCHDOG_STREAK_PAGE_SIZE),
+      page: '1',
+    });
+    const { data } = await this.request(
+      'GET',
+      `${this.repoPath}/actions/workflows/${WATCHDOG_SOURCE_WORKFLOW_FILE}/runs?${query}`,
+    );
+    const runs = data?.workflow_runs;
+    if (!Array.isArray(runs)) {
+      throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'watchdog run history shape was invalid');
+    }
+    let streak = 0;
+    for (const run of runs) {
+      if (streak >= WATCHDOG_READ_FAILURE_STREAK_LIMIT) break;
+      if (!validGitHubId(run?.id)
+        || !Number.isSafeInteger(run?.run_attempt)
+        || run.run_attempt < 1
+        || !Number.isFinite(Date.parse(run?.created_at ?? ''))) {
+        throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'watchdog run history entry was invalid');
+      }
+      if (excludeRunId !== null && String(run.id) === String(excludeRunId)) continue;
+      if (now - Date.parse(run.created_at) > WATCHDOG_READ_FAILURE_STREAK_WINDOW_MS) break;
+      const jobs = await this.#readAttemptJobs(run.id, run.run_attempt);
+      const marker = jobs
+        .find((job) => job?.name === WATCHDOG_CLASSIFY_JOB_NAME)
+        ?.steps
+        ?.find((step) => step?.name === WATCHDOG_READ_FAILURE_STEP_NAME);
+      if (marker?.conclusion !== 'success') break;
+      streak += 1;
+    }
+    return streak;
   }
 
   async readSourceRunIdentity({ sourceRunId, sourceRunAttempt, expectedSourceHeadSha = null }) {
@@ -1283,6 +1493,7 @@ export async function prepareRecoveryDispatch({
       dispatchEligible: false,
       dispatchAuthorized: false,
       reason: error instanceof Error ? error.message : String(error),
+      readFailureCode: readFailureCodeOf(error),
     };
   }
   const classified = classifyWatchdogSnapshot(snapshot);
@@ -1300,6 +1511,7 @@ export async function prepareRecoveryDispatch({
       dispatchEligible: false,
       dispatchAuthorized: false,
       reason: error instanceof Error ? error.message : String(error),
+      readFailureCode: readFailureCodeOf(error),
     };
   }
   if (exact.sha !== snapshot.main.sha || exact.gate?.state !== 'success') {
@@ -1332,6 +1544,7 @@ export async function prepareRecoveryDispatch({
       dispatchEligible: false,
       dispatchAuthorized: false,
       reason: error instanceof Error ? error.message : String(error),
+      readFailureCode: readFailureCodeOf(error),
     };
   }
   try {
@@ -1589,6 +1802,36 @@ export async function bindAuthorizedRecovery({
   };
 }
 
+// One blind run is not worth paging on; a sustained blind watchdog is the exact
+// green-while-dead shape that hid the pagination bug for months. The current
+// run counts itself, so the limit is reached after LIMIT consecutive runs.
+export async function resolveReadFailureExit({
+  github,
+  result,
+  sourceRunId = process.env.GITHUB_RUN_ID,
+}) {
+  if (!result?.readFailureCode) return { failJob: false, streak: 0, reason: null };
+  let priors;
+  try {
+    priors = await github.readReadFailureStreak({ excludeRunId: sourceRunId ?? null });
+  } catch (error) {
+    // The streak read travels the same path that just failed, so an unreadable
+    // history is itself evidence the watchdog is blind. Fail closed rather than
+    // let the detector die exactly when it is needed.
+    return {
+      failJob: true,
+      streak: null,
+      reason: `the read-failure streak could not be read: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  const streak = priors + 1;
+  return {
+    failJob: streak >= WATCHDOG_READ_FAILURE_STREAK_LIMIT,
+    streak,
+    reason: `${streak} consecutive scheduled runs could not read GitHub (${result.readFailureCode})`,
+  };
+}
+
 function readArgument(argv, name, fallback = undefined) {
   const index = argv.indexOf(name);
   return index === -1 ? fallback : argv[index + 1];
@@ -1603,6 +1846,12 @@ function writeWorkflowResult(result) {
     `prior_id=${result.priorId ?? result.recoveryAttemptId ?? ''}`,
     `workflow_run_id=${result.runId ?? ''}`,
     `run_attempt=${result.runAttempt ?? ''}`,
+    // Gates the classify job's read-failure marker step, which is the durable
+    // record a later run counts. Keep the name in step with
+    // WATCHDOG_READ_FAILURE_STEP_NAME in the watchdog workflow.
+    `read_failure=${typeof result.readFailureCode === 'string' && result.readFailureCode !== ''}`,
+    `read_failure_code=${result.readFailureCode ?? ''}`,
+    `read_failure_streak=${result.readFailureStreak ?? ''}`,
     `rejection=${result.rejection ? Buffer.from(JSON.stringify(result.rejection)).toString('base64url') : ''}`,
   ];
   if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
@@ -1630,13 +1879,28 @@ async function main() {
     const github = new GitHubWatchdogClient({
       repository: process.env.GITHUB_REPOSITORY,
       token: process.env.GH_TOKEN,
+      // The streak read is the escalation path for budget exhaustion, so it
+      // cannot share a budget the snapshot can exhaust. Carving the reserve out
+      // of the same ceiling keeps the per-run total at
+      // WATCHDOG_MAX_API_REQUESTS.
+      maxRequests: WATCHDOG_MAX_API_REQUESTS - WATCHDOG_STREAK_API_RESERVE,
+    });
+    const streakGithub = new GitHubWatchdogClient({
+      repository: process.env.GITHUB_REPOSITORY,
+      token: process.env.GH_TOKEN,
+      maxRequests: WATCHDOG_STREAK_API_RESERVE,
     });
     const result = await prepareRecoveryDispatch({
       github,
       control,
       autoRecoveryEnabled: readArgument(process.argv, '--auto-recovery-enabled', 'false') === 'true',
     });
-    writeWorkflowResult(result);
+    const escalation = await resolveReadFailureExit({ github: streakGithub, result });
+    // The annotation goes out before the result so the machine-readable JSON
+    // blob stays the last line of stdout.
+    if (escalation.failJob) console.log(`::error::WATCHDOG_READ_PATH_BLIND: ${escalation.reason}`);
+    writeWorkflowResult({ ...result, readFailureStreak: escalation.streak });
+    if (escalation.failJob) process.exitCode = 1;
     return;
   }
   if (phase === 'dispatch') {
@@ -1704,13 +1968,19 @@ async function main() {
 
 if (isMainModule(import.meta.url, process.argv[1])) {
   main().catch((error) => {
+    const reason = error instanceof Error ? error.message : String(error);
+    // Every phase fails here, classify included. Reaching this handler means a
+    // credential, a variable, or the controller itself is broken — an
+    // unambiguous hard failure, not the transient upstream condition the
+    // read-failure streak exists to rate-limit. classify used to be excluded,
+    // which is what made the job structurally unable to go red.
+    console.log(`::error::WATCHDOG_PHASE_FAILED: ${reason}`);
     writeWorkflowResult({
       outcome: 'DEFERRED_AMBIGUOUS',
       headSha: null,
       dispatchAuthorized: false,
-      reason: error instanceof Error ? error.message : String(error),
+      reason,
     });
-    const phase = readArgument(process.argv, '--phase', 'classify');
-    if (phase !== 'classify') process.exitCode = 1;
+    process.exitCode = 1;
   });
 }

--- a/scripts/dispatch-stale-railway-reconcile.mjs
+++ b/scripts/dispatch-stale-railway-reconcile.mjs
@@ -1441,11 +1441,24 @@ function defaultSleep(ms) {
 
 export async function readWatchdogSnapshot({ github, control, clock = Date.now }) {
   const now = clock();
-  const [main, runSummaries, status] = await Promise.all([
+  const [mainRead, runSummariesRead, controlRead] = await Promise.allSettled([
     github.readMainAndGate(),
     github.readTargetRunSummaries(),
     control.status(),
   ]);
+  // A control-plane rejection can settle before a concurrent GitHub read
+  // rejection. Preserve GitHub blindness as the primary failure so the named
+  // workflow marker and sustained-failure escalation cannot stay green.
+  const githubReadFailure = [mainRead, runSummariesRead].find(
+    (read) => read.status === 'rejected' && readFailureCodeOf(read.reason),
+  );
+  if (githubReadFailure) throw githubReadFailure.reason;
+  for (const read of [controlRead, mainRead, runSummariesRead]) {
+    if (read.status === 'rejected') throw read.reason;
+  }
+  const main = mainRead.value;
+  const runSummaries = runSummariesRead.value;
+  const status = controlRead.value;
   let controlState = unwrapControl(status);
   const relevantSummaries = selectRunSummariesForHydration({ now, runSummaries, controlState });
   const hydratedRuns = await github.hydrateTargetRuns(relevantSummaries);

--- a/tests/railway-stale-reconcile-dispatch.test.mjs
+++ b/tests/railway-stale-reconcile-dispatch.test.mjs
@@ -10,6 +10,7 @@ import {
   ACCEPTED_FRESHNESS_MS,
   FINAL_ACCEPTANCE_STEP_NAME,
   GITHUB_API_VERSION,
+  GITHUB_PAGE_SIZE,
   GITHUB_WATCHDOG_USER_AGENT,
   GitHubWatchdogClient,
   GitHubWatchdogError,
@@ -24,12 +25,24 @@ import {
   WATCHDOG_DISPATCH_STEP_NAME,
   WATCHDOG_HISTORY_WINDOW_MS,
   WATCHDOG_JOB_READ_CONCURRENCY,
+  WATCHDOG_CLASSIFY_JOB_NAME,
   WATCHDOG_MAX_PAGES,
+  WATCHDOG_READ_FAILURE_STEP_NAME,
+  WATCHDOG_READ_FAILURE_STREAK_LIMIT,
+  WATCHDOG_READ_FAILURE_STREAK_WINDOW_MS,
+  WATCHDOG_READ_RETRY_ATTEMPTS,
+  WATCHDOG_READ_RETRY_BASE_MS,
+  WATCHDOG_READ_RETRY_MAX_MS,
+  WATCHDOG_SOURCE_WORKFLOW_FILE,
+  WATCHDOG_STREAK_API_RESERVE,
+  WATCHDOG_STREAK_PAGE_SIZE,
   classifyWatchdogSnapshot,
   dispatchGitHubRecovery,
   prepareRecoveryDispatch,
   readWatchdogSnapshot,
   rejectAuthorizedRecovery,
+  resolveReadFailureExit,
+  retryAttemptsFor,
 } from '../scripts/dispatch-stale-railway-reconcile.mjs';
 
 const NOW = Date.parse('2026-08-07T12:00:00Z');
@@ -653,10 +666,36 @@ describe('stale Railway reconcile classification', () => {
   });
 });
 
-function json(data, { status = 200, link = null } = {}) {
+const REPOSITORY_ID = 1130564872;
+
+// GitHub answers every paginated read with a `next` link on the numeric
+// repository-ID path (`/repositories/<id>/...`), never the
+// `/repos/<owner>/<repo>/...` path that was requested. Building the link from
+// the request pathname is the mock shape that let the watchdog paginate fine
+// in tests and defer forever in production, so the production form is the
+// shared default here: pass `next: <request url>` and every collection —
+// statuses, runs, jobs, the fail-closed table, the budget walk — is exercised
+// against the rewritten path. `link` stays available for the cases that must
+// forge some other shape.
+function productionNextLink(requestUrl, page = null) {
+  const next = new URL(requestUrl);
+  next.pathname = next.pathname.replace(/^\/repos\/[^/]+\/[^/]+/, `/repositories/${REPOSITORY_ID}`);
+  next.searchParams.set('page', String(page ?? Number(next.searchParams.get('page')) + 1));
+  return `<${next}>; rel="next"`;
+}
+
+function json(data, { status = 200, next = null, nextPage = null, link = null } = {}) {
+  const header = link ?? (next === null ? null : productionNextLink(next, nextPage));
   return Response.json(data, {
     status,
-    headers: link ? { link } : undefined,
+    headers: header ? { link: header } : undefined,
+  });
+}
+
+function throttled(status, headers = {}) {
+  return new Response(JSON.stringify({ message: `HTTP ${status}` }), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
   });
 }
 
@@ -698,9 +737,7 @@ describe('allowlisted GitHub watchdog transport', () => {
         const page = parsed.searchParams.get('page');
         if (parsed.pathname.endsWith('/statuses')) {
           return page === '1'
-            ? json([{ context: 'other', state: 'success' }], {
-              link: `<https://api.github.com${parsed.pathname}?per_page=100&page=2>; rel="next"`,
-            })
+            ? json([{ context: 'other', state: 'success' }], { next: url })
             : json([{ context: 'gate', state: 'success', updated_at: '2026-08-07T11:59:00Z' }]);
         }
         if (parsed.pathname.endsWith('/railway-deploy-trigger.yml/runs')) {
@@ -708,23 +745,17 @@ describe('allowlisted GitHub watchdog transport', () => {
             return json({ total_count: 0, workflow_runs: [] });
           }
           if (page === '1') {
-            const next = new URL(parsed);
-            next.searchParams.set('page', '2');
             return json({ total_count: 2, workflow_runs: [{
               ...rawRun({ id: 11, runAttempt: 2, displayTitle: 'ordinary' }),
               created_at: '2026-08-07T11:00:00Z',
               updated_at: '2026-08-07T11:10:00Z',
-            }] }, {
-              link: `<${next}>; rel="next"`,
-            });
+            }] }, { next: url });
           }
           return json({ total_count: 2, workflow_runs: [rawRun({ id: 12 })] });
         }
         if (parsed.pathname.includes('/runs/11/attempts/1/jobs')) {
           return page === '1'
-            ? json({ total_count: 2, jobs: [{ id: 1, steps: [] }] }, {
-              link: `<https://api.github.com${parsed.pathname}?per_page=100&page=2>; rel="next"`,
-            })
+            ? json({ total_count: 2, jobs: [{ id: 1, steps: [] }] }, { next: url })
             : json({ total_count: 2, jobs: [{ id: 2, steps: [] }] });
         }
         if (parsed.pathname.includes('/runs/11/attempts/2/jobs')) {
@@ -770,7 +801,7 @@ describe('allowlisted GitHub watchdog transport', () => {
         if (!parsed.pathname.endsWith('/statuses')) throw new Error(`unexpected ${url}`);
         return page === '1'
           ? json([{ context: 'other', state: 'success' }], {
-            link: `<https://api.github.com/repositories/1130564872/statuses/${HEAD}`
+            link: `<https://api.github.com/repositories/${REPOSITORY_ID}/statuses/${HEAD}`
               + '?per_page=100&page=2>; rel="next"',
           })
           : json([{ context: 'gate', state: 'success', updated_at: '2026-08-07T11:59:00Z' }]);
@@ -784,6 +815,184 @@ describe('allowlisted GitHub watchdog transport', () => {
       `https://api.github.com/repos/o/r/commits/${HEAD}/statuses?per_page=100&page=1`,
       `https://api.github.com/repos/o/r/commits/${HEAD}/statuses?per_page=100&page=2`,
     ]);
+  });
+
+  // `readNewestGate` is the only paginated read with no `total_count`, so the
+  // frozen-total, duplicate-id, and truncation invariants are all inert on the
+  // one collection that actually paginates in production. Statuses come back
+  // newest-first, so the walk stops on the first `gate` and never pays for the
+  // pages behind it.
+  it('stops the status walk on the newest gate instead of draining every page', async () => {
+    const pages = [];
+    const client = new GitHubWatchdogClient({
+      repository: 'o/r',
+      token: 'token',
+      now: () => NOW,
+      fetchImpl: async (url) => {
+        pages.push(Number(new URL(url).searchParams.get('page')));
+        return json(
+          [
+            { context: 'other', state: 'success' },
+            { context: 'gate', state: 'success', updated_at: '2026-08-07T11:59:00Z' },
+            { context: 'gate', state: 'failure', updated_at: '2026-08-07T10:00:00Z' },
+          ],
+          { next: url },
+        );
+      },
+    });
+
+    assert.deepEqual(await client.readNewestGate(HEAD), {
+      state: 'success',
+      updatedAt: '2026-08-07T11:59:00Z',
+    });
+    assert.deepEqual(pages, [1]);
+  });
+
+  // A short or Link-less origin response used to return a partial prefix, and
+  // a walk that never reached the gate reported it as `missing`. That is
+  // fail-closed today only by accident of the `'missing'` mapping; a full
+  // final page with no `next` is a truncated read, not an absent gate.
+  it('rejects a truncated status walk instead of reporting the gate missing', async () => {
+    const fullPage = (context) => Array.from(
+      { length: GITHUB_PAGE_SIZE },
+      () => ({ context, state: 'success', updated_at: '2026-08-07T11:00:00Z' }),
+    );
+    const truncated = new GitHubWatchdogClient({
+      repository: 'o/r',
+      token: 'token',
+      now: () => NOW,
+      fetchImpl: async () => json(fullPage('other')),
+    });
+    await assert.rejects(
+      truncated.readNewestGate(HEAD),
+      (error) => error instanceof GitHubWatchdogError && error.code === 'GITHUB_READ_FAILED',
+    );
+
+    // A genuinely absent gate ends on a short page and stays `missing`, which
+    // the classifier maps to DEFERRED_NON_GREEN_MAIN.
+    const absent = new GitHubWatchdogClient({
+      repository: 'o/r',
+      token: 'token',
+      now: () => NOW,
+      fetchImpl: async (url) => (Number(new URL(url).searchParams.get('page')) === 1
+        ? json(fullPage('other'), { next: url })
+        : json([{ context: 'other', state: 'success' }])),
+    });
+    assert.deepEqual(await absent.readNewestGate(HEAD), { state: 'missing', updatedAt: null });
+  });
+
+  // One transient 403 mid-walk used to abort the whole read and land in the
+  // silent DEFERRED_AMBIGUOUS tier — during a failure storm, exactly the
+  // condition the watchdog exists to catch.
+  it('retries transient read failures with bounded jittered backoff', async () => {
+    const delays = [];
+    const responses = [
+      throttled(403),
+      throttled(500),
+      json({ object: { sha: HEAD } }),
+    ];
+    const client = new GitHubWatchdogClient({
+      repository: 'o/r',
+      token: 'token',
+      now: () => NOW,
+      sleep: async (ms) => { delays.push(ms); },
+      random: () => 1,
+      fetchImpl: async () => responses.shift(),
+    });
+
+    assert.equal(await client.readCurrentMain(), HEAD);
+    assert.equal(responses.length, 0);
+    // Every attempt is a real request, so retries are charged to the budget.
+    assert.equal(client.requestCount, 3);
+    assert.deepEqual(delays, [WATCHDOG_READ_RETRY_BASE_MS, WATCHDOG_READ_RETRY_BASE_MS * 2]);
+  });
+
+  it('bounds the retry ladder and keeps definitive read failures single-shot', async () => {
+    const exhausted = new GitHubWatchdogClient({
+      repository: 'o/r',
+      token: 'token',
+      now: () => NOW,
+      sleep: async () => {},
+      fetchImpl: async () => throttled(429),
+    });
+    await assert.rejects(
+      exhausted.readCurrentMain(),
+      (error) => error instanceof GitHubWatchdogError
+        && error.code === 'GITHUB_READ_FAILED'
+        && error.status === 429,
+    );
+    assert.equal(exhausted.requestCount, WATCHDOG_READ_RETRY_ATTEMPTS + 1);
+
+    for (const status of [401, 404, 422]) {
+      const definitive = new GitHubWatchdogClient({
+        repository: 'o/r',
+        token: 'token',
+        now: () => NOW,
+        sleep: async () => { throw new Error('a definitive read must not back off'); },
+        fetchImpl: async () => throttled(status),
+      });
+      await assert.rejects(
+        definitive.readCurrentMain(),
+        (error) => error.code === 'GITHUB_READ_FAILED' && error.status === status,
+      );
+      assert.equal(definitive.requestCount, 1, `HTTP ${status}`);
+    }
+  });
+
+  it('honors Retry-After and the rate-limit reset ahead of the exponential ceiling', async () => {
+    const cases = [
+      [{ 'retry-after': '3' }, 3_000],
+      [{ 'retry-after': new Date(NOW + 2_000).toUTCString() }, 2_000],
+      [{ 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': String(Math.floor(NOW / 1_000) + 5) }, 5_000],
+      // A secondary-limit window longer than the ladder is clamped: sleeping it
+      // out would blow the classify job's own timeout, and the third failure
+      // escalates through the read-failure streak instead.
+      [{ 'retry-after': '600' }, WATCHDOG_READ_RETRY_MAX_MS],
+    ];
+    for (const [headers, expected] of cases) {
+      const delays = [];
+      const responses = [throttled(403, headers), json({ object: { sha: HEAD } })];
+      const client = new GitHubWatchdogClient({
+        repository: 'o/r',
+        token: 'token',
+        now: () => NOW,
+        sleep: async (ms) => { delays.push(ms); },
+        random: () => 0,
+        fetchImpl: async () => responses.shift(),
+      });
+      assert.equal(await client.readCurrentMain(), HEAD);
+      assert.deepEqual(delays, [expected], JSON.stringify(headers));
+    }
+  });
+
+  // The dispatch POST may already have created a run, so a resend would be a
+  // second Railway deploy. Transient POST statuses stay ambiguous and the
+  // durable hold decides — the retry ladder must never touch them.
+  it('never retries the dispatch POST', async () => {
+    for (const status of [403, 429, 500]) {
+      let calls = 0;
+      const client = new GitHubWatchdogClient({
+        repository: 'o/r',
+        token: 'token',
+        now: () => NOW,
+        sleep: async () => { throw new Error('a dispatch must not back off'); },
+        fetchImpl: async () => { calls += 1; return throttled(status); },
+      });
+      await assert.rejects(
+        client.dispatchRecovery({ recoveryAttemptId: 'recovery-1', expectedHeadSha: HEAD }),
+        (error) => error.code === 'GITHUB_DISPATCH_AMBIGUOUS' && error.ambiguous === true,
+      );
+      assert.equal(calls, 1, `HTTP ${status}`);
+    }
+    // The observed single call above holds even if the outer guard is removed,
+    // because a POST error never satisfies the read-retry classifier either.
+    // Pin the outer guard directly so it is not a rule only a second rule
+    // proves.
+    assert.equal(retryAttemptsFor('POST', WATCHDOG_READ_RETRY_ATTEMPTS), 1);
+    assert.equal(
+      retryAttemptsFor('GET', WATCHDOG_READ_RETRY_ATTEMPTS),
+      WATCHDOG_READ_RETRY_ATTEMPTS + 1,
+    );
   });
 
   // Replaces the former 'skipped next page' rejection case. A skipped cursor
@@ -800,13 +1009,11 @@ describe('allowlisted GitHub watchdog transport', () => {
         const parsed = new URL(url);
         const page = Number(parsed.searchParams.get('page'));
         seen.push(page);
-        const skipAhead = new URL(parsed);
-        skipAhead.searchParams.set('page', '9');
         return json(
           page === 1
             ? { total_count: 2, workflow_runs: [rawRun({ id: 1 })] }
             : { total_count: 2, workflow_runs: [rawRun({ id: 2 })] },
-          { link: page === 1 ? `<${skipAhead}>; rel="next"` : null },
+          page === 1 ? { next: url, nextPage: 9 } : {},
         );
       },
     });
@@ -1049,11 +1256,9 @@ describe('allowlisted GitHub watchdog transport', () => {
           const page = Number(parsed.searchParams.get('page'));
           const start = (page - 1) * 100;
           const workflowRuns = allRuns.slice(start, start + 100);
-          const next = new URL(parsed);
-          next.searchParams.set('page', String(page + 1));
           return json(
             { total_count: allRuns.length, workflow_runs: workflowRuns },
-            { link: start + workflowRuns.length < allRuns.length ? `<${next}>; rel="next"` : null },
+            start + workflowRuns.length < allRuns.length ? { next: url } : {},
           );
         }
         const match = /\/actions\/runs\/(\d+)\/attempts\/1\/jobs$/.exec(parsed.pathname);
@@ -1174,9 +1379,7 @@ describe('allowlisted GitHub watchdog transport', () => {
           const parsed = new URL(url);
           const page = Number(parsed.searchParams.get('page'));
           const body = pages[page - 1] ?? pages.at(-1);
-          const next = new URL(parsed);
-          next.searchParams.set('page', String(body.nextPage ?? page + 1));
-          return json(body, { link: body.next ? `<${next}>; rel="next"` : null });
+          return json(body, body.next ? { next: url, nextPage: body.nextPage ?? null } : {});
         },
       });
       await assert.rejects(
@@ -1213,9 +1416,7 @@ describe('allowlisted GitHub watchdog transport', () => {
           }
           const page = Number(parsed.searchParams.get('page'));
           const body = pages[page - 1] ?? pages.at(-1);
-          const next = new URL(parsed);
-          next.searchParams.set('page', String(page + 1));
-          return json(body, { link: body.next ? `<${next}>; rel="next"` : null });
+          return json(body, body.next ? { next: url } : {});
         },
       });
       await assert.rejects(
@@ -1236,9 +1437,7 @@ describe('allowlisted GitHub watchdog transport', () => {
       token: 'token',
       fetchImpl: async (url) => {
         pages += 1;
-        const next = new URL(url);
-        next.searchParams.set('page', String(pages + 1));
-        return json([], { link: `<${next}>; rel="next"` });
+        return json([], { next: url });
       },
     });
     await assert.rejects(
@@ -1847,11 +2046,196 @@ describe('durably held recovery dispatch orchestration', () => {
   });
 });
 
+// The classify job used to be excluded from ever setting a non-zero exit code,
+// even when main() threw, and no workflow step gated on its outcome. Budget
+// exhaustion, the page cap, or one un-retried 403 all produced a warning, exit
+// 0, and a green check — the same green-while-dead shape that hid the
+// pagination bug for months. This suite owns the two ways it can now go red.
+describe('watchdog read-failure escalation', () => {
+  const watchdogRun = (id, { createdAt = new Date(NOW - 60_000).toISOString(), runAttempt = 1 } = {}) => ({
+    id,
+    run_attempt: runAttempt,
+    created_at: createdAt,
+  });
+
+  const classifyJobs = (markerConclusion, { jobName = WATCHDOG_CLASSIFY_JOB_NAME } = {}) => [{
+    id: 1,
+    name: jobName,
+    steps: [
+      { name: 'Read or classify reconciliation control state', conclusion: 'success' },
+      ...(markerConclusion === null
+        ? []
+        : [{ name: WATCHDOG_READ_FAILURE_STEP_NAME, conclusion: markerConclusion }]),
+    ],
+  }];
+
+  const streakClient = ({ runs, jobsByRun, calls = [] }) => new GitHubWatchdogClient({
+    repository: 'o/r',
+    token: 'token',
+    now: () => NOW,
+    maxRequests: WATCHDOG_STREAK_API_RESERVE,
+    fetchImpl: async (url) => {
+      const parsed = new URL(url);
+      calls.push(`${parsed.pathname}${parsed.search}`);
+      if (parsed.pathname.endsWith(`/${WATCHDOG_SOURCE_WORKFLOW_FILE}/runs`)) {
+        return json({ total_count: runs.length, workflow_runs: runs });
+      }
+      const match = /\/actions\/runs\/(\d+)\/attempts\/\d+\/jobs$/.exec(parsed.pathname);
+      if (match) {
+        const jobs = jobsByRun[match[1]] ?? [];
+        return json({ total_count: jobs.length, jobs });
+      }
+      throw new Error(`unexpected ${url}`);
+    },
+  });
+
+  it('counts consecutive marked runs and stops at the first run that read GitHub', async () => {
+    const calls = [];
+    const client = streakClient({
+      calls,
+      runs: [watchdogRun(31), watchdogRun(32), watchdogRun(33)],
+      jobsByRun: {
+        31: classifyJobs('success'),
+        32: classifyJobs('skipped'),
+        33: classifyJobs('success'),
+      },
+    });
+
+    assert.equal(await client.readReadFailureStreak(), 1);
+    // Run 33 sits behind an unmarked run, so its jobs are never read.
+    assert.ok(!calls.some((call) => call.includes('/runs/33/')));
+    assert.equal(
+      calls[0],
+      `/repos/o/r/actions/workflows/${WATCHDOG_SOURCE_WORKFLOW_FILE}`
+      + `/runs?event=schedule&status=completed&per_page=${WATCHDOG_STREAK_PAGE_SIZE}&page=1`,
+    );
+  });
+
+  it('excludes the current run, caps the walk at the limit, and stays inside its reserve', async () => {
+    const calls = [];
+    const client = streakClient({
+      calls,
+      runs: [41, 42, 43, 44, 45].map((id) => watchdogRun(id)),
+      jobsByRun: Object.fromEntries([41, 42, 43, 44, 45].map((id) => [id, classifyJobs('success')])),
+    });
+
+    assert.equal(await client.readReadFailureStreak({ excludeRunId: '41' }), WATCHDOG_READ_FAILURE_STREAK_LIMIT);
+    assert.ok(!calls.some((call) => call.includes('/runs/41/')));
+    assert.ok(client.requestCount <= WATCHDOG_STREAK_API_RESERVE);
+  });
+
+  it('treats an absent marker, an aged run, and a foreign job as no evidence', async () => {
+    const cases = [
+      // Cancelled before the marker step could run.
+      { runs: [watchdogRun(51)], jobsByRun: { 51: classifyJobs(null) } },
+      // Older than the streak window, so the schedule had a gap.
+      {
+        runs: [watchdogRun(52, {
+          createdAt: new Date(NOW - WATCHDOG_READ_FAILURE_STREAK_WINDOW_MS - 1_000).toISOString(),
+        })],
+        jobsByRun: { 52: classifyJobs('success') },
+      },
+      // A marker with the right name under some other job proves nothing.
+      { runs: [watchdogRun(53)], jobsByRun: { 53: classifyJobs('success', { jobName: 'dispatch' }) } },
+    ];
+    for (const [index, fixture] of cases.entries()) {
+      assert.equal(await streakClient(fixture).readReadFailureStreak(), 0, `case ${index}`);
+    }
+  });
+
+  it('fails the classify job only once the blindness is sustained', async () => {
+    const streaks = [];
+    const github = { readReadFailureStreak: async () => streaks.shift() };
+
+    // A classification that is ambiguous for a non-read reason stays green and
+    // never spends a request on the history.
+    assert.deepEqual(
+      await resolveReadFailureExit({
+        github: { readReadFailureStreak: async () => { throw new Error('must not read'); } },
+        result: { outcome: 'DEFERRED_AMBIGUOUS', readFailureCode: null },
+        sourceRunId: '1',
+      }),
+      { failJob: false, streak: 0, reason: null },
+    );
+
+    for (const [priors, failJob] of [[0, false], [1, false], [2, true], [3, true]]) {
+      streaks.push(priors);
+      const escalation = await resolveReadFailureExit({
+        github,
+        result: { outcome: 'DEFERRED_AMBIGUOUS', readFailureCode: 'GITHUB_READ_BUDGET_EXCEEDED' },
+        sourceRunId: '1',
+      });
+      assert.equal(escalation.streak, priors + 1);
+      assert.equal(escalation.failJob, failJob, `priors ${priors}`);
+    }
+  });
+
+  it('fails closed when the streak read itself cannot complete', async () => {
+    const escalation = await resolveReadFailureExit({
+      github: {
+        readReadFailureStreak: async () => {
+          throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'GitHub returned HTTP 403', { status: 403 });
+        },
+      },
+      result: { outcome: 'DEFERRED_AMBIGUOUS', readFailureCode: 'GITHUB_READ_FAILED' },
+      sourceRunId: '1',
+    });
+
+    assert.equal(escalation.failJob, true);
+    assert.equal(escalation.streak, null);
+    assert.match(escalation.reason, /streak could not be read/);
+  });
+
+  it('reports a GitHub read failure distinctly from a control-plane failure', async () => {
+    const github = {
+      readMainAndGate: async () => {
+        throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'GitHub returned HTTP 500', { status: 500 });
+      },
+      readTargetRunSummaries: async () => [],
+      hydrateTargetRuns: async () => [],
+    };
+    const blind = await prepareRecoveryDispatch({
+      github,
+      control: { status: async () => ({ data: {} }) },
+      clock: () => NOW,
+    });
+    assert.equal(blind.outcome, 'DEFERRED_AMBIGUOUS');
+    assert.equal(blind.readFailureCode, 'GITHUB_READ_FAILED');
+
+    const controlDown = await prepareRecoveryDispatch({
+      github: { ...github, readMainAndGate: async () => ({ sha: HEAD, gate: { state: 'success' } }) },
+      control: { status: async () => { throw new Error('control plane unreachable'); } },
+      clock: () => NOW,
+    });
+    assert.equal(controlDown.outcome, 'DEFERRED_AMBIGUOUS');
+    assert.equal(controlDown.readFailureCode, null);
+  });
+
+  // The marker step name is the contract between the controller and the
+  // workflow: a rename on either side silently retires the detector.
+  it('pins the workflow marker step to the controller constant', () => {
+    const workflow = readFileSync(
+      resolve(fileURLToPath(new URL('../.github/workflows/', import.meta.url)), WATCHDOG_SOURCE_WORKFLOW_FILE),
+      'utf8',
+    );
+    assert.match(
+      workflow,
+      new RegExp(`^ {6}- name: ${WATCHDOG_READ_FAILURE_STEP_NAME}$`, 'm'),
+    );
+    // `always()` keeps the run that trips the streak from skipping its own
+    // marker and resetting the count.
+    assert.match(
+      workflow,
+      /^ {8}if: always\(\) && steps\.controller\.outputs\.read_failure == 'true'$/m,
+    );
+  });
+});
+
 describe('watchdog phase process contract', () => {
-  it('keeps classify warning-success but makes a non-dispatched dispatch phase fail with structured output', () => {
+  it('fails every phase, classify included, when the controller cannot run at all', () => {
     const tempRoot = mkdtempSync(resolve(tmpdir(), 'railway-watchdog-cli-'));
     try {
-      for (const [phase, expectedStatus] of [['classify', 0], ['dispatch', 1]]) {
+      for (const phase of ['classify', 'dispatch']) {
         const outputPath = resolve(tempRoot, `${phase}.output`);
         const result = spawnSync(process.execPath, [SCRIPT, '--phase', phase], {
           encoding: 'utf8',
@@ -1863,10 +2247,15 @@ describe('watchdog phase process contract', () => {
           },
         });
 
-        assert.equal(result.status, expectedStatus, result.stderr);
+        assert.equal(result.status, 1, result.stderr);
         assert.match(result.stdout, /::warning::DEFERRED_AMBIGUOUS:/);
+        assert.match(result.stdout, /::error::WATCHDOG_PHASE_FAILED:/);
         assert.equal(JSON.parse(result.stdout.trim().split('\n').at(-1)).outcome, 'DEFERRED_AMBIGUOUS');
-        assert.match(readFileSync(outputPath, 'utf8'), /^outcome=DEFERRED_AMBIGUOUS$/m);
+        const output = readFileSync(outputPath, 'utf8');
+        assert.match(output, /^outcome=DEFERRED_AMBIGUOUS$/m);
+        // A crash is not a read-path failure, so it must not leave a streak
+        // marker that a later run would count.
+        assert.match(output, /^read_failure=false$/m);
       }
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });

--- a/tests/railway-stale-reconcile-dispatch.test.mjs
+++ b/tests/railway-stale-reconcile-dispatch.test.mjs
@@ -2211,6 +2211,41 @@ describe('watchdog read-failure escalation', () => {
     assert.equal(controlDown.readFailureCode, null);
   });
 
+  it('preserves GitHub blindness when the control-plane rejection settles first', async () => {
+    const order = [];
+    const github = {
+      readMainAndGate: async () => {
+        await new Promise((resolve) => setImmediate(resolve));
+        order.push('github');
+        throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'GitHub returned HTTP 500', { status: 500 });
+      },
+      readTargetRunSummaries: async () => [],
+      readReadFailureStreak: async () => 0,
+    };
+    const blind = await prepareRecoveryDispatch({
+      github,
+      control: {
+        status: async () => {
+          order.push('control');
+          throw new Error('control plane unreachable');
+        },
+      },
+      clock: () => NOW,
+    });
+
+    assert.deepEqual(order, ['control', 'github']);
+    assert.equal(blind.outcome, 'DEFERRED_AMBIGUOUS');
+    assert.equal(blind.readFailureCode, 'GITHUB_READ_FAILED');
+    assert.deepEqual(
+      await resolveReadFailureExit({ github, result: blind, sourceRunId: '1' }),
+      {
+        failJob: false,
+        streak: 1,
+        reason: '1 consecutive scheduled runs could not read GitHub (GITHUB_READ_FAILED)',
+      },
+    );
+  });
+
   // The marker step name is the contract between the controller and the
   // workflow: a rename on either side silently retires the detector.
   it('pins the workflow marker step to the controller constant', () => {


### PR DESCRIPTION
Closes #6474. Refs #6469, #6477, #6378.

#6469 fixed the pagination bug that was firing. This closes the mechanisms that would have hidden the next one.

> **Rebased onto #6477.** That PR landed this issue's prose corrections while this branch was in flight. Its `#paginate` comment described `readNewestGate` as bounded solely by `WATCHDOG_MAX_PAGES`, with a truncated read surfacing as a fail-closed `state: 'missing'` — both true when written, both made **false** by the walk change below, so the comment now points at `stopWhen` and `requireShortFinalPage`. The runbook wording from #6477 is kept verbatim; this branch no longer touches that file.

## P1 — `classify` can now fail the job

`phase !== 'classify'` excluded classify from ever setting a non-zero exit code, even when `main()` threw. Budget exhaustion, the 10-page cap, or one un-retried 403 all produced warning → exit 0 → green check. Two paths now go red:

- **A crash in any phase, classify included, exits 1.** Reaching the top-level handler means a credential, a variable, or the controller itself is broken — an unambiguous hard failure, not the transient upstream condition the streak exists to rate-limit.
- **A sustained read-path failure exits 1** after `WATCHDOG_READ_FAILURE_STREAK_LIMIT` (3) consecutive scheduled runs, ~45 minutes of blindness.

Snapshot reads now settle independently and prioritize any `GITHUB_READ_*` rejection over a simultaneous control-plane rejection. A faster control outage can no longer erase GitHub blindness and leave the marker green.

The streak lives in GitHub's own run history, so no control-plane change was needed. A blind run reports by **running** a named marker step in the classify job; a healthy run skips it. A later run reads its own recent completed scheduled runs and counts those step conclusions — the same step-conclusion pattern this file already uses for the target workflow.

Three properties are load-bearing, and each is pinned by a test:

- **`always()` on the marker.** The run that first trips the streak fails the controller step, and a default `success()` guard would skip its own marker — the streak would reset and the job would go red only every third run instead of staying red until reads recover.
- **Fail closed.** The streak read travels the same path that just failed, so an unreadable history is itself evidence the watchdog is blind → exit 1 immediately.
- **Reserved budget.** Budget exhaustion is one of the conditions the streak escalates, so it cannot share a budget the snapshot can exhaust. `WATCHDOG_STREAK_API_RESERVE` (5) is carved out of the same ceiling — the per-run total stays at `WATCHDOG_MAX_API_REQUESTS` (250) — and the streak costs at most 1 runs read + 1 job read per counted run.

A run with no marker (cancelled before it ran, or a schedule gap wider than the 2h window) carries no evidence and ends the count — a bounded fail-open costing one cycle, since a still-broken read path re-accumulates on the next run.

## P1 — the read path retries

Every non-ok GET resolved straight to `GITHUB_READ_FAILED`, so one transient 403 mid-walk aborted the whole read and landed in the silent tier. Retryable GETs — 403 secondary-rate-limit, 408, 409, 429, 5xx, and transport failures — now get a bounded exponential ladder with full jitter, honoring `Retry-After` and `x-ratelimit-reset`.

- The advertised delay is **clamped** to `WATCHDOG_READ_RETRY_MAX_MS`. A minutes-long secondary-limit window across ~90 reads would blow the classify job's own 10-minute timeout; the third failure escalates through the streak instead.
- `GITHUB_READ_TIMEOUT` is deliberately **not** retryable — each attempt burns the full request timeout against an origin that already proved it is not answering.
- Retries are charged to the request budget.
- The dispatch POST is untouched and guarded twice, since a resend would be a second Railway deploy. `retryAttemptsFor` is exported so the outer guard is provable on its own: without that, the mutation removing it **survived**, because the inner classifier also blocks POST retries.
- The transient-status predicate is now shared with the POST definitive/ambiguous split, so the two cannot drift.

## P1 — `readNewestGate` stops at the newest gate

It was the only `#paginate` caller passing no `readTotalCount`, so the frozen-`total_count`, duplicate-id, and truncation invariants were all inert on the one collection that paginates in production. A short or Link-less origin response returned a partial prefix and reported `state: 'missing'` — fail-closed, but wrong-and-green.

Statuses are newest-first, so the walk stops on the first `context === 'gate'` via a `stopWhen` predicate — which also removes a page of I/O per snapshot — and a `requireShortFinalPage` rule throws `GITHUB_READ_FAILED` when the walk ends with no gate on a page exactly `GITHUB_PAGE_SIZE` long carrying no `next`. That is a body-derived condition an origin cannot spoof, matching the sibling precedent in `resolve-railway-reconcile-control.mjs`.

## P2 — the mock shape that hid the bug is no longer the suite default

The shared `json()` helper now builds the next Link on the production `/repositories/<numeric-id>/...` path by default, so runs, jobs, the fail-closed table and the budget walk all run against the production shape — not one statuses-only test a future editor can normalize away. A raw `link` escape hatch remains for cases that must forge another shape.

Measured: a mutant that follows the origin link is now caught by **6** tests, against **4** before.

## P3 — the unreachable guard

The orphaned `!Number.isSafeInteger(currentPage) || currentPage < 1` check is dropped; the comment names what actually bounds the walk. The other three P3 items shipped in #6477.

## Verification

- `tests/railway-stale-reconcile-dispatch.test.mjs`: **65 pass** (51 before), including the concurrent control-plane and GitHub failure regression. `railway-deploy-trigger-watchdog-workflow.test.mjs`: 8 pass. Both re-run after the final rebase.
- Every original guard was proven killable by mutation — **10/10 mutants killed**: streak off-by-one, fail-open on the streak read, marker counted under any job, the streak window, the truncation rule, `stopWhen`, the retry ladder, the POST gate, and restoring the classify carve-out.
- The full repository pre-push gate passed, including frontend and API type checks, Unicode safety, version sync, and changed-test execution.
- Workflow YAML re-parsed to confirm the `classify` job carries no `name:` key, so the jobs API reports its id — which is what `WATCHDOG_CLASSIFY_JOB_NAME` matches on.

## Not changed

`WATCHDOG_MAX_API_REQUESTS` stays at 250. The issue notes 4 runs/hour × 250 sits at the ~1000/hr per-repo `GITHUB_TOKEN` ceiling with no headroom, and retries can now spend up to 3× on a failing read. Lowering the cap would make budget exhaustion *more* likely, and exhaustion now escalates through the streak rather than going silent. Re-sizing that budget wants its own measurement.

https://claude.ai/code/session_016RLhYt6zjNGkCisqurMP5W

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
