### PR TITLE
fix(energy): let the IEA country keys re-export seededAt, and give the guard test a fixture that can fail (#6489)

### DIFF
--- a/scripts/seed-iea-oil-stocks.mjs
+++ b/scripts/seed-iea-oil-stocks.mjs
@@ -228,10 +228,19 @@ async function fetchIeaOilStocks() {
 
 // Declared up front so runSeed can extend their TTL on fetch failure or
 // validation skip — keeps country keys alive as long as the index lives.
-const COUNTRY_EXTRA_KEYS = Object.values(COUNTRY_MAP).map(iso2 => ({
+export const COUNTRY_EXTRA_KEYS = Object.values(COUNTRY_MAP).map(iso2 => ({
   key: `energy:iea-oil-stocks:v1:${iso2}`,
   ttl: TTL_SECONDS,
   transform: (data) => data.members?.find(m => m.iso2 === iso2) ?? null,
+  // `seededAt` collides by NAME with the fetcher envelope's own `seededAt`, which
+  // buildIndex renames to `updatedAt` and therefore strips from the canonical key.
+  // The leak guard compares top-level field names across the envelope and a single
+  // member, so it flagged this as a pre-publish leak and exited 1 (#6489) — but the
+  // two fields are different values that merely share a name: parseRecord stamps a
+  // per-record `seededAt` on EVERY member, and these country keys are the detailed
+  // record (industryDays/publicDays/abroadDays/obligationThreshold) that the index
+  // projection deliberately drops. Re-exporting it is intended, not a raw-state leak.
+  allowPrePublishFields: ['seededAt'],
 }));
 
 // Analysis key included in extraKeys so runSeed extends its TTL on fetch

--- a/tests/seed-extra-key-leak-guard.test.mjs
+++ b/tests/seed-extra-key-leak-guard.test.mjs
@@ -18,6 +18,12 @@ import {
   findLeakedPrePublishFields,
   MAX_SEEDED_VALUE_BYTES,
 } from '../scripts/_seed-utils.mjs';
+import {
+  buildIndex,
+  buildOilStocksAnalysis,
+  COUNTRY_EXTRA_KEYS,
+  parseRecord,
+} from '../scripts/seed-iea-oil-stocks.mjs';
 
 // The real thing: seed-forecasts' raw fetcher output vs its published projection.
 const RAW = {
@@ -93,16 +99,49 @@ test('a sub-object extra key is not flagged (seed-sanctions-pressure)', () => {
   assert.deepEqual(findLeakedPrePublishFields(raw, published, raw._state), []);
 });
 
-test('a from-scratch extra key is not flagged (seed-iea-oil-stocks)', () => {
-  // raw {members, dataMonth, seededAt}; canonical buildIndex → {dataMonth, updatedAt, members}.
-  // The only flaggable field is `seededAt`, and no extra-key payload carries it.
-  const raw = { members: [{ iso2: 'DE' }], dataMonth: '2026-06', seededAt: 123 };
-  const published = { dataMonth: '2026-06', updatedAt: 123, members: [{ iso2: 'DE' }] };
-  const analysis = { updatedAt: 123, dataMonth: '2026-06', ieaMembers: [], belowObligation: [], regionalSummary: {}, shockScenario: null };
+// #6489: this test used to build its member by hand as `{ iso2: 'DE' }` and assert
+// "the only flaggable field is `seededAt`, and no extra-key payload carries it".
+// That claim was false in production: parseRecord stamps `seededAt` on EVERY member,
+// so the real country transform leaked it, the guard exited 1, and the bundle went
+// red — while this test stayed green, because a hand-written stub cannot exhibit the
+// bug. Build the fixture from the REAL parseRecord/buildIndex/COUNTRY_EXTRA_KEYS.
+test('the real country extra key carries seededAt, and only the allowlist clears it (seed-iea-oil-stocks)', () => {
+  const seededAt = '2026-08-12T07:32:58.000Z';
+  // A real IEA CSV row for the country named in the production violation.
+  const member = parseRecord({
+    countryName: 'Australia',
+    yearMonth: '202605',
+    total: '58',
+    industry: '40',
+    publicData: '10',
+    abroadIndustry: '5',
+    abroadPublic: '3',
+  }, seededAt);
 
+  // The fixture must be ABLE to exhibit the bug, or the assertions below are vacuous.
+  assert.equal(member.seededAt, seededAt, 'parseRecord must stamp seededAt on the member');
+
+  const raw = { members: [member], dataMonth: member.dataMonth, seededAt };
+  const published = buildIndex(raw.members, raw.dataMonth, raw.seededAt);
+  assert.ok(!('seededAt' in published), 'buildIndex must strip seededAt (it renames it to updatedAt)');
+
+  const ek = COUNTRY_EXTRA_KEYS.find(k => k.key === 'energy:iea-oil-stocks:v1:AU');
+  assert.ok(ek, 'expected an AU country extra key');
+  const ekData = ek.transform(raw);
+
+  // Guard is live: WITHOUT the opt-out the real payload leaks exactly [seededAt].
+  // If this ever returns [], the guard has stopped seeing this shape.
+  assert.deepEqual(findLeakedPrePublishFields(raw, published, ekData, {}), ['seededAt']);
+
+  // And the shipped key declares the opt-out, so the seeder publishes. Deleting
+  // `allowPrePublishFields` from COUNTRY_EXTRA_KEYS turns this line red.
+  assert.deepEqual(findLeakedPrePublishFields(raw, published, ekData, ek), []);
+
+  // The analysis keys are unaffected: buildOilStocksAnalysis returns `updatedAt`.
+  const analysis = buildOilStocksAnalysis(raw.members, raw.dataMonth, raw.seededAt);
+  assert.ok(!('seededAt' in analysis));
   assert.deepEqual(findLeakedPrePublishFields(raw, published, analysis), []);
   assert.deepEqual(findLeakedPrePublishFields(raw, published, { fetchedAt: 1, recordCount: 0 }), []);
-  assert.deepEqual(findLeakedPrePublishFields(raw, published, raw.members[0]), []);
 });
 
 test('a null/non-object extra-key payload never throws', () => {


### PR DESCRIPTION
Fixes #6489.

## What broke

`seed-bundle-energy-sources` went red. The `IEA-Oil-Stocks` section exits 1 in 0.7s — a hard failure (`failed:1 graceful:0`), not a graceful skip:

```
[IEA-Oil-Stocks]   CONTRACT VIOLATION on extraKey energy:iea-oil-stocks:v1:AU: re-exports 1
  pre-publish field(s) that publishTransform strips from the canonical key: seededAt.
[IEA-Oil-Stocks] Failed after 0.7s: exit 1
```

`findLeakedPrePublishFields` flags a field present at the **top level** of both the raw fetcher output and the extraKey payload but absent from the canonical payload:

| object | top-level shape |
|---|---|
| raw fetcher output | `{ members, dataMonth, seededAt }` |
| canonical, via `buildIndex` | `{ dataMonth, updatedAt, members }` — **renames** `seededAt` → `updatedAt` |
| country extraKey | the raw member, and `parseRecord` stamps `seededAt` on **every** member |

**The two `seededAt` fields are different values that merely share a name** — one is the envelope's run timestamp, the other a per-record field. The guard compares top-level names across two structurally different objects (the envelope vs. a single member), so this is a nominal collision, not the raw-state leak the guard was built for (#5311's 11.5 MB dashboard key).

These country keys are the deliberately **detailed** record — `industryDays`, `publicDays`, `abroadDays`, `obligationThreshold`, all dropped by the index projection — and `seededAt` is part of that detail. So the fix is `allowPrePublishFields: ['seededAt']`, the escape hatch the guard itself documents.

## The existing test could not have caught this

There was already a test for this exact seeder, and it was vacuous:

```js
// The only flaggable field is `seededAt`, and no extra-key payload carries it.
const raw = { members: [{ iso2: 'DE' }], dataMonth: '2026-06', seededAt: 123 };
assert.deepEqual(findLeakedPrePublishFields(raw, published, raw.members[0]), []);
```

That comment was false in production. The member is a hand-written `{ iso2: 'DE' }` with no `seededAt`, so **the fixture cannot exhibit the bug** — the test stayed green while the bundle went red.

Rebuilt from the real `parseRecord` / `buildIndex` / `COUNTRY_EXTRA_KEYS`, and it now asserts **both** directions:

- the real payload leaks exactly `['seededAt']` **without** the opt-out — proving the guard is still live on this shape, so the test can never pass just because the situation went benign
- and `[]` with it

It also asserts the fixture's own preconditions (`parseRecord` stamps `seededAt`; `buildIndex` strips it), so a future refactor that changes either shape fails loudly instead of silently going vacuous again.

## Verification

Reproduced against the real functions before touching anything:

```
real parseRecord member keys: iso2, dataMonth, daysOfCover, netExporter, industryDays,
                              publicDays, abroadDays, belowObligation, obligationThreshold, seededAt
without allowPrePublishFields -> ["seededAt"]
with    allowPrePublishFields -> []
existing test's stub member   -> []          <-- why the test passed
```

**Mutation-verified.** Deleting `allowPrePublishFields` turns the new test red at the exact assertion:

```
✖ the real country extra key carries seededAt, and only the allowlist clears it
  AssertionError: actual: [ 'seededAt' ], expected: []
```

(reverted by file copy, not `git checkout`)

| gate | result |
|---|---|
| `tests/seed-extra-key-leak-guard.test.mjs` | 12 pass, 0 fail |
| the other 4 files importing this seeder | 66 pass, 0 fail |
| `npm run typecheck` | clean |
| `biome check` (changed files) | clean |
| pre-push gates | all passed |

The sweep covers `seed-ttl-outlives-staleness-fleet`, `seed-contract-transform-regressions`, `seeder-canonical-ttl-vs-cron`, and `iea-oil-stocks-seed` — scoped by changed module, since this adds an export.

## Why it went red with no related merge

The bundle gate skips a section while `elapsed < intervalMs * 0.8`. This section runs on a 40-day interval, so the threshold is 46080 min. The 2026-08-11 run logged:

```
[IEA-Oil-Stocks] Skipped, last seeded 46078min ago (interval: 57600min)
```

**Two minutes short of eligibility.** The next run crossed it, ran for the first time in 33 days, and failed immediately. A 40-day fuse — which is also why a broken contract could sit unnoticed for over a month.

## Urgency

The ~25 `energy:iea-oil-stocks:v1:<ISO2>` keys had **7.0 days of TTL left** (written 33 days ago on a 40-day TTL, never extended), and nothing re-seeds them while this crashes.

The comment claiming runSeed extends extraKey TTLs "on fetch failure or validation skip" does not cover a hard `exit 1` in the publish path. The canonical index TTL *was* refreshed to a full 40 days, so the index side looked healthy while the country keys counted down. Three consumers read them: `get-country-energy-profile.ts:410`, `compute-energy-shock.ts:186`, `chat-analyst-context.ts:528`.

## Deliberately out of scope

Left in #6489 rather than scope-creeping this fix:

1. Extending extraKey TTL preservation to publish-path failures, so an exit-1 cannot silently start a countdown on the extra keys.
2. A CI check exercising every seeder's `extraKeys` transforms against its `publishTransform` — the guard is a pure function, so it is cheap — to catch this class at merge time instead of on a 40-day fuse.

https://claude.ai/code/session_01MHjHA4EXK4GgXAJBqGihGf
