### PR TITLE
docs(company-monitoring): remove provider approval claims

### DIFF
--- a/docs/internal/company-monitoring/provider-policy.md
+++ b/docs/internal/company-monitoring/provider-policy.md
@@ -6,14 +6,14 @@
 
 This review freezes the policy and price inputs used by the Company Monitoring
 Stage 0 decision. It is not legal advice or a durable provider guarantee. Provider
-terms, prices, approved-use declarations, and model endpoints must be refreshed
+terms, prices, declared use cases, and model endpoints must be refreshed
 before any paid runtime is enabled.
 
 ## Exa
 
-Status for evaluation: approved. Status for paid runtime: blocked pending a
-separate runtime-scoped approval and its 64-hex evidence digest. Evaluation
-approval and API access cannot be reused as production approval.
+The Exa adapter remains dark while
+`COMPANY_MONITORING_ROLLOUT_FLAGS.exaProvider` in
+`convex/config/productCatalog.ts` is false.
 
 - Use only Exa's official API. No browser scraping or credential sharing.
 - The current Search price is $7 per 1,000 requests for up to ten results,
@@ -32,9 +32,9 @@ Sources: [Exa pricing](https://exa.ai/pricing),
 
 ## X
 
-Status: blocked pending written approval for the intended commercial use and a
-reviewed, enforced compliance implementation. An `approved` status alone is
-insufficient.
+The X adapter remains dark while `COMPANY_MONITORING_ROLLOUT_FLAGS.xProvider`
+in `convex/config/productCatalog.ts` is false. Activation must retain the
+content-handling controls below.
 
 - Use only the official X API. Recent search covers seven days and returns up to
   100 Posts per request; full-archive search is a separate pay-per-use or
@@ -43,20 +43,18 @@ insufficient.
   Pay-per-use plans have a two-million-Post monthly read cap.
 - X requires the declared use case to remain current. Its agreement requires an
   Enterprise plan when use grows beyond commercial prototyping, initial
-  integration, or a limited number of end users. Company Monitoring therefore
-  cannot infer production approval from API credentials or purchased credits.
+  integration, or a limited number of end users. API credentials and purchased
+  credits do not activate the Company Monitoring rollout flag.
 - Offline X Content must track deletion, edit, protection, suspension, and
   withholding. Applicable removals must occur as soon as reasonably possible and
   within 24 hours of a request. Batch compliance may be used for bounded audits;
   high-volume compliance streams require Enterprise access.
-- X Content may not train an AI or machine-learning model. This product may use a
-  version-locked inference policy only after the approved use case explicitly
-  covers it. Raw X text, handles, or provider URLs cannot enter customer alerts,
-  logs, or committed evaluation fixtures.
+- X Content may not train an AI or machine-learning model. Raw X text, handles,
+  or provider URLs cannot enter customer alerts, logs, or committed evaluation
+  fixtures.
 
-The runtime result passes only with a 64-hex written commercial-use evidence
-digest and affirmative enforcement flags for offline edit/deletion/protection/
-withholding compliance and the model-training prohibition.
+Before activation, runtime enforcement must cover offline edit, deletion,
+protection, and withholding handling plus the model-training prohibition.
 
 Sources: [X pricing](https://docs.x.com/x-api/getting-started/pricing),
 [usage and billing](https://docs.x.com/x-api/fundamentals/post-cap),
@@ -129,7 +127,7 @@ account cannot reuse this package.
 ## Frozen requirements and mutable runtime evidence
 
 Provider access, retention, compliance, and model-routing requirements are part
-of the frozen approved-threshold projection. Runtime approval status, evidence
-digests, and enforcement flags live in a separate mutable result record. That
-separation permits honest evidence to arrive without changing the approved
-threshold digest while preventing a status-only promotion.
+of the frozen approved-threshold projection. Runtime status, evidence digests,
+and enforcement flags live in a separate mutable result record. That separation
+permits honest evidence to arrive without changing the approved threshold digest
+while preventing a status-only promotion.

--- a/docs/internal/company-monitoring/viability.md
+++ b/docs/internal/company-monitoring/viability.md
@@ -10,7 +10,7 @@
 Company Monitoring must not proceed to paid-provider runtime or customer-visible
 behavior. Only fixtures and dark contracts are permitted. The base-rate,
 provider-independent rediscovery, and external-customer usefulness studies have
-not run, and the provider policy package is not approved for runtime. Missing
+not run, and the provider-policy runtime checks have not completed. Missing
 evidence is a stop, not a zero and not a provisional pass.
 
 ## Stage 0 gate record
@@ -21,8 +21,12 @@ evidence is a stop, not a zero and not a provisional pass.
 | Provider-independent rediscovery | At least 100 frozen pairs, point estimate at least 0.60, exact one-sided 90% Clopper-Pearson lower bound at least 0.50 | Pair protocol preregistered; private manifest and aggregate result absent | Stop |
 | Historical usefulness | Same ten admitted impacts for two external target customers, including one independent customer; positive, negative, and mixed coverage; at least seven of ten useful from each | Protocol frozen; no external customer judgments recorded | Stop |
 | Admission quality | Every metric, denominator, bound method, calibration method, seed, and approver frozen before scoring | Frozen and integrity-bound to the named approval | Pass for Stage 0 contract freeze |
-| Provider policy | Separate paid-runtime approval for Exa; written X commercial-use evidence and enforced compliance; enforced model ZDR, no-training, no-reasoning, and pinned routing | Exa is approved only for evaluation; every paid-runtime result remains blocked | Stop |
+| Provider policy | Official API access, bounded retention, enforced X offline-content lifecycle controls, and enforced model ZDR, no-training, no-reasoning, and pinned routing | Runtime policy controls are incomplete; paid-provider runtime remains dark | Stop |
 | 500-company economics | Exactly one account-level shared-discovery workload of 500 companies; modeled monthly cost no more than $125 before paid beta | $110.8659375 including allocated infrastructure and 25% contingency | Pass as a model only |
+
+The provider-policy row is an operational summary. The linked `cm_eval_v1`
+machine contract remains authoritative for current stop reasons; changing this
+documentation does not revise that frozen contract.
 
 The machine test recomputes this table's decisive arithmetic and requires the
 recorded stop reasons to equal the computed reasons. Editing the prose cannot


### PR DESCRIPTION
## Summary

Company Monitoring documentation no longer says that Exa needs a separate paid-runtime approval or that X needs written commercial-use approval. It now describes the actual code-level rollout flags and keeps the technical provider controls visible without presenting vendor approval artifacts as documentation requirements.

This is an editorial change only. The frozen cm_eval_v1 machine contract and runtime behavior are unchanged and remain authoritative for current stop reasons.

## Test plan

- [x] Focused Markdown lint passes for both changed files.
- [x] npm run docs:check passes with all 150 claims matching code.
- [x] Repository documentation search finds neither removed approval claim.
- [x] The full pre-push gate passes.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this PR changes internal documentation only and does not alter runtime configuration, protocol data, or provider execution.

## Related

Related: #6003

Related: #6006

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)