### PR TITLE
fix(sentry): filter the round-6 CSP webfont injectors (unpkg, jsDelivr)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -387,6 +387,32 @@ function shouldSuppressCspViolation(
       // 14d). Exact host + /file/ asset-root path.
       if (url.protocol === 'https:' && url.hostname === 'antbank-cdn.marmot-cloud.com'
           && url.pathname.startsWith('/file/') && fontFile.test(url.pathname)) return true;
+      // ---- Round 6. Sized on the window strictly AFTER the round-5 rules were
+      // live (commit 03e4c1e8, 2026-08-10T14:18Z), per the note above. In that
+      // window this issue took THREE events total and every previously-ruled
+      // host had drained to zero — round 5 worked. These two generic package
+      // CDNs are all that remains, so they are the whole live tail of a 357k
+      // headline that is otherwise historical.
+      //
+      // Both are pinned by host + font-file extension rather than a path
+      // prefix, because neither serves fonts from a stable root: they mirror
+      // whatever an arbitrary npm package or GitHub repo happens to ship.
+      // `font-src 'self' data:` means we load NO cross-origin webfont from any
+      // host, so a font block here can never be a first-party regression; a
+      // non-font asset from either CDN still surfaces.
+      //
+      // unpkg: element-ui@2.15.6 theme-chalk icons (.ttf + .woff — the same
+      // face in two formats, the fallback-chain pattern noted above).
+      // `element-ui` appears in neither package.json nor src.
+      if (url.protocol === 'https:' && url.hostname === 'unpkg.com'
+          && fontFile.test(url.pathname)) return true;
+      // jsDelivr: a Korean webfont (Pretendard) served from its GitHub mirror,
+      // `/gh/Project-Noonnu/noonfonts_2107@1.1/`. We DO legitimately load JS
+      // from this host — chart.js in the widget-sanitizer iframe — but only
+      // under `/npm/`, and never a font. That is the same argument the
+      // style-src jsDelivr rule below makes for CSS.
+      if (url.protocol === 'https:' && url.hostname === 'cdn.jsdelivr.net'
+          && fontFile.test(url.pathname)) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube live stream manifests.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -252,6 +252,34 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'font-src', 'http://images.simplycodes.com/fonts/simply-circular/CircularXXWeb-Regular.woff2', '', false));
     });
 
+    it('suppresses the round-6 package-CDN webfonts (unpkg, jsDelivr)', () => {
+      // The exact URIs still leaking in the window strictly AFTER the round-5
+      // rules went live (03e4c1e8, 2026-08-10T14:18Z) — three events, the whole
+      // live tail of this issue. Both formats of the element-ui face appear
+      // because an @font-face src: list is tried in order.
+      assert.ok(suppress('enforce', 'font-src', 'https://unpkg.com/element-ui@2.15.6/lib/theme-chalk/fonts/element-icons.ttf', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://unpkg.com/element-ui@2.15.6/lib/theme-chalk/fonts/element-icons.woff', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://cdn.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff', '', false));
+    });
+
+    it('keeps NON-font assets from the round-6 package CDNs visible', () => {
+      // These two rules are host + extension only (no path prefix), so the
+      // extension check is the ONLY thing keeping them narrow. jsDelivr in
+      // particular serves our own chart.js: a script block from it must still
+      // reach Sentry, or a real widget-sandbox CSP regression goes silent.
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js', '', false));
+      assert.ok(!suppress('enforce', 'script-src', 'https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://unpkg.com/element-ui@2.15.6/lib/theme-chalk/index.css', '', false));
+      // http: on both, pinning the shared protocol conjunct.
+      assert.ok(!suppress('enforce', 'font-src', 'http://unpkg.com/element-ui@2.15.6/lib/theme-chalk/fonts/element-icons.woff', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'http://cdn.jsdelivr.net/gh/x/y.woff', '', false));
+      // Sibling registrable domains and subdomains an endsWith() refactor eats.
+      assert.ok(!suppress('enforce', 'font-src', 'https://evilunpkg.com/x.woff', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdn.unpkg.com/x.woff', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://evil-cdn.jsdelivr.net/gh/x/y.woff', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://jsdelivr.net/gh/x/y.woff', '', false));
+    });
+
     it('does NOT suppress a SIBLING registrable domain of a pinned font host', () => {
       // The `<host>.evil.com` fixtures elsewhere are rejected by ANY hostname
       // check, including a suffix match, so they cannot prove exactness. These


### PR DESCRIPTION
## Summary

`WORLDMONITOR-TR` should stop taking events. Two rules cover the only hosts still reaching Sentry, and the CSP filter now suppresses every injected webfont observed in production.

Its 357,276-event headline is cumulative history, not live volume. Running the **shipped** predicate against 800 real sampled events shows the round-5 rules already suppress 99.6%, and in the window strictly after those rules deployed (03e4c1e8, 2026-08-10T14:18Z) the issue took **three events total** — all from these two hosts, with every previously-ruled host at zero.

| blocked host | sampled events | before this PR |
|---|---|---|
| migaku, slant, shopback, typekit, scite, gstatic, alicdn, simplycodes, merci-app, doubao | 797 | already suppressed |
| `unpkg.com` | 2 | leaking |
| `cdn.jsdelivr.net` | 1 | leaking |

Sizing on the post-deploy window is what makes those numbers trustworthy — this file already records a round where shopback looked like it was escaping a brand-new rule until its events were grouped by `build_sha` and every one turned out to predate the rule's own commit.

Worth noting for anyone reading the issue: it is titled after `unpkg/element-ui`, which is 0.2% of sampled volume. The title tracks the latest event, not the distribution.

## Review risk: jsDelivr is a host we actually use

Both rules pin host + font-file extension with **no path prefix**, because neither CDN serves fonts from a stable root — they mirror whatever npm package or GitHub repo a page happens to reference. That stays safe because `font-src 'self' data:` means we load no cross-origin webfont from any host, so a font block here can never be a first-party regression.

jsDelivr needs that narrowing most: we do legitimately load chart.js from it in the widget-sanitizer iframe, but only under `/npm/` and never a font. A test pins that a `script-src` block from that exact chart.js URL still reports, so a real widget-sandbox CSP regression cannot go silent.

## Validation

- `tests/csp-filter.test.mjs` 142 pass (318 with `deploy-config`)
- 5 mutants, 5 killed — drop either rule, widen the unpkg host to `endsWith`, drop jsDelivr's font-extension narrowing, drop the `https:` conjunct
- Re-running the shipped predicate over the same 800 events after the change: **0 leaking**
- `npm run typecheck` and biome clean

Related: #6408, #6369 — rounds 5 and 4 of this issue.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
