### PR TITLE
ci(e2e): upload Playwright traces when variant-smoke-full fails (#6496)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -487,20 +487,31 @@ jobs:
       # undiagnosable after the fact (#6496: a "Target page, context or browser
       # has been closed" close whose cause the log could not name).
       #
+      # `!cancelled()`, NOT `failure()`: retries mean the MOST common flake here
+      # never reddens the job at all. Run 31586695334 finished green-but-flaky —
+      # settings-source-live-apply failed at bootUntilNewsSettles and passed on
+      # retry — and Playwright kept the failed attempt's trace either way. A
+      # `failure()` guard would have thrown away the only evidence of the exact
+      # class of bug this step exists to catch.
+      #
       # Placed after BOTH smoke steps: a failing step ends the job, so whichever
-      # one failed is the one whose test-results/ this uploads. `if: failure()`
-      # also covers a failure before Playwright ever ran (npm ci, browser
-      # install) — hence `if-no-files-found: warn`, which says so in the log
-      # instead of failing the job a second time for a different reason.
+      # one failed owns the test-results/ this uploads.
+      #
+      # `ignore`, not `warn`: a clean run leaves nothing but a hidden
+      # .last-run.json, which the action skips, and a warning printed on every
+      # green run is noise that teaches people to skip the log. No artifact on
+      # the run page IS the "nothing was captured" signal.
+      #
       # run_attempt is in the name because a re-run keeps the same run_id and
-      # v6 rejects a duplicate artifact name within one run.
-      - name: Upload Playwright artifacts on failure
-        if: failure()
+      # v6 rejects a duplicate artifact name within one run — that collision
+      # would land exactly when someone re-runs the job to chase a flake.
+      - name: Upload Playwright artifacts
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: playwright-variant-smoke-full-${{ github.run_id }}-${{ github.run_attempt }}
           path: test-results/
-          if-no-files-found: warn
+          if-no-files-found: ignore
           retention-days: 14
 
   resilience-validation-smoke:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -481,6 +481,27 @@ jobs:
       # system Chrome fails the required PR job instead of silently skipping.
       - name: Run strict WebMCP iframe smoke in Chrome
         run: npm run test:e2e:webmcp
+      # playwright.config.ts already retains a trace, a video and a screenshot
+      # for every failed test (retain-on-failure) — but nothing collected them,
+      # so they died with the runner and every flake in this required gate was
+      # undiagnosable after the fact (#6496: a "Target page, context or browser
+      # has been closed" close whose cause the log could not name).
+      #
+      # Placed after BOTH smoke steps: a failing step ends the job, so whichever
+      # one failed is the one whose test-results/ this uploads. `if: failure()`
+      # also covers a failure before Playwright ever ran (npm ci, browser
+      # install) — hence `if-no-files-found: warn`, which says so in the log
+      # instead of failing the job a second time for a different reason.
+      # run_attempt is in the name because a re-run keeps the same run_id and
+      # v6 rejects a duplicate artifact name within one run.
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: playwright-variant-smoke-full-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-results/
+          if-no-files-found: warn
+          retention-days: 14
 
   resilience-validation-smoke:
     needs: changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -476,40 +476,57 @@ jobs:
       # regression guard no job invokes reports green while the regression
       # ships.
       - run: npm run test:e2e:ci-smoke
-      # WebMCP is exposed only by an enabled Chrome milestone. Keep this probe
-      # separate from the bundled-Chromium smoke so an unavailable or stale
-      # system Chrome fails the required PR job instead of silently skipping.
-      - name: Run strict WebMCP iframe smoke in Chrome
-        run: npm run test:e2e:webmcp
       # playwright.config.ts already retains a trace, a video and a screenshot
       # for every failed test (retain-on-failure) — but nothing collected them,
       # so they died with the runner and every flake in this required gate was
       # undiagnosable after the fact (#6496: a "Target page, context or browser
       # has been closed" close whose cause the log could not name).
       #
-      # `!cancelled()`, NOT `failure()`: retries mean the MOST common flake here
+      # ONE UPLOAD PER PLAYWRIGHT RUN, each immediately after its own. Playwright
+      # clears the output dir when it starts, so a single upload at the end of
+      # the job collects only the LAST run's leftovers: run 31587725167 proved
+      # it, uploading the WebMCP step's screenshots while the ci-smoke flake's
+      # trace — the whole point of the upload — had already been deleted.
+      #
+      # `!cancelled()`, NOT `failure()`: retries mean the most common flake here
       # never reddens the job at all. Run 31586695334 finished green-but-flaky —
       # settings-source-live-apply failed at bootUntilNewsSettles and passed on
       # retry — and Playwright kept the failed attempt's trace either way. A
       # `failure()` guard would have thrown away the only evidence of the exact
       # class of bug this step exists to catch.
       #
-      # Placed after BOTH smoke steps: a failing step ends the job, so whichever
-      # one failed owns the test-results/ this uploads.
-      #
-      # `ignore`, not `warn`: a clean run leaves nothing but a hidden
+      # `ignore`, not `warn`: a clean ci-smoke run leaves nothing but a hidden
       # .last-run.json, which the action skips, and a warning printed on every
-      # green run is noise that teaches people to skip the log. No artifact on
-      # the run page IS the "nothing was captured" signal.
+      # green run is noise that teaches people to skip the log.
       #
       # run_attempt is in the name because a re-run keeps the same run_id and
       # v6 rejects a duplicate artifact name within one run — that collision
       # would land exactly when someone re-runs the job to chase a flake.
-      - name: Upload Playwright artifacts
+      - name: Upload ci-smoke Playwright artifacts
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: playwright-variant-smoke-full-${{ github.run_id }}-${{ github.run_attempt }}
+          name: playwright-ci-smoke-${{ github.run_id }}-${{ github.run_attempt }}
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+      # WebMCP is exposed only by an enabled Chrome milestone. Keep this probe
+      # separate from the bundled-Chromium smoke so an unavailable or stale
+      # system Chrome fails the required PR job instead of silently skipping.
+      - name: Run strict WebMCP iframe smoke in Chrome
+        id: webmcp
+        run: npm run test:e2e:webmcp
+      # Gated on the WebMCP step having actually run: when ci-smoke fails this
+      # step is skipped, and without the guard this upload would re-publish the
+      # ci-smoke output the step above already has, under a second name.
+      # embed.spec.ts attaches screenshots on success, so unlike the ci-smoke
+      # artifact this one appears on green runs too — its presence is not by
+      # itself a failure signal.
+      - name: Upload WebMCP Playwright artifacts
+        if: ${{ !cancelled() && steps.webmcp.outcome != 'skipped' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: playwright-webmcp-${{ github.run_id }}-${{ github.run_attempt }}
           path: test-results/
           if-no-files-found: ignore
           retention-days: 14

--- a/e2e/keyword-spike-flow.spec.ts
+++ b/e2e/keyword-spike-flow.spec.ts
@@ -246,20 +246,3 @@ test.describe('keyword spike modal/badge flow', () => {
     expect(result.emittedTitles.length).toBe(0);
   });
 });
-
-// TEMPORARY — reverted in the next commit on this branch.
-//
-// #6496 acceptance, second half: the FIRST probe proved a red job uploads its
-// artifacts. It could not prove the case the upload was widened for — a run
-// that is GREEN because the retry passed, whose first attempt left a trace
-// behind. This reproduces exactly that shape: fail on attempt 0, pass on the
-// retry, so Playwright reports "1 flaky", the job exits 0, and the artifact
-// must still arrive carrying the failed attempt's trace.
-test('TEMP #6496 flaky-shape probe (fails once, passes on retry)', async ({ page }, testInfo) => {
-  await page.goto('/');
-  await page.waitForLoadState('domcontentloaded');
-  expect(
-    testInfo.retry,
-    'deliberate first-attempt failure — proves a green-but-flaky run still uploads its trace',
-  ).toBeGreaterThan(0);
-});

--- a/e2e/keyword-spike-flow.spec.ts
+++ b/e2e/keyword-spike-flow.spec.ts
@@ -246,3 +246,16 @@ test.describe('keyword spike modal/badge flow', () => {
     expect(result.emittedTitles.length).toBe(0);
   });
 });
+
+// TEMPORARY — reverted in the next commit on this branch.
+//
+// #6496 acceptance: prove the new "Upload Playwright artifacts on failure" step
+// in .github/workflows/test.yml really fires and really carries a trace.zip.
+// Reading the YAML proves nothing; only a real red run does. The navigation is
+// deliberate — it gives the trace, the video and the screenshot something to
+// record before the assertion fails.
+test('TEMP #6496 artifact-upload probe (deliberate failure)', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForLoadState('domcontentloaded');
+  expect(1, 'deliberate failure — proves the artifact upload step fires').toBe(2);
+});

--- a/e2e/keyword-spike-flow.spec.ts
+++ b/e2e/keyword-spike-flow.spec.ts
@@ -246,16 +246,3 @@ test.describe('keyword spike modal/badge flow', () => {
     expect(result.emittedTitles.length).toBe(0);
   });
 });
-
-// TEMPORARY — reverted in the next commit on this branch.
-//
-// #6496 acceptance: prove the new "Upload Playwright artifacts on failure" step
-// in .github/workflows/test.yml really fires and really carries a trace.zip.
-// Reading the YAML proves nothing; only a real red run does. The navigation is
-// deliberate — it gives the trace, the video and the screenshot something to
-// record before the assertion fails.
-test('TEMP #6496 artifact-upload probe (deliberate failure)', async ({ page }) => {
-  await page.goto('/');
-  await page.waitForLoadState('domcontentloaded');
-  expect(1, 'deliberate failure — proves the artifact upload step fires').toBe(2);
-});

--- a/e2e/keyword-spike-flow.spec.ts
+++ b/e2e/keyword-spike-flow.spec.ts
@@ -246,3 +246,20 @@ test.describe('keyword spike modal/badge flow', () => {
     expect(result.emittedTitles.length).toBe(0);
   });
 });
+
+// TEMPORARY — reverted in the next commit on this branch.
+//
+// #6496 acceptance, second half: the FIRST probe proved a red job uploads its
+// artifacts. It could not prove the case the upload was widened for — a run
+// that is GREEN because the retry passed, whose first attempt left a trace
+// behind. This reproduces exactly that shape: fail on attempt 0, pass on the
+// retry, so Playwright reports "1 flaky", the job exits 0, and the artifact
+// must still arrive carrying the failed attempt's trace.
+test('TEMP #6496 flaky-shape probe (fails once, passes on retry)', async ({ page }, testInfo) => {
+  await page.goto('/');
+  await page.waitForLoadState('domcontentloaded');
+  expect(
+    testInfo.retry,
+    'deliberate first-attempt failure — proves a green-but-flaky run still uploads its trace',
+  ).toBeGreaterThan(0);
+});

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -444,36 +444,40 @@ describe('CI workflow coverage', () => {
   // every failed test and CI collected none of them, so run 31584738075 died
   // with the only evidence that could have named its browser close. The job is
   // required, so it reddens on flakes nobody can then diagnose.
-  it('collects the Playwright artifacts a failed variant-smoke-full leaves behind (#6496)', () => {
+  it('collects what every playwright run in variant-smoke-full leaves behind (#6496)', () => {
     const job = testJobBlock('variant-smoke-full');
 
     // The uploaded path has to be the directory Playwright actually writes.
     // The config leaves outputDir at its default, so that is `test-results`;
-    // pinning one later without repointing the upload would strand the upload
-    // on an empty folder while every run still reported green.
+    // pinning one later without repointing the uploads would strand them on an
+    // empty folder while every run still reported green.
     const configuredOutputDir = playwrightConfig.match(/^\s*outputDir:\s*['"]([^'"]+)['"]/m);
     const outputDir = (configuredOutputDir?.[1] ?? 'test-results').replace(/^\.\//, '').replace(/\/$/, '');
 
-    // A failing step ends the job, so an upload placed BEFORE the smoke steps
-    // can only fire for a failure that happened before any test wrote the
-    // output dir. Anything at or after this offset can see it.
-    const lastPlaywrightRun = Math.max(job.lastIndexOf('test:e2e:ci-smoke'), job.lastIndexOf('test:e2e:webmcp'));
-    assert.notEqual(lastPlaywrightRun, -1, 'variant-smoke-full must still invoke playwright');
+    const steps = jobSteps(job);
+    // `- run: …` (the whole step on the dash line) and `run: …` under a named
+    // step are both real here, and matching only the second form silently
+    // narrowed this guard to the WebMCP run alone.
+    const runs = steps
+      .map((step, index) => ({ ...step, index }))
+      .filter((step) => /\n\s*(?:- )?run: npm run test:e2e:/.test(step.block));
+    assert.ok(runs.length > 0, 'variant-smoke-full must still invoke playwright');
+    assert.equal(
+      runs.length,
+      (job.match(/\n\s*(?:- )?run: npm run test:e2e:/g) ?? []).length,
+      'every `npm run test:e2e:*` line in the job must be attributed to exactly one step — if this ' +
+        'fails the step splitter has drifted and the per-run checks below cover less than they claim',
+    );
 
-    // Judge EVERY upload step, not just the first one: a build- or report-
-    // upload added ahead of this one later must not make the guard fail for a
-    // step it was never about.
     const rejected: string[] = [];
-    const collectors = jobSteps(job).filter(({ block, offset }) => {
+    const qualifies = (block: string): boolean => {
       if (!/\n\s*uses: actions\/upload-artifact@/.test(block)) return false;
       const why: string[] = [];
-      if (offset < lastPlaywrightRun) why.push('runs before the last playwright invocation');
-      // The condition has to survive a failed step AND a green run. Without an
-      // `if:` at all the step is skipped the moment a smoke step fails — the
-      // only time it matters. With `failure()` it skips the green-but-flaky
-      // run, which is what retries make the COMMON shape here: the failed
-      // attempt's trace is retained, the job is green, and the evidence would
-      // be thrown away.
+      // The condition has to survive a failed step AND a green run. With no
+      // `if:` the step is skipped the moment a run above it fails — the only
+      // time it matters. With `failure()` it skips the green-but-flaky run,
+      // which retries make the COMMON shape here: the failed attempt's trace
+      // is retained, the job is green, and the evidence would be dropped.
       if (!/\n {8}if: [^\n]*(?:!\s*cancelled\(\)|always\(\))/.test(block)) {
         why.push('is not guarded by an `if:` that runs on both failure and success (`!cancelled()`)');
       }
@@ -487,13 +491,33 @@ describe('CI workflow coverage', () => {
         return false;
       }
       return true;
-    });
+    };
 
-    assert.ok(
-      collectors.length > 0,
-      'variant-smoke-full must upload the Playwright output dir after the smoke run — without it a ' +
-        'failure of this required gate leaves nothing but the console log to diagnose (#6496).' +
-        (rejected.length > 0 ? `\nUpload steps that do not qualify:\n${rejected.join('\n')}` : ''),
+    // Each playwright run needs its OWN collector, before the next one starts:
+    // `playwright test` clears the output dir on startup, so a single upload at
+    // the end of the job carries only the last run's leftovers and silently
+    // drops the earlier run's traces (observed in run 31587725167).
+    const artifactNames: string[] = [];
+    for (const [position, run] of runs.entries()) {
+      const script = run.block.match(/npm run (test:e2e:[\w:-]+)/)?.[1] ?? 'playwright';
+      const nextRun = runs[position + 1]?.index ?? steps.length;
+      const collector = steps.slice(run.index + 1, nextRun).find((step) => qualifies(step.block));
+      assert.ok(
+        collector,
+        `${script} has no artifact upload between it and the next playwright run — the next run wipes ` +
+          `${outputDir}/ on startup, so its traces would be gone before anything collected them (#6496).` +
+          (rejected.length > 0 ? `\nUpload steps that do not qualify:\n${rejected.join('\n')}` : ''),
+      );
+      artifactNames.push(collector.block.match(/\n {10}name: ([^\n]+)/)?.[1]?.trim() ?? '');
+    }
+
+    // Distinct names, or the second upload 409s against the first and the run
+    // ends up with one of the two sets of traces.
+    assert.equal(
+      new Set(artifactNames).size,
+      artifactNames.length,
+      `each playwright run's artifact needs its own name — upload-artifact rejects a duplicate name ` +
+        `within one run, so a collision drops one run's traces entirely. Got: ${artifactNames.join(', ')}`,
     );
   });
 

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -21,6 +21,7 @@ const desktopBuildWorkflow = read(resolve(workflowsDir, 'build-desktop.yml'));
 const desktopCanaryWorkflow = read(resolve(workflowsDir, 'test-linux-app.yml'));
 const lintCodeWorkflow = read(resolve(workflowsDir, 'lint-code.yml'));
 const protoCheckWorkflow = read(resolve(workflowsDir, 'proto-check.yml'));
+const playwrightConfig = read(resolve(root, 'playwright.config.ts'));
 const workflowText = readdirSync(workflowsDir)
   .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
   .map((name) => read(resolve(workflowsDir, name)))
@@ -176,6 +177,34 @@ function workflowStepBlocksByUses(workflow: string, action: string): string[] {
   }
   assert.ok(blocks.length > 0, `workflow must define ${action}`);
   return blocks;
+}
+
+// Every step of a job block, with the offset it starts at so a caller can ask
+// where a step sits relative to another (step ORDER decides whether an
+// `if: failure()` step can see what an earlier step produced).
+function jobSteps(jobBlock: string): { block: string; offset: number }[] {
+  // Anchored with `m` rather than a leading `\n`: consuming the newline that
+  // separates two steps would leave the next step with no `\n` to match on,
+  // and matchAll would silently return every OTHER step.
+  const steps: { block: string; offset: number }[] = [];
+  for (const match of jobBlock.matchAll(/^ {6}- [^\n]*\n(?:(?! {6}- )[^\n]*\n)*/gm)) {
+    steps.push({ block: `\n${match[0]}`, offset: match.index ?? 0 });
+  }
+  return steps;
+}
+
+// The `path:` of an upload step, normalized, as a list — the input accepts a
+// single path or a block scalar of several, and a guard that only understood
+// the single-path form would redden the day someone adds a second path.
+function stepPaths(stepBlock: string): string[] {
+  const inline = stepBlock.match(/\n {10}path: (?!\|)([^\n]+)/);
+  if (inline) return [inline[1].trim().replace(/\/$/, '')];
+  const block = stepBlock.match(/\n {10}path: \|[-+]?\n((?: {12}[^\n]*\n)+)/);
+  if (!block) return [];
+  return block[1]
+    .split('\n')
+    .map((line) => line.trim().replace(/\/$/, ''))
+    .filter((line) => line.length > 0);
 }
 
 function workflowRunScript(stepBlock: string): string {
@@ -409,6 +438,55 @@ describe('CI workflow coverage', () => {
     for (const job of TIMEOUT_CAPPED_TEST_JOBS) {
       assert.match(testJobBlock(job), /\n {4}timeout-minutes: \d+\n/, `${job} must set timeout-minutes`);
     }
+  });
+
+  // #6496: playwright.config.ts retained a trace, a video and a screenshot for
+  // every failed test and CI collected none of them, so run 31584738075 died
+  // with the only evidence that could have named its browser close. The job is
+  // required, so it reddens on flakes nobody can then diagnose.
+  it('collects the Playwright artifacts a failed variant-smoke-full leaves behind (#6496)', () => {
+    const job = testJobBlock('variant-smoke-full');
+
+    // The uploaded path has to be the directory Playwright actually writes.
+    // The config leaves outputDir at its default, so that is `test-results`;
+    // pinning one later without repointing the upload would strand the upload
+    // on an empty folder while every run still reported green.
+    const configuredOutputDir = playwrightConfig.match(/^\s*outputDir:\s*['"]([^'"]+)['"]/m);
+    const outputDir = (configuredOutputDir?.[1] ?? 'test-results').replace(/^\.\//, '').replace(/\/$/, '');
+
+    // A failing step ends the job, so an upload placed BEFORE the smoke steps
+    // can only fire for a failure that happened before any test wrote the
+    // output dir. Anything at or after this offset can see it.
+    const lastPlaywrightRun = Math.max(job.lastIndexOf('test:e2e:ci-smoke'), job.lastIndexOf('test:e2e:webmcp'));
+    assert.notEqual(lastPlaywrightRun, -1, 'variant-smoke-full must still invoke playwright');
+
+    // Judge EVERY upload step, not just the first one: a build- or report-
+    // upload added ahead of this one later must not make the guard fail for a
+    // step it was never about.
+    const rejected: string[] = [];
+    const collectors = jobSteps(job).filter(({ block, offset }) => {
+      if (!/\n\s*uses: actions\/upload-artifact@/.test(block)) return false;
+      const why: string[] = [];
+      if (offset < lastPlaywrightRun) why.push('runs before the last playwright invocation');
+      if (!/\n {8}if: failure\(\)\n/.test(block)) why.push('is not guarded by `if: failure()`');
+      if (!stepPaths(block).includes(outputDir)) why.push(`does not upload ${outputDir}/`);
+      // A re-run keeps the same run_id and upload-artifact rejects a duplicate
+      // name within one run, so a name without run_attempt fails to upload
+      // exactly when someone re-runs the job to reproduce the flake.
+      if (!/\n {10}name: [^\n]*github\.run_attempt/.test(block)) why.push('has no github.run_attempt in its name');
+      if (why.length > 0) {
+        rejected.push(`  - "${block.trim().split('\n')[0].replace(/^-\s*/, '')}" ${why.join('; ')}`);
+        return false;
+      }
+      return true;
+    });
+
+    assert.ok(
+      collectors.length > 0,
+      'variant-smoke-full must upload the Playwright output dir after the smoke run — without it a ' +
+        'failure of this required gate leaves nothing but the console log to diagnose (#6496).' +
+        (rejected.length > 0 ? `\nUpload steps that do not qualify:\n${rejected.join('\n')}` : ''),
+    );
   });
 
   it('keeps the deploy gate wired to every Test workflow check job', () => {

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -468,7 +468,15 @@ describe('CI workflow coverage', () => {
       if (!/\n\s*uses: actions\/upload-artifact@/.test(block)) return false;
       const why: string[] = [];
       if (offset < lastPlaywrightRun) why.push('runs before the last playwright invocation');
-      if (!/\n {8}if: failure\(\)\n/.test(block)) why.push('is not guarded by `if: failure()`');
+      // The condition has to survive a failed step AND a green run. Without an
+      // `if:` at all the step is skipped the moment a smoke step fails — the
+      // only time it matters. With `failure()` it skips the green-but-flaky
+      // run, which is what retries make the COMMON shape here: the failed
+      // attempt's trace is retained, the job is green, and the evidence would
+      // be thrown away.
+      if (!/\n {8}if: [^\n]*(?:!\s*cancelled\(\)|always\(\))/.test(block)) {
+        why.push('is not guarded by an `if:` that runs on both failure and success (`!cancelled()`)');
+      }
       if (!stepPaths(block).includes(outputDir)) why.push(`does not upload ${outputDir}/`);
       // A re-run keeps the same run_id and upload-artifact rejects a duplicate
       // name within one run, so a name without run_attempt fails to upload


### PR DESCRIPTION
Closes #6496.

## The gap

`playwright.config.ts` already retains a trace, a video and a screenshot for every
failed test — `trace: 'retain-on-failure'` (line 43), `screenshot: 'only-on-failure'`
(44), `video: 'retain-on-failure'` (45). The failing run even prints where it wrote
them:

```
attachment #1: trace (application/zip)
test-results/dashboard-news-request-bud-c1081-...-chromium/trace.zip
```

Nothing collected them. `variant-smoke-full` is the only CI job that runs `playwright
test` (`test:dom` is vitest; `perf-style-layout-budget` drives Chromium through a script
and already uploads its own report), and it had no upload step:

```
$ gh api repos/koala73/worldmonitor/actions/runs/31584738075/artifacts --jq '.total_count'
0
```

That run is the case in point — `variant-smoke-full` reddened on `main` with `Target
page, context or browser has been closed` on both the attempt and the retry, and the log
alone cannot say whether that was a renderer crash, a browser exit, or a Playwright
transport fault. The evidence died with the runner.

## The change

One upload per Playwright invocation, each immediately after its own run:

```yaml
- run: npm run test:e2e:ci-smoke
- name: Upload ci-smoke Playwright artifacts
  if: ${{ !cancelled() }}
  uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
  with:
    name: playwright-ci-smoke-${{ github.run_id }}-${{ github.run_attempt }}
    path: test-results/
    if-no-files-found: ignore
    retention-days: 14
- name: Run strict WebMCP iframe smoke in Chrome
  id: webmcp
  run: npm run test:e2e:webmcp
- name: Upload WebMCP Playwright artifacts
  if: ${{ !cancelled() && steps.webmcp.outcome != 'skipped' }}
  ...
```

Every decision here was forced by a run on this branch, not by reasoning:

- **One upload per run, not one at the end.** `playwright test` clears its output dir on
  startup, so the second invocation deletes the first one's `test-results/`. Run
  31587725167 uploaded the WebMCP step's screenshots while the ci-smoke flake's trace was
  already gone.
- **`!cancelled()`, not `failure()`.** Retries make green-but-flaky the common shape: run
  31586695334 ended green carrying a real flake (`settings-source-live-apply` at
  `bootUntilNewsSettles`) whose trace Playwright had kept. `failure()` would have deleted
  exactly the evidence this step exists for. See the
  [note on #6496](https://github.com/koala73/worldmonitor/issues/6496#issuecomment-5265550586)
  revising that acceptance criterion.
- **`steps.webmcp.outcome != 'skipped'`** on the second upload: when ci-smoke fails,
  WebMCP never runs, and without the gate this would re-publish the first step's output
  under a second name.
- **`if-no-files-found: ignore`, not `warn`.** A run that retained nothing leaves only a
  hidden `.last-run.json`, which the action skips; a warning on every such run is noise.
- **`run_attempt` in the name**, because a re-run keeps the same `run_id` and v6 rejects a
  duplicate artifact name within one run — that collision would land exactly when someone
  re-runs the job to chase a flake.

## The guard

`tests/ci-workflow-coverage.test.mts` pins the contract: for **every** `npm run
test:e2e:*` step there must be a qualifying upload before the next one, with distinct
artifact names. It also asserts its own coverage — the runs it attributes to steps must
equal the `npm run test:e2e:*` lines in the job — because the first version matched only
the `run:`-under-a-named-step form, silently checked the WebMCP pair alone, and six
mutants walked past it.

Mutation sweep, each mutant applied to a byte-restored copy and reverted the same way.
The last two are legitimate edits that must **not** redden:

```
KILLED    A: both uploads deleted
KILLED    B: collapsed to a single upload at the end of the job
KILLED    C: ci-smoke upload moved above its own playwright run
KILLED    D: the `if:` condition dropped
KILLED    E: condition narrowed to failure()
KILLED    F: run_attempt dropped from the ci-smoke artifact name
KILLED    G: ci-smoke path drifts from the Playwright output dir
KILLED    H: playwright.config.ts pins a different outputDir
KILLED    I: both uploads share one artifact name (second 409s)
SURVIVES  J: an unrelated upload step added before the playwright runs
SURVIVES  K: ci-smoke path widened to a block-scalar list
```

## Proof it fires

Reading the YAML proves nothing: a step that never fires and a step that fires on the
wrong directory look identical in a green run. Each temporary probe commit is reverted
immediately after the run it produced — the net diff of this PR is the workflow step and
the guard, nothing under `e2e/`.

| Claim | Evidence |
| --- | --- |
| A red run uploads trace + video + screenshot | [31586695334](https://github.com/koala73/worldmonitor/actions/runs/31586695334): job RED, artifact holds `trace.zip`, `video.webm`, `test-failed-1.png` for both attempts |
| A green-but-flaky run uploads too | [31587725167](https://github.com/koala73/worldmonitor/actions/runs/31587725167): job GREEN, artifact present — and it exposed the wrong-directory bug fixed above |
| …carrying the flaky attempt's own trace | [31588886292](https://github.com/koala73/worldmonitor/actions/runs/31588886292): job GREEN, `playwright-ci-smoke-…` 1.4 MB with that attempt's `trace.zip`, `video.webm`, screenshot |
| It catches a flake nobody staged | [31589294381](https://github.com/koala73/worldmonitor/actions/runs/31589294381): final run, all jobs green, `1 flaky` — `dashboard container scroll hydration (#5876)` — and its trace arrived on its own |
| The guard runs in CI, not just locally | same run, `unit` job: `✔ collects what every playwright run in variant-smoke-full leaves behind (#6496)` |

Not yet observed: a run where Playwright retains **nothing**, which would publish no
ci-smoke artifact at all. Three of the four smoke runs on this branch contained a flake,
so the case has not come up — which is its own comment on the state of this gate. The
WebMCP artifact is present on green runs by design: `embed.spec.ts` attaches screenshots
on success, so unlike the ci-smoke one its presence is not a failure signal.

## Follow-up filed

The captured traces produced the first real evidence about the browser close: context and
page created, routes installed, `Navigate to "/"` at t=0.091 s, and at t=6.563 s the
target is simply gone — no `after` record for the navigation, no network events, no
console, no snapshot. Enough to rule things out, not enough to name the cause. Filed as
**#6501** with the decoded timeline and the three additions that would name it
(`page.on('crash')`, `DEBUG=pw:browser` stderr, memory sampling).

The other flake caught today was `Object with guid response@… was not bound in the
connection` — the known #5685 protocol flake, still occurring and still absorbed by
`retries: 1`.

## Testing

- `npx tsx --test tests/ci-workflow-coverage.test.mts` — 25/25 pass.
- Mutation sweep above: 9 killed, 2 legitimate edits survive.
- `npx biome check` clean on both changed files.
- CI evidence in the table above.

https://claude.ai/code/session_01R83ivqzDUWZXtzKwh3GyP3
