### PR TITLE
fix(resilience): stop a transient seed-meta read failure from faking a dead producer

### DIFF
--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -2,7 +2,7 @@ import countryNames from '../../../../shared/country-names.json';
 import iso2ToIso3Json from '../../../../shared/iso2-to-iso3.json';
 import wgiIndicatorKeys from '../../../../shared/wgi-indicator-keys.json';
 import { normalizeCountryToken } from '../../../_shared/country-token';
-import { getCachedJson } from '../../../_shared/redis';
+import { getCachedJson, readCachedJson } from '../../../_shared/redis';
 import { classifyDimensionFreshness, readFreshnessMap, resolveSeedMetaKey } from './_dimension-freshness';
 import { getLanguageCoverageFactor } from './_language-coverage';
 import { MACRO_FISCAL_INDICATOR_WEIGHTS } from './_macro-fiscal-weights';
@@ -970,8 +970,53 @@ export function matchesCountryText(value: unknown, countryCode: string): boolean
 // dateToSortableNumber() removed in PR 3 §3.5: only the now-removed
 // getCountryBisExchangeRates() used it.
 
+// `seed-meta:` reads gate FAIL-CLOSED preflights, so for them a read ERROR and
+// a genuine MISS must not be the same answer. `getCachedJson` collapses both to
+// `null` (see `readCachedJson`, which does distinguish them), and a preflight
+// reading that `null` declares the producer dead.
+//
+// #6484: within 25 minutes of the education activation deploying, that turned a
+// 1500 ms Upstash timeout under the concurrent ranking warm into
+// `source-failure` for 196/196 countries — published, and cached for six hours,
+// while the seeder was healthy and the payload was present.
+//
+// Retrying only the ERROR case keeps the alarm honest: a genuinely absent
+// seed-meta still returns `null` on the first read and still fails closed,
+// which is the signal that a Railway bundle is not publishing.
+const SEED_META_READ_ATTEMPTS = 3;
+const SEED_META_RETRY_BASE_MS = 120;
+
+function isSeedMetaKey(key: string): boolean {
+  return key.startsWith('seed-meta:');
+}
+
+async function readSeedMetaResilient(key: string): Promise<unknown | null> {
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < SEED_META_READ_ATTEMPTS; attempt++) {
+    const read = await readCachedJson(key, true);
+    if (read.status === 'hit') return read.value;
+    // A genuine miss is information, not a failure — return it immediately so
+    // a dead producer still fails closed on the first attempt.
+    if (read.status === 'miss') return null;
+    lastError = read.error;
+    if (attempt < SEED_META_READ_ATTEMPTS - 1) {
+      await new Promise((resolve) => { setTimeout(resolve, SEED_META_RETRY_BASE_MS * 2 ** attempt); });
+    }
+  }
+  // Still failing after retries. Return null so behaviour matches today's
+  // fail-closed path rather than introducing a new throwing mode under load,
+  // but say so — an operator seeing source-failure needs to know whether the
+  // producer is dead or Redis was unreachable.
+  console.warn(
+    `[Resilience] seed-meta read failed after ${SEED_META_READ_ATTEMPTS} attempts key=${key} `
+    + `error=${lastError instanceof Error ? lastError.message : String(lastError)} — `
+    + 'downstream preflights will fail closed; this is a READ failure, not proof the producer is dead',
+  );
+  return null;
+}
+
 async function defaultSeedReader(key: string): Promise<unknown | null> {
-  return getCachedJson(key, true);
+  return isSeedMetaKey(key) ? readSeedMetaResilient(key) : getCachedJson(key, true);
 }
 
 export function createMemoizedSeedReader(reader: ResilienceSeedReader = defaultSeedReader): ResilienceSeedReader {
@@ -981,6 +1026,14 @@ export function createMemoizedSeedReader(reader: ResilienceSeedReader = defaultS
       const p = Promise.resolve(reader(key));
       cache.set(key, p);
       p.catch(() => cache.delete(key));
+      // Do NOT retain a null seed-meta result. This memo is shared across every
+      // country in a ranking build, so caching one unresolved read propagates it
+      // to all 196 — the #6484 amplifier. Evicting null costs at most one extra
+      // read per country for a key that is genuinely absent, and buys back the
+      // per-country retry that keeps a transient blip local.
+      if (isSeedMetaKey(key)) {
+        p.then((value) => { if (value == null) cache.delete(key); }).catch(() => {});
+      }
     }
     return cache.get(key)!;
   };

--- a/tests/resilience-seed-meta-preflight.test.mts
+++ b/tests/resilience-seed-meta-preflight.test.mts
@@ -1,0 +1,174 @@
+// Seed-meta preflight read semantics for FAIL-CLOSED dimensions.
+//
+// The incident this pins (#6484, 2026-08-12): within 25 minutes of the
+// education activation deploying, `education` came back `source-failure` with
+// coverage 0 for 196/196 countries in production. The seeder was healthy and
+// the payload was present — `seed-meta:resilience:education-attainment` was
+// 26h old against an 8-day budget, and scoring the same production data
+// serially resolved 181 observed countries.
+//
+// The chain:
+//   1. The ranking warm scores ~196 countries CONCURRENTLY.
+//   2. Under that burst `getCachedJson` hits its 1500 ms op timeout.
+//   3. `getCachedJson` collapses MISS and ERROR to the same `null`.
+//   4. `createMemoizedSeedReader` caches that resolved `null`, so ONE failed
+//      read is shared by every country in the build.
+//   5. The preflight reads `null` as "the producer never published" and
+//      fail-closes, publishing a 6-hour-cached source-failure for the world.
+//
+// A fail-closed preflight is correct for a genuinely absent producer and wrong
+// for a 1.5-second network blip. These tests hold both halves of that line, so
+// a future change cannot fix the blip by making real outages silent.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { afterEach, describe, it } from 'node:test';
+
+import { scoreEducation, createMemoizedSeedReader } from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
+
+const META_KEY = 'seed-meta:resilience:education-attainment';
+const DATA_KEY = 'resilience:education-attainment:v1';
+
+// A payload that clears the #6472 activation floors. Both the seed-meta proof
+// (`rankableRecordCount`) and the payload's own usable-record count must exceed
+// 180, so a one-country fixture would fail for reasons unrelated to the read
+// path this suite tests. Built from the real rankable universe so the codes are
+// genuine rather than synthetic strings the universe check would reject.
+const RANKABLE_CODES: string[] = Object.values(
+  JSON.parse(readFileSync(new URL('../scripts/shared/sovereign-status.json', import.meta.url), 'utf8')).entries,
+).map((entry: any) => entry.iso2).slice(0, 185);
+
+const EDUCATION_PAYLOAD = {
+  countries: Object.fromEntries(RANKABLE_CODES.map((code, i) => [code, { value: 40 + (i % 50), year: 2024 }])),
+};
+
+const originalFetch = globalThis.fetch;
+const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+const originalFlag = process.env.RESILIENCE_EDUCATION_ENABLED;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalUrl == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+  if (originalToken == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+  if (originalFlag == null) delete process.env.RESILIENCE_EDUCATION_ENABLED;
+  else process.env.RESILIENCE_EDUCATION_ENABLED = originalFlag;
+});
+
+interface StubOptions {
+  /** Number of leading reads of the meta key that fail like a timeout. */
+  metaFailures?: number;
+  /** When true the meta key is genuinely absent (Upstash returns result:null). */
+  metaMissing?: boolean;
+}
+
+function installRedisStub(options: StubOptions = {}) {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+  process.env.RESILIENCE_EDUCATION_ENABLED = 'true';
+
+  const counts = { meta: 0, data: 0 };
+  let remainingMetaFailures = options.metaFailures ?? 0;
+
+  const values: Record<string, unknown> = {
+    // `rankableRecordCount` satisfies the #6472 activation-proof gate. It is
+    // deliberately present here: this suite is about the READ path, so the
+    // fixture must clear every other preflight or a green result would prove
+    // nothing about the thing under test.
+    [META_KEY]: { fetchedAt: Date.now(), recordCount: 189, rankableRecordCount: 181 },
+    [DATA_KEY]: EDUCATION_PAYLOAD,
+  };
+
+  globalThis.fetch = (async (input: unknown) => {
+    const href = typeof input === 'string' ? input : (input as Request).url;
+    const key = decodeURIComponent(new URL(href).pathname.replace(/^\/get\//, ''));
+    if (key === META_KEY) {
+      counts.meta++;
+      if (remainingMetaFailures > 0) {
+        remainingMetaFailures--;
+        // Exactly what AbortSignal.timeout produces at 1500 ms: a thrown
+        // fetch, which readCachedJson reports as status 'error'.
+        throw Object.assign(new Error('The operation was aborted due to timeout'), { name: 'TimeoutError' });
+      }
+      if (options.metaMissing) return new Response(JSON.stringify({ result: null }), { status: 200 });
+    }
+    if (key === DATA_KEY) counts.data++;
+    const value = values[key];
+    return new Response(JSON.stringify({ result: value == null ? null : JSON.stringify(value) }), { status: 200 });
+  }) as typeof fetch;
+
+  return counts;
+}
+
+describe('seed-meta preflight — transient read error vs genuine absence', () => {
+  it('does not fail closed when the seed-meta read times out but the producer is healthy', async () => {
+    // The production shape: one timed-out read of a key that is present and
+    // fresh. Before #6484 this published source-failure for every country.
+    installRedisStub({ metaFailures: 1 });
+
+    const score = await scoreEducation('US');
+
+    assert.equal(
+      score.imputationClass,
+      null,
+      'a transient seed-meta read timeout must not be reported as a dead producer',
+    );
+    assert.ok(score.coverage > 0, `expected real coverage, got ${score.coverage}`);
+    assert.ok(score.score > 0, `expected a real score, got ${score.score}`);
+  });
+
+  it('still fails closed when the producer genuinely never published', async () => {
+    // The over-correction guard. Retrying a transient error must not make a
+    // real outage silent — an absent seed-meta is the signal that the Railway
+    // bundle is not publishing, and it must stay loud.
+    //
+    // Asserted as a THROW rather than a source-failure shape: scoreEducation
+    // raises ResilienceConfigurationError and `scoreAllDimensions` is what
+    // converts that into the coverage-0 source-failure row. Asserting the
+    // shape here would test the wrong layer.
+    installRedisStub({ metaMissing: true });
+
+    await assert.rejects(
+      () => scoreEducation('US'),
+      (err: Error) => err.name === 'ResilienceConfigurationError'
+        && /required seed-meta absent or unhealthy/.test(err.message),
+      'an absent seed-meta must still fail closed — that is the operator alarm',
+    );
+  });
+
+  it('retries the failing read rather than trusting the first answer', async () => {
+    const counts = installRedisStub({ metaFailures: 2 });
+    const score = await scoreEducation('US');
+    assert.ok(counts.meta > 1, `expected a retry, saw ${counts.meta} meta read(s)`);
+    assert.equal(score.imputationClass, null);
+  });
+});
+
+describe('memoized seed reader — one failed read must not poison the batch', () => {
+  it('does not cache a null seed-meta read across countries', async () => {
+    // The amplifier. `createMemoizedSeedReader` caches a resolved null, so in
+    // the ranking warm ONE failed read became source-failure for all 196
+    // countries. A later country in the same build must get its own attempt.
+    installRedisStub({ metaFailures: 1 });
+    const reader = createMemoizedSeedReader();
+
+    const first = await reader(META_KEY);
+    const second = await reader(META_KEY);
+
+    assert.ok(
+      first != null || second != null,
+      'a transient null must not be memoized for the rest of the build',
+    );
+    assert.notEqual(second, null, 'the second read in the same batch must retry rather than reuse the failure');
+  });
+
+  it('still memoizes a successful read', async () => {
+    const counts = installRedisStub();
+    const reader = createMemoizedSeedReader();
+    await reader(META_KEY);
+    await reader(META_KEY);
+    assert.equal(counts.meta, 1, 'a hit must be cached — memoization is the point of this reader');
+  });
+});


### PR DESCRIPTION
A fail-closed preflight is correct for a producer that never published and wrong for a 1.5-second network blip. Today it cannot tell them apart.

## Reproduced against production

Read-only, 196 countries through `scoreAllDimensions` with one memoized reader — exactly how the ranking warm runs it:

```
[REDIS-TIMEOUT] getCachedJson key=resilience:static:HK timeoutMs=1500
[REDIS-TIMEOUT] getCachedJson key=displacement:summary:v1:2025 timeoutMs=1500

education dimension outcome across the batch:
  source-failure   196
```

196/196, while the payload was present and the seed-meta was 26h old against an 8-day budget.

## Two independent faults

**1. Miss/error conflation.** `getCachedJson` collapses a MISS and a read ERROR to the same `null`, and the preflight reads that `null` as proof the seeder is dead. Seed-meta reads now go through `readCachedJson` — which reports `hit`/`miss`/`error` — and retry **only** the error case.

A genuine miss still returns on the first attempt, so a dead producer fails closed immediately. That half must not regress, and it has its own test: retrying a transient error must never make a real outage silent.

After exhausting retries the read still returns `null` rather than introducing a new throwing mode under load — but it logs that this was a *read* failure, not proof the producer is dead, because those need different remediations.

**2. Amplification.** `createMemoizedSeedReader` cached a resolved `null`. That memo is shared across every country in a ranking build, so **one** failed read became the answer for all 196 — turning a blip into a published, six-hour-cached outage. Null seed-meta results are no longer retained. Cost: at most one extra read per country for a genuinely absent key. Gain: a transient failure stays local.

## Scope — this is not the current production outage

Worth being explicit, because I initially misattributed it. The live `education` outage is the **#6472 activation-proof gate**: the published `seed-meta:resilience:education-attainment` predates both `rankableRecordCount` and its `countrySet` fallback, so `scoreEducation` throws **serially, at zero concurrency, on a healthy fresh key**:

```
US: THREW ResilienceConfigurationError: ... rankable coverage is unproven/180
```

That needs the education seed-meta republished (or `RESILIENCE_EDUCATION_ENABLED=false` to roll back). This PR fixes a **latent** fault found while diagnosing that one. They are independent, and this PR alone will not restore the dimension.

## Tests

Written proof-first and observed red before implementing — **3 red / 2 green**. The two greens matter: they are the over-correction guard and a memoize-a-hit control, so the fixture is proven capable of passing before the fix, not merely failing.

| | |
|---|---|
| a timed-out read on a healthy producer | must not fail closed |
| an absent seed-meta | must **still** fail closed |
| the failing read | must be retried, not trusted |
| a null seed-meta | must not be memoized across countries |
| a successful read | must still be memoized |

The fixture clears the #6472 activation floors (`rankableRecordCount` plus a 185-country payload built from the real rankable universe), so a green result proves something about the read path rather than passing for an unrelated reason.

## Verification

- `npm run test:data` — **23,073 tests, 0 failures**
- 146 tests across the seven scorer-touching suites
- typecheck clean, biome clean

Refs #6484, #6460, #6483
