### PR TITLE
chore(gitignore): ignore public/sources/ and tie the rule to the build (#6498)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ public/crises/
 public/tools/
 public/reference/
 public/research/
+public/sources/
 public/crawlable-corpus.json
 .DS_Store
 *.log

--- a/scripts/build-crawlable-corpus.mjs
+++ b/scripts/build-crawlable-corpus.mjs
@@ -164,7 +164,10 @@ function displayCountryName(code, fallbackName) {
   return COUNTRY_DISPLAY_NAMES[code] || fallbackName || code;
 }
 
-const GENERATED_DIRS = [
+// Exported so a test can hold .gitignore to this list. Every directory here is
+// deleted and rewritten on each build, so one missing an ignore rule shows up
+// as permanent untracked noise and can be committed by a stray `git add -A`.
+export const GENERATED_DIRS = [
   'countries',
   'chokepoints',
   'crises',

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -10,6 +10,7 @@ import {
   buildCorpus,
   chokepointMetaDescription,
   countryMetaDescription,
+  GENERATED_DIRS,
   gitFileLastmod,
   loadCorpusData,
 } from '../scripts/build-crawlable-corpus.mjs';
@@ -127,6 +128,26 @@ function productionScriptNonce() {
 }
 
 describe('crawlable corpus generator', () => {
+  // #6492 added public/sources/ to GENERATED_DIRS and not to .gitignore, so
+  // every built worktree carried it as untracked noise. Nothing tied the two
+  // lists together, so the next directory added would repeat it.
+  it('gitignores every directory the build deletes and rewrites', () => {
+    const ignored = new Set(
+      readFileSync(join(repoRoot, '.gitignore'), 'utf8')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line && !line.startsWith('#')),
+    );
+    for (const dir of GENERATED_DIRS) {
+      // 'reference/changelog' is covered by the broader 'public/reference/'.
+      const [topLevel] = dir.split('/');
+      assert.ok(
+        ignored.has(`public/${topLevel}/`),
+        `public/${topLevel}/ is missing from .gitignore — the build rewrites it every run, so it must not be tracked`,
+      );
+    }
+  });
+
   it('keeps future long source names inside the meta-description boundary', () => {
     const descriptions = new Set();
     for (let length = 1; length <= 100; length += 1) {


### PR DESCRIPTION
Closes #6498. Follow-up to #6491 / PR #6492.

## The gap

`scripts/build-crawlable-corpus.mjs` declares its own output directories and deletes each one before rewriting it:

```js
const GENERATED_DIRS = [
  'countries', 'chokepoints', 'crises', 'tools',
  'reference/changelog', 'research', 'sources',
];
```

Six of the seven have a matching `.gitignore` rule. `sources` — added by #6492 — did not, so any worktree that had run a build carried a permanent `?? public/sources/`: noise on every unrelated PR, and one `git add -A` from committing a build artifact that the next build deletes and rewrites.

## The fix

One ignore rule, plus the part that keeps it from happening again.

Nothing tied `.gitignore` to `GENERATED_DIRS`, so the next directory added would repeat the omission. `GENERATED_DIRS` is now exported and a test asserts `.gitignore` covers every entry. `'reference/changelog'` is matched by the broader `public/reference/`, so the assertion checks the top-level segment.

Removing the new rule turns the test red:

```
AssertionError: public/sources/ is missing from .gitignore —
the build rewrites it every run, so it must not be tracked
```

## This does not affect the live page

`worldmonitor.app/sources/` returns 200 and will continue to. These directories are rebuilt from committed data at deploy time — `npm run build` runs `build:crawlable-corpus` before `vite build` copies `public/` into the output — so git never needed to carry them.

`public/countries/` is the precedent already in production: gitignored, and `worldmonitor.app/countries/norway/` serves 200. This change puts `sources` on the same footing as its six siblings.

Not to be confused with `public/sitemap.xml`, which *is* generated and committed on purpose — it is not in `GENERATED_DIRS`, comes from the separate `build:sitemap` step, and has `build:sitemap:check` gating the committed copy. No equivalent exists for `sources`.

## Verification

```
$ npm run build:crawlable-corpus
Wrote crawlable corpus: 196 countries, 13 chokepoints, ... 1 source catalog page.
$ git status --short
# clean — was '?? public/sources/'
```

| Check | Result |
|---|---|
| `tests/crawlable-corpus.test.mjs` | 5 pass (1 new) |
| Mutant: remove the new ignore rule | new test goes red |
| `tests/deploy-config.test.mjs` | 176 pass |
| `docs:check`, `sources:check`, biome | pass |

https://claude.ai/code/session_01Wm1w4JR4u6NU5yRui56jL6