### PR TITLE
fix(ci): recover deploy gate from GitHub API failures

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -1,4 +1,5 @@
 name: Deploy Gate
+run-name: Deploy Gate ${{ github.event.workflow_run.head_sha || github.event_name }}
 
 # Runs whenever Test, Typecheck, Lint Code, or Security Audit completes on a PR/push.
 # Checks whether all required PR smoke gates have passed for the same commit SHA.
@@ -8,9 +9,15 @@ name: Deploy Gate
 # (#5479): event-driven evaluation alone can strand a PR — the check-runs API
 # can serve stale reads (~1 min normally, longer during GitHub degradation),
 # and the last workflow_run event for a SHA is the last time anything
-# re-evaluates. The sweep finds open-PR head SHAs whose gate status is still
-# "pending" and re-evaluates them, so a stranded PR heals within 30 minutes
+# re-evaluates. The sweep finds open-PR head SHAs whose gate status is pending
+# and re-evaluates them, so a stranded PR heals within 30 minutes
 # with no manual re-run.
+
+# Four workflow_run events can target the same SHA. Keep only the newest
+# evaluator so their retry windows do not multiply the installation API load.
+concurrency:
+  group: deploy-gate-${{ github.event.workflow_run.head_sha || github.event_name }}
+  cancel-in-progress: true
 
 on:
   workflow_run:
@@ -21,6 +28,9 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
+  checks: read
+  pull-requests: read
   statuses: write
 
 jobs:
@@ -54,6 +64,66 @@ jobs:
           name_count() {
             printf '%s\n' "$1" | tr ',' '\n' | wc -l | tr -d ' '
           }
+          # Retry a primary-rate-limit response once at GitHub's published
+          # reset time. The rate_limit endpoint does not spend primary budget;
+          # keeping this bounded avoids turning an outage into an infinite job.
+          gh_api_with_rate_limit_retry() {
+            local resource="$1"
+            shift
+            local error_file output result reset now wait_seconds
+            error_file=$(mktemp "${RUNNER_TEMP:-/tmp}/deploy-gate-error.XXXXXX")
+            if output=$(gh api "$@" 2>"$error_file"); then
+              rm -f "$error_file"
+              printf '%s\n' "$output"
+              return 0
+            else
+              result=$?
+            fi
+
+            cat "$error_file" >&2
+            if ! grep -qi 'rate limit exceeded' "$error_file"; then
+              rm -f "$error_file"
+              return "$result"
+            fi
+
+            reset=$(gh api rate_limit --jq ".resources.$resource.reset" 2>/dev/null || true)
+            if ! [ "$reset" -eq "$reset" ] 2>/dev/null; then
+              echo "::error::GitHub API rate limit was exhausted and its reset time was unavailable."
+              rm -f "$error_file"
+              return "$result"
+            fi
+
+            now=$(date +%s)
+            wait_seconds=$((reset - now + 5))
+            if [ "$wait_seconds" -lt 1 ]; then wait_seconds=1; fi
+            echo "GitHub $resource API budget exhausted; retrying once in ${wait_seconds}s." >&2
+            rm -f "$error_file"
+            sleep "$wait_seconds"
+            gh api "$@"
+          }
+          post_gate_status() {
+            local state="$1"
+            local description="$2"
+            gh_api_with_rate_limit_retry core "repos/$REPO/statuses/$SHA" --method POST \
+              --field state="$state" \
+              --field context="gate" \
+              --field description="$(gate_description "$description")"
+          }
+          # The runner invokes this block with `bash -e`. If anything escapes
+          # the bounded API retry after evaluation starts, make one last status
+          # attempt. BASHPID keeps command-substitution subshells from posting
+          # duplicate statuses; only this top-level shell owns the fallback.
+          gate_shell_pid=$BASHPID
+          active_sha=""
+          post_pending_on_exit() {
+            exit_code=$?
+            if [ "$exit_code" -eq 0 ] || [ "$BASHPID" != "$gate_shell_pid" ] || [ -z "$active_sha" ]; then
+              return
+            fi
+            SHA="$active_sha"
+            post_gate_status "pending" "Deploy Gate could not evaluate; retry scheduled" || true
+          }
+          trap post_pending_on_exit EXIT
           # Every job of every workflow named in the workflow_run trigger above.
           # A job missing here is never inspected, so it reports red on the PR
           # while this gate still posts success — CI theatre, not a gate (#5402).
@@ -70,23 +140,73 @@ jobs:
           # `typecheck-changes` / `lint-changes` so all three are evaluated
           # instead of two being masked by the third (#5822).
           required='["changes","typecheck-changes","lint-changes","docs-stats","unit","consumer-prices","umami-postgres","sidecar","convex-tests","dom-tests","desktop-config","desktop-rust","variant-smoke-full","resilience-validation-smoke","digest-image","typecheck","biome","public-docs","mintlify-slugs","security-audit"]'
+          repo_owner=${REPO%%/*}
+          repo_name=${REPO#*/}
 
           if [ -n "$SHA" ]; then
             # workflow_run event — evaluate exactly the triggering SHA.
             shas="$SHA"
           else
-            # schedule / workflow_dispatch — sweep open PRs whose gate status
-            # is still pending. Public-repo reads need no extra permission.
-            shas=$(gh api "repos/$REPO/pulls?state=open&per_page=100" --jq '.[].head.sha' | sort -u | while read -r s; do
-              # The API guarantees newest-first status history. Preserve that
-              # order because updated_at ties within the same second.
-              state=$(
-                gh api --paginate --slurp \
-                  "repos/$REPO/commits/$s/statuses?per_page=100" |
-                  jq -r 'flatten | map(select(.context == "gate")) | first | .state // "missing"'
-              )
-              if [ "$state" = "pending" ]; then echo "$s"; fi
-            done)
+            # schedule / workflow_dispatch — read every open PR head and its
+            # `gate` context in one paginated GraphQL query. A failed
+            # event-driven run normally posts pending through the EXIT trap. If
+            # even that write fails, cross-reference missing contexts with
+            # recent failed runs of this workflow. That recovers an old head
+            # whose checks were rerun without re-evaluating every dormant
+            # legacy PR with no gate context (#5851).
+            pr_gate_states=$(gh_api_with_rate_limit_retry graphql graphql --paginate --slurp \
+              -f owner="$repo_owner" \
+              -f name="$repo_name" \
+              -f query='query($owner: String!, $name: String!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  pullRequests(first: 100, states: [OPEN], after: $endCursor) {
+                    nodes {
+                      headRefOid
+                      commits(last: 1) {
+                        nodes {
+                          commit {
+                            status { context(name: "gate") { state } }
+                          }
+                        }
+                      }
+                    }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+              }')
+            pending_shas=$(printf '%s\n' "$pr_gate_states" | jq -r '
+              .[].data.repository.pullRequests.nodes[] |
+              select(.commits.nodes[0].commit.status.context.state == "PENDING") |
+              .headRefOid
+            ')
+            missing_shas=$(printf '%s\n' "$pr_gate_states" | jq -r '
+              .[].data.repository.pullRequests.nodes[] |
+              select(.commits.nodes[0].commit.status.context == null) |
+              .headRefOid
+            ')
+            failed_missing_shas=""
+            if [ -n "$missing_shas" ]; then
+              recent_run_cutoff=$(($(date +%s) - 86400))
+              recent_run_cutoff_iso=$(date -u -d "@$recent_run_cutoff" +%Y-%m-%dT%H:%M:%SZ)
+              failed_gate_shas=$(gh_api_with_rate_limit_retry core \
+                "repos/$REPO/actions/workflows/deploy-gate.yml/runs?event=workflow_run&status=failure&created=>=$recent_run_cutoff_iso&per_page=100" \
+                --paginate --slurp |
+                jq -r --argjson cutoff "$recent_run_cutoff" '
+                  .[].workflow_runs[] |
+                  select(
+                    (.created_at | fromdateiso8601) >= $cutoff and
+                    (.display_title | test("^Deploy Gate [0-9a-f]{40}$"))
+                  ) |
+                  .display_title |
+                  sub("^Deploy Gate "; "")
+                ')
+              failed_missing_shas=$(printf '%s\n' "$missing_shas" | while read -r missing_sha; do
+                if printf '%s\n' "$failed_gate_shas" | grep -qx "$missing_sha"; then
+                  echo "$missing_sha"
+                fi
+              done)
+            fi
+            shas=$(printf '%s\n%s\n' "$pending_shas" "$failed_missing_shas" | sed '/^$/d' | sort -u)
             if [ -z "$shas" ]; then
               echo "sweep: no open PRs with a pending gate status"
               exit 0
@@ -97,39 +217,46 @@ jobs:
 
           for SHA in $shas; do
           echo "── evaluating $SHA"
+          active_sha="$SHA"
 
           # Poll check-runs for this SHA and find the latest result for each required job.
-          #
-          # PAGINATE. `filter=latest` still returns one entry per check-run NAME,
-          # and a push to main now carries more than 100 of them (153 on
-          # d38195c86, 161 on 704537706) — Convex Deploy, the Railway trigger,
-          # IndexNow and the monitors all publish here, not just the gated
-          # workflows. A single un-paginated page held ZERO of the 20 required
-          # names on d38195c86, so the gate read "everything pending" from a page
-          # that did not contain the answer: it posted a stuck `pending` on main
-          # head, and before #6390 it built a ~300-character description from all
-          # 20 names and died on the API's 140-character cap. That 422 was the
-          # symptom; this truncation is the cause (#6389).
-          #
-          # `--slurp` cannot be combined with gh's own `--jq`, so pipe to jq the
-          # way the sweep above already does. Project to just the three fields
-          # the gate logic reads — more pages means more bytes, and passing the
-          # un-projected JSON to python3 via the RUNS_JSON env var overflowed
-          # Linux's 128KB-per-arg/env limit (MAX_ARG_STRLEN) once it crossed
-          # ~131KB, failing the gate with "Argument list too long" (exit 126).
           #
           # #5479: the check-runs API can lag ~1 minute behind a job's completion,
           # and workflow_run fires a bounded number of times per SHA — when the
           # LAST event's single poll got a stale read, the posted "pending"
           # status was never refreshed and the PR stayed stuck until a manual
           # re-run (PRs #5476/#5475/#5481). When jobs still read as pending,
-          # re-poll a few times before concluding pending. The all-complete case
-          # breaks on the first pass, so the happy path costs nothing extra.
+          # re-poll once after a longer delay before concluding pending. The
+          # all-complete case breaks on the first pass. GraphQL has a separate
+          # installation budget from REST core and returns the current rollup in
+          # two pages (115 contexts measured on 2026-08-12). The measured request
+          # totals are three for a complete SHA and five for a still-pending SHA;
+          # the old two-page/five-poll REST path cost three and eleven, all from
+          # core.
           # NOTE: the python3 -c body must stay at column 0 of the block scalar —
           # indenting it with the loops would be a Python IndentationError.
-          for attempt in 1 2 3 4 5; do
-            runs=$(gh api --paginate --slurp "repos/$REPO/commits/$SHA/check-runs?per_page=100" |
-              jq -c "[.[].check_runs[]] | map(select(.name as \$name | $required | index(\$name)) | {name, conclusion, completed_at})")
+          for attempt in 1 2; do
+            runs=$(gh_api_with_rate_limit_retry graphql graphql --paginate --slurp \
+              -f owner="$repo_owner" \
+              -f name="$repo_name" \
+              -F sha="$SHA" \
+              -f query='query($owner: String!, $name: String!, $sha: GitObjectID!, $endCursor: String) {
+                repository(owner: $owner, name: $name) {
+                  object(oid: $sha) {
+                    ... on Commit {
+                      statusCheckRollup {
+                        contexts(first: 100, after: $endCursor) {
+                          nodes {
+                            ... on CheckRun { name conclusion databaseId startedAt completedAt }
+                          }
+                          pageInfo { hasNextPage endCursor }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' |
+              jq -c --argjson required "$required" '[.[].data.repository.object.statusCheckRollup.contexts.nodes[]? | select(has("name") and (.name as $name | $required | index($name)))]')
 
             status=$(RUNS_JSON="$runs" REQUIRED_JOBS="$required" python3 -c "
           import json
@@ -142,8 +269,15 @@ jobs:
           for name in required:
             matches = [r for r in runs if r.get('name') == name]
             if matches:
-              latest_run = sorted(matches, key=lambda r: r.get('completed_at') or '')[-1]
-              latest[name] = latest_run.get('conclusion') or 'pending'
+              latest_run = sorted(
+                  matches,
+                  key=lambda r: (
+                      r.get('databaseId') or 0,
+                      r.get('completedAt') or r.get('startedAt') or '',
+                  ),
+              )[-1]
+              conclusion = latest_run.get('conclusion')
+              latest[name] = conclusion.lower() if conclusion else 'pending'
             else:
               latest[name] = 'pending'
 
@@ -159,30 +293,24 @@ jobs:
             if [ -z "$pending" ]; then
               break
             fi
-            if [ "$attempt" -lt 5 ]; then
-              sleep 30
+            if [ "$attempt" -lt 2 ]; then
+              sleep 60
             fi
           done
 
           if [ -n "$pending" ]; then
-            gh api "repos/$REPO/statuses/$SHA" --method POST \
-              --field state="pending" \
-              --field context="gate" \
-              --field description="$(gate_description "Waiting for required PR gates ($(name_count "$pending")): $pending")"
+            post_gate_status "pending" "Waiting for required PR gates ($(name_count "$pending")): $pending"
+            active_sha=""
             continue
           fi
 
           # Treat "skipped" as passing (docs-only PRs skip code checks)
           if [ -n "$failed" ]; then
-            gh api "repos/$REPO/statuses/$SHA" --method POST \
-              --field state="failure" \
-              --field context="gate" \
-              --field description="$(gate_description "Required PR gates did not pass ($(name_count "$failed")): $failed")"
+            post_gate_status "failure" "Required PR gates did not pass ($(name_count "$failed")): $failed"
+            active_sha=""
             continue
           fi
 
-          gh api "repos/$REPO/statuses/$SHA" --method POST \
-            --field state="success" \
-            --field context="gate" \
-            --field description="All required PR gates passed"
+          post_gate_status "success" "All required PR gates passed"
+          active_sha=""
           done

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -682,20 +682,30 @@ describe('CI workflow coverage', () => {
     );
   });
 
-  it('paginates gate status history during the scheduled self-healing sweep', () => {
+  it('batches pending gate discovery during the scheduled self-healing sweep', () => {
     const deployGateJob = workflowJobBlock(deployGateWorkflow, 'gate');
 
-    assert.match(deployGateJob, /gh api --paginate --slurp/);
-    assert.match(deployGateJob, /commits\/\$s\/statuses\?per_page=100/);
+    assert.match(
+      deployGateWorkflow,
+      /^run-name: Deploy Gate \$\{\{ github\.event\.workflow_run\.head_sha \|\| github\.event_name \}\}$/m,
+    );
+    assert.match(deployGateJob, /graphql --paginate --slurp/);
+    assert.match(deployGateJob, /pullRequests\(first: 100, states: \[OPEN\], after: \$endCursor\)/);
+    assert.match(deployGateJob, /pageInfo \{ hasNextPage endCursor \}/);
+    assert.match(deployGateJob, /contexts\(first: 100, after: \$endCursor\)/);
+    assert.match(deployGateJob, /status \{ context\(name: "gate"\) \{ state \} \}/);
+    assert.match(deployGateJob, /context\.state == "PENDING"/);
+    assert.match(deployGateJob, /context == null/);
     assert.match(
       deployGateJob,
-      /flatten \| map\(select\(\.context == "gate"\)\) \| first/,
+      /actions\/workflows\/deploy-gate\.yml\/runs\?event=workflow_run&status=failure&created=>=\$recent_run_cutoff_iso/,
     );
-    assert.doesNotMatch(deployGateJob, /sort_by\(\.updated_at\)/);
+    assert.match(deployGateJob, /created_at \| fromdateiso8601/);
+    assert.match(deployGateJob, /display_title \| test\("\^Deploy Gate \[0-9a-f\]\{40\}\$"\)/);
     assert.doesNotMatch(
       deployGateJob,
-      /commits\/\$s\/status"/,
-      'the combined status endpoint silently truncates large commit-status histories',
+      /commits\/\$s\/statuses/,
+      'the sweep must not spend one paginated REST request per open PR',
     );
   });
 

--- a/tests/deploy-gate-status-description.test.mjs
+++ b/tests/deploy-gate-status-description.test.mjs
@@ -32,80 +32,185 @@ const REQUIRED = JSON.parse(gateStep.run.match(/required='(\[[^']*\])'/)[1]);
  * `conclusions` maps a required check name to its conclusion; a name left out
  * is absent from the API response, which the step reads as pending.
  *
- * `fillerFirstPage` reproduces production: `filter=latest` returns one entry
- * per check-run NAME, a push to main carries more than 100 of them, and on
- * d38195c86 page one held ZERO of the 20 required names. Pass it to put the
- * required entries on page two, where only a paginated read can see them.
+ * Options can force API failures, drive the scheduled-sweep path, and add an
+ * older completed suite so the harness also proves that a newer pending rerun
+ * cannot be masked by its predecessor.
  */
-function runGate(conclusions, { fillerFirstPage = 0 } = {}) {
+function runGate(conclusions, {
+  failedRunCreatedAt = '2026-08-12T12:15:00Z',
+  failedRunSha = SHA,
+  graphQlFailures = 0,
+  graphQlFailureKind = 'generic',
+  previousConclusions,
+  resetAvailable = true,
+  statusFailures = 0,
+  statusFailureKind = 'generic',
+  sweepState,
+} = {}) {
   const tempDir = mkdtempSync(join(repoRoot, '.tmp-deploy-gate-'));
   const fakeBin = join(tempDir, 'bin');
   const runsFile = join(tempDir, 'check-runs.json');
+  const failuresFile = join(tempDir, 'graphql-failures');
+  const statusFailuresFile = join(tempDir, 'status-failures');
+  const sweepFile = join(tempDir, 'sweep.json');
   const postedFile = join(tempDir, 'posted');
   const rejectedFile = join(tempDir, 'rejected');
+  const callsFile = join(tempDir, 'calls');
 
   try {
     mkdirSync(fakeBin);
+    writeFileSync(failuresFile, String(graphQlFailures));
+    writeFileSync(statusFailuresFile, String(statusFailures));
     writeFileSync(postedFile, '');
     writeFileSync(rejectedFile, '');
-    const required = Object.entries(conclusions).map(([name, conclusion]) => ({
-      name,
-      conclusion,
-      completed_at: '2026-08-10T05:00:00Z',
+    writeFileSync(callsFile, '');
+    const runsFor = (values, timestamp, idBase) => REQUIRED.flatMap((name, index) => values?.[name]
+      ? [{
+        name,
+        conclusion: values[name] === 'pending' ? null : values[name].toUpperCase(),
+        databaseId: idBase + index,
+        completedAt: values[name] === 'pending' ? null : timestamp,
+        startedAt: values[name] === 'pending' ? null : timestamp,
+      }]
+      : []);
+    const requiredRuns = [
+      ...(previousConclusions
+        ? runsFor(previousConclusions, '2026-08-10T04:00:00Z', 1000)
+        : []),
+      ...runsFor(conclusions, '2026-08-10T05:00:00Z', 2000),
+    ];
+    const filler = Array.from({ length: 100 }, (_, index) => ({
+      name: `unrelated-${index}`,
+      conclusion: 'SUCCESS',
+      databaseId: index,
+      completedAt: '2026-08-10T03:00:00Z',
+      startedAt: '2026-08-10T02:00:00Z',
     }));
-    const filler = Array.from({ length: fillerFirstPage }, (_, index) => ({
-      name: `indexnow-submit-${index}`,
-      conclusion: 'skipped',
-      completed_at: '2026-08-10T05:00:00Z',
-    }));
-    // The shape gh returns: one object per page, and `--slurp` wraps them in an
-    // array. Without pagination the caller sees page one and nothing else.
+    // `gh api graphql --paginate --slurp` returns an array of page responses;
+    // the workflow's jq projection then keeps only the required check names.
     writeFileSync(
       runsFile,
-      JSON.stringify(
-        fillerFirstPage > 0
-          ? [{ check_runs: filler }, { check_runs: required }]
-          : [{ check_runs: required }],
-      ),
+      JSON.stringify([{
+        data: {
+          repository: {
+            object: {
+              statusCheckRollup: {
+                contexts: {
+                  nodes: filler,
+                  pageInfo: { hasNextPage: true, endCursor: 'page-two' },
+                },
+              },
+            },
+          },
+        },
+      }, {
+        data: {
+          repository: {
+            object: {
+              statusCheckRollup: {
+                contexts: {
+                  nodes: requiredRuns,
+                  pageInfo: { hasNextPage: false, endCursor: 'done' },
+                },
+              },
+            },
+          },
+        },
+      }]),
+    );
+    const sweepNode = (sha, state) => ({
+      headRefOid: sha,
+      commits: { nodes: [{ commit: { status: { context: state ? { state } : null } } }] },
+    });
+    writeFileSync(
+      sweepFile,
+      JSON.stringify([{
+        data: {
+          repository: {
+            pullRequests: {
+              nodes: Array.from({ length: 100 }, (_, index) => sweepNode(`other-${index}`, 'SUCCESS')),
+              pageInfo: { hasNextPage: true, endCursor: 'page-two' },
+            },
+          },
+        },
+      }, {
+        data: {
+          repository: {
+            pullRequests: {
+              nodes: [sweepNode(SHA, sweepState)],
+              pageInfo: { hasNextPage: false, endCursor: 'done' },
+            },
+          },
+        },
+      }]),
     );
 
-    // Three behaviours matter, and each is a real API behaviour rather than a
-    // convenience. The check-runs read serves ONLY page one unless --paginate
-    // is passed, and applies a --jq filter itself when given one, so a step
-    // that forgets to paginate sees exactly what production saw. The status
-    // POST enforces the real 140-character cap the way the API does — a 422 and
-    // a non-zero exit — so this harness reproduces #6389 rather than describing
-    // it.
+    // The fake keeps the production failure semantics: gh exits non-zero on an
+    // API error, rate-limit recovery must consult the reset time, and commit
+    // statuses reject descriptions over GitHub's real 140-character cap.
     writeFileSync(
       join(fakeBin, 'gh'),
       [
         '#!/bin/sh',
+        'if [ "$1" = "api" ] && [ "$2" = "rate_limit" ]; then',
+        '  case "$*" in',
+        '    *".resources.graphql.reset"*) resource=graphql ;;',
+        '    *".resources.core.reset"*) resource=core ;;',
+        '    *) resource=unknown ;;',
+        '  esac',
+        '  echo "rate-limit:$resource" >> "$FAKE_CALLS"',
+        '  [ "$FAKE_RESET_AVAILABLE" = "1" ] && printf \'%s\\n\' "$FAKE_RESET_AT"',
+        '  exit 0',
+        'fi',
         'case "$*" in',
-        '  *"/check-runs"*)',
-        '    filter=""',
-        '    take_next=0',
+        '  *"pullRequests(first:"*)',
         '    paginate=0',
+        '    slurp=0',
         '    for arg in "$@"; do',
-        '      if [ "$take_next" = "1" ]; then filter="$arg"; take_next=0; continue; fi',
-        '      case "$arg" in',
-        '        --jq|-q) take_next=1 ;;',
-        '        --paginate) paginate=1 ;;',
-        '      esac',
+        '      [ "$arg" = "--paginate" ] && paginate=1',
+        '      [ "$arg" = "--slurp" ] && slurp=1',
         '    done',
+        '    echo "graphql-sweep-page" >> "$FAKE_CALLS"',
         '    if [ "$paginate" = "1" ]; then',
-        // gh refuses --slurp together with --jq, and without --slurp a paginated
-        // read emits bare concatenated page bodies rather than the array the
-        // filter indexes. Half a pagination fix must not pass here.
-        '      case " $* " in *" --slurp "*) ;; *) exit 96 ;; esac',
-        '      body=$(cat "$FAKE_CHECK_RUNS")',
+        '      echo "graphql-sweep-page" >> "$FAKE_CALLS"',
+        '      [ "$slurp" = "1" ] || exit 96',
+        '      cat "$FAKE_SWEEP_RESPONSES"',
         '    else',
-        '      body=$(jq -c \'.[0]\' "$FAKE_CHECK_RUNS")',
+        '      jq -c \'[.[0]]\' "$FAKE_SWEEP_RESPONSES"',
         '    fi',
-        '    if [ -n "$filter" ]; then',
-        '      printf \'%s\' "$body" | jq -c "$filter"',
-        '    else',
+        '    exit 0',
+        '    ;;',
+        '  *"statusCheckRollup"*)',
+        '    paginate=0',
+        '    slurp=0',
+        '    for arg in "$@"; do',
+        '      [ "$arg" = "--paginate" ] && paginate=1',
+        '      [ "$arg" = "--slurp" ] && slurp=1',
+        '    done',
+        '    echo "graphql-check-page" >> "$FAKE_CALLS"',
+        '    failures=$(cat "$FAKE_FAILURES")',
+        '    if [ "$failures" -gt 0 ]; then',
+        '      echo $((failures - 1)) > "$FAKE_FAILURES"',
+        '      if [ "$FAKE_FAILURE_KIND" = "rate_limit" ]; then',
+        '        echo "gh: API rate limit exceeded for installation (HTTP 403)" >&2',
+        '      else',
+        '        echo "gh: forced GraphQL failure (HTTP 500)" >&2',
+        '      fi',
+        '      exit 1',
+        '    fi',
+        '    body=$(cat "$FAKE_CHECK_RUNS")',
+        '    if [ "$paginate" = "1" ]; then',
+        '      echo "graphql-check-page" >> "$FAKE_CALLS"',
+        '      [ "$slurp" = "1" ] || exit 96',
         '      printf \'%s\' "$body"',
+        '    else',
+        '      printf \'%s\' "$body" | jq -c \'[.[0]]\'',
         '    fi',
+        '    exit 0',
+        '    ;;',
+        '  *"actions/workflows/deploy-gate.yml/runs"*)',
+        '    echo "rest-failed-runs-page" >> "$FAKE_CALLS"',
+        '    printf \'[{"workflow_runs":[{"created_at":"%s","display_title":"Deploy Gate %s"}]}]\' "$FAKE_FAILED_RUN_CREATED_AT" "$FAKE_FAILED_RUN_SHA"',
         '    exit 0',
         '    ;;',
         '  *"/statuses/"*)',
@@ -117,6 +222,17 @@ function runGate(conclusions, { fillerFirstPage = 0 } = {}) {
         '        description=*) description=${arg#description=} ;;',
         '      esac',
         '    done',
+        '    echo "status:$state" >> "$FAKE_CALLS"',
+        '    status_failures=$(cat "$FAKE_STATUS_FAILURES")',
+        '    if [ "$status_failures" -gt 0 ]; then',
+        '      echo $((status_failures - 1)) > "$FAKE_STATUS_FAILURES"',
+        '      if [ "$FAKE_STATUS_FAILURE_KIND" = "rate_limit" ]; then',
+        '        echo "gh: API rate limit exceeded for installation (HTTP 403)" >&2',
+        '      else',
+        '        echo "gh: forced commit-status failure (HTTP 500)" >&2',
+        '      fi',
+        '      exit 1',
+        '    fi',
         '    if [ "${#description}" -gt 140 ]; then',
         '      printf \'%s|%s\\n\' "$state" "$description" >> "$FAKE_REJECTED"',
         '      echo "gh: Validation failed: Description is too long (maximum is 140 characters) (Validation Failed)" >&2',
@@ -130,23 +246,50 @@ function runGate(conclusions, { fillerFirstPage = 0 } = {}) {
         '',
       ].join('\n'),
     );
-    // The step sleeps 30s between poll attempts; four of those would make this
-    // suite take two minutes to learn nothing.
-    writeFileSync(join(fakeBin, 'sleep'), ['#!/bin/sh', 'exit 0', ''].join('\n'));
-    for (const command of ['gh', 'sleep']) chmodSync(join(fakeBin, command), 0o755);
+    // The step sleeps between poll attempts and may wait for a rate-limit reset;
+    // neither delay should slow this deterministic harness.
+    writeFileSync(join(fakeBin, 'date'), [
+      '#!/bin/sh',
+      'case "$*" in',
+      '  *"+%Y-%m-%dT%H:%M:%SZ"*) printf \'%s\\n\' "$FAKE_CUTOFF_ISO" ;;',
+      '  *) printf \'%s\\n\' "$FAKE_NOW" ;;',
+      'esac',
+      '',
+    ].join('\n'));
+    writeFileSync(join(fakeBin, 'sleep'), [
+      '#!/bin/sh',
+      'echo "sleep:$1" >> "$FAKE_CALLS"',
+      'exit 0',
+      '',
+    ].join('\n'));
+    for (const command of ['gh', 'date', 'sleep']) chmodSync(join(fakeBin, command), 0o755);
 
     const result = spawnSync('bash', ['-e', '-c', gateStep.run], {
       cwd: repoRoot,
       encoding: 'utf8',
       env: {
         ...process.env,
+        FAKE_CALLS: callsFile,
         FAKE_CHECK_RUNS: runsFile,
+        FAKE_CUTOFF_ISO: '2026-08-11T12:30:00Z',
+        FAKE_FAILED_RUN_CREATED_AT: failedRunCreatedAt,
+        FAKE_FAILED_RUN_SHA: failedRunSha,
+        FAKE_FAILURE_KIND: graphQlFailureKind,
+        FAKE_FAILURES: failuresFile,
         FAKE_POSTED: postedFile,
         FAKE_REJECTED: rejectedFile,
+        FAKE_NOW: String(Date.parse('2026-08-12T12:30:00Z') / 1000),
+        FAKE_RESET_AT: String(Date.parse('2026-08-12T12:30:10Z') / 1000),
+        FAKE_RESET_AVAILABLE: resetAvailable ? '1' : '0',
+        FAKE_STATUS_FAILURE_KIND: statusFailureKind,
+        FAKE_STATUS_FAILURES: statusFailuresFile,
+        FAKE_SWEEP_RESPONSES: sweepFile,
+        FAKE_SHA: SHA,
         GH_TOKEN: 'test-token',
         PATH: `${fakeBin}:${process.env.PATH}`,
         REPO: 'koala73/worldmonitor',
-        SHA,
+        RUNNER_TEMP: tempDir,
+        SHA: sweepState === undefined ? SHA : '',
       },
     });
 
@@ -158,7 +301,12 @@ function runGate(conclusions, { fillerFirstPage = 0 } = {}) {
         return { state: line.slice(0, separator), description: line.slice(separator + 1) };
       });
 
-    return { ...result, posted: parse(postedFile), rejected: parse(rejectedFile) };
+    return {
+      ...result,
+      calls: readFileSync(callsFile, 'utf8').split('\n').filter(Boolean),
+      posted: parse(postedFile),
+      rejected: parse(rejectedFile),
+    };
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
   }
@@ -189,6 +337,18 @@ describe('deploy gate commit-status description', () => {
     assert.ok(result.posted[0].description.length <= 140);
     assert.match(result.posted[0].description, new RegExp(`Waiting for required PR gates \\(${REQUIRED.length}\\):`));
     assert.match(result.posted[0].description, /\.\.\.$/, 'a truncated description must say it was cut');
+    assert.deepEqual(
+      result.calls,
+      [
+        'graphql-check-page',
+        'graphql-check-page',
+        'sleep:60',
+        'graphql-check-page',
+        'graphql-check-page',
+        'status:pending',
+      ],
+      'the pending path must use five HTTP calls, down from eleven, with one bounded wait',
+    );
   });
 
   it('posts a failure status when every required check failed', () => {
@@ -216,29 +376,175 @@ describe('deploy gate commit-status description', () => {
     assert.doesNotMatch(result.posted[0].description, /\.\.\.$/, 'a description that fits must not be cut');
   });
 
-  it('reads every page, so a required check on page two is not read as pending', () => {
-    // What actually happened on d38195c86: 153 check runs, and an un-paginated
-    // read of the first 100 held ZERO of the 20 required names. The gate posted
-    // `Waiting for required PR gates (6): …` over six checks that had already
-    // passed, and nothing re-evaluates a main commit — the self-healing sweep
-    // walks open PR heads only. Before #6390 the same misread produced all 20
-    // names, a ~300-character description and a 422 that posted nothing at all.
-    const result = runGate(conclusionsFor('success'), { fillerFirstPage: 100 });
-
-    assert.equal(result.status, 0, result.stderr);
-    assert.deepEqual(
-      result.posted,
-      [{ state: 'success', description: 'All required PR gates passed' }],
-      'every required check passed on page two; a gate that cannot see page two invents a pending verdict',
-    );
-  });
-
   it('still posts success when everything passed or skipped', () => {
     const conclusions = conclusionsFor('success');
     conclusions['desktop-rust'] = 'skipped';
     const result = runGate(conclusions);
 
     assert.equal(result.status, 0, result.stderr);
-    assert.deepEqual(result.posted, [{ state: 'success', description: 'All required PR gates passed' }]);
+    assert.deepEqual(result.posted, [
+      { state: 'success', description: 'All required PR gates passed' },
+    ]);
+    assert.deepEqual(result.calls, ['graphql-check-page', 'graphql-check-page', 'status:success']);
+  });
+
+  it('does not let an older completed run mask a newer pending rerun', () => {
+    const current = conclusionsFor('success');
+    current.unit = 'pending';
+    const result = runGate(current, { previousConclusions: conclusionsFor('success') });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.posted.at(-1).state, 'pending');
+    assert.match(result.posted.at(-1).description, /unit/);
+  });
+
+  it('leaves a named pending gate when the check read crashes, then self-heals on the next evaluation', () => {
+    const crashed = runGate(conclusionsFor('success'), { graphQlFailures: 1 });
+
+    assert.notEqual(crashed.status, 0, 'the forced API failure must actually crash the evaluation');
+    assert.deepEqual(crashed.posted, [
+      { state: 'pending', description: 'Deploy Gate could not evaluate; retry scheduled' },
+    ]);
+
+    const healed = runGate(conclusionsFor('success'), { sweepState: 'PENDING' });
+    assert.equal(healed.status, 0, healed.stderr);
+    assert.deepEqual(healed.posted.at(-1), {
+      state: 'success',
+      description: 'All required PR gates passed',
+    });
+    assert.deepEqual(
+      healed.calls.slice(0, 2),
+      ['graphql-sweep-page', 'graphql-sweep-page'],
+      'a pending gate beyond the first 100 open PRs must enter recovery',
+    );
+  });
+
+  it('backs off to the installation reset and retries a rate-limited read once', () => {
+    const result = runGate(conclusionsFor('success'), {
+      graphQlFailures: 1,
+      graphQlFailureKind: 'rate_limit',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.calls, [
+      'graphql-check-page',
+      'rate-limit:graphql',
+      'sleep:15',
+      'graphql-check-page',
+      'graphql-check-page',
+      'status:success',
+    ]);
+  });
+
+  it('posts pending when a rate-limited check read still fails after one retry', () => {
+    const result = runGate(conclusionsFor('success'), {
+      graphQlFailures: 2,
+      graphQlFailureKind: 'rate_limit',
+    });
+
+    assert.notEqual(result.status, 0, 'a persistent rate limit must fail the evaluation');
+    assert.deepEqual(result.posted, [
+      { state: 'pending', description: 'Deploy Gate could not evaluate; retry scheduled' },
+    ]);
+  });
+
+  it('posts pending when a rate-limit reset is unavailable', () => {
+    const result = runGate(conclusionsFor('success'), {
+      graphQlFailures: 1,
+      graphQlFailureKind: 'rate_limit',
+      resetAvailable: false,
+    });
+
+    assert.notEqual(result.status, 0, 'an unavailable reset must fail the evaluation');
+    assert.deepEqual(result.calls, [
+      'graphql-check-page',
+      'rate-limit:graphql',
+      'status:pending',
+    ]);
+    assert.deepEqual(result.posted, [
+      { state: 'pending', description: 'Deploy Gate could not evaluate; retry scheduled' },
+    ]);
+  });
+
+  it('falls back to pending when the verdict status write fails', () => {
+    const result = runGate(conclusionsFor('success'), { statusFailures: 1 });
+
+    assert.notEqual(result.status, 0, 'the forced status failure must fail the evaluation');
+    assert.deepEqual(result.calls, [
+      'graphql-check-page',
+      'graphql-check-page',
+      'status:success',
+      'status:pending',
+    ]);
+    assert.deepEqual(result.posted, [
+      { state: 'pending', description: 'Deploy Gate could not evaluate; retry scheduled' },
+    ]);
+  });
+
+  it('retries a rate-limited verdict status write', () => {
+    const result = runGate(conclusionsFor('success'), {
+      statusFailures: 1,
+      statusFailureKind: 'rate_limit',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.calls, [
+      'graphql-check-page',
+      'graphql-check-page',
+      'status:success',
+      'rate-limit:core',
+      'sleep:15',
+      'status:success',
+    ]);
+    assert.deepEqual(result.posted, [
+      { state: 'success', description: 'All required PR gates passed' },
+    ]);
+  });
+
+  it('heals a recent missing gate after both status writes fail', () => {
+    const stranded = runGate(conclusionsFor('success'), { statusFailures: 2 });
+
+    assert.notEqual(stranded.status, 0, 'both status writes must fail the first evaluation');
+    assert.deepEqual(stranded.posted, []);
+    assert.deepEqual(stranded.calls.slice(-2), ['status:success', 'status:pending']);
+
+    const healed = runGate(conclusionsFor('success'), { sweepState: null });
+    assert.equal(healed.status, 0, healed.stderr);
+    assert.deepEqual(healed.calls.slice(0, 2), ['graphql-sweep-page', 'graphql-sweep-page']);
+    assert.equal(healed.calls[2], 'rest-failed-runs-page');
+    assert.deepEqual(healed.posted.at(-1), {
+      state: 'success',
+      description: 'All required PR gates passed',
+    });
+  });
+
+  it('does not recover a missing gate without a matching recent failed run', () => {
+    const result = runGate(conclusionsFor('success'), {
+      failedRunSha: '0123456789abcdef0123456789abcdef01234567',
+      sweepState: null,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.calls, [
+      'graphql-sweep-page',
+      'graphql-sweep-page',
+      'rest-failed-runs-page',
+    ]);
+    assert.deepEqual(result.posted, []);
+  });
+
+  it('does not recover a missing gate from a stale failed run', () => {
+    const result = runGate(conclusionsFor('success'), {
+      failedRunCreatedAt: '2026-08-10T12:15:00Z',
+      sweepState: null,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.calls, [
+      'graphql-sweep-page',
+      'graphql-sweep-page',
+      'rest-failed-runs-page',
+    ]);
+    assert.deepEqual(result.posted, []);
   });
 });


### PR DESCRIPTION
## Summary

Deploy Gate failures now leave a machine-readable `gate` status instead of silently stranding a PR. Rate-limited GitHub reads and writes retry once at the published reset; any later error posts a fail-closed `pending` status, and if both status writes fail, the scheduled sweep recovers the missing context from the failed run's SHA without a human rerun.

Duplicate evaluators for one SHA are canceled, check-rollup reads use the separate GraphQL budget, and the sweep batches open-PR status discovery instead of reading status history once per PR.

### Request budget

These are raw HTTP requests for the measured 115-context rollup on 2026-08-12:

| Per-SHA path | Before | After |
|---|---:|---:|
| All required checks complete | 3 REST core requests | 2 GraphQL pages + 1 REST status = 3 |
| Required checks still pending | 10 REST check pages + 1 status = 11 | 4 GraphQL pages + 1 REST status = 5 |

The current scheduled sweep reads 97 open PRs in one GraphQL page. It consults the REST failed-run list only when an open PR has no `gate` context, with both server-side and client-side 24-hour cutoffs.

## Validation

- Forced generic read failure, persistent installation rate limit, unavailable reset, verdict-write failure, and double status-write failure in the executable workflow harness.
- Proved the double-write failure leaves no status, then the scheduled sweep finds the SHA through its failed run name and posts the correct final status.
- Proved pagination past 100 check contexts and 100 open PRs, queued rerun ordering, and raw request counts.
- `40` focused tests passed after rebasing onto current `main`.
- `npm run typecheck`, focused Biome lint, YAML parse, and all pre-push gates passed.
- Live probes confirmed 115 status-check contexts over two GraphQL pages, 97 open PRs over one page, and GitHub acceptance of the server-side workflow-run `created` filter.

## Post-deploy monitoring

The updated `workflow_run` definition executes from the default branch, so production acceptance starts after merge. For the first 24 hours and at least two scheduled sweeps:

- Check Deploy Gate failures for `API rate limit exceeded`, the bounded retry message, and `Deploy Gate could not evaluate`.
- Verify every affected SHA has a `gate` context and that `pending` or missing contexts converge to the correct verdict without a manual rerun.
- Treat any new missing context after a failed Deploy Gate run, or a pending context that survives two sweeps, as a rollback trigger. Revert this commit and rerun the affected gate while the workflow is corrected.

Fixes #6508

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6-000000)
