### PR TITLE
fix(sources): require explicit provider retirement

### DIFF
--- a/scripts/source-attribution.mjs
+++ b/scripts/source-attribution.mjs
@@ -34,6 +34,7 @@ const DOCS_PATH = 'docs/source-attribution.mdx';
 const BEGIN_MARKER = '{/* BEGIN GENERATED SOURCE ATTRIBUTION */}';
 const END_MARKER = '{/* END GENERATED SOURCE ATTRIBUTION */}';
 const MANIFEST_STATUSES = new Set(['terms-review', 'reviewed', 'excluded']);
+const CREDIT_BEARING_STATUSES = new Set(['terms-review', 'reviewed']);
 const ERROR_PRINT_LIMIT = 20;
 const REGENERATE_HINT = 'run node scripts/source-attribution.mjs --write';
 const REFERENCE_DISPLAY_LIMIT = 4;
@@ -737,10 +738,29 @@ export function loadManifest(rootDir = ROOT) {
   };
 }
 
-export function buildManifest(inventory, previous = { entries: [], logicalEntries: [] }) {
+function retirementRequiredMessage(host) {
+  return `${host} left the scan; confirm removal with --retire ${host} or restore a discoverable reference`;
+}
+
+export function buildManifest(
+  inventory,
+  previous = { entries: [], logicalEntries: [] },
+  { retireHosts = [] } = {},
+) {
   const previousByHost = new Map((previous.entries || []).map((entry) => [entry.host, entry]));
   const entries = inventory.map((observed) => mergeEntry(observed, previousByHost.get(observed.host)));
   const observedHosts = new Set(inventory.map((entry) => entry.host));
+  const retireHostSet = new Set(retireHosts);
+  for (const host of retireHostSet) {
+    const previousEntry = previousByHost.get(host);
+    if (!previousEntry) throw new Error(`source-attribution: cannot retire unknown host ${host}`);
+    if (observedHosts.has(host)) {
+      throw new Error(`source-attribution: cannot retire ${host} because the scanner still finds it`);
+    }
+    if (previousEntry.observed === false) {
+      throw new Error(`source-attribution: cannot retire ${host} because it is already retired`);
+    }
+  }
   // Retain retired rows as explicit exclusions rather than silently deleting a
   // credit. This makes removals reviewable and keeps historical attribution
   // visible while ensuring only currently observed hosts count as active.
@@ -754,6 +774,16 @@ export function buildManifest(inventory, previous = { entries: [], logicalEntrie
     // source path that does not contain it. The docs cell falls back to
     // "No current fetch observed", which is what is actually true.
     const { references, ...retained } = oldEntry;
+    if (retained.observed !== false && !MANIFEST_STATUSES.has(retained.status)) {
+      throw new Error(`source-attribution: cannot retire ${retained.host} because its manifest status is invalid`);
+    }
+    if (
+      retained.observed !== false
+      && CREDIT_BEARING_STATUSES.has(retained.status)
+      && !retireHostSet.has(retained.host)
+    ) {
+      throw new Error(`source-attribution: ${retirementRequiredMessage(retained.host)}`);
+    }
     entries.push(retained.observed === false
       ? retained
       : {
@@ -842,7 +872,7 @@ export function validateManifest(inventory, manifest) {
       // the provider really was removed, or the scanner simply lost sight of a
       // URL that moved somewhere lexical discovery cannot see. Say both, because
       // regenerating on the second retires a provider the code still fetches.
-      errors.push(`manifest marks ${entry.host} observed but scanner found no current reference — if the provider was removed, ${REGENERATE_HINT} to retire the row; if its URL moved out of the scanned tree, restore a discoverable reference or add it to DYNAMIC_HOSTS instead`);
+      errors.push(`manifest marks ${entry.host} observed but scanner found no current reference — ${retirementRequiredMessage(entry.host)} or add it to DYNAMIC_HOSTS`);
     }
   }
   for (const entry of manifest.logicalEntries || []) {
@@ -945,8 +975,8 @@ export function buildSourceAttributionStats({ rootDir = ROOT } = {}) {
   return sourceAttributionStats(inventory, manifest);
 }
 
-function printStats(stats) {
-  console.log(`source-attribution: ${stats.activeHosts} active hosts (${stats.structuredHosts} structured/API, ${stats.feedHosts} feed, ${stats.operationalStatusHosts} operational-status; ${stats.reviewNeeded} terms-review)`);
+function printStats(stats, log = console.log) {
+  log(`source-attribution: ${stats.activeHosts} active hosts (${stats.structuredHosts} structured/API, ${stats.feedHosts} feed, ${stats.operationalStatusHosts} operational-status; ${stats.reviewNeeded} terms-review)`);
 }
 
 function serializeManifest(manifest) {
@@ -988,47 +1018,82 @@ export function checkSourceAttribution(rootDir = ROOT) {
   return { errors: [], stats: sourceAttributionStats(inventory, previous) };
 }
 
-function main() {
-  if (process.argv.includes('--write')) {
-    const inventory = scanUpstreamHosts(ROOT);
-    const previous = loadManifest(ROOT);
-    const manifest = buildManifest(inventory, previous);
-    // Render and count before writing anything. Both throw on a manifest row
-    // that no longer validates, and a row retired by an earlier run is now kept
-    // rather than dropped — so writing first would leave the manifest rewritten,
-    // the docs stale, and every rerun repeating it.
-    const section = renderAttributionSection(inventory, manifest);
-    const stats = sourceAttributionStats(inventory, manifest);
-    const serialized = serializeManifest(manifest);
-    writeFileSync(join(ROOT, MANIFEST_PATH), serialized);
-    // The mirror is what `scripts/`-rooted Railway services read. Writing it
-    // here keeps a manual `cp` from being the only thing holding them equal.
-    writeFileSync(join(ROOT, MIRROR_PATH), serialized);
-    updateDocs(ROOT, section);
-    const retired = manifest.entries.filter((entry) => entry.observed === false).map((entry) => entry.host);
-    const newlyRetired = retired.filter(
-      (host) => (previous.entries || []).some((entry) => entry.host === host && entry.observed !== false),
-    );
-    if (newlyRetired.length) {
-      // Retiring drops a provider from the published count and from license
-      // review. That must never happen quietly just because someone regenerated.
-      console.warn(`source-attribution: retired ${newlyRetired.length} host(s) no longer found by the scanner: ${newlyRetired.join(', ')}`);
-      console.warn('source-attribution: confirm each was removed deliberately — a URL that moved out of the scanned tree looks identical here.');
+function parseRetireHosts(args) {
+  const retireHosts = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] !== '--retire') continue;
+    const host = args[index + 1];
+    if (!host || host.startsWith('--')) {
+      throw new Error('source-attribution: --retire requires a host');
     }
-    printStats(stats);
-    return;
+    retireHosts.push(host);
+    index += 1;
   }
-  const { errors, stats } = checkSourceAttribution(ROOT);
-  if (errors.length) {
-    console.error(`source-attribution: ${errors.length} manifest error(s)`);
-    // A single stale scan can fault every row, so cap the listing: an unbounded
-    // dump buries the first (and usually only) cause the reader needs.
-    for (const error of errors.slice(0, ERROR_PRINT_LIMIT)) console.error(`- ${error}`);
-    if (errors.length > ERROR_PRINT_LIMIT) console.error(`- ...and ${errors.length - ERROR_PRINT_LIMIT} more`);
-    process.exitCode = 1;
-    return;
-  }
-  printStats(stats);
+  return [...new Set(retireHosts)];
 }
 
-if (process.argv[1] && process.argv[1].endsWith('scripts/source-attribution.mjs')) main();
+export function runSourceAttribution({
+  rootDir = ROOT,
+  args = [],
+  log = console.log,
+  warn = console.warn,
+  reportError = console.error,
+} = {}) {
+  let retireHosts;
+  try {
+    retireHosts = parseRetireHosts(args);
+  } catch (error) {
+    reportError(error.message);
+    return 1;
+  }
+  if (retireHosts.length && !args.includes('--write')) {
+    reportError('source-attribution: --retire requires --write');
+    return 1;
+  }
+  if (args.includes('--write')) {
+    try {
+      const inventory = scanUpstreamHosts(rootDir);
+      const previous = loadManifest(rootDir);
+      const manifest = buildManifest(inventory, previous, { retireHosts });
+      // Render and count before writing anything. Both throw on a manifest row
+      // that no longer validates, and a row retired by an earlier run is now kept
+      // rather than dropped — so writing first would leave the manifest rewritten,
+      // the docs stale, and every rerun repeating it.
+      const section = renderAttributionSection(inventory, manifest);
+      const stats = sourceAttributionStats(inventory, manifest);
+      const serialized = serializeManifest(manifest);
+      writeFileSync(join(rootDir, MANIFEST_PATH), serialized);
+      // The mirror is what `scripts/`-rooted Railway services read. Writing it
+      // here keeps a manual `cp` from being the only thing holding them equal.
+      writeFileSync(join(rootDir, MIRROR_PATH), serialized);
+      updateDocs(rootDir, section);
+      const retired = manifest.entries.filter((entry) => entry.observed === false).map((entry) => entry.host);
+      const newlyRetired = retired.filter(
+        (host) => (previous.entries || []).some((entry) => entry.host === host && entry.observed !== false),
+      );
+      if (newlyRetired.length) {
+        warn(`source-attribution: retired ${newlyRetired.length} host(s): ${newlyRetired.join(', ')}`);
+      }
+      printStats(stats, log);
+    } catch (error) {
+      reportError(error.message);
+      return 1;
+    }
+    return 0;
+  }
+  const { errors, stats } = checkSourceAttribution(rootDir);
+  if (errors.length) {
+    reportError(`source-attribution: ${errors.length} manifest error(s)`);
+    // A single stale scan can fault every row, so cap the listing: an unbounded
+    // dump buries the first (and usually only) cause the reader needs.
+    for (const error of errors.slice(0, ERROR_PRINT_LIMIT)) reportError(`- ${error}`);
+    if (errors.length > ERROR_PRINT_LIMIT) reportError(`- ...and ${errors.length - ERROR_PRINT_LIMIT} more`);
+    return 1;
+  }
+  printStats(stats, log);
+  return 0;
+}
+
+if (process.argv[1] && process.argv[1].endsWith('scripts/source-attribution.mjs')) {
+  process.exitCode = runSourceAttribution({ args: process.argv.slice(2) });
+}

--- a/tests/source-attribution.test.mjs
+++ b/tests/source-attribution.test.mjs
@@ -8,6 +8,7 @@ import {
   loadManifest,
   matchGeneratedAttributionSection,
   renderAttributionSection,
+  runSourceAttribution,
   scanUpstreamHosts,
   sourceAttributionStats,
   validateManifest,
@@ -35,13 +36,14 @@ function makeFixtureCheckout() {
   const manifest = buildManifest(inventory, { entries: [], logicalEntries: [] });
   const manifestPath = join(dir, 'shared/source-attribution-manifest.json');
   const mirrorPath = join(dir, 'scripts/shared/source-attribution-manifest.json');
+  const docsPath = join(dir, 'docs/source-attribution.mdx');
   const writeManifest = (value) => {
     const serialized = `${JSON.stringify(value, null, 2)}\n`;
     writeFileSync(manifestPath, serialized);
     writeFileSync(mirrorPath, serialized);
   };
   const writeDocs = (value) => writeFileSync(
-    join(dir, 'docs/source-attribution.mdx'),
+    docsPath,
     `---\ntitle: "Source Attribution"\n---\n\n${renderAttributionSection(inventory, value)}\n`,
   );
   writeManifest(manifest);
@@ -51,9 +53,18 @@ function makeFixtureCheckout() {
     manifest,
     manifestPath,
     mirrorPath,
+    docsPath,
     writeManifest,
     writeDocs,
     cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+function readFixtureArtifacts(fixture) {
+  return {
+    manifest: readFileSync(fixture.manifestPath, 'utf8'),
+    mirror: readFileSync(fixture.mirrorPath, 'utf8'),
+    docs: readFileSync(fixture.docsPath, 'utf8'),
   };
 }
 
@@ -278,6 +289,177 @@ test('a retired row survives regeneration instead of being deleted', () => {
   );
   // Retention only makes --write a fixpoint if it is stable across runs.
   assert.deepEqual(buildManifest([], rebuilt), rebuilt);
+  assert.throws(
+    () => buildManifest([], rebuilt, { retireHosts: ['gone.example'] }),
+    /cannot retire gone\.example because it is already retired/,
+  );
+});
+
+test('credit-bearing hosts cannot leave the inventory without explicit retirement', () => {
+  for (const status of ['terms-review', 'reviewed']) {
+    const previous = {
+      entries: [{
+        host: `${status}.example`,
+        provider: status,
+        license: 'Provider terms',
+        attribution: `Credit ${status}.`,
+        observed: true,
+        kind: 'structured',
+        status,
+        references: [{ path: 'scripts/seed-provider.mjs' }],
+      }],
+      logicalEntries: [],
+    };
+
+    assert.throws(
+      () => buildManifest([], previous),
+      new RegExp(`${status}\\.example left the scan; confirm removal with --retire ${status}\\.example`),
+    );
+    assert.equal(previous.entries[0].observed, true, 'a refused retirement must not mutate the previous manifest');
+  }
+});
+
+test('an explicit retirement drops a credit-bearing host from the active inventory', () => {
+  const previous = {
+    entries: [{
+      host: 'gone.example',
+      provider: 'Gone',
+      license: 'Provider terms',
+      attribution: 'Credit Gone.',
+      observed: true,
+      kind: 'feed',
+      status: 'terms-review',
+      references: [{ path: 'src/config/feeds.ts' }],
+    }],
+    logicalEntries: [],
+  };
+
+  const rebuilt = buildManifest([], previous, { retireHosts: ['gone.example'] });
+  const retired = rebuilt.entries.find((entry) => entry.host === 'gone.example');
+  assert.equal(retired.observed, false);
+  assert.equal(retired.status, 'excluded');
+  assert.equal(retired.references, undefined);
+  assert.equal(retired.attribution, 'Credit Gone.', 'explicit retirement must preserve required credit');
+});
+
+test('an invalid manifest status cannot be laundered into retirement', () => {
+  const previous = {
+    entries: [{
+      host: 'invalid-status.example',
+      provider: 'Invalid Status',
+      license: 'Provider terms',
+      attribution: 'Credit Invalid Status.',
+      observed: true,
+      kind: 'structured',
+      status: 'review',
+      references: [{ path: 'scripts/seed-provider.mjs' }],
+    }],
+    logicalEntries: [],
+  };
+
+  assert.throws(
+    () => buildManifest([], previous),
+    /cannot retire invalid-status\.example because its manifest status is invalid/,
+  );
+  assert.throws(
+    () => buildManifest([], previous, { retireHosts: ['invalid-status.example'] }),
+    /cannot retire invalid-status\.example because its manifest status is invalid/,
+    'explicit retirement must not normalize malformed compliance state',
+  );
+  assert.equal(previous.entries[0].observed, true);
+  assert.equal(previous.entries[0].status, 'review');
+});
+
+test('an explicit retirement host must name a current manifest row that left the scan', () => {
+  const previous = {
+    entries: [{
+      host: 'current.example',
+      provider: 'Current',
+      license: 'Provider terms',
+      attribution: 'Credit Current.',
+      observed: true,
+      kind: 'structured',
+      status: 'terms-review',
+      references: [{ path: 'server/current.ts' }],
+    }],
+    logicalEntries: [],
+  };
+  const inventory = [{
+    host: 'current.example',
+    kinds: ['structured'],
+    references: [{ path: 'server/current.ts' }],
+  }];
+
+  assert.throws(
+    () => buildManifest(inventory, previous, { retireHosts: ['current.example'] }),
+    /cannot retire current\.example because the scanner still finds it/,
+  );
+  assert.throws(
+    () => buildManifest([], previous, { retireHosts: ['typo.example'] }),
+    /cannot retire unknown host typo\.example/,
+  );
+});
+
+test('the CLI refuses malformed, unpaired, or still-observed retirement requests without writing', () => {
+  const fixture = makeFixtureCheckout();
+  try {
+    const before = readFixtureArtifacts(fixture);
+    for (const [label, args, expected] of [
+      ['missing value at end', ['--write', '--retire'], /--retire requires a host/],
+      ['another flag used as the value', ['--retire', '--write'], /--retire requires a host/],
+      ['missing --write', ['--retire', 'fixture.example'], /--retire requires --write/],
+      ['still observed', ['--write', '--retire', 'fixture.example'], /cannot retire fixture\.example because the scanner still finds it/],
+    ]) {
+      const errors = [];
+      const exitCode = runSourceAttribution({
+        rootDir: fixture.dir,
+        args,
+        log: () => {},
+        warn: () => {},
+        reportError: (message) => errors.push(message),
+      });
+      assert.equal(exitCode, 1, `${label} must fail`);
+      assert.ok(errors.some((error) => expected.test(error)), `${label} reported ${JSON.stringify(errors)}`);
+      assert.deepEqual(readFixtureArtifacts(fixture), before, `${label} must not rewrite attribution artifacts`);
+    }
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test('the CLI explicitly retires a missing fixture host and updates every artifact', () => {
+  const fixture = makeFixtureCheckout();
+  try {
+    writeFileSync(join(fixture.dir, 'scripts/seed-fixture.mjs'), 'export const removed = true;\n');
+    const before = readFixtureArtifacts(fixture);
+    const errors = [];
+    const warnings = [];
+    const exitCode = runSourceAttribution({
+      rootDir: fixture.dir,
+      args: ['--write', '--retire', 'fixture.example'],
+      log: () => {},
+      warn: (message) => warnings.push(message),
+      reportError: (message) => errors.push(message),
+    });
+
+    assert.equal(exitCode, 0, JSON.stringify(errors));
+    assert.deepEqual(errors, []);
+    assert.ok(warnings.some((warning) => /retired 1 host\(s\): fixture\.example/.test(warning)));
+
+    const after = readFixtureArtifacts(fixture);
+    assert.notEqual(after.manifest, before.manifest);
+    assert.equal(after.mirror, after.manifest, 'the scripts/shared mirror must match the retired manifest');
+    assert.notEqual(after.docs, before.docs);
+    const retired = JSON.parse(after.manifest).entries.find((entry) => entry.host === 'fixture.example');
+    assert.equal(retired.observed, false);
+    assert.equal(retired.status, 'excluded');
+    assert.equal(retired.references, undefined);
+    assert.match(retired.attribution, /Credit fixture\.example/);
+    assert.match(after.docs, /fixture\.example\) \| Excluded \/ candidate — No current fetch observed/);
+    assert.deepEqual(checkSourceAttribution(fixture.dir).errors, [], 'the explicit retirement must leave a clean fixpoint');
+  } finally {
+    fixture.cleanup();
+  }
 });
 
 test('a retired host that comes back is counted again instead of staying excluded', () => {
@@ -369,7 +551,7 @@ test('a retired row stops claiming a source path it is no longer found in', () =
       references: [{ path: 'src/config/feeds.ts' }],
     }],
     logicalEntries: [],
-  });
+  }, { retireHosts: ['gone.example'] });
   const retired = rebuilt.entries.find((entry) => entry.host === 'gone.example');
   assert.equal(retired.observed, false);
   assert.equal(retired.references, undefined, 'a host the scanner cannot find must not publish a source path');
@@ -443,7 +625,11 @@ test('a reviewed host loses its verdict across a retire and revive round trip', 
     status: 'reviewed',
     references: [{ path: 'scripts/seed-roundtrip.mjs' }],
   };
-  const retired = buildManifest([], { entries: [reviewed], logicalEntries: [] });
+  const retired = buildManifest(
+    [],
+    { entries: [reviewed], logicalEntries: [] },
+    { retireHosts: ['roundtrip.example'] },
+  );
   const revived = buildManifest(
     [{ host: 'roundtrip.example', kinds: ['structured'], references: [{ path: 'scripts/seed-roundtrip.mjs' }] }],
     retired,


### PR DESCRIPTION
## Summary

Source attribution generation now stops before a credit-bearing provider can disappear because lexical scanning no longer sees it. Maintainers must either restore a discoverable reference or use `--write --retire <host>` to confirm the removal; an explicit retirement preserves the provider credit and updates the manifest, Railway mirror, and docs together. Malformed status, unknown host, current host, repeated retirement, and incomplete CLI requests all fail before any artifact is written.

The end-to-end tests use a disposable checkout. They prove that refused requests leave all three artifacts byte-identical and that an accepted retirement produces a clean generator fixpoint.

Fixes #6500.

## Validation

- `node --test tests/source-attribution.test.mjs` - 30 passed
- `npm run sources:check`
- `npm run sources:generate` - no generated drift
- `npm run typecheck`
- `npm run lint` - passed; existing warnings are outside the changed files
- Repository pre-push gate - passed, including frontend/API type checks and the focused test file

## Post-Deploy Monitoring & Validation

This is a repository maintenance command and does not change the deployed application runtime.

- Owner: source-attribution maintainer
- Validation window: the first source removal and `sources:generate` run after merge
- Healthy signal: an unconfirmed missing credit-bearing host exits nonzero before writes; an explicit retirement updates all artifacts and the next `sources:check` passes
- Failure signal: a provider credit disappears without `--retire`, rejected commands dirty tracked artifacts, or the follow-up check reports drift
- Logs/search: `source-attribution:` messages, especially `left the scan`, `cannot retire`, and `retired 1 host(s)`
- Rollback: revert this commit and restore the removed discoverable reference; no data migration or runtime rollback is required

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
