### PR TITLE
fix(docs): repair the Mintlify deploy break and the lint that missed it

### DIFF
--- a/docs/methodology/education-flag-flip-runbook.md
+++ b/docs/methodology/education-flag-flip-runbook.md
@@ -318,8 +318,8 @@ so baseline and proposed see byte-identical inputs).
 | Gate | Threshold | Measured (pillar-combined) |
 |---|---|---|
 | `gate-1-spearman` | >= 0.85 | 1.00 |
-| `gate-2-country-drift` | <= 15 | 3.45 (VU) |
-| `gate-6-cohort-median` | <= 10 | −1.08 (fragile-states) |
+| `gate-2-country-drift` | &lt;= 15 | 3.45 (VU) |
+| `gate-6-cohort-median` | &lt;= 10 | −1.08 (fragile-states) |
 | `gate-7-matched-pair` | all hold | 9/9 hold after audited `in-vs-za` rebaseline; gap 1.77, min 1 |
 | `gate-9-effective-influence` | >= 80% Core | 92.16% (47/51) |
 

--- a/docs/methodology/financial-system-exposure.md
+++ b/docs/methodology/financial-system-exposure.md
@@ -60,7 +60,7 @@ The original construct dropped the slot for them. That was the single largest co
 | Country state | Component 1 slot |
 |---|---|
 | DRS row present; market-access proxy does not fire | `normalizeLowerBetter(value, 0, 15)`, full 0.35 weight, coverage 1.0 |
-| DRS row present; debt ≤1% GNI, BIS claims <5% GDP, and zero reporting parents | same observed score at 30% certainty: runtime weight 0.105, nominal weight 0.35, `certaintyCoverage 0.3` |
+| DRS row present; debt ≤1% GNI, BIS claims &lt;5% GDP, and zero reporting parents | same observed score at 30% certainty: runtime weight 0.105, nominal weight 0.35, `certaintyCoverage 0.3` |
 | No DRS row, `lendingType=LNX`, **and** present in BIS CBS | imputed score **75**, `certaintyCoverage 0.3`, `imputed: true`, `imputationClass: 'not-applicable'` |
 | Borrower missing its DRS row | slot drops out of the blend (possible partial payload) |
 | Absent from both DRS and BIS CBS | slot drops out of the blend (genuine data gap) |

--- a/docs/research/reports/strait-of-hormuz-transit-report-2026-07/distribution-brief.md
+++ b/docs/research/reports/strait-of-hormuz-transit-report-2026-07/distribution-brief.md
@@ -5,7 +5,7 @@ authentic, manual outreach. Any message requires separate explicit approval
 from the repository owner before sending (per #5668 guardrails), and nothing
 here may be automated. No dofollow placements, paid links, or link exchanges.
 
-Report: <https://www.worldmonitor.app/research/strait-of-hormuz-transit-report-2026-07/>
+Report: https://www.worldmonitor.app/research/strait-of-hormuz-transit-report-2026-07/
 Angle: original, recomputable numbers on the five-month transit collapse —
 1,400 transits since March 1 versus 14,547 in the same 2025 window, from IMF
 PortWatch data, with the AIS-undercount caveat stated up front and the full

--- a/tests/mdx-lint.test.mjs
+++ b/tests/mdx-lint.test.mjs
@@ -4,14 +4,17 @@
  * Mintlify parses all .md and .mdx files as MDX, which means:
  * 1. `<foo` is interpreted as a JSX tag (bare angle brackets)
  * 2. `{expr}` is interpreted as a JSX expression (bare curly braces)
+ * 3. `<https://example.com>` autolinks are not valid MDX
  *
- * Both cause deploy failures when used outside fenced code blocks or
+ * All cause deploy failures when used outside fenced code blocks or
  * inline code spans. Fix: use `&lt;` / `&#123;` or wrap in backticks.
  *
+ * Mintlify parses every non-ignored file on disk, not just the pages
+ * reachable from docs.json navigation, so this walks the whole tree.
  * Files listed in docs/.mintignore are excluded from these checks.
  */
-import { readFileSync, readdirSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, readdirSync, existsSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { fileURLToPath } from 'node:url';
@@ -27,64 +30,59 @@ const ignored = existsSync(mintignorePath)
       .filter(l => l && !l.startsWith('#'))
   : [];
 
-function isIgnored(filename) {
+function isIgnored(relPath) {
+  const posix = relPath.split(sep).join('/');
   return ignored.some(pattern => {
-    if (pattern.endsWith('/')) return filename.startsWith(pattern);
-    return filename === pattern;
+    if (pattern.endsWith('/')) {
+      const dir = pattern.slice(0, -1);
+      return posix === dir || posix.startsWith(pattern);
+    }
+    return posix === pattern;
   });
 }
 
-function collectNavigationPages(node, pages = new Set()) {
-  if (Array.isArray(node)) {
-    for (const item of node) collectNavigationPages(item, pages);
-    return pages;
+/**
+ * Mintlify parses every .md/.mdx file it finds under docs/, not only the
+ * pages wired into docs.json. Anything unreachable from navigation still
+ * fails the build the moment its path is in a deployment's changed set.
+ */
+function collectDocFiles(dir, found = []) {
+  for (const entry of readdirSync(dir).sort()) {
+    const abs = join(dir, entry);
+    if (isIgnored(relative(DOCS_DIR, abs))) continue;
+    if (statSync(abs).isDirectory()) collectDocFiles(abs, found);
+    else if (entry.endsWith('.mdx') || entry.endsWith('.md')) found.push(abs);
   }
-
-  if (!node || typeof node !== 'object') return pages;
-
-  if (Array.isArray(node.pages)) {
-    for (const page of node.pages) {
-      if (typeof page === 'string') pages.add(page);
-      else collectNavigationPages(page, pages);
-    }
-  }
-
-  for (const value of Object.values(node)) {
-    if (value !== node.pages) collectNavigationPages(value, pages);
-  }
-
-  return pages;
+  return found;
 }
 
-function resolveNavigationPage(page) {
-  for (const ext of ['.mdx', '.md']) {
-    const candidate = `${page}${ext}`;
-    if (!isIgnored(candidate) && existsSync(join(DOCS_DIR, candidate))) {
-      return join(DOCS_DIR, candidate);
-    }
+const docFiles = collectDocFiles(DOCS_DIR);
+
+/** Length of the leading YAML frontmatter block, in lines (0 when absent). */
+function frontmatterLength(lines) {
+  if (lines[0]?.trim() !== '---') return 0;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') return i + 1;
   }
-  return null;
+  return 0;
 }
 
-const topLevelDocFiles = readdirSync(DOCS_DIR)
-  .filter(f => (f.endsWith('.mdx') || f.endsWith('.md')) && !isIgnored(f))
-  .map(f => join(DOCS_DIR, f));
-
-const docsConfig = JSON.parse(readFileSync(join(DOCS_DIR, 'docs.json'), 'utf8'));
-const navigationDocFiles = [...collectNavigationPages(docsConfig)]
-  .map(resolveNavigationPage)
-  .filter(Boolean);
-
-const docFiles = [...new Set([...topLevelDocFiles, ...navigationDocFiles])];
-
-/** Strip fenced code blocks and inline code spans from content. */
+/** Strip frontmatter, fenced code blocks and inline code spans from content. */
 function stripCode(content) {
   const lines = content.split('\n');
   let inFence = false;
   const result = [];
+  // Frontmatter is YAML, not MDX — Mintlify never parses it as content.
+  const bodyStart = frontmatterLength(lines);
 
-  for (const line of lines) {
-    if (/^```/.test(line)) {
+  for (let i = 0; i < lines.length; i++) {
+    if (i < bodyStart) {
+      result.push('');
+      continue;
+    }
+    const line = lines[i];
+    // Fences inside list items are indented, so anchor on leading whitespace.
+    if (/^\s*```/.test(line)) {
       inFence = !inFence;
       result.push('');
       continue;
@@ -103,7 +101,7 @@ function stripCode(content) {
 function findBareAngleBrackets(lines) {
   const issues = [];
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].match(/<[=\d-]|\b[A-Za-z_$][\w$.-]*<(?!\/)[^>\n]+>/);
+    const match = lines[i].match(/<[=\d-]|<https?:|\b[A-Za-z_$][\w$.-]*<(?!\/)[^>\n]+>/);
     if (match) {
       issues.push({ line: i + 1, text: lines[i].trim(), type: 'angle bracket' });
     }
@@ -125,10 +123,67 @@ function findBareCurlyBraces(lines) {
   return issues;
 }
 
+describe('MDX lint covers the whole published tree', () => {
+  it('walks nested directories, not just top-level and navigation pages', () => {
+    const names = docFiles.map(f => relative(DOCS_DIR, f).split(sep).join('/'));
+    // A silently-empty walk would make every check below pass vacuously.
+    assert.ok(names.length > 300, `expected the docs tree, got ${names.length} files`);
+    assert.ok(
+      names.some(n => n.includes('/')),
+      'walk found no nested files — it is only reading the top level'
+    );
+    // Regression anchor: this page is nested and absent from docs.json
+    // navigation, so the old top-level+navigation corpus never saw it and
+    // its `<5% GDP` reached Mintlify (deploy failure, 2026-08-12).
+    assert.ok(
+      names.includes('methodology/financial-system-exposure.md'),
+      'nested non-navigation pages are missing from the corpus'
+    );
+  });
+
+  it('flags the syntax classes that have broken real deploys', () => {
+    const cases = [
+      'BIS claims <5% GDP',
+      '| `gate-2-country-drift` | <= 15 |',
+      'Report: <https://www.worldmonitor.app/research/>',
+    ];
+    for (const line of cases) {
+      assert.equal(
+        findBareAngleBrackets(stripCode(line)).length,
+        1,
+        `detector missed a known Mintlify parse failure: ${line}`
+      );
+    }
+    assert.equal(
+      findBareCurlyBraces(stripCode('GET returns {purged:true} for the caller')).length,
+      1,
+      'detector missed a bare JSX expression'
+    );
+  });
+
+  it('does not flag the escaped and fenced forms docs actually use', () => {
+    const clean = [
+      'BIS claims &lt;5% GDP',
+      'the anchor sits at < 20 points',
+      '`elapsed < intervalMs * 0.8`',
+      '---\napplies_when: "returns {purged:true} but GET is stale"\n---\nbody',
+      'Steps:\n\n  ```bash\n  NAME=resilience-${CAPTURE_DATE}.json\n  ```\n',
+    ];
+    for (const sample of clean) {
+      const lines = stripCode(sample);
+      assert.deepEqual(
+        [...findBareAngleBrackets(lines), ...findBareCurlyBraces(lines)],
+        [],
+        `false positive on valid MDX: ${JSON.stringify(sample)}`
+      );
+    }
+  });
+});
+
 describe('MDX files have no bare angle brackets', () => {
   for (const file of docFiles) {
-    const name = file.split('/').pop();
-    it(`${name} has no bare <equals, <digit, or <hyphen outside code`, () => {
+    const name = relative(DOCS_DIR, file).split(sep).join('/');
+    it(`${name} has no bare <equals, <digit, <hyphen, or autolink outside code`, () => {
       const content = readFileSync(file, 'utf8');
       const lines = stripCode(content);
       const issues = findBareAngleBrackets(lines);
@@ -144,7 +199,7 @@ describe('MDX files have no bare angle brackets', () => {
 
 describe('MDX files have no bare curly braces', () => {
   for (const file of docFiles) {
-    const name = file.split('/').pop();
+    const name = relative(DOCS_DIR, file).split(sep).join('/');
     it(`${name} has no bare {expression} outside code`, () => {
       const content = readFileSync(file, 'utf8');
       const lines = stripCode(content);


### PR DESCRIPTION
## Summary

The Mintlify deployment failed on `methodology/financial-system-exposure.md`: MDX v3 reads `<5% GDP` in a table cell as the start of a JSX tag, and `5` cannot start a tag name. That page builds again, and two more pages carrying the same class of break are fixed before they could fail deploys of their own.

The more useful half is why this reached production at all. `tests/mdx-lint.test.mjs` was already looking for exactly this pattern and still let it through — its corpus was top-level `docs/*.md{,x}` plus the pages reachable from `docs.json` navigation. The failing page is nested *and* absent from navigation, so nothing ever linted it. Mintlify parses every non-ignored file on disk, so navigation membership was never the right filter. The lint now walks the whole tree, 360 files instead of ~200, and that widening is what surfaced the other two breaks.

## What MDX v3 actually rejects

Verified by compiling each form with `@mdx-js/mdx@3`, which reproduces Mintlify's message, line and column exactly.

| Form | Verdict | Where |
|---|---|---|
| `<5%`, `<= 15` | Rejected — a digit or `=` cannot start a JSX name | `financial-system-exposure.md`, `education-flag-flip-runbook.md` |
| `<https://…>` | Rejected — CommonMark autolink, but MDX reads `https` as a tag name and `:` as a namespace | `distribution-brief.md` |
| `< 20` | **Accepted** — whitespace cannot start a name, so it stays literal text | left untouched throughout |

That last row is why this PR does not escape every `<` in the diff's neighbourhood. The repo escapes `< 20` by convention, but it is not a build breaker and churning it would hide the three that are.

## Why widening the corpus was not a one-line change

Two bugs in the lint's own `stripCode` were invisible at the old corpus size and produced five false positives the moment it grew: fenced blocks were anchored `/^```/`, so fences indented inside list items never toggled and leaked their contents, and YAML frontmatter was never stripped, so `applies_when: "... {purged:true} ..."` read as a JSX expression. Both are fixed, and the detector now also catches the autolink form the old pattern missed.

Three meta-tests keep the gate honest: the corpus must exceed 300 files, contain nested paths, and contain the page that leaked; the detectors must fire on all four known-bad forms; and they must stay quiet on the escaped and fenced forms the docs actually use. Without them a future walker bug would turn all 720 file checks green and silent.

## Validation

- Reproduced the original failure locally before fixing: same message, same `63:46` position Mintlify reported.
- Compiled all 356 published pages with a real MDX parser — 0 failures.
- Mutation-tested the gate: restoring `<5%` fails it at line 63; restored from a file copy afterwards.
- 733/733 pass across `mdx-lint`, `repo-hygiene` and `public-doc-plan-references`. `biome` and `markdownlint-cli2` clean on all four changed files.

The MDX parser used for ground truth is a scratchpad harness, not a new dependency — CI keeps the existing zero-dependency heuristic.

Related: #6515

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
