### PR TITLE
fix(railway): keep protected recovery reachable

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -127,11 +127,12 @@ the live audit.
 
 The reconciliation controller is a dedicated Cloudflare Worker backed by one
 SQLite Durable Object. Its foundation can be deployed while the existing
-Railway trigger remains unchanged: keep both
+Railway integration remains unchanged. Keep both
 `RAILWAY_RECONCILE_CUTOVER_ACTIVE` and
 `RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED` set to `false` until the lease-aware
-target workflow has landed and the legacy trigger has been disabled and
-drained.
+target workflow, protected environments, role credentials, and authenticated
+status probe are ready. Activate the flags separately with the staged cutover
+below.
 
 Provision these GitHub Actions environments with a `main`-only deployment
 branch policy:
@@ -196,6 +197,35 @@ Worker and the one matching consumer environment together and repeat both the
 version and authenticated status probes. Never rotate across an active lease,
 hold, or barrier: the old run would lose its only authorization path and the
 result would require protected operator recovery.
+
+#### Staged cutover
+
+Do not enable both activation flags in one operation.
+
+1. Confirm the current `main` head has an exact green `gate`, no target mutation
+   or verifier run is active, and authenticated controller status has no lease,
+   barrier, attempt, or dispatch hold. Confirm every protected environment has
+   only the role credentials its jobs read.
+2. Set `RAILWAY_RECONCILE_CUTOVER_ACTIVE=true` while keeping
+   `RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED=false`. This enables the ordinary
+   lease-fenced mutation and verifier cycle plus protected manual retry, but it
+   cannot authorize a watchdog dispatch. Run one exact-green-head cycle and
+   require terminal acceptance to populate `lastAccepted`. Unset the cutover
+   flag to roll back admission of new mutation jobs.
+3. Enable `RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED` only after `lastAccepted`
+   has been observed fresh, watchdog read failures fail the job after their
+   bounded streak, and a baseline exists for green deferrals caused by a live
+   paginated GitHub inventory. Run the watchdog in `dispatch` mode and require
+   `HEALTHY` with no dispatch. Unset this flag first to roll back automatic
+   recovery authority.
+
+The native Railway source integration is not the lease-aware mutation path. It
+can continue to accept ordinary builds: the reconcile trigger reads the live
+deployment inventory and treats an accepted or in-progress build for the exact
+commit as a no-op. The repository has no separate legacy GitHub workflow that
+deploys with `RAILWAY_PRODUCTION_TOKEN`; that token remains only in read paths.
+If either fact changes, disable and drain the new competing mutation path before
+the staged cutover.
 
 To print the authenticated raw controller state without dispatching anything,
 run the watchdog's `status` mode from `main`:
@@ -447,11 +477,18 @@ The reconciliation control plane deliberately separates two failures:
   Manual Recovery** workflow records an audited resolution. Lease expiry alone
   never clears this barrier.
 
-The watchdog is observe-only unless both `RAILWAY_RECONCILE_CUTOVER_ACTIVE` and
-`RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED` are exactly `true`. The first flag is
-the hard fence against dispatching the legacy target contract; the second is
-the operational recovery switch. `RECOVERY_AUTHORIZED` means the controller
-persisted a one-use dispatch hold but has not yet dispatched it;
+The watchdog cannot create a hold or dispatch a new recovery unless both
+`RAILWAY_RECONCILE_CUTOVER_ACTIVE` and
+`RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED` are exactly `true`. Classification is
+deliberately read-and-repair: if an earlier authorized watchdog or manual
+recovery dispatch left a `DISPATCH_HELD` record, an ordinary scheduled run may
+bind its exact accepted workflow run or close it after definitive pre-dispatch
+rejection. That repair is independent of both flags because it completes an
+authorization that already exists; it never creates a hold or sends a dispatch.
+The first flag enables the lease-aware mutation contract and protected manual
+retry, while the second authorizes new automatic recovery. `RECOVERY_AUTHORIZED`
+means the controller persisted a one-use dispatch hold but has not yet
+dispatched it;
 `RECOVERY_DISPATCHED` means GitHub accepted the request and the controller
 durably bound its exact workflow run and attempt. A green
 watchdog run means only that observation did not poison `main`; authoritative

--- a/scripts/dispatch-stale-railway-reconcile.mjs
+++ b/scripts/dispatch-stale-railway-reconcile.mjs
@@ -1464,6 +1464,10 @@ export async function readWatchdogSnapshot({ github, control, clock = Date.now }
   const hydratedRuns = await github.hydrateTargetRuns(relevantSummaries);
   const runInventory = mergeRunInventory(runSummaries, hydratedRuns);
 
+  // This loop repairs only an authorization that already exists. It never
+  // creates a hold or dispatches a run, so it stays active even when automatic
+  // recovery is disabled. Otherwise a successful GitHub dispatch followed by
+  // a failed bind step could leave the durable hold ambiguous forever.
   for (const hold of controlState.dispatchHolds ?? []) {
     if (hold?.state !== 'DISPATCH_HELD' || !hold.recoveryAttemptId) continue;
     const correlated = await github.findRunByRecoveryAttemptId(hold.recoveryAttemptId, runInventory);

--- a/scripts/railway-cli.mjs
+++ b/scripts/railway-cli.mjs
@@ -94,15 +94,16 @@ export const DEFAULT_CONCURRENCY = 8;
 
 export function runRailway(args, options = {}, spawnImpl = spawnSync) {
   const { env: sourceEnv = process.env, ...spawnOptions } = options;
+  const timeout = spawnOptions.timeout ?? RAILWAY_CALL_TIMEOUT_MS;
   const result = spawnImpl('railway', args, {
     encoding: 'utf8',
     maxBuffer: 10 * 1024 * 1024,
-    timeout: RAILWAY_CALL_TIMEOUT_MS,
+    timeout,
     ...spawnOptions,
     env: createRailwayCliEnv(sourceEnv),
   });
   if (result.signal) {
-    throw new Error(`railway ${args.join(' ')} timed out after ${RAILWAY_CALL_TIMEOUT_MS}ms`);
+    throw new Error(`railway ${args.join(' ')} timed out after ${timeout}ms`);
   }
   if (result.error) throw result.error;
   if (result.status !== 0) {
@@ -185,6 +186,7 @@ export function resolveEnvironmentId(environmentName, projectId = process.env.RA
 export async function readDeployments(service, environment, window, {
   env = process.env,
   execFileImpl = execFileAsync,
+  timeoutMs = RAILWAY_CALL_TIMEOUT_MS,
 } = {}) {
   const { stdout } = await execFileImpl('railway', [
     'deployment',
@@ -199,7 +201,7 @@ export async function readDeployments(service, environment, window, {
   ], {
     encoding: 'utf8',
     maxBuffer: 64 * 1024 * 1024,
-    timeout: RAILWAY_CALL_TIMEOUT_MS,
+    timeout: timeoutMs,
     env: createRailwayCliEnv(env),
   });
   return JSON.parse(stdout);
@@ -226,8 +228,11 @@ const FLEET_QUERY = `query FleetDeployments($input: DeploymentListInput!, $first
 }`;
 
 /** Run one GraphQL document through the Railway CLI and return `data`. */
-export function runRailwayApi(query, variables) {
-  const stdout = runRailway(['api', query, '--variables', JSON.stringify(variables), '--compact']);
+export function runRailwayApi(query, variables, { timeoutMs = RAILWAY_CALL_TIMEOUT_MS } = {}) {
+  const stdout = runRailway(
+    ['api', query, '--variables', JSON.stringify(variables), '--compact'],
+    { timeout: timeoutMs },
+  );
   // `railway api` can print advisory lines before the payload; the JSON document
   // is the first line that parses.
   for (const line of stdout.split('\n')) {
@@ -255,6 +260,8 @@ export async function readAllDeployments(service, environmentId, {
   pageSize = 500,
   maxPages = 200,
   api = runRailwayApi,
+  deadline = Number.POSITIVE_INFINITY,
+  now = () => performance.now(),
 } = {}) {
   if (!service?.id || !environmentId) {
     throw new Error('service id and environment id are required for complete deployment history');
@@ -263,10 +270,16 @@ export async function readAllDeployments(service, environmentId, {
   const seenCursors = new Set();
   let after = null;
   for (let page = 1; page <= maxPages; page += 1) {
+    const remainingMs = deadline - now();
+    if (!(remainingMs > 0)) {
+      throw new Error(`Railway provider proof deadline expired before page ${page} for ${service.name}`);
+    }
     const data = await api(FLEET_QUERY, {
       input: { serviceId: service.id, environmentId },
       first: pageSize,
       ...(after ? { after } : {}),
+    }, {
+      timeoutMs: Math.min(RAILWAY_CALL_TIMEOUT_MS, Math.max(1, Math.floor(remainingMs))),
     });
     const connection = data?.deployments;
     if (!Array.isArray(connection?.edges)

--- a/scripts/railway-cli.mjs
+++ b/scripts/railway-cli.mjs
@@ -242,6 +242,57 @@ export function runRailwayApi(query, variables) {
 }
 
 /**
+ * Read one service's complete deployment history with cursor pagination.
+ *
+ * Most callers need only a bounded recent window. Manual recovery is
+ * different: before it authorizes another mutation, it must prove that no
+ * older deployment is still in flight. The CLI caps a direct history read at
+ * 1,000 records, so a full first page is not exhaustion. This reader is used
+ * only for that uncommon fallback and returns only after Railway says there is
+ * no next page. A repeated cursor or the defensive page budget fails closed.
+ */
+export async function readAllDeployments(service, environmentId, {
+  pageSize = 500,
+  maxPages = 200,
+  api = runRailwayApi,
+} = {}) {
+  if (!service?.id || !environmentId) {
+    throw new Error('service id and environment id are required for complete deployment history');
+  }
+  const deployments = [];
+  const seenCursors = new Set();
+  let after = null;
+  for (let page = 1; page <= maxPages; page += 1) {
+    const data = await api(FLEET_QUERY, {
+      input: { serviceId: service.id, environmentId },
+      first: pageSize,
+      ...(after ? { after } : {}),
+    });
+    const connection = data?.deployments;
+    if (!Array.isArray(connection?.edges)
+      || typeof connection?.pageInfo?.hasNextPage !== 'boolean') {
+      throw new Error(`Railway returned an incomplete deployment history page for ${service.name}`);
+    }
+    const pageDeployments = connection.edges.map((edge) => edge?.node);
+    if (pageDeployments.some((deployment) => !deployment
+      || typeof deployment.id !== 'string'
+      || typeof deployment.status !== 'string'
+      || deployment.serviceId !== service.id)) {
+      throw new Error(`Railway returned a malformed deployment history record for ${service.name}`);
+    }
+    deployments.push(...pageDeployments);
+    if (connection.pageInfo.hasNextPage !== true) return deployments;
+    const next = connection.pageInfo.endCursor;
+    if (typeof next !== 'string' || next === '' || seenCursors.has(next)) {
+      throw new Error(`Railway deployment history cursor did not advance for ${service.name}`);
+    }
+    seenCursors.add(next);
+    after = next;
+  }
+  throw new Error(`Railway deployment history exceeded ${maxPages} pages for ${service.name}`);
+}
+
+/**
  * Every repository service's recent deployment history, in a handful of calls
  * instead of one per service.
  *

--- a/scripts/resolve-railway-reconcile-control.mjs
+++ b/scripts/resolve-railway-reconcile-control.mjs
@@ -13,12 +13,13 @@ import {
   canonicalJson,
 } from './railway-reconcile-control-client.mjs';
 import {
+  RAILWAY_CALL_TIMEOUT_MS,
   readAllDeployments,
   readDeployments,
   readRepositoryServices,
   resolveEnvironmentId,
 } from './railway-cli.mjs';
-import { IN_FLIGHT_STATUSES } from './railway-deployments.mjs';
+import { IN_FLIGHT_STATUSES, isKnownStatus } from './railway-deployments.mjs';
 
 export const RECOVERY_PROTOCOL_VERSION = 1;
 export const TARGET_WORKFLOW = 'railway-deploy-trigger.yml';
@@ -34,6 +35,7 @@ export const OUTAGE_RETRY_MIN_WAIT_MS = LEASE_DURATION_MS
 export const RECOVERY_GITHUB_MAX_PAGES = 10;
 export const RECOVERY_GITHUB_MAX_REQUESTS = 100;
 export const RECOVERY_GITHUB_REQUEST_TIMEOUT_MS = 10_000;
+export const PROVIDER_PROOF_BUDGET_MS = 35 * 60 * 1000;
 
 const API_VERSION = '2026-03-10';
 const DECISIONS = new Set([
@@ -886,6 +888,8 @@ export async function verifyNoActiveRailwayDeployments({
   readDeploymentsImpl = readDeployments,
   readAllDeploymentsImpl = readAllDeployments,
   resolveEnvironmentIdImpl = resolveEnvironmentId,
+  monotonicNow = () => performance.now(),
+  deadline = null,
 } = {}) {
   if (typeof readRepositoryServicesImpl !== 'function'
     || typeof readDeploymentsImpl !== 'function'
@@ -895,21 +899,60 @@ export async function verifyNoActiveRailwayDeployments({
   }
   const services = readRepositoryServicesImpl(environment);
   if (services.length === 0) fail('PROVIDER_EVIDENCE_UNREADABLE', 'Railway Viewer returned no repository services');
+  const proofDeadline = deadline ?? (monotonicNow() + PROVIDER_PROOF_BUDGET_MS);
+  const remainingMs = () => {
+    const remaining = proofDeadline - monotonicNow();
+    if (!(remaining > 0)) {
+      fail('PROVIDER_EVIDENCE_INCOMPLETE', 'Railway provider inactivity proof exceeded its deadline');
+    }
+    return Math.max(1, Math.floor(remaining));
+  };
+  const assertInactive = (deployments, service) => {
+    const active = deployments.find((deployment) => (
+      deployment?.status === 'REMOVING' || IN_FLIGHT_STATUSES.includes(deployment?.status)
+    ));
+    if (active) fail('PROVIDER_ACTIVITY_NOT_CLEARED', `Railway still reports active work for ${service.name}`);
+    const unknown = deployments.find((deployment) => !isKnownStatus(deployment?.status));
+    if (unknown) {
+      fail(
+        'PROVIDER_ACTIVITY_NOT_CLEARED',
+        `Railway reported unrecognized deployment status for ${service.name}`,
+      );
+    }
+  };
+  const readBounded = async (service) => {
+    try {
+      return await readDeploymentsImpl(
+        service,
+        environment,
+        1000,
+        { timeoutMs: Math.min(RAILWAY_CALL_TIMEOUT_MS, remainingMs()) },
+      );
+    } catch (cause) {
+      fail(
+        'PROVIDER_EVIDENCE_INCOMPLETE',
+        `Railway bounded deployment history was unreadable for ${service.name}`,
+        { cause },
+      );
+    }
+  };
   let checked = 0;
   let environmentId = null;
   for (let index = 0; index < services.length; index += 8) {
     const batch = services.slice(index, index + 8);
-    const boundedHistories = await Promise.all(
-      batch.map((service) => readDeploymentsImpl(service, environment, 1000)),
-    );
+    const boundedHistories = await Promise.all(batch.map(readBounded));
     const histories = await Promise.all(boundedHistories.map(async (deployments, offset) => {
       if (!Array.isArray(deployments)) {
         fail('PROVIDER_EVIDENCE_UNREADABLE', 'Railway deployment history was malformed');
       }
       if (deployments.length < 1000) return deployments;
+      remainingMs();
       environmentId ??= resolveEnvironmentIdImpl(environment);
       try {
-        const complete = await readAllDeploymentsImpl(batch[offset], environmentId);
+        const complete = await readAllDeploymentsImpl(batch[offset], environmentId, {
+          deadline: proofDeadline,
+          now: monotonicNow,
+        });
         if (!Array.isArray(complete)) throw new Error('complete deployment history was malformed');
         return complete;
       } catch (cause) {
@@ -921,11 +964,26 @@ export async function verifyNoActiveRailwayDeployments({
       }
     }));
     histories.forEach((deployments, offset) => {
-      const active = deployments.find((deployment) => IN_FLIGHT_STATUSES.includes(deployment?.status));
-      if (active) fail('PROVIDER_ACTIVITY_NOT_CLEARED', `Railway still reports active work for ${batch[offset].name}`);
+      assertInactive(deployments, batch[offset]);
       checked += 1;
     });
   }
+
+  // Pagination is newest-first. A deployment can be inserted after the first
+  // page was read and never appear in the older cursors. Re-sweep the entire
+  // fleet only after every complete-history read has finished so the proof's
+  // final observation is the newest bounded window for every service.
+  for (let index = 0; index < services.length; index += 8) {
+    const batch = services.slice(index, index + 8);
+    const finalHistories = await Promise.all(batch.map(readBounded));
+    finalHistories.forEach((deployments, offset) => {
+      if (!Array.isArray(deployments)) {
+        fail('PROVIDER_EVIDENCE_UNREADABLE', 'Railway deployment history was malformed');
+      }
+      assertInactive(deployments, batch[offset]);
+    });
+  }
+  remainingMs();
   return { ok: true, checkedServices: checked };
 }
 

--- a/scripts/resolve-railway-reconcile-control.mjs
+++ b/scripts/resolve-railway-reconcile-control.mjs
@@ -12,7 +12,12 @@ import {
   RailwayReconcileControlClient,
   canonicalJson,
 } from './railway-reconcile-control-client.mjs';
-import { readDeployments, readRepositoryServices } from './railway-cli.mjs';
+import {
+  readAllDeployments,
+  readDeployments,
+  readRepositoryServices,
+  resolveEnvironmentId,
+} from './railway-cli.mjs';
 import { IN_FLIGHT_STATUSES } from './railway-deployments.mjs';
 
 export const RECOVERY_PROTOCOL_VERSION = 1;
@@ -879,26 +884,43 @@ export async function verifyNoActiveRailwayDeployments({
   environment = 'production',
   readRepositoryServicesImpl = readRepositoryServices,
   readDeploymentsImpl = readDeployments,
+  readAllDeploymentsImpl = readAllDeployments,
+  resolveEnvironmentIdImpl = resolveEnvironmentId,
 } = {}) {
-  if (typeof readRepositoryServicesImpl !== 'function' || typeof readDeploymentsImpl !== 'function') {
+  if (typeof readRepositoryServicesImpl !== 'function'
+    || typeof readDeploymentsImpl !== 'function'
+    || typeof readAllDeploymentsImpl !== 'function'
+    || typeof resolveEnvironmentIdImpl !== 'function') {
     throw new TypeError('Railway evidence readers must be functions');
   }
   const services = readRepositoryServicesImpl(environment);
   if (services.length === 0) fail('PROVIDER_EVIDENCE_UNREADABLE', 'Railway Viewer returned no repository services');
   let checked = 0;
+  let environmentId = null;
   for (let index = 0; index < services.length; index += 8) {
     const batch = services.slice(index, index + 8);
-    const histories = await Promise.all(
+    const boundedHistories = await Promise.all(
       batch.map((service) => readDeploymentsImpl(service, environment, 1000)),
     );
-    histories.forEach((deployments, offset) => {
-      if (!Array.isArray(deployments)) fail('PROVIDER_EVIDENCE_UNREADABLE', 'Railway deployment history was malformed');
-      if (deployments.length >= 1000) {
+    const histories = await Promise.all(boundedHistories.map(async (deployments, offset) => {
+      if (!Array.isArray(deployments)) {
+        fail('PROVIDER_EVIDENCE_UNREADABLE', 'Railway deployment history was malformed');
+      }
+      if (deployments.length < 1000) return deployments;
+      environmentId ??= resolveEnvironmentIdImpl(environment);
+      try {
+        const complete = await readAllDeploymentsImpl(batch[offset], environmentId);
+        if (!Array.isArray(complete)) throw new Error('complete deployment history was malformed');
+        return complete;
+      } catch (cause) {
         fail(
           'PROVIDER_EVIDENCE_INCOMPLETE',
           `Railway deployment history did not prove exhaustion for ${batch[offset].name}`,
+          { cause },
         );
       }
+    }));
+    histories.forEach((deployments, offset) => {
       const active = deployments.find((deployment) => IN_FLIGHT_STATUSES.includes(deployment?.status));
       if (active) fail('PROVIDER_ACTIVITY_NOT_CLEARED', `Railway still reports active work for ${batch[offset].name}`);
       checked += 1;

--- a/tests/railway-fleet-deployments.test.mjs
+++ b/tests/railway-fleet-deployments.test.mjs
@@ -12,6 +12,7 @@ import { describe, it } from 'node:test';
 
 import {
   createRailwayCliEnv,
+  readAllDeployments,
   readDeployments,
   readFleetDeployments,
   runRailway,
@@ -213,6 +214,101 @@ describe('fleet paging', () => {
         api: () => ({}), accumulatorFactory: createFleetAccumulator,
       }),
       /no deployments connection/,
+    );
+  });
+});
+
+describe('complete per-service history paging', () => {
+  it('continues by cursor until Railway proves exhaustion', async () => {
+    const calls = [];
+    const pages = [
+      {
+        edges: [{ node: { id: 'deployment-1', ...node('service-1', 'SUCCESS', '2026-08-04T11:00:00Z', 'aaa') } }],
+        pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+      },
+      {
+        edges: [{ node: { id: 'deployment-2', ...node('service-1', 'REMOVED', '2026-08-03T11:00:00Z', 'bbb') } }],
+        pageInfo: { hasNextPage: false, endCursor: 'cursor-2' },
+      },
+    ];
+    const deployments = await readAllDeployments(
+      { id: 'service-1', name: 'seed-one' },
+      'environment-1',
+      {
+        api: async (_query, variables) => {
+          calls.push(variables);
+          return { deployments: pages.shift() };
+        },
+      },
+    );
+
+    assert.equal(deployments.length, 2);
+    assert.deepEqual(calls, [
+      { input: { serviceId: 'service-1', environmentId: 'environment-1' }, first: 500 },
+      { input: { serviceId: 'service-1', environmentId: 'environment-1' }, first: 500, after: 'cursor-1' },
+    ]);
+  });
+
+  it('fails closed when a cursor repeats', async () => {
+    await assert.rejects(
+      readAllDeployments(
+        { id: 'service-1', name: 'seed-one' },
+        'environment-1',
+        {
+          api: async () => ({
+            deployments: {
+              edges: [],
+              pageInfo: { hasNextPage: true, endCursor: 'stuck' },
+            },
+          }),
+        },
+      ),
+      /cursor did not advance/,
+    );
+  });
+
+  it('fails closed when the defensive page budget cannot prove exhaustion', async () => {
+    await assert.rejects(
+      readAllDeployments(
+        { id: 'service-1', name: 'seed-one' },
+        'environment-1',
+        {
+          maxPages: 1,
+          api: async () => ({
+            deployments: {
+              edges: [],
+              pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+            },
+          }),
+        },
+      ),
+      /exceeded 1 pages/,
+    );
+  });
+
+  it('fails closed on an ambiguous page or a record from another service', async () => {
+    await assert.rejects(
+      readAllDeployments(
+        { id: 'service-1', name: 'seed-one' },
+        'environment-1',
+        { api: async () => ({ deployments: { edges: [], pageInfo: {} } }) },
+      ),
+      /incomplete deployment history page/,
+    );
+    await assert.rejects(
+      readAllDeployments(
+        { id: 'service-1', name: 'seed-one' },
+        'environment-1',
+        {
+          api: async () => ({
+            deployments: {
+              edges: [{ node: { id: 'deployment-1', ...node('service-2', 'SUCCESS', '2026-08-04T11:00:00Z', 'aaa') } }],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          }),
+        },
+      ),
+      /malformed deployment history record/,
     );
   });
 });

--- a/tests/railway-fleet-deployments.test.mjs
+++ b/tests/railway-fleet-deployments.test.mjs
@@ -219,6 +219,36 @@ describe('fleet paging', () => {
 });
 
 describe('complete per-service history paging', () => {
+  it('caps every API page to the shared deadline and checks it before the next page', async () => {
+    const observedTimeouts = [];
+    const times = [10, 50];
+    let calls = 0;
+    await assert.rejects(
+      readAllDeployments(
+        { id: 'service-1', name: 'seed-one' },
+        'environment-1',
+        {
+          deadline: 50,
+          now: () => times.shift(),
+          api: async (_query, _variables, options) => {
+            calls += 1;
+            observedTimeouts.push(options.timeoutMs);
+            return {
+              deployments: {
+                edges: [],
+                pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+              },
+            };
+          },
+        },
+      ),
+      /deadline expired before page 2/,
+    );
+
+    assert.equal(calls, 1, 'the expired deadline must stop before another API call');
+    assert.deepEqual(observedTimeouts, [40], 'the API page gets only the remaining proof budget');
+  });
+
   it('continues by cursor until Railway proves exhaustion', async () => {
     const calls = [];
     const pages = [

--- a/tests/railway-reconcile-control-resolution.test.mjs
+++ b/tests/railway-reconcile-control-resolution.test.mjs
@@ -14,6 +14,7 @@ import {
   verifyNoActiveRailwayDeployments,
 } from '../scripts/resolve-railway-reconcile-control.mjs';
 import { RailwayReconcileControlClient } from '../scripts/railway-reconcile-control-client.mjs';
+import { readAllDeployments } from '../scripts/railway-cli.mjs';
 
 const HEAD = 'a'.repeat(40);
 const PRIOR_ID = 'attempt-prior-0001';
@@ -1013,9 +1014,123 @@ describe('read-only Railway provider inactivity proof', () => {
     });
 
     assert.deepEqual(proof, { ok: true, checkedServices: 17 });
-    assert.equal(calls.length, 17);
+    assert.equal(calls.length, 34, 'the complete scan is followed by a final fleet sweep');
     assert.ok(calls.every(({ environment, limit }) => environment === 'production' && limit === 1000));
     assert.equal(maxActive, 8);
+  });
+
+  it('shares one monotonic deadline with bounded and complete-history reads', async () => {
+    const service = { id: 'service-full', name: 'seed-full-history' };
+    const boundedOptions = [];
+    let boundedCalls = 0;
+    let completeOptions;
+    const monotonicNow = () => 1_000;
+    const proof = await verifyNoActiveRailwayDeployments({
+      deadline: 6_000,
+      monotonicNow,
+      readRepositoryServicesImpl: () => [service],
+      readDeploymentsImpl: async (_service, _environment, _limit, options) => {
+        boundedOptions.push(options);
+        boundedCalls += 1;
+        return boundedCalls === 1
+          ? Array.from({ length: 1000 }, (_, index) => ({ id: `deployment-${index}`, status: 'SUCCESS' }))
+          : [{ id: 'deployment-final', status: 'SUCCESS' }];
+      },
+      resolveEnvironmentIdImpl: () => 'environment-1',
+      readAllDeploymentsImpl: async (_service, _environmentId, options) => {
+        completeOptions = options;
+        return [{ id: 'deployment-complete', status: 'SUCCESS' }];
+      },
+    });
+
+    assert.deepEqual(proof, { ok: true, checkedServices: 1 });
+    assert.deepEqual(boundedOptions, [{ timeoutMs: 5000 }, { timeoutMs: 5000 }]);
+    assert.equal(completeOptions.deadline, 6000);
+    assert.equal(completeOptions.now, monotonicNow);
+  });
+
+  it('returns page-deadline exhaustion as incomplete provider evidence', async () => {
+    const service = { id: 'service-full', name: 'seed-full-history' };
+    let clock = 0;
+    await assert.rejects(
+      verifyNoActiveRailwayDeployments({
+        deadline: 10,
+        monotonicNow: () => clock,
+        readRepositoryServicesImpl: () => [service],
+        readDeploymentsImpl: async () => Array.from(
+          { length: 1000 },
+          (_, index) => ({ id: `deployment-${index}`, status: 'SUCCESS' }),
+        ),
+        resolveEnvironmentIdImpl: () => 'environment-1',
+        readAllDeploymentsImpl: (observedService, environmentId, options) => readAllDeployments(
+          observedService,
+          environmentId,
+          {
+            ...options,
+            api: async () => {
+              clock = 10;
+              return {
+                deployments: {
+                  edges: [],
+                  pageInfo: { hasNextPage: true, endCursor: 'cursor-1' },
+                },
+              };
+            },
+          },
+        ),
+      }),
+      (error) => error.code === 'PROVIDER_EVIDENCE_INCOMPLETE'
+        && error.cause?.message.includes('deadline expired before page 2'),
+    );
+  });
+
+  it('fails closed for REMOVING and unknown statuses in bounded histories', async () => {
+    for (const status of ['REMOVING', 'PROVIDER_ADDED_A_NEW_STATUS']) {
+      await assert.rejects(
+        verifyNoActiveRailwayDeployments({
+          readRepositoryServicesImpl: () => [{ id: 'service-1', name: 'seed-one' }],
+          readDeploymentsImpl: async () => [{ id: 'deployment-1', status }],
+        }),
+        (error) => error.code === 'PROVIDER_ACTIVITY_NOT_CLEARED',
+        status,
+      );
+    }
+  });
+
+  it('fails closed for REMOVING and unknown statuses in paginated histories', async () => {
+    for (const status of ['REMOVING', 'PROVIDER_ADDED_A_NEW_STATUS']) {
+      await assert.rejects(
+        verifyNoActiveRailwayDeployments({
+          readRepositoryServicesImpl: () => [{ id: 'service-1', name: 'seed-one' }],
+          readDeploymentsImpl: async () => Array.from(
+            { length: 1000 },
+            (_, index) => ({ id: `deployment-${index}`, status: 'SUCCESS' }),
+          ),
+          resolveEnvironmentIdImpl: () => 'environment-1',
+          readAllDeploymentsImpl: async () => [{ id: 'deployment-complete', status }],
+        }),
+        (error) => error.code === 'PROVIDER_ACTIVITY_NOT_CLEARED',
+        status,
+      );
+    }
+  });
+
+  it('rejects active work that appears only in the final fleet sweep', async () => {
+    let calls = 0;
+    await assert.rejects(
+      verifyNoActiveRailwayDeployments({
+        readRepositoryServicesImpl: () => [{ id: 'service-1', name: 'seed-one' }],
+        readDeploymentsImpl: async () => {
+          calls += 1;
+          return [{
+            id: calls === 1 ? 'deployment-initial' : 'deployment-inserted',
+            status: calls === 1 ? 'SUCCESS' : 'BUILDING',
+          }];
+        },
+      }),
+      (error) => error.code === 'PROVIDER_ACTIVITY_NOT_CLEARED',
+    );
+    assert.equal(calls, 2);
   });
 
   it('pages a full CLI window to positive exhaustion and checks older active work', async () => {

--- a/tests/railway-reconcile-control-resolution.test.mjs
+++ b/tests/railway-reconcile-control-resolution.test.mjs
@@ -1018,14 +1018,57 @@ describe('read-only Railway provider inactivity proof', () => {
     assert.equal(maxActive, 8);
   });
 
-  it('fails closed when exactly 1000 deployments do not prove history exhaustion', async () => {
+  it('pages a full CLI window to positive exhaustion and checks older active work', async () => {
+    const service = { id: 'service-full', name: 'seed-full-history' };
+    const complete = Array.from(
+      { length: 1001 },
+      (_, index) => ({ id: `deployment-${index}`, status: index === 1000 ? 'BUILDING' : 'SUCCESS' }),
+    );
     await assert.rejects(
       verifyNoActiveRailwayDeployments({
-        readRepositoryServicesImpl: () => [{ name: 'seed-full-history' }],
+        readRepositoryServicesImpl: () => [service],
+        readDeploymentsImpl: async () => complete.slice(0, 1000),
+        resolveEnvironmentIdImpl(environment) {
+          assert.equal(environment, 'production');
+          return 'environment-1';
+        },
+        readAllDeploymentsImpl(observedService, environmentId) {
+          assert.equal(observedService, service);
+          assert.equal(environmentId, 'environment-1');
+          return complete;
+        },
+      }),
+      (error) => error.code === 'PROVIDER_ACTIVITY_NOT_CLEARED',
+    );
+  });
+
+  it('accepts a complete paginated history with no active provider work', async () => {
+    const complete = Array.from(
+      { length: 1001 },
+      (_, index) => ({ id: `deployment-${index}`, status: 'SUCCESS' }),
+    );
+    const proof = await verifyNoActiveRailwayDeployments({
+      readRepositoryServicesImpl: () => [{ id: 'service-full', name: 'seed-full-history' }],
+      readDeploymentsImpl: async () => complete.slice(0, 1000),
+      resolveEnvironmentIdImpl: () => 'environment-1',
+      readAllDeploymentsImpl: async () => complete,
+    });
+
+    assert.deepEqual(proof, { ok: true, checkedServices: 1 });
+  });
+
+  it('fails closed when complete history paging cannot prove exhaustion', async () => {
+    await assert.rejects(
+      verifyNoActiveRailwayDeployments({
+        readRepositoryServicesImpl: () => [{ id: 'service-full', name: 'seed-full-history' }],
         readDeploymentsImpl: async () => Array.from(
           { length: 1000 },
           (_, index) => ({ id: `deployment-${index}`, status: 'SUCCESS' }),
         ),
+        resolveEnvironmentIdImpl: () => 'environment-1',
+        readAllDeploymentsImpl: async () => {
+          throw new Error('page budget exhausted');
+        },
       }),
       (error) => error.code === 'PROVIDER_EVIDENCE_INCOMPLETE',
     );

--- a/tests/railway-stale-reconcile-dispatch.test.mjs
+++ b/tests/railway-stale-reconcile-dispatch.test.mjs
@@ -1680,6 +1680,49 @@ describe('durably held recovery dispatch orchestration', () => {
     assert.equal((await snapshotPromise).main.sha, HEAD);
   });
 
+  it('repairs an already-issued dispatch hold during classification without creating a new dispatch', async () => {
+    const hold = {
+      state: 'DISPATCH_HELD',
+      recoveryAttemptId: 'operator-retry-already-issued',
+      headSha: HEAD,
+      sourceRunId: '9007',
+      sourceRunAttempt: 1,
+      sourceHeadSha: HEAD,
+    };
+    const bindCalls = [];
+    let bound = false;
+    const snapshot = await readWatchdogSnapshot({
+      github: {
+        readMainAndGate: async () => ({ sha: HEAD, gate: { state: 'success' } }),
+        readTargetRunSummaries: async () => [],
+        hydrateTargetRuns: async () => [],
+        findRunByRecoveryAttemptId: async () => ({ id: 9008, runAttempt: 1 }),
+      },
+      control: {
+        status: async () => ({
+          data: eligibleControl({
+            dispatchHolds: bound
+              ? [{ ...hold, state: 'RUN_BOUND', runId: '9008', runAttempt: 1 }]
+              : [hold],
+          }),
+        }),
+        bindRun: async (body) => {
+          bindCalls.push(body);
+          bound = true;
+        },
+      },
+      clock: () => NOW,
+    });
+
+    assert.deepEqual(bindCalls, [{
+      recoveryAttemptId: hold.recoveryAttemptId,
+      headSha: hold.headSha,
+      runId: '9008',
+      runAttempt: 1,
+    }]);
+    assert.equal(snapshot.controlState.dispatchHolds[0].state, 'RUN_BOUND');
+  });
+
   it('closes a cancellation-before-job hold only after exact terminal source evidence proves POST never started', async () => {
     const hold = {
       state: 'DISPATCH_HELD',


### PR DESCRIPTION
## Summary

Protected Railway recovery can now prove provider inactivity for services whose deployment history exceeds the CLI's 1,000-record window. The ordinary proof keeps its bounded concurrent CLI reads; only a full window falls back to cursor pagination, and incomplete pages, malformed records, repeated cursors, or the page budget fail closed.

This also records the staged activation contract: cutover admission is enabled before automatic watchdog recovery, while classification may still finish binding or rejecting a dispatch hold that was already authorized.

The production cutover exercise exposed this limit on `ais-relay` after the first exact-main reconciliation entered a mutation barrier. A direct source retry restored the one failed Railway deployment, but protected recovery made no controller write because the old verifier could not prove exhaustion. Automatic recovery remains disabled until this fix is on `main`, a protected retry reaches fresh terminal acceptance, and a no-dispatch watchdog baseline is healthy.

## Validation

- `node --test tests/railway-fleet-deployments.test.mjs tests/railway-reconcile-control-resolution.test.mjs tests/railway-stale-reconcile-dispatch.test.mjs tests/railway-deploy-trigger-watchdog-workflow.test.mjs` — 122 passed.
- `npm run test:data` — degraded locally: the suite was stopped after more than 20 minutes with unrelated Company Monitoring test files still running and no reported failure.
- `markdownlint-cli2 docs/railway-seed-consolidation-runbook.md` — 0 errors.
- Live read-only pagination exhausted 3,759 `ais-relay` deployments and found no in-flight record; the full provider proof checked all 80 repository services with no active deployment.

## Post-Deploy Monitoring & Validation

- Owner: `koala73`; observe the first protected `authorize_current_main_retry` run and its correlated Railway reconcile.
- Expected: recovery proof checks all repository services, the retry verifier records fresh `lastAccepted`, the mutation barrier clears, and the watchdog reports `HEALTHY` with no dispatch while automatic recovery is still off.
- Search recovery logs for `PROVIDER_EVIDENCE_INCOMPLETE`, `PROVIDER_ACTIVITY_NOT_CLEARED`, and `OPERATOR_RESOLUTION_RECORDED`.
- Failure response: keep `RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED=false`; if the lease-aware mutation path is unsafe, also set `RAILWAY_RECONCILE_CUTOVER_ACTIVE=false` and preserve the barrier for protected diagnosis.
- Enable automatic recovery only after the fresh acceptance and healthy watchdog baseline are both observed.

Related: #6378

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
