### PR TITLE
fix(ci): invalidate stale deploy gate statuses

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -207,6 +207,35 @@ jobs:
               select(.commits.nodes[0].commit.status.context == null) |
               .headRefOid
             ')
+
+            # Invalidate every stale terminal result before any slower recovery
+            # reads start. If the first write pass has partial failures, retry
+            # every failed SHA once so the EXIT trap is not the only fallback
+            # for a multi-SHA cohort.
+            remaining_invalidation_shas="$stale_terminal_shas"
+            for invalidation_attempt in 1 2; do
+              if [ -z "$remaining_invalidation_shas" ]; then
+                break
+              fi
+              if [ "$invalidation_attempt" -eq 2 ]; then
+                echo "sweep: retrying stale gate invalidation for: $remaining_invalidation_shas"
+              fi
+              stale_invalidation_failures=""
+              for SHA in $remaining_invalidation_shas; do
+                active_sha="$SHA"
+                if ! post_gate_status "pending" "Required PR gate contract changed; re-evaluation scheduled"; then
+                  stale_invalidation_failures=$(printf '%s\n%s\n' "$stale_invalidation_failures" "$SHA" | sed '/^$/d')
+                fi
+                active_sha=""
+              done
+              remaining_invalidation_shas="$stale_invalidation_failures"
+            done
+            if [ -n "$remaining_invalidation_shas" ]; then
+              echo "::error::Could not invalidate stale gate statuses for: $remaining_invalidation_shas"
+              active_sha=$(printf '%s\n' "$remaining_invalidation_shas" | sed -n '1p')
+              exit 1
+            fi
+
             failed_missing_shas=""
             if [ -n "$missing_shas" ]; then
               recent_run_cutoff=$(($(date +%s) - 86400))
@@ -241,23 +270,6 @@ jobs:
             fi
             echo "sweep: re-evaluating pending or stale gate on:"
             echo "$shas"
-
-            # Invalidate every stale terminal result before the slower check-run
-            # reads start. A scheduled replacement can cancel this job at any
-            # point, but no old success may remain mergeable while it waits.
-            stale_invalidation_failures=""
-            for SHA in $stale_terminal_shas; do
-              active_sha="$SHA"
-              if ! post_gate_status "pending" "Required PR gate contract changed; re-evaluation scheduled"; then
-                stale_invalidation_failures=$(printf '%s\n%s\n' "$stale_invalidation_failures" "$SHA" | sed '/^$/d')
-              fi
-              active_sha=""
-            done
-            if [ -n "$stale_invalidation_failures" ]; then
-              echo "::error::Could not invalidate stale gate statuses for: $stale_invalidation_failures"
-              active_sha=$(printf '%s\n' "$stale_invalidation_failures" | sed -n '1p')
-              exit 1
-            fi
           fi
 
           for SHA in $shas; do

--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -10,13 +10,14 @@ run-name: Deploy Gate ${{ github.event.workflow_run.head_sha || github.event_nam
 # can serve stale reads (~1 min normally, longer during GitHub degradation),
 # and the last workflow_run event for a SHA is the last time anything
 # re-evaluates. The sweep finds open-PR head SHAs whose gate status is pending
-# and re-evaluates them, so a stranded PR heals within 30 minutes
-# with no manual re-run.
+# or whose required-check contract stamp is stale, then re-evaluates them. A
+# stranded PR heals within 30 minutes, and a success from an older gate cannot
+# stay mergeable after the required set changes (#5851).
 
 # Four workflow_run events can target the same SHA. Keep only the newest
 # evaluator so their retry windows do not multiply the installation API load.
 concurrency:
-  group: deploy-gate-${{ github.event.workflow_run.head_sha || github.event_name }}
+  group: deploy-gate-${{ github.event.workflow_run.head_sha || 'sweep' }}
   cancel-in-progress: true
 
 on:
@@ -52,13 +53,18 @@ jobs:
           # reads as "missing", not "failure", to branch protection, to
           # check-railway-deploy-drift.mjs and to the Seed Freshness Monitor.
           # Keep the state and the COUNT, which survive truncation; the full
-          # list is already in this log.
+          # list is already in this log. Reserve space for the contract stamp:
+          # the sweep uses it to distinguish current evidence from a stale
+          # success that covered an older required list (#5851).
           gate_description() {
             text="$1"
-            if [ "${#text}" -le 140 ]; then
-              printf '%s' "$text"
+            suffix=" $gate_stamp"
+            text_limit=$((140 - ${#suffix}))
+            if [ "${#text}" -le "$text_limit" ]; then
+              printf '%s%s' "$text" "$suffix"
             else
-              printf '%s...' "${text:0:137}"
+              preview_length=$((text_limit - 3))
+              printf '%s...%s' "${text:0:$preview_length}" "$suffix"
             fi
           }
           name_count() {
@@ -140,6 +146,8 @@ jobs:
           # `typecheck-changes` / `lint-changes` so all three are evaluated
           # instead of two being masked by the third (#5822).
           required='["changes","typecheck-changes","lint-changes","docs-stats","unit","consumer-prices","umami-postgres","sidecar","convex-tests","dom-tests","desktop-config","desktop-rust","variant-smoke-full","resilience-validation-smoke","digest-image","typecheck","biome","public-docs","mintlify-slugs","security-audit"]'
+          gate_contract=$(REQUIRED_JOBS="$required" python3 -c 'import hashlib, os; print(hashlib.sha256(os.environ["REQUIRED_JOBS"].encode()).hexdigest()[:12])')
+          gate_stamp="[gate-contract:$gate_contract]"
           repo_owner=${REPO%%/*}
           repo_name=${REPO#*/}
 
@@ -148,12 +156,13 @@ jobs:
             shas="$SHA"
           else
             # schedule / workflow_dispatch — read every open PR head and its
-            # `gate` context in one paginated GraphQL query. A failed
-            # event-driven run normally posts pending through the EXIT trap. If
-            # even that write fails, cross-reference missing contexts with
-            # recent failed runs of this workflow. That recovers an old head
-            # whose checks were rerun without re-evaluating every dormant
-            # legacy PR with no gate context (#5851).
+            # `gate` context in one paginated GraphQL query. Pending statuses
+            # and statuses without the exact current required-set stamp are
+            # re-evaluated. A failed event-driven run normally posts pending
+            # through the EXIT trap. If even that write fails, cross-reference
+            # missing contexts with recent failed runs of this workflow. That
+            # recovers an old head whose checks were rerun without evaluating
+            # every dormant legacy PR with no gate context (#5851).
             pr_gate_states=$(gh_api_with_rate_limit_retry graphql graphql --paginate --slurp \
               -f owner="$repo_owner" \
               -f name="$repo_name" \
@@ -165,7 +174,7 @@ jobs:
                       commits(last: 1) {
                         nodes {
                           commit {
-                            status { context(name: "gate") { state } }
+                            status { context(name: "gate") { state description } }
                           }
                         }
                       }
@@ -174,11 +183,25 @@ jobs:
                   }
                 }
               }')
-            pending_shas=$(printf '%s\n' "$pr_gate_states" | jq -r '
-              .[].data.repository.pullRequests.nodes[] |
-              select(.commits.nodes[0].commit.status.context.state == "PENDING") |
-              .headRefOid
-            ')
+            stale_terminal_shas=$(printf '%s\n' "$pr_gate_states" |
+              jq -r --arg gate_stamp "$gate_stamp" '
+                .[].data.repository.pullRequests.nodes[] |
+                .commits.nodes[0].commit.status.context as $gate |
+                select(
+                  $gate != null and
+                  $gate.state != "PENDING" and
+                  (($gate.description // "") | endswith($gate_stamp) | not)
+                ) |
+                .headRefOid
+              ' |
+              awk '!seen[$0]++')
+            pending_shas=$(printf '%s\n' "$pr_gate_states" |
+              jq -r '
+                .[].data.repository.pullRequests.nodes[] |
+                select(.commits.nodes[0].commit.status.context.state == "PENDING") |
+                .headRefOid
+              ' |
+              awk '!seen[$0]++')
             missing_shas=$(printf '%s\n' "$pr_gate_states" | jq -r '
               .[].data.repository.pullRequests.nodes[] |
               select(.commits.nodes[0].commit.status.context == null) |
@@ -206,13 +229,35 @@ jobs:
                 fi
               done)
             fi
-            shas=$(printf '%s\n%s\n' "$pending_shas" "$failed_missing_shas" | sed '/^$/d' | sort -u)
+            # A SHA can head more than one open PR. Deduplicate without sorting:
+            # stale terminal candidates must stay ahead of already-fail-closed
+            # pending candidates so a busy sweep cannot starve stale greens.
+            shas=$(printf '%s\n%s\n%s\n' "$stale_terminal_shas" "$pending_shas" "$failed_missing_shas" |
+              sed '/^$/d' |
+              awk '!seen[$0]++')
             if [ -z "$shas" ]; then
-              echo "sweep: no open PRs with a pending gate status"
+              echo "sweep: no open PRs with a pending or stale gate status"
               exit 0
             fi
-            echo "sweep: re-evaluating pending gate on:"
+            echo "sweep: re-evaluating pending or stale gate on:"
             echo "$shas"
+
+            # Invalidate every stale terminal result before the slower check-run
+            # reads start. A scheduled replacement can cancel this job at any
+            # point, but no old success may remain mergeable while it waits.
+            stale_invalidation_failures=""
+            for SHA in $stale_terminal_shas; do
+              active_sha="$SHA"
+              if ! post_gate_status "pending" "Required PR gate contract changed; re-evaluation scheduled"; then
+                stale_invalidation_failures=$(printf '%s\n%s\n' "$stale_invalidation_failures" "$SHA" | sed '/^$/d')
+              fi
+              active_sha=""
+            done
+            if [ -n "$stale_invalidation_failures" ]; then
+              echo "::error::Could not invalidate stale gate statuses for: $stale_invalidation_failures"
+              active_sha=$(printf '%s\n' "$stale_invalidation_failures" | sed -n '1p')
+              exit 1
+            fi
           fi
 
           for SHA in $shas; do
@@ -235,6 +280,12 @@ jobs:
           # core.
           # NOTE: the python3 -c body must stay at column 0 of the block scalar —
           # indenting it with the loops would be a Python IndentationError.
+          max_attempts=2
+          if [ -n "$stale_terminal_shas" ] && printf '%s\n' "$stale_terminal_shas" | grep -qx "$SHA"; then
+            # The stale result is already fail-closed above. Do not let its
+            # 60-second retry delay starve the rest of the sweep.
+            max_attempts=1
+          fi
           for attempt in 1 2; do
             runs=$(gh_api_with_rate_limit_retry graphql graphql --paginate --slurp \
               -f owner="$repo_owner" \
@@ -291,6 +342,9 @@ jobs:
             failed=$(echo "$status" | awk -F= '/^failed=/ { print $2 }')
 
             if [ -z "$pending" ]; then
+              break
+            fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
               break
             fi
             if [ "$attempt" -lt 2 ]; then

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -682,9 +682,14 @@ describe('CI workflow coverage', () => {
     );
   });
 
-  it('batches pending gate discovery during the scheduled self-healing sweep', () => {
+  it('batches pending and stale-contract gate discovery during the scheduled self-healing sweep', () => {
     const deployGateJob = workflowJobBlock(deployGateWorkflow, 'gate');
 
+    assert.match(
+      deployGateWorkflow,
+      /^ {2}group: deploy-gate-\$\{\{ github\.event\.workflow_run\.head_sha \|\| 'sweep' \}\}$/m,
+      'schedule and workflow_dispatch must share one sweep concurrency group while workflow_run stays keyed by SHA',
+    );
     assert.match(
       deployGateWorkflow,
       /^run-name: Deploy Gate \$\{\{ github\.event\.workflow_run\.head_sha \|\| github\.event_name \}\}$/m,
@@ -693,8 +698,12 @@ describe('CI workflow coverage', () => {
     assert.match(deployGateJob, /pullRequests\(first: 100, states: \[OPEN\], after: \$endCursor\)/);
     assert.match(deployGateJob, /pageInfo \{ hasNextPage endCursor \}/);
     assert.match(deployGateJob, /contexts\(first: 100, after: \$endCursor\)/);
-    assert.match(deployGateJob, /status \{ context\(name: "gate"\) \{ state \} \}/);
+    assert.match(deployGateJob, /status \{ context\(name: "gate"\) \{ state description \} \}/);
+    assert.match(deployGateJob, /stale_terminal_shas=/);
+    assert.match(deployGateJob, /\$gate\.state != "PENDING"/);
     assert.match(deployGateJob, /context\.state == "PENDING"/);
+    assert.match(deployGateJob, /endswith\(\$gate_stamp\) \| not/);
+    assert.match(deployGateJob, /awk '!seen\[\$0\]\+\+'/);
     assert.match(deployGateJob, /context == null/);
     assert.match(
       deployGateJob,

--- a/tests/deploy-gate-status-description.test.mjs
+++ b/tests/deploy-gate-status-description.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   chmodSync,
   mkdirSync,
@@ -24,7 +25,10 @@ const SHA = 'fedcba9876543210fedcba9876543210fedcba98';
 
 // The whole required list, read from the workflow so the test cannot pass by
 // pinning a shorter list than production actually gates on.
-const REQUIRED = JSON.parse(gateStep.run.match(/required='(\[[^']*\])'/)[1]);
+const REQUIRED_LITERAL = gateStep.run.match(/required='(\[[^']*\])'/)[1];
+const REQUIRED = JSON.parse(REQUIRED_LITERAL);
+const GATE_STAMP = `[gate-contract:${createHash('sha256').update(REQUIRED_LITERAL).digest('hex').slice(0, 12)}]`;
+const stamped = (description) => `${description} ${GATE_STAMP}`;
 
 /**
  * Run the gate step against a fabricated check-runs answer.
@@ -45,7 +49,8 @@ function runGate(conclusions, {
   resetAvailable = true,
   statusFailures = 0,
   statusFailureKind = 'generic',
-  sweepState,
+  sweepStatus,
+  sweepStatuses,
 } = {}) {
   const tempDir = mkdtempSync(join(repoRoot, '.tmp-deploy-gate-'));
   const fakeBin = join(tempDir, 'bin');
@@ -54,6 +59,7 @@ function runGate(conclusions, {
   const statusFailuresFile = join(tempDir, 'status-failures');
   const sweepFile = join(tempDir, 'sweep.json');
   const postedFile = join(tempDir, 'posted');
+  const postTargetsFile = join(tempDir, 'post-targets');
   const rejectedFile = join(tempDir, 'rejected');
   const callsFile = join(tempDir, 'calls');
 
@@ -62,6 +68,7 @@ function runGate(conclusions, {
     writeFileSync(failuresFile, String(graphQlFailures));
     writeFileSync(statusFailuresFile, String(statusFailures));
     writeFileSync(postedFile, '');
+    writeFileSync(postTargetsFile, '');
     writeFileSync(rejectedFile, '');
     writeFileSync(callsFile, '');
     const runsFor = (values, timestamp, idBase) => REQUIRED.flatMap((name, index) => values?.[name]
@@ -118,9 +125,17 @@ function runGate(conclusions, {
         },
       }]),
     );
-    const sweepNode = (sha, state) => ({
+    const sweepNode = (sha, status) => ({
       headRefOid: sha,
-      commits: { nodes: [{ commit: { status: { context: state ? { state } : null } } }] },
+      commits: {
+        nodes: [{
+          commit: {
+            status: {
+              context: status,
+            },
+          },
+        }],
+      },
     });
     writeFileSync(
       sweepFile,
@@ -128,7 +143,13 @@ function runGate(conclusions, {
         data: {
           repository: {
             pullRequests: {
-              nodes: Array.from({ length: 100 }, (_, index) => sweepNode(`other-${index}`, 'SUCCESS')),
+              nodes: Array.from(
+                { length: 100 },
+                (_, index) => sweepNode(`other-${index}`, {
+                  state: 'SUCCESS',
+                  description: stamped('All required PR gates passed'),
+                }),
+              ),
               pageInfo: { hasNextPage: true, endCursor: 'page-two' },
             },
           },
@@ -137,7 +158,8 @@ function runGate(conclusions, {
         data: {
           repository: {
             pullRequests: {
-              nodes: [sweepNode(SHA, sweepState)],
+              nodes: sweepStatuses?.map(({ sha, status }) => sweepNode(sha, status))
+                ?? [sweepNode(SHA, sweepStatus ?? null)],
               pageInfo: { hasNextPage: false, endCursor: 'done' },
             },
           },
@@ -216,6 +238,7 @@ function runGate(conclusions, {
         '  *"/statuses/"*)',
         '    state=""',
         '    description=""',
+        '    target_sha=${2##*/}',
         '    for arg in "$@"; do',
         '      case "$arg" in',
         '        state=*) state=${arg#state=} ;;',
@@ -239,6 +262,7 @@ function runGate(conclusions, {
         '      exit 1',
         '    fi',
         '    printf \'%s|%s\\n\' "$state" "$description" >> "$FAKE_POSTED"',
+        '    printf \'%s\\n\' "$target_sha" >> "$FAKE_POST_TARGETS"',
         '    exit 0',
         '    ;;',
         'esac',
@@ -277,6 +301,7 @@ function runGate(conclusions, {
         FAKE_FAILURE_KIND: graphQlFailureKind,
         FAKE_FAILURES: failuresFile,
         FAKE_POSTED: postedFile,
+        FAKE_POST_TARGETS: postTargetsFile,
         FAKE_REJECTED: rejectedFile,
         FAKE_NOW: String(Date.parse('2026-08-12T12:30:00Z') / 1000),
         FAKE_RESET_AT: String(Date.parse('2026-08-12T12:30:10Z') / 1000),
@@ -289,7 +314,7 @@ function runGate(conclusions, {
         PATH: `${fakeBin}:${process.env.PATH}`,
         REPO: 'koala73/worldmonitor',
         RUNNER_TEMP: tempDir,
-        SHA: sweepState === undefined ? SHA : '',
+        SHA: sweepStatus === undefined && sweepStatuses === undefined ? SHA : '',
       },
     });
 
@@ -304,6 +329,7 @@ function runGate(conclusions, {
     return {
       ...result,
       calls: readFileSync(callsFile, 'utf8').split('\n').filter(Boolean),
+      postTargets: readFileSync(postTargetsFile, 'utf8').split('\n').filter(Boolean),
       posted: parse(postedFile),
       rejected: parse(rejectedFile),
     };
@@ -336,7 +362,10 @@ describe('deploy gate commit-status description', () => {
     assert.equal(result.posted[0].state, 'pending');
     assert.ok(result.posted[0].description.length <= 140);
     assert.match(result.posted[0].description, new RegExp(`Waiting for required PR gates \\(${REQUIRED.length}\\):`));
-    assert.match(result.posted[0].description, /\.\.\.$/, 'a truncated description must say it was cut');
+    assert.ok(
+      result.posted[0].description.endsWith(`... ${GATE_STAMP}`),
+      'a truncated description must say it was cut and preserve the contract stamp',
+    );
     assert.deepEqual(
       result.calls,
       [
@@ -372,8 +401,8 @@ describe('deploy gate commit-status description', () => {
 
     assert.equal(result.status, 0, result.stderr);
     assert.equal(result.posted[0].state, 'pending');
-    assert.equal(result.posted[0].description, 'Waiting for required PR gates (2): unit,biome');
-    assert.doesNotMatch(result.posted[0].description, /\.\.\.$/, 'a description that fits must not be cut');
+    assert.equal(result.posted[0].description, stamped('Waiting for required PR gates (2): unit,biome'));
+    assert.doesNotMatch(result.posted[0].description, /\.\.\. /, 'a description that fits must not be cut');
   });
 
   it('still posts success when everything passed or skipped', () => {
@@ -383,7 +412,7 @@ describe('deploy gate commit-status description', () => {
 
     assert.equal(result.status, 0, result.stderr);
     assert.deepEqual(result.posted, [
-      { state: 'success', description: 'All required PR gates passed' },
+      { state: 'success', description: stamped('All required PR gates passed') },
     ]);
     assert.deepEqual(result.calls, ['graphql-check-page', 'graphql-check-page', 'status:success']);
   });
@@ -403,20 +432,111 @@ describe('deploy gate commit-status description', () => {
 
     assert.notEqual(crashed.status, 0, 'the forced API failure must actually crash the evaluation');
     assert.deepEqual(crashed.posted, [
-      { state: 'pending', description: 'Deploy Gate could not evaluate; retry scheduled' },
+      { state: 'pending', description: stamped('Deploy Gate could not evaluate; retry scheduled') },
     ]);
 
-    const healed = runGate(conclusionsFor('success'), { sweepState: 'PENDING' });
+    const healed = runGate(conclusionsFor('success'), {
+      sweepStatus: {
+        state: 'PENDING',
+        description: stamped('Deploy Gate could not evaluate; retry scheduled'),
+      },
+    });
     assert.equal(healed.status, 0, healed.stderr);
     assert.deepEqual(healed.posted.at(-1), {
       state: 'success',
-      description: 'All required PR gates passed',
+      description: stamped('All required PR gates passed'),
     });
     assert.deepEqual(
       healed.calls.slice(0, 2),
       ['graphql-sweep-page', 'graphql-sweep-page'],
       'a pending gate beyond the first 100 open PRs must enter recovery',
     );
+  });
+
+  it('invalidates and evaluates stale contracts before current pending gates', () => {
+    const staleSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const pendingSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const oldStamp = '[gate-contract:001122334455]';
+    const result = runGate(conclusionsFor('success'), {
+      // Put pending first in the API response and duplicate the stale SHA. The
+      // workflow must still invalidate/evaluate stale first, exactly once.
+      sweepStatuses: [
+        {
+          sha: pendingSha,
+          status: {
+            state: 'PENDING',
+            description: stamped('Deploy Gate could not evaluate; retry scheduled'),
+          },
+        },
+        {
+          sha: staleSha,
+          status: {
+            state: 'SUCCESS',
+            description: `All required PR gates passed ${oldStamp}`,
+          },
+        },
+        {
+          sha: staleSha,
+          status: {
+            state: 'SUCCESS',
+            description: `All required PR gates passed ${oldStamp}`,
+          },
+        },
+      ],
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.calls, [
+      'graphql-sweep-page',
+      'graphql-sweep-page',
+      'status:pending',
+      'graphql-check-page',
+      'graphql-check-page',
+      'status:success',
+      'graphql-check-page',
+      'graphql-check-page',
+      'status:success',
+    ]);
+    assert.deepEqual(result.posted, [
+      {
+        state: 'pending',
+        description: stamped('Required PR gate contract changed; re-evaluation scheduled'),
+      },
+      { state: 'success', description: stamped('All required PR gates passed') },
+      { state: 'success', description: stamped('All required PR gates passed') },
+    ]);
+    assert.deepEqual(result.postTargets, [staleSha, staleSha, pendingSha]);
+  });
+
+  it('does not sleep or retry a stale contract after invalidating it', () => {
+    const conclusions = conclusionsFor('success');
+    conclusions.unit = 'pending';
+    const result = runGate(conclusions, {
+      sweepStatus: {
+        state: 'SUCCESS',
+        description: 'All required PR gates passed [gate-contract:001122334455]',
+      },
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.calls, [
+      'graphql-sweep-page',
+      'graphql-sweep-page',
+      'status:pending',
+      'graphql-check-page',
+      'graphql-check-page',
+      'status:pending',
+    ]);
+    assert.deepEqual(result.posted, [
+      {
+        state: 'pending',
+        description: stamped('Required PR gate contract changed; re-evaluation scheduled'),
+      },
+      {
+        state: 'pending',
+        description: stamped('Waiting for required PR gates (1): unit'),
+      },
+    ]);
   });
 
   it('backs off to the installation reset and retries a rate-limited read once', () => {
@@ -444,7 +564,7 @@ describe('deploy gate commit-status description', () => {
 
     assert.notEqual(result.status, 0, 'a persistent rate limit must fail the evaluation');
     assert.deepEqual(result.posted, [
-      { state: 'pending', description: 'Deploy Gate could not evaluate; retry scheduled' },
+      { state: 'pending', description: stamped('Deploy Gate could not evaluate; retry scheduled') },
     ]);
   });
 
@@ -462,7 +582,7 @@ describe('deploy gate commit-status description', () => {
       'status:pending',
     ]);
     assert.deepEqual(result.posted, [
-      { state: 'pending', description: 'Deploy Gate could not evaluate; retry scheduled' },
+      { state: 'pending', description: stamped('Deploy Gate could not evaluate; retry scheduled') },
     ]);
   });
 
@@ -477,7 +597,7 @@ describe('deploy gate commit-status description', () => {
       'status:pending',
     ]);
     assert.deepEqual(result.posted, [
-      { state: 'pending', description: 'Deploy Gate could not evaluate; retry scheduled' },
+      { state: 'pending', description: stamped('Deploy Gate could not evaluate; retry scheduled') },
     ]);
   });
 
@@ -497,7 +617,7 @@ describe('deploy gate commit-status description', () => {
       'status:success',
     ]);
     assert.deepEqual(result.posted, [
-      { state: 'success', description: 'All required PR gates passed' },
+      { state: 'success', description: stamped('All required PR gates passed') },
     ]);
   });
 
@@ -508,20 +628,20 @@ describe('deploy gate commit-status description', () => {
     assert.deepEqual(stranded.posted, []);
     assert.deepEqual(stranded.calls.slice(-2), ['status:success', 'status:pending']);
 
-    const healed = runGate(conclusionsFor('success'), { sweepState: null });
+    const healed = runGate(conclusionsFor('success'), { sweepStatus: null });
     assert.equal(healed.status, 0, healed.stderr);
     assert.deepEqual(healed.calls.slice(0, 2), ['graphql-sweep-page', 'graphql-sweep-page']);
     assert.equal(healed.calls[2], 'rest-failed-runs-page');
     assert.deepEqual(healed.posted.at(-1), {
       state: 'success',
-      description: 'All required PR gates passed',
+      description: stamped('All required PR gates passed'),
     });
   });
 
   it('does not recover a missing gate without a matching recent failed run', () => {
     const result = runGate(conclusionsFor('success'), {
       failedRunSha: '0123456789abcdef0123456789abcdef01234567',
-      sweepState: null,
+      sweepStatus: null,
     });
 
     assert.equal(result.status, 0, result.stderr);
@@ -536,7 +656,7 @@ describe('deploy gate commit-status description', () => {
   it('does not recover a missing gate from a stale failed run', () => {
     const result = runGate(conclusionsFor('success'), {
       failedRunCreatedAt: '2026-08-10T12:15:00Z',
-      sweepState: null,
+      sweepStatus: null,
     });
 
     assert.equal(result.status, 0, result.stderr);

--- a/tests/deploy-gate-status-description.test.mjs
+++ b/tests/deploy-gate-status-description.test.mjs
@@ -391,6 +391,10 @@ describe('deploy gate commit-status description', () => {
     assert.equal(result.posted[0].state, 'failure');
     assert.ok(result.posted[0].description.length <= 140);
     assert.match(result.posted[0].description, new RegExp(`Required PR gates did not pass \\(${REQUIRED.length}\\):`));
+    assert.ok(
+      result.posted[0].description.endsWith(`... ${GATE_STAMP}`),
+      'a truncated failure description must preserve the contract stamp',
+    );
   });
 
   it('keeps the whole list when it fits', () => {
@@ -536,6 +540,81 @@ describe('deploy gate commit-status description', () => {
         state: 'pending',
         description: stamped('Waiting for required PR gates (1): unit'),
       },
+    ]);
+  });
+
+  it('invalidates stale contracts before missing-status recovery reads', () => {
+    const staleSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const missingSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const result = runGate(conclusionsFor('success'), {
+      failedRunSha: missingSha,
+      sweepStatuses: [
+        {
+          sha: staleSha,
+          status: {
+            state: 'SUCCESS',
+            description: 'All required PR gates passed [gate-contract:001122334455]',
+          },
+        },
+        { sha: missingSha, status: null },
+      ],
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(
+      result.calls.indexOf('status:pending') < result.calls.indexOf('rest-failed-runs-page'),
+      'stale success must become fail-closed before the missing-status API lookup can wait or fail',
+    );
+    assert.deepEqual(result.postTargets.slice(0, 3), [staleSha, staleSha, missingSha]);
+  });
+
+  it('retries every stale contract whose first invalidation write fails', () => {
+    const firstStaleSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const secondStaleSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const result = runGate(conclusionsFor('success'), {
+      statusFailures: 2,
+      sweepStatuses: [
+        {
+          sha: firstStaleSha,
+          status: {
+            state: 'SUCCESS',
+            description: 'All required PR gates passed [gate-contract:001122334455]',
+          },
+        },
+        {
+          sha: secondStaleSha,
+          status: {
+            state: 'SUCCESS',
+            description: 'All required PR gates passed [gate-contract:001122334455]',
+          },
+        },
+      ],
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.calls.slice(0, 6), [
+      'graphql-sweep-page',
+      'graphql-sweep-page',
+      'status:pending',
+      'status:pending',
+      'status:pending',
+      'status:pending',
+    ]);
+    assert.deepEqual(result.posted.slice(0, 2), [
+      {
+        state: 'pending',
+        description: stamped('Required PR gate contract changed; re-evaluation scheduled'),
+      },
+      {
+        state: 'pending',
+        description: stamped('Required PR gate contract changed; re-evaluation scheduled'),
+      },
+    ]);
+    assert.deepEqual(result.postTargets, [
+      firstStaleSha,
+      secondStaleSha,
+      firstStaleSha,
+      secondStaleSha,
     ]);
   });
 


### PR DESCRIPTION
## Summary

A previously green `gate` status now stops being authoritative when the required-check list changes. Each verdict carries a deterministic contract stamp, and the scheduled recovery sweep treats any mismatched terminal verdict as stale.

The sweep first moves every stale terminal verdict to a current, fail-closed pending status. It then processes stale candidates before already-pending candidates and avoids the 60-second second poll for stale entries, so a busy or cancelled sweep cannot leave an old success mergeable. Scheduled and manual sweeps also share one concurrency group.

Fixes #5851.

## Validation

- Mutation proof: the new stale-success regression failed before the workflow change because the scheduled sweep performed discovery only.
- Focused workflow tests passed after the final rebase: 42 passed, 0 failed.
- The pre-push gate passed, including typecheck, Unicode safety, changed tests, and version sync.
- `npm run typecheck` passed. `npm run lint` passed with existing diagnostics outside the changed files; the safe HTML guard passed.
- The broad `npm run test:data` run was stopped after process inspection showed only the slow Company Monitoring blind-evaluation file remained. That exact file then passed in isolation: 42 passed, 0 failed, in about 25.5 minutes.

## Post-Deploy Monitoring & Validation

- **Owner:** the repository maintainer who merges this PR. Codex can run the verification on request.
- **Window:** the first two scheduled Deploy Gate runs after merge, up to 60 minutes.
- **Logs:** inspect the `Deploy Gate` workflow for `sweep: re-evaluating pending or stale gate on:` and any `Could not invalidate stale gate statuses` or rate-limit errors.
- **Healthy:** legacy unstamped terminal statuses move to a current stamped pending or final verdict; each scheduled run completes before the next 30-minute tick; scheduled and manual sweeps do not overlap.
- **Failure:** an unstamped success remains after one completed sweep, the same stale cohort repeats without progress, runs are repeatedly cancelled, or API-limit errors prevent invalidation.
- **Mitigation:** run the workflow manually after the active sweep finishes and keep affected heads pending. Revert this commit only if the expanded sweep causes harmful API pressure, then rerun affected PR checks so branch protection remains fail-closed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.6--sol-000000)
