### PR TITLE
fix(resilience): activate non-DRS debt imputation

### DIFF
--- a/docs/methodology/financial-system-exposure.md
+++ b/docs/methodology/financial-system-exposure.md
@@ -333,7 +333,7 @@ redis-cli GET 'economic:bis-lbs:v1' | jq '.countries.BR'
 
 If any of these return null or empty, **do NOT flip the flag** — flipping with absent envelopes throws `ResilienceConfigurationError` on every `/api/resilience/*` request and stamps every country's `financialSystemExposure` as `imputationClass='source-failure'`. The fix is recoverable (flip the flag back OFF, fix the seeder, re-run, retry) but produces user-visible Sentry noise during the gap.
 
-The active non-DRS path also requires the WB debt contract envelope to be schema v2. Confirm the canonical value has `_seed.schemaVersion >= 2` and at least 40 valid unique entries in `data.nonDrsCountryCodes`. A schema-v1 payload is now a fail-closed configuration error instead of silently disabling the imputation for every eligible country.
+The active non-DRS path also requires the WB debt contract envelope to be schema v2. The scorer preserves this canonical envelope long enough to enforce numeric `_seed.schemaVersion >= 2`, then validates at least 40 valid unique entries in `data.nonDrsCountryCodes`. A schema-v1 payload is now a fail-closed configuration error instead of silently disabling the imputation for every eligible country.
 
 ## Alternatives considered (and rejected)
 

--- a/docs/methodology/financial-system-exposure.md
+++ b/docs/methodology/financial-system-exposure.md
@@ -73,7 +73,7 @@ On the 2026-08-11 production-shaped fixture, Chad moves from **67 at coverage 1.
 
 **Why `not-applicable` and not `unmonitored`**: non-participation in the DRS means there is no reported short-term external commercial debt to roll over. That is a mild positive, not an unknown, so the class that describes it is "the indicator does not apply here".
 
-**Discriminator**: the World Bank country catalog's `lendingType=LNX` classification is the explicit non-borrower signal. A missing DRS row is never enough by itself, because an accepted annual payload can still omit an eligible borrower. The imputation also requires a valid BIS CBS row. Payload schema v1 did not carry `nonDrsCountryCodes`; the scorer remains backward-compatible with that payload but treats eligibility as unknown, so the slot drops instead of receiving a positive imputation until schema v2 is seeded.
+**Discriminator**: the World Bank country catalog's `lendingType=LNX` classification is the explicit non-borrower signal. A missing DRS row is never enough by itself, because an accepted annual payload can still omit an eligible borrower. The imputation also requires a valid BIS CBS row. Payload schema v1 did not carry `nonDrsCountryCodes`; the active scorer now fails closed unless this schema-v2 field contains at least 40 valid unique codes, matching the seeder's producer contract.
 
 This typed LNX/BIS imputation counts as a resolving component for FATF singleton handling. It is explicit `not-applicable` evidence with score 75 and partial certainty, not three-source absence, and therefore cannot produce a perfect 100-point dimension through the imputed-debt path.
 
@@ -283,6 +283,10 @@ Production already runs with the flag enabled, as tracked in #6511, so the OFF a
 
 This live measurement was **degraded** by a WGI source-failure state that affected the same governance-related dimensions in both arms. The paired movement result is still a genuine same-run flag comparison, but it is not an undegraded production-health snapshot; do not use it to claim WGI health or final post-deploy acceptance.
 
+**#6519 schema-v1 → schema-v2 activation (2026-08-12, 196 scorable countries):** the fail-closed WB IDS seeder published 119 debt rows and 72 unique `lendingType=LNX` codes. The subsequent production ranking refresh moved **48** of the 71 countries with a missing IDS row and a valid BIS row from coverage 0.65 to 0.76 with `imputedWeight=0.35`. The other 23 are not confirmed `LNX` and correctly remain unknown; row absence alone cannot trigger the imputation. Across the full ranking, Spearman was **0.99997**, **196/196 (100%)** moved by less than 3 points, the maximum absolute movement was **0.35**, no country moved more than 12, and headline eligibility did not change. The committed capture is [`resilience-financial-system-exposure-non-drs-activation-2026-08-12.json`](../snapshots/resilience-financial-system-exposure-non-drs-activation-2026-08-12.json).
+
+The debt slot uses the `not-applicable` imputation class. The published dimension-level `imputationClass` remains `null` because `weightedBlend` reports a class only for a fully imputed dimension; the same result contains observed BIS and FATF inputs. `imputedWeight=0.35` is the published proof that the debt slot activated.
+
 ## Data sources and licensing
 
 | Component | Source | License |
@@ -328,6 +332,8 @@ redis-cli GET 'economic:bis-lbs:v1' | jq '.countries.BR'
 ```
 
 If any of these return null or empty, **do NOT flip the flag** — flipping with absent envelopes throws `ResilienceConfigurationError` on every `/api/resilience/*` request and stamps every country's `financialSystemExposure` as `imputationClass='source-failure'`. The fix is recoverable (flip the flag back OFF, fix the seeder, re-run, retry) but produces user-visible Sentry noise during the gap.
+
+The active non-DRS path also requires the WB debt contract envelope to be schema v2. Confirm the canonical value has `_seed.schemaVersion >= 2` and at least 40 valid unique entries in `data.nonDrsCountryCodes`. A schema-v1 payload is now a fail-closed configuration error instead of silently disabling the imputation for every eligible country.
 
 ## Alternatives considered (and rejected)
 

--- a/docs/snapshots/resilience-financial-system-exposure-non-drs-activation-2026-08-12.json
+++ b/docs/snapshots/resilience-financial-system-exposure-non-drs-activation-2026-08-12.json
@@ -1,0 +1,155 @@
+{
+  "artifactVersion": 1,
+  "issue": 6519,
+  "capturedAt": "2026-08-12T15:50:39.328Z",
+  "source": "Live production Redis before and after a fail-closed seed-wb-external-debt run, followed by the documented seed-resilience-scores force-refresh path.",
+  "debtPayload": {
+    "key": "economic:wb-external-debt:v1",
+    "before": {
+      "capturedAt": "2026-08-12T15:45:59.860Z",
+      "fetchedAt": "2026-08-01T08:04:36.606Z",
+      "schemaVersion": 1,
+      "recordCount": 119,
+      "nonDrsCountryCodeCount": null
+    },
+    "activationRun": {
+      "runId": "1786549576493-63vjcc",
+      "completedAt": "2026-08-12T15:46:18.279Z",
+      "state": "OK",
+      "recordCount": 119,
+      "payloadBytes": 19084
+    },
+    "verifiedAfter": {
+      "verifiedAt": "2026-08-12T15:46:39.785Z",
+      "fetchedAt": "2026-08-12T15:46:17.184Z",
+      "schemaVersion": 2,
+      "state": "OK",
+      "recordCount": 119,
+      "countryCount": 119,
+      "nonDrsCountryCodeCount": 72,
+      "nonDrsCountryCodesUnique": true,
+      "nonDrsCountryCodesValidIso2": true
+    }
+  },
+  "rankingTransition": {
+    "key": "resilience:ranking:v27",
+    "beforeFetchedAt": "2026-08-12T15:11:29.976Z",
+    "afterFetchedAt": "2026-08-12T15:49:47.770Z",
+    "countryOverlap": 196,
+    "spearman": 0.99997,
+    "countriesWithAbsDeltaUnder3": 196,
+    "countriesWithAbsDeltaUnder3Pct": 100,
+    "maxAbsDelta": 0.35,
+    "countriesWithAbsDeltaOver12": [],
+    "headlineEligibilityChanges": [],
+    "verdict": "PASS"
+  },
+  "nonDrsActivation": {
+    "preSeedMissingDebtWithBisCount": 71,
+    "confirmedLnxActivatedCount": 48,
+    "unconfirmedLnxRemainedDroppedCount": 23,
+    "activatedContract": {
+      "coverageBefore": 0.65,
+      "coverageAfter": 0.76,
+      "imputedWeightBefore": 0,
+      "imputedWeightAfter": 0.35,
+      "slotImputationClass": "not-applicable",
+      "publishedAggregateImputationClass": null
+    },
+    "aggregateImputationClassNote": "weightedBlend reports a dimension-level imputationClass only when the dimension is fully imputed. These countries retain observed BIS and FATF inputs, so the published aggregate class is null while imputedWeight=0.35 proves the debt slot used the configured not-applicable imputation.",
+    "activatedCountryCodes": [
+      "AD",
+      "AE",
+      "AT",
+      "AU",
+      "BE",
+      "BH",
+      "BN",
+      "BS",
+      "CA",
+      "CH",
+      "CY",
+      "CZ",
+      "DE",
+      "DK",
+      "EE",
+      "ES",
+      "FI",
+      "FR",
+      "GB",
+      "GR",
+      "HK",
+      "HU",
+      "IE",
+      "IL",
+      "IS",
+      "IT",
+      "JP",
+      "KR",
+      "KW",
+      "LI",
+      "LT",
+      "LU",
+      "LV",
+      "MO",
+      "MT",
+      "NL",
+      "NO",
+      "NZ",
+      "OM",
+      "PT",
+      "QA",
+      "SA",
+      "SE",
+      "SG",
+      "SI",
+      "SK",
+      "SM",
+      "US"
+    ],
+    "unconfirmedLnxCountryCodes": [
+      "AG",
+      "BB",
+      "CL",
+      "CR",
+      "FM",
+      "GQ",
+      "HR",
+      "KI",
+      "KN",
+      "LY",
+      "MH",
+      "MY",
+      "NA",
+      "NR",
+      "PA",
+      "PL",
+      "PW",
+      "RO",
+      "SC",
+      "TT",
+      "TV",
+      "UY",
+      "VE"
+    ]
+  },
+  "representativeCountries": {
+    "US": {
+      "before": { "overallScore": 59.22, "dimensionScore": 90, "coverage": 0.65, "imputedWeight": 0 },
+      "after": { "overallScore": 59.19, "dimensionScore": 85, "coverage": 0.76, "imputedWeight": 0.35 }
+    },
+    "LU": {
+      "before": { "overallScore": 66.93, "dimensionScore": 70, "coverage": 0.65, "imputedWeight": 0 },
+      "after": { "overallScore": 66.95, "dimensionScore": 72, "coverage": 0.76, "imputedWeight": 0.35 }
+    },
+    "CH": {
+      "before": { "overallScore": 77.71, "dimensionScore": 84, "coverage": 0.65, "imputedWeight": 0 },
+      "after": { "overallScore": 77.36, "dimensionScore": 81, "coverage": 0.76, "imputedWeight": 0.35 }
+    },
+    "SG": {
+      "before": { "overallScore": 57.91, "dimensionScore": 70, "coverage": 0.65, "imputedWeight": 0 },
+      "after": { "overallScore": 58.07, "dimensionScore": 72, "coverage": 0.76, "imputedWeight": 0.35 }
+    }
+  },
+  "scopeCorrection": "The pre-seed 71-country bucket meant no WB IDS row plus a valid BIS row. Only 48 of those countries are explicitly classified as lendingType=LNX by the World Bank catalog. The other 23 must remain unknown; imputing them from row absence alone would restore the partial-payload defect fixed in PR #6463."
+}

--- a/scripts/seed-wb-external-debt.mjs
+++ b/scripts/seed-wb-external-debt.mjs
@@ -214,13 +214,11 @@ export function declareRecords(data) {
   return Object.keys(data?.countries || {}).length;
 }
 
-export { CANONICAL_KEY, CACHE_TTL, fetchWbExternalDebt };
-
-if (process.argv[1]?.endsWith('seed-wb-external-debt.mjs')) {
-  runSeed('economic', 'wb-external-debt', CANONICAL_KEY, fetchWbExternalDebt, {
+export function createWbExternalDebtSeedOptions(now = new Date()) {
+  return {
     validateFn: validate,
     ttlSeconds: CACHE_TTL,
-    sourceVersion: `wb-ids-${new Date().getFullYear()}`,
+    sourceVersion: `wb-ids-${now.getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
     // Empty result = real upstream failure (floor is 80 LMICs). Without this,
     // a transient WB outage would refresh seed-meta on a tiny payload and
@@ -231,7 +229,19 @@ if (process.argv[1]?.endsWith('seed-wb-external-debt.mjs')) {
     maxStaleMin: 100800,
     contentMeta: wbCountryDictContentMeta,
     maxContentAgeMin: MAX_CONTENT_AGE_MIN,
-  }).catch((err) => {
+  };
+}
+
+export { CANONICAL_KEY, CACHE_TTL, fetchWbExternalDebt };
+
+if (process.argv[1]?.endsWith('seed-wb-external-debt.mjs')) {
+  runSeed(
+    'economic',
+    'wb-external-debt',
+    CANONICAL_KEY,
+    fetchWbExternalDebt,
+    createWbExternalDebtSeedOptions(),
+  ).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);
     process.exit(1);

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -72,7 +72,11 @@ export type CacheReadResult = { status: 'hit'; value: unknown } | { status: 'mis
  * seed-owned keys written unprefixed by the Railway seeders, mirroring
  * `getCachedJson`'s own raw flag. Leave false for keys this app writes.
  */
-export async function readCachedJson(key: string, raw = false): Promise<CacheReadResult> {
+async function readCachedJsonInternal(
+  key: string,
+  raw = false,
+  unwrapSeedEnvelope = true,
+): Promise<CacheReadResult> {
   if (process.env.LOCAL_API_MODE === 'tauri-sidecar') {
     try {
       const { sidecarCacheGet } = await import('./sidecar-cache');
@@ -99,13 +103,18 @@ export async function readCachedJson(key: string, raw = false): Promise<CacheRea
     // Envelope-aware by default — RPC consumers get the bare payload regardless
     // of whether the writer has migrated to contract mode. Legacy shapes pass
     // through unchanged (unwrapEnvelope returns {_seed: null, data: raw}).
+    const parsed = JSON.parse(data.result);
     return {
       status: 'hit',
-      value: unwrapEnvelope(JSON.parse(data.result)).data,
+      value: unwrapSeedEnvelope ? unwrapEnvelope(parsed).data : parsed,
     };
   } catch (error) {
     return { status: 'error', error };
   }
+}
+
+export async function readCachedJson(key: string, raw = false): Promise<CacheReadResult> {
+  return readCachedJsonInternal(key, raw, true);
 }
 
 function logCacheReadError(key: string, err: unknown): void {
@@ -192,6 +201,14 @@ export async function getCachedRawString(key: string): Promise<string | null> {
 
 export async function getCachedJson(key: string, raw = false): Promise<unknown | null> {
   const read = await readCachedJson(key, raw);
+  if (read.status === 'hit') return read.value;
+  if (read.status === 'error') logCacheReadError(key, read.error);
+  return null;
+}
+
+/** Read a JSON value without discarding its runSeed contract metadata. */
+export async function getCachedEnvelopeJson(key: string, raw = false): Promise<unknown | null> {
+  const read = await readCachedJsonInternal(key, raw, false);
   if (read.status === 'hit') return read.value;
   if (read.status === 'error') logCacheReadError(key, read.error);
   return null;

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -2028,8 +2028,8 @@ export async function scoreFinancialSystemExposure(
   const debtEnvelope = readWbExternalDebtEnvelope(debtRaw);
   if (debtEnvelope == null) {
     throw new ResilienceConfigurationError(
-      `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=true but ${RESILIENCE_WB_EXTERNAL_DEBT_KEY} data envelope is absent or malformed after a healthy seed-meta preflight. ` +
-        'Re-run seed-wb-external-debt and confirm the payload includes countries before scoring.',
+      `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=true requires ${RESILIENCE_WB_EXTERNAL_DEBT_KEY} schema v2 with valid countries and nonDrsCountryCodes after a healthy seed-meta preflight. ` +
+        'Re-run seed-wb-external-debt and confirm the published envelope schema before scoring.',
       [RESILIENCE_WB_EXTERNAL_DEBT_KEY],
     );
   }
@@ -2188,22 +2188,21 @@ function readWbExternalDebtEnvelope(raw: unknown): WbExternalDebtEnvelope | null
   }
 
   const rawNonDrsCountryCodes = (raw as { nonDrsCountryCodes?: unknown }).nonDrsCountryCodes;
-  if (
-    rawNonDrsCountryCodes != null
-    && (
-      !Array.isArray(rawNonDrsCountryCodes)
-      || rawNonDrsCountryCodes.some((code) => typeof code !== 'string' || !/^[A-Z]{2}$/.test(code))
-      || new Set(rawNonDrsCountryCodes).size !== rawNonDrsCountryCodes.length
-    )
-  ) {
-    return null;
+  // Match the producer's fail-closed floor so an empty or truncated cohort
+  // cannot preserve the schema shape while silently disabling imputation.
+  if (!Array.isArray(rawNonDrsCountryCodes) || rawNonDrsCountryCodes.length < 40) return null;
+
+  const nonDrsCountryCodes = new Set<string>();
+  for (const code of rawNonDrsCountryCodes) {
+    if (typeof code !== 'string' || !/^[A-Z]{2}$/.test(code) || nonDrsCountryCodes.has(code)) return null;
+    nonDrsCountryCodes.add(code);
   }
 
   return {
     countries,
-    // Backward-compatible with the last v1 payload: until the v2 seeder runs,
-    // unknown eligibility stays null/drop rather than receiving an imputation.
-    nonDrsCountryCodes: new Set((rawNonDrsCountryCodes ?? []) as string[]),
+    // The active scorer requires schema v2. Accepting the former v1 shape here
+    // silently disables the non-DRS imputation for every eligible country.
+    nonDrsCountryCodes,
   };
 }
 

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -2,7 +2,8 @@ import countryNames from '../../../../shared/country-names.json';
 import iso2ToIso3Json from '../../../../shared/iso2-to-iso3.json';
 import wgiIndicatorKeys from '../../../../shared/wgi-indicator-keys.json';
 import { normalizeCountryToken } from '../../../_shared/country-token';
-import { getCachedJson, readCachedJson } from '../../../_shared/redis';
+import { getCachedEnvelopeJson, getCachedJson, readCachedJson } from '../../../_shared/redis';
+import { unwrapEnvelope } from '../../../_shared/seed-envelope';
 import { classifyDimensionFreshness, readFreshnessMap, resolveSeedMetaKey } from './_dimension-freshness';
 import { getLanguageCoverageFactor } from './_language-coverage';
 import { MACRO_FISCAL_INDICATOR_WEIGHTS } from './_macro-fiscal-weights';
@@ -318,6 +319,7 @@ const RESILIENCE_TRADE_RESTRICTIONS_KEY = 'trade:restrictions:v1:tariff-overview
 const RESILIENCE_TRADE_BARRIERS_KEY = 'trade:barriers:v1:tariff-gap:50';
 // plan 2026-04-25-004 Phase 2: financialSystemExposure component seed keys.
 const RESILIENCE_WB_EXTERNAL_DEBT_KEY = 'economic:wb-external-debt:v1';
+const RESILIENCE_WB_EXTERNAL_DEBT_SCHEMA_VERSION = 2;
 const RESILIENCE_BIS_LBS_KEY = 'economic:bis-lbs:v1';
 const RESILIENCE_FATF_LISTING_KEY = 'economic:fatf-listing:v1';
 const RESILIENCE_CYBER_KEY = 'cyber:threats:v2';
@@ -1016,7 +1018,13 @@ async function readSeedMetaResilient(key: string): Promise<unknown | null> {
 }
 
 async function defaultSeedReader(key: string): Promise<unknown | null> {
-  return isSeedMetaKey(key) ? readSeedMetaResilient(key) : getCachedJson(key, true);
+  if (isSeedMetaKey(key)) return readSeedMetaResilient(key);
+  // Preserve the contract envelope for WB debt so its numeric schemaVersion
+  // remains available to the fail-closed scorer. Other seed readers retain
+  // the established bare-data behavior.
+  return key === RESILIENCE_WB_EXTERNAL_DEBT_KEY
+    ? getCachedEnvelopeJson(key, true)
+    : getCachedJson(key, true);
 }
 
 interface MemoizedSeedReaderOptions {
@@ -2182,12 +2190,22 @@ interface WbExternalDebtEnvelope {
 
 function readWbExternalDebtEnvelope(raw: unknown): WbExternalDebtEnvelope | null {
   if (raw == null || typeof raw !== 'object') return null;
-  const countries = (raw as { countries?: Record<string, unknown> }).countries;
+  const unwrapped = unwrapEnvelope(raw);
+  const schemaVersion = unwrapped._seed?.schemaVersion
+    ?? (raw as { schemaVersion?: unknown }).schemaVersion;
+  if (
+    typeof schemaVersion !== 'number'
+    || !Number.isInteger(schemaVersion)
+    || schemaVersion < RESILIENCE_WB_EXTERNAL_DEBT_SCHEMA_VERSION
+  ) return null;
+  const payload = unwrapped.data;
+  if (payload == null || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const countries = (payload as { countries?: Record<string, unknown> }).countries;
   if (!countries || typeof countries !== 'object' || Array.isArray(countries) || Object.keys(countries).length === 0) {
     return null;
   }
 
-  const rawNonDrsCountryCodes = (raw as { nonDrsCountryCodes?: unknown }).nonDrsCountryCodes;
+  const rawNonDrsCountryCodes = (payload as { nonDrsCountryCodes?: unknown }).nonDrsCountryCodes;
   // Match the producer's fail-closed floor so an empty or truncated cohort
   // cannot preserve the schema shape while silently disabling imputation.
   if (!Array.isArray(rawNonDrsCountryCodes) || rawNonDrsCountryCodes.length < 40) return null;

--- a/tests/chat-analyst.test.mts
+++ b/tests/chat-analyst.test.mts
@@ -21,7 +21,7 @@ import {
   extractKeywords,
 } from '../server/worldmonitor/intelligence/v1/chat-analyst-context.ts';
 import { assembleBriefStoryContext } from '../server/worldmonitor/intelligence/v1/brief-story-context.ts';
-import { readCachedJson, __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
+import { getCachedEnvelopeJson, readCachedJson, __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
 import {
   CII_RISK_SCORE_CACHE_KEYS,
   ELECTRICITY_INDEX_KEY,
@@ -1110,6 +1110,31 @@ describe('buildHeadlinesFromGdeltIntel — #5856 review round', () => {
 });
 
 describe('readCachedJson — key prefixing and envelope fidelity (#5856 review round)', () => {
+  it('can preserve contract metadata for schema-aware consumers', async () => {
+    const originalFetch = globalThis.fetch;
+    const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    const enveloped = {
+      _seed: { fetchedAt: NOW_MS, recordCount: 1, sourceVersion: 'wb-ids-test', schemaVersion: 2, state: 'OK' },
+      data: { countries: { BR: { value: 10, year: 2024 } } },
+    };
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      result: JSON.stringify(enveloped),
+    }), { status: 200 })) as typeof fetch;
+    try {
+      const result = await getCachedEnvelopeJson('economic:wb-external-debt:v1', true);
+      assert.deepEqual(result, enveloped);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+      else process.env.UPSTASH_REDIS_REST_URL = originalUrl;
+      if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
+    }
+  });
+
   it('raw=true reads the unprefixed seed key while raw=false applies the deployment prefix', async () => {
     const originalFetch = globalThis.fetch;
     const originalEnv = {

--- a/tests/helpers/resilience-finsys-fixtures.mts
+++ b/tests/helpers/resilience-finsys-fixtures.mts
@@ -122,6 +122,7 @@ export function createFinSysFixtureReader(
   nowMs: number = Date.now(),
 ): ResilienceSeedReader {
   const debt = {
+    schemaVersion: 2,
     countries: { ...FINSYS_DEBT_FIXTURE, ...(overrides.debt ?? {}) },
     nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES,
   };

--- a/tests/helpers/resilience-finsys-fixtures.mts
+++ b/tests/helpers/resilience-finsys-fixtures.mts
@@ -7,12 +7,11 @@
 //   economic:bis-lbs:v1           (200 countries)
 //   economic:fatf-listing:v1      (FATF plenary publication 2026-06-01)
 //
-// The `nonDrsCountryCodes` subset is pinned from the World Bank country
-// catalog's lendingType=LNX classification captured on the same date. The
-// values are pinned, not live-fetched, so the calibration gates are
-// deterministic and run in CI without credentials. The subset is the union
-// of the `sanctions-isolated` cohort, the dimension-level matched pairs,
-// and the issue's stub probe, plus DE as an unremarkable-OECD control.
+// The `nonDrsCountryCodes` cohort is pinned from the World Bank country
+// catalog's lendingType=LNX classification. The values are pinned, not
+// live-fetched, so the calibration gates are deterministic and run in CI
+// without credentials. It includes every LNX country used by this fixture and
+// stays above the producer contract's 40-country fail-closed floor.
 //
 // WHY REAL VALUES MATTER HERE: the failure this file exists to prevent is a
 // construct that ranks financially severed states ABOVE financially deep
@@ -57,7 +56,11 @@ export const FINSYS_DEBT_FIXTURE: Readonly<Record<string, FinSysDebtEntry>> = {
 
 /** World Bank country-catalog records classified as lendingType=LNX. */
 export const FINSYS_NON_DRS_COUNTRY_CODES: ReadonlyArray<string> = [
-  'CH', 'CU', 'DE', 'KP', 'LU', 'MC', 'SG', 'US',
+  'AD', 'AE', 'AT', 'AU', 'BE', 'BH', 'BN', 'BS', 'CA', 'CH', 'CU', 'CY',
+  'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GR', 'HK', 'HU', 'IE',
+  'IL', 'IS', 'IT', 'JP', 'KP', 'KR', 'KW', 'LI', 'LT', 'LU', 'LV', 'MC',
+  'MO', 'MT', 'NL', 'NO', 'NZ', 'OM', 'PT', 'QA', 'SA', 'SE', 'SG', 'SI',
+  'SK', 'SM', 'US',
 ];
 
 /** `economic:bis-lbs:v1` — BIS CBS by-parent claims and reporter count. */

--- a/tests/helpers/resilience-fixtures.mts
+++ b/tests/helpers/resilience-fixtures.mts
@@ -1,4 +1,5 @@
 import sovereignStatus from '../../scripts/shared/sovereign-status.json';
+import { FINSYS_NON_DRS_COUNTRY_CODES } from './resilience-finsys-fixtures.mts';
 
 export type FixtureMap = Record<string, unknown>;
 
@@ -433,6 +434,7 @@ export const RESILIENCE_FIXTURES: FixtureMap = {
       US: { value: 0, year: 2024 },     // HIC, WB IDS doesn't publish — fixture treats as 0 for the test triple
       YE: { value: 14, year: 2023 },    // ~14% GNI — fragile state near worst goalpost → score ~7
     },
+    nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES,
     seededAt: '2026-04-25T00:00:00.000Z',
   },
   'economic:bis-lbs:v1': {

--- a/tests/helpers/resilience-fixtures.mts
+++ b/tests/helpers/resilience-fixtures.mts
@@ -429,6 +429,7 @@ export const RESILIENCE_FIXTURES: FixtureMap = {
     seededAt: '2026-08-11T08:03:25.357Z',
   },
   'economic:wb-external-debt:v1': {
+    schemaVersion: 2,
     countries: {
       NO: { value: 2, year: 2024 },     // 2% GNI — Norway low external debt → score ~87
       US: { value: 0, year: 2024 },     // HIC, WB IDS doesn't publish — fixture treats as 0 for the test triple

--- a/tests/resilience-financial-system-exposure.test.mts
+++ b/tests/resilience-financial-system-exposure.test.mts
@@ -49,11 +49,21 @@ import {
 
 const TEST_ISO2 = 'XX';
 const VALID_DEBT_CONTROL_COUNTRY = 'ZZ';
+const VALID_DEBT_SCHEMA_VERSION = 2;
 
 function reachableDebtEnvelope(additionalNonDrsCountryCodes: ReadonlyArray<string> = []): unknown {
   return {
-    countries: { [VALID_DEBT_CONTROL_COUNTRY]: { value: 1, year: 2024 } },
-    nonDrsCountryCodes: [...new Set([...FINSYS_NON_DRS_COUNTRY_CODES, ...additionalNonDrsCountryCodes])],
+    _seed: {
+      fetchedAt: Date.now(),
+      recordCount: 1,
+      sourceVersion: 'wb-ids-test',
+      schemaVersion: VALID_DEBT_SCHEMA_VERSION,
+      state: 'OK',
+    },
+    data: {
+      countries: { [VALID_DEBT_CONTROL_COUNTRY]: { value: 1, year: 2024 } },
+      nonDrsCountryCodes: [...new Set([...FINSYS_NON_DRS_COUNTRY_CODES, ...additionalNonDrsCountryCodes])],
+    },
   };
 }
 
@@ -233,16 +243,31 @@ describe('scoreFinancialSystemExposure — fail-closed preflight', () => {
   });
 
   it('throws when healthy seed-meta is followed by an absent or malformed WB data envelope', async () => {
+    const validNonDrsCountryCodes = [...FINSYS_NON_DRS_COUNTRY_CODES];
+    const malformedNonDrsCountryCodes = [...validNonDrsCountryCodes];
+    malformedNonDrsCountryCodes[0] = 'bad';
+    const duplicateNonDrsCountryCodes = [...validNonDrsCountryCodes];
+    duplicateNonDrsCountryCodes[0] = duplicateNonDrsCountryCodes[1];
     for (const debtPayload of [
       null,
       {},
-      { countries: {} },
-      { countries: [], nonDrsCountryCodes: [] },
+      { schemaVersion: VALID_DEBT_SCHEMA_VERSION, countries: {} },
+      { schemaVersion: VALID_DEBT_SCHEMA_VERSION, countries: [], nonDrsCountryCodes: [] },
       {
+        schemaVersion: VALID_DEBT_SCHEMA_VERSION,
         countries: { [VALID_DEBT_CONTROL_COUNTRY]: { value: 1, year: 2024 } },
         nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES.slice(0, 39),
       },
-      { countries: { ZZ: { value: 1 } }, nonDrsCountryCodes: ['LU', 'LU'] },
+      {
+        schemaVersion: VALID_DEBT_SCHEMA_VERSION,
+        countries: { ZZ: { value: 1 } },
+        nonDrsCountryCodes: malformedNonDrsCountryCodes,
+      },
+      {
+        schemaVersion: VALID_DEBT_SCHEMA_VERSION,
+        countries: { ZZ: { value: 1 } },
+        nonDrsCountryCodes: duplicateNonDrsCountryCodes,
+      },
     ]) {
       await assert.rejects(
         () => scoreFinancialSystemExposure(TEST_ISO2, readerWithDebtPayload(debtPayload)),
@@ -268,6 +293,31 @@ describe('scoreFinancialSystemExposure — fail-closed preflight', () => {
         && /schema v2.*nonDrsCountryCodes/.test(err.message)
       ),
       'the active non-DRS path must fail closed when production falls back to schema v1',
+    );
+  });
+
+  it('throws when an otherwise valid-looking WB payload declares schema v1', async () => {
+    const reader = readerWithDebtPayload({
+      _seed: {
+        fetchedAt: Date.now(),
+        recordCount: 1,
+        sourceVersion: 'wb-ids-test',
+        schemaVersion: 1,
+        state: 'OK',
+      },
+      data: {
+        countries: { [VALID_DEBT_CONTROL_COUNTRY]: { value: 1, year: 2024 } },
+        nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES,
+      },
+    });
+
+    await assert.rejects(
+      () => scoreFinancialSystemExposure(TEST_ISO2, reader),
+      (err: unknown) => (
+        err instanceof ResilienceConfigurationError
+        && err.missingKeys.includes('economic:wb-external-debt:v1')
+      ),
+      'the scorer must enforce the numeric schema boundary before using the unwrapped payload',
     );
   });
 });
@@ -299,7 +349,7 @@ describe('scoreFinancialSystemExposure — formula math', () => {
       if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
       if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
       if (key === 'economic:wb-external-debt:v1') {
-        return { countries: { [TEST_ISO2]: { value: 0, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES };
+        return { schemaVersion: VALID_DEBT_SCHEMA_VERSION, countries: { [TEST_ISO2]: { value: 0, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES };
       }
       if (key === 'economic:bis-lbs:v1') return { countries: { [TEST_ISO2]: { totalXborderPctGdp: 25, parentCount: 10 } } };
       if (key === 'economic:fatf-listing:v1') return { listings: { [TEST_ISO2]: 'compliant' }, publicationDate: '2026-02-13' };
@@ -315,7 +365,7 @@ describe('scoreFinancialSystemExposure — formula math', () => {
     if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
     if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
     if (key === 'economic:wb-external-debt:v1') {
-      return { countries: { [TEST_ISO2]: { value: 15, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES };
+      return { schemaVersion: VALID_DEBT_SCHEMA_VERSION, countries: { [TEST_ISO2]: { value: 15, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES };
     }
     if (key === 'economic:bis-lbs:v1') return { countries: { [TEST_ISO2]: { totalXborderPctGdp: xborderPct, parentCount: 1 } } };
     if (key === 'economic:fatf-listing:v1') return { listings: { [TEST_ISO2]: 'black' }, publicationDate: '2026-02-13' };
@@ -537,7 +587,7 @@ describe('scoreFinancialSystemExposure — comprehensive-embargo cap (#6459)', (
   const bestCaseReader = (iso2: string): ResilienceSeedReader => async (key) => {
     if (key.startsWith('seed-meta:')) return { status: 'ok', fetchedAt: Date.now() };
     if (key === 'economic:wb-external-debt:v1') {
-      return { countries: { [iso2]: { value: 0, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES };
+      return { schemaVersion: VALID_DEBT_SCHEMA_VERSION, countries: { [iso2]: { value: 0, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES };
     }
     if (key === 'economic:bis-lbs:v1') return { countries: { [iso2]: { totalXborderPctGdp: 25, parentCount: 10 } } };
     if (key === 'economic:fatf-listing:v1') {
@@ -619,7 +669,7 @@ describe('scoreFinancialSystemExposure — non-DRS short-term-debt slot (#6459)'
     if (key.startsWith('seed-meta:')) return { status: 'ok', fetchedAt: Date.now() };
     if (key === 'economic:wb-external-debt:v1') {
       return opts.debtRow
-        ? { countries: { [TEST_ISO2]: { value: 0, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES }
+        ? { schemaVersion: VALID_DEBT_SCHEMA_VERSION, countries: { [TEST_ISO2]: { value: 0, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES }
         : reachableDebtEnvelope(opts.confirmedNonDrs ? [TEST_ISO2] : []);
     }
     if (key === 'economic:bis-lbs:v1') {
@@ -696,6 +746,7 @@ describe('scoreFinancialSystemExposure — market-access-constrained debt certai
       if (key.startsWith('seed-meta:')) return { status: 'ok', fetchedAt: Date.now() };
       if (key === 'economic:wb-external-debt:v1') {
         return {
+          schemaVersion: VALID_DEBT_SCHEMA_VERSION,
           countries: { [TEST_ISO2]: { value: values.debtPct, year: 2024 } },
           nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES,
         };
@@ -866,6 +917,7 @@ describe('scoreFinancialSystemExposure — #6459 inversion probe (pinned)', () =
     if (key === 'economic:wb-external-debt:v1') {
       // MC/LU absent: neither is a World Bank Debtor Reporting System filer.
       return {
+        schemaVersion: VALID_DEBT_SCHEMA_VERSION,
         countries: { RU: { value: 3, year: 2024 }, TD: { value: 1, year: 2024 } },
         nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES,
       };

--- a/tests/resilience-financial-system-exposure.test.mts
+++ b/tests/resilience-financial-system-exposure.test.mts
@@ -41,16 +41,27 @@ import {
   ResilienceConfigurationError,
   type ResilienceSeedReader,
 } from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
-import { FINSYS_FIXTURE_CAPTURED_AT, createFinSysFixtureReader } from './helpers/resilience-finsys-fixtures.mts';
+import {
+  FINSYS_FIXTURE_CAPTURED_AT,
+  FINSYS_NON_DRS_COUNTRY_CODES,
+  createFinSysFixtureReader,
+} from './helpers/resilience-finsys-fixtures.mts';
 
 const TEST_ISO2 = 'XX';
 const VALID_DEBT_CONTROL_COUNTRY = 'ZZ';
 
-function reachableDebtEnvelope(nonDrsCountryCodes: ReadonlyArray<string> = []): unknown {
+function reachableDebtEnvelope(additionalNonDrsCountryCodes: ReadonlyArray<string> = []): unknown {
   return {
     countries: { [VALID_DEBT_CONTROL_COUNTRY]: { value: 1, year: 2024 } },
-    nonDrsCountryCodes,
+    nonDrsCountryCodes: [...new Set([...FINSYS_NON_DRS_COUNTRY_CODES, ...additionalNonDrsCountryCodes])],
   };
+}
+
+function readerWithDebtPayload(debtPayload: unknown): ResilienceSeedReader {
+  const fixtureReader = createFinSysFixtureReader();
+  return async (key) => (
+    key === 'economic:wb-external-debt:v1' ? debtPayload : fixtureReader(key)
+  );
 }
 
 // The dim is flag-gated for staged rollout (matches energy v2 pattern).
@@ -227,21 +238,14 @@ describe('scoreFinancialSystemExposure — fail-closed preflight', () => {
       {},
       { countries: {} },
       { countries: [], nonDrsCountryCodes: [] },
+      {
+        countries: { [VALID_DEBT_CONTROL_COUNTRY]: { value: 1, year: 2024 } },
+        nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES.slice(0, 39),
+      },
       { countries: { ZZ: { value: 1 } }, nonDrsCountryCodes: ['LU', 'LU'] },
     ]) {
-      const reader: ResilienceSeedReader = async (key) => {
-        if (key.startsWith('seed-meta:')) return { fetchedAt: Date.now(), status: 'ok' };
-        if (key === 'economic:wb-external-debt:v1') return debtPayload;
-        if (key === 'economic:bis-lbs:v1') {
-          return { countries: { [TEST_ISO2]: { totalXborderPctGdp: 25, parentCount: 10 } } };
-        }
-        if (key === 'economic:fatf-listing:v1') {
-          return { listings: { IR: 'black', KP: 'black' }, publicationDate: '2026-06-01' };
-        }
-        return null;
-      };
       await assert.rejects(
-        () => scoreFinancialSystemExposure(TEST_ISO2, reader),
+        () => scoreFinancialSystemExposure(TEST_ISO2, readerWithDebtPayload(debtPayload)),
         (err: unknown) => (
           err instanceof ResilienceConfigurationError
           && err.missingKeys.includes('economic:wb-external-debt:v1')
@@ -249,6 +253,22 @@ describe('scoreFinancialSystemExposure — fail-closed preflight', () => {
         'source-level WB data failure must not become a positive per-country imputation',
       );
     }
+  });
+
+  it('throws when the WB payload regresses to schema v1 without non-DRS metadata', async () => {
+    const reader = readerWithDebtPayload({
+      countries: { [VALID_DEBT_CONTROL_COUNTRY]: { value: 1, year: 2024 } },
+    });
+
+    await assert.rejects(
+      () => scoreFinancialSystemExposure(TEST_ISO2, reader),
+      (err: unknown) => (
+        err instanceof ResilienceConfigurationError
+        && err.missingKeys.includes('economic:wb-external-debt:v1')
+        && /schema v2.*nonDrsCountryCodes/.test(err.message)
+      ),
+      'the active non-DRS path must fail closed when production falls back to schema v1',
+    );
   });
 });
 
@@ -278,7 +298,9 @@ describe('scoreFinancialSystemExposure — formula math', () => {
       if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
       if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
       if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
-      if (key === 'economic:wb-external-debt:v1') return { countries: { [TEST_ISO2]: { value: 0, year: 2024 } } };
+      if (key === 'economic:wb-external-debt:v1') {
+        return { countries: { [TEST_ISO2]: { value: 0, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES };
+      }
       if (key === 'economic:bis-lbs:v1') return { countries: { [TEST_ISO2]: { totalXborderPctGdp: 25, parentCount: 10 } } };
       if (key === 'economic:fatf-listing:v1') return { listings: { [TEST_ISO2]: 'compliant' }, publicationDate: '2026-02-13' };
       return null;
@@ -292,7 +314,9 @@ describe('scoreFinancialSystemExposure — formula math', () => {
     if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now() };
     if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now() };
     if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now() };
-    if (key === 'economic:wb-external-debt:v1') return { countries: { [TEST_ISO2]: { value: 15, year: 2024 } } };
+    if (key === 'economic:wb-external-debt:v1') {
+      return { countries: { [TEST_ISO2]: { value: 15, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES };
+    }
     if (key === 'economic:bis-lbs:v1') return { countries: { [TEST_ISO2]: { totalXborderPctGdp: xborderPct, parentCount: 1 } } };
     if (key === 'economic:fatf-listing:v1') return { listings: { [TEST_ISO2]: 'black' }, publicationDate: '2026-02-13' };
     return null;
@@ -512,7 +536,9 @@ describe('scoreFinancialSystemExposure — formula math', () => {
 describe('scoreFinancialSystemExposure — comprehensive-embargo cap (#6459)', () => {
   const bestCaseReader = (iso2: string): ResilienceSeedReader => async (key) => {
     if (key.startsWith('seed-meta:')) return { status: 'ok', fetchedAt: Date.now() };
-    if (key === 'economic:wb-external-debt:v1') return { countries: { [iso2]: { value: 0, year: 2024 } } };
+    if (key === 'economic:wb-external-debt:v1') {
+      return { countries: { [iso2]: { value: 0, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES };
+    }
     if (key === 'economic:bis-lbs:v1') return { countries: { [iso2]: { totalXborderPctGdp: 25, parentCount: 10 } } };
     if (key === 'economic:fatf-listing:v1') {
       return { listings: { IR: 'black', KP: 'black' }, publicationDate: '2026-06-01' };
@@ -593,7 +619,7 @@ describe('scoreFinancialSystemExposure — non-DRS short-term-debt slot (#6459)'
     if (key.startsWith('seed-meta:')) return { status: 'ok', fetchedAt: Date.now() };
     if (key === 'economic:wb-external-debt:v1') {
       return opts.debtRow
-        ? { countries: { [TEST_ISO2]: { value: 0, year: 2024 } }, nonDrsCountryCodes: [] }
+        ? { countries: { [TEST_ISO2]: { value: 0, year: 2024 } }, nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES }
         : reachableDebtEnvelope(opts.confirmedNonDrs ? [TEST_ISO2] : []);
     }
     if (key === 'economic:bis-lbs:v1') {
@@ -669,7 +695,10 @@ describe('scoreFinancialSystemExposure — market-access-constrained debt certai
     async (key) => {
       if (key.startsWith('seed-meta:')) return { status: 'ok', fetchedAt: Date.now() };
       if (key === 'economic:wb-external-debt:v1') {
-        return { countries: { [TEST_ISO2]: { value: values.debtPct, year: 2024 } } };
+        return {
+          countries: { [TEST_ISO2]: { value: values.debtPct, year: 2024 } },
+          nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES,
+        };
       }
       if (key === 'economic:bis-lbs:v1') {
         return { countries: { [TEST_ISO2]: { totalXborderPctGdp: values.claimsPctGdp, parentCount: values.parentCount } } };
@@ -838,7 +867,7 @@ describe('scoreFinancialSystemExposure — #6459 inversion probe (pinned)', () =
       // MC/LU absent: neither is a World Bank Debtor Reporting System filer.
       return {
         countries: { RU: { value: 3, year: 2024 }, TD: { value: 1, year: 2024 } },
-        nonDrsCountryCodes: ['LU', 'MC'],
+        nonDrsCountryCodes: FINSYS_NON_DRS_COUNTRY_CODES,
       };
     }
     if (key === 'economic:bis-lbs:v1') {

--- a/tests/seed-wb-external-debt.test.mjs
+++ b/tests/seed-wb-external-debt.test.mjs
@@ -19,6 +19,7 @@ import { describe, it } from 'node:test';
 
 import {
   combineExternalDebt,
+  createWbExternalDebtSeedOptions,
   deriveNonDrsCountryCodes,
   validate,
 } from '../scripts/seed-wb-external-debt.mjs';
@@ -172,5 +173,14 @@ describe('validate', () => {
       ample[`X${i.toString().padStart(2, '0')}`] = { value: 5, year: 2023 };
     }
     assert.equal(validate({ countries: ample, nonDrsCountryCodes: countryCodes(50) }), true);
+  });
+});
+
+describe('published seed contract', () => {
+  it('pins the canonical envelope at schema v2', () => {
+    const options = createWbExternalDebtSeedOptions(new Date('2026-08-12T00:00:00.000Z'));
+    assert.equal(options.schemaVersion, 2);
+    assert.equal(options.sourceVersion, 'wb-ids-2026');
+    assert.equal(options.validateFn, validate, 'the published schema must use the tested cohort validator');
   });
 });


### PR DESCRIPTION
## Summary

Production now publishes and consumes the World Bank external-debt schema-v2 non-DRS cohort. This restores the guarded debt-slot imputation for 48 catalog-confirmed LNX countries without treating row absence alone as eligibility.

The scorer now fails closed when the cohort is missing, malformed, duplicated, or below the producer's 40-country floor. The exact `runSeed` options are pinned to schema version 2, and the live before/after evidence is committed.

## Production evidence

| Gate | Result |
| --- | --- |
| Debt seed | Schema 1 -> 2; 119 debt rows; 72 valid unique non-DRS codes |
| Activation | 48 countries moved from 0.65 to 0.76 dimension coverage and from 0 to 0.35 imputed weight |
| Rank movement | Spearman 0.99997; all 196 absolute score deltas below 3; maximum delta 0.35; none above 12 |
| Headline eligibility | No changes |

The other 23 countries with no debt row and a BIS row remain unknown because the World Bank lending-type catalog does not confirm LNX status. Aggregate `imputationClass` remains null by the `weightedBlend` contract when observed BIS or FATF data is also present; `imputedWeight: 0.35` is the slot-level activation proof.

## Validation

- Full pre-push gate passed, including 1,140 resilience tests and 107 server handler tests.
- 67 focused resilience tests passed after the final rebase.
- 17 World Bank external-debt seeder tests passed.
- `npm run typecheck:api` passed.
- `npm run typecheck:contract-tests` passed.
- Biome, Markdown lint, artifact JSON parsing, and `git diff --check` passed.

## Post-deploy monitoring and validation

- Window: the first resilience refresh after deployment and the following 24 hours.
- Healthy state: debt schema version 2; at least 40 valid unique cohort codes; 196 ranking rows; no financial-system source failure; activated samples keep about 0.76 coverage and 0.35 imputed weight.
- Watch: `ResilienceConfigurationError`, `economic:wb-external-debt:v1`, `nonDrsCountryCodes`, seed logs, `/api/health?compact=1`, and Sentry.
- Failure state: schema below 2, a missing or invalid cohort, configuration errors, or ranking source-failure decoration.
- Mitigation: rerun the debt seeder and forced resilience ranking refresh. If the reader blocks before the producer is repaired, roll back this PR or disable the financial-system exposure flag.
- Owner: WorldMonitor deployment operator or maintainer.

Fixes #6519

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT 5.6](https://img.shields.io/badge/GPT_5.6-000000)
