### PR TITLE
fix(auth): restore readable input text in Clerk sign-in/sign-up modal

### DIFF
--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -60,15 +60,28 @@ function getAppearance() {
     ? document.documentElement.dataset.theme !== 'light'
     : true;
 
+  // Both naming generations are listed for every color. The @clerk/ui v1
+  // bundle (loaded at runtime via __internal_ClerkUICtor) parses ONLY the
+  // new names -- colorForeground / colorInput / colorInputForeground /
+  // colorMutedForeground -- and silently ignores the legacy v5 names, so
+  // without the new names text falls back to light-dark() defaults that
+  // resolve near-black (e.g. invisible OTP digits on the dark card). The
+  // legacy names stay for clerk-js's own legacy components. Unknown keys
+  // are ignored by either parser, so the union is safe.
   return isDark
     ? {
         variables: {
           colorBackground: '#0f0f0f',
           colorInputBackground: '#141414',
+          colorInput: '#141414',
           colorInputText: '#e8e8e8',
+          colorInputForeground: '#e8e8e8',
           colorText: '#e8e8e8',
+          colorForeground: '#e8e8e8',
           colorTextSecondary: '#aaaaaa',
+          colorMutedForeground: '#aaaaaa',
           colorPrimary: '#44ff88',
+          colorPrimaryForeground: '#000000',
           colorNeutral: '#e8e8e8',
           colorDanger: '#ff4444',
           borderRadius: '4px',
@@ -95,10 +108,15 @@ function getAppearance() {
         variables: {
           colorBackground: '#ffffff',
           colorInputBackground: '#f8f9fa',
+          colorInput: '#f8f9fa',
           colorInputText: '#1a1a1a',
+          colorInputForeground: '#1a1a1a',
           colorText: '#1a1a1a',
+          colorForeground: '#1a1a1a',
           colorTextSecondary: '#555555',
+          colorMutedForeground: '#555555',
           colorPrimary: '#16a34a',
+          colorPrimaryForeground: '#ffffff',
           colorNeutral: '#1a1a1a',
           colorDanger: '#dc2626',
           borderRadius: '4px',


### PR DESCRIPTION
## Problem

During sign-up, the email verification (OTP) input renders its digits in near-black on the dark modal card, making the code invisible as you type it.

## Root cause

The auth modal is rendered by the `@clerk/ui` v1 bundle (loaded at runtime via `__internal_ClerkUICtor`). That bundle parses only the new-generation appearance variable names — `colorForeground`, `colorInput`, `colorInputForeground`, `colorMutedForeground` — and silently ignores the legacy v5 names (`colorText`, `colorInputBackground`, `colorInputText`, `colorTextSecondary`) that `getAppearance()` in `src/services/clerk.ts` was passing.

With those variables unset, foreground colors fall back to Clerk's `light-dark()` defaults, which resolve to `#131316` (near-black) when no dark `color-scheme` is in effect. The OTP segment specifically renders `color: $colorInputForeground` over a transparent background (verified in the `@clerk/ui@1.30.1` source), so the digits end up black on the `#111111` card.

## Fix

Add the new-generation variable names alongside the legacy ones in both dark and light themes (`colorInput`, `colorInputForeground`, `colorForeground`, `colorMutedForeground`, `colorPrimaryForeground`). Unknown keys are ignored by either parser, so keeping the union is safe for clerk-js's own legacy components.

## Verification

- `tsc --noEmit` and `biome lint` clean.
- Built a contrast harness reproducing the exact OTP segment styling rule from `@clerk/ui` (transparent background, `color: $colorInputForeground`) with the before/after variable sets — before: digits invisible on the dark card; after: readable `#e8e8e8` digits on dark, `#1a1a1a` on light.

![OTP contrast before/after](https://raw.githubusercontent.com/ayobamiseun/worldmonitor/otp-contrast-assets/otp-contrast-before-after.png)
