### PR TITLE
refactor(markets): one stablecoin classifier instead of three copies across CJS, ESM, and TS

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2784,8 +2784,10 @@ async function seedCryptoQuotes() {
 const _stablecoinCfg = requireShared('stablecoins.json');
 const STABLECOIN_IDS = _stablecoinCfg.ids.join(',');
 const STABLECOIN_PAPRIKA_MAP = _stablecoinCfg.coinpaprika;
-const STABLECOIN_ON_PEG_MAX = _stablecoinCfg.pegThresholds.onPegMaxDeviation;
-const STABLECOIN_SLIGHT_DEPEG_MAX = _stablecoinCfg.pegThresholds.slightDepegMaxDeviation;
+// Row shaping and peg classification live in ONE module shared with the
+// primary seeder and the RPC gap path — a private variant here means the
+// stored value depends on which writer ran last. (#6319, extends #6308)
+const { classifyStablecoin } = requireShared('stablecoin-classifier.cjs');
 const STABLECOIN_SEED_TTL = 7200; // 2h — 1h buffer over 5min cron cadence (was 1h = 55min buffer)
 
 async function fetchStablecoinCoinPaprika() {
@@ -2813,12 +2815,7 @@ async function seedStablecoinMarkets() {
     console.warn(`[Stablecoin] CoinGecko failed: ${err.message} — trying CoinPaprika`);
     try { data = await fetchStablecoinCoinPaprika(); } catch (e2) { console.warn(`[Stablecoin] CoinPaprika also failed: ${e2.message} — skipping`); return 0; }
   }
-  const stablecoins = data.map((coin) => {
-    const price = coin.current_price || 0;
-    const deviation = Math.abs(price - 1.0);
-    const pegStatus = deviation <= STABLECOIN_ON_PEG_MAX ? 'ON PEG' : deviation <= STABLECOIN_SLIGHT_DEPEG_MAX ? 'SLIGHT DEPEG' : 'DEPEGGED';
-    return { id: coin.id, symbol: (coin.symbol || '').toUpperCase(), name: coin.name, price, deviation: +(deviation * 100).toFixed(3), pegStatus, marketCap: coin.market_cap || 0, volume24h: coin.total_volume || 0, change24h: coin.price_change_percentage_24h || 0, change7d: coin.price_change_percentage_7d_in_currency || 0, image: coin.image || '' };
-  });
+  const stablecoins = data.map((coin) => classifyStablecoin(coin));
   const totalMarketCap = stablecoins.reduce((s, c) => s + c.marketCap, 0);
   const totalVolume24h = stablecoins.reduce((s, c) => s + c.volume24h, 0);
   const depeggedCount = stablecoins.filter((c) => c.pegStatus === 'DEPEGGED').length;

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -170,6 +170,7 @@
       "scripts/shared/rss-allowed-domains.cjs",
       "scripts/shared/rss-allowed-domains.json",
       "scripts/shared/source-tiers.json",
+      "scripts/shared/stablecoin-classifier.cjs",
       "scripts/shared/stablecoins.json",
       "scripts/shared/stocks.json",
       "scripts/shared/ucdp-candidate.cjs",
@@ -183,6 +184,7 @@
       "shared/rss-allowed-domains.cjs",
       "shared/rss-allowed-domains.json",
       "shared/source-tiers.json",
+      "shared/stablecoin-classifier.cjs",
       "shared/stablecoins.json",
       "shared/stocks.json"
     ],
@@ -1148,6 +1150,7 @@
       "scripts/shared/etfs.json",
       "scripts/shared/gulf.json",
       "scripts/shared/other-tokens.json",
+      "scripts/shared/stablecoin-classifier.cjs",
       "scripts/shared/stablecoins.json",
       "shared/ai-tokens.json",
       "shared/crypto.json",

--- a/scripts/seed-stablecoin-markets.mjs
+++ b/scripts/seed-stablecoin-markets.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, loadSharedConfig, CHROME_UA, runSeed, sleep, fetchCoinPaprikaTickersById, coingeckoEndpoint } from './_seed-utils.mjs';
+// scripts/shared/ mirror (NOT ../shared/): this seeder deploys via Railway
+// rootDirectory=scripts, where the repo-root shared/ folder does not exist.
+// The mirror is byte-locked to shared/ by tests/scripts-shared-mirror.test.mjs.
+import { classifyStablecoin } from './shared/stablecoin-classifier.cjs';
 
 const stablecoinConfig = loadSharedConfig('stablecoins.json');
 
@@ -10,12 +14,6 @@ const CANONICAL_KEY = 'market:stablecoins:v1';
 const CACHE_TTL = 5400; // 90min — 1h buffer over 10min cron cadence (was 60min = 50min buffer)
 
 const STABLECOIN_IDS = stablecoinConfig.ids.join(',');
-
-// Shared with the relay's backup seeder and with the RPC handler, which
-// classifies coins this seed does not carry. Three producers writing peg
-// status against three private copies of these numbers would let the same
-// coin read "ON PEG" from one path and "SLIGHT DEPEG" from another. (#6308)
-const { onPegMaxDeviation: ON_PEG_MAX, slightDepegMaxDeviation: SLIGHT_DEPEG_MAX } = stablecoinConfig.pegThresholds;
 
 async function fetchWithRateLimitRetry(url, maxAttempts = 5, headers = { Accept: 'application/json', 'User-Agent': CHROME_UA }) {
   for (let i = 0; i < maxAttempts; i++) {
@@ -80,28 +78,11 @@ async function fetchStablecoinMarkets() {
     data = await fetchFromCoinPaprika();
   }
 
-  const stablecoins = data.map((coin) => {
-    const price = coin.current_price || 0;
-    const deviation = Math.abs(price - 1.0);
-    let pegStatus;
-    if (deviation <= ON_PEG_MAX) pegStatus = 'ON PEG';
-    else if (deviation <= SLIGHT_DEPEG_MAX) pegStatus = 'SLIGHT DEPEG';
-    else pegStatus = 'DEPEGGED';
-
-    return {
-      id: coin.id,
-      symbol: (coin.symbol || '').toUpperCase(),
-      name: coin.name,
-      price,
-      deviation: +(deviation * 100).toFixed(3),
-      pegStatus,
-      marketCap: coin.market_cap || 0,
-      volume24h: coin.total_volume || 0,
-      change24h: coin.price_change_percentage_24h || 0,
-      change7d: coin.price_change_percentage_7d_in_currency || 0,
-      image: coin.image || '',
-    };
-  });
+  // Shared with the relay's backup seeder and with the RPC handler, which
+  // classifies coins this seed does not carry. Three producers shaping rows
+  // with three private copies of this logic would let the same coin read a
+  // different peg status from each path. (#6308, #6319)
+  const stablecoins = data.map((coin) => classifyStablecoin(coin));
 
   const totalMarketCap = stablecoins.reduce((sum, c) => sum + c.marketCap, 0);
   const totalVolume24h = stablecoins.reduce((sum, c) => sum + c.volume24h, 0);

--- a/scripts/shared/stablecoin-classifier.cjs
+++ b/scripts/shared/stablecoin-classifier.cjs
@@ -1,0 +1,62 @@
+// The ONE deviation → peg-status mapping and provider-row shaping for
+// `market:stablecoins:v1`, shared by all three writers of that key:
+//
+//   - scripts/ais-relay.cjs            (backup seeder, CJS: requireShared)
+//   - scripts/seed-stablecoin-markets.mjs (primary seeder, ESM: static import
+//     of the scripts/shared/ mirror)
+//   - server/worldmonitor/market/v1/list-stablecoin-markets.ts (gap lookups,
+//     TS: sibling .d.cts carries the types)
+//
+// #6308 unified the threshold NUMBERS into stablecoins.json; this module
+// unifies the logic that applies them (#6319). The two seeders write the SAME
+// Redis key, so a private variant here means the stored value depends on
+// which writer ran last.
+//
+// CJS deliberately: require()-able from the relay, importable from ESM via
+// Node's CJS named-export detection, and bundleable from TS. Mirrored
+// byte-for-byte at scripts/shared/stablecoin-classifier.cjs for the Railway
+// rootDirectory=scripts deploys (locked by tests/scripts-shared-mirror.test.mjs).
+
+// Sibling resolution works in BOTH homes: shared/stablecoins.json and
+// scripts/shared/stablecoins.json are themselves mirror-locked.
+const { pegThresholds: DEFAULT_PEG_THRESHOLDS } = require('./stablecoins.json');
+
+// Provider numerics arrive as JSON of unknown shape; a string or missing
+// price must not become NaN in the stored payload.
+function toFiniteNumber(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Shape one CoinGecko-format market row (CoinPaprika rows are pre-mapped to
+ * this format by both seeders) into the stablecoin object stored in
+ * `market:stablecoins:v1` and returned by ListStablecoinMarkets.
+ *
+ * `deviation` is stored as a percentage rounded to 3 decimals; `pegStatus`
+ * compares the RAW deviation against the thresholds, so rounding can never
+ * move a coin across a peg boundary.
+ */
+function classifyStablecoin(row, thresholds = DEFAULT_PEG_THRESHOLDS) {
+  const price = toFiniteNumber(row.current_price);
+  const deviation = Math.abs(price - 1.0);
+  return {
+    id: row.id,
+    symbol: String(row.symbol || '').toUpperCase(),
+    name: String(row.name || ''),
+    price,
+    deviation: +(deviation * 100).toFixed(3),
+    pegStatus: deviation <= thresholds.onPegMaxDeviation
+      ? 'ON PEG'
+      : deviation <= thresholds.slightDepegMaxDeviation
+        ? 'SLIGHT DEPEG'
+        : 'DEPEGGED',
+    marketCap: toFiniteNumber(row.market_cap),
+    volume24h: toFiniteNumber(row.total_volume),
+    change24h: toFiniteNumber(row.price_change_percentage_24h),
+    change7d: toFiniteNumber(row.price_change_percentage_7d_in_currency),
+    image: String(row.image || ''),
+  };
+}
+
+module.exports = { classifyStablecoin };

--- a/server/worldmonitor/market/v1/list-stablecoin-markets.ts
+++ b/server/worldmonitor/market/v1/list-stablecoin-markets.ts
@@ -24,13 +24,16 @@ import type {
   StablecoinSummary,
   UnresolvedStablecoin,
 } from '../../../../src/generated/server/worldmonitor/market/v1/service_server';
-import stablecoinConfig from '../../../../shared/stablecoins.json';
+// The same row shaping the two Railway seeders apply when writing the seed
+// snapshot — a gap coin and a seeded coin sitting in one response must not be
+// labelled on different rules. Thresholds default to shared/stablecoins.json
+// inside the module. (#6308, #6319)
+import { classifyStablecoin } from '../../../../shared/stablecoin-classifier.cjs';
 import { cachedFetchJson, readCachedJson, setCachedJson } from '../../../_shared/redis';
 import { sha256Hex } from '../../../_shared/hash';
 import {
   fetchCryptoMarketsWithSource,
   parseStringArray,
-  type CoinGeckoMarketItem,
   type CryptoMarketsSource,
 } from './_shared';
 
@@ -62,9 +65,6 @@ const MAX_ECHOED_ID_LENGTH = 64;
 // CoinGecko IDs are lowercase alphanumerics and hyphens. Anchored, with no
 // nested quantifier or alternation, so it is linear on any input.
 const COINGECKO_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
-
-const { onPegMaxDeviation: ON_PEG_MAX, slightDepegMaxDeviation: SLIGHT_DEPEG_MAX } =
-  stablecoinConfig.pegThresholds;
 
 /**
  * Closed vocabularies, exported so tests can pin them against the proto
@@ -125,12 +125,6 @@ function isGapPayload(value: unknown): value is GapPayload {
   return Array.isArray(payload.coins)
     && (payload.source === 'coingecko' || payload.source === 'coinpaprika')
     && typeof payload.fetchedAt === 'string';
-}
-
-/** Provider numerics arrive as JSON of unknown shape; a string price must not become NaN. */
-function toFiniteNumber(value: unknown): number {
-  const n = typeof value === 'number' ? value : Number(value);
-  return Number.isFinite(n) ? n : 0;
 }
 
 function unavailableResponse(unresolved: UnresolvedStablecoin[]): ListStablecoinMarketsResponse {
@@ -223,33 +217,6 @@ function normalizeRequestedCoins(raw: unknown): {
 }
 
 /**
- * Mirrors the classification scripts/seed-stablecoin-markets.mjs applies, off
- * the same shared thresholds — a gap coin and a seeded coin sitting in one
- * response must not be labelled on different rules.
- */
-function toStablecoin(item: CoinGeckoMarketItem): Stablecoin {
-  const price = toFiniteNumber(item.current_price);
-  const deviation = Math.abs(price - 1.0);
-  return {
-    id: item.id,
-    symbol: String(item.symbol || '').toUpperCase(),
-    name: String(item.name || ''),
-    price,
-    deviation: +(deviation * 100).toFixed(3),
-    pegStatus: deviation <= ON_PEG_MAX
-      ? 'ON PEG'
-      : deviation <= SLIGHT_DEPEG_MAX
-        ? 'SLIGHT DEPEG'
-        : 'DEPEGGED',
-    marketCap: toFiniteNumber(item.market_cap),
-    volume24h: toFiniteNumber(item.total_volume),
-    change24h: toFiniteNumber(item.price_change_percentage_24h),
-    change7d: toFiniteNumber(item.price_change_percentage_7d_in_currency),
-    image: String(item.image || ''),
-  };
-}
-
-/**
  * Resolves IDs the snapshot does not carry, in ONE batched provider call.
  *
  * Keyed on the exact ID SET, so reuse is per request shape, not per coin:
@@ -320,7 +287,7 @@ async function resolveGapCoins(ids: string[]): Promise<{
           return null;
         }
         incompleteFallback = source === 'coinpaprika' && usable.length < ids.length;
-        return { coins: usable.map(toStablecoin), source, fetchedAt: new Date().toISOString() };
+        return { coins: usable.map((item) => classifyStablecoin(item)), source, fetchedAt: new Date().toISOString() };
       },
       GAP_NEGATIVE_TTL,
       { timeoutMs: GAP_FETCH_TIMEOUT_MS, cacheFetcherErrors: false },

--- a/shared/stablecoin-classifier.cjs
+++ b/shared/stablecoin-classifier.cjs
@@ -1,0 +1,62 @@
+// The ONE deviation → peg-status mapping and provider-row shaping for
+// `market:stablecoins:v1`, shared by all three writers of that key:
+//
+//   - scripts/ais-relay.cjs            (backup seeder, CJS: requireShared)
+//   - scripts/seed-stablecoin-markets.mjs (primary seeder, ESM: static import
+//     of the scripts/shared/ mirror)
+//   - server/worldmonitor/market/v1/list-stablecoin-markets.ts (gap lookups,
+//     TS: sibling .d.cts carries the types)
+//
+// #6308 unified the threshold NUMBERS into stablecoins.json; this module
+// unifies the logic that applies them (#6319). The two seeders write the SAME
+// Redis key, so a private variant here means the stored value depends on
+// which writer ran last.
+//
+// CJS deliberately: require()-able from the relay, importable from ESM via
+// Node's CJS named-export detection, and bundleable from TS. Mirrored
+// byte-for-byte at scripts/shared/stablecoin-classifier.cjs for the Railway
+// rootDirectory=scripts deploys (locked by tests/scripts-shared-mirror.test.mjs).
+
+// Sibling resolution works in BOTH homes: shared/stablecoins.json and
+// scripts/shared/stablecoins.json are themselves mirror-locked.
+const { pegThresholds: DEFAULT_PEG_THRESHOLDS } = require('./stablecoins.json');
+
+// Provider numerics arrive as JSON of unknown shape; a string or missing
+// price must not become NaN in the stored payload.
+function toFiniteNumber(value) {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Shape one CoinGecko-format market row (CoinPaprika rows are pre-mapped to
+ * this format by both seeders) into the stablecoin object stored in
+ * `market:stablecoins:v1` and returned by ListStablecoinMarkets.
+ *
+ * `deviation` is stored as a percentage rounded to 3 decimals; `pegStatus`
+ * compares the RAW deviation against the thresholds, so rounding can never
+ * move a coin across a peg boundary.
+ */
+function classifyStablecoin(row, thresholds = DEFAULT_PEG_THRESHOLDS) {
+  const price = toFiniteNumber(row.current_price);
+  const deviation = Math.abs(price - 1.0);
+  return {
+    id: row.id,
+    symbol: String(row.symbol || '').toUpperCase(),
+    name: String(row.name || ''),
+    price,
+    deviation: +(deviation * 100).toFixed(3),
+    pegStatus: deviation <= thresholds.onPegMaxDeviation
+      ? 'ON PEG'
+      : deviation <= thresholds.slightDepegMaxDeviation
+        ? 'SLIGHT DEPEG'
+        : 'DEPEGGED',
+    marketCap: toFiniteNumber(row.market_cap),
+    volume24h: toFiniteNumber(row.total_volume),
+    change24h: toFiniteNumber(row.price_change_percentage_24h),
+    change7d: toFiniteNumber(row.price_change_percentage_7d_in_currency),
+    image: String(row.image || ''),
+  };
+}
+
+module.exports = { classifyStablecoin };

--- a/shared/stablecoin-classifier.d.cts
+++ b/shared/stablecoin-classifier.d.cts
@@ -1,0 +1,43 @@
+// Type declarations for shared/stablecoin-classifier.cjs.
+//
+// The return shape matches the generated `Stablecoin` message
+// (src/generated/server/worldmonitor/market/v1/service_server.ts) field for
+// field — the classifier is what produces the rows that message describes,
+// both in the Redis snapshot and in RPC gap lookups.
+
+/** CoinGecko /coins/markets row shape (CoinPaprika rows are pre-mapped to it). */
+export interface StablecoinProviderRow {
+  id: string;
+  symbol?: unknown;
+  name?: unknown;
+  image?: unknown;
+  current_price?: unknown;
+  market_cap?: unknown;
+  total_volume?: unknown;
+  price_change_percentage_24h?: unknown;
+  price_change_percentage_7d_in_currency?: unknown;
+}
+
+export interface StablecoinPegThresholds {
+  onPegMaxDeviation: number;
+  slightDepegMaxDeviation: number;
+}
+
+export interface ClassifiedStablecoin {
+  id: string;
+  symbol: string;
+  name: string;
+  price: number;
+  deviation: number;
+  pegStatus: string;
+  marketCap: number;
+  volume24h: number;
+  change24h: number;
+  change7d: number;
+  image: string;
+}
+
+export function classifyStablecoin(
+  row: StablecoinProviderRow,
+  thresholds?: StablecoinPegThresholds,
+): ClassifiedStablecoin;

--- a/tests/scripts-shared-mirror.test.mjs
+++ b/tests/scripts-shared-mirror.test.mjs
@@ -25,6 +25,10 @@ const MIRRORED_FILES = [
   'iso2-to-region.json',
   'iso3-to-iso2.json',
   'publisher-families.js',
+  'stablecoin-classifier.cjs',
+  // The classifier's default thresholds come from its SIBLING stablecoins.json
+  // (both homes), so a drift in the JSON mirror silently changes classification.
+  'stablecoins.json',
   'story-identity.js',
   'un-to-iso2.json',
 ];

--- a/tests/stablecoin-classifier.test.mjs
+++ b/tests/stablecoin-classifier.test.mjs
@@ -1,0 +1,195 @@
+// Guards #6319: ONE deviation → peg-status mapping and row shaping for
+// `market:stablecoins:v1`, consumed by all three writers of that key.
+//
+// Three layers:
+//   1. The classifier itself — peg boundaries and provider-row coercion.
+//   2. Byte-parity — the shared module reproduces, byte for byte, the
+//      payload rows the pre-#6319 inline copies produced for realistic
+//      provider input (the acceptance criterion the extraction ran under).
+//   3. Enforcement — each writer imports the shared module and no writer
+//      carries a private copy of the classification. Without this, the next
+//      "quick fix" lands in one file and the two seeders of the SAME Redis
+//      key diverge again (#6308 found exactly that drift on the relay).
+//
+// The seeder imports the ESM path (static import of the scripts/shared
+// mirror) and the relay the CJS path (requireShared), so this file loads the
+// module BOTH ways rather than trusting one loader to vouch for the other.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The ESM leg: the exact import form scripts/seed-stablecoin-markets.mjs uses.
+import { classifyStablecoin as classifyViaEsm } from '../scripts/shared/stablecoin-classifier.cjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+// The CJS leg: the canonical shared/ copy, the one requireShared prefers.
+const require = createRequire(import.meta.url);
+const { classifyStablecoin } = require('../shared/stablecoin-classifier.cjs');
+
+const { pegThresholds } = JSON.parse(
+  readFileSync(join(repoRoot, 'shared', 'stablecoins.json'), 'utf-8'),
+);
+
+describe('classifyStablecoin — peg boundaries', () => {
+  const at = (price) => classifyStablecoin({ id: 'tether', current_price: price }).pegStatus;
+
+  it('classifies exact $1.00 as ON PEG', () => {
+    assert.equal(at(1.0), 'ON PEG');
+  });
+
+  // Band membership only, with prices safely inside each band. The exact
+  // boundary is NOT testable through price arithmetic: `1.01 - 1.0` is
+  // 0.010000000000000009 in floats, so a coin priced exactly at a threshold
+  // already classified as the worse band before the extraction — behavior at
+  // the boundary is pinned by the byte-parity suite below, not idealized here.
+  it('classifies prices inside the on-peg band as ON PEG', () => {
+    assert.equal(at(1.004), 'ON PEG');
+    assert.equal(at(0.996), 'ON PEG');
+  });
+
+  it('classifies prices between the bands as SLIGHT DEPEG', () => {
+    assert.equal(at(1.008), 'SLIGHT DEPEG');
+    assert.equal(at(0.992), 'SLIGHT DEPEG');
+  });
+
+  it('classifies prices beyond the slight-depeg band as DEPEGGED', () => {
+    assert.equal(at(1.02), 'DEPEGGED');
+    assert.equal(at(0.98), 'DEPEGGED');
+  });
+
+  it('classifies a missing price as DEPEGGED at 100% deviation, not ON PEG at NaN', () => {
+    const coin = classifyStablecoin({ id: 'tether' });
+    assert.equal(coin.pegStatus, 'DEPEGGED');
+    assert.equal(coin.price, 0);
+    assert.equal(coin.deviation, 100);
+  });
+
+  it('classifies on the RAW deviation — rounding the stored percentage never moves a coin across a boundary', () => {
+    // deviation 0.0050004 rounds to the stored "0.500" but exceeds the 0.005
+    // threshold; a classifier reading its own rounded output would say ON PEG.
+    const coin = classifyStablecoin({ id: 'tether', current_price: 1.0050004 });
+    assert.equal(coin.deviation, 0.5);
+    assert.equal(coin.pegStatus, 'SLIGHT DEPEG');
+  });
+
+  it('accepts explicit threshold overrides', () => {
+    assert.equal(
+      classifyStablecoin(
+        { id: 'tether', current_price: 1.04 },
+        { onPegMaxDeviation: 0.05, slightDepegMaxDeviation: 0.1 },
+      ).pegStatus,
+      'ON PEG',
+    );
+  });
+
+  it('ESM and CJS entry points resolve the same implementation behaviour', () => {
+    const row = { id: 'dai', symbol: 'dai', name: 'Dai', current_price: 0.9995, market_cap: 5e9, total_volume: 1e8, price_change_percentage_24h: 0.01, price_change_percentage_7d_in_currency: -0.02, image: 'https://x/dai.png' };
+    assert.deepEqual(classifyViaEsm(row), classifyStablecoin(row));
+  });
+});
+
+describe('classifyStablecoin — byte parity with the replaced inline copies', () => {
+  // The pre-#6319 seeder/relay shaping, frozen verbatim (modulo formatting).
+  // scripts/ais-relay.cjs and scripts/seed-stablecoin-markets.mjs carried
+  // this exact logic; both wrote market:stablecoins:v1.
+  function legacySeederShape(coin) {
+    const price = coin.current_price || 0;
+    const deviation = Math.abs(price - 1.0);
+    let pegStatus;
+    if (deviation <= pegThresholds.onPegMaxDeviation) pegStatus = 'ON PEG';
+    else if (deviation <= pegThresholds.slightDepegMaxDeviation) pegStatus = 'SLIGHT DEPEG';
+    else pegStatus = 'DEPEGGED';
+    return {
+      id: coin.id,
+      symbol: (coin.symbol || '').toUpperCase(),
+      name: coin.name,
+      price,
+      deviation: +(deviation * 100).toFixed(3),
+      pegStatus,
+      marketCap: coin.market_cap || 0,
+      volume24h: coin.total_volume || 0,
+      change24h: coin.price_change_percentage_24h || 0,
+      change7d: coin.price_change_percentage_7d_in_currency || 0,
+      image: coin.image || '',
+    };
+  }
+
+  // Realistic provider rows: CoinGecko /coins/markets output, plus the shapes
+  // the CoinPaprika fallback produces after both seeders' field mapping
+  // (image always '', occasional null percent-changes).
+  const PROVIDER_ROWS = [
+    { id: 'tether', symbol: 'usdt', name: 'Tether', image: 'https://assets.coingecko.com/usdt.png', current_price: 1.001, market_cap: 112_000_000_000, total_volume: 48_000_000_000, price_change_percentage_24h: 0.02, price_change_percentage_7d_in_currency: -0.05 },
+    { id: 'usd-coin', symbol: 'usdc', name: 'USDC', image: 'https://assets.coingecko.com/usdc.png', current_price: 0.9998, market_cap: 33_000_000_000, total_volume: 6_000_000_000, price_change_percentage_24h: -0.01, price_change_percentage_7d_in_currency: 0.0 },
+    // CoinGecko sends null for a change window it cannot compute.
+    { id: 'first-digital-usd', symbol: 'fdusd', name: 'First Digital USD', image: '', current_price: 0.993, market_cap: 2_000_000_000, total_volume: 4_000_000_000, price_change_percentage_24h: null, price_change_percentage_7d_in_currency: null },
+    // CoinPaprika-mapped row: image always ''.
+    { id: 'ethena-usde', symbol: 'usde', name: 'Ethena USDe', image: '', current_price: 0.985, market_cap: 3_000_000_000, total_volume: 90_000_000, price_change_percentage_24h: -0.4, price_change_percentage_7d_in_currency: -1.1 },
+    // Provider glitch: zero/missing price must not throw or go NaN.
+    { id: 'dai', symbol: 'dai', name: 'Dai', image: '', current_price: 0, market_cap: 5_000_000_000, total_volume: 0, price_change_percentage_24h: 0, price_change_percentage_7d_in_currency: 0 },
+    // Threshold-exact prices: parity here is what pins the float-arithmetic
+    // boundary behavior (see the band-membership suite above).
+    { id: 'tether', symbol: 'usdt', name: 'Tether', image: '', current_price: 1.005, market_cap: 1, total_volume: 1, price_change_percentage_24h: 0, price_change_percentage_7d_in_currency: 0 },
+    { id: 'tether', symbol: 'usdt', name: 'Tether', image: '', current_price: 0.99, market_cap: 1, total_volume: 1, price_change_percentage_24h: 0, price_change_percentage_7d_in_currency: 0 },
+  ];
+
+  it('produces byte-identical rows for realistic provider input', () => {
+    for (const row of PROVIDER_ROWS) {
+      assert.equal(
+        JSON.stringify(classifyStablecoin(row)),
+        JSON.stringify(legacySeederShape(row)),
+        `row ${row.id} diverged from the legacy seeder shaping`,
+      );
+    }
+  });
+
+  it('hardens the degenerate cases the seeders previously mis-serialized', () => {
+    // Not parity — documented divergence. A string price passed the legacy
+    // `|| 0` through as a string; a missing name dropped the key entirely.
+    // The shared module keeps the TS handler's coercions for these.
+    const coin = classifyStablecoin({ id: 'x', current_price: '1.001' });
+    assert.equal(coin.price, 1.001);
+    assert.equal(coin.name, '');
+  });
+});
+
+describe('every writer of market:stablecoins:v1 uses the shared classifier', () => {
+  const WRITERS = [
+    'scripts/ais-relay.cjs',
+    'scripts/seed-stablecoin-markets.mjs',
+    'server/worldmonitor/market/v1/list-stablecoin-markets.ts',
+  ];
+
+  for (const relPath of WRITERS) {
+    const source = readFileSync(join(repoRoot, relPath), 'utf-8');
+
+    it(`${relPath} imports stablecoin-classifier.cjs`, () => {
+      assert.match(
+        source,
+        /stablecoin-classifier\.cjs/,
+        `${relPath} no longer references the shared classifier`,
+      );
+    });
+
+    it(`${relPath} carries no private peg classification`, () => {
+      // The status literals and the deviation formula may live ONLY in the
+      // shared module. Their reappearance in a writer is the #6308 drift
+      // pattern starting over.
+      assert.doesNotMatch(
+        source,
+        /['"]SLIGHT DEPEG['"]/,
+        `${relPath} contains a private copy of the peg-status mapping`,
+      );
+      assert.doesNotMatch(
+        source,
+        /Math\.abs\(\s*price\s*-\s*1(\.0)?\s*\)/,
+        `${relPath} contains a private copy of the deviation formula`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
Closes #6319.

## Problem

The `deviation → peg-status` mapping and provider-row shaping for `market:stablecoins:v1` was copy-pasted, in three stylistic variants, in all three writers of that key:

- `scripts/ais-relay.cjs` — backup seeder (CJS, single-line ternary)
- `scripts/seed-stablecoin-markets.mjs` — primary seeder (ESM, if/else-if)
- `server/worldmonitor/market/v1/list-stablecoin-markets.ts` — RPC gap path (TS, if-cascade)

#6308 unified the threshold *numbers* into `shared/stablecoins.json`; the logic applying them still diverged file by file. The two seeders write the **same Redis key**, so a divergence means the stored value depends on which writer ran last — not hypothetical, per the drift #6308 found on the relay.

## Approach

One `classifyStablecoin(providerRow, thresholds?)` in **`shared/stablecoin-classifier.cjs`**, reaching all three runtimes the same way the shared JSON already does (the `rss-allowed-domains.cjs` mechanism the issue pointed at):

- **Relay (CJS):** `requireShared('stablecoin-classifier.cjs')` — root `shared/` first, `scripts/shared/` fallback.
- **Seeder (ESM):** static import of the `scripts/shared/` mirror (this bundle deploys with Railway `rootDirectory=scripts`, where repo-root `shared/` doesn't exist — same pattern as `seed-aviation.mjs`).
- **Edge handler (TS):** direct import with a sibling `.d.cts`; the declared return shape matches the generated `Stablecoin` message field for field.

Default thresholds come from the **sibling** `stablecoins.json` (present and mirror-locked in both homes), so no consumer plumbs them.

The unified shape keeps the TS handler's coercions (`toFiniteNumber`, `String()`), which are byte-identical to the seeders' previous `|| 0` shaping for real provider input, and strictly saner for degenerate rows (a string price no longer serializes as a string into Redis; a missing name no longer drops the key from the JSON).

## Acceptance criteria → where each is enforced

- **One implementation consumed by all three writers** — writers now call `classifyStablecoin()`; `tests/stablecoin-classifier.test.mjs` asserts each file references the module **and** no longer contains the peg-status literals or the deviation formula, so a private copy can't quietly come back.
- **A test that fails if any writer stops using it** — same suite; it also loads the module through both entry forms the writers use (ESM static import of the mirror, CJS `require` of the root copy).
- **Byte-identical `market:stablecoins:v1` payloads** — parity suite compares the shared classifier against the frozen pre-#6319 inline shaping over realistic CoinGecko/CoinPaprika rows, including `null` change windows, zero prices, and threshold-exact prices (which pin the float-arithmetic boundary behavior).
- **Relay watch paths cover the new module** — `scripts/shared/stablecoin-classifier.cjs` + `shared/stablecoin-classifier.cjs` added to the `ais-relay` service, the mirror path to `seed-bundle-market-backup` (the root path there is rejected as extraneous by the closure audit, which models the seeder's mirror-only import). Verified by `railway-watch-path-audit.test.mjs`.

The mirror pair — and `stablecoins.json`, which was previously unlocked — are now pinned in `scripts-shared-mirror.test.mjs`. No `Dockerfile.relay` change needed: it blanket-copies `shared/`, which `requireShared` prefers.

## Verification

- `tests/stablecoin-classifier.test.mjs`: 16/16
- `scripts-shared-mirror` + `railway-watch-path-audit` + `dockerfile-relay-imports` + `railway-deploy-trigger`: 153/153
- `stablecoin-coin-filter` + `shared-relay` + `seed-envelope-parity`: 64/64, `mcp-api-parity` + `route-cache-tier`: 31/31
- `tsc --noEmit` (root + `tsconfig.api.json`), `biome lint`, `node --check` on the relay: clean
