### PR TITLE
docs(resilience): commit the education post-flip acceptance artifact (#6460)

### DIFF
--- a/docs/snapshots/resilience-education-acceptance-2026-08-13.json
+++ b/docs/snapshots/resilience-education-acceptance-2026-08-13.json
@@ -1,0 +1,5001 @@
+{
+  "schemaVersion": 2,
+  "measuredAt": "2026-08-13T07:37:45.159Z",
+  "capture": {
+    "source": "production-seed-dry-run",
+    "activeFormula": "pc",
+    "startedAt": "2026-08-13T07:36:48.462Z",
+    "completedAt": "2026-08-13T07:37:45.159Z",
+    "harness": "scripts/dry-run-resilience-education-flip.mjs",
+    "harnessCommitSha": "465c3837cf51403e9eee1cf1afb5ca05b37e366c",
+    "harnessSha256": "257ac3adf845690ac4902618e10a2fd0e800309b8ffef740436785ea987c4664",
+    "redis": {
+      "source": "production-upstash-redis-rest",
+      "resolvedKeyCount": 647,
+      "keyDigests": {
+        "conflict:ucdp-events:v1": "f077acb1bfb95a2419fa0bb3eda902901b21882c656652129bc50da241c32e52",
+        "cyber:threats:v2": "ad83ac0908d18815ad506f1443718a979529c581842f4a655461c85353cae2e4",
+        "displacement:summary:v1:2026": "3be8f2edaca74014907b894b46fd072743660f44dd43340eff384b7ba28babbe",
+        "economic:bis:dsr:v1": "12a76f9aa70ddf309ee4ae0e7443ae31d5af607e2886daa840b7c84358ed41b8",
+        "economic:energy:v1:all": "b5e126d4329347c93b659c763b78bd4a6eed374b8cdb90ed3ab48aec2c790819",
+        "economic:imf:labor:v1": "776308255e816e7986ca755854a5c7a31de34a703c06fd650caf7b13bd325d97",
+        "economic:imf:macro:v2": "d55544280c5b0e5ab83493e269d9f958a17fcfb2f0cd3bfc8f0063846c106a10",
+        "economic:national-debt:v1": "0d7bfe78915103395189cbadc6615870b8d3393e4b7089ed88ee7dd9756eb303",
+        "energy:gas-storage:v1:AD": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:AE": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:AF": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:AG": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:AL": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:AM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:AO": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:AR": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:AT": "b33f89c389160d5ae9aa68acf6c7c4a6ea55226b8da2942e717779f970b7119c",
+        "energy:gas-storage:v1:AU": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:AZ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BB": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BD": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BE": "601b8ce18e3244cb4592865cbdbdd10583362e91b7f4a778cc42bb94666d3c11",
+        "energy:gas-storage:v1:BF": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BG": "becb580f58eaf35d39e557dbb5f7e04ea83a8c208d04ae93ccecc54b7862868f",
+        "energy:gas-storage:v1:BH": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BI": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BJ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BN": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BO": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BR": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BS": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BT": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BW": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BY": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:BZ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CD": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CF": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CG": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CH": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CI": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CL": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CN": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CO": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CR": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CU": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CV": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:CY": "7e09e2b78e1c56535fa2e3599c96c5401cfa99f6a72c06b9f66dc843a4eb0e6f",
+        "energy:gas-storage:v1:CZ": "bf88782e951ba0aa9d51a05fb1b9c8063a50bf589cc5725c2f299cea18ffb741",
+        "energy:gas-storage:v1:DE": "78b14570e59cbf49c96a3ef01c8711478e6482b422f0f5558ff414c997ede1b6",
+        "energy:gas-storage:v1:DJ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:DK": "ee9f5d8e2956c7a2e873f128e6a8dd0971c9c1d27edeff1501fbbcd908b5dbfd",
+        "energy:gas-storage:v1:DM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:DO": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:DZ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:EC": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:EE": "63aa794c99dcf6c23e7426f70d7063b1175de225733e4de157af0ce6171f45c0",
+        "energy:gas-storage:v1:EG": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:ER": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:ES": "5fb1bbc259a5d641dbb2f9d4b3d90075d60f781d8890ca0ba5ce81f06ea0d728",
+        "energy:gas-storage:v1:ET": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:FI": "8dd25b5312cb9f5bd920dbe6a5d10abe825d3c8425b5f44b571211be04c40ec4",
+        "energy:gas-storage:v1:FJ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:FM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:FR": "72043ab5cd181671a5e87b9daaa3da6ff62692af5a78950be5788c9c0616e417",
+        "energy:gas-storage:v1:GA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:GB": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:GD": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:GE": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:GH": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:GM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:GN": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:GQ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:GR": "3fc61019a7d717372a3b7b53009f75325fe642ffb3ea54801e55c5c40e416d25",
+        "energy:gas-storage:v1:GT": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:GW": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:GY": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:HK": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:HN": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:HR": "224899f99d1c6eda82572df0dba8caee813527ea83095b39a4c0c452125a95a0",
+        "energy:gas-storage:v1:HT": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:HU": "878ed283afa005e8b0f208ed26f15f8959c86051e34c761e751f55fd26aa67be",
+        "energy:gas-storage:v1:ID": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:IE": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:IL": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:IN": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:IQ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:IR": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:IS": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:IT": "eacef79fbde2cc83733ee6a9945c2556dc5869473977c3691d743bc3bce44ce3",
+        "energy:gas-storage:v1:JM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:JO": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:JP": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:KE": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:KG": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:KH": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:KI": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:KM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:KN": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:KP": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:KR": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:KW": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:KZ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:LA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:LB": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:LC": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:LI": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:LK": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:LR": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:LS": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:LT": "0ac562dfe80d88ca7f40fe417c7927459ffd530306bde822e04e816c25d75b95",
+        "energy:gas-storage:v1:LU": "75fce0bed2a5e7eb1f09d96a3e03739cf072e2b0b8e6874c277ed0d50e5cb5ef",
+        "energy:gas-storage:v1:LV": "19f4b6c838cd79f2d647f223515b9f841d958ce64fd298540b29e6bc7c85c6f0",
+        "energy:gas-storage:v1:LY": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MC": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MD": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:ME": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MG": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MH": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MK": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:ML": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MN": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MO": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MR": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MT": "2ec51ee65897cb3b3b9b9c6d28d43c0c35eb754ac73049a2c2f81a471bdb526d",
+        "energy:gas-storage:v1:MU": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MV": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MW": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MX": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MY": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:MZ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:NA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:NE": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:NG": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:NI": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:NL": "506cd3a5fbca39d6231041ac07fa57243372378b39bcd4cc9a633c09f5cb7e54",
+        "energy:gas-storage:v1:NO": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:NP": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:NR": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:NZ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:OM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:PA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:PE": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:PG": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:PH": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:PK": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:PL": "db1dd13eb899bb8c1c7561108afea662509a90dc3337a2c6b6a625cdc5e1c11b",
+        "energy:gas-storage:v1:PT": "ad2f4e4fc8197e43581f07efe68cc93a63a6478b1e0a00e9b6022949820f2309",
+        "energy:gas-storage:v1:PW": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:PY": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:QA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:RO": "01d389884a66172ae4a717d1b66c9f63fafbc360c13a2a7f31b3a74297648cd1",
+        "energy:gas-storage:v1:RS": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:RU": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:RW": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SB": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SC": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SD": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SE": "53618293bfabcaa3e2cca819456c15d82b98b0b8aba411f6c366fe58af80c55c",
+        "energy:gas-storage:v1:SG": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SI": "f7893e1b5599c96f2c7727db345e1ac32cd9fd4e5dfd585a12eb1af09fca4471",
+        "energy:gas-storage:v1:SK": "39eb923841b1963958db5f851b0a381d5d300de06aa7a1efe1a8aae3f8bdc1ae",
+        "energy:gas-storage:v1:SL": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SN": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SO": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SR": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SS": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:ST": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SV": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SY": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:SZ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TD": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TG": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TH": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TJ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TL": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TN": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TO": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TR": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TT": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TV": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TW": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:TZ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:UA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:UG": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:US": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:UY": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:UZ": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:VC": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:VE": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:VN": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:VU": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:WS": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:YE": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:ZA": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:ZM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:gas-storage:v1:ZW": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:mix:v1:AD": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:mix:v1:AE": "b4d8f4a0d10107016b46d563f7d6eac29f154721b68290e7fe2e4303a237e323",
+        "energy:mix:v1:AF": "260f700246573ad15f9d6c29aea8cebf405cf0f97a7398cf3fdd32b592620acf",
+        "energy:mix:v1:AG": "9c0fb181f3c07b1752b5e030c1f88d25dcc79b1b240e8007994973e6102a8fd0",
+        "energy:mix:v1:AL": "bbebd27b5daa4bd92b7db283c84e0a5c3bdf683cf1896a834eda7b2c6a7c663c",
+        "energy:mix:v1:AM": "df0de68d43130d606f1b0ff887219afa663a124f6011165a51f98a1ba21dcd0a",
+        "energy:mix:v1:AO": "ed39947f7e57988d883eab77942ae23e32838407a78098691524301703bc8d9f",
+        "energy:mix:v1:AR": "f479000ac21499c43ebbef38852bf532de054992494ea131f3ae5d872a7284cd",
+        "energy:mix:v1:AT": "becf7d953434f6851171570a1cec568371f404c5c9a7e74a7d2f892873b97aaf",
+        "energy:mix:v1:AU": "1a4dd62526c4cd94b6152b95bfd63113ebe0e2fe10e3bdbe000b1db2ba452c78",
+        "energy:mix:v1:AZ": "c268697e8ebd1a897ce6da30d2a7528ba3f1cea1b79357eb0d34847bb1ebe126",
+        "energy:mix:v1:BA": "ec72c58f6efb8fe0c49b8f221f9488300e38ac349bca6d85a32aecb23f314825",
+        "energy:mix:v1:BB": "8a3fbeb247a85dceaa71231ef4a0419e6f659ded77cdfd87a824278f5bf79b98",
+        "energy:mix:v1:BD": "a0e5b9b8375b6aaeb161329b770a09f289c78af5af0f26f0afcaf1a3b345b7a1",
+        "energy:mix:v1:BE": "a0f4329913c8d35f4da12d7798cdf8ce47fee5b9895266c2a71eddf9d3b1a20a",
+        "energy:mix:v1:BF": "2215ea84e50ff75f438b81aa07ee76bc3b797ecbf7709fe4ce7710772051fd58",
+        "energy:mix:v1:BG": "9769929f42f1e11c58f12017779aede516a11036465c30a1b5941b71a6f20c6f",
+        "energy:mix:v1:BH": "d95e26bf68252d7c5aff099b7bf4adadc747eb41190238081f546a848dc190d9",
+        "energy:mix:v1:BI": "1e316f3b6a9dd595929cf35b5f4df1644a3f8a7d0e950f4a18be8977360bdc25",
+        "energy:mix:v1:BJ": "649f32adc6fe6a1d808ed21a78a28f87e43d4ba1dc9a9008dd0df1fe60cd334d",
+        "energy:mix:v1:BN": "c7c861899a9daa2fe49a23a3c964f92587ebd4f918d507dfda5ea175fbbe895e",
+        "energy:mix:v1:BO": "dde48023470ae0139b7d4ce4dcf01e2af18f39e173cf3f655d8e12892a9deb75",
+        "energy:mix:v1:BR": "7226d173f8e7f3ea8f2a8f01d89c7b64d302e7d1be5f8e9dcb77bdea11b7c4e8",
+        "energy:mix:v1:BS": "71d1a4124d65261940a7144fe939877f76d0b1cae1cd23f4f6bbc15abb60ac81",
+        "energy:mix:v1:BT": "8ec265f360c8682d3ac861fa425d16c370cb5a3a79fcf68476803d77d6d221a5",
+        "energy:mix:v1:BW": "58c66eda0f308f15dc996f0c792db7f00d6baf4ed09ce53c5361a86a9c5390c6",
+        "energy:mix:v1:BY": "789f560042de0c9c84f5ad78805a64b0493ef0b823928a4a9e8a15406c674120",
+        "energy:mix:v1:BZ": "8551a8a7f5e9ac16cefe0cf0da7c2e5eb8465290565bf4d219316e18d3638749",
+        "energy:mix:v1:CA": "6f191d10251ae3e5273cba109679f2ad021450d2ce6c8ca4fffe4a52e78087d6",
+        "energy:mix:v1:CD": "09495fa90b4d0f6722709c421aef01d5a2914c266e5312e945ef118ee8ab9055",
+        "energy:mix:v1:CF": "4c7c0bd9b782b86e0fb1e9cdd27b7a8bba38172fe0ec9f2916fd8a6b07036dcc",
+        "energy:mix:v1:CG": "3f44222b75c991f00b645842a17ea9664a385c72d839166dc4e9833fc9252da6",
+        "energy:mix:v1:CH": "c9ae22cc3a1d7129d0e3e96cc66c837d2b180db1a52dfd5575de4c1154fcc049",
+        "energy:mix:v1:CI": "9da7a23472247e4bdcb126a04bcc007c0ddae56158ceff9382acf6377cf51296",
+        "energy:mix:v1:CL": "29644c407ed2b609a214e7bac7fb98eaef3c7d1f14012b2c7466e42be8ffa8aa",
+        "energy:mix:v1:CM": "0d3cd2e9f4fb8fc9fee4db806d100954a3568d5afb0261d17e330420e033b57e",
+        "energy:mix:v1:CN": "dac165ab65646f7d396937f56ba59d5ebb891e1aa55ad8e1588d1c328ac8fc84",
+        "energy:mix:v1:CO": "0103d9bb599447dc7872dcbd2e5452a4bb6f1fd6cfec917e9c95910d3d0936d0",
+        "energy:mix:v1:CR": "e28cb7b9a9d4defe3ec8ff7a31d2b13a86944f708e53d9df42d3681f91a1fe51",
+        "energy:mix:v1:CU": "ac79f22f0b1c45a1dcb0007962b80fc089bde0490e38192f8e96531d427487f0",
+        "energy:mix:v1:CV": "e54cac7078d870050dd0dde797b9a2ceb907e5699d7c34eddcf4c86678066a3f",
+        "energy:mix:v1:CY": "250316e30de6d264a8ce8c2be0fbc6325f5d8d522c3c737cff496c3d4e2246e1",
+        "energy:mix:v1:CZ": "d01f32728e681297751c08600f8f7e43423eb10ee3cb4a62898420b39118aac7",
+        "energy:mix:v1:DE": "d96d38faabe451b32d7f6664200a40b91664ae5587be7a005940d08667fe9f31",
+        "energy:mix:v1:DJ": "301fde755f2a4a78f0fbcd08445842bde5a91f0511e1672d052846f01776c4c8",
+        "energy:mix:v1:DK": "e22bf536cb4215d8502760ae944a29b57b84b49b61215cb6016708b6a5179db1",
+        "energy:mix:v1:DM": "9172299ed0894eb2be0345b8ec378d231db98fe9197321c0ca0ce7825f8068c9",
+        "energy:mix:v1:DO": "d188b7d349c580ec27478659d9c6add1e21214d13f96c35bb62f2c9136f8d3ac",
+        "energy:mix:v1:DZ": "9d8fc904d79e5d0dd683bce7faa6699e8e1f3cc9c219cd1c2a7257590d2f75e4",
+        "energy:mix:v1:EC": "f6e079da6cde849509e793e86011ad33388f3d2192de0b9fd4a3c461c8efc707",
+        "energy:mix:v1:EE": "fbb0927bcddbc6c00c59ee6dcff597ddecf451472a36127f4404dfa5e27fe00d",
+        "energy:mix:v1:EG": "ef73d31ebfa6772020027dd9149ff9894b4d278da8816a7725764bb383392a0d",
+        "energy:mix:v1:ER": "7dea6689a50f389406378728d0cbc692cd39c569f20ff9cefd0a3e49582feb0a",
+        "energy:mix:v1:ES": "daf1848ae00126718c575888a8ee80ef3335cac382a89ccf8687abf9e30b36ad",
+        "energy:mix:v1:ET": "ea98a6412944a13f7499fdd47767081512a3478d27a28c0aa765485f5e49038f",
+        "energy:mix:v1:FI": "adcfa5811ff65cd185b4e48475d050e9a367f9d17b1c482674c136f448926c53",
+        "energy:mix:v1:FJ": "57efd634b35b8155bbe7874ed977c2038ed60e47876fda8c57e38a77ab755ad7",
+        "energy:mix:v1:FM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:mix:v1:FR": "47f6d203fb7dae6ccfddb3043b3f8c6d41d76aa002efe6a4474201165f4683f0",
+        "energy:mix:v1:GA": "cdd11794a746ae59d681e0e2d599b765768c33e83886bfaeb91d144ed4d1390c",
+        "energy:mix:v1:GB": "6b9e6001790be4961e6d5072842b48498564464772c4198a012efbf12c45457e",
+        "energy:mix:v1:GD": "0153c5c1e55966acbe25b409cf40b06c6f6be27be1771b7dcdd38dabb77118c1",
+        "energy:mix:v1:GE": "ea3dab26159f4bf0b70d3436cf805813c770184556e522741914e6b782efc229",
+        "energy:mix:v1:GH": "4f9aa02a91cef7590536cfae4047b388af18a4b622c343662dab1de295f7dc2c",
+        "energy:mix:v1:GM": "7a9a7c846dd36fad8ce3a93674ae30e78b443a104aeedf76761fa234b751cc2b",
+        "energy:mix:v1:GN": "1d6b74a6821df314c668d5c75e2cfb5ff7d1a781cf840a5c0989d6b66c662565",
+        "energy:mix:v1:GQ": "b2b1bccde520e3b4d31cc876f67ad610cb2c1bc504703dbdf1e7850ee3b0316a",
+        "energy:mix:v1:GR": "1656db72df70f2e48f1fde36d12d530cf0c90d3e3e69557139dbe8be00753a97",
+        "energy:mix:v1:GT": "6c70a47a5e3cca62d5b5078ae19351015413dace565839af0b8a53baa6e8c4f8",
+        "energy:mix:v1:GW": "6227e86afd8e34e54bdd464ea2c8e45be1a6a4e9d42044821069ad6d53ac0371",
+        "energy:mix:v1:GY": "ea26a798194ea06782def618474987cf96838e6bd7ac76394d336bc0dfefe584",
+        "energy:mix:v1:HK": "bc844953b0a9a07246b2f4c125da1b65b3a335c512986434a953bc6a876de2ff",
+        "energy:mix:v1:HN": "65efd9245c08d642c1d6b2588b80627af52a7acc621a6862a67673eb90c1827c",
+        "energy:mix:v1:HR": "9d411e1a319fc2d4d6b5032596f760c8ef7fc97e25c02fb06c3e015253e700e3",
+        "energy:mix:v1:HT": "41fc28b3653574d731fcb684271a180b79a3fdaea143097aef08aeadfcd14b0f",
+        "energy:mix:v1:HU": "16392c47c933d39c869bc6400fc69f54145b84a4fef302c0ee60933218557c57",
+        "energy:mix:v1:ID": "557b5752029407d7ca7e1c3e8f586fd6811be0027c824c4f553bf81df4ae3f22",
+        "energy:mix:v1:IE": "f5415c4d51013924aeae6cffc7556f4b3d50f9d696cf51335cd6a23d2e26d72a",
+        "energy:mix:v1:IL": "fae850e2745b020f2b17a16eb72d7484ca514a6f325c72412eb39a10822c5346",
+        "energy:mix:v1:IN": "d9bc46328ff1ccf5778f2820cb4df7e99af96343eb90db5775cafcc20fb7e121",
+        "energy:mix:v1:IQ": "23cb6bec880b85b15ba646764d2406fbd5da8beae89e4dd3ead61e9678f0d11b",
+        "energy:mix:v1:IR": "8dc3a97bf4c57c32dc1c590a9bad69ee8e67c2bde53169b28e8d077014b3e2c7",
+        "energy:mix:v1:IS": "773f7ee7a5ee37a9e36f034176751e8e9207da4145152cae142e9f57662f3169",
+        "energy:mix:v1:IT": "fe53ce38d3e73f3e88c9607af4986923015242633b840eef30ea72a83ed27337",
+        "energy:mix:v1:JM": "a16b0f7cd6a1609984aabf37f58d14ebff6e50b5bfbba29227975281849f5278",
+        "energy:mix:v1:JO": "07f6556a3723ef429eae02cf6e5661243238cc724ef870f8c134fee0807eb4bf",
+        "energy:mix:v1:JP": "02c0942680088ad5f3a2cde78ab332c63f3aa4e4c43ce1848b892641ea7e3423",
+        "energy:mix:v1:KE": "d7b0e65f1a626f4902b6257daa7690c497a48e6ea91d0eeb93ad27c74509573d",
+        "energy:mix:v1:KG": "a20832708cd20130cc337fb7fe16d52661030959e5625a35fe76fd327a727649",
+        "energy:mix:v1:KH": "b6b5580c46e7395c792a98d7c1ac4c23e96b992e87a80c7de77595f56fcc0b53",
+        "energy:mix:v1:KI": "5d6cd905e00a75d3743c054a8a9ddb91cd01d2adc63de7dde0d2c66c25455e59",
+        "energy:mix:v1:KM": "1d11cc0a19c819519223a01234197dccbd4df3720ae2125e030b67401601db2e",
+        "energy:mix:v1:KN": "4385f77454b1edf5221e705cdde238133cb05f28c88f6833ff462d75d99885be",
+        "energy:mix:v1:KP": "04b45bc95585c91b7ab12e253f9fcce6098fb22dc128084353b58d0583965dd6",
+        "energy:mix:v1:KR": "39a0881290471b745681639811e4ec3f5a07d0c160c79a26f11492fbc413b3aa",
+        "energy:mix:v1:KW": "73caae6a93cb244b218b351277eb2b08bfeb63a68785d3cba7c65d9316618e6b",
+        "energy:mix:v1:KZ": "4be895e8a9e945a2dc066c640624c36a9d1c4c7b4908c30070c9dde3d74921b6",
+        "energy:mix:v1:LA": "b93df6598a5fa594a5066d1084c501b33886a4cb8bd39329704ba3caf3f8b85c",
+        "energy:mix:v1:LB": "3c38cc8b6779566655c3546e1c060e6f5df2d8c9270d1c31b513d9a14196dcfd",
+        "energy:mix:v1:LC": "b4b0b9037b8ec478ad500da3010ec852b62bebe8d23bd51350541bc5b7f8a74f",
+        "energy:mix:v1:LI": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:mix:v1:LK": "bb437fff22b4e28216ef8f5140b3f2c95af1293b4a45ed45a2f9cf8e31e6c6a8",
+        "energy:mix:v1:LR": "860984d0fdafdaa7e77972dd36359f245d22f4e9bab11481a40b957a6c59b52f",
+        "energy:mix:v1:LS": "c87b5da7da29b95fbf630023c9dd1555b87a36d534b58c04d0e8c7b8413a9bd6",
+        "energy:mix:v1:LT": "097bffee62e606815269d0da95b7f2e4270889178d6c34fbc99d318a252a00de",
+        "energy:mix:v1:LU": "22e4911b8ba946d3cc3bae064924cfa559fba095ee723eaadfecd238e63fa395",
+        "energy:mix:v1:LV": "1bb29051060f86580675ec311a3686981495ccbcab70b5e14887dc4c8017faf5",
+        "energy:mix:v1:LY": "43c5699e7d76fb63b036a14a93923031d1a05238fa6fb183acc70eb40c26b6f5",
+        "energy:mix:v1:MA": "f98837ee4b9c7ae54b5d850a5702bd48071526e2a7464081088afd139fdce2a0",
+        "energy:mix:v1:MC": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:mix:v1:MD": "52f7aa387cfd3c2b6166ea7a50b0a5cef3dd4bbbe26eb17efabe6edd8b35644d",
+        "energy:mix:v1:ME": "e567b68f1f31340ee83c679027044efabe9de845c01f44d2cab0f406a425587d",
+        "energy:mix:v1:MG": "6709a8e096dec46771f13eaaa26e602dea7fed3b50d363fef4e2b3f497eab9e8",
+        "energy:mix:v1:MH": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:mix:v1:MK": "49cce3357492e965a7392f22ca1731ad12209526859e2b6a4374ed7110ea841f",
+        "energy:mix:v1:ML": "79b4edfb46daf12294d8e33fa47740dcc2e7bfa255fcc274d98dd7da05d2670d",
+        "energy:mix:v1:MM": "6b81d2a08fa9ab74f55f81d781a34bb07d336b7a7d6d89a4b5a2136a14f84129",
+        "energy:mix:v1:MN": "91094c4231e2c5e260b2f5ab4af74dac1de96bcd0cbfc27f67c60ab81474d14f",
+        "energy:mix:v1:MO": "87c7cd3b57bfa3cf7407ccdaa41f9ae2e1fe47db921c6b3d77318c473e093d33",
+        "energy:mix:v1:MR": "82f9389f989a2a491224110d71232bc56f98428a89c0205743b01eeb9f6dfa74",
+        "energy:mix:v1:MT": "72f4ae35546b51064f66d46eca05e8158ddc20b8bedcd5e5b11a7d85060a16f0",
+        "energy:mix:v1:MU": "2981011a12fb82755bfbf871e7862b108ee36db0f214f5a143e72993f31522be",
+        "energy:mix:v1:MV": "5c28b7fc646cd8748bff30c8c6af67ca06eb477ec4cac78bfa2e2a9e6ef629e8",
+        "energy:mix:v1:MW": "cae2929c2c2b4a944d060c8b3e78500e40904ed5060acf2a245720dc19476f42",
+        "energy:mix:v1:MX": "8ed80b263d066211a547db865c2c4f0f168abeae8ea7d1aad2a768935a2d787a",
+        "energy:mix:v1:MY": "d8f61e0360ee42823fe09060682180e4d1b42658bae575ebbf2974b6dc964384",
+        "energy:mix:v1:MZ": "ac3d48159f90b11ebd7c738bf9150c8a148743694c8bc58e5fb4a82ee18e6f36",
+        "energy:mix:v1:NA": "d14e306530be6f46165862cb497374534d3cb4299b3e996182df36396fd3dca3",
+        "energy:mix:v1:NE": "b44eb76abb3ec2854a92d9523685b935d8be2d0957d76e91a972933ae5935630",
+        "energy:mix:v1:NG": "06756208f43f1b082df5b1f2909a28ad6b726a30b144b63cf708992ff47ba886",
+        "energy:mix:v1:NI": "e43d04df84b79ad802888742ef856ef464152fc820f7339d92c0152a4ac84277",
+        "energy:mix:v1:NL": "a2c8ef81f04c60b3c793792278635d18262eceb944e9029ab45e7eae38462e96",
+        "energy:mix:v1:NO": "cb58025f456ebcba78aa1de40096a471fbf7a01dc598227120e6c1b75671e75b",
+        "energy:mix:v1:NP": "76599bc95fd26661651d7a85f96b52831bd575addfe58fadbf23d0fbc0822389",
+        "energy:mix:v1:NR": "0ca3b23e99a3a7c4e17f2e3dbea9bf118b870c2083251e57f318c3faa92823a9",
+        "energy:mix:v1:NZ": "273a976c70a0503c4049455921ccfffbec6b9d2648a9bdba28150962a78153c1",
+        "energy:mix:v1:OM": "01435a1f8c394acd83efb66d547efa7c089e8902bf835efadbe4bf203b219007",
+        "energy:mix:v1:PA": "659f9f1548a0f8af3c9aa1ff023f0ea2fadb2f862185b7afff78b003bfe2338f",
+        "energy:mix:v1:PE": "63482da2a196e858830fc05a8d8fc2ac8b719b67bab4bf93fe3613925b35dabc",
+        "energy:mix:v1:PG": "7287a8248e391ae231f8b89cf5954167c880e15581a48b812c1f1754ffb8b598",
+        "energy:mix:v1:PH": "a482b1987718f0fdf3dbfca15bd5b7ac88dd8f00a42e3a6afe0da107599f75a5",
+        "energy:mix:v1:PK": "6732b83dee91f430c3239b05ccc8ff54bbb2f6a9ef0a021f88e17f509c731749",
+        "energy:mix:v1:PL": "78ed347f8565c41146ee1581378ea15c7b7eec06856c4cc1fb53b7159ffa4702",
+        "energy:mix:v1:PT": "1c2160aab5eb61a2afbccf7144a822ee2cf0655612be3d9989fedbedd6499f3d",
+        "energy:mix:v1:PW": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:mix:v1:PY": "42a4c2cd7a3db29a0e909abf57d45a9aae6e0821cf8e18c9c8fbc6b381d1ddd4",
+        "energy:mix:v1:QA": "363cb6aece47ee5d6d5681705950acdcda98fc27f3f5f875b5838d1eeb32cc37",
+        "energy:mix:v1:RO": "5d9fca90ec9084af8582a4dcb557e1114404072133558cc2f37826a208a63e62",
+        "energy:mix:v1:RS": "f9f42f77d497fc616acb5aebba11b6ae0d04db44d99dfa94d67674e203e33ea2",
+        "energy:mix:v1:RU": "4f55fa93283a195b1c00d123b848cc46d1582e1edfd6c5a54757573230d537a2",
+        "energy:mix:v1:RW": "d03d3c33f612d352075dbda30a68044c0847b004045afdfa66f70283edeab159",
+        "energy:mix:v1:SA": "e6ff5253339981ba4ebc898b12f15ba632abf6d7db96e395b18e5f4220f1fbf6",
+        "energy:mix:v1:SB": "19f13072d01830e9dcd9d8e0b22fca1f5bd648a422811f31b1c6b0ebb225d1d0",
+        "energy:mix:v1:SC": "a28e26dfbfb8013df642cdd6768c735edf4619a0ead35740262a1261994cc432",
+        "energy:mix:v1:SD": "ad32c6cf8b626a3e1eb73536977374e714439d9a7b0204b81628110db4cdb23b",
+        "energy:mix:v1:SE": "d1c6de498fed7aac58ce4e32eff37b7ceaf0660c7d796c3092346e9db8e60c92",
+        "energy:mix:v1:SG": "36b7f75f283afb2c6b37e945dd9fd1b4716da1d10ad274fa79d93b70da2ca3c4",
+        "energy:mix:v1:SI": "983756058a63c13fe68ae548c2c9d309a20b3e8b7d577b4779461bf05b1ffca8",
+        "energy:mix:v1:SK": "0ebf4f07f5dbdf6f46437c1f9172072282f91342e6bf6231642821262f77f918",
+        "energy:mix:v1:SL": "d90c2e83ec413add4be16dfb3a34f60184a93abc9e85d54a32c2c1cc454d46fd",
+        "energy:mix:v1:SM": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:mix:v1:SN": "3bc31c72ffe886ecfcccae0b51ab1c8e8af8a4bd3e3fa11cfec53895f5e45307",
+        "energy:mix:v1:SO": "41e22d2dab96b75c53d96f4666b5da5b9ef4eaeeac039b92a56d1c8e6fd5c071",
+        "energy:mix:v1:SR": "912fd398e1f67abae1470d5a1da809c06b9ebb41016f9ff18cd968e509e51e3a",
+        "energy:mix:v1:SS": "5b0be8f05b72c11c4472e34ca39e570b220e1f1842d6ee4fc525803292fa6e82",
+        "energy:mix:v1:ST": "c9a574c81e1e00c904ea8a854710831e3b36ffdd7bbd299081d44d5a85e7183b",
+        "energy:mix:v1:SV": "807e25a1f9979d8d2e4214184f6cf38eff8bc2a93bba6b80a9f1883dadcb12ed",
+        "energy:mix:v1:SY": "d08de28422517cd01237d877091123d7e3bc4c1a4eb35f9c4155f0b9652b339c",
+        "energy:mix:v1:SZ": "90859e51d83cfa92121b7b7acac429f0791e66959a5a8d18d0dc582d5ac58bc0",
+        "energy:mix:v1:TD": "7aed544ae9c4692e37dd99dcf4ff7fe69d7c3b1073d9b71aed56618d49dd636c",
+        "energy:mix:v1:TG": "d60bb31b82a6ca6dec2bcee10a44314f890db50b1c3371522277ff08ea0687bd",
+        "energy:mix:v1:TH": "89850ca713cec6a13fed2ff693c88e5c1c511b9f9823ece41499864c79d97691",
+        "energy:mix:v1:TJ": "03b83003219f3b9f847f4821e1e68f6738e3f014e0dd83fdc76f37a937cd8fa2",
+        "energy:mix:v1:TL": "d6740a2884b0f1290adbb407048ce5eebe9486ba24afe7bf4682da8fd88b569c",
+        "energy:mix:v1:TM": "d87cc3fdc6681e584c36c2f2845fc6059c8b852037959c4f9bcdb18f4868c383",
+        "energy:mix:v1:TN": "9750faf3da25cb5336f88101f7b6f74f0e8a4923c9013e1147eb3b12fe7aeabb",
+        "energy:mix:v1:TO": "b6eb5f5536ff69556b6be9f8a93855643066a70df67f8c7746308508f9a368ff",
+        "energy:mix:v1:TR": "a1c5e837a2ec23ec71fafbd1c6cbef17a0b9f9bc03f54a1719ef46394e657894",
+        "energy:mix:v1:TT": "eedda6188d21e55aabd6e8c54d6800f96e1e950957ab6bc2a547695cdac8a8c4",
+        "energy:mix:v1:TV": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "energy:mix:v1:TW": "cf8c30d0db1eb659670c9915807316d1b1a9fe485c6c94e860094b7d927e95bc",
+        "energy:mix:v1:TZ": "c93bdefaeeb63be9fd6f17226c2c99dbe5f2835d541ac9b0eddb79c1f171f0a3",
+        "energy:mix:v1:UA": "ce2a2556986e84a2d6cd4a364c475b87eea48271e17e7e11dc130c5b62f124ef",
+        "energy:mix:v1:UG": "9a67a09c06ed73c7d87d8b2e58b70c205ee016b4797a8d4e1edb9dddc039d77f",
+        "energy:mix:v1:US": "72e9fb7fa9eed7d93f0e9eb94ea620db02c32fea0b6fea462768f46e236f67d7",
+        "energy:mix:v1:UY": "749744ce597fda240a100475e1ef63a31b1e2d40c18d8399aaece9fce39c6922",
+        "energy:mix:v1:UZ": "9066482618888be2c3085201d2a44da07c7d54f4c97e176bc46b19eb1915085a",
+        "energy:mix:v1:VC": "1f4ef2ac21efd73fd121d3b921dae7f04fe25d12dfee251ec86672e1a4fa6113",
+        "energy:mix:v1:VE": "35562a2585f4eb791c8132e2b2691eb1e997803e88d09981efa4536f97a3681c",
+        "energy:mix:v1:VN": "d561150b7268d4157f2745891e813b36872c339cf7493ee859d7fcdff1d989ef",
+        "energy:mix:v1:VU": "76f7f18e902f16d87bc85967c9c7ded0440c06e0cea2eca992c874573ebef061",
+        "energy:mix:v1:WS": "eb3f987be4ac2c34b3cca83b7d6743b064a9c7986f3be25e7adb31c6944b4797",
+        "energy:mix:v1:YE": "3a38b0b0d5112a984a4814b92b39ca79e5c66e90b1eb43d57907e3bca688f9c0",
+        "energy:mix:v1:ZA": "796ea4b74a4ac7efecfa2f7c27f7ddd3ff6fb44a32bcb0a6dfd8c67960b821ce",
+        "energy:mix:v1:ZM": "1358b11e0a966a880d2fdfbd12940ec0f364a9b7fae46086772b76d1235c5a65",
+        "energy:mix:v1:ZW": "90e3937d8450fb04f4e57972f320d2317a8aceb53c00708f3ef372ced683f2ea",
+        "infra:outages:v1": "8c4558311ebd683c7e046c09208f89243caf0c7109d05cb34b41ee9ff39111c4",
+        "intelligence:gpsjam:v2": "8f6f09a1574cd526b687b78214e380be0c42e056f6b33951d6f9d806458d26c1",
+        "intelligence:social:reddit:v1": "dd451291d172fe885fd47bced34edb3dd6ea6b81520965dc7827b9256ea2085c",
+        "news:threat:summary:v1": "74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b",
+        "resilience:education-attainment:v1": "21a710d5977414c3f3e590c0c25451c8763edb4f2452c6f239c6f2b13eb3f92c",
+        "resilience:recovery:external-debt:v1": "183c74d16366551a8ad736840e9026ac6f7e728bb153a1298cf1b7546d04e3d5",
+        "resilience:recovery:fiscal-space:v1": "a6c7ed55bc1e3f2ca1ed3f98933a4e38eebc5584e4d1a689ff25b9213e904ba7",
+        "resilience:recovery:import-hhi:v1": "f2e770208403bba1ce171751b5cf183d02c48ccfd428069c2901c07f68c18490",
+        "resilience:recovery:reexport-share:v1": "8eb74825f6ad1c8140e4ccc4d3570897fbe3ef8ea1675453772be1ffbe5b5701",
+        "resilience:recovery:reserve-adequacy:v1": "dfd2548b0fd1716205c3d5e1e0a1b52378c4b57044d9ea93a645523b872fe309",
+        "resilience:recovery:sovereign-wealth:v1": "04ebc1eb3f7da3084cd1bb406c881366fdc24b6b8095602751e487d365785e89",
+        "resilience:static:AD": "abe883505bbf36b2e976092bae7789a6363dbf6439c32233ed976f807673e517",
+        "resilience:static:AE": "4e718916aa84e8390d3df12d49374671a5bd94681a126a6b7c0b433a0f825112",
+        "resilience:static:AF": "3f5533bb6d7ee0f4f3e3772f91d09aa3fb927dc529c0e8ee75e244d146750d56",
+        "resilience:static:AG": "6c005dd0afe96cad386aa51e923da96ff80f30d7e8df77a3d9b1077710fb0c29",
+        "resilience:static:AL": "25f63bcdaf7f34d4350173828302ff73394cca737bcd4cd5321303b2fc877503",
+        "resilience:static:AM": "e33c80702486827d43bf88b94f57951b4f8846b170969879397a6be3c8fa883c",
+        "resilience:static:AO": "a8531adf4e70e2f7592f0463f476029b1af50f6d66b144173bbffb017f273223",
+        "resilience:static:AR": "9e8c9dcca62ca0a93c7bb2f70f2b65290b0a11b59caeebb0a9f91a09e4e3cd6a",
+        "resilience:static:AT": "2c556f9194d5a71303fbfd16b99c3badba6ad15b2f8b20523e04f544a4c26418",
+        "resilience:static:AU": "24ce0add4a37349dc7043ec057ebc37109ec3661cf6c68b1bced22d90757b5a5",
+        "resilience:static:AZ": "eab59aa4aaa57ffaa940d85c297a1560c3db612d3a593d7b9b08374bdcb6963b",
+        "resilience:static:BA": "3d873c7bca6bdf8f331a0a6f97e6232e9f62db67d9713e42e731d55a3a68da4f",
+        "resilience:static:BB": "dd3503d81a4c42fe110e90c96679f794c8607b35d193f72309654f8b33014388",
+        "resilience:static:BD": "7992926e33aa0b2a8dd58d1c73c84c046faddf4d471c713ac49378009f573b92",
+        "resilience:static:BE": "4da5e27a27a909eabec9118f3f4718093d3a4b602fadcdd16e363aa7eaba376f",
+        "resilience:static:BF": "2a8d623012fdc81eaba96004efa23ae575bb3f5eafe16e102213cb3f74d75921",
+        "resilience:static:BG": "1860ff3fa41b7c524e87509417689ce4c7a9176aba522bbfed13fa94ebf0f5cb",
+        "resilience:static:BH": "81ed59f16422de9a46086672608ecd67a754d76c0de81a846b34464b1c2bc4e3",
+        "resilience:static:BI": "e3590b209a87da75e800c4c6e37d0fe87b36eeaa1b07738915eaf0c41375c431",
+        "resilience:static:BJ": "979f2c0b9a41b5abb0472a12c733c09e35711bc334e8bb5792c52338ef6d3222",
+        "resilience:static:BN": "18d35557e879c112f58320cea5a612f750b6c7f21800bac46745f8be3955a610",
+        "resilience:static:BO": "94df27c95c3f0e207e54bed00748d9c71894959247422aa644bd3d7f3fc270e7",
+        "resilience:static:BR": "b7a8390028a0e7e5d6905c702b0fdf4722b62e8919abd25c60a849ebe91ad4f2",
+        "resilience:static:BS": "c819d804c0a8fd06705914ffcbe1bda084ab11169852bdf5af40bf6543cbdf5f",
+        "resilience:static:BT": "01e244a47f06b908d7a96f96dec91833ebef17af3f09fd91bfe2329672b4de64",
+        "resilience:static:BW": "2e9fd0427f90f4236631bb8d4b11db3e8126be187789013b668432ca6ce5704a",
+        "resilience:static:BY": "b0995b48fe0dca8a7c3f7e622426c5bb2bc50383b437e19de60423a20a015327",
+        "resilience:static:BZ": "8be0fe16a3fa44fefe26824b49e1d8c767c52dc9ae8854de2501b1ede3fafe7e",
+        "resilience:static:CA": "86a166a6c7f3e1074e7d0751713b773ced9cb735d7d9f907b1ac0ba50dcb7df9",
+        "resilience:static:CD": "f71ab5f715c671cb270b1464629d5333e2ec2950cecea0887b7f34a018a75d66",
+        "resilience:static:CF": "3a5cd7278d3142e5a85342c1f4b60832d31b1ad5cbddddb38f51b42b803939d0",
+        "resilience:static:CG": "e9db67618630986927531cfca9b82c0cd58b0f6dc611d97e970ae9b6f7c2795d",
+        "resilience:static:CH": "47c9b0edf917e7cfc34f128e04d40eb4fd7ada304eafcc8714f720f1403fe3ad",
+        "resilience:static:CI": "c5b5ce6de93091bbb3171cda76a398a6cd356a47134546fa6fa3f0c48a03d804",
+        "resilience:static:CL": "b1b87c4859750977ac783406344b17f2c226aafbd68bea8c43f1f44a4fe1ca33",
+        "resilience:static:CM": "84e6e48a22d68292566556b4f5fe45fa5affc9804064432148613dc93cec4800",
+        "resilience:static:CN": "efcdef4cbe5ec348f9bc35fd064b6c938987c9fd1e6fb0a598da0617513842d5",
+        "resilience:static:CO": "415f02e070f4c61e1e0934cf770d1e33c04172fa184a7015a2bb63421025fbd9",
+        "resilience:static:CR": "f63f5406bd3f64741cd5d3b224c9b55880e961967efbfb45620ae9281506c8e3",
+        "resilience:static:CU": "15ce2dcf81a4db5bbaeeba851adef85acc9b0192c8c4ca1a3c7b14c2236b3e6f",
+        "resilience:static:CV": "2f328d8adedc0f3aedf1f6d36f48ddfedfb49f13715347b29e1b23b26bff48fd",
+        "resilience:static:CY": "3b730a83e030102c29c837afb6ab479b0c913f5253b3ac838f065fad083ab117",
+        "resilience:static:CZ": "33c327da7726e2b3a8e1731aac3cf9649d997dcabdf1bdf79e2711daca44aea1",
+        "resilience:static:DE": "1462c7ec42cb4c30ee2451b1821e600e938a378a8c11d00783c5133fbd3d629e",
+        "resilience:static:DJ": "e44efb1dec07c414bc3901ca4e90ca59a8dae55c3b2b20e3c2d8714d71d01d0a",
+        "resilience:static:DK": "e84097a333ba3183e24c9d7ed1bae1378f3ad49171fccce16268d3ecfe23cdb1",
+        "resilience:static:DM": "c0ab2b84be98370be00e7ea61a3a8021abf97e2503e870829f541dbcbf8a0da5",
+        "resilience:static:DO": "5d57116f231387dacc422641898767831675e6182abb25723030d0e1c537550b",
+        "resilience:static:DZ": "b4042483ceae2365f26e741adcc13aaf21bb818ae0eb86b9ef0c12c66c8f0113",
+        "resilience:static:EC": "853668c578cbd2ee95109fe324dab49c38be63f3a1049ad17d1035b9081f7c01",
+        "resilience:static:EE": "d4e3ba6bce440d8684e3294db964255c7089c0d54d51d6837c6b32a138e9877f",
+        "resilience:static:EG": "755a7c65263a6a739ff0d00d1a5529a35613be5e7e27936a7e81529b33915128",
+        "resilience:static:ER": "084a9ac7597100f2a6c8996ce7b4544f5f1db43dda1f10730dc73042a26cdb47",
+        "resilience:static:ES": "e32d0fe1332f4b355d4d346930ac03456621b57a021636385a89fa3e1ac2308a",
+        "resilience:static:ET": "44956295e8746e4dffc10152bde9c4bb6f76328c883aef68e056b78b7470b3d9",
+        "resilience:static:FI": "54ac8198c82d5314a0d3d7b15ae081872d51172e02d1b69d7ec99b145c0f3412",
+        "resilience:static:FJ": "275e2ae34d96e2031785af9e389eb508c65faf10f272ab9a397161b7b26021d7",
+        "resilience:static:FM": "5e019a4bc33ecc46484f7ed1e6681f3486e2a20704b420bbc154cf0e8d1d5bdf",
+        "resilience:static:FR": "eade3618160a4123dd794f85e175faa557ba66de3af073544161e57d5e8bd2ce",
+        "resilience:static:GA": "789610ee0af2730ed64031f1730665eebc98f4615070da30890e2206b70b509d",
+        "resilience:static:GB": "28ed87d8378da69bcbea9a0e58fdf66300f2ed9b339c2f18a76e9e57f8c221fe",
+        "resilience:static:GD": "6caf6d6288445e971f9b9178b1e1534c37b14fa7ccfb3c687a9a87cf508653f1",
+        "resilience:static:GE": "c826ed94a377643da26d4b132426f4a72c2d8b802d3b476a644378fb4a5b0194",
+        "resilience:static:GH": "0b7f457d2233621bc69f662b9c288c3a191e71afc46ffa0d11492d86f07b02ca",
+        "resilience:static:GM": "8a8e88e2bd65e2963a97f2e4de95f8d7088c1704c51126daef7f5eec52795c58",
+        "resilience:static:GN": "060aede71195c0ce76ff0a46bb86c88b0a29a9e007986f3c4f0789e81cfa49de",
+        "resilience:static:GQ": "f231fa07ad1069bf19f64b74b25a445a9fd28abfd6efcca1356a3dcc2f629d31",
+        "resilience:static:GR": "52ddd8a4f545b870125d8c807f3d0de5cbc9709f61c1e7b6bec91cf1d2a62286",
+        "resilience:static:GT": "5f57aaf1c9739d9c40c0be5d17f07947b98d90c2101f2c3a1539930463404ffd",
+        "resilience:static:GW": "d012bd4598248fb8d894e330861f59d890e3b213196e0cc7d2816aca4f6c2ec5",
+        "resilience:static:GY": "257bd246c97f4d0e1f60c18695454779ab7a38976aad90c100e8a61dd8b6dc2f",
+        "resilience:static:HK": "7534d3b91e7c691aa63c56db44b3fd2397bb96d5134b631a53676328899e7b2b",
+        "resilience:static:HN": "be0eced27b950e105a8293c6e194aa05fa97a60301a8f80897d09309361d4261",
+        "resilience:static:HR": "3a32bd1c213d616e195070d2a5ddadc0feccb6b94c828acf3a56ec032db9d2be",
+        "resilience:static:HT": "d8689b61e77d862cdc85bfa4434d47ea41bdebb4bff35224116aad99d8eded01",
+        "resilience:static:HU": "8ad09118a42cc439c073acbba8e43acaa922d09773bdefbddd43df36b398a20a",
+        "resilience:static:ID": "127490f86336b9168c47aebd5b1b52edaf05db6ab61ff1e7f9faffc6e15f4331",
+        "resilience:static:IE": "dde7c55e0df4f31903dc01c2c2ca134fbbec771b771a7b942fa74b13ab616352",
+        "resilience:static:IL": "f145116dc2f270bcb2e3062f98f874525ab2e4d4cdb3d7f8ad49cc66117bc519",
+        "resilience:static:IN": "316578e057372f379f77c296433b18891e4c176843eab6f6239abfdf1b7dd367",
+        "resilience:static:IQ": "2acd990c1622d9163348a828dd46080bd1c8bdf0d60049f8b9cbc69c151d7f8f",
+        "resilience:static:IR": "ea9de29a86eb551aac9d433ddbdb4f59e14690be0d119340eb15ac96a319d76f",
+        "resilience:static:IS": "7bc14a5ae3d75b60f66ea95c57e772c251e335a4a4df2750b8cbe07efac321a0",
+        "resilience:static:IT": "2effa27ca8ee6d2b87eba2893e73b910fadee94205aec5a63f48d781db00c23d",
+        "resilience:static:JM": "2ce67105e1898c88dd3389d9e16bfc09509228bb46f8a10a9a020c52f0302fc9",
+        "resilience:static:JO": "632d39539bb1a816e932743344792b3e51fc7db75c9f76bbbc8ea39956a2784b",
+        "resilience:static:JP": "c154781b59f24a82d7f3214609d7589c89a4a5c50587f5733d27d3ad18533972",
+        "resilience:static:KE": "bd2e19a61bf154585abcff75e81258b60b298d04b6aad4b8d23dc957c7955eb3",
+        "resilience:static:KG": "90236913200703727032e3753a2aff71402892b72da19e6bafd2b5549f27e980",
+        "resilience:static:KH": "65b4cedb08526e9ad26f97c2f694705e7f097c98ee5522086b235a8cc5d103a4",
+        "resilience:static:KI": "649cb8bc346c2c45581ef1a522770b025a1dd8f64118759f7c65749d60bcc795",
+        "resilience:static:KM": "fd4f2f5b6b9fd8a78f6fb0f74c9ac07c4e97f9152515ae9a4fe8816d75ce4116",
+        "resilience:static:KN": "feb25d204ad701ef7661b0f48a0e37f51968fcdde3acb978f50b061180249ba6",
+        "resilience:static:KP": "ed24597bcb6b1766ca79c6ad9a4151cd9afbf7f3cb3219ff6d88c4a2b6823283",
+        "resilience:static:KR": "624cd6cfb77dd55cdf59507fc123f4d3c850d87d0f137e215c6a586a9fd12fff",
+        "resilience:static:KW": "8877e15e9ee939f6526d49b08901e78eebaaeaaa01a28cb8d496805569585b23",
+        "resilience:static:KZ": "8bf9173e66d8a8290dbad356cd777cf4ba6665af76d26642baeaba74c95b4f3f",
+        "resilience:static:LA": "f06bd51191af8b2daaa2bbc4a893e97284039d618ee6c4bde07335f0f8ee2d03",
+        "resilience:static:LB": "a7f22b55ecc386c9dec82f8d5dff689b7fba19efb3af3f984193c4ffcc05f78c",
+        "resilience:static:LC": "55506b44404dd8c69ac5b648a4a2f7221409a2c29e783dd7eac70f62b6c66363",
+        "resilience:static:LI": "5269c8507ceaeaca1f3cd1b401131e0c824ee263092c7d04c49b3da044448af4",
+        "resilience:static:LK": "7c93f5ad629868d7780c437a0a3fc4976aee2124a18656b85b40f1dee921b7b3",
+        "resilience:static:LR": "9ec40abbc0a63644df8673c9ccb793903a20cb885882138f3b54f332647c71c2",
+        "resilience:static:LS": "01c6645a14fdc17f10b3e1173e0fd43204ab9886630f7356d8e3dc7f4a901dcb",
+        "resilience:static:LT": "9bbd2187a6b5b0173732001d072ed9f5728a66e36e0922350603e57db0618bcb",
+        "resilience:static:LU": "7da036c6e25be37c126149013d04508522f8fc002503297f64735af6a1d4f2a7",
+        "resilience:static:LV": "4f75ea49845b65726848bf3023a1371d08a047d01309f27376ae09be9ae70f6c",
+        "resilience:static:LY": "43f005d00e75f692b16680a52f53cd82701803b7ad821dea5ccd7f741b89b67e",
+        "resilience:static:MA": "5478398d4540acfd3f9ee1a75d81af7fc5a8a2a1e7fbbb508df2ddbdfe1bf319",
+        "resilience:static:MC": "d9f866545e76381436af07ee66f46b9b64167826fb5d0371728e583bc3f28496",
+        "resilience:static:MD": "0cf417b5b59c65bd91174e4e8f4b27ecc588e0516defe49bbd112e1075155427",
+        "resilience:static:ME": "baeb81b32e8111ef5980943bc016a20f78b832c9e6c6f9f14bc70beda1e59d05",
+        "resilience:static:MG": "dbf9015a68fefc227ec0e0feed971df9af6fe995d1fda0d1e1154445bbbf5808",
+        "resilience:static:MH": "b1a82ce467073e399743323338870ee9ccd52199c683b235a76a65883ab72d71",
+        "resilience:static:MK": "c7ad5da96f94214417096ac695483b1876af33f624e70ce72e35b31086d8f2c3",
+        "resilience:static:ML": "f03bfbdf3925baf9cc41306c1dd0e19eaab510ea7adff6d765ff65879d6e0969",
+        "resilience:static:MM": "e411823d4e040a4f7c6c66baa8ebb0b6a04a1dbdd5484dbbd4f3f309e4cb4b6e",
+        "resilience:static:MN": "37234978f8a6ac568c9c9910cee5b8dc6427eca10c4cd32a38bbf5f62f6fd09c",
+        "resilience:static:MO": "9a56509271cc19020f9ae37fbcd66c5d1fa84f54d0f59667dada2e85d05b89ce",
+        "resilience:static:MR": "ab6fe4bb389b567f1a83fde625f14d6f03cc8685d657f8c1b47f2c7d56d0111d",
+        "resilience:static:MT": "d73efbb8255b296896e609779cc57c4ff3f819bd9c6a5f5aef77529a26814654",
+        "resilience:static:MU": "ee2a3bcb9c0613fe8c6dbf0a7a8dc713985773d4468825ded5669f3cefe8bc2c",
+        "resilience:static:MV": "f44a24b1e4cca68880eb70c2aa47327a6c058932a694701d75dbc3863e43f85c",
+        "resilience:static:MW": "48cbfdff70918b8afcccc4c6b52233ff16d52a427639d85cc8556665676ccdc0",
+        "resilience:static:MX": "15e6aac08310c5e108782c265f57c8b6eac7944ca65205494ebbeff5223ff514",
+        "resilience:static:MY": "c4c33ea2d21b6ee1a5cfe39aa2be5be7af5921794bbbb932d9b0692e49b17642",
+        "resilience:static:MZ": "e03c2c2a0c653e7f6219c054f7ad722c4557bd8d212778f729410d0868a99c6e",
+        "resilience:static:NA": "08d5f74ebe31b52ef209be57789d5a82fa6e4bca2ca34703421cbac8227da19a",
+        "resilience:static:NE": "fd741aa821fd47615427805f32c2670a01aa8a99b3bce2dc8845977eb0d8ab76",
+        "resilience:static:NG": "66de44a364d4163f4244a5d457a463b850ba970a6f6ac0f14d045598cb96b727",
+        "resilience:static:NI": "84ed434afa5d622b6c25f28d07cfe9b9190262185f5540271666deebce59d432",
+        "resilience:static:NL": "5559d1417b96bbdebb993ee582e331e08f3b15e7b9f3499b4419b17ebfe5846a",
+        "resilience:static:NO": "b774d75ee3e3256f52b2d49f2de41e2916369b3beedda4ff126406641293688a",
+        "resilience:static:NP": "414390cfdf0c5092a299505ea7c42f5bbc5782de4b38a5390d18de691368e423",
+        "resilience:static:NR": "5f2143f26433e491c276c80f14b5bc84eddcf61759bfe62d4d29b3e1b0136db1",
+        "resilience:static:NZ": "84b5dfd01d9fa8d1385837e4489062833f55723f6ce933c1f729ded77b8f02cf",
+        "resilience:static:OM": "9d939596a67ad85142a0a6313ee810f4c98d9cad8f419d2a5257b33cc21757f1",
+        "resilience:static:PA": "61942b3c7fc1068f80d4c42c45a9455cb3fd1864ecb309040352a42c9960523e",
+        "resilience:static:PE": "12f60a1906ca6eb1c73feda6f285e048685dbf2c9e05ce4910590f7be3ae50ac",
+        "resilience:static:PG": "6dd7a64940da331694590e4529ac8c0c7b2213ecde909f4d5a8d021df31423c4",
+        "resilience:static:PH": "212d1c4196a365ce5c26ef63ffcb4d5e32dd8450e6b09d844447a830e2502054",
+        "resilience:static:PK": "839ff44c23900402eca65ca1635e5d55c67bd9b5e85708855144b5121646d35f",
+        "resilience:static:PL": "ddaa7f77845fea94574411740102575660e7e717e5e4f171f052fd14ae55adba",
+        "resilience:static:PT": "944606e8b3b2dc3bfab386834239134a2986ea38a4c84db35586c4e20daab642",
+        "resilience:static:PW": "c1e1dc9693c2f613fd0d6181947028170ff28742b8aa57df48e32c2e0f9c43be",
+        "resilience:static:PY": "a63df261bbf569f49ee6b64690f98e49fd881649e3a5c1666aed5cff0bfc7ee2",
+        "resilience:static:QA": "ced1e24b21207a488018a7c81750dd9ca6f6fd41e95f54ed364a31c36c9feeb4",
+        "resilience:static:RO": "4f423c211b8c50d93bc54c030e41d8dc0e1e5ea3a2d9547cfb74af9bd6af19ae",
+        "resilience:static:RS": "d10acb2643dd711e7aa9dd4fbe88f1c527eedbcd954db8fef65df05013ef7aaf",
+        "resilience:static:RU": "aa7d9bc960a04283a03e0f2faf4f5dfc18bec21e1242e7a1f76e6c3e060209c6",
+        "resilience:static:RW": "2ce06dc9c49d41c976b0de98d2531874e828ca6d2e0e35ad475ee6dfa4cf4962",
+        "resilience:static:SA": "ea21c025fb3763648c0cf8016bfbca37255e70b432a491382686cd8f9d53a189",
+        "resilience:static:SB": "12d785f6e77f090adf487be447996080b590eb5d90f145867c592d8ec9577f2c",
+        "resilience:static:SC": "58816f122b80e58928d21181e3f92a56d05a9e41caea5cc82f20963d66da50f0",
+        "resilience:static:SD": "30d88d7acaf980200cd5bef768ef2cbf7bfbbfd89565682c441a2fb1a63ff6e3",
+        "resilience:static:SE": "e636f00e7f0ec3d8ab9d48f55ba97cbd2450cb5660f5adf2801f8dfcc2042b24",
+        "resilience:static:SG": "43e1a8714434163b85f21293a7e0874dc0ac2054237df348ae19d852b3fa24ed",
+        "resilience:static:SI": "2df10b156d6cd7e0ee6bfae0e804fd45aa03569a7ccecef3d934e36bd40b3676",
+        "resilience:static:SK": "c6cbbf6a888b93da159fbaab8e03e66a458e9c61b96bbe32424d5ca9a7f61770",
+        "resilience:static:SL": "6263a3887d0453cace8f8637285ad2a1eaefbca9d90ef95eb4b6a4a688612469",
+        "resilience:static:SM": "1c8ff6871efe9b8ca1ac610555e458bf69b860fd305b116c5fde779153ead4af",
+        "resilience:static:SN": "a795b8bd163f114092eb46aaab875dcca591888261fe4b3197fde26c92eeffc0",
+        "resilience:static:SO": "f3aa152b2d5a8ecc7c370487ad2619deb472e8db9e97931cbc00f1f0e7bc8386",
+        "resilience:static:SR": "e881cfb0cd02b230a4355ebdb3c02c62c3dbacc676206201bbaa218d8ae11241",
+        "resilience:static:SS": "af5fece4b2e72268fd2fc114b20571371f5a26017d9c62b732519fa1fbf5df39",
+        "resilience:static:ST": "76841dc9307d1b59c8e221f5d4dddbd4be3d40910ea83a8dac55b74fd8caf7d7",
+        "resilience:static:SV": "e26427cebca748b572d9b7d447716796684b14d58194f7aebb519340ec2b935b",
+        "resilience:static:SY": "6c2abcfb0b81dba89d172b7b3e150483fc89b6241b658f265515b4bcab5ac5cb",
+        "resilience:static:SZ": "4756209b3de3e5503430a44a5fdf00daf553798267d362d6a1c55cb84a76d054",
+        "resilience:static:TD": "445e6127702997fa0c728a314d2aadee9c946db9ed5153f20d0b813f993e43c4",
+        "resilience:static:TG": "1537d2eb61f7459a1c30ca1727dbe73b1f5fcbf67cccead9264d0c5b5814e46b",
+        "resilience:static:TH": "536cce7dc65cf2a3950bcda434626e2f39224d1341f6fc05535968f08fdfe8e8",
+        "resilience:static:TJ": "ed0f558127ace69233c23e5c3129ac3c676fc38037e235d3bbbe9f270c0e2564",
+        "resilience:static:TL": "5a0e4b8dcfbb2139a4d61141836e35da5c7fe366f8f5754b12e103dc3d1d36eb",
+        "resilience:static:TM": "7e1f913462079b2950f80b7ab267a8d8ff3c36664fc3aab73e2b19f738c0c1aa",
+        "resilience:static:TN": "abf896b1becb5981168e0c0c8474c145c191962434211103ffc00d48a57d5c8d",
+        "resilience:static:TO": "47f7218b3977dfbaf09cf8fcf4b29a8ff0ed35ac591003cdd5a87b81617b1cd6",
+        "resilience:static:TR": "8c8a496a80d71d83d03f4c41e048f8f6162fe83fdf5ee94cffe2bf045c01cd0b",
+        "resilience:static:TT": "aa49c4cf2a4e7ca366654acf8e06e2cbf7b3cbe89e70a067908968997ace213e",
+        "resilience:static:TV": "79fbf071f94fdf081cb67364bf75cd5a0d1513b15310e7cb9be2ad6670efa247",
+        "resilience:static:TW": "9dddb9e519c3a763fad9808ab51c39c86bf1e3e45ed35c8e5eec05d8e45b67e6",
+        "resilience:static:TZ": "79cb43479f27ef55f4d093ea3d25b54d6fc997d14ffca74f71bf3b86e9d1180c",
+        "resilience:static:UA": "149b01e98a5f1338c5857846713926ae45b0a9ca2c82e268569ef2de706c529b",
+        "resilience:static:UG": "de63af202034f4ab7db121193c9eb9ffba2e7fa30509cafcfda3a43661c6a30b",
+        "resilience:static:US": "0ad9d81ed39f2d6a47e300a9f390438e8daa5555f840fd0629d5877b54e460b5",
+        "resilience:static:UY": "1638e89b580d072ba7c3cac9cc6bd7ba502d8a0fe73c5a55285b801b92757c99",
+        "resilience:static:UZ": "bed3f80cc92d00cca0ffa5d164cab8cec52a62dd0e6a33644f958d1401577185",
+        "resilience:static:VC": "636ac52f069b41a53ad8405dd80ffd05061afc51058816517a52539f3eec560b",
+        "resilience:static:VE": "5a4ba015b6e35df5fec847c78885c88cf6b689433083b968b190eee5c7b91076",
+        "resilience:static:VN": "e78a2bbda2c84601da6758b599ee071f106c8785922fce1287d228ac6810d18a",
+        "resilience:static:VU": "b93645cb8a0618d4fe1935bc3e654f4576c27f1ad45679f0ea7a1e8d978dd418",
+        "resilience:static:WS": "eab8b573ab30a46cf15f16c950552e186c3642d115c81051f62a58dd77bd6488",
+        "resilience:static:YE": "23946512a67ecab1136151fa9cc99be664f2f11d77cbe16bb816d1fa1aa782b9",
+        "resilience:static:ZA": "871f7106dae5ac65ec671c2a8666220eced220c47e3552ef8adb9cf0f37bb32a",
+        "resilience:static:ZM": "faf6d49e03e5512b562874bd2c521e7b0de00c9186f060df15cc2edf5055765e",
+        "resilience:static:ZW": "89263e152cfcb79c2479d24b10800f161826238107ced460f0ee15900e1cbc00",
+        "seed-meta:conflict:ucdp-events": "5d7b6eb05be61175638b0563cd5410d13f73a27017ec3a41a14862c5e456b3fb",
+        "seed-meta:cyber:threats": "13ee722d6c2dc051e595edc264e6828ed9ea82c1a86dbf049124a6bec85f46b3",
+        "seed-meta:displacement:summary": "90d692978da5795a0b012992f157fa8dafe2b342690ff70765ba49787a39c7f2",
+        "seed-meta:economic:bis": "8519aeb3ff90b6cc93e569e1d0d0f2b897b4d30d657c8a6d215ff669601a2ec0",
+        "seed-meta:economic:bis-dsr": "6114efbfcda83c9b5fd2a27092b27b03a8954e23a514dded4b4acb304567d5f4",
+        "seed-meta:economic:bis-lbs": "b3496d42fd7208a90bbeb37da56bb47396f081e73c9dc24ee49cb73560040a00",
+        "seed-meta:economic:energy-prices": "5c4864b16e78dd7637d1a103885d874c8216c69e283b3e4b06fd5b255bfb6470",
+        "seed-meta:economic:fatf-listing": "4e12e88eec9a282e6775b88c75f1f6a1026c909719d5c3bce2e4ba33636ad680",
+        "seed-meta:economic:imf-labor": "c20d569fe3d92633c7ecb8bc38168899f2f416996ec93ce34aef119ec2501431",
+        "seed-meta:economic:imf-macro": "7afcfa310642166db29db687e3b699b291f9716fb1dcfeaf8868d977010dc2c3",
+        "seed-meta:economic:national-debt": "6515c3f3a0cfc32fd190cfa7b2f323a1c55dafdafcf848e4489d8185d3360ec8",
+        "seed-meta:economic:owid-energy-mix": "b72dc14b6e774f20d31fc3ebce9f9999b04502226240f8e19b559d40ba4e18b4",
+        "seed-meta:economic:wb-external-debt": "93b69612c57780ec7a6dadb494406e75e37bcb83e70dde9a585e3c4df3014b62",
+        "seed-meta:energy:gas-storage-countries": "e24ac91da741505fcd8e66d48594165cf202972c109b21df393db282594e5c88",
+        "seed-meta:infra:outages": "3abd1fa4411809c2817282aba219d9756749a664653ec197ccd7fc0c83483e10",
+        "seed-meta:intelligence:gpsjam": "c04597ece3b8e80845041fbf4ad22de7f4a60f51d18ad68c0ddadbd52b19823a",
+        "seed-meta:intelligence:social-reddit": "bb0c6f45735f417426a58d6af3189c7967c8d13e20d89fa04b63b56415f7f41c",
+        "seed-meta:news:threat-summary": "671d35472ba7717c102cf6e8421401fb4614d8ce9eb287b5e66fecf8e40d0f84",
+        "seed-meta:resilience:education-attainment": "48b078549d557255cf08dc1e3ae650c205cfbf5f1afda35d3fdb114981da322c",
+        "seed-meta:resilience:fossil-electricity-share": "8d3bbdd2005a0afec5f57ef19ada9a26b36d2f6569b3e645851e2b963991055d",
+        "seed-meta:resilience:low-carbon-generation": "e64d3dfd200623107bd4469311a53bf356f236d529906857457107254c3c5afb",
+        "seed-meta:resilience:power-losses": "8858539e7bc9638388b9d1a14b69ecc65eff2544a8db784e8af907a5b7d0082e",
+        "seed-meta:resilience:recovery:external-debt": "0bd95f7322fd9b7a05fd5d9688f58155abfaf3e890f6de2fac7f101b9f997a11",
+        "seed-meta:resilience:recovery:fiscal-space": "c76ee588d404232afe80542d1049a792b5c4e2429122af0a32cb33682fd3e0fb",
+        "seed-meta:resilience:recovery:fuel-stocks": "44f8e65eb781395a8f2e8220b1d616da72e1fcf6b6d79c42b276f0817f458839",
+        "seed-meta:resilience:recovery:import-hhi": "beb147888ac7aa171524f2c7085e15e8e78ea340ab4da0be59d426180bb4b3e6",
+        "seed-meta:resilience:recovery:reexport-share": "c39b424b27ac69df23fb6388fe7d7af9df91beff2c9ce03f56ace97a51f7153b",
+        "seed-meta:resilience:recovery:reserve-adequacy": "3e9d60051289275da03df10b0f3fd1a76e927f10656084f616dc3e7435810aa2",
+        "seed-meta:resilience:recovery:sovereign-wealth": "b0d03c3f11cd006a84ccf93b4ce7cb59261064346abf831f6bbcf3fc710b24be",
+        "seed-meta:resilience:static": "a6129dac7f56235584312b4c0cfc5eec68d9e5d005bf3016cb89b5d41c9a9c6b",
+        "seed-meta:supply_chain:shipping_stress": "ae5f68096398dea7c2365cdb7f52987c398534b9dc932e324f38d63b636ff4aa",
+        "seed-meta:supply_chain:transit-summaries": "568dff8c7f33e21df707593aff06a4c35af00a5c444f456192cc2435c07009f2",
+        "seed-meta:trade:barriers:v1:tariff-gap:50": "c835ce2af7269165fc92e1bd93f257da7d7af5e7cb13aed9ec3fb534ca48010b",
+        "seed-meta:trade:restrictions:v1:tariff-overview:50": "4408e8b918693ff3c011074811a08f8d24c787a2f71fd3c21beaafab4f61e4c9",
+        "seed-meta:unrest:events": "8c6075751bd0a65f0e5c04db090a7257516045227f7d2864bd052a07b947b974",
+        "supply_chain:shipping_stress:v1": "36a8be401881de1c767c7286ce416209fe990067b1313928d15d3fbc33cded5e",
+        "supply_chain:transit-summaries:v1": "1d68e3b65cede91b0610f68b7594afc5c0cec84922c80288ebb1653437b298de",
+        "trade:barriers:v1:tariff-gap:50": "7853578dc5435f1381c0924678cabc8325c02c47da7706538bd4b14426419eb4",
+        "trade:restrictions:v1:tariff-overview:50": "2f258bbf1e4de2c8b48100ec23005d77735077ecf2ad9fe56e63420c49519551",
+        "unrest:events:v1": "edb00f63f983c33c8b75a2c4990a34616db7671e4457a6b1f3541f4e5dc46bf0"
+      },
+      "snapshotSha256": "0aba002ceb7ebf99555fbc9966358b776ac46f4e55821006492cad2216a9c6e3"
+    }
+  },
+  "educationWeight": 0.5,
+  "shippedEducationWeight": 0.5,
+  "universeSize": 196,
+  "educationCoverageCountries": 181,
+  "sourceFailures": {},
+  "blockingSourceFailures": {},
+  "acceptanceGates": {
+    "verdict": "PASS",
+    "gatingFormula": "pc",
+    "gates": {
+      "pc": [
+        {
+          "id": "gate-1-spearman",
+          "name": "Spearman vs baseline >= 0.85",
+          "status": "pass",
+          "detail": "rho 1 over 196 countries",
+          "evidence": {
+            "spearman": 0.9961418760054007,
+            "countries": 196
+          }
+        },
+        {
+          "id": "gate-2-country-drift",
+          "name": "Max country drift <= 15 points",
+          "status": "pass",
+          "detail": "max |delta| 3.45 (VU)",
+          "evidence": {
+            "topMovers": [
+              {
+                "countryCode": "VU",
+                "delta": -3.45
+              },
+              {
+                "countryCode": "RU",
+                "delta": 2.21
+              },
+              {
+                "countryCode": "IL",
+                "delta": 2.15
+              },
+              {
+                "countryCode": "MW",
+                "delta": -1.98
+              },
+              {
+                "countryCode": "SR",
+                "delta": -1.93
+              },
+              {
+                "countryCode": "UG",
+                "delta": -1.89
+              },
+              {
+                "countryCode": "RW",
+                "delta": -1.83
+              },
+              {
+                "countryCode": "NP",
+                "delta": -1.79
+              },
+              {
+                "countryCode": "NR",
+                "delta": -1.78
+              },
+              {
+                "countryCode": "KI",
+                "delta": -1.75
+              },
+              {
+                "countryCode": "UA",
+                "delta": 1.67
+              },
+              {
+                "countryCode": "KH",
+                "delta": -1.54
+              },
+              {
+                "countryCode": "BI",
+                "delta": -1.43
+              },
+              {
+                "countryCode": "KZ",
+                "delta": 1.42
+              },
+              {
+                "countryCode": "BT",
+                "delta": -1.39
+              }
+            ]
+          }
+        },
+        {
+          "id": "gate-6-cohort-median",
+          "name": "Cohort median shift <= 10 points",
+          "status": "pass",
+          "detail": "worst fragile-states -1.07",
+          "evidence": {
+            "cohortShifts": [
+              {
+                "cohort": "net-fuel-exporters",
+                "members": 22,
+                "medianShift": 0.32
+              },
+              {
+                "cohort": "net-energy-importers-oecd",
+                "members": 18,
+                "medianShift": -0.06
+              },
+              {
+                "cohort": "nuclear-heavy-generation",
+                "members": 16,
+                "medianShift": 0.41
+              },
+              {
+                "cohort": "coal-heavy-domestic",
+                "members": 12,
+                "medianShift": 0.74
+              },
+              {
+                "cohort": "small-island-importers",
+                "members": 18,
+                "medianShift": -0.53
+              },
+              {
+                "cohort": "sanctions-isolated",
+                "members": 8,
+                "medianShift": 0.23
+              },
+              {
+                "cohort": "fragile-states",
+                "members": 18,
+                "medianShift": -1.07
+              }
+            ]
+          }
+        },
+        {
+          "id": "gate-7-matched-pair",
+          "name": "Every matched pair holds direction and minGap",
+          "status": "pass",
+          "detail": "9/9 pairs pass",
+          "evidence": {
+            "pairs": [
+              {
+                "pairId": "de-vs-fr",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 1.78,
+                "baselineGap": 1.82,
+                "gapDelta": -0.04,
+                "minGap": 1
+              },
+              {
+                "pairId": "no-vs-ca",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 16.22,
+                "baselineGap": 16.09,
+                "gapDelta": 0.13,
+                "minGap": 3
+              },
+              {
+                "pairId": "uae-vs-bh",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 21.27,
+                "baselineGap": 21.35,
+                "gapDelta": -0.08,
+                "minGap": 5
+              },
+              {
+                "pairId": "jp-vs-kr",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 10.81,
+                "baselineGap": 10.72,
+                "gapDelta": 0.09,
+                "minGap": 1
+              },
+              {
+                "pairId": "in-vs-za",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 1.22,
+                "baselineGap": 1.99,
+                "gapDelta": -0.77,
+                "minGap": 1
+              },
+              {
+                "pairId": "ch-vs-sg",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 18.97,
+                "baselineGap": 18.72,
+                "gapDelta": 0.25,
+                "minGap": 5
+              },
+              {
+                "pairId": "pt-vs-uz",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 5.7,
+                "baselineGap": 7.06,
+                "gapDelta": -1.36,
+                "minGap": 3
+              },
+              {
+                "pairId": "es-vs-by",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 8.54,
+                "baselineGap": 9.86,
+                "gapDelta": -1.32,
+                "minGap": 3
+              },
+              {
+                "pairId": "ch-vs-tm",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 27.43,
+                "baselineGap": 28.19,
+                "gapDelta": -0.76,
+                "minGap": 5
+              }
+            ],
+            "regressions": [],
+            "preExisting": []
+          }
+        },
+        {
+          "id": "gate-9-effective-influence-baseline",
+          "name": "Core extraction baseline and education sample are measurable",
+          "status": "pass",
+          "detail": "48/52 Core indicators measurable (92.31%); education 181/181",
+          "evidence": {
+            "coreImplemented": 48,
+            "coreTotal": 52,
+            "educationPairedSampleSize": 181,
+            "expectedEducationSampleSize": 181,
+            "educationCountryCodes": [
+              "AF",
+              "AL",
+              "DZ",
+              "AD",
+              "AO",
+              "AG",
+              "AR",
+              "AM",
+              "AU",
+              "AT",
+              "AZ",
+              "BS",
+              "BH",
+              "BD",
+              "BY",
+              "BE",
+              "BZ",
+              "BJ",
+              "BT",
+              "BO",
+              "BA",
+              "BW",
+              "BR",
+              "BN",
+              "BG",
+              "BF",
+              "BI",
+              "CV",
+              "KH",
+              "CM",
+              "CA",
+              "CF",
+              "TD",
+              "CL",
+              "CN",
+              "CO",
+              "KM",
+              "CG",
+              "CD",
+              "CR",
+              "CI",
+              "HR",
+              "CU",
+              "CY",
+              "CZ",
+              "DK",
+              "DJ",
+              "DM",
+              "DO",
+              "EC",
+              "EG",
+              "SV",
+              "EE",
+              "SZ",
+              "ET",
+              "FJ",
+              "FI",
+              "FR",
+              "GM",
+              "GE",
+              "DE",
+              "GH",
+              "GR",
+              "GD",
+              "GT",
+              "GN",
+              "GW",
+              "GY",
+              "HT",
+              "HN",
+              "HU",
+              "IS",
+              "IN",
+              "ID",
+              "IR",
+              "IQ",
+              "IE",
+              "IL",
+              "IT",
+              "JM",
+              "JP",
+              "JO",
+              "KZ",
+              "KE",
+              "KI",
+              "KR",
+              "KW",
+              "LA",
+              "LV",
+              "LB",
+              "LS",
+              "LR",
+              "LT",
+              "LU",
+              "MG",
+              "MW",
+              "MY",
+              "MV",
+              "ML",
+              "MT",
+              "MH",
+              "MR",
+              "MU",
+              "MX",
+              "FM",
+              "MD",
+              "MN",
+              "ME",
+              "MA",
+              "MZ",
+              "MM",
+              "NA",
+              "NR",
+              "NP",
+              "NL",
+              "NZ",
+              "NI",
+              "NE",
+              "NG",
+              "MK",
+              "NO",
+              "OM",
+              "PK",
+              "PW",
+              "PA",
+              "PG",
+              "PY",
+              "PE",
+              "PH",
+              "PL",
+              "PT",
+              "QA",
+              "RO",
+              "RU",
+              "RW",
+              "LC",
+              "WS",
+              "SM",
+              "SA",
+              "SN",
+              "RS",
+              "SC",
+              "SL",
+              "SG",
+              "SK",
+              "SI",
+              "SB",
+              "SO",
+              "ZA",
+              "ES",
+              "LK",
+              "SD",
+              "SR",
+              "SE",
+              "CH",
+              "TJ",
+              "TZ",
+              "TH",
+              "TL",
+              "TG",
+              "TO",
+              "TT",
+              "TN",
+              "TR",
+              "TM",
+              "TV",
+              "UG",
+              "UA",
+              "AE",
+              "GB",
+              "US",
+              "UY",
+              "UZ",
+              "VU",
+              "VE",
+              "VN",
+              "YE",
+              "ZM",
+              "ZW",
+              "HK",
+              "MO"
+            ],
+            "educationRow": {
+              "tier": "core",
+              "extractionStatus": "implemented"
+            }
+          }
+        }
+      ],
+      "d6": [
+        {
+          "id": "gate-1-spearman",
+          "name": "Spearman vs baseline >= 0.85",
+          "status": "pass",
+          "detail": "rho 1 over 196 countries",
+          "evidence": {
+            "spearman": 0.9968391463009828,
+            "countries": 196
+          }
+        },
+        {
+          "id": "gate-2-country-drift",
+          "name": "Max country drift <= 15 points",
+          "status": "pass",
+          "detail": "max |delta| 2.13 (KI)",
+          "evidence": {
+            "topMovers": [
+              {
+                "countryCode": "KI",
+                "delta": -2.13
+              },
+              {
+                "countryCode": "VU",
+                "delta": -2.08
+              },
+              {
+                "countryCode": "BT",
+                "delta": -1.44
+              },
+              {
+                "countryCode": "SN",
+                "delta": -1.4
+              },
+              {
+                "countryCode": "BJ",
+                "delta": -1.37
+              },
+              {
+                "countryCode": "TZ",
+                "delta": -1.34
+              },
+              {
+                "countryCode": "CV",
+                "delta": -1.32
+              },
+              {
+                "countryCode": "MG",
+                "delta": -1.32
+              },
+              {
+                "countryCode": "TV",
+                "delta": -1.3
+              },
+              {
+                "countryCode": "MV",
+                "delta": -1.29
+              },
+              {
+                "countryCode": "SB",
+                "delta": -1.29
+              },
+              {
+                "countryCode": "GW",
+                "delta": -1.27
+              },
+              {
+                "countryCode": "TG",
+                "delta": -1.25
+              },
+              {
+                "countryCode": "KH",
+                "delta": -1.23
+              },
+              {
+                "countryCode": "KM",
+                "delta": -1.21
+              }
+            ]
+          }
+        },
+        {
+          "id": "gate-6-cohort-median",
+          "name": "Cohort median shift <= 10 points",
+          "status": "pass",
+          "detail": "worst fragile-states -0.91",
+          "evidence": {
+            "cohortShifts": [
+              {
+                "cohort": "net-fuel-exporters",
+                "members": 22,
+                "medianShift": -0.17
+              },
+              {
+                "cohort": "net-energy-importers-oecd",
+                "members": 18,
+                "medianShift": 0.27
+              },
+              {
+                "cohort": "nuclear-heavy-generation",
+                "members": 16,
+                "medianShift": 0.56
+              },
+              {
+                "cohort": "coal-heavy-domestic",
+                "members": 12,
+                "medianShift": 0.39
+              },
+              {
+                "cohort": "small-island-importers",
+                "members": 18,
+                "medianShift": -0.44
+              },
+              {
+                "cohort": "sanctions-isolated",
+                "members": 8,
+                "medianShift": -0.23
+              },
+              {
+                "cohort": "fragile-states",
+                "members": 18,
+                "medianShift": -0.91
+              }
+            ]
+          }
+        },
+        {
+          "id": "gate-7-matched-pair",
+          "name": "Every matched pair holds direction and minGap",
+          "status": "fail",
+          "detail": "0 caused by this flip; 1 already failing at baseline (de-vs-fr 0.74->0.69 vs min 1)",
+          "evidence": {
+            "pairs": [
+              {
+                "pairId": "de-vs-fr",
+                "status": "near-flip",
+                "baselineStatus": "near-flip",
+                "regression": false,
+                "preExisting": true,
+                "gap": 0.69,
+                "baselineGap": 0.74,
+                "gapDelta": -0.05,
+                "minGap": 1
+              },
+              {
+                "pairId": "no-vs-ca",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 9.31,
+                "baselineGap": 9.51,
+                "gapDelta": -0.2,
+                "minGap": 3
+              },
+              {
+                "pairId": "uae-vs-bh",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 14.81,
+                "baselineGap": 14.97,
+                "gapDelta": -0.16,
+                "minGap": 5
+              },
+              {
+                "pairId": "jp-vs-kr",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 8.06,
+                "baselineGap": 8.02,
+                "gapDelta": 0.04,
+                "minGap": 1
+              },
+              {
+                "pairId": "in-vs-za",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 1.58,
+                "baselineGap": 1.86,
+                "gapDelta": -0.28,
+                "minGap": 1
+              },
+              {
+                "pairId": "ch-vs-sg",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 13.34,
+                "baselineGap": 13.16,
+                "gapDelta": 0.18,
+                "minGap": 5
+              },
+              {
+                "pairId": "pt-vs-uz",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 4.87,
+                "baselineGap": 6.23,
+                "gapDelta": -1.36,
+                "minGap": 3
+              },
+              {
+                "pairId": "es-vs-by",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 5.71,
+                "baselineGap": 7.07,
+                "gapDelta": -1.36,
+                "minGap": 3
+              },
+              {
+                "pairId": "ch-vs-tm",
+                "status": "pass",
+                "baselineStatus": "pass",
+                "regression": false,
+                "preExisting": false,
+                "gap": 19.85,
+                "baselineGap": 20.74,
+                "gapDelta": -0.89,
+                "minGap": 5
+              }
+            ],
+            "regressions": [],
+            "preExisting": [
+              "de-vs-fr"
+            ]
+          }
+        }
+      ]
+    },
+    "nonGatingFailures": [
+      {
+        "id": "gate-7-matched-pair",
+        "name": "Every matched pair holds direction and minGap",
+        "status": "fail",
+        "detail": "0 caused by this flip; 1 already failing at baseline (de-vs-fr 0.74->0.69 vs min 1)",
+        "evidence": {
+          "pairs": [
+            {
+              "pairId": "de-vs-fr",
+              "status": "near-flip",
+              "baselineStatus": "near-flip",
+              "regression": false,
+              "preExisting": true,
+              "gap": 0.69,
+              "baselineGap": 0.74,
+              "gapDelta": -0.05,
+              "minGap": 1
+            },
+            {
+              "pairId": "no-vs-ca",
+              "status": "pass",
+              "baselineStatus": "pass",
+              "regression": false,
+              "preExisting": false,
+              "gap": 9.31,
+              "baselineGap": 9.51,
+              "gapDelta": -0.2,
+              "minGap": 3
+            },
+            {
+              "pairId": "uae-vs-bh",
+              "status": "pass",
+              "baselineStatus": "pass",
+              "regression": false,
+              "preExisting": false,
+              "gap": 14.81,
+              "baselineGap": 14.97,
+              "gapDelta": -0.16,
+              "minGap": 5
+            },
+            {
+              "pairId": "jp-vs-kr",
+              "status": "pass",
+              "baselineStatus": "pass",
+              "regression": false,
+              "preExisting": false,
+              "gap": 8.06,
+              "baselineGap": 8.02,
+              "gapDelta": 0.04,
+              "minGap": 1
+            },
+            {
+              "pairId": "in-vs-za",
+              "status": "pass",
+              "baselineStatus": "pass",
+              "regression": false,
+              "preExisting": false,
+              "gap": 1.58,
+              "baselineGap": 1.86,
+              "gapDelta": -0.28,
+              "minGap": 1
+            },
+            {
+              "pairId": "ch-vs-sg",
+              "status": "pass",
+              "baselineStatus": "pass",
+              "regression": false,
+              "preExisting": false,
+              "gap": 13.34,
+              "baselineGap": 13.16,
+              "gapDelta": 0.18,
+              "minGap": 5
+            },
+            {
+              "pairId": "pt-vs-uz",
+              "status": "pass",
+              "baselineStatus": "pass",
+              "regression": false,
+              "preExisting": false,
+              "gap": 4.87,
+              "baselineGap": 6.23,
+              "gapDelta": -1.36,
+              "minGap": 3
+            },
+            {
+              "pairId": "es-vs-by",
+              "status": "pass",
+              "baselineStatus": "pass",
+              "regression": false,
+              "preExisting": false,
+              "gap": 5.71,
+              "baselineGap": 7.07,
+              "gapDelta": -1.36,
+              "minGap": 3
+            },
+            {
+              "pairId": "ch-vs-tm",
+              "status": "pass",
+              "baselineStatus": "pass",
+              "regression": false,
+              "preExisting": false,
+              "gap": 19.85,
+              "baselineGap": 20.74,
+              "gapDelta": -0.89,
+              "minGap": 5
+            }
+          ],
+          "regressions": [],
+          "preExisting": [
+            "de-vs-fr"
+          ]
+        }
+      }
+    ]
+  },
+  "scores": {
+    "AF": {
+      "baseline": {
+        "pc": 32.59,
+        "d6": 49.23,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 31.79,
+        "d6": 48.36,
+        "educationScore": 6,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "AL": {
+      "baseline": {
+        "pc": 60.4,
+        "d6": 71.79,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 60.05,
+        "d6": 71.49,
+        "educationScore": 54,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "DZ": {
+      "baseline": {
+        "pc": 53.92,
+        "d6": 65.99,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 53.03,
+        "d6": 65.39,
+        "educationScore": 27,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "AD": {
+      "baseline": {
+        "pc": 66.05,
+        "d6": 78.94,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 65.46,
+        "d6": 78.3,
+        "educationScore": 65,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "AO": {
+      "baseline": {
+        "pc": 39.02,
+        "d6": 53.36,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 38.23,
+        "d6": 52.47,
+        "educationScore": 21,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "AG": {
+      "baseline": {
+        "pc": 55.69,
+        "d6": 72.48,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 55.95,
+        "d6": 72.65,
+        "educationScore": 85,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "AR": {
+      "baseline": {
+        "pc": 50.26,
+        "d6": 65.25,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 50.24,
+        "d6": 65.2,
+        "educationScore": 63,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "AM": {
+      "baseline": {
+        "pc": 51.17,
+        "d6": 64.91,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 51.94,
+        "d6": 65.69,
+        "educationScore": 96,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "AU": {
+      "baseline": {
+        "pc": 60.89,
+        "d6": 76.36,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 61.04,
+        "d6": 76.51,
+        "educationScore": 85,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "AT": {
+      "baseline": {
+        "pc": 62.19,
+        "d6": 76.47,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 62.35,
+        "d6": 76.63,
+        "educationScore": 86,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "AZ": {
+      "baseline": {
+        "pc": 54.15,
+        "d6": 67.22,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 55.04,
+        "d6": 68.15,
+        "educationScore": 95,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BS": {
+      "baseline": {
+        "pc": 45.81,
+        "d6": 64.38,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 46.51,
+        "d6": 65.05,
+        "educationScore": 97,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BH": {
+      "baseline": {
+        "pc": 42.57,
+        "d6": 59.63,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 43.03,
+        "d6": 60.16,
+        "educationScore": 85,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BD": {
+      "baseline": {
+        "pc": 38.94,
+        "d6": 53.75,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 38.47,
+        "d6": 53.25,
+        "educationScore": 32,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BB": {
+      "baseline": {
+        "pc": 60.82,
+        "d6": 72.76,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 60.48,
+        "d6": 72.61,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BY": {
+      "baseline": {
+        "pc": 52.44,
+        "d6": 66.53,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 53.48,
+        "d6": 67.63,
+        "educationScore": 99,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BE": {
+      "baseline": {
+        "pc": 57.86,
+        "d6": 71.69,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 57.94,
+        "d6": 71.77,
+        "educationScore": 80,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BZ": {
+      "baseline": {
+        "pc": 51.92,
+        "d6": 65.99,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 51.08,
+        "d6": 65.37,
+        "educationScore": 47,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BJ": {
+      "baseline": {
+        "pc": 40.35,
+        "d6": 55.15,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 39.11,
+        "d6": 53.78,
+        "educationScore": 4,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BT": {
+      "baseline": {
+        "pc": 54.24,
+        "d6": 70.87,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.85,
+        "d6": 69.43,
+        "educationScore": 17,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BO": {
+      "baseline": {
+        "pc": 43.49,
+        "d6": 58.99,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 43.37,
+        "d6": 58.84,
+        "educationScore": 55,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BA": {
+      "baseline": {
+        "pc": 56.4,
+        "d6": 68.41,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 56.46,
+        "d6": 68.49,
+        "educationScore": 68,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BW": {
+      "baseline": {
+        "pc": 46.08,
+        "d6": 60.33,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 45.46,
+        "d6": 59.67,
+        "educationScore": 45,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BR": {
+      "baseline": {
+        "pc": 55.63,
+        "d6": 69.5,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 55.84,
+        "d6": 69.75,
+        "educationScore": 68,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BN": {
+      "baseline": {
+        "pc": 58.49,
+        "d6": 71.87,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 58.33,
+        "d6": 71.69,
+        "educationScore": 73,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BG": {
+      "baseline": {
+        "pc": 58.88,
+        "d6": 71.32,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 59.27,
+        "d6": 71.74,
+        "educationScore": 85,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BF": {
+      "baseline": {
+        "pc": 36.69,
+        "d6": 50.26,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 35.53,
+        "d6": 49.35,
+        "educationScore": 4,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "BI": {
+      "baseline": {
+        "pc": 38.69,
+        "d6": 52.96,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 37.26,
+        "d6": 52.13,
+        "educationScore": 8,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CV": {
+      "baseline": {
+        "pc": 53.55,
+        "d6": 67.76,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.32,
+        "d6": 66.44,
+        "educationScore": 29,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "KH": {
+      "baseline": {
+        "pc": 50.59,
+        "d6": 63.55,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 49.05,
+        "d6": 62.32,
+        "educationScore": 9,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CM": {
+      "baseline": {
+        "pc": 39.54,
+        "d6": 53.31,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 38.38,
+        "d6": 52.63,
+        "educationScore": 11,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CA": {
+      "baseline": {
+        "pc": 59.02,
+        "d6": 74.24,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 59.45,
+        "d6": 74.67,
+        "educationScore": 95,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CF": {
+      "baseline": {
+        "pc": 36.27,
+        "d6": 50.94,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 35.08,
+        "d6": 50.21,
+        "educationScore": 4,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TD": {
+      "baseline": {
+        "pc": 36.36,
+        "d6": 50.34,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 35.33,
+        "d6": 49.47,
+        "educationScore": 2,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CL": {
+      "baseline": {
+        "pc": 56.69,
+        "d6": 70.04,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 56.81,
+        "d6": 70.16,
+        "educationScore": 75,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CN": {
+      "baseline": {
+        "pc": 52.97,
+        "d6": 65.87,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.21,
+        "d6": 65.44,
+        "educationScore": 32,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CO": {
+      "baseline": {
+        "pc": 47.54,
+        "d6": 63.47,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 48.48,
+        "d6": 64.03,
+        "educationScore": 64,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "KM": {
+      "baseline": {
+        "pc": 48.1,
+        "d6": 60.58,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 46.96,
+        "d6": 59.37,
+        "educationScore": 21,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CG": {
+      "baseline": {
+        "pc": 42.07,
+        "d6": 55.1,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 41.47,
+        "d6": 54.48,
+        "educationScore": 15,
+        "educationCoverage": 0.6,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CD": {
+      "baseline": {
+        "pc": 37.28,
+        "d6": 51.47,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 36.44,
+        "d6": 51.03,
+        "educationScore": 21,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CR": {
+      "baseline": {
+        "pc": 49.33,
+        "d6": 64.83,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 48.89,
+        "d6": 64.33,
+        "educationScore": 48,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CI": {
+      "baseline": {
+        "pc": 42.36,
+        "d6": 57.27,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 41.3,
+        "d6": 56.14,
+        "educationScore": 13,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "HR": {
+      "baseline": {
+        "pc": 57.25,
+        "d6": 69.91,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 57.58,
+        "d6": 70.26,
+        "educationScore": 84,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CU": {
+      "baseline": {
+        "pc": 47.01,
+        "d6": 61.57,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 47.2,
+        "d6": 61.67,
+        "educationScore": 60,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CY": {
+      "baseline": {
+        "pc": 58.05,
+        "d6": 70.77,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 58.31,
+        "d6": 71.03,
+        "educationScore": 84,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CZ": {
+      "baseline": {
+        "pc": 67.04,
+        "d6": 77.57,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 67.49,
+        "d6": 78.01,
+        "educationScore": 94,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "DK": {
+      "baseline": {
+        "pc": 71.45,
+        "d6": 81.04,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 71.49,
+        "d6": 81.08,
+        "educationScore": 85,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "DJ": {
+      "baseline": {
+        "pc": 42.51,
+        "d6": 56.61,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 41.76,
+        "d6": 55.78,
+        "educationScore": 11,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "DM": {
+      "baseline": {
+        "pc": 57.76,
+        "d6": 71.72,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 57.19,
+        "d6": 70.93,
+        "educationScore": 55,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "DO": {
+      "baseline": {
+        "pc": 49.55,
+        "d6": 62.54,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 49.34,
+        "d6": 62.32,
+        "educationScore": 57,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "EC": {
+      "baseline": {
+        "pc": 49.64,
+        "d6": 62.96,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 49.35,
+        "d6": 62.84,
+        "educationScore": 50,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "EG": {
+      "baseline": {
+        "pc": 47.73,
+        "d6": 60.39,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 47.76,
+        "d6": 60.44,
+        "educationScore": 55,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SV": {
+      "baseline": {
+        "pc": 52.31,
+        "d6": 64.68,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 51.62,
+        "d6": 64,
+        "educationScore": 35,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GQ": {
+      "baseline": {
+        "pc": 40.25,
+        "d6": 51,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 39.99,
+        "d6": 50.96,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "ER": {
+      "baseline": {
+        "pc": 37.26,
+        "d6": 52.67,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 37.36,
+        "d6": 52.69,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "EE": {
+      "baseline": {
+        "pc": 61.09,
+        "d6": 74.02,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 61.49,
+        "d6": 74.4,
+        "educationScore": 94,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SZ": {
+      "baseline": {
+        "pc": 39.64,
+        "d6": 54.51,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 39.1,
+        "d6": 53.94,
+        "educationScore": 35,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "ET": {
+      "baseline": {
+        "pc": 36.27,
+        "d6": 50.16,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 35.4,
+        "d6": 49.25,
+        "educationScore": 7,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "FJ": {
+      "baseline": {
+        "pc": 55.41,
+        "d6": 70.06,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 54.98,
+        "d6": 69.58,
+        "educationScore": 51,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "FI": {
+      "baseline": {
+        "pc": 64.87,
+        "d6": 77.56,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 65.05,
+        "d6": 77.73,
+        "educationScore": 90,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "FR": {
+      "baseline": {
+        "pc": 60.85,
+        "d6": 73.69,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 61.13,
+        "d6": 73.97,
+        "educationScore": 83,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GA": {
+      "baseline": {
+        "pc": 44.87,
+        "d6": 57.51,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 44.65,
+        "d6": 57.46,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GM": {
+      "baseline": {
+        "pc": 49.37,
+        "d6": 62.34,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 48.23,
+        "d6": 61.35,
+        "educationScore": 21,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GE": {
+      "baseline": {
+        "pc": 53.03,
+        "d6": 64.95,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 53.78,
+        "d6": 65.69,
+        "educationScore": 96,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "DE": {
+      "baseline": {
+        "pc": 62.67,
+        "d6": 74.43,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 62.91,
+        "d6": 74.66,
+        "educationScore": 86,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GH": {
+      "baseline": {
+        "pc": 44.44,
+        "d6": 58.02,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 43.4,
+        "d6": 56.91,
+        "educationScore": 20,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GR": {
+      "baseline": {
+        "pc": 59.14,
+        "d6": 70.88,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 59.25,
+        "d6": 71.02,
+        "educationScore": 74,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GD": {
+      "baseline": {
+        "pc": 58.79,
+        "d6": 71.57,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 58.33,
+        "d6": 70.82,
+        "educationScore": 57,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GT": {
+      "baseline": {
+        "pc": 51.12,
+        "d6": 64.3,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 49.81,
+        "d6": 63.34,
+        "educationScore": 19,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GN": {
+      "baseline": {
+        "pc": 38.56,
+        "d6": 52.3,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 37.59,
+        "d6": 51.24,
+        "educationScore": 4,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GW": {
+      "baseline": {
+        "pc": 40.38,
+        "d6": 53.59,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 39.21,
+        "d6": 52.32,
+        "educationScore": 10,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GY": {
+      "baseline": {
+        "pc": 54.35,
+        "d6": 68.1,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 53.17,
+        "d6": 67.54,
+        "educationScore": 39,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "HT": {
+      "baseline": {
+        "pc": 44,
+        "d6": 58.16,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 42.7,
+        "d6": 57.33,
+        "educationScore": 10,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "HN": {
+      "baseline": {
+        "pc": 47.6,
+        "d6": 61.72,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 46.82,
+        "d6": 60.93,
+        "educationScore": 26,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "HU": {
+      "baseline": {
+        "pc": 58.8,
+        "d6": 72.47,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 59.22,
+        "d6": 72.91,
+        "educationScore": 88,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "IS": {
+      "baseline": {
+        "pc": 74.58,
+        "d6": 83.34,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 74.63,
+        "d6": 83.38,
+        "educationScore": 86,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "IN": {
+      "baseline": {
+        "pc": 48.72,
+        "d6": 61.54,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 47.72,
+        "d6": 61.03,
+        "educationScore": 36,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "ID": {
+      "baseline": {
+        "pc": 52.17,
+        "d6": 64.63,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 51.57,
+        "d6": 64.04,
+        "educationScore": 39,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "IR": {
+      "baseline": {
+        "pc": 33.46,
+        "d6": 48.63,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 33.68,
+        "d6": 48.76,
+        "educationScore": 47,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "IQ": {
+      "baseline": {
+        "pc": 40.94,
+        "d6": 63.19,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 40.44,
+        "d6": 63.03,
+        "educationScore": 19,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "IE": {
+      "baseline": {
+        "pc": 62.49,
+        "d6": 73.97,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 62.78,
+        "d6": 74.24,
+        "educationScore": 92,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "IL": {
+      "baseline": {
+        "pc": 55.52,
+        "d6": 69.96,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 57.67,
+        "d6": 71.12,
+        "educationScore": 92,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "IT": {
+      "baseline": {
+        "pc": 63.4,
+        "d6": 74.57,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 63.13,
+        "d6": 74.34,
+        "educationScore": 60,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "JM": {
+      "baseline": {
+        "pc": 55.86,
+        "d6": 69.61,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 55.69,
+        "d6": 69.42,
+        "educationScore": 65,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "JP": {
+      "baseline": {
+        "pc": 67.48,
+        "d6": 77.94,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 67.77,
+        "d6": 78.19,
+        "educationScore": 91,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "JO": {
+      "baseline": {
+        "pc": 53.68,
+        "d6": 65.78,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 53.25,
+        "d6": 65.38,
+        "educationScore": 45,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "KZ": {
+      "baseline": {
+        "pc": 53.2,
+        "d6": 66.21,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 54.62,
+        "d6": 66.91,
+        "educationScore": 97,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "KE": {
+      "baseline": {
+        "pc": 40.4,
+        "d6": 53.66,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 39.99,
+        "d6": 53.21,
+        "educationScore": 37,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "KI": {
+      "baseline": {
+        "pc": 54.32,
+        "d6": 69.46,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.57,
+        "d6": 67.33,
+        "educationScore": 15,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "KP": {
+      "baseline": {
+        "pc": 44.1,
+        "d6": 61.23,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 44.27,
+        "d6": 61.24,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "KR": {
+      "baseline": {
+        "pc": 56.76,
+        "d6": 69.92,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 56.96,
+        "d6": 70.13,
+        "educationScore": 82,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "KW": {
+      "baseline": {
+        "pc": 63.87,
+        "d6": 74.9,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 63.35,
+        "d6": 74.4,
+        "educationScore": 43,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "KG": {
+      "baseline": {
+        "pc": 52.35,
+        "d6": 65.69,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.37,
+        "d6": 65.65,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LA": {
+      "baseline": {
+        "pc": 49.77,
+        "d6": 65.35,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 48.74,
+        "d6": 64.31,
+        "educationScore": 18,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LV": {
+      "baseline": {
+        "pc": 60.36,
+        "d6": 73.47,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 60.87,
+        "d6": 73.98,
+        "educationScore": 95,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LB": {
+      "baseline": {
+        "pc": 40.85,
+        "d6": 59.48,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 41.34,
+        "d6": 59.72,
+        "educationScore": 46,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LS": {
+      "baseline": {
+        "pc": 51.44,
+        "d6": 64.7,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 50.51,
+        "d6": 63.8,
+        "educationScore": 29,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LR": {
+      "baseline": {
+        "pc": 44.92,
+        "d6": 57.58,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 44.07,
+        "d6": 56.72,
+        "educationScore": 18,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LY": {
+      "baseline": {
+        "pc": 43.14,
+        "d6": 56.85,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 43.43,
+        "d6": 56.86,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LI": {
+      "baseline": {
+        "pc": 74,
+        "d6": 81.46,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 73.12,
+        "d6": 81.3,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LT": {
+      "baseline": {
+        "pc": 59.68,
+        "d6": 71.37,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 60.19,
+        "d6": 71.86,
+        "educationScore": 96,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LU": {
+      "baseline": {
+        "pc": 65.12,
+        "d6": 77.26,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 65.03,
+        "d6": 77.16,
+        "educationScore": 82,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MG": {
+      "baseline": {
+        "pc": 41.24,
+        "d6": 56.36,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 40.05,
+        "d6": 55.04,
+        "educationScore": 8,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MW": {
+      "baseline": {
+        "pc": 43.43,
+        "d6": 56,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 41.45,
+        "d6": 54.93,
+        "educationScore": 8,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MY": {
+      "baseline": {
+        "pc": 55.61,
+        "d6": 68.35,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 55.79,
+        "d6": 68.53,
+        "educationScore": 75,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MV": {
+      "baseline": {
+        "pc": 50.41,
+        "d6": 65.64,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 49.28,
+        "d6": 64.35,
+        "educationScore": 17,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "ML": {
+      "baseline": {
+        "pc": 33.25,
+        "d6": 47.29,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 32.03,
+        "d6": 46.59,
+        "educationScore": 5,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MT": {
+      "baseline": {
+        "pc": 53.19,
+        "d6": 67.32,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.76,
+        "d6": 66.88,
+        "educationScore": 59,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MH": {
+      "baseline": {
+        "pc": 59.43,
+        "d6": 72.12,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 59.12,
+        "d6": 71.78,
+        "educationScore": 69,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MR": {
+      "baseline": {
+        "pc": 45.32,
+        "d6": 59.4,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 44.57,
+        "d6": 58.6,
+        "educationScore": 4,
+        "educationCoverage": 0.6,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MU": {
+      "baseline": {
+        "pc": 56.63,
+        "d6": 68.72,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 56.01,
+        "d6": 68.12,
+        "educationScore": 50,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MX": {
+      "baseline": {
+        "pc": 45.31,
+        "d6": 60.64,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 45.2,
+        "d6": 60.56,
+        "educationScore": 45,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "FM": {
+      "baseline": {
+        "pc": 62.85,
+        "d6": 74.33,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 62.5,
+        "d6": 73.93,
+        "educationScore": 63,
+        "educationCoverage": 0.6,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MD": {
+      "baseline": {
+        "pc": 52.73,
+        "d6": 65.89,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 53.09,
+        "d6": 66.28,
+        "educationScore": 80,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MC": {
+      "baseline": {
+        "pc": 65.8,
+        "d6": 72.82,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 64.41,
+        "d6": 72.61,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MN": {
+      "baseline": {
+        "pc": 56.68,
+        "d6": 68.92,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 57.25,
+        "d6": 69.47,
+        "educationScore": 93,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "ME": {
+      "baseline": {
+        "pc": 57.23,
+        "d6": 69.09,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 57.57,
+        "d6": 69.4,
+        "educationScore": 84,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MA": {
+      "baseline": {
+        "pc": 48.71,
+        "d6": 61.7,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 47.82,
+        "d6": 60.77,
+        "educationScore": 12,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MZ": {
+      "baseline": {
+        "pc": 38.58,
+        "d6": 52.07,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 37.56,
+        "d6": 51,
+        "educationScore": 10,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MM": {
+      "baseline": {
+        "pc": 42.92,
+        "d6": 58.86,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 42.1,
+        "d6": 58.4,
+        "educationScore": 24,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "NA": {
+      "baseline": {
+        "pc": 48.52,
+        "d6": 61.62,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 47.76,
+        "d6": 60.84,
+        "educationScore": 39,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "NR": {
+      "baseline": {
+        "pc": 64.34,
+        "d6": 74.51,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 62.56,
+        "d6": 73.52,
+        "educationScore": 45,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "NP": {
+      "baseline": {
+        "pc": 53.85,
+        "d6": 67.11,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.06,
+        "d6": 66.01,
+        "educationScore": 11,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "NL": {
+      "baseline": {
+        "pc": 62.42,
+        "d6": 74.47,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 62.4,
+        "d6": 74.44,
+        "educationScore": 79,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "NZ": {
+      "baseline": {
+        "pc": 67.3,
+        "d6": 79.61,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 67.21,
+        "d6": 79.53,
+        "educationScore": 81,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "NI": {
+      "baseline": {
+        "pc": 58.31,
+        "d6": 70.02,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 57.45,
+        "d6": 69.54,
+        "educationScore": 31,
+        "educationCoverage": 0.6,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "NE": {
+      "baseline": {
+        "pc": 34.31,
+        "d6": 47.39,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 33.26,
+        "d6": 46.25,
+        "educationScore": 1,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "NG": {
+      "baseline": {
+        "pc": 37.51,
+        "d6": 50.96,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 37.37,
+        "d6": 50.83,
+        "educationScore": 42,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MK": {
+      "baseline": {
+        "pc": 51.73,
+        "d6": 64.83,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 51.76,
+        "d6": 64.87,
+        "educationScore": 67,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "NO": {
+      "baseline": {
+        "pc": 75.11,
+        "d6": 83.75,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 75.67,
+        "d6": 83.98,
+        "educationScore": 90,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "OM": {
+      "baseline": {
+        "pc": 52.88,
+        "d6": 65.5,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 53.13,
+        "d6": 65.76,
+        "educationScore": 78,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "PK": {
+      "baseline": {
+        "pc": 37.96,
+        "d6": 52.43,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 37.59,
+        "d6": 51.99,
+        "educationScore": 21,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "PW": {
+      "baseline": {
+        "pc": 66.43,
+        "d6": 76.34,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 66.96,
+        "d6": 76.89,
+        "educationScore": 95,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "PA": {
+      "baseline": {
+        "pc": 50.95,
+        "d6": 65.56,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 50.73,
+        "d6": 65.32,
+        "educationScore": 55,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "PG": {
+      "baseline": {
+        "pc": 52.35,
+        "d6": 65.37,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 51.21,
+        "d6": 64.28,
+        "educationScore": 16,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "PY": {
+      "baseline": {
+        "pc": 56.8,
+        "d6": 69.38,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 56.43,
+        "d6": 69.03,
+        "educationScore": 50,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "PE": {
+      "baseline": {
+        "pc": 58.16,
+        "d6": 69.82,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 58.02,
+        "d6": 69.81,
+        "educationScore": 58,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "PH": {
+      "baseline": {
+        "pc": 53.42,
+        "d6": 65.63,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.86,
+        "d6": 65.1,
+        "educationScore": 39,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "PL": {
+      "baseline": {
+        "pc": 59.66,
+        "d6": 72.07,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 60.18,
+        "d6": 72.61,
+        "educationScore": 93,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "PT": {
+      "baseline": {
+        "pc": 63.51,
+        "d6": 75.91,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 62.96,
+        "d6": 75.4,
+        "educationScore": 54,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "QA": {
+      "baseline": {
+        "pc": 59.18,
+        "d6": 72.01,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 59.35,
+        "d6": 72.19,
+        "educationScore": 81,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "RO": {
+      "baseline": {
+        "pc": 55.78,
+        "d6": 68.09,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 55.95,
+        "d6": 68.27,
+        "educationScore": 74,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "RU": {
+      "baseline": {
+        "pc": 52.63,
+        "d6": 66.6,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 54.84,
+        "d6": 67.72,
+        "educationScore": 96,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "RW": {
+      "baseline": {
+        "pc": 45.25,
+        "d6": 58.91,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 43.42,
+        "d6": 57.92,
+        "educationScore": 16,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "KN": {
+      "baseline": {
+        "pc": 51.84,
+        "d6": 69.73,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 51.63,
+        "d6": 69.56,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LC": {
+      "baseline": {
+        "pc": 60.27,
+        "d6": 73.67,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 59.84,
+        "d6": 73.14,
+        "educationScore": 59,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "VC": {
+      "baseline": {
+        "pc": 53.47,
+        "d6": 69.81,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 53.15,
+        "d6": 69.64,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "WS": {
+      "baseline": {
+        "pc": 64.98,
+        "d6": 76.37,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 64.21,
+        "d6": 75.61,
+        "educationScore": 52,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SM": {
+      "baseline": {
+        "pc": 58.03,
+        "d6": 73.08,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 57.55,
+        "d6": 72.31,
+        "educationScore": 63,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "ST": {
+      "baseline": {
+        "pc": 56.13,
+        "d6": 67.97,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 55.96,
+        "d6": 67.83,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SA": {
+      "baseline": {
+        "pc": 58.16,
+        "d6": 70.05,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 58.55,
+        "d6": 70.45,
+        "educationScore": 80,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SN": {
+      "baseline": {
+        "pc": 42.67,
+        "d6": 56.49,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 41.38,
+        "d6": 55.09,
+        "educationScore": 6,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "RS": {
+      "baseline": {
+        "pc": 58.28,
+        "d6": 70.51,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 58.65,
+        "d6": 70.88,
+        "educationScore": 79,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SC": {
+      "baseline": {
+        "pc": 61.22,
+        "d6": 73.9,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 61.45,
+        "d6": 74.13,
+        "educationScore": 90,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SL": {
+      "baseline": {
+        "pc": 42.67,
+        "d6": 55.95,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 41.54,
+        "d6": 54.76,
+        "educationScore": 7,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SG": {
+      "baseline": {
+        "pc": 55.87,
+        "d6": 68.75,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 55.87,
+        "d6": 68.74,
+        "educationScore": 83,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SK": {
+      "baseline": {
+        "pc": 58.74,
+        "d6": 72.19,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 59.24,
+        "d6": 72.69,
+        "educationScore": 93,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SI": {
+      "baseline": {
+        "pc": 62.33,
+        "d6": 75.12,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 62.51,
+        "d6": 75.31,
+        "educationScore": 85,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SB": {
+      "baseline": {
+        "pc": 57.71,
+        "d6": 70.18,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 56.6,
+        "d6": 68.89,
+        "educationScore": 12,
+        "educationCoverage": 0.6,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SO": {
+      "baseline": {
+        "pc": 21,
+        "d6": 35.38,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 20.55,
+        "d6": 34.85,
+        "educationScore": 4,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "ZA": {
+      "baseline": {
+        "pc": 46.73,
+        "d6": 59.68,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 46.5,
+        "d6": 59.45,
+        "educationScore": 52,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SS": {
+      "baseline": {
+        "pc": 28.71,
+        "d6": 46.26,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 28.93,
+        "d6": 46.3,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "ES": {
+      "baseline": {
+        "pc": 62.3,
+        "d6": 73.6,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 62.02,
+        "d6": 73.34,
+        "educationScore": 60,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "LK": {
+      "baseline": {
+        "pc": 46.46,
+        "d6": 60.88,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 46.71,
+        "d6": 61.15,
+        "educationScore": 71,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SD": {
+      "baseline": {
+        "pc": 18.34,
+        "d6": 31.87,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 18.19,
+        "d6": 31.66,
+        "educationScore": 21,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SR": {
+      "baseline": {
+        "pc": 57.76,
+        "d6": 70,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 55.83,
+        "d6": 69.03,
+        "educationScore": 33,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SE": {
+      "baseline": {
+        "pc": 65.61,
+        "d6": 77.52,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 65.94,
+        "d6": 77.84,
+        "educationScore": 92,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "CH": {
+      "baseline": {
+        "pc": 74.59,
+        "d6": 81.91,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 74.84,
+        "d6": 82.08,
+        "educationScore": 89,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "SY": {
+      "baseline": {
+        "pc": 23.67,
+        "d6": 44.31,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 24.04,
+        "d6": 44.43,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TJ": {
+      "baseline": {
+        "pc": 58.04,
+        "d6": 70.9,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 58.68,
+        "d6": 71.36,
+        "educationScore": 82,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TZ": {
+      "baseline": {
+        "pc": 40.9,
+        "d6": 54.56,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 39.67,
+        "d6": 53.22,
+        "educationScore": 5,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TH": {
+      "baseline": {
+        "pc": 51.91,
+        "d6": 64.46,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 51.39,
+        "d6": 64,
+        "educationScore": 42,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TL": {
+      "baseline": {
+        "pc": 52.21,
+        "d6": 67.32,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.1,
+        "d6": 67.23,
+        "educationScore": 68,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TG": {
+      "baseline": {
+        "pc": 41.81,
+        "d6": 54.84,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 40.62,
+        "d6": 53.59,
+        "educationScore": 6,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TO": {
+      "baseline": {
+        "pc": 59.72,
+        "d6": 72.99,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 58.94,
+        "d6": 72.16,
+        "educationScore": 46,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TT": {
+      "baseline": {
+        "pc": 52.78,
+        "d6": 68.17,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.87,
+        "d6": 68.27,
+        "educationScore": 71,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TN": {
+      "baseline": {
+        "pc": 44.37,
+        "d6": 58.49,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 43.47,
+        "d6": 57.52,
+        "educationScore": 21,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TR": {
+      "baseline": {
+        "pc": 45.14,
+        "d6": 58.83,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 44.57,
+        "d6": 58.54,
+        "educationScore": 39,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TM": {
+      "baseline": {
+        "pc": 46.4,
+        "d6": 61.17,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 47.41,
+        "d6": 62.23,
+        "educationScore": 99,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TV": {
+      "baseline": {
+        "pc": 64.7,
+        "d6": 76.21,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 63.52,
+        "d6": 74.91,
+        "educationScore": 34,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "UG": {
+      "baseline": {
+        "pc": 42.25,
+        "d6": 55.47,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 40.36,
+        "d6": 54.42,
+        "educationScore": 11,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "UA": {
+      "baseline": {
+        "pc": 40.75,
+        "d6": 56.53,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 42.42,
+        "d6": 57.49,
+        "educationScore": 76,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "AE": {
+      "baseline": {
+        "pc": 63.92,
+        "d6": 74.6,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 64.3,
+        "d6": 74.97,
+        "educationScore": 86,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "GB": {
+      "baseline": {
+        "pc": 59.57,
+        "d6": 71.9,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 59.92,
+        "d6": 72.24,
+        "educationScore": 88,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "US": {
+      "baseline": {
+        "pc": 58.42,
+        "d6": 73.11,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 59.09,
+        "d6": 73.8,
+        "educationScore": 96,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "UY": {
+      "baseline": {
+        "pc": 63.64,
+        "d6": 75,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 62.79,
+        "d6": 74.19,
+        "educationScore": 41,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "UZ": {
+      "baseline": {
+        "pc": 56.45,
+        "d6": 69.68,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 57.26,
+        "d6": 70.53,
+        "educationScore": 98,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "VU": {
+      "baseline": {
+        "pc": 56.12,
+        "d6": 68.99,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 52.67,
+        "d6": 66.91,
+        "educationScore": 11,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "VE": {
+      "baseline": {
+        "pc": 33.11,
+        "d6": 51.15,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 33.36,
+        "d6": 51.48,
+        "educationScore": 66,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "VN": {
+      "baseline": {
+        "pc": 51.9,
+        "d6": 64.62,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 51.16,
+        "d6": 64.07,
+        "educationScore": 38,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "YE": {
+      "baseline": {
+        "pc": 31.01,
+        "d6": 48.54,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 30.5,
+        "d6": 48.28,
+        "educationScore": 17,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "ZM": {
+      "baseline": {
+        "pc": 44.46,
+        "d6": 57.75,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 43.51,
+        "d6": 56.77,
+        "educationScore": 22,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "ZW": {
+      "baseline": {
+        "pc": 37.39,
+        "d6": 53.56,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 36.63,
+        "d6": 52.67,
+        "educationScore": 11,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "HK": {
+      "baseline": {
+        "pc": 51.86,
+        "d6": 68.23,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 51.74,
+        "d6": 68.02,
+        "educationScore": 70,
+        "educationCoverage": 1,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "MO": {
+      "baseline": {
+        "pc": 67.02,
+        "d6": 78.97,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 66.26,
+        "d6": 78.19,
+        "educationScore": 55,
+        "educationCoverage": 0.8,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      }
+    },
+    "TW": {
+      "baseline": {
+        "pc": 64.39,
+        "d6": 77.1,
+        "educationScore": 0,
+        "educationCoverage": 0,
+        "educationImputationClass": "",
+        "sourceFailureDimensions": []
+      },
+      "proposed": {
+        "pc": 64.27,
+        "d6": 76.94,
+        "educationScore": 50,
+        "educationCoverage": 0.3,
+        "educationImputationClass": "unmonitored",
+        "sourceFailureDimensions": []
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Commits the education post-flip acceptance artifact — the last open box on `docs/methodology/education-flag-flip-runbook.md` step 5, and the only thing keeping #6460 open.

Captured read-only against production seeds at `465c3837c`:

```
VERDICT: PASS   (active pillar-combined formula, 196 countries)
  gate-1-spearman                      rho 1
  gate-2-country-drift                 max |delta| 3.45 (VU)
  gate-6-cohort-median                 worst fragile-states -1.07
  gate-7-matched-pair                  9/9 pairs pass
  gate-9-effective-influence-baseline  48/52 Core (92.31%); education 181/181
```

`sourceFailures: {}`, `blockingSourceFailures: {}`, at the shipped weight of 0.5.

## Why this capture is trustworthy where the previous one was not

#6532 removed an earlier committed PASS snapshot because its test trusted self-declared verdict and gate fields. This artifact is validated by that replacement validator, which recomputes score-derived gates, cross-checks gate 9 against observed education coverage, pins the harness commit and source digest, and carries a Redis snapshot hash for input provenance.

**Proven non-vacuous, not assumed.** Mutating `scores.US.proposed.pc` by +20 turns `any committed education acceptance artifacts are internally consistent` red; restored from a file copy, 13/13 pass. The artifact filename matches the validator's glob, so the suite genuinely reads it rather than passing over an empty set.

## Two earlier attempts were refused, and nothing was committed for either

That is the reason this is the first capture that means anything:

| Date | Refusal | Cleared by |
|---|---|---|
| 2026-08-12 | batch-wide education `source-failure` on a healthy seed (#6510) | #6517 |
| 2026-08-12 | harness aborted on Taiwan — structurally absent from WGI, member of no gate (#6520) | #6532 |

Both preconditions are now genuinely met rather than waived. #6532's own post-deploy instruction was to *"re-run the read-only education capture after the affected Taiwan source failures recover, and commit a PASS artifact only with independent provenance evidence"* — both conditions verified below.

## Production verification at capture time

A full sweep of all 196 published `resilience:score:v27:*` payloads reports **zero** source-failure dimensions (Taiwan's `stateContinuity` and San Marino's `socialCohesion` both cleared once the rotation picked up #6532). Spot-checked alongside it, all recent construct fixes are live and coherent:

- `AL 70 < SG 72 < GB 74` — #6529's diversity conditioning, Bosnia 90 → 46
- `US/LU/CH/SG/GB` at coverage **0.76** — #6519's non-DRS imputation firing after the debt seed republished with 72 `nonDrsCountryCodes`
- `ER`/`TW` fin-sys `0/0` — #6461/#6515 absence handling
- Education healthy across the sampled cohort (US 96/1.0, DE 86/1.0, JP 91/0.8, MC `unmonitored`)

## Validation

- `tests/dry-run-resilience-education-flip.test.mts`: **13/13 pass**, including the committed-artifact consistency check
- Mutation probe: corrupted score → red; restored → green
- Read-only capture — `_dimension-scorers.ts` performs no writes; the harness never calls `buildResilienceScore` / `ensureResilienceScoreCached`

## Note on gate 7

The harness prints a legacy-formula diagnostic (`de-vs-fr` under its floor on the retired `d6` formula). That is explicitly **not** part of the active `pc` acceptance verdict, and all 9 pairs pass on the active formula. The separate whole-index minGap concern is tracked in #6466.

Closes #6460.
