### PR TITLE
fix(desktop): show bottom-zone panels in the 900-1599px band

### DIFF
--- a/e2e/desktop-bottom-zone.spec.ts
+++ b/e2e/desktop-bottom-zone.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * #6426: the desktop app treats >= 900px as ultrawide (getUltraWideMinWidth,
+ * src/app/panel-layout.ts) and moves saved bottom-set panels into
+ * #mapBottomGrid — but panels.css hid that container below 1600px
+ * unconditionally, so for any desktop window in the 900-1599px band the
+ * user's bottom-zone panels sat in a display:none container with nothing
+ * indicating where they went.
+ *
+ * The web bundle is booted in desktop mode through isDesktopRuntime()'s
+ * user-agent sniff ("Tauri" in navigator.userAgent) — the same signal the
+ * packaged app can be detected by — so this runs against the standard e2e
+ * dev server without a desktop build.
+ */
+
+test.use({
+  userAgent:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Tauri/2.0',
+});
+
+test.describe('desktop bottom zone in the 900-1599px band', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('wm-layer-warning-dismissed', 'true');
+      localStorage.setItem('worldmonitor-variant', 'happy');
+    });
+  });
+
+  test('saved bottom-set panel is visible at 1200px and returns to the main grid below 900px', async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 800 });
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    // The Tauri UA sniff must have produced the desktop layout, or the band
+    // under test does not exist.
+    await expect(page.locator('main.main-content.desktop-grid')).toHaveCount(1, { timeout: 30_000 });
+
+    // Discover a real panel id in this variant, then persist it as the
+    // bottom set the same way savePanelOrder() does. Both keys are needed:
+    // applySavedPanelOrder() early-returns when `panel-order` is absent, so
+    // seeding only the bottom-set key never reaches the zone logic.
+    const firstPanel = page.locator('#panelsGrid > .panel[data-panel]').first();
+    await firstPanel.waitFor({ state: 'attached', timeout: 60_000 });
+    const panelId = await firstPanel.getAttribute('data-panel');
+    expect(panelId).toBeTruthy();
+
+    await page.evaluate((id) => {
+      const order = Array.from(document.querySelectorAll('.panel[data-panel]'))
+        .map((el) => (el as HTMLElement).dataset.panel)
+        .filter((v): v is string => typeof v === 'string' && v.length > 0);
+      localStorage.setItem('panel-order', JSON.stringify(order));
+      localStorage.setItem('panel-order-bottom-set', JSON.stringify([id]));
+    }, panelId);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+
+    // The panel must land in the bottom grid AND be visible — before the
+    // fix it landed there but the container was display:none !important.
+    const seeded = page.locator(`#mapBottomGrid .panel[data-panel="${panelId}"]`);
+    await expect(seeded).toBeVisible({ timeout: 60_000 });
+
+    // Below the desktop ultrawide threshold the zone logic moves the panel
+    // back to the main grid; it must stay visible through the transition.
+    await page.setViewportSize({ width: 850, height: 800 });
+    await expect(page.locator(`#panelsGrid .panel[data-panel="${panelId}"]`)).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/e2e/desktop-bottom-zone.spec.ts
+++ b/e2e/desktop-bottom-zone.spec.ts
@@ -1,4 +1,9 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
+
+const DESKTOP_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Tauri/2.0';
+const VIEWPORT_HEIGHT = 800;
+const TEST_STATE_INITIALIZED_KEY = '__desktop_bottom_zone_test_initialized';
 
 /**
  * #6426: the desktop app treats >= 900px as ultrawide (getUltraWideMinWidth,
@@ -14,23 +19,55 @@ import { expect, test } from '@playwright/test';
  * dev server without a desktop build.
  */
 
-test.use({
-  userAgent:
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Tauri/2.0',
-});
+async function prepareDashboard(page: Page, width: number): Promise<void> {
+  await page.setViewportSize({ width, height: VIEWPORT_HEIGHT });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => document.documentElement.dataset.wmEventHandlersReady === 'true');
+}
+
+async function seedBottomPanel(page: Page): Promise<string> {
+  const firstPanel = page.locator('#panelsGrid > .panel[data-panel]').first();
+  await expect(firstPanel).toBeAttached({ timeout: 60_000 });
+  const panelId = await firstPanel.getAttribute('data-panel');
+  expect(panelId).toBeTruthy();
+
+  await page.evaluate((id) => {
+    const order = Array.from(document.querySelectorAll('.panel[data-panel]'))
+      .map((el) => (el as HTMLElement).dataset.panel)
+      .filter((v): v is string => typeof v === 'string' && v.length > 0);
+    localStorage.setItem('panel-order', JSON.stringify(order));
+    localStorage.setItem('panel-order-bottom-set', JSON.stringify([id]));
+  }, panelId);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => document.documentElement.dataset.wmEventHandlersReady === 'true');
+
+  return panelId!;
+}
+
+function panelIn(grid: string, panelId: string) {
+  return `#${grid} .panel[data-panel="${panelId}"]`;
+}
+
+async function clearDashboardState(page: Page): Promise<void> {
+  await page.addInitScript((initializedKey) => {
+    if (localStorage.getItem(initializedKey) === 'true') return;
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem('wm-layer-warning-dismissed', 'true');
+    localStorage.setItem('worldmonitor-variant', 'happy');
+    localStorage.setItem(initializedKey, 'true');
+  }, TEST_STATE_INITIALIZED_KEY);
+}
 
 test.describe('desktop bottom zone in the 900-1599px band', () => {
+  test.use({ userAgent: DESKTOP_USER_AGENT });
+
   test.beforeEach(async ({ page }) => {
-    await page.addInitScript(() => {
-      localStorage.setItem('wm-layer-warning-dismissed', 'true');
-      localStorage.setItem('worldmonitor-variant', 'happy');
-    });
+    await clearDashboardState(page);
   });
 
-  test('saved bottom-set panel is visible at 1200px and returns to the main grid below 900px', async ({ page }) => {
-    await page.setViewportSize({ width: 1200, height: 800 });
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
-
+  test('saved bottom-set panel follows both desktop breakpoint seams', async ({ page }) => {
+    await prepareDashboard(page, 1200);
     // The Tauri UA sniff must have produced the desktop layout, or the band
     // under test does not exist.
     await expect(page.locator('main.main-content.desktop-grid')).toHaveCount(1, { timeout: 30_000 });
@@ -38,29 +75,68 @@ test.describe('desktop bottom zone in the 900-1599px band', () => {
     // Discover a real panel id in this variant, then persist it as the
     // bottom set the same way savePanelOrder() does. Both keys are needed:
     // applySavedPanelOrder() early-returns when `panel-order` is absent, so
-    // seeding only the bottom-set key never reaches the zone logic.
-    const firstPanel = page.locator('#panelsGrid > .panel[data-panel]').first();
-    await firstPanel.waitFor({ state: 'attached', timeout: 60_000 });
-    const panelId = await firstPanel.getAttribute('data-panel');
-    expect(panelId).toBeTruthy();
-
-    await page.evaluate((id) => {
-      const order = Array.from(document.querySelectorAll('.panel[data-panel]'))
-        .map((el) => (el as HTMLElement).dataset.panel)
-        .filter((v): v is string => typeof v === 'string' && v.length > 0);
-      localStorage.setItem('panel-order', JSON.stringify(order));
-      localStorage.setItem('panel-order-bottom-set', JSON.stringify([id]));
-    }, panelId);
-    await page.reload({ waitUntil: 'domcontentloaded' });
+    // seeding only the bottom-set key never reaches the zone logic. The app
+    // readiness marker is required so initPanelTabs() cannot overwrite the
+    // seed with its still-empty in-memory bottom set.
+    const panelId = await seedBottomPanel(page);
 
     // The panel must land in the bottom grid AND be visible — before the
     // fix it landed there but the container was display:none !important.
-    const seeded = page.locator(`#mapBottomGrid .panel[data-panel="${panelId}"]`);
+    const seeded = page.locator(panelIn('mapBottomGrid', panelId));
     await expect(seeded).toBeVisible({ timeout: 60_000 });
 
-    // Below the desktop ultrawide threshold the zone logic moves the panel
-    // back to the main grid; it must stay visible through the transition.
-    await page.setViewportSize({ width: 850, height: 800 });
-    await expect(page.locator(`#panelsGrid .panel[data-panel="${panelId}"]`)).toBeVisible({ timeout: 30_000 });
+    // The desktop threshold is inclusive: 900px keeps the panel in the
+    // bottom zone, while 899px moves it back to the main grid.
+    await page.setViewportSize({ width: 900, height: VIEWPORT_HEIGHT });
+    await expect(seeded).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(panelIn('panelsGrid', panelId))).toHaveCount(0);
+
+    await page.setViewportSize({ width: 899, height: VIEWPORT_HEIGHT });
+    await expect(page.locator(panelIn('panelsGrid', panelId))).toBeVisible({ timeout: 30_000 });
+    await expect(seeded).toHaveCount(0);
+
+    // Returning above the desktop threshold restores the remembered bottom
+    // placement, including the upper edge of the web-only hide band.
+    await page.setViewportSize({ width: 1599, height: VIEWPORT_HEIGHT });
+    await expect(seeded).toBeVisible({ timeout: 30_000 });
+    await page.setViewportSize({ width: 1600, height: VIEWPORT_HEIGHT });
+    await expect(seeded).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('empty bottom zone stays collapsed in the desktop band', async ({ page }) => {
+    await prepareDashboard(page, 1200);
+
+    const metrics = await page.evaluate(() => {
+      const grid = document.getElementById('mapBottomGrid');
+      if (!grid) throw new Error('map bottom grid was not rendered');
+      return { children: grid.children.length, height: grid.getBoundingClientRect().height };
+    });
+
+    expect(metrics.children).toBe(0);
+    expect(metrics.height).toBeLessThanOrEqual(4);
+  });
+});
+
+test.describe('web bottom zone below the web breakpoint', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearDashboardState(page);
+  });
+
+  test('keeps the bottom zone hidden through 1599px and shows it at 1600px', async ({ page }) => {
+    await prepareDashboard(page, 1200);
+    await expect(page.locator('main.main-content.desktop-grid')).toHaveCount(0);
+
+    const panelId = await seedBottomPanel(page);
+    const seeded = page.locator(panelIn('mapBottomGrid', panelId));
+
+    await expect(page.locator('#mapBottomGrid')).toBeHidden();
+    await expect(page.locator(panelIn('panelsGrid', panelId))).toBeVisible({ timeout: 30_000 });
+
+    await page.setViewportSize({ width: 1599, height: VIEWPORT_HEIGHT });
+    await expect(page.locator('#mapBottomGrid')).toBeHidden();
+    await expect(page.locator(panelIn('panelsGrid', panelId))).toBeVisible({ timeout: 30_000 });
+
+    await page.setViewportSize({ width: 1600, height: VIEWPORT_HEIGHT });
+    await expect(seeded).toBeVisible({ timeout: 30_000 });
   });
 });

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -2821,8 +2821,20 @@ body.panel-drag-active .map-bottom-grid:empty::after {
   border-top-color: var(--accent);
 }
 
-/* Hide drop zone completely on smaller screens (overridden by media query in main.css) */
+/* Hide the drop zone below the ultrawide threshold — which is RUNTIME
+   dependent, so the breakpoints here must mirror getUltraWideMinWidth()
+   (src/app/panel-layout.ts): 1600px on the web, 900px in the desktop app
+   (`.desktop-grid` on .main-content). Hiding the desktop app's zone below
+   1600px is #6426: from 900px up, ensureCorrectZones() moves saved
+   bottom-set panels INTO this container, so a blanket 1599px rule makes
+   those panels vanish for any desktop window in the 900-1599px band. */
 @media (max-width: 1599px) {
+  .main-content:not(.desktop-grid) .map-bottom-grid {
+    display: none !important;
+  }
+}
+
+@media (max-width: 899px) {
   .map-bottom-grid {
     display: none !important;
   }

--- a/tests/responsive-zone-listener.test.mjs
+++ b/tests/responsive-zone-listener.test.mjs
@@ -13,6 +13,10 @@ const panelLayoutSrc = readFileSync(
   resolve(__dirname, '../src/app/panel-layout.ts'),
   'utf-8',
 );
+const panelsCss = readFileSync(
+  resolve(__dirname, '../src/styles/panels.css'),
+  'utf-8',
+);
 
 class FakeMediaQueryList extends EventTarget {
   constructor(media) {
@@ -132,6 +136,29 @@ describe('panel layout responsive zone wiring', () => {
     assert.match(panelLayoutSrc, /addResponsiveZoneListener\(/);
     assert.match(panelLayoutSrc, /this\.getUltraWideMinWidth\(\)/);
     assert.match(panelLayoutSrc, /addResponsiveZoneListener\([\s\S]*?ensureCorrectZones\(\)/);
+  });
+
+  it('keeps CSS visibility thresholds aligned with the runtime thresholds', () => {
+    const thresholds = panelLayoutSrc.match(/return this\.ctx\.isDesktopApp \? (\d+) : (\d+);/);
+    assert.ok(thresholds, 'getUltraWideMinWidth() must keep an explicit desktop/web threshold pair');
+    const desktopMinWidth = Number(thresholds[1]);
+    const webMinWidth = Number(thresholds[2]);
+
+    assert.match(
+      panelsCss,
+      new RegExp(`@media \\(max-width: ${desktopMinWidth - 1}px\\)`),
+      'CSS must hide the bottom zone below the desktop runtime threshold',
+    );
+    assert.match(
+      panelsCss,
+      new RegExp(`@media \\(max-width: ${webMinWidth - 1}px\\)`),
+      'CSS must hide the bottom zone below the web runtime threshold',
+    );
+    assert.match(
+      panelsCss,
+      /\.main-content:not\(\.desktop-grid\)\s+\.map-bottom-grid\s*\{\s*display:\s*none\s*!important;/,
+      'the web-only hide must exclude the desktop runtime marker',
+    );
   });
 
   it('does not register post-render listeners after destroy during async panel setup', () => {


### PR DESCRIPTION
Closes #6426.

## Problem

The desktop app treats **≥ 900px** as ultrawide (`getUltraWideMinWidth()`, `src/app/panel-layout.ts`), so from 900px up `ensureCorrectZones()` moves saved bottom-set panels out of `#panelsGrid` and into `#mapBottomGrid`. But `panels.css` hid that container below **1600px** unconditionally, with `!important`, for every runtime — its comment claimed a `main.css` media query overrides it, which nothing does (the only `main.css` rules for the container are `:empty` cosmetics).

Result: for any desktop window between 900px and 1599px, every panel the user placed in the bottom zone was moved into a `display: none` container. Still in the DOM, but indistinguishable from data loss, and the recovery path (widen past 1600px) undiscoverable.

## Fix

Align the CSS with the runtime thresholds it was already supposed to mirror, using the `desktop-grid` class the desktop app statically stamps on `.main-content`:

```css
@media (max-width: 1599px) {
  .main-content:not(.desktop-grid) .map-bottom-grid { display: none !important; }
}
@media (max-width: 899px) {
  .map-bottom-grid { display: none !important; }
}
```

- **Web:** unchanged — hidden below 1600px, exactly as before.
- **Desktop 900–1599px:** container visible; the panels the zone logic puts there render.
- **Desktop < 900px:** hidden — matching the width at which `ensureCorrectZones()` moves panels back to the main grid.

The stale "overridden by media query in main.css" comment is replaced by one naming the real contract (breakpoints must mirror `getUltraWideMinWidth()`).

## Regression spec

`e2e/desktop-bottom-zone.spec.ts` boots the standard e2e web bundle in desktop mode through `isDesktopRuntime()`'s Tauri user-agent sniff (no desktop build needed), persists a bottom-set panel the way `savePanelOrder()` does (both `panel-order` and `panel-order-bottom-set` — `applySavedPanelOrder()` early-returns without the former), and pins both sides of the band:

- at **1200px**: the panel is inside `#mapBottomGrid` **and visible** — before the fix it landed there but the container was `display:none`, and the spec fails;
- at **850px**: the panel returns to `#panelsGrid` and stays visible.

## Verification

- Spec passes with the fix, fails against the pre-fix CSS (verified both ways).
- Also verified interactively against a `VITE_DESKTOP_RUNTIME=1` dev build at 1200×800: seeded bottom-set panel renders below the map, `getComputedStyle(#mapBottomGrid).display === 'grid'`; narrowing to 850px returns it to the main grid.
- `biome lint` clean.
