### PR TITLE
ci: let the acceptance-artifact validator run on the PR that commits one

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,13 @@ jobs:
             --paginate --jq '.[].filename')
           CODE=$(echo "$FILES" | awk '
             /^docs\/research\/seo-ai-visibility\// { count++; next }
+            # Committed resilience acceptance artifacts are docs-path data that
+            # tests/dry-run-resilience-education-flip.test.mts validates —
+            # recomputing gates, checking provenance, and rejecting a
+            # self-declared verdict. That validator lives in the `unit` job, so
+            # without this rule the guard skips on exactly the PR that commits
+            # an artifact and can only ever fire on unrelated changes.
+            /^docs\/snapshots\/resilience-.*-acceptance-.*\.json$/ { count++; next }
             /\.md$/ { next }
             /^docs\// { next }
             /^src-tauri\// && $0 !~ /^src-tauri\/sidecar\// && $0 !~ /^src-tauri\/.*\.json$/ { next }


### PR DESCRIPTION
## Problem

The `unit` job runs `tests/dry-run-resilience-education-flip.test.mts`, whose `any committed education acceptance artifacts are internally consistent` case is the guard #6532 added after removing a committed PASS snapshot whose test had trusted self-declared verdict and gate fields.

**That guard cannot fire on the change it exists to police.** The `changes` filter drops everything under `docs/`, acceptance artifacts live at `docs/snapshots/*.json`, so `code=false` and `unit` skips. The validator only ever ran on unrelated code PRs — never on an artifact commit.

Measured on #6542, which committed the first real artifact: every required check passed while `unit` skipped, so the artifact merged without its own validator running once in CI. Running the filter program against that PR's file list returns `0` code-triggering files.

That artifact was in fact sound — validated locally 13/13, and a mutation of `scores.US.proposed.pc` was observed turning the consistency test red before being restored. But that was a property of how it happened to be captured, not something CI enforced. The next one has no such guarantee.

## Fix

One rule, placed before the blanket `docs/` skip, matching the existing `docs/research/seo-ai-visibility/` precedent for docs-path content that is really code input.

Verified against the real filter program, not asserted:

| File | code-triggering |
|---|---|
| `docs/snapshots/resilience-education-acceptance-2026-08-13.json` | **1 (runs)** |
| `docs/snapshots/resilience-ranking-2026-05-28.json` | 0 (skips) |
| `docs/methodology/foo.mdx` | 0 (skips) |
| `README.md` | 0 (skips) |

So the guard fires for acceptance artifacts and nothing else — the existing ranking snapshots and ordinary docs are unaffected, and no docs-only PR starts paying for the full unit suite.

The pattern is `resilience-.*-acceptance-.*\.json` rather than education-only, so the energy-v2 acceptance artifact the runbook still owes (`docs/methodology/energy-v2-flag-flip-runbook.md`, recorded as never captured) lands guarded too rather than needing this fixed a second time.

## Validation

- Workflow YAML parses; 13 jobs intact; the `unit` job's condition is unchanged (`needs.changes.outputs.code == 'true'`)
- `awk` parses the added comment lines — confirmed by running the exact program
- Diff is 7 added lines, no deletions

## Note

This PR's own file list is `.github/workflows/test.yml`, which is code — so `unit` runs here and you can see the suite green on the same commit that adds the rule.

Related: #6532 (added the validator), #6542 (committed the first artifact, merged with the validator skipped), #6460 (closed by that artifact).
