### PR TITLE
fix(sentry-triage): convex OCC conflict herds + Y4 trampoline gate hole

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -26,7 +26,7 @@ The freshness clock a seeder declares over the *observation dates inside* the pa
 
 Two rules follow from what the contract reduces to. It reports a single newest timestamp, so a payload assembled from *several independently-failing sources* must derive one clock per source and report the **oldest** of them; reducing all their dates together takes the newest, and the still-living source then hides the dead one indefinitely — an alarm that can only fire when every source dies at once. And an undatable payload must report nothing rather than a default, because "we cannot date this" and "this is stale" warrant the same response, while a fabricated recent date warrants none.
 
-Sizing the budget belongs to the source's own publication calendar, measured rather than assumed: the widest gap the source routinely takes — a holiday cluster, a non-working period, a weekend either side — plus room for one missed run. A budget guessed generously enough to never false-alarm has usually also stopped detecting the freeze it exists for. See also: Seed-Owned Key, Activation Marker.
+Sizing the budget belongs to the source's own publication calendar, measured rather than assumed: the widest gap the source routinely takes — a holiday cluster, a non-working period, a weekend either side — plus room for one missed run. A budget guessed generously enough to never false-alarm has usually also stopped detecting the freeze it exists for. See also: Seed-Owned Key, Activation Marker, Content Clock.
 
 ### Activation Marker
 
@@ -137,6 +137,22 @@ The invariant that exactly one layer owns retry policy for any external provider
 ### Rate-Limit Outcome
 
 The typed value a provider-rate-limited operation returns *instead of throwing*, so every downstream surface renders a deliberate retry state — an HTTP 429 with a retry hint at the service boundary, a structured error code on the public API — rather than collapsing the limit into a generic failure. The outcome only exists after the owning retry layer has exhausted its bounded attempts; a raw rate-limit error escaping before that point is a defect, not an outcome. See also: Retry Ownership.
+
+## Error Telemetry & Suppression
+
+### Trampoline Frame
+
+A stack frame contributed by a monkeypatched global — most often a third-party script's `window.fetch` wrapper — that appears in a trace as though it were a caller but merely passes the call through. Trampoline frames make third-party failures look first-party, which is why suppression gates must classify them; the trap is that their *names* are minifier output, renamed at will across builds and eventually omitted entirely, so any gate that recognizes a trampoline by name shape is on a treadmill. Identity comes instead from build-stable structural facts: which first-party chunk the frame is attributed to, and whether the wrapping script's own frame is present in the same trace. A gate that admits trampoline frames from a chunk is safe only under an *enforced* invariant that the chunk's backing modules perform no network work of their own — enforced meaning a test fails when it stops being true, not a comment asserting it. See also: Vacuous Guard.
+
+## Timestamps & Hot-Document Writes
+
+### Content Clock
+
+A timestamp whose meaning is "the data beside it was confirmed against its source at this moment" — as distinct from a write stamp, which records only that a write happened. A clock becomes a content clock the moment any consumer compares it against another clock to decide which of two sources holds the fresher content; from then on, two rules bind every writer. Any write that changes the content the clock dates must stamp the clock in the same write, or the clock silently stops dating the content. And the clock may be throttled only for *no-change* writes: skipping a write when the content is identical cannot mis-order a freshness comparison, because whichever side then wins names the same content. The seeder-payload instance of the same idea is the Content-Age Contract — date the observations, never the run. See also: Content-Age Contract, Touch Mutation.
+
+### Touch Mutation
+
+A fire-and-forget mutation that stamps a credential's last-used time as a side effect of validating it. The stamp is telemetry — nothing may treat it as a Content Clock — which is what licenses aggressive suppression of the write. Its discipline is a debounce split across two lines that share one window constant: the *scheduling* site consults the stamp returned by the validation read and schedules nothing while the stamp is fresh, so no queue of touches can accumulate behind a debounce boundary and herd-write the same hot document when the window expires; the mutation re-checks staleness on execution as the second line, turning any straggler that races anyway into a read-only no-op — and in an optimistic-concurrency store, an execution that never writes cannot conflict. Splitting the window's value across the two lines is the failure mode: the halves drift and the herd returns. See also: Content Clock.
 
 ## Test & Guard Verification
 

--- a/convex/__tests__/apiKeys.test.ts
+++ b/convex/__tests__/apiKeys.test.ts
@@ -1,5 +1,5 @@
 import { convexTest } from "convex-test";
-import { expect, test, describe } from "vitest";
+import { afterEach, beforeEach, expect, test, describe, vi } from "vitest";
 import schema from "../schema";
 import { api, internal } from "../_generated/api";
 import { getFeaturesForPlan } from "../lib/entitlements";
@@ -456,5 +456,101 @@ describe("touchKeyLastUsed", () => {
 
     // Should not throw
     await t.mutation(internal.apiKeys.touchKeyLastUsed, { keyId: created.id });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP route /api/internal-validate-api-key — touch scheduling gate
+//
+// Convex Insights (2026-08): apiKeys:touchKeyLastUsed produced 1,036 OCC
+// write conflicts on userApiKeys in 14 days (max retry depth 3), because the
+// route scheduled a touch on EVERY validation and the mutation's internal
+// 5-minute debounce is a read-then-write: at each debounce-boundary every
+// concurrently scheduled touch reads the same stale lastUsedAt and they all
+// patch the same hot document. The gate moves the staleness check to the
+// route, so a fresh key schedules NOTHING — the herd never forms.
+//
+// The observable for "was a touch scheduled": queue a validate inside the
+// debounce window, let the fake clock pass the boundary, THEN drain the
+// scheduler. A queued touch would now see a stale lastUsedAt and write; a
+// gated route queued nothing, so lastUsedAt must not move.
+// ---------------------------------------------------------------------------
+
+describe("HTTP route /api/internal-validate-api-key — touch scheduling gate", () => {
+  const SHARED_SECRET = "test-shared-secret";
+  const T0 = new Date("2026-08-13T00:00:00Z").getTime();
+
+  beforeEach(() => {
+    process.env.CONVEX_SERVER_SHARED_SECRET = SHARED_SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CONVEX_SERVER_SHARED_SECRET;
+    vi.useRealTimers();
+  });
+
+  async function validate(t: ReturnType<typeof convexTest>, keyHash: string) {
+    return t.fetch("/api/internal-validate-api-key", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-convex-shared-secret": SHARED_SECRET,
+      },
+      body: JSON.stringify({ keyHash }),
+    });
+  }
+
+  async function readLastUsedAt(t: ReturnType<typeof convexTest>, keyHash: string) {
+    return t.run(async (ctx) => {
+      const row = await ctx.db
+        .query("userApiKeys")
+        .withIndex("by_keyHash", (q) => q.eq("keyHash", keyHash))
+        .unique();
+      return row?.lastUsedAt;
+    });
+  }
+
+  test("validate inside the debounce window schedules no touch; after expiry it does", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const t = convexTest(schema, modules);
+    await seedApiEntitlement(t, "user-api");
+    await t.withIdentity(API_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+    const keyHash = makeKeyArgs(1).keyHash;
+
+    // Phase 1 — first validate: lastUsedAt unset, so the touch must be scheduled.
+    const res1 = await validate(t, keyHash);
+    expect(res1.status).toBe(200);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await readLastUsedAt(t, keyHash)).toBe(T0);
+
+    // Phase 2 — validate at T0+2min (inside the 5-min debounce). Leave the
+    // scheduler undrained and move past the boundary before draining: a
+    // queued touch would execute with a stale read and write T0+6min.
+    vi.setSystemTime(T0 + 2 * 60_000);
+    const res2 = await validate(t, keyHash);
+    expect(res2.status).toBe(200);
+    vi.setSystemTime(T0 + 6 * 60_000);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await readLastUsedAt(t, keyHash)).toBe(T0);
+
+    // Phase 3 — validate after expiry: the gate must reopen.
+    const res3 = await validate(t, keyHash);
+    expect(res3.status).toBe(200);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await readLastUsedAt(t, keyHash)).toBe(T0 + 6 * 60_000);
+  });
+
+  test("response body does not leak lastUsedAt (gateway contract unchanged)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const t = convexTest(schema, modules);
+    await seedApiEntitlement(t, "user-api");
+    await t.withIdentity(API_USER).mutation(api.apiKeys.createApiKey, makeKeyArgs(1));
+
+    const res = await validate(t, makeKeyArgs(1).keyHash);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(Object.keys(body).sort()).toEqual(["id", "name", "userId"]);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
   });
 });

--- a/convex/__tests__/mcpProTokens.test.ts
+++ b/convex/__tests__/mcpProTokens.test.ts
@@ -562,6 +562,53 @@ describe("HTTP route /api/internal-validate-pro-mcp-token", () => {
     await t.finishAllScheduledFunctions(vi.runAllTimers);
     vi.useRealTimers();
   });
+
+  // Touch scheduling gate — same OCC write-conflict class as
+  // apiKeys:touchKeyLastUsed (see apiKeys.test.ts for the full mechanism
+  // note). A validate inside the 5-min debounce must schedule nothing; the
+  // observable is a deliberately late drain that would let a queued touch
+  // write with a stale read.
+  test("validate inside the debounce window schedules no touch; after expiry it does", async () => {
+    const T0 = new Date("2026-08-13T00:00:00Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const t = convexTest(schema, modules);
+    await seedProEntitlement(t, "user-pro");
+    const issued = await t.mutation(internal.mcpProTokens.issueProMcpToken, {
+      userId: "user-pro",
+    });
+
+    const validate = () =>
+      t.fetch("/api/internal-validate-pro-mcp-token", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-convex-shared-secret": SHARED_SECRET,
+        },
+        body: JSON.stringify({ tokenId: issued.tokenId }),
+      });
+    const readLastUsedAt = () =>
+      t.run(async (ctx) => (await ctx.db.get(issued.tokenId))?.lastUsedAt);
+
+    // Phase 1 — first validate: lastUsedAt unset → touch scheduled.
+    expect((await validate()).status).toBe(200);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await readLastUsedAt()).toBe(T0);
+
+    // Phase 2 — inside the window: drain only after the boundary; a queued
+    // touch would write T0+6min, a gated route queued nothing.
+    vi.setSystemTime(T0 + 2 * 60_000);
+    expect((await validate()).status).toBe(200);
+    vi.setSystemTime(T0 + 6 * 60_000);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await readLastUsedAt()).toBe(T0);
+
+    // Phase 3 — after expiry the gate reopens.
+    expect((await validate()).status).toBe(200);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await readLastUsedAt()).toBe(T0 + 6 * 60_000);
+    vi.useRealTimers();
+  });
 });
 
 describe("HTTP route /api/internal-revoke-pro-mcp-token", () => {

--- a/convex/__tests__/users.test.ts
+++ b/convex/__tests__/users.test.ts
@@ -1,7 +1,8 @@
 import { convexTest } from "convex-test";
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import schema from "../schema";
 import { api } from "../_generated/api";
+import { LAST_SEEN_REFRESH_WINDOW_MS } from "../users";
 
 const modules = import.meta.glob("../**/*.ts");
 
@@ -280,6 +281,114 @@ describe("users:ensureRecord — email policy", () => {
         .unique(),
     );
     expect(rowAfter?.email).toBe("alice@example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-change debounce (OCC write-avoidance)
+//
+// Convex Insights 2026-07-28: users:ensureRecord produced 1,618 OCC write
+// conflicts on `users` in ONE day, because every call — including calls that
+// changed nothing — patched `lastSeenAt`, so concurrent tabs / auth-refresh
+// storms all rewrote the same document. A call that changes no material field
+// inside the refresh window must be read-only.
+//
+// The #6335 invariant is the safety bound: whenever `email` is rewritten,
+// `lastSeenAt` is stamped in the SAME patch (that timestamp dates the
+// address for the login-email freshness comparison in subscriptionHelpers).
+// The skip below fires only when the email — and everything else — is
+// identical, so the invariant is untouched; lastSeenAt merely becomes a
+// lower bound that lags true activity by at most the window.
+// ---------------------------------------------------------------------------
+
+describe("users:ensureRecord — no-change debounce", () => {
+  const T0 = new Date("2026-08-13T00:00:00Z").getTime();
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function readRow(t: ReturnType<typeof convexTest>) {
+    return t.run(async (ctx) =>
+      await ctx.db
+        .query("users")
+        .withIndex("by_userId", (q) => q.eq("userId", USER_A.subject))
+        .unique(),
+    );
+  }
+
+  test("identical repeat inside the window is read-only (action 'unchanged', lastSeenAt keeps)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const t = convexTest(schema, modules);
+    const asA = t.withIdentity(USER_A);
+    const args = {
+      localeTag: "en-US",
+      localePrimary: "en",
+      timezone: "America/New_York",
+      country: "US",
+    };
+    await asA.mutation(api.users.ensureRecord, args);
+    expect((await readRow(t))?.lastSeenAt).toBe(T0);
+
+    vi.setSystemTime(T0 + 60_000);
+    const repeat = await asA.mutation(api.users.ensureRecord, args);
+    expect(repeat.ok).toBe(true);
+    expect(repeat.ok && repeat.action).toBe("unchanged");
+    expect((await readRow(t))?.lastSeenAt).toBe(T0);
+  });
+
+  test("identical repeat after the window refreshes lastSeenAt", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const t = convexTest(schema, modules);
+    const asA = t.withIdentity(USER_A);
+    const args = { localeTag: "en-US", localePrimary: "en" };
+    await asA.mutation(api.users.ensureRecord, args);
+
+    const later = T0 + LAST_SEEN_REFRESH_WINDOW_MS + 1_000;
+    vi.setSystemTime(later);
+    const repeat = await asA.mutation(api.users.ensureRecord, args);
+    expect(repeat.ok && repeat.action).toBe("patched");
+    expect((await readRow(t))?.lastSeenAt).toBe(later);
+  });
+
+  test("material change inside the window writes immediately and stamps lastSeenAt (#6335)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const t = convexTest(schema, modules);
+    await t
+      .withIdentity({ ...USER_A, email: "old@a.com" })
+      .mutation(api.users.ensureRecord, { localeTag: "en-US", localePrimary: "en" });
+
+    vi.setSystemTime(T0 + 60_000);
+    const changed = await t
+      .withIdentity({ ...USER_A, email: "new@b.com" })
+      .mutation(api.users.ensureRecord, { localeTag: "en-US", localePrimary: "en" });
+    expect(changed.ok && changed.action).toBe("patched");
+
+    const row = await readRow(t);
+    expect(row?.email).toBe("new@b.com");
+    expect(row?.lastSeenAt).toBe(T0 + 60_000);
+  });
+
+  test("providing timezone for the first time inside the window is a material change", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    const t = convexTest(schema, modules);
+    const asA = t.withIdentity(USER_A);
+    await asA.mutation(api.users.ensureRecord, { localeTag: "en-US", localePrimary: "en" });
+
+    vi.setSystemTime(T0 + 60_000);
+    const withTz = await asA.mutation(api.users.ensureRecord, {
+      localeTag: "en-US",
+      localePrimary: "en",
+      timezone: "Europe/Paris",
+    });
+    expect(withTz.ok && withTz.action).toBe("patched");
+    const row = await readRow(t);
+    expect(row?.timezone).toBe("Europe/Paris");
+    expect(row?.lastSeenAt).toBe(T0 + 60_000);
   });
 });
 

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -147,6 +147,71 @@ async function processEvent(
 // Tests
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Customers no-op rewrite skip (OCC write-avoidance)
+//
+// Convex Insights (2026-08): processWebhookEvent produced OCC write conflicts
+// on `customers` because Dodo delivers related events for one purchase in a
+// burst (subscription.active + subscription.updated within milliseconds) and
+// every subscription event unconditionally re-patched the same customers row
+// with identical userId/email — pure conflict fuel, since no consumer reads
+// customers.updatedAt (verified repo-wide). An identical upsert must be
+// read-only; a real identity change must still write.
+// ---------------------------------------------------------------------------
+
+describe("processWebhookEvent — customers no-op rewrite skip", () => {
+  async function readCustomer(t: ReturnType<typeof convexTest>) {
+    return t.run(async (ctx) =>
+      await ctx.db
+        .query("customers")
+        .withIndex("by_dodoCustomerId", (q) => q.eq("dodoCustomerId", "cust_test_001"))
+        .unique(),
+    );
+  }
+
+  test("second subscription event with identical customer identity does not rewrite the row", async () => {
+    const t = convexTest(schema, modules);
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+
+    await processEvent(t, "wh_occ_1", "subscription.active", makeSubscriptionPayload(), BASE_TIMESTAMP);
+    const first = await readCustomer(t);
+    expect(first).not.toBeNull();
+
+    // Different delivery (new webhookId, later timestamp), same identity —
+    // the Dodo burst shape that produced the conflicts.
+    await processEvent(
+      t,
+      "wh_occ_2",
+      "subscription.active",
+      makeSubscriptionPayload(),
+      BASE_TIMESTAMP + 60_000,
+    );
+    const second = await readCustomer(t);
+    expect(second?.updatedAt).toBe(first?.updatedAt);
+  });
+
+  test("changed customer email still rewrites the row", async () => {
+    const t = convexTest(schema, modules);
+    await seedProductPlan(t, "pdt_test_pro", "pro_monthly", "Pro Monthly");
+
+    await processEvent(t, "wh_occ_3", "subscription.active", makeSubscriptionPayload(), BASE_TIMESTAMP);
+
+    const changed = makeSubscriptionPayload({
+      customer: {
+        customer_id: "cust_test_001",
+        email: "renamed@example.com",
+        name: "Test User",
+      },
+    });
+    await processEvent(t, "wh_occ_4", "subscription.active", changed, BASE_TIMESTAMP + 60_000);
+
+    const row = await readCustomer(t);
+    expect(row?.email).toBe("renamed@example.com");
+    expect(row?.normalizedEmail).toBe("renamed@example.com");
+    expect(row?.updatedAt).toBe(BASE_TIMESTAMP + 60_000);
+  });
+});
+
 describe("webhook processWebhookEvent", () => {
   test("subscription.active creates new subscription", async () => {
     const t = convexTest(schema, modules);

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -235,6 +235,10 @@ export const validateKeyByHash = internalQuery({
       name: key.name,
       scopes: key.scopes,
       companyMonitoringAccountId: key.companyMonitoringAccountId,
+      // Consumed ONLY by the /api/internal-validate-api-key route to decide
+      // whether scheduling touchKeyLastUsed is worthwhile; the route strips
+      // it before responding, so the gateway cache blob is unchanged.
+      lastUsedAt: key.lastUsedAt,
     };
   },
 });
@@ -258,8 +262,17 @@ export const getKeyOwner = internalQuery({
  * Bump lastUsedAt for a key (fire-and-forget from the gateway).
  * Skips the write if lastUsedAt was updated within the last 5 minutes
  * to reduce Convex write load for hot keys.
+ *
+ * Exported because the debounce check ALSO runs in http.ts before the touch
+ * is even scheduled. The in-mutation check alone was a read-then-write race:
+ * every validation scheduled a touch, and at each debounce boundary all
+ * concurrently scheduled touches read the same stale lastUsedAt and patched
+ * the same hot document — 1,036 OCC write conflicts on userApiKeys in 14
+ * days, reaching retry depth 3 (Convex Insights, 2026-08). Gating at the
+ * schedule site keeps the herd from forming; this in-mutation check stays as
+ * the second line, making any touch that does race a no-op on retry.
  */
-const TOUCH_DEBOUNCE_MS = 5 * 60 * 1000;
+export const TOUCH_DEBOUNCE_MS = 5 * 60 * 1000;
 
 export const touchKeyLastUsed = internalMutation({
   args: { keyId: v.id("userApiKeys") },

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,6 +1,7 @@
 import { anyApi, httpRouter } from "convex/server";
 import { httpAction, type ActionCtx } from "./_generated/server";
 import { internal } from "./_generated/api";
+import { TOUCH_DEBOUNCE_MS } from "./apiKeys";
 import {
   CHECKOUT_RATE_LIMITED,
   isCheckoutRateLimitedOutcome,
@@ -1107,6 +1108,19 @@ http.route({
 // User API key validation (service-to-service only)
 // ---------------------------------------------------------------------------
 
+// Schedule-site half of the lastUsedAt debounce (the mutation-side half lives
+// in touchKeyLastUsed / touchProMcpTokenLastUsed). Scheduling a touch on
+// EVERY validation meant that at each debounce boundary all concurrently
+// scheduled touches read the same stale lastUsedAt and patched the same hot
+// document — 1,036 OCC write conflicts on userApiKeys in 14 days at up to
+// retry depth 3 (Convex Insights, 2026-08). A fresh lastUsedAt makes the
+// touch a guaranteed no-op, so don't enqueue it at all; only genuinely stale
+// (or never-touched) rows schedule, which also drops one scheduled job per
+// validation off the scheduler.
+function touchIsDue(lastUsedAt: unknown): boolean {
+  return typeof lastUsedAt !== "number" || lastUsedAt <= Date.now() - TOUCH_DEBOUNCE_MS;
+}
+
 // Service-to-service: validate a user API key by its SHA-256 hash.
 // Called by the Vercel edge gateway to look up user-owned keys.
 http.route({
@@ -1142,7 +1156,7 @@ http.route({
       { keyHash: body.keyHash },
     );
 
-    if (result) {
+    if (result && touchIsDue(result.lastUsedAt)) {
       try {
         await ctx.scheduler.runAfter(0, (internal as any).apiKeys.touchKeyLastUsed, { keyId: result.id });
       } catch (err) {
@@ -1152,7 +1166,14 @@ http.route({
       }
     }
 
-    return new Response(JSON.stringify(result), {
+    // Strip the gate's input from the response: the gateway caches this blob
+    // in Redis for 60s and its shape is load-bearing (isUserKeyResult in
+    // api/_user-api-key.js) — lastUsedAt exists for the gate above only.
+    const publicResult = result
+      ? (({ lastUsedAt: _lastUsedAt, ...rest }) => rest)(result)
+      : null;
+
+    return new Response(JSON.stringify(publicResult), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
@@ -1305,7 +1326,7 @@ http.route({
         { tokenId: body.tokenId },
       );
 
-      if (result) {
+      if (result && touchIsDue(result.lastUsedAt)) {
         try {
           await ctx.scheduler.runAfter(
             0,
@@ -1322,7 +1343,11 @@ http.route({
         }
       }
 
-      return new Response(JSON.stringify(result), {
+      // Strip the gate's input: the wire contract is exactly `{ userId }`
+      // (pinned by mcpProTokens.test.ts) — lastUsedAt feeds the gate only.
+      const publicResult = result ? { userId: result.userId } : null;
+
+      return new Response(JSON.stringify(publicResult), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });

--- a/convex/mcpProTokens.ts
+++ b/convex/mcpProTokens.ts
@@ -1,5 +1,6 @@
 import { ConvexError, v } from "convex/values";
 import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
+import { TOUCH_DEBOUNCE_MS } from "./apiKeys";
 import { requireUserId, resolveUserId } from "./lib/auth";
 import { getFeaturesForPlan } from "./lib/entitlements";
 
@@ -16,8 +17,9 @@ import { getFeaturesForPlan } from "./lib/entitlements";
 /** Maximum number of active (non-revoked) Pro MCP tokens per user. */
 const MAX_TOKENS_PER_USER = 5;
 
-/** Debounce window for touchProMcpTokenLastUsed (matches apiKeys). */
-const TOUCH_DEBOUNCE_MS = 5 * 60 * 1000;
+// The touch debounce window is imported from apiKeys.ts — the comment above
+// says "matches apiKeys", and a shared constant is what makes that true by
+// construction (http.ts gates BOTH validate routes on the same window).
 
 // ---------------------------------------------------------------------------
 // Internal (service-to-service) — called from edge/HTTP actions
@@ -130,7 +132,10 @@ export const validateProMcpToken = internalQuery({
   handler: async (ctx, args) => {
     const row = await ctx.db.get(args.tokenId);
     if (!row || row.revokedAt) return null;
-    return { userId: row.userId };
+    // lastUsedAt is consumed ONLY by the validate route's touch-scheduling
+    // gate (http.ts) and stripped before the response — the wire contract
+    // stays exactly `{ userId }` (pinned by mcpProTokens.test.ts).
+    return { userId: row.userId, lastUsedAt: row.lastUsedAt };
   },
 });
 

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -1117,12 +1117,25 @@ export async function handleSubscriptionActive(
 
   if (incomingDodoCustomerId) {
     if (existingCustomer) {
-      await ctx.db.patch(existingCustomer._id, {
-        userId,
-        email,
-        normalizedEmail,
-        updatedAt: eventTimestamp,
-      });
+      // Skip the rewrite when nothing changes. Dodo delivers related events
+      // for one purchase in a burst (subscription.active + payment.succeeded
+      // + subscription.updated within milliseconds), and re-patching the same
+      // customers row with identical values was pure OCC-conflict fuel —
+      // Convex Insights recorded these as processWebhookEvent write conflicts
+      // on `customers`. Safe to skip: no consumer reads customers.updatedAt
+      // (verified repo-wide, 2026-08-13); it's a bookkeeping stamp only.
+      const customerUnchanged =
+        existingCustomer.userId === userId &&
+        existingCustomer.email === email &&
+        existingCustomer.normalizedEmail === normalizedEmail;
+      if (!customerUnchanged) {
+        await ctx.db.patch(existingCustomer._id, {
+          userId,
+          email,
+          normalizedEmail,
+          updatedAt: eventTimestamp,
+        });
+      }
     } else {
       await ctx.db.insert("customers", {
         userId,

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -34,6 +34,16 @@ const LOCALE_PRIMARY_RE = /^[a-z]{2,3}$/;
 // ISO 3166-1 alpha-2.
 const COUNTRY_RE = /^[A-Z]{2}$/;
 
+// A call that changes no material field refreshes `lastSeenAt` at most this
+// often; inside the window it is read-only. Why: every-call patching made
+// concurrent tabs / auth-refresh storms rewrite the same users doc — Convex
+// Insights recorded 1,618 OCC write conflicts on `users` on 2026-07-28 alone.
+// Read-only mutations cannot conflict. The #6335 email-freshness comparison
+// stays sound: any write still stamps `lastSeenAt` in the same patch, so the
+// timestamp remains a dated-address lower bound that lags by at most this
+// window. Matches the 5-min touch debounce convention (apiKeys.ts).
+export const LAST_SEEN_REFRESH_WINDOW_MS = 5 * 60 * 1000;
+
 function isValidTimezone(tz: string): boolean {
   // Use try/catch around `new Intl.DateTimeFormat(undefined, { timeZone })`
   // rather than `Intl.supportedValuesOf('timeZone').includes(...)`. The
@@ -122,6 +132,28 @@ export const ensureRecord = mutation({
       //   supplies a non-empty value (Clerk identity is source of truth;
       //   users do change their primary email). Empty incoming → leave
       //   existing alone (defends transient gaps during email-change flows).
+      //
+      // No-change debounce: when NONE of the above would change the row and
+      // lastSeenAt is inside LAST_SEEN_REFRESH_WINDOW_MS, return without
+      // writing. A read-only mutation cannot OCC-conflict, which is the fix
+      // for concurrent tabs / auth-refresh storms all patching the same doc
+      // (1,618 conflicts on 2026-07-28 alone). The #6335 invariant — an
+      // email rewrite always stamps lastSeenAt in the same patch — holds
+      // because the skip requires the email to be identical.
+      const emailChanged =
+        incomingEmail.length > 0 &&
+        (existing.email !== incomingEmail ||
+          existing.normalizedEmail !== incomingNormalizedEmail);
+      const materialChange =
+        existing.localeTag !== args.localeTag ||
+        existing.localePrimary !== args.localePrimary ||
+        (args.timezone !== undefined && existing.timezone !== args.timezone) ||
+        (args.country !== undefined && existing.country !== args.country) ||
+        emailChanged;
+      if (!materialChange && now - existing.lastSeenAt < LAST_SEEN_REFRESH_WINDOW_MS) {
+        return { ok: true as const, action: "unchanged" as const };
+      }
+
       const patch: Record<string, unknown> = {
         localeTag: args.localeTag,
         localePrimary: args.localePrimary,

--- a/docs/solutions/database-issues/convex-occ-write-conflicts-hot-document-write-avoidance.md
+++ b/docs/solutions/database-issues/convex-occ-write-conflicts-hot-document-write-avoidance.md
@@ -1,0 +1,134 @@
+---
+title: Convex OCC write conflicts on hot documents fixed by write-avoidance
+date: 2026-08-13
+category: database-issues
+module: convex
+problem_type: database_issue
+component: database
+symptoms:
+  - "Convex Insights shows six 'Retried due to write conflicts' warnings across five functions in the production deployment (processWebhookEvent flagged on two tables)"
+  - "apiKeys:touchKeyLastUsed hit 1,036 OCC conflicts on userApiKeys in 14 days (retry depth up to 3), concentrated on a few hot key documents"
+  - "users:ensureRecord logged 1,618 conflicts in one day as concurrent tabs and auth-refresh storms rewrote the same users doc"
+  - "payments/webhookMutations:processWebhookEvent re-patched the same customers row with identical userId/email during millisecond Dodo webhook bursts (~103 conflicts/14d)"
+root_cause: async_timing
+resolution_type: code_fix
+severity: medium
+related_components:
+  - authentication
+  - payments
+  - background_job
+tags:
+  - convex
+  - occ
+  - write-conflicts
+  - hot-document
+  - debounce
+  - write-avoidance
+  - axiom-convex-logs
+  - mutation-retries
+---
+
+# Convex OCC write conflicts on hot documents fixed by write-avoidance
+
+> Merge state: the fix is unmerged as of this writing (2026-08-13, session branch `worktree-sleepy-gliding-flask`). All file:line citations below are against that branch's working tree.
+
+## Problem
+
+Convex Insights raised six "Retried due to write conflicts" warnings across five functions — `apiKeys:touchKeyLastUsed`, `mcpProTokens:touchProMcpTokenLastUsed`, `users:ensureRecord`, `userPreferences:setPreferences`, and `payments/webhookMutations:processWebhookEvent` (flagged twice: once per contended table, `customers` and `subscriptions`). Convex uses optimistic concurrency control (OCC): a mutation that reads a document and later patches it conflicts with any concurrent mutation that wrote the same document first, and the loser is retried (up to a bounded depth) before becoming a permanent failure. Three independent write-amplification patterns were feeding the retry machinery with pointless writes:
+
+1. **Scheduled-touch herd on hot credential docs.** `convex/http.ts` scheduled `apiKeys:touchKeyLastUsed` via `ctx.scheduler.runAfter` on **every** API-key validation. The gateway's Redis cache for key validation has a 60s TTL, so each hot key produced roughly one validation per minute per region. The mutation's internal 5-minute debounce (`convex/apiKeys.ts:282`) is a read-then-write: at each 5-minute boundary, every concurrently scheduled touch read the same stale `lastUsedAt` and all patched the same document. Result: 1,036 conflicts on `userApiKeys` in 14 days, retry depth up to 3, concentrated on ~7 hot key docs (top doc: 391 conflicts). `mcpProTokens:touchProMcpTokenLastUsed` mirrored the pattern (9 conflicts).
+
+2. **Unconditional `lastSeenAt` patch.** `users:ensureRecord` patched the caller's `users` row on every call, so concurrent tabs and auth-refresh storms rewrote the same doc — 1,618 conflicts on 2026-07-28 alone, business-hours shaped (the client had only a per-tab in-flight guard).
+
+3. **Identical-value webhook re-patch.** Dodo delivers related events for one purchase in a millisecond burst (`subscription.active` + `payment.succeeded` + `subscription.updated`); `payments/webhookMutations:processWebhookEvent` re-patched the same `customers` row with identical values each time (~103 conflicts/14d). The amplification driver is structural: `subscription.updated` with an active status forwards the original checkout's metadata into `handleSubscriptionActive`, so the active-handler path — including its customers upsert — re-runs on every routine renewal/update event for the life of the subscription (session history, PR #6364 session).
+
+Two flagged functions were deliberately **not** changed: the `userPreferences:setPreferences` rate-limit counter is an exact per-user limiter whose same-user write serialization is the design (max retry depth 1, all absorbed), and the `subscriptions` patches carry webhook-ordering semantics in `updatedAt`.
+
+Zero permanent OCC failures occurred in the 14-day window — retries absorbed everything. The fix removes the fuel before retry depth 3 becomes permanent failure under growth.
+
+## Symptoms
+
+- Convex Insights: "Retried due to write conflicts" warnings on `apiKeys:touchKeyLastUsed`, `mcpProTokens:touchProMcpTokenLastUsed`, `users:ensureRecord`, `payments/webhookMutations:processWebhookEvent`, `userPreferences:setPreferences`.
+- Insights' Conflicting Document ID column showed heavy concentration on a handful of hot docs (top `userApiKeys` doc: 391 of 1,036 conflicts).
+- Axiom `convex-logs` dataset, `data.occ_info.*` fields, confirmed retry depth (up to 3) and the daily shape (1,618 `users` conflicts on 2026-07-28). Note: `wm_api_usage` could not see any of this — it covers gateway routes only.
+- No user-visible errors: zero permanent OCC failures in 14 days.
+
+## What Didn't Work
+
+**The in-mutation debounce alone.** `touchKeyLastUsed` already skipped the write when `lastUsedAt` was fresh (`convex/apiKeys.ts:282`) — and that check IS the read-then-write race. It runs inside the scheduled mutation, after `http.ts` had already enqueued one touch per validation. Inside the window the executions were harmless no-ops (only writers conflict), but at each 5-minute boundary the whole queued herd read the same stale timestamp, all decided the write was due, and all patched the same doc. A debounce inside the mutation cannot prevent the herd; it can only make retries of the losers no-ops.
+
+**Attributing the Insights warnings to the concurrent "too many system operations" query timeouts.** Initially plausible — both showed up in the same Insights view — but disproven by telemetry: the `occ_info` stream had zero events in the stall minute, the heaviest OCC day had zero query timeouts, and the failure modes live on different sides of the engine (OCC is mutation-side write contention; the timeouts hit read-only queries, which cannot OCC-conflict at all). Two co-located warnings, two unrelated mechanisms.
+
+**Read-avoidance on the users row (prior session).** The #6335 welcome-email session (PR #6364) first made the webhook activation handler skip the `users` row read entirely when a signed checkout-email stamp verified — and had to reverse it after review, because unconditional stamp precedence sends mail to a stale address whenever the users row is the fresher side. The durable outcome is the opposite constraint: the webhook handler *must* read `userRow.lastSeenAt` and compare it against the stamp's `issuedAt`, which makes `lastSeenAt` a load-bearing content clock, not just a touch stamp (session history). Any write-avoidance on `ensureRecord` has to be designed against that consumer — see Why This Works.
+
+## Solution
+
+Three write-avoidance changes, each verified red-first (test written and failing before the fix). Wire contracts are byte-identical throughout.
+
+**1. Gate the touch at the schedule site** (`convex/http.ts:1120-1122`):
+
+```ts
+function touchIsDue(lastUsedAt: unknown): boolean {
+  return typeof lastUsedAt !== "number" || lastUsedAt <= Date.now() - TOUCH_DEBOUNCE_MS;
+}
+```
+
+Before, the route scheduled unconditionally; after, both validation routes schedule only when due:
+
+```ts
+// convex/http.ts:1159-1161 (API keys; MCP tokens mirror at :1329-1335)
+if (result && touchIsDue(result.lastUsedAt)) {
+  await ctx.scheduler.runAfter(0, (internal as any).apiKeys.touchKeyLastUsed, { keyId: result.id });
+}
+```
+
+To feed the gate, `validateKeyByHash` now returns `lastUsedAt` (`convex/apiKeys.ts:241`) and `validateProMcpToken` returns `{ userId, lastUsedAt }` (`convex/mcpProTokens.ts:138`). The routes strip it before responding: the API-key route destructures it out (`convex/http.ts:1172-1174`) because the gateway caches the blob in Redis for 60s and its shape is load-bearing (`isUserKeyResult` in `api/_user-api-key.js`); the MCP route pins the body to exactly `{ userId }` (`convex/http.ts:1348`). `TOUCH_DEBOUNCE_MS` is exported once from `convex/apiKeys.ts:275` and imported by both `convex/http.ts:4` and `convex/mcpProTokens.ts:3` — single source, so the two halves of the debounce cannot drift. The in-mutation checks stay as the second line (`convex/apiKeys.ts:282`, `convex/mcpProTokens.ts:180`).
+
+**2. Make `ensureRecord` read-only when nothing changed** (`convex/users.ts:143-155`):
+
+```ts
+if (!materialChange && now - existing.lastSeenAt < LAST_SEEN_REFRESH_WINDOW_MS) {
+  return { ok: true as const, action: "unchanged" as const };
+}
+```
+
+`LAST_SEEN_REFRESH_WINDOW_MS = 5 * 60 * 1000` is exported at `convex/users.ts:45` (matching the touch-debounce convention). `materialChange` (`convex/users.ts:147-152`) covers locale fields, explicitly provided timezone/country, and email changes. The #6335 invariant — any email rewrite stamps `lastSeenAt` in the same patch — holds because the skip requires the email to be identical; every taken write path still stamps `lastSeenAt` (`convex/users.ts:160`).
+
+**3. Skip the identical customers upsert** (`convex/payments/subscriptionHelpers.ts:1127-1138`): when `userId`, `email`, and `normalizedEmail` are all unchanged, don't patch. Safe because no consumer reads `customers.updatedAt` (verified repo-wide, 2026-08-13); it is a bookkeeping stamp only.
+
+**Tests — replicating the race without OCC.** True OCC conflicts cannot be produced in `convex-test`, so the tests replicate the *write amplification* instead: validate inside the debounce window, deliberately leave the scheduler undrained, advance the fake clock past the boundary (`vi.setSystemTime`), then drain (`t.finishAllScheduledFunctions(vi.runAllTimers)`). A touch that was wrongly queued now executes with a stale read and writes `T0+6min`; a gated route queued nothing, so `lastUsedAt` must stay at `T0`. Red before the fix (both routes wrote `T0+6min`), green after.
+
+- `convex/__tests__/apiKeys.test.ts:479-556` — the three-phase gate test (`:512`, boundary drain at `:526-534`) plus the wire-contract pin: response keys exactly `["id", "name", "userId"]` (`:553`).
+- `convex/__tests__/mcpProTokens.test.ts:571-612` — mirrored gate test; body pinned to `{ userId: "user-pro" }` at `:507-526`.
+- `convex/__tests__/users.test.ts:304-393` — identical repeat inside window is read-only with `action: "unchanged"` (`:320`); repeat after window refreshes (`:341`); material change inside window writes immediately and stamps `lastSeenAt` (#6335, `:356`); first-time timezone counts as material (`:375`).
+- `convex/__tests__/webhook.test.ts:162-213` — second identical-identity delivery leaves `updatedAt` untouched (`:172`); a changed email still rewrites (`:193`).
+
+## Why This Works
+
+In Convex OCC, **only executions that write can conflict**. Every one of the three changes converts a redundant write into no execution at all (the touch is never scheduled) or a read-only return (the mutation exits before `ctx.db.patch`). A read-only mutation cannot lose an OCC race, and an unscheduled job cannot pile up at a debounce boundary — the herd never forms, instead of being absorbed by retries after it forms.
+
+The schedule-site gate specifically fixes the boundary-herd mechanism: with the gate, a fresh `lastUsedAt` means *nothing is queued*, so when the window expires there is no backlog of touches holding the same stale read — at most one validation (the first after expiry) schedules the one touch that actually writes. As a bonus, one scheduled job per validation disappears from the scheduler.
+
+**Safety against the #6335 content-clock consumer.** The welcome-email handler picks an address by comparing `userRow.lastSeenAt` against the checkout stamp's `issuedAt`, so throttling `lastSeenAt` could in principle bias that pick toward the stamp. It cannot mis-deliver here: whenever the row's email differs from the current Clerk identity email, `materialChange` forces the write-and-stamp immediately, so the row loses the freshness comparison only while its address is *identical* to Clerk's — and between two sources holding equal addresses, either pick sends to the same place. `lastSeenAt` degrades only to a lower bound lagging true activity by at most 5 minutes. The mutation-proven freshness suites from the #6335 session (`convex/__tests__/webhook.test.ts`, `checkoutLoginEmailMetadata.test.ts`, `identitySigning.test.ts`) all pass against the fix (session history). A secondary benefit: that same handler *reads* the users row inside its transaction, so reducing `ensureRecord`'s write rate also de-conflicts the webhook-read vs `ensureRecord`-write pair on active users.
+
+The correctness constraints all hold: gateway wire contracts are byte-identical (the new `lastUsedAt` field is stripped before the response on both routes, and tests pin both bodies), and the two semantics-carrying write sites (`setPreferences` rate limiting, `subscriptions.updatedAt` ordering) were left alone because their writes are load-bearing.
+
+## Prevention
+
+- **In Convex, only writing executions OCC-conflict — prefer write-avoidance over retry-absorption.** Gate at the schedule site (don't enqueue work whose input already proves it a no-op) and skip no-change patches (return before `ctx.db.patch` when the row would be identical). Removing the write removes the conflict class; retries merely hide it until depth runs out.
+- **Scope the no-change skip: it applies to unconditional-patch mutations, not CAS-guarded ones.** The convex-gotchas skill reference `convex-occ-retry-vs-app-cas-conflict-different-layers` rejects "server-side no-op if unchanged" — correctly, for CAS-guarded mutations like `setPreferences`, where the syncVersion bump *is* the contract. Write-avoidance is a real lever only where the skipped write carries no semantics (touch stamps, identical upserts, unconditional heartbeats).
+- **Before adding a skip-gate to previously-unconditional work, check what the redundancy was silently providing.** See `docs/solutions/design-patterns/deduping-redundant-work-removes-the-recovery-it-was-accidentally-providing.md` — its checklist is exactly the #6335 analysis above (a "redundant" `lastSeenAt` stamp turned out to be a load-bearing content clock; the fix survives because email changes still force the write).
+- **A debounce inside the mutation is the second line, not the fix.** The in-mutation freshness check is itself a read-then-write and races with every concurrently scheduled sibling at the window boundary. Keep it (it makes racing stragglers no-ops), but the primary gate belongs where the work is *scheduled*, sharing one exported constant so the two halves can't drift (`convex/apiKeys.ts:275` → `convex/http.ts:4`, `convex/mcpProTokens.ts:3`).
+- **An exact rate limiter's conflicts are by-design — don't "fix" them.** A per-user exact counter serializes same-user writes on purpose; its OCC retries (depth 1, fully absorbed) are the mechanism working. "Fixing" it means changing its semantics (e.g. to a sharded/approximate limiter), which is a product decision, not a bug fix. Same for timestamps that carry ordering semantics, like `subscriptions.updatedAt`.
+- **Read Convex Insights' Conflicting Document ID column first.** Hot-doc concentration (here: ~7 docs, top doc 391/1,036) tells you whether you have a systemic pattern or a few hot rows, and points straight at the amplification mechanism.
+- **Axiom `convex-logs` `data.occ_info.*` is the queryable record** for retry depth, daily shape, and per-function conflict counts. `wm_api_usage` is gateway-routes-only and sees none of it. When counting failures there, always filter `data.topic == 'function_execution'` — bare `data.status != 'success'` also matches null-status telemetry topics and inflates counts ~500×.
+- **Test the amplification, not the OCC.** `convex-test` cannot produce real OCC conflicts, but the herd is reproducible deterministically: queue work inside the debounce window, advance the fake clock past the boundary, then drain the scheduler (`t.finishAllScheduledFunctions(vi.runAllTimers)`). Assert on what the drained queue *wrote* — a wrongly queued job leaves a stale-read write behind; a gated site leaves the doc untouched.
+
+## Related Issues
+
+- `docs/solutions/design-patterns/deduping-redundant-work-removes-the-recovery-it-was-accidentally-providing.md` — the counterweight checklist applied in Why This Works.
+- `docs/solutions/integration-issues/vendor-sdk-hidden-retries-nested-retry-ladder.md` — same amplification theme (hidden layers multiplying work) in the same payments territory.
+- convex-gotchas skill reference `convex-occ-retry-vs-app-cas-conflict-different-layers` — the CAS-race class behind the same Insights metric; this doc covers the complementary write-amplification class (see the scoping bullet in Prevention).
+- #6335 / PR #6364 — the session that made `lastSeenAt` load-bearing and verified the webhook re-patch amplification mechanism.
+- #6256 — same write-amplification class fixed the same way (unconditional per-transaction work gated at the call site).
+- #5426 — Convex retry-contention adjacent (hung action holding an idempotency lock, retries 409ing).

--- a/docs/solutions/logic-errors/name-shaped-trampoline-allowlist-cannot-match-a-nameless-frame.md
+++ b/docs/solutions/logic-errors/name-shaped-trampoline-allowlist-cannot-match-a-nameless-frame.md
@@ -1,0 +1,99 @@
+---
+title: "Vite's fourth trampoline rename was no name at all — fn: '' defeats a name-shaped allowlist"
+date: 2026-08-13
+category: logic-errors
+module: Sentry error filtering
+problem_type: logic_error
+component: tooling
+severity: medium
+symptoms:
+  - "Sentry WORLDMONITOR-Y4 (`TypeError: Failed to fetch`, 28 events / 27 users, error level) kept firing despite the beforeSend suppression gate shipped 2026-08-04 (PR #6129)"
+  - "Replaying the shipped predicate against all 28 production events split 100% clean on the previous fix's deploy time: 14/14 pre-deploy suppressed by current code, 14/14 post-deploy surfaced"
+  - "Every surfaced event was blocked by exactly one panel-storage chunk frame with fn: null (normalized to ''), which no name-shaped regex can match"
+  - "isTrampolineFrameFunction('') returned false, so one nameless frame defeated the .every() allowlist and the whole event surfaced"
+root_cause: logic_error
+resolution_type: code_fix
+related_components: [testing_framework, development_workflow]
+tags: [sentry, before-send, stack-gating, vite-minification, debugbear, fetch-wrapper, anonymous-frame, regression-testing]
+---
+
+# Vite's fourth trampoline rename was no name at all — fn: '' defeats a name-shaped allowlist
+
+> Merge state: the fix is unmerged as of this writing (2026-08-13, session branch `worktree-sleepy-gliding-flask`). File:line citations are against that branch's working tree.
+
+## Problem
+
+Sentry issue WORLDMONITOR-Y4 ("TypeError: Failed to fetch", 28 events / 27 users, error level) kept firing even though a suppression gate for exactly this class had shipped on 2026-08-04 in PR #6129. The gate in `src/bootstrap/sentry-init.ts` suppresses a bare `Failed to fetch` only when a DebugBear RUM collector frame is present AND every non-infra frame is either that collector or a trampoline-shaped frame confined to the two fetch-free Vite chunks (`panel-storage` / `widget-store`) — see the gate at `src/bootstrap/sentry-init.ts:616-623`.
+
+The hole: the trampoline test was purely name-shaped. A later Vite build emitted one `panel-storage-*.js` hop with **no function name at all** — Sentry records `function: null`, which the gate coalesces to `''` via `f.function ?? ''` (`src/bootstrap/sentry-init.ts:621`). The empty string matched neither the fetch-anchored pattern nor the bare-minified-name pattern, so a single nameless frame defeated the `.every()` and the entire class re-surfaced as new events under the same issue.
+
+This is the **fourth build-rename** of one wrapper class. Each prior fix was correct for the shape it saw; each was defeated by the next minifier output:
+
+1. **VC** (PR #5143, the original gate): trampoline named `window.fetch` — anchored match.
+2. **VQ** (PR #5293): same trampoline emitted as `Rt.window.fetch` — fix added an optional bounded (≤3-char) minified receiver prefix (`src/bootstrap/sentry-init.ts:589-594`). That PR's body already recorded the half-lesson: "a filter keyed on a minified frame's function name is build-fragile … the chunk-filename gate is the durable half of that predicate."
+3. **Y4** (PR #6129): one hop emitted as a bare ≤2-char minified name (`t`) with no `fetch` in it at all — fix admitted bare names at ≤2 chars, only inside the two chunks (`src/bootstrap/sentry-init.ts:595-604`), and introduced the fetch-free-chunk guard test.
+4. **Y4 recurrence** (this session): the hop emitted **anonymously** — no name-shaped pattern can ever match `''`.
+
+## Symptoms
+
+- The issue's event stream continued past the prior fix's deploy, with fresh events daily (e.g. 2026-08-13T05:18:41Z), despite the filter "already existing."
+- Every post-deploy event's stack was fully consistent with the suppressed class — DebugBear collector frames plus panel-storage/widget-store trampoline hops — except for exactly one `function: null` frame in a `panel-storage-*.js` chunk.
+- 8 distinct `panel-storage` chunk hashes appeared across the 14 post-deploy events: multiple production builds, all emitting the anonymous hop.
+
+## What Didn't Work
+
+**The name-shape lineage (VC → VQ → Y4).** Three consecutive fixes each widened a regex to admit the newest minifier spelling of the same trampoline: `window.fetch`, then `Rt.window.fetch` (bounded receiver), then bare `t` (≤2-char bound). All three were locally correct and individually well-bounded — and all three shared the same structural flaw: they anchored a suppression allowlist on the *shape of a name the minifier happens to emit*. The minifier owes no stability there, and the fourth rename produced the one shape (`''` — no name at all) that no name pattern, however widened, can match. The lineage was a treadmill: each fix guaranteed only that the *previous* build's spelling was covered. Nor is this DebugBear-specific: the sibling extension-wrapper gate was defeated the same way by Sentry's aliased-property annotation on `window.fetch` frames (PR #6028).
+
+**Widening past the observed shape (prior session).** The 2026-08-03 session that shipped PR #6129 first tried a broader widening — and two existing `tests/sentry-beforesend.test.mjs` cases went red. Its recorded verdict: the failures were "deliberate safety bounds — my widening was too broad and would have created a real blind spot," and the gate was narrowed to exactly the observed shape (session history). That is the operating rule for this gate: the beforeSend suite is adversarial to widening by design; when it goes red on a widening, the widening is wrong, not the tests.
+
+**Checking frames via the Sentry issue-events LIST endpoint (this session's near-miss).** The first "is every post-deploy event really all-DebugBear?" verification queried the issue's events list endpoint — which **omits `entries`/stacktraces entirely**. A frame predicate evaluated against those payloads is vacuous: it sees zero frames and can "confirm" anything. The real check required fetching **each event individually** via `/projects/{org}/{proj}/events/{id}/`, which is the only representation that carries the stacktrace. (The same trimming hides `extra` fields like `interactionTarget` — a trap independently hit during the 2026-08-05 INP field pull.)
+
+## Solution
+
+One line in the predicate at `src/bootstrap/sentry-init.ts:614-615` — admit the empty name on the same bound as the bare minified name:
+
+```ts
+// before
+const isTrampolineFrameFunction = (fn: string) =>
+  /^(?:\w{1,3}\.)?(?:window\.)?fetch$/.test(fn) || /^\w{1,2}$/.test(fn);
+
+// after
+const isTrampolineFrameFunction = (fn: string) =>
+  /^(?:\w{1,3}\.)?(?:window\.)?fetch$/.test(fn) || /^\w{1,2}$/.test(fn) || fn === '';
+```
+
+The diagnosis that justified it is the durable technique: **replay the shipped predicate against every production event, split by the prior fix's deploy time.** A Python script re-implemented the exact shipped gate and ran it over all 28 Y4 events (each fetched individually — see the near-miss above). Split at the 2026-08-04T05:06Z merge of PR #6129: 14/14 pre-deploy events suppressed by current code; 14/14 post-deploy events blocked, each by exactly one `fn: ''` panel-storage frame. A 100% clean split on deploy time is the signature of a *recurrence with a new shape* (the old fix works on everything it saw), versus a mixed split, which would mean the original fix was incomplete. After adding `|| fn === ''`, the replay suppressed 28/28.
+
+Regression coverage (red before the fix, green after; suite 256/256) in the "Y4 anonymous trampoline hop" describe at `tests/sentry-beforesend.test.mjs:1486-1521`:
+
+- the **exact production stack** — fixture frames verbatim from event 2026-08-13T05:18:41Z (`tests/sentry-beforesend.test.mjs:1488-1497`) — is suppressed;
+- an anonymous frame in a **non-allowlisted** chunk (`runtime-*.js`) still surfaces (`:1504-1513`);
+- an anonymous trampoline frame **without a collector frame** still surfaces (`:1515-1520`).
+
+Sentry issue handling: plain resolve — never `inNextRelease` on this project.
+
+## Why This Works
+
+Admitting `''` looks like the widest possible tolerance, but the safety of this gate was never carried by the name regex. It is carried by an **enforced invariant**: neither `src/utils/panel-storage.ts` nor `src/services/widget-store.ts` issues any network call, so a frame attributed to those chunks *cannot* be the real fetch caller — whether or not the minifier kept a name for it. That invariant is not asserted in a comment; it is enforced by `tests/debugbear-trampoline-chunks.test.mjs:30-54`, which fails the suite if either module ever gains `fetch`/`XMLHttpRequest`/`EventSource`/`WebSocket`/`sendBeacon` (comment-stripped source scan, `:39-41`), and by a wiring guard (`:56-68`) that fails if the gate stops keying on those chunk names — so the guard cannot silently outlive the thing it protects.
+
+The anchors themselves are deliberately WM-controlled: the gate keys on this repo's own Vite code-split chunk names — Rollup derives `panel-storage`/`widget-store` from the first-party module filenames behind their dynamic imports, not from `manualChunks` entries — so nothing DebugBear's deploys can rename is part of the identity (session history — both prior fixing sessions verified the chunk-name wiring in `vite.config.ts` as the pre-flight before touching the gate).
+
+The other two load-bearing halves are untouched: the empty name is admitted **only** inside the two allowlisted chunks (any other first-party module can emit anonymous frames, and most of them do fetch), and a DebugBear collector frame is still **required** (it is the only reason these trampolines appear in a stack at all). `fetchContent` and `apiClient.fetch` — real callers that earlier fixes were careful not to swallow — still surface, and their tests still assert it.
+
+## Prevention
+
+- **Treat minifier output shape as adversarial and unstable.** Never anchor a security- or suppression-relevant allowlist on name shape alone — a build tool will eventually emit the one shape your regex family cannot express (here: no name at all). Four renames of one wrapper class, plus the sibling extension-gate defeat (PR #6028), are the empirical proof.
+- **Bound tolerances by an enforced invariant, not by regex tightness.** The honest bound here is "these chunks are fetch-free," proven continuously by a guard test that fails when the invariant breaks — not "the name looks trampoline-ish." When you widen a tolerance, ask what *enforced* fact makes the widening safe; if the answer is only "the regex is still narrow," the widening is not safe.
+- **When a filter "already exists" but the issue still fires, replay the shipped predicate against ALL events and split by the fix's deploy time.** Re-implement the exact shipped logic as a script, run it over every production event, and partition at the deploy timestamp. 100% clean split = recurrence with a new shape (name the exact blocking frame); mixed results = the original fix was incomplete. Either way you get the hole named with evidence, not a guess.
+- **The Sentry issue-events LIST endpoint omits `entries`/stacktraces (and trims `extra`).** Any frame-level check against list payloads is vacuous. Fetch each event individually via `/projects/{org}/{proj}/events/{id}/` before asserting anything about frames.
+- **Decide explicitly what `f.function ?? ''` means.** Sentry records anonymous frames as `function: null`; gate code that coalesces to `''` must make the empty name an explicit branch of the predicate, or the decision is made by omission (here it failed closed for suppression — the event surfaced — but by accident, not by design).
+- **Respect the adversarial suite.** `tests/sentry-beforesend.test.mjs` is deliberately hostile to over-widening — a red preservation test on a widening means the widening is wrong. Pair every new suppression fixture with the counter-fixtures that must keep surfacing.
+- **Resolve with plain resolve** — never `inNextRelease` on this project (it pins to a release that browser events can never order past, permanently muting the issue).
+
+## Related Issues
+
+- `docs/solutions/best-practices/sentry-noise-filtering-with-stack-gating-and-signature-matching.md` — the general stack-gating discipline (WR/TZ era). This doc is the build-fragility sequel: that one answers "how to classify third-party noise correctly," this one answers "how to keep a classification alive across builds." Its name-regex-centric guidance is nuanced by the lineage here.
+- `docs/solutions/logic-errors/one-route-401-declared-the-whole-anon-session-dead.md` — sibling use of the population-replay diagnostic style against Sentry events (WORLDMONITOR-WG).
+- PR #5143 (VC, original gate) → PR #5293 (VQ, receiver prefix) → PR #6129 (Y4, bare-name bound + the fetch-free-chunk guard test) — the lineage, all merged.
+- PR #6028 — the same name-shape failure class on the sibling extension-wrapper gate (aliased-property annotation).
+- Issue #5388 — why the DebugBear RUM collector runs in production (100% sample at the time); the `window.fetch` wrapping itself is documented in PR #5143's body.

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -602,8 +602,17 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // issues a fetch of its own, so a bare minified frame in them cannot be
       // the real caller; tests/debugbear-trampoline-chunks.test.mjs fails if
       // either module ever gains one, rather than letting the gate rot silently.
+      // WORLDMONITOR-Y4 recurrence is the FOURTH build-rename: a later Vite build
+      // emitted one panel-storage hop with no function name at all, and `''`
+      // matched neither pattern above, so a single nameless frame defeated the
+      // `.every()` and the whole class re-surfaced. Measured 2026-08-13: all 14
+      // events before the bare-name deploy are suppressed by it, all 14 after it
+      // surfaced, every one blocked by exactly that `fn: null` panel-storage frame.
+      // An empty name is admitted on the same bound as the bare name — only inside
+      // the two chunks whose modules issue no fetch of their own — so it cannot
+      // hide a real caller; `fetchContent` and `apiClient.fetch` still surface.
       const isTrampolineFrameFunction = (fn: string) =>
-        /^(?:\w{1,3}\.)?(?:window\.)?fetch$/.test(fn) || /^\w{1,2}$/.test(fn);
+        /^(?:\w{1,3}\.)?(?:window\.)?fetch$/.test(fn) || /^\w{1,2}$/.test(fn) || fn === '';
       if (/^(?:TypeError: )?Failed to fetch$/.test(msg)
           && frames.some(f => isDebugBearRumScriptFrame(f.filename ?? ''))
           && nonInfraFrames.every(f =>

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -1467,6 +1467,59 @@ describe('sentry beforeSend — Y4 bare minified trampoline hop', () => {
   });
 });
 
+// ─── WORLDMONITOR-Y4 recurrence: ANONYMOUS trampoline hop ─────────────────────
+//
+// Fourth build-rename of the same VC/VQ/Y4 wrapper. The 2026-08-04 fix admitted
+// a bare minified hop (`t`), and every Y4 event before that deploy is suppressed
+// by it. Every event AFTER it still surfaced (14/14, 2026-08-12..13), each one
+// blocked by a single `panel-storage-*.js` frame Sentry recorded with NO
+// function name at all: a later Vite build emitted that hop anonymously.
+// `isTrampolineFrameFunction('')` was false, so one nameless frame defeated the
+// `.every()` and the whole class re-surfaced.
+//
+// Admitting '' is bounded by exactly the argument that already licenses the
+// bare-name tolerance: neither module backing these two chunks issues a fetch of
+// its own (tests/debugbear-trampoline-chunks.test.mjs fails if either ever
+// gains one), so a frame in them cannot be the real caller whether or not the
+// minifier kept a name for it. The chunk allowlist and the required collector
+// frame remain the load-bearing halves — the safety tests below pin both.
+describe('sentry beforeSend — Y4 anonymous trampoline hop', () => {
+  // Verbatim from event 2026-08-13T05:18:41Z (28/28 Y4 events carry a DebugBear frame).
+  const y4AnonStack = [
+    { filename: '/lpMwA9KpC6pf.js', lineno: 8, function: null },
+    { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: null },
+    { filename: '/lpMwA9KpC6pf.js', lineno: 8, function: null },
+    { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: null },
+    { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: 't' },
+    { filename: '/assets/widget-store-CdO-mBNc.js', lineno: 2, function: 'Cn.window.fetch' },
+    { filename: '/assets/panel-storage-D-2Xh2lU.js', lineno: 2, function: null },
+    { filename: '/assets/panel-storage-D-2Xh2lU.js', lineno: 2, function: 'c' },
+  ];
+
+  it('suppresses the exact Y4 recurrence stack (anonymous hop)', () => {
+    assert.equal(beforeSend(makeEvent('Failed to fetch', 'TypeError', y4AnonStack)), null,
+      'an anonymous hop is the same DebugBear wrapper class as VC/VQ/Y4');
+  });
+
+  it('does NOT suppress an anonymous frame in a NON-allowlisted chunk', () => {
+    // The chunk allowlist is what stops '' from becoming a blanket bypass: any
+    // first-party module CAN emit an anonymous frame, and most of them do fetch.
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/lpMwA9KpC6pf.js', lineno: 1, function: 't' },
+      { filename: '/assets/runtime-BQi6MP9w.js', lineno: 2, function: null },
+    ]);
+    assert.ok(beforeSend(event) !== null,
+      'an anonymous frame outside the two fetch-free chunks is a real caller');
+  });
+
+  it('does NOT suppress an anonymous trampoline frame without a DebugBear frame', () => {
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/assets/panel-storage-D-2Xh2lU.js', lineno: 2, function: null },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'no collector frame means no trampoline explanation');
+  });
+});
+
 // ─── WORLDMONITOR-WK: zero-frame RangeError confined to iOS ───────────────────
 //
 // 23 events / 20 users, 100% iOS, 21 inside the Google app's in-app WebView.


### PR DESCRIPTION
## Summary

Two production findings from today's Sentry triage, both fixed test-first. Convex Insights was showing six "Retried due to write conflicts" warnings across five functions — telemetry (Axiom `convex-logs` `occ_info`) put the real cost at 1,036 OCC conflicts/14d on `userApiKeys` at retry depth up to 3, plus a 1,618-conflict single-day storm on `users`. Separately, Sentry WORLDMONITOR-Y4 kept firing at error level despite the suppression gate shipped for it on 2026-08-04: replaying the shipped predicate against all 28 production events split 100% clean on that deploy time (14/14 before suppressed, 14/14 after surfaced), each survivor blocked by exactly one anonymous (`function: null`) panel-storage frame that no name-shaped regex can match.

## Convex: write-avoidance instead of retry-absorption

In Convex OCC, only executions that *write* can conflict. Every conflict here traced to a redundant write, so each fix converts one into no execution at all or a read-only return:

| Site | Before | After |
|---|---|---|
| `http.ts` validate routes | scheduled a `lastUsedAt` touch on **every** validation; the in-mutation 5-min debounce is a read-then-write, so the queued herd stampeded the same doc at each window boundary | `touchIsDue()` gates both schedule sites — a fresh stamp enqueues nothing, so no herd can form |
| `users:ensureRecord` | patched `lastSeenAt` unconditionally — concurrent tabs/auth storms rewrote one doc | returns `action:"unchanged"` without writing when nothing material changed inside a 5-min window |
| webhook `customers` upsert | Dodo delivers event bursts per purchase and re-runs the active handler for a subscription's whole life, re-patching identical values | skips the patch when `userId`/`email`/`normalizedEmail` are unchanged |

Decisions a reviewer should check:

- **Wire contracts are byte-identical.** `validateKeyByHash`/`validateProMcpToken` now return `lastUsedAt` to feed the gate, and both routes strip it before responding — the MCP body is pinned to exactly `{userId}` and the API-key response keys to `["id","name","userId"]` by tests, because the gateway caches that blob in Redis and its shape is load-bearing.
- **The ensureRecord skip is safe against the #6335 email-freshness comparison** (`lastSeenAt` dates the row's address): any email change still forces the write-and-stamp in the same patch, so the row can only lose the freshness comparison while its address is identical to Clerk's — and then either pick mails the same address. The #6335 mutation-proven suites pass unchanged.
- **Two flagged sites are deliberately untouched:** the `setPreferences` rate-limit counter (an exact per-user limiter — serialized writes are its design; max retry depth 1, all absorbed) and `subscriptions.updatedAt` (carries webhook-ordering semantics).

Since `convex-test` cannot produce real OCC conflicts, the new tests replicate the amplification deterministically: validate inside the debounce window, leave the scheduler undrained, advance the fake clock past the boundary, then drain — a wrongly queued touch writes with a stale read; a gated route leaves the doc untouched. Red before the fix on both routes, green after.

## Sentry: the fourth build-rename of the Y4 trampoline

The DebugBear fetch-wrapper gate has now been defeated by Vite/minifier renames four times: `window.fetch` (VC) → `Rt.window.fetch` (VQ) → bare `t` (Y4) → no name at all (this PR). The fix admits `fn === ''` — safe because the gate's safety was never the name regex: it is the enforced invariant that the two allowlisted chunks' modules issue no network call (`tests/debugbear-trampoline-chunks.test.mjs` fails the suite if that ever changes), plus the still-required collector frame. Regression tests pin the exact production stack and both safety bounds (anonymous frame in a non-allowlisted chunk, and without a collector frame, both still surface).

## Validation

- Convex suite: 75 files / 1,498 tests green (includes the 4 new red-first tests); `tests/sentry-beforesend.test.mjs` 256/256; DebugBear guard 3/3; mdx-lint 731/731 over the new docs pages.
- `tsc` (main), `typecheck:api` + convex string-call audit, and the convex tsconfig all clean; `docs:check` green.
- Post-fix replay of the shipped Sentry predicate suppresses 28/28 Y4 production events; WORLDMONITOR-Y4 resolved in Sentry (plain resolve).
- Both solution docs went through grounding validation against the tree (70 claims checked across the two runs; every file:line citation verified).

Also ships two grounded solution docs (`docs/solutions/database-issues/…write-avoidance.md`, `docs/solutions/logic-errors/…nameless-frame.md`) and three CONCEPTS.md entries (Content Clock, Touch Mutation, Trampoline Frame).

Related: #6335, #6545

## New concepts

**OCC write-avoidance (schedule-site gating)**

In an optimistic-concurrency store, a transaction only retries when it *wrote* and its read set was invalidated — read-only executions can never lose a race. That inverts the usual instinct for hot-document contention: instead of absorbing conflicts with retries (they merely hide the cost until retry depth runs out), remove the write. Two shapes ship here:

```ts
// Gate at the schedule site: a fresh stamp means nothing is ever enqueued,
// so no backlog of touches can share one stale read at the window boundary.
if (result && touchIsDue(result.lastUsedAt)) {
  await ctx.scheduler.runAfter(0, internal.apiKeys.touchKeyLastUsed, { keyId: result.id });
}
```

and the no-change skip (`ensureRecord`, the webhook customers upsert): return before `ctx.db.patch` when the row would be identical. The in-mutation debounce stays as the second line — it makes any straggler that races anyway a no-op on retry — but it cannot be the primary defense, because it is itself a read-then-write that every concurrently queued sibling passes at the boundary.

When *not* to use it: writes that carry semantics. An exact rate-limit counter's serialized writes are its contract, and a timestamp consumers compare for ordering/freshness may only be skipped when every change to the content it dates still stamps it in the same write.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_01AmZoei2dAPDptqMqX9Vrpx
