### PR TITLE
fix(feeds): carry the RSS <source> publisher into corroboration counts

### DIFF
--- a/scripts/shared/publisher-families.js
+++ b/scripts/shared/publisher-families.js
@@ -15,13 +15,21 @@
  *   - singleton family ids are namespaced (`label:<name>`) so they can never
  *     collide with a curated family id.
  *
- * KNOWN LIMIT — cross-publisher syndication. This map collapses one
- * publisher's own labels. It cannot see that an unrelated outlet reprinted a
- * Reuters wire, because the feed label the item arrives under says nothing
- * about the wire it came from: the ingest parser stamps `item.source =
- * feed.name` (server/worldmonitor/news/v1/list-feed-digest.ts) and drops the
- * RSS `<source>` element that names the originating publisher. Recovering
- * that is tracked in #6430; it is a parser change, not a map change.
+ * Cross-publisher syndication (#6430): the server ingest parser now carries
+ * the RSS `<source>` element — the originating publisher Google News stamps
+ * per item — as `originPublisher`, and the digest's corroboration counts
+ * resolve THAT through this map when present, falling back to the feed
+ * label. To let an origin NAME ("Reuters", "Associated Press") land in the
+ * same family as the feed labels it syndicates through, each curated
+ * family's `publisher` name is indexed alongside its labels. An unknown
+ * origin name stays its own singleton family — same fail-closed direction
+ * as an unmapped label.
+ *
+ * REMAINING LIMIT — origin names outside the curated set. "BBC News" from a
+ * Google News <source> does not fold into the 'bbc' family unless curated
+ * (no fuzzy matching, by design), and direct non-Google-News feeds mostly
+ * carry no <source> element at all — for those the feed label remains the
+ * best available publisher signal.
  */
 /**
  * Curated label -> publisher family. Only families with 2+ labels appear; an
@@ -197,6 +205,15 @@ for (const [familyId, entry] of Object.entries(PUBLISHER_FAMILY_DATA)) {
     familyByLabel.set(label, familyId);
     familyByLowerLabel.set(label.toLowerCase(), familyId);
   }
+}
+// The publisher NAME resolves to its family too, so an origin publisher
+// recovered from the RSS <source> element ("Reuters", "Associated Press")
+// joins the family of the labels it syndicates through (#6430). Set-if-absent:
+// a curated LABEL always wins over a same-spelling publisher name, so label
+// resolution is unchanged by construction.
+for (const [familyId, entry] of Object.entries(PUBLISHER_FAMILY_DATA)) {
+  const lowerName = entry.publisher.toLowerCase();
+  if (!familyByLowerLabel.has(lowerName)) familyByLowerLabel.set(lowerName, familyId);
 }
 
 /**

--- a/server/worldmonitor/news/v1/dedup.mjs
+++ b/server/worldmonitor/news/v1/dedup.mjs
@@ -62,7 +62,7 @@ export function deduplicateHeadlines(headlines) {
  * hashing all such items accumulated one phantom story:track row with
  * pooled corroboration.
  *
- * @template {{ title: string; source: string; publishedAt?: number }} T
+ * @template {{ title: string; source: string; originPublisher?: string; publishedAt?: number }} T
  * @param {T[]} items
  * @param {(title: string) => string} normalizeTitle title normalizer
  *   (strips source suffixes etc. — stays caller-owned so hash identity is
@@ -92,9 +92,13 @@ export async function assignStoryIdentity(items, normalizeTitle, sha256Hex) {
       }
     }
 
+    // #6430: the originating publisher (RSS <source>, carried as
+    // originPublisher) outranks the feed label — one wire under several
+    // feeds' labels is one publisher. Absent (direct feeds, Atom), the
+    // feed label remains the best available signal.
     const corroborationCount = Math.max(
       1,
-      countPublisherFamilies(indices.map((i) => items[i].source)),
+      countPublisherFamilies(indices.map((i) => items[i].originPublisher || items[i].source)),
     );
 
     if (canonical === null) {

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -175,6 +175,14 @@ const DIPLOMACY_SEVERITY_PROMOTION_MIN_TIER12_SOURCES = 3;
 
 interface ParsedItem {
   source: string;
+  // Originating publisher from the RSS <source> element ('' when absent).
+  // Google News feeds — which back 154 of the 366 server digest labels —
+  // stamp it per item, naming the outlet that actually wrote the story.
+  // Corroboration counting prefers this over `source`: a Reuters wire
+  // arriving through the "Oil & Gas" keyword feed and through "Reuters
+  // Energy" is ONE publisher, not two (#6430). Internal to the digest
+  // build; `source` stays what the UI credits, links, and tiers.
+  originPublisher: string;
   title: string;
   link: string;
   publishedAt: number;
@@ -606,8 +614,17 @@ function parseRssXml(xml: string, feed: ServerFeed, variant: string): ParseResul
     const isAlert = threat.level === 'critical' || threat.level === 'high';
     const description = extractDescription(block, isAtom, title);
 
+    // RSS 2.0 <source url="...">Name</source> — the originating publisher,
+    // emitted per item by Google News. Atom's <source> is a metadata
+    // CONTAINER (nested elements, no text of its own), so only the RSS
+    // dialect is read; extractTag's [^<]* body would not match a container
+    // anyway, but skipping Atom keeps that an invariant rather than a
+    // regex accident.
+    const originPublisher = isAtom ? '' : extractTag(block, 'source');
+
     items.push({
       source: feed.name,
+      originPublisher,
       title,
       link,
       publishedAt,
@@ -980,7 +997,10 @@ function computeEntityCorroborationSignals(
       // signal that feeds importanceScore and the diplomacy severity
       // promotion. The tier is a property of the LABEL, so a family joins
       // tier12Sources when any of its labels is tier 1-2.
-      const family = publisherFamilyFor(item.source);
+      // #6430: the originating publisher (RSS <source>) outranks the feed
+      // label — a wire syndicated through a keyword feed corroborates as
+      // the wire, not as the query it arrived through.
+      const family = publisherFamilyFor(item.originPublisher || item.source);
       if (family) {
         bucket.sources.add(family);
         if (getSourceTier(item.source) <= 2) bucket.tier12Sources.add(family);

--- a/shared/publisher-families.js
+++ b/shared/publisher-families.js
@@ -15,13 +15,21 @@
  *   - singleton family ids are namespaced (`label:<name>`) so they can never
  *     collide with a curated family id.
  *
- * KNOWN LIMIT — cross-publisher syndication. This map collapses one
- * publisher's own labels. It cannot see that an unrelated outlet reprinted a
- * Reuters wire, because the feed label the item arrives under says nothing
- * about the wire it came from: the ingest parser stamps `item.source =
- * feed.name` (server/worldmonitor/news/v1/list-feed-digest.ts) and drops the
- * RSS `<source>` element that names the originating publisher. Recovering
- * that is tracked in #6430; it is a parser change, not a map change.
+ * Cross-publisher syndication (#6430): the server ingest parser now carries
+ * the RSS `<source>` element — the originating publisher Google News stamps
+ * per item — as `originPublisher`, and the digest's corroboration counts
+ * resolve THAT through this map when present, falling back to the feed
+ * label. To let an origin NAME ("Reuters", "Associated Press") land in the
+ * same family as the feed labels it syndicates through, each curated
+ * family's `publisher` name is indexed alongside its labels. An unknown
+ * origin name stays its own singleton family — same fail-closed direction
+ * as an unmapped label.
+ *
+ * REMAINING LIMIT — origin names outside the curated set. "BBC News" from a
+ * Google News <source> does not fold into the 'bbc' family unless curated
+ * (no fuzzy matching, by design), and direct non-Google-News feeds mostly
+ * carry no <source> element at all — for those the feed label remains the
+ * best available publisher signal.
  */
 /**
  * Curated label -> publisher family. Only families with 2+ labels appear; an
@@ -197,6 +205,15 @@ for (const [familyId, entry] of Object.entries(PUBLISHER_FAMILY_DATA)) {
     familyByLabel.set(label, familyId);
     familyByLowerLabel.set(label.toLowerCase(), familyId);
   }
+}
+// The publisher NAME resolves to its family too, so an origin publisher
+// recovered from the RSS <source> element ("Reuters", "Associated Press")
+// joins the family of the labels it syndicates through (#6430). Set-if-absent:
+// a curated LABEL always wins over a same-spelling publisher name, so label
+// resolution is unchanged by construction.
+for (const [familyId, entry] of Object.entries(PUBLISHER_FAMILY_DATA)) {
+  const lowerName = entry.publisher.toLowerCase();
+  if (!familyByLowerLabel.has(lowerName)) familyByLowerLabel.set(lowerName, familyId);
 }
 
 /**

--- a/tests/rss-origin-publisher.test.mts
+++ b/tests/rss-origin-publisher.test.mts
@@ -1,0 +1,161 @@
+/**
+ * #6430 — the RSS <source> element names the originating publisher, and the
+ * digest's corroboration counts must prefer it over the feed label.
+ *
+ * Google News feeds back 154 of the 366 server digest labels and stamp
+ * <source url="...">Name</source> per item. Before this, parseRssXml dropped
+ * the element and stamped `item.source = feed.name`, so a Reuters wire
+ * arriving through the "Oil & Gas" keyword feed and through "Reuters Energy"
+ * counted as two publishers — cross-publisher syndication was the documented
+ * known limit of #6428's family counting.
+ *
+ * `item.source` itself is deliberately untouched: it is what the UI credits,
+ * links, and tiers. Only the corroboration counts read originPublisher.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { publisherFamilyFor } from '../shared/publisher-families.js';
+import { assignStoryIdentity } from '../server/worldmonitor/news/v1/dedup.mjs';
+import { __testing__ } from '../server/worldmonitor/news/v1/list-feed-digest.ts';
+
+const { parseRssXml, computeEntityCorroborationSignals } = __testing__;
+
+const FEED = { url: 'https://news.google.com/rss/search?q=oil', name: 'Oil & Gas', lang: 'en' };
+
+function rss(itemsXml: string): string {
+  return `<?xml version="1.0"?><rss version="2.0"><channel>${itemsXml}</channel></rss>`;
+}
+
+describe('parseRssXml carries the RSS <source> element (#6430)', () => {
+  it('extracts the originating publisher, entity-decoded, leaving item.source as the feed label', () => {
+    const xml = rss(`<item>
+      <title>Oil prices climb as supply concerns mount</title>
+      <link>https://example.com/a</link>
+      <pubDate>Tue, 07 Jul 2026 12:00:00 GMT</pubDate>
+      <source url="https://www.spglobal.com">S&amp;P Global</source>
+    </item>`);
+    const parsed = parseRssXml(xml, FEED, 'full');
+    assert.ok(parsed && parsed.items.length === 1);
+    assert.equal(parsed.items[0]!.originPublisher, 'S&P Global');
+    assert.equal(parsed.items[0]!.source, 'Oil & Gas');
+  });
+
+  it('stamps an empty originPublisher when the element is absent', () => {
+    const xml = rss(`<item>
+      <title>Oil prices climb as supply concerns mount</title>
+      <link>https://example.com/a</link>
+      <pubDate>Tue, 07 Jul 2026 12:00:00 GMT</pubDate>
+    </item>`);
+    const parsed = parseRssXml(xml, FEED, 'full');
+    assert.ok(parsed && parsed.items.length === 1);
+    assert.equal(parsed.items[0]!.originPublisher, '');
+  });
+
+  it('never reads Atom <source>, which is a metadata container, not a name', () => {
+    const xml = `<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"><entry>
+      <title>Oil prices climb as supply concerns mount</title>
+      <link href="https://example.com/a"/>
+      <published>2026-07-07T12:00:00Z</published>
+      <source><title>Republished Origin Feed</title><id>urn:x</id></source>
+    </entry></feed>`;
+    const parsed = parseRssXml(xml, FEED, 'full');
+    assert.ok(parsed && parsed.items.length === 1);
+    assert.equal(parsed.items[0]!.originPublisher, '');
+  });
+});
+
+describe('publisherFamilyFor resolves curated publisher names (#6430)', () => {
+  it('folds an origin NAME into the family of the labels it syndicates through', () => {
+    assert.equal(publisherFamilyFor('Reuters'), publisherFamilyFor('Reuters Energy'));
+    assert.equal(publisherFamilyFor('Associated Press'), publisherFamilyFor('AP News'));
+    assert.equal(publisherFamilyFor('associated press'), publisherFamilyFor('AP News'));
+  });
+
+  it('keeps unknown origin names as their own singleton family (fail closed)', () => {
+    assert.equal(publisherFamilyFor('Some Independent Blog'), 'label:some independent blog');
+  });
+
+  it('leaves feed-label resolution unchanged', () => {
+    assert.equal(publisherFamilyFor('Reuters World'), 'reuters');
+    assert.equal(publisherFamilyFor('BBC Persian'), publisherFamilyFor('BBC World'));
+    assert.equal(publisherFamilyFor('Brand New Feed'), 'label:brand new feed');
+  });
+});
+
+describe('story-identity corroboration prefers originPublisher (#6430)', () => {
+  const TITLE_A = 'Missile attack kills troops in border strike officials say';
+  const TITLE_B = 'Missile attack kills troops in border strike officials add';
+
+  it('one wire under a keyword feed and its own feed counts as ONE publisher', async () => {
+    const items = [
+      { title: TITLE_A, source: 'Oil & Gas', originPublisher: 'Reuters', publishedAt: 1 },
+      { title: TITLE_B, source: 'Reuters Energy', originPublisher: '', publishedAt: 2 },
+    ];
+    const assignment = await assignStoryIdentity(items, (t: string) => t.toLowerCase(), async (t: string) => t);
+    assert.equal(assignment.get(items[0]!)!.corroborationCount, 1);
+  });
+
+  it('the same pair WITHOUT origin attribution still counts two — the pre-#6430 inflation', async () => {
+    const items = [
+      { title: TITLE_A, source: 'Oil & Gas', originPublisher: '', publishedAt: 1 },
+      { title: TITLE_B, source: 'Reuters Energy', originPublisher: '', publishedAt: 2 },
+    ];
+    const assignment = await assignStoryIdentity(items, (t: string) => t.toLowerCase(), async (t: string) => t);
+    assert.equal(assignment.get(items[0]!)!.corroborationCount, 2);
+  });
+
+  it('genuinely independent origins through one keyword feed count in full', async () => {
+    const items = [
+      { title: TITLE_A, source: 'Oil & Gas', originPublisher: 'Reuters', publishedAt: 1 },
+      { title: TITLE_B, source: 'Oil & Gas', originPublisher: 'Al Jazeera', publishedAt: 2 },
+    ];
+    const assignment = await assignStoryIdentity(items, (t: string) => t.toLowerCase(), async (t: string) => t);
+    assert.equal(assignment.get(items[0]!)!.corroborationCount, 2);
+  });
+});
+
+describe('entity corroboration prefers originPublisher (#6430)', () => {
+  const now = 1_745_000_000_000;
+  const base = {
+    link: '',
+    isAlert: false,
+    level: 'info',
+    category: 'world',
+    confidence: 0,
+    classSource: 'keyword',
+    importanceScore: 0,
+    corroborationCount: 1,
+    entityCorroborationCount: 0,
+    lang: 'en',
+    description: '',
+    isOpinion: false,
+    isFeelGood: false,
+    isEphemeralLiveCoverage: false,
+    tickers: [],
+  };
+
+  type EntityItems = Parameters<typeof computeEntityCorroborationSignals>[0];
+
+  it('one wire under two labels emits no signal; two origins do', () => {
+    const oneWire = [
+      { ...base, source: 'Oil & Gas', originPublisher: 'Reuters', title: 'US and Iran close deal to ease Hormuz tensions', titleHash: 'h-1', publishedAt: now },
+      { ...base, source: 'Reuters Energy', originPublisher: '', title: 'Iran deal could calm oil markets after Hormuz alarm', titleHash: 'h-2', publishedAt: now },
+    ] as unknown as EntityItems;
+    assert.equal(
+      computeEntityCorroborationSignals(oneWire, now).get('h-1'),
+      undefined,
+      'a Reuters wire syndicated through a keyword feed must not corroborate Reuters',
+    );
+
+    const twoPublishers = [
+      { ...base, source: 'Oil & Gas', originPublisher: 'Reuters', title: 'US and Iran close deal to ease Hormuz tensions', titleHash: 'h-1', publishedAt: now },
+      { ...base, source: 'Oil & Gas', originPublisher: 'Al Jazeera', title: 'Iran deal could calm oil markets after Hormuz alarm', titleHash: 'h-2', publishedAt: now },
+    ] as unknown as EntityItems;
+    assert.deepEqual(computeEntityCorroborationSignals(twoPublishers, now).get('h-1'), {
+      sourceCount: 2,
+      tier12SourceCount: 0,
+    });
+  });
+});


### PR DESCRIPTION
Closes #6430 (fix-sketch items 1 and 2; items 3 and 4 deliberately left open — see below).

## Problem

`parseRssXml` stamped `item.source = feed.name` and dropped the RSS `<source>` element that names the originating publisher — which Google News, backing 154 of the 366 server digest labels, emits per item. A Reuters wire arriving through the `Oil & Gas` keyword feed and through `Reuters Energy` carried two labels → two families → one wire. Cross-publisher syndication was the documented known limit of #6428's publisher-family counting (`shared/publisher-families.js` header).

## What this does

**1. Parse `<source>` into a distinct field.** RSS dialect only — Atom's `<source>` is a metadata *container* (nested elements, no text of its own), so it is skipped explicitly rather than by regex accident. The value lands in a new internal `ParsedItem.originPublisher` (`''` when absent). `item.source` is untouched: it stays what the UI credits, links, and tiers, and the digest payload shape is unchanged — no proto change.

**2. Prefer it in both corroboration counts inside the digest build:**
- story-identity cluster counts (`dedup.mjs`): `countPublisherFamilies(items.map(i => i.originPublisher || i.source))`
- entity-corroboration buckets (`computeEntityCorroborationSignals`): `publisherFamilyFor(item.originPublisher || item.source)`; the tier check stays on `item.source` — the tier is a property of the label, per the #6428 comment.

**Family resolution for origin names.** An origin is a publisher *name* ("Reuters", "Associated Press"), not a feed label, so each curated family's `publisher` name now resolves through the same lookup — set-if-absent under the labels, so label resolution is unchanged by construction. Unknown origin names stay their own singleton family (`label:<name>`), the same fail-closed direction as unmapped labels: nothing is ever fuzzy-matched into a family.

## Deliberately out of scope (per the issue's own scope notes)

- **Display credit (item 3):** whether a story surfaced through `Oil & Gas` but written by Reuters should *credit* Reuters touches tiering, the per-source cap in `selectTopStories`, and the brief footer — a product decision this PR does not make. `originPublisher` is now carried, so making it is a follow-up wiring change.
- **Replay re-measurement (item 4):** quantifying what this removes on top of #6428's 33.5% needs the replay-tick corpus from that measurement; the `>= 2` gate is not re-tuned here ("the counts get more honest; no weights move without their own measurement").
- Downstream consumers of the digest *API payload* (scripts clustering, client) keep counting feed labels — their inputs don't carry the field, and the payload shape is deliberately unchanged.

## Tests (`tests/rss-origin-publisher.test.mts`, 10 cases)

- `parseRssXml`: extracts `<source url="...">` entity-decoded (`S&amp;P Global` → `S&P Global`), leaves `item.source` as the feed label; `''` when absent; never reads Atom's `<source>` container.
- Family map: origin names fold into the right family, unknown names stay singletons, label resolution byte-for-byte unchanged.
- Story identity: wire + keyword-feed pair with origin attribution counts **1** publisher; the same pair without origin still counts 2 (the pre-fix inflation, pinned as documentation); two genuinely distinct origins through one keyword feed count 2.
- Entity corroboration: one wire under two labels emits no signal; two origins under one label do.

`publisher-families.js` mirror re-synced (locked by `scripts-shared-mirror.test.mjs`). Full related suites green: 311/311 across publisher-families, corroboration-publisher-count, story-track persistence, ticker-extract, pubdate-required, story-identity, clustering, importance-score-parity, mcp-world-brief-corroboration, brief-from-digest-stories, and the mirror lock. `tsc --noEmit` (root + api) and `biome lint` clean.
