### PR TITLE
fix(ops): default deploy drift head to origin main

### DIFF
--- a/scripts/check-railway-deploy-drift.mjs
+++ b/scripts/check-railway-deploy-drift.mjs
@@ -707,7 +707,20 @@ export function readRepeatedArguments(argv, name) {
   return values;
 }
 
-export function resolveComparisonHead(argv, { git = runGit } = {}) {
+export function resolveOriginMainRelation(headSha, originMainSha, ancestry) {
+  if (!originMainSha) return 'unavailable';
+  if (headSha === originMainSha) return 'exact';
+  const forward = ancestry(headSha, originMainSha);
+  if (forward === 'yes') return 'behind';
+  const reverse = ancestry(originMainSha, headSha);
+  if (reverse === 'yes') return 'ahead';
+  return forward === 'no' && reverse === 'no' ? 'diverged' : 'unknown';
+}
+
+export function resolveComparisonHead(argv, {
+  git = runGit,
+  ancestry = () => 'unknown',
+} = {}) {
   const explicit = readArgument(argv, '--head', null);
   if (explicit === null) {
     git([
@@ -717,15 +730,45 @@ export function resolveComparisonHead(argv, { git = runGit } = {}) {
       '+refs/heads/main:refs/remotes/origin/main',
     ]);
   }
-  const target = explicit ?? 'origin/main';
-  return git(['rev-parse', '--verify', '--end-of-options', `${target}^{commit}`]);
+  let originMainSha = null;
+  try {
+    originMainSha = git(['rev-parse', '--verify', '--end-of-options', 'origin/main^{commit}']);
+  } catch (error) {
+    if (explicit === null) {
+      throw new Error(
+        'cannot resolve origin/main for the deploy-drift comparison; fetch main or pass --head explicitly',
+        { cause: error },
+      );
+    }
+  }
+
+  let headSha = originMainSha;
+  let headSource = 'origin/main';
+  if (explicit !== null) {
+    headSource = '--head';
+    try {
+      headSha = git(['rev-parse', '--verify', '--end-of-options', `${explicit}^{commit}`]);
+    } catch (error) {
+      throw new Error(`cannot resolve --head ${explicit} to a commit`, { cause: error });
+    }
+  }
+
+  return {
+    headSha,
+    headSource,
+    originMainSha,
+    originMainRelation: resolveOriginMainRelation(headSha, originMainSha, ancestry),
+  };
+}
+
+export function formatComparisonHead({ headSource, originMainRelation }) {
+  return `source=${headSource} vs-origin-main=${originMainRelation}`;
 }
 
 
 
-
-function printReport(results, summary, headSha, graceSha) {
-  console.log(`Railway deploy-drift check: head=${headSha.slice(0, 9)} grace=${graceSha.slice(0, 9)} services=${results.length} ${JSON.stringify(summary.counts)}`);
+function printReport(results, summary, headSha, graceSha, headContext) {
+  console.log(`Railway deploy-drift check: head=${headSha.slice(0, 9)} ${formatComparisonHead(headContext)} grace=${graceSha.slice(0, 9)} services=${results.length} ${JSON.stringify(summary.counts)}`);
 
   if (summary.blocking.length > 0) {
     console.error(`Railway deploy-drift check found ${summary.blocking.length} service(s) not running the head commit:`);
@@ -768,7 +811,6 @@ async function main() {
   // Manual/operator runs default to the production line, never a feature
   // worktree's HEAD. The workflow passes its immutable event SHA explicitly,
   // then fetches newer main ancestry without moving this target.
-  const headSha = resolveComparisonHead(process.argv);
   // `git merge-base --is-ancestor` exits non-zero both when the answer is no
   // and when the object is missing (a shallow checkout that never fetched the
   // commit). Both collapse to "cannot prove it", which keeps the service
@@ -782,14 +824,8 @@ async function main() {
   // "cannot prove it keeps the service reported" behaviour.
   const ancestry = createAncestryResolver({ git: runGit });
   const isAncestor = (ancestor, descendant) => ancestry(ancestor, descendant) === 'yes';
-  let authorizedMainSha = null;
-  try {
-    authorizedMainSha = runGit(['rev-parse', '--verify', 'origin/main^{commit}']);
-  } catch {
-    // AHEAD acceptance needs a positive repository-lineage proof. A missing
-    // ref is not fatal for exact CURRENT results, but every AHEAD result fails
-    // closed in the summary below.
-  }
+  const headContext = resolveComparisonHead(process.argv, { git: runGit, ancestry });
+  const { headSha, originMainSha: authorizedMainSha } = headContext;
   // The newest commit that has been available longer than the build grace.
   // On a checkout too shallow to reach back that far, rev-list answers with
   // nothing and this falls back to head — the stricter reading.
@@ -960,6 +996,8 @@ async function main() {
     console.log(JSON.stringify({
       environment,
       headSha,
+      headSource: headContext.headSource,
+      originMainRelation: headContext.originMainRelation,
       graceSha,
       deepPass: {
         attempted: deepPass.deepenedServices,
@@ -978,12 +1016,12 @@ async function main() {
     }, null, 2));
   }
   else if (strict) {
-    console.log(`Strict Railway deploy-drift check: head=${headSha.slice(0, 9)} services=${results.length}`);
+    console.log(`Strict Railway deploy-drift check: head=${headSha.slice(0, 9)} ${formatComparisonHead(headContext)} services=${results.length}`);
     for (const problem of summary.blocking) {
       console.error(`- ${problem.service ?? 'unknown'} [${problem.verdict}] ${problem.detail ?? ''}`);
     }
     for (const service of summary.missing) console.error(`- ${service} [MISSING] was not positively classified`);
-  } else printReport(results, summary, headSha, graceSha);
+  } else printReport(results, summary, headSha, graceSha, headContext);
   if (!summary.ok || configurationDrift.length > 0) process.exitCode = 1;
 }
 

--- a/tests/railway-deploy-drift.test.mjs
+++ b/tests/railway-deploy-drift.test.mjs
@@ -21,10 +21,12 @@ import {
   classifyServiceDeploy,
   classifyFleetWithinDeadline,
   deepenNoBuildWindows,
+  formatComparisonHead,
   resolveDeepPassDeadlineAt,
   isProblemVerdict,
   readRepeatedArguments,
   resolveComparisonHead,
+  resolveOriginMainRelation,
   summarizeDeployDrift,
   summarizeStrictDeployDrift,
 } from '../scripts/check-railway-deploy-drift.mjs';
@@ -715,7 +717,7 @@ describe('strict terminal reconciliation drift', () => {
     );
   });
 
-  it('refreshes origin/main before a manual comparison while preserving an explicit CI head', () => {
+  it('refreshes origin/main before a manual comparison and reports an exact relation', () => {
     const calls = [];
     let refreshed = false;
     const git = (args) => {
@@ -724,15 +726,17 @@ describe('strict terminal reconciliation drift', () => {
         refreshed = true;
         return '';
       }
-      return args[3].startsWith('origin/main')
-        ? refreshed ? HEAD : PREVIOUS
-        : NEWER;
+      assert.equal(args.at(-1), 'origin/main^{commit}');
+      return refreshed ? HEAD : PREVIOUS;
     };
-    assert.equal(resolveComparisonHead(['node', 'script'], { git }), HEAD);
-    assert.equal(
-      resolveComparisonHead(['node', 'script', '--head', NEWER], { git }),
-      NEWER,
-    );
+    const result = resolveComparisonHead(['node', 'script'], { git });
+    assert.deepEqual(result, {
+      headSha: HEAD,
+      headSource: 'origin/main',
+      originMainSha: HEAD,
+      originMainRelation: 'exact',
+    });
+    assert.equal(formatComparisonHead(result), 'source=origin/main vs-origin-main=exact');
     assert.deepEqual(calls, [
       [
         'fetch',
@@ -741,8 +745,24 @@ describe('strict terminal reconciliation drift', () => {
         '+refs/heads/main:refs/remotes/origin/main',
       ],
       ['rev-parse', '--verify', '--end-of-options', 'origin/main^{commit}'],
-      ['rev-parse', '--verify', '--end-of-options', `${NEWER}^{commit}`],
     ]);
+  });
+
+  it('reports an explicit stale head as behind origin/main', () => {
+    const result = resolveComparisonHead(['node', 'script', '--head', PREVIOUS], {
+      git: (args) => {
+        if (args.at(-1) === 'origin/main^{commit}') return HEAD;
+        if (args.at(-1) === `${PREVIOUS}^{commit}`) return PREVIOUS;
+        throw new Error(`unexpected git call: ${args.join(' ')}`);
+      },
+      ancestry: (ancestor, descendant) => (
+        ancestor === PREVIOUS && descendant === HEAD ? 'yes' : 'no'
+      ),
+    });
+    assert.equal(result.headSha, PREVIOUS);
+    assert.equal(result.headSource, '--head');
+    assert.equal(result.originMainRelation, 'behind');
+    assert.equal(formatComparisonHead(result), 'source=--head vs-origin-main=behind');
   });
 
   it('fails a manual comparison when main cannot be refreshed', () => {
@@ -765,19 +785,49 @@ describe('strict terminal reconciliation drift', () => {
   });
 
   it('treats an explicit comparison ref as data, never as a git option', () => {
-    let call;
+    const calls = [];
     resolveComparisonHead(['node', 'script', '--head=--upload-pack=evil'], {
       git: (args) => {
-        call = args;
+        calls.push(args);
         return HEAD;
       },
     });
-    assert.deepEqual(call, [
+    assert.deepEqual(calls.at(-1), [
       'rev-parse',
       '--verify',
       '--end-of-options',
       '--upload-pack=evil^{commit}',
     ]);
+  });
+
+  it('keeps an explicit head usable when origin/main is unavailable', () => {
+    const result = resolveComparisonHead(['node', 'script', '--head', HEAD], {
+      git: (args) => {
+        if (args.at(-1) === 'origin/main^{commit}') throw new Error('missing ref');
+        if (args.at(-1) === `${HEAD}^{commit}`) return HEAD;
+        throw new Error(`unexpected git call: ${args.join(' ')}`);
+      },
+    });
+    assert.deepEqual(result, {
+      headSha: HEAD,
+      headSource: '--head',
+      originMainSha: null,
+      originMainRelation: 'unavailable',
+    });
+  });
+
+  it('distinguishes ahead, diverged, and unresolved head relationships', () => {
+    const lookup = (answers) => (
+      ancestor,
+      descendant,
+    ) => answers[`${ancestor}..${descendant}`] ?? 'unknown';
+    assert.equal(resolveOriginMainRelation(
+      NEWER,
+      HEAD,
+      lookup({ [`${HEAD}..${NEWER}`]: 'yes' }),
+    ), 'ahead');
+    assert.equal(resolveOriginMainRelation(PREVIOUS, HEAD, () => 'no'), 'diverged');
+    assert.equal(resolveOriginMainRelation(PREVIOUS, HEAD, () => 'unknown'), 'unknown');
   });
 
   it('fails closed on an empty or malformed expected fleet', () => {


### PR DESCRIPTION
## Summary

- default manual deploy-drift comparisons to `origin/main` instead of the current worktree's `HEAD`, and report the selected head's relationship to main in text and JSON output
- classify a serving descendant as `AHEAD` before a stale-head build failure, while preserving newer rejected-push precedence and strict authorized-main lineage checks
- keep scheduled monitoring pinned to its immutable trigger checkout via an explicit `--head`, and place user-supplied refs behind Git's option boundary

Closes #6205.

## Type of change

- [x] Bug fix
- [x] CI / Build / Infrastructure

## Affected areas

- [x] Other: Railway deploy-drift monitoring and reconciliation

## Checklist

- [x] No API keys or secrets committed
- [x] Targeted API typecheck passes (`npm run typecheck:api`)
- [x] Deploy-drift and workflow regression tests pass
- [x] RSS / Railway pre-seed checklist items are not applicable

## Validation

- `node --test tests/railway-deploy-drift.test.mjs` - 93 passed
- focused seed-freshness workflow contract - 1 passed
- strict convergence regressions - 17 passed
- `npm run typecheck:api`
- Biome on touched JS/test files
- `npm run lint:unicode -- --staged=false`
- `node --check` and `git diff --check`

After rebasing the reviewed patch onto the latest `main`, the deploy-drift suite was rerun: 93 passed. The workflow contract was also rechecked structurally; its broader Windows/WSL shell fixture still has the repository's existing `gate_state: command not found` platform failures.

## Documentation Alignment Checklist

N/A - this changes an internal operational monitor and does not publish methodology, API/MCP, generated-documentation, Redis, CII/CRI, news, digest, or briefing claims.

## Screenshots

N/A - no user-facing UI changes.

## AI-assisted development disclosure

This change was developed with OpenAI Codex assistance. I reviewed the implementation and tests, verified the behavior and safety properties, and take responsibility for the submitted code.