### PR TITLE
fix(desktop): converge raw bridge-globals checks on isDesktopRuntime()

### DIFF
--- a/e2e/desktop-early-boot.spec.ts
+++ b/e2e/desktop-early-boot.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * #5912: desktop-runtime detection must not depend on the Tauri bridge
+ * globals, which are ABSENT during desktop:dev early boot and in
+ * VITE_DESKTOP_RUNTIME=1 browser builds. isDesktopRuntime() covers that gap
+ * through its user-agent sniff; the raw `'__TAURI__' in window` checks this
+ * issue converged did not.
+ *
+ * This spec reproduces the early-boot signal set exactly: a Tauri user agent
+ * with NO bridge globals (the web bundle under the standard e2e server never
+ * attaches them). The observable is main.ts's context-menu suppression — a
+ * site that sniffed raw globals, so before the fix it skipped the listener
+ * in precisely the environment it exists for.
+ */
+
+const TAURI_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Tauri/2.0';
+
+async function contextMenuDefaultPrevented(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    document.body.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+}
+
+async function loadDashboard(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.setItem('wm-layer-warning-dismissed', 'true');
+    localStorage.setItem('worldmonitor-variant', 'happy');
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  // main.ts module scope has run once panels exist.
+  await page.waitForSelector('.panel[data-panel]', { state: 'attached', timeout: 60_000 });
+}
+
+test.describe('desktop early boot (Tauri UA, no bridge globals) — #5912', () => {
+  test.describe('desktop runtime', () => {
+    test.use({ userAgent: TAURI_UA });
+
+    test('context-menu suppression is active without the bridge globals', async ({ page }) => {
+      await loadDashboard(page);
+
+      // Premise: this run really is bridge-less — the UA is the ONLY signal.
+      const hasGlobals = await page.evaluate(
+        () => '__TAURI__' in window || '__TAURI_INTERNALS__' in window,
+      );
+      expect(hasGlobals).toBe(false);
+
+      expect(await contextMenuDefaultPrevented(page)).toBe(true);
+    });
+  });
+
+  test.describe('web runtime (control)', () => {
+    test('context menu stays native in a plain browser', async ({ page }) => {
+      await loadDashboard(page);
+      expect(await contextMenuDefaultPrevented(page)).toBe(false);
+    });
+  });
+});

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -9,6 +9,7 @@
 import { isIosLikeUserAgent } from './platform-ua';
 import { SENTRY_ALLOW_URLS } from './sentry-allow-urls';
 import { getSentryBuildMetadata } from './sentry-build-metadata';
+import { isDesktopRuntime } from '@/services/desktop-runtime';
 
 type SentryNs = typeof import('@sentry/browser');
 
@@ -64,7 +65,10 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
     environment: (location.hostname === 'worldmonitor.app' || location.hostname.endsWith('.worldmonitor.app')) ? 'production'
       : location.hostname.includes('vercel.app') ? 'preview'
       : 'development',
-    enabled: Boolean(sentryDsn) && !location.hostname.startsWith('localhost') && !('__TAURI_INTERNALS__' in window),
+    // !isDesktopRuntime(), not a raw bridge-globals sniff (#5912): the
+    // desktop shell must not double-report to browser Sentry, and the raw
+    // check enabled it during desktop:dev early boot (bridge not yet attached).
+    enabled: Boolean(sentryDsn) && !location.hostname.startsWith('localhost') && !isDesktopRuntime(),
     allowUrls: SENTRY_ALLOW_URLS,
     sendDefaultPii: true,
     tracesSampleRate: 0.1,

--- a/src/config/basemap.ts
+++ b/src/config/basemap.ts
@@ -6,7 +6,7 @@
 // (desktop-runtime is dependency-free by design — see its header — so this
 // module stays entry-bundle-lean.)
 
-import { isDesktopRuntime } from '@/services/desktop-runtime';
+import { isDesktopRuntime } from '@/config/desktop-runtime';
 
 const R2_PROXY = import.meta.env.VITE_PMTILES_URL ?? '';
 const R2_PUBLIC = import.meta.env.VITE_PMTILES_URL_PUBLIC ?? '';

--- a/src/config/basemap.ts
+++ b/src/config/basemap.ts
@@ -3,11 +3,20 @@
 // can render without dragging maplibre+deck.gl into the entry bundle.
 // maplibre-using helpers live in `./basemap-styles.ts` and are loaded
 // lazily alongside MapContainer/DeckGLMap when the map panel mounts.
+// (desktop-runtime is dependency-free by design — see its header — so this
+// module stays entry-bundle-lean.)
+
+import { isDesktopRuntime } from '@/services/desktop-runtime';
 
 const R2_PROXY = import.meta.env.VITE_PMTILES_URL ?? '';
 const R2_PUBLIC = import.meta.env.VITE_PMTILES_URL_PUBLIC ?? '';
-const isTauri = typeof window !== 'undefined' && '__TAURI__' in window;
-export const R2_BASE = isTauri && R2_PUBLIC ? R2_PUBLIC : R2_PROXY;
+// isDesktopRuntime(), not a raw bridge-globals sniff (#5912): the desktop app has
+// no same-origin proxy, and that is a property of the desktop BUILD — under
+// `desktop:dev` early boot the bridge global is not attached yet, so a raw
+// check routed tiles at the proxy and broke them exactly when developing the
+// desktop shell.
+const isDesktop = typeof window !== 'undefined' && isDesktopRuntime();
+export const R2_BASE = isDesktop && R2_PUBLIC ? R2_PUBLIC : R2_PROXY;
 
 const hasTilesUrl = !!R2_BASE;
 

--- a/src/config/desktop-runtime.ts
+++ b/src/config/desktop-runtime.ts
@@ -1,0 +1,73 @@
+/**
+ * "Am I running inside the Tauri desktop shell?" — and nothing else.
+ *
+ * This detector lives in config because configuration is its lowest consumer:
+ * variant and basemap selection both run before the services layer is ready.
+ * Keep it dependency-free so those modules remain safe at first paint.
+ */
+
+// Named keys only, never the whole `import.meta.env` object, so no unrelated
+// build-time value can reach client code. Enforced by
+// tests/runtime-env-guards.test.mjs.
+const ENV = (() => {
+  try {
+    return {
+      VITE_DESKTOP_RUNTIME: import.meta.env.VITE_DESKTOP_RUNTIME,
+    };
+  } catch {
+    return {} as Record<string, string | undefined>;
+  }
+})();
+
+const FORCE_DESKTOP_RUNTIME = ENV.VITE_DESKTOP_RUNTIME === '1';
+
+export type RuntimeProbe = {
+  hasTauriGlobals: boolean;
+  userAgent: string;
+  locationProtocol: string;
+  locationHost: string;
+  locationOrigin: string;
+};
+
+export function detectDesktopRuntime(probe: RuntimeProbe): boolean {
+  const tauriInUserAgent = probe.userAgent.includes('Tauri');
+  const secureLocalhostOrigin = (
+    probe.locationProtocol === 'https:' && (
+      probe.locationHost === 'localhost' ||
+      probe.locationHost.startsWith('localhost:') ||
+      probe.locationHost === '127.0.0.1' ||
+      probe.locationHost.startsWith('127.0.0.1:')
+    )
+  );
+
+  // Tauri production windows can expose tauri-like hosts/schemes without
+  // always exposing bridge globals at first paint.
+  const tauriLikeLocation = (
+    probe.locationProtocol === 'tauri:' ||
+    probe.locationProtocol === 'asset:' ||
+    probe.locationHost === 'tauri.localhost' ||
+    probe.locationHost.endsWith('.tauri.localhost') ||
+    probe.locationOrigin.startsWith('tauri://') ||
+    secureLocalhostOrigin
+  );
+
+  return probe.hasTauriGlobals || tauriInUserAgent || tauriLikeLocation;
+}
+
+export function isDesktopRuntime(): boolean {
+  if (FORCE_DESKTOP_RUNTIME) {
+    return true;
+  }
+
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return detectDesktopRuntime({
+    hasTauriGlobals: '__TAURI_INTERNALS__' in window || '__TAURI__' in window,
+    userAgent: window.navigator?.userAgent ?? '',
+    locationProtocol: window.location?.protocol ?? '',
+    locationHost: window.location?.host ?? '',
+    locationOrigin: window.location?.origin ?? '',
+  });
+}

--- a/src/config/variant.ts
+++ b/src/config/variant.ts
@@ -1,4 +1,4 @@
-import { isDesktopRuntime } from '@/services/desktop-runtime';
+import { isDesktopRuntime } from '@/config/desktop-runtime';
 
 /**
  * Every variant a user can switch to. One desktop binary ships and switches
@@ -38,8 +38,7 @@ export const SITE_VARIANT: string = (() => {
   // VITE_DESKTOP_RUNTIME=1 browser builds they never are — a raw check made
   // SITE_VARIANT resolve by hostname here while the variant switcher
   // (event-handlers.ts) wrote the stored variant on isDesktopRuntime(),
-  // splitting the two halves of one feature. desktop-runtime is imported
-  // directly (not services/runtime, which imports this module back).
+  // splitting the two halves of one feature.
   if (isDesktopRuntime()) {
     const stored = loadStoredVariant();
     if (isSiteVariant(stored)) return stored;

--- a/src/config/variant.ts
+++ b/src/config/variant.ts
@@ -1,3 +1,5 @@
+import { isDesktopRuntime } from '@/services/desktop-runtime';
+
 /**
  * Every variant a user can switch to. One desktop binary ships and switches
  * between all of these in-app (#5908), so this list is also the set
@@ -31,8 +33,14 @@ function loadStoredVariant(): string | null {
 export const SITE_VARIANT: string = (() => {
   if (typeof window === 'undefined') return buildVariant;
 
-  const isTauri = '__TAURI_INTERNALS__' in window || '__TAURI__' in window;
-  if (isTauri) {
+  // isDesktopRuntime(), not a raw bridge-globals sniff (#5912): under
+  // `desktop:dev` early boot the bridge globals are not attached yet, and in
+  // VITE_DESKTOP_RUNTIME=1 browser builds they never are — a raw check made
+  // SITE_VARIANT resolve by hostname here while the variant switcher
+  // (event-handlers.ts) wrote the stored variant on isDesktopRuntime(),
+  // splitting the two halves of one feature. desktop-runtime is imported
+  // directly (not services/runtime, which imports this module back).
+  if (isDesktopRuntime()) {
     const stored = loadStoredVariant();
     if (isSiteVariant(stored)) return stored;
     return buildVariant;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import './styles/base-layer.css';
 import './bootstrap/zod-csp';
 import { SITE_VARIANT } from '@/config/variant';
+import { isDesktopRuntime } from '@/services/desktop-runtime';
 import { installLcpAttributionDebug } from '@/bootstrap/lcp-attribution';
 import { markLcpDebug } from '@/utils/lcp-debug';
 import { enqueueSentryCall, installPreInitErrorQueue, scheduleSentryInit } from '@/bootstrap/sentry-defer';
@@ -613,8 +614,11 @@ Object.defineProperty(window, 'beta', {
   },
 });
 
-// Suppress native WKWebView context menu in Tauri — allows custom JS context menus
-if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
+// Suppress native WKWebView context menu in Tauri — allows custom JS context
+// menus. isDesktopRuntime(), not a raw globals sniff (#5912): during
+// desktop:dev early boot the bridge globals are not attached yet, so the raw
+// check skipped this listener in the very webview it exists for.
+if (isDesktopRuntime()) {
   document.addEventListener('contextmenu', (e) => {
     const target = e.target as HTMLElement;
     // Allow native menu on text inputs/textareas for copy/paste
@@ -627,7 +631,10 @@ if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
 // property exists but reading it throws SecurityError (WORLDMONITOR-Y5), which
 // at module scope aborts every top-level statement below. Read it once, safely.
 const swContainer = readServiceWorkerContainer();
-if (!('__TAURI_INTERNALS__' in window) && !('__TAURI__' in window) && swContainer) {
+// !isDesktopRuntime(), not a raw globals sniff (#5912): the desktop app must
+// never install the web service worker, and the raw check let it slip in
+// during desktop:dev early boot (bridge globals not yet attached).
+if (!isDesktopRuntime() && swContainer) {
   installSwUpdateHandler({ version: __APP_VERSION__, swContainer });
 
   const SW_UPDATE_SUCCESS_INTERVAL_MS = 60 * 60 * 1000;

--- a/src/services/desktop-runtime.ts
+++ b/src/services/desktop-runtime.ts
@@ -1,80 +1,8 @@
-/**
- * "Am I running inside the Tauri desktop shell?" — and nothing else.
- *
- * Extracted from `runtime.ts` (#5911) because that module also owns API base
- * URLs and the desktop fetch patch, so it imports `@/config/variant` and
- * `@/services/clerk`. Anything that needs only this boolean — the external-URL
- * router, checkout — would otherwise drag that whole graph in, which both
- * widens bundles and makes the module unimportable in test harnesses that stub
- * a partial browser environment (`config/variant.ts` reads `location` at
- * module scope).
- *
- * `runtime.ts` re-exports both functions, so existing importers are unaffected
- * and there is still one implementation.
- */
-
-// Same guarded allow-list wrapper as `runtime.ts`: named keys only, never the
-// whole `import.meta.env` object, so no unrelated build-time value can reach
-// client code. Enforced for both files by tests/runtime-env-guards.test.mjs.
-const ENV = (() => {
-  try {
-    return {
-      VITE_DESKTOP_RUNTIME: import.meta.env.VITE_DESKTOP_RUNTIME,
-    };
-  } catch {
-    return {} as Record<string, string | undefined>;
-  }
-})();
-
-const FORCE_DESKTOP_RUNTIME = ENV.VITE_DESKTOP_RUNTIME === '1';
-
-export type RuntimeProbe = {
-  hasTauriGlobals: boolean;
-  userAgent: string;
-  locationProtocol: string;
-  locationHost: string;
-  locationOrigin: string;
-};
-
-export function detectDesktopRuntime(probe: RuntimeProbe): boolean {
-  const tauriInUserAgent = probe.userAgent.includes('Tauri');
-  const secureLocalhostOrigin = (
-    probe.locationProtocol === 'https:' && (
-      probe.locationHost === 'localhost' ||
-      probe.locationHost.startsWith('localhost:') ||
-      probe.locationHost === '127.0.0.1' ||
-      probe.locationHost.startsWith('127.0.0.1:')
-    )
-  );
-
-  // Tauri production windows can expose tauri-like hosts/schemes without
-  // always exposing bridge globals at first paint.
-  const tauriLikeLocation = (
-    probe.locationProtocol === 'tauri:' ||
-    probe.locationProtocol === 'asset:' ||
-    probe.locationHost === 'tauri.localhost' ||
-    probe.locationHost.endsWith('.tauri.localhost') ||
-    probe.locationOrigin.startsWith('tauri://') ||
-    secureLocalhostOrigin
-  );
-
-  return probe.hasTauriGlobals || tauriInUserAgent || tauriLikeLocation;
-}
-
-export function isDesktopRuntime(): boolean {
-  if (FORCE_DESKTOP_RUNTIME) {
-    return true;
-  }
-
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  return detectDesktopRuntime({
-    hasTauriGlobals: '__TAURI_INTERNALS__' in window || '__TAURI__' in window,
-    userAgent: window.navigator?.userAgent ?? '',
-    locationProtocol: window.location?.protocol ?? '',
-    locationHost: window.location?.host ?? '',
-    locationOrigin: window.location?.origin ?? '',
-  });
-}
+// Compatibility surface for service-layer consumers and test mocks. The
+// canonical detector lives below services so config modules can use it without
+// reversing the project's dependency direction.
+export {
+  detectDesktopRuntime,
+  isDesktopRuntime,
+  type RuntimeProbe,
+} from '@/config/desktop-runtime';

--- a/src/services/push-notifications.ts
+++ b/src/services/push-notifications.ts
@@ -21,6 +21,7 @@
 //     device is a no-op from the user's perspective.
 
 import { getClerkToken, getCurrentClerkUser } from '@/services/clerk';
+import { isDesktopRuntime } from '@/services/desktop-runtime';
 import { VAPID_PUBLIC_KEY, isWebPushConfigured, urlBase64ToUint8Array, arrayBufferToBase64 } from '@/config/push';
 
 export type PushPermission = 'default' | 'granted' | 'denied' | 'unsupported';
@@ -39,7 +40,10 @@ export type PushPermission = 'default' | 'granted' | 'denied' | 'unsupported';
  */
 export function isWebPushSupported(): boolean {
   if (typeof window === 'undefined') return false;
-  if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) return false;
+  // isDesktopRuntime(), not a raw globals sniff (#5912): "no web push" is a
+  // property of the desktop BUILD (native notifications own that surface),
+  // and the raw check reported "web" during desktop:dev early boot.
+  if (isDesktopRuntime()) return false;
   if (!('serviceWorker' in navigator)) return false;
   if (!('PushManager' in window)) return false;
   if (typeof Notification === 'undefined') return false;

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -1,3 +1,5 @@
+import { isDesktopRuntime } from '@/services/desktop-runtime';
+
 interface CircuitState {
   failures: number;
   cooldownUntil: number;
@@ -52,8 +54,10 @@ const DEFAULT_MAX_CACHE_ENTRIES = 256;
 
 function isDesktopOfflineMode(): boolean {
   if (typeof window === 'undefined') return false;
-  const hasTauri = Boolean((window as unknown as { __TAURI__?: unknown }).__TAURI__);
-  return hasTauri && typeof navigator !== 'undefined' && navigator.onLine === false;
+  // isDesktopRuntime(), not a raw bridge-globals sniff (#5912): "offline
+  // desktop app" is a property of the desktop runtime, and the raw global is
+  // absent during desktop:dev early boot even though the app IS the desktop.
+  return isDesktopRuntime() && typeof navigator !== 'undefined' && navigator.onLine === false;
 }
 
 export class CircuitBreaker<T> {

--- a/tests/desktop-runtime-detector-convergence.test.mjs
+++ b/tests/desktop-runtime-detector-convergence.test.mjs
@@ -1,0 +1,86 @@
+// #5912 — one desktop-runtime detector, no raw __TAURI__ sniffs.
+//
+// Two detectors used to coexist and disagree: isDesktopRuntime()
+// (src/services/desktop-runtime.ts) answers "is this the desktop product?"
+// from env flag + globals + UA + tauri-like origins, while six call sites
+// sniffed the raw bridge globals — which are ABSENT during desktop:dev early
+// boot and in VITE_DESKTOP_RUNTIME=1 browser builds. Concrete split-brain:
+// SITE_VARIANT resolved on the raw check while the variant switcher wrote
+// the stored variant on isDesktopRuntime().
+//
+// This locks the convergence: the token __TAURI may appear ONLY in
+//   - src/services/desktop-runtime.ts  (the detector itself)
+//   - src/services/tauri-bridge.ts     (the IPC accessor: it does not ask
+//     "is this the desktop?", it reads window.__TAURI__.core.invoke — the
+//     one legitimate "is the bridge attached RIGHT NOW?" consumer)
+// Anywhere else, use isDesktopRuntime() (or detectDesktopRuntime with an
+// explicit probe). A new raw sniff reintroduces the early-boot split-brain.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const srcRoot = join(repoRoot, 'src');
+
+const ALLOWED = new Set([
+  'src/services/desktop-runtime.ts',
+  'src/services/tauri-bridge.ts',
+]);
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === 'generated') continue; // codegen output, not hand-written call sites
+      yield* walk(full);
+    } else if (/\.(ts|tsx|js|mjs)$/.test(entry) && !entry.endsWith('.d.ts')) {
+      yield full;
+    }
+  }
+}
+
+describe('desktop-runtime detector convergence (#5912)', () => {
+  it('no raw __TAURI__ sniff outside the detector and the bridge accessor', () => {
+    const offending = [];
+    for (const file of walk(srcRoot)) {
+      const rel = relative(repoRoot, file);
+      if (ALLOWED.has(rel)) continue;
+      const src = readFileSync(file, 'utf-8');
+      if (src.includes('__TAURI')) {
+        for (const [lineNo, line] of src.split('\n').entries()) {
+          if (line.includes('__TAURI')) offending.push(`${rel}:${lineNo + 1}: ${line.trim()}`);
+        }
+      }
+    }
+    assert.deepEqual(
+      offending,
+      [],
+      'raw __TAURI__ checks found outside the allow-list — use isDesktopRuntime() ' +
+        '(src/services/desktop-runtime.ts) instead; it stays true during desktop:dev ' +
+        `early boot and in VITE_DESKTOP_RUNTIME=1 browser builds:\n${offending.join('\n')}`,
+    );
+  });
+
+  it('the previously split-brained call sites resolve through isDesktopRuntime', () => {
+    const CONVERGED = [
+      'src/config/variant.ts',
+      'src/config/basemap.ts',
+      'src/main.ts',
+      'src/services/push-notifications.ts',
+      'src/utils/circuit-breaker.ts',
+      'src/bootstrap/sentry-init.ts',
+    ];
+    for (const rel of CONVERGED) {
+      const src = readFileSync(join(repoRoot, rel), 'utf-8');
+      assert.match(
+        src,
+        /isDesktopRuntime/,
+        `${rel} no longer calls isDesktopRuntime() — if desktop detection moved, update this list`,
+      );
+    }
+  });
+});

--- a/tests/desktop-runtime-detector-convergence.test.mjs
+++ b/tests/desktop-runtime-detector-convergence.test.mjs
@@ -1,7 +1,7 @@
 // #5912 — one desktop-runtime detector, no raw __TAURI__ sniffs.
 //
 // Two detectors used to coexist and disagree: isDesktopRuntime()
-// (src/services/desktop-runtime.ts) answers "is this the desktop product?"
+// (src/config/desktop-runtime.ts) answers "is this the desktop product?"
 // from env flag + globals + UA + tauri-like origins, while six call sites
 // sniffed the raw bridge globals — which are ABSENT during desktop:dev early
 // boot and in VITE_DESKTOP_RUNTIME=1 browser builds. Concrete split-brain:
@@ -9,7 +9,7 @@
 // the stored variant on isDesktopRuntime().
 //
 // This locks the convergence: the token __TAURI may appear ONLY in
-//   - src/services/desktop-runtime.ts  (the detector itself)
+//   - src/config/desktop-runtime.ts    (the detector itself)
 //   - src/services/tauri-bridge.ts     (the IPC accessor: it does not ask
 //     "is this the desktop?", it reads window.__TAURI__.core.invoke — the
 //     one legitimate "is the bridge attached RIGHT NOW?" consumer)
@@ -27,7 +27,7 @@ const repoRoot = resolve(__dirname, '..');
 const srcRoot = join(repoRoot, 'src');
 
 const ALLOWED = new Set([
-  'src/services/desktop-runtime.ts',
+  'src/config/desktop-runtime.ts',
   'src/services/tauri-bridge.ts',
 ]);
 
@@ -60,9 +60,20 @@ describe('desktop-runtime detector convergence (#5912)', () => {
       offending,
       [],
       'raw __TAURI__ checks found outside the allow-list — use isDesktopRuntime() ' +
-        '(src/services/desktop-runtime.ts) instead; it stays true during desktop:dev ' +
+        '(src/config/desktop-runtime.ts) instead; it stays true during desktop:dev ' +
         `early boot and in VITE_DESKTOP_RUNTIME=1 browser builds:\n${offending.join('\n')}`,
     );
+  });
+
+  it('keeps the canonical detector in a layer config modules may import', () => {
+    const variant = readFileSync(join(repoRoot, 'src/config/variant.ts'), 'utf-8');
+    const basemap = readFileSync(join(repoRoot, 'src/config/basemap.ts'), 'utf-8');
+    const serviceCompatibility = readFileSync(join(repoRoot, 'src/services/desktop-runtime.ts'), 'utf-8');
+
+    assert.match(variant, /from ['"]@\/config\/desktop-runtime['"]/);
+    assert.match(basemap, /from ['"]@\/config\/desktop-runtime['"]/);
+    assert.match(serviceCompatibility, /from ['"]@\/config\/desktop-runtime['"]/);
+    assert.doesNotMatch(serviceCompatibility, /function (?:detect|is)DesktopRuntime/);
   });
 
   it('the previously split-brained call sites resolve through isDesktopRuntime', () => {

--- a/tests/runtime-env-guards.test.mjs
+++ b/tests/runtime-env-guards.test.mjs
@@ -6,10 +6,10 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const runtimeSrc = readFileSync(resolve(__dirname, '../src/services/runtime.ts'), 'utf-8');
-// #5911 split the desktop detector (and its VITE_DESKTOP_RUNTIME read) into a
-// dependency-free leaf. The allow-list invariant follows the code: both halves
-// are asserted, so the split cannot be used to smuggle in a whole-env snapshot.
-const desktopRuntimeSrc = readFileSync(resolve(__dirname, '../src/services/desktop-runtime.ts'), 'utf-8');
+// The desktop detector (and its VITE_DESKTOP_RUNTIME read) lives in a
+// dependency-free config leaf. The allow-list invariant follows the canonical
+// implementation, so moving it cannot be used to smuggle in a whole-env snapshot.
+const desktopRuntimeSrc = readFileSync(resolve(__dirname, '../src/config/desktop-runtime.ts'), 'utf-8');
 const variantSrc = readFileSync(resolve(__dirname, '../src/config/variant.ts'), 'utf-8');
 
 describe('runtime env guards', () => {


### PR DESCRIPTION
Closes #5912.

## Problem

Two desktop-runtime detectors coexisted and disagreed. `isDesktopRuntime()` (`src/services/desktop-runtime.ts`) answers "is this the desktop product?" from the env flag, bridge globals, user agent, and tauri-like origins. Six call sites instead sniffed the raw bridge globals — which are **absent during `desktop:dev` early boot** (the bridge attaches after first paint) and **never present in `VITE_DESKTOP_RUNTIME=1` browser builds**. Those sites behaved as *web* in exactly the environments where they had to behave as desktop.

## What converged, and what each raw check was breaking

| Site | Failure under early boot / browser desktop builds |
|---|---|
| `config/variant.ts` | The issue's named split-brain: `SITE_VARIANT` resolved by hostname while the variant switcher (`event-handlers.ts`) wrote the stored variant on `isDesktopRuntime()` — two halves of one feature on different detectors. Imports `desktop-runtime` directly, since `services/runtime` imports this module back. |
| `config/basemap.ts` | Tiles routed at the same-origin proxy the desktop build does not have. |
| `main.ts` (two sites) | The WKWebView context-menu suppression skipped in the very webview it exists for; the web service worker allowed to install inside the desktop shell. |
| `services/push-notifications.ts` | Web push offered on a desktop build (native notifications own that surface). |
| `utils/circuit-breaker.ts` | Desktop-offline mode never engaged pre-bridge. |
| `bootstrap/sentry-init.ts` | Browser Sentry enabled inside the desktop shell. *(Not in the issue's original list — the site has grown since it was filed.)* |

**The deliberate carve-out** the issue anticipated: `services/tauri-bridge.ts` keeps its raw access. It does not ask "is this the desktop?" — it reads `window.__TAURI__.core.invoke`, the one legitimate "is the bridge attached RIGHT NOW?" consumer.

`desktop-runtime.ts` was extracted dependency-free (#5911) precisely so early config modules could import it without dragging the `runtime.ts` → variant/Clerk graph; this PR is that extraction paying off.

## Regression tests

- **`tests/desktop-runtime-detector-convergence.test.mjs`** locks the convergence the way this repo locks invariants: the raw token may appear only in the detector and the bridge accessor; any new sniff anywhere in `src/` fails with a pointer to `isDesktopRuntime()`. A second case pins that the six converged files still resolve through it.
- **`e2e/desktop-early-boot.spec.ts`** reproduces the early-boot signal set *exactly* — Tauri user agent with **no** bridge globals (asserted in-test as the premise) — against the standard e2e web server, and pins the context-menu suppression, with a plain-browser control proving the assertion isn't vacuous. Verified both ways: passes with the fix, fails against the pre-fix sources.

## Verification

- New enforcement test + e2e spec pass; e2e fails on pre-fix sources (checked by stashing `src/`).
- 90/90 across the related unit suites (runtime-env-guards, both circuit-breaker suites, desktop-one-binary-model, bootstrap-runtime, sentry-defer-replay, brief-web-push, push-registration-failure-detail, variant-inline-bootstrap, and the new convergence lock).
- `tsc --noEmit` and `biome lint` clean.
