### PR TITLE
fix(railway): stop recovery approval emails and retry failures

### DIFF
--- a/.github/workflows/railway-reconcile-manual-recovery.yml
+++ b/.github/workflows/railway-reconcile-manual-recovery.yml
@@ -21,7 +21,7 @@ on:
         required: true
         type: string
       approver:
-        description: Independent audit approver identity; environment protection verifies it externally
+        description: Delegated operator identity recorded in the immutable recovery audit trail
         required: true
         type: string
       reason:
@@ -101,11 +101,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    # GitHub does not expose the approving reviewer identity as a trustworthy
-    # workflow expression. The required approver input is an audit assertion,
-    # not a claim that YAML discovered the live reviewer. Required reviewers,
-    # prevent-self-review, and live reviewer identity/evidence are an
-    # EXTERNAL PROVISIONING GATE. YAML proves only the environment target.
+    # This environment is a main-only secret boundary with no required reviewer.
+    # For a single operator, self-review adds no independent authorization and
+    # sends an approval email for every recovery attempt. The approver input
+    # records delegated operator identity in the immutable controller audit.
+    # Safety remains fail-closed through exact-main and repeated provider-inactivity proof,
+    # role-specific HMACs, controller CAS/generation checks, exact run binding,
+    # and terminal deployment verification.
     environment:
       name: ingestion-acceptance-production-breakglass
       deployment: false

--- a/.github/workflows/railway-reconcile-manual-recovery.yml
+++ b/.github/workflows/railway-reconcile-manual-recovery.yml
@@ -21,7 +21,7 @@ on:
         required: true
         type: string
       approver:
-        description: Delegated operator identity recorded in the immutable recovery audit trail
+        description: Operator audit identity; may equal the GitHub actor
         required: true
         type: string
       reason:
@@ -104,7 +104,8 @@ jobs:
     # This environment is a main-only secret boundary with no required reviewer.
     # For a single operator, self-review adds no independent authorization and
     # sends an approval email for every recovery attempt. The approver input
-    # records delegated operator identity in the immutable controller audit.
+    # records delegated operator identity in the immutable controller audit and
+    # can equal the GitHub actor.
     # Safety remains fail-closed through exact-main and repeated provider-inactivity proof,
     # role-specific HMACs, controller CAS/generation checks, exact run binding,
     # and terminal deployment verification.

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -277,6 +277,12 @@ the protected resolution also records the separately revalidated current head.
 This separation keeps the convergence-acceptance route reachable after main
 moves, including when it must reset a full 64-run mutation lineage.
 
+The protected retry is the only path that can replace a same-head Railway
+deployment in `FAILED`. Ordinary runs continue to report that failure without
+retrying it. A recovery still adopts any same-head deployment that is active or
+that reached a running state, so the one-use controller hold cannot duplicate
+work that Railway already accepted.
+
 `retryEvidence` has exactly one of these forms. Its `evidenceId` must differ
 from the outer evidence ID:
 

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -147,7 +147,7 @@ rejects every other host even if a workflow variable is misconfigured.
 | `ingestion-acceptance-production-watchdog` | Watchdog HMAC only; no Railway credential |
 | `ingestion-acceptance-production` | Mutation HMAC, `RAILWAY_RECONCILE_DEPLOY_TOKEN_V2`, and project ID |
 | `ingestion-acceptance-production-verification` | Verifier HMAC, `RAILWAY_RECONCILE_VIEWER_TOKEN`, project ID, and GitHub read evidence |
-| `ingestion-acceptance-production-breakglass` | Operator HMAC plus the same `RAILWAY_RECONCILE_VIEWER_TOKEN`; required reviewers gate the resolve job |
+| `ingestion-acceptance-production-breakglass` | Operator HMAC plus the same `RAILWAY_RECONCILE_VIEWER_TOKEN`; main-only secret boundary with no required reviewer |
 
 Both Railway tokens are distinct project tokens with identical capability; the
 names record intended use, not an enforced boundary. See the scope note below.
@@ -173,14 +173,13 @@ workflow contract tests, so treat any change to those guards as a change to a
 security boundary. Note also that `projectTokenCreate` rejects a CLI session
 with `Not Authorized`; both tokens must be created from the Railway dashboard.
 
-Breakglass approval is **one-person by deliberate choice.** The environment
-requires a reviewer, so `resolve` pauses until a human approves and GitHub
-records who did, but `prevent_self_review` is **off**: the operator who
-dispatches recovery may approve their own run. Turning it on with a single
-reviewer would deadlock the emergency path — the one person able to trigger
-recovery would be forbidden from approving it, exactly when it is needed. Real
-two-person control needs a second named reviewer added first; until then the
-`approver` workflow input stays an audit assertion, not a verified second party.
+Breakglass authorization is **one-person by deliberate choice.** The environment
+keeps its `main`-only branch policy and isolated secrets, but has no required
+reviewer. Requiring that same operator to review their own dispatch adds no
+independent authorization and sends one approval email for every recovery
+attempt. The `approver` workflow input records the delegated operator identity
+in the immutable controller audit; it is not a verified second party. Real
+two-person control requires a second named operator and `prevent_self_review`.
 
 The protected resolver deliberately repeats the GitHub, convergence, and
 provider-inactivity reads after environment approval; the earlier proof is not

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -178,7 +178,8 @@ keeps its `main`-only branch policy and isolated secrets, but has no required
 reviewer. Requiring that same operator to review their own dispatch adds no
 independent authorization and sends one approval email for every recovery
 attempt. The `approver` workflow input records the delegated operator identity
-in the immutable controller audit; it is not a verified second party. Real
+in the immutable controller audit and can equal the dispatch actor; it is not a
+verified second party. Real
 two-person control requires a second named operator and `prevent_self_review`.
 
 The protected resolver deliberately repeats the GitHub, convergence, and
@@ -277,11 +278,12 @@ the protected resolution also records the separately revalidated current head.
 This separation keeps the convergence-acceptance route reachable after main
 moves, including when it must reset a full 64-run mutation lineage.
 
-The protected retry is the only path that can replace a same-head Railway
-deployment in `FAILED`. Ordinary runs continue to report that failure without
-retrying it. A recovery still adopts any same-head deployment that is active or
-that reached a running state, so the one-use controller hold cannot duplicate
-work that Railway already accepted.
+The protected retry hold carries an immutable capability that is the only path
+that can replace a same-head Railway deployment in `FAILED`. Ordinary runs and
+watchdog-created recovery holds continue to report that failure without
+retrying it. A recovery still adopts any active same-head deployment, or a
+running same-head replacement newer than the failure, so the one-use controller
+hold cannot duplicate work that Railway already accepted.
 
 `retryEvidence` has exactly one of these forms. Its `evidenceId` must differ
 from the outer evidence ID:

--- a/scripts/resolve-railway-reconcile-control.mjs
+++ b/scripts/resolve-railway-reconcile-control.mjs
@@ -227,7 +227,6 @@ export function validateRecoveryRequest(value, { now = Date.now } = {}) {
   if (!sanitizeReason(value.reason)) fail('REASON_INVALID', 'reason must be a sanitized single line of 10-240 characters');
   requireActor(value.actor, 'actor');
   requireApprover(value.approver);
-  if (value.actor === value.approver) fail('ACTOR_APPROVER_MUST_DIFFER', 'actor and approver must be distinct');
   requireActor(value.triggeringActor, 'triggeringActor');
   requireRunId(value.operatorRunId, 'operatorRunId');
   requireAttempt(value.operatorRunAttempt, 'operatorRunAttempt');

--- a/scripts/trigger-railway-deploys.mjs
+++ b/scripts/trigger-railway-deploys.mjs
@@ -31,9 +31,10 @@
 // measurement above is what they look like working — and clearing them rebuilds
 // all 77 services on every merge for no gain in the tail that matters.
 //
-// It does not re-trigger a build that Railway already ran and FAILED. That is a
-// real failure that scripts/check-railway-deploy-drift.mjs reports; retrying it
-// here would bury the alarm under a retry loop.
+// Ordinary runs do not re-trigger a build that Railway already ran and FAILED.
+// That is a real failure that scripts/check-railway-deploy-drift.mjs reports;
+// retrying it automatically would bury the alarm under a retry loop. A
+// controller-authorized manual recovery may retry that exact failed head once.
 //
 // Usage:
 //   node scripts/trigger-railway-deploys.mjs
@@ -58,6 +59,7 @@ import {
   runRailway,
 } from './railway-cli.mjs';
 import {
+  FAILED_STATUSES,
   REJECTED_STATUS,
   createFleetAccumulator,
   isKnownStatus,
@@ -167,6 +169,7 @@ export function planServiceDeploy({
   headSha,
   changedPathsSince,
   readError = null,
+  retryFailedHead = false,
   // Tri-state: 'yes' | 'no' | 'unknown'. Used to refuse deploying a service
   // BACKWARDS. Defaults to 'unknown', which REFUSES rather than deploys — the
   // one place in this script where uncertainty must not resolve toward
@@ -202,7 +205,9 @@ export function planServiceDeploy({
   // A record for head in a status we RECOGNISE as non-refusal means Railway has
   // taken this commit — queued it, built it, or built it and failed. This also
   // subsumes "the service is already running head". SKIPPED is excluded on
-  // purpose: that record IS the refusal this script exists to compensate.
+  // purpose: that record IS the refusal this script exists to compensate. An
+  // exact controller-authorized recovery also excludes FAILED so that the one
+  // requested retry can create a replacement deployment.
   //
   // "Recognise" is load-bearing. `status !== 'SKIPPED'` treats every UNKNOWN
   // status as handled, and Railway's enum already carries two this file does
@@ -212,9 +217,11 @@ export function planServiceDeploy({
   // trigger never retries — the unmatched case silently meaning HEALTHY, which
   // is the failure this whole change exists to remove.
   const forHead = ordered.filter((deployment) => deployment?.meta?.commitHash === headSha);
-  const taken = forHead.find(
-    (deployment) => deployment.status !== REJECTED_STATUS && isKnownStatus(deployment.status),
-  );
+  const taken = forHead.find((deployment) => (
+    deployment.status !== REJECTED_STATUS
+    && isKnownStatus(deployment.status)
+    && !(retryFailedHead && FAILED_STATUSES.includes(deployment.status))
+  ));
   if (taken) {
     return {
       ...base,
@@ -904,7 +911,13 @@ function printReport(plans, summary, headSha, { dryRun, elapsedMs }) {
   }
 }
 
-async function buildDeployPlanningContext({ environment, window, concurrency, headSha }) {
+async function buildDeployPlanningContext({
+  environment,
+  window,
+  concurrency,
+  headSha,
+  recoveryAttemptId = null,
+}) {
   const projectId = process.env.RAILWAY_PROJECT_ID;
   if (typeof projectId !== 'string' || projectId.length === 0) {
     throw new Error('RAILWAY_PROJECT_ID is required');
@@ -966,6 +979,7 @@ async function buildDeployPlanningContext({ environment, window, concurrency, he
     changedPathsSince,
     readError,
     ancestry,
+    retryFailedHead: recoveryAttemptId !== null,
   });
   const plans = (await mapWithConcurrency(repositoryServices, concurrency, async (service) => {
     const { deployments, error: readError } = histories.get(service.id)
@@ -1071,7 +1085,15 @@ async function main() {
         // A runner-less job or a contender rejected by durable admission must
         // perform neither production setup nor Railway reads.
         installPinnedRailwayCli();
-        planningContext = await buildDeployPlanningContext({ environment, window, concurrency, headSha });
+        planningContext = await buildDeployPlanningContext({
+          environment,
+          window,
+          concurrency,
+          headSha,
+          // The controller admits this callback only after validating this
+          // exact bound recovery hold. Ordinary runs pass null.
+          recoveryAttemptId,
+        });
         return planningContext;
       },
       refreshService: (plan) => planningContext.refreshService(plan),

--- a/scripts/trigger-railway-deploys.mjs
+++ b/scripts/trigger-railway-deploys.mjs
@@ -60,7 +60,9 @@ import {
 } from './railway-cli.mjs';
 import {
   FAILED_STATUSES,
+  IN_FLIGHT_STATUSES,
   REJECTED_STATUS,
+  RUNNING_STATUSES,
   createFleetAccumulator,
   isKnownStatus,
   newestRunning,
@@ -143,9 +145,10 @@ export const FAILING_ACQUIRE_DEFERRALS = new Set([
 // two days of the busiest cron in the fleet while staying one CLI call.
 export const DEFAULT_DEPLOYMENT_WINDOW = 200;
 
-// A build that is queued, running, finished or even failed for the head commit
-// all mean the same thing here: Railway has taken this commit, so triggering a
-// second build of it would only duplicate work or bury a failure.
+// For ordinary planning, a build that is queued, running, finished or failed
+// for the head commit means Railway has taken it. A controller-authorized
+// recovery treats the newest unresolved FAILED record differently while still
+// adopting active work and a newer running replacement.
 export const HANDLED_BY_RAILWAY = 'ALREADY_TAKEN';
 
 // Deploying is the safe direction, so every "we could not tell" resolves here.
@@ -202,12 +205,11 @@ export function planServiceDeploy({
   // unparseable timestamp sorts oldest rather than producing NaN comparisons.
   const ordered = orderByRecency(deployments);
 
-  // A record for head in a status we RECOGNISE as non-refusal means Railway has
-  // taken this commit — queued it, built it, or built it and failed. This also
-  // subsumes "the service is already running head". SKIPPED is excluded on
-  // purpose: that record IS the refusal this script exists to compensate. An
-  // exact controller-authorized recovery also excludes FAILED so that the one
-  // requested retry can create a replacement deployment.
+  // A record for head in a status we RECOGNISE as non-refusal normally means
+  // Railway has taken this commit — queued it, built it, or built it and
+  // failed. This also subsumes "the service is already running head". SKIPPED
+  // is excluded on purpose: that record IS the refusal this script exists to
+  // compensate.
   //
   // "Recognise" is load-bearing. `status !== 'SKIPPED'` treats every UNKNOWN
   // status as handled, and Railway's enum already carries two this file does
@@ -217,11 +219,22 @@ export function planServiceDeploy({
   // trigger never retries — the unmatched case silently meaning HEALTHY, which
   // is the failure this whole change exists to remove.
   const forHead = ordered.filter((deployment) => deployment?.meta?.commitHash === headSha);
-  const taken = forHead.find((deployment) => (
-    deployment.status !== REJECTED_STATUS
-    && isKnownStatus(deployment.status)
-    && !(retryFailedHead && FAILED_STATUSES.includes(deployment.status))
-  ));
+  const failedHeadIndex = retryFailedHead
+    ? forHead.findIndex((deployment) => FAILED_STATUSES.includes(deployment.status))
+    : -1;
+  const retryingFailedHead = failedHeadIndex >= 0;
+  const failedHeadDetail = `protected recovery is replacing failed ${headSha.slice(0, 9)}`;
+  const taken = retryingFailedHead
+    ? forHead.find((deployment, index) => (
+      // In-flight work is active regardless of creation order. A running
+      // deployment is a replacement only when it is newer than the failure;
+      // an older success does not clear the failed-build alarm.
+      IN_FLIGHT_STATUSES.includes(deployment.status)
+      || (index < failedHeadIndex && RUNNING_STATUSES.includes(deployment.status))
+    ))
+    : forHead.find((deployment) => (
+      deployment.status !== REJECTED_STATUS && isKnownStatus(deployment.status)
+    ));
   if (taken) {
     return {
       ...base,
@@ -247,6 +260,14 @@ export function planServiceDeploy({
 
   const running = newestRunning(ordered);
   if (!running) {
+    if (retryingFailedHead) {
+      return {
+        ...base,
+        action: 'deploy',
+        reason: 'FAILED_HEAD_RETRY',
+        detail: failedHeadDetail,
+      };
+    }
     // Nothing has ever run. That is not a service lagging a merge — it is one
     // that was never started, is stopped, or is provisioned but idle, and
     // starting it is a decision nobody made here. The drift check reports it as
@@ -263,8 +284,10 @@ export function planServiceDeploy({
     return {
       ...base,
       action: 'deploy',
-      reason: 'UNKNOWN_SOURCE',
-      detail: DEPLOY_REASONS.UNKNOWN_SOURCE,
+      reason: retryingFailedHead ? 'FAILED_HEAD_RETRY' : 'UNKNOWN_SOURCE',
+      detail: retryingFailedHead
+        ? failedHeadDetail
+        : DEPLOY_REASONS.UNKNOWN_SOURCE,
     };
   }
   // PROVE forward motion before deploying anything.
@@ -306,6 +329,15 @@ export function planServiceDeploy({
 
   // runningToHead === 'yes': head provably contains what the service runs, so
   // any deploy from here moves it forward.
+  if (retryingFailedHead) {
+    return {
+      ...base,
+      runningSha,
+      action: 'deploy',
+      reason: 'FAILED_HEAD_RETRY',
+      detail: failedHeadDetail,
+    };
+  }
   const changedPaths = changedPathsSince(runningSha);
   if (changedPaths === null) {
     return {
@@ -716,7 +748,13 @@ export async function runLeasedReconcile({
   let operationError = null;
   let completed = null;
   try {
-    const context = await buildPlan();
+    const retryFailedHead = recoveryAttemptId !== null
+      && acquisition.dispatchHold?.recoveryAttemptId === recoveryAttemptId
+      && acquisition.dispatchHold?.headSha === headSha
+      && acquisition.dispatchHold?.state === 'LEASE_ACQUIRED'
+      && acquisition.dispatchHold?.linkedAttemptId === attempt.attemptId
+      && acquisition.dispatchHold?.failedHeadRetryAuthorized === true;
+    const context = await buildPlan({ retryFailedHead });
     const plans = [...context.plans].sort((left, right) => left.service.localeCompare(right.service));
     const intent = createIntentManifest({
       attemptId: attempt.attemptId,
@@ -916,7 +954,7 @@ async function buildDeployPlanningContext({
   window,
   concurrency,
   headSha,
-  recoveryAttemptId = null,
+  retryFailedHead = false,
 }) {
   const projectId = process.env.RAILWAY_PROJECT_ID;
   if (typeof projectId !== 'string' || projectId.length === 0) {
@@ -979,7 +1017,7 @@ async function buildDeployPlanningContext({
     changedPathsSince,
     readError,
     ancestry,
-    retryFailedHead: recoveryAttemptId !== null,
+    retryFailedHead,
   });
   const plans = (await mapWithConcurrency(repositoryServices, concurrency, async (service) => {
     const { deployments, error: readError } = histories.get(service.id)
@@ -1081,7 +1119,7 @@ async function main() {
       recoveryAttemptId,
       producer,
       authorizeCurrent: () => readExactCurrentMainAuthorization({ repository, headSha }),
-      buildPlan: async () => {
+      buildPlan: async ({ retryFailedHead }) => {
         // A runner-less job or a contender rejected by durable admission must
         // perform neither production setup nor Railway reads.
         installPinnedRailwayCli();
@@ -1090,9 +1128,9 @@ async function main() {
           window,
           concurrency,
           headSha,
-          // The controller admits this callback only after validating this
-          // exact bound recovery hold. Ordinary runs pass null.
-          recoveryAttemptId,
+          // This capability comes from the immutable admitted hold. Watchdog
+          // recovery IDs do not authorize replacing a failed deployment.
+          retryFailedHead,
         });
         return planningContext;
       },

--- a/tests/railway-deploy-trigger.test.mjs
+++ b/tests/railway-deploy-trigger.test.mjs
@@ -120,8 +120,50 @@ describe('deploy planning', () => {
       retryFailedHead: true,
     });
     assert.equal(result.action, 'deploy');
-    assert.equal(result.reason, 'CLOSURE_CHANGED');
+    assert.equal(result.reason, 'FAILED_HEAD_RETRY');
     assert.equal(result.observedDeploymentId, null);
+  });
+
+  it('retries the newest failed head even when an older same-head build succeeded', () => {
+    const result = plan({
+      deployments: [
+        deployment('FAILED', HEAD, { id: 'dep-failed', createdAt: '2026-08-04T12:00:00.000Z' }),
+        deployment('SUCCESS', HEAD, { id: 'dep-old-success', createdAt: '2026-08-04T11:58:00.000Z' }),
+        deployment('SUCCESS', RUNNING, { createdAt: '2026-08-04T11:00:00.000Z' }),
+      ],
+      changedPathsSince: () => [],
+      retryFailedHead: true,
+      ancestry: (ancestor, descendant) => (ancestor === HEAD && descendant === HEAD ? 'yes' : 'no'),
+    });
+    assert.equal(result.action, 'deploy');
+    assert.equal(result.reason, 'FAILED_HEAD_RETRY');
+    assert.equal(result.observedDeploymentId, null);
+  });
+
+  it('retries an authorized failed first build instead of calling it never deployed', () => {
+    const result = plan({
+      deployments: [deployment('FAILED', HEAD, {
+        id: 'dep-failed',
+        createdAt: '2026-08-04T12:00:00.000Z',
+      })],
+      retryFailedHead: true,
+    });
+    assert.equal(result.action, 'deploy');
+    assert.equal(result.reason, 'FAILED_HEAD_RETRY');
+  });
+
+  it('adopts a running same-head replacement newer than the failed build', () => {
+    const result = plan({
+      deployments: [
+        deployment('SUCCESS', HEAD, { id: 'dep-replacement', createdAt: '2026-08-04T12:01:00.000Z' }),
+        deployment('FAILED', HEAD, { id: 'dep-failed', createdAt: '2026-08-04T12:00:00.000Z' }),
+        deployment('SUCCESS', RUNNING),
+      ],
+      retryFailedHead: true,
+    });
+    assert.equal(result.action, 'skip');
+    assert.equal(result.reason, HANDLED_BY_RAILWAY);
+    assert.equal(result.observedDeploymentId, 'dep-replacement');
   });
 
   it('does not duplicate active head work during protected recovery', () => {
@@ -463,6 +505,7 @@ function fakeControl(events, { acquire } = {}) {
         data: {
           attempt: { attemptId: 'attempt-1' },
           leaseCapability: 'lease-capability-abcdefghijklmnopqrstuvwxyz',
+          dispatchHold: null,
         },
       };
     }),
@@ -759,7 +802,19 @@ describe('protected leased mutation orchestration', () => {
         if (attempts === 1) {
           throw new ControlPlaneError('DISPATCH_HOLD_ACTIVE', 'not bound', { definitive: true });
         }
-        return { data: { attempt: { attemptId: 'attempt-1' }, leaseCapability: 'lease-capability-abcdefghijklmnopqrstuvwxyz' } };
+        return {
+          data: {
+            attempt: { attemptId: 'attempt-1' },
+            leaseCapability: 'lease-capability-abcdefghijklmnopqrstuvwxyz',
+            dispatchHold: {
+              recoveryAttemptId: 'recovery-1',
+              headSha: HEAD,
+              state: 'LEASE_ACQUIRED',
+              linkedAttemptId: 'attempt-1',
+              failedHeadRetryAuthorized: false,
+            },
+          },
+        };
       },
     });
     await runLeasedReconcile(leasedOptions(events, {
@@ -771,6 +826,75 @@ describe('protected leased mutation orchestration', () => {
       recoveryHoldPollMs: 1_000,
     }));
     assert.deepEqual(events.slice(0, 5), ['authorize', 'acquire:1', 'authorize', 'acquire:2', 'build']);
+  });
+
+  it('takes failed-head retry authority from the admitted hold, not the recovery ID', async () => {
+    for (const failedHeadRetryAuthorized of [false, true]) {
+      const events = [];
+      let planningAuthority = null;
+      const control = fakeControl(events, {
+        acquire: async () => ({
+          data: {
+            attempt: { attemptId: 'attempt-1' },
+            leaseCapability: 'lease-capability-abcdefghijklmnopqrstuvwxyz',
+            dispatchHold: {
+              recoveryAttemptId: 'recovery-1',
+              headSha: HEAD,
+              state: 'LEASE_ACQUIRED',
+              linkedAttemptId: 'attempt-1',
+              failedHeadRetryAuthorized,
+            },
+          },
+        }),
+      });
+      await runLeasedReconcile(leasedOptions(events, {
+        control,
+        recoveryAttemptId: 'recovery-1',
+        buildPlan: async ({ retryFailedHead }) => {
+          planningAuthority = retryFailedHead;
+          return { projectId: 'project-1', environmentId: 'environment-1', plans: [] };
+        },
+      }));
+      assert.equal(planningAuthority, failedHeadRetryAuthorized);
+    }
+  });
+
+  it('rejects failed-head retry authority from a mismatched admitted hold', async () => {
+    const mismatches = [
+      { recoveryAttemptId: 'different-recovery' },
+      { headSha: 'f'.repeat(40) },
+      { state: 'RUN_BOUND' },
+      { linkedAttemptId: 'different-attempt' },
+    ];
+    for (const mismatch of mismatches) {
+      const events = [];
+      let planningAuthority = null;
+      const control = fakeControl(events, {
+        acquire: async () => ({
+          data: {
+            attempt: { attemptId: 'attempt-1' },
+            leaseCapability: 'lease-capability-abcdefghijklmnopqrstuvwxyz',
+            dispatchHold: {
+              recoveryAttemptId: 'recovery-1',
+              headSha: HEAD,
+              state: 'LEASE_ACQUIRED',
+              linkedAttemptId: 'attempt-1',
+              failedHeadRetryAuthorized: true,
+              ...mismatch,
+            },
+          },
+        }),
+      });
+      await runLeasedReconcile(leasedOptions(events, {
+        control,
+        recoveryAttemptId: 'recovery-1',
+        buildPlan: async ({ retryFailedHead }) => {
+          planningAuthority = retryFailedHead;
+          return { projectId: 'project-1', environmentId: 'environment-1', plans: [] };
+        },
+      }));
+      assert.equal(planningAuthority, false);
+    }
   });
 
   it('defers definitive lease contention without planning or provider access', async () => {

--- a/tests/railway-deploy-trigger.test.mjs
+++ b/tests/railway-deploy-trigger.test.mjs
@@ -110,6 +110,34 @@ describe('deploy planning', () => {
     assert.equal(result.reason, HANDLED_BY_RAILWAY);
   });
 
+  it('retries a failed head only when protected recovery explicitly authorizes it', () => {
+    const failed = deployment('FAILED', HEAD, {
+      id: 'dep-failed',
+      createdAt: '2026-08-04T12:00:00.000Z',
+    });
+    const result = plan({
+      deployments: [failed, deployment('SUCCESS', RUNNING)],
+      retryFailedHead: true,
+    });
+    assert.equal(result.action, 'deploy');
+    assert.equal(result.reason, 'CLOSURE_CHANGED');
+    assert.equal(result.observedDeploymentId, null);
+  });
+
+  it('does not duplicate active head work during protected recovery', () => {
+    const result = plan({
+      deployments: [
+        deployment('FAILED', HEAD, { id: 'dep-failed', createdAt: '2026-08-04T12:00:00.000Z' }),
+        deployment('BUILDING', HEAD, { id: 'dep-building', createdAt: '2026-08-04T11:59:00.000Z' }),
+        deployment('SUCCESS', RUNNING),
+      ],
+      retryFailedHead: true,
+    });
+    assert.equal(result.action, 'skip');
+    assert.equal(result.reason, HANDLED_BY_RAILWAY);
+    assert.equal(result.observedDeploymentId, 'dep-building');
+  });
+
   it('still deploys when the only record for head is Railway refusing it', () => {
     // This is the whole point: a SKIPPED record means Railway declined, so it
     // must never count as "already taken".

--- a/tests/railway-reconcile-control-resolution.test.mjs
+++ b/tests/railway-reconcile-control-resolution.test.mjs
@@ -198,6 +198,10 @@ describe('protected Railway reconciliation request validation', () => {
     ]) {
       assert.equal(validateRecoveryRequest(request(decision), { now: () => NOW }).decision, decision);
     }
+    assert.doesNotThrow(() => validateRecoveryRequest(request(
+      'authorize_current_main_retry',
+      { approver: 'operator-user' },
+    ), { now: () => NOW }));
 
     const invalid = [
       request('authorize_current_main_retry', { decision: 'clear_barrier' }),
@@ -205,7 +209,6 @@ describe('protected Railway reconciliation request validation', () => {
       request('authorize_current_main_retry', { reason: 'too short' }),
       request('authorize_current_main_retry', { reason: 'unsafe\nreason text' }),
       request('authorize_current_main_retry', { actor: 'bad actor' }),
-      request('authorize_current_main_retry', { approver: 'operator-user' }),
       request('authorize_current_main_retry', { reason: 'Reviewed at https://unsafe.example now.' }),
       request('authorize_current_main_retry', { reason: 'Reviewed secret: leaked-value now.' }),
       request('authorize_current_main_retry', { operatorRunId: 'run-1' }),

--- a/tests/railway-reconcile-manual-recovery-workflow.test.mjs
+++ b/tests/railway-reconcile-manual-recovery-workflow.test.mjs
@@ -41,15 +41,22 @@ describe('Railway reconciliation protected manual recovery workflow', () => {
     }
   });
 
-  it('uses the distinct break-glass environment and treats reviewer identity as an external provisioning gate', () => {
+  it('uses the distinct break-glass secret boundary without a self-review gate', () => {
+    const inputs = workflow.on.workflow_dispatch.inputs;
     assert.equal(workflow.jobs.resolve.environment.name, 'ingestion-acceptance-production-breakglass');
     assert.equal(workflow.jobs.resolve.environment.deployment, false);
-    assert.match(source, /EXTERNAL/);
-    assert.match(source, /PROVISIONING GATE/);
-    assert.match(source, /prevent-self-review/);
-    assert.match(source, /reviewer identity\/evidence/);
-    assert.match(source, /approver input is an audit assertion/);
-    assert.match(source, /not a claim that YAML discovered the live reviewer/);
+    assert.equal(
+      inputs.approver.description,
+      'Delegated operator identity recorded in the immutable recovery audit trail',
+    );
+    assert.match(source, /main-only secret boundary/);
+    assert.match(source, /no required reviewer/);
+    assert.match(source, /self-review adds no independent authorization/);
+    assert.match(source, /exact-main and repeated provider-inactivity proof/);
+    assert.match(source, /controller CAS\/generation checks/);
+    assert.doesNotMatch(source, /EXTERNAL PROVISIONING GATE/);
+    assert.doesNotMatch(source, /prevent-self-review/);
+    assert.doesNotMatch(source, /reviewer identity\/evidence/);
   });
 
   it('rejects non-main dispatches before secrets and checks out exact main for both proof passes', () => {

--- a/tests/railway-reconcile-manual-recovery-workflow.test.mjs
+++ b/tests/railway-reconcile-manual-recovery-workflow.test.mjs
@@ -47,7 +47,7 @@ describe('Railway reconciliation protected manual recovery workflow', () => {
     assert.equal(workflow.jobs.resolve.environment.deployment, false);
     assert.equal(
       inputs.approver.description,
-      'Delegated operator identity recorded in the immutable recovery audit trail',
+      'Operator audit identity; may equal the GitHub actor',
     );
     assert.match(source, /main-only secret boundary/);
     assert.match(source, /no required reviewer/);

--- a/workers/railway-reconcile-control/index.test.mjs
+++ b/workers/railway-reconcile-control/index.test.mjs
@@ -1196,7 +1196,9 @@ test('dispatch holds never age out and require an exact RUN_BOUND recovery to co
     headSha,
   });
   assert.equal(held.status, 201);
-  assert.equal((await responseBody(held)).dispatchHold.state, 'DISPATCH_HELD');
+  const heldData = await responseBody(held);
+  assert.equal(heldData.dispatchHold.state, 'DISPATCH_HELD');
+  assert.equal(heldData.dispatchHold.failedHeadRetryAuthorized, false);
 
   clock.now += 7 * 24 * 60 * 60 * 1000;
   const blocked = await send(control, clock, '/v1/mutation/acquire', 'mutation', {
@@ -1250,6 +1252,7 @@ test('dispatch holds never age out and require an exact RUN_BOUND recovery to co
     runId: '31190000001',
   });
   assert.equal(lease.dispatchHold.state, 'LEASE_ACQUIRED');
+  assert.equal(lease.dispatchHold.failedHeadRetryAuthorized, false);
   assert.equal(lease.dispatchHold.linkedAttemptId, lease.attempt.attemptId);
   assert.equal(lease.attempt.recoveryAttemptId, recoveryAttemptId);
   assert.equal(lease.attempt.runId, '31190000001');
@@ -2127,6 +2130,24 @@ test('operator-authorized retry hold derives source provenance from the operator
   assert.equal(snapshot.dispatchHolds.length, 1);
   assert.equal(snapshot.dispatchHolds[0].sourceRunId, '41181545180');
   assert.equal(snapshot.dispatchHolds[0].sourceRunAttempt, 3);
+  assert.equal(snapshot.dispatchHolds[0].failedHeadRetryAuthorized, true);
+});
+
+test('one-person operator resolution records the same actor and audit identity', async () => {
+  const { clock, control } = makeControl();
+  const headSha = '7'.repeat(40);
+  const lease = await createManualBarrier(control, clock, { headSha });
+  const resolved = await send(control, clock, '/v1/operator/resolve', 'operator', operatorRequest(
+    lease.attempt.attemptId,
+    headSha,
+    'authorize_current_main_retry',
+    { approver: 'oncall-engineer' },
+  ));
+  assert.equal(resolved.status, 200);
+  const snapshot = await responseBody(await getStatus(control, clock));
+  assert.equal(snapshot.currentAttempt.actor, 'oncall-engineer');
+  assert.equal(snapshot.currentAttempt.approver, 'oncall-engineer');
+  assert.equal(snapshot.dispatchHolds[0].failedHeadRetryAuthorized, true);
 });
 
 test('authorized retry carries bounded superseded run lineage through admission and acceptance', async () => {
@@ -2550,16 +2571,13 @@ test('operator resolution rejects superseded attempts and mismatched barriers wi
   assert.equal((await responseBody(mismatchedBarrier)).error.code, 'BARRIER_MISMATCH');
 });
 
-test('operator resolution rejects unsafe decisions, shared approvers, and injectable reasons', async () => {
+test('operator resolution rejects unsafe decisions and injectable reasons', async () => {
   const { clock, control } = makeControl();
   const lease = await createManualBarrier(control, clock, {
     headSha: 'f'.repeat(40),
   });
   const cases = [
     operatorRequest(lease.attempt.attemptId, lease.attempt.headSha, 'resolve_pre_mutation_hold'),
-    operatorRequest(lease.attempt.attemptId, lease.attempt.headSha, 'authorize_current_main_retry', {
-      approver: 'oncall-engineer',
-    }),
     operatorRequest(lease.attempt.attemptId, lease.attempt.headSha, 'authorize_current_main_retry', {
       reason: 'See [proof](https://evil.test) before retry.',
     }),

--- a/workers/railway-reconcile-control/src/index.js
+++ b/workers/railway-reconcile-control/src/index.js
@@ -491,6 +491,7 @@ function publicDispatchHold(hold) {
     boundAt = null,
     admittedAt = null,
     linkedAttemptId = null,
+    failedHeadRetryAuthorized = false,
     reason = null,
     evidenceDigest = null,
     closedAt = null,
@@ -510,6 +511,7 @@ function publicDispatchHold(hold) {
     boundAt,
     admittedAt,
     linkedAttemptId,
+    failedHeadRetryAuthorized,
     reason,
     evidenceDigest,
     closedAt,
@@ -1165,6 +1167,7 @@ async function createDispatchHold(storage, body, now) {
     sourceHeadSha,
     sourceRunId,
     sourceRunAttempt: body.sourceRunAttempt,
+    failedHeadRetryAuthorized: false,
     supersededRuns: [],
   };
   meta.activeDispatchHoldIds.push(recoveryAttemptId);
@@ -1359,7 +1362,6 @@ async function resolveOperator(storage, body, now, randomUuid) {
   if (!OPERATOR_DECISIONS.has(body.decision)) reject(400, 'INVALID_OPERATOR_DECISION');
   const actor = requireIdentifier(body.actor, 'INVALID_ACTOR_ID');
   const approver = requireIdentifier(body.approver, 'INVALID_APPROVER_ID');
-  if (actor === approver) reject(400, 'OPERATOR_APPROVER_MUST_DIFFER');
   const reason = requireOperatorReason(body.reason);
   const evidenceDigest = requireDigest(body.evidenceDigest, 'INVALID_EVIDENCE_DIGEST');
   const intentDigest = body.intentDigest === null
@@ -1592,6 +1594,7 @@ async function resolveOperator(storage, body, now, randomUuid) {
       sourceHeadSha: expectedHead,
       sourceRunId: operatorRunId,
       sourceRunAttempt: body.operatorRunAttempt,
+      failedHeadRetryAuthorized: true,
       supersededRuns,
     };
     meta.activeDispatchHoldIds.push(attemptId);


### PR DESCRIPTION
## Summary

Railway recovery no longer asks the sole operator to approve their own GitHub deployment, and an operator-authorized retry now replaces a failed current-head Railway build. The first live no-review retry proved that the approval pause was gone, but it also exposed the remaining defect: run `31690025192` ended `NO_MUTATION` after adopting failed deployment `ba338994-e6b6-4edd-b1e7-63832b8bf60b`.

The main-only environment remains the isolated secret boundary. Failed-build retry authority now comes from an immutable controller capability created only by the protected operator flow; ordinary runs and automatic watchdog holds cannot use it. Recovery still adopts active same-head work or a newer running replacement, and it fails closed if the admitted hold does not match the exact recovery ID, head, and leased attempt.

The live environment's required-reviewer rule was removed while its exact `main` deployment-branch policy was retained. A real two-person approval gate can be restored later only when a second operator exists.

Related: #6524

## Validation

- Live recovery run `31690025192` started without a pending-deployment approval.
- Railway recovery and control-plane suite: 280 tests passed.
- API typecheck and Convex string-call audit passed.
- Full repository pre-push gate passed, including frontend/API typechecks, 103 change-scoped tests, Markdown lint, Unicode safety, and version sync.

## Rollout

Deploy the updated reconcile-control Worker before the next manual retry. Then run one `authorize_current_main_retry` recovery and require a new deployment ID plus terminal verifier acceptance; do not treat a green GitHub wrapper alone as production acceptance.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
