### PR TITLE
fix(csp-filter): suppress the Google Fonts /l/font subsetting endpoint

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -288,6 +288,13 @@ function shouldSuppressCspViolation(
     try {
       const url = new URL(blockedURI);
       if (url.protocol === 'https:' && url.hostname === 'fonts.gstatic.com' && /^\/s\/.+/.test(url.pathname) && fontFile.test(url.pathname)) return true;
+      // ---- Round 7. The /l/font?kit=... SUBSETTING endpoint — Google-injected
+      // stylesheets (Translate-class) request text-subsetted faces from it.
+      // Extensionless and outside /s/, so the rule above cannot match it; it
+      // regressed the issue with a single event on 2026-08-13T14:00Z after
+      // round 6 had drained every other host to zero. Exact path (not a /l/
+      // prefix) on the same pinned host; https: only, like every rule here.
+      if (url.protocol === 'https:' && url.hostname === 'fonts.gstatic.com' && url.pathname === '/l/font') return true;
       // Perplexity's Comet browser / extension injects its own UI webfont
       // (frontend-cdn.perplexity.ai/_agi_assets/fonts/*.woff2) into every page.
       // We never load it; the block is the overlay's font failing regardless of

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -242,6 +242,29 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://fonts.gstatic.com/x/a/b.woff2', '', false));
     });
 
+    it('suppresses the Google Fonts /l/font subsetting endpoint (TR round 7)', () => {
+      // Verbatim from the 2026-08-13T14:00Z regression event: Google-injected
+      // stylesheets (Translate-class) request SUBSETTED faces from the
+      // extensionless /l/font?kit=... endpoint, which the /s/-prefixed,
+      // extension-tested rule above cannot match.
+      assert.ok(suppress('enforce', 'font-src',
+        'https://fonts.gstatic.com/l/font?kit=1PtFg83HX_SGhgqO0yLcmjzUAuWexRNRo6uH6mSinjBIwc7EJTFEoAQw3Q&skey=9f5b077cc22e75c7&v=v18', '', false));
+    });
+
+    it('does NOT suppress the /l/font path on a lookalike host', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.gstatic.com.evil.com/l/font?kit=abc', '', false));
+    });
+
+    it('does NOT suppress other /l/* paths on fonts.gstatic.com', () => {
+      // Pins the exact-path conjunct: the rule is the /l/font endpoint, not a
+      // /l/ prefix.
+      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.gstatic.com/l/other?kit=abc', '', false));
+    });
+
+    it('does NOT suppress http: on the /l/font endpoint', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'http://fonts.gstatic.com/l/font?kit=abc', '', false));
+    });
+
     it('does NOT suppress http: font-src on the injected-webfont hosts', () => {
       // Pins the `url.protocol === 'https:'` conjunct the new rules share; the
       // other new negatives only cover lookalike host and non-font path.


### PR DESCRIPTION
## Summary

WORLDMONITOR-TR (the 357k-event CSP font-src issue) regressed today on a **single event**: `fonts.gstatic.com/l/font?kit=…` blocked on the finance dashboard at 14:00Z. The regression is real but tiny — round 6 (unpkg + jsDelivr, merged 08-10) drained every previously-ruled host to zero, and the recent event tail (80/day on 08-09 → 1 today) was stale-bundle drain, verified per host against rule deploy times. The one live escape: Google Fonts' **extensionless `/l/font?kit=` subsetting endpoint** (Google-Translate-class injected stylesheets request text-subsetted faces from it), which the existing `fonts.gstatic.com` rule cannot match — that rule pins the `/s/` path *and* a font-file extension, and `/l/font` has neither.

These CSP events are our own `securitypolicyviolation` → `captureMessage` pipeline (`src/main.ts:518`), so the fix belongs in `shouldSuppressCspViolation`, not Sentry-side: one exact-path rule on the already-pinned host (`/l/font` only — not a `/l/` prefix), https:-only like every rule in the block. Worth knowing: the Sentry project's CSP source-ignore option (`sentry:csp_ignored_sources`) is empty and would have been a **no-op** here anyway — it filters native `report-uri` security reports, and this project's CSP ships no `report-uri`; everything arrives through the SDK.

Red-first: the verbatim regression URL as a fixture (failed before the rule), plus three counter-tests pinning the lookalike host, the exact-path conjunct (`/l/other` still surfaces), and the https: conjunct. `tests/csp-filter.test.mjs` 146/146; `tsc` clean. CSP enforcement is untouched — the injected font stays blocked; we only stop reporting it.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_01AmZoei2dAPDptqMqX9Vrpx
