### PR TITLE
fix(seeders): seed-bundle-resilience defers every section forever — #6531's budget is below every section's timeout+grace

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -516,6 +516,69 @@ missing number, and they justify very different scores. A country nobody
 surveys must not be scored like a country where the thing being measured
 verifiably does not happen.
 
+## Seed Bundle Orchestration
+
+### Bundle Wall Budget
+
+The total wall-clock time one bundle tick may occupy, chosen to sit below the
+container's hard kill so a member is shed cleanly instead of being killed
+mid-publish.
+
+The budget only shapes anything while it stays under that kill; at or above it
+the container dies first and the budget is decorative. Every member must fit the
+budget outright — a member whose worst case cannot fit is not under pressure, it
+can never run at all, which is a configuration error rather than load.
+
+### Section Worst Case
+
+The longest wall-clock a member can occupy: its own timeout plus the grace the
+runner allows between asking a child to stop and forcing it.
+
+Distinct from expected runtime, which is usually far smaller. Admission is
+decided on the worst case, so an over-declared timeout costs the bundle budget
+the member will never actually spend.
+
+### Admission Headroom
+
+Slack reserved above a member's worst case to cover the work the runner itself
+performs before it admits anything.
+
+Load-bearing rather than defensive: the runner's freshness checks run before the
+budget test, so the budget is already partly spent when the first member is
+considered. Deriving this from the runner's own per-check bound, rather than
+choosing a number, is what keeps the admission rule and the runtime rule from
+drifting apart — when they drift, the admission rule accepts a band of
+configurations the runtime rejects on every tick.
+
+### Section Deferral
+
+A due member skipped for lack of remaining budget on this tick, expected to run
+on a later one.
+
+Deferral is load-shedding, not failure — but it only pays for itself if the
+member eventually runs. A member deferred on every tick is a stall wearing
+deferral's clothing, and telling those two apart is the whole reason this
+vocabulary exists.
+
+### Graceful Skip
+
+A member that hit a transient upstream failure, extended its last-good data
+instead of publishing, and lost nothing.
+
+It must not crash the bundle: one rate-limited source firing a deploy-crash
+alert is the alert fatigue that makes the alarm worthless. Real staleness is
+caught by freshness monitoring on the published data, never by the tick's exit
+status.
+
+### Starved Tick
+
+A tick that completed no member while deferring due work — it published nothing
+and shed work at the same time.
+
+Indistinguishable from a healthy no-op by exit status alone, which is why it is
+named and reported explicitly. A tick where every member was merely fresh is a
+healthy no-op and must not be confused with it.
+
 ## Flagged ambiguities
 
 - *"Pool"* had been used for both a labelled market category and the complete set of markets — these are distinct. A pool is always a labelled subset; the complete set has no pool and must be requested as an explicit union.

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -815,6 +815,8 @@ pre-seed evidence under the health-probe cutover contract.
 | **Replaces** | 2 services |
 | **Net savings** | 1 slot |
 | **Members** | Resilience Scores (6h), Resilience Static (annual window Oct 1-3, skips most runs), Food Stocks (monthly USDA PSD + FAOSTAT fill; needs `USDA_FAS_PSD_API_KEY`) |
+| **Wall budget** | 570 seconds, below Railway's 10-minute container kill. Section timeouts are 240s / 420s / 480s, so each fits the budget once the runner's 10s kill grace is added. Resilience Scores stays first in the array: it is the member that keeps `resilience:ranking:v27` and `resilience:intervals:v10:*` alive between cron fires, so it must be offered the budget before the heavier annual and monthly members. |
+| **Do not** | raise any section timeout above `maxBundleMs - 10_000`. A section whose timeout plus kill grace exceeds the budget is deferred on **every** tick while the bundle still exits 0 — #6556 ran this service dead for six hours behind a green badge. `tests/bundle-budget-admission.test.mjs` fails the PR, and `runBundle` refuses to start, but the arithmetic is worth knowing before you edit. |
 
 ### Bundle 5: seed-bundle-derived-signals
 

--- a/docs/solutions/logic-errors/an-admission-guard-that-ignores-prior-runtime-cost-repeats-the-bug-it-guards.md
+++ b/docs/solutions/logic-errors/an-admission-guard-that-ignores-prior-runtime-cost-repeats-the-bug-it-guards.md
@@ -171,6 +171,31 @@ This shape has nothing to do with Railway or seed bundles. It appears wherever a
 - An anti-vacuity check must use a different token from the extractor it checks. Two counts derived from one regex agree with each other in exactly the case where both are blind (`tests/helpers/bundle-section-parser.mjs:168` vs `:177`).
 - A static parser that can return a *wrong* number is worse than one that returns none, because a wrong smaller timeout is one a budget gate happily passes. `extractBundleSections` drops any section using a nested, shorthand, or spread `timeoutMs` (`tests/helpers/bundle-section-parser.mjs:242-245`), and the caller's independent `script:` count then fails loudly on the dropped section.
 
+## This is the third fix to the same exit-code contract
+
+The durable signal is the recurrence, not any one bug. Three separate
+corrections have now landed on `_bundle-runner.mjs`'s answer to "did real work
+happen?", each a different mechanism reaching the same wrong exit code:
+
+- **#5077 / #5078** — a member's graceful exit-75 was counted in the same
+  `failed` tally as a hard crash, so one transient upstream blip crashed the
+  whole bundle. Fixed by splitting `gracefulFailed` out so only hard failures
+  gate the exit code. That fix has no entry here; it survives only as a note.
+- **#6483** — a different mechanism (a stale image, because the build was
+  skipped) with the same shape: the service was wrong for ~24 hours and the only
+  detector was a downstream staleness alarm.
+- **#6556** — this one. Admission arithmetic made every member permanently
+  unadmittable and the bundle reported success forever.
+
+Two things follow. First, treat any change to this file's exit-code switch as
+high-risk by default and enumerate the states that deliberately do *not* alarm,
+asking what else lands in that bucket — that question is what found the
+`ran:0 deferred:>0` hole. Second, the fixes compose and must be checked against
+each other rather than in isolation: the `starvedTick` exit added here would
+have re-broken #5077 if it had fired on a graceful-only tick, which is why it
+carries `gracefulFailed === 0` and why a test asserts the graceful exemption
+still holds.
+
 ## Related Issues
 
 - Issue #6556 — P1, the silent stall (fix in PR #6564, branch `fix/6556-bundle-budget-admission`).

--- a/docs/solutions/logic-errors/an-admission-guard-that-ignores-prior-runtime-cost-repeats-the-bug-it-guards.md
+++ b/docs/solutions/logic-errors/an-admission-guard-that-ignores-prior-runtime-cost-repeats-the-bug-it-guards.md
@@ -1,0 +1,187 @@
+---
+module: seed-bundle-runner
+date: 2026-08-13
+problem_type: logic_error
+component: background_job
+severity: critical
+symptoms:
+  - Railway paints `seed-bundle-resilience` SUCCESS every tick while every section is deferred and nothing publishes
+  - The startup admission guard passes a section sized at exactly `maxBundleMs - KILL_GRACE_MS`, which the runtime check then rejects on every tick
+  - "`findUnadmittableSections([{timeoutMs: 560_000}], 570_000)` returns `[]` even though the section can never be admitted"
+  - A seed-meta staleness alarm is the only signal that surfaces six hours of silent non-publication, ~14h after the fact
+root_cause: logic_error
+resolution_type: code_fix
+related_components: [tooling, testing_framework]
+tags: [green-while-dead, admission-gate, budget-headroom, runtime-cost-blind-spot, railway-cron, static-config-gate, silent-pass, seed-bundle-runner]
+---
+
+# A static admission gate that ignores the runtime's own pre-consumption admits configurations that can never run
+
+## Problem
+
+`scripts/_bundle-runner.mjs` gives Railway cron bundles an optional wall-time budget. A section is admitted only when its worst case still fits the budget that is left:
+
+```js
+// scripts/_bundle-runner.mjs:413-425
+const elapsedBundle = Date.now() - t0;
+const worstCase = sectionWorstCaseMs(section);
+if (elapsedBundle + worstCase > maxBundleMs) { /* deferred */ }
+```
+
+Worst case is `timeoutMs + KILL_GRACE_MS`, and `KILL_GRACE_MS` is `10_000` (`scripts/_bundle-runner.mjs:130`, `scripts/_bundle-runner.mjs:137-139`).
+
+PR #6531 shipped `seed-bundle-resilience` with `maxBundleMs: 570_000` against sections declared at `600_000`, `900_000` and `600_000`. The cheapest section therefore needed `610_000`ms of a `570_000`ms budget. No section could be admitted on any tick, ever.
+
+Deferral is load-shedding, not failure. It was counted in no exit path, so the bundle exited 0 on every tick, Railway painted SUCCESS, and the service published nothing for six hours (issue #6556). The first alarm was seed-meta staleness at `maxStaleMin: 840`, about fourteen hours after the service stopped working.
+
+## Symptoms
+
+- Production log of the active deployment, in full, on every cron tick:
+
+  ```
+  [Bundle:resilience] Starting (3 sections, budget 570s)
+    [Resilience-Scores] Deferred, needs 610s (timeout+grace) but only 570s left in bundle budget
+    [Resilience-Static] Skipped, last seeded 64442min ago (interval: 129600min)
+    [Food-Stocks] Deferred, needs 610s (timeout+grace) but only 570s left in bundle budget
+  [Bundle:resilience] Finished in 0.1s, ran:0 skipped:1 deferred:2 failed:0 graceful:0
+  ```
+
+  Exit code 0. Railway badge green. `diagnose-railway-seeders` reported `HEALTHY — Currently green; last run clean`.
+- `Finished in 0.1s` for a bundle whose one due member normally takes 5.7s of real work. The tick was over before it began.
+- No Redis write: `seed-meta:resilience:scores` stayed at `2026-08-13T06:01:55Z`, the last tick on the previous image.
+- The section being starved for a 610s window measures ~5.7s warm and 1-2 min cold. The declared timeout was two orders of magnitude above the real cost, which is what made it unadmittable.
+- Nothing detected it for six hours. Detection finally came from key expiry (`resilience:ranking:v27`, 12h TTL), not from the service.
+
+## What Didn't Work
+
+The first fix in PR #6564 added a startup guard so a section that cannot fit the whole budget is rejected before anything spawns, instead of being deferred forever in silence. The predicate was:
+
+```js
+// first attempt
+export function findUnadmittableSections(sections, maxBundleMs) {
+  if (!Number.isFinite(maxBundleMs)) return [];
+  return sections.filter((section) => sectionWorstCaseMs(section) > maxBundleMs);
+}
+```
+
+That guard carries the same defect it was written to catch. Put the two inequalities side by side:
+
+| | Test | Admits |
+|---|---|---|
+| Static gate (startup) | `worstCase > maxBundleMs` rejects | `timeoutMs <= maxBundleMs - KILL_GRACE_MS` |
+| Runtime check (per section) | `elapsed + worstCase > maxBundleMs` defers | `timeoutMs <= maxBundleMs - KILL_GRACE_MS - elapsed` |
+
+The two boundaries differ by `elapsed`, and `elapsed` is never zero. The freshness gate runs before the budget check, in the same loop body: `readSectionFreshness` at `scripts/_bundle-runner.mjs:401`, the budget test at `scripts/_bundle-runner.mjs:419`. That gate makes up to three Redis reads per section — `canonicalKey` (`scripts/_bundle-runner.mjs:87`), `freshnessMetaKey` (`scripts/_bundle-runner.mjs:89`), `completionMetaKey` (`scripts/_bundle-runner.mjs:93`) — each one bounded by `REDIS_READ_TIMEOUT_MS` (`scripts/_bundle-runner.mjs:55`, applied at `scripts/_bundle-runner.mjs:62`).
+
+So a section sized at exactly `maxBundleMs - KILL_GRACE_MS` passed the new startup guard and was still deferred on every tick, forever, exiting 0 — #6556 surviving its own fix. Against the real config, the guard admitted every `timeoutMs` up to `560_000` for a `570_000` budget, while the runtime admitted none of them.
+
+Three independent reviewers found this, one from a different model family that verified it by execution rather than by reading: `findUnadmittableSections([{ timeoutMs: 560_000 }], 570_000)` returned `[]`.
+
+The issue itself prescribed the same wrong threshold. Acceptance criterion 3 of #6556 reads "for each section, `timeoutMs + KILL_GRACE_MS <= maxBundleMs`". The first fix implemented the stated criterion faithfully, and the criterion was the bug.
+
+Two smaller versions of the same silent-pass shape were fixed in the same round:
+
+- The repo-wide gate's anti-vacuity check compared `extractBundleSections(...).length` against a count derived from the *same* regex. It only proved the extractor agreed with itself: a section the anchor cannot see is absent from both counts, the equality holds, and the gate passes on a bundle it never read. It now counts `script:` with a deliberately different token (`tests/helpers/bundle-section-parser.mjs:177`, asserted at `tests/bundle-budget-admission.test.mjs:128-133`).
+- `starvedTick` first fired on `ran:0 && deferred > 0` alone. That paged on a benign upstream 429: the only admitted section exits 75, the last-good TTL is extended, no data is lost, yet Railway prints "Deploy Crashed!". It is narrowed with `gracefulFailed === 0` at `scripts/_bundle-runner.mjs:478`.
+
+## Solution
+
+Derive an explicit headroom constant from the runner's own pre-admission cost, and use the same constant in the runner and in the CI gate.
+
+Before:
+
+```js
+export function findUnadmittableSections(sections, maxBundleMs) {
+  if (!Number.isFinite(maxBundleMs)) return [];
+  return sections.filter((section) => sectionWorstCaseMs(section) > maxBundleMs);
+}
+```
+
+After (`scripts/_bundle-runner.mjs:154-167`):
+
+```js
+export const REDIS_READ_TIMEOUT_MS = 5_000;                 // scripts/_bundle-runner.mjs:55
+export const ADMISSION_HEADROOM_MS = 3 * REDIS_READ_TIMEOUT_MS;
+
+export function findUnadmittableSections(sections, maxBundleMs) {
+  if (!Number.isFinite(maxBundleMs)) return [];
+  return sections.filter(
+    (section) => sectionWorstCaseMs(section) + ADMISSION_HEADROOM_MS > maxBundleMs,
+  );
+}
+```
+
+The `3 *` is not a taste call: it is the number of Redis reads `readSectionFreshness` can make before a section reaches the budget test (`scripts/_bundle-runner.mjs:83-98`). `REDIS_READ_TIMEOUT_MS` is the same constant the `AbortSignal` uses, so the headroom cannot drift away from the cost it stands for.
+
+`runBundle` throws on a violating config before spawning anything, and names the remedy (`scripts/_bundle-runner.mjs:367-380`):
+
+```js
+const unadmittable = findUnadmittableSections(sections, maxBundleMs);
+if (unadmittable.length > 0) {
+  const largestFittingTimeoutMs = maxBundleMs - KILL_GRACE_MS - ADMISSION_HEADROOM_MS;
+  throw new Error(/* ... 'NEVER' needs 585000ms (timeoutMs 560000 + 10000ms kill grace + 15000ms admission headroom) ... */);
+}
+```
+
+Three further changes close the routes around it:
+
+1. A declared-but-unusable budget throws instead of reading as "no budget" (`scripts/_bundle-runner.mjs:351-356`). Every guard is gated on `Number.isFinite(maxBundleMs)`, so `maxBundleMs: '570000'` or a `NaN` from `Number(process.env.X)` would disable the startup check *and* the per-tick deferral — the same outage by a different route.
+2. A tick that admitted nothing while deferring due work exits non-zero (`scripts/_bundle-runner.mjs:478-490`). `ran:0 deferred:>0` is otherwise indistinguishable from a healthy no-op in Railway's badge, which is what hid #6556 for six hours.
+3. The section timeouts were right-sized to measured runtime, with the measurement written down next to each number (`scripts/seed-bundle-resilience.mjs:31`, `:35`, `:40`): `240_000` / `420_000` / `480_000` against `maxBundleMs: 570_000` (`scripts/seed-bundle-resilience.mjs:48`). The cheapest now needs `265_000`ms of `570_000`ms. The file also records why a timeout above Railway's 10-minute cap never bounded anything: the container is SIGKILLed first, taking the logs with it (`scripts/seed-bundle-resilience.mjs:12-18`).
+
+`tests/bundle-budget-admission.test.mjs` is the repo-wide tripwire. It parses every `scripts/seed-bundle-*.mjs` statically and applies the runner's own threshold, headroom included (`tests/bundle-budget-admission.test.mjs:184`):
+
+```js
+if (section.worstCaseMs + ADMISSION_HEADROOM_MS <= bundle.maxBundleMs) continue;
+```
+
+It calls `sectionWorstCaseMs` from the runner rather than restating `timeoutMs + KILL_GRACE_MS` (`tests/bundle-budget-admission.test.mjs:147-150`), and it also asserts each budget is below Railway's 600_000ms container cap (`tests/bundle-budget-admission.test.mjs:109-113`) — nothing checked that, so a 900_000 budget satisfied every per-section assertion while the container still died mid-publish. All six budgeted bundles pass (3/3 tests green, 246ms).
+
+## Why This Works
+
+A budget is spent by more than the thing being budgeted. The runtime check consumes the budget *incrementally* — `elapsed` grows across the loop, and it is already non-zero at the first section because the freshness gate ran first. A static gate that compares only the item's own cost against the total is answering a different question from the one the runtime asks. The gate's answer is optimistic by exactly the amount the runtime consumes before it asks.
+
+The general form: **any static gate over a budget that a runtime check consumes incrementally must reserve the runtime's own pre-consumption, or it admits a band of values the runtime rejects.** The width of that false-admit band is the pre-consumption. Here it was `elapsed`, up to 15s of Redis reads, and every `timeoutMs` in `(545_000, 560_000]` sat inside it.
+
+The reservation must be *derived*, not chosen. `ADMISSION_HEADROOM_MS = 3 * REDIS_READ_TIMEOUT_MS` is written in terms of the consumer's own constant and the consumer's own read count. If someone raises the Redis timeout, the headroom moves with it and the gate stays honest. A magic `15_000` would have been correct on the day it was written and silently wrong afterwards — a second copy of the same class of drift that produced the original bug, where `maxBundleMs` was picked without reference to `KILL_GRACE_MS`.
+
+Deriving it also makes the gate and the runner share one source of truth. `findUnadmittableSections` is exported and used by both the runner (`scripts/_bundle-runner.mjs:367`) and CI (`tests/bundle-budget-admission.test.mjs:184` uses the same exported constants), so the static threshold and the runtime threshold cannot disagree about which sections are admittable.
+
+## Prevention
+
+**The diagnostic.** When a static gate and a runtime check test the same budget, write both inequalities down side by side and solve each for the boundary value:
+
+```
+gate    admits  x  <=  B - c1
+runtime admits  x  <=  B - c1 - c2      (c2 = whatever the runtime spent first)
+```
+
+If the gate's boundary is a value the runtime rejects, the gate is lying, and the size of the lie is `c2`. Then ask the question that finds `c2`: **what has already run by the time the runtime check executes?** Read the code path from the top of the loop body to the check itself, not just the check. In this case three lines separated the freshness gate from the budget test, and those three lines were the entire bug.
+
+This shape has nothing to do with Railway or seed bundles. It appears wherever a config-time validator and a request-time enforcer share a limit: an upload size validated against `maxBodyBytes` while the server has already buffered headers; a retry budget checked against a deadline that the connect phase already consumed; a queue admission test against a memory cap that ignores per-worker overhead; a rate limiter that validates a configured burst against a window the handler has already partly spent.
+
+**The test shape.** Pin *both* boundary directions. A gate that rejects everything passes a one-sided rejection test for entirely the wrong reason, and so does a gate that admits everything on the acceptance test:
+
+- `tests/bundle-runner.test.mjs:694-713` — a section at exactly `maxBundleMs - KILL_GRACE_MS` (50s timeout, 60s budget) must be rejected at startup, with the fixture asserting `must-not-run` never appears in output.
+- `tests/bundle-runner.test.mjs:715-731` — a section with headroom to spare (34s timeout, 60s budget: 34 + 10 + 15 = 59) must be admitted and must actually run. This is the assertion that proves the rejection above is arithmetic rather than blanket refusal.
+
+**Three more habits this round earned:**
+
+- Do not implement a stated acceptance criterion without checking its arithmetic. #6556's criterion 3 encoded the same off-by-`elapsed` error, and a faithful implementation reproduced the bug.
+- An anti-vacuity check must use a different token from the extractor it checks. Two counts derived from one regex agree with each other in exactly the case where both are blind (`tests/helpers/bundle-section-parser.mjs:168` vs `:177`).
+- A static parser that can return a *wrong* number is worse than one that returns none, because a wrong smaller timeout is one a budget gate happily passes. `extractBundleSections` drops any section using a nested, shorthand, or spread `timeoutMs` (`tests/helpers/bundle-section-parser.mjs:242-245`), and the caller's independent `script:` count then fails loudly on the dropped section.
+
+## Related Issues
+
+- Issue #6556 — P1, the silent stall (fix in PR #6564, branch `fix/6556-bundle-budget-admission`).
+- PR #6531 — introduced `maxBundleMs: 570_000` alongside the `Food-Stocks` section.
+- `docs/railway-seed-consolidation-runbook.md` — now records the resilience bundle's wall budget, the per-section values, and the ceiling a new timeout must respect.
+
+## Related Learnings
+
+- `docs/solutions/design-patterns/primary-fallback-inversion-budget-transfer.md` — closest mechanical sibling: time-budget arithmetic that ignores the real shared clock, in a different system.
+- `docs/solutions/logic-errors/a-check-gate-that-rebuilt-its-expectation-from-the-artifact-it-was-checking.md` — same "gate reports green while broken" family, different root cause (circular self-reference rather than a missing term).
+- `docs/solutions/logic-errors/pre-push-green-tree-cache-attested-a-tree-the-gates-never-ran.md` — same family: an automation reports success over work it never performed.
+- `docs/solutions/conventions/verify-the-verifier-mutation-test-every-detection-layer.md` — the repo convention this round exercised: every guard written to catch something must be mutation-tested until it goes red.
+- `docs/solutions/integration-issues/merged-is-not-ran-long-cron-seeders.md` — same infrastructure area and the same detection gap: only a staleness alarm catches it.
+- Issue #6562 — follow-ups deliberately scoped out of the fix (unmeasured `Resilience-Static` timeout, its orphaned lock on SIGTERM, the unbounded laggard phase, and per-section starvation while the bundle still reports success).

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -49,12 +49,17 @@ loadEnvFile(import.meta.url);
 const REDIS_URL = process.env.UPSTASH_REDIS_REST_URL;
 const REDIS_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
 
+// Per-read bound on the freshness gate's Redis lookups. Exported because the
+// admission headroom below is derived from it: those reads run BEFORE a section
+// can be admitted, so they are budget the section will never get.
+export const REDIS_READ_TIMEOUT_MS = 5_000;
+
 async function readRedisKey(key) {
   if (!REDIS_URL || !REDIS_TOKEN) return null;
   try {
     const resp = await fetch(`${REDIS_URL}/get/${encodeURIComponent(key)}`, {
       headers: { Authorization: `Bearer ${REDIS_TOKEN}` },
-      signal: AbortSignal.timeout(5_000),
+      signal: AbortSignal.timeout(REDIS_READ_TIMEOUT_MS),
     });
     if (!resp.ok) return null;
     const body = await resp.json();
@@ -134,14 +139,31 @@ export function sectionWorstCaseMs(section) {
 }
 
 /**
- * Sections that can never be admitted, whatever else the tick does. The
- * admission test in runBundle is `elapsed + worstCase <= maxBundleMs`, so a
- * section whose worst case alone exceeds the budget fails it even as the
- * first section of an otherwise empty tick. Returns [] when unbudgeted.
+ * Slack a section must leave on top of its own worst case to be admittable in
+ * practice. The runtime test is `elapsed + worstCase <= maxBundleMs` and
+ * `elapsed` is never 0: before the first section is admitted the runner has
+ * already run its freshness gate, which makes up to three Redis reads
+ * (canonicalKey, freshnessMetaKey, completionMetaKey), each bounded by
+ * REDIS_READ_TIMEOUT_MS.
+ *
+ * Without this, a section sized at exactly maxBundleMs - KILL_GRACE_MS passes a
+ * naive `worstCase > maxBundleMs` check and is still deferred on every tick
+ * forever — #6556 surviving its own fix. Sizing the headroom off the read
+ * timeout keeps the two numbers linked instead of drifting apart.
+ */
+export const ADMISSION_HEADROOM_MS = 3 * REDIS_READ_TIMEOUT_MS;
+
+/**
+ * Sections that can never be admitted, whatever else the tick does. A section
+ * whose worst case plus ADMISSION_HEADROOM_MS exceeds the budget fails the
+ * runtime admission test even as the first section of an otherwise empty tick.
+ * Returns [] when unbudgeted.
  */
 export function findUnadmittableSections(sections, maxBundleMs) {
   if (!Number.isFinite(maxBundleMs)) return [];
-  return sections.filter((section) => sectionWorstCaseMs(section) > maxBundleMs);
+  return sections.filter(
+    (section) => sectionWorstCaseMs(section) + ADMISSION_HEADROOM_MS > maxBundleMs,
+  );
 }
 
 function streamLines(stream, onLine) {
@@ -321,6 +343,18 @@ export async function runBundle(label, sections, opts = {}) {
 
   const maxBundleMs = opts.maxBundleMs ?? Infinity;
 
+  // A declared-but-unusable budget must not read as "no budget". Every guard
+  // below is gated on Number.isFinite(maxBundleMs), so `maxBundleMs: '570000'`
+  // or a NaN from `Number(process.env.X)` would silently disable the admission
+  // check AND the per-tick deferral, restoring the exact #6556 shape by a
+  // different route. Only an omitted budget means unbudgeted.
+  if (opts.maxBundleMs != null && !(Number.isFinite(maxBundleMs) && maxBundleMs > 0)) {
+    throw new Error(
+      `[Bundle:${label}] maxBundleMs must be a positive finite number, got ${JSON.stringify(opts.maxBundleMs)}. `
+      + 'Omit the option entirely for an unbudgeted bundle.',
+    );
+  }
+
   // Admission arithmetic assertion. The per-tick budget check below defers a
   // section whose worst case does not fit the REMAINING budget — a load-shed
   // that assumes the section fits the budget at all. When it does not, the
@@ -333,11 +367,15 @@ export async function runBundle(label, sections, opts = {}) {
   const unadmittable = findUnadmittableSections(sections, maxBundleMs);
   if (unadmittable.length > 0) {
     const detail = unadmittable
-      .map((s) => `'${s.label}' needs ${sectionWorstCaseMs(s)}ms (timeoutMs ${s.timeoutMs || DEFAULT_SECTION_TIMEOUT_MS} + ${KILL_GRACE_MS}ms kill grace)`)
+      .map((s) => `'${s.label}' needs ${sectionWorstCaseMs(s) + ADMISSION_HEADROOM_MS}ms (timeoutMs ${s.timeoutMs || DEFAULT_SECTION_TIMEOUT_MS} + ${KILL_GRACE_MS}ms kill grace + ${ADMISSION_HEADROOM_MS}ms admission headroom)`)
       .join('; ');
+    const largestFittingTimeoutMs = maxBundleMs - KILL_GRACE_MS - ADMISSION_HEADROOM_MS;
+    const remedy = largestFittingTimeoutMs > 0
+      ? `Lower those section timeouts to at most ${largestFittingTimeoutMs}ms, or raise maxBundleMs (it must stay under the Railway container cap).`
+      : `No section timeout can fit this budget at all — ${KILL_GRACE_MS}ms kill grace plus ${ADMISSION_HEADROOM_MS}ms admission headroom already exceed it. Raise maxBundleMs (it must stay under the Railway container cap).`;
     throw new Error(
       `[Bundle:${label}] maxBundleMs=${maxBundleMs} is below the worst case of ${unadmittable.length} section(s), which can therefore never be admitted on any tick: ${detail}. `
-      + 'Lower those section timeouts, or raise maxBundleMs (it must stay under the Railway container cap).',
+      + remedy,
     );
   }
 
@@ -431,7 +469,13 @@ export async function runBundle(label, sections, opts = {}) {
   // section runs on a later tick, so this state repeating is a stalled
   // service — the shape that made #6556 invisible for six hours. Report it as
   // a failure; `ran:0 deferred:0` (everything fresh) stays a healthy no-op.
-  const starvedTick = ran === 0 && deferred > 0;
+  // `gracefulFailed === 0` is load-bearing: a tick whose only admitted section
+  // hit a transient upstream blip (child exit 75, last-good TTL extended, no
+  // data lost) already has an exit-0 exemption precisely so one flaky source
+  // does not fire "Deploy Crashed!". Without this clause a benign 429 that
+  // happened to also push a sibling past the budget would page — alert fatigue
+  // on the exact alarm this change exists to make trustworthy.
+  const starvedTick = ran === 0 && deferred > 0 && gracefulFailed === 0;
   if (starvedTick) {
     console.error(
       `[Bundle:${label}] ran:0 while ${deferred} due section(s) were deferred — this tick published nothing and shed work. `

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -364,7 +364,20 @@ export async function runBundle(label, sections, opts = {}) {
   // badge. Throw instead, alongside the dependsOn contract above, so the
   // misconfiguration surfaces on the first tick rather than as data ageing
   // out half a day later.
-  const unadmittable = findUnadmittableSections(sections, maxBundleMs);
+  //
+  // Sections already failing the requiredEnv gate are excluded. They cannot run
+  // this tick regardless of their timeout, so throwing on their arithmetic
+  // would take the bundle's HEALTHY members down as collateral during an
+  // environment outage — the per-section CONFIG_ERROR path deliberately fails
+  // only the affected section. Nothing is hidden by deferring the question:
+  // tests/bundle-budget-admission.test.mjs checks every section's arithmetic
+  // statically, with no knowledge of the environment, so an oversized timeout
+  // still cannot reach production behind a missing secret.
+  const envGated = new Set(missingEnvBySection.keys());
+  const unadmittable = findUnadmittableSections(
+    sections.filter((section) => !envGated.has(section.label)),
+    maxBundleMs,
+  );
   if (unadmittable.length > 0) {
     const detail = unadmittable
       .map((s) => `'${s.label}' needs ${sectionWorstCaseMs(s) + ADMISSION_HEADROOM_MS}ms (timeoutMs ${s.timeoutMs || DEFAULT_SECTION_TIMEOUT_MS} + ${KILL_GRACE_MS}ms kill grace + ${ADMISSION_HEADROOM_MS}ms admission headroom)`)

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -19,6 +19,16 @@
  * existing bundles whose individual sections already exceed 9min (e.g.
  * 600_000-1 timeouts in imf-extended, energy-sources) are not silently
  * broken by adopting the runner.
+ *
+ * Deferral is only ever meant to shed load under pressure, so two guards keep
+ * it from turning into a silent outage (#6556, where seed-bundle-resilience
+ * deferred all three sections on every tick and exited 0 for six hours):
+ *   1. A section whose worst case does not fit the WHOLE budget can never be
+ *      admitted on any tick. That is a static config error, not pressure, so
+ *      runBundle throws before spawning anything.
+ *   2. A tick that admitted work yet completed none of it while deferring a
+ *      due section exits non-zero. `ran:0 deferred:>0` is otherwise
+ *      indistinguishable from a healthy no-op in Railway's badge.
  */
 
 import { spawn } from 'node:child_process';
@@ -107,7 +117,32 @@ export async function readSectionFreshness(section, readKey = readRedisKey) {
 // Stream child stdio line-by-line so hung sections surface progress instead of
 // looking like a silent crash. Escalate SIGTERM → SIGKILL on timeout so child
 // processes with in-flight HTTPS sockets can't outlive the deadline.
-const KILL_GRACE_MS = 10_000;
+//
+// Exported because a section's worst-case wall time is `timeoutMs +
+// KILL_GRACE_MS`, and both the startup admission check below and the
+// repo-wide gate in tests/bundle-budget-admission.test.mjs must compute it
+// from the same constant rather than a copied literal.
+export const KILL_GRACE_MS = 10_000;
+export const DEFAULT_SECTION_TIMEOUT_MS = 300_000;
+
+/**
+ * Worst-case wall time a section can occupy: its own timeout plus the grace
+ * window the runner allows between SIGTERM and SIGKILL.
+ */
+export function sectionWorstCaseMs(section) {
+  return (section.timeoutMs || DEFAULT_SECTION_TIMEOUT_MS) + KILL_GRACE_MS;
+}
+
+/**
+ * Sections that can never be admitted, whatever else the tick does. The
+ * admission test in runBundle is `elapsed + worstCase <= maxBundleMs`, so a
+ * section whose worst case alone exceeds the budget fails it even as the
+ * first section of an otherwise empty tick. Returns [] when unbudgeted.
+ */
+export function findUnadmittableSections(sections, maxBundleMs) {
+  if (!Number.isFinite(maxBundleMs)) return [];
+  return sections.filter((section) => sectionWorstCaseMs(section) > maxBundleMs);
+}
 
 function streamLines(stream, onLine) {
   let buf = '';
@@ -284,8 +319,29 @@ export async function runBundle(label, sections, opts = {}) {
     }
   }
 
-  const t0 = Date.now();
   const maxBundleMs = opts.maxBundleMs ?? Infinity;
+
+  // Admission arithmetic assertion. The per-tick budget check below defers a
+  // section whose worst case does not fit the REMAINING budget — a load-shed
+  // that assumes the section fits the budget at all. When it does not, the
+  // section is deferred on every tick forever and the bundle still exits 0:
+  // #6556 shipped maxBundleMs 570s against a cheapest section of 610s, so
+  // seed-bundle-resilience ran nothing for six hours under a green Railway
+  // badge. Throw instead, alongside the dependsOn contract above, so the
+  // misconfiguration surfaces on the first tick rather than as data ageing
+  // out half a day later.
+  const unadmittable = findUnadmittableSections(sections, maxBundleMs);
+  if (unadmittable.length > 0) {
+    const detail = unadmittable
+      .map((s) => `'${s.label}' needs ${sectionWorstCaseMs(s)}ms (timeoutMs ${s.timeoutMs || DEFAULT_SECTION_TIMEOUT_MS} + ${KILL_GRACE_MS}ms kill grace)`)
+      .join('; ');
+    throw new Error(
+      `[Bundle:${label}] maxBundleMs=${maxBundleMs} is below the worst case of ${unadmittable.length} section(s), which can therefore never be admitted on any tick: ${detail}. `
+      + 'Lower those section timeouts, or raise maxBundleMs (it must stay under the Railway container cap).',
+    );
+  }
+
+  const t0 = Date.now();
   const budgetLabel = Number.isFinite(maxBundleMs) ? `, budget ${Math.round(maxBundleMs / 1000)}s` : '';
   console.log(`[Bundle:${label}] Starting (${sections.length} sections${budgetLabel})`);
 
@@ -302,7 +358,7 @@ export async function runBundle(label, sections, opts = {}) {
     }
 
     const scriptPath = join(__dirname, section.script);
-    const timeout = section.timeoutMs || 300_000;
+    const timeout = section.timeoutMs || DEFAULT_SECTION_TIMEOUT_MS;
 
     const freshness = await readSectionFreshness(section);
     if (freshness?.fetchedAt) {
@@ -319,7 +375,9 @@ export async function runBundle(label, sections, opts = {}) {
     const elapsedBundle = Date.now() - t0;
     // Worst-case runtime is timeoutMs + KILL_GRACE_MS (child may ignore SIGTERM
     // and need SIGKILL after grace). Admit only when the full worst-case fits.
-    const worstCase = timeout + KILL_GRACE_MS;
+    // Shared with the startup check so the two can never disagree about which
+    // sections are admittable.
+    const worstCase = sectionWorstCaseMs(section);
     if (elapsedBundle + worstCase > maxBundleMs) {
       const remainingSec = Math.max(0, Math.round((maxBundleMs - elapsedBundle) / 1000));
       const needSec = Math.round(worstCase / 1000);
@@ -368,11 +426,22 @@ export async function runBundle(label, sections, opts = {}) {
 
   const totalSec = ((Date.now() - t0) / 1000).toFixed(1);
   console.log(`[Bundle:${label}] Finished in ${totalSec}s, ran:${ran} skipped:${skipped} deferred:${deferred} failed:${failed} graceful:${gracefulFailed}`);
-  // Graceful-only run (transient skips, no hard failures): exit 0 so Railway
-  // does not paint CRASHED and fire a spurious alert. Real staleness is caught
-  // independently by the /api/health freshness monitor keyed on seed-meta TTL.
-  if (failed === 0 && gracefulFailed > 0) {
+  // A tick that completed no section while deferring a due one accomplished
+  // nothing AND shed work. Deferral only pays for itself if the deferred
+  // section runs on a later tick, so this state repeating is a stalled
+  // service — the shape that made #6556 invisible for six hours. Report it as
+  // a failure; `ran:0 deferred:0` (everything fresh) stays a healthy no-op.
+  const starvedTick = ran === 0 && deferred > 0;
+  if (starvedTick) {
+    console.error(
+      `[Bundle:${label}] ran:0 while ${deferred} due section(s) were deferred — this tick published nothing and shed work. `
+      + 'Exiting non-zero: a fully-deferred tick is indistinguishable from a healthy no-op, so it must not report success.',
+    );
+  } else if (failed === 0 && gracefulFailed > 0) {
+    // Graceful-only run (transient skips, no hard failures): exit 0 so Railway
+    // does not paint CRASHED and fire a spurious alert. Real staleness is caught
+    // independently by the /api/health freshness monitor keyed on seed-meta TTL.
     console.log(`[Bundle:${label}] ${gracefulFailed} graceful fetch skip(s), no hard failures — no data lost, exiting 0 (not a crash)`);
   }
-  process.exit(failed > 0 ? 1 : 0);
+  process.exit(failed > 0 || starvedTick ? 1 : 0);
 }

--- a/scripts/seed-bundle-resilience.mjs
+++ b/scripts/seed-bundle-resilience.mjs
@@ -19,10 +19,15 @@ import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 await runBundle('resilience', [
   // Warm runs finish in ~5.7s (196/196 scores already cached; the work is an
   // intervals recompute, one /refresh=1 call bounded at 60s, and 2 verify
-  // GETs). Cold runs are 1-2min. 240s is ~2x the cold path. The individual
-  // laggard warm-up (batches of 5 x 30s over up to 196 countries) can exceed
-  // any value that fits the container cap, so it is bounded by the seeder's
-  // own per-request timeouts rather than by this number.
+  // GETs). Cold runs are 1-2min. 240s is ~2x the cold path.
+  //
+  // Caveat: the individual laggard warm-up has no aggregate deadline of its
+  // own — batches of 5 countries at a 30s per-request timeout over up to 196
+  // countries is ~20min worst case, so a badly degraded run is SIGTERM'd here
+  // at 240s rather than finishing. That is not a regression: the old 600s
+  // timeout sat above Railway's 10-minute container kill, so the same run died
+  // by container SIGKILL with its logs lost. Giving that phase its own budget
+  // (like Food-Stocks' fetchPhaseTimeoutMs) is tracked separately.
   { label: 'Resilience-Scores', script: 'seed-resilience-scores.mjs', seedMetaKey: 'resilience:scores', intervalMs: 2 * HOUR, timeoutMs: 240_000 },
   // 11 dataset adapters run concurrently (Promise.allSettled), each fetch
   // withRetry(2, 750) over a 30s timeout, so the design worst case is ~92s for

--- a/scripts/seed-bundle-resilience.mjs
+++ b/scripts/seed-bundle-resilience.mjs
@@ -17,9 +17,11 @@ import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 // under a green badge. A timeout above the container cap never bounded anything
 // anyway: Railway SIGKILLs at 10 minutes, taking the logs with it.
 await runBundle('resilience', [
-  // Warm runs finish in ~5.7s (196/196 scores already cached; the work is an
-  // intervals recompute, one /refresh=1 call bounded at 60s, and 2 verify
-  // GETs). Cold runs are 1-2min. 240s is ~2x the cold path.
+  // Warm runs finish in ~5.7s — measured, not estimated: the last healthy
+  // production tick before #6531 logged `[Resilience-Scores] Done (5.7s)` with
+  // 196/196 scores pre-warmed (quoted in #6556). The work is an intervals
+  // recompute, one /refresh=1 call bounded at 60s, and 2 verify GETs. Cold runs
+  // are 1-2min. 240s is ~2x the cold path.
   //
   // Caveat: the individual laggard warm-up has no aggregate deadline of its
   // own — batches of 5 countries at a 30s per-request timeout over up to 196

--- a/scripts/seed-bundle-resilience.mjs
+++ b/scripts/seed-bundle-resilience.mjs
@@ -8,14 +8,37 @@ import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 // window, so hourly Railway fires run this ~every 2h. The seeder is cheap on
 // warm runs (~5-10s: intervals recompute + one /refresh=1 HTTP + 2 verify
 // GETs); the expensive warm path only runs when scores are actually missing.
+//
+// timeoutMs note: section timeouts are sized against measured runtime and each seeder's own
+// internal deadline, NOT against Railway's container cap. #6556: every section
+// here was declared at 600-900s, which is above the 570s bundle budget once the
+// runner's 10s kill grace is added, so the admission check deferred all three
+// on every tick and exited 0 — the service published nothing for six hours
+// under a green badge. A timeout above the container cap never bounded anything
+// anyway: Railway SIGKILLs at 10 minutes, taking the logs with it.
 await runBundle('resilience', [
-  { label: 'Resilience-Scores', script: 'seed-resilience-scores.mjs', seedMetaKey: 'resilience:scores', intervalMs: 2 * HOUR, timeoutMs: 600_000 },
-  { label: 'Resilience-Static', script: 'seed-resilience-static.mjs', seedMetaKey: 'resilience:static', intervalMs: 90 * DAY, timeoutMs: 900_000 },
-  { label: 'Food-Stocks', script: 'seed-food-stocks.mjs', seedMetaKey: 'resilience:food-stocks', intervalMs: 30 * DAY, timeoutMs: 600_000 },
+  // Warm runs finish in ~5.7s (196/196 scores already cached; the work is an
+  // intervals recompute, one /refresh=1 call bounded at 60s, and 2 verify
+  // GETs). Cold runs are 1-2min. 240s is ~2x the cold path. The individual
+  // laggard warm-up (batches of 5 x 30s over up to 196 countries) can exceed
+  // any value that fits the container cap, so it is bounded by the seeder's
+  // own per-request timeouts rather than by this number.
+  { label: 'Resilience-Scores', script: 'seed-resilience-scores.mjs', seedMetaKey: 'resilience:scores', intervalMs: 2 * HOUR, timeoutMs: 240_000 },
+  // 11 dataset adapters run concurrently (Promise.allSettled), each fetch
+  // withRetry(2, 750) over a 30s timeout, so the design worst case is ~92s for
+  // the slowest chain plus a Redis pipeline publish. 420s is ~4.5x that.
+  { label: 'Resilience-Static', script: 'seed-resilience-static.mjs', seedMetaKey: 'resilience:static', intervalMs: 90 * DAY, timeoutMs: 420_000 },
+  // The seeder caps its own fetch phase at 420s (fetchPhaseTimeoutMs), so a
+  // slow USDA PSD or FAOSTAT aborts through runSeed's graceful last-good path
+  // rather than being SIGTERM'd here, which the runner counts as a hard
+  // failure. 480_000 leaves that bound 60s of publish headroom.
+  { label: 'Food-Stocks', script: 'seed-food-stocks.mjs', seedMetaKey: 'resilience:food-stocks', intervalMs: 30 * DAY, timeoutMs: 480_000 },
 ], {
   // Railway kills the container at 10 minutes. The runner admits a section only
   // when `timeoutMs + KILL_GRACE_MS` still fits the remaining budget, so without
   // this a 600s section plus grace could start with no room to finish and be
-  // SIGKILLed mid-publish instead of skipped cleanly.
+  // SIGKILLed mid-publish instead of skipped cleanly. Every section above must
+  // fit this budget outright — runBundle now refuses to start otherwise, and
+  // tests/bundle-budget-admission.test.mjs pins the arithmetic in CI.
   maxBundleMs: 570_000,
 });

--- a/tests/bundle-budget-admission.test.mjs
+++ b/tests/bundle-budget-admission.test.mjs
@@ -27,9 +27,15 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { DEFAULT_SECTION_TIMEOUT_MS, KILL_GRACE_MS } from '../scripts/_bundle-runner.mjs';
+import {
+  ADMISSION_HEADROOM_MS,
+  DEFAULT_SECTION_TIMEOUT_MS,
+  KILL_GRACE_MS,
+  sectionWorstCaseMs,
+} from '../scripts/_bundle-runner.mjs';
 import {
   countSectionAnchors,
+  countSectionScriptKeys,
   extractBundleOption,
   extractBundleSections,
   listBundleFiles,
@@ -39,6 +45,11 @@ import {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SCRIPTS_DIR = join(resolve(__dirname, '..'), 'scripts');
+
+// Railway hard-kills a cron container at 10 minutes. Every wall budget exists
+// to keep a section from being SIGKILLed mid-publish by that limit, so a budget
+// at or above it is not a budget.
+const RAILWAY_CONTAINER_CAP_MS = 600_000;
 
 /**
  * Parse every bundle once. Throws rather than skipping on any unresolvable
@@ -53,11 +64,37 @@ function readBudgetedBundles() {
     const name = basename(bundlePath);
     // Strip once: identifier resolution must not read a commented-out
     // declaration, and the anchor count must match what the extractor saw.
-    const src = stripLineComments(readFileSync(bundlePath, 'utf-8'));
+    const raw = readFileSync(bundlePath, 'utf-8');
+    const src = stripLineComments(raw);
+    // stripLineComments is a string scanner, not a JS tokenizer: it cannot tell
+    // a comment from a regex literal, so `const RE = /[//]/` would swallow the
+    // rest of the file. Both the extractor and the counts below read the
+    // STRIPPED source, so that truncation hides sections from every check at
+    // once and the gate passes on a file it never saw. Comparing the script-key
+    // count across the strip is what makes that loud. A deliberately
+    // commented-out section trips this too — delete it rather than commenting
+    // it, so the gate keeps meaning what it says.
+    assert.equal(
+      countSectionScriptKeys(src),
+      countSectionScriptKeys(raw),
+      `${name}: ${countSectionScriptKeys(raw) - countSectionScriptKeys(src)} \`script:\` key(s) disappeared when `
+      + 'comments were stripped. Either a section is commented out (delete it instead), or the stripper mis-read a '
+      + 'regex literal and truncated the file. Either way this gate is not reading the real config.',
+    );
     if (src.includes('maxBundleMs')) sawMaxBundleMsLiteral++;
 
     const budgetExpr = extractBundleOption(src, 'maxBundleMs');
     if (budgetExpr == null) continue;          // unbudgeted bundle — nothing to check
+
+    // extractBundleOption takes the FIRST textual `maxBundleMs:` in the file.
+    // A second one (a defaults object, a commented example that survived) would
+    // make the gate check a budget the runner never uses.
+    assert.equal(
+      (src.match(/maxBundleMs:/g) || []).length,
+      1,
+      `${name}: expected exactly one maxBundleMs declaration, found `
+      + `${(src.match(/maxBundleMs:/g) || []).length}. The gate cannot tell which one runBundle receives.`,
+    );
 
     const maxBundleMs = resolveExpr(src, budgetExpr, {}, { file: bundlePath });
     assert.ok(
@@ -65,14 +102,34 @@ function readBudgetedBundles() {
       `${name}: maxBundleMs expression "${budgetExpr}" did not resolve to a positive number. `
       + 'Extend tests/helpers/bundle-section-parser.mjs rather than leaving this bundle unchecked.',
     );
+    // The budget only means anything if it is under the ceiling it exists to
+    // stay beneath. Nothing else in the repo checks this: a bundle declaring
+    // maxBundleMs 900_000 would satisfy every per-section assertion below and
+    // still be hard-killed by Railway at 10 minutes, mid-publish.
+    assert.ok(
+      maxBundleMs < RAILWAY_CONTAINER_CAP_MS,
+      `${name}: maxBundleMs ${maxBundleMs}ms is at or above Railway's ${RAILWAY_CONTAINER_CAP_MS}ms container kill. `
+      + 'The container dies before the budget is reached, so the budget shapes nothing.',
+    );
 
     const sections = extractBundleSections(src);
-    const anchors = countSectionAnchors(src);
     assert.equal(
       sections.length,
-      anchors,
-      `${name}: parsed ${sections.length} section(s) from ${anchors} \`{ label: ... }\` anchor(s). `
+      countSectionAnchors(src),
+      `${name}: parsed ${sections.length} section(s) from ${countSectionAnchors(src)} \`{ label: ... }\` anchor(s). `
       + 'A dropped section is a silent pass — fix the parser before trusting this gate.',
+    );
+    // Second, independent count. The anchor check above shares its regex with
+    // the extractor, so on its own it only proves the extractor agrees with
+    // itself — a section the anchor cannot see is missing from both sides and
+    // the equality still holds. `script:` is declared by every section and is
+    // matched by a different pattern, so this is the check that actually
+    // catches a section the gate never read.
+    assert.equal(
+      sections.length,
+      countSectionScriptKeys(src),
+      `${name}: parsed ${sections.length} section(s) but found ${countSectionScriptKeys(src)} \`script:\` key(s). `
+      + 'The gate is not reading every declared section — fix the parser before trusting it.',
     );
     assert.ok(sections.length > 0, `${name} declares maxBundleMs but no parseable sections`);
 
@@ -87,7 +144,10 @@ function readBudgetedBundles() {
           Number.isFinite(timeoutMs) && timeoutMs > 0,
           `${name} / ${section.label}: timeoutMs expression "${section.timeoutMsExpr}" did not resolve to a positive number.`,
         );
-        return { ...section, timeoutMs, worstCaseMs: timeoutMs + KILL_GRACE_MS };
+        // Call the runner's own helper rather than restating `timeoutMs +
+        // KILL_GRACE_MS`. A gate that recomputes the formula it is guarding
+        // stops guarding it the moment the formula changes.
+        return { ...section, timeoutMs, worstCaseMs: sectionWorstCaseMs({ timeoutMs }) };
       }),
     });
   }
@@ -117,12 +177,17 @@ test('every budgeted bundle section fits its own bundle budget', () => {
   for (const bundle of budgeted) {
     for (const section of bundle.sections) {
       checked++;
-      if (section.worstCaseMs <= bundle.maxBundleMs) continue;
+      // Same threshold the runner enforces, headroom included. Comparing bare
+      // worstCase against the budget would pass a section sized at exactly
+      // `maxBundleMs - KILL_GRACE_MS`, which the runtime check then defers on
+      // every tick forever — #6556 surviving its own gate.
+      if (section.worstCaseMs + ADMISSION_HEADROOM_MS <= bundle.maxBundleMs) continue;
       violations.push(
-        `${bundle.name} / ${section.label}: worst case ${section.worstCaseMs}ms `
-        + `(timeoutMs ${section.timeoutMs} + ${KILL_GRACE_MS}ms kill grace) exceeds maxBundleMs ${bundle.maxBundleMs}ms `
-        + `— it can never be admitted. Lower timeoutMs to <= ${bundle.maxBundleMs - KILL_GRACE_MS}, or raise the budget `
-        + 'below Railway\'s 10-minute container cap.',
+        `${bundle.name} / ${section.label}: needs ${section.worstCaseMs + ADMISSION_HEADROOM_MS}ms `
+        + `(timeoutMs ${section.timeoutMs} + ${KILL_GRACE_MS}ms kill grace + ${ADMISSION_HEADROOM_MS}ms admission headroom) `
+        + `but maxBundleMs is ${bundle.maxBundleMs}ms — it can never be admitted. Lower timeoutMs to <= `
+        + `${bundle.maxBundleMs - KILL_GRACE_MS - ADMISSION_HEADROOM_MS}, or raise the budget below Railway's `
+        + '10-minute container cap.',
       );
     }
   }
@@ -144,8 +209,8 @@ test('seed-bundle-resilience admits Resilience-Scores on a cron tick (#6556 regr
 
   for (const section of bundle.sections) {
     assert.ok(
-      section.worstCaseMs <= bundle.maxBundleMs,
-      `${section.label} needs ${section.worstCaseMs}ms of a ${bundle.maxBundleMs}ms budget — it would be deferred forever`,
+      section.worstCaseMs + ADMISSION_HEADROOM_MS <= bundle.maxBundleMs,
+      `${section.label} needs ${section.worstCaseMs + ADMISSION_HEADROOM_MS}ms of a ${bundle.maxBundleMs}ms budget — it would be deferred forever`,
     );
   }
 

--- a/tests/bundle-budget-admission.test.mjs
+++ b/tests/bundle-budget-admission.test.mjs
@@ -1,0 +1,163 @@
+// Static guard: in every budgeted `scripts/seed-bundle-*.mjs`, each section's
+// worst-case wall time (`timeoutMs` + the runner's SIGTERM→SIGKILL grace) must
+// fit `maxBundleMs`.
+//
+// Why this needs a CI gate rather than a code review:
+//
+// `_bundle-runner.mjs` admits a section only when
+// `elapsed + timeoutMs + KILL_GRACE_MS <= maxBundleMs`. That check is a
+// load-shed — it assumes the section fits the budget at all, and defers it to
+// the next tick when the current one is too far along. A section whose worst
+// case exceeds the WHOLE budget fails the check on every tick forever, and
+// deferral is not an error, so the bundle still exits 0 and Railway paints
+// SUCCESS.
+//
+// #6556: `seed-bundle-resilience` shipped `maxBundleMs: 570_000` alongside
+// sections of 600s, 900s and 600s. The cheapest needed 610s. All three were
+// deferred on every tick, `ran:0`, exit 0, green badge — and the service
+// published nothing for six hours. The only detector was seed-meta ageing past
+// a 14h staleness alarm, roughly fourteen hours after the service died.
+//
+// The runner now refuses to start on that config (see
+// `findUnadmittableSections`), which turns the silent stall into a loud one.
+// This gate is the earlier tripwire: it fails the PR that would deploy it.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DEFAULT_SECTION_TIMEOUT_MS, KILL_GRACE_MS } from '../scripts/_bundle-runner.mjs';
+import {
+  countSectionAnchors,
+  extractBundleOption,
+  extractBundleSections,
+  listBundleFiles,
+  resolveExpr,
+  stripLineComments,
+} from './helpers/bundle-section-parser.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = join(resolve(__dirname, '..'), 'scripts');
+
+/**
+ * Parse every bundle once. Throws rather than skipping on any unresolvable
+ * value: a section this gate cannot read is a section it cannot vouch for,
+ * and silently dropping it would turn the guard into a false pass.
+ */
+function readBudgetedBundles() {
+  const budgeted = [];
+  let sawMaxBundleMsLiteral = 0;
+
+  for (const bundlePath of listBundleFiles(SCRIPTS_DIR)) {
+    const name = basename(bundlePath);
+    // Strip once: identifier resolution must not read a commented-out
+    // declaration, and the anchor count must match what the extractor saw.
+    const src = stripLineComments(readFileSync(bundlePath, 'utf-8'));
+    if (src.includes('maxBundleMs')) sawMaxBundleMsLiteral++;
+
+    const budgetExpr = extractBundleOption(src, 'maxBundleMs');
+    if (budgetExpr == null) continue;          // unbudgeted bundle — nothing to check
+
+    const maxBundleMs = resolveExpr(src, budgetExpr, {}, { file: bundlePath });
+    assert.ok(
+      Number.isFinite(maxBundleMs) && maxBundleMs > 0,
+      `${name}: maxBundleMs expression "${budgetExpr}" did not resolve to a positive number. `
+      + 'Extend tests/helpers/bundle-section-parser.mjs rather than leaving this bundle unchecked.',
+    );
+
+    const sections = extractBundleSections(src);
+    const anchors = countSectionAnchors(src);
+    assert.equal(
+      sections.length,
+      anchors,
+      `${name}: parsed ${sections.length} section(s) from ${anchors} \`{ label: ... }\` anchor(s). `
+      + 'A dropped section is a silent pass — fix the parser before trusting this gate.',
+    );
+    assert.ok(sections.length > 0, `${name} declares maxBundleMs but no parseable sections`);
+
+    budgeted.push({
+      name,
+      maxBundleMs,
+      sections: sections.map((section) => {
+        const timeoutMs = section.timeoutMsExpr == null
+          ? DEFAULT_SECTION_TIMEOUT_MS                 // runBundle's own fallback
+          : resolveExpr(src, section.timeoutMsExpr, {}, { file: bundlePath });
+        assert.ok(
+          Number.isFinite(timeoutMs) && timeoutMs > 0,
+          `${name} / ${section.label}: timeoutMs expression "${section.timeoutMsExpr}" did not resolve to a positive number.`,
+        );
+        return { ...section, timeoutMs, worstCaseMs: timeoutMs + KILL_GRACE_MS };
+      }),
+    });
+  }
+
+  assert.equal(
+    budgeted.length,
+    sawMaxBundleMsLiteral,
+    `${sawMaxBundleMsLiteral} bundle(s) mention maxBundleMs but only ${budgeted.length} were parsed as budgeted. `
+    + 'The option extractor missed one, so those bundles are going unchecked.',
+  );
+  return budgeted;
+}
+
+test('the kill grace is a real number, so the admission arithmetic cannot pass vacuously', () => {
+  // `NaN > budget` is false, so a broken import would make every comparison
+  // below succeed while proving nothing.
+  assert.ok(Number.isFinite(KILL_GRACE_MS) && KILL_GRACE_MS > 0, 'KILL_GRACE_MS must be a positive number');
+  assert.ok(Number.isFinite(DEFAULT_SECTION_TIMEOUT_MS) && DEFAULT_SECTION_TIMEOUT_MS > 0);
+});
+
+test('every budgeted bundle section fits its own bundle budget', () => {
+  const budgeted = readBudgetedBundles();
+  assert.ok(budgeted.length > 0, 'no budgeted bundle found — the gate would pass vacuously');
+
+  const violations = [];
+  let checked = 0;
+  for (const bundle of budgeted) {
+    for (const section of bundle.sections) {
+      checked++;
+      if (section.worstCaseMs <= bundle.maxBundleMs) continue;
+      violations.push(
+        `${bundle.name} / ${section.label}: worst case ${section.worstCaseMs}ms `
+        + `(timeoutMs ${section.timeoutMs} + ${KILL_GRACE_MS}ms kill grace) exceeds maxBundleMs ${bundle.maxBundleMs}ms `
+        + `— it can never be admitted. Lower timeoutMs to <= ${bundle.maxBundleMs - KILL_GRACE_MS}, or raise the budget `
+        + 'below Railway\'s 10-minute container cap.',
+      );
+    }
+  }
+
+  assert.ok(checked > 0, 'no sections checked — the parser is broken');
+  assert.deepEqual(
+    violations,
+    [],
+    `${violations.length} permanently-unadmittable bundle section(s) found:\n  - ${violations.join('\n  - ')}\n\n`
+    + 'Such a section is deferred on every tick while the bundle exits 0, which is the #6556 silent stall.',
+  );
+});
+
+test('seed-bundle-resilience admits Resilience-Scores on a cron tick (#6556 regression)', () => {
+  // The acceptance criterion from the issue, pinned by name so a future edit
+  // to this specific bundle cannot re-break the service the issue was about.
+  const bundle = readBudgetedBundles().find((b) => b.name === 'seed-bundle-resilience.mjs');
+  assert.ok(bundle, 'seed-bundle-resilience.mjs must declare a wall budget');
+
+  for (const section of bundle.sections) {
+    assert.ok(
+      section.worstCaseMs <= bundle.maxBundleMs,
+      `${section.label} needs ${section.worstCaseMs}ms of a ${bundle.maxBundleMs}ms budget — it would be deferred forever`,
+    );
+  }
+
+  // Sections are offered the budget in array order, so the member that keeps
+  // `resilience:ranking:v27` and `resilience:intervals:v10:*` alive between
+  // cron fires has to be offered it first. Behind the annual Resilience-Static
+  // or the monthly Food-Stocks it would be deferred on exactly the ticks those
+  // heavier members are due — a partial rerun of #6556 that the per-section
+  // arithmetic above cannot see.
+  assert.equal(
+    bundle.sections[0].label,
+    'Resilience-Scores',
+    'Resilience-Scores must be offered the wall budget before its heavier, rarer siblings',
+  );
+});

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -672,6 +672,39 @@ test('a section whose worst case exceeds the whole budget is rejected at startup
   }
 });
 
+test('an env-gated section does not take its healthy siblings down via the admission check', async () => {
+  // The startup throw is deliberately loud, but its blast radius is the whole
+  // bundle. A section already failing the requiredEnv gate cannot run this tick
+  // whatever its timeout says, so letting its arithmetic throw would stop the
+  // bundle's healthy members from publishing for the duration of an unrelated
+  // secret outage — while requiredEnv's own path exists precisely to fail only
+  // the affected section. Nothing is lost: the CI gate checks that timeout
+  // statically, with no knowledge of the environment.
+  const cleanup = writeFixture('_bundle-fixture-env-gated-sibling.mjs', `console.log('healthy-sibling-ran');\n`);
+  try {
+    const { code, stdout, stderr } = await runBundleWith(
+      [
+        { label: 'HEALTHY', script: '_bundle-fixture-env-gated-sibling.mjs', intervalMs: 1, timeoutMs: 5_000 },
+        {
+          label: 'GATED_AND_OVERSIZED',
+          script: '_bundle-fixture-must-not-run.mjs',
+          intervalMs: 1,
+          timeoutMs: 5_000_000,                       // would throw on its own
+          requiredEnv: ['WM_BUNDLE_TEST_ABSENT_SECRET'],
+        },
+      ],
+      { maxBundleMs: 60_000 },
+    );
+    assert.match(stdout, /\[HEALTHY\] healthy-sibling-ran/, `the healthy section must still run; stdout:\n${stdout}`);
+    assert.match(stderr, /section=GATED_AND_OVERSIZED status=CONFIG_ERROR/);
+    assert.equal(code, 1, 'the missing secret still fails the bundle');
+    assert.doesNotMatch(stdout + stderr, /can therefore never be admitted/, 'must not throw on an env-gated section');
+    assert.doesNotMatch(stdout + stderr, /must-not-run/);
+  } finally {
+    cleanup();
+  }
+});
+
 test('a declared-but-unusable maxBundleMs fails instead of silently unbudgeting', async () => {
   // Every budget guard is gated on Number.isFinite(maxBundleMs), so a string
   // (or a NaN from Number(process.env.X)) would turn all of them off and let a

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -595,21 +595,108 @@ test('timeout emits terminal reason BEFORE SIGTERM/SIGKILL grace (survives conta
 });
 
 test('budget check accounts for SIGKILL grace when deferring', async () => {
-  const cleanup = writeFixture(
+  const cleanupFirst = writeFixture(
+    '_bundle-fixture-budget-first.mjs',
+    `await new Promise((r) => setTimeout(r, 2000));\nconsole.log('first-ran');\n`,
+  );
+  const cleanupGated = writeFixture(
     '_bundle-fixture-sleep.mjs',
-    `console.log('ok');\n`,
+    `console.log('gated-ran');\n`,
   );
   try {
-    // timeoutMs (15s) + grace (10s) = 25s worst-case. Budget 20s must defer.
+    // Budget 35s. FIRST is admittable (20s + 10s grace = 30s) and burns ~2s of
+    // it. GATED's own timeout (24s) still fits the ~33s that remain — only
+    // adding the 10s kill grace (34s) pushes it over. Deferring under that
+    // cumulative pressure is the feature; a section that cannot fit the WHOLE
+    // budget is a config bug and is rejected at startup instead (see below).
+    //
+    // FIRST's timeout is 10x its sleep on purpose. This file spawns real child
+    // processes, and a loaded CI runner has already produced one cold-start
+    // flake here (PR #3617). A timeout close to the sleep would turn that into
+    // a section failure and change the exit code the test is asserting on.
     const { code, stdout } = await runBundleWith(
-      [{ label: 'GATED', script: '_bundle-fixture-sleep.mjs', intervalMs: 1, timeoutMs: 15_000 }],
-      { maxBundleMs: 20_000 },
+      [
+        { label: 'FIRST', script: '_bundle-fixture-budget-first.mjs', intervalMs: 1, timeoutMs: 20_000 },
+        { label: 'GATED', script: '_bundle-fixture-sleep.mjs', intervalMs: 1, timeoutMs: 24_000 },
+      ],
+      { maxBundleMs: 35_000 },
     );
-    assert.equal(code, 0, 'deferred sections are not failures');
-    assert.match(stdout, /\[GATED\] Deferred, needs 25s \(timeout\+grace\)/);
-    assert.match(stdout, /deferred:1/);
+    assert.equal(code, 0, 'a deferral after real work is pressure, not a failure');
+    assert.match(stdout, /\[FIRST\] first-ran/);
+    assert.match(stdout, /\[GATED\] Deferred, needs 34s \(timeout\+grace\)/);
+    assert.match(stdout, /ran:1 skipped:0 deferred:1/);
+    assert.doesNotMatch(stdout, /gated-ran/);
+  } finally {
+    cleanupFirst();
+    cleanupGated();
+  }
+});
+
+test('a section whose worst case exceeds the whole budget is rejected at startup', async () => {
+  // #6556: seed-bundle-resilience declared maxBundleMs 570s against sections
+  // whose cheapest worst case was 610s, so EVERY tick deferred EVERY section
+  // and exited 0. Railway painted SUCCESS for six hours while the service was
+  // dead. A section that cannot fit the whole budget can never be admitted on
+  // any tick, which makes it a static config error, not runtime pressure.
+  const cleanup = writeFixture('_bundle-fixture-unadmittable.mjs', `console.log('must-not-run');\n`);
+  try {
+    const { code, stdout, stderr } = await runBundleWith(
+      [{ label: 'NEVER', script: '_bundle-fixture-unadmittable.mjs', intervalMs: 1, timeoutMs: 560_000 }],
+      { maxBundleMs: 560_000 },
+    );
+    assert.notEqual(code, 0, 'a permanently unadmittable section must not exit 0');
+    assert.match(
+      stderr,
+      /maxBundleMs=560000 is below the worst case of 1 section\(s\)[^\n]*'NEVER' needs 570000ms \(timeoutMs 560000 \+ 10000ms kill grace\)/,
+      `expected the admission-arithmetic error; stderr:\n${stderr}`,
+    );
+    assert.doesNotMatch(stdout + stderr, /must-not-run/, 'nothing may spawn once the config is known bad');
   } finally {
     cleanup();
+  }
+});
+
+test('a tick that runs nothing while deferring due work exits non-zero', async () => {
+  // The residual silent-stall shape that survives the startup check: every
+  // section fits the budget on its own, but the one that ran consumed enough
+  // of it to starve the rest AND published nothing. ran:0 with deferred:>0 is
+  // indistinguishable from a healthy no-op in Railway's badge, so the runner
+  // has to say so itself.
+  const cleanupGrace = writeFixture(
+    '_bundle-fixture-slow-graceful.mjs',
+    `await new Promise((r) => setTimeout(r, 3000));\nconsole.log('=== Failed gracefully ===');\nprocess.exit(${GRACEFUL_FETCH_FAILURE_EXIT_CODE});\n`,
+  );
+  const cleanupLate = writeFixture('_bundle-fixture-late.mjs', `console.log('late-ran');\n`);
+  try {
+    const { code, stdout, stderr } = await runBundleWith(
+      [
+        // Budget 35s. GRACE fits with 5s to spare (20s + 10s grace) so it is
+        // admitted, then burns ~3s and exits 75. LATE needs 34s (24s + grace)
+        // and only ~32s remain, so it defers. Both fit the budget on their
+        // own, so the startup check passes and this is genuine pressure.
+        //
+        // GRACE's timeout is 20s for a 3s sleep so a slow cold start cannot
+        // turn the graceful exit into a timeout, which would change the
+        // counters this test asserts on. Load only widens the margin on the
+        // other side: the slower GRACE is, the harder LATE defers.
+        { label: 'GRACE', script: '_bundle-fixture-slow-graceful.mjs', intervalMs: 1, timeoutMs: 20_000 },
+        { label: 'LATE', script: '_bundle-fixture-late.mjs', intervalMs: 1, timeoutMs: 24_000 },
+      ],
+      { maxBundleMs: 35_000 },
+    );
+    assert.equal(code, 1, 'a tick that published nothing while starving due work is not a success');
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:1 failed:0 graceful:1/);
+    assert.match(
+      stderr,
+      /\[Bundle:test\] ran:0 while 1 due section\(s\) were deferred/,
+      `expected the zero-admission explanation; stderr:\n${stderr}`,
+    );
+    assert.doesNotMatch(stdout, /late-ran/);
+    // The graceful-only exemption must not launder this state back to green.
+    assert.doesNotMatch(stdout, /no data lost, exiting 0/);
+  } finally {
+    cleanupGrace();
+    cleanupLate();
   }
 });
 

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -187,6 +187,12 @@ async function startFakeUpstash({
   hashes = new Map(),
   beforeCommand,
   failCommand,
+  // Delay applied to each GET before responding. Lets a test burn bundle wall
+  // time inside the freshness gate rather than inside a section, which is the
+  // only way to reach `ran:0 deferred:>0` without a failure. Must stay under
+  // the runner's REDIS_READ_TIMEOUT_MS or the read aborts and the section reads
+  // as due instead of fresh.
+  getDelayMs = 0,
 } = {}) {
   const pipelines = [];
   const commands = [];
@@ -239,8 +245,12 @@ async function startFakeUpstash({
     if (req.method === 'GET' && req.url?.startsWith('/get/')) {
       const key = decodeURIComponent(req.url.slice('/get/'.length));
       reads.push(key);
-      res.setHeader('Content-Type', 'application/json');
-      res.end(JSON.stringify({ result: strings.get(key) ?? null }));
+      const send = () => {
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ result: strings.get(key) ?? null }));
+      };
+      if (getDelayMs > 0) setTimeout(send, getDelayMs);
+      else send();
       return;
     }
     if (req.method === 'POST' && req.url === '/pipeline') {
@@ -597,33 +607,39 @@ test('timeout emits terminal reason BEFORE SIGTERM/SIGKILL grace (survives conta
 test('budget check accounts for SIGKILL grace when deferring', async () => {
   const cleanupFirst = writeFixture(
     '_bundle-fixture-budget-first.mjs',
-    `await new Promise((r) => setTimeout(r, 2000));\nconsole.log('first-ran');\n`,
+    `await new Promise((r) => setTimeout(r, 16000));\nconsole.log('first-ran');\n`,
   );
   const cleanupGated = writeFixture(
     '_bundle-fixture-sleep.mjs',
     `console.log('gated-ran');\n`,
   );
   try {
-    // Budget 35s. FIRST is admittable (20s + 10s grace = 30s) and burns ~2s of
-    // it. GATED's own timeout (24s) still fits the ~33s that remain — only
-    // adding the 10s kill grace (34s) pushes it over. Deferring under that
-    // cumulative pressure is the feature; a section that cannot fit the WHOLE
-    // budget is a config bug and is rejected at startup instead (see below).
+    // Budget 60s. FIRST is admittable (30s + 10s grace + 15s headroom = 55s)
+    // and burns ~16s of it. GATED's own timeout (35s) still fits the ~44s that
+    // remain — only adding the 10s kill grace (45s) pushes it over. Deferring
+    // under that cumulative pressure is the feature; a section that cannot fit
+    // the whole budget is a config bug rejected at startup instead (see below).
     //
-    // FIRST's timeout is 10x its sleep on purpose. This file spawns real child
-    // processes, and a loaded CI runner has already produced one cold-start
-    // flake here (PR #3617). A timeout close to the sleep would turn that into
-    // a section failure and change the exit code the test is asserting on.
+    // FIRST has to burn more than ADMISSION_HEADROOM_MS for GATED to defer at
+    // all: any section that passes the startup check by definition fits the
+    // budget with the headroom to spare, so only elapsed time beyond that
+    // headroom can squeeze it out. That is what makes this test slow, and why
+    // it cannot be tightened without also weakening what it proves.
+    //
+    // FIRST's timeout is ~2x its sleep on purpose. This file spawns real child
+    // processes and a loaded CI runner has already produced one cold-start
+    // flake here (PR #3617); a timeout close to the sleep would turn that into
+    // a section failure and change the exit code being asserted.
     const { code, stdout } = await runBundleWith(
       [
-        { label: 'FIRST', script: '_bundle-fixture-budget-first.mjs', intervalMs: 1, timeoutMs: 20_000 },
-        { label: 'GATED', script: '_bundle-fixture-sleep.mjs', intervalMs: 1, timeoutMs: 24_000 },
+        { label: 'FIRST', script: '_bundle-fixture-budget-first.mjs', intervalMs: 1, timeoutMs: 30_000 },
+        { label: 'GATED', script: '_bundle-fixture-sleep.mjs', intervalMs: 1, timeoutMs: 35_000 },
       ],
-      { maxBundleMs: 35_000 },
+      { maxBundleMs: 60_000 },
     );
     assert.equal(code, 0, 'a deferral after real work is pressure, not a failure');
     assert.match(stdout, /\[FIRST\] first-ran/);
-    assert.match(stdout, /\[GATED\] Deferred, needs 34s \(timeout\+grace\)/);
+    assert.match(stdout, /\[GATED\] Deferred, needs 45s \(timeout\+grace\)/);
     assert.match(stdout, /ran:1 skipped:0 deferred:1/);
     assert.doesNotMatch(stdout, /gated-ran/);
   } finally {
@@ -647,7 +663,7 @@ test('a section whose worst case exceeds the whole budget is rejected at startup
     assert.notEqual(code, 0, 'a permanently unadmittable section must not exit 0');
     assert.match(
       stderr,
-      /maxBundleMs=560000 is below the worst case of 1 section\(s\)[^\n]*'NEVER' needs 570000ms \(timeoutMs 560000 \+ 10000ms kill grace\)/,
+      /maxBundleMs=560000 is below the worst case of 1 section\(s\)[^\n]*'NEVER' needs 585000ms \(timeoutMs 560000 \+ 10000ms kill grace \+ 15000ms admission headroom\)/,
       `expected the admission-arithmetic error; stderr:\n${stderr}`,
     );
     assert.doesNotMatch(stdout + stderr, /must-not-run/, 'nothing may spawn once the config is known bad');
@@ -656,44 +672,141 @@ test('a section whose worst case exceeds the whole budget is rejected at startup
   }
 });
 
-test('a tick that runs nothing while deferring due work exits non-zero', async () => {
-  // The residual silent-stall shape that survives the startup check: every
-  // section fits the budget on its own, but the one that ran consumed enough
-  // of it to starve the rest AND published nothing. ran:0 with deferred:>0 is
-  // indistinguishable from a healthy no-op in Railway's badge, so the runner
-  // has to say so itself.
-  const cleanupGrace = writeFixture(
-    '_bundle-fixture-slow-graceful.mjs',
-    `await new Promise((r) => setTimeout(r, 3000));\nconsole.log('=== Failed gracefully ===');\nprocess.exit(${GRACEFUL_FETCH_FAILURE_EXIT_CODE});\n`,
-  );
-  const cleanupLate = writeFixture('_bundle-fixture-late.mjs', `console.log('late-ran');\n`);
+test('a declared-but-unusable maxBundleMs fails instead of silently unbudgeting', async () => {
+  // Every budget guard is gated on Number.isFinite(maxBundleMs), so a string
+  // (or a NaN from Number(process.env.X)) would turn all of them off and let a
+  // 600s section run in a container that dies at 600s — #6556's outcome via a
+  // different route. A missing budget is unbudgeted; a broken one is an error.
+  const cleanup = writeFixture('_bundle-fixture-bad-budget.mjs', `console.log('bad-budget-ran');\n`);
   try {
     const { code, stdout, stderr } = await runBundleWith(
+      [{ label: 'ANY', script: '_bundle-fixture-bad-budget.mjs', intervalMs: 1, timeoutMs: 5_000 }],
+      { maxBundleMs: '60000' },
+    );
+    assert.notEqual(code, 0, 'a non-numeric budget must not be treated as "no budget"');
+    assert.match(stderr, /maxBundleMs must be a positive finite number, got "60000"/, `stderr:\n${stderr}`);
+    assert.doesNotMatch(stdout + stderr, /bad-budget-ran/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('a section sized exactly at the budget is rejected, not silently deferred forever', async () => {
+  // The boundary the first version of this guard got wrong. `timeoutMs +
+  // KILL_GRACE_MS === maxBundleMs` passes a naive `worstCase > maxBundleMs`
+  // check, but the runtime test is `elapsed + worstCase <= maxBundleMs` and
+  // elapsed is never zero — the freshness gate has already run. So the section
+  // was admissible on paper and deferred on every real tick: #6556 surviving
+  // its own fix. ADMISSION_HEADROOM_MS is what closes it.
+  const cleanup = writeFixture('_bundle-fixture-exact-budget.mjs', `console.log('exact-ran');\n`);
+  try {
+    const { code, stdout, stderr } = await runBundleWith(
+      [{ label: 'EXACT', script: '_bundle-fixture-exact-budget.mjs', intervalMs: 1, timeoutMs: 50_000 }],
+      { maxBundleMs: 60_000 },
+    );
+    assert.notEqual(code, 0, 'worstCase === maxBundleMs leaves zero room for the freshness gate');
+    assert.match(stderr, /'EXACT' needs 75000ms/, `stderr:\n${stderr}`);
+    assert.doesNotMatch(stdout + stderr, /exact-ran/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('a section with headroom to spare is admitted', async () => {
+  // The other side of the boundary — proves the guard rejects on the specific
+  // arithmetic rather than rejecting everything, which would pass the test
+  // above for the wrong reason.
+  const cleanup = writeFixture('_bundle-fixture-fits.mjs', `console.log('fits-ran');\n`);
+  try {
+    const { code, stdout } = await runBundleWith(
+      [{ label: 'FITS', script: '_bundle-fixture-fits.mjs', intervalMs: 1, timeoutMs: 34_000 }],
+      { maxBundleMs: 60_000 },
+    );
+    assert.equal(code, 0, `34s + 10s grace + 15s headroom = 59s fits a 60s budget; stdout:\n${stdout}`);
+    assert.match(stdout, /\[FITS\] fits-ran/);
+    assert.match(stdout, /ran:1 skipped:0 deferred:0/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('a tick that runs nothing while deferring due work exits non-zero', async () => {
+  // The residual silent-stall shape that survives the startup check. Every
+  // section fits the budget on its own, but the runner's OWN freshness gate
+  // burns enough wall time to squeeze the due section out, so the tick
+  // published nothing and shed work. `ran:0 deferred:>0` is indistinguishable
+  // from a healthy no-op in Railway's badge, so the runner has to say so.
+  //
+  // A degraded Upstash is the production shape: four fresh sections whose
+  // reads each take ~4.5s (under the runner's 5s read timeout, so they still
+  // resolve as fresh and are skipped rather than run) push elapsed past the
+  // 15s admission headroom, and DUE then no longer fits.
+  const cleanupDue = writeFixture('_bundle-fixture-starved-due.mjs', `console.log('due-ran');\n`);
+  const freshMeta = JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 });
+  const redis = await startFakeUpstash({
+    getDelayMs: 4_500,
+    strings: new Map([
+      ['seed-meta:starve:a', freshMeta],
+      ['seed-meta:starve:b', freshMeta],
+      ['seed-meta:starve:c', freshMeta],
+      ['seed-meta:starve:d', freshMeta],
+    ]),
+  });
+  try {
+    const skipped = ['a', 'b', 'c', 'd'].map((k) => ({
+      label: `FRESH_${k.toUpperCase()}`,
+      script: '_bundle-fixture-starved-due.mjs',
+      seedMetaKey: `starve:${k}`,
+      intervalMs: DAY,
+      timeoutMs: 5_000,
+    }));
+    const { code, stdout, stderr } = await runBundleWith(
       [
-        // Budget 35s. GRACE fits with 5s to spare (20s + 10s grace) so it is
-        // admitted, then burns ~3s and exits 75. LATE needs 34s (24s + grace)
-        // and only ~32s remain, so it defers. Both fit the budget on their
-        // own, so the startup check passes and this is genuine pressure.
-        //
-        // GRACE's timeout is 20s for a 3s sleep so a slow cold start cannot
-        // turn the graceful exit into a timeout, which would change the
-        // counters this test asserts on. Load only widens the margin on the
-        // other side: the slower GRACE is, the harder LATE defers.
-        { label: 'GRACE', script: '_bundle-fixture-slow-graceful.mjs', intervalMs: 1, timeoutMs: 20_000 },
-        { label: 'LATE', script: '_bundle-fixture-late.mjs', intervalMs: 1, timeoutMs: 24_000 },
+        ...skipped,
+        { label: 'DUE', script: '_bundle-fixture-starved-due.mjs', intervalMs: 1, timeoutMs: 35_000 },
       ],
-      { maxBundleMs: 35_000 },
+      { maxBundleMs: 60_000 },
+      { UPSTASH_REDIS_REST_URL: redis.url, UPSTASH_REDIS_REST_TOKEN: redis.token },
     );
     assert.equal(code, 1, 'a tick that published nothing while starving due work is not a success');
-    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:1 failed:0 graceful:1/);
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:4 deferred:1 failed:0 graceful:0/);
     assert.match(
       stderr,
       /\[Bundle:test\] ran:0 while 1 due section\(s\) were deferred/,
       `expected the zero-admission explanation; stderr:\n${stderr}`,
     );
+    assert.doesNotMatch(stdout, /due-ran/);
+  } finally {
+    cleanupDue();
+    await redis.close();
+  }
+});
+
+test('a transient graceful skip that also defers work stays exit 0', async () => {
+  // The narrowing on starvedTick. A child exit 75 means the last-good TTL was
+  // extended and no data was lost — a rate-limited upstream, not a stall. If
+  // that blip also pushed a sibling past the budget, `ran:0 deferred:1` is
+  // technically true but firing "Deploy Crashed!" for it is exactly the alert
+  // fatigue the graceful exemption exists to prevent. The deferred section
+  // retries on the next tick; real staleness is caught by the seed-meta
+  // freshness monitor, not by this exit code.
+  const cleanupGrace = writeFixture(
+    '_bundle-fixture-slow-graceful.mjs',
+    `await new Promise((r) => setTimeout(r, 16000));\nconsole.log('=== Failed gracefully ===');\nprocess.exit(${GRACEFUL_FETCH_FAILURE_EXIT_CODE});\n`,
+  );
+  const cleanupLate = writeFixture('_bundle-fixture-late.mjs', `console.log('late-ran');\n`);
+  try {
+    const { code, stdout } = await runBundleWith(
+      [
+        { label: 'GRACE', script: '_bundle-fixture-slow-graceful.mjs', intervalMs: 1, timeoutMs: 30_000 },
+        { label: 'LATE', script: '_bundle-fixture-late.mjs', intervalMs: 1, timeoutMs: 35_000 },
+      ],
+      { maxBundleMs: 60_000 },
+    );
+    assert.equal(code, 0, 'a transient upstream blip must not page, even when it also defers a sibling');
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:1 failed:0 graceful:1/);
+    assert.match(stdout, /no data lost, exiting 0/);
     assert.doesNotMatch(stdout, /late-ran/);
-    // The graceful-only exemption must not launder this state back to green.
-    assert.doesNotMatch(stdout, /no data lost, exiting 0/);
   } finally {
     cleanupGrace();
     cleanupLate();

--- a/tests/bundle-section-parser.test.mjs
+++ b/tests/bundle-section-parser.test.mjs
@@ -15,6 +15,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   countSectionAnchors,
+  countSectionScriptKeys,
   extractBundleOption,
   extractBundleSections,
   resolveExpr,
@@ -211,4 +212,65 @@ test('countSectionAnchors exceeds parsed sections when one cannot be read', () =
   const sample = "const S = [{ label: 'NoScript', intervalMs: 1000 }];\n";
   assert.equal(extractBundleSections(sample).length, 0);
   assert.equal(countSectionAnchors(stripLineComments(sample)), 1);
+});
+
+// ── Anti-vacuity: the script-key count must be independent of the anchor ──
+
+test('a section whose label is not the first key is still counted', () => {
+  // The hole a self-comparing check cannot see. The anchor regex requires
+  // `{` immediately before `label:`, so this section is invisible to it —
+  // and if the gate derived its "nothing was dropped" count from that same
+  // regex, both sides would read 0 and the gate would pass on a bundle it
+  // never parsed. The independent `script:` count is what catches it.
+  const sample = "const S = [{ script: 'seed-a.mjs', label: 'LabelSecond', intervalMs: 1000, timeoutMs: 60_000 }];\n";
+  const stripped = stripLineComments(sample);
+  assert.equal(countSectionAnchors(stripped), 0, 'anchor regex cannot see this shape');
+  assert.equal(extractBundleSections(sample).length, 0, 'extractor cannot see it either');
+  assert.equal(countSectionScriptKeys(stripped), 1, 'the independent count must still see it');
+});
+
+test('a double-quoted label is parsed rather than silently dropped', () => {
+  const sample = 'const S = [{ label: "DoubleQuoted", script: "seed-a.mjs", intervalMs: 1000, timeoutMs: 60_000 }];\n';
+  const sections = extractBundleSections(sample);
+  assert.equal(sections.length, 1);
+  assert.equal(sections[0].label, 'DoubleQuoted');
+  assert.equal(sections[0].script, 'seed-a.mjs');
+  assert.equal(sections[0].timeoutMsExpr, '60_000');
+  assert.equal(countSectionScriptKeys(stripLineComments(sample)), 1);
+});
+
+test('countSectionScriptKeys ignores a script-like key inside a longer name', () => {
+  // `postScript:` must not inflate the count, or the gate fails on a healthy
+  // bundle — a false alarm is its own kind of broken guard.
+  const sample = "const S = [{ label: 'A', script: 'seed-a.mjs', postScript: 'x', intervalMs: 1 }];\n";
+  assert.equal(countSectionScriptKeys(stripLineComments(sample)), 1);
+});
+
+test('a shorthand or spread timeout is dropped rather than defaulted', () => {
+  // Both shapes make the scanner find NO `timeoutMs:` and fall back to the
+  // runner's 300s default — a number nobody wrote, and a smaller one than the
+  // real 900s, so a budget gate would pass a section that cannot fit.
+  const shorthand = "const timeoutMs = 900_000;\nconst S = [{ label: 'A', script: 'seed-a.mjs', intervalMs: 1, timeoutMs }];\n";
+  assert.equal(extractBundleSections(shorthand).length, 0, 'shorthand timeout must not be defaulted');
+  assert.equal(countSectionScriptKeys(stripLineComments(shorthand)), 1, 'the count still sees it, so the gate fails loudly');
+
+  const spread = "const COMMON = { timeoutMs: 900_000 };\nconst S = [{ label: 'A', script: 'seed-a.mjs', intervalMs: 1, ...COMMON }];\n";
+  assert.equal(extractBundleSections(spread).length, 0, 'spread config must not be defaulted');
+  assert.equal(countSectionScriptKeys(stripLineComments(spread)), 1);
+});
+
+test('a section declaring a nested timeoutMs is dropped rather than mis-read', () => {
+  // Reading the FIRST timeoutMs in the block would take the nested retry
+  // budget as the section's own — a smaller number that a budget gate would
+  // happily pass. Fail closed: drop it so the caller's count check fires.
+  const sample = [
+    "const S = [{",
+    "  label: 'Nested', script: 'seed-a.mjs', intervalMs: 1000,",
+    "  retry: { timeoutMs: 500 },",
+    "  timeoutMs: 300_000,",
+    "}];",
+  ].join('\n');
+  const stripped = stripLineComments(sample);
+  assert.equal(extractBundleSections(sample).length, 0, 'ambiguous timeout must not be guessed');
+  assert.equal(countSectionScriptKeys(stripped), 1, 'the count still sees the section, so the gate fails loudly');
 });

--- a/tests/bundle-section-parser.test.mjs
+++ b/tests/bundle-section-parser.test.mjs
@@ -1,0 +1,214 @@
+// Sanity tests for tests/helpers/bundle-section-parser.mjs — the static
+// reader behind the two repo-wide bundle gates
+// (tests/seeder-canonical-ttl-vs-cron.test.mjs and
+// tests/bundle-budget-admission.test.mjs).
+//
+// Both gates fail-closed on anything the parser cannot read, so a parser bug
+// shows up as a broken build rather than a silent pass. These tests keep it
+// honest about the two ways it could quietly under-report: dropping a section
+// it cannot brace-balance, and reading configuration out of a comment.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  countSectionAnchors,
+  extractBundleOption,
+  extractBundleSections,
+  resolveExpr,
+  stripLineComments,
+} from './helpers/bundle-section-parser.mjs';
+
+// ── Resolver ─────────────────────────────────────────────────────────────
+
+test('resolver: numeric literal', () => {
+  assert.equal(resolveExpr('', '43200'), 43200);
+});
+
+test('resolver: numeric literal with underscores (7_200, 86_400)', () => {
+  assert.equal(resolveExpr('', '7_200'), 7200);
+  assert.equal(resolveExpr('', '86_400'), 86400);
+});
+
+test('resolver: simple multiplication', () => {
+  assert.equal(resolveExpr('', '35 * 24 * 3600'), 35 * 24 * 3600);
+});
+
+test('resolver: preseeded HOUR/DAY/WEEK constants', () => {
+  assert.equal(resolveExpr('', '12 * HOUR'), 12 * 3600 * 1000);
+  assert.equal(resolveExpr('', '7 * DAY'), 7 * 24 * 3600 * 1000);
+  assert.equal(resolveExpr('', 'WEEK'), 7 * 24 * 3600 * 1000);
+});
+
+test('resolver: const declared in src (with underscored numeric)', () => {
+  const src = 'const TTL_SECONDS = 86_400;\n';
+  assert.equal(resolveExpr(src, 'TTL_SECONDS'), 86400);
+});
+
+test('resolver: export const declared in src', () => {
+  const src = 'export const CACHE_TTL_SECONDS = 2700;\n';
+  assert.equal(resolveExpr(src, 'CACHE_TTL_SECONDS'), 2700);
+});
+
+test('resolver: const expression mixing identifiers + arithmetic', () => {
+  const src = 'const TTL = 35 * 24 * 3600;\n';
+  assert.equal(resolveExpr(src, 'TTL'), 35 * 24 * 3600);
+});
+
+test('resolver: returns null on unresolvable identifier', () => {
+  assert.equal(resolveExpr('', 'COMPLETELY_UNKNOWN'), null);
+});
+
+test('resolver: rejects unsafe input', () => {
+  assert.equal(resolveExpr('', 'process.env.X'), null);
+  assert.equal(resolveExpr('', 'someFunction()'), null);
+});
+
+test('resolver: follows a relative named import to a sibling module', () => {
+  // seed-bundle-macro.mjs declares its Education section timeout as an
+  // imported constant. Without import-following the budget gate cannot read
+  // that section at all. The cycle guard must key on the FILE, not its
+  // directory, or importing from a sibling in the same folder looks like a
+  // self-reference and resolves to null.
+  const dir = mkdtempSync(join(tmpdir(), 'wm-bundle-parser-'));
+  const bundlePath = join(dir, 'seed-bundle-sample.mjs');
+  writeFileSync(join(dir, 'seed-thing.mjs'), 'export const THING_TIMEOUT_MS = 300_000;\n');
+  const src = "import { THING_TIMEOUT_MS } from './seed-thing.mjs';\n";
+  writeFileSync(bundlePath, src);
+
+  assert.equal(resolveExpr(src, 'THING_TIMEOUT_MS', {}, { file: bundlePath }), 300_000);
+  // Without the file anchor there is nothing to resolve against.
+  assert.equal(resolveExpr(src, 'THING_TIMEOUT_MS'), null);
+});
+
+test('resolver: follows a renamed named import', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wm-bundle-parser-'));
+  const bundlePath = join(dir, 'seed-bundle-sample.mjs');
+  writeFileSync(join(dir, 'seed-thing.mjs'), 'export const RAW_MS = 120_000;\n');
+  const src = "import { RAW_MS as SECTION_MS } from './seed-thing.mjs';\n";
+  writeFileSync(bundlePath, src);
+  assert.equal(resolveExpr(src, 'SECTION_MS', {}, { file: bundlePath }), 120_000);
+});
+
+test('resolver: a bare package specifier is not followed', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wm-bundle-parser-'));
+  const bundlePath = join(dir, 'seed-bundle-sample.mjs');
+  const src = "import { SOME_MS } from 'some-package';\n";
+  writeFileSync(bundlePath, src);
+  assert.equal(resolveExpr(src, 'SOME_MS', {}, { file: bundlePath }), null);
+});
+
+// ── Comment stripping ────────────────────────────────────────────────────
+
+test('stripLineComments: removes line and block comments, keeps string literals', () => {
+  const src = [
+    "const URL = 'https://example.com/a//b';     // trailing comment",
+    '/* block',
+    '   comment */',
+    'const N = 5;',
+  ].join('\n');
+  const out = stripLineComments(src);
+  assert.match(out, /https:\/\/example\.com\/a\/\/b/, 'a URL inside a string is not a comment');
+  assert.doesNotMatch(out, /trailing comment/);
+  assert.doesNotMatch(out, /block/);
+  assert.match(out, /const N = 5;/);
+});
+
+test('a commented-out section is not reported as live configuration', () => {
+  // The doc-parity extractor trap: a guard that binds to a commented-out
+  // declaration reports on code that does not run.
+  const sample = [
+    "const SECTIONS = [",
+    "  { label: 'Live', script: 'seed-live.mjs', intervalMs: 1000, timeoutMs: 60_000 },",
+    "  // { label: 'Retired', script: 'seed-retired.mjs', intervalMs: 1000, timeoutMs: 900_000 },",
+    "];",
+  ].join('\n');
+  const sections = extractBundleSections(sample);
+  assert.deepEqual(sections.map((s) => s.label), ['Live']);
+  assert.equal(countSectionAnchors(stripLineComments(sample)), 1);
+});
+
+test('extractBundleOption ignores a budget quoted in a comment', () => {
+  const sample = [
+    '// Historically this bundle ran with maxBundleMs: 999_000 before #6556.',
+    '], { maxBundleMs: 570_000 });',
+  ].join('\n');
+  assert.equal(extractBundleOption(sample, 'maxBundleMs'), '570_000');
+});
+
+test('extractBundleOption returns null for an unbudgeted bundle', () => {
+  assert.equal(extractBundleOption("await runBundle('x', []);\n", 'maxBundleMs'), null);
+});
+
+// ── Section extraction ───────────────────────────────────────────────────
+
+test('extractBundleSections: catches sections with intervalMs and timeoutMs', () => {
+  const sample = `
+const HOUR = 60 * 60 * 1000;
+export const SECTIONS = [
+  { label: 'A', script: 'seed-a.mjs', intervalMs: HOUR, timeoutMs: 120_000 },
+  { label: 'B', script: 'seed-b.mjs', canonicalKey: 'foo', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
+];
+`;
+  const sections = extractBundleSections(sample);
+  assert.equal(sections.length, 2);
+  assert.equal(sections[0].label, 'A');
+  assert.equal(sections[0].timeoutMsExpr, '120_000');
+  assert.equal(sections[1].intervalMsExpr, '12 * HOUR');
+  assert.equal(countSectionAnchors(stripLineComments(sample)), 2);
+});
+
+test('extractBundleSections: reports a missing timeoutMs as null, not as a default', () => {
+  // runBundle falls back to DEFAULT_SECTION_TIMEOUT_MS; the parser must not
+  // invent a number, so callers can tell "omitted" from "declared".
+  const sample = "const S = [{ label: 'A', script: 'seed-a.mjs', intervalMs: 1000 }];\n";
+  assert.equal(extractBundleSections(sample)[0].timeoutMsExpr, null);
+});
+
+test('extractBundleSections: handles sections with nested objects (Greptile P2)', () => {
+  // Pre-fix the regex `\{ ... \}` non-greedy match would END at the first
+  // inner `}` (the close of `{ 'X-Auth': '...' }`), leaving the outer
+  // section's `script:` and `intervalMs:` outside the captured block →
+  // section silently dropped → real new violation could slip past the guard.
+  const sample = `
+const HOUR = 60 * 60 * 1000;
+export const SECTIONS = [
+  {
+    label: 'WithNested',
+    script: 'seed-with-nested.mjs',
+    extraHeaders: { 'X-Auth': 'Bearer xxx', 'Content-Type': 'application/json' },
+    intervalMs: 6 * HOUR,
+    timeoutMs: 300_000,
+  },
+];
+`;
+  const sections = extractBundleSections(sample);
+  assert.equal(sections.length, 1, 'section with nested object must be detected');
+  assert.equal(sections[0].label, 'WithNested');
+  assert.equal(sections[0].script, 'seed-with-nested.mjs');
+  assert.equal(sections[0].intervalMsExpr, '6 * HOUR');
+});
+
+test('extractBundleSections: handles strings containing braces', () => {
+  // Defensive: if a string literal contains `{` or `}`, brace-counting
+  // must not be confused.
+  const sample = `
+const SECTIONS = [
+  { label: 'StrWithBrace', script: 'seed-str.mjs', regexFilter: 'foo\\\\{bar}', intervalMs: 1000 },
+];
+`;
+  const sections = extractBundleSections(sample);
+  assert.equal(sections.length, 1);
+  assert.equal(sections[0].script, 'seed-str.mjs');
+  assert.equal(sections[0].intervalMsExpr, '1000');
+});
+
+test('countSectionAnchors exceeds parsed sections when one cannot be read', () => {
+  // The anti-vacuity contract the budget gate relies on: an anchor the
+  // extractor drops must remain visible in the anchor count.
+  const sample = "const S = [{ label: 'NoScript', intervalMs: 1000 }];\n";
+  assert.equal(extractBundleSections(sample).length, 0);
+  assert.equal(countSectionAnchors(stripLineComments(sample)), 1);
+});

--- a/tests/helpers/bundle-section-parser.mjs
+++ b/tests/helpers/bundle-section-parser.mjs
@@ -165,15 +165,34 @@ export function resolveExpr(src, expr, scope = {}, opts = {}) {
   return safeEval(expr, expanded);
 }
 
-const SECTION_ANCHOR_RE = /\{\s*label:\s*'([^']+)'/g;
+const SECTION_ANCHOR_RE = /\{\s*label:\s*(['"])((?:(?!\1).)+)\1/g;
+
+// Deliberately a DIFFERENT token from the anchor regex. A section-count check
+// that re-uses SECTION_ANCHOR_RE only proves the extractor agrees with itself:
+// a section written as `{ script: 'x.mjs', label: 'y' }` (label not first) or
+// with a double-quoted label is missed by BOTH the extractor and an
+// anchor-derived count, the two numbers match, and the gate passes on a bundle
+// it never actually read. Every real section declares `script:`, so counting
+// that independently is what makes the comparison load-bearing.
+const SECTION_SCRIPT_KEY_RE = /(?:^|[{,\s])script:\s*['"]/g;
 
 /**
- * Count `{ label: '...' }` anchors in already-comment-stripped source.
+ * Count `{ label: ... }` anchors in already-comment-stripped source.
  * `extractBundleSections` drops an anchor it cannot fully parse; comparing
  * the two counts is how a caller proves nothing was dropped silently.
  */
 export function countSectionAnchors(bundleSrc) {
   return [...bundleSrc.matchAll(SECTION_ANCHOR_RE)].length;
+}
+
+/**
+ * Count `script:` keys in already-comment-stripped source — an independent
+ * lower bound on how many sections the file declares. Callers assert this
+ * against `extractBundleSections(...).length` so a section the anchor regex
+ * cannot see still fails the gate instead of vanishing from it.
+ */
+export function countSectionScriptKeys(bundleSrc) {
+  return [...bundleSrc.matchAll(SECTION_SCRIPT_KEY_RE)].length;
 }
 
 /**
@@ -190,7 +209,7 @@ export function extractBundleSections(rawBundleSrc) {
   const bundleSrc = stripLineComments(rawBundleSrc);
   const sections = [];
   for (const m of bundleSrc.matchAll(SECTION_ANCHOR_RE)) {
-    const label = m[1];
+    const label = m[2];
     const startIdx = m.index;
     // Walk forward balancing braces, respecting string literals.
     let depth = 0, endIdx = -1, inStr = false, strCh = '';
@@ -207,15 +226,28 @@ export function extractBundleSections(rawBundleSrc) {
     }
     if (endIdx < 0) continue;     // unbalanced — skip
     const block = bundleSrc.slice(startIdx, endIdx + 1);
-    const scriptM = block.match(/script:\s*'([^']+)'/);
+    const scriptM = block.match(/script:\s*['"]([^'"]+)['"]/);
     const intervalM = block.match(/intervalMs:\s*([^,}\n]+)/);
     if (!scriptM || !intervalM) continue;
-    const timeoutM = block.match(/timeoutMs:\s*([^,}\n]+)/);
+    // Shapes this text scanner cannot read correctly. Each would yield a WRONG
+    // timeout rather than no timeout, and a wrong (usually smaller) number is
+    // one a budget gate happily passes — the silent-pass this parser exists to
+    // avoid. No bundle uses any of them today; if one ever does, drop the
+    // section so the caller's script-key count check fails loudly instead of
+    // the gate quietly checking a number nobody wrote.
+    //
+    //   nested:    `retry: { timeoutMs: 500 }, timeoutMs: 300_000` -> reads 500
+    //   shorthand: `{ ..., timeoutMs }`                            -> reads none, defaults
+    //   spread:    `{ ...COMMON }`                                 -> reads none, defaults
+    const timeoutMatches = [...block.matchAll(/timeoutMs:\s*([^,}\n]+)/g)];
+    const hasShorthandTimeout = /[{,]\s*timeoutMs\s*[,}]/.test(block);
+    const hasSpread = /\.\.\./.test(block);
+    if (timeoutMatches.length > 1 || hasShorthandTimeout || hasSpread) continue;
     sections.push({
       label,
       script: scriptM[1],
       intervalMsExpr: intervalM[1].trim(),
-      timeoutMsExpr: timeoutM ? timeoutM[1].trim() : null,
+      timeoutMsExpr: timeoutMatches.length === 1 ? timeoutMatches[0][1].trim() : null,
     });
   }
   return sections;

--- a/tests/helpers/bundle-section-parser.mjs
+++ b/tests/helpers/bundle-section-parser.mjs
@@ -1,0 +1,240 @@
+// Shared static parser for `scripts/seed-bundle-*.mjs` section configuration.
+//
+// Bundle scripts call `await runBundle(...)` at module top level and end in
+// `process.exit()`, so a test cannot import one to read its configuration —
+// importing would spawn the real seeders. Both repo-wide bundle gates
+// therefore read the source:
+//
+//   - tests/seeder-canonical-ttl-vs-cron.test.mjs — canonical TTL vs cron interval
+//   - tests/bundle-budget-admission.test.mjs      — timeout + kill grace vs wall budget
+//
+// One parser means a fix to the brace balancer or the resolver lands for both
+// gates at once, and neither drifts into silently dropping a section — a
+// dropped section is a false PASS, which is the failure mode that matters for
+// a guard like this.
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+/**
+ * Conventional bundle-level duration constants, re-exported by
+ * `_bundle-runner.mjs`. Pre-seeded so `12 * HOUR` resolves without parsing
+ * the runner's own declarations.
+ */
+export const PRESEEDED = {
+  MIN: 60 * 1000,
+  HOUR: 60 * 60 * 1000,
+  DAY: 24 * 60 * 60 * 1000,
+  WEEK: 7 * 24 * 60 * 60 * 1000,
+};
+
+/**
+ * Remove `//` line comments and block comments, leaving string literals
+ * intact (so `'https://example.com'` and `regexFilter: 'a//b'` survive).
+ *
+ * Load-bearing for correctness, not just tidiness: a commented-out section or
+ * a comment quoting `maxBundleMs: 570_000` would otherwise be parsed as live
+ * configuration, and a gate that reads a commented-out declaration reports on
+ * code that does not run.
+ */
+export function stripLineComments(src) {
+  let out = '';
+  let inStr = false;
+  let strCh = '';
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    const next = src[i + 1];
+    if (inStr) {
+      out += c;
+      if (c === '\\') { out += next ?? ''; i++; continue; }
+      if (c === strCh) inStr = false;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === '`') { inStr = true; strCh = c; out += c; continue; }
+    if (c === '/' && next === '/') {
+      while (i < src.length && src[i] !== '\n') i++;
+      out += '\n';
+      continue;
+    }
+    if (c === '/' && next === '*') {
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i++;                       // land on '/', loop's i++ steps past it
+      continue;
+    }
+    out += c;
+  }
+  return out;
+}
+
+/** Strip JS numeric-separator underscores so safe-eval can parse them. */
+export function stripNumericUnderscores(s) {
+  // 7_200 → 7200, 86_400 → 86400. Only between digits, never adjacent.
+  return s.replace(/(\d)_(?=\d)/g, '$1');
+}
+
+/**
+ * Safely evaluate a simple numeric expression. Allows digits, +-/*(), and
+ * underscored identifiers (which must be in `scope`). Rejects anything
+ * else with null. No `eval` — uses Function constructor with a strict
+ * input-character whitelist + name-substitution.
+ */
+export function safeEval(expr, scope = {}) {
+  const trimmed = stripNumericUnderscores(String(expr).trim());
+  if (!/^[\w\s+\-*/().,_]+$/.test(trimmed)) return null;
+  let substituted = trimmed;
+  for (const [name, value] of Object.entries(scope)) {
+    if (typeof value !== 'number') continue;
+    substituted = substituted.replace(new RegExp(`\\b${name}\\b`, 'g'), `(${value})`);
+  }
+  if (!/^[\d\s+\-*/().]+$/.test(substituted)) return null;
+  try {
+    const result = Function(`"use strict"; return (${substituted})`)();
+    return Number.isFinite(result) ? result : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve `name` through the named imports declared in `src`, reading the
+ * imported module's source. Only relative specifiers are followed — a bare
+ * package specifier is not repo configuration.
+ *
+ * `seed-bundle-macro.mjs` declares its Education section timeout as an
+ * imported constant, so without this a gate over that bundle would either
+ * skip the section (false pass) or hard-fail on a legitimate config.
+ */
+function resolveImportedIdentifier(src, name, opts) {
+  if (!opts.file) return null;
+  for (const m of src.matchAll(/import\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g)) {
+    const specifier = m[2];
+    if (!specifier.startsWith('.')) continue;
+    for (const clause of m[1].split(',')) {
+      const parts = clause.trim().split(/\s+as\s+/).map((s) => s.trim()).filter(Boolean);
+      if (parts.length === 0) continue;
+      const imported = parts[0];
+      const local = parts[1] ?? imported;
+      if (local !== name) continue;
+      const targetPath = resolve(dirname(opts.file), specifier);
+      let targetSrc;
+      try { targetSrc = readFileSync(targetPath, 'utf-8'); } catch { return null; }
+      return resolveIdentifier(stripLineComments(targetSrc), imported, {}, {
+        ...opts,
+        file: targetPath,
+      });
+    }
+  }
+  return null;
+}
+
+/**
+ * Find a `const|let|var|export const <name> = <expr>` declaration in `src`
+ * and resolve to a number, following relative named imports when `opts.file`
+ * (the absolute path `src` was read from) is supplied. Cycle-guarded per
+ * file: the guard must key on the FILE, not its directory, or a bundle
+ * importing a constant from a sibling module in `scripts/` looks like a
+ * self-reference and resolves to null.
+ */
+export function resolveIdentifier(src, name, scope = {}, opts = {}) {
+  const seen = opts._seen ?? new Set();
+  const seenKey = `${opts.file ?? ''}::${name}`;
+  if (seen.has(seenKey)) return null;
+  if (name in scope) return scope[name];
+  if (name in PRESEEDED) return PRESEEDED[name];
+  seen.add(seenKey);
+  const nextOpts = { ...opts, _seen: seen };
+  // Match: optional `export `, then `const|let|var <name> = <rhs>` up to ; // or newline
+  const re = new RegExp(`(?:^|\\n)\\s*(?:export\\s+)?(?:const|let|var)\\s+${name}\\s*=\\s*([^;\\n]+?)(?:\\s*(?://|;)|$)`, 'm');
+  const m = src.match(re);
+  if (!m) return resolveImportedIdentifier(src, name, nextOpts);
+  return resolveExpr(src, m[1].trim(), scope, nextOpts);
+}
+
+export function resolveExpr(src, expr, scope = {}, opts = {}) {
+  const direct = safeEval(expr, { ...PRESEEDED, ...scope });
+  if (direct != null) return direct;
+  if (/^\w+$/.test(expr)) return resolveIdentifier(src, expr, scope, opts);
+  const idents = [...new Set([...expr.matchAll(/\b([A-Za-z_]\w*)\b/g)].map(m => m[1]))];
+  const expanded = { ...scope, ...PRESEEDED };
+  for (const id of idents) {
+    if (id in expanded) continue;
+    const v = resolveIdentifier(src, id, scope, opts);
+    if (v != null) expanded[id] = v;
+  }
+  return safeEval(expr, expanded);
+}
+
+const SECTION_ANCHOR_RE = /\{\s*label:\s*'([^']+)'/g;
+
+/**
+ * Count `{ label: '...' }` anchors in already-comment-stripped source.
+ * `extractBundleSections` drops an anchor it cannot fully parse; comparing
+ * the two counts is how a caller proves nothing was dropped silently.
+ */
+export function countSectionAnchors(bundleSrc) {
+  return [...bundleSrc.matchAll(SECTION_ANCHOR_RE)].length;
+}
+
+/**
+ * Extract bundle sections via brace-balanced scan from each `{ label: '...'`
+ * anchor. The non-greedy `\{...?\}` regex would match at the first inner
+ * `}` for sections containing nested objects (e.g. `extraHeaders: {...}`),
+ * silently dropping them — which would let a real new violation slip past
+ * the guard. Greptile P2 on PR #3625.
+ *
+ * `bundleSrc` is comment-stripped first, so a commented-out section is not
+ * reported as live configuration.
+ */
+export function extractBundleSections(rawBundleSrc) {
+  const bundleSrc = stripLineComments(rawBundleSrc);
+  const sections = [];
+  for (const m of bundleSrc.matchAll(SECTION_ANCHOR_RE)) {
+    const label = m[1];
+    const startIdx = m.index;
+    // Walk forward balancing braces, respecting string literals.
+    let depth = 0, endIdx = -1, inStr = false, strCh = '';
+    for (let i = startIdx; i < bundleSrc.length; i++) {
+      const c = bundleSrc[i];
+      if (inStr) {
+        if (c === '\\') i++;     // skip escape
+        else if (c === strCh) inStr = false;
+        continue;
+      }
+      if (c === '"' || c === "'" || c === '`') { inStr = true; strCh = c; continue; }
+      if (c === '{') depth++;
+      else if (c === '}') { depth--; if (depth === 0) { endIdx = i; break; } }
+    }
+    if (endIdx < 0) continue;     // unbalanced — skip
+    const block = bundleSrc.slice(startIdx, endIdx + 1);
+    const scriptM = block.match(/script:\s*'([^']+)'/);
+    const intervalM = block.match(/intervalMs:\s*([^,}\n]+)/);
+    if (!scriptM || !intervalM) continue;
+    const timeoutM = block.match(/timeoutMs:\s*([^,}\n]+)/);
+    sections.push({
+      label,
+      script: scriptM[1],
+      intervalMsExpr: intervalM[1].trim(),
+      timeoutMsExpr: timeoutM ? timeoutM[1].trim() : null,
+    });
+  }
+  return sections;
+}
+
+/**
+ * Read a scalar option from the `runBundle(label, sections, opts)` call, e.g.
+ * `maxBundleMs`. Returns the raw expression, or null when the bundle does not
+ * declare it (an unbudgeted bundle).
+ */
+export function extractBundleOption(rawBundleSrc, name) {
+  const m = stripLineComments(rawBundleSrc).match(new RegExp(`${name}:\\s*([^,}\\n]+)`));
+  return m ? m[1].trim() : null;
+}
+
+/** Absolute paths of every `scripts/seed-bundle-*.mjs`, sorted. */
+export function listBundleFiles(scriptsDir) {
+  return readdirSync(scriptsDir)
+    .filter((f) => f.startsWith('seed-bundle-') && f.endsWith('.mjs'))
+    .sort()
+    .map((f) => join(scriptsDir, f));
+}

--- a/tests/seeder-canonical-ttl-vs-cron.test.mjs
+++ b/tests/seeder-canonical-ttl-vs-cron.test.mjs
@@ -46,9 +46,14 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  extractBundleSections,
+  listBundleFiles,
+  resolveExpr,
+} from './helpers/bundle-section-parser.mjs';
 
 const __filename = fileURLToPath(import.meta.url);     // ESM: must declare explicitly (Greptile P1 on PR #3625)
 const __dirname = dirname(__filename);
@@ -103,109 +108,10 @@ const KNOWN_VIOLATIONS = {
   'Displacement:seed-displacement-summary.mjs': '24h TTL vs 24h cron (1×)',
 };
 
-// Conventional bundle-level constants. Pre-seeded so `12 * HOUR` works
-// without parsing the bundle's own declaration.
-const PRESEEDED = {
-  MIN: 60 * 1000,
-  HOUR: 60 * 60 * 1000,
-  DAY: 24 * 60 * 60 * 1000,
-  WEEK: 7 * 24 * 60 * 60 * 1000,
-};
-
-/** Strip JS numeric-separator underscores so safe-eval can parse them. */
-function stripNumericUnderscores(s) {
-  // 7_200 → 7200, 86_400 → 86400. Only between digits, never adjacent.
-  return s.replace(/(\d)_(?=\d)/g, '$1');
-}
-
-/**
- * Safely evaluate a simple numeric expression. Allows digits, +-/*(), and
- * underscored identifiers (which must be in `scope`). Rejects anything
- * else with null. No `eval` — uses Function constructor with a strict
- * input-character whitelist + name-substitution.
- */
-function safeEval(expr, scope = {}) {
-  const trimmed = stripNumericUnderscores(String(expr).trim());
-  if (!/^[\w\s+\-*/().,_]+$/.test(trimmed)) return null;
-  let substituted = trimmed;
-  for (const [name, value] of Object.entries(scope)) {
-    if (typeof value !== 'number') continue;
-    substituted = substituted.replace(new RegExp(`\\b${name}\\b`, 'g'), `(${value})`);
-  }
-  if (!/^[\d\s+\-*/().]+$/.test(substituted)) return null;
-  try {
-    const result = Function(`"use strict"; return (${substituted})`)();
-    return Number.isFinite(result) ? result : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Find a `const|let|var|export const <name> = <expr>` declaration in `src`
- * and resolve to a number. Cycle-guarded.
- */
-function resolveIdentifier(src, name, scope = {}, _seen = new Set()) {
-  if (_seen.has(name)) return null;
-  if (name in scope) return scope[name];
-  if (name in PRESEEDED) return PRESEEDED[name];
-  _seen.add(name);
-  // Match: optional `export `, then `const|let|var <name> = <rhs>` up to ; // or newline
-  const re = new RegExp(`(?:^|\\n)\\s*(?:export\\s+)?(?:const|let|var)\\s+${name}\\s*=\\s*([^;\\n]+?)(?:\\s*(?://|;)|$)`, 'm');
-  const m = src.match(re);
-  if (!m) return null;
-  return resolveExpr(src, m[1].trim(), scope, _seen);
-}
-
-function resolveExpr(src, expr, scope = {}, _seen = new Set()) {
-  const direct = safeEval(expr, { ...PRESEEDED, ...scope });
-  if (direct != null) return direct;
-  if (/^\w+$/.test(expr)) return resolveIdentifier(src, expr, scope, _seen);
-  const idents = [...new Set([...expr.matchAll(/\b([A-Za-z_]\w*)\b/g)].map(m => m[1]))];
-  const expanded = { ...scope, ...PRESEEDED };
-  for (const id of idents) {
-    if (id in expanded) continue;
-    const v = resolveIdentifier(src, id, scope, _seen);
-    if (v != null) expanded[id] = v;
-  }
-  return safeEval(expr, expanded);
-}
-
-/**
- * Extract bundle sections via brace-balanced scan from each `{ label: '...'`
- * anchor. The non-greedy `\{...?\}` regex would match at the first inner
- * `}` for sections containing nested objects (e.g. `extraHeaders: {...}`),
- * silently dropping them — which would let a real new violation slip past
- * the guard. Greptile P2 on PR #3625.
- */
-function extractBundleSections(bundleSrc) {
-  const sections = [];
-  const anchorRe = /\{\s*label:\s*'([^']+)'/g;
-  for (const m of bundleSrc.matchAll(anchorRe)) {
-    const label = m[1];
-    const startIdx = m.index;
-    // Walk forward balancing braces, respecting string literals.
-    let depth = 0, endIdx = -1, inStr = false, strCh = '';
-    for (let i = startIdx; i < bundleSrc.length; i++) {
-      const c = bundleSrc[i];
-      if (inStr) {
-        if (c === '\\') i++;     // skip escape
-        else if (c === strCh) inStr = false;
-        continue;
-      }
-      if (c === '"' || c === "'" || c === '`') { inStr = true; strCh = c; continue; }
-      if (c === '{') depth++;
-      else if (c === '}') { depth--; if (depth === 0) { endIdx = i; break; } }
-    }
-    if (endIdx < 0) continue;     // unbalanced — skip
-    const block = bundleSrc.slice(startIdx, endIdx + 1);
-    const scriptM = block.match(/script:\s*'([^']+)'/);
-    const intervalM = block.match(/intervalMs:\s*([^,}\n]+)/);
-    if (!scriptM || !intervalM) continue;
-    sections.push({ label, script: scriptM[1], intervalMsExpr: intervalM[1].trim() });
-  }
-  return sections;
-}
+// The section parser and safe expression resolver live in
+// tests/helpers/bundle-section-parser.mjs, shared with
+// tests/bundle-budget-admission.test.mjs and covered by
+// tests/bundle-section-parser.test.mjs.
 
 function extractRunSeedTtl(seederSrc) {
   const m = seederSrc.match(/ttlSeconds:\s*([^,}\n]+)/);
@@ -215,9 +121,7 @@ function extractRunSeedTtl(seederSrc) {
 // ── Tests ────────────────────────────────────────────────────────────────
 
 test('every bundle section using runSeed has canonical TTL ≥ 3× cron interval', () => {
-  const bundleFiles = readdirSync(SCRIPTS_DIR)
-    .filter(f => f.startsWith('seed-bundle-') && f.endsWith('.mjs'))
-    .map(f => join(SCRIPTS_DIR, f));
+  const bundleFiles = listBundleFiles(SCRIPTS_DIR);
   assert.ok(bundleFiles.length > 0, 'no scripts/seed-bundle-*.mjs files found');
 
   const newViolations = [];     // (a) new violations not in allowlist → fail
@@ -300,101 +204,4 @@ test('every bundle section using runSeed has canonical TTL ≥ 3× cron interval
   assert.deepEqual(resolvedAllowlistEntries, [],
     `${resolvedAllowlistEntries.length} KNOWN_VIOLATIONS entry/entries are stale:\n  - ${resolvedAllowlistEntries.join('\n  - ')}`,
   );
-});
-
-// ── Sanity tests for the resolver itself ─────────────────────────────────
-
-test('resolver: numeric literal', () => {
-  assert.equal(resolveExpr('', '43200'), 43200);
-});
-
-test('resolver: numeric literal with underscores (7_200, 86_400)', () => {
-  assert.equal(resolveExpr('', '7_200'), 7200);
-  assert.equal(resolveExpr('', '86_400'), 86400);
-});
-
-test('resolver: simple multiplication', () => {
-  assert.equal(resolveExpr('', '35 * 24 * 3600'), 35 * 24 * 3600);
-});
-
-test('resolver: preseeded HOUR/DAY/WEEK constants', () => {
-  assert.equal(resolveExpr('', '12 * HOUR'), 12 * 3600 * 1000);
-  assert.equal(resolveExpr('', '7 * DAY'), 7 * 24 * 3600 * 1000);
-  assert.equal(resolveExpr('', 'WEEK'), 7 * 24 * 3600 * 1000);
-});
-
-test('resolver: const declared in src (with underscored numeric)', () => {
-  const src = 'const TTL_SECONDS = 86_400;\n';
-  assert.equal(resolveExpr(src, 'TTL_SECONDS'), 86400);
-});
-
-test('resolver: export const declared in src', () => {
-  const src = 'export const CACHE_TTL_SECONDS = 2700;\n';
-  assert.equal(resolveExpr(src, 'CACHE_TTL_SECONDS'), 2700);
-});
-
-test('resolver: const expression mixing identifiers + arithmetic', () => {
-  const src = 'const TTL = 35 * 24 * 3600;\n';
-  assert.equal(resolveExpr(src, 'TTL'), 35 * 24 * 3600);
-});
-
-test('resolver: returns null on unresolvable identifier', () => {
-  assert.equal(resolveExpr('', 'COMPLETELY_UNKNOWN'), null);
-});
-
-test('resolver: rejects unsafe input', () => {
-  assert.equal(resolveExpr('', 'process.env.X'), null);
-  assert.equal(resolveExpr('', 'someFunction()'), null);
-});
-
-test('extractBundleSections: catches sections with intervalMs', () => {
-  const sample = `
-const HOUR = 60 * 60 * 1000;
-export const SECTIONS = [
-  { label: 'A', script: 'seed-a.mjs', intervalMs: HOUR, timeoutMs: 120_000 },
-  { label: 'B', script: 'seed-b.mjs', canonicalKey: 'foo', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
-];
-`;
-  const sections = extractBundleSections(sample);
-  assert.equal(sections.length, 2);
-  assert.equal(sections[0].label, 'A');
-  assert.equal(sections[1].intervalMsExpr, '12 * HOUR');
-});
-
-test('extractBundleSections: handles sections with nested objects (Greptile P2)', () => {
-  // Pre-fix the regex `\{ ... \}` non-greedy match would END at the first
-  // inner `}` (the close of `{ 'X-Auth': '...' }`), leaving the outer
-  // section's `script:` and `intervalMs:` outside the captured block →
-  // section silently dropped → real new violation could slip past the guard.
-  const sample = `
-const HOUR = 60 * 60 * 1000;
-export const SECTIONS = [
-  {
-    label: 'WithNested',
-    script: 'seed-with-nested.mjs',
-    extraHeaders: { 'X-Auth': 'Bearer xxx', 'Content-Type': 'application/json' },
-    intervalMs: 6 * HOUR,
-    timeoutMs: 300_000,
-  },
-];
-`;
-  const sections = extractBundleSections(sample);
-  assert.equal(sections.length, 1, 'section with nested object must be detected');
-  assert.equal(sections[0].label, 'WithNested');
-  assert.equal(sections[0].script, 'seed-with-nested.mjs');
-  assert.equal(sections[0].intervalMsExpr, '6 * HOUR');
-});
-
-test('extractBundleSections: handles strings containing braces', () => {
-  // Defensive: if a string literal contains `{` or `}`, brace-counting
-  // must not be confused.
-  const sample = `
-const SECTIONS = [
-  { label: 'StrWithBrace', script: 'seed-str.mjs', regexFilter: 'foo\\\\{bar}', intervalMs: 1000 },
-];
-`;
-  const sections = extractBundleSections(sample);
-  assert.equal(sections.length, 1);
-  assert.equal(sections[0].script, 'seed-str.mjs');
-  assert.equal(sections[0].intervalMsExpr, '1000');
 });


### PR DESCRIPTION
Fixes #6556.

## The bug

`seed-bundle-resilience` published nothing for six hours behind a green Railway badge.

`_bundle-runner` admits a section only when `elapsed + timeoutMs + KILL_GRACE_MS <= maxBundleMs`. #6531 set `maxBundleMs: 570_000` against sections declaring 600_000 / 900_000 / 600_000, so the cheapest needed 610_000. No section could ever be admitted. Every tick deferred everything and exited 0 — and deferral is not a failure, so Railway painted SUCCESS. The only detector was a seed-meta staleness alarm ~14 hours later.

Reproduced against the shipped config before touching anything:

```
shipped: unadmittable 3/3 — Resilience-Scores needs 610000ms,
Resilience-Static needs 910000ms, Food-Stocks needs 610000ms
```

which matches the production log in the issue exactly.

## The fix

**Right-sized timeouts**, against measured runtime and each seeder's own internal deadline rather than against the container cap: Scores 600s -> 240s (~5.7s warm, 1-2min cold), Static 900s -> 420s (~92s design worst case across 11 concurrent adapters), Food-Stocks 600s -> 480s (its own `fetchPhaseTimeoutMs` is 420s, so runSeed's graceful last-good path fires before the runner SIGTERMs). None of the old values bounded anything anyway — Railway SIGKILLs the container at 10 minutes, taking the logs with it.

**A startup guard.** A section whose worst case cannot fit the whole budget can never be admitted on any tick. That is a static config error, not runtime pressure, so `runBundle` now throws before spawning anything — alongside the `dependsOn` contract already there.

**A starved-tick exit code.** A tick that completed nothing while deferring due work exits non-zero. `ran:0 deferred:>0` is otherwise indistinguishable from a healthy no-op.

**A repo-wide CI gate** (`tests/bundle-budget-admission.test.mjs`) asserting the arithmetic for every section of every budgeted bundle, so the next mis-sized budget fails the PR rather than the service.

## Review found the guard reproducing the bug it catches

Worth calling out, because it is the same failure class twice. Three reviewers independently found that the startup check used `worstCase > maxBundleMs`, so a section sized at exactly `maxBundleMs - KILL_GRACE_MS` **passed the guard and was still deferred forever** — the runtime test is `elapsed + worstCase <= maxBundleMs`, and `elapsed` is never zero because the freshness gate has already run. The cross-model pass verified it by execution:

```
findUnadmittableSections([{timeoutMs: 560_000}], 570_000)  ->  []
```

Fixed with `ADMISSION_HEADROOM_MS`, derived from the runner's own `REDIS_READ_TIMEOUT_MS` (up to three freshness reads precede admission) so the two numbers cannot drift apart. Both boundary directions are now pinned by tests, and all six budgeted bundles still pass.

Two more of the same shape, also from review:

- The gate's own anti-vacuity check was **self-comparing** — `countSectionAnchors` shared its regex with the extractor, so "nothing was dropped" only proved the extractor agreed with itself. A section written `{ script: ..., label: ... }` is invisible to both sides, the counts match, and the gate passes on a bundle it never read. Now counts `script:` independently; mutation-tested by reordering keys in `seed-bundle-portwatch`, which the old check passed and the new one fails.
- `starvedTick` was too broad: it fired when the only admitted section exited 75 (a transient upstream blip, no data lost), turning a benign 429 into "Deploy Crashed!" — the alert fatigue the graceful exemption exists to prevent. Narrowed, and the remaining shape now has a real test driving a slow fake Upstash so the freshness gate itself burns the budget.

Plus fail-closed handling wherever the config parser could return a *wrong* number rather than no number (a wrong, smaller timeout is one a budget gate passes): nested/shorthand/spread timeouts drop the section, a non-finite `maxBundleMs` throws instead of silently unbudgeting the tick, and the gate now asserts each budget is under Railway's 10-minute cap — nothing checked that, so a `900_000` budget satisfied every other assertion while the container still died mid-publish.

## A latent bug fixed on the way

Extracting the shared parser exposed one: an apostrophe in a section comment (`the seeder's`) opened a phantom string literal and broke brace balancing, silently hiding **all** of `seed-bundle-portwatch-port-activity` from the existing TTL-vs-cron gate. Sections visible to that gate: 97 -> 98, no new violations. Verified the extraction is otherwise behaviour-preserving by diffing that gate's skip list before and after — identical except the bundle it had been dropping.

## Acceptance (from the issue)

- [x] `seed-bundle-resilience` admits and runs `Resilience-Scores` on its cron tick — every section now fits the budget with headroom; pinned by name in the regression test
- [x] A tick that defers every due section fails loudly rather than exiting 0 — plus the stronger startup guard, which catches it before a tick runs at all
- [x] The admission arithmetic is pinned by a test, for every section of every budgeted bundle
- [ ] `/api/health` returns to OK for `resilienceRanking` / `resilienceIntervals` — follows from the first cron tick after deploy; verify post-merge

## Verification

914 tests green across the bundle, resilience, registry, and CI-wiring suites; `biome lint` and `tsc --noEmit` clean. Both new guards were mutation-tested — reverting the timeouts to the #6531 values turns the gate red with the exact production numbers (610000ms / 910000ms), and reordering a section's keys turns the anti-vacuity check red.

Follow-ups deliberately scoped out are tracked in #6562 (unmeasured Static timeout ahead of its Oct 1-3 window, its orphaned 2h lock on SIGTERM, the unbounded laggard phase in Scores, and per-section starvation while the bundle still reports success).

https://claude.ai/code/session_01Ck7uJE6cyS1NeZV6FDVmkG
