### PR TITLE
fix(resilience): fail closed on malformed blend inputs

### DIFF
--- a/docs/solutions/best-practices/weighted-blend-renormalization-turns-corruption-into-a-higher-score.md
+++ b/docs/solutions/best-practices/weighted-blend-renormalization-turns-corruption-into-a-higher-score.md
@@ -57,9 +57,11 @@ weighted mean of whatever survived. When the surviving legs read **higher** than
 the leg that was lost, **losing data raises the score**. A data-quality
 regression is published as an improvement in national resilience.
 
-This is filed as **issue #6528** and is **not fixed**. What follows is the
-measured mechanism, two remedies that look right and are not, and the diagnostic
-that separated them.
+This was **issue #6528**. The fix keeps the generic blend conservative when a
+reader can prove that a field was present but malformed: the slot keeps its
+design weight and contributes an explicit fallback score. Genuine absence keeps
+the existing coverage-weighted behavior. What follows is the measured mechanism,
+the remedies that were rejected, and the diagnostic that separated them.
 
 ## Symptoms (measured, not reasoned)
 
@@ -205,7 +207,7 @@ When someone asks "what happens if this component goes null?", the answer is a
 number from the real blend, per transform, not an argument about
 renormalisation.
 
-## Candidate remedies (issue #6528 — options, not decisions)
+## Candidate remedies (issue #6528 — decision recorded)
 
 1. **Impute rather than drop.** A missing slot resolves to a conservative score
    at reduced `certaintyCoverage`, keeping its weight in the denominator while
@@ -227,17 +229,22 @@ renormalisation.
    the same `null` (`:2339-2340`), so the information does not exist at the
    blend layer today.
 
-Note that remedy 1 also fixes the coverage/score contradiction: an imputed slot
-keeps the denominator whole, so the score stays put and coverage still falls —
-both signals then point the same way.
+The implementation chooses remedy 3 at the reader boundary and uses the
+generic blend's explicit fallback path. A malformed BIS claims or parent-count
+field contributes zero at its design weight, while coverage still falls. A
+legitimately absent field remains unannotated and keeps the prior absence
+semantics. This preserves existing call-site behavior while making the
+malformed-input path fail closed.
 
 ## Scope
 
 This is a property of `weightedBlend`'s drop-and-renormalise semantics, so it is
 **not specific to `financialSystemExposure`, to BIS data, or to `parentCount`**.
-There are 23 `weightedBlend` call sites in
-`server/worldmonitor/resilience/v1/_dimension-scorers.ts`, and every dimension
-whose slots can read at different levels inherits the behaviour.
+The primitive now supports an explicit fallback for any reader that can prove
+that a null score came from malformed input. There are 23 `weightedBlend` call
+sites in `server/worldmonitor/resilience/v1/_dimension-scorers.ts`; readers that
+only report genuine absence retain the old behavior until they can provide that
+distinction.
 
 **Exposure is proportional to the spread between the dropped slot and the
 survivors.** A dimension whose slots cluster tightly barely moves when one
@@ -248,27 +255,26 @@ risk.
 
 ## What is guarded today — and what is not
 
-`tests/resilience-financial-system-exposure.test.mts:651-694` pins one property:
-the diversity conditioning must never **widen** the inflation it inherited.
+`tests/resilience-dimension-scorers.test.mts` pins the generic contract: an
+explicit fallback keeps a malformed slot in the denominator, while an
+unannotated null still follows the existing absence behavior. The financial
+system exposure tests then exercise that contract through a stringified BIS
+`parentCount` and assert that the published score does not rise.
 
 ```ts
-assert.ok(conditionedInflation <= inheritedInflation, ...);   // :686
-assert.ok(inheritedInflation > 0,                             // :691
-  'guard integrity: if the blend stops inflating, delete this test and close #6528 '
-  + 'rather than letting it pass vacuously');
+assert.ok(conditionedInflation <= 0, ...);  // malformed input must not raise score
+assert.ok(inheritedInflation > 0, ...);     // pre-fix counterfactual stays non-vacuous
 ```
 
-The second assertion is the load-bearing one. A comparison test of the form
-"A ≤ B" passes trivially when both are zero — that is, it would go green the day
-the blend stops inflating *and* the day someone accidentally neuters the
-fixture. The non-vacuity assert forces the guard to fail loudly rather than
-succeed silently once its premise dies. The inherited baseline is computed by a
-local `blendFinSys` helper (`:61`) that mirrors the drop-and-renormalise
-semantics for the *unconditioned* side only; the conditioned side always runs
-the real `scoreFinancialSystemExposure`.
+The second assertion keeps the old counterfactual non-vacuous. The inherited
+baseline is computed by a local `blendFinSys` helper (`:61`) that mirrors the
+pre-fix drop-and-renormalise semantics for the *unconditioned* side only; the
+conditioned side always runs the real `scoreFinancialSystemExposure` and must
+stay at or below the honest score.
 
-That is a regression guard on **one dimension**. It is not a fix, and it does
-not constrain the other 22 call sites.
+The generic test constrains the blend primitive; the reader-level test shows how
+to connect a real parser failure to that path. It does not claim that a reader
+which cannot distinguish absence from corruption is safe by default.
 
 ## Prevention
 
@@ -298,9 +304,9 @@ conclusion.
 
 ## Related
 
-- Issue #6528 — the open blend-layer defect described here.
+- Issue #6528 — fixed by the explicit malformed-slot fallback path.
 - PR #6529 — diversity-conditioned integration premium; carries the one-dimension
-  regression guard and reduces (does not fix) the inflation.
+  regression guard and now benefits from the blend fix.
 - `_dimension-scorers.ts:2139-2143` — the same renormalisation failure caught
   once before on the debt slot (#6459), fixed there by imputing rather than
   dropping.

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -69,9 +69,14 @@ export interface ResilienceDimensionScore {
 
 export type ResilienceSeedReader = (key: string) => Promise<unknown | null>;
 
-interface WeightedMetric {
+export interface WeightedMetric {
   score: number | null;
   weight: number;
+  // A known malformed reading can preserve its design weight with a
+  // conservative fallback instead of letting weightedBlend renormalize the
+  // missing weight onto unrelated survivors. Genuine absence leaves this
+  // unset and keeps the existing coverage-weighted drop behavior.
+  fallbackScore?: number;
   // When a sub-metric is imputed (absence is a typed signal, not a gap), certaintyCoverage
   // expresses how confident we are in the imputation: 1.0 = real data, 0 = fully absent.
   // Omit for real data (auto: 1.0 if score != null, 0 if null).
@@ -803,20 +808,17 @@ export function normalizeBandLowerBetter(value: number): number {
 //     exists to fix. The sibling `normalizeBandLowerBetter` neutralises
 //     malformed input the same way.
 //
-// Capping the band is necessary but not SUFFICIENT to make a `parentCount`
-// parse regression fail closed, and this function cannot make it so. The same
-// missing count also nulls the Component 4 slot, and `weightedBlend`
-// renormalises the freed weight onto the survivors — for a country whose debt
-// and FATF legs read high, that renormalisation RAISES the published score.
-// Measured on the pinned Albania fixture: honest 70 -> 80 with the count
-// unparseable.
+// Capping the band is necessary but not sufficient to make a `parentCount`
+// parse regression fail closed. The reader marks a present-but-invalid count
+// as malformed, and the blend retains that slot with a conservative fallback
+// score of zero. A genuinely absent count remains null without a fallback, so
+// it keeps the existing absence and coverage semantics.
 //
-// That inflation is a property of the blend, not of this conditioning, and it
-// predates it: the same measurement against the raw band is 75 -> 86, so the
-// conditioning strictly REDUCES it (+10 vs +11). Coupling the two BIS slots so
-// a half-parsed row resolves neither was measured too and is worse still
-// (-> 83): it frees even more weight onto the high legs. The real fix is at
-// the blend layer — see issue #6528 — and is deliberately not attempted here.
+// This distinction matters because `weightedBlend` otherwise renormalises a
+// missing Component 4 slot onto the survivors. For a country whose debt and
+// FATF legs read high, that can raise the published score. The generic blend
+// now supports an explicit fallback for this known-corrupt-input case; the
+// conditioning function only supplies the bounded band value and its signal.
 //
 // Known conservative edge: parentCount counts only parents above 1% of GDP,
 // so a country integrated through many sub-threshold parents forfeits a
@@ -872,16 +874,25 @@ const IMPUTATION_CLASS_TIE_BREAK: readonly ImputationClass[] = [
 const MINUTE_MS = 60 * 1000;
 const WGI_INDICATOR_KEYS: readonly string[] = wgiIndicatorKeys;
 
-function weightedBlend(metrics: WeightedMetric[]): ResilienceDimensionScore {
+export function weightedBlend(metrics: WeightedMetric[]): ResilienceDimensionScore {
   const totalWeight = metrics.reduce((sum, metric) => sum + metric.weight, 0);
   const available = metrics.filter(hasFiniteMetricScore);
   const availableWeight = available.reduce((sum, metric) => sum + metric.weight, 0);
+  const fallback = metrics.filter((metric) => !hasFiniteMetricScore(metric) && Number.isFinite(metric.fallbackScore));
+  const fallbackWeight = fallback.reduce((sum, metric) => sum + metric.weight, 0);
+  const scoringWeight = availableWeight + fallbackWeight;
 
-  if (!availableWeight || !totalWeight) {
+  if (!scoringWeight || !totalWeight) {
     return { score: 0, coverage: 0, observedWeight: 0, imputedWeight: 0, imputationClass: null, freshness: { lastObservedAtMs: 0, staleness: '' } };
   }
 
-  const weightedScore = available.reduce((sum, metric) => sum + metric.score * metric.weight, 0) / availableWeight;
+  // A malformed slot with an explicit fallback keeps its weight in the
+  // denominator. This prevents a low leg from disappearing and raising the
+  // published score, while ordinary absence still renormalizes as before.
+  const weightedScore = (
+    available.reduce((sum, metric) => sum + metric.score * metric.weight, 0)
+    + fallback.reduce((sum, metric) => sum + (metric.fallbackScore ?? 0) * metric.weight, 0)
+  ) / scoringWeight;
 
   // Coverage: weighted average of certainty per metric, computed against the
   // NOMINAL design-time weight rather than the runtime weight. Real data → 1.0;
@@ -2211,10 +2222,9 @@ export async function scoreFinancialSystemExposure(
       // proportion to demonstrated parent breadth (see
       // `normalizeDiversityConditionedBand`). Passing `parentCount` from the
       // same BIS row keeps level and breadth reads consistent per country.
-      // A missing count caps the premium here but cannot stop the blend from
-      // renormalising the freed Component 4 weight onto the surviving legs —
-      // pre-existing, measured, and reduced (not caused) by the conditioning:
-      // issue #6528.
+      // A missing count caps the premium here. A malformed claims field is
+      // also retained as a conservative zero fallback by weightedBlend so a
+      // parser regression cannot free this slot's weight onto unrelated legs.
       //
       // This slot now has TWO designed inputs (level and breadth), so it can
       // resolve only half-observed. `certaintyCoverage` says which: a withheld
@@ -2229,6 +2239,7 @@ export async function scoreFinancialSystemExposure(
         ? null
         : normalizeDiversityConditionedBand(bisCountry.totalXborderPctGdp, bisCountry.parentCount),
       weight: FIN_SYS_BAND_WEIGHT,
+      fallbackScore: bisCountry?.totalXborderPctGdpMalformed ? 0 : undefined,
       certaintyCoverage: resolveFinSysBandCertainty(bisCountry),
     },
     {
@@ -2242,6 +2253,7 @@ export async function scoreFinancialSystemExposure(
         ? null
         : normalizeHigherBetter(bisCountry.parentCount, 1, 10),
       weight: FIN_SYS_REDUNDANCY_WEIGHT,
+      fallbackScore: bisCountry?.parentCountMalformed ? 0 : undefined,
       // A count computed over an incomplete reporting-parent set is an
       // undercount, not an observation — same reasoning as the band slot.
       certaintyCoverage: bisCountry != null && !bisCountry.parentSetComplete
@@ -2343,6 +2355,11 @@ function readWbExternalDebtPct(envelope: WbExternalDebtEnvelope, countryCode: st
 interface BisLbsCountry {
   totalXborderPctGdp: number | null;
   parentCount: number | null;
+  // True when the field was present but failed the reader's type/range
+  // contract. A genuinely absent field remains distinguishable and keeps the
+  // scorer's existing coverage-weighted absence behavior.
+  totalXborderPctGdpMalformed: boolean;
+  parentCountMalformed: boolean;
   /**
    * False when the seed envelope reports that the BIS collection ran with an
    * incomplete reporting-parent set (`successfulParents < parentCountries`).
@@ -2460,19 +2477,16 @@ const FIN_SYS_BIS_REPORTING_PARENTS_MAX = 16;
  * `Object.values(parents).filter(...).length` over an enumerated list, so a
  * legitimate value is a non-negative integer no larger than that list.
  *
- * The pre-existing `typeof === 'number'` check rejects the UNREACHABLE cases
- * (`NaN`, `Infinity`, a stringified count) while trusting any finite number,
- * including reachable-by-corruption ones. That asymmetry matters more now that
- * the band premium reads the same field: a payload carrying `parentCount: 500`
- * clamps to redundancy 100 and earns BOTH the full premium (0.30) and a perfect
- * Component 4 (0.15), so a corrupt cache entry buys 0.45 of the dimension where
- * before it bought 0.15.
+ * The type, finiteness, integer, and range checks reject malformed or
+ * impossible values. `readBisLbsCountry` keeps the nullable result for the
+ * conditioning arithmetic, and separately records when a non-null raw field
+ * failed these checks so the blend can retain its design weight with a
+ * conservative fallback.
  *
- * An implausible value is treated exactly like a malformed one — absent — so
- * this adds no new resolution path. The freed Component 4 weight still
- * renormalises onto the survivors (issue #6528); that is unchanged and out of
- * scope here. What changes is that an impossible count no longer reads as
- * demonstrated diversity.
+ * An implausible value is therefore treated as absent for diversity evidence,
+ * but not as an ordinary missing slot when it was present in the payload.
+ * Genuine absence remains distinguishable and keeps the existing
+ * coverage-weighted absence semantics.
  */
 function readPlausibleParentCount(rawParentCount: unknown, maxParents: number): number | null {
   if (typeof rawParentCount !== 'number') return null;
@@ -2504,12 +2518,19 @@ function readBisLbsCountry(raw: unknown, countryCode: string): BisLbsCountry | n
     ? rawSuccessfulParents >= attemptedParents
     : true;
 
+  const totalXborderPctGdp = typeof rawClaims === 'number' && rawClaims >= 0
+    ? safeNum(rawClaims)
+    : null;
+  const parentCount = readPlausibleParentCount(rawParentCount, attemptedParents);
+
   return {
     // `safeNum(null)` and `safeNum('')` are numeric zero by design. These
     // fields use zero as a real financial-isolation signal, so require a raw
     // number rather than manufacturing an observed zero from malformed data.
-    totalXborderPctGdp: typeof rawClaims === 'number' ? safeNum(rawClaims) : null,
-    parentCount: readPlausibleParentCount(rawParentCount, attemptedParents),
+    totalXborderPctGdp,
+    parentCount,
+    totalXborderPctGdpMalformed: rawClaims != null && totalXborderPctGdp == null,
+    parentCountMalformed: rawParentCount != null && parentCount == null,
     parentSetComplete,
   };
 }

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -32,6 +32,7 @@ import {
   scoreStateContinuity,
   scoreInflationStability,
   scoreTradePolicy,
+  weightedBlend,
   roundScore,
   sqrtCount,
   summarizeCyber,
@@ -192,6 +193,27 @@ describe('resilience dimension scorers', () => {
     assert.equal(result.observedWeight, 5);
     assert.equal(result.imputedWeight, 0);
     assert.equal(result.imputationClass, null);
+  });
+
+  it('weightedBlend retains a known malformed slot without renormalizing its weight', () => {
+    const complete = weightedBlend([
+      { score: 100, weight: 0.5 },
+      { score: 0, weight: 0.5 },
+    ]);
+    const malformed = weightedBlend([
+      { score: 100, weight: 0.5 },
+      { score: null, weight: 0.5, fallbackScore: 0 },
+    ]);
+    const genuinelyAbsent = weightedBlend([
+      { score: 100, weight: 0.5 },
+      { score: null, weight: 0.5 },
+    ]);
+
+    assert.equal(complete.score, 50);
+    assert.equal(malformed.score, complete.score, 'a malformed low slot must not free weight onto the high survivor');
+    assert.equal(malformed.coverage, 0.5, 'the retained malformed slot must still reduce coverage');
+    assert.equal(malformed.observedWeight, 0.5, 'the fallback must not masquerade as observed data');
+    assert.equal(genuinelyAbsent.score, 100, 'legitimate absence keeps the existing coverage-weighted behavior');
   });
 
   it('returns all serialized dimensions with bounded scores and coverage', async () => {

--- a/tests/resilience-financial-system-exposure.test.mts
+++ b/tests/resilience-financial-system-exposure.test.mts
@@ -65,13 +65,15 @@ import {
 const TEST_ISO2 = 'XX';
 
 /**
- * Albania's blend on a given band score, mirroring `weightedBlend`'s
- * drop-and-renormalise semantics. Used only to measure the INHERITED
- * inflation (the unconditioned band) as a baseline the conditioning is
- * compared against — the conditioned side of that comparison always goes
- * through the real `scoreFinancialSystemExposure`.
+ * Albania's blend on a given band score, mirroring the production blend. The
+ * optional preFixRenormalization mode preserves the old drop-and-renormalise
+ * arithmetic for the inherited-baseline counterfactual only.
  */
-function blendFinSys(band: number, parentCount: number | null): number {
+function blendFinSys(
+  band: number | null,
+  parentCount: number | null,
+  options: { preFixRenormalization?: boolean } = {},
+): number {
   // Every leg goes through the PRODUCTION transform at the PRODUCTION weight,
   // imported rather than restated. The earlier version hand-rolled the debt
   // normalization as `100 - value / 15 * 100` and the redundancy leg as
@@ -105,12 +107,13 @@ function blendFinSys(band: number, parentCount: number | null): number {
   ];
   let num = 0;
   let den = 0;
+  const totalWeight = slots.reduce((sum, [, weight]) => sum + weight, 0);
   for (const [score, weight] of slots) {
     if (score == null) continue;
     num += score * weight;
     den += weight;
   }
-  return Math.round(num / den);
+  return Math.round(num / (options.preFixRenormalization ? den : totalWeight));
 }
 const VALID_DEBT_CONTROL_COUNTRY = 'ZZ';
 const VALID_DEBT_SCHEMA_VERSION = 2;
@@ -814,7 +817,7 @@ describe('scoreFinancialSystemExposure — the band slot reports its own certain
     );
   });
 
-  it('an OBSERVED parentCount of 0 is distinguished from an absent one', async () => {
+  it('an OBSERVED parentCount of 0 is distinguished from a malformed one', async () => {
     // 0 means "no parent clears the 1%-of-GDP threshold" — an observation, not
     // an absence. Both withhold the whole premium, so the BAND leg is identical:
     assert.equal(normalizeDiversityConditionedBand(AL_CLAIMS, 0), 75);
@@ -824,32 +827,27 @@ describe('scoreFinancialSystemExposure — the band slot reports its own certain
       'AL',
       createFinSysFixtureReader({ bis: { AL: { totalXborderPctGdp: AL_CLAIMS, parentCount: 0 } } }),
     );
-    const breadthAbsent = await scoreFinancialSystemExposure(
+    const malformedBreadth = await scoreFinancialSystemExposure(
       'AL',
       createFinSysFixtureReader({
-        bis: { AL: { totalXborderPctGdp: AL_CLAIMS, parentCount: null as unknown as number } },
+        bis: { AL: { totalXborderPctGdp: AL_CLAIMS, parentCount: String(FINSYS_BIS_FIXTURE.AL.parentCount) as unknown as number } },
       }),
     );
 
     assert.ok(
-      observedZero.coverage > breadthAbsent.coverage,
-      `an observed 0 must report higher coverage than an absent count `
-        + `(observed ${observedZero.coverage}, absent ${breadthAbsent.coverage})`,
+      observedZero.coverage > malformedBreadth.coverage,
+      `an observed 0 must report higher coverage than a malformed count `
+        + `(observed ${observedZero.coverage}, malformed ${malformedBreadth.coverage})`,
     );
 
-    // ...and the uncomfortable half, pinned deliberately rather than left to be
-    // rediscovered: at the DIMENSION level the absent count scores HIGHER than
-    // the observed 0, because Component 4 scores an observed 0 as a real 0 that
-    // drags the blend down, while a null drops the slot and `weightedBlend`
-    // renormalises its 0.15 onto the high survivors. Measuring worse therefore
-    // scores worse than measuring nothing. That is issue #6528, not this
-    // conditioning — the band leg above is identical in both — and it is pinned
-    // here so a future blend fix shows up as this assertion flipping.
+    // A malformed count must not score higher than an observed zero. The failed
+    // slot retains its design weight in the fixed blend and contributes no
+    // score, while the observed zero contributes an explicit zero at that same
+    // weight. This is the #6528 contract at the real scorer seam.
     assert.ok(
-      breadthAbsent.score > observedZero.score,
-      'expected the #6528 renormalisation to favour the absent count '
-        + `(absent ${breadthAbsent.score}, observed-zero ${observedZero.score}) — if this flipped, `
-        + 'the blend was fixed: delete this assertion and close #6528',
+      malformedBreadth.score <= observedZero.score,
+      'a malformed count must not outrank an observed zero '
+        + `(malformed ${malformedBreadth.score}, observed-zero ${observedZero.score})`,
     );
   });
 
@@ -858,10 +856,10 @@ describe('scoreFinancialSystemExposure — the band slot reports its own certain
     // redundancy 100 and earn BOTH the full premium (0.30) and a perfect
     // Component 4 (0.15) — 0.45 of the dimension bought by a corrupt field.
     const honest = await scoreFinancialSystemExposure('AL', createFinSysFixtureReader());
-    const breadthAbsent = await scoreFinancialSystemExposure(
+    const malformedBreadth = await scoreFinancialSystemExposure(
       'AL',
       createFinSysFixtureReader({
-        bis: { AL: { totalXborderPctGdp: AL_CLAIMS, parentCount: null as unknown as number } },
+        bis: { AL: { totalXborderPctGdp: AL_CLAIMS, parentCount: String(FINSYS_BIS_FIXTURE.AL.parentCount) as unknown as number } },
       }),
     );
     // What a TRUSTED implausible count would have scored: an out-of-range count
@@ -882,7 +880,7 @@ describe('scoreFinancialSystemExposure — the band slot reports its own certain
       );
       assert.equal(
         corrupt.score,
-        breadthAbsent.score,
+        malformedBreadth.score,
         `parentCount=${bogus} must score exactly like an absent count`,
       );
       assert.ok(
@@ -896,14 +894,12 @@ describe('scoreFinancialSystemExposure — the band slot reports its own certain
       );
     }
 
-    // The residual, stated so nobody reads the above as "corruption now fails
-    // closed": the dimension score still rises above the honest reading, because
-    // the freed Component 4 weight renormalises onto the high survivors. This
-    // fix bounds the damage (the premium is no longer bought), it does not
-    // remove it — that is issue #6528.
+    // A corrupt count must not raise the honest dimension score. The fixed
+    // blend keeps the missing slot in the denominator with a zero contribution,
+    // so the data-quality regression cannot buy resilience.
     assert.ok(
-      breadthAbsent.score > honest.score,
-      'residual #6528 inflation expected; if this flipped, the blend was fixed',
+      malformedBreadth.score <= honest.score,
+      `corrupt parentCount must not raise the honest score (honest ${honest.score}, corrupt ${malformedBreadth.score})`,
     );
   });
 
@@ -925,23 +921,54 @@ describe('scoreFinancialSystemExposure — the band slot reports its own certain
   });
 });
 
-describe('scoreFinancialSystemExposure — half-parsed BIS row (pre-existing blend inflation)', () => {
-  it('the conditioning must not widen the renormalisation inflation it inherited', async () => {
-    // A `parentCount` that fails to parse nulls the Component 4 slot, and
-    // `weightedBlend` renormalises its freed 0.15 onto the survivors. When the
-    // surviving legs read high, that RAISES the published score: Albania goes
-    // 70 -> 80 with its count unparseable. `readBisLbsCountry` requires a raw
-    // number, so a seeder publishing the count as a string is exactly this.
+describe('scoreFinancialSystemExposure — half-parsed BIS row', () => {
+  it('does not let a malformed claims field raise the published score', async () => {
+    const real = FINSYS_BIS_FIXTURE.AL;
+    const honest = await scoreFinancialSystemExposure('AL', createFinSysFixtureReader());
+    const malformedClaims = [
+      ['string', String(real.totalXborderPctGdp) as unknown as number],
+      ['negative', -1],
+      ['NaN', Number.NaN],
+      ['Infinity', Number.POSITIVE_INFINITY],
+    ] as const;
+
+    for (const [label, totalXborderPctGdp] of malformedClaims) {
+      const result = await scoreFinancialSystemExposure(
+        'AL',
+        createFinSysFixtureReader({ bis: { AL: { ...real, totalXborderPctGdp } } }),
+      );
+
+      // A present-but-invalid claims field is a retained zero at the 0.30
+      // band weight. The mirror uses a null band to model the parser result
+      // and keeps the fixed denominator, so this checks reader-to-blend wiring
+      // rather than only checking that the score moves in the safe direction.
+      assert.equal(
+        blendFinSys(null, real.parentCount),
+        result.score,
+        `${label} claims must retain the band weight as a zero fallback`,
+      );
+      assert.ok(
+        result.score <= honest.score,
+        `${label} claims must not raise the honest score (honest ${honest.score}, corrupt ${result.score})`,
+      );
+      assert.ok(
+        result.coverage < honest.coverage,
+        `${label} claims must lower coverage (honest ${honest.coverage}, corrupt ${result.coverage})`,
+      );
+    }
+  });
+
+  it('does not let a malformed parentCount raise the published score', async () => {
+    // A `parentCount` that fails to parse nulls the Component 4 slot. Before
+    // #6528, `weightedBlend` renormalised the freed 0.15 onto the survivors and
+    // Albania rose from 70 to 80. `readBisLbsCountry` requires a raw number, so
+    // a seeder publishing the count as a string is exactly this corruption.
     //
     // This is a property of the blend and PREDATES the diversity conditioning
-    // — against the raw band the same measurement is 74 -> 86. The real fix is
-    // at the blend layer (issue #6528); conditioning cannot close it, because
-    // the band slot has no way to hold weight the blend has already freed.
-    //
-    // What this test pins is the part the conditioning DOES own: it must never
-    // make the inherited inflation worse. Coupling the two BIS slots so a
-    // half-parsed row resolves neither was tried and measured at 83 — worse,
-    // because it frees even more weight onto the high legs.
+    // — against the raw band the same measurement is 74 -> 86. The reader now
+    // distinguishes this malformed field from a genuinely absent one, and the
+    // blend retains its weight with a conservative fallback. The conditioning
+    // arithmetic and coverage signal must remain unchanged.
     const real = FINSYS_BIS_FIXTURE.AL;
     const honest = await scoreFinancialSystemExposure('AL', createFinSysFixtureReader());
     const halfParsed = await scoreFinancialSystemExposure(
@@ -953,14 +980,11 @@ describe('scoreFinancialSystemExposure — half-parsed BIS row (pre-existing ble
 
     const conditionedInflation = halfParsed.score - honest.score;
 
-    // MIRROR FIDELITY. `blendFinSys` only means anything as a baseline if it
-    // reproduces production's arithmetic, and the way it silently stopped doing
-    // so was a missing `roundScore` on two legs — worth exactly one point, which
-    // was enough to publish "+12" for what is really +11. Feed the mirror the
-    // CONDITIONED band (the leg the live scorer actually consumes) and it must
-    // land on the real scorer's number, in both the honest and dropped states.
-    // If the weights, the debt transform, or the renormalisation drift apart
-    // again, this fails instead of the baseline quietly going wrong.
+    // MIRROR FIDELITY. Feed the mirror the CONDITIONED band (the leg the live
+    // scorer actually consumes) and it must land on the real scorer's number,
+    // in both the honest and malformed states. If the weights, the debt
+    // transform, or the missing-slot policy drift apart, this fails instead of
+    // the baseline quietly going wrong.
     assert.equal(
       blendFinSys(normalizeDiversityConditionedBand(real.totalXborderPctGdp, real.parentCount), real.parentCount),
       honest.score,
@@ -972,32 +996,32 @@ describe('scoreFinancialSystemExposure — half-parsed BIS row (pre-existing ble
       'blendFinSys no longer reproduces the real scorer on the half-parsed payload',
     );
 
-    // The same country, same corruption, scored on the UNCONDITIONED band —
-    // the inflation this construct inherited rather than introduced.
-    const rawHonest = blendFinSys(normalizeBandLowerBetter(real.totalXborderPctGdp), real.parentCount);
-    const rawHalfParsed = blendFinSys(normalizeBandLowerBetter(real.totalXborderPctGdp), null);
+    // The same country, same corruption, scored on the UNCONDITIONED band with
+    // the pre-fix arithmetic — the inflation this construct inherited rather
+    // than introduced.
+    const rawHonest = blendFinSys(
+      normalizeBandLowerBetter(real.totalXborderPctGdp),
+      real.parentCount,
+      { preFixRenormalization: true },
+    );
+    const rawHalfParsed = blendFinSys(
+      normalizeBandLowerBetter(real.totalXborderPctGdp),
+      null,
+      { preFixRenormalization: true },
+    );
     const inheritedInflation = rawHalfParsed - rawHonest;
 
     assert.ok(
-      conditionedInflation <= inheritedInflation,
-      `conditioning must not widen the inherited inflation `
-        + `(conditioned +${conditionedInflation} vs inherited +${inheritedInflation})`,
+      conditionedInflation <= 0,
+      `the real blend must not inflate on a half-parsed row (honest ${honest.score}, half-parsed ${halfParsed.score})`,
     );
-    // Guard integrity, on the LIVE side. `inheritedInflation` comes entirely
-    // from the local mirror, so it keeps reporting a positive number even after
-    // the blend is fixed — it can only catch the mirror being neutered, never
-    // its own premise dying. This assertion reads the real scorer, so the day
-    // #6528 lands and `weightedBlend` stops inflating, this test goes RED and
-    // says so instead of passing vacuously.
-    assert.ok(
-      conditionedInflation > 0,
-      'the real blend no longer inflates on a half-parsed row — delete this test '
-        + 'and close #6528 rather than letting it pass vacuously',
-    );
+    // Guard integrity: the old counterfactual must still demonstrate the
+    // defect this regression test protects against. If this turns non-positive
+    // the fixture or its pre-fix mirror was neutered.
     assert.ok(
       inheritedInflation > 0,
-      'mirror integrity: the unconditioned baseline stopped inflating, so the '
-        + 'fixture or the mirror no longer models the drop-and-renormalise path',
+      'pre-fix mirror integrity: the unconditioned baseline stopped inflating, '
+        + 'so the fixture or counterfactual no longer models the old path',
     );
   });
 


### PR DESCRIPTION
## Summary

A malformed BIS claims or parent-count field could disappear from `weightedBlend`; its weight was redistributed to healthier surviving legs, so a data-quality regression could increase the published financial-system resilience score. This PR keeps the design weight for reader-detected malformed fields and contributes a zero fallback while retaining the existing coverage signal. Genuine absence stays on the prior absence path, so ordinary data-desert semantics do not change.

## Design

- `weightedBlend` accepts an explicit `fallbackScore` for a known malformed slot. The fallback stays in the scoring denominator but does not masquerade as observed coverage.
- The BIS reader distinguishes present-invalid claims and parent-count values, including negative, non-finite, and out-of-range values, from null or undefined absence.
- Regression tests cover the generic blend and the real financial-system exposure scorer, including the pre-fix inflation counterfactual.

## Validation

- `./node_modules/.bin/tsx --test tests/resilience-*.test.mts` — 977 passed across 169 suites.
- `npm run typecheck` — passed.
- `npm run typecheck:api` — passed.
- `npm run lint` and `npm run lint:md` — passed; lint reported only existing repository warnings.
- The full pre-push gate passed, including 49 edge-function bundles and the resilience suite. Credential-only live probes remained skipped because no Upstash credentials were available; this is not a production-acceptance claim.

## New concepts

An explicit fallback is a fail-closed scoring slot for known corruption. It preserves nominal weight while lowering confidence and score; it is different from genuine absence, which can keep the existing coverage-weighted behavior.

```ts
// A malformed low slot must not free its weight onto the high survivor.
weightedBlend([{ score: 100, weight: 0.5 }, { score: null, weight: 0.5, fallbackScore: 0 }]);
```

Use this only when the reader can prove that a value was present but malformed. Do not use it to hide a legitimate data desert.

## Related

Fixes #6528

## Post-Deploy Monitoring & Validation

- After the next BIS seed publication and resilience ranking refresh, inspect financial-system exposure score/ranking cache entries and their `coverage` values. Check service logs for malformed BIS or source-failure signals.
- Expected result: malformed fields never raise the published score, coverage decreases, no blend exception occurs, and genuine absence keeps its prior behavior.
- If score inflation or a coverage mismatch appears, revert this PR or disable the affected resilience release control. WorldMonitor maintainers own the check during the next seed and ranking refresh window.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-GPT_5-000000)
