### PR TITLE
fix(docs): point API Reference OpenAPI download at real bundle

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -261,6 +261,7 @@
           },
           {
             "tab": "API Reference",
+            "openapi": "api/worldmonitor.openapi.yaml",
             "groups": [
               {
                 "group": "Overview",
@@ -726,6 +727,7 @@
           },
           {
             "tab": "API 参考",
+            "openapi": "api/worldmonitor.openapi.yaml",
             "groups": [
               {
                 "group": "概览",

--- a/tests/mintlify-openapi-download-contract.test.mjs
+++ b/tests/mintlify-openapi-download-contract.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import { load as loadYaml } from 'js-yaml';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const docsConfig = JSON.parse(readFileSync(resolve(root, 'docs/docs.json'), 'utf8'));
+const bundlePath = resolve(root, 'docs/api/worldmonitor.openapi.yaml');
+
+function findTab(language, label) {
+  const tabs = docsConfig.navigation.languages.find((entry) => entry.language === language)?.tabs;
+  return tabs?.find((tab) => tab.tab === label);
+}
+
+describe('Mintlify OpenAPI download contract', () => {
+  it('binds both API Reference tabs to the unified World Monitor bundle', () => {
+    for (const [language, label] of [
+      ['en', 'API Reference'],
+      ['zh-Hans', 'API 参考'],
+    ]) {
+      const tab = findTab(language, label);
+      assert.ok(tab, `${language} ${label} tab must exist`);
+      assert.equal(
+        tab.openapi,
+        'api/worldmonitor.openapi.yaml',
+        `${language} ${label} tab must inherit the unified OpenAPI bundle`,
+      );
+    }
+  });
+
+  it('keeps the configured bundle real and production-directed', () => {
+    const bundle = loadYaml(readFileSync(bundlePath, 'utf8'));
+    assert.equal(bundle.openapi, '3.1.0');
+    assert.equal(bundle.info?.title, 'WorldMonitor API');
+    assert.deepEqual(bundle.servers, [{ url: 'https://api.worldmonitor.app' }]);
+    assert.ok(Object.keys(bundle.paths ?? {}).length > 0, 'the unified bundle must contain API paths');
+  });
+});


### PR DESCRIPTION
Closes #6574

## Summary

- Bind the English and Chinese Mintlify API Reference tabs to the unified World Monitor OpenAPI bundle.
- Add a regression test that verifies the configured bundle is OpenAPI 3.1, identifies WorldMonitor API, and targets `https://api.worldmonitor.app`.

## Intent

Prevent `/docs/api-reference/openapi.json` from falling back to Mintlify's Plant Store demo specification at `sandbox.mintlify.com`. Existing per-service OpenAPI navigation entries remain unchanged.

Non-goals: no API runtime, authentication, endpoint, or generated-contract changes.

## Validation Matrix

- `node --test tests/mintlify-openapi-download-contract.test.mjs tests/openapi-servers-contract.test.mjs tests/docs-i18n-parity.test.mjs` — 323 passed.
- `npm run lint:mintlify-slugs` — passed.
- `npm run docs:check` — passed; 160 claims match code.
- `./node_modules/.bin/biome lint tests/mintlify-openapi-download-contract.test.mjs` — passed.
- Pre-push hook — passed, including frontend typecheck and changed-test execution.
- `git diff --check` — passed.

## Review Gates

- Code Review Expert — passed; no P0–P3 findings.
- Outcome review — passed against issue #6574 acceptance criteria.

## Documentation

The Mintlify navigation configuration is the documentation change. No prose or generated API artifacts require refresh.

## Screenshots / UI Evidence

Not applicable: this change repairs a machine-readable JSON download route, not a visual surface. The pre-change live response was captured from `https://www.worldmonitor.app/docs/api-reference/openapi.json`.

## Residual Findings

None. After the Mintlify deployment, re-fetch the route to confirm the hosted response reports the World Monitor bundle rather than the Plant Store fallback.