### PR TITLE
fix(license): move project header below AGPL text so scanners detect AGPL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-World Monitor — Real-time global intelligence dashboard
-Copyright (C) 2024-2026 Elie Habib
-
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
@@ -667,3 +664,6 @@ specific requirements.
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
 <https://www.gnu.org/licenses/>.
+
+World Monitor — Real-time global intelligence dashboard
+Copyright (C) 2024-2026 Elie Habib

--- a/tests/license-docs.test.mjs
+++ b/tests/license-docs.test.mjs
@@ -42,6 +42,17 @@ function assertNoMatch(relativePath, text, pattern, label) {
 }
 
 describe('project license docs', () => {
+  it('keeps the project header below the complete AGPL text for license scanners', () => {
+    const license = readFileSync(join(root, 'LICENSE'), 'utf8');
+    const agplEnd = license.indexOf('END OF TERMS AND CONDITIONS');
+    const projectHeader = license.indexOf('World Monitor — Real-time global intelligence dashboard');
+    const projectCopyright = license.indexOf('Copyright (C) 2024-2026 Elie Habib');
+
+    assert.ok(agplEnd >= 0, 'root LICENSE must contain the complete AGPL text');
+    assert.ok(projectHeader > agplEnd, 'project header must follow the complete AGPL text');
+    assert.ok(projectCopyright > agplEnd, 'project copyright must follow the complete AGPL text');
+  });
+
   it('do not claim AGPL prohibits commercial use', () => {
     for (const { relativePath, text } of readProjectLicenseDocs()) {
       assertNoMatch(relativePath, text, /AGPL[\s\S]{0,160}non-?commercial/i, 'AGPL non-commercial framing');


### PR DESCRIPTION
## Summary
- Move the World Monitor project and copyright header below the complete AGPL-3.0 text in the root LICENSE file.
- Add a regression test that keeps the project header below the license text.

Closes #6576

## Intent
The root LICENSE currently starts with project-specific text, which causes GitHub to report NOASSERTION and can make OSS diligence scanners classify the repository license as unknown. This change keeps the full AGPL text and copyright notice intact while placing the standard license content first.

Non-goals: no runtime behavior, package metadata, client-license, or hosted-service license changes.

## Validation Matrix
| Check | Result |
| --- | --- |
| `node --test tests/license-docs.test.mjs` | Pass: 5 tests, 0 failures |
| Root LICENSE ordering check | Pass: project header follows `END OF TERMS AND CONDITIONS` |
| `git diff --check` | Pass |
| Pre-push gate | Pass: typecheck, Unicode safety, changed tests, version sync, and applicable guards |

The dependency bootstrap reported one moderate npm audit advisory; no dependency files changed.

## Review Gates
- Code Review Expert: pass; no P0-P3 findings.
- Outcome Reviewer: pass against live issue #6576 and the final diff.

## Documentation
Not applicable. The existing license documentation already describes AGPL-3.0-only; this change corrects root-file detection metadata only.

## Screenshots / UI Evidence
Not applicable; this is a repository metadata change with no user interface change.

## Residual Findings
None.