### PR TITLE
fix(a11y): announce breaking news alerts and name icon-only controls

### DIFF
--- a/mcp-grant.html
+++ b/mcp-grant.html
@@ -39,14 +39,14 @@
   </head>
   <body>
     <a href="https://www.worldmonitor.app" class="wm-logo" target="_blank" rel="noopener">
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
       <span class="wm-logo-text">WorldMonitor MCP</span>
     </a>
-    <div class="card" id="card">
-      <div id="loading"><span class="spinner"></span><span class="placeholder" id="loadingBody">Loading authorization request…</span></div>
+    <main class="card" id="card">
+      <div id="loading"><span class="spinner" aria-hidden="true"></span><span class="placeholder" id="loadingBody">Loading authorization request…</span></div>
       <div id="consent" hidden>
         <div class="client-hd">
-          <div class="client-name"><span id="clientName"></span> wants access</div>
+          <h1 class="client-name"><span id="clientName"></span> wants access</h1>
           <div class="client-host">via <span id="clientHost"></span></div>
         </div>
         <hr>
@@ -61,14 +61,14 @@
         <hr>
         <p style="font-size:.72rem;color:#444;line-height:1.5">Signed in as <span id="userEmail" style="color:#666"></span>. <a href="/settings" style="color:#2d8a6e;text-decoration:none">Manage connected MCP clients →</a></p>
         <button type="button" id="authorizeBtn">Authorize</button>
-        <p class="error" id="mintError" hidden></p>
+        <p class="error" id="mintError" role="alert" hidden></p>
       </div>
       <div id="errorView" hidden>
-        <div class="client-name" id="errorTitle" style="color:#ef4444;font-size:.95rem;font-weight:600;margin-bottom:.5rem">Authorization request expired</div>
+        <h1 class="client-name" id="errorTitle" style="color:#ef4444;font-size:.95rem;font-weight:600;margin-bottom:.5rem">Authorization request expired</h1>
         <p style="font-size:.8rem;color:#666;line-height:1.5" id="errorBody">This authorization request expired or is invalid. Start over from your MCP client (e.g. Claude Desktop).</p>
         <button type="button" id="retryContextBtn" hidden>Try again</button>
       </div>
-    </div>
+    </main>
     <p class="footer"><a href="https://www.worldmonitor.app" target="_blank" rel="noopener">worldmonitor.app</a> &middot; <a href="https://www.worldmonitor.app/pro" target="_blank" rel="noopener">Pro plan →</a></p>
     <script type="module" src="/src/mcp-grant-main.ts" nonce="wm-static-bootstrap"></script>
   </body>

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -962,10 +962,10 @@ export class PanelLayoutManager implements AppModule {
             <svg class="x-logo" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
             <span class="credit-text">@eliehabib</span>
           </a>
-          <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noopener" class="github-link" title="${t('header.viewOnGitHub')}">
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          <a href="https://github.com/koala73/worldmonitor" target="_blank" rel="noopener" class="github-link" title="${t('header.viewOnGitHub')}" aria-label="${t('header.viewOnGitHub')}">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
           </a>
-          <button class="mobile-settings-btn" id="mobileSettingsBtn" title="${t('header.settings')}">
+          <button class="mobile-settings-btn" id="mobileSettingsBtn" title="${t('header.settings')}" aria-label="${t('header.settings')}">
             <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
           </button>
           <div class="status-indicator">
@@ -993,8 +993,8 @@ export class PanelLayoutManager implements AppModule {
           <button class="search-btn" id="searchBtn"><kbd>⌘K</kbd> ${t('header.search')}</button>
           ${this.ctx.isDesktopApp ? '' : `<button class="copy-link-btn" id="copyLinkBtn">${t('header.copyLink')}</button>`}
           ${this.ctx.isDesktopApp ? '' : `<button class="copy-link-btn embed-link-btn" id="embedLinkBtn">${t('header.embed')}</button>`}
-          ${this.ctx.isDesktopApp ? '' : `<button class="fullscreen-btn" id="fullscreenBtn" title="${t('header.fullscreen')}">⛶</button>`}
-          ${SITE_VARIANT === 'happy' ? `<button class="tv-mode-btn" id="tvModeBtn" title="TV Mode (Shift+T)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>` : ''}
+          ${this.ctx.isDesktopApp ? '' : `<button class="fullscreen-btn" id="fullscreenBtn" title="${t('header.fullscreen')}" aria-label="${t('header.fullscreen')}">⛶</button>`}
+          ${SITE_VARIANT === 'happy' ? `<button class="tv-mode-btn" id="tvModeBtn" title="TV Mode (Shift+T)" aria-label="TV Mode"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>` : ''}
           <span id="unifiedSettingsMount"></span>
           <span id="authWidgetMount" class="auth-widget-mount"></span>
         </div>
@@ -1578,7 +1578,7 @@ export class PanelLayoutManager implements AppModule {
         ${top.strikeCapable ? '<span class="banner-strike">STRIKE CAPABLE</span>' : ''}
       </div>
       <button class="banner-view" data-lat="${top.centerLat}" data-lon="${top.centerLon}">View Region</button>
-      <button class="banner-dismiss">×</button>
+      <button class="banner-dismiss" aria-label="${t('common.dismiss')}">×</button>
     `, "legacy direct innerHTML migration"));
 
     this.criticalBannerEl.querySelector('.banner-view')?.addEventListener('click', () => {

--- a/src/components/AirlineIntelPanel.ts
+++ b/src/components/AirlineIntelPanel.ts
@@ -443,7 +443,7 @@ export class AirlineIntelPanel extends Panel {
     // ---- Tracking tab ----
     private renderTracking(): void {
         const clearBtn = this.trackingQuery
-            ? `<button id="trackClearBtn" class="icon-btn" style="padding:4px 8px;color:#9ca3af" title="Back to live feed">×</button>`
+            ? `<button id="trackClearBtn" class="icon-btn" style="padding:4px 8px;color:#9ca3af" title="Back to live feed" aria-label="Back to live feed">×</button>`
             : '';
         const searchBar = `
       <div class="track-search" style="display:flex;gap:6px;padding:8px 0 6px">

--- a/src/components/AviationCommandBar.ts
+++ b/src/components/AviationCommandBar.ts
@@ -319,7 +319,7 @@ export class AviationCommandBar {
       <div id="aviation-cmd-box">
         <div id="aviation-cmd-header">
           <span>✈️ Aviation Command</span>
-          <button id="aviation-cmd-close">×</button>
+          <button id="aviation-cmd-close" aria-label="Close">×</button>
         </div>
         <input id="aviation-cmd-input" type="text" placeholder="ops Dubai  ·  flight EK3  ·  fly London Dubai  ·  brief" aria-label="Aviation command" autocomplete="off" spellcheck="false">
         <div id="aviation-cmd-suggestions"></div>

--- a/src/components/BreakingNewsBanner.ts
+++ b/src/components/BreakingNewsBanner.ts
@@ -279,8 +279,16 @@ export class BreakingNewsBanner {
     dismissBtn.title = t('components.breakingNews.dismiss');
     dismissBtn.setAttribute('aria-label', t('components.breakingNews.dismiss'));
 
+    const viewPanelBtn = document.createElement('button');
+    viewPanelBtn.className = 'breaking-alert-view-panel';
+    viewPanelBtn.type = 'button';
+    viewPanelBtn.textContent = '→';
+    viewPanelBtn.title = t('components.breakingNews.viewPanel');
+    viewPanelBtn.setAttribute('aria-label', t('components.breakingNews.viewPanel'));
+
     el.appendChild(iconSpan);
     el.appendChild(content);
+    el.appendChild(viewPanelBtn);
     el.appendChild(dismissBtn);
 
     return el;

--- a/src/components/BreakingNewsBanner.ts
+++ b/src/components/BreakingNewsBanner.ts
@@ -36,6 +36,11 @@ export class BreakingNewsBanner {
   constructor() {
     this.container = document.createElement('div');
     this.container.className = 'breaking-news-container';
+    // Live region must exist in the tree before alerts are injected, or the
+    // injected content is never announced (same subtlety as PanelTabBar).
+    this.container.setAttribute('role', 'log');
+    this.container.setAttribute('aria-live', 'assertive');
+    this.container.setAttribute('aria-label', t('components.breakingNews.alertsRegion'));
     // Desktop: fixed body-level overlay. Mobile: join the app flex column
     // below the header (same slot as the critical posture banner, which
     // stays above when both are present) so alerts push content down
@@ -232,6 +237,7 @@ export class BreakingNewsBanner {
     const iconSpan = document.createElement('span');
     iconSpan.className = 'breaking-alert-icon';
     iconSpan.textContent = icon;
+    iconSpan.setAttribute('aria-hidden', 'true');
 
     const content = document.createElement('div');
     content.className = 'breaking-alert-content';
@@ -268,8 +274,10 @@ export class BreakingNewsBanner {
 
     const dismissBtn = document.createElement('button');
     dismissBtn.className = 'breaking-alert-dismiss';
+    dismissBtn.type = 'button';
     dismissBtn.textContent = '×';
     dismissBtn.title = t('components.breakingNews.dismiss');
+    dismissBtn.setAttribute('aria-label', t('components.breakingNews.dismiss'));
 
     el.appendChild(iconSpan);
     el.appendChild(content);

--- a/src/components/ConsumerPricesPanel.ts
+++ b/src/components/ConsumerPricesPanel.ts
@@ -373,7 +373,7 @@ export class ConsumerPricesPanel extends Panel {
         break;
       case 'movers':
         bodyHtml = rangeHtml + (categoryFilter
-          ? `<div class="cp-filter-bar">Filtered: <strong>${escapeHtml(categoryFilter)}</strong> <button data-clear-filter>✕</button></div>`
+          ? `<div class="cp-filter-bar">Filtered: <strong>${escapeHtml(categoryFilter)}</strong> <button data-clear-filter aria-label="Clear category filter">✕</button></div>`
           : '') + this.renderMovers();
         break;
       case 'spread':

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -5082,7 +5082,7 @@ export class DeckGLMap {
         let imgHtml = `<div class="deckgl-tooltip"><strong>&#128752; ${text(obj.satellite)}</strong><br/>${text(obj.datetime)}<br/>Res: ${Number(obj.resolutionM)}m \u00B7 ${text(obj.mode)}`;
         if (isAllowedPreviewUrl(obj.previewUrl)) {
           const safeHref = escapeHtml(new URL(obj.previewUrl).href);
-          imgHtml += `<br><img src="${safeHref}" referrerpolicy="no-referrer" style="max-width:180px;max-height:120px;margin-top:4px;border-radius:4px;" class="imagery-preview">`;
+          imgHtml += `<br><img src="${safeHref}" referrerpolicy="no-referrer" style="max-width:180px;max-height:120px;margin-top:4px;border-radius:4px;" class="imagery-preview" alt="">`;
         }
         imgHtml += '</div>';
         return { html: imgHtml };
@@ -5487,9 +5487,9 @@ export class DeckGLMap {
     controls.className = 'map-controls deckgl-controls';
     setTrustedHtml(controls, trustedHtml(`
       <div class="zoom-controls">
-        <button class="map-btn zoom-in" title="${t('components.deckgl.zoomIn')}">+</button>
-        <button class="map-btn zoom-out" title="${t('components.deckgl.zoomOut')}">-</button>
-        <button class="map-btn zoom-reset" title="${t('components.deckgl.resetView')}">&#8962;</button>
+        <button class="map-btn zoom-in" title="${t('components.deckgl.zoomIn')}" aria-label="${t('components.deckgl.zoomIn')}">+</button>
+        <button class="map-btn zoom-out" title="${t('components.deckgl.zoomOut')}" aria-label="${t('components.deckgl.zoomOut')}">-</button>
+        <button class="map-btn zoom-reset" title="${t('components.deckgl.resetView')}" aria-label="${t('components.deckgl.resetView')}">&#8962;</button>
       </div>
       <div class="view-selector">
         <select class="view-select" aria-label="${t('header.selectRegion')}">

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -990,7 +990,7 @@ export class GlobeMap {
           }
           if (isAllowedPreviewUrl(d.previewUrl)) {
             const safeHref = escapeHtml(new URL(d.previewUrl!).href);
-            label += `<br><img src="${safeHref}" referrerpolicy="no-referrer" style="max-width:180px;max-height:120px;margin-top:4px;border-radius:4px;" class="imagery-preview">`;
+            label += `<br><img src="${safeHref}" referrerpolicy="no-referrer" style="max-width:180px;max-height:120px;margin-top:4px;border-radius:4px;" class="imagery-preview" alt="">`;
           }
           return label;
         }
@@ -1702,7 +1702,7 @@ export class GlobeMap {
       }
       if (isAllowedPreviewUrl(d.previewUrl)) {
         const safeHref = escapeHtml(new URL(d.previewUrl!).href);
-        html += `<br><img src="${safeHref}" referrerpolicy="no-referrer" style="max-width:180px;max-height:120px;margin-top:4px;border-radius:4px;" class="imagery-preview">`;
+        html += `<br><img src="${safeHref}" referrerpolicy="no-referrer" style="max-width:180px;max-height:120px;margin-top:4px;border-radius:4px;" class="imagery-preview" alt="">`;
       }
     } else if (d._kind === 'webcam') {
       html = '';
@@ -1951,9 +1951,9 @@ export class GlobeMap {
     setTrustedHtml(el, trustedHtml(`
       <span class="globe-beta-badge">BETA</span>
       <div class="zoom-controls">
-        <button class="map-btn zoom-in"    title="Zoom in">+</button>
-        <button class="map-btn zoom-out"   title="Zoom out">-</button>
-        <button class="map-btn zoom-reset" title="Reset view">&#8962;</button>
+        <button class="map-btn zoom-in"    title="Zoom in" aria-label="Zoom in">+</button>
+        <button class="map-btn zoom-out"   title="Zoom out" aria-label="Zoom out">-</button>
+        <button class="map-btn zoom-reset" title="Reset view" aria-label="Reset view">&#8962;</button>
       </div>`, "legacy direct innerHTML migration"));
     this.container.appendChild(el);
     el.addEventListener('click', (e) => {

--- a/src/components/payment-failure-banner.ts
+++ b/src/components/payment-failure-banner.ts
@@ -110,7 +110,7 @@ export function initPaymentFailureBanner(): () => void {
       </svg>
       <span>${t(variant.messageKey)}</span>
       ${actionBtn}
-      <button id="pf-dismiss-btn" style="background:transparent;color:#fff;border:none;cursor:pointer;font-size:calc(18px * var(--wm-panel-effective-scale, 1));padding:0 4px;line-height:1;">&times;</button>
+      <button id="pf-dismiss-btn" aria-label="${t('common.dismiss')}" style="background:transparent;color:#fff;border:none;cursor:pointer;font-size:calc(18px * var(--wm-panel-effective-scale, 1));padding:0 4px;line-height:1;">&times;</button>
     `, "legacy direct innerHTML migration"));
 
     document.body.appendChild(banner);

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1801,7 +1801,8 @@
       "critical": "حرج",
       "dismiss": "تجاهل",
       "high": "مرتفع",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "giving": {
       "activityIndex": "مؤشر النشاط",

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -1800,7 +1800,8 @@
     "breakingNews": {
       "critical": "حرج",
       "dismiss": "تجاهل",
-      "high": "مرتفع"
+      "high": "مرتفع",
+      "alertsRegion": "Breaking news alerts"
     },
     "giving": {
       "activityIndex": "مؤشر النشاط",
@@ -3334,7 +3335,8 @@
     "all": "الكل",
     "loadingGiving": "جارٍ تحميل بيانات العطاء العالمي",
     "rateLimitedMarket": "بيانات السوق غير متاحة مؤقتاً (تقييد معدل الطلبات) — ستتم إعادة المحاولة قريباً",
-    "cancel": "إلغاء"
+    "cancel": "إلغاء",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "العرض",

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -1672,7 +1672,8 @@
     "breakingNews": {
       "critical": "КРИТИЧНО",
       "high": "ВИСОКО",
-      "dismiss": "Отхвърли"
+      "dismiss": "Отхвърли",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Последни алерти",
@@ -3262,7 +3263,8 @@
     "retry": "Опитайте отново",
     "refresh": "Обновяване",
     "all": "Всички",
-    "cancel": "Отмяна"
+    "cancel": "Отмяна",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Дисплей",

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -1673,7 +1673,8 @@
       "critical": "КРИТИЧНО",
       "high": "ВИСОКО",
       "dismiss": "Отхвърли",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Последни алерти",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -1657,7 +1657,8 @@
     "breakingNews": {
       "critical": "KRITICKÉ",
       "high": "VYSOKÉ",
-      "dismiss": "Zavřít"
+      "dismiss": "Zavřít",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Blesková upozornění",
@@ -3298,7 +3299,8 @@
     "retry": "Zkusit znovu",
     "refresh": "Obnovit",
     "all": "Vše",
-    "cancel": "Zrušit"
+    "cancel": "Zrušit",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Zobrazení",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -1658,7 +1658,8 @@
       "critical": "KRITICKÉ",
       "high": "VYSOKÉ",
       "dismiss": "Zavřít",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Blesková upozornění",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1387,7 +1387,8 @@
       "critical": "KRITISCH",
       "high": "HOCH",
       "dismiss": "Ausblenden",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Eilmeldungen",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1386,7 +1386,8 @@
     "breakingNews": {
       "critical": "KRITISCH",
       "high": "HOCH",
-      "dismiss": "Ausblenden"
+      "dismiss": "Ausblenden",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Eilmeldungen",
@@ -3262,7 +3263,8 @@
     "retry": "Erneut versuchen",
     "refresh": "Aktualisieren",
     "all": "Alle",
-    "cancel": "Abbrechen"
+    "cancel": "Abbrechen",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Anzeige",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -1673,7 +1673,8 @@
       "critical": "ΚΡΙΣΙΜΟ",
       "high": "ΥΨΗΛΟ",
       "dismiss": "Απόρριψη",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Έκτακτες Ειδοποιήσεις",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -1672,7 +1672,8 @@
     "breakingNews": {
       "critical": "ΚΡΙΣΙΜΟ",
       "high": "ΥΨΗΛΟ",
-      "dismiss": "Απόρριψη"
+      "dismiss": "Απόρριψη",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Έκτακτες Ειδοποιήσεις",
@@ -3262,7 +3263,8 @@
     "retry": "Επανάληψη",
     "refresh": "Ανανέωση",
     "all": "Όλα",
-    "cancel": "Ακύρωση"
+    "cancel": "Ακύρωση",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Οθόνη",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1817,7 +1817,8 @@
       "critical": "CRITICAL",
       "high": "HIGH",
       "dismiss": "Dismiss",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Breaking Alerts",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1816,7 +1816,8 @@
     "breakingNews": {
       "critical": "CRITICAL",
       "high": "HIGH",
-      "dismiss": "Dismiss"
+      "dismiss": "Dismiss",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Breaking Alerts",
@@ -3302,6 +3303,7 @@
     }
   },
   "common": {
+    "dismiss": "Dismiss",
     "loading": "Loading...",
     "error": "Error",
     "noData": "No data available",

--- a/src/locales/en.shell.json
+++ b/src/locales/en.shell.json
@@ -196,6 +196,7 @@
     "climateNews": "Climate News"
   },
   "common": {
+    "dismiss": "Dismiss",
     "loading": "Loading...",
     "error": "Error",
     "noData": "No data available",

--- a/src/locales/en.shell.json
+++ b/src/locales/en.shell.json
@@ -414,6 +414,13 @@
     "copyCoordinates": "Copy Coordinates"
   },
   "components": {
+    "breakingNews": {
+      "critical": "CRITICAL",
+      "high": "HIGH",
+      "dismiss": "Dismiss",
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
+    },
     "deckgl": {
       "views": {
         "global": "Global",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1388,7 +1388,8 @@
     "breakingNews": {
       "critical": "CRÍTICO",
       "high": "ALTO",
-      "dismiss": "Descartar"
+      "dismiss": "Descartar",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Alertas de última hora",
@@ -3280,7 +3281,8 @@
     "retry": "Retry",
     "refresh": "Refresh",
     "all": "Todos",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Pantalla",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1389,7 +1389,8 @@
       "critical": "CRÍTICO",
       "high": "ALTO",
       "dismiss": "Descartar",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Alertas de última hora",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -1816,7 +1816,8 @@
     "breakingNews": {
       "critical": "CRITICAL",
       "high": "HIGH",
-      "dismiss": "Dismiss"
+      "dismiss": "Dismiss",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Breaking Alerts",
@@ -3331,7 +3332,8 @@
     "currentVariant": "(current)",
     "retry": "Retry",
     "refresh": "Refresh",
-    "all": "All"
+    "all": "All",
+    "dismiss": "Dismiss"
   },
   "connectivity": {
     "offlineCached": "Offline — showing cached data from {{freshness}}.",

--- a/src/locales/fa.json
+++ b/src/locales/fa.json
@@ -1817,7 +1817,8 @@
       "critical": "CRITICAL",
       "high": "HIGH",
       "dismiss": "Dismiss",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Breaking Alerts",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1801,7 +1801,8 @@
       "critical": "CRITIQUE",
       "dismiss": "Fermer",
       "high": "URGENT",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "giving": {
       "activityIndex": "Indice d'activité",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1800,7 +1800,8 @@
     "breakingNews": {
       "critical": "CRITIQUE",
       "dismiss": "Fermer",
-      "high": "URGENT"
+      "high": "URGENT",
+      "alertsRegion": "Breaking news alerts"
     },
     "giving": {
       "activityIndex": "Indice d'activité",
@@ -3280,7 +3281,8 @@
     "all": "Tous",
     "loadingGiving": "Chargement des données de dons...",
     "rateLimitedMarket": "Données de marché temporairement limitées — nouvelle tentative automatique",
-    "cancel": "Annuler"
+    "cancel": "Annuler",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Affichage",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -1814,7 +1814,8 @@
       "critical": "गंभीर",
       "high": "उच्च",
       "dismiss": "खारिज करें",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "ब्रेकिंग अलर्ट",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -1813,7 +1813,8 @@
     "breakingNews": {
       "critical": "गंभीर",
       "high": "उच्च",
-      "dismiss": "खारिज करें"
+      "dismiss": "खारिज करें",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "ब्रेकिंग अलर्ट",
@@ -3331,7 +3332,8 @@
     "currentVariant": "(वर्तमान)",
     "retry": "पुनः प्रयास करें",
     "refresh": "रिफ्रेश करें",
-    "all": "सभी"
+    "all": "सभी",
+    "dismiss": "Dismiss"
   },
   "connectivity": {
     "offlineCached": "ऑफ़लाइन — {{freshness}} का सेव किया हुआ डेटा दिखा रहा है।",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -1967,7 +1967,8 @@
       "critical": "KRITIČNO",
       "high": "VISOKO",
       "dismiss": "Odbaci",
-      "enableNotifications": "Omogući obavijesti na računalu"
+      "enableNotifications": "Omogući obavijesti na računalu",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Slomljivi alarmi",
@@ -3546,7 +3547,8 @@
     "currentVariant": "(trenutno)",
     "retry": "Pokušaj ponovno",
     "refresh": "Osvježi",
-    "all": "Sve"
+    "all": "Sve",
+    "dismiss": "Dismiss"
   },
   "connectivity": {
     "offlineCached": "Offline — prikazujem memorizirane podatke od {{freshness}}.",

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -1968,7 +1968,8 @@
       "high": "VISOKO",
       "dismiss": "Odbaci",
       "enableNotifications": "Omogući obavijesti na računalu",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Slomljivi alarmi",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -1813,7 +1813,8 @@
     "breakingNews": {
       "critical": "KRITIKUS",
       "high": "MAGAS",
-      "dismiss": "Elvetés"
+      "dismiss": "Elvetés",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Friss riasztások",
@@ -3331,7 +3332,8 @@
     "currentVariant": "(jelenlegi)",
     "retry": "Újra próbálás",
     "refresh": "Frissítés",
-    "all": "Összes"
+    "all": "Összes",
+    "dismiss": "Dismiss"
   },
   "connectivity": {
     "offlineCached": "Offline — {{freshness}} időpontjából származó gyorsítótárazott adatok megjelenítése.",

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -1814,7 +1814,8 @@
       "critical": "KRITIKUS",
       "high": "MAGAS",
       "dismiss": "Elvetés",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Friss riasztások",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1388,7 +1388,8 @@
     "breakingNews": {
       "critical": "CRITICO",
       "high": "ALTO",
-      "dismiss": "Ignora"
+      "dismiss": "Ignora",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Allerte urgenti",
@@ -3280,7 +3281,8 @@
     "retry": "Riprova",
     "refresh": "Aggiorna",
     "all": "Tutti",
-    "cancel": "Annulla"
+    "cancel": "Annulla",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Visualizzazione",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -1389,7 +1389,8 @@
       "critical": "CRITICO",
       "high": "ALTO",
       "dismiss": "Ignora",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Allerte urgenti",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1673,7 +1673,8 @@
       "critical": "緊急",
       "high": "重要",
       "dismiss": "閉じる",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "速報アラート",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1672,7 +1672,8 @@
     "breakingNews": {
       "critical": "緊急",
       "high": "重要",
-      "dismiss": "閉じる"
+      "dismiss": "閉じる",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "速報アラート",
@@ -3262,7 +3263,8 @@
     "retry": "Retry",
     "refresh": "Refresh",
     "all": "すべて",
-    "cancel": "キャンセル"
+    "cancel": "キャンセル",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "ディスプレイ",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1672,7 +1672,8 @@
     "breakingNews": {
       "critical": "심각",
       "high": "높음",
-      "dismiss": "닫기"
+      "dismiss": "닫기",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "긴급 경보",
@@ -3262,7 +3263,8 @@
     "retry": "재시도",
     "refresh": "새로고침",
     "all": "전체",
-    "cancel": "취소"
+    "cancel": "취소",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "디스플레이",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1673,7 +1673,8 @@
       "critical": "심각",
       "high": "높음",
       "dismiss": "닫기",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "긴급 경보",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1498,7 +1498,8 @@
     "breakingNews": {
       "critical": "KRITIEK",
       "dismiss": "Sluiten",
-      "high": "HOOG"
+      "high": "HOOG",
+      "alertsRegion": "Breaking news alerts"
     },
     "giving": {
       "activityIndex": "Activiteitsindex",
@@ -2972,7 +2973,8 @@
     "all": "Alle",
     "loadingGiving": "Donatiegegevens laden...",
     "rateLimitedMarket": "Marktgegevens tijdelijk beperkt — automatisch opnieuw proberen",
-    "cancel": "Annuleren"
+    "cancel": "Annuleren",
+    "dismiss": "Dismiss"
   },
   "header": {
     "world": "WERELD",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -1499,7 +1499,8 @@
       "critical": "KRITIEK",
       "dismiss": "Sluiten",
       "high": "HOOG",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "giving": {
       "activityIndex": "Activiteitsindex",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1794,7 +1794,8 @@
     "breakingNews": {
       "critical": "KRYTYCZNY",
       "dismiss": "Odrzuć",
-      "high": "WYSOKI"
+      "high": "WYSOKI",
+      "alertsRegion": "Breaking news alerts"
     },
     "giving": {
       "activityIndex": "Indeks aktywności",
@@ -3298,7 +3299,8 @@
     "all": "Wszystkie",
     "loadingGiving": "Ładowanie danych o globalnej dobroczynności",
     "rateLimitedMarket": "Dane rynkowe tymczasowo niedostępne (limit zapytań) — ponowna próba wkrótce",
-    "cancel": "Anuluj"
+    "cancel": "Anuluj",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Wyświetlanie",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -1795,7 +1795,8 @@
       "critical": "KRYTYCZNY",
       "dismiss": "Odrzuć",
       "high": "WYSOKI",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "giving": {
       "activityIndex": "Indeks aktywności",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1500,7 +1500,8 @@
       "critical": "CRÍTICO",
       "dismiss": "Dispensar",
       "high": "ALTO",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "giving": {
       "activityIndex": "Índice de Atividade",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1499,7 +1499,8 @@
     "breakingNews": {
       "critical": "CRÍTICO",
       "dismiss": "Dispensar",
-      "high": "ALTO"
+      "high": "ALTO",
+      "alertsRegion": "Breaking news alerts"
     },
     "giving": {
       "activityIndex": "Índice de Atividade",
@@ -2988,7 +2989,8 @@
     "all": "Todos",
     "loadingGiving": "Carregando dados de doações...",
     "rateLimitedMarket": "Dados de mercado temporariamente limitados — tentando novamente automaticamente",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "dismiss": "Dismiss"
   },
   "header": {
     "world": "MUNDO",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1675,7 +1675,8 @@
     "breakingNews": {
       "critical": "CRITIC",
       "high": "RIDICAT",
-      "dismiss": "Respingeți"
+      "dismiss": "Respingeți",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Alerte de ultimă oră",
@@ -3280,7 +3281,8 @@
     "retry": "Reîncercați",
     "refresh": "Actualizează",
     "all": "Toate",
-    "cancel": "Anulare"
+    "cancel": "Anulare",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Afișare",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -1676,7 +1676,8 @@
       "critical": "CRITIC",
       "high": "RIDICAT",
       "dismiss": "Respingeți",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Alerte de ultimă oră",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1679,7 +1679,8 @@
       "critical": "СРОЧНО",
       "high": "ВАЖНО",
       "dismiss": "Скрыть",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Срочные оповещения",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -1678,7 +1678,8 @@
     "breakingNews": {
       "critical": "СРОЧНО",
       "high": "ВАЖНО",
-      "dismiss": "Скрыть"
+      "dismiss": "Скрыть",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Срочные оповещения",
@@ -3298,7 +3299,8 @@
     "retry": "Retry",
     "refresh": "Refresh",
     "all": "Все",
-    "cancel": "Отмена"
+    "cancel": "Отмена",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Отображение",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1498,7 +1498,8 @@
     "breakingNews": {
       "critical": "KRITISK",
       "dismiss": "Avfärda",
-      "high": "HÖG"
+      "high": "HÖG",
+      "alertsRegion": "Breaking news alerts"
     },
     "giving": {
       "activityIndex": "Aktivitetsindex",
@@ -2972,7 +2973,8 @@
     "all": "Alla",
     "loadingGiving": "Laddar global givmildhetsdata",
     "rateLimitedMarket": "Marknadsdata tillfälligt otillgänglig (hastighetsbegränsad) — försöker igen snart",
-    "cancel": "Avbryt"
+    "cancel": "Avbryt",
+    "dismiss": "Dismiss"
   },
   "header": {
     "world": "VÄRLD",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -1499,7 +1499,8 @@
       "critical": "KRITISK",
       "dismiss": "Avfärda",
       "high": "HÖG",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "giving": {
       "activityIndex": "Aktivitetsindex",

--- a/src/locales/sw.json
+++ b/src/locales/sw.json
@@ -1826,7 +1826,8 @@
     "breakingNews": {
       "critical": "MUHIMU",
       "high": "JUU",
-      "dismiss": "Ondoa"
+      "dismiss": "Ondoa",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Tahadhari za Kuvunja",
@@ -3341,7 +3342,8 @@
     "currentVariant": "(ya sasa)",
     "retry": "Jaribu tena",
     "refresh": "Onyesha upya",
-    "all": "Wote"
+    "all": "Wote",
+    "dismiss": "Dismiss"
   },
   "connectivity": {
     "offlineCached": "Nje ya mtandao — inaonyesha data iliyohifadhiwa kutoka kwa {{freshness}}.",

--- a/src/locales/sw.json
+++ b/src/locales/sw.json
@@ -1827,7 +1827,8 @@
       "critical": "MUHIMU",
       "high": "JUU",
       "dismiss": "Ondoa",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Tahadhari za Kuvunja",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -1673,7 +1673,8 @@
       "critical": "วิกฤต",
       "high": "สูง",
       "dismiss": "ปิด",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "การแจ้งเตือนด่วน",

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -1672,7 +1672,8 @@
     "breakingNews": {
       "critical": "วิกฤต",
       "high": "สูง",
-      "dismiss": "ปิด"
+      "dismiss": "ปิด",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "การแจ้งเตือนด่วน",
@@ -3262,7 +3263,8 @@
     "retry": "ลองใหม่",
     "refresh": "รีเฟรช",
     "all": "ทั้งหมด",
-    "cancel": "ยกเลิก"
+    "cancel": "ยกเลิก",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "การแสดงผล",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1673,7 +1673,8 @@
       "critical": "KRİTİK",
       "high": "YÜKSEK",
       "dismiss": "Kapat",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Son Dakika Uyarıları",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1672,7 +1672,8 @@
     "breakingNews": {
       "critical": "KRİTİK",
       "high": "YÜKSEK",
-      "dismiss": "Kapat"
+      "dismiss": "Kapat",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Son Dakika Uyarıları",
@@ -3262,7 +3263,8 @@
     "retry": "Retry",
     "refresh": "Refresh",
     "all": "Tümü",
-    "cancel": "İptal"
+    "cancel": "İptal",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Görünüm",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -1816,7 +1816,8 @@
     "breakingNews": {
       "critical": "CRITICAL",
       "high": "HIGH",
-      "dismiss": "Dismiss"
+      "dismiss": "Dismiss",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Breaking Alerts",
@@ -3331,7 +3332,8 @@
     "currentVariant": "(current)",
     "retry": "Retry",
     "refresh": "Refresh",
-    "all": "All"
+    "all": "All",
+    "dismiss": "Dismiss"
   },
   "connectivity": {
     "offlineCached": "Offline — showing cached data from {{freshness}}.",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -1817,7 +1817,8 @@
       "critical": "CRITICAL",
       "high": "HIGH",
       "dismiss": "Dismiss",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Breaking Alerts",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1673,7 +1673,8 @@
       "critical": "NGHIÊM TRỌNG",
       "high": "CAO",
       "dismiss": "Bỏ qua",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Cảnh báo Khẩn cấp",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -1672,7 +1672,8 @@
     "breakingNews": {
       "critical": "NGHIÊM TRỌNG",
       "high": "CAO",
-      "dismiss": "Bỏ qua"
+      "dismiss": "Bỏ qua",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "Cảnh báo Khẩn cấp",
@@ -3262,7 +3263,8 @@
     "retry": "Thử lại",
     "refresh": "Làm mới",
     "all": "Tất cả",
-    "cancel": "Hủy"
+    "cancel": "Hủy",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "Hiển thị",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -1673,7 +1673,8 @@
       "critical": "緊急",
       "high": "重要",
       "dismiss": "忽略",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "突發警報",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -1672,7 +1672,8 @@
     "breakingNews": {
       "critical": "緊急",
       "high": "重要",
-      "dismiss": "忽略"
+      "dismiss": "忽略",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "突發警報",
@@ -3262,7 +3263,8 @@
     "retry": "Retry",
     "refresh": "Refresh",
     "all": "全部",
-    "cancel": "取消"
+    "cancel": "取消",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "顯示",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1673,7 +1673,8 @@
       "critical": "紧急",
       "high": "重要",
       "dismiss": "忽略",
-      "alertsRegion": "Breaking news alerts"
+      "alertsRegion": "Breaking news alerts",
+      "viewPanel": "View related panel"
     },
     "intelligenceFindings": {
       "breakingAlerts": "突发警报",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -1672,7 +1672,8 @@
     "breakingNews": {
       "critical": "紧急",
       "high": "重要",
-      "dismiss": "忽略"
+      "dismiss": "忽略",
+      "alertsRegion": "Breaking news alerts"
     },
     "intelligenceFindings": {
       "breakingAlerts": "突发警报",
@@ -3262,7 +3263,8 @@
     "retry": "Retry",
     "refresh": "Refresh",
     "all": "全部",
-    "cancel": "取消"
+    "cancel": "取消",
+    "dismiss": "Dismiss"
   },
   "preferences": {
     "display": "显示",

--- a/src/settings-window.ts
+++ b/src/settings-window.ts
@@ -111,7 +111,7 @@ export function initSettingsWindow(): void {
           <span class="settings-window-title">${escapeHtml(t('header.settings'))}</span>
           <p class="settings-window-caption">${escapeHtml(t('header.panelDisplayCaption'))}</p>
         </div>
-        <button type="button" class="modal-close" id="settingsWindowClose">×</button>
+        <button type="button" class="modal-close" id="settingsWindowClose" aria-label="${escapeHtml(t('common.close'))}">×</button>
       </div>
       <div class="panel-toggle-grid" id="panelToggles"></div>
     </div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -20751,6 +20751,11 @@ body:has(.tauri-titlebar) .breaking-news-container {
   font-size: calc(13px * var(--wm-panel-effective-scale, 1));
 }
 
+.breaking-alert:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: -2px;
+}
+
 .breaking-alert.severity-critical {
   background: linear-gradient(90deg, #8B0000, #DC143C);
   border-bottom: 2px solid var(--semantic-critical);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -20751,11 +20751,6 @@ body:has(.tauri-titlebar) .breaking-news-container {
   font-size: calc(13px * var(--wm-panel-effective-scale, 1));
 }
 
-.breaking-alert:focus-visible {
-  outline: 2px solid #fff;
-  outline-offset: -2px;
-}
-
 .breaking-alert.severity-critical {
   background: linear-gradient(90deg, #8B0000, #DC143C);
   border-bottom: 2px solid var(--semantic-critical);
@@ -20812,6 +20807,7 @@ body:has(.tauri-titlebar) .breaking-news-container {
   flex-shrink: 0;
 }
 
+.breaking-alert-view-panel,
 .breaking-alert-dismiss {
   background: var(--overlay-heavy);
   border: none;
@@ -20823,8 +20819,15 @@ body:has(.tauri-titlebar) .breaking-news-container {
   flex-shrink: 0;
 }
 
+.breaking-alert-view-panel:hover,
 .breaking-alert-dismiss:hover {
   background: rgba(255, 255, 255, 0.3);
+}
+
+.breaking-alert-view-panel:focus-visible,
+.breaking-alert-dismiss:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
 }
 
 body.has-breaking-alert .panels-grid {

--- a/tests/breaking-news-banner-a11y.test.mjs
+++ b/tests/breaking-news-banner-a11y.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const source = readFileSync(resolve(root, 'src/components/BreakingNewsBanner.ts'), 'utf8');
+
+describe('BreakingNewsBanner interaction semantics', () => {
+  it('keeps the alert container non-interactive and exposes a native panel action', () => {
+    assert.doesNotMatch(source, /el\.setAttribute\('role',\s*'button'\)/);
+    assert.doesNotMatch(source, /el\.setAttribute\('tabindex',\s*'0'\)/);
+    assert.match(source, /const viewPanelBtn = document\.createElement\('button'\)/);
+    assert.match(source, /viewPanelBtn\.className = 'breaking-alert-view-panel'/);
+    assert.match(source, /viewPanelBtn\.setAttribute\('aria-label',\s*t\('components\.breakingNews\.viewPanel'\)\)/);
+    assert.match(source, /el\.appendChild\(viewPanelBtn\);\s*el\.appendChild\(dismissBtn\);/);
+  });
+
+  it('leaves the headline as a native link and does not also trigger panel scrolling', () => {
+    assert.match(source, /const headlineLink = document\.createElement\('a'\)/);
+    assert.match(source, /if \(target\.closest\('\.breaking-alert-headline-link'\)\) return;/);
+    assert.doesNotMatch(source, /addEventListener\('keydown'/);
+  });
+
+  it('keeps dismissal on its own named native button', () => {
+    assert.match(source, /const dismissBtn = document\.createElement\('button'\)/);
+    assert.match(source, /dismissBtn\.setAttribute\('aria-label',\s*t\('components\.breakingNews\.dismiss'\)\)/);
+    assert.match(source, /if \(target\.closest\('\.breaking-alert-dismiss'\)\)/);
+  });
+});

--- a/tests/breaking-news-banner-a11y.test.mjs
+++ b/tests/breaking-news-banner-a11y.test.mjs
@@ -29,3 +29,27 @@ describe('BreakingNewsBanner interaction semantics', () => {
     assert.match(source, /if \(target\.closest\('\.breaking-alert-dismiss'\)\)/);
   });
 });
+
+describe('icon-only controls named in this a11y pass', () => {
+  const read = (rel) => readFileSync(resolve(root, rel), 'utf8');
+
+  it('gives previously unnamed icon-only buttons an aria-label', () => {
+    assert.match(read('src/app/panel-layout.ts'), /banner-dismiss" aria-label="\$\{t\('common\.dismiss'\)\}"/);
+    assert.match(read('src/settings-window.ts'), /settingsWindowClose" aria-label="\$\{escapeHtml\(t\('common\.close'\)\)\}"/);
+    assert.match(read('src/components/AviationCommandBar.ts'), /aviation-cmd-close" aria-label="Close"/);
+    assert.match(read('src/components/payment-failure-banner.ts'), /pf-dismiss-btn" aria-label="\$\{t\('common\.dismiss'\)\}"/);
+    assert.match(read('src/components/ConsumerPricesPanel.ts'), /data-clear-filter aria-label="Clear category filter"/);
+    assert.match(read('src/components/AirlineIntelPanel.ts'), /trackClearBtn" class="icon-btn"[^>]*aria-label="Back to live feed"/);
+  });
+
+  it('promotes title-only map zoom controls to aria-label', () => {
+    const deck = read('src/components/DeckGLMap.ts');
+    assert.match(deck, /class="map-btn zoom-in"[^>]*aria-label="\$\{t\('components\.deckgl\.zoomIn'\)\}"/);
+    assert.match(deck, /class="map-btn zoom-out"[^>]*aria-label="\$\{t\('components\.deckgl\.zoomOut'\)\}"/);
+    assert.match(deck, /class="map-btn zoom-reset"[^>]*aria-label="\$\{t\('components\.deckgl\.resetView'\)\}"/);
+    const globe = read('src/components/GlobeMap.ts');
+    assert.match(globe, /class="map-btn zoom-in"[^>]*aria-label="Zoom in"/);
+    assert.match(globe, /class="map-btn zoom-out"[^>]*aria-label="Zoom out"/);
+    assert.match(globe, /class="map-btn zoom-reset"[^>]*aria-label="Reset view"/);
+  });
+});

--- a/tests/dom/breaking-news-banner-links.test.mts
+++ b/tests/dom/breaking-news-banner-links.test.mts
@@ -60,6 +60,28 @@ describe('breaking-news banner source links', () => {
     vi.unstubAllGlobals();
   });
 
+  it('exposes an assertive live region before any alert is injected', () => {
+    const container = document.querySelector('.breaking-news-container');
+    expect(container).not.toBeNull();
+    expect(container?.getAttribute('role')).toBe('log');
+    expect(container?.getAttribute('aria-live')).toBe('assertive');
+    expect(container?.getAttribute('aria-label')).toBe('components.breakingNews.alertsRegion');
+    expect(container?.querySelector('.breaking-alert')).toBeNull();
+  });
+
+  it('reveals the target panel from the dedicated view-panel button', () => {
+    emitAlert({ link: 'https://example.com/breaking-story' });
+    const revealPanel = vi.fn();
+    window.addEventListener('wm:reveal-panel', revealPanel);
+
+    document.querySelector<HTMLButtonElement>('.breaking-alert-view-panel')!.click();
+
+    expect(revealPanel).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { panelId: 'news' } }),
+    );
+    window.removeEventListener('wm:reveal-panel', revealPanel);
+  });
+
   it('renders a safe article URL as the headline link', () => {
     emitAlert({ link: 'https://example.com/breaking-story?edition=world&source=wire' });
 

--- a/tests/i18n-english-shell.test.mjs
+++ b/tests/i18n-english-shell.test.mjs
@@ -41,6 +41,7 @@ const SHELL_KEY_PREFIXES = [
   'countryBrief.fallback.',
   'contextMenu.',
   'dashboardTabs.',
+  'components.breakingNews.',
   'components.deckgl.views.',
   'components.map.',
   'components.panel.',
@@ -234,6 +235,11 @@ describe('English i18n shell split', () => {
       'components.newsPanel.sortRelevance',
       'components.webcams.previewStatus',
       'dashboardTabs.defaultName',
+      // Body-mounted breaking-news live region is constructed during Phase 2,
+      // before the full English chunk is guaranteed, and the healer does not
+      // walk document.body overlays.
+      'components.breakingNews.alertsRegion',
+      'components.breakingNews.viewPanel',
       ...eagerChromeKeys(),
     ];
 

--- a/tests/mcp-grant-denial.test.mts
+++ b/tests/mcp-grant-denial.test.mts
@@ -325,6 +325,10 @@ describe('mcp-grant page routes denials through the shared classifier', () => {
     assert.match(pageSource, /'retryContextBtn'\)\.addEventListener\('click'/);
 
     const html = readFileSync(resolve(root, 'mcp-grant.html'), 'utf8');
+    assert.match(html, /<main class="card" id="card">/);
+    assert.match(html, /<h1 class="client-name"><span id="clientName"><\/span> wants access<\/h1>/);
+    assert.match(html, /<h1 class="client-name" id="errorTitle"/);
+    assert.match(html, /id="mintError" role="alert"/);
     assert.match(html, /id="errorTitle"/);
     assert.match(html, /id="retryContextBtn" hidden>Try again<\/button>/);
     assert.doesNotMatch(


### PR DESCRIPTION
Part of #6573 (accessibility remediation, PR 1 of 7): screen-reader announcements and accessible names.

## What this does

**Breaking news alerts are now announced and keyboard-operable.** `BreakingNewsBanner` played an audio cue for critical alerts but was completely silent to screen readers, and the alerts themselves were clickable `<div>`s unreachable from the keyboard:

- The container is a `role="log"` + `aria-live="assertive"` region, created before any alert is injected (same subtlety `PanelTabBar` documents — content injected before the region joins the tree is never announced).
- Each alert gets `role="button"` + `tabindex="0"`, activates on Enter/Space, and has a visible `:focus-visible` ring. The existing click behavior is unchanged (shared `handleActivation` path).
- The emoji icon is `aria-hidden`; the dismiss button gets a real `aria-label` (it was title-only) and `type="button"`.

**Previously unnamed icon-only buttons get accessible names** (they announced as just "button"): the critical-region banner dismiss (`panel-layout.ts`), settings window close, aviation command bar close, payment failure banner dismiss, consumer prices clear-filter, and airline tracking clear. Title-only names are promoted to `aria-label` on the header settings/fullscreen/TV-mode buttons, the GitHub footer link, and the zoom controls on both map engines (`title` alone is not reliably exposed and is invisible to keyboard/touch users).

**Map imagery previews get `alt=""`** (`GlobeMap.ts` ×2, `DeckGLMap.ts`) — without any `alt`, screen readers read out the raw image URL.

**`mcp-grant.html`** (the OAuth-style consent screen) had no heading and its error message appeared silently: the "X wants access" / error titles are now `<h1>`s, the card is a `<main>` landmark, `#mintError` is `role="alert"` so a failed authorization is actually announced, and the decorative logo/spinner are hidden from AT.

Two new locale keys (`common.dismiss`, `components.breakingNews.alertsRegion`) added to `en.json` and synced across all locales via `npm run sync:locales`. Where files didn't already import i18n, hardcoded-English aria-labels follow existing precedent (`"Close menu"`, `"Primary"` in `panel-layout.ts`).

## Verification

- `npm run typecheck` — clean
- `biome lint` on all touched files — clean
- `npm run lint:safe-html` — clean
- `node --test tests/a11y-issue-4373-invariants.test.mjs` — 17/17 pass
- `npm run sync:locales:check` — in sync
