### PR TITLE
fix(license): put AGPL title first for GitHub detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,3 @@
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
@@ -667,3 +662,8 @@ For more information on this, and how to apply and follow the GNU AGPL, see
 
 World Monitor — Real-time global intelligence dashboard
 Copyright (C) 2024-2026 Elie Habib
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.

--- a/tests/license-docs.test.mjs
+++ b/tests/license-docs.test.mjs
@@ -42,15 +42,19 @@ function assertNoMatch(relativePath, text, pattern, label) {
 }
 
 describe('project license docs', () => {
-  it('keeps the project header below the complete AGPL text for license scanners', () => {
+  it('keeps the canonical AGPL header first and project notices below the complete text', () => {
     const license = readFileSync(join(root, 'LICENSE'), 'utf8');
+    const firstContentLine = license.split('\n').find((line) => line.trim().length > 0);
     const agplEnd = license.indexOf('END OF TERMS AND CONDITIONS');
     const projectHeader = license.indexOf('World Monitor — Real-time global intelligence dashboard');
     const projectCopyright = license.indexOf('Copyright (C) 2024-2026 Elie Habib');
+    const projectNotice = license.indexOf('\nThis program is free software:');
 
+    assert.equal(firstContentLine?.trim(), 'GNU AFFERO GENERAL PUBLIC LICENSE', 'root LICENSE must start with the canonical AGPL header');
     assert.ok(agplEnd >= 0, 'root LICENSE must contain the complete AGPL text');
     assert.ok(projectHeader > agplEnd, 'project header must follow the complete AGPL text');
     assert.ok(projectCopyright > agplEnd, 'project copyright must follow the complete AGPL text');
+    assert.ok(projectNotice > agplEnd, 'project notice must follow the complete AGPL text');
   });
 
   it('do not claim AGPL prohibits commercial use', () => {


### PR DESCRIPTION
## Summary
- Move the project notice that still preceded the AGPL title below the complete canonical AGPL-3.0 text.
- Require the root LICENSE to start with `GNU AFFERO GENERAL PUBLIC LICENSE` in the existing regression test.

Fixes #6576
Follow-up to #6579

## Intent
PR #6579 moved the World Monitor name and copyright lines, but GitHub still reported `NOASSERTION` because the five-line `This program is free software...` notice remained before the canonical AGPL title. This follow-up puts the canonical license first while preserving both project notices after the complete license text.

Non-goals: no runtime behavior, package metadata, client-license, or hosted-service license changes.

## Validation Matrix
| Check | Result |
| --- | --- |
| `node --test tests/license-docs.test.mjs` | Pass: 5 tests, 0 failures |
| Root LICENSE ordering check | Pass: first content line is `GNU AFFERO GENERAL PUBLIC LICENSE`; custom notices follow `END OF TERMS AND CONDITIONS` |
| `git diff --check` | Pass |
| Pre-push gate | Pass: typecheck, Unicode safety, changed tests, version sync, and applicable guards |
| Live GitHub license endpoint before this follow-up | Existing main returned `name: Other`, `spdx_id: NOASSERTION` after #6579 |

## Review Gates
- Code Review Expert: pass; no P0-P3 findings.
- Outcome Reviewer: pass against the reopened #6576 contract and the follow-up diff.

## Documentation
Not applicable. Existing license documentation already describes AGPL-3.0-only.

## Screenshots / UI Evidence
Not applicable; this is repository license metadata with no user interface change.

## Residual Findings
None.