### PR TITLE
docs: publish panel implementation count

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 
 - **500+ curated news feeds** across 15 categories, AI-synthesized into briefs
 - **Dual map engine** — 3D globe (globe.gl) and WebGL flat map (deck.gl) with 56 map layer types
+- **Panel inventory** — 109 concrete panel implementations across six specialized variants
 - **Cross-stream correlation** — military, economic, disaster, and escalation signal convergence
 - **Country Instability Index (CII)** — server-authoritative CII v8 stress scoring for 31 Tier-1 countries
 - **Finance radar** — 29 stock exchanges, commodities, crypto, and 7-signal market composite

--- a/api/_product-catalog.generated.js
+++ b/api/_product-catalog.generated.js
@@ -169,6 +169,7 @@ export const PUBLIC_PRODUCT_FACTS = {
     "locales": 28,
     "variants": 6,
     "mapLayers": 56,
+    "panelImplementations": 109,
     "feedDefinitions": 632,
     "freshnessTrackedSourceGroups": 35,
     "sourceAttributionHosts": 536,

--- a/docs/PRESS_KIT.md
+++ b/docs/PRESS_KIT.md
@@ -116,6 +116,7 @@ World Monitor aggregates publicly available data from dozens of sources. No prop
 | News feeds monitored | 500+ |
 | Live video streams | 8 |
 | Data layers on map | 56 layer types |
+| Panel implementations | 109 concrete classes |
 | Countries monitored | 200+ |
 | Languages supported | 27 (including RTL) |
 | Military bases mapped | 220+ |

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -25,7 +25,7 @@ This section gives procurement, security, and engineering teams a concise view o
 
 ### Technical capabilities
 
-World Monitor combines an interactive 3D globe and flat map, configurable intelligence panels, source-attributed news and OSINT, market and economic data, country risk and resilience scoring, infrastructure and supply-chain analysis, scenario modelling, AI-generated briefs, and alerting workflows. The generated product inventory currently records 56 map-layer definitions, more than 100 panel implementations, and six product variants.
+World Monitor combines an interactive 3D globe and flat map, configurable intelligence panels, source-attributed news and OSINT, market and economic data, country risk and resilience scoring, infrastructure and supply-chain analysis, scenario modelling, AI-generated briefs, and alerting workflows. The generated product inventory currently records 56 map-layer definitions, 109 concrete panel implementations, and six product variants. The panel figure counts concrete classes that extend the shared `Panel` base in [`src/components`](https://github.com/koala73/worldmonitor/tree/main/src/components); the base class itself is excluded, and a class reused by multiple variants is counted once.
 
 | Capability | Current scope |
 | --- | --- |

--- a/public/agents.md
+++ b/public/agents.md
@@ -2,7 +2,7 @@
 
 > How AI agents should work with worldmonitor.app: machine surfaces, authentication, crawl policy, rate limits, and discovery endpoints. Prefer the structured surfaces below over scraping the HTML dashboard — the dashboard is a WebGL SPA and yields nothing useful to a text parser.
 
-World Monitor is a real-time global intelligence dashboard: 500+ news feeds, 56 map layer types, country risk/resilience scores, AI briefs, forecasts, and market/supply-chain correlation, served as machine-readable JSON with documented methodology and provenance.
+World Monitor is a real-time global intelligence dashboard: 500+ news feeds, 56 map layer types, 109 concrete panel implementations, country risk/resilience scores, AI briefs, forecasts, and market/supply-chain correlation, served as machine-readable JSON with documented methodology and provenance.
 
 ## Machine surfaces (use these)
 

--- a/public/ai-search.md
+++ b/public/ai-search.md
@@ -40,6 +40,7 @@ World Monitor is useful for investors, portfolio managers, energy and commodity 
 ## Data Coverage
 
 - 56 map layer types
+- 109 concrete panel implementations across six variants
 - 500+ curated RSS feeds
 - 536+ observed upstream hosts
 - 13 maritime chokepoints with AIS-based transit intelligence

--- a/public/home.md
+++ b/public/home.md
@@ -7,6 +7,7 @@ Open-source (AGPL-3.0), used by 2M+ people across 190+ countries, as featured in
 ## What you get
 
 - Real-time global map with 56 data layers, 536+ observed upstream hosts, and 500+ curated news feeds
+- 109 concrete panel implementations across six specialized variants, with shared classes reused across builds
 - CII v8 for 31 Tier-1 countries, 196-country resilience scores, and global live conflict tracking
 - Market quotes, sector heatmaps, and macro indicators
 - 13 shipping chokepoints with live AIS vessel-transit intelligence

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Real-time global intelligence dashboard — AI-powered news aggregation, geopolitical monitoring, and infrastructure tracking in a unified situational awareness interface.
 
-World Monitor is an open-source (AGPL-3.0) intelligence platform that aggregates 500+ curated news feeds, 56 map layer types, and multiple AI models into a single dashboard. It runs as a web app, installable PWA, and native desktop application (Tauri) for macOS, Windows, and Linux.
+World Monitor is an open-source (AGPL-3.0) intelligence platform that aggregates 500+ curated news feeds, 56 map layer types, 109 concrete panel implementations, and multiple AI models into a single dashboard. It runs as a web app, installable PWA, and native desktop application (Tauri) for macOS, Windows, and Linux.
 
 A single codebase produces six specialized variants — geopolitical, technology, finance, commodity, happy, and energy — each with distinct feeds, panels, map layers, and branding. The multi-variant architecture uses build-time selection via the VITE_VARIANT environment variable, with runtime switching available via the header bar. Each variant tree-shakes unused data files so audience-specific builds can omit unrelated panels, feeds, and map registries.
 
@@ -253,6 +253,7 @@ Build-time: Vite HTML plugin transforms meta tags, Open Graph data, PWA manifest
 ## Desktop Application
 
 Native desktop app built with Tauri (Rust + Node.js sidecar). The sidecar mirrors all 60+ cloud API handlers locally with gzip compression. Features:
+
 - OS keychain integration for configured upstream API keys (macOS Keychain, Windows Credential Manager)
 - Token-authenticated sidecar prevents unauthorized local access
 - Cloud fallback when local handlers fail

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Real-time global intelligence dashboard — AI-powered news aggregation, geopolitical monitoring, and infrastructure tracking in a unified situational awareness interface.
 
-World Monitor is an open-source (AGPL-3.0) intelligence platform that aggregates 500+ news feeds, 56 map layer types, and multiple AI models into a single dashboard. Used by 2M+ people across 190+ countries, as featured in WIRED. It runs as a web app, installable PWA, and native desktop application (Tauri) for macOS, Windows, and Linux.
+World Monitor is an open-source (AGPL-3.0) intelligence platform that aggregates 500+ news feeds, 56 map layer types, 109 concrete panel implementations, and multiple AI models into a single dashboard. Used by 2M+ people across 190+ countries, as featured in WIRED. It runs as a web app, installable PWA, and native desktop application (Tauri) for macOS, Windows, and Linux.
 
 A single codebase produces six specialized variants — geopolitical (World Monitor), technology (Tech Monitor), finance (Finance Monitor), commodities (Commodity Monitor), positive news (Happy Monitor), and energy (Energy Monitor) — each with distinct feeds, panels, map layers, and branding. The multi-variant architecture uses build-time selection via the VITE_VARIANT environment variable, with runtime switching available via the header bar.
 

--- a/public/product-facts.json
+++ b/public/product-facts.json
@@ -165,6 +165,7 @@
     "locales": 28,
     "variants": 6,
     "mapLayers": 56,
+    "panelImplementations": 109,
     "feedDefinitions": 632,
     "freshnessTrackedSourceGroups": 35,
     "sourceAttributionHosts": 536,

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -950,7 +950,9 @@ function claims(s) {
     { file: 'README.md', re: /(\d+)\+\s+curated news feeds/, value: s.feedDefinitions, min: true },
     { file: 'README.md', re: /(\d+)\+\s+observed upstream hosts/, value: s.sourceAttributionHosts },
     { file: 'README.md', re: /(\d+)\s+stock exchanges/, value: s.stockExchangeCount },
+    { file: 'README.md', re: /(\d+)\s+concrete panel implementations/, value: s.panelClasses },
     { file: 'docs/overview.mdx', re: /(\d+)\+\s+curated news feeds/, value: s.feedDefinitions, min: true },
+    { file: 'docs/overview.mdx', re: /(\d+)\s+concrete panel implementations/, value: s.panelClasses },
     { file: 'docs/overview.mdx', re: /(\d+)\+\s+observed upstream hosts/, value: s.sourceAttributionHosts },
     { file: 'docs/overview.mdx', re: /interface supports (\d+)\s+languages/, value: s.locales },
     { file: 'docs/overview.mdx', re: /lists (\d+)\s+active providers/, value: s.sourceAttribution.providerCount },
@@ -1025,10 +1027,14 @@ function claims(s) {
 
     // ---- MCP tool count on public agent-discovery and marketing surfaces (#5389) ----
     { file: 'public/home.md', re: /(\d+)-tool MCP server/, value: s.mcpToolCount },
+    { file: 'public/home.md', re: /(\d+)\s+concrete panel implementations/, value: s.panelClasses },
     { file: 'public/agents.md', re: /Streamable HTTP, (\d+)\s+tools/, value: s.mcpToolCount },
+    { file: 'public/agents.md', re: /(\d+)\s+concrete panel implementations/, value: s.panelClasses },
     { file: 'public/developers.md', re: /Streamable HTTP, (\d+)\s+tools/, value: s.mcpToolCount },
     { file: 'public/llms.txt', re: /Streamable HTTP, (\d+)\s+tools/, value: s.mcpToolCount },
+    { file: 'public/llms.txt', re: /(\d+)\s+concrete panel implementations/, value: s.panelClasses },
     { file: 'public/llms-full.txt', re: /Streamable HTTP, (\d+)\s+tools/, value: s.mcpToolCount },
+    { file: 'public/llms-full.txt', re: /(\d+)\s+concrete panel implementations/, value: s.panelClasses },
     { file: 'public/llms-full.txt', re: /MCP server endpoint, (\d+)\s+tools/, value: s.mcpToolCount },
     { file: 'public/ai-search.md', re: /- (\d+)\s+MCP tools/, value: s.mcpToolCount },
     { file: 'public/ai-search.md', re: /- (\d+)\s+supported languages/, value: s.locales },
@@ -1037,6 +1043,7 @@ function claims(s) {
     // drifted (24 vs 26) precisely because nothing pinned it; these siblings
     // were one capability change away from the same fate.
     { file: 'public/ai-search.md', re: /- (\d+)\s+map layer types/, value: s.layerDefinitions },
+    { file: 'public/ai-search.md', re: /- (\d+)\s+concrete panel implementations/, value: s.panelClasses },
     { file: 'public/ai-search.md', re: /- (\d+)\+\s+observed upstream hosts/, value: s.sourceAttributionHosts },
     { file: 'public/ai-search.md', re: /- (\d+)\s+live Country Instability Index countries/, value: s.tier1Countries },
     { file: 'public/ai-search.md', re: /- (\d+)-country resilience rankings/, value: s.rankableUniverseCountries },
@@ -1082,6 +1089,7 @@ function claims(s) {
     { file: 'docs/mcp-quickstart.mdx', re: /WorldMonitor exposes (\d+)\s+live tools/, value: s.mcpToolCount },
     { file: 'docs/mcp-quickstart.mdx', re: /receives (\d+)\s+compressed tool descriptions/, value: s.mcpToolCount },
     { file: 'public/mcp-server.md', re: /server ships \*\*(\d+)\s+tools\*\*/, value: s.mcpToolCount },
+    { file: 'public/product-facts.json', re: /"panelImplementations":\s*(\d+)/, value: s.panelClasses },
 
     { file: 'docs/data-sources.mdx', re: /monitors (\d+)\s+data sources/, value: s.freshnessSources },
     { file: 'docs/source-attribution.mdx', re: /\*\*(\d+) active upstream hosts\*\*/, value: s.sourceAttributionHosts },
@@ -1096,6 +1104,7 @@ function claims(s) {
     { file: 'docs/COMMUNITY-PROMOTION-GUIDE.md', re: /"(\d+)\s+global stock exchanges mapped/, value: s.stockExchangeCount },
     { file: 'docs/COMMUNITY-PROMOTION-GUIDE.md', re: /Finance variant with (\d+)\s+exchanges/, value: s.stockExchangeCount },
     { file: 'docs/PRESS_KIT.md', re: /\| Stock exchanges mapped \| (\d+) \|/, value: s.stockExchangeCount },
+    { file: 'docs/PRESS_KIT.md', re: /\| Panel implementations \| (\d+) concrete classes \|/, value: s.panelClasses },
     { file: 'public/llms-full.txt', re: /Stock Exchanges\*\*: (\d+)\s+global exchanges/, value: s.stockExchangeCount },
     { file: 'public/llms-full.txt', re: /Central Banks & Institutions\*\*: (\d+)\s+central-bank and supranational finance institutions/, value: s.centralBankInstitutionCount },
     { file: 'public/llms-full.txt', re: /Unique layers: (\d+)\s+stock exchanges/, value: s.stockExchangeCount },

--- a/scripts/generate-public-product-facts.mjs
+++ b/scripts/generate-public-product-facts.mjs
@@ -191,6 +191,7 @@ const facts = {
     locales: stats.locales,
     variants: stats.variantCount,
     mapLayers: stats.layerDefinitions,
+    panelImplementations: stats.panelClasses,
     feedDefinitions: stats.feedDefinitions,
     freshnessTrackedSourceGroups: stats.freshnessSources,
     sourceAttributionHosts: stats.sourceAttributionHosts,

--- a/scripts/shared/product-catalog.generated.json
+++ b/scripts/shared/product-catalog.generated.json
@@ -167,6 +167,7 @@
       "locales": 28,
       "variants": 6,
       "mapLayers": 56,
+      "panelImplementations": 109,
       "feedDefinitions": 632,
       "freshnessTrackedSourceGroups": 35,
       "sourceAttributionHosts": 536,

--- a/scripts/shared/product-facts.generated.json
+++ b/scripts/shared/product-facts.generated.json
@@ -165,6 +165,7 @@
     "locales": 28,
     "variants": 6,
     "mapLayers": 56,
+    "panelImplementations": 109,
     "feedDefinitions": 632,
     "freshnessTrackedSourceGroups": 35,
     "sourceAttributionHosts": 536,

--- a/shared/product-catalog.generated.json
+++ b/shared/product-catalog.generated.json
@@ -167,6 +167,7 @@
       "locales": 28,
       "variants": 6,
       "mapLayers": 56,
+      "panelImplementations": 109,
       "feedDefinitions": 632,
       "freshnessTrackedSourceGroups": 35,
       "sourceAttributionHosts": 536,

--- a/shared/product-facts.generated.json
+++ b/shared/product-facts.generated.json
@@ -165,6 +165,7 @@
     "locales": 28,
     "variants": 6,
     "mapLayers": 56,
+    "panelImplementations": 109,
     "feedDefinitions": 632,
     "freshnessTrackedSourceGroups": 35,
     "sourceAttributionHosts": 536,

--- a/tests/public-product-facts.test.mjs
+++ b/tests/public-product-facts.test.mjs
@@ -89,6 +89,7 @@ describe('public product facts generation contract', () => {
     assert.equal(sharedFacts.product.primaryCtaLabel, 'View Pro plans');
     assert.equal(sharedFacts.currency, 'USD');
     assert.equal(sharedFacts.capabilities.mcpTools, registryToolCount());
+    assert.equal(sharedFacts.capabilities.panelImplementations, readJson('docs/generated/stats.json').panelClasses);
     assert.equal(sharedFacts.capabilities.sourceAttributionHosts, readJson('docs/generated/stats.json').sourceAttributionHosts);
     assert.equal(
       sharedFacts.capabilities.sourceAttributionProviders,


### PR DESCRIPTION
## Summary

- Replace the vague public panel claim with the exact inventory count: 109 concrete panel implementations.
- Define the count as concrete classes extending the shared `Panel` base; exclude the base class and count shared classes once.
- Publish `capabilities.panelImplementations` in generated product facts.
- Add docs-stats and product-facts assertions so public copies cannot drift from code.

## Intent

Make the panel inventory publicly verifiable and keep it aligned with the existing `panelClasses` source computation.

## Validation Matrix

- `npm run docs:check` — pass; 169 doc claims match code.
- `npm run product:facts:check` — pass.
- `node --import tsx --test tests/public-product-facts.test.mjs` — 7 passed.
- `npm run typecheck` — pass.
- `npm run typecheck:api` — pass.
- `npm run lint:md` — pass across 235 files.
- Pre-push hook — pass, including 253 edge tests and 737 MDX tests.

## Review Gates

- Independent code review completed with no P0-P3 findings.
- No reviewers requested or assigned.
- No merge or auto-merge action taken.

## Documentation

Updated README, public agent/AI surfaces, docs overview, press kit, and generated product-facts/catalog surfaces.

## Screenshots/UI Evidence

Not applicable — this is a documentation and machine-readable product metadata change.

## Residual Findings

None for the scoped change. The public runtime pages will reflect this after the PR is merged and deployed.