### PR TITLE
fix(seo): submit every sitemap host to IndexNow, and actually run the variant batches

### DIFF
--- a/.github/workflows/indexnow-submit.yml
+++ b/.github/workflows/indexnow-submit.yml
@@ -26,7 +26,10 @@ jobs:
         github.event.deployment.creator.login == 'vercel[bot]'
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Seven hosts are now submitted sequentially rather than two; each request
+    # carries its own 15s deadline (REQUEST_TIMEOUT_MS), so this bounds a stuck
+    # run rather than being the only thing that ever stops one.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -96,11 +99,15 @@ jobs:
               || grep -Fxq "public/${APEX_KEY_PATH}" <<< "$CHANGED_FILES"; then
               SUBMIT_APEX=true
             fi
-            if grep -Eq '^(\.github/workflows/indexnow-submit\.yml|blog-site/src/.*|pro-test/index\.html|pro-test/src/.*|public/blog/.*|public/sitemap\.xml|scripts/build-crawlable-corpus\.mjs|scripts/build-sitemap\.mjs|scripts/seo-indexnow-submit\.mjs|vercel\.json)$' <<< "$CHANGED_FILES" \
+            if grep -Eq '^(\.github/workflows/indexnow-submit\.yml|blog-site/src/.*|pro-test/index\.html|pro-test/src/.*|public/blog/.*|public/pro/.*|public/sitemap\.xml|scripts/build-crawlable-corpus\.mjs|scripts/build-sitemap\.mjs|scripts/seo-indexnow-submit\.mjs|vercel\.json)$' <<< "$CHANGED_FILES" \
               || grep -Fxq "public/${WWW_KEY_PATH}" <<< "$CHANGED_FILES"; then
               SUBMIT_WWW=true
             fi
-            if grep -Eq '^(\.github/workflows/indexnow-submit\.yml|middleware\.ts|public/sitemap\.xml|scripts/build-sitemap\.mjs|scripts/seo-indexnow-submit\.mjs|src/config/variant-dashboard-html\.ts|src/config/variant-meta\.ts|vercel\.json)$' <<< "$CHANGED_FILES"; then
+            # Each variant batch submits the bare root as well as /dashboard, and
+            # vercel.json rewrites every variant root to /pro/welcome.html — so
+            # the welcome page's sources and committed build output change what
+            # five submitted URLs serve.
+            if grep -Eq '^(\.github/workflows/indexnow-submit\.yml|middleware\.ts|pro-test/index\.html|pro-test/src/.*|public/pro/.*|public/sitemap\.xml|scripts/build-sitemap\.mjs|scripts/seo-indexnow-submit\.mjs|src/config/variant-dashboard-html\.ts|src/config/variant-meta\.ts|vercel\.json)$' <<< "$CHANGED_FILES"; then
               SUBMIT_VARIANTS=true
             fi
             for key_path in $VARIANT_KEY_PATHS; do
@@ -125,6 +132,13 @@ jobs:
         # Every host is attempted even when one fails, so a single broken
         # variant cannot hide the state of the others.
         run: |
+          # An empty list would iterate zero times and exit 0 — green with zero
+          # submissions, the exact silent failure this step exists to end. Fail
+          # closed instead, so a lost gate output cannot look like success.
+          if [[ -z "${VARIANT_HOSTS// /}" ]]; then
+            echo "::error::no IndexNow variant hosts were derived from public/sitemap.xml"
+            exit 1
+          fi
           status=0
           for host in $VARIANT_HOSTS; do
             node scripts/seo-indexnow-submit.mjs --host "$host" || status=1

--- a/.github/workflows/indexnow-submit.yml
+++ b/.github/workflows/indexnow-submit.yml
@@ -139,8 +139,11 @@ jobs:
             echo "::error::no IndexNow variant hosts were derived from public/sitemap.xml"
             exit 1
           fi
+          # Split on whitespace without also glob-expanding: an unquoted $VAR
+          # would let a '*' in a host name expand against the workspace.
+          read -ra hosts <<< "$VARIANT_HOSTS"
           status=0
-          for host in $VARIANT_HOSTS; do
+          for host in "${hosts[@]}"; do
             node scripts/seo-indexnow-submit.mjs --host "$host" || status=1
           done
           exit $status

--- a/.github/workflows/indexnow-submit.yml
+++ b/.github/workflows/indexnow-submit.yml
@@ -1,9 +1,10 @@
 name: IndexNow Submission
 
-# Submit the canonical apex MCP URL and the www product/blog surfaces only after
-# Vercel reports that the exact production deployment succeeded. The changed-
-# file gate avoids resubmitting unchanged URLs on unrelated deploys;
-# workflow_dispatch remains available for an operator-requested recovery.
+# Submit the canonical apex MCP URL, the www product/blog surfaces, and every
+# variant dashboard host only after Vercel reports that the exact production
+# deployment succeeded. The changed-file gate avoids resubmitting unchanged URLs
+# on unrelated deploys; workflow_dispatch remains available for an
+# operator-requested recovery.
 on:
   deployment_status:
   workflow_dispatch:
@@ -55,16 +56,42 @@ jobs:
               process.stdout.write(new URL(batch.keyLocation).pathname.slice(1));
             "
           )"
+          # Derived from the committed sitemap, so a newly published variant host
+          # is submitted without editing this workflow (#6563).
+          VARIANT_HOSTS="$(
+            node --input-type=module -e "
+              import { INDEXNOW_VARIANT_HOSTS } from './scripts/seo-indexnow-submit.mjs';
+              process.stdout.write(INDEXNOW_VARIANT_HOSTS.join(' '));
+            "
+          )"
+          # Every distinct key file the variants own, so a per-variant key added
+          # later still triggers a resubmission when it is rotated.
+          VARIANT_KEY_PATHS="$(
+            node --input-type=module -e "
+              import { INDEXNOW_BATCHES, INDEXNOW_VARIANT_HOSTS } from './scripts/seo-indexnow-submit.mjs';
+              const hosts = new Set(INDEXNOW_VARIANT_HOSTS);
+              const paths = new Set(
+                INDEXNOW_BATCHES
+                  .filter(({ host }) => hosts.has(host))
+                  .map(({ keyLocation }) => new URL(keyLocation).pathname.slice(1)),
+              );
+              process.stdout.write([...paths].join(' '));
+            "
+          )"
+          echo "variant_hosts=$VARIANT_HOSTS" >> "$GITHUB_OUTPUT"
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "submit_apex=true" >> "$GITHUB_OUTPUT"
             echo "submit_www=true" >> "$GITHUB_OUTPUT"
+            echo "submit_variants=true" >> "$GITHUB_OUTPUT"
           elif ! git rev-parse "${DEPLOYED_SHA}^" >/dev/null 2>&1; then
             echo "submit_apex=true" >> "$GITHUB_OUTPUT"
             echo "submit_www=true" >> "$GITHUB_OUTPUT"
+            echo "submit_variants=true" >> "$GITHUB_OUTPUT"
           else
             CHANGED_FILES="$(git diff-tree --no-commit-id --name-only -r "${DEPLOYED_SHA}^" "$DEPLOYED_SHA")"
             SUBMIT_APEX=false
             SUBMIT_WWW=false
+            SUBMIT_VARIANTS=false
             if grep -Eq '^(\.github/workflows/indexnow-submit\.yml|api/mcp\.ts|api/mcp/.*|middleware\.ts|public/mcp-server\.md|public/sitemap\.xml|scripts/build-sitemap\.mjs|scripts/seo-indexnow-submit\.mjs|vercel\.json)$' <<< "$CHANGED_FILES" \
               || grep -Fxq "public/${APEX_KEY_PATH}" <<< "$CHANGED_FILES"; then
               SUBMIT_APEX=true
@@ -73,8 +100,17 @@ jobs:
               || grep -Fxq "public/${WWW_KEY_PATH}" <<< "$CHANGED_FILES"; then
               SUBMIT_WWW=true
             fi
+            if grep -Eq '^(\.github/workflows/indexnow-submit\.yml|middleware\.ts|public/sitemap\.xml|scripts/build-sitemap\.mjs|scripts/seo-indexnow-submit\.mjs|src/config/variant-dashboard-html\.ts|src/config/variant-meta\.ts|vercel\.json)$' <<< "$CHANGED_FILES"; then
+              SUBMIT_VARIANTS=true
+            fi
+            for key_path in $VARIANT_KEY_PATHS; do
+              if grep -Fxq "public/${key_path}" <<< "$CHANGED_FILES"; then
+                SUBMIT_VARIANTS=true
+              fi
+            done
             echo "submit_apex=$SUBMIT_APEX" >> "$GITHUB_OUTPUT"
             echo "submit_www=$SUBMIT_WWW" >> "$GITHUB_OUTPUT"
+            echo "submit_variants=$SUBMIT_VARIANTS" >> "$GITHUB_OUTPUT"
           fi
       - name: Submit the canonical MCP URL
         if: steps.relevant.outputs.submit_apex == 'true'
@@ -82,3 +118,15 @@ jobs:
       - name: Submit canonical www product and blog URLs
         if: steps.relevant.outputs.submit_www == 'true'
         run: node scripts/seo-indexnow-submit.mjs --host www.worldmonitor.app
+      - name: Submit canonical variant dashboard URLs
+        if: steps.relevant.outputs.submit_variants == 'true'
+        env:
+          VARIANT_HOSTS: ${{ steps.relevant.outputs.variant_hosts }}
+        # Every host is attempted even when one fails, so a single broken
+        # variant cannot hide the state of the others.
+        run: |
+          status=0
+          for host in $VARIANT_HOSTS; do
+            node scripts/seo-indexnow-submit.mjs --host "$host" || status=1
+          done
+          exit $status

--- a/scripts/seo-indexnow-submit.mjs
+++ b/scripts/seo-indexnow-submit.mjs
@@ -27,6 +27,10 @@ const BLOG_AUTHORS_DIR = new URL('../blog-site/src/pages/authors/', import.meta.
 const GLOSSARY_SOURCE = new URL('../blog-site/src/data/glossary.ts', import.meta.url);
 const ROOT_SITEMAP = new URL('../public/sitemap.xml', import.meta.url);
 const USER_AGENT = 'WorldMonitor-IndexNow/1.0 (+https://www.worldmonitor.app)';
+// Every host is submitted sequentially inside one 10-minute job, and fetch has
+// no default deadline — one unresponsive search engine would otherwise stall
+// the run until the job timeout and leave later hosts unsubmitted.
+const REQUEST_TIMEOUT_MS = 15_000;
 
 function decodeXml(value) {
   return String(value)
@@ -102,6 +106,12 @@ const WWW_URLS = uniqueSorted([
  * dashboards. Derived from the sitemap rather than restated so a new variant
  * cannot be silently omitted from IndexNow the way commodity and energy were
  * (#6563). The deploy workflow reads this export to submit each one.
+ *
+ * Deriving it makes this list agree with the sitemap by construction, so the
+ * sitemap cannot also be its proof: tests/indexnow-submit.test.mjs pins it to
+ * WEB_DASHBOARD_VARIANTS — the registry of variants the app actually serves —
+ * so a variant dropped upstream in build-sitemap.mjs fails there instead of
+ * quietly shrinking this list.
  */
 export const INDEXNOW_VARIANT_HOSTS = Object.freeze(
   uniqueSorted(ROOT_SITEMAP_URLS.map((url) => new URL(url).hostname))
@@ -144,6 +154,7 @@ export async function verifyIndexNowKey(batchConfig, { fetchImpl = globalThis.fe
   const response = await fetchImpl(batchConfig.keyLocation, {
     method: 'GET',
     redirect: 'manual',
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     headers: {
       Accept: 'text/plain',
       'User-Agent': USER_AGENT,
@@ -163,6 +174,7 @@ export async function verifyIndexNowKey(batchConfig, { fetchImpl = globalThis.fe
 async function submit(endpoint, batchConfig, fetchImpl) {
   const response = await fetchImpl(endpoint, {
     method: 'POST',
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
       'User-Agent': USER_AGENT,

--- a/scripts/seo-indexnow-submit.mjs
+++ b/scripts/seo-indexnow-submit.mjs
@@ -88,11 +88,25 @@ function getBlogUrls() {
   ];
 }
 
-const APEX_URLS = uniqueSorted(getSitemapUrlsForHost('worldmonitor.app'));
+const APEX_HOST = 'worldmonitor.app';
+const WWW_HOST = 'www.worldmonitor.app';
+
+const APEX_URLS = uniqueSorted(getSitemapUrlsForHost(APEX_HOST));
 const WWW_URLS = uniqueSorted([
-  ...getSitemapUrlsForHost('www.worldmonitor.app'),
+  ...getSitemapUrlsForHost(WWW_HOST),
   ...getBlogUrls(),
 ]);
+
+/**
+ * Every remaining host the committed sitemap publishes — today the variant
+ * dashboards. Derived from the sitemap rather than restated so a new variant
+ * cannot be silently omitted from IndexNow the way commodity and energy were
+ * (#6563). The deploy workflow reads this export to submit each one.
+ */
+export const INDEXNOW_VARIANT_HOSTS = Object.freeze(
+  uniqueSorted(ROOT_SITEMAP_URLS.map((url) => new URL(url).hostname))
+    .filter((host) => host !== APEX_HOST && host !== WWW_HOST),
+);
 
 function urlsForHost(host, extraUrls = []) {
   return uniqueSorted([...getSitemapUrlsForHost(host), ...extraUrls]);
@@ -108,11 +122,11 @@ function batch(host, urls, key = INDEXNOW_KEY) {
 }
 
 export const INDEXNOW_BATCHES = Object.freeze([
-  batch('worldmonitor.app', APEX_URLS, APEX_INDEXNOW_KEY),
-  batch('www.worldmonitor.app', WWW_URLS),
-  batch('tech.worldmonitor.app', urlsForHost('tech.worldmonitor.app', ['https://tech.worldmonitor.app/'])),
-  batch('finance.worldmonitor.app', urlsForHost('finance.worldmonitor.app', ['https://finance.worldmonitor.app/'])),
-  batch('happy.worldmonitor.app', urlsForHost('happy.worldmonitor.app', ['https://happy.worldmonitor.app/'])),
+  batch(APEX_HOST, APEX_URLS, APEX_INDEXNOW_KEY),
+  batch(WWW_HOST, WWW_URLS),
+  // The sitemap lists each variant's canonical /dashboard; the bare root is the
+  // AI-crawler stub surface middleware.ts serves, so submit both.
+  ...INDEXNOW_VARIANT_HOSTS.map((host) => batch(host, urlsForHost(host, [`https://${host}/`]))),
 ]);
 
 export const INDEXNOW_ENDPOINTS = Object.freeze([

--- a/tests/indexnow-submit.test.mjs
+++ b/tests/indexnow-submit.test.mjs
@@ -63,6 +63,54 @@ describe('IndexNow submission', () => {
     assert.equal(new Set(apexBatch.urls).size, apexBatch.urls.length, 'apex batch must not contain duplicates');
   });
 
+  it('gives every host published in the committed sitemap its own IndexNow batch', () => {
+    const sitemap = readFileSync(new URL('../public/sitemap.xml', import.meta.url), 'utf8');
+    const sitemapHosts = new Set(
+      [...sitemap.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/g)].map((match) => new URL(match[1].trim()).hostname),
+    );
+    const batchHosts = new Set(indexNow.INDEXNOW_BATCHES.map(({ host }) => host));
+
+    for (const host of sitemapHosts) {
+      assert.ok(
+        batchHosts.has(host),
+        `${host} appears in public/sitemap.xml but has no INDEXNOW_BATCHES entry, so its URLs are never submitted`,
+      );
+    }
+    for (const host of batchHosts) {
+      assert.ok(
+        sitemapHosts.has(host),
+        `${host} has an INDEXNOW_BATCHES entry but publishes no sitemap URL`,
+      );
+    }
+  });
+
+  it('submits every configured batch host from the deploy workflow', () => {
+    const workflow = readFileSync(
+      new URL('../.github/workflows/indexnow-submit.yml', import.meta.url),
+      'utf8',
+    );
+    // Hosts the workflow names outright (`--host worldmonitor.app`); the shell
+    // variable form used for the variant loop deliberately does not match.
+    const literalHosts = [...workflow.matchAll(/--host ((?:[a-z0-9-]+\.)*worldmonitor\.app)\b/g)]
+      .map((match) => match[1]);
+    assert.ok(
+      Array.isArray(indexNow.INDEXNOW_VARIANT_HOSTS),
+      'the script must export the variant host list the workflow iterates',
+    );
+    assert.match(
+      workflow,
+      /INDEXNOW_VARIANT_HOSTS/,
+      'the workflow must derive its variant hosts from the script, not restate them',
+    );
+    assert.match(workflow, /--host "\$host"/, 'the variant step must submit each derived host');
+
+    assert.deepEqual(
+      new Set([...literalHosts, ...indexNow.INDEXNOW_VARIANT_HOSTS]),
+      new Set(indexNow.INDEXNOW_BATCHES.map(({ host }) => host)),
+      'every INDEXNOW_BATCHES host must be reachable from a workflow submission step',
+    );
+  });
+
   it('keeps every submitted URL and key location on the declared host', () => {
     for (const batch of indexNow.INDEXNOW_BATCHES) {
       assert.equal(new URL(batch.keyLocation).hostname, batch.host);

--- a/tests/indexnow-submit.test.mjs
+++ b/tests/indexnow-submit.test.mjs
@@ -1,6 +1,131 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import YAML from 'yaml';
+
+import { WEB_DASHBOARD_VARIANTS } from '../src/config/variant-dashboard-html.ts';
+
+/**
+ * The web-served variant registry, which is what the app actually deploys — not
+ * the sitemap, and not the IndexNow config derived from it. Both of those are
+ * downstream of this list, so comparing them to each other proves nothing
+ * (#6563). Same source and same reason as tests/sentry-allow-urls.test.mts.
+ */
+const SERVED_VARIANT_HOSTS = WEB_DASHBOARD_VARIANTS
+  .map((variant) => `${variant}.worldmonitor.app`)
+  .sort();
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const WORKFLOW_PATH = resolve(repoRoot, '.github/workflows/indexnow-submit.yml');
+const workflowSource = readFileSync(WORKFLOW_PATH, 'utf8');
+const workflowDoc = YAML.parse(workflowSource);
+const workflowSteps = workflowDoc.jobs['submit-indexnow'].steps;
+
+function workflowStep({ id, name }) {
+  const step = workflowSteps.find((candidate) => (id ? candidate.id === id : candidate.name === name));
+  assert.ok(step, `indexnow workflow must define the ${id ?? name} step`);
+  return step;
+}
+
+// Each gate run spawns several short-lived node processes, so the cases are run
+// concurrently — serially they dominate this file's runtime.
+function runStep(script, env) {
+  return new Promise((resolvePromise) => {
+    const child = spawn('bash', ['-e', '-c', script], { cwd: repoRoot, env });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (status) => resolvePromise({ stdout, stderr, status }));
+  });
+}
+
+/**
+ * Execute the workflow's real relevance-gate script with `git` stubbed to report
+ * `changedFiles`, and return the `$GITHUB_OUTPUT` it produced. Running the
+ * committed shell — rather than regex-matching it — is what makes the gate's
+ * behaviour testable in both directions.
+ */
+async function runRelevanceGate(changedFiles, eventName = 'deployment_status') {
+  const dir = mkdtempSync(join(tmpdir(), 'indexnow-gate-'));
+  try {
+    const gitStub = join(dir, 'git');
+    writeFileSync(
+      gitStub,
+      [
+        '#!/bin/bash',
+        '[[ "$1" == "rev-parse" ]] && exit 0',
+        `[[ "$1" == "diff-tree" ]] && { printf '%s\\n' ${changedFiles.map((file) => JSON.stringify(file)).join(' ')}; exit 0; }`,
+        'exit 0',
+        '',
+      ].join('\n'),
+    );
+    chmodSync(gitStub, 0o755);
+    const outputFile = join(dir, 'github-output');
+    writeFileSync(outputFile, '');
+
+    const { stderr, status } = await runStep(workflowStep({ id: 'relevant' }).run, {
+      ...process.env,
+      DEPLOYED_SHA: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+      EVENT_NAME: eventName,
+      GITHUB_OUTPUT: outputFile,
+      PATH: `${dir}:${process.env.PATH}`,
+    });
+    assert.equal(status, 0, stderr);
+
+    return Object.fromEntries(
+      readFileSync(outputFile, 'utf8')
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => [line.slice(0, line.indexOf('=')), line.slice(line.indexOf('=') + 1)]),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Execute the workflow's real variant submit step with `node` stubbed, and
+ * report which hosts it actually invoked plus the step's exit status.
+ */
+async function runVariantSubmitStep(variantHosts, { failingHost = null } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'indexnow-submit-'));
+  try {
+    const nodeStub = join(dir, 'node');
+    writeFileSync(
+      nodeStub,
+      [
+        '#!/bin/bash',
+        // Invocation is `node scripts/seo-indexnow-submit.mjs --host <host>`.
+        '[[ "$2" == "--host" ]] || exit 90',
+        // Tagged so the step's own ::error:: annotations are not mistaken for
+        // submissions — a bare echo would make a failing step look busy.
+        'echo "submitted:$3"',
+        failingHost ? `[[ "$3" == "${failingHost}" ]] && exit 1` : '',
+        'exit 0',
+        '',
+      ].filter(Boolean).join('\n'),
+    );
+    chmodSync(nodeStub, 0o755);
+
+    const { stdout, status } = await runStep(
+      workflowStep({ name: 'Submit canonical variant dashboard URLs' }).run,
+      { ...process.env, PATH: `${dir}:${process.env.PATH}`, VARIANT_HOSTS: variantHosts },
+    );
+    const hosts = stdout
+      .split('\n')
+      .filter((line) => line.startsWith('submitted:'))
+      .map((line) => line.slice('submitted:'.length));
+    return { hosts, status };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 const originalFetch = globalThis.fetch;
 const importFetchCalls = [];
@@ -63,51 +188,127 @@ describe('IndexNow submission', () => {
     assert.equal(new Set(apexBatch.urls).size, apexBatch.urls.length, 'apex batch must not contain duplicates');
   });
 
-  it('gives every host published in the committed sitemap its own IndexNow batch', () => {
-    const sitemap = readFileSync(new URL('../public/sitemap.xml', import.meta.url), 'utf8');
-    const sitemapHosts = new Set(
-      [...sitemap.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/g)].map((match) => new URL(match[1].trim()).hostname),
+  it('submits every web variant the app actually serves', () => {
+    // Anchored to the served-variant registry, NOT to the sitemap the batches
+    // are derived from — comparing the sitemap to a list built out of it is a
+    // tautology with no falsifying input, and would stay green through the very
+    // regression #6563 reported (a variant dropped from build-sitemap.mjs).
+    assert.ok(SERVED_VARIANT_HOSTS.length >= 5, `expected at least 5 web variant hosts, got ${SERVED_VARIANT_HOSTS.length}`);
+    assert.deepEqual(
+      [...indexNow.INDEXNOW_VARIANT_HOSTS],
+      SERVED_VARIANT_HOSTS,
+      'every served variant needs an IndexNow batch, and no other host may acquire one',
     );
-    const batchHosts = new Set(indexNow.INDEXNOW_BATCHES.map(({ host }) => host));
+  });
 
-    for (const host of sitemapHosts) {
+  it('submits every canonical URL the sitemap publishes, for every host', () => {
+    const sitemap = readFileSync(new URL('../public/sitemap.xml', import.meta.url), 'utf8');
+    const sitemapUrls = [...sitemap.matchAll(/<loc>\s*([^<]+?)\s*<\/loc>/g)].map((match) => match[1].trim());
+    assert.ok(sitemapUrls.length > 0, 'sitemap parse produced no URLs');
+
+    for (const url of sitemapUrls) {
+      const host = new URL(url).hostname;
+      const batch = indexNow.INDEXNOW_BATCHES.find((candidate) => candidate.host === host);
+      assert.ok(batch, `${host} appears in public/sitemap.xml but has no INDEXNOW_BATCHES entry`);
       assert.ok(
-        batchHosts.has(host),
-        `${host} appears in public/sitemap.xml but has no INDEXNOW_BATCHES entry, so its URLs are never submitted`,
-      );
-    }
-    for (const host of batchHosts) {
-      assert.ok(
-        sitemapHosts.has(host),
-        `${host} has an INDEXNOW_BATCHES entry but publishes no sitemap URL`,
+        batch.urls.includes(url),
+        `${url} is published in the sitemap but is not in the ${host} batch, so it is never submitted`,
       );
     }
   });
 
-  it('submits every configured batch host from the deploy workflow', () => {
-    const workflow = readFileSync(
-      new URL('../.github/workflows/indexnow-submit.yml', import.meta.url),
-      'utf8',
+  it('submits every configured batch host from the deploy workflow', async () => {
+    // Three links, each pinned by execution or exact equality rather than a
+    // regex over the YAML: the gate emits the derived hosts, the submit step
+    // consumes that exact output, and the loop invokes --host for each one.
+    const emitted = (await runRelevanceGate(['public/sitemap.xml'])).variant_hosts;
+    assert.equal(
+      emitted,
+      indexNow.INDEXNOW_VARIANT_HOSTS.join(' '),
+      'the gate must publish the hosts derived from the sitemap',
     );
-    // Hosts the workflow names outright (`--host worldmonitor.app`); the shell
-    // variable form used for the variant loop deliberately does not match.
-    const literalHosts = [...workflow.matchAll(/--host ((?:[a-z0-9-]+\.)*worldmonitor\.app)\b/g)]
-      .map((match) => match[1]);
-    assert.ok(
-      Array.isArray(indexNow.INDEXNOW_VARIANT_HOSTS),
-      'the script must export the variant host list the workflow iterates',
+    assert.equal(
+      workflowStep({ name: 'Submit canonical variant dashboard URLs' }).env.VARIANT_HOSTS,
+      '${{ steps.relevant.outputs.variant_hosts }}',
+      'the submit step must consume the gate output, not a restated list',
     );
-    assert.match(
-      workflow,
-      /INDEXNOW_VARIANT_HOSTS/,
-      'the workflow must derive its variant hosts from the script, not restate them',
-    );
-    assert.match(workflow, /--host "\$host"/, 'the variant step must submit each derived host');
+    const { hosts } = await runVariantSubmitStep(emitted);
 
+    // Hosts the workflow names outright (`--host worldmonitor.app`); the variant
+    // loop's hosts come from actually running it, so pointing the loop at a
+    // different variable drops them here.
+    const literalHosts = [...workflowSource.matchAll(/--host ((?:[a-z0-9-]+\.)*worldmonitor\.app)\b/g)]
+      .map((match) => match[1]);
     assert.deepEqual(
-      new Set([...literalHosts, ...indexNow.INDEXNOW_VARIANT_HOSTS]),
+      new Set([...literalHosts, ...hosts]),
       new Set(indexNow.INDEXNOW_BATCHES.map(({ host }) => host)),
       'every INDEXNOW_BATCHES host must be reachable from a workflow submission step',
+    );
+  });
+
+  it('attempts every variant host even after one of them fails', async () => {
+    const hostList = indexNow.INDEXNOW_VARIANT_HOSTS.join(' ');
+    const [failed, healthy] = await Promise.all([
+      runVariantSubmitStep(hostList, { failingHost: indexNow.INDEXNOW_VARIANT_HOSTS[0] }),
+      runVariantSubmitStep(hostList),
+    ]);
+
+    assert.deepEqual(failed.hosts, [...indexNow.INDEXNOW_VARIANT_HOSTS], 'no host may be skipped by an earlier failure');
+    assert.notEqual(failed.status, 0, 'a failed host must still fail the step');
+    assert.equal(healthy.status, 0, 'an all-healthy run must succeed');
+  });
+
+  it('fails the variant step rather than reporting green on zero submissions', async () => {
+    // A renamed step output or an emptied host list resolves this env var to ''.
+    // Iterating nothing must not be indistinguishable from submitting everything.
+    for (const empty of ['', '   ']) {
+      const { hosts, status } = await runVariantSubmitStep(empty);
+      assert.deepEqual(hosts, [], 'an empty host list must submit nothing');
+      assert.notEqual(status, 0, `VARIANT_HOSTS=${JSON.stringify(empty)} must fail the step, not pass it`);
+    }
+  });
+
+  it('gates variant resubmission on the surfaces that change variant URLs', async () => {
+    const variantKeyPath = new URL(
+      indexNow.INDEXNOW_BATCHES.find(({ host }) => host === indexNow.INDEXNOW_VARIANT_HOSTS[0]).keyLocation,
+    ).pathname.slice(1);
+    const resubmits = [
+      'public/sitemap.xml',
+      'scripts/build-sitemap.mjs',
+      'middleware.ts',
+      'src/config/variant-meta.ts',
+      // Every variant root is rewritten to the welcome page, so its sources and
+      // committed output change what the submitted root URLs serve.
+      'public/pro/welcome.html',
+      'pro-test/src/welcome.ts',
+      `public/${variantKeyPath}`,
+    ];
+    const inert = ['blog-site/src/content/blog/a-post.md', 'src/components/SomePanel.tsx'];
+
+    const [resubmitGates, inertGates, dispatchGate] = await Promise.all([
+      Promise.all(resubmits.map((changed) => runRelevanceGate([changed]))),
+      Promise.all(inert.map((changed) => runRelevanceGate([changed]))),
+      runRelevanceGate([], 'workflow_dispatch'),
+    ]);
+
+    resubmits.forEach((changed, index) => {
+      assert.equal(
+        resubmitGates[index].submit_variants,
+        'true',
+        `${changed} changes variant URLs or their ownership proof, so it must resubmit`,
+      );
+    });
+    inert.forEach((changed, index) => {
+      assert.equal(
+        inertGates[index].submit_variants,
+        'false',
+        `${changed} cannot change a variant URL, so it must not resubmit`,
+      );
+    });
+    assert.equal(
+      dispatchGate.submit_variants,
+      'true',
+      'operator-requested recovery must cover the variants too',
     );
   });
 

--- a/tests/indexnow-submit.test.mjs
+++ b/tests/indexnow-submit.test.mjs
@@ -329,6 +329,29 @@ describe('IndexNow submission', () => {
     }
   });
 
+  it('bounds every request so one stalled endpoint cannot consume the job', async () => {
+    // fetch has no default deadline, and seven hosts are submitted sequentially
+    // inside one job — without this, a hung endpoint strands the later hosts.
+    const requests = [];
+    const apexBatch = indexNow.INDEXNOW_BATCHES.find(({ host }) => host === 'worldmonitor.app');
+    const fetchImpl = async (url, init) => {
+      requests.push({ url: String(url), init });
+      if (String(url) === apexBatch.keyLocation) return new Response(apexBatch.key, { status: 200 });
+      return new Response(null, { status: 202 });
+    };
+
+    await indexNow.submitIndexNowBatch(apexBatch, {
+      endpoints: ['https://api.indexnow.org/IndexNow'],
+      fetchImpl,
+    });
+
+    assert.equal(requests.length, 2, 'expected the key verification plus one submission');
+    for (const { url, init } of requests) {
+      assert.ok(init.signal, `${url} must carry an abort signal`);
+      assert.equal(typeof init.signal.aborted, 'boolean', `${url} signal must be an AbortSignal`);
+    }
+  });
+
   it('requires a direct key response with the exact key body', async () => {
     const requests = [];
     const fetchImpl = async (url, init) => {


### PR DESCRIPTION
Fixes #6563.

## The issue was half the story

`INDEXNOW_BATCHES` did omit `commodity` and `energy`. But adding them would have shipped a **no-op**: `.github/workflows/indexnow-submit.yml` only ever invoked `--host worldmonitor.app` and `--host www.worldmonitor.app`, so **all five** variant batches were configuration that never executed. The issue's premise that "their three sibling variants get instant submission" was wrong — `tech`, `finance`, and `happy` were not being submitted either. Nothing was.

So this fixes the host list, and the reason the host list never mattered.

## What changed

**Derive, don't restate.** `INDEXNOW_VARIANT_HOSTS` comes from the committed root sitemap and is exported for the workflow to consume, so a newly published variant is submitted without editing either file.

**Submit them.** A new workflow step iterates the derived hosts. Every host is attempted even when one fails, so a single broken variant cannot hide the state of the others, and an empty list fails the step instead of exiting 0 with zero submissions.

**Guard it with tests that can actually fail** (see below).

**Two fixes the review surfaced:**
- The variant relevance gate never watched the welcome page, though `vercel.json` rewrites every variant root to `/pro/welcome.html` and each batch submits that root. Replaying the gate over the last 200 commits: of the 15 touching `public/pro/welcome.html`, **6 would have silently skipped submission**. The www root had the same gap; fixed alongside.
- No request had a deadline. `fetch` has no default timeout, so one stalled endpoint could consume the entire job and leave later hosts unsubmitted — a risk that grew when 2 hosts became 7. Every request now carries a 15s deadline, and the job timeout goes 5 → 10 minutes so it bounds a stuck run rather than being the only thing that ever stops one.

## The guards had to be rewritten to have teeth

The first round's closed-world guard compared sitemap hosts to batch hosts — but once the batches were *derived* from the sitemap, both sides read the same source. Adversarial review proved it had **no falsifying input**: it stayed green through the literal #6563 regression moved one hop upstream (variant `route()` calls deleted from `build-sitemap.mjs`), and through an empty variant list.

The guard is now anchored to `WEB_DASHBOARD_VARIANTS` — the registry of variants the app actually serves — mirroring `tests/sentry-allow-urls.test.mts`, which uses the same source for the same class of guard.

Each of these was verified to survive the old assertion and fail against the new one:

| Regression | Old guard | New guard |
|---|---|---|
| `commodity` + `energy` dropped from the sitemap (the #6563 shape) | passes | **fails** |
| Every variant dropped | passes | **fails** |
| Unrelated host (`api.worldmonitor.app`) silently acquires a batch | passes | **fails** |
| Variant batch drops `/dashboard`, keeps only the root | passes | **fails** |
| Submit loop points at the wrong shell variable | passes | **fails** |
| Variant step iterates an empty list and exits 0 | passes | **fails** |
| `variant-meta.ts` removed from the relevance gate | passes | **fails** |
| Gate over-fires on a blog-only deploy | passes | **fails** |

The workflow tests **execute** the committed shell rather than regex-matching it: the relevance gate runs with `git` stubbed, and the submit step runs with `node` stubbed, so the wiring — gate output → step env → loop → invocation — is pinned by behaviour, not by substring presence.

## Verification

- 14/14 in `tests/indexnow-submit.test.mjs`; 227/227 across the sitemap/IndexNow/variant slice; biome clean.
- Tests written red-first: both original guards were observed failing for the right reason before the fix.
- **Live production probe** — all seven hosts pass the script's own `verifyIndexNowKey` (direct HTTP 200, exact key body), so `commodity` and `energy` will clear the ownership gate rather than 403 `UserForbidden`. This is the check #6563 explicitly asked for rather than assumed.

```
OK  worldmonitor.app (1 urls)          OK  happy.worldmonitor.app (2 urls)
OK  www.worldmonitor.app (325 urls)    OK  tech.worldmonitor.app (2 urls)
OK  commodity.worldmonitor.app (2 urls)
OK  energy.worldmonitor.app (2 urls)   OK  finance.worldmonitor.app (2 urls)
```

## Deliberate non-changes

- **Over-firing is not treated as a bug.** Resubmitting unchanged URLs is harmless to IndexNow; under-submitting is the defect being fixed. The gate is tuned to never miss, not to never repeat.
- **No explicit per-host allowlist.** A hand-maintained allowlist is exactly what produced #6563. A sitemap host that cannot serve the key file now fails CI at the population guard, before it can reach a deploy.
- **The variant gate does not watch `src/components/**` or `src/app/**`.** Cross-model review suggested it; firing on nearly every deploy would make the gate meaningless.

## Filed separately

#6588 — the AI-crawler stub in `middleware.ts:212-215` omits `energy` from its variant link list. Same drift family, different consumer; this change does not depend on it.

https://claude.ai/code/session_011UQDVvZkFqc7ermepiWtmH
