### PR TITLE
fix(seo): derive AI crawler variant links

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -151,6 +151,16 @@ function escHtml(s: string): string {
     .replace(/'/g, '&#39;');
 }
 
+// Keep the AI-crawler internal-link graph aligned with the variant host map
+// and metadata. Adding a served variant here automatically adds its link.
+const AI_CRAWLER_VARIANT_LINKS = Object.values(VARIANT_HOST_MAP)
+  .map((variant) => {
+    const og = VARIANT_OG[variant];
+    if (!og) throw new Error(`[middleware] missing crawler metadata for variant "${variant}"`);
+    return `<li><a href="${escHtml(og.url)}">${escHtml(og.name)}</a></li>`;
+  })
+  .join('\n');
+
 export default function middleware(request: Request) {
   const url = new URL(request.url);
   const ua = request.headers.get('user-agent') ?? '';
@@ -209,10 +219,7 @@ export default function middleware(request: Request) {
 <h2>Explore the platform</h2>
 <ul>
 <li><a href="https://www.worldmonitor.app/dashboard">World Monitor — geopolitics &amp; intelligence</a></li>
-<li><a href="https://tech.worldmonitor.app/dashboard">Tech Monitor</a></li>
-<li><a href="https://finance.worldmonitor.app/dashboard">Finance Monitor</a></li>
-<li><a href="https://commodity.worldmonitor.app/dashboard">Commodity Monitor</a></li>
-<li><a href="https://happy.worldmonitor.app/dashboard">Happy Monitor</a></li>
+${AI_CRAWLER_VARIANT_LINKS}
 <li><a href="https://www.worldmonitor.app/pro">World Monitor Pro</a></li>
 <li><a href="https://www.worldmonitor.app/blog/">Blog</a></li>
 <li><a href="https://github.com/koala73/worldmonitor">Open source on GitHub</a></li>

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -702,12 +702,34 @@ describe('welcome landing page routing', () => {
       );
     }
 
-    for (const variant of ['full', 'tech', 'finance', 'commodity', 'happy']) {
-      assert.ok(
-        middlewareSource.includes(`href="${variantUrls[variant]}"`),
-        `AI crawler body must link ${variant} to its dashboard canonical`
-      );
-    }
+    assert.ok(
+      middlewareSource.includes(`href="${variantUrls.full}"`),
+      'AI crawler body must link the full dashboard canonical',
+    );
+    assert.match(
+      middlewareSource,
+      /const AI_CRAWLER_VARIANT_LINKS = Object\.values\(VARIANT_HOST_MAP\)/,
+      'AI crawler body links must be derived from the canonical variant host map',
+    );
+    assert.match(
+      middlewareSource,
+      /const og = VARIANT_OG\[variant\]/,
+      'AI crawler body link labels and URLs must come from variant metadata',
+    );
+    assert.match(
+      middlewareSource,
+      /escHtml\(og\.url\)/,
+      'AI crawler body link URLs must stay HTML-escaped',
+    );
+    assert.match(
+      middlewareSource,
+      /escHtml\(og\.name\)/,
+      'AI crawler body link labels must stay HTML-escaped',
+    );
+    assert.ok(
+      middlewareSource.includes('${AI_CRAWLER_VARIANT_LINKS}'),
+      'AI crawler body must render the generated variant links',
+    );
   });
 
   it('redirects legacy root map-state deep links to /dashboard before welcome routing', () => {

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -16,6 +16,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import middleware from '../middleware';
+import { WEB_DASHBOARD_VARIANTS } from '../src/config/variant-dashboard-html';
+import { VARIANT_META } from '../src/config/variant-meta';
 
 const TELEGRAM_BOT_UA = 'TelegramBot (like TwitterBot)';
 const SLACKBOT_UA = 'Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)';
@@ -49,6 +51,23 @@ function call(pathOrUrl: string, ua: string, headers: Record<string, string> = {
   });
   return middleware(req) as Response | void;
 }
+
+describe('middleware AI crawler variant stub', () => {
+  it('links every web-served variant dashboard', async () => {
+    const res = call('https://tech.worldmonitor.app/', 'Mozilla/5.0 GPTBot/1.1');
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 200);
+
+    const html = await res.text();
+    for (const variant of WEB_DASHBOARD_VARIANTS) {
+      const { siteName: name, url: dashboardUrl } = VARIANT_META[variant];
+      assert.ok(
+        html.includes(`<li><a href="${dashboardUrl}">${name}</a></li>`),
+        `AI crawler stub must link the ${variant} dashboard`,
+      );
+    }
+  });
+});
 
 describe('middleware bot gate / keyed API clients', () => {
   const KEYED_API_PATH = '/api/forecast/v1/get-forecast-scorecard';


### PR DESCRIPTION
## Summary

AI crawlers previously received a variant link list with no path to Energy Atlas. The stub now derives every non-full variant link from the served host map and its OG metadata, so a new served variant cannot be omitted silently. The response keeps the full dashboard link, escapes generated labels and URLs, and fails closed if variant metadata is missing.

Regression coverage enumerates `WEB_DASHBOARD_VARIANTS` and checks the exact URL and label markup for every served variant.

Fixes #6588

## Tests

- `./node_modules/.bin/tsx --test tests/middleware-bot-gate.test.mts tests/deploy-config.test.mjs` — 243 passed.
- `npm run typecheck` and `npm run typecheck:contract-tests` — passed.
- `npm run lint:safe-html` and the pre-push gate — passed.
- Full data suite: 23,885 passed, 6 skipped; one unrelated bundle-runner timing test failed in the aggregate run and passed on isolated rerun.

## Post-Deploy Monitoring & Validation

- Window/owner: verify during the first deploy; repository owner.
- Query: request `/` on `tech`, `finance`, `commodity`, `happy`, and `energy` with `User-Agent: GPTBot`.
- Healthy: each response is HTTP 200 and contains its exact dashboard `<li><a>` link, including `https://energy.worldmonitor.app/dashboard`.
- Failure/mitigation: a missing link or non-200 response is a deploy regression; revert this PR and repeat the smoke check.
- No new metrics or persistent state are introduced; inspect Vercel request logs only if a smoke request fails.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/MODEL_SLUG-GPT_5-000000)
