### PR TITLE
fix(a11y): give form controls accessible names

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -18,7 +18,7 @@
       <div class="settings-main">
         <div class="settings-sidebar">
           <div class="settings-sidebar-search">
-            <input id="settingsSearch" type="text" placeholder="Search settings..." autocomplete="off" />
+            <input id="settingsSearch" type="text" placeholder="Search settings..." aria-label="Search settings" autocomplete="off" />
           </div>
           <nav class="settings-sidebar-nav" id="sidebarNav" role="tablist" aria-label="Settings sections"></nav>
         </div>

--- a/src/components/AirlineIntelPanel.ts
+++ b/src/components/AirlineIntelPanel.ts
@@ -533,11 +533,11 @@ export class AirlineIntelPanel extends Panel {
             const dep = this.pricesDep || new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10);
             const form = `
         <div class="price-controls">
-          <input id="priceFromInput" class="price-input" placeholder="From" maxlength="3" value="${escapeHtml(this.pricesOrigin)}" style="width:54px">
-          <span style="color:#6b7280">\u2192</span>
-          <input id="priceToInput" class="price-input" placeholder="To" maxlength="3" value="${escapeHtml(this.pricesDest)}" style="width:54px">
-          <input id="priceDepInput" class="price-input" type="date" value="${escapeHtml(dep)}" style="width:128px">
-          <select id="priceCabinSelect" class="price-input" style="width:110px">
+          <input id="priceFromInput" class="price-input" placeholder="From" aria-label="Origin airport code" maxlength="3" value="${escapeHtml(this.pricesOrigin)}" style="width:54px">
+          <span style="color:#6b7280" aria-hidden="true">\u2192</span>
+          <input id="priceToInput" class="price-input" placeholder="To" aria-label="Destination airport code" maxlength="3" value="${escapeHtml(this.pricesDest)}" style="width:54px">
+          <input id="priceDepInput" class="price-input" type="date" aria-label="Departure date" value="${escapeHtml(dep)}" style="width:128px">
+          <select id="priceCabinSelect" class="price-input" aria-label="Cabin class" style="width:110px">
             <option value="ECONOMY"${this.pricesCabin === 'ECONOMY' ? ' selected' : ''}>Economy</option>
             <option value="PREMIUM_ECONOMY"${this.pricesCabin === 'PREMIUM_ECONOMY' ? ' selected' : ''}>Premium Economy</option>
             <option value="BUSINESS"${this.pricesCabin === 'BUSINESS' ? ' selected' : ''}>Business</option>
@@ -593,7 +593,7 @@ export class AirlineIntelPanel extends Panel {
             ${escapeHtml(t('components.airlineIntel.tripDays'))}:
             <input id="datesTripDurInput" class="price-input" type="number" min="1" value="${this.datesTripDuration}" style="width:44px">
           </label>
-          <select id="datesCabinSelect" class="price-input" style="width:110px">
+          <select id="datesCabinSelect" class="price-input" aria-label="Cabin class" style="width:110px">
             <option value="ECONOMY"${this.pricesCabin === 'ECONOMY' ? ' selected' : ''}>Economy</option>
             <option value="PREMIUM_ECONOMY"${this.pricesCabin === 'PREMIUM_ECONOMY' ? ' selected' : ''}>Premium Economy</option>
             <option value="BUSINESS"${this.pricesCabin === 'BUSINESS' ? ' selected' : ''}>Business</option>

--- a/src/components/AviationCommandBar.ts
+++ b/src/components/AviationCommandBar.ts
@@ -321,7 +321,7 @@ export class AviationCommandBar {
           <span>✈️ Aviation Command</span>
           <button id="aviation-cmd-close">×</button>
         </div>
-        <input id="aviation-cmd-input" type="text" placeholder="ops Dubai  ·  flight EK3  ·  fly London Dubai  ·  brief" autocomplete="off" spellcheck="false">
+        <input id="aviation-cmd-input" type="text" placeholder="ops Dubai  ·  flight EK3  ·  fly London Dubai  ·  brief" aria-label="Aviation command" autocomplete="off" spellcheck="false">
         <div id="aviation-cmd-suggestions"></div>
         <div id="aviation-cmd-result"></div>
         <div id="aviation-cmd-history-list"></div>

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -5388,7 +5388,7 @@ export class DeckGLMap {
         <button class="map-btn zoom-reset" title="${t('components.deckgl.resetView')}">&#8962;</button>
       </div>
       <div class="view-selector">
-        <select class="view-select">
+        <select class="view-select" aria-label="${t('header.selectRegion')}">
           <option value="global">${t('components.deckgl.views.global')}</option>
           <option value="america">${t('components.deckgl.views.americas')}</option>
           <option value="mena">${t('components.deckgl.views.mena')}</option>

--- a/src/components/InvestmentsPanel.ts
+++ b/src/components/InvestmentsPanel.ts
@@ -158,20 +158,20 @@ export class InvestmentsPanel extends Panel {
         <button class="${toggleCls}" data-action="toggle-filters" title="Filters" aria-label="Toggle filters" aria-pressed="${this.filtersExpanded}">⚙</button>
       </div>
       <div class="${filtersCls}">
-        <select class="fdi-filter" data-filter="investingCountry">
+        <select class="fdi-filter" data-filter="investingCountry" aria-label="Filter by investing country">
           <option value="ALL">🌐 ${t('components.investments.allCountries')}</option>
           <option value="SA"${this.filters.investingCountry === 'SA' ? ' selected' : ''}>🇸🇦 ${t('components.investments.saudiArabia')}</option>
           <option value="UAE"${this.filters.investingCountry === 'UAE' ? ' selected' : ''}>🇦🇪 ${t('components.investments.uae')}</option>
         </select>
-        <select class="fdi-filter" data-filter="sector">
+        <select class="fdi-filter" data-filter="sector" aria-label="Filter by sector">
           <option value="ALL">${t('components.investments.allSectors')}</option>
           ${sectors.map(s => `<option value="${s}"${this.filters.sector === s ? ' selected' : ''}>${escapeHtml(getSectorLabel(s as GulfInvestmentSector))}</option>`).join('')}
         </select>
-        <select class="fdi-filter" data-filter="entity">
+        <select class="fdi-filter" data-filter="entity" aria-label="Filter by entity">
           <option value="ALL">${t('components.investments.allEntities')}</option>
           ${entities.map(e => `<option value="${escapeHtml(e)}"${this.filters.entity === e ? ' selected' : ''}>${escapeHtml(e)}</option>`).join('')}
         </select>
-        <select class="fdi-filter" data-filter="status">
+        <select class="fdi-filter" data-filter="status" aria-label="Filter by status">
           <option value="ALL">${t('components.investments.allStatuses')}</option>
           <option value="operational"${sel('operational')}>${t('components.investments.operational')}</option>
           <option value="under-construction"${sel('under-construction')}>${t('components.investments.underConstruction')}</option>

--- a/src/components/PlaybackControl.ts
+++ b/src/components/PlaybackControl.ts
@@ -23,7 +23,7 @@ export class PlaybackControl {
           <button class="playback-close" aria-label="${t('components.playback.close')}">×</button>
         </div>
         <div class="playback-slider-container">
-          <input type="range" class="playback-slider" min="0" max="100" value="100">
+          <input type="range" class="playback-slider" min="0" max="100" value="100" aria-label="${t('components.playback.historicalPlayback')}">
           <div class="playback-time">${t('components.playback.live')}</div>
         </div>
         <div class="playback-controls">

--- a/src/components/RuntimeConfigPanel.ts
+++ b/src/components/RuntimeConfigPanel.ts
@@ -326,10 +326,10 @@ export class RuntimeConfigPanel extends Panel {
           <span class="runtime-secret-status ${statusClass}">${escapeHtml(status)}</span>
           <span class="runtime-secret-check ${checkClass}">&#x2713;</span>
           ${helpText ? `<div class="runtime-secret-meta">${escapeHtml(helpText)}</div>` : ''}
-          <select data-model-select class="${inputClass}" ${isDesktopRuntime() ? '' : 'disabled'}>
+          <select data-model-select class="${inputClass}" aria-label="${escapeHtml(key)} model" ${isDesktopRuntime() ? '' : 'disabled'}>
             ${storedModel ? `<option value="${escapeHtml(storedModel)}" selected>${escapeHtml(storedModel)}</option>` : '<option value="" selected disabled>Loading models...</option>'}
           </select>
-          <input type="text" data-model-manual class="${inputClass} hidden-input" placeholder="Or type model name" autocomplete="off" ${isDesktopRuntime() ? '' : 'disabled'} ${storedModel ? `value="${escapeHtml(storedModel)}"` : ''}>
+          <input type="text" data-model-manual class="${inputClass} hidden-input" placeholder="Or type model name" aria-label="${escapeHtml(key)} model" autocomplete="off" ${isDesktopRuntime() ? '' : 'disabled'} ${storedModel ? `value="${escapeHtml(storedModel)}"` : ''}>
           ${hintText ? `<span class="runtime-secret-hint">${escapeHtml(hintText)}</span>` : ''}
         </div>
       `;
@@ -346,7 +346,7 @@ export class RuntimeConfigPanel extends Panel {
         <span class="runtime-secret-check ${checkClass}">&#x2713;</span>
         ${helpText ? `<div class="runtime-secret-meta">${escapeHtml(helpText)}</div>` : ''}
         <div class="runtime-input-wrapper${showGetKey ? ' has-suffix' : ''}">
-          <input type="${PLAINTEXT_KEYS.has(key) ? 'text' : 'password'}" data-secret="${key}" placeholder="${pending ? t('modals.runtimeConfig.placeholder.staged') : t('modals.runtimeConfig.placeholder.setSecret')}" autocomplete="off" ${isDesktopRuntime() ? '' : 'disabled'} class="${inputClass}" ${pending ? `value="${PLAINTEXT_KEYS.has(key) ? escapeHtml(this.pendingSecrets.get(key) || '') : MASKED_SENTINEL}"` : (PLAINTEXT_KEYS.has(key) && state.present ? `value="${escapeHtml(getRuntimeConfigSnapshot().secrets[key]?.value || '')}"` : '')}>
+          <input type="${PLAINTEXT_KEYS.has(key) ? 'text' : 'password'}" data-secret="${key}" aria-label="${escapeHtml(key)}" placeholder="${pending ? t('modals.runtimeConfig.placeholder.staged') : t('modals.runtimeConfig.placeholder.setSecret')}" autocomplete="off" ${isDesktopRuntime() ? '' : 'disabled'} class="${inputClass}" ${pending ? `value="${PLAINTEXT_KEYS.has(key) ? escapeHtml(this.pendingSecrets.get(key) || '') : MASKED_SENTINEL}"` : (PLAINTEXT_KEYS.has(key) && state.present ? `value="${escapeHtml(getRuntimeConfigSnapshot().secrets[key]?.value || '')}"` : '')}>
           ${getKeyHtml}
         </div>
         ${hintText ? `<span class="runtime-secret-hint">${escapeHtml(hintText)}</span>` : ''}

--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -365,7 +365,7 @@ export class SearchModal {
           </div>
           <div class="search-sheet-header">
             <span class="search-sheet-icon" aria-hidden="true"></span>
-            <input type="text" class="search-input" placeholder="${this.placeholder}" autofocus />
+            <input type="text" class="search-input" placeholder="${this.placeholder}" aria-label="${this.placeholder}" autofocus />
             <button class="search-sheet-cancel" aria-label="Close">\u00D7</button>
           </div>
           ${this.renderScopeMarkup()}
@@ -411,7 +411,7 @@ export class SearchModal {
           </div>
           <div class="search-header">
             <span class="search-icon" aria-hidden="true"></span>
-            <input type="text" class="search-input" placeholder="${this.placeholder}" autofocus />
+            <input type="text" class="search-input" placeholder="${this.placeholder}" aria-label="${this.placeholder}" autofocus />
             <kbd class="search-kbd">ESC</kbd>
           </div>
           ${this.renderScopeMarkup()}

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -789,7 +789,7 @@ export class UnifiedSettings {
             <div class="unified-settings-region-bar" id="usPanelCatBar"></div>
           </div>
           <div class="panels-search">
-            <input type="text" placeholder="${t('header.filterPanels')}" value="${escapeHtml(this.panelFilter)}" />
+            <input type="text" placeholder="${t('header.filterPanels')}" aria-label="${t('header.filterPanels')}" value="${escapeHtml(this.panelFilter)}" />
           </div>
           <div class="panel-toggle-grid" id="usPanelToggles"></div>
           <div class="panels-footer">
@@ -811,7 +811,7 @@ export class UnifiedSettings {
           </div>
           ` : ''}
           <div class="sources-search">
-            <input type="text" placeholder="${t('header.filterSources')}" value="${escapeHtml(this.sourceFilter)}" />
+            <input type="text" placeholder="${t('header.filterSources')}" aria-label="${t('header.filterSources')}" value="${escapeHtml(this.sourceFilter)}" />
           </div>
           <div class="sources-toggle-grid" id="usSourceToggles"></div>
           <div class="sources-footer">
@@ -1636,7 +1636,7 @@ export class UnifiedSettings {
           <p class="api-keys-desc">Create API keys to access WorldMonitor data programmatically. Keys are shown once on creation — store them securely.</p>
         </div>
         <div class="api-keys-create-form">
-          <input type="text" class="api-keys-name-input" placeholder="Key name (e.g. my-app)" maxlength="64" />
+          <input type="text" class="api-keys-name-input" placeholder="Key name (e.g. my-app)" aria-label="API key name" maxlength="64" />
           <button class="btn btn-primary api-keys-create-btn">Create Key</button>
         </div>
         <div class="api-keys-created-banner" id="usApiKeysBanner" style="display:none;"></div>

--- a/src/components/WatchlistTableView.ts
+++ b/src/components/WatchlistTableView.ts
@@ -279,7 +279,7 @@ export class WatchlistTableView<T> {
           data-watchlist-search="1">
         <div class="watchlist-control-row">
           <div class="watchlist-pills">${pills}</div>
-          <select class="watchlist-sort" data-watchlist-sort="1">${sortOpts}</select>
+          <select class="watchlist-sort" data-watchlist-sort="1" aria-label="Sort watchlist">${sortOpts}</select>
         </div>
       </div>
     `;

--- a/src/components/watchlist-modal.ts
+++ b/src/components/watchlist-modal.ts
@@ -77,7 +77,7 @@ export function openWatchlistModal(): void {
         <div class="wl-region-bar" role="group" aria-label="Filter catalog by region"></div>
         <label class="wl-search">
           <span class="sr-only">Search built-in market catalog</span>
-          <input id="wmCatalogSearch" type="search" placeholder="Search stocks and indices" />
+          <input id="wmCatalogSearch" type="search" placeholder="Search stocks and indices" aria-label="Search stocks and indices" />
         </label>
         <div class="wl-grid" role="group" aria-label="Built-in market symbols"></div>
         <div class="wl-counter" aria-live="polite"></div>

--- a/src/live-channels-window.ts
+++ b/src/live-channels-window.ts
@@ -462,7 +462,7 @@ export async function initLiveChannelsWindow(containerEl?: HTMLElement): Promise
               <span class="live-news-manage-search-icon">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
               </span>
-              <input type="text" id="liveChannelsSearch" class="live-news-manage-search-input" placeholder="${escapeHtml(t('header.search') ?? 'Search')}..." autocomplete="off" />
+              <input type="text" id="liveChannelsSearch" class="live-news-manage-search-input" placeholder="${escapeHtml(t('header.search') ?? 'Search')}..." aria-label="${escapeHtml(t('header.search') ?? 'Search')}" autocomplete="off" />
             </div>
           </div>
           <div class="panel-tabs" id="liveChannelsTabBar"></div>

--- a/src/services/notifications-settings.ts
+++ b/src/services/notifications-settings.ts
@@ -486,7 +486,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
 
         html += `<div class="ai-flow-section-label" style="margin-top:8px">Delivery Mode</div>
           ${!DIGEST_CRON_ENABLED ? '<div class="ai-flow-toggle-desc" style="margin-bottom:4px">Digest delivery is not yet active.</div>' : ''}
-          <select class="unified-settings-select" id="usDigestMode"${!DIGEST_CRON_ENABLED ? ' disabled' : ''}>
+          <select class="unified-settings-select" id="usDigestMode" aria-label="Delivery mode"${!DIGEST_CRON_ENABLED ? ' disabled' : ''}>
             <option value="realtime"${isRealtime ? ' selected' : ''}>Real-time (immediate)</option>
             ${DIGEST_CRON_ENABLED ? `<option value="daily"${digestMode === 'daily' ? ' selected' : ''}>Daily digest</option>
             <option value="twice_daily"${digestMode === 'twice_daily' ? ' selected' : ''}>Twice daily</option>
@@ -499,7 +499,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
             docs/archive/plans/forbid-realtime-all-events.md §2a.
           -->
           <div class="ai-flow-section-label" style="margin-top:8px">Sensitivity</div>
-          <select class="unified-settings-select" id="usNotifSensitivity">
+          <select class="unified-settings-select" id="usNotifSensitivity" aria-label="Notification sensitivity">
             <option value="all"${isRealtime ? ' disabled' : ''}${sensitivity === 'all' && !isRealtime ? ' selected' : ''}>All events${isRealtime ? ' (digest only)' : ''}</option>
             <option value="high"${isRealtime ? ' disabled' : ''}${sensitivity === 'high' && !isRealtime ? ' selected' : ''}>High &amp; critical${isRealtime ? ' (digest only)' : ''}</option>
             <option value="critical"${sensitivity === 'critical' || ((sensitivity === 'all' || sensitivity === 'high') && isRealtime) ? ' selected' : ''}>Critical only</option>
@@ -543,15 +543,15 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
                 <div class="ai-flow-toggle-label-wrap" style="min-width:60px">
                   <div class="ai-flow-toggle-label">From</div>
                 </div>
-                <select class="unified-settings-select" id="usQhStart" style="width:auto">${hourOptions}</select>
+                <select class="unified-settings-select" id="usQhStart" aria-label="Quiet hours start" style="width:auto">${hourOptions}</select>
                 <div class="ai-flow-toggle-label-wrap" style="min-width:30px">
                   <div class="ai-flow-toggle-label">To</div>
                 </div>
-                <select class="unified-settings-select" id="usQhEnd" style="width:auto">${hourOptionsEnd}</select>
+                <select class="unified-settings-select" id="usQhEnd" aria-label="Quiet hours end" style="width:auto">${hourOptionsEnd}</select>
               </div>
               <div style="margin-top:4px">
                 <div class="ai-flow-toggle-label" style="margin-bottom:4px">During quiet hours</div>
-                <select class="unified-settings-select" id="usQhOverride">
+                <select class="unified-settings-select" id="usQhOverride" aria-label="During quiet hours">
                   <option value="critical_only"${qhOverride === 'critical_only' ? ' selected' : ''}>Critical only (suppress others)</option>
                   <option value="silence_all"${qhOverride === 'silence_all' ? ' selected' : ''}>Silence all</option>
                   ${QUIET_HOURS_BATCH_ENABLED ? `<option value="batch_on_wake"${qhOverride === 'batch_on_wake' ? ' selected' : ''}>Batch — deliver on wake</option>` : ''}
@@ -564,7 +564,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
               <div class="ai-flow-toggle-label-wrap" style="min-width:60px">
                 <div class="ai-flow-toggle-label">Send at</div>
               </div>
-              <select class="unified-settings-select" id="usDigestHour" style="width:auto">${hourOptionsDigest}</select>
+              <select class="unified-settings-select" id="usDigestHour" aria-label="Digest send hour" style="width:auto">${hourOptionsDigest}</select>
             </div>
             <div id="usTwiceDailyHint" class="ai-flow-toggle-desc" style="margin-top:4px;${digestMode === 'twice_daily' ? '' : 'display:none'}">Also sends at ${((digestHour + 12) % 24) === 0 ? '12 AM' : ((digestHour + 12) % 24) < 12 ? `${(digestHour + 12) % 24} AM` : ((digestHour + 12) % 24) === 12 ? '12 PM' : `${((digestHour + 12) % 24) - 12} PM`}</div>
             <div class="ai-flow-toggle-row" style="margin-top:8px">
@@ -573,7 +573,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
                 <div class="ai-flow-toggle-desc">Prepend a personalized intelligence brief tailored to your watchlist and interests</div>
               </div>
               <label class="ai-flow-switch">
-                <input type="checkbox" id="usAiDigestEnabled"${aiDigestEnabled ? ' checked' : ''}>
+                <input type="checkbox" id="usAiDigestEnabled" aria-label="AI executive summary"${aiDigestEnabled ? ' checked' : ''}>
                 <span class="ai-flow-slider"></span>
               </label>
             </div>
@@ -582,7 +582,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           <div class="ai-flow-toggle-desc" style="margin-bottom:6px">Restrict alerts to specific countries (ISO-3166 alpha-2). Leave empty to receive alerts from all countries. When set, global alerts without a country (markets, shipping) are excluded; breaking-news alerts are still delivered.</div>
           <div id="usNotifCountryPicker"></div>
           <div class="ai-flow-section-label" style="margin-top:8px">Timezone</div>
-          <select class="unified-settings-select" id="usSharedTimezone" style="width:100%">${makeTzOptions(sharedTz)}</select>`;
+          <select class="unified-settings-select" id="usSharedTimezone" aria-label="Timezone" style="width:100%">${makeTzOptions(sharedTz)}</select>`;
         return html;
       }
 

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -59,14 +59,16 @@ function toggleRowHtml(
   checked: boolean,
   disabled = false,
 ): string {
+  // The visible text lives outside the wrapping <label>, so the checkbox
+  // needs an explicit aria-labelledby/-describedby to have an accessible name.
   return `
     <div class="ai-flow-toggle-row${disabled ? ' is-disabled' : ''}">
       <div class="ai-flow-toggle-label-wrap">
-        <div class="ai-flow-toggle-label">${label}</div>
-        <div class="ai-flow-toggle-desc">${desc}</div>
+        <div class="ai-flow-toggle-label" id="${id}-label">${label}</div>
+        <div class="ai-flow-toggle-desc" id="${id}-desc">${desc}</div>
       </div>
       <label class="ai-flow-switch${disabled ? ' is-disabled' : ''}">
-        <input type="checkbox" id="${id}"${checked ? ' checked' : ''}${disabled ? ' disabled' : ''}>
+        <input type="checkbox" id="${id}" aria-labelledby="${id}-label" aria-describedby="${id}-desc"${checked ? ' checked' : ''}${disabled ? ' disabled' : ''}>
         <span class="ai-flow-slider"></span>
       </label>
     </div>
@@ -132,11 +134,11 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   const currentThemePref = getThemePreference();
   html += `<div class="ai-flow-toggle-row">
     <div class="ai-flow-toggle-label-wrap">
-      <div class="ai-flow-toggle-label">${t('preferences.theme')}</div>
+      <div class="ai-flow-toggle-label" id="us-theme-label">${t('preferences.theme')}</div>
       <div class="ai-flow-toggle-desc">${t('preferences.themeDesc')}</div>
     </div>
   </div>`;
-  html += `<select class="unified-settings-select" id="us-theme">`;
+  html += `<select class="unified-settings-select" id="us-theme" aria-labelledby="us-theme-label">`;
   for (const opt of [
     { value: 'auto', label: t('preferences.themeAuto') },
     { value: 'dark', label: t('preferences.themeDark') },
@@ -151,11 +153,11 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   const currentFont = getFontFamily();
   html += `<div class="ai-flow-toggle-row">
     <div class="ai-flow-toggle-label-wrap">
-      <div class="ai-flow-toggle-label">${t('preferences.fontFamily')}</div>
+      <div class="ai-flow-toggle-label" id="us-font-family-label">${t('preferences.fontFamily')}</div>
       <div class="ai-flow-toggle-desc">${t('preferences.fontFamilyDesc')}</div>
     </div>
   </div>`;
-  html += `<select class="unified-settings-select" id="us-font-family">`;
+  html += `<select class="unified-settings-select" id="us-font-family" aria-labelledby="us-font-family-label">`;
   for (const opt of [
     { value: 'mono', label: t('preferences.fontMono') },
     { value: 'system', label: t('preferences.fontSystem') },
@@ -170,11 +172,11 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   const currentFontScale = getFontScale();
   html += `<div class="ai-flow-toggle-row">
     <div class="ai-flow-toggle-label-wrap">
-      <div class="ai-flow-toggle-label">${t('preferences.fontScale', { defaultValue: 'Panel text size' })}</div>
+      <div class="ai-flow-toggle-label" id="us-font-scale-label">${t('preferences.fontScale', { defaultValue: 'Panel text size' })}</div>
       <div class="ai-flow-toggle-desc">${t('preferences.fontScaleDesc', { defaultValue: 'Sets panel text globally. A panel-specific value replaces this setting.' })}</div>
     </div>
   </div>`;
-  html += `<select class="unified-settings-select" id="us-font-scale">`;
+  html += `<select class="unified-settings-select" id="us-font-scale" aria-labelledby="us-font-scale-label">`;
   for (const scale of FONT_SCALE_STEPS) {
     const selected = scale === currentFontScale ? ' selected' : '';
     html += `<option value="${scale}"${selected}>${fontScaleLabel(scale)}</option>`;
@@ -185,11 +187,11 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   const currentProvider = getMapProvider();
   html += `<div class="ai-flow-toggle-row">
     <div class="ai-flow-toggle-label-wrap">
-      <div class="ai-flow-toggle-label">${t('preferences.mapProvider')}</div>
+      <div class="ai-flow-toggle-label" id="us-map-provider-label">${t('preferences.mapProvider')}</div>
       <div class="ai-flow-toggle-desc">${t('preferences.mapProviderDesc')}</div>
     </div>
   </div>`;
-  html += `<select class="unified-settings-select" id="us-map-provider">`;
+  html += `<select class="unified-settings-select" id="us-map-provider" aria-labelledby="us-map-provider-label">`;
   for (const opt of MAP_PROVIDER_OPTIONS) {
     const selected = opt.value === currentProvider ? ' selected' : '';
     html += `<option value="${opt.value}"${selected}>${escapeHtml(opt.label)}</option>`;
@@ -200,11 +202,11 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   const currentMapTheme = getMapTheme(currentProvider);
   html += `<div class="ai-flow-toggle-row">
     <div class="ai-flow-toggle-label-wrap">
-      <div class="ai-flow-toggle-label">${t('preferences.mapTheme')}</div>
+      <div class="ai-flow-toggle-label" id="us-map-theme-label">${t('preferences.mapTheme')}</div>
       <div class="ai-flow-toggle-desc">${t('preferences.mapThemeDesc')}</div>
     </div>
   </div>`;
-  html += `<select class="unified-settings-select" id="us-map-theme">`;
+  html += `<select class="unified-settings-select" id="us-map-theme" aria-labelledby="us-map-theme-label">`;
   for (const opt of MAP_THEME_OPTIONS[currentProvider]) {
     const selected = opt.value === currentMapTheme ? ' selected' : '';
     html += `<option value="${opt.value}"${selected}>${escapeHtml(opt.label)}</option>`;
@@ -217,11 +219,11 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   const currentPreset = getGlobeVisualPreset();
   html += `<div class="ai-flow-toggle-row">
     <div class="ai-flow-toggle-label-wrap">
-      <div class="ai-flow-toggle-label">${t('preferences.globePreset')}</div>
+      <div class="ai-flow-toggle-label" id="us-globe-visual-preset-label">${t('preferences.globePreset')}</div>
       <div class="ai-flow-toggle-desc">${t('preferences.globePresetDesc')}</div>
     </div>
   </div>`;
-  html += `<select class="unified-settings-select" id="us-globe-visual-preset">`;
+  html += `<select class="unified-settings-select" id="us-globe-visual-preset" aria-labelledby="us-globe-visual-preset-label">`;
   for (const opt of GLOBE_VISUAL_PRESET_OPTIONS) {
     const selected = opt.value === currentPreset ? ' selected' : '';
     html += `<option value="${opt.value}"${selected}>${escapeHtml(opt.label)}</option>`;
@@ -229,8 +231,8 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   html += `</select>`;
 
   // Language
-  html += `<div class="ai-flow-section-label">${t('header.languageLabel')}</div>`;
-  html += `<select class="unified-settings-lang-select" id="us-language">`;
+  html += `<div class="ai-flow-section-label" id="us-language-label">${t('header.languageLabel')}</div>`;
+  html += `<select class="unified-settings-lang-select" id="us-language" aria-labelledby="us-language-label">`;
   for (const lang of LANGUAGES) {
     const selected = lang.code === currentLang ? ' selected' : '';
     html += `<option value="${lang.code}"${selected}>${lang.flag} ${escapeHtml(lang.label)}</option>`;
@@ -354,11 +356,11 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
   const currentQuality = getStreamQuality();
   html += `<div class="ai-flow-toggle-row">
     <div class="ai-flow-toggle-label-wrap">
-      <div class="ai-flow-toggle-label">${t('components.insights.streamQualityLabel')}</div>
+      <div class="ai-flow-toggle-label" id="us-stream-quality-label">${t('components.insights.streamQualityLabel')}</div>
       <div class="ai-flow-toggle-desc">${t('components.insights.streamQualityDesc')}</div>
     </div>
   </div>`;
-  html += `<select class="unified-settings-select" id="us-stream-quality">`;
+  html += `<select class="unified-settings-select" id="us-stream-quality" aria-labelledby="us-stream-quality-label">`;
   for (const opt of STREAM_QUALITY_OPTIONS) {
     const selected = opt.value === currentQuality ? ' selected' : '';
     html += `<option value="${opt.value}"${selected}>${escapeHtml(opt.label)}</option>`;

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -346,11 +346,11 @@ function renderSecretInput(key: RuntimeSecretKey, _featureId: RuntimeFeatureId):
       <div class="settings-secret-row">
         <div class="settings-secret-label">${escapeHtml(label)}</div>
         <span class="settings-secret-status ${statusClass}">${escapeHtml(statusText)}</span>
-        <select data-model-select data-feature="${_featureId}" class="${inputClass}">
+        <select data-model-select data-feature="${_featureId}" class="${inputClass}" aria-label="${escapeHtml(label)}">
           ${storedModel ? `<option value="${escapeHtml(storedModel)}" selected>${escapeHtml(storedModel)}</option>` : '<option value="" selected disabled>Loading models...</option>'}
         </select>
         <input type="text" data-model-manual data-feature="${_featureId}" class="${inputClass} hidden-input"
-          placeholder="Or type model name" autocomplete="off"
+          placeholder="Or type model name" aria-label="${escapeHtml(label)}" autocomplete="off"
           ${storedModel ? `value="${escapeHtml(storedModel)}"` : ''}>
         ${hintText ? `<span class="settings-secret-hint">${escapeHtml(hintText)}</span>` : ''}
       </div>
@@ -367,7 +367,7 @@ function renderSecretInput(key: RuntimeSecretKey, _featureId: RuntimeFeatureId):
       <span class="settings-secret-status ${statusClass}">${escapeHtml(statusText)}</span>
       <div class="settings-input-wrapper${showGetKey ? ' has-suffix' : ''}">
         <input type="${isPlaintext ? 'text' : 'password'}" data-secret="${key}" data-feature="${_featureId}"
-          placeholder="${pending ? 'Staged' : 'Enter value...'}" autocomplete="off" class="${inputClass}"
+          placeholder="${pending ? 'Staged' : 'Enter value...'}" aria-label="${escapeHtml(label)}" autocomplete="off" class="${inputClass}"
           ${pending ? `value="${isPlaintext ? escapeHtml(settingsManager.getPending(key) || '') : MASKED_SENTINEL}"` : (isPlaintext && state.present ? `value="${escapeHtml(getRuntimeConfigSnapshot().secrets[key]?.value || '')}"` : '')}>
         ${getKeyHtml}
       </div>
@@ -848,7 +848,10 @@ async function initSettingsWindow(): Promise<void> {
   const headerTitle = document.querySelector('.settings-header-title');
   if (headerTitle) headerTitle.textContent = t('modals.settingsWindow.shellTitle');
   const searchInputEl = document.getElementById('settingsSearch') as HTMLInputElement | null;
-  if (searchInputEl) searchInputEl.placeholder = t('modals.settingsWindow.shellSearchPlaceholder');
+  if (searchInputEl) {
+    searchInputEl.placeholder = t('modals.settingsWindow.shellSearchPlaceholder');
+    searchInputEl.setAttribute('aria-label', t('modals.settingsWindow.shellSearchPlaceholder'));
+  }
   const cancelEl = document.getElementById('cancelBtn');
   if (cancelEl) cancelEl.textContent = t('modals.settingsWindow.shellCancel');
   const okEl = document.getElementById('okBtn');

--- a/src/utils/country-chip-picker.ts
+++ b/src/utils/country-chip-picker.ts
@@ -115,7 +115,7 @@ export function mountCountryChipPicker(
     setTrustedHtml(root, trustedHtml(`
       <div class="us-notif-country-chips" data-country-chip-row>${chipRow}${extraChips}</div>
       <div class="us-notif-country-add-row" style="margin-top:6px;display:flex;gap:6px;align-items:center">
-        <input type="text" class="unified-settings-input" data-country-add-input placeholder="Add code (e.g. PL)" maxlength="2" style="width:90px;text-transform:uppercase">
+        <input type="text" class="unified-settings-input" data-country-add-input placeholder="Add code (e.g. PL)" aria-label="Add country code" maxlength="2" style="width:90px;text-transform:uppercase">
         <button type="button" class="us-notif-ch-btn" data-country-add-btn>Add</button>
         <span class="us-notif-country-error" data-country-error style="color:#c00;font-size:12px;display:none">Enter a 2-letter ISO country code (e.g. US, GB).</span>
       </div>


### PR DESCRIPTION
Part of #6573 (accessibility remediation, PR 2 of 7): accessible names for form controls.

## Problem

Placeholder-only labeling is the dominant pattern in the codebase: only 3 of ~67 `<input>`s and 3 of ~36 `<select>`s expose an accessible name. Placeholders disappear on typing, aren't announced reliably, and several controls (date pickers, sliders, selects, password fields) had no name of any kind — a screen reader announces them as bare "edit text" / "combo box" / "slider, 100".

## What this does

**Preferences panel (`preferences-content.ts`)** — the highest-irony cluster, since these are the accessibility-relevant settings themselves:
- The `toggleRowHtml` helper wrapped its checkbox in a `<label>` whose visible text lives in a *sibling* div, so the wrapping label contributed no name — every AI-flow toggle checkbox was unnamed. The label/description divs now carry `${id}-label`/`${id}-desc` ids and the checkbox references them via `aria-labelledby`/`aria-describedby`. One helper change names every toggle row in the app.
- Theme, font family, font scale, map provider, map theme, globe preset, stream quality, and language selects are linked to their existing visible label divs the same way (no visual change, no duplicated strings).

**Search fields**: command-deck search (both mobile-sheet and desktop variants in `SearchModal.ts`), the settings shell search (both the static markup in `settings.html` and the runtime locale swap in `settings-main.ts`, so the name localizes with the placeholder), live channels search, watchlist catalog search.

**Notifications settings**: delivery mode, sensitivity, quiet-hours start/end/override, digest hour, and timezone selects, plus the AI-digest checkbox (same text-outside-label pattern as the preferences toggles).

**Secret/model configuration**: runtime secret inputs and Ollama model pickers are named after the key/feature they edit, in both the desktop `RuntimeConfigPanel` and the settings-window variant — previously nothing distinguished one password field from another.

**Misc**: playback timeline slider (was "slider, 100" with no context), DeckGL map view/region select, watchlist sort select, the four investments-panel filter selects, API key name input, aviation command input, airline price search (origin/destination/date/cabin ×2), country chip picker input.

Labels reuse the adjacent visible text or existing `t()` keys wherever one exists; plain-English `aria-label`s follow existing repo precedent (`"Close menu"`, `"Primary"`) where no key exists, keeping this PR free of locale churn.

## Verification

- `npm run typecheck` — clean
- `biome lint` on all 15 touched files — clean
- `npm run lint:safe-html` — clean
- `node --test tests/a11y-issue-4373-invariants.test.mjs tests/a11y-issue-5059-invariants.test.mjs` — 43/43 pass
