### PR TITLE
chore(agent-readiness): report OpenAPI bundle capacity in CI and spend the 93 KB it found (#6558)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,11 @@ jobs:
         # earlier. Placed before the suite on purpose: an over-budget artifact
         # fails test:data anyway, and failing here costs 30s instead of 10min
         # while the upload step below still publishes the breakdown.
-        run: node scripts/openapi-capacity-report.mjs --out openapi-capacity.json
+        #
+        # Written to RUNNER_TEMP, not the workspace: a CI-only artifact dropped
+        # in the repo root is untracked state that a later `git status` gate
+        # would trip over.
+        run: node scripts/openapi-capacity-report.mjs --out "$RUNNER_TEMP/openapi-capacity.json"
       - name: Upload OpenAPI capacity report
         # `!cancelled()` rather than `always()`: an over-budget run is exactly
         # when the breakdown is worth reading, and a cancelled job has nothing
@@ -221,7 +225,7 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: openapi-capacity-${{ github.run_attempt }}
-          path: openapi-capacity.json
+          path: ${{ runner.temp }}/openapi-capacity.json
           if-no-files-found: warn
           retention-days: 14
       - name: Build dashboard artifacts for built-output tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,14 @@ jobs:
             # without this rule the guard skips on exactly the PR that commits
             # an artifact and can only ever fire on unrelated changes.
             /^docs\/snapshots\/resilience-.*-acceptance-.*\.json$/ { count++; next }
+            # The generated OpenAPI bundle sits under docs/ but is the INPUT to
+            # the served public/openapi.json. Its <= 950,000-byte scanner guard
+            # (tests/openapi-json-dedup.test.mjs) and the capacity report that
+            # tracks the approach to it both run in `unit`, so without this
+            # carve-out a PR that only regenerates the bundle sets code=false
+            # and skips the one gate that measures the artifact it changed
+            # (#6558).
+            /^docs\/api\/worldmonitor\.openapi\.yaml$/ { count++; next }
             /\.md$/ { next }
             /^docs\// { next }
             /^src-tauri\// && $0 !~ /^src-tauri\/sidecar\// && $0 !~ /^src-tauri\/.*\.json$/ { next }
@@ -187,6 +195,35 @@ jobs:
         env:
           HEALTH_PROBE_CUTOVER_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: node --import tsx scripts/check-health-probe-cutovers.mts "$HEALTH_PROBE_CUTOVER_BASE"
+      - name: OpenAPI bundle capacity (#6558)
+        # The <= 950,000-byte scanner guard lives in
+        # tests/openapi-json-dedup.test.mjs and stays the gate. This step
+        # publishes what that guard is silent about on the way to the wall:
+        # served bytes, remaining headroom, and how many more operations fit.
+        # The last three crossings were each discovered by a red build on
+        # whichever PR happened to be last in line; the number belongs in front
+        # of a reviewer before that.
+        #
+        # Exits nonzero only when the artifact is over budget or could not be
+        # measured at all — a breached reserve warns, because a second hard
+        # failure at the same wall would just be the same red build one commit
+        # earlier. Placed before the suite on purpose: an over-budget artifact
+        # fails test:data anyway, and failing here costs 30s instead of 10min
+        # while the upload step below still publishes the breakdown.
+        run: node scripts/openapi-capacity-report.mjs --out openapi-capacity.json
+      - name: Upload OpenAPI capacity report
+        # `!cancelled()` rather than `always()`: an over-budget run is exactly
+        # when the breakdown is worth reading, and a cancelled job has nothing
+        # to say. run_attempt in the name because upload-artifact v6 rejects a
+        # duplicate name within a run, which collides on the re-run someone
+        # starts to chase the failure.
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: openapi-capacity-${{ github.run_attempt }}
+          path: openapi-capacity.json
+          if-no-files-found: warn
+          retention-days: 14
       - name: Build dashboard artifacts for built-output tests
         run: VITE_VARIANT=full ./node_modules/.bin/vite build
       - run: WM_EXPECT_BUILT_OUTPUT=1 npm run test:data

--- a/docs/agent-discovery.mdx
+++ b/docs/agent-discovery.mdx
@@ -39,7 +39,7 @@ Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+j
 |---|---|---|
 | [`/.well-known/api-catalog`](https://worldmonitor.app/.well-known/api-catalog) | [RFC 9727](https://datatracker.ietf.org/doc/html/rfc9727) | JSON linkset bundling every other discovery URL — start here if you want one fetch and a map |
 | [`/openapi.yaml`](https://www.worldmonitor.app/openapi.yaml) | OpenAPI 3.1 | Single bundled spec covering **every** REST service (Conflict, Resilience, Market, Economic, Maritime, Aviation, Climate, …) — feed it to any code-generator |
-| [`/openapi.json`](https://www.worldmonitor.app/openapi.json) | OpenAPI 3.1 | Byte-identical bundle as minified JSON — same spec as `/openapi.yaml`, for tooling and scanners that only parse JSON |
+| [`/openapi.json`](https://www.worldmonitor.app/openapi.json) | OpenAPI 3.1 | Minified JSON bundle for tooling and scanners that only parse JSON. Same operations, parameters, request bodies and responses as `/openapi.yaml`; shared structures are `$ref`-collapsed and component schemas no operation can reach are omitted, to stay under scanner body caps |
 | [`/docs/api-versioning`](https://www.worldmonitor.app/docs/api-versioning) | Policy | REST compatibility, deprecation notice, and sunset-header contract |
 | [`/.well-known/mcp/server-card.json`](https://worldmonitor.app/.well-known/mcp/server-card.json) | MCP | Transport (`streamableHttp`), endpoint, OAuth resource, scopes, streaming, capability flags |
 | [`/.well-known/oauth-authorization-server`](https://api.worldmonitor.app/.well-known/oauth-authorization-server) | [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) | OAuth 2.1 authorization-server metadata (PKCE, DCR, token endpoints) |

--- a/docs/perf/openapi-bundle-capacity-2026-08-13.md
+++ b/docs/perf/openapi-bundle-capacity-2026-08-13.md
@@ -1,0 +1,135 @@
+# Unified OpenAPI bundle — capacity baseline and reduction plan
+
+Measured 2026-08-13 against `docs/api/worldmonitor.openapi.yaml` at `27690f1`. Issue [#6558](https://github.com/koala73/worldmonitor/issues/6558).
+
+Regenerate every number here with:
+
+```bash
+node scripts/openapi-capacity-report.mjs --json
+```
+
+## Why there is a budget at all
+
+`public/openapi.json` is the machine copy of the API contract. Agent-readiness scanners fetch it and cap the body they will analyse at roughly 1 MB. When the spec crossed that cap on 2026-07-05, ora.ai/orank's function-calling compatibility check flipped from a computed verdict — "192/192 with typed schemas" — to "API spec found but couldn't validate function calling compatibility", the same failure elevenlabs' 1.8 MB and openrouter's 1.5 MB specs get. Sub-800 KB specs get computed verdicts. See [#4852](https://github.com/koala73/worldmonitor/issues/4852).
+
+The guard is `tests/openapi-json-dedup.test.mjs`, which fails when the served artifact exceeds **950,000 bytes**.
+
+**Raising the budget is not a remedy.** The cap belongs to the scanner, not to us; moving our number does not move theirs. The value is pinned by a literal assertion in that test so a raise cannot pass as a one-line edit, and it may only change if scanner behaviour is re-verified empirically first.
+
+## Baseline
+
+| | Before #6558 | After #6558 |
+| --- | --- | --- |
+| Served bytes | 946,682 | 853,100 |
+| Headroom under 950,000 | 3,318 (0.35%) | 96,900 (10.2%) |
+| Operations | 218 | 218 |
+| Mean bytes per operation | 4,343 | 3,913 |
+| Room for | 0 more operations | ~24 more operations |
+
+The "before" column is the state the issue was filed from: less than one operation's worth of headroom. [#6531](https://github.com/koala73/worldmonitor/pull/6531) landed the food-stocks operation into 1.7 KB of headroom and had to find the bytes to pay for it inside that same PR.
+
+Two measurement corrections landed with this baseline:
+
+- **Bytes, not code units.** The guard measured `JSON.stringify(spec).length`, which counts UTF-16 code units. The cap is a body-size cap in bytes and the descriptions carry non-ASCII punctuation, so the guard was reading 264 bytes low. It now measures UTF-8 bytes through `buildBundle()` — the same call that writes the artifact — so the gate cannot guard a document the build does not emit.
+- **The report runs on every PR.** `unit` publishes `openapi-capacity.json` as a CI artifact plus a job summary, and the `changes` filter now routes `docs/api/worldmonitor.openapi.yaml` into that job. The bundle lives under `docs/`, which the filter excluded wholesale, so a PR that only regenerated it previously skipped the one gate that measures it.
+
+## Where the bytes go
+
+Sections of the served document:
+
+| Section | Bytes | Share | Entries |
+| --- | --- | --- | --- |
+| `components.schemas` | 485,959 | 57.0% | 634 |
+| `paths` | 348,722 | 40.9% | 216 |
+| `components.parameters` | 9,450 | 1.1% | 39 |
+| `components.responses` | 4,490 | 0.5% | 11 |
+| `webhooks` | 3,539 | 0.4% | 1 |
+
+Inside `paths`, cost by Operation Object field — this is where generated pressure shows up, because a field with a high per-operation cost is one an injector stamps fleet-wide:
+
+| Field | Bytes | Per operation |
+| --- | --- | --- |
+| `responses` | 195,129 | 895 |
+| `parameters` | 83,692 | 384 |
+| `description` | 32,320 | 148 |
+| `operationId` | 7,706 | 35 |
+| `summary` | 6,853 | 31 |
+| `requestBody` | 6,290 | 29 |
+| `tags` | 6,196 | 28 |
+| `security` | 2,790 | 13 |
+
+## What is already collapsed
+
+Four emit-time transforms run in `scripts/build-openapi-json.mjs`. None of them touch `docs/api/worldmonitor.openapi.yaml`, so Mintlify, the injectors and the contract tests still see the complete generated document.
+
+| Transform | Effect on this bundle |
+| --- | --- |
+| `dedupeErrorResponses` | 11 repeated non-2xx bodies hoisted into 1,311 `$ref`s |
+| `dedupeSharedParameters` | 39 fleet-wide parameters hoisted into 323 `$ref`s |
+| `dedupeSharedChinaProvenanceSchemas` | 17 of 17 shared provenance value schemas reused |
+| `dropUnreachableSchemas` | 210 schemas removed, 93,582 bytes |
+
+2xx responses are never hoisted: orank credits only the inline `responses["200"]` schema, verified 2026-07-05.
+
+`dropUnreachableSchemas` is new in #6558. The generator emits one component schema per RPC message, but a GET operation spends its request message as `parameters` and never points at the request schema, so 210 of 844 definitions were served while unreachable from every operation, response, parameter, header and sibling schema. A Schema Object documents something only through the `$ref` that reaches it, so removing one with no inbound pointer removes no documentation a client, agent or scanner could arrive at. `tests/openapi-unreachable-schemas.test.mjs` proves the served document has no dangling `$ref`, that every retained schema is byte-identical, and that nothing outside `components.schemas` changes.
+
+## Reduction plan
+
+110 repeated subtrees are still inline, worth about **41,891 bytes** if all were collapsed. That total is non-overlapping: a repeated parent and the repeated child inside it can only be spent once, so the report attributes the bytes to whichever is hoisted first and does not promise them twice.
+
+Ranked by yield against risk. Take them in order; each is independent.
+
+### 1. Generalise the repeated-schema-subtree hoist — about 26 KB
+
+`dedupeSharedChinaProvenanceSchemas` hoists exactly one hand-named family. The same shape repeats across unrelated services, because every service's generator emits the same optional-timestamp and unavailability unions:
+
+| Repeated subtree | Copies | Unit | Recoverable |
+| --- | --- | --- | --- |
+| China decision-signal timestamp union | 9 | 698 | 5,232 |
+| China decision-signal timestamp property | 4 | 726 | 2,046 |
+| Climate `measuredAt` / `fetchedAt` | 33 | 107 | 2,016 |
+| Timestamp union inner arm | 8 | 324 | 1,960 |
+| Supply-chain war-risk tier enum | 5 | 467 | 1,692 |
+| Provenance claims block | 2 | 1,424 | 1,380 |
+| Economic `unavailable` envelope | 10 | 170 | 1,134 |
+
+Replace the hand-named pass with a generic one: canonicalise every schema subtree, hoist any that repeats and exceeds a byte floor, keep the byte floor above the `$ref` cost. Safe by the same reasoning the parameter dedup already relies on — Schema Objects reached by `$ref` are not scanner-credited the way an inline 2xx response is, and only byte-identical subtrees group, so a definition whose description legitimately differs never collapses with another.
+
+**Do this first.** It is the largest remaining block and needs no new empirical verification.
+
+### 2. Hoist repeated response `headers` blocks — about 5.4 KB
+
+The idempotency header trio (`Idempotency-Key`, `Idempotent-Replayed`, and the wrapper) is stamped verbatim on 16 operations' 200 responses at 402 bytes each. `components.headers` would collapse them.
+
+**Requires scanner re-verification before landing.** The response object stays inline, but a `$ref` would appear inside a 2xx body, and the rule that 2xx responses stay inline was established empirically against orank rather than from the spec. Re-run that check before spending this.
+
+### 3. Repeated inline `example` blocks — about 1.1 KB
+
+Four company-monitoring 200 examples repeat the same company object. Small, and examples are worth keeping legible; take it only if the reserve is already breached.
+
+### 4. Per-operation `description` — 32,320 bytes, last resort
+
+The largest single hand-written block. This is documentation, not repetition, and trimming it makes the spec worse for the agents it exists to serve. Only ever trim boilerplate prefixes that repeat verbatim across operations, and only after 1 and 2 are spent.
+
+### Not on the table
+
+- Raising the 950,000-byte budget.
+- Removing operations, request bodies, or response schemas.
+- `operationId`, `summary`, `tags` (20,755 bytes combined) — scanner-credited metadata.
+
+## Triggers
+
+`scripts/openapi-capacity-report.mjs` classifies the artifact on every `unit` run:
+
+| Status | Condition | CI behaviour |
+| --- | --- | --- |
+| `ok` | headroom of at least 3 mean operations | `::notice::` with the numbers |
+| `reserve-breached` | positive headroom below that reserve | `::warning::`, step still passes |
+| `over-budget` | headroom below zero | `::error::`, step fails |
+| `unmeasured` | zero operations or zero bytes | `::error::`, step fails |
+
+The reserve is derived from the bundle's own mean cost per operation rather than being a fixed number, so it always means "room for three more operations like the ones already here". At this baseline that is 11,739 bytes.
+
+`reserve-breached` warns rather than fails on purpose. The ceiling already has a hard gate; a second hard failure at the same wall would just be the same red build one commit earlier. The warning is the lead time — when it appears, take step 1.
+
+`unmeasured` is deliberately not a pass. A bundle that generated nothing has enormous headroom, and reporting that as healthy is the exact failure this report exists to replace.

--- a/docs/perf/openapi-bundle-capacity-2026-08-13.md
+++ b/docs/perf/openapi-bundle-capacity-2026-08-13.md
@@ -75,39 +75,39 @@ Four emit-time transforms run in `scripts/build-openapi-json.mjs`. None of them 
 
 ## Reduction plan
 
-110 repeated subtrees are still inline, worth about **41,891 bytes** if all were collapsed. That total is non-overlapping: a repeated parent and the repeated child inside it can only be spent once, so the report attributes the bytes to whichever is hoisted first and does not promise them twice.
+77 repeated subtrees are still inline, worth about **31,130 bytes** if all were collapsed. Two rules keep that number honest, and both matter because it is what the next capacity decision will be sized from:
+
+- **Non-overlapping.** A repeated parent and the repeated child inside it can only be spent once. The report attributes the bytes to whichever is hoisted first and excludes the other in both directions — the copies that sit inside a selection and the copies that wrap one.
+- **Referenceable positions only.** A subtree is counted only where OpenAPI 3.1 actually permits a Reference Object. `responses.200.headers` is a `Map[string, Header | Reference]`, so its entries can be hoisted while the map cannot; a Media Type Object and an `example` payload cannot be hoisted at all; and a 2xx response is excluded by project rule because scanners credit only the inline one. Counting those positions would offer bytes no edit can take.
 
 Ranked by yield against risk. Take them in order; each is independent.
 
-### 1. Generalise the repeated-schema-subtree hoist — about 26 KB
+### 1. Generalise the repeated-schema-subtree hoist — about 26.8 KB
 
 `dedupeSharedChinaProvenanceSchemas` hoists exactly one hand-named family. The same shape repeats across unrelated services, because every service's generator emits the same optional-timestamp and unavailability unions:
 
 | Repeated subtree | Copies | Unit | Recoverable |
 | --- | --- | --- | --- |
 | China decision-signal timestamp union | 9 | 698 | 5,232 |
-| China decision-signal timestamp property | 4 | 726 | 2,046 |
 | Climate `measuredAt` / `fetchedAt` | 33 | 107 | 2,016 |
-| Timestamp union inner arm | 8 | 324 | 1,960 |
+| Provenance `content_freshness` value | 8 | 324 | 1,960 |
 | Supply-chain war-risk tier enum | 5 | 467 | 1,692 |
 | Provenance claims block | 2 | 1,424 | 1,380 |
 | Economic `unavailable` envelope | 10 | 170 | 1,134 |
+| Provenance confidence arm | 17 | 96 | 832 |
+| Aviation `updatedAt` | 8 | 153 | 763 |
 
 Replace the hand-named pass with a generic one: canonicalise every schema subtree, hoist any that repeats and exceeds a byte floor, keep the byte floor above the `$ref` cost. Safe by the same reasoning the parameter dedup already relies on — Schema Objects reached by `$ref` are not scanner-credited the way an inline 2xx response is, and only byte-identical subtrees group, so a definition whose description legitimately differs never collapses with another.
 
 **Do this first.** It is the largest remaining block and needs no new empirical verification.
 
-### 2. Hoist repeated response `headers` blocks — about 5.4 KB
+### 2. Hoist the repeated idempotency headers — about 4.3 KB
 
-The idempotency header trio (`Idempotency-Key`, `Idempotent-Replayed`, and the wrapper) is stamped verbatim on 16 operations' 200 responses at 402 bytes each. `components.headers` would collapse them.
+`Idempotent-Replayed` (17 copies, 217 bytes) and `Idempotency-Key` (17 copies, 142 bytes) are stamped verbatim onto the 200 responses of every idempotent operation. `components.headers` collapses them.
 
-**Requires scanner re-verification before landing.** The response object stays inline, but a `$ref` would appear inside a 2xx body, and the rule that 2xx responses stay inline was established empirically against orank rather than from the spec. Re-run that check before spending this.
+**Requires scanner re-verification before landing.** The response object stays inline, but a `$ref` would appear inside a 2xx body, and the rule that 2xx responses stay inline was established empirically against orank rather than from the spec. Re-run that check before spending this. Note the unit of work is the individual header entries, not the enclosing `headers` map — the map is not a referenceable position.
 
-### 3. Repeated inline `example` blocks — about 1.1 KB
-
-Four company-monitoring 200 examples repeat the same company object. Small, and examples are worth keeping legible; take it only if the reserve is already breached.
-
-### 4. Per-operation `description` — 32,320 bytes, last resort
+### 3. Per-operation `description` — 32,320 bytes, last resort
 
 The largest single hand-written block. This is documentation, not repetition, and trimming it makes the spec worse for the agents it exists to serve. Only ever trim boilerplate prefixes that repeat verbatim across operations, and only after 1 and 2 are spent.
 
@@ -115,6 +115,7 @@ The largest single hand-written block. This is documentation, not repetition, an
 
 - Raising the 950,000-byte budget.
 - Removing operations, request bodies, or response schemas.
+- Hoisting a 2xx response, or anything inside an `example` payload.
 - `operationId`, `summary`, `tags` (20,755 bytes combined) — scanner-credited metadata.
 
 ## Triggers

--- a/docs/zh/agent-discovery.mdx
+++ b/docs/zh/agent-discovery.mdx
@@ -39,7 +39,7 @@ Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+j
 |---|---|---|
 | [`/.well-known/api-catalog`](https://worldmonitor.app/.well-known/api-catalog) | [RFC 9727](https://datatracker.ietf.org/doc/html/rfc9727) | JSON 链接集，打包了所有其他发现 URL——如果你只想要一次请求和一张地图，从这里开始 |
 | [`/openapi.yaml`](https://www.worldmonitor.app/openapi.yaml) | OpenAPI 3.1 | 单一打包规范，覆盖**所有** REST 服务（Conflict、Resilience、Market、Economic、Maritime、Aviation、Climate……）——可喂给任何代码生成器 |
-| [`/openapi.json`](https://www.worldmonitor.app/openapi.json) | OpenAPI 3.1 | 字节一致的压缩 JSON 打包——与 `/openapi.yaml` 同一份规范，面向只解析 JSON 的工具与扫描器 |
+| [`/openapi.json`](https://www.worldmonitor.app/openapi.json) | OpenAPI 3.1 | 压缩 JSON 打包，面向只解析 JSON 的工具与扫描器。操作、参数、请求体与响应与 `/openapi.yaml` 完全一致；为控制在扫描器的响应体大小上限内，共享结构以 `$ref` 合并，并省略任何操作都无法引用到的组件 schema |
 | [`/.well-known/mcp/server-card.json`](https://worldmonitor.app/.well-known/mcp/server-card.json) | MCP | 传输方式（`streamableHttp`）、端点、OAuth 资源、作用域、流式、能力标志 |
 | [`/.well-known/oauth-authorization-server`](https://api.worldmonitor.app/.well-known/oauth-authorization-server) | [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) | OAuth 2.1 授权服务器元数据（PKCE、DCR、令牌端点） |
 | [`/.well-known/oauth-protected-resource`](https://worldmonitor.app/.well-known/oauth-protected-resource) | [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) | `https://worldmonitor.app/mcp` 的资源元数据 |

--- a/public/openapi.md
+++ b/public/openapi.md
@@ -13,6 +13,8 @@ The World Monitor OpenAPI Specification is the machine-readable contract for the
 
 The spec is generated on every deploy from the canonical proto/service definitions, so it always matches the running gateway — there is no hand-maintained drift.
 
+The YAML and JSON forms describe the same API: identical paths, operations, parameters, request bodies and responses. They are not byte-for-byte the same document. Agent-readiness scanners cap the body they will analyse near 1 MB, so the JSON is minified, collapses repeated structures into `$ref`s, and omits component schemas that no operation, response or parameter can reach. Generate clients from either; use the YAML if you want every generated message type, including request messages that GET operations express as query parameters.
+
 ## Related descriptors
 
 - **Commerce / pricing endpoints** live in a separate spec (kept out of the root bundle for size): https://www.worldmonitor.app/docs/openapi/CommerceService.openapi.yaml

--- a/scripts/build-openapi-json.mjs
+++ b/scripts/build-openapi-json.mjs
@@ -19,46 +19,97 @@
  * the human-readable YAML. Wired into `build:openapi` (and therefore every
  * web-variant build + the default prebuild hook). Idempotent.
  *
- * It also $ref-dedupes repeated non-2xx error responses and the structurally
- * identical China provenance value schemas (see openapi-dedup-*.mjs). The
- * 2026-07-05 rate-limit/idempotency/example doc injections grew the minified
- * JSON from ~752 KB to ~1.04 MB, crossing the ~1 MB cap and flipping orank's
- * function-calling check to "couldn't validate". Dedup keeps the served JSON
- * below its guarded scanner budget with identical semantics;
- * tests/openapi-json-dedup.test.mjs proves the transform is lossless.
+ * Four emit-time transforms keep the served JSON below its guarded scanner
+ * budget with identical semantics. The 2026-07-05 rate-limit/idempotency/example
+ * doc injections grew the minified JSON from ~752 KB to ~1.04 MB, crossing the
+ * ~1 MB cap and flipping orank's function-calling check to "couldn't validate":
+ *
+ *   - repeated non-2xx error responses      -> components.responses $refs
+ *   - fleet-wide injected parameters        -> components.parameters $refs
+ *   - shared China provenance value schemas -> reused $refs
+ *     (all three in openapi-dedup-*.mjs; tests prove they are lossless)
+ *   - component schemas nothing can reach   -> removed
+ *     (openapi-drop-unreachable-schemas.mjs)
+ *
+ * `scripts/openapi-capacity-report.mjs` measures what is left and ranks what to
+ * collapse next; docs/perf/openapi-bundle-capacity-2026-08-13.md is the plan.
  */
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 import { dedupeErrorResponses, dedupeSharedParameters } from './openapi-dedup-responses.mjs';
 import { dedupeSharedChinaProvenanceSchemas } from './openapi-dedup-schemas.mjs';
+import { dropUnreachableSchemas } from './openapi-drop-unreachable-schemas.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
-const yamlPath = resolve(scriptDir, '../docs/api/worldmonitor.openapi.yaml');
-const jsonPath = resolve(scriptDir, '../public/openapi.json');
+export const yamlPath = resolve(scriptDir, '../docs/api/worldmonitor.openapi.yaml');
+export const jsonPath = resolve(scriptDir, '../public/openapi.json');
 
-const spec = parseYaml(readFileSync(yamlPath, 'utf8'));
+/**
+ * Produce the exact artifact `public/openapi.json` receives, without writing it.
+ *
+ * Exported so the capacity report (#6558) measures the SAME bytes this script
+ * emits rather than a re-implementation that can drift from it. `bytes` is the
+ * UTF-8 length actually written to disk and served — `json.length` counts UTF-16
+ * code units and undercounts every non-ASCII character in the descriptions
+ * (264 bytes on the 2026-08-13 bundle), which is the wrong unit for a body cap
+ * expressed in bytes.
+ *
+ * @param {{ spec?: object }} [options] Pre-parsed bundle. The YAML parse of the
+ *   2.6 MB source costs seconds; callers that already hold the document (the
+ *   contract tests, via the cached loader) pass it in. Mutated in place, exactly
+ *   as the CLI path mutates its own freshly parsed copy.
+ */
+export function buildBundle({ spec: provided } = {}) {
+  const spec = provided ?? parseYaml(readFileSync(yamlPath, 'utf8'));
 
-if (!spec || typeof spec !== 'object' || typeof spec.openapi !== 'string') {
-  throw new Error(
-    `build-openapi-json: parsed ${yamlPath} but it is not a valid OpenAPI document (missing top-level "openapi" version string)`,
+  if (!spec || typeof spec !== 'object' || typeof spec.openapi !== 'string') {
+    throw new Error(
+      `build-openapi-json: parsed ${yamlPath} but it is not a valid OpenAPI document (missing top-level "openapi" version string)`,
+    );
+  }
+
+  const stats = dedupeErrorResponses(spec);
+  const schemaStats = dedupeSharedChinaProvenanceSchemas(spec);
+  const paramStats = dedupeSharedParameters(spec);
+  // Last: the dedup passes hoist responses and parameters into components, and
+  // those hoisted entries carry schema $refs that keep their targets reachable.
+  // Running the drop first would strand them.
+  const unreachableStats = dropUnreachableSchemas(spec);
+
+  // Minified: this artifact is machine-consumed (scanners/agents), and the
+  // smaller payload dodges fetch-size caps. The YAML remains the human copy.
+  const json = JSON.stringify(spec);
+
+  return {
+    spec,
+    json,
+    bytes: Buffer.byteLength(json, 'utf8'),
+    stats,
+    schemaStats,
+    paramStats,
+    unreachableStats,
+  };
+}
+
+function main() {
+  const { spec, json, bytes, stats, schemaStats, paramStats, unreachableStats } = buildBundle();
+  writeFileSync(jsonPath, json);
+
+  const pathCount = spec.paths ? Object.keys(spec.paths).length : 0;
+  console.log(
+    `build-openapi-json: wrote ${jsonPath} (OpenAPI ${spec.openapi}, ${pathCount} paths, ` +
+      `${bytes} bytes; hoisted ${stats.hoisted} shared error responses into ${stats.replacedRefs} $refs; ` +
+      `hoisted ${paramStats.hoisted} fleet-wide parameters into ${paramStats.replacedRefs} $refs; ` +
+      `reused ${schemaStats.replacedRefs}/${schemaStats.compared} shared China provenance schemas; ` +
+      `dropped ${unreachableStats.dropped} unreachable schemas worth ${unreachableStats.bytesFreed} bytes)`,
   );
 }
 
-const stats = dedupeErrorResponses(spec);
-const schemaStats = dedupeSharedChinaProvenanceSchemas(spec);
-const paramStats = dedupeSharedParameters(spec);
-
-// Minified: this artifact is machine-consumed (scanners/agents), and the
-// smaller payload dodges fetch-size caps. The YAML remains the human copy.
-const json = JSON.stringify(spec);
-writeFileSync(jsonPath, json);
-
-const pathCount = spec.paths ? Object.keys(spec.paths).length : 0;
-console.log(
-  `build-openapi-json: wrote ${jsonPath} (OpenAPI ${spec.openapi}, ${pathCount} paths, ` +
-    `${json.length} bytes; hoisted ${stats.hoisted} shared error responses into ${stats.replacedRefs} $refs; ` +
-    `hoisted ${paramStats.hoisted} fleet-wide parameters into ${paramStats.replacedRefs} $refs; ` +
-    `reused ${schemaStats.replacedRefs}/${schemaStats.compared} shared China provenance schemas)`,
-);
+// Importing this module must not write the artifact: the capacity report and
+// the contract tests import `buildBundle` for measurement only.
+const invokedDirectly = process.argv[1]
+  && pathToFileURL(realpathSync(process.argv[1])).href
+    === pathToFileURL(realpathSync(fileURLToPath(import.meta.url))).href;
+if (invokedDirectly) main();

--- a/scripts/build-openapi-json.mjs
+++ b/scripts/build-openapi-json.mjs
@@ -43,7 +43,11 @@ import { dedupeSharedChinaProvenanceSchemas } from './openapi-dedup-schemas.mjs'
 import { dropUnreachableSchemas } from './openapi-drop-unreachable-schemas.mjs';
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
-export const yamlPath = resolve(scriptDir, '../docs/api/worldmonitor.openapi.yaml');
+// OPENAPI_YAML_PATH exists so the capacity report's "could not measure" exit can
+// be exercised as a real process against a real missing/invalid source, instead
+// of being asserted from a hand-built report object that never runs the CLI.
+export const yamlPath = process.env.OPENAPI_YAML_PATH
+  ?? resolve(scriptDir, '../docs/api/worldmonitor.openapi.yaml');
 export const jsonPath = resolve(scriptDir, '../public/openapi.json');
 
 /**
@@ -73,9 +77,11 @@ export function buildBundle({ spec: provided } = {}) {
   const stats = dedupeErrorResponses(spec);
   const schemaStats = dedupeSharedChinaProvenanceSchemas(spec);
   const paramStats = dedupeSharedParameters(spec);
-  // Last: the dedup passes hoist responses and parameters into components, and
-  // those hoisted entries carry schema $refs that keep their targets reachable.
-  // Running the drop first would strand them.
+  // Last by convention, not by necessity. The drop seeds reachability from
+  // EVERY non-schema bucket (see openapi-drop-unreachable-schemas.mjs), so the
+  // responses and parameters the passes above hoist into components keep their
+  // schema targets alive wherever it runs — that unconditional seeding, not
+  // this ordering, is the invariant a future edit must preserve.
   const unreachableStats = dropUnreachableSchemas(spec);
 
   // Minified: this artifact is machine-consumed (scanners/agents), and the

--- a/scripts/openapi-capacity-report.mjs
+++ b/scripts/openapi-capacity-report.mjs
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+/**
+ * Capacity report for the unified public/openapi.json (#6558).
+ *
+ * The artifact is a recurring capacity risk for agent-readiness scanners: they
+ * cap spec bodies around 1 MB, and ora.ai/orank's function-calling check
+ * degrades from a computed verdict to "couldn't validate" above it (#4852).
+ * `tests/openapi-json-dedup.test.mjs` guards the ceiling, but a guard only
+ * speaks the moment it breaks — it reports nothing on the way there, so the
+ * last three crossings were each discovered by a red build on the PR that
+ * happened to be last in line (#4852, #6440's food-stocks operation, the
+ * billing-verification 503 that landed 497 bytes over).
+ *
+ * This reports the number the guard is silent about: how many bytes the served
+ * artifact actually spends, how many are left, and — when the answer is "not
+ * many" — which repeated or generated structures are worth collapsing next.
+ *
+ * Measurement contract:
+ *   - Bytes come from `buildBundle()` in build-openapi-json.mjs, the same call
+ *     that writes the artifact. A re-implementation here could drift from what
+ *     is served; an import cannot.
+ *   - Bytes are UTF-8 bytes, not `String#length`. The cap is a body-size cap in
+ *     bytes and the descriptions carry non-ASCII punctuation, so the two
+ *     numbers differ (264 bytes apart on the 2026-08-13 bundle) and only one of
+ *     them is what a scanner fetches.
+ *
+ * Usage:
+ *   node scripts/openapi-capacity-report.mjs               # human summary
+ *   node scripts/openapi-capacity-report.mjs --json        # report to stdout
+ *   node scripts/openapi-capacity-report.mjs --out cap.json
+ *
+ * Exit codes (every non-pass is nonzero):
+ *   0  measured; artifact within budget (a breached reserve warns, see below)
+ *   1  artifact is OVER budget
+ *   2  the tool was misused (bad args, unwritable --out)
+ *   3  the bundle could not be measured (no operations, no bytes)
+ *
+ * A breached reserve exits 0 on purpose. The ceiling already has a gate; a
+ * second hard failure at the same wall would just be the same red build one
+ * commit earlier. The reserve is an advisory number that makes the trend
+ * legible while there is still room to act on it.
+ */
+
+import { appendFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { buildBundle } from './build-openapi-json.mjs';
+import { unreachableSchemaNames } from './openapi-drop-unreachable-schemas.mjs';
+
+/**
+ * The scanner budget, in bytes of the served artifact.
+ *
+ * Single source of truth: `tests/openapi-json-dedup.test.mjs` imports this
+ * rather than restating it, so the gate and the report can never disagree about
+ * where the wall is. Raising it is NOT the remedy for a crossing — the cap
+ * belongs to the scanner, not to us, and the value is separately pinned by a
+ * literal assertion in that test so a raise cannot pass as a one-line edit.
+ */
+export const SCANNER_BUDGET_BYTES = 950_000;
+
+/**
+ * How many more typical operations the artifact should be able to absorb before
+ * the capacity work becomes urgent.
+ *
+ * Derived, not invented: the unit is this bundle's own mean cost per operation,
+ * so "reserve" always means "room for N more operations like the ones already
+ * here" even as the spec's shape changes. Three is the observed lead time —
+ * #6531 landed one operation into 1.7 KB of headroom, which is less than one
+ * operation's worth, and the fix had to be found inside that same PR.
+ */
+export const RESERVE_OPERATIONS = 3;
+
+/**
+ * Byte cost of the `{"$ref":"#/components/…/Name"}` that replaces a hoisted
+ * subtree. Deliberately an over-estimate of the common case (~36-44 bytes) so
+ * the reported yield of a reduction is a floor rather than a promise.
+ */
+export const ESTIMATED_REF_BYTES = 44;
+
+/**
+ * Subtrees smaller than this are ignored by the repetition analysis. Below it
+ * the $ref that would replace a repeat costs a meaningful fraction of the
+ * repeat itself, and the list degenerates into thousands of `{"type":"string"}`.
+ */
+export const MIN_REPEATED_SUBTREE_BYTES = 96;
+
+/** How many entries each ranked list carries into the report. */
+export const TOP_N = 20;
+
+const HTTP_METHODS = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
+const SCHEMA_REF_PREFIX = '#/components/schemas/';
+
+const escapePointer = (segment) => String(segment).replaceAll('~', '~0').replaceAll('/', '~1');
+
+/** Count the operations (method entries) across paths + webhooks. */
+function countOperations(spec) {
+  let operations = 0;
+  for (const container of [spec.paths, spec.webhooks]) {
+    for (const pathItem of Object.values(container ?? {})) {
+      if (!pathItem || typeof pathItem !== 'object') continue;
+      for (const method of Object.keys(pathItem)) {
+        if (HTTP_METHODS.has(method.toLowerCase())) operations += 1;
+      }
+    }
+  }
+  return operations;
+}
+
+/** Byte cost of each top-level section, and of each `components.*` bucket. */
+export function sectionBreakdown(spec) {
+  const sections = [];
+  for (const [key, value] of Object.entries(spec)) {
+    const bytes = Buffer.byteLength(JSON.stringify(value), 'utf8');
+    const entries = value && typeof value === 'object' ? Object.keys(value).length : null;
+    sections.push({ pointer: `/${escapePointer(key)}`, bytes, entries });
+    if (key !== 'components' || !value || typeof value !== 'object') continue;
+    for (const [bucket, contents] of Object.entries(value)) {
+      sections.push({
+        pointer: `/components/${escapePointer(bucket)}`,
+        bytes: Buffer.byteLength(JSON.stringify(contents), 'utf8'),
+        entries: contents && typeof contents === 'object' ? Object.keys(contents).length : null,
+      });
+    }
+  }
+  return sections.sort((a, b) => b.bytes - a.bytes);
+}
+
+/**
+ * Byte cost of each Operation Object field, summed over every operation.
+ *
+ * This is where "generated" pressure shows up: a field whose per-operation cost
+ * is high is one an injector stamps fleet-wide, and fleet-wide stamps are the
+ * structures worth collapsing before hand-written documentation is touched.
+ */
+export function operationFieldBreakdown(spec) {
+  const totals = new Map();
+  const operations = countOperations(spec);
+  for (const container of [spec.paths, spec.webhooks]) {
+    for (const pathItem of Object.values(container ?? {})) {
+      if (!pathItem || typeof pathItem !== 'object') continue;
+      for (const [method, op] of Object.entries(pathItem)) {
+        if (!HTTP_METHODS.has(method.toLowerCase()) || !op || typeof op !== 'object') continue;
+        for (const [field, value] of Object.entries(op)) {
+          // + the `"field":` key and its trailing comma, which the field's own
+          // presence is equally responsible for.
+          const bytes = Buffer.byteLength(JSON.stringify(value), 'utf8') + field.length + 4;
+          totals.set(field, (totals.get(field) ?? 0) + bytes);
+        }
+      }
+    }
+  }
+  return [...totals]
+    .map(([field, bytes]) => ({
+      field,
+      bytes,
+      bytesPerOperation: operations > 0 ? Math.round(bytes / operations) : null,
+    }))
+    .sort((a, b) => b.bytes - a.bytes);
+}
+
+/**
+ * Rank the repeated subtrees that are still inline after the existing dedup
+ * passes, without double-counting nested repeats.
+ *
+ * The naive version of this list is wrong in a way that flatters it: a repeated
+ * `headers` object and the repeated header entries *inside* it are both
+ * repeated, and adding their yields promises bytes that can only be spent once.
+ * Candidates are taken greedily from the largest, and a later candidate counts
+ * only the occurrences that do not already sit inside a selected subtree.
+ */
+export function repeatedStructures(spec, { minBytes = MIN_REPEATED_SUBTREE_BYTES, topN = TOP_N } = {}) {
+  const parentOf = new Map();
+  /** @type {Map<string, { occurrences: number, unitBytes: number, nodes: object[], pointers: string[] }>} */
+  const groups = new Map();
+
+  // Canonical form is built bottom-up so every node is stringified once. Key
+  // order does not change a JSON object's byte length, so the canonical
+  // string's length is the node's real cost in the artifact.
+  const canonical = (node, pointer, parent) => {
+    if (Array.isArray(node)) {
+      parentOf.set(node, parent);
+      return `[${node.map((child, i) => canonical(child, `${pointer}/${i}`, node)).join(',')}]`;
+    }
+    if (node && typeof node === 'object') {
+      parentOf.set(node, parent);
+      const serialized = `{${Object.keys(node)
+        .sort()
+        .map((k) => `${JSON.stringify(k)}:${canonical(node[k], `${pointer}/${escapePointer(k)}`, node)}`)
+        .join(',')}}`;
+      const unitBytes = Buffer.byteLength(serialized, 'utf8');
+      if (unitBytes >= minBytes) {
+        let group = groups.get(serialized);
+        if (!group) {
+          group = { occurrences: 0, unitBytes, nodes: [], pointers: [] };
+          groups.set(serialized, group);
+        }
+        group.occurrences += 1;
+        group.nodes.push(node);
+        if (group.pointers.length < 3) group.pointers.push(pointer || '/');
+      }
+      return serialized;
+    }
+    return JSON.stringify(node) ?? 'null';
+  };
+  canonical(spec, '', null);
+
+  const insideSelected = (node, selected) => {
+    let parent = parentOf.get(node);
+    while (parent) {
+      if (selected.has(parent)) return true;
+      parent = parentOf.get(parent);
+    }
+    return false;
+  };
+
+  const candidates = [...groups.values()]
+    .filter((group) => group.occurrences >= 2 && group.unitBytes > ESTIMATED_REF_BYTES)
+    .sort(
+      (a, b) =>
+        (b.occurrences - 1) * (b.unitBytes - ESTIMATED_REF_BYTES)
+        - (a.occurrences - 1) * (a.unitBytes - ESTIMATED_REF_BYTES),
+    );
+
+  const selectedNodes = new Set();
+  const selected = [];
+  for (const group of candidates) {
+    const free = group.nodes.filter((node) => !insideSelected(node, selectedNodes));
+    if (free.length < 2) continue;
+    for (const node of free) selectedNodes.add(node);
+    selected.push({
+      pointers: group.pointers,
+      occurrences: free.length,
+      unitBytes: group.unitBytes,
+      estimatedRecoverableBytes: (free.length - 1) * (group.unitBytes - ESTIMATED_REF_BYTES),
+    });
+  }
+
+  selected.sort((a, b) => b.estimatedRecoverableBytes - a.estimatedRecoverableBytes);
+  return {
+    estimatedRecoverableBytes: selected.reduce((sum, s) => sum + s.estimatedRecoverableBytes, 0),
+    groups: selected.length,
+    top: selected.slice(0, topN),
+  };
+}
+
+/**
+ * Component schemas still unreachable in the SERVED document.
+ *
+ * `buildBundle()` already drops these (openapi-drop-unreachable-schemas.mjs),
+ * so a healthy report reads zero. It stays in the report as the regression
+ * detector for that transform: a non-zero count means the drop stopped
+ * engaging — the failure mode where a saving quietly stops being taken and only
+ * the budget notices, a year later, from the wrong direction.
+ *
+ * `bytes` is exact: the measured difference between the document with and
+ * without them, not a sum of parts that ignores separators.
+ */
+export function unreferencedComponentSchemas(spec) {
+  const schemas = spec?.components?.schemas;
+  if (!schemas || typeof schemas !== 'object') return { count: 0, bytes: 0, names: [] };
+
+  const names = [...unreachableSchemaNames(spec)];
+  if (names.length === 0) return { count: 0, bytes: 0, names: [] };
+
+  const trimmed = { ...spec, components: { ...spec.components, schemas: { ...schemas } } };
+  for (const name of names) delete trimmed.components.schemas[name];
+  const bytes = Buffer.byteLength(JSON.stringify(spec), 'utf8')
+    - Buffer.byteLength(JSON.stringify(trimmed), 'utf8');
+
+  return { count: names.length, bytes, names: names.slice(0, TOP_N) };
+}
+
+/**
+ * Turn a built bundle into the capacity report.
+ *
+ * @param {{ spec: object, bytes: number, stats: object, schemaStats: object, paramStats: object }} bundle
+ */
+export function buildCapacityReport(bundle, { budgetBytes = SCANNER_BUDGET_BYTES } = {}) {
+  const { spec, bytes } = bundle;
+  const operations = countOperations(spec);
+
+  // A bundle with no operations, or no bytes, is not a healthy artifact that
+  // happens to be small — it is a build that produced nothing. Reporting
+  // "941 KB of headroom" for it would be the exact failure mode this report
+  // exists to replace, so it is a measurement failure, never a pass.
+  if (!(bytes > 0) || operations === 0) {
+    return {
+      schemaVersion: 1,
+      artifact: 'public/openapi.json',
+      status: 'unmeasured',
+      reason: operations === 0
+        ? 'the bundle declares zero operations — nothing was generated'
+        : `the bundle serialized to ${bytes} bytes — nothing was generated`,
+      bytes,
+      budgetBytes,
+      operations,
+    };
+  }
+
+  const headroomBytes = budgetBytes - bytes;
+  const bytesPerOperation = Math.round(bytes / operations);
+  const reserveBytes = bytesPerOperation * RESERVE_OPERATIONS;
+  const status = headroomBytes < 0
+    ? 'over-budget'
+    : headroomBytes < reserveBytes
+      ? 'reserve-breached'
+      : 'ok';
+
+  const repeated = repeatedStructures(spec);
+  return {
+    schemaVersion: 1,
+    artifact: 'public/openapi.json',
+    status,
+    bytes,
+    budgetBytes,
+    headroomBytes,
+    headroomPct: Number(((headroomBytes / budgetBytes) * 100).toFixed(3)),
+    operations,
+    bytesPerOperation,
+    operationsRemaining: Math.floor(headroomBytes / bytesPerOperation),
+    reserveBytes,
+    reserveOperations: RESERVE_OPERATIONS,
+    transforms: {
+      errorResponses: bundle.stats,
+      chinaProvenanceSchemas: bundle.schemaStats,
+      sharedParameters: bundle.paramStats,
+      unreachableSchemas: bundle.unreachableStats,
+    },
+    sections: sectionBreakdown(spec),
+    operationFields: operationFieldBreakdown(spec),
+    unreferencedComponentSchemas: unreferencedComponentSchemas(spec),
+    repeatedStructures: repeated,
+  };
+}
+
+const kb = (bytes) => `${(bytes / 1024).toFixed(1)} KB`;
+
+/** GitHub-flavoured markdown for the job summary. */
+export function formatMarkdown(report) {
+  if (report.status === 'unmeasured') {
+    return `### OpenAPI bundle capacity\n\n**NOT MEASURED** — ${report.reason}\n`;
+  }
+  const verdict = {
+    ok: 'within budget',
+    'reserve-breached': `below the ${report.reserveOperations}-operation reserve`,
+    'over-budget': 'OVER BUDGET',
+  }[report.status];
+
+  const lines = [
+    '### OpenAPI bundle capacity',
+    '',
+    `\`public/openapi.json\` is **${report.bytes.toLocaleString('en-US')} bytes** of a `
+      + `${report.budgetBytes.toLocaleString('en-US')}-byte scanner budget — `
+      + `**${report.headroomBytes.toLocaleString('en-US')} bytes free** (${report.headroomPct}%), ${verdict}.`,
+    '',
+    '| Metric | Value |',
+    '| --- | --- |',
+    `| Served bytes | ${report.bytes.toLocaleString('en-US')} |`,
+    `| Budget | ${report.budgetBytes.toLocaleString('en-US')} |`,
+    `| Headroom | ${report.headroomBytes.toLocaleString('en-US')} (${report.headroomPct}%) |`,
+    `| Operations | ${report.operations} (${report.bytesPerOperation} bytes each, mean) |`,
+    `| Room for | ~${report.operationsRemaining} more operations |`,
+    `| Reserve | ${report.reserveBytes.toLocaleString('en-US')} (${report.reserveOperations} operations) |`,
+    '',
+    '<details><summary>Largest sections</summary>',
+    '',
+    '| Section | Bytes | Entries |',
+    '| --- | --- | --- |',
+    ...report.sections.slice(0, 8).map((s) => `| \`${s.pointer}\` | ${s.bytes.toLocaleString('en-US')} | ${s.entries ?? '—'} |`),
+    '',
+    '</details>',
+    '',
+    '<details><summary>Reduction candidates (lossless, unspent)</summary>',
+    '',
+    `- ${report.repeatedStructures.groups} repeated subtrees are still inline: `
+      + `**~${kb(report.repeatedStructures.estimatedRecoverableBytes)}** (non-overlapping estimate)`,
+    `- Unreachable component schemas remaining: **${report.unreferencedComponentSchemas.count}** `
+      + '(the emit-time drop should keep this at 0)',
+    '',
+    '| Repeated subtree | × | Unit | Est. recoverable |',
+    '| --- | --- | --- | --- |',
+    ...report.repeatedStructures.top.slice(0, 10).map(
+      (r) => `| \`${r.pointers[0]}\` | ${r.occurrences} | ${r.unitBytes} | ${r.estimatedRecoverableBytes.toLocaleString('en-US')} |`,
+    ),
+    '',
+    '</details>',
+    '',
+    'Plan and rationale: `docs/perf/openapi-bundle-capacity-2026-08-13.md`',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function parseArgs(argv) {
+  const args = { json: false, out: null };
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i];
+    if (arg === '--json') args.json = true;
+    else if (arg === '--out') {
+      const next = rest[++i];
+      if (!next || next.startsWith('--')) throw new Error('--out requires a file path');
+      args.out = next;
+    } else throw new Error(`unknown argument: ${arg}`);
+  }
+  return args;
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (err) {
+    console.error(`[openapi-capacity] ${err instanceof Error ? err.message : String(err)}`);
+    console.error('[openapi-capacity] usage: openapi-capacity-report.mjs [--json] [--out <file>]');
+    process.exit(2);
+  }
+
+  let bundle;
+  try {
+    bundle = buildBundle();
+  } catch (err) {
+    // Exit 3, not the 1 an unhandled throw would produce: an unparseable or
+    // missing bundle is "could not measure", and reporting it as "over budget"
+    // sends the next reader hunting for bytes that were never counted.
+    console.error(`::error::openapi capacity NOT MEASURED — the bundle could not be built: ${
+      err instanceof Error ? err.message : String(err)}`);
+    process.exit(3);
+  }
+
+  const report = buildCapacityReport(bundle);
+  const serialized = `${JSON.stringify(report, null, 2)}\n`;
+
+  if (args.out) {
+    try {
+      writeFileSync(args.out, serialized);
+    } catch (err) {
+      console.error(`[openapi-capacity] cannot write ${args.out}: ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(2);
+    }
+  }
+  if (args.json) process.stdout.write(serialized);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    try {
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${formatMarkdown(report)}\n`);
+    } catch {
+      // The summary is a convenience surface. The JSON artifact and the
+      // annotations below carry the same numbers, so losing it is not a
+      // reason to fail the step.
+    }
+  }
+
+  if (report.status === 'unmeasured') {
+    console.error(`::error::openapi capacity NOT MEASURED — ${report.reason}`);
+    process.exit(3);
+  }
+
+  const headline = `public/openapi.json is ${report.bytes} bytes of ${report.budgetBytes} `
+    + `(${report.headroomBytes} free, ~${report.operationsRemaining} more operations at `
+    + `${report.bytesPerOperation} bytes each)`;
+
+  if (report.status === 'over-budget') {
+    console.error(`::error::OVER BUDGET — ${headline}`);
+    console.error('[openapi-capacity] extend the dedup passes or drop unreachable schemas; do NOT raise the budget');
+    process.exit(1);
+  }
+  if (report.status === 'reserve-breached') {
+    console.warn(
+      `::warning::OpenAPI bundle reserve breached — ${headline}. `
+        + `Collapsing the repeated structures still inline would return ~${report.repeatedStructures.estimatedRecoverableBytes} bytes; `
+        + 'see docs/perf/openapi-bundle-capacity-2026-08-13.md',
+    );
+  } else {
+    // stderr, not stdout: under `--json` stdout is the machine-readable report
+    // and a human line mixed into it makes the artifact unparseable. GitHub
+    // reads workflow commands from both streams, so the annotation still lands.
+    console.error(`::notice::${headline}`);
+  }
+  console.error(`[openapi-capacity] ${report.status}: ${headline}`);
+}
+
+const invokedDirectly = process.argv[1]
+  && pathToFileURL(realpathSync(process.argv[1])).href
+    === pathToFileURL(realpathSync(fileURLToPath(import.meta.url))).href;
+if (invokedDirectly) main();

--- a/scripts/openapi-capacity-report.mjs
+++ b/scripts/openapi-capacity-report.mjs
@@ -86,8 +86,65 @@ export const MIN_REPEATED_SUBTREE_BYTES = 96;
 /** How many entries each ranked list carries into the report. */
 export const TOP_N = 20;
 
+/**
+ * Operation-count floor below which the bundle is treated as not generated.
+ *
+ * `bytes > 0 && operations > 0` only catches the impossible case — a committed
+ * 2.6 MB source YAML does not produce an empty document. The plausible failure
+ * is a PARTIAL generation: a codegen or injector change that emits a handful of
+ * operations, which would report a delighted 900 KB of headroom. The bundle has
+ * grown monotonically through 193 -> 217 -> 218 operations; 100 is far below
+ * anything real and far above anything a broken generator would produce.
+ */
+export const MIN_PLAUSIBLE_OPERATIONS = 100;
+
 const HTTP_METHODS = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
-const SCHEMA_REF_PREFIX = '#/components/schemas/';
+
+// Which document positions can actually hold a `$ref`. An ALLOW-list, not a
+// deny-list: a position nobody thought about must fall out of the estimate
+// rather than into it, because the number this feeds is a promise about bytes
+// a future edit can spend. Counting an unreferenceable position is how a
+// reduction plan offers savings no edit can take — `responses.200.headers` is
+// a `Map[string, Header | Reference]`, so each ENTRY can become a `$ref` while
+// the map itself cannot, and `content['application/json']` is a Media Type
+// Object, which OpenAPI 3.1 does not allow a Reference in at all.
+
+/** Single-value slots that hold a Schema (or Reference) directly. */
+const REF_SLOT_KEYS = new Set([
+  'schema', 'items', 'not', 'additionalProperties', 'contains', 'propertyNames',
+  'if', 'then', 'else', 'requestBody',
+]);
+
+/** Array-valued keys whose ELEMENTS hold a Schema (or Reference). */
+const REF_ARRAY_KEYS = new Set(['oneOf', 'anyOf', 'allOf', 'prefixItems', 'parameters']);
+
+/** Maps whose ENTRIES hold a referenceable Object. */
+const REF_ENTRY_CONTAINERS = new Set([
+  'properties', 'patternProperties', 'dependentSchemas', 'definitions', '$defs',
+  'schemas', 'responses', 'headers', 'parameters', 'requestBodies', 'examples',
+  'links', 'callbacks', 'securitySchemes',
+]);
+
+/**
+ * Keys whose value is arbitrary instance data, not a referenceable Object.
+ *
+ * `example` holds a literal payload; `enum`/`const`/`default` hold values. Their
+ * CONTENTS are excluded too — an example payload can contain a key called
+ * `schema` or `properties` without any of it being an OpenAPI construct.
+ */
+const RAW_DATA_KEYS = new Set(['example', 'enum', 'const', 'default']);
+
+/** Can a `$ref` stand where this node stands? */
+function isReferenceablePosition(parentKey, grandparentKey, inRawData) {
+  if (inRawData) return false;
+  // A 2xx response is referenceable in OpenAPI but off-limits here: orank
+  // credits only the inline `responses["200"]` schema, so the dedup passes
+  // deliberately never hoist one (openapi-dedup-responses.mjs). Offering those
+  // bytes would be offering a change the project has already ruled out.
+  if (grandparentKey === 'responses' && /^2\d\d$/.test(String(parentKey))) return false;
+  if (REF_SLOT_KEYS.has(parentKey) || REF_ARRAY_KEYS.has(parentKey)) return true;
+  return REF_ENTRY_CONTAINERS.has(grandparentKey);
+}
 
 const escapePointer = (segment) => String(segment).replaceAll('~', '~0').replaceAll('/', '~1');
 
@@ -141,8 +198,12 @@ export function operationFieldBreakdown(spec) {
         if (!HTTP_METHODS.has(method.toLowerCase()) || !op || typeof op !== 'object') continue;
         for (const [field, value] of Object.entries(op)) {
           // + the `"field":` key and its trailing comma, which the field's own
-          // presence is equally responsible for.
-          const bytes = Buffer.byteLength(JSON.stringify(value), 'utf8') + field.length + 4;
+          // presence is equally responsible for. The key is measured in bytes
+          // too — a non-ASCII extension field (`x-π`) is longer than its
+          // `String#length`, and undercounting keys is the very error this
+          // report exists to stop making.
+          const bytes = Buffer.byteLength(JSON.stringify(value), 'utf8')
+            + Buffer.byteLength(field, 'utf8') + 4;
           totals.set(field, (totals.get(field) ?? 0) + bytes);
         }
       }
@@ -164,52 +225,89 @@ export function operationFieldBreakdown(spec) {
  * The naive version of this list is wrong in a way that flatters it: a repeated
  * `headers` object and the repeated header entries *inside* it are both
  * repeated, and adding their yields promises bytes that can only be spent once.
- * Candidates are taken greedily from the largest, and a later candidate counts
- * only the occurrences that do not already sit inside a selected subtree.
+ * Candidates are taken greedily from the largest, and a later candidate is
+ * dropped when it overlaps an already-selected subtree in EITHER direction —
+ * whether its copies sit inside one, or contain one. Containment has to be
+ * checked too: a small subtree repeated 30 times outranks the larger structure
+ * wrapping three of them, gets selected first, and the wrapper would then be
+ * credited its full size including bytes already counted.
  */
 export function repeatedStructures(spec, { minBytes = MIN_REPEATED_SUBTREE_BYTES, topN = TOP_N } = {}) {
   const parentOf = new Map();
-  /** @type {Map<string, { occurrences: number, unitBytes: number, nodes: object[], pointers: string[] }>} */
+  const pointerOf = new Map();
+  /** @type {Map<string, { occurrences: number, unitBytes: number, nodes: object[] }>} */
   const groups = new Map();
 
   // Canonical form is built bottom-up so every node is stringified once. Key
   // order does not change a JSON object's byte length, so the canonical
   // string's length is the node's real cost in the artifact.
-  const canonical = (node, pointer, parent) => {
+  //
+  // `parentKey`/`grandparentKey` are what decide whether a `$ref` could stand
+  // in this node's place; an array passes its own key down so an element of
+  // `oneOf` still reads as `oneOf`. `inRawData` marks everything under an
+  // `example`/`enum`/`const`/`default`: still serialized, still costs bytes,
+  // but not a candidate at any depth.
+  const canonical = (node, pointer, parent, parentKey, grandparentKey, inRawData) => {
     if (Array.isArray(node)) {
       parentOf.set(node, parent);
-      return `[${node.map((child, i) => canonical(child, `${pointer}/${i}`, node)).join(',')}]`;
+      return `[${node
+        .map((child, i) => canonical(child, `${pointer}/${i}`, node, parentKey, grandparentKey, inRawData))
+        .join(',')}]`;
     }
     if (node && typeof node === 'object') {
       parentOf.set(node, parent);
+      pointerOf.set(node, pointer || '/');
       const serialized = `{${Object.keys(node)
         .sort()
-        .map((k) => `${JSON.stringify(k)}:${canonical(node[k], `${pointer}/${escapePointer(k)}`, node)}`)
+        .map((k) => `${JSON.stringify(k)}:${canonical(
+          node[k],
+          `${pointer}/${escapePointer(k)}`,
+          node,
+          k,
+          parentKey,
+          inRawData || RAW_DATA_KEYS.has(k),
+        )}`)
         .join(',')}}`;
       const unitBytes = Buffer.byteLength(serialized, 'utf8');
-      if (unitBytes >= minBytes) {
+      if (isReferenceablePosition(parentKey, grandparentKey, inRawData) && unitBytes >= minBytes) {
         let group = groups.get(serialized);
         if (!group) {
-          group = { occurrences: 0, unitBytes, nodes: [], pointers: [] };
+          group = { occurrences: 0, unitBytes, nodes: [] };
           groups.set(serialized, group);
         }
         group.occurrences += 1;
         group.nodes.push(node);
-        if (group.pointers.length < 3) group.pointers.push(pointer || '/');
       }
       return serialized;
     }
     return JSON.stringify(node) ?? 'null';
   };
-  canonical(spec, '', null);
+  // The root document is not a referenceable position, so it starts with no
+  // parent or grandparent key and falls out of the allow-list naturally.
+  canonical(spec, '', null, null, null, false);
 
-  const insideSelected = (node, selected) => {
+  // Selected nodes, plus every ancestor of one. The first set catches a
+  // candidate nested inside a selection; the second catches a candidate that
+  // wraps one. Without the second, the wrapper's already-counted inner bytes
+  // get promised twice.
+  const selectedNodes = new Set();
+  const ancestorsOfSelected = new Set();
+  const overlapsSelection = (node) => {
+    if (ancestorsOfSelected.has(node)) return true;
     let parent = parentOf.get(node);
     while (parent) {
-      if (selected.has(parent)) return true;
+      if (selectedNodes.has(parent)) return true;
       parent = parentOf.get(parent);
     }
     return false;
+  };
+  const markSelected = (node) => {
+    selectedNodes.add(node);
+    let parent = parentOf.get(node);
+    while (parent && !ancestorsOfSelected.has(parent)) {
+      ancestorsOfSelected.add(parent);
+      parent = parentOf.get(parent);
+    }
   };
 
   const candidates = [...groups.values()]
@@ -220,14 +318,16 @@ export function repeatedStructures(spec, { minBytes = MIN_REPEATED_SUBTREE_BYTES
         - (a.occurrences - 1) * (a.unitBytes - ESTIMATED_REF_BYTES),
     );
 
-  const selectedNodes = new Set();
   const selected = [];
   for (const group of candidates) {
-    const free = group.nodes.filter((node) => !insideSelected(node, selectedNodes));
+    const free = group.nodes.filter((node) => !overlapsSelection(node));
     if (free.length < 2) continue;
-    for (const node of free) selectedNodes.add(node);
+    for (const node of free) markSelected(node);
     selected.push({
-      pointers: group.pointers,
+      // Pointers come from the counted copies, never from the whole group: a
+      // row that names occurrences its own count excluded sends the reader to
+      // the wrong place.
+      pointers: free.slice(0, 3).map((node) => pointerOf.get(node) ?? '/'),
       occurrences: free.length,
       unitBytes: group.unitBytes,
       estimatedRecoverableBytes: (free.length - 1) * (group.unitBytes - ESTIMATED_REF_BYTES),
@@ -246,13 +346,20 @@ export function repeatedStructures(spec, { minBytes = MIN_REPEATED_SUBTREE_BYTES
  * Component schemas still unreachable in the SERVED document.
  *
  * `buildBundle()` already drops these (openapi-drop-unreachable-schemas.mjs),
- * so a healthy report reads zero. It stays in the report as the regression
- * detector for that transform: a non-zero count means the drop stopped
- * engaging — the failure mode where a saving quietly stops being taken and only
- * the budget notices, a year later, from the wrong direction.
+ * so a healthy report reads zero.
+ *
+ * This is NOT a regression detector for that transform and must not be read as
+ * one: it re-runs the same `unreachableSchemaNames` walk the drop used, so a
+ * walk that regressed to "everything is reachable" would delete nothing AND
+ * report nothing — the guard would agree with itself. What catches that is
+ * `transforms.<name>.engaged` below, which is computed from the transform's own
+ * returned counts, and the `>= 150` floor in
+ * tests/openapi-unreachable-schemas.test.mjs. This field's job is narrower:
+ * surface orphans that a LATER pass reintroduced after the drop ran.
  *
  * `bytes` is exact: the measured difference between the document with and
- * without them, not a sum of parts that ignores separators.
+ * without them, mirroring the transform (which also removes an emptied
+ * `components.schemas`), not a sum of parts that ignores separators.
  */
 export function unreferencedComponentSchemas(spec) {
   const schemas = spec?.components?.schemas;
@@ -263,6 +370,7 @@ export function unreferencedComponentSchemas(spec) {
 
   const trimmed = { ...spec, components: { ...spec.components, schemas: { ...schemas } } };
   for (const name of names) delete trimmed.components.schemas[name];
+  if (Object.keys(trimmed.components.schemas).length === 0) delete trimmed.components.schemas;
   const bytes = Buffer.byteLength(JSON.stringify(spec), 'utf8')
     - Buffer.byteLength(JSON.stringify(trimmed), 'utf8');
 
@@ -270,25 +378,55 @@ export function unreferencedComponentSchemas(spec) {
 }
 
 /**
+ * Which emit-time transforms actually did work on this bundle.
+ *
+ * Derived from each transform's OWN returned counts, so it stays true when a
+ * transform silently stops engaging — the case a re-derivation from the
+ * transformed document cannot see, because a disengaged transform and a
+ * document with nothing left to do look identical from the output side.
+ */
+function transformEngagement(bundle) {
+  const engaged = (n) => Number.isFinite(n) && n > 0;
+  return {
+    errorResponses: { ...bundle.stats, engaged: engaged(bundle.stats?.replacedRefs) },
+    chinaProvenanceSchemas: {
+      ...bundle.schemaStats,
+      engaged: engaged(bundle.schemaStats?.replacedRefs),
+    },
+    sharedParameters: { ...bundle.paramStats, engaged: engaged(bundle.paramStats?.replacedRefs) },
+    unreachableSchemas: {
+      ...bundle.unreachableStats,
+      engaged: engaged(bundle.unreachableStats?.dropped),
+    },
+  };
+}
+
+/**
  * Turn a built bundle into the capacity report.
  *
- * @param {{ spec: object, bytes: number, stats: object, schemaStats: object, paramStats: object }} bundle
+ * @param {{ spec: object, bytes: number, stats: object, schemaStats: object,
+ *   paramStats: object, unreachableStats: object }} bundle
  */
-export function buildCapacityReport(bundle, { budgetBytes = SCANNER_BUDGET_BYTES } = {}) {
+export function buildCapacityReport(bundle, {
+  budgetBytes = SCANNER_BUDGET_BYTES,
+  minOperations = MIN_PLAUSIBLE_OPERATIONS,
+} = {}) {
   const { spec, bytes } = bundle;
   const operations = countOperations(spec);
 
-  // A bundle with no operations, or no bytes, is not a healthy artifact that
-  // happens to be small — it is a build that produced nothing. Reporting
-  // "941 KB of headroom" for it would be the exact failure mode this report
-  // exists to replace, so it is a measurement failure, never a pass.
-  if (!(bytes > 0) || operations === 0) {
+  // A bundle with no bytes, or implausibly few operations, is not a healthy
+  // artifact that happens to be small — it is a build that produced little or
+  // nothing. Reporting "900 KB of headroom" for it would be the exact failure
+  // mode this report exists to replace, so it is a measurement failure, never
+  // a pass. The floor is what makes this catch a PARTIAL generation; a
+  // zero-only check only ever fires on the impossible case.
+  if (!(bytes > 0) || operations < minOperations) {
     return {
       schemaVersion: 1,
       artifact: 'public/openapi.json',
       status: 'unmeasured',
-      reason: operations === 0
-        ? 'the bundle declares zero operations — nothing was generated'
+      reason: bytes > 0
+        ? `the bundle declares only ${operations} operations (floor ${minOperations}) — generation looks partial`
         : `the bundle serialized to ${bytes} bytes — nothing was generated`,
       bytes,
       budgetBytes,
@@ -297,7 +435,9 @@ export function buildCapacityReport(bundle, { budgetBytes = SCANNER_BUDGET_BYTES
   }
 
   const headroomBytes = budgetBytes - bytes;
-  const bytesPerOperation = Math.round(bytes / operations);
+  // At least 1: a bundle small enough to round to 0 bytes/operation would make
+  // reserveBytes 0, and `reserve-breached` unreachable in both directions.
+  const bytesPerOperation = Math.max(1, Math.round(bytes / operations));
   const reserveBytes = bytesPerOperation * RESERVE_OPERATIONS;
   const status = headroomBytes < 0
     ? 'over-budget'
@@ -319,12 +459,7 @@ export function buildCapacityReport(bundle, { budgetBytes = SCANNER_BUDGET_BYTES
     operationsRemaining: Math.floor(headroomBytes / bytesPerOperation),
     reserveBytes,
     reserveOperations: RESERVE_OPERATIONS,
-    transforms: {
-      errorResponses: bundle.stats,
-      chinaProvenanceSchemas: bundle.schemaStats,
-      sharedParameters: bundle.paramStats,
-      unreachableSchemas: bundle.unreachableStats,
-    },
+    transforms: transformEngagement(bundle),
     sections: sectionBreakdown(spec),
     operationFields: operationFieldBreakdown(spec),
     unreferencedComponentSchemas: unreferencedComponentSchemas(spec),
@@ -391,7 +526,7 @@ export function formatMarkdown(report) {
 }
 
 function parseArgs(argv) {
-  const args = { json: false, out: null };
+  const args = { json: false, out: null, budgetBytes: SCANNER_BUDGET_BYTES };
   const rest = argv.slice(2);
   for (let i = 0; i < rest.length; i++) {
     const arg = rest[i];
@@ -400,6 +535,16 @@ function parseArgs(argv) {
       const next = rest[++i];
       if (!next || next.startsWith('--')) throw new Error('--out requires a file path');
       args.out = next;
+    } else if (arg === '--budget') {
+      // What-if lever for local analysis ("how much would we need to cut to sit
+      // under 800 KB?"), and the only way to exercise the over-budget exit
+      // without a fabricated bundle. It cannot weaken the gate: the gate is
+      // tests/openapi-json-dedup.test.mjs, which pins 950,000 literally, and
+      // the CI step's exact argument list is pinned in
+      // tests/ci-workflow-coverage.test.mts.
+      const next = Number(rest[++i]);
+      if (!Number.isInteger(next) || next <= 0) throw new Error('--budget requires a positive integer');
+      args.budgetBytes = next;
     } else throw new Error(`unknown argument: ${arg}`);
   }
   return args;
@@ -411,7 +556,7 @@ function main() {
     args = parseArgs(process.argv);
   } catch (err) {
     console.error(`[openapi-capacity] ${err instanceof Error ? err.message : String(err)}`);
-    console.error('[openapi-capacity] usage: openapi-capacity-report.mjs [--json] [--out <file>]');
+    console.error('[openapi-capacity] usage: openapi-capacity-report.mjs [--json] [--out <file>] [--budget <bytes>]');
     process.exit(2);
   }
 
@@ -424,10 +569,11 @@ function main() {
     // sends the next reader hunting for bytes that were never counted.
     console.error(`::error::openapi capacity NOT MEASURED — the bundle could not be built: ${
       err instanceof Error ? err.message : String(err)}`);
-    process.exit(3);
+    process.exitCode = 3;
+    return;
   }
 
-  const report = buildCapacityReport(bundle);
+  const report = buildCapacityReport(bundle, { budgetBytes: args.budgetBytes });
   const serialized = `${JSON.stringify(report, null, 2)}\n`;
 
   if (args.out) {
@@ -438,11 +584,19 @@ function main() {
       process.exit(2);
     }
   }
+  // `process.stdout.write` + `process.exit` truncates a piped write. Every exit
+  // below therefore sets `process.exitCode` and returns, letting Node drain
+  // stdout before it ends — otherwise the machine-readable report is exactly
+  // the thing lost on the failure paths that need it most.
   if (args.json) process.stdout.write(serialized);
 
   if (process.env.GITHUB_STEP_SUMMARY) {
+    // Rendered OUTSIDE the try: only the write is allowed to fail silently. A
+    // bug in formatMarkdown is a bug, and swallowing it here would hide it on
+    // the one surface that renders it.
+    const markdown = formatMarkdown(report);
     try {
-      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${formatMarkdown(report)}\n`);
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${markdown}\n`);
     } catch {
       // The summary is a convenience surface. The JSON artifact and the
       // annotations below carry the same numbers, so losing it is not a
@@ -452,7 +606,8 @@ function main() {
 
   if (report.status === 'unmeasured') {
     console.error(`::error::openapi capacity NOT MEASURED — ${report.reason}`);
-    process.exit(3);
+    process.exitCode = 3;
+    return;
   }
 
   const headline = `public/openapi.json is ${report.bytes} bytes of ${report.budgetBytes} `
@@ -462,7 +617,8 @@ function main() {
   if (report.status === 'over-budget') {
     console.error(`::error::OVER BUDGET — ${headline}`);
     console.error('[openapi-capacity] extend the dedup passes or drop unreachable schemas; do NOT raise the budget');
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   if (report.status === 'reserve-breached') {
     console.warn(

--- a/scripts/openapi-drop-unreachable-schemas.mjs
+++ b/scripts/openapi-drop-unreachable-schemas.mjs
@@ -14,8 +14,10 @@
  * documents something only through the `$ref` that points at it. A schema with
  * no inbound pointer documents nothing a client, agent or scanner can arrive
  * at. Every operation, request body, response and parameter survives untouched,
- * and `tests/openapi-unreachable-schemas.test.mjs` proves it: no dangling
- * `$ref` remains, every retained schema is byte-identical, and nothing outside
+ * and `tests/openapi-unreachable-schemas.test.mjs` proves it: no schema name
+ * mentioned anywhere in the served document is left unresolvable — checked by
+ * scanning the serialized text, not by re-running this file's own notion of a
+ * reference — every retained schema is byte-identical, and nothing outside
  * `components.schemas` changes.
  *
  * Reachability is transitive and computed from the whole document rather than
@@ -32,12 +34,29 @@
 
 const SCHEMA_REF_PREFIX = '#/components/schemas/';
 
+/** `#/components/schemas/Foo/properties/bar` -> `Foo`; null when it is not one. */
+function schemaNameFromPointer(value) {
+  if (typeof value !== 'string' || !value.startsWith(SCHEMA_REF_PREFIX)) return null;
+  const segment = value.slice(SCHEMA_REF_PREFIX.length).split('/')[0];
+  // RFC 6901 escaping. Component names cannot contain `/` or `~` today, so this
+  // is belt-and-braces — but the failure direction of getting it wrong is
+  // deleting a live schema, which is the one direction that must not happen.
+  return segment.replaceAll('~1', '/').replaceAll('~0', '~') || null;
+}
+
 /**
  * Component-schema names referenced anywhere inside `node`.
  *
- * Takes the first pointer segment after the prefix, so a pointer *into* a
- * schema (`#/components/schemas/Foo/properties/bar`) counts as a reference to
- * `Foo` — dropping `Foo` would strand it.
+ * A pointer *into* a schema (`#/components/schemas/Foo/properties/bar`) counts
+ * as a reference to `Foo` — dropping `Foo` would strand it.
+ *
+ * `$ref` is not the whole vocabulary. OpenAPI 3.1 also lets a document name a
+ * component schema through `discriminator.mapping`, whose values are either a
+ * bare component name or a URI reference and carry NO `$ref` key — a walk that
+ * matches only on the key deletes those targets and strands the mapping. The
+ * bundle carries no discriminator today, which is exactly why this has to be
+ * handled here rather than noticed later: the first proto to add one would
+ * silently lose its subtypes. `$dynamicRef` is covered for the same reason.
  */
 export function collectSchemaRefs(node, into = new Set()) {
   if (Array.isArray(node)) {
@@ -46,9 +65,22 @@ export function collectSchemaRefs(node, into = new Set()) {
   }
   if (!node || typeof node !== 'object') return into;
   for (const [key, value] of Object.entries(node)) {
-    if (key === '$ref' && typeof value === 'string' && value.startsWith(SCHEMA_REF_PREFIX)) {
-      into.add(value.slice(SCHEMA_REF_PREFIX.length).split('/')[0]);
-      continue;
+    if (key === '$ref' || key === '$dynamicRef') {
+      const name = schemaNameFromPointer(value);
+      if (name) {
+        into.add(name);
+        continue;
+      }
+    }
+    if (key === 'discriminator' && value && typeof value === 'object' && value.mapping
+      && typeof value.mapping === 'object') {
+      for (const target of Object.values(value.mapping)) {
+        if (typeof target !== 'string' || target.length === 0) continue;
+        // Either `#/components/schemas/Foo` or the bare name `Foo`. An external
+        // URI resolves to neither and is left alone.
+        const name = schemaNameFromPointer(target) ?? (target.includes('/') ? null : target);
+        if (name) into.add(name);
+      }
     }
     collectSchemaRefs(value, into);
   }

--- a/scripts/openapi-drop-unreachable-schemas.mjs
+++ b/scripts/openapi-drop-unreachable-schemas.mjs
@@ -1,0 +1,119 @@
+/**
+ * Drop component schemas that nothing in the document can reach.
+ *
+ * Why: the sebuf generator emits one component schema per RPC message, but a
+ * GET operation spends its request message as `parameters` and never points at
+ * the request schema. On the 2026-08-13 bundle that left 210 of 844 schemas —
+ * 93,582 bytes, ~10% of the artifact — carried, served, and counted against the
+ * ~1 MB scanner body cap while being unreachable from every operation,
+ * response, parameter, header and sibling schema. The budget had 3,318 bytes
+ * left at the time (#6558); this returns thirty times that.
+ *
+ * Why this is lossless for the OpenAPI contract: a Schema Object in
+ * `components.schemas` is not itself part of any operation's contract — it
+ * documents something only through the `$ref` that points at it. A schema with
+ * no inbound pointer documents nothing a client, agent or scanner can arrive
+ * at. Every operation, request body, response and parameter survives untouched,
+ * and `tests/openapi-unreachable-schemas.test.mjs` proves it: no dangling
+ * `$ref` remains, every retained schema is byte-identical, and nothing outside
+ * `components.schemas` changes.
+ *
+ * Reachability is transitive and computed from the whole document rather than
+ * from operations alone, so a schema referenced only by a hoisted
+ * `components.responses` / `components.parameters` entry (the dedup passes
+ * create those) survives, as does one reached through a nested JSON pointer
+ * such as `#/components/schemas/Foo/properties/bar` — that pointer needs `Foo`.
+ *
+ * Like the dedup passes, this runs ONLY when emitting `public/openapi.json`
+ * (build-openapi-json.mjs). `docs/api/worldmonitor.openapi.yaml` keeps every
+ * schema, so Mintlify, the injectors and the contract tests still see the full
+ * generated document.
+ */
+
+const SCHEMA_REF_PREFIX = '#/components/schemas/';
+
+/**
+ * Component-schema names referenced anywhere inside `node`.
+ *
+ * Takes the first pointer segment after the prefix, so a pointer *into* a
+ * schema (`#/components/schemas/Foo/properties/bar`) counts as a reference to
+ * `Foo` — dropping `Foo` would strand it.
+ */
+export function collectSchemaRefs(node, into = new Set()) {
+  if (Array.isArray(node)) {
+    for (const child of node) collectSchemaRefs(child, into);
+    return into;
+  }
+  if (!node || typeof node !== 'object') return into;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '$ref' && typeof value === 'string' && value.startsWith(SCHEMA_REF_PREFIX)) {
+      into.add(value.slice(SCHEMA_REF_PREFIX.length).split('/')[0]);
+      continue;
+    }
+    collectSchemaRefs(value, into);
+  }
+  return into;
+}
+
+/**
+ * Names in `components.schemas` that nothing can reach.
+ *
+ * @param {object} spec
+ * @returns {Set<string>}
+ */
+export function unreachableSchemaNames(spec) {
+  const schemas = spec?.components?.schemas;
+  if (!schemas || typeof schemas !== 'object') return new Set();
+
+  // Seed from everything that is NOT a component schema: paths, webhooks, and
+  // the other component buckets. Seeding from the other buckets unconditionally
+  // is the conservative direction — it can only keep a schema alive, never
+  // strand one — and it is what makes the pass safe to run after the dedup
+  // passes have hoisted responses and parameters out of the operations.
+  const seeds = new Set();
+  for (const [key, value] of Object.entries(spec)) {
+    if (key === 'components') continue;
+    collectSchemaRefs(value, seeds);
+  }
+  for (const [bucket, value] of Object.entries(spec.components)) {
+    if (bucket === 'schemas') continue;
+    collectSchemaRefs(value, seeds);
+  }
+
+  const reachable = new Set();
+  const queue = [...seeds];
+  while (queue.length > 0) {
+    const name = queue.pop();
+    // A pointer at a name that does not exist is a pre-existing dangling ref,
+    // not something this pass created; ignore it rather than inventing an entry.
+    if (reachable.has(name) || !Object.hasOwn(schemas, name)) continue;
+    reachable.add(name);
+    for (const nested of collectSchemaRefs(schemas[name])) {
+      if (!reachable.has(nested)) queue.push(nested);
+    }
+  }
+
+  return new Set(Object.keys(schemas).filter((name) => !reachable.has(name)));
+}
+
+/**
+ * Remove unreachable component schemas. Mutates `spec` in place.
+ *
+ * `bytesFreed` is measured, not summed from the parts: it is the difference
+ * between the serialized document before and after, so key separators and the
+ * name keys themselves are all accounted for.
+ *
+ * @param {object} spec
+ * @returns {{ dropped: number, bytesFreed: number, names: string[] }}
+ */
+export function dropUnreachableSchemas(spec) {
+  const names = [...unreachableSchemaNames(spec)];
+  if (names.length === 0) return { dropped: 0, bytesFreed: 0, names: [] };
+
+  const before = Buffer.byteLength(JSON.stringify(spec), 'utf8');
+  for (const name of names) delete spec.components.schemas[name];
+  if (Object.keys(spec.components.schemas).length === 0) delete spec.components.schemas;
+  const after = Buffer.byteLength(JSON.stringify(spec), 'utf8');
+
+  return { dropped: names.length, bytesFreed: before - after, names };
+}

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -807,6 +807,22 @@ describe('CI workflow coverage', () => {
       /path: \$\{\{ runner\.temp \}\}\/openapi-capacity\.json/,
       'the capacity artifact must be read from the same path the step wrote',
     );
+    // `if: failure()` would publish nothing on a green run and `if: success()`
+    // nothing on a red one; the breakdown is worth reading in both cases, and
+    // an over-budget run is when it matters most. Narrowing this to either
+    // would stop publishing on exactly the runs someone goes looking for it.
+    const upload = unit.slice(unit.indexOf('- name: Upload OpenAPI capacity report'));
+    assert.match(
+      upload.slice(0, upload.indexOf('- name: ', 1)),
+      /if: \$\{\{ !cancelled\(\) \}\}/,
+      'the capacity artifact must be uploaded whether the step passed or failed',
+    );
+    // The report must run BEFORE the suite: an over-budget artifact fails
+    // test:data anyway, and failing at the front costs 30s instead of 10min.
+    assert.ok(
+      unit.indexOf('openapi-capacity-report.mjs') < unit.indexOf('npm run test:data'),
+      'the capacity report must run before the test suite',
+    );
   });
 
   it('keeps resilience validation bundle inputs in the CI change filter', () => {

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -786,13 +786,26 @@ describe('CI workflow coverage', () => {
     const unit = testJobBlock('unit');
     assert.match(
       unit,
-      /^\s+run: node scripts\/openapi-capacity-report\.mjs --out openapi-capacity\.json\s*$/m,
+      /^\s+run: node scripts\/openapi-capacity-report\.mjs --out "\$RUNNER_TEMP\/openapi-capacity\.json"\s*$/m,
       'unit job must publish the OpenAPI capacity report',
+    );
+    // No `--budget`: the step must measure against the real 950,000 guard. The
+    // flag exists for local what-if analysis and to exercise the over-budget
+    // exit in tests, and passing it here would be the one-line way to make the
+    // reported headroom mean nothing.
+    assert.ok(
+      !/openapi-capacity-report\.mjs[^\n]*--budget/.test(unit),
+      'the CI step must not override the scanner budget',
     );
     assert.match(
       unit,
       /name: openapi-capacity-\$\{\{ github\.run_attempt \}\}/,
       'the capacity artifact name must carry run_attempt — upload-artifact v6 rejects a duplicate name within a run, which collides on the re-run started to chase the failure',
+    );
+    assert.match(
+      unit,
+      /path: \$\{\{ runner\.temp \}\}\/openapi-capacity\.json/,
+      'the capacity artifact must be read from the same path the step wrote',
     );
   });
 

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -763,6 +763,39 @@ describe('CI workflow coverage', () => {
     }
   });
 
+  it('routes the generated OpenAPI bundle into the job that measures it (#6558)', () => {
+    // Executes the real awk rather than matching its source. The bundle lives
+    // under `docs/`, which the blanket `/^docs\// { next }` rule excludes, so
+    // this carve-out is the only thing keeping a bundle-only PR from setting
+    // code=false and skipping `unit` — the job that runs BOTH the
+    // <= 950,000-byte scanner guard and the capacity report, against the very
+    // artifact such a PR changes.
+    const awkBlock = shellAwkAssignmentBlock('CODE');
+    const codeFilterSays = (path: string) => evaluateAwkAssignmentBlock(awkBlock, [path]) > 0;
+
+    assert.ok(
+      codeFilterSays('docs/api/worldmonitor.openapi.yaml'),
+      'a PR that only regenerates the unified OpenAPI bundle must still run the unit job',
+    );
+    // Prose under docs/ stays excluded — the carve-out is for the machine
+    // artifact, not for the directory.
+    for (const path of ['docs/api-reference.mdx', 'docs/perf/openapi-bundle-capacity-2026-08-13.md']) {
+      assert.ok(!codeFilterSays(path), `${path} must not set code=true`);
+    }
+
+    const unit = testJobBlock('unit');
+    assert.match(
+      unit,
+      /^\s+run: node scripts\/openapi-capacity-report\.mjs --out openapi-capacity\.json\s*$/m,
+      'unit job must publish the OpenAPI capacity report',
+    );
+    assert.match(
+      unit,
+      /name: openapi-capacity-\$\{\{ github\.run_attempt \}\}/,
+      'the capacity artifact name must carry run_attempt — upload-artifact v6 rejects a duplicate name within a run, which collides on the re-run started to chase the failure',
+    );
+  });
+
   it('keeps resilience validation bundle inputs in the CI change filter', () => {
     assert.ok(
       testWorkflow.includes('validation: ${{ steps.diff.outputs.validation }}'),

--- a/tests/openapi-capacity-report.test.mjs
+++ b/tests/openapi-capacity-report.test.mjs
@@ -4,7 +4,7 @@ import { existsSync, mkdtempSync, readFileSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { loadUnifiedOpenApiSpec } from './_lib/openapi-spec-cache.mjs';
 
 import { buildBundle } from '../scripts/build-openapi-json.mjs';
@@ -208,6 +208,18 @@ describe('contributor breakdowns', () => {
   it('escapes path separators so the pointers are valid JSON Pointers', () => {
     const pointers = sectionBreakdown({ 'a/b': { x: 1 } }).map((s) => s.pointer);
     assert.deepEqual(pointers, ['/a~1b'], 'a "/" inside a key must be escaped as ~1');
+  });
+
+  it('charges webhook operations too, not only paths', () => {
+    // countOperations walks paths AND webhooks; a field breakdown that walked
+    // only paths would divide real bytes by an inflated operation count.
+    const spec = {
+      paths: { '/a': { get: { description: 'x'.repeat(100) } } },
+      webhooks: { ping: { post: { description: 'y'.repeat(100) } } },
+    };
+    const [description] = operationFieldBreakdown(spec);
+    assert.equal(description.bytes > 200, true, 'both operations must be counted');
+    assert.equal(description.bytesPerOperation, Math.round(description.bytes / 2));
   });
 });
 
@@ -470,6 +482,23 @@ describe('CLI', () => {
     assert.match(result.stderr, /NOT MEASURED/);
   });
 
+  it('warns without failing when the reserve is breached', () => {
+    // The advisory band, and the only path that prints the plan-doc pointer.
+    // A budget just above the current size leaves positive headroom below the
+    // three-operation reserve.
+    const budget = realBundle.bytes + 1900;
+    const result = run(['--budget', String(budget)]);
+    assert.equal(result.status, 0, 'a breached reserve advises, it does not fail the build');
+    assert.match(result.stderr, /::warning::OpenAPI bundle reserve breached/);
+    assert.match(result.stderr, /docs\/perf\/openapi-bundle-capacity-2026-08-13\.md/);
+  });
+
+  it('exits 2 when --out cannot be written', () => {
+    const result = run(['--out', tmpdir()]); // a directory, not a file
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /cannot write/);
+  });
+
   it('exits 2 on misuse rather than reporting a number it did not measure', () => {
     for (const args of [['--nope'], ['--out'], ['--budget', 'x'], ['--budget', '-1']]) {
       assert.equal(run(args).status, 2, `${args.join(' ')} must be a usage error`);
@@ -488,6 +517,22 @@ describe('build-openapi-json CLI', () => {
     assert.ok(existsSync(artifact), 'the build must write the artifact');
     assert.equal(statSync(artifact).size, realBundle.bytes);
     assert.match(result.stdout, /dropped \d+ unreachable schemas/);
+  });
+
+  it('writes nothing when the module is merely imported', () => {
+    // The whole point of the invokedDirectly guard: the capacity report and
+    // three test files import this module for measurement. If the guard stopped
+    // matching, every import would rewrite the served artifact as a side
+    // effect. Asserted through the log line main() prints, so the check itself
+    // cannot disturb the file it is protecting.
+    const probe = spawnSync(
+      'node',
+      ['--input-type=module', '-e', `import ${JSON.stringify(pathToFileURL(buildScript).href)}; console.log('IMPORTED');`],
+      { cwd: root, encoding: 'utf8' },
+    );
+    assert.equal(probe.status, 0, probe.stderr);
+    assert.equal(probe.stdout.trim(), 'IMPORTED');
+    assert.ok(!/build-openapi-json: wrote/.test(probe.stdout), 'importing must not run main()');
   });
 
   it('refuses a source that is not an OpenAPI document', () => {

--- a/tests/openapi-capacity-report.test.mjs
+++ b/tests/openapi-capacity-report.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { execFileSync, spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
@@ -10,6 +10,7 @@ import { loadUnifiedOpenApiSpec } from './_lib/openapi-spec-cache.mjs';
 import { buildBundle } from '../scripts/build-openapi-json.mjs';
 import {
   ESTIMATED_REF_BYTES,
+  MIN_PLAUSIBLE_OPERATIONS,
   RESERVE_OPERATIONS,
   SCANNER_BUDGET_BYTES,
   buildCapacityReport,
@@ -20,17 +21,25 @@ import {
   unreferencedComponentSchemas,
 } from '../scripts/openapi-capacity-report.mjs';
 
-// The <= 950,000-byte guard in tests/openapi-json-dedup.test.mjs only speaks
-// the moment it breaks. #4852, the food-stocks operation and the
+// The <= 950,000-byte guard in tests/openapi-json-dedup.test.mjs only speaks the
+// moment it breaks. #4852, the food-stocks operation and the
 // billing-verification 503 each crossed the cap and were discovered by a red
 // build on whichever PR happened to be last in line. This report is the number
 // the guard is silent about on the way there, so the properties worth pinning
 // are the ones that would let it lie: measuring bytes the build does not emit,
-// reporting a comfortable headroom for a bundle that generated nothing, and
-// promising the same bytes twice when repeated structures nest.
+// reporting a comfortable headroom for a bundle that generated almost nothing,
+// and promising the same bytes twice when repeated structures nest.
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const reportScript = resolve(root, 'scripts/openapi-capacity-report.mjs');
+const buildScript = resolve(root, 'scripts/build-openapi-json.mjs');
+const planPath = 'docs/perf/openapi-bundle-capacity-2026-08-13.md';
+
+// One build of the real bundle for every test that needs it. The source YAML is
+// 2.6 MB and each build re-walks the whole document; the sibling
+// tests/openapi-json-dedup.test.mjs hoists its fixture for the same reason.
+const realBundle = buildBundle({ spec: loadUnifiedOpenApiSpec() });
+const realReport = buildCapacityReport(realBundle);
 
 /** A bundle shaped like buildBundle()'s return, with the bytes we want to test. */
 const fakeBundle = (spec, bytes) => ({
@@ -47,37 +56,41 @@ const oneOperationSpec = () => ({
   paths: { '/a': { get: { responses: { 200: { description: 'ok' } } }, summary: 'not an operation' } },
 });
 
+/** Synthetic spec with `count` operations, for the plausibility floor. */
+const nOperationSpec = (count) => {
+  const paths = {};
+  for (let i = 0; i < count; i++) paths[`/p${i}`] = { get: { responses: { 200: { description: 'ok' } } } };
+  return { openapi: '3.1.0', paths };
+};
+
 describe('buildCapacityReport — budget arithmetic', () => {
   it('measures the bytes the build actually emits, in UTF-8', () => {
-    const bundle = buildBundle({ spec: loadUnifiedOpenApiSpec() });
-    const report = buildCapacityReport(bundle);
-    assert.equal(report.bytes, bundle.bytes);
-    assert.equal(report.bytes, Buffer.byteLength(bundle.json, 'utf8'));
+    assert.equal(realReport.bytes, realBundle.bytes);
+    assert.equal(realReport.bytes, Buffer.byteLength(realBundle.json, 'utf8'));
     // The distinction is the point: the cap is a body-size cap in bytes, and
     // the bundle's non-ASCII punctuation makes String#length a different — and
     // always smaller — number.
     assert.ok(
-      bundle.bytes > bundle.json.length,
+      realBundle.bytes > realBundle.json.length,
       'the bundle carries non-ASCII text, so bytes must exceed UTF-16 code units',
     );
-    assert.equal(report.headroomBytes, SCANNER_BUDGET_BYTES - bundle.bytes);
+    assert.equal(realReport.headroomBytes, SCANNER_BUDGET_BYTES - realBundle.bytes);
   });
 
   it('sits inside the budget with the reserve intact', () => {
     // Not a restatement of the guard: this asserts the RESERVE, which the guard
     // does not check. A green guard with a breached reserve is the state #6558
     // was filed from (3,318 bytes left of 950,000).
-    const report = buildCapacityReport(buildBundle({ spec: loadUnifiedOpenApiSpec() }));
     assert.equal(
-      report.status,
+      realReport.status,
       'ok',
-      `capacity is ${report.status}: ${report.headroomBytes} bytes left, reserve is ${report.reserveBytes}`,
+      `capacity is ${realReport.status}: ${realReport.headroomBytes} bytes left, reserve is ${realReport.reserveBytes}`,
     );
   });
 
   it('pins both directions of the reserve boundary', () => {
     const at = (budgetBytes) =>
-      buildCapacityReport(fakeBundle(oneOperationSpec(), 100), { budgetBytes });
+      buildCapacityReport(fakeBundle(oneOperationSpec(), 100), { budgetBytes, minOperations: 1 });
     // One operation costing 100 bytes ⇒ reserve = 3 × 100.
     assert.equal(at(400).reserveBytes, 100 * RESERVE_OPERATIONS);
     assert.equal(at(400).status, 'ok', 'headroom exactly equal to the reserve is not a breach');
@@ -86,36 +99,68 @@ describe('buildCapacityReport — budget arithmetic', () => {
 
   it('pins both directions of the budget boundary', () => {
     const at = (budgetBytes) =>
-      buildCapacityReport(fakeBundle(oneOperationSpec(), 100), { budgetBytes });
+      buildCapacityReport(fakeBundle(oneOperationSpec(), 100), { budgetBytes, minOperations: 1 });
     assert.equal(at(100).status, 'reserve-breached', 'zero headroom is still within budget');
     assert.equal(at(100).headroomBytes, 0);
     assert.equal(at(99).status, 'over-budget');
     assert.equal(at(99).headroomBytes, -1);
   });
 
+  it('keeps the reserve reachable when the mean operation rounds toward zero', () => {
+    // bytesPerOperation floors at 1; without that, reserveBytes is 0 and
+    // `reserve-breached` becomes unreachable from both sides.
+    const report = buildCapacityReport(fakeBundle(nOperationSpec(100), 10), { budgetBytes: 1000 });
+    assert.ok(report.bytesPerOperation >= 1);
+    assert.ok(report.reserveBytes > 0, 'a zero reserve can never be breached');
+  });
+
   it('counts operations across paths and webhooks, and only real HTTP methods', () => {
     const spec = oneOperationSpec();
     spec.webhooks = { ping: { post: { responses: {} }, description: 'not an operation' } };
-    const report = buildCapacityReport(fakeBundle(spec, 100), { budgetBytes: 1000 });
+    const report = buildCapacityReport(fakeBundle(spec, 100), { budgetBytes: 1000, minOperations: 1 });
     assert.equal(report.operations, 2);
     assert.equal(report.bytesPerOperation, 50);
     assert.equal(report.operationsRemaining, Math.floor(900 / 50));
   });
 
-  it('refuses to call an empty bundle healthy', () => {
-    // The dangerous direction. A build that emitted nothing has enormous
-    // "headroom", and reporting that as a pass is precisely how a gate goes
-    // green while measuring nothing.
-    const noOperations = buildCapacityReport(fakeBundle({ openapi: '3.1.0', paths: {} }, 500));
-    assert.equal(noOperations.status, 'unmeasured');
-    assert.match(noOperations.reason, /zero operations/);
-
-    const noBytes = buildCapacityReport(fakeBundle(oneOperationSpec(), 0));
+  it('refuses to call an empty or partial bundle healthy', () => {
+    // The dangerous direction. A build that emitted little or nothing has
+    // enormous "headroom", and reporting that as a pass is precisely how a gate
+    // goes green while measuring nothing.
+    const noBytes = buildCapacityReport(fakeBundle(nOperationSpec(200), 0));
     assert.equal(noBytes.status, 'unmeasured');
     assert.match(noBytes.reason, /nothing was generated/);
 
-    for (const report of [noOperations, noBytes]) {
+    // The PLAUSIBLE failure, which a zero-only check cannot see: a codegen or
+    // injector change that emits a handful of operations instead of 218.
+    const partial = buildCapacityReport(fakeBundle(nOperationSpec(5), 4000));
+    assert.equal(partial.status, 'unmeasured');
+    assert.match(partial.reason, /only 5 operations/);
+
+    for (const report of [noBytes, partial]) {
       assert.equal(report.headroomBytes, undefined, 'an unmeasured bundle must not publish headroom');
+    }
+  });
+
+  it('puts the real bundle far above the plausibility floor', () => {
+    // Guards the floor from the other side: a floor set above the real
+    // operation count would make every run unmeasured.
+    assert.ok(
+      realReport.operations >= MIN_PLAUSIBLE_OPERATIONS * 2,
+      `only ${realReport.operations} operations against a ${MIN_PLAUSIBLE_OPERATIONS} floor`,
+    );
+  });
+
+  it('reports transform engagement from each transform’s own counts', () => {
+    // Derived from the returned stats, not re-derived from the transformed
+    // document: a disengaged transform and a document with nothing left to do
+    // are indistinguishable from the output side.
+    for (const [name, entry] of Object.entries(realReport.transforms)) {
+      assert.equal(entry.engaged, true, `${name} did no work on the real bundle`);
+    }
+    const idle = buildCapacityReport(fakeBundle(nOperationSpec(200), 4000)).transforms;
+    for (const [name, entry] of Object.entries(idle)) {
+      assert.equal(entry.engaged, false, `${name} must report disengagement`);
     }
   });
 });
@@ -151,6 +196,15 @@ describe('contributor breakdowns', () => {
     assert.equal(description.bytesPerOperation, Math.round(description.bytes / 2));
   });
 
+  it('measures a non-ASCII field key in bytes, not UTF-16 code units', () => {
+    // The same error class the whole report exists to stop making, one level
+    // down: `field.length` undercounts every multi-byte key.
+    const spec = { paths: { '/a': { get: { 'x-π': 'v' } } } };
+    const [field] = operationFieldBreakdown(spec);
+    assert.equal(field.field, 'x-π');
+    assert.equal(field.bytes, Buffer.byteLength(JSON.stringify('v'), 'utf8') + Buffer.byteLength('x-π', 'utf8') + 4);
+  });
+
   it('escapes path separators so the pointers are valid JSON Pointers', () => {
     const pointers = sectionBreakdown({ 'a/b': { x: 1 } }).map((s) => s.pointer);
     assert.deepEqual(pointers, ['/a~1b'], 'a "/" inside a key must be escaped as ~1');
@@ -158,18 +212,18 @@ describe('contributor breakdowns', () => {
 });
 
 describe('repeatedStructures — no promising the same bytes twice', () => {
-  const wrapper = (fill) => ({
-    description: fill,
-    child: { description: fill, marker: 'inner' },
-  });
+  // Fixtures use real OpenAPI positions, because the estimate is only allowed
+  // to count places a `$ref` could actually go.
+  const schemaSpec = (properties) => ({ components: { schemas: { S: { properties } } } });
 
-  it('counts a repeated parent OR its repeated child, never both', () => {
+  it('counts a repeated parent OR its repeated child, never both (parent wins first)', () => {
     const fill = 'z'.repeat(200);
-    const spec = { a: wrapper(fill), b: wrapper(fill), c: wrapper(fill) };
-    const result = repeatedStructures(spec, { minBytes: 64 });
+    const properties = {};
+    for (let i = 0; i < 3; i++) {
+      properties[`w${i}`] = { description: fill, properties: { inner: { description: fill, type: 'string' } } };
+    }
+    const result = repeatedStructures(schemaSpec(properties), { minBytes: 64 });
 
-    // The child repeats three times too, but every copy lives inside a parent
-    // already selected for hoisting — those bytes can only be spent once.
     assert.equal(result.groups, 1, 'the nested repeat must not be counted separately');
     const [top] = result.top;
     assert.equal(top.occurrences, 3);
@@ -177,25 +231,124 @@ describe('repeatedStructures — no promising the same bytes twice', () => {
     assert.equal(result.estimatedRecoverableBytes, top.estimatedRecoverableBytes);
   });
 
-  it('still counts a repeat that sits outside every selected subtree', () => {
+  it('counts a repeated parent OR its repeated child, never both (child wins first)', () => {
+    // The direction an ancestors-only filter misses. The child repeats 30 times
+    // and outranks the wrapper, so it is selected first; the wrapper then looks
+    // "free" because none of its copies sits INSIDE a selection — each one
+    // CONTAINS one. Crediting it re-sells bytes already counted.
+    const child = () => ({ description: 'c'.repeat(80), type: 'string' });
+    const properties = {};
+    for (let i = 0; i < 27; i++) properties[`f${i}`] = child();
+    for (let i = 0; i < 3; i++) {
+      properties[`w${i}`] = { description: 'p'.repeat(300), properties: { inner: child() } };
+    }
+
+    const result = repeatedStructures(schemaSpec(properties), { minBytes: 64 });
+    assert.equal(result.groups, 1, 'the wrapper overlaps the already-counted children');
+    assert.equal(result.top[0].occurrences, 30);
+    assert.equal(
+      result.estimatedRecoverableBytes,
+      29 * (result.top[0].unitBytes - ESTIMATED_REF_BYTES),
+    );
+  });
+
+  it('publishes pointers that name occurrences the entry actually counted', () => {
     const fill = 'z'.repeat(200);
-    const loose = { description: fill, marker: 'inner' };
-    const spec = { a: wrapper(fill), b: wrapper(fill), c: wrapper(fill), d: loose, e: loose };
-    const result = repeatedStructures(spec, { minBytes: 64 });
+    const inner = () => ({ description: fill, type: 'string' });
+    const properties = {};
+    for (let i = 0; i < 3; i++) {
+      properties[`w${i}`] = { description: fill, properties: { inner: inner() } };
+    }
+    properties.d = inner();
+    properties.e = inner();
+
+    const result = repeatedStructures(schemaSpec(properties), { minBytes: 64 });
     assert.equal(result.groups, 2);
-    assert.equal(result.top[1].occurrences, 2, 'only the two free copies count');
+
+    const free = result.top.find((r) => r.occurrences === 2);
+    assert.ok(free, 'the two copies outside the selected wrappers form their own entry');
+    // A pointer naming an excluded copy would send the reader to a location the
+    // count did not include.
+    for (const pointer of free.pointers) {
+      assert.ok(
+        /\/properties\/(d|e)$/.test(pointer),
+        `${pointer} is not one of the counted occurrences`,
+      );
+    }
+  });
+
+  it('does not price a container map, or a Media Type Object, as one hoistable unit', () => {
+    // `responses.200.headers` is a Map[string, Header | Reference]: each ENTRY
+    // can become a $ref, the map cannot. `content['application/json']` is a
+    // Media Type Object, where OpenAPI 3.1 allows no Reference at all.
+    const header = () => ({ description: 'h'.repeat(120), schema: { type: 'string' } });
+    const mediaType = () => ({ schema: { description: 'm'.repeat(120), type: 'object' } });
+    const response = () => ({ headers: { A: header(), B: header() }, content: { 'application/json': mediaType() } });
+    const spec = {
+      paths: {
+        '/a': { get: { responses: { 200: response() } } },
+        '/b': { get: { responses: { 200: response() } } },
+      },
+    };
+    const result = repeatedStructures(spec, { minBytes: 64 });
+    for (const entry of result.top) {
+      for (const pointer of entry.pointers) {
+        assert.ok(!pointer.endsWith('/headers'), `the headers MAP is not referenceable: ${pointer}`);
+        assert.ok(!pointer.endsWith('/application~1json'), `a Media Type Object is not referenceable: ${pointer}`);
+      }
+    }
+    assert.ok(result.groups > 0, 'the individual header entries and schemas are still candidates');
+  });
+
+  it('never offers a 2xx response, which must stay inline for the scanner', () => {
+    const body = () => ({ description: 'r'.repeat(200), content: { 'application/json': { schema: { type: 'object' } } } });
+    const spec = {
+      paths: {
+        '/a': { get: { responses: { 200: body(), 503: body() } } },
+        '/b': { get: { responses: { 200: body(), 503: body() } } },
+      },
+    };
+    const result = repeatedStructures(spec, { minBytes: 64 });
+    for (const entry of result.top) {
+      for (const pointer of entry.pointers) {
+        assert.ok(!/\/responses\/2\d\d$/.test(pointer), `2xx responses stay inline: ${pointer}`);
+      }
+    }
+    // The non-2xx twin is still fair game, so this is not vacuous.
+    assert.ok(
+      result.top.some((entry) => entry.pointers.some((p) => p.endsWith('/responses/503'))),
+      'the repeated 503 body is a legitimate candidate',
+    );
+  });
+
+  it('does not price repeated example payloads, which no $ref can replace', () => {
+    const payload = { company: { name: 'x'.repeat(200), id: 'abc' } };
+    const spec = {
+      paths: {
+        '/a': { post: { responses: { 503: { content: { 'application/json': { example: structuredClone(payload) } } } } } },
+        '/b': { post: { responses: { 503: { content: { 'application/json': { example: structuredClone(payload) } } } } } },
+      },
+    };
+    // The repeated 503 wrapper is a candidate; the example payload inside it is
+    // not, at any depth — an example that repeats is a documentation choice,
+    // not repetition a component can absorb.
+    const result = repeatedStructures(spec, { minBytes: 64 });
+    for (const entry of result.top) {
+      for (const pointer of entry.pointers) {
+        assert.ok(!pointer.includes('/example'), `example payloads are not candidates: ${pointer}`);
+      }
+    }
   });
 
   it('ignores subtrees too small to be worth a $ref, and singletons', () => {
-    const spec = { a: { t: 'string' }, b: { t: 'string' }, c: { description: 'q'.repeat(300) } };
+    const spec = schemaSpec({ a: { t: 'string' }, b: { t: 'string' }, c: { description: 'q'.repeat(300) } });
     assert.deepEqual(repeatedStructures(spec), { estimatedRecoverableBytes: 0, groups: 0, top: [] });
   });
 
   it('finds real repetition left in the served bundle', () => {
     // Vacuity guard: a walk that silently visits nothing would satisfy every
     // assertion above while reporting an empty reduction plan forever.
-    const { spec } = buildBundle({ spec: loadUnifiedOpenApiSpec() });
-    const result = repeatedStructures(spec);
+    const result = realReport.repeatedStructures;
     assert.ok(result.groups > 20, `expected repeated structure in a generated spec, got ${result.groups}`);
     assert.ok(result.estimatedRecoverableBytes > 10_000, `only ${result.estimatedRecoverableBytes} bytes ranked`);
     assert.ok(result.top.length > 0 && result.top[0].pointers.length > 0);
@@ -205,10 +358,9 @@ describe('repeatedStructures — no promising the same bytes twice', () => {
   });
 });
 
-describe('unreferencedComponentSchemas — the drop’s regression detector', () => {
+describe('unreferencedComponentSchemas', () => {
   it('reads zero on the served bundle, because buildBundle already dropped them', () => {
-    const { spec } = buildBundle({ spec: loadUnifiedOpenApiSpec() });
-    assert.deepEqual(unreferencedComponentSchemas(spec), { count: 0, bytes: 0, names: [] });
+    assert.deepEqual(unreferencedComponentSchemas(realBundle.spec), { count: 0, bytes: 0, names: [] });
   });
 
   it('reports the exact byte cost when orphans are present', () => {
@@ -224,61 +376,132 @@ describe('unreferencedComponentSchemas — the drop’s regression detector', ()
     delete spec.components.schemas.Orphan;
     assert.equal(result.bytes, before - Buffer.byteLength(JSON.stringify(spec), 'utf8'));
   });
+
+  it('mirrors the transform when every schema is an orphan', () => {
+    // The transform deletes an emptied `components.schemas`; a trimmed copy that
+    // keeps `"schemas":{}` undercounts the saving by those bytes.
+    const spec = {
+      openapi: '3.1.0',
+      paths: {},
+      components: { schemas: { Orphan: { description: 'x'.repeat(200) } } },
+    };
+    const before = Buffer.byteLength(JSON.stringify(spec), 'utf8');
+    const result = unreferencedComponentSchemas(spec);
+    delete spec.components.schemas;
+    assert.equal(result.bytes, before - Buffer.byteLength(JSON.stringify(spec), 'utf8'));
+  });
 });
 
 describe('formatMarkdown', () => {
-  it('leads with the numbers a reviewer needs and never hides an unmeasured run', () => {
-    const report = buildCapacityReport(buildBundle({ spec: loadUnifiedOpenApiSpec() }));
-    const markdown = formatMarkdown(report);
+  it('leads with the numbers a reviewer needs', () => {
+    const markdown = formatMarkdown(realReport);
     assert.match(markdown, /OpenAPI bundle capacity/);
-    assert.ok(markdown.includes(report.bytes.toLocaleString('en-US')));
-    assert.ok(markdown.includes(report.headroomBytes.toLocaleString('en-US')));
+    assert.ok(markdown.includes(realReport.bytes.toLocaleString('en-US')));
+    assert.ok(markdown.includes(realReport.headroomBytes.toLocaleString('en-US')));
+    assert.match(markdown, /within budget/);
     // The plan path is pointed at from the job summary and the CI annotation,
     // so a rename that leaves those strings behind sends every future reader to
     // a 404 without anything going red.
-    const planPath = 'docs/perf/openapi-bundle-capacity-2026-08-13.md';
     assert.ok(markdown.includes(planPath));
     assert.ok(existsSync(resolve(root, planPath)), `${planPath} must exist — the report links to it`);
+  });
 
-    const dead = formatMarkdown(buildCapacityReport(fakeBundle({ openapi: '3.1.0', paths: {} }, 500)));
+  it('renders every status verdict, and never makes an unmeasured run read as a pass', () => {
+    const at = (budgetBytes) =>
+      formatMarkdown(buildCapacityReport(fakeBundle(oneOperationSpec(), 100), { budgetBytes, minOperations: 1 }));
+    assert.match(at(399), /below the 3-operation reserve/);
+    assert.match(at(99), /OVER BUDGET/);
+
+    const dead = formatMarkdown(buildCapacityReport(fakeBundle(nOperationSpec(200), 0)));
     assert.match(dead, /NOT MEASURED/);
     assert.ok(!/within budget/.test(dead), 'an unmeasured run must not read as a pass');
   });
 });
 
 describe('CLI', () => {
+  const run = (args, env = {}) =>
+    spawnSync('node', [reportScript, ...args], {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    });
+
   it('writes the report to --out, stdout and the job summary, and exits 0', () => {
     const dir = mkdtempSync(join(tmpdir(), 'wm-openapi-capacity-'));
     const outPath = join(dir, 'capacity.json');
     const summaryPath = join(dir, 'summary.md');
 
-    const run = spawnSync('node', [reportScript, '--json', '--out', outPath], {
-      cwd: root,
-      encoding: 'utf8',
-      env: { ...process.env, GITHUB_STEP_SUMMARY: summaryPath },
-    });
+    const result = run(['--json', '--out', outPath], { GITHUB_STEP_SUMMARY: summaryPath });
 
-    assert.equal(run.status, 0, run.stderr);
+    assert.equal(result.status, 0, result.stderr);
     // stdout must be the report and NOTHING else — a human line mixed in is
     // what makes a "machine-readable" artifact unparseable downstream.
-    const fromStdout = JSON.parse(run.stdout);
+    const fromStdout = JSON.parse(result.stdout);
     assert.equal(fromStdout.schemaVersion, 1);
     assert.equal(fromStdout.artifact, 'public/openapi.json');
     assert.equal(fromStdout.budgetBytes, SCANNER_BUDGET_BYTES);
-    assert.equal(readFileSync(outPath, 'utf8'), run.stdout);
+    assert.equal(readFileSync(outPath, 'utf8'), result.stdout);
     assert.match(readFileSync(summaryPath, 'utf8'), /OpenAPI bundle capacity/);
     // The annotation is the surface a reviewer sees without opening artifacts.
-    assert.match(run.stderr, /::(notice|warning)::/);
+    assert.match(result.stderr, /::(notice|warning)::/);
+  });
+
+  it('exits 1 and still emits a complete report when the artifact is over budget', () => {
+    // The single most important contract in the script: the over-budget exit.
+    // `--budget` is the only way to reach it without fabricating a bundle, and
+    // the report must survive the failing exit intact — `process.exit` after an
+    // unflushed stdout write is how a piped consumer loses exactly the payload
+    // it needed.
+    const result = run(['--json', '--budget', '1000']);
+    assert.equal(result.status, 1);
+    const report = JSON.parse(result.stdout);
+    assert.equal(report.status, 'over-budget');
+    assert.equal(report.budgetBytes, 1000);
+    assert.ok(report.headroomBytes < 0);
+    assert.match(result.stderr, /::error::OVER BUDGET/);
+    assert.match(result.stderr, /do NOT raise the budget/);
+  });
+
+  it('exits 3 rather than 1 when the bundle cannot be built at all', () => {
+    // "Could not measure" must never be reported as "over budget" — that sends
+    // the next reader hunting for bytes nobody counted.
+    const result = run([], { OPENAPI_YAML_PATH: join(tmpdir(), 'wm-no-such-bundle.yaml') });
+    assert.equal(result.status, 3);
+    assert.match(result.stderr, /NOT MEASURED/);
   });
 
   it('exits 2 on misuse rather than reporting a number it did not measure', () => {
-    assert.throws(
-      () => execFileSync('node', [reportScript, '--nope'], { cwd: root, stdio: 'pipe' }),
-      (err) => err.status === 2,
-    );
-    assert.throws(
-      () => execFileSync('node', [reportScript, '--out'], { cwd: root, stdio: 'pipe' }),
-      (err) => err.status === 2,
-    );
+    for (const args of [['--nope'], ['--out'], ['--budget', 'x'], ['--budget', '-1']]) {
+      assert.equal(run(args).status, 2, `${args.join(' ')} must be a usage error`);
+    }
+  });
+});
+
+describe('build-openapi-json CLI', () => {
+  it('writes public/openapi.json when run directly, at the byte count the report publishes', () => {
+    // Every consumer of the budget now measures buildBundle() in memory, so
+    // without this nothing observes the file the world actually fetches — and
+    // the CLI entry is guarded by a predicate that could stop matching.
+    const result = spawnSync('node', [buildScript], { cwd: root, encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = resolve(root, 'public/openapi.json');
+    assert.ok(existsSync(artifact), 'the build must write the artifact');
+    assert.equal(statSync(artifact).size, realBundle.bytes);
+    assert.match(result.stdout, /dropped \d+ unreachable schemas/);
+  });
+
+  it('refuses a source that is not an OpenAPI document', () => {
+    assert.throws(() => buildBundle({ spec: {} }), /not a valid OpenAPI document/);
+    assert.throws(() => buildBundle({ spec: { openapi: 3.1 } }), /not a valid OpenAPI document/);
+  });
+
+  it('the guard and the build agree byte-for-byte across two YAML parsers', () => {
+    // The report's central claim is that it measures "the same call that writes
+    // the artifact". The CLI path parses with the `yaml` package; the tests pass
+    // a js-yaml parse in through the cached loader. If those two documents ever
+    // differed, the guard would be guarding a document nobody serves.
+    const fromDisk = buildBundle();
+    assert.equal(fromDisk.bytes, realBundle.bytes);
+    assert.equal(fromDisk.json, realBundle.json);
   });
 });

--- a/tests/openapi-capacity-report.test.mjs
+++ b/tests/openapi-capacity-report.test.mjs
@@ -1,0 +1,284 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { loadUnifiedOpenApiSpec } from './_lib/openapi-spec-cache.mjs';
+
+import { buildBundle } from '../scripts/build-openapi-json.mjs';
+import {
+  ESTIMATED_REF_BYTES,
+  RESERVE_OPERATIONS,
+  SCANNER_BUDGET_BYTES,
+  buildCapacityReport,
+  formatMarkdown,
+  operationFieldBreakdown,
+  repeatedStructures,
+  sectionBreakdown,
+  unreferencedComponentSchemas,
+} from '../scripts/openapi-capacity-report.mjs';
+
+// The <= 950,000-byte guard in tests/openapi-json-dedup.test.mjs only speaks
+// the moment it breaks. #4852, the food-stocks operation and the
+// billing-verification 503 each crossed the cap and were discovered by a red
+// build on whichever PR happened to be last in line. This report is the number
+// the guard is silent about on the way there, so the properties worth pinning
+// are the ones that would let it lie: measuring bytes the build does not emit,
+// reporting a comfortable headroom for a bundle that generated nothing, and
+// promising the same bytes twice when repeated structures nest.
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const reportScript = resolve(root, 'scripts/openapi-capacity-report.mjs');
+
+/** A bundle shaped like buildBundle()'s return, with the bytes we want to test. */
+const fakeBundle = (spec, bytes) => ({
+  spec,
+  bytes,
+  stats: { hoisted: 0, replacedRefs: 0 },
+  schemaStats: { compared: 0, replacedRefs: 0 },
+  paramStats: { hoisted: 0, replacedRefs: 0 },
+  unreachableStats: { dropped: 0, bytesFreed: 0, names: [] },
+});
+
+const oneOperationSpec = () => ({
+  openapi: '3.1.0',
+  paths: { '/a': { get: { responses: { 200: { description: 'ok' } } }, summary: 'not an operation' } },
+});
+
+describe('buildCapacityReport — budget arithmetic', () => {
+  it('measures the bytes the build actually emits, in UTF-8', () => {
+    const bundle = buildBundle({ spec: loadUnifiedOpenApiSpec() });
+    const report = buildCapacityReport(bundle);
+    assert.equal(report.bytes, bundle.bytes);
+    assert.equal(report.bytes, Buffer.byteLength(bundle.json, 'utf8'));
+    // The distinction is the point: the cap is a body-size cap in bytes, and
+    // the bundle's non-ASCII punctuation makes String#length a different — and
+    // always smaller — number.
+    assert.ok(
+      bundle.bytes > bundle.json.length,
+      'the bundle carries non-ASCII text, so bytes must exceed UTF-16 code units',
+    );
+    assert.equal(report.headroomBytes, SCANNER_BUDGET_BYTES - bundle.bytes);
+  });
+
+  it('sits inside the budget with the reserve intact', () => {
+    // Not a restatement of the guard: this asserts the RESERVE, which the guard
+    // does not check. A green guard with a breached reserve is the state #6558
+    // was filed from (3,318 bytes left of 950,000).
+    const report = buildCapacityReport(buildBundle({ spec: loadUnifiedOpenApiSpec() }));
+    assert.equal(
+      report.status,
+      'ok',
+      `capacity is ${report.status}: ${report.headroomBytes} bytes left, reserve is ${report.reserveBytes}`,
+    );
+  });
+
+  it('pins both directions of the reserve boundary', () => {
+    const at = (budgetBytes) =>
+      buildCapacityReport(fakeBundle(oneOperationSpec(), 100), { budgetBytes });
+    // One operation costing 100 bytes ⇒ reserve = 3 × 100.
+    assert.equal(at(400).reserveBytes, 100 * RESERVE_OPERATIONS);
+    assert.equal(at(400).status, 'ok', 'headroom exactly equal to the reserve is not a breach');
+    assert.equal(at(399).status, 'reserve-breached');
+  });
+
+  it('pins both directions of the budget boundary', () => {
+    const at = (budgetBytes) =>
+      buildCapacityReport(fakeBundle(oneOperationSpec(), 100), { budgetBytes });
+    assert.equal(at(100).status, 'reserve-breached', 'zero headroom is still within budget');
+    assert.equal(at(100).headroomBytes, 0);
+    assert.equal(at(99).status, 'over-budget');
+    assert.equal(at(99).headroomBytes, -1);
+  });
+
+  it('counts operations across paths and webhooks, and only real HTTP methods', () => {
+    const spec = oneOperationSpec();
+    spec.webhooks = { ping: { post: { responses: {} }, description: 'not an operation' } };
+    const report = buildCapacityReport(fakeBundle(spec, 100), { budgetBytes: 1000 });
+    assert.equal(report.operations, 2);
+    assert.equal(report.bytesPerOperation, 50);
+    assert.equal(report.operationsRemaining, Math.floor(900 / 50));
+  });
+
+  it('refuses to call an empty bundle healthy', () => {
+    // The dangerous direction. A build that emitted nothing has enormous
+    // "headroom", and reporting that as a pass is precisely how a gate goes
+    // green while measuring nothing.
+    const noOperations = buildCapacityReport(fakeBundle({ openapi: '3.1.0', paths: {} }, 500));
+    assert.equal(noOperations.status, 'unmeasured');
+    assert.match(noOperations.reason, /zero operations/);
+
+    const noBytes = buildCapacityReport(fakeBundle(oneOperationSpec(), 0));
+    assert.equal(noBytes.status, 'unmeasured');
+    assert.match(noBytes.reason, /nothing was generated/);
+
+    for (const report of [noOperations, noBytes]) {
+      assert.equal(report.headroomBytes, undefined, 'an unmeasured bundle must not publish headroom');
+    }
+  });
+});
+
+describe('contributor breakdowns', () => {
+  it('ranks sections and expands the components buckets', () => {
+    const spec = {
+      openapi: '3.1.0',
+      paths: { '/a': { get: { responses: {} } } },
+      components: { schemas: { A: { type: 'string' } }, parameters: { P: { name: 'p' } } },
+    };
+    const sections = sectionBreakdown(spec);
+    const pointers = sections.map((s) => s.pointer);
+    assert.ok(pointers.includes('/components/schemas'));
+    assert.ok(pointers.includes('/components/parameters'));
+    for (let i = 1; i < sections.length; i++) {
+      assert.ok(sections[i - 1].bytes >= sections[i].bytes, 'sections must be ranked by bytes');
+    }
+    assert.equal(sections.find((s) => s.pointer === '/components/schemas').entries, 1);
+  });
+
+  it('attributes operation-field cost per operation, not per document', () => {
+    const spec = {
+      openapi: '3.1.0',
+      paths: {
+        '/a': { get: { description: 'x'.repeat(100) } },
+        '/b': { get: { description: 'y'.repeat(100) } },
+      },
+    };
+    const [description] = operationFieldBreakdown(spec);
+    assert.equal(description.field, 'description');
+    assert.ok(description.bytes > 200);
+    assert.equal(description.bytesPerOperation, Math.round(description.bytes / 2));
+  });
+
+  it('escapes path separators so the pointers are valid JSON Pointers', () => {
+    const pointers = sectionBreakdown({ 'a/b': { x: 1 } }).map((s) => s.pointer);
+    assert.deepEqual(pointers, ['/a~1b'], 'a "/" inside a key must be escaped as ~1');
+  });
+});
+
+describe('repeatedStructures — no promising the same bytes twice', () => {
+  const wrapper = (fill) => ({
+    description: fill,
+    child: { description: fill, marker: 'inner' },
+  });
+
+  it('counts a repeated parent OR its repeated child, never both', () => {
+    const fill = 'z'.repeat(200);
+    const spec = { a: wrapper(fill), b: wrapper(fill), c: wrapper(fill) };
+    const result = repeatedStructures(spec, { minBytes: 64 });
+
+    // The child repeats three times too, but every copy lives inside a parent
+    // already selected for hoisting — those bytes can only be spent once.
+    assert.equal(result.groups, 1, 'the nested repeat must not be counted separately');
+    const [top] = result.top;
+    assert.equal(top.occurrences, 3);
+    assert.equal(top.estimatedRecoverableBytes, 2 * (top.unitBytes - ESTIMATED_REF_BYTES));
+    assert.equal(result.estimatedRecoverableBytes, top.estimatedRecoverableBytes);
+  });
+
+  it('still counts a repeat that sits outside every selected subtree', () => {
+    const fill = 'z'.repeat(200);
+    const loose = { description: fill, marker: 'inner' };
+    const spec = { a: wrapper(fill), b: wrapper(fill), c: wrapper(fill), d: loose, e: loose };
+    const result = repeatedStructures(spec, { minBytes: 64 });
+    assert.equal(result.groups, 2);
+    assert.equal(result.top[1].occurrences, 2, 'only the two free copies count');
+  });
+
+  it('ignores subtrees too small to be worth a $ref, and singletons', () => {
+    const spec = { a: { t: 'string' }, b: { t: 'string' }, c: { description: 'q'.repeat(300) } };
+    assert.deepEqual(repeatedStructures(spec), { estimatedRecoverableBytes: 0, groups: 0, top: [] });
+  });
+
+  it('finds real repetition left in the served bundle', () => {
+    // Vacuity guard: a walk that silently visits nothing would satisfy every
+    // assertion above while reporting an empty reduction plan forever.
+    const { spec } = buildBundle({ spec: loadUnifiedOpenApiSpec() });
+    const result = repeatedStructures(spec);
+    assert.ok(result.groups > 20, `expected repeated structure in a generated spec, got ${result.groups}`);
+    assert.ok(result.estimatedRecoverableBytes > 10_000, `only ${result.estimatedRecoverableBytes} bytes ranked`);
+    assert.ok(result.top.length > 0 && result.top[0].pointers.length > 0);
+    for (let i = 1; i < result.top.length; i++) {
+      assert.ok(result.top[i - 1].estimatedRecoverableBytes >= result.top[i].estimatedRecoverableBytes);
+    }
+  });
+});
+
+describe('unreferencedComponentSchemas — the drop’s regression detector', () => {
+  it('reads zero on the served bundle, because buildBundle already dropped them', () => {
+    const { spec } = buildBundle({ spec: loadUnifiedOpenApiSpec() });
+    assert.deepEqual(unreferencedComponentSchemas(spec), { count: 0, bytes: 0, names: [] });
+  });
+
+  it('reports the exact byte cost when orphans are present', () => {
+    const spec = {
+      openapi: '3.1.0',
+      paths: { '/a': { get: { responses: { 200: { schema: { $ref: '#/components/schemas/Used' } } } } } },
+      components: { schemas: { Used: { type: 'object' }, Orphan: { description: 'x'.repeat(300) } } },
+    };
+    const before = Buffer.byteLength(JSON.stringify(spec), 'utf8');
+    const result = unreferencedComponentSchemas(spec);
+    assert.equal(result.count, 1);
+    assert.deepEqual(result.names, ['Orphan']);
+    delete spec.components.schemas.Orphan;
+    assert.equal(result.bytes, before - Buffer.byteLength(JSON.stringify(spec), 'utf8'));
+  });
+});
+
+describe('formatMarkdown', () => {
+  it('leads with the numbers a reviewer needs and never hides an unmeasured run', () => {
+    const report = buildCapacityReport(buildBundle({ spec: loadUnifiedOpenApiSpec() }));
+    const markdown = formatMarkdown(report);
+    assert.match(markdown, /OpenAPI bundle capacity/);
+    assert.ok(markdown.includes(report.bytes.toLocaleString('en-US')));
+    assert.ok(markdown.includes(report.headroomBytes.toLocaleString('en-US')));
+    // The plan path is pointed at from the job summary and the CI annotation,
+    // so a rename that leaves those strings behind sends every future reader to
+    // a 404 without anything going red.
+    const planPath = 'docs/perf/openapi-bundle-capacity-2026-08-13.md';
+    assert.ok(markdown.includes(planPath));
+    assert.ok(existsSync(resolve(root, planPath)), `${planPath} must exist — the report links to it`);
+
+    const dead = formatMarkdown(buildCapacityReport(fakeBundle({ openapi: '3.1.0', paths: {} }, 500)));
+    assert.match(dead, /NOT MEASURED/);
+    assert.ok(!/within budget/.test(dead), 'an unmeasured run must not read as a pass');
+  });
+});
+
+describe('CLI', () => {
+  it('writes the report to --out, stdout and the job summary, and exits 0', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wm-openapi-capacity-'));
+    const outPath = join(dir, 'capacity.json');
+    const summaryPath = join(dir, 'summary.md');
+
+    const run = spawnSync('node', [reportScript, '--json', '--out', outPath], {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env, GITHUB_STEP_SUMMARY: summaryPath },
+    });
+
+    assert.equal(run.status, 0, run.stderr);
+    // stdout must be the report and NOTHING else — a human line mixed in is
+    // what makes a "machine-readable" artifact unparseable downstream.
+    const fromStdout = JSON.parse(run.stdout);
+    assert.equal(fromStdout.schemaVersion, 1);
+    assert.equal(fromStdout.artifact, 'public/openapi.json');
+    assert.equal(fromStdout.budgetBytes, SCANNER_BUDGET_BYTES);
+    assert.equal(readFileSync(outPath, 'utf8'), run.stdout);
+    assert.match(readFileSync(summaryPath, 'utf8'), /OpenAPI bundle capacity/);
+    // The annotation is the surface a reviewer sees without opening artifacts.
+    assert.match(run.stderr, /::(notice|warning)::/);
+  });
+
+  it('exits 2 on misuse rather than reporting a number it did not measure', () => {
+    assert.throws(
+      () => execFileSync('node', [reportScript, '--nope'], { cwd: root, stdio: 'pipe' }),
+      (err) => err.status === 2,
+    );
+    assert.throws(
+      () => execFileSync('node', [reportScript, '--out'], { cwd: root, stdio: 'pipe' }),
+      (err) => err.status === 2,
+    );
+  });
+});

--- a/tests/openapi-json-dedup.test.mjs
+++ b/tests/openapi-json-dedup.test.mjs
@@ -7,6 +7,8 @@ import { loadUnifiedOpenApiSpec } from './_lib/openapi-spec-cache.mjs';
 
 import { dedupeErrorResponses, dedupeSharedParameters } from '../scripts/openapi-dedup-responses.mjs';
 import { dedupeSharedChinaProvenanceSchemas } from '../scripts/openapi-dedup-schemas.mjs';
+import { buildBundle } from '../scripts/build-openapi-json.mjs';
+import { SCANNER_BUDGET_BYTES } from '../scripts/openapi-capacity-report.mjs';
 
 // Guards the served public/openapi.json against the ~1 MB scanner body cap.
 // On 2026-07-05 the per-op rate-limit/idempotency/example doc injections grew
@@ -25,10 +27,15 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const buildScriptPath = resolve(root, 'scripts/build-openapi-json.mjs');
 
 // Leave headroom under the ~1 MB cap: the spec sat at ~752 KB when the check
-// last passed and ~814 KB deduped today. If this fails, either extend the
+// last passed and ~853 KB deduped today. If this fails, either extend the
 // dedup (more shared structure) or trim the newest per-op injection — do NOT
 // raise the budget past 1 MB.
-const SIZE_BUDGET_BYTES = 950_000;
+//
+// The value lives in scripts/openapi-capacity-report.mjs so the gate and the
+// CI capacity report cannot disagree about where the wall is, and is pinned
+// literally below so raising it stays a deliberate two-file edit rather than a
+// one-line workaround (#6558).
+const SIZE_BUDGET_BYTES = SCANNER_BUDGET_BYTES;
 
 const HTTP_METHODS = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
 
@@ -301,14 +308,29 @@ describe('public OpenAPI dedupe (real bundle)', () => {
     assert.ok(paramStats.replacedRefs >= 200, `expected fleet-wide dedup, got ${paramStats.replacedRefs} refs`);
   });
 
-  it(`keeps the minified JSON under the ${SIZE_BUDGET_BYTES}-byte scanner budget`, () => {
-    const bytes = JSON.stringify(deduped).length;
+  it('the budget is 950,000 bytes and raising it is not the remedy', () => {
+    // A literal pin, not a restatement: the guard below reads the shared
+    // constant, so without this a crossing could be "fixed" by editing one
+    // number in one file. The cap belongs to the scanner (#4852) — moving our
+    // number does not move it.
+    assert.equal(SIZE_BUDGET_BYTES, 950_000);
+  });
+
+  it(`keeps the served JSON under the ${SIZE_BUDGET_BYTES}-byte scanner budget`, () => {
+    // Measured through buildBundle — the same call that writes the artifact —
+    // so the gate can never guard a document the build does not emit. It
+    // applies one transform this file's `deduped` fixture does not (the
+    // unreachable-schema drop), and it counts UTF-8 BYTES: `String#length` is
+    // UTF-16 code units and undercut the served size by 264 bytes on the
+    // 2026-08-13 bundle, against a cap expressed in bytes.
+    const { bytes } = buildBundle({ spec: loadUnifiedOpenApiSpec() });
     assert.ok(
       bytes <= SIZE_BUDGET_BYTES,
-      `public/openapi.json would be ${bytes} bytes (budget ${SIZE_BUDGET_BYTES}). ` +
+      `public/openapi.json is ${bytes} bytes (budget ${SIZE_BUDGET_BYTES}). ` +
         'Scanners cap spec bodies around 1 MB (orank function-calling-compat degrades to ' +
         '"couldn\'t validate" above it). Extend scripts/openapi-dedup-responses.mjs or slim ' +
-        'the newest per-op injection instead of raising this budget.',
+        'the newest per-op injection instead of raising this budget. ' +
+        '`node scripts/openapi-capacity-report.mjs` ranks what is worth collapsing next.',
     );
   });
 });
@@ -321,5 +343,21 @@ describe('build-openapi-json wiring', () => {
     assert.match(src, /dedupeErrorResponses\(spec\)/);
     assert.match(src, /dedupeSharedChinaProvenanceSchemas\(spec\)/);
     assert.match(src, /dedupeSharedParameters\(spec\)/);
+  });
+
+  it('every transform actually engaged on the bundle it emits', () => {
+    // The source match above proves the calls are written down; this proves
+    // they did something. A transform that silently stops finding work is the
+    // regression the byte budget notices last and from the wrong direction.
+    const { stats, schemaStats, paramStats, unreachableStats } = buildBundle({
+      spec: loadUnifiedOpenApiSpec(),
+    });
+    assert.ok(stats.replacedRefs >= 500, `error-response dedup: ${stats.replacedRefs} refs`);
+    assert.ok(paramStats.replacedRefs >= 200, `parameter dedup: ${paramStats.replacedRefs} refs`);
+    // `replacedRefs === compared` alone passes at 0 === 0, which is exactly the
+    // silent-disengagement case this test exists for.
+    assert.ok(schemaStats.compared > 0, 'China provenance dedup compared nothing');
+    assert.equal(schemaStats.replacedRefs, schemaStats.compared);
+    assert.ok(unreachableStats.dropped >= 150, `unreachable drop: ${unreachableStats.dropped} schemas`);
   });
 });

--- a/tests/openapi-unreachable-schemas.test.mjs
+++ b/tests/openapi-unreachable-schemas.test.mjs
@@ -1,0 +1,222 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { loadUnifiedOpenApiSpec } from './_lib/openapi-spec-cache.mjs';
+
+import {
+  dropUnreachableSchemas,
+  unreachableSchemaNames,
+} from '../scripts/openapi-drop-unreachable-schemas.mjs';
+import { dedupeErrorResponses, dedupeSharedParameters } from '../scripts/openapi-dedup-responses.mjs';
+import { dedupeSharedChinaProvenanceSchemas } from '../scripts/openapi-dedup-schemas.mjs';
+
+// The generator emits one component schema per RPC message, but a GET operation
+// spends its request message as `parameters` and never points at the request
+// schema — so ~210 definitions were carried, served, and counted against the
+// scanner body budget while being unreachable from every operation, response,
+// and sibling schema (#6558). Dropping them at JSON-emit time returns ~93 KB of
+// a 950 KB budget that had 3,318 bytes left.
+//
+// "Unreachable" has to mean unreachable, so these tests attack the transform
+// from the direction that would actually hurt: a schema reached only through a
+// nested JSON pointer, only from a hoisted component, or only through another
+// schema, must survive. The real-bundle tests then prove the served document
+// has no dangling $ref and that every schema an operation can still reach is
+// byte-identical to what it was before.
+
+const HTTP_METHODS = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
+
+/** Every `#/components/schemas/...` pointer in a document, as component names. */
+function schemaRefNames(node, into = new Set()) {
+  if (Array.isArray(node)) {
+    for (const child of node) schemaRefNames(child, into);
+    return into;
+  }
+  if (!node || typeof node !== 'object') return into;
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '$ref' && typeof value === 'string' && value.startsWith('#/components/schemas/')) {
+      into.add(value.slice('#/components/schemas/'.length).split('/')[0]);
+      continue;
+    }
+    schemaRefNames(value, into);
+  }
+  return into;
+}
+
+function servedBundle() {
+  const spec = loadUnifiedOpenApiSpec();
+  dedupeErrorResponses(spec);
+  dedupeSharedChinaProvenanceSchemas(spec);
+  dedupeSharedParameters(spec);
+  return spec;
+}
+
+describe('unreachableSchemaNames (fixture)', () => {
+  const fixture = () => ({
+    openapi: '3.1.0',
+    paths: {
+      '/a': {
+        get: {
+          responses: {
+            200: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Used' } } } },
+          },
+        },
+        // A non-method key on the path item must not be mistaken for an operation.
+        summary: 'not an operation',
+      },
+    },
+    components: {
+      schemas: {
+        Used: { properties: { next: { $ref: '#/components/schemas/UsedIndirectly' } } },
+        UsedIndirectly: { type: 'string' },
+        Orphan: { type: 'object' },
+        OrphanReferencedOnlyByOrphan: { type: 'integer' },
+      },
+    },
+  });
+
+  it('keeps schemas reachable transitively and drops orphans, including orphan-only referents', () => {
+    const spec = fixture();
+    spec.components.schemas.Orphan = { $ref: '#/components/schemas/OrphanReferencedOnlyByOrphan' };
+    assert.deepEqual(
+      [...unreachableSchemaNames(spec)].sort(),
+      ['Orphan', 'OrphanReferencedOnlyByOrphan'],
+    );
+  });
+
+  it('keeps a schema reached only through a nested JSON pointer', () => {
+    const spec = fixture();
+    spec.components.schemas.Used.properties.next = {
+      $ref: '#/components/schemas/Orphan/properties/inner',
+    };
+    spec.components.schemas.Orphan = { properties: { inner: { type: 'string' } } };
+    // Orphan is now reached only by a pointer THROUGH it; UsedIndirectly lost
+    // its only referent to that same edit, so the two must land on opposite
+    // sides of the verdict.
+    assert.deepEqual(
+      [...unreachableSchemaNames(spec)].sort(),
+      ['OrphanReferencedOnlyByOrphan', 'UsedIndirectly'],
+    );
+  });
+
+  it('keeps a schema reached only from a hoisted component (responses/parameters/headers)', () => {
+    for (const bucket of ['responses', 'parameters', 'headers']) {
+      const spec = fixture();
+      spec.components[bucket] = { Hoisted: { schema: { $ref: '#/components/schemas/Orphan' } } };
+      assert.ok(
+        !unreachableSchemaNames(spec).has('Orphan'),
+        `a schema referenced from components.${bucket} is reachable`,
+      );
+    }
+  });
+
+  it('keeps a schema reached only from webhooks', () => {
+    const spec = fixture();
+    delete spec.components.schemas.Orphan;
+    spec.webhooks = {
+      ping: { post: { requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/OrphanReferencedOnlyByOrphan' } } } } } },
+    };
+    assert.deepEqual([...unreachableSchemaNames(spec)], []);
+  });
+
+  it('returns nothing for a spec with no components.schemas', () => {
+    assert.deepEqual([...unreachableSchemaNames({ openapi: '3.1.0', paths: {} })], []);
+  });
+});
+
+describe('dropUnreachableSchemas (fixture)', () => {
+  it('removes exactly the unreachable names and reports what it freed', () => {
+    const spec = {
+      openapi: '3.1.0',
+      paths: { '/a': { get: { responses: { 200: { schema: { $ref: '#/components/schemas/Used' } } } } } },
+      components: { schemas: { Used: { type: 'object' }, Orphan: { type: 'string', description: 'x'.repeat(200) } } },
+    };
+    const before = JSON.stringify(spec).length;
+    const stats = dropUnreachableSchemas(spec);
+    assert.equal(stats.dropped, 1);
+    assert.deepEqual(Object.keys(spec.components.schemas), ['Used']);
+    assert.equal(stats.bytesFreed, before - JSON.stringify(spec).length);
+    assert.ok(stats.bytesFreed > 200, `expected the description bytes back, got ${stats.bytesFreed}`);
+  });
+
+  it('is idempotent: a second pass has nothing left to drop', () => {
+    const spec = {
+      openapi: '3.1.0',
+      paths: { '/a': { get: { responses: { 200: { schema: { $ref: '#/components/schemas/Used' } } } } } },
+      components: { schemas: { Used: { type: 'object' }, Orphan: { type: 'string' } } },
+    };
+    assert.equal(dropUnreachableSchemas(spec).dropped, 1);
+    assert.deepEqual(dropUnreachableSchemas(spec), { dropped: 0, bytesFreed: 0, names: [] });
+  });
+
+  it('leaves components.schemas absent rather than empty when everything is unreachable', () => {
+    const spec = { openapi: '3.1.0', paths: {}, components: { schemas: { Orphan: { type: 'string' } } } };
+    dropUnreachableSchemas(spec);
+    assert.equal(spec.components?.schemas, undefined);
+  });
+});
+
+describe('unreachable schema drop (real bundle)', () => {
+  const before = servedBundle();
+  const after = servedBundle();
+  const stats = dropUnreachableSchemas(after);
+
+  it('actually engages — the generated request-message orphans are real', () => {
+    // Vacuity guard. A reachability bug that marks everything reachable makes
+    // every other assertion here pass while the transform does nothing, and the
+    // budget is too tight for that to go unnoticed for long.
+    assert.ok(stats.dropped >= 150, `expected the generated orphans, dropped only ${stats.dropped}`);
+    assert.ok(stats.bytesFreed >= 60_000, `expected a material saving, freed ${stats.bytesFreed} bytes`);
+  });
+
+  it('drops only request-message-shaped orphans, never a response or operation schema', () => {
+    const responseShaped = stats.names.filter((name) => /Response$/.test(name));
+    assert.deepEqual(responseShaped, [], 'a *Response schema no operation reaches means the walk is wrong');
+  });
+
+  it('leaves no dangling $ref anywhere in the served document', () => {
+    const present = new Set(Object.keys(after.components?.schemas ?? {}));
+    const dangling = [...schemaRefNames(after)].filter((name) => !present.has(name));
+    assert.deepEqual(dangling, [], 'the served JSON must resolve every document-local schema ref');
+  });
+
+  it('is lossless for everything an operation can reach: retained schemas are byte-identical', () => {
+    const retained = Object.keys(after.components.schemas);
+    assert.ok(retained.length > 0);
+    for (const name of retained) {
+      assert.equal(
+        JSON.stringify(after.components.schemas[name]),
+        JSON.stringify(before.components.schemas[name]),
+        `${name} changed under a transform that may only remove unreachable entries`,
+      );
+    }
+  });
+
+  it('changes nothing outside components.schemas', () => {
+    const strip = (spec) => {
+      const copy = { ...spec, components: { ...spec.components } };
+      delete copy.components.schemas;
+      return JSON.stringify(copy);
+    };
+    assert.equal(strip(after), strip(before));
+  });
+
+  it('every operation still resolves its 2xx response schema', () => {
+    // The scanner credits the inline responses['200'] schema, so the refs that
+    // matter most are the ones reachable from a 2xx body.
+    const present = new Set(Object.keys(after.components.schemas));
+    let checked = 0;
+    for (const [path, pathItem] of Object.entries(after.paths)) {
+      for (const [method, op] of Object.entries(pathItem ?? {})) {
+        if (!HTTP_METHODS.has(method) || !op?.responses) continue;
+        for (const [status, response] of Object.entries(op.responses)) {
+          if (!/^2/.test(status)) continue;
+          for (const name of schemaRefNames(response)) {
+            checked += 1;
+            assert.ok(present.has(name), `${method.toUpperCase()} ${path} ${status} lost ${name}`);
+          }
+        }
+      }
+    }
+    assert.ok(checked > 100, `expected the 2xx bodies to reference schemas, saw ${checked}`);
+  });
+});

--- a/tests/openapi-unreachable-schemas.test.mjs
+++ b/tests/openapi-unreachable-schemas.test.mjs
@@ -229,6 +229,20 @@ describe('unreachable schema drop (real bundle)', () => {
     }
   });
 
+  it('is order-independent: running the drop first emits the identical document', () => {
+    // build-openapi-json.mjs runs the drop last and its comment says that is a
+    // convention rather than a requirement — the unconditional seeding from
+    // every non-schema bucket is what actually keeps hoisted components' schema
+    // targets alive. This is that claim, executed. If it ever fails, the
+    // comment is wrong and the ordering is load-bearing after all.
+    const first = loadUnifiedOpenApiSpec();
+    dropUnreachableSchemas(first);
+    dedupeErrorResponses(first);
+    dedupeSharedChinaProvenanceSchemas(first);
+    dedupeSharedParameters(first);
+    assert.equal(JSON.stringify(first), JSON.stringify(after));
+  });
+
   it('changes nothing outside components.schemas', () => {
     const strip = (spec) => {
       const copy = { ...spec, components: { ...spec.components } };

--- a/tests/openapi-unreachable-schemas.test.mjs
+++ b/tests/openapi-unreachable-schemas.test.mjs
@@ -25,21 +25,24 @@ import { dedupeSharedChinaProvenanceSchemas } from '../scripts/openapi-dedup-sch
 
 const HTTP_METHODS = new Set(['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']);
 
-/** Every `#/components/schemas/...` pointer in a document, as component names. */
-function schemaRefNames(node, into = new Set()) {
-  if (Array.isArray(node)) {
-    for (const child of node) schemaRefNames(child, into);
-    return into;
+/**
+ * Every component-schema name the document mentions ANYWHERE, found without
+ * reusing the transform's own idea of what a reference looks like.
+ *
+ * This is deliberately a regex over the serialized document rather than a
+ * second key-aware walk. A walk that matched on `$ref` the way
+ * `collectSchemaRefs` does would share its blind spot exactly — the safety net
+ * would be woven from the same thread as the thing it is catching, and could
+ * never fail for a vocabulary gap. Scanning raw text finds a schema name
+ * wherever it is written: `$ref`, `$dynamicRef`, a `discriminator.mapping`
+ * value, or a construct nobody has thought of yet.
+ */
+function mentionedSchemaNames(spec) {
+  const names = new Set();
+  for (const [, name] of JSON.stringify(spec).matchAll(/#\/components\/schemas\/([A-Za-z0-9_.\-~]+)/g)) {
+    names.add(name.replaceAll('~1', '/').replaceAll('~0', '~'));
   }
-  if (!node || typeof node !== 'object') return into;
-  for (const [key, value] of Object.entries(node)) {
-    if (key === '$ref' && typeof value === 'string' && value.startsWith('#/components/schemas/')) {
-      into.add(value.slice('#/components/schemas/'.length).split('/')[0]);
-      continue;
-    }
-    schemaRefNames(value, into);
-  }
-  return into;
+  return names;
 }
 
 function servedBundle() {
@@ -121,6 +124,41 @@ describe('unreachableSchemaNames (fixture)', () => {
   it('returns nothing for a spec with no components.schemas', () => {
     assert.deepEqual([...unreachableSchemaNames({ openapi: '3.1.0', paths: {} })], []);
   });
+
+  it('keeps a schema named only by discriminator.mapping — the edge with no $ref key', () => {
+    // The bundle carries no discriminator today, which is exactly why this is a
+    // fixture and not a real-bundle assertion: the first proto to add one would
+    // otherwise silently lose its subtypes, and the served document would ship
+    // a mapping pointing at a schema that is no longer there.
+    for (const target of ['#/components/schemas/Orphan', 'Orphan']) {
+      const spec = fixture();
+      spec.components.schemas.Used = {
+        oneOf: [{ $ref: '#/components/schemas/UsedIndirectly' }],
+        discriminator: { propertyName: 'kind', mapping: { orphan: target } },
+      };
+      assert.ok(
+        !unreachableSchemaNames(spec).has('Orphan'),
+        `discriminator.mapping value ${target} must keep its target alive`,
+      );
+    }
+  });
+
+  it('ignores a discriminator.mapping value that points outside this document', () => {
+    const spec = fixture();
+    spec.components.schemas.Used = {
+      discriminator: { propertyName: 'kind', mapping: { remote: 'https://example.com/schemas/Other' } },
+    };
+    // No crash, no invented component, and the genuine orphans still go.
+    assert.ok(unreachableSchemaNames(spec).has('Orphan'));
+  });
+
+  it('keeps a schema reached only by $dynamicRef', () => {
+    const spec = fixture();
+    spec.components.schemas.Used = { $dynamicRef: '#/components/schemas/Orphan' };
+    const unreachable = unreachableSchemaNames(spec);
+    assert.ok(!unreachable.has('Orphan'));
+    assert.ok(unreachable.has('UsedIndirectly'), 'the schema that lost its referent is now unreachable');
+  });
 });
 
 describe('dropUnreachableSchemas (fixture)', () => {
@@ -173,10 +211,10 @@ describe('unreachable schema drop (real bundle)', () => {
     assert.deepEqual(responseShaped, [], 'a *Response schema no operation reaches means the walk is wrong');
   });
 
-  it('leaves no dangling $ref anywhere in the served document', () => {
+  it('leaves no schema name mentioned anywhere in the served document unresolvable', () => {
     const present = new Set(Object.keys(after.components?.schemas ?? {}));
-    const dangling = [...schemaRefNames(after)].filter((name) => !present.has(name));
-    assert.deepEqual(dangling, [], 'the served JSON must resolve every document-local schema ref');
+    const dangling = [...mentionedSchemaNames(after)].filter((name) => !present.has(name));
+    assert.deepEqual(dangling, [], 'the served JSON must resolve every document-local schema name');
   });
 
   it('is lossless for everything an operation can reach: retained schemas are byte-identical', () => {
@@ -210,7 +248,7 @@ describe('unreachable schema drop (real bundle)', () => {
         if (!HTTP_METHODS.has(method) || !op?.responses) continue;
         for (const [status, response] of Object.entries(op.responses)) {
           if (!/^2/.test(status)) continue;
-          for (const name of schemaRefNames(response)) {
+          for (const name of mentionedSchemaNames(response)) {
             checked += 1;
             assert.ok(present.has(name), `${method.toUpperCase()} ${path} ${status} lost ${name}`);
           }


### PR DESCRIPTION
Closes #6558.

## The state this was filed from

`public/openapi.json` had **3,318 bytes** left of its 950,000-byte scanner budget — less than one operation. The guard in `tests/openapi-json-dedup.test.mjs` only speaks the moment it breaks, so the last three crossings (#4852, the food-stocks operation, the billing-verification 503 that landed 497 bytes over) were each discovered by a red build on whichever PR happened to be last in line.

**946,682 -> 853,100 bytes. Headroom 3,318 -> 96,900 (room for ~24 more operations).**

## Track it

- **`scripts/openapi-capacity-report.mjs`** measures the served artifact through `buildBundle()` — the same call that writes it, so the report cannot drift from what is served — and publishes bytes, headroom, per-section and per-operation-field cost, and the repeated structures worth collapsing next. JSON artifact plus a job summary on every PR.
- **The `changes` filter now routes `docs/api/worldmonitor.openapi.yaml` into `unit`.** The bundle lives under `docs/`, which the filter excluded wholesale, so a PR that only regenerated it skipped the one gate that measures it.
- **The guard counts UTF-8 bytes**, not UTF-16 code units — it was reading 264 bytes low against a cap expressed in bytes. The 950,000 value moves to one place and gains a literal pin, so raising it cannot pass as a one-line edit.

## Spend it

**`scripts/openapi-drop-unreachable-schemas.mjs`** removes component schemas nothing can reach. The generator emits one schema per RPC message, but a GET operation spends its request message as `parameters` and never points at the request schema — 210 of 844 definitions were served while unreachable from every operation, response, parameter, header and sibling schema.

Emit-time only: `docs/api/worldmonitor.openapi.yaml` keeps every schema, so Mintlify, the injectors and the contract tests still see the complete document.

## Verification

- The served artifact resolves **all 2,441 `$ref`s** with zero dangling, 218 operations each keeping an **inline** 2xx response, and 634 schemas retained.
- Every retained schema is byte-identical; nothing outside `components.schemas` changes; the drop is idempotent.
- Reachability is proven against the **serialized document**, not a second copy of the walk's own logic — so a vocabulary gap cannot hide behind a matching oracle.
- Mutation-tested: dropping the component-bucket seeds, losing transitivity, mishandling nested JSON pointers, and disabling `discriminator.mapping` each turn the suite red.
- The CI carve-out is proven by **executing the real awk**, and goes red when the pattern is removed while its comment stays.
- 50 tests across the two new files; 1,700 in the scoped sweep. `docs-stats --check`, biome, and markdownlint clean.

## Review

Nine reviewers plus an independent cross-model pass (Codex/gpt-5.5). Two defects were found by more than one reviewer working separately and are fixed in `ccb7a10`:

1. **Reachability missed part of its vocabulary** — a schema named only by `discriminator.mapping` (values carry no `$ref` key) was deleted and its mapping stranded; same for `$dynamicRef`. Latent today (the bundle has no discriminator), which is exactly why it had to be closed now: the first proto to add one would have silently lost its subtypes.
2. **The reduction estimate promised bytes twice, and bytes that cannot be spent** — the non-overlap filter excluded candidates *inside* a selection but not ones that *contain* it, and every repeated object was priced as if a `$ref` could replace it (including container maps, Media Type Objects, `example` payloads, and 2xx responses the project has ruled out). Candidate positions are now an allow-list; the estimate goes 41,891 -> 31,130 bytes.

Also closed: an operation floor on `unmeasured` (a partial generation emitting 5 operations would have reported 900 KB of headroom), a self-referential "regression detector", untested exit-1/exit-3 paths, `process.exit` truncating a piped `--json` report, and public docs advertising `/openapi.json` as a "byte-identical bundle — same spec as `/openapi.yaml`".

## Known residuals

- **`buildBundle()`'s four transforms are four hand-named stats fields** threaded through three files with nothing keeping them in sync (maintainability, P2). A registry refactor was proposed; deliberately not taken here — it is churn across three files on top of an already-large diff, and the naming inconsistency predates it. Worth doing when a fifth transform lands.
- **Per-service `docs/api/*Service.openapi.{json,yaml}` specs skip the job that runs their contract test** — the same filter gap this PR closes for the unified bundle. Pre-existing and out of scope; filed as #6650.

## Post-Deploy Monitoring & Validation

The only production-visible change is the body of `https://www.worldmonitor.app/openapi.json`.

- **Watch:** the artifact resolves and stays under budget — `curl -s https://www.worldmonitor.app/openapi.json | wc -c` should read ~853,100 and must stay under 950,000.
- **Healthy signal:** the `OpenAPI bundle capacity` step reports `::notice::` with `status: ok` on every `unit` run; the `openapi-capacity-<run_attempt>` artifact carries the breakdown.
- **Failure signal:** `::warning::` (reserve breached, advisory) or `::error::` (over budget or unmeasurable, fails the step). An `unmeasured` verdict means the bundle did not generate — treat as a build failure, not a capacity problem.
- **Scanner-side check:** re-run the ora.ai/orank agent-readiness scan after deploy and confirm the function-calling compatibility check still returns a computed verdict rather than "couldn't validate". That check is the reason the budget exists, and this PR moves the artifact 93 KB further from the cap, so a regression there would be surprising and worth investigating immediately.
- **Rollback trigger:** any client or scanner reporting an unresolvable `$ref` in `/openapi.json`. Revert the `dropUnreachableSchemas(spec)` call in `scripts/build-openapi-json.mjs` — the transform is emit-time only, so reverting that one line restores the previous document with no source change.
- **Window / owner:** first deploy plus the next scheduled agent-readiness scan; owner is whoever merges.
