### PR TITLE
fix(ci): run OpenAPI service spec contract tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,11 @@ jobs:
             # without this rule the guard skips on exactly the PR that commits
             # an artifact and can only ever fire on unrelated changes.
             /^docs\/snapshots\/resilience-.*-acceptance-.*\.json$/ { count++; next }
+            # Per-service OpenAPI specs are generated machine artifacts consumed
+            # by tests/openapi-filter-param-schemas.test.mjs, which enumerates
+            # every JSON spec. Keep the JSON/YAML siblings on the same `unit`
+            # job when a PR changes only docs/api output (#6650).
+            /^docs\/api\/[^\/]+Service\.openapi\.(json|yaml)$/ { count++; next }
             # The generated OpenAPI bundle sits under docs/ but is the INPUT to
             # the served public/openapi.json. Its <= 950,000-byte scanner guard
             # (tests/openapi-json-dedup.test.mjs) and the capacity report that

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -763,13 +763,11 @@ describe('CI workflow coverage', () => {
     }
   });
 
-  it('routes the generated OpenAPI bundle into the job that measures it (#6558)', () => {
-    // Executes the real awk rather than matching its source. The bundle lives
-    // under `docs/`, which the blanket `/^docs\// { next }` rule excludes, so
-    // this carve-out is the only thing keeping a bundle-only PR from setting
-    // code=false and skipping `unit` — the job that runs BOTH the
-    // <= 950,000-byte scanner guard and the capacity report, against the very
-    // artifact such a PR changes.
+  it('routes generated OpenAPI artifacts into the owning unit job (#6558, #6650)', () => {
+    // Executes the real awk rather than matching its source. These artifacts
+    // live under `docs/`, which the blanket `/^docs\// { next }` rule excludes,
+    // so the carve-outs are the only thing keeping an OpenAPI-only PR from
+    // setting code=false and skipping the contract tests in `unit`.
     const awkBlock = shellAwkAssignmentBlock('CODE');
     const codeFilterSays = (path: string) => evaluateAwkAssignmentBlock(awkBlock, [path]) > 0;
 
@@ -777,6 +775,15 @@ describe('CI workflow coverage', () => {
       codeFilterSays('docs/api/worldmonitor.openapi.yaml'),
       'a PR that only regenerates the unified OpenAPI bundle must still run the unit job',
     );
+    for (const path of [
+      'docs/api/MarketService.openapi.json',
+      'docs/api/MarketService.openapi.yaml',
+    ]) {
+      assert.ok(
+        codeFilterSays(path),
+        `${path} must set code=true so the OpenAPI filter-parameter contract test runs`,
+      );
+    }
     // Prose under docs/ stays excluded — the carve-out is for the machine
     // artifact, not for the directory.
     for (const path of ['docs/api-reference.mdx', 'docs/perf/openapi-bundle-capacity-2026-08-13.md']) {


### PR DESCRIPTION
## Summary

A pull request that changes only a generated per-service OpenAPI spec now runs the `unit` job, so `tests/openapi-filter-param-schemas.test.mjs` cannot be skipped when one of its JSON inputs changes. The `changes.code` AWK filter recognizes both JSON and YAML `docs/api/<Service>Service.openapi.*` artifacts while keeping prose under `docs/` excluded.

Fixes #6650.

## Validation

- `./node_modules/.bin/tsx --test tests/ci-workflow-coverage.test.mts` — 26 passed; evaluates the real AWK block.
- `./node_modules/.bin/tsx --test tests/openapi-filter-param-schemas.test.mjs` — 5 passed.
- `npm run typecheck` — passed.
- `npm run lint` — passed; existing Biome warnings remain.
- `npm run test:data` — unrelated pre-push fixture failures under the sandbox temp path (`mktemp` under `/var/folders`); no issue-specific failures.

## Post-Deploy Monitoring & Validation

No production monitoring is required because this changes CI routing only. On the first PR that changes only `docs/api/*Service.openapi.{json,yaml}`, confirm that `unit` starts and the OpenAPI filter-parameter contract test passes; treat a skipped `unit` job or contract failure as a rollback trigger.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/MODEL_SLUG-GPT_5-000000)