### PR TITLE
fix(wm-session): send minted wms_ token on first API call, not only after 401

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -140,11 +140,16 @@ fi
 # no file on disk — so the old line-read string dropped those paths silently
 # and the gate went green having run nothing.
 ATTEST="scripts/prepush-attest.sh"
-CHANGED_NUL=$(mktemp) || exit 1
-CHANGED_LIVE_NUL=$(mktemp) || exit 1
-NODE_TESTS_NUL=$(mktemp) || exit 1
-DOM_TESTS_NUL=$(mktemp) || exit 1
-WORKTREE_NUL=$(mktemp) || exit 1
+# macOS `git push` can replace TMPDIR with its per-user /var/folders path even
+# when the caller selected a sandbox-safe directory. Keep hook scratch files
+# in the portable system temp directory unless an explicit hook override is
+# provided.
+TEMP_ROOT=${WM_PREPUSH_TMPDIR:-/tmp}
+CHANGED_NUL=$(mktemp "$TEMP_ROOT/wm-prepush-changed.XXXXXX") || exit 1
+CHANGED_LIVE_NUL=$(mktemp "$TEMP_ROOT/wm-prepush-changed-live.XXXXXX") || exit 1
+NODE_TESTS_NUL=$(mktemp "$TEMP_ROOT/wm-prepush-node-tests.XXXXXX") || exit 1
+DOM_TESTS_NUL=$(mktemp "$TEMP_ROOT/wm-prepush-dom-tests.XXXXXX") || exit 1
+WORKTREE_NUL=$(mktemp "$TEMP_ROOT/wm-prepush-worktree.XXXXXX") || exit 1
 trap 'rm -f "$CHANGED_NUL" "$CHANGED_LIVE_NUL" "$NODE_TESTS_NUL" "$DOM_TESTS_NUL" "$WORKTREE_NUL"' EXIT
 
 # read_paths: NUL stdin -> the _collected array (bash 3.2 has no namerefs, so

--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -24,6 +24,42 @@ async function isValidEnterpriseKey(key) {
   return timingSafeIncludes(key, validKeys);
 }
 
+async function validateCredential(key, forceKey) {
+  if (isSessionTokenShape(key)) {
+    // Anonymous session tokens are NOT proof of any specific user identity
+    // — anyone can mint one via POST /api/wm-session. Reject when the caller
+    // demands a "real" key (premium / tier-gated endpoints set forceKey=true
+    // exactly because they need user-bound auth or a Pro-grade Bearer JWT).
+    if (forceKey) {
+      return { valid: false, required: true, error: 'Pro authentication required' };
+    }
+    if (await validateSessionToken(key)) {
+      return { valid: true, required: false, kind: 'session' };
+    }
+    return { valid: false, required: true, error: 'Invalid session token' };
+  }
+
+  // Enterprise key (WORLDMONITOR_VALID_KEYS) — checked BEFORE the wm_ user-key
+  // fallthrough so an operator-issued key that happens to start with wm_ is
+  // still recognized. `credential` records the authority that actually won;
+  // downstream identity/rate-limit code must not infer it again from headers.
+  if (key && await isValidEnterpriseKey(key)) {
+    return { valid: true, required: true, kind: 'enterprise', credential: key };
+  }
+
+  // wm_-prefixed user API keys — gateway re-validates against the user-key
+  // table. We must return required:true / valid:false for the gateway fallback.
+  if (key && key.startsWith('wm_')) {
+    return { valid: false, required: true, error: USER_API_KEY_GATEWAY_VALIDATION_ERROR };
+  }
+
+  if (key) {
+    return { valid: false, required: true, error: 'Invalid API key' };
+  }
+
+  return { valid: false, required: true, error: 'API key required' };
+}
+
 function getCookie(req, name) {
   const raw = req.headers.get('Cookie') || req.headers.get('cookie') || '';
   if (!raw) return '';
@@ -64,66 +100,36 @@ export async function validateApiKey(req, options = {}) {
   const headerKey = getHeaderApiKey(req);
   const sessionCookie = getCookie(req, 'wm-session');
   const testerCookie = getCookie(req, 'wm-pro-key') || getCookie(req, 'wm-widget-key');
-  // Session-shaped headers (wms_) must not beat HttpOnly tester cookies.
-  // Returning tester/widget users mint a wms_ token in a new tab; JS cannot
-  // see wm-pro-key / wm-widget-key, so the interceptor still attaches wms_.
-  // headerKey || testerCookie would then authenticate as kind:'session' and
-  // 401 forceKey paths even though a valid pro cookie is on the wire.
-  const key = (headerKey && !isSessionTokenShape(headerKey) ? headerKey : '')
-    || testerCookie
-    || headerKey
-    || sessionCookie;
   const origin = req.headers.get('Origin') || '';
 
   // Desktop app — always require an enterprise key.
   if (isDesktopOrigin(origin)) {
     if (!headerKey) return { valid: false, required: true, error: 'API key required for desktop access' };
     if (!await isValidEnterpriseKey(headerKey)) return { valid: false, required: true, error: 'Invalid API key' };
-    return { valid: true, required: true, kind: 'enterprise' };
+    return { valid: true, required: true, kind: 'enterprise', credential: headerKey };
   }
 
-  // Browser anonymous session: HMAC-signed token from /api/wm-session.
-  // Validation is purely cryptographic — no DB lookup, no header trust.
-  if (isSessionTokenShape(key)) {
-    // Anonymous session tokens are NOT proof of any specific user identity
-    // — anyone can mint one via POST /api/wm-session. Reject when the caller
-    // demands a "real" key (premium / tier-gated endpoints set forceKey=true
-    // exactly because they need user-bound auth or a Pro-grade Bearer JWT).
-    if (forceKey) {
-      return { valid: false, required: true, error: 'Pro authentication required' };
-    }
-    if (await validateSessionToken(key)) {
-      return { valid: true, required: false, kind: 'session' };
-    }
-    return { valid: false, required: true, error: 'Invalid session token' };
+  // Explicit non-session headers remain authoritative. They are machine/API
+  // credentials and must never silently fall back to ambient browser cookies.
+  if (headerKey && !isSessionTokenShape(headerKey)) {
+    return validateCredential(headerKey, forceKey);
   }
 
-  // Enterprise key (WORLDMONITOR_VALID_KEYS) — checked BEFORE the wm_ user-key
-  // fallthrough so an operator-issued key that happens to start with wm_ is
-  // still recognized. Pre-#3541 the static allowlist accepted any prefix; some
-  // legacy operator keys (e.g. the Railway relay's WORLDMONITOR_RELAY_KEY) use
-  // the wm_ prefix from before user-issued keys were namespaced. Without this
-  // ordering, those keys get punted to validateUserApiKey() and 401 because
-  // the Convex user-key table has no record of an operator-minted value.
-  // Collision risk is negligible (wm_ user keys carry ≥192 bits of entropy
-  // and would have to be added to the static env list to be honored at all,
-  // which itself requires server-env-write access).
-  if (key && await isValidEnterpriseKey(key)) {
-    return { valid: true, required: true, kind: 'enterprise' };
+  // Returning tester/widget users mint an anonymous wms_ token in a new tab,
+  // while their real tester credential is HttpOnly. Prefer that cookie only
+  // after it validates. A rotated cookie must not permanently shadow the fresh
+  // anonymous header/cookie on non-forceKey routes.
+  if (testerCookie && await isValidEnterpriseKey(testerCookie)) {
+    return { valid: true, required: true, kind: 'enterprise', credential: testerCookie };
   }
 
-  // wm_-prefixed user API keys — gateway re-validates against the user-key
-  // table. We must return required:true / valid:false for the gateway's
-  // fallback at server/gateway.ts:~440 to trigger validateUserApiKey().
-  if (key && key.startsWith('wm_')) {
-    return { valid: false, required: true, error: USER_API_KEY_GATEWAY_VALIDATION_ERROR };
-  }
+  if (headerKey) return validateCredential(headerKey, forceKey);
+  if (sessionCookie) return validateCredential(sessionCookie, forceKey);
 
-  // Non-wm_ key that isn't in the enterprise allowlist.
-  if (key) {
-    return { valid: false, required: true, error: 'Invalid API key' };
-  }
+  // Preserve the useful invalid-key error when the only credential is a stale
+  // tester cookie. The fallback above applies only when valid anonymous
+  // authority is also present.
+  if (testerCookie) return { valid: false, required: true, error: 'Invalid API key' };
 
-  // No credentials at all.
   return { valid: false, required: true, error: 'API key required' };
 }

--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -64,7 +64,15 @@ export async function validateApiKey(req, options = {}) {
   const headerKey = getHeaderApiKey(req);
   const sessionCookie = getCookie(req, 'wm-session');
   const testerCookie = getCookie(req, 'wm-pro-key') || getCookie(req, 'wm-widget-key');
-  const key = headerKey || testerCookie || sessionCookie;
+  // Session-shaped headers (wms_) must not beat HttpOnly tester cookies.
+  // Returning tester/widget users mint a wms_ token in a new tab; JS cannot
+  // see wm-pro-key / wm-widget-key, so the interceptor still attaches wms_.
+  // headerKey || testerCookie would then authenticate as kind:'session' and
+  // 401 forceKey paths even though a valid pro cookie is on the wire.
+  const key = (headerKey && !isSessionTokenShape(headerKey) ? headerKey : '')
+    || testerCookie
+    || headerKey
+    || sessionCookie;
   const origin = req.headers.get('Origin') || '';
 
   // Desktop app — always require an enterprise key.

--- a/api/_api-key.test.mjs
+++ b/api/_api-key.test.mjs
@@ -98,6 +98,24 @@ test('dual wm-pro-key cookies use the first value sent by the browser', async ()
   assert.equal(r.kind, 'enterprise');
 });
 
+test('dual wm-session cookies use the first value sent by the browser', async () => {
+  // getCookie() is first-match. An invalid host-only wm-session listed first
+  // shadows a later valid Domain cookie — the production tombstone in
+  // api/wm-session.js exists so the browser should not send both after a mint.
+  const { token } = await issueSessionToken();
+  const shadowed = await validateApiKey(makeReq({
+    cookie: `wm-session=wms_invalid; wm-session=${encodeURIComponent(token)}`,
+  }));
+  assert.equal(shadowed.valid, false, 'first-match keeps the invalid host-only cookie');
+  assert.equal(shadowed.error, 'Invalid session token');
+
+  const tombstoned = await validateApiKey(makeReq({
+    cookie: `wm-session=${encodeURIComponent(token)}`,
+  }));
+  assert.equal(tombstoned.valid, true, 'after tombstone only the valid Domain cookie remains');
+  assert.equal(tombstoned.kind, 'session');
+});
+
 test('PR #3557 review: wms_ session token is REJECTED when forceKey=true (premium endpoints)', async () => {
   // wms_ tokens are anonymous and freely mintable via /api/wm-session — they
   // are NOT proof of a paying user. forceKey=true means the route demands a
@@ -106,6 +124,65 @@ test('PR #3557 review: wms_ session token is REJECTED when forceKey=true (premiu
   const r = await validateApiKey(makeReq({ key: token }), { forceKey: true });
   assert.equal(r.valid, false);
   assert.equal(r.required, true);
+  assert.match(r.error, /Pro authentication/);
+});
+
+// Returning tester/widget users mint a wms_ token in a new tab. JS cannot see
+// HttpOnly wm-pro-key / wm-widget-key, so sendWith still attaches wms_. A
+// session-shaped header must not beat the tester cookie (kind:'session' would
+// 401 forceKey paths even though a valid pro cookie is on the wire).
+
+test('wms_ header + wm-pro-key cookie authenticates as enterprise (header + shadowed cookie → valid)', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({
+    key: token,
+    cookie: `wm-pro-key=${encodeURIComponent(ENTERPRISE_KEY)}`,
+  }));
+  assert.equal(r.valid, true);
+  assert.equal(r.kind, 'enterprise');
+});
+
+test('wms_ header + wm-pro-key cookie + forceKey still authenticates as enterprise', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({
+    key: token,
+    cookie: `wm-pro-key=${encodeURIComponent(ENTERPRISE_KEY)}`,
+  }), { forceKey: true });
+  assert.equal(r.valid, true, 'wms_ must not 401 a forceKey request that also carries wm-pro-key');
+  assert.equal(r.kind, 'enterprise');
+});
+
+test('wms_ header + wm-widget-key cookie authenticates as enterprise (header + shadowed cookie → valid)', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({
+    key: token,
+    cookie: `wm-widget-key=${encodeURIComponent(ENTERPRISE_KEY)}`,
+  }));
+  assert.equal(r.valid, true);
+  assert.equal(r.kind, 'enterprise');
+});
+
+test('wms_ header + wm-widget-key cookie + forceKey still authenticates as enterprise', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({
+    key: token,
+    cookie: `wm-widget-key=${encodeURIComponent(ENTERPRISE_KEY)}`,
+  }), { forceKey: true });
+  assert.equal(r.valid, true, 'wms_ must not 401 a forceKey request that also carries wm-widget-key');
+  assert.equal(r.kind, 'enterprise');
+});
+
+test('wms_ header ALONE is still kind session (XP preserved)', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({ key: token }));
+  assert.equal(r.valid, true);
+  assert.equal(r.kind, 'session');
+});
+
+test('wms_ header ALONE + forceKey is still rejected with Pro authentication', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({ key: token }), { forceKey: true });
+  assert.equal(r.valid, false);
   assert.match(r.error, /Pro authentication/);
 });
 

--- a/api/_api-key.test.mjs
+++ b/api/_api-key.test.mjs
@@ -80,6 +80,7 @@ test('HttpOnly wm-pro-key cookie is accepted as enterprise key without a JS-read
   assert.equal(r.valid, true);
   assert.equal(r.required, true);
   assert.equal(r.kind, 'enterprise');
+  assert.equal(r.credential, ENTERPRISE_KEY, 'result must expose the credential that actually authenticated');
 });
 
 test('HttpOnly wm-widget-key cookie is accepted as enterprise key without a JS-readable header', async () => {
@@ -87,6 +88,7 @@ test('HttpOnly wm-widget-key cookie is accepted as enterprise key without a JS-r
   assert.equal(r.valid, true);
   assert.equal(r.required, true);
   assert.equal(r.kind, 'enterprise');
+  assert.equal(r.credential, ENTERPRISE_KEY, 'result must expose the credential that actually authenticated');
 });
 
 test('dual wm-pro-key cookies use the first value sent by the browser', async () => {
@@ -140,6 +142,7 @@ test('wms_ header + wm-pro-key cookie authenticates as enterprise (header + shad
   }));
   assert.equal(r.valid, true);
   assert.equal(r.kind, 'enterprise');
+  assert.equal(r.credential, ENTERPRISE_KEY, 'automatic wms_ must not become the enterprise principal');
 });
 
 test('wms_ header + wm-pro-key cookie + forceKey still authenticates as enterprise', async () => {
@@ -150,6 +153,7 @@ test('wms_ header + wm-pro-key cookie + forceKey still authenticates as enterpri
   }), { forceKey: true });
   assert.equal(r.valid, true, 'wms_ must not 401 a forceKey request that also carries wm-pro-key');
   assert.equal(r.kind, 'enterprise');
+  assert.equal(r.credential, ENTERPRISE_KEY);
 });
 
 test('wms_ header + wm-widget-key cookie authenticates as enterprise (header + shadowed cookie → valid)', async () => {
@@ -160,6 +164,7 @@ test('wms_ header + wm-widget-key cookie authenticates as enterprise (header + s
   }));
   assert.equal(r.valid, true);
   assert.equal(r.kind, 'enterprise');
+  assert.equal(r.credential, ENTERPRISE_KEY, 'automatic wms_ must not become the enterprise principal');
 });
 
 test('wms_ header + wm-widget-key cookie + forceKey still authenticates as enterprise', async () => {
@@ -170,6 +175,42 @@ test('wms_ header + wm-widget-key cookie + forceKey still authenticates as enter
   }), { forceKey: true });
   assert.equal(r.valid, true, 'wms_ must not 401 a forceKey request that also carries wm-widget-key');
   assert.equal(r.kind, 'enterprise');
+  assert.equal(r.credential, ENTERPRISE_KEY);
+});
+
+for (const cookieName of ['wm-pro-key', 'wm-widget-key']) {
+  test(`stale ${cookieName} does not shadow a valid wms_ header on anonymous routes`, async () => {
+    const { token } = await issueSessionToken();
+    const r = await validateApiKey(makeReq({
+      key: token,
+      cookie: `${cookieName}=${encodeURIComponent('rotated-old-key')}`,
+    }));
+    assert.equal(r.valid, true);
+    assert.equal(r.required, false);
+    assert.equal(r.kind, 'session');
+    assert.equal(r.credential, undefined);
+  });
+}
+
+test('stale tester cookie does not shadow a valid HttpOnly wm-session cookie', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({
+    cookie: `wm-pro-key=${encodeURIComponent('rotated-old-key')}; wm-session=${encodeURIComponent(token)}`,
+  }));
+  assert.equal(r.valid, true);
+  assert.equal(r.required, false);
+  assert.equal(r.kind, 'session');
+});
+
+test('stale tester cookie cannot turn anonymous authority into forceKey access', async () => {
+  const { token } = await issueSessionToken();
+  const r = await validateApiKey(makeReq({
+    key: token,
+    cookie: `wm-pro-key=${encodeURIComponent('rotated-old-key')}`,
+  }), { forceKey: true });
+  assert.equal(r.valid, false);
+  assert.equal(r.required, true);
+  assert.match(r.error, /Pro authentication/);
 });
 
 test('wms_ header ALONE is still kind session (XP preserved)', async () => {
@@ -199,6 +240,7 @@ test('enterprise key carries kind=enterprise (the only key kind that bypasses en
   const r = await validateApiKey(makeReq({ key: ENTERPRISE_KEY }));
   assert.equal(r.valid, true);
   assert.equal(r.kind, 'enterprise');
+  assert.equal(r.credential, ENTERPRISE_KEY);
 });
 
 test('enterprise key allowlist uses timingSafeIncludes, not Array.includes', async () => {

--- a/api/v2/shipping/webhooks/[subscriberId].ts
+++ b/api/v2/shipping/webhooks/[subscriberId].ts
@@ -67,7 +67,7 @@ export default async function handler(req: Request): Promise<Response> {
     });
   }
 
-  const ownerHash = await callerFingerprint(req);
+  const ownerHash = await callerFingerprint(req, apiKeyResult.credential);
   if (record.ownerTag !== ownerHash) {
     return new Response(JSON.stringify({ error: 'Forbidden' }), {
       status: 403,

--- a/api/v2/shipping/webhooks/[subscriberId]/[action].ts
+++ b/api/v2/shipping/webhooks/[subscriberId]/[action].ts
@@ -79,7 +79,7 @@ export default async function handler(req: Request): Promise<Response> {
     });
   }
 
-  const ownerHash = await callerFingerprint(req);
+  const ownerHash = await callerFingerprint(req, apiKeyResult.credential);
   if (record.ownerTag !== ownerHash) {
     return new Response(JSON.stringify({ error: 'Forbidden' }), {
       status: 403,

--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -21,6 +21,8 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { timingSafeEqualSecret, timingSafeIncludes } from './_crypto.js';
+// @ts-expect-error — JS module, no declaration file
+import { isSessionTokenShape } from './_session.js';
 import { validateBearerToken } from '../server/auth-session';
 import { getBillingVerificationDenial, getEntitlements } from '../server/_shared/entitlement-check';
 
@@ -97,10 +99,14 @@ export default async function handler(req: Request): Promise<Response> {
     req.headers.get('X-WorldMonitor-Key') ??
     req.headers.get('X-Api-Key') ??
     '';
+  const explicitWorldMonitorKey = isSessionTokenShape(headerWorldMonitorKey)
+    ? ''
+    : headerWorldMonitorKey;
   const worldMonitorKey =
-    headerWorldMonitorKey ||
+    explicitWorldMonitorKey ||
     getCookie(req, 'wm-pro-key') ||
-    getCookie(req, 'wm-widget-key');
+    getCookie(req, 'wm-widget-key') ||
+    headerWorldMonitorKey;
   if (await hasValidWorldMonitorKey(worldMonitorKey)) {
     isPro = true;
   } else {

--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -89,6 +89,16 @@ function sessionCookie(req, name, value) {
   return `${name}=${encodeURIComponent(value)}; Path=/; Max-Age=${COOKIE_MAX_AGE_SECONDS}${cookieDomainAttribute(req)}; HttpOnly; Secure; SameSite=Lax`;
 }
 
+/**
+ * Host-only Max-Age=0 tombstone for the same name/path. An older api-host
+ * wm-session (no Domain) would otherwise shadow the new Domain=.worldmonitor.app
+ * cookie: browsers send both, and first-match readers keep the stale host-only
+ * value. Only emit this on shared-domain production hosts.
+ */
+function hostOnlySessionTombstone() {
+  return `${SESSION_COOKIE}=; Path=/; Max-Age=0; HttpOnly; Secure; SameSite=Lax`;
+}
+
 function clearReadableCookie(name) {
   return `${name}=; Domain=.worldmonitor.app; Path=/; Max-Age=0; Secure; SameSite=Lax`;
 }
@@ -217,7 +227,12 @@ export default async function handler(req, ctx) {
     return respond({ error: 'Invalid session key' }, 401, cors, 'auth_401');
   }
 
-  let headers = appendHeader(cors, 'Set-Cookie', sessionCookie(req, SESSION_COOKIE, issued.token));
+  let headers = cors;
+  if (shouldUseSharedCookieDomain(req)) {
+    // Tombstone first so the subsequent Domain cookie is the only live wm-session.
+    headers = appendHeader(headers, 'Set-Cookie', hostOnlySessionTombstone());
+  }
+  headers = appendHeader(headers, 'Set-Cookie', sessionCookie(req, SESSION_COOKIE, issued.token));
 
   // Best-effort cleanup for old JS-readable cookies only when replacing that
   // key. A no-key session refresh must preserve existing HttpOnly key cookies.

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -73,7 +73,13 @@ function setCookies(resp) {
 
 function cookieValue(cookies, name) {
   const prefix = `${name}=`;
-  const found = cookies.find((cookie) => cookie.startsWith(prefix));
+  const found = cookies.find((cookie) => {
+    if (!cookie.startsWith(prefix)) return false;
+    const attrs = cookie.split(';').map((part) => part.trim().toLowerCase());
+    const maxAge = attrs.find((attr) => attr.startsWith('max-age='));
+    if (maxAge && Number(maxAge.slice('max-age='.length)) <= 0) return false;
+    return true;
+  });
   if (!found) return '';
   return decodeURIComponent(found.slice(prefix.length).split(';')[0]);
 }
@@ -125,6 +131,27 @@ test('POST sets a valid HttpOnly cookie and returns the anonymous-only fallback 
   assert.equal(await validateSessionToken(token), true);
   assert.match(cookies.join('\n'), /wm-session=.*HttpOnly/);
   assert.match(cookies.join('\n'), /wm-session=.*Domain=\.worldmonitor\.app/);
+});
+
+test('production Set-Cookie tombstones the host-only cookie before the shared-domain cookie', async () => {
+  // An older api.worldmonitor.app host-only wm-session would otherwise shadow
+  // Domain=.worldmonitor.app. Tombstone first, then the live Domain cookie.
+  const resp = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }));
+  assert.equal(resp.status, 200);
+  const body = await resp.json();
+  const cookies = setCookies(resp);
+  const sessionCookies = cookies.filter((cookie) => cookie.startsWith('wm-session='));
+  assert.equal(sessionCookies.length, 2, 'host-only tombstone then Domain cookie');
+  assert.match(sessionCookies[0], /^wm-session=; Path=\/; Max-Age=0; HttpOnly; Secure; SameSite=Lax$/);
+  assert.match(sessionCookies[0], /HttpOnly/);
+  assert.doesNotMatch(sessionCookies[0], /Domain=/);
+  assert.match(sessionCookies[1], /Domain=\.worldmonitor\.app/);
+  assert.match(sessionCookies[1], /HttpOnly/);
+  assert.match(sessionCookies[1], /SameSite=Lax/);
+  assert.doesNotMatch(sessionCookies[1], /SameSite=None/);
+  const token = cookieValue(cookies, 'wm-session');
+  assert.equal(body.token, token, 'live Domain cookie value still equals the JSON token');
+  assert.match(token, /^wms_/);
 });
 
 test('POST emits one anonymous mint usage event without exposing cookie material', async () => {
@@ -246,9 +273,9 @@ test('localhost session cookie remains host-only for dev', async () => {
   const resp = await handler(makeLocalReq('POST', { origin: 'http://localhost:5173' }));
   assert.equal(resp.status, 200);
   const cookies = setCookies(resp);
-  const session = cookies.find((cookie) => cookie.startsWith('wm-session='));
-  assert.ok(session, 'wm-session cookie should be set');
-  assert.doesNotMatch(session, /Domain=/);
+  const sessionCookies = cookies.filter((cookie) => cookie.startsWith('wm-session='));
+  assert.equal(sessionCookies.length, 1, 'localhost must not emit a host-only tombstone');
+  assert.doesNotMatch(sessionCookies[0], /Domain=/);
 });
 
 test('OPTIONS preflight returns 204 with CORS', async () => {

--- a/scripts/company-monitoring-blind-evaluation.mts
+++ b/scripts/company-monitoring-blind-evaluation.mts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import {
   BlindEvaluationError,
   canonicalReportJson,
@@ -196,24 +198,40 @@ function score(values: string[]): { json: string; outcome: ScoreReport['outcome'
 const EXIT_ENGINE_ERROR = 1;
 const EXIT_GATE_NOT_PASSED = 2;
 
-function main(): void {
-  const [commandValue, ...values] = process.argv.slice(2);
-  const command = commandValue as Command | undefined;
-  if (!command) usage();
-  if (command === 'forecast') process.stdout.write(`${forecast(values)}\n`);
-  else if (command === 'score') {
-    const { json, outcome } = score(values);
-    process.stdout.write(`${json}\n`);
-    if (outcome !== 'pass') process.exitCode = EXIT_GATE_NOT_PASSED;
-  } else process.stdout.write(`${digestCommand(command, values)}\n`);
+export type BlindEvaluationCliResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: 0 | typeof EXIT_ENGINE_ERROR | typeof EXIT_GATE_NOT_PASSED;
+};
+
+export function runBlindEvaluationCli(args: string[]): BlindEvaluationCliResult {
+  try {
+    const [commandValue, ...values] = args;
+    const command = commandValue as Command | undefined;
+    if (!command) usage();
+    if (command === 'forecast') {
+      return { stdout: `${forecast(values)}\n`, stderr: '', exitCode: 0 };
+    }
+    if (command === 'score') {
+      const { json, outcome } = score(values);
+      return {
+        stdout: `${json}\n`,
+        stderr: '',
+        exitCode: outcome === 'pass' ? 0 : EXIT_GATE_NOT_PASSED,
+      };
+    }
+    return { stdout: `${digestCommand(command, values)}\n`, stderr: '', exitCode: 0 };
+  } catch (error) {
+    const message = error instanceof BlindEvaluationError
+      ? error.code
+      : error instanceof Error ? error.message : String(error);
+    return { stdout: '', stderr: `${message}\n`, exitCode: EXIT_ENGINE_ERROR };
+  }
 }
 
-try {
-  main();
-} catch (error) {
-  const message = error instanceof BlindEvaluationError
-    ? error.code
-    : error instanceof Error ? error.message : String(error);
-  process.stderr.write(`${message}\n`);
-  process.exitCode = EXIT_ENGINE_ERROR;
+if (process.argv[1] && pathToFileURL(resolve(process.argv[1])).href === import.meta.url) {
+  const result = runBlindEvaluationCli(process.argv.slice(2));
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  process.exitCode = result.exitCode;
 }

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -721,7 +721,7 @@ export async function fetchTradeFlows() {
 
   for (const [reporter, partner] of pairs) {
     await fetchFlowPair(reporter, partner, flows, stats, now);
-    await sleep(500);
+    if (!process.env.NODE_TEST_CONTEXT) await sleep(500);
   }
 
   const coverage = {

--- a/server/__tests__/gateway-api-rate-limit.test.ts
+++ b/server/__tests__/gateway-api-rate-limit.test.ts
@@ -72,6 +72,7 @@ vi.mock("../_shared/user-api-key", () => ({
 }));
 
 import { createDomainGateway } from "../gateway";
+import { hashKeySync } from "../_shared/usage-identity";
 
 function makeGateway() {
   return createDomainGateway([
@@ -91,6 +92,16 @@ function userKeyRequest() {
   return new Request("https://www.worldmonitor.app/api/news/v1/list-feed-digest", {
     method: "GET",
     headers: { "X-Api-Key": "wm_test_starter_key" },
+  });
+}
+
+function mixedEnterpriseRequest(sessionToken: string) {
+  return new Request("https://www.worldmonitor.app/api/news/v1/list-feed-digest", {
+    method: "GET",
+    headers: {
+      "X-WorldMonitor-Key": sessionToken,
+      Cookie: "wm-pro-key=enterprise-browser-key",
+    },
   });
 }
 
@@ -119,6 +130,24 @@ afterEach(() => {
 });
 
 describe("#3199 U4 — gateway per-account rate-limit wiring", () => {
+  test("mixed browser auth keeps the enterprise burst identity stable across wms_ rotation", async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = "enterprise-browser-key";
+    process.env.API_RATE_LIMIT_ENFORCE = "true";
+    const gateway = makeGateway();
+
+    const first = await gateway(mixedEnterpriseRequest("wms_first-anonymous-session"), ctx);
+    const second = await gateway(mixedEnterpriseRequest("wms_second-anonymous-session"), ctx);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(checkBurst).toHaveBeenCalledTimes(2);
+    expect(checkBurst.mock.calls.map(([, identity]) => identity)).toEqual([
+      hashKeySync("enterprise-browser-key"),
+      hashKeySync("enterprise-browser-key"),
+    ]);
+    expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
   test("eligible Starter wm_ key engages the per-account layer (isUserApiKey discriminator)", async () => {
     const res = await makeGateway()(userKeyRequest(), ctx);
     expect(res.status).toBe(200);

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -1200,11 +1200,11 @@ export function createDomainGateway(
     // request). Telemetry stays attributed via the verified userId set
     // above; entitlement re-check (`features.tier ≥ 1 && mcpAccess`) was
     // already performed before flipping `internalMcpVerified = true`.
-    let keyCheck: { valid: boolean; required: boolean; error?: string; kind?: 'enterprise' | 'session' | 'user' } = internalMcpVerified || isPublicNoAuthRpc || seedRefreshVerified || relayWarmPingVerified
+    let keyCheck: { valid: boolean; required: boolean; error?: string; kind?: 'enterprise' | 'session' | 'user'; credential?: string } = internalMcpVerified || isPublicNoAuthRpc || seedRefreshVerified || relayWarmPingVerified
       ? { valid: true, required: false }
       : ((await validateApiKey(request, {
           forceKey: (isTierGated && !sessionUserId) || needsLegacyProBearerGate,
-        })) as { valid: boolean; required: boolean; error?: string; kind?: 'enterprise' | 'session' | 'user' });
+        })) as { valid: boolean; required: boolean; error?: string; kind?: 'enterprise' | 'session' | 'user'; credential?: string });
 
     // User-owned API keys (wm_ prefix): when the static WORLDMONITOR_VALID_KEYS
     // check fails, try async Convex-backed validation for user-issued keys.
@@ -1312,8 +1312,14 @@ export function createDomainGateway(
     // them valid, wmKey is set, !isUserApiKey, and 'wms_' doesn't startsWith
     // 'wm_'), so telemetry mislabelled them as enterprise_api_key with
     // customer_id='enterprise-unmapped'. PR #3557 round-3 review.
-    if (keyCheck.valid && wmKey && !isUserApiKey && keyCheck.kind === 'enterprise') {
-      usage.enterpriseApiKey = wmKey;
+    // A browser request can carry both an automatic wms_ header and an HttpOnly
+    // enterprise cookie. Use the credential validateApiKey actually selected;
+    // the raw header belongs to a different anonymous principal.
+    const enterpriseCredential = keyCheck.valid && keyCheck.kind === 'enterprise'
+      ? (keyCheck.credential ?? wmKey)
+      : '';
+    if (enterpriseCredential && !isUserApiKey) {
+      usage.enterpriseApiKey = enterpriseCredential;
     }
 
     // ── Active-subscription gate for user API keys (#4611) ──────────────────
@@ -1501,7 +1507,10 @@ export function createDomainGateway(
     // tier ≥ 1 + mcpAccess === true above. Some ENDPOINT_ENTITLEMENTS
     // routes require tier 2, but Pro MCP callers only reach the gateway
     // through the MCP edge's whitelisted tool set.
-    const isEnterpriseAuth = keyCheck.valid && wmKey && !isUserApiKey && keyCheck.kind === 'enterprise';
+    const isEnterpriseAuth = keyCheck.valid
+      && Boolean(enterpriseCredential)
+      && !isUserApiKey
+      && keyCheck.kind === 'enterprise';
     if (!isEnterpriseAuth && !internalMcpVerified && !seedRefreshVerified && !relayWarmPingVerified) {
       const entitlementCheck = await checkEntitlementDetailed(sessionUserId, pathname, corsHeaders, {
         clerkRole: sessionRole,
@@ -1738,7 +1747,7 @@ export function createDomainGateway(
           // minting keys, and each operator key gets its own 1,000/min budget
           // rather than contending for one shared bucket. (User keys below key
           // on userId so a customer can't multiply their allowance.)
-          identity = wmKey ? hashKeySync(wmKey) : '';
+          identity = hashKeySync(enterpriseCredential);
         } else if (sessionUserId) {
           // Reuse the entitlement the #4611 gate above already resolved for this
           // same user key (undefined ⇒ the gate didn't run, e.g. a Clerk-session

--- a/server/worldmonitor/shipping/v2/list-webhooks.ts
+++ b/server/worldmonitor/shipping/v2/list-webhooks.ts
@@ -29,7 +29,7 @@ export async function listWebhooks(
   // sides equal 'anon' — exposing every 'anon'-bucket tenant's webhooks to
   // every Clerk-session holder. See registerWebhook for full rationale.
   const apiKeyResult = (await validateApiKey(ctx.request, { forceKey: true })) as {
-    valid: boolean; required: boolean; error?: string;
+    valid: boolean; required: boolean; error?: string; credential?: string;
   };
   if (apiKeyResult.required && !apiKeyResult.valid) {
     throw new ApiError(401, apiKeyResult.error ?? 'API key required', '');
@@ -37,7 +37,7 @@ export async function listWebhooks(
 
   await requirePremiumRpcAccess(ctx.request, ApiError, 'PRO subscription required');
 
-  const ownerHash = await callerFingerprint(ctx.request);
+  const ownerHash = await callerFingerprint(ctx.request, apiKeyResult.credential);
   const smembersResult = await runRedisPipeline([['SMEMBERS', ownerIndexKey(ownerHash)]]);
   const memberIds = (smembersResult[0]?.result as string[] | null) ?? [];
 

--- a/server/worldmonitor/shipping/v2/register-webhook.ts
+++ b/server/worldmonitor/shipping/v2/register-webhook.ts
@@ -39,7 +39,7 @@ export async function registerWebhook(
   // gate and the documented "X-WorldMonitor-Key required" contract in
   // docs/api-shipping-v2.mdx.
   const apiKeyResult = (await validateApiKey(ctx.request, { forceKey: true })) as {
-    valid: boolean; required: boolean; error?: string;
+    valid: boolean; required: boolean; error?: string; credential?: string;
   };
   if (apiKeyResult.required && !apiKeyResult.valid) {
     throw new ApiError(401, apiKeyResult.error ?? 'API key required', '');
@@ -80,7 +80,7 @@ export async function registerWebhook(
     ]);
   }
 
-  const ownerTag = await callerFingerprint(ctx.request);
+  const ownerTag = await callerFingerprint(ctx.request, apiKeyResult.credential);
   const newSubscriberId = generateSubscriberId();
   const secret = await generateSecret();
 

--- a/server/worldmonitor/shipping/v2/webhook-shared.ts
+++ b/server/worldmonitor/shipping/v2/webhook-shared.ts
@@ -154,12 +154,12 @@ export function ownerIndexKey(ownerHash: string): string {
   return `webhook:owner:${ownerHash}:v1`;
 }
 
-/** SHA-256 hash of the caller's API key — used as ownerTag and owner index key. Never secret. */
-export async function callerFingerprint(req: Request): Promise<string> {
-  const key =
-    req.headers.get('X-WorldMonitor-Key') ??
-    req.headers.get('X-Api-Key') ??
-    '';
+/** SHA-256 hash of the resolved API credential — used as ownerTag and owner index key. Never secret. */
+export async function callerFingerprint(req: Request, resolvedCredential?: string): Promise<string> {
+  const key = resolvedCredential
+    ?? req.headers.get('X-WorldMonitor-Key')
+    ?? req.headers.get('X-Api-Key')
+    ?? '';
   if (!key) return 'anon';
   const encoded = new TextEncoder().encode(key);
   const hashBuffer = await crypto.subtle.digest('SHA-256', encoded);

--- a/shared/company-monitoring-evaluation.ts
+++ b/shared/company-monitoring-evaluation.ts
@@ -394,7 +394,9 @@ export function stratifiedBootstrapUpperBound(examples: CalibrationExample[], ca
     for (const [, stratum] of orderedStrata) {
       for (let index = 0; index < stratum.length; index += 1) {
         const example = stratum[Math.floor(random() * stratum.length)]!;
-        sampleCounts[sortedRank.get(example)!] += 1;
+        const rank = sortedRank.get(example);
+        assert.ok(rank !== undefined, 'bootstrap example must have a canonical rank');
+        sampleCounts[rank] = sampleCounts[rank]! + 1;
       }
     }
 

--- a/shared/company-monitoring-evaluation.ts
+++ b/shared/company-monitoring-evaluation.ts
@@ -371,6 +371,13 @@ export function stratifiedBootstrapUpperBound(examples: CalibrationExample[], ca
   const seed = asNumber(calibration.bootstrapSeed, 'bootstrapSeed');
   const confidence = asNumber(calibration.confidenceLevel, 'calibration.confidenceLevel');
   const random = mulberry32(seed);
+  assert.ok(examples.length > 0, 'calibration examples must not be empty');
+  const sorted = [...examples].sort(
+    (left, right) => left.confidence - right.confidence
+      || compareCodePoints(left.opaqueExampleId, right.opaqueExampleId),
+  );
+  const sortedRank = new Map(sorted.map((example, index) => [example, index]));
+  const sampleCounts = new Uint32Array(sorted.length);
   const strata = new Map<string, CalibrationExample[]>();
   for (const example of examples) {
     const key = `${example.goldMateriality}\u0000${example.goldDirection}`;
@@ -383,13 +390,41 @@ export function stratifiedBootstrapUpperBound(examples: CalibrationExample[], ca
   );
   const estimates: number[] = [];
   for (let iteration = 0; iteration < iterations; iteration += 1) {
-    const sample: CalibrationExample[] = [];
+    sampleCounts.fill(0);
     for (const [, stratum] of orderedStrata) {
       for (let index = 0; index < stratum.length; index += 1) {
-        sample.push(stratum[Math.floor(random() * stratum.length)]!);
+        const example = stratum[Math.floor(random() * stratum.length)]!;
+        sampleCounts[sortedRank.get(example)!] += 1;
       }
     }
-    estimates.push(adaptiveExpectedCalibrationError(sample));
+
+    // Every bootstrap sample is a multiset of the same frozen examples. Sorting
+    // that multiset 10,000 times produces the same order as walking this one
+    // canonical sort and expanding each sampled count. Keep the original
+    // per-example accumulation order so the frozen floating-point result is
+    // byte-for-byte identical without the repeated allocations and O(n log n)
+    // sorts that otherwise dominate the unit suite under concurrency.
+    const bins = Array.from({ length: 10 }, () => ({
+      count: 0,
+      confidence: 0,
+      correct: 0,
+    }));
+    let sampleIndex = 0;
+    for (const [rank, example] of sorted.entries()) {
+      for (let copy = 0; copy < sampleCounts[rank]!; copy += 1) {
+        const bin = bins[Math.min(9, Math.floor((sampleIndex * 10) / sorted.length))]!;
+        bin.count += 1;
+        bin.confidence += example.confidence;
+        if (example.correct) bin.correct += 1;
+        sampleIndex += 1;
+      }
+    }
+    estimates.push(bins.reduce((ece, bin) => {
+      if (bin.count === 0) return ece;
+      const averageConfidence = bin.confidence / bin.count;
+      const averageAccuracy = bin.correct / bin.count;
+      return ece + (bin.count / sorted.length) * Math.abs(averageConfidence - averageAccuracy);
+    }, 0));
   }
   estimates.sort((left, right) => left - right);
   return percentileOrderStatistic(estimates, confidence, iterations);

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -82,10 +82,10 @@ let cookieIssuedThisSession = false;
 // Latched once a mint proves the browser did not keep the previous cookie.
 let cookiePersistenceBroken = false;
 // Anonymous-only fallback for clients that reject the shared-domain HttpOnly
-// cookie. Kept in memory (never local/session storage) and activated only
-// after the server proves a prior cookie did not make the round trip.
+// cookie. Kept in memory (never local/session storage) and attached on
+// anonymous API calls as soon as a mint returns a token. Cookie remains
+// primary via credentials:include.
 let anonymousSessionHeaderToken: string | null = null;
-let useAnonymousSessionHeader = false;
 
 interface StoredSession {
   exp: number;
@@ -453,7 +453,6 @@ function noteMintCookieEvidence(hadSession: boolean, aCookieExistedWhenSent: boo
     // direct evidence outranks inference, same doctrine as noteRouteSuccess.
     cookieIssuedThisSession = true;
     cookiePersistenceBroken = false;
-    useAnonymousSessionHeader = false;
     return;
   }
   cookieIssuedThisSession = true;
@@ -470,7 +469,6 @@ function noteMintCookieEvidence(hadSession: boolean, aCookieExistedWhenSent: boo
   // without one: the browser is not storing it (strict cookie settings, an
   // in-app WebView, partitioned storage, a privacy extension).
   cookiePersistenceBroken = true;
-  useAnonymousSessionHeader = anonymousSessionHeaderToken !== null;
 }
 
 /**
@@ -556,17 +554,15 @@ async function mintSession(body?: { widgetKey?: string; proKey?: string }): Prom
       return { ok: false, cause: 'malformed' };
     }
     if (typeof data?.exp !== 'number') return { ok: false, cause: 'malformed' };
-    if (
-      sessionIdentityGeneration === identityGenerationWhenSent &&
-      typeof data.token === 'string' &&
-      data.token.startsWith('wms_')
-    ) {
-      anonymousSessionHeaderToken = data.token;
-    }
-    // Absent on an older deployment: treat as "no evidence either way" and
-    // leave the latch alone rather than accusing a healthy browser.
-    if (typeof data.hadSession === 'boolean') {
-      noteMintCookieEvidence(data.hadSession, aCookieExistedWhenSent);
+    if (sessionIdentityGeneration === identityGenerationWhenSent) {
+      if (typeof data.token === 'string' && data.token.startsWith('wms_')) {
+        anonymousSessionHeaderToken = data.token;
+      }
+      // Absent on an older deployment: treat as "no evidence either way" and
+      // leave the latch alone rather than accusing a healthy browser.
+      if (typeof data.hadSession === 'boolean') {
+        noteMintCookieEvidence(data.hadSession, aCookieExistedWhenSent);
+      }
     }
     return { ok: true, session: { exp: data.exp } };
   } catch {
@@ -585,11 +581,19 @@ export async function ensureWmSession(): Promise<boolean> {
   const stored = loadFromStorage();
   if (isFresh(stored)) {
     cached = stored;
-    return true;
+    // sessionStorage only stores {exp}. After reload the in-memory wms_
+    // token is gone; short-circuiting here would send the first RPC
+    // cookie-only (the XP bug). Remint unless we already have a token.
+    if (anonymousSessionHeaderToken) return true;
   }
 
+  const identityGenerationWhenStarted = sessionIdentityGeneration;
   inflight = (async () => {
     const fresh = await fetchNewSession();
+    // A key-session mint may replace this anonymous identity while its request
+    // is in flight. The replacement is already authoritative; let the caller
+    // replay through it without overwriting its cache or persistence verdict.
+    if (sessionIdentityGeneration !== identityGenerationWhenStarted) return true;
     if (fresh) {
       cached = fresh;
       sessionGeneration += 1;
@@ -600,7 +604,6 @@ export async function ensureWmSession(): Promise<boolean> {
       // as the API rejecting a good cookie (WORLDMONITOR-WG/XP).
       if (cookiePersistenceBroken) {
         if (anonymousSessionHeaderToken) {
-          useAnonymousSessionHeader = true;
           return true;
         }
         markWmSessionDead('cookie_not_persisted', '/api/wm-session');
@@ -638,7 +641,6 @@ export async function establishWmKeySession(keys: { widgetKey?: string; proKey?:
   recentRouteFailures.clear();
   cookiePersistenceBroken = false;
   anonymousSessionHeaderToken = null;
-  useAnonymousSessionHeader = false;
   saveToStorage(fresh);
   return true;
 }
@@ -671,7 +673,6 @@ export function __resetWmSessionForTests(): void {
   cookieIssuedThisSession = false;
   cookiePersistenceBroken = false;
   anonymousSessionHeaderToken = null;
-  useAnonymousSessionHeader = false;
   lastMintFailureCause = null;
   sentryEnqueue = enqueueSentryCall;
   fetchNewSessionTimeoutMs = 10_000;
@@ -865,8 +866,12 @@ export function installWmSessionFetchInterceptor(): void {
 
     const sendWith = (h: Headers, src: typeof input): Promise<Response> => {
       const requestHeaders = new Headers(h);
+      // Attach whenever the mint already handed us a token. Waiting on
+      // useAnonymousSessionHeader left the first post-mint RPC cookie-only,
+      // which 401s when the HttpOnly cookie has not landed yet (or never
+      // will). Cookie remains primary via credentials:'include'; the header
+      // is a same-token backup and is skipped if the caller already authed.
       if (
-        useAnonymousSessionHeader &&
         anonymousSessionHeaderToken &&
         !requestHeaders.has('Authorization') &&
         !requestHeaders.has('X-WorldMonitor-Key') &&
@@ -992,9 +997,6 @@ export function installWmSessionFetchInterceptor(): void {
         // false, so hadSession:false alone cannot safely prove persistence is
         // broken, while replaying without the returned token would send every
         // concurrent follower into the retry_401 quorum.
-        if (isCurrentSessionIdentity() && anonymousSessionHeaderToken) {
-          useAnonymousSessionHeader = true;
-        }
         const retryResp = await replayAndReport();
         return retryResp.status === 401 ? null : retryResp;
       })();

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -770,23 +770,20 @@ test('a tick that runs nothing while deferring due work exits non-zero', async (
   // published nothing and shed work. `ran:0 deferred:>0` is indistinguishable
   // from a healthy no-op in Railway's badge, so the runner has to say so.
   //
-  // A degraded Upstash is the production shape: four fresh sections whose
-  // reads each take ~4.5s (under the runner's 5s read timeout, so they still
-  // resolve as fresh and are skipped rather than run) push elapsed past the
-  // 15s admission headroom, and DUE then no longer fits.
+  // A degraded Upstash is the production shape: nine fresh sections whose
+  // reads each take ~2s push elapsed past the 15s admission headroom, and DUE
+  // then no longer fits. Keep each response well below the runner's 5s read
+  // timeout: a 4.5s fixture used to race that timeout under suite contention,
+  // turning a freshness test into a load-dependent false red.
   const cleanupDue = writeFixture('_bundle-fixture-starved-due.mjs', `console.log('due-ran');\n`);
   const freshMeta = JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 });
+  const freshKeys = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'];
   const redis = await startFakeUpstash({
-    getDelayMs: 4_500,
-    strings: new Map([
-      ['seed-meta:starve:a', freshMeta],
-      ['seed-meta:starve:b', freshMeta],
-      ['seed-meta:starve:c', freshMeta],
-      ['seed-meta:starve:d', freshMeta],
-    ]),
+    getDelayMs: 2_000,
+    strings: new Map(freshKeys.map((key) => [`seed-meta:starve:${key}`, freshMeta])),
   });
   try {
-    const skipped = ['a', 'b', 'c', 'd'].map((k) => ({
+    const skipped = freshKeys.map((k) => ({
       label: `FRESH_${k.toUpperCase()}`,
       script: '_bundle-fixture-starved-due.mjs',
       seedMetaKey: `starve:${k}`,
@@ -802,7 +799,7 @@ test('a tick that runs nothing while deferring due work exits non-zero', async (
       { UPSTASH_REDIS_REST_URL: redis.url, UPSTASH_REDIS_REST_TOKEN: redis.token },
     );
     assert.equal(code, 1, 'a tick that published nothing while starving due work is not a success');
-    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:4 deferred:1 failed:0 graceful:0/);
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:9 deferred:1 failed:0 graceful:0/);
     assert.match(
       stderr,
       /\[Bundle:test\] ran:0 while 1 due section\(s\) were deferred/,

--- a/tests/company-monitoring-blind-evaluation.test.mts
+++ b/tests/company-monitoring-blind-evaluation.test.mts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
+import { runBlindEvaluationCli } from '../scripts/company-monitoring-blind-evaluation.mts';
 import {
   BlindEvaluationError,
   canonicalReportJson,
@@ -1356,15 +1357,17 @@ describe('Company Monitoring cumulative continuation', () => {
 });
 
 describe('Company Monitoring blind evaluation CLI', () => {
+  const protocolPath = fileURLToPath(
+    new URL('./fixtures/company-monitoring-evaluation/protocol.json', import.meta.url),
+  );
+
   it('requires the independently retained pilot digest for forecast', () => {
     const result = spawnSync(
       fileURLToPath(new URL('../node_modules/.bin/tsx', import.meta.url)),
       [
         fileURLToPath(new URL('../scripts/company-monitoring-blind-evaluation.mts', import.meta.url)),
         'forecast',
-        '--protocol', fileURLToPath(
-          new URL('./fixtures/company-monitoring-evaluation/protocol.json', import.meta.url),
-        ),
+        '--protocol', protocolPath,
         '--approved-threshold-digest', APPROVED_THRESHOLD_DIGEST,
         '--pilot-corpus', 'unused.json',
         '--pilot-gold', 'unused.json',
@@ -1379,23 +1382,13 @@ describe('Company Monitoring blind evaluation CLI', () => {
   });
 
   it('refuses to seal an artifact under the wrong digest command', () => {
-    const result = spawnSync(
-      fileURLToPath(new URL('../node_modules/.bin/tsx', import.meta.url)),
-      [
-        fileURLToPath(new URL('../scripts/company-monitoring-blind-evaluation.mts', import.meta.url)),
-        'digest-corpus',
-        fileURLToPath(new URL('./fixtures/company-monitoring-evaluation/protocol.json', import.meta.url)),
-      ],
-      { encoding: 'utf8' },
-    );
-    assert.equal(result.status, 1);
+    const result = runBlindEvaluationCli(['digest-corpus', protocolPath]);
+    assert.equal(result.exitCode, 1);
     assert.match(result.stderr, /digest-corpus input schema invalid/);
   });
 
   it('rejects incomplete and nested-field artifacts in every digest command', () => {
     const workspace = mkdtempSync(join(tmpdir(), 'cm-blind-digest-cli-'));
-    const cli = fileURLToPath(new URL('../scripts/company-monitoring-blind-evaluation.mts', import.meta.url));
-    const tsx = fileURLToPath(new URL('../node_modules/.bin/tsx', import.meta.url));
     const bundle = lockedBundle({ namespace: 'digest-shapes' });
     const expansion = examples('digest-expansion', 2, 180_000);
     const cases = [
@@ -1445,18 +1438,18 @@ describe('Company Monitoring blind evaluation CLI', () => {
     const run = (command: string, value: unknown, name: string) => {
       const path = join(workspace, `${name}.json`);
       writeFileSync(path, JSON.stringify(value));
-      return spawnSync(tsx, [cli, command, path], { encoding: 'utf8' });
+      return runBlindEvaluationCli([command, path]);
     };
 
     try {
       for (const testCase of cases) {
         const incomplete = structuredClone(testCase.value);
         testCase.remove(incomplete);
-        assert.equal(run(testCase.command, incomplete, `${testCase.command}-missing`).status, 1);
+        assert.equal(run(testCase.command, incomplete, `${testCase.command}-missing`).exitCode, 1);
 
         const nested = structuredClone(testCase.value);
         testCase.nest(nested);
-        assert.equal(run(testCase.command, nested, `${testCase.command}-nested`).status, 1);
+        assert.equal(run(testCase.command, nested, `${testCase.command}-nested`).exitCode, 1);
       }
     } finally {
       rmSync(workspace, { recursive: true, force: true });
@@ -1465,20 +1458,15 @@ describe('Company Monitoring blind evaluation CLI', () => {
 
   it('separates a passing gate, a rejected gate, and an engine error by exit code', () => {
     const workspace = mkdtempSync(join(tmpdir(), 'cm-blind-cli-'));
-    const cli = fileURLToPath(new URL('../scripts/company-monitoring-blind-evaluation.mts', import.meta.url));
-    const tsx = fileURLToPath(new URL('../node_modules/.bin/tsx', import.meta.url));
-    const protocolPath = fileURLToPath(
-      new URL('./fixtures/company-monitoring-evaluation/protocol.json', import.meta.url),
-    );
 
-    const runScore = (bundle: ReturnType<typeof lockedBundle>): { status: number | null; stdout: string } => {
+    const runScore = (bundle: ReturnType<typeof lockedBundle>) => {
       const write = (name: string, value: unknown): string => {
         const path = join(workspace, name);
         writeFileSync(path, JSON.stringify(value));
         return path;
       };
-      const result = spawnSync(tsx, [
-        cli, 'score',
+      return runBlindEvaluationCli([
+        'score',
         '--protocol', protocolPath,
         '--approved-threshold-digest', APPROVED_THRESHOLD_DIGEST,
         '--corpus', write('corpus.json', bundle.corpus),
@@ -1486,13 +1474,12 @@ describe('Company Monitoring blind evaluation CLI', () => {
         '--gold', write('gold.json', bundle.gold),
         '--predictions', write('predictions.json', bundle.predictions),
         '--forecast', write('forecast.json', bundle.forecast),
-      ], { encoding: 'utf8' });
-      return { status: result.status, stdout: result.stdout };
+      ]);
     };
 
     try {
       const passing = runScore(lockedBundle({ namespace: 'cli-pass' }));
-      assert.equal(passing.status, 0);
+      assert.equal(passing.exitCode, 0);
       assert.equal((JSON.parse(passing.stdout) as ScoreReport).outcome, 'pass');
 
       // A rejected gate must NOT look like success to a wrapper checking $?.
@@ -1501,7 +1488,7 @@ describe('Company Monitoring blind evaluation CLI', () => {
         eligibleCount: 200,
         mistakes: 60,
       }));
-      assert.equal(rejected.status, 2);
+      assert.equal(rejected.exitCode, 2);
       assert.equal((JSON.parse(rejected.stdout) as ScoreReport).outcome, 'fail');
 
       const shortfall = runScore(lockedBundle({
@@ -1509,21 +1496,18 @@ describe('Company Monitoring blind evaluation CLI', () => {
         publishLimit: 90,
         mistakes: 20,
       }));
-      assert.equal(shortfall.status, 2);
+      assert.equal(shortfall.exitCode, 2);
       assert.equal((JSON.parse(shortfall.stdout) as ScoreReport).outcome, 'incomplete');
 
-      const usageError = spawnSync(tsx, [cli, 'score', '--corpus'], { encoding: 'utf8' });
-      assert.equal(usageError.status, 1);
+      const usageError = runBlindEvaluationCli(['score', '--corpus']);
+      assert.equal(usageError.exitCode, 1);
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }
   });
 
   it('requires all five continuation inputs together', () => {
-    const result = spawnSync(
-      fileURLToPath(new URL('../node_modules/.bin/tsx', import.meta.url)),
-      [
-        fileURLToPath(new URL('../scripts/company-monitoring-blind-evaluation.mts', import.meta.url)),
+    const result = runBlindEvaluationCli([
         'score',
         '--protocol', 'unused.json',
         '--approved-threshold-digest', APPROVED_THRESHOLD_DIGEST,
@@ -1536,10 +1520,8 @@ describe('Company Monitoring blind evaluation CLI', () => {
         '--previous-gold', 'unused.json',
         '--previous-predictions', 'unused.json',
         '--previous-report', 'unused.json',
-      ],
-      { encoding: 'utf8' },
-    );
-    assert.equal(result.status, 1);
+    ]);
+    assert.equal(result.exitCode, 1);
     assert.match(result.stderr, /continuation requires all five previous inputs/);
   });
 });

--- a/tests/company-monitoring-blind-evaluation.test.mts
+++ b/tests/company-monitoring-blind-evaluation.test.mts
@@ -1459,13 +1459,13 @@ describe('Company Monitoring blind evaluation CLI', () => {
   it('separates a passing gate, a rejected gate, and an engine error by exit code', () => {
     const workspace = mkdtempSync(join(tmpdir(), 'cm-blind-cli-'));
 
-    const runScore = (bundle: ReturnType<typeof lockedBundle>) => {
+    const scoreArgs = (bundle: ReturnType<typeof lockedBundle>): string[] => {
       const write = (name: string, value: unknown): string => {
         const path = join(workspace, name);
         writeFileSync(path, JSON.stringify(value));
         return path;
       };
-      return runBlindEvaluationCli([
+      return [
         'score',
         '--protocol', protocolPath,
         '--approved-threshold-digest', APPROVED_THRESHOLD_DIGEST,
@@ -1474,8 +1474,10 @@ describe('Company Monitoring blind evaluation CLI', () => {
         '--gold', write('gold.json', bundle.gold),
         '--predictions', write('predictions.json', bundle.predictions),
         '--forecast', write('forecast.json', bundle.forecast),
-      ]);
+      ];
     };
+    const runScore = (bundle: ReturnType<typeof lockedBundle>) =>
+      runBlindEvaluationCli(scoreArgs(bundle));
 
     try {
       const passing = runScore(lockedBundle({ namespace: 'cli-pass' }));
@@ -1483,13 +1485,30 @@ describe('Company Monitoring blind evaluation CLI', () => {
       assert.equal((JSON.parse(passing.stdout) as ScoreReport).outcome, 'pass');
 
       // A rejected gate must NOT look like success to a wrapper checking $?.
-      const rejected = runScore(lockedBundle({
+      const rejectedArgs = scoreArgs(lockedBundle({
         namespace: 'cli-fail',
         eligibleCount: 200,
         mistakes: 60,
       }));
+      const rejected = runBlindEvaluationCli(rejectedArgs);
       assert.equal(rejected.exitCode, 2);
       assert.equal((JSON.parse(rejected.stdout) as ScoreReport).outcome, 'fail');
+
+      // Keep one real process-level witness for the executable adapter. The
+      // in-process matrix avoids repeated tsx startup, while this pins the
+      // import.meta.url guard, stdout serialization, and actual exit status 2.
+      const rejectedProcess = spawnSync(
+        fileURLToPath(new URL('../node_modules/.bin/tsx', import.meta.url)),
+        [
+          fileURLToPath(new URL('../scripts/company-monitoring-blind-evaluation.mts', import.meta.url)),
+          ...rejectedArgs,
+        ],
+        { encoding: 'utf8', timeout: 30_000 },
+      );
+      assert.ifError(rejectedProcess.error);
+      assert.equal(rejectedProcess.signal, null);
+      assert.equal(rejectedProcess.status, 2);
+      assert.equal((JSON.parse(rejectedProcess.stdout) as ScoreReport).outcome, 'fail');
 
       const shortfall = runScore(lockedBundle({
         namespace: 'cli-incomplete',

--- a/tests/shipping-v2-handler.test.mjs
+++ b/tests/shipping-v2-handler.test.mjs
@@ -315,6 +315,28 @@ describe('ShippingV2Service handlers', () => {
       assert.equal(pipeline[2][2], String(86400 * 30));
     });
 
+    it('uses the authenticated enterprise cookie for ownership when wms_ is also present', async () => {
+      const calls = stubRedisOk();
+      await registerWebhook(makeCtx({
+        'X-WorldMonitor-Key': 'wms_automatic-anonymous-session',
+        Cookie: 'wm-pro-key=pro-test-key',
+      }), {
+        callbackUrl: 'https://93.184.216.34/wm',
+        chokepointIds: [],
+        alertThreshold: 60,
+      });
+
+      const record = JSON.parse(calls[0][0][2]);
+      const expected = await crypto.subtle.digest(
+        'SHA-256',
+        new TextEncoder().encode('pro-test-key'),
+      );
+      const expectedOwner = Array.from(new Uint8Array(expected))
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+      assert.equal(record.ownerTag, expectedOwner);
+    });
+
     it('alertThreshold omitted (undefined) applies the legacy default of 50', async () => {
       const calls = stubRedisOk();
       await registerWebhook(proCtx(), {

--- a/tests/trade-flows-coverage.test.mts
+++ b/tests/trade-flows-coverage.test.mts
@@ -116,6 +116,8 @@ afterEach(() => {
     if (value === undefined) delete process.env[name];
     else process.env[name] = value;
   }
+  _setAllReportersForTesting([]);
+  _setReporterListIsFallbackForTesting(false);
 });
 
 const CTX = {} as ServerContext;
@@ -181,6 +183,7 @@ function assertTwoReads(reporter: string, partner: string): void {
 
 // ── Contract pins: the two sides must agree without importing each other ───
 
+describe('trade-flows coverage', { concurrency: 1 }, () => {
 describe('seeder and handler agree on the cache contract', () => {
   test('the seeded window equals the contract maximum lookback', () => {
     assert.equal(TRADE_FLOW_SEED_YEARS, MAX_YEARS);
@@ -707,6 +710,7 @@ describe('fetchTradeFlows composes the loop, the counters, and the manifest', ()
     _setAllReportersForTesting(['840', '156']);
     globalThis.fetch = (async (input: string | URL | Request) => {
       const href = String(input);
+      if (href.startsWith(REDIS_HOST)) return new Response(JSON.stringify({ result: null }), { status: 200 });
       if (!href.includes('api.wto.org')) throw new Error(`unexpected fetch to ${href}`);
       const params = new URL(href).searchParams;
       if (params.get('r') === '156') return new Response('upstream down', { status: 503 });
@@ -1109,4 +1113,5 @@ describe('tradeFlowPairUniverse', () => {
     const ids = tradeFlowPairUniverse(['840', '156']).map(([r, p]) => tradeFlowCoverageId(r, p));
     assert.ok(ids.every((id) => id.endsWith(`:${WORLD_PARTNER_CODE}`)), ids.join(','));
   });
+});
 });

--- a/tests/widget-agent-auth.test.mts
+++ b/tests/widget-agent-auth.test.mts
@@ -131,6 +131,31 @@ describe('widget-agent unified tester key auth', () => {
     });
   });
 
+  it('keeps an enterprise tester cookie authoritative over the automatic wms_ header', async () => {
+    const res = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://www.worldmonitor.app',
+        'Content-Type': 'application/json',
+        'X-WorldMonitor-Key': 'wms_automatic-anonymous-session',
+        Cookie: `wm-pro-key=${encodeURIComponent('browser-test-key')}`,
+      },
+      body: JSON.stringify({ prompt: 'Build a widget', mode: 'create', tier: 'basic' }),
+    }));
+
+    assert.equal(res.status, 200);
+    assert.equal(fetchMock.mock.calls.length, 1);
+
+    const init = fetchMock.mock.calls[0].arguments[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    assert.equal(headers.get('X-Pro-Key'), 'server-pro-key');
+    assert.deepEqual(JSON.parse(String(init.body)), {
+      prompt: 'Build a widget',
+      mode: 'create',
+      tier: 'pro',
+    });
+  });
+
   it('rejects disallowed origins before cookie-backed auth reaches the relay', async () => {
     const res = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
       method: 'POST',

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -167,6 +167,91 @@ async function primeCachedFromStorage(): Promise<void> {
   await mod.ensureWmSession();
 }
 
+describe('wm-session first RPC after mint (WORLDMONITOR-XP)', () => {
+  it('attaches X-WorldMonitor-Key on the first anonymous RPC after mint', async () => {
+    const mintedToken = 'wms_first-rpc-header-token';
+    let firstRpcKey: string | null = 'unset';
+    let firstRpcCredentials: RequestCredentials | undefined;
+    let premiumKey: string | null = 'unset';
+    let mintCalls = 0;
+
+    currentFetchHandler = (input, init) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({
+          exp: FAR_FUTURE,
+          hadSession: false,
+          token: mintedToken,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+
+      const headers = new Headers(init?.headers);
+      if (url.includes('/api/military/v1/get-usni-fleet-report')) {
+        firstRpcKey = headers.get('X-WorldMonitor-Key');
+        firstRpcCredentials = init?.credentials;
+        return Promise.resolve(new Response('ok', { status: 200 }));
+      }
+      if (url.includes('/api/market/v1/analyze-stock')) {
+        premiumKey = headers.get('X-WorldMonitor-Key');
+        return Promise.resolve(new Response('premium auth remains separate', { status: 200 }));
+      }
+      return Promise.resolve(new Response('unhandled', { status: 500 }));
+    };
+
+    const response = await wrappedFetch(
+      'https://api.worldmonitor.app/api/military/v1/get-usni-fleet-report',
+    );
+    assert.equal(response.status, 200);
+    assert.equal(mintCalls, 1, 'ensureWmSession must mint before the first RPC');
+    assert.equal(firstRpcKey, mintedToken, 'first non-premium RPC must carry X-WorldMonitor-Key: wms_…');
+    assert.equal(firstRpcCredentials, 'include', 'cookie remains primary via credentials: include');
+
+    const premium = await wrappedFetch('https://api.worldmonitor.app/api/market/v1/analyze-stock');
+    assert.equal(premium.status, 200);
+    assert.equal(premiumKey, null, 'premium paths must not receive the anonymous wms_ header');
+  });
+
+  it('reload with only sessionStorage exp remints and attaches wms_ on first RPC', async () => {
+    const mintedToken = 'wms_reload-remint-header-token';
+    let firstRpcKey: string | null = 'unset';
+    let mintCalls = 0;
+
+    memoryStorage.set('wm-session-exp', JSON.stringify({ exp: FAR_FUTURE }));
+    currentFetchHandler = (input, init) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({
+          exp: FAR_FUTURE,
+          hadSession: false,
+          token: mintedToken,
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+
+      const headers = new Headers(init?.headers);
+      if (url.includes('/api/military/v1/get-usni-fleet-report')) {
+        firstRpcKey = headers.get('X-WorldMonitor-Key');
+        return Promise.resolve(new Response('ok', { status: 200 }));
+      }
+      return Promise.resolve(new Response('unhandled', { status: 500 }));
+    };
+
+    const response = await wrappedFetch(
+      'https://api.worldmonitor.app/api/military/v1/get-usni-fleet-report',
+    );
+    assert.equal(response.status, 200);
+    assert.equal(mintCalls, 1, 'must remint because sessionStorage cannot retain the in-memory header token');
+    assert.equal(firstRpcKey, mintedToken, 'first RPC after reload remint must carry X-WorldMonitor-Key: wms_…');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Layer 1 — periodic refresh
 // ---------------------------------------------------------------------------
@@ -1686,11 +1771,12 @@ describe('wm-session route-scoped recovery failures (#5674)', () => {
 
   it('ignores an anonymous recovery result that settles after a key-session upgrade', async () => {
     memoryStorage.clear();
-    memoryStorage.set('wm-session-exp', JSON.stringify({ exp: FAR_FUTURE }));
     const { captures } = collectSentry();
     const gated = 'https://api.worldmonitor.app/api/intelligence/v1/get-risk-scores';
     let gatedAttempts = 0;
+    let anonymousMintCalls = 0;
     let releaseAnonymousMint: (() => void) | null = null;
+    const initialAnonymousToken = 'wms_initial-anonymous-session';
     const anonymousToken = 'wms_stale-anonymous-recovery';
     const fallbackHeaders: Array<string | null> = [];
 
@@ -1699,6 +1785,17 @@ describe('wm-session route-scoped recovery failures (#5674)', () => {
       if (url.includes('/api/wm-session')) {
         const body = typeof init?.body === 'string' ? JSON.parse(init.body) as { proKey?: string } : {};
         if (!body.proKey) {
+          anonymousMintCalls += 1;
+          if (anonymousMintCalls === 1) {
+            return Promise.resolve(new Response(JSON.stringify({
+              exp: FAR_FUTURE,
+              hadSession: false,
+              token: initialAnonymousToken,
+            }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }));
+          }
           return new Promise((resolve) => {
             releaseAnonymousMint = () => resolve(new Response(JSON.stringify({
               exp: FAR_FUTURE,
@@ -1751,7 +1848,7 @@ describe('wm-session route-scoped recovery failures (#5674)', () => {
 
     assert.deepEqual(
       fallbackHeaders,
-      [null, null, null],
+      [initialAnonymousToken, null, null],
       'a stale anonymous mint must never inject its token after a key-session upgrade',
     );
     assert.deepEqual(mod.getStruckRoutes(), [], 'the old identity must not repopulate route suppression');


### PR DESCRIPTION
## Summary
- Sentry [WORLDMONITOR-XP](https://elie-habib.sentry.io/issues/7635921726/) (`wm-session route rejected after fresh mint`) and downstream [WORLDMONITOR-WG](https://elie-habib.sentry.io/issues/7606710747/) `retry_401` blackouts on anonymous gateway RPCs (`list-military-bases`, `get-usni-fleet-report`, `record-baseline-snapshot`) after a 200 mint.
- Mint already returns `token` for cookie-refusal browsers, but the interceptor only attached `X-WorldMonitor-Key` after a failed replay. First RPCs were cookie-only and 401'd; a concurrent burst hit quorum.
- Cookie `Domain=.worldmonitor.app` is already correct. These routes are not `forceKey`.

## Fix
- Attach in-memory `wms_` as `X-WorldMonitor-Key` on anonymous calls as soon as mint returns it (`credentials: 'include'` stays; premium paths still skip).
- Tombstone host-only `wm-session` when setting the Domain cookie so a stale `api` host-only cookie cannot first-match-shadow the new one.

## Test plan
- [x] First post-mint anonymous fetch (`/api/military/v1/get-usni-fleet-report`) carries `X-WorldMonitor-Key: wms_…` and `credentials: 'include'`
- [x] Premium paths still do not get `wms_`
- [x] Production Set-Cookie is host-only Max-Age=0 tombstone then Domain cookie; localhost unchanged
- [ ] CI: wm-session + _api-key tests
