### PR TITLE
fix(seeders): release resilience lock on SIGTERM

### DIFF
--- a/scripts/seed-resilience-static.mjs
+++ b/scripts/seed-resilience-static.mjs
@@ -81,6 +81,29 @@ export function countryRedisKey(iso2) {
   return `${RESILIENCE_STATIC_PREFIX}${iso2}`;
 }
 
+export function installSigtermLockCleanup({
+  runId,
+  processRef = process,
+  release = releaseLock,
+  logError = console.error,
+} = {}) {
+  if (!runId) throw new Error('installSigtermLockCleanup requires runId');
+
+  const onSigterm = async () => {
+    logError(`  [${LOCK_DOMAIN}] SIGTERM received — releasing lock runId=${runId}`);
+    try {
+      await release(LOCK_DOMAIN, runId);
+    } catch (error) {
+      logError(`  [${LOCK_DOMAIN}] SIGTERM cleanup error: ${error?.message || error}`);
+    } finally {
+      processRef.exit(143);
+    }
+  };
+
+  processRef.once('SIGTERM', onSigterm);
+  return () => processRef.off('SIGTERM', onSigterm);
+}
+
 function nowSeedYear(now = new Date()) {
   return now.getUTCFullYear();
 }
@@ -1226,6 +1249,7 @@ export async function main() {
     return;
   }
 
+  const removeSigtermHandler = installSigtermLockCleanup({ runId });
   try {
     const result = await seedResilienceStatic();
     logSeedResult('resilience:static', result?.manifest?.recordCount ?? 0, Date.now() - startedAt, {
@@ -1235,6 +1259,7 @@ export async function main() {
     });
   } finally {
     await releaseLock(LOCK_DOMAIN, runId);
+    removeSigtermHandler();
   }
 }
 

--- a/tests/resilience-static-sigterm-lock.test.mjs
+++ b/tests/resilience-static-sigterm-lock.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { EventEmitter, once } from 'node:events';
+import { test } from 'node:test';
+
+import { installSigtermLockCleanup } from '../scripts/seed-resilience-static.mjs';
+
+class FakeProcess extends EventEmitter {
+  exitCodes = [];
+
+  exit(code) {
+    this.exitCodes.push(code);
+    this.emit('exit-called', code);
+  }
+}
+
+test('SIGTERM releases the resilience-static lock before exiting', async () => {
+  const processRef = new FakeProcess();
+  const calls = [];
+  let resolveRelease;
+  const releaseStarted = new Promise((resolve) => { resolveRelease = resolve; });
+  let finishRelease;
+  const releaseFinished = new Promise((resolve) => { finishRelease = resolve; });
+
+  const removeHandler = installSigtermLockCleanup({
+    runId: 'resilience-static:test-run',
+    processRef,
+    release: async (...args) => {
+      calls.push(args);
+      resolveRelease();
+      await releaseFinished;
+    },
+    logError: () => {},
+  });
+
+  processRef.emit('SIGTERM');
+  await releaseStarted;
+  assert.deepEqual(processRef.exitCodes, [], 'must not exit before lock release settles');
+
+  const exitCalled = once(processRef, 'exit-called');
+  finishRelease();
+  assert.deepEqual(await exitCalled, [143]);
+  assert.deepEqual(calls, [['resilience:static', 'resilience-static:test-run']]);
+  assert.equal(processRef.listenerCount('SIGTERM'), 0, 'the one-shot handler must not remain installed');
+
+  removeHandler();
+});
+
+test('SIGTERM still exits when lock cleanup fails', async () => {
+  const processRef = new FakeProcess();
+  const errors = [];
+  installSigtermLockCleanup({
+    runId: 'resilience-static:test-failure',
+    processRef,
+    release: async () => { throw new Error('synthetic Redis failure'); },
+    logError: (message) => errors.push(message),
+  });
+
+  const exitCalled = once(processRef, 'exit-called');
+  processRef.emit('SIGTERM');
+
+  assert.deepEqual(await exitCalled, [143]);
+  assert.match(errors.join('\n'), /SIGTERM cleanup error: synthetic Redis failure/);
+});


### PR DESCRIPTION
## Summary

- install a one-shot SIGTERM handler after `seed-resilience-static` acquires its two-hour lock
- release the same lock/run ID before exiting with the conventional status 143
- remove the handler after normal completion and cover successful and failed cleanup paths with focused regressions

Refs #6562 (item 2 only).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: resilience static seeder lock lifecycle

## Root cause and compatibility

The existing `finally` releases the lock on ordinary completion, but Node's default SIGTERM handling terminates the process without unwinding that async `finally`. A bundle timeout could therefore leave `seed-lock:resilience:static` present for its full two-hour TTL. The handler is installed only after successful acquisition and calls the existing run-ID-verified `releaseLock`, so normal completion, skipped runs, and lock contention remain unchanged. Cleanup failure is logged without credentials and still exits within the bundle runner's SIGKILL grace window.

## Validation

- `npm run typecheck:api`
- `npm run lint:unicode -- --staged=false`
- `node --test tests/resilience-static-sigterm-lock.test.mjs tests/resilience-static-seed.test.mjs tests/seed-bundle-resilience-recovery.test.mjs` - 73 passed
- `npx --no-install biome check scripts/seed-resilience-static.mjs tests/resilience-static-sigterm-lock.test.mjs`
- `node --check scripts/seed-resilience-static.mjs`
- `git diff --check`

## Checklist

- [x] No API keys or secrets committed
- [x] Targeted API typecheck passes (`npm run typecheck:api`)
- [x] Focused and adjacent resilience seeder tests pass
- [x] RSS / Railway pre-seed checklist items are not applicable (no key, schedule, health target, or service change)

## Documentation Alignment Checklist

N/A - this fixes an internal seeder lock lifecycle and does not alter published methodology, API/MCP contracts, generated documentation, Redis data shapes, CII/CRI, news, digest, or briefing claims.

## Screenshots

N/A - no user-facing UI changes.

## AI-assisted development disclosure

OpenAI Codex assisted with issue triage, implementation, regression tests, and review. I reviewed the final diff, verified the failure mode and safety properties, ran the validation above, and take responsibility for the submitted change.