### PR TITLE
fix(csp-filter): suppress the cdnjs FontAwesome webfonts (TR round 8)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -420,6 +420,30 @@ function shouldSuppressCspViolation(
       // style-src jsDelivr rule below makes for CSS.
       if (url.protocol === 'https:' && url.hostname === 'cdn.jsdelivr.net'
           && fontFile.test(url.pathname)) return true;
+      // ---- Round 8. Sized on the window strictly AFTER the round-7 rule was
+      // live (commit a769c51a, 2026-08-13T14:18Z), per the note above. In that
+      // window this issue took 172 events and 171 of them (99.4%) were this one
+      // host; the single remaining jsDelivr event came from a bundle built
+      // 2026-08-06, i.e. drain from a stale client rather than a rule escaping.
+      //
+      // cdnjs is the third generic package CDN in this list, and it is pinned
+      // the same way unpkg and jsDelivr are above — host + font-file extension,
+      // no path prefix — for the same reason: it mirrors whatever an arbitrary
+      // npm package ships, so it has no stable font root to anchor to.
+      //
+      // Every one of the 171 events is FontAwesome 6.7.2 requesting the same
+      // four faces in the .woff2/.ttf fallback chain
+      // (/ajax/libs/font-awesome/6.7.2/webfonts/fa-{solid-900,regular-400,
+      // brands-400,v4compatibility}.*), with an EMPTY sourceFile — the
+      // signature of an extension-injected stylesheet rather than a document
+      // one. This is the third-CDN counterpart of the existing
+      // use.fontawesome.com rules: `font-awesome` is in neither package.json
+      // nor src, `cdnjs` appears nowhere in the repo, and the dashboard's
+      // font-src is `'self' data:` with no cross-origin host at all, so a font
+      // block here can never be a first-party regression. Non-font assets from
+      // cdnjs still surface.
+      if (url.protocol === 'https:' && url.hostname === 'cdnjs.cloudflare.com'
+          && fontFile.test(url.pathname)) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube live stream manifests.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -303,6 +303,37 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://jsdelivr.net/gh/x/y.woff', '', false));
     });
 
+    it('suppresses the round-8 cdnjs FontAwesome webfonts', () => {
+      // Every distinct URI observed in the window strictly AFTER the round-7
+      // rule went live (a769c51a, 2026-08-13T14:18Z): 171 of that window's 172
+      // events, i.e. the whole live tail of this issue. All four faces appear in
+      // both .woff2 and .ttf because an @font-face src: list is tried in order —
+      // the same fallback-chain shape the round-3 and round-6 rules were widened
+      // for. Real production URIs, so a path/extension refactor that stops
+      // matching them fails here rather than in Sentry.
+      const cdnjsFa = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/webfonts';
+      for (const face of ['fa-solid-900', 'fa-regular-400', 'fa-brands-400']) {
+        assert.ok(suppress('enforce', 'font-src', `${cdnjsFa}/${face}.woff2`, '', false));
+        assert.ok(suppress('enforce', 'font-src', `${cdnjsFa}/${face}.ttf`, '', false));
+      }
+      assert.ok(suppress('enforce', 'font-src', `${cdnjsFa}/fa-v4compatibility.woff2`, '', false));
+    });
+
+    it('keeps NON-font assets from cdnjs visible', () => {
+      // Host + extension only, like the other two package CDNs, so the extension
+      // and protocol checks are the ONLY things keeping this rule narrow.
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css', '', false));
+      assert.ok(!suppress('enforce', 'script-src', 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js', '', false));
+      assert.ok(!suppress('enforce', 'style-src-elem', 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css', '', false));
+      // http:, pinning the protocol conjunct.
+      assert.ok(!suppress('enforce', 'font-src', 'http://cdnjs.cloudflare.com/ajax/libs/x/y.woff2', '', false));
+      // Sibling registrable domains and subdomains an endsWith() refactor eats.
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdnjs.cloudflare.com.evil.com/ajax/libs/x/y.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://evil-cdnjs.cloudflare.com/ajax/libs/x/y.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cdnjs.com/ajax/libs/x/y.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://cloudflare.com/ajax/libs/x/y.woff2', '', false));
+    });
+
     it('does NOT suppress a SIBLING registrable domain of a pinned font host', () => {
       // The `<host>.evil.com` fixtures elsewhere are rejected by ANY hostname
       // check, including a suffix match, so they cannot prove exactness. These


### PR DESCRIPTION
## Problem

`WORLDMONITOR-TR` (CSP violation reports) is still taking **173 events/24h** against a 357k-event headline.

Round 7 (#6560, `a769c51a`, live 2026-08-13T14:18Z) closed the Google Fonts `/l/font` subsetting endpoint. Sizing the tail on the window **strictly after that deploy** — the discipline this filter's own comments established, after ShopBack once looked like it was escaping a brand-new rule until its events were grouped by `build_sha` — leaves:

| blocked host | events in post-round-7 window | share |
|---|---|---|
| `cdnjs.cloudflare.com` | 171 | **99.4%** |
| `cdn.jsdelivr.net` | 1 | 0.6% |

172 events total, all `font-src`. The single jsDelivr event came from a bundle built 2026-08-06 (`d8db1c35`), i.e. a pre-round-6 client draining — not the round-6 rule escaping.

Every one of the 171 is FontAwesome 6.7.2 requesting the same four faces in the `.woff2`/`.ttf` fallback chain, each with an **empty `sourceFile`** — the signature of an extension-injected stylesheet rather than a document one:

```
/ajax/libs/font-awesome/6.7.2/webfonts/fa-solid-900.{woff2,ttf}
/ajax/libs/font-awesome/6.7.2/webfonts/fa-regular-400.{woff2,ttf}
/ajax/libs/font-awesome/6.7.2/webfonts/fa-brands-400.{woff2,ttf}
/ajax/libs/font-awesome/6.7.2/webfonts/fa-v4compatibility.woff2
```

## Why this can never be first-party

Three independent grounds, the same ones every rule above it uses:

1. `cdnjs` appears nowhere in the repo (`rg` over the tree excluding `node_modules`/`dist`/lockfiles: zero hits).
2. `font-awesome` is in neither `package.json` nor `src/`.
3. The dashboard's `font-src` is `'self' data:` — **no cross-origin host at all**, so we load no cross-origin webfont from anywhere.

This is the third-CDN counterpart of the two existing `use.fontawesome.com` rules (`font-src` and `style-src-elem`) — same vendor font, injected through a different public CDN.

## Shape of the rule

Pinned host + font-file extension, **no path prefix** — identical to the round-6 `unpkg` and `cdn.jsdelivr.net` rules and for the same documented reason: cdnjs is a generic package CDN that mirrors whatever an arbitrary npm package ships, so it has no stable font root to anchor to. Non-font assets from cdnjs (its JS and CSS) still surface under every directive.

No CSP policy is weakened — this only changes which violation reports reach Sentry.

## Tests

`tests/csp-filter.test.mjs` gains two cases built from the **real production URIs**, so a path/extension refactor that stops matching them fails in CI rather than silently in Sentry:

- `suppresses the round-8 cdnjs FontAwesome webfonts` — all four faces in both formats.
- `keeps NON-font assets from cdnjs visible` — cdnjs `.js`/`.css` under `font-src`, `script-src` and `style-src-elem`; `http:`; and the sibling/subdomain hosts an `endsWith()` refactor would eat (`cdnjs.cloudflare.com.evil.com`, `evil-cdnjs.cloudflare.com`, `cdnjs.com`, `cloudflare.com`).

**Verified red before green** by reverting `src/main.ts` to `HEAD` via file copy and re-running: the positive case fails pre-change, passes post-change.

```
tests/csp-filter.test.mjs                     148/148 pass
+ tests/deploy-config.test.mjs (tsx runner)   326/326 pass
npm run typecheck                             clean
biome lint src/main.ts tests/csp-filter.test.mjs   clean
```

## Note on resolving the issue

`WORLDMONITOR-TR` is deliberately **left unresolved** until this deploys. Resolving before the filter is live guarantees an immediate regression from live traffic, which is what happened to this issue in earlier rounds.

https://claude.ai/code/session_015GrCsyRe7ULRX46EC8JV8T
