### PR TITLE
refactor(railway): quiesce legacy reconciliation schedules

### DIFF
--- a/.github/workflows/railway-deploy-trigger-watchdog.yml
+++ b/.github/workflows/railway-deploy-trigger-watchdog.yml
@@ -72,17 +72,11 @@ jobs:
           --phase "$WATCHDOG_PHASE"
           --auto-recovery-enabled "$AUTO_RECOVERY_ENABLED"
 
-      # This step is the durable record of a blind run: a later classify run
-      # reads its own recent workflow history and counts how many consecutive
-      # runs ran it. Success means this run could not read GitHub; skipped
-      # means it could. The step name is the contract — it must stay identical
-      # to WATCHDOG_READ_FAILURE_STEP_NAME in the controller, which the test
-      # suite pins. The controller itself fails the job once the streak holds.
-      # `always()` is load-bearing: the run that first trips the streak fails
-      # the controller step, and a default `success()` guard would skip its own
-      # marker. The streak would then reset and the job would only go red when
-      # the threshold was reached again instead of staying red until reads
-      # recover.
+      # This step records why the current manual classifier failed. Success
+      # means this invocation could not read GitHub; skipped means it could.
+      # The step name is pinned to WATCHDOG_READ_FAILURE_STEP_NAME by tests.
+      # `always()` is load-bearing because the controller deliberately fails
+      # the current job on its first unreadable GitHub result.
       - name: Record watchdog read-path failure
         if: always() && steps.controller.outputs.read_failure == 'true'
         env:

--- a/.github/workflows/railway-deploy-trigger-watchdog.yml
+++ b/.github/workflows/railway-deploy-trigger-watchdog.yml
@@ -1,8 +1,9 @@
-name: Railway Deploy Trigger Watchdog
+name: Railway Deploy Trigger Watchdog (Manual Rollback Only)
+run-name: Manual Railway rollback watchdog (${{ inputs.mode }})
 
+# Transitional rollback surface only. It may inspect or dispatch recovery only
+# after an explicit manual invocation; do not add a schedule or dispatcher.
 on:
-  schedule:
-    - cron: '8,23,38,53 * * * *'
   workflow_dispatch:
     inputs:
       mode:
@@ -65,22 +66,23 @@ jobs:
           RAILWAY_RECONCILE_CONTROL_URL: ${{ vars.RAILWAY_RECONCILE_CONTROL_URL }}
           RAILWAY_RECONCILE_WATCHDOG_HMAC: ${{ secrets.RAILWAY_RECONCILE_WATCHDOG_HMAC }}
           WATCHDOG_PHASE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode == 'status' && 'status' || 'classify' }}
-          AUTO_RECOVERY_ENABLED: ${{ vars.RAILWAY_RECONCILE_CUTOVER_ACTIVE == 'true' && vars.RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED == 'true' && (github.event_name == 'schedule' || inputs.mode == 'dispatch') }}
+          AUTO_RECOVERY_ENABLED: ${{ vars.RAILWAY_RECONCILE_CUTOVER_ACTIVE == 'true' && vars.RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED == 'true' && github.event_name == 'workflow_dispatch' && inputs.mode == 'dispatch' }}
         run: >-
           node scripts/dispatch-stale-railway-reconcile.mjs
           --phase "$WATCHDOG_PHASE"
           --auto-recovery-enabled "$AUTO_RECOVERY_ENABLED"
 
       # This step is the durable record of a blind run: a later classify run
-      # reads its own recent scheduled history and counts how many consecutive
+      # reads its own recent workflow history and counts how many consecutive
       # runs ran it. Success means this run could not read GitHub; skipped
       # means it could. The step name is the contract — it must stay identical
       # to WATCHDOG_READ_FAILURE_STEP_NAME in the controller, which the test
       # suite pins. The controller itself fails the job once the streak holds.
       # `always()` is load-bearing: the run that first trips the streak fails
       # the controller step, and a default `success()` guard would skip its own
-      # marker. The streak would then reset and the job would only go red every
-      # third run instead of staying red until reads recover.
+      # marker. The streak would then reset and the job would only go red when
+      # the threshold was reached again instead of staying red until reads
+      # recover.
       - name: Record watchdog read-path failure
         if: always() && steps.controller.outputs.read_failure == 'true'
         env:

--- a/.github/workflows/railway-deploy-trigger.yml
+++ b/.github/workflows/railway-deploy-trigger.yml
@@ -1,11 +1,11 @@
-name: Railway Deploy Trigger
+name: Railway Deploy Trigger (Manual Rollback Only)
 run-name: >-
-  Railway reconcile ${{ github.event_name == 'workflow_dispatch' && inputs.recovery_attempt_id || github.event_name }}
-  @ ${{ github.event_name == 'workflow_dispatch' && inputs.expected_head_sha || github.sha }}
+  Manual Railway rollback reconcile ${{ inputs.recovery_attempt_id }}
+  @ ${{ inputs.expected_head_sha }}
 
+# Transitional rollback surface only. Native Railway GitHub autodeploy owns the
+# normal path; do not add a schedule or another automatic event here.
 on:
-  schedule:
-    - cron: '7,17,27,37,47,57 * * * *'
   workflow_dispatch:
     inputs:
       dryRun:

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -26,6 +26,70 @@
 
 ## Deployment safety guardrails
 
+### Native autodeploy target and quiesced rollback surface
+
+The normal deployment architecture is intentionally small:
+
+| Boundary | Authority | Normal-operation rule |
+|---|---|---|
+| Merge safety | GitHub protected `main` | Require a PR, current-base checks with `strict=true`, administrator enforcement, zero required human approvals, and no bypass actors. |
+| Service selection | Railway's native watch paths, backed by `scripts/railway-services.json` and its closure audit | A source migration may change `source.checkSuites` only. It must not change watch paths or another service field. |
+| Deployment creation | Railway's native GitHub integration on explicit branch `main` | No GitHub Actions workflow dispatches, retries, leases, or repairs a normal deployment. |
+| Drift detection | One hourly, read-only Railway workflow after the monitor migration | Unknown, failed, skipped, overdue, or contradictory state is red. The monitor has no mutation token, dispatch permission, retry, reviewer, or acceptance baseline. |
+| Recovery | Operator diagnosis followed by an explicit Railway action or batch rollback | Recovery is never automatic and never turns missing evidence green. Seed/ingestion freshness remains a separate acceptance surface. |
+
+The permanent monitor uses a credential issued to a dedicated Railway
+`VIEWER` identity. The legacy token names described later in this rollback
+section are not proof of read-only capability and are deleted with the old
+control plane; never reuse a deploy-capable project token for the target
+monitor.
+
+During the bounded rollback window, **Railway Deploy Trigger (Manual Rollback
+Only)** and **Railway Deploy Trigger Watchdog (Manual Rollback Only)** retain
+`workflow_dispatch` as an emergency surface. They have no `schedule`, `push`,
+`workflow_run`, repository-dispatch, heartbeat, or replacement dispatcher. Keep
+both `RAILWAY_RECONCILE_CUTOVER_ACTIVE=false` and
+`RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED=false` in normal operation. The first
+flag continues to guard every legacy mutation; the watchdog can authorize a
+dispatch only when both flags are exactly `true` and an operator explicitly
+runs it in `dispatch` mode.
+
+No recovery environment is approved in normal operation. In particular, do
+not approve a pending deployment for
+`ingestion-acceptance-production-breakglass`, the manual-recovery workflow, the
+Watchdog, or the legacy control worker just to clear a queue or alarm. A pending
+approval is itself a stop condition: leave it unapproved, stop the cutover,
+identify the originating run, and cancel or resolve it without granting
+recovery authority. Normal viewer/ingestion environments retain zero required
+reviewers so ordinary PRs and native Railway deployments never wait for a
+person.
+
+#### Exact native-cutover stop conditions
+
+Stop before the next service or batch, preserve sanitized evidence, and roll
+back only the current bounded batch when any of these is true:
+
+1. `main` protection is not `strict=true`, PR-required, administrator-enforced,
+   zero-approval, no-bypass, or its required contexts differ from the captured
+   set.
+2. Either legacy activation flag is unexpectedly true, or any Trigger mutation,
+   verifier, Watchdog dispatch/bind/reject, manual recovery, or control-worker
+   deployment is active, waiting, or ambiguous.
+3. A recovery environment has a pending approval. Never approve it to continue
+   a normal cutover.
+4. The watch/config audit is nonzero, incomplete, unauthorized, contradictory,
+   or emits unsanitized data; a repository-linked service is not on explicit
+   `main`; or `source.checkSuites` is not a boolean.
+5. A scoped source patch changes watch paths, cron, root directory, Dockerfile,
+   variables, repository, branch, or any field other than the selected
+   services' `source.checkSuites`; selected readback is not exact.
+6. A relevant merge produces no deployment, an unexpected service deploys, a
+   build fails or exceeds its grace window, or a deployment SHA/ancestry cannot
+   be proved. An unrelated merge must create no deployment for the service.
+7. GitHub, Railway, or Git ancestry cannot be read completely, or any other
+   evidence is missing, truncated, timed out, or contradictory. Unknown means
+   stop; there is no baseline or “warn and continue” path.
+
 ### Watch paths are a live contract, and an accurate one
 
 Railway stores watch paths in each service's environment configuration, not in
@@ -56,10 +120,11 @@ after the merge gates went green. Over closure-relevant merges that is p90
 self-reinforcing: the freshness monitor goes red exactly when the fleet is
 behind.
 
-So the closures stay, and
-`.github/workflows/railway-deploy-trigger.yml` deploys the services whose
-closure actually changed, gated on main's own `gate` status rather than on
-Railway's reading of the entire suite. Clearing the filters fleet-wide remains
+So the closures stay. The target is Railway's native GitHub integration on
+`main`, with `source.checkSuites=false` only after strict pre-merge protection
+and bounded readback have passed. The legacy
+`.github/workflows/railway-deploy-trigger.yml` is manual rollback only; it is
+not the normal deployment owner. Clearing the filters fleet-wide remains
 rejected on cost: roughly 75 build-minutes per push across 77 services at ~30
 merges a day, and three always-on services (ais-relay, notification-relay,
 scenario-worker) restarting on every merge, dropping the AIS websocket
@@ -123,19 +188,18 @@ use the broader account-scoped `RAILWAY_API_TOKEN`. Missing or inaccessible
 context intentionally fails the acceptance run rather than silently skipping
 the live audit.
 
-### Reconciliation control-plane provisioning
+### Legacy reconciliation control plane (rollback window only)
 
-The reconciliation controller is a dedicated Cloudflare Worker backed by one
-SQLite Durable Object. Its foundation can be deployed while the existing
-Railway integration remains unchanged. Keep both
+The reconciliation controller is a temporary legacy rollback surface backed by
+a Cloudflare Worker and one SQLite Durable Object. It is not part of normal
+native-autodeploy operation and must not receive automatic traffic. Keep both
 `RAILWAY_RECONCILE_CUTOVER_ACTIVE` and
-`RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED` set to `false` until the lease-aware
-target workflow, protected environments, role credentials, and authenticated
-status probe are ready. Activate the flags separately with the staged cutover
-below.
+`RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED` set to `false` unless an operator has
+explicitly chosen the bounded legacy rollback path after a stop condition.
 
-Provision these GitHub Actions environments with a `main`-only deployment
-branch policy:
+Until final deletion, retain these GitHub Actions environments with a
+`main`-only deployment branch policy. Do not approve or invoke them in normal
+operation:
 
 Set the non-secret repository variable `RAILWAY_RECONCILE_CONTROL_URL` to the
 dedicated HTTPS origin compiled into the shipped control client; the client
@@ -173,7 +237,8 @@ workflow contract tests, so treat any change to those guards as a change to a
 security boundary. Note also that `projectTokenCreate` rejects a CLI session
 with `Not Authorized`; both tokens must be created from the Railway dashboard.
 
-Breakglass authorization is **one-person by deliberate choice.** The environment
+Breakglass authorization is **one-person by deliberate choice during the
+bounded rollback window only.** The environment
 keeps its `main`-only branch policy and isolated secrets, but has no required
 reviewer. Requiring that same operator to review their own dispatch adds no
 independent authorization and sends one approval email for every recovery
@@ -198,26 +263,25 @@ version and authenticated status probes. Never rotate across an active lease,
 hold, or barrier: the old run would lose its only authorization path and the
 result would require protected operator recovery.
 
-#### Staged cutover
+#### Quiescing and exceptional rollback
 
-Do not enable both activation flags in one operation.
+Normal operation keeps both activation flags false and the two legacy workflows
+manual-only. Confirm the current `main` head has an exact green `gate`, no
+mutation, verifier, Watchdog, manual-recovery, or control-worker job is active,
+and authenticated controller status has no lease, barrier, attempt, or dispatch
+hold. A stale hold is diagnosed and resolved as an incident; it is not a reason
+to re-enable automatic entrants.
 
-1. Confirm the current `main` head has an exact green `gate`, no target mutation
-   or verifier run is active, and authenticated controller status has no lease,
-   barrier, attempt, or dispatch hold. Confirm every protected environment has
-   only the role credentials its jobs read.
-2. Set `RAILWAY_RECONCILE_CUTOVER_ACTIVE=true` while keeping
-   `RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED=false`. This enables the ordinary
-   lease-fenced mutation and verifier cycle plus protected manual retry, but it
-   cannot authorize a watchdog dispatch. Run one exact-green-head cycle and
-   require terminal acceptance to populate `lastAccepted`. Unset the cutover
-   flag to roll back admission of new mutation jobs.
-3. Enable `RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED` only after `lastAccepted`
-   has been observed fresh, watchdog read failures fail the job after their
-   bounded streak, and a baseline exists for green deferrals caused by a live
-   paginated GitHub inventory. Run the watchdog in `dispatch` mode and require
-   `HEALTHY` with no dispatch. Unset this flag first to roll back automatic
-   recovery authority.
+If an operator explicitly selects legacy rollback during the bounded rollback
+window, change one flag at a time, run exactly the named manual workflow, and
+restore both flags to false immediately after the terminal result is captured.
+`RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED` may be true only for an explicit
+manual Watchdog `dispatch` invocation while
+`RAILWAY_RECONCILE_CUTOVER_ACTIVE=true`; there is no scheduled retry. Stop on
+any active/ambiguous provider call, stale or contradictory controller state,
+unexpected deployment, failed readback, or pending environment approval. Do
+not use an acceptance baseline to authorize rollback or to make its result
+green.
 
 The native Railway source integration is not the lease-aware mutation path. It
 can continue to accept ordinary builds: the reconcile trigger reads the live
@@ -225,10 +289,11 @@ deployment inventory and treats an accepted or in-progress build for the exact
 commit as a no-op. The repository has no separate legacy GitHub workflow that
 deploys with `RAILWAY_PRODUCTION_TOKEN`; that token remains only in read paths.
 If either fact changes, disable and drain the new competing mutation path before
-the staged cutover.
+the native-autodeploy cutover.
 
-To print the authenticated raw controller state without dispatching anything,
-run the watchdog's `status` mode from `main`:
+During rollback diagnosis only, print the authenticated raw controller state
+without dispatching anything by running the Watchdog's manual `status` mode
+from `main`:
 
 ```bash
 gh workflow run railway-deploy-trigger-watchdog.yml --ref main -f mode=status
@@ -439,29 +504,25 @@ blobs. Never re-fetch with `--depth` afterwards: that re-shallows the clone and
 strands exactly those commits. An unanswerable question reports the service
 (`CLOSURE_UNKNOWN`) rather than excusing it.
 
-Accepted degradations go in `scripts/railway-deploy-drift-baseline.json`, each
-with an owner issue and the whole file with an expiry, split by the same
-`applyAcceptanceBaseline` that `scripts/check-seed-freshness.mjs` applies to
-compact health — so expiry, prune-on-recovery, and "a service failing with a
-different verdict than the one baselined still blocks" cannot acquire two
-meanings. It held 62 `REJECTED_PUSH` entries — every filtered service — until
-[#6142](https://github.com/koala73/worldmonitor/issues/6142) made the check
-closure-aware; those were not degradations, they were the check demanding that a
-filtered service run head. The last remaining entry — `umami` at `BEHIND` against
-[#6064](https://github.com/koala73/worldmonitor/issues/6064) — was pruned on
-2026-08-06 once the service was running head again, so the file is now empty.
-Acknowledged entries are printed on every run and do not fail it, so a green
-monitor here means "nothing new went stale", not "every service is on head". A
-service that recovers is printed as `recovered` — prune it. The expiry does not
-fire on an empty list: it exists to stop a suppression outliving its cause, and
-with nothing suppressed there is nothing to re-review.
+The native-autodeploy target accepts no deploy-drift baseline. Do not add,
+extend, or renew an entry in `scripts/railway-deploy-drift-baseline.json`; any
+nonempty suppression blocks cutover. Historical entries were removed after the
+closure-aware classifier landed, and the final legacy baseline file and
+application path are deleted with the reconciliation control plane. Until that
+deletion, read the unbaselined problem set directly and treat every unknown or
+unaccepted verdict as red.
 
 #### Recovering a stale service
 
-Use the **Railway Deploy Trigger** workflow. Its manual dry-run reports the
-closure plan without mutation; a normal manual dispatch runs the same
-green-`main` authorization as the automatic path. Do not run the trigger script
-directly for production recovery:
+In normal native-autodeploy operation, diagnose the red read-only monitor and
+choose an explicit Railway action or roll back only the current migration
+batch. Nothing retries or dispatches recovery automatically.
+
+During the bounded legacy rollback window only, use **Railway Deploy Trigger
+(Manual Rollback Only)**. Its manual dry-run reports the closure plan without
+mutation; a non-dry-run dispatch is possible only while
+`RAILWAY_RECONCILE_CUTOVER_ACTIVE=true`. Do not run the trigger script directly
+for production recovery:
 
 ```bash
 # Local inspection only; this cannot authorize a production mutation.
@@ -484,28 +545,31 @@ local guarantees are still useful for previews:
 
 Run `git fetch origin` before a local preview so `origin/main` is current.
 
-The reconciliation control plane deliberately separates two failures:
+The rollback-only reconciliation control plane distinguishes two legacy
+failure states:
 
 - A runner-less or pre-mutation attempt owns no unbounded GitHub lock. Once any
   bounded `LEASED`/`PREPARED` lease expires and no dispatch hold is ambiguous,
-  the independent watchdog can dispatch a replacement. It never cancels the
-  old run.
+  an operator may explicitly run the manual-only Watchdog in `dispatch` mode
+  with both activation flags true. It never cancels the old run and has no
+  schedule.
 - Once `MUTATION_STARTED` is durable, a project/environment-wide barrier blocks
-  every automatic head until the exact result passes terminal deployment
-  convergence plus strict zero drift, or the protected **Railway Reconcile
-  Manual Recovery** workflow records an audited resolution. Lease expiry alone
-  never clears this barrier.
+  every subsequent legacy mutation until the exact result passes terminal
+  deployment convergence plus strict zero drift, or the protected **Railway
+  Reconcile Manual Recovery** workflow records an audited resolution. Lease
+  expiry alone never clears this barrier.
 
-The watchdog cannot create a hold or dispatch a new recovery unless both
+The Watchdog cannot create a hold or dispatch a new recovery unless both
 `RAILWAY_RECONCILE_CUTOVER_ACTIVE` and
 `RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED` are exactly `true`. Classification is
 deliberately read-and-repair: if an earlier authorized watchdog or manual
-recovery dispatch left a `DISPATCH_HELD` record, an ordinary scheduled run may
+recovery dispatch left a `DISPATCH_HELD` record, an explicit manual run may
 bind its exact accepted workflow run or close it after definitive pre-dispatch
 rejection. That repair is independent of both flags because it completes an
 authorization that already exists; it never creates a hold or sends a dispatch.
-The first flag enables the lease-aware mutation contract and protected manual
-retry, while the second authorizes new automatic recovery. `RECOVERY_AUTHORIZED`
+The first flag enables the lease-aware mutation contract, while the second
+permits the operator-invoked Watchdog to authorize one recovery.
+`RECOVERY_AUTHORIZED`
 means the controller persisted a one-use dispatch hold but has not yet
 dispatched it;
 `RECOVERY_DISPATCHED` means GitHub accepted the request and the controller

--- a/scripts/check-railway-reconcile-age.mjs
+++ b/scripts/check-railway-reconcile-age.mjs
@@ -4,6 +4,7 @@
 //
 // WHY THIS EXISTS
 //
+// During the bounded rollback window,
 // .github/workflows/railway-deploy-trigger.yml has two outcomes that are
 // indistinguishable at the workflow-status level:
 //
@@ -50,18 +51,17 @@ export const RECONCILE_STEP_NAMES = Object.freeze([
 
 export const DEFAULT_WORKFLOW_FILE = 'railway-deploy-trigger.yml';
 
-// Sized against the workflow's bounded ten-minute schedule, not against a
-// fixture. A young head whose gate has not resolved can defer several ticks on
-// purpose; three hours still gives the scheduler 18 chances to produce one
-// strict acceptance before liveness alarms.
+// Retained only for the bounded manual rollback surface. Three hours limits the
+// evidence lookback so an old controller success cannot authorize or excuse a
+// failed rollback attempt; normal native autodeploy does not run this scanner.
 export const DEFAULT_MAX_RECONCILE_AGE_MS = 3 * 60 * 60 * 1000;
 
 // The listing is bounded by TIME, never by a run count.
 //
 // A count was the original design and it was unusable while every Deploy Gate
 // evaluation woke this workflow — measured at ~33/hour. Keep the time contract
-// even after moving to a bounded cadence: it makes the liveness decision
-// independent of delayed or dropped scheduler ticks.
+// during the rollback window so the liveness decision is independent of how
+// many explicit attempts an operator made.
 //
 // With a `created:>=` filter the window spans the threshold BY CONSTRUCTION,
 // which also collapses the old three-state result into two: if no run inside
@@ -155,7 +155,7 @@ export function describeReconcileSummary(summary) {
       : `Fleet last reconciled ${hours(summary.ageMs)}h ago (run ${summary.runId}).`;
   }
   return summary.inspected === 0
-    ? `The fleet has not been reconciled in ${hours(summary.maxAgeMs)}h: this workflow produced NO completed run in that window at all. The bounded reconciliation schedule is not firing.`
+    ? `The fleet has not been reconciled in ${hours(summary.maxAgeMs)}h: the manual rollback workflow produced NO completed run in that window.`
     : `The fleet has not been reconciled in ${hours(summary.maxAgeMs)}h. ${summary.inspected} run(s) completed in that window and none of them deployed.`;
 }
 

--- a/scripts/dispatch-stale-railway-reconcile.mjs
+++ b/scripts/dispatch-stale-railway-reconcile.mjs
@@ -24,17 +24,9 @@ export const WATCHDOG_JOB_READ_CONCURRENCY = 6;
 export const DISPATCH_CORRELATION_ATTEMPTS = 3;
 export const DISPATCH_CORRELATION_POLL_MS = 1_000;
 export const WATCHDOG_SOURCE_WORKFLOW_FILE = 'railway-deploy-trigger-watchdog.yml';
-// The classify job cannot report a read-path failure by failing, because one
-// transient failure is not worth paging on. It reports by *running* a named
-// step instead: present-and-successful means this run was blind, skipped means
-// it read GitHub fine. A later run counts those step conclusions across its own
-// recent history and fails the job once the blindness is sustained.
-export const WATCHDOG_CLASSIFY_JOB_NAME = 'classify';
+// The workflow records a named diagnostic step whenever the manual classifier
+// fails closed on unreadable GitHub state.
 export const WATCHDOG_READ_FAILURE_STEP_NAME = 'Record watchdog read-path failure';
-export const WATCHDOG_READ_FAILURE_STREAK_LIMIT = 3;
-export const WATCHDOG_READ_FAILURE_STREAK_WINDOW_MS = 2 * 60 * 60_000;
-export const WATCHDOG_STREAK_PAGE_SIZE = 5;
-export const WATCHDOG_STREAK_API_RESERVE = 5;
 export const MANUAL_RECOVERY_SOURCE_WORKFLOW_FILE = 'railway-reconcile-manual-recovery.yml';
 export const WATCHDOG_DISPATCH_JOB_NAME = 'Dispatch authorized recovery';
 export const WATCHDOG_DISPATCH_STEP_NAME = 'Dispatch exact Railway deploy-trigger run';
@@ -111,8 +103,7 @@ function isRetryableGitHubStatus(status) {
 }
 
 // Only a GitHub read failure marks the run blind. A control-plane outage or an
-// ambiguous classification is a different tier that stays warning-green, which
-// is why the streak keys on the code rather than on DEFERRED_AMBIGUOUS itself.
+// ambiguous classification is a different tier that stays warning-green.
 function readFailureCodeOf(error) {
   return error instanceof GitHubWatchdogError && error.code.startsWith('GITHUB_READ_')
     ? error.code
@@ -271,14 +262,6 @@ export class GitHubWatchdogClient {
           }))
       );
     }
-    if (method === 'GET' && url.pathname === `${this.repoPath}/actions/workflows/${WATCHDOG_SOURCE_WORKFLOW_FILE}/runs`) {
-      return exactQuery(url, {
-        event: 'schedule',
-        status: 'completed',
-        per_page: String(WATCHDOG_STREAK_PAGE_SIZE),
-        page: '1',
-      });
-    }
     if (method === 'GET' && new RegExp(`^${this.repoPathPattern}/actions/runs/\\d+/attempts/\\d+/jobs$`).test(url.pathname)) {
       return paginated && exactQuery(url, { per_page: String(GITHUB_PAGE_SIZE), page });
     }
@@ -323,8 +306,8 @@ export class GitHubWatchdogClient {
   #retryDelayMs(attempt, error) {
     if (Number.isFinite(error.retryAfterMs) && error.retryAfterMs >= 0) {
       // A secondary-limit window can be minutes long. Sleeping it out would
-      // blow the classify job's own timeout, so clamp and let the third
-      // failure escalate through the read-failure streak instead.
+      // blow the classify job's own timeout, so clamp and let the exhausted
+      // read fail the current manual invocation.
       return Math.min(error.retryAfterMs, WATCHDOG_READ_RETRY_MAX_MS);
     }
     // Full jitter: pick uniformly below the exponential ceiling so the six
@@ -743,54 +726,6 @@ export class GitHubWatchdogClient {
     return history.find((run) => (
       displayTitleHasIdentifier(run.displayTitle, recoveryAttemptId)
     )) ?? null;
-  }
-
-  // Counts how many of the watchdog's own most recent scheduled runs recorded a
-  // read-path failure, newest first, stopping at the first run that did not.
-  // Only the newest page is read and the walk is capped at the streak limit, so
-  // this costs at most one runs read plus one job read per counted run.
-  //
-  // A run whose marker step is absent — cancelled before it ran, or a schedule
-  // gap wider than the window — carries no evidence either way and ends the
-  // count. That delays detection by one cycle at worst: a read path that is
-  // still broken re-accumulates on the very next run.
-  async readReadFailureStreak({ excludeRunId = null } = {}) {
-    const now = this.now();
-    if (!Number.isFinite(now)) throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'watchdog clock was invalid');
-    const query = new URLSearchParams({
-      event: 'schedule',
-      status: 'completed',
-      per_page: String(WATCHDOG_STREAK_PAGE_SIZE),
-      page: '1',
-    });
-    const { data } = await this.request(
-      'GET',
-      `${this.repoPath}/actions/workflows/${WATCHDOG_SOURCE_WORKFLOW_FILE}/runs?${query}`,
-    );
-    const runs = data?.workflow_runs;
-    if (!Array.isArray(runs)) {
-      throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'watchdog run history shape was invalid');
-    }
-    let streak = 0;
-    for (const run of runs) {
-      if (streak >= WATCHDOG_READ_FAILURE_STREAK_LIMIT) break;
-      if (!validGitHubId(run?.id)
-        || !Number.isSafeInteger(run?.run_attempt)
-        || run.run_attempt < 1
-        || !Number.isFinite(Date.parse(run?.created_at ?? ''))) {
-        throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'watchdog run history entry was invalid');
-      }
-      if (excludeRunId !== null && String(run.id) === String(excludeRunId)) continue;
-      if (now - Date.parse(run.created_at) > WATCHDOG_READ_FAILURE_STREAK_WINDOW_MS) break;
-      const jobs = await this.#readAttemptJobs(run.id, run.run_attempt);
-      const marker = jobs
-        .find((job) => job?.name === WATCHDOG_CLASSIFY_JOB_NAME)
-        ?.steps
-        ?.find((step) => step?.name === WATCHDOG_READ_FAILURE_STEP_NAME);
-      if (marker?.conclusion !== 'success') break;
-      streak += 1;
-    }
-    return streak;
   }
 
   async readSourceRunIdentity({ sourceRunId, sourceRunAttempt, expectedSourceHeadSha = null }) {
@@ -1854,33 +1789,14 @@ export async function bindAuthorizedRecovery({
   };
 }
 
-// One blind run is not worth paging on; a sustained blind watchdog is the exact
-// green-while-dead shape that hid the pagination bug for months. The current
-// run counts itself, so the limit is reached after LIMIT consecutive runs.
-export async function resolveReadFailureExit({
-  github,
-  result,
-  sourceRunId = process.env.GITHUB_RUN_ID,
-}) {
-  if (!result?.readFailureCode) return { failJob: false, streak: 0, reason: null };
-  let priors;
-  try {
-    priors = await github.readReadFailureStreak({ excludeRunId: sourceRunId ?? null });
-  } catch (error) {
-    // The streak read travels the same path that just failed, so an unreadable
-    // history is itself evidence the watchdog is blind. Fail closed rather than
-    // let the detector die exactly when it is needed.
-    return {
-      failJob: true,
-      streak: null,
-      reason: `the read-failure streak could not be read: ${error instanceof Error ? error.message : String(error)}`,
-    };
-  }
-  const streak = priors + 1;
+// The watchdog is manual rollback only. There is no later scheduled run that
+// can accumulate a failure streak, so any unreadable GitHub state must make the
+// current invocation red immediately.
+export async function resolveReadFailureExit({ result }) {
+  if (!result?.readFailureCode) return { failJob: false, reason: null };
   return {
-    failJob: streak >= WATCHDOG_READ_FAILURE_STREAK_LIMIT,
-    streak,
-    reason: `${streak} consecutive scheduled runs could not read GitHub (${result.readFailureCode})`,
+    failJob: true,
+    reason: `the manual watchdog could not read GitHub (${result.readFailureCode})`,
   };
 }
 
@@ -1898,12 +1814,10 @@ function writeWorkflowResult(result) {
     `prior_id=${result.priorId ?? result.recoveryAttemptId ?? ''}`,
     `workflow_run_id=${result.runId ?? ''}`,
     `run_attempt=${result.runAttempt ?? ''}`,
-    // Gates the classify job's read-failure marker step, which is the durable
-    // record a later run counts. Keep the name in step with
-    // WATCHDOG_READ_FAILURE_STEP_NAME in the watchdog workflow.
+    // Gates the classify job's read-failure marker step, which records why the
+    // current manual invocation failed.
     `read_failure=${typeof result.readFailureCode === 'string' && result.readFailureCode !== ''}`,
     `read_failure_code=${result.readFailureCode ?? ''}`,
-    `read_failure_streak=${result.readFailureStreak ?? ''}`,
     `rejection=${result.rejection ? Buffer.from(JSON.stringify(result.rejection)).toString('base64url') : ''}`,
   ];
   if (process.env.GITHUB_OUTPUT) appendFileSync(process.env.GITHUB_OUTPUT, `${lines.join('\n')}\n`);
@@ -1931,27 +1845,17 @@ async function main() {
     const github = new GitHubWatchdogClient({
       repository: process.env.GITHUB_REPOSITORY,
       token: process.env.GH_TOKEN,
-      // The streak read is the escalation path for budget exhaustion, so it
-      // cannot share a budget the snapshot can exhaust. Carving the reserve out
-      // of the same ceiling keeps the per-run total at
-      // WATCHDOG_MAX_API_REQUESTS.
-      maxRequests: WATCHDOG_MAX_API_REQUESTS - WATCHDOG_STREAK_API_RESERVE,
-    });
-    const streakGithub = new GitHubWatchdogClient({
-      repository: process.env.GITHUB_REPOSITORY,
-      token: process.env.GH_TOKEN,
-      maxRequests: WATCHDOG_STREAK_API_RESERVE,
     });
     const result = await prepareRecoveryDispatch({
       github,
       control,
       autoRecoveryEnabled: readArgument(process.argv, '--auto-recovery-enabled', 'false') === 'true',
     });
-    const escalation = await resolveReadFailureExit({ github: streakGithub, result });
+    const escalation = await resolveReadFailureExit({ result });
     // The annotation goes out before the result so the machine-readable JSON
     // blob stays the last line of stdout.
     if (escalation.failJob) console.log(`::error::WATCHDOG_READ_PATH_BLIND: ${escalation.reason}`);
-    writeWorkflowResult({ ...result, readFailureStreak: escalation.streak });
+    writeWorkflowResult(result);
     if (escalation.failJob) process.exitCode = 1;
     return;
   }
@@ -2023,9 +1927,8 @@ if (isMainModule(import.meta.url, process.argv[1])) {
     const reason = error instanceof Error ? error.message : String(error);
     // Every phase fails here, classify included. Reaching this handler means a
     // credential, a variable, or the controller itself is broken — an
-    // unambiguous hard failure, not the transient upstream condition the
-    // read-failure streak exists to rate-limit. classify used to be excluded,
-    // which is what made the job structurally unable to go red.
+    // unambiguous hard failure. Classify used to be excluded, which is what
+    // made the job structurally unable to go red.
     console.log(`::error::WATCHDOG_PHASE_FAILED: ${reason}`);
     writeWorkflowResult({
       outcome: 'DEFERRED_AMBIGUOUS',

--- a/tests/railway-deploy-trigger-watchdog-workflow.test.mjs
+++ b/tests/railway-deploy-trigger-watchdog-workflow.test.mjs
@@ -158,4 +158,15 @@ describe('Railway deploy trigger watchdog workflow contract', () => {
       assert.ok(!source.includes(forbidden), `workflow must not contain ${forbidden}`);
     }
   });
+
+  it('fails a blind manual classification immediately without a scheduled-history dependency', () => {
+    const marker = workflow.jobs.classify.steps.find(
+      (step) => step.name === 'Record watchdog read-path failure',
+    );
+    assert.equal(String(marker.if), "always() && steps.controller.outputs.read_failure == 'true'");
+    assert.match(dispatchSource, /the manual watchdog could not read GitHub/);
+    assert.match(dispatchSource, /if \(!result\?\.readFailureCode\).*failJob: false/s);
+    assert.match(dispatchSource, /failJob: true/);
+    assert.doesNotMatch(dispatchSource, /readReadFailureStreak|event:\s*'schedule'/);
+  });
 });

--- a/tests/railway-deploy-trigger-watchdog-workflow.test.mjs
+++ b/tests/railway-deploy-trigger-watchdog-workflow.test.mjs
@@ -20,8 +20,12 @@ const target = YAML.parse(readFileSync(
 ));
 
 describe('Railway deploy trigger watchdog workflow contract', () => {
-  it('uses the exact offset cadence, raw-status mode, and an isolated concurrency lane', () => {
-    assert.deepEqual(workflow.on.schedule, [{ cron: '8,23,38,53 * * * *' }]);
+  it('is manual rollback only with raw-status mode and an isolated concurrency lane', () => {
+    assert.match(workflow.name, /manual rollback only/i);
+    assert.deepEqual(Object.keys(workflow.on), ['workflow_dispatch']);
+    assert.ok(workflow.on.workflow_dispatch);
+    assert.doesNotMatch(source, /^\s*schedule:/m);
+    assert.doesNotMatch(source, /^\s*(?:push|pull_request|workflow_run|repository_dispatch):/m);
     assert.equal(workflow.on.workflow_dispatch.inputs.mode.default, 'classify');
     assert.deepEqual(workflow.on.workflow_dispatch.inputs.mode.options, [
       'status', 'classify', 'dispatch',
@@ -127,11 +131,20 @@ describe('Railway deploy trigger watchdog workflow contract', () => {
     assert.match(workflow.jobs.bind.if, /RECOVERY_DISPATCH_ACCEPTED/);
   });
 
+  it('keeps cutover-disabled manual classification out of recovery jobs', () => {
+    assert.match(String(workflow.jobs.dispatch.if), /RAILWAY_RECONCILE_CUTOVER_ACTIVE == 'true'/);
+    assert.match(String(workflow.jobs.bind.if), /RAILWAY_RECONCILE_CUTOVER_ACTIVE == 'true'/);
+    assert.match(String(workflow.jobs.reject.if), /needs\.dispatch\.result == 'success'/);
+    assert.doesNotMatch(source, /railway-reconcile-manual-recovery\.yml|workflow_call:/);
+  });
+
   it('keeps activation fail-closed and contains no Railway mutation or cancellation capability', () => {
     const controller = workflow.jobs.classify.steps.find((step) => step.id === 'controller');
     assert.match(controller.env.AUTO_RECOVERY_ENABLED, /RAILWAY_RECONCILE_AUTO_RECOVERY_ENABLED == 'true'/);
     assert.match(controller.env.AUTO_RECOVERY_ENABLED, /RAILWAY_RECONCILE_CUTOVER_ACTIVE == 'true'/);
+    assert.match(controller.env.AUTO_RECOVERY_ENABLED, /github\.event_name == 'workflow_dispatch'/);
     assert.match(controller.env.AUTO_RECOVERY_ENABLED, /inputs\.mode == 'dispatch'/);
+    assert.doesNotMatch(controller.env.AUTO_RECOVERY_ENABLED, /schedule/);
     for (const forbidden of [
       'RAILWAY_TOKEN',
       'RAILWAY_RECONCILE_DEPLOY_TOKEN',

--- a/tests/railway-deploy-trigger-workflow.test.mjs
+++ b/tests/railway-deploy-trigger-workflow.test.mjs
@@ -95,22 +95,12 @@ describe('Railway deploy trigger lease-aware workflow', () => {
     assert.match(stepNamed('mutation', 'Trigger lease-fenced deploys for the exact green head').run, /--recovery-attempt-id/);
   });
 
-  it('uses one bounded offset schedule without repository-wide workflow fan-out', () => {
-    assert.equal(Object.hasOwn(workflow.on, 'workflow_run'), false);
-    assert.deepEqual(workflow.on?.schedule, [{ cron: '7,17,27,37,47,57 * * * *' }]);
-    const freshness = YAML.parse(readFileSync(
-      resolve(repoRoot, '.github/workflows/seed-freshness-monitor.yml'),
-      'utf8',
-    ));
-    const freshnessMinutes = new Set((freshness.on?.schedule ?? []).flatMap(({ cron }) => {
-      const minute = cron.split(' ')[0];
-      const step = /^\*\/(\d+)$/.exec(minute);
-      if (step) return Array.from({ length: 60 / Number(step[1]) }, (_, index) => index * Number(step[1]));
-      return minute.split(',').map(Number);
-    }));
-    const reconcileMinutes = workflow.on.schedule[0].cron.split(' ')[0].split(',').map(Number);
-    assert.equal(reconcileMinutes.length, 6);
-    assert.deepEqual(reconcileMinutes.filter((minute) => freshnessMinutes.has(minute)), []);
+  it('is manual rollback only and exposes no automatic trigger', () => {
+    assert.match(workflow.name, /manual rollback only/i);
+    assert.deepEqual(Object.keys(workflow.on), ['workflow_dispatch']);
+    assert.ok(workflow.on.workflow_dispatch);
+    assert.doesNotMatch(source, /^\s*schedule:/m);
+    assert.doesNotMatch(source, /^\s*(?:push|pull_request|workflow_run|repository_dispatch):/m);
   });
 
   it('keeps dry-run isolated, explicit, read-only, and lease-free', () => {
@@ -141,6 +131,16 @@ describe('Railway deploy trigger lease-aware workflow', () => {
     assert.match(mutate.run, /command_status=\$command_status/);
     assert.doesNotMatch(JSON.stringify(mutation), /RAILWAY_PRODUCTION_TOKEN/);
     assert.doesNotMatch(JSON.stringify(mutation), /npm install --global @railway\/cli/);
+  });
+
+  it('keeps an ordinary cutover-disabled dispatch out of every protected path', () => {
+    assert.match(String(job('preview').if), /dry_run == 'true'/);
+    assert.match(String(job('mutation').if), /RAILWAY_RECONCILE_CUTOVER_ACTIVE == 'true'/);
+    assert.deepEqual(job('verifier').needs, ['admission', 'mutation']);
+    assert.match(String(job('verifier').if), /needs\.mutation\.outputs\.manifest_ready == 'true'/);
+    assert.equal(job('liveness').environment, undefined);
+    assert.deepEqual(referencedSecrets('liveness'), []);
+    assert.doesNotMatch(source, /railway-reconcile-manual-recovery\.yml|workflow_call:/);
   });
 
   it('checks out the exact admitted SHA and never persists checkout credentials', () => {

--- a/tests/railway-reconcile-age.test.mjs
+++ b/tests/railway-reconcile-age.test.mjs
@@ -12,9 +12,9 @@
 // the negative answer decidable. A count-bounded window was unusable when every
 // Deploy Gate evaluation woke this workflow (~33/hour, measured): the newest 30
 // runs could not reach back past a three-hour threshold. Keep the time contract
-// under the bounded schedule so delayed or dropped ticks do not change the
-// liveness meaning. "No run in the window reconciled" is a proof, including an
-// EMPTY window, which is the #6203 failure itself.
+// while the bounded manual rollback surface still exists. "No run in the
+// window reconciled" is a proof, including an EMPTY window, which is the #6203
+// failure itself.
 
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
@@ -130,8 +130,9 @@ describe('reconcile-age window summary', () => {
     assert.throws(() => summarizeReconcileHistory([]), /numeric now/);
   });
 
-  it('keeps a three-hour liveness window around the bounded schedule', () => {
-    // The schedule gets 18 ten-minute opportunities before liveness alarms.
+  it('keeps a bounded three-hour manual rollback evidence window', () => {
+    // The temporary rollback surface retains a finite lookback; it does not
+    // infer health from an unbounded history of old controller successes.
     assert.equal(DEFAULT_MAX_RECONCILE_AGE_MS, 3 * HOUR);
   });
 });
@@ -330,18 +331,14 @@ describe('the cross-file names this scanner depends on', () => {
     );
   });
 
-  it('uses a bounded schedule with enough attempts inside the liveness window', () => {
+  it('is retained only behind an explicit manual rollback invocation', () => {
+    assert.deepEqual(Object.keys(workflow.on), ['workflow_dispatch']);
     assert.equal(Object.hasOwn(workflow.on, 'workflow_run'), false);
-    const schedules = workflow.on?.schedule ?? [];
-    assert.deepEqual(schedules, [{ cron: '7,17,27,37,47,57 * * * *' }]);
-    const minutes = schedules[0].cron.split(' ')[0].split(',').map(Number);
-    const cyclic = [...minutes, minutes[0] + 60];
-    const gaps = cyclic.slice(1).map((minute, index) => minute - cyclic[index]);
-    const maxGapMinutes = Math.max(...gaps);
-    assert.equal(maxGapMinutes, 10);
-    assert.ok(
-      (DEFAULT_MAX_RECONCILE_AGE_MS / (maxGapMinutes * 60_000)) >= 18,
-      'the liveness window must include at least 18 scheduled attempts',
-    );
+    assert.equal(Object.hasOwn(workflow.on, 'schedule'), false);
+    const liveness = workflow.jobs.liveness;
+    assert.match(String(liveness.if), /needs\.verifier\.result != 'success'/);
+    const enforcement = liveness.steps.find((step) => step.name === 'Enforce reconciliation liveness');
+    assert.match(enforcement.run, /CUTOVER_ACTIVE/);
+    assert.match(enforcement.run, /check-railway-reconcile-age\.mjs/);
   });
 });

--- a/tests/railway-stale-reconcile-dispatch.test.mjs
+++ b/tests/railway-stale-reconcile-dispatch.test.mjs
@@ -25,17 +25,12 @@ import {
   WATCHDOG_DISPATCH_STEP_NAME,
   WATCHDOG_HISTORY_WINDOW_MS,
   WATCHDOG_JOB_READ_CONCURRENCY,
-  WATCHDOG_CLASSIFY_JOB_NAME,
   WATCHDOG_MAX_PAGES,
   WATCHDOG_READ_FAILURE_STEP_NAME,
-  WATCHDOG_READ_FAILURE_STREAK_LIMIT,
-  WATCHDOG_READ_FAILURE_STREAK_WINDOW_MS,
   WATCHDOG_READ_RETRY_ATTEMPTS,
   WATCHDOG_READ_RETRY_BASE_MS,
   WATCHDOG_READ_RETRY_MAX_MS,
   WATCHDOG_SOURCE_WORKFLOW_FILE,
-  WATCHDOG_STREAK_API_RESERVE,
-  WATCHDOG_STREAK_PAGE_SIZE,
   classifyWatchdogSnapshot,
   dispatchGitHubRecovery,
   prepareRecoveryDispatch,
@@ -945,8 +940,8 @@ describe('allowlisted GitHub watchdog transport', () => {
       [{ 'retry-after': new Date(NOW + 2_000).toUTCString() }, 2_000],
       [{ 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': String(Math.floor(NOW / 1_000) + 5) }, 5_000],
       // A secondary-limit window longer than the ladder is clamped: sleeping it
-      // out would blow the classify job's own timeout, and the third failure
-      // escalates through the read-failure streak instead.
+      // out would blow the classify job's own timeout, and the exhausted read
+      // fails the current manual invocation instead.
       [{ 'retry-after': '600' }, WATCHDOG_READ_RETRY_MAX_MS],
     ];
     for (const [headers, expected] of cases) {
@@ -2315,144 +2310,29 @@ describe('durably held recovery dispatch orchestration', () => {
   });
 });
 
-// The classify job used to be excluded from ever setting a non-zero exit code,
-// even when main() threw, and no workflow step gated on its outcome. Budget
-// exhaustion, the page cap, or one un-retried 403 all produced a warning, exit
-// 0, and a green check — the same green-while-dead shape that hid the
-// pagination bug for months. This suite owns the two ways it can now go red.
-describe('watchdog read-failure escalation', () => {
-  const watchdogRun = (id, { createdAt = new Date(NOW - 60_000).toISOString(), runAttempt = 1 } = {}) => ({
-    id,
-    run_attempt: runAttempt,
-    created_at: createdAt,
-  });
-
-  const classifyJobs = (markerConclusion, { jobName = WATCHDOG_CLASSIFY_JOB_NAME } = {}) => [{
-    id: 1,
-    name: jobName,
-    steps: [
-      { name: 'Read or classify reconciliation control state', conclusion: 'success' },
-      ...(markerConclusion === null
-        ? []
-        : [{ name: WATCHDOG_READ_FAILURE_STEP_NAME, conclusion: markerConclusion }]),
-    ],
-  }];
-
-  const streakClient = ({ runs, jobsByRun, calls = [] }) => new GitHubWatchdogClient({
-    repository: 'o/r',
-    token: 'token',
-    now: () => NOW,
-    maxRequests: WATCHDOG_STREAK_API_RESERVE,
-    fetchImpl: async (url) => {
-      const parsed = new URL(url);
-      calls.push(`${parsed.pathname}${parsed.search}`);
-      if (parsed.pathname.endsWith(`/${WATCHDOG_SOURCE_WORKFLOW_FILE}/runs`)) {
-        return json({ total_count: runs.length, workflow_runs: runs });
-      }
-      const match = /\/actions\/runs\/(\d+)\/attempts\/\d+\/jobs$/.exec(parsed.pathname);
-      if (match) {
-        const jobs = jobsByRun[match[1]] ?? [];
-        return json({ total_count: jobs.length, jobs });
-      }
-      throw new Error(`unexpected ${url}`);
-    },
-  });
-
-  it('counts consecutive marked runs and stops at the first run that read GitHub', async () => {
-    const calls = [];
-    const client = streakClient({
-      calls,
-      runs: [watchdogRun(31), watchdogRun(32), watchdogRun(33)],
-      jobsByRun: {
-        31: classifyJobs('success'),
-        32: classifyJobs('skipped'),
-        33: classifyJobs('success'),
-      },
-    });
-
-    assert.equal(await client.readReadFailureStreak(), 1);
-    // Run 33 sits behind an unmarked run, so its jobs are never read.
-    assert.ok(!calls.some((call) => call.includes('/runs/33/')));
-    assert.equal(
-      calls[0],
-      `/repos/o/r/actions/workflows/${WATCHDOG_SOURCE_WORKFLOW_FILE}`
-      + `/runs?event=schedule&status=completed&per_page=${WATCHDOG_STREAK_PAGE_SIZE}&page=1`,
-    );
-  });
-
-  it('excludes the current run, caps the walk at the limit, and stays inside its reserve', async () => {
-    const calls = [];
-    const client = streakClient({
-      calls,
-      runs: [41, 42, 43, 44, 45].map((id) => watchdogRun(id)),
-      jobsByRun: Object.fromEntries([41, 42, 43, 44, 45].map((id) => [id, classifyJobs('success')])),
-    });
-
-    assert.equal(await client.readReadFailureStreak({ excludeRunId: '41' }), WATCHDOG_READ_FAILURE_STREAK_LIMIT);
-    assert.ok(!calls.some((call) => call.includes('/runs/41/')));
-    assert.ok(client.requestCount <= WATCHDOG_STREAK_API_RESERVE);
-  });
-
-  it('treats an absent marker, an aged run, and a foreign job as no evidence', async () => {
-    const cases = [
-      // Cancelled before the marker step could run.
-      { runs: [watchdogRun(51)], jobsByRun: { 51: classifyJobs(null) } },
-      // Older than the streak window, so the schedule had a gap.
-      {
-        runs: [watchdogRun(52, {
-          createdAt: new Date(NOW - WATCHDOG_READ_FAILURE_STREAK_WINDOW_MS - 1_000).toISOString(),
-        })],
-        jobsByRun: { 52: classifyJobs('success') },
-      },
-      // A marker with the right name under some other job proves nothing.
-      { runs: [watchdogRun(53)], jobsByRun: { 53: classifyJobs('success', { jobName: 'dispatch' }) } },
-    ];
-    for (const [index, fixture] of cases.entries()) {
-      assert.equal(await streakClient(fixture).readReadFailureStreak(), 0, `case ${index}`);
-    }
-  });
-
-  it('fails the classify job only once the blindness is sustained', async () => {
-    const streaks = [];
-    const github = { readReadFailureStreak: async () => streaks.shift() };
-
-    // A classification that is ambiguous for a non-read reason stays green and
-    // never spends a request on the history.
+// A manual-only watchdog has no later scheduled run that can turn a warning
+// into a failure. The current invocation must therefore go red on its first
+// unreadable GitHub result.
+describe('manual watchdog read-failure exit', () => {
+  it('keeps ambiguity from a non-GitHub dependency separate from read blindness', async () => {
     assert.deepEqual(
       await resolveReadFailureExit({
-        github: { readReadFailureStreak: async () => { throw new Error('must not read'); } },
         result: { outcome: 'DEFERRED_AMBIGUOUS', readFailureCode: null },
-        sourceRunId: '1',
       }),
-      { failJob: false, streak: 0, reason: null },
+      { failJob: false, reason: null },
     );
-
-    for (const [priors, failJob] of [[0, false], [1, false], [2, true], [3, true]]) {
-      streaks.push(priors);
-      const escalation = await resolveReadFailureExit({
-        github,
-        result: { outcome: 'DEFERRED_AMBIGUOUS', readFailureCode: 'GITHUB_READ_BUDGET_EXCEEDED' },
-        sourceRunId: '1',
-      });
-      assert.equal(escalation.streak, priors + 1);
-      assert.equal(escalation.failJob, failJob, `priors ${priors}`);
-    }
   });
 
-  it('fails closed when the streak read itself cannot complete', async () => {
-    const escalation = await resolveReadFailureExit({
-      github: {
-        readReadFailureStreak: async () => {
-          throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'GitHub returned HTTP 403', { status: 403 });
-        },
+  it('fails the first manual invocation that cannot read GitHub', async () => {
+    assert.deepEqual(
+      await resolveReadFailureExit({
+        result: { outcome: 'DEFERRED_AMBIGUOUS', readFailureCode: 'GITHUB_READ_BUDGET_EXCEEDED' },
+      }),
+      {
+        failJob: true,
+        reason: 'the manual watchdog could not read GitHub (GITHUB_READ_BUDGET_EXCEEDED)',
       },
-      result: { outcome: 'DEFERRED_AMBIGUOUS', readFailureCode: 'GITHUB_READ_FAILED' },
-      sourceRunId: '1',
-    });
-
-    assert.equal(escalation.failJob, true);
-    assert.equal(escalation.streak, null);
-    assert.match(escalation.reason, /streak could not be read/);
+    );
   });
 
   it('reports a GitHub read failure distinctly from a control-plane failure', async () => {
@@ -2489,7 +2369,6 @@ describe('watchdog read-failure escalation', () => {
         throw new GitHubWatchdogError('GITHUB_READ_FAILED', 'GitHub returned HTTP 500', { status: 500 });
       },
       readTargetRunSummaries: async () => [],
-      readReadFailureStreak: async () => 0,
     };
     const blind = await prepareRecoveryDispatch({
       github,
@@ -2506,17 +2385,15 @@ describe('watchdog read-failure escalation', () => {
     assert.equal(blind.outcome, 'DEFERRED_AMBIGUOUS');
     assert.equal(blind.readFailureCode, 'GITHUB_READ_FAILED');
     assert.deepEqual(
-      await resolveReadFailureExit({ github, result: blind, sourceRunId: '1' }),
+      await resolveReadFailureExit({ result: blind }),
       {
-        failJob: false,
-        streak: 1,
-        reason: '1 consecutive scheduled runs could not read GitHub (GITHUB_READ_FAILED)',
+        failJob: true,
+        reason: 'the manual watchdog could not read GitHub (GITHUB_READ_FAILED)',
       },
     );
   });
 
-  // The marker step name is the contract between the controller and the
-  // workflow: a rename on either side silently retires the detector.
+  // The marker step name is the contract between the controller and workflow.
   it('pins the workflow marker step to the controller constant', () => {
     const workflow = readFileSync(
       resolve(fileURLToPath(new URL('../.github/workflows/', import.meta.url)), WATCHDOG_SOURCE_WORKFLOW_FILE),
@@ -2526,8 +2403,7 @@ describe('watchdog read-failure escalation', () => {
       workflow,
       new RegExp(`^ {6}- name: ${WATCHDOG_READ_FAILURE_STEP_NAME}$`, 'm'),
     );
-    // `always()` keeps the run that trips the streak from skipping its own
-    // marker and resetting the count.
+    // `always()` records the read failure even after the controller step fails.
     assert.match(
       workflow,
       /^ {8}if: always\(\) && steps\.controller\.outputs\.read_failure == 'true'$/m,
@@ -2557,8 +2433,8 @@ describe('watchdog phase process contract', () => {
         assert.equal(JSON.parse(result.stdout.trim().split('\n').at(-1)).outcome, 'DEFERRED_AMBIGUOUS');
         const output = readFileSync(outputPath, 'utf8');
         assert.match(output, /^outcome=DEFERRED_AMBIGUOUS$/m);
-        // A crash is not a read-path failure, so it must not leave a streak
-        // marker that a later run would count.
+        // A crash is not a classified GitHub read-path failure, so the
+        // diagnostic marker remains skipped.
         assert.match(output, /^read_failure=false$/m);
       }
     } finally {


### PR DESCRIPTION
## Summary

The legacy Railway reconciler no longer wakes on a timer or launches automatic recovery. Both legacy workflows now remain available only as explicitly invoked, cutover-gated rollback surfaces while the repository moves toward Railway's native GitHub autodeploy path.

A manual Watchdog run now fails on its first unreadable GitHub result. The obsolete scheduled-history failure streak, which could leave a manual run green while blind, has been removed. The runbook now records the target architecture, staged cutover, stop conditions, and the rule that normal deployment must never require a recovery-environment approval.

This PR is U1 only. It intentionally does not change live Railway service configuration, repository variables, GitHub protection, deployment state, or environment approvals.

## Validation

- 112 focused workflow/controller tests passed.
- 140 adjacent reconciliation and recovery tests passed.
- `npm run typecheck` and `npm run typecheck:api` passed.
- Markdown lint and the repository pre-push gate passed.
- Full review found one P1 cross-file fail-closed defect; it was fixed and independently revalidated.

## Post-Deploy Monitoring & Validation

Immediately after merge, before any native-autodeploy canary:

- set both legacy reconciliation controls false and verify that no legacy work is active, queued, or waiting for review;
- resolve the refreshed Railway audit to zero and normalize repository-linked service sources;
- enable strict required-check freshness while preserving the existing contexts, admin enforcement, and zero approval count;
- verify that no protected deployment is pending review.

Healthy means the legacy workflows stay dormant, no deployment approval is requested, protection is strict, and the Railway audit is clean before U2/U3 begins. Any automatic legacy run, ambiguous audit result, active recovery, or approval request is a stop condition. Do not approve or dispatch recovery in normal operation; stop the cutover and investigate instead.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/gpt--5.6--sol-000000)
