### PR TITLE
feat(llm): add OrcaRouter as a named LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ GROQ_API_KEY=
 # Get yours at: https://openrouter.ai/
 OPENROUTER_API_KEY=
 
+# OrcaRouter API (optional gateway — 150+ provider-scoped models, e.g.
+# deepseek/deepseek-v4-flash, openai/gpt-4o-mini, anthropic/claude-opus-4.8)
+# Get yours at: https://www.orcarouter.ai
+ORCAROUTER_API_KEY=
+
 # Optional: forecast enrichment model routing
 # Defaults stay unchanged unless you set these.
 # Precedence:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See the **[self-hosting guide](https://www.worldmonitor.app/docs/getting-started
 |----------|-------------|
 | **Frontend** | Vanilla TypeScript, Vite, globe.gl + Three.js, deck.gl + MapLibre GL |
 | **Desktop** | Tauri 2 (Rust) with Node.js sidecar |
-| **AI/ML** | Ollama / Groq / OpenRouter, Transformers.js (browser-side) |
+| **AI/ML** | Ollama / Groq / OpenRouter / OrcaRouter, Transformers.js (browser-side) |
 | **API Contracts** | Protocol Buffers (298 protos, 36 services), sebuf HTTP annotations |
 | **Deployment** | Vercel Edge Functions (60+), Railway relay, Tauri, PWA |
 | **Caching** | Redis (Upstash), 3-tier cache, CDN, service worker |

--- a/scripts/lib/llm-chain.cjs
+++ b/scripts/lib/llm-chain.cjs
@@ -53,6 +53,14 @@ const LLM_PROVIDERS = [
     headers: (key) => ({ 'Authorization': `Bearer ${key}`, 'Content-Type': 'application/json', 'HTTP-Referer': 'https://worldmonitor.app', 'X-Title': 'World Monitor', 'User-Agent': SERVICE_UA }),
     timeout: 20_000,
   },
+  {
+    name: 'orcarouter',
+    envKey: 'ORCAROUTER_API_KEY',
+    apiUrl: 'https://api.orcarouter.ai/v1/chat/completions',
+    model: 'deepseek/deepseek-v4-flash',
+    headers: (key) => ({ 'Authorization': `Bearer ${key}`, 'Content-Type': 'application/json', 'User-Agent': SERVICE_UA }),
+    timeout: 20_000,
+  },
 ];
 
 /**

--- a/server/_shared/llm-health.ts
+++ b/server/_shared/llm-health.ts
@@ -288,6 +288,9 @@ export function warmHealthCache(): void {
   if (typeof process !== 'undefined' && process.env?.OPENROUTER_API_KEY) {
     providerUrls.push('https://openrouter.ai/api/v1/chat/completions');
   }
+  if (typeof process !== 'undefined' && process.env?.ORCAROUTER_API_KEY) {
+    providerUrls.push('https://api.orcarouter.ai/v1/chat/completions');
+  }
 
   for (const url of providerUrls) {
     void isProviderAvailable(url);

--- a/server/_shared/llm.ts
+++ b/server/_shared/llm.ts
@@ -31,7 +31,7 @@ export interface ProviderCredentials {
   extraBody?: Record<string, unknown>;
 }
 
-export type LlmProviderName = 'ollama' | 'groq' | 'openrouter' | 'generic';
+export type LlmProviderName = 'ollama' | 'groq' | 'openrouter' | 'generic' | 'orcarouter';
 
 export interface ProviderCredentialOverrides {
   model?: string;
@@ -124,6 +124,19 @@ export function getProviderCredentials(
     };
   }
 
+  if (provider === 'orcarouter') {
+    const apiKey = process.env.ORCAROUTER_API_KEY;
+    if (!apiKey) return null;
+    return {
+      apiUrl: 'https://api.orcarouter.ai/v1/chat/completions',
+      model: overrides.model || 'deepseek/deepseek-v4-flash',
+      headers: {
+        'Authorization': `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+    };
+  }
+
   // Generic OpenAI-compatible endpoint via LLM_API_URL/LLM_API_KEY/LLM_MODEL
   if (provider === 'generic') {
     const apiUrl = process.env.LLM_API_URL;
@@ -192,8 +205,18 @@ export function stripThinkingTags(text: string): string {
 // via OpenRouter; groq (llama-3.3-70b-versatile) is the free-tier/outage
 // fallback. Ollama stays first so self-hosted deployments are untouched —
 // it is skipped in cloud where OLLAMA_API_URL is unset.
+//
+// orcarouter is deliberately NOT in the default chain: WorldMonitor's default
+// routing keeps the China-hosted provider exclusion (#4993) and the
+// DeepSeek-V4-Flash pin (#4944), both of which are OpenRouter-side policy that
+// a third-party gateway would bypass. It is still a first-class named
+// provider — present in PROVIDER_SET so LLM_TOOL_PROVIDER /
+// LLM_REASONING_PROVIDER / FORECAST_LLM_*_PROVIDER_ORDER and explicit
+// providerOrder all accept it — and only runs when the user opts in by
+// setting ORCAROUTER_API_KEY.
 const PROVIDER_CHAIN = ['ollama', 'openrouter', 'groq', 'generic'] as const;
-const PROVIDER_SET = new Set<string>(PROVIDER_CHAIN);
+const OPTIONAL_PROVIDERS = ['orcarouter'] as const;
+const PROVIDER_SET = new Set<string>([...PROVIDER_CHAIN, ...OPTIONAL_PROVIDERS]);
 
 export interface LlmCallOptions {
   messages: Array<{ role: string; content: string }>;

--- a/server/worldmonitor/news/v1/summarize-article.ts
+++ b/server/worldmonitor/news/v1/summarize-article.ts
@@ -157,6 +157,7 @@ export async function summarizeArticle(
     ollama: 'OLLAMA_API_URL not configured',
     groq: 'GROQ_API_KEY not configured',
     openrouter: 'OPENROUTER_API_KEY not configured',
+    orcarouter: 'ORCAROUTER_API_KEY not configured',
   };
 
   const credentials = getProviderCredentials(provider);

--- a/src/services/desktop-readiness.ts
+++ b/src/services/desktop-readiness.ts
@@ -23,6 +23,7 @@ const keyBackedFeatures: RuntimeFeatureId[] = [
   'aiOllama',
   'aiGroq',
   'aiOpenRouter',
+  'aiOrcaRouter',
   'economicFred',
   'internetOutages',
   'acledConflicts',
@@ -130,7 +131,7 @@ export function getDesktopReadinessChecks(localBackendEnabled: boolean): Desktop
     { id: 'startup', label: 'Desktop startup + sidecar API health', ready: localBackendEnabled },
     { id: 'map', label: 'Map rendering (local layers + static geo assets)', ready: true },
     { id: 'core-intel', label: 'Core intelligence panels (Live News, Monitor, Strategic Risk)', ready: true },
-    { id: 'summaries', label: 'Summaries (provider-backed or browser fallback)', ready: isFeatureAvailable('aiOllama') || isFeatureAvailable('aiGroq') || isFeatureAvailable('aiOpenRouter') },
+    { id: 'summaries', label: 'Summaries (provider-backed or browser fallback)', ready: isFeatureAvailable('aiOllama') || isFeatureAvailable('aiGroq') || isFeatureAvailable('aiOpenRouter') || isFeatureAvailable('aiOrcaRouter') },
     { id: 'market', label: 'Market panel live data paths', ready: true },
     { id: 'live-tracking', label: 'At least one live-tracking mode (AIS or OpenSky)', ready: liveTrackingReady },
   ];

--- a/src/services/runtime-config.ts
+++ b/src/services/runtime-config.ts
@@ -4,6 +4,7 @@ import { invokeTauri } from './tauri-bridge';
 export type RuntimeSecretKey =
   | 'GROQ_API_KEY'
   | 'OPENROUTER_API_KEY'
+  | 'ORCAROUTER_API_KEY'
   | 'EXA_API_KEYS'
   | 'BRAVE_API_KEYS'
   | 'SERPAPI_API_KEYS'
@@ -33,6 +34,7 @@ export type RuntimeSecretKey =
 export type RuntimeFeatureId =
   | 'aiGroq'
   | 'aiOpenRouter'
+  | 'aiOrcaRouter'
   | 'stockNewsSearchExa'
   | 'stockNewsSearchBrave'
   | 'stockNewsSearchSerpApi'
@@ -83,6 +85,7 @@ const TOGGLES_STORAGE_KEY = 'worldmonitor-runtime-feature-toggles';
 const defaultToggles: Record<RuntimeFeatureId, boolean> = {
   aiGroq: true,
   aiOpenRouter: true,
+  aiOrcaRouter: true,
   stockNewsSearchExa: true,
   stockNewsSearchBrave: true,
   stockNewsSearchSerpApi: true,
@@ -128,6 +131,13 @@ export const RUNTIME_FEATURES: RuntimeFeatureDefinition[] = [
     name: 'OpenRouter summarization',
     description: 'Secondary LLM provider for AI summary fallback.',
     requiredSecrets: ['OPENROUTER_API_KEY'],
+    fallback: 'Falls back to local browser model only.',
+  },
+  {
+    id: 'aiOrcaRouter',
+    name: 'OrcaRouter summarization',
+    description: 'Unified AI gateway LLM provider (150+ provider-scoped models) for AI summary fallback. Opt-in: only fires when ORCAROUTER_API_KEY is set.',
+    requiredSecrets: ['ORCAROUTER_API_KEY'],
     fallback: 'Falls back to local browser model only.',
   },
   {

--- a/src/services/settings-constants.ts
+++ b/src/services/settings-constants.ts
@@ -3,6 +3,7 @@ import type { RuntimeSecretKey, RuntimeFeatureId } from './runtime-config';
 export const SIGNUP_URLS: Partial<Record<RuntimeSecretKey, string>> = {
   GROQ_API_KEY: 'https://console.groq.com/keys',
   OPENROUTER_API_KEY: 'https://openrouter.ai/settings/keys',
+  ORCAROUTER_API_KEY: 'https://www.orcarouter.ai',
   EXA_API_KEYS: 'https://dashboard.exa.ai/api-keys',
   BRAVE_API_KEYS: 'https://api-dashboard.search.brave.com/app/keys',
   SERPAPI_API_KEYS: 'https://serpapi.com/manage-api-key',
@@ -39,6 +40,7 @@ export const MASKED_SENTINEL = '__WM_MASKED__';
 export const HUMAN_LABELS: Record<RuntimeSecretKey, string> = {
   GROQ_API_KEY: 'Groq API Key',
   OPENROUTER_API_KEY: 'OpenRouter API Key',
+  ORCAROUTER_API_KEY: 'OrcaRouter API Key',
   EXA_API_KEYS: 'Exa API Keys',
   BRAVE_API_KEYS: 'Brave Search API Keys',
   SERPAPI_API_KEYS: 'SerpAPI Keys',
@@ -76,7 +78,7 @@ export const SETTINGS_CATEGORIES: SettingsCategory[] = [
   {
     id: 'ai',
     label: 'AI & Summarization',
-    features: ['aiOllama', 'aiGroq', 'aiOpenRouter'],
+    features: ['aiOllama', 'aiGroq', 'aiOpenRouter', 'aiOrcaRouter'],
   },
   {
     id: 'economy',

--- a/src/services/summarization-outcome.ts
+++ b/src/services/summarization-outcome.ts
@@ -19,7 +19,7 @@
  * itself imports @/services/i18n and cannot be.
  */
 
-export type AttemptedSummarizationProvider = 'ollama' | 'groq' | 'openrouter' | 'browser';
+export type AttemptedSummarizationProvider = 'ollama' | 'groq' | 'openrouter' | 'orcarouter' | 'browser';
 
 export type SummarizationChainOutcome =
   /** Nothing was eligible: anon/free, feature disabled, or no local model. Expected. */

--- a/src/services/summarization.ts
+++ b/src/services/summarization.ts
@@ -1,7 +1,7 @@
 /**
  * Summarization Service with Fallback Chain
  * Server-side Redis caching handles cross-user deduplication
- * Fallback: Ollama -> Groq -> OpenRouter -> Browser T5
+ * Fallback: Ollama -> OpenRouter -> OrcaRouter -> Groq -> Browser T5
  *
  * Uses NewsServiceClient.summarizeArticle() RPC instead of legacy
  * per-provider fetch endpoints.
@@ -50,7 +50,7 @@ export interface SummarizationResult {
 export type ProgressCallback = (step: number, total: number, message: string) => void;
 
 export interface SummarizeOptions {
-  skipCloudProviders?: boolean;  // true = skip Ollama/Groq/OpenRouter, go straight to browser T5
+  skipCloudProviders?: boolean;  // true = skip Ollama/OpenRouter/OrcaRouter/Groq, go straight to browser T5
   skipBrowserFallback?: boolean; // true = skip browser T5 fallback
   /**
    * Optional article bodies paired 1:1 with `headlines`. When supplied and
@@ -112,9 +112,13 @@ interface ApiProviderDef {
 // Order matches the server's default chain since #4944: OpenRouter
 // (DeepSeek V4 Flash) ahead of Groq — the RPC honors the client-supplied
 // provider, so the client's try-order decides which model summarizes.
+// OrcaRouter sits between the two as an opt-in: it only fires when the
+// server holds ORCAROUTER_API_KEY, so without a key this slot is a no-op
+// and existing users see the historic ollama → openrouter → groq chain.
 const API_PROVIDERS: ApiProviderDef[] = [
   { featureId: 'aiOllama',      provider: 'ollama',     label: 'Ollama' },
   { featureId: 'aiOpenRouter',  provider: 'openrouter', label: 'OpenRouter' },
+  { featureId: 'aiOrcaRouter',  provider: 'orcarouter', label: 'OrcaRouter' },
   { featureId: 'aiGroq',        provider: 'groq',       label: 'Groq AI' },
 ];
 
@@ -272,7 +276,7 @@ async function runApiChain(
 }
 
 /**
- * Generate a summary using the fallback chain: Ollama -> Groq -> OpenRouter -> Browser T5
+ * Generate a summary using the fallback chain: Ollama -> OpenRouter -> OrcaRouter -> Groq -> Browser T5
  * Server-side Redis caching is handled by the SummarizeArticle RPC handler.
  *
  * @param geoContext Optional geographic signal context to include in the prompt

--- a/tests/shared-llm.test.mts
+++ b/tests/shared-llm.test.mts
@@ -8,6 +8,7 @@ const originalFetch = globalThis.fetch;
 const originalAbortSignalTimeout = AbortSignal.timeout;
 const originalGroqApiKey = process.env.GROQ_API_KEY;
 const originalOpenRouterApiKey = process.env.OPENROUTER_API_KEY;
+const originalOrcaRouterApiKey = process.env.ORCAROUTER_API_KEY;
 const originalOllamaApiUrl = process.env.OLLAMA_API_URL;
 const originalLlmApiUrl = process.env.LLM_API_URL;
 const originalLlmApiKey = process.env.LLM_API_KEY;
@@ -31,6 +32,9 @@ afterEach(() => {
 
   if (originalOpenRouterApiKey === undefined) delete process.env.OPENROUTER_API_KEY;
   else process.env.OPENROUTER_API_KEY = originalOpenRouterApiKey;
+
+  if (originalOrcaRouterApiKey === undefined) delete process.env.ORCAROUTER_API_KEY;
+  else process.env.ORCAROUTER_API_KEY = originalOrcaRouterApiKey;
 
   if (originalOllamaApiUrl === undefined) delete process.env.OLLAMA_API_URL;
   else process.env.OLLAMA_API_URL = originalOllamaApiUrl;
@@ -768,5 +772,107 @@ describe('callLlm', () => {
       true,
       'the accepted empty stream resets the streak before the next rejection',
     );
+  });
+
+  it('reaches the orcarouter gateway when pinned via providerOrder', async () => {
+    process.env.ORCAROUTER_API_KEY = 'sk-orca-test-key';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const postUrls: string[] = [];
+    const postBodies: Array<Record<string, unknown>> = [];
+    const postHeaders: Array<Record<string, string>> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if ((init?.method || 'GET') === 'GET') return new Response('', { status: 200 });
+      postUrls.push(url);
+      postBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>);
+      postHeaders.push((init?.headers ?? {}) as Record<string, string>);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'orcarouter response' } }],
+        usage: { total_tokens: 8 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'Summarize the setup.' }],
+      providerOrder: ['orcarouter'],
+    });
+
+    assert.ok(result);
+    assert.equal(result.provider, 'orcarouter');
+    assert.equal(result.model, 'deepseek/deepseek-v4-flash');
+    assert.deepEqual(postUrls.filter(url => url.includes('/chat/completions')), [
+      'https://api.orcarouter.ai/v1/chat/completions',
+    ]);
+    assert.equal(postBodies[0]?.model, 'deepseek/deepseek-v4-flash');
+    assert.equal(postHeaders[0]?.Authorization, 'Bearer sk-orca-test-key');
+  });
+
+  it('falls back to orcarouter within an explicit provider order', async () => {
+    process.env.OPENROUTER_API_KEY = 'or-test-key';
+    process.env.ORCAROUTER_API_KEY = 'sk-orca-test-key';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const postUrls: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if ((init?.method || 'GET') === 'GET') return new Response('', { status: 200 });
+      postUrls.push(url);
+      if (url.includes('openrouter.ai')) return new Response('upstream error', { status: 503 });
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'orcarouter fallback response' } }],
+        usage: { total_tokens: 5 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'Try orca after openrouter.' }],
+      providerOrder: ['openrouter', 'orcarouter'],
+    });
+
+    assert.ok(result);
+    assert.equal(result.provider, 'orcarouter');
+    assert.deepEqual(postUrls.filter(url => url.includes('/chat/completions')), [
+      'https://openrouter.ai/api/v1/chat/completions',
+      'https://api.orcarouter.ai/v1/chat/completions',
+    ]);
+  });
+
+  it('skips orcarouter in an explicit order when ORCAROUTER_API_KEY is absent', async () => {
+    delete process.env.ORCAROUTER_API_KEY;
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+    delete process.env.LLM_API_KEY;
+
+    const postUrls: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if ((init?.method || 'GET') === 'GET') return new Response('', { status: 200 });
+      postUrls.push(url);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'groq response' } }],
+        usage: { total_tokens: 3 },
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await callLlm({
+      messages: [{ role: 'user', content: 'hi' }],
+      providerOrder: ['orcarouter', 'groq'],
+    });
+
+    assert.ok(result);
+    assert.equal(result.provider, 'groq');
+    assert.deepEqual(postUrls.filter(url => url.includes('/chat/completions')), [
+      'https://api.groq.com/openai/v1/chat/completions',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Adds **OrcaRouter** as a named LLM provider across the server LLM client and the client-side summarization chain, mirroring how OpenRouter is wired today.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that exposes 150+ provider-scoped models (e.g. `deepseek/deepseek-v4-flash`, `openai/gpt-4o-mini`, `anthropic/claude-opus-4.8`) behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Because the provider is a thin base-URL + key swap, users who set `ORCAROUTER_API_KEY` get a fully named provider in the existing chain; users who don't are completely unaffected (the provider is skipped, exactly like Groq/OpenRouter are today when their key is absent).

## Type of change

- [x] New feature

## Affected areas

- [x] AI Insights / World Brief
- [x] Config / Settings
- [ ] Other: server-side LLM client + scripts LLM chain

## What this changes

- `server/_shared/llm.ts`: adds `orcarouter` to the `LlmProviderName` union and `getProviderCredentials()` (base URL `https://api.orcarouter.ai/v1/chat/completions`, auth via `ORCAROUTER_API_KEY`, default model `deepseek/deepseek-v4-flash`). Registered in `PROVIDER_SET` as an optional provider so `LLM_TOOL_PROVIDER=orcarouter`, `LLM_REASONING_PROVIDER=orcarouter` and the `FORECAST_LLM_*_PROVIDER_ORDER` envs accept it — but it is deliberately **not** added to the default `PROVIDER_CHAIN`, so default routing (including the China-hosted-provider exclusion from #4993) is unchanged unless the user opts in.
- `server/_shared/llm-health.ts`: warms the health cache for `api.orcarouter.ai` when `ORCAROUTER_API_KEY` is set.
- `server/worldmonitor/news/v1/summarize-article.ts`: adds `orcarouter` to the provider `skipReasons` map.
- `scripts/lib/llm-chain.cjs`: adds an `orcarouter` entry to `LLM_PROVIDERS` (inert without the key).
- `src/services/summarization.ts`: adds an OrcaRouter entry to the client `API_PROVIDERS` chain, right after OpenRouter.
- `src/services/summarization-outcome.ts`: extends `AttemptedSummarizationProvider` with `'orcarouter'`.
- `src/services/runtime-config.ts`: adds `ORCAROUTER_API_KEY` to `RuntimeSecretKey` and an `aiOrcaRouter` feature to `RuntimeFeatureId` / `RUNTIME_FEATURES`.
- `src/services/settings-constants.ts`: adds the OrcaRouter sign-up URL, human label, and the `aiOrcaRouter` feature to the AI settings category.
- `src/services/desktop-readiness.ts`: counts `aiOrcaRouter` among the key-backed AI features and the summaries readiness check.
- `.env.example` + `README.md`: document `ORCAROUTER_API_KEY` and the provider.
- `tests/`: provider credential + chain coverage for `orcarouter`.

## How to use it

1. Get a key at https://www.orcarouter.ai (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY` in your environment or the settings vault.
3. Either leave it as an available fallback in the summarization chain, or pin it explicitly: `LLM_TOOL_PROVIDER=orcarouter`, `LLM_REASONING_PROVIDER=orcarouter`, or `FORECAST_LLM_COMBINED_PROVIDER_ORDER=orcarouter`.

## Verification

- `npm run typecheck` — clean
- Targeted tests for the LLM client / summarization chain — pass
- L3 live check against `https://api.orcarouter.ai/v1/chat/completions` with a real key: 200 + valid completion.

I'm an engineer on the OrcaRouter team.
