### PR TITLE
fix(sentry-triage): admit extension frames to the DebugBear trampoline gate

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -618,6 +618,22 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // the ''-only tolerance shipped and Z6 kept firing from builds that
       // contained it. '' stays admitted (other SDK paths/versions may omit the
       // stamp); both are bounded by the same fetch-free-chunk invariant.
+      // The FIFTH escape is not a build-rename at all — it is an extra frame from
+      // OUTSIDE the page. WORLDMONITOR-Z6 kept firing after the '?' tolerance
+      // shipped, carrying a stack identical to the one above plus a tab-suspender
+      // extension's `freeze-controller.js` above DebugBear's collector (the
+      // extension aborts in-flight fetches when it freezes a background tab).
+      // `nonInfraFrames` drops only `<anonymous>`, `[native code]`, and
+      // `sentry-*.js`, so an extension frame stays in the set, matches neither
+      // predicate, and one frame defeats the `.every()` — the same single-frame
+      // failure mode as the nameless hop, arriving from a different direction.
+      // An extension frame can never be OUR caller (that is precisely what the
+      // two extension gates above already assume), and this gate still requires a
+      // collector frame plus a fetch-free trampoline for every remaining frame, so
+      // admitting it cannot hide a first-party fetch — a real caller alongside the
+      // extension still surfaces, which the regression tests assert.
+      const isExtensionFrameFile = (file: string) =>
+        /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(file);
       const isTrampolineFrameFunction = (fn: string) =>
         /^(?:\w{1,3}\.)?(?:window\.)?fetch$/.test(fn) || /^\w{1,2}$/.test(fn)
         || fn === '' || fn === '?';
@@ -626,7 +642,11 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
           && nonInfraFrames.every(f =>
             isDebugBearRumScriptFrame(f.filename ?? '')
             || (/\/assets\/(?:panel-storage|widget-store)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? '')
-              && isTrampolineFrameFunction(f.function ?? '')))) {
+              && isTrampolineFrameFunction(f.function ?? ''))
+            // Kept last so the trampoline predicate stays adjacent to the chunk
+            // allowlist it is bound to — tests/debugbear-trampoline-chunks.test.mjs
+            // asserts that coupling by source locality.
+            || isExtensionFrameFile(f.filename ?? ''))) {
         return null;
       }
       // Suppress Sentry SDK DOM breadcrumb null-access on document.activeElement/contains.

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -1579,6 +1579,57 @@ describe('sentry beforeSend — Y4 anonymous trampoline hop', () => {
     ]);
     assert.ok(beforeSend(event) !== null, 'no collector frame means no trampoline explanation');
   });
+
+  // ── A browser-extension frame riding the same wrapper ───────────────────────
+  //
+  // WORLDMONITOR-Z6 kept firing after the '?' fix with a stack identical to
+  // y4RuntimeStack except for ONE extra frame: a tab-suspender extension's
+  // freeze-controller.js sitting above DebugBear's collector. `nonInfraFrames`
+  // drops only <anonymous>, [native code], and sentry-*.js, so the extension
+  // frame stays in the set, matches neither the collector predicate nor the
+  // trampoline predicate, and a single frame defeats the `.every()` — the same
+  // failure mode as the nameless hop before it, from a different direction.
+  //
+  // An extension frame can never be OUR caller, and the surrounding gate still
+  // demands a DebugBear collector frame plus fetch-free trampolines for every
+  // remaining frame, so admitting it cannot hide a first-party fetch.
+  const z6ExtensionStack = [
+    { filename: 'chrome-extension://nbgpkmdjdopfhiibdminmpbpmnppcjgm/freeze-controller.js', lineno: 279, function: '?' },
+    ...y4RuntimeStack,
+  ];
+
+  it('suppresses the exact Z6 stack (extension frame above the DebugBear wrapper)', () => {
+    assert.equal(beforeSend(makeEvent('Failed to fetch', 'TypeError', z6ExtensionStack)), null,
+      'a tab-suspender extension aborting a DebugBear-wrapped fetch is not our bug');
+  });
+
+  it('suppresses the moz-extension variant of the same shape', () => {
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: 'moz-extension://a1b2c3/freeze-controller.js', lineno: 279, function: '?' },
+      ...y4RuntimeStack,
+    ]);
+    assert.equal(beforeSend(event), null, 'the extension family is not Chrome-specific');
+  });
+
+  it('does NOT suppress an extension frame without a DebugBear collector', () => {
+    // The collector frame is what explains the trampolines; without it an
+    // extension frame alone must not buy suppression of a first-party fetch.
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: 'chrome-extension://nbgpkmdjdopfhiibdminmpbpmnppcjgm/freeze-controller.js', lineno: 279, function: '?' },
+      { filename: '/assets/panels-DzUv7BBV.js', lineno: 100, function: 'loadCountryGeometry' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'a genuine first-party caller must still surface');
+  });
+
+  it('does NOT suppress an extension stack that also carries a real first-party caller', () => {
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: 'chrome-extension://nbgpkmdjdopfhiibdminmpbpmnppcjgm/freeze-controller.js', lineno: 279, function: '?' },
+      ...y4RuntimeStack,
+      { filename: '/assets/panels-DzUv7BBV.js', lineno: 100, function: 'loadCountryGeometry' },
+    ]);
+    assert.ok(beforeSend(event) !== null,
+      'the extension tolerance must not swallow a named first-party fetch caller');
+  });
 });
 
 // ─── WORLDMONITOR-WK: zero-frame RangeError confined to iOS ───────────────────


### PR DESCRIPTION
`WORLDMONITOR-Z6` (bare `TypeError: Failed to fetch`, error level) survived the `'?'` tolerance that was supposed to close it and kept reaching Sentry — 6 users on the current production bundle. This closes the actual escape.

The stack is identical to the one that fix pinned, except for **one extra frame from outside the page**: a tab-suspender extension's `freeze-controller.js` sitting above DebugBear's collector. Such an extension aborts in-flight fetches when it freezes a background tab, which is what rejects the fetch in the first place.

`nonInfraFrames` (`sentry-init.ts:347`) drops only `<anonymous>`, `[native code]`, and `sentry-*.js`, so the extension frame stayed in the set, matched neither the collector predicate nor the trampoline predicate, and a single frame defeated the `.every()`. That is the same single-frame failure mode as the nameless-hop escape before it — arriving from outside the page rather than from a Vite rename, which is why no amount of function-name tolerance would ever have caught it.

## Why this cannot hide a real fetch failure

An extension frame can never be *our* caller — the two extension gates already above this one assume exactly that. The gate is otherwise unchanged and still demands a DebugBear collector frame **and** a fetch-free trampoline for every remaining frame. The two negative tests pin the boundary: an extension frame with no collector, and an extension stack that also carries a named first-party caller (`loadCountryGeometry`), both still surface.

The new clause is deliberately ordered **last** so the trampoline predicate stays adjacent to the chunk allowlist it is bound to — `tests/debugbear-trampoline-chunks.test.mjs` asserts that coupling by source locality, and inserting the clause between them tripped it. Reordering keeps that guard's assertion true rather than widening its bound.

## Validation

- `tests/sentry-beforesend.test.mjs` **265/265** pass. The two new positive tests were confirmed **red before the fix** (the verbatim production stack and its `moz-extension` variant), and the two negatives passed both before and after, so the change flips exactly the intended cases.
- `tests/debugbear-trampoline-chunks.test.mjs` 3/3 pass.
- `npx tsc --noEmit` clean.

The fixture uses `'?'` rather than `null` for the anonymous frames: the SDK stamps every parsed frame with `function || UNKNOWN_FUNCTION` before `beforeSend` runs, so a fixture built from Sentry's ingest representation tests a shape production never sends — the trap documented at `sentry-init.ts:612`.

Related: [WORLDMONITOR-Z6](https://elie-habib.sentry.io/issues/7669509725/)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

https://claude.ai/code/session_01LBZyutschaksw2oWE7rfX4
