### PR TITLE
ops(payments): alarm on the terminal checkout 429 rate (#6698)

### DIFF
--- a/convex/__tests__/checkoutRateLimit.test.ts
+++ b/convex/__tests__/checkoutRateLimit.test.ts
@@ -1,7 +1,8 @@
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { api } from "../_generated/api";
+import { api, internal } from "../_generated/api";
+import type { ActionCtx } from "../_generated/server";
 import { createDodoCheckoutSession } from "../lib/dodo";
 import {
   CHECKOUT_RATE_LIMITED,
@@ -15,6 +16,12 @@ import {
   retryAfterMsFromError,
   runCheckoutWithRateLimitRetry,
 } from "../payments/checkoutRateLimit";
+import {
+  CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS,
+  CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD,
+  CHECKOUT_RATE_LIMIT_EVENT_RETENTION_MS,
+  recordTerminalCheckoutRateLimit,
+} from "../payments/checkoutRateLimitAlarm";
 import schema from "../schema";
 
 vi.mock("../lib/dodo", () => ({
@@ -529,5 +536,226 @@ describe("provider client retry contract", () => {
     expect(testOptions.environment).toBe("test_mode");
 
     expect(() => buildCheckoutClientOptions({})).toThrow(/DODO_API_KEY/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #6698 — the alarm on the tail of the ladder above.
+//
+// These run the REAL producer (the checkout action) into the REAL reducer (the
+// recording mutation) with only the provider network stubbed. Pinning the two
+// halves separately against hand-written literals would let the seam drift and
+// leave the alarm silent with every test still green.
+// ---------------------------------------------------------------------------
+describe("terminal rate-limit alarm", () => {
+  const ALARM_USER = "user_alarm_probe";
+  const ALARM_PRODUCT = "prod_alarm_probe";
+
+  async function readAlarmRows(t: ReturnType<typeof convexTest>) {
+    return t.run(async (ctx) =>
+      ctx.db.query("checkoutRateLimitEvents").withIndex("by_occurredAt").collect(),
+    );
+  }
+
+  /** Drive one real relay checkout to a terminal 429. */
+  async function exhaustLadderViaRelay(
+    t: ReturnType<typeof convexTest>,
+    productId = ALARM_PRODUCT,
+  ) {
+    const response = await t.fetch("/relay/create-checkout", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TEST_RELAY_SECRET}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ userId: ALARM_USER, productId }),
+    });
+    expect(response.status).toBe(429);
+    return response;
+  }
+
+  test("an exhausted ladder records exactly one occurrence with its buyer context", async () => {
+    process.env.DODO_IDENTITY_SIGNING_SECRET = TEST_SIGNING_SECRET;
+    process.env.RELAY_SHARED_SECRET = TEST_RELAY_SECRET;
+    mockSustainedProviderRateLimit();
+    pinRetryClock();
+    const t = convexTest(schema, modules);
+
+    await exhaustLadderViaRelay(t);
+
+    const rows = await readAlarmRows(t);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      userId: ALARM_USER,
+      productId: ALARM_PRODUCT,
+    });
+    expect(rows[0].occurredAt).toBeGreaterThan(0);
+    // One buyer, one occurrence — the alarm must count terminal outcomes, not
+    // the provider attempts the ladder made getting there.
+    expect(createDodoCheckoutSession).toHaveBeenCalledTimes(
+      CHECKOUT_RATE_LIMIT_MAX_ATTEMPTS,
+    );
+    expect(rows[0].alertedAt).toBeUndefined();
+  });
+
+  test("a checkout the ladder rescues records nothing", async () => {
+    process.env.DODO_IDENTITY_SIGNING_SECRET = TEST_SIGNING_SECRET;
+    process.env.RELAY_SHARED_SECRET = TEST_RELAY_SECRET;
+    pinRetryClock();
+    // 429 once, then success — #6027 working as designed. Counting this would
+    // make the alarm measure provider turbulence the buyer never saw.
+    vi.mocked(createDodoCheckoutSession)
+      .mockRejectedValueOnce(sdkRateLimitError())
+      .mockResolvedValue({ checkout_url: "https://checkout.dodopayments.com/ok" });
+    const t = convexTest(schema, modules);
+
+    const response = await t.fetch("/relay/create-checkout", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${TEST_RELAY_SECRET}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ userId: ALARM_USER, productId: ALARM_PRODUCT }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await readAlarmRows(t)).toHaveLength(0);
+  });
+
+  test("the public action path records too, so neither entry point is blind", async () => {
+    process.env.DODO_IDENTITY_SIGNING_SECRET = TEST_SIGNING_SECRET;
+    mockSustainedProviderRateLimit();
+    pinRetryClock();
+    const t = convexTest(schema, modules);
+
+    await t
+      .withIdentity(TEST_USER)
+      .action(api.payments.checkout.createCheckout, { productId: ALARM_PRODUCT })
+      .catch(() => undefined);
+
+    const rows = await readAlarmRows(t);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(TEST_USER.subject);
+  });
+
+  test("crossing the 24h threshold pages once and stamps the alert", async () => {
+    const t = convexTest(schema, modules);
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    const base = Date.UTC(2026, 7, 14, 9, 0, 0);
+
+    for (let i = 0; i < CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD - 1; i += 1) {
+      const verdict = await t.mutation(
+        internal.payments.checkoutRateLimitAlarm.recordCheckoutRateLimited,
+        { userId: ALARM_USER, productId: ALARM_PRODUCT, occurredAt: base + i * 60_000 },
+      );
+      expect(verdict.kind).toBe("below-threshold");
+    }
+    expect(errors).not.toHaveBeenCalled();
+
+    const breach = await t.mutation(
+      internal.payments.checkoutRateLimitAlarm.recordCheckoutRateLimited,
+      {
+        userId: ALARM_USER,
+        productId: ALARM_PRODUCT,
+        occurredAt: base + CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD * 60_000,
+      },
+    );
+
+    expect(breach.kind).toBe("alert");
+    expect(errors).toHaveBeenCalledTimes(1);
+    expect(String(errors.mock.calls[0][0])).toContain("[checkout-rate-limit-alarm]");
+    expect(String(errors.mock.calls[0][0])).toContain(
+      `day=${CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD}/${CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD}`,
+    );
+
+    const stamped = (await readAlarmRows(t)).filter((row) => row.alertedAt !== undefined);
+    expect(stamped).toHaveLength(1);
+  });
+
+  test("a re-breach inside the cooldown does not page a second time", async () => {
+    const t = convexTest(schema, modules);
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    const base = Date.UTC(2026, 7, 14, 9, 0, 0);
+
+    for (let i = 0; i < CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD; i += 1) {
+      await t.mutation(
+        internal.payments.checkoutRateLimitAlarm.recordCheckoutRateLimited,
+        { userId: ALARM_USER, productId: ALARM_PRODUCT, occurredAt: base + i * 60_000 },
+      );
+    }
+    expect(errors).toHaveBeenCalledTimes(1);
+    // The cooldown runs from the ALERT, not from the first occurrence — the
+    // breach happened on the last write of the loop above.
+    const firstAlertAt = base + (CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD - 1) * 60_000;
+
+    const suppressed = await t.mutation(
+      internal.payments.checkoutRateLimitAlarm.recordCheckoutRateLimited,
+      {
+        userId: ALARM_USER,
+        productId: ALARM_PRODUCT,
+        occurredAt: firstAlertAt + CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS - 1,
+      },
+    );
+    expect(suppressed.kind).toBe("cooldown");
+    expect(errors).toHaveBeenCalledTimes(1);
+
+    // Exactly one cooldown later the alarm speaks again: a live incident must
+    // stay visible, not go quiet after its first event.
+    const reopened = await t.mutation(
+      internal.payments.checkoutRateLimitAlarm.recordCheckoutRateLimited,
+      {
+        userId: ALARM_USER,
+        productId: ALARM_PRODUCT,
+        occurredAt: firstAlertAt + CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS,
+      },
+    );
+    expect(reopened.kind).toBe("alert");
+    expect(errors).toHaveBeenCalledTimes(2);
+  });
+
+  test("retention prunes only what both windows have finished with", async () => {
+    const t = convexTest(schema, modules);
+    const now = Date.UTC(2026, 7, 14, 9, 0, 0);
+    const expired = now - CHECKOUT_RATE_LIMIT_EVENT_RETENTION_MS - 60_000;
+    const insideRetention = now - CHECKOUT_RATE_LIMIT_EVENT_RETENTION_MS + 60_000;
+
+    await t.mutation(
+      internal.payments.checkoutRateLimitAlarm.recordCheckoutRateLimited,
+      { userId: ALARM_USER, productId: ALARM_PRODUCT, occurredAt: expired },
+    );
+    await t.mutation(
+      internal.payments.checkoutRateLimitAlarm.recordCheckoutRateLimited,
+      { userId: ALARM_USER, productId: ALARM_PRODUCT, occurredAt: insideRetention },
+    );
+    // Only this third write carries a `now` recent enough to age the first row out.
+    await t.mutation(
+      internal.payments.checkoutRateLimitAlarm.recordCheckoutRateLimited,
+      { userId: ALARM_USER, productId: ALARM_PRODUCT, occurredAt: now },
+    );
+
+    const remaining = (await readAlarmRows(t)).map((row) => row.occurredAt).sort();
+    expect(remaining).toEqual([insideRetention, now]);
+  });
+
+  test("a failed recording keeps the buyer's outcome and reports the blind alarm", async () => {
+    const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+    const brokenCtx = {
+      runMutation: vi.fn().mockRejectedValue(new Error("write conflict")),
+    } as unknown as ActionCtx;
+
+    // Fail-open: the wrapper must resolve, or a degraded alarm would convert a
+    // retryable rate limit into a hard checkout failure for the buyer.
+    await expect(
+      recordTerminalCheckoutRateLimit(brokenCtx, {
+        userId: ALARM_USER,
+        productId: ALARM_PRODUCT,
+      }),
+    ).resolves.toBeUndefined();
+
+    // ...but silence here would leave the alarm dead with nothing to show for
+    // it, so the failure is itself an ops signal.
+    expect(errors).toHaveBeenCalledTimes(1);
+    expect(String(errors.mock.calls[0][0])).toContain("the rate alarm is blind");
+    expect(String(errors.mock.calls[0][0])).toContain("write conflict");
   });
 });

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -58,6 +58,7 @@ import type * as payments_businessSeats from "../payments/businessSeats.js";
 import type * as payments_cacheActions from "../payments/cacheActions.js";
 import type * as payments_checkout from "../payments/checkout.js";
 import type * as payments_checkoutRateLimit from "../payments/checkoutRateLimit.js";
+import type * as payments_checkoutRateLimitAlarm from "../payments/checkoutRateLimitAlarm.js";
 import type * as payments_returnUrlOrigin from "../payments/returnUrlOrigin.js";
 import type * as payments_seedProductPlans from "../payments/seedProductPlans.js";
 import type * as payments_subscriptionEmails from "../payments/subscriptionEmails.js";
@@ -128,6 +129,7 @@ declare const fullApi: ApiFromModules<{
   "payments/cacheActions": typeof payments_cacheActions;
   "payments/checkout": typeof payments_checkout;
   "payments/checkoutRateLimit": typeof payments_checkoutRateLimit;
+  "payments/checkoutRateLimitAlarm": typeof payments_checkoutRateLimitAlarm;
   "payments/returnUrlOrigin": typeof payments_returnUrlOrigin;
   "payments/seedProductPlans": typeof payments_seedProductPlans;
   "payments/subscriptionEmails": typeof payments_subscriptionEmails;

--- a/convex/payments/checkout.ts
+++ b/convex/payments/checkout.ts
@@ -32,6 +32,7 @@ import {
   isCheckoutRateLimitedOutcome,
   runCheckoutWithRateLimitRetry,
 } from "./checkoutRateLimit";
+import { recordTerminalCheckoutRateLimit } from "./checkoutRateLimitAlarm";
 
 const ACTIVE_SUBSCRIPTION_EXISTS = "ACTIVE_SUBSCRIPTION_EXISTS";
 const PAYMENT_IN_PROGRESS = "PAYMENT_IN_PROGRESS";
@@ -209,6 +210,7 @@ async function getCheckoutBlockingPendingPayment(
 }
 
 async function _createCheckoutSession(
+  ctx: ActionCtx,
   args: CheckoutArgs,
   user: UserInfo,
 ) {
@@ -317,6 +319,16 @@ async function _createCheckoutSession(
       console.warn(
         `[checkout] Dodo rate limited checkout creation for user=${user.userId} product=${args.productId} after bounded retry (<=${CHECKOUT_RATE_LIMIT_MAX_ATTEMPTS} attempts); retry after ${result.retryAfterSeconds}s`,
       );
+      // The ladder's tail (#6698). This warn is per-occurrence and pages
+      // nobody by design; the recorder below owns the RATE and escalates to
+      // Convex auto-Sentry once a documented per-day/per-week threshold is
+      // crossed. Awaited (not scheduled) so the count is durable before the
+      // buyer's 429 is returned, and fail-open so a degraded alarm cannot
+      // convert a retryable rate limit into a hard checkout failure.
+      await recordTerminalCheckoutRateLimit(ctx, {
+        userId: user.userId,
+        productId: args.productId,
+      });
       return result;
     }
     return anonymousClaimToken
@@ -376,7 +388,7 @@ export const createCheckout = action({
         identity.name
       : undefined;
 
-    const result = await _createCheckoutSession(args, {
+    const result = await _createCheckoutSession(ctx, args, {
       userId,
       email: identity?.email,
       name: customerName,
@@ -434,6 +446,7 @@ export const internalCreateCheckout = internalAction({
       return buildPendingBlockedResponse(pending);
     }
     return _createCheckoutSession(
+      ctx,
       {
         productId: args.productId,
         returnUrl: args.returnUrl,

--- a/convex/payments/checkoutRateLimitAlarm.ts
+++ b/convex/payments/checkoutRateLimitAlarm.ts
@@ -1,0 +1,262 @@
+/**
+ * Rate alarm for terminal checkout 429s (#6698).
+ *
+ * #6027 built the bounded provider-retry ladder in `checkoutRateLimit.ts`.
+ * This module watches its TAIL: the checkouts where the ladder ran, was
+ * exhausted, and Dodo was still limiting the shared `DODO_API_KEY`, so the
+ * buyer got a terminal `429 CHECKOUT_RATE_LIMITED`. Each of those is a
+ * paying-intent click that ends in a manual retry.
+ *
+ * Why the signal is recorded server-side rather than read out of Sentry:
+ * the browser event (`WORLDMONITOR-Y1`, level `info`) is emitted by the
+ * client SDK after the fetch resolves, so it is subject to ad-blocking,
+ * client sampling and project inbound filters, and it pages nobody. The
+ * Convex action is the single choke point BOTH entry points funnel through
+ * (`createCheckout` and the relay's `internalCreateCheckout`), so counting
+ * here cannot miss an occurrence the buyer actually experienced.
+ *
+ * Shape: one row per terminal 429, evaluated on insert against a rolling
+ * 24h burst threshold and a rolling 7d drift threshold. Crossing either one
+ * emits a structured `console.error`, which Convex auto-Sentry forwards as an
+ * error-level event — the same ops channel `reportDodoWebhookFailure` and the
+ * refund alert already use. Below threshold the row is recorded silently, so
+ * today's ~0.5/day floor never pages.
+ *
+ * Thresholds, their false-alarm rates, and the named owner are documented in
+ * `docs/payments-checkout-rate-limit-operations.md`. Change them there too.
+ *
+ * Known bound: recording reads a bounded range of the `by_occurredAt` index in
+ * the same transaction as its insert, so two terminal 429s landing at the same
+ * instant contend on OCC and Convex retries them. At the observed rate
+ * (~0.5/day) that never happens, and if a storm ever exhausts the retries the
+ * caller's fail-open wrapper reports the dropped write as its own ops signal —
+ * the alarm degrades loudly, not silently.
+ */
+
+import { v } from "convex/values";
+import { internalMutation, type ActionCtx } from "../_generated/server";
+import { internal } from "../_generated/api";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+/** Burst window — "how bad is it right now". */
+export const CHECKOUT_RATE_LIMIT_ALARM_DAY_WINDOW_MS = DAY_MS;
+
+/** Drift window — "has the floor moved" (the issue's per-week ask). */
+export const CHECKOUT_RATE_LIMIT_ALARM_WEEK_WINDOW_MS = 7 * DAY_MS;
+
+/**
+ * Thresholds are sized against the observed floor, NOT against a test
+ * fixture: 7 terminal 429s over 2026-08-01 -> 2026-08-13 is ~0.54/day and
+ * ~3.8/week. Treating arrivals as Poisson at that rate, `>= 5 in 24h` is a
+ * ~1-in-11-year false alarm and `>= 12 in 7d` is a ~1-in-35-year one, while a
+ * 3x sustained rise pages in ~2 weeks and a 10x launch spike inside ~2 days.
+ * The full sensitivity table is in the ops doc.
+ */
+export const CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD = 5;
+export const CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD = 12;
+
+/**
+ * Minimum gap between two ops signals. A sustained storm keeps crossing the
+ * threshold on every subsequent checkout; without this each buyer would emit
+ * their own `console.error`. 6h keeps a live incident visible (4 events/day)
+ * without turning one outage into an inbox.
+ */
+export const CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS = 6 * HOUR_MS;
+
+/**
+ * Rows older than this are deleted on insert. Strictly LONGER than the week
+ * window so pruning can never remove a row the drift count still needs — a
+ * retention equal to the window would silently shrink `weekCount` at the
+ * boundary and make the drift alarm quietly unreachable.
+ */
+export const CHECKOUT_RATE_LIMIT_EVENT_RETENTION_MS =
+  CHECKOUT_RATE_LIMIT_ALARM_WEEK_WINDOW_MS + DAY_MS;
+
+/**
+ * Hard cap on rows read per evaluation, newest first. Far above both
+ * thresholds, so truncation can only ever UNDERSTATE a count that is already
+ * an order of magnitude past firing — it can delay nothing that the day
+ * threshold has not already caught.
+ */
+export const CHECKOUT_RATE_LIMIT_ALARM_SCAN_LIMIT = 500;
+
+/** Deletes per insert. Bounded so one mutation cannot blow the write limit. */
+export const CHECKOUT_RATE_LIMIT_EVENT_PRUNE_BATCH = 50;
+
+export interface CheckoutRateLimitOccurrence {
+  occurredAt: number;
+  /** Set on the row whose insert emitted an ops signal. */
+  alertedAt?: number;
+}
+
+export type CheckoutRateLimitAlarmVerdict =
+  | {
+      kind: "alert";
+      dayCount: number;
+      weekCount: number;
+      breachedWindows: ("day" | "week")[];
+    }
+  | {
+      kind: "cooldown";
+      dayCount: number;
+      weekCount: number;
+      nextEligibleAt: number;
+    }
+  | { kind: "below-threshold"; dayCount: number; weekCount: number };
+
+/**
+ * Pure classifier for the alarm branch, exported for unit tests.
+ *
+ * `occurrences` must already include the occurrence being recorded — the
+ * verdict describes the state AFTER this terminal 429, which is what the
+ * operator reading the Sentry event needs.
+ *
+ * The cooldown clock is derived from the `alertedAt` stamps carried by the
+ * occurrences themselves rather than a separate singleton document, so there
+ * is no pre-seeded state row whose absence could silently disarm the alarm.
+ */
+export function classifyCheckoutRateLimitAlarm(input: {
+  occurrences: readonly CheckoutRateLimitOccurrence[];
+  now: number;
+}): CheckoutRateLimitAlarmVerdict {
+  const dayFloor = input.now - CHECKOUT_RATE_LIMIT_ALARM_DAY_WINDOW_MS;
+  const weekFloor = input.now - CHECKOUT_RATE_LIMIT_ALARM_WEEK_WINDOW_MS;
+  let dayCount = 0;
+  let weekCount = 0;
+  let lastAlertAt: number | null = null;
+  for (const occurrence of input.occurrences) {
+    // Inclusive at the floor: an occurrence exactly one window old still
+    // counts. Undercounting is the failure mode that makes an alarm silent,
+    // so the boundary resolves toward firing.
+    if (occurrence.occurredAt >= dayFloor) dayCount += 1;
+    if (occurrence.occurredAt >= weekFloor) weekCount += 1;
+    if (
+      typeof occurrence.alertedAt === "number" &&
+      (lastAlertAt === null || occurrence.alertedAt > lastAlertAt)
+    ) {
+      lastAlertAt = occurrence.alertedAt;
+    }
+  }
+
+  const breachedWindows: ("day" | "week")[] = [];
+  if (dayCount >= CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD) breachedWindows.push("day");
+  if (weekCount >= CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD) breachedWindows.push("week");
+  if (breachedWindows.length === 0) {
+    return { kind: "below-threshold", dayCount, weekCount };
+  }
+
+  // `lastAlertAt === null` is the never-alerted state and MUST fire. Defaulting
+  // it to `now` (or to the newest occurrence) would put the very first breach
+  // inside its own cooldown and the alarm would never speak.
+  if (
+    lastAlertAt !== null &&
+    input.now - lastAlertAt < CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS
+  ) {
+    return {
+      kind: "cooldown",
+      dayCount,
+      weekCount,
+      nextEligibleAt: lastAlertAt + CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS,
+    };
+  }
+  return { kind: "alert", dayCount, weekCount, breachedWindows };
+}
+
+/**
+ * Records one terminal `CHECKOUT_RATE_LIMITED` and pages when the rate
+ * crosses either window's threshold.
+ *
+ * Internal-only: the caller is the checkout action, which has already proven
+ * the outcome came from an exhausted provider ladder. Nothing user-supplied
+ * decides whether a row is written.
+ */
+export const recordCheckoutRateLimited = internalMutation({
+  args: {
+    userId: v.string(),
+    productId: v.string(),
+    occurredAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const inserted = await ctx.db.insert("checkoutRateLimitEvents", {
+      userId: args.userId,
+      productId: args.productId,
+      occurredAt: args.occurredAt,
+    });
+
+    // Read newest-first so a truncated scan keeps the most recent occurrences,
+    // which are the ones both windows are measured over.
+    const occurrences = await ctx.db
+      .query("checkoutRateLimitEvents")
+      .withIndex("by_occurredAt")
+      .order("desc")
+      .take(CHECKOUT_RATE_LIMIT_ALARM_SCAN_LIMIT);
+
+    const verdict = classifyCheckoutRateLimitAlarm({
+      occurrences,
+      now: args.occurredAt,
+    });
+
+    if (verdict.kind === "alert") {
+      await ctx.db.patch(inserted, { alertedAt: args.occurredAt });
+      // sentry-coverage-ok: this console.error IS the deliverable. Convex
+      // auto-Sentry forwards it as an error-level event; the message prefix is
+      // held stable so every breach lands in one Sentry issue rather than
+      // minting a new one per count.
+      console.error(
+        `[checkout-rate-limit-alarm] terminal CHECKOUT_RATE_LIMITED rate breached ` +
+          `(day=${verdict.dayCount}/${CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD} in 24h, ` +
+          `week=${verdict.weekCount}/${CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD} in 7d, ` +
+          `windows=${verdict.breachedWindows.join("+")}, ` +
+          `latestUserId=${args.userId}, latestProductId=${args.productId}). ` +
+          `Dodo is limiting the shared DODO_API_KEY past the #6027 bounded ladder; ` +
+          `buyers are being told to retry by hand. Runbook: ` +
+          `docs/payments-checkout-rate-limit-operations.md`,
+      );
+    }
+
+    // Prune AFTER evaluating, so a retention pass can never shrink the count
+    // that decided this verdict.
+    const expired = await ctx.db
+      .query("checkoutRateLimitEvents")
+      .withIndex("by_occurredAt", (q) =>
+        q.lt("occurredAt", args.occurredAt - CHECKOUT_RATE_LIMIT_EVENT_RETENTION_MS),
+      )
+      .take(CHECKOUT_RATE_LIMIT_EVENT_PRUNE_BATCH);
+    for (const row of expired) {
+      await ctx.db.delete(row._id);
+    }
+
+    return verdict;
+  },
+});
+
+/**
+ * Fail-open recorder for the checkout action.
+ *
+ * The buyer already has a typed outcome and a retry hint; a degraded alarm
+ * must never turn that into a hard checkout failure. But a swallowed write
+ * would leave the alarm permanently silent with nothing to show for it, so
+ * the failure path emits its own ops signal — a broken alarm alarms.
+ */
+export async function recordTerminalCheckoutRateLimit(
+  ctx: ActionCtx,
+  args: { userId: string; productId: string },
+): Promise<void> {
+  try {
+    await ctx.runMutation(
+      internal.payments.checkoutRateLimitAlarm.recordCheckoutRateLimited,
+      { ...args, occurredAt: Date.now() },
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // sentry-coverage-ok: the console.error below IS the Sentry report. It is
+    // deliberately not rethrown — see the doc comment above.
+    console.error(
+      `[checkout-rate-limit-alarm] failed to record terminal CHECKOUT_RATE_LIMITED ` +
+        `for user=${args.userId} product=${args.productId}; the rate alarm is blind ` +
+        `until this recovers: ${msg}`,
+    );
+  }
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1060,6 +1060,29 @@ export default defineSchema({
     .index("by_dodoPaymentId", ["dodoPaymentId"])
     .index("by_reconciledAt", ["reconciledAt"]),
 
+  // One row per checkout that exhausted the #6027 provider-429 retry ladder
+  // and returned a terminal CHECKOUT_RATE_LIMITED to the buyer (#6698). This
+  // is the rate signal the alarm in `payments/checkoutRateLimitAlarm.ts`
+  // measures; the browser-side Sentry event is corroboration, not the source,
+  // because it is ad-blockable and fires at level `info`.
+  //
+  // Deliberately payload-free and self-pruning: each insert deletes a bounded
+  // batch of rows older than CHECKOUT_RATE_LIMIT_EVENT_RETENTION_MS, so a
+  // storm drains over the inserts that follow it rather than accumulating for
+  // the lifetime of the deployment. Rows left behind when 429s stop entirely
+  // are inert — every count is window-relative, so a stale row can never
+  // inflate a verdict.
+  checkoutRateLimitEvents: defineTable({
+    userId: v.string(),
+    productId: v.string(),
+    occurredAt: v.number(),
+    // Stamped on the row whose insert crossed a threshold and emitted the ops
+    // signal. This doubles as the alert cooldown clock, which is why the alarm
+    // needs no pre-seeded singleton document — there is no state row whose
+    // absence could silently disarm it.
+    alertedAt: v.optional(v.number()),
+  }).index("by_occurredAt", ["occurredAt"]),
+
   productPlans: defineTable({
     dodoProductId: v.string(),
     planKey: v.string(),

--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,4 +1,10 @@
 roadmap-pro.md
+# Payments ops runbook (#6698). Tracked in git so the alert threshold and
+# owner ship with the code that reads them, but kept off the public site: it
+# names our provider rate-limit tier, counts failed purchases, and records an
+# unverified gap in the checkout retry ladder. docs/internal/ is gitignored,
+# so it cannot live there.
+payments-checkout-rate-limit-operations.md
 internal/
 plans/
 PRESS_KIT.md

--- a/docs/payments-checkout-rate-limit-operations.md
+++ b/docs/payments-checkout-rate-limit-operations.md
@@ -1,0 +1,157 @@
+---
+title: "Checkout Rate-Limit Operations"
+description: "Operational contract for the terminal CHECKOUT_RATE_LIMITED rate alarm: thresholds, owner, triage, and Dodo's published per-key rate limit."
+---
+
+# Checkout Rate-Limit Operations
+
+Issue [#6027](https://github.com/koala73/worldmonitor/issues/6027) stopped Dodo
+`429`s from hard-blocking checkout by absorbing them in a bounded server-side
+retry ladder. This page owns the **tail** of that ladder: the checkouts where
+the ladder ran, was exhausted, and Dodo was still limiting our shared API key,
+so the buyer got a terminal `429 CHECKOUT_RATE_LIMITED` and a "please retry"
+toast. Nothing watched that rate before [#6698](https://github.com/koala73/worldmonitor/issues/6698).
+
+## What the alarm measures
+
+- **Signal source is the server, not the browser.** Every terminal 429 writes
+  one row to `checkoutRateLimitEvents` from
+  `convex/payments/checkout.ts`. Both entry points funnel through that function
+  (`createCheckout` for the dashboard, `internalCreateCheckout` for the
+  `/relay/create-checkout` edge gateway), so no occurrence can be missed by an
+  ad blocker, client sampling, or a Sentry project inbound filter.
+- **Only exhausted ladders count.** A 429 the ladder absorbed and retried into
+  a successful checkout writes nothing. The alarm measures buyers who were
+  turned away, not provider turbulence they never saw.
+- **The browser Sentry issue stays as corroboration.** `WORLDMONITOR-Y1`
+  (`Checkout error: rate_limited`) is level `info` and pages nobody by design.
+  Keep it `unresolved` — resolving it discards the only pre-alarm history of
+  this failure.
+
+## Thresholds and owner
+
+| Field | Value |
+| --- | --- |
+| Burst window | 24h rolling, fires at **5** terminal 429s |
+| Drift window | 7d rolling, fires at **12** terminal 429s |
+| Cooldown between signals | 6h |
+| Row retention | 8d (drift window plus one day of margin) |
+| Channel | `console.error` from Convex, forwarded to Sentry by Convex auto-Sentry as an error-level event |
+| Message prefix | `[checkout-rate-limit-alarm]` |
+| Owner | `@koala73` — reassign here and in the Sentry issue owner if payments ownership moves |
+
+Constants live in `convex/payments/checkoutRateLimitAlarm.ts`. Change them
+there and in the table above together.
+
+### How the thresholds were sized
+
+Sized against the observed floor, not against a test fixture: **7 terminal
+429s between 2026-08-01 and 2026-08-13** is about 0.54/day and 3.8/week.
+Treating arrivals as Poisson at that rate:
+
+| Threshold | False alarm rate at today's floor |
+| --- | --- |
+| 5 in 24h | about one per 11 years |
+| 12 in 7d | about one per 35 years |
+
+Sensitivity to a sustained rise, same model:
+
+| Rate vs. today | Days for the 24h alarm to fire | Weeks for the 7d alarm to fire |
+| --- | --- | --- |
+| 2x | 201 | 12 |
+| 3x | 41 | 2 |
+| 5x | 7 | 1 |
+| 10x | 2 | 1 |
+
+Read that as designed: the 7d window is the drift detector and the 24h window
+is the burst detector. A launch or campaign spike pages within a day or two. A
+slow 2x drift takes about three months to reach the drift threshold — if that
+is too slow once real growth data exists, lower the 7d threshold to 10 first
+(about one false alarm per 3.5 years) rather than touching the 24h one.
+
+### The alarm's own failure mode
+
+If the recording mutation fails, the checkout still returns its normal typed
+429 to the buyer — a degraded alarm must never turn a retryable rate limit
+into a hard checkout failure. But the failure is not swallowed: it emits its
+own `[checkout-rate-limit-alarm] ... the rate alarm is blind` error. Treat that
+message as "the alarm is down", not as noise.
+
+## When it fires
+
+1. **Confirm the shape.** The Sentry message carries `day=N/5`, `week=N/12`,
+   which windows breached, and the most recent buyer and product. A day breach
+   with a normal week count is a burst; a week breach alone is drift.
+2. **Check whether it is us.** The limit is keyed to the API key, and checkout
+   is not the only caller holding `DODO_API_KEY` — see the next section. Look
+   for a `product-catalog` cache miss or a Railway price-poll in the same
+   minute before assuming buyer contention.
+3. **Size the damage.** Each row is one paying-intent click that ended in a
+   manual retry. Query `checkoutRateLimitEvents` for the affected `userId`s;
+   the buyer is not stranded (the client renders a wait-and-retry toast and
+   gates re-clicks during the cooldown), but the conversion is at risk.
+4. **If it is sustained, raise the ceiling.** Dodo tiers are below; upgrading
+   is a support request, not a code change.
+5. **Only then consider client-side auto-retry.** #6698 deliberately ranks this
+   last: it adds pressure to the same shared bucket and is unjustified until
+   the alarm shows real growth.
+
+## Dodo's published rate limits
+
+From the [Dodo Payments API reference](https://docs.dodopayments.com/api-reference/introduction),
+read 2026-08-14. These are the real numbers #6027's ladder constants can be
+sized against.
+
+| Tier | Burst (per second) | Sustained (per minute) |
+| --- | --- | --- |
+| Tier 0 (default) | 40 | 240 |
+| Tier 1 | 100 | 1,000 |
+| Tier 2 | 500 | 5,000 |
+
+- **Keyed on the authentication method and business tier** — one bucket for
+  every caller holding `DODO_API_KEY`, which is what makes a client-side retry
+  useless here. Unauthenticated requests are limited separately by IP
+  (20/s, 100/min).
+- **Raisable: yes.** "Contact support to upgrade your business to a higher rate
+  limit tier." We have not requested an upgrade, and we have not confirmed
+  which tier the account is actually on — assume Tier 0 until support says
+  otherwise.
+- **Advertised headers on a limited response:** `X-RateLimit-Limit`,
+  `X-RateLimit-Remaining`, `X-RateLimit-Reset`.
+
+### What those numbers imply
+
+240 requests/minute sustained is far above WorldMonitor's checkout volume, so
+the terminal 429s are almost certainly **burst** collisions against the 40/s
+ceiling rather than sustained exhaustion. Checkout traffic alone cannot
+plausibly produce a 40-request second at current volume, which points at the
+other holders of the same key:
+
+- `api/product-catalog.js` fetches all **9** catalog products concurrently on a
+  Redis cache miss (1h TTL). One miss is a 9-request burst; several edge
+  regions missing in the same second multiply it.
+- `convex/payments/billing.ts` (portal sessions, the 6-hourly stuck-payment
+  reconciliation) and the Railway price poll in `scripts/ais-relay.cjs` share
+  the key too.
+
+That is arithmetic plus a hypothesis, not a measured cause. The alarm exists to
+supply the correlation data needed to confirm or kill it.
+
+### Known gap in the ladder's provider floor
+
+`retryAfterMsFromError` in `convex/payments/checkoutRateLimit.ts` reads only
+`retry-after-ms` and `retry-after`. Dodo's API reference documents neither on a
+429 — it documents `X-RateLimit-Reset`. If Dodo does not also send
+`Retry-After`, the ladder's "honor the advertised provider floor" branch never
+engages in production and every wait is pure jitter. This has not been verified
+against a live 429 response's headers. Capturing those headers on the next
+alarm firing is the cheapest way to settle it; teaching the ladder to read
+`X-RateLimit-Reset` is the fix if it is confirmed.
+
+## Related
+
+- `convex/payments/checkoutRateLimitAlarm.ts` — thresholds, classifier, recorder
+- `convex/payments/checkoutRateLimit.ts` — #6027's bounded retry ladder
+- `src/services/checkout-errors.ts` — the buyer-facing `rate_limited` mapping
+- `tests/checkout-rate-limit-alarm.test.mts`,
+  `convex/__tests__/checkoutRateLimit.test.ts` — threshold and end-to-end coverage

--- a/tests/checkout-rate-limit-alarm.test.mts
+++ b/tests/checkout-rate-limit-alarm.test.mts
@@ -1,0 +1,215 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS,
+  CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD,
+  CHECKOUT_RATE_LIMIT_ALARM_DAY_WINDOW_MS,
+  CHECKOUT_RATE_LIMIT_ALARM_SCAN_LIMIT,
+  CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD,
+  CHECKOUT_RATE_LIMIT_ALARM_WEEK_WINDOW_MS,
+  CHECKOUT_RATE_LIMIT_EVENT_RETENTION_MS,
+  classifyCheckoutRateLimitAlarm,
+  type CheckoutRateLimitOccurrence,
+} from '../convex/payments/checkoutRateLimitAlarm.ts';
+
+// ---------------------------------------------------------------------------
+// classifyCheckoutRateLimitAlarm — the rate alarm on the tail of #6027's
+// provider-429 ladder (#6698).
+//
+// The thing under test is an ALARM, so the assertions below are written
+// against the question that matters for one: can it stay quiet while buyers
+// are being turned away? Every "does not fire" case therefore pins WHY it did
+// not fire, and every silent-forever path (cooldown with no prior alert,
+// retention shorter than the window, boundary rounding) gets its own case.
+//
+// Observed floor these thresholds are sized against: 7 terminal 429s over
+// 2026-08-01 -> 2026-08-13 (~0.54/day, ~3.8/week) — see
+// docs/payments-checkout-rate-limit-operations.md.
+// ---------------------------------------------------------------------------
+
+const NOW = Date.UTC(2026, 7, 14, 12, 0, 0);
+const MINUTE_MS = 60_000;
+
+/** `count` occurrences spread one minute apart, ending `agoMs` before NOW. */
+function burst(count: number, agoMs = 0): CheckoutRateLimitOccurrence[] {
+  return Array.from({ length: count }, (_, i) => ({
+    occurredAt: NOW - agoMs - i * MINUTE_MS,
+  }));
+}
+
+describe('classifyCheckoutRateLimitAlarm — fires', () => {
+  it('alerts on the first breach of the 24h burst threshold', () => {
+    const verdict = classifyCheckoutRateLimitAlarm({
+      occurrences: burst(CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD),
+      now: NOW,
+    });
+    assert.equal(verdict.kind, 'alert');
+    if (verdict.kind === 'alert') {
+      assert.equal(verdict.dayCount, CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD);
+      assert.deepEqual(verdict.breachedWindows, ['day']);
+    }
+  });
+
+  it('alerts on the 7d drift threshold even when no single day is bursty', () => {
+    // Spread across the week so the 24h count stays at 1 — this is the
+    // "the floor moved" case the day window cannot see.
+    const occurrences = Array.from(
+      { length: CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD },
+      (_, i) => ({ occurredAt: NOW - i * 12 * 60 * 60 * 1000 }),
+    );
+    const verdict = classifyCheckoutRateLimitAlarm({ occurrences, now: NOW });
+    assert.equal(verdict.kind, 'alert');
+    if (verdict.kind === 'alert') {
+      assert.ok(
+        verdict.dayCount < CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD,
+        'day window must be under threshold or this proves nothing about drift',
+      );
+      assert.deepEqual(verdict.breachedWindows, ['week']);
+    }
+  });
+
+  it('reports both windows when a burst also carries the week over', () => {
+    const verdict = classifyCheckoutRateLimitAlarm({
+      occurrences: burst(CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD),
+      now: NOW,
+    });
+    assert.equal(verdict.kind, 'alert');
+    if (verdict.kind === 'alert') {
+      assert.deepEqual(verdict.breachedWindows, ['day', 'week']);
+    }
+  });
+
+  it('fires again once the cooldown has fully elapsed', () => {
+    const occurrences = burst(CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD);
+    occurrences[occurrences.length - 1].alertedAt =
+      NOW - CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS;
+    const verdict = classifyCheckoutRateLimitAlarm({ occurrences, now: NOW });
+    assert.equal(verdict.kind, 'alert');
+  });
+
+  it('counts an occurrence sitting exactly on the window floor', () => {
+    // One event exactly 24h old plus (threshold - 1) fresh ones. If the
+    // boundary were exclusive this would sit one under and stay silent.
+    const occurrences = [
+      ...burst(CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD - 1),
+      { occurredAt: NOW - CHECKOUT_RATE_LIMIT_ALARM_DAY_WINDOW_MS },
+    ];
+    const verdict = classifyCheckoutRateLimitAlarm({ occurrences, now: NOW });
+    assert.equal(verdict.kind, 'alert');
+  });
+});
+
+describe('classifyCheckoutRateLimitAlarm — stays quiet, and says why', () => {
+  it('does not fire at the observed production floor', () => {
+    // 7 occurrences spread over 13 days is the rate the issue documents.
+    const occurrences = Array.from({ length: 7 }, (_, i) => ({
+      occurredAt: NOW - i * 13 * 24 * 60 * 60 * 1000 / 7,
+    }));
+    const verdict = classifyCheckoutRateLimitAlarm({ occurrences, now: NOW });
+    assert.equal(verdict.kind, 'below-threshold');
+    if (verdict.kind === 'below-threshold') {
+      assert.ok(verdict.weekCount < CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD);
+    }
+  });
+
+  it('stays below threshold one occurrence short of the burst', () => {
+    const verdict = classifyCheckoutRateLimitAlarm({
+      occurrences: burst(CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD - 1),
+      now: NOW,
+    });
+    assert.equal(verdict.kind, 'below-threshold');
+    if (verdict.kind === 'below-threshold') {
+      assert.equal(verdict.dayCount, CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD - 1);
+    }
+  });
+
+  it('excludes occurrences that have aged out of both windows', () => {
+    const stale = Array.from(
+      { length: CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD * 2 },
+      (_, i) => ({
+        occurredAt: NOW - CHECKOUT_RATE_LIMIT_ALARM_WEEK_WINDOW_MS - MINUTE_MS - i * MINUTE_MS,
+      }),
+    );
+    const verdict = classifyCheckoutRateLimitAlarm({ occurrences: stale, now: NOW });
+    assert.equal(verdict.kind, 'below-threshold');
+    if (verdict.kind === 'below-threshold') {
+      assert.equal(verdict.dayCount, 0);
+      assert.equal(verdict.weekCount, 0);
+    }
+  });
+
+  it('suppresses a re-breach inside the cooldown, reporting when it reopens', () => {
+    const lastAlertAt = NOW - CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS + MINUTE_MS;
+    const occurrences = burst(CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD + 3);
+    occurrences[1].alertedAt = lastAlertAt;
+    const verdict = classifyCheckoutRateLimitAlarm({ occurrences, now: NOW });
+    assert.equal(verdict.kind, 'cooldown');
+    if (verdict.kind === 'cooldown') {
+      assert.equal(
+        verdict.nextEligibleAt,
+        lastAlertAt + CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS,
+      );
+      // The counts still describe the live breach — a suppressed signal must
+      // not also lose the numbers.
+      assert.ok(verdict.dayCount >= CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD);
+    }
+  });
+
+  it('uses the NEWEST alertedAt, not the first one it happens to see', () => {
+    // Ordered newest-first, as the mutation reads them. An implementation that
+    // stopped at the first stamp would read the stale one and re-page.
+    const occurrences = burst(CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD + 2);
+    occurrences[0].alertedAt = NOW - CHECKOUT_RATE_LIMIT_ALARM_COOLDOWN_MS - MINUTE_MS;
+    occurrences[3].alertedAt = NOW - MINUTE_MS;
+    const verdict = classifyCheckoutRateLimitAlarm({ occurrences, now: NOW });
+    assert.equal(verdict.kind, 'cooldown');
+  });
+});
+
+describe('classifyCheckoutRateLimitAlarm — cannot be silent forever', () => {
+  it('fires on a breach that has never alerted, whatever the timestamps', () => {
+    // The classic dead-alarm bug: defaulting "last alert" to now (or to the
+    // newest occurrence) puts the first breach inside its own cooldown.
+    const occurrences = burst(CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD);
+    assert.ok(
+      occurrences.every((o) => o.alertedAt === undefined),
+      'fixture must carry no alert stamp or this proves nothing',
+    );
+    const verdict = classifyCheckoutRateLimitAlarm({ occurrences, now: NOW });
+    assert.equal(verdict.kind, 'alert');
+  });
+
+  it('keeps retention strictly longer than the drift window', () => {
+    // Retention equal to the window would delete rows the week count still
+    // needs, shrinking weekCount at the boundary until the drift alarm could
+    // never reach its threshold.
+    assert.ok(
+      CHECKOUT_RATE_LIMIT_EVENT_RETENTION_MS > CHECKOUT_RATE_LIMIT_ALARM_WEEK_WINDOW_MS,
+      'retention must outlive the longest window the alarm measures',
+    );
+  });
+
+  it('keeps the scan cap far above both thresholds', () => {
+    // Truncation understates counts. That is only safe while the cap sits far
+    // past the point where the alarm has already fired.
+    assert.ok(
+      CHECKOUT_RATE_LIMIT_ALARM_SCAN_LIMIT >= CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD * 10,
+      'a scan cap near the threshold could silently suppress a real breach',
+    );
+  });
+
+  it('keeps thresholds above the observed floor but reachable', () => {
+    // Sized to the incident, not to a fixture: a threshold at or below the
+    // steady-state rate is permanently lit, one far above it never fires.
+    assert.ok(CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD > 1);
+    assert.ok(
+      CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD > CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD,
+      'the drift window must tolerate more than one day of burst',
+    );
+    assert.ok(
+      CHECKOUT_RATE_LIMIT_ALARM_WEEK_THRESHOLD <
+        CHECKOUT_RATE_LIMIT_ALARM_DAY_THRESHOLD * 7,
+      'a week threshold at 7x the day threshold is unreachable by sustained drift',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

#6027's bounded provider-429 ladder works. Nothing watched its tail: 7 buyers hit a terminal `429 CHECKOUT_RATE_LIMITED` between 2026-08-01 and 2026-08-13, visible only as `WORLDMONITOR-Y1` at level `info`, which pages nobody.

Every exhausted ladder now writes one `checkoutRateLimitEvents` row from the Convex checkout action — the single choke point both `createCheckout` and the relay's `internalCreateCheckout` funnel through, so no occurrence is lost to an ad blocker, client sampling, or a Sentry inbound filter. Crossing **5-in-24h** (burst) or **12-in-7d** (drift) emits a structured `console.error` that Convex auto-Sentry forwards as an error-level event, with a 6h cooldown so one incident is not an inbox.

A checkout the ladder rescues records nothing — the alarm measures buyers turned away, not provider turbulence they never saw.

### Threshold sizing

Sized against the observed floor (7 events / 13 days ≈ 0.54/day), not a fixture. Poisson at that rate:

| Threshold | False alarm at today's floor | 3x rise | 10x spike |
| --- | --- | --- | --- |
| 5 in 24h | ~1 per 11 years | ~41 days | ~2 days |
| 12 in 7d | ~1 per 35 years | ~2 weeks | ~1 week |

### Dodo's per-key limit (AC #2)

From the [API reference](https://docs.dodopayments.com/api-reference/introduction), read 2026-08-14: **Tier 0 default is 40 req/s burst, 240 req/min sustained**, keyed on the authentication method and business tier. Raisable to Tier 1 (100/s, 1,000/min) or Tier 2 (500/s, 5,000/min) via support. #6027's constants were sized against an assumed number; they now have a real one.

240/min sustained is far above our checkout volume, so these are almost certainly **burst** collisions — which points at the other holders of the same key (`api/product-catalog.js` fires 9 concurrent product fetches per cache miss; `payments/billing.ts`; the Railway price poll). Documented as arithmetic plus a hypothesis, not a measured cause.

## Green-while-dead hardening

The deliverable is an alarm, so it was reviewed for whether it can report green while buyers are being turned away:

- **Failed recording is not silent.** The recorder is fail-open for the buyer (a degraded alarm must never turn a retryable 429 into a hard checkout failure) but emits its own `the rate alarm is blind` error. A broken alarm alarms.
- **No pre-seeded singleton.** The cooldown clock lives on the event rows themselves, so there is no state document whose absence could disarm it — and no new `convex-deploy.yml` seed step.
- **Retention (8d) is strictly longer than the drift window (7d)**, so pruning can never shrink the count it is measured against. Pinned by a test.
- **First breach cannot be trapped in its own cooldown** — the never-alerted state fires. Pinned by a test.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Convex payments/checkout, ops alerting

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- [x] `docs/payments-checkout-rate-limit-operations.md` documents the thresholds, sizing, owner (`@koala73`), triage runbook, and Dodo's published limits. Added to `docs/.mintignore` — tracked in git so the threshold ships with the code that reads it, but kept off the public site because it names our provider tier, counts failed purchases, and records an unverified gap in the retry ladder. `docs/internal/` was not an option: it is gitignored, so the runbook would silently never have been committed.

## Test plan

- `tests/checkout-rate-limit-alarm.test.mts` — 14 classifier tests (thresholds, window boundaries, cooldown, silent-forever guards)
- `convex/__tests__/checkoutRateLimit.test.ts` — 28 tests, 7 new, end-to-end through the **real** action into the **real** mutation with only the provider network stubbed
- **Mutation sweep: 11/11 mutants killed** (breach never escalates, first breach self-suppressed, exclusive boundary, retention equal to window, swallowed recorder failure, oldest-alertedAt-wins, unstamped alert, over-broad prune, unreachable week threshold, missing recorder call, recording every checkout). Reverted by file copy; tree verified clean afterwards.
- Full convex suite: 1235/1235 across 57 files
- `npx tsc --noEmit`, `npm run typecheck:api`, `check-sentry-coverage --diff` (clean, 5 files), `mdx-lint` (739), `docs-i18n-parity` (247), `docs-stats --check`, `convex-entrypoint-hygiene`, `check-public-doc-plan-references`, `check-local-secret-dumps`, biome

## Related

- Fixes #6698
- Builds on #6027 / #6032

## Known Residuals

- **P2.** `retryAfterMsFromError` reads only `retry-after-ms` / `retry-after`. Dodo's API reference documents neither on a 429 — it documents `X-RateLimit-Reset`. If Dodo does not also send `Retry-After`, the ladder's "honor the advertised provider floor" branch never engages in production and every wait is pure jitter. **Unverified against a live 429's headers**; capturing them on the next firing settles it. Left out of scope deliberately — #6698 ranks ladder changes behind "watch it first".
- **P3.** The account's actual Dodo tier is unconfirmed. The doc assumes Tier 0; confirming it (and whether an upgrade is warranted) is a support request, which is #6698's step 2 and not a code change.
- **P3.** A sustained 2x drift takes ~12 weeks to reach the 7d threshold. Retune to 10 (≈1 false alarm per 3.5 years) once real growth data exists.
- **Per #6698's acceptance criteria, `WORLDMONITOR-Y1` stays `unresolved`** until this alert is live in production — resolving it discards the only pre-alarm history.

## Post-Deploy Monitoring & Validation

- **Window:** from Convex deploy through the first week. Owner: merger.
- **Healthy signals:** `checkoutRateLimitEvents` accrues rows at roughly the historical rate (~0.5/day) with no `[checkout-rate-limit-alarm]` Sentry event; the table stays small.
- **Failure signals:** `the rate alarm is blind` errors (recorder degraded — the alarm is down, triage first); an immediate breach on deploy (thresholds mis-sized against real volume, not the Sentry-visible subset — retune rather than mute).
- **Rollback:** revert this PR. The ladder and the buyer-facing 429 path are untouched by it, so reverting only removes the watching.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
