### PR TITLE
fix(convex): take the prefs limiter's stale-row sweep off the write path (#6706)

### DIFF
--- a/convex/__tests__/userPreferences.test.ts
+++ b/convex/__tests__/userPreferences.test.ts
@@ -1,7 +1,9 @@
 import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import schema from "../schema";
-import { api } from "../_generated/api";
+import { api, internal } from "../_generated/api";
+import type { MutationCtx } from "../_generated/server";
+import { checkUserPrefsWriteRateLimit } from "../userPreferences";
 import {
   MAX_PREFS_BLOB_SIZE,
   USER_PREFS_WRITE_RATE_LIMIT,
@@ -26,6 +28,90 @@ const USER_B = {
 
 function makeT() {
   return convexTest(schema, modules);
+}
+
+/**
+ * A recorded index-range bound, e.g. ["eq", "windowStart", 1699999980000].
+ * Convex derives a mutation's OCC read set from the index ranges it scans, so
+ * the bounds a query declares ARE the read set — recording them is the direct
+ * observation of what #6706 is about, not a proxy for it.
+ */
+type RecordedBound = [method: string, field: string, value: unknown];
+type RecordedRange = { table: string; index: string; bounds: RecordedBound[] };
+
+/**
+ * Mirrors the index-range builder handed to `withIndex`, recording each bound
+ * and delegating to the real builder. Every call returns the wrapper again so
+ * chained bounds (`q.eq(...).eq(...)`) are captured in order.
+ */
+function recordRange(realRange: any, bounds: RecordedBound[]) {
+  const wrap = (method: "eq" | "lt" | "lte" | "gt" | "gte") =>
+    (field: string, value: unknown) => {
+      bounds.push([method, field, value]);
+      return recordRange(realRange[method](field, value), bounds);
+    };
+  return {
+    eq: wrap("eq"),
+    lt: wrap("lt"),
+    lte: wrap("lte"),
+    gt: wrap("gt"),
+    gte: wrap("gte"),
+    // Convex consumes the builder by calling `export()` exactly once. Delegating
+    // it is what keeps the recorded bounds and the range Convex actually scans
+    // the same object graph rather than two independent constructions.
+    export: () => realRange.export(),
+  };
+}
+
+/**
+ * Wraps a REAL convex-test `ctx.db` so the reads and writes still hit the real
+ * in-memory database — only the index ranges are observed on the way through.
+ * There is no second implementation of the limiter's storage, so the test
+ * cannot pass for a reason the production path would not also produce.
+ */
+function recordingDb(db: any, recorded: RecordedRange[]) {
+  return {
+    query: (table: string) => {
+      const q = db.query(table);
+      return {
+        withIndex: (index: string, rangeFn: (rq: any) => any) => {
+          const bounds: RecordedBound[] = [];
+          const built = q.withIndex(index, (rq: any) => rangeFn(recordRange(rq, bounds)));
+          recorded.push({ table, index, bounds });
+          return built;
+        },
+      };
+    },
+    get: (id: any) => db.get(id),
+    insert: (table: string, doc: any) => db.insert(table, doc),
+    patch: (id: any, patch: any) => db.patch(id, patch),
+    delete: (id: any) => db.delete(id),
+  };
+}
+
+async function seedLimiterRow(
+  t: ReturnType<typeof convexTest>,
+  userId: string,
+  windowStart: number,
+  count: number,
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("userPreferenceWriteRateLimits", {
+      userId,
+      windowStart,
+      count,
+      updatedAt: windowStart,
+    });
+  });
+}
+
+async function limiterRows(t: ReturnType<typeof convexTest>, userId: string) {
+  return await t.run(async (ctx) => {
+    return await ctx.db
+      .query("userPreferenceWriteRateLimits")
+      .withIndex("by_user_window", (q) => q.eq("userId", userId))
+      .collect();
+  });
 }
 
 async function writePref(
@@ -132,15 +218,20 @@ describe("userPreferences.setPreferences write rate limit", () => {
 
     await expect(writePref(t, USER_A, 0)).resolves.toEqual({ ok: true, syncVersion: 1 });
 
-    const rows = await t.run(async (ctx) => {
-      return await ctx.db
-        .query("userPreferenceWriteRateLimits")
-        .withIndex("by_user_window", (q) => q.eq("userId", USER_A.subject))
-        .collect();
-    });
+    const rows = await limiterRows(t, USER_A.subject);
 
-    expect(rows).toHaveLength(1);
+    // Consolidation is scoped to the current window — that is the one range the
+    // write path is allowed to touch (#6706). The count is 4 (1 + 2 duplicates,
+    // plus this write), NOT 103: the expired window's 99 is neither folded in
+    // nor deleted here. It survives until `pruneStaleWriteRateLimits` collects
+    // it, which is the whole point of moving that sweep off the write path.
+    expect(rows).toHaveLength(2);
     expect(rows[0]).toMatchObject({
+      userId: USER_A.subject,
+      windowStart: TEST_WINDOW_START - USER_PREFS_WRITE_RATE_WINDOW_MS,
+      count: 99,
+    });
+    expect(rows[1]).toMatchObject({
       userId: USER_A.subject,
       windowStart: TEST_WINDOW_START,
       count: 4,
@@ -283,5 +374,157 @@ describe("userPreferences.setPreferences write rate limit", () => {
       [layerOwnership]: "[]",
       [fontScale]: "1",
     });
+  });
+});
+
+/**
+ * #6706 (WORLDMONITOR-ZE). Convex builds a mutation's OCC read set from the
+ * index ranges it scans. The limiter used to end every write with a stale-row
+ * sweep keyed on `userId` ALONE, which pulled the user's whole row set — across
+ * all windows — into the read set of a write that only ever needs the current
+ * window. A second concurrent write by the same user (two dashboard tabs, or a
+ * dragged slider persisting per change) invalidated that read set, and because
+ * the contending writes kept arriving, every retry collided too — Convex
+ * exhausted its retries and the preference write FAILED.
+ *
+ * The bound below is the fix's contract: no query the write path issues against
+ * `userPreferenceWriteRateLimits` may leave `windowStart` unbounded.
+ */
+describe("userPreferences write-path OCC read set (#6706)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("limiter accounting scans only the caller's current window", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = makeT();
+
+    // Rows this user left behind in earlier windows — exactly what the old
+    // sweep reached for, and what dragged the read set wide.
+    await seedLimiterRow(t, USER_A.subject, TEST_WINDOW_START - USER_PREFS_WRITE_RATE_WINDOW_MS, 7);
+    await seedLimiterRow(t, USER_A.subject, TEST_WINDOW_START - 5 * USER_PREFS_WRITE_RATE_WINDOW_MS, 3);
+    await seedLimiterRow(t, USER_A.subject, TEST_WINDOW_START, 1);
+
+    const recorded: RecordedRange[] = [];
+    const result = await t.run(async (ctx) => {
+      return await checkUserPrefsWriteRateLimit(
+        { db: recordingDb(ctx.db, recorded) } as unknown as MutationCtx,
+        USER_A.subject,
+      );
+    });
+
+    expect(result).toEqual({ ok: true });
+
+    const limiterScans = recorded.filter((r) => r.table === "userPreferenceWriteRateLimits");
+    expect(limiterScans.length).toBeGreaterThan(0);
+    for (const scan of limiterScans) {
+      expect(scan.bounds).toEqual([
+        ["eq", "userId", USER_A.subject],
+        ["eq", "windowStart", TEST_WINDOW_START],
+      ]);
+    }
+  });
+
+  test("a write leaves other windows' rows untouched", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = makeT();
+
+    const previousWindow = TEST_WINDOW_START - USER_PREFS_WRITE_RATE_WINDOW_MS;
+    await seedLimiterRow(t, USER_A.subject, previousWindow, 7);
+
+    await expect(writePref(t, USER_A, 0)).resolves.toEqual({ ok: true, syncVersion: 1 });
+
+    const rows = await limiterRows(t, USER_A.subject);
+    expect(rows.map((row) => ({ windowStart: row.windowStart, count: row.count }))).toEqual([
+      { windowStart: previousWindow, count: 7 },
+      { windowStart: TEST_WINDOW_START, count: 1 },
+    ]);
+  });
+});
+
+describe("userPreferences.pruneStaleWriteRateLimits", () => {
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("collects expired windows and never the live counter", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = makeT();
+
+    await seedLimiterRow(t, USER_A.subject, TEST_WINDOW_START - 10 * USER_PREFS_WRITE_RATE_WINDOW_MS, 4);
+    await seedLimiterRow(t, USER_A.subject, TEST_WINDOW_START - USER_PREFS_WRITE_RATE_WINDOW_MS, 7);
+    await seedLimiterRow(t, USER_A.subject, TEST_WINDOW_START, 12);
+    await seedLimiterRow(t, USER_B.subject, TEST_WINDOW_START - 2 * USER_PREFS_WRITE_RATE_WINDOW_MS, 5);
+    await seedLimiterRow(t, USER_B.subject, TEST_WINDOW_START, USER_PREFS_WRITE_RATE_LIMIT);
+
+    await expect(
+      t.mutation(internal.userPreferences.pruneStaleWriteRateLimits, {}),
+    ).resolves.toMatchObject({ deleted: 3, cutoff: TEST_WINDOW_START, rescheduled: false });
+
+    expect(await limiterRows(t, USER_A.subject)).toMatchObject([
+      { windowStart: TEST_WINDOW_START, count: 12 },
+    ]);
+    // USER_B was at the cap. Had the prune touched the live row, the very next
+    // write would have been admitted — a limiter bypass, not just early GC.
+    expect(await limiterRows(t, USER_B.subject)).toMatchObject([
+      { windowStart: TEST_WINDOW_START, count: USER_PREFS_WRITE_RATE_LIMIT },
+    ]);
+    await expectRateLimited(writePref(t, USER_B, 0));
+  });
+
+  test("self-drains across runs when a batch fills", async () => {
+    // The continuation is queued via ctx.scheduler.runAfter(0); convex-test
+    // can't cleanly execute a self-scheduling mutation's continuation, so the
+    // drain is driven by re-invoking and the queued callbacks are discarded.
+    vi.useFakeTimers();
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = makeT();
+
+    for (let i = 1; i <= 5; i++) {
+      await seedLimiterRow(t, USER_A.subject, TEST_WINDOW_START - i * USER_PREFS_WRITE_RATE_WINDOW_MS, i);
+    }
+    await seedLimiterRow(t, USER_A.subject, TEST_WINDOW_START, 1);
+
+    await expect(
+      t.mutation(internal.userPreferences.pruneStaleWriteRateLimits, { limit: 2 }),
+    ).resolves.toMatchObject({ deleted: 2, rescheduled: true });
+    await expect(
+      t.mutation(internal.userPreferences.pruneStaleWriteRateLimits, { limit: 2 }),
+    ).resolves.toMatchObject({ deleted: 2, rescheduled: true });
+    await expect(
+      t.mutation(internal.userPreferences.pruneStaleWriteRateLimits, { limit: 2 }),
+    ).resolves.toMatchObject({ deleted: 1, rescheduled: false });
+
+    expect(await limiterRows(t, USER_A.subject)).toMatchObject([
+      { windowStart: TEST_WINDOW_START, count: 1 },
+    ]);
+  });
+
+  test("a zero or non-finite limit falls back instead of rescheduling forever", async () => {
+    // Fake timers for the same reason as the drain test above: the first pass
+    // below reschedules, and a continuation firing on its own mid-test would
+    // open a transaction while this one is still running.
+    vi.useFakeTimers();
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = makeT();
+
+    await seedLimiterRow(t, USER_A.subject, TEST_WINDOW_START - USER_PREFS_WRITE_RATE_WINDOW_MS, 7);
+
+    // limit:0 would make take(0) return [] and read `0 >= 0` as a full batch —
+    // an empty reschedule loop that deletes nothing. The floor turns it into a
+    // real pass instead.
+    await expect(
+      t.mutation(internal.userPreferences.pruneStaleWriteRateLimits, { limit: 0 }),
+    ).resolves.toMatchObject({ deleted: 1, rescheduled: true });
+    await expect(
+      t.mutation(internal.userPreferences.pruneStaleWriteRateLimits, { limit: 0 }),
+    ).resolves.toMatchObject({ deleted: 0, rescheduled: false });
+
+    await seedLimiterRow(t, USER_A.subject, TEST_WINDOW_START - USER_PREFS_WRITE_RATE_WINDOW_MS, 7);
+    await expect(
+      t.mutation(internal.userPreferences.pruneStaleWriteRateLimits, { limit: Number.NaN }),
+    ).resolves.toMatchObject({ deleted: 1, rescheduled: false });
   });
 });

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -46,6 +46,20 @@ crons.hourly(
   {},
 );
 
+// Retention sweep for the preference-write rate limiter (#6706). The limiter
+// used to drop expired-window rows inline on every write, which widened that
+// mutation's OCC read set from one counter row to the caller's entire row set
+// and livelocked users writing from two tabs. Collecting them here keeps the
+// write path's read set at exactly the current window. Hourly, not daily: a
+// user writing continuously produces one row per 60s window, so an hourly tick
+// bounds the table at ~60 rows per active user instead of ~1440.
+crons.hourly(
+  "user-prefs-rate-limit-prune",
+  { minuteUTC: 52 },
+  internal.userPreferences.pruneStaleWriteRateLimits,
+  {},
+);
+
 // PRO-launch broadcast ramp runner. Wakes once a day at 13:00 UTC
 // (~9am ET / 6am PT / 3pm CET — early enough that any kill-gate
 // trip can be triaged within US business hours, late enough that

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -125,7 +125,13 @@ export default defineSchema({
     windowStart: v.number(),
     count: v.number(),
     updatedAt: v.number(),
-  }).index("by_user_window", ["userId", "windowStart"]),
+  })
+    .index("by_user_window", ["userId", "windowStart"])
+    // Retention scan for `pruneStaleWriteRateLimits` (#6706). Expired-window
+    // rows are garbage-collected off the write path, so the sweep needs a
+    // cross-user range on age alone; without it the prune would be a full
+    // table scan whose read set collides with every live counter.
+    .index("by_windowStart", ["windowStart"]),
 
   notificationChannels: defineTable(
     v.union(

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -1,5 +1,12 @@
 import { ConvexError, v } from "convex/values";
-import { internalQuery, mutation, query, type MutationCtx } from "./_generated/server";
+import {
+  internalMutation,
+  internalQuery,
+  mutation,
+  query,
+  type MutationCtx,
+} from "./_generated/server";
+import { internal } from "./_generated/api";
 import {
   CURRENT_PREFS_SCHEMA_VERSION,
   MAX_PREFS_BLOB_SIZE,
@@ -58,7 +65,12 @@ type UserPrefsWriteRateLimitResult =
   | { ok: false; reason: "RATE_LIMITED"; limit: number; reset: number };
 
 const RATE_LIMIT_COUNTER_SCAN_LIMIT = USER_PREFS_WRITE_RATE_LIMIT + 1;
-const RATE_LIMIT_STALE_CLEANUP_LIMIT = 5;
+/**
+ * Per-run delete cap for `pruneStaleWriteRateLimits`. Rows are four scalar
+ * fields, so 500 deletes sit far under Convex's per-mutation write budget while
+ * still draining an hour of expired windows for hundreds of users in one pass.
+ */
+const RATE_LIMIT_PRUNE_BATCH = 500;
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -87,12 +99,30 @@ export function preserveOmittedRollingDeploymentFields(
   return merged ?? incomingData;
 }
 
-async function checkUserPrefsWriteRateLimit(
+function currentRateLimitWindowStart(now: number): number {
+  return Math.floor(now / USER_PREFS_WRITE_RATE_WINDOW_MS) * USER_PREFS_WRITE_RATE_WINDOW_MS;
+}
+
+/**
+ * Every index range this touches is bounded to `(userId, windowStart)` — the
+ * single row the limiter actually accounts against. Convex derives a mutation's
+ * OCC read set from the ranges it scans, so widening this by even one unbounded
+ * query drags the caller's rows from every other window into the read set, and
+ * any concurrent write by the SAME user (two dashboard tabs, or a dragged
+ * slider persisting per change) invalidates it. That is how #6706
+ * (WORLDMONITOR-ZE) livelocked: retries collided with the still-arriving
+ * contending writes until Convex exhausted them and the write failed outright.
+ *
+ * Expired-window rows are therefore NOT collected here. They are opportunistic
+ * garbage with no reader, and `pruneStaleWriteRateLimits` ages them out on a
+ * cron instead — off the user-facing path entirely.
+ */
+export async function checkUserPrefsWriteRateLimit(
   ctx: MutationCtx,
   userId: string,
 ): Promise<UserPrefsWriteRateLimitResult> {
   const now = Date.now();
-  const windowStart = Math.floor(now / USER_PREFS_WRITE_RATE_WINDOW_MS) * USER_PREFS_WRITE_RATE_WINDOW_MS;
+  const windowStart = currentRateLimitWindowStart(now);
   const reset = windowStart + USER_PREFS_WRITE_RATE_WINDOW_MS;
   const currentRows = await ctx.db
     .query("userPreferenceWriteRateLimits")
@@ -136,16 +166,61 @@ async function checkUserPrefsWriteRateLimit(
     });
   }
 
-  const staleRows = await ctx.db
-    .query("userPreferenceWriteRateLimits")
-    .withIndex("by_user_window", (q) => q.eq("userId", userId))
-    .take(RATE_LIMIT_STALE_CLEANUP_LIMIT);
-  for (const row of staleRows) {
-    if (row.windowStart !== windowStart) await ctx.db.delete(row._id);
-  }
-
   return { ok: true };
 }
+
+/**
+ * Retention sweep for `userPreferenceWriteRateLimits` (#6706). The limiter used
+ * to garbage-collect expired windows inline on every write, which is what
+ * widened the write path's OCC read set and livelocked concurrent writers. The
+ * work itself still has to happen — the table gains a row per user per window
+ * they write in and has no native TTL — so it moved here, where nothing
+ * contends with it.
+ *
+ * The cutoff is the CURRENT window start and is not operator-overridable. A row
+ * at or above it is a live counter; deleting one would hand that user a fresh
+ * budget, so the only knob exposed is the batch size. Rows below it can never
+ * be read or incremented again — `checkUserPrefsWriteRateLimit` only ever scans
+ * `(userId, currentWindowStart)` — so they are safe to drop unconditionally.
+ */
+export const pruneStaleWriteRateLimits = internalMutation({
+  args: {
+    // Per-run delete cap. Optional so tests can drive the drain-over-multiple-
+    // runs behavior without seeding RATE_LIMIT_PRUNE_BATCH rows.
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    // Floor of 1, and a non-finite value falls back to the default rather than
+    // propagating: `take(0)` returns [], and the `>= batch` check below would
+    // read 0 >= 0 as "a full batch" and reschedule forever, deleting nothing.
+    const requestedBatch = args.limit;
+    const batch = Number.isFinite(requestedBatch)
+      ? Math.max(1, Math.floor(requestedBatch as number))
+      : RATE_LIMIT_PRUNE_BATCH;
+    const cutoff = currentRateLimitWindowStart(Date.now());
+
+    const stale = await ctx.db
+      .query("userPreferenceWriteRateLimits")
+      .withIndex("by_windowStart", (q) => q.lt("windowStart", cutoff))
+      .take(batch);
+    for (const row of stale) {
+      await ctx.db.delete(row._id);
+    }
+
+    // Self-drain: a full batch means more expired rows remain. Each pass
+    // deletes `batch` rows and the cutoff only ever moves forward, so the chain
+    // terminates. Without it a single hourly tick would cap at `batch` rows and
+    // a backlog larger than that could outpace the schedule indefinitely.
+    const rescheduled = stale.length >= batch;
+    if (rescheduled) {
+      await ctx.scheduler.runAfter(0, internal.userPreferences.pruneStaleWriteRateLimits, {
+        limit: batch,
+      });
+    }
+
+    return { deleted: stale.length, cutoff, rescheduled };
+  },
+});
 
 export const setPreferences = mutation({
   args: {


### PR DESCRIPTION
Closes #6706 (`WORLDMONITOR-ZE`).

## The bug

`checkUserPrefsWriteRateLimit` ended **every** preference write with a stale-window cleanup keyed on `userId` alone:

```ts
.withIndex("by_user_window", (q) => q.eq("userId", userId))   // no windowStart
```

Convex derives a mutation's OCC read set from the index ranges it scans, so that one unbounded query widened the read set from *the single current-window counter* to *the caller's entire row set across all windows*. A second concurrent write by the same user — two dashboard tabs, or a dragged slider persisting per change — invalidated it, and because the contending writes kept arriving, every retry collided too. Convex exhausted its automatic retries, so this was a **write that actually failed**, not one that was merely delayed.

## The fix

The sweep is opportunistic GC with no reader, so it moves off the user-facing path entirely — option 3 in the issue, the shape it calls durable.

- **`checkUserPrefsWriteRateLimit`** now only ever scans `(userId, currentWindowStart)`. Its read set is the one counter row it accounts against.
- **`pruneStaleWriteRateLimits`** (new `internalMutation`, hourly cron at :52) deletes rows below the current window start in bounded 500-row batches that self-drain. The cutoff is **derived, not operator-overridable**: a row at or above it is a live counter, and dropping one would hand that user a fresh budget — a limiter bypass, not early GC. The only knob exposed is batch size, with a floor of 1 so `limit: 0` cannot become an empty reschedule loop.
- **New `by_windowStart` index** so the sweep is a range scan whose read set is disjoint from every live counter row, instead of a full table scan that would collide with all of them.

Hourly rather than daily: a user writing continuously produces one row per 60s window, so an hourly tick bounds the table at ~60 rows per active user instead of ~1440.

## Acceptance criteria

| From the issue | Status |
|---|---|
| Write path's OCC read set no longer includes rows outside the current window | Enforced by test — see below |
| Regression test at the Convex layer | Added (read-set observation; `convex-test` has no OCC simulation, so a two-mutation race cannot be driven there — the read set itself is the observable that decides the conflict) |
| `WORLDMONITOR-ZE` quiet for a day after deploy | Post-deploy, tracked on the issue |

## Testing

`npm run test:convex` → `convex/__tests__/userPreferences.test.ts` 13/13, stable across 3 consecutive runs.

The regression test wraps the **real** `convex-test` `ctx.db` and records the index ranges the **real** limiter opens, delegating every read and write through to the real database — there is no second implementation of the limiter's storage, so it cannot pass for a reason production would not also produce. It asserts every range against `userPreferenceWriteRateLimits` is bounded to `(userId, currentWindowStart)`.

Proven RED on the pre-fix code before the fix landed:

```
AssertionError: expected [ [ 'eq', 'userId', …(1) ] ] to deeply equal [ [ 'eq', 'userId', …(1) ], …(1) ]
-   [ "eq", "windowStart", 1699999980000 ]
```

**Mutation-tested** — each of these mutants is killed:

| Mutant | Killed by |
|---|---|
| `lt` → `lte` on the prune cutoff | `collects expired windows and never the live counter`, `self-drains across runs` |
| Drop the batch floor (`Math.max(1, …)`) | `a zero or non-finite limit falls back instead of rescheduling forever` |
| `>=` → `>` on the self-drain condition | `self-drains across runs`, `a zero or non-finite limit…` |
| Restore the unbounded sweep | Both read-set tests (the original RED run) |

One existing test changed contract deliberately: `consolidates duplicate counter rows left by concurrent first writes` asserted the write path *deletes* an older-window row. It now asserts the current-window duplicates are still consolidated (count 4, not 103 — the expired window's 99 is neither folded in nor deleted) while the expired row survives until the prune collects it. That survival *is* the fix.

Other gates: `npm run typecheck` green, `npm run lint` green (`biome check` clean on all 4 changed files), `tests/convex-entrypoint-hygiene.test.mjs` 4/4.

Full-suite note: `companyMonitoringAccountLifecycle.test.ts > dense destructive purge continues across the bounded 93-company page` fails with a 5s timeout on this machine. Verified **pre-existing** — it fails identically on `origin/main` with all four of my files reverted. Not touched by this change.

## Deploy note

Adding `by_windowStart` triggers a Convex index backfill on this table. The table is small and the index is only read by the cron, so no user-facing path depends on the backfill completing. Rows accumulated before this deploy are cleared by the first tick's self-draining chain.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 5, 1M context)

https://claude.ai/code/session_01NotV3tBLmtYQrcswVY9Knn