### PR TITLE
fix(payments): honor X-RateLimit-Reset as the checkout ladder's provider floor

### DIFF
--- a/convex/__tests__/checkoutRateLimit.test.ts
+++ b/convex/__tests__/checkoutRateLimit.test.ts
@@ -70,6 +70,17 @@ function pinRetryClock() {
   return vi.spyOn(checkoutRetryClock, "sleep").mockResolvedValue(undefined);
 }
 
+/**
+ * Fixed wall clock for the absolute-timestamp header cases. Whole seconds, so
+ * an HTTP-date round-trip (which truncates to seconds) stays exact.
+ */
+const FIXED_NOW = 1_786_000_000_000;
+
+/** Pin only the clock, leaving sleep/jitter untouched. */
+function pinRetryClockNow() {
+  return vi.spyOn(checkoutRetryClock, "now").mockReturnValue(FIXED_NOW);
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   // restoreAllMocks does not reset module-factory vi.fn()s — clear queued
@@ -131,6 +142,94 @@ describe("checkout rate-limit classification", () => {
       retryAfterMsFromError(sdkRateLimitError({ "retry-after": "soon" })),
     ).toBeNull();
     expect(retryAfterMsFromError(new Error("no headers"))).toBeNull();
+  });
+
+  test("reads Retry-After in its RFC 9110 HTTP-date form", () => {
+    pinRetryClockNow();
+
+    expect(
+      retryAfterMsFromError(
+        sdkRateLimitError({
+          "retry-after": new Date(FIXED_NOW + 5_000).toUTCString(),
+        }),
+      ),
+    ).toBe(5_000);
+  });
+
+  /**
+   * Dodo advertises X-RateLimit-Reset on a limited response but does not
+   * publish its unit, and the header is genuinely ambiguous in the wild — this
+   * repo's own API emits it as epoch-MILLISECONDS
+   * (server/_shared/api-key-rate-limit.ts) while the IETF draft's
+   * RateLimit-Reset is delta-SECONDS. Reading an epoch as a delta would yield a
+   * ~57-year floor and silently disable the ladder's retries, so each encoding
+   * is pinned.
+   */
+  test("honors X-RateLimit-Reset across delta, epoch-seconds, and epoch-ms encodings", () => {
+    pinRetryClockNow();
+
+    // Delta-seconds (IETF RateLimit-Reset convention).
+    expect(
+      retryAfterMsFromError(sdkRateLimitError({ "x-ratelimit-reset": "30" })),
+    ).toBe(30_000);
+
+    // Epoch-seconds.
+    expect(
+      retryAfterMsFromError(
+        sdkRateLimitError({
+          "x-ratelimit-reset": String(FIXED_NOW / 1_000 + 30),
+        }),
+      ),
+    ).toBe(30_000);
+
+    // Epoch-milliseconds (this repo's own legacy convention).
+    expect(
+      retryAfterMsFromError(
+        sdkRateLimitError({ "x-ratelimit-reset": String(FIXED_NOW + 45_000) }),
+      ),
+    ).toBe(45_000);
+  });
+
+  test("clamps an already-elapsed X-RateLimit-Reset to zero rather than going negative", () => {
+    pinRetryClockNow();
+
+    // A reset in the past must not produce a negative floor, which would
+    // subtract from the jittered ladder wait.
+    expect(
+      retryAfterMsFromError(
+        sdkRateLimitError({ "x-ratelimit-reset": String(FIXED_NOW - 60_000) }),
+      ),
+    ).toBe(0);
+  });
+
+  test("prefers an explicit Retry-After over the weaker X-RateLimit-Reset window hint", () => {
+    pinRetryClockNow();
+
+    expect(
+      retryAfterMsFromError(
+        sdkRateLimitError({
+          "retry-after-ms": "1500",
+          "retry-after": "3",
+          "x-ratelimit-reset": "30",
+        }),
+      ),
+    ).toBe(1_500);
+    expect(
+      retryAfterMsFromError(
+        sdkRateLimitError({ "retry-after": "3", "x-ratelimit-reset": "30" }),
+      ),
+    ).toBe(3_000);
+  });
+
+  test("ignores an unparseable or negative X-RateLimit-Reset", () => {
+    pinRetryClockNow();
+
+    expect(
+      retryAfterMsFromError(sdkRateLimitError({ "x-ratelimit-reset": "soon" })),
+    ).toBeNull();
+    expect(
+      retryAfterMsFromError(sdkRateLimitError({ "x-ratelimit-reset": "-5" })),
+    ).toBeNull();
   });
 });
 

--- a/convex/__tests__/checkoutRateLimit.test.ts
+++ b/convex/__tests__/checkoutRateLimit.test.ts
@@ -157,6 +157,28 @@ describe("checkout rate-limit classification", () => {
   });
 
   /**
+   * A numeric Retry-After must never reach the HTTP-date branch. V8 parses
+   * "-5" as a real date (May 2001), so falling through would launder a
+   * negative delta into a stale timestamp and clamp it to 0 — reporting "wait
+   * zero" where the header was simply invalid and no floor was advertised.
+   * Every RFC 9110 date form starts with a day name, so no valid date is lost.
+   */
+  test("rejects a negative numeric Retry-After instead of reading it as a date", () => {
+    pinRetryClockNow();
+
+    expect(
+      retryAfterMsFromError(sdkRateLimitError({ "retry-after": "-5" })),
+    ).toBeNull();
+    expect(
+      retryAfterMsFromError(sdkRateLimitError({ "retry-after": "-0.5" })),
+    ).toBeNull();
+    // A zero delta is advertised, not invalid — it stays 0, not null.
+    expect(
+      retryAfterMsFromError(sdkRateLimitError({ "retry-after": "0" })),
+    ).toBe(0);
+  });
+
+  /**
    * Dodo advertises X-RateLimit-Reset on a limited response but does not
    * publish its unit, and the header is genuinely ambiguous in the wild — this
    * repo's own API emits it as epoch-MILLISECONDS

--- a/convex/payments/checkoutRateLimit.ts
+++ b/convex/payments/checkoutRateLimit.ts
@@ -33,10 +33,66 @@ export function checkoutRateLimitedOutcomeFromError(
 }
 
 /**
+ * A bare X-RateLimit-Reset number is read as delta-seconds below this and as an
+ * absolute epoch at or above it. Nothing separates the two encodings but
+ * magnitude: a delta this large is ~31 years (never a real wait), while an
+ * epoch in seconds has exceeded 1e9 since 2001.
+ */
+const RATE_LIMIT_RESET_DELTA_CEILING = 1e9;
+
+/**
+ * An absolute reset at or above this is already in milliseconds. Epoch-seconds
+ * stays below 1e12 until the year 33658, and epoch-ms has exceeded it since
+ * 2001, so the two cannot collide in any plausible present.
+ */
+const RATE_LIMIT_RESET_EPOCH_SECONDS_CEILING = 1e12;
+
+/**
+ * Parse Retry-After per RFC 9110: either delta-seconds or an HTTP-date. The
+ * date form is resolved against the clock seam, so a date already in the past
+ * yields 0 rather than a negative floor.
+ */
+function retryAfterHeaderToMs(raw: string | null): number | null {
+  if (raw === null) return null;
+  const seconds = Number.parseFloat(raw);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const resetAtMs = Date.parse(raw);
+  if (!Number.isFinite(resetAtMs)) return null;
+  return Math.max(0, resetAtMs - checkoutRetryClock.now());
+}
+
+/**
+ * Parse X-RateLimit-Reset, which Dodo advertises on a limited response without
+ * publishing its unit. The header is genuinely ambiguous in the wild — the IETF
+ * draft's RateLimit-Reset is delta-seconds, while this repo's own API emits
+ * X-RateLimit-Reset as epoch-milliseconds (server/_shared/api-key-rate-limit.ts)
+ * — so all three encodings are accepted and disambiguated by magnitude. Reading
+ * an epoch as a delta would produce a decades-long floor that silently disables
+ * the ladder's retries, which is the failure this guards against.
+ */
+function rateLimitResetHeaderToMs(raw: string | null): number | null {
+  if (raw === null) return null;
+  const value = Number.parseFloat(raw);
+  if (!Number.isFinite(value) || value < 0) return null;
+  if (value < RATE_LIMIT_RESET_DELTA_CEILING) return value * 1000;
+  const resetAtMs =
+    value < RATE_LIMIT_RESET_EPOCH_SECONDS_CEILING ? value * 1000 : value;
+  return Math.max(0, resetAtMs - checkoutRetryClock.now());
+}
+
+/**
  * Extract the provider's advertised wait from a typed SDK error, when present.
- * Returns milliseconds, or null when no parseable Retry-After is advertised.
- * Callers must cap it — a verbatim honor can be minutes (see billing.ts
- * renewal reconciliation, which pins maxRetries: 0 for the same reason).
+ * Returns milliseconds, or null when nothing parseable is advertised.
+ *
+ * Precedence runs strongest-signal first: Retry-After is an explicit "wait this
+ * long" directive, while X-RateLimit-Reset only says when the window rolls over
+ * — so the latter is a fallback, never an override.
+ *
+ * Callers must cap the result — a verbatim honor can be minutes (see billing.ts
+ * renewal reconciliation, which pins maxRetries: 0 for the same reason). The
+ * ladder does this by admitting a retry only when the wait fits its budget, so
+ * a reset further out than the budget correctly ends the ladder instead of
+ * spending attempts the provider has already said will fail.
  */
 export function retryAfterMsFromError(error: unknown): number | null {
   const headers = (error as { headers?: unknown } | null)?.headers;
@@ -50,9 +106,9 @@ export function retryAfterMsFromError(error: unknown): number | null {
   const get = (name: string) => (headers as Headers).get(name);
   const ms = Number.parseFloat(get("retry-after-ms") ?? "");
   if (Number.isFinite(ms) && ms >= 0) return ms;
-  const seconds = Number.parseFloat(get("retry-after") ?? "");
-  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
-  return null;
+  const retryAfterMs = retryAfterHeaderToMs(get("retry-after"));
+  if (retryAfterMs !== null) return retryAfterMs;
+  return rateLimitResetHeaderToMs(get("x-ratelimit-reset"));
 }
 
 /**

--- a/convex/payments/checkoutRateLimit.ts
+++ b/convex/payments/checkoutRateLimit.ts
@@ -55,7 +55,12 @@ const RATE_LIMIT_RESET_EPOCH_SECONDS_CEILING = 1e12;
 function retryAfterHeaderToMs(raw: string | null): number | null {
   if (raw === null) return null;
   const seconds = Number.parseFloat(raw);
-  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  // Anything that parses as a number is delta-seconds and is decided here.
+  // Falling through to Date.parse would launder an invalid negative delta into
+  // a stale date — V8 reads "-5" as May 2001 — which then clamps to 0 and
+  // reports "wait zero" where nothing was validly advertised. Every RFC 9110
+  // date form begins with a day name, so no real date is numeric-leading.
+  if (Number.isFinite(seconds)) return seconds >= 0 ? seconds * 1000 : null;
   const resetAtMs = Date.parse(raw);
   if (!Number.isFinite(resetAtMs)) return null;
   return Math.max(0, resetAtMs - checkoutRetryClock.now());

--- a/docs/payments-checkout-rate-limit-operations.md
+++ b/docs/payments-checkout-rate-limit-operations.md
@@ -151,6 +151,12 @@ headers, strongest signal first:
 `Retry-After` wins over `X-RateLimit-Reset` deliberately: the first is a
 directive to wait, the second only reports when the window resets.
 
+A numeric `Retry-After` is always read as delta-seconds and never retried as a
+date — a negative value is rejected outright rather than falling through to the
+date branch, where V8 would read `-5` as May 2001 and clamp it to "wait zero".
+No real HTTP-date is lost to this: all three RFC 9110 date forms begin with a
+day name.
+
 Originally the ladder read only the two `Retry-After` forms. Dodo's API
 reference documents neither on a 429 — it documents `X-RateLimit-Reset` — so if
 Dodo does not also send `Retry-After`, the "honor the advertised provider floor"

--- a/docs/payments-checkout-rate-limit-operations.md
+++ b/docs/payments-checkout-rate-limit-operations.md
@@ -137,16 +137,52 @@ other holders of the same key:
 That is arithmetic plus a hypothesis, not a measured cause. The alarm exists to
 supply the correlation data needed to confirm or kill it.
 
-### Known gap in the ladder's provider floor
+### The ladder's provider floor
 
-`retryAfterMsFromError` in `convex/payments/checkoutRateLimit.ts` reads only
-`retry-after-ms` and `retry-after`. Dodo's API reference documents neither on a
-429 — it documents `X-RateLimit-Reset`. If Dodo does not also send
-`Retry-After`, the ladder's "honor the advertised provider floor" branch never
-engages in production and every wait is pure jitter. This has not been verified
-against a live 429 response's headers. Capturing those headers on the next
-alarm firing is the cheapest way to settle it; teaching the ladder to read
-`X-RateLimit-Reset` is the fix if it is confirmed.
+`retryAfterMsFromError` in `convex/payments/checkoutRateLimit.ts` reads three
+headers, strongest signal first:
+
+| Header | Meaning | Unit |
+| --- | --- | --- |
+| `retry-after-ms` | Explicit wait | Milliseconds |
+| `retry-after` | Explicit wait (RFC 9110) | Delta-seconds **or** an HTTP-date |
+| `x-ratelimit-reset` | When the window rolls over | Inferred — see below |
+
+`Retry-After` wins over `X-RateLimit-Reset` deliberately: the first is a
+directive to wait, the second only reports when the window resets.
+
+Originally the ladder read only the two `Retry-After` forms. Dodo's API
+reference documents neither on a 429 — it documents `X-RateLimit-Reset` — so if
+Dodo does not also send `Retry-After`, the "honor the advertised provider floor"
+branch never engaged and every wait was pure jitter. The ladder now reads
+`X-RateLimit-Reset` as well.
+
+**Its unit is inferred by magnitude, because Dodo does not publish one.** The
+header is genuinely ambiguous across the industry: the IETF draft's
+`RateLimit-Reset` is delta-seconds, while this repo's own API emits
+`X-RateLimit-Reset` as epoch-milliseconds (`server/_shared/api-key-rate-limit.ts`).
+All three encodings are accepted:
+
+- below `1e9` — delta-seconds (a delta that large would be ~31 years)
+- `1e9` to `1e12` — epoch-seconds (an epoch in seconds passed `1e9` in 2001)
+- `1e12` and above — epoch-milliseconds
+
+A reset already in the past clamps to `0`, so it can never subtract from the
+jittered wait. Each encoding is pinned by a test, and the sweep confirms an
+epoch misread as a delta is caught — that defect would produce a decades-long
+floor and silently disable every retry.
+
+**Two things are still unmeasured, and the alarm is what will settle them:**
+
+1. Which encoding Dodo actually sends. The magnitude rules cover all three, so
+   this is safe rather than settled.
+2. Whether the reset describes the **burst** (40/s) or the **sustained**
+   (240/min) window. This matters: if Dodo reports a sustained reset up to 60s
+   out while the real block is a per-second burst that clears immediately,
+   honoring it as a hard floor ends the ladder early and turns a checkout the
+   ladder would have rescued into a terminal 429. Watch for the alarm rate
+   rising after this change ships — that is the signature, and the fix would be
+   to cap the reset-derived floor rather than to stop reading the header.
 
 ## Related
 


### PR DESCRIPTION
## Summary

#6701 shipped the alarm that watches the tail of #6027's checkout retry ladder, and recorded a P2 residual: the ladder's "honor the advertised provider floor" branch was probably never running in production. It read only `retry-after-ms` and `retry-after`, and Dodo's API reference documents **neither** on a 429 — it documents `X-RateLimit-Reset`. So every ladder wait was pure jitter, and a buyer's retry could re-enter a window the provider had already said was closed.

The ladder now reads `X-RateLimit-Reset`, ranked behind both `Retry-After` forms. That order is deliberate: `Retry-After` is a directive to wait, while `X-RateLimit-Reset` only reports when the window rolls over — a weaker signal that should never override an explicit one.

Also fixes the RFC 9110 HTTP-date form of `Retry-After`, which previously fell through `parseFloat` to `NaN` and advertised no floor at all.

### Why the unit is inferred, not assumed

Dodo does not publish the header's unit, and `X-RateLimit-Reset` is genuinely ambiguous in the wild — **this repo's own API emits it as epoch-milliseconds** (`server/_shared/api-key-rate-limit.ts:240`), while the IETF draft's `RateLimit-Reset` is delta-seconds. Picking one and being wrong is not a small error:

| Value range | Read as | Rationale |
| --- | --- | --- |
| `< 1e9` | delta-seconds | A delta that large would be ~31 years |
| `1e9` to `1e12` | epoch-seconds | Epoch-seconds passed `1e9` in 2001, stays under `1e12` until year 33658 |
| `>= 1e12` | epoch-milliseconds | Epoch-ms passed `1e12` in 2001 |

These ranges cannot collide in any plausible present. Reading an epoch as a delta would have produced a **~57-year floor that silently disabled every retry** — the ladder would have looked healthy while never retrying once. A reset already in the past clamps to `0` so it can never subtract from the jittered wait.

### The risk worth watching after deploy

Whether Dodo's reset describes the **burst** (40/s) or **sustained** (240/min) window is still unmeasured. If it reports a sustained reset up to 60s out while the real block is a per-second burst that clears immediately, honoring it as a hard floor ends the ladder early and converts a checkout the ladder *would* have rescued into a terminal 429. The #6701 alarm is exactly the instrument that detects this — see Post-Deploy Monitoring. The fix in that case is to cap the reset-derived floor, not to stop reading the header.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Convex payments/checkout retry ladder

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

N/A for the Audit Council items — this publishes no public documentation claim. The only doc touched is `docs/payments-checkout-rate-limit-operations.md`, the internal ops runbook #6701 added, which stays in `docs/.mintignore` because it names our provider tier and counts failed purchases. Its "Known gap in the ladder's provider floor" section is replaced by the shipped precedence table plus the two things still unmeasured.

## Test plan

Bug-fix protocol followed both times — the test was pinned red before the code changed.

- 6 new cases in `convex/__tests__/checkoutRateLimit.test.ts`: each of the three encodings, an already-elapsed reset clamping to `0`, header precedence, the HTTP-date form, and unparseable/negative rejection.
- **Mutation sweep: 9/9 mutants killed, 0 survivors** — including epoch-read-as-delta, a widened delta ceiling, inverted precedence, a dropped clamp, and the negative fall-through. Reverted by file copy; tree verified clean afterwards.
- Wired to the **real** production error shape, not just a fixture: the SDK's 429 is `RateLimitError extends APIError<429, Headers>`, so `.headers.get()` is a genuine `Headers` instance on the live path.
- Full convex suite **1241/1241 across 57 files**, `npx tsc --noEmit`, biome, markdownlint, `lint:public-docs`, `docs:check` — all clean.

**Test-run caveat for reviewers:** the convex suite needs `--maxWorkers=2` in a worktree. At the default worker count it over-subscribes and reports ~17 unrelated timeout failures in `companyMonitoring*` and `poolSelection`; those files pass in isolation and do not import this module.

## Related

- Related: #6698 (this is the P2 residual its step 3 deferred, not the issue itself — #6698 is already closed by #6701)
- Builds on #6027 (the bounded ladder) and #6701 (the alarm)

## Known Residuals

- **P3.** Which encoding Dodo actually sends is still unobserved. The magnitude rules cover all three, so this is *safe* rather than *settled* — capturing a live 429's headers would settle it.
- **P3.** The account's real Dodo tier is unconfirmed; the runbook assumes Tier 0. That is a support request, and remains #6698's step 2.
- The second commit fixes a defect the first one introduced: adding the HTTP-date branch let a negative `Retry-After` fall through to `Date.parse`, which is **not** inert — V8 reads `"-5"` as May 2001, clamping to `0` and reporting "wait zero" where nothing valid was advertised. Inert in the ladder today (`?? 0` collapses both), but a trap for any caller that distinguishes "no floor" from "zero floor". Kept as a separate commit so the defect and its fix stay legible.

## Post-Deploy Monitoring & Validation

- **Window:** from Convex deploy through the first two weeks. Owner: merger.
- **Healthy signal:** the `checkoutRateLimitEvents` rate stays at or below its historical ~0.5/day with no `[checkout-rate-limit-alarm]` Sentry event.
- **Failure signal:** the alarm rate *rises* after this deploys. That is the burst-vs-sustained hypothesis above confirming itself — the reset is being honored as a floor longer than the real block lasts. Remedy is to cap the reset-derived floor to the ladder budget, not to revert to jitter-only.
- **Rollback:** revert this PR. It touches only header parsing; the ladder's structure, budget, and the buyer-facing 429 path are untouched.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
