### PR TITLE
fix(railway): bound deploy drift reads

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -578,6 +578,16 @@ configuration, or classify deployments.
 node scripts/check-railway-deploy-drift.mjs        # add --json for the machine-readable form
 ```
 
+The deployment check does not rediscover the live image by scanning through
+days of skipped pushes. The same Viewer-safe service projection supplies each
+service's `activeDeployments` as the running baseline. A fleet-wide deployment
+stream then reads only far enough to cross the frozen comparison commit's
+timestamp, which preserves newer `SKIPPED`, `FAILED`, and in-flight evidence.
+Only a service with no active running source, or one whose source changes while
+the two read-only snapshots are taken, falls back to a direct history read. If
+the recent stream cannot cross the comparison timestamp, the check still fails
+closed; it does not turn a capped or rate-limited read into health.
+
 The watch-path filter is one way a merge fails to reach production; a GitHub
 integration that stopped delivering (#6064) and a build that failed after the
 merge landed are others. This check is deliberately agnostic about which. For

--- a/scripts/check-railway-deploy-drift.mjs
+++ b/scripts/check-railway-deploy-drift.mjs
@@ -829,8 +829,15 @@ async function main() {
     projectId,
     environmentId,
     concurrency,
+    includeActiveDeployments: true,
     deadlineAt: deepPassDeadlineAt,
   })).services;
+  const initialDeploymentsByService = new Map(
+    Object.entries(liveById).map(([serviceId, config]) => [
+      serviceId,
+      config.activeDeployments,
+    ]),
+  );
   const changedPathsSince = createChangedPathsReader(headSha, { git: runGit });
   const changedPathsIn = createCommitPathsReader({ git: runGit });
 
@@ -850,7 +857,10 @@ async function main() {
     window,
     concurrency,
     notBefore: headCommittedAt,
-    accumulatorFactory: createFleetAccumulator,
+    accumulatorFactory: (args) => createFleetAccumulator({
+      ...args,
+      initialDeploymentsByService,
+    }),
     onRoute: (route) => {
       // stderr, not stdout: --json must remain one parseable document, and a
       // human progress line in front of it breaks every machine consumer.

--- a/scripts/railway-cli.mjs
+++ b/scripts/railway-cli.mjs
@@ -16,6 +16,8 @@ import { readFileSync } from 'node:fs';
 import { performance } from 'node:perf_hooks';
 import { promisify } from 'node:util';
 
+import { limitDeploymentHistory } from './railway-deployments.mjs';
+
 const execFileAsync = promisify(execFile);
 
 export const REPOSITORY = 'koala73/worldmonitor';
@@ -528,10 +530,14 @@ export async function readFleetDeployments({
   deadlineAt = Number.POSITIVE_INFINITY,
   monotonicNow = Date.now,
 }) {
-  const accumulator = accumulatorFactory({ serviceIds, notBefore });
+  const accumulator = accumulatorFactory({
+    serviceIds,
+    notBefore,
+  });
   let after = null;
   let pages = 0;
   let records = 0;
+  const seenCursors = new Set();
   while (pages < maxPages) {
     if (monotonicNow() >= deadlineAt) {
       throw new Error(DEPLOYMENT_READ_DEADLINE_ERROR);
@@ -542,16 +548,36 @@ export async function readFleetDeployments({
       ...(after ? { after } : {}),
     });
     const connection = data?.deployments;
-    if (!connection?.edges) throw new Error('railway api returned no deployments connection');
+    if (!Array.isArray(connection?.edges)) {
+      throw new Error('railway api returned no deployments connection');
+    }
+    if (typeof connection.pageInfo?.hasNextPage !== 'boolean') {
+      throw new Error('railway deployments pageInfo.hasNextPage must be a boolean');
+    }
+    const nextCursor = connection.pageInfo.endCursor;
+    if (connection.pageInfo.hasNextPage
+      && (typeof nextCursor !== 'string' || nextCursor.length === 0 || seenCursors.has(nextCursor))) {
+      throw new Error('railway deployments cursor did not advance');
+    }
+    const nodes = connection.edges.map((edge, index) => {
+      if (!edge?.node || typeof edge.node !== 'object' || Array.isArray(edge.node)
+        || typeof edge.node.id !== 'string' || edge.node.id.length === 0
+        || typeof edge.node.status !== 'string' || edge.node.status.length === 0
+        || typeof edge.node.serviceId !== 'string' || edge.node.serviceId.length === 0) {
+        throw new Error(`railway deployment edge ${index} is malformed`);
+      }
+      return edge.node;
+    });
     pages += 1;
     records += connection.edges.length;
-    accumulator.absorb(connection.edges.map((edge) => edge?.node).filter(Boolean));
-    if (!connection.pageInfo?.hasNextPage) {
+    accumulator.absorb(nodes);
+    if (!connection.pageInfo.hasNextPage) {
       accumulator.markExhausted();
       break;
     }
     if (accumulator.done) break;
-    after = connection.pageInfo.endCursor;
+    seenCursors.add(nextCursor);
+    after = nextCursor;
   }
   const result = accumulator.result();
   const complete = accumulator.done;
@@ -591,6 +617,7 @@ export async function readDeploymentsForFleet({
   onRoute = () => {},
   deadlineAt = Number.POSITIVE_INFINITY,
   monotonicNow = Date.now,
+  readFleet = readFleetDeployments,
   readDirect = readDeployments,
 }) {
   const byId = new Map(services.map((service) => [service.id, service]));
@@ -601,7 +628,7 @@ export async function readDeploymentsForFleet({
     onRoute({ route: 'per-service', reason: DEPLOYMENT_READ_DEADLINE_ERROR });
   } else if (projectId && environmentId && accumulatorFactory) {
     try {
-      const fleet = await readFleetDeployments({
+      const fleet = await readFleet({
         projectId,
         environmentId,
         serviceIds: [...byId.keys()],
@@ -624,7 +651,10 @@ export async function readDeploymentsForFleet({
           // returned `window`. Leaving them in silently changes what the
           // classifier sees — and every extra SKIPPED record costs a `git show`,
           // which is what actually dominates a sweep's wall clock.
-          results.set(serviceId, { deployments: deployments.slice(0, window), error: null });
+          results.set(serviceId, {
+            deployments: limitDeploymentHistory(deployments, window),
+            error: null,
+          });
         }
       }
       needDirect = fleet.unresolved.map((serviceId) => byId.get(serviceId)).filter(Boolean);

--- a/scripts/railway-deployments.mjs
+++ b/scripts/railway-deployments.mjs
@@ -36,6 +36,15 @@ export const IN_FLIGHT_STATUSES = Object.freeze([
 // even though this record carries the newest commit SHA.
 export const FAILED_STATUSES = Object.freeze(['FAILED']);
 
+const VIEWER_ACTIVE_DEPLOYMENTS = new WeakSet();
+const RFC3339_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+export function isValidDeploymentTimestamp(value) {
+  return typeof value === 'string'
+    && RFC3339_TIMESTAMP.test(value)
+    && Number.isFinite(Date.parse(value));
+}
+
 export function isKnownStatus(status) {
   return status === REJECTED_STATUS
     || RUNNING_STATUSES.includes(status)
@@ -67,7 +76,27 @@ export function orderByRecency(deployments) {
 
 /** The newest record that actually reached a running state, or undefined. */
 export function newestRunning(orderedDeployments) {
-  return orderedDeployments.find((deployment) => RUNNING_STATUSES.includes(deployment?.status));
+  return orderedDeployments.find((deployment) => (
+    VIEWER_ACTIVE_DEPLOYMENTS.has(deployment)
+    && RUNNING_STATUSES.includes(deployment?.status)
+  )) ?? orderedDeployments.find((deployment) => RUNNING_STATUSES.includes(deployment?.status));
+}
+
+/**
+ * Keep the requested recent-event window plus an older running baseline.
+ *
+ * A busy service can have `window` newer SKIPPED records. Dropping the next
+ * record in that case also drops the Viewer-provided answer to "what is
+ * running", so retain at most that one extra record.
+ */
+export function limitDeploymentHistory(orderedDeployments, window) {
+  const limited = orderedDeployments.slice(0, window);
+  const activeRunning = orderedDeployments.find((deployment) => (
+    VIEWER_ACTIVE_DEPLOYMENTS.has(deployment)
+    && RUNNING_STATUSES.includes(deployment?.status)
+  ));
+  if (activeRunning && !limited.includes(activeRunning)) limited.push(activeRunning);
+  return limited;
 }
 
 /**
@@ -85,38 +114,139 @@ export function newestRunning(orderedDeployments) {
  *      only exist at or after head's commit time, so once the stream is older
  *      than that, no later page can hold one.
  *
- * A service still missing a RUNNING record when paging stops is `unresolved` —
- * NOT "a service with no deployments". Conflating those would let an exhausted
- * page budget fabricate NEVER_DEPLOYED for a healthy service, which is the same
- * fail-open shape as every other bug in this file's history. The caller falls
- * back to a direct per-service read for those.
+ * The Viewer-safe service projection seeds each service's active deployments,
+ * so the fleet stream only has to cross the comparison-head timestamp. That
+ * captures every recent SKIPPED/FAILED/in-flight event without paging through
+ * days of skip noise to rediscover the image Railway already identifies as
+ * active. A service still missing a RUNNING record at that boundary is
+ * `unresolved` — NOT "a service with no deployments" — and only that service
+ * falls back to a direct history read.
  */
-export function createFleetAccumulator({ serviceIds, notBefore = Number.NEGATIVE_INFINITY }) {
+export function createFleetAccumulator({
+  serviceIds,
+  notBefore = Number.NEGATIVE_INFINITY,
+  initialDeploymentsByService = new Map(),
+}) {
+  if (!(initialDeploymentsByService instanceof Map)) {
+    throw new TypeError('initial Railway deployments must be a Map keyed by service id');
+  }
   const wanted = new Set(serviceIds);
   const byService = new Map(wanted.size > 0 ? [...wanted].map((id) => [id, []]) : []);
   const covered = new Set();
+  const seenIds = new Map([...wanted].map((id) => [id, new Map()]));
+  const activeEvidenceServices = new Set();
+  const newestActiveAt = new Map();
+  const staleActiveEvidence = new Set();
   let oldestSeen = Number.POSITIVE_INFINITY;
   let exhausted = false;
+
+  const refreshCoverage = (serviceId) => {
+    const deployments = byService.get(serviceId);
+    const hasRunning = activeEvidenceServices.has(serviceId)
+      ? !staleActiveEvidence.has(serviceId) && deployments.some((deployment) => (
+        VIEWER_ACTIVE_DEPLOYMENTS.has(deployment)
+        && RUNNING_STATUSES.includes(deployment?.status)
+      ))
+      : deployments.some((deployment) => RUNNING_STATUSES.includes(deployment?.status));
+    if (hasRunning) covered.add(serviceId);
+    else covered.delete(serviceId);
+  };
+
+  const absorbDeployment = (node, { active = false } = {}) => {
+    const id = node?.serviceId;
+    if (!wanted.has(id)) return;
+    const deployments = byService.get(id);
+    const seen = seenIds.get(id);
+    if (!active
+      && !seen.has(node?.id)
+      && activeEvidenceServices.has(id)
+      && node?.status !== 'REMOVED'
+      && RUNNING_STATUSES.includes(node?.status)
+      && createdAtMs(node) >= (newestActiveAt.get(id) ?? Number.POSITIVE_INFINITY)) {
+      // A distinct deployable record newer than the earlier Viewer snapshot
+      // can be a manual upload or rollback that became active mid-scan. The
+      // old active marker is no longer proof; force a fresh direct read unless
+      // this fleet stream exhausts and therefore contains the full history.
+      staleActiveEvidence.add(id);
+      for (const deployment of deployments) VIEWER_ACTIVE_DEPLOYMENTS.delete(deployment);
+      refreshCoverage(id);
+    }
+    if (typeof node?.id === 'string' && node.id.length > 0) {
+      const existing = seen.get(node.id);
+      if (existing) {
+        // The active projection is read first. The later fleet stream can
+        // carry the same deployment after BUILDING became FAILED/SUCCESS, so
+        // replace only that older snapshot. Repeated fleet records stay
+        // newest-first and the first one wins.
+        if (!active && existing.active) {
+          const preserveActive = !staleActiveEvidence.has(id)
+            && deployments[existing.index]?.status === node?.status;
+          if (preserveActive) VIEWER_ACTIVE_DEPLOYMENTS.add(node);
+          deployments[existing.index] = node;
+          seen.set(node.id, { index: existing.index, active: preserveActive });
+          refreshCoverage(id);
+        }
+        return;
+      }
+      seen.set(node.id, { index: deployments.length, active });
+    }
+    if (active) VIEWER_ACTIVE_DEPLOYMENTS.add(node);
+    deployments.push(node);
+    refreshCoverage(id);
+  };
+
+  for (const [serviceId, deployments] of initialDeploymentsByService) {
+    if (!wanted.has(serviceId)) continue;
+    if (!Array.isArray(deployments)) {
+      throw new TypeError(`initial Railway deployments for ${serviceId} must be an array`);
+    }
+    activeEvidenceServices.add(serviceId);
+    for (const deployment of deployments) {
+      if (deployment?.serviceId !== serviceId) {
+        throw new Error(`initial Railway deployment belongs to another service while reading ${serviceId}`);
+      }
+      if (!isValidDeploymentTimestamp(deployment.createdAt)) {
+        throw new Error(`initial Railway deployment for ${serviceId} must have a valid createdAt timestamp`);
+      }
+      newestActiveAt.set(
+        serviceId,
+        Math.max(newestActiveAt.get(serviceId) ?? Number.NEGATIVE_INFINITY, Date.parse(deployment.createdAt)),
+      );
+      // Active deployment evidence answers what is serving, but it must not
+      // advance the recent-event cursor. The fleet stream still has to cross
+      // the comparison-head timestamp so a skipped or failed push cannot hide
+      // behind an older active image.
+      absorbDeployment(deployment, { active: true });
+    }
+  }
 
   return {
     absorb(nodes) {
       for (const node of nodes ?? []) {
-        const at = createdAtMs(node);
+        if (!isValidDeploymentTimestamp(node?.createdAt)) {
+          throw new Error('Railway fleet deployment must have a valid createdAt timestamp');
+        }
+        const at = Date.parse(node.createdAt);
         if (at < oldestSeen) oldestSeen = at;
-        const id = node?.serviceId;
-        if (!wanted.has(id)) continue;
-        byService.get(id).push(node);
-        if (RUNNING_STATUSES.includes(node?.status)) covered.add(id);
+        absorbDeployment(node);
       }
     },
     markExhausted() { exhausted = true; },
-    /** Every service located AND the stream is older than head — or there is no more stream. */
+    /** Recent head events are complete, or Railway proved there is no more stream. */
     get done() {
-      return exhausted || (covered.size === wanted.size && oldestSeen < notBefore);
+      return exhausted || (
+        oldestSeen < notBefore
+        && (activeEvidenceServices.size > 0 || covered.size === wanted.size)
+      );
     },
     result() {
       return {
-        byService,
+        byService: new Map(
+          [...byService].map(([serviceId, deployments]) => [
+            serviceId,
+            orderByRecency(deployments),
+          ]),
+        ),
         // Exhausting the stream proves a service genuinely has no running
         // deployment; running out of budget proves nothing.
         unresolved: exhausted ? [] : [...wanted].filter((id) => !covered.has(id)),

--- a/scripts/railway-viewer-deployment-config.mjs
+++ b/scripts/railway-viewer-deployment-config.mjs
@@ -9,6 +9,7 @@ import {
   resolveEnvironmentId,
   runRailwayApiAsync,
 } from './railway-cli.mjs';
+import { isValidDeploymentTimestamp } from './railway-deployments.mjs';
 
 export const DEPLOYMENT_CONFIG_READ_DEADLINE_ERROR = 'run deadline reached before deployment configuration read';
 
@@ -19,10 +20,14 @@ export const DEPLOYMENT_ONLY_QUERY = `query ViewerDeploymentConfig(
   $projectId: String!
   $environmentId: String!
   $serviceId: String!
+  $includeActiveDeployments: Boolean!
 ) {
   serviceInstance(environmentId: $environmentId, serviceId: $serviceId) {
     serviceId
     source { repo image }
+    activeDeployments @include(if: $includeActiveDeployments) {
+      id status createdAt serviceId meta
+    }
     rootDirectory
     watchPatterns
     dockerfilePath
@@ -60,7 +65,34 @@ function triggerNodes(connection) {
   });
 }
 
-export function projectViewerDeploymentConfig({ service, instance, triggers }) {
+function activeDeploymentNodes(instance, service) {
+  if (!Array.isArray(instance.activeDeployments)) {
+    throw new Error(`Railway active deployments must be an array for ${service.name}`);
+  }
+  return instance.activeDeployments.map((deployment, index) => {
+    if (!deployment || typeof deployment !== 'object' || Array.isArray(deployment)
+      || typeof deployment.id !== 'string' || deployment.id.length === 0
+      || typeof deployment.status !== 'string' || deployment.status.length === 0
+      || !isValidDeploymentTimestamp(deployment.createdAt)) {
+      throw new Error(`Railway active deployment ${index} is malformed for ${service.name}`);
+    }
+    if (deployment.serviceId !== service.id) {
+      throw new Error(`Railway active deployment ${deployment.id} belongs to another service while reading ${service.name}`);
+    }
+    if (deployment.meta != null
+      && (typeof deployment.meta !== 'object' || Array.isArray(deployment.meta))) {
+      throw new Error(`Railway active deployment ${deployment.id} has malformed metadata for ${service.name}`);
+    }
+    return deployment;
+  });
+}
+
+export function projectViewerDeploymentConfig({
+  service,
+  instance,
+  triggers,
+  includeActiveDeployments = false,
+}) {
   if (!service?.id || !instance || typeof instance !== 'object' || Array.isArray(instance)) {
     throw new Error(`Railway returned no serviceInstance projection for ${service?.name ?? service?.id ?? 'unknown service'}`);
   }
@@ -102,6 +134,9 @@ export function projectViewerDeploymentConfig({ service, instance, triggers }) {
       startCommand: instance.startCommand ?? null,
       cronSchedule: instance.cronSchedule ?? null,
     },
+    ...(includeActiveDeployments
+      ? { activeDeployments: activeDeploymentNodes(instance, service) }
+      : {}),
   };
 }
 
@@ -114,6 +149,7 @@ export async function readViewerDeploymentConfig(
     resolveEnvironment = resolveEnvironmentId,
     api = runRailwayApiAsync,
     concurrency = DEFAULT_CONCURRENCY,
+    includeActiveDeployments = false,
     deadlineAt = Number.POSITIVE_INFINITY,
     monotonicNow = () => performance.now(),
   } = {},
@@ -150,6 +186,7 @@ export async function readViewerDeploymentConfig(
       projectId,
       environmentId: resolvedEnvironmentId,
       serviceId: service.id,
+      includeActiveDeployments,
     }, {
       timeoutMs: Math.min(RAILWAY_CALL_TIMEOUT_MS, Math.max(1, Math.floor(remainingMs))),
     });
@@ -160,6 +197,7 @@ export async function readViewerDeploymentConfig(
       service,
       instance: data?.serviceInstance,
       triggers: data?.deploymentTriggers,
+      includeActiveDeployments,
     })];
   });
   return { services: Object.fromEntries(projected) };

--- a/tests/railway-deploy-drift-workflow.test.mjs
+++ b/tests/railway-deploy-drift-workflow.test.mjs
@@ -75,6 +75,7 @@ function fakeRailwayCli({ repoRoot: fixtureRoot, headSha, previousSha }) {
     return {
       serviceId: service.id,
       source: { repo: repository, image: null },
+      activeDeployments: deployments(service),
       rootDirectory,
       watchPatterns: entry?.watchPatterns ?? [],
       dockerfilePath: entry?.dockerfile ?? null,
@@ -155,10 +156,20 @@ function fakeRailwayCli({ repoRoot: fixtureRoot, headSha, previousSha }) {
       writeJson({
         data: {
           deployments: {
-            pageInfo: { hasNextPage: false, endCursor: null },
-            edges: manifest.services.flatMap((service) => (
-              deployments(service).map((node) => ({ node }))
-            )),
+            // The fleet event stream deliberately has no running deployment.
+            // A healthy probe must use serviceInstance.activeDeployments as
+            // its running baseline, stop after this page crosses head time,
+            // and avoid every per-service deployment-list fallback.
+            pageInfo: { hasNextPage: true, endCursor: 'older-events' },
+            edges: manifest.services.map((service) => ({
+              node: {
+                id: `skipped-${service.id}`,
+                serviceId: service.id,
+                status: 'SKIPPED',
+                createdAt: '2000-01-01T00:00:00.000Z',
+                meta: { commitHash: previousSha },
+              },
+            })),
           },
         },
       });
@@ -166,11 +177,7 @@ function fakeRailwayCli({ repoRoot: fixtureRoot, headSha, previousSha }) {
       fail('unexpected Railway GraphQL document');
     }
   } else if (args[0] === 'deployment' && args[1] === 'list') {
-    if (requireProject()) {
-      const service = servicesById.get(argument('--service'));
-      if (!service) fail(`unknown deployment service ${argument('--service')}`);
-      else writeJson(deployments(service));
-    }
+    fail(`unexpected per-service deployment fallback: ${JSON.stringify(args)}`);
   } else {
     fail(`unexpected Railway CLI arguments: ${JSON.stringify(args)}`);
   }
@@ -330,6 +337,10 @@ describe('Railway Deploy Drift workflow', () => {
         `healthy deploy drift failed\nstdout:\n${healthyDrift.stdout}\nstderr:\n${healthyDrift.stderr}`,
       );
       assert.match(healthyDrift.stdout, /Every service this repository deploys is running/);
+      assert.match(
+        healthyDrift.stderr,
+        /Read 80 service histories in 1 fleet page\(s\) \(80 records\), 0 direct fallback\(s\)\./,
+      );
 
       const projectedConfigDrift = executeWorkflowShell(audit.run, fixture, {
         mode: 'config-drift',

--- a/tests/railway-fleet-deployments.test.mjs
+++ b/tests/railway-fleet-deployments.test.mjs
@@ -25,7 +25,11 @@ import {
   runRailwayApiAsync,
   selectExpectedRepositoryServices,
 } from '../scripts/railway-cli.mjs';
-import { createFleetAccumulator } from '../scripts/railway-deployments.mjs';
+import {
+  createFleetAccumulator,
+  limitDeploymentHistory,
+  newestRunning,
+} from '../scripts/railway-deployments.mjs';
 
 const HEAD_AT = Date.parse('2026-08-04T12:00:00.000Z');
 
@@ -251,10 +255,67 @@ describe('immutable native-autodeploy fleet', () => {
 });
 
 function node(serviceId, status, at, commitHash) {
-  return { serviceId, status, createdAt: at, meta: commitHash ? { commitHash } : {} };
+  return {
+    id: `${serviceId}-${status}-${String(at)}-${commitHash ?? 'none'}`,
+    serviceId,
+    status,
+    createdAt: at,
+    meta: commitHash ? { commitHash } : {},
+  };
 }
 
 describe('fleet accumulator', () => {
+  it('rejects malformed Viewer active-deployment baselines', () => {
+    assert.throws(
+      () => createFleetAccumulator({
+        serviceIds: ['a'],
+        initialDeploymentsByService: [],
+      }),
+      /must be a Map/i,
+    );
+    assert.throws(
+      () => createFleetAccumulator({
+        serviceIds: ['a'],
+        initialDeploymentsByService: new Map([['a', {}]]),
+      }),
+      /for a must be an array/i,
+    );
+    assert.throws(
+      () => createFleetAccumulator({
+        serviceIds: ['a'],
+        initialDeploymentsByService: new Map([
+          ['a', [node('b', 'SUCCESS', '2026-08-01T11:00:00Z', 'aaa')]],
+        ]),
+      }),
+      /belongs to another service/i,
+    );
+  });
+
+  it('uses Viewer active deployments as the running baseline and reads only recent fleet events', () => {
+    const initialDeploymentsByService = new Map([
+      ['a', [node('a', 'SUCCESS', '2026-08-01T11:00:00Z', 'aaa')]],
+      ['b', [node('b', 'CRASHED', '2026-08-01T10:00:00Z', 'bbb')]],
+    ]);
+    const accumulator = createFleetAccumulator({
+      serviceIds: ['a', 'b'],
+      notBefore: HEAD_AT,
+      initialDeploymentsByService,
+    });
+
+    accumulator.absorb([
+      node('a', 'SKIPPED', '2026-08-04T11:00:00Z', 'head-a'),
+      node('b', 'FAILED', '2026-08-04T10:00:00Z', 'head-b'),
+    ]);
+
+    assert.equal(accumulator.done, true, 'the stream is already older than the comparison head');
+    assert.deepEqual(accumulator.result().unresolved, []);
+    assert.deepEqual(
+      accumulator.result().byService.get('a').map((deployment) => deployment.status),
+      ['SKIPPED', 'SUCCESS'],
+      'recent refusal evidence must be retained ahead of the active running baseline',
+    );
+  });
+
   it('groups a mixed stream by service', () => {
     const accumulator = createFleetAccumulator({ serviceIds: ['a', 'b'], notBefore: 0 });
     accumulator.absorb([
@@ -273,7 +334,163 @@ describe('fleet accumulator', () => {
     assert.deepEqual([...accumulator.result().byService.keys()], ['a']);
   });
 
-  it('is not done until every service has shown a RUNNING record', () => {
+  it('uses foreign stream records to prove the global cursor crossed head', () => {
+    const initialDeploymentsByService = new Map([
+      ['a', [node('a', 'SUCCESS', '2026-08-04T13:00:00Z', 'aaa')]],
+    ]);
+    const accumulator = createFleetAccumulator({
+      serviceIds: ['a'],
+      notBefore: HEAD_AT,
+      initialDeploymentsByService,
+    });
+
+    accumulator.absorb([node('foreign', 'SUCCESS', '2026-08-04T11:00:00Z', 'bbb')]);
+
+    assert.equal(accumulator.done, true);
+    assert.equal(accumulator.result().byService.get('a').length, 1);
+  });
+
+  it('rejects malformed fleet timestamps instead of treating them as older than head', () => {
+    const accumulator = createFleetAccumulator({
+      serviceIds: ['a'],
+      notBefore: HEAD_AT,
+      initialDeploymentsByService: new Map([
+        ['a', [node('a', 'SUCCESS', '2026-08-04T13:00:00Z', 'aaa')]],
+      ]),
+    });
+
+    for (const createdAt of ['not-a-date', 0, '2026-08-04']) {
+      assert.throws(
+        () => accumulator.absorb([node('foreign', 'FAILED', createdAt, 'head')]),
+        /valid createdAt/i,
+      );
+    }
+    assert.equal(accumulator.done, false);
+  });
+
+  it('uses the later fleet status when an active deployment changes state', () => {
+    const activeBuilding = {
+      ...node('a', 'BUILDING', '2026-08-04T10:00:00Z', 'head'),
+      id: 'deployment-a',
+    };
+    const accumulator = createFleetAccumulator({
+      serviceIds: ['a'],
+      notBefore: HEAD_AT,
+      initialDeploymentsByService: new Map([['a', [activeBuilding]]]),
+    });
+
+    accumulator.absorb([{
+      ...node('a', 'FAILED', '2026-08-04T11:00:00Z', 'head'),
+      id: 'deployment-a',
+    }]);
+
+    assert.deepEqual(
+      accumulator.result().byService.get('a').map((deployment) => deployment.status),
+      ['FAILED'],
+    );
+    assert.deepEqual(accumulator.result().unresolved, ['a']);
+  });
+
+  it('keeps active provenance when the fleet repeats the same deployment state', () => {
+    const active = {
+      ...node('a', 'SUCCESS', '2026-08-04T10:00:00Z', 'serving'),
+      id: 'deployment-a',
+    };
+    const accumulator = createFleetAccumulator({
+      serviceIds: ['a'],
+      notBefore: HEAD_AT,
+      initialDeploymentsByService: new Map([['a', [active]]]),
+    });
+
+    accumulator.absorb([{ ...active }]);
+
+    assert.equal(newestRunning(accumulator.result().byService.get('a')).meta.commitHash, 'serving');
+    assert.deepEqual(accumulator.result().unresolved, []);
+  });
+
+  it('requires a fresh direct read when a distinct newer deployment becomes active mid-scan', () => {
+    const active = {
+      ...node('a', 'SUCCESS', '2026-08-04T10:00:00Z', 'viewer-head'),
+      id: 'viewer-active-a',
+    };
+    const accumulator = createFleetAccumulator({
+      serviceIds: ['a'],
+      notBefore: HEAD_AT,
+      initialDeploymentsByService: new Map([['a', [active]]]),
+    });
+
+    accumulator.absorb([{
+      ...node('a', 'SUCCESS', '2026-08-04T11:00:00Z'),
+      id: 'replacement-a',
+    }]);
+
+    assert.deepEqual(accumulator.result().unresolved, ['a']);
+  });
+
+  it('does not restore stale Viewer provenance after a newer deployment on an exhausted stream', () => {
+    const active = {
+      ...node('a', 'SUCCESS', '2026-08-04T10:00:00Z', 'viewer-head'),
+      id: 'viewer-active-a',
+    };
+    const replacement = {
+      ...node('a', 'SUCCESS', '2026-08-04T11:00:00Z'),
+      id: 'replacement-a',
+    };
+    const accumulator = createFleetAccumulator({
+      serviceIds: ['a'],
+      notBefore: HEAD_AT,
+      initialDeploymentsByService: new Map([['a', [active]]]),
+    });
+
+    accumulator.absorb([replacement, { ...active }]);
+    accumulator.markExhausted();
+
+    assert.equal(newestRunning(accumulator.result().byService.get('a')).id, replacement.id);
+    assert.deepEqual(accumulator.result().unresolved, []);
+  });
+
+  it('keeps the Viewer-active source authoritative over newer removed history', () => {
+    const active = node('a', 'SUCCESS', '2026-08-04T10:00:00Z', 'serving');
+    const accumulator = createFleetAccumulator({
+      serviceIds: ['a'],
+      notBefore: HEAD_AT,
+      initialDeploymentsByService: new Map([['a', [active]]]),
+    });
+
+    accumulator.absorb([
+      node('a', 'REMOVED', '2026-08-04T11:00:00Z', 'aborted-head'),
+      node('a', 'SKIPPED', '2026-08-04T09:00:00Z', 'skipped'),
+    ]);
+
+    assert.equal(newestRunning(accumulator.result().byService.get('a')), active);
+  });
+
+  it('retains only a Viewer-active running baseline beyond the recent-event window', () => {
+    const skipped = Array.from({ length: 50 }, (_, index) => node(
+      'a',
+      'SKIPPED',
+      new Date(Date.parse('2026-08-05T12:00:00Z') - index * 1_000).toISOString(),
+      `skip-${index}`,
+    ));
+    const active = node('a', 'SUCCESS', '2026-08-01T11:00:00Z', 'running');
+
+    const accumulator = createFleetAccumulator({
+      serviceIds: ['a'],
+      initialDeploymentsByService: new Map([['a', [active]]]),
+    });
+    accumulator.absorb(skipped);
+    const limited = limitDeploymentHistory(accumulator.result().byService.get('a'), 50);
+
+    assert.equal(limited.length, 51);
+    assert.equal(newestRunning(limited), active);
+
+    const historical = node('a', 'SUCCESS', '2026-08-01T10:00:00Z', 'historical');
+    const directWindow = limitDeploymentHistory([...skipped, historical], 50);
+    assert.equal(directWindow.length, 50, 'shared mutation callers retain their exact history window');
+    assert.equal(newestRunning(directWindow), undefined);
+  });
+
+  it('is not done until every service has shown a RUNNING record without Viewer baselines', () => {
     const accumulator = createFleetAccumulator({ serviceIds: ['a', 'b'], notBefore: HEAD_AT });
     accumulator.absorb([node('a', 'SUCCESS', '2026-08-04T01:00:00Z', 'aaa')]);
     assert.equal(accumulator.done, false, 'b has not been located yet');
@@ -291,7 +508,7 @@ describe('fleet accumulator', () => {
     assert.equal(accumulator.done, true);
   });
 
-  it('a SKIPPED-only service is NOT counted as located', () => {
+  it('a SKIPPED-only service is NOT counted as located without Viewer baselines', () => {
     // SKIPPED never produced an image, so it cannot answer "what is running".
     const accumulator = createFleetAccumulator({ serviceIds: ['a'], notBefore: HEAD_AT });
     accumulator.absorb([node('a', 'SKIPPED', '2026-08-04T01:00:00Z', 'aaa')]);
@@ -323,7 +540,15 @@ describe('fleet paging', () => {
     return () => {
       const page = pages[index] ?? { edges: [], pageInfo: { hasNextPage: false } };
       index += 1;
-      return { deployments: page };
+      return {
+        deployments: {
+          ...page,
+          pageInfo: {
+            ...page.pageInfo,
+            ...(page.pageInfo?.hasNextPage ? { endCursor: `cursor-${index}` } : {}),
+          },
+        },
+      };
     };
   }
   const page = (nodes, hasNextPage) => ({
@@ -344,7 +569,37 @@ describe('fleet paging', () => {
     assert.deepEqual(result.unresolved, []);
   });
 
-  it('keeps paging while a service is still missing', async () => {
+  it('does not discard Viewer running baselines when the recent stream contains only skipped pushes', async () => {
+    const initialDeploymentsByService = new Map([
+      ['a', [node('a', 'SUCCESS', '2026-08-01T11:00:00Z', 'aaa')]],
+      ['b', [node('b', 'SUCCESS', '2026-08-01T10:00:00Z', 'bbb')]],
+    ]);
+    const api = pager([
+      page([
+        node('a', 'SKIPPED', '2026-08-04T11:00:00Z', 'head-a'),
+        node('b', 'SKIPPED', '2026-08-04T10:00:00Z', 'head-b'),
+      ], true),
+    ]);
+
+    const result = await readFleetDeployments({
+      projectId: 'p',
+      environmentId: 'e',
+      serviceIds: ['a', 'b'],
+      notBefore: HEAD_AT,
+      maxPages: 1,
+      api,
+      accumulatorFactory: (args) => createFleetAccumulator({
+        ...args,
+        initialDeploymentsByService,
+      }),
+    });
+
+    assert.equal(result.pages, 1);
+    assert.deepEqual(result.unresolved, []);
+    assert.deepEqual(result.byService.get('a').map((deployment) => deployment.status), ['SKIPPED', 'SUCCESS']);
+  });
+
+  it('keeps paging while a service is still missing without Viewer baselines', async () => {
     const api = pager([
       page([node('a', 'SUCCESS', '2026-08-04T11:00:00Z', 'aaa')], true),
       page([node('b', 'SUCCESS', '2026-08-04T10:00:00Z', 'bbb')], true),
@@ -404,6 +659,43 @@ describe('fleet paging', () => {
       }),
       /no deployments connection/,
     );
+    await assert.rejects(
+      () => readFleetDeployments({
+        projectId: 'p',
+        environmentId: 'e',
+        serviceIds: ['a'],
+        notBefore: HEAD_AT,
+        api: () => ({ deployments: { edges: [], pageInfo: {} } }),
+        accumulatorFactory: (args) => createFleetAccumulator({
+          ...args,
+          initialDeploymentsByService: new Map([
+            ['a', [node('a', 'SUCCESS', '2026-08-04T13:00:00Z', 'aaa')]],
+          ]),
+        }),
+      }),
+      /hasNextPage.*boolean/i,
+    );
+    await assert.rejects(
+      () => readFleetDeployments({
+        projectId: 'p',
+        environmentId: 'e',
+        serviceIds: ['a'],
+        notBefore: HEAD_AT,
+        api: () => ({
+          deployments: {
+            edges: [{ node: node('a', 'SKIPPED', '2026-08-04T11:00:00Z', 'head') }],
+            pageInfo: { hasNextPage: true, endCursor: null },
+          },
+        }),
+        accumulatorFactory: (args) => createFleetAccumulator({
+          ...args,
+          initialDeploymentsByService: new Map([
+            ['a', [node('a', 'SUCCESS', '2026-08-04T13:00:00Z', 'aaa')]],
+          ]),
+        }),
+      }),
+      /cursor/i,
+    );
   });
 
   it('checks the shared run deadline before every fleet page', async () => {
@@ -431,6 +723,113 @@ describe('fleet paging', () => {
 });
 
 describe('fleet read deadline', () => {
+  it('refreshes only a service whose active source changes during the fleet scan', async () => {
+    const services = [{ id: 'a' }, { id: 'b' }];
+    const directReads = [];
+    const active = new Map([
+      ['a', [{ ...node('a', 'SUCCESS', '2026-08-04T10:00:00Z', 'old-a'), id: 'active-a' }]],
+      ['b', [{ ...node('b', 'SUCCESS', '2026-08-04T10:00:00Z', 'head-b'), id: 'active-b' }]],
+    ]);
+    const api = () => ({
+      deployments: {
+        edges: [
+          { node: { ...node('a', 'SUCCESS', '2026-08-04T11:00:00Z'), id: 'replacement-a' } },
+          { node: node('b', 'SKIPPED', '2026-08-04T09:00:00Z', 'skip-b') },
+        ],
+        pageInfo: { hasNextPage: true, endCursor: 'older-events' },
+      },
+    });
+    const result = await readDeploymentsForFleet({
+      services,
+      environment: 'production',
+      environmentId: 'environment-1',
+      projectId: 'project-1',
+      window: 50,
+      notBefore: HEAD_AT,
+      accumulatorFactory: (args) => createFleetAccumulator({
+        ...args,
+        initialDeploymentsByService: active,
+      }),
+      readFleet: (args) => readFleetDeployments({ ...args, api }),
+      readDirect: async (service) => {
+        directReads.push(service.id);
+        return [node(service.id, 'SUCCESS', '2026-08-04T11:30:00Z', `fresh-${service.id}`)];
+      },
+    });
+
+    assert.deepEqual(directReads, ['a']);
+    assert.equal(newestRunning(result.get('a').deployments).meta.commitHash, 'fresh-a');
+    assert.equal(newestRunning(result.get('b').deployments).meta.commitHash, 'head-b');
+  });
+
+  it('falls back to direct reads when the fleet page is malformed', async () => {
+    const directReads = [];
+    const result = await readDeploymentsForFleet({
+      services: [{ id: 'a' }, { id: 'b' }],
+      environment: 'production',
+      environmentId: 'environment-1',
+      projectId: 'project-1',
+      window: 50,
+      accumulatorFactory: (args) => createFleetAccumulator({
+        ...args,
+        initialDeploymentsByService: new Map([
+          ['a', [node('a', 'SUCCESS', '2026-08-04T10:00:00Z', 'head-a')]],
+          ['b', [node('b', 'SUCCESS', '2026-08-04T10:00:00Z', 'head-b')]],
+        ]),
+      }),
+      readFleet: (args) => readFleetDeployments({
+        ...args,
+        api: () => ({ deployments: { edges: [], pageInfo: {} } }),
+      }),
+      readDirect: async (service) => {
+        directReads.push(service.id);
+        return [node(service.id, 'SUCCESS', '2026-08-04T11:00:00Z', `fresh-${service.id}`)];
+      },
+    });
+
+    assert.deepEqual(directReads.sort(), ['a', 'b']);
+    assert.equal(result.get('a').error, null);
+    assert.equal(result.get('b').error, null);
+  });
+
+  it('direct-reads only the service missing a Viewer active baseline', async () => {
+    const directReads = [];
+    const active = node('a', 'SUCCESS', '2026-08-04T10:00:00Z', 'serving-a');
+    const api = () => ({
+      deployments: {
+        edges: [
+          node('a', 'SKIPPED', '2026-08-04T11:00:00Z', 'skip-a'),
+          node('b', 'SKIPPED', '2026-08-04T10:00:00Z', 'skip-b'),
+        ].map((deployment) => ({ node: deployment })),
+        pageInfo: { hasNextPage: true, endCursor: 'older-events' },
+      },
+    });
+    const result = await readDeploymentsForFleet({
+      services: [{ id: 'a' }, { id: 'b' }],
+      environment: 'production',
+      environmentId: 'environment-1',
+      projectId: 'project-1',
+      window: 50,
+      notBefore: HEAD_AT,
+      accumulatorFactory: (args) => createFleetAccumulator({
+        ...args,
+        initialDeploymentsByService: new Map([
+          ['a', [active]],
+          ['b', []],
+        ]),
+      }),
+      readFleet: (args) => readFleetDeployments({ ...args, api }),
+      readDirect: async (service) => {
+        directReads.push(service.id);
+        return [node(service.id, 'SUCCESS', '2026-08-04T09:00:00Z', `serving-${service.id}`)];
+      },
+    });
+
+    assert.deepEqual(directReads, ['b']);
+    assert.equal(newestRunning(result.get('a').deployments), active);
+    assert.equal(newestRunning(result.get('b').deployments).meta.commitHash, 'serving-b');
+  });
+
   it('scopes every direct fallback read to the explicit Railway project', async () => {
     const options = [];
     const result = await readDeploymentsForFleet({

--- a/tests/railway-viewer-deployment-config.test.mjs
+++ b/tests/railway-viewer-deployment-config.test.mjs
@@ -41,11 +41,23 @@ function service({
   };
 }
 
-function viewerResponse(serviceId, { instance = {}, trigger = {}, pageInfo = {} } = {}) {
+function viewerResponse(serviceId, {
+  instance = {},
+  trigger = {},
+  pageInfo = {},
+  activeDeployments = [{
+    id: `deployment-${serviceId}`,
+    serviceId,
+    status: 'SUCCESS',
+    createdAt: '2026-08-14T12:00:00.000Z',
+    meta: { commitHash: 'a'.repeat(40) },
+  }],
+} = {}) {
   return {
     serviceInstance: {
       serviceId,
       source: { repo: 'koala73/worldmonitor', image: null },
+      activeDeployments,
       ...instance,
     },
     deploymentTriggers: {
@@ -124,11 +136,26 @@ describe('Viewer-compatible deployment-only projection', () => {
       startCommand: 'node seed-example.mjs',
       cronSchedule: '0 * * * *',
     });
+    assert.equal(Object.hasOwn(projected, 'activeDeployments'), false);
     assert.equal(Object.hasOwn(projected, 'variables'), false);
+  });
+
+  it('projects active deployment evidence only when the deploy drift caller opts in', () => {
+    const response = viewerResponse('svc-1');
+    const projected = projectViewerDeploymentConfig({
+      service: { id: 'svc-1', name: 'seed-example', source: { repo: 'koala73/worldmonitor' } },
+      instance: response.serviceInstance,
+      triggers: response.deploymentTriggers,
+      includeActiveDeployments: true,
+    });
+
+    assert.deepEqual(projected.activeDeployments, response.serviceInstance.activeDeployments);
   });
 
   it('makes variable reads structurally impossible and refuses deployment-only apply', () => {
     assert.match(DEPLOYMENT_ONLY_QUERY, /serviceInstance/);
+    assert.match(DEPLOYMENT_ONLY_QUERY, /\$includeActiveDeployments:\s*Boolean!/);
+    assert.match(DEPLOYMENT_ONLY_QUERY, /activeDeployments\s+@include\(if:\s*\$includeActiveDeployments\)/);
     assert.match(DEPLOYMENT_ONLY_QUERY, /deploymentTriggers/);
     assert.match(DEPLOYMENT_ONLY_QUERY, /first:\s*2/);
     assert.doesNotMatch(DEPLOYMENT_ONLY_QUERY, /variables|environmentVariables/i);
@@ -305,6 +332,40 @@ describe('Viewer-compatible deployment-only projection', () => {
       }),
       /malformed deployment trigger/i,
     );
+    assert.throws(
+      () => projectViewerDeploymentConfig({
+        ...base,
+        includeActiveDeployments: true,
+        instance: {
+          ...base.instance,
+          activeDeployments: [{
+            id: 'deployment-1',
+            serviceId: 'svc-other',
+            status: 'SUCCESS',
+            createdAt: '2026-08-14T12:00:00.000Z',
+            meta: { commitHash: 'a'.repeat(40) },
+          }],
+        },
+      }),
+      /active deployment.*another service/i,
+    );
+    assert.throws(
+      () => projectViewerDeploymentConfig({
+        ...base,
+        includeActiveDeployments: true,
+        instance: {
+          ...base.instance,
+          activeDeployments: [{
+            id: 'deployment-1',
+            serviceId: 'svc-1',
+            status: 'SUCCESS',
+            createdAt: 'not-a-date',
+            meta: { commitHash: 'a'.repeat(40) },
+          }],
+        },
+      }),
+      /active deployment.*malformed/i,
+    );
   });
 
   it('audits native source invariants across non-seeder repository services', () => {
@@ -422,7 +483,7 @@ describe('Viewer-compatible deployment-only projection', () => {
       environmentId: 'environment-1',
       concurrency: 2,
       api: async (_query, variables) => {
-        calls.push(variables.serviceId);
+        calls.push(variables);
         active += 1;
         maxActive = Math.max(maxActive, active);
         await new Promise((resolve) => setTimeout(resolve, 5));
@@ -432,7 +493,36 @@ describe('Viewer-compatible deployment-only projection', () => {
     });
     assert.equal(maxActive, 2);
     assert.equal(calls.length, services.length);
+    assert.equal(calls.every((variables) => variables.includeActiveDeployments === false), true);
     assert.deepEqual(Object.keys(projected.services).sort(), services.map((service) => service.id).sort());
+    assert.equal(
+      Object.values(projected.services).every((config) => !Object.hasOwn(config, 'activeDeployments')),
+      true,
+    );
+  });
+
+  it('requests and validates active deployment evidence for deploy drift only', async () => {
+    const services = [{
+      id: 'svc-1',
+      name: 'service-1',
+      source: { repo: 'koala73/worldmonitor' },
+    }];
+    const calls = [];
+    const projected = await readViewerDeploymentConfig('production', services, {
+      projectId: 'project-1',
+      environmentId: 'environment-1',
+      includeActiveDeployments: true,
+      api: async (_query, variables) => {
+        calls.push(variables);
+        return viewerResponse(variables.serviceId);
+      },
+    });
+
+    assert.equal(calls[0].includeActiveDeployments, true);
+    assert.deepEqual(
+      projected.services['svc-1'].activeDeployments,
+      viewerResponse('svc-1').serviceInstance.activeDeployments,
+    );
   });
 
   it('fails the whole projection when one Viewer API read fails', async () => {


### PR DESCRIPTION
The hourly read-only Railway drift audit was exhausting the Viewer token on deployment history reads, then reporting `All jobs have failed` after Railway returned `429`. This change makes the normal audit use Railway's active-deployment projection as its running baseline and scan only the recent global event stream.

## What changed

- Read `activeDeployments` through the existing Viewer-only GraphQL boundary. No variable or mutation capability is added.
- Stop the global fleet scan after it crosses the frozen comparison-head timestamp, while retaining recent skipped, failed, and in-flight evidence.
- Fall back to a direct service history only when active evidence is absent, malformed, or changes during the two read-only snapshots.
- Reject malformed timestamps, pagination, cursors, and cross-service records instead of accepting partial evidence.
- Preserve the mutation planner's existing deployment window; the older active baseline is retained only for the read-only drift classifier.

## Operational effect

| Path | Before | After local production read |
|---|---:|---:|
| Fleet pages | 10 | 1 |
| Fleet records | 5,000 | 500 |
| Direct service fallbacks | 80 | 0 |

The old path consumed the token's read budget and caused the current false-red workflow. The new path remains fail-closed: incomplete or contradictory evidence is red or selectively refreshed, never converted to health.

## Validation

- `node --test tests/railway-*.test.mjs` — 602 passed
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run lint`
- `npm run docs:check`
- full pre-push gate, including 67 changed Railway tests and repository-wide Markdown lint
- independent correctness and adversarial re-review: no remaining actionable findings

## After merge

Observe the next scheduled `Railway Deploy Drift` run. Normal evidence should show one fleet page, zero direct fallbacks, no Railway `429`, and an empty blocking set. This PR does not dispatch, deploy, approve, or change any Railway setting.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT--5-000000)