### PR TITLE
test(analytics): exercise late transport rejection

### DIFF
--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -1449,12 +1449,15 @@ describe('collector latch release is module-owned (#6288)', () => {
     const onUnhandled = (reason: unknown) => { leaked.push(reason); };
     process.on('unhandledRejection', onUnhandled);
     let settleLate: ((response: Response) => void) | undefined;
-    let failLate: ((error: unknown) => void) | undefined;
+    let failSecond: ((error: unknown) => void) | undefined;
     let calls = 0;
     window.fetch = (() => {
       calls += 1;
       if (calls === 1) {
-        return new Promise<Response>((resolve, reject) => { settleLate = resolve; failLate = reject; });
+        return new Promise<Response>((resolve) => { settleLate = resolve; });
+      }
+      if (calls === 2) {
+        return new Promise<Response>((_resolve, reject) => { failSecond = reject; });
       }
       return Promise.resolve(collectorResponse(true, 200));
     }) as typeof window.fetch;
@@ -1486,7 +1489,14 @@ describe('collector latch release is module-owned (#6288)', () => {
       const secondAbandoned = window.fetch(UMAMI_SEND_URL, collectorEventInit());
       void secondAbandoned.catch(() => {});
       await drainPromiseHandlers();
-      failLate?.(new TypeError('Failed to fetch'));
+
+      const secondLatchDeadline = findLatchDeadline(fakeTimers.timers);
+      assert.ok(secondLatchDeadline, 'the second request must still be outstanding at its deadline');
+      secondLatchDeadline.callback();
+      await assert.rejects(secondAbandoned, { name: 'TimeoutError' });
+
+      assert.ok(failSecond, 'the abandoned second transport must still be rejectable');
+      failSecond(new TypeError('Failed to fetch'));
       await drainPromiseHandlers();
       await new Promise((resolve) => globalThis.queueMicrotask(() => resolve(null)));
 


### PR DESCRIPTION
## Summary

- make the late-rejection half of the collector race regression use its own deferred transport
- race that second request out on the module-owned latch deadline before rejecting the abandoned transport
- verify the tracker reports `TimeoutError` while the late transport rejection stays handled

Closes #6708.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: analytics collector regression tests

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Validation

- `npx --no-install tsx --test tests/analytics-beacon-rejection.test.mts` - 59 passed
- mutation check: replacing the collector `Promise.race` with a direct transport await makes the targeted regression fail with a pending promise; restoring it makes the test pass
- `npm run typecheck`
- `npx --no-install biome check tests/analytics-beacon-rejection.test.mts`
- `npm run lint:unicode -- --staged=false`
- `git diff --check`

The app-variant, RSS, and Railway pre-seed checklist items are not applicable to this test-only change.

## Documentation Alignment Checklist

N/A - this test-only change does not publish or change documentation claims.

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key

## Screenshots

N/A - no user-facing UI changes.