### PR TITLE
fix(ops): bound Railway deploy health API reads

### DIFF
--- a/.github/workflows/railway-deploy-drift.yml
+++ b/.github/workflows/railway-deploy-drift.yml
@@ -1,20 +1,20 @@
-name: Railway Deploy Drift
+name: Railway Native Deploy Health
 
 on:
   schedule:
-    - cron: '17 * * * *'
+    - cron: '17 */6 * * *'
   workflow_dispatch:
 
 concurrency:
-  group: railway-deploy-drift-${{ github.ref }}
+  group: railway-native-deploy-health-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  config-audit:
-    name: Railway deployment configuration
+  monitor:
+    name: Railway native deployment health
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -22,36 +22,7 @@ jobs:
       name: ingestion-acceptance-production
       deployment: false
     steps:
-      - name: Start config-audit run budget
-        run: echo "RAILWAY_CONFIG_AUDIT_JOB_STARTED_AT_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
-
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 1
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: '24'
-
-      - name: Install pinned Railway CLI
-        run: npm install --global @railway/cli@5.30.1
-
-      - name: Audit Railway deployment configuration
-        env:
-          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_VIEWER_API_TOKEN }}
-          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
-        run: node scripts/audit-railway-watch-paths.mjs --environment production --deployment-only --concurrency 4 --json
-
-  deploy-drift:
-    name: Railway deployment drift
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    environment:
-      name: ingestion-acceptance-production
-      deployment: false
-    steps:
-      - name: Start deploy-drift run budget
+      - name: Start deploy-health run budget
         run: echo "RAILWAY_DRIFT_JOB_STARTED_AT_MS=$(date +%s%3N)" >> "$GITHUB_ENV"
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -76,8 +47,8 @@ jobs:
       - name: Install pinned Railway CLI
         run: npm install --global @railway/cli@5.30.1
 
-      - name: Check Railway deploy drift against main
+      - name: Check Railway deployment configuration and drift
         env:
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_PRODUCTION_VIEWER_API_TOKEN }}
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
-        run: node scripts/check-railway-deploy-drift.mjs --head "$RAILWAY_COMPARISON_SHA" --concurrency 4
+        run: node scripts/check-railway-deploy-drift.mjs --head "$RAILWAY_COMPARISON_SHA" --concurrency 2 --audit-deployment-config

--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -99,7 +99,7 @@ jobs:
         run: git checkout --detach "$GATED_SHA"
 
       # This workflow owns only ingestion/data acceptance. Deployment
-      # configuration and image drift have their own hourly read-only workflow.
+      # configuration and image drift have their own six-hourly read-only workflow.
       - name: Check ingestion operational acceptance
         if: ${{ !cancelled() && steps.gate.conclusion != 'failure' }}
         run: node scripts/check-seed-freshness.mjs

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -35,7 +35,7 @@ The normal deployment architecture is intentionally small:
 | Merge safety | GitHub protected `main` | Require a PR, current-base checks with `strict=true`, administrator enforcement, zero required human approvals, and no bypass actors. |
 | Service selection | Railway's native watch paths, backed by `scripts/railway-services.json`, its closure audit, and the exact identity roster in `scripts/railway-native-autodeploy-fleet.json` | A source migration may change `source.checkSuites` only. It must not change watch paths, fleet identity, or another service field. |
 | Deployment creation | Railway's native GitHub integration on explicit branch `main` | No GitHub Actions workflow dispatches, retries, leases, or repairs a normal deployment. |
-| Drift detection | One hourly, read-only Railway workflow after the monitor migration | Missing, detached, replaced, unexpected, unknown, failed, skipped, overdue, or contradictory state is red. The monitor has no mutation token, dispatch permission, retry, reviewer, or acceptance baseline. |
+| Drift detection | One six-hourly, read-only Railway workflow after the monitor migration | Missing, detached, replaced, unexpected, unknown, failed, skipped, overdue, or contradictory state is red. The monitor has no mutation token, dispatch permission, retry, reviewer, or acceptance baseline. |
 | Recovery | Operator diagnosis followed by an explicit Railway action or batch rollback | Recovery is never automatic and never turns missing evidence green. Seed/ingestion freshness remains a separate acceptance surface. |
 
 The permanent monitor uses a credential issued to a dedicated Railway
@@ -248,9 +248,10 @@ The audit only proves the trigger config matches the registry. Proving a merge
 actually reached production is the separate
 [deploy-drift check](#deploy-drift-check) below.
 
-The hourly `Railway Deploy Drift` workflow performs this audit in deployment-only
-mode and runs the independent deployment-history check. `Seed Freshness Monitor`
-owns ingestion acceptance only. Create the dedicated GitHub Actions environment
+The six-hourly `Railway Native Deploy Health` workflow performs this audit in
+deployment-only mode and runs the deployment-history check from the same
+Viewer projection. `Seed Freshness Monitor` owns ingestion acceptance only.
+Create the dedicated GitHub Actions environment
 `ingestion-acceptance-production`, restrict its deployment branch policy to
 `main`, and configure:
 
@@ -262,7 +263,7 @@ Do not define the Viewer token as a repository or organization secret:
 `workflow_dispatch` can target another ref, while the environment's server-side
 branch policy keeps the production credential unavailable there. The workflow
 references the environment with deployment tracking disabled and maps the token
-to `RAILWAY_API_TOKEN` only on the two read steps. It never links a checkout,
+to `RAILWAY_API_TOKEN` only on the combined read step. It never links a checkout,
 requests variables, or passes `--apply`. Missing or inaccessible context fails
 the monitor rather than silently skipping the live audit. See
 [Deploy-drift check](#deploy-drift-check) for the exact workflow contract.
@@ -531,11 +532,12 @@ Its one `monitor` job checks ingestion operational acceptance through
 configuration, classify deployment history, or imply that a merge reached a
 container.
 
-Read the separate hourly `Railway Deploy Drift` workflow for production source,
-build, trigger, and deployment conclusions. A red Seed Freshness run says the
-ingestion observation failed or could not be authorized. A red Railway Deploy
-Drift run says the fleet configuration or deployment evidence failed. Neither
-workflow hides or gates the other's conclusion.
+Read the separate six-hourly `Railway Native Deploy Health` workflow for
+production source, build, trigger, and deployment conclusions. A red Seed
+Freshness run says the ingestion observation failed or could not be authorized.
+A red Railway Native Deploy Health run says the fleet configuration or
+deployment evidence failed. Neither workflow hides or gates the other's
+conclusion.
 
 `monitor` fails on
 every actionable problem, including `SEED_ERROR`, `STALE_SEED`,
@@ -549,22 +551,22 @@ controls" gap.
 #### Deploy-drift check
 
 The permanent read-only surface is `.github/workflows/railway-deploy-drift.yml`
-(`Railway Deploy Drift`). It runs at minute 17 of every hour and on explicit
-manual dispatch. Its two jobs are independent: one audits the Viewer-safe
-source/build/deploy projection and the other checks deployment history and Git
-closure. Neither job depends on or dispatches the other.
+(`Railway Native Deploy Health`). It runs at minute 17 every six hours and on
+explicit manual dispatch. One job reads the Viewer-safe source/build/deploy
+projection once, audits it, and reuses the same evidence to check deployment
+history and Git closure. It normally makes one bounded fleet-history request
+after the per-service projection and performs direct history fallback only when
+a service has no stable active-deployment baseline.
 
-Both jobs run only for the literal `refs/heads/main`. The configuration audit
-uses a depth-one checkout because it compares Railway configuration with the
-immutable fleet manifest and does not inspect Git ancestry. The deployment
-check freezes the event SHA against the checkout SHA, uses full Git history
-with a blobless filter, and fails if the exact comparison commit cannot be
-fetched. It passes that immutable commit with `--head`; a local manual
+The job runs only for the literal `refs/heads/main`. It freezes the event SHA
+against the checkout SHA, uses full Git history with a blobless filter, and
+fails if the exact comparison commit cannot be fetched. It passes that
+immutable commit with `--head`; a local manual
 invocation without `--head` first refreshes the explicit `origin/main`
 tracking ref and then resolves it, never the current feature-branch `HEAD`.
 
 The workflow maps `RAILWAY_PRODUCTION_VIEWER_API_TOKEN` to
-`RAILWAY_API_TOKEN` only on the identity-verification and read steps. The
+`RAILWAY_API_TOKEN` only on the combined read step. The
 credential must belong to the dedicated Railway Viewer identity. It must not
 be exposed to checkout, setup, dependency installation, or any command with
 mutation authority. The deployment-only audit cannot query variables and
@@ -575,7 +577,7 @@ remains a separate ingestion monitor and must not install Railway, read Railway
 configuration, or classify deployments.
 
 ```bash
-node scripts/check-railway-deploy-drift.mjs        # add --json for the machine-readable form
+node scripts/check-railway-deploy-drift.mjs --audit-deployment-config # add --json for the machine-readable form
 ```
 
 The deployment check does not rediscover the live image by scanning through

--- a/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
+++ b/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
@@ -357,11 +357,12 @@ The original implementation used
 no deployment suppression: every unknown, failed, overdue, contradictory, or
 otherwise unaccepted result is directly red.
 
-`.github/workflows/railway-deploy-drift.yml` now owns two independent read-only
-jobs: the Viewer-safe source/build/trigger audit and deployment-history drift.
-It runs hourly and on manual dispatch, only on `main`, with deployment tracking
-disabled for its GitHub environment. `Seed Freshness Monitor` owns ingestion
-acceptance only and no longer installs Railway or reports a fleet conclusion.
+`.github/workflows/railway-deploy-drift.yml` now owns one combined read-only job:
+the Viewer-safe source/build/trigger audit and deployment-history drift share a
+single per-service projection. It runs every six hours and on manual dispatch,
+only on `main`, with deployment tracking disabled for its GitHub environment.
+`Seed Freshness Monitor` owns ingestion acceptance only and no longer installs
+Railway or reports a fleet conclusion.
 
 The deployment job checks out full history with `fetch-depth: 0` and a blobless
 filter, freezes the event SHA, and refreshes the explicit `origin/main` tracking
@@ -414,12 +415,21 @@ missing, pending, or failed gate fails that workflow; it is never converted
 into a green skip. It deliberately does not run on an ingestion push because
 Railway may not have deployed or executed that revision yet.
 
-`Railway Deploy Drift` is a separate hourly workflow and has no dependency on
-the Seed Freshness gate. The gate and deployment drift share an upstream: an
-ungated or red main is exactly when Railway can refuse a push, so using the gate
-to skip the drift probe would hide the blast radius. Its two independent jobs
-therefore publish Railway configuration and deployment conclusions directly,
+`Railway Native Deploy Health` is a separate six-hourly workflow and has no
+dependency on the Seed Freshness gate. The gate and deployment drift share an
+upstream: an ungated or red main is exactly when Railway can refuse a push, so
+using the gate to skip the drift probe would hide the blast radius. Its one job
+publishes both Railway configuration and deployment conclusions directly,
 without changing the ingestion workflow's verdict.
+
+The earlier two-job hourly layout duplicated the expensive Viewer projection:
+both jobs queried all 80 services, so each scheduled run produced about 160
+per-service GraphQL calls before deployment-history reads. On 2026-08-15 this
+exhausted Railway's rolling API allowance and both jobs failed with HTTP 429.
+The combined job queries each service once with concurrency two, reuses that
+projection for both conclusions, and runs every six hours. A quota failure
+still fails closed; lowering request volume prevents the monitor from creating
+the condition it is meant to observe.
 
 ## Prevention
 

--- a/scripts/audit-railway-watch-paths.mjs
+++ b/scripts/audit-railway-watch-paths.mjs
@@ -506,9 +506,9 @@ export async function waitForRailwayServiceConfigConvergence(
   return remaining;
 }
 
-function printAudit(drift) {
+export function printAudit(drift) {
   if (drift.length === 0) {
-    console.log('Railway operational-config audit passed: registry-managed Dockerfile paths, cron schedules, and watch paths match production, and every other live seeder watches broadly enough not to miss a helper change.');
+    console.log('Railway operational-config audit passed: live Railway configuration matches repository policy.');
     return;
   }
 

--- a/scripts/check-railway-deploy-drift.mjs
+++ b/scripts/check-railway-deploy-drift.mjs
@@ -24,6 +24,7 @@
 //   node scripts/check-railway-deploy-drift.mjs --json
 //   node scripts/check-railway-deploy-drift.mjs --head <sha> --window 200
 //   node scripts/check-railway-deploy-drift.mjs --concurrency 4
+//   node scripts/check-railway-deploy-drift.mjs --audit-deployment-config
 
 import { readFileSync, realpathSync } from 'node:fs';
 import { performance } from 'node:perf_hooks';
@@ -44,6 +45,10 @@ import {
   selectExpectedRepositoryServices,
 } from './railway-cli.mjs';
 import { readViewerDeploymentConfig } from './railway-viewer-deployment-config.mjs';
+import {
+  auditRailwayServiceConfig,
+  printAudit,
+} from './audit-railway-watch-paths.mjs';
 import {
   FAILED_STATUSES,
   IN_FLIGHT_STATUSES,
@@ -745,6 +750,7 @@ async function main() {
   });
   const asJson = process.argv.includes('--json');
   const strict = process.argv.includes('--strict');
+  const auditDeploymentConfig = process.argv.includes('--audit-deployment-config');
   const expectedServices = readRepeatedArguments(process.argv, '--expected-service');
   const environment = readArgument(process.argv, '--environment', DEFAULT_ENVIRONMENT);
   const window = Number(readArgument(process.argv, '--window', String(DEFAULT_DEPLOYMENT_WINDOW)));
@@ -811,9 +817,8 @@ async function main() {
   // repository's declaration and the live config is what Railway is actually
   // filtering on; resolveServiceClosure unions them, because between a merged
   // registry edit and the audit's --apply each knows a path the other does not.
-  const registryByService = new Map(
-    JSON.parse(readFileSync(REGISTRY_URL, 'utf8')).map((entry) => [entry.service, entry]),
-  );
+  const registry = JSON.parse(readFileSync(REGISTRY_URL, 'utf8'));
+  const registryByService = new Map(registry.map((entry) => [entry.service, entry]));
   // The dedicated Viewer cannot see environment-variable values. Read only the
   // explicit source/build/deploy projection used by closure classification.
   assertRailwayCallCanStart('resolving the Railway environment id');
@@ -832,6 +837,18 @@ async function main() {
     includeActiveDeployments: true,
     deadlineAt: deepPassDeadlineAt,
   })).services;
+  const configurationDrift = auditDeploymentConfig
+    ? auditRailwayServiceConfig(
+        { services: liveById },
+        new Map(services.map((service) => [service.name, service.id])),
+        registry,
+        {
+          evaluateRequiredEnv: false,
+          requireMainTrigger: true,
+        },
+      )
+    : [];
+  if (auditDeploymentConfig && !asJson) printAudit(configurationDrift);
   const initialDeploymentsByService = new Map(
     Object.entries(liveById).map(([serviceId, config]) => [
       serviceId,
@@ -952,6 +969,10 @@ async function main() {
         capped: deepPass.capped,
         deadlineDeferred: deepPass.deadlineDeferred,
       },
+      configurationAudit: {
+        evaluated: auditDeploymentConfig,
+        drift: configurationDrift,
+      },
       summary,
       results,
     }, null, 2));
@@ -963,7 +984,7 @@ async function main() {
     }
     for (const service of summary.missing) console.error(`- ${service} [MISSING] was not positively classified`);
   } else printReport(results, summary, headSha, graceSha);
-  if (!summary.ok) process.exitCode = 1;
+  if (!summary.ok || configurationDrift.length > 0) process.exitCode = 1;
 }
 
 // realpath BOTH sides: Node sets import.meta.url to the realpath while argv[1]

--- a/tests/railway-deploy-drift-workflow.test.mjs
+++ b/tests/railway-deploy-drift-workflow.test.mjs
@@ -41,8 +41,8 @@ function gitRevision(revision) {
   return result.stdout.trim();
 }
 
-function fakeRailwayCli({ repoRoot: fixtureRoot, headSha, previousSha }) {
-  const { readFileSync: readFixture } = require('node:fs');
+function fakeRailwayCli({ repoRoot: fixtureRoot, headSha, previousSha, queryLog }) {
+  const { appendFileSync, readFileSync: readFixture } = require('node:fs');
 
   const repository = 'koala73/worldmonitor';
   const manifest = JSON.parse(readFixture(`${fixtureRoot}/scripts/railway-native-autodeploy-fleet.json`, 'utf8'));
@@ -128,6 +128,7 @@ function fakeRailwayCli({ repoRoot: fixtureRoot, headSha, previousSha }) {
     const query = args[1] ?? '';
     const variables = JSON.parse(argument('--variables'));
     if (query.includes('ViewerDeploymentConfig')) {
+      if (queryLog) appendFileSync(queryLog, 'ViewerDeploymentConfig\n');
       const service = servicesById.get(variables.serviceId);
       if (!service) {
         fail(`unknown service ${variables.serviceId}`);
@@ -153,6 +154,7 @@ function fakeRailwayCli({ repoRoot: fixtureRoot, headSha, previousSha }) {
         });
       }
     } else if (query.includes('FleetDeployments')) {
+      if (queryLog) appendFileSync(queryLog, 'FleetDeployments\n');
       writeJson({
         data: {
           deployments: {
@@ -190,14 +192,15 @@ function createProbeFixture() {
   const startedAtMs = Date.now();
   const fakeRailway = join(directory, 'railway');
   const fakeDate = join(directory, 'date');
+  const queryLog = join(directory, 'query-log');
   writeFileSync(
     fakeRailway,
-    `#!/usr/bin/env node\nconst fixture = ${JSON.stringify({ repoRoot, headSha, previousSha })};\n(${fakeRailwayCli.toString()})(fixture);\n`,
+    `#!/usr/bin/env node\nconst fixture = ${JSON.stringify({ repoRoot, headSha, previousSha, queryLog })};\n(${fakeRailwayCli.toString()})(fixture);\n`,
   );
   writeFileSync(fakeDate, `#!/bin/sh\nprintf '%s\\n' '${startedAtMs}'\n`);
   chmodSync(fakeRailway, 0o755);
   chmodSync(fakeDate, 0o755);
-  return { directory, headSha, startedAtMs };
+  return { directory, headSha, queryLog, startedAtMs };
 }
 
 function executeWorkflowShell(run, fixture, {
@@ -219,35 +222,33 @@ function executeWorkflowShell(run, fixture, {
       RAILWAY_API_TOKEN: mode,
       RAILWAY_PROJECT_ID: 'project-1',
       RAILWAY_COMPARISON_SHA: fixture.headSha,
-      RAILWAY_CONFIG_AUDIT_JOB_STARTED_AT_MS: String(startedAtMs),
       RAILWAY_DRIFT_JOB_STARTED_AT_MS: String(startedAtMs),
     },
   });
 }
 
-describe('Railway Deploy Drift workflow', () => {
-  it('is one hourly and manually dispatchable read-only workflow', () => {
-    assert.equal(workflow.name, 'Railway Deploy Drift');
-    assert.deepEqual(workflow.on.schedule, [{ cron: '17 * * * *' }]);
+describe('Railway Native Deploy Health workflow', () => {
+  it('is one six-hourly and manually dispatchable read-only workflow', () => {
+    assert.equal(workflow.name, 'Railway Native Deploy Health');
+    assert.deepEqual(workflow.on.schedule, [{ cron: '17 */6 * * *' }]);
     assert.ok(Object.hasOwn(workflow.on, 'workflow_dispatch'));
     assert.deepEqual(workflow.permissions, { contents: 'read' });
     assert.deepEqual(workflow.concurrency, {
-      group: 'railway-deploy-drift-${{ github.ref }}',
+      group: 'railway-native-deploy-health-${{ github.ref }}',
       'cancel-in-progress': true,
     });
   });
 
-  it('publishes independent config and deployment conclusions on main only', () => {
-    assert.deepEqual(Object.keys(workflow.jobs).sort(), ['config-audit', 'deploy-drift']);
-    for (const job of Object.values(workflow.jobs)) {
-      assert.equal(job.if, MAIN_GUARD);
-      assert.equal(job.needs, undefined);
-      assert.equal(job['continue-on-error'], undefined);
-      assert.deepEqual(job.environment, {
-        name: 'ingestion-acceptance-production',
-        deployment: false,
-      });
-    }
+  it('publishes one combined configuration and deployment conclusion on main only', () => {
+    assert.deepEqual(Object.keys(workflow.jobs), ['monitor']);
+    const job = workflow.jobs.monitor;
+    assert.equal(job.if, MAIN_GUARD);
+    assert.equal(job.needs, undefined);
+    assert.equal(job['continue-on-error'], undefined);
+    assert.deepEqual(job.environment, {
+      name: 'ingestion-acceptance-production',
+      deployment: false,
+    });
   });
 
   it('uses only the dedicated Viewer API token and never a mutation surface', () => {
@@ -270,86 +271,74 @@ describe('Railway Deploy Drift workflow', () => {
     assert.doesNotMatch(source, /gh\s+(?:workflow\s+run|api[^\n]*dispatch)|repository_dispatch|retry|recovery/i);
   });
 
-  it('runs the Viewer-compatible deployment projection without variable access', () => {
-    const audit = stepNamed(workflow.jobs['config-audit'], 'Audit Railway deployment configuration');
-    assert.match(
-      audit.run,
-      /node scripts\/audit-railway-watch-paths\.mjs --environment production --deployment-only --concurrency 4 --json/,
+  it('runs one Viewer-compatible combined probe without variable access', () => {
+    const check = stepNamed(
+      workflow.jobs.monitor,
+      'Check Railway deployment configuration and drift',
     );
-    assert.doesNotMatch(audit.run, /variable|environment config|--apply/i);
+    assert.match(
+      check.run,
+      /node scripts\/check-railway-deploy-drift\.mjs --head "\$RAILWAY_COMPARISON_SHA" --concurrency 2 --audit-deployment-config/,
+    );
+    assert.doesNotMatch(check.run, /variable|environment config|--apply/i);
+    assert.doesNotMatch(source, /audit-railway-watch-paths\.mjs/);
   });
 
-  it('starts and executes both run budgets before every prerequisite', () => {
+  it('starts and executes the run budget before every prerequisite', () => {
     const fixture = createProbeFixture();
     try {
-      for (const { jobName, stepName, variable } of [
-        {
-          jobName: 'config-audit',
-          stepName: 'Start config-audit run budget',
-          variable: 'RAILWAY_CONFIG_AUDIT_JOB_STARTED_AT_MS',
-        },
-        {
-          jobName: 'deploy-drift',
-          stepName: 'Start deploy-drift run budget',
-          variable: 'RAILWAY_DRIFT_JOB_STARTED_AT_MS',
-        },
-      ]) {
-        const job = workflow.jobs[jobName];
-        const budget = stepNamed(job, stepName);
-        const githubEnv = join(fixture.directory, `budget-env-${jobName}`);
-        assert.equal(steps(job).indexOf(budget), 0);
-        const result = executeWorkflowShell(budget.run, fixture, { githubEnv });
-        assert.equal(result.status, 0, result.stderr);
-        assert.equal(
-          readFileSync(githubEnv, 'utf8'),
-          `${variable}=${fixture.startedAtMs}\n`,
-        );
-      }
+      const job = workflow.jobs.monitor;
+      const budget = stepNamed(job, 'Start deploy-health run budget');
+      const githubEnv = join(fixture.directory, 'budget-env-monitor');
+      assert.equal(steps(job).indexOf(budget), 0);
+      const result = executeWorkflowShell(budget.run, fixture, { githubEnv });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(
+        readFileSync(githubEnv, 'utf8'),
+        `RAILWAY_DRIFT_JOB_STARTED_AT_MS=${fixture.startedAtMs}\n`,
+      );
     } finally {
       rmSync(fixture.directory, { recursive: true, force: true });
     }
   });
 
-  it('executes both production probes and preserves their fail-closed verdicts', () => {
-    const audit = stepNamed(
-      workflow.jobs['config-audit'],
-      'Audit Railway deployment configuration',
-    );
-    const drift = stepNamed(
-      workflow.jobs['deploy-drift'],
-      'Check Railway deploy drift against main',
+  it('reuses one Viewer projection and preserves both fail-closed verdicts', () => {
+    const check = stepNamed(
+      workflow.jobs.monitor,
+      'Check Railway deployment configuration and drift',
     );
     const fixture = createProbeFixture();
 
     try {
-      const healthyAudit = executeWorkflowShell(audit.run, fixture);
-      assert.equal(
-        healthyAudit.status,
-        0,
-        `healthy config audit failed\nstdout:\n${healthyAudit.stdout}\nstderr:\n${healthyAudit.stderr}`,
-      );
-      assert.match(healthyAudit.stdout, /"drift": \[\]/);
-
-      const healthyDrift = executeWorkflowShell(drift.run, fixture);
+      writeFileSync(fixture.queryLog, '');
+      const healthyDrift = executeWorkflowShell(check.run, fixture);
       assert.equal(
         healthyDrift.status,
         0,
         `healthy deploy drift failed\nstdout:\n${healthyDrift.stdout}\nstderr:\n${healthyDrift.stderr}`,
       );
+      assert.match(healthyDrift.stdout, /Railway operational-config audit passed/);
       assert.match(healthyDrift.stdout, /Every service this repository deploys is running/);
       assert.match(
         healthyDrift.stderr,
         /Read 80 service histories in 1 fleet page\(s\) \(80 records\), 0 direct fallback\(s\)\./,
       );
+      const queries = readFileSync(fixture.queryLog, 'utf8').trim().split('\n');
+      assert.equal(
+        queries.filter((query) => query === 'ViewerDeploymentConfig').length,
+        80,
+        'the config audit must reuse the deployment projection instead of reading 80 services twice',
+      );
+      assert.equal(queries.filter((query) => query === 'FleetDeployments').length, 1);
 
-      const projectedConfigDrift = executeWorkflowShell(audit.run, fixture, {
+      const projectedConfigDrift = executeWorkflowShell(check.run, fixture, {
         mode: 'config-drift',
       });
       assert.notEqual(projectedConfigDrift.status, 0);
-      assert.match(projectedConfigDrift.stdout, /"sourceBranch"/);
-      assert.match(projectedConfigDrift.stdout, /"actual": "feature\/drift"/);
+      assert.match(projectedConfigDrift.stderr, /source branch "feature\/drift" != "main"/);
+      assert.match(projectedConfigDrift.stdout, /Every service this repository deploys is running/);
 
-      const deploymentDrift = executeWorkflowShell(drift.run, fixture, {
+      const deploymentDrift = executeWorkflowShell(check.run, fixture, {
         mode: 'deploy-drift',
       });
       assert.notEqual(deploymentDrift.status, 0);
@@ -360,15 +349,7 @@ describe('Railway Deploy Drift workflow', () => {
   });
 
   it('freezes checkout head, fetches ancestry fatally, and passes the immutable target', () => {
-    const configCheckout = steps(workflow.jobs['config-audit'])
-      .find((step) => step.uses?.startsWith('actions/checkout@'));
-    assert.ok(configCheckout);
-    assert.equal(configCheckout.uses, 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10');
-    assert.equal(configCheckout.with?.['fetch-depth'], 1);
-    assert.equal(configCheckout.with?.filter, undefined);
-    assert.equal(configCheckout.with?.ref, undefined);
-
-    const drift = workflow.jobs['deploy-drift'];
+    const drift = workflow.jobs.monitor;
     const driftCheckout = steps(drift).find((step) => step.uses?.startsWith('actions/checkout@'));
     assert.ok(driftCheckout);
     assert.equal(driftCheckout.uses, 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10');
@@ -376,7 +357,7 @@ describe('Railway Deploy Drift workflow', () => {
     assert.equal(driftCheckout.with?.filter, 'blob:none');
     assert.equal(driftCheckout.with?.ref, undefined);
     const freeze = stepNamed(drift, 'Freeze comparison head and fetch main ancestry');
-    const check = stepNamed(drift, 'Check Railway deploy drift against main');
+    const check = stepNamed(drift, 'Check Railway deployment configuration and drift');
     assert.ok(steps(drift).indexOf(freeze) < steps(drift).indexOf(check));
     assert.match(freeze.run, /git rev-parse HEAD/);
     assert.match(freeze.run, /GITHUB_SHA/);
@@ -388,13 +369,14 @@ describe('Railway Deploy Drift workflow', () => {
     assert.doesNotMatch(freeze.run, /git fetch[^\n]*--depth|git fetch[^\n]*\|\|/);
     assert.doesNotMatch(freeze.run, /git checkout|git switch|git reset/);
     assert.match(check.run, /--head "\$RAILWAY_COMPARISON_SHA"/);
-    assert.match(check.run, /--concurrency 4/);
+    assert.match(check.run, /--concurrency 2/);
+    assert.match(check.run, /--audit-deployment-config/);
     assert.doesNotMatch(check.run, /\|\||continue-on-error/);
   });
 
   it('executes the frozen-head shell fail-closed on a mismatch or fetch failure', () => {
     const freeze = stepNamed(
-      workflow.jobs['deploy-drift'],
+      workflow.jobs.monitor,
       'Freeze comparison head and fetch main ancestry',
     );
     const directory = mkdtempSync(join(tmpdir(), 'railway-drift-freeze-'));


### PR DESCRIPTION
## Why

The hourly Railway Deploy Drift workflow ran two parallel 80-service Viewer projections. That created about 160 per-service GraphQL reads per tick, exhausted the rolling Railway allowance, and produced repeated HTTP 429 failures and All jobs have failed emails.

## What changed

- combine configuration and deployment checks into one fail-closed job
- reuse one Viewer projection for both conclusions
- lower service-read concurrency from four to two
- run at minute 17 every six hours instead of every hour
- keep manual dispatch, immutable main ancestry, Viewer-only credentials, and direct-red drift semantics
- document the quota incident and the new operating contract

The live workflow is intentionally disabled while the production checkSuites cutover and proof run are completed.

## Verification

- 805 Railway-focused tests passed
- workflow end-to-end contract proves 80 Viewer config reads and one fleet read, with zero duplicate projection
- markdownlint, Biome, Unicode, public-doc checks, API typecheck, and all pre-push gates passed