### PR TITLE
docs(mcp): drop delisted mcp.so registry mention

### DIFF
--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -30,7 +30,7 @@ Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pas
 
 Server identifier: `worldmonitor` v1.16.0.
 
-Registry listings: the server is published in the [official MCP registry](https://registry.modelcontextprotocol.io/v0/servers?search=worldmonitor) as `app.worldmonitor/mcp` — a domain-verified namespace, so clients that resolve servers through the registry get the same endpoint and metadata as the server card above — and listed on [Smithery](https://smithery.ai/servers/worldmonitor/wm-mcp) and [mcp.so](https://mcp.so/server/world-monitor).
+Registry listings: the server is published in the [official MCP registry](https://registry.modelcontextprotocol.io/v0/servers?search=worldmonitor) as `app.worldmonitor/mcp` — a domain-verified namespace, so clients that resolve servers through the registry get the same endpoint and metadata as the server card above — and listed on [Smithery](https://smithery.ai/servers/worldmonitor/wm-mcp).
 
 ### Protocol negotiation
 

--- a/docs/zh/mcp-overview.mdx
+++ b/docs/zh/mcp-overview.mdx
@@ -30,7 +30,7 @@ Pro 订阅者无需粘贴任何 API key 即可接入 Claude Desktop / Cursor / c
 
 服务器标识：`worldmonitor` v1.16.0。
 
-注册表登记：该服务器以 `app.worldmonitor/mcp` 之名发布于[官方 MCP 注册表](https://registry.modelcontextprotocol.io/v0/servers?search=worldmonitor) —— 这是一个经过域名验证的命名空间，因此通过注册表解析服务器的客户端获得的端点和元数据与上方的服务器卡片一致 —— 并在 [Smithery](https://smithery.ai/servers/worldmonitor/wm-mcp) 和 [mcp.so](https://mcp.so/server/world-monitor) 上列出。
+注册表登记：该服务器以 `app.worldmonitor/mcp` 之名发布于[官方 MCP 注册表](https://registry.modelcontextprotocol.io/v0/servers?search=worldmonitor) —— 这是一个经过域名验证的命名空间，因此通过注册表解析服务器的客户端获得的端点和元数据与上方的服务器卡片一致 —— 并在 [Smithery](https://smithery.ai/servers/worldmonitor/wm-mcp) 上列出。
 
 ### 协议协商
 


### PR DESCRIPTION
The MCP overview page (en + zh) says the server is listed on Smithery and mcp.so. The mcp.so listing page (https://mcp.so/server/world-monitor) now returns 404 - the server has been delisted from that directory (both the dashed and plain slug variants are gone while the mcp.so site itself is up). The Smithery listing is still live and verified. This PR removes only the dead mcp.so mention from both language versions.