### PR TITLE
fix(seeders): bound Resilience-Scores laggard warm-up with an aggregate budget

### DIFF
--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -94,6 +94,56 @@ const INTERVAL_SOURCE_VERSION = `resilience-intervals:${INTERVAL_KEY_PREFIX}${IN
 const INTERVAL_META_KEY = 'seed-meta:resilience:intervals';
 export const RESILIENCE_INTERVAL_MIN_RECORD_COUNT = 180;
 export const RESILIENCE_INTERVAL_PROBE_COUNTRY_CODE = 'US';
+
+// #6562 item 3: the laggard warm-up phase previously had no aggregate
+// deadline — batches of 5 countries at a 30s per-request timeout over up to
+// 196 countries is ~20 min worst case, longer than any timeout that fits the
+// 240s Resilience-Scores section cap. This wall budget bounds the phase with
+// headroom below the section timeout so a degraded run stops warming and
+// still publishes the ranking + intervals for what did warm, instead of
+// being SIGTERM'd mid-warm and publishing nothing.
+export const LAGGARD_WARMUP_BUDGET_MS = 150_000;
+export const LAGGARD_WARMUP_BATCH_SIZE = 5;
+
+// Individual warm-up for countries the bulk ranking warm path timed out on.
+// Bounded by LAGGARD_WARMUP_BUDGET_MS so the phase cannot outlive the section
+// timeout; on exhaustion it stops early and the caller still publishes the
+// ranking aggregate and intervals for whatever did warm (#6562 item 3).
+export async function warmLaggardCountries(stillMissing, {
+  apiKey,
+  budgetMs = LAGGARD_WARMUP_BUDGET_MS,
+  batchSize = LAGGARD_WARMUP_BATCH_SIZE,
+  apiBase = API_BASE,
+  fetchImpl = (u, i) => globalThis.fetch(u, i),
+} = {}) {
+  if (stillMissing.length === 0) return 0;
+  if (!apiKey) {
+    console.warn(`[resilience-scores] ${stillMissing.length} laggards found but neither WORLDMONITOR_API_KEY nor WORLDMONITOR_VALID_KEYS is set — skipping individual warmup`);
+    return 0;
+  }
+  console.log(`[resilience-scores] Warming ${stillMissing.length} laggards individually...`);
+  const deadline = Date.now() + budgetMs;
+  let warmed = 0;
+  for (let i = 0; i < stillMissing.length; i += batchSize) {
+    if (Date.now() > deadline) {
+      console.warn(`[resilience-scores] Laggard warmup budget exhausted after ${warmed}/${stillMissing.length} — continuing with partial warmup so the ranking and intervals still publish (#6562 item 3)`);
+      break;
+    }
+    const batch = stillMissing.slice(i, i + batchSize);
+    const results = await Promise.allSettled(batch.map(async (cc) => {
+      const scoreUrl = `${apiBase}/api/resilience/v1/get-resilience-score?countryCode=${cc}`;
+      const resp = await fetchImpl(scoreUrl, {
+        headers: { 'User-Agent': SEED_UA, 'Accept': 'application/json', 'X-WorldMonitor-Key': apiKey },
+        signal: AbortSignal.timeout(30_000),
+      });
+      if (!resp.ok) throw new Error(`${cc}: HTTP ${resp.status}`);
+      return cc;
+    }));
+    warmed += results.filter((r) => r.status === 'fulfilled').length;
+  }
+  console.log(`[resilience-scores] Laggards warmed: ${warmed}/${stillMissing.length}`);
+  return warmed;
+}
 export { computeIntervals };
 
 function isKnownScoreFormulaTag(value) {
@@ -526,29 +576,9 @@ export async function seedResilienceScores({ runtimeCacheState = fetchRuntimeCac
       if (parseCachedScorePayload(raw, expectedCacheState) == null) stillMissing.push(countryCodes[i]);
     }
 
-    // Warm laggards individually (countries the bulk ranking timed out on)
-    if (stillMissing.length > 0 && !WM_KEY) {
-      console.warn(`[resilience-scores] ${stillMissing.length} laggards found but neither WORLDMONITOR_API_KEY nor WORLDMONITOR_VALID_KEYS is set — skipping individual warmup`);
-    }
-    let laggardsWarmed = 0;
-    if (stillMissing.length > 0 && WM_KEY) {
-      console.log(`[resilience-scores] Warming ${stillMissing.length} laggards individually...`);
-      const BATCH = 5;
-      for (let i = 0; i < stillMissing.length; i += BATCH) {
-        const batch = stillMissing.slice(i, i + BATCH);
-        const results = await Promise.allSettled(batch.map(async (cc) => {
-          const scoreUrl = `${API_BASE}/api/resilience/v1/get-resilience-score?countryCode=${cc}`;
-          const resp = await fetch(scoreUrl, {
-            headers: { 'User-Agent': SEED_UA, 'Accept': 'application/json', 'X-WorldMonitor-Key': WM_KEY },
-            signal: AbortSignal.timeout(30_000),
-          });
-          if (!resp.ok) throw new Error(`${cc}: HTTP ${resp.status}`);
-          return cc;
-        }));
-        laggardsWarmed += results.filter(r => r.status === 'fulfilled').length;
-      }
-      console.log(`[resilience-scores] Laggards warmed: ${laggardsWarmed}/${stillMissing.length}`);
-    }
+    // Warm laggards individually (countries the bulk ranking timed out on).
+    // The phase is bounded by LAGGARD_WARMUP_BUDGET_MS — see #6562 item 3.
+    const laggardsWarmed = await warmLaggardCountries(stillMissing, { apiKey: WM_KEY });
 
     const rankingPresent = await refreshRankingAggregate({ url, token, laggardsWarmed });
     // refresh=1 rotates every per-country score, not only the ranking aggregate.

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -21,6 +21,8 @@ import {
   fetchRuntimeCacheState,
   parseCachedScorePayload,
   seedResilienceScores,
+  warmLaggardCountries,
+  LAGGARD_WARMUP_BUDGET_MS,
 } from '../scripts/seed-resilience-scores.mjs';
 
 const D6_DOMAINS = [
@@ -1103,5 +1105,74 @@ describe('handler warm pipeline is chunked', () => {
       /for\s*\([^)]*i\s*\+=\s*SET_BATCH/,
       'pipeline SETs must be issued in SET_BATCH-sized chunks',
     );
+  });
+});
+
+describe('laggard warmup aggregate budget (#6562 item 3)', () => {
+  it('LAGGARD_WARMUP_BUDGET_MS stays below the 240s Resilience-Scores section timeout', () => {
+    assert.ok(
+      LAGGARD_WARMUP_BUDGET_MS < 240_000,
+      `budget ${LAGGARD_WARMUP_BUDGET_MS}ms must leave headroom below the 240s section cap`,
+    );
+  });
+
+  it('stops warming once the budget is exhausted and reports the partial count', async () => {
+    const stillMissing = Array.from({ length: 12 }, (_, i) => `C${String(i).padStart(2, '0')}`);
+    const fetched = [];
+    const fetchImpl = async (url) => {
+      fetched.push(String(url));
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      return new Response('{}', { status: 200 });
+    };
+    const warmed = await warmLaggardCountries(stillMissing, {
+      apiKey: 'test-key',
+      budgetMs: 1,
+      batchSize: 5,
+      fetchImpl,
+    });
+    assert.equal(fetched.length, 5, 'only the first batch may start before the deadline trips');
+    assert.equal(warmed, 5);
+  });
+
+  it('warms every laggard when the budget holds', async () => {
+    const stillMissing = ['US', 'FR', 'DE', 'JP', 'KR', 'BR'];
+    const fetched = [];
+    const fetchImpl = async (url) => {
+      fetched.push(String(url));
+      return new Response('{}', { status: 200 });
+    };
+    const warmed = await warmLaggardCountries(stillMissing, {
+      apiKey: 'test-key',
+      budgetMs: 10_000,
+      batchSize: 5,
+      fetchImpl,
+    });
+    assert.equal(fetched.length, stillMissing.length);
+    assert.equal(warmed, stillMissing.length);
+  });
+
+  it('skips warmup without an API key and fetches nothing', async () => {
+    const warmed = await warmLaggardCountries(['US'], {
+      apiKey: null,
+      fetchImpl: async () => {
+        throw new Error('must not fetch without an API key');
+      },
+    });
+    assert.equal(warmed, 0);
+  });
+
+  it('counts only fulfilled requests toward the warmed total', async () => {
+    const fetchImpl = async (url) => {
+      const cc = new URL(String(url)).searchParams.get('countryCode');
+      if (cc === 'FR') return new Response('{}', { status: 503 });
+      return new Response('{}', { status: 200 });
+    };
+    const warmed = await warmLaggardCountries(['US', 'FR', 'DE'], {
+      apiKey: 'test-key',
+      budgetMs: 10_000,
+      batchSize: 5,
+      fetchImpl,
+    });
+    assert.equal(warmed, 2);
   });
 });


### PR DESCRIPTION
## Summary

- extract the individual laggard warm-up into `warmLaggardCountries` and give it a wall budget (`LAGGARD_WARMUP_BUDGET_MS = 150_000`), mirroring the `FAOSTAT_STAGE_BUDGET_MS` pattern from `seed-food-stocks.mjs`
- on budget exhaustion the loop stops warming and logs a warning, and the seeder still publishes the ranking aggregate and intervals for whatever did warm
- cover budget exhaustion, full warm-up, missing API key, and partial fulfillment with focused unit tests

Refs #6562 (item 3 only).

## Type of change

- [x] Bug fix

## Root cause and compatibility

Batches of 5 countries at a 30s per-request timeout over up to 196 countries is ~20 minutes worst case - longer than any timeout that fits the 240s `Resilience-Scores` section cap, so a degraded laggard phase was only ever bounded by being killed mid-warm, publishing nothing. The 150s budget leaves ~90s headroom below the section timeout for the ranking refresh and interval publication that follow. Behavior when the budget holds, when no API key is configured, and batch semantics (size 5, `Promise.allSettled`, 30s per-request timeout) are unchanged; countries skipped by an exhausted budget simply stay cold and are retried by the next 2h cron tick instead of the run dying with no output.

## Validation

- `node --test tests/resilience-scores-seed.test.mjs` - 63 passed (58 existing + 5 new)
- `node --test tests/resilience-static-seed.test.mjs tests/seed-bundle-resilience-recovery.test.mjs tests/resilience-static-sigterm-lock.test.mjs` - 64 passed
- `node --check scripts/seed-resilience-scores.mjs`
- `git diff --check`
- biome could not run in the sandbox (no node_modules in the sparse checkout); CI lint will cover it

## Checklist

- [x] No API keys or secrets committed
- [x] Targeted focused tests pass
- [x] RSS / Railway pre-seed checklist items are not applicable (no key, schedule, health target, or service change)

## AI-assisted development disclosure

ZCode assisted with reading #6562, implementing the budget, and writing the regressions. I reviewed the final diff, ran the validation above, and take responsibility for the submitted change.