### PR TITLE
fix(i18n): the zh-TW consumers, and the round-2 guard follow-ups

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "desktop:check-rust-floors": "node scripts/check-rust-security-floors.mjs",
     "sync:locales": "node scripts/sync-locale-keys.mjs",
     "sync:locales:check": "node scripts/sync-locale-keys.mjs --check",
+    "locales:zh-tw": "python3 scripts/convert-zh-tw.py",
+    "locales:zh-tw:check": "python3 scripts/convert-zh-tw.py --check",
     "sync:bootstrap-tier-keys": "node scripts/sync-bootstrap-tier-keys.mjs",
     "sync:bootstrap-tier-keys:check": "node scripts/sync-bootstrap-tier-keys.mjs --check",
     "sandbox:fixtures": "node scripts/generate-sandbox-fixtures.mjs",

--- a/scripts/convert-zh-tw.py
+++ b/scripts/convert-zh-tw.py
@@ -24,16 +24,26 @@ Why Python rather than `opencc-js`:
 Two kinds of override, because two kinds of error:
     PHRASE_OVERRIDES  Applied to every value. Only for terms whose replacement
                       is unconditional in this product's vocabulary.
-    KEY_OVERRIDES     Applied to one catalogue entry, before the phrase rules,
-                      so an entry can opt out of a global rule. Needed where the
+    KEY_OVERRIDES     Applied to one catalogue entry BEFORE the phrase rules,
+                      which pre-empts them: the per-entry rule rewrites the
+                      substring first, so the global rule finds nothing left to
+                      match. It is not an opt-out flag — there is no way to say
+                      "skip the global rule here", only to spell out the
+                      replacement this entry wants instead, and that replacement
+                      must not itself contain a phrase-rule source or the global
+                      rule would fire on it anyway (asserted in
+                      tests/i18n-zh-tw-catalogue.test.mts). Needed where the
                       correct Traditional form depends on the sentence: `訪問` is
                       both "access" (存取) and "visit" (造訪), and only the string
                       itself says which.
 
 Usage:
-    pip install opencc-python-reimplemented
+    pip install opencc-python-reimplemented==0.1.7
     python3 scripts/convert-zh-tw.py            # rewrite both catalogues
     python3 scripts/convert-zh-tw.py --check    # exit 1 if either is stale
+
+    npm run locales:zh-tw                       # the same two, as repo scripts
+    npm run locales:zh-tw:check
 
 Output is byte-identical to the committed catalogues, so `--check` is a real
 staleness gate rather than a formatting diff. Verified against
@@ -43,6 +53,7 @@ no override pins, which `--check` will surface.
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -147,8 +158,31 @@ def render(data) -> str:
     return json.dumps(data, ensure_ascii=False, indent=2) + "\n"
 
 
-def main() -> int:
-    check_only = "--check" in sys.argv[1:]
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse the command line, rejecting anything not defined here.
+
+    Membership tests over `sys.argv` accept typos silently: `--chek` was not
+    `--check`, so the script took the write path, rewrote both catalogues and
+    exited 0 — a staleness gate turning into a writer on a one-character slip,
+    reported as success. argparse exits 2 on an unrecognised argument instead.
+    """
+    parser = argparse.ArgumentParser(
+        prog="scripts/convert-zh-tw.py",
+        description=(
+            "Regenerate the Traditional Chinese catalogues from the Simplified "
+            "ones with OpenCC s2twp plus the Taiwan phrasing overrides."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="write nothing; exit 1 if either catalogue differs from this script's output",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    check_only = parse_args(argv).check
     converter = OpenCC("s2twp")
     stale = []
 

--- a/scripts/sync-locale-keys.mjs
+++ b/scripts/sync-locale-keys.mjs
@@ -5,6 +5,13 @@
  * Existing translations are preserved. Missing keys are copied from English
  * so all locales share the same key structure (i18next still falls back to en).
  *
+ * Generated catalogues are the exception. `zh-TW.json` is converted from
+ * `zh.json` by scripts/convert-zh-tw.py, not translated from en.json, so an
+ * English literal written here is both wrong for the file and temporary: the
+ * next generator run overwrites it, and `convert-zh-tw.py --check` fails on it
+ * in the meantime. Their key gaps are still reported and counted — they are
+ * real, and the generator is what closes them.
+ *
  * Usage:
  *   node scripts/sync-locale-keys.mjs          # write updates
  *   node scripts/sync-locale-keys.mjs --check    # exit 1 if any locale is out of sync
@@ -15,11 +22,16 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { flattenKeys } from './_locale-keys.mjs';
+// Imported rather than restated: this file would otherwise be a third place
+// that has to be told zh-TW is generated, after translate-locales.mjs and the
+// catalogue test.
+import { GENERATED_LOCALES } from './translate-locales.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LOCALES_DIR = join(__dirname, '..', 'src', 'locales');
 const EN_PATH = join(LOCALES_DIR, 'en.json');
 const CHECK_ONLY = process.argv.includes('--check');
+const GENERATED_HINT = 'Run: npm run locales:zh-tw';
 // Shell bundles (*.shell.json) are intentionally partial first-paint resources, not full locales.
 
 /**
@@ -100,10 +112,12 @@ function main() {
     .sort();
 
   let totalMissing = 0;
+  let generatedMissing = 0;
   let outOfSync = false;
 
   for (const file of localeFiles) {
     const path = join(LOCALES_DIR, file);
+    const localeCode = file.replace(/\.json$/, '');
     const locale = readJson(path, file);
     const localeKeys = new Set(flattenKeys(locale));
     const missing = [...enKeys].filter((key) => !localeKeys.has(key));
@@ -115,6 +129,17 @@ function main() {
 
     outOfSync = true;
     totalMissing += missing.length;
+
+    // Reported and counted, never written — see the header. Writing English
+    // here would also make the failure self-inflicted: the next
+    // `convert-zh-tw.py --check` compares against zh.json and finds the
+    // placeholder, so the fix for a sync run would be another regeneration.
+    if (GENERATED_LOCALES.has(localeCode)) {
+      generatedMissing += missing.length;
+      console.log(`${file}: missing ${missing.length} key(s) — generated, not written here (${GENERATED_HINT})`);
+      continue;
+    }
+
     console.log(`${file}: missing ${missing.length} key(s)`);
 
     if (!CHECK_ONLY) {
@@ -126,6 +151,9 @@ function main() {
   if (CHECK_ONLY) {
     if (outOfSync) {
       console.error(`\nLocale files are missing ${totalMissing} key(s) total. Run: npm run sync:locales`);
+      if (generatedMissing > 0) {
+        console.error(`${generatedMissing} of those are in generated catalogues, which that command does not write. ${GENERATED_HINT}`);
+      }
       process.exit(1);
     }
     console.log(`All ${localeFiles.length} locale files match en.json (${enKeys.size} keys each).`);
@@ -137,7 +165,12 @@ function main() {
     return;
   }
 
-  console.log(`\nSynced ${totalMissing} missing key(s) across ${localeFiles.length} locale files.`);
+  console.log(
+    `\nSynced ${totalMissing - generatedMissing} missing key(s) across ${localeFiles.length} locale files.`,
+  );
+  if (generatedMissing > 0) {
+    console.log(`${generatedMissing} key(s) are in generated catalogues and were left alone. ${GENERATED_HINT}`);
+  }
 }
 
 // Run only when invoked directly (importing this file must not read/write files).

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -7,7 +7,7 @@ import { escapeHtml, sanitizeUrl, unsafeRawHtml } from '@/utils/sanitize';
 import { computeNewSinceVisit } from '@/utils/new-since-visit';
 import { analysisWorker, enrichWithVelocityML, getClusterAssetContext, MAX_DISTANCE_KM, activityTracker, generateSummary, translateText, preloadRelatedAssetTables } from '@/services';
 import { SITE_VARIANT } from '@/config';
-import { t, getCurrentLanguage } from '@/services/i18n';
+import { t, getCurrentLanguage, getCurrentLanguageTag } from '@/services/i18n';
 import { track } from '@/services/analytics';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import {
@@ -259,7 +259,11 @@ export class NewsPanel extends Panel {
     if (this.currentHeadlines.length === 0) return;
 
     // Check cache first (include variant, version, and language)
-    const currentLang = getCurrentLanguage();
+    // The full tag, not the stripped code: this is the language the model is
+    // asked to WRITE in, and a Traditional reader asking for `zh` gets
+    // Simplified prose back. It keys the cache too, so the two scripts cannot
+    // serve each other's summary.
+    const currentLang = getCurrentLanguageTag();
     const cacheKey = `panel_summary_v3_${SITE_VARIANT}_${this.panelId}_${currentLang}`;
     const cached = this.getCachedSummary(cacheKey);
     if (cached) {
@@ -310,7 +314,10 @@ export class NewsPanel extends Panel {
   }
 
   private async handleTranslate(element: HTMLElement, text: string): Promise<void> {
-    const currentLang = getCurrentLanguage();
+    // Target language for the translation, so the full tag — same reason as
+    // handleSummarize above. The `en` short-circuit is unaffected: no tag that
+    // resolves to a Chinese catalogue equals 'en'.
+    const currentLang = getCurrentLanguageTag();
     if (currentLang === 'en') return; // Assume news is mostly English, no need to translate if UI is English (or add detection later)
 
     const titleEl = element.closest('.item')?.querySelector('.item-title') as HTMLElement;

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -1,7 +1,7 @@
 import type { MapLayers } from '@/types';
 import { CURATED_COUNTRIES } from '@/config/countries';
 // boundary-ignore: commands are built lazily at runtime via getAllCommands()
-import { getCurrentLanguage, t } from '@/services/i18n';
+import { getCurrentLanguage, getCurrentLanguageTag, t } from '@/services/i18n';
 import { toFlagEmoji } from '@/utils/country-flag';
 
 export interface Command {
@@ -344,7 +344,12 @@ function injectLocalizedKeywords(commands: Command[]): Command[] {
 }
 
 function buildCountryCommands(): Command[] {
-  const lang = getCurrentLanguage();
+  // Script-sensitive, so the full tag: Intl.DisplayNames renders `zh` as
+  // Simplified — 美国, and 韩国 where Traditional readers say 南韓, a different
+  // word rather than a different character. The memo key reads the same
+  // accessor on purpose; keying it on the stripped code would let whichever
+  // catalogue built first answer for both.
+  const lang = getCurrentLanguageTag();
   if (lang === _cachedLang && _cachedCountryCommands.length > 0) {
     return _cachedCountryCommands;
   }

--- a/src/shared/language-tags.ts
+++ b/src/shared/language-tags.ts
@@ -11,32 +11,59 @@
  */
 
 /**
- * Traditional-Chinese tags, matched before the region suffix is stripped.
+ * Regions whose Chinese is written in Traditional script.
  *
- * `zh-TW`/`zh-HK`/`zh-Hant` would otherwise collapse to `zh` and serve the
- * Simplified dictionary to readers who asked for Traditional (#6546).
+ * Only consulted when the tag carries no script subtag: an explicit `Hans`
+ * outranks the region, so `zh-Hans-TW` stays Simplified.
  */
-export const TRADITIONAL_CHINESE_TAGS: ReadonlySet<string> = new Set([
-  'zh-tw',
-  'zh-hk',
-  'zh-mo',
-  'zh-hant',
-]);
+const TRADITIONAL_CHINESE_REGIONS: ReadonlySet<string> = new Set(['tw', 'hk', 'mo']);
+
+/**
+ * Split a tag into the two subtags that decide Chinese script, stopping at the
+ * first singleton.
+ *
+ * A singleton (`-u-`, `-x-`) opens an extension, and what follows it is not
+ * language data: `zh-TW-u-ca-chinese` carries a two-letter `ca` that reads as a
+ * region if the walk does not stop. Length is what separates the fields — four
+ * letters is a script, two letters or three digits is a region — so the walk
+ * does not depend on position, and `zh-Hant-TW` and `zh-TW` both parse.
+ */
+function parseSubtags(subtags: readonly string[]): { script: string; region: string } {
+  let script = '';
+  let region = '';
+
+  for (const subtag of subtags) {
+    if (subtag.length === 1) break;
+    if (!script && subtag.length === 4) script = subtag;
+    else if (!region && (subtag.length === 2 || subtag.length === 3)) region = subtag;
+  }
+
+  return { script, region };
+}
 
 /**
  * Resolve a browser/user language tag to a catalogue code.
  *
  * Returns `zh-TW` for Traditional tags, the base subtag for anything else the
- * catalogue supports, and `en` otherwise. The match must stay narrow: `zh-SG`
- * and `zh-Hans-*` are Simplified and have to keep resolving to `zh`, which is
- * why this tests explicit tags plus the `zh-hant` prefix rather than treating
- * every regioned `zh` as Traditional.
+ * catalogue supports, and `en` otherwise. The Traditional match must stay
+ * narrow: `zh-SG` and `zh-Hans-*` are Simplified and have to keep resolving to
+ * `zh`, which is why this reads the script and region subtags rather than
+ * treating every regioned `zh` as Traditional.
+ *
+ * `_` is folded to `-` first. `zh_TW` is not valid BCP-47 and no browser emits
+ * it, but it is the POSIX locale spelling, so it arrives from stored
+ * preferences and hand-written config rather than from `navigator.language`.
  */
 export function resolveLanguageTag(lng: string, supported: ReadonlySet<string>): string {
-  const tag = (lng || 'en').toLowerCase();
-  if (TRADITIONAL_CHINESE_TAGS.has(tag) || tag.startsWith('zh-hant')) {
-    return 'zh-TW';
+  const tag = (lng || 'en').toLowerCase().replace(/_/g, '-');
+  const subtags = tag.split('-');
+  const base = subtags[0] || 'en';
+
+  if (base === 'zh') {
+    const { script, region } = parseSubtags(subtags.slice(1));
+    if (script === 'hant') return 'zh-TW';
+    if (!script && TRADITIONAL_CHINESE_REGIONS.has(region)) return 'zh-TW';
   }
-  const base = tag.split('-')[0] || 'en';
+
   return supported.has(base) ? base : 'en';
 }

--- a/src/utils/map-locale.ts
+++ b/src/utils/map-locale.ts
@@ -1,31 +1,50 @@
-import { getCurrentLanguage } from '@/services/i18n';
+import { getCurrentLanguageTag } from '@/services/i18n';
 
-const LANG_TO_TILE_FIELD: Record<string, string> = {
-  en: 'name:en',
-  bg: 'name:bg',
-  cs: 'name:cs',
-  fr: 'name:fr',
-  de: 'name:de',
-  el: 'name:el',
-  es: 'name:es',
-  hr: 'name:hr',
-  hu: 'name:hu',
-  it: 'name:it',
-  pl: 'name:pl',
-  pt: 'name:pt',
-  nl: 'name:nl',
-  sv: 'name:sv',
-  ru: 'name:ru',
-  uk: 'name:uk',
-  ar: 'name:ar',
-  zh: 'name:zh',
-  ja: 'name:ja',
-  ko: 'name:ko',
-  ro: 'name:ro',
-  tr: 'name:tr',
-  th: 'name:th',
-  hi: 'name:hi',
-  // vi — not available in Protomaps/OSM tiles
+/**
+ * Tile name fields to try, in order, per catalogue language.
+ *
+ * One entry each, except Chinese: it is the only language where the three tile
+ * sources this app can load disagree on the field name. Measured against the
+ * live sources on 2026-08-14 (`vector_layers[].fields` of each TileJSON, and a
+ * z10 tile decoded for Taipei, Beijing and Hong Kong):
+ *
+ *   Protomaps (the default basemap)  name:zh-Hans, name:zh-Hant — no `name:zh`
+ *   OpenFreeMap (the fallback style) all three
+ *   CARTO                            name:zh only
+ *
+ * So both scripts list their script-tagged field first and `name:zh` second,
+ * which is the only Chinese field CARTO carries. For a Traditional reader that
+ * second hop is Chinese of unknown script rather than the English the coalesce
+ * would otherwise fall to, which is the better of the two.
+ */
+const LANG_TO_TILE_FIELDS: Record<string, readonly string[]> = {
+  en: ['name:en'],
+  bg: ['name:bg'],
+  cs: ['name:cs'],
+  fr: ['name:fr'],
+  de: ['name:de'],
+  el: ['name:el'],
+  es: ['name:es'],
+  hr: ['name:hr'],
+  hu: ['name:hu'],
+  it: ['name:it'],
+  pl: ['name:pl'],
+  pt: ['name:pt'],
+  nl: ['name:nl'],
+  sv: ['name:sv'],
+  ru: ['name:ru'],
+  uk: ['name:uk'],
+  ar: ['name:ar'],
+  zh: ['name:zh-Hans', 'name:zh'],
+  'zh-TW': ['name:zh-Hant', 'name:zh'],
+  ja: ['name:ja'],
+  ko: ['name:ko'],
+  ro: ['name:ro'],
+  tr: ['name:tr'],
+  th: ['name:th'],
+  hi: ['name:hi'],
+  // vi — absent from CARTO. Protomaps and OpenFreeMap both carry name:vi, so
+  // this row is addable; left alone here as it is not part of the zh-TW fix.
 };
 
 type Expression = [string, ...unknown[]];
@@ -45,19 +64,28 @@ interface LocalizableMap {
   setLayoutProperty?: (layerId: string, property: 'text-field', value: Expression) => void;
 }
 
-export function getLocalizedNameField(lang?: string): string {
-  const code = lang ?? getCurrentLanguage();
-  return LANG_TO_TILE_FIELD[code] ?? 'name:en';
+const ENGLISH_ONLY: readonly string[] = ['name:en'];
+
+/**
+ * Tile fields for a language, most specific first.
+ *
+ * Reads the full tag rather than the stripped code: the table is keyed by
+ * catalogue language, and `zh-TW` collapsed to `zh` can only ever find the
+ * Simplified row.
+ */
+export function getLocalizedNameFields(lang?: string): readonly string[] {
+  const code = lang ?? getCurrentLanguageTag();
+  return LANG_TO_TILE_FIELDS[code] ?? ENGLISH_ONLY;
 }
 
 export function getLocalizedNameExpression(lang?: string): Expression {
-  const field = getLocalizedNameField(lang);
+  const fields = getLocalizedNameFields(lang);
 
-  if (field === 'name:en') {
+  if (fields[0] === 'name:en') {
     return ['coalesce', ['get', 'name:en'], ['get', 'name']];
   }
 
-  return ['coalesce', ['get', field], ['get', 'name:en'], ['get', 'name']];
+  return ['coalesce', ...fields.map((field) => ['get', field]), ['get', 'name:en'], ['get', 'name']];
 }
 
 export function isLocalizableTextField(textField: unknown): boolean {

--- a/tests/dom/helpers/i18n.mts
+++ b/tests/dom/helpers/i18n.mts
@@ -12,6 +12,8 @@
 import i18next from 'i18next';
 
 import en from '@/locales/en.json';
+import zhHans from '@/locales/zh.json';
+import zhHant from '@/locales/zh-TW.json';
 
 /**
  * Initialise the i18next singleton with the real English dictionary.
@@ -42,4 +44,42 @@ export async function initTestI18n(): Promise<void> {
 /** Translate through the same singleton the components use. */
 export function tt(key: string, options?: Record<string, unknown>): string {
   return i18next.t(key, options);
+}
+
+/**
+ * Point the singleton at one of the two Chinese catalogues, switchable.
+ *
+ * Separate from `initTestI18n()` because the zh-TW behavioural tests are all
+ * COMPARISONS between the two scripts — asserting one in isolation cannot tell
+ * a working fix from a hardcoded string. Both dictionaries are registered up
+ * front so the switch is synchronous from the caller's point of view.
+ *
+ * Verifies the language actually took, and that its dictionary resolved: a tag
+ * silently collapsing `zh-TW` to `zh` is the exact bug class these tests exist
+ * to catch, so it must not be able to hide inside the harness.
+ */
+export async function useChineseCatalogue(lng: 'zh' | 'zh-TW'): Promise<void> {
+  if (!i18next.isInitialized) {
+    await i18next.init({
+      lng,
+      fallbackLng: 'en',
+      supportedLngs: ['zh', 'zh-TW', 'en'],
+      resources: {
+        zh: { translation: zhHans as Record<string, unknown> },
+        'zh-TW': { translation: zhHant as Record<string, unknown> },
+      },
+      interpolation: { escapeValue: false },
+    });
+  } else {
+    await i18next.changeLanguage(lng);
+  }
+
+  if (i18next.language !== lng) {
+    throw new Error(`[dom-harness] asked for ${lng}, i18next reports ${i18next.language}`);
+  }
+
+  const probe = i18next.t('preferences.display');
+  if (typeof probe !== 'string' || probe.length === 0 || probe === 'preferences.display') {
+    throw new Error(`[dom-harness] ${lng} dictionary did not load — t() returned ${String(probe)}`);
+  }
 }

--- a/tests/dom/i18n-zh-tw-behaviour.test.mts
+++ b/tests/dom/i18n-zh-tw-behaviour.test.mts
@@ -1,0 +1,190 @@
+/**
+ * Follow-up 5 from the #6561 review — the behavioural half of the zh-TW work
+ * had no test.
+ *
+ * `tests/i18n-language-tag-resolution.test.mts` covers `resolveLanguageTag`,
+ * which is the resolver BENEATH these call sites, not the call sites
+ * themselves. Nothing asserted what a Traditional reader actually receives from
+ * the places that read the resolved tag: how dates and numbers format
+ * (`getLocale`), what a relative timestamp says (`formatTime`), and which entry
+ * the language picker marks as selected. Two more callers move onto the same
+ * accessor in this PR — `Intl.DisplayNames` country names in the command
+ * palette, which also memoises on the tag — so they are covered here too.
+ *
+ * This needs the Vite pipeline rather than `node --test`: `@/services/i18n`
+ * evaluates `import.meta.glob` at load. The switchable Chinese harness lives
+ * next to the English one in `tests/dom/helpers/i18n.mts`, since every
+ * assertion here is a COMPARISON between the two catalogues.
+ *
+ * The Simplified rows are the ones that fail if the accessor swap goes too far
+ * — every one of these fixes is wrong in the other direction as well.
+ */
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { getAllCommands } from '@/config/commands';
+import { getCurrentLanguage, getCurrentLanguageTag, getLocale } from '@/services/i18n';
+import { renderPreferences } from '@/services/preferences-content';
+import { formatTime } from '@/utils';
+import { getLocalizedNameExpression } from '@/utils/map-locale';
+
+import { useChineseCatalogue as useLanguage } from './helpers/i18n.mts';
+
+beforeAll(async () => {
+  await useLanguage('zh-TW');
+});
+
+describe('the accessors themselves', () => {
+  it('keeps the script in the tag and drops it from the feed language', async () => {
+    await useLanguage('zh-TW');
+    // Both are correct answers to different questions: a Traditional reader
+    // wants Traditional UI, and the same Chinese-language feeds as everyone
+    // else. That is why both accessors exist and why each caller has to pick.
+    expect(getCurrentLanguageTag()).toBe('zh-TW');
+    expect(getCurrentLanguage()).toBe('zh');
+  });
+});
+
+describe('getLocale — date and number formatting', () => {
+  it('returns zh-TW rather than collapsing to the zh-CN default', async () => {
+    await useLanguage('zh-TW');
+    expect(getLocale()).toBe('zh-TW');
+
+    await useLanguage('zh');
+    expect(getLocale()).toBe('zh-CN');
+  });
+
+  it('produces Taiwanese conventions where the two locales differ', async () => {
+    await useLanguage('zh-TW');
+    const traditional = {
+      time: new Intl.DateTimeFormat(getLocale(), { timeStyle: 'short', timeZone: 'UTC' })
+        .format(new Date('2026-08-14T17:30:00Z')),
+      speed: new Intl.NumberFormat(getLocale(), { style: 'unit', unit: 'kilometer-per-hour' }).format(50),
+      compact: new Intl.NumberFormat(getLocale(), { notation: 'compact' }).format(12_345_678),
+    };
+
+    await useLanguage('zh');
+    const simplified = {
+      time: new Intl.DateTimeFormat(getLocale(), { timeStyle: 'short', timeZone: 'UTC' })
+        .format(new Date('2026-08-14T17:30:00Z')),
+      speed: new Intl.NumberFormat(getLocale(), { style: 'unit', unit: 'kilometer-per-hour' }).format(50),
+      compact: new Intl.NumberFormat(getLocale(), { notation: 'compact' }).format(12_345_678),
+    };
+
+    // 12-hour clock, spelled-out units and the Traditional 萬 — none of which
+    // a `zh-CN` locale produces.
+    expect(traditional.time).toContain('下午');
+    expect(traditional.speed).toBe('50 公里/小時');
+    expect(traditional.compact).toContain('萬');
+
+    expect(simplified.time).not.toContain('下午');
+    expect(simplified.speed).toBe('50 km/h');
+    expect(simplified.compact).toContain('万');
+  });
+});
+
+describe('formatTime — relative timestamps on every news item', () => {
+  const minutesAgo = (n: number): Date => new Date(Date.now() - n * 60_000);
+
+  it('renders Traditional characters for a Traditional reader', async () => {
+    await useLanguage('zh-TW');
+    expect(formatTime(minutesAgo(3))).toBe('3 分鐘前');
+    expect(formatTime(minutesAgo(60 * 2))).toBe('2 小時前');
+    expect(formatTime(minutesAgo(60 * 24 * 5))).toBe('5 天前');
+  });
+
+  it('leaves Simplified readers on Simplified', async () => {
+    await useLanguage('zh');
+    expect(formatTime(minutesAgo(3))).toBe('3分钟前');
+    expect(formatTime(minutesAgo(60 * 2))).toBe('2小时前');
+  });
+});
+
+describe('language picker — which entry is marked selected', () => {
+  /**
+   * The marked options, read as attributes.
+   *
+   * Not `select.value` / `selectedOptions`: happy-dom does not derive
+   * selectedness from the `selected` attribute when the markup arrives through
+   * innerHTML — measured here, it reports the SECOND option as selected while
+   * the attribute sits on `zh-TW`. The attribute is what a real browser reads,
+   * and it is what this renderer actually decides, so assert that directly.
+   */
+  function markedOptions(): Array<{ value: string; label: string }> {
+    document.body.innerHTML = renderPreferences({ isDesktopApp: false }).html;
+    const select = document.querySelector<HTMLSelectElement>('#us-language');
+    if (!select) throw new Error('language select missing from preferences markup');
+
+    return [...select.querySelectorAll('option[selected]')].map((option) => ({
+      value: option.getAttribute('value') ?? '',
+      label: option.textContent ?? '',
+    }));
+  }
+
+  it('marks 繁體中文 for a Traditional reader', async () => {
+    await useLanguage('zh-TW');
+    const marked = markedOptions();
+
+    expect(marked).toHaveLength(1);
+    expect(marked[0]?.value).toBe('zh-TW');
+    expect(marked[0]?.label).toContain('繁體中文');
+  });
+
+  it('marks 简体中文 for a Simplified reader', async () => {
+    await useLanguage('zh');
+    const marked = markedOptions();
+
+    expect(marked).toHaveLength(1);
+    expect(marked[0]?.value).toBe('zh');
+    expect(marked[0]?.label).toContain('简体中文');
+  });
+});
+
+describe('command palette country names', () => {
+  function countryLabel(code: string): string {
+    const command = getAllCommands().find((cmd) => cmd.id === `country:${code}`);
+    if (!command) throw new Error(`country command missing for ${code}`);
+    return command.label;
+  }
+
+  // 美国/美國 is a character difference; 韩国/南韓 is a different word, so a
+  // converter run over the catalogue would not have caught it either.
+  it('builds Traditional names from the full tag', async () => {
+    await useLanguage('zh-TW');
+    expect(countryLabel('US')).toBe('美國');
+    expect(countryLabel('KR')).toBe('南韓');
+  });
+
+  it('rebuilds when the script changes — the memo key moved with the accessor', async () => {
+    // Order matters: zh-TW is built first (above), so a memo still keyed on the
+    // stripped `zh` would answer this from the Traditional cache.
+    await useLanguage('zh');
+    expect(countryLabel('US')).toBe('美国');
+    expect(countryLabel('KR')).toBe('韩国');
+
+    await useLanguage('zh-TW');
+    expect(countryLabel('US')).toBe('美國');
+  });
+});
+
+describe('map labels', () => {
+  it('asks the tile source for the reader’s own script', async () => {
+    await useLanguage('zh-TW');
+    expect(getLocalizedNameExpression()).toEqual([
+      'coalesce',
+      ['get', 'name:zh-Hant'],
+      ['get', 'name:zh'],
+      ['get', 'name:en'],
+      ['get', 'name'],
+    ]);
+
+    await useLanguage('zh');
+    expect(getLocalizedNameExpression()).toEqual([
+      'coalesce',
+      ['get', 'name:zh-Hans'],
+      ['get', 'name:zh'],
+      ['get', 'name:en'],
+      ['get', 'name'],
+    ]);
+  });
+});

--- a/tests/dom/i18n-zh-tw-llm-target.test.mts
+++ b/tests/dom/i18n-zh-tw-llm-target.test.mts
@@ -1,0 +1,149 @@
+/**
+ * The two NewsPanel call sites that send a language to the LLM.
+ *
+ * Separate file from `i18n-zh-tw-behaviour.test.mts` because reaching them
+ * needs `@/services` mocked at the module level, and that barrel is on the
+ * import path of half the things the other file exercises.
+ *
+ * What makes these different from the other accessor swaps: the tag is not
+ * read here, it is SENT. `translateText(text, lang)` and `generateSummary(…,
+ * lang, …)` both put it in front of a model as the language to write in, so a
+ * stripped `zh` produces Simplified prose for a Traditional reader no matter
+ * how correct the UI around it is. The same value keys the summary cache, so
+ * the two scripts have to miss each other's entries as well.
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useChineseCatalogue } from './helpers/i18n.mts';
+
+// Parameters are declared so the assertions below can index the recorded call
+// by position — `vi.fn(async () => …)` records an empty tuple type.
+const translateText = vi.fn(async (_text: string, _targetLang: string) => '翻譯結果');
+const generateSummary = vi.fn(
+  async (_headlines: string[], _onProgress: undefined, _panelId: string, _lang: string, _options?: unknown) =>
+    ({ summary: '摘要', provider: 'test', model: 'test', cached: false }),
+);
+
+// A full stub rather than `importOriginal`: the real barrel starts workers and
+// network clients on import, none of which these two paths touch.
+vi.mock('@/services', () => ({
+  analysisWorker: { clusterNews: vi.fn(async () => []) },
+  enrichWithVelocityML: vi.fn(async (clusters: unknown) => clusters),
+  getClusterAssetContext: vi.fn(() => null),
+  MAX_DISTANCE_KM: 100,
+  activityTracker: {
+    register: vi.fn(),
+    unregister: vi.fn(),
+    onChange: vi.fn(),
+    markAsSeen: vi.fn(),
+    markItemsSeen: vi.fn(),
+    updateItems: vi.fn(() => []),
+    getPreviousVisitTime: vi.fn(() => 0),
+    shouldHighlight: vi.fn(() => false),
+    isNewItem: vi.fn(() => false),
+  },
+  generateSummary,
+  translateText,
+  preloadRelatedAssetTables: vi.fn(async () => {}),
+}));
+
+/** The private methods under test, reached without widening the public API. */
+interface NewsPanelInternals {
+  handleTranslate(element: HTMLElement, text: string): Promise<void>;
+  handleSummarize(): Promise<void>;
+  currentHeadlines: string[];
+  currentBodies: string[];
+  lastHeadlineSignature: string;
+}
+
+let NewsPanel: typeof import('@/components/NewsPanel')['NewsPanel'];
+
+beforeAll(async () => {
+  await useChineseCatalogue('zh-TW');
+  ({ NewsPanel } = await import('@/components/NewsPanel'));
+});
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  localStorage.clear();
+  translateText.mockClear();
+  generateSummary.mockClear();
+});
+
+function newPanel(): NewsPanelInternals {
+  const panel = new NewsPanel('news', 'News');
+  // Both handlers bail on `!this.element?.isConnected` after the await, which
+  // is the guard against writing into a panel the user has since closed.
+  document.body.appendChild(panel.getElement());
+  return panel as unknown as NewsPanelInternals;
+}
+
+/** A headline row shaped the way `handleTranslate` walks it. */
+function headlineRow(): HTMLElement {
+  const item = document.createElement('div');
+  item.className = 'item';
+  const title = document.createElement('div');
+  title.className = 'item-title';
+  title.textContent = 'Sanctions package agreed';
+  const button = document.createElement('button');
+  button.className = 'item-translate-btn';
+  item.append(title, button);
+  document.body.appendChild(item);
+  return button;
+}
+
+describe('headline translation target', () => {
+  it('asks for Traditional Chinese, not the stripped code', async () => {
+    await useChineseCatalogue('zh-TW');
+    const panel = newPanel();
+
+    await panel.handleTranslate(headlineRow(), 'Sanctions package agreed');
+
+    expect(translateText).toHaveBeenCalledWith('Sanctions package agreed', 'zh-TW');
+  });
+
+  it('still asks for Simplified when that is the catalogue', async () => {
+    await useChineseCatalogue('zh');
+    const panel = newPanel();
+
+    await panel.handleTranslate(headlineRow(), 'Sanctions package agreed');
+
+    expect(translateText).toHaveBeenCalledWith('Sanctions package agreed', 'zh');
+  });
+});
+
+describe('panel summary target and cache key', () => {
+  async function summarize(panel: NewsPanelInternals): Promise<void> {
+    panel.currentHeadlines = ['Sanctions package agreed', 'Talks resume in Vienna'];
+    panel.currentBodies = [];
+    panel.lastHeadlineSignature = 'sig-1';
+    await panel.handleSummarize();
+  }
+
+  it('sends the full tag as the language to write in', async () => {
+    await useChineseCatalogue('zh-TW');
+    await summarize(newPanel());
+
+    expect(generateSummary).toHaveBeenCalledTimes(1);
+    expect(generateSummary.mock.calls[0]?.[3]).toBe('zh-TW');
+  });
+
+  it('caches under a key the other script cannot read', async () => {
+    await useChineseCatalogue('zh-TW');
+    await summarize(newPanel());
+    const traditionalKeys = Object.keys(localStorage).filter((k) => k.startsWith('panel_summary_'));
+
+    await useChineseCatalogue('zh');
+    generateSummary.mockClear();
+    await summarize(newPanel());
+    const allKeys = Object.keys(localStorage).filter((k) => k.startsWith('panel_summary_'));
+
+    // The Simplified run must have gone to the model rather than reading the
+    // Traditional summary back out of storage.
+    expect(generateSummary).toHaveBeenCalledTimes(1);
+    expect(traditionalKeys).toHaveLength(1);
+    expect(traditionalKeys[0]).toMatch(/_zh-TW$/);
+    expect(allKeys).toHaveLength(2);
+  });
+});

--- a/tests/i18n-language-tag-resolution.test.mts
+++ b/tests/i18n-language-tag-resolution.test.mts
@@ -13,18 +13,56 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { resolveLanguageTag } from '../src/shared/language-tags.ts';
 
-// Mirrors SUPPORTED_LANGUAGES in src/services/i18n.ts. Not imported: that module
-// evaluates `import.meta.glob` at load time, which does not exist outside Vite.
-// The registry itself is gated separately by scripts/docs-stats.mjs.
-const SUPPORTED = new Set([
-  'en', 'bg', 'cs', 'fr', 'de', 'el', 'es', 'hr', 'hu', 'it', 'pl', 'pt', 'nl',
-  'sv', 'ru', 'uk', 'ar', 'fa', 'zh', 'zh-TW', 'ja', 'ko', 'ro', 'tr', 'th',
-  'vi', 'hi', 'sw',
-]);
+/**
+ * SUPPORTED_LANGUAGES, read out of src/services/i18n.ts.
+ *
+ * The module cannot be imported — it evaluates `import.meta.glob` at load time,
+ * which does not exist outside Vite — but it can be read, which is what
+ * scripts/docs-stats.mjs already does to the same constant.
+ *
+ * It used to be mirrored here instead, and a mirror answers the wrong question:
+ * every row below asserts what a tag resolves to GIVEN a registry, so with a
+ * private copy of that registry they keep passing after the app stops shipping
+ * the language they resolve to. Dropping `zh-TW` upstream left this file green
+ * while `resolve('zh-TW')` in the app returned `en`.
+ */
+function readSupportedLanguages(): string[] {
+  const source = readFileSync(
+    fileURLToPath(new URL('../src/services/i18n.ts', import.meta.url)),
+    'utf8',
+  );
+  const block = source.match(/const\s+SUPPORTED_LANGUAGES\s*=\s*\[([\s\S]*?)\]\s*as const/);
+  if (!block) throw new Error('could not read SUPPORTED_LANGUAGES from src/services/i18n.ts');
+  return [...block[1]!.matchAll(/'([^']+)'/g)].map((match) => match[1]!);
+}
+
+const SUPPORTED = new Set(readSupportedLanguages());
 
 const resolve = (tag: string): string => resolveLanguageTag(tag, SUPPORTED);
+
+describe('resolveLanguageTag — the registry the rows below resolve against', () => {
+  it('reads the shipped registry, and finds the codes these rows depend on', () => {
+    // A parse that quietly returned nothing would send every tag to the `en`
+    // fallback, and the Simplified rows — the ones that matter most — would
+    // pass for the wrong reason.
+    assert.ok(
+      SUPPORTED.size > 20,
+      `parsed ${SUPPORTED.size} language(s) out of src/services/i18n.ts, so the parse is broken`,
+    );
+    // Naming them makes removing one a red test here rather than a silent
+    // change of meaning in every assertion below.
+    for (const code of ['zh', 'zh-TW', 'en', 'pt', 'sw', 'ja']) {
+      assert.ok(
+        SUPPORTED.has(code),
+        `${code} is no longer in SUPPORTED_LANGUAGES, so the rows asserting it resolve are stale`,
+      );
+    }
+  });
+});
 
 describe('resolveLanguageTag — Traditional Chinese', () => {
   const traditional = [

--- a/tests/i18n-language-tag-resolution.test.mts
+++ b/tests/i18n-language-tag-resolution.test.mts
@@ -8,8 +8,8 @@
 // the repo would have noticed.
 //
 // So the negative rows below matter more than the positive ones. They are the
-// reason `resolveLanguageTag` matches an explicit tag list plus the `zh-hant`
-// prefix rather than `zh-` wholesale.
+// reason `resolveLanguageTag` reads the script and region subtags rather than
+// treating `zh-` wholesale as Traditional.
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -65,6 +65,44 @@ describe('resolveLanguageTag — Simplified Chinese stays on zh', () => {
       assert.equal(resolve(tag), 'zh');
     });
   }
+});
+
+describe('resolveLanguageTag — subtags the exact-match list missed', () => {
+  // Both rows below resolved wrongly while the matcher compared whole strings:
+  // `zh-TW-u-ca-chinese` fell through to `zh` (Simplified copy for a Traditional
+  // reader) and `zh_TW` fell through to `en`.
+  it('reads a region that is followed by an extension', () => {
+    assert.equal(resolve('zh-TW-u-ca-chinese'), 'zh-TW');
+    assert.equal(resolve('zh-Hant-u-ca-chinese'), 'zh-TW');
+    assert.equal(resolve('zh-Hant-TW-u-nu-hanidec'), 'zh-TW');
+  });
+
+  it('accepts the POSIX underscore spelling', () => {
+    assert.equal(resolve('zh_TW'), 'zh-TW');
+    assert.equal(resolve('zh_tw'), 'zh-TW');
+    assert.equal(resolve('zh_Hant'), 'zh-TW');
+    assert.equal(resolve('pt_BR'), 'pt');
+  });
+
+  it('stops at the singleton — an extension subtag is not a region', () => {
+    // `-x-tw` is private use, not Taiwan. A walk that keeps reading past the
+    // singleton sees a two-letter `tw` and serves Traditional to a `zh` reader.
+    assert.equal(resolve('zh-x-tw'), 'zh');
+    assert.equal(resolve('zh-u-rg-twzzzz'), 'zh');
+  });
+
+  it('lets an explicit script outrank the region', () => {
+    // Simplified in a Traditional region is a real combination, and the script
+    // subtag is the one that says which characters to render.
+    assert.equal(resolve('zh-Hans-TW'), 'zh');
+    assert.equal(resolve('zh-Hans-HK'), 'zh');
+    assert.equal(resolve('zh_Hans_TW'), 'zh');
+  });
+
+  it('keeps Simplified regions on zh through the same path', () => {
+    assert.equal(resolve('zh_CN'), 'zh');
+    assert.equal(resolve('zh-CN-u-ca-chinese'), 'zh');
+  });
 });
 
 describe('resolveLanguageTag — everything else', () => {

--- a/tests/i18n-zh-tw-catalogue.test.mts
+++ b/tests/i18n-zh-tw-catalogue.test.mts
@@ -25,6 +25,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { load as loadYaml } from 'js-yaml';
 import * as OpenCC from 'opencc-js';
 import { GENERATED_LOCALES, LOCALES, TRANSLATABLE_LOCALES } from '../scripts/translate-locales.mjs';
 
@@ -36,6 +37,50 @@ const CATALOGUES = [
   { name: 'src', simplified: 'src/locales/zh.json', traditional: 'src/locales/zh-TW.json' },
   { name: 'pro-test', simplified: 'pro-test/src/locales/zh.json', traditional: 'pro-test/src/locales/zh-TW.json' },
 ];
+
+/**
+ * Every test this file is supposed to register, written out.
+ *
+ * Most of the tests below are registered from data — one per entry in
+ * CATALOGUES, one per catalogue named in EXPECTED_KEY_RULES — and a loop over
+ * an empty list registers nothing at all. That is not a red build: a runner
+ * reports the tests it was given, so emptying CATALOGUES deletes both copies of
+ * `no value is left in Simplified` and the suite passes with fewer tests than
+ * it had. `--check` does not cover the gap either, because it regenerates from
+ * the same tables these tests are auditing.
+ *
+ * So registration goes through `test()` below, which records the name, and the
+ * census at the bottom compares what was recorded against this list. Removing a
+ * test is then an edit in two places rather than a deletion that leaves no
+ * trace. What it cannot defend is its own deletion, or the file's — nothing
+ * inside a file can.
+ */
+const EXPECTED_TESTS = [
+  'src: no value is left in Simplified',
+  'pro-test: no value is left in Simplified',
+  'catches a Simplified value planted in the Traditional catalogue',
+  'the generator table still holds every term enforced here',
+  'every replacement is itself Traditional and settles the rule that produced it',
+  'src: carries none of the rejected terms',
+  'pro-test: carries none of the rejected terms',
+  'the generator table still holds every rule enforced here',
+  'every per-entry source term has a decided allow-list',
+  'src: every per-entry override is applied',
+  'pro-test: every per-entry override is applied',
+  'keeps generated locales inside LOCALES',
+  'runs --check in the unit job, with nothing in front of it',
+  'the npm scripts invoke the same generator CI does',
+  'runs the unit job at all when a catalogue input changes',
+  'requires the unit job before deploying',
+];
+
+const registered: string[] = [];
+
+/** `it`, plus the census entry that makes its absence visible. */
+const test = (name: string, fn: () => void): void => {
+  registered.push(name);
+  it(name, fn);
+};
 
 /**
  * The rejected terms, written out here and not only read from the generator.
@@ -81,19 +126,28 @@ const load = (rel: string): Map<string, string> =>
   flatten(JSON.parse(readFileSync(repoPath(rel), 'utf8')));
 
 /**
- * The same terms read back out of the generator, so the literal above and the
+ * The same rules read back out of the generator, so the literal above and the
  * table that actually runs cannot drift apart. Same technique
  * `scripts/docs-stats.mjs` uses to read SUPPORTED_LANGUAGES out of i18n.ts.
+ *
+ * Both sides are returned, not just the banned one. EXPECTED_BANNED pins what a
+ * rule rejects; nothing pinned what it produces, so a rule could be pointed at a
+ * Simplified replacement — `"訪問": "访问"` — and the term it is named for would
+ * still be absent from the catalogue. The suite would agree the vocabulary was
+ * settled while the generator wrote the opposite of the decision.
  *
  * The trailing comma is optional in Python, so it is optional here too — a last
  * entry written without one used to parse as absent, which is the failure this
  * function must not have.
  */
-function readBannedTerms(): string[] {
+function readPhraseRules(): { from: string; to: string }[] {
   const source = readFileSync(repoPath('scripts/convert-zh-tw.py'), 'utf8');
   const block = source.match(/^PHRASE_OVERRIDES = \{$([\s\S]*?)^\}$/m);
   assert.ok(block, 'could not find PHRASE_OVERRIDES in scripts/convert-zh-tw.py');
-  return [...block[1]!.matchAll(/^\s*"([^"]+)": "[^"]+",?$/gm)].map((m) => m[1]!);
+  return [...block[1]!.matchAll(/^\s*"([^"]+)": "([^"]+)",?$/gm)].map((m) => ({
+    from: m[1]!,
+    to: m[2]!,
+  }));
 }
 
 interface KeyRule {
@@ -184,7 +238,7 @@ describe('zh-TW catalogues — Simplified script drift', () => {
   // changes under conversion. Values that are identical in both scripts (地震,
   // 港口, 首都) legitimately match and are skipped rather than whitelisted.
   for (const catalogue of CATALOGUES) {
-    it(`${catalogue.name}: no value is left in Simplified`, () => {
+    test(`${catalogue.name}: no value is left in Simplified`, () => {
       const simplified = load(catalogue.simplified);
       const traditional = load(catalogue.traditional);
 
@@ -213,7 +267,7 @@ describe('zh-TW catalogues — Simplified script drift', () => {
     });
   }
 
-  it('catches a Simplified value planted in the Traditional catalogue', () => {
+  test('catches a Simplified value planted in the Traditional catalogue', () => {
     // Proves the rule above has teeth, without mutating a committed file.
     const planted = '实时更新已就绪';
     assert.notEqual(s2tw(planted), planted, 'fixture must be script-sensitive');
@@ -221,18 +275,56 @@ describe('zh-TW catalogues — Simplified script drift', () => {
 });
 
 describe('zh-TW catalogues — settled vocabulary', () => {
-  it('the generator table still holds every term enforced here', () => {
+  test('the generator table still holds every term enforced here', () => {
     // Not a floor on the count: a floor of 8 over 12 terms lets 4 go silently,
     // and a parse that finds nothing at all has to fail rather than pass empty.
     assert.deepEqual(
-      readBannedTerms().sort(),
+      readPhraseRules()
+        .map((rule) => rule.from)
+        .sort(),
       [...EXPECTED_BANNED].sort(),
       'PHRASE_OVERRIDES and EXPECTED_BANNED disagree — a rule was dropped, renamed, or written in a form the parser misses',
     );
   });
 
+  test('every replacement is itself Traditional and settles the rule that produced it', () => {
+    // The replacement side has no hardcoded copy — writing one would just move
+    // the decision, since a wrong replacement written in both places still
+    // ships. These are the two properties a replacement has to have whatever it
+    // says, so they hold without anyone restating the table.
+    const rules = [
+      ...readPhraseRules().map((rule) => ({ where: 'PHRASE_OVERRIDES', ...rule })),
+      ...readKeyOverrides().map((rule) => ({
+        where: `KEY_OVERRIDES ${rule.catalogue}/${rule.path}`,
+        from: rule.from,
+        to: rule.to,
+      })),
+    ];
+    assert.ok(rules.length > 12, `parsed ${rules.length} rule(s), so this is checking almost nothing`);
+
+    const failures: string[] = [];
+    for (const rule of rules) {
+      // Simplified on the replacement side. `"訪問": "访问"` passes every other
+      // gate in this file: the banned term does leave the catalogue.
+      if (s2tw(rule.to) !== rule.to) {
+        failures.push(`${rule.where}: "${rule.from}" → "${rule.to}" is not Traditional`);
+      }
+      // A replacement that still contains a banned term is a rule that did not
+      // finish, and for KEY_OVERRIDES it is also the pre-emption failing: the
+      // per-entry rule runs first precisely so the global rule finds nothing
+      // left to match.
+      const unresolved = EXPECTED_BANNED.filter((term) => rule.to.includes(term));
+      if (unresolved.length > 0) {
+        failures.push(`${rule.where}: "${rule.to}" still contains ${unresolved.join(', ')}`);
+      }
+      if (rule.from === rule.to) failures.push(`${rule.where}: "${rule.from}" replaces itself`);
+    }
+
+    assert.deepEqual(failures, []);
+  });
+
   for (const catalogue of CATALOGUES) {
-    it(`${catalogue.name}: carries none of the rejected terms`, () => {
+    test(`${catalogue.name}: carries none of the rejected terms`, () => {
       const traditional = load(catalogue.traditional);
       const hits: string[] = [];
 
@@ -251,7 +343,7 @@ describe('zh-TW catalogues — settled vocabulary', () => {
 });
 
 describe('zh-TW catalogues — per-entry overrides', () => {
-  it('the generator table still holds every rule enforced here', () => {
+  test('the generator table still holds every rule enforced here', () => {
     assert.deepEqual(
       sortRules(readKeyOverrides()),
       sortRules(EXPECTED_KEY_RULES),
@@ -259,7 +351,7 @@ describe('zh-TW catalogues — per-entry overrides', () => {
     );
   });
 
-  it('every per-entry source term has a decided allow-list', () => {
+  test('every per-entry source term has a decided allow-list', () => {
     // Without this a rule could be added to both tables above and still reach
     // no catalogue-wide ban, which is the gap the per-entry checks leave open.
     assert.deepEqual(
@@ -273,9 +365,17 @@ describe('zh-TW catalogues — per-entry overrides', () => {
     // Scoped off the literal, not the parse, so a parser that finds nothing
     // registers a failing test rather than no test.
     const scoped = EXPECTED_KEY_RULES.filter((rule) => rule.catalogue === catalogue.name);
-    if (scoped.length === 0) continue;
 
-    it(`${catalogue.name}: every per-entry override is applied`, () => {
+    test(`${catalogue.name}: every per-entry override is applied`, () => {
+      // Registered whether or not there are rules to check. Skipping
+      // registration on an empty list is how the last rule for a catalogue
+      // stops being enforced without anything going red, and an empty loop
+      // below would report no failures for the same reason.
+      assert.ok(
+        scoped.length > 0,
+        `no per-entry rule is declared for ${catalogue.name}; if that is intended, drop it from EXPECTED_TESTS too`,
+      );
+
       const traditional = load(catalogue.traditional);
       const failures: string[] = [];
 
@@ -306,9 +406,27 @@ describe('zh-TW catalogues — per-entry overrides', () => {
 // exist because that check is one deleted workflow line away from being silent,
 // and everything else about the catalogue would stay green.
 describe('zh-TW catalogues — the generator is the freshness gate', () => {
-  const workflow = readFileSync(repoPath('.github/workflows/test.yml'), 'utf8').replace(/\r\n/g, '\n');
+  interface WorkflowStep {
+    id?: string;
+    name?: string;
+    run?: string;
+    if?: string;
+    'continue-on-error'?: unknown;
+  }
+  interface WorkflowJob {
+    if?: string;
+    'continue-on-error'?: unknown;
+    steps?: WorkflowStep[];
+  }
 
-  it('keeps generated locales inside LOCALES', () => {
+  const workflow = loadYaml(readFileSync(repoPath('.github/workflows/test.yml'), 'utf8')) as {
+    jobs: Record<string, WorkflowJob | undefined>;
+  };
+  const unit = workflow.jobs.unit;
+  const stepsOf = (job: WorkflowJob | undefined): WorkflowStep[] => job?.steps ?? [];
+  const checkCommand = 'python3 scripts/convert-zh-tw.py --check';
+
+  test('keeps generated locales inside LOCALES', () => {
     assert.ok(GENERATED_LOCALES.size > 0, 'GENERATED_LOCALES is empty, so nothing below is checking anything');
     for (const locale of GENERATED_LOCALES) {
       // Dropping it from LOCALES would also drop it from the freshness gate and
@@ -319,23 +437,132 @@ describe('zh-TW catalogues — the generator is the freshness gate', () => {
     }
   });
 
-  it('runs --check inside a job the deploy gate requires', () => {
-    // Presence alone is not enough: a step in a job outside the required set
-    // reports red without blocking anything.
-    const unitJob = workflow.match(/\n {2}unit:\n([\s\S]*?)(?=\n {2}[a-z][\w-]*:\n)/);
-    assert.ok(unitJob, 'could not locate the unit job in .github/workflows/test.yml');
-    assert.match(
-      unitJob[1]!,
-      /convert-zh-tw\.py --check/,
-      'the staleness gate for the generated catalogues is not run by the unit job',
+  test('runs --check in the unit job, with nothing in front of it', () => {
+    // The previous version of this test searched the file for the string
+    // `convert-zh-tw.py --check` inside the unit job's text. Presence is the
+    // weakest of the three things that have to be true: a step can be present
+    // and conditional, present and `continue-on-error`, or present with the
+    // command edited into something that always succeeds. The workflow is
+    // parsed rather than pattern-matched so those are readable properties
+    // instead of substrings that happen to be nearby.
+    assert.ok(unit, 'no unit job in .github/workflows/test.yml');
+    const steps = stepsOf(unit).filter((step) => (step.run ?? '').includes('convert-zh-tw.py'));
+    assert.equal(steps.length, 1, `expected exactly one step running the generator, found ${steps.length}`);
+    const step = steps[0]!;
+
+    // An explicit `false` is the same as absent; anything else — `true`, or an
+    // expression that resolves at run time — is not something this can read.
+    const blocks = (value: unknown): boolean => value === undefined || value === false;
+    assert.equal(step.if, undefined, 'the step is conditional, so it can decline to run and stay green');
+    assert.ok(blocks(step['continue-on-error']), 'the step is allowed to fail, so it reports without blocking');
+    assert.ok(blocks(unit['continue-on-error']), 'the unit job is allowed to fail, so nothing in it blocks');
+
+    // The body, line for line. `|| true`, a dropped `--check`, a dropped
+    // version pin and an inserted `pip install --upgrade` all land here.
+    assert.deepEqual(
+      (step.run ?? '')
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean),
+      ['pip install opencc-python-reimplemented==0.1.7', checkCommand],
+      'the step no longer runs exactly the pinned install and the check',
+    );
+  });
+
+  test('the npm scripts invoke the same generator CI does', () => {
+    // Two ways to run one thing is two things to keep true. The scripts exist
+    // so a contributor has the same command CI has; asserting they are the same
+    // string is what keeps that claim from decaying into a second, older
+    // invocation that disagrees about the flag or the file.
+    const pkg = JSON.parse(readFileSync(repoPath('package.json'), 'utf8')) as {
+      scripts: Record<string, string | undefined>;
+    };
+    assert.equal(pkg.scripts['locales:zh-tw'], 'python3 scripts/convert-zh-tw.py');
+    assert.equal(pkg.scripts['locales:zh-tw:check'], checkCommand);
+  });
+
+  test('runs the unit job at all when a catalogue input changes', () => {
+    // The third leg, and the one presence-plus-gate-membership misses entirely.
+    // deploy-gate.yml reads a skipped required job as passing (docs-only PRs
+    // skip the code checks by design), so `unit` being required is worth
+    // exactly what the condition on `unit` is worth: if a PR touching the
+    // catalogues sets code=false, the job skips, the gate counts a pass, and
+    // the staleness check never ran.
+    assert.ok(unit, 'no unit job in .github/workflows/test.yml');
+    assert.equal(
+      unit.if,
+      "needs.changes.outputs.code == 'true'",
+      'the unit job runs on a different condition now, and the filter read below is no longer the one that decides',
     );
 
+    const diff = stepsOf(workflow.jobs.changes).find((step) => step.id === 'diff');
+    assert.ok(diff?.run, 'could not find the diff step of the changes job');
+    const program = diff.run.match(/CODE=\$\(echo "\$FILES" \| awk '([\s\S]*?)'\)/);
+    assert.ok(program, 'could not read the CODE filter out of the changes job');
+    const body = program[1]!;
+
+    // The filter is an exclusion list: an unmatched path falls through to a
+    // bare `{ count++ }` and sets code=true. Everything below reasons from
+    // that, so it is asserted rather than assumed.
+    assert.match(
+      body,
+      /^\s*\{ count\+\+ \}\s*$/m,
+      'the CODE filter no longer counts unmatched paths, so it is not an exclusion list and this test cannot read it',
+    );
+
+    // Only rules whose whole action is `next` exclude; `{ count++; next }` is a
+    // carve-back that counts. A compound rule contributes its leading pattern
+    // only, which matches a superset of what awk excludes — proving a path is
+    // outside the superset proves it is outside the real exclusion set.
+    const exclusions = body
+      .split(/\r?\n/)
+      .filter((line) => /\{\s*next\s*\}\s*$/.test(line))
+      .map((line) => line.match(/\/((?:[^/\\]|\\.)+)\//))
+      .filter((match): match is RegExpMatchArray => match !== null)
+      .map((match) => new RegExp(match[1]!));
+
+    assert.ok(exclusions.length >= 5, `parsed ${exclusions.length} exclusion rule(s), so the parse is broken`);
+    assert.ok(
+      exclusions.some((pattern) => pattern.test('README.md')),
+      'the parsed rules exclude nothing at all, so the assertion below would pass on any input',
+    );
+
+    // Everything the generator reads or is defined by. A PR that only touches
+    // these has to reach the unit job.
+    const inputs = [
+      'src/locales/zh.json',
+      'src/locales/zh-TW.json',
+      'pro-test/src/locales/zh.json',
+      'pro-test/src/locales/zh-TW.json',
+      'scripts/convert-zh-tw.py',
+      'tests/i18n-zh-tw-catalogue.test.mts',
+    ];
+    assert.deepEqual(
+      inputs.filter((path) => exclusions.some((pattern) => pattern.test(path))),
+      [],
+      'a PR touching only these paths sets code=false, so unit skips and the deploy gate counts the skip as a pass',
+    );
+  });
+
+  test('requires the unit job before deploying', () => {
     const gate = readFileSync(repoPath('.github/workflows/deploy-gate.yml'), 'utf8');
     const required = gate.match(/required='(\[[^']*\])'/);
     assert.ok(required, 'could not read the required-job list from deploy-gate.yml');
     assert.ok(
       (JSON.parse(required[1]!) as string[]).includes('unit'),
       'the unit job is no longer gate-required, so the catalogue check stopped blocking merges',
+    );
+  });
+});
+
+describe('zh-TW catalogues — the tests above are all still here', () => {
+  it('registers every test it is supposed to', () => {
+    // Runs after the whole file has been evaluated, so `registered` is complete
+    // by now regardless of where this sits.
+    assert.deepEqual(
+      [...registered].sort(),
+      [...EXPECTED_TESTS].sort(),
+      'the set of registered tests changed — a data-driven loop registered nothing, or a test was added or removed without updating EXPECTED_TESTS',
     );
   });
 });

--- a/tests/map-locale.test.mts
+++ b/tests/map-locale.test.mts
@@ -9,10 +9,14 @@ async function loadMapLocale(defaultLang = 'en') {
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const sourcePath = resolve(__dirname, '..', 'src', 'utils', 'map-locale.ts');
   const source = readFileSync(sourcePath, 'utf-8');
-  const patched = source.replace(
-    "import { getCurrentLanguage } from '@/services/i18n';",
-    `const getCurrentLanguage = () => '${defaultLang}';`,
-  );
+  const importLine = "import { getCurrentLanguageTag } from '@/services/i18n';";
+  const patched = source.replace(importLine, `const getCurrentLanguageTag = () => '${defaultLang}';`);
+  // A silent no-match would leave the '@/services/i18n' alias in a data: URL
+  // import, which fails to resolve — but say which line moved rather than
+  // making the next reader work that back from a module-resolution error.
+  if (patched === source) {
+    throw new Error(`[map-locale test] stub target not found in map-locale.ts: ${importLine}`);
+  }
   const transformed = transformSync(patched, {
     loader: 'ts',
     format: 'esm',
@@ -27,43 +31,93 @@ const enMod = await loadMapLocale('en');
 const arMod = await loadMapLocale('ar');
 
 const {
-  getLocalizedNameField,
+  getLocalizedNameFields,
   getLocalizedNameExpression,
   isLocalizableTextField,
   localizeMapLabels,
 } = enMod;
 
-// ── getLocalizedNameField ───────────────────────────────────────────
+// ── getLocalizedNameFields ──────────────────────────────────────────
 
-describe('getLocalizedNameField', () => {
+describe('getLocalizedNameFields', () => {
   it('returns mapped tile field for supported language', () => {
-    assert.equal(getLocalizedNameField('ko'), 'name:ko');
+    assert.deepEqual(getLocalizedNameFields('ko'), ['name:ko']);
   });
 
   it('falls back to name:en for unsupported language', () => {
-    assert.equal(getLocalizedNameField('xx'), 'name:en');
+    assert.deepEqual(getLocalizedNameFields('xx'), ['name:en']);
   });
 
   it('falls back to name:en for Vietnamese (no CARTO tile field)', () => {
-    assert.equal(getLocalizedNameField('vi'), 'name:en');
+    assert.deepEqual(getLocalizedNameFields('vi'), ['name:en']);
   });
 
   it('returns correct field for every mapped language', () => {
-    const expected: Record<string, string> = {
-      en: 'name:en', bg: 'name:bg', cs: 'name:cs', fr: 'name:fr',
-      de: 'name:de', el: 'name:el', es: 'name:es', hr: 'name:hr',
-      hi: 'name:hi', it: 'name:it',
-      pl: 'name:pl', pt: 'name:pt', nl: 'name:nl', sv: 'name:sv',
-      ru: 'name:ru', ar: 'name:ar', zh: 'name:zh', ja: 'name:ja',
-      ko: 'name:ko', ro: 'name:ro', tr: 'name:tr', th: 'name:th',
+    const expected: Record<string, string[]> = {
+      en: ['name:en'], bg: ['name:bg'], cs: ['name:cs'], fr: ['name:fr'],
+      de: ['name:de'], el: ['name:el'], es: ['name:es'], hr: ['name:hr'],
+      hi: ['name:hi'], it: ['name:it'],
+      pl: ['name:pl'], pt: ['name:pt'], nl: ['name:nl'], sv: ['name:sv'],
+      ru: ['name:ru'], ar: ['name:ar'], ja: ['name:ja'],
+      ko: ['name:ko'], ro: ['name:ro'], tr: ['name:tr'], th: ['name:th'],
+      zh: ['name:zh-Hans', 'name:zh'], 'zh-TW': ['name:zh-Hant', 'name:zh'],
     };
-    for (const [lang, field] of Object.entries(expected)) {
-      assert.equal(getLocalizedNameField(lang), field, `lang=${lang}`);
+    for (const [lang, fields] of Object.entries(expected)) {
+      assert.deepEqual(getLocalizedNameFields(lang), fields, `lang=${lang}`);
     }
   });
 
   it('falls back to name:en for empty string', () => {
-    assert.equal(getLocalizedNameField(''), 'name:en');
+    assert.deepEqual(getLocalizedNameFields(''), ['name:en']);
+  });
+});
+
+// ── Chinese: script-tagged tile fields ──────────────────────────────
+
+describe('Chinese tile fields', () => {
+  // Measured on 2026-08-14 against the TileJSON of each source this app loads,
+  // and confirmed on a decoded z10 tile: Protomaps — the DEFAULT basemap — has
+  // name:zh-Hans and name:zh-Hant and no name:zh at all, so the plain `name:zh`
+  // this table used to hold was resolving to name:en, i.e. English labels for
+  // Chinese readers. CARTO is the mirror image: name:zh only.
+  it('asks for the Traditional field first when the catalogue is zh-TW', () => {
+    assert.deepEqual(getLocalizedNameFields('zh-TW'), ['name:zh-Hant', 'name:zh']);
+  });
+
+  it('asks for the Simplified field first when the catalogue is zh', () => {
+    assert.deepEqual(getLocalizedNameFields('zh'), ['name:zh-Hans', 'name:zh']);
+  });
+
+  it('never offers one script the other script’s field', () => {
+    assert.ok(!getLocalizedNameFields('zh-TW').includes('name:zh-Hans'));
+    assert.ok(!getLocalizedNameFields('zh').includes('name:zh-Hant'));
+  });
+
+  it('keeps name:zh as the second hop for CARTO, ahead of English', () => {
+    for (const lang of ['zh', 'zh-TW']) {
+      const expr = getLocalizedNameExpression(lang);
+      const fields = expr.slice(1).map((get: unknown) => (get as [string, string])[1]);
+      assert.deepEqual(fields.slice(-2), ['name:en', 'name'], `lang=${lang}`);
+      assert.equal(fields[1], 'name:zh', `lang=${lang}`);
+    }
+  });
+});
+
+// ── The tile source carries the fields this table names ─────────────
+
+describe('Protomaps field names', () => {
+  // The Chinese rows are only correct while the default basemap spells the
+  // fields this way. @protomaps/basemaps ships that list, so the assertion
+  // reads the source of truth rather than a copy of it: if upstream renames or
+  // drops a script variant, this reds instead of the labels silently going
+  // English.
+  it('declares zh-Hant and zh-Hans as separate languages', async () => {
+    const { language_script_pairs } = await import('@protomaps/basemaps');
+    const langs = new Set(language_script_pairs.map((p: { lang: string }) => p.lang));
+
+    assert.ok(langs.has('zh-Hant'), 'Protomaps no longer declares zh-Hant');
+    assert.ok(langs.has('zh-Hans'), 'Protomaps no longer declares zh-Hans');
+    assert.ok(!langs.has('zh'), 'Protomaps now declares a plain zh — the second hop can be reconsidered');
   });
 });
 
@@ -85,7 +139,9 @@ describe('getLocalizedNameExpression', () => {
   });
 
   it('returns 3-element coalesce for CJK languages', () => {
-    for (const lang of ['zh', 'ja', 'ko']) {
+    // zh and zh-TW are the exception — they carry a second script-tagged field
+    // and are covered in the Chinese block below.
+    for (const lang of ['ja', 'ko']) {
       const expr = getLocalizedNameExpression(lang);
       assert.equal(expr.length, 4, `lang=${lang} should have coalesce + 3 gets`);
       assert.deepEqual(expr[1], ['get', `name:${lang}`]);

--- a/tests/pro-locale-freshness.test.mjs
+++ b/tests/pro-locale-freshness.test.mjs
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  GENERATED_LOCALES,
   LOCALES,
   baselinePathFor,
   classifyKeys,
@@ -23,6 +24,23 @@ const BASELINE_PATH = join(ROOT, baselinePathFor(true));
 const REFRESH_HINT =
   'Run: ANTHROPIC_API_KEY=... node scripts/translate-locales.mjs --pro-test  ' +
   '(then rebuild pro-test and commit public/pro/).';
+
+// The locales below iterate LOCALES, which keeps zh-TW so the freshness gate
+// still covers it. The command in REFRESH_HINT no longer writes it: zh-TW is
+// converted from zh.json by scripts/convert-zh-tw.py, and translate-locales.mjs
+// skips generated locales on the write path (it even rejects --only=zh-TW). A
+// reader who follows the hint on a stale zh-TW gets a run that reports the same
+// gap and changes nothing.
+const GENERATED_HINT =
+  'Generated locales (' +
+  [...GENERATED_LOCALES].sort().join(', ') +
+  ') are not written by that command — regenerate with: npm run locales:zh-tw';
+
+/** Appended only when a generated locale is actually implicated. */
+const hintFor = (locales) =>
+  locales.some((locale) => GENERATED_LOCALES.has(locale))
+    ? REFRESH_HINT + '  ' + GENERATED_HINT
+    : REFRESH_HINT;
 
 const readJson = (file) => JSON.parse(readFileSync(file, 'utf8'));
 const enFlat = flatten(readJson(join(LOCALES_DIR, 'en.json')));
@@ -104,6 +122,7 @@ describe('pro locale freshness', () => {
     const baselinePlurals = findPluralBases(baseline);
 
     const problems = [];
+    const problemLocales = [];
     for (const locale of LOCALES) {
       const file = join(LOCALES_DIR, locale + '.json');
       if (!existsSync(file)) continue;
@@ -114,6 +133,7 @@ describe('pro locale freshness', () => {
         expectedKeysForLocale(baseline, baselinePlurals, categories),
       );
       if (result.missing.length || result.stale.length || result.orphan.length) {
+        problemLocales.push(locale);
         problems.push(
           locale + ': ' + result.missing.length + ' missing, ' + result.stale.length + ' stale, ' +
             result.orphan.length + ' orphaned (e.g. ' +
@@ -121,7 +141,7 @@ describe('pro locale freshness', () => {
         );
       }
     }
-    assert.deepEqual(problems, [], 'pro locales are out of date. ' + REFRESH_HINT);
+    assert.deepEqual(problems, [], 'pro locales are out of date. ' + hintFor(problemLocales));
   });
 
   it('does not let a locale drift back toward untranslated English', () => {


### PR DESCRIPTION
Follow-up to #6561 (merged as `05fc2bb`). It carries both halves of what was
left, in one PR:

- **§3–§6 of the 2026-08-13 review** — the consumers that still strip the
  region, the tile name field, tag resolution, and the behaviour tests those
  three fixes did not have. Four commits, written before #6561 merged.
- **The seven round-2 follow-ups.** One commit.

The branch was based on `03be90c`, which the squash merge did not put on main,
so it is rebased onto `4a3fa3d` rather than merged, and every number below was
re-measured there. `git merge-tree --write-tree upstream/main HEAD` reports zero
conflicts. `public/pro/` is untouched — nothing here reaches `pro-test/src`.

---

## §6 — `resolveLanguageTag` reads subtags (`63c8772`)

The matcher compared whole strings against a four-tag list plus one prefix, so
`zh-TW-u-ca-chinese` fell through to the base subtag (Simplified copy for a
reader who asked for Traditional) and `zh_TW` fell through to `en`. It folds `_`
to `-` and reads the script and region subtags now.

It stops at the first singleton, because what follows one is extension data, not
language data: `zh-TW-u-ca-chinese` carries a two-letter `ca` that reads as a
region to a walk that does not stop, and `zh-x-tw` a `tw`. An explicit script
outranks the region, which is what makes `zh-Hans-TW` Simplified — the
exact-match list had no way to express that. The three new negative rows
(`zh-x-tw`, `zh-u-rg-twzzzz`, `zh-Hans-TW`) each fail if the corresponding
branch goes.

## §4 — the tile name field (`49e5094`)

The question was whether the tile source carries `name:zh-Hant` before this was
fixable. Measured against the TileJSON of all three sources the app can load,
and confirmed on a decoded z10 tile for Taipei, Beijing and Hong Kong:

| source | fields |
|---|---|
| Protomaps (default basemap) | `name:zh-Hans`, `name:zh-Hant`, **no** `name:zh` |
| OpenFreeMap (fallback style) | all three |
| CARTO | `name:zh` only |

So yes — and the same measurement says the existing `zh` row was already wrong.
`name:zh` does not exist on the default basemap, so the coalesce fell through to
`name:en`: Simplified readers have been getting English labels. Both scripts now
list their script-tagged field first and `name:zh` second, which is the only
Chinese field CARTO carries.

The guard reads `@protomaps/basemaps`' own language list rather than a copy, so
an upstream rename reds here instead of turning labels English in silence.

## §3 — the two consumers (`60bb370`)

`src/config/commands.ts` builds the country list through `Intl.DisplayNames`,
which renders a stripped `zh` as Simplified: 美国 for US, and 韩国 for KR where
Taiwan says 南韓 — a different word, not a character variant, so no converter
pass over the catalogue would have caught it. The memo key reads the same
accessor, as it must: keyed on the stripped code, whichever catalogue built
first answers for both.

`src/components/NewsPanel.ts` passes the language to `translateText()` and
`generateSummary()` as the language for the model to **write in**, so a
Traditional reader asking for a headline translation or a panel summary got
Simplified prose back. It also keys the summary cache, so the two scripts were
sharing entries.

The four `getCurrentLanguage()` reads left in that file (`:555`, `:565`, `:726`,
`:822`) keep the stripped accessor. They ask what language a *feed* is in, or
whether the UI is English at all — both are answers Traditional and Simplified
readers share. That file having both kinds is why the accessors are separate.

## §5 — behaviour tests (`0f93eb2`)

C1 covers `resolveLanguageTag`, which is the resolver *beneath* these call sites,
so all three could regress green. Asserted per script: `getLocale()` returns
`zh-TW` and the difference is visible (下午5:30 against 17:30, 1235萬 against
1235万); `formatTime()` renders 3 分鐘前 rather than 3分钟前; the picker marks
繁體中文; the palette builds 美國/南韓; the map asks for `name:zh-Hant`.

Every assertion is a pair. A fix that hardcodes Traditional is as broken as the
stripped accessor was, and only the Simplified row says so.

---

## Round-2 items (`0d85915`)

All seven in one commit, because six of them are the same finding: a guard that
reports on the object it is derived from, or that stops existing instead of
going red.

### 1 — the CI guard proved presence, not blocking

The old assertion searched the unit job's text for `convert-zh-tw.py --check`.
The workflow is parsed with `js-yaml` now (already a devDependency, already used
by the OpenAPI contract tests), and the three legs are separate assertions: the
step carries no `if` and no `continue-on-error`, the job carries no
`continue-on-error`, and the run body is compared line for line against the
pinned install and the check.

The third leg is the one presence-plus-membership missed entirely. `deploy-gate.yml`
counts a skipped required job as a pass, so `unit` being required is worth
exactly what the condition on `unit` is worth. The condition is pinned, the
`CODE` filter is read out of the `changes` job, and the generator's inputs are
asserted to be outside its exclusion set.

The filter is an exclusion list over a default of `{ count++ }`, which is
asserted rather than assumed. Only rules whose whole action is `next` count as
exclusions — `{ count++; next }` is a carve-back — and a compound rule
contributes its leading pattern only. That over-approximates what awk excludes,
so a path outside the parsed set is outside the real one.

### 2 — two guards that disappeared rather than failed

Both are data-driven registration: a loop over an empty list registers nothing,
and a runner reports the tests it was given, not the ones it should have had.
Test names are recorded as they register and compared against a written-out
list, so removing one is an edit in two places. `if (scoped.length === 0)
continue` is gone; that test registers unconditionally and asserts it has rules,
because an empty loop reports no failures for the same reason.

What this cannot defend is its own deletion, or the file's. Nothing inside a
file can.

### 3 — the replacement side had no check

Correcting the repro rather than reproducing it. Planting `"訪問": "访问"` and
regenerating is **already red** on the pre-PR tree, but only in `pro-test`, and
by accident: the drift guard compares whole values, `pro-test` happens to hold
`welcome.pricing.eyebrow: "访问"` as an entire value, and `src`'s seven
occurrences all sit inside longer strings that do convert, so `src` stayed
green.

Change the replacement to something Simplified that is not identical to the
Simplified source and the whole-value coincidence goes away: `"高階": "进阶"`,
regenerated, is green on the pre-PR tree and red here, with the new assertion
the only failure. That is the case the check is for.

Both sides of every rule are parsed now: a replacement must be unchanged by
cn→tw conversion, must not contain a banned term, and must differ from its
source. The middle one is also the pre-emption claim in `KEY_OVERRIDES` — the
per-entry rule runs first so the global rule finds nothing left to match, which
only holds if the replacement is clean.

### 4 — the third writer

`scripts/sync-locale-keys.mjs` filled every locale from `en.json`, `zh-TW`
included, with English literals the generator overwrites and `--check` then
fails on. Measured: one key added to `en.json`, then `npm run sync:locales`.

| | files written | `zh-TW.json` `__mutationProbe` |
|---|---|---|
| before | 28 | `"Mutation probe"` |
| after | 27 | absent |

It still reports and counts the gap — that gap is real — but names the generator
instead of itself. `GENERATED_LOCALES` is imported rather than restated, so this
is not a third place that has to be told.

`REFRESH_HINT` in `pro-locale-freshness` had the same problem from the other
side: it pointed at a command that no longer writes `zh-TW`. The generator hint
is appended only when a generated locale is actually implicated.

### 5 — npm scripts

`locales:zh-tw` and `locales:zh-tw:check`, and a test asserting they are the
same string CI runs, since two ways to run one thing is two things to keep true.
`==0.1.7` is in the docstring's `Usage:`.

### 6 — docstring and `--chek`

The docstring said `KEY_OVERRIDES` lets an entry "opt out". It pre-empts: the
per-entry rule rewrites the substring first, so the global rule finds nothing to
match. There is no way to say "skip the global rule here", only to spell out the
replacement this entry wants — and that replacement has to be clean, which is
the assertion added in item 3.

`--chek` missed the membership test on `sys.argv`, took the write path, rewrote
both catalogues and exited 0. With `argparse`: `error: unrecognized arguments:
--chek`, exit 2, nothing written.

### 7 — the mirrored registry

`tests/i18n-language-tag-resolution.test.mts` kept its own copy of
`SUPPORTED_LANGUAGES`, so every row asserted resolution *given a registry* while
holding a private one — dropping `zh-TW` upstream left the file green. It reads
the registry with the regex `scripts/docs-stats.mjs` already uses (the ban is on
importing the module, which evaluates `import.meta.glob`, not on reading it),
and names the codes its rows depend on so removing one reds here.

---

## Mutation results

Applied to a clean tree, one at a time, restored after each. "before" is the
same mutation against the parent of `0d85915`.

| mutation | before | after |
|---|---|---|
| `continue-on-error: true` on the `--check` step | green | **red** |
| `if: ${{ github.event_name == 'schedule' }}` on that step | green | **red** |
| `... convert-zh-tw.py --check \|\| true` | green | **red** |
| `unit` job's `if` switched to `desktop_rust` | green | **red** |
| `/^src\/locales\// { next }` added to the `CODE` filter | green | **red** |
| `unit` removed from `deploy-gate.yml` `required` | red | **red** |
| `CATALOGUES` emptied | green | **red** |
| the only `pro-test` per-entry rule retired, in both tables | green | **red** |
| `"訪問": "访问"` + regenerate | red (see item 3) | **red** |
| `"高階": "进阶"` + regenerate | green | **red** |
| `locales:zh-tw:check` loses `--check` | n/a | **red** |
| `zh-TW` removed from `SUPPORTED_LANGUAGES` | green | **red** |
| `--chek` | exit 0, both catalogues rewritten | exit 2, nothing written |
| key added to `en.json`, `npm run sync:locales` | writes English into `zh-TW.json` | leaves it alone |

Control: rewriting one of the mutated files with no textual change is green, so
the harness is not producing the reds by itself.

## Verification

- `test:data` against `4a3fa3d`: **314 unique failing names on both sides, and
  the two-way difference is empty in both directions.** Branch 23930 tests /
  23682 pass / 235 fail; baseline 23914 / 23666 / 235. The +16 tests and +5
  suites are exactly what these five commits add. The standing failures are
  identical on both sides — this checkout is Windows and a number of suites
  assert POSIX path separators.
- `test:dom`: 39 files / 358 tests, all passing.
- `typecheck`, `typecheck:dom-tests`, `lint`, `sync:locales:check`
  (27 files / 2684 keys each), `convert-zh-tw.py --check`: all clean.
- All 14 changed blobs: 0 NUL bytes, 0 CR bytes, no BOM.

## Not measured

- The prompt effect of the `NewsPanel` change.
  `server/worldmonitor/news/v1/_shared.ts:76`
  uppercases the language code straight into the prompt (`in ZH-TW language`,
  and `into zh-TW` in translate mode), so passing the script-bearing tag is
  necessary; whether the code should be a language name instead is a separate
  decision. There is no LLM provider running locally, so the tests assert the
  arguments the call sites pass, not what a model returns.
- Whether `en.json`'s Chinese sources are right. `zh.json` is the input to the
  generator; anything wrong in it converts faithfully.
