### PR TITLE
test(helpers): teach the bundle-section scanner regex literals, re-exports, and word boundaries

### DIFF
--- a/tests/bundle-section-parser.test.mjs
+++ b/tests/bundle-section-parser.test.mjs
@@ -274,3 +274,58 @@ test('a section declaring a nested timeoutMs is dropped rather than mis-read', (
   assert.equal(extractBundleSections(sample).length, 0, 'ambiguous timeout must not be guessed');
   assert.equal(countSectionScriptKeys(stripped), 1, 'the count still sees the section, so the gate fails loudly');
 });
+
+// ── #6562 item 5: scanner residuals ──────────────────────────────────────
+
+test('stripLineComments: a regex literal containing // is not a line comment', () => {
+  // The exact shape from the issue: `const RE = /[//]/` used to truncate the
+  // file at the first slash pair, and the count cross-check blamed a
+  // commented-out section.
+  const src = [
+    "const RE = /[//]/;",
+    "const N = 5;",
+  ].join('\n');
+  const out = stripLineComments(src);
+  assert.match(out, /\/\[\/\/\]\//, 'the regex literal survives verbatim');
+  assert.match(out, /const N = 5;/, 'source after the regex literal survives');
+});
+
+test('stripLineComments: division and keyword-prefixed regexes stay intact', () => {
+  const src = [
+    'const half = 10 / 2 / 1;',
+    'function f(s) { return /[//]+$/g.test(s); }',
+    "const U = 'https://example.com//path';",
+  ].join('\n');
+  const out = stripLineComments(src);
+  assert.ok(out.includes('10 / 2 / 1'), 'division slashes are untouched');
+  assert.ok(out.includes('return /[//]+$/g.test(s)'), 'keyword-prefixed regex survives');
+  assert.match(out, /https:\/\/example\.com\/\/path/, 'URL in string survives');
+});
+
+test('resolver: follows a named import from a default-plus-named statement', () => {
+  // `import def, { X } from './y.mjs'` used to be invisible to the resolver.
+  const dir = mkdtempSync(join(tmpdir(), 'wm-bundle-parser-'));
+  const bundlePath = join(dir, 'seed-bundle-sample.mjs');
+  writeFileSync(join(dir, 'seed-thing.mjs'), 'export const THING_MS = 90_000;\n');
+  const src = "import defaultThing from './other.mjs';\nimport base, { THING_MS } from './seed-thing.mjs';\n";
+  writeFileSync(bundlePath, src);
+  assert.equal(resolveExpr(src, 'THING_MS', {}, { file: bundlePath }), 90_000);
+});
+
+test('resolver: follows an `export { X } from` re-export', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wm-bundle-parser-'));
+  const bundlePath = join(dir, 'seed-bundle-sample.mjs');
+  writeFileSync(join(dir, 'origin.mjs'), 'export const ORIGIN_MS = 45_000;\n');
+  writeFileSync(join(dir, 'middle.mjs'), "export { ORIGIN_MS as SHARED_MS } from './origin.mjs';\n");
+  const src = "import { SHARED_MS } from './middle.mjs';\n";
+  writeFileSync(bundlePath, src);
+  assert.equal(resolveExpr(src, 'SHARED_MS', {}, { file: bundlePath }), 45_000);
+});
+
+test('extractBundleOption requires a word boundary before the key', () => {
+  // Without the boundary, `fooMaxBundleMs:` satisfied a `maxBundleMs` lookup.
+  const sample = '], { fooMaxBundleMs: 999_000 });';
+  assert.equal(extractBundleOption(sample, 'maxBundleMs'), null);
+  const real = '], { maxBundleMs: 570_000 });';
+  assert.equal(extractBundleOption(real, 'maxBundleMs'), '570_000');
+});

--- a/tests/helpers/bundle-section-parser.mjs
+++ b/tests/helpers/bundle-section-parser.mjs
@@ -37,20 +37,38 @@ export const PRESEEDED = {
  * configuration, and a gate that reads a commented-out declaration reports on
  * code that does not run.
  */
+// Keywords after which a `/` starts a regex literal rather than division.
+// `return /re/.test(x)` is the realistic shape in this repo's scripts; without
+// the keyword check the previous-significant-character heuristic would read
+// the `n` of `return` as an operand end and swallow the regex as a comment.
+const KEYWORDS_BEFORE_REGEX = new Set([
+  'return', 'typeof', 'instanceof', 'in', 'of', 'new', 'delete', 'void',
+  'case', 'do', 'else', 'yield', 'await', 'throw',
+]);
+
 export function stripLineComments(src) {
   let out = '';
   let inStr = false;
   let strCh = '';
+  // Regex-vs-division state (#6562 item 5): a bare `/` starts a regex literal
+  // unless the previous significant token ENDS an operand (identifier, number,
+  // closing bracket, quote, or dot). Inside a regex literal `//` is not a
+  // comment — `const RE = /[//]/` used to truncate the file at that point.
+  let prevSignificant = '';
+  let lastWord = '';
+  const regexAllowed = () =>
+    (lastWord && KEYWORDS_BEFORE_REGEX.has(lastWord)) ||
+    !/[)\]\w$"'.]/.test(prevSignificant);
   for (let i = 0; i < src.length; i++) {
     const c = src[i];
     const next = src[i + 1];
     if (inStr) {
       out += c;
       if (c === '\\') { out += next ?? ''; i++; continue; }
-      if (c === strCh) inStr = false;
+      if (c === strCh) { inStr = false; prevSignificant = strCh; lastWord = ''; }
       continue;
     }
-    if (c === '"' || c === "'" || c === '`') { inStr = true; strCh = c; out += c; continue; }
+    if (c === '"' || c === "'" || c === '`') { inStr = true; strCh = c; out += c; prevSignificant = c; lastWord = ''; continue; }
     if (c === '/' && next === '/') {
       while (i < src.length && src[i] !== '\n') i++;
       out += '\n';
@@ -62,7 +80,37 @@ export function stripLineComments(src) {
       i++;                       // land on '/', loop's i++ steps past it
       continue;
     }
+    if (c === '/' && regexAllowed()) {
+      // Regex literal: emit it verbatim (it may contain `//` or `/*`),
+      // honoring character classes and escapes. A newline before the closing
+      // `/` means this was not a regex after all — emit the slash alone and
+      // let the rest of the line be re-examined as ordinary source.
+      const start = i;
+      i++;
+      let inClass = false;
+      let closed = false;
+      while (i < src.length) {
+        const rc = src[i];
+        if (rc === '\\') i++;
+        else if (rc === '[') inClass = true;
+        else if (rc === ']') inClass = false;
+        else if (rc === '/' && !inClass) { closed = true; break; }
+        else if (rc === '\n') break;
+        i++;
+      }
+      if (!closed) {
+        out += c;                // lone slash — division or malformed line
+        prevSignificant = c; lastWord = '';
+        continue;
+      }
+      out += src.slice(start, i + 1);
+      prevSignificant = '/'; lastWord = '';
+      continue;
+    }
     out += c;
+    if (/\s/.test(c)) continue; // whitespace keeps the previous token significant
+    if (/[\w$]/.test(c)) { lastWord += c; prevSignificant = c; }
+    else { lastWord = ''; prevSignificant = c; }
   }
   return out;
 }
@@ -107,22 +155,62 @@ export function safeEval(expr, scope = {}) {
  */
 function resolveImportedIdentifier(src, name, opts) {
   if (!opts.file) return null;
+  const follow = (specifier, importedName) => {
+    if (!specifier.startsWith('.')) return null;
+    const targetPath = resolve(dirname(opts.file), specifier);
+    let targetSrc;
+    try { targetSrc = readFileSync(targetPath, 'utf-8'); } catch { return null; }
+    return resolveIdentifier(stripLineComments(targetSrc), importedName, {}, {
+      ...opts,
+      file: targetPath,
+    });
+  };
+  // Default (optionally plus named) imports: `import X from`, `import def, { X } from`
+  // (#6562 item 5 — a default clause used to make the whole statement
+  // invisible to the named-import regex below).
+  for (const m of src.matchAll(/import\s+([\w$]+)\s*(?:,\s*\{([^}]*)\})?\s*from\s*['"]([^'"]+)['"]/g)) {
+    const defaultLocal = m[1];
+    const namedClause = m[2];
+    const specifier = m[3];
+    if (defaultLocal === name) {
+      // Default imports are not repo configuration in practice; resolving one
+      // would need export-default tracking. Fail closed instead of guessing.
+      return null;
+    }
+    if (namedClause == null) continue;
+    for (const clause of namedClause.split(',')) {
+      const parts = clause.trim().split(/\s+as\s+/).map((s) => s.trim()).filter(Boolean);
+      if (parts.length === 0) continue;
+      const imported = parts[0];
+      const local = parts[1] ?? imported;
+      if (local !== name) continue;
+      return follow(specifier, imported);
+    }
+  }
+  // Bare named imports without a default clause: `import { X } from`.
   for (const m of src.matchAll(/import\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g)) {
     const specifier = m[2];
-    if (!specifier.startsWith('.')) continue;
     for (const clause of m[1].split(',')) {
       const parts = clause.trim().split(/\s+as\s+/).map((s) => s.trim()).filter(Boolean);
       if (parts.length === 0) continue;
       const imported = parts[0];
       const local = parts[1] ?? imported;
       if (local !== name) continue;
-      const targetPath = resolve(dirname(opts.file), specifier);
-      let targetSrc;
-      try { targetSrc = readFileSync(targetPath, 'utf-8'); } catch { return null; }
-      return resolveIdentifier(stripLineComments(targetSrc), imported, {}, {
-        ...opts,
-        file: targetPath,
-      });
+      return follow(specifier, imported);
+    }
+  }
+  // Re-exports: `export { X } from '...'` / `export { X as Y } from '...'`.
+  // The alias is what THIS file exposes, so match on it, then resolve the
+  // original name inside the target module (#6562 item 5).
+  for (const m of src.matchAll(/export\s*\{([^}]*)\}\s*from\s*['"]([^'"]+)['"]/g)) {
+    const specifier = m[2];
+    for (const clause of m[1].split(',')) {
+      const parts = clause.trim().split(/\s+as\s+/).map((s) => s.trim()).filter(Boolean);
+      if (parts.length === 0) continue;
+      const original = parts[0];
+      const exposed = parts[1] ?? original;
+      if (exposed !== name) continue;
+      return follow(specifier, original);
     }
   }
   return null;
@@ -259,7 +347,11 @@ export function extractBundleSections(rawBundleSrc) {
  * declare it (an unbudgeted bundle).
  */
 export function extractBundleOption(rawBundleSrc, name) {
-  const m = stripLineComments(rawBundleSrc).match(new RegExp(`${name}:\\s*([^,}\\n]+)`));
+  // Word boundary before the key (#6562 item 5): without it a bundle declaring
+  // `fooMaxBundleMs:` would satisfy a `maxBundleMs` lookup. The gates also
+  // assert exactly one textual match per bundle; the boundary keeps that
+  // assertion meaningful rather than load-bearing.
+  const m = stripLineComments(rawBundleSrc).match(new RegExp(`(?<![\\w$])${name}:\\s*([^,}\\n]+)`));
   return m ? m[1].trim() : null;
 }
 


### PR DESCRIPTION
## Summary

The three `tests/helpers/bundle-section-parser.mjs` residuals from #6562 item 5. The gate already fails closed on each, so these are correctness-of-coverage improvements, not silent passes:

- **`stripLineComments` now recognizes regex literals.** A `/` after an operand-ending token is division; otherwise it starts a regex literal, scanned verbatim with character-class and escape handling plus a keyword set (`return`, `typeof`, ...) so `return /[//]/.test(x)` survives. Previously `const RE = /[//]/` truncated the file at the first slash pair and the `script:` count cross-check blamed a commented-out section.
- **`resolveImportedIdentifier` follows `import def, { X } from './y.mjs'` and `export { X } from './y.mjs'` / `export { X as Y } from` re-exports.** A default clause used to make the whole statement invisible to the named-import regex. Default imports themselves are deliberately NOT resolved (would need export-default tracking) — they fail closed to null, matching the parser's existing posture.
- **`extractBundleOption` requires a word boundary before the key.** `fooMaxBundleMs:` can no longer satisfy a `maxBundleMs` lookup; the gates' exactly-one-match assertion stays meaningful.

Per the issue: if bundle config ever grows beyond flat literals, the scanner should be replaced with a real parse — these fixes extend the existing scanner's reach without changing that recommendation.

Refs #6562 (item 5 only).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [x] CI / Build / Infrastructure

## Validation

- `node --test tests/bundle-section-parser.test.mjs` — 31 passed (26 existing + 5 new covering each residual)
- `node --test tests/bundle-budget-admission.test.mjs tests/seeder-canonical-ttl-vs-cron.test.mjs` — 4 passed (both gates over real bundle sources)
- `node --check tests/helpers/bundle-section-parser.mjs`
- `git diff --check`

## Checklist

- [x] No API keys or secrets committed
- [x] Parser regressions and both consuming gates pass

## AI-assisted development disclosure

ZCode assisted with implementing the scanner changes and regressions from the issue spec. I reviewed the final diff, ran the validation above, and take responsibility for the submitted change.