### PR TITLE
fix(refresh): release the lane latch on a scheduler-owned lease, not callback settlement

### DIFF
--- a/src/app/refresh-scheduler.ts
+++ b/src/app/refresh-scheduler.ts
@@ -1,9 +1,90 @@
 import type { AppContext, AppModule } from '@/app/app-context';
 import { startSmartPollLoop, VisibilityHub, type SmartPollLoopHandle } from '@/services/runtime';
 
+/**
+ * #6683: a lane's in-flight latch may only be held for a lease THIS scheduler
+ * owns. `finally` releases the latch only when the awaited callback settles,
+ * and a callback whose network call never settles — a third-party `fetch`
+ * wrapper that rebuilds the request without `init.signal`, or re-wraps the
+ * promise without forwarding rejection — parks the lane for the life of the
+ * page with no outward symptom. Racing a scheduler-owned deadline mirrors
+ * `withCollectorDeadline` from #6681 and inherits its two lessons:
+ *
+ *  1. the race wraps the WHOLE callback promise, so every `await` between
+ *     latch-acquire and latch-release is inside the bound, not just the first
+ *     fetch (the collector's first fix missed the response-body read);
+ *  2. the lease sits a grace period above any request-side
+ *     `AbortSignal.timeout`, so a cooperative lane always wins its own race
+ *     and is never miscounted as wedged.
+ *
+ * The request-side bound is each lane's own `AbortSignal.timeout(...)` and is
+ * not declared here, so the lease is floored well above typical request
+ * timeouts and anchored to the lane's interval; only the already-anomalous
+ * stalled tail ever reaches it (a healthy lane settles in milliseconds).
+ */
+const LANE_LEASE_FLOOR_MS = 15_000;
+const LANE_LEASE_GRACE_MS = 5_000;
+
+function laneLeaseMs(intervalMs: number): number {
+  return Math.max(intervalMs, LANE_LEASE_FLOOR_MS) + LANE_LEASE_GRACE_MS;
+}
+
+/**
+ * Run one refresh lane callback under a scheduler-owned lease (#6683).
+ * Extracted so the lease semantics are unit-testable in isolation.
+ *
+ * - the latch (`inFlight`) is released in a `finally` that now ALWAYS runs,
+ *   because the awaited promise is the callback raced against the lease —
+ *   never the bare callback, which may not settle at all;
+ * - the loser of the race is `.catch`-silenced so an abandoned callback's
+ *   late rejection cannot surface as an unhandled rejection on the page;
+ * - on expiry the lane warns (a wedged lane is otherwise indistinguishable
+ *   from one whose data has not changed). A refresh lane is idempotent — it
+ *   re-reads current state — so releasing and re-running is safe (no #6288
+ *   duplicate-write caveat). Cancellation of a cooperative callback stays
+ *   with the poll loop's own controller (stop()/hidden aborts), which this
+ *   scheduler now forwards via `fn(signal)` instead of dropping it.
+ */
+export async function runLaneWithLease(
+  name: string,
+  fn: (signal?: AbortSignal) => Promise<boolean | void>,
+  signal: AbortSignal | undefined,
+  intervalMs: number,
+  inFlight: Set<string>,
+  warn: (message: string) => void = console.warn,
+): Promise<boolean | void> {
+  if (inFlight.has(name)) return;
+  inFlight.add(name);
+  const leaseMs = laneLeaseMs(intervalMs);
+  let leaseTimer: ReturnType<typeof setTimeout> | undefined;
+  const lease = new Promise<{ expired: true }>((resolve) => {
+    leaseTimer = setTimeout(() => resolve({ expired: true }), leaseMs);
+  });
+  try {
+    const callback = Promise.resolve(fn(signal));
+    void callback.catch(() => {});
+    const settled = callback.then(
+      (value) => ({ expired: false as const, value }),
+      (error) => ({ expired: false as const, error }),
+    );
+    const raced = await Promise.race([settled, lease]);
+    if (raced.expired) {
+      warn(
+        `[App] Refresh ${name} lease expired after ${leaseMs}ms without settling — latch released and lane re-runnable; the callback is still parked (unbounded await, or a fetch wrapper that drops the abort signal)`,
+      );
+      return;
+    }
+    if ('error' in raced) throw raced.error;
+    return raced.value;
+  } finally {
+    if (leaseTimer !== undefined) clearTimeout(leaseTimer);
+    inFlight.delete(name);
+  }
+}
+
 export interface RefreshRegistration {
   name: string;
-  fn: () => Promise<boolean | void>;
+  fn: (signal?: AbortSignal) => Promise<boolean | void>;
   intervalMs: number;
   condition?: () => boolean;
   runImmediately?: boolean;
@@ -44,24 +125,19 @@ export class RefreshScheduler implements AppModule {
 
   scheduleRefresh(
     name: string,
-    fn: () => Promise<boolean | void>,
+    fn: (signal?: AbortSignal) => Promise<boolean | void>,
     intervalMs: number,
     condition?: () => boolean,
     options: { runImmediately?: boolean } = {},
   ): void {
     this.refreshRunners.get(name)?.loop.stop();
 
-    const loop = startSmartPollLoop(async () => {
+    const loop = startSmartPollLoop(async (pollCtx) => {
       if (this.ctx.isDestroyed) return;
       if (condition && !condition()) return;
-      if (this.ctx.inFlight.has(name)) return;
-
-      this.ctx.inFlight.add(name);
-      try {
-        return await fn();
-      } finally {
-        this.ctx.inFlight.delete(name);
-      }
+      if (this.ctx.isDestroyed) return;
+      if (condition && !condition()) return;
+      return runLaneWithLease(name, fn, pollCtx?.signal, intervalMs, this.ctx.inFlight);
     }, {
       intervalMs,
       pauseWhenHidden: true,

--- a/tests/smart-poll-loop.test.mjs
+++ b/tests/smart-poll-loop.test.mjs
@@ -730,3 +730,96 @@ describe('VisibilityHub', () => {
     hub.destroy();
   });
 });
+
+describe('runLaneWithLease (#6683)', () => {
+  const schedulerRaw = readFileSync(resolve(__dirname, '..', 'src', 'app', 'refresh-scheduler.ts'), 'utf-8');
+  const schedulerSrc = stripTS(schedulerRaw)
+    .replace(/:\s*ReturnType<typeof\s+setTimeout>\s*\|\s*undefined/g, '')
+    .replace(/new Promise<\{ expired: true \}>/g, 'new Promise')
+    .replace(/\s+as\s+const\b/g, '')
+    .replace(/:\s*Promise<boolean\s*\|\s*void>/g, '')
+    .replace(/fn:\s*\(signal\?\)/g, 'fn')
+    .replace(/:\s*AbortSignal\s*\|\s*undefined/g, '')
+    .replace(/:\s*Set<string>/g, '')
+    .replace(/warn:\s*\(message\)\s*=>\s*void\s*=\s*console\.warn/g, 'warn = console.warn');
+
+  function buildRunLaneWithLease(timers) {
+    const leaseBody = extractBody(schedulerSrc, 'runLaneWithLease');
+    const factory = new Function(
+      'setTimeout', 'clearTimeout', 'console',
+      `
+      const LANE_LEASE_FLOOR_MS = 15000;
+      const LANE_LEASE_GRACE_MS = 5000;
+      function laneLeaseMs(intervalMs) { return Math.max(intervalMs, LANE_LEASE_FLOOR_MS) + LANE_LEASE_GRACE_MS; }
+      return async function runLaneWithLease(name, fn, signal, intervalMs, inFlight, warn) { ${leaseBody} };
+      `,
+    );
+    return factory(
+      timers.setTimeout.bind(timers),
+      timers.clearTimeout.bind(timers),
+      console,
+    );
+  }
+
+  it('releases the latch when the callback never settles, and re-runs are possible', async () => {
+    const timers = createFakeTimers();
+    const runLane = buildRunLaneWithLease(timers);
+    const inFlight = new Set();
+    const warns = [];
+    const ac = new AbortController();
+    let started = 0;
+    let passedSignal = undefined;
+    const neverSettles = (sig) => {
+      started += 1;
+      passedSignal = sig;
+      return new Promise(() => {});
+    };
+
+    const first = runLane('lane', neverSettles, ac.signal, 1000, inFlight, (m) => warns.push(m));
+    assert.ok(inFlight.has('lane'), 'latch held while running');
+    timers.advanceBy(20001);
+    await first;
+    assert.ok(!inFlight.has('lane'), 'latch released despite the callback never settling');
+    assert.equal(started, 1);
+    assert.equal(warns.length, 1);
+    assert.match(warns[0], /lease expired after 20000ms/);
+    assert.ok(passedSignal === ac.signal, 'the poll signal is forwarded to the callback');
+
+    const second = runLane('lane', async () => true, undefined, 1000, inFlight, (m) => warns.push(m));
+    assert.equal(await second, true);
+    assert.equal(warns.length, 1, 'healthy re-run does not warn');
+  });
+
+  it('healthy callback: value passes through, no warn, latch released', async () => {
+    const timers = createFakeTimers();
+    const runLane = buildRunLaneWithLease(timers);
+    const inFlight = new Set();
+    const warns = [];
+    const out = await runLane('lane', async () => false, undefined, 30000, inFlight, (m) => warns.push(m));
+    assert.equal(out, false, 'backoff sentinel passes through untouched');
+    assert.equal(warns.length, 0);
+    assert.ok(!inFlight.has('lane'));
+  });
+
+  it('rejected callback: the rejection propagates and the latch still releases', async () => {
+    const timers = createFakeTimers();
+    const runLane = buildRunLaneWithLease(timers);
+    const inFlight = new Set();
+    const warns = [];
+    await assert.rejects(
+      () => runLane('lane', async () => { throw new Error('boom'); }, undefined, 1000, inFlight, (m) => warns.push(m)),
+      /boom/,
+    );
+    assert.ok(!inFlight.has('lane'));
+    assert.equal(warns.length, 0, 'a real rejection is not a lease expiry');
+  });
+
+  it('an already-latched lane is a no-op', async () => {
+    const timers = createFakeTimers();
+    const runLane = buildRunLaneWithLease(timers);
+    const inFlight = new Set(['lane']);
+    let started = 0;
+    await runLane('lane', async () => { started += 1; }, undefined, 1000, inFlight);
+    assert.equal(started, 0);
+  });
+});


### PR DESCRIPTION
Fixes #6683.

## Summary

- `RefreshScheduler`'s in-flight latch is now released by a scheduler-owned lease raced against the whole callback promise — not by the `finally` of a bare `await fn()`, which only runs when the callback settles. A callback parked forever by a third-party `fetch` wrapper that drops `init.signal` (or re-wraps the promise without forwarding rejection) can no longer kill the lane for the life of the page.
- The lease logic lives in an extracted, exported `runLaneWithLease()` so the semantics are unit-testable in isolation; `scheduleRefresh` now forwards the poll loop's `AbortSignal` to the callback (`fn(signal)` — optional parameter, structurally compatible with every existing zero-arg registration), fixing the second hazard the issue names: this wrapper used to drop the signal, so stop()/hide aborts could never reach a cooperative callback.
- On expiry the lane emits a `console.warn` — the observability the issue asks for, since a wedged lane is otherwise indistinguishable from one whose data has not changed.

## Sizing and inherited lessons

Mirrors `withCollectorDeadline` from #6681 and inherits its two hard-won lessons:

1. **Every await between latch-acquire and latch-release is inside the bound** — the race wraps the entire callback promise, not the first fetch inside it (the collector's first fix missed the response-body read one line later).
2. **The lease sits strictly above the request-side bound** — `max(intervalMs, 15s floor) + 5s grace`, the same grace sizing as `LATCH_RELEASE_GRACE_MS`. A cooperative lane always wins its own race; only the already-anomalous stalled tail ever reaches the lease (a healthy lane settles in milliseconds and never arms it meaningfully).

A refresh lane is idempotent — it re-reads current state — so releasing the latch and re-running on the next tick is safe; #6288's duplicate-write caveat does not apply. The abandoned callback's late rejection is `.catch`-silenced so it cannot surface as an unhandled rejection. Cancellation of a cooperative callback stays with the poll loop's own controller (stop()/hidden aborts), which the scheduler now forwards instead of dropping; `AbortSignal` has no trigger-side `abort()`, so the lease deliberately does not attempt one.

## Validation

- `node --test tests/smart-poll-loop.test.mjs` — 32 passed (28 existing + 4 new: never-settling callback releases the latch after exactly the sized lease, warns once, and the signal is forwarded; healthy callback passes its value through with no warn and releases the latch; a real rejection propagates and is not miscounted as a lease expiry; an already-latched lane is a no-op). Fake-timer driven, no wall-clock sleeps.
- The new tests are built with the file's existing source-extraction pattern (`stripTS` + `extractBody` + injected timers), extended with the lease helper's type shapes.
- `git diff --check`
- typecheck/lint not runnable in this sandbox (no node_modules); CI covers them.

## Checklist

- [x] No API keys or secrets committed
- [x] Focused regressions pass under fake timers
- [x] RSS / Railway pre-seed checklist items are not applicable (frontend scheduler only)

## AI-assisted development disclosure

ZCode assisted with implementing the lease from the issue's suggested direction and writing the regressions. I reviewed the final diff, ran the validation above, and take responsibility for the submitted change.