### PR TITLE
test(dom): stop billing module-graph transform to a single test's timeout

### DIFF
--- a/tests/dom/fx-panel-data.test.mts
+++ b/tests/dom/fx-panel-data.test.mts
@@ -44,6 +44,17 @@ async function loadService() {
   return (await import('@/services/economic')).getFxPanelData;
 }
 
+// #6677: the FIRST dynamic import of the economic module graph pays for the
+// whole graph's transform (1.2MB of generated clients plus the i18n locale
+// glob), and that wall time is billed to whichever test runs it — under load
+// it lands ~10ms over the 5000ms vitest default and reddens this file as a
+// false positive. Subsequent resetModules() imports take ~35ms because they
+// reuse the transform cache and only re-execute. Importing the graph once at
+// module scope moves the transform cost into the file's import phase, which
+// vitest does not bill to any testTimeout. The vi.mock calls above still
+// apply to every later re-import, so the reset semantics are unchanged.
+await import('@/services/economic');
+
 const YOY = {
   rates: [
     { countryCode: 'AR', currency: 'ARS', yoyChange: -38.4, drawdown24m: -41, asOf: '2026-08-01' },

--- a/tests/dom/story-data-cached-cii.test.mts
+++ b/tests/dom/story-data-cached-cii.test.mts
@@ -22,6 +22,15 @@ afterEach(() => {
   else Reflect.deleteProperty(globalThis, 'localStorage');
 });
 
+// #6677: this file's single test pays for the story-data module graph's
+// transform (the generated IntelligenceServiceClient alone is ~1.9k lines)
+// inside its testTimeout, which under load lands just over the 5000ms vitest
+// default — a false red on a green tree. Importing the graph once at module
+// scope moves the transform cost into the file's import phase, which vitest
+// does not bill to any testTimeout. The vi.resetModules() in beforeEach still
+// re-executes the module against this test's localStorage afterwards.
+await import('../../src/services/story-data.ts');
+
 it('selects the canonical cached score for a normalized country code', async () => {
   localStorage.setItem('wm:risk-scores', JSON.stringify({
     savedAt: Date.now(),


### PR DESCRIPTION
Fixes #6677.

## Diagnosis (what the two tests were actually waiting on)

Not a timer, not an unmocked network call — **the module graph's first transform**. Measured on a full `test:dom` run with per-test durations:

| test | before | after |
|---|---|---|
| `fx-panel-data > returns all four sources...` (first `loadService()`) | **2911ms** | 82ms |
| every later `loadService()` in the same file | 35-192ms | 48-89ms |
| `story-data-cached-cii` (single test, single import) | **907ms** | 32ms |

The first dynamic `import('@/services/economic')` pays for transforming the whole graph (the 1.2MB of generated OpenAPI clients plus the i18n `import.meta.glob` locale dictionaries); every subsequent `vi.resetModules()` + import reuses the transform cache and only re-executes, which is why these two files sat alone at ~5s under load while the other 31 stayed fast — and why the outcome flipped with wall-clock duration only. That transform wall time is billed to whichever test runs it, and under load it lands ~10ms over vitest's default 5000ms `testTimeout` — the false red from the issue.

## Fix

Import the graph once at module scope in both files. The transform cost moves into the file's **import phase**, which vitest does not bill to any `testTimeout` — exactly the "remove what they are waiting on" remedy the issue asks for, not a timeout bump. The `vi.resetModules()` per test is untouched, so the ECB circuit-breaker cache isolation (the reason `loadService()` exists, per the file's own header) is unchanged; `vi.mock` applies to every re-import as before.

## Validation

- Full `npx vitest run --config vitest.dom.config.mts` — **37 files / 344 tests passed**; the two formerly-5s tests now run in 32-89ms under the same full-suite load
- Single-file runs of both files remain green
- `git diff --check`

Note: this sandbox installed vitest+happy-dom fresh (`npm install --no-save vitest happy-dom`) to reproduce the issue's measurements; CI numbers may differ in absolute terms but the billing mechanism (transform in first in-test import vs import phase) is structural.

## Checklist

- [x] No API keys or secrets committed
- [x] Full dom suite green with per-test timing evidence

## AI-assisted development disclosure

ZCode assisted with the measurement, diagnosis, and fix. I reviewed the final diff, ran the validation above, and take responsibility for the submitted change.