### PR TITLE
test(e2e): charge digest counts against a post-boot baseline, not absolute totals

### DIFF
--- a/e2e/settings-source-live-apply.spec.ts
+++ b/e2e/settings-source-live-apply.spec.ts
@@ -170,17 +170,24 @@ test.describe('settings source live apply (#6380)', () => {
   test('toggling sources and closing Settings reloads news once, without a reload', async ({ page }) => {
     await seedProFullVariant(page);
     const log = await bootUntilNewsSettles(page);
+    // #6724: snapshot the count AFTER the boot check passes, so a late boot
+    // digest is never charged to the toggle assertion below.
+    const baseline = log.urls.length;
 
     await openSourcesTab(page);
     const disabled = await disableFirstSources(page, TOGGLE_COUNT);
 
     // Clicking inside the modal must not refetch — the overlay covers the
     // dashboard, so a per-click load is pure request spend the user cannot see.
+    // #6724: a late boot digest that lands after the SETTLE_MS window but
+    // before this assertion was charged to the toggle. Snapshot the count
+    // after the boot check passes, then assert the delta across the modal
+    // interaction — a straggler that predates the modal cannot inflate it.
     expect(
-      log.urls.length,
+      log.urls.length - baseline,
       `toggling ${TOGGLE_COUNT} sources inside the open modal must not issue a news load ` +
-        `(requests: ${log.urls.length})`,
-    ).toBe(1);
+        `(requests since boot settle: ${log.urls.length - baseline}, baseline: ${baseline})`,
+    ).toBe(0);
 
     const secondDigest = page.waitForRequest(DIGEST_GLOB, { timeout: 30_000 });
     await page.locator('.unified-settings-close').click();
@@ -190,26 +197,29 @@ test.describe('settings source live apply (#6380)', () => {
 
     // ...and exactly one, not one per toggle. Wait out the same window the boot
     // check used, so a delayed storm cannot slip past after the first arrival.
+    // #6724: same baseline-delta pattern as the toggle assertion above.
     await page.waitForTimeout(SETTLE_MS);
     expect(
-      log.urls.length,
+      log.urls.length - baseline,
       `disabling ${disabled.length} sources (${disabled.join(', ')}) must cost exactly one ` +
-        `extra news load, not one per click (requests: ${log.urls.length})`,
-    ).toBe(2);
+        `extra news load, not one per click (requests since baseline: ${log.urls.length - baseline})`,
+    ).toBe(1);
   });
 
   test('closing Settings without touching sources issues no news load', async ({ page }) => {
     await seedProFullVariant(page);
     const log = await bootUntilNewsSettles(page);
+    // #6724: same baseline-delta pattern.
+    const baseline = log.urls.length;
 
     await openSourcesTab(page);
     await page.locator('.unified-settings-close').click();
     await page.waitForTimeout(SETTLE_MS);
 
     expect(
-      log.urls.length,
+      log.urls.length - baseline,
       `an unchanged source selection has the same news work-list, so closing Settings must ` +
-        `not spend a digest request (requests: ${log.urls.length})`,
-    ).toBe(1);
+        `not spend a digest request (requests since baseline: ${log.urls.length - baseline})`,
+    ).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #6724.

## Summary

The toggle assertion at `e2e/settings-source-live-apply.spec.ts:183` intermittently fails with `Expected: 1, Received: 2` in `variant-smoke-full`. The boot assertion in the same run PASSED (count was 1 at line 124), so a second digest arrived *after* the 8s `SETTLE_MS` window but *before* the toggle assertion — on a loaded runner a boot-path digest can land later than 8s.

The fix is the issue's option 2: snapshot `log.urls.length` immediately after the boot check passes, then assert the **delta** across the modal interaction. A straggler that predates the modal cannot inflate the delta. Applied to both tests in the suite:

1. **Toggle assertion** (line 183): was `toBe(1)` against absolute count → now `toBe(0)` against `log.urls.length - baseline`
2. **Close-without-touching assertion** (line 221): same pattern
3. **Post-close digest count** (line 205): was `toBe(2)` → now `toBe(1)` against delta (one new digest after close is correct regardless of boot count)

The boot assertion inside `bootUntilNewsSettles` keeps its absolute `toBe(1)` — that IS the boot property, and the baseline is snapshotted after it.

## Why not option 1 (real idle check)

Option 1 (wait for no-request-for-N-ms) would be the stronger fix but requires a polling loop in `bootUntilNewsSettles` and changes the boot helper's contract for all its callers. Option 2 is a two-line change per test that removes the false failure while keeping the property the test defends (toggling must not refetch).

## Validation

- Syntax + pattern verification: 2 baseline declarations, 6 delta assertions, boot assertion unchanged
- No Playwright runner in this sandbox; CI covers the e2e suite
- `git diff --check`

## AI-assisted development disclosure

ZCode assisted with implementing the baseline-delta pattern from the issue's suggested fix. I reviewed the final diff, ran the validation above, and take responsibility for the submitted change.