### PR TITLE
fix(geometry): bound the country GeoJSON fetch with a timeout signal

### DIFF
--- a/src/services/country-geometry.ts
+++ b/src/services/country-geometry.ts
@@ -14,6 +14,10 @@ interface CountryHit {
 }
 
 const COUNTRY_GEOJSON_URL = '/data/countries.geojson';
+/** The base GeoJSON is the module-level gate for every geometry consumer;
+ * a hung fetch parks `loadPromise` forever, so bound it well above a normal
+ * static-asset load but well below "stuck for the session". */
+const COUNTRY_GEOJSON_TIMEOUT_MS = 15_000;
 
 /** Optional higher-resolution boundary overrides sourced from Natural Earth (served from R2 CDN). */
 const COUNTRY_OVERRIDES_URL = 'https://maps.worldmonitor.app/country-boundary-overrides.geojson';
@@ -254,7 +258,14 @@ async function ensureLoaded(): Promise<void> {
 
     markLcpDebug('wm:data:country-geometry-fetch-start');
     try {
-      const response = await fetch(COUNTRY_GEOJSON_URL);
+      // Bound the fetch: `loadPromise` is cached at module scope, so an
+      // unbounded await parks every future ensureLoaded() caller forever —
+      // the map never renders country boundaries and coordinate lookups
+      // silently degrade. The override fetch below already carries a signal;
+      // this is the same treatment for the primary asset.
+      const response = await fetch(COUNTRY_GEOJSON_URL, {
+        signal: makeTimeout(COUNTRY_GEOJSON_TIMEOUT_MS),
+      });
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }


### PR DESCRIPTION
## Summary

The primary country GeoJSON fetch in `ensureLoaded()` (`src/services/country-geometry.ts:257`) was a bare `await fetch(COUNTRY_GEOJSON_URL)` with no abort signal. `loadPromise` is cached at module scope, so a hung CDN fetch parks every future `ensureLoaded()` caller forever — the map never renders country boundaries and `getCountryAtCoordinates` silently degrades for the rest of the session. The `catch` at the end only fires on rejection, which an unbounded fetch never produces.

The override fetch a few lines below already carries `signal: makeTimeout(COUNTRY_OVERRIDE_TIMEOUT_MS)` — this is the same treatment for the primary asset, with a 15s timeout sized well above a normal static-asset load but well below "stuck for the session".

This is the same failure shape #6683 documented for the refresh scheduler (and #6288 for the collector queue): a shared resource gated on an unbounded await.

## Validation

- `git diff --check`
- Full `npx vitest run --config vitest.dom.config.mts`: identical pass/fail set with and without this change (35 test files fail in both cases — a pre-existing sandbox infrastructure issue, not caused by this diff; CI covers the suite)
- The pattern is identical to the override fetch's existing timeout

## Checklist

- [x] No API keys or secrets committed

## AI-assisted development disclosure

ZCode assisted with identifying the unguarded fetch and implementing the timeout. I reviewed the final diff, ran the validation above, and take responsibility for the submitted change.