### PR TITLE
fix(sentry): name the Umami beacon rejection instead of guessing it from chunks (#6746)

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -333,6 +333,22 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /Unexpected identifier 'm'/, // Foreign script injection on Opera; pre-compiled bundle can't parse-fail at runtime (WORLDMONITOR-NT)
       /PlayerControlsInterface\.\w+ is not a function/, // Android Chrome WebView native bridge injection (Bilibili/UC/QQ-style host) — never emitted by our code (WORLDMONITOR-P2)
       /github\.com\/styled-components\/styled-components\/blob/, // styled-components runtime error (errors.md#N URL); we don't depend on styled-components, so it can only be a browser extension (Grammarly et al.) injecting its own bundle — WORLDMONITOR-SE
+      // The Umami tracker's beacon POST failed at the network layer and the
+      // tracker (third-party, served from abacus.worldmonitor.app) leaked its
+      // own rejection. A dropped analytics beacon is invisible to the user and
+      // unactionable — same disposition as the host-suffixed
+      // `Failed to fetch (abacus.worldmonitor.app)` already covered by
+      // THIRD_PARTY_FETCH_HOST_ALLOWLIST above; this is the bare-message variant
+      // that carries no host to match on (WORLDMONITOR-Z6/ZG, #6746).
+      //
+      // This belongs in ignoreErrors, not the stack-gated beforeSend block,
+      // precisely BECAUSE the string is ours: `CollectorTransportError` is
+      // constructed at exactly one line (analytics-collector-transport.ts) for
+      // exactly one condition, so the match has no blind spot to trade away.
+      // The rule that keeps generic runtime/network phrasings out of this array
+      // exists because they can also come from our own minified bundle and would
+      // hide real bugs — an exact marker we mint ourselves is the opposite case.
+      /^(?:CollectorTransportError: )?Umami collector beacon transport rejected\b/,
     ],
     beforeSend(event) {
       const msg = event.exception?.values?.[0]?.value ?? '';
@@ -632,8 +648,40 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // collector frame plus a fetch-free trampoline for every remaining frame, so
       // admitting it cannot hide a first-party fetch — a real caller alongside the
       // extension still surfaces, which the regression tests assert.
+      // SUPERSEDED for new builds, RETAINED for old ones (#6746). The collector
+      // now rejects with a named `CollectorTransportError` that ignoreErrors
+      // matches exactly, so this stack-shape heuristic is no longer how the
+      // class is identified going forward. It stays because a browser running a
+      // cached pre-#6746 bundle still emits the bare `Failed to fetch`, and
+      // those sessions keep their coverage until the bundle ages out.
+      //
+      // DO NOT widen the chunk allowlist below to close a new escape of this
+      // class — that is the sixth-round trap. The allowlist is safe only while
+      // every chunk it names is caller-free, and Rollup re-partitions freely:
+      // `analytics-*.js` already carries `runtime.ts`, the interceptor every API
+      // request passes through. Adding it would suppress genuine
+      // api.worldmonitor.app outages. Fix new escapes at the source, the way
+      // CollectorTransportError does. `tests/debugbear-trampoline-chunks.test.mjs`
+      // now checks the built chunks, not just their namesake source files.
       const isExtensionFrameFile = (file: string) =>
         /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(file);
+      // On the chunk allowlist below (#6746): `panel-storage` is retained but is
+      // NO LONGER EMITTED as a chunk — the current build folds that module into
+      // `font-settings-*.js` and `analytics-*.js` — so that arm now matches only
+      // bundles cached from before the repartition. It still covers them
+      // (WORLDMONITOR-VC), which is why it is not deleted, but it cannot be
+      // verified against a current artifact and is therefore declared in
+      // KNOWN_ABSENT_CHUNKS in tests/debugbear-trampoline-chunks.test.mjs rather
+      // than silently trusted. `widget-store` is the arm still checked against a
+      // real built chunk.
+      //
+      // DO NOT add a chunk here to close a new escape of this class — that is
+      // the sixth-round trap. The allowlist is safe only while every chunk it
+      // names is caller-free, and Rollup repartitions freely: `analytics-*.js`
+      // already carries `runtime.ts`, the interceptor every API request passes
+      // through, so admitting it would suppress genuine api.worldmonitor.app
+      // outages. Fix new escapes at the source, the way CollectorTransportError
+      // does in analytics-collector-transport.ts.
       const isTrampolineFrameFunction = (fn: string) =>
         /^(?:\w{1,3}\.)?(?:window\.)?fetch$/.test(fn) || /^\w{1,2}$/.test(fn)
         || fn === '' || fn === '?';

--- a/src/services/analytics-collector-transport.ts
+++ b/src/services/analytics-collector-transport.ts
@@ -129,6 +129,43 @@ export class CollectorDeliveryError extends Error {
 }
 
 /**
+ * Identity for the network-layer rejection handed back to the TRACKER.
+ *
+ * The tracker is third-party code served from abacus.worldmonitor.app and does
+ * not handle its own rejection, so a failed beacon surfaced as an unhandled
+ * `TypeError: Failed to fetch` — no host in the message, no caller in the stack,
+ * and therefore indistinguishable in Sentry from a genuine api.worldmonitor.app
+ * outage. Five rounds of chunk-name heuristics tried to tell them apart from the
+ * stack instead (WORLDMONITOR-VC/VQ/Y4/Z6/ZG); each broke the next time Vite
+ * re-partitioned the `window.fetch` trampolines into a different chunk, and the
+ * chunk that carries them now also carries `runtime.ts`, so no widening of that
+ * allowlist can stay safe. Naming the rejection at its source is the stable
+ * form of the same intent: one exact string, from one line, for one condition.
+ *
+ * What this deliberately does NOT change is WHICH outcomes reject. An HTTP error
+ * still resolves with the real Response (see `runCollectorRequest`) — only a
+ * network-layer failure ever reaches this wrapper — so the native-fetch
+ * semantics the tracker expects are preserved and only the rejection's identity
+ * moves. Scope is bounded to classified collector writes: the pass-through
+ * branches in `installCollectorFetchGate` hand app fetches the untouched
+ * original promise, so no first-party request can acquire this wrapper.
+ *
+ * The original error is retained on `cause` so failure classification stays
+ * exact — `collectorFailureFromError` unwraps it rather than flattening every
+ * wrapped timeout into `network`.
+ */
+export class CollectorTransportError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(`Umami collector beacon transport rejected: ${detail}`);
+    this.name = 'CollectorTransportError';
+    this.cause = cause;
+  }
+}
+
+/**
  * Depth of the serialization queue in front of the single in-flight slot.
  *
  * MUST stay >= `UMAMI_QUEUE_LIMIT` in `src/services/analytics.ts`. That buffer
@@ -431,6 +468,11 @@ export async function inspectCollectorResponse(response: Response): Promise<Coll
 }
 
 export function collectorFailureFromError(error: unknown): CollectorFailure {
+  // Unwrap the tracker-facing wrapper first: without this, a wrapped
+  // TimeoutError would miss the `TimeoutError` branch below and be recorded as
+  // `network`, silently corrupting the timeout/raced split the health cohorts
+  // are built on.
+  if (error instanceof CollectorTransportError) return collectorFailureFromError(error.cause);
   if (error instanceof CollectorDeliveryError) return error.failure;
   if (error instanceof Error && error.name === 'TimeoutError') {
     // A platform abort and this module's latch deadline both arrive as
@@ -982,10 +1024,43 @@ async function runCollectorRequest(request: CollectorRequest, generation: number
     if (failure) request.rejectDelivery(new CollectorDeliveryError(failure));
     else request.resolveDelivery(response);
   } catch (error) {
+    const failure = collectorFailureFromError(error);
     if (generation === collectorTransportGeneration) {
-      recordCollectorOutcome(request, collectorFailureFromError(error));
+      recordCollectorOutcome(request, failure);
     }
-    request.reject(error);
+    // Only the TRACKER-facing promise is renamed, and only for the failure shape
+    // that arrives ANONYMOUS. The tracker leaks its rejection, so this is the
+    // promise that reaches Sentry (see CollectorTransportError).
+    //
+    // Scoped to `network` because that is the whole ambiguity: the raw error
+    // there is a bare `TypeError: Failed to fetch`, which carries no host and no
+    // caller and is therefore indistinguishable from a first-party API outage.
+    // A `timeout` already rejects with a distinctly-named `TimeoutError` that
+    // Sentry groups on its own and our filters already recognise, so renaming it
+    // would buy nothing while breaking the identity the timeout suite pins in a
+    // dozen places (#6086 / #6288). Anything unrecognised classifies as
+    // `network` and is therefore wrapped by default — the fail-safe direction,
+    // since an unnamed rejection is exactly what must not reach Sentry
+    // unattributed.
+    //
+    // A CALLER cancellation is never wrapped. When the caller aborts with its
+    // own reason, that exact object propagates through the forwarded
+    // AbortController and must come back identity-equal — a contract the
+    // compatibility suite asserts with `error === reason`
+    // (tests/analytics-beacon-rejection.test.mts). It also needs no attribution:
+    // the caller already knows why it aborted. Detected by identity rather than
+    // by shape, because a caller reason is an arbitrary value that classifies as
+    // `network` like anything else unrecognised.
+    //
+    // `delivery` keeps the raw error either way: it is our own internal signal,
+    // and the retry policy and health cohorts classify off it.
+    const callerSignal = request.init?.signal;
+    const isCallerCancellation = callerSignal?.aborted === true && callerSignal.reason === error;
+    request.reject(
+      failure.kind === 'network' && !isCallerCancellation
+        ? new CollectorTransportError(error)
+        : error,
+    );
     request.rejectDelivery(error);
   } finally {
     timeoutBoundInit?.cleanup();

--- a/tests/collector-transport-rejection-identity.test.mts
+++ b/tests/collector-transport-rejection-identity.test.mts
@@ -1,0 +1,185 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+/**
+ * WORLDMONITOR-Z6 / ZG (#6746).
+ *
+ * The Umami tracker is third-party code that does not handle its own rejection,
+ * so a failed beacon POST used to surface as an unhandled bare
+ * `TypeError: Failed to fetch` — no host in the message, no caller in the stack.
+ * Sentry could not separate it from a genuine api.worldmonitor.app outage, and
+ * five rounds of chunk-name heuristics that tried to do it from the stack each
+ * broke on the next Vite re-partition.
+ *
+ * The fix gives the rejection an identity at its source. These tests pin the
+ * three properties that make that identity load-bearing:
+ *
+ *   1. The tracker-facing rejection carries the marker.
+ *   2. The shipped Sentry filter actually matches that marker.
+ *   3. Naming it did not corrupt the failure classification the health cohorts
+ *      and the retry policy read.
+ */
+
+const _store = new Map<string, string>();
+before(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      localStorage: {
+        getItem: (k: string) => _store.get(k) ?? null,
+        setItem: (k: string, v: string) => { _store.set(k, v); },
+        removeItem: (k: string) => { _store.delete(k); },
+      },
+      fetch: () => Promise.reject(new TypeError('Failed to fetch')),
+    },
+  });
+});
+
+const {
+  CollectorTransportError,
+  CollectorDeliveryError,
+  collectorFailureFromError,
+  configureCollectorTransport,
+  installCollectorFetchGate,
+  resetCollectorTransportForTesting,
+} = await import('../src/services/analytics-collector-transport.ts');
+
+const COLLECTOR_ENDPOINT = 'https://abacus.worldmonitor.app/api/send';
+
+/** Same shape the module builds for its own latch deadline. */
+function timeoutError(raced: boolean): Error {
+  const error = new Error('collector deadline elapsed');
+  error.name = 'TimeoutError';
+  (error as Error & { collectorLatchRaced?: boolean }).collectorLatchRaced = raced;
+  return error;
+}
+
+describe('collector transport rejection identity (WORLDMONITOR-Z6/ZG)', () => {
+  // The assertions below this one all exercise the class in isolation, which
+  // would keep passing if the dispatch site stopped USING it. This drives a real
+  // collector write through the installed gate so the call site itself is pinned
+  // — reverting `runCollectorRequest` to `request.reject(error)` fails here.
+  it('rejects the TRACKER-facing promise with the marker, and delivery with the raw error', async () => {
+    resetCollectorTransportForTesting();
+    const outcomes: unknown[] = [];
+    configureCollectorTransport({
+      endpoint: COLLECTOR_ENDPOINT,
+      isCriticalEvent: () => false,
+      onOutcome: (outcome) => { outcomes.push(outcome); },
+      reportEnvironmentHealth: async () => true,
+    });
+    assert.ok(installCollectorFetchGate(), 'gate must install over the stubbed window.fetch');
+
+    // window.fetch is stubbed (see `before`) to reject with a bare
+    // `TypeError: Failed to fetch` — the exact production shape.
+    const transport = (window as unknown as { fetch: typeof fetch }).fetch(COLLECTOR_ENDPOINT, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'event', payload: { name: 'triage-probe' } }),
+    });
+
+    const rejection = await transport.then(
+      () => { throw new Error('collector write should not resolve when the network fails'); },
+      (error: unknown) => error,
+    );
+
+    assert.ok(
+      rejection instanceof CollectorTransportError,
+      `tracker-facing rejection must carry the marker, got: ${String(rejection)}`,
+    );
+    // And the raw browser error must survive underneath, or classification and
+    // diagnosis both lose the real cause.
+    assert.ok((rejection as InstanceType<typeof CollectorTransportError>).cause instanceof TypeError);
+
+    resetCollectorTransportForTesting();
+  });
+
+  it('leaves an already-named TimeoutError unwrapped', () => {
+    // The wrap is scoped to the ANONYMOUS shape. A timeout already rejects with
+    // a distinctly-named TimeoutError that Sentry groups on its own, and the
+    // #6086/#6288 timeout suites pin that identity on the tracker-facing promise
+    // in a dozen places. Renaming it would buy no attribution and break a real
+    // contract, so this pins the narrowing rather than leaving it incidental.
+    assert.equal(collectorFailureFromError(timeoutError(false)).kind, 'timeout');
+    assert.equal(collectorFailureFromError(new TypeError('Failed to fetch')).kind, 'network');
+  });
+
+  it('names the beacon failure instead of passing the bare browser error through', () => {
+    const wrapped = new CollectorTransportError(new TypeError('Failed to fetch'));
+
+    assert.equal(wrapped.name, 'CollectorTransportError');
+    assert.match(wrapped.message, /^Umami collector beacon transport rejected: /);
+    // The underlying browser phrasing is retained for diagnosis — the point is
+    // that it is no longer the WHOLE message, which is what made it
+    // indistinguishable from a first-party outage.
+    assert.match(wrapped.message, /Failed to fetch$/);
+  });
+
+  it('the shipped Sentry ignoreErrors entry matches that exact message', () => {
+    // Read the pattern out of the shipped config rather than restating it, so a
+    // rename on either side fails here instead of silently un-filtering the
+    // class in production.
+    const sentryInit = readFileSync(
+      new URL('../src/bootstrap/sentry-init.ts', import.meta.url),
+      'utf8',
+    );
+    const entry = sentryInit.match(
+      /^\s*(\/\^\?*\(\?:CollectorTransportError: \)\?Umami collector beacon transport rejected\\b\/),\s*$/m,
+    ) ?? sentryInit.match(/^\s*(\/[^\n]*Umami collector beacon transport rejected[^\n]*\/),\s*$/m);
+    assert.ok(
+      entry,
+      'sentry-init.ts must carry an ignoreErrors entry for the collector beacon marker — ' +
+        'without it the rejection is named but still reported, and Z6/ZG stay open.',
+    );
+
+    // Rebuild the literal and check it against the real message, so the test
+    // proves the filter FIRES rather than merely that a line exists.
+    const source = entry[1].replace(/^\//, '').replace(/\/$/, '');
+    const pattern = new RegExp(source);
+    const message = new CollectorTransportError(new TypeError('Failed to fetch')).message;
+    assert.ok(
+      pattern.test(message),
+      `the shipped pattern ${entry[1]} does not match the message the code emits (${message})`,
+    );
+
+    // Counter-check: it must NOT swallow a bare first-party fetch failure, which
+    // is the whole reason the chunk-name allowlist could not be widened.
+    assert.equal(pattern.test('Failed to fetch'), false);
+    assert.equal(pattern.test('TypeError: Failed to fetch'), false);
+  });
+
+  it('keeps timeout classification exact through the wrapper', () => {
+    // A wrapped TimeoutError that fell through to `network` would silently
+    // corrupt the timeout/raced split the health cohorts are built on — the
+    // failure mode that makes "just wrap it" quietly wrong.
+    assert.deepEqual(
+      collectorFailureFromError(new CollectorTransportError(timeoutError(false))),
+      { kind: 'timeout' },
+    );
+    assert.deepEqual(
+      collectorFailureFromError(new CollectorTransportError(timeoutError(true))),
+      { kind: 'timeout', raced: true },
+    );
+    assert.deepEqual(
+      collectorFailureFromError(new CollectorTransportError(new TypeError('Failed to fetch'))),
+      { kind: 'network' },
+    );
+  });
+
+  it('still unwraps a delivery failure carried through the wrapper', () => {
+    const failure = { kind: 'missing-receipt', status: 200 } as const;
+    assert.deepEqual(
+      collectorFailureFromError(new CollectorTransportError(new CollectorDeliveryError(failure))),
+      failure,
+    );
+  });
+
+  it('leaves the unwrapped classification path untouched', () => {
+    // The wrapper is additive: every pre-existing input must classify exactly as
+    // it did before, or the retry policy changes behaviour as a side effect.
+    assert.deepEqual(collectorFailureFromError(timeoutError(false)), { kind: 'timeout' });
+    assert.deepEqual(collectorFailureFromError(timeoutError(true)), { kind: 'timeout', raced: true });
+    assert.deepEqual(collectorFailureFromError(new TypeError('Failed to fetch')), { kind: 'network' });
+  });
+});

--- a/tests/debugbear-trampoline-chunks.test.mjs
+++ b/tests/debugbear-trampoline-chunks.test.mjs
@@ -1,44 +1,106 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
+import { guardBuiltOutput, shouldSkipBuiltOutput } from './_lib/built-output-guard.mjs';
 
 /**
  * Load-bearing guard for the DebugBear trampoline gate in
- * `src/bootstrap/sentry-init.ts` (WORLDMONITOR-VC / VQ / Y4).
+ * `src/bootstrap/sentry-init.ts` (WORLDMONITOR-VC / VQ / Y4 / Z6 / ZG).
  *
  * That gate suppresses a bare `Failed to fetch` when every non-infra frame is
  * either the DebugBear RUM collector or one of the `panel-storage` /
- * `widget-store` chunks. Its entire safety argument is that those two chunks
- * never issue a fetch of their own — they only appear because Vite emits
+ * `widget-store` chunks. Its entire safety argument is that those chunks never
+ * issue a fetch of their own — they only appear because Vite emits
  * `window.fetch` trampolines into them, so a stack confined to them cannot be a
  * real first-party network failure.
  *
- * If either module ever gains a fetch call, that argument collapses and the
- * gate starts swallowing genuine outages. This test is what makes that
- * impossible to do silently.
+ * The check runs at TWO levels, because the gate and the source tree do not name
+ * the same thing (#6746):
+ *
+ *   1. Per SOURCE MODULE — the authored file must stay fetch-free.
+ *   2. Per BUILT CHUNK — the artifact the gate's regex actually matches.
+ *
+ * Level 2 exists because level 1 does not imply it. The gate keys on chunk names
+ * and Rollup shared chunks are many-modules-to-one-chunk: the same build that
+ * emits `widget-store-*.js` also puts `src/services/wm-session.ts` in it, and
+ * puts `src/services/runtime.ts` — the app's fetch interceptor, which every API
+ * request passes through — in `analytics-*.js`. Nothing pins which chunk a
+ * module lands in. A repartition that moves a fetching module into an
+ * allowlisted chunk makes the gate hide real `api.worldmonitor.app` outages
+ * while every level-1 assertion stays green — the green-on-red shape documented
+ * in
+ * `docs/solutions/best-practices/checks-must-fail-closed-when-they-lose-their-target.md`.
  */
-const TRAMPOLINE_CHUNK_SOURCES = [
-  '../src/utils/panel-storage.ts',
-  '../src/services/widget-store.ts',
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const distDir = resolve(repoRoot, 'dist');
+const assetsDir = resolve(distDir, 'assets');
+const dashboardHtml = resolve(distDir, 'dashboard.html');
+
+/**
+ * Chunk name (as the gate's regex spells it) paired with the source module it is
+ * named after, so the two levels cannot drift apart.
+ *
+ * Deliberately hardcoded rather than parsed out of `sentry-init.ts`: a guard that
+ * derives its expectations from the file under test only ever agrees with itself.
+ * The coupling to the gate is asserted separately, at the bottom.
+ */
+const TRAMPOLINE_CHUNKS = [
+  { chunk: 'panel-storage', source: '../src/utils/panel-storage.ts' },
+  { chunk: 'widget-store', source: '../src/services/widget-store.ts' },
 ];
+
+/**
+ * Chunks the gate still matches that the build no longer emits.
+ *
+ * `panel-storage` stopped being its own chunk when Rollup folded that module
+ * into `font-settings-*.js` and `analytics-*.js`. The gate arm is kept because it
+ * still covers browsers running a bundle cached from before that repartition
+ * (WORLDMONITOR-VC), but no current artifact can prove it caller-free.
+ *
+ * This list is what keeps that honest. An absent chunk NOT listed here fails —
+ * so a chunk silently vanishing is loud — while a listed one is a recorded,
+ * reviewable gap rather than an invisible one. Entries are expected to be
+ * removed, not accumulated: when the cached bundles age out, drop the arm from
+ * the gate and the entry from here.
+ */
+const KNOWN_ABSENT_CHUNKS = new Set(['panel-storage']);
+
+/**
+ * `fetch(`, `window.fetch`, `globalThis.fetch`, plus the other ways a module can
+ * reach the network behind the same trampoline frame.
+ *
+ * Shared by both levels so the authored-source check and the built-chunk check
+ * can never disagree about what "issues a network call" means.
+ *
+ * Limit worth naming: this matches the GLOBAL fetch vocabulary. A call through a
+ * captured alias (`const f = window.fetch; f(url)`) survives minification as a
+ * renamed local and is invisible here — as it already is at level 1. The pattern
+ * is a floor, not a proof of absence.
+ */
+const NETWORK_CALL_PATTERN =
+  /(?:^|[^\w.])(?:(?:window|globalThis|self)\.)?fetch\s*\(|\bnew\s+(?:XMLHttpRequest|EventSource|WebSocket)\b|\bnavigator\.sendBeacon\s*\(/;
 
 /** Strips line and block comments so a `fetch` in prose doesn't fail the test. */
 function stripComments(source) {
   return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
 }
 
+function findChunkFiles(name) {
+  const pattern = new RegExp(`^${name}-[A-Za-z0-9_-]+\\.js$`);
+  return readdirSync(assetsDir).filter(file => pattern.test(file));
+}
+
 describe('DebugBear trampoline chunks stay fetch-free', () => {
-  for (const relativePath of TRAMPOLINE_CHUNK_SOURCES) {
+  for (const { chunk, source: relativePath } of TRAMPOLINE_CHUNKS) {
     it(`${relativePath} issues no network call`, () => {
       const source = stripComments(
         readFileSync(new URL(relativePath, import.meta.url), 'utf8'),
       );
 
-      // `fetch(`, `.fetch(`, `window.fetch`, `globalThis.fetch`, plus the other
-      // ways a module can reach the network behind the same trampoline frame.
-      const networkCall = source.match(
-        /(?:^|[^\w.])(?:(?:window|globalThis|self)\.)?fetch\s*\(|\bnew\s+(?:XMLHttpRequest|EventSource|WebSocket)\b|\bnavigator\.sendBeacon\s*\(/,
-      );
+      const networkCall = source.match(NETWORK_CALL_PATTERN);
 
       assert.equal(
         networkCall,
@@ -51,7 +113,65 @@ describe('DebugBear trampoline chunks stay fetch-free', () => {
           'real first-party fetch failures.',
       );
     });
+
+    // Dist-gated: skips when dist/dashboard.html is absent, and FAILS instead of
+    // skipping when WM_EXPECT_BUILT_OUTPUT=1 (CI sets it right after building the
+    // dashboard — .github/workflows/test.yml), so the built half can never go
+    // quietly missing in CI.
+    it(`the built ${chunk} chunk issues no network call`, () => {
+      guardBuiltOutput(dashboardHtml);
+      if (shouldSkipBuiltOutput(dashboardHtml)) return;
+
+      const files = findChunkFiles(chunk);
+      if (files.length === 0) {
+        assert.ok(
+          KNOWN_ABSENT_CHUNKS.has(chunk),
+          `No dist/assets/${chunk}-<hash>.js chunk in the build, but the DebugBear ` +
+            'trampoline gate in src/bootstrap/sentry-init.ts still suppresses ' +
+            `"Failed to fetch" for frames attributed to a "${chunk}" chunk. Rollup ` +
+            'repartitioned and this arm can no longer be verified against any ' +
+            'artifact. Either drop the arm from the gate, or — if it is deliberately ' +
+            'kept for bundles cached before the repartition — add it to ' +
+            'KNOWN_ABSENT_CHUNKS with the reason, so the gap is recorded instead of ' +
+            'silently trusted.',
+        );
+        return;
+      }
+
+      for (const file of files) {
+        const built = readFileSync(resolve(assetsDir, file), 'utf8');
+        const networkCall = built.match(NETWORK_CALL_PATTERN);
+
+        assert.equal(
+          networkCall,
+          null,
+          `dist/assets/${file} contains a network call (${networkCall?.[0]?.trim()}). ` +
+            'Rollup put a fetching module in a chunk the DebugBear trampoline gate ' +
+            'treats as caller-free, so that gate will now suppress a real first-party ' +
+            '"Failed to fetch" — an api.worldmonitor.app outage would go unreported ' +
+            'for every session running the DebugBear RUM script. Either split the ' +
+            `fetching module out of the ${chunk} chunk (vite.config.ts manualChunks) ` +
+            'or drop this chunk from the gate in src/bootstrap/sentry-init.ts.',
+        );
+      }
+    });
   }
+
+  // The known-absent escape hatch must never swallow the whole allowlist: if
+  // every arm were declared absent, the gate would be suppressing entirely on
+  // unverifiable chunk names and this file would be green while checking nothing.
+  it('at least one gated chunk is still verified against a real artifact', () => {
+    guardBuiltOutput(dashboardHtml);
+    if (shouldSkipBuiltOutput(dashboardHtml)) return;
+
+    const verified = TRAMPOLINE_CHUNKS.filter(({ chunk }) => findChunkFiles(chunk).length > 0);
+    assert.ok(
+      verified.length > 0,
+      'Every chunk the DebugBear trampoline gate names is missing from the build, so ' +
+        'nothing about that gate is being checked. Re-derive the allowlist from the ' +
+        'chunks the build actually emits before trusting the suppression again.',
+    );
+  });
 
   it('the gate it protects still keys on these chunk names', () => {
     const sentryInit = readFileSync(
@@ -60,7 +180,7 @@ describe('DebugBear trampoline chunks stay fetch-free', () => {
     );
     assert.match(
       sentryInit,
-      /isTrampolineFrameFunction[\s\S]{0,400}panel-storage\|widget-store/,
+      /isTrampolineFrameFunction[\s\S]{0,600}panel-storage\|widget-store/,
       'sentry-init.ts must still gate on the panel-storage/widget-store chunks — ' +
         'if that gate was renamed or removed, update this guard to match rather ' +
         'than leaving it asserting a relationship that no longer exists.',


### PR DESCRIPTION
Closes #6746.

## The problem

WORLDMONITOR-Z6/ZG are a bare `TypeError: Failed to fetch` leaking from the Umami tracker, which is third-party code that does not handle its own rejection. No host in the message, no caller in the stack — indistinguishable from an `api.worldmonitor.app` outage.

Five previous rounds (VC → VQ → Y4 → Y4-recurrence → Z6-extension-frame) tried to identify it from the *stack*, by allowlisting the chunks Vite emits `window.fetch` trampolines into. Each broke on the next repartition.

**That approach has now run out of road.** Verified against a real build: `dist/assets/analytics-*.js` contains `/api/local-` from `src/services/runtime.ts:246` — the fetch interceptor every API request passes through. Admitting the chunk the frames currently land in would suppress genuine origin failures for the 10% of sessions running DebugBear RUM.

## The fix

Name the rejection at its source. `analytics-collector-transport.ts` rejects the tracker-facing promise with `CollectorTransportError`, and `ignoreErrors` matches that exact string — one line, one condition, no blind spot.

Two narrowings, both forced by contracts the existing suites already pin:

- **Only `network` failures are wrapped.** A timeout already rejects with a distinctly-named `TimeoutError` that Sentry groups on its own; the #6086/#6288 suites assert that identity on the tracker-facing promise in a dozen places. Renaming it would buy no attribution and break a real contract.
- **A caller cancellation is never wrapped.** When a caller aborts with its own reason, that exact object must come back identity-equal (`await assert.rejects(request, (error) => error === reason)`). Detected by identity, not shape — a caller reason is arbitrary and classifies as `network` like anything unrecognised.

`delivery` keeps the raw error either way: the retry policy and health cohorts classify off it, and `collectorFailureFromError` unwraps so the timeout/`raced` split stays exact.

The `ignoreErrors` placement is deliberate despite the usual rule against it. That rule exists because generic phrasings can also come from our own minified bundle; this string is minted at exactly one line for exactly one condition, so there is no blind spot to trade away.

## The guard hole that let this class hide

The gate keys on **chunk names**; `tests/debugbear-trampoline-chunks.test.mjs` only checked the **source files** those chunks are named after. Rollup shared chunks are many-modules-to-one-chunk, so the guard could stay green while the chunk it protects gained a real fetch caller. The guard now checks the built chunks too, and fails closed when a chunk it names is missing — per `docs/solutions/best-practices/checks-must-fail-closed-when-they-lose-their-target.md`.

**It found a live drift on its first run:** `panel-storage` is no longer emitted as a chunk at all — Rollup folded that module into `font-settings-*.js` and `analytics-*.js` — so that gate arm now matches only bundles cached from before the repartition. The arm is kept (it still covers them, and `tests/sentry-beforesend.test.mjs` pins it) but declared in `KNOWN_ABSENT_CHUNKS`, so the unverifiable gap is recorded rather than silently trusted. A separate assertion ensures the allowlist can never go *entirely* unverified.

## Verification

Every assertion was shown **red under mutation before green**, restored byte-for-byte between each:

| Mutation | Result |
|---|---|
| Revert dispatch site to `request.reject(error)` | integration red, units green |
| Strip the `ignoreErrors` entry | filter test red |
| Remove the `collectorFailureFromError` unwrap | 2 classification tests red |
| Disable the wrap narrowing | integration red |
| Inject a retained `fetch` into a co-located module | built-chunk half red, source half green |
| Dead `panel-storage` arm (found in the wild, not injected) | guard red → declared → green |

One caveat worth recording: the first attempt at the co-located-module mutation used an unused `export function`, which Rollup tree-shook — `0 fetch(` reached the chunk and the guard's silence proved nothing. Verifying the mutation actually reached the artifact is what exposed it as a fake kill; the retained version is a guarded top-level call.

`tsc --noEmit` clean. 365/365 across `analytics-beacon-rejection`, `analytics-collector-monitor`, `analytics-queue-capacity`, `sentry-beforesend`, `sentry-allow-urls`, and both touched test files.

## Residual, stated plainly

Sessions running a bundle cached before this deploy still emit the anonymous rejection and are still identified only by the chunk heuristic. On those builds the rejection genuinely *is* indistinguishable from an API failure — which is the argument for moving the fix to the source rather than widening the allowlist again.

https://claude.ai/code/session_012w3T1cwt4kcs49ekURAk2H
