### PR TITLE
fix(sentry): tag collector transport rejections, add ignoreErrors entry

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -70,6 +70,11 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
     sendDefaultPii: true,
     tracesSampleRate: 0.1,
     ignoreErrors: [
+      // #6746: the analytics collector gate tags its transport rejections
+      // with [wm-collector], making them self-identifying. This replaces
+      // the DebugBear trampoline chunk-name allowlist in beforeSend (which
+      // had to be widened six times as Vite re-partitioned chunks).
+      /\[wm-collector\]/,
       'Invalid WebGL2RenderingContext',
       'WebGL context lost',
       /imageManager/,
@@ -632,6 +637,16 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // collector frame plus a fetch-free trampoline for every remaining frame, so
       // admitting it cannot hide a first-party fetch — a real caller alongside the
       // extension still surfaces, which the regression tests assert.
+      //
+      // RETIRED (#6746, WORLDMONITOR-Z6/ZG): the chunk-name allowlist above
+      // was structurally unsound — Rollup re-partitions shared chunks across
+      // builds, so `analytics-*.js` now carries `runtime.ts` (which issues
+      // real fetches), and admitting it would suppress genuine API outages.
+      // The replacement is a `[wm-collector]` tag on the collector gate's
+      // transport rejection (analytics-collector-transport.ts) plus a single
+      // `ignoreErrors` entry — self-identifying, no chunk-name guessing.
+      // The gate below is kept temporarily for cached pre-tag builds and
+      // can be deleted once those age out of the Sentry event stream.
       const isExtensionFrameFile = (file: string) =>
         /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(file);
       const isTrampolineFrameFunction = (fn: string) =>

--- a/src/services/analytics-collector-transport.ts
+++ b/src/services/analytics-collector-transport.ts
@@ -985,7 +985,22 @@ async function runCollectorRequest(request: CollectorRequest, generation: number
     if (generation === collectorTransportGeneration) {
       recordCollectorOutcome(request, collectorFailureFromError(error));
     }
-    request.reject(error);
+    // #6746: the raw network error (bare `TypeError: Failed to fetch`) is
+    // returned to third-party tracker code (DebugBear, Umami) whose own
+    // wrappers may re-throw it without our stack frames — making it
+    // indistinguishable from a real first-party API outage in Sentry. Wrap
+    // it so the rejection self-identifies as collector-originated and a
+    // single Sentry `ignoreErrors` entry can catch it without the fragile
+    // chunk-name trampoline allowlist.
+    const tagged = error instanceof Error
+      ? Object.create(error, {
+        message: { value: `[wm-collector] ${error.message}`, enumerable: true },
+        name: { value: error.name, enumerable: true },
+      })
+      : error;
+    request.reject(tagged);
+    // The delivery deferred is pre-caught by design (see enqueueCollectorRequest);
+    // the original error is fine there since it never surfaces unhandled.
     request.rejectDelivery(error);
   } finally {
     timeoutBoundInit?.cleanup();


### PR DESCRIPTION
Fixes #6746 (WORLDMONITOR-Z6/ZG). The collector gate's transport rejection now self-identifies with a [wm-collector] message prefix, and a single ignoreErrors entry catches it. The old chunk-name trampoline gate is annotated as retired (kept temporarily for cached pre-tag builds). See issue for why the chunk allowlist was structurally unsound (six escapes across build re-partitions).