### PR TITLE
fix(checkout): settle the entitlement wait on three signals, not one (#6760)

### DIFF
--- a/src/services/checkout-banner-state.ts
+++ b/src/services/checkout-banner-state.ts
@@ -17,6 +17,27 @@ export type CheckoutSuccessBannerState = 'pending' | 'active' | 'timeout';
 export const EXTENDED_UNLOCK_TIMEOUT_MS = 30_000;
 
 /**
+ * How often the banner re-reads `isEntitled()` while it waits.
+ *
+ * The entitlement subscription only emits on a TRANSITION this page observed.
+ * A buyer returning from Dodo's hosted checkout is on a cold load, so the
+ * entitlement is often already true by the time Convex authenticates — no
+ * transition, no event, and an event-only wait never settles (WORLDMONITOR-PZ).
+ * Polling is a synchronous read of an in-memory store, so 1s costs nothing.
+ */
+export const ENTITLEMENT_POLL_MS = 1_000;
+
+/**
+ * How long the banner keeps watching after it has announced a timeout.
+ *
+ * The banner never auto-dismisses in the wait-for-entitlement flow, so a
+ * genuinely slow activation should still be able to correct the message rather
+ * than leave a paying customer looking at a failure until they reload. Bounded
+ * rather than page-lifetime so the watchers cannot leak.
+ */
+export const LATE_ACTIVATION_GRACE_MS = 300_000;
+
+/**
  * Auto-dismiss window for the classic (non-waitForEntitlement) banner.
  * Informational-only usage where the panel unlock is already guaranteed.
  */

--- a/src/services/checkout-entitlement-wait.ts
+++ b/src/services/checkout-entitlement-wait.ts
@@ -1,0 +1,148 @@
+/**
+ * Post-checkout entitlement wait for the checkout-success banner.
+ *
+ * The buyer lands here straight back from Dodo's HOSTED checkout, so the page
+ * is a cold load: Clerk must hydrate, then Convex must authenticate, then the
+ * entitlement subscription must deliver. That whole chain is what this state
+ * machine is waiting on.
+ *
+ * WORLDMONITOR-PZ / #6760 is what it is shaped around. The first version
+ * subscribed to `onEntitlementChange` and nothing else, then tore the
+ * subscription down at the deadline. Production showed that losing all three
+ * bets at once is routine: of the timeout events carrying a Clerk id, three
+ * users held an ACTIVE `pro_monthly` whose subscription period had already
+ * started BEFORE Sentry recorded the timeout — one of them 2 m 19 s before. The
+ * money and the entitlement were right; only the banner was wrong.
+ *
+ * So the wait now settles on three independent signals rather than one:
+ *
+ *  1. A change event (the fast path, unchanged).
+ *  2. A POLL of `isEntitled()`. A change event only fires on a TRANSITION the
+ *     page observed. An entitlement that was already true when the
+ *     subscription finally authenticated produces no transition at all, and the
+ *     event-only wait waits forever. This is the same late-hydration bet the
+ *     email watcher in `checkout.ts` already hedges by polling Clerk.
+ *  3. A RE-CHECK at the deadline, before any failure is announced. Cheap, and
+ *     it is the single case the production data showed most often.
+ *
+ * And a deadline is no longer terminal: the wait keeps watching for
+ * `lateGraceMs` afterwards, so a genuinely slow activation still flips the
+ * banner back to `active` instead of stranding the buyer on a failure message
+ * until they reload.
+ *
+ * Shape: pure DI module. Entitlement access and every timer are injected so the
+ * state machine is testable without a DOM, a network, or `checkout.ts`'s
+ * dependency graph (which pulls `dodopayments-checkout`). Same shape and same
+ * reason as `entitlement-watchdog.ts`.
+ *
+ * See tests/checkout-entitlement-wait.test.mts.
+ */
+
+export type EntitlementWaitState = 'active' | 'timeout';
+
+export interface EntitlementWaitDeps {
+  /** Current entitlement verdict. `isEntitled` from `entitlements.ts`. */
+  isEntitled: () => boolean;
+  /** Subscribe to entitlement transitions. Returns an unsubscribe. */
+  onEntitlementChange: (listener: () => void) => () => void;
+  setTimeout: (handler: () => void, ms: number) => number;
+  clearTimeout: (id: number) => void;
+  setInterval: (handler: () => void, ms: number) => number;
+  clearInterval: (id: number) => void;
+  /**
+   * Fired on every settled state change, in order. `timeout` may be followed
+   * by `active` when a late activation lands inside the grace window; neither
+   * state is ever reported twice.
+   */
+  onState: (state: EntitlementWaitState) => void;
+  /**
+   * Fired exactly once, when the deadline passes AND the re-check confirms
+   * there is still no entitlement. This is the telemetry signal — it must stay
+   * rare enough to mean something, so it deliberately does not fire for a wait
+   * that was merely slow.
+   */
+  onTimeoutReport: () => void;
+}
+
+export interface EntitlementWaitConfig {
+  /** How long to wait before declaring the activation timed out. */
+  timeoutMs: number;
+  /** How often to re-read `isEntitled()` while waiting. */
+  pollMs: number;
+  /** How long to keep watching after the deadline for a late activation. */
+  lateGraceMs: number;
+}
+
+/**
+ * Start waiting for the post-checkout entitlement.
+ *
+ * Returns a cleanup that tears down every watcher. Safe to call twice.
+ */
+export function startEntitlementWait(
+  config: EntitlementWaitConfig,
+  deps: EntitlementWaitDeps,
+): () => void {
+  if (deps.isEntitled()) {
+    deps.onState('active');
+    return () => {};
+  }
+
+  let done = false;
+  let unsubscribe: (() => void) | null = null;
+  let deadlineHandle: number | null = null;
+  let pollHandle: number | null = null;
+  let graceHandle: number | null = null;
+
+  const stopAll = (): void => {
+    done = true;
+    unsubscribe?.();
+    unsubscribe = null;
+    if (deadlineHandle !== null) {
+      deps.clearTimeout(deadlineHandle);
+      deadlineHandle = null;
+    }
+    if (pollHandle !== null) {
+      deps.clearInterval(pollHandle);
+      pollHandle = null;
+    }
+    if (graceHandle !== null) {
+      deps.clearTimeout(graceHandle);
+      graceHandle = null;
+    }
+  };
+
+  /** Settle on `active` if the entitlement is present. Returns whether it settled. */
+  const settleIfEntitled = (): boolean => {
+    if (done) return false;
+    if (!deps.isEntitled()) return false;
+    stopAll();
+    deps.onState('active');
+    return true;
+  };
+
+  deadlineHandle = deps.setTimeout(() => {
+    deadlineHandle = null;
+    // Re-check BEFORE announcing a failure. The production data says the
+    // entitlement is frequently already active at this exact moment.
+    if (settleIfEntitled()) return;
+    if (done) return;
+    deps.onState('timeout');
+    deps.onTimeoutReport();
+    // Keep watching. The banner stays on screen either way, so a late
+    // activation should still be able to correct it.
+    graceHandle = deps.setTimeout(() => {
+      graceHandle = null;
+      stopAll();
+    }, config.lateGraceMs);
+  }, config.timeoutMs);
+
+  pollHandle = deps.setInterval(() => {
+    settleIfEntitled();
+  }, config.pollMs);
+
+  unsubscribe = deps.onEntitlementChange(() => {
+    settleIfEntitled();
+  });
+
+  return stopAll;
+}

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -46,10 +46,13 @@ import { shouldSkipSentryForAction } from './checkout-sentry-policy';
 import { isEntitled, onEntitlementChange } from './entitlements';
 import {
   CLASSIC_AUTO_DISMISS_MS,
+  ENTITLEMENT_POLL_MS,
   EXTENDED_UNLOCK_TIMEOUT_MS,
+  LATE_ACTIVATION_GRACE_MS,
   maskEmail,
   type CheckoutSuccessBannerState,
 } from './checkout-banner-state';
+import { startEntitlementWait } from './checkout-entitlement-wait';
 import { isAffiliateCode, loadActiveReferral } from './referral-capture';
 import { trackCheckoutStart } from './analytics';
 import { showDuplicateSubscriptionDialog } from './checkout-duplicate-dialog';
@@ -1461,42 +1464,45 @@ export function showCheckoutSuccess(
     return;
   }
 
-  let resolved = false;
-  const timeoutHandle = setTimeout(() => {
-    if (resolved) return;
-    resolved = true;
-    unsubscribe();
-    stopEmailWatchers();
-    _currentBannerCleanup = null;
-    currentState = 'timeout';
-    setBannerText(banner, 'timeout', currentMaskedEmail);
-    enqueueSentryCall((s) => s.captureMessage('Checkout entitlement-activation timeout', {
-      level: 'warning',
-      tags: { component: 'dodo-checkout', action: 'entitlement-timeout' },
-    }));
-  }, EXTENDED_UNLOCK_TIMEOUT_MS);
-
-  const unsubscribe = onEntitlementChange(() => {
-    if (resolved) return;
-    if (!isEntitled()) return;
-    resolved = true;
-    clearTimeout(timeoutHandle);
-    unsubscribe();
-    stopEmailWatchers();
-    _currentBannerCleanup = null;
-    currentState = 'active';
-    setBannerText(banner, 'active', currentMaskedEmail);
-  });
+  // The wait settles on a change event, a poll, or a re-check at the deadline,
+  // and keeps watching for a bounded grace period afterwards — see
+  // `checkout-entitlement-wait.ts` for why one signal was not enough
+  // (WORLDMONITOR-PZ / #6760).
+  const stopWait = startEntitlementWait(
+    {
+      timeoutMs: EXTENDED_UNLOCK_TIMEOUT_MS,
+      pollMs: ENTITLEMENT_POLL_MS,
+      lateGraceMs: LATE_ACTIVATION_GRACE_MS,
+    },
+    {
+      isEntitled,
+      onEntitlementChange,
+      setTimeout: (handler, ms) => window.setTimeout(handler, ms),
+      clearTimeout: (id) => window.clearTimeout(id),
+      setInterval: (handler, ms) => window.setInterval(handler, ms),
+      clearInterval: (id) => window.clearInterval(id),
+      onState: (state) => {
+        stopEmailWatchers();
+        currentState = state;
+        setBannerText(banner, state, currentMaskedEmail);
+        // Only an `active` verdict is final. After a `timeout` the wait is
+        // still watching for a late activation, so the cleanup must stay
+        // registered or a re-entrant banner would orphan those watchers.
+        if (state === 'active') _currentBannerCleanup = null;
+      },
+      onTimeoutReport: () => {
+        enqueueSentryCall((s) => s.captureMessage('Checkout entitlement-activation timeout', {
+          level: 'warning',
+          tags: { component: 'dodo-checkout', action: 'entitlement-timeout' },
+        }));
+      },
+    },
+  );
 
   // Register cleanup so a re-entrant showCheckoutSuccess call (e.g. a
   // double-fire of `checkout.status=succeeded`) tears down this
-  // banner's listener + timer before mounting a replacement.
-  _currentBannerCleanup = () => {
-    if (resolved) return;
-    resolved = true;
-    clearTimeout(timeoutHandle);
-    unsubscribe();
-  };
+  // banner's watchers before mounting a replacement.
+  _currentBannerCleanup = stopWait;
 }
 
 function setBannerText(

--- a/tests/checkout-banner-initial-state.test.mts
+++ b/tests/checkout-banner-initial-state.test.mts
@@ -10,6 +10,8 @@ import assert from 'node:assert/strict';
 import {
   EXTENDED_UNLOCK_TIMEOUT_MS,
   CLASSIC_AUTO_DISMISS_MS,
+  ENTITLEMENT_POLL_MS,
+  LATE_ACTIVATION_GRACE_MS,
 } from '../src/services/checkout-banner-state.ts';
 
 describe('banner timing constants', () => {
@@ -25,5 +27,25 @@ describe('banner timing constants', () => {
     // If this ever flips, the non-extended flow would outlive the
     // entitlement-wait flow, which defeats the "fast fade" intent.
     assert.ok(CLASSIC_AUTO_DISMISS_MS < EXTENDED_UNLOCK_TIMEOUT_MS);
+  });
+
+  it('ENTITLEMENT_POLL_MS is 1s', () => {
+    assert.equal(ENTITLEMENT_POLL_MS, 1_000);
+  });
+
+  it('LATE_ACTIVATION_GRACE_MS is 5min', () => {
+    assert.equal(LATE_ACTIVATION_GRACE_MS, 300_000);
+  });
+
+  it('the poll fits several times inside the deadline', () => {
+    // A poll interval at or near the deadline would make the poll pointless —
+    // the deadline re-check would always beat it (WORLDMONITOR-PZ).
+    assert.ok(ENTITLEMENT_POLL_MS * 5 <= EXTENDED_UNLOCK_TIMEOUT_MS);
+  });
+
+  it('the late-activation grace outlives the deadline', () => {
+    // The grace window exists to catch activations SLOWER than the deadline.
+    // A grace shorter than the wait itself would close before those land.
+    assert.ok(LATE_ACTIVATION_GRACE_MS > EXTENDED_UNLOCK_TIMEOUT_MS);
   });
 });

--- a/tests/checkout-entitlement-wait.test.mts
+++ b/tests/checkout-entitlement-wait.test.mts
@@ -1,0 +1,244 @@
+/**
+ * Behavioural tests for the post-checkout entitlement wait
+ * (`src/services/checkout-entitlement-wait.ts`).
+ *
+ * WORLDMONITOR-PZ / #6760. Production evidence: of the checkout-timeout events
+ * that carried a Clerk id, three users held an ACTIVE `pro_monthly` whose
+ * subscription period had already started BEFORE Sentry recorded the timeout —
+ * one of them 2 m 19 s before. The payment and the entitlement were correct;
+ * the banner declared an activation failure anyway.
+ *
+ * The three cases named `PZ:` below are that bug. They fail against the logic
+ * as it shipped (subscribe-only, tear down at the deadline) and pass against
+ * the fix.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  startEntitlementWait,
+  type EntitlementWaitDeps,
+  type EntitlementWaitState,
+} from '../src/services/checkout-entitlement-wait.ts';
+
+type Timer = { at: number; fn: () => void; every: number | null };
+
+/** Deterministic fake clock — no real timers, so ordering cannot flake. */
+function createClock() {
+  let now = 0;
+  let seq = 1;
+  const timers = new Map<number, Timer>();
+  return {
+    now: () => now,
+    pendingCount: () => timers.size,
+    setTimeout(fn: () => void, ms: number): number {
+      const id = seq++;
+      timers.set(id, { at: now + ms, fn, every: null });
+      return id;
+    },
+    clearTimeout(id: number): void {
+      timers.delete(id);
+    },
+    setInterval(fn: () => void, ms: number): number {
+      const id = seq++;
+      timers.set(id, { at: now + ms, fn, every: ms });
+      return id;
+    },
+    clearInterval(id: number): void {
+      timers.delete(id);
+    },
+    /** Advance time, firing due timers in chronological order. */
+    advance(ms: number): void {
+      const target = now + ms;
+      for (;;) {
+        let pickId: number | null = null;
+        let pick: Timer | null = null;
+        for (const [id, t] of timers) {
+          if (t.at <= target && (pick === null || t.at < pick.at)) {
+            pickId = id;
+            pick = t;
+          }
+        }
+        if (pickId === null || pick === null) break;
+        now = pick.at;
+        if (pick.every === null) timers.delete(pickId);
+        else pick.at = now + pick.every;
+        pick.fn();
+      }
+      now = target;
+    },
+  };
+}
+
+const TIMEOUT_MS = 30_000;
+const POLL_MS = 1_000;
+const GRACE_MS = 300_000;
+
+let clock: ReturnType<typeof createClock>;
+let entitled: boolean;
+let states: EntitlementWaitState[];
+let timeoutReports: number;
+let listeners: Array<() => void>;
+let unsubscribeCount: number;
+
+beforeEach(() => {
+  clock = createClock();
+  entitled = false;
+  states = [];
+  timeoutReports = 0;
+  listeners = [];
+  unsubscribeCount = 0;
+});
+
+function deps(): EntitlementWaitDeps {
+  return {
+    isEntitled: () => entitled,
+    onEntitlementChange: (listener) => {
+      listeners.push(listener);
+      return () => {
+        unsubscribeCount += 1;
+        listeners = listeners.filter((l) => l !== listener);
+      };
+    },
+    setTimeout: (fn, ms) => clock.setTimeout(fn, ms),
+    clearTimeout: (id) => clock.clearTimeout(id),
+    setInterval: (fn, ms) => clock.setInterval(fn, ms),
+    clearInterval: (id) => clock.clearInterval(id),
+    onState: (s) => states.push(s),
+    onTimeoutReport: () => {
+      timeoutReports += 1;
+    },
+  };
+}
+
+/** Entitlement flips AND the subscription notifies — the happy path. */
+function grantWithEvent(): void {
+  entitled = true;
+  for (const l of [...listeners]) l();
+}
+
+/** Entitlement flips with NO notification — a subscription that hydrated late. */
+function grantSilently(): void {
+  entitled = true;
+}
+
+const start = () =>
+  startEntitlementWait(
+    { timeoutMs: TIMEOUT_MS, pollMs: POLL_MS, lateGraceMs: GRACE_MS },
+    deps(),
+  );
+
+describe('checkout entitlement wait', () => {
+  it('resolves active immediately when the user is already entitled', () => {
+    entitled = true;
+    start();
+    assert.deepEqual(states, ['active']);
+    assert.equal(timeoutReports, 0);
+    assert.equal(clock.pendingCount(), 0, 'must not schedule a deadline it will never need');
+  });
+
+  it('resolves active when the entitlement arrives with a change event', () => {
+    start();
+    clock.advance(2_000);
+    grantWithEvent();
+    assert.deepEqual(states, ['active']);
+    assert.equal(timeoutReports, 0);
+    clock.advance(TIMEOUT_MS * 2);
+    assert.deepEqual(states, ['active'], 'the deadline must not fire after resolution');
+  });
+
+  it('ignores a change event that does not carry an entitlement', () => {
+    start();
+    for (const l of [...listeners]) l();
+    assert.deepEqual(states, [], 'a non-entitling change must leave the banner pending');
+  });
+
+  it('reports a timeout exactly once when the entitlement genuinely never arrives', () => {
+    start();
+    clock.advance(TIMEOUT_MS);
+    assert.deepEqual(states, ['timeout']);
+    assert.equal(timeoutReports, 1);
+    clock.advance(TIMEOUT_MS * 3);
+    assert.equal(timeoutReports, 1, 'the timeout must be reported once, not per tick');
+  });
+
+  it('cleanup stops the deadline and unsubscribes', () => {
+    const cleanup = start();
+    cleanup();
+    assert.ok(unsubscribeCount >= 1, 'must unsubscribe from entitlement changes');
+    clock.advance(TIMEOUT_MS * 2);
+    assert.deepEqual(states, [], 'a cleaned-up wait must not report anything');
+    assert.equal(timeoutReports, 0);
+  });
+
+  it('cleanup is safe to call twice', () => {
+    const cleanup = start();
+    cleanup();
+    cleanup();
+    clock.advance(TIMEOUT_MS * 2);
+    assert.deepEqual(states, []);
+  });
+
+  // ---- WORLDMONITOR-PZ: the three cases that shipped broken ----
+
+  it('PZ: re-checks the entitlement at the deadline before declaring a timeout', () => {
+    start();
+    // The entitlement lands, but the subscription never notifies this page.
+    grantSilently();
+    clock.advance(TIMEOUT_MS);
+    assert.deepEqual(
+      states,
+      ['active'],
+      'the entitlement was already active at the deadline — the banner must not claim a failure',
+    );
+    assert.equal(timeoutReports, 0, 'must not report a timeout that did not happen');
+  });
+
+  it('PZ: sees an entitlement that arrives without a change event', () => {
+    start();
+    clock.advance(3_000);
+    grantSilently();
+    // Well before the deadline: a poll must notice.
+    clock.advance(5_000);
+    assert.deepEqual(states, ['active']);
+    assert.equal(timeoutReports, 0);
+    assert.ok(clock.now() < TIMEOUT_MS, 'must resolve before the deadline, not at it');
+  });
+
+  it('PZ: a late activation after the timeout still flips the banner to active', () => {
+    start();
+    clock.advance(TIMEOUT_MS);
+    assert.deepEqual(states, ['timeout'], 'precondition: the deadline passed with no entitlement');
+    // One second later the entitlement finally lands.
+    clock.advance(1_000);
+    grantWithEvent();
+    assert.deepEqual(
+      states,
+      ['timeout', 'active'],
+      'a buyer whose entitlement lands late must see the banner recover',
+    );
+    assert.equal(timeoutReports, 1, 'the late recovery must not re-report the timeout');
+  });
+
+  it('stops watching once the late-activation grace window expires', () => {
+    start();
+    clock.advance(TIMEOUT_MS);
+    assert.deepEqual(states, ['timeout']);
+    clock.advance(GRACE_MS + POLL_MS);
+    assert.equal(clock.pendingCount(), 0, 'the grace window must be bounded, not a page-lifetime leak');
+    // An activation after the window closed is nobody's business any more.
+    grantWithEvent();
+    assert.deepEqual(states, ['timeout'], 'no state may be reported after teardown');
+  });
+
+  it('polls only until it settles — no timers survive an active resolution', () => {
+    start();
+    clock.advance(2_000);
+    grantSilently();
+    clock.advance(POLL_MS);
+    assert.deepEqual(states, ['active']);
+    assert.equal(clock.pendingCount(), 0, 'the deadline and the poll must both be cleared');
+    assert.ok(unsubscribeCount >= 1, 'must unsubscribe once settled');
+  });
+});

--- a/tests/checkout-overlay-lifecycle.test.mts
+++ b/tests/checkout-overlay-lifecycle.test.mts
@@ -212,6 +212,8 @@ const stubSources: Record<string, string> = {
   './checkout-banner-state': `
     export const CLASSIC_AUTO_DISMISS_MS = 5000;
     export const EXTENDED_UNLOCK_TIMEOUT_MS = 30000;
+    export const ENTITLEMENT_POLL_MS = 1000;
+    export const LATE_ACTIVATION_GRACE_MS = 300000;
     export const maskEmail = (email) => email ?? null;
   `,
   './referral-capture': `

--- a/tests/checkout-pending-dialog.test.mts
+++ b/tests/checkout-pending-dialog.test.mts
@@ -194,6 +194,8 @@ const stubSources: Record<string, string> = {
   './checkout-banner-state': `
     export const CLASSIC_AUTO_DISMISS_MS = 5000;
     export const EXTENDED_UNLOCK_TIMEOUT_MS = 30000;
+    export const ENTITLEMENT_POLL_MS = 1000;
+    export const LATE_ACTIVATION_GRACE_MS = 300000;
     export const maskEmail = (email) => email ?? null;
   `,
   './referral-capture': `

--- a/tests/checkout-referral-policy.test.mts
+++ b/tests/checkout-referral-policy.test.mts
@@ -129,6 +129,8 @@ const stubSources: Record<string, string> = {
   './checkout-banner-state': `
     export const CLASSIC_AUTO_DISMISS_MS = 5000;
     export const EXTENDED_UNLOCK_TIMEOUT_MS = 30000;
+    export const ENTITLEMENT_POLL_MS = 1000;
+    export const LATE_ACTIVATION_GRACE_MS = 300000;
     export const maskEmail = (email) => email ?? null;
   `,
   // Only the storage read is faked — it is the harness's control knob for

--- a/tests/checkout-unparsable-success-body.test.mts
+++ b/tests/checkout-unparsable-success-body.test.mts
@@ -188,6 +188,8 @@ const stubSources: Record<string, string> = {
   './checkout-banner-state': `
     export const CLASSIC_AUTO_DISMISS_MS = 5000;
     export const EXTENDED_UNLOCK_TIMEOUT_MS = 30000;
+    export const ENTITLEMENT_POLL_MS = 1000;
+    export const LATE_ACTIVATION_GRACE_MS = 300000;
     export const maskEmail = (email) => email ?? null;
   `,
   './referral-capture': `

--- a/tests/desktop-checkout-handoff.test.mts
+++ b/tests/desktop-checkout-handoff.test.mts
@@ -231,6 +231,8 @@ const stubSources: Record<string, string> = {
   './checkout-banner-state': `
     export const CLASSIC_AUTO_DISMISS_MS = 5000;
     export const EXTENDED_UNLOCK_TIMEOUT_MS = 30000;
+    export const ENTITLEMENT_POLL_MS = 1000;
+    export const LATE_ACTIVATION_GRACE_MS = 300000;
     export const maskEmail = (email) => email ?? null;
   `,
   './referral-capture': `


### PR DESCRIPTION
Fixes #6760 (WORLDMONITOR-PZ).

## No money was lost — checked, not assumed

`Checkout entitlement-activation timeout` reads like a failed purchase. It is not
one. Of the events carrying a Clerk id, **three users hold an ACTIVE
`pro_monthly` whose subscription period had already STARTED before Sentry
recorded the timeout** — one of them 2 m 19 s before:

| PZ event (UTC) | subscription periodStart | status today |
|---|---|---|
| 2026-07-21 13:43:28 | 2026-07-21 13:41:09Z | active, renewing |
| 2026-07-15 10:46:46 | renewed 2026-08-15 | active, renewing |
| 2026-05-29 10:31:16 | renewed 2026-07-29 | active, renewing |

The other two have **no row** in `subscriptions` (full table, 538 rows),
`paymentWebhookFailures` (2), `unattributedPaymentEvents` (6), or
`paymentReconciliationAttempts` (empty) — they never paid.
`unattributedPaymentEvents` is clean too: its 3 `charged=true` rows are the
5-seat deal, all `resolved=true`; the 3 unresolved rows are `charged=false`
(2 x `CARD_DECLINED`, 1 x 3-DS failure), so nothing is owed.

The payment and the entitlement were correct. Only the banner was wrong.

## Root cause

The wait bet everything on `onEntitlementChange`. That event fires only on a
transition **this page observed**, and the buyer arrives on a cold load straight
back from Dodo's hosted checkout: Clerk hydrates, then Convex authenticates,
then the subscription delivers. An entitlement already true by the time Convex
authenticates produces no transition at all, so the wait never settled.

Then the deadline **tore the subscription down** (`checkout.ts:1468` as shipped),
so a late activation could not correct the banner either — the buyer sat on a
failure message until they reloaded.

The email watcher beside it already hedges exactly this late-hydration bet by
polling Clerk every 500 ms for 15 s. The entitlement watcher never got the same
hedge.

## The change

Extract the wait into `src/services/checkout-entitlement-wait.ts` — a pure DI
module, same shape and same reason as `entitlement-watchdog.ts` (testable
without a DOM, a network, or `checkout.ts`'s `dodopayments-checkout` graph).

It settles on **three independent signals** instead of one:

1. The change event (fast path, unchanged).
2. A **poll** of `isEntitled()` (`ENTITLEMENT_POLL_MS = 1s`) — catches an
   entitlement that never produced a transition.
3. A **re-check at the deadline, before announcing failure** — the case the
   production data showed most often.

And the deadline is no longer terminal: the wait keeps watching for
`LATE_ACTIVATION_GRACE_MS = 5min`, bounded so the watchers cannot leak.

One ordering subtlety: on `timeout` the banner cleanup now stays **registered**.
Watchers are still live past the deadline, so nulling it would let a re-entrant
banner orphan them.

## Tests

Red/green was demonstrated, not assumed. The current logic was extracted
verbatim first; the three `PZ:` cases **failed against it** and the six
behaviour-preservation cases stayed green:

```
✖ PZ: re-checks the entitlement at the deadline before declaring a timeout
✖ PZ: sees an entitlement that arrives without a change event
✖ PZ: a late activation after the timeout still flips the banner to active
```

After the fix: **11/11 green**.

The two guard tests written *after* the fix had never been red, so they were
mutation-tested rather than trusted — both mutants KILLED, each by its intended
test:

| mutant | result |
|---|---|
| grace window never tears down | KILLED |
| poll interval never cleared | KILLED |

## Verification

- `tsc --noEmit` — exit 0
- checkout + entitlement suites — **280/280 pass**
- `biome lint` on changed files — clean
- `docs-stats --check` — OK
- All re-run **after** rebasing onto current `main` (which landed #6736 and
  #6759; the docs-stats churn this branch originally needed was dropped because
  #6736 derives those counts now).

## Known limitation, deliberately not fixed here

The five esbuild stub harnesses that fake `checkout-banner-state` hardcode the
constant values and have no parity guard against the real module. That hazard
pre-dates this PR (it already applied to the other two constants); this PR only
adds two more entries to it. The real constants are pinned in
`tests/checkout-banner-initial-state.test.mts`.

https://claude.ai/code/session_01Rnc842MNgEwHsYfTdBYfsp
