### PR TITLE
fix(deploy): stop false alarms for dormant path deploys

### DIFF
--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -24,7 +24,7 @@
 // Why scan run history instead of listening for workflow_run events: the
 // event fires only on completion, so a workflow that never runs (deleted,
 // broken trigger) produces no event at all. A time-bounded scan of the runs
-// API sees that as "no completed run on main in the window" — an alarm.
+// API sees that as "no run on main in the window" — an alarm.
 //
 // DIRECTION OF FAILURE
 //
@@ -51,7 +51,7 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // run must not have changed anything under convex/.
     skipProofPath: 'convex/',
     // Convex Deploy fires on EVERY push to main (no path filter; the changes
-    // job decides whether to deploy). So "no completed run in the window"
+    // job decides whether to deploy). So "no run in the window"
     // means "no merge to main in the window". The observed max gap across the
     // last 100 completed runs is ~5 days (quiet weekend), so 7 days is the
     // backstop for a workflow that stopped firing at all.
@@ -67,9 +67,15 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // plus its own file and test. A push touching ONLY those paths must
     // deploy; a deploy job skipped there is an unexpected skip, which alarms.
     skipProofPath: null,
+    triggerPaths: Object.freeze([
+      'workers/railway-reconcile-control/**',
+      '.github/workflows/deploy-railway-reconcile-control.yml',
+      'tests/deploy-railway-reconcile-control-workflow.test.mjs',
+    ]),
     // Path-filtered and rare: the Worker is dormant control-plane infra and a
-    // healthy stretch with no matching push is ordinary. 14 days is the
-    // backstop for a trigger that stopped firing.
+    // healthy stretch with no matching push is ordinary. Every tick proves
+    // whether a deploy was due from the trigger-path tree diff; this window
+    // only marks an active run as stuck and labels an old baseline.
     noRunWindowMs: 14 * 24 * 60 * 60 * 1000,
   }),
   Object.freeze({
@@ -80,8 +86,14 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // CLOUDFLARE_API_TOKEN fails it silently like the reconcile Worker's
     // missing secrets did.
     skipProofPath: null,
-    // Same dormant reasoning as the reconcile Worker: last run 2026-08-02,
-    // and a healthy run can be weeks apart.
+    triggerPaths: Object.freeze([
+      'workers/api-cors-preflight/**',
+      'api/_bootstrap-public-tier.js',
+      '.github/workflows/deploy-worker.yml',
+    ]),
+    // Same dormant reasoning as the reconcile Worker: a healthy run can be
+    // weeks apart, so the trigger-path tree — not age — decides whether a
+    // deploy is due.
     noRunWindowMs: 14 * 24 * 60 * 60 * 1000,
   }),
 ]);
@@ -90,8 +102,8 @@ export const MONITORED_WORKFLOWS = Object.freeze([
 export const DEFAULT_NO_RUN_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 // A run that is still executing is not a verdict: the next tick decides. The
-// API's `status=completed` filter should exclude these, but a mis-read must
-// not alarm (a fresh run is the deploy in progress, which is healthy).
+// A fresh active run is the deploy in progress, which is healthy until the
+// next tick. An active run older than its workflow window is stuck and alarms.
 const ACTIVE_RUN_STATUSES = new Set(['queued', 'in_progress', 'waiting', 'pending', 'requested']);
 
 // Conclusions that mean "no verdict, do not judge this run".
@@ -184,15 +196,14 @@ function parseTimestamp(value) {
 }
 
 /**
- * Resolve the newest completed run of one workflow on main, or a structured
- * verdict when there is none.
+ * Resolve the newest run of one workflow on main, including queued or active
+ * work, or a structured verdict when there is none.
  *
  * `gh` is injected rather than imported so the I/O path is testable.
  */
 export function readNewestRun({ gh, repository, workflowFile, now, noRunWindowMs = DEFAULT_NO_RUN_WINDOW_MS }) {
   const query = [
     'branch=main',
-    'status=completed',
     'per_page=100',
   ].join('&');
   const payload = JSON.parse(gh([
@@ -203,11 +214,15 @@ export function readNewestRun({ gh, repository, workflowFile, now, noRunWindowMs
   if (!Array.isArray(runs)) {
     throw new Error(`the run listing for ${workflowFile} was not an object with a workflow_runs array`);
   }
+  for (const candidate of runs) {
+    if (parseTimestamp(candidate?.created_at) === null) {
+      throw new Error(`run ${candidate?.id ?? '?'} of ${workflowFile} has an unreadable created_at timestamp`);
+    }
+  }
 
   // The API returns newest-first, but nothing forces that: sort defensively so
-  // the newest run cannot depend on an undocumented ordering. A run with an
-  // unreadable created_at sorts last — an unreadable record must not decide
-  // the verdict.
+  // the newest run cannot depend on an undocumented ordering. The validation
+  // above makes any unreadable timestamp a read failure instead of hiding it.
   const ordered = [...runs].sort((left, right) => {
     const leftMs = parseTimestamp(left?.created_at);
     const rightMs = parseTimestamp(right?.created_at);
@@ -222,18 +237,25 @@ export function readNewestRun({ gh, repository, workflowFile, now, noRunWindowMs
     return {
       found: false,
       verdict: 'NO_RUN',
-      detail: `no completed run of ${workflowFile} on main is recorded at all`,
+      detail: `no run of ${workflowFile} on main is recorded at all`,
     };
   }
   const createdMs = parseTimestamp(newest.created_at);
-  if (createdMs === null || now - createdMs > noRunWindowMs) {
+  const conclusion = ACTIVE_RUN_STATUSES.has(newest.status)
+    ? newest.status
+    : (newest.conclusion ?? null);
+  if (now - createdMs > noRunWindowMs) {
     return {
       found: true,
       verdict: 'NO_RUN_IN_WINDOW',
       runId: newest.id ?? null,
       createdAt: newest.created_at ?? null,
-      conclusion: newest.conclusion ?? null,
-      detail: `the newest completed run of ${workflowFile} on main (${newest.id}) predates the ${noRunWindowMs / (60 * 60 * 1000)}h window — the workflow may have stopped running`,
+      conclusion,
+      runAttempt: newest.run_attempt ?? 1,
+      headSha: newest.head_sha ?? null,
+      event: newest.event ?? null,
+      displayTitle: newest.display_title ?? null,
+      detail: `the newest run of ${workflowFile} on main (${newest.id}) predates the ${noRunWindowMs / (60 * 60 * 1000)}h window — the workflow may have stopped running`,
     };
   }
   return {
@@ -241,7 +263,7 @@ export function readNewestRun({ gh, repository, workflowFile, now, noRunWindowMs
     verdict: 'RUN_FOUND',
     runId: newest.id ?? null,
     createdAt: newest.created_at ?? null,
-    conclusion: newest.conclusion ?? null,
+    conclusion,
     runAttempt: newest.run_attempt ?? 1,
     headSha: newest.head_sha ?? null,
     event: newest.event ?? null,
@@ -289,7 +311,24 @@ export function readRunJobs({ gh, repository, runId, runAttempt }) {
  * healthy. `git` is injected for testability.
  */
 export function diffTouchesPath({ git, parentSha, headSha, pathPrefix }) {
-  const result = git(['diff', '--name-only', `${parentSha}`, `${headSha}`, '--', pathPrefix]);
+  return diffTouchesPaths({ git, baseSha: parentSha, headSha, paths: [pathPrefix] });
+}
+
+/**
+ * Did any of `paths` change between a deployed baseline and the current tree?
+ *
+ * Path-filtered workflows can be dormant indefinitely. Their age alone says
+ * nothing about health; the trigger-path tree diff says whether a newer deploy
+ * was required. A read failure throws so the caller reports UNKNOWN, never OK.
+ */
+export function diffTouchesPaths({ git, baseSha, headSha, paths }) {
+  if (typeof baseSha !== 'string' || baseSha.length === 0) {
+    throw new Error('the deployed baseline SHA is missing');
+  }
+  if (!Array.isArray(paths) || paths.length === 0) {
+    throw new Error('the deploy trigger path list is missing');
+  }
+  const result = git(['diff', '--name-only', `${baseSha}`, `${headSha}`, '--', ...paths]);
   return result.trim().length > 0;
 }
 
@@ -304,8 +343,8 @@ export function diffTouchesPath({ git, parentSha, headSha, pathPrefix }) {
  *
  * Returns { state: 'OK' | 'ALARM', verdict, detail, runId }.
  */
-export function judgeWorkflow({ workflow, run, jobs, skipProof }) {
-  if (run.verdict === 'NO_RUN' || run.verdict === 'NO_RUN_IN_WINDOW') {
+export function judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequired }) {
+  if (run.verdict === 'NO_RUN') {
     return {
       state: 'ALARM',
       verdict: run.verdict,
@@ -313,11 +352,61 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof }) {
       detail: run.detail,
     };
   }
+  if (run.verdict === 'NO_RUN_IN_WINDOW') {
+    if (!Array.isArray(workflow.triggerPaths) || workflow.triggerPaths.length === 0) {
+      return {
+        state: 'ALARM',
+        verdict: run.verdict,
+        runId: run.runId ?? null,
+        detail: run.detail,
+      };
+    }
+    if (ACTIVE_RUN_STATUSES.has(run.conclusion)) {
+      return {
+        state: 'ALARM',
+        verdict: 'RUN_STUCK',
+        runId: run.runId ?? null,
+        detail: `run ${run.runId} has remained ${run.conclusion} beyond the workflow age window`,
+      };
+    }
+    if (deploymentRequired === true) {
+      return {
+        state: 'ALARM',
+        verdict: 'DEPLOY_MISSING_AFTER_CHANGE',
+        runId: run.runId ?? null,
+        detail: `run ${run.runId} is outside the age window and at least one deploy trigger path changed after ${run.headSha ?? 'an unreadable baseline'}`,
+      };
+    }
+    if (deploymentRequired !== false) {
+      return {
+        state: 'ALARM',
+        verdict: 'DEPLOY_STATE_UNPROVEN',
+        runId: run.runId ?? null,
+        detail: `run ${run.runId} is outside the age window and the deploy trigger path state could not be proven`,
+      };
+    }
+
+    // The current trigger-path tree matches this old run's head. It is a valid
+    // production baseline only if the run and its deploy job both succeeded.
+    const baseline = judgeWorkflow({
+      workflow,
+      run: { ...run, verdict: 'RUN_FOUND' },
+      jobs,
+      skipProof,
+      deploymentRequired: false,
+    });
+    if (baseline.state !== 'OK' || baseline.verdict !== 'DEPLOYED') return baseline;
+    return {
+      state: 'OK',
+      verdict: 'DEPLOY_NOT_DUE',
+      runId: run.runId ?? null,
+      detail: `run ${run.runId} is outside the age window, but no deploy trigger path changed after ${run.headSha}`,
+    };
+  }
 
   const conclusion = run.conclusion;
   if (ACTIVE_RUN_STATUSES.has(conclusion)) {
-    // A completed listing should not contain these, but an in-flight run is a
-    // deploy under way — the next tick decides.
+    // An in-flight run is a deploy under way — the next tick decides.
     return { state: 'OK', verdict: 'IN_PROGRESS', runId: run.runId, detail: `run ${run.runId} is still ${conclusion}` };
   }
   if (INDETERMINATE_RUN_CONCLUSIONS.has(conclusion)) {
@@ -330,6 +419,24 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof }) {
       runId: run.runId,
       detail: `run ${run.runId} (${run.displayTitle ?? run.event ?? '?'}) concluded ${conclusion}`,
     };
+  }
+  if (Array.isArray(workflow.triggerPaths) && workflow.triggerPaths.length > 0) {
+    if (deploymentRequired === true) {
+      return {
+        state: 'ALARM',
+        verdict: 'DEPLOY_MISSING_AFTER_CHANGE',
+        runId: run.runId ?? null,
+        detail: `run ${run.runId} succeeded, but at least one deploy trigger path changed after ${run.headSha ?? 'an unreadable baseline'} without a newer run`,
+      };
+    }
+    if (deploymentRequired !== false) {
+      return {
+        state: 'ALARM',
+        verdict: 'DEPLOY_STATE_UNPROVEN',
+        runId: run.runId ?? null,
+        detail: `run ${run.runId} succeeded, but the deploy trigger path state could not be proven`,
+      };
+    }
   }
 
   // The run succeeded. The deploy job is the one that matters: a success with
@@ -413,7 +520,19 @@ export function checkPostmergeDeploys({ repository, gh, git, now = Date.now() })
     try {
       const run = readNewestRun({ gh, repository, workflowFile: workflow.file, now, noRunWindowMs: workflow.noRunWindowMs });
       let jobs = null;
-      if (run.found && run.verdict === 'RUN_FOUND') {
+      let deploymentRequired = null;
+      if (run.found && Array.isArray(workflow.triggerPaths)) {
+        deploymentRequired = diffTouchesPaths({
+          git,
+          baseSha: run.headSha,
+          headSha: 'origin/main',
+          paths: workflow.triggerPaths,
+        });
+      }
+      if (run.found && run.conclusion === 'success' && deploymentRequired !== true && (
+        run.verdict === 'RUN_FOUND'
+        || (run.verdict === 'NO_RUN_IN_WINDOW' && deploymentRequired === false)
+      )) {
         jobs = readRunJobs({
           gh,
           repository,
@@ -434,7 +553,7 @@ export function checkPostmergeDeploys({ repository, gh, git, now = Date.now() })
       results.push({
         workflow: workflow.file,
         displayName: workflow.displayName,
-        ...judgeWorkflow({ workflow, run, jobs, skipProof }),
+        ...judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequired }),
       });
     } catch (error) {
       // #6479: one unreadable record used to abort the whole walk, so a

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -14,6 +14,7 @@ import {
   checkPostmergeDeploys,
   createRetryingGh,
   diffTouchesPath,
+  diffTouchesPaths,
   isRetryableGhFailure,
   judgeWorkflow,
   readNewestRun,
@@ -109,11 +110,25 @@ describe('post-merge deploy monitor', () => {
         workflow,
         run: run({ runId: 333 }),
         jobs: new Map([[workflow.deployJobName, { name: workflow.deployJobName, conclusion: 'success', status: 'completed' }]]),
+        deploymentRequired: workflow.triggerPaths ? false : null,
         now: NOW,
       });
       assert.equal(verdict.state, 'OK', workflow.file);
       assert.equal(verdict.verdict, 'DEPLOYED', workflow.file);
     }
+  });
+
+  it('alarms immediately when current main changed a path-filtered deploy trigger', () => {
+    const verdict = judgeWorkflow({
+      workflow: WORKER,
+      run: run({ runId: 334 }),
+      jobs: new Map([['Wrangler deploy', { name: 'Wrangler deploy', conclusion: 'success', status: 'completed' }]]),
+      deploymentRequired: true,
+      now: NOW,
+    });
+
+    assert.equal(verdict.state, 'ALARM');
+    assert.equal(verdict.verdict, 'DEPLOY_MISSING_AFTER_CHANGE');
   });
 
   it('accepts a convex=false skip only when the head diff proves it', () => {
@@ -156,6 +171,7 @@ describe('post-merge deploy monitor', () => {
         workflow,
         run: run({ runId: 666 }),
         jobs: new Map([[workflow.deployJobName, { name: workflow.deployJobName, conclusion: 'skipped', status: 'completed' }]]),
+        deploymentRequired: false,
         now: NOW,
       });
       assert.equal(verdict.state, 'ALARM', workflow.file);
@@ -179,6 +195,7 @@ describe('post-merge deploy monitor', () => {
       workflow: RECONCILE,
       run: run({ runId: 888 }),
       jobs: new Map([['Wrangler deploy', { name: 'Wrangler deploy', conclusion: 'failure', status: 'completed' }]]),
+      deploymentRequired: false,
       now: NOW,
     });
     assert.equal(verdict.state, 'ALARM');
@@ -209,12 +226,12 @@ describe('post-merge deploy monitor', () => {
     }
   });
 
-  it('alarms when no completed run exists in the window', () => {
+  it('alarms when no run exists in the window', () => {
     // The workflow stopped running entirely (deleted, broken trigger) — the
     // case a workflow_run event can never see.
     const noRun = judgeWorkflow({
       workflow: CONVEX,
-      run: { found: false, verdict: 'NO_RUN', detail: 'no completed run at all' },
+      run: { found: false, verdict: 'NO_RUN', detail: 'no run at all' },
       jobs: null,
       now: NOW,
     });
@@ -238,6 +255,64 @@ describe('post-merge deploy monitor', () => {
     assert.equal(staleRun.verdict, 'NO_RUN_IN_WINDOW');
   });
 
+  it('does not age out a path-filtered deploy when its trigger paths are unchanged', () => {
+    const staleRun = {
+      found: true,
+      verdict: 'NO_RUN_IN_WINDOW',
+      runId: 42,
+      createdAt: new Date(NOW - 15 * 24 * HOUR).toISOString(),
+      conclusion: 'success',
+      headSha: 'a'.repeat(40),
+      detail: 'predates the window',
+    };
+
+    const verdict = judgeWorkflow({
+      workflow: WORKER,
+      run: staleRun,
+      jobs: new Map([['Wrangler deploy', { name: 'Wrangler deploy', conclusion: 'success', status: 'completed' }]]),
+      deploymentRequired: false,
+      now: NOW,
+    });
+
+    assert.equal(verdict.state, 'OK');
+    assert.equal(verdict.verdict, 'DEPLOY_NOT_DUE');
+    assert.match(verdict.detail, /trigger path/i);
+
+    const failedBaseline = judgeWorkflow({
+      workflow: WORKER,
+      run: { ...staleRun, conclusion: 'failure' },
+      jobs: null,
+      deploymentRequired: false,
+      now: NOW,
+    });
+    assert.equal(failedBaseline.state, 'ALARM', 'an unchanged tree cannot turn a failed baseline green');
+    assert.equal(failedBaseline.verdict, 'RUN_FAILED');
+  });
+
+  it('still alarms when a path-filtered deploy is old and a trigger path changed', () => {
+    const staleRun = {
+      found: true,
+      verdict: 'NO_RUN_IN_WINDOW',
+      runId: 43,
+      createdAt: new Date(NOW - 15 * 24 * HOUR).toISOString(),
+      conclusion: 'success',
+      headSha: 'b'.repeat(40),
+      detail: 'predates the window',
+    };
+
+    const verdict = judgeWorkflow({
+      workflow: WORKER,
+      run: staleRun,
+      jobs: null,
+      deploymentRequired: true,
+      now: NOW,
+    });
+
+    assert.equal(verdict.state, 'ALARM');
+    assert.equal(verdict.verdict, 'DEPLOY_MISSING_AFTER_CHANGE');
+    assert.match(verdict.detail, /trigger path/i);
+  });
+
   it('reads the newest run and the attempts-scoped jobs', () => {
     const newest = readNewestRun({
       gh: ghRuns('convex-deploy.yml', [
@@ -248,7 +323,7 @@ describe('post-merge deploy monitor', () => {
       workflowFile: 'convex-deploy.yml',
       now: NOW,
     });
-    assert.equal(newest.runId, 2, 'must pick the newest completed run, not the first page entry');
+    assert.equal(newest.runId, 2, 'must pick the newest run, not the first page entry');
     assert.equal(newest.conclusion, 'failure');
     assert.equal(newest.runAttempt, 2);
 
@@ -267,6 +342,39 @@ describe('post-merge deploy monitor', () => {
     assert.equal(jobs.get('deploy').conclusion, 'skipped');
   });
 
+  it('reads active runs so an in-flight path deploy is not a false alarm', () => {
+    const active = readNewestRun({
+      gh: (args) => {
+        assert.doesNotMatch(args.join(' '), /status=completed/, 'the newest run may still be queued or running');
+        return JSON.stringify({
+          workflow_runs: [{
+            id: 3,
+            created_at: new Date(NOW - 1000).toISOString(),
+            status: 'in_progress',
+            conclusion: null,
+            run_attempt: 1,
+            head_sha: 'f'.repeat(40),
+            event: 'push',
+          }],
+        });
+      },
+      repository: 'koala73/worldmonitor',
+      workflowFile: 'deploy-worker.yml',
+      now: NOW,
+    });
+
+    assert.equal(active.verdict, 'RUN_FOUND');
+    assert.equal(active.conclusion, 'in_progress');
+    const verdict = judgeWorkflow({
+      workflow: WORKER,
+      run: active,
+      jobs: null,
+      deploymentRequired: true,
+    });
+    assert.equal(verdict.state, 'OK');
+    assert.equal(verdict.verdict, 'IN_PROGRESS');
+  });
+
   it('throws on an unreadable run listing instead of resolving to healthy', () => {
     assert.throws(
       () => readNewestRun({
@@ -276,6 +384,21 @@ describe('post-merge deploy monitor', () => {
         now: NOW,
       }),
       /workflow_runs/,
+    );
+    assert.throws(
+      () => readNewestRun({
+        gh: ghRuns('deploy-worker.yml', [{
+          id: 7,
+          created_at: 'not-a-timestamp',
+          conclusion: 'success',
+          run_attempt: 1,
+          head_sha: '7'.repeat(40),
+        }]),
+        repository: 'koala73/worldmonitor',
+        workflowFile: 'deploy-worker.yml',
+        now: NOW,
+      }),
+      /created_at/,
     );
     assert.throws(
       () => readRunJobs({
@@ -307,6 +430,73 @@ describe('post-merge deploy monitor', () => {
       }),
       true,
     );
+    const calls = [];
+    assert.equal(
+      diffTouchesPaths({
+        git: (args) => { calls.push(args); return ''; },
+        baseSha: 'd'.repeat(40),
+        headSha: 'origin/main',
+        paths: ['workers/api-cors-preflight/**', 'api/_bootstrap-public-tier.js'],
+      }),
+      false,
+    );
+    assert.deepEqual(calls[0], [
+      'diff',
+      '--name-only',
+      'd'.repeat(40),
+      'origin/main',
+      '--',
+      'workers/api-cors-preflight/**',
+      'api/_bootstrap-public-tier.js',
+    ]);
+  });
+
+  it('proves a stale path-filtered deploy against current main before reporting healthy', () => {
+    const deployedHead = '9'.repeat(40);
+    const gitCalls = [];
+    const gh = (args) => {
+      const joined = args.join(' ');
+      const runsMatch = joined.match(/workflows\/([^/]+)\/runs/);
+      if (runsMatch) {
+        const stale = runsMatch[1] === 'deploy-worker.yml';
+        return JSON.stringify({
+          workflow_runs: [{
+            id: stale ? 700 : 701,
+            created_at: new Date(NOW - (stale ? 15 * 24 * HOUR : HOUR)).toISOString(),
+            conclusion: 'success',
+            run_attempt: 1,
+            head_sha: stale ? deployedHead : '8'.repeat(40),
+            event: 'push',
+            display_title: 'push',
+          }],
+        });
+      }
+      return jobsPayload([
+        { name: 'deploy', conclusion: 'success', status: 'completed' },
+        { name: 'Wrangler deploy', conclusion: 'success', status: 'completed' },
+      ]);
+    };
+
+    const results = checkPostmergeDeploys({
+      repository: 'koala73/worldmonitor',
+      gh,
+      git: (args) => { gitCalls.push(args); return ''; },
+      now: NOW,
+    });
+
+    const worker = results.find((entry) => entry.workflow === 'deploy-worker.yml');
+    assert.equal(worker.state, 'OK');
+    assert.equal(worker.verdict, 'DEPLOY_NOT_DUE');
+    assert.equal(gitCalls.length, 2, 'both path-filtered workflows require current-tree proof');
+    const workerDiff = gitCalls.find((args) => args.includes('workers/api-cors-preflight/**'));
+    assert.deepEqual(workerDiff, [
+      'diff',
+      '--name-only',
+      deployedHead,
+      'origin/main',
+      '--',
+      ...WORKER.triggerPaths,
+    ]);
   });
 
   it('honours the no-run window as a boundary, not a race', () => {
@@ -329,6 +519,8 @@ describe('post-merge deploy monitor', () => {
       now: NOW,
     });
     assert.equal(outside.verdict, 'NO_RUN_IN_WINDOW');
+    assert.equal(outside.headSha, 'e'.repeat(40), 'a stale run must retain the deployed head for path proof');
+    assert.equal(outside.runAttempt, 1);
   });
 });
 

--- a/tests/postmerge-deploy-monitor-workflow.test.mjs
+++ b/tests/postmerge-deploy-monitor-workflow.test.mjs
@@ -11,6 +11,8 @@ import { fileURLToPath } from 'node:url';
 
 import YAML from 'yaml';
 
+import { MONITORED_WORKFLOWS } from '../scripts/check-postmerge-deploys.mjs';
+
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const workflowPath = resolve(repoRoot, '.github/workflows/postmerge-deploy-monitor.yml');
 const workflow = YAML.parse(readFileSync(workflowPath, 'utf8'));
@@ -49,5 +51,19 @@ describe('post-merge deploy monitor workflow', () => {
 
   it('needs no write permissions — it only reads GitHub and the git tree', () => {
     assert.deepEqual(workflow.permissions, { contents: 'read' });
+  });
+
+  it('keeps dormant deploy proof paths identical to the workflow triggers', () => {
+    for (const monitored of MONITORED_WORKFLOWS.filter((entry) => entry.triggerPaths)) {
+      const deployWorkflow = YAML.parse(readFileSync(
+        resolve(repoRoot, `.github/workflows/${monitored.file}`),
+        'utf8',
+      ));
+      assert.deepEqual(
+        monitored.triggerPaths,
+        deployWorkflow.on.push.paths,
+        `${monitored.file} trigger paths and monitor proof paths must move together`,
+      );
+    }
   });
 });


### PR DESCRIPTION
## Summary

The post-merge deploy monitor no longer fails every ten minutes merely because a path-filtered Worker has been dormant for 14 days. It now compares the latest run's head with current `main` using the workflow's exact trigger paths: unchanged paths report `DEPLOY_NOT_DUE`, while a changed trigger path without a newer run reports `DEPLOY_MISSING_AFTER_CHANGE` immediately. Queued and in-progress runs remain permitted in-flight work; missing or malformed evidence remains non-healthy. A contract test keeps the proof paths synchronized with each workflow's `on.push.paths` list.

## Validation

- `node --test tests/check-postmerge-deploys.test.mjs tests/postmerge-deploy-monitor-workflow.test.mjs` — 37 tests passed.
- Focused Biome lint passed for the three changed files.
- The full pre-push gate passed TypeScript, API type checks, Unicode safety, changed tests, and version synchronization.
- A live read-only check reported Convex as a proven skip, Railway Reconcile Control as deployed, and api-cors-preflight run `30741257511` as `DEPLOY_NOT_DUE` because no trigger path changed after its deployed head.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT_5.6_sol-000000)
