### PR TITLE
fix(desktop): probe /api/sidecar-health on the resolved port; consume readiness

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1853,10 +1853,15 @@ export class App {
       initAisStream();
     }
 
-    // Wait for sidecar readiness on desktop so bootstrap hits a live server
+    // Wait for sidecar readiness on desktop so bootstrap hits a live server.
+    // Consume the result: a sidecar that never answered its own health probe
+    // should leave a signal rather than being silently treated as ready (#6779).
     if (isDesktopRuntime()) {
-      await waitForSidecarReady(3000);
-      markLcpDebug('wm:boot:sidecar-ready');
+      const sidecarReady = await waitForSidecarReady(3000);
+      markLcpDebug(sidecarReady ? 'wm:boot:sidecar-ready' : 'wm:boot:sidecar-not-ready');
+      if (!sidecarReady) {
+        console.warn('[boot] Local sidecar did not report ready within 3s; bootstrap may fall back to cloud.');
+      }
     }
 
     // Anonymous browser session token (issue #3541). Server's validateApiKey

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -228,13 +228,23 @@ export type {
 } from './smart-poll-loop';
 
 export async function waitForSidecarReady(timeoutMs = 3000): Promise<boolean> {
+  // Resolve the Tauri-confirmed port first. The main app window otherwise never
+  // calls resolveLocalApiPort, so getApiBaseUrl would fall back to the guessed
+  // default port and could report not-ready for a sidecar that is actually up
+  // on an EADDRINUSE-fallback port — a false alarm now that the caller acts on
+  // the result (#6779).
+  await resolveLocalApiPort();
   const baseUrl = getApiBaseUrl();
   if (!baseUrl) return false;
   const pollInterval = 200;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      const res = await fetch(`${baseUrl}/api/service-status`, { method: 'GET' });
+      // Probe the sidecar's own dependency-free liveness endpoint, not the
+      // generic /api/service-status page — /api/sidecar-health is served only
+      // by the local Node sidecar, so a 200 confirms *this* process is up on
+      // the resolved port rather than something else answering on it (#6779).
+      const res = await fetch(`${baseUrl}/api/sidecar-health`, { method: 'GET' });
       if (res.ok) return true;
     } catch {
       // sidecar not ready yet

--- a/tests/dom/sidecar-readiness.test.mts
+++ b/tests/dom/sidecar-readiness.test.mts
@@ -22,7 +22,7 @@ afterEach(() => {
 
 describe('waitForSidecarReady (#6779)', () => {
   it('probes /api/sidecar-health (not /api/service-status) and returns true on 200', async () => {
-    const fetchMock = vi.fn(async () => new Response('{"status":"ok"}', { status: 200 }));
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) => new Response('{"status":"ok"}', { status: 200 }));
     vi.stubGlobal('fetch', fetchMock);
 
     const ready = await waitForSidecarReady(1000);

--- a/tests/dom/sidecar-readiness.test.mts
+++ b/tests/dom/sidecar-readiness.test.mts
@@ -1,0 +1,54 @@
+/**
+ * #6779 — the desktop sidecar readiness probe must hit the sidecar's own
+ * dependency-free liveness endpoint (/api/sidecar-health), not the generic
+ * /api/service-status page, and must return an honest boolean the caller can act
+ * on (App.ts logs when it's false instead of silently treating not-ready as ready).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+let desktop = true;
+vi.mock('@/services/desktop-runtime', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/desktop-runtime')>()),
+  isDesktopRuntime: () => desktop,
+}));
+
+const { waitForSidecarReady } = await import('@/services/runtime');
+
+afterEach(() => {
+  desktop = true;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('waitForSidecarReady (#6779)', () => {
+  it('probes /api/sidecar-health (not /api/service-status) and returns true on 200', async () => {
+    const fetchMock = vi.fn(async () => new Response('{"status":"ok"}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ready = await waitForSidecarReady(1000);
+
+    expect(ready).toBe(true);
+    const probedUrl = String(fetchMock.mock.calls[0]?.[0] ?? '');
+    expect(probedUrl).toContain('/api/sidecar-health');
+    expect(probedUrl).not.toContain('/api/service-status');
+  });
+
+  it('returns false when the sidecar never answers within the timeout', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('ECONNREFUSED'); }));
+
+    const ready = await waitForSidecarReady(400);
+
+    expect(ready).toBe(false);
+  });
+
+  it('returns false off the desktop runtime (no local base URL to probe)', async () => {
+    desktop = false;
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ready = await waitForSidecarReady(1000);
+
+    expect(ready).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Desktop sidecar readiness had three problems: `waitForSidecarReady` polled `/api/service-status` (a static page that always reports `operational` and checks nothing), it **discarded** the returned boolean (so a sidecar that never came up was silently treated as ready), and the main app window never resolves the Tauri-confirmed port — so the probe always hit the guessed default `46123`.

This fixes the TS layer:
- Probe **`/api/sidecar-health`**, the sidecar's own dependency-free, auth-exempt liveness route.
- **Resolve the Tauri-confirmed port before probing**, so the main window checks the real port (including an EADDRINUSE-fallback port), not the `46123` guess — otherwise the new signal below would false-alarm on a healthy sidecar bound elsewhere.
- **Consume the boolean** in `App.ts`: on not-ready it logs a warning and emits a distinct `wm:boot:sidecar-not-ready` LCP marker, instead of discarding it. Boot proceeds whether ready or not — no new blocking path.

## Scope / deferred

The deeper Rust-side hardening (main.rs writing `DEFAULT_LOCAL_API_PORT` into shared state on a port-file timeout; propagating an "unassigned" port instead of masking it as `46123`) is **deferred** — it needs desktop-runtime verification that isn't available in this environment (no cargo). This PR is the safe, testable TS subset.

## Validation

- New DOM test: asserts the probe hits `/api/sidecar-health` (not `/api/service-status`), returns `true` on 200, `false` on timeout, and `false` (no network) off the desktop runtime.
- `tsc --noEmit` + biome clean. No blocking/hang path added (boot falls through on either outcome).

Closes #6779

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
