### PR TITLE
refactor(mcp): collapse cache-tool freshness onto _freshnessChecks

### DIFF
--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -49,9 +49,7 @@ export async function executeTool(
   data: Record<string, unknown>;
 }> {
   const reads = tool._cacheKeys.map(k => readJsonFromUpstash(k));
-  const freshnessChecks = tool._freshnessChecks?.length
-    ? tool._freshnessChecks
-    : [{ key: tool._seedMetaKey, maxStaleMin: tool._maxStaleMin }];
+  const freshnessChecks = tool._freshnessChecks;
   const metaReads = freshnessChecks.map((check) => readJsonFromUpstash(check.key));
   // #6080 deployment-order grace. Only checks declaring a content contract pay
   // for this read, so it is one extra command on get_chokepoint_status and

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -563,8 +563,6 @@ export const CACHE_TOOLS: ToolDef[] = [
       'market:gulf-quotes:v1',
       'market:fear-greed:v1',
     ],
-    _seedMetaKey: 'seed-meta:market:stocks',
-    _maxStaleMin: 30,
     _freshnessChecks: [...MARKET_FRESHNESS_CHECKS],
     // NOTE: `GET /api/market/v1/get-gold-intelligence` is NOT covered here.
     // The audit-time cross-reference matched on the single `market:commodities-bootstrap:v1`
@@ -686,8 +684,6 @@ export const CACHE_TOOLS: ToolDef[] = [
       'unrest:events:v1',
       CII_RISK_SCORE_CACHE_KEYS.stale,
     ],
-    _seedMetaKey: 'seed-meta:conflict:ucdp-events',
-    _maxStaleMin: 30,
     // Per-key budgets (#5864): unrest:events:v1 is materializer-backed since
     // #5863 and was invisible to this envelope — a dead 15-min pipeline still
     // reported stale:false to agents.
@@ -751,8 +747,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['aviation:delays-bootstrap:v2'],
-    _seedMetaKey: 'seed-meta:aviation:faa',
-    _maxStaleMin: 90,
+    _freshnessChecks: [{ key: 'seed-meta:aviation:faa', maxStaleMin: 90 }],
     _apiPaths: [],
   },
   {
@@ -884,8 +879,6 @@ export const CACHE_TOOLS: ToolDef[] = [
       'intelligence:cross-source-signals:v1',
       'intelligence:advisories-bootstrap:v1',
     ],
-    _seedMetaKey: 'seed-meta:news:insights',
-    _maxStaleMin: 30,
     // Per-key budgets (#5864): the envelope used to gate on the insights meta
     // alone, so a stalled GDELT materializer left agents reading stale:false
     // for hours. Every bundled key now carries its own freshness budget,
@@ -986,8 +979,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       'wildfire:fires:v1',
       'natural:events:v1',
     ],
-    _seedMetaKey: 'seed-meta:seismology:earthquakes',
-    _maxStaleMin: 30,
+    _freshnessChecks: [{ key: 'seed-meta:seismology:earthquakes', maxStaleMin: 30 }],
     _apiPaths: [
       "GET /api/natural/v1/list-natural-events",
       "GET /api/seismology/v1/list-earthquakes",
@@ -1029,8 +1021,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['theater_posture:sebuf:stale:v1'],
-    _seedMetaKey: 'seed-meta:intelligence:risk-scores',
-    _maxStaleMin: 120,
+    _freshnessChecks: [{ key: 'seed-meta:intelligence:risk-scores', maxStaleMin: 120 }],
     // CASCADE-MIRROR EQUIVALENCE: the API handler at
     // server/worldmonitor/military/v1/get-theater-posture.ts:23 reads 3 cascade
     // variants (live + stale + backup) and returns the freshest available.
@@ -1096,8 +1087,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['cyber:threats-bootstrap:v2'],
-    _seedMetaKey: 'seed-meta:cyber:threats',
-    _maxStaleMin: 240,
+    _freshnessChecks: [{ key: 'seed-meta:cyber:threats', maxStaleMin: 240 }],
     _apiPaths: [],
   },
   {
@@ -1267,8 +1257,6 @@ export const CACHE_TOOLS: ToolDef[] = [
       [BOOTSTRAP_CACHE_KEYS.chinaMacro]: 'china-macro',
       [BOOTSTRAP_CACHE_KEYS.chinaReleaseCalendar]: 'china-release-calendar',
     },
-    _seedMetaKey: 'seed-meta:economic:econ-calendar',
-    _maxStaleMin: 1440,
     _freshnessChecks: [
       { key: 'seed-meta:economic:econ-calendar', maxStaleMin: 1440 },
       { key: 'seed-meta:economic:china-macro-transport', maxStaleMin: 4320 },
@@ -1340,8 +1328,6 @@ export const CACHE_TOOLS: ToolDef[] = [
       'economic:imf:labor:v1',
       'economic:imf:external:v1',
     ],
-    _seedMetaKey: 'seed-meta:economic:imf-macro',
-    _maxStaleMin: 100800, // monthly WEO release; 70d = 2× interval (absorbs one missed run)
     _freshnessChecks: [
       { key: 'seed-meta:economic:imf-macro', maxStaleMin: 100800 },
       { key: 'seed-meta:economic:imf-growth', maxStaleMin: 100800 },
@@ -1386,8 +1372,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['economic:eurostat:house-prices:v1'],
-    _seedMetaKey: 'seed-meta:economic:eurostat-house-prices',
-    _maxStaleMin: 60 * 24 * 50, // weekly cron, annual data
+    _freshnessChecks: [{ key: 'seed-meta:economic:eurostat-house-prices', maxStaleMin: 60 * 24 * 50 }], // weekly cron, annual data
     _apiPaths: [],
   },
   {
@@ -1426,8 +1411,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['economic:eurostat:gov-debt-q:v1'],
-    _seedMetaKey: 'seed-meta:economic:eurostat-gov-debt-q',
-    _maxStaleMin: 60 * 24 * 14, // quarterly data, 2-day cron
+    _freshnessChecks: [{ key: 'seed-meta:economic:eurostat-gov-debt-q', maxStaleMin: 60 * 24 * 14 }], // quarterly data, 2-day cron
     _apiPaths: [],
   },
   {
@@ -1466,8 +1450,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['economic:eurostat:industrial-production:v1'],
-    _seedMetaKey: 'seed-meta:economic:eurostat-industrial-production',
-    _maxStaleMin: 60 * 24 * 5, // monthly data, daily cron
+    _freshnessChecks: [{ key: 'seed-meta:economic:eurostat-industrial-production', maxStaleMin: 60 * 24 * 5 }], // monthly data, daily cron
     _apiPaths: [],
   },
   {
@@ -1533,8 +1516,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['prediction:markets-bootstrap:v1'],
-    _seedMetaKey: 'seed-meta:prediction:markets',
-    _maxStaleMin: 90,
+    _freshnessChecks: [{ key: 'seed-meta:prediction:markets', maxStaleMin: 90 }],
     _apiPaths: [
       "GET /api/prediction/v1/list-prediction-markets",
     ],
@@ -1597,8 +1579,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['sanctions:entities:v1', 'sanctions:pressure:v1'],
-    _seedMetaKey: 'seed-meta:sanctions:entities',
-    _maxStaleMin: 1440,
+    _freshnessChecks: [{ key: 'seed-meta:sanctions:entities', maxStaleMin: 1440 }],
     _apiPaths: [
       "GET /api/sanctions/v1/list-sanctions-pressure",
       "GET /api/sanctions/v1/lookup-sanction-entity",
@@ -1652,8 +1633,7 @@ export const CACHE_TOOLS: ToolDef[] = [
     // year segment from both keys and collide on the same `summary` label,
     // causing the second result to overwrite the first.
     _cacheKeys: [`displacement:summary:v1:${new Date().getUTCFullYear()}`],
-    _seedMetaKey: 'seed-meta:displacement:summary',
-    _maxStaleMin: 3600,
+    _freshnessChecks: [{ key: 'seed-meta:displacement:summary', maxStaleMin: 3600 }],
     // Audit miss: handler uses cachedFetchJson with a year-suffixed key the
     // audit's regex couldn't statically resolve. The op IS covered by this
     // tool — same underlying displacement:summary:v1:<year> cache.
@@ -1727,8 +1707,6 @@ export const CACHE_TOOLS: ToolDef[] = [
     // (scripts/seed-health-air-quality.mjs exports HEALTH_AIR_QUALITY_KEY +
     // CLIMATE_AIR_QUALITY_KEY) so no duplicate seed work.
     _cacheKeys: ['health:disease-outbreaks:v1', 'health:air-quality:v1'],
-    _seedMetaKey: 'seed-meta:health:disease-outbreaks',
-    _maxStaleMin: 2880,
     _freshnessChecks: [
       { key: 'seed-meta:health:disease-outbreaks', maxStaleMin: 2880 }, // daily cron; 48h budget
       { key: 'seed-meta:health:air-quality', maxStaleMin: 180 },        // hourly cron; 3h budget
@@ -1832,8 +1810,6 @@ export const CACHE_TOOLS: ToolDef[] = [
       'resilience:fossil-electricity-share:v1',   // STANDALONE_KEYS::fossilElectricityShare
       'economic:worldbank-renewable:v1',          // BOOTSTRAP_KEYS::renewableEnergy
     ],
-    _seedMetaKey: 'seed-meta:energy:eia-petroleum',
-    _maxStaleMin: 4320, // EIA petroleum daily-bundle baseline; per-key budgets via _freshnessChecks below
     _freshnessChecks: [
       { key: 'seed-meta:energy:eia-petroleum',                  maxStaleMin: 4320 },   // daily bundle; 72h = 3× interval
       { key: 'seed-meta:energy:electricity-prices',             maxStaleMin: 2880 },   // daily cron (14:00 UTC); 48h = 2× interval
@@ -1904,8 +1880,6 @@ export const CACHE_TOOLS: ToolDef[] = [
       return selectDatasets(data, argStrList(params.dataset));
     },
     _cacheKeys: ['climate:anomalies:v2', 'climate:disasters:v1', 'climate:co2-monitoring:v1', 'climate:air-quality:v1', 'climate:ocean-ice:v1', 'climate:news-intelligence:v1', 'weather:alerts:v1'],
-    _seedMetaKey: 'seed-meta:climate:co2-monitoring',
-    _maxStaleMin: 2880,
     _freshnessChecks: [
       { key: 'seed-meta:climate:anomalies', maxStaleMin: 120 },
       { key: 'seed-meta:climate:disasters', maxStaleMin: 720 },
@@ -1956,8 +1930,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['infra:outages:v1'],
-    _seedMetaKey: 'seed-meta:infra:outages',
-    _maxStaleMin: 30,
+    _freshnessChecks: [{ key: 'seed-meta:infra:outages', maxStaleMin: 30 }],
     _apiPaths: [
       "GET /api/infrastructure/v1/list-internet-outages",
     ],
@@ -2028,8 +2001,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       'trade:customs-revenue:v1',
       'comtrade:flows:v1',
     ],
-    _seedMetaKey: 'seed-meta:trade:customs-revenue',
-    _maxStaleMin: 2880,
+    _freshnessChecks: [{ key: 'seed-meta:trade:customs-revenue', maxStaleMin: 2880 }],
     _apiPaths: [
       "GET /api/supply-chain/v1/get-shipping-stress",
       "GET /api/trade/v1/get-customs-revenue",
@@ -2120,8 +2092,6 @@ export const CACHE_TOOLS: ToolDef[] = [
     _cacheLabels: {
       'trade:tariffs:v2:840': 'all',
     },
-    _seedMetaKey: 'seed-meta:trade:tariffs',
-    _maxStaleMin: 420, // tariff fleet meta; per-key budgets via _freshnessChecks below
     _freshnessChecks: [
       { key: 'seed-meta:trade:tariffs',               maxStaleMin: 420 },   // inside TARIFF_TTL 480
       { key: 'seed-meta:economic:bigmac',             maxStaleMin: 10080 }, // weekly seed; 7d
@@ -2259,8 +2229,6 @@ export const CACHE_TOOLS: ToolDef[] = [
       'portwatch:chokepoints:ref:v1',               // STANDALONE_KEYS::portwatchChokepointsRef
       'energy:chokepoint-flows:v1',                 // STANDALONE_KEYS::chokepointFlows
     ],
-    _seedMetaKey: 'seed-meta:supply_chain:transit-summaries',
-    _maxStaleMin: 30, // transit-summaries 10-min relay baseline; per-key budgets via _freshnessChecks below
     _freshnessChecks: [
       { key: 'seed-meta:supply_chain:transit-summaries',   maxStaleMin: 30 },             // 10-min relay; 30min = 3× interval
       { key: 'seed-meta:supply_chain:chokepoint_transits', maxStaleMin: 30 },             // 10-min relay; 30min = 3× interval
@@ -2316,8 +2284,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['positive_events:geo-bootstrap:v1'],
-    _seedMetaKey: 'seed-meta:positive-events:geo',
-    _maxStaleMin: 60,
+    _freshnessChecks: [{ key: 'seed-meta:positive-events:geo', maxStaleMin: 60 }],
     _apiPaths: [
       'GET /api/positive-events/v1/list-positive-geo-events',
     ],
@@ -2358,8 +2325,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['radiation:observations:v1'],
-    _seedMetaKey: 'seed-meta:radiation:observations',
-    _maxStaleMin: 30,
+    _freshnessChecks: [{ key: 'seed-meta:radiation:observations', maxStaleMin: 30 }],
     _apiPaths: [
       "GET /api/radiation/v1/list-radiation-observations",
     ],
@@ -2400,8 +2366,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['research:tech-events-bootstrap:v1'],
-    _seedMetaKey: 'seed-meta:research:tech-events',
-    _maxStaleMin: 480,
+    _freshnessChecks: [{ key: 'seed-meta:research:tech-events', maxStaleMin: 480 }],
     _apiPaths: [
       'GET /api/research/v1/list-tech-events',
     ],
@@ -2439,8 +2404,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['forecast:predictions:v2'],
-    _seedMetaKey: 'seed-meta:forecast:predictions',
-    _maxStaleMin: 90,
+    _freshnessChecks: [{ key: 'seed-meta:forecast:predictions', maxStaleMin: 90 }],
     _apiPaths: [
       "GET /api/forecast/v1/get-forecasts",
     ],
@@ -2472,8 +2436,7 @@ export const CACHE_TOOLS: ToolDef[] = [
     }),
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _cacheKeys: ['forecast:scorecard:v1'],
-    _seedMetaKey: 'seed-meta:forecast:scorecard',
-    _maxStaleMin: 2160,
+    _freshnessChecks: [{ key: 'seed-meta:forecast:scorecard', maxStaleMin: 2160 }],
     _apiPaths: [
       "GET /api/forecast/v1/get-forecast-scorecard",
     ],
@@ -2511,8 +2474,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       return data;
     },
     _cacheKeys: ['intelligence:social:reddit:v1'],
-    _seedMetaKey: 'seed-meta:intelligence:social-reddit',
-    _maxStaleMin: 30,
+    _freshnessChecks: [{ key: 'seed-meta:intelligence:social-reddit', maxStaleMin: 30 }],
     _apiPaths: [
       "GET /api/intelligence/v1/get-social-velocity",
     ],
@@ -2584,8 +2546,7 @@ export const CACHE_TOOLS: ToolDef[] = [
     },
     _cacheKeys: ['temporal:anomalies:v1'],
     _cacheLabels: { 'temporal:anomalies:v1': 'snapshot' },
-    _seedMetaKey: 'seed-meta:temporal:anomalies',
-    _maxStaleMin: 45,
+    _freshnessChecks: [{ key: 'seed-meta:temporal:anomalies', maxStaleMin: 45 }],
     _apiPaths: [],
   },
 
@@ -2686,8 +2647,7 @@ export const CACHE_TOOLS: ToolDef[] = [
     },
     _cacheKeys: ['seismology:earthquakes:v1'],
     _cacheLabels: { 'seismology:earthquakes:v1': 'earthquakes' },
-    _seedMetaKey: 'seed-meta:seismology:earthquakes',
-    _maxStaleMin: 30,
+    _freshnessChecks: [{ key: 'seed-meta:seismology:earthquakes', maxStaleMin: 30 }],
     _apiPaths: [],
   },
 

--- a/api/mcp/registry/index.ts
+++ b/api/mcp/registry/index.ts
@@ -49,8 +49,8 @@ for (const tool of TOOL_REGISTRY) {
 // the registry or the module-level schema consts. Codex Round 2 explicitly
 // flagged shallow `{ ...prop }` as insufficient for these shapes.
 //
-// `_*`-prefixed internal fields (_apiPaths, _cacheKeys, _seedMetaKey,
-// _maxStaleMin, _freshnessChecks, _coverageKeys, _postFilter, _execute)
+// `_*`-prefixed internal fields (_apiPaths, _cacheKeys,
+// _freshnessChecks, _coverageKeys, _postFilter, _execute)
 // are NEVER enumerated — the function only constructs a fresh object with
 // the public-shape fields (name, description, inputSchema, annotations).
 //

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -183,9 +183,10 @@ export interface CacheToolDef extends BaseToolDef {
   // Explicit output labels for keys whose last informative segment is too
   // generic (for example economic:china:macro:v2 -> "china-macro").
   _cacheLabels?: Record<string, string>;
-  _seedMetaKey: string;
-  _maxStaleMin: number;
-  _freshnessChecks?: FreshnessCheck[];
+  // Per-key freshness contract. Required and non-empty (tuple = at least one
+  // element) — every cache tool must declare at least one freshness budget, and
+  // the dispatcher reads this list directly with no synthesized fallback.
+  _freshnessChecks: [FreshnessCheck, ...FreshnessCheck[]];
   _execute?: never;
   // Optional in-memory post-filter applied to the label-walked `data` map
   // AFTER the Redis reads + freshness + cache_all_null guard. Pure narrowing:
@@ -216,8 +217,6 @@ export interface CacheToolDef extends BaseToolDef {
 // hybrid _execute's `_coverageKeys` are equivalent for that audit.
 export interface RpcToolDef extends BaseToolDef {
   _cacheKeys?: never;
-  _seedMetaKey?: never;
-  _maxStaleMin?: never;
   _freshnessChecks?: never;
   _execute: (
     params: Record<string, unknown>,

--- a/tests/fixtures/jmespath-samples/README.md
+++ b/tests/fixtures/jmespath-samples/README.md
@@ -59,7 +59,7 @@ this feature.
 `executeTool()` reads cache via `readJsonFromUpstash` which calls
 `fetch()` directly, not `deps.redisPipeline`. Mocking `deps` doesn't
 intercept the cache reads, so we'd have to mock `globalThis.fetch`
-keyed by each tool's `_cacheKeys + _seedMetaKey` to get the cache path
+keyed by each tool's `_cacheKeys + _freshnessChecks[].key` to get the cache path
 to feed our fixtures. Calling `applyJmespath` directly on the
 already-assembled tool response is simpler AND uniquely correct for
 what we measure — the projection delta, not the cache-path overhead.

--- a/tests/mcp-analysis-cache-tools.test.mjs
+++ b/tests/mcp-analysis-cache-tools.test.mjs
@@ -23,8 +23,10 @@ describe('get_temporal_anomalies cache tool', () => {
   it('is registered with the cache-tool contract fields', () => {
     assert.ok(tool, 'tool must exist in CACHE_TOOLS');
     assert.deepEqual(tool._cacheKeys, ['temporal:anomalies:v1']);
-    assert.equal(tool._seedMetaKey, 'seed-meta:temporal:anomalies');
-    assert.equal(tool._maxStaleMin, 45);
+    // Migrated from the retired seed-meta/stale-budget pair — the single
+    // synthesized freshness check must carry the original key + budget verbatim.
+    assert.equal(tool._freshnessChecks[0].key, 'seed-meta:temporal:anomalies');
+    assert.equal(tool._freshnessChecks[0].maxStaleMin, 45);
     assert.deepEqual(tool._apiPaths, []);
     assert.equal(tool._outputBudgetBytes, 65536);
     assert.deepEqual(tool.annotations, {
@@ -104,8 +106,10 @@ describe('get_test_site_seismicity cache tool', () => {
   it('is registered with the cache-tool contract fields', () => {
     assert.ok(tool, 'tool must exist in CACHE_TOOLS');
     assert.deepEqual(tool._cacheKeys, ['seismology:earthquakes:v1']);
-    assert.equal(tool._seedMetaKey, 'seed-meta:seismology:earthquakes');
-    assert.equal(tool._maxStaleMin, 30);
+    // Migrated from the retired seed-meta/stale-budget pair — the single
+    // synthesized freshness check must carry the original key + budget verbatim.
+    assert.equal(tool._freshnessChecks[0].key, 'seed-meta:seismology:earthquakes');
+    assert.equal(tool._freshnessChecks[0].maxStaleMin, 30);
     assert.deepEqual(tool._apiPaths, []);
     assert.deepEqual(tool.annotations, {
       readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false,

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -1243,8 +1243,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
       description: 'test seam',
       inputSchema: { type: 'object', properties: {}, required: [] },
       _cacheKeys: ['fake:key:v1'],
-      _seedMetaKey: 'seed-meta:fake',
-      _maxStaleMin: 60,
+      _freshnessChecks: [{ key: 'seed-meta:fake', maxStaleMin: 60 }],
       _apiPaths: [],
       _postFilter: (data) => {
         data.mutated = true; // mutate the clone, then blow up mid-filter


### PR DESCRIPTION
## Summary

`CacheToolDef` required a `_seedMetaKey` + `_maxStaleMin` pair **and** carried an optional `_freshnessChecks` list. `dispatch.ts` preferred the list, else synthesized `[{ key: _seedMetaKey, maxStaleMin: _maxStaleMin }]`. So the pair was **dead** for the ~10 tools that declared both, and the (redundant) freshness source for the ~20 that declared only it — two ways to say one thing.

This collapses everything onto `_freshnessChecks`:
- The **20 pair-only tools** get `_freshnessChecks: [{ key, maxStaleMin }]` reproducing the synthesized fallback exactly, then drop the pair.
- The **10 both-tools** drop the dead pair, keep their `_freshnessChecks` (with `minRecordCount` / `requireContentFreshness` / `contentFreshnessActivationKey`) untouched.
- `_freshnessChecks` becomes a required non-empty tuple `[FreshnessCheck, ...FreshnessCheck[]]`; `_seedMetaKey`/`_maxStaleMin` are removed from the type; the `dispatch.ts` fallback is dropped.

**Behavior-preserving** — no freshness threshold changed.

## Validation

- Reviewed value-preservation for all 30 tools: every migrated tool's `_freshnessChecks[0].key`/`.maxStaleMin` equals its old pair (verified against `origin/main` line-by-line, including computed expressions like `60 * 24 * 50`); the 10 both-tools' lists are byte-identical.
- Zero remaining `_seedMetaKey`/`_maxStaleMin` references anywhere; the two assert tests now read `_freshnessChecks[0]` with the same expected values.
- `tsc -p tsconfig.api.json` clean; full MCP suite (~1180 tests) passes; biome clean.

Closes #6777

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
