### PR TITLE
fix(energy): JODI oil reads last year's file, and jodiGas contentMeta can never date the snapshot

### DIFF
--- a/scripts/seed-jodi-oil.mjs
+++ b/scripts/seed-jodi-oil.mjs
@@ -322,7 +322,15 @@ async function fetchCsv(url) {
     headers: { 'User-Agent': CHROME_UA, Accept: 'text/csv,text/plain,*/*' },
     signal: AbortSignal.timeout(30_000),
   });
-  if (!resp.ok) throw new Error(`JODI CSV fetch failed: HTTP ${resp.status} for ${url}`);
+  if (!resp.ok) {
+    const err = new Error(`JODI CSV fetch failed: HTTP ${resp.status} for ${url}`);
+    // A missing static file does not appear during a 2s backoff, and this
+    // seeder now tries two naming conventions per year — retrying each 404
+    // three times would spend ~12s of the bundle's wall-clock budget just to
+    // rediscover that a year is not published under that name.
+    if (resp.status === 404) err.nonRetryable = true;
+    throw err;
+  }
   return resp.text();
 }
 
@@ -364,30 +372,95 @@ export function jodiSourceYears(now = new Date()) {
   };
 }
 
+/**
+ * Every published filename for one JODI year file, in the order to try them.
+ *
+ * JODI names each completed year `<kind>/<year>.csv` (2002 through 2025) but
+ * publishes the year in progress as `<kind>/<kind>year<year>.csv`. Asking only
+ * for the plain name meant the current year 404d for the whole of 2026 (#6799).
+ * Plain name first: it is what every settled year uses, so a completed year
+ * costs one request.
+ */
+export function jodiCsvCandidates(kind, year) {
+  return [
+    `${JODI_BASE}${kind}/${year}.csv`,
+    `${JODI_BASE}${kind}/${kind}year${year}.csv`,
+  ];
+}
+
+/**
+ * Fetch one JODI year, trying each published naming convention in turn.
+ *
+ * Returns `{ ok, text, url, attempted, error }` rather than a bare string so a
+ * caller can tell "this year is unreachable" from "this year is empty". That
+ * distinction is the actual #6799 defect: the previous `.catch(() => '')`
+ * collapsed both into an empty string, and an unreachable CURRENT year then
+ * degraded silently to publishing the prior year as if it were current.
+ */
+export async function fetchYearCsv(kind, year, options = {}) {
+  const fetcher = options.fetchCsv ?? fetchCsv;
+  const retries = options.retries ?? 2;
+  const attempted = jodiCsvCandidates(kind, year);
+  let lastError = null;
+
+  for (const url of attempted) {
+    try {
+      const text = await withRetry(() => fetcher(url), retries, 2000);
+      return { ok: true, text, url, attempted, error: null };
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  return {
+    ok: false,
+    text: '',
+    url: null,
+    attempted,
+    error: lastError?.message || String(lastError),
+  };
+}
+
 async function fetchAllRows() {
   const { currentYear, priorYear, lookbackYear } = jodiSourceYears();
 
   const [primaryCurrent, primaryPrior, secondaryCurrent, secondaryPrior, secondaryLookback] =
     await Promise.all([
-      withRetry(() => fetchCsv(`${JODI_BASE}primary/${currentYear}.csv`), 2, 2000)
-        .catch(e => { console.warn(`  primary/${currentYear}.csv failed: ${e.message}`); return ''; }),
-      withRetry(() => fetchCsv(`${JODI_BASE}primary/${priorYear}.csv`), 2, 2000)
-        .catch(e => { console.warn(`  primary/${priorYear}.csv failed: ${e.message}`); return ''; }),
-      withRetry(() => fetchCsv(`${JODI_BASE}secondary/${currentYear}.csv`), 2, 2000)
-        .catch(e => { console.warn(`  secondary/${currentYear}.csv failed: ${e.message}`); return ''; }),
-      withRetry(() => fetchCsv(`${JODI_BASE}secondary/${priorYear}.csv`), 2, 2000)
-        .catch(e => { console.warn(`  secondary/${priorYear}.csv failed: ${e.message}`); return ''; }),
+      fetchYearCsv('primary', currentYear),
+      fetchYearCsv('primary', priorYear),
+      fetchYearCsv('secondary', currentYear),
+      fetchYearCsv('secondary', priorYear),
       // Optional: its absence only withholds the demand change, never the seed.
-      withRetry(() => fetchCsv(`${JODI_BASE}secondary/${lookbackYear}.csv`), 2, 2000)
-        .catch(e => { console.warn(`  secondary/${lookbackYear}.csv failed: ${e.message}`); return ''; }),
+      fetchYearCsv('secondary', lookbackYear),
     ]);
 
+  for (const [label, result] of [
+    [`primary/${currentYear}`, primaryCurrent],
+    [`primary/${priorYear}`, primaryPrior],
+    [`secondary/${currentYear}`, secondaryCurrent],
+    [`secondary/${priorYear}`, secondaryPrior],
+    [`secondary/${lookbackYear}`, secondaryLookback],
+  ]) {
+    if (!result.ok) console.warn(`  ${label} unavailable (tried ${result.attempted.length} names): ${result.error}`);
+  }
+
+  // Losing BOTH current-year files is not a soft degrade — every month the
+  // snapshot can still date itself from is last year's, so the publish silently
+  // becomes a re-run of a stale vintage. Say so loudly: this is what went
+  // unnoticed from January to August 2026.
+  if (!primaryCurrent.ok && !secondaryCurrent.ok) {
+    console.error(
+      `  [jodi-oil] CURRENT_YEAR_UNAVAILABLE ${currentYear}: no primary or secondary file resolved `
+      + `under any known naming convention. Publishing from ${priorYear} only — the snapshot cannot `
+      + 'advance past that year until this is fixed. Check whether JODI renamed the download again.',
+    );
+  }
+
   return mergeSourceRows(
-    primaryCurrent,
-    primaryPrior,
-    secondaryCurrent,
-    secondaryPrior,
-    secondaryLookback,
+    primaryCurrent.text,
+    primaryPrior.text,
+    secondaryCurrent.text,
+    secondaryPrior.text,
+    secondaryLookback.text,
   );
 }
 

--- a/scripts/shared/jodi-content-age.mjs
+++ b/scripts/shared/jodi-content-age.mjs
@@ -1,5 +1,29 @@
 import { monthIndex, monthPeriodEnd } from './jodi-demand-change.mjs';
 
+/**
+ * Milliseconds for a clock supplied as either a `Date` or epoch ms, or null
+ * when it is neither usable.
+ *
+ * Both shapes reach this module. Callers inside the seeders pass a `Date`;
+ * runSeed's content-age hook passes `startMs`, a number
+ * (`contentMeta(data, startMs)`, scripts/_seed-utils.mjs). Accepting only
+ * `instanceof Date` made `jodiDatasetContentMeta` return null for every
+ * runSeed-driven call, and api/health.js reads a null newestItemAt as
+ * STALE_CONTENT — so jodiGas and lngVulnerability were permanently stale
+ * regardless of how current the file was (#6799).
+ *
+ * Still fail-closed for a genuinely unusable clock (NaN, null, a string): the
+ * caller cannot date a file without knowing "now", and guessing would let a
+ * mis-stamped row vouch for freshness.
+ */
+function clockMs(now) {
+  if (now instanceof Date) {
+    const ms = now.getTime();
+    return Number.isFinite(ms) ? ms : null;
+  }
+  return typeof now === 'number' && Number.isFinite(now) ? now : null;
+}
+
 export const MAX_JODI_CONTENT_AGE_MONTHS = 6;
 
 /**
@@ -57,9 +81,11 @@ export function assessChinaJodiCoverage(records, now, hasMeasurements) {
   }
 
   const sourceMonth = monthIndex(china.dataMonth);
-  const currentMonth = now instanceof Date && Number.isFinite(now.getTime())
-    ? now.getUTCFullYear() * 12 + now.getUTCMonth()
-    : null;
+  const nowForMonth = clockMs(now);
+  const nowDate = nowForMonth === null ? null : new Date(nowForMonth);
+  const currentMonth = nowDate === null
+    ? null
+    : nowDate.getUTCFullYear() * 12 + nowDate.getUTCMonth();
   if (sourceMonth == null || currentMonth == null || sourceMonth > currentMonth) {
     return { ok: false, reason: 'china-invalid-month', dataMonth: china.dataMonth ?? null, ageMonths: null };
   }
@@ -123,7 +149,7 @@ export function jodiDatasetContentMeta(
   minCountries = MIN_JODI_CONTENT_AGE_COUNTRIES,
 ) {
   if (!Array.isArray(records)) return null;
-  const nowMs = now instanceof Date && Number.isFinite(now.getTime()) ? now.getTime() : null;
+  const nowMs = clockMs(now);
   if (nowMs === null) return null;
 
   /** @type {Map<number, number>} */

--- a/tests/china-energy-coverage.test.mjs
+++ b/tests/china-energy-coverage.test.mjs
@@ -341,6 +341,33 @@ describe('JODI publishes the rest of the world without China (#6395)', () => {
     assert.equal(jodiDatasetContentMeta(null, hasMeasurement, NOW), null);
   });
 
+  it('dates content age when called with epoch ms, which is what runSeed passes', () => {
+    // runSeed invokes the hook as `contentMeta(data, startMs)` — a NUMBER
+    // (scripts/_seed-utils.mjs). This helper used to demand `now instanceof
+    // Date` and return null for anything else, and a null newestItemAt is read
+    // as STALE_CONTENT by api/health.js. jodiGas and lngVulnerability were
+    // therefore permanently stale no matter how current the file was (#6799).
+    //
+    // Every other test here passes `NOW`, a Date — which is exactly why the
+    // real call shape was never exercised.
+    const records = reporters('2026-01', 3);
+    const fromDate = jodiDatasetContentMeta(records, hasMeasurement, NOW);
+    const fromEpochMs = jodiDatasetContentMeta(records, hasMeasurement, NOW.getTime());
+
+    assert.ok(fromDate, 'fixture must produce a datable month');
+    assert.deepEqual(fromEpochMs, fromDate, 'epoch ms and Date must agree');
+
+    // The future-month rejection has to survive the number path too, or the
+    // fix would trade a false stale for a file dated by mis-stamped rows.
+    assert.equal(
+      jodiDatasetContentMeta(reporters('2027-03', 5), hasMeasurement, NOW.getTime()),
+      null,
+    );
+    // A genuinely unusable clock still refuses to date the file.
+    assert.equal(jodiDatasetContentMeta(records, hasMeasurement, Number.NaN), null);
+    assert.equal(jodiDatasetContentMeta(records, hasMeasurement, null), null);
+  });
+
   it('one fast reporter cannot date a file everyone else stopped updating', () => {
     // JODI carries a long reporting tail — a single country sitting on a
     // current month while the leading cohort is frozen must not read as fresh.

--- a/tests/jodi-oil-seed.test.mjs
+++ b/tests/jodi-oil-seed.test.mjs
@@ -11,6 +11,8 @@ import {
   assessOilDemandChange,
   computeOilDemandChange,
   jodiSourceYears,
+  jodiCsvCandidates,
+  fetchYearCsv,
   validateCoverage,
   mergeSourceRows,
   CANONICAL_KEY,
@@ -716,5 +718,64 @@ describe('golden fixture (JODI Oil CSV)', () => {
         assert.ok(val === null || typeof val === 'number', `${prod}.${field} should be number|null, got ${typeof val}`);
       }
     }
+  });
+});
+
+describe('JODI current-year source resolution (#6799)', () => {
+  // JODI publishes every past year as `<kind>/<year>.csv`, but named the 2026
+  // files `<kind>/<kind>year<year>.csv`. The seeder asked only for the first
+  // shape, got a 404, and its `.catch(() => '')` turned that into "publish from
+  // last year's file" — so production served December 2025 oil data from
+  // January to August 2026 while reporting recordCount 50 and a fresh
+  // fetchedAt. Nothing on the seed clock could see it; only the content clock
+  // added in #6395 eventually surfaced it.
+
+  it('offers both published filename conventions, plain name first', () => {
+    assert.deepEqual(jodiCsvCandidates('primary', 2026), [
+      'https://www.jodidata.org/_resources/files/downloads/oil-data/annual-csv/primary/2026.csv',
+      'https://www.jodidata.org/_resources/files/downloads/oil-data/annual-csv/primary/primaryyear2026.csv',
+    ]);
+    assert.deepEqual(jodiCsvCandidates('secondary', 2026), [
+      'https://www.jodidata.org/_resources/files/downloads/oil-data/annual-csv/secondary/2026.csv',
+      'https://www.jodidata.org/_resources/files/downloads/oil-data/annual-csv/secondary/secondaryyear2026.csv',
+    ]);
+  });
+
+  it('falls through to the second convention when the first 404s', async () => {
+    const asked = [];
+    const fetchCsv = async (url) => {
+      asked.push(url);
+      if (url.endsWith('/2026.csv')) throw new Error('HTTP 404');
+      return 'REF_AREA,TIME_PERIOD\nDE,2026-05\n';
+    };
+    const result = await fetchYearCsv('primary', 2026, { fetchCsv, retries: 0 });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.text, 'REF_AREA,TIME_PERIOD\nDE,2026-05\n');
+    assert.match(result.url, /primaryyear2026\.csv$/);
+    assert.equal(asked.length, 2, 'must try the plain name before the prefixed one');
+  });
+
+  it('stops at the first convention that answers', async () => {
+    const asked = [];
+    const fetchCsv = async (url) => { asked.push(url); return 'rows'; };
+    const result = await fetchYearCsv('secondary', 2025, { fetchCsv, retries: 0 });
+
+    assert.equal(result.ok, true);
+    assert.match(result.url, /secondary\/2025\.csv$/);
+    assert.equal(asked.length, 1, 'a working plain name must not trigger a second request');
+  });
+
+  it('reports a total miss instead of silently returning an empty string', async () => {
+    // The silent-empty return is the actual defect: a year that cannot be
+    // fetched AT ALL must be distinguishable from a year that is legitimately
+    // empty, or the next rename degrades to stale data just as quietly.
+    const fetchCsv = async () => { throw new Error('HTTP 404'); };
+    const result = await fetchYearCsv('primary', 2026, { fetchCsv, retries: 0 });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.text, '');
+    assert.match(result.error, /404/);
+    assert.deepEqual(result.attempted, jodiCsvCandidates('primary', 2026));
   });
 });


### PR DESCRIPTION
Fixes the two JODI defects diagnosed in #6799. They surface as the same monitor status but are unrelated, and only one of them restores data.

## 1. JODI renamed the current-year download; we silently read last year's file

Every settled year is published as `annual-csv/<kind>/<year>.csv`. The year in progress is not:

| URL | status |
|---|---|
| `.../primary/2025.csv` | 200 |
| `.../primary/2026.csv` | **404** ← what the seeder asked for |
| `.../primary/primaryyear2026.csv` | **200**, 3.96 MB ← what exists |
| `.../secondary/secondaryyear2026.csv` | **200**, 9.00 MB |

`.catch(() => '')` turned the 404 into an empty string, so every run published from the 2025 file alone. `secondary/2025.csv` holds exactly `2025-01`…`2025-12`, so `extractCountryData` correctly picked December 2025 — **the month selection was never at fault.**

Production has served December oil data since January while reporting `recordCount: 50` and a fresh `fetchedAt`. Nothing on the seed clock could see it.

Verified against live upstream after the fix:

| request | resolves via | newest month |
|---|---|---|
| `primary/2026` | `primaryyear2026.csv` | **2026-05** |
| `secondary/2026` | `secondaryyear2026.csv` | **2026-05** |
| `primary/2025` | `2025.csv` — one request, unchanged | 2025-12 |

Content age: **228 days → 77 days** against a 186-day budget.

**The filename is only today's trigger.** The defect is that a year which could not be fetched *at all* was indistinguishable from a year that is legitimately empty. `fetchYearCsv` now returns `{ok, text, url, attempted, error}`, and losing **both** current-year files logs `CURRENT_YEAR_UNAVAILABLE` naming the consequence — "publishing from 2025 only, the snapshot cannot advance" — instead of a per-file warning that reads like noise.

404 is marked `nonRetryable`: trying two conventions per year would otherwise spend ~12 s of the bundle's wall-clock budget rediscovering a missing file. That also took the new tests from 6 s to 343 ms.

## 2. `jodiGas`/`lngVulnerability` could never produce a timestamp

`runSeed` invokes the hook with epoch milliseconds (`_seed-utils.mjs:2208`):

```js
const result = contentMeta(data, startMs);
```

`jodiDatasetContentMeta` required a `Date`:

```js
const nowMs = now instanceof Date && Number.isFinite(now.getTime()) ? now.getTime() : null;
if (nowMs === null) return null;
```

A number is not a `Date`, so it returned `null` unconditionally → `newestItemAt: null` → `contentStale` in `api/health.js:1774` → permanent `STALE_CONTENT`, regardless of how current the file was. Production carries `newestItemAt: None` against `recordCount: 57`.

`jodiOil` escaped it only because it computes content-meta itself with a real `Date` inside `prepareOilPublish`, bypassing the hook. These two keys share one seed-meta row (`api/health.js:970-971`), so they are one failure counted twice.

Both call sites in that module took the same `instanceof` check, so the China month assessment carried the identical latent bug; one helper now normalises for both. Still fail-closed on a genuinely unusable clock (`NaN`, `null`, a string) — a file cannot be dated without knowing *now*, and guessing would let a mis-stamped row vouch for freshness.

**Why it survived:** every existing test passes `NOW = new Date(...)`. The real call shape was never exercised.

## What this does NOT fix

`jodiGas` will still report `STALE_CONTENT` after this merges — and that is now the *correct* answer. Its fetch is healthy (`GAS_world_NewFormat.zip` → 200) but its newest month is `2026-01`:

| key | newest month | content age | budget | after this PR |
|---|---|---:|---:|---|
| `jodiOil` | 2026-05 | 77 d | 186 d | **fresh** |
| `jodiGas` | 2026-01 | 197 d | 186 d | **still stale, by 11 d** |

Repairing the measurement makes that alarm truthful rather than silent. Whether 186 days matches JODI gas's real cadence is item 3 of #6799 and deliberately not decided here.

## Testing

`test:data` — **24,433 pass, 0 fail**. `docs:check`, `sources:check`, `typecheck:api`, biome all clean.

New coverage, each written red first:

- `jodiCsvCandidates` returns both conventions, plain name first.
- `fetchYearCsv` falls through to the prefixed name on 404, **stops at the first name that answers** (a settled year must not cost two requests), and reports a total miss as `ok: false` with the attempted URLs rather than an empty string.
- `jodiDatasetContentMeta` agrees between `Date` and epoch ms, keeps rejecting future months on the number path, and still refuses `NaN`/`null`.

The end-to-end proof is in the commits: calling the real exported `fetchYearCsv` against live upstream resolves `primaryyear2026.csv` with `newest=2026-05`, and `gasContentMeta` now returns identical output for both clock shapes.

## Post-Deploy Monitoring & Validation

**Neither fix takes effect on the next tick.** `_bundle-runner.mjs:528` skips a member while `elapsed < intervalMs * 0.8`; JODI's interval is 35 days and the last run was 2026-08-11, so the next eligible run is **2026-09-09 07:30 UTC**. The Railway cron itself is healthy (`30 7 * * *`, `nextCronRunAt: 2026-08-17T07:30:00Z`) — JODI is gated, not stalled, so a manual service run prints `Skipped, last seeded 7776min ago` and exits.

Verifying before September requires deliberately clearing `seed-meta:energy:jodi-oil` to bypass the gate. That is justified here only because the 2026 files are already proven to exist and carry May data — it is a real intervention, not a "trigger", and should be a conscious decision.

**Watch after the next JODI run (owner: me):**

- `/api/health?compact=1` — `jodiOil` should leave `problems` entirely. `jodiGas` and `lngVulnerability` should remain but with a real `contentAgeMin` (~197 d) instead of `null`; a null there means the contentMeta fix did not take.
- Seeder logs — `CURRENT_YEAR_UNAVAILABLE` must NOT appear. If it does, JODI renamed the download again and the candidate list needs another entry.
- `seed-meta:energy:jodi-oil` — `newestItemAt` should advance to a 2026 month-end.

**Failure signal / rollback trigger:** `jodiOil` dropping to `EMPTY`, or `recordCount` falling below the 40-country floor after the merge — either would mean the 2026 files parse differently than the 2025 ones. Rollback is a revert; no data migration to unwind.
