### PR TITLE
fix(energy): give JODI gas its own 230-day content budget

### DIFF
--- a/scripts/seed-jodi-gas.mjs
+++ b/scripts/seed-jodi-gas.mjs
@@ -12,7 +12,7 @@ import {
   readExistingSeedMeta,
 } from './_seed-utils.mjs';
 import {
-  MAX_JODI_CONTENT_AGE_MIN,
+  MAX_JODI_GAS_CONTENT_AGE_MIN,
   assessChinaJodiCoverage,
   buildChinaRowDiagnostic,
   hasFiniteMeasurementAtPaths,
@@ -367,7 +367,7 @@ if (isMain) {
       return { freshnessMetaPatch: { chinaRow: await buildGasChinaRowDiagnostic(records) } };
     },
     contentMeta: gasContentMeta,
-    maxContentAgeMin: MAX_JODI_CONTENT_AGE_MIN,
+    maxContentAgeMin: MAX_JODI_GAS_CONTENT_AGE_MIN,
 
     declareRecords,
     schemaVersion: 1,

--- a/scripts/shared/jodi-content-age.mjs
+++ b/scripts/shared/jodi-content-age.mjs
@@ -36,6 +36,24 @@ export const MAX_JODI_CONTENT_AGE_MONTHS = 6;
 export const MAX_JODI_CONTENT_AGE_MIN = MAX_JODI_CONTENT_AGE_MONTHS * 31 * 24 * 60;
 
 /**
+ * Gas content budget, in minutes. Separate from the oil budget above because
+ * the two files do not lag by the same amount.
+ *
+ * Measured 2026-08-16: the oil files had advanced to 2026-05 (77 days) while
+ * the gas world file's newest month was 2026-01 (197 days). Holding gas to the
+ * shared six-month figure reported a file that is behaving normally for its own
+ * publisher as STALE_CONTENT by 11 days, which is a threshold sized to the
+ * wrong dataset rather than a real staleness (#6799).
+ *
+ * 230 days rather than a figure closer to the observed 197: the gas age climbs
+ * daily until JODI publishes the next month, so a threshold set near the
+ * observed peak clears today and re-alarms on the first missed publish. 230
+ * absorbs one skipped month while still surfacing a genuine stall — the file
+ * would have to fall a further month behind its own worst observed lag.
+ */
+export const MAX_JODI_GAS_CONTENT_AGE_MIN = 230 * 24 * 60;
+
+/**
  * How many countries must report a month before it can date the whole file.
  *
  * A JODI file carries a long reporting tail — one country can sit years behind


### PR DESCRIPTION
Item 3 of #6799, split out of #6800 so that PR stayed mergeable.

#6800 repaired the JODI gas content clock, which had been returning `null` and so reporting `STALE_CONTENT` for the wrong reason. With the measurement working, the true state shows: gas is **genuinely 197 days behind** against a budget of 186, and the budget is the part that is wrong.

## Oil and gas do not lag by the same amount

Measured 2026-08-16 against the live files:

| key | newest month | content age | shared 186 d budget |
|---|---|---:|---|
| `jodiOil` | 2026-05 | 77 d | fresh |
| `jodiGas` | 2026-01 | 197 d | **stale by 11 d** |

`MAX_JODI_CONTENT_AGE_MIN` was one constant for both files, so the gas world file — publishing at its own ordinary cadence — was measured against a threshold sized for oil.

## Why a separate constant, and why 230

**Split rather than widen the shared one.** Oil sits at 77 days and gains nothing from a looser bound, and raising the shared figure would cost real detection on the file that just spent five months frozen reading last year's data (#6800). The oil budget stays at 186.

**230 rather than something near the observed 197.** The gas age climbs every day until JODI publishes the next month, so a threshold set at the observed peak clears today and re-alarms on the first missed publish:

| budget | verdict today | headroom |
|---|---|---:|
| 186 d (shared, before) | STALE | −11 d |
| 200 d | fresh | **+3 d** |
| 230 d (this PR) | fresh | **+33 d** |

200 was the initial instruction; the arithmetic above is why it moved to 230. 33 days absorbs one skipped publish while still surfacing a genuine stall — the file would have to fall a further month behind its own worst observed lag before this clears it.

This is a deliberate threshold choice recorded as such, not a measurement.

## Testing

`tests/jodi-gas-seed.test.mjs`, `tests/china-energy-coverage.test.mjs`, `tests/jodi-oil-seed.test.mjs` — 135 pass, 0 fail. Existing assertions pin the oil payload against `MAX_JODI_CONTENT_AGE_MIN`, so the split is covered in both directions: oil still asserts the 186-day constant, gas now carries its own.

## Post-Deploy Monitoring & Validation

`seed-bundle-energy-sources` gates JODI members on a 35-day interval (effective gate 28 days), so this takes effect on the same run as #6800's fix — next eligible **2026-09-09 07:30 UTC**, or sooner if `seed-meta:energy:jodi-gas` is deliberately cleared.

**Watch:** after that run, `/api/health?compact=1` should no longer list `jodiGas` or `lngVulnerability` in `problems`. If either still appears, read `contentAgeMin` — a real number near 197 means the budget needs revisiting, whereas `null` would mean #6800's clock fix did not take.

**Failure signal:** `jodiGas` reporting `STALE_CONTENT` with `contentAgeMin > 331200` (230 d) is a genuine publisher stall and should be investigated upstream, not widened again.
