### PR TITLE
fix(seeders): fit the SIPRI fan-out in its deadline, and report a bundle tick that published nothing

### DIFF
--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -597,13 +597,24 @@ export async function runBundle(label, sections, opts = {}) {
   // section runs on a later tick, so this state repeating is a stalled
   // service — the shape that made #6556 invisible for six hours. Report it as
   // a failure; `ran:0 deferred:0` (everything fresh) stays a healthy no-op.
-  // `gracefulFailed === 0` is load-bearing: a tick whose only admitted section
-  // hit a transient upstream blip (child exit 75, last-good TTL extended, no
-  // data lost) already has an exit-0 exemption precisely so one flaky source
-  // does not fire "Deploy Crashed!". Without this clause a benign 429 that
-  // happened to also push a sibling past the budget would page — alert fatigue
-  // on the exact alarm this change exists to make trustworthy.
-  const starvedTick = ran === 0 && deferred > 0 && gracefulFailed === 0;
+  // This used to carry `&& gracefulFailed === 0`, exempting a tick whose only
+  // admitted section hit a transient blip (child exit 75, last-good TTL
+  // extended, no data lost) so one flaky source would not fire "Deploy
+  // Crashed!". That premise holds for the FAILING section and not for the ones
+  // it shed — those published nothing and extended no TTL.
+  //
+  // seed-bundle-static-ref is the counter-example that removed it:
+  // Arms-Suppliers burns its full 390s fetch deadline (SIPRI answers in ~10.6s
+  // and it issues ~200 requests at concurrency 4) and exits 75, leaving 179s of
+  // a 570s budget. All four remaining due sections need >=190s, so every one
+  // defers and `ran:0`. gracefulFailed was 1, so this stayed false and the
+  // bundle reported success for weeks while mineralProduction and
+  // submarineCables had no key in Redis at all (#6799).
+  //
+  // The exemption below still covers the case it was written for — `ran > 0`
+  // with a graceful skip, where real work published and one source blipped. A
+  // tick that published NOTHING has no successful work to vouch for it.
+  const starvedTick = ran === 0 && deferred > 0;
   if (starvedTick) {
     console.error(
       `[Bundle:${label}] ran:0 while ${deferred} due section(s) were deferred — this tick published nothing and shed work. `

--- a/scripts/_defense-industrial-source.mjs
+++ b/scripts/_defense-industrial-source.mjs
@@ -188,7 +188,22 @@ function sipriFilters(importerId, startYear, endYear) {
 export async function fetchSipriSupplierDependencies({
   fetchFn = fetch,
   baseUrl = process.env.SIPRI_ARMS_API_BASE_URL || DEFAULT_SIPRI_BASE_URL,
-  concurrency = 4,
+  // 8, not 4, and the ceiling below is the reason it can go no higher.
+  //
+  // This issues one POST per mapped importer — ~200 of them (the catalog is 385
+  // entries, ~185 of which are non-state actors that map to no ISO2). SIPRI
+  // answers in ~10.6s regardless of payload size; even `getMaxYear`, which
+  // returns four bytes, takes ~6.8s. At concurrency 4 that is 50 requests per
+  // worker, ~547s, against a 390s fetchPhaseTimeoutMs — the fetch phase could
+  // never finish, so it burned the whole deadline and exited 75 on every run.
+  //
+  // That is also why seed-bundle-static-ref published nothing: a 390s failure
+  // inside a 570s bundle budget left 179s, and every remaining due section
+  // needed >=190s. mineralProduction and submarineCables had no key in Redis at
+  // all as a result (#6799).
+  //
+  // At 8 the same work is ~277s, inside the deadline with ~110s of margin.
+  concurrency = 8,
   delayMs = 150,
   logger = console,
 } = {}) {

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -812,30 +812,42 @@ test('a tick that runs nothing while deferring due work exits non-zero', async (
   }
 });
 
-test('a transient graceful skip that also defers work stays exit 0', async () => {
-  // The narrowing on starvedTick. A child exit 75 means the last-good TTL was
-  // extended and no data was lost — a rate-limited upstream, not a stall. If
-  // that blip also pushed a sibling past the budget, `ran:0 deferred:1` is
-  // technically true but firing "Deploy Crashed!" for it is exactly the alert
-  // fatigue the graceful exemption exists to prevent. The deferred section
-  // retries on the next tick; real staleness is caught by the seed-meta
-  // freshness monitor, not by this exit code.
+test('a graceful skip that publishes nothing and defers work exits non-zero', async () => {
+  // Was: 'stays exit 0'. The graceful exemption used to cover this on the
+  // premise that a child exit 75 extended the last-good TTL and lost no data.
+  // That is true of the FAILING section and false of the ones it shed.
+  //
+  // seed-bundle-static-ref proved it: Arms-Suppliers burns its whole 390s fetch
+  // deadline (SIPRI answers in ~10.6s and it makes ~200 requests at concurrency
+  // 4) and exits 75, leaving 179s of a 570s budget. Every remaining due section
+  // needs >=190s, so all four defer and `ran:0`. Because gracefulFailed was 1,
+  // starvedTick stayed false and the bundle reported success — while
+  // mineralProduction and submarineCables had NO key in Redis at all. The one
+  // scenario the guard was written for was the one it could not see (#6799).
+  //
+  // The exemption now applies where its premise holds: `ran > 0` — some work
+  // published and one source blipped. A tick that published NOTHING has no
+  // successful work to vouch for it, whatever the reason.
   const cleanupGrace = writeFixture(
     '_bundle-fixture-slow-graceful.mjs',
     `await new Promise((r) => setTimeout(r, 16000));\nconsole.log('=== Failed gracefully ===');\nprocess.exit(${GRACEFUL_FETCH_FAILURE_EXIT_CODE});\n`,
   );
   const cleanupLate = writeFixture('_bundle-fixture-late.mjs', `console.log('late-ran');\n`);
   try {
-    const { code, stdout } = await runBundleWith(
+    const { code, stdout, stderr } = await runBundleWith(
       [
         { label: 'GRACE', script: '_bundle-fixture-slow-graceful.mjs', intervalMs: 1, timeoutMs: 30_000 },
         { label: 'LATE', script: '_bundle-fixture-late.mjs', intervalMs: 1, timeoutMs: 35_000 },
       ],
       { maxBundleMs: 60_000 },
     );
-    assert.equal(code, 0, 'a transient upstream blip must not page, even when it also defers a sibling');
+    assert.equal(code, 1, 'a tick that published nothing and shed due work must not report success');
     assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:1 failed:0 graceful:1/);
-    assert.match(stdout, /no data lost, exiting 0/);
+    assert.match(
+      stderr,
+      /\[Bundle:test\] ran:0 while 1 due section\(s\) were deferred/,
+      `expected the starvation explanation; stderr:\n${stderr}`,
+    );
     assert.doesNotMatch(stdout, /late-ran/);
   } finally {
     cleanupGrace();

--- a/tests/seed-defense-industrial.test.mjs
+++ b/tests/seed-defense-industrial.test.mjs
@@ -152,3 +152,63 @@ describe('defense-industrial deployment wiring', () => {
     assert.match(supplierSeeder, /maxContentAgeMin:\s*800 \* 24 \* 60/);
   });
 });
+
+describe('SIPRI importer fan-out fits its fetch deadline (#6799)', () => {
+  // The seeder POSTs once per mapped importer. SIPRI answers in ~10.6s whatever
+  // the payload, so the wall time is (importers / concurrency) * latency and
+  // has to land inside fetchPhaseTimeoutMs. At concurrency 4 it did not: ~200
+  // importers took ~547s against a 390s deadline, so the phase burned the whole
+  // deadline and exited 75 every run — which then starved every later section
+  // of seed-bundle-static-ref out of its 570s budget.
+
+  const OBSERVED_SIPRI_LATENCY_S = 10.6; // measured 2026-08-16 against live SIPRI
+  const MAPPED_IMPORTERS = 200;          // 385 catalog entries, ~185 unmapped non-state actors
+  const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+  it('the configured concurrency leaves the fetch phase inside its deadline', () => {
+    const seeder = readFileSync(join(root, 'scripts/seed-defense-industrial-suppliers.mjs'), 'utf8');
+    const deadline = /fetchPhaseTimeoutMs:\s*([\d.]+)\s*\*\s*60\s*\*\s*1000/.exec(seeder);
+    assert.ok(deadline, 'the supplier seeder must declare fetchPhaseTimeoutMs');
+    const deadlineS = Number(deadline[1]) * 60;
+
+    const source = readFileSync(join(root, 'scripts/_defense-industrial-source.mjs'), 'utf8');
+    const declared = /^\s*concurrency = (\d+),$/m.exec(source);
+    assert.ok(declared, 'the SIPRI fan-out must declare a default concurrency');
+    const concurrency = Number(declared[1]);
+
+    const worstCaseS = (MAPPED_IMPORTERS / concurrency) * OBSERVED_SIPRI_LATENCY_S;
+    assert.ok(
+      worstCaseS < deadlineS,
+      `concurrency ${concurrency} needs ${Math.round(worstCaseS)}s for ${MAPPED_IMPORTERS} importers `
+      + `at ${OBSERVED_SIPRI_LATENCY_S}s each, but fetchPhaseTimeoutMs is ${deadlineS}s. `
+      + 'The phase cannot finish, so it burns the full deadline and exits 75 every run.',
+    );
+  });
+
+  it('actually runs the requests in parallel up to that concurrency', async () => {
+    // The arithmetic above is worthless if the pool silently serialises.
+    let inFlight = 0;
+    let peak = 0;
+    // Real ISO2-mappable names, or the catalog fails the >=150 importer floor
+    // before any request is made and this measures nothing.
+    // Real ISO2-mappable names, and the EntityId keyed to the NAME rather than
+    // the index: a repeated name carrying two ids trips the mapping-collision
+    // guard and the run throws before issuing a single request.
+    const names = ['Ukraine', 'Poland', 'Japan', 'Egypt', 'India', 'Brazil', 'Norway', 'Chile'];
+    const catalog = Array.from({ length: 160 }, (_, i) => ({
+      EntityId: 1000 + (i % names.length),
+      Name: names[i % names.length],
+    }));
+    const fetchFn = async (url) => {
+      if (String(url).includes('getMaxYear')) return new Response('2025');
+      if (String(url).includes('getAllCountriesTrimmed')) return new Response(JSON.stringify(catalog));
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight -= 1;
+      return new Response(JSON.stringify({ bytes: '' }));
+    };
+    await fetchSipriSupplierDependencies({ fetchFn, delayMs: 0 }).catch(() => {});
+    assert.ok(peak > 1, `expected parallel requests, saw peak in-flight ${peak}`);
+  });
+});


### PR DESCRIPTION
Items 1 and 3 of the `seed-bundle-static-ref` diagnosis in #6799. Item 2 (the budget itself) is filed separately as #6806 — it needs its own review.

`mineralProduction` and `submarineCables` have **no key in Redis at all** — not stale, never published. Two defects kept them out, and the second is why nobody noticed.

## 1. The SIPRI fan-out could not finish, by arithmetic

`seed-defense-industrial-suppliers` POSTs once per mapped importer — ~200 of them (385 catalog entries, ~185 non-state actors that map to no ISO2). Measured against live SIPRI on 2026-08-16:

| call | time | payload |
|---|---:|---|
| `trades/getMaxYear` | 6.75 s | **4 bytes** |
| `countries/getAllCountriesTrimmed` | 6.82 s | 30 KB |
| `trades/import-export-csv` (one importer) | **10.65 s** | 840 bytes |

~7 s of server-side latency regardless of payload. At `concurrency = 4` that is 50 requests per worker:

```
concurrency 4:  50 × 10.65s ≈ 547s   vs 390s fetchPhaseTimeoutMs  → OVERRUNS by 157s
concurrency 8:  25 × 10.65s ≈ 277s   vs 390s                      → fits, ~110s margin
```

It was never going to complete. It burned the full deadline and exited 75 on **every** run. The pool already capped at 8, so this stays inside the designed envelope.

## 2. The starvation guard was disabled by the thing that caused the starvation

That 390 s failure sits inside a 570 s bundle budget, leaving 179 s while every remaining due section needs ≥190 s. All four defer, `ran:0`. From the production log:

```
[Arms-Suppliers] Failed after 390.4s: graceful fetch failure (exit 75)
  [Military-Bases]     Deferred, needs 550s but only 179s left
  [Submarine-Cables]   Deferred, needs 310s but only 179s left
  [Mineral-Production] Deferred, needs 190s but only 179s left
  [Defense-Patents]    Deferred, needs 190s but only 179s left
[Bundle:static-ref] Finished, ran:0 skipped:2 deferred:4 failed:0 graceful:1
[Bundle:static-ref] 1 graceful fetch skip(s), no hard failures — exiting 0 (not a crash)
```

The guard read:

```js
const starvedTick = ran === 0 && deferred > 0 && gracefulFailed === 0;
```

`gracefulFailed` was 1, so it stayed false and the bundle reported success. Its premise — exit 75 extended the last-good TTL, no data lost — is true of the **failing** section and false of the four it **shed**: those published nothing and extended no TTL. The one scenario the guard was written for was the one it could not see.

The exemption now applies where the premise holds, `ran > 0`: real work published and one source blipped. A tick that published NOTHING has no successful work to vouch for it, whatever the reason.

**An existing test pinned the old behaviour as correct** — `'a transient graceful skip that also defers work stays exit 0'`. It is inverted here, with the production evidence in the comment, because that exact shape hid a total outage for weeks.

## What this does and does not fix

`mineralProduction` should publish on the next `static-ref` tick. **`submarineCables` will not** — at ~277 s for Arms-Suppliers there are 293 s left and it needs 310 s. That is #6806: the budget is 3.2× oversubscribed and `Military-Bases` alone needs 550 s of 570 s, clearing the config-error guard by 20 s while being a whole-budget section in practice.

## Testing

`test:data` — **24,435 pass, 0 fail**. biome clean.

Two new guards:

- **The deadline arithmetic is asserted**, derived from the declared `concurrency` and the declared `fetchPhaseTimeoutMs` rather than restated. Mutation-tested — reverting to 4 fails with the numbers: `concurrency 4 needs 530s for 200 importers at 10.6s each, but fetchPhaseTimeoutMs is 390s`.
- **The pool really parallelises.** Without this the arithmetic above would happily describe a serial loop. (Writing it surfaced a fixture trap worth noting: repeating a country name with distinct `EntityId`s trips the mapping-collision guard, so the run throws before issuing a single request and the test measures nothing — the fixture keys the id to the name.)

## Post-Deploy Monitoring & Validation

**Watch after the next `seed-bundle-static-ref` tick (cron `0 3 * * *`, owner: me):**

- Railway logs — `[Arms-Suppliers]` should complete in ~280 s instead of `Failed after 390.4s`. If it still hits the deadline, SIPRI latency has moved and the arithmetic needs re-measuring, not the concurrency raised again.
- `[Bundle:static-ref] Finished ... ran:N` should show `ran >= 1`. A `ran:0` tick now exits non-zero, so a recurrence paints CRASHED instead of green.
- `/api/health?compact=1` — `mineralProduction` should leave `problems`. `submarineCables` is expected to remain until #6806.
- Its ack in `scripts/seed-freshness-baseline.json` (#6439, expired 2026-08-15) can be removed once it publishes.

**Failure signal / rollback trigger:** SIPRI 429s appearing in `SIPRI importer requests failed (...)` would mean concurrency 8 is over their rate limit — revert to 4 and pursue #6806 instead, since at 4 the phase cannot fit regardless. Rollback is a revert; no data migration.
