### PR TITLE
fix(health): rank unknown status as degraded instead of OK (#6780)

### DIFF
--- a/src/services/data-freshness.ts
+++ b/src/services/data-freshness.ts
@@ -479,7 +479,20 @@ class DataFreshnessTracker {
   }
 
   private healthStatusIsError(status: string): boolean {
-    return status === 'SEED_ERROR' || status === 'REDIS_DOWN' || status === 'REDIS_PARTIAL';
+    return (
+      status === 'SEED_ERROR' ||
+      status === 'REDIS_DOWN' ||
+      status === 'REDIS_PARTIAL' ||
+      (status !== 'OK' &&
+        status !== 'NOT_CONFIGURED' &&
+        status !== 'OK_CASCADE' &&
+        status !== 'EMPTY' &&
+        status !== 'EMPTY_DATA' &&
+        status !== 'EMPTY_ON_DEMAND' &&
+        status !== 'STALE_SEED' &&
+        status !== 'STALE_CONTENT' &&
+        status !== 'COVERAGE_PARTIAL')
+    );
   }
 
   private healthStatusHasNoData(status: string): boolean {

--- a/src/services/health-freshness.ts
+++ b/src/services/health-freshness.ts
@@ -70,7 +70,7 @@ function statusRank(status: string): number {
     case 'NOT_CONFIGURED':
       return 0;
     default:
-      return 0;
+      return 5;
   }
 }
 

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -184,6 +184,37 @@ describe('health freshness ingestion', () => {
     assert.equal(bis?.lastError, 'REDIS_DOWN');
   });
 
+  it('ranks unknown status as degraded/error rather than OK', async () => {
+    const checkedAtMs = Date.now();
+    const applied = await refreshDataFreshnessFromHealth({
+      endpoint: '/api/health',
+      urlResolver: (path) => path,
+      fetchFn: async () => jsonResponse({
+        checkedAt: new Date(checkedAtMs).toISOString(),
+        checks: {
+          bisPolicy: {
+            status: 'OK',
+            records: 12,
+            seedAgeMin: 0,
+            maxStaleMin: 360,
+          },
+          bisDsr: {
+            status: 'UNKNOWN_DEGRADED_STATE',
+            records: 0,
+            seedAgeMin: 5,
+            maxStaleMin: 360,
+          },
+        },
+      }),
+    });
+
+    assert.equal(applied, 1);
+    const bis = dataFreshness.getSource('bis');
+    assert.equal(bis?.healthStatus, 'UNKNOWN_DEGRADED_STATE');
+    assert.equal(bis?.status, 'error');
+    assert.equal(bis?.lastError, 'UNKNOWN_DEGRADED_STATE');
+  });
+
   it('marks mapped sources unhealthy when /api/health reports top-level redis outage without checks', async () => {
     const mappedSources = new Set(Object.values(HEALTH_CHECK_SOURCE_MAP).flat());
     const checkedAtMs = Date.now();


### PR DESCRIPTION
Fixes #6780

### Problem
In `src/services/health-freshness.ts`, `statusRank()` returned `0` (the same rank as `OK` and `NOT_CONFIGURED`) for any unhandled or unrecognized status string in the `default` case. When an upstream check emitted an unhandled error/degraded state, it lost against `OK` when picking the worst health status across mapped checks, masking outages.

### Solution
- Updated `statusRank()` default branch to return `5` (error rank) so unexpected status strings outrank `OK`.
- Updated `healthStatusIsError()` in `src/services/data-freshness.ts` to flag unknown non-OK statuses as errors.
- Added unit test in `tests/data-freshness-health.test.mts` asserting that unhandled status codes rank as errors over `OK`.