### PR TITLE
fix(session): report mint_failed only for a mint that was actually attempted

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1876,7 +1876,16 @@ export class App {
     if (!isDesktopRuntime()) {
       window.addEventListener(WM_SESSION_DEGRADED_EVENT, this.handleWmSessionDegraded);
       installWmSessionFetchInterceptor();
-      await ensureWmSession();
+      // Guarded like every other call site (the interceptor's own, and both
+      // periodic-refresh handlers). ensureWmSession() genuinely rejects on the
+      // old WebView / Smart-TV engines this module targets — `new
+      // AbortController()` and the timeout setTimeout sit outside mintSession's
+      // try — and init() has no try/catch, so a bare await would abort boot
+      // here: no bootstrap hydration, no auth, no UI. main.ts catches that with
+      // `.catch(console.error)`, so it would not even reach Sentry. Session
+      // establishment is best-effort at this point; the refresh-on-401 layer is
+      // the safety net.
+      await ensureWmSession().catch(() => false);
       markLcpDebug('wm:boot:session-ready');
     }
 

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -113,12 +113,23 @@ let sentryEnqueue: typeof enqueueSentryCall = enqueueSentryCall;
 //    siblings. Cleared only by expiry, by its own route succeeding, by the
 //    global cooldown, or by a key-bound session replacing the identity.
 const routeStrikes = new Map<string, number>();
-// 2. Corroboration evidence — bounded route TAG -> when it failed. Keyed by the
-//    TAG so two ids of one dynamic endpoint cannot masquerade as two
-//    independent routes and fake a quorum. Any successful credentialed response
-//    clears it: a 200 proves the cookie is being delivered, which is precisely
-//    the counter-evidence the #5674 diagnosis rested on.
-const recentRouteFailures = new Map<string, number>();
+// 2. Corroboration evidence — bounded route TAG -> when it failed and, when the
+//    failure was a mint rather than a route denial, why. Keyed by the TAG so two
+//    ids of one dynamic endpoint cannot masquerade as two independent routes and
+//    fake a quorum. Any successful credentialed response clears it: a 200 proves
+//    the cookie is being delivered, which is precisely the counter-evidence the
+//    #5674 diagnosis rested on.
+//
+//    The cause rides the evidence because the verdict that TIPS a quorum is
+//    usually not the one carrying the diagnosis. In the modal WORLDMONITOR-WG
+//    burst the leader's mint fails (cause `network`, one strike, below quorum)
+//    and a follower's replay tips it — with a causeless retry_401, because the
+//    follower replays with no cookie, none ever having been minted. Reading the
+//    tipping verdict alone would tag an all-mints-failed episode `none` and send
+//    triage hunting a cookie problem on a bystander panel. Bounded by
+//    SESSION_DEAD_CORROBORATION_MS and voided by any success, so this is
+//    episode-scoped evidence, not the ambient last-value state #6804 removed.
+const recentRouteFailures = new Map<string, { at: number; cause: MintFailureCause | null }>();
 
 // Sentry tags must stay low-cardinality. Interceptor traffic only ever targets
 // our own /api/ surface, but dynamic segments (`/api/v2/shipping/webhooks/
@@ -211,7 +222,7 @@ function isRouteStruck(rawPath: string): boolean {
  * the returned count only sees failures from the last
  * SESSION_DEAD_CORROBORATION_MS.
  */
-function recordRouteStrike(rawPath: string): number {
+function recordRouteStrike(rawPath: string, cause: MintFailureCause | null): number {
   const now = Date.now();
   for (const [struck, until] of routeStrikes) {
     if (until <= now) routeStrikes.delete(struck);
@@ -219,11 +230,29 @@ function recordRouteStrike(rawPath: string): number {
   routeStrikes.set(rawPath, now + SESSION_DEAD_ROUTE_STRIKE_TTL_MS);
 
   const corroborationFloor = now - SESSION_DEAD_CORROBORATION_MS;
-  for (const [tag, at] of recentRouteFailures) {
-    if (at <= corroborationFloor) recentRouteFailures.delete(tag);
+  for (const [tag, seen] of recentRouteFailures) {
+    if (seen.at <= corroborationFloor) recentRouteFailures.delete(tag);
   }
-  recentRouteFailures.set(toRouteTag(rawPath), now);
+  recentRouteFailures.set(toRouteTag(rawPath), { at: now, cause });
   return recentRouteFailures.size;
+}
+
+/**
+ * The mint cause to report for an episode the quorum just tipped.
+ *
+ * The tipping verdict frequently has no cause of its own — a retry_401 never
+ * does — while the evidence that put the quorum within one strike often does.
+ * Prefer the tipping verdict's own cause, then the most recent mint cause still
+ * inside the corroboration window, so `none` keeps meaning "no mint failed in
+ * this episode" rather than "the last verdict happened not to be a mint".
+ */
+function episodeMintCause(tippingCause: MintFailureCause | null): MintFailureCause | null {
+  if (tippingCause) return tippingCause;
+  let latest: { at: number; cause: MintFailureCause | null } | null = null;
+  for (const seen of recentRouteFailures.values()) {
+    if (seen.cause && (latest === null || seen.at > latest.at)) latest = seen;
+  }
+  return latest?.cause ?? null;
 }
 
 /**
@@ -415,8 +444,8 @@ function noteRecoveryFailure(verdict: RecoveryVerdict, rawPath: string): void {
   // retry, and a single client-side blip is not evidence that the session is
   // unusable — production shows the server minting normally for everyone else
   // at that moment (WORLDMONITOR-WG).
-  if (recordRouteStrike(rawPath) >= SESSION_DEAD_ROUTE_QUORUM) {
-    markWmSessionDead(verdict.reason, rawPath, cause);
+  if (recordRouteStrike(rawPath, cause) >= SESSION_DEAD_ROUTE_QUORUM) {
+    markWmSessionDead(verdict.reason, rawPath, episodeMintCause(cause));
     return;
   }
   // Below quorum, a transport mint failure gets no captureMessage. WG is the

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -629,6 +629,21 @@ const SESSION_ATTEMPT_OK: SessionAttempt = { ok: true };
 // mintCauseIsServerVerdict), so it needs corroboration like a transport blip.
 const SESSION_ATTEMPT_THREW: SessionAttempt = { ok: false, kind: 'mint_failed', cause: 'unknown' };
 
+/**
+ * `unknown` is the one cause that says "we do not know what happened", so
+ * discarding the exception on the way to it defeats the tag this module exists
+ * to make legible. Send the throw itself; the verdict is unchanged.
+ *
+ * This is a live path, not a defensive floor: `new AbortController()` and the
+ * timeout `setTimeout` sit OUTSIDE mintSession's try (see the AbortSignal.timeout
+ * note there), and markWmSessionDead's `new CustomEvent(...)` is unguarded — all
+ * three on exactly the old WebView / Smart-TV engines that comment names.
+ */
+function reportUnknownMintThrow(error: unknown): SessionAttempt {
+  try { sentryEnqueue((s) => s.captureException(error)); } catch { /* best-effort telemetry */ }
+  return SESSION_ATTEMPT_THREW;
+}
+
 async function attemptWmSession(): Promise<SessionAttempt> {
   if (isWmSessionDead()) return { ok: false, kind: 'suppressed' };
   if (isFresh(cached)) return SESSION_ATTEMPT_OK;
@@ -1032,7 +1047,7 @@ export function installWmSessionFetchInterceptor(): void {
     // for that result instead of each multiplying the failed retry.
     if (!recoveryInFlight) {
       const recovery = (async (): Promise<Response | null> => {
-        let attempt = await attemptWmSession().catch(() => SESSION_ATTEMPT_THREW);
+        let attempt = await attemptWmSession().catch(reportUnknownMintThrow);
         // A transport failure is the one cause worth immediately re-attempting:
         // the server never answered, so a second try costs one request and may
         // simply succeed. Bounded to a single retry, and only for a transport
@@ -1041,7 +1056,7 @@ export function installWmSessionFetchInterceptor(): void {
         // is not retried either: nothing was asked, so there is nothing to ask
         // again until the cooldown lapses.
         if (!attempt.ok && attempt.kind === 'mint_failed' && mintCauseIsTransport(attempt.cause)) {
-          attempt = await attemptWmSession().catch(() => SESSION_ATTEMPT_THREW);
+          attempt = await attemptWmSession().catch(reportUnknownMintThrow);
         }
         if (!attempt.ok) {
           // Only an attempt that actually reached the mint may be reported as

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -92,7 +92,7 @@ interface StoredSession {
 }
 
 let cached: StoredSession | null = null;
-let inflight: Promise<boolean> | null = null;
+let inflight: Promise<SessionAttempt> | null = null;
 let recoveryInFlight: Promise<Response | null> | null = null;
 let sessionGeneration = 0;
 let sessionIdentityGeneration = 0;
@@ -320,13 +320,24 @@ function markWmSessionDead(
   // could not be told apart from a server outage, a rate-limit, a CORS block or
   // a dropped connection — and each of those needs a different fix. This is the
   // same aggregability argument that added the `route` tag in #5674.
-  const tags: Record<string, string> = { kind: 'wm_session_dead', reason, route: routeTag };
-  if (cause) tags.mint_cause = cause;
+  //
+  // Emitted UNCONDITIONALLY (#6804). Writing the tag only when a cause existed
+  // collapsed two different states into the same blank Sentry bucket: "this
+  // episode has no mint cause" (a retry_401 denial, or a mint that succeeded and
+  // then lost its cookie) and "the tag was dropped". `none` says the first out
+  // loud, so a blank now means only one thing — a client too old to carry it.
+  const mintCause: MintCauseTag = cause ?? 'none';
+  const tags: Record<string, string> = {
+    kind: 'wm_session_dead',
+    reason,
+    route: routeTag,
+    mint_cause: mintCause,
+  };
   addSessionBreadcrumb('wm-session recovery failed', {
     route: routeTag,
     blocked: blockedTag,
     reason,
-    ...(cause ? { mint_cause: cause } : {}),
+    mint_cause: mintCause,
   });
   try {
     sentryEnqueue((s) => s.captureMessage(
@@ -364,6 +375,15 @@ function reportRouteRecoveryFailure(rawPath: string): void {
 }
 
 /**
+ * What the recovery path observed. `mint_failed` carries its cause in the same
+ * value, so the reporter cannot be handed a category without the evidence for
+ * it — the shape that produced causeless `mint_failed` events (#6804).
+ */
+type RecoveryVerdict =
+  | { reason: 'retry_401' }
+  | { reason: 'mint_failed'; cause: MintFailureCause };
+
+/**
  * Decide how far a failed recovery should reach.
  *
  * `mint_failed` is session-wide only when the SERVER produced the failure —
@@ -380,16 +400,13 @@ function reportRouteRecoveryFailure(rawPath: string): void {
  * `retry_401` only implicates the one route that was replayed, so it needs
  * SESSION_DEAD_ROUTE_QUORUM distinct routes before it may black out the tab.
  */
-function noteRecoveryFailure(
-  reason: WmSessionDeadReason,
-  rawPath: string,
-  cause: MintFailureCause | null = null,
-): void {
+function noteRecoveryFailure(verdict: RecoveryVerdict, rawPath: string): void {
+  const cause = verdict.reason === 'mint_failed' ? verdict.cause : null;
   // A mint the SERVER refused (or answered unusably) is session-wide by
   // construction, exactly as before: no route can succeed against an endpoint
   // that will not issue a token, so this still skips the quorum.
-  if (reason === 'mint_failed' && !mintCauseIsTransport(cause)) {
-    markWmSessionDead(reason, rawPath, cause);
+  if (mintCauseIsServerVerdict(cause)) {
+    markWmSessionDead(verdict.reason, rawPath, cause);
     return;
   }
   // Everything else needs corroboration from a second distinct route before it
@@ -399,14 +416,14 @@ function noteRecoveryFailure(
   // unusable — production shows the server minting normally for everyone else
   // at that moment (WORLDMONITOR-WG).
   if (recordRouteStrike(rawPath) >= SESSION_DEAD_ROUTE_QUORUM) {
-    markWmSessionDead(reason, rawPath, cause);
+    markWmSessionDead(verdict.reason, rawPath, cause);
     return;
   }
   // Below quorum, a transport mint failure gets no captureMessage. WG is the
   // blackout counter (#5245) and no blackout happened; XP counts routes that
   // reject a demonstrably fresh cookie, which this route did not do — the
   // cookie never arrived. The breadcrumb from the eventual episode carries it.
-  if (reason === 'retry_401') reportRouteRecoveryFailure(rawPath);
+  if (verdict.reason === 'retry_401') reportRouteRecoveryFailure(rawPath);
 }
 
 function sessionDegradedResponse(): Response {
@@ -482,8 +499,16 @@ function noteMintCookieEvidence(hadSession: boolean, aCookieExistedWhenSent: boo
  * completed, so the server never rendered a verdict at all. They say nothing
  * about whether the next attempt will work, and must not be read as one
  * (WORLDMONITOR-WG — see mintCauseIsTransport).
+ *
+ * `unknown` is the defensive floor: the mint path threw somewhere it was not
+ * expected to. It is not a server verdict either, so it takes the corroboration
+ * route rather than blacking out the tab on a client-side bug — but it is not
+ * retried, because we cannot say what would be retried.
  */
-type MintFailureCause = 'refused' | 'malformed' | 'timeout' | 'network';
+type MintFailureCause = 'refused' | 'malformed' | 'timeout' | 'network' | 'unknown';
+// What the `mint_cause` Sentry tag may say. `none` is the explicit "this
+// episode has no mint cause" — see markWmSessionDead (#6804).
+type MintCauseTag = MintFailureCause | 'none';
 type MintOutcome =
   | { ok: true; session: StoredSession }
   | { ok: false; cause: MintFailureCause };
@@ -502,16 +527,15 @@ function mintCauseIsTransport(cause: MintFailureCause | null): boolean {
   return cause === 'timeout' || cause === 'network';
 }
 
-// The cause of the most recent failed mint, for the recovery path to read.
-// Module-scoped rather than threaded through ensureWmSession's boolean return
-// because that boolean is part of this module's public surface and is consumed
-// by callers (periodic refresh, page boot) that have no use for the cause.
-let lastMintFailureCause: MintFailureCause | null = null;
-
-async function fetchNewSession(body?: { widgetKey?: string; proKey?: string }): Promise<StoredSession | null> {
-  const outcome = await mintSession(body);
-  lastMintFailureCause = outcome.ok ? null : outcome.cause;
-  return outcome.ok ? outcome.session : null;
+/**
+ * Only a cause the SERVER produced justifies suppressing every anonymous call
+ * at once. Stated positively rather than as `!mintCauseIsTransport(...)`,
+ * because that spelling made every value the taxonomy did not yet name — a
+ * missing cause, and now `unknown` — default to the most expensive verdict the
+ * client can reach (#6804).
+ */
+function mintCauseIsServerVerdict(cause: MintFailureCause | null): boolean {
+  return cause === 'refused' || cause === 'malformed';
 }
 
 async function mintSession(body?: { widgetKey?: string; proKey?: string }): Promise<MintOutcome> {
@@ -573,9 +597,41 @@ async function mintSession(body?: { widgetKey?: string; proKey?: string }): Prom
   }
 }
 
-export async function ensureWmSession(): Promise<boolean> {
-  if (isWmSessionDead()) return false;
-  if (isFresh(cached)) return true;
+/**
+ * What ONE attempt at securing a session actually did.
+ *
+ * The bare boolean could not answer the only question the recovery path needs
+ * answered — did we ask the server, and what did it say? So recovery read the
+ * cause from a module-scoped `lastMintFailureCause` instead, which is ambient:
+ * it belongs to whichever mint finished last, not to this attempt, and it is
+ * `null` for every `false` that never reached a mint at all. Both readings were
+ * then reported as `mint_failed` (#6804). Returning the verdict alongside the
+ * result makes the two inseparable by construction.
+ */
+type SessionAttempt =
+  | { ok: true }
+  // The session is already suppressed, so NO mint was attempted. This is not a
+  // mint failure: the blackout that suppressed it was captured when it was
+  // declared, and reporting it again would count one episode once per request
+  // that happened to be in flight — inflating WORLDMONITOR-WG (the blackout
+  // counter, #5245) and, worse, re-arming the cooldown each time, because
+  // markWmSessionDead extends sessionDeadUntil before its already-dead return.
+  | { ok: false; kind: 'suppressed' }
+  // The mint SUCCEEDED; the browser then proved it will not keep the cookie.
+  // markWmSessionDead('cookie_not_persisted') has already recorded that verdict
+  // and named the right remedy — relabelling the same episode `mint_failed`
+  // downstream contradicts it and points diagnosis at the server.
+  | { ok: false; kind: 'cookie_not_persisted' }
+  | { ok: false; kind: 'mint_failed'; cause: MintFailureCause };
+
+const SESSION_ATTEMPT_OK: SessionAttempt = { ok: true };
+// A throw from the attempt itself. Not a server verdict (see
+// mintCauseIsServerVerdict), so it needs corroboration like a transport blip.
+const SESSION_ATTEMPT_THREW: SessionAttempt = { ok: false, kind: 'mint_failed', cause: 'unknown' };
+
+async function attemptWmSession(): Promise<SessionAttempt> {
+  if (isWmSessionDead()) return { ok: false, kind: 'suppressed' };
+  if (isFresh(cached)) return SESSION_ATTEMPT_OK;
   if (inflight) return inflight;
 
   const stored = loadFromStorage();
@@ -584,37 +640,39 @@ export async function ensureWmSession(): Promise<boolean> {
     // sessionStorage only stores {exp}. After reload the in-memory wms_
     // token is gone; short-circuiting here would send the first RPC
     // cookie-only (the XP bug). Remint unless we already have a token.
-    if (anonymousSessionHeaderToken) return true;
+    if (anonymousSessionHeaderToken) return SESSION_ATTEMPT_OK;
   }
 
   const identityGenerationWhenStarted = sessionIdentityGeneration;
-  inflight = (async () => {
-    const fresh = await fetchNewSession();
+  inflight = (async (): Promise<SessionAttempt> => {
+    const outcome = await mintSession();
     // A key-session mint may replace this anonymous identity while its request
     // is in flight. The replacement is already authoritative; let the caller
     // replay through it without overwriting its cache or persistence verdict.
-    if (sessionIdentityGeneration !== identityGenerationWhenStarted) return true;
-    if (fresh) {
-      cached = fresh;
-      sessionGeneration += 1;
-      saveToStorage(fresh);
-      // A cookie the browser will not keep cannot authorize anything, and the
-      // next route's 401 would buy another useless mint. Suppress up front and
-      // name the real cause, instead of letting the retry_401 quorum report it
-      // as the API rejecting a good cookie (WORLDMONITOR-WG/XP).
-      if (cookiePersistenceBroken) {
-        if (anonymousSessionHeaderToken) {
-          return true;
-        }
-        markWmSessionDead('cookie_not_persisted', '/api/wm-session');
-        return false;
+    if (sessionIdentityGeneration !== identityGenerationWhenStarted) return SESSION_ATTEMPT_OK;
+    if (!outcome.ok) return { ok: false, kind: 'mint_failed', cause: outcome.cause };
+    cached = outcome.session;
+    sessionGeneration += 1;
+    saveToStorage(outcome.session);
+    // A cookie the browser will not keep cannot authorize anything, and the
+    // next route's 401 would buy another useless mint. Suppress up front and
+    // name the real cause, instead of letting the retry_401 quorum report it
+    // as the API rejecting a good cookie (WORLDMONITOR-WG/XP).
+    if (cookiePersistenceBroken) {
+      if (anonymousSessionHeaderToken) {
+        return SESSION_ATTEMPT_OK;
       }
-      return true;
+      markWmSessionDead('cookie_not_persisted', '/api/wm-session');
+      return { ok: false, kind: 'cookie_not_persisted' };
     }
-    return false;
+    return SESSION_ATTEMPT_OK;
   })().finally(() => { inflight = null; });
 
   return inflight;
+}
+
+export async function ensureWmSession(): Promise<boolean> {
+  return (await attemptWmSession()).ok;
 }
 
 export function getWmSessionToken(): string | null {
@@ -624,8 +682,9 @@ export function getWmSessionToken(): string | null {
 }
 
 export async function establishWmKeySession(keys: { widgetKey?: string; proKey?: string }): Promise<boolean> {
-  const fresh = await fetchNewSession(keys);
-  if (!fresh) return false;
+  const outcome = await mintSession(keys);
+  if (!outcome.ok) return false;
+  const fresh = outcome.session;
   cached = fresh;
   sessionGeneration += 1;
   sessionIdentityGeneration += 1;
@@ -673,7 +732,6 @@ export function __resetWmSessionForTests(): void {
   cookieIssuedThisSession = false;
   cookiePersistenceBroken = false;
   anonymousSessionHeaderToken = null;
-  lastMintFailureCause = null;
   sentryEnqueue = enqueueSentryCall;
   fetchNewSessionTimeoutMs = 10_000;
 }
@@ -898,7 +956,7 @@ export function installWmSessionFetchInterceptor(): void {
     const replayAndReport = async (): Promise<Response> => {
       const replayed = await sendWith(new Headers(headers), requestClone ?? input);
       if (isCurrentSessionIdentity()) {
-        if (replayed.status === 401) noteRecoveryFailure('retry_401', path);
+        if (replayed.status === 401) noteRecoveryFailure({ reason: 'retry_401' }, path);
         else noteRouteSuccess(path);
       }
       return replayed;
@@ -974,18 +1032,25 @@ export function installWmSessionFetchInterceptor(): void {
     // for that result instead of each multiplying the failed retry.
     if (!recoveryInFlight) {
       const recovery = (async (): Promise<Response | null> => {
-        let fresh = await ensureWmSession().catch(() => false);
+        let attempt = await attemptWmSession().catch(() => SESSION_ATTEMPT_THREW);
         // A transport failure is the one cause worth immediately re-attempting:
         // the server never answered, so a second try costs one request and may
         // simply succeed. Bounded to a single retry, and only for a transport
         // cause — a refusal is not retried, because the server already answered
-        // and would answer the same way (WORLDMONITOR-WG).
-        if (!fresh && mintCauseIsTransport(lastMintFailureCause)) {
-          fresh = await ensureWmSession().catch(() => false);
+        // and would answer the same way (WORLDMONITOR-WG). A suppressed attempt
+        // is not retried either: nothing was asked, so there is nothing to ask
+        // again until the cooldown lapses.
+        if (!attempt.ok && attempt.kind === 'mint_failed' && mintCauseIsTransport(attempt.cause)) {
+          attempt = await attemptWmSession().catch(() => SESSION_ATTEMPT_THREW);
         }
-        if (!fresh) {
-          if (isCurrentSessionIdentity()) {
-            noteRecoveryFailure('mint_failed', path, lastMintFailureCause);
+        if (!attempt.ok) {
+          // Only an attempt that actually reached the mint may be reported as
+          // `mint_failed`. `suppressed` and `cookie_not_persisted` already have
+          // their own verdict on record — re-reporting either one attributes a
+          // failure to a mint that never happened, or overwrites the diagnosis
+          // of one that succeeded (#6804).
+          if (attempt.kind === 'mint_failed' && isCurrentSessionIdentity()) {
+            noteRecoveryFailure({ reason: 'mint_failed', cause: attempt.cause }, path);
           }
           return null;
         }

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -2542,3 +2542,213 @@ describe('wm-session cookie-persistence detection — concurrent mints', () => {
     );
   });
 });
+
+describe('wm-session mint cause provenance (#6804)', () => {
+  function captureSink() {
+    const captures: Array<{ ctx: { tags?: Record<string, string> } }> = [];
+    mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
+      fn({
+        addBreadcrumb: () => {},
+        captureMessage: (_m: string, ctx: { tags?: Record<string, string> }) => { captures.push({ ctx }); },
+      });
+    }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
+    return captures;
+  }
+
+  // A response the test releases by hand, so a request can still be in flight
+  // at the exact moment an unrelated route declares the session dead. That is
+  // the only way into recovery while the cooldown is already engaged — every
+  // request that STARTS after the blackout is short-circuited far earlier.
+  function deferredResponse(): { promise: Promise<Response>; resolve: (r: Response) => void } {
+    let resolve!: (r: Response) => void;
+    const promise = new Promise<Response>((res) => { resolve = res; });
+    return { promise, resolve };
+  }
+
+  function urlOf(input: RequestInfo | URL): string {
+    if (typeof input === 'string') return input;
+    return input instanceof URL ? input.href : input.url;
+  }
+
+  it('does not re-arm the cooldown from a recovery that attempted no mint', async () => {
+    // The session is already suppressed, so ensureWmSession() returns false
+    // from its very first line without asking the server for anything. Reading
+    // that as `mint_failed` runs markWmSessionDead again, and markWmSessionDead
+    // pushes sessionDeadUntil out by a fresh 15 minutes BEFORE its
+    // already-dead early return — so every request that happened to be in
+    // flight when the blackout landed silently lengthens it.
+    memoryStorage.clear();
+    const captures = captureSink();
+    const gate = deferredResponse();
+    let bystanderSent = 0;
+
+    currentFetchHandler = (input) => {
+      const url = urlOf(input);
+      if (url.includes('/api/wm-session')) {
+        return Promise.resolve(new Response('mint unavailable', { status: 503 }));
+      }
+      if (url.includes('get-vessel-snapshot')) {
+        bystanderSent += 1;
+        return gate.promise;
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const realNow = Date.now;
+    let skewMs = 0;
+    Date.now = () => realNow.call(Date) + skewMs;
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const bystander = wrappedFetch('https://api.worldmonitor.app/api/maritime/v1/get-vessel-snapshot');
+      await new Promise((r) => setTimeout(r, 0));
+      assert.equal(bystanderSent, 1, 'the bystander must be in flight before the blackout is declared');
+
+      await wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series');
+      assert.equal(mod.isWmSessionDead(), true, 'a server refusal blacks out immediately');
+
+      // Ten minutes into the 15-minute cooldown, the bystander's answer lands.
+      skewMs = 10 * 60 * 1000;
+      gate.resolve(new Response('unauthorized', { status: 401 }));
+      const resp = await bystander;
+      assert.equal(resp.status, 401, "an in-flight request still gets the server's own answer");
+
+      // One minute past the cooldown the blackout actually earned.
+      skewMs = 16 * 60 * 1000;
+      assert.equal(
+        mod.isWmSessionDead(),
+        false,
+        'a suppressed call attempted no mint, so it must not extend the blackout it was suppressed by',
+      );
+    } finally {
+      console.warn = originalWarn;
+      Date.now = realNow;
+    }
+
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1, 'one blackout, reported once');
+  });
+
+  it('does not strike a bystander route for a mint that was never attempted', async () => {
+    // Same suppressed path, transport flavour. `lastMintFailureCause` still
+    // holds `network` from the mints that produced the blackout, so the
+    // bystander's non-attempt inherits a cause it never earned and is filed as
+    // corroborating evidence — suppressing an innocent route for 15 minutes.
+    memoryStorage.clear();
+    const captures = captureSink();
+    const gate = deferredResponse();
+    let bystanderSent = 0;
+
+    currentFetchHandler = (input) => {
+      const url = urlOf(input);
+      if (url.includes('/api/wm-session')) return Promise.reject(new TypeError('Failed to fetch'));
+      if (url.includes('get-vessel-snapshot')) {
+        bystanderSent += 1;
+        return gate.promise;
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const bystander = wrappedFetch('https://api.worldmonitor.app/api/maritime/v1/get-vessel-snapshot');
+      await new Promise((r) => setTimeout(r, 0));
+      assert.equal(bystanderSent, 1, 'the bystander must be in flight before the blackout is declared');
+
+      await wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health');
+      await wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series');
+      assert.equal(mod.isWmSessionDead(), true, 'two corroborating transport failures justify the blackout');
+
+      gate.resolve(new Response('unauthorized', { status: 401 }));
+      assert.equal((await bystander).status, 401);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    assert.deepEqual(
+      mod.getStruckRoutes(),
+      [],
+      'a route that merely happened to be in flight must not be struck by a mint nobody attempted',
+    );
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1, 'one blackout, reported once');
+  });
+
+  it('tags a retry_401 blackout with an explicit mint_cause', async () => {
+    // The tag was written conditionally, so "this episode had no mint cause"
+    // and "the tag was dropped" produced the same blank bucket in Sentry and
+    // could not be told apart. Emit it always.
+    memoryStorage.clear();
+    const captures = captureSink();
+
+    currentFetchHandler = (input) => {
+      const url = urlOf(input);
+      if (url.includes('/api/wm-session')) {
+        return Promise.resolve(new Response(JSON.stringify({
+          exp: FAR_FUTURE,
+          hadSession: true,
+          token: 'wms_retry-quorum-token',
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health');
+      await wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1);
+    assert.equal(dead[0].ctx.tags?.reason, 'retry_401');
+    assert.equal(
+      dead[0].ctx.tags?.mint_cause,
+      'none',
+      'a route denial has no mint cause, and saying so is not the same as saying nothing',
+    );
+  });
+
+  it('keeps cookie_not_persisted as its own verdict rather than a causeless mint_failed', async () => {
+    // The mint SUCCEEDED here — the browser then refused to keep the cookie.
+    // markWmSessionDead already recorded that verdict, so the recovery caller
+    // must not relabel the same episode `mint_failed` on its way out.
+    memoryStorage.clear();
+    const captures = captureSink();
+
+    currentFetchHandler = (input) => {
+      const url = urlOf(input);
+      if (url.includes('/api/wm-session')) {
+        // Every mint answers normally and reports no incoming cookie, with no
+        // header token to fall back to.
+        return Promise.resolve(new Response(JSON.stringify({ exp: FAR_FUTURE, hadSession: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const resp = await wrappedFetch('https://api.worldmonitor.app/api/maritime/v1/get-vessel-snapshot');
+      assert.equal(resp.status, 401);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1, 'one episode, one verdict');
+    assert.equal(dead[0].ctx.tags?.reason, 'cookie_not_persisted');
+    assert.equal(
+      dead[0].ctx.tags?.mint_cause,
+      'none',
+      'a mint that succeeded has no failure cause, and the tag must say so',
+    );
+  });
+});

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -2028,6 +2028,11 @@ describe('wm-session route-scoped recovery failures (#5674)', () => {
 // Exceptions the module sent via Sentry's captureException, most recent last.
 // Reset by every captureSink() call.
 let capturedExceptions: unknown[] = [];
+// Breadcrumbs the module added, most recent last. Reset by every captureSink()
+// call. The breadcrumb carries the same route/reason/mint_cause fields as the
+// event and is the only record that survives when the capture itself is
+// suppressed, so it needs its own assertions rather than being discarded.
+let capturedCrumbs: Array<{ message?: string; data?: Record<string, string> }> = [];
 
 // Shared Sentry sink for the dead-session capture tests.
 //
@@ -2039,6 +2044,7 @@ let capturedExceptions: unknown[] = [];
 function captureSink(onCapture?: () => void) {
   const captures: Array<{ msg: string; ctx: { level?: string; tags?: Record<string, string> } }> = [];
   capturedExceptions = [];
+  capturedCrumbs = [];
   mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
     fn({
       captureMessage: (msg: string, ctx: { level?: string; tags?: Record<string, string> }) => {
@@ -2046,7 +2052,9 @@ function captureSink(onCapture?: () => void) {
         onCapture?.();
       },
       captureException: (err: unknown) => { capturedExceptions.push(err); },
-      addBreadcrumb: () => {},
+      addBreadcrumb: (crumb: { message?: string; data?: Record<string, string> }) => {
+        capturedCrumbs.push(crumb);
+      },
     });
   }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
   return captures;
@@ -2714,6 +2722,11 @@ describe('wm-session mint cause provenance (#6804)', () => {
       'none',
       'a route denial has no mint cause, and saying so is not the same as saying nothing',
     );
+    // The breadcrumb carries the same fields for the same reason, and is what
+    // survives when a later capture is suppressed. Locked separately: the tag
+    // and the crumb were changed in lockstep, so one assertion cannot hold both.
+    const crumb = capturedCrumbs.filter((c) => c.message === 'wm-session recovery failed').at(-1);
+    assert.equal(crumb?.data?.mint_cause, 'none', 'the breadcrumb states it too');
   });
 
   it('keeps cookie_not_persisted as its own verdict rather than a causeless mint_failed', async () => {
@@ -2852,5 +2865,46 @@ describe('wm-session mint cause provenance (#6804)', () => {
     assert.equal(await mod.establishWmKeySession({ proKey: 'legacy-pro-key' }), false);
     assert.equal(mod.isWmSessionDead(), false, 'a refused key mint is not a blackout');
     assert.deepEqual(mod.getStruckRoutes(), [], 'and it strikes no route');
+  });
+
+  it('names the mint cause when a burst blackout is tipped by a cookie-less replay', async () => {
+    // The modal WORLDMONITOR-WG shape: a dashboard boot burst plus a flaky
+    // transport. The leader's mint fails, records strike #1 and stops below
+    // quorum; the follower then replays with NO cookie (none was ever minted),
+    // so its 401 is guaranteed rather than evidential, and IT tips the quorum —
+    // with a retry_401 verdict that carries no cause of its own.
+    //
+    // The episode was caused entirely by failed mints, so tagging it
+    // `mint_cause: none` would assert something false and send triage looking
+    // at a bystander panel for a cookie problem that does not exist. `none` is
+    // a positive claim now, and it has to be earned.
+    memoryStorage.clear();
+    const captures = captureSink();
+
+    currentFetchHandler = (input) => {
+      const url = urlOf(input);
+      if (url.includes('/api/wm-session')) return Promise.reject(new TypeError('Failed to fetch'));
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await Promise.all([
+        wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health'),
+        wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series'),
+      ]);
+      assert.equal(mod.isWmSessionDead(), true, 'the burst does black out');
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1, 'exactly one capture per degraded episode');
+    assert.equal(
+      dead[0].ctx.tags?.mint_cause,
+      'network',
+      'every mint in this episode failed at the transport level — the tag must say so',
+    );
   });
 });

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -2794,8 +2794,11 @@ describe('wm-session mint cause provenance (#6804)', () => {
     const captures = captureSink();
     const realAbortController = globalThis.AbortController;
     const boom = new Error('AbortController is not a constructor');
-    (globalThis as unknown as { AbortController: unknown }).AbortController = function () {
-      throw boom;
+    // A class, not a function expression: `new AbortController()` needs a
+    // constructible, and an arrow would throw the engine's own TypeError
+    // instead of the sentinel the exception assertion below looks for.
+    (globalThis as unknown as { AbortController: unknown }).AbortController = class {
+      constructor() { throw boom; }
     };
 
     currentFetchHandler = () => Promise.resolve(new Response('unauthorized', { status: 401 }));

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -2025,20 +2025,34 @@ describe('wm-session route-scoped recovery failures (#5674)', () => {
 // two routes before it may black out the tab.
 // ---------------------------------------------------------------------------
 
-describe('wm-session mint failure cause (WORLDMONITOR-WG)', () => {
-  function captureSink() {
-    const captures: Array<{ msg: string; ctx: { level?: string; tags?: Record<string, string> } }> = [];
-    mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
-      fn({
-        captureMessage: (msg: string, ctx: { level?: string; tags?: Record<string, string> }) => {
-          captures.push({ msg, ctx });
-        },
-        addBreadcrumb: () => {},
-      });
-    }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
-    return captures;
-  }
+// Exceptions the module sent via Sentry's captureException, most recent last.
+// Reset by every captureSink() call.
+let capturedExceptions: unknown[] = [];
 
+// Shared Sentry sink for the dead-session capture tests.
+//
+// `onCapture` runs SYNCHRONOUSLY inside markWmSessionDead, after it has already
+// pushed sessionDeadUntil out and before it returns. That is the one seam where
+// a test can advance the clock between one verdict and the next, which is what
+// makes "a second, redundant verdict re-armed the cooldown" observable at all —
+// both calls otherwise land on the same millisecond and extend it by zero.
+function captureSink(onCapture?: () => void) {
+  const captures: Array<{ msg: string; ctx: { level?: string; tags?: Record<string, string> } }> = [];
+  capturedExceptions = [];
+  mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
+    fn({
+      captureMessage: (msg: string, ctx: { level?: string; tags?: Record<string, string> }) => {
+        captures.push({ msg, ctx });
+        onCapture?.();
+      },
+      captureException: (err: unknown) => { capturedExceptions.push(err); },
+      addBreadcrumb: () => {},
+    });
+  }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
+  return captures;
+}
+
+describe('wm-session mint failure cause (WORLDMONITOR-WG)', () => {
   function isDegraded(resp: Response): boolean {
     return resp.status === 503 && resp.headers.get('X-Wm-Session-Degraded') === '1';
   }
@@ -2544,17 +2558,6 @@ describe('wm-session cookie-persistence detection — concurrent mints', () => {
 });
 
 describe('wm-session mint cause provenance (#6804)', () => {
-  function captureSink() {
-    const captures: Array<{ ctx: { tags?: Record<string, string> } }> = [];
-    mod.__setWmSessionSentryEnqueueForTests(((fn: (s: unknown) => void) => {
-      fn({
-        addBreadcrumb: () => {},
-        captureMessage: (_m: string, ctx: { tags?: Record<string, string> }) => { captures.push({ ctx }); },
-      });
-    }) as Parameters<typeof mod.__setWmSessionSentryEnqueueForTests>[0]);
-    return captures;
-  }
-
   // A response the test releases by hand, so a request can still be in flight
   // at the exact moment an unrelated route declares the session dead. That is
   // the only way into recovery while the cooldown is already engaged — every
@@ -2717,8 +2720,20 @@ describe('wm-session mint cause provenance (#6804)', () => {
     // The mint SUCCEEDED here — the browser then refused to keep the cookie.
     // markWmSessionDead already recorded that verdict, so the recovery caller
     // must not relabel the same episode `mint_failed` on its way out.
+    //
+    // Asserting the tags alone would NOT prove that: markWmSessionDead's
+    // already-dead early return swallows a second capture, and one route cannot
+    // reach the corroboration quorum, so every tag assertion stays green with
+    // the guard removed. Two observables have teeth here and both are checked
+    // below — the cooldown must not be re-armed (the clock is advanced inside
+    // the first capture so a second verdict would land 10 minutes later), and
+    // the route whose 401 triggered recovery must not be struck by a mint that
+    // succeeded.
     memoryStorage.clear();
-    const captures = captureSink();
+    const realNow = Date.now;
+    let skewMs = 0;
+    Date.now = () => realNow.call(Date) + skewMs;
+    const captures = captureSink(() => { skewMs = 10 * 60 * 1000; });
 
     currentFetchHandler = (input) => {
       const url = urlOf(input);
@@ -2738,10 +2753,25 @@ describe('wm-session mint cause provenance (#6804)', () => {
     try {
       const resp = await wrappedFetch('https://api.worldmonitor.app/api/maritime/v1/get-vessel-snapshot');
       assert.equal(resp.status, 401);
+
+      // One minute past the cooldown the cookie_not_persisted verdict earned.
+      // A relabel would have re-armed it from the skewed clock, to t+25min.
+      skewMs = 16 * 60 * 1000;
+      assert.equal(
+        mod.isWmSessionDead(),
+        false,
+        'a second, redundant verdict for the same episode must not extend the blackout',
+      );
     } finally {
       console.warn = originalWarn;
+      Date.now = realNow;
     }
 
+    assert.deepEqual(
+      mod.getStruckRoutes(),
+      [],
+      'a mint that SUCCEEDED must not strike the route whose 401 triggered recovery',
+    );
     const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
     assert.equal(dead.length, 1, 'one episode, one verdict');
     assert.equal(dead[0].ctx.tags?.reason, 'cookie_not_persisted');
@@ -2750,5 +2780,74 @@ describe('wm-session mint cause provenance (#6804)', () => {
       'none',
       'a mint that succeeded has no failure cause, and the tag must say so',
     );
+  });
+
+  it('reports a thrown attempt as mint_cause unknown, and does not black out on it', async () => {
+    // `new AbortController()` and the timeout setTimeout sit OUTSIDE
+    // mintSession's try — on the old WebView / Smart-TV engines the
+    // AbortSignal.timeout comment names, a throw there rejects the whole
+    // attempt. The old code read the stale (usually null) module-scoped cause,
+    // failed the transport test, and blacked out every anonymous call for 15
+    // minutes over a client-side throw. It must now take the same corroboration
+    // route a transport blip does, and say `unknown` rather than nothing.
+    memoryStorage.clear();
+    const captures = captureSink();
+    const realAbortController = globalThis.AbortController;
+    const boom = new Error('AbortController is not a constructor');
+    (globalThis as unknown as { AbortController: unknown }).AbortController = function () {
+      throw boom;
+    };
+
+    currentFetchHandler = () => Promise.resolve(new Response('unauthorized', { status: 401 }));
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const first = await wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health');
+      assert.equal(first.status, 401, "the server's own answer is handed back");
+      assert.equal(
+        mod.isWmSessionDead(),
+        false,
+        'one client-side throw is not a server verdict and must not black out the tab',
+      );
+      assert.deepEqual(
+        mod.getStruckRoutes(),
+        ['/api/infrastructure/v1/get-cable-health'],
+        'it still counts as evidence against its own route',
+      );
+
+      // A second distinct route inside the corroboration window is what earns
+      // the blackout — the same rule a transport failure follows.
+      await wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series');
+      assert.equal(mod.isWmSessionDead(), true, 'two corroborating routes do justify it');
+    } finally {
+      console.warn = originalWarn;
+      (globalThis as unknown as { AbortController: typeof AbortController }).AbortController = realAbortController;
+    }
+
+    const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
+    assert.equal(dead.length, 1, 'exactly one capture per degraded episode');
+    assert.equal(dead[0].ctx.tags?.reason, 'mint_failed');
+    assert.equal(
+      dead[0].ctx.tags?.mint_cause,
+      'unknown',
+      'a throw is a distinct cause, not a blank tag and not a server refusal',
+    );
+    assert.ok(
+      capturedExceptions.includes(boom),
+      'the exception itself must be reported — `unknown` alone tells on-call nothing',
+    );
+  });
+
+  it('leaves session state alone when a key-session mint is refused', async () => {
+    // establishWmKeySession moved from the deleted fetchNewSession wrapper to
+    // mintSession. Its failure path touches none of the identity/state resets.
+    memoryStorage.clear();
+    captureSink();
+    currentFetchHandler = () => Promise.resolve(new Response('mint unavailable', { status: 503 }));
+
+    assert.equal(await mod.establishWmKeySession({ proKey: 'legacy-pro-key' }), false);
+    assert.equal(mod.isWmSessionDead(), false, 'a refused key mint is not a blackout');
+    assert.deepEqual(mod.getStruckRoutes(), [], 'and it strikes no route');
   });
 });


### PR DESCRIPTION
Fixes #6804.

## First, a correction to the issue's headline number

The issue reports `mint_cause` absent on **99.2%** of `mint_failed` events. That
ratio is real but it is **pre-tag history**, not a live gap.

`mint_cause` shipped in #6413 on **2026-08-10 15:40Z**. WORLDMONITOR-WG's 645
lifetime `mint_failed` events are dominated by the 07-20 -> 07-27 spike, which
ran entirely before the tag existed. Since the deploy there are **7**
`mint_failed` events:

| when | `mint_cause` | breadcrumb shape |
|---|---|---|
| 08-11T02:32Z | `refused` | `{route, blocked, reason, mint_cause}` |
| 08-11T14:21Z | `malformed` | `{route, blocked, reason, mint_cause}` |
| 08-11T18:35Z | *(absent)* | `{route, blocked, reason}` |
| 08-11T21:24Z | *(absent)* | no breadcrumb, no `route` tag |
| 08-15T17:07Z | `malformed` | `{route, blocked, reason, mint_cause}` |
| 08-16T09:58Z | `malformed` | `{route, blocked, reason, mint_cause}` |
| 08-16T15:18Z | `malformed` | `{route, blocked, reason, mint_cause}` |

The two causeless events carry a breadcrumb byte-identical to the **pre-#6413**
shape (`git show e88891d55^:src/services/wm-session.ts`) — one from an Electron
34 desktop build, one with neither `route` nor a breadcrumb at all (a bundle
predating even #5674). Neither can be attributed to the shipped code, and the
`release` tag is `worldmonitor@2.10.0` on every event, so it cannot separate
them.

**So: no production event proves the current code emits a causeless
`mint_failed`.** The defect below is real by code reading and is now proven by
test, but it is **latent**. That matches the issue's own framing — WG is at 1-3
events/day and this tag is the instrument the next regrowth would be diagnosed
with.

## The defect

`ensureWmSession()` returned a bare boolean, so the recovery path read the
failure cause from a module-scoped `lastMintFailureCause`. That value is
**ambient**: it belongs to whichever mint finished last, not to this attempt,
and it is `null` for every `false` that never reached a mint at all.

Two of `ensureWmSession()`'s `false` returns attempt no mint —

- the `isWmSessionDead()` short-circuit on its very first line, and
- `cookie_not_persisted`, where the mint **succeeded** and the browser then
  refused to keep the cookie

— and both were reported downstream as `mint_failed`, the most expensive verdict
the client can reach.

## The fix

`attemptWmSession()` returns the verdict with the result:

```ts
type SessionAttempt =
  | { ok: true }
  | { ok: false; kind: 'suppressed' }            // no mint attempted
  | { ok: false; kind: 'cookie_not_persisted' }  // mint SUCCEEDED
  | { ok: false; kind: 'mint_failed'; cause: MintFailureCause };
```

Only `kind === 'mint_failed'` may be reported. `lastMintFailureCause` and its
`fetchNewSession` wrapper are deleted, so a stale cause is no longer
representable. `ensureWmSession(): Promise<boolean>` is unchanged as the public
surface.

Three consequences the refactor removes:

1. **A suppressed call re-armed the blackout.** `markWmSessionDead` extends
   `sessionDeadUntil` by a fresh 15 minutes *before* its already-dead early
   return, so every request that happened to be in flight when a blackout landed
   silently lengthened it.
2. **A suppressed call struck a bystander route.** It inherited the previous
   mints' transport cause and was filed as corroborating evidence, suppressing
   for 15 minutes an endpoint that had rejected nothing and for which no mint was
   attempted.
3. **`mint_cause` was written conditionally**, so "this episode has no mint
   cause" and "the tag was dropped" shared one blank Sentry bucket. It is now
   always emitted; `none` says the first out loud, and a blank now means only one
   thing — a client too old to carry it.

The blackout gate is restated as `mintCauseIsServerVerdict` (`refused` |
`malformed`) rather than `!mintCauseIsTransport`, because the negative spelling
made every value the taxonomy did not yet name default to an immediate
session-wide blackout.

## `unknown`: a live path, not a defensive floor

A throw out of the attempt is now `cause: 'unknown'` and takes the corroboration
route instead of blacking out the tab. This is reachable in the browser
population this module explicitly targets: `new AbortController()`
(`wm-session.ts:551`) and the timeout `setTimeout` (`:556`) sit **outside**
`mintSession`'s `try` (which opens at `:560`), and the comment immediately above
names the reason — older Safari/WebView and Smart-TV engines. `markWmSessionDead`'s
`new CustomEvent(...)` is unguarded for the same class of engine.

Under the old code that throw read the stale (usually `null`) cause, failed the
transport test, and blacked out every anonymous API call for 15 minutes over a
client-side throw. `reportUnknownMintThrow` also sends the exception itself —
`unknown` with no exception attached tells on-call nothing.

## `none` has to be earned

The cross-model adversarial pass found that `mint_cause: none` could be a **false
claim** in the modal WORLDMONITOR-WG shape, and it reproduces. In a dashboard
boot burst over a flaky transport:

1. the recovery leader's mint fails at transport level and records strike #1 —
   below quorum, so no blackout;
2. the followers fall through to a replay carrying **no cookie** (none was ever
   minted), so their 401s are guaranteed rather than evidential;
3. the first of those tips the quorum with a `retry_401` verdict that has no
   cause of its own.

The episode was caused entirely by failed mints and was tagged `reason:
retry_401, route: <a bystander panel>, mint_cause: none`. That is worse than the
blank tag it replaces — a blank read as "unknown", a truthful non-claim, while
`none` asserts the mints were healthy and sends triage hunting a cookie problem
that does not exist. Verified before fixing: the test failed `'none' !==
'network'`.

The cause now rides the corroboration evidence. `recentRouteFailures` stores
`{ at, cause }`, and when the quorum tips, `episodeMintCause` prefers the tipping
verdict's own cause and falls back to the most recent mint cause still inside the
60-second window. That state is bounded by `SESSION_DEAD_CORROBORATION_MS` and
voided by any success, so it is episode-scoped evidence — not the ambient
last-value state this PR removes.

`none` still means "no mint failed in this episode": the `retry_401` test, where
mints succeed and only routes deny, still asserts it and still passes.

## One boot-path guard outside this module

`src/App.ts:1879` awaited `ensureWmSession()` bare. It genuinely rejects on the
engines this PR documents, `init()` has no `try`/`catch`, and `src/main.ts:581`
swallows the rejection with `.catch(console.error)` — so that throw aborted boot
before bootstrap hydration, auth, and the entire UI mount, and never reached
Sentry. Strictly worse than the 15-minute blackout this module exists to bound.
Now guarded like the module's own three call sites.

The throw predates this PR; the asymmetry did not. This PR declares that path
live and defends the recovery side of it, so leaving the side whose failure
costs the whole boot undefended was not defensible.

## Testing

Seven cases in a new `wm-session mint cause provenance (#6804)` block. **Each
behavior test was re-run against the pre-fix file and fails on the assertion it
is named for**, not on an unrelated one:

| test | fails pre-fix on |
|---|---|
| does not re-arm the cooldown from a recovery that attempted no mint | `isWmSessionDead()` still true 1 min past the earned 15 |
| does not strike a bystander route for a mint that was never attempted | `getStruckRoutes()` contains the in-flight bystander |
| tags a retry_401 blackout with an explicit mint_cause | `mint_cause` undefined |
| keeps cookie_not_persisted as its own verdict | cooldown re-armed to t+25min |
| reports a thrown attempt as mint_cause unknown | blacked out on one client-side throw |
| names the mint cause when a burst blackout is tipped by a cookie-less replay | `'none' !== 'network'` |

The remaining case pins `establishWmKeySession`'s failure path across the
`fetchNewSession` -> `mintSession` swap and passes both before and after, which
is correct — it characterizes a behavior-preserving change.

The cooldown re-arm is only observable because the capture sink advances the
clock between one verdict and the next; both otherwise land on the same
millisecond and extend it by zero.

Two guards added late are mutation-verified: reverting `episodeMintCause` to the
tipping cause, and the breadcrumb's `mint_cause` to its old conditional spread,
each turn exactly one test red. The breadcrumb one was a **surviving mutant** the
adversarial sweep caught — tag and breadcrumb were changed in lockstep for the
same reason, but only the tag was locked.

Local: 59/59 in `wm-session-auto-refresh`, 121/121 across the wm-session +
premium-fetch set, `tsc --noEmit` clean, `biome lint` clean,
`lint:boundaries` clean.

## Review

Nine reviewers plus an independent cross-model adversarial pass (Codex/gpt-5.5).

- Three independently found that the `cookie_not_persisted` test asserted only
  its tags and could not detect the relabel regression it was named for. It now
  asserts the cooldown and the strike store.
- Six flagged `unknown` as untested; security established it is a live path
  rather than a defensive floor.
- The adversarial pass found the `mint_cause: none` false claim above, the
  unguarded boot await, and three surviving mutants.

All fixed here except the two residuals below.

### Known residuals (accepted, not fixed here)

- **`wm-session.ts` is 1122 lines and the pure type/predicate cluster could move
  to a sibling `wm-session-types.ts`** (maintainability P2, owner: human).
  Declined here — a structural split of a security-sensitive module inside a
  bugfix PR makes the diff harder to review against the issue.
- **No console reader for the dead-session reason/cause** (agent-native). The
  module exports `isWmSessionDead()` and `getStruckRoutes()` for exactly this,
  and `sessionDeadReason` has no getter, so the enrichment this PR adds is
  visible in Sentry but not from the console. Worth a follow-up
  `getWmSessionDeadReason()`; it is new public API surface beyond #6804.
- **No counter for how often a recovery races a blackout announcement.** The
  `suppressed` path is now deliberately silent; if that race is frequent in
  production it is invisible rather than merely unreported.
- **Two surviving mutants left unpinned.** Deleting `&& isCurrentSessionIdentity()`
  from the recovery report changes nothing observable in the suite (a pre-existing
  guard, but this PR rewrote the line it sits on), and extending the retry
  condition to include `suppressed` is behaviourally inert today. The first needs
  an identity change staged mid-recovery to pin.
- **The route quorum can mix reasons** (one `retry_401` + one transport
  `mint_failed`) but the resulting event reports only the triggering verdict.
  Pre-existing.

## Post-Deploy Monitoring & Validation

**Watch:** WORLDMONITOR-WG (`7606710747`), tag distribution for `mint_cause`.

**Expected healthy signals**
- Every new `wm_session_dead` event carries a `mint_cause` tag. The blank bucket
  stops growing — a blank from this deploy forward means an old cached bundle.
- `retry_401` events (~97% of WG volume) read `mint_cause: none`.
- WG daily volume stays in its current 1-3/day band.

**Failure signals / rollback trigger**
- `mint_cause: unknown` appearing at more than a trickle means a real throw path
  on production engines — the paired `captureException` names it. That is new
  information, not a regression, but it warrants a look.
- A step-change up in WG daily volume, or `reason: mint_failed` share rising
  above its current ~1%, would suggest the corroboration route is now letting
  through episodes that used to black out immediately. Revert if so.

**⚠️ Breaking change for saved Sentry searches:** `mint_cause` is now written on
**every** `wm_session_dead` event. Any saved search, alert, or dashboard that
uses `!has:mint_cause` to mean "this is a `retry_401`" stops separating
anything after this deploy. Split on `mint_cause:none` instead. I could not
enumerate saved searches from the API — worth a manual check before merge.

**Window/owner:** 48h after deploy, ops.
