### PR TITLE
fix(seeders): right-size the Submarine-Cables bundle slot to its measured runtime

### DIFF
--- a/scripts/seed-bundle-static-ref.mjs
+++ b/scripts/seed-bundle-static-ref.mjs
@@ -7,7 +7,19 @@ await runBundle('static-ref', [
   // budget defer lower-priority members without missing their real cadence.
   { label: 'Arms-Suppliers', script: 'seed-defense-industrial-suppliers.mjs', seedMetaKey: 'military:arms-suppliers-complete', canonicalKey: 'military:arms-suppliers:complete:v1', intervalMs: 10 * DAY, timeoutMs: 450_000 },
   { label: 'Defense-Industrial', script: 'seed-defense-industrial.mjs', seedMetaKey: 'military:defense-industrial', canonicalKey: 'military:industrial-base:v1', intervalMs: 10 * DAY, timeoutMs: 100_000 },
-  { label: 'Submarine-Cables', script: 'seed-submarine-cables.mjs', seedMetaKey: 'infrastructure:submarine-cables', canonicalKey: 'infrastructure:submarine-cables:v1', intervalMs: WEEK, timeoutMs: 300_000 },
+  // 90s, not 300s. The runner admits on the DECLARED worst case
+  // (timeoutMs + KILL_GRACE_MS) because it decides before running, so a timeout
+  // is a reservation rather than a ceiling drawn down on use — and 300s asked
+  // for a 310s slot to do work that measures ~22s. With 293s left after
+  // Arms-Suppliers it was refused by 17 seconds on every tick, which is why
+  // infrastructure:submarine-cables:v1 has never existed (#6799).
+  //
+  // Measured 2026-08-17 against submarinecablemap.com: the seeder fetches the
+  // CURATED list (CABLE_REGIONS, 86 cables) rather than the 702 in all.json —
+  // 18 batches of 5 at ~0.97s, plus ~5s for cable-geo.json (739KB) and
+  // landing-point-geo.json (360KB). 90s is ~4x that, which keeps room for a
+  // slower link from Railway while reserving 100s instead of 310s.
+  { label: 'Submarine-Cables', script: 'seed-submarine-cables.mjs', seedMetaKey: 'infrastructure:submarine-cables', canonicalKey: 'infrastructure:submarine-cables:v1', intervalMs: WEEK, timeoutMs: 90_000 },
   { label: 'Defense-Patents', script: 'seed-defense-patents.mjs', seedMetaKey: 'military:defense-patents', canonicalKey: 'patents:defense:latest', intervalMs: WEEK, timeoutMs: 180_000, requiredEnv: ['USPTO_API_KEY'] },
   { label: 'Chokepoint-Baselines', script: 'seed-chokepoint-baselines.mjs', seedMetaKey: 'energy:chokepoint-baselines', canonicalKey: 'energy:chokepoint-baselines:v1', intervalMs: 400 * DAY, timeoutMs: 60_000 },
   { label: 'Military-Bases', script: 'seed-military-bases.mjs', seedMetaKey: 'military:bases', intervalMs: 30 * DAY, timeoutMs: 540_000 },

--- a/tests/seed-submarine-cables.test.mjs
+++ b/tests/seed-submarine-cables.test.mjs
@@ -1,5 +1,8 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   CABLE_REGIONS,
@@ -123,5 +126,60 @@ describe('seed-submarine-cables detail fetch resilience', () => {
         && err.message.includes('failed details:'),
     );
     assert.ok(state.detailIds.length > 80, 'test should cover the full strategic cable list');
+  });
+});
+
+describe('Submarine-Cables declares a bundle slot it can actually be given (#6799)', () => {
+  // seed-bundle-static-ref admits a section only when its DECLARED worst case
+  // (timeoutMs + KILL_GRACE_MS) fits the budget still left on the tick — the
+  // runner decides before running, so the declaration is all it has to go on.
+  //
+  // That makes the timeout a reservation, not a ceiling drawn down on use, and
+  // over-declaring is a real cost: Submarine-Cables asked for 300s to do ~141s
+  // of work, so with 293s left it was refused by 17 seconds and its key was
+  // never written at all. Under-declaring is the opposite failure and just as
+  // bad — Arms-Suppliers declared 450s for ~547s of work and burned its whole
+  // fetch deadline on every run.
+  //
+  // So this is two-sided: the declaration must cover the measured runtime, and
+  // its reservation must still fit the budget that realistically remains.
+  //
+  // Measured 2026-08-17 against submarinecablemap.com. Note the seeder fetches
+  // the CURATED list (CABLE_REGIONS), not the 702 cables in all.json — 86 ids,
+  // 18 batches of 5 at ~0.97s, plus ~5s for cable-geo.json (739KB) and
+  // landing-point-geo.json (360KB).
+  const MEASURED_RUNTIME_S = 22;
+  const KILL_GRACE_S = 10;
+  // What is left of the 570s budget once Arms-Suppliers has run at its measured
+  // ~277s. The ceiling is expressed against this rather than as a ratio because
+  // the harm from over-declaring is the absolute reservation, not the multiple.
+  const BUDGET_REMAINING_S = 293;
+
+  const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+  it('covers the measured run and still fits the budget that remains', () => {
+    const bundle = readFileSync(join(root, 'scripts/seed-bundle-static-ref.mjs'), 'utf8');
+    const row = /label: 'Submarine-Cables'[^}]*timeoutMs:\s*([\d_]+)/.exec(bundle);
+    assert.ok(row, 'seed-bundle-static-ref must declare a Submarine-Cables timeoutMs');
+    const declaredS = Number(row[1].replace(/_/g, '')) / 1000;
+
+    assert.ok(
+      declaredS >= MEASURED_RUNTIME_S,
+      `declared ${declaredS}s is below the measured ${MEASURED_RUNTIME_S}s — the section would be `
+      + 'killed mid-run, which is how Arms-Suppliers burned its deadline every tick',
+    );
+    assert.ok(
+      declaredS + KILL_GRACE_S <= BUDGET_REMAINING_S,
+      `declared ${declaredS}s reserves ${declaredS + KILL_GRACE_S}s, more than the `
+      + `${BUDGET_REMAINING_S}s left after Arms-Suppliers. The bundle admits on the declaration, `
+      + 'so a reservation this size locks the section out of every tick (#6799).',
+    );
+  });
+
+  it('the curated list is what sets that runtime, not all.json', () => {
+    // If the seeder ever switched to the full catalogue the measurement above
+    // would be ~6x optimistic and the slot too small, so pin what it iterates.
+    const ids = CABLE_REGIONS.flatMap((region) => region.ids);
+    assert.ok(ids.length > 80 && ids.length < 200, `curated list is ${ids.length} ids`);
   });
 });


### PR DESCRIPTION
`infrastructure:submarine-cables:v1` has **never existed** — `ttl -2` on both the canonical key and its seed-meta. Not a fetch failure: the section was refused admission on every tick.

Last of the three `seed-bundle-static-ref` defects from #6799. The other two are fixed in #6807; the budget itself is #6806.

## A timeout is a reservation, not a ceiling

`runBundle` admits a section only when its **declared** worst case fits the budget still left on the tick, because it decides *before* running and the declaration is all it has:

```js
const worstCase = sectionWorstCaseMs(section);   // timeoutMs + KILL_GRACE_MS
if (elapsedBundle + worstCase > maxBundleMs) { defer }
```

So `timeoutMs` is pre-booked, not drawn down on use, and over-declaring is a real cost rather than harmless slack.

```
declared 300s → reserve 310s → 293s available → STARVED by 17s   (run needs ~22s)
declared  90s → reserve 100s → 293s available → FITS             (271s to spare)
```

It missed by **17 seconds**, every tick, for work that finishes in a fraction of the slot.

## The measurement, and a correction

Measured 2026-08-17 against `submarinecablemap.com`:

| call | time | size |
|---|---:|---|
| `cable-geo.json` | 2.79 s | 739 KB |
| `landing-point-geo.json` | 2.26 s | 360 KB |
| one batch of 5 `cable/{id}.json` | 0.97 s | — |

**The seeder iterates the CURATED list — `CABLE_REGIONS`, 86 ids — not the 702 cables in `all.json`.** A first pass measured against the full catalogue and got ~141 s; the real figure is:

```
86 cables → ceil(86/5) = 18 batches × 0.97s + ~5s preamble ≈ 22s
```

So 300 s was over-declared by **13×**, not 2×. This ships 90 s (~4× measured), which keeps room for a slower link from Railway while reserving 100 s instead of 310 s.

## The guard is two-sided, because this bundle has been bitten both ways

- **Under-declaring** kills the section mid-run — `Arms-Suppliers` declared 450 s for ~547 s of work and burned its full 390 s fetch deadline every tick (#6807).
- **Over-declaring** locks the section out — this.

The ceiling is expressed against the budget that actually remains rather than as a ratio, since the harm is the absolute reservation, not the multiple. A second test pins that the curated list is what sets the runtime: on `all.json` the same measurement would be ~6× optimistic and the slot too small.

Mutation-tested — restoring 300 s fails with the numbers:

```
declared 300s reserves 310s, more than the 293s left after Arms-Suppliers.
The bundle admits on the declaration, so a reservation this size locks the
section out of every tick (#6799).
```

## Testing

`test:data` — 24,488 tests, **24,481 pass**. One failure, `parses hostile markup without superlinear rescans`, is a wall-clock ratio assertion in the China policy suite that flaked under concurrent load; verified green in isolation at **147 ms vs 1170 ms** under contention, and unrelated to this diff. biome clean.

## Post-Deploy Monitoring & Validation

`seed-bundle-static-ref` runs `0 3 * * *`. `Submarine-Cables` has a WEEK interval, so it is due on the next tick.

**Watch (owner: me):**

- Railway logs — `[Submarine-Cables]` should show a completed run rather than `Deferred, needs 310s but only ...s left`. Expect ~22 s; anything approaching 90 s means the upstream is far slower from Railway than measured here and the slot needs re-measuring, not widening by reflex.
- `/api/health?compact=1` — `submarineCables` should leave `problems` once the key is written.
- `infrastructure:submarine-cables:v1` should exist with a non-zero record count for the first time.

**Failure signal:** the section running to 90 s and being killed mid-run would mean the declaration is now too small — the `Arms-Suppliers` failure mode — and the measurement must be redone from Railway rather than locally.

**Known limit:** `Mineral-Production` (190 s reserve) and `Submarine-Cables` (100 s) now both fit the 293 s remainder, together as well as individually, but that depends on `Arms-Suppliers` landing near its measured ~277 s. If SIPRI slows, the squeeze returns — that fragility is #6806, not this PR.
