### PR TITLE
fix(seo): prevent rootless docs routes from returning 404

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,3 +1,5 @@
+import { getRootlessDocsDestination } from './src/config/docs-root-redirects';
+
 const BOT_UA =
   /bot|crawl|spider|slurp|archiver|wget|curl\/|python-requests|scrapy|httpclient|go-http|java\/|libwww|perl|ruby|php\/|ahrefsbot|semrushbot|mj12bot|dotbot|baiduspider|yandexbot|sogou|bytespider|petalbot|gptbot|claudebot|ccbot/i;
 
@@ -171,6 +173,15 @@ export default function middleware(request: Request) {
     const dashboardUrl = new URL(request.url);
     dashboardUrl.pathname = '/dashboard';
     return Response.redirect(dashboardUrl.toString(), 308);
+  }
+
+  if (request.method === 'GET' || request.method === 'HEAD') {
+    const docsDestination = getRootlessDocsDestination(path);
+    if (docsDestination) {
+      const canonicalUrl = new URL(docsDestination);
+      canonicalUrl.search = url.search;
+      return Response.redirect(canonicalUrl.toString(), 308);
+    }
   }
 
   // Variant-aware crawlable stub for social preview bots AND AI crawlers
@@ -366,5 +377,9 @@ ${AI_CRAWLER_VARIANT_LINKS}
 }
 
 export const config = {
-  matcher: ['/', '/mcp', '/api/:path*'],
+  matcher: [
+    '/mcp',
+    '/api/:path*',
+    '/((?!api(?:/|$)|mcp(?:/|$)|.*\\.[^/]+$).*)',
+  ],
 };

--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -7,7 +7,7 @@ if [ "$VERCEL_GIT_COMMIT_REF" = "main" ] && [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; t
   git cat-file -e "$VERCEL_GIT_PREVIOUS_SHA" 2>/dev/null && {
     WEB_CHANGES=$(git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- \
       'src/' 'api/' 'server/' 'shared/' 'public/' 'blog-site/' 'pro-test/' 'proto/' 'convex/' \
-      'CHANGELOG.md' 'docs/snapshots/' \
+      'CHANGELOG.md' 'docs/docs.json' 'docs/snapshots/' \
       'scripts/build-crawlable-corpus.mjs' 'scripts/build-research-reports.mjs' \
       'scripts/build-sitemap.mjs' 'scripts/discover-content-corpus-pages.mjs' \
       'scripts/crawlable-live-tools.mjs' 'scripts/crawlable-sources-page.mjs' \
@@ -69,6 +69,7 @@ git diff --name-only "$COMPARE_SHA" HEAD -- \
   'proto/' \
   'convex/' \
   'CHANGELOG.md' \
+  'docs/docs.json' \
   'docs/snapshots/' \
   'scripts/build-crawlable-corpus.mjs' \
   'scripts/build-research-reports.mjs' \

--- a/src/config/docs-root-redirects.ts
+++ b/src/config/docs-root-redirects.ts
@@ -1,0 +1,69 @@
+import docsConfigJson from '../../docs/docs.json';
+
+const DOCS_ORIGIN = 'https://www.worldmonitor.app';
+
+type DocsConfigLike = {
+  navigation?: unknown;
+  redirects?: Array<{ source: string; destination: string }>;
+};
+
+const VERCEL_OWNED_DOC_PATHS = new Set([
+  '/about',
+  '/changelog',
+  '/contact',
+  '/pricing',
+  '/privacy',
+  '/support',
+  '/terms',
+]);
+
+function normalizePath(path: string): string {
+  const withLeadingSlash = path.startsWith('/') ? path : `/${path}`;
+  return withLeadingSlash.length > 1 ? withLeadingSlash.replace(/\/+$/, '') : withLeadingSlash;
+}
+
+function addNavigationPages(node: unknown, routes: Map<string, string>): void {
+  if (Array.isArray(node)) {
+    for (const entry of node) addNavigationPages(entry, routes);
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'pages' && Array.isArray(value)) {
+      for (const page of value) {
+        if (typeof page === 'string') {
+          const path = normalizePath(page);
+          routes.set(path, `${DOCS_ORIGIN}/docs${path}`);
+        } else {
+          addNavigationPages(page, routes);
+        }
+      }
+      continue;
+    }
+    addNavigationPages(value, routes);
+  }
+}
+
+export function buildRootlessDocsRedirects(config: DocsConfigLike): Map<string, string> {
+  const routes = new Map<string, string>();
+  addNavigationPages(config.navigation, routes);
+
+  for (const redirect of config.redirects ?? []) {
+    const source = normalizePath(redirect.source);
+    const destination = normalizePath(redirect.destination);
+    routes.set(source, `${DOCS_ORIGIN}/docs${destination}`);
+  }
+
+  return routes;
+}
+
+export const ROOTLESS_DOC_REDIRECTS = buildRootlessDocsRedirects(
+  docsConfigJson as DocsConfigLike
+);
+
+export function getRootlessDocsDestination(pathname: string): string | null {
+  const path = normalizePath(pathname);
+  if (VERCEL_OWNED_DOC_PATHS.has(path)) return null;
+  return ROOTLESS_DOC_REDIRECTS.get(path) ?? null;
+}

--- a/src/config/docs-root-redirects.ts
+++ b/src/config/docs-root-redirects.ts
@@ -16,6 +16,7 @@ const VERCEL_OWNED_DOC_PATHS = new Set([
   '/contact',
   '/pricing',
   '/privacy',
+  '/sandbox',
   '/support',
   '/terms',
 ]);

--- a/src/config/docs-root-redirects.ts
+++ b/src/config/docs-root-redirects.ts
@@ -1,6 +1,9 @@
 import docsConfigJson from '../../docs/docs.json';
+import { WEB_APP_ORIGIN } from './web-origin';
 
-const DOCS_ORIGIN = 'https://www.worldmonitor.app';
+const docsOrigin = new URL(WEB_APP_ORIGIN);
+docsOrigin.hostname = `www.${docsOrigin.hostname}`;
+const DOCS_ORIGIN = docsOrigin.origin;
 
 type DocsConfigLike = {
   navigation?: unknown;

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -358,6 +358,7 @@ describe('crawlable content corpus deployment contracts', () => {
     assert.ok(vercelIgnoreSource.includes("'CHANGELOG.md'"));
     assert.ok(vercelIgnoreSource.includes("'docs/snapshots/'"));
     for (const path of [
+      'docs/docs.json',
       'scripts/crawlable-sources-page.mjs',
       'scripts/source-origin.mjs',
       'scripts/source-origin.d.mts',
@@ -369,7 +370,7 @@ describe('crawlable content corpus deployment contracts', () => {
     }
   });
 
-  it('builds Vercel on main and preview for script-only inventory derivation changes', () => {
+  it('builds Vercel on main and preview for generated web-input changes', () => {
     const fixture = mkdtempSync(join(tmpdir(), 'wm-vercel-ignore-'));
     try {
       const fixtureEnv = { ...process.env };
@@ -386,6 +387,7 @@ describe('crawlable content corpus deployment contracts', () => {
       git('commit', '-qm', 'base');
 
       for (const path of [
+        'docs/docs.json',
         'scripts/crawlable-sources-page.mjs',
         'scripts/source-origin.mjs',
         'scripts/source-origin.d.mts',

--- a/tests/docs-root-redirects.test.mts
+++ b/tests/docs-root-redirects.test.mts
@@ -67,6 +67,32 @@ describe('rootless Mintlify route canonicalization', () => {
     }
   });
 
+  it('defers SPA-reserved first segments that also appear in the docs map', () => {
+    const catchAll = vercelConfig.rewrites.find((rewrite) => (
+      rewrite.destination === '/dashboard.html' && rewrite.source.includes('(?!')
+    ));
+    assert.ok(catchAll, 'expected the SPA catch-all rewrite');
+    const lookaheadStart = catchAll.source.indexOf('(?!');
+    const lookaheadEnd = catchAll.source.lastIndexOf(').*)');
+    assert.ok(lookaheadStart >= 0 && lookaheadEnd > lookaheadStart, 'expected a negative-lookahead catch-all');
+    const reservedRoots = catchAll.source
+      .slice(lookaheadStart + 3, lookaheadEnd)
+      .split('|')
+      .filter((token) => /^[a-z][a-z0-9-]*$/.test(token))
+      .map((token) => `/${token}`);
+
+    assert.ok(reservedRoots.includes('/sandbox'), 'SPA catch-all must still reserve sandbox');
+    assert.ok(ROOTLESS_DOC_REDIRECTS.has('/sandbox'), 'docs still publishes sandbox; owned-path must keep deferring it');
+
+    for (const path of reservedRoots.filter((root) => ROOTLESS_DOC_REDIRECTS.has(root))) {
+      assert.equal(
+        getRootlessDocsDestination(path),
+        null,
+        `${path} is reserved by the SPA catch-all and must not 308 to /docs`
+      );
+    }
+  });
+
   it('redirects registered root and nested docs routes on every host', () => {
     for (const [host, path, expected] of [
       ['www.worldmonitor.app', '/api-brief', 'https://www.worldmonitor.app/docs/api-brief'],
@@ -85,12 +111,13 @@ describe('rootless Mintlify route canonicalization', () => {
   });
 
   it('does not intercept product routes, unknown routes, or non-read methods', () => {
-    for (const path of ['/pricing', '/changelog', '/country-intel']) {
+    for (const path of ['/pricing', '/changelog', '/country-intel', '/sandbox', '/sandbox/', '/sandbox/index.json']) {
       assert.equal(
         middleware(new Request(`https://www.worldmonitor.app${path}`, {
           headers: { host: 'www.worldmonitor.app', 'user-agent': 'Googlebot' },
         })),
-        undefined
+        undefined,
+        `${path} must keep the product sandbox/Vercel contract`
       );
     }
     assert.equal(

--- a/tests/docs-root-redirects.test.mts
+++ b/tests/docs-root-redirects.test.mts
@@ -1,0 +1,126 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import middleware, { config as middlewareConfig } from '../middleware.ts';
+import {
+  ROOTLESS_DOC_REDIRECTS,
+  buildRootlessDocsRedirects,
+  getRootlessDocsDestination,
+} from '../src/config/docs-root-redirects.ts';
+
+const vercelConfig = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, '../vercel.json'), 'utf8')
+) as {
+  redirects: Array<{ source: string; destination: string }>;
+  rewrites: Array<{ source: string; destination: string }>;
+};
+
+describe('rootless Mintlify route canonicalization', () => {
+  it('derives current and future routes from docs navigation and aliases', () => {
+    const routes = buildRootlessDocsRedirects({
+      navigation: {
+        tabs: [{
+          groups: [{
+            pages: [
+              'future-page',
+              { group: 'Nested', pages: ['future-section/future-page'] },
+            ],
+          }],
+        }],
+      },
+      redirects: [{ source: '/old-future-page', destination: '/future-page' }],
+    });
+
+    assert.equal(routes.get('/future-page'), 'https://www.worldmonitor.app/docs/future-page');
+    assert.equal(
+      routes.get('/future-section/future-page'),
+      'https://www.worldmonitor.app/docs/future-section/future-page'
+    );
+    assert.equal(routes.get('/old-future-page'), 'https://www.worldmonitor.app/docs/future-page');
+  });
+
+  it('covers every published string page in docs.json without a hand-maintained allowlist', () => {
+    for (const path of [
+      '/api-brief',
+      '/mcp-tools-reference',
+      '/architecture',
+      '/methodology/chokepoints',
+      '/panels/forecast',
+    ]) {
+      assert.ok(ROOTLESS_DOC_REDIRECTS.has(path), `missing generated docs route ${path}`);
+    }
+    assert.ok(ROOTLESS_DOC_REDIRECTS.size > 200, 'expected the complete Mintlify navigation, not a remediation list');
+  });
+
+  it('defers exact paths already owned by Vercel routes', () => {
+    const exactVercelPaths = [...vercelConfig.redirects, ...vercelConfig.rewrites]
+      .map((redirect) => redirect.source)
+      .filter((source) => /^\/[a-z0-9.-]+$/.test(source));
+
+    for (const path of exactVercelPaths.filter((source) => ROOTLESS_DOC_REDIRECTS.has(source))) {
+      assert.equal(
+        getRootlessDocsDestination(path),
+        null,
+        `${path} must preserve the earlier Vercel route contract`
+      );
+    }
+  });
+
+  it('redirects registered root and nested docs routes on every host', () => {
+    for (const [host, path, expected] of [
+      ['www.worldmonitor.app', '/api-brief', 'https://www.worldmonitor.app/docs/api-brief'],
+      ['happy.worldmonitor.app', '/mcp-tools-reference/', 'https://www.worldmonitor.app/docs/mcp-tools-reference'],
+      ['api.worldmonitor.app', '/architecture', 'https://www.worldmonitor.app/docs/architecture'],
+      ['finance.worldmonitor.app', '/methodology/chokepoints', 'https://www.worldmonitor.app/docs/methodology/chokepoints'],
+      ['commodity.worldmonitor.app', '/panels/forecast', 'https://www.worldmonitor.app/docs/panels/forecast'],
+    ] as const) {
+      const response = middleware(new Request(`https://${host}${path}?source=gsc`, {
+        headers: { host, 'user-agent': 'Googlebot' },
+      }));
+      assert.ok(response instanceof Response, `${host}${path} must return a redirect`);
+      assert.equal(response.status, 308);
+      assert.equal(response.headers.get('location'), `${expected}?source=gsc`);
+    }
+  });
+
+  it('does not intercept product routes, unknown routes, or non-read methods', () => {
+    for (const path of ['/pricing', '/changelog', '/country-intel']) {
+      assert.equal(
+        middleware(new Request(`https://www.worldmonitor.app${path}`, {
+          headers: { host: 'www.worldmonitor.app', 'user-agent': 'Googlebot' },
+        })),
+        undefined
+      );
+    }
+    assert.equal(
+      middleware(new Request('https://www.worldmonitor.app/api-brief', {
+        method: 'POST',
+        headers: { host: 'www.worldmonitor.app', 'user-agent': 'Mozilla/5.0' },
+      })),
+      undefined
+    );
+  });
+
+  it('matches future extensionless docs routes without intercepting static assets', () => {
+    const routeMatcher = middlewareConfig.matcher.find((matcher) => matcher.startsWith('/((?!'));
+    assert.ok(routeMatcher, 'expected a general extensionless-route middleware matcher');
+    const routeRegex = new RegExp(`^${routeMatcher}$`);
+
+    for (const path of [
+      '/',
+      '/api-brief',
+      '/architecture',
+      '/future-section/future-page',
+      '/methodology/chokepoints',
+      '/panels/forecast',
+    ]) {
+      assert.match(path, routeRegex, `middleware must inspect extensionless route ${path}`);
+    }
+    for (const path of ['/api/health', '/mcp', '/assets/app.js', '/docs/chunk.css']) {
+      assert.doesNotMatch(path, routeRegex, `general matcher must leave ${path} to its dedicated route`);
+    }
+    assert.ok(middlewareConfig.matcher.includes('/api/:path*'));
+    assert.ok(middlewareConfig.matcher.includes('/mcp'));
+  });
+});


### PR DESCRIPTION
## Summary

Googlebot requests for rootless documentation URLs such as `/api-brief` and `/mcp-tools-reference` now receive a permanent redirect to their canonical `/docs/*` pages instead of a 404.

The redirect registry is generated from the published Mintlify navigation and aliases at build time. New documentation pages therefore inherit the protection without another hand-maintained redirect list. Exact product routes remain owned by Vercel, unknown paths remain true 404s, and non-read requests are not redirected.

The supplied Search Console export contains 41 URLs in this rootless-docs family. The generated registry currently covers 250 published routes and aliases. The 117 obsolete hashed asset URLs in the export intentionally remain 404s to avoid creating soft-404 noise; the 304 `/api-reference/*` rows are covered by the existing canonical redirect.

Related: #6832

## Validation

- `npx tsx --test tests/deploy-config.test.mjs tests/docs-root-redirects.test.mts` — 222 tests passed.
- The pre-push gate passed browser and API type checks, boundary checks, and 253 changed-file tests.
- The middleware-specific TypeScript check, shell syntax check, and scoped lint completed successfully.
- A production-style middleware bundle completed at 22.4 KB minified.

## Post-deploy monitoring and validation

- Immediately probe representative root and nested routes on `www`, variant, and `api` hosts. Healthy behavior is `308` with a `Location` on `https://www.worldmonitor.app/docs/*`, followed by a `200` canonical page.
- Check Vercel request logs for `/api-brief`, `/mcp-tools-reference`, and `/methodology/chokepoints`. Treat any remaining 404, redirect loop, middleware 5xx, or material latency increase as a failure.
- Confirm `/pricing`, `/changelog`, unknown product paths, static assets, and API POST requests keep their current behavior.
- Watch Search Console over the next 2–4 weeks. The affected URLs should move from **Not found (404)** to **Page with redirect** as Google recrawls them.
- Roll back if product routes are intercepted or middleware errors/latency increase. WorldMonitor maintainers own the immediate probes and the Search Console follow-up.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
