### PR TITLE
fix(consumer-prices): route kroger_us through Exa, give pao_de_acucar_br a render wait

### DIFF
--- a/consumer-prices-core/configs/retailers/kroger_us.yaml
+++ b/consumer-prices-core/configs/retailers/kroger_us.yaml
@@ -11,6 +11,20 @@ retailer:
     numResults: 5
     urlPathContains: /p/
     queryTemplate: "{canonicalName} grocery {market} price"
+    # kroger.com blocks Firecrawl outright: /v1/scrape answers HTTP 500 on every
+    # candidate, and the consecutive errors then trip the provider cooldown, so
+    # the production failure list reads mostly provider-cooldown — an echo of
+    # the 500s rather than a separate fault. 0/12 pages, dragging US to a 0.375
+    # completion ratio (COVERAGE_DEGRADED, #6841).
+    #
+    # Exa reaches the same pages. Probed live 2026-08-17, twice 60s apart so a
+    # transient engine outage could not be mistaken for a standing block:
+    #   firecrawl -> HTTP 500 on all three urls, both passes
+    #   exa       -> "Hiland Dairy Whole Milk" $7.49, real page titles
+    # So this is a routing gap, not an unscrapeable retailer: without an
+    # explicit fallback the adapter only ever tries Firecrawl
+    # (search.ts pushes 'exa' solely when this is set).
+    extractionFallback: exa
 
   rateLimit:
     requestsPerMinute: 15

--- a/consumer-prices-core/configs/retailers/pao_de_acucar_br.yaml
+++ b/consumer-prices-core/configs/retailers/pao_de_acucar_br.yaml
@@ -17,6 +17,26 @@ retailer:
     maxExtractionCandidates: 4
     urlPathContains: /produto/
     queryTemplate: "{canonicalName} supermercado Brasil {currency} preço"
+    # This storefront hydrates product data late, the same shape carrefour_sa
+    # documents. At the default settle Firecrawl returns a shell and extracts
+    # productName AND price as null — not a price-selector miss but an empty
+    # page — which surfaced as missing-price on 11/11 items and dragged BR to a
+    # 0.45 completion ratio (COVERAGE_DEGRADED, #6841).
+    #
+    # Probed live 2026-08-17 on two product URLs:
+    #   waitFor=0      -> {"productName":null,"price":null}
+    #   waitFor=8000   -> "Leite Pasteurizado ... Xandô Garrafa 1l"  R$ 9.49
+    #   waitFor=15000  -> identical
+    #
+    # Necessary but NOT sufficient: the full basket goes 0/11 -> 3/11, so 8 items
+    # still miss. A 15000 comparison run scored 2/11 — do not read that as 8000
+    # being better. This retailer's draws are unstable (see above), so a 3-vs-2
+    # difference across single runs is inside that variance. 8000 is kept as the
+    # cheaper settle with no evidence the longer one helps; the remaining
+    # failures are tracked in #6841 and are more likely discovery or basket
+    # matching than hydration (a 15000 run matched Água Mineral to a 12-pack at
+    # R$44.28 instead of the single 1,5L bottle at R$2.89).
+    renderWaitMs: 8000
 
   rateLimit:
     requestsPerMinute: 10


### PR DESCRIPTION
Two consumer-price retailers are returning **zero** usable pages, dragging both markets below the 0.5 completion floor:

```
consumerPricesCoverageUS  COVERAGE_DEGRADED  completionRatio 0.375
  kroger_us    0/12 pages   provider-cooldown × 6, provider-error × 6
  walmart_us   9/12 pages   partial

consumerPricesCoverageBR  COVERAGE_DEGRADED  completionRatio 0.4545
  pao_de_acucar_br  0/11 pages   missing-price × 11
  carrefour_br     10/11 pages   partial
```

Both surfaced between 2026-08-16 17:07 and 2026-08-17 04:49. Unrelated to the rollout-config pruning in #6793 — that only removed dead softening; these are genuine scraper faults that would have shown regardless.

Diagnosed with the repo's own `src/adapters/extraction.diag.ts`, which drives the real `SearchAdapter`, plus per-URL probes that bypass the cooldown gate.

## kroger_us — a routing gap, not an unscrapeable retailer. FIXED.

The production failure list reads mostly `provider-cooldown`, which is an **echo**: consecutive Firecrawl errors trip the gate, so most candidates never reach the site. The real signal is underneath:

```
firecrawl:provider-error(Firecrawl extract failed: HTTP 500)
```

Probed per-URL with no gate, twice 60 s apart so a transient engine outage could not be mistaken for a standing block:

| route | result |
|---|---|
| Firecrawl | **HTTP 500 on all 3 urls, both passes** |
| Exa | `"Hiland Dairy Whole Milk"` **$7.49** — real page titles, real prices |

Exa reaches the pages Firecrawl cannot. The adapter only adds Exa when `extractionFallback: exa` is set (`search.ts:435`); `kroger_us` never set it, so it defaulted to `none` and only ever tried the blocked route.

**Fix:** `extractionFallback: exa`. Verified with the full diagnostic — **0/12 → 12/12**, every basket item with a real Kroger product name and price.

## pao_de_acucar_br — late hydration. PARTIALLY fixed.

Firecrawl returned `{"productName": null, "price": null}` **without throwing**, and with zero rendered content. `productName: null` is the discriminator: a price-selector break would still yield a title. Getting nothing means the page was never delivered — and because Firecrawl did not throw, it was a shell rather than a refusal.

Same shape `carrefour_sa` documents ("MAF storefronts hydrate product data late… 2.2KB breadcrumb shell… missing-price on every candidate"). Probed live on two product URLs:

```
waitFor=0      -> {"productName":null,"price":null}
waitFor=8000   -> "Leite Pasteurizado Tipo A Integral Xandô Garrafa 1l"  R$ 9.49
waitFor=15000  -> identical
```

**Fix applied:** `renderWaitMs: 8000` → **0/11 → 3/11**, with correct accented product names and plausible prices.

### Still open: 8 of 11 items remain `missing-price`

The render wait is necessary but not sufficient. A 15 s comparison run scored **2/11**, i.e. no better than 8 s and arguably worse — but this retailer's own config already documents that *"Exa's draws for this domain are unstable"* (store-flyer PDFs and marketing pages for 7 of 11 items on 2026-08-08, 4-5/5 live product pages minutes later). **A 3-vs-2 difference across single runs is within that known draw variance and should not be read as a signal.** 8000 is kept because it is the cheaper settle with no evidence the longer one helps.

Worth noting from the 15 s run: `Água Mineral 1.5L` matched a **12-pack at R$ 44.28** rather than the single 1.5 L bottle at R$ 2.89 — so some remaining failures may be basket-matching rather than extraction.

Next steps for this half, not yet done:
1. Determine whether the 8 failures are draw quality (wrong pages), hydration beyond 15 s, or genuine per-page price absence — run the diagnostic several times and see whether the failing set is stable or rotates.
2. If the failing set rotates, the fix is discovery (query template / `numResults` / `urlPathContains`), not the render wait.
3. `renderWaitMs` is schema-capped at 15 s, so anything slower than that needs a different acquisition route.

## Coverage impact

BR should clear the floor even at 3/11: `(10 + 3) / 22 = 0.59` against a 0.5 floor. US clears outright at `(9 + 12) / 24 = 0.875`. Both need confirming against `/api/health?compact=1` after the next scrape.

## Verification

Both verified with the repo's own `extraction.diag.ts`, which drives the real `SearchAdapter`, so the verdict is the one the seeder records:

```
kroger_us:         0/12 -> 12/12   every item, real product names and prices
pao_de_acucar_br:  0/11 ->  3/11   real accented names, plausible BRL prices
```

`consumer-prices-core` unit suite: **254 pass across 27 files**, including `config/loader.test.ts`, which parses both changed YAMLs. (`npm run validate` needs `DATABASE_URL` — it validates stored data, not config schema — so it was not run.)

## What I nearly got wrong

I was one step from retiring **both** retailers on the `tesco_gb` precedent (disable + replace). Probing the routes individually first is what prevented that:

- Kroger looked like a rate-limit problem from the health payload (`provider-cooldown × 6`). It was a hard 500 with the cooldown as an echo, and Exa could reach the pages the whole time.
- PDA looked unscrapeable — all fields null, zero rendered bytes, and a direct `curl` that had the site resetting the connection outright. It just needed an 8-second settle.

Retiring either would have removed a working retailer and left its market on a single source. `wholefoods_us` is already disabled for an unfixable reason (Amazon login), so the US bench is thinner than it looks.

## Post-Deploy Monitoring & Validation

**Watch after the next consumer-prices scrape (owner: me):**

- `/api/health?compact=1` — `consumerPricesCoverageUS` should leave `problems` (expected ratio `(9 + 12) / 24 = 0.875`). `consumerPricesCoverageBR` should also clear at `(10 + 3) / 22 = 0.59` against the 0.5 floor, but with far less margin.
- Per-retailer `coverage.retailers[]` is the real check: `kroger_us` should read `completionRatio` near 1.0, and `pao_de_acucar_br` should no longer read `0`.
- **Exa call volume** — Kroger now routes *every* extraction through Exa, since Firecrawl 500s on all of its pages. That is the intent, but it shifts cost onto the Exa quota; watch for `provider-error` appearing on the Exa side where Firecrawl's used to be.

**Failure signals:** BR falling back under 0.5 (only ~0.09 of headroom), or `kroger_us` showing Exa `provider-error` — which would mean the fallback is now the blocked route and the retailer genuinely has none left.
