### PR TITLE
fix(monitor): print the clock that actually fired on a STALE_CONTENT row

### DIFF
--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -82,6 +82,17 @@ export function findOperationalProblems(payload, now = Date.now()) {
       ...(Number.isFinite(problem?.maxStaleMin)
         ? { maxStaleMin: problem.maxStaleMin }
         : {}),
+      // The content clock, carried so the report can name the pair that
+      // actually fired. Without these a STALE_CONTENT line could only print
+      // the SEED pair, which is by definition inside budget for that status —
+      // the reader sees `age=1200m max=5760m` on a problem row and reasonably
+      // concludes the monitor is broken.
+      ...(Number.isFinite(problem?.contentAgeMin)
+        ? { contentAgeMin: problem.contentAgeMin }
+        : {}),
+      ...(Number.isFinite(problem?.maxContentAgeMin)
+        ? { maxContentAgeMin: problem.maxContentAgeMin }
+        : {}),
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -274,10 +285,36 @@ function readAcceptanceBaseline() {
   return JSON.parse(readFileSync(BASELINE_URL, 'utf8'));
 }
 
+/**
+ * Health runs TWO independent clocks and this line has to print the one that
+ * actually fired.
+ *
+ *   seed    seedAgeMin vs maxStaleMin        "is the seeder running"  -> STALE_SEED
+ *   content contentAgeMin vs maxContentAgeMin "is the data advancing"  -> STALE_CONTENT
+ *
+ * This printed the seed pair unconditionally, so every STALE_CONTENT line read
+ * as a contradiction: euFsi showed `age=1200m max=5760m` — comfortably inside
+ * budget — while the breach was contentAgeMin 19230 against maxContentAgeMin
+ * 14400. A reader can only conclude the monitor is wrong, and the numbers that
+ * would explain it are already on the wire and simply were not printed.
+ */
 function describeProblem(problem) {
-  const freshness = Number.isFinite(problem.seedAgeMin)
-    ? ` age=${problem.seedAgeMin}m max=${problem.maxStaleMin ?? 'unknown'}m`
-    : '';
+  // A content budget with no readable content age is its OWN failure mode:
+  // health scores `contentAgeMin == null` as stale (fail-closed), so the source
+  // is flagged because the clock could not be read, not because it ran out.
+  // jodiGas reads exactly this way. Printing the seed pair there reproduces the
+  // original bug on the other branch, so name the unreadable clock instead.
+  const contentClock = problem.status === 'STALE_CONTENT'
+    && Number.isFinite(problem.maxContentAgeMin);
+  const contentAge = Number.isFinite(problem.contentAgeMin)
+    ? `${problem.contentAgeMin}m`
+    : 'unknown (no dated item; scored stale)';
+  const freshness = contentClock
+    ? ` contentAge=${contentAge} maxContentAge=${problem.maxContentAgeMin}m`
+      + (Number.isFinite(problem.seedAgeMin) ? ` (seed age=${problem.seedAgeMin}m ok)` : '')
+    : Number.isFinite(problem.seedAgeMin)
+      ? ` age=${problem.seedAgeMin}m max=${problem.maxStaleMin ?? 'unknown'}m`
+      : '';
   return `${problem.name}: status=${problem.status} records=${problem.records ?? 'unknown'}${freshness}`;
 }
 

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -807,6 +807,76 @@ describe('scheduled seed freshness monitor', () => {
       ]);
     });
 
+    it('a STALE_CONTENT row prints the clock that fired, not the one that did not', () => {
+      // Health runs two independent clocks. STALE_CONTENT is decided by
+      // contentAgeMin vs maxContentAgeMin, but this line used to print the SEED
+      // pair unconditionally — which for that status is ALWAYS inside budget.
+      // Production read `euFsi: status=STALE_CONTENT age=1200m max=5760m`, so
+      // the only available conclusion was that the monitor was wrong. The
+      // numbers that explain it were on the wire and were being dropped by the
+      // projection before the formatter ever saw them.
+      const payload = {
+        status: 'DEGRADED',
+        checkedAt: '2026-08-17T10:00:00.000Z',
+        summary: { total: 1, ok: 0, warn: 1, crit: 0 },
+        problems: {
+          euFsi: {
+            status: 'STALE_CONTENT',
+            records: 252,
+            seedAgeMin: 1200,
+            maxStaleMin: 5760,
+            contentAgeMin: 19230,
+            maxContentAgeMin: 14400,
+          },
+        },
+      };
+      const [problem] = findOperationalProblems(payload);
+      assert.equal(problem.contentAgeMin, 19230, 'the projection must carry the content clock');
+      assert.equal(problem.maxContentAgeMin, 14400);
+
+      const report = formatAcceptanceReport(
+        baselineResult({ blocking: [problem] }),
+        '2026-08-17T10:00:00.000Z',
+      );
+      const line = report.errors.find((row) => row.includes('euFsi'));
+      assert.match(line, /contentAge=19230m maxContentAge=14400m/, 'the breached pair must be named');
+      assert.match(line, /seed age=1200m ok/, 'and the healthy clock marked as such, not omitted');
+      assert.doesNotMatch(
+        line,
+        /\bage=1200m max=5760m/,
+        'the bare seed pair must not be presented as the reason for a content breach',
+      );
+    });
+
+    it('names an UNREADABLE content clock rather than falling back to the seed pair', () => {
+      // health scores `contentAgeMin == null` as stale (fail-closed), so a source
+      // can be STALE_CONTENT because nothing in the payload carries a date at
+      // all. jodiGas reads exactly this way in production. Printing the seed
+      // pair here would reproduce the original bug on the other branch: the
+      // reader again sees a clock that is comfortably inside budget.
+      const problem = {
+        name: 'jodiGas',
+        status: 'STALE_CONTENT',
+        records: 57,
+        seedAgeMin: 8793,
+        maxStaleMin: 57600,
+        contentAgeMin: null,
+        maxContentAgeMin: 267840,
+      };
+      const report = formatAcceptanceReport(
+        baselineResult({ blocking: [problem] }),
+        '2026-08-17T10:00:00.000Z',
+      );
+      const line = report.errors.find((row) => row.includes('jodiGas'));
+      assert.match(line, /contentAge=unknown/, 'an unreadable clock must be named as unreadable');
+      assert.match(line, /scored stale/, 'and the fail-closed scoring made explicit');
+      assert.doesNotMatch(
+        line,
+        /\bage=8793m max=57600m/,
+        'the passing seed pair must not be offered as the reason',
+      );
+    });
+
     it('still reports the blocking problems on the run where the baseline expires', () => {
       const report = formatAcceptanceReport(
         baselineResult({ blocking: [blocked], expired: true, expiresAt: '2020-01-01' }),


### PR DESCRIPTION
## Problem

The seed freshness report printed the **seed** pair on every problem row. For a `STALE_CONTENT` source that pair is by definition inside budget, so the line argued against its own verdict:

```
- euFsi:      status=STALE_CONTENT records=252 age=1200m max=5760m
- statcanWds: status=STALE_CONTENT records=2   age=1497m max=4320m
```

1200 under 5760, 1497 under 4320, both flagged anyway. The only conclusion available to a reader is that the monitor is wrong. It isn't — health runs **two independent clocks**, and the report was printing the one that didn't fire:

| clock | compares | answers | status |
|---|---|---|---|
| seed | `seedAgeMin` vs `maxStaleMin` | is the seeder running | `STALE_SEED` |
| content | `contentAgeMin` vs `maxContentAgeMin` | is the data advancing | `STALE_CONTENT` |

The real breaches were `euFsi` 19230/14400 and `statcanWds` 111390/108000. Both numbers were already on the wire from `/api/health`.

## Root cause — two ends, not one

The formatter could not have printed the content pair even if it had asked for it. `findOperationalProblems` projected only `name`/`status`/`records`/`seedAgeMin`/`maxStaleMin` and dropped the content fields before the formatter ever saw them. Fixed at both ends: carry them through the projection, then select the pair by status.

## The null-content case

`health` scores `contentAgeMin == null` as stale — **fail-closed** — so a source can be `STALE_CONTENT` because nothing in its payload carries a date at all, not because the data is old. `jodiGas` and `lngVulnerability` read exactly this way in production. Printing their seed pair would reproduce the original bug on the other branch, so an unreadable clock is now named as unreadable.

## Verification

Live run against production, all four `STALE_CONTENT` sources:

```
euFsi:            contentAge=19327m  maxContentAge=14400m  (seed age=1266m ok)
statcanWds:       contentAge=111487m maxContentAge=108000m (seed age=1563m ok)
jodiGas:          contentAge=unknown (no dated item; scored stale) maxContentAge=267840m
lngVulnerability: contentAge=unknown (no dated item; scored stale) maxContentAge=267840m
```

Checked every `STALE_CONTENT` source in the live payload carries a finite `maxContentAgeMin`, so none falls back to the seed pair.

**Mutation-checked**, both tests:

- reverting the formatter to the seed-only line → **both** new tests fail
- dropping the projection carry (the actual original bug) → the projection assertion fails

`STALE_SEED` and `EMPTY` rows are unchanged; a test pins that the seed pair is still what a `STALE_SEED` row prints.

Suites: `seed-freshness-monitor`, `railway-deploy-convergence`, `activation-marker-unknown-state`, `railway-deploy-trigger-workflow` — **115 pass, 0 fail**. Biome clean.

## Scope

Reporting only. No threshold, verdict, or acknowledgement changes — the same sources block before and after.

## Found while fixing this

The corrected output surfaced two things worth separate follow-up, both **pre-existing** and neither addressed here:

1. `jodiGas` / `lngVulnerability` have **no dated item at all** (`contentAgeMin: null`), so they fail closed regardless of budget.
2. Their stored `maxContentAgeMin` is `267840m` = **186 d**, still the shared oil budget — the 230 d from #6802 has not reached the seed-meta row, since content budgets are persisted per-seed rather than read from code.
