### PR TITLE
[superseded] fix(energy): JODI 2026 filename rename + contentMeta accepts epoch ms

### DIFF
--- a/scripts/seed-jodi-oil.mjs
+++ b/scripts/seed-jodi-oil.mjs
@@ -367,14 +367,21 @@ export function jodiSourceYears(now = new Date()) {
 async function fetchAllRows() {
   const { currentYear, priorYear, lookbackYear } = jodiSourceYears();
 
+  // #6799: JODI renamed the current-year downloads — 2025 and earlier use
+  // `<year>.csv`, 2026+ uses `primaryyear<year>.csv` / `secondaryyear<year>.csv`.
+  // Try the new name first, fall back to the old one so prior years still work.
+  const fetchCurrentYear = kind =>
+    withRetry(() => fetchCsv(`${JODI_BASE}${kind}/${kind}year${currentYear}.csv`), 2, 2000)
+      .then(csv => csv || Promise.reject(new Error('empty')))
+      .catch(() => withRetry(() => fetchCsv(`${JODI_BASE}${kind}/${currentYear}.csv`), 2, 2000))
+      .catch(e => { console.warn(`  ${kind}/${currentYear}.csv failed (tried both names): ${e.message}`); return ''; });
+
   const [primaryCurrent, primaryPrior, secondaryCurrent, secondaryPrior, secondaryLookback] =
     await Promise.all([
-      withRetry(() => fetchCsv(`${JODI_BASE}primary/${currentYear}.csv`), 2, 2000)
-        .catch(e => { console.warn(`  primary/${currentYear}.csv failed: ${e.message}`); return ''; }),
+      fetchCurrentYear('primary'),
       withRetry(() => fetchCsv(`${JODI_BASE}primary/${priorYear}.csv`), 2, 2000)
         .catch(e => { console.warn(`  primary/${priorYear}.csv failed: ${e.message}`); return ''; }),
-      withRetry(() => fetchCsv(`${JODI_BASE}secondary/${currentYear}.csv`), 2, 2000)
-        .catch(e => { console.warn(`  secondary/${currentYear}.csv failed: ${e.message}`); return ''; }),
+      fetchCurrentYear('secondary'),
       withRetry(() => fetchCsv(`${JODI_BASE}secondary/${priorYear}.csv`), 2, 2000)
         .catch(e => { console.warn(`  secondary/${priorYear}.csv failed: ${e.message}`); return ''; }),
       // Optional: its absence only withholds the demand change, never the seed.

--- a/scripts/shared/jodi-content-age.mjs
+++ b/scripts/shared/jodi-content-age.mjs
@@ -57,8 +57,10 @@ export function assessChinaJodiCoverage(records, now, hasMeasurements) {
   }
 
   const sourceMonth = monthIndex(china.dataMonth);
-  const currentMonth = now instanceof Date && Number.isFinite(now.getTime())
-    ? now.getUTCFullYear() * 12 + now.getUTCMonth()
+  // #6799: accept both Date and epoch-ms (runSeed's hook passes a number).
+  const nowDate = now instanceof Date ? now : typeof now === 'number' && Number.isFinite(now) ? new Date(now) : null;
+  const currentMonth = nowDate && Number.isFinite(nowDate.getTime())
+    ? nowDate.getUTCFullYear() * 12 + nowDate.getUTCMonth()
     : null;
   if (sourceMonth == null || currentMonth == null || sourceMonth > currentMonth) {
     return { ok: false, reason: 'china-invalid-month', dataMonth: china.dataMonth ?? null, ageMonths: null };
@@ -123,7 +125,13 @@ export function jodiDatasetContentMeta(
   minCountries = MIN_JODI_CONTENT_AGE_COUNTRIES,
 ) {
   if (!Array.isArray(records)) return null;
-  const nowMs = now instanceof Date && Number.isFinite(now.getTime()) ? now.getTime() : null;
+  // #6799: runSeed's contentMeta hook passes epoch milliseconds (a number),
+  // not a Date. Accept both so the hook works — previously `instanceof Date`
+  // rejected the number unconditionally and contentMeta always returned null.
+  const nowMs =
+    now instanceof Date ? (Number.isFinite(now.getTime()) ? now.getTime() : null)
+    : typeof now === 'number' && Number.isFinite(now) ? now
+    : null;
   if (nowMs === null) return null;
 
   /** @type {Map<number, number>} */


### PR DESCRIPTION
Fixes both defects from #6799.

1. **jodiOil filename**: JODI renamed 2026+ downloads from `<year>.csv` to `primaryyear<year>.csv` / `secondaryyear<year>.csv`. The fetch now tries the new name first, falls back to the old one so prior years still work.

2. **jodiGas contentMeta**: runSeed passes epoch ms (a number) but jodiDatasetContentMeta required `instanceof Date`, so it always returned null — permanent STALE_CONTENT. Both instanceof Date guards now accept epoch ms too.