### PR TITLE
fix(prepush): bound concurrent heavy gates

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -48,12 +48,6 @@ node scripts/check-vite-env-secrets.mjs || exit 1
 
 export npm_config_cache="${npm_config_cache:-/tmp/worldmonitor-npm-cache}"
 
-# Ensure dependencies are installed (worktrees start with no node_modules)
-if [ ! -d node_modules ]; then
-  echo "node_modules missing, running npm ci..."
-  npm ci --cache "$npm_config_cache" || exit 1
-fi
-
 echo "Checking PR status for current branch..."
 BRANCH=$(git branch --show-current)
 if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; then
@@ -150,7 +144,17 @@ CHANGED_LIVE_NUL=$(mktemp "$TEMP_ROOT/wm-prepush-changed-live.XXXXXX") || exit 1
 NODE_TESTS_NUL=$(mktemp "$TEMP_ROOT/wm-prepush-node-tests.XXXXXX") || exit 1
 DOM_TESTS_NUL=$(mktemp "$TEMP_ROOT/wm-prepush-dom-tests.XXXXXX") || exit 1
 WORKTREE_NUL=$(mktemp "$TEMP_ROOT/wm-prepush-worktree.XXXXXX") || exit 1
-trap 'rm -f "$CHANGED_NUL" "$CHANGED_LIVE_NUL" "$NODE_TESTS_NUL" "$DOM_TESTS_NUL" "$WORKTREE_NUL"' EXIT
+PREPUSH_COMMON_DIR=""
+PREPUSH_ADMISSION_LEASE=""
+cleanup_prepush() {
+  rm -f "$CHANGED_NUL" "$CHANGED_LIVE_NUL" "$NODE_TESTS_NUL" "$DOM_TESTS_NUL" "$WORKTREE_NUL"
+  if [ -n "$PREPUSH_ADMISSION_LEASE" ] && [ -n "$PREPUSH_COMMON_DIR" ]; then
+    node scripts/prepush-admission.mjs release "$PREPUSH_COMMON_DIR" "$PREPUSH_ADMISSION_LEASE" >/dev/null || {
+      echo "WARNING: could not release the pre-push admission slot; stale recovery will reclaim it." >&2
+    }
+  fi
+}
+trap cleanup_prepush EXIT
 
 # read_paths: NUL stdin -> the _collected array (bash 3.2 has no namerefs, so
 # callers copy it out immediately).
@@ -309,6 +313,37 @@ else
   echo "Could not compare the worktree against HEAD (status $DIRTY_STATUS) — this run will not be cached."
 fi
 
+# Bound only local hook runners. CI invokes the npm scripts directly without
+# these variables and retains its normal full-width worker count.
+WM_PREPUSH_TEST_CONCURRENCY="${WM_PREPUSH_TEST_CONCURRENCY:-2}"
+case "$WM_PREPUSH_TEST_CONCURRENCY" in
+  '' | 0 | *[!0-9]*)
+    echo "ERROR: WM_PREPUSH_TEST_CONCURRENCY must be a positive integer."
+    exit 1
+    ;;
+esac
+export WM_PREPUSH_TEST_CONCURRENCY
+export VITEST_MAX_THREADS="${VITEST_MAX_THREADS:-$WM_PREPUSH_TEST_CONCURRENCY}"
+
+# The checks below are the expensive phase. Every linked worktree resolves the
+# same Git common directory, so two pushes may run here while later pushes wait
+# instead of letting every hook fan out across every core at once. The helper
+# uses mkdir-owned slots because flock(1) is not installed by default on macOS;
+# token-owned release plus stale-owner recovery keeps crashes from wedging all
+# future pushes. Override only for a measured machine-specific need.
+PREPUSH_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+  echo "ERROR: could not resolve the Git common directory for pre-push admission."
+  exit 1
+}
+PREPUSH_ADMISSION_LEASE=$(node scripts/prepush-admission.mjs acquire "$PREPUSH_COMMON_DIR" "$$") || exit 1
+
+# A fresh worktree's install is part of the expensive phase too. Keep it under
+# the shared lease so several new worktrees cannot all run npm ci at once.
+if [ ! -d node_modules ]; then
+  echo "node_modules missing, running npm ci..."
+  npm ci --cache "$npm_config_cache" || exit 1
+fi
+
 if changed '^(src/|tests/|e2e/|middleware|index\.html|vite\.config|scripts/|types/)'; then
   echo "Running type check..."
   npm run typecheck || exit 1
@@ -464,8 +499,8 @@ DOM_TESTS_CHANGED=("${_collected[@]}")
 # assertions are absent exactly when the contract they pin is being rewritten.
 # Same convention as the invariant lints above, which each fire on their own
 # implementation script.
-if path_matches '^(\.husky/pre-push|scripts/prepush-changed-tests\.sh|scripts/prepush-attest\.sh|vitest\.dom\.config\.mts|package\.json)$'; then
-  for contract_test in tests/prepush-changed-tests.test.mjs tests/prepush-attest.test.mjs; do
+if path_matches '^(\.husky/pre-push|scripts/prepush-admission\.mjs|scripts/prepush-changed-tests\.sh|scripts/prepush-attest\.sh|vitest\.dom\.config\.mts|package\.json)$'; then
+  for contract_test in tests/prepush-admission.test.mjs tests/prepush-changed-tests.test.mjs tests/prepush-attest.test.mjs; do
     [ -f "$contract_test" ] || continue
     already_listed=false
     for listed in "${TESTS_CHANGED[@]}"; do
@@ -538,21 +573,21 @@ fi
 if [ "$RUN_ALL" != true ]; then
   if [ "$RUN_RESILIENCE" = true ]; then
     echo "Running resilience tests (resilience files changed)..."
-    timeout 120 npx tsx --test tests/resilience-*.test.mjs tests/resilience-*.test.mts || exit 1
+    timeout 120 npx tsx --test --test-concurrency="$WM_PREPUSH_TEST_CONCURRENCY" tests/resilience-*.test.mjs tests/resilience-*.test.mts || exit 1
   fi
   if [ "$RUN_SEED" = true ]; then
     echo "Running seed tests (scripts/ changed)..."
     if [ "${#SEED_TESTS[@]}" -gt 0 ]; then
       # Quoted expansion, not word-splitting: `tests/trade flows-seed.test.mjs`
       # is one argument, not two nonexistent ones.
-      timeout 120 npx tsx --test "${SEED_TESTS[@]}" || exit 1
+      timeout 120 npx tsx --test --test-concurrency="$WM_PREPUSH_TEST_CONCURRENCY" "${SEED_TESTS[@]}" || exit 1
     else
       echo "  No matching seed tests found, skipping."
     fi
   fi
   if [ "$RUN_SERVER" = true ]; then
     echo "Running server handler tests (server/ changed)..."
-    timeout 120 npx tsx --test "${SERVER_TESTS[@]}" || exit 1
+    timeout 120 npx tsx --test --test-concurrency="$WM_PREPUSH_TEST_CONCURRENCY" "${SERVER_TESTS[@]}" || exit 1
   fi
   if [ "$RUN_RESILIENCE" = false ] && [ "$RUN_SEED" = false ] && [ "$RUN_SERVER" = false ] \
     && [ "${#TESTS_CHANGED[@]}" -eq 0 ] && [ "${#DOM_TESTS_CHANGED[@]}" -eq 0 ]; then

--- a/scripts/prepush-admission.mjs
+++ b/scripts/prepush-admission.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+
+import { randomUUID } from 'node:crypto';
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+const DEFAULT_MAX_PARALLEL = 2;
+const DEFAULT_POLL_MS = 250;
+const DEFAULT_STALE_MS = 30_000;
+const DEFAULT_WAIT_MS = 12 * 60_000;
+
+function positiveInteger(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const value = Number(raw);
+  if (!/^[1-9]\d*$/.test(raw) || !Number.isSafeInteger(value)) {
+    throw new TypeError(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+function usage() {
+  console.error('usage: prepush-admission.mjs <acquire|release> <git-common-dir> [lease-or-owner-pid]');
+}
+
+function admissionRoot(commonDir) {
+  const canonicalCommonDir = realpathSync(resolve(commonDir));
+  const root = join(canonicalCommonDir, 'wm-prepush-admission');
+  mkdirSync(root, { mode: 0o700, recursive: true });
+  const stat = lstatSync(root);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) {
+    throw new Error(`Unsafe pre-push admission directory: ${root}`);
+  }
+  return root;
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === 'EPERM';
+  }
+}
+
+function readOwner(slotPath) {
+  const raw = readFileSync(join(slotPath, 'owner.json'), 'utf8');
+  try {
+    return { owner: JSON.parse(raw), raw };
+  } catch (error) {
+    error.ownerRaw = raw;
+    throw error;
+  }
+}
+
+function sameFile(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function quarantineOwnedSlot(slotPath, expectedRaw, expectedStat, reason) {
+  const quarantinePath = `${slotPath}.${reason}-${randomUUID()}`;
+  try {
+    renameSync(slotPath, quarantinePath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+
+  try {
+    const movedStat = lstatSync(quarantinePath);
+    let movedRaw = null;
+    try {
+      movedRaw = readFileSync(join(quarantinePath, 'owner.json'), 'utf8');
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+    if (!sameFile(expectedStat, movedStat) || movedRaw !== expectedRaw) {
+      try {
+        renameSync(quarantinePath, slotPath);
+        return false;
+      } catch {
+        // Fail closed. Never delete a lease whose identity changed, and never
+        // overwrite another owner that acquired the original slot path.
+      }
+      throw new Error(`Pre-push admission slot changed owner during ${reason}`);
+    }
+    rmSync(quarantinePath, { recursive: true });
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+function reclaimIfStale(slotPath, staleMs) {
+  let stat;
+  try {
+    stat = lstatSync(slotPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+
+  // Avoid parsing every live owner's record on every poll. Directory mtime is
+  // refreshed when owner.json is created, so a young slot cannot be stale.
+  if (Date.now() - stat.mtimeMs < staleMs) return false;
+
+  let ownerRecord;
+  try {
+    ownerRecord = readOwner(slotPath);
+  } catch (error) {
+    // A creator may be between mkdir and owner.json. Treat it as fresh until
+    // the directory itself exceeds the stale grace period.
+    if (error instanceof SyntaxError || error?.code === 'ENOENT' || error?.code === 'EISDIR') {
+      return quarantineOwnedSlot(slotPath, error.ownerRaw ?? null, stat, 'stale');
+    }
+    throw error;
+  }
+
+  const acquiredAt = Number(ownerRecord?.owner?.acquiredAt ?? stat.mtimeMs);
+  const ageMs = Date.now() - acquiredAt;
+  if (ageMs < staleMs) return false;
+  // Age alone cannot prove that a heavy phase ended. Reclaim only when its
+  // recorded process is gone, or the cap can be exceeded by a long push.
+  if (processIsAlive(Number(ownerRecord?.owner?.pid))) return false;
+
+  return quarantineOwnedSlot(slotPath, ownerRecord.raw, stat, 'stale');
+}
+
+function tryAcquire(root, settings) {
+  const { maxParallel, ownerPid, staleMs } = settings;
+  for (let slotNumber = 1; slotNumber <= maxParallel; slotNumber += 1) {
+    const slotPath = join(root, `slot-${slotNumber}`);
+    while (true) {
+      try {
+        mkdirSync(slotPath, { mode: 0o700 });
+      } catch (error) {
+        if (error?.code !== 'EEXIST') throw error;
+        if (reclaimIfStale(slotPath, staleMs)) continue;
+        break;
+      }
+
+      const createdStat = lstatSync(slotPath);
+      const token = randomUUID();
+      try {
+        writeFileSync(
+          join(slotPath, 'owner.json'),
+          `${JSON.stringify({ acquiredAt: Date.now(), pid: ownerPid, token })}\n`,
+          { flag: 'wx', mode: 0o600 },
+        );
+      } catch (error) {
+        let currentRaw = null;
+        try {
+          currentRaw = readFileSync(join(slotPath, 'owner.json'), 'utf8');
+        } catch (readError) {
+          if (readError?.code !== 'ENOENT') throw readError;
+        }
+        quarantineOwnedSlot(slotPath, currentRaw, createdStat, 'failed');
+        throw error;
+      }
+      return JSON.stringify({ slotPath, token });
+    }
+  }
+  return null;
+}
+
+async function acquire(root, ownerPid) {
+  const maxParallel = positiveInteger('WM_PREPUSH_ADMISSION_MAX', DEFAULT_MAX_PARALLEL);
+  const pollMs = positiveInteger('WM_PREPUSH_ADMISSION_POLL_MS', DEFAULT_POLL_MS);
+  const staleMs = positiveInteger('WM_PREPUSH_ADMISSION_STALE_MS', DEFAULT_STALE_MS);
+  const waitMs = positiveInteger('WM_PREPUSH_ADMISSION_WAIT_MS', DEFAULT_WAIT_MS);
+  const deadline = Date.now() + waitMs;
+  let announcedWait = false;
+  const settings = { maxParallel, ownerPid, staleMs };
+
+  while (true) {
+    const lease = tryAcquire(root, settings);
+    if (lease) return lease;
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for a pre-push heavy-phase slot after ${waitMs}ms`);
+    }
+    if (!announcedWait) {
+      console.error(`Pre-push heavy phase is busy (${maxParallel} active); waiting for a slot...`);
+      announcedWait = true;
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, pollMs));
+  }
+}
+
+function release(root, encodedLease) {
+  let lease;
+  try {
+    lease = JSON.parse(encodedLease);
+  } catch {
+    throw new TypeError('Invalid pre-push admission lease');
+  }
+
+  const slotPath = resolve(String(lease.slotPath ?? ''));
+  if (dirname(slotPath) !== root || !/^slot-[1-9]\d*$/.test(slotPath.slice(root.length + 1))) {
+    throw new Error('Pre-push admission lease escapes its root');
+  }
+
+  let ownerRecord;
+  let stat;
+  try {
+    stat = lstatSync(slotPath);
+    ownerRecord = readOwner(slotPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return;
+    throw error;
+  }
+  if (ownerRecord.owner.token !== lease.token) {
+    throw new Error('Pre-push admission lease does not own this slot');
+  }
+  quarantineOwnedSlot(slotPath, ownerRecord.raw, stat, 'released');
+}
+
+async function main() {
+  const [mode, commonDir, value] = process.argv.slice(2);
+  if (!['acquire', 'release'].includes(mode) || !commonDir || (mode === 'release' && !value)) {
+    usage();
+    process.exitCode = 2;
+    return;
+  }
+
+  let root;
+  try {
+    root = admissionRoot(commonDir);
+    if (mode === 'acquire') {
+      const ownerPid = value === undefined ? process.ppid : Number(value);
+      if (!Number.isInteger(ownerPid) || ownerPid <= 0) {
+        throw new TypeError('owner pid must be a positive integer');
+      }
+      console.log(await acquire(root, ownerPid));
+    } else {
+      release(root, value);
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = error instanceof TypeError ? 2 : 1;
+  }
+}
+
+await main();

--- a/scripts/prepush-admission.mjs
+++ b/scripts/prepush-admission.mjs
@@ -16,6 +16,12 @@ const DEFAULT_MAX_PARALLEL = 2;
 const DEFAULT_POLL_MS = 250;
 const DEFAULT_STALE_MS = 30_000;
 const DEFAULT_WAIT_MS = 12 * 60_000;
+const RECLAIM_LOCK = '.reclaim-lock';
+
+function retryableAcquireError(error) {
+  return error?.code === 'ENOENT'
+    || (error instanceof Error && error.message.includes('changed owner during'));
+}
 
 function positiveInteger(name, fallback) {
   const raw = process.env[name];
@@ -90,8 +96,9 @@ function quarantineOwnedSlot(slotPath, expectedRaw, expectedStat, reason) {
       } catch {
         // Fail closed. Never delete a lease whose identity changed, and never
         // overwrite another owner that acquired the original slot path.
+        // Leave the quarantine in place and let acquire retry the wait loop.
       }
-      throw new Error(`Pre-push admission slot changed owner during ${reason}`);
+      return false;
     }
     rmSync(quarantinePath, { recursive: true });
     return true;
@@ -136,6 +143,49 @@ function reclaimIfStale(slotPath, staleMs) {
   return quarantineOwnedSlot(slotPath, ownerRecord.raw, stat, 'stale');
 }
 
+function stealStaleLock(lockPath, staleMs) {
+  let stat;
+  try {
+    stat = lstatSync(lockPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return true;
+    throw error;
+  }
+  if (Date.now() - stat.mtimeMs < staleMs) return false;
+
+  const quarantinePath = `${lockPath}.stale-${randomUUID()}`;
+  try {
+    renameSync(lockPath, quarantinePath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') return true;
+    throw error;
+  }
+  rmSync(quarantinePath, { recursive: true, force: true });
+  return true;
+}
+
+function tryReclaimLock(root, staleMs) {
+  const lockPath = join(root, RECLAIM_LOCK);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      mkdirSync(lockPath, { mode: 0o700 });
+      return lockPath;
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+      if (!stealStaleLock(lockPath, staleMs)) return null;
+    }
+  }
+  return null;
+}
+
+function releaseReclaimLock(lockPath) {
+  try {
+    rmSync(lockPath, { recursive: true, force: true });
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+}
+
 function tryAcquire(root, settings) {
   const { maxParallel, ownerPid, staleMs } = settings;
   for (let slotNumber = 1; slotNumber <= maxParallel; slotNumber += 1) {
@@ -145,11 +195,25 @@ function tryAcquire(root, settings) {
         mkdirSync(slotPath, { mode: 0o700 });
       } catch (error) {
         if (error?.code !== 'EEXIST') throw error;
-        if (reclaimIfStale(slotPath, staleMs)) continue;
+        // One waiter at a time may quarantine a given slot. Concurrent reclaim
+        // of the same dead lease is what let a third owner occupy slot-N.
+        const lockPath = tryReclaimLock(root, staleMs);
+        if (!lockPath) break;
+        try {
+          if (reclaimIfStale(slotPath, staleMs)) continue;
+        } finally {
+          releaseReclaimLock(lockPath);
+        }
         break;
       }
 
-      const createdStat = lstatSync(slotPath);
+      let createdStat;
+      try {
+        createdStat = lstatSync(slotPath);
+      } catch (error) {
+        if (error?.code === 'ENOENT') continue;
+        throw error;
+      }
       const token = randomUUID();
       try {
         writeFileSync(
@@ -165,6 +229,7 @@ function tryAcquire(root, settings) {
           if (readError?.code !== 'ENOENT') throw readError;
         }
         quarantineOwnedSlot(slotPath, currentRaw, createdStat, 'failed');
+        if (retryableAcquireError(error)) continue;
         throw error;
       }
       return JSON.stringify({ slotPath, token });
@@ -183,7 +248,12 @@ async function acquire(root, ownerPid) {
   const settings = { maxParallel, ownerPid, staleMs };
 
   while (true) {
-    const lease = tryAcquire(root, settings);
+    let lease;
+    try {
+      lease = tryAcquire(root, settings);
+    } catch (error) {
+      if (!retryableAcquireError(error)) throw error;
+    }
     if (lease) return lease;
     if (Date.now() >= deadline) {
       throw new Error(`Timed out waiting for a pre-push heavy-phase slot after ${waitMs}ms`);

--- a/scripts/prepush-changed-tests.sh
+++ b/scripts/prepush-changed-tests.sh
@@ -48,6 +48,13 @@
 # the runner fails. An empty list is a no-op, not a failure.
 
 TEST_TIMEOUT="${WM_PREPUSH_TEST_TIMEOUT:-120}"
+TEST_CONCURRENCY="${WM_PREPUSH_TEST_CONCURRENCY:-2}"
+case "$TEST_CONCURRENCY" in
+  '' | 0 | *[!0-9]*)
+    echo "ERROR: WM_PREPUSH_TEST_CONCURRENCY must be a positive integer." >&2
+    exit 2
+    ;;
+esac
 
 mode="${1:-}"
 case "$mode" in
@@ -118,7 +125,7 @@ case "$mode" in
     echo "Running changed test files only..."
     # Quoted expansion, not word-splitting: a test path containing a space is
     # one argument, not two nonexistent ones.
-    timeout "$TEST_TIMEOUT" npx tsx --test "${selected[@]}" || exit 1
+    timeout "$TEST_TIMEOUT" npx tsx --test --test-concurrency="$TEST_CONCURRENCY" "${selected[@]}" || exit 1
     ;;
 
   run-dom)

--- a/tests/prepush-admission.test.mjs
+++ b/tests/prepush-admission.test.mjs
@@ -211,6 +211,61 @@ describe('pre-push heavy-phase admission', () => {
     release(dir, lease);
   });
 
+  test('concurrent stale reclaim does not abort waiters or exceed the cap', async () => {
+    const dir = commonDir();
+    const slot = join(dir, 'wm-prepush-admission', 'slot-1');
+    mkdirSync(slot, { recursive: true });
+    writeFileSync(
+      join(slot, 'owner.json'),
+      `${JSON.stringify({ acquiredAt: Date.now() - 60_000, pid: 999_999_999, token: 'crashed' })}\n`,
+    );
+    const staleTime = new Date(Date.now() - 60_000);
+    utimesSync(slot, staleTime, staleTime);
+
+    const env = {
+      ...process.env,
+      WM_PREPUSH_ADMISSION_MAX: '1',
+      WM_PREPUSH_ADMISSION_POLL_MS: '10',
+      WM_PREPUSH_ADMISSION_WAIT_MS: String(2_000),
+      WM_PREPUSH_ADMISSION_STALE_MS: '20',
+    };
+    const worker = join(dir, 'reclaim-worker.mjs');
+    writeFileSync(
+      worker,
+      `import { spawnSync } from 'node:child_process';\n` +
+        `const [script, commonDir] = process.argv.slice(2);\n` +
+        `const acquire = spawnSync(process.execPath, [script, 'acquire', commonDir], { encoding: 'utf8', env: process.env });\n` +
+        `if (acquire.status !== 0) { console.error(acquire.stderr); process.exit(acquire.status ?? 1); }\n` +
+        `await new Promise((resolve) => setTimeout(resolve, 80));\n` +
+        `const release = spawnSync(process.execPath, [script, 'release', commonDir, acquire.stdout.trim()], { encoding: 'utf8', env: process.env });\n` +
+        `if (release.status !== 0) { console.error(release.stderr); process.exit(release.status ?? 1); }\n`,
+    );
+    const children = Array.from({ length: 3 }, () => spawn(process.execPath, [worker, SCRIPT, dir], {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }));
+
+    let maxSlots = 0;
+    const sample = setInterval(() => {
+      maxSlots = Math.max(maxSlots, slots(dir).length);
+    }, 5);
+    const results = await Promise.all(children.map((child) => new Promise((resolveChild) => {
+      let stderr = '';
+      child.stderr.on('data', (chunk) => { stderr += chunk; });
+      child.on('close', (status) => resolveChild({ status, stderr }));
+    })));
+    clearInterval(sample);
+
+    assert.deepEqual(results.map(({ status }) => status), [0, 0, 0], JSON.stringify(results));
+    assert.equal(
+      results.some(({ stderr }) => stderr.includes('changed owner')),
+      false,
+      JSON.stringify(results),
+    );
+    assert.ok(maxSlots <= 1, `concurrent reclaim must not exceed the cap (saw ${maxSlots})`);
+    assert.deepEqual(slots(dir), []);
+  });
+
   test('never reclaims an old slot while its owner process is alive', () => {
     const dir = commonDir();
     const slot = join(dir, 'wm-prepush-admission', 'slot-1');

--- a/tests/prepush-admission.test.mjs
+++ b/tests/prepush-admission.test.mjs
@@ -1,0 +1,243 @@
+import { strict as assert } from 'node:assert';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { after, describe, test } from 'node:test';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const SCRIPT = join(REPO_ROOT, 'scripts', 'prepush-admission.mjs');
+const FIXTURES = [];
+const GIT_LOCAL_ENV_VARS = execFileSync('git', ['rev-parse', '--local-env-vars'], {
+  encoding: 'utf8',
+})
+  .trim()
+  .split('\n');
+
+function isolatedGitEnv() {
+  const env = { ...process.env };
+  for (const name of GIT_LOCAL_ENV_VARS) delete env[name];
+  return env;
+}
+
+after(() => {
+  for (const fixture of FIXTURES) rmSync(fixture, { recursive: true, force: true });
+});
+
+function commonDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'wm-prepush-admission-'));
+  FIXTURES.push(dir);
+  return dir;
+}
+
+function run(mode, dir, lease, env = {}) {
+  return spawnSync(process.execPath, [SCRIPT, mode, dir, ...(lease ? [lease] : [])], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      WM_PREPUSH_ADMISSION_MAX: '2',
+      WM_PREPUSH_ADMISSION_POLL_MS: '10',
+      WM_PREPUSH_ADMISSION_WAIT_MS: '80',
+      WM_PREPUSH_ADMISSION_STALE_MS: '20',
+      ...env,
+    },
+  });
+}
+
+function acquire(dir, env) {
+  const result = run('acquire', dir, null, env);
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim();
+}
+
+function release(dir, lease) {
+  const result = run('release', dir, lease);
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function slots(dir) {
+  const root = join(dir, 'wm-prepush-admission');
+  try {
+    return readdirSync(root).filter((entry) => /^slot-[1-9]\d*$/.test(entry));
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
+describe('pre-push heavy-phase admission', () => {
+  test('five linked worktrees never occupy more than two heavy-phase slots', async () => {
+    const dir = commonDir();
+    const repo = join(dir, 'repo');
+    const gitEnv = isolatedGitEnv();
+    mkdirSync(repo);
+    execFileSync('git', ['init', '--quiet', '--initial-branch=main', '.'], { cwd: repo, env: gitEnv });
+    execFileSync('git', ['config', 'user.email', 'prepush-admission@example.invalid'], { cwd: repo, env: gitEnv });
+    execFileSync('git', ['config', 'user.name', 'Prepush Admission Fixture'], { cwd: repo, env: gitEnv });
+    execFileSync('git', ['commit', '--quiet', '--allow-empty', '-m', 'base'], { cwd: repo, env: gitEnv });
+    const worktrees = Array.from({ length: 5 }, (_, index) => join(dir, `worktree-${index + 1}`));
+    for (const worktree of worktrees) {
+      execFileSync('git', ['worktree', 'add', '--quiet', '--detach', worktree, 'HEAD'], {
+        cwd: repo,
+        env: gitEnv,
+      });
+    }
+
+    const worker = join(dir, 'worker.mjs');
+    writeFileSync(
+      worker,
+      `import { execFileSync, spawnSync } from 'node:child_process';\n` +
+        `const [script] = process.argv.slice(2);\n` +
+        `const commonDir = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], { encoding: 'utf8' }).trim();\n` +
+        `const acquire = spawnSync(process.execPath, [script, 'acquire', commonDir], { encoding: 'utf8', env: process.env });\n` +
+        `if (acquire.status !== 0) { console.error(acquire.stderr); process.exit(acquire.status ?? 1); }\n` +
+        `await new Promise((resolve) => setTimeout(resolve, 120));\n` +
+        `const release = spawnSync(process.execPath, [script, 'release', commonDir, acquire.stdout.trim()], { encoding: 'utf8', env: process.env });\n` +
+        `if (release.status !== 0) { console.error(release.stderr); process.exit(release.status ?? 1); }\n`,
+    );
+
+    const env = {
+      ...gitEnv,
+      WM_PREPUSH_ADMISSION_MAX: '2',
+      WM_PREPUSH_ADMISSION_POLL_MS: '10',
+      WM_PREPUSH_ADMISSION_WAIT_MS: String(2_000),
+      WM_PREPUSH_ADMISSION_STALE_MS: '500',
+    };
+    const children = worktrees.map((worktree) => spawn(process.execPath, [worker, SCRIPT], {
+      cwd: worktree,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }));
+
+    let maxSlots = 0;
+    const sample = setInterval(() => {
+      maxSlots = Math.max(maxSlots, slots(join(repo, '.git')).length);
+    }, 5);
+    const results = await Promise.all(children.map((child) => new Promise((resolveChild) => {
+      let stderr = '';
+      child.stderr.on('data', (chunk) => { stderr += chunk; });
+      child.on('close', (status) => resolveChild({ status, stderr }));
+    })));
+    clearInterval(sample);
+
+    assert.deepEqual(results.map(({ status }) => status), [0, 0, 0, 0, 0], JSON.stringify(results));
+    assert.equal(maxSlots, 2, 'five callers must queue behind exactly two admission slots');
+    assert.deepEqual(slots(join(repo, '.git')), []);
+  });
+
+  test('admits only the configured number of hooks and queues the next one', () => {
+    const dir = commonDir();
+    const first = acquire(dir);
+    const second = acquire(dir);
+
+    assert.equal(slots(dir).length, 2);
+    const blocked = run('acquire', dir);
+    assert.notEqual(blocked.status, 0);
+    assert.match(blocked.stderr, /Timed out waiting for a pre-push heavy-phase slot/);
+
+    release(dir, first);
+    const replacement = acquire(dir);
+    assert.equal(slots(dir).length, 2);
+
+    release(dir, second);
+    release(dir, replacement);
+    assert.deepEqual(slots(dir), []);
+  });
+
+  test('a lease token cannot release another hook owner', () => {
+    const dir = commonDir();
+    const lease = acquire(dir);
+    const parsed = JSON.parse(lease);
+    const forged = JSON.stringify({ ...parsed, token: 'not-the-owner' });
+
+    const result = run('release', dir, forged);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /does not own/);
+    assert.equal(slots(dir).length, 1);
+
+    release(dir, lease);
+  });
+
+  test('reclaims a stale slot left by a crashed hook', () => {
+    const dir = commonDir();
+    const root = join(dir, 'wm-prepush-admission');
+    const slot = join(root, 'slot-1');
+    mkdirSync(slot, { recursive: true });
+    writeFileSync(
+      join(slot, 'owner.json'),
+      `${JSON.stringify({ acquiredAt: Date.now() - 60_000, pid: 999_999_999, token: 'crashed' })}\n`,
+    );
+    const staleTime = new Date(Date.now() - 60_000);
+    utimesSync(slot, staleTime, staleTime);
+
+    const lease = acquire(dir);
+    assert.equal(JSON.parse(lease).slotPath, realpathSync(slot));
+    assert.equal(slots(dir).length, 1);
+    release(dir, lease);
+  });
+
+  test('reclaims a stale mkdir left before its owner record was written', () => {
+    const dir = commonDir();
+    const slot = join(dir, 'wm-prepush-admission', 'slot-1');
+    mkdirSync(slot, { recursive: true });
+    const staleTime = new Date(Date.now() - 60_000);
+    utimesSync(slot, staleTime, staleTime);
+
+    const lease = acquire(dir, { WM_PREPUSH_ADMISSION_MAX: '1' });
+    assert.equal(JSON.parse(lease).slotPath, realpathSync(slot));
+    release(dir, lease);
+  });
+
+  test('reclaims a stale malformed owner record using its exact bytes', () => {
+    const dir = commonDir();
+    const slot = join(dir, 'wm-prepush-admission', 'slot-1');
+    mkdirSync(slot, { recursive: true });
+    writeFileSync(join(slot, 'owner.json'), '{"pid":');
+    const staleTime = new Date(Date.now() - 60_000);
+    utimesSync(slot, staleTime, staleTime);
+
+    const lease = acquire(dir, { WM_PREPUSH_ADMISSION_MAX: '1' });
+    assert.equal(JSON.parse(lease).slotPath, realpathSync(slot));
+    release(dir, lease);
+  });
+
+  test('never reclaims an old slot while its owner process is alive', () => {
+    const dir = commonDir();
+    const slot = join(dir, 'wm-prepush-admission', 'slot-1');
+    mkdirSync(slot, { recursive: true });
+    writeFileSync(
+      join(slot, 'owner.json'),
+      `${JSON.stringify({ acquiredAt: Date.now() - 3_600_000, pid: process.pid, token: 'live' })}\n`,
+    );
+    const staleTime = new Date(Date.now() - 3_600_000);
+    utimesSync(slot, staleTime, staleTime);
+
+    const result = run('acquire', dir, null, { WM_PREPUSH_ADMISSION_MAX: '1' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Timed out waiting for a pre-push heavy-phase slot/);
+    assert.equal(readFileSync(join(slot, 'owner.json'), 'utf8').includes('"token":"live"'), true);
+  });
+
+  test('rejects unsafe numeric configuration', () => {
+    const dir = commonDir();
+    const result = run('acquire', dir, null, { WM_PREPUSH_ADMISSION_MAX: 'all' });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /WM_PREPUSH_ADMISSION_MAX must be a positive integer/);
+
+    const unsafe = run('acquire', dir, null, {
+      WM_PREPUSH_ADMISSION_MAX: '999999999999999999999',
+    });
+    assert.equal(unsafe.status, 2);
+    assert.match(unsafe.stderr, /WM_PREPUSH_ADMISSION_MAX must be a positive integer/);
+  });
+});

--- a/tests/prepush-changed-tests.test.mjs
+++ b/tests/prepush-changed-tests.test.mjs
@@ -110,6 +110,25 @@ function partition(mode, { cwd, changed = CHANGED } = {}) {
   return out.split('\0').filter(Boolean);
 }
 
+function loadDomTestConfig(env = {}) {
+  const probe = join(fixtureDir('wm-dom-config-probe-'), 'probe.mts');
+  writeFileSync(
+    probe,
+    `const m = await import(${JSON.stringify(join(REPO_ROOT, 'vitest.dom.config.mts'))});\n` +
+      'console.log(JSON.stringify(m.default?.test ?? null));\n',
+  );
+  const childEnv = { ...process.env };
+  delete childEnv.VITEST_MAX_THREADS;
+  Object.assign(childEnv, env);
+  const out = execFileSync(join(REPO_ROOT, 'node_modules', '.bin', 'tsx'), [probe], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: childEnv,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  return JSON.parse(out.trim().split('\n').at(-1));
+}
+
 describe('pre-push changed-test partition', () => {
   const cwd = makeFixtureWorktree();
 
@@ -220,19 +239,8 @@ describe('partition stays in step with the vitest DOM project', () => {
   // Resolved in a CHILD process on purpose: importing it here would pull
   // vitest/config (~220MB RSS) into the shared `npm run test:data` runner,
   // which already OOMs at the tail of its ~390-file single-process run.
-  const include = (() => {
-    const probe = join(fixtureDir('wm-dom-config-probe-'), 'probe.mts');
-    writeFileSync(
-      probe,
-      `const m = await import(${JSON.stringify(join(REPO_ROOT, 'vitest.dom.config.mts'))});\n` +
-        'console.log(JSON.stringify(m.default?.test?.include ?? null));\n',
-    );
-    const out = execFileSync(join(REPO_ROOT, 'node_modules', '.bin', 'tsx'), [probe], {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-    });
-    return JSON.parse(out.trim().split('\n').at(-1));
-  })();
+  const defaultConfig = loadDomTestConfig();
+  const include = defaultConfig.include;
 
   test('every DOM include glob lives under the prefix the partition claims', () => {
     assert.ok(Array.isArray(include) && include.length > 0, 'DOM config must declare test.include');
@@ -277,6 +285,15 @@ describe('partition stays in step with the vitest DOM project', () => {
     const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
     assert.match(pkg.scripts['test:dom'], /vitest run --config vitest\.dom\.config\.mts/);
   });
+
+  test('the local hook can cap vitest workers without slowing CI by default', () => {
+    assert.equal(defaultConfig.maxWorkers, undefined);
+    assert.equal(loadDomTestConfig({ VITEST_MAX_THREADS: '2' }).maxWorkers, 2);
+    assert.throws(
+      () => loadDomTestConfig({ VITEST_MAX_THREADS: 'not-a-number' }),
+      /VITEST_MAX_THREADS must be a positive integer/,
+    );
+  });
 });
 
 describe('runner dispatch', () => {
@@ -285,7 +302,7 @@ describe('runner dispatch', () => {
   // green when `-n` becomes `-z` or `|| exit 1` is dropped, silently skipping
   // the suite. The decision now lives in the script, so these run it for real
   // against stubbed runners and assert what was invoked.
-  function runDispatch(mode, list, { stubExit = 0 } = {}) {
+  function runDispatch(mode, list, { stubExit = 0, concurrency } = {}) {
     const dir = fixtureDir('wm-prepush-dispatch-');
     const log = join(dir, 'invocations.log');
     for (const bin of ['npm', 'npx']) {
@@ -300,7 +317,11 @@ describe('runner dispatch', () => {
         cwd: REPO_ROOT,
         input: nulList(list),
         encoding: 'utf8',
-        env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+        env: {
+          ...process.env,
+          PATH: `${dir}:${process.env.PATH}`,
+          ...(concurrency ? { WM_PREPUSH_TEST_CONCURRENCY: concurrency } : {}),
+        },
       });
     } catch (err) {
       status = err.status;
@@ -335,7 +356,20 @@ describe('runner dispatch', () => {
     ]);
     assert.equal(status, 0);
     // Quoted expansion — the path with a space stays one argument.
-    assert.match(invocations, /^npx tsx --test tests\/handlers\.test\.mts tests\/a b\.test\.mjs$/);
+    assert.match(
+      invocations,
+      /^npx tsx --test --test-concurrency=2 tests\/handlers\.test\.mts tests\/a b\.test\.mjs$/,
+    );
+  });
+
+  test('changed node tests honor an explicit local worker cap', () => {
+    const { status, invocations } = runDispatch(
+      'run-node',
+      ['tests/handlers.test.mts'],
+      { concurrency: '3' },
+    );
+    assert.equal(status, 0);
+    assert.equal(invocations, 'npx tsx --test --test-concurrency=3 tests/handlers.test.mts');
   });
 
   test('an empty node list runs nothing and does not fail the push', () => {
@@ -407,6 +441,7 @@ describe('pre-push hook wiring', () => {
     // assertions absent exactly when the thing they pin was being rewritten.
     for (const path of [
       '\\.husky/pre-push',
+      'scripts/prepush-admission\\.mjs',
       'scripts/prepush-changed-tests\\.sh',
       'scripts/prepush-attest\\.sh',
       'vitest\\.dom\\.config\\.mts',
@@ -417,8 +452,26 @@ describe('pre-push hook wiring', () => {
         `pre-push must re-run the contract tests when ${path} changes`,
       );
     }
-    for (const testFile of ['tests/prepush-changed-tests.test.mjs', 'tests/prepush-attest.test.mjs']) {
+    for (const testFile of [
+      'tests/prepush-admission.test.mjs',
+      'tests/prepush-changed-tests.test.mjs',
+      'tests/prepush-attest.test.mjs',
+    ]) {
       assert.ok(hook.includes(testFile), `${testFile} must be in the contract-test list`);
     }
+  });
+
+  test('caps every direct node:test runner in the hook', () => {
+    const directRuns = hook
+      .split('\n')
+      .filter((line) => line.includes('npx tsx --test'));
+
+    assert.equal(directRuns.length, 3);
+    assert.ok(
+      directRuns.every((line) =>
+        line.includes('--test-concurrency="$WM_PREPUSH_TEST_CONCURRENCY"'),
+      ),
+      'every direct node:test runner must use the configured worker cap',
+    );
   });
 });

--- a/tests/prepush-changed-tests.test.mjs
+++ b/tests/prepush-changed-tests.test.mjs
@@ -474,4 +474,11 @@ describe('pre-push hook wiring', () => {
       'every direct node:test runner must use the configured worker cap',
     );
   });
+
+  test('exports VITEST_MAX_THREADS from the configured worker cap', () => {
+    assert.match(
+      hook,
+      /export VITEST_MAX_THREADS="\$\{VITEST_MAX_THREADS:-\$WM_PREPUSH_TEST_CONCURRENCY\}"/,
+    );
+  });
 });

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -319,7 +319,9 @@ describe('a poisoned shared hooksPath self-heals at push time (#6104)', () => {
 describe('a clean push runs the changed tests and attests the tree', () => {
   test('dispatches the changed test and caches HEAD^{tree}', () => {
     const fixture = makeFixture({ branchFiles: { 'tests/alpha.test.mjs': 'x\n' } });
-    const { status, stdout, invocations } = fixture.run();
+    const { status, stdout, invocations } = fixture.run({
+      WM_PREPUSH_STUB_REQUIRE_SLOT_FOR: 'npx tsx',
+    });
 
     assert.equal(status, 0, stdout);
     assert.deepEqual(tsxRuns(invocations), [
@@ -331,7 +333,10 @@ describe('a clean push runs the changed tests and attests the tree', () => {
 
   test('a heavy-phase failure still releases its admission slot', () => {
     const fixture = makeFixture({ branchFiles: { 'scripts/failing-change.mjs': 'x\n' } });
-    const { status } = fixture.run({ WM_PREPUSH_STUB_FAIL: 'npm run typecheck' });
+    const { status } = fixture.run({
+      WM_PREPUSH_STUB_FAIL: 'npm run typecheck',
+      WM_PREPUSH_STUB_REQUIRE_SLOT_FOR: 'npm run',
+    });
 
     assert.equal(status, 1);
     assert.deepEqual(admissionSlots(fixture.root), [], 'an || exit 1 path must not wedge later pushes');

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -16,7 +16,7 @@
 import { strict as assert } from 'node:assert';
 import { after, describe, test } from 'node:test';
 import { execFileSync } from 'node:child_process';
-import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -39,7 +39,13 @@ after(() => rmSync(WORK, { recursive: true, force: true }));
 // argument containing a space from two separate arguments.
 const STUB_BODY = (name, log) =>
   `#!/bin/sh\necho "== ${name}" >> ${JSON.stringify(log)}\n` +
-  `for a in "$@"; do echo ">$a" >> ${JSON.stringify(log)}; done\nexit 0\n`;
+  `for a in "$@"; do echo ">$a" >> ${JSON.stringify(log)}; done\n` +
+  `if [ "${'$'}{WM_PREPUSH_STUB_REQUIRE_SLOT_FOR:-}" = "${name} ${'$'}1" ]; then\n` +
+  `  common=$(/usr/bin/git rev-parse --path-format=absolute --git-common-dir) || exit 86\n` +
+  `  [ -d "${'$'}common/wm-prepush-admission/slot-1" ] || [ -d "${'$'}common/wm-prepush-admission/slot-2" ] || exit 86\n` +
+  `fi\n` +
+  `[ "${'$'}{WM_PREPUSH_STUB_FAIL:-}" = "${name} $*" ] && exit 1\n` +
+  `exit 0\n`;
 
 /**
  * Stubs live OUTSIDE the fixture repo: an untracked `stub-bin/` inside it would
@@ -51,7 +57,12 @@ function makeStubs(auxDir) {
   mkdirSync(bin, { recursive: true });
   for (const name of ['npm', 'npx', 'node', 'gh', 'make']) {
     const stub = join(bin, name);
-    writeFileSync(stub, STUB_BODY(name, log));
+    const realScriptDispatch = name === 'node'
+      ? `case "$1" in\n` +
+        `  scripts/prepush-admission.mjs|*/scripts/prepush-admission.mjs) exec ${JSON.stringify(process.execPath)} "$@" ;;\n` +
+        `esac\n`
+      : '';
+    writeFileSync(stub, STUB_BODY(name, log).replace('#!/bin/sh\n', `#!/bin/sh\n${realScriptDispatch}`));
     chmodSync(stub, 0o755);
   }
   return { bin, log };
@@ -73,7 +84,7 @@ function hookEnv(bin) {
 
 let fixtureCount = 0;
 /**
- * A repo carrying the real hook and the two scripts it delegates to, with
+ * A repo carrying the real hook and its delegated scripts, with
  * `refs/remotes/origin/main` at the base commit so branch scoping resolves.
  */
 function makeFixture({ branchFiles = {}, scriptsCjs = true, failAttestMode = null } = {}) {
@@ -87,7 +98,7 @@ function makeFixture({ branchFiles = {}, scriptsCjs = true, failAttestMode = nul
     mkdirSync(join(root, dir), { recursive: true });
   }
   copyFileSync(HOOK, join(root, '.husky', 'pre-push'));
-  for (const script of ['prepush-attest.sh', 'prepush-changed-tests.sh']) {
+  for (const script of ['prepush-admission.mjs', 'prepush-attest.sh', 'prepush-changed-tests.sh']) {
     copyFileSync(join(REPO_ROOT, 'scripts', script), join(root, 'scripts', script));
   }
   // Fault injection: make one attest mode fail while its siblings still work,
@@ -184,14 +195,15 @@ function pushWithPoisonedSharedHooksPath() {
   const env = hookEnv(bin);
   delete env.WM_ALLOW_FOREIGN_HOOKS;
 
-  // The identity repair must run the real bootstrap helper. Every later node
-  // call in the 500-line gate stays stubbed, as in makeFixture().
+  // Identity repair and admission must run their real helpers. Other node
+  // calls in the gate stay stubbed, as in makeFixture().
   const nodeStub = join(bin, 'node');
   writeFileSync(
     nodeStub,
     `#!/bin/sh\n` +
       `case "$1" in\n` +
       `  */scripts/bootstrap-worktree.mjs) exec ${JSON.stringify(process.execPath)} "$@" ;;\n` +
+      `  scripts/prepush-admission.mjs|*/scripts/prepush-admission.mjs) exec ${JSON.stringify(process.execPath)} "$@" ;;\n` +
       `esac\n` +
       STUB_BODY('node', log).replace('#!/bin/sh\n', ''),
   );
@@ -212,6 +224,7 @@ function pushWithPoisonedSharedHooksPath() {
   for (const script of [
     'bootstrap-worktree.mjs',
     'check-local-secret-dumps.mjs',
+    'prepush-admission.mjs',
     'prepush-attest.sh',
     'prepush-changed-tests.sh',
   ]) {
@@ -281,6 +294,16 @@ function tsxRuns(invocations) {
   return runs;
 }
 
+function admissionSlots(root) {
+  const admissionRoot = join(root, '.git', 'wm-prepush-admission');
+  try {
+    return readdirSync(admissionRoot).filter((entry) => /^slot-[1-9]\d*$/.test(entry));
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+}
+
 describe('a poisoned shared hooksPath self-heals at push time (#6104)', () => {
   test('repairs the shared value and runs this worktree hook in the same push', () => {
     const result = pushWithPoisonedSharedHooksPath();
@@ -299,8 +322,32 @@ describe('a clean push runs the changed tests and attests the tree', () => {
     const { status, stdout, invocations } = fixture.run();
 
     assert.equal(status, 0, stdout);
-    assert.deepEqual(tsxRuns(invocations), [['tsx', '--test', 'tests/alpha.test.mjs']]);
+    assert.deepEqual(tsxRuns(invocations), [
+      ['tsx', '--test', '--test-concurrency=2', 'tests/alpha.test.mjs'],
+    ]);
     assert.equal(fixture.cached(), fixture.tree(), 'a clean, resolved, green run is attestable');
+    assert.deepEqual(admissionSlots(fixture.root), [], 'EXIT cleanup releases the heavy-phase slot');
+  });
+
+  test('a heavy-phase failure still releases its admission slot', () => {
+    const fixture = makeFixture({ branchFiles: { 'scripts/failing-change.mjs': 'x\n' } });
+    const { status } = fixture.run({ WM_PREPUSH_STUB_FAIL: 'npm run typecheck' });
+
+    assert.equal(status, 1);
+    assert.deepEqual(admissionSlots(fixture.root), [], 'an || exit 1 path must not wedge later pushes');
+  });
+
+  test('a fresh worktree installs dependencies while holding an admission slot', () => {
+    const fixture = makeFixture({ branchFiles: { 'tests/alpha.test.mjs': 'x\n' } });
+    rmSync(join(fixture.root, 'node_modules'), { recursive: true });
+
+    const { status, stdout, invocations } = fixture.run({
+      WM_PREPUSH_STUB_REQUIRE_SLOT_FOR: 'npm ci',
+    });
+
+    assert.equal(status, 0, stdout);
+    assert.match(invocations, /== npm\n>ci\n/);
+    assert.deepEqual(admissionSlots(fixture.root), [], 'EXIT cleanup releases the install lease');
   });
 
   test('the second push of that tree skips the gates entirely', () => {
@@ -373,7 +420,9 @@ describe('worktree drift blocks the push (#5800 item 1)', () => {
 
     const { status, stdout, invocations } = fixture.run();
     assert.equal(status, 0, stdout);
-    assert.deepEqual(tsxRuns(invocations), [['tsx', '--test', 'tests/gamma.test.mjs']]);
+    assert.deepEqual(tsxRuns(invocations), [
+      ['tsx', '--test', '--test-concurrency=2', 'tests/gamma.test.mjs'],
+    ]);
     assert.match(stdout, /not byte-identical to HEAD/);
     assert.equal(fixture.cached(), null);
   });
@@ -405,7 +454,14 @@ describe('C-quoted and space-bearing paths still reach the runner (#5800 item 2)
     assert.equal(status, 0, stdout);
     assert.deepEqual(
       tsxRuns(invocations),
-      [['tsx', '--test', 'tests/back\\slash.test.mjs', 'tests/café.test.mjs', 'tests/with space.test.mjs']],
+      [[
+        'tsx',
+        '--test',
+        '--test-concurrency=2',
+        'tests/back\\slash.test.mjs',
+        'tests/café.test.mjs',
+        'tests/with space.test.mjs',
+      ]],
       'every path must arrive intact and as a single argument',
     );
   });

--- a/vitest.dom.config.mts
+++ b/vitest.dom.config.mts
@@ -1,6 +1,18 @@
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+function optionalPositiveInteger(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return undefined;
+  const value = Number(raw);
+  if (!/^[1-9]\d*$/.test(raw) || !Number.isSafeInteger(value)) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+const prepushMaxWorkers = optionalPositiveInteger('VITEST_MAX_THREADS');
+
 /**
  * DOM-behavioral test project (#5634).
  *
@@ -26,6 +38,9 @@ export default defineConfig({
   },
   test: {
     environment: 'happy-dom',
+    // Local pre-push exports this cap so several worktrees cannot each fan out
+    // to every core. CI leaves it unset and retains Vitest's full-width default.
+    ...(prepushMaxWorkers === undefined ? {} : { maxWorkers: prepushMaxWorkers }),
     // Both extensions on purpose: `tests/` is 573 `.test.mjs` to 416
     // `.test.mts`, so an `.mts`-only glob would silently never run a file a
     // contributor named after the repo's more common convention — the exact


### PR DESCRIPTION
## Summary

Concurrent pushes from linked worktrees now share a repository-wide two-slot heavy-phase budget instead of multiplying test workers until the machine becomes unresponsive. The budget also covers dependency installation in fresh worktrees, while each direct `node:test` path and local DOM test run receives a worker cap of two.

The admission lease uses the Git common directory, token- and inode-fenced cleanup, live-process checks, and stale malformed-record recovery. Cleanup runs through the hook's `EXIT` trap, including `|| exit 1` paths. CI retains its existing Vitest width because `VITEST_MAX_THREADS` is only set by the local hook or an explicit caller.

| Evidence | Before | After |
|---|---:|---:|
| Cross-worktree heavy phases | Unbounded | Maximum 2 across 5 linked worktrees |
| Historical push latency from the issue | 45.6s median / 216.5s slowest across 66 runs | Needs post-merge observation on equivalent real pushes |
| Five-worktree admission fixture | No equivalent guard | 0.60-0.68s for five 120ms lease workloads; all completed |

Fixes #6767.

## Validation

- The real pre-push hook passed during `git push`: 88 tests, 0 failures, with the new shared lease active.
- Focused hook and admission suite: 53 tests, 0 failures.
- macOS `/tmp` canonical-path probe: 8 tests, 0 failures.
- Full data suite: 24,382 tests; 24,376 passed, 6 skipped, 0 failed.
- DOM suite with `VITEST_MAX_THREADS=2`: 351 tests passed. The same suite also passed with the variable unset, proving the CI-default path remains uncapped.
- `npm run typecheck`, `npm run typecheck:api`, `npm run lint:boundaries`, shell syntax checks, Node syntax checks, and `git diff --check` passed.

## Post-Deploy Monitoring & Validation

This changes local Git hooks only; it does not change production runtime or require a deployment. Repository maintainers should watch the next five concurrent-worktree pushes, or seven days, whichever comes first.

- Expected: no more than two exact `wm-prepush-admission/slot-*` directories exist, queued hooks print the busy/waiting message, and every slot disappears after success or failure.
- Failure signals: admission timeouts during normal pushes, an exact slot left by a dead process beyond the stale grace period, or more than two heavy phases observed at once.
- Rollback: revert commit `194971339`; if immediate containment is needed while investigating, set `WM_PREPUSH_ADMISSION_MAX=1` for local pushes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
