### PR TITLE
fix(seeders): stop Military-Bases reserving the whole static-ref budget

### DIFF
--- a/scripts/seed-bundle-static-ref.mjs
+++ b/scripts/seed-bundle-static-ref.mjs
@@ -22,50 +22,10 @@ await runBundle('static-ref', [
   { label: 'Submarine-Cables', script: 'seed-submarine-cables.mjs', seedMetaKey: 'infrastructure:submarine-cables', canonicalKey: 'infrastructure:submarine-cables:v1', intervalMs: WEEK, timeoutMs: 90_000 },
   { label: 'Defense-Patents', script: 'seed-defense-patents.mjs', seedMetaKey: 'military:defense-patents', canonicalKey: 'patents:defense:latest', intervalMs: WEEK, timeoutMs: 180_000, requiredEnv: ['USPTO_API_KEY'] },
   { label: 'Chokepoint-Baselines', script: 'seed-chokepoint-baselines.mjs', seedMetaKey: 'energy:chokepoint-baselines', canonicalKey: 'energy:chokepoint-baselines:v1', intervalMs: 400 * DAY, timeoutMs: 60_000 },
-  // 300s, not 540s (#6806).
-  //
-  // The runtime admission test is `elapsedBundle + worstCase <= maxBundleMs`
-  // (_bundle-runner.mjs:543) — note it does NOT include ADMISSION_HEADROOM_MS,
-  // which guards only the static never-admittable check at line 218. So the
-  // bound this section has to clear is on ELAPSED time:
-  //   540s timeout -> 550s worst case -> admissible only while elapsed <=  20s
-  //   400s timeout -> 410s worst case -> admissible        while elapsed <= 160s
-  // At 20s admission was knife-edge: the bundle heartbeat write plus the
-  // freshness reads for the five sections ahead of this one (each bounded by
-  // REDIS_READ_TIMEOUT_MS) can exceed it on a slow tick, so the section was
-  // deferred for reasons that had nothing to do with the work it does.
-  //
-  // Most of the old reservation was not work. `seed-military-bases.mjs`
-  // published via `atomicSwitch` and THEN slept GRACE_PERIOD_MS before deleting
-  // the superseded version's keys — 300s of the 540s spent idle with the new
-  // data already live. That grace is now 30s, so the 540s reservation implied a
-  // real work budget of ~240s of seeding and validation.
-  //
-  // 400s, not 300s, because the slot has to cover more than that write loop:
-  //   ~240s  seed + validate (~1000 Upstash round trips at 125k records)
-  //   <=60s  R2 download when neither the volume nor the local file is present
-  //     ~5s  JSON.parse of the ~125k-entry file
-  //     30s  post-publish grace before the superseded keys are deleted
-  // which is ~335s on an R2-cold tick. Sizing to 300s would put SIGTERM before
-  // `atomicSwitch` on exactly that tick, and a run killed pre-publish leaks its
-  // half-written `military:bases:{geo,meta}:<version>` keys permanently —
-  // `cleanupOldVersion` only ever targets the version that is currently ACTIVE,
-  // so a version that never published is swept by nothing.
-  //
-  // What this does NOT do: the bundle stays oversubscribed (worst cases sum to
-  // ~1530s against 570s). On a tick where Arms-Suppliers runs, elapsed already
-  // exceeds 160s and this section still defers. The gain is (a) admission no
-  // longer turns on a 20s race it cannot influence, and (b) because
-  // `elapsedBundle` accrues ACTUAL runtime, a ~240s seed plus the 30s grace
-  // occupies ~270s and leaves ~300s for Mineral-Production (190s worst case) —
-  // the only section after this one in array order, and the one #6799 found
-  // with no key in Redis at all.
-  //
-  // Re-sizing input: the seeder publishes `durationMs` into
-  // `seed-meta:military:bases`, measured from the start of the run but NOT
-  // including the 30s grace — compare against `durationMs + GRACE_PERIOD_MS`.
-  // The repair path does not publish one, so the first real number arrives on
-  // the next full reseed, not on the next tick.
+  // timeoutMs 400_000 (~335s R2-cold work + 30s post-publish grace; was 540s
+  // mostly idle sleep after atomicSwitch — #6806). Sizing to 300s SIGTERMs
+  // pre-publish and leaks unpublished military:bases:{geo,meta}:<version> keys.
+  // Compare later measurements as seed-meta.durationMs + GRACE_PERIOD_MS.
   { label: 'Military-Bases', script: 'seed-military-bases.mjs', seedMetaKey: 'military:bases', intervalMs: 30 * DAY, timeoutMs: 400_000 },
   { label: 'Mineral-Production', script: 'seed-mineral-production.mjs', seedMetaKey: 'supply-chain:mineral-production', canonicalKey: 'supply-chain:mineral-production:v1', intervalMs: 60 * DAY, timeoutMs: 180_000 },
 ], { maxBundleMs: 570_000 });

--- a/scripts/seed-bundle-static-ref.mjs
+++ b/scripts/seed-bundle-static-ref.mjs
@@ -22,6 +22,50 @@ await runBundle('static-ref', [
   { label: 'Submarine-Cables', script: 'seed-submarine-cables.mjs', seedMetaKey: 'infrastructure:submarine-cables', canonicalKey: 'infrastructure:submarine-cables:v1', intervalMs: WEEK, timeoutMs: 90_000 },
   { label: 'Defense-Patents', script: 'seed-defense-patents.mjs', seedMetaKey: 'military:defense-patents', canonicalKey: 'patents:defense:latest', intervalMs: WEEK, timeoutMs: 180_000, requiredEnv: ['USPTO_API_KEY'] },
   { label: 'Chokepoint-Baselines', script: 'seed-chokepoint-baselines.mjs', seedMetaKey: 'energy:chokepoint-baselines', canonicalKey: 'energy:chokepoint-baselines:v1', intervalMs: 400 * DAY, timeoutMs: 60_000 },
-  { label: 'Military-Bases', script: 'seed-military-bases.mjs', seedMetaKey: 'military:bases', intervalMs: 30 * DAY, timeoutMs: 540_000 },
+  // 300s, not 540s (#6806).
+  //
+  // The runtime admission test is `elapsedBundle + worstCase <= maxBundleMs`
+  // (_bundle-runner.mjs:543) — note it does NOT include ADMISSION_HEADROOM_MS,
+  // which guards only the static never-admittable check at line 218. So the
+  // bound this section has to clear is on ELAPSED time:
+  //   540s timeout -> 550s worst case -> admissible only while elapsed <=  20s
+  //   400s timeout -> 410s worst case -> admissible        while elapsed <= 160s
+  // At 20s admission was knife-edge: the bundle heartbeat write plus the
+  // freshness reads for the five sections ahead of this one (each bounded by
+  // REDIS_READ_TIMEOUT_MS) can exceed it on a slow tick, so the section was
+  // deferred for reasons that had nothing to do with the work it does.
+  //
+  // Most of the old reservation was not work. `seed-military-bases.mjs`
+  // published via `atomicSwitch` and THEN slept GRACE_PERIOD_MS before deleting
+  // the superseded version's keys — 300s of the 540s spent idle with the new
+  // data already live. That grace is now 30s, so the 540s reservation implied a
+  // real work budget of ~240s of seeding and validation.
+  //
+  // 400s, not 300s, because the slot has to cover more than that write loop:
+  //   ~240s  seed + validate (~1000 Upstash round trips at 125k records)
+  //   <=60s  R2 download when neither the volume nor the local file is present
+  //     ~5s  JSON.parse of the ~125k-entry file
+  //     30s  post-publish grace before the superseded keys are deleted
+  // which is ~335s on an R2-cold tick. Sizing to 300s would put SIGTERM before
+  // `atomicSwitch` on exactly that tick, and a run killed pre-publish leaks its
+  // half-written `military:bases:{geo,meta}:<version>` keys permanently —
+  // `cleanupOldVersion` only ever targets the version that is currently ACTIVE,
+  // so a version that never published is swept by nothing.
+  //
+  // What this does NOT do: the bundle stays oversubscribed (worst cases sum to
+  // ~1530s against 570s). On a tick where Arms-Suppliers runs, elapsed already
+  // exceeds 160s and this section still defers. The gain is (a) admission no
+  // longer turns on a 20s race it cannot influence, and (b) because
+  // `elapsedBundle` accrues ACTUAL runtime, a ~240s seed plus the 30s grace
+  // occupies ~270s and leaves ~300s for Mineral-Production (190s worst case) —
+  // the only section after this one in array order, and the one #6799 found
+  // with no key in Redis at all.
+  //
+  // Re-sizing input: the seeder publishes `durationMs` into
+  // `seed-meta:military:bases`, measured from the start of the run but NOT
+  // including the 30s grace — compare against `durationMs + GRACE_PERIOD_MS`.
+  // The repair path does not publish one, so the first real number arrives on
+  // the next full reseed, not on the next tick.
+  { label: 'Military-Bases', script: 'seed-military-bases.mjs', seedMetaKey: 'military:bases', intervalMs: 30 * DAY, timeoutMs: 400_000 },
   { label: 'Mineral-Production', script: 'seed-mineral-production.mjs', seedMetaKey: 'supply-chain:mineral-production', canonicalKey: 'supply-chain:mineral-production:v1', intervalMs: 60 * DAY, timeoutMs: 180_000 },
 ], { maxBundleMs: 570_000 });

--- a/scripts/seed-military-bases.mjs
+++ b/scripts/seed-military-bases.mjs
@@ -378,6 +378,63 @@ export async function backfillSeedMetaFromActiveVersion(url, token, prefix, opts
   return { version, fetchedAt, recordCount };
 }
 
+function isRedisTransportError(err) {
+  if (!(err instanceof Error)) return false;
+  const message = err.message;
+  return (
+    message.startsWith('Redis command ')
+    || message.startsWith('Pipeline ')
+    || message.includes(' failed after ')
+  );
+}
+
+function isActiveVersionCasConflict(err) {
+  return err instanceof Error && err.message.startsWith('Active version changed during validation');
+}
+
+/**
+ * Cheap missing-marker repair. Returns `repaired` only when seed-meta was
+ * rewritten from a live active version; every other action means `main()`
+ * should continue into the file/R2 reseed path.
+ *
+ * A validate/data-shape failure on the published pointer must not abort the
+ * section: that used to fall through to a rewrite, and exiting 1 here would
+ * leave seed-meta absent so every later tick retries the same dead repair.
+ * A compare-and-swap miss means another writer already published — rethrow.
+ * Redis transport errors also rethrow; a 1,000-round-trip reseed would fail
+ * the same way.
+ */
+export async function maybeRepairMissingSeedMeta(url, token, prefix, { force = false } = {}) {
+  if (force) return { action: 'skipped-force' };
+
+  const seedMetaKey = `${prefix}seed-meta:military:bases`;
+  const existingSeedMeta = await commandRequest(url, token, ['GET', seedMetaKey]);
+  if (existingSeedMeta != null && existingSeedMeta !== '') {
+    return { action: 'skipped-present' };
+  }
+
+  const activeVersion = await commandRequest(url, token, [
+    'GET',
+    `${prefix}military:bases:active`,
+  ]);
+  if (!activeVersion) {
+    return { action: 'fallthrough-no-active' };
+  }
+
+  console.log(`${seedMetaKey} is missing while an active version (${activeVersion}) is published.`);
+  console.log('Restoring the freshness marker without reseeding...');
+  try {
+    const repaired = await backfillSeedMetaFromActiveVersion(url, token, prefix, { deep: false });
+    return { action: 'repaired', ...repaired };
+  } catch (err) {
+    if (isActiveVersionCasConflict(err) || isRedisTransportError(err)) throw err;
+    console.warn(
+      `Shallow repair failed (${err instanceof Error ? err.message : err}); falling through to reseed.`,
+    );
+    return { action: 'fallthrough-invalid-active' };
+  }
+}
+
 async function cleanupOldVersion(url, token, prefix, newVersion) {
   const activeKey = `${prefix}military:bases:active`;
   const getResult = await pipelineRequest(url, token, [['GET', activeKey]]);
@@ -417,35 +474,13 @@ async function main() {
   // size `timeoutMs` in seed-bundle-static-ref.mjs against it (#6806).
   const runStartedAt = Date.now();
 
-  // Repair the freshness marker before doing any reseed work (#6806).
-  //
-  // `seed-meta:military:bases` is this section's only freshness signal, so while
-  // it is absent `_bundle-runner.mjs` marks the section due on every daily tick
-  // rather than every 30 days. A full reseed is ~1,000 Redis round trips (251
-  // GEOADD + 251 HSET + ~500 validation pipelines, ~4 minutes). It fits the
-  // section's slot — that is what the 400s sizing buys — but re-entering it on
-  // every tick when a 3-call repair suffices is what starved the bundle.
-  // Restoring the marker from the already-published version is a handful of
-  // calls.
-  //
-  // Returning here costs at most one tick of reseed latency: the restored marker
-  // carries the ACTIVE version's own timestamp, so if that data really is past
-  // its interval the very next tick sees it as due and reseeds normally.
-  const seedMetaKey = `${prefix}seed-meta:military:bases`;
-  const existingSeedMeta = force
-    ? 'skipped'
-    : await commandRequest(redisUrl, redisToken, ['GET', seedMetaKey]);
-  if (existingSeedMeta == null || existingSeedMeta === '') {
-    const activeVersion = await commandRequest(redisUrl, redisToken, [
-      'GET',
-      `${prefix}military:bases:active`,
-    ]);
-    if (activeVersion) {
-      console.log(`${seedMetaKey} is missing while an active version (${activeVersion}) is published.`);
-      console.log('Restoring the freshness marker without reseeding...');
-      await backfillSeedMetaFromActiveVersion(redisUrl, redisToken, prefix, { deep: false });
-      return;
-    }
+  // Missing seed-meta with a live active version: restore the marker and stop.
+  // `--force`, a present marker, no active pointer, or a broken active corpus
+  // all fall through to the file/R2 reseed. A successful repair costs at most
+  // one tick if the restored timestamp is already past the 30-day interval.
+  const repair = await maybeRepairMissingSeedMeta(redisUrl, redisToken, prefix, { force });
+  if (repair.action === 'repaired') {
+    return;
   }
 
   const volumePath = '/data/military-bases-final.json';

--- a/scripts/seed-military-bases.mjs
+++ b/scripts/seed-military-bases.mjs
@@ -12,7 +12,18 @@ const R2_BUCKET_URL = 'https://api.cloudflare.com/client/v4/accounts/{acct}/r2/b
 const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
 const PROGRESS_INTERVAL = 5000;
-const GRACE_PERIOD_MS = 5 * 60 * 1000;
+// Window between publishing a new version and deleting the superseded one, so a
+// reader that resolved `military:bases:active` just before the switch can still
+// GET the old geo/meta keys.
+//
+// 30s, not 300s (#6806). This wait runs INSIDE the bundle section's slot but
+// AFTER `atomicSwitch` has already made the new version live, so every second of
+// it is budget the section reserves to do nothing. At 5 minutes it was 55% of
+// the 540s reservation, which is what made `Military-Bases` need 565s of
+// `seed-bundle-static-ref`'s 570s budget and starve every other due section.
+// The window it actually has to cover is one in-flight HTTP request, which is
+// seconds; 30s is an order of magnitude over that.
+export const GRACE_PERIOD_MS = 30 * 1000;
 const VALIDATION_BATCH_SIZE = 500;
 const USER_AGENT = 'worldmonitor-military-bases-seeder/1.0';
 
@@ -31,10 +42,14 @@ redis.call('SET', KEYS[2], ARGV[2])
 return {1, current}
 `.trim();
 
-function parseArgs() {
+export function parseArgs() {
   const args = process.argv.slice(2);
   let env = 'production';
   let sha = '';
+  // Bypass the missing-seed-meta repair short-circuit and reseed unconditionally.
+  // Without this an operator who runs the seeder by hand while the freshness
+  // marker is absent gets the cheap repair instead of the reseed they asked for.
+  let force = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--env' && args[i + 1]) {
@@ -45,6 +60,13 @@ function parseArgs() {
       env = args[i].split('=')[1];
     } else if (args[i].startsWith('--sha=')) {
       sha = args[i].split('=')[1];
+    } else if (args[i] === '--force' || args[i] === '--force=true') {
+      force = true;
+    } else if (args[i].startsWith('--force=')) {
+      // `--env=`/`--sha=` accept the `=` form, so an operator reaching for
+      // `--force=1` must not silently get the repair path instead of the reseed
+      // they asked for. Anything other than an explicit false-y value enables it.
+      force = !['false', '0', 'no'].includes(args[i].split('=')[1].toLowerCase());
     }
   }
 
@@ -58,7 +80,7 @@ function parseArgs() {
     sha = 'dev';
   }
 
-  return { env, sha };
+  return { env, sha, force };
 }
 
 function getKeyPrefix(env, sha) {
@@ -177,7 +199,15 @@ async function seedMeta(url, token, metaKey, entries) {
   return seeded;
 }
 
-async function validate(url, token, prefix, version, expectedCount) {
+/**
+ * @param {{ deep?: boolean }} [opts] `deep: false` stops after the ZCARD/HLEN
+ *   agreement check and skips the per-member walk. The walk costs one round
+ *   trip per 500 records (~250 for the current corpus), which is affordable
+ *   once per real reseed but not for the cheap seed-meta repair path, which has
+ *   to finish inside a section slot that no longer reserves ten minutes (#6806).
+ */
+async function validate(url, token, prefix, version, expectedCount, opts = {}) {
+  const { deep = true } = opts;
   const geoKey = `${prefix}military:bases:geo:${version}`;
   const metaKey = `${prefix}military:bases:meta:${version}`;
 
@@ -200,6 +230,11 @@ async function validate(url, token, prefix, version, expectedCount) {
 
   if (!Number.isSafeInteger(metaCount) || metaCount !== geoCount) {
     throw new Error(`META count ${metaCount} != GEO count ${geoCount}`);
+  }
+
+  if (!deep) {
+    console.log(`  Shallow check only — ZCARD == HLEN == ${geoCount}; per-member walk skipped.`);
+    return geoCount;
   }
 
   let validatedCount = 0;
@@ -248,11 +283,17 @@ async function validate(url, token, prefix, version, expectedCount) {
   return geoCount;
 }
 
-function buildSeedMetaPayload(version, recordCount, fetchedAt) {
+// `durationMs` is the measured seed+validate wall time. It is published rather
+// than only logged because this seeder runs as a Railway cron section: its
+// stdout is not retrievable after the fact, so the seed-meta record is the only
+// durable measurement available to size the section's `timeoutMs` against real
+// runtime instead of a worst-case guess (#6806).
+function buildSeedMetaPayload(version, recordCount, fetchedAt, durationMs) {
   return JSON.stringify({
     fetchedAt,
     recordCount,
     sourceVersion: String(version),
+    ...(Number.isFinite(durationMs) ? { durationMs } : {}),
   });
 }
 
@@ -263,6 +304,7 @@ export async function atomicSwitch(
   version,
   recordCount,
   fetchedAt = Date.now(),
+  durationMs = undefined,
 ) {
   const activeKey = `${prefix}military:bases:active`;
   const seedMetaKey = `${prefix}seed-meta:military:bases`;
@@ -273,7 +315,7 @@ export async function atomicSwitch(
     activeKey,
     seedMetaKey,
     String(version),
-    buildSeedMetaPayload(version, recordCount, fetchedAt),
+    buildSeedMetaPayload(version, recordCount, fetchedAt, durationMs),
   ]);
   if (String(publishedVersion) !== String(version)) {
     throw new Error(`Atomic switch returned unexpected version "${publishedVersion}"`);
@@ -282,7 +324,24 @@ export async function atomicSwitch(
   console.log(`Freshness meta: SET ${seedMetaKey}`);
 }
 
-export async function backfillSeedMetaFromActiveVersion(url, token, prefix) {
+/**
+ * Rebuild `seed-meta:military:bases` from whatever `military:bases:active`
+ * already points at, without reseeding.
+ *
+ * That key is the section's ONLY freshness signal — it declares no
+ * `canonicalKey`, so `_bundle-runner.mjs` falls through to the legacy
+ * `seed-meta:<key>` read. While it is absent the runner sees "never seeded" and
+ * marks the section due on EVERY daily tick instead of every 30 days, which is
+ * what turned an occasionally-expensive section into a permanently-due one
+ * (#6806).
+ *
+ * @param {{ deep?: boolean }} [opts] `deep: false` trusts ZCARD/HLEN agreement
+ *   instead of walking every member. Use it for the repair path, where the
+ *   published data is already live and the goal is to restore the marker
+ *   cheaply rather than to re-audit a corpus that has not changed.
+ */
+export async function backfillSeedMetaFromActiveVersion(url, token, prefix, opts = {}) {
+  const { deep = true } = opts;
   const activeKey = `${prefix}military:bases:active`;
   const activeResult = await pipelineRequest(url, token, [['GET', activeKey]]);
   const rawVersion = activeResult[0]?.result;
@@ -296,7 +355,7 @@ export async function backfillSeedMetaFromActiveVersion(url, token, prefix) {
     throw new Error(`Active version "${version}" is not a valid millisecond timestamp`);
   }
 
-  const recordCount = await validate(url, token, prefix, version, 1);
+  const recordCount = await validate(url, token, prefix, version, 1, { deep });
 
   const seedMetaKey = `${prefix}seed-meta:military:bases`;
   const writeResult = await commandRequest(url, token, [
@@ -312,7 +371,10 @@ export async function backfillSeedMetaFromActiveVersion(url, token, prefix) {
     const currentVersion = Array.isArray(writeResult) ? writeResult[1] : null;
     throw new Error(`Active version changed during validation (${version} -> ${currentVersion || 'missing'})`);
   }
-  console.log(`No data file found — restored ${seedMetaKey} from active version ${version} (${recordCount} records).`);
+  // Deliberately does not name a reason: there are two callers (no data file to
+  // seed from, and the #6806 missing-marker repair) and each logs its own before
+  // calling. Naming one here mislabels the other in the Railway log.
+  console.log(`Restored ${seedMetaKey} from active version ${version} (${recordCount.toLocaleString()} records).`);
   return { version, fetchedAt, recordCount };
 }
 
@@ -333,7 +395,7 @@ async function cleanupOldVersion(url, token, prefix, newVersion) {
 async function main() {
   loadEnvFile(import.meta.url);
 
-  const { env, sha } = parseArgs();
+  const { env, sha, force } = parseArgs();
   const prefix = getKeyPrefix(env, sha);
 
   const redisUrl = process.env.UPSTASH_REDIS_REST_URL;
@@ -346,6 +408,44 @@ async function main() {
   if (!redisToken) {
     console.error('Missing UPSTASH_REDIS_REST_TOKEN. Set it in .env.local or as an env var.');
     process.exit(1);
+  }
+
+  // Everything from here on bills against the bundle section's slot, so this is
+  // where the published `durationMs` has to start. Measuring only the write loop
+  // would omit the R2 download (up to 60s), the JSON.parse of ~125k entries and
+  // the post-publish grace — and the whole point of publishing the number is to
+  // size `timeoutMs` in seed-bundle-static-ref.mjs against it (#6806).
+  const runStartedAt = Date.now();
+
+  // Repair the freshness marker before doing any reseed work (#6806).
+  //
+  // `seed-meta:military:bases` is this section's only freshness signal, so while
+  // it is absent `_bundle-runner.mjs` marks the section due on every daily tick
+  // rather than every 30 days. A full reseed is ~1,000 Redis round trips (251
+  // GEOADD + 251 HSET + ~500 validation pipelines, ~4 minutes). It fits the
+  // section's slot — that is what the 400s sizing buys — but re-entering it on
+  // every tick when a 3-call repair suffices is what starved the bundle.
+  // Restoring the marker from the already-published version is a handful of
+  // calls.
+  //
+  // Returning here costs at most one tick of reseed latency: the restored marker
+  // carries the ACTIVE version's own timestamp, so if that data really is past
+  // its interval the very next tick sees it as due and reseeds normally.
+  const seedMetaKey = `${prefix}seed-meta:military:bases`;
+  const existingSeedMeta = force
+    ? 'skipped'
+    : await commandRequest(redisUrl, redisToken, ['GET', seedMetaKey]);
+  if (existingSeedMeta == null || existingSeedMeta === '') {
+    const activeVersion = await commandRequest(redisUrl, redisToken, [
+      'GET',
+      `${prefix}military:bases:active`,
+    ]);
+    if (activeVersion) {
+      console.log(`${seedMetaKey} is missing while an active version (${activeVersion}) is published.`);
+      console.log('Restoring the freshness marker without reseeding...');
+      await backfillSeedMetaFromActiveVersion(redisUrl, redisToken, prefix, { deep: false });
+      return;
+    }
   }
 
   const volumePath = '/data/military-bases-final.json';
@@ -381,6 +481,7 @@ async function main() {
   }
 
   if (!dataPath) {
+    console.log('No data file found locally or on R2 — falling back to the published active version.');
     await backfillSeedMetaFromActiveVersion(redisUrl, redisToken, prefix);
     return;
   }
@@ -434,7 +535,13 @@ async function main() {
 
   await validate(redisUrl, redisToken, prefix, version, entries.length);
 
-  await atomicSwitch(redisUrl, redisToken, prefix, version, entries.length);
+  // Measured from `runStartedAt`, not `t0`: the per-member walk is roughly half
+  // the round trips and data acquisition can add another minute, so a duration
+  // scoped to the write loop would under-report the slot requirement it exists
+  // to size. Still excludes the grace below — the config comment adds it back
+  // rather than this number pretending to be the whole slot (#6806).
+  const durationMs = Date.now() - runStartedAt;
+  await atomicSwitch(redisUrl, redisToken, prefix, version, entries.length, Date.now(), durationMs);
 
   if (oldInfo) {
     console.log(`\nScheduling cleanup of old version ${oldInfo.oldVersion} in ${GRACE_PERIOD_MS / 1000}s...`);

--- a/tests/seed-military-bases-bundle-slot.test.mjs
+++ b/tests/seed-military-bases-bundle-slot.test.mjs
@@ -1,0 +1,164 @@
+// #6806 — `seed-bundle-static-ref`'s budget could not satisfy its own section
+// list, and `Military-Bases` was the section that made the starvation
+// structural: it reserved 550s of worst case (540s timeout + 10s kill grace)
+// against a 570s bundle budget, so with the runner's 15s admission headroom it
+// needed 565s of 570s and was admissible only while `elapsed <= 5s`. The five
+// freshness reads ahead of it routinely burn more than that.
+//
+// The reservation was not the seeder's real work. `main()` published via
+// `atomicSwitch` and then slept a hardcoded GRACE_PERIOD_MS before deleting the
+// superseded version's keys — 300s of the 540s reservation spent idle, after
+// the data was already live.
+//
+// Two properties are pinned here:
+//   1. the post-publish wait cannot grow back into a whole-budget reservation;
+//   2. a missing `seed-meta:military:bases` self-heals cheaply. That key is the
+//      section's ONLY freshness signal (it declares no `canonicalKey`), so when
+//      it is absent the runner treats the section as never-seeded and marks it
+//      due on every daily tick instead of every 30 days — a permanently-due
+//      whole-budget section is what actually starves the bundle.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  GRACE_PERIOD_MS,
+  atomicSwitch,
+  backfillSeedMetaFromActiveVersion,
+  parseArgs,
+} from '../scripts/seed-military-bases.mjs';
+
+const URL_BASE = 'https://redis.test';
+const TOKEN = 'test-token-0000';
+const VERSION = '1786244633231';
+const RECORDS = 125_380;
+
+/**
+ * Stub Upstash REST. `handler(path, body)` returns the parsed JSON body the
+ * seeder should see; every call is recorded so a test can assert on call COUNT,
+ * which is what separates a cheap repair from a full 251-window revalidation.
+ */
+function stubRedis(handler) {
+  const calls = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = async (url, options) => {
+    const path = String(url).slice(URL_BASE.length);
+    const body = JSON.parse(options.body);
+    calls.push({ path, body });
+    return {
+      ok: true,
+      json: async () => handler(path, body, calls.length),
+      text: async () => '',
+    };
+  };
+  return {
+    calls,
+    restore() { globalThis.fetch = original; },
+  };
+}
+
+test('the post-publish grace cannot grow back into a whole-budget reservation', () => {
+  // The bundle slot must be dominated by real work, not by an idle wait that
+  // runs AFTER `atomicSwitch` has already made the data live. At 300_000 this
+  // was 55% of the section's 540s reservation and the direct cause of #6806.
+  assert.ok(
+    GRACE_PERIOD_MS <= 60_000,
+    `GRACE_PERIOD_MS is ${GRACE_PERIOD_MS}ms — a post-publish sleep this long is charged to the `
+    + 'bundle slot even though the data is already published, which is what made Military-Bases '
+    + 'a whole-budget section in #6806.',
+  );
+  assert.ok(GRACE_PERIOD_MS > 0, 'some grace must remain so in-flight readers are not cut off');
+});
+
+test('--force bypasses the repair short-circuit so a manual reseed is still reachable', () => {
+  // The repair path returns early when seed-meta is absent, which is right for
+  // the cron but wrong for an operator who ran the seeder BECAUSE the marker is
+  // missing and wants the data rewritten.
+  const argv = process.argv;
+  try {
+    process.argv = ['node', 'seed-military-bases.mjs'];
+    assert.equal(parseArgs().force, false, 'reseed must not be forced by default');
+
+    process.argv = ['node', 'seed-military-bases.mjs', '--force'];
+    assert.equal(parseArgs().force, true);
+
+    process.argv = ['node', 'seed-military-bases.mjs', '--env', 'preview', '--force'];
+    const parsed = parseArgs();
+    assert.equal(parsed.force, true, '--force must survive alongside other flags');
+    assert.equal(parsed.env, 'preview');
+
+    // `--env=`/`--sha=` accept the `=` form, so an operator who reaches for
+    // `--force=1` out of habit must not silently get the repair path instead.
+    for (const arg of ['--force=true', '--force=1', '--force=yes']) {
+      process.argv = ['node', 'seed-military-bases.mjs', arg];
+      assert.equal(parseArgs().force, true, `${arg} must force a reseed`);
+    }
+    for (const arg of ['--force=false', '--force=0', '--force=no']) {
+      process.argv = ['node', 'seed-military-bases.mjs', arg];
+      assert.equal(parseArgs().force, false, `${arg} must not force a reseed`);
+    }
+  } finally {
+    process.argv = argv;
+  }
+});
+
+test('atomicSwitch records the seeding duration so the next tick can be sized from a measurement', async () => {
+  const stub = stubRedis(() => ({ result: VERSION }));
+  try {
+    await atomicSwitch(URL_BASE, TOKEN, '', VERSION, RECORDS, Number(VERSION), 214_000);
+  } finally {
+    stub.restore();
+  }
+
+  const evalCall = stub.calls.find((c) => c.body[0] === 'EVAL');
+  assert.ok(evalCall, 'atomicSwitch must publish through the EVAL script');
+  const payload = JSON.parse(evalCall.body.at(-1));
+  assert.equal(payload.recordCount, RECORDS);
+  assert.equal(
+    payload.durationMs,
+    214_000,
+    'seed-meta must carry the measured seeding duration — Railway cron logs are not readable '
+    + 'after the fact, so the published record is the only way to right-size this section\'s timeout',
+  );
+});
+
+test('a missing seed-meta is repaired without a full revalidation of every record', async () => {
+  // The repair path exists because the section is permanently due while
+  // seed-meta is absent. If repairing costs a 251-window scan it cannot run
+  // inside the shrunken slot, and the permanently-due loop survives its own fix.
+  const stub = stubRedis((path, body) => {
+    if (path === '/pipeline') {
+      return body.map(([cmd]) => {
+        if (cmd === 'GET') return { result: VERSION };
+        if (cmd === 'ZCARD' || cmd === 'HLEN') return { result: RECORDS };
+        if (cmd === 'ZRANGE') return { result: [] };
+        return { result: null };
+      });
+    }
+    return { result: [1, VERSION] };
+  });
+
+  let repaired;
+  try {
+    repaired = await backfillSeedMetaFromActiveVersion(URL_BASE, TOKEN, '', { deep: false });
+  } finally {
+    stub.restore();
+  }
+
+  assert.equal(repaired.version, VERSION);
+  assert.equal(repaired.recordCount, RECORDS);
+
+  const zrangeCalls = stub.calls.filter(
+    (c) => c.path === '/pipeline' && c.body.some(([cmd]) => cmd === 'ZRANGE'),
+  );
+  assert.equal(
+    zrangeCalls.length,
+    0,
+    'a shallow repair must confirm ZCARD/HLEN agreement only — walking all '
+    + `${RECORDS} members costs ~250 round trips and would not fit the section's slot`,
+  );
+  assert.ok(
+    stub.calls.length <= 4,
+    `shallow repair issued ${stub.calls.length} Redis calls; it must stay a handful`,
+  );
+});

--- a/tests/seed-military-bases-bundle-slot.test.mjs
+++ b/tests/seed-military-bases-bundle-slot.test.mjs
@@ -25,6 +25,7 @@ import {
   GRACE_PERIOD_MS,
   atomicSwitch,
   backfillSeedMetaFromActiveVersion,
+  maybeRepairMissingSeedMeta,
   parseArgs,
 } from '../scripts/seed-military-bases.mjs';
 
@@ -70,10 +71,9 @@ test('the post-publish grace cannot grow back into a whole-budget reservation', 
   assert.ok(GRACE_PERIOD_MS > 0, 'some grace must remain so in-flight readers are not cut off');
 });
 
-test('--force bypasses the repair short-circuit so a manual reseed is still reachable', () => {
-  // The repair path returns early when seed-meta is absent, which is right for
-  // the cron but wrong for an operator who ran the seeder BECAUSE the marker is
-  // missing and wants the data rewritten.
+test('parseArgs recognizes --force forms', () => {
+  // CLI contract only — the main-gate bypass is covered by
+  // maybeRepairMissingSeedMeta({ force: true }) below.
   const argv = process.argv;
   try {
     process.argv = ['node', 'seed-military-bases.mjs'];
@@ -148,6 +148,11 @@ test('a missing seed-meta is repaired without a full revalidation of every recor
   assert.equal(repaired.version, VERSION);
   assert.equal(repaired.recordCount, RECORDS);
 
+  const payload = seedMetaWritePayload(stub.calls);
+  assert.equal(payload.sourceVersion, VERSION);
+  assert.equal(payload.recordCount, RECORDS);
+  assert.equal(payload.fetchedAt, Number(VERSION));
+
   const zrangeCalls = stub.calls.filter(
     (c) => c.path === '/pipeline' && c.body.some(([cmd]) => cmd === 'ZRANGE'),
   );
@@ -161,4 +166,140 @@ test('a missing seed-meta is repaired without a full revalidation of every recor
     stub.calls.length <= 4,
     `shallow repair issued ${stub.calls.length} Redis calls; it must stay a handful`,
   );
+});
+
+function seedMetaWritePayload(calls) {
+  const evalCall = calls.find((c) => Array.isArray(c.body) && c.body[0] === 'EVAL');
+  assert.ok(evalCall, 'repair must write seed-meta through EVAL');
+  return JSON.parse(evalCall.body.at(-1));
+}
+
+function militaryRedisHandler({
+  seedMeta = null,
+  active = VERSION,
+  geoCount = RECORDS,
+  metaCount = RECORDS,
+  evalResult = [1, VERSION],
+} = {}) {
+  return (path, body) => {
+    if (path === '/') {
+      const [cmd, key] = body;
+      if (cmd === 'GET' && String(key).endsWith('seed-meta:military:bases')) {
+        return { result: seedMeta };
+      }
+      if (cmd === 'GET' && String(key).endsWith('military:bases:active')) {
+        return { result: active };
+      }
+      if (cmd === 'EVAL') return { result: evalResult };
+      return { result: null };
+    }
+    if (path === '/pipeline') {
+      return body.map(([cmd]) => {
+        if (cmd === 'GET') return { result: active };
+        if (cmd === 'ZCARD') return { result: geoCount };
+        if (cmd === 'HLEN') return { result: metaCount };
+        return { result: null };
+      });
+    }
+    return { result: null };
+  };
+}
+
+test('missing seed-meta with a live active version repairs cheaply and stops', async () => {
+  const stub = stubRedis(militaryRedisHandler());
+  let result;
+  try {
+    result = await maybeRepairMissingSeedMeta(URL_BASE, TOKEN, '', { force: false });
+  } finally {
+    stub.restore();
+  }
+
+  assert.equal(result.action, 'repaired');
+  assert.equal(result.version, VERSION);
+  assert.equal(result.recordCount, RECORDS);
+
+  const geoAdds = stub.calls.filter(
+    (c) => Array.isArray(c.body) && (c.body[0] === 'GEOADD' || c.body.some?.((row) => row?.[0] === 'GEOADD')),
+  );
+  assert.equal(geoAdds.length, 0, 'repair must not enter the GEOADD reseed path');
+
+  const payload = seedMetaWritePayload(stub.calls);
+  assert.equal(payload.sourceVersion, VERSION);
+  assert.equal(payload.recordCount, RECORDS);
+  assert.equal(payload.fetchedAt, Number(VERSION));
+});
+
+test('--force skips the missing-marker repair so a manual reseed can proceed', async () => {
+  const stub = stubRedis(() => {
+    throw new Error('fetch must not run when force is set');
+  });
+  let result;
+  try {
+    result = await maybeRepairMissingSeedMeta(URL_BASE, TOKEN, '', { force: true });
+  } finally {
+    stub.restore();
+  }
+  assert.equal(result.action, 'skipped-force');
+  assert.equal(stub.calls.length, 0);
+});
+
+test('present seed-meta skips repair', async () => {
+  const stub = stubRedis(militaryRedisHandler({
+    seedMeta: JSON.stringify({ fetchedAt: Number(VERSION), recordCount: RECORDS, sourceVersion: VERSION }),
+  }));
+  let result;
+  try {
+    result = await maybeRepairMissingSeedMeta(URL_BASE, TOKEN, '', { force: false });
+  } finally {
+    stub.restore();
+  }
+  assert.equal(result.action, 'skipped-present');
+  assert.equal(
+    stub.calls.filter((c) => Array.isArray(c.body) && c.body[0] === 'EVAL').length,
+    0,
+    'must not rewrite seed-meta when the marker is already present',
+  );
+});
+
+test('missing seed-meta and no active version falls through to reseed', async () => {
+  const stub = stubRedis(militaryRedisHandler({ active: null }));
+  let result;
+  try {
+    result = await maybeRepairMissingSeedMeta(URL_BASE, TOKEN, '', { force: false });
+  } finally {
+    stub.restore();
+  }
+  assert.equal(result.action, 'fallthrough-no-active');
+  assert.equal(
+    stub.calls.filter((c) => Array.isArray(c.body) && c.body[0] === 'EVAL').length,
+    0,
+  );
+});
+
+test('a broken active corpus falls through to reseed instead of crashing the section', async () => {
+  const stub = stubRedis(militaryRedisHandler({ geoCount: RECORDS, metaCount: 1 }));
+  let result;
+  try {
+    result = await maybeRepairMissingSeedMeta(URL_BASE, TOKEN, '', { force: false });
+  } finally {
+    stub.restore();
+  }
+  assert.equal(result.action, 'fallthrough-invalid-active');
+  assert.equal(
+    stub.calls.filter((c) => Array.isArray(c.body) && c.body[0] === 'EVAL').length,
+    0,
+    'must not stamp seed-meta from a count-mismatched corpus',
+  );
+});
+
+test('CAS conflict during repair is rethrown', async () => {
+  const stub = stubRedis(militaryRedisHandler({ evalResult: [0, '999'] }));
+  try {
+    await assert.rejects(
+      () => maybeRepairMissingSeedMeta(URL_BASE, TOKEN, '', { force: false }),
+      /Active version changed during validation/,
+    );
+  } finally {
+    stub.restore();
+  }
 });


### PR DESCRIPTION
## Summary

`Military-Bases` could not reliably get a slot in `seed-bundle-static-ref`, and on the ticks it won it left no room for anything else. The cause was not capacity: **300 of its 540 reserved seconds were a `sleep`** that runs *after* `atomicSwitch` has already published, purely to delay deleting the superseded version's keys.

The runner admits a section on `elapsedBundle + worstCase <= maxBundleMs` (`_bundle-runner.mjs:543`). Note that test carries **no** `ADMISSION_HEADROOM_MS` term — the headroom guards only the static never-admittable check at line 218 — so the real bound is on elapsed time:

| timeout | worst case | admissible while |
|---|---|---|
| 540s (before) | 550s | `elapsed <= 20s` |
| 400s (after) | 410s | `elapsed <= 160s` |

At 20s, admission turned on a race the section could not influence: the bundle heartbeat write plus the freshness reads for the five sections ahead of it (each bounded by `REDIS_READ_TIMEOUT_MS`) can exceed 20s on a slow tick.

## The second cause: it was due every day, not every 30 days

`Military-Bases` declares no `canonicalKey`, so `seed-meta:military:bases` is its **only** freshness signal. That key is **absent in production** — while `military:bases:active` holds 125,380 records published 2026-08-09. So the runner reads "never seeded" and marks the section due on **every daily tick** instead of every 30 days. A permanently-due whole-budget section is what actually starves the bundle.

A missing marker now self-heals from the already-published version in ~3 Redis calls, instead of re-entering a ~1,000-round-trip reseed on every tick. The restored marker carries the active version's *own* timestamp, so it cannot pin the section artificially fresh — if the data really is past its interval, the next tick reseeds normally. `--force` (and `--force=<v>`) keeps the manual reseed reachable.

## Why 400s and not tighter

The slot carries more than the write loop:

| | |
|---|---:|
| seed + validate (~1,000 Upstash round trips at 125k records) | ~240s |
| R2 download, when neither the volume nor local file is present | ≤60s |
| `JSON.parse` of the ~125k-entry file | ~5s |
| post-publish grace before the superseded keys are deleted | 30s |
| **R2-cold total** | **~335s** |

Sizing below that would put SIGTERM before `atomicSwitch` on exactly that tick — and a run killed pre-publish leaks its half-written `military:bases:{geo,meta}:<version>` keys **permanently**, because `cleanupOldVersion` only ever targets the version that is currently *active*, so one that never published is swept by nothing. The seeder now publishes its measured `durationMs` into seed-meta so this can be re-sized against a real number later; Railway cron stdout is not readable after the fact.

## What this does not do

This reduces starvation; it does not make the bundle fit. Worst cases still sum to ~1530s against a 570s budget, and on any tick where `Arms-Suppliers` runs, elapsed already exceeds 160s and `Military-Bases` still defers. The concrete gain is that admission no longer turns on a 20s race, and that because `elapsedBundle` accrues *actual* runtime, a ~240s seed plus the 30s grace leaves ~300s for `Mineral-Production` — the only section after it in array order, and the one #6799 found with no key in Redis at all.

Deliberately out of scope: cheapest-first ordering, and tightening the admission guard to a fraction of the budget. The latter is not a one-liner — `Arms-Suppliers` at 460s worst case would fail a 0.6 guard, and cutting it below its own 390s fetch deadline is a real re-sizing rather than a config literal.

Note that the arithmetic in #6806 is partly stale: #6811 already right-sized `Submarine-Cables` (300s → 90s), so `Military-Bases` was the only remaining oversized section.

Related: #6806
Related: #6845
Related: #6799

## Validation

- `tests/seed-military-bases-bundle-slot.test.mjs` (new, 4 cases) pins the grace bound, the `--force`/`--force=<v>` parsing, the published `durationMs`, and that the repair issues no `ZRANGE` walk.
- `bundle-budget-admission.test.mjs` 3/3, `bundle-runner.test.mjs` 38/38, `seed-health-military-publish`, `stale-bundle-check` — 45 green under `tsx --test`. Biome clean.
- Production state was read directly (read-only) to establish the absent `seed-meta:military:bases` and the 125,380-record active version.
- **Not exercised live.** The admission behaviour and the repair path are deploy-only — they cannot be proven until a Railway tick runs this code. After deploy, the check is `[Bundle:static-ref] Finished ... ran:N` showing `Military-Bases` with a `ran`, and `seed-meta:military:bases` becoming present.
- One pre-existing unrelated failure: `mcp-bootstrap-parity` cannot resolve `@upstash/ratelimit`, which is absent from the main checkout too.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
