### PR TITLE
perf(prepush): share pro-test npm and vite caches across worktrees

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -339,9 +339,15 @@ PREPUSH_ADMISSION_LEASE=$(node scripts/prepush-admission.mjs acquire "$PREPUSH_C
 
 # A fresh worktree's install is part of the expensive phase too. Keep it under
 # the shared lease so several new worktrees cannot all run npm ci at once.
+# Symlinking node_modules is known-broken here: a later cleanup can delete
+# the symlink *target*. Copy, hardlink, or share caches.
+if [ -L node_modules ]; then
+  echo "ERROR: node_modules is a symlink. Copy, hardlink, or npm ci — never symlink."
+  exit 1
+fi
 if [ ! -d node_modules ]; then
   echo "node_modules missing, running npm ci..."
-  npm ci --cache "$npm_config_cache" || exit 1
+  npm ci --cache "$npm_config_cache" --prefer-offline || exit 1
 fi
 
 if changed '^(src/|tests/|e2e/|middleware|index\.html|vite\.config|scripts/|types/)'; then
@@ -697,9 +703,34 @@ if [ "$RUN_ALL" = true ] || path_matches '^(pro-test|public/pro)/|^convex/config
     echo "ERROR: product config generation failed"
     exit 1
   }
+  if [ -L pro-test/node_modules ]; then
+    echo "ERROR: pro-test/node_modules is a symlink. Copy, hardlink, or npm ci — never symlink."
+    exit 1
+  fi
   if [ ! -d pro-test/node_modules ]; then
     echo "  Installing pro-test deps..."
-    (cd pro-test && npm ci --cache "$npm_config_cache") || exit 1
+    (cd pro-test && npm ci --cache "$npm_config_cache" --prefer-offline) || exit 1
+  fi
+  # Point Vite's default cacheDir (pro-test/node_modules/.vite) at a
+  # lockfile-sharded directory under the shared git-common-dir. Do not
+  # edit pro-test/vite.config.ts here: that path trips this gate and
+  # forces a public/pro rebuild. The .vite link is a cache dir, not a
+  # node_modules symlink. Serialize concurrent writes with flock.
+  if [ -n "$PREPUSH_COMMON_DIR" ]; then
+    _lock_hash=$(sha256sum < pro-test/package-lock.json 2>/dev/null | cut -c1-12)
+    [ -n "$_lock_hash" ] || _lock_hash=nolock
+    _vite_cache="$PREPUSH_COMMON_DIR/wm-vite-cache/pro-test-${_lock_hash}"
+    mkdir -p "$_vite_cache"
+    if [ -d pro-test/node_modules ] && [ ! -e pro-test/node_modules/.vite ]; then
+      ln -s "$_vite_cache" pro-test/node_modules/.vite
+    fi
+    if command -v flock >/dev/null 2>&1; then
+      exec 9>"$PREPUSH_COMMON_DIR/wm-vite-cache/pro-test.build.lock"
+      if ! flock -w 180 9; then
+        echo "ERROR: could not lock shared pro-test vite cache"
+        exit 1
+      fi
+    fi
   fi
   (cd pro-test && npm run build >/dev/null) || {
     echo "ERROR: pro-test build failed"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "build:sitemap:check": "npm run build:crawlable-corpus && node scripts/build-sitemap.mjs --check",
     "verify:sitemaps": "node scripts/verify-sitemaps.mjs",
     "prebuild:pro": "npm run product:facts",
-    "build:pro": "cd pro-test && npm ci && npm run build",
+    "build:pro": "cd pro-test && npm ci --prefer-offline && npm run build",
     "build:openapi": "node -e \"require('fs').cpSync('docs/api/worldmonitor.openapi.yaml', 'public/openapi.yaml')\" && node scripts/build-openapi-json.mjs",
     "gen:openapi:security": "node scripts/openapi-inject-security.mjs",
     "gen:openapi:examples": "node scripts/openapi-inject-examples.mjs",

--- a/scripts/bootstrap-worktree.mjs
+++ b/scripts/bootstrap-worktree.mjs
@@ -209,6 +209,18 @@ export function shouldInstallDependencies({
   return forceInstall || !existsSync(resolve(rootDir, 'node_modules/.package-lock.json'));
 }
 
+export function assertNodeModulesNotSymlink(rootDir = process.cwd(), label = 'node_modules') {
+  const target = resolve(rootDir, 'node_modules');
+  try {
+    if (lstatSync(target).isSymbolicLink()) {
+      throw new Error(`${label} is a symlink; copy, hardlink, or npm ci — never symlink`);
+    }
+  } catch (error) {
+    if (error?.code === 'ENOENT') return;
+    throw error;
+  }
+}
+
 export function installDependencies({
   cacheDir = DEFAULT_NPM_CACHE,
   dryRun = false,
@@ -216,7 +228,11 @@ export function installDependencies({
   log = console.log,
   rootDir = process.cwd(),
 } = {}) {
-  const args = ['ci', '--cache', cacheDir];
+  assertNodeModulesNotSymlink(
+    rootDir,
+    basename(rootDir) === 'pro-test' ? 'pro-test/node_modules' : 'node_modules',
+  );
+  const args = ['ci', '--cache', cacheDir, '--prefer-offline'];
   if (ignoreScripts) args.push('--ignore-scripts');
 
   if (dryRun) {
@@ -451,16 +467,27 @@ export function bootstrapWorktree(options = {}) {
   assertNoForbiddenEnvDumps(rootDir);
 
   if (!options.skipInstall) {
+    const installOpts = {
+      cacheDir: options.cacheDir || DEFAULT_NPM_CACHE,
+      dryRun: options.dryRun,
+      ignoreScripts: options.ignoreScripts,
+      log,
+    };
     if (shouldInstallDependencies({ forceInstall: options.forceInstall, rootDir })) {
-      installDependencies({
-        cacheDir: options.cacheDir || DEFAULT_NPM_CACHE,
-        dryRun: options.dryRun,
-        ignoreScripts: options.ignoreScripts,
-        log,
-        rootDir,
-      });
+      installDependencies({ ...installOpts, rootDir });
     } else {
+      assertNodeModulesNotSymlink(rootDir, 'node_modules');
       log('[worktree] verified npm install present; skipping npm ci');
+    }
+
+    const proTestRoot = resolve(rootDir, 'pro-test');
+    if (existsSync(resolve(proTestRoot, 'package.json'))) {
+      if (shouldInstallDependencies({ forceInstall: options.forceInstall, rootDir: proTestRoot })) {
+        installDependencies({ ...installOpts, rootDir: proTestRoot });
+      } else {
+        assertNodeModulesNotSymlink(proTestRoot, 'pro-test/node_modules');
+        log('[worktree] verified pro-test npm install present; skipping npm ci');
+      }
     }
   }
 

--- a/scripts/pro-test-vite-cache.mjs
+++ b/scripts/pro-test-vite-cache.mjs
@@ -1,0 +1,64 @@
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export const ENV_CACHE_DIR = 'WM_PRO_TEST_VITE_CACHE';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_PRO_TEST_ROOT = resolve(REPO_ROOT, 'pro-test');
+
+export function hashLockfile(contents) {
+  return createHash('sha256').update(contents).digest('hex').slice(0, 12);
+}
+
+export function readGitCommonDir(cwd, runGit = spawnSync) {
+  const result = runGit(
+    'git',
+    ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+    { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+  );
+  if (result.status !== 0) return '';
+  return (result.stdout || '').trim();
+}
+
+export function resolveProTestViteCacheDir({
+  env = process.env,
+  proTestRoot = DEFAULT_PRO_TEST_ROOT,
+  gitCommonDir,
+  lockfileContents,
+  runGit = spawnSync,
+} = {}) {
+  const override = env[ENV_CACHE_DIR];
+  if (typeof override === 'string' && override.trim()) {
+    return resolve(override.trim());
+  }
+
+  const lockPath = resolve(proTestRoot, 'package-lock.json');
+  let contents = lockfileContents;
+  if (contents == null) {
+    try {
+      contents = readFileSync(lockPath, 'utf8');
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+      contents = '';
+    }
+  }
+  const shard = contents ? hashLockfile(contents) : 'nolock';
+
+  const common = gitCommonDir !== undefined ? gitCommonDir : readGitCommonDir(proTestRoot, runGit);
+  if (common) {
+    return resolve(common, 'wm-vite-cache', `pro-test-${shard}`);
+  }
+
+  return resolve(proTestRoot, 'node_modules', '.vite');
+}
+
+const isDirectRun = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (isDirectRun) {
+  process.stdout.write(`${resolveProTestViteCacheDir()}\n`);
+}

--- a/tests/bootstrap-worktree.test.mjs
+++ b/tests/bootstrap-worktree.test.mjs
@@ -16,6 +16,7 @@ import { join } from 'node:path';
 
 import {
   assertNoForbiddenEnvDumps,
+  assertNodeModulesNotSymlink,
   bootstrapWorktree,
   decideHooksPathAction,
   linkEnvFiles,
@@ -139,7 +140,7 @@ describe('worktree bootstrap helper', () => {
 
     bootstrapWorktree({ dryRun: true, rootDir: root, skipEnv: true, log: line => logs.push(line) });
     assert.deepEqual(logs, [
-      '[worktree] would run: npm ci --cache /tmp/worldmonitor-npm-cache',
+      '[worktree] would run: npm ci --cache /tmp/worldmonitor-npm-cache --prefer-offline',
       '[worktree] bootstrap complete',
     ]);
 
@@ -152,6 +153,60 @@ describe('worktree bootstrap helper', () => {
       '[worktree] verified npm install present; skipping npm ci',
       '[worktree] bootstrap complete',
     ]);
+  });
+
+  it('seeds pro-test deps when that package is present', () => {
+    const root = makeTempDir();
+    writeFileSync(join(root, 'package.json'), '{}');
+    mkdirSync(join(root, 'pro-test'));
+    writeFileSync(join(root, 'pro-test', 'package.json'), '{}');
+    const logs = [];
+
+    bootstrapWorktree({ dryRun: true, rootDir: root, skipEnv: true, log: line => logs.push(line) });
+    assert.deepEqual(logs, [
+      '[worktree] would run: npm ci --cache /tmp/worldmonitor-npm-cache --prefer-offline',
+      '[worktree] would run: npm ci --cache /tmp/worldmonitor-npm-cache --prefer-offline',
+      '[worktree] bootstrap complete',
+    ]);
+
+    mkdirSync(join(root, 'node_modules'));
+    writeFileSync(join(root, 'node_modules', '.package-lock.json'), '{}');
+    mkdirSync(join(root, 'pro-test', 'node_modules'));
+    writeFileSync(join(root, 'pro-test', 'node_modules', '.package-lock.json'), '{}');
+    logs.length = 0;
+
+    bootstrapWorktree({ rootDir: root, skipEnv: true, log: line => logs.push(line) });
+    assert.deepEqual(logs, [
+      '[worktree] verified npm install present; skipping npm ci',
+      '[worktree] verified pro-test npm install present; skipping npm ci',
+      '[worktree] bootstrap complete',
+    ]);
+  });
+
+  it('refuses a node_modules symlink instead of following it', (t) => {
+    const root = makeTempDir();
+    const target = makeTempDir('wm-stolen-node-modules-');
+    writeFileSync(join(root, 'package.json'), '{}');
+
+    try {
+      symlinkSync(target, join(root, 'node_modules'));
+    } catch (error) {
+      if (error?.code === 'EPERM' || error?.code === 'EACCES') {
+        t.skip('symlink creation is unavailable in this environment');
+        return;
+      }
+      throw error;
+    }
+
+    assert.throws(
+      () => assertNodeModulesNotSymlink(root),
+      /node_modules is a symlink/,
+    );
+    assert.throws(
+      () => bootstrapWorktree({ dryRun: true, rootDir: root, skipEnv: true, log: quiet }),
+      /node_modules is a symlink/,
+    );
+    assert.equal(readlinkSync(join(root, 'node_modules')), target);
   });
 
   it('parses bootstrap flags', () => {

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -16,7 +16,7 @@
 import { strict as assert } from 'node:assert';
 import { after, describe, test } from 'node:test';
 import { execFileSync } from 'node:child_process';
-import { chmodSync, copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, readlinkSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -87,7 +87,12 @@ let fixtureCount = 0;
  * A repo carrying the real hook and its delegated scripts, with
  * `refs/remotes/origin/main` at the base commit so branch scoping resolves.
  */
-function makeFixture({ branchFiles = {}, scriptsCjs = true, failAttestMode = null } = {}) {
+function makeFixture({
+  branchFiles = {},
+  scriptsCjs = true,
+  failAttestMode = null,
+  proTestNodeModules = true,
+} = {}) {
   const id = fixtureCount++;
   const root = join(WORK, `repo-${id}`);
   const { bin, log } = makeStubs(join(WORK, `aux-${id}`));
@@ -122,7 +127,9 @@ function makeFixture({ branchFiles = {}, scriptsCjs = true, failAttestMode = nul
   // one, so they all have to exist and be tracked for the gate to reach its
   // own verdict. An empty pro-test/node_modules skips the install branch
   // (git does not track empty directories, so it stays invisible to `dirty`).
-  mkdirSync(join(root, 'pro-test', 'node_modules'), { recursive: true });
+  if (proTestNodeModules) {
+    mkdirSync(join(root, 'pro-test', 'node_modules'), { recursive: true });
+  }
   for (const [path, contents] of Object.entries({
     'src/config/products.generated.ts': 'export const PRODUCTS = [];\n',
     'src/config/product-ids.generated.ts': 'export const PRODUCT_IDS = [];\n',
@@ -526,6 +533,91 @@ describe('a broken enumeration blocks the push, it does not empty the list', () 
       assert.equal(fixture.cached(), null);
     });
   }
+});
+
+function npmRuns(invocations) {
+  const lines = invocations.split('\n');
+  const runs = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i] !== '== npm') continue;
+    const args = [];
+    for (let j = i + 1; j < lines.length && lines[j].startsWith('>'); j += 1) {
+      args.push(lines[j].slice(1));
+    }
+    runs.push(args);
+  }
+  return runs;
+}
+
+describe('pro-test freshness install prefers the shared npm cache (#6766)', () => {
+  test('npm ci --prefer-offline when pro-test/node_modules is missing', () => {
+    const fixture = makeFixture({
+      branchFiles: { 'pro-test/src/stale.ts': 'export const n = 1;\n' },
+      proTestNodeModules: false,
+    });
+
+    const { status, stdout, invocations } = fixture.run();
+    assert.equal(status, 0, stdout);
+    const ci = npmRuns(invocations).find((args) => args[0] === 'ci');
+    assert.ok(ci, `expected npm ci, got:\n${invocations}`);
+    assert.ok(ci.includes('--prefer-offline'), ci.join(' '));
+    assert.ok(ci.includes('--cache'), ci.join(' '));
+  });
+
+  test('shares Vite cache via .vite link, never a node_modules symlink', () => {
+    const fixture = makeFixture({
+      branchFiles: {
+        'pro-test/src/stale.ts': 'export const n = 1;\n',
+        'pro-test/package-lock.json': '{"lockfileVersion":3}\n',
+      },
+    });
+
+    const { status, stdout } = fixture.run();
+    assert.equal(status, 0, stdout);
+    const nodeModules = join(fixture.root, 'pro-test', 'node_modules');
+    assert.equal(lstatSync(nodeModules).isSymbolicLink(), false);
+    const viteCache = join(nodeModules, '.vite');
+    assert.equal(lstatSync(viteCache).isSymbolicLink(), true);
+    assert.match(readlinkSync(viteCache), /wm-vite-cache\/pro-test-[0-9a-f]{12}$/);
+  });
+
+  test('still fails when a committed public/pro/ byte is stale', () => {
+    const fixture = makeFixture({
+      branchFiles: { 'pro-test/src/stale.ts': 'export const n = 1;\n' },
+    });
+    writeFileSync(join(fixture.root, 'public/pro/index.html'), '<!doctype html>\n<!-- stale -->\n');
+
+    const { status, stdout } = fixture.run();
+    assert.equal(status, 1, stdout);
+    assert.match(stdout, /product catalog, generated config, pro locales, or public\/pro\/ is stale/);
+  });
+
+  test('refuses a pro-test/node_modules symlink instead of installing through it', (t) => {
+    const fixture = makeFixture({
+      branchFiles: { 'pro-test/src/stale.ts': 'export const n = 1;\n' },
+    });
+    const stolen = join(WORK, `stolen-nm-${fixtureCount}`);
+    mkdirSync(stolen, { recursive: true });
+    rmSync(join(fixture.root, 'pro-test', 'node_modules'), { recursive: true, force: true });
+    try {
+      symlinkSync(stolen, join(fixture.root, 'pro-test', 'node_modules'));
+    } catch (error) {
+      if (error?.code === 'EPERM' || error?.code === 'EACCES') {
+        t.skip('symlink creation is unavailable in this environment');
+        return;
+      }
+      throw error;
+    }
+
+    const { status, stdout, invocations } = fixture.run();
+    assert.equal(status, 1, stdout);
+    assert.match(stdout, /pro-test\/node_modules is a symlink/);
+    assert.equal(
+      npmRuns(invocations).filter((args) => args[0] === 'ci').length,
+      0,
+      'must not npm ci through a symlink',
+    );
+  });
 });
 
 describe('the gate does not fail closed on its own edge cases', () => {

--- a/tests/pro-test-vite-cache.test.mjs
+++ b/tests/pro-test-vite-cache.test.mjs
@@ -1,0 +1,105 @@
+import { strict as assert } from 'node:assert';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+import {
+  ENV_CACHE_DIR,
+  hashLockfile,
+  resolveProTestViteCacheDir,
+} from '../scripts/pro-test-vite-cache.mjs';
+
+describe('pro-test vite cacheDir (#6766)', () => {
+  it('honours WM_PRO_TEST_VITE_CACHE over git and lockfile', () => {
+    const dir = resolve('/tmp/explicit-pro-test-vite');
+    const resolved = resolveProTestViteCacheDir({
+      env: { [ENV_CACHE_DIR]: dir },
+      gitCommonDir: '/repo/.git',
+      lockfileContents: '{"lockfileVersion":3}',
+    });
+    assert.equal(resolved, dir);
+  });
+
+  it('shards a git-common-dir cache by the lockfile hash', () => {
+    const lockfile = '{"lockfileVersion":3,"packages":{}}';
+    const shard = hashLockfile(lockfile);
+    const resolved = resolveProTestViteCacheDir({
+      env: {},
+      gitCommonDir: '/repos/wm/.git',
+      lockfileContents: lockfile,
+    });
+    assert.equal(resolved, resolve('/repos/wm/.git/wm-vite-cache', `pro-test-${shard}`));
+    assert.equal(shard, createHash('sha256').update(lockfile).digest('hex').slice(0, 12));
+  });
+
+  it('gives two worktrees the same path for the same lockfile', () => {
+    const lockfile = '{"name":"worldmonitor-pro"}';
+    const a = resolveProTestViteCacheDir({
+      env: {},
+      gitCommonDir: '/repos/wm/.git',
+      lockfileContents: lockfile,
+    });
+    const b = resolveProTestViteCacheDir({
+      env: {},
+      gitCommonDir: '/repos/wm/.git',
+      lockfileContents: lockfile,
+    });
+    assert.equal(a, b);
+  });
+
+  it('isolates a lockfile bump from a stale dep-optimize cache', () => {
+    const common = '/repos/wm/.git';
+    const before = resolveProTestViteCacheDir({
+      env: {},
+      gitCommonDir: common,
+      lockfileContents: '{"packages":{"a":{}}}',
+    });
+    const after = resolveProTestViteCacheDir({
+      env: {},
+      gitCommonDir: common,
+      lockfileContents: '{"packages":{"a":{},"b":{}}}',
+    });
+    assert.notEqual(before, after);
+  });
+
+  it('falls back to the per-package vite cache when git is unavailable', () => {
+    const root = mkdtempSync(join(tmpdir(), 'wm-pro-test-vite-'));
+    const resolved = resolveProTestViteCacheDir({
+      env: {},
+      proTestRoot: root,
+      gitCommonDir: '',
+      lockfileContents: '{}',
+    });
+    assert.equal(resolved, resolve(root, 'node_modules', '.vite'));
+  });
+
+  it('reads package-lock.json from the pro-test root when contents are not injected', () => {
+    const root = mkdtempSync(join(tmpdir(), 'wm-pro-test-lock-'));
+    const lockfile = '{"fromDisk":true}\n';
+    writeFileSync(join(root, 'package-lock.json'), lockfile);
+    const resolved = resolveProTestViteCacheDir({
+      env: {},
+      proTestRoot: root,
+      gitCommonDir: '/repos/wm/.git',
+    });
+    assert.equal(
+      resolved,
+      resolve('/repos/wm/.git/wm-vite-cache', `pro-test-${hashLockfile(lockfile)}`),
+    );
+  });
+
+  it('does not point cacheDir at node_modules or a symlink of it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'wm-pro-test-nosym-'));
+    mkdirSync(join(root, 'node_modules'));
+    const resolved = resolveProTestViteCacheDir({
+      env: {},
+      proTestRoot: root,
+      gitCommonDir: '/repos/wm/.git',
+      lockfileContents: '{}',
+    });
+    assert.ok(!resolved.startsWith(resolve(root, 'node_modules')));
+    assert.match(resolved, /wm-vite-cache/);
+  });
+});


### PR DESCRIPTION
## Summary

A fresh worktree that tripped the pro-test freshness gate used to spend ~55s on `npm ci` + `vite build` before it even compared `public/pro/`. After this change the same gate still fails a stale marketing bundle, but the install and Vite cache are shared across worktrees instead of being paid again on every checkout.

Closes koala73/worldmonitor#6766.

## What changed

`npm ci` at the hook's admission-leased install site and in worktree bootstrap now passes `--prefer-offline` against the existing `/tmp/worldmonitor-npm-cache`. Bootstrap also seeds `pro-test/node_modules` (copy/`npm ci`, never a `node_modules` symlink — that path is known-broken here).

Vite's default `node_modules/.vite` is linked at hook time to a lockfile-sharded directory under the same git-common-dir that koala73/worldmonitor#6846 uses for admission, so every worktree of the same repo and lockfile shares one cache. Concurrent hook builds take a `flock` on that directory.

`pro-test/vite.config.ts` is intentionally untouched. Editing it would put `pro-test/` in the branch delta, fire this same gate, and force a `public/pro/` rebuild. On this machine a clean rebuild of current `main` already produces different hashed assets than the committed production bytes — a pre-existing drift, not something this cache change should ship.

## Measurements

Issue report (`curious-frolicking-kite`, 2026-08-16):

| step | cold | warm |
| --- | --- | --- |
| `pro-test` `npm ci` | 23.6s | skipped |
| `pro-test` `npm run build` | 31.3s | 7.1s |
| **total** | **54.9s** | **7.1s** |

This worktree (Node 24.19, after `npm ci --prefer-offline`):

| step | result |
| --- | --- |
| `pro-test` `npm ci --prefer-offline` | 40.7s (tarball extract; no network when cache is warm) |
| `vite build` first run | 22.5s |
| `vite build` second run | 21.8s |
| two concurrent `vite build`s | both exit 0, **byte-identical** outputs (42 files) |
| `cacheDir` vs default output | **identical** |
| full `generate-product-config` + `npm run build` | 28.8s; this machine's hashed assets still differ from committed `public/pro/` (pre-existing) |

The ≤20s first-push target is the bootstrap-seeded path: `pro-test/node_modules` is already present, so the hook skips `npm ci` and only rebuilds. Production `vite build` did not write a `cacheDir` on this machine, so the 31s→7s warm number from the issue is likely OS page cache + an already-installed tree more than a Vite dep-optimize hit.

## Test plan

- [x] Hook fixture: missing `pro-test/node_modules` runs `npm ci --prefer-offline`
- [x] Hook fixture: a `pro-test/node_modules` symlink is refused and does not run `npm ci`
- [x] Hook fixture: `.vite` is a link into `wm-vite-cache/pro-test-<hash>`; `node_modules` itself is not a symlink
- [x] Hook fixture: reverting one byte of committed `public/pro/index.html` still fails with the existing stale-bundle error
- [x] Bootstrap dry-run seeds `pro-test` and includes `--prefer-offline`
- [x] Bootstrap refuses a `node_modules` symlink instead of following it
- [x] Cache resolver: env override, lockfile shard, same lockfile → same path, missing git → fallback
- [x] Two concurrent Vite builds, outputs hashed equal
- [x] Gate trigger list and `git diff` paths unchanged
- [x] Rebased onto koala73/worldmonitor#6846; root `npm ci` stays under the admission lease

## Known Residuals

- `pro-test/vite.config.ts` does not set `cacheDir`. The hook shares Vite's default cache directory instead, so this PR does not have to rebuild `public/pro/`.
- Dedicated multi-persona `ce-code-review` did not finish (reviewer hung). Orchestrator reviewed correctness, gate regressions, and the symlink landmine locally.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This only changes the local pre-push hook and worktree bootstrap. Production `/pro` bytes are not in the diff; a stale committed bundle still fails the same hook error.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Grok](https://img.shields.io/badge/Grok_4.6-000000)
