### PR TITLE
fix(monitor): stop the seed pair standing in for an operator-only content clock

### DIFF
--- a/scripts/check-seed-freshness.mjs
+++ b/scripts/check-seed-freshness.mjs
@@ -286,36 +286,52 @@ function readAcceptanceBaseline() {
 }
 
 /**
- * Health runs TWO independent clocks and this line has to print the one that
- * actually fired.
+ * Health decides STALE_CONTENT on a different clock from STALE_SEED, and this
+ * line has to print the one that actually fired.
  *
- *   seed    seedAgeMin vs maxStaleMin        "is the seeder running"  -> STALE_SEED
- *   content contentAgeMin vs maxContentAgeMin "is the data advancing"  -> STALE_CONTENT
+ *   seed     seedAgeMin vs maxStaleMin         "is the seeder running"  -> STALE_SEED
+ *   content  contentAgeMin vs maxContentAgeMin "is the data advancing"  -> STALE_CONTENT
  *
  * This printed the seed pair unconditionally, so every STALE_CONTENT line read
  * as a contradiction: euFsi showed `age=1200m max=5760m` — comfortably inside
  * budget — while the breach was contentAgeMin 19230 against maxContentAgeMin
- * 14400. A reader can only conclude the monitor is wrong, and the numbers that
- * would explain it are already on the wire and simply were not printed.
+ * 14400. A reader can only conclude the monitor is wrong.
+ *
+ * The seed pair is by definition INSIDE budget on a STALE_CONTENT row, so it is
+ * never the reason and must never be printed as though it were. That holds even
+ * when the content numbers are missing, which happens two different ways:
+ *
+ *   contentAgeMin === null   health fail-closes on an unreadable content clock,
+ *                            so the source is stale because nothing in the
+ *                            payload carries a date (jodiGas).
+ *   no content fields at all health also reaches STALE_CONTENT via
+ *                            requireContentFreshness — a per-country verdict
+ *                            (portwatchPortActivity). That detail names WHICH
+ *                            country is stale, so api/health.js strips it from
+ *                            the public compact shape (#6060) that this monitor
+ *                            reads. The numbers are operator-only by design and
+ *                            are not coming; say so and point at where they live.
  */
 function describeProblem(problem) {
-  // A content budget with no readable content age is its OWN failure mode:
-  // health scores `contentAgeMin == null` as stale (fail-closed), so the source
-  // is flagged because the clock could not be read, not because it ran out.
-  // jodiGas reads exactly this way. Printing the seed pair there reproduces the
-  // original bug on the other branch, so name the unreadable clock instead.
-  const contentClock = problem.status === 'STALE_CONTENT'
-    && Number.isFinite(problem.maxContentAgeMin);
-  const contentAge = Number.isFinite(problem.contentAgeMin)
-    ? `${problem.contentAgeMin}m`
-    : 'unknown (no dated item; scored stale)';
-  const freshness = contentClock
-    ? ` contentAge=${contentAge} maxContentAge=${problem.maxContentAgeMin}m`
-      + (Number.isFinite(problem.seedAgeMin) ? ` (seed age=${problem.seedAgeMin}m ok)` : '')
-    : Number.isFinite(problem.seedAgeMin)
-      ? ` age=${problem.seedAgeMin}m max=${problem.maxStaleMin ?? 'unknown'}m`
-      : '';
-  return `${problem.name}: status=${problem.status} records=${problem.records ?? 'unknown'}${freshness}`;
+  const seedClock = Number.isFinite(problem.seedAgeMin)
+    ? ` age=${problem.seedAgeMin}m max=${problem.maxStaleMin ?? 'unknown'}m`
+    : '';
+
+  if (problem.status !== 'STALE_CONTENT') {
+    return `${problem.name}: status=${problem.status} records=${problem.records ?? 'unknown'}${seedClock}`;
+  }
+
+  // Marked `ok` so the healthy clock is never mistaken for the failing one.
+  const seedAside = Number.isFinite(problem.seedAgeMin)
+    ? ` (seed age=${problem.seedAgeMin}m ok)`
+    : '';
+  const contentClock = Number.isFinite(problem.maxContentAgeMin)
+    ? ` contentAge=${Number.isFinite(problem.contentAgeMin)
+      ? `${problem.contentAgeMin}m`
+      : 'unknown (no dated item; scored stale)'} maxContentAge=${problem.maxContentAgeMin}m`
+    : ' contentAge=operator-only (per-country freshness; see detailed /api/health)';
+
+  return `${problem.name}: status=${problem.status} records=${problem.records ?? 'unknown'}${contentClock}${seedAside}`;
 }
 
 /**

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -877,6 +877,35 @@ describe('scheduled seed freshness monitor', () => {
       );
     });
 
+    it('does not present the seed pair when the content clock is operator-only', () => {
+      // health also reaches STALE_CONTENT via requireContentFreshness — a
+      // per-country verdict. That detail names WHICH country is stale, so
+      // api/health.js strips it from the public compact shape (#6060) this
+      // monitor reads, and the row arrives with NO content fields at all.
+      // portwatchPortActivity reads exactly this way. Falling back to the seed
+      // pair here reproduced the original bug a third time: `age=297m
+      // max=2160m` is inside budget and explains nothing.
+      const problem = {
+        name: 'portwatchPortActivity',
+        status: 'STALE_CONTENT',
+        records: 174,
+        seedAgeMin: 297,
+        maxStaleMin: 2160,
+      };
+      const report = formatAcceptanceReport(
+        baselineResult({ blocking: [problem] }),
+        '2026-08-17T17:00:00.000Z',
+      );
+      const line = report.errors.find((row) => row.includes('portwatchPortActivity'));
+      assert.match(line, /contentAge=operator-only/, 'the withheld clock must be named as withheld');
+      assert.match(line, /detailed \/api\/health/, 'and the operator pointed at where it lives');
+      assert.doesNotMatch(
+        line,
+        /\bage=297m max=2160m/,
+        'the passing seed pair must never stand in as the reason for a content verdict',
+      );
+    });
+
     it('still reports the blocking problems on the run where the baseline expires', () => {
       const report = formatAcceptanceReport(
         baselineResult({ blocking: [blocked], expired: true, expiresAt: '2020-01-01' }),


### PR DESCRIPTION
Follow-up to #6843, which fixed two of **three** `STALE_CONTENT` branches. The third surfaced hours after that PR merged:

```
- portwatchPortActivity: status=STALE_CONTENT records=174 age=297m max=2160m
```

297 against 2160 — inside budget, flagged anyway. Exactly the contradiction #6843 set out to kill.

## Why #6843's verification missed it

That PR checked the live payload and found every `STALE_CONTENT` source carried a finite `maxContentAgeMin`. True at 10:00 UTC, false by 17:00. **A point-in-time census cannot establish a closed world** — the guard needed to derive from the code paths that produce the status, not from the sources that happened to be failing.

## The third branch

Health reaches `STALE_CONTENT` two ways (`api/health.js:2125` and `:2131`). The second is `requireContentFreshness` — a per-country verdict, used by `portwatchPortActivity` for CN/HK. It carries **no** `contentAgeMin` at all, so #6843's guard fell through to the seed pair.

The numbers aren't merely absent — they're **withheld on purpose**. The `contentFreshness` block names *which* country is stale, so `healthResponseBody` strips it from the public compact shape (#6060, alongside `decisionGroups` and `chinaRow`). This monitor reads that public shape; the detail lives behind the operator/enterprise key on detailed `/api/health` (`api/health.js:2697`).

So no change to this monitor can recover those numbers, and none should try. The fix is to stop guessing:

| case | output |
|---|---|
| finite `contentAgeMin` | `contentAge=Nm maxContentAge=Nm` |
| `contentAgeMin: null` | `contentAge=unknown (no dated item; scored stale)` |
| no content fields | `contentAge=operator-only (per-country freshness; see detailed /api/health)` |

`describeProblem` now returns early for non-`STALE_CONTENT`, so a content verdict can never reach the seed pair by any path.

## Verification

Live, all four `STALE_CONTENT` sources now explain themselves:

```
statcanWds:            contentAge=111904m maxContentAge=108000m (seed age=1980m ok)
jodiGas:               contentAge=unknown (no dated item; scored stale)
lngVulnerability:      contentAge=unknown (no dated item; scored stale)
portwatchPortActivity: contentAge=operator-only (per-country freshness; ...)
```

**Mutation-checked**: pointing the operator-only branch back at the seed pair fails the new test and nothing else.

117 pass / 0 fail across `seed-freshness-monitor`, `railway-deploy-convergence`, `activation-marker-unknown-state`, `railway-deploy-trigger-workflow`. Biome clean.

Reporting only. No threshold, verdict, or acknowledgement changes.
