### PR TITLE
fix(mcp): authenticate the world brief loopback self-fetch

### DIFF
--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -961,8 +961,16 @@ export const RPC_TOOLS: ToolDef[] = [
       // gateway-backed path to retain entitlement and replay protection.
       const insightsUrl = `${base}/api/infrastructure/v1/get-bootstrap-data?keys=insights`;
       const insightsAuth = await buildAuthHeaders(context, 'GET', insightsUrl, null);
+      // On a self-hosted install `base` is the sidecar's own loopback origin,
+      // whose global auth gate requires the per-session LOCAL_API_TOKEN (the
+      // MCP key authenticates the client, not this internal hop). Route the
+      // headers through the loopback helper so the process attaches the token
+      // it already holds — mirroring get_defense_industrial_base (#6538).
       const insightsRes = await fetch(insightsUrl, {
-        headers: { ...insightsAuth, 'User-Agent': UA },
+        headers: buildMcpDownstreamHeaders(base, execution, {
+          ...insightsAuth,
+          'User-Agent': UA,
+        }),
         signal: AbortSignal.timeout(6_000),
       });
       await assertMcpToolFetchOk(insightsRes, {

--- a/tests/mcp-world-brief-routing.test.mjs
+++ b/tests/mcp-world-brief-routing.test.mjs
@@ -153,6 +153,40 @@ afterEach(() => {
 });
 
 describe('get_world_brief seeded brief routing', () => {
+  it('authenticates a local loopback self-fetch with the sidecar token', async () => {
+    // #6538: on self-host the bootstrap hop targets the sidecar's own global
+    // auth gate. The MCP key authenticates the client; this internal hop must
+    // present the per-session LOCAL_API_TOKEN the process already holds.
+    process.env.LOCAL_API_TOKEN = 'local-sidecar-token';
+    const fetchCalls = [];
+
+    globalThis.fetch = async (input, init = {}) => {
+      fetchCalls.push({ url: String(input), headers: new Headers(init.headers) });
+      const { pathname } = new URL(String(input));
+      if (pathname === '/api/infrastructure/v1/get-bootstrap-data') return insightsResponse();
+      throw new Error(`Unexpected downstream URL: ${input}`);
+    };
+
+    const response = await mcpHandler(new Request('http://127.0.0.1:43123/mcp', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-WorldMonitor-Key': ENV_KEY,
+      },
+      body: JSON.stringify(callBody('get_world_brief', {})),
+    }), makeDeps());
+
+    assert.equal(response.status, 200);
+    assert.equal(fetchCalls.length, 1);
+    assert.equal(
+      fetchCalls[0].headers.get('X-WorldMonitor-Local-Token'),
+      'local-sidecar-token',
+      'the internal bootstrap fetch must carry the sidecar token on loopback',
+    );
+    const body = await response.json();
+    assert.match(body.result.content[0].text, /Seeded grounded world brief\./);
+  });
+
   it('preserves non-production origins without exposing them in telemetry tags', () => {
     const cases = [
       {


### PR DESCRIPTION
## Summary

`get_world_brief`'s internal bootstrap hop fetches `/api/infrastructure/v1/get-bootstrap-data` through `${base}`. On a self-hosted install, `base` is the sidecar's own loopback origin, and that endpoint sits behind `local-api-server.mjs`'s global auth gate. The MCP key authenticates the client (`auth_kind: env_key`), not this internal hop, so the sidecar rejects its own fetch with 401 — and the operator cannot fix it from outside because inbound copies of `X-WorldMonitor-Local-Token` are deliberately stripped; only nginx injects it on proxied traffic.

The fix routes the hop's headers through the existing `buildMcpDownstreamHeaders` helper, mirroring `get_defense_industrial_base`: when the target is the loopback sidecar origin, the process attaches the `LOCAL_API_TOKEN` it already holds. Non-loopback targets are unchanged.

## Type of change

- [x] Bug fix

## Affected areas

- [x] AI Insights / World Brief
- [x] API endpoints (`/api/*`)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — not applicable: the defect only reproduces on a self-hosted loopback deployment
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed — N/A

## Documentation Alignment Checklist

- Claim ledger: N/A — no documentation claims changed
- Audit Council signoffs: N/A

## Testing

- New regression: `tests/mcp-world-brief-routing.test.mjs` → `authenticates a local loopback self-fetch with the sidecar token` (drives the full MCP handler against a loopback origin with `LOCAL_API_TOKEN` set and asserts the downstream fetch carries `X-WorldMonitor-Local-Token`)
- `npx tsx --test tests/mcp-world-brief-routing.test.mjs` — 6/6 pass
- `npx tsx --test tests/mcp-defense-industrial-tool.test.mjs tests/mcp-api-parity.test.mjs tests/mcp-error-fingerprint.test.mjs` — 35/35 pass
- `npm run typecheck`, `biome check` on both changed files, `git diff --check` — all clean

Fixes #6538