### PR TITLE
fix(mcp): preserve bounded validation detail on RPC 400s

### DIFF
--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -8,6 +8,7 @@ import {
   BothSourcesFailedError,
   createMcpToolExecutionContext,
   downstreamErrorTags,
+  McpValidationDetailError,
 } from './downstream';
 import { mcpErrorFingerprint } from './error-fingerprint';
 import { argBool, summarizeData } from './filters';
@@ -439,6 +440,21 @@ export async function dispatchToolsCall(
           stale: true,
           unavailable_inputs: err.unavailableInputs,
           failed_inputs: err.failedInputs,
+        },
+      );
+    }
+    // #6559: a downstream RPC 400 with field-level violations is a caller
+    // input problem, not an internal failure. Re-emit the bounded projection
+    // as structured JSON-RPC error data so agents can correct the request
+    // without seeing raw response text.
+    if (err instanceof McpValidationDetailError) {
+      return rpcError(
+        id,
+        -32602,
+        'Invalid params: downstream validation failed',
+        corsHeaders,
+        {
+          validation_violations: err.violations,
         },
       );
     }

--- a/api/mcp/downstream.ts
+++ b/api/mcp/downstream.ts
@@ -76,6 +76,72 @@ export class ToolFetchError extends Error {
   }
 }
 
+/**
+ * One bounded field-level validation violation carried to the MCP caller.
+ * Only `field`/`description` strings survive, each length-capped; every other
+ * property of the upstream body is dropped before it can leave this module.
+ */
+export type McpValidationViolation = {
+  field: string;
+  description: string;
+};
+
+export class McpValidationDetailError extends ToolFetchError {
+  readonly violations: McpValidationViolation[];
+
+  constructor(
+    operation: string,
+    status: number,
+    safeCode: string,
+    responseMarker: DownstreamResponseMarker,
+    violations: McpValidationViolation[],
+  ) {
+    super(operation, status, safeCode, responseMarker);
+    this.name = 'McpValidationDetailError';
+    this.violations = violations;
+  }
+}
+
+const MAX_VALIDATION_VIOLATIONS = 10;
+const MAX_VALIDATION_FIELD_CHARS = 64;
+const MAX_VALIDATION_DESCRIPTION_CHARS = 200;
+
+/**
+ * Extract a closed, bounded projection of the generated RPC servers'
+ * `{"violations":[{"field":...,"description":...}]}` 400 bodies.
+ *
+ * Returns null unless the body parses as JSON and carries a usable
+ * `violations` array — malformed, non-JSON, empty, or entirely mis-shaped
+ * input keeps the existing generic failure contract. Raw text, unknown
+ * fields, non-strings, and anything past the caps never propagate.
+ */
+function parseBoundedValidationViolations(detail: string): McpValidationViolation[] | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(detail);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const rawViolations = (parsed as { violations?: unknown }).violations;
+  if (!Array.isArray(rawViolations)) return null;
+
+  const violations: McpValidationViolation[] = [];
+  for (const entry of rawViolations) {
+    if (violations.length >= MAX_VALIDATION_VIOLATIONS) break;
+    if (typeof entry !== 'object' || entry === null) continue;
+    const field = (entry as { field?: unknown }).field;
+    const description = (entry as { description?: unknown }).description;
+    if (typeof field !== 'string' || field.trim() === '') continue;
+    if (typeof description !== 'string') continue;
+    violations.push({
+      field: field.slice(0, MAX_VALIDATION_FIELD_CHARS),
+      description: description.slice(0, MAX_VALIDATION_DESCRIPTION_CHARS),
+    });
+  }
+  return violations.length > 0 ? violations : null;
+}
+
 type DownstreamObservation = {
   operation: string;
   tool: string;
@@ -203,13 +269,25 @@ async function readBoundedResponseText(
 
 async function classifyFailure(
   response: ToolFetchResponse,
-): Promise<{ errorCode: string; marker: DownstreamResponseMarker }> {
+): Promise<{
+  errorCode: string;
+  marker: DownstreamResponseMarker;
+  violations?: McpValidationViolation[];
+}> {
   if (response.status === 405) {
     return { errorCode: 'method_not_allowed', marker: 'method_not_allowed' };
   }
 
   const type = contentType(response);
-  const detail = await readBoundedResponseText(response);
+  // 400s carry the generated servers' violation lists, which can legitimately
+  // exceed the 4 KB classification budget before the bounded projection below
+  // caps the surviving data at 10 x (64 + 200) characters. Keep the read
+  // bounded (16 KB) — larger or hostile bodies still truncate and fall back
+  // to the generic contract instead of buffering unbounded upstream output.
+  const detail = await readBoundedResponseText(
+    response,
+    response.status === 400 ? 16_384 : 4_096,
+  );
   if (!detail) {
     return {
       errorCode: defaultSafeErrorCode(response.status),
@@ -220,6 +298,20 @@ async function classifyFailure(
   if (type.includes('json')) {
     try {
       const parsed = JSON.parse(detail) as { code?: unknown; error?: unknown };
+      // #6559: generated RPC servers reject invalid input with HTTP 400 and a
+      // {violations:[{field,description}]} body. Preserve the bounded,
+      // field-level projection so agent callers can correct the request;
+      // every other JSON error keeps the closed-set code mapping.
+      if (response.status === 400) {
+        const violations = parseBoundedValidationViolations(detail);
+        if (violations) {
+          return {
+            errorCode: 'validation_failed',
+            marker: 'json_error',
+            violations,
+          };
+        }
+      }
       return {
         errorCode: safeGatewayErrorCode(parsed.code ?? parsed.error, response.status),
         marker: 'json_error',
@@ -312,6 +404,15 @@ export async function assertMcpToolFetchOk(
     failure.errorCode,
     failure.marker,
   );
+  if (failure.violations) {
+    throw new McpValidationDetailError(
+      operation,
+      response.status,
+      failure.errorCode,
+      failure.marker,
+      failure.violations,
+    );
+  }
   throw new ToolFetchError(
     operation,
     response.status,

--- a/tests/mcp-validation-detail.test.mjs
+++ b/tests/mcp-validation-detail.test.mjs
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  HMAC_SECRET,
+  callBody,
+  makeProDeps,
+  proReq,
+} from './helpers/mcp-pro-deps.mjs';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+function validationBody(violations) {
+  return new Response(JSON.stringify({ violations }), {
+    status: 400,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('MCP downstream validation detail', () => {
+  let mcpHandler;
+
+  beforeEach(async () => {
+    process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+    process.env.MCP_TELEMETRY = 'false';
+    const mod = await import(`../api/mcp.ts?validation-detail=${Date.now()}-${Math.random()}`);
+    mcpHandler = mod.mcpHandler;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.keys(process.env).forEach((key) => {
+      if (!(key in originalEnv)) delete process.env[key];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('preserves field violations for a GET RPC 400 through an existing tool', async () => {
+    globalThis.fetch = async () => validationBody([
+      { field: 'country_code', description: 'country_code is required' },
+    ]);
+
+    const response = await mcpHandler(
+      proReq('POST', callBody('get_defense_industrial_base', { country_code: '' })),
+      makeProDeps().deps,
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.error.code, -32602);
+    assert.equal(body.error.message, 'Invalid params: downstream validation failed');
+    assert.deepEqual(body.error.data.validation_violations, [
+      { field: 'country_code', description: 'country_code is required' },
+    ]);
+  });
+
+  it('preserves field violations for a POST RPC 400 through an existing tool', async () => {
+    globalThis.fetch = async () => validationBody([
+      { field: 'query', description: 'query must be at least 2 characters' },
+    ]);
+
+    const response = await mcpHandler(
+      proReq('POST', callBody('search_intel_history', { query: 'x' })),
+      makeProDeps().deps,
+    );
+    const body = await response.json();
+
+    assert.equal(body.error.code, -32602);
+    assert.deepEqual(body.error.data.validation_violations, [
+      { field: 'query', description: 'query must be at least 2 characters' },
+    ]);
+  });
+
+  it('bounds the projection: at most 10 violations, capped strings, no extra fields', async () => {
+    const upstream = Array.from({ length: 14 }, (_, i) => ({
+      field: `field_${i}_${'f'.repeat(100)}`,
+      description: `d_${'d'.repeat(300)}`,
+      internalDetail: 'SECRET_INTERNAL_SENTINEL',
+    }));
+    globalThis.fetch = async () => validationBody(upstream);
+
+    const response = await mcpHandler(
+      proReq('POST', callBody('search_intel_history', { query: 'x' })),
+      makeProDeps().deps,
+    );
+    const body = await response.json();
+
+    assert.equal(body.error.code, -32602);
+    const violations = body.error.data.validation_violations;
+    assert.equal(violations.length, 10);
+    for (const violation of violations) {
+      assert.ok(violation.field.length <= 64);
+      assert.ok(violation.description.length <= 200);
+      assert.deepEqual(Object.keys(violation).sort(), ['description', 'field']);
+    }
+    assert.ok(!JSON.stringify(body).includes('SECRET_INTERNAL_SENTINEL'));
+  });
+
+  it('keeps the generic contract for malformed, non-JSON, and non-validation 400 bodies', async () => {
+    const cases = [
+      ['malformed json', () => new Response('not json', { status: 400, headers: { 'Content-Type': 'application/json' } })],
+      ['html body', () => new Response('<html>bad</html>', { status: 400, headers: { 'Content-Type': 'text/html' } })],
+      ['other json error', () => new Response(JSON.stringify({ error: 'other' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })],
+      ['violations not an array', () => new Response(JSON.stringify({ violations: 'not-an-array' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })],
+      ['non-string field', () => new Response(JSON.stringify({ violations: [{ field: 1, description: 'x' }] }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })],
+    ];
+
+    for (const [label, makeResponse] of cases) {
+      globalThis.fetch = async () => makeResponse();
+      const res = await mcpHandler(
+        proReq('POST', callBody('search_intel_history', { query: 'x' })),
+        makeProDeps().deps,
+      );
+      const body = await res.json();
+      assert.equal(body.error.code, -32603, `expected generic -32603 for ${label}`);
+      assert.equal(body.error.data, undefined);
+    }
+  });
+
+  it('exposes the shared helper contract directly for MCP-internal callers', async () => {
+    const mod = await import(`../api/mcp/downstream.ts?validation-detail=${Date.now()}-${Math.random()}`);
+    const observation = {
+      operation: 'unit-probe',
+      tool: 'unit_probe',
+      auth: { kind: 'env_key' },
+    };
+    const error = await mod.assertMcpToolFetchOk(validationBody([
+      { field: 'limit', description: 'limit must be <= 16' },
+    ]), observation).then(() => null, (err) => err);
+
+    assert.ok(error instanceof mod.McpValidationDetailError);
+    assert.equal(error.safeCode, 'validation_failed');
+    assert.deepEqual(error.violations, [{ field: 'limit', description: 'limit must be <= 16' }]);
+  });
+});


### PR DESCRIPTION
## Summary

When an internal proto/sebuf RPC rejects MCP input with HTTP 400, the generated server emits a field-level `{"violations":[{"field":...,"description":...}]}` body. The sibling-fetch error path collapsed that to `<label> HTTP 400` (`assertToolFetchOk`) or a closed-set code (`assertMcpToolFetchOk`), and dispatch mapped both to JSON-RPC `-32603 Internal error: data fetch failed` — so agent callers could not correct the request from the response (#6559).

This PR preserves the validation detail as **structured JSON-RPC error data**, through the shared downstream path used by the RPC tools:

- `classifyFailure` now extracts a closed, bounded projection for 400 JSON bodies: at most **10** violations, `field` capped at **64** chars, `description` capped at **200** chars, strings only. Every other property of the upstream body is dropped inside the classifier.
- The bounded read for 400 bodies rises from 4 KB to 16 KB (real violation lists can exceed 4 KB); hostile/oversized bodies still truncate and fall back to the generic contract. All other statuses keep the 4 KB budget.
- `assertMcpToolFetchOk` throws `McpValidationDetailError` (a `ToolFetchError` subclass) carrying `validation_violations`, with `safeCode: 'validation_failed'`; telemetry markers are unchanged (`json_error`).
- Dispatch re-emits it as `-32602 Invalid params: downstream validation failed` with `data.validation_violations` — the code agents already treat as "fix your arguments".
- Malformed, non-JSON, non-validation, and unparseable bodies keep the existing generic `-32603` contract; billing denials, source-unavailable errors, and the generic fallback are unchanged.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)

## Checklist

- [ ] Tested on worldmonitor.app variant — N/A: server-side error-contract change exercised through the MCP handler tests
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- Claim ledger: N/A — no documentation claims changed
- Audit Council signoffs: N/A

## Testing

- New suite `tests/mcp-validation-detail.test.mjs` (5 tests):
  - GET RPC 400 through `get_defense_industrial_base` → `-32602` + `validation_violations`
  - POST RPC 400 through `search_intel_history` → `-32602` + `validation_violations`
  - bounds: 14 upstream violations → 10 survive, strings capped, extra upstream fields (`internalDetail` sentinel) never leak
  - malformed JSON / HTML / non-validation JSON / mis-shaped `violations` → generic `-32603`, no data
  - shared helper direct contract (`McpValidationDetailError`, `safeCode`, violations)
- `npx tsx --test tests/mcp-error-fingerprint.test.mjs tests/mcp-defense-industrial-tool.test.mjs tests/mcp-world-brief-routing.test.mjs tests/mcp-validation-detail.test.mjs` — 20/20
- `npx tsx --test tests/mcp.test.mjs` — 161/161
- `npm run typecheck`, `biome check` on all three files, `git diff --check` — clean

Fixes #6559