### PR TITLE
fix(mcp): preserve RPC ValidationError details for agents

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -66,6 +66,13 @@
       "removal_issue": null
     },
     {
+      "path": "api/mcp/bounded-body.ts",
+      "category": "internal-helper",
+      "reason": "Bounded sibling-response body reader shared by MCP billing-denial and downstream error classification (#6559). Pure helper module for the external-protocol MCP handler family above — exports no route.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/mcp/downstream.ts",
       "category": "internal-helper",
       "reason": "Canonical sibling-request routing and credential-safe downstream error classification for MCP RPC tools (#5514). Pure helper module for the external-protocol MCP handler family above — exports no route.",

--- a/api/mcp/billing-denial.ts
+++ b/api/mcp/billing-denial.ts
@@ -6,6 +6,7 @@
 // renewal verification exists to cover.
 
 import type { BillingVerificationStatus } from '../../server/_shared/entitlement-check';
+import { readBoundedResponseText } from './bounded-body';
 
 export type BillingVerificationCode =
   | BillingVerificationStatus
@@ -46,12 +47,43 @@ export class BillingDenialError extends Error {
 
 // Structural subset of Response so test doubles that stub only {ok, status}
 // (several suites do) pass through the non-billing path instead of throwing
-// on a missing headers object.
+// on a missing headers object. `body` / `text` are optional so those doubles
+// still work; they are only read on HTTP 400 to extract proto violations.
 type ToolFetchResponse = {
   ok: boolean;
   status: number;
   headers?: { get(name: string): string | null };
+  body?: ReadableStream<Uint8Array> | null;
+  text?: () => Promise<string>;
 };
+
+export type RpcValidationViolation = {
+  field: string;
+  description: string;
+};
+
+const MAX_VALIDATION_BODY_BYTES = 4096;
+const MAX_VALIDATION_VIOLATIONS = 8;
+const MAX_VIOLATION_FIELD_LEN = 64;
+const MAX_VIOLATION_DESCRIPTION_LEN = 200;
+const SAFE_VIOLATION_FIELD = /^[A-Za-z_][A-Za-z0-9_.]{0,63}$/;
+const UNSAFE_VIOLATION_DESCRIPTION = /[<>]|authorization\s*:|bearer\s/i;
+
+export class RpcValidationError extends Error {
+  readonly operation: string;
+  readonly status: number;
+  readonly violations: readonly RpcValidationViolation[];
+
+  constructor(label: string, violations: readonly RpcValidationViolation[]) {
+    // Keep the `<tool> HTTP <status>` shape so dispatch's client-4xx
+    // log-severity downgrade and mcpErrorFingerprint grouping still match.
+    super(`${label} HTTP 400`);
+    this.name = 'RpcValidationError';
+    this.operation = label;
+    this.status = 400;
+    this.violations = violations;
+  }
+}
 
 /**
  * Throws BillingDenialError when a non-ok gateway response carries the
@@ -74,13 +106,75 @@ export function throwIfBillingDenial(response: ToolFetchResponse, label: string)
   );
 }
 
+function sanitizeViolationField(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const field = value.trim().slice(0, MAX_VIOLATION_FIELD_LEN);
+  return SAFE_VIOLATION_FIELD.test(field) ? field : null;
+}
+
+function sanitizeViolationDescription(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const description = value.replace(/\s+/g, ' ').trim().slice(0, MAX_VIOLATION_DESCRIPTION_LEN);
+  if (!description || UNSAFE_VIOLATION_DESCRIPTION.test(description)) return null;
+  return description;
+}
+
+/**
+ * Extract proto/sebuf `ValidationError.violations` from a sibling 400 body.
+ * Only `{field, description}` pairs survive, each length-bounded and
+ * character-restricted. Malformed JSON, HTML, oversized leftovers, unknown
+ * keys, and credential-like text are dropped — never copied into the error.
+ */
+export async function extractSafeRpcViolations(
+  response: ToolFetchResponse,
+): Promise<readonly RpcValidationViolation[]> {
+  const type = (response.headers?.get('Content-Type') ?? '').toLowerCase();
+  if (type.includes('html')) return [];
+
+  const detail = await readBoundedResponseText(response, MAX_VALIDATION_BODY_BYTES);
+  if (!detail) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(detail);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== 'object' || !('violations' in parsed)) return [];
+  const raw = (parsed as { violations: unknown }).violations;
+  if (!Array.isArray(raw)) return [];
+
+  const violations: RpcValidationViolation[] = [];
+  for (const item of raw) {
+    if (violations.length >= MAX_VALIDATION_VIOLATIONS) break;
+    if (!item || typeof item !== 'object') continue;
+    const record = item as { field?: unknown; description?: unknown };
+    const field = sanitizeViolationField(record.field);
+    const description = sanitizeViolationDescription(record.description);
+    if (!field || !description) continue;
+    violations.push({ field, description });
+  }
+  return violations;
+}
+
 /**
  * Standard non-ok handling for tool `_execute` gateway fetches: billing
- * denials become typed errors dispatch can re-emit faithfully; everything
+ * denials become typed errors dispatch can re-emit faithfully; proto 400
+ * bodies with safe field violations become RpcValidationError; everything
  * else keeps the existing `<label> HTTP <status>` Error contract.
+ *
+ * HTTP 400 response bodies are consumed only to classify violations. Callers
+ * must await this helper — a forgotten await would let execution continue
+ * and treat the 400 as success.
  */
-export function assertToolFetchOk(response: ToolFetchResponse, label: string): void {
+export async function assertToolFetchOk(response: ToolFetchResponse, label: string): Promise<void> {
   if (response.ok) return;
   throwIfBillingDenial(response, label);
+  if (response.status === 400) {
+    const violations = await extractSafeRpcViolations(response);
+    if (violations.length > 0) {
+      throw new RpcValidationError(label, violations);
+    }
+  }
   throw new Error(`${label} HTTP ${response.status}`);
 }

--- a/api/mcp/bounded-body.ts
+++ b/api/mcp/bounded-body.ts
@@ -1,0 +1,42 @@
+type BoundedBodyResponse = {
+  body?: ReadableStream<Uint8Array> | null;
+  text?: () => Promise<string>;
+};
+
+/**
+ * Read at most `maxBytes` of a sibling Response. Used only to classify
+ * untrusted error bodies; the unread tail is discarded, never copied.
+ */
+export async function readBoundedResponseText(
+  response: BoundedBodyResponse,
+  maxBytes: number,
+): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const text = typeof response.text === 'function'
+      ? await response.text().catch(() => '')
+      : '';
+    return text.slice(0, maxBytes);
+  }
+
+  const decoder = new TextDecoder();
+  let bytesRead = 0;
+  let text = '';
+  try {
+    while (bytesRead < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done || !value) break;
+      const remaining = maxBytes - bytesRead;
+      const chunk = value.byteLength > remaining ? value.subarray(0, remaining) : value;
+      text += decoder.decode(chunk, { stream: bytesRead + chunk.byteLength < maxBytes });
+      bytesRead += chunk.byteLength;
+      if (chunk.byteLength < value.byteLength) break;
+    }
+    text += decoder.decode();
+    return text;
+  } catch {
+    return '';
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+}

--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -3,7 +3,7 @@ import { readExistsFlags, readJsonFromUpstash, redisPipeline } from '../_upstash
 import { captureSilentError } from '../_sentry-edge.js';
 import { secondsUntilUtcMidnight } from '../../server/_shared/pro-mcp-token';
 import { getMcpBillingVerificationDenial } from './auth';
-import { BillingDenialError } from './billing-denial';
+import { BillingDenialError, RpcValidationError } from './billing-denial';
 import {
   BothSourcesFailedError,
   createMcpToolExecutionContext,
@@ -441,6 +441,15 @@ export async function dispatchToolsCall(
           failed_inputs: err.failedInputs,
         },
       );
+    }
+    // #6559: proto/sebuf ValidationError 400s keep their field/detail pairs as
+    // structured JSON-RPC error data (`error.data.violations`). This is NOT a
+    // tools/call result envelope (`result.content` / `isError`) — agents read
+    // `error.code === -32602` and `error.data.violations[]`.
+    if (err instanceof RpcValidationError) {
+      return rpcError(id, -32602, 'Invalid params', corsHeaders, {
+        violations: err.violations,
+      });
     }
     return rpcError(id, -32603, 'Internal error: data fetch failed', corsHeaders);
   }

--- a/api/mcp/downstream.ts
+++ b/api/mcp/downstream.ts
@@ -1,4 +1,5 @@
-import { BillingDenialError, throwIfBillingDenial } from './billing-denial';
+import { BillingDenialError, RpcValidationError, throwIfBillingDenial } from './billing-denial';
+import { readBoundedResponseText } from './bounded-body';
 import { emitTelemetry } from './telemetry';
 import type {
   McpAuthContext,
@@ -167,40 +168,6 @@ function safeGatewayErrorCode(value: unknown, status: number): string {
   return SAFE_GATEWAY_ERROR_MESSAGES.get(normalized) ?? defaultSafeErrorCode(status);
 }
 
-async function readBoundedResponseText(
-  response: ToolFetchResponse,
-  maxBytes = 4096,
-): Promise<string> {
-  const reader = response.body?.getReader();
-  if (!reader) {
-    const text = typeof response.text === 'function'
-      ? await response.text().catch(() => '')
-      : '';
-    return text.slice(0, maxBytes);
-  }
-
-  const decoder = new TextDecoder();
-  let bytesRead = 0;
-  let text = '';
-  try {
-    while (bytesRead < maxBytes) {
-      const { done, value } = await reader.read();
-      if (done || !value) break;
-      const remaining = maxBytes - bytesRead;
-      const chunk = value.byteLength > remaining ? value.subarray(0, remaining) : value;
-      text += decoder.decode(chunk, { stream: bytesRead + chunk.byteLength < maxBytes });
-      bytesRead += chunk.byteLength;
-      if (chunk.byteLength < value.byteLength) break;
-    }
-    text += decoder.decode();
-    return text;
-  } catch {
-    return '';
-  } finally {
-    await reader.cancel().catch(() => {});
-  }
-}
-
 async function classifyFailure(
   response: ToolFetchResponse,
 ): Promise<{ errorCode: string; marker: DownstreamResponseMarker }> {
@@ -209,7 +176,7 @@ async function classifyFailure(
   }
 
   const type = contentType(response);
-  const detail = await readBoundedResponseText(response);
+  const detail = await readBoundedResponseText(response, 4096);
   if (!detail) {
     return {
       errorCode: defaultSafeErrorCode(response.status),
@@ -379,6 +346,14 @@ export function downstreamErrorTags(
       downstream_status: String(error.status),
       downstream_error_code: error.billingCode,
       downstream_response_marker: 'billing_verification',
+    };
+  }
+  if (error instanceof RpcValidationError) {
+    return {
+      downstream_operation: error.operation,
+      downstream_status: String(error.status),
+      downstream_error_code: 'rpc_validation',
+      downstream_response_marker: 'json_error',
     };
   }
   if (error instanceof ToolFetchError) {

--- a/api/mcp/registry/company-intel-tools.ts
+++ b/api/mcp/registry/company-intel-tools.ts
@@ -233,7 +233,7 @@ export const COMPANY_INTEL_TOOL: ToolDef = {
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(timeoutMs),
       });
-      assertToolFetchOk(response, path.split('/').pop() ?? path);
+      await assertToolFetchOk(response, path.split('/').pop() ?? path);
       return response.json();
     };
 

--- a/api/mcp/registry/nlp-tools.ts
+++ b/api/mcp/registry/nlp-tools.ts
@@ -178,7 +178,7 @@ async function fetchNlpDigestItems(
     headers: { ...auth, 'User-Agent': NLP_UA },
     signal: AbortSignal.timeout(NLP_DIGEST_TIMEOUT_MS),
   });
-  assertToolFetchOk(res, 'list-feed-digest');
+  await assertToolFetchOk(res, 'list-feed-digest');
   const body = await res.json() as {
     categories?: Record<string, NlpDigestCategoryGroup>;
     feedStatuses?: Record<string, string>;
@@ -345,7 +345,7 @@ export const NLP_TOOLS: ToolDef[] = [
         // slow-but-successful cache-miss classifications the handler completes.
         signal: AbortSignal.timeout(25_000),
       });
-      assertToolFetchOk(res, 'classify-event');
+      await assertToolFetchOk(res, 'classify-event');
       const result = await res.json() as {
         classification?: { category?: string; subcategory?: string; severity?: string; confidence?: number };
       };

--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -772,7 +772,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(8_000),
       });
-      assertToolFetchOk(response, 'list-global-tenders');
+      await assertToolFetchOk(response, 'list-global-tenders');
       const result = await response.json() as ProcurementRouteResponse;
       return {
         opportunities: (result.tenders || []).map(compactProcurementOpportunity),
@@ -1189,7 +1189,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(8_000),
       });
-      assertToolFetchOk(res, 'get-country-risk');
+      await assertToolFetchOk(res, 'get-country-risk');
       return res.json();
     },
     _apiPaths: [
@@ -1272,7 +1272,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(8_000),
       });
-      assertToolFetchOk(res, 'get-food-stocks');
+      await assertToolFetchOk(res, 'get-food-stocks');
       return res.json();
     },
     _apiPaths: [
@@ -1738,7 +1738,7 @@ export const RPC_TOOLS: ToolDef[] = [
         body,
         signal: AbortSignal.timeout(25_000),
       });
-      assertToolFetchOk(res, 'deduct-situation');
+      await assertToolFetchOk(res, 'deduct-situation');
       return res.json();
     },
     _apiPaths: [
@@ -1781,7 +1781,7 @@ export const RPC_TOOLS: ToolDef[] = [
         body,
         signal: AbortSignal.timeout(25_000),
       });
-      assertToolFetchOk(res, 'get-forecasts');
+      await assertToolFetchOk(res, 'get-forecasts');
       return res.json();
     },
     _apiPaths: [],
@@ -1844,7 +1844,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(25_000),
       });
-      assertToolFetchOk(res, 'search-google-flights');
+      await assertToolFetchOk(res, 'search-google-flights');
       return res.json();
     },
     _apiPaths: [
@@ -1902,7 +1902,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(25_000),
       });
-      assertToolFetchOk(res, 'search-google-dates');
+      await assertToolFetchOk(res, 'search-google-dates');
       return res.json();
     },
     _apiPaths: [
@@ -1981,7 +1981,7 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(15_000),
       });
-      assertToolFetchOk(res, 'get-mineral-production');
+      await assertToolFetchOk(res, 'get-mineral-production');
       return res.json();
     },
     _coverageKeys: [

--- a/tests/mcp-billing-denial.test.mjs
+++ b/tests/mcp-billing-denial.test.mjs
@@ -7,6 +7,7 @@ import { strict as assert } from 'node:assert';
 import {
   assertToolFetchOk,
   BillingDenialError,
+  RpcValidationError,
   throwIfBillingDenial,
 } from '../api/mcp/billing-denial.ts';
 
@@ -19,10 +20,10 @@ function response(status, headerMap = {}) {
 }
 
 describe('billing-denial propagation helpers', () => {
-  it('does nothing on an OK response, even with a billing header present', () => {
+  it('does nothing on an OK response, even with a billing header present', async () => {
     const res = response(200, { 'X-Billing-Verification': 'subscription_lapsed' });
     throwIfBillingDenial(res, 'tool');
-    assertToolFetchOk(res, 'tool');
+    await assertToolFetchOk(res, 'tool');
   });
 
   it('throws a typed denial carrying status, code, and Retry-After', () => {
@@ -41,10 +42,10 @@ describe('billing-denial propagation helpers', () => {
     );
   });
 
-  it('an UNKNOWN marker value falls through to the generic Error, never a typed denial', () => {
+  it('an UNKNOWN marker value falls through to the generic Error, never a typed denial', async () => {
     const res = response(503, { 'X-Billing-Verification': 'grant_everything' });
     throwIfBillingDenial(res, 'tool');
-    assert.throws(
+    await assert.rejects(
       () => assertToolFetchOk(res, 'tool'),
       (err) => !(err instanceof BillingDenialError) && err.message === 'tool HTTP 503',
     );
@@ -69,10 +70,10 @@ describe('billing-denial propagation helpers', () => {
     );
   });
 
-  it('tolerates test doubles without a headers object', () => {
+  it('tolerates test doubles without a headers object', async () => {
     const bare = { ok: false, status: 503 };
     throwIfBillingDenial(bare, 'tool');
-    assert.throws(
+    await assert.rejects(
       () => assertToolFetchOk(bare, 'tool'),
       (err) => !(err instanceof BillingDenialError) && err.message === 'tool HTTP 503',
     );
@@ -94,6 +95,117 @@ describe('billing-denial propagation helpers', () => {
     assert.throws(
       () => throwIfBillingDenial(res, 'tool'),
       (err) => err instanceof BillingDenialError && err.retryAfterSeconds === undefined,
+    );
+  });
+});
+
+function jsonResponse(status, body, headers = { 'Content-Type': 'application/json' }) {
+  return new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+    status,
+    headers,
+  });
+}
+
+describe('assertToolFetchOk RPC validation 400s', () => {
+  it('throws RpcValidationError with bounded field/detail pairs from a proto 400', async () => {
+    const res = jsonResponse(400, {
+      violations: [{ field: 'countryCode', description: 'countryCode is required' }],
+      password: 'should-not-leak',
+    });
+    await assert.rejects(
+      () => assertToolFetchOk(res, 'get-food-stocks'),
+      (err) =>
+        err instanceof RpcValidationError
+        && err.status === 400
+        && err.operation === 'get-food-stocks'
+        && err.message === 'get-food-stocks HTTP 400'
+        && err.violations.length === 1
+        && err.violations[0].field === 'countryCode'
+        && err.violations[0].description === 'countryCode is required'
+        && !JSON.stringify(err).includes('should-not-leak')
+        && !('password' in err),
+    );
+  });
+
+  it('caps the violation list and description length', async () => {
+    const res = jsonResponse(400, {
+      violations: Array.from({ length: 12 }, (_, i) => ({
+        field: `field${i}`,
+        description: 'x'.repeat(250),
+      })),
+    });
+    try {
+      await assertToolFetchOk(res, 'tool');
+      assert.fail('expected RpcValidationError');
+    } catch (err) {
+      assert.ok(err instanceof RpcValidationError);
+      assert.equal(err.violations.length, 8);
+      assert.equal(err.violations[0].description.length, 200);
+    }
+  });
+
+  it('an oversized 400 body does not leak the unread tail', async () => {
+    const secret = 'wm_live_oversize_secret';
+    const res = jsonResponse(400, `${'{"violations":['}${' '.repeat(5000)}"${secret}"]}`);
+    await assert.rejects(
+      () => assertToolFetchOk(res, 'tool'),
+      (err) =>
+        !(err instanceof RpcValidationError)
+        && err.message === 'tool HTTP 400'
+        && !String(err).includes(secret),
+    );
+  });
+
+  it('does not leak malformed, HTML, or credential-like 400 bodies', async () => {
+    const cases = [
+      jsonResponse(400, '{not json', { 'Content-Type': 'application/json' }),
+      jsonResponse(400, '<html><body>password=supersecret</body></html>', { 'Content-Type': 'text/html' }),
+      jsonResponse(400, {
+        violations: [{ field: 'countryCode', description: 'Authorization: Bearer leaked-token' }],
+      }),
+      jsonResponse(400, {
+        violations: [{ field: '<script>', description: 'countryCode is required' }],
+      }),
+    ];
+    for (const res of cases) {
+      await assert.rejects(
+        () => assertToolFetchOk(res, 'tool'),
+        (err) =>
+          !(err instanceof RpcValidationError)
+          && err.message === 'tool HTTP 400'
+          && !String(err).includes('supersecret')
+          && !String(err).includes('leaked-token')
+          && !String(err).includes('<script>')
+          && !String(err).includes('<html>'),
+      );
+    }
+  });
+
+  it('non-validation HTTP errors stay generic Errors', async () => {
+    await assert.rejects(
+      () => assertToolFetchOk(jsonResponse(500, { message: 'boom' }), 'tool'),
+      (err) => !(err instanceof RpcValidationError) && err.message === 'tool HTTP 500',
+    );
+    await assert.rejects(
+      () => assertToolFetchOk(jsonResponse(404, { violations: [{ field: 'x', description: 'no' }] }), 'tool'),
+      (err) => !(err instanceof RpcValidationError) && err.message === 'tool HTTP 404',
+    );
+  });
+
+  it('billing denials still win over a 400 body', async () => {
+    const res = new Response(
+      JSON.stringify({ violations: [{ field: 'countryCode', description: 'countryCode is required' }] }),
+      {
+        status: 400,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Billing-Verification': 'subscription_lapsed',
+        },
+      },
+    );
+    await assert.rejects(
+      () => assertToolFetchOk(res, 'tool'),
+      (err) => err instanceof BillingDenialError && err.billingCode === 'subscription_lapsed',
     );
   });
 });

--- a/tests/mcp-rpc-validation-error.test.mjs
+++ b/tests/mcp-rpc-validation-error.test.mjs
@@ -1,0 +1,160 @@
+// #6559 — proto/sebuf ValidationError 400s must reach MCP callers as
+// structured JSON-RPC error data (`error.code === -32602`,
+// `error.data.violations`), not a tools/call result envelope and not the
+// generic -32603 "Internal error: data fetch failed".
+import { afterEach, describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { TOOL_REGISTRY } from '../api/mcp/registry/index.ts';
+import { dispatchToolsCall } from '../api/mcp/dispatch.ts';
+import { RpcValidationError } from '../api/mcp/billing-denial.ts';
+import { downstreamErrorTags } from '../api/mcp/downstream.ts';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+process.env.MCP_TELEMETRY = 'false';
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  process.env.MCP_TELEMETRY = 'false';
+});
+
+function json400(violations) {
+  return new Response(JSON.stringify({ violations }), {
+    status: 400,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function callTool(name, args, fetchImpl) {
+  globalThis.fetch = fetchImpl;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = () => {};
+  console.error = () => {};
+  try {
+    return await dispatchToolsCall(
+      new Request('http://localhost/mcp'),
+      { kind: 'env_key', apiKey: 'test' },
+      {},
+      { id: 42, params: { name, arguments: args } },
+      {},
+    );
+  } finally {
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+}
+
+describe('MCP RPC ValidationError preservation', () => {
+  it('registry still exposes the GET and POST tools this contract covers', () => {
+    assert.ok(TOOL_REGISTRY.some((tool) => tool.name === 'get_food_stocks'));
+    assert.ok(TOOL_REGISTRY.some((tool) => tool.name === 'analyze_situation'));
+  });
+
+  it('GET get_food_stocks 400 returns JSON-RPC -32602 with data.violations', async () => {
+    const res = await callTool(
+      'get_food_stocks',
+      {},
+      async (input) => {
+        const url = String(typeof input === 'string' ? input : input.url);
+        assert.match(url, /\/api\/resilience\/v1\/get-food-stocks/);
+        return json400([{ field: 'countryCode', description: 'countryCode is required' }]);
+      },
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602);
+    assert.equal(body.error?.message, 'Invalid params');
+    assert.deepEqual(body.error?.data, {
+      violations: [{ field: 'countryCode', description: 'countryCode is required' }],
+    });
+    assert.equal(body.result, undefined);
+  });
+
+  it('POST analyze_situation 400 returns JSON-RPC -32602 with data.violations', async () => {
+    const res = await callTool(
+      'analyze_situation',
+      { query: '' },
+      async (input) => {
+        const url = String(typeof input === 'string' ? input : input.url);
+        assert.match(url, /\/api\/intelligence\/v1\/deduct-situation/);
+        return json400([{ field: 'query', description: 'query is required' }]);
+      },
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602);
+    assert.deepEqual(body.error?.data?.violations, [
+      { field: 'query', description: 'query is required' },
+    ]);
+    assert.equal(body.result, undefined);
+  });
+
+  it('untrusted 400 bodies stay on the generic -32603 fallback', async () => {
+    const res = await callTool(
+      'get_food_stocks',
+      { country_code: 'EG' },
+      async () => new Response('<html>wm_live_secret</html>', {
+        status: 400,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    );
+    const body = await res.json();
+    assert.equal(body.error?.code, -32603);
+    assert.equal(body.error?.message, 'Internal error: data fetch failed');
+    assert.equal(body.error?.data, undefined);
+    assert.ok(!JSON.stringify(body).includes('wm_live_secret'));
+    assert.ok(!JSON.stringify(body).includes('<html>'));
+  });
+
+  it('non-validation HTTP errors stay on the generic -32603 fallback', async () => {
+    const res = await callTool(
+      'get_food_stocks',
+      { country_code: 'EG' },
+      async () => new Response(JSON.stringify({ message: 'upstream exploded' }), {
+        status: 502,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const body = await res.json();
+    assert.equal(body.error?.code, -32603);
+    assert.equal(body.error?.data, undefined);
+    assert.ok(!JSON.stringify(body).includes('upstream exploded'));
+  });
+
+  it('telemetry classifies the validation path as client_4xx', async () => {
+    process.env.MCP_TELEMETRY = 'true';
+    const captured = [];
+    const originalLog = console.log;
+    console.log = (line) => captured.push(line);
+    try {
+      await callTool(
+        'get_food_stocks',
+        {},
+        async () => json400([{ field: 'countryCode', description: 'countryCode is required' }]),
+      );
+    } finally {
+      console.log = originalLog;
+    }
+    const event = captured.find((line) => line && line.tag === 'mcp.toolcall');
+    assert.equal(event?.ok, false);
+    assert.equal(event?.error_kind, 'client_4xx');
+    assert.equal(event?.tool, 'get_food_stocks');
+  });
+});
+
+describe('downstreamErrorTags for RpcValidationError', () => {
+  it('emits bounded validation tags without the violation text', () => {
+    const err = new RpcValidationError('get-food-stocks', [
+      { field: 'countryCode', description: 'countryCode is required' },
+    ]);
+    const tags = downstreamErrorTags(err);
+    assert.deepEqual(tags, {
+      downstream_operation: 'get-food-stocks',
+      downstream_status: '400',
+      downstream_error_code: 'rpc_validation',
+      downstream_response_marker: 'json_error',
+    });
+    assert.ok(!JSON.stringify(tags).includes('countryCode is required'));
+  });
+});


### PR DESCRIPTION
## Summary

An MCP agent that called `get_food_stocks` without `country_code` (or any other proto-validated RPC tool with a bad field) used to see only `Internal error: data fetch failed`. The sibling RPC had already returned HTTP 400 with `{ "violations": [{ "field": "countryCode", "description": "countryCode is required" }] }`, but `assertToolFetchOk` discarded the body and dispatch flattened the throw into JSON-RPC `-32603`.

Agents now get JSON-RPC `-32602 Invalid params` with `error.data.violations` — structured error data, not a `tools/call` result envelope. Billing denials, non-400 failures, telemetry `client_4xx` / `server_error` classification, and the generic fallback are unchanged. Malformed, HTML, oversized, and credential-like 400 bodies never copy raw content into the error.

Closes koala73/worldmonitor#6559

## Test plan

- `tsx --test tests/mcp-billing-denial.test.mjs tests/mcp-rpc-validation-error.test.mjs tests/mcp-downstream-error-classification.test.mjs` — 33 passed
- `npm run typecheck:api` — passed
- `npm run lint:boundaries` — passed
- Covered: helper GET-shaped 400, dispatch GET (`get_food_stocks`) and POST (`analyze_situation`), HTML/malformed/oversize/credential leak guards, billing-denial precedence, 5xx fallback, `client_4xx` telemetry

## Post-Deploy Monitoring & Validation

- Logs: `[mcp] tool execution error:` for `get_food_stocks` / `analyze_situation` should stay warning-level on HTTP 400; watch for a spike in `-32602` vs the previous `-32603` on those tools
- Telemetry: `mcp.toolcall` with `error_kind=client_4xx` on validation 400s; `server_error` must still be used for 5xx sibling failures
- Sentry: `mcp-tool-execution` fingerprints for `get-food-stocks:400` / `deduct-situation:400` should remain grouped; no new events should include raw HTML or `Authorization` / `Bearer` strings
- Healthy: agents retry with the named field after a 400; billing 403/503 still emit `X-Billing-Verification`
- Failure / rollback: if callers start seeing leaked body text in `error.data`, or billing denials flatten to `-32603`, revert this PR
- Window / owner: first 24h of MCP traffic after deploy; MCP / API owner

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Grok](https://img.shields.io/badge/Grok_4.6-000000)
