### PR TITLE
fix(ops): report PUBLISH_BLOCKED when a coverage gate refuses to publish

### DIFF
--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -34,7 +34,7 @@
 import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { GRACEFUL_FETCH_FAILURE_EXIT_CODE, loadEnvFile } from './_seed-utils.mjs';
+import { GRACEFUL_FETCH_FAILURE_EXIT_CODE, loadEnvFile, PUBLISH_BLOCKED_EXIT_CODE } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -337,6 +337,17 @@ function spawnSeed(scriptPath, { timeoutMs, label, bundleStartedAtMs }) {
           status: 'GRACEFUL_FAIL',
           reason: `graceful fetch failure (exit ${GRACEFUL_FETCH_FAILURE_EXIT_CODE})`,
         });
+      } else if (code === PUBLISH_BLOCKED_EXIT_CODE) {
+        // #6396: exit 0 must mean "the keys were written". A member whose
+        // coverage gate refused to publish — after preserving the last-good
+        // TTL — signals it with this dedicated code so the summary can never
+        // report OK for a section that wrote no seed-meta.
+        settle({
+          elapsed,
+          ok: false,
+          status: 'PUBLISH_BLOCKED',
+          reason: `coverage gate refused to publish (exit ${PUBLISH_BLOCKED_EXIT_CODE})`,
+        });
       } else {
         settle({ elapsed, ok: false, reason: `exit ${code ?? 'null'}${signal ? ` (signal ${signal})` : ''}` });
       }
@@ -526,7 +537,7 @@ export async function runBundle(label, sections, opts = {}) {
     ))))
     : null;
 
-  let ran = 0, skipped = 0, deferred = 0, failed = 0, gracefulFailed = 0, stalled = 0;
+  let ran = 0, skipped = 0, deferred = 0, failed = 0, gracefulFailed = 0, stalled = 0, publishBlocked = 0;
 
   let disabled = 0;
   for (const section of sections) {
@@ -628,6 +639,7 @@ export async function runBundle(label, sections, opts = {}) {
       // "Deploy Crashed!") over a benign per-member skip. Track it separately so
       // only HARD failures gate the exit code; the skip stays fully logged above.
       if (status === 'GRACEFUL_FAIL') gracefulFailed++;
+      else if (status === 'PUBLISH_BLOCKED') publishBlocked++;
       else failed++;
     }
   }
@@ -639,7 +651,11 @@ export async function runBundle(label, sections, opts = {}) {
   // rides along at the tail for the same reason: it is the starvation signal
   // #6562 item 4 exists to surface.
   const disabledField = disabled > 0 ? ` disabled:${disabled}` : '';
-  console.log(`[Bundle:${label}] Finished in ${totalSec}s, ran:${ran} skipped:${skipped} deferred:${deferred}${disabledField} failed:${failed} graceful:${gracefulFailed} stalled:${stalled}`);
+  // publish_blocked appends ONLY when non-zero, like `disabled:` above, so
+  // the documented summary line stays byte-identical for bundles without gate
+  // refusals (#6396).
+  const publishBlockedField = publishBlocked > 0 ? ` publish_blocked:${publishBlocked}` : '';
+  console.log(`[Bundle:${label}] Finished in ${totalSec}s, ran:${ran} skipped:${skipped} deferred:${deferred}${disabledField} failed:${failed} graceful:${gracefulFailed} stalled:${stalled}${publishBlockedField}`);
   // A tick that completed no section while deferring a due one accomplished
   // nothing AND shed work. Deferral only pays for itself if the deferred
   // section runs on a later tick, so this state repeating is a stalled
@@ -683,6 +699,13 @@ export async function runBundle(label, sections, opts = {}) {
     // does not paint CRASHED and fire a spurious alert. Real staleness is caught
     // independently by the /api/health freshness monitor keyed on seed-meta TTL.
     console.log(`[Bundle:${label}] ${gracefulFailed} graceful fetch skip(s), no hard failures — no data lost, exiting 0 (not a crash)`);
+  }
+  if (failed === 0 && publishBlocked > 0) {
+    // #6396: a gate refusal is not a crash — the member verified preservation
+    // of the last-good snapshot before exiting, and the freshness monitor
+    // alarms if the refusal persists. What changed versus the old exit-0
+    // silence is that the per-section line and summary now say so.
+    console.log(`[Bundle:${label}] ${publishBlocked} publish-blocked section(s) preserved last-good and wrote no seed keys — exiting 0; the freshness monitor owns the alarm`);
   }
   process.exit(failed > 0 || starvedTick || stalled > 0 ? 1 : 0);
 }

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -778,6 +778,12 @@ export const PERMANENT_4XX_STATUSES = new Set([400, 401, 403, 404, 410, 413, 422
 // generic crash.
 export const GRACEFUL_FETCH_FAILURE_EXIT_CODE = 75;
 
+// #6396: the seeder fetched its data but its coverage gate refused to publish
+// (and preserved the last-good TTL instead). Distinct from EX_TEMPFAIL so the
+// bundle runner can report PUBLISH_BLOCKED rather than OK for a section whose
+// entire purpose — writing the seed keys — did not happen.
+export const PUBLISH_BLOCKED_EXIT_CODE = 76;
+
 // Cap upstream Retry-After hints so a stuck/abusive header can't park the
 // bundle past its section timeoutMs. Mirrors _yahoo-fetch.mjs convention.
 const MAX_RETRY_AFTER_MS = 60_000;

--- a/scripts/seed-jodi-oil.mjs
+++ b/scripts/seed-jodi-oil.mjs
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 
 import {
   loadEnvFile,
+  PUBLISH_BLOCKED_EXIT_CODE,
   CHROME_UA,
   getRedisCredentials,
   acquireLockSafely,
@@ -587,7 +588,11 @@ async function main() {
       } else {
         console.warn('  COVERAGE GATE: no last-good snapshot exists to preserve');
       }
-      return;
+      // #6396: the gate refused to publish, so exit 0 would make the bundle
+      // report OK for a section whose seed keys were not written. Signal the
+      // dedicated outcome; main()'s finally still releases the lock on this
+      // return path.
+      return { publishBlocked: true };
     }
 
     console.log(chinaCoverage.ok
@@ -643,7 +648,9 @@ async function main() {
 
 const isMain = process.argv[1]?.endsWith('seed-jodi-oil.mjs');
 if (isMain) {
-  main().catch(err => {
+  main().then((outcome) => {
+    if (outcome?.publishBlocked) process.exit(PUBLISH_BLOCKED_EXIT_CODE);
+  }).catch(err => {
     console.error(err);
     process.exit(1);
   });

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -12,7 +12,7 @@ import { mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { GRACEFUL_FETCH_FAILURE_EXIT_CODE } from '../scripts/_seed-utils.mjs';
+import { GRACEFUL_FETCH_FAILURE_EXIT_CODE, PUBLISH_BLOCKED_EXIT_CODE } from '../scripts/_seed-utils.mjs';
 import { DAY, readSectionFreshness, bundleHeartbeatKey, BUNDLE_HEARTBEAT_TTL_SECONDS } from '../scripts/_bundle-runner.mjs';
 import {
   SUPERSEDED_KEY_TTL_SECONDS,
@@ -1028,6 +1028,50 @@ test('graceful-only fetch failure exits 0 (no data lost) but still logs the skip
     assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:0 failed:0 graceful:1/);
     assert.match(stdout, /\[Bundle:test\] 1 graceful fetch skip\(s\), no hard failures — no data lost, exiting 0/);
     assert.doesNotMatch(combined, /\[Bundle:test\] section=GRACEFUL status=OK/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('a coverage-gate refusal reports PUBLISH_BLOCKED, never OK (#6396)', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-publish-blocked.mjs',
+    `console.error('COVERAGE GATE FAILED: china-missing (dataMonth=missing)');\nconsole.log('Extended TTL on 52 key(s)');\nprocess.exit(${PUBLISH_BLOCKED_EXIT_CODE});\n`,
+  );
+  try {
+    const { code, stdout, stderr } = await runBundleWith([
+      { label: 'GATED', script: '_bundle-fixture-publish-blocked.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    const combined = stdout + stderr;
+    // The gate refused to publish and preserved the last-good TTL: not a
+    // crash (the freshness monitor owns the staleness alarm), but the summary
+    // must never be able to say OK for a section that wrote no seed keys.
+    assert.equal(code, 0, 'publish-blocked-only tick preserves last-good and is not a crash');
+    assert.match(combined, /\[GATED\] COVERAGE GATE FAILED: china-missing/);
+    assert.match(combined, new RegExp(`Failed after .*s: coverage gate refused to publish \\(exit ${PUBLISH_BLOCKED_EXIT_CODE}\\)`));
+    assert.match(combined, new RegExp(`\\[Bundle:test\\] section=GATED status=PUBLISH_BLOCKED .*reason=coverage gate refused to publish \\(exit ${PUBLISH_BLOCKED_EXIT_CODE}\\)`));
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:0 failed:0 graceful:0 stalled:0 publish_blocked:1/);
+    assert.match(stdout, /\[Bundle:test\] 1 publish-blocked section\(s\) preserved last-good and wrote no seed keys/);
+    assert.doesNotMatch(combined, /\[Bundle:test\] section=GATED status=OK/);
+    assert.doesNotMatch(stdout, /graceful:1/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('bundles without gate refusals keep a byte-identical summary line', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-ok-member.mjs',
+    `console.log('seeded');\n`,
+  );
+  try {
+    const { code, stdout } = await runBundleWith([
+      { label: 'OKMEMBER', script: '_bundle-fixture-ok-member.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    assert.equal(code, 0);
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:1 skipped:0 deferred:0 failed:0 graceful:0 stalled:0$/m);
+    // publish_blocked is appended only when non-zero, exactly like disabled:.
+    assert.doesNotMatch(stdout, /publish_blocked/);
   } finally {
     cleanup();
   }


### PR DESCRIPTION
## Summary

The bundle runner mapped child exit 0 to `status=OK`, so `seed-jodi-oil`'s coverage-gate path — which logs `COVERAGE GATE FAILED`, extends the last-good TTL, and returns — produced a healthy-looking section whose entire purpose, publishing `seed-meta:energy:jodi-oil`, did not happen (#6396). The identical `china-missing` condition was previously classified two different ways across the two JODI members, one of them silently.

This implements the issue's preferred option: a distinct, explicitly-signalled runner status.

- `PUBLISH_BLOCKED_EXIT_CODE = 76` joins `GRACEFUL_FETCH_FAILURE_EXIT_CODE = 75` in `_seed-utils.mjs` (single source of truth; `exit 0` keeps meaning "the keys were written").
- The runner maps exit 76 to `status=PUBLISH_BLOCKED` with reason `coverage gate refused to publish (exit 76)`, counts it in a `publish_blocked` summary field appended **only when non-zero** (like `disabled:`, the documented line stays byte-identical otherwise), and explains the tick on stdout.
- `seed-jodi-oil`'s gate now signals the outcome via `main()`'s return value, so the `finally` block still releases the lock before `process.exit(76)` — no lock leak.
- Exit-code semantics: a gate refusal is not a crash — the member verified preservation of the last-good snapshot, and the freshness monitor owns the staleness alarm — but it can no longer masquerade as `OK`.
- `seed-jodi-gas` no longer has a refusing gate (it publishes the other countries and carries the China diagnostic), so the historical two-way split cannot recur; any future gate copied from this pattern now has the non-OK outcome to signal.

## Type of change

- [x] Bug fix

## Affected areas

- [x] CI / Build / Infrastructure

## Checklist

- [ ] Tested on worldmonitor.app variant — N/A: cron/bundle-runner contract exercised by tests
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- Claim ledger: N/A
- Audit Council signoffs: N/A

## Testing

- New: `a coverage-gate refusal reports PUBLISH_BLOCKED, never OK (#6396)` — drives the runner with a member exiting through the gate path; asserts the per-section `status=PUBLISH_BLOCKED` line, the `publish_blocked:1` summary field, the explanatory tick line, exit 0, and that `status=OK` never appears.
- New: `bundles without gate refusals keep a byte-identical summary line` — `publish_blocked` is absent when zero.
- `node --test tests/bundle-runner.test.mjs` — 40/40 (including the two above)
- `node --test tests/jodi-oil-seed.test.mjs` — 64/64; `node --test tests/jodi-gas-seed.test.mjs` — pass
- `npm run typecheck`, `biome check` on all four changed files, `git diff --check` — clean

Fixes #6396