### PR TITLE
perf(prepush): fetch only to disprove a suspected contamination violation (#6764)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -80,20 +80,38 @@ if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; the
     BASE_REF="$PR_BASE_REF"
   fi
   BASE_REF="${BASE_REF:-main}"
-  # Refresh the remote-tracking ref before trusting it. A stacked branch's
-  # base may not be fetched locally at all yet, and even origin/main can be
-  # stale in a long-lived worktree — either way, counting against a stale
-  # ref reintroduces the exact false-positive this guard is meant to avoid.
+  # Refresh the remote-tracking ref only when the cached one could change the
+  # verdict (#6764). A fetch can only move origin/$BASE_REF forward, and
+  # `rev-list --count origin/$BASE_REF..HEAD` can therefore only stay the same
+  # or shrink — so a cached count within budget is already a guaranteed pass,
+  # and paying a warm 2s / cold 70s fetch on every push buys nothing. Fetch to
+  # disprove a suspected violation, or when the ref is not cached locally at
+  # all (first push of a stacked branch, stale long-lived worktree).
   # A failed fetch (offline, network hiccup) is not fatal: fall through to
   # whatever's already cached locally, same as before this change.
-  git fetch origin "$BASE_REF" --quiet 2>/dev/null || true
-  if ! git rev-parse --verify -q "origin/$BASE_REF" >/dev/null; then
-    echo "  Base ref 'origin/$BASE_REF' not resolvable, falling back to origin/main."
-    BASE_REF="main"
-    git fetch origin "$BASE_REF" --quiet 2>/dev/null || true
+  WM_MAX_COMMITS_AHEAD=20
+  WM_GUARD_NEED_FETCH=false
+  WM_GUARD_CACHED_COUNT=""
+  if git rev-parse --verify -q "origin/$BASE_REF" >/dev/null; then
+    WM_GUARD_CACHED_COUNT=$(git rev-list --count "origin/$BASE_REF..HEAD" 2>/dev/null || echo 0)
+    if [ "$WM_GUARD_CACHED_COUNT" -gt "$WM_MAX_COMMITS_AHEAD" ]; then
+      WM_GUARD_NEED_FETCH=true
+    fi
+  else
+    WM_GUARD_NEED_FETCH=true
   fi
-  COMMIT_COUNT=$(git rev-list --count "origin/$BASE_REF..HEAD" 2>/dev/null || echo 0)
-  if [ "$COMMIT_COUNT" -gt 20 ]; then
+  if [ "$WM_GUARD_NEED_FETCH" = true ]; then
+    git fetch origin "$BASE_REF" --quiet 2>/dev/null || true
+    if ! git rev-parse --verify -q "origin/$BASE_REF" >/dev/null; then
+      echo "  Base ref 'origin/$BASE_REF' not resolvable, falling back to origin/main."
+      BASE_REF="main"
+      git fetch origin "$BASE_REF" --quiet 2>/dev/null || true
+    fi
+    COMMIT_COUNT=$(git rev-list --count "origin/$BASE_REF..HEAD" 2>/dev/null || echo 0)
+  else
+    COMMIT_COUNT="$WM_GUARD_CACHED_COUNT"
+  fi
+  if [ "$COMMIT_COUNT" -gt "$WM_MAX_COMMITS_AHEAD" ]; then
     echo ""
     echo "============================================================"
     echo "ERROR: Branch '$BRANCH' is $COMMIT_COUNT commits ahead of origin/$BASE_REF."

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -35,6 +35,13 @@ const GIT_LOCAL_ENV_VARS = execFileSync('git', ['rev-parse', '--local-env-vars']
 const WORK = mkdtempSync(join(tmpdir(), 'wm-prepush-hook-'));
 after(() => rmSync(WORK, { recursive: true, force: true }));
 
+// Resolved before any stub directory exists on a PATH, so it always names the
+// real git — /usr/bin/git is not a portable assumption (Git-for-Windows keeps
+// it at /mingw64/bin/git).
+const REAL_GIT = execFileSync('bash', ['-c', 'command -v git'], {
+  encoding: 'utf8',
+}).trim();
+
 // One argument per line, `>` prefixed, so an assertion can tell a single
 // argument containing a space from two separate arguments.
 const STUB_BODY = (name, log) =>
@@ -54,6 +61,7 @@ const STUB_BODY = (name, log) =>
 function makeStubs(auxDir) {
   const bin = join(auxDir, 'bin');
   const log = join(auxDir, 'invocations.log');
+  const gitLog = join(auxDir, 'git-invocations.log');
   mkdirSync(bin, { recursive: true });
   for (const name of ['npm', 'npx', 'node', 'gh', 'make']) {
     const stub = join(bin, name);
@@ -65,7 +73,18 @@ function makeStubs(auxDir) {
     writeFileSync(stub, STUB_BODY(name, log).replace('#!/bin/sh\n', `#!/bin/sh\n${realScriptDispatch}`));
     chmodSync(stub, 0o755);
   }
-  return { bin, log };
+  // Transparent pass-through for the hook's own git usage that records fetch
+  // invocations, so a test can assert the contamination guard skipped the
+  // network without having to stub git itself (#6764).
+  const gitWrap = join(bin, 'git');
+  writeFileSync(
+    gitWrap,
+    `#!/bin/sh\n` +
+      `[ "$1" = fetch ] && echo "git-fetch $*" >> ${JSON.stringify(gitLog)}\n` +
+      `exec ${JSON.stringify(REAL_GIT)} "$@"\n`,
+  );
+  chmodSync(gitWrap, 0o755);
+  return { bin, log, gitLog };
 }
 
 function hookEnv(bin) {
@@ -90,7 +109,7 @@ let fixtureCount = 0;
 function makeFixture({ branchFiles = {}, scriptsCjs = true, failAttestMode = null } = {}) {
   const id = fixtureCount++;
   const root = join(WORK, `repo-${id}`);
-  const { bin, log } = makeStubs(join(WORK, `aux-${id}`));
+  const { bin, log, gitLog } = makeStubs(join(WORK, `aux-${id}`));
   const env = hookEnv(bin);
   const git = (args) => execFileSync('git', args, { cwd: root, env, encoding: 'utf8' });
 
@@ -166,7 +185,9 @@ function makeFixture({ branchFiles = {}, scriptsCjs = true, failAttestMode = nul
     }
     const invocations = existsSync(log) ? readFileSync(log, 'utf8') : '';
     rmSync(log, { force: true });
-    return { status, stdout, invocations };
+    const gitCalls = existsSync(gitLog) ? readFileSync(gitLog, 'utf8') : '';
+    rmSync(gitLog, { force: true });
+    return { status, stdout, invocations, gitCalls };
   };
 
   const cachePath = join(root, '.git', 'wm-prepush-green');
@@ -526,6 +547,77 @@ describe('a broken enumeration blocks the push, it does not empty the list', () 
       assert.equal(fixture.cached(), null);
     });
   }
+});
+
+describe('the contamination guard fetches only to disprove a violation (#6764)', () => {
+  // A fetch can only move origin/$BASE_REF forward, so the count against it
+  // can only shrink. A cached count within budget is therefore a guaranteed
+  // pass, and the common path must pay no network for it — while a suspected
+  // violation still gets the fetch it needs before the guard errors.
+
+  const externalEnv = (() => {
+    const env = { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' };
+    for (const name of GIT_LOCAL_ENV_VARS) delete env[name];
+    return env;
+  })();
+  const externalGit = (cwd, args) =>
+    execFileSync('git', args, { cwd, env: externalEnv, encoding: 'utf8' });
+  const fetchCount = (gitCalls) => (gitCalls.match(/^git-fetch /gm) || []).length;
+
+  test('a branch within budget pushes with no fetch at all', () => {
+    const fixture = makeFixture({ branchFiles: { 'tests/guard.test.mjs': 'x\n' } });
+    fixture.git(['checkout', '-q', '-b', 'feature/within-budget']);
+
+    const { status, stdout, gitCalls } = fixture.run();
+    assert.equal(status, 0, stdout);
+    assert.equal(fetchCount(gitCalls), 0, 'cached count 1 ≤ 20 is already a guaranteed pass');
+  });
+
+  test('a stale-ref false positive still fetches, disproves itself, and passes', () => {
+    const fixture = makeFixture();
+    const id = fixtureCount++;
+    const bare = join(WORK, `guard-bare-${id}`);
+    const clone2 = join(WORK, `guard-clone2-${id}`);
+    externalGit(WORK, ['init', '--quiet', '--bare', '--initial-branch=main', bare]);
+    fixture.git(['remote', 'add', 'origin', bare]);
+    const base = fixture.git(['rev-parse', 'HEAD']).trim();
+    fixture.git(['push', '--quiet', 'origin', 'main']); // remote main = base
+    // Advance the remote through a second clone so the fixture's cached
+    // origin/main stays stale — the exact false-positive shape the guard
+    // exists to avoid.
+    externalGit(WORK, ['clone', '--quiet', bare, clone2]);
+    externalGit(clone2, ['config', 'user.email', 'guard-fixture@example.invalid']);
+    externalGit(clone2, ['config', 'user.name', 'Guard Fixture']);
+    for (let i = 0; i < 25; i++) {
+      externalGit(clone2, ['commit', '--allow-empty', '--quiet', '-m', `bulk ${i}`]);
+    }
+    externalGit(clone2, ['push', '--quiet', 'origin', 'main']);
+    // Bring the new tip in WITHOUT admitting it to the cached tracking ref.
+    // The explicit re-stale is needed because a modern git opportunistically
+    // refreshes refs/remotes/origin/main on any fetch that contacts the
+    // remote, refspec or not.
+    fixture.git(['fetch', '--quiet', 'origin', 'main:refs/heads/__remote-main']);
+    fixture.git(['update-ref', 'refs/remotes/origin/main', base]);
+    fixture.git(['checkout', '-q', '-b', 'feature/on-new-main', '__remote-main']);
+    fixture.git(['commit', '--allow-empty', '--quiet', '-m', 'real work']);
+
+    const { status, stdout, gitCalls } = fixture.run();
+    assert.equal(status, 0, stdout);
+    assert.equal(fetchCount(gitCalls), 1, 'cached count 26 > 20 must fetch exactly once to recompute');
+  });
+
+  test('a genuinely contaminated branch still errors after trying to disprove', () => {
+    const fixture = makeFixture();
+    fixture.git(['checkout', '-q', '-b', 'feature/contaminated']);
+    for (let i = 0; i < 25; i++) {
+      fixture.git(['commit', '--allow-empty', '--quiet', '-m', `stray ${i}`]);
+    }
+
+    const { status, stdout, gitCalls } = fixture.run();
+    assert.equal(status, 1, 'the guard must not get weaker');
+    assert.match(stdout, /commits ahead/);
+    assert.equal(fetchCount(gitCalls), 1, 'the cached count may be a stale-ref false positive, so it still fetches first');
+  });
 });
 
 describe('the gate does not fail closed on its own edge cases', () => {


### PR DESCRIPTION
Closes #6764.

## The change

The branch-contamination guard refreshed `origin/$BASE_REF` on **every push** so the >20-commits check would not false-positive against a stale tracking ref. This inverts it, per the equivalence argument in the issue:

> A fetch can only move `origin/$BASE_REF` **forward**, and `git rev-list --count origin/$BASE_REF..HEAD` can therefore only stay the same or **shrink**.

So:

- cached count ≤ 20 → post-fetch count ≤ 20 → the guard passes either way → **skip the fetch**
- cached count > 20 → may be a stale-ref false positive → **fetch, recompute, only then error**
- ref not cached locally at all → **must fetch**, as before (first push of a stacked branch)

The fallback chain (unresolvable base → `main`), the non-fatal offline behavior, and the error text are unchanged. `20` is now `WM_MAX_COMMITS_AHEAD`, used by both the skip decision and the final verdict so they cannot drift.

## What it buys

The warm fetch was 2.1s and the cold one 71.9s when `main` had moved — charged to every push from ~18 concurrent sessions, on the critical path before any gate runs. The common path (cached count within budget) now pays zero network.

## Tests

Three regression tests in `tests/prepush-hook-gate.test.mjs`, using a new transparent `git` pass-through wrapper in the stub bin that records `fetch` invocations without stubbing git itself:

1. **within budget** — a feature branch 1 commit ahead of the cached ref pushes with **zero** fetches.
2. **stale-ref false positive** — the fixture's cached `origin/main` is deliberately left stale behind a remote that advanced 25 commits (explicit `update-ref` re-stale, because modern git opportunistically refreshes tracking refs on any fetch); the branch is really 1 commit ahead. The guard fetches **exactly once**, recomputes to 1, and the push passes. This is the exact scenario the original fetch existed for.
3. **genuinely contaminated** — 25 commits ahead with nothing new on the remote: still fetches once (to try to disprove), then errors with the same message as before. The guard does not get weaker.

One pre-existing portability nit fixed en route: `command -v git` is resolved at module load for the wrapper (Git-for-Windows keeps git at `/mingw64/bin/git`, not `/usr/bin/git`).

Verified locally: the three new tests pass; no other test in the file changed outcome relative to the pre-change baseline.