### PR TITLE
fix(seeders): no-data military-bases fallback stops walking and stops exiting green (#6845 item 2)

### DIFF
--- a/scripts/seed-military-bases.mjs
+++ b/scripts/seed-military-bases.mjs
@@ -3,7 +3,7 @@
 import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join } from 'node:path';
-import { loadEnvFile } from './_seed-utils.mjs';
+import { loadEnvFile, GRACEFUL_FETCH_FAILURE_EXIT_CODE } from './_seed-utils.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -24,6 +24,14 @@ const PROGRESS_INTERVAL = 5000;
 // The window it actually has to cover is one in-flight HTTP request, which is
 // seconds; 30s is an order of magnitude over that.
 export const GRACE_PERIOD_MS = 30 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+// Mirrors Military-Bases' `intervalMs` in seed-bundle-static-ref.mjs. The
+// seeder owns the "is the published data already stale" verdict because it is
+// the only party that knows the no-data fallback restored data it could not
+// refresh (#6845): without this, that fallback restores the active version's
+// own timestamp and exits green every day while the data ages forever — due
+// again next tick, indistinguishable from progress.
+export const SECTION_INTERVAL_MS = 30 * DAY_MS;
 const VALIDATION_BATCH_SIZE = 500;
 const USER_AGENT = 'worldmonitor-military-bases-seeder/1.0';
 
@@ -517,7 +525,24 @@ async function main() {
 
   if (!dataPath) {
     console.log('No data file found locally or on R2 — falling back to the published active version.');
-    await backfillSeedMetaFromActiveVersion(redisUrl, redisToken, prefix);
+    // Shallow on purpose (#6845): the corpus was validated when it was
+    // published, no new data arrived, and re-walking all ~125k members costs
+    // ~250 round trips — every day, proving nothing about freshness.
+    const backfilled = await backfillSeedMetaFromActiveVersion(redisUrl, redisToken, prefix, { deep: false });
+    const ageMs = Date.now() - backfilled.fetchedAt;
+    if (ageMs > SECTION_INTERVAL_MS) {
+      console.warn(
+        `  Published data is ${Math.floor(ageMs / DAY_MS)}d old — past the `
+          + `${Math.round(SECTION_INTERVAL_MS / DAY_MS)}d interval, and this fallback could not `
+          + `refresh it. Exiting ${GRACEFUL_FETCH_FAILURE_EXIT_CODE} so this tick is `
+          + 'distinguishable from progress instead of exiting green forever (#6845).',
+      );
+      // exitCode rather than process.exit(): the keep-alive sockets behind the
+      // Redis REST client need to drain, and tearing them down synchronously
+      // trips libuv assertions on some platforms.
+      process.exitCode = GRACEFUL_FETCH_FAILURE_EXIT_CODE;
+      return;
+    }
     return;
   }
 

--- a/tests/seed-military-bases-no-data-fallback.test.mjs
+++ b/tests/seed-military-bases-no-data-fallback.test.mjs
@@ -1,0 +1,136 @@
+// #6845 item 2 — when the volume file, the local file and R2 are all
+// unavailable, the seeder restored the freshness marker from the active
+// version and exited 0, with a DEEP validation walk (~250 round trips for
+// ~125k members). The restored marker carries the active version's own
+// timestamp, so once that data passed its interval the section was due again
+// next tick and took the same path: a ~500-round-trip deep walk, every day,
+// exiting green, with the data never refreshed and the tick indistinguishable
+// from progress.
+//
+// Pinned here, end to end against the real script and a fake Upstash:
+//   1. the fallback validates shallowly — no ZRANGE member walk at all;
+//   2. data already past the interval exits GRACEFUL_FETCH_FAILURE_EXIT_CODE
+//      (75) with a distinct warning, so the runner records GRACEFUL_FAIL;
+//   3. data within the interval still exits 0 quietly.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+const SCRIPTS_DIR = fileURLToPath(new URL('../scripts/', import.meta.url));
+const DAY = 24 * 60 * 60 * 1000;
+
+function startFakeUpstash({ activeVersion, geoCount = 3, metaCount = 3 }) {
+  const strings = new Map([
+    ['military:bases:active', activeVersion],
+    // Present on purpose: the missing-marker repair path would otherwise
+    // short-circuit the run before the no-data fallback this file exercises.
+    ['seed-meta:military:bases', JSON.stringify({
+      fetchedAt: Number(activeVersion),
+      recordCount: geoCount,
+      sourceVersion: activeVersion,
+    })],
+  ]);
+  const geoMembers = new Map([[`military:bases:geo:${activeVersion}`, ['a', 'b', 'c']]]);
+  const zranges = [];
+  const server = createServer((req, res) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', c => { body += c; });
+    req.on('end', () => {
+      const commands = JSON.parse(body);
+      const run = ([operation, key, ...args]) => {
+        if (operation === 'GET') return { result: strings.get(key) ?? null };
+        if (operation === 'ZCARD') return { result: geoMembers.get(key)?.length ?? 0 };
+        if (operation === 'HLEN') return { result: metaCount };
+        if (operation === 'ZRANGE') {
+          zranges.push(key);
+          return { result: geoMembers.get(key) ?? [] };
+        }
+        if (operation === 'SCAN') return { result: ['0', []] };
+        if (operation === 'TTL') return { result: -1 };
+        if (operation === 'SET') {
+          strings.set(key, args[0]);
+          return { result: 'OK' };
+        }
+        if (operation === 'EVAL') {
+          // Backfill-if-active shape: CAS on the active version.
+          const current = strings.get('military:bases:active') ?? '';
+          return { result: [1, current] };
+        }
+        return { result: null };
+      };
+      const results = req.url === '/pipeline' ? commands.map(run) : run(commands);
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(results));
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        token: 'test-token',
+        zranges: () => zranges,
+        async close() {
+          return new Promise((done) => server.close(done));
+        },
+      });
+    });
+  });
+}
+
+function runSeeder(fake, env = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [join(SCRIPTS_DIR, 'seed-military-bases.mjs')], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        UPSTASH_REDIS_REST_URL: fake.url,
+        UPSTASH_REDIS_REST_TOKEN: fake.token,
+        // No CLOUDFLARE_* credentials and no /data volume: the local data
+        // file is absent from the repo, so the run must take the fallback.
+        CLOUDFLARE_R2_TOKEN: '',
+        CLOUDFLARE_API_TOKEN: '',
+        CLOUDFLARE_R2_ACCOUNT_ID: '',
+        ...env,
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', c => { stdout += c; });
+    child.stderr.on('data', c => { stderr += c; });
+    child.on('close', code => resolve({ code, stdout, stderr }));
+  });
+}
+
+test('the no-data fallback walks nothing and exits 0 while data is within its interval', async () => {
+  const fake = await startFakeUpstash({ activeVersion: String(Date.now() - 60_000) });
+  try {
+    const { code, stdout, stderr } = await runSeeder(fake);
+    assert.equal(code, 0, `exit 0 expected\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    assert.match(stdout, /falling back to the published active version/);
+    assert.equal(fake.zranges().length, 0, 'the fallback must validate shallowly — a daily ~250-round-trip member walk proves nothing about freshness');
+    assert.doesNotMatch(stdout, /past the \d+d interval/);
+  } finally {
+    await fake.close();
+  }
+});
+
+test('data past its interval exits 75 with a distinct warning instead of green', async () => {
+  const fake = await startFakeUpstash({ activeVersion: String(Date.now() - 31 * DAY) });
+  try {
+    const { code, stdout, stderr } = await runSeeder(fake);
+    assert.equal(code, 75, `exit 75 expected for already-stale data\nstdout:\n${stdout}\nstderr:\n${stderr}`);
+    assert.match(`${stdout}${stderr}`, /past the 30d interval/);
+    assert.match(`${stdout}${stderr}`, /distinguishable from progress/);
+    assert.equal(fake.zranges().length, 0, 'the stale path must also stay shallow');
+  } finally {
+    await fake.close();
+  }
+});


### PR DESCRIPTION
Second follow-up from #6845: the no-data fallback could loop green forever while the data aged.

## The loop

When the volume file, the local file and R2 are all unavailable, `main()` fell back to `backfillSeedMetaFromActiveVersion(...)` with the **deep** validation walk (~250 round trips for ~125k members) and exited 0. The restored marker carries the active version's **own** timestamp, so once that data passed its 30-day interval the section was due again next tick and took the same path — every day, exiting green, with the data never refreshed and the tick indistinguishable from progress.

## Fix

1. **The fallback validates shallowly.** The corpus was validated when it was published, no new data arrived, and re-walking all members daily proves nothing about freshness.
2. **Already-stale data exits `GRACEFUL_FETCH_FAILURE_EXIT_CODE` (75)** with a distinct warning (`past the 30d interval ... distinguishable from progress`), so the runner records `GRACEFUL_FAIL` instead of a green tick. Data within its interval still exits 0 quietly. The interval mirrors `Military-Bases`' `intervalMs` in `seed-bundle-static-ref.mjs`.

One platform nit: the stale exit uses `process.exitCode = 75` + return rather than `process.exit(75)` — the keep-alive sockets behind the Redis REST client need to drain, and tearing them down synchronously trips libuv `UV_HANDLE_CLOSING` assertions (observed on Windows; harmless per the stack, but exit codes got clobbered).

## Tests

`tests/seed-military-bases-no-data-fallback.test.mjs` runs the real script as a child against a fake Upstash HTTP server:

- fresh active version → exit 0, fallback message, **zero ZRANGE calls** (the daily walk is gone);
- active version 31d old → exit 75, the stale warning, still zero ZRANGE calls.

Existing suites re-run green on this branch: 9/9 seeder bundle-slot, 48/48 bundle-runner.