### PR TITLE
fix(canada): give StatCan freshness its own issue

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -919,7 +919,7 @@ const SEED_META = {
       issue: 6676,
       status: 'EMPTY',
     },
-  }, // daily seed-bundle-macro 08:00 UTC. Toronto-today 409 "not released yet" is quiet like 404; CPI/LFS still POST. EMPTY ack #6676 expires 2026-08-16T08:00Z (real cron tick, not 13:00Z). Floor is the two resilience cubes (CPI YoY + LFS).
+  }, // daily seed-bundle-macro 08:00 UTC. Toronto-today 409 "not released yet" is quiet like 404; CPI/LFS still POST. First-publish EMPTY ack #6676 retired after recovery. Floor is the two resilience cubes (CPI YoY + LFS).
   eurostatCountryData: { key: 'seed-meta:economic:eurostat-country-data', maxStaleMin: 4320 }, // daily seed; 4320min = 3 days = 3x interval
   eurostatHousePrices: { key: 'seed-meta:economic:eurostat-house-prices', maxStaleMin: 60 * 24 * 50 }, // weekly cron, annual data; 50d threshold = 35d TTL + 15d buffer
   eurostatGovDebtQ:    { key: 'seed-meta:economic:eurostat-gov-debt-q',   maxStaleMin: 60 * 24 * 14 }, // 2d cron, quarterly data; 14d threshold matches TTL + quarterly release drift
@@ -1196,8 +1196,8 @@ const ON_DEMAND_KEYS = new Set([
   // marker after its first successful publish; from then on it is strict forever.
   'cbrRates',
   // Same deploy-before-first-tick bridge as cbrRates for the two Canada
-  // national-statistics seeders (#6616). Softening lifts once the durable
-  // activation marker exists.
+  // national-statistics seeders: bocValet (#6616) and statcanWds (#6676).
+  // Softening lifts once the durable activation marker exists.
   'bocValet',
   'statcanWds',
   'riskScoresLive',

--- a/scripts/seed-statcan-wds.mjs
+++ b/scripts/seed-statcan-wds.mjs
@@ -2,7 +2,7 @@
 
 /**
  * Statistics Canada Web Data Service — same-day cube radar plus the CPI / LFS
- * series the Country Resilience Index consumes for CA. Issue #6616.
+ * series the Country Resilience Index consumes for CA. Issue #6676.
  * Independent clock from Bank of Canada Valet. Empty change-list is valid quiet.
  */
 

--- a/tests/statcan-wds.test.mjs
+++ b/tests/statcan-wds.test.mjs
@@ -32,6 +32,7 @@ import {
   LFS_PRODUCT_ID,
 } from '../scripts/lib/statcan-wds.mjs';
 import { DAY_MIN } from '../scripts/_content-age-helpers.mjs';
+import { __testing__ as healthTesting } from '../api/health.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const changedDoc = JSON.parse(readFileSync(resolve(here, 'fixtures/statcan-wds/changed-cube-list.json'), 'utf8'));
@@ -361,7 +362,7 @@ test('StatCan scored freshness is invariant across UTC, Toronto, and Dubai proce
   ]);
 });
 
-test('the StatCan and BoC EMPTY waivers are retired, and the 08:00 cron stays documented', () => {
+test('the StatCan and BoC EMPTY waivers are retired with independent issue ownership', () => {
   // Was: pinned both waivers' exact anchors, to prove they used the real 08:00
   // UTC tick rather than a mistaken 13:00 one. Both probes now publish, so the
   // monitor reports them as "no longer reported; remove it" and #6799 pruned
@@ -382,6 +383,14 @@ test('the StatCan and BoC EMPTY waivers are retired, and the 08:00 cron stays do
       `${name} publishes again; do not suppress a future recurrence`,
     );
   }
+
+  assert.match(seederSrc, /Issue #6676\./, 'the StatCan seeder must point to its own tracking issue');
+  assert.doesNotMatch(seederSrc, /Issue #6616\./, 'the StatCan seeder must not point to the BoC issue');
+  assert.equal(
+    healthTesting.SEED_META.statcanWds.cutover?.issue,
+    6676,
+    'the StatCan health cutover must point to its own tracking issue',
+  );
 
   // The 13:00 anchor was never a real cron. Keep it out of every surface.
   assert.doesNotMatch(healthSrc, /2026-08-16T13:00/);


### PR DESCRIPTION
## Summary

Before this change, the StatCan WDS seeder and the shared Canada activation note still identified the Bank of Canada issue, which made first-publish follow-up ambiguous even though the health cutover already used its dedicated tracker. StatCan WDS ownership is now consistently bound to #6676, with a runtime-metadata assertion that prevents comments or shadow declarations from satisfying the regression test.

Fixes #6676.

## Validation

- `npm run test:data` — 24,493 passed, 0 failed, 6 skipped.
- Pre-push gates passed, including browser and API type checks, architectural boundaries, the health cutover check, the 14-test StatCan suite, and 253 Edge Function tests.
- A direct production `/api/health` probe was not possible without credentials; the protected endpoint returned 401.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required. This PR corrects ownership metadata and strengthens regression coverage; it does not change seeding or health runtime behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
