### PR TITLE
fix(consumer-prices): the US water window admits the pack it declares (#6869)

### DIFF
--- a/consumer-prices-core/configs/baskets/essentials_us.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_us.yaml
@@ -90,8 +90,13 @@ basket:
       weight: 0.07
       baseUnit: ml
       substitutionGroup: water_still
-      minBaseQty: 6000
-      maxBaseQty: 10000
+      # 24 x 16 fl oz = 11,356 ml and 24 x 16.9 fl oz = 11,995 ml; the old
+      # 6,000-10,000 ceiling sat below the pack the canonical name itself
+      # declares, so any correctly-parsed hit for THIS product hard-failed the
+      # window (#6869). 12,500 admits both bottle sizes while still rejecting
+      # the 32-packs retailers actually serve (~15,331 g at water density).
+      minBaseQty: 10000
+      maxBaseQty: 12500
       negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg

--- a/consumer-prices-core/tests/unit/basket-size-corpus.test.ts
+++ b/consumer-prices-core/tests/unit/basket-size-corpus.test.ts
@@ -154,3 +154,38 @@ describe('basket corpus vs the #6267 size rules', () => {
     });
   });
 });
+
+describe('US drinking water: the window admits the pack it declares (#6869)', () => {
+  // 24 x 16 fl oz = 11,356 ml sat ABOVE the old 10,000 ceiling, so the item
+  // could only ever price through sizes that failed to parse — a price that
+  // survived because the window never ran. The raised window admits both the
+  // declared 16oz pack and the very common 16.9oz bottle, while the 32-packs
+  // Walmart actually serves (~1.6x the intended pack) stay rejected.
+  const us = loadAllBasketConfigs().find((b) => b.slug === 'essentials-us');
+  const water = us?.items.find((it) => it.id === 'water_1_5l');
+
+  it('finds the item (guard against silent config moves)', () => {
+    expect(water).toBeTruthy();
+  });
+
+  // Same-unit sizes, so the verdict exercises the hard window rather than the
+  // cross-dimension density band: the declared pack expressed in the item's
+  // own ml, and the 32-pack retailers actually serve.
+  const cases: Array<[string, SizeWindowStatus]> = [
+    ['24 x 473 ml', 'pass'],
+    ['11.4 L', 'pass'],
+    ['32 x 500 ml', 'fail'],
+  ];
+
+  for (const [sizeText, expected] of cases) {
+    it(`"${sizeText}" -> ${expected}`, () => {
+      const r = validateSearchHit({
+        canonicalName: water!.canonicalName,
+        productName: 'Aquafina Purified Drinking Water',
+        sizeText,
+        item: water!,
+      });
+      expect(r.signals.sizeWindow).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
Closes #6869, taking the issue's primary suggestion (raise the ceiling).

## The contradiction

24 × 16 fl oz = **11,356 ml** and 24 × 16.9 fl oz = **11,995 ml** both sat above the item's `maxBaseQty: 10000`, so any hit that parsed correctly **for the product the item describes** hard-failed the quantity window — the item could only ever price through sizes that failed to parse, a price that survived because the gate never ran.

## The fix

`minBaseQty: 10000` / `maxBaseQty: 12500`:

- both common bottle sizes (16oz and the very common 16.9oz) are admitted in the item's own unit;
- the 32-packs Walmart actually serves stay rejected both ways — same-unit `32 × 500 ml` = 16,000 ml fails the hard window, and the cross-dimension ~15,331 g reading fails the density band (lo = 15,331/1.1 ≈ 13,937 > 12,500 → `unit-mismatch`), roughly 1.6× the intended pack.

## Tests

Four additions to the basket corpus suite. The replay cases deliberately use **same-unit** sizes (`24 x 473 ml`, `11.4 L`, `32 x 500 ml`) so the verdict exercises the hard window rather than landing in the neutral cross-dimension branch — a subtlety the first draft of this fix got wrong and the tests caught. Plus a guard that the item is still found, against silent config moves.

`consumer-prices-core` unit suite: 57/57 green.