### PR TITLE
fix(consumer-prices): an unreadable size no longer publishes as verified (#6868)

### DIFF
--- a/consumer-prices-core/configs/baskets/essentials_us.yaml
+++ b/consumer-prices-core/configs/baskets/essentials_us.yaml
@@ -90,8 +90,13 @@ basket:
       weight: 0.07
       baseUnit: ml
       substitutionGroup: water_still
-      minBaseQty: 6000
-      maxBaseQty: 10000
+      # 24 x 16 fl oz = 11,356 ml and 24 x 16.9 fl oz = 11,995 ml; the old
+      # 6,000-10,000 ceiling sat below the pack the canonical name itself
+      # declares, so any correctly-parsed hit for THIS product hard-failed the
+      # window (#6869). 12,500 admits both bottle sizes while still rejecting
+      # the 32-packs retailers actually serve (~15,331 g at water density).
+      minBaseQty: 10000
+      maxBaseQty: 12500
       negativeTokens: ["sparkling", "flavored", "flavoured"]
 
     - id: sugar_1kg

--- a/consumer-prices-core/src/adapters/validator.test.ts
+++ b/consumer-prices-core/src/adapters/validator.test.ts
@@ -307,7 +307,9 @@ describe('validateSearchHit — wrong-product admissions (#6267)', () => {
       item: item({ baseUnit: 'ct', minBaseQty: 10, maxBaseQty: 15 }),
     });
     expect(r.ok).toBe(true);
-    expect(r.signals.sizeWindow).toBe('unknown');
+    // #6868: the count-unit carve-out is a deliberate could-not-verify, not
+    // the neutral nothing-to-verify.
+    expect(r.signals.sizeWindow).toBe('unreadable');
     expect(r.signals.extractedBaseQty).toBe(660);
   });
 
@@ -397,7 +399,9 @@ describe('validateSearchHit — wrong-product admissions (#6267)', () => {
       sizeText: '12 pcs',
       item: item({ baseUnit: 'g', minBaseQty: 350, maxBaseQty: 450 }),
     });
-    expect(r.signals.sizeWindow).toBe('unknown');
+    // #6868: the count-unit carve-out stays a non-reject, but it is now
+    // labeled could-not-verify rather than neutral — nothing was checked.
+    expect(r.signals.sizeWindow).toBe('unreadable');
     expect(r.ok).toBe(true);
   });
 
@@ -456,5 +460,55 @@ describe('validateSearchHit — non-food and token overlap', () => {
     expect(r.ok).toBe(false);
     expect(r.reasons).toContain('empty-product-name');
     expect(r.score).toBe(0);
+  });
+});
+
+// ── #6868: "could not verify" is not "nothing to verify" ──────────────────────
+describe('unreadable size scoring (#6868)', () => {
+  const waterItem = item({ baseUnit: 'ml', minBaseQty: 6000, maxBaseQty: 10000 });
+
+  it('a present-but-unparseable sizeText is unreadable, not unknown', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Drinking Water 24 Pack 16oz',
+      productName: 'Drinking Water 24 Pack 16oz',
+      sizeText: '24 unidades',
+      item: waterItem,
+    });
+    expect(r.signals.sizeWindow).toBe('unreadable');
+  });
+
+  it('no longer reaches auto on token overlap alone (0.70 < 0.75)', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Drinking Water 24 Pack 16oz',
+      productName: 'Drinking Water 24 Pack 16oz',
+      sizeText: 'pack 12x lx',
+      item: waterItem,
+    });
+    expect(r.signals.tokenOverlap).toBe(1);
+    expect(r.score).toBeCloseTo(0.55 + 0.05 + 0.1);
+    expect(r.score).toBeLessThan(AUTO_MATCH_THRESHOLD);
+  });
+
+  it('a structurally-absent size keeps the neutral 0.2 and still clears auto', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Drinking Water 24 Pack 16oz',
+      productName: 'Drinking Water 24 Pack 16oz',
+      sizeText: undefined,
+      item: waterItem,
+    });
+    expect(r.signals.sizeWindow).toBe('unknown');
+    expect(r.score).toBeCloseTo(0.55 + 0.2 + 0.1);
+    expect(r.score).toBeGreaterThanOrEqual(AUTO_MATCH_THRESHOLD);
+  });
+
+  it('no window configured stays neutral unknown', () => {
+    const r = validateSearchHit({
+      canonicalName: 'Drinking Water 24 Pack 16oz',
+      productName: 'Drinking Water 24 Pack 16oz',
+      sizeText: 'pack 12x lx',
+      item: item({}),
+    });
+    expect(r.signals.sizeWindow).toBe('unknown');
+    expect(r.score).toBeCloseTo(0.55 + 0.2 + 0.1);
   });
 });

--- a/consumer-prices-core/src/adapters/validator.ts
+++ b/consumer-prices-core/src/adapters/validator.ts
@@ -40,7 +40,7 @@ const CONTENT_MEASURE_UNITS = new Set(['g', 'ml']);
 const DENSITY_G_PER_ML_MIN = 0.8;
 const DENSITY_G_PER_ML_MAX = 1.2;
 
-export type SizeWindowStatus = 'pass' | 'fail' | 'unit-mismatch' | 'unknown';
+export type SizeWindowStatus = 'pass' | 'fail' | 'unit-mismatch' | 'unknown' | 'unreadable';
 
 export interface ValidatorInput {
   canonicalName: string;
@@ -140,7 +140,12 @@ function evaluateSizeWindow(
   if (item.minBaseQty == null && item.maxBaseQty == null) return noSize;
   if (!sizeText) return noSize;
   const parsed = parseSize(sizeText);
-  if (!parsed) return noSize;
+  if (!parsed) {
+    // #6868: a size that was PRESENT but could not be read is a failure to
+    // verify, not an absence of something to verify. Scoring treats the two
+    // differently; the status carries which one happened.
+    return { status: 'unreadable' as const, baseQty: null, baseUnit: null };
+  }
 
   const min = item.minBaseQty ?? 0;
   const max = item.maxBaseQty ?? Number.POSITIVE_INFINITY;
@@ -148,7 +153,9 @@ function evaluateSizeWindow(
   if (parsed.baseUnit !== item.baseUnit) {
     // A count unit on either side carries no content information at all.
     if (!CONTENT_MEASURE_UNITS.has(item.baseUnit) || !CONTENT_MEASURE_UNITS.has(parsed.baseUnit)) {
-      return { status: 'unknown', baseQty: parsed.baseQuantity, baseUnit: parsed.baseUnit };
+      // #6867's deliberate count-unit carve-out: no content information on
+      // one side, so nothing was verified either way (#6868 split).
+      return { status: 'unreadable', baseQty: parsed.baseQuantity, baseUnit: parsed.baseUnit };
     }
     // Both sides measure content, in different dimensions. Convert across the
     // density band and reject only when NO plausible density lands the product
@@ -218,7 +225,15 @@ export function validateSearchHit(input: ValidatorInput): ValidatorResult {
   // Score combines positive signals even when hard-failing, so candidate rows
   // retain their relative quality for later review.
   // Weights: token overlap 0.55, size 0.35 (or 0.2 neutral when unknown), class-clean 0.10.
-  const sizeComponent = sizeEval.status === 'pass' ? 0.35 : sizeEval.status === 'unknown' ? 0.2 : 0;
+  // 'unreadable' — a size was present but nothing could be verified (#6868) —
+  // drops to 0.05: at full token overlap the hit lands at 0.70, below
+  // AUTO_MATCH_THRESHOLD, so it records as a reviewable candidate instead of
+  // publishing as a verified price. Structurally-absent sizes keep 0.2.
+  const sizeComponent =
+    sizeEval.status === 'pass' ? 0.35
+    : sizeEval.status === 'unknown' ? 0.2
+    : sizeEval.status === 'unreadable' ? 0.05
+    : 0;
   const classClean = nonFood || negHit ? 0 : 0.1;
   const score = Math.min(1, Math.max(0, overlap * 0.55 + sizeComponent + classClean));
 

--- a/consumer-prices-core/tests/unit/basket-size-corpus.test.ts
+++ b/consumer-prices-core/tests/unit/basket-size-corpus.test.ts
@@ -154,3 +154,38 @@ describe('basket corpus vs the #6267 size rules', () => {
     });
   });
 });
+
+describe('US drinking water: the window admits the pack it declares (#6869)', () => {
+  // 24 x 16 fl oz = 11,356 ml sat ABOVE the old 10,000 ceiling, so the item
+  // could only ever price through sizes that failed to parse — a price that
+  // survived because the window never ran. The raised window admits both the
+  // declared 16oz pack and the very common 16.9oz bottle, while the 32-packs
+  // Walmart actually serves (~1.6x the intended pack) stay rejected.
+  const us = loadAllBasketConfigs().find((b) => b.slug === 'essentials-us');
+  const water = us?.items.find((it) => it.id === 'water_1_5l');
+
+  it('finds the item (guard against silent config moves)', () => {
+    expect(water).toBeTruthy();
+  });
+
+  // Same-unit sizes, so the verdict exercises the hard window rather than the
+  // cross-dimension density band: the declared pack expressed in the item's
+  // own ml, and the 32-pack retailers actually serve.
+  const cases: Array<[string, SizeWindowStatus]> = [
+    ['24 x 473 ml', 'pass'],
+    ['11.4 L', 'pass'],
+    ['32 x 500 ml', 'fail'],
+  ];
+
+  for (const [sizeText, expected] of cases) {
+    it(`"${sizeText}" -> ${expected}`, () => {
+      const r = validateSearchHit({
+        canonicalName: water!.canonicalName,
+        productName: 'Aquafina Purified Drinking Water',
+        sizeText,
+        item: water!,
+      });
+      expect(r.signals.sizeWindow).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
Closes #6868.

## The change

`'unknown'` splits into two statuses with distinct score contributions:

| status | when | size score | full-overlap total |
|---|---|---|---|
| `'unknown'` (unchanged) | structurally absent — no window configured, or no `sizeText` at all | 0.2 | 0.85 → still `auto` |
| `'unreadable'` (new) | a size **was present** but nothing could be verified — `parseSize` returned nothing, or the deliberate count-unit carve-out applied | 0.05 | **0.70 → `candidate`** |

At 0.70 the hit is below `AUTO_MATCH_THRESHOLD`, so it records as a reviewable candidate instead of entering the published aggregates — exactly the acceptance criterion's "no longer reaches `auto` on token overlap alone".

## One judgment call, flagged for review

The **density-band verdict keeps `'unknown'`**: a cross-dimension size whose magnitude the band reconciled *was* checked — a weaker verification, not none. Flipping it to 0.05 would demote every cross-dimension-labelled canonical product (the Vegetable-Oil-48oz-in-ml shape the corpus test explicitly protects). If you intended the carve-outs plural to include it, it's a one-line change on top.

## The corpus replay, before this ships (#6867 methodology)

Replaying every configured item's canonical name through `validateSearchHit`:

- **119 items total; 17 canonical rows move auto → candidate** — the count-based `eggs` items across all twelve markets, plus six prefixed canonical names whose own size does not parse (`water_1_5l` — see #6869 — among them).
- Live population, from the issue's own 90-day replay across 8 markets / 21 retailers: **339 of 3,604 observations (9.4%) carry a `sizeText` `parseSize` cannot read** — those stop publishing as verified.
- `pass`-count floor in the corpus test is untouched: the 17 were already non-`pass` (`unknown`) before the split.

## Tests

Four new pins plus two re-labels:

- present-but-unparseable → `'unreadable'`, scores exactly 0.70 < threshold;
- absent `sizeText` → keeps 0.2, clears `auto` (regression fixture per the acceptance criteria);
- no window configured → stays neutral `'unknown'`;
- the count-unit carve-out tests (eggs, bread slices) are re-labeled `'unreadable'` with unchanged non-rejecting verdicts — the carve-out still doesn't reject, it just no longer scores as if it had verified something.

`consumer-prices-core` unit suites: 91/91 green (the `prompt-anchor` suite's `exa-js` import error is pre-existing on clean main).