### PR TITLE
chore(codeowners): own the sebuf-contract paths from the repo account

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
 # Adding or modifying api-route-exceptions.json opts an endpoint out of the
-# sebuf contract. Every change here needs review to prevent drift.
-/api/api-route-exceptions.json @SebastienMelki
+# sebuf contract. The CI gate validates an entry's shape, not whether the
+# exception is justified, so the manifest needs a human. Ownership sits with
+# the repo owner: GitHub skips the review request when the code owner is the
+# PR author, so this fires only when someone else opens the escape hatch.
+/api/api-route-exceptions.json @koala73
 
-# The enforcement script and its CI wiring are the teeth behind the manifest.
-/scripts/enforce-sebuf-api-contract.mjs @SebastienMelki
+# The enforcement script is the teeth behind the manifest, so a change to it
+# cannot be policed by the gate it defines. Same ownership rule applies.
+/scripts/enforce-sebuf-api-contract.mjs @koala73


### PR DESCRIPTION
## Why

Every PR touching `api/api-route-exceptions.json` auto-requested a review from `@SebastienMelki`. It looked like a manual self-assignment because GitHub attributes a CODEOWNERS auto-request to the **PR author** — on #5998 the timeline reads `actor=koala73 req=SebastienMelki`, stamped `2026-08-01T18:08:49Z`, identical to the PR's `createdAt`. The at-open timestamp plus an owned path in the file list is what identifies it as CODEOWNERS rather than a human.

## Why not just delete the rules

That was the other option, and it's the wrong one. `api-route-exceptions.json` **is the escape hatch out of the sebuf gate**: per `scripts/enforce-sebuf-api-contract.mjs:5-10`, a file under `api/` passes by being a real sebuf gateway *or* by being listed in the manifest. The gate (`npm run lint:api-contract`, wired at `.github/workflows/lint-code.yml:49`) validates an entry's *shape* — category, reason, owner, removal_issue — but cannot judge whether the exception is justified. The second path is the enforcement script itself, which likewise cannot police edits to its own teeth.

So these two rules guard precisely what CI structurally cannot. The human check stays.

## What changed

Both paths move from `@SebastienMelki` to `@koala73`. GitHub does not request review from the PR author, so:

- Owner-authored PRs touching these files: silent. (A code owner reviewing their own PR was a no-op guard.)
- PRs from anyone else — agent accounts, Dependabot, collaborators: still land a review request, which is the case where the guard carries information.

Sebastien keeps `write` access on the repo; only the auto-ping target changes.

## Notes

- CODEOWNERS is read from the **default branch**, so this has no effect until merge.
- Nothing in `tests/`, `scripts/`, `.github/workflows/`, or `e2e/` references CODEOWNERS, so no test asserts the old owner.
- The `@SebastienMelki` string at `scripts/enforce-sebuf-api-contract.mjs:176` is a *manifest entry's* `owner` field — an unrelated concept, deliberately left alone.

Claude-Session: https://claude.ai/code/session_01MW1bTKejzAhV46N3w7WtUX
