### PR TITLE
fix(prefs): stop concurrent tabs clobbering the shared dirty-key set

### DIFF
--- a/src/utils/cloud-prefs-migrations.ts
+++ b/src/utils/cloud-prefs-migrations.ts
@@ -140,6 +140,44 @@ export function settledDirtyKeys(
   return settled;
 }
 
+/**
+ * #4746: read-modify-write projection for ADDING dirty keys. Two same-user
+ * tabs share one persisted marker set; a wholesale overwrite by the second
+ * tab drops the first tab's pending markers. Union with whatever the entry
+ * already holds (empty for another user's entry — parsePersistedDirtyKeys
+ * refuses cross-user reads — so the write correctly re-scopes it).
+ */
+export function unionPersistedDirtyKeys(
+  raw: string | null,
+  allowedKeys: Iterable<string>,
+  userId: string,
+  additions: Iterable<string>,
+): { userId: string; keys: string[] } {
+  const merged = new Set(parsePersistedDirtyKeys(raw, allowedKeys, userId));
+  const allowed = new Set(allowedKeys);
+  for (const key of additions) {
+    if (typeof key === 'string' && allowed.has(key)) merged.add(key);
+  }
+  return { userId, keys: [...merged] };
+}
+
+/**
+ * #4746: read-modify-write projection for SETTLING dirty keys. Removes only
+ * the settled keys; a wholesale overwrite here would resurrect nothing but
+ * could drop another tab's still-pending markers.
+ */
+export function withoutPersistedDirtyKeys(
+  raw: string | null,
+  allowedKeys: Iterable<string>,
+  userId: string,
+  removals: Iterable<string>,
+): { userId: string; keys: string[] } {
+  const remove = new Set(removals);
+  const keys = parsePersistedDirtyKeys(raw, allowedKeys, userId)
+    .filter((key) => !remove.has(key));
+  return { userId, keys };
+}
+
 export function parsePersistedDirtyKeys(
   raw: string | null,
   allowedKeys: Iterable<string>,

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -44,6 +44,8 @@ import {
   mergeCloudWithLocalDirty,
   parsePersistedDirtyKeys,
   settledDirtyKeys,
+  unionPersistedDirtyKeys,
+  withoutPersistedDirtyKeys,
 } from './cloud-prefs-migrations';
 import {
   isTemporaryCloudPrefsStatus,
@@ -190,6 +192,58 @@ let _cachedToken: string | null = null; // synchronous token cache for flush()
 const _dirtyKeys = new Set<CloudSyncKey>();
 let _dirtyKeysUserId: string | null = null;
 
+/**
+ * #4746: persistDirtyKeys used to serialize only THIS tab's in-memory set,
+ * so two same-user tabs writing different keys clobbered each other's
+ * pending markers (last writer wins on the single shared
+ * KEY_DIRTY_KEYS entry). The write is now split per call-site semantics:
+ *
+ *   add    (markDirtyKey)          -> union with the persisted set
+ *   settle (clearSettledDirtyKeys) -> targeted remove of the settled keys
+ *   reset  (hydrate cleanup,
+ *           sign-out)              -> overwrite / remove (persistDirtyKeys)
+ *
+ * The naive "always union" fix is wrong on purpose: re-reading the disk set
+ * inside clearSettledDirtyKeys would resurrect keys the upload just settled
+ * (the stale-dirty-key regression class from #3695), so settle removes only
+ * what this tab's upload actually durably synced.
+ */
+function writePersistedDirtyKeys(payload: { userId: string; keys: string[] }): void {
+  if (payload.keys.length === 0) {
+    Storage.prototype.removeItem.call(localStorage, KEY_DIRTY_KEYS);
+    return;
+  }
+  Storage.prototype.setItem.call(localStorage, KEY_DIRTY_KEYS, JSON.stringify(payload));
+}
+
+function persistDirtyKeyAddition(key: CloudSyncKey): void {
+  if (!_dirtyKeysUserId) return;
+  try {
+    writePersistedDirtyKeys(unionPersistedDirtyKeys(
+      localStorage.getItem(KEY_DIRTY_KEYS),
+      CLOUD_SYNC_KEYS,
+      _dirtyKeysUserId,
+      [key],
+    ));
+  } catch {
+    // localStorage unavailable: keep the in-memory guard for this page view.
+  }
+}
+
+function persistSettledDirtyKeyRemovals(removals: string[]): void {
+  if (!_dirtyKeysUserId) return;
+  try {
+    writePersistedDirtyKeys(withoutPersistedDirtyKeys(
+      localStorage.getItem(KEY_DIRTY_KEYS),
+      CLOUD_SYNC_KEYS,
+      _dirtyKeysUserId,
+      removals,
+    ));
+  } catch {
+    // localStorage unavailable: keep the in-memory guard for this page view.
+  }
+}
+
 function persistDirtyKeys(): void {
   try {
     if (_dirtyKeys.size === 0) {
@@ -222,7 +276,7 @@ function hydrateDirtyKeysFromStorage(userId: string): void {
 
 function markDirtyKey(key: CloudSyncKey): void {
   _dirtyKeys.add(key);
-  persistDirtyKeys();
+  persistDirtyKeyAddition(key);
 }
 
 /**
@@ -239,11 +293,11 @@ function markDirtyKey(key: CloudSyncKey): void {
  * current local value.
  */
 function clearSettledDirtyKeys(postedBlob: Record<string, string>): void {
-  let changed = false;
+  const settled: string[] = [];
   for (const key of settledDirtyKeys(postedBlob, buildCloudBlob(), _dirtyKeys)) {
-    changed = _dirtyKeys.delete(key as CloudSyncKey) || changed;
+    if (_dirtyKeys.delete(key as CloudSyncKey)) settled.push(key);
   }
-  if (changed) persistDirtyKeys();
+  if (settled.length > 0) persistSettledDirtyKeyRemovals(settled);
 }
 
 // ── 503 retry tracking ───────────────────────────────────────────────────────

--- a/tests/cloud-prefs-migrations.test.mjs
+++ b/tests/cloud-prefs-migrations.test.mjs
@@ -1,5 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import {
+  parsePersistedDirtyKeys,
+  unionPersistedDirtyKeys,
+  withoutPersistedDirtyKeys,
+} from '../src/utils/cloud-prefs-migrations';
 
 /**
  * Exercises the applyMigrations() plumbing from cloud-prefs-sync.ts.
@@ -64,5 +69,54 @@ describe('applyMigrations (cloud-prefs-sync plumbing)', () => {
     const data = { a: 1 };
     const result = applyMigrations(data, 1, 5, {});
     assert.deepEqual(result, { a: 1 });
+  });
+});
+
+
+describe('persisted dirty-key read-modify-write projections (#4746)', () => {
+  const ALLOWED = ['worldmonitor-theme', 'worldmonitor-monitors', 'wm-market-watchlist-v1'];
+  const entry = (userId, keys) => JSON.stringify({ userId, keys });
+
+  it('unions additions with the persisted set instead of overwriting it', () => {
+    const raw = entry('user-1', ['worldmonitor-theme']);
+    const result = unionPersistedDirtyKeys(raw, ALLOWED, 'user-1', ['wm-market-watchlist-v1']);
+    assert.deepEqual(result.keys.sort(), ['wm-market-watchlist-v1', 'worldmonitor-theme']);
+    assert.equal(result.userId, 'user-1');
+  });
+
+  it('unions onto an absent or malformed entry as a fresh set', () => {
+    for (const raw of [null, 'not json', entry('user-2', ['worldmonitor-theme'])]) {
+      const result = unionPersistedDirtyKeys(raw, ALLOWED, 'user-1', ['worldmonitor-monitors']);
+      assert.deepEqual(result.keys, ['worldmonitor-monitors'], `raw=${raw}`);
+      assert.equal(result.userId, 'user-1');
+    }
+  });
+
+  it('drops disallowed keys from additions but keeps valid persisted ones', () => {
+    const raw = entry('user-1', ['worldmonitor-theme']);
+    const result = unionPersistedDirtyKeys(raw, ALLOWED, 'user-1', ['not-a-pref-key', 'worldmonitor-monitors']);
+    assert.deepEqual(result.keys.sort(), ['worldmonitor-monitors', 'worldmonitor-theme']);
+  });
+
+  it('removes only the settled keys, keeping another tab pending marker', () => {
+    const raw = entry('user-1', ['worldmonitor-theme', 'wm-market-watchlist-v1']);
+    const result = withoutPersistedDirtyKeys(raw, ALLOWED, 'user-1', ['worldmonitor-theme']);
+    assert.deepEqual(result.keys, ['wm-market-watchlist-v1']);
+  });
+
+  it('removal on a foreign-user or malformed entry clears it for the new owner', () => {
+    for (const raw of [null, 'not json', entry('user-2', ['worldmonitor-theme'])]) {
+      const result = withoutPersistedDirtyKeys(raw, ALLOWED, 'user-1', ['worldmonitor-theme']);
+      assert.deepEqual(result.keys, [], `raw=${raw}`);
+    }
+  });
+
+  it('round-trips through parsePersistedDirtyKeys for the owning user', () => {
+    const unioned = unionPersistedDirtyKeys(entry('user-1', ['worldmonitor-theme']), ALLOWED, 'user-1', ['worldmonitor-monitors']);
+    const serialized = JSON.stringify(unioned);
+    assert.deepEqual(
+      parsePersistedDirtyKeys(serialized, ALLOWED, 'user-1').sort(),
+      ['worldmonitor-monitors', 'worldmonitor-theme'],
+    );
   });
 });

--- a/tests/cloud-prefs-panel-sync-guard.test.mjs
+++ b/tests/cloud-prefs-panel-sync-guard.test.mjs
@@ -258,8 +258,13 @@ describe('cloud prefs panel sync guardrails', () => {
     );
     assert.match(
       cloudSyncSrc,
-      /if \(changed\) persistDirtyKeys\(\);/,
-      'successful uploads must clear only the dirty keys that actually settled',
+      /function markDirtyKey\(key: CloudSyncKey\): void \{\s*_dirtyKeys\.add\(key\);\s*persistDirtyKeyAddition\(key\);\s*\}/,
+      'marking a key dirty must union into the persisted set so concurrent same-user tabs cannot clobber each other (#4746)',
+    );
+    assert.match(
+      cloudSyncSrc,
+      /if \(settled\.length > 0\) persistSettledDirtyKeyRemovals\(settled\);/,
+      'successful uploads must clear only the dirty keys that actually settled, by targeted removal — never a wholesale overwrite (#4746)',
     );
     assert.match(
       cloudSyncSrc,

--- a/tests/cloud-prefs-sync-concurrency.test.mts
+++ b/tests/cloud-prefs-sync-concurrency.test.mts
@@ -667,3 +667,164 @@ describe('cloud preference write serialization', () => {
     });
   });
 });
+
+// #4746 - two same-user tabs share one KEY_DIRTY_KEYS entry. A faithful
+// simulation needs each tab's install() patch to fire only for that tab's
+// writes, so each tab gets its own Storage prototype over one shared backing
+// map (a single shared prototype would stack both patches and make tab A
+// observe tab B's writes, which real renderer isolation never does).
+async function runTwoTabDirtyKeyHarness(
+  drive: (
+    tabA: Awaited<ReturnType<typeof loadCloudPrefsModule>>,
+    tabB: Awaited<ReturnType<typeof loadCloudPrefsModule>>,
+    readPersistedDirtyKeys: () => string[],
+    withTabA: <T>(fn: () => Promise<T>) => Promise<T>,
+    withTabB: <T>(fn: () => Promise<T>) => Promise<T>,
+  ) => Promise<void>,
+): Promise<void> {
+  const backing = new Map<string, string>();
+  const makeStorageClass = () => class SharedBackingStorage {
+    get length(): number { return backing.size; }
+    getItem(key: string): string | null { return backing.has(key) ? backing.get(key)! : null; }
+    setItem(key: string, value: string): void { backing.set(key, String(value)); }
+    removeItem(key: string): void { backing.delete(key); }
+    clear(): void { backing.clear(); }
+    key(index: number): string | null { return [...backing.keys()][index] ?? null; }
+  };
+  const StorageA = makeStorageClass();
+  const StorageB = makeStorageClass();
+  const storageA = new StorageA();
+  const storageB = new StorageB();
+  const documentListeners = new Map<string, Array<() => void>>();
+  const originals = {
+    CustomEvent: globalThis.CustomEvent,
+    Storage: globalThis.Storage,
+    document: globalThis.document,
+    localStorage: globalThis.localStorage,
+    window: globalThis.window,
+  };
+  const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  const originalCloudPrefsToken = Object.getOwnPropertyDescriptor(globalThis, '__cloudPrefsToken');
+  const originalFetch = globalThis.fetch;
+
+  const installGlobals = (StorageClass: unknown, storageInstance: unknown): void => {
+    Object.assign(globalThis, {
+      __cloudPrefsToken: 'two-tab-token',
+      CustomEvent: class TestCustomEvent {
+        detail: unknown;
+        type: string;
+        constructor(type: string, init?: { detail?: unknown }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+      Storage: StorageClass,
+      document: {
+        visibilityState: 'visible',
+        addEventListener(type: string, listener: () => void) {
+          const arr = documentListeners.get(type) ?? [];
+          arr.push(listener);
+          documentListeners.set(type, arr);
+        },
+        body: { appendChild() {} },
+        createElement() { return { addEventListener() {}, className: '', innerHTML: '', remove() {} }; },
+        querySelector() { return null; },
+      },
+      localStorage: storageInstance,
+      window: {
+        addEventListener() {},
+        dispatchEvent() { return true; },
+      },
+    });
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { onLine: true },
+    });
+  };
+
+  globalThis.fetch = (async (_input: unknown, init: RequestInit = {}) => {
+    const method = init.method ?? 'GET';
+    if (method === 'GET') {
+      return Response.json({ data: {}, schemaVersion: 2, syncVersion: 0 });
+    }
+    return Response.json({ ok: true, syncVersion: 1 });
+  }) as typeof fetch;
+
+  const readPersistedDirtyKeys = (): string[] => {
+    const raw = backing.get('wm-cloud-prefs-dirty-keys');
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw) as { keys?: unknown };
+      return Array.isArray(parsed.keys) ? parsed.keys.filter((k): k is string => typeof k === 'string') : [];
+    } catch {
+      return [];
+    }
+  };
+
+  const withTabA = async <T>(fn: () => Promise<T>): Promise<T> => {
+    installGlobals(StorageA, storageA);
+    return fn();
+  };
+  const withTabB = async <T>(fn: () => Promise<T>): Promise<T> => {
+    installGlobals(StorageB, storageB);
+    return fn();
+  };
+
+  try {
+    const tabA = await withTabA(() => loadCloudPrefsModule());
+    const tabB = await withTabB(() => loadCloudPrefsModule());
+    await drive(tabA, tabB, readPersistedDirtyKeys, withTabA, withTabB);
+  } finally {
+    Object.assign(globalThis, originals);
+    if (originalNavigator) Object.defineProperty(globalThis, 'navigator', originalNavigator);
+    if (originalCloudPrefsToken) Object.defineProperty(globalThis, '__cloudPrefsToken', originalCloudPrefsToken);
+    else delete (globalThis as { __cloudPrefsToken?: unknown }).__cloudPrefsToken;
+    globalThis.fetch = originalFetch;
+  }
+}
+describe('two-tab dirty-key persistence (#4746)', () => {
+  it('unions markers across concurrent same-user tabs and settles only the uploading tab keys', async () => {
+    await runTwoTabDirtyKeyHarness(async (tabA, tabB, readPersistedDirtyKeys, withTabA, withTabB) => {
+      // Each tab signs in and installs while ITS Storage prototype is the
+      // global one, so its write patch lands on its own prototype. Writes and
+      // uploads then run through the same per-tab globals — exactly the
+      // renderer isolation two real tabs have over one shared profile.
+      await withTabA(async () => {
+        await tabA.onSignIn('user-1', 'full');
+        tabA.install('full');
+      });
+      await withTabB(async () => {
+        await tabB.onSignIn('user-1', 'full');
+        tabB.install('full');
+      });
+
+      // Tab A dirties the watchlist key. Old code: disk = {A}.
+      await withTabA(async () => {
+        globalThis.localStorage.setItem('wm-market-watchlist-v1', 'tab-a-edit');
+      });
+      assert.deepEqual(readPersistedDirtyKeys(), ['wm-market-watchlist-v1']);
+
+      // Tab B (same user, same browser profile) dirties a different key.
+      // Old wholesale overwrite: disk = {B}, A's marker lost.
+      await withTabB(async () => {
+        globalThis.localStorage.setItem('worldmonitor-theme', 'tab-b-edit');
+      });
+      assert.deepEqual(
+        [...readPersistedDirtyKeys()].sort(),
+        ['wm-market-watchlist-v1', 'worldmonitor-theme'],
+        'the second tab write must union, not clobber, the first tab marker',
+      );
+
+      // Tab A uploads and settles only its own key: B's still-pending marker
+      // must survive on disk for B's own upload/hydrate.
+      await withTabA(async () => {
+        await tabA.syncNow();
+      });
+      assert.deepEqual(
+        readPersistedDirtyKeys(),
+        ['worldmonitor-theme'],
+        'a settled upload must remove only the keys that tab durably synced',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`persistDirtyKeys()` serialized **only the calling tab's** in-memory `_dirtyKeys` to the single shared `KEY_DIRTY_KEYS` entry, so two same-user tabs writing different keys dropped each other's pending markers (last writer wins) — the surface newly introduced by #4741 (#4746).

The naive "always union with the persisted set" fix is wrong on purpose: re-reading the disk set inside `clearSettledDirtyKeys` would resurrect keys the upload just settled — the stale-dirty-key regression class from #3695. This PR splits the write per call-site semantics, as proposed in the issue:

- **add** (`markDirtyKey`) → read-modify-write **union** — never drops another tab's marker
- **settle** (`clearSettledDirtyKeys`) → read-modify-write **targeted remove** of only the keys that upload durably synced — never a wholesale overwrite
- **reset** (hydrate cleanup, sign-out) → overwrite/remove, unchanged

The union/remove projections live as pure helpers in `cloud-prefs-migrations.ts` (`unionPersistedDirtyKeys`, `withoutPersistedDirtyKeys`), reusing `parsePersistedDirtyKeys` for user-scoping: a foreign user's or malformed entry reads as empty, so the write re-scopes it to the current owner instead of merging across accounts.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Config / Settings

## Checklist

- [ ] Tested on worldmonitor.app variant — N/A: localStorage concurrency exercised through the two-tab behavioral test below
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- Claim ledger: N/A
- Audit Council signoffs: N/A

## Testing

- New behavioral test `two-tab dirty-key persistence (#4746)` (`tests/cloud-prefs-sync-concurrency.test.mts`): two module instances over one shared backing store, each with its **own Storage prototype** so each tab's `install()` patch fires only for its own writes (real renderer isolation). Asserts: tab A's marker survives tab B's write (union), and tab A's `syncNow` settles **only** its own key while tab B's still-pending marker survives. Verified to fail against the pre-fix implementation and pass with the fix.
- 6 pure-helper cases in `tests/cloud-prefs-migrations.test.mjs`: union, absent/malformed/foreign-user entry, disallowed-key filtering, targeted removal, round-trip.
- Updated the source-text guards in `tests/cloud-prefs-panel-sync-guard.test.mjs` to the new union/targeted-remove contract.
- `npx tsx --test tests/cloud-prefs-migrations.test.mjs tests/cloud-prefs-sync-concurrency.test.mts` — 24/24
- `npm run typecheck`, `biome check` on all five changed files, `git diff --check` — clean
- Known unrelated: `tests/cloud-prefs-panel-sync-guard.test.mjs > updates the live disabled-source set…` fails identically on pristine `origin/main` (verified via stash) — pre-existing, untouched by this PR.

Fixes #4746