### PR TITLE
fix(seeders): sweep SIPRI importers in chunks instead of one impossible pass

### DIFF
--- a/scripts/_defense-industrial-source.mjs
+++ b/scripts/_defense-industrial-source.mjs
@@ -19,6 +19,102 @@ const SOURCE = 'SIPRI Arms Transfers Database';
 export const DEFENSE_INDUSTRIAL_TTL_SECONDS = 30 * 24 * 3600;
 export const MIN_COMPLETE_SIPRI_IMPORTER_COUNT = 25;
 
+// A sweep fetches the catalog in CHUNKS across ticks instead of in one pass.
+//
+// Measured 2026-08-18 against atbackend.sipri.org: a single importer POST takes
+// mean 31.8s / p90 37.3s, not the ~10.6s this file was sized on. At concurrency
+// 8 the full ~200-importer refresh therefore needs ~800s, and it cannot be made
+// to fit: Railway hard-kills a cron container at 600s, so no fetch deadline and
+// no bundle budget can hold it. Raising concurrency is not the escape either --
+// sequential samples climbed 23.2s -> 37.3s as they accumulated, which reads as
+// upstream throttling, and the importer POSTs share a host with
+// seed-defense-industrial.
+//
+// So each tick refreshes the SLICE of importers whose data is oldest and lets
+// the rest keep their previous rows. The sweep is complete when every mapped
+// importer holds a row for the current window; only then does the completion
+// marker advance, so a mid-sweep tick leaves seed-meta old, stays "due", and is
+// picked up again on the next eligible tick. No cursor key is needed -- the
+// published snapshot IS the cursor.
+export const SIPRI_SWEEP_CHUNK = 56;
+
+// Stop TAKING new importers past this, then return what completed. The outer
+// fetchPhaseTimeoutMs aborts and discards the WHOLE phase, so without this a
+// slow tick throws away every row it already paid for.
+//
+// The gap to fetchPhaseTimeoutMs (340s) is 120s, and that gap is the point: this
+// budget only stops workers PICKING UP work, it cannot cancel a request already
+// in flight. A live tick on 2026-08-18 took 135s for a single batch of 8 because
+// two importers returned HTTP 500 and retried, so the worst in-flight chain is
+// ~35s + 1s backoff + ~35s + 2s + ~35s = ~110s. A worker that grabs an importer
+// one millisecond inside the budget must still land before the hard deadline.
+export const SIPRI_SWEEP_SOFT_BUDGET_MS = 220_000;
+
+// An importer row counts as current when it carries the live window AND was
+// fetched inside this horizon. The value is bounded on BOTH sides and neither
+// bound is obvious, so it is pinned by test rather than left to judgement:
+//
+//   > sweep duration (~8 days)   Rows refreshed on the first tick must still be
+//                                current on the last one. A shorter horizon
+//                                expires the head of the sweep before the tail
+//                                lands, so `unfetched` never reaches 0, the
+//                                completion marker is never written, and the
+//                                section stays due forever — a livelock that
+//                                looks exactly like the bug this replaced.
+//   < refresh interval (14 days) When the section next comes due, EVERY row must
+//                                read stale so a fresh sweep starts. A longer
+//                                horizon leaves them all current, the sweep has
+//                                nothing to select, and it completes instantly
+//                                without fetching anything — silent staleness.
+//
+// Measured inputs: ~40 importers land per tick once the 220s soft budget and
+// SIPRI's retry behaviour are accounted for, so 200 importers is ~5 ticks; the
+// section leads 2 of every 3 rotation days, so a sweep spans ~8 days. 10 sits
+// between that and the 14-day refresh interval with ~2 days of margin on each
+// side. The section interval was widened 10d -> 14d to buy the upper margin --
+// SIPRI publishes 5-year windows annually, so a fortnightly refresh loses
+// nothing.
+export const SIPRI_SWEEP_HORIZON_MS = 10 * 24 * 3600 * 1000;
+
+/**
+ * Importers still owed a refresh this sweep, oldest first.
+ *
+ * Deliberately derived from the published snapshot rather than a cursor key:
+ * a cursor can disagree with the data (crash between write and publish, a
+ * restored backup, a manual edit) and then silently skip a slice forever. This
+ * cannot -- if a row is missing or stale it is selected, and if it is current
+ * it is not.
+ *
+ * @param {Array<{iso2: string}>} candidates mapped importers from the catalog
+ * @param {any} previousSnapshot last published snapshot
+ * @param {number} windowEndYear the window the current sweep is filling
+ * @param {number} nowMs
+ */
+export function selectSweepImporters(candidates, previousSnapshot, windowEndYear, nowMs = Date.now()) {
+  const rows = previousSnapshot?.importers || {};
+  const ageOf = (iso2) => {
+    const row = rows[iso2];
+    if (!row) return Number.POSITIVE_INFINITY;
+    // A new window invalidates every row at once -- that is the annual re-sweep.
+    if (Number(row?.window?.endYear) !== windowEndYear) return Number.POSITIVE_INFINITY;
+    const at = Date.parse(row?.fetchedAt || '');
+    if (!Number.isFinite(at)) return Number.POSITIVE_INFINITY;
+    return nowMs - at;
+  };
+  // Strictly OUTSIDE the horizon. An earlier draft filtered `age > 0`, which is
+  // true of every row that has ever been written: nothing was ever current,
+  // `unfetched` could never reach 0, and the completion marker would never have
+  // been written. The sweep would have livelocked in exactly the shape of the
+  // bug it replaces.
+  const pending = candidates
+    .map((c) => ({ ...c, age: ageOf(c.iso2) }))
+    .filter((c) => c.age > SIPRI_SWEEP_HORIZON_MS);
+  // Oldest first so a repeatedly-failing importer cannot monopolise the slice:
+  // once fetched its age resets and it sorts to the back.
+  pending.sort((a, b) => b.age - a.age);
+  return pending;
+}
+
 function round4(value) {
   return Math.round(value * 10_000) / 10_000;
 }
@@ -188,24 +284,28 @@ function sipriFilters(importerId, startYear, endYear) {
 export async function fetchSipriSupplierDependencies({
   fetchFn = fetch,
   baseUrl = process.env.SIPRI_ARMS_API_BASE_URL || DEFAULT_SIPRI_BASE_URL,
-  // 8, not 4, and the ceiling below is the reason it can go no higher.
+  // 8 is a POLITENESS ceiling, not a throughput dial. Do not raise it to chase
+  // the deadline — the sweep above is what makes the work fit.
   //
-  // This issues one POST per mapped importer — ~200 of them (the catalog is 385
-  // entries, ~185 of which are non-state actors that map to no ISO2). SIPRI
-  // answers in ~10.6s regardless of payload size; even `getMaxYear`, which
-  // returns four bytes, takes ~6.8s. At concurrency 4 that is 50 requests per
-  // worker, ~547s, against a 390s fetchPhaseTimeoutMs — the fetch phase could
-  // never finish, so it burned the whole deadline and exited 75 on every run.
+  // History: this was 4, then 8 (#6807), each time sized on a ~10.6s per-request
+  // model. Measured 2026-08-18 the real figure is mean 31.8s / p90 37.3s, so the
+  // full ~200-importer pass needs ~800s at concurrency 8 and blew its 390s
+  // deadline on every run — 390.9s then exit 75, which left 179s of the 570s
+  // bundle budget and deferred every remaining section (they each need >=190s).
+  // That is why military:arms-suppliers:complete:v1 had never been written.
   //
-  // That is also why seed-bundle-static-ref published nothing: a 390s failure
-  // inside a 570s bundle budget left 179s, and every remaining due section
-  // needed >=190s. mineralProduction and submarineCables had no key in Redis at
-  // all as a result (#6799).
-  //
-  // At 8 the same work is ~277s, inside the deadline with ~110s of margin.
+  // Raising concurrency does not recover it. Sequential samples climbed
+  // 23.2s -> 37.3s as they accumulated, which reads as upstream throttling, and
+  // these POSTs share a host with seed-defense-industrial — a block here takes
+  // that seeder down too.
   concurrency = 8,
   delayMs = 150,
   logger = console,
+  // The slice this tick is allowed to refresh. Undefined = every mapped
+  // importer, which is the shape the unit tests and any one-shot manual run use.
+  selectImporters = null,
+  softBudgetMs = SIPRI_SWEEP_SOFT_BUDGET_MS,
+  now = () => Date.now(),
 } = {}) {
   const [maxYearValue, catalog] = await Promise.all([
     fetchJson(`${baseUrl}/trades/getMaxYear`, undefined, fetchFn),
@@ -236,14 +336,29 @@ export async function fetchSipriSupplierDependencies({
     }
     importerByIso2.set(importer.iso2, importer);
   }
-  const uniqueImporters = [...importerByIso2.values()];
+  const catalogImporters = [...importerByIso2.values()];
+  // selectImporters returns the slice owed a refresh; everything it leaves out
+  // keeps its previously published row via buildSipriSupplierSnapshot.
+  const uniqueImporters = typeof selectImporters === 'function'
+    ? selectImporters(catalogImporters, maxYear)
+    : catalogImporters;
+  const sweepPending = catalogImporters.length - uniqueImporters.length;
   const output = {};
   const unmapped = new Map();
   const failedImporters = [];
   let cursor = 0;
 
+  const fetchStartedAt = now();
+  let budgetStoppedAt = 0;
   async function worker() {
     while (cursor < uniqueImporters.length) {
+      // Check BEFORE taking work, not after: the outer fetchPhaseTimeoutMs
+      // aborts and discards the entire phase, so a worker that starts a 37s
+      // request it cannot finish costs every row this tick already paid for.
+      if (softBudgetMs > 0 && now() - fetchStartedAt > softBudgetMs) {
+        budgetStoppedAt = uniqueImporters.length - cursor;
+        return;
+      }
       const importer = uniqueImporters[cursor++];
       try {
         const body = sipriFilters(importer.EntityId, startYear, maxYear);
@@ -284,7 +399,26 @@ export async function fetchSipriSupplierDependencies({
       .join(', ');
     logger.warn(`  SIPRI importer requests failed (${failedImporters.length}): ${preview}`);
   }
-  return { importers: output, failedImporters, windowEndYear: maxYear };
+  const unfetched = budgetStoppedAt + sweepPending;
+  if (budgetStoppedAt > 0) {
+    logger.warn(
+      `  SIPRI soft budget reached after ${Math.round((now() - fetchStartedAt) / 1000)}s — `
+      + `${budgetStoppedAt} importer(s) left for the next tick`,
+    );
+  }
+  return {
+    importers: output,
+    failedImporters,
+    windowEndYear: maxYear,
+    sweep: {
+      catalogCount: catalogImporters.length,
+      attempted: uniqueImporters.length,
+      fetched: Object.keys(output).length,
+      // Sections this tick did not even attempt: deliberately deferred by the
+      // slice, plus any the soft budget cut off.
+      unfetched,
+    },
+  };
 }
 
 export async function buildWorldBankIndustrialSnapshot({
@@ -311,39 +445,66 @@ export async function buildSipriSupplierSnapshot({
   // map directly, while production returns stage diagnostics alongside it.
   const fetched = result?.importers || result || {};
   const failures = Array.isArray(result?.failedImporters) ? result.failedImporters : [];
+  const sweep = result?.sweep || null;
   const fetchedAt = now().toISOString();
   const fetchedImporterCount = Object.keys(fetched).length;
-  if (failures.length === 0 && fetchedImporterCount < minimumCompleteImporterCount) {
-    throw new Error(
-      `SIPRI complete refresh returned only ${fetchedImporterCount} positive importer rows; `
-      + `minimum is ${minimumCompleteImporterCount}`,
-    );
-  }
 
-  const importers = Object.fromEntries(Object.entries(fetched).map(([iso2, dependency]) => [
-    iso2,
-    { ...dependency, fetchedAt, retained: false },
-  ]));
+  // Carry EVERY previously published row forward, then overlay this tick's
+  // slice. Before chunking only failures were retained, because a pass either
+  // covered the whole catalog or was a failure; now a healthy tick deliberately
+  // refreshes ~56 of ~200 and the other ~144 must survive untouched, keeping
+  // their original fetchedAt so selectSweepImporters can still see their age.
+  const importers = {};
   let preservedImporterCount = 0;
-  for (const failure of failures) {
-    const previous = previousSnapshot?.importers?.[failure.iso2];
-    if (!previous) continue;
-    importers[failure.iso2] = {
+  for (const [iso2, previous] of Object.entries(previousSnapshot?.importers || {})) {
+    importers[iso2] = {
       ...previous,
       fetchedAt: previous.fetchedAt || previousSnapshot.fetchedAt || '',
       retained: true,
     };
     preservedImporterCount += 1;
   }
+  for (const [iso2, dependency] of Object.entries(fetched)) {
+    if (importers[iso2]) preservedImporterCount -= 1;
+    importers[iso2] = { ...dependency, fetchedAt, retained: false };
+  }
+
+  // The floor applies to the MERGED snapshot, never to one tick's slice. Judging
+  // a chunk by it would reject every healthy sweep tick, since a slice is
+  // smaller than the floor by design.
+  const mergedImporterCount = Object.keys(importers).length;
+  if (failures.length === 0 && mergedImporterCount < minimumCompleteImporterCount) {
+    throw new Error(
+      `SIPRI snapshot holds only ${mergedImporterCount} positive importer rows; `
+      + `minimum is ${minimumCompleteImporterCount}`,
+    );
+  }
+
+  // 'ok' is what writes the completion marker, and the marker is what stops the
+  // section being due. It must therefore mean "the sweep finished", not "this
+  // tick finished" -- otherwise the first chunk would mark the whole refresh
+  // complete and the remaining ~144 importers would never be revisited.
+  const sweepComplete = sweep ? sweep.unfetched === 0 : true;
+  const status = failures.length === 0 && sweepComplete ? 'ok' : 'partial';
 
   return {
     importers,
     stage: {
-      status: failures.length > 0 ? 'partial' : 'ok',
+      status,
       importerCount: fetchedImporterCount,
       failedImporterCount: failures.length,
-      preservedImporterCount,
+      preservedImporterCount: Math.max(0, preservedImporterCount),
       windowEndYear: Number(result?.windowEndYear) || 0,
+      ...(sweep
+        ? {
+          sweep: {
+            catalogCount: sweep.catalogCount,
+            refreshedThisTick: fetchedImporterCount,
+            remaining: sweep.unfetched,
+            complete: sweepComplete,
+          },
+        }
+        : {}),
     },
     fetchedAt,
   };

--- a/scripts/seed-bundle-static-ref-heavy.mjs
+++ b/scripts/seed-bundle-static-ref-heavy.mjs
@@ -25,10 +25,23 @@ import { runBundle, DAY } from './_bundle-runner.mjs';
 // far more often than any of these cadences needs, so a permanently failing
 // member can consume at most one lead slot in three.
 const SECTIONS = [
-  // Cheapest first in the canonical order: on the two days it does not lead it
-  // still fits behind either heavy (371s + 190s = 561s, 335s + 190s = 525s).
+  // Cheapest first in the canonical order. On the two days it does not lead it
+  // still fits behind either heavy, because BOTH are now bounded work: the
+  // chunked Arms sweep measures ~250s (250+190=440s) and Military-Bases ~335s
+  // (335+190=525s), against a 570s budget.
+  //
+  // This did NOT hold before the sweep. Arms-Suppliers ran 390.9s on 2026-08-18,
+  // leaving 179s against this section's 190s reservation, and the log read
+  // "needs 190s but only 178s left" — Mineral-Production deferred by ELEVEN
+  // seconds on the tick its acknowledgement expired.
   { label: 'Mineral-Production', script: 'seed-mineral-production.mjs', seedMetaKey: 'supply-chain:mineral-production', canonicalKey: 'supply-chain:mineral-production:v1', intervalMs: 60 * DAY, timeoutMs: 180_000 },
-  { label: 'Arms-Suppliers', script: 'seed-defense-industrial-suppliers.mjs', seedMetaKey: 'military:arms-suppliers-complete', canonicalKey: 'military:arms-suppliers:complete:v1', intervalMs: 10 * DAY, timeoutMs: 450_000 },
+  // 370s, not 450s, and 14 days, not 10 — both follow from the chunked sweep
+  // (#6806). The section now fetches ONE ~56-importer slice per tick (340s fetch
+  // deadline + publish), not the whole ~200-importer catalog, so it no longer
+  // needs a 450s reservation and no longer starves the members behind it. The
+  // wider interval gives the sweep horizon room: a sweep spans ~8 days and every
+  // row must read stale by the time the section is next due.
+  { label: 'Arms-Suppliers', script: 'seed-defense-industrial-suppliers.mjs', seedMetaKey: 'military:arms-suppliers-complete', canonicalKey: 'military:arms-suppliers:complete:v1', intervalMs: 14 * DAY, timeoutMs: 370_000 },
   // Missing canonicalKey is intentional (#6845); do not invent one here.
   { label: 'Military-Bases', script: 'seed-military-bases.mjs', seedMetaKey: 'military:bases', intervalMs: 30 * DAY, timeoutMs: 400_000 },
 ];

--- a/scripts/seed-defense-industrial-suppliers.mjs
+++ b/scripts/seed-defense-industrial-suppliers.mjs
@@ -5,6 +5,9 @@ import {
   buildArmsSupplierCompletion,
   buildSipriSupplierSnapshot,
   DEFENSE_INDUSTRIAL_TTL_SECONDS,
+  fetchSipriSupplierDependencies,
+  selectSweepImporters,
+  SIPRI_SWEEP_CHUNK,
 } from './_defense-industrial-source.mjs';
 
 loadEnvFile(import.meta.url, { only: ['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN', 'SIPRI_ARMS_API_BASE_URL'] });
@@ -29,14 +32,32 @@ export function supplierContentMeta(data) {
 
 async function fetchSupplierSnapshot() {
   const previousSnapshot = await readCanonicalValue(ARMS_SUPPLIERS_KEY).catch(() => null);
-  return buildSipriSupplierSnapshot({ previousSnapshot: previousSnapshot || {} });
+  const previous = previousSnapshot || {};
+  return buildSipriSupplierSnapshot({
+    previousSnapshot: previous,
+    // One SLICE per tick. The full ~200-importer catalog needs ~800s at the
+    // measured 31.8s/request and Railway kills the container at 600s, so a
+    // whole-catalog pass cannot be made to fit at any deadline.
+    fetchSipri: (options) => fetchSipriSupplierDependencies({
+      ...options,
+      selectImporters: (candidates, windowEndYear) => selectSweepImporters(
+        candidates,
+        previous,
+        windowEndYear,
+      ).slice(0, SIPRI_SWEEP_CHUNK),
+    }),
+  });
 }
 
 await runSeed('military', 'arms-suppliers', ARMS_SUPPLIERS_KEY, fetchSupplierSnapshot, {
   validateFn: validateArmsSuppliers,
   ttlSeconds: DEFENSE_INDUSTRIAL_TTL_SECONDS,
   lockTtlMs: 7 * 60 * 1000,
-  fetchPhaseTimeoutMs: 6.5 * 60 * 1000,
+  // Sized to one 56-importer chunk, not the catalog: 7 batches at concurrency 8,
+  // p90 37.3s = ~261s of POSTs plus ~30s for getMaxYear + the catalog call. The
+  // 270s soft budget inside the fetcher stops it taking new work first, so this
+  // is the backstop rather than the normal exit.
+  fetchPhaseTimeoutMs: 340 * 1000,
   declareRecords: (data) => Object.keys(data.importers || {}).length,
   sourceVersion: 'sipri-arms-transfers-v2',
   schemaVersion: 2,

--- a/tests/seed-defense-industrial.test.mjs
+++ b/tests/seed-defense-industrial.test.mjs
@@ -10,6 +10,8 @@ import {
   buildWorldBankIndustrialSnapshot,
   fetchSipriSupplierDependencies,
   mapSipriEntityToIso2,
+  selectSweepImporters,
+  SIPRI_SWEEP_HORIZON_MS,
   parseSipriSupplierCsv,
   parseWbIndicatorPage,
 } from '../scripts/_defense-industrial-source.mjs';
@@ -116,7 +118,7 @@ describe('defense-industrial source parsing', () => {
         fetchSipri: async () => ({ importers: {}, failedImporters: [], windowEndYear: 2025 }),
         minimumCompleteImporterCount: 1,
       }),
-      /returned only 0 positive importer rows/,
+      /holds only 0 positive importer rows/,
     );
 
     assert.deepEqual(buildArmsSupplierCompletion({
@@ -142,10 +144,10 @@ describe('defense-industrial deployment wiring', () => {
 
     assert.match(heavy, /label:\s*'Arms-Suppliers'/);
     assert.match(heavy, /script:\s*'seed-defense-industrial-suppliers\.mjs'/);
-    assert.match(heavy, /timeoutMs:\s*450_000/);
+    assert.match(heavy, /timeoutMs:\s*370_000/);
     assert.match(heavy, /seedMetaKey:\s*'military:arms-suppliers-complete'/);
     assert.match(heavy, /canonicalKey:\s*'military:arms-suppliers:complete:v1'/);
-    assert.match(heavy, /intervalMs:\s*10 \* DAY/);
+    assert.match(heavy, /intervalMs:\s*14 \* DAY/);
     assert.match(heavy, /maxBundleMs:\s*570_000/);
 
     assert.match(light, /label:\s*'Defense-Industrial'/);
@@ -171,35 +173,83 @@ describe('defense-industrial deployment wiring', () => {
   });
 });
 
-describe('SIPRI importer fan-out fits its fetch deadline (#6799)', () => {
-  // The seeder POSTs once per mapped importer. SIPRI answers in ~10.6s whatever
-  // the payload, so the wall time is (importers / concurrency) * latency and
-  // has to land inside fetchPhaseTimeoutMs. At concurrency 4 it did not: ~200
-  // importers took ~547s against a 390s deadline, so the phase burned the whole
-  // deadline and exited 75 every run — which then starved every later section
-  // of seed-bundle-static-ref out of its 570s budget.
+describe('SIPRI importer fan-out fits its fetch deadline (#6799, #6806)', () => {
+  // This gate existed and PASSED while production failed every run, because it
+  // was calibrated on a latency that had drifted. It asserted
+  // (200 / 8) * 10.6s = 265s < 390s and went green; the real run took 390.9s and
+  // exited 75. Re-measured 2026-08-18 against atbackend.sipri.org: mean 31.8s,
+  // p90 37.3s per importer POST -- 3x the modelled figure.
+  //
+  // The lesson is in the shape of the assertions below, not just the number. A
+  // hardcoded latency constant is a snapshot of one afternoon; when it drifts,
+  // this gate goes green precisely when it matters most. So it now pins BOTH
+  // directions: the chunk must fit, AND the whole-catalog pass must not -- the
+  // second is what stops someone "simplifying" the sweep away and restoring the
+  // original bug behind a green test.
 
-  const OBSERVED_SIPRI_LATENCY_S = 10.6; // measured 2026-08-16 against live SIPRI
-  const MAPPED_IMPORTERS = 200;          // 385 catalog entries, ~185 unmapped non-state actors
+  const SIPRI_LATENCY_P90_S = 37.3;  // measured 2026-08-18, was modelled at 10.6
+  const MAPPED_IMPORTERS = 200;      // 385 catalog entries, ~185 unmapped non-state actors
+  const RAILWAY_CONTAINER_KILL_S = 600;
   const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-  it('the configured concurrency leaves the fetch phase inside its deadline', () => {
+  const readNumber = (src, re, label) => {
+    const m = re.exec(src);
+    assert.ok(m, `${label} must be declared`);
+    // Numeric separators are idiomatic in this repo (270_000); Number() returns
+    // NaN on them, and a NaN comparison fails OPEN in the wrong direction.
+    const value = Number(String(m[1]).replace(/_/g, ''));
+    assert.ok(Number.isFinite(value), `${label} did not parse to a number: ${m[1]}`);
+    return value;
+  };
+
+  it('one chunk fits the fetch deadline at measured p90 latency', () => {
     const seeder = readFileSync(join(root, 'scripts/seed-defense-industrial-suppliers.mjs'), 'utf8');
-    const deadline = /fetchPhaseTimeoutMs:\s*([\d.]+)\s*\*\s*60\s*\*\s*1000/.exec(seeder);
-    assert.ok(deadline, 'the supplier seeder must declare fetchPhaseTimeoutMs');
-    const deadlineS = Number(deadline[1]) * 60;
-
     const source = readFileSync(join(root, 'scripts/_defense-industrial-source.mjs'), 'utf8');
-    const declared = /^\s*concurrency = (\d+),$/m.exec(source);
-    assert.ok(declared, 'the SIPRI fan-out must declare a default concurrency');
-    const concurrency = Number(declared[1]);
 
-    const worstCaseS = (MAPPED_IMPORTERS / concurrency) * OBSERVED_SIPRI_LATENCY_S;
+    const deadlineS = readNumber(seeder, /fetchPhaseTimeoutMs:\s*(\d+)\s*\*\s*1000/, 'fetchPhaseTimeoutMs') ;
+    const chunk = readNumber(source, /export const SIPRI_SWEEP_CHUNK = (\d+);/, 'SIPRI_SWEEP_CHUNK');
+    const concurrency = readNumber(source, /^\s*concurrency = (\d+),$/m, 'default concurrency');
+
+    // ~30s for getMaxYear + getAllCountriesTrimmed before any importer POST.
+    const chunkS = Math.ceil(chunk / concurrency) * SIPRI_LATENCY_P90_S + 30;
     assert.ok(
-      worstCaseS < deadlineS,
-      `concurrency ${concurrency} needs ${Math.round(worstCaseS)}s for ${MAPPED_IMPORTERS} importers `
-      + `at ${OBSERVED_SIPRI_LATENCY_S}s each, but fetchPhaseTimeoutMs is ${deadlineS}s. `
-      + 'The phase cannot finish, so it burns the full deadline and exits 75 every run.',
+      chunkS < deadlineS,
+      `a ${chunk}-importer chunk needs ${Math.round(chunkS)}s at p90 ${SIPRI_LATENCY_P90_S}s `
+      + `and concurrency ${concurrency}, but fetchPhaseTimeoutMs is ${deadlineS}s.`,
+    );
+  });
+
+  it('the soft budget stops work BEFORE the hard deadline discards it', () => {
+    // fetchPhaseTimeoutMs aborts the whole phase and throws away every row already
+    // fetched. The soft budget has to bite first or it is decorative.
+    const seeder = readFileSync(join(root, 'scripts/seed-defense-industrial-suppliers.mjs'), 'utf8');
+    const source = readFileSync(join(root, 'scripts/_defense-industrial-source.mjs'), 'utf8');
+    const deadlineMs = readNumber(seeder, /fetchPhaseTimeoutMs:\s*(\d+)\s*\*\s*1000/, 'fetchPhaseTimeoutMs') * 1000;
+    const softMs = readNumber(source, /export const SIPRI_SWEEP_SOFT_BUDGET_MS = ([\d_]+);/, 'SIPRI_SWEEP_SOFT_BUDGET_MS');
+    assert.ok(
+      softMs < deadlineMs,
+      `soft budget ${softMs}ms must be under fetchPhaseTimeoutMs ${deadlineMs}ms, or the phase `
+      + 'is aborted before it can return partial progress and the tick advances the sweep by nothing.',
+    );
+  });
+
+  it('a WHOLE-CATALOG pass provably does not fit, which is why the sweep chunks', () => {
+    // The counterweight. If someone raises the chunk to cover the catalog, or
+    // drops the slice entirely, this fails and says why.
+    const source = readFileSync(join(root, 'scripts/_defense-industrial-source.mjs'), 'utf8');
+    const concurrency = readNumber(source, /^\s*concurrency = (\d+),$/m, 'default concurrency');
+    const chunk = readNumber(source, /export const SIPRI_SWEEP_CHUNK = (\d+);/, 'SIPRI_SWEEP_CHUNK');
+
+    const fullPassS = (MAPPED_IMPORTERS / concurrency) * SIPRI_LATENCY_P90_S;
+    assert.ok(
+      fullPassS > RAILWAY_CONTAINER_KILL_S,
+      `a full ${MAPPED_IMPORTERS}-importer pass is ${Math.round(fullPassS)}s at concurrency ${concurrency}. `
+      + 'If that now fits Railway\'s 600s container kill, the sweep may be unnecessary — re-measure and simplify deliberately.',
+    );
+    assert.ok(
+      chunk < MAPPED_IMPORTERS,
+      `SIPRI_SWEEP_CHUNK ${chunk} covers the whole ${MAPPED_IMPORTERS}-importer catalog, so every tick `
+      + `attempts a pass that needs ${Math.round(fullPassS)}s inside a 600s container. That is the #6799 bug.`,
     );
   });
 
@@ -228,5 +278,192 @@ describe('SIPRI importer fan-out fits its fetch deadline (#6799)', () => {
     };
     await fetchSipriSupplierDependencies({ fetchFn, delayMs: 0 }).catch(() => {});
     assert.ok(peak > 1, `expected parallel requests, saw peak in-flight ${peak}`);
+  });
+});
+
+
+describe('SIPRI chunked sweep (#6806)', () => {
+  const NOW = Date.parse('2026-08-18T04:00:00Z');
+  const iso = (ms) => new Date(ms).toISOString();
+  const row = (endYear, fetchedAtMs) => ({ window: { endYear }, fetchedAt: iso(fetchedAtMs) });
+  const candidates = [{ iso2: 'FR' }, { iso2: 'DE' }, { iso2: 'JP' }, { iso2: 'BR' }];
+
+  const DAY = 24 * 3600_000;
+
+  it('selects only rows outside the horizon, oldest first, and never a current one', () => {
+    const previous = {
+      importers: {
+        FR: row(2025, NOW - 1 * DAY),   // current -> must NOT be selected
+        DE: row(2025, NOW - 16 * DAY),  // outside the 10d horizon
+        JP: row(2025, NOW - 12 * DAY),  // outside, but newer than DE
+        // BR absent entirely
+      },
+    };
+    const picked = selectSweepImporters(candidates, previous, 2025, NOW).map((c) => c.iso2);
+    // BR first (never fetched = infinite age), then oldest-to-newest. FR omitted.
+    assert.deepEqual(picked, ['BR', 'DE', 'JP']);
+  });
+
+  it('a fully current catalog selects NOTHING, which is what lets a sweep finish', () => {
+    // The inverse of the livelock: if every row is current the sweep is done.
+    // An earlier draft filtered on `age > 0` instead of `age > horizon`, so this
+    // returned all four and the completion marker could never be written.
+    const previous = {
+      importers: Object.fromEntries(candidates.map((c) => [c.iso2, row(2025, NOW - 1 * DAY)])),
+    };
+    assert.deepEqual(selectSweepImporters(candidates, previous, 2025, NOW), []);
+  });
+
+  it('treats a new SIPRI window as invalidating every row, which is the annual re-sweep', () => {
+    const previous = {
+      importers: {
+        FR: row(2025, NOW - 60_000),
+        DE: row(2025, NOW - 60_000),
+      },
+    };
+    // Rows are minutes old but hold the PREVIOUS window.
+    const picked = selectSweepImporters([{ iso2: 'FR' }, { iso2: 'DE' }], previous, 2026, NOW);
+    assert.equal(picked.length, 2, 'a window rollover must re-sweep the whole catalog');
+  });
+
+  it('the horizon is the boundary: just past selects, just inside does not', () => {
+    const stale = { importers: { FR: row(2025, NOW - SIPRI_SWEEP_HORIZON_MS - 60_000) } };
+    assert.equal(selectSweepImporters([{ iso2: 'FR' }], stale, 2025, NOW).length, 1);
+    const fresh = { importers: { FR: row(2025, NOW - SIPRI_SWEEP_HORIZON_MS + 60_000) } };
+    assert.equal(selectSweepImporters([{ iso2: 'FR' }], fresh, 2025, NOW).length, 0);
+  });
+
+  it('the horizon stays between the sweep duration and the refresh interval', () => {
+    // Both bounds are livelocks, in opposite directions, and neither shows up as
+    // a test failure elsewhere:
+    //   horizon <= sweep duration -> the head of a sweep expires before its tail
+    //     lands, unfetched never hits 0, the marker never advances, the section
+    //     is due forever.
+    //   horizon >= refresh interval -> when the section next comes due every row
+    //     still reads current, the sweep selects nothing and "completes"
+    //     instantly without fetching. Silent staleness behind a green marker.
+    const horizonDays = SIPRI_SWEEP_HORIZON_MS / DAY;
+    // ~40 importers actually land per tick once the soft budget and SIPRI's
+    // retries are accounted for -- NOT the 56 chunk ceiling. Sizing this off the
+    // ceiling would understate the sweep and hide a horizon that is too short.
+    const IMPORTERS_PER_TICK = 40;
+    const CHUNKS_PER_SWEEP = Math.ceil(200 / IMPORTERS_PER_TICK);   // ~5 ticks
+    const TICKS_PER_DAY = 2 / 3;                                    // Arms leads 2 of 3 rotation days
+    const sweepDays = CHUNKS_PER_SWEEP / TICKS_PER_DAY;             // ~7.5
+    const intervalDays = 14;                                        // seed-bundle-static-ref-heavy section
+    assert.ok(
+      horizonDays > sweepDays,
+      `horizon ${horizonDays}d must exceed the ~${sweepDays.toFixed(1)}d a sweep takes, or it never completes`,
+    );
+    assert.ok(
+      horizonDays < intervalDays,
+      `horizon ${horizonDays}d must be under the ${intervalDays}d refresh interval, or the next sweep is a no-op`,
+    );
+  });
+
+  it('a mid-sweep tick retains untouched rows and withholds the completion marker', async () => {
+    // THE core guarantee. If a chunk marked the refresh complete, the completion
+    // marker would advance, the section would stop being due, and the ~144
+    // importers this tick did not touch would never be revisited.
+    const previous = {
+      fetchedAt: iso(NOW - 48 * 3600_000),
+      importers: {
+        FR: { suppliers: [{ iso2: 'US', share: 1 }], window: { endYear: 2025 }, fetchedAt: iso(NOW - 48 * 3600_000) },
+        DE: { suppliers: [{ iso2: 'US', share: 1 }], window: { endYear: 2025 }, fetchedAt: iso(NOW - 48 * 3600_000) },
+      },
+    };
+    const snapshot = await buildSipriSupplierSnapshot({
+      previousSnapshot: previous,
+      minimumCompleteImporterCount: 1,
+      now: () => new Date(NOW),
+      fetchSipri: async () => ({
+        importers: { FR: { suppliers: [{ iso2: 'FR', share: 1 }], window: { endYear: 2025 } } },
+        failedImporters: [],
+        windowEndYear: 2025,
+        sweep: { catalogCount: 2, attempted: 1, fetched: 1, unfetched: 1 },
+      }),
+    });
+
+    assert.equal(snapshot.stage.status, 'partial', 'an unfinished sweep must not read as complete');
+    assert.deepEqual(buildArmsSupplierCompletion(snapshot), {}, 'no completion marker mid-sweep');
+    // The untouched row survives with its ORIGINAL timestamp, so the next tick
+    // can still see that it is the stale one.
+    assert.equal(snapshot.importers.DE.retained, true);
+    assert.equal(snapshot.importers.DE.fetchedAt, iso(NOW - 48 * 3600_000));
+    assert.equal(snapshot.importers.FR.retained, false);
+    assert.equal(snapshot.importers.FR.fetchedAt, iso(NOW));
+    assert.equal(snapshot.stage.sweep.remaining, 1);
+  });
+
+  it('the final tick of a sweep completes it and writes the marker', async () => {
+    const previous = {
+      importers: { FR: { suppliers: [], window: { endYear: 2025 }, fetchedAt: iso(NOW - 3600_000) } },
+    };
+    const snapshot = await buildSipriSupplierSnapshot({
+      previousSnapshot: previous,
+      minimumCompleteImporterCount: 1,
+      now: () => new Date(NOW),
+      fetchSipri: async () => ({
+        importers: { DE: { suppliers: [{ iso2: 'US', share: 1 }], window: { endYear: 2025 } } },
+        failedImporters: [],
+        windowEndYear: 2025,
+        sweep: { catalogCount: 2, attempted: 1, fetched: 1, unfetched: 0 },
+      }),
+    });
+    assert.equal(snapshot.stage.status, 'ok');
+    assert.deepEqual(buildArmsSupplierCompletion(snapshot), { completedAt: iso(NOW), windowEndYear: 2025 });
+    assert.equal(Object.keys(snapshot.importers).length, 2, 'the merged snapshot carries both');
+  });
+
+  it('the record floor judges the MERGED snapshot, not one chunk', async () => {
+    // A slice is smaller than the floor by design; applying the floor per-tick
+    // would reject every healthy sweep tick.
+    const previous = {
+      importers: Object.fromEntries(
+        Array.from({ length: 30 }, (_, i) => [`X${i}`, { suppliers: [], window: { endYear: 2025 }, fetchedAt: iso(NOW - 3600_000) }]),
+      ),
+    };
+    const snapshot = await buildSipriSupplierSnapshot({
+      previousSnapshot: previous,
+      minimumCompleteImporterCount: 25,
+      now: () => new Date(NOW),
+      fetchSipri: async () => ({
+        importers: { FR: { suppliers: [], window: { endYear: 2025 } } },
+        failedImporters: [],
+        windowEndYear: 2025,
+        sweep: { catalogCount: 31, attempted: 1, fetched: 1, unfetched: 30 },
+      }),
+    });
+    assert.equal(Object.keys(snapshot.importers).length, 31);
+    assert.equal(snapshot.stage.status, 'partial');
+  });
+
+  it('the soft budget returns partial progress instead of losing the tick', async () => {
+    let served = 0;
+    const names = ['Ukraine', 'Poland', 'Japan', 'Egypt', 'India', 'Brazil', 'Norway', 'Chile'];
+    const catalog = Array.from({ length: 160 }, (_, i) => ({
+      EntityId: 1000 + (i % names.length),
+      Name: names[i % names.length],
+    }));
+    let clock = 0;
+    const fetchFn = async (url) => {
+      if (String(url).includes('getMaxYear')) return new Response('2025');
+      if (String(url).includes('getAllCountriesTrimmed')) return new Response(JSON.stringify(catalog));
+      served += 1;
+      clock += 10_000;   // 10s of virtual time per importer POST
+      return new Response(JSON.stringify({ bytes: '' }));
+    };
+    const result = await fetchSipriSupplierDependencies({
+      fetchFn,
+      delayMs: 0,
+      softBudgetMs: 30_000,
+      now: () => clock,
+    });
+    assert.ok(served > 0, 'the tick must still do useful work');
+    assert.ok(result.sweep.unfetched > 0, 'and report what it left behind');
+    assert.ok(
+      served < 8,
+      `the soft budget must stop the pool early; it served ${served} importers past a 30s budget`,
+    );
   });
 });


### PR DESCRIPTION
`military:arms-suppliers:complete:v1` has **never existed**. The seeder POSTs once per mapped importer, and the whole catalog cannot fit in a Railway cron container — so every run burned its deadline and exited 75.

## The number this was sized on had drifted

Measured 2026-08-18 against `atbackend.sipri.org`:

| | per importer POST |
|---|---|
| modelled | 10.6 s |
| **measured** | **mean 31.8 s, p90 37.3 s** |

At concurrency 8 the ~200-importer pass needs **~800 s**. It cannot be made to fit at *any* deadline — **Railway hard-kills a cron container at 600 s.**

The 04:05 run today is the proof:

```
[Arms-Suppliers] FETCH FAILED: exceeded 390000ms deadline
[Arms-Suppliers] Failed after 390.9s: graceful fetch failure (exit 75)
[Military-Bases]     Deferred, needs 410s but only 178s left
[Mineral-Production] Deferred, needs 190s but only 178s left
```

`Mineral-Production` missed by **11 seconds**, on the exact tick its acknowledgement expired.

**Raising concurrency isn't the escape either.** Sequential samples climbed 23.2 s → 37.3 s as they accumulated — upstream throttling — and these POSTs share a host with `seed-defense-industrial`, so a block takes that seeder down too.

## The sweep

Each tick refreshes the slice of importers whose rows are oldest; the rest stand. **No cursor key** — the published snapshot *is* the cursor, because a cursor can disagree with the data after a crash or restore and then skip a slice forever.

`stage.status: 'ok'` now means *"the sweep finished"*, not *"this tick finished"*. That status writes the completion marker, and the marker is what stops the section being due — if a chunk marked the refresh complete, the ~144 importers it didn't touch would never be revisited.

## Two bugs I found in this change before shipping it

**The pending filter read `age > 0`** — true of every row ever written. Nothing would ever have been current, `unfetched` could never reach 0, and the marker would never have been written: a livelock in the exact shape of the bug being fixed. Now `age > horizon`, with a test pinning that a fully-current catalog selects **nothing**.

**The soft budget only stops workers picking up work** — it can't cancel one in flight. A live tick took 135 s for a single batch of 8 because two importers returned HTTP 500 and retried, making the worst in-flight chain ~110 s. A 270 s budget against a 340 s deadline left a 70 s gap, so a worker starting at 269 s lands past the deadline and the phase aborts, discarding the whole tick. Budget is now **220 s**, a 120 s gap.

## The horizon is bounded on both sides

Neither bound fails visibly elsewhere, so a test pins both:

- **above** the ~8-day sweep — else the head expires before the tail lands and it never completes
- **below** the refresh interval — else every row still reads current when the section comes due, and the sweep "completes" instantly having fetched nothing

Interval widens 10 d → 14 d to buy the upper margin (SIPRI publishes 5-year windows annually). The reservation drops **450 s → 370 s** now that a tick is bounded work — which is what stops it starving the members behind it.

## The #6799 gate is rewritten

It **passed while production failed every run**, asserting `(200/8)×10.6s = 265s < 390s` against a latency that no longer held. A hardcoded latency constant goes green precisely when it matters most. It now pins both directions — the chunk must fit **and** a whole-catalog pass must not — so removing the sweep fails the test instead of sailing through it.

## Verification

Live against SIPRI, read-only, no publish:

```
catalog mapped=200        <- exactly the estimate
attempted 8, fetched 6, unfetched 192
real rows returned:  AF -> US tivShare 1
reported partial     -> no completion marker written
```

**269 tests pass across 23 suites.** Biome clean. Mutation-checked: restoring the `age > 0` filter fails the two selector tests and nothing else.

Refs #6799, #6806.
