### PR TITLE
fix(sentry): suppress HTML-as-JS arrow-function SyntaxError

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -868,6 +868,14 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
         || (excType === 'SyntaxError' && /^Unexpected (?:token|keyword)/.test(msg))
         || /^SyntaxError: Unexpected (?:token|keyword)/.test(msg)
         || /Invalid or unexpected token/.test(msg)
+        // V8 wording when HTML (or other non-JS) is parsed as a script:
+        // Electron / in-app wrappers fetch the SPA document (`/dashboard`)
+        // as if it were JS, then report the parse failure against the
+        // document URL. Our compiled bundle cannot emit this at runtime —
+        // a genuine first-party SyntaxError keeps a source-mapped .ts /
+        // hashed-chunk frame (hasFirstParty → preserved). Same family as
+        // Unexpected token/keyword above (WORLDMONITOR-ZS).
+        || /^(?:SyntaxError: )?Malformed arrow function parameter list/.test(msg)
         || /^Operation timed out/.test(msg)
         || /Cannot inject key into script value/.test(msg)
         || /Connection lost while action was in flight/.test(msg)

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -1173,6 +1173,45 @@ describe('SyntaxError via deck.gl/maplibre init path (WORLDMONITOR-SP)', () => {
   });
 });
 
+// ─── WORLDMONITOR-ZS: HTML document parsed as JavaScript ──────────────────
+//
+// V8 `SyntaxError: Malformed arrow function parameter list` when an Electron /
+// in-app wrapper loads the SPA document as a script. The only frame is the
+// document path (or an injected third-party frame) — never a hashed /assets
+// chunk. Same `hasAnyStack && !hasFirstParty` family as Unexpected token/keyword.
+describe('HTML-as-JS SyntaxError (WORLDMONITOR-ZS)', () => {
+  const MSG = 'Malformed arrow function parameter list';
+  const documentFrame = { filename: '/dashboard', lineno: 13, function: '?' };
+
+  it('suppresses the V8 HTML-as-JS parse error attributed to the document URL', () => {
+    const event = makeEvent(MSG, 'SyntaxError', [documentFrame]);
+    assert.equal(beforeSend(event), null,
+      'document-URL SyntaxError must be suppressed as HTML-as-JS noise');
+  });
+
+  it('suppresses the type-prefixed value variant', () => {
+    const event = makeEvent(`SyntaxError: ${MSG}`, 'SyntaxError', [documentFrame]);
+    assert.equal(beforeSend(event), null);
+  });
+
+  it('suppresses the same message with an extension-only stack', () => {
+    const event = makeEvent(MSG, 'SyntaxError', [extensionFrame()]);
+    assert.equal(beforeSend(event), null);
+  });
+
+  it('does NOT suppress the same SyntaxError with a first-party frame', () => {
+    const event = makeEvent(MSG, 'SyntaxError', [firstPartyFrame()]);
+    assert.ok(beforeSend(event) !== null,
+      'first-party SyntaxError must still reach Sentry');
+  });
+
+  it('does NOT suppress the same SyntaxError with an empty stack', () => {
+    const event = makeEvent(MSG, 'SyntaxError', []);
+    assert.ok(beforeSend(event) !== null,
+      'empty-stack parse error is not proven third-party and must surface');
+  });
+});
+
 // ─── WORLDMONITOR-TG: mainWorldSdk extension-global ReferenceError ─────────
 //
 // A browser-extension SDK injected into the page's main world references its


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Suppresses [WORLDMONITOR-ZS](https://elie-habib.sentry.io/issues/WORLDMONITOR-ZS): V8 `SyntaxError: Malformed arrow function parameter list` when an Electron/in-app wrapper loads the SPA document (`/dashboard`) as JavaScript.

The dashboard was already running (map, fetches, posture panel). The only frame is the HTML document URL pointing at a `<meta>` tag — not a hashed `/assets/*.js` chunk. Our compiled bundle cannot emit this parse error at runtime.

Class: **noise**. Filter layer: `beforeSend`, stacked with the existing `hasAnyStack && !hasFirstParty` SyntaxError family (`Unexpected token` / `Unexpected keyword`). A first-party or empty-stack event with the same message still reaches Sentry.

Fixes WORLDMONITOR-ZS

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Sentry `beforeSend` noise filter

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked (N/A — no published docs)
- [ ] All required Audit Council role signoffs attached (N/A)
- [ ] Generated docs regenerated from proto where applicable (N/A)
- [ ] Fixture-backed examples recomputed (N/A)
- [ ] Redis writers/readers enumerated for every documented key (N/A)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae1d6ace-57da-436a-84e6-57640b43a1a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae1d6ace-57da-436a-84e6-57640b43a1a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

