### PR TITLE
fix(wm-session): stop cookie-less 401s from tipping a session blackout

### DIFF
--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -679,12 +679,16 @@ async function attemptWmSession(): Promise<SessionAttempt> {
   if (inflight) return inflight;
 
   const stored = loadFromStorage();
-  if (isFresh(stored)) {
+  // sessionStorage only stores {exp}. After reload the in-memory wms_
+  // token is gone; treating that expiry as a live session would send the
+  // first RPC cookie-only (the XP bug). Remint unless we already have a
+  // token. Do NOT write `cached = stored` first: a failed remint would
+  // then make the next attemptWmSession hit `isFresh(cached)` above and
+  // return OK with no token — the leftover that turned one transport
+  // mint blip into cookie-less 401s on every boot panel (WORLDMONITOR-WG).
+  if (isFresh(stored) && anonymousSessionHeaderToken) {
     cached = stored;
-    // sessionStorage only stores {exp}. After reload the in-memory wms_
-    // token is gone; short-circuiting here would send the first RPC
-    // cookie-only (the XP bug). Remint unless we already have a token.
-    if (anonymousSessionHeaderToken) return SESSION_ATTEMPT_OK;
+    return SESSION_ATTEMPT_OK;
   }
 
   const identityGenerationWhenStarted = sessionIdentityGeneration;
@@ -1000,8 +1004,20 @@ export function installWmSessionFetchInterceptor(): void {
     const replayAndReport = async (): Promise<Response> => {
       const replayed = await sendWith(new Headers(headers), requestClone ?? input);
       if (isCurrentSessionIdentity()) {
-        if (replayed.status === 401) noteRecoveryFailure({ reason: 'retry_401' }, path);
-        else noteRouteSuccess(path);
+        if (replayed.status === 401) {
+          // retry_401 means "a demonstrably fresh cookie was rejected".
+          // A 401 after a mint that never succeeded is guaranteed — we
+          // sent neither wms_ nor a newly issued cookie — so it must not
+          // corroborate a transport mint failure into a tab-wide blackout.
+          // The modal WORLDMONITOR-WG residual was exactly that: mint
+          // failed (network), then USNI / vessel-snapshot replayed
+          // cookie-less and tipped the quorum. sessionGeneration ticks
+          // only on a successful mint, which is also what the cookie-only
+          // test fixtures use (body is `{exp}` with no token).
+          if (anonymousSessionHeaderToken || sessionGeneration > 0) {
+            noteRecoveryFailure({ reason: 'retry_401' }, path);
+          }
+        } else noteRouteSuccess(path);
       }
       return replayed;
     };

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -766,6 +766,14 @@ function withCredentials(init?: RequestInit): RequestInit {
 // instead of silently no-op'ing on the install guard. Without it, future
 // tests that wipe state and expect a fresh install would see a stale
 // `window.fetch` wrapper from a prior test.
+// Test-only: populate `cached` the way a successful mint does, without
+// going through attemptWmSession. The storage-prime helper used to rely
+// on writing `{exp}` into `cached` before remint; that path is gone so a
+// leftover failed remint cannot look like a live session.
+export function __primeWmSessionCacheForTests(exp: number): void {
+  cached = { exp };
+}
+
 export function __resetWmSessionForTests(): void {
   cached = null;
   inflight = null;

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -159,12 +159,22 @@ function setStoredSessionExp(_token: string, expMs: number): void {
 const FAR_FUTURE = Date.now() + 12 * 60 * 60 * 1000;
 const PAST = Date.now() - 1000;
 
-// Force the in-memory `cached` state by calling the module's API. ensureWmSession
-// reads sessionStorage when cached is null — set the storage and prime via
-// getWmSessionToken doesn't help because that only reads cached. We rely on
-// ensureWmSession's storage path to populate `cached`.
+// Force the in-memory `cached` expiry the way a successful mint does.
+// ensureWmSession no longer copies sessionStorage `{exp}` into `cached`
+// without a token (that leftover is the WG bug), so tests that want
+// "session already established this page" use the dedicated prime hook.
 async function primeCachedFromStorage(): Promise<void> {
-  await mod.ensureWmSession();
+  const raw = memoryStorage.get('wm-session-exp');
+  if (!raw) {
+    await mod.ensureWmSession();
+    return;
+  }
+  const parsed = JSON.parse(raw) as { exp?: unknown };
+  if (typeof parsed.exp !== 'number') {
+    await mod.ensureWmSession();
+    return;
+  }
+  mod.__primeWmSessionCacheForTests(parsed.exp);
 }
 
 describe('wm-session first RPC after mint (WORLDMONITOR-XP)', () => {

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -2867,17 +2867,17 @@ describe('wm-session mint cause provenance (#6804)', () => {
     assert.deepEqual(mod.getStruckRoutes(), [], 'and it strikes no route');
   });
 
-  it('names the mint cause when a burst blackout is tipped by a cookie-less replay', async () => {
-    // The modal WORLDMONITOR-WG shape: a dashboard boot burst plus a flaky
-    // transport. The leader's mint fails, records strike #1 and stops below
-    // quorum; the follower then replays with NO cookie (none was ever minted),
-    // so its 401 is guaranteed rather than evidential, and IT tips the quorum —
-    // with a retry_401 verdict that carries no cause of its own.
+  it('does not let a cookie-less follower replay tip a transport-mint blackout', async () => {
+    // The modal WORLDMONITOR-WG residual (USNI + vessel-snapshot on 2026-08-18):
+    // a dashboard boot burst plus a flaky transport. The leader's mint fails
+    // and records strike #1; the follower then replays with NO cookie (none
+    // was ever minted), so its 401 is guaranteed rather than evidential.
+    // Counting that as retry_401 tipped the quorum and blanked every anonymous
+    // panel for 15 minutes over a mint that never issued a session.
     //
-    // The episode was caused entirely by failed mints, so tagging it
-    // `mint_cause: none` would assert something false and send triage looking
-    // at a bystander panel for a cookie problem that does not exist. `none` is
-    // a positive claim now, and it has to be earned.
+    // Two *independent* mint failures still corroborate (the sequential
+    // "TWO routes corroborate" test above). A shared recovery plus a
+    // cookie-less replay must not.
     memoryStorage.clear();
     const captures = captureSink();
 
@@ -2894,17 +2894,49 @@ describe('wm-session mint cause provenance (#6804)', () => {
         wrappedFetch('https://api.worldmonitor.app/api/infrastructure/v1/get-cable-health'),
         wrappedFetch('https://api.worldmonitor.app/api/economic/v1/get-bls-series'),
       ]);
-      assert.equal(mod.isWmSessionDead(), true, 'the burst does black out');
+      assert.equal(
+        mod.isWmSessionDead(),
+        false,
+        'a guaranteed cookie-less 401 must not corroborate a transport mint failure',
+      );
     } finally {
       console.warn = originalWarn;
     }
 
     const dead = captures.filter((c) => c.ctx.tags?.kind === 'wm_session_dead');
-    assert.equal(dead.length, 1, 'exactly one capture per degraded episode');
-    assert.equal(
-      dead[0].ctx.tags?.mint_cause,
-      'network',
-      'every mint in this episode failed at the transport level — the tag must say so',
-    );
+    assert.equal(dead.length, 0, 'no blackout — the mint never issued a session');
+  });
+
+  it('remints after a failed reload remint instead of treating stored exp as success', async () => {
+    // Reload leaves sessionStorage `{exp}` and no in-memory wms_ token.
+    // Writing that expiry into `cached` *before* the remint meant a
+    // transport failure left the next ensureWmSession looking fresh, so
+    // every follow-up RPC went cookie-only and 401'd (WORLDMONITOR-XP/WG).
+    memoryStorage.set('wm-session-exp', JSON.stringify({ exp: FAR_FUTURE }));
+    captureSink();
+
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = urlOf(input);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.reject(new TypeError('Failed to fetch'));
+      }
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    try {
+      await wrappedFetch('https://api.worldmonitor.app/api/military/v1/get-usni-fleet-report');
+      const mintsAfterFirst = mintCalls;
+      await wrappedFetch('https://api.worldmonitor.app/api/maritime/v1/get-vessel-snapshot');
+      assert.ok(
+        mintCalls > mintsAfterFirst,
+        'a leftover stored exp must not skip remint on the next route',
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stops a remaining `WORLDMONITOR-WG` path where a failed anonymous-session mint plus two cookie-less boot RPCs (typically USNI fleet + vessel-snapshot) declared the whole tab dead for 15 minutes.

Production Axiom (`wm_api_usage`, last 6h, `auth_kind=anon`) showed the same ~2.5k browser requests **without** `X-WorldMonitor-Key` hitting both routes:

- `/api/maritime/v1/get-vessel-snapshot`: 1.6% `auth_401`
- `/api/military/v1/get-usni-fleet-report`: 95% `auth_401`

Those no-header calls are the interceptor sending cookie-only after a mint that never returned a `wms_` token. The latest WG episode (`retry_401`, `mint_cause=network`) was the shared recovery leader failing to mint, then the follower replaying with no credential and tipping the two-route quorum.

This does **not** make cookie-only USNI origin calls succeed. It stops those guaranteed 401s from blacking out every anonymous panel.

## What changed

In `src/services/wm-session.ts`:

1. Do not copy sessionStorage `{exp}` into `cached` before a remint succeeds. A failed remint was leaving the next `ensureWmSession()` looking fresh with no in-memory token.
2. Record `retry_401` only after a mint has actually succeeded (`anonymousSessionHeaderToken` or `sessionGeneration > 0`). A guaranteed cookie-less 401 is not evidence that a fresh cookie was rejected.

Two *independent* transport mint failures still corroborate and black out, as before.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Other: anonymous `wm-session` interceptor

## Checklist

- [x] No API keys or secrets committed
- [x] Focused proof: `tsx --test tests/wm-session-auto-refresh.test.mts` — 60 passed
- [x] New or repointed health probes: N/A

## Documentation Alignment Checklist

- [x] N/A — no published methodology/API/MCP contract change

Fixes WORLDMONITOR-WG

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae1d6ace-57da-436a-84e6-57640b43a1a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae1d6ace-57da-436a-84e6-57640b43a1a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

