### PR TITLE
fix(military): wrap viewport longitudes and retry transient OpenSky failures

### DIFF
--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -594,6 +594,12 @@ const WINGBITS_BASE = 'https://customer-api.wingbits.com/v1/flights';
 const OPENSKY_TOKEN_URL = 'https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token';
 const OPENSKY_AUTH_COOLDOWN_MS = 60_000;
 const OPENSKY_AUTH_RETRY_DELAYS = [0, 2_000, 5_000];
+
+// #6249: the single global /states/all query has no per-region isolation any
+// more, so one transient network blip or 5xx zeroes OpenSky's entire
+// contribution for the cycle. Bounded ladder for non-401/non-429 failures,
+// mirroring the auth ladder's shape. 429 stays unretried (#6241).
+const OPENSKY_FETCH_RETRY_DELAYS = [0, 1_500];
 // This seeder is a one-shot process on a */5 Railway cron, so the 429 cooldown
 // CANNOT live in a module variable the way the relay's does — the deadline has
 // to outlive the process. Redis is the only state that does (#6241).
@@ -889,55 +895,83 @@ async function getOpenSkyToken() {
 // what a global query costs — so the previous PACIFIC+WESTERN pair (1,296 and
 // 4,824 sq°) spent 8 credits/run for strictly less coverage than 4 buys. See
 // docs/solutions/integration-issues/opensky-bbox-area-billing-flat-top-tier.md (#6222).
-async function fetchOpenSkyAuthenticated() {
+// Exported as a test seam: the full fetchAllStates path staggers 13 blind-spot
+// regions at 1s each before reaching this tier, which is far too slow for the
+// retry-contract tests that need to drive it directly.
+export async function fetchOpenSkyAuthenticated() {
   const url = `${OPENSKY_BASE}/states/all?extended=1`;
 
-  for (let attempt = 0; attempt < 2; attempt += 1) {
+  // One direct+proxy attempt. 401 returns for a token-refresh retry; any
+  // other failure propagates so the ladder below can classify it.
+  const attemptOnce = async (token) => {
+    const headers = { Authorization: `Bearer ${token}` };
+    try {
+      const data = await fetchJsonDirect(url, { headers });
+      return { ok: true, transport: 'direct', data };
+    } catch (directError) {
+      if (isOpenSkyUnauthorizedError(directError)) return { unauthorized: true };
+      // Never retry a 429 through the proxy. The quota is per ACCOUNT, and both
+      // paths carry the same bearer token — a different egress IP cannot change
+      // the verdict, so the retry is guaranteed to fail while still costing a
+      // request, proxy bandwidth, and latency on every cycle of a multi-hour
+      // exhaustion window. It also bounds the double-spend window: a direct
+      // request that OpenSky served but that failed client-side has already
+      // debited its credits, and retrying debits them again (#6222).
+      if (isOpenSkyRateLimitedError(directError)) throw directError;
+      if (!PROXY_ENABLED) throw directError;
+      try {
+        const data = await proxyFetchJson(url, { headers });
+        return { ok: true, transport: 'proxy', data };
+      } catch (proxyError) {
+        if (isOpenSkyUnauthorizedError(proxyError)) return { unauthorized: true };
+        throw combineOpenSkyFetchErrors(directError, proxyError);
+      }
+    }
+  };
+
+  let lastError = null;
+  for (const delayMs of OPENSKY_FETCH_RETRY_DELAYS) {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
     const token = await getOpenSkyToken();
     if (!token) return { states: null, status: getOpenSkyAuthStatus() };
-    const headers = { Authorization: `Bearer ${token}` };
 
     try {
-      let data;
-      try {
-        data = await fetchJsonDirect(url, { headers });
-        return { states: data.states || [], status: `success:direct` };
-      } catch (directError) {
-        if (isOpenSkyUnauthorizedError(directError)) {
-          clearOpenSkyToken();
-          if (attempt === 0) continue;
-        }
-        if (!PROXY_ENABLED) throw directError;
-        // Never retry a 429 through the proxy. The quota is per ACCOUNT, and both
-        // paths carry the same bearer token — a different egress IP cannot change
-        // the verdict, so the retry is guaranteed to fail while still costing a
-        // request, proxy bandwidth, and latency on every cycle of a multi-hour
-        // exhaustion window. It also bounds the double-spend window: a direct
-        // request that OpenSky served but that failed client-side has already
-        // debited its credits, and retrying debits them again (#6222).
-        if (isOpenSkyRateLimitedError(directError)) throw directError;
-        try {
-          data = await proxyFetchJson(url, { headers });
-          return { states: data.states || [], status: `success:proxy` };
-        } catch (proxyError) {
-          if (isOpenSkyUnauthorizedError(proxyError)) {
-            clearOpenSkyToken();
-            if (attempt === 0) continue;
-          }
-          throw combineOpenSkyFetchErrors(directError, proxyError);
-        }
+      let outcome = await attemptOnce(token);
+      if (outcome.unauthorized) {
+        // 401 keeps the immediate refresh semantics: clear, re-auth, retry
+        // once — never the backoff ladder, which is for transient failures.
+        clearOpenSkyToken();
+        const refreshed = await getOpenSkyToken();
+        if (!refreshed) return { states: null, status: getOpenSkyAuthStatus() };
+        outcome = await attemptOnce(refreshed);
       }
-    } catch (error) {
+      if (outcome.ok) {
+        return { states: outcome.data.states || [], status: `success:${outcome.transport}` };
+      }
+      // Second consecutive unauthorized: report it, do not loop.
+      clearOpenSkyToken();
       return {
         states: null,
-        status: `error:${redactProxy(error.message)}`,
-        rateLimited: isOpenSkyRateLimitedError(error),
-        retryAfterSeconds: error?.retryAfterSeconds ?? null,
+        status: 'error:OpenSky unauthorized after token refresh',
       };
+    } catch (error) {
+      if (isOpenSkyRateLimitedError(error)) {
+        return {
+          states: null,
+          status: `error:${redactProxy(error.message)}`,
+          rateLimited: true,
+          retryAfterSeconds: error?.retryAfterSeconds ?? null,
+        };
+      }
+      lastError = error;
     }
   }
-
-  return { states: null, status: getOpenSkyAuthStatus() };
+  return {
+    states: null,
+    status: `error:${redactProxy(lastError?.message || 'OpenSky fetch failed')}`,
+  };
 }
 
 // No anonymous fallback. OpenSky's unauthenticated tier is 400 credits/day PER

--- a/server/worldmonitor/military/v1/_bounds.ts
+++ b/server/worldmonitor/military/v1/_bounds.ts
@@ -1,0 +1,47 @@
+import type { ListMilitaryFlightsRequest } from '../../../../src/generated/server/worldmonitor/military/v1/service_server';
+
+/**
+ * #6249: MapLibre's `getBounds()` returns longitudes outside [-180, 180]
+ * once the user pans across world copies, and API callers can send
+ * `sw_lon=-190` directly. The live seed's coverage predicate requires
+ * `region.west <= bounds.west`, so an unwrapped west below -180 fails
+ * coverage, falls back to per-viewer relay recovery, and the relay rejects
+ * the out-of-range bbox with an empty result — while the global snapshot
+ * that would have answered sits right there.
+ *
+ * Pure module (no Redis/network imports) so the normalization is unit
+ * testable in isolation from the handler's side effects.
+ */
+export interface RequestBounds {
+  south: number;
+  north: number;
+  west: number;
+  east: number;
+}
+
+function wrapLongitude(lon: number): number {
+  return (((lon + 180) % 360) + 360) % 360 - 180;
+}
+
+/** False for NaN/±Infinity in any corner coordinate — the caller must answer empty. */
+export function hasFiniteRequestBounds(req: ListMilitaryFlightsRequest): boolean {
+  return [req.swLat, req.swLon, req.neLat, req.neLon].every(Number.isFinite);
+}
+
+/**
+ * Normalize a request bbox: swap inverted corners, wrap longitudes into
+ * [-180, 180], and widen a world-spanning or antimeridian-crossing box to
+ * the full longitude range instead of emitting an inverted west/east pair
+ * the downstream coverage predicate and bbox filter can never satisfy.
+ */
+export function normalizeBounds(req: ListMilitaryFlightsRequest): RequestBounds {
+  const west = wrapLongitude(Math.min(req.swLon, req.neLon));
+  const east = wrapLongitude(Math.max(req.swLon, req.neLon));
+  const spannedGlobe = req.neLon - req.swLon >= 360 || west > east;
+  return {
+    south: Math.min(req.swLat, req.neLat),
+    north: Math.max(req.swLat, req.neLat),
+    west: spannedGlobe ? -180 : west,
+    east: spannedGlobe ? 180 : east,
+  };
+}

--- a/server/worldmonitor/military/v1/_bounds.ts
+++ b/server/worldmonitor/military/v1/_bounds.ts
@@ -20,7 +20,13 @@ export interface RequestBounds {
 }
 
 function wrapLongitude(lon: number): number {
-  return (((lon + 180) % 360) + 360) % 360 - 180;
+  // Already-canonical values must pass through unchanged. The `%` wrap
+  // introduces float noise (177.34 -> 177.34000000000003) and maps +180
+  // onto -180, which then looks like an antimeridian inversion.
+  if (lon > -180 && lon <= 180) return lon;
+  const wrapped = (((lon + 180) % 360) + 360) % 360 - 180;
+  if (wrapped === -180 && lon > 0) return 180;
+  return wrapped;
 }
 
 /** False for NaN/±Infinity in any corner coordinate — the caller must answer empty. */

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/military/v1/service_server';
 
 import { isMilitaryCallsign, isMilitaryHex, detectAircraftType, UPSTREAM_TIMEOUT_MS } from './_shared';
+import { hasFiniteRequestBounds, normalizeBounds, type RequestBounds } from './_bounds';
 import { cachedFetchJson, getRawJson, readCachedJson, setCachedJson } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
@@ -27,13 +28,6 @@ const STALE_SNAPSHOT_NEG_TTL = 30;
 const quantize = (v: number, step: number) => Math.round(v / step) * step;
 const clamp = (v: number, min: number, max: number) => Math.min(max, Math.max(min, v));
 const BBOX_GRID_STEP = 1; // 1-degree grid (~111 km at equator)
-
-interface RequestBounds {
-  south: number;
-  north: number;
-  west: number;
-  east: number;
-}
 
 // Coverage is a property of the SNAPSHOT, not of the producer's query shape.
 //
@@ -66,15 +60,6 @@ function seedCovers(coverage: SeedCoverage, bounds: RequestBounds): boolean {
   );
 }
 
-
-function normalizeBounds(req: ListMilitaryFlightsRequest): RequestBounds {
-  return {
-    south: Math.min(req.swLat, req.neLat),
-    north: Math.max(req.swLat, req.neLat),
-    west: Math.min(req.swLon, req.neLon),
-    east: Math.max(req.swLon, req.neLon),
-  };
-}
 
 function filterFlightsToBounds(
   flights: ListMilitaryFlightsResponse['flights'],
@@ -468,6 +453,9 @@ export async function listMilitaryFlights(
   const redistributableOnly = requiresRedistributableProviders(ctx.request);
   try {
     if (!req.neLat && !req.neLon && !req.swLat && !req.swLon) return emptyResponse();
+    // #6249: a NaN/Infinity corner cannot be normalized into a meaningful
+    // bbox; answer empty instead of letting it reach the relay as garbage.
+    if (!hasFiniteRequestBounds(req)) return emptyResponse();
     const requestBounds = normalizeBounds(req);
 
     // Quantize bbox to a 1° grid so nearby map views share cache entries.

--- a/tests/military-flights-bounds.test.mts
+++ b/tests/military-flights-bounds.test.mts
@@ -47,6 +47,23 @@ describe('military-flights request bounds normalization (#6249)', () => {
     assert.deepEqual(bounds, { south: -90, north: 90, west: -180, east: 180 });
   });
 
+  it('does not widen a Pacific box that only touches +180', () => {
+    // Fiji / MapLibre east-edge: wrap(+180) must stay +180, not invert to -180.
+    assert.deepEqual(
+      normalizeBounds(req({ swLon: 177.34, neLon: 180 })),
+      { south: 0, north: 1, west: 177.34, east: 180 },
+    );
+    assert.deepEqual(
+      normalizeBounds(req({ swLon: 140, neLon: 180 })),
+      { south: 0, north: 1, west: 140, east: 180 },
+    );
+    // World-copy of 140..180.
+    assert.deepEqual(
+      normalizeBounds(req({ swLon: 500, neLon: 540 })),
+      { south: 0, north: 1, west: 140, east: 180 },
+    );
+  });
+
   it('swaps inverted corners and wraps the result', () => {
     const bounds = normalizeBounds(req({ swLat: 10, swLon: 20, neLat: 5, neLon: 10 }));
     assert.deepEqual(bounds, { south: 5, north: 10, west: 10, east: 20 });

--- a/tests/military-flights-bounds.test.mts
+++ b/tests/military-flights-bounds.test.mts
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  hasFiniteRequestBounds,
+  normalizeBounds,
+} from '../server/worldmonitor/military/v1/_bounds.ts';
+
+type Req = Parameters<typeof normalizeBounds>[0];
+const req = (over: Partial<Req> = {}): Req => ({
+  swLat: 0,
+  swLon: 0,
+  neLat: 1,
+  neLon: 1,
+  ...over,
+} as Req);
+
+describe('military-flights request bounds normalization (#6249)', () => {
+  it('wraps an unwrapped west longitude from a world-copy viewport', () => {
+    // A narrow world-copy viewport that does not cross the antimeridian:
+    // raw 185..190 wraps cleanly to -175..-170.
+    const bounds = normalizeBounds(req({ swLon: 185, neLon: 190 }));
+    assert.deepEqual(bounds, { south: 0, north: 1, west: -175, east: -170 });
+    // The global seed coverage predicate accepts every wrapped box.
+    assert.ok(bounds.west >= -180 && bounds.east <= 180);
+  });
+
+  it('widens a world-spanning viewport to the full longitude range', () => {
+    const bounds = normalizeBounds(req({ swLon: -200, neLon: 170 }));
+    assert.deepEqual(bounds, { south: 0, north: 1, west: -180, east: 180 });
+  });
+
+  it('widens a wrapped antimeridian-crossing box instead of inverting west/east', () => {
+    // Raw 170..190 crosses the antimeridian: wrapped west=170 > east=-170.
+    const bounds = normalizeBounds(req({ swLon: 170, neLon: 190 }));
+    assert.deepEqual(bounds, { south: 0, north: 1, west: -180, east: 180 });
+  });
+
+  it('normalizes inverted corners by swapping before wrapping', () => {
+    // sw/ne given as (170, -170): existing callers rely on min/max swapping.
+    const bounds = normalizeBounds(req({ swLon: 170, neLon: -170 }));
+    assert.deepEqual(bounds, { south: 0, north: 1, west: -170, east: 170 });
+  });
+
+  it('keeps exact antimeridian boundaries untouched', () => {
+    const bounds = normalizeBounds(req({ swLat: -90, swLon: -180, neLat: 90, neLon: 180 }));
+    assert.deepEqual(bounds, { south: -90, north: 90, west: -180, east: 180 });
+  });
+
+  it('swaps inverted corners and wraps the result', () => {
+    const bounds = normalizeBounds(req({ swLat: 10, swLon: 20, neLat: 5, neLon: 10 }));
+    assert.deepEqual(bounds, { south: 5, north: 10, west: 10, east: 20 });
+  });
+
+  it('rejects non-finite coordinates before normalization', () => {
+    for (const over of [
+      { swLat: Number.NaN },
+      { swLon: Number.POSITIVE_INFINITY },
+      { neLat: Number.NaN },
+      { neLon: Number.NEGATIVE_INFINITY },
+    ]) {
+      assert.equal(hasFiniteRequestBounds(req(over)), false, JSON.stringify(over));
+    }
+    assert.equal(hasFiniteRequestBounds(req()), true);
+  });
+});

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -44,13 +44,37 @@ async function importRedisFresh() {
   return import(`${REDIS_MODULE_URL}?t=${Date.now()}-${Math.random().toString(16).slice(2)}`);
 }
 
+function resolveRelativeTsModule(fromDir, specifier) {
+  const candidates = [
+    resolve(fromDir, specifier),
+    resolve(fromDir, `${specifier}.ts`),
+    resolve(fromDir, `${specifier}.js`),
+    resolve(fromDir, `${specifier}.mjs`),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate) && statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 async function importPatchedTsModule(relPath, replacements) {
   const sourcePath = resolve(root, relPath);
+  const sourceDir = dirname(sourcePath);
   let source = readFileSync(sourcePath, 'utf-8');
 
   for (const [specifier, targetPath] of Object.entries(replacements)) {
     source = source.replaceAll(`'${specifier}'`, `'${pathToFileURL(targetPath).href}'`);
   }
+
+  // The patched file is imported from /tmp. Remaining relative specifiers
+  // (e.g. `./_bounds` after a same-directory extract) still resolve against
+  // that temp dir unless they are rewritten to the original sibling path.
+  source = source.replaceAll(/from '((?:\.\.?\/)[^']+)'/g, (match, specifier) => {
+    const targetPath = resolveRelativeTsModule(sourceDir, specifier);
+    return targetPath ? `from '${pathToFileURL(targetPath).href}'` : match;
+  });
 
   const tempDir = mkdtempSync(join(tmpdir(), 'wm-ts-module-'));
   const tempPath = join(tempDir, basename(sourcePath));
@@ -2227,6 +2251,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
   async function importListMilitaryFlights() {
     return importPatchedTsModule('server/worldmonitor/military/v1/list-military-flights.ts', {
       './_shared': resolve(root, 'server/worldmonitor/military/v1/_shared.ts'),
+      './_bounds': resolve(root, 'server/worldmonitor/military/v1/_bounds.ts'),
       '../../../_shared/constants': resolve(root, 'server/_shared/constants.ts'),
       '../../../_shared/redis': resolve(root, 'server/_shared/redis.ts'),
       '../../../_shared/relay': resolve(root, 'server/_shared/relay.ts'),

--- a/tests/seed-military-flights-opensky-retry.test.mjs
+++ b/tests/seed-military-flights-opensky-retry.test.mjs
@@ -1,0 +1,97 @@
+// #6249 — the single global OpenSky /states/all query retries bounded,
+// transient failures and leaves 429s (and auth failures) on their existing
+// no-retry / immediate-refresh contracts.
+
+import { beforeEach, afterEach, describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.WINGBITS_API_KEY = 'test-wingbits';
+process.env.WM_ENABLE_NONCOMMERCIAL_ADSB_GAP_FILL = '1';
+process.env.OPENSKY_CLIENT_ID = 'test-id';
+process.env.OPENSKY_CLIENT_SECRET = 'test-secret';
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+delete process.env.OPENSKY_PROXY_AUTH;
+
+const { fetchOpenSkyAuthenticated } = await import('../scripts/seed-military-flights.mjs');
+
+const TOKEN_URL = 'https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token';
+const STATES_URL = 'https://opensky-network.org/api/states/all?extended=1';
+
+const originalFetch = globalThis.fetch;
+let statesCalls;
+let statesResponses;
+let tokenCalls;
+
+function installStates(responses) {
+  statesResponses = [...responses];
+  statesCalls = [];
+  tokenCalls = 0;
+  globalThis.fetch = async (url) => {
+    const raw = typeof url === 'string' ? url : url.url;
+    if (raw === TOKEN_URL) {
+      tokenCalls += 1;
+      return Response.json({ access_token: `token-${tokenCalls}`, expires_in: 1800 });
+    }
+    if (raw === STATES_URL) {
+      statesCalls.push(raw);
+      const next = statesResponses.shift();
+      if (typeof next === 'number') {
+        return new Response(JSON.stringify({ error: 'upstream' }), {
+          status: next,
+          headers: { 'Content-Type': 'application/json', ...({ 429: { 'Retry-After': '900' } })[next] },
+        });
+      }
+      return Response.json(next ?? { states: [] });
+    }
+    return Response.json({});
+  };
+}
+
+beforeEach(() => installStates([]));
+afterEach(() => { globalThis.fetch = originalFetch; });
+
+describe('OpenSky global fetch retry ladder (#6249)', () => {
+  test('a transient 5xx is retried once and then succeeds', async () => {
+    installStates([500, { states: [['ae0001', 'RCH101', 'US', 40, -100]] }]);
+    const result = await fetchOpenSkyAuthenticated();
+    assert.equal(result.status, 'success:direct');
+    assert.equal(result.states.length, 1);
+    assert.equal(statesCalls.length, 2, 'exactly one bounded retry');
+  });
+
+  test('a 429 is never retried', async () => {
+    installStates([429]);
+    const result = await fetchOpenSkyAuthenticated();
+    assert.match(result.status, /error:.*429/);
+    assert.equal(result.rateLimited, true);
+    assert.equal(result.retryAfterSeconds, 900);
+    assert.equal(statesCalls.length, 1, 'a 429 must not be retried (#6241)');
+  });
+
+  test('a 401 refreshes the token immediately and retries once', async () => {
+    installStates([401, { states: [] }]);
+    const result = await fetchOpenSkyAuthenticated();
+    assert.equal(result.status, 'success:direct');
+    assert.equal(statesCalls.length, 2);
+    // The first token may still be module-cached from a prior test, so the
+    // observable contract is that a refresh POST happened for the retry.
+    assert.ok(tokenCalls >= 1, 'the unauthorized attempt must refresh the token');
+  });
+
+  test('two consecutive 401s report without looping', async () => {
+    installStates([401, 401]);
+    const result = await fetchOpenSkyAuthenticated();
+    assert.match(result.status, /unauthorized after token refresh/);
+    assert.equal(result.states, null);
+    assert.equal(statesCalls.length, 2);
+  });
+
+  test('a persistent transient failure exhausts the ladder and reports the error', async () => {
+    installStates([503, 503]);
+    const result = await fetchOpenSkyAuthenticated();
+    assert.match(result.status, /error:/);
+    assert.equal(result.states, null);
+    assert.equal(statesCalls.length, 2, 'ladder is bounded at two attempts');
+  });
+});

--- a/tests/seed-military-flights-opensky-retry.test.mjs
+++ b/tests/seed-military-flights-opensky-retry.test.mjs
@@ -20,20 +20,26 @@ const STATES_URL = 'https://opensky-network.org/api/states/all?extended=1';
 
 const originalFetch = globalThis.fetch;
 let statesCalls;
+let statesAuth;
 let statesResponses;
 let tokenCalls;
+let tokenSerial = 0;
 
 function installStates(responses) {
   statesResponses = [...responses];
   statesCalls = [];
+  statesAuth = [];
   tokenCalls = 0;
-  globalThis.fetch = async (url) => {
+  globalThis.fetch = async (url, init = {}) => {
     const raw = typeof url === 'string' ? url : url.url;
     if (raw === TOKEN_URL) {
       tokenCalls += 1;
-      return Response.json({ access_token: `token-${tokenCalls}`, expires_in: 1800 });
+      tokenSerial += 1;
+      return Response.json({ access_token: `token-${tokenSerial}`, expires_in: 1800 });
     }
     if (raw === STATES_URL) {
+      const headers = init.headers && typeof init.headers === 'object' ? init.headers : {};
+      statesAuth.push(headers.Authorization || headers.authorization || '');
       statesCalls.push(raw);
       const next = statesResponses.shift();
       if (typeof next === 'number') {
@@ -74,9 +80,13 @@ describe('OpenSky global fetch retry ladder (#6249)', () => {
     const result = await fetchOpenSkyAuthenticated();
     assert.equal(result.status, 'success:direct');
     assert.equal(statesCalls.length, 2);
-    // The first token may still be module-cached from a prior test, so the
-    // observable contract is that a refresh POST happened for the retry.
-    assert.ok(tokenCalls >= 1, 'the unauthorized attempt must refresh the token');
+    assert.match(statesAuth[0], /^Bearer /);
+    assert.match(statesAuth[1], /^Bearer /);
+    assert.notEqual(
+      statesAuth[1],
+      statesAuth[0],
+      'the unauthorized attempt must refresh the bearer, not retry the same token',
+    );
   });
 
   test('two consecutive 401s report without looping', async () => {


### PR DESCRIPTION
## Summary

Two robustness gaps left behind by #6244's review (#6249), both in the military-flight path:

### 1. Unwrapped / non-finite longitudes missed the global seed coverage

MapLibre's `getBounds()` returns longitudes outside `[-180, 180]` once the user pans across world copies, and API callers can send `sw_lon=-190` directly. The global seed coverage predicate requires `region.west <= bounds.west`, so an unwrapped west below -180 failed coverage, fell back to per-viewer relay recovery, and the relay rejected the out-of-range bbox — an empty result while the answering snapshot sat in Redis. NaN corners behaved identically.

`normalizeBounds` now lives in a pure module (`_bounds.ts`, no Redis/network imports):

- corners are swapped (`min`/`max`) as before;
- longitudes are wrapped into `[-180, 180]`;
- a world-spanning viewport (raw span >= 360) or a wrapped antimeridian crossing widens to the full longitude range instead of emitting an inverted west/east pair the coverage predicate and bbox filter can never satisfy;
- non-finite coordinates are rejected with `emptyResponse()` before normalization.

### 2. The single global OpenSky query had no retry on transient failures

After #6244's consolidation, one timeout/5xx/network blip zeroed OpenSky's entire contribution for the cycle. The fetch now runs a bounded ladder `[0, 1500ms]` for non-401/non-429 failures, mirroring the auth ladder's shape:

- **429 is still never retried** (#6241) — returns immediately with `rateLimited`/`retryAfterSeconds` as before;
- **401 keeps its immediate token-refresh semantics** (clear, re-auth, retry once) rather than joining the backoff ladder;
- the direct→proxy fallback structure and `combineOpenSkyFetchErrors` are preserved;
- `fetchOpenSkyAuthenticated` is exported as a test seam so the contracts are driven directly (the full `fetchAllStates` path staggers 13 blind-spot regions at 1s each before reaching this tier).

## Type of change

- [x] Bug fix

## Affected areas

- [x] Map / Globe

## Checklist

- [ ] Tested on worldmonitor.app variant — N/A: pure normalization + seeder contracts exercised by unit tests
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Documentation Alignment Checklist

- Claim ledger: N/A
- Audit Council signoffs: N/A

## Testing

- New `tests/military-flights-bounds.test.mts` — 7 cases: world-copy wrap (185..190 → -175..-170), raw span >= 360 → global, wrapped antimeridian (170..190) → global, inverted corners swapped, exact ±180/±90 boundaries, NaN/±Infinity rejection.
- New `tests/seed-military-flights-opensky-retry.test.mjs` — 5 cases: transient 5xx retried once then succeeds (exactly 2 state calls); 429 never retried (exactly 1 call, `rateLimited` preserved); 401 refreshes and retries once; double-401 reports without looping; persistent transient failure exhausts the bounded ladder.
- `node --test tests/seed-military-flights-opensky-budget.test.mjs` — 3/3 (zero-credit contracts intact)
- `npx tsx --test tests/gateway-required-bbox.test.mts` — 12/12
- `npm run typecheck`, `biome check` on all five changed files, `git diff --check` — clean
- Known unrelated: `tests/military-flight-pagination.test.mts` fails 0/8 identically on pristine `origin/main` (verified via checkout) — pre-existing, untouched by this PR.

Fixes #6249