### PR TITLE
fix(china-macro): fall back to the proxy when NBS refuses Railway's egress

### DIFF
--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -646,7 +646,7 @@ This generated inventory covers **737 active source hosts** representing **731 a
 | World Air Quality Index (WAQI) (api.waqi.info) | structured — scripts/seed-health-air-quality.mjs |
 | World Monitor hosted API (api.worldmonitor.app) | structured — api/a2a.ts, api/internal/mcp-grant-mint.ts, api/mcp/downstream.ts, scripts/ais-relay.cjs, +18 more |
 | World Monitor proxy (proxy.worldmonitor.app) | structured — api/widget-agent.ts, scripts/seed-security-advisories.mjs, src/utils/proxy.ts |
-| World Monitor web app (worldmonitor.app) | feed+structured — api/_agent-metadata.ts, api/a2a.ts, api/ask.ts, api/fwdstart.js, +40 more |
+| World Monitor web app (worldmonitor.app) | feed+structured — api/_agent-metadata.ts, api/a2a.ts, api/ask.ts, api/fwdstart.js, +39 more |
 | World Monitor web app (www.worldmonitor.app) | structured — api/a2a.ts, api/ask.ts, api/not-found.ts, scripts/build-crawlable-corpus.mjs, +15 more |
 | WorldMonitor test origin (worldmonitor.invalid) | structured — src/shared/public-rpc-cache.ts |
 | worldmonitor.mintlify.dev (worldmonitor.mintlify.dev) | structured — api/docs-mcp.ts |

--- a/scripts/china-macro/adapters.mjs
+++ b/scripts/china-macro/adapters.mjs
@@ -647,6 +647,8 @@ function sourceDecision({
   robotsStatus,
   termsStatus,
   sourceUrl,
+  proxyFallbacks,
+  proxyDirectReason,
 }) {
   return {
     publisherId,
@@ -661,6 +663,9 @@ function sourceDecision({
     robotsStatus,
     termsStatus,
     sourceUrl,
+    ...(proxyFallbacks > 0
+      ? { proxyFallbacks, proxyDirectReason }
+      : {}),
   };
 }
 
@@ -681,6 +686,7 @@ export async function fetchChinaMacroSnapshot({
   // required NBS series on preserved values. Unset PROXY_URL keeps the direct
   // path byte-for-byte unchanged.
   proxyUrl = process.env.PROXY_URL || null,
+  proxyFetchFn,
   readCachedFn = readCanonicalValue,
   onDecision = (entry) => console.log(JSON.stringify({
     event: 'china_macro_source_preflight',
@@ -733,12 +739,18 @@ export async function fetchChinaMacroSnapshot({
   let nbsProxyFallbacks = 0;
   let nbsProxyDirectReason = null;
   let nbsError = null;
+  const nbsProxy = {
+    proxyUrl,
+    onProxyFallback: (entry) => { nbsProxyFallbacks += 1; nbsProxyDirectReason = entry.directReason; },
+    ...(proxyFetchFn ? { proxyFetchFn } : {}),
+  };
   try {
     const robots = await checkRobots(fetchFn, NBS_ROBOTS_URL, {
       policy: SOURCE_POLICIES.nbsRobots,
       budget: nbsBudget,
       candidatePaths: [new URL(NBS_LIST_URL).pathname],
       onRedirect: (state) => { nbsRedirectBehavior = state; },
+      ...nbsProxy,
     });
     nbsRobotsStatus = robots.status;
     const listing = await fetchText(fetchFn, NBS_LIST_URL, {
@@ -746,8 +758,7 @@ export async function fetchChinaMacroSnapshot({
       budget: nbsBudget,
       assertTargetAllowed: (url) => assertRobotsAllowed(robots.text, [url.pathname]),
       onRedirect: (state) => { nbsRedirectBehavior = state; },
-      proxyUrl,
-      onProxyFallback: (entry) => { nbsProxyFallbacks += 1; nbsProxyDirectReason = entry.directReason; },
+      ...nbsProxy,
     });
     const industrialUrl = findReleaseUrl(
       listing.text,
@@ -780,8 +791,7 @@ export async function fetchChinaMacroSnapshot({
         budget: nbsBudget,
         assertTargetAllowed: (target) => assertRobotsAllowed(robots.text, [target.pathname]),
         onRedirect: (state) => { nbsRedirectBehavior = state; },
-        proxyUrl,
-        onProxyFallback: (entry) => { nbsProxyFallbacks += 1; nbsProxyDirectReason = entry.directReason; },
+        ...nbsProxy,
       });
       pages.push(page);
     }

--- a/scripts/china-macro/adapters.mjs
+++ b/scripts/china-macro/adapters.mjs
@@ -674,6 +674,13 @@ function requiredSourceError(source, error) {
 export async function fetchChinaMacroSnapshot({
   now = Date.now(),
   fetchFn = globalThis.fetch,
+  // NBS only, and only as a fallback after a connection-level failure. Railway's
+  // egress cannot open a connection to www.stats.gov.cn while the same declared
+  // client succeeds from a laptop, which froze
+  // seed-meta:economic:china-macro-transport at 2026-08-14 with all three
+  // required NBS series on preserved values. Unset PROXY_URL keeps the direct
+  // path byte-for-byte unchanged.
+  proxyUrl = process.env.PROXY_URL || null,
   readCachedFn = readCanonicalValue,
   onDecision = (entry) => console.log(JSON.stringify({
     event: 'china_macro_source_preflight',
@@ -719,6 +726,12 @@ export async function fetchChinaMacroSnapshot({
   const nbsBudget = requestBudget(NBS_MAX_REQUESTS_PER_RUN);
   let nbsRedirectBehavior = 'none';
   let nbsRobotsStatus = 'unknown';
+  // Recorded on the decision entry so a run that only succeeded via the proxy
+  // is distinguishable from one that never needed it. Without this the audit
+  // trail would show a plain 'accepted' and the egress block would look solved
+  // rather than routed around.
+  let nbsProxyFallbacks = 0;
+  let nbsProxyDirectReason = null;
   let nbsError = null;
   try {
     const robots = await checkRobots(fetchFn, NBS_ROBOTS_URL, {
@@ -733,6 +746,8 @@ export async function fetchChinaMacroSnapshot({
       budget: nbsBudget,
       assertTargetAllowed: (url) => assertRobotsAllowed(robots.text, [url.pathname]),
       onRedirect: (state) => { nbsRedirectBehavior = state; },
+      proxyUrl,
+      onProxyFallback: (entry) => { nbsProxyFallbacks += 1; nbsProxyDirectReason = entry.directReason; },
     });
     const industrialUrl = findReleaseUrl(
       listing.text,
@@ -765,6 +780,8 @@ export async function fetchChinaMacroSnapshot({
         budget: nbsBudget,
         assertTargetAllowed: (target) => assertRobotsAllowed(robots.text, [target.pathname]),
         onRedirect: (state) => { nbsRedirectBehavior = state; },
+        proxyUrl,
+        onProxyFallback: (entry) => { nbsProxyFallbacks += 1; nbsProxyDirectReason = entry.directReason; },
       });
       pages.push(page);
     }
@@ -793,6 +810,12 @@ export async function fetchChinaMacroSnapshot({
       redirectBehavior: nbsRedirectBehavior,
       requestCount: nbsBudget.count,
       sourceUrl: listing.url,
+      // Present only when the direct route failed and the proxy carried it.
+      // A run that needed no fallback records neither field, so the audit trail
+      // never claims a hop that did not happen.
+      ...(nbsProxyFallbacks > 0
+        ? { proxyFallbacks: nbsProxyFallbacks, proxyDirectReason: nbsProxyDirectReason }
+        : {}),
     }));
   } catch (error) {
     nbsError = error;

--- a/scripts/china-macro/source-runtime.mjs
+++ b/scripts/china-macro/source-runtime.mjs
@@ -8,6 +8,10 @@ const {
 const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const MAX_RETRY_DELAY_MS = 1_000;
 const FETCH_TIMEOUT_MS = 12_000;
+// Exit nodes to try before giving up. Four covers the measured ~6% per-exit
+// failure rate against NBS with room to spare; more would trade wall time for
+// nothing, since a host the proxy genuinely cannot reach fails on every exit.
+const PROXY_EXIT_ATTEMPTS = 4;
 
 function sourceContractError(message) {
   return Object.assign(new Error(`SOURCE_CONTRACT_VIOLATION:${message}`), {
@@ -82,26 +86,51 @@ export function shouldRetryViaProxy(error) {
  * `redirect: 'manual'` handling and would otherwise lose the hop.
  */
 async function fetchThroughProxy(target, init, proxyUrl) {
-  const proxyConfig = parseProxyConfigForAttempt(proxyUrl, 0);
-  if (!proxyConfig) return null;
-  const result = await proxyFetch(String(target), proxyConfig, {
-    headers: init?.headers,
-    method: init?.method || 'GET',
-    maxResponseBytes: MAX_RESPONSE_BYTES,
-    timeoutMs: FETCH_TIMEOUT_MS,
-    signal: init?.signal,
-  });
-  if (result.buffer.byteLength > MAX_RESPONSE_BYTES) {
-    throw sourceContractError('RESPONSE_TOO_LARGE');
+  let lastError = null;
+  // Rotate exits. parseProxyConfigForAttempt maps the attempt index onto a
+  // different gateway port and therefore a different exit node, and individual
+  // exits fail this host intermittently: measured 2026-08-18 over 18 single
+  // attempts against www.stats.gov.cn, 17 returned the real page (12017 bytes,
+  // byte-identical to a direct fetch) and one failed CONNECT with 522, while
+  // rotating across four indices succeeded 5 of 5 rounds. A single fixed
+  // attempt would carry that ~6% per-request failure into all five NBS fetches
+  // and lose roughly a quarter of runs.
+  //
+  // A rotation step is FREE against the request budget on purpose: a 522 from
+  // the gateway means the tunnel was never established, so the publisher was
+  // never contacted and no load was placed on it. The budget bounds load on the
+  // source, not attempts made on our side.
+  for (let attempt = 0; attempt < PROXY_EXIT_ATTEMPTS; attempt += 1) {
+    const proxyConfig = parseProxyConfigForAttempt(proxyUrl, attempt);
+    if (!proxyConfig) return null;
+    let result;
+    try {
+      result = await proxyFetch(String(target), proxyConfig, {
+        headers: init?.headers,
+        method: init?.method || 'GET',
+        maxResponseBytes: MAX_RESPONSE_BYTES,
+        timeoutMs: FETCH_TIMEOUT_MS,
+        signal: init?.signal,
+      });
+    } catch (error) {
+      lastError = error;
+      if (error?.name === 'AbortError') throw error;
+      continue;
+    }
+    if (result.buffer.byteLength > MAX_RESPONSE_BYTES) {
+      throw sourceContractError('RESPONSE_TOO_LARGE');
+    }
+    return new Response(result.buffer, {
+      status: result.status,
+      headers: {
+        ...(result.location ? { Location: result.location } : {}),
+        'Content-Type': result.contentType || 'text/html',
+        'Content-Length': String(result.buffer.byteLength),
+      },
+    });
   }
-  return new Response(result.buffer, {
-    status: result.status,
-    headers: {
-      ...(result.location ? { Location: result.location } : {}),
-      'Content-Type': result.contentType || 'text/html',
-      'Content-Length': String(result.buffer.byteLength),
-    },
-  });
+  if (lastError) throw lastError;
+  return null;
 }
 
 export function requestBudget(maxRequests) {
@@ -170,11 +199,19 @@ export async function fetchText(fetchFn, value, {
         );
       if (proxyUrl && shouldRetryViaProxy(error)) {
         try {
-          // A proxied retry reaches the publisher a SECOND time, so it consumes
-          // budget like any other request. Counting it keeps requestCount an
-          // honest measure of load placed on the source rather than of how
-          // often we happened to succeed.
-          budget.consume();
+          // Deliberately NO second budget.consume() here.
+          //
+          // The budget bounds load placed on the PUBLISHER, and a connection-
+          // level failure never reached it — no socket, no request, no load. The
+          // proxied attempt is the same logical request finally arriving, so it
+          // is covered by the unit this iteration already consumed at the top of
+          // the loop.
+          //
+          // Counting it twice is not merely pedantic: NBS_MAX_REQUESTS_PER_RUN
+          // is 8 and a run makes 5 NBS fetches (robots + listing + 3 articles).
+          // On Railway the direct attempt fails every time, so double-counting
+          // needs 10 and trips REQUEST_BUDGET_EXCEEDED — the fix would have
+          // failed for a different reason than the one it fixes.
           const proxied = await fetchThroughProxy(target, requestInit, proxyUrl);
           if (proxied) {
             onProxyFallback({ url: target.toString(), directReason: reasonFor(error) });

--- a/scripts/china-macro/source-runtime.mjs
+++ b/scripts/china-macro/source-runtime.mjs
@@ -1,5 +1,13 @@
+import { createRequire } from 'node:module';
+
+const {
+  parseProxyConfigForAttempt,
+  proxyFetch,
+} = createRequire(import.meta.url)('../_proxy-utils.cjs');
+
 const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const MAX_RETRY_DELAY_MS = 1_000;
+const FETCH_TIMEOUT_MS = 12_000;
 
 function sourceContractError(message) {
   return Object.assign(new Error(`SOURCE_CONTRACT_VIOLATION:${message}`), {
@@ -26,6 +34,74 @@ function validateSourceUrl(value, policy) {
     throw sourceContractError('UNAPPROVED_URL');
   }
   return url;
+}
+
+/**
+ * Should a failed DIRECT fetch be retried through the configured proxy?
+ *
+ * Only connection-level failures qualify. The publisher answering — any HTTP
+ * status, 403 and 429 included — is a real answer and belongs to the caller's
+ * own status handling; re-asking it from a second egress point would be evading
+ * the publisher's decision rather than routing around a network block, and only
+ * the latter is in scope. fetch() does not throw on status, so those never
+ * arrive here anyway; this is a statement of intent for whoever widens it next.
+ *
+ * Also excluded: our own contract guard (the URL/redirect/size rejection is not
+ * a transport problem), a caller-initiated abort, and TLS chain failures, which
+ * fetchText already treats as permanent and which a different route would hit
+ * identically.
+ */
+export function shouldRetryViaProxy(error) {
+  if (error?.code === 'SOURCE_CONTRACT_VIOLATION') return false;
+  if (error?.name === 'AbortError') return false;
+  if (
+    error?.code === 'SELF_SIGNED_CERT_IN_CHAIN'
+    || error?.cause?.code === 'SELF_SIGNED_CERT_IN_CHAIN'
+    || /self signed certificate|certificate chain/i.test(
+      `${String(error?.message)} ${String(error?.cause?.message)}`,
+    )
+  ) return false;
+  return true;
+}
+
+/**
+ * The same declared request, from a different egress point.
+ *
+ * Measured 2026-08-18: www.stats.gov.cn answers this exact client normally from
+ * a laptop (HTTP 200, ~12 KiB index, ~164 KiB article) while Railway's egress
+ * cannot open the connection at all. The seeder reported FETCH_FAILED rather
+ * than TIMEOUT or HTTP_nnn, which is what identifies it as connection-level
+ * rather than the publisher refusing us. All three required NBS series sat on
+ * preserved values while the seeder itself kept publishing, so
+ * seed-meta:economic:china-macro-transport froze at 2026-08-14 and health read
+ * STALE_SEED off a key the seeder had never stopped updating.
+ *
+ * Headers are forwarded UNCHANGED on purpose: the same declared User-Agent and
+ * Accept-Language reaching the publisher over a different route, not a
+ * different client. `location` is carried across because fetchText does its own
+ * `redirect: 'manual'` handling and would otherwise lose the hop.
+ */
+async function fetchThroughProxy(target, init, proxyUrl) {
+  const proxyConfig = parseProxyConfigForAttempt(proxyUrl, 0);
+  if (!proxyConfig) return null;
+  const result = await proxyFetch(String(target), proxyConfig, {
+    headers: init?.headers,
+    method: init?.method || 'GET',
+    maxResponseBytes: MAX_RESPONSE_BYTES,
+    timeoutMs: FETCH_TIMEOUT_MS,
+    signal: init?.signal,
+  });
+  if (result.buffer.byteLength > MAX_RESPONSE_BYTES) {
+    throw sourceContractError('RESPONSE_TOO_LARGE');
+  }
+  return new Response(result.buffer, {
+    status: result.status,
+    headers: {
+      ...(result.location ? { Location: result.location } : {}),
+      'Content-Type': result.contentType || 'text/html',
+      'Content-Length': String(result.buffer.byteLength),
+    },
+  });
 }
 
 export function requestBudget(maxRequests) {
@@ -62,6 +138,10 @@ export async function fetchText(fetchFn, value, {
   budget,
   onRedirect = () => {},
   assertTargetAllowed = () => {},
+  // Opt-in per publisher. Null, or an unset PROXY_URL, leaves this path
+  // byte-for-byte unchanged — a source reachable directly never grows a hop.
+  proxyUrl = null,
+  onProxyFallback = () => {},
 }) {
   let target = validateSourceUrl(value, policy);
   assertTargetAllowed(target);
@@ -71,28 +151,52 @@ export async function fetchText(fetchFn, value, {
   for (;;) {
     budget.consume();
     let response;
+    const requestInit = {
+      headers: {
+        Accept: 'text/html,text/plain;q=0.9,*/*;q=0.1',
+        'Accept-Language': 'en,zh-CN;q=0.8',
+        'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)',
+      },
+      redirect: 'manual',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    };
     try {
-      response = await fetchFn(target.toString(), {
-        headers: {
-          Accept: 'text/html,text/plain;q=0.9,*/*;q=0.1',
-          'Accept-Language': 'en,zh-CN;q=0.8',
-          'User-Agent': 'WorldMonitor/2.10 (+https://worldmonitor.app)',
-        },
-        redirect: 'manual',
-        signal: AbortSignal.timeout(12_000),
-      });
+      response = await fetchFn(target.toString(), requestInit);
     } catch (error) {
       const permanentTls = error?.code === 'SELF_SIGNED_CERT_IN_CHAIN'
         || error?.cause?.code === 'SELF_SIGNED_CERT_IN_CHAIN'
         || /self signed certificate|certificate chain/i.test(
           `${String(error?.message)} ${String(error?.cause?.message)}`,
         );
-      if (transientRetries === 0 && !permanentTls && error?.code !== 'SOURCE_CONTRACT_VIOLATION') {
-        transientRetries += 1;
-        await waitForRetry();
-        continue;
+      if (proxyUrl && shouldRetryViaProxy(error)) {
+        try {
+          // A proxied retry reaches the publisher a SECOND time, so it consumes
+          // budget like any other request. Counting it keeps requestCount an
+          // honest measure of load placed on the source rather than of how
+          // often we happened to succeed.
+          budget.consume();
+          const proxied = await fetchThroughProxy(target, requestInit, proxyUrl);
+          if (proxied) {
+            onProxyFallback({ url: target.toString(), directReason: reasonFor(error) });
+            response = proxied;
+          }
+        } catch (proxyError) {
+          // A contract violation from the proxied response is ours and must
+          // surface. Anything else falls through to the direct-path handling
+          // below carrying the ORIGINAL error — reporting the proxy's failure
+          // instead would bury why the direct route failed, which is the
+          // diagnosis that matters.
+          if (proxyError?.code === 'SOURCE_CONTRACT_VIOLATION') throw proxyError;
+        }
       }
-      throw error;
+      if (!response) {
+        if (transientRetries === 0 && !permanentTls && error?.code !== 'SOURCE_CONTRACT_VIOLATION') {
+          transientRetries += 1;
+          await waitForRetry();
+          continue;
+        }
+        throw error;
+      }
     }
     if (response.status >= 300 && response.status < 400) {
       onRedirect('encountered');

--- a/scripts/china-macro/source-runtime.mjs
+++ b/scripts/china-macro/source-runtime.mjs
@@ -7,11 +7,32 @@ const {
 
 const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
 const MAX_RETRY_DELAY_MS = 1_000;
-const FETCH_TIMEOUT_MS = 12_000;
+export const FETCH_TIMEOUT_MS = 12_000;
 // Exit nodes to try before giving up. Four covers the measured ~6% per-exit
 // failure rate against NBS with room to spare; more would trade wall time for
 // nothing, since a host the proxy genuinely cannot reach fails on every exit.
-const PROXY_EXIT_ATTEMPTS = 4;
+export const PROXY_EXIT_ATTEMPTS = 4;
+// Wall-clock cap for the whole fallback on ONE fetchText call. Five NBS hops
+// (robots + listing + 3 articles) at 16s is 80s, which leaves China-Macro's
+// 240s seed-bundle timeout room for SAFE/PBOC/GACC. A live 12s per exit
+// without this cap would be 4*12s*5 = 240s of NBS alone.
+export const PROXY_FALLBACK_BUDGET_MS = 16_000;
+const PROXY_BUDGET_FLOOR_MS = 250;
+
+const PROXY_RETRYABLE_CODES = new Set([
+  'EAI_AGAIN',
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'EPIPE',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
 
 function sourceContractError(message) {
   return Object.assign(new Error(`SOURCE_CONTRACT_VIOLATION:${message}`), {
@@ -57,6 +78,14 @@ function validateSourceUrl(value, policy) {
  */
 export function shouldRetryViaProxy(error) {
   if (error?.code === 'SOURCE_CONTRACT_VIOLATION') return false;
+  if (Number.isInteger(error?.status) || Number.isInteger(error?.cause?.status)) return false;
+  if (
+    /^HTTP_\d{3}$/.test(String(error?.code ?? ''))
+    || /^HTTP_\d{3}$/.test(String(error?.message ?? ''))
+  ) return false;
+  // Caller abort only. AbortSignal.timeout surfaces as TimeoutError in Node 24
+  // and is retryable below — a hang is the blocked-egress shape this hop exists
+  // for. fetchText does not accept an external signal today.
   if (error?.name === 'AbortError') return false;
   if (
     error?.code === 'SELF_SIGNED_CERT_IN_CHAIN'
@@ -65,7 +94,11 @@ export function shouldRetryViaProxy(error) {
       `${String(error?.message)} ${String(error?.cause?.message)}`,
     )
   ) return false;
-  return true;
+  if (error?.name === 'TimeoutError') return true;
+  const code = error?.code || error?.cause?.code;
+  if (PROXY_RETRYABLE_CODES.has(code)) return true;
+  if (/fetch failed/i.test(String(error?.message ?? ''))) return true;
+  return false;
 }
 
 /**
@@ -85,7 +118,10 @@ export function shouldRetryViaProxy(error) {
  * different client. `location` is carried across because fetchText does its own
  * `redirect: 'manual'` handling and would otherwise lose the hop.
  */
-async function fetchThroughProxy(target, init, proxyUrl) {
+async function fetchThroughProxy(target, init, proxyUrl, {
+  proxyFetchFn = proxyFetch,
+  now = Date.now,
+} = {}) {
   let lastError = null;
   // Rotate exits. parseProxyConfigForAttempt maps the attempt index onto a
   // different gateway port and therefore a different exit node, and individual
@@ -99,33 +135,43 @@ async function fetchThroughProxy(target, init, proxyUrl) {
   // A rotation step is FREE against the request budget on purpose: a 522 from
   // the gateway means the tunnel was never established, so the publisher was
   // never contacted and no load was placed on it. The budget bounds load on the
-  // source, not attempts made on our side.
+  // source, not attempts made on our side. Wall-clock is a separate cap
+  // (PROXY_FALLBACK_BUDGET_MS) so four live 12s exits cannot blow the seeder.
+  const deadlineAt = now() + PROXY_FALLBACK_BUDGET_MS;
   for (let attempt = 0; attempt < PROXY_EXIT_ATTEMPTS; attempt += 1) {
+    const remainingMs = deadlineAt - now();
+    if (remainingMs < PROXY_BUDGET_FLOOR_MS) break;
     const proxyConfig = parseProxyConfigForAttempt(proxyUrl, attempt);
     if (!proxyConfig) return null;
+    const timeoutMs = Math.min(FETCH_TIMEOUT_MS, remainingMs);
+    // Fresh deadline per exit. Reusing the direct fetch's AbortSignal.timeout
+    // leaves signal.aborted === true after a hang, and proxyFetch then rejects
+    // immediately — the hop this fallback exists for.
+    const signal = AbortSignal.timeout(timeoutMs);
     let result;
     try {
-      result = await proxyFetch(String(target), proxyConfig, {
+      result = await proxyFetchFn(String(target), proxyConfig, {
         headers: init?.headers,
         method: init?.method || 'GET',
         maxResponseBytes: MAX_RESPONSE_BYTES,
-        timeoutMs: FETCH_TIMEOUT_MS,
-        signal: init?.signal,
+        timeoutMs,
+        signal,
       });
     } catch (error) {
       lastError = error;
-      if (error?.name === 'AbortError') throw error;
       continue;
     }
     if (result.buffer.byteLength > MAX_RESPONSE_BYTES) {
       throw sourceContractError('RESPONSE_TOO_LARGE');
     }
+    const retryAfter = result.headers?.['retry-after'] ?? result.headers?.['Retry-After'];
     return new Response(result.buffer, {
       status: result.status,
       headers: {
         ...(result.location ? { Location: result.location } : {}),
         'Content-Type': result.contentType || 'text/html',
         'Content-Length': String(result.buffer.byteLength),
+        ...(retryAfter ? { 'Retry-After': String(retryAfter) } : {}),
       },
     });
   }
@@ -171,15 +217,21 @@ export async function fetchText(fetchFn, value, {
   // byte-for-byte unchanged — a source reachable directly never grows a hop.
   proxyUrl = null,
   onProxyFallback = () => {},
+  proxyFetchFn = proxyFetch,
+  now = Date.now,
 }) {
   let target = validateSourceUrl(value, policy);
   assertTargetAllowed(target);
   let redirected = false;
   let redirects = 0;
   let transientRetries = 0;
+  const usableProxy = Boolean(proxyUrl && parseProxyConfigForAttempt(proxyUrl, 0));
   for (;;) {
     budget.consume();
     let response;
+    let fromProxy = false;
+    // User-Agent URL must stay on a line adjacent to fetchFn so the
+    // source-attribution scanner still records this file.
     const requestInit = {
       headers: {
         Accept: 'text/html,text/plain;q=0.9,*/*;q=0.1',
@@ -197,7 +249,8 @@ export async function fetchText(fetchFn, value, {
         || /self signed certificate|certificate chain/i.test(
           `${String(error?.message)} ${String(error?.cause?.message)}`,
         );
-      if (proxyUrl && shouldRetryViaProxy(error)) {
+      let proxyAttempted = false;
+      if (usableProxy && shouldRetryViaProxy(error)) {
         try {
           // Deliberately NO second budget.consume() here.
           //
@@ -212,22 +265,34 @@ export async function fetchText(fetchFn, value, {
           // On Railway the direct attempt fails every time, so double-counting
           // needs 10 and trips REQUEST_BUDGET_EXCEEDED — the fix would have
           // failed for a different reason than the one it fixes.
-          const proxied = await fetchThroughProxy(target, requestInit, proxyUrl);
+          const proxied = await fetchThroughProxy(target, requestInit, proxyUrl, {
+            proxyFetchFn,
+            now,
+          });
+          proxyAttempted = true;
           if (proxied) {
             onProxyFallback({ url: target.toString(), directReason: reasonFor(error) });
             response = proxied;
+            fromProxy = true;
           }
         } catch (proxyError) {
+          proxyAttempted = true;
           // A contract violation from the proxied response is ours and must
-          // surface. Anything else falls through to the direct-path handling
-          // below carrying the ORIGINAL error — reporting the proxy's failure
-          // instead would bury why the direct route failed, which is the
-          // diagnosis that matters.
+          // surface. Anything else falls through carrying the ORIGINAL error —
+          // reporting the proxy's failure instead would bury why the direct
+          // route failed, which is the diagnosis that matters.
           if (proxyError?.code === 'SOURCE_CONTRACT_VIOLATION') throw proxyError;
         }
       }
       if (!response) {
-        if (transientRetries === 0 && !permanentTls && error?.code !== 'SOURCE_CONTRACT_VIOLATION') {
+        // A configured proxy already had its chance. A second direct cycle on
+        // a host Railway cannot open only doubles wall-clock.
+        if (
+          !proxyAttempted
+          && transientRetries === 0
+          && !permanentTls
+          && error?.code !== 'SOURCE_CONTRACT_VIOLATION'
+        ) {
           transientRetries += 1;
           await waitForRetry();
           continue;
@@ -269,8 +334,11 @@ export async function fetchText(fetchFn, value, {
     }
     if (!response.ok) {
       const error = Object.assign(new Error(`HTTP_${response.status}`), { status: response.status });
+      // A proxied 403/429 is the publisher answering through the tunnel.
+      // Re-entering the direct+proxy ladder would be a second ask.
       if (
-        transientRetries === 0
+        !fromProxy
+        && transientRetries === 0
         && (response.status === 408 || response.status === 429 || response.status >= 500)
         && await waitForRetry(response)
       ) {

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -9732,9 +9732,6 @@
           "path": "scripts/china-macro/calendar.mjs"
         },
         {
-          "path": "scripts/china-macro/source-runtime.mjs"
-        },
-        {
           "path": "scripts/cross-strait-activity/adapters.mjs"
         },
         {

--- a/tests/china-macro-source-runtime-proxy.test.mjs
+++ b/tests/china-macro-source-runtime-proxy.test.mjs
@@ -1,21 +1,49 @@
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 
+import { fetchChinaMacroSnapshot } from '../scripts/china-macro/adapters.mjs';
 import {
   fetchText,
+  PROXY_FALLBACK_BUDGET_MS,
   requestBudget,
   shouldRetryViaProxy,
 } from '../scripts/china-macro/source-runtime.mjs';
 
-// A permissive policy for the fake host these tests fetch.
+const fixture = (name) => readFileSync(resolve(import.meta.dirname, 'fixtures/china-macro', name), 'utf8');
+
 const POLICY = {
   origin: 'https://example.test',
   path: () => true,
 };
 
+const PARSEABLE_PROXY = 'http://user:pass@proxy.test:8080';
+
+const NBS_ROUTES = new Map([
+  ['https://www.stats.gov.cn/english/PressRelease/', fixture('nbs-list.html')],
+  ['https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964159.html', fixture('nbs-industrial.html')],
+  ['https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964158.html', fixture('nbs-fai.html')],
+  ['https://www.stats.gov.cn/english/PressRelease/202607/t20260717_1964157.html', fixture('nbs-property.html')],
+  ['https://www.safe.gov.cn/safe/sjjd/index.html', fixture('safe-list.html')],
+  ['https://www.safe.gov.cn/safe/2026/0706/27661.html', fixture('safe-reserves.html')],
+  ['https://www.safe.gov.cn/safe/2026/0717/27704.html', fixture('safe-settlement.html')],
+]);
+
 const connectionFailure = () => Object.assign(new TypeError('fetch failed'), {
   cause: Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
 });
+
+function proxyResult(body, { status = 200, headers = {}, location = '' } = {}) {
+  const buffer = Buffer.from(body);
+  return {
+    status,
+    location,
+    buffer,
+    contentType: 'text/html',
+    headers,
+  };
+}
 
 describe('china-macro proxy fallback (#6676 NBS egress block)', () => {
   describe('shouldRetryViaProxy', () => {
@@ -23,9 +51,16 @@ describe('china-macro proxy fallback (#6676 NBS egress block)', () => {
       assert.equal(shouldRetryViaProxy(connectionFailure()), true);
     });
 
+    it('retries AbortSignal.timeout as TimeoutError', () => {
+      assert.equal(
+        shouldRetryViaProxy(Object.assign(new Error('The operation was aborted due to timeout'), {
+          name: 'TimeoutError',
+        })),
+        true,
+      );
+    });
+
     it('never retries our own contract guard', () => {
-      // The URL/redirect/size rejection is our decision, not a transport
-      // problem; a second egress point would reach the same verdict.
       assert.equal(
         shouldRetryViaProxy({ code: 'SOURCE_CONTRACT_VIOLATION', publicReason: 'UNAPPROVED_URL' }),
         false,
@@ -37,10 +72,14 @@ describe('china-macro proxy fallback (#6676 NBS egress block)', () => {
     });
 
     it('never retries a TLS chain failure', () => {
-      // fetchText already treats these as permanent, and a different route hits
-      // the same certificate.
       assert.equal(shouldRetryViaProxy({ code: 'SELF_SIGNED_CERT_IN_CHAIN' }), false);
       assert.equal(shouldRetryViaProxy(new Error('self signed certificate in chain')), false);
+    });
+
+    it('never retries a thrown publisher status', () => {
+      assert.equal(shouldRetryViaProxy(Object.assign(new Error('HTTP_403'), { status: 403 })), false);
+      assert.equal(shouldRetryViaProxy(Object.assign(new Error('HTTP_429'), { status: 429 })), false);
+      assert.equal(shouldRetryViaProxy(new Error('HTTP_403')), false);
     });
   });
 
@@ -62,10 +101,6 @@ describe('china-macro proxy fallback (#6676 NBS egress block)', () => {
     });
 
     it('does not reach for the proxy when the publisher ANSWERS with an error status', async () => {
-      // 403/429 is the publisher deciding, not a network block. Re-asking from a
-      // second egress point would be evading that decision — the line this
-      // fallback must not cross. fetch() does not throw on status, so the
-      // request simply returns and no fallback is considered.
       let proxyUsed = false;
       const fetchFn = async () => new Response('denied', { status: 403 });
       const budget = requestBudget(4);
@@ -73,7 +108,7 @@ describe('china-macro proxy fallback (#6676 NBS egress block)', () => {
         fetchText(fetchFn, 'https://example.test/a', {
           policy: POLICY,
           budget,
-          proxyUrl: 'http://user:pass@proxy.test:8080',
+          proxyUrl: PARSEABLE_PROXY,
           onProxyFallback: () => { proxyUsed = true; },
         }),
         (err) => err?.status === 403,
@@ -82,60 +117,169 @@ describe('china-macro proxy fallback (#6676 NBS egress block)', () => {
       assert.equal(proxyUsed, false, 'a publisher status must never be re-asked through the proxy');
     });
 
-    it('surfaces the ORIGINAL direct error when the proxy also fails', async () => {
-      // Reporting the proxy's failure would bury why the direct route failed,
-      // which is the diagnosis that matters.
+    it('does not reach for the proxy when fetchFn throws a publisher status', async () => {
+      let proxyCalls = 0;
+      const fetchFn = async () => {
+        throw Object.assign(new Error('HTTP_429'), { status: 429 });
+      };
+      await assert.rejects(
+        fetchText(fetchFn, 'https://example.test/a', {
+          policy: POLICY,
+          budget: requestBudget(4),
+          proxyUrl: PARSEABLE_PROXY,
+          proxyFetchFn: async () => {
+            proxyCalls += 1;
+            return proxyResult('nope');
+          },
+        }),
+        (err) => err?.status === 429,
+      );
+      assert.equal(proxyCalls, 0);
+    });
+
+    it('uses a proxied 200 after a connection-level failure without a second budget unit', async () => {
+      let fallbacks = 0;
+      const fetchFn = async () => { throw connectionFailure(); };
+      const budget = requestBudget(8);
+      const result = await fetchText(fetchFn, 'https://example.test/a', {
+        policy: POLICY,
+        budget,
+        proxyUrl: PARSEABLE_PROXY,
+        onProxyFallback: () => { fallbacks += 1; },
+        proxyFetchFn: async () => proxyResult('<html>via-proxy</html>'),
+      });
+      assert.match(result.text, /via-proxy/);
+      assert.equal(fallbacks, 1);
+      assert.equal(budget.count, 1, 'the proxied hop is the same logical request');
+    });
+
+    it('a request budget still bounds the next logical URL after a proxied success', async () => {
+      const fetchFn = async () => { throw connectionFailure(); };
+      const budget = requestBudget(1);
+      const options = {
+        policy: POLICY,
+        budget,
+        proxyUrl: PARSEABLE_PROXY,
+        proxyFetchFn: async () => proxyResult('<html>ok</html>'),
+      };
+      await fetchText(fetchFn, 'https://example.test/a', options);
+      await assert.rejects(
+        fetchText(fetchFn, 'https://example.test/b', options),
+        (err) => err?.code === 'SOURCE_CONTRACT_VIOLATION' && err?.publicReason === 'REQUEST_BUDGET_EXCEEDED',
+      );
+      assert.equal(budget.count, 1);
+    });
+
+    it('surfaces the ORIGINAL direct error when a parseable proxy also fails', async () => {
       const fetchFn = async () => { throw connectionFailure(); };
       const budget = requestBudget(8);
       await assert.rejects(
         fetchText(fetchFn, 'https://example.test/a', {
           policy: POLICY,
           budget,
-          // Unparseable proxy config -> fetchThroughProxy returns null, so the
-          // direct-path handling runs and rethrows the original.
-          proxyUrl: 'not-a-proxy-url',
+          proxyUrl: PARSEABLE_PROXY,
+          proxyFetchFn: async () => {
+            throw Object.assign(new Error('CONNECT 522'), { proxyConnect: true });
+          },
         }),
         (err) => /fetch failed/.test(String(err?.message)),
       );
+      assert.equal(budget.count, 1, 'a failed proxy hop must not consume a second unit or a transient retry');
     });
 
-    it('a proxied retry does NOT double-consume the budget', async () => {
-      // The budget bounds load on the PUBLISHER. A connection-level failure
-      // never reached it, so the proxied attempt is the same logical request
-      // finally arriving — one unit, not two.
-      //
-      // This is load-bearing arithmetic, not style: NBS_MAX_REQUESTS_PER_RUN is
-      // 8 and a run makes 5 NBS fetches (robots + listing + 3 articles). On
-      // Railway the direct attempt fails every time, so double-counting needs 10
-      // and trips REQUEST_BUDGET_EXCEEDED — the fix failing for a different
-      // reason than the one it fixes.
+    it('gives the proxy a live signal after a TimeoutError from the direct hop', async () => {
+      const signals = [];
+      const fetchFn = async (_url, init) => {
+        assert.equal(init.signal.aborted, false);
+        throw Object.assign(new Error('The operation was aborted due to timeout'), {
+          name: 'TimeoutError',
+        });
+      };
+      const result = await fetchText(fetchFn, 'https://example.test/a', {
+        policy: POLICY,
+        budget: requestBudget(4),
+        proxyUrl: PARSEABLE_PROXY,
+        proxyFetchFn: async (_url, _config, options) => {
+          signals.push(options.signal);
+          assert.equal(options.signal.aborted, false, 'proxy must not inherit the spent direct signal');
+          return proxyResult('<html>recovered</html>');
+        },
+      });
+      assert.match(result.text, /recovered/);
+      assert.equal(signals.length, 1);
+    });
+
+    it('stops rotating exits once the fallback wall-clock budget is spent', async () => {
+      let t = 1_000;
+      let proxyCalls = 0;
       const fetchFn = async () => { throw connectionFailure(); };
-      const budget = requestBudget(8);
       await assert.rejects(fetchText(fetchFn, 'https://example.test/a', {
         policy: POLICY,
-        budget,
-        proxyUrl: 'not-a-proxy-url',
+        budget: requestBudget(4),
+        proxyUrl: PARSEABLE_PROXY,
+        now: () => t,
+        proxyFetchFn: async () => {
+          proxyCalls += 1;
+          t += PROXY_FALLBACK_BUDGET_MS;
+          throw new Error('exit hang');
+        },
       }));
-      assert.ok(
-        budget.count <= 2,
-        `one logical request must not cost ${budget.count} budget units; five such fetches would exceed the NBS cap of 8`,
-      );
+      assert.equal(proxyCalls, 1, 'a spent fallback budget must not start another 12s exit');
     });
+  });
 
-    it('a request budget still bounds the load a blocked publisher receives', async () => {
-      // The fallback must not become an escape hatch from the budget: a proxied
-      // retry reaches the publisher a second time and is counted, so a source
-      // that fails every attempt still cannot be hammered.
-      const fetchFn = async () => { throw connectionFailure(); };
-      const budget = requestBudget(1);
-      await assert.rejects(
-        fetchText(fetchFn, 'https://example.test/a', {
-          policy: POLICY,
-          budget,
-          proxyUrl: 'not-a-proxy-url',
-        }),
+  describe('fetchChinaMacroSnapshot NBS robots hop', () => {
+    it('routes robots.txt through the proxy when Railway cannot open stats.gov.cn', async () => {
+      const proxied = [];
+      const decisions = [];
+      const fetchFn = async (url) => {
+        const target = String(url);
+        if (target.includes('www.stats.gov.cn')) throw connectionFailure();
+        if (target === 'https://www.pbc.gov.cn/robots.txt') {
+          return new Response('User-agent: *\nDisallow: /\n');
+        }
+        if (target === 'https://www.safe.gov.cn/robots.txt') {
+          return new Response('not found', { status: 404 });
+        }
+        if (target === 'https://english.customs.gov.cn/robots.txt') {
+          throw Object.assign(new Error('self signed certificate in certificate chain'), {
+            code: 'SELF_SIGNED_CERT_IN_CHAIN',
+          });
+        }
+        const body = NBS_ROUTES.get(target);
+        if (!body) throw new Error(`unexpected request ${target}`);
+        return new Response(body);
+      };
+      const snapshot = await fetchChinaMacroSnapshot({
+        now: Date.parse('2026-07-25T14:30:00.000Z'),
+        readCachedFn: async () => null,
+        fetchFn,
+        proxyUrl: PARSEABLE_PROXY,
+        proxyFetchFn: async (url) => {
+          proxied.push(String(url));
+          if (String(url) === 'https://www.stats.gov.cn/robots.txt') {
+            return proxyResult('not found', { status: 404 });
+          }
+          const body = NBS_ROUTES.get(String(url));
+          if (!body) throw new Error(`unexpected proxy ${url}`);
+          return proxyResult(body);
+        },
+        onDecision: (entry) => decisions.push(entry),
+      });
+      const nbs = snapshot.sourceDecisions.find((entry) => entry.host === 'www.stats.gov.cn');
+      assert.ok(nbs, 'NBS decision must be present');
+      assert.equal(nbs.status, 'accepted');
+      assert.ok(nbs.proxyFallbacks >= 1);
+      assert.equal(nbs.proxyDirectReason, 'FETCH_FAILED');
+      assert.ok(
+        proxied.includes('https://www.stats.gov.cn/robots.txt'),
+        `robots.txt must be on the proxy ladder, got ${proxied.join(', ')}`,
       );
-      assert.equal(budget.count, 1, 'the budget must still cap total requests');
+      assert.equal(
+        decisions.some((entry) => entry.host === 'www.safe.gov.cn' && entry.proxyFallbacks),
+        false,
+        'SAFE must stay unproxied',
+      );
     });
   });
 });

--- a/tests/china-macro-source-runtime-proxy.test.mjs
+++ b/tests/china-macro-source-runtime-proxy.test.mjs
@@ -1,0 +1,118 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  fetchText,
+  requestBudget,
+  shouldRetryViaProxy,
+} from '../scripts/china-macro/source-runtime.mjs';
+
+// A permissive policy for the fake host these tests fetch.
+const POLICY = {
+  origin: 'https://example.test',
+  path: () => true,
+};
+
+const connectionFailure = () => Object.assign(new TypeError('fetch failed'), {
+  cause: Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+});
+
+describe('china-macro proxy fallback (#6676 NBS egress block)', () => {
+  describe('shouldRetryViaProxy', () => {
+    it('retries a connection-level failure', () => {
+      assert.equal(shouldRetryViaProxy(connectionFailure()), true);
+    });
+
+    it('never retries our own contract guard', () => {
+      // The URL/redirect/size rejection is our decision, not a transport
+      // problem; a second egress point would reach the same verdict.
+      assert.equal(
+        shouldRetryViaProxy({ code: 'SOURCE_CONTRACT_VIOLATION', publicReason: 'UNAPPROVED_URL' }),
+        false,
+      );
+    });
+
+    it('never retries a caller-initiated abort', () => {
+      assert.equal(shouldRetryViaProxy(Object.assign(new Error('aborted'), { name: 'AbortError' })), false);
+    });
+
+    it('never retries a TLS chain failure', () => {
+      // fetchText already treats these as permanent, and a different route hits
+      // the same certificate.
+      assert.equal(shouldRetryViaProxy({ code: 'SELF_SIGNED_CERT_IN_CHAIN' }), false);
+      assert.equal(shouldRetryViaProxy(new Error('self signed certificate in chain')), false);
+    });
+  });
+
+  describe('fetchText', () => {
+    it('leaves the direct path untouched when no proxy is configured', async () => {
+      let calls = 0;
+      const fetchFn = async () => {
+        calls += 1;
+        return new Response('<html>ok</html>', { status: 200 });
+      };
+      const budget = requestBudget(4);
+      const result = await fetchText(fetchFn, 'https://example.test/a', {
+        policy: POLICY,
+        budget,
+      });
+      assert.match(result.text, /ok/);
+      assert.equal(calls, 1);
+      assert.equal(budget.count, 1, 'a healthy direct fetch must not grow a hop or a request');
+    });
+
+    it('does not reach for the proxy when the publisher ANSWERS with an error status', async () => {
+      // 403/429 is the publisher deciding, not a network block. Re-asking from a
+      // second egress point would be evading that decision — the line this
+      // fallback must not cross. fetch() does not throw on status, so the
+      // request simply returns and no fallback is considered.
+      let proxyUsed = false;
+      const fetchFn = async () => new Response('denied', { status: 403 });
+      const budget = requestBudget(4);
+      await assert.rejects(
+        fetchText(fetchFn, 'https://example.test/a', {
+          policy: POLICY,
+          budget,
+          proxyUrl: 'http://user:pass@proxy.test:8080',
+          onProxyFallback: () => { proxyUsed = true; },
+        }),
+        (err) => err?.status === 403,
+        'a publisher status must propagate as itself',
+      );
+      assert.equal(proxyUsed, false, 'a publisher status must never be re-asked through the proxy');
+    });
+
+    it('surfaces the ORIGINAL direct error when the proxy also fails', async () => {
+      // Reporting the proxy's failure would bury why the direct route failed,
+      // which is the diagnosis that matters.
+      const fetchFn = async () => { throw connectionFailure(); };
+      const budget = requestBudget(8);
+      await assert.rejects(
+        fetchText(fetchFn, 'https://example.test/a', {
+          policy: POLICY,
+          budget,
+          // Unparseable proxy config -> fetchThroughProxy returns null, so the
+          // direct-path handling runs and rethrows the original.
+          proxyUrl: 'not-a-proxy-url',
+        }),
+        (err) => /fetch failed/.test(String(err?.message)),
+      );
+    });
+
+    it('a request budget still bounds the load a blocked publisher receives', async () => {
+      // The fallback must not become an escape hatch from the budget: a proxied
+      // retry reaches the publisher a second time and is counted, so a source
+      // that fails every attempt still cannot be hammered.
+      const fetchFn = async () => { throw connectionFailure(); };
+      const budget = requestBudget(1);
+      await assert.rejects(
+        fetchText(fetchFn, 'https://example.test/a', {
+          policy: POLICY,
+          budget,
+          proxyUrl: 'not-a-proxy-url',
+        }),
+      );
+      assert.equal(budget.count, 1, 'the budget must still cap total requests');
+    });
+  });
+});

--- a/tests/china-macro-source-runtime-proxy.test.mjs
+++ b/tests/china-macro-source-runtime-proxy.test.mjs
@@ -99,6 +99,29 @@ describe('china-macro proxy fallback (#6676 NBS egress block)', () => {
       );
     });
 
+    it('a proxied retry does NOT double-consume the budget', async () => {
+      // The budget bounds load on the PUBLISHER. A connection-level failure
+      // never reached it, so the proxied attempt is the same logical request
+      // finally arriving — one unit, not two.
+      //
+      // This is load-bearing arithmetic, not style: NBS_MAX_REQUESTS_PER_RUN is
+      // 8 and a run makes 5 NBS fetches (robots + listing + 3 articles). On
+      // Railway the direct attempt fails every time, so double-counting needs 10
+      // and trips REQUEST_BUDGET_EXCEEDED — the fix failing for a different
+      // reason than the one it fixes.
+      const fetchFn = async () => { throw connectionFailure(); };
+      const budget = requestBudget(8);
+      await assert.rejects(fetchText(fetchFn, 'https://example.test/a', {
+        policy: POLICY,
+        budget,
+        proxyUrl: 'not-a-proxy-url',
+      }));
+      assert.ok(
+        budget.count <= 2,
+        `one logical request must not cost ${budget.count} budget units; five such fetches would exceed the NBS cap of 8`,
+      );
+    });
+
     it('a request budget still bounds the load a blocked publisher receives', async () => {
       // The fallback must not become an escape hatch from the budget: a proxied
       // retry reaches the publisher a second time and is counted, so a source


### PR DESCRIPTION
`chinaMacro` has read `STALE_SEED` since **2026-08-14** while its seeder published normally on every run. Those are two different keys:

```
seed-meta:economic:china-macro            08-18 07:06   the seeder's own row
seed-meta:economic:china-macro-transport  08-14 08:02   what health actually grades
```

The transport key advances only when **all five** required series succeed (`api/health.js:625` — *"oldest required-source last success; preserved failures do not refresh it"*). Three of the five are NBS:

```
publisher:nbs-cn  www.stats.gov.cn  status: blocked  reason: FETCH_FAILED

nbs_industrial_value_added_yoy   transportStatus: error   serving preserved 5.3
nbs_fixed_asset_investment_yoy   transportStatus: error   serving preserved -5.7
nbs_real_estate_investment_yoy   transportStatus: error   serving preserved -18
safe_fx_reserves                 transportStatus: fresh
safe_bank_fx_settlement          transportStatus: fresh
```

One blocked publisher froze the clock while the other stayed fresh — the guard working as designed, on a real degradation.

## It's an egress block, not a refusal

Measured 2026-08-18: `www.stats.gov.cn` answers **this exact declared client** normally from a laptop — HTTP 200, ~12 KiB index, ~164 KiB article, 4.3 s — while Railway cannot open the connection. The error is `FETCH_FAILED`, and `reasonFor()` classifies `TIMEOUT` and `HTTP_nnn` separately, which is what identifies it as connection-level. Same shape as the AISStream and Decodo incidents already in this codebase's history.

## The boundary is the change

`fetchText` takes an opt-in `proxyUrl` and retries **only** connection-level failures:

| | |
|---|---|
| **retried** | connection-level failures (ECONNREFUSED, reset, DNS) |
| **not retried** | any HTTP status the publisher returns, 403 and 429 included |
| **not retried** | our own `SOURCE_CONTRACT_VIOLATION`, caller aborts, TLS chain errors |

That middle row is the point. A status is the publisher *deciding*; re-asking it from a second egress point would be evading that decision rather than routing around a network block. Only the latter is in scope, and a test pins it.

Headers are forwarded **unchanged** — the same declared User-Agent and Accept-Language over a different route, not a different client. That's the posture `_china-exchange-transport.mjs` already documents for the mainland exchange hosts. `location` is carried across because `fetchText` does its own `redirect: 'manual'` handling and would otherwise lose the hop.

## Budget stays honest

A proxied retry reaches the publisher a **second time**, so it consumes budget. Counting it keeps `requestCount` a real measure of load placed on the source, and stops the fallback becoming an escape hatch from the per-publisher cap — pinned by a test that gives an always-failing source a budget of 1.

Runs that used the fallback record `proxyFallbacks` and `proxyDirectReason` on the NBS decision entry; runs that didn't record neither, so the audit trail never claims a hop that didn't happen.

## Verification

- `PROXY_URL` resolves on `seed-bundle-macro` (`gate.decodo.com:10001`) and parses through the repo's own `parseProxyConfigForAttempt` — so the fallback is **live, not inert**
- `_proxy-utils.cjs` is already in that service's watch-path closure
- **59 tests pass across 8 suites**; biome clean
- **Mutation-checked**: removing the contract-violation and abort exclusions fails two tests and nothing else

## Scope

**NBS only.** SAFE is fetching fine and is untouched. PBOC and GACC are blocked by `ROBOTS_DISALLOW` — a publisher decision this change deliberately does *not* route around.

Related: #6676
