### PR TITLE
fix(portwatch): widen the CN/HK content budget to 10 days across all ten sites

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -812,7 +812,7 @@ const SEED_META = {
   // scripts/seed-portwatch-port-activity.mjs and CHINA_CORRIDOR_KEYS in
   // get-china-corridor-control-towers.ts, and it exists so a producer-side
   // change cannot narrow the alarm scope without health noticing.
-  portwatchPortActivity: { key: 'seed-meta:supply_chain:portwatch-ports',   maxStaleMin: 2160, minRecordCount: 174, requireContentFreshness: { countries: ['CN', 'HK'], budgetMinutes: 2 * 72 * 60 }, contentFreshnessActivation: 'portwatchContentFreshness' },
+  portwatchPortActivity: { key: 'seed-meta:supply_chain:portwatch-ports',   maxStaleMin: 2160, minRecordCount: 174, requireContentFreshness: { countries: ['CN', 'HK'], budgetMinutes: 10 * 24 * 60 }, contentFreshnessActivation: 'portwatchContentFreshness' },
   corridorrisk:        { key: 'seed-meta:supply_chain:corridorrisk',         maxStaleMin: 120 },
   chokepointTransits:  { key: 'seed-meta:supply_chain:chokepoint_transits',  maxStaleMin: 30 }, // relay every 10min; 30min = 3x interval,
   transitSummaries:    { key: 'seed-meta:supply_chain:transit-summaries',    maxStaleMin: 30 }, // relay every 10min; 30min = 3x interval,

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -2239,7 +2239,7 @@ export const CACHE_TOOLS: ToolDef[] = [
         key: 'seed-meta:supply_chain:portwatch-ports',
         maxStaleMin: 2160, // 12h cron; 36h = 3× interval
         minRecordCount: 174,
-        requireContentFreshness: { countries: ['CN', 'HK'], budgetMinutes: 2 * 72 * 60 },
+        requireContentFreshness: { countries: ['CN', 'HK'], budgetMinutes: 10 * 24 * 60 },
         contentFreshnessActivationKey: PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY,
       },
       { key: 'seed-meta:energy:chokepoint-baselines',      maxStaleMin: 60 * 24 * 400 },  // ~400d static registry

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -239,7 +239,7 @@ const SEED_DOMAINS = {
     key: 'seed-meta:supply_chain:portwatch-ports',
     intervalMin: 720,
     minRecordCount: 174,
-    requireContentFreshness: { countries: ['CN', 'HK'], budgetMinutes: 2 * 72 * 60 },
+    requireContentFreshness: { countries: ['CN', 'HK'], budgetMinutes: 10 * 24 * 60 },
     contentFreshnessActivationKey: PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY,
   }, // 12h cron (0 */12 * * *); intervalMin = maxStaleMin / 3 (2160 / 3); #3613 requires 174-country coverage before OK.
   'energy:chokepoint-flows': { key: 'seed-meta:energy:chokepoint-flows', intervalMin: 360 }, // 6h relay loop; intervalMin = maxStaleMin / 2 (720 / 2)

--- a/scripts/_portwatch-content-freshness.mjs
+++ b/scripts/_portwatch-content-freshness.mjs
@@ -3,11 +3,22 @@
 // ordering so those contracts can be tested without loading the full runner.
 
 export const PORTWATCH_CONTENT_FRESHNESS_CADENCE_MINUTES = 12 * 60;
-// One full cold-fetch rotation is six 12-hour runs (174 countries / 30 slots).
-// Keep two rotations of headroom so the health alarm measures a stalled source,
-// not the normal tail of the producer's bounded recovery queue. The parity test
-// derives the actual producer rotation and fails if either side drifts.
-export const PORTWATCH_CONTENT_FRESHNESS_BUDGET_MINUTES = 2 * 72 * 60;
+// One full cold-fetch rotation is six 12-hour runs (174 countries / 30 slots),
+// so two rotations -- the derived floor this budget must clear -- is 144h/6d.
+// The parity test recomputes that floor from the seeder's own constants and the
+// cron cadence, and fails if the budget drops under it.
+//
+// 10 days is an OPERATOR CHOICE above that floor (3.3 rotations), not a derived
+// value. It was raised from the bare 2-rotation 6d on 2026-08-18 while CN sat at
+// 6.9 days and 173 of 174 countries were fresh.
+//
+// The cost is stated plainly because the next person will need it: this clock is
+// contentAsOfChangedAt -- upstream's own max(date) advancing, never our
+// fetchedAt -- so it measures the SOURCE going quiet, not our fetch lagging. At
+// 10 days a genuinely stalled critical country stays invisible ~4 days longer
+// than the rotation math alone would allow. Lower it back toward the derived
+// floor if that detection delay ever costs more than the alarm did.
+export const PORTWATCH_CONTENT_FRESHNESS_BUDGET_MINUTES = 10 * 24 * 60;
 export const PORTWATCH_MAX_REPORTED_STALE_COUNTRIES = 40;
 export const PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY =
   'seed-activated:supply_chain:portwatch-ports:content-freshness';

--- a/server/worldmonitor/supply-chain/v1/china-corridor-source-adapters.ts
+++ b/server/worldmonitor/supply-chain/v1/china-corridor-source-adapters.ts
@@ -248,7 +248,7 @@ function adaptPortwatch(
         retrievalTime,
         retrievalTimePrecision: retrievalTime ? 'instant' : 'unknown',
         transportFreshness: transport,
-        contentFreshness: contentFreshness(observedAt, 2 * 72 * 60, assessedAt),
+        contentFreshness: contentFreshness(observedAt, 10 * 24 * 60, assessedAt),
         summary: `PortWatch activity observation available for ${portName}.`,
         metrics: metrics([
           ['tankerCalls30d', numberValue(port.tankerCalls30d)],

--- a/shared/china-activity-nowcast-registry.ts
+++ b/shared/china-activity-nowcast-registry.ts
@@ -107,7 +107,7 @@ export const CHINA_ACTIVITY_PROXY_REGISTRY: readonly Readonly<ChinaActivityProxy
         interpolate: false,
         description: 'Use the latest reviewed aggregate inside the window and expose missing nodes separately.',
       },
-      freshnessBudgetMinutes: 2 * 72 * 60,
+      freshnessBudgetMinutes: 10 * 24 * 60,
       source: {
         publisherId: 'publisher:imf-portwatch',
         publisherName: 'IMF PortWatch',

--- a/tests/china-corridor-source-adapters.test.mts
+++ b/tests/china-corridor-source-adapters.test.mts
@@ -1,10 +1,18 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
+import { PORTWATCH_CONTENT_FRESHNESS_BUDGET_MINUTES } from '../scripts/_portwatch-content-freshness.mjs';
 import { buildChinaCorridorSourceBundle } from '../server/worldmonitor/supply-chain/v1/china-corridor-source-adapters.ts';
 
 const ASSESSED_AT = '2026-07-25T12:00:00.000Z';
 const FRESH_META = { fetchedAt: Date.parse('2026-07-25T11:30:00.000Z') };
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const BUDGET_MS = PORTWATCH_CONTENT_FRESHNESS_BUDGET_MINUTES * MINUTE_MS;
+const assessedAtMs = Date.parse(ASSESSED_AT);
+const justInsideBudgetIso = new Date(assessedAtMs - BUDGET_MS + 1).toISOString();
+const justPastBudgetIso = new Date(assessedAtMs - BUDGET_MS - 1).toISOString();
+const frozenPastBudgetIso = new Date(assessedAtMs - BUDGET_MS - 36 * HOUR_MS).toISOString();
 
 describe('China corridor source adapters (#5578)', () => {
   it('preserves missing PortWatch metrics instead of manufacturing zero values', () => {
@@ -27,15 +35,16 @@ describe('China corridor source adapters (#5578)', () => {
   // resets `fetchedAt` while returning an unchanged upstream `asof`. Ageing
   // `fetchedAt` admits a frozen observation for one budget window out of every
   // cache lifetime — the same conflation this issue exists to end, one layer
-  // below the health alarm.
+  // below the health alarm. Offsets are budget-relative so a later budget move
+  // cannot turn this frozen clock into a fresh observation.
   it('reads the content clock, so a refetch of frozen upstream data stays stale', () => {
     const bundle = buildChinaCorridorSourceBundle({
       portwatchChina: {
         // Retrieved seconds ago ...
         fetchedAt: '2026-07-25T11:59:00.000Z',
-        // ... but upstream has not advanced in 168h, past the 144h budget.
+        // ... but upstream has not advanced past the content budget.
         asof: '2026-07-17',
-        contentAsOfChangedAt: Date.parse('2026-07-18T12:00:00.000Z'),
+        contentAsOfChangedAt: Date.parse(frozenPastBudgetIso),
         ports: [{ portId: 'port1188', portName: 'Shanghai', trendDelta: 2 }],
       },
       portwatchMeta: FRESH_META,
@@ -47,10 +56,10 @@ describe('China corridor source adapters (#5578)', () => {
       'stale',
       'a fresh retrieval of frozen upstream content is not current',
     );
-    assert.equal(signal?.observationTime, '2026-07-18T12:00:00.000Z');
+    assert.equal(signal?.observationTime, frozenPastBudgetIso);
   });
 
-  it('keeps the 144-hour boundary consistent for corridor consumers', () => {
+  it('keeps the content-budget boundary consistent for corridor consumers', () => {
     const buildPortSignal = (contentAsOfChangedAt: string) => buildChinaCorridorSourceBundle({
       portwatchChina: {
         fetchedAt: '2026-07-25T11:59:00.000Z',
@@ -60,12 +69,21 @@ describe('China corridor source adapters (#5578)', () => {
       portwatchMeta: FRESH_META,
     }, ASSESSED_AT).families.port.signals[0];
 
+    // The previous 144h pair is now well inside the 10-day operator budget.
     assert.equal(
       buildPortSignal('2026-07-19T12:00:00.001Z')?.contentFreshness,
       'current',
     );
     assert.equal(
       buildPortSignal('2026-07-19T11:59:59.999Z')?.contentFreshness,
+      'current',
+    );
+    assert.equal(
+      buildPortSignal(justInsideBudgetIso)?.contentFreshness,
+      'current',
+    );
+    assert.equal(
+      buildPortSignal(justPastBudgetIso)?.contentFreshness,
       'stale',
     );
   });

--- a/tests/health-content-freshness.test.mjs
+++ b/tests/health-content-freshness.test.mjs
@@ -26,7 +26,7 @@ const {
 
 const NOW = Date.parse('2026-08-03T14:42:58.000Z');
 const MINUTE_MS = 60_000;
-const PORTWATCH_CONTENT_BUDGET_MINUTES = 2 * 72 * 60;
+const PORTWATCH_CONTENT_BUDGET_MINUTES = 10 * 24 * 60;
 const PORTWATCH_META_KEY = 'seed-meta:supply_chain:portwatch-ports';
 const PORTWATCH_DATA_KEY = 'supply_chain:portwatch-ports:v1:_countries';
 const PORTWATCH_ACTIVATION_KEY = ACTIVATION_MARKERS.portwatchContentFreshness;
@@ -180,9 +180,13 @@ describe('portwatchPortActivity classification', () => {
   // count alone lets OK persist while the observation ages past budget — the
   // exact green-while-dead failure this alarm exists to prevent.
   it('re-ages the producer measurement instead of trusting a frozen count', () => {
-    // Seeder measured CN just inside the 144h budget. Health reads that same
-    // meta after the observation crosses the pinned boundary at 145h.
-    const observedAt = NOW - 145 * 60 * MINUTE_MS;
+    // Seeder measured CN just inside the budget. Health reads that same meta
+    // after the observation crosses the pinned boundary.
+    //
+    // Derived from PORTWATCH_CONTENT_BUDGET_MINUTES, never hardcoded hours: the
+    // fixture means "one hour PAST the boundary", and a literal 145h silently
+    // became "well inside it" the moment the budget moved 144h -> 240h.
+    const observedAt = NOW - (PORTWATCH_CONTENT_BUDGET_MINUTES + 60) * MINUTE_MS;
     const entry = classifyPortwatch({
       fetchedAt: NOW - 12 * 60 * MINUTE_MS,
       recordCount: 174,
@@ -191,7 +195,8 @@ describe('portwatchPortActivity classification', () => {
         criticalStaleCountries: [],
         criticalOldestObservedAt: observedAt,
         criticalOldestObservedCountry: 'CN',
-        criticalOldestAgeMinutes: 143 * 60,
+        // The producer's own frozen number, one hour INSIDE the boundary.
+        criticalOldestAgeMinutes: PORTWATCH_CONTENT_BUDGET_MINUTES - 60,
       }),
     });
 
@@ -202,7 +207,7 @@ describe('portwatchPortActivity classification', () => {
     );
     assert.equal(
       entry.contentFreshness.criticalOldestAgeMinutes,
-      145 * 60,
+      PORTWATCH_CONTENT_BUDGET_MINUTES + 60,
       'the published age is recomputed against now, not echoed from the producer',
     );
   });
@@ -212,12 +217,12 @@ describe('portwatchPortActivity classification', () => {
       fetchedAt: NOW - 12 * 60 * MINUTE_MS,
       recordCount: 174,
       contentFreshness: contentFreshnessOf({
-        criticalOldestObservedAt: NOW - 143 * 60 * MINUTE_MS,
+        criticalOldestObservedAt: NOW - (PORTWATCH_CONTENT_BUDGET_MINUTES - 60) * MINUTE_MS,
         criticalOldestAgeMinutes: 142 * 60,
       }),
     });
     assert.equal(entry.status, 'OK');
-    assert.equal(entry.contentFreshness.criticalOldestAgeMinutes, 143 * 60);
+    assert.equal(entry.contentFreshness.criticalOldestAgeMinutes, PORTWATCH_CONTENT_BUDGET_MINUTES - 60);
   });
 
   it('uses the raw millisecond boundary when re-aging content', () => {
@@ -240,7 +245,7 @@ describe('portwatchPortActivity classification', () => {
     // certify a 180h-old observation as fresh.
     const entry = classifyPortwatch(completeRun(contentFreshnessOf({
       budgetMinutes: 30 * 24 * 60,
-      criticalOldestObservedAt: NOW - 180 * 60 * MINUTE_MS,
+      criticalOldestObservedAt: NOW - (PORTWATCH_CONTENT_BUDGET_MINUTES + 36 * 60) * MINUTE_MS,
       criticalOldestAgeMinutes: 180 * 60,
     })));
     assert.equal(entry.status, 'STALE_CONTENT');

--- a/tests/mcp-portwatch-content-freshness-parity.test.mjs
+++ b/tests/mcp-portwatch-content-freshness-parity.test.mjs
@@ -52,10 +52,13 @@ const PORTWATCH_DATA_KEY = 'supply_chain:portwatch-ports:v1:_countries';
 const PORTWATCH_SEED_DOMAIN = 'supply_chain:portwatch-ports';
 const ACTIVATION_KEY = PORTWATCH_CONTENT_FRESHNESS_ACTIVATION_KEY;
 
-// Synthetic regression shape from the #6060 audit: CN last observed more than
-// 170h before the health snapshot, therefore past the 144h content budget.
+// Synthetic regression shape from the #6060 audit: CN last observed well before
+// the health snapshot. Note this fixture now alarms via the COUNT path
+// (criticalFreshCount 1 of 2), not the age path — the content budget moved to
+// 240h on 2026-08-18 and this observation sits inside it. Both paths are real
+// triggers in api/_content-freshness.js; the count is the one under test here.
 const CN_OBSERVED_AT = Date.parse('2026-07-26T12:02:43.475Z');
-const PORTWATCH_CONTENT_BUDGET_MINUTES = 2 * 72 * 60;
+const PORTWATCH_CONTENT_BUDGET_MINUTES = 10 * 24 * 60;
 
 // Parameterised on the clock because the three surfaces do not share one:
 // classifyKey and evaluateFreshness take `now` as an argument, while the
@@ -222,9 +225,9 @@ describe('#6080 — MCP freshness envelope vs /api/health on PortWatch content',
     const meta = completeRun(contentFreshnessOf({
       criticalFreshCount: 2,
       criticalStaleCountries: [],
-      criticalOldestObservedAt: NOW - 145 * 60 * MINUTE_MS,
+      criticalOldestObservedAt: NOW - (PORTWATCH_CONTENT_BUDGET_MINUTES + 60) * MINUTE_MS,
       criticalOldestObservedCountry: 'CN',
-      criticalOldestAgeMinutes: 143 * 60, // the producer's own frozen number
+      criticalOldestAgeMinutes: PORTWATCH_CONTENT_BUDGET_MINUTES - 60, // the producer's own frozen number
     }));
 
     assert.equal(healthVerdict(meta).status, 'STALE_CONTENT');
@@ -546,7 +549,7 @@ describe('#6080 — executeTool reads the activation marker', () => {
 
   it('flags stale content end-to-end through the tool', async () => {
     const result = await runWithRedis(
-      baseKeys(liveMeta({ criticalAgeHours: 170 })),
+      baseKeys(liveMeta({ criticalAgeHours: PORTWATCH_CONTENT_BUDGET_MINUTES / 60 + 26 })),
       { markers: [ACTIVATION_KEY] },
     );
     assert.equal(result.stale, true);
@@ -596,7 +599,7 @@ describe('#6080 — executeTool reads the activation marker', () => {
 
   it('still flags stale content when the marker read fails', async () => {
     const result = await runWithRedis(
-      baseKeys(liveMeta({ criticalAgeHours: 170 })),
+      baseKeys(liveMeta({ criticalAgeHours: PORTWATCH_CONTENT_BUDGET_MINUTES / 60 + 26 })),
       { markers: [ACTIVATION_KEY], failActivationRead: true },
     );
 

--- a/tests/portwatch-content-freshness.test.mjs
+++ b/tests/portwatch-content-freshness.test.mjs
@@ -3,8 +3,8 @@
 //
 // Regression shape from #6060: a 12:03 UTC run reports status OK, 174
 // countries seeded, 174/174 coverage complete and zero refreshFailures, while
-// `supply_chain:portwatch-ports:v1:CN` carries content that is more than 170
-// hours old — outside the widened 144-hour budget. Fresh transport metadata
+// `supply_chain:portwatch-ports:v1:CN` carries content past the content budget
+// (240h since 2026-08-18; 144h before that). Fresh transport metadata
 // plus complete country cardinality must not hide stale decision-critical data.
 //
 // These tests pin the seed-meta half of the split: the run publishes an
@@ -33,6 +33,12 @@ const { ACTIVATION_MARKERS, SEED_META } = __testing__;
 
 const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
+// Fixture ages are expressed RELATIVE to the budget, never as literal hours.
+// They previously read 150h/170h/180h, which meant "past budget" only while the
+// budget happened to be 144h; raising it to 240h silently turned every one of
+// them into a fresh observation and the staleness assertions stopped testing
+// staleness at all.
+const BUDGET_H = PORTWATCH_CONTENT_FRESHNESS_BUDGET_MINUTES / 60;
 // Frozen to the audit hour in #6060 so ages are exact rather than clock-seeded.
 const NOW = Date.parse('2026-08-02T14:40:00.000Z');
 
@@ -60,8 +66,8 @@ function countryDataOf(entries) {
 }
 
 describe('buildContentFreshnessReport', () => {
-  it('matches the corridor adapter 144-hour content budget', () => {
-    assert.equal(PORTWATCH_CONTENT_FRESHNESS_BUDGET_MINUTES, 2 * 72 * 60);
+  it('matches the corridor adapter content budget', () => {
+    assert.equal(PORTWATCH_CONTENT_FRESHNESS_BUDGET_MINUTES, 10 * 24 * 60);
   });
 
   it('declares exactly the countries the China corridor adapter consumes', () => {
@@ -69,12 +75,17 @@ describe('buildContentFreshnessReport', () => {
   });
 
   it('reproduces the #6060 audit: complete cardinality with stale China content', () => {
-    // The exact shape of the production observation: CN is well beyond the
-    // two-rotation budget and HK remains fresh inside an otherwise complete
-    // 174-country run.
+    // The shape of the #6060 production observation: CN well beyond the budget,
+    // HK fresh, inside an otherwise complete 174-country run.
+    //
+    // Offsets are budget-relative. The original fixture used the literal
+    // observation dates (CN 170h, HK 62h), which encoded "stale" only while the
+    // budget was 144h — at 240h both became fresh and this stopped reproducing
+    // the audit it is named for.
+    const CN_OBSERVED_AT = NOW - (BUDGET_H + 26) * HOUR_MS;
     const entries = [
-      payload('CN', '2026-07-26T12:02:43.475Z'),
-      payload('HK', '2026-07-31T00:03:02.206Z'),
+      payload('CN', new Date(CN_OBSERVED_AT).toISOString()),
+      payload('HK', new Date(NOW - (BUDGET_H - 82) * HOUR_MS).toISOString()),
       ...Array.from({ length: 172 }, (_, index) =>
         payload(`X${index}`, new Date(NOW - HOUR_MS).toISOString())),
     ];
@@ -84,16 +95,16 @@ describe('buildContentFreshnessReport', () => {
     });
 
     assert.equal(report.coveredCount, 174, 'cardinality is still complete');
-    assert.equal(report.freshCount, 173, 'HK is 62h old — inside the 144h budget');
-    assert.equal(report.staleCount, 1, 'CN is 170h old — outside the 144h budget');
+    assert.equal(report.freshCount, 173, 'HK sits inside the budget');
+    assert.equal(report.staleCount, 1, 'CN sits past the budget');
     assert.equal(report.unknownCount, 0);
     assert.deepEqual(report.staleCountries, ['CN']);
     assert.equal(report.staleCountriesTruncated, 0);
-    assert.equal(report.oldestObservedAt, Date.parse('2026-07-26T12:02:43.475Z'));
+    assert.equal(report.oldestObservedAt, CN_OBSERVED_AT);
     assert.equal(report.oldestObservedCountry, 'CN');
     assert.equal(
       report.oldestAgeMinutes,
-      Math.round((NOW - Date.parse('2026-07-26T12:02:43.475Z')) / MINUTE_MS),
+      Math.round((NOW - CN_OBSERVED_AT) / MINUTE_MS),
     );
     assert.equal(report.budgetMinutes, PORTWATCH_CONTENT_FRESHNESS_BUDGET_MINUTES);
     assert.equal(report.assessedAt, NOW);
@@ -105,7 +116,7 @@ describe('buildContentFreshnessReport', () => {
     assert.equal(report.criticalOldestObservedCountry, 'CN');
     assert.equal(
       report.criticalOldestAgeMinutes,
-      Math.round((NOW - Date.parse('2026-07-26T12:02:43.475Z')) / MINUTE_MS),
+      Math.round((NOW - CN_OBSERVED_AT) / MINUTE_MS),
     );
   });
 
@@ -120,9 +131,10 @@ describe('buildContentFreshnessReport', () => {
       countryData: countryDataOf([
         payload('CN', new Date(NOW - HOUR_MS).toISOString()),
         payload('HK', new Date(NOW - HOUR_MS).toISOString()),
-        // Back of the rotation: refreshed 6-7 days ago, entirely normal.
-        payload('BR', new Date(NOW - 170 * HOUR_MS).toISOString()),
-        payload('ZA', new Date(NOW - 150 * HOUR_MS).toISOString()),
+        // Back of the rotation, past the content budget: visible as counts,
+        // but not decision-gating because neither is a critical country.
+        payload('BR', new Date(NOW - (BUDGET_H + 26) * HOUR_MS).toISOString()),
+        payload('ZA', new Date(NOW - (BUDGET_H + 6) * HOUR_MS).toISOString()),
       ]),
       now: NOW,
     });
@@ -211,7 +223,7 @@ describe('buildContentFreshnessReport', () => {
   });
 
   it('bounds the published stale-country list and reports what it dropped', () => {
-    const stale = new Date(NOW - 150 * HOUR_MS).toISOString();
+    const stale = new Date(NOW - (BUDGET_H + 6) * HOUR_MS).toISOString();
     const overflow = PORTWATCH_MAX_REPORTED_STALE_COUNTRIES + 7;
     const report = buildContentFreshnessReport({
       countryData: countryDataOf(
@@ -251,17 +263,19 @@ describe('buildContentFreshnessReport', () => {
 // The seeder reserves the first cold-fetch slots for CN/HK instead of letting
 // them follow the fleet rotation: MAX_COLD_FETCH_PER_RUN caps refreshes at 30
 // of 174 per run on a 12h cron, so a full sweep is ceil(174/30) = 6 runs = 72h,
-// one rotation inside the 144h content budget. CN and HK feed the China
+// comfortably inside the 240h content budget. CN and HK feed the China
 // corridor adapter and the activity-nowcast's maritime family, so they must be
 // refreshed every run they are due, not once per fleet sweep.
 // The alarm's clock must measure CONTENT, not retrieval. `fetchedAt` resets on
 // every successful fetch — including the forced refetch at MAX_CACHE_AGE_MS
 // (168h) that returns an UNCHANGED upstream `asof`. Ageing that would green the
-// alarm for 144h of every 168h during an indefinite upstream freeze, which is
-// the precise failure #6060 exists to end.
+// alarm for a full budget window out of every 168h cache lifetime during an
+// indefinite upstream freeze, which is the precise failure #6060 exists to end.
+// Since the budget moved to 240h that window now EXCEEDS the cache lifetime, so
+// ageing the retrieval clock would green the alarm permanently.
 describe('content clock survives a refetch that returns unchanged upstream data', () => {
   it('ages the upstream content date, not the retrieval timestamp', () => {
-    const frozenSince = NOW - 180 * HOUR_MS;
+    const frozenSince = NOW - (BUDGET_H + 36) * HOUR_MS;
     const report = buildContentFreshnessReport({
       countryData: countryDataOf([
         {
@@ -286,7 +300,7 @@ describe('content clock survives a refetch that returns unchanged upstream data'
     );
     assert.equal(report.criticalFreshCount, 1);
     assert.equal(report.criticalOldestObservedAt, frozenSince);
-    assert.equal(report.criticalOldestAgeMinutes, 180 * 60);
+    assert.equal(report.criticalOldestAgeMinutes, (BUDGET_H + 36) * 60);
   });
 
   it('counts content as fresh when the upstream date actually advanced', () => {
@@ -356,7 +370,7 @@ describe('content clock survives a refetch that returns unchanged upstream data'
     // Legacy payloads written before the content clock was introduced.
     const report = buildContentFreshnessReport({
       countryData: countryDataOf([
-        payload('CN', new Date(NOW - 150 * HOUR_MS).toISOString()),
+        payload('CN', new Date(NOW - (BUDGET_H + 6) * HOUR_MS).toISOString()),
         payload('HK', new Date(NOW - HOUR_MS).toISOString()),
       ]),
       now: NOW,
@@ -654,7 +668,7 @@ describe('buildPortActivityMetaPayload', () => {
   it('publishes content freshness alongside the transport/cardinality fields', () => {
     const meta = buildPortActivityMetaPayload({
       countryData: countryDataOf([
-        payload('CN', '2026-07-26T12:02:43.475Z'),
+        payload('CN', new Date(NOW - (BUDGET_H + 26) * HOUR_MS).toISOString()),
         ...Array.from({ length: 173 }, (_, index) =>
           payload(`X${index}`, new Date(NOW - HOUR_MS).toISOString())),
       ]),

--- a/tests/seed-health-portwatch-port-activity.test.mjs
+++ b/tests/seed-health-portwatch-port-activity.test.mjs
@@ -20,7 +20,7 @@ process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
 const { handleSeedHealth } = await import('../api/seed-health.js');
 
 const PORTWATCH_META_KEY = 'seed-meta:supply_chain:portwatch-ports';
-const PORTWATCH_CONTENT_BUDGET_MINUTES = 2 * 72 * 60;
+const PORTWATCH_CONTENT_BUDGET_MINUTES = 10 * 24 * 60;
 const TEST_NOW = Date.parse('2026-08-03T14:42:58.000Z');
 const DECISION_META_KEY = 'seed-meta:intelligence:china-decision-signals';
 const PREDICTION_META_KEY = 'seed-meta:prediction:markets';
@@ -208,7 +208,7 @@ test('seed-health flags stale decision-critical PortWatch content separately fro
       criticalFreshCount: 1,
       criticalStaleCountries: ['CN'],
       criticalMissingCountries: 0,
-      criticalOldestObservedAt: now - (145 * 60 * 60 * 1000),
+      criticalOldestObservedAt: now - ((PORTWATCH_CONTENT_BUDGET_MINUTES + 60) * 60 * 1000),
     },
   });
 


### PR DESCRIPTION
`portwatchPortActivity` reads `STALE_CONTENT` on a **single country**: 173 of 174 fresh, CN at 6.9 days against a 6-day budget, HK fine. Operator decision to widen to 10 days.

## The budget lives in ten places

Three of them were only found because the repo's own parity tests failed:

```
scripts/_portwatch-content-freshness.mjs        the producer constant
api/health.js                                   health's re-age check
api/seed-health.js                              ← found by a parity test
api/mcp/registry/cache-tools.ts                 ← found by a parity test
server/.../china-corridor-source-adapters.ts    ← found by a parity test
shared/china-activity-nowcast-registry.ts
+ four test files
```

Without those tests this would have shipped a three-way divergence: health saying 10 days while `seed-health`, MCP, and the corridor adapter still said 6.

## Changing `api/health.js` alone would have been a no-op

`contentStale` fires on `criticalFreshCount < criticalCountries.length` **before** any age comparison (`api/_content-freshness.js:204`), and that count is computed by the **producer** from its own constant. Both sides had to move — and the seeder must republish before the alarm actually clears.

## Recorded as a choice, not a derivation

The producer constant now says plainly that 10 days is an **operator choice above the derived floor**. The floor is two producer rotations — 174 countries ÷ 30 cold-fetch slots = 6 runs × 12 h = 72 h, so 144 h — and the parity test recomputes it from the seeder's constants and the cron.

The cost is written where the next reader needs it: this clock is `contentAsOfChangedAt`, upstream's own `max(date)`, **never our `fetchedAt`** — so it measures the *source* going quiet. At 10 days a genuinely stalled critical country stays invisible ~4 days longer than the rotation math allows.

One side effect worth noting: 240 h now **exceeds** the 168 h `MAX_CACHE_AGE_MS` cache lifetime, which *strengthens* the #6060 rule against ageing the retrieval clock — doing so would now green the alarm permanently rather than for one window per cache lifetime. That comment is updated.

## The fixtures were quietly hollowed out

They encoded staleness as literal hours (`150h`, `170h`, `180h`, `criticalAgeHours: 170`) and absolute dates (`2026-07-26`). Those meant "past budget" only while the budget was 144 h — at 240 h **every one became a fresh observation**, so assertions named *"flags stale content"* passed without testing staleness at all.

They now read `BUDGET_H + 26`, `PORTWATCH_CONTENT_BUDGET_MINUTES - 60`, and so on, so the next budget change can't hollow them out the same way.

## Validation

**178 tests pass across 18 suites.** Biome clean, inventory-facts check clean. No runtime behaviour beyond the threshold itself — the alarm clears once the seeder republishes with the new producer constant.

Related: #6060, #6080
