### PR TITLE
test(convex): prevent company monitoring timeout flakes

### DIFF
--- a/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
+++ b/convex/__tests__/companyMonitoringOnboardingReplay.test.ts
@@ -270,7 +270,7 @@ describe("bounded onboarding and replay", () => {
       obligations: (await ctx.db.query("companyMonitoringScanObligations").collect()).length,
       work: (await ctx.db.query("companyMonitoringScanWorkItems").collect()).length,
     }))).toEqual({ obligations: 200, work: 8 });
-  });
+  }, 15_000);
 
   test("an import retry heals rows committed before scan scheduling without duplicates", async () => {
     const t = convexTest(schema, modules);
@@ -309,7 +309,7 @@ describe("bounded onboarding and replay", () => {
       obligations: (await ctx.db.query("companyMonitoringScanObligations").collect()).length,
       work: (await ctx.db.query("companyMonitoringScanWorkItems").collect()).length,
     }))).toEqual(healed);
-  });
+  }, 15_000);
 
   test("committed direct and import rows replay, changed tuples conflict, and no-ops reevaluate", async () => {
     const t = convexTest(schema, modules);


### PR DESCRIPTION
## Summary

Company Monitoring's Convex suite no longer reports fixture-heavy onboarding tests as 5-second failures when suite contention pushes otherwise passing work past Vitest's default. The two remaining affected tests use the established 15-second local bound, while the global 5-second signal and the 93/100-row boundary fixtures stay unchanged.

## Validation

- Before the change, `npx vitest run convex/__tests__` reproduced the 100-row import timeout at 9.214 seconds: 1,261 passed and 1 failed.
- The two relevant files pass 46/46 in isolation.
- Three consecutive full Convex-suite runs pass 1,262/1,262. One earlier post-change pass failed only in the separate `poolSelection.test.ts` 1,000-email timeout; the next three runs were fully green.
- Biome passes on the changed file, and the pre-push Convex type check passes.

Fixes #6911.

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because this change only adjusts per-test timeout metadata. On the exact PR head, the PR author will watch the `convex-tests` job through its terminal state; healthy means the full suite is green, while any 15-second timeout or logic assertion failure is a stop signal for performance or correctness investigation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
