### PR TITLE
fix(seed): repoint defense-patents seeder from PatentsView to USPTO ODP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,15 @@ OPENAQ_API_KEY=
 WAQI_API_KEY=
 
 
+# ------ Defense Patents (Railway seed) ------
+
+# USPTO Open Data Portal (required for scripts/seed-defense-patents.mjs).
+# Register at: https://data.uspto.gov/apis — free, sent as the X-API-KEY header.
+# The seeder also accepts USPTO_ODP_API_KEY_2 / _1 as fallbacks, in that order.
+# NOTE: this seeder used to call PatentsView, which now rejects keyless
+# requests with 403; PatentsView keys are issued by hand and we hold none.
+USPTO_ODP_API_KEY=
+
 # ------ Aviation Intelligence (Vercel) ------
 
 # AviationStack (live flight data, airport flights, carrier ops)

--- a/scripts/seed-defense-patents.mjs
+++ b/scripts/seed-defense-patents.mjs
@@ -1,6 +1,17 @@
 #!/usr/bin/env node
-// Seed USPTO PatentsView defense/dual-use patent filings (issue #2047).
-// Weekly cron — top 20 recent filings per strategic CPC category.
+// Seed USPTO defense/dual-use granted patents (issue #2047).
+// Weekly cron — most recent grants per strategic CPC category.
+//
+// Source: USPTO Open Data Portal (ODP), api.uspto.gov.
+//
+// Previously this seeder called PatentsView (search.patentsview.org/api/v1)
+// with no credentials. That API has required an `X-Api-Key` header since the
+// legacy api.patentsview.org shutdown, so every request returned 403, and each
+// category failure was only console.warn'd — the panel silently served
+// increasingly stale cache behind the 21-day TTL. No PatentsView key is
+// provisioned in this environment (theirs is issued by hand via a service
+// desk), so the seeder now uses USPTO's own ODP API, whose key we already
+// hold. ODP application metadata carries no abstract; the panel renders none.
 
 import { loadEnvFile, CHROME_UA, runSeed, sleep } from './_seed-utils.mjs';
 
@@ -8,11 +19,15 @@ loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'patents:defense:latest';
 const CACHE_TTL = 1_814_400; // 21 days (3× weekly interval)
-const PATENTSVIEW_API = 'https://search.patentsview.org/api/v1/patent/';
+const ODP_SEARCH_API = 'https://api.uspto.gov/api/v1/patent/applications/search';
 const INTER_CATEGORY_DELAY_MS = 3_000;
 const MAX_PER_CATEGORY = 20;
+const GRANT_WINDOW_MONTHS = 24;
+const RETRIES_PER_CATEGORY = 1;
 
-// Key defense/dual-use assignees
+// Key defense/dual-use assignees. ODP indexes the applicant of record, so
+// these match `applicationMetaData.firstApplicantName` — "Raytheon Company"
+// and "RAYTHEON BBN TECHNOLOGIES CORP." both match "Raytheon".
 const DEFENSE_ASSIGNEES = [
   'Raytheon', 'Lockheed', 'Northrop', 'Huawei', 'SMIC', 'TSMC', 'DARPA',
   'Boeing', 'L3Harris', 'General Dynamics', 'BAE Systems', 'Thales',
@@ -27,58 +42,122 @@ const CPC_CATEGORIES = [
   { code: 'C12N', desc: 'Microorganisms / Biotechnology' },
 ];
 
-function buildQuery(cpcCode) {
-  return JSON.stringify({
-    _and: [
-      { _begins: { 'cpc_at_issue.cpc_subclass_id': cpcCode } },
-      {
-        _or: DEFENSE_ASSIGNEES.map((a) => ({ _text_phrase: { 'assignees.assignee_organization': a } })),
-      },
-    ],
-  });
+const FIELDS = [
+  'applicationNumberText',
+  'applicationMetaData.inventionTitle',
+  'applicationMetaData.grantDate',
+  'applicationMetaData.patentNumber',
+  'applicationMetaData.firstApplicantName',
+  'applicationMetaData.cpcClassificationBag',
+];
+
+/** Auth failures are not retryable and must not read as a quiet week. */
+class OdpAuthError extends Error {}
+
+/**
+ * Resolve the ODP API key.
+ *
+ * The vault holds two entries: `USPTO_ODP_API_KEY_1` is a truncated copy of
+ * `USPTO_ODP_API_KEY_2` (a bad vault write dropped its first character), so
+ * `_2` is preferred and `_1` is only a last resort. `USPTO_ODP_API_KEY` is
+ * the plain name a deployment may inject directly.
+ */
+function odpApiKey() {
+  const key = process.env.USPTO_ODP_API_KEY
+    || process.env.USPTO_ODP_API_KEY_2
+    || process.env.USPTO_ODP_API_KEY_1;
+  if (!key) {
+    throw new OdpAuthError(
+      'No USPTO ODP API key: set USPTO_ODP_API_KEY (or USPTO_ODP_API_KEY_2). '
+      + 'Free keys: https://data.uspto.gov/apis',
+    );
+  }
+  return key;
 }
 
-async function fetchCategoryPatents(category) {
-  const url = new URL(PATENTSVIEW_API);
-  url.searchParams.set('q', buildQuery(category.code));
-  url.searchParams.set('f', JSON.stringify(['patent_id', 'patent_title', 'patent_date', 'patent_abstract', 'assignees.assignee_organization', 'cpc_at_issue.cpc_subclass_id']));
-  url.searchParams.set('o', JSON.stringify({ size: MAX_PER_CATEGORY }));
-  url.searchParams.set('s', JSON.stringify([{ patent_date: 'desc' }]));
+function grantWindowStart() {
+  const d = new Date();
+  d.setMonth(d.getMonth() - GRANT_WINDOW_MONTHS);
+  return d.toISOString().slice(0, 10);
+}
 
-  const resp = await fetch(url.toString(), {
-    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-    signal: AbortSignal.timeout(20_000),
+function buildQuery(cpcCode) {
+  const assignees = DEFENSE_ASSIGNEES.map((a) => `"${a}"`).join(' OR ');
+  return [
+    `applicationMetaData.cpcClassificationBag:${cpcCode}*`,
+    `applicationMetaData.firstApplicantName:(${assignees})`,
+    `applicationMetaData.grantDate:[${grantWindowStart()} TO 9999-12-31]`,
+  ].join(' AND ');
+}
+
+async function fetchCategoryPatents(category, apiKey) {
+  const resp = await fetch(ODP_SEARCH_API, {
+    method: 'POST',
+    headers: {
+      'X-API-KEY': apiKey,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      'User-Agent': CHROME_UA,
+    },
+    body: JSON.stringify({
+      q: buildQuery(category.code),
+      fields: FIELDS,
+      sort: [{ field: 'applicationMetaData.grantDate', order: 'desc' }],
+      pagination: { offset: 0, limit: MAX_PER_CATEGORY },
+    }),
+    signal: AbortSignal.timeout(30_000),
   });
 
+  if (resp.status === 401 || resp.status === 403) {
+    throw new OdpAuthError(`HTTP ${resp.status} — ODP key rejected`);
+  }
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   const data = await resp.json();
 
-  return (data.patents ?? []).map((p) => ({
-    patentId: String(p.patent_id ?? ''),
-    title: String(p.patent_title ?? '').slice(0, 300),
-    date: String(p.patent_date ?? ''),
-    assignee: String(p.assignees?.[0]?.assignee_organization ?? '').slice(0, 200),
-    cpcCode: category.code,
-    cpcDesc: category.desc,
-    abstract: String(p.patent_abstract ?? '').slice(0, 500),
-    url: p.patent_id ? `https://patents.google.com/patent/US${p.patent_id}` : '',
-  })).filter((p) => p.patentId && p.date);
+  return (data.patentFileWrapperDataBag ?? []).map((wrapper) => {
+    const meta = wrapper.applicationMetaData ?? {};
+    const patentId = String(meta.patentNumber ?? '');
+    return {
+      patentId,
+      title: String(meta.inventionTitle ?? '').slice(0, 300),
+      date: String(meta.grantDate ?? ''),
+      assignee: String(meta.firstApplicantName ?? '').slice(0, 200),
+      cpcCode: category.code,
+      cpcDesc: category.desc,
+      abstract: '', // not exposed by ODP application metadata
+      url: patentId ? `https://patents.google.com/patent/US${patentId}` : '',
+    };
+  }).filter((p) => p.patentId && p.date);
 }
 
 async function fetchAllPatents() {
+  const apiKey = odpApiKey(); // throws before any request when unset
   const all = [];
+  const failedCategories = [];
 
   for (let i = 0; i < CPC_CATEGORIES.length; i++) {
     const category = CPC_CATEGORIES[i];
     if (i > 0) await sleep(INTER_CATEGORY_DELAY_MS);
     console.log(`  Fetching ${category.code} (${category.desc})...`);
 
-    try {
-      const patents = await fetchCategoryPatents(category);
-      console.log(`    ${patents.length} patents`);
-      all.push(...patents);
-    } catch (err) {
-      console.warn(`    ${category.code}: failed (${err.message})`);
+    for (let attempt = 0; attempt <= RETRIES_PER_CATEGORY; attempt++) {
+      try {
+        const patents = await fetchCategoryPatents(category, apiKey);
+        console.log(`    ${patents.length} patents`);
+        all.push(...patents);
+        break;
+      } catch (err) {
+        // A rejected key fails every category identically — stop now rather
+        // than burn the retry budget and report it as five separate blips.
+        if (err instanceof OdpAuthError) throw err;
+        if (attempt < RETRIES_PER_CATEGORY) {
+          console.warn(`    ${category.code}: ${err.message} — retrying`);
+          await sleep(INTER_CATEGORY_DELAY_MS);
+          continue;
+        }
+        console.warn(`    ${category.code}: failed (${err.message})`);
+        failedCategories.push(category.code);
+      }
     }
   }
 
@@ -90,11 +169,24 @@ async function fetchAllPatents() {
     return true;
   }).sort((a, b) => b.date.localeCompare(a.date));
 
-  return { patents: deduped, total: deduped.length, fetchedAt: new Date().toISOString() };
+  return {
+    patents: deduped,
+    total: deduped.length,
+    failedCategories,
+    fetchedAt: new Date().toISOString(),
+  };
 }
 
+// A partial sweep is a failure, not a thin week: writing it would overwrite a
+// complete cache with one missing whole CPC categories, and the 21-day TTL
+// would hide that for three cron cycles. Fail loud, keep the last good set.
 function validate(data) {
-  return Array.isArray(data?.patents) && data.patents.length > 0;
+  if (!Array.isArray(data?.patents) || data.patents.length === 0) return false;
+  if (data.failedCategories?.length) {
+    console.error(`  categories failed: ${data.failedCategories.join(', ')}`);
+    return false;
+  }
+  return true;
 }
 
 export function declareRecords(data) {
@@ -104,7 +196,7 @@ export function declareRecords(data) {
 runSeed('military', 'defense-patents', CANONICAL_KEY, fetchAllPatents, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
-  sourceVersion: 'patentsview-v1',
+  sourceVersion: 'uspto-odp-v1',
   recordCount: (d) => d?.patents?.length ?? 0,
   declareRecords,
   schemaVersion: 1,


### PR DESCRIPTION
## Problem

`scripts/seed-defense-patents.mjs` called `https://search.patentsview.org/api/v1/patent/` with no credentials.

That API has required an `X-Api-Key` header since the legacy `api.patentsview.org` shutdown, so every request returned **403**. The failure was invisible: each category error was only `console.warn`'d, and `validate()` only rejected when *all five* categories failed. The Defense Patents panel therefore served cache up to **21 days** old (the TTL) without anything going red.

## Fix

Repointed the seeder at USPTO's own Open Data Portal — `POST https://api.uspto.gov/api/v1/patent/applications/search`, `X-API-KEY` header. Per-CPC query: `cpcClassificationBag:<code>*` AND applicant of record in the defense list AND a 24-month `grantDate` window, sorted grant-date descending, 20 per class.

ODP was chosen over simply adding a PatentsView key because PatentsView keys are issued by hand through their service desk; the USPTO ODP key is free and self-serve.

## Failure paths made loud

Silence was the actual defect, so:

- A missing key throws **before** any HTTP call.
- `401`/`403` aborts the whole run rather than reporting five separate blips.
- One retry per category absorbs transients.
- `validate()` now rejects a **partial** sweep. Writing one would overwrite a complete cache with one missing whole CPC classes, and the 21-day TTL would hide that for three cron cycles. Failing keeps the last good set.

## Verification

Ran live against ODP: **82 grants across all five CPC categories**, `validate=true`.

```
H04B: 20   F42B: 20   G06N: 20   H01L: 19   C12N: 3
```

Missing-key path throws before any request. `biome lint` clean.

## Deployment note

Deployments must set `USPTO_ODP_API_KEY` (or `USPTO_ODP_API_KEY_2` / `_1`, tried in that order) or the seeder exits 1 by design. Documented in `.env.example`.

## Behavior deltas

- `abstract` is now empty — ODP application metadata exposes no abstract field. `DefensePatentsPanel` never rendered it.
- `assignee` is now the applicant of record (`firstApplicantName`), e.g. `"RAYTHEON BBN TECHNOLOGIES CORP."`.
- The ~20 locale strings reading "Source: USPTO PatentsView" are left untouched in this PR; happy to sweep them in a follow-up.
