### PR TITLE
docs: point the release-packaging cross-reference at its current filename

### DIFF
--- a/docs/TAURI_VALIDATION_REPORT.md
+++ b/docs/TAURI_VALIDATION_REPORT.md
@@ -66,4 +66,4 @@ If preflight fails, use one of these approved remediations:
 - Pre-vendor Rust crates (`src-tauri/vendor/`) and run Cargo in offline mode.
 - Use CI runners that restore package/cache artifacts from a trusted internal store before builds.
 
-For release packaging details, see `docs/RELEASE_PACKAGING.md` (section: **Network preflight and remediation**).
+For release packaging details, see `docs/release-packaging.mdx` (section: **Network preflight and remediation**).


### PR DESCRIPTION
`docs/TAURI_VALIDATION_REPORT.md` line 69 sends the reader somewhere that no longer exists:

> For release packaging details, see `docs/RELEASE_PACKAGING.md` (section: **Network preflight and remediation**).

That file became `docs/release-packaging.mdx` in `caa3e9f82` (*"fix(docs): rename doc files to lowercase for Mintlify"*, 2026-03-12).

**Only the filename moved.** `## Network preflight and remediation` is still there, at line 36 of the renamed file, so the section the sentence points at is still the right place to land. One line.

Checked in both directions before sending: `docs/RELEASE_PACKAGING.md` is absent from `git ls-tree -r HEAD`, `docs/release-packaging.mdx` is present, and the reverse link is fine - `docs/release-packaging.mdx:53` and `docs/zh/release-packaging.mdx:47` both point at `docs/TAURI_VALIDATION_REPORT.md`, which does exist.

The other stale uppercase reference in the tree is `docs/PRESS_KIT.md`, cited three times in `docs/audits/documentation-code-alignment-final-audit-2026-06-08.md`. Left alone deliberately: that is a dated audit describing what was true when it was written, and correcting it would be rewriting a record rather than fixing a pointer.

Found by [docproof](https://github.com/marketplace/actions/docproof-documentation-check), which checks whether the paths a document names still exist in the tree. I read every one of its findings on this repository by hand before sending anything, and this is the only one I am proposing a change for - most of the rest are in `docs/Docs_To_Review/`, whose own README says the files there are not the source of truth, and two others are sentences that already tell the reader the file was deleted.
