### PR TITLE
fix(procurement): harden WebMCP request lifecycle

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -426,6 +426,7 @@ export class DataLoaderManager implements AppModule {
   private readonly marketLoadGuard = new LatestRequestGuard();
   private globalTenderGeneration = 0;
   private globalTenderFilters: GlobalTenderFilters = {};
+  private activeGlobalTenderScopedGeneration: number | null = null;
   private dailyBriefFrameworkUnsubscribe: (() => void) | null = null;
   private marketImplicationsFrameworkUnsubscribe: (() => void) | null = null;
   private cachedSatRecs: SatRecEntry[] | null = null;
@@ -553,6 +554,8 @@ export class DataLoaderManager implements AppModule {
   }
 
   destroy(): void {
+    this.globalTenderGeneration += 1;
+    this.activeGlobalTenderScopedGeneration = null;
     this.stopSatellitePropagation();
     if (this.imageryRetryTimer) { clearTimeout(this.imageryRetryTimer); this.imageryRetryTimer = null; }
     this.applyTimeRangeFilterToNewsPanelsDebounced.cancel();
@@ -3739,42 +3742,86 @@ export class DataLoaderManager implements AppModule {
     }
   }
 
-  async loadGlobalTenders(filters?: GlobalTenderFilters, append = false): Promise<void> {
+  async loadGlobalTenders(filters?: GlobalTenderFilters, append = false, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) return;
     const procurementPanel = this.ctx.panels['global-procurement'] as GlobalProcurementPanel | undefined;
     if (!procurementPanel) return;
+    if (
+      filters === undefined
+      && signal === undefined
+      && this.activeGlobalTenderScopedGeneration !== null
+    ) return;
     const requestGeneration = ++this.globalTenderGeneration;
+    this.activeGlobalTenderScopedGeneration = signal ? requestGeneration : null;
+    const previousGlobalTenderFilters = { ...this.globalTenderFilters };
     const requestFilters = filters ?? this.globalTenderFilters;
     this.globalTenderFilters = { ...requestFilters, cursor: '' };
-    procurementPanel.setRequestHandler((nextFilters, shouldAppend) => {
-      void this.loadGlobalTenders(nextFilters, shouldAppend);
-    });
-    if (!hasPremiumAccess()) {
-      procurementPanel?.clear();
-      return;
-    }
-    procurementPanel.setLoading(true, append);
+    let canceledFiltersRestored = false;
+    const releaseScopedRequest = () => {
+      if (this.activeGlobalTenderScopedGeneration === requestGeneration) {
+        this.activeGlobalTenderScopedGeneration = null;
+      }
+    };
+    const restoreCanceledFilters = () => {
+      if (
+        canceledFiltersRestored
+        || signal?.aborted !== true
+        || requestGeneration !== this.globalTenderGeneration
+      ) return;
+      canceledFiltersRestored = true;
+      this.globalTenderFilters = previousGlobalTenderFilters;
+    };
+    signal?.addEventListener('abort', () => {
+      restoreCanceledFilters();
+      releaseScopedRequest();
+    }, { once: true });
+    const isCanceledOrStale = () => {
+      restoreCanceledFilters();
+      return signal?.aborted === true || requestGeneration !== this.globalTenderGeneration;
+    };
     try {
-      const { fetchGlobalTenders } = await import('@/services/global-tenders');
-      const data = await fetchGlobalTenders(requestFilters);
-      if (requestGeneration !== this.globalTenderGeneration) return;
+      procurementPanel.setRequestHandler((nextFilters, shouldAppend, requestSignal) => {
+        return this.loadGlobalTenders(nextFilters, shouldAppend, requestSignal);
+      });
       if (!hasPremiumAccess()) {
+        if (isCanceledOrStale()) return;
         procurementPanel.clear();
         return;
       }
-      procurementPanel.update(data, append);
-      this.ctx.statusPanel?.updateApi('Global Procurement', {
-        status: !data.dataAvailable ? 'error' : ['partial', 'stale'].includes(data.availability) ? 'warning' : 'ok',
-      });
-    } catch (error) {
-      if (requestGeneration !== this.globalTenderGeneration || !hasPremiumAccess()) return;
-      console.warn('[App] Global tenders failed:', error);
-      procurementPanel.showUnavailable();
-      this.ctx.statusPanel?.updateApi('Global Procurement', { status: 'error' });
+      if (isCanceledOrStale()) return;
+      procurementPanel.setLoading(true, append);
+      try {
+        const { fetchGlobalTenders } = await import('@/services/global-tenders');
+        if (isCanceledOrStale()) return;
+        const data = await fetchGlobalTenders(requestFilters, signal);
+        if (isCanceledOrStale()) return;
+        if (!hasPremiumAccess()) {
+          if (isCanceledOrStale()) return;
+          procurementPanel.clear();
+          return;
+        }
+        if (isCanceledOrStale()) return;
+        procurementPanel.update(data, append);
+        if (isCanceledOrStale()) return;
+        this.ctx.statusPanel?.updateApi('Global Procurement', {
+          status: !data.dataAvailable ? 'error' : ['partial', 'stale'].includes(data.availability) ? 'warning' : 'ok',
+        });
+      } catch (error) {
+        if (isCanceledOrStale() || !hasPremiumAccess()) return;
+        console.warn('[App] Global tenders failed:', error);
+        if (isCanceledOrStale()) return;
+        procurementPanel.showUnavailable();
+        if (isCanceledOrStale()) return;
+        this.ctx.statusPanel?.updateApi('Global Procurement', { status: 'error' });
+      }
+    } finally {
+      releaseScopedRequest();
     }
   }
 
   async clearGlobalTenders(): Promise<void> {
     this.globalTenderGeneration += 1;
+    this.activeGlobalTenderScopedGeneration = null;
     this.globalTenderFilters = {};
     const procurementPanel = this.ctx.panels['global-procurement'] as GlobalProcurementPanel | undefined;
     procurementPanel?.clear();

--- a/src/components/GlobalProcurementPanel.ts
+++ b/src/components/GlobalProcurementPanel.ts
@@ -1,9 +1,66 @@
 import { Panel } from './Panel';
 import type { GlobalTender, ListGlobalTendersResponse } from '@/generated/client/worldmonitor/economic/v1/service_client';
 import type { GlobalTenderFilters } from '@/services/global-tenders';
-import { escapeHtml, sanitizeUrl, unsafeRawHtml } from '@/utils/sanitize';
+import { PanelGateReason } from '@/services/panel-gating';
+import { isMobileDevice } from '@/utils';
+import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 
-type RequestHandler = (filters: GlobalTenderFilters, append: boolean) => void;
+type RequestHandler = (
+  filters: GlobalTenderFilters,
+  append: boolean,
+  signal: AbortSignal,
+) => void | Promise<void>;
+
+type DeclarativeSubmitEvent = SubmitEvent & {
+  readonly agentInvoked?: boolean;
+  respondWith?: (response: Promise<unknown>) => void;
+};
+
+type DeclarativeToolEvent = Event & {
+  readonly toolName?: string;
+};
+
+interface PendingAgentInvocation {
+  id: number;
+  form: HTMLFormElement;
+  previousFilters: GlobalTenderFilters;
+  promise: Promise<ProcurementSearchToolResult>;
+  resolve: (result: ProcurementSearchToolResult) => void;
+}
+
+export interface ProcurementSearchToolSuccess {
+  ok: true;
+  matchCount: number;
+  availability: string;
+  countryCoverage: 'observed' | 'unknown' | 'not_requested';
+  appliedFilters: string[];
+  appliedFiltersTruncated: boolean;
+  sourceStatusSummary: Array<{
+    source: string;
+    state: string;
+    recordCount: number;
+  }>;
+  sourceStatusesTruncated: boolean;
+}
+
+export interface ProcurementSearchToolFailure {
+  ok: false;
+  code: string;
+  message: string;
+  retryable: true;
+}
+
+export type ProcurementSearchToolResult = ProcurementSearchToolSuccess | ProcurementSearchToolFailure;
+
+class RetryableProcurementSearchError extends Error {
+  public readonly retryable = true;
+
+  constructor(public readonly code: string, message: string) {
+    super(message);
+    this.name = 'RetryableProcurementSearchError';
+  }
+}
 
 const DEFAULT_FILTERS: GlobalTenderFilters = {
   query: '',
@@ -19,6 +76,12 @@ const DEFAULT_FILTERS: GlobalTenderFilters = {
 // Any evidence-backed keyword match (automationFit level "low" scores 30), so
 // the toggle means "has technology-relevance evidence", nothing stronger.
 const TECH_RELEVANCE_MIN_SCORE = 30;
+const DECLARATIVE_TOOL_NAME = 'search_procurement';
+const DECLARATIVE_TOOL_DESCRIPTION = 'Search official global procurement opportunities using visible filters.';
+const MAX_AGENT_SOURCE_STATUSES = 8;
+const MAX_AGENT_APPLIED_FILTERS = 16;
+const MAX_AGENT_FILTER_NAME_LENGTH = 32;
+const MAX_AGENT_RESULT_JSON_LENGTH = 1_500;
 
 const SOURCES = [
   ['', 'All sources'],
@@ -52,6 +115,16 @@ export class GlobalProcurementPanel extends Panel {
   private filters: GlobalTenderFilters = { ...DEFAULT_FILTERS };
   private requestHandler: RequestHandler | null = null;
   private loading = false;
+  private pendingAgentInvocation: PendingAgentInvocation | null = null;
+  private settlingAgentForm: HTMLFormElement | null = null;
+  private nextAgentInvocationId = 0;
+  private agentToolActive = false;
+  private requestStarting = false;
+  private activeRequestController: AbortController | null = null;
+  private activeRequestPreviousFilters: GlobalTenderFilters | null = null;
+  private lifecycleEpoch = 0;
+  private contentRevision = 0;
+  private disposed = false;
 
   constructor() {
     super({
@@ -64,34 +137,177 @@ export class GlobalProcurementPanel extends Panel {
     });
     this.showLoading('Loading procurement opportunities…');
 
+    for (const eventName of ['pointerdown', 'mousedown', 'click', 'beforeinput', 'keydown']) {
+      this.content.addEventListener(eventName, (event) => this.guardPendingFormInteraction(event), { capture: true });
+    }
+    for (const eventName of ['input', 'change']) {
+      this.content.addEventListener(eventName, (event) => this.restorePendingFormValues(event), { capture: true });
+    }
+
     this.content.addEventListener('submit', (event) => {
       const form = (event.target as HTMLElement).closest<HTMLFormElement>('[data-procurement-filters]');
       if (!form) return;
       event.preventDefault();
+      const submitEvent = event as DeclarativeSubmitEvent;
+      if (submitEvent.agentInvoked !== true) {
+        // The exact declaring form must stay mounted while Chrome owns its
+        // respondWith() promise. Its controls intentionally remain part of the
+        // declarative schema, so ignore a keyboard-generated human submit
+        // instead of letting it replace the filters for the in-flight result.
+        if (this.loading || this.pendingAgentInvocation !== null || this.settlingAgentForm !== null) return;
+        const previousFilters = { ...this.filters };
+        this.filters = this.readFilters(form);
+        this.setAgentToolActive(false);
+        this.request({ ...this.filters, cursor: '' }, false, previousFilters);
+        return;
+      }
+
+      if (typeof submitEvent.respondWith !== 'function') return;
+      if (this.loading || this.pendingAgentInvocation !== null || this.settlingAgentForm !== null) {
+        this.respondWithRetryableFailure(submitEvent, new RetryableProcurementSearchError(
+          'request_in_progress',
+          'A procurement search is already in progress. Retry after the visible results finish updating.',
+        ));
+        return;
+      }
+      if (!this.canDeclareTool() || form.getAttribute('toolname') !== DECLARATIVE_TOOL_NAME) {
+        this.respondWithRetryableFailure(submitEvent, new RetryableProcurementSearchError(
+          'panel_unavailable',
+          'The procurement search form is not currently available. Retry after the panel is visible and its data is ready.',
+        ));
+        return;
+      }
+
+      const previousFilters = { ...this.filters };
       this.filters = this.readFilters(form);
-      this.request({ ...this.filters, cursor: '' }, false);
+      const pending = this.beginAgentInvocation(form, previousFilters);
+      try {
+        submitEvent.respondWith(pending.promise);
+      } catch {
+        this.filters = { ...pending.previousFilters };
+        this.failAgentInvocation(pending.id, new RetryableProcurementSearchError(
+          'response_channel_unavailable',
+          'The procurement search response channel was unavailable. Retry the search.',
+        ));
+        return;
+      }
+
+      this.setAgentToolActive(true);
+      if (!this.request({ ...this.filters, cursor: '' }, false, pending.previousFilters)) {
+        this.filters = { ...pending.previousFilters };
+        this.failAgentInvocation(pending.id, new RetryableProcurementSearchError(
+          'request_not_started',
+          'The procurement search could not start because the panel is not ready. Retry when the form is available.',
+        ));
+      }
     });
 
     this.content.addEventListener('click', (event) => {
       const target = event.target as HTMLElement;
       if (target.closest('[data-procurement-load-more]')) {
+        if (this.loading || this.pendingAgentInvocation !== null || this.settlingAgentForm !== null) return;
         const cursor = this.data?.nextCursor;
         if (cursor) this.request({ ...this.filters, cursor }, true);
         return;
       }
       if (target.closest('[data-procurement-reset]')) {
+        if (this.pendingAgentInvocation !== null) {
+          this.cancelAgentOperation();
+          return;
+        }
+        if (this.loading || this.settlingAgentForm !== null) return;
+        this.cancelAgentOperation();
+        const previousFilters = { ...this.filters };
         this.filters = { ...DEFAULT_FILTERS };
-        this.request({ ...this.filters }, false);
+        this.request({ ...this.filters }, false, previousFilters);
       }
     });
+
+    this.content.addEventListener('reset', (event) => {
+      const form = (event.target as HTMLElement).closest<HTMLFormElement>('[data-procurement-filters]');
+      if (!form) return;
+      this.cancelAgentOperation();
+    });
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('toolactivated', (event) => {
+        const toolEvent = event as DeclarativeToolEvent;
+        if (toolEvent.toolName !== DECLARATIVE_TOOL_NAME || !this.canDeclareTool()) return;
+        this.setAgentToolActive(true);
+      }, { signal: this.signal });
+      window.addEventListener('toolcancel', (event) => {
+        const toolEvent = event as DeclarativeToolEvent;
+        if (toolEvent.toolName !== DECLARATIVE_TOOL_NAME) return;
+        this.cancelAgentOperation();
+      }, { signal: this.signal });
+      window.addEventListener('resize', () => this.handlePanelVisibilityChange(), { signal: this.signal });
+    }
+
   }
 
   public setRequestHandler(handler: RequestHandler): void {
     this.requestHandler = handler;
+    if (this.pendingAgentInvocation !== null || this.settlingAgentForm !== null) {
+      // DataLoader re-enters loadGlobalTenders() for every form request and
+      // installs the same handler again. Re-registering while loading would
+      // remove the declaring attributes and cancel Chrome's active response.
+      this.syncAgentFormVisualState();
+      return;
+    }
+    this.syncDeclarativeToolState();
   }
 
   public setLoading(loading: boolean, append = false): void {
+    const contentRevision = ++this.contentRevision;
+    const supersededInvocation = loading && !this.requestStarting
+      ? this.pendingAgentInvocation
+      : null;
+    if (supersededInvocation) {
+      this.abortActiveRequest();
+      this.failAgentInvocation(supersededInvocation.id, new RetryableProcurementSearchError(
+        'superseded',
+        'The procurement search was superseded by a newer refresh. Retry the search.',
+      ));
+      this.loading = loading;
+      this.syncAgentFormVisualState();
+      this.deferAfterAgentSettlement(() => {
+        if (
+          this.pendingAgentInvocation !== null
+          || this.settlingAgentForm !== null
+          || this.disposed
+          || this.contentRevision !== contentRevision
+        ) return;
+        if (loading && !append && !this.data) {
+          this.showLoading('Loading procurement opportunities…');
+          return;
+        }
+        this.render();
+      });
+      return;
+    }
     this.loading = loading;
+    if (this.pendingAgentInvocation !== null || this.settlingAgentForm !== null) {
+      // Changing the declarative form or its registration while respondWith()
+      // is pending cancels the browser invocation. Keep that exact form node
+      // mounted and update only non-schema visual state until it settles.
+      this.syncAgentFormVisualState();
+      if (this.pendingAgentInvocation === null) {
+        this.deferAfterAgentSettlement(() => {
+          if (
+            this.settlingAgentForm !== null
+            || this.disposed
+            || this.contentRevision !== contentRevision
+          ) return;
+          if (loading && !append && !this.data) {
+            this.showLoading('Loading procurement opportunities…');
+            return;
+          }
+          this.render();
+        });
+      }
+      return;
+    }
+    this.syncDeclarativeToolState();
     if (loading && !append && !this.data) {
       this.showLoading('Loading procurement opportunities…');
       return;
@@ -100,6 +316,9 @@ export class GlobalProcurementPanel extends Panel {
   }
 
   public update(data: ListGlobalTendersResponse, append = false): void {
+    if (this.disposed) return;
+    const contentRevision = ++this.contentRevision;
+    this.activeRequestPreviousFilters = null;
     this.loading = false;
     if (append && this.data) {
       const tenders = new Map(this.data.tenders.map((tender) => [tender.id, tender]));
@@ -109,29 +328,230 @@ export class GlobalProcurementPanel extends Panel {
       this.data = data;
     }
     this.setCount(this.data.total);
+    const invocationId = this.pendingAgentInvocation?.id;
+    if (invocationId !== undefined) {
+      if (!this.renderAgentTerminalResult()) {
+        this.failAgentInvocation(invocationId, new RetryableProcurementSearchError(
+          'response_target_unavailable',
+          'The procurement results view was replaced before the search completed. Retry on the current panel.',
+        ));
+        return;
+      }
+      if (!data.dataAvailable) {
+        this.failAgentInvocation(invocationId, new RetryableProcurementSearchError(
+          'procurement_unavailable',
+          'Procurement sources are currently unavailable, so the search could not return a reliable result. Retry later.',
+        ));
+        return;
+      }
+      this.resolveAgentInvocation(invocationId, this.agentResult(data));
+      return;
+    }
+
+    if (this.settlingAgentForm !== null) {
+      this.deferAfterAgentSettlement(() => {
+        if (
+          this.settlingAgentForm !== null
+          || this.disposed
+          || this.contentRevision !== contentRevision
+        ) return;
+        this.render();
+      });
+      return;
+    }
+
+    this.syncDeclarativeToolState();
     this.render();
   }
 
   public showUnavailable(): void {
+    if (this.disposed) return;
+    const contentRevision = ++this.contentRevision;
+    this.activeRequestPreviousFilters = null;
     this.loading = false;
     this.data = null;
     this.setCount(0);
+    const invocationId = this.pendingAgentInvocation?.id;
+    if (invocationId !== undefined) {
+      this.renderAgentTerminalError('Procurement opportunities are currently unavailable.');
+      this.failAgentInvocation(invocationId, new RetryableProcurementSearchError(
+        'procurement_unavailable',
+        'Procurement sources are currently unavailable, so the search did not complete. Retry later.',
+      ));
+      this.deferAfterAgentSettlement(() => {
+        if (
+          this.disposed
+          || this.pendingAgentInvocation !== null
+          || this.settlingAgentForm !== null
+          || this.contentRevision !== contentRevision
+        ) return;
+        this.showError('Procurement opportunities are currently unavailable.', () => this.request({ ...this.filters }, false), 60);
+      });
+      return;
+    }
+    if (this.settlingAgentForm !== null) {
+      this.deferAfterAgentSettlement(() => {
+        if (
+          this.settlingAgentForm !== null
+          || this.disposed
+          || this.contentRevision !== contentRevision
+        ) return;
+        this.showError('Procurement opportunities are currently unavailable.', () => this.request({ ...this.filters }, false), 60);
+      });
+      return;
+    }
     this.showError('Procurement opportunities are currently unavailable.', () => this.request({ ...this.filters }, false), 60);
   }
 
   public clear(): void {
+    this.contentRevision += 1;
+    this.abortActiveRequest();
+    const pending = this.pendingAgentInvocation;
+    const preservesAgentForm = pending !== null || this.settlingAgentForm !== null;
+    if (pending) {
+      this.failAgentInvocation(pending.id, new RetryableProcurementSearchError(
+        'panel_unavailable',
+        'The procurement panel became unavailable before the search completed. Retry after access is restored.',
+      ));
+    }
     this.data = null;
     this.filters = { ...DEFAULT_FILTERS };
     this.loading = false;
     this.setCount(0);
+    if (preservesAgentForm) {
+      this.deferAfterAgentSettlement(() => {
+        if (
+          this.settlingAgentForm !== null
+          || this.disposed
+          || this.data !== null
+        ) return;
+        this.clearSensitiveContent();
+      });
+      return;
+    }
     this.clearSensitiveContent();
   }
 
-  private request(filters: GlobalTenderFilters, append: boolean): void {
-    if (!this.requestHandler || this.loading) return;
+  public override showGatedCta(reason: PanelGateReason, onAction: () => void): void {
+    const lifecycleEpoch = ++this.lifecycleEpoch;
+    const hadPendingInvocation = this.pendingAgentInvocation !== null || this.settlingAgentForm !== null;
+    this.cancelForUnavailablePanel();
+    if (hadPendingInvocation) {
+      this.deferAfterAgentSettlement(() => {
+        if (!this.disposed && this.lifecycleEpoch === lifecycleEpoch) super.showGatedCta(reason, onAction);
+      });
+      return;
+    }
+    super.showGatedCta(reason, onAction);
+  }
+
+  public override showLocked(features: string[] = []): void {
+    const lifecycleEpoch = ++this.lifecycleEpoch;
+    const hadPendingInvocation = this.pendingAgentInvocation !== null || this.settlingAgentForm !== null;
+    this.cancelForUnavailablePanel();
+    if (hadPendingInvocation) {
+      this.deferAfterAgentSettlement(() => {
+        if (!this.disposed && this.lifecycleEpoch === lifecycleEpoch) super.showLocked(features);
+      });
+      return;
+    }
+    super.showLocked(features);
+  }
+
+  public override unlockPanel(): void {
+    this.lifecycleEpoch += 1;
+    const wasLocked = this.isLocked;
+    super.unlockPanel();
+    if (wasLocked) this.syncDeclarativeToolState();
+  }
+
+  public override hide(): void {
+    const hadPendingInvocation = this.pendingAgentInvocation !== null || this.settlingAgentForm !== null;
+    super.hide();
+    this.cancelForUnavailablePanel();
+    if (!hadPendingInvocation && this.data && !this.isLocked) this.render();
+  }
+
+  public override show(): void {
+    super.show();
+    this.syncDeclarativeToolState();
+    if (this.data && !this.isLocked) this.render();
+  }
+
+  public override notifyConnected(): void {
+    super.notifyConnected();
+    this.syncDeclarativeToolState();
+    if (this.data && !this.isLocked) this.render();
+  }
+
+  public override destroy(): void {
+    if (this.disposed) return;
+    const hadPendingInvocation = this.pendingAgentInvocation !== null || this.settlingAgentForm !== null;
+    this.lifecycleEpoch += 1;
+    this.disposed = true;
+    this.cancelForUnavailablePanel();
+    if (hadPendingInvocation) {
+      this.deferAfterAgentSettlement(() => {
+        super.destroy();
+      });
+      return;
+    }
+    super.destroy();
+  }
+
+  private request(
+    filters: GlobalTenderFilters,
+    append: boolean,
+    previousFilters: GlobalTenderFilters = this.filters,
+  ): boolean {
+    if (
+      !this.requestHandler
+      || this.loading
+      || this.disposed
+      || this.isLocked
+      || !this.isPanelToolVisible()
+    ) return false;
+    this.abortActiveRequest();
+    const controller = new AbortController();
+    this.activeRequestController = controller;
+    this.activeRequestPreviousFilters = { ...previousFilters };
     this.filters = { ...filters, cursor: '' };
-    this.setLoading(true, append);
-    this.requestHandler(filters, append);
+    const invocationId = this.pendingAgentInvocation?.id ?? null;
+    let completion: void | Promise<void>;
+    this.requestStarting = true;
+    try {
+      this.setLoading(true, append);
+      completion = this.requestHandler(filters, append, controller.signal);
+    } catch {
+      controller.abort();
+      if (this.activeRequestController === controller) this.activeRequestController = null;
+      if (this.activeRequestPreviousFilters) this.filters = { ...this.activeRequestPreviousFilters };
+      this.activeRequestPreviousFilters = null;
+      this.loading = false;
+      if (invocationId === null) {
+        this.render();
+      } else {
+        this.syncAgentFormVisualState();
+      }
+      return false;
+    } finally {
+      this.requestStarting = false;
+    }
+    void Promise.resolve(completion).then(
+      () => {
+        const wasActiveRequest = this.activeRequestController === controller;
+        if (wasActiveRequest) this.activeRequestController = null;
+        this.handleRequestHandlerSettled(invocationId, controller.signal);
+        if (wasActiveRequest) this.activeRequestPreviousFilters = null;
+      },
+      () => {
+        const wasActiveRequest = this.activeRequestController === controller;
+        if (wasActiveRequest) this.activeRequestController = null;
+        if (!this.disposed && !controller.signal.aborted) this.showUnavailable();
+        if (wasActiveRequest) this.activeRequestPreviousFilters = null;
+      },
+    );
+    return true;
   }
 
   private readFilters(form: HTMLFormElement): GlobalTenderFilters {
@@ -149,13 +569,20 @@ export class GlobalProcurementPanel extends Panel {
   }
 
   private render(): void {
-    const data = this.data;
-    const controls = this.renderControls();
-    if (!data) {
-      this.setSafeContent(unsafeRawHtml(`${controls}<div class="economic-empty">No procurement snapshot is available yet.</div>`, 'global procurement controls'));
+    if (this.pendingAgentInvocation !== null || this.settlingAgentForm !== null) {
+      this.syncAgentFormVisualState();
       return;
     }
+    const controls = this.renderControls();
+    this.setTrustedContent(trustedHtml(`
+      ${controls}
+      <div data-procurement-results>${this.renderResultsMarkup()}</div>
+    `, 'escaped global procurement controls and results'));
+  }
 
+  private renderResultsMarkup(): string {
+    const data = this.data;
+    if (!data) return '<div class="economic-empty">No procurement snapshot is available yet.</div>';
     const sourceSummary = data.sourceStatuses.map((source) => {
       const lastSuccess = source.lastSuccessfulAt ? ` · last success ${new Date(source.lastSuccessfulAt).toLocaleString()}` : '';
       return `${source.source}: ${source.state} (${source.recordCount})${lastSuccess}`;
@@ -175,34 +602,402 @@ export class GlobalProcurementPanel extends Panel {
       ? `<button type="button" class="debt-load-more" data-procurement-load-more${this.loading ? ' disabled' : ''}>${this.loading ? 'Loading…' : 'Load more'} <span class="debt-load-more-count">(${Math.max(0, data.total - visible)} remaining)</span></button>`
       : '';
 
-    this.setSafeContent(unsafeRawHtml(`
-      ${controls}
+    return `
       ${availability}
       <div class="global-procurement-summary">Showing ${visible.toLocaleString()} of ${data.total.toLocaleString()} matching opportunities</div>
       ${cards ? `<div class="spending-list global-procurement-list">${cards}</div>` : ''}
       ${loadMore}
       <div class="economic-footer"><span class="economic-source">${escapeHtml(sourceSummary)}${data.fetchedAt ? ` · snapshot ${escapeHtml(new Date(data.fetchedAt).toLocaleString())}` : ''}</span></div>
-    `, 'global procurement results'));
+    `;
   }
 
   private renderControls(): string {
-    return `<form class="global-procurement-controls" data-procurement-filters>
-      <input class="global-procurement-input" name="query" data-procurement-query type="search" value="${escapeHtml(String(this.filters.query || ''))}" placeholder="Search title or description" aria-label="Search procurement opportunities">
-      <input class="global-procurement-input" name="buyer" type="search" value="${escapeHtml(String(this.filters.buyer || ''))}" placeholder="Buyer" aria-label="Filter by buyer">
-      <input class="global-procurement-input global-procurement-country" name="country" data-procurement-country type="text" maxlength="2" value="${escapeHtml(String(this.filters.country || ''))}" placeholder="Country" aria-label="Filter by ISO country code">
-      <select class="global-procurement-select" name="source" data-procurement-source aria-label="Filter by source">
+    const declareTool = this.canDeclareTool();
+    const toolAttributes = declareTool
+      ? ` toolname="${DECLARATIVE_TOOL_NAME}" tooldescription="${DECLARATIVE_TOOL_DESCRIPTION}" toolautosubmit`
+      : '';
+    const activeClass = this.agentToolActive || this.pendingAgentInvocation ? ' webmcp-tool-active' : '';
+    return `<form class="global-procurement-controls${activeClass}" data-procurement-filters aria-busy="${this.loading}"${toolAttributes}>
+      <input class="global-procurement-input" name="query" data-procurement-query type="search" value="${escapeHtml(String(this.filters.query || ''))}" placeholder="Search title or description" aria-label="Search procurement opportunities" toolparamdescription="Words to match in opportunity titles or descriptions.">
+      <input class="global-procurement-input" name="buyer" type="search" value="${escapeHtml(String(this.filters.buyer || ''))}" placeholder="Buyer" aria-label="Filter by buyer" toolparamdescription="Buyer or contracting authority name to match.">
+      <input class="global-procurement-input global-procurement-country" name="country" data-procurement-country type="text" maxlength="2" value="${escapeHtml(String(this.filters.country || ''))}" placeholder="Country" aria-label="Filter by ISO country code" toolparamdescription="Optional two-letter ISO 3166-1 alpha-2 country code; normalized to uppercase.">
+      <select class="global-procurement-select" name="source" data-procurement-source aria-label="Filter by source" toolparamdescription="Official procurement source to search; select All sources to search every source.">
         ${SOURCES.map(([value, label]) => `<option value="${value}"${selected(this.filters.source, value)}>${label}</option>`).join('')}
       </select>
-      <select class="global-procurement-select" name="sort" data-procurement-sort aria-label="Sort opportunities">
+      <select class="global-procurement-select" name="sort" data-procurement-sort aria-label="Sort opportunities" toolparamdescription="Ordering for matching procurement opportunities.">
         ${SORTS.map(([value, label]) => `<option value="${value}"${selected(this.filters.sort, value)}>${label}</option>`).join('')}
       </select>
       <label class="global-procurement-toggle" title="Shows only opportunities whose title, description, or categories matched technology keywords. Keyword relevance evidence only — not an indication of bidding eligibility.">
-        <input type="checkbox" name="techRelevant" data-procurement-tech-relevant${(this.filters.minAutomationScore || 0) > 0 ? ' checked' : ''}${this.loading ? ' disabled' : ''}>
+        <input type="checkbox" name="techRelevant" data-procurement-tech-relevant toolparamdescription="Whether to show only opportunities with technology-relevance keyword evidence."${(this.filters.minAutomationScore || 0) > 0 ? ' checked' : ''}${this.loading ? ' disabled' : ''}>
         Technology relevant only
       </label>
       <button type="submit" class="global-procurement-apply"${this.loading ? ' disabled' : ''}>Apply</button>
-      <button type="button" class="global-procurement-reset" data-procurement-reset${this.loading ? ' disabled' : ''}>Reset</button>
+      <button type="button" class="global-procurement-reset" data-procurement-reset aria-label="Reset filters or cancel the active search" title="Reset filters or cancel the active search"${this.loading ? ' disabled' : ''}>Reset</button>
     </form>`;
+  }
+
+  private canDeclareTool(): boolean {
+    return !this.disposed
+      && !this.isLocked
+      && this.element.isConnected
+      && this.isPanelToolVisible()
+      && this.requestHandler !== null
+      && this.data?.dataAvailable === true
+      && !this.loading
+      && this.settlingAgentForm === null;
+  }
+
+  private isPanelToolVisible(): boolean {
+    if (this.element.classList.contains('hidden')) return false;
+    return !(typeof window !== 'undefined'
+      && isMobileDevice()
+      && this.element.classList.contains('mobile-cat-hidden'));
+  }
+
+  private respondWithRetryableFailure(
+    event: DeclarativeSubmitEvent,
+    error: RetryableProcurementSearchError,
+  ): void {
+    try {
+      event.respondWith?.(Promise.resolve(this.failureResult(error)));
+    } catch {
+      // There is no live invocation state to clean up when the browser rejects
+      // this already-busy response channel synchronously.
+    }
+  }
+
+  private beginAgentInvocation(
+    form: HTMLFormElement,
+    previousFilters: GlobalTenderFilters,
+  ): PendingAgentInvocation {
+    const previousId = this.pendingAgentInvocation?.id;
+    if (previousId !== undefined) {
+      this.failAgentInvocation(previousId, new RetryableProcurementSearchError(
+        'superseded',
+        'The procurement search was superseded by a newer agent request. Retry the earlier search if it is still needed.',
+      ));
+    }
+
+    const id = ++this.nextAgentInvocationId;
+    let resolve!: (result: ProcurementSearchToolResult) => void;
+    const promise = new Promise<ProcurementSearchToolResult>((onResolve) => {
+      resolve = onResolve;
+    });
+    const pending = { id, form, previousFilters, promise, resolve };
+    this.pendingAgentInvocation = pending;
+    return pending;
+  }
+
+  private resolveAgentInvocation(id: number, result: ProcurementSearchToolResult): void {
+    const pending = this.pendingAgentInvocation;
+    if (!pending || pending.id !== id) return;
+    this.pendingAgentInvocation = null;
+    this.settlingAgentForm = pending.form;
+    this.setAgentToolActive(false);
+    pending.resolve(result);
+    this.syncDeclarativeToolStateAfterSettlement(pending.form);
+  }
+
+  private failAgentInvocation(id: number, error: RetryableProcurementSearchError): void {
+    this.resolveAgentInvocation(id, this.failureResult(error));
+  }
+
+  private failureResult(error: RetryableProcurementSearchError): ProcurementSearchToolFailure {
+    return {
+      ok: false,
+      code: String(error.code || 'request_failed').slice(0, 64),
+      message: String(error.message || 'The procurement search failed. Retry later.').slice(0, 320),
+      retryable: true,
+    };
+  }
+
+  private handleRequestHandlerSettled(invocationId: number | null, signal: AbortSignal): void {
+    if (
+      signal.aborted
+      || invocationId === null
+      || this.pendingAgentInvocation?.id !== invocationId
+      || !this.loading
+    ) return;
+    const contentRevision = ++this.contentRevision;
+    this.loading = false;
+    this.failAgentInvocation(invocationId, new RetryableProcurementSearchError(
+      'request_did_not_settle',
+      'The procurement search ended without a terminal result. Retry the search.',
+    ));
+    this.deferAfterAgentSettlement(() => {
+      if (
+        this.pendingAgentInvocation === null
+        && this.settlingAgentForm === null
+        && this.data
+        && !this.isLocked
+        && !this.disposed
+        && this.contentRevision === contentRevision
+      ) this.render();
+    });
+  }
+
+  private agentResult(data: ListGlobalTendersResponse): ProcurementSearchToolResult {
+    const countryCoverage = data.countryCoverage === 'observed' || data.countryCoverage === 'not_requested'
+      ? data.countryCoverage
+      : 'unknown';
+    const appliedFilters = Array.isArray(data.appliedFilters) ? data.appliedFilters : [];
+    const result: ProcurementSearchToolSuccess = {
+      ok: true,
+      matchCount: Math.max(0, Number.isSafeInteger(data.total) ? data.total : 0),
+      availability: String(data.availability || 'available').slice(0, 32),
+      countryCoverage,
+      appliedFilters: appliedFilters.slice(0, MAX_AGENT_APPLIED_FILTERS).map((filter) => (
+        String(filter).slice(0, MAX_AGENT_FILTER_NAME_LENGTH)
+      )),
+      appliedFiltersTruncated: appliedFilters.length > MAX_AGENT_APPLIED_FILTERS
+        || appliedFilters.some((filter) => String(filter).length > MAX_AGENT_FILTER_NAME_LENGTH),
+      sourceStatusSummary: data.sourceStatuses.slice(0, MAX_AGENT_SOURCE_STATUSES).map((source) => ({
+        source: String(source.source || 'unknown').slice(0, 48),
+        state: String(source.state || 'unknown').slice(0, 32),
+        recordCount: Math.max(0, Number.isSafeInteger(source.recordCount) ? source.recordCount : 0),
+      })),
+      sourceStatusesTruncated: data.sourceStatuses.length > MAX_AGENT_SOURCE_STATUSES,
+    };
+    while (JSON.stringify(result).length > MAX_AGENT_RESULT_JSON_LENGTH) {
+      const lastSourceStatus = result.sourceStatusSummary[result.sourceStatusSummary.length - 1];
+      const lastAppliedFilter = result.appliedFilters[result.appliedFilters.length - 1];
+      if (lastSourceStatus && (
+        !lastAppliedFilter
+        || JSON.stringify(lastSourceStatus).length >= JSON.stringify(lastAppliedFilter).length
+      )) {
+        result.sourceStatusSummary.pop();
+        result.sourceStatusesTruncated = true;
+        continue;
+      }
+      if (lastAppliedFilter) {
+        result.appliedFilters.pop();
+        result.appliedFiltersTruncated = true;
+        continue;
+      }
+      break;
+    }
+    return result;
+  }
+
+  private setAgentToolActive(active: boolean): void {
+    this.agentToolActive = active;
+    this.syncAgentFormVisualState();
+  }
+
+  private syncAgentFormVisualState(): void {
+    const pendingInvocation = this.pendingAgentInvocation;
+    const form = pendingInvocation?.form
+      ?? this.content.querySelector<HTMLFormElement>('[data-procurement-filters]');
+    if (!form) return;
+    const pending = pendingInvocation !== null;
+    form.classList.toggle('webmcp-tool-active', this.agentToolActive || pending);
+    form.classList.toggle('webmcp-request-pending', pending);
+    form.setAttribute('aria-busy', String(this.loading));
+    for (const control of form.querySelectorAll<HTMLElement>('input, select, button')) {
+      if (pending && !control.matches('[data-procurement-reset]')) control.setAttribute('aria-disabled', 'true');
+      else control.removeAttribute('aria-disabled');
+    }
+  }
+
+  private syncDeclarativeToolStateAfterSettlement(settlingForm: HTMLFormElement): void {
+    // Let the browser observe the respondWith() promise settlement before any
+    // unavailable/loading transition removes registration attributes.
+    this.deferAfterAgentSettlement(() => {
+      if (this.settlingAgentForm === settlingForm) this.settlingAgentForm = null;
+      if (this.pendingAgentInvocation !== null) return;
+      const form = this.content.querySelector<HTMLFormElement>('[data-procurement-filters]');
+      if (form) this.syncRenderedFilters(form, true);
+      this.syncDeclarativeToolState();
+    });
+  }
+
+  private renderAgentTerminalResult(): boolean {
+    const form = this.pendingAgentInvocation?.form;
+    const results = this.content.querySelector<HTMLElement>('[data-procurement-results]');
+    if (
+      !form
+      || !results
+      || !form.isConnected
+      || !results.isConnected
+      || !this.content.contains(form)
+    ) return false;
+
+    this.syncRenderedFilters(form, false);
+    form.setAttribute('aria-busy', 'false');
+    setTrustedHtml(results, trustedHtml(this.renderResultsMarkup(), 'escaped global procurement terminal results'));
+    return true;
+  }
+
+  private renderAgentTerminalError(message: string): void {
+    const results = this.content.querySelector<HTMLElement>('[data-procurement-results]');
+    const form = this.pendingAgentInvocation?.form;
+    form?.setAttribute('aria-busy', 'false');
+    if (!results) return;
+    setTrustedHtml(results, trustedHtml(
+      `<div class="economic-warning">${escapeHtml(message)}</div>`,
+      'escaped global procurement terminal error',
+    ));
+  }
+
+  private syncRenderedFilters(form: HTMLFormElement, updateDefaults: boolean): void {
+    const query = form.elements.namedItem('query') as HTMLInputElement | null;
+    const buyer = form.elements.namedItem('buyer') as HTMLInputElement | null;
+    const country = form.elements.namedItem('country') as HTMLInputElement | null;
+    const source = form.elements.namedItem('source') as HTMLSelectElement | null;
+    const sort = form.elements.namedItem('sort') as HTMLSelectElement | null;
+    const techRelevant = form.elements.namedItem('techRelevant') as HTMLInputElement | null;
+    if (query) {
+      query.value = String(this.filters.query || '');
+      if (updateDefaults) query.defaultValue = query.value;
+    }
+    if (buyer) {
+      buyer.value = String(this.filters.buyer || '');
+      if (updateDefaults) buyer.defaultValue = buyer.value;
+    }
+    if (country) {
+      country.value = String(this.filters.country || '');
+      if (updateDefaults) country.defaultValue = country.value;
+    }
+    if (source) {
+      source.value = String(this.filters.source || '');
+      if (updateDefaults) {
+        for (const option of source.options) option.defaultSelected = option.selected;
+      }
+    }
+    if (sort) {
+      sort.value = String(this.filters.sort || 'closing_soon');
+      if (updateDefaults) {
+        for (const option of sort.options) option.defaultSelected = option.selected;
+      }
+    }
+    if (techRelevant) {
+      techRelevant.checked = (this.filters.minAutomationScore || 0) > 0;
+      if (updateDefaults) techRelevant.defaultChecked = techRelevant.checked;
+    }
+  }
+
+  private guardPendingFormInteraction(event: Event): void {
+    const pending = this.pendingAgentInvocation;
+    const target = event.target instanceof Element ? event.target : null;
+    if (!pending || !target || !pending.form.contains(target)) return;
+    if (event instanceof KeyboardEvent && event.key === 'Tab') return;
+    if (target.closest('[data-procurement-reset]')) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+
+  private restorePendingFormValues(event: Event): void {
+    const pending = this.pendingAgentInvocation;
+    const target = event.target instanceof Element ? event.target : null;
+    if (!pending || !target || !pending.form.contains(target)) return;
+    event.stopImmediatePropagation();
+    this.syncRenderedFilters(pending.form, false);
+  }
+
+  private syncDeclarativeToolState(): void {
+    if (this.pendingAgentInvocation !== null || this.settlingAgentForm !== null) {
+      this.syncAgentFormVisualState();
+      return;
+    }
+    const form = this.content.querySelector<HTMLFormElement>('[data-procurement-filters]');
+    if (!form) return;
+    if (this.canDeclareTool()) {
+      form.setAttribute('toolname', DECLARATIVE_TOOL_NAME);
+      form.setAttribute('tooldescription', DECLARATIVE_TOOL_DESCRIPTION);
+      form.setAttribute('toolautosubmit', '');
+    } else {
+      form.removeAttribute('toolname');
+      form.removeAttribute('tooldescription');
+      form.removeAttribute('toolautosubmit');
+    }
+    this.syncAgentFormVisualState();
+  }
+
+  private removeDeclarativeToolAttributes(): void {
+    if (this.settlingAgentForm !== null) return;
+    const form = this.content.querySelector<HTMLFormElement>('[data-procurement-filters]');
+    if (!form) return;
+    form.removeAttribute('toolname');
+    form.removeAttribute('tooldescription');
+    form.removeAttribute('toolautosubmit');
+    form.classList.remove('webmcp-tool-active', 'webmcp-request-pending');
+    form.setAttribute('aria-busy', String(this.loading));
+    for (const control of form.querySelectorAll<HTMLElement>('input, select, button')) {
+      control.removeAttribute('aria-disabled');
+    }
+  }
+
+  private handlePanelVisibilityChange(): void {
+    if (this.disposed) return;
+    if (!this.isPanelToolVisible()) {
+      if (this.pendingAgentInvocation !== null) this.cancelForUnavailablePanel();
+      else this.removeDeclarativeToolAttributes();
+      return;
+    }
+    this.syncDeclarativeToolState();
+  }
+
+  private deferAfterAgentSettlement(callback: () => void): void {
+    // Blink attaches its respondWith() reaction after the submit dispatch
+    // returns. A task boundary guarantees that reaction observes the fulfilled
+    // result before registration attributes or the declaring form can change.
+    setTimeout(callback, 0);
+  }
+
+  private abortActiveRequest(restoreFilters = false): boolean {
+    const controller = this.activeRequestController;
+    this.activeRequestController = null;
+    const previousFilters = this.activeRequestPreviousFilters;
+    this.activeRequestPreviousFilters = null;
+    const restoredFilters = restoreFilters && previousFilters !== null;
+    if (restoredFilters) this.filters = { ...previousFilters };
+    controller?.abort();
+    return restoredFilters;
+  }
+
+  private cancelForUnavailablePanel(): void {
+    const wasLoading = this.loading;
+    const pending = this.pendingAgentInvocation;
+    const restoredRequestFilters = this.abortActiveRequest(true);
+    this.loading = false;
+    if (wasLoading || restoredRequestFilters || pending !== null) this.contentRevision += 1;
+    if (pending) {
+      this.filters = { ...pending.previousFilters };
+      this.failAgentInvocation(pending.id, new RetryableProcurementSearchError(
+        'panel_unavailable',
+        'The procurement panel became unavailable before the search completed. Retry after it is restored.',
+      ));
+      this.agentToolActive = false;
+      return;
+    }
+    this.agentToolActive = false;
+    if (restoredRequestFilters && this.settlingAgentForm === null && !this.disposed) this.render();
+    this.removeDeclarativeToolAttributes();
+  }
+
+  private cancelAgentOperation(): void {
+    const pending = this.pendingAgentInvocation;
+    this.setAgentToolActive(false);
+    if (!pending) return;
+    const contentRevision = ++this.contentRevision;
+    this.abortActiveRequest();
+    this.loading = false;
+    this.filters = { ...pending.previousFilters };
+    this.syncRenderedFilters(pending.form, false);
+    this.failAgentInvocation(pending.id, new RetryableProcurementSearchError(
+      'canceled',
+      'The procurement search was canceled before it completed. Retry if results are still needed.',
+    ));
+    this.deferAfterAgentSettlement(() => {
+      if (
+        this.pendingAgentInvocation === null
+        && this.settlingAgentForm === null
+        && this.data
+        && !this.isLocked
+        && !this.disposed
+        && this.contentRevision === contentRevision
+      ) this.render();
+    });
   }
 
   private renderTenderCard(tender: GlobalTender): string {

--- a/src/services/global-tenders.ts
+++ b/src/services/global-tenders.ts
@@ -18,17 +18,25 @@ export function clearGlobalTenderCache(): void {
   tenderBreaker.clearCache();
 }
 
-export async function fetchGlobalTenders(filters: GlobalTenderFilters = {}): Promise<ListGlobalTendersResponse> {
+export async function fetchGlobalTenders(
+  filters: GlobalTenderFilters = {},
+  signal?: AbortSignal,
+): Promise<ListGlobalTendersResponse> {
   const request: ListGlobalTendersRequest = {
     country: '', countries: [], region: '', source: '', status: '', deadlineFrom: '', deadlineTo: '', minValue: 0, maxValue: 0,
     currency: '', category: '', query: '', pageSize: 25, cursor: '', sort: 'closing_soon', buyer: '', publishedFrom: '', publishedTo: '', minAutomationScore: 0, ...filters,
   };
   return tenderBreaker.execute(
-    () => client.listGlobalTenders(request, { signal: AbortSignal.timeout(20_000) }),
+    () => client.listGlobalTenders(request, {
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(20_000)])
+        : AbortSignal.timeout(20_000),
+    }),
     EMPTY_TENDERS,
     {
       cacheKey: JSON.stringify(request),
       shouldCache: (response) => response.dataAvailable || response.availability === 'empty',
+      ignoreError: () => signal?.aborted === true,
     },
   );
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -11726,6 +11726,31 @@ a.prediction-link:hover {
   border-bottom: 1px solid var(--border);
 }
 
+/* biome-ignore lint/correctness/noUnknownPseudoClass: Chrome declarative WebMCP pseudo-class. */
+.global-procurement-controls:tool-form-active {
+  outline: 2px dashed var(--green);
+  outline-offset: -2px;
+  background: color-mix(in srgb, var(--green) 8%, transparent);
+}
+
+.global-procurement-controls.webmcp-tool-active {
+  outline: 2px dashed var(--green);
+  outline-offset: -2px;
+  background: color-mix(in srgb, var(--green) 8%, transparent);
+}
+
+/* Keep the exact declaring controls in Chrome's active schema and visually
+ * distinguish the pending state. Event handlers block competing interaction;
+ * pointer targeting must remain intact so panel dragging still sees controls. */
+.global-procurement-controls.webmcp-request-pending > :not([data-procurement-reset]) {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.global-procurement-controls.webmcp-request-pending > .global-procurement-toggle:focus-within {
+  opacity: 1;
+}
+
 .global-procurement-toggle {
   display: flex;
   align-items: center;
@@ -11756,7 +11781,8 @@ a.prediction-link:hover {
 
 .global-procurement-input:focus,
 .global-procurement-select:focus {
-  outline: 1px solid var(--green);
+  outline: 2px solid var(--green);
+  outline-offset: 1px;
   border-color: var(--green);
 }
 
@@ -11774,6 +11800,30 @@ a.prediction-link:hover {
 .global-procurement-apply {
   color: var(--green);
   border-color: color-mix(in srgb, var(--green) 40%, var(--border));
+}
+
+/* biome-ignore lint/correctness/noUnknownPseudoClass: Chrome declarative WebMCP pseudo-class. */
+.global-procurement-apply:tool-submit-active {
+  outline: 2px dashed var(--green);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 18%, transparent);
+}
+
+.global-procurement-controls.webmcp-tool-active .global-procurement-apply {
+  outline: 2px dashed var(--green);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--green) 18%, transparent);
+}
+
+.global-procurement-controls .global-procurement-input:focus-visible,
+.global-procurement-controls .global-procurement-select:focus-visible,
+.global-procurement-controls .global-procurement-toggle input:focus-visible,
+.global-procurement-controls .global-procurement-apply:focus-visible,
+.global-procurement-controls .global-procurement-reset:focus-visible {
+  outline: 2px solid var(--semantic-info);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--semantic-info) 24%, transparent);
+  opacity: 1;
 }
 
 .global-procurement-apply:disabled,

--- a/src/utils/circuit-breaker.ts
+++ b/src/utils/circuit-breaker.ts
@@ -361,6 +361,12 @@ export class CircuitBreaker<T> {
        * retaining that entry as a fallback. Circuit cooldown still applies.
        */
       forceRefresh?: boolean;
+      /**
+       * Treat caller-owned cancellation as neither an upstream failure nor a
+       * fallback result. Matching errors are rethrown on the foreground path
+       * so the caller can stop its own lifecycle without opening cooldown.
+       */
+      ignoreError?: (error: unknown) => boolean;
     } = {},
   ): Promise<R> {
     const offline = isDesktopOfflineMode();
@@ -450,6 +456,7 @@ export class CircuitBreaker<T> {
             // the default and matches the market-quote use case.
             return { kind: 'not-cacheable' };
           } catch (e) {
+            if (options.ignoreError?.(e)) return { kind: 'failed' };
             console.warn(`[${this.name}] Background refresh failed:`, e);
             this.recordFailure(String(e));
             return { kind: 'failed' };
@@ -488,6 +495,7 @@ export class CircuitBreaker<T> {
       }
       return result;
     } catch (e) {
+      if (options.ignoreError?.(e)) throw e;
       const msg = String(e);
       console.error(`[${this.name}] Failed:`, msg);
       this.recordFailure(msg);

--- a/tests/circuit-breaker-swr-eviction.test.mts
+++ b/tests/circuit-breaker-swr-eviction.test.mts
@@ -79,6 +79,33 @@ describe('CircuitBreaker — evictOnRefreshFailure (#3795 review-2)', () => {
     }
   });
 
+  it('rethrows caller cancellation without recording an upstream failure', async () => {
+    const mod = await import(`${CIRCUIT_BREAKER_URL}?t=${Date.now()}-ignored-cancel`);
+    const { createCircuitBreaker, clearAllCircuitBreakers } = mod;
+    clearAllCircuitBreakers();
+
+    try {
+      const breaker = createCircuitBreaker<Payload>({
+        name: 'Ignored caller cancellation',
+        maxFailures: 1,
+        persistCache: false,
+      });
+      const cancellation = new DOMException('Canceled by caller', 'AbortError');
+      await assert.rejects(
+        breaker.execute(
+          async () => { throw cancellation; },
+          { quotes: [] },
+          { ignoreError: (error) => error === cancellation },
+        ),
+        cancellation,
+      );
+      assert.equal(breaker.isOnCooldown(), false);
+      assert.equal(breaker.getStatus(), 'ok');
+    } finally {
+      clearAllCircuitBreakers();
+    }
+  });
+
   it('default behaviour preserved: without evictOnRefreshFailure, refresh that fails shouldCache keeps the stale entry', async () => {
     // Mirrors the market-quote-cache-keying test's intent: transient
     // upstream blips must NOT wipe previously-good cached data when the

--- a/tests/dom/global-procurement-data-loader.test.mts
+++ b/tests/dom/global-procurement-data-loader.test.mts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AppContext } from '@/app/app-context';
+import type { ListGlobalTendersResponse } from '@/generated/client/worldmonitor/economic/v1/service_client';
+import type { GlobalTenderFilters } from '@/services/global-tenders';
+
+const procurementMocks = vi.hoisted(() => ({
+  fetchGlobalTenders: vi.fn(),
+}));
+
+vi.mock('@/services/panel-gating', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/services/panel-gating')>(),
+  hasPremiumAccess: () => true,
+}));
+
+vi.mock('@/services/global-tenders', () => ({
+  clearGlobalTenderCache: vi.fn(),
+  fetchGlobalTenders: procurementMocks.fetchGlobalTenders,
+}));
+
+function response(total = 0): ListGlobalTendersResponse {
+  return {
+    tenders: [],
+    nextCursor: '',
+    fetchedAt: '2026-08-18T12:00:00.000Z',
+    dataAvailable: true,
+    availability: 'available',
+    sourceStatuses: [],
+    total,
+    appliedFilters: [],
+    countryCoverage: 'not_requested',
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((onResolve) => {
+    resolve = onResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('Global procurement DataLoader cancellation', () => {
+  it('does not let canceled scoped filters seed an overlapping unfiltered refresh', async () => {
+    type RequestHandler = (
+      filters: GlobalTenderFilters,
+      append: boolean,
+      signal: AbortSignal,
+    ) => void | Promise<void>;
+
+    const procurementPanel = {
+      setRequestHandler: vi.fn((_handler: RequestHandler) => undefined),
+      setLoading: vi.fn(),
+      update: vi.fn(),
+      clear: vi.fn(),
+      showUnavailable: vi.fn(),
+    };
+    const statusPanel = { updateApi: vi.fn() };
+    const ctx = {
+      panels: {
+        'global-procurement': procurementPanel,
+      },
+      statusPanel,
+    } as unknown as AppContext;
+
+    procurementMocks.fetchGlobalTenders.mockReset();
+    procurementMocks.fetchGlobalTenders.mockResolvedValue(response(1));
+    const { DataLoaderManager } = await import('@/app/data-loader');
+    const loader = new DataLoaderManager(ctx, {
+      renderCriticalBanner: () => undefined,
+      refreshOpenCountryBrief: () => undefined,
+    });
+
+    await loader.loadGlobalTenders({ query: 'baseline' });
+    const requestHandlerCalls = procurementPanel.setRequestHandler.mock.calls;
+    const requestHandler = requestHandlerCalls[requestHandlerCalls.length - 1]?.[0];
+    if (!requestHandler) throw new Error('Global procurement request handler was not registered');
+
+    const agentFetch = deferred<ListGlobalTendersResponse>();
+    procurementMocks.fetchGlobalTenders.mockImplementationOnce(() => agentFetch.promise);
+    const controller = new AbortController();
+    const agentRequest = requestHandler({ query: 'agent-only' }, false, controller.signal);
+    await vi.waitFor(() => expect(procurementMocks.fetchGlobalTenders).toHaveBeenCalledTimes(2));
+    expect(procurementMocks.fetchGlobalTenders.mock.calls[1]?.[1]).toBe(controller.signal);
+
+    await loader.loadGlobalTenders();
+    expect(procurementMocks.fetchGlobalTenders).toHaveBeenCalledTimes(2);
+
+    controller.abort();
+    expect((procurementMocks.fetchGlobalTenders.mock.calls[1]?.[1] as AbortSignal).aborted).toBe(true);
+    await loader.loadGlobalTenders();
+    const refreshFilters = procurementMocks.fetchGlobalTenders.mock.calls[2]?.[0] as GlobalTenderFilters | undefined;
+    expect(refreshFilters).toMatchObject({ query: 'baseline', cursor: '' });
+
+    agentFetch.resolve(response(99));
+    await agentRequest;
+    expect(procurementPanel.update).not.toHaveBeenCalledWith(expect.objectContaining({ total: 99 }), false);
+  });
+
+  it('invalidates an unscoped procurement load when the DataLoader is destroyed', async () => {
+    const procurementPanel = {
+      setRequestHandler: vi.fn(),
+      setLoading: vi.fn(),
+      update: vi.fn(),
+      clear: vi.fn(),
+      showUnavailable: vi.fn(),
+    };
+    const statusPanel = { updateApi: vi.fn() };
+    const ctx = {
+      panels: {
+        'global-procurement': procurementPanel,
+      },
+      statusPanel,
+    } as unknown as AppContext;
+    const pendingFetch = deferred<ListGlobalTendersResponse>();
+    procurementMocks.fetchGlobalTenders.mockReset();
+    procurementMocks.fetchGlobalTenders.mockImplementationOnce(() => pendingFetch.promise);
+    const { DataLoaderManager } = await import('@/app/data-loader');
+    const loader = new DataLoaderManager(ctx, {
+      renderCriticalBanner: () => undefined,
+      refreshOpenCountryBrief: () => undefined,
+    });
+
+    const load = loader.loadGlobalTenders();
+    await vi.waitFor(() => expect(procurementMocks.fetchGlobalTenders).toHaveBeenCalledTimes(1));
+    loader.destroy();
+    pendingFetch.resolve(response(77));
+    await load;
+
+    expect(procurementPanel.update).not.toHaveBeenCalled();
+    expect(statusPanel.updateApi).not.toHaveBeenCalled();
+  });
+});

--- a/tests/dom/global-procurement-webmcp.test.mts
+++ b/tests/dom/global-procurement-webmcp.test.mts
@@ -1,0 +1,829 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  GlobalProcurementPanel,
+  type ProcurementSearchToolResult,
+} from '@/components/GlobalProcurementPanel';
+import type { ListGlobalTendersResponse, TenderSourceStatus } from '@/generated/client/worldmonitor/economic/v1/service_client';
+import type { GlobalTenderFilters } from '@/services/global-tenders';
+import { PanelGateReason } from '@/services/panel-gating';
+
+import { initTestI18n } from './helpers/i18n.mts';
+
+const CONTENT_DEBOUNCE_MS = 150;
+const DESKTOP_VIEWPORT_WIDTH = 1024;
+
+type TestRequestHandler = (
+  filters: GlobalTenderFilters,
+  append: boolean,
+  signal: AbortSignal,
+) => void | Promise<void>;
+
+function sourceStatus(index = 0, overrides: Partial<TenderSourceStatus> = {}): TenderSourceStatus {
+  return {
+    source: `source-${index}`,
+    state: 'ok',
+    recordCount: index + 1,
+    fetchedAt: '2026-08-18T12:00:00.000Z',
+    lastSuccessfulAt: '2026-08-18T12:00:00.000Z',
+    stale: false,
+    paced: false,
+    ...overrides,
+  };
+}
+
+function response(overrides: Partial<ListGlobalTendersResponse> = {}): ListGlobalTendersResponse {
+  return {
+    tenders: [],
+    nextCursor: '',
+    fetchedAt: '2026-08-18T12:00:00.000Z',
+    dataAvailable: true,
+    availability: 'available',
+    sourceStatuses: [sourceStatus()],
+    total: 0,
+    appliedFilters: [],
+    countryCoverage: 'not_requested',
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function form(panel: GlobalProcurementPanel): HTMLFormElement {
+  const element = panel.getElement().querySelector<HTMLFormElement>('[data-procurement-filters]');
+  if (!element) throw new Error('procurement form missing');
+  return element;
+}
+
+function commitResponse(panel: GlobalProcurementPanel, data = response()): void {
+  panel.update(data);
+  vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+}
+
+function dispatchAgentSubmit(element: HTMLFormElement): {
+  event: Event;
+  response: Promise<ProcurementSearchToolResult>;
+} {
+  let agentResponse: Promise<ProcurementSearchToolResult> | undefined;
+  const event = new Event('submit', { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    agentInvoked: { value: true },
+    respondWith: {
+      value: (pending: Promise<ProcurementSearchToolResult>) => {
+        agentResponse = pending;
+      },
+    },
+  });
+  element.dispatchEvent(event);
+  if (!agentResponse) throw new Error('respondWith was not called');
+  return { event, response: agentResponse };
+}
+
+function dispatchToolEvent(type: string, toolName = 'search_procurement'): void {
+  const event = new Event(type);
+  Object.defineProperty(event, 'toolName', { value: toolName });
+  window.dispatchEvent(event);
+}
+
+function resizeTo(width: number): void {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: width,
+  });
+  window.dispatchEvent(new Event('resize'));
+}
+
+async function expectRetryableFailure(
+  promise: Promise<ProcurementSearchToolResult>,
+  code: string,
+) {
+  const [settlement] = await Promise.allSettled([promise]);
+  expect(settlement?.status).toBe('fulfilled');
+  if (!settlement || settlement.status !== 'fulfilled') {
+    throw new Error(`Expected ${code} to resolve as a structured tool result`);
+  }
+  expect(settlement.value).toMatchObject({ ok: false, code, retryable: true });
+  expect(JSON.parse(JSON.stringify(settlement.value))).toEqual(settlement.value);
+  if (settlement.value.ok) throw new Error(`Expected ${code} failure result`);
+  return settlement.value;
+}
+
+function expectSignalAborted(signal: AbortSignal | null): void {
+  expect(signal).not.toBeNull();
+  if (!signal) throw new Error('Expected the request handler to receive an AbortSignal');
+  expect(signal.aborted).toBe(true);
+}
+
+beforeAll(async () => {
+  await initTestI18n();
+});
+
+describe('GlobalProcurementPanel declarative WebMCP tool', () => {
+  let panels: GlobalProcurementPanel[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resizeTo(DESKTOP_VIEWPORT_WIDTH);
+    panels = [];
+  });
+
+  afterEach(() => {
+    for (const panel of panels) panel.destroy();
+    vi.advanceTimersByTime(0);
+    document.body.innerHTML = '';
+    resizeTo(DESKTOP_VIEWPORT_WIDTH);
+    vi.useRealTimers();
+  });
+
+  function mount(handler?: TestRequestHandler): GlobalProcurementPanel {
+    const panel = new GlobalProcurementPanel();
+    panels.push(panel);
+    if (handler) panel.setRequestHandler(handler);
+    document.body.appendChild(panel.getElement());
+    return panel;
+  }
+
+  it('declares exactly one bounded read-only search form with the human filter contract', () => {
+    const panel = mount(() => undefined);
+    commitResponse(panel);
+
+    const tools = panel.getElement().querySelectorAll<HTMLFormElement>('form[toolname]');
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.getAttribute('toolname')).toBe('search_procurement');
+    expect(tools[0]?.getAttribute('tooldescription')).toBe(
+      'Search official global procurement opportunities using visible filters.',
+    );
+    expect(tools[0]?.hasAttribute('toolautosubmit')).toBe(true);
+
+    const parameterControls = tools[0]?.querySelectorAll<HTMLInputElement | HTMLSelectElement>('[toolparamdescription]');
+    expect(parameterControls).toHaveLength(6);
+    expect([...parameterControls!].map((control) => control.name)).toEqual([
+      'query',
+      'buyer',
+      'country',
+      'source',
+      'sort',
+      'techRelevant',
+    ]);
+    expect([...parameterControls!].every((control) => !control.required)).toBe(true);
+
+    const country = tools[0]?.elements.namedItem('country') as HTMLInputElement;
+    expect(country.maxLength).toBe(2);
+    expect(country.getAttribute('toolparamdescription')).toContain('ISO 3166-1 alpha-2');
+    const technologyRelevant = tools[0]?.elements.namedItem('techRelevant') as HTMLInputElement;
+    expect(technologyRelevant.type).toBe('checkbox');
+
+    const source = tools[0]?.elements.namedItem('source') as HTMLSelectElement;
+    expect([...source.options].map((option) => [option.value, option.textContent])).toEqual([
+      ['', 'All sources'],
+      ['sam', 'SAM.gov'],
+      ['ted', 'TED'],
+      ['contracts-finder', 'Contracts Finder'],
+      ['canada-buys', 'CanadaBuys'],
+      ['gets', 'GETS'],
+      ['world-bank', 'World Bank'],
+    ]);
+    const sort = tools[0]?.elements.namedItem('sort') as HTMLSelectElement;
+    expect([...sort.options].map((option) => option.value)).toEqual([
+      'closing_soon',
+      'newest',
+      'estimated_value',
+      'relevance',
+    ]);
+  });
+
+  it('withholds the tool when the form is unusable, hidden, gated, unavailable, or destroyed', () => {
+    const unmountedPanel = new GlobalProcurementPanel();
+    panels.push(unmountedPanel);
+    unmountedPanel.setRequestHandler(() => undefined);
+    commitResponse(unmountedPanel);
+    expect(form(unmountedPanel).hasAttribute('toolname')).toBe(false);
+    document.body.appendChild(unmountedPanel.getElement());
+    unmountedPanel.notifyConnected();
+    expect(form(unmountedPanel).getAttribute('toolname')).toBe('search_procurement');
+
+    const panel = mount();
+    commitResponse(panel);
+    expect(form(panel).hasAttribute('toolname')).toBe(false);
+
+    panel.setRequestHandler(() => undefined);
+    expect(form(panel).getAttribute('toolname')).toBe('search_procurement');
+
+    panel.setLoading(true);
+    expect(form(panel).hasAttribute('toolname')).toBe(false);
+    expect(form(panel).getAttribute('aria-busy')).toBe('true');
+    commitResponse(panel);
+    expect(form(panel).getAttribute('toolname')).toBe('search_procurement');
+
+    panel.update(response({ dataAvailable: false, availability: 'unavailable' }));
+    expect(form(panel).hasAttribute('toolname')).toBe(false);
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+    expect(form(panel).hasAttribute('toolname')).toBe(false);
+
+    commitResponse(panel);
+    panel.hide();
+    expect(form(panel).hasAttribute('toolname')).toBe(false);
+    panel.show();
+    expect(form(panel).getAttribute('toolname')).toBe('search_procurement');
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+
+    panel.showGatedCta(PanelGateReason.FREE_TIER, () => undefined);
+    expect(panel.getElement().querySelector('form[toolname]')).toBeNull();
+    panel.unlockPanel();
+    expect(form(panel).getAttribute('toolname')).toBe('search_procurement');
+    expect(form(panel).hasAttribute('toolautosubmit')).toBe(true);
+
+    const destroyPanel = mount(() => undefined);
+    commitResponse(destroyPanel);
+    const destroyedForm = form(destroyPanel);
+    destroyPanel.destroy();
+    panels = panels.filter((candidate) => candidate !== destroyPanel);
+    expect(destroyedForm.hasAttribute('toolname')).toBe(false);
+  });
+
+  it('fails closed when a stale agent submit targets an unavailable or detached form', async () => {
+    const handler = vi.fn(() => undefined);
+    const panel = mount(handler);
+    commitResponse(panel, response({ dataAvailable: false, availability: 'unavailable' }));
+    const unavailableForm = form(panel);
+    expect(unavailableForm.hasAttribute('toolname')).toBe(false);
+
+    const unavailableInvocation = dispatchAgentSubmit(unavailableForm);
+    await expectRetryableFailure(unavailableInvocation.response, 'panel_unavailable');
+    expect(handler).not.toHaveBeenCalled();
+
+    commitResponse(panel);
+    const detachedForm = form(panel);
+    expect(detachedForm.getAttribute('toolname')).toBe('search_procurement');
+    panel.getElement().remove();
+
+    const detachedInvocation = dispatchAgentSubmit(detachedForm);
+    await expectRetryableFailure(detachedInvocation.response, 'panel_unavailable');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('withholds mobile-category-hidden tools and restores the lingering class on desktop', async () => {
+    let requestSignal: AbortSignal | null = null;
+    const handler = vi.fn((_filters: GlobalTenderFilters, _append: boolean, signal: AbortSignal) => {
+      requestSignal = signal;
+      return new Promise<void>(() => undefined);
+    });
+    const panel = mount(handler);
+    commitResponse(panel);
+    const currentForm = form(panel);
+
+    resizeTo(480);
+    panel.getElement().classList.add('mobile-cat-hidden');
+    window.dispatchEvent(new Event('resize'));
+    expect(currentForm.hasAttribute('toolname')).toBe(false);
+
+    // A stale browser-side descriptor must still fail closed at use time.
+    const staleInvocation = dispatchAgentSubmit(currentForm);
+    await expectRetryableFailure(staleInvocation.response, 'panel_unavailable');
+    expect(handler).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(0);
+
+    resizeTo(DESKTOP_VIEWPORT_WIDTH);
+    expect(panel.getElement().classList.contains('mobile-cat-hidden')).toBe(true);
+    expect(currentForm.getAttribute('toolname')).toBe('search_procurement');
+    expect(currentForm.hasAttribute('toolautosubmit')).toBe(true);
+
+    const pendingInvocation = dispatchAgentSubmit(currentForm);
+    resizeTo(480);
+    await expectRetryableFailure(pendingInvocation.response, 'panel_unavailable');
+    expectSignalAborted(requestSignal);
+    expect(currentForm.isConnected).toBe(true);
+    expect(currentForm.getAttribute('toolname')).toBe('search_procurement');
+    vi.advanceTimersByTime(0);
+    expect(currentForm.hasAttribute('toolname')).toBe(false);
+
+    resizeTo(DESKTOP_VIEWPORT_WIDTH);
+    expect(currentForm.getAttribute('toolname')).toBe('search_procurement');
+  });
+
+  it('preserves the declaring form until visible results update and returns only a bounded terminal summary', async () => {
+    const requestCompletion = deferred<void>();
+    const handler = vi.fn(() => requestCompletion.promise);
+    const panel = mount(handler);
+    commitResponse(panel);
+
+    const currentForm = form(panel);
+    const currentResults = panel.getElement().querySelector<HTMLElement>('[data-procurement-results]');
+    expect(currentResults).not.toBeNull();
+    (currentForm.elements.namedItem('query') as HTMLInputElement).value = 'cloud';
+    (currentForm.elements.namedItem('buyer') as HTMLInputElement).value = 'Ministry';
+    (currentForm.elements.namedItem('country') as HTMLInputElement).value = 'us';
+    (currentForm.elements.namedItem('source') as HTMLSelectElement).value = 'sam';
+    (currentForm.elements.namedItem('sort') as HTMLSelectElement).value = 'relevance';
+    (currentForm.elements.namedItem('techRelevant') as HTMLInputElement).checked = true;
+
+    dispatchToolEvent('toolactivated');
+    expect(currentForm.classList.contains('webmcp-tool-active')).toBe(true);
+    const invocation = dispatchAgentSubmit(currentForm);
+    expect(invocation.event.defaultPrevented).toBe(true);
+    expect(handler).toHaveBeenCalledWith({
+      query: 'cloud',
+      buyer: 'Ministry',
+      country: 'US',
+      source: 'sam',
+      sort: 'relevance',
+      pageSize: 25,
+      cursor: '',
+      minAutomationScore: 30,
+    }, false, expect.any(AbortSignal));
+
+    // The production DataLoader re-enters loadGlobalTenders() and installs its
+    // panel handler again before the request reaches the first await. That
+    // setter must not unregister the exact form backing respondWith().
+    panel.setRequestHandler(handler);
+    expect(currentForm.getAttribute('toolname')).toBe('search_procurement');
+    expect(currentForm.getAttribute('tooldescription')).toBe(
+      'Search official global procurement opportunities using visible filters.',
+    );
+    expect(currentForm.hasAttribute('toolautosubmit')).toBe(true);
+    expect(currentForm.classList.contains('webmcp-request-pending')).toBe(true);
+    expect([...currentForm.elements].filter((control) => !control.matches('[data-procurement-reset]'))
+      .every((control) => control.getAttribute('aria-disabled') === 'true')).toBe(true);
+    expect(currentForm.querySelector('[data-procurement-reset]')?.hasAttribute('aria-disabled')).toBe(false);
+    expect([...currentForm.elements].every((control) => !control.hasAttribute('disabled'))).toBe(true);
+
+    let settled = false;
+    let formAtSettlement: HTMLFormElement | null = null;
+    void invocation.response.then(() => {
+      settled = true;
+      formAtSettlement = form(panel);
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    expect(form(panel)).toBe(currentForm);
+    expect(currentForm.getAttribute('aria-busy')).toBe('true');
+
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+    expect(form(panel)).toBe(currentForm);
+
+    // Programmatic input and keyboard submission can bypass pointer styling.
+    // Preserve the filters owned by the active agent request.
+    (currentForm.elements.namedItem('query') as HTMLInputElement).value = 'roads';
+    (currentForm.elements.namedItem('query') as HTMLInputElement).dispatchEvent(
+      new Event('input', { bubbles: true, cancelable: true }),
+    );
+    expect((currentForm.elements.namedItem('query') as HTMLInputElement).value).toBe('cloud');
+    currentForm.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    const competingInvocation = dispatchAgentSubmit(currentForm);
+    await expectRetryableFailure(competingInvocation.response, 'request_in_progress');
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    panel.update(response({
+      tenders: [{
+        id: 'secret-tender',
+        source: 'sam',
+        sourceNoticeId: 'secret-tender',
+        officialUrl: 'https://example.test/secret-tender',
+        title: 'Sensitive tender title',
+        description: 'Sensitive tender content must not enter the tool response.',
+        status: 'open',
+        categoryCodes: [],
+        sectors: [],
+        eligibilityRequirements: [],
+        submissionUrls: [],
+        participationMode: 'unknown',
+      }],
+      availability: 'partial',
+      total: 42,
+      countryCoverage: 'observed',
+      appliedFilters: ['country', 'source', 'query', 'buyer', 'min_automation_score'],
+      sourceStatuses: Array.from({ length: 10 }, (_, index) => sourceStatus(index, {
+        state: index === 1 ? 'error' : 'ok',
+      })),
+    }));
+    expect(form(panel)).toBe(currentForm);
+    expect(panel.getElement().querySelector('[data-procurement-results]')).toBe(currentResults);
+    expect(panel.getElement().textContent).toContain('Showing 1 of 42 matching opportunities');
+    // The old debounced full-form render landed here and canceled Blink's
+    // invocation. The exact declaring node must survive that historical window.
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+    expect(form(panel)).toBe(currentForm);
+    requestCompletion.resolve();
+
+    const result = await invocation.response;
+    expect(result).toEqual({
+      ok: true,
+      matchCount: 42,
+      availability: 'partial',
+      countryCoverage: 'observed',
+      appliedFilters: ['country', 'source', 'query', 'buyer', 'min_automation_score'],
+      appliedFiltersTruncated: false,
+      sourceStatusSummary: Array.from({ length: 8 }, (_, index) => ({
+        source: `source-${index}`,
+        state: index === 1 ? 'error' : 'ok',
+        recordCount: index + 1,
+      })),
+      sourceStatusesTruncated: true,
+    });
+    expect(JSON.stringify(result)).not.toContain('Sensitive tender');
+    expect(settled).toBe(true);
+    expect(formAtSettlement).toBe(currentForm);
+    expect(form(panel)).toBe(currentForm);
+    expect((form(panel).elements.namedItem('query') as HTMLInputElement).value).toBe('cloud');
+    expect((form(panel).elements.namedItem('country') as HTMLInputElement).value).toBe('US');
+    expect(form(panel).classList.contains('webmcp-tool-active')).toBe(false);
+    expect(form(panel).classList.contains('webmcp-request-pending')).toBe(false);
+    expect([...form(panel).elements].every((control) => !control.hasAttribute('aria-disabled'))).toBe(true);
+  });
+
+  it('defers synchronous terminal cleanup until the response promise is observable', async () => {
+    let panel!: GlobalProcurementPanel;
+    panel = mount(() => panel.clear());
+    commitResponse(panel);
+    const currentForm = form(panel);
+    const invocation = dispatchAgentSubmit(currentForm);
+    let formAtSettlement: HTMLFormElement | null = null;
+    void invocation.response.then(() => {
+      formAtSettlement = currentForm.isConnected ? currentForm : null;
+    });
+    panel.update(response({ total: 7 }));
+
+    await expectRetryableFailure(invocation.response, 'panel_unavailable');
+    expect(formAtSettlement).toBe(currentForm);
+    expect(currentForm.isConnected).toBe(true);
+    expect(currentForm.getAttribute('toolname')).toBe('search_procurement');
+
+    vi.advanceTimersByTime(0);
+    expect(currentForm.isConnected).toBe(false);
+    expect(panel.getElement().textContent).toContain('Showing 0 of 7 matching opportunities');
+  });
+
+  it('does not let a same-turn gate preserve content cleared during settlement', async () => {
+    const sensitiveTitle = 'Sensitive procurement result that must stay cleared';
+    const panel = mount(() => new Promise<void>(() => undefined));
+    commitResponse(panel, response({
+      tenders: [{
+        id: 'sensitive-result',
+        source: 'sam',
+        sourceNoticeId: 'sensitive-result',
+        officialUrl: '',
+        title: sensitiveTitle,
+        description: '',
+        status: 'open',
+        categoryCodes: [],
+        sectors: [],
+        eligibilityRequirements: [],
+        submissionUrls: [],
+        participationMode: 'unknown',
+      }],
+      total: 1,
+    }));
+    expect(panel.getElement().textContent).toContain(sensitiveTitle);
+
+    const invocation = dispatchAgentSubmit(form(panel));
+    panel.clear();
+    panel.showGatedCta(PanelGateReason.FREE_TIER, () => undefined);
+
+    await expectRetryableFailure(invocation.response, 'panel_unavailable');
+    vi.advanceTimersByTime(0);
+    panel.unlockPanel();
+
+    expect(panel.getElement().textContent).not.toContain(sensitiveTitle);
+  });
+
+  it('defers a superseding refresh repaint until the agent failure is observable', async () => {
+    const panel = mount(() => new Promise<void>(() => undefined));
+    commitResponse(panel);
+    const currentForm = form(panel);
+    const invocation = dispatchAgentSubmit(currentForm);
+    let formAtSettlement: HTMLFormElement | null = null;
+    void invocation.response.then(() => {
+      formAtSettlement = currentForm.isConnected ? currentForm : null;
+    });
+
+    panel.setLoading(true);
+    await expectRetryableFailure(invocation.response, 'superseded');
+    expect(formAtSettlement).toBe(currentForm);
+    expect(currentForm.isConnected).toBe(true);
+
+    vi.advanceTimersByTime(0);
+    expect(currentForm.isConnected).toBe(false);
+  });
+
+  it('preserves the declaring form across a same-turn hide and show', async () => {
+    const panel = mount(() => new Promise<void>(() => undefined));
+    commitResponse(panel);
+    const currentForm = form(panel);
+    const invocation = dispatchAgentSubmit(currentForm);
+    let formAtSettlement: HTMLFormElement | null = null;
+    void invocation.response.then(() => {
+      formAtSettlement = currentForm.isConnected ? currentForm : null;
+    });
+
+    panel.hide();
+    panel.show();
+
+    await expectRetryableFailure(invocation.response, 'panel_unavailable');
+    expect(formAtSettlement).toBe(currentForm);
+    expect(form(panel)).toBe(currentForm);
+    expect(currentForm.isConnected).toBe(true);
+
+    vi.advanceTimersByTime(0);
+    expect(form(panel)).toBe(currentForm);
+    expect(currentForm.getAttribute('toolname')).toBe('search_procurement');
+  });
+
+  it('renders the latest settled data after same-turn visibility changes', async () => {
+    const panel = mount(() => new Promise<void>(() => undefined));
+    commitResponse(panel);
+    const invocation = dispatchAgentSubmit(form(panel));
+
+    panel.update(response({ total: 1 }));
+    panel.update(response({ total: 2 }));
+    panel.hide();
+    panel.show();
+
+    const result = await invocation.response;
+    expect(result).toMatchObject({ ok: true, matchCount: 1 });
+    expect(panel.getElement().textContent).toContain('Showing 0 of 1 matching opportunities');
+
+    vi.advanceTimersByTime(0);
+    expect(panel.getElement().textContent).toContain('Showing 0 of 2 matching opportunities');
+  });
+
+  it('invalidates a deferred gate when access is restored in the same tick', async () => {
+    const panel = mount(() => new Promise<void>(() => undefined));
+    commitResponse(panel);
+    const currentForm = form(panel);
+    const invocation = dispatchAgentSubmit(currentForm);
+
+    panel.showGatedCta(PanelGateReason.FREE_TIER, () => undefined);
+    panel.unlockPanel();
+    await expectRetryableFailure(invocation.response, 'panel_unavailable');
+    vi.advanceTimersByTime(0);
+
+    expect(panel.getElement().classList.contains('panel-is-locked')).toBe(false);
+    expect(currentForm.isConnected).toBe(true);
+    expect(currentForm.getAttribute('toolname')).toBe('search_procurement');
+  });
+
+  it('always completes base teardown after a pending invocation settles', async () => {
+    const panel = mount(() => new Promise<void>(() => undefined));
+    commitResponse(panel);
+    const lifecycleSignal = (panel as unknown as { signal: AbortSignal }).signal;
+    const invocation = dispatchAgentSubmit(form(panel));
+
+    panel.destroy();
+    panel.showGatedCta(PanelGateReason.FREE_TIER, () => undefined);
+    panel.unlockPanel();
+
+    await expectRetryableFailure(invocation.response, 'panel_unavailable');
+    expect(lifecycleSignal.aborted).toBe(false);
+    vi.advanceTimersByTime(0);
+    expect(lifecycleSignal.aborted).toBe(true);
+  });
+
+  it('preserves unknown country coverage on zero results and bounds applied filter names', async () => {
+    const panel = mount(() => new Promise<void>(() => undefined));
+    commitResponse(panel);
+
+    const invocation = dispatchAgentSubmit(form(panel));
+    const appliedFilters = [
+      'country',
+      ...Array.from({ length: 19 }, (_, index) => `filter-${index}-${'x'.repeat(40)}`),
+    ];
+    panel.update(response({
+      total: 0,
+      countryCoverage: 'unknown',
+      appliedFilters,
+    }));
+
+    const result = await invocation.response;
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('Expected a successful zero-result summary');
+    expect(result.matchCount).toBe(0);
+    expect(result.countryCoverage).toBe('unknown');
+    expect(result.appliedFilters).toHaveLength(16);
+    expect(result.appliedFilters[0]).toBe('country');
+    expect(result.appliedFilters.every((filter) => filter.length <= 32)).toBe(true);
+    expect(result.appliedFiltersTruncated).toBe(true);
+  });
+
+  it('keeps the complete serialized tool result within the WebMCP response budget', async () => {
+    const panel = mount(() => new Promise<void>(() => undefined));
+    commitResponse(panel);
+    const invocation = dispatchAgentSubmit(form(panel));
+    const escapedText = String.fromCharCode(0).repeat(64);
+
+    panel.update(response({
+      total: Number.MAX_SAFE_INTEGER,
+      availability: escapedText,
+      appliedFilters: Array.from({ length: 16 }, () => escapedText),
+      sourceStatuses: Array.from({ length: 8 }, (_, index) => sourceStatus(index, {
+        source: escapedText,
+        state: escapedText,
+      })),
+    }));
+
+    const result = await invocation.response;
+    expect(result.ok).toBe(true);
+    expect(JSON.stringify(result).length).toBeLessThanOrEqual(1_500);
+    if (!result.ok) throw new Error('Expected a bounded success result');
+    expect(result.appliedFiltersTruncated || result.sourceStatusesTruncated).toBe(true);
+  });
+
+  it('resolves cancellation and never lets a late request answer the canceled invocation', async () => {
+    const requestCompletion = deferred<void>();
+    let requestSignal: AbortSignal | null = null;
+    let lateUpdateApplied = false;
+    let panel!: GlobalProcurementPanel;
+    panel = mount((_filters, _append, signal) => {
+      requestSignal = signal;
+      return requestCompletion.promise.then(() => {
+        if (signal.aborted) return;
+        lateUpdateApplied = true;
+        panel.update(response({ total: 99 }));
+      });
+    });
+    commitResponse(panel);
+
+    const invocation = dispatchAgentSubmit(form(panel));
+    dispatchToolEvent('toolcancel');
+    await expectRetryableFailure(invocation.response, 'canceled');
+    expectSignalAborted(requestSignal);
+
+    requestCompletion.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(lateUpdateApplied).toBe(false);
+    expect(panel.getElement().textContent).not.toContain('99 matching opportunities');
+    expect(form(panel).classList.contains('webmcp-tool-active')).toBe(false);
+    expect(form(panel).getAttribute('toolname')).toBe('search_procurement');
+  });
+
+  it('guards pending controls while keeping Reset available to abort the request', async () => {
+    const requestCompletion = deferred<void>();
+    let requestSignal: AbortSignal | null = null;
+    const panel = mount((_filters, _append, signal) => {
+      requestSignal = signal;
+      return requestCompletion.promise;
+    });
+    commitResponse(panel);
+
+    const currentForm = form(panel);
+    const query = currentForm.elements.namedItem('query') as HTMLInputElement;
+    query.value = 'cloud';
+    const invocation = dispatchAgentSubmit(currentForm);
+
+    let mousedownReachedPanel = false;
+    panel.getElement().addEventListener('mousedown', () => {
+      mousedownReachedPanel = true;
+    });
+    const mousedown = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    query.dispatchEvent(mousedown);
+    expect(mousedown.defaultPrevented).toBe(true);
+    expect(mousedownReachedPanel).toBe(false);
+
+    const keydown = new KeyboardEvent('keydown', {
+      key: 'x',
+      bubbles: true,
+      cancelable: true,
+    });
+    query.dispatchEvent(keydown);
+    expect(keydown.defaultPrevented).toBe(true);
+    const tab = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    query.dispatchEvent(tab);
+    expect(tab.defaultPrevented).toBe(false);
+    query.value = 'tampered';
+    query.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
+    expect(query.value).toBe('cloud');
+
+    const reset = currentForm.querySelector<HTMLButtonElement>('[data-procurement-reset]');
+    expect(reset?.hasAttribute('aria-disabled')).toBe(false);
+    reset?.click();
+
+    await expectRetryableFailure(invocation.response, 'canceled');
+    expectSignalAborted(requestSignal);
+    expect(currentForm.isConnected).toBe(true);
+    vi.advanceTimersByTime(0);
+    expect(currentForm.isConnected).toBe(false);
+    expect((form(panel).elements.namedItem('query') as HTMLInputElement).value).toBe('');
+
+    requestCompletion.resolve();
+    await Promise.resolve();
+    expect((form(panel).elements.namedItem('query') as HTMLInputElement).value).toBe('');
+  });
+
+  it('clears agent activation when the form reset algorithm runs', () => {
+    const panel = mount(() => undefined);
+    commitResponse(panel);
+    const currentForm = form(panel);
+    dispatchToolEvent('toolactivated');
+    expect(currentForm.classList.contains('webmcp-tool-active')).toBe(true);
+
+    currentForm.reset();
+    expect(currentForm.classList.contains('webmcp-tool-active')).toBe(false);
+    expect(currentForm.getAttribute('toolname')).toBe('search_procurement');
+  });
+
+  it('restores applied filters when lifecycle cancellation aborts a human request', () => {
+    let requestSignal: AbortSignal | null = null;
+    const panel = mount((_filters, _append, signal) => {
+      requestSignal = signal;
+      return new Promise<void>(() => undefined);
+    });
+    commitResponse(panel);
+    const currentForm = form(panel);
+    (currentForm.elements.namedItem('query') as HTMLInputElement).value = 'roads';
+    currentForm.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    panel.hide();
+    panel.show();
+
+    expectSignalAborted(requestSignal);
+    expect((form(panel).elements.namedItem('query') as HTMLInputElement).value).toBe('');
+    expect(panel.getElement().textContent).toContain('Showing 0 of 0 matching opportunities');
+  });
+
+  it('restores human filters before a gate snapshots and later unlocks the form', () => {
+    let requestSignal: AbortSignal | null = null;
+    const panel = mount((_filters, _append, signal) => {
+      requestSignal = signal;
+      return new Promise<void>(() => undefined);
+    });
+    commitResponse(panel);
+    const currentForm = form(panel);
+    (currentForm.elements.namedItem('query') as HTMLInputElement).value = 'roads';
+    currentForm.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+
+    panel.showGatedCta(PanelGateReason.FREE_TIER, () => undefined);
+    expectSignalAborted(requestSignal);
+    panel.unlockPanel();
+
+    const restoredForm = form(panel);
+    expect((restoredForm.elements.namedItem('query') as HTMLInputElement).value).toBe('');
+    expect([...restoredForm.elements].every((control) => !control.hasAttribute('disabled'))).toBe(true);
+    expect(restoredForm.getAttribute('toolname')).toBe('search_procurement');
+  });
+
+  it('resolves unavailable and non-settling requests as explicit retryable failures', async () => {
+    const unavailableCompletion = deferred<void>();
+    const unavailablePanel = mount(() => unavailableCompletion.promise);
+    commitResponse(unavailablePanel);
+    const unavailableInvocation = dispatchAgentSubmit(form(unavailablePanel));
+    unavailablePanel.update(response({ dataAvailable: false, availability: 'unavailable' }));
+    unavailableCompletion.resolve();
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+    await expectRetryableFailure(unavailableInvocation.response, 'procurement_unavailable');
+    expect(form(unavailablePanel).hasAttribute('toolname')).toBe(false);
+
+    const nonSettlingPanel = mount(async () => undefined);
+    commitResponse(nonSettlingPanel);
+    const nonSettlingInvocation = dispatchAgentSubmit(form(nonSettlingPanel));
+    await expectRetryableFailure(nonSettlingInvocation.response, 'request_did_not_settle');
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+    expect(form(nonSettlingPanel).getAttribute('toolname')).toBe('search_procurement');
+  });
+
+  it('keeps human submit, reset, and load-more behavior on the shared request path', () => {
+    const handler = vi.fn(() => new Promise<void>(() => undefined));
+    const panel = mount(handler);
+    commitResponse(panel, response({ nextCursor: '25', total: 50 }));
+
+    const currentForm = form(panel);
+    (currentForm.elements.namedItem('query') as HTMLInputElement).value = 'roads';
+    currentForm.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    expect(handler).toHaveBeenLastCalledWith(
+      expect.objectContaining({ query: 'roads', cursor: '' }),
+      false,
+      expect.any(AbortSignal),
+    );
+
+    panel.update(response({ nextCursor: '25', total: 50 }));
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+    panel.getElement().querySelector<HTMLButtonElement>('[data-procurement-load-more]')?.click();
+    expect(handler).toHaveBeenLastCalledWith(
+      expect.objectContaining({ query: 'roads', cursor: '25' }),
+      true,
+      expect.any(AbortSignal),
+    );
+
+    panel.update(response());
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+    panel.getElement().querySelector<HTMLButtonElement>('[data-procurement-reset]')?.click();
+    expect(handler).toHaveBeenLastCalledWith(expect.objectContaining({
+      query: '',
+      buyer: '',
+      country: '',
+      source: '',
+      sort: 'closing_soon',
+      cursor: '',
+      minAutomationScore: 0,
+    }), false, expect.any(AbortSignal));
+  });
+});


### PR DESCRIPTION
## Summary

Adds a declarative WebMCP `search_procurement` tool to the Global Procurement panel and hardens its request lifecycle.

closes #6213 

Key changes:


- Returns bounded, structured success and retryable failure results.
- Preserves country-coverage and applied-filter semantics.
- Keeps the declaring form stable while an invocation is active.
- Blocks conflicting pointer and keyboard interactions while preserving accessibility.
- Propagates cancellation through the panel, data loader, RPC, and circuit breaker.
- Restores filters and ignores stale results after cancellation.
- Handles hidden, gated, unlocked, mobile, and destroyed panel states safely.
- Adds regression coverage for lifecycle, cancellation, accessibility, and stale-request races.

Validation:

- `npm run typecheck`
- `npm run typecheck:dom-tests`
- Full DOM suite: 46 files and 403 tests passed
- Circuit-breaker tests: 3 passed
- Boundary lint and focused Biome checks passed

## Type of change

- [x] Bug fix
- [x] New feature


## Affected areas

- [x] Other: Global Procurement panel and declarative WebMCP integration

## Checklist

- [x] Tested on [[worldmonitor.app](https://worldmonitor.app/)](https://worldmonitor.app) variant
- [x] Tested on [[tech.worldmonitor.app](https://tech.worldmonitor.app/)](https://tech.worldmonitor.app) variant (N/A — no tech-specific behavior changed)
- [x] New RSS feed domains added to `api/rss-proxy.js` allowlist (N/A — no feeds added)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] New or repointed health probes have a completed Railway-side pre-seed, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (N/A — no health probes changed)


- [x] Claim ledger attached or linked (N/A)
- [x] All required Audit Council role signoffs attached (N/A)
- [x] Generated docs regenerated from proto where applicable (N/A — no proto changes)
- [x] Fixture-backed examples recomputed (N/A)
- [x] Redis writers/readers enumerated for every documented key (N/A)

