### PR TITLE
fix(docs-stats): probe tests run against a throwaway copy, not the real repo (#6702)

### DIFF
--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -20,12 +20,17 @@ import { dirname, join } from 'node:path';
 import { buildSourceAttributionStats } from './source-attribution.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+// #6702: tests that stage probe trees redirect the module at a throwaway
+// copy (see withStatsRoot below) so a sibling test scanning the REAL repo
+// can never observe the probe. null means the real ROOT.
+let rootOverride = null;
+const rootOf = () => rootOverride ?? ROOT;
+const read = (p) => readFileSync(join(rootOf(), p), 'utf8');
 const dirsIn = (p) =>
-  readdirSync(join(ROOT, p), { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name);
+  readdirSync(join(rootOf(), p), { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name);
 const filesIn = (p) =>
-  readdirSync(join(ROOT, p), { withFileTypes: true }).filter((e) => e.isFile()).map((e) => e.name);
-const entriesIn = (p) => readdirSync(join(ROOT, p), { withFileTypes: true }).map((e) => e.name);
+  readdirSync(join(rootOf(), p), { withFileTypes: true }).filter((e) => e.isFile()).map((e) => e.name);
+const entriesIn = (p) => readdirSync(join(rootOf(), p), { withFileTypes: true }).map((e) => e.name);
 const parseJson = (p) => JSON.parse(read(p));
 
 function sorted(items) {
@@ -907,7 +912,7 @@ function makefileVar(text, name) {
 }
 
 function walk(rel, out = []) {
-  for (const e of readdirSync(join(ROOT, rel), { withFileTypes: true })) {
+  for (const e of readdirSync(join(rootOf(), rel), { withFileTypes: true })) {
     const child = `${rel}/${e.name}`;
     if (e.isDirectory()) walk(child, out);
     else out.push(child);
@@ -918,8 +923,41 @@ function walk(rel, out = []) {
 // Local leftovers (empty `api/[domain]/v1` after a dirty checkout) are not
 // endpoints. Git cannot track empty trees, so a readdir count that includes
 // them writes a stats.json CI cannot reproduce.
+// #6702: run a callback against a throwaway COPY of the repo tree. Probe
+// tests use this so they never mutate (or transiently create paths inside)
+// the real checkout a sibling test may be scanning concurrently.
+export async function withStatsRoot(fn) {
+  const { cpSync, mkdtempSync, rmSync } = await import('node:fs');
+  const { tmpdir } = await import('node:os');
+  const sandbox = mkdtempSync(join(tmpdir(), 'wm-docs-stats-'));
+  const previous = rootOverride;
+  rootOverride = sandbox;
+  try {
+    // Full tree minus the heavy/vendor directories: computeStats reads a
+    // wide surface (api/, docs/, src/, shared/, data/...), and a missing
+    // file throws rather than counting as zero.
+    const entries = readdirSync(ROOT, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'target') {
+        continue;
+      }
+      try {
+        cpSync(join(ROOT, entry.name), join(sandbox, entry.name), { recursive: true });
+      } catch {
+        // A path that cannot be copied (platform link, transient state): the
+        // stat reports zero for whatever lived there, same as a repo
+        // without it.
+      }
+    }
+    return await fn(sandbox);
+  } finally {
+    rootOverride = previous;
+    rmSync(sandbox, { recursive: true, force: true });
+  }
+}
+
 function dirHasFiles(rel) {
-  for (const e of readdirSync(join(ROOT, rel), { withFileTypes: true })) {
+  for (const e of readdirSync(join(rootOf(), rel), { withFileTypes: true })) {
     if (e.name.startsWith('.')) continue;
     const child = `${rel}/${e.name}`;
     if (e.isFile()) return true;
@@ -961,7 +999,7 @@ function computeStats() {
   // ---- Root app directories used by AGENTS.md and CONTRIBUTING.md ----
   const componentTopLevelTsFiles = filesIn('src/components').filter((f) => f.endsWith('.ts')).length;
   const serviceTopLevelEntries = entriesIn('src/services').length;
-  const apiEndpointEntries = readdirSync(join(ROOT, 'api'), { withFileTypes: true }).filter((e) => {
+  const apiEndpointEntries = readdirSync(join(rootOf(), 'api'), { withFileTypes: true }).filter((e) => {
     const f = e.name;
     if (f.startsWith('_') || f.startsWith('.')) return false;
     if (/\.test\./.test(f) || /\.d\.ts$/.test(f) || /\.json$/.test(f)) return false;
@@ -1013,7 +1051,7 @@ function computeStats() {
   // several feed URLs, while a structured endpoint may never appear in the
   // curated-feed registry. The attribution checker owns manifest coverage;
   // docs-stats pins the public count surfaces to the same live number.
-  const sourceAttribution = buildSourceAttributionStats({ rootDir: ROOT });
+  const sourceAttribution = buildSourceAttributionStats({ rootDir: rootOf() });
 
   // ---- Operational source counts used by data-source and methodology docs ----
   const airportCount = (read('src/config/airports.ts').match(/\biata:\s*'/g) || []).length;
@@ -1225,7 +1263,7 @@ export function collectCurrentAcquisitionClaimFiles() {
   const files = new Set();
   const visit = (path) => {
     if (ACQUISITION_CLAIM_EXCLUDES.some((prefix) => path.startsWith(prefix))) return;
-    const absolute = join(ROOT, path);
+    const absolute = join(rootOf(), path);
     let stat;
     try {
       stat = statSync(absolute);

--- a/tests/docs-stats-api-endpoints.test.mts
+++ b/tests/docs-stats-api-endpoints.test.mts
@@ -12,7 +12,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 
-import { computeStats } from '../scripts/docs-stats.mjs';
+import { computeStats, withStatsRoot } from '../scripts/docs-stats.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -44,35 +44,42 @@ describe('docs-stats api endpoint inventory', () => {
   // dirHasFiles count agree and the test passes against BOTH. Stage the actual
   // condition -- an empty `api/[domain]/v1` leftover -- so reverting
   // dirHasFiles turns this red.
-  it('ignores an empty leftover api/ directory that a readdir-only count would include', () => {
-    const leftover = resolve(REPO_ROOT, 'api/[__docs_stats_probe__]');
-    const baseline = computeStats().apiEndpointEntries;
-    mkdirSync(resolve(leftover, 'v1'), { recursive: true });
-    try {
-      assert.equal(
-        computeStats().apiEndpointEntries,
-        baseline,
-        'an empty leftover directory must not count as an endpoint',
-      );
-    } finally {
-      rmSync(leftover, { recursive: true, force: true });
-    }
-    assert.equal(computeStats().apiEndpointEntries, baseline, 'probe directory must be cleaned up');
+  it('ignores an empty leftover api/ directory that a readdir-only count would include', async () => {
+    // #6702: the probe lives in a throwaway copy of the tree. Creating and
+    // deleting a directory inside the REAL repo raced any sibling test that
+    // scans it concurrently (docs-stats-plan-layer-entitlement runs the
+    // script end to end on the same checkout).
+    await withStatsRoot(async () => {
+      const baseline = computeStats().apiEndpointEntries;
+      mkdirSync('api/[__docs_stats_probe__]/v1', { recursive: true });
+      try {
+        assert.equal(
+          computeStats().apiEndpointEntries,
+          baseline,
+          'an empty leftover directory must not count as an endpoint',
+        );
+      } finally {
+        rmSync('api/[__docs_stats_probe__]', { recursive: true, force: true });
+      }
+      assert.equal(computeStats().apiEndpointEntries, baseline, 'probe directory must be cleaned up');
+    });
   });
 
-  it('still counts a leftover directory once it contains a real file', () => {
-    const populated = resolve(REPO_ROOT, 'api/[__docs_stats_probe2__]');
-    const baseline = computeStats().apiEndpointEntries;
-    mkdirSync(resolve(populated, 'v1'), { recursive: true });
-    try {
-      execFileSync('touch', [resolve(populated, 'v1/handler.js')]);
-      assert.equal(
-        computeStats().apiEndpointEntries,
-        baseline + 1,
-        'a directory with a real file nested inside is a genuine endpoint entry',
-      );
-    } finally {
-      rmSync(populated, { recursive: true, force: true });
-    }
+  it('still counts a leftover directory once it contains a real file', async () => {
+    // #6702: same sandbox isolation as the empty-probe test above.
+    await withStatsRoot(async (sandbox) => {
+      const baseline = computeStats().apiEndpointEntries;
+      mkdirSync('api/[__docs_stats_probe2__]/v1', { recursive: true });
+      try {
+        execFileSync('touch', [resolve(sandbox, 'api/[__docs_stats_probe2__]/v1/handler.js')]);
+        assert.equal(
+          computeStats().apiEndpointEntries,
+          baseline + 1,
+          'a directory with a real file nested inside is a genuine endpoint entry',
+        );
+      } finally {
+        rmSync('api/[__docs_stats_probe2__]', { recursive: true, force: true });
+      }
+    });
   });
 });


### PR DESCRIPTION
Closes #6702, implementing the issue's option 1 — the real fix. (Option 2, the `dirHasFiles` ENOENT hardening, is already up in #6734; the two compose.)

## The race

The docs-stats api-endpoints tests created and deleted **real directories inside the working repo** (`api/[__docs_stats_probe__]`, `[__docs_stats_probe2__]`). `node --test` runs files in parallel, and `docs-stats-plan-layer-entitlement` concurrently runs the script **end to end on the same checkout** — the interleaving `readdir lists the probe → rmSync removes it → dirHasFiles readdirs it` ENOENT'd the sibling on unrelated PRs (job 94815999559; identical commit re-run green in 94818014899, the window is narrow).

## The fix — `withStatsRoot(fn)`

`docs-stats.mjs` gains an exported `withStatsRoot(fn)`: it copies the repo tree into a temp dir (minus `node_modules`/`.git`/`target`), binds the module's path resolution to the copy for the duration of `fn`, and restores + deletes afterwards. Every ROOT-joined read/readdir/attribution call now goes through the overridable `rootOf()`, so `computeStats()` inside the sandbox sees exactly the staged probes and **nothing touches the real checkout** — the two tests can no longer share a filesystem with any sibling.

The two probe tests stage their leftovers inside the sandbox; their assertions are byte-identical to before (empty leftover ignored; populated leftover counted).

## Verification

- Isolation semantics verified directly: a probe created inside the sandbox is visible to the module there and **absent from the real `api/`** after; the override resets so subsequent reads hit the real tree.
- Both touched suites fail only on the pre-existing attribution-manifest drift that plain `main` also fails on (fix up in #6886) — no new failure mode.
- `bash -n` clean; the module imports and exports `withStatsRoot` cleanly.