### PR TITLE
ci: keep Umami Postgres tests, stop running them on unrelated PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,9 @@ jobs:
           echo "validation=$( [ "$VALIDATION" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
           # Umami's database race cannot be covered by the normal no-Docker
           # unit suite. Run a real PostgreSQL gate only when its managed image,
-          # migration, patch, focused tests, or this workflow changes.
+          # migration, patch, or focused tests change. Do not trigger on every
+          # Test workflow edit: unit already pins the job shape, and rebuilding
+          # two Umami images is the cost that made this look like a per-PR tax.
           UMAMI=$(echo "$FILES" | awk '
             /^\.dockerignore$/ { count++ }
             /^Dockerfile\.umami$/ { count++ }
@@ -106,7 +108,6 @@ jobs:
             /^docker\/umami\// { count++ }
             /^scripts\/umami-retention\.sql$/ { count++ }
             /^tests\/umami-(runtime-remediation\.test|postgres-integration|runtime-write-probe)\.mjs$/ { count++ }
-            /^\.github\/workflows\/test\.yml$/ { count++ }
             END { print count + 0 }
           ')
           echo "umami=$( [ "$UMAMI" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
@@ -631,9 +632,13 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  # The focused suite is already inside `unit` / test:data. This job exists
+  # only for validation-docs PRs that skip `unit` (docs/ is carved out of
+  # `code`). Running it on every code PR paid a second npm ci for the same
+  # files.
   resilience-validation-smoke:
     needs: changes
-    if: needs.changes.outputs.code == 'true' || needs.changes.outputs.validation == 'true'
+    if: needs.changes.outputs.validation == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
+          # Specialized jobs (desktop-rust, umami, digest, …) are path-filtered
+          # on PRs. Do the same on push to main. Forcing them true here used to
+          # compile the Tauri crate and rebuild Umami images on every merge —
+          # weather, news, embed — which is not a desktop or analytics gate.
+          # Fail open (run everything) only when we cannot see the file list:
+          # a zero parent SHA, a compare error, or GitHub's 300-file cap.
+          emit_all_true() {
             echo "code=true" >> "$GITHUB_OUTPUT"
             echo "digest=true" >> "$GITHUB_OUTPUT"
             echo "validation=true" >> "$GITHUB_OUTPUT"
@@ -34,10 +40,31 @@ jobs:
             echo "consumer_prices=true" >> "$GITHUB_OUTPUT"
             echo "desktop_config=true" >> "$GITHUB_OUTPUT"
             echo "desktop_rust=true" >> "$GITHUB_OUTPUT"
-            exit 0
+          }
+          ZERO=0000000000000000000000000000000000000000
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BEFORE="${{ github.event.before }}"
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "$ZERO" ]; then
+              echo "No usable parent SHA; running every Test job."
+              emit_all_true
+              exit 0
+            fi
+            if ! FILES=$(gh api "repos/${{ github.repository }}/compare/${BEFORE}...${{ github.sha }}" \
+              --jq '.files[]?.filename'); then
+              echo "Compare API failed; running every Test job."
+              emit_all_true
+              exit 0
+            fi
+            FILE_COUNT=$(printf '%s\n' "$FILES" | grep -c . || true)
+            if [ "$FILE_COUNT" -ge 300 ]; then
+              echo "Compare listing is truncated at 300 files; running every Test job."
+              emit_all_true
+              exit 0
+            fi
+          else
+            FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
+              --paginate --jq '.[].filename')
           fi
-          FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
-            --paginate --jq '.[].filename')
           CODE=$(echo "$FILES" | awk '
             /^docs\/research\/seo-ai-visibility\// { count++; next }
             # Committed resilience acceptance artifacts are docs-path data that
@@ -146,10 +173,13 @@ jobs:
             END { print count + 0 }
           ')
           echo "desktop_config=$( [ "$DESKTOP_CONFIG" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+          # Compile the Tauri crate only when the crate itself changes.
+          # Workflow edits are covered by desktop-config (cheap) and by the
+          # unit contract that pins this job's shape — they must not pay
+          # cargo test --locked (45 min budget) the way test.yml used to.
           DESKTOP_RUST=$(echo "$FILES" | awk '
             /^src-tauri\/sidecar\// { next }
-            /^src-tauri\// { count++; next }
-            /^\.github\/workflows\/test\.yml$/ { count++ }
+            /^src-tauri\// { count++ }
             END { print count + 0 }
           ')
           echo "desktop_rust=$( [ "$DESKTOP_RUST" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -857,6 +857,37 @@ describe('CI workflow coverage', () => {
     }
   });
 
+  it('runs resilience-validation-smoke only when validation inputs change', () => {
+    const job = testJobBlock('resilience-validation-smoke');
+    assert.match(
+      job,
+      /\n {4}if: needs\.changes\.outputs\.validation == 'true'\n/,
+      'the smoke job is the validation-docs path; unit already runs the same files on code PRs',
+    );
+    assert.doesNotMatch(
+      job,
+      /outputs\.code == 'true'/,
+      'a second npm ci on every code PR re-runs tests already inside test:data',
+    );
+  });
+
+  it('does not rebuild Umami images for an unrelated Test workflow edit', () => {
+    const umamiFilter = shellAwkAssignmentBlock('UMAMI');
+    assert.equal(
+      evaluateAwkAssignmentBlock(umamiFilter, ['.github/workflows/test.yml']),
+      0,
+      'editing test.yml must not set umami=true — unit pins the job shape',
+    );
+    assert.ok(
+      evaluateAwkAssignmentBlock(umamiFilter, ['Dockerfile.umami']) > 0,
+      'Dockerfile.umami must still set umami=true',
+    );
+    assert.ok(
+      evaluateAwkAssignmentBlock(umamiFilter, ['scripts/umami-retention.sql']) > 0,
+      'the retention SQL must still set umami=true',
+    );
+  });
+
   it('routes the root Docker context policy into image build jobs', () => {
     for (const variable of ['DIGEST', 'UMAMI']) {
       const awkBlock = shellAwkAssignmentBlock(variable);

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -116,7 +116,6 @@ const REQUIRED_DESKTOP_CONFIG_INPUTS = [
 const REQUIRED_DESKTOP_RUST_INPUTS = [
   'src-tauri/sidecar/',
   'src-tauri/',
-  '.github/workflows/test.yml',
 ] as const;
 
 function escapeRegExp(value: string): string {
@@ -871,6 +870,31 @@ describe('CI workflow coverage', () => {
     );
   });
 
+  it('path-filters Test jobs on push to main instead of compiling everything', () => {
+    const changes = testWorkflow.slice(testWorkflow.indexOf('id: diff'));
+    const pushGate = changes.slice(0, changes.indexOf('CODE=$('));
+    assert.match(
+      pushGate,
+      /compare\/\$\{BEFORE\}\.\.\.\$\{\{ github\.sha \}\}/,
+      'push to main must classify files from the compare API',
+    );
+    assert.match(
+      pushGate,
+      /No usable parent SHA; running every Test job/,
+      'a zero parent SHA must fail open',
+    );
+    assert.match(
+      pushGate,
+      /Compare listing is truncated at 300 files; running every Test job/,
+      'a truncated compare must fail open',
+    );
+    assert.match(pushGate, /emit_all_true/);
+    assert.ok(
+      pushGate.indexOf('compare/${BEFORE}') < pushGate.lastIndexOf('emit_all_true'),
+      'the compare must run; fail-open is only the truncated/error path',
+    );
+  });
+
   it('does not rebuild Umami images for an unrelated Test workflow edit', () => {
     const umamiFilter = shellAwkAssignmentBlock('UMAMI');
     assert.equal(
@@ -935,6 +959,21 @@ describe('CI workflow coverage', () => {
         `test.yml desktop_rust filter must cover ${input}`,
       );
     }
+    assert.equal(
+      evaluateAwkAssignmentBlock(desktopRustFilter, ['src-tauri/src/lib.rs']),
+      1,
+      'desktop-rust must compile when the Tauri crate changes',
+    );
+    assert.equal(
+      evaluateAwkAssignmentBlock(desktopRustFilter, ['src-tauri/sidecar/local-api-server.js']),
+      0,
+      'desktop-rust must skip sidecar-only changes (those ride the code filter)',
+    );
+    assert.equal(
+      evaluateAwkAssignmentBlock(desktopRustFilter, ['.github/workflows/test.yml']),
+      0,
+      'desktop-rust must not compile the Tauri crate for a Test workflow edit',
+    );
     assert.match(
       testJobBlock('desktop-config'),
       /if: needs\.changes\.outputs\.desktop_config == 'true'/,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refute: do **not** delete `umami-postgres`. That job is a local Postgres integration gate for the session-data migration, the concurrent upsert race (#6024), and the retention SQL (#6375). A Railway disk monitor cannot replace it, and we already have one: `umami-storage-monitor.yml` (15-minute cron on volume usage + retention-runner health).

What *was* senseless is the CI tax:

- Any edit to `.github/workflows/test.yml` rebuilt both Umami images.
- `resilience-validation-smoke` ran a second `npm ci` on every code PR for files already executed by `unit` / `test:data`.
- **Every push to `main` forced `desktop-rust=true`.** That job is `cargo test --locked` of the Tauri crate (45 min budget). It compiled on weather, news, embed, and demographics merges that did not touch `src-tauri/`. Cache hits were ~1 min; cold/cancelled runs went to ~14–45 min. Not critical on every push — only when the crate changes.

This PR keeps the Umami and desktop-rust gates, path-filters them on PRs **and** on push to main (compare API; fail open if the parent SHA is missing, compare fails, or GitHub truncates at 300 files), and restricts the resilience smoke to `validation == true`.

## Type of change

- [x] CI / Build / Infrastructure

## Affected areas

- [x] Other: PR and main-push CI path filters (`umami-postgres`, `desktop-rust`, `resilience-validation-smoke`)

## Checklist

- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`) — not applicable; workflow + contract tests only
- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — N/A (CI path filters)
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A

## Documentation Alignment Checklist

- [ ] N/A — this PR does not publish or change documentation claims

## Verification

```text
node --import tsx --test tests/ci-workflow-coverage.test.mts
# 30 passed, 0 failed
```

Contract tests now pin: Umami and desktop-rust stay off for `test.yml`-only edits; desktop-rust compiles only for `src-tauri/` (not sidecar); push to main uses the compare API instead of forcing every specialized job.

## Review

**Kept (not superfluous)**

- `umami-postgres` + write probe: real Postgres, path-filtered
- `desktop-rust`: real `cargo test` when the Tauri crate changes
- `umami-storage-monitor.yml`: production volume / days-to-full, scheduled
- `variant-smoke-full`, `consumer-prices`, `digest-image`: path-gated or the product smoke

**Tightened**

- Push to main no longer forces `desktop_rust` / `umami` / `digest` / … true
- Umami and desktop-rust filters no longer include `test.yml`
- `resilience-validation-smoke` only when `validation` inputs change

**Also noted, not changed**

- `typecheck.yml` / `lint-code.yml` still force `code=true` on push. Those are cheap tsc/biome, not a 45-minute crate compile.
- `digest-image` still has a wide path filter (`scripts/`, `api/`, …). That is an image-build smoke, not a duplicate of `test:data`.
- Railway native disk monitors (Observability → Disk Usage → Add monitor) are the right *notify* path. They do not replace the Umami integration test.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a015c9-5630-7652-bbef-10a5f14173b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a015c9-5630-7652-bbef-10a5f14173b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

