### PR TITLE
fix(sentry): give the marketing surface a real filtering policy

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -1,0 +1,115 @@
+/**
+ * Marketing-surface Sentry filtering policy.
+ *
+ * `/` (rewritten to `/pro/welcome.html`) and `/pro` render from this bundle,
+ * whose Sentry client is a SEPARATE `@sentry/react` init (`./sentry.ts`). The
+ * dashboard's ~250-entry `ignoreErrors` array and its `beforeSend` live in
+ * `src/bootstrap/sentry-init.ts` and never run here, so browser/extension noise
+ * the dashboard has filtered for months still lands as marketing-surface
+ * issues. The 2026-08-19 triage found five, every one sent by
+ * `sentry.javascript.react` with a null release (the dashboard SDK reports as
+ * `sentry.javascript.browser` and always carries `worldmonitor@<version>`):
+ * WORLDMONITOR-ZY, -ZX, -ZZ, -ZW and -15. WORLDMONITOR-15 is named in the
+ * dashboard's own suppressor comment in `src/bootstrap/sentry-init.ts` — it has
+ * been dropped there since #4005 and leaked here the whole time.
+ *
+ * Deliberately NOT a copy of the dashboard array. Those entries were vetted
+ * against the dashboard bundle (deck.gl / MapLibre / Convex / IndexedDB);
+ * copying them wholesale would suppress messages this React bundle genuinely
+ * can emit, which is the exact observability blind spot `ignoreErrors` is
+ * supposed to avoid. Only patterns impossible from ANY first-party bundle
+ * belong here — anything that could come from our own minified output goes in
+ * `marketingBeforeSend` behind the first-party-frame gate instead.
+ *
+ * Kept dependency-free (no `@sentry/react` import) so
+ * `tests/pro-sentry-filter-policy.test.mts` can import the real values rather
+ * than re-deriving them from source text — same reason as `./sentry-allow-urls.ts`.
+ */
+
+/** Minimal structural view of the Sentry event fields this policy reads. */
+interface PolicyFrame {
+  filename?: string;
+}
+interface PolicyException {
+  value?: string;
+  stacktrace?: { frames?: PolicyFrame[] };
+}
+export interface PolicyEvent {
+  exception?: { values?: PolicyException[] };
+}
+
+export const MARKETING_IGNORE_ERRORS: RegExp[] = [
+  /ResizeObserver loop/,
+  /^TypeError: Load failed/,
+  /^TypeError: Failed to fetch/,
+  /^TypeError: NetworkError/,
+  /Non-Error promise rejection captured with value:/,
+  // WKWebView host-app JS bridge timeout — Apple WebKit emits this exact phrase
+  // when a JS-to-native `postMessage` gets no reply within the host's window.
+  // Common in the in-app browsers that open marketing links (DuckDuckGo,
+  // Instagram, Reddit). We never postMessage to a WKScriptMessageHandler, so it
+  // is browser-native and unactionable. Verbatim from the dashboard array,
+  // where it has run since WORLDMONITOR-KJ (WORLDMONITOR-ZY).
+  /WKWebView API client did not respond to this postMessage/,
+  // Browser-extension messaging API. `chrome.runtime`/`browser.runtime` is only
+  // reachable from an extension context; this bundle never calls it, so the
+  // rejection always belongs to an extension injected into the page
+  // (WORLDMONITOR-ZX).
+  /runtime\.sendMessage\(\)/,
+];
+
+/** Sentry's own hashed SDK chunk — infrastructure, never evidence of our code. */
+const SENTRY_CHUNK_FRAME = /\/assets\/sentry-[A-Za-z0-9_-]+\.js/;
+/** Marketing bundle output. `pro-test/vite.config.ts` sets `base: '/pro/'`. */
+const MARKETING_ASSET_FRAME = /\/pro\/assets\/[A-Za-z0-9_-]+\.js/;
+/** A whole message that is nothing but a short identifier. */
+const BARE_SYMBOL_MESSAGE = /^[a-zA-Z_$]+$/;
+/**
+ * Every browser phrasing for "a module failed to load or link". Chrome/Edge
+ * `Failed to fetch dynamically imported module`, Safari `Importing a module
+ * script failed.`, Firefox `error loading dynamically imported module`, and the
+ * link-time counterpart `Importing binding name '<x>' is not found.`
+ */
+const MODULE_LOAD_FAILURE =
+  /(?:Failed to fetch|error loading) dynamically imported module|Importing a module script failed|Importing binding name '[^']*' is not found/i;
+
+/**
+ * Stack-gated suppressors for messages that our own minified bundle COULD
+ * produce, so they must not go in `MARKETING_IGNORE_ERRORS` (which matches on
+ * message text alone, with no access to frames).
+ */
+export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
+  const msg = event.exception?.values?.[0]?.value ?? '';
+
+  // A message that is nothing but a 1-3 character identifier (`ga`, `Ba`) is an
+  // injected in-app-browser/extension script rethrowing its own minified
+  // symbol. Our bundles throw `Error` objects built from written-out strings;
+  // even minified, the *message* text survives verbatim, so a bare short
+  // identifier can never be ours. Unconditional (no frame gate) exactly as in
+  // the dashboard's `beforeSend`, where it is the first statement
+  // (WORLDMONITOR-ZZ, -ZW).
+  if (msg.length <= 3 && BARE_SYMBOL_MESSAGE.test(msg)) return null;
+
+  const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+  const nonInfraFrames = frames.filter(
+    (f) =>
+      f.filename &&
+      f.filename !== '<anonymous>' &&
+      f.filename !== '[native code]' &&
+      !SENTRY_CHUNK_FRAME.test(f.filename),
+  );
+  const hasFirstParty = nonInfraFrames.some(
+    (f) => /\.(ts|tsx)$/.test(f.filename ?? '') || MARKETING_ASSET_FRAME.test(f.filename ?? ''),
+  );
+
+  // Stale-chunk-after-deploy: the browser fires these as synthetic TypeErrors
+  // at fetch/link time, not at any first-party call site, so they arrive with
+  // zero frames. A built bundle always links consistently, so at runtime this
+  // is version skew (a hashed filename that 404s after a deploy), never a code
+  // defect. Gated on `!hasFirstParty` so a genuine `import()` regression inside
+  // our own code — which rides a `/pro/assets/*.js` frame — still surfaces
+  // (WORLDMONITOR-15).
+  if (!hasFirstParty && MODULE_LOAD_FAILURE.test(msg)) return null;
+
+  return event;
+}

--- a/pro-test/src/sentry.ts
+++ b/pro-test/src/sentry.ts
@@ -1,10 +1,15 @@
 import * as Sentry from '@sentry/react';
 
 import { SENTRY_ALLOW_URLS } from './sentry-allow-urls';
+import { MARKETING_IGNORE_ERRORS, marketingBeforeSend } from './sentry-filter-policy';
 
 /**
  * Shared Sentry bootstrap for both marketing entries (/pro and root welcome).
  * Must be imported before the React render in every entry's main file.
+ *
+ * The filtering policy lives in `./sentry-filter-policy.ts` (dependency-free so
+ * the guard can import the real values); read that file for why it is a small
+ * vetted set rather than a copy of the dashboard's array.
  */
 export function initSentry(): void {
   const sentryDsn = import.meta.env.VITE_SENTRY_DSN?.trim();
@@ -17,12 +22,7 @@ export function initSentry(): void {
     enabled: Boolean(sentryDsn) && !location.hostname.startsWith('localhost'),
     allowUrls: SENTRY_ALLOW_URLS,
     tracesSampleRate: 0.1,
-    ignoreErrors: [
-      /ResizeObserver loop/,
-      /^TypeError: Load failed/,
-      /^TypeError: Failed to fetch/,
-      /^TypeError: NetworkError/,
-      /Non-Error promise rejection captured with value:/,
-    ],
+    ignoreErrors: MARKETING_IGNORE_ERRORS,
+    beforeSend: (event) => marketingBeforeSend(event),
   });
 }

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -1,0 +1,169 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  MARKETING_IGNORE_ERRORS,
+  marketingBeforeSend,
+  type PolicyEvent,
+} from '../pro-test/src/sentry-filter-policy.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+/**
+ * The marketing surface (`/` and `/pro`) runs its own `@sentry/react` client,
+ * so none of `src/bootstrap/sentry-init.ts` applies to it. Every event below is
+ * a real production event pulled from the 2026-08-19 triage; each `sdk` was
+ * `sentry.javascript.react` with a null release, which is what distinguishes a
+ * marketing-bundle event from a dashboard one.
+ *
+ * Both halves matter. The suppression cases prove the policy fires; the KEEP
+ * cases are positive controls that prove each gate is load-bearing — delete the
+ * length bound or the `!hasFirstParty` gate and a KEEP case goes red instead of
+ * the suite staying green on absence alone.
+ */
+
+/**
+ * Sentry's InboundFilters tests a pattern against the exception value AND the
+ * combined `"<type>: <value>"` form — which is why entries like
+ * `/^TypeError: Load failed/` can anchor on the type prefix.
+ */
+function isIgnored(type: string, value: string): boolean {
+  return MARKETING_IGNORE_ERRORS.some((p) => p.test(value) || p.test(`${type}: ${value}`));
+}
+
+function event(value: string, filenames: string[] = []): PolicyEvent {
+  return {
+    exception: {
+      values: [{
+        value,
+        stacktrace: { frames: filenames.map((filename) => ({ filename })) },
+      }],
+    },
+  };
+}
+
+describe('marketing ignoreErrors', () => {
+  it('drops the WKWebView host-bridge timeout (WORLDMONITOR-ZY)', () => {
+    assert.equal(
+      isIgnored('Error', 'WKWebView API client did not respond to this postMessage'),
+      true,
+    );
+  });
+
+  it('drops the extension runtime.sendMessage rejection (WORLDMONITOR-ZX)', () => {
+    assert.equal(isIgnored('Error', 'Invalid call to runtime.sendMessage(). Tab not found.'), true);
+  });
+
+  // Positive control: the array must not have grown a pattern broad enough to
+  // swallow an ordinary marketing-bundle bug.
+  it('keeps a genuine first-party error message', () => {
+    assert.equal(
+      isIgnored('TypeError', "Cannot read properties of undefined (reading 'entitlement')"),
+      false,
+    );
+    assert.equal(isIgnored('Error', 'Dodo checkout session could not be created'), false);
+  });
+});
+
+describe('marketingBeforeSend — bare minified symbol', () => {
+  it('drops a whole-message minified symbol (WORLDMONITOR-ZZ "ga", -ZW "Ba")', () => {
+    // Real frames: the prerendered welcome document itself, from an iOS
+    // Google-app in-app browser injecting its own script.
+    assert.equal(marketingBeforeSend(event('ga', ['https://www.worldmonitor.app/'])), null);
+    assert.equal(marketingBeforeSend(event('Ba', ['https://www.worldmonitor.app/'])), null);
+  });
+
+  // Positive control for the length bound. `plan` is 4 characters, so the gate
+  // must let it through; without this, widening `<= 3` to `<= 8` would go
+  // unnoticed and start hiding real errors.
+  it('keeps a 4-character message', () => {
+    const kept = event('plan');
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  // Positive control for the "identifier only" shape.
+  it('keeps a short message that is not a bare identifier', () => {
+    for (const value of ['404', 'a b', '']) {
+      const kept = event(value);
+      assert.equal(marketingBeforeSend(kept), kept, `expected ${JSON.stringify(value)} kept`);
+    }
+  });
+});
+
+describe('marketingBeforeSend — stale chunk after deploy', () => {
+  it('drops the zero-frame Safari phrasing (WORLDMONITOR-15)', () => {
+    // The real event carried no stacktrace at all.
+    assert.equal(marketingBeforeSend(event('Importing a module script failed.')), null);
+  });
+
+  it('drops the Chrome and Firefox phrasings and the link-time counterpart', () => {
+    for (const value of [
+      'Failed to fetch dynamically imported module: https://www.worldmonitor.app/pro/assets/index-a1b2c3.js',
+      'error loading dynamically imported module',
+      "Importing binding name 'WelcomeApp' is not found.",
+    ]) {
+      assert.equal(marketingBeforeSend(event(value)), null, `expected ${value} dropped`);
+    }
+  });
+
+  it('ignores the Sentry SDK chunk when deciding first-partyness', () => {
+    // Only frame is Sentry's own hashed chunk → still no first-party evidence.
+    assert.equal(
+      marketingBeforeSend(event('Importing a module script failed.', [
+        '/pro/assets/sentry-DMxp_zBn.js',
+      ])),
+      null,
+    );
+  });
+
+  // Positive control for the `!hasFirstParty` gate. A module-load failure that
+  // DOES ride one of our own chunks is a real `import()` regression and must
+  // survive; drop the gate and this goes red.
+  it('keeps a module-load failure that carries a marketing-bundle frame', () => {
+    const kept = event('Failed to fetch dynamically imported module', [
+      '/pro/assets/index-a1b2c3.js',
+    ]);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  it('keeps a module-load failure that carries a source-mapped frame', () => {
+    const kept = event('Importing a module script failed.', ['pro-test/src/WelcomeApp.tsx']);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  // Positive control: an ordinary crash must pass straight through.
+  it('keeps an ordinary first-party crash', () => {
+    const kept = event("Cannot read properties of undefined (reading 'plan')", [
+      '/pro/assets/index-a1b2c3.js',
+    ]);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+});
+
+describe('policy wiring', () => {
+  // A perfect policy that nothing calls filters nothing. The values themselves
+  // are exercised above; this only proves `Sentry.init` actually receives them.
+  it('initSentry passes both halves of the policy to Sentry.init', () => {
+    const source = readFileSync(resolve(root, 'pro-test/src/sentry.ts'), 'utf8');
+    assert.match(source, /from '\.\/sentry-filter-policy'/);
+    assert.match(source, /ignoreErrors:\s*MARKETING_IGNORE_ERRORS/);
+    assert.match(source, /beforeSend:\s*\(event\)\s*=>\s*marketingBeforeSend\(event\)/);
+  });
+
+  it('does not copy the dashboard array wholesale', () => {
+    // The dashboard list is vetted against a different bundle (deck.gl /
+    // MapLibre / Convex). If someone bulk-copies it here, the marketing surface
+    // silently inherits suppressors for messages this bundle can emit.
+    const dashboard = readFileSync(resolve(root, 'src/bootstrap/sentry-init.ts'), 'utf8');
+    const dashboardCount = (dashboard.match(/^\s{6}\/.*\/,\s*(\/\/.*)?$/gm) ?? []).length;
+    assert.ok(dashboardCount > 100, `sanity: expected a large dashboard array, got ${dashboardCount}`);
+    assert.ok(
+      MARKETING_IGNORE_ERRORS.length < 20,
+      `marketing array must stay a vetted subset, got ${MARKETING_IGNORE_ERRORS.length}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Errors on `/` and `/pro` now get filtered. They never were before — not because a pattern was missing, but because the marketing pages run a **second Sentry client** that nothing had ever configured.

`src/bootstrap/sentry-init.ts` is not the whole story. It configures `sentry.javascript.browser` for the dashboard: ~250 `ignoreErrors` patterns and a 550-line `beforeSend`. The marketing pages render from the `pro-test` React bundle, which calls its own `Sentry.init` — five patterns, no `beforeSend` at all. Every suppressor the dashboard has accumulated stops at that boundary.

```mermaid
flowchart TB
  A["/dashboard"] --> B["sentry.javascript.browser<br/>src/bootstrap/sentry-init.ts"]
  C["/ and /pro"] --> D["sentry.javascript.react<br/>pro-test/src/sentry.ts"]
  B --> E["~250 ignoreErrors<br/>+ 550-line beforeSend"]
  D --> F["5 ignoreErrors<br/>no beforeSend"]
```

The 2026-08-19 Sentry triage found five open issues that were purely this gap. All five carry `sdk: sentry.javascript.react` and a **null release** — the dashboard client always stamps `worldmonitor@<version>`, so that pair is what distinguishes the two surfaces in the event payload. The clearest case is `WORLDMONITOR-15`: the dashboard's own suppressor comment names it by ID, has dropped it since #4005, and it kept billing events from `/` the entire time.

## The design decision worth reviewing

The obvious fix — share the dashboard's array — is the wrong one, and this PR deliberately doesn't do it.

Those ~250 entries were vetted against the *dashboard* bundle: deck.gl, MapLibre, Convex, IndexedDB. Several are only safe because that bundle can't emit them. Applied to a React/Clerk/Dodo bundle, entries like `Cannot read properties of undefined (reading 'then')` or `^timeout$` would start swallowing real marketing bugs — the exact observability blind spot `ignoreErrors` exists to avoid, since it matches on message text with no access to frames.

So the policy splits on ambiguity, the same way the dashboard's does:

| Where | Admits | This PR adds |
|---|---|---|
| `MARKETING_IGNORE_ERRORS` | only messages impossible from *any* first-party bundle | WKWebView host-bridge timeout, extension `runtime.sendMessage()` |
| `marketingBeforeSend` | anything our own minified output could produce, behind a first-party-frame gate | bare minified symbol (`ga`, `Ba`), stale-chunk-after-deploy |

A test asserts the marketing array stays a small vetted subset, so a future bulk-copy fails rather than silently landing.

## Validation

- **Positive controls, not just suppression.** The suite checks keep-cases alongside drop-cases: a 4-character message, a module-load failure that *does* carry a `/pro/assets/*.js` frame, an ordinary first-party crash. Without them the gates could pass vacuously.
- **Mutation sweep — 7/7 killed.** Widening the length bound `3 → 8`, deleting either gate, removing either new pattern, and dropping the SDK-chunk frame filter each turn the suite red.
- **Shipped, not just compiled.** Built the marketing bundle and confirmed all four suppressors are present in `public/pro/assets/index-*.js`. The #5019 Sentry chunk-split contract still passes.
- **Typecheck covers this.** Worth knowing: the root `npm run typecheck` only includes `src/`, so it never sees `pro-test/`. Ran `pro-test`'s own `npm run lint` and confirmed with a deliberate type error that it actually reaches the new file.

## A note on Sentry magic words

This PR intentionally carries **no** `Fixes WORLDMONITOR-…` line, in either the commit message or here.

That syntax is what mints Sentry's `inCommit` resolution pin — and a pinned issue only reopens on an event in a release Sentry orders strictly newer than the pin. Browser events here carry a deliberately static `worldmonitor@<version>` release, so that ordering is unsatisfiable and the issue is muted permanently. Resolving #6917/#6918's issues that way is exactly how the two pins found during this triage were created; both were stripped via an `unresolved → resolved` cycle and verified back to `statusDetails: {}`.

All five issues above were resolved with a plain status write instead, which regresses correctly on the next event in any release. Please don't add a closing keyword when merging.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
