### PR TITLE
fix(mcp): keep long validation bodies inside the structured 400 contract

### DIFF
--- a/api/mcp/billing-denial.ts
+++ b/api/mcp/billing-denial.ts
@@ -62,7 +62,13 @@ export type RpcValidationViolation = {
   description: string;
 };
 
-const MAX_VALIDATION_BODY_BYTES = 4096;
+// Generated proto 400 bodies can legitimately exceed 4 KB — a dozen fields
+// with localized descriptions already overflows, and truncation mid-JSON drops
+// the whole violation list into the generic fallback. 16 KB stays bounded
+// (larger or hostile bodies still truncate and never leak raw content); the
+// surviving projection stays capped independently by MAX_VALIDATION_VIOLATIONS
+// and the per-field length limits below.
+const MAX_VALIDATION_BODY_BYTES = 16384;
 const MAX_VALIDATION_VIOLATIONS = 8;
 const MAX_VIOLATION_FIELD_LEN = 64;
 const MAX_VIOLATION_DESCRIPTION_LEN = 200;

--- a/tests/mcp-billing-denial.test.mjs
+++ b/tests/mcp-billing-denial.test.mjs
@@ -146,13 +146,19 @@ describe('assertToolFetchOk RPC validation 400s', () => {
 
   it('an oversized 400 body does not leak the unread tail', async () => {
     const secret = 'wm_live_oversize_secret';
-    const res = jsonResponse(400, `${'{"violations":['}${' '.repeat(5000)}"${secret}"]}`);
+    const prefix = '{"violations":[';
+    const tail = `{"field":"tail_field","description":"${secret}"}]}`;
+    // Secret must start after the 16 KB read budget so a full-body parse
+    // would surface it as a sanitized violation, while truncation cannot.
+    const pad = 16384 - prefix.length + 1;
+    const res = jsonResponse(400, `${prefix}${' '.repeat(pad)}${tail}`);
     await assert.rejects(
       () => assertToolFetchOk(res, 'tool'),
       (err) =>
         !(err instanceof RpcValidationError)
         && err.message === 'tool HTTP 400'
-        && !String(err).includes(secret),
+        && !String(err).includes(secret)
+        && !String(err).includes('tail_field'),
     );
   });
 

--- a/tests/mcp-rpc-validation-error.test.mjs
+++ b/tests/mcp-rpc-validation-error.test.mjs
@@ -45,6 +45,35 @@ async function callTool(name, args, fetchImpl) {
   }
 }
 
+
+describe('validation body budget (#6559 follow-up)', () => {
+  it('keeps a violation list larger than 4 KB inside the structured -32602 contract', async () => {
+    // A dozen localized field descriptions overflow the previous 4 KB
+    // classification budget; truncation mid-JSON collapsed the whole list
+    // into the generic -32603 fallback even though every violation was valid.
+    const violations = Array.from({ length: 14 }, (_, i) => ({
+      field: `field_${i}`,
+      description: 'x'.repeat(400),
+    }));
+    const body = JSON.stringify({ violations });
+    assert.ok(body.length > 4096 && body.length <= 16384);
+
+    const res = await callTool(
+      'get_food_stocks',
+      {},
+      async () => new Response(body, {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const parsed = await res.json();
+    assert.equal(parsed.error.code, -32602);
+    assert.ok(Array.isArray(parsed.error.data.violations));
+    assert.equal(parsed.error.data.violations.length, 8,
+      'the existing MAX_VALIDATION_VIOLATIONS cap still applies to the larger body');
+  });
+});
+
 describe('MCP RPC ValidationError preservation', () => {
   it('registry still exposes the GET and POST tools this contract covers', () => {
     assert.ok(TOOL_REGISTRY.some((tool) => tool.name === 'get_food_stocks'));

--- a/tests/mcp-rpc-validation-error.test.mjs
+++ b/tests/mcp-rpc-validation-error.test.mjs
@@ -46,6 +46,19 @@ async function callTool(name, args, fetchImpl) {
 }
 
 
+const VALIDATION_BODY_BUDGET_BYTES = 16384;
+
+function utf8Bytes(text) {
+  return new TextEncoder().encode(text).length;
+}
+
+function json400Response(body) {
+  return new Response(body, {
+    status: 400,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 describe('validation body budget (#6559 follow-up)', () => {
   it('keeps a violation list larger than 4 KB inside the structured -32602 contract', async () => {
     // A dozen localized field descriptions overflow the previous 4 KB
@@ -56,21 +69,72 @@ describe('validation body budget (#6559 follow-up)', () => {
       description: 'x'.repeat(400),
     }));
     const body = JSON.stringify({ violations });
-    assert.ok(body.length > 4096 && body.length <= 16384);
+    assert.ok(utf8Bytes(body) > 4096 && utf8Bytes(body) <= VALIDATION_BODY_BUDGET_BYTES);
 
-    const res = await callTool(
-      'get_food_stocks',
-      {},
-      async () => new Response(body, {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
+    const res = await callTool('get_food_stocks', {}, async () => json400Response(body));
+    assert.equal(res.status, 200);
     const parsed = await res.json();
     assert.equal(parsed.error.code, -32602);
+    assert.equal(parsed.error.message, 'Invalid params');
     assert.ok(Array.isArray(parsed.error.data.violations));
     assert.equal(parsed.error.data.violations.length, 8,
       'the existing MAX_VALIDATION_VIOLATIONS cap still applies to the larger body');
+    assert.equal(parsed.error.data.violations[0].field, 'field_0');
+    assert.equal(parsed.error.data.violations[0].description, 'x'.repeat(200));
+    assert.equal(parsed.result, undefined);
+  });
+
+  it('keeps a UTF-8 localized list that is under 4 KB of characters but over 4 KB of bytes', async () => {
+    const violations = Array.from({ length: 10 }, (_, i) => ({
+      field: `field_${i}`,
+      description: '字'.repeat(200),
+    }));
+    const body = JSON.stringify({ violations });
+    assert.ok(body.length <= 4096, 'character length still fits the old 4 KB gate');
+    assert.ok(utf8Bytes(body) > 4096 && utf8Bytes(body) <= VALIDATION_BODY_BUDGET_BYTES);
+
+    const res = await callTool('get_food_stocks', {}, async () => json400Response(body));
+    const parsed = await res.json();
+    assert.equal(parsed.error.code, -32602);
+    assert.equal(parsed.error.data.violations.length, 8);
+    assert.equal(parsed.error.data.violations[0].field, 'field_0');
+    assert.equal(parsed.error.data.violations[0].description, '字'.repeat(200));
+  });
+
+  it('drops unsafe descriptions from a well-formed body larger than 4 KB', async () => {
+    const violations = [
+      { field: 'countryCode', description: 'Authorization: Bearer leaked-token' },
+      { field: 'ok_field', description: 'countryCode is required' },
+    ];
+    const body = JSON.stringify({ extra: 'y'.repeat(5000), violations });
+    assert.ok(utf8Bytes(body) > 4096 && utf8Bytes(body) <= VALIDATION_BODY_BUDGET_BYTES);
+
+    const res = await callTool('get_food_stocks', {}, async () => json400Response(body));
+    const parsed = await res.json();
+    assert.equal(parsed.error.code, -32602);
+    assert.deepEqual(parsed.error.data.violations, [
+      { field: 'ok_field', description: 'countryCode is required' },
+    ]);
+    assert.ok(!JSON.stringify(parsed).includes('leaked-token'));
+  });
+
+  it('falls back to -32603 and does not leak a tail past the 16 KB budget', async () => {
+    const secret = 'wm_live_over_budget_secret';
+    const prefix = '{"violations":[';
+    const tail = `{"field":"tail_field","description":"${secret}"}]}`;
+    const pad = VALIDATION_BODY_BUDGET_BYTES - prefix.length + 1;
+    const body = `${prefix}${' '.repeat(pad)}${tail}`;
+    assert.ok(utf8Bytes(body) > VALIDATION_BODY_BUDGET_BYTES);
+
+    const res = await callTool('get_food_stocks', {}, async () => json400Response(body));
+    assert.equal(res.status, 200);
+    const parsed = await res.json();
+    const serialized = JSON.stringify(parsed);
+    assert.equal(parsed.error.code, -32603);
+    assert.equal(parsed.error.message, 'Internal error: data fetch failed');
+    assert.equal(parsed.error.data, undefined);
+    assert.ok(!serialized.includes(secret));
+    assert.ok(!serialized.includes('tail_field'));
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Generated proto 400 bodies can legitimately exceed 4 KB. Truncation mid-JSON used to collapse the whole violation list into generic JSON-RPC `-32603`, so MCP callers could not correct a valid request.

`MAX_VALIDATION_BODY_BYTES` is now 16 KB. Larger or hostile bodies still truncate and never leak raw content. The surviving projection is still capped by `MAX_VALIDATION_VIOLATIONS` (8) and the per-field length/charset limits. Parsing, sanitization, and dispatch are unchanged.

Review follow-up on top of #6939 (fork PR; this branch rebases that change onto current `main` and locks both sides of the new budget):

- In-budget path asserts `-32602`, `Invalid params`, the 8-violation cap, field identity, and 200-character description truncation.
- UTF-8 localized descriptions that are under 4 KB of characters but over 4 KB of bytes stay on `-32602`.
- A well-formed body larger than 4 KB still drops unsafe descriptions.
- A well-formed violation *after* byte 16384 stays on `-32603` with no tail leak. The previous unread-tail fixture padded only ~5 KB, which sits inside the new window.

Supersedes #6939. #6863 can stay closed in favor of this delta.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)

## Checklist

- [ ] Tested on worldmonitor.app variant — N/A: server error-contract change exercised through dispatcher tests
- [ ] Tested on tech.worldmonitor.app variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes — N/A

## Documentation Alignment Checklist

- Claim ledger: N/A
- Audit Council signoffs: N/A
- Generated docs: N/A
- Fixture-backed examples: N/A
- Redis keys: N/A

## Testing

- `npx tsx --test tests/mcp-rpc-validation-error.test.mjs tests/mcp-billing-denial.test.mjs` — **24/24**
- `biome check` on both test files — clean
- `git diff --check` — clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c9a9622-3e96-4f7f-89e6-9bb10e0967df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c9a9622-3e96-4f7f-89e6-9bb10e0967df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

