### PR TITLE
fix(feeds): restore Sequoia feed validation

### DIFF
--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -10,7 +10,7 @@ The inventory is **generated, not hand-written**: `scripts/source-attribution.mj
 ## Observed Source Inventory
 
 {/* BEGIN GENERATED SOURCE ATTRIBUTION */}
-This generated inventory covers **748 active source hosts** representing **742 active providers** (**318 structured/API**, **463 feed**, and **30 operational-status** hosts). It is derived from source declarations in `scripts/`, `server/`, `api/`, and `src/`. Each row shows the configured provider identity and where the source is referenced.
+This generated inventory covers **748 active source hosts** representing **742 active providers** (**318 structured/API**, **462 feed**, and **30 operational-status** hosts). It is derived from source declarations in `scripts/`, `server/`, `api/`, and `src/`. Each row shows the configured provider identity and where the source is referenced.
 
 | Provider | Observed surface |
 | --- | --- |
@@ -521,7 +521,7 @@ This generated inventory covers **748 active source hosts** representing **742 a
 | sedeaplicaciones.minetur.gob.es (sedeaplicaciones.minetur.gob.es) | structured — scripts/backfill-fuel-prices-prev.mjs, scripts/seed-fuel-prices.mjs |
 | seekingalpha.com (seekingalpha.com) | feed+structured — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts, src/config/variants/finance.ts, src/config/variants/tech.ts |
 | semianalysis.com (semianalysis.com) | feed — src/config/feeds.ts |
-| sequoiacap.com (sequoiacap.com) | feed — src/config/feeds.ts |
+| sequoiacap.com (sequoiacap.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | SerpAPI (serpapi.com) | structured — server/worldmonitor/market/v1/stock-news-search.ts |
 | services7.arcgis.com (services7.arcgis.com) | structured — scripts/fetch-mirta-bases.mjs |
 | services9.arcgis.com (services9.arcgis.com) | structured — scripts/build-chokepoint-transit-snapshot.mjs, scripts/seed-portwatch-chokepoints-ref.mjs, scripts/seed-portwatch-disruptions.mjs, scripts/seed-portwatch-port-activity.mjs, +1 more |
@@ -825,7 +825,7 @@ This generated inventory covers **748 active source hosts** representing **742 a
 | www.sciencedaily.com (www.sciencedaily.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | www.scmp.com (www.scmp.com) | feed — src/config/feeds.ts |
 | www.semianalysis.com (www.semianalysis.com) | feed+structured — server/worldmonitor/news/v1/_feeds.ts, src/config/variants/tech.ts |
-| www.sequoiacap.com (www.sequoiacap.com) | feed+structured — server/worldmonitor/news/v1/_feeds.ts, src/config/variants/tech.ts |
+| www.sequoiacap.com (www.sequoiacap.com) | structured — src/config/variants/tech.ts |
 | www.seznamzpravy.cz (www.seznamzpravy.cz) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | www.shareable.net (www.shareable.net) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | www.silverseek.com (www.silverseek.com) | feed — src/config/feeds.ts |

--- a/scripts/crawlable-sources-page.mjs
+++ b/scripts/crawlable-sources-page.mjs
@@ -158,6 +158,7 @@ const SOURCE_DOMAIN_OVERRIDES = new Map([
   ['www.newyorkfed.org', 'finance'],
   ['www.nfx.com', 'technology'],
   ['www.reddit.com', 'news'],
+  ['www.sequoiacap.com', 'technology'],
   ['SWF Institute', 'finance'],
   ['Toronto Transit Commission (TTC) GTFS-RT', 'infrastructure'],
   ['United Nations Population Division', 'finance'],

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -451,7 +451,7 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Y Combinator Blog', url: 'https://www.ycombinator.com/blog/rss/' },
       { name: 'a16z Blog', url: 'https://www.a16z.news/feed' },
       { name: 'First Round Review', url: 'https://review.firstround.com/articles/rss' },
-      { name: 'Sequoia Blog', url: 'https://www.sequoiacap.com/feed/' },
+      { name: 'Sequoia Blog', url: gn('site:sequoiacap.com when:7d') },
       { name: 'Stratechery', url: 'https://stratechery.com/feed/' },
     ],
     regionalStartups: [

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -7992,6 +7992,9 @@
       "status": "terms-review",
       "references": [
         {
+          "path": "server/worldmonitor/news/v1/_feeds.ts"
+        },
+        {
           "path": "src/config/feeds.ts"
         }
       ]
@@ -13028,15 +13031,12 @@
     {
       "host": "www.sequoiacap.com",
       "provider": "www.sequoiacap.com",
-      "kind": "feed+structured",
+      "kind": "structured",
       "observed": true,
       "license": "Provider terms for this feed publisher; verify before redistribution",
       "attribution": "Credit www.sequoiacap.com and link to the original feed publisher.",
       "status": "terms-review",
       "references": [
-        {
-          "path": "server/worldmonitor/news/v1/_feeds.ts"
-        },
         {
           "path": "src/config/variants/tech.ts"
         }

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -97,6 +97,18 @@ describe('sources catalog domain assignment', () => {
     assert.equal(catalog[0].domainId, 'infrastructure');
   });
 
+  it('assigns the structured Sequoia provider to technology', () => {
+    const catalog = buildSourceCatalog([
+      {
+        provider: 'www.sequoiacap.com',
+        host: 'www.sequoiacap.com',
+        kind: 'structured',
+        references: [{ path: 'src/config/variants/tech.ts' }],
+      },
+    ]);
+    assert.equal(catalog[0].domainId, 'technology');
+  });
+
   it('assigns Toronto Transit Commission (TTC) GTFS-RT to infrastructure instead of failing the corpus build', () => {
     const catalog = buildSourceCatalog([
       {

--- a/tests/feeds-client-server-parity.test.mjs
+++ b/tests/feeds-client-server-parity.test.mjs
@@ -173,7 +173,6 @@ describe('feed parity: client vs server (PR #3715 follow-up)', () => {
     'CSIS',
     'South China Morning Post',
     'a16z Blog',
-    'Sequoia Blog',
     'EU Startups',
     'Tech in Asia',
     'SemiAnalysis',


### PR DESCRIPTION
## Summary

Feed Validation can complete again after Sequoia moved its RSS payload behind a non-allowlisted Framer CDN redirect. The server digest now uses the same Google News fallback as the client, which preserves Sequoia coverage without widening the RSS proxy allowlist to a multi-tenant host. The client/server parity ratchet now treats Sequoia as resolved drift so the direct route cannot return unnoticed.

The crawlable source catalog also classifies Sequoia's remaining structured provider under Tech Ecosystem. This keeps the catalog's closed-world build gate intact after the feed route change.

## Validation

- `npm run test:feeds:ci` — 805 OK, with no CI guardrail violations
- `node --import tsx --test tests/feeds-client-server-parity.test.mjs tests/source-attribution.test.mjs` — 45 passed
- affected attribution and documentation-count tests — 179 passed
- `node --import tsx --test tests/crawlable-corpus.test.mjs` — 24 passed
- `npm run build:crawlable-corpus`
- `npm run typecheck:api`
- repository pre-push gate

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
