### PR TITLE
fix(monitor): separate seed health from deploy checks

### DIFF
--- a/.github/workflows/seed-freshness-monitor.yml
+++ b/.github/workflows/seed-freshness-monitor.yml
@@ -13,8 +13,8 @@ concurrency:
 
 permissions:
   contents: read
-  # Per-source statuses keep an unchanged incident machine-visible without
-  # making every scheduled observation look like a new failed run.
+  # Per-source statuses live on a historical operational anchor. They never
+  # become part of the deployable main revision's check suite.
   statuses: write
 
 jobs:
@@ -103,7 +103,7 @@ jobs:
         if: ${{ !cancelled() && steps.gate.conclusion != 'failure' }}
         # The probe remains strict and exits non-zero for every active problem.
         # The next step decides whether that problem is a new transition or the
-        # same durable incident already attached to a first-parent revision.
+        # same durable incident already attached to the operational anchor.
         continue-on-error: true
         run: node scripts/check-seed-freshness.mjs --json-output "$RUNNER_TEMP/seed-freshness-observation.json"
 
@@ -113,6 +113,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SEED_ACCEPTANCE_SHA: ${{ steps.gate.outputs.sha || github.sha }}
           SEED_ACCEPTANCE_OUTCOME: ${{ steps.acceptance.outcome }}
+          # PR #6876 introduced the transition publisher. Its historical merge
+          # commit is an ancestor of every supported monitored revision and is
+          # never a future deployment candidate.
+          SEED_STATUS_SHA: b93afd05d0f4ea2c465e79fd064e87fc1f9fb2f3
           SEED_STATUS_WRITER_LOGIN: github-actions[bot]
         run: |
           # During the first post-merge race, the newest gated ancestor can
@@ -126,6 +130,13 @@ jobs:
             echo "Transition publisher is not active on gated revision $SEED_ACCEPTANCE_SHA; waiting for a gated activation revision."
             exit 0
           fi
+          status_args=()
+          if grep -q -- "'status-sha':" scripts/update-seed-health-statuses.mjs; then
+            status_args=(--status-sha "$SEED_STATUS_SHA")
+          else
+            echo "Gated revision $SEED_ACCEPTANCE_SHA predates anchored statuses; using its compatible transition publisher until the activation revision is gated."
+          fi
           node scripts/update-seed-health-statuses.mjs \
             --sha "$SEED_ACCEPTANCE_SHA" \
+            "${status_args[@]}" \
             --report "$RUNNER_TEMP/seed-freshness-observation.json"

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -538,18 +538,29 @@ container.
 
 The probe is strict on every run, but the workflow conclusion is
 transition-based. `scripts/update-seed-health-statuses.mjs` publishes one
-durable `ingestion/seed/<source>` commit status on the exact gated revision.
+durable `ingestion/seed/<source>` status on the historical operational anchor
+`b93afd05d0f4ea2c465e79fd064e87fc1f9fb2f3`. The exact gated revision remains
+the revision being observed, but it does not receive source-health statuses.
+This separation prevents a continuing data incident from making Railway read
+an unrelated deployable commit as a failed check suite.
 A new failure, a changed failure class, an expired acknowledgement, a probe
 transport error, or a malformed observation fails the workflow. The same
-unchanged incident on a later poll keeps its per-source status red but does not
-create another generic failed run. This preserves the alarm while separating
-"still broken" from "broke again".
+unchanged incident remains red on the anchor, appends no new status, and does
+not create another generic failed run. This preserves the alarm while
+separating "still broken" from "broke again".
 
 Recovery is not inferred from a merge, image build, or elapsed time. The
 publisher posts success only after the live compact-health observation stops
 reporting that source. The first run after this status lifecycle is activated
-can fail once to establish the durable status for incidents that already
-exist; later exact repeats are quiet.
+imports the newest trusted legacy projection before it initializes the anchor,
+so an incident that already exists does not become a false new alert. Later
+exact repeats are quiet. The publisher also proves that the anchor is an
+ancestor of the monitored revision before it writes any status.
+
+The acceptance context is the completion marker and is always written last. If
+GitHub accepts only part of a projection, the next poll overlays those trusted
+partial statuses on the last complete projection, repairs the anchor, and does
+not report an already-written source transition again.
 
 Read the separate six-hourly `Railway Native Deploy Health` workflow for
 production source, build, trigger, and deployment conclusions. A red Seed
@@ -565,7 +576,10 @@ run on an ingestion push because Railway may not have deployed or executed
 that revision yet. This is the operational acceptance gate for the "merged and
 green, but production data is still unhealthy" gap. A workflow failure means
 new operational information or an unreadable control plane; the durable source
-statuses remain the current incident inventory between transitions.
+statuses on the operational anchor remain the current incident inventory
+between transitions. A genuinely new or changed incident can still fail one
+scheduled run; persistent incident state cannot be copied onto later main
+commits.
 
 #### Deploy-drift check
 

--- a/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
+++ b/docs/solutions/integration-issues/railway-seeder-watch-paths-can-skip-deployments.md
@@ -152,6 +152,28 @@ same `gate` status branch protection requires.
 
 ## Solution
 
+### Keep operational status off deployable commits
+
+The Seed Freshness Monitor observes the newest gated `main` revision but writes
+its durable `ingestion/seed/*` projection to the fixed historical merge commit
+`b93afd05d0f4ea2c465e79fd064e87fc1f9fb2f3`. That commit introduced the
+transition publisher, is required to be an ancestor of the observed revision,
+and cannot become a future deployment candidate.
+
+This keeps the protection without recreating the lag source described above:
+a new or materially changed incident still fails one monitor run, the anchor
+keeps the source status non-green until live recovery, and unchanged polls
+append nothing. The first anchored run imports the newest trusted legacy
+projection from recent first-parent history, so already-active incidents move
+to the anchor without being reported as new failures. Because the acceptance
+context is written last, a later poll can also distinguish an empty anchor from
+a partial write, repair that write, and avoid reporting the same transition
+twice.
+
+Do not move this projection back to `main`, a gated ancestor selected for the
+probe, or any other commit Railway may be asked to deploy. GitHub commit status
+is deployment input in this repository, not only an observability surface.
+
 ### The audit: the registry contract, unchanged
 
 `scripts/railway-services.json` remains the repository-side contract. Each

--- a/scripts/update-seed-health-statuses.mjs
+++ b/scripts/update-seed-health-statuses.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-// Publish Seed Freshness as durable, per-source commit statuses.
+// Publish Seed Freshness as durable, per-source operational statuses.
 //
 // The health probe remains strict. A new or changed source incident fails this
-// workflow once. An unchanged incident stays red on every gated main revision,
-// but later scheduled observations do not generate another generic failed run.
-// Recovery is posted only after the live health payload stops reporting it.
+// workflow once. Statuses live on one historical anchor commit so operational
+// incidents cannot poison the check suite of an unrelated deployable revision.
+// Unchanged observations append nothing. Recovery is posted only after the live
+// health payload stops reporting the source.
 
 import { spawnSync } from 'node:child_process';
 import { readFileSync, realpathSync } from 'node:fs';
@@ -148,6 +149,20 @@ function runGit(args) {
   return result.stdout.trim();
 }
 
+function isAncestor(ancestor, descendant) {
+  const args = ['merge-base', '--is-ancestor', ancestor, descendant];
+  const result = spawnSync('git', args, {
+    encoding: 'utf8',
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: 30_000,
+  });
+  if (result.signal) throw new Error(`git ${args.join(' ')} timed out`);
+  if (result.error) throw result.error;
+  if (result.status === 0) return true;
+  if (result.status === 1) return false;
+  throw new Error(`git ${args.join(' ')} failed (${result.status}): ${result.stderr.trim()}`);
+}
+
 export function validateObservationCheckedAt(value, now = Date.now()) {
   if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) {
     throw new Error('seed acceptance observation checkedAt must be a normalized UTC ISO instant');
@@ -174,6 +189,18 @@ function completionMarkerCheckedAt(status) {
     throw new Error('seed acceptance completion marker has an invalid observed checkedAt');
   }
   return { checkedAt, timestamp };
+}
+
+function statusMeaningMatches(current, previous) {
+  if (!previous || current.state !== previous.state) return false;
+  if (current.context !== ACCEPTANCE_CONTEXT) {
+    return current.description === previous.description;
+  }
+  const withoutObservationTime = (description) => description.replace(
+    /; observed \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    '',
+  );
+  return withoutObservationTime(current.description) === withoutObservationTime(previous.description);
 }
 
 function readObservation(path, now = Date.now()) {
@@ -228,6 +255,43 @@ function readPreviousObservation({ repository, shas, trustedWriter }) {
   return { sha: null, checkedAt: null, checkedAtTimestamp: null, statuses: new Map() };
 }
 
+function readAnchorObservation({ repository, sha, trustedWriter }) {
+  const statuses = readCommitStatuses({ repository, sha });
+  const seedStatuses = statuses.filter(
+    (status) => typeof status?.context === 'string' && status.context.startsWith(STATUS_PREFIX),
+  );
+  if (seedStatuses.length === 0) {
+    return {
+      state: 'empty',
+      checkedAt: null,
+      checkedAtTimestamp: null,
+      statuses: new Map(),
+    };
+  }
+
+  const projection = latestStatusesByContext([statuses], STATUS_PREFIX, { creatorLogin: trustedWriter });
+  const markerStatus = projection.get(ACCEPTANCE_CONTEXT);
+  const marker = markerStatus ? completionMarkerCheckedAt(markerStatus) : null;
+  const newestIsMarker = seedStatuses[0].context === ACCEPTANCE_CONTEXT;
+  // A pre-transition marker has no observation timestamp, so it cannot prove
+  // ordering. Preserve the existing one-time bootstrap alert instead of using
+  // legacy source statuses to suppress the first ordered projection.
+  if (newestIsMarker && !marker) {
+    return {
+      state: 'legacy',
+      checkedAt: null,
+      checkedAtTimestamp: null,
+      statuses: new Map(),
+    };
+  }
+  return {
+    state: newestIsMarker ? 'complete' : 'partial',
+    checkedAt: marker?.checkedAt ?? null,
+    checkedAtTimestamp: marker?.timestamp ?? null,
+    statuses: projection,
+  };
+}
+
 function isMainModule() {
   return pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url;
 }
@@ -238,15 +302,21 @@ function main() {
     options: {
       report: { type: 'string' },
       sha: { type: 'string', default: process.env.GITHUB_SHA },
+      'status-sha': { type: 'string', default: process.env.SEED_STATUS_SHA },
     },
     strict: true,
   });
   const reportPath = values.report;
-  const sha = values.sha;
+  const observedSha = values.sha;
+  const statusSha = values['status-sha'];
   const repository = process.env.GITHUB_REPOSITORY;
   if (!reportPath) throw new Error('--report is required');
-  if (!sha) throw new Error('--sha or GITHUB_SHA is required');
+  if (!observedSha) throw new Error('--sha or GITHUB_SHA is required');
+  if (!statusSha) throw new Error('--status-sha or SEED_STATUS_SHA is required');
   if (!repository) throw new Error('GITHUB_REPOSITORY is required');
+  if (!isAncestor(statusSha, observedSha)) {
+    throw new Error(`seed status anchor ${statusSha} is not an ancestor of monitored revision ${observedSha}`);
+  }
 
   const observation = readObservation(reportPath);
   const current = buildSeedHealthStatuses(observation.acceptance, observation.checkedAt);
@@ -255,25 +325,46 @@ function main() {
     throw new Error('SEED_STATUS_HISTORY_LIMIT must be an integer from 1 to 100');
   }
   const trustedWriter = requireStatusWriterLogin();
-  const previousObservation = readPreviousObservation({
+  const anchoredObservation = readAnchorObservation({
     repository,
-    shas: firstParentShas(sha, historyLimit),
+    sha: statusSha,
     trustedWriter,
   });
+  // The first anchored run imports the latest completed legacy projection from
+  // main. A partial anchor write overlays that complete projection so the next
+  // run repairs the projection without alerting again for a source status that
+  // GitHub already accepted. Once the newest anchor status is its completion
+  // marker, the anchor is the sole authority.
+  const legacyObservation = anchoredObservation.state === 'complete'
+    ? null
+    : readPreviousObservation({
+      repository,
+      shas: firstParentShas(observedSha, historyLimit),
+      trustedWriter,
+    });
+  const previousObservation = anchoredObservation.state === 'complete'
+    ? { ...anchoredObservation, sha: statusSha }
+    : {
+        sha: legacyObservation.sha,
+        checkedAt: anchoredObservation.checkedAt ?? legacyObservation.checkedAt,
+        checkedAtTimestamp: anchoredObservation.checkedAtTimestamp
+          ?? legacyObservation.checkedAtTimestamp,
+        statuses: new Map([
+          ...legacyObservation.statuses,
+          ...anchoredObservation.statuses,
+        ]),
+      };
   if (previousObservation.checkedAtTimestamp != null
     && Date.parse(observation.checkedAt) <= previousObservation.checkedAtTimestamp) {
     throw new Error(`seed acceptance observation checkedAt ${observation.checkedAt} is not newer than completed projection ${previousObservation.checkedAt}`);
   }
   const plan = planStatusLifecycle({ current, previous: previousObservation.statuses });
-  let updates = previousObservation.sha === sha
-    ? plan.updates.filter((status) => {
-      const previous = previousObservation.statuses.get(status.context);
-      return !previous
-        || previous.state !== status.state
-        || previous.description !== status.description;
-    })
+  let updates = anchoredObservation.state === 'complete'
+    ? plan.updates.filter(
+        (status) => !statusMeaningMatches(status, anchoredObservation.statuses.get(status.context)),
+      )
     : plan.updates;
-  if (previousObservation.sha === sha && updates.length > 0
+  if (anchoredObservation.state === 'complete' && updates.length > 0
     && !updates.some((status) => status.context === ACCEPTANCE_CONTEXT)) {
     updates = [...updates, current.find((status) => status.context === ACCEPTANCE_CONTEXT)];
   }
@@ -281,11 +372,14 @@ function main() {
     ...updates.filter((status) => status.context !== ACCEPTANCE_CONTEXT),
     ...updates.filter((status) => status.context === ACCEPTANCE_CONTEXT),
   ];
-  postCommitStatuses({ repository, sha, statuses: orderedUpdates });
+  postCommitStatuses({ repository, sha: statusSha, statuses: orderedUpdates });
 
   console.log(JSON.stringify({
     checkedAt: observation.checkedAt,
-    sha,
+    observedSha,
+    statusSha,
+    anchorState: anchoredObservation.state,
+    importedFromSha: anchoredObservation.state === 'complete' ? null : legacyObservation.sha,
     statusesPublished: orderedUpdates.length,
     newOrChangedFailures: plan.alerting.map((status) => status.context),
   }, null, 2));

--- a/tests/seed-freshness-workflow.test.mjs
+++ b/tests/seed-freshness-workflow.test.mjs
@@ -61,6 +61,37 @@ function runPublisherWithoutActivation(acceptanceOutcome) {
   }
 }
 
+function runPublisherFromLegacyRevision() {
+  const tempDir = mkdtempSync(join(repoRoot, '.tmp-seed-freshness-legacy-publisher-'));
+  const scriptsDir = join(tempDir, 'scripts');
+  const argsLog = join(tempDir, 'publisher-args.json');
+  const reportPath = join(tempDir, 'seed-freshness-observation.json');
+  try {
+    mkdirSync(scriptsDir);
+    writeFileSync(join(scriptsDir, 'update-seed-health-statuses.mjs'), [
+      "import { writeFileSync } from 'node:fs';",
+      'writeFileSync(process.env.ARGS_LOG, JSON.stringify(process.argv.slice(2)));',
+      '',
+    ].join('\n'));
+    const publisher = stepNamed('Publish ingestion operational transitions');
+    const result = spawnSync('bash', ['-e', '-c', publisher.run], {
+      cwd: tempDir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        ARGS_LOG: argsLog,
+        RUNNER_TEMP: tempDir,
+        SEED_ACCEPTANCE_OUTCOME: 'success',
+        SEED_ACCEPTANCE_SHA: HEAD_SHA,
+        SEED_STATUS_SHA: 'b93afd05d0f4ea2c465e79fd064e87fc1f9fb2f3',
+      },
+    });
+    return { result, args: JSON.parse(readFileSync(argsLog, 'utf8')), reportPath };
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 const HEAD_SHA = '0123456789abcdef';
 // Frozen so the age bound is a boundary, not a race against the wall clock:
 // `date` is faked below and every ancestor age is expressed against this.
@@ -302,11 +333,16 @@ describe('seed freshness workflow control plane', () => {
     assert.equal(publisher.env.GH_TOKEN, '${{ github.token }}');
     assert.equal(publisher.env.SEED_ACCEPTANCE_SHA, '${{ steps.gate.outputs.sha || github.sha }}');
     assert.equal(publisher.env.SEED_ACCEPTANCE_OUTCOME, '${{ steps.acceptance.outcome }}');
+    assert.equal(publisher.env.SEED_STATUS_SHA, 'b93afd05d0f4ea2c465e79fd064e87fc1f9fb2f3');
     assert.equal(publisher.env.SEED_STATUS_WRITER_LOGIN, 'github-actions[bot]');
     assert.match(publisher.run, /update-seed-health-statuses\.mjs/);
     assert.match(publisher.run, /if \[ ! -f scripts\/update-seed-health-statuses\.mjs \]/);
     assert.match(publisher.run, /not active on gated revision/);
     assert.match(publisher.run, /--sha "\$SEED_ACCEPTANCE_SHA"/);
+    assert.match(publisher.run, /status_args=\(\)/);
+    assert.match(publisher.run, /grep -q -- "'status-sha':"/);
+    assert.match(publisher.run, /status_args=\(--status-sha "\$SEED_STATUS_SHA"\)/);
+    assert.match(publisher.run, /"\$\{status_args\[@\]\}"/);
     assert.match(publisher.run, /--report "\$RUNNER_TEMP\/seed-freshness-observation\.json"/);
     assertBashSyntax(publisher.run);
     assert.equal(workflow.permissions.statuses, 'write');
@@ -320,6 +356,15 @@ describe('seed freshness workflow control plane', () => {
     const success = runPublisherWithoutActivation('success');
     assert.equal(success.status, 0, success.stderr);
     assert.match(success.stdout, /waiting for a gated activation revision/);
+  });
+
+  it('keeps the pre-anchor publisher compatible during the first gated-revision race', () => {
+    const legacy = runPublisherFromLegacyRevision();
+    assert.equal(legacy.result.status, 0, legacy.result.stderr);
+    assert.deepEqual(legacy.args, [
+      '--sha', HEAD_SHA,
+      '--report', legacy.reportPath,
+    ]);
   });
 
   it('checks out the resolved revision before the ingestion probe', () => {

--- a/tests/seed-health-status-publisher.test.mjs
+++ b/tests/seed-health-status-publisher.test.mjs
@@ -18,6 +18,7 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const publisher = resolve(repoRoot, 'scripts/update-seed-health-statuses.mjs');
 const HEAD = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const ANCESTOR = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const STATUS_ANCHOR = 'cccccccccccccccccccccccccccccccccccccccc';
 const WRITER = 'github-actions[bot]';
 
 const failure = {
@@ -64,7 +65,10 @@ function runPublisher({
   observedAt,
   headStatuses = [],
   ancestorStatuses = [],
+  statusStatuses = [],
   observationOverride,
+  statusSha = HEAD,
+  ancestryValid = true,
 }) {
   const tempDir = mkdtempSync(join(repoRoot, '.tmp-seed-status-publisher-'));
   const fakeBin = join(tempDir, 'bin');
@@ -77,11 +81,20 @@ function runPublisher({
     writeFileSync(reportPath, JSON.stringify(observationOverride ?? observation(blocking, { acknowledged, observedAt })));
     writeFileSync(join(statusesDir, `${HEAD}.json`), JSON.stringify(headStatuses));
     writeFileSync(join(statusesDir, `${ANCESTOR}.json`), JSON.stringify(ancestorStatuses));
+    writeFileSync(join(statusesDir, `${STATUS_ANCHOR}.json`), JSON.stringify(statusStatuses));
     writeFileSync(postLog, '');
     writeFileSync(join(fakeBin, 'git'), [
       '#!/bin/sh',
-      'case "$1" in log) ;; *) exit 90 ;; esac',
-      `printf '%s\\n%s\\n' '${HEAD}' '${ANCESTOR}'`,
+      'case "$1" in',
+      '  log)',
+      `    printf '%s\\n%s\\n' '${HEAD}' '${ANCESTOR}'`,
+      '    ;;',
+      '  merge-base)',
+      '    [ "$2" = "--is-ancestor" ] || exit 91',
+      '    [ "$FAKE_ANCESTRY_VALID" = "true" ]',
+      '    ;;',
+      '  *) exit 90 ;;',
+      'esac',
       '',
     ].join('\n'));
     writeFileSync(join(fakeBin, 'gh'), [
@@ -113,13 +126,20 @@ function runPublisher({
     chmodSync(join(fakeBin, 'git'), 0o755);
     chmodSync(join(fakeBin, 'gh'), 0o755);
 
-    const result = spawnSync(process.execPath, [publisher, '--sha', HEAD, '--report', reportPath], {
+    const args = [
+      publisher,
+      '--sha', HEAD,
+      '--status-sha', statusSha,
+      '--report', reportPath,
+    ];
+    const result = spawnSync(process.execPath, args, {
       cwd: repoRoot,
       encoding: 'utf8',
       env: {
         ...process.env,
         FAKE_POST_LOG: postLog,
         FAKE_STATUS_DIR: statusesDir,
+        FAKE_ANCESTRY_VALID: String(ancestryValid),
         GH_TOKEN: 'test-token',
         GITHUB_REPOSITORY: 'koala73/worldmonitor',
         SEED_STATUS_WRITER_LOGIN: WRITER,
@@ -133,6 +153,90 @@ function runPublisher({
 }
 
 describe('seed health status publisher', () => {
+  it('keeps an unchanged incident off a new monitored revision', () => {
+    const firstAt = checkedAt(-120_000);
+    const repeated = runPublisher({
+      blocking: [{ name: 'example', status: 'STALE_SEED', seedAgeMin: 1_500 }],
+      observedAt: checkedAt(-60_000),
+      statusStatuses: [aggregate(firstAt), trusted(failure)],
+      statusSha: STATUS_ANCHOR,
+    });
+
+    assert.equal(repeated.status, 0, repeated.stderr);
+    assert.match(repeated.stdout, new RegExp(`"observedSha": "${HEAD}"`));
+    assert.match(repeated.stdout, new RegExp(`"statusSha": "${STATUS_ANCHOR}"`));
+    assert.doesNotMatch(repeated.posts, new RegExp(`/statuses/${HEAD}`));
+    assert.equal(repeated.posts, '', 'an unchanged incident must not append another anchor status');
+  });
+
+  it('posts recovery only to an initialized operational anchor', () => {
+    const firstAt = checkedAt(-120_000);
+    const recovered = runPublisher({
+      blocking: [],
+      observedAt: checkedAt(-60_000),
+      statusStatuses: [aggregate(firstAt), trusted(failure)],
+      statusSha: STATUS_ANCHOR,
+    });
+
+    assert.equal(recovered.status, 0, recovered.stderr);
+    assert.match(recovered.posts, new RegExp(`/statuses/${STATUS_ANCHOR}`));
+    assert.doesNotMatch(recovered.posts, new RegExp(`/statuses/${HEAD}`));
+    assert.match(recovered.posts, /context=ingestion\/seed\/example/);
+    assert.match(recovered.posts, /state=success/);
+    assert.match(recovered.posts, /description=recovered; no longer reported/);
+    assert.match(recovered.posts, /context=ingestion\/seed\/acceptance/);
+  });
+
+  it('imports an unchanged legacy incident onto an empty anchor without alerting again', () => {
+    const firstAt = checkedAt(-120_000);
+    const migrated = runPublisher({
+      blocking: [{ name: 'example', status: 'STALE_SEED' }],
+      observedAt: checkedAt(-60_000),
+      ancestorStatuses: [aggregate(firstAt), trusted(failure)],
+      statusSha: STATUS_ANCHOR,
+    });
+
+    assert.equal(migrated.status, 0, migrated.stderr);
+    assert.match(migrated.stdout, /"newOrChangedFailures": \[\]/);
+    assert.match(migrated.stdout, new RegExp(`"importedFromSha": "${ANCESTOR}"`));
+    assert.match(migrated.posts, new RegExp(`/statuses/${STATUS_ANCHOR}`));
+    assert.doesNotMatch(migrated.posts, new RegExp(`/statuses/${HEAD}`));
+    assert.match(migrated.posts, /context=ingestion\/seed\/example/);
+    assert.match(migrated.posts, /context=ingestion\/seed\/acceptance/);
+  });
+
+  it('imports a legacy recovery onto an empty anchor without touching the monitored revision', () => {
+    const firstAt = checkedAt(-120_000);
+    const recovered = runPublisher({
+      blocking: [],
+      observedAt: checkedAt(-60_000),
+      ancestorStatuses: [aggregate(firstAt), trusted(failure)],
+      statusSha: STATUS_ANCHOR,
+    });
+
+    assert.equal(recovered.status, 0, recovered.stderr);
+    assert.match(recovered.stdout, /"newOrChangedFailures": \[\]/);
+    assert.match(recovered.stdout, new RegExp(`"importedFromSha": "${ANCESTOR}"`));
+    assert.match(recovered.posts, new RegExp(`/statuses/${STATUS_ANCHOR}`));
+    assert.doesNotMatch(recovered.posts, new RegExp(`/statuses/${HEAD}`));
+    assert.match(recovered.posts, /context=ingestion\/seed\/example/);
+    assert.match(recovered.posts, /state=success/);
+    assert.match(recovered.posts, /description=recovered; no longer reported/);
+    assert.match(recovered.posts, /context=ingestion\/seed\/acceptance/);
+  });
+
+  it('fails closed when the status anchor is outside the monitored lineage', () => {
+    const result = runPublisher({
+      blocking: [],
+      statusSha: STATUS_ANCHOR,
+      ancestryValid: false,
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /is not an ancestor of monitored revision/);
+    assert.equal(result.posts, '');
+  });
+
   it('fails once for a new incident, stays quiet for the same incident, and posts recovery', () => {
     const currentProblem = [{ name: 'example', status: 'STALE_SEED', seedAgeMin: 999 }];
     const firstAt = checkedAt(-120_000);
@@ -185,15 +289,50 @@ describe('seed health status publisher', () => {
     assert.equal(result.posts, '');
   });
 
-  it('does not accept an old aggregate marker beneath a partial status projection', () => {
+  it('repairs a partial anchor projection without re-alerting the same incident', () => {
+    const firstAt = checkedAt(-120_000);
     const result = runPublisher({
       blocking: [{ name: 'example', status: 'STALE_SEED' }],
-      // GitHub returns newest first. The source status is newer than the
-      // aggregate marker, so the earlier write did not complete.
-      headStatuses: [trusted(failure), aggregate(checkedAt(-60_000))],
+      observedAt: checkedAt(-60_000),
+      // GitHub accepted the new failure status, then the workflow stopped
+      // before posting the anchor completion marker.
+      statusStatuses: [trusted(failure)],
+      ancestorStatuses: [aggregate(firstAt)],
+      statusSha: STATUS_ANCHOR,
     });
-    assert.equal(result.status, 1, result.stderr);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /"anchorState": "partial"/);
+    assert.match(result.stdout, /"newOrChangedFailures": \[\]/);
+    assert.match(result.posts, new RegExp(`/statuses/${STATUS_ANCHOR}`));
+    assert.doesNotMatch(result.posts, new RegExp(`/statuses/${HEAD}`));
     assert.match(result.posts, /context=ingestion\/seed\/example/);
+    assert.match(result.posts, /context=ingestion\/seed\/acceptance/);
+  });
+
+  it('finishes a partial anchor recovery with the completion marker only', () => {
+    const firstAt = checkedAt(-120_000);
+    const result = runPublisher({
+      blocking: [],
+      observedAt: checkedAt(-60_000),
+      // The recovery source status was accepted after the last complete
+      // projection, but its final acceptance marker was not.
+      statusStatuses: [
+        trusted({
+          context: 'ingestion/seed/example',
+          state: 'success',
+          description: 'recovered; no longer reported',
+        }),
+        aggregate(firstAt),
+        trusted(failure),
+      ],
+      statusSha: STATUS_ANCHOR,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /"anchorState": "partial"/);
+    assert.match(result.posts, new RegExp(`/statuses/${STATUS_ANCHOR}`));
+    assert.doesNotMatch(result.posts, /context=ingestion\/seed\/example/);
     assert.match(result.posts, /context=ingestion\/seed\/acceptance/);
   });
 
@@ -349,7 +488,6 @@ describe('seed health status publisher', () => {
       ],
     });
     assert.equal(unchanged.status, 0, unchanged.stderr);
-    assert.doesNotMatch(unchanged.posts, /context=ingestion\/seed\/example/);
-    assert.match(unchanged.posts, /context=ingestion\/seed\/acceptance/);
+    assert.equal(unchanged.posts, '', 'unchanged same-anchor observations must append no statuses');
   });
 });


### PR DESCRIPTION
## Summary

Active Seed Freshness incidents no longer make unrelated `main` commits look failed to Railway. The monitor still probes the exact gated revision and fails once for a genuinely new or changed incident, but its durable `ingestion/seed/*` projection now lives on a fixed historical operational anchor that cannot become a future deployment candidate.

The first anchored run imports the newest trusted legacy projection, semantic repeats append nothing, and recovery stays non-green until live health clears the source. The publisher fails closed if the anchor leaves the observed lineage and repairs trusted partial writes without reporting the same transition twice.

## Validation

- Pre-push gates passed: browser and API type checks, changed workflow/publisher tests, full markdown lint, Unicode safety, and version sync.
- Focused workflow and publisher tests: 25 passed, 0 failed.
- The earlier broad data suite recorded 25,033 passed, 19 skipped, and one unrelated load-sensitive China policy timing failure; that test passed alone with 26 of 26 cases.
- Live post-merge workflow behavior remains a production observation gate because the status writer requires GitHub Actions credentials and a deployable merged revision.

## Related

Related: #6876

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
