### PR TITLE
fix(analytics): pump a stale collector latch from wall-clock enqueue

### DIFF
--- a/src/services/analytics-collector-transport.ts
+++ b/src/services/analytics-collector-transport.ts
@@ -193,18 +193,16 @@ const REQUEST_TIMEOUT_MS = 20_000;
  *
  * The abort signal and the latch deadline must NOT expire on the same tick. A
  * transport that honors the abort still needs a moment to reject — in a browser
- * that rejection is queued as a task, and on the native path the platform's
- * `AbortSignal.timeout` timer is not ordered against this module's `setTimeout`
- * at all. Firing both at once would make the winner unspecified, so a perfectly
- * cooperative transport would intermittently be reclassified as `raced` and lose
- * the retry it is entitled to. The grace period buys determinism: the transport
- * always gets first refusal, and the module only steps in for a transport that
- * did not answer the abort at all.
+ * that rejection is queued as a task, and the request and latch timers remain
+ * independent clocks. Firing both at once would make the winner unspecified, so
+ * a perfectly cooperative transport would intermittently be reclassified as
+ * `raced` and lose the retry it is entitled to. The grace period buys
+ * determinism: the transport always gets first refusal, and the module only
+ * steps in for a transport that did not answer the abort at all.
  *
  * Sized well above the rejection itself because the two clocks can drift under
- * load: a long task, or a hidden tab under Chromium's intensive throttling
- * (setTimeout clamped to ~1/min after 5 minutes), can leave both timers due in
- * one wake-up. The extra latency lands ONLY on the already-anomalous stalled
+ * load: a long task, or a throttled fallback timer, can leave both timers due
+ * in one wake-up. The extra latency lands ONLY on the already-anomalous stalled
  * tail — a healthy write settles in milliseconds and never sees this timer — so
  * widening it costs nothing on the happy path and buys margin against a false
  * `raced`, which would cost a legitimate write both its retry and its durable
@@ -944,10 +942,8 @@ function withRequestAbort(
  * (`orig(new Request(url, { method, headers, body }))`, the standard shape for
  * RUM SDKs that re-time requests) silently drops `init.signal`, and one that
  * re-wraps the promise without forwarding rejection never settles at all. On
- * the native branch the entire deadline lives inside the `AbortSignal.timeout`
- * object such a wrapper discards, so that path — which carries essentially all
- * real traffic — had strictly LESS module-side protection than the
- * compatibility path.
+ * the native branch the request deadline lives inside the signal such a wrapper
+ * may discard, so the latch below retains its own signal instead.
  *
  * `deadline` is the half nobody else can withhold. Keep sending the abort too:
  * cancelling a well-behaved transport is still correct, and the race only stops
@@ -959,6 +955,30 @@ function withCollectorDeadline(
 ): TimeoutBoundInit {
   // First, because withManualAbort throws when AbortController is unavailable.
   const bound = withRequestAbort(init, timeoutMs);
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    // Keep the latch on the platform timer behind `AbortSignal.timeout`, not on
+    // a page `setTimeout`. Hidden tabs throttle page timers to roughly once a
+    // minute, so a 25s setTimeout latch can fail to pump even one queue slot
+    // inside a 60s health window (#6947). The fetch wrapper may discard the
+    // signal passed below; this retained signal still belongs to this module.
+    const latchSignal = AbortSignal.timeout(timeoutMs + LATCH_RELEASE_GRACE_MS);
+    let releaseLatch: (() => void) | undefined;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      releaseLatch = () => reject(createTimeoutError(timeoutMs, true));
+      if (latchSignal.aborted) releaseLatch();
+      else latchSignal.addEventListener('abort', releaseLatch, { once: true });
+    });
+    void deadline.catch(() => {});
+    return {
+      init: bound.init,
+      deadline,
+      cleanup: () => {
+        if (releaseLatch) latchSignal.removeEventListener('abort', releaseLatch);
+        bound.cleanup();
+      },
+    };
+  }
+
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_resolve, reject) => {
     deadlineTimer = setTimeout(

--- a/src/services/analytics-collector-transport.ts
+++ b/src/services/analytics-collector-transport.ts
@@ -83,7 +83,9 @@ export type CollectorFailure = {
    *    aggregate's verdict, and carries its own Sentry fingerprint segment.
    *    Not gold-plating — this fix REMOVES `queue-overflow`, the parked page's
    *    only other symptom, so without these the population goes dark exactly
-   *    when the bug is fixed (#6288).
+   *    when the bug is fixed (#6288). Hidden-tab timer throttling can still
+   *    withhold the latch callback; enqueue force-expires a stale slot from
+   *    wall-clock before overflowing (#6947).
    */
   raced?: boolean;
 };
@@ -193,23 +195,35 @@ const REQUEST_TIMEOUT_MS = 20_000;
  *
  * The abort signal and the latch deadline must NOT expire on the same tick. A
  * transport that honors the abort still needs a moment to reject — in a browser
- * that rejection is queued as a task, and the request and latch timers remain
- * independent clocks. Firing both at once would make the winner unspecified, so
- * a perfectly cooperative transport would intermittently be reclassified as
- * `raced` and lose the retry it is entitled to. The grace period buys
- * determinism: the transport always gets first refusal, and the module only
- * steps in for a transport that did not answer the abort at all.
+ * that rejection is queued as a task, and on the native path the platform's
+ * `AbortSignal.timeout` timer is not ordered against this module's `setTimeout`
+ * at all. Firing both at once would make the winner unspecified, so a perfectly
+ * cooperative transport would intermittently be reclassified as `raced` and lose
+ * the retry it is entitled to. The grace period buys determinism: the transport
+ * always gets first refusal, and the module only steps in for a transport that
+ * did not answer the abort at all.
  *
  * Sized well above the rejection itself because the two clocks can drift under
- * load: a long task, or a throttled fallback timer, can leave both timers due
- * in one wake-up. The extra latency lands ONLY on the already-anomalous stalled
+ * load: a long task, or a hidden tab under Chromium's intensive throttling
+ * (setTimeout clamped to ~1/min after 5 minutes), can leave both timers due in
+ * one wake-up. The extra latency lands ONLY on the already-anomalous stalled
  * tail — a healthy write settles in milliseconds and never sees this timer — so
  * widening it costs nothing on the happy path and buys margin against a false
  * `raced`, which would cost a legitimate write both its retry and its durable
  * marker. It is a hedge, not a guarantee: see the known limitation in the
  * `raced` docblock.
+ *
+ * The timer is not the only release path. Hidden-tab throttling can withhold
+ * this callback across a whole 60s health window (#6947). Enqueue compares
+ * `Date.now()` against `collectorInFlightStartedAt` and force-expires a stale
+ * latch before applying `COLLECTOR_QUEUE_LIMIT`, so a queue that is already
+ * full still pumps when JS next runs.
  */
 const LATCH_RELEASE_GRACE_MS = 5_000;
+
+function collectorLatchDeadlineMs(): number {
+  return REQUEST_TIMEOUT_MS + LATCH_RELEASE_GRACE_MS;
+}
 
 /**
  * Statuses safe to retry for an APPEND-ONLY event.
@@ -297,6 +311,15 @@ let collectorHealthReporter: CollectorHealthReporter = (report) =>
 
 const collectorRequestQueue: CollectorRequest[] = [];
 let collectorRequestInFlight = false;
+/** Wall-clock start of the current in-flight write; 0 when the slot is free. */
+let collectorInFlightStartedAt = 0;
+/**
+ * Bumped when a stale in-flight write is force-expired from enqueue. The parked
+ * request's `.finally()` must not clear a slot the next write already owns.
+ */
+let collectorInFlightEpoch = 0;
+/** Rejects the current in-flight latch deadline. Cleared on settle or reset. */
+let expireCollectorInFlightLatch: (() => void) | undefined;
 let collectorFetchOriginal: typeof window.fetch | null = null;
 let collectorFetchWrapper: typeof window.fetch | null = null;
 let collectorUnloadFlush: (() => void) | null = null;
@@ -863,6 +886,12 @@ type TimeoutBoundInit = AbortBoundInit & {
    * serialized slot never depends on the callee honoring `init.signal`.
    */
   deadline: Promise<never>;
+  /**
+   * Force-reject `deadline` without waiting for the timer. Used when enqueue
+   * observes that wall-clock has already passed the latch bound (#6947).
+   * No-op after `cleanup()`.
+   */
+  expire: () => void;
 };
 
 /**
@@ -942,8 +971,10 @@ function withRequestAbort(
  * (`orig(new Request(url, { method, headers, body }))`, the standard shape for
  * RUM SDKs that re-time requests) silently drops `init.signal`, and one that
  * re-wraps the promise without forwarding rejection never settles at all. On
- * the native branch the request deadline lives inside the signal such a wrapper
- * may discard, so the latch below retains its own signal instead.
+ * the native branch the entire deadline lives inside the `AbortSignal.timeout`
+ * object such a wrapper discards, so that path — which carries essentially all
+ * real traffic — had strictly LESS module-side protection than the
+ * compatibility path.
  *
  * `deadline` is the half nobody else can withhold. Keep sending the abort too:
  * cancelling a well-behaved transport is still correct, and the race only stops
@@ -955,36 +986,14 @@ function withCollectorDeadline(
 ): TimeoutBoundInit {
   // First, because withManualAbort throws when AbortController is unavailable.
   const bound = withRequestAbort(init, timeoutMs);
-  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
-    // Keep the latch on the platform timer behind `AbortSignal.timeout`, not on
-    // a page `setTimeout`. Hidden tabs throttle page timers to roughly once a
-    // minute, so a 25s setTimeout latch can fail to pump even one queue slot
-    // inside a 60s health window (#6947). The fetch wrapper may discard the
-    // signal passed below; this retained signal still belongs to this module.
-    const latchSignal = AbortSignal.timeout(timeoutMs + LATCH_RELEASE_GRACE_MS);
-    let releaseLatch: (() => void) | undefined;
-    const deadline = new Promise<never>((_resolve, reject) => {
-      releaseLatch = () => reject(createTimeoutError(timeoutMs, true));
-      if (latchSignal.aborted) releaseLatch();
-      else latchSignal.addEventListener('abort', releaseLatch, { once: true });
-    });
-    void deadline.catch(() => {});
-    return {
-      init: bound.init,
-      deadline,
-      cleanup: () => {
-        if (releaseLatch) latchSignal.removeEventListener('abort', releaseLatch);
-        bound.cleanup();
-      },
-    };
-  }
-
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  let fireDeadline: (() => void) | undefined;
   const deadline = new Promise<never>((_resolve, reject) => {
-    deadlineTimer = setTimeout(
-      () => reject(createTimeoutError(timeoutMs, true)),
-      timeoutMs + LATCH_RELEASE_GRACE_MS,
-    );
+    fireDeadline = () => {
+      fireDeadline = undefined;
+      reject(createTimeoutError(timeoutMs, true));
+    };
+    deadlineTimer = setTimeout(fireDeadline, timeoutMs + LATCH_RELEASE_GRACE_MS);
   });
   // The transport wins the race in every healthy case, and the loser of a
   // Promise.race is still rejected. Keep that from surfacing as an unhandled
@@ -993,7 +1002,11 @@ function withCollectorDeadline(
   return {
     init: bound.init,
     deadline,
+    expire: () => {
+      fireDeadline?.();
+    },
     cleanup: () => {
+      fireDeadline = undefined;
       clearTimeout(deadlineTimer);
       bound.cleanup();
     },
@@ -1013,6 +1026,7 @@ async function runCollectorRequest(request: CollectorRequest, generation: number
     collectorDispatchDepth += 1;
     try {
       timeoutBoundInit = withCollectorDeadline(request.init);
+      expireCollectorInFlightLatch = () => timeoutBoundInit?.expire();
       deadline = timeoutBoundInit.deadline;
       responsePromise = request.originalFetch(request.input, timeoutBoundInit.init);
     } finally {
@@ -1087,16 +1101,32 @@ async function runCollectorRequest(request: CollectorRequest, generation: number
   }
 }
 
+function releaseStaleCollectorLatch(now = Date.now()): boolean {
+  if (!collectorRequestInFlight) return false;
+  if (now - collectorInFlightStartedAt < collectorLatchDeadlineMs()) return false;
+  const expire = expireCollectorInFlightLatch;
+  expireCollectorInFlightLatch = undefined;
+  collectorInFlightEpoch += 1;
+  collectorRequestInFlight = false;
+  expire?.();
+  return true;
+}
+
 function drainCollectorRequestQueue(): void {
+  releaseStaleCollectorLatch();
   if (collectorRequestInFlight || collectorRequestQueue.length === 0) return;
   const request = collectorRequestQueue.shift();
   if (!request) return;
 
   collectorRequestInFlight = true;
+  collectorInFlightStartedAt = Date.now();
   const generation = collectorTransportGeneration;
+  const epoch = collectorInFlightEpoch;
   void runCollectorRequest(request, generation).finally(() => {
     if (generation !== collectorTransportGeneration) return;
+    if (epoch !== collectorInFlightEpoch) return;
     collectorRequestInFlight = false;
+    expireCollectorInFlightLatch = undefined;
     drainCollectorRequestQueue();
   });
 }
@@ -1167,6 +1197,12 @@ function enqueueCollectorRequest(
   };
   const transport = transportDeferred.promise;
   const delivery = deliveryDeferred.promise;
+
+  // Pump a stale latch BEFORE the overflow check. A full queue whose in-flight
+  // write has already exceeded the wall-clock bound must make room for this
+  // enqueue rather than shedding it (#6947). Drain is a no-op when the slot is
+  // still within its deadline.
+  drainCollectorRequestQueue();
 
   if (collectorRequestQueue.length >= COLLECTOR_QUEUE_LIMIT) {
     const dropIndex = collectorRequestQueue.findIndex((candidate) => !candidate.critical);
@@ -1275,6 +1311,9 @@ export function observeCollectorDelivery<T>(
 
 export function resetCollectorTransportForTesting(): void {
   collectorTransportGeneration += 1;
+  collectorInFlightEpoch += 1;
+  collectorInFlightStartedAt = 0;
+  expireCollectorInFlightLatch = undefined;
   for (const request of collectorRequestQueue.splice(0, collectorRequestQueue.length)) {
     const error = new Error('Umami collector transport reset');
     request.reject(error);

--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -1022,13 +1022,16 @@ describe('collector request timeout compatibility (#6086)', () => {
         const queued = window.fetch(UMAMI_SEND_URL, collectorEventInit());
         await drainPromiseHandlers();
 
-        assert.equal(deadlines.length, 1, `${label}: the native path must request a collector deadline`);
-        assert.equal(deadlines[0]?.ms, 20_000, `${label}: the deadline must be the collector bound`);
+        const requestDeadlines = deadlines.filter((deadline) => deadline.ms === 20_000);
+        const latchDeadlines = deadlines.filter((deadline) => deadline.ms === LATCH_DEADLINE_MS);
+        assert.equal(requestDeadlines.length, 1, `${label}: the native path must request a collector deadline`);
+        assert.equal(latchDeadlines.length, 1, `${label}: the native path must retain a latch deadline`);
+        assert.equal(requestDeadlines[0]?.ms, 20_000, `${label}: the deadline must be the collector bound`);
         assert.equal(calls, 1, `${label}: the second write waits for the stalled request`);
 
         // Fire the DEADLINE, never the caller signal. If either native branch
         // substituted a non-timing signal, nothing aborts and both awaits hang.
-        deadlines[0]?.controller.abort(createNativeTimeoutError());
+        requestDeadlines[0]?.controller.abort(createNativeTimeoutError());
 
         await assert.rejects(stalled, { name: 'TimeoutError' });
         assert.equal((await queued).status, 200);
@@ -1224,20 +1227,63 @@ describe('collector latch release is module-owned (#6288)', () => {
       // Fire the request-side deadline exactly as production does. It reaches a
       // transport that threw the signal away, so nothing settles. This is the
       // boundary #6088 bought and no further.
-      assert.equal(requestDeadlines[0]?.ms, 20_000, 'the native path must still bind the request-side deadline');
-      requestDeadlines[0]?.controller.abort(createNativeTimeoutError());
+      const requestDeadline = requestDeadlines.find((deadline) => deadline.ms === 20_000);
+      assert.ok(requestDeadline, 'the native path must still bind the request-side deadline');
+      requestDeadline.controller.abort(createNativeTimeoutError());
       await drainPromiseHandlers();
       assert.equal(parkedSettled, false, 'the premise: the transport promise never settles');
       assert.equal(calls, 1, 'aborting a transport that discards the signal cannot drain the queue');
 
-      const latchDeadline = findLatchDeadline(fakeTimers.timers);
-      assert.ok(latchDeadline, 'the module must own a latch deadline the transport cannot withhold');
-      latchDeadline.callback();
+      const latchDeadline = requestDeadlines.find((deadline) => deadline.ms === LATCH_DEADLINE_MS);
+      assert.ok(latchDeadline, 'the module must own a native latch deadline the transport cannot withhold');
+      latchDeadline.controller.abort(createNativeTimeoutError());
 
       const error = await parked.then(() => null, (reason: unknown) => reason);
       assert.equal((error as Error | null)?.name, 'TimeoutError');
       await drainPromiseHandlers(() => calls === 2, 'the queued write reaches the network');
       assert.equal((await queued).status, 200, 'the write behind the park is delivered, not shed');
+    } finally {
+      console.warn = originalWarn;
+      fakeTimers.restore();
+      if (timeoutDescriptor) Object.defineProperty(AbortSignal, 'timeout', timeoutDescriptor);
+    }
+  });
+
+  it('uses a native latch signal that hidden-tab timer throttling cannot withhold (#6947)', { timeout: 10_000 }, async () => {
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
+    const deadlines: { ms: number; controller: AbortController }[] = [];
+    Object.defineProperty(AbortSignal, 'timeout', {
+      configurable: true,
+      value: (ms: number) => {
+        const controller = new AbortController();
+        deadlines.push({ ms, controller });
+        return controller.signal;
+      },
+    });
+    const fakeTimers = installFakeTimers();
+    const originalWarn = console.warn;
+    console.warn = () => {};
+    let calls = 0;
+    window.fetch = (() => {
+      calls += 1;
+      return calls === 1 ? parkForever() : Promise.resolve(collectorResponse(true, 200));
+    }) as typeof window.fetch;
+    installCollectorFetchGate();
+
+    try {
+      const parked = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void parked.catch(() => {});
+      const queued = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      await drainPromiseHandlers();
+      assert.equal(calls, 1, 'the second write waits behind the parked request');
+
+      const latch = deadlines.find((deadline) => deadline.ms === LATCH_DEADLINE_MS);
+      assert.ok(latch, 'the native path must retain a 25s latch signal outside the fetch wrapper');
+      latch.controller.abort(createNativeTimeoutError());
+
+      await assert.rejects(parked, { name: 'TimeoutError' });
+      await drainPromiseHandlers(() => calls === 2, 'the queued write reaches the network');
+      assert.equal((await queued).status, 200);
     } finally {
       console.warn = originalWarn;
       fakeTimers.restore();

--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -833,6 +833,13 @@ function collectorEventInit(signal?: AbortSignal): RequestInit {
   };
 }
 
+function collectorCriticalEventInit(): RequestInit {
+  return {
+    method: 'POST',
+    body: JSON.stringify({ type: 'event', payload: { name: 'checkout-start' } }),
+  };
+}
+
 function rejectWhenAborted(signal: AbortSignal | null | undefined): Promise<Response> {
   assert.ok(signal, 'the collector request must carry a timeout signal');
   return new Promise<Response>((_resolve, reject) => {
@@ -1274,7 +1281,11 @@ describe('collector latch release is module-owned (#6288)', () => {
     let calls = 0;
     window.fetch = (() => {
       calls += 1;
-      return calls === 1 ? parkForever() : Promise.resolve(collectorResponse(true, 200));
+      // Park the successor too. If the parked write's `.finally()` skips the
+      // epoch guard it will start a third fetch while call 2 still owns the
+      // slot. Resolving 200 from call 2 onward would hide that overlap:
+      // `extra` still returns 200 and overflow stays at 0.
+      return calls <= 2 ? parkForever() : Promise.resolve(collectorResponse(true, 200));
     }) as typeof window.fetch;
     installCollectorFetchGate();
 
@@ -1294,7 +1305,9 @@ describe('collector latch release is module-owned (#6288)', () => {
 
       now += LATCH_DEADLINE_MS;
       const extra = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void extra.catch(() => {});
       await drainPromiseHandlers(() => calls >= 2, 'the stale latch must release without a timer callback');
+      assert.equal(calls, 2, 'exactly one write is dispatched from the stale release, not the whole backlog');
 
       const parkedError = await parked.then(() => null, (reason: unknown) => reason);
       assert.equal((parkedError as Error | null)?.name, 'TimeoutError');
@@ -1303,8 +1316,23 @@ describe('collector latch release is module-owned (#6288)', () => {
         { kind: 'timeout', raced: true },
         'the withheld-timer pump must classify the abandoned write as raced',
       );
-      assert.equal((await extra).status, 200, 'the write that would have overflowed is delivered');
+      await drainPromiseHandlers();
+      assert.equal(
+        calls,
+        2,
+        'the parked write must not start a third fetch after the successor owns the slot',
+      );
+      assert.equal(
+        await Promise.race([extra.then(() => 'settled'), Promise.resolve('pending')]),
+        'pending',
+        'the wake-up write stays queued behind the successor, not overflowed',
+      );
       assert.equal(overflowWarnings.length, 0, 'a stale latch must not shed the enqueue that woke it');
+
+      const leftoverLatch = fakeTimers.timers.find((timer) => timer.delay === LATCH_DEADLINE_MS);
+      leftoverLatch?.callback();
+      await drainPromiseHandlers();
+      assert.equal(calls, 2, 'firing the withheld latch timer after expire must not start another fetch');
     } finally {
       Date.now = originalNow;
       console.warn = originalWarn;
@@ -1341,8 +1369,11 @@ describe('collector latch release is module-owned (#6288)', () => {
     try {
       const parked = window.fetch(UMAMI_SEND_URL, collectorEventInit());
       void parked.catch(() => {});
+      const queuedWrites: Promise<Response>[] = [];
       for (let index = 0; index < COLLECTOR_QUEUE_LIMIT; index += 1) {
-        void window.fetch(UMAMI_SEND_URL, collectorEventInit()).catch(() => {});
+        const queued = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+        void queued.catch(() => {});
+        queuedWrites.push(queued);
       }
       await drainPromiseHandlers();
       now += LATCH_DEADLINE_MS - 1;
@@ -1354,9 +1385,176 @@ describe('collector latch release is module-owned (#6288)', () => {
       );
       assert.equal(calls, 1, 'the in-flight slot must stay parked until the latch deadline');
       assert.equal(
+        await Promise.race([extra.then(() => 'settled'), Promise.resolve('pending')]),
+        'pending',
+        'the incoming write is admitted by evicting an older waiter, not overflowed itself',
+      );
+      const dropped = await queuedWrites[0]!.then(() => null, (reason: unknown) => reason);
+      assert.equal(
+        collectorFailureFromError(dropped)?.kind,
+        'queue-overflow',
+        'the oldest queued non-critical write is the overflow victim',
+      );
+      assert.equal(
         await Promise.race([parked.then(() => 'settled'), Promise.resolve('pending')]),
         'pending',
         'the parked write must not be force-expired before the latch deadline',
+      );
+    } finally {
+      Date.now = originalNow;
+      console.warn = originalWarn;
+      fakeTimers.restore();
+      if (timeoutDescriptor) Object.defineProperty(AbortSignal, 'timeout', timeoutDescriptor);
+    }
+  });
+
+  it('pumps a stale latch from wall-clock even when the queue is not full (#6947)', { timeout: 10_000 }, async () => {
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
+    Object.defineProperty(AbortSignal, 'timeout', {
+      configurable: true,
+      value: () => new AbortController().signal,
+    });
+    const fakeTimers = installFakeTimers();
+    let now = 1_700_000_000_000;
+    const originalNow = Date.now;
+    Date.now = () => now;
+    const originalWarn = console.warn;
+    const overflowWarnings: Array<Record<string, unknown>> = [];
+    console.warn = (...args: unknown[]) => {
+      const detail = args[1];
+      if (detail && typeof detail === 'object' && (detail as { failureKind?: unknown }).failureKind === 'queue-overflow') {
+        overflowWarnings.push(detail as Record<string, unknown>);
+      }
+    };
+    let calls = 0;
+    window.fetch = (() => {
+      calls += 1;
+      return calls <= 2 ? parkForever() : Promise.resolve(collectorResponse(true, 200));
+    }) as typeof window.fetch;
+    installCollectorFetchGate();
+
+    try {
+      const parked = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void parked.catch(() => {});
+      const queued = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void queued.catch(() => {});
+      await drainPromiseHandlers();
+      assert.equal(calls, 1, 'one waiter sits behind the parked write');
+
+      now += LATCH_DEADLINE_MS;
+      const extra = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void extra.catch(() => {});
+      await drainPromiseHandlers(() => calls >= 2, 'a later enqueue must pump a stale latch below the overflow bound');
+      assert.equal(calls, 2, 'the queued waiter is dispatched; extra stays behind it');
+      await drainPromiseHandlers();
+      assert.equal(calls, 2, 'the parked write must not start a third fetch after the successor owns the slot');
+      assert.equal(overflowWarnings.length, 0);
+      assert.equal(
+        await Promise.race([extra.then(() => 'settled'), Promise.resolve('pending')]),
+        'pending',
+      );
+    } finally {
+      Date.now = originalNow;
+      console.warn = originalWarn;
+      fakeTimers.restore();
+      if (timeoutDescriptor) Object.defineProperty(AbortSignal, 'timeout', timeoutDescriptor);
+    }
+  });
+
+  it('pumps a full queue from wall-clock on the compatibility path too (#6947)', { timeout: 10_000 }, async () => {
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
+    Object.defineProperty(AbortSignal, 'timeout', { configurable: true, value: undefined });
+    const fakeTimers = installFakeTimers();
+    let now = 1_700_000_000_000;
+    const originalNow = Date.now;
+    Date.now = () => now;
+    const originalWarn = console.warn;
+    const overflowWarnings: Array<Record<string, unknown>> = [];
+    console.warn = (...args: unknown[]) => {
+      const detail = args[1];
+      if (detail && typeof detail === 'object' && (detail as { failureKind?: unknown }).failureKind === 'queue-overflow') {
+        overflowWarnings.push(detail as Record<string, unknown>);
+      }
+    };
+    let calls = 0;
+    window.fetch = (() => {
+      calls += 1;
+      return calls <= 2 ? parkForever() : Promise.resolve(collectorResponse(true, 200));
+    }) as typeof window.fetch;
+    installCollectorFetchGate();
+
+    try {
+      const parked = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void parked.catch(() => {});
+      for (let index = 0; index < COLLECTOR_QUEUE_LIMIT; index += 1) {
+        void window.fetch(UMAMI_SEND_URL, collectorEventInit()).catch(() => {});
+      }
+      await drainPromiseHandlers();
+      assert.equal(calls, 1, 'the queue is full behind one parked write');
+
+      now += LATCH_DEADLINE_MS;
+      const extra = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void extra.catch(() => {});
+      await drainPromiseHandlers(() => calls >= 2, 'the compatibility path must pump from wall-clock without a timer callback');
+      assert.equal(calls, 2, 'exactly one write is dispatched from the stale release');
+      const parkedError = await parked.then(() => null, (reason: unknown) => reason);
+      assert.deepEqual(
+        collectorFailureFromError(parkedError),
+        { kind: 'timeout', raced: true },
+      );
+      await drainPromiseHandlers();
+      assert.equal(calls, 2, 'the parked write must not start a third fetch after the successor owns the slot');
+      assert.equal(overflowWarnings.length, 0, 'a stale latch must not shed the enqueue that woke it');
+    } finally {
+      Date.now = originalNow;
+      console.warn = originalWarn;
+      fakeTimers.restore();
+      if (timeoutDescriptor) Object.defineProperty(AbortSignal, 'timeout', timeoutDescriptor);
+    }
+  });
+
+  it('admits a non-critical extra after pumping a stale all-critical queue (#6947)', { timeout: 10_000 }, async () => {
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
+    Object.defineProperty(AbortSignal, 'timeout', {
+      configurable: true,
+      value: () => new AbortController().signal,
+    });
+    const fakeTimers = installFakeTimers();
+    let now = 1_700_000_000_000;
+    const originalNow = Date.now;
+    Date.now = () => now;
+    const originalWarn = console.warn;
+    const overflowWarnings: Array<Record<string, unknown>> = [];
+    console.warn = (...args: unknown[]) => {
+      const detail = args[1];
+      if (detail && typeof detail === 'object' && (detail as { failureKind?: unknown }).failureKind === 'queue-overflow') {
+        overflowWarnings.push(detail as Record<string, unknown>);
+      }
+    };
+    let calls = 0;
+    window.fetch = (() => {
+      calls += 1;
+      return calls <= 2 ? parkForever() : Promise.resolve(collectorResponse(true, 200));
+    }) as typeof window.fetch;
+    installCollectorFetchGate();
+
+    try {
+      const parked = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void parked.catch(() => {});
+      for (let index = 0; index < COLLECTOR_QUEUE_LIMIT; index += 1) {
+        void window.fetch(UMAMI_SEND_URL, collectorCriticalEventInit()).catch(() => {});
+      }
+      await drainPromiseHandlers();
+      now += LATCH_DEADLINE_MS;
+      const extra = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void extra.catch(() => {});
+      await drainPromiseHandlers(() => calls >= 2, 'the stale latch must make room before the all-critical overflow branch');
+      assert.equal(calls, 2);
+      assert.equal(overflowWarnings.length, 0, 'drain-before-overflow must not reject the incoming non-critical write');
+      assert.equal(
+        await Promise.race([extra.then(() => 'settled'), Promise.resolve('pending')]),
+        'pending',
+        'the non-critical extra is queued behind the remaining critical waiters',
       );
     } finally {
       Date.now = originalNow;

--- a/tests/analytics-beacon-rejection.test.mts
+++ b/tests/analytics-beacon-rejection.test.mts
@@ -1022,16 +1022,13 @@ describe('collector request timeout compatibility (#6086)', () => {
         const queued = window.fetch(UMAMI_SEND_URL, collectorEventInit());
         await drainPromiseHandlers();
 
-        const requestDeadlines = deadlines.filter((deadline) => deadline.ms === 20_000);
-        const latchDeadlines = deadlines.filter((deadline) => deadline.ms === LATCH_DEADLINE_MS);
-        assert.equal(requestDeadlines.length, 1, `${label}: the native path must request a collector deadline`);
-        assert.equal(latchDeadlines.length, 1, `${label}: the native path must retain a latch deadline`);
-        assert.equal(requestDeadlines[0]?.ms, 20_000, `${label}: the deadline must be the collector bound`);
+        assert.equal(deadlines.length, 1, `${label}: the native path must request a collector deadline`);
+        assert.equal(deadlines[0]?.ms, 20_000, `${label}: the deadline must be the collector bound`);
         assert.equal(calls, 1, `${label}: the second write waits for the stalled request`);
 
         // Fire the DEADLINE, never the caller signal. If either native branch
         // substituted a non-timing signal, nothing aborts and both awaits hang.
-        requestDeadlines[0]?.controller.abort(createNativeTimeoutError());
+        deadlines[0]?.controller.abort(createNativeTimeoutError());
 
         await assert.rejects(stalled, { name: 'TimeoutError' });
         assert.equal((await queued).status, 200);
@@ -1227,16 +1224,15 @@ describe('collector latch release is module-owned (#6288)', () => {
       // Fire the request-side deadline exactly as production does. It reaches a
       // transport that threw the signal away, so nothing settles. This is the
       // boundary #6088 bought and no further.
-      const requestDeadline = requestDeadlines.find((deadline) => deadline.ms === 20_000);
-      assert.ok(requestDeadline, 'the native path must still bind the request-side deadline');
-      requestDeadline.controller.abort(createNativeTimeoutError());
+      assert.equal(requestDeadlines[0]?.ms, 20_000, 'the native path must still bind the request-side deadline');
+      requestDeadlines[0]?.controller.abort(createNativeTimeoutError());
       await drainPromiseHandlers();
       assert.equal(parkedSettled, false, 'the premise: the transport promise never settles');
       assert.equal(calls, 1, 'aborting a transport that discards the signal cannot drain the queue');
 
-      const latchDeadline = requestDeadlines.find((deadline) => deadline.ms === LATCH_DEADLINE_MS);
-      assert.ok(latchDeadline, 'the module must own a native latch deadline the transport cannot withhold');
-      latchDeadline.controller.abort(createNativeTimeoutError());
+      const latchDeadline = findLatchDeadline(fakeTimers.timers);
+      assert.ok(latchDeadline, 'the module must own a latch deadline the transport cannot withhold');
+      latchDeadline.callback();
 
       const error = await parked.then(() => null, (reason: unknown) => reason);
       assert.equal((error as Error | null)?.name, 'TimeoutError');
@@ -1249,20 +1245,32 @@ describe('collector latch release is module-owned (#6288)', () => {
     }
   });
 
-  it('uses a native latch signal that hidden-tab timer throttling cannot withhold (#6947)', { timeout: 10_000 }, async () => {
+  // #6947: Chromium intensive throttling can withhold a 25s setTimeout (and
+  // AbortSignal.timeout, which uses the same scheduler) across an entire 60s
+  // health window. The overflow enqueue is itself a JS turn — Date.now still
+  // advances — so the latch must pump from wall-clock on enqueue, not from a
+  // timer callback the page never receives.
+  it('pumps a full queue from wall-clock on enqueue when the latch timer is withheld (#6947)', { timeout: 10_000 }, async () => {
     const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
-    const deadlines: { ms: number; controller: AbortController }[] = [];
     Object.defineProperty(AbortSignal, 'timeout', {
       configurable: true,
-      value: (ms: number) => {
-        const controller = new AbortController();
-        deadlines.push({ ms, controller });
-        return controller.signal;
-      },
+      // Never auto-fire: a real AbortSignal.timeout would hold the process for 20s
+      // and is not the latch under test. The request-side abort is discarded by
+      // parkForever the same way a rebuilding wrapper discards it in production.
+      value: () => new AbortController().signal,
     });
     const fakeTimers = installFakeTimers();
+    let now = 1_700_000_000_000;
+    const originalNow = Date.now;
+    Date.now = () => now;
     const originalWarn = console.warn;
-    console.warn = () => {};
+    const overflowWarnings: Array<Record<string, unknown>> = [];
+    console.warn = (...args: unknown[]) => {
+      const detail = args[1];
+      if (detail && typeof detail === 'object' && (detail as { failureKind?: unknown }).failureKind === 'queue-overflow') {
+        overflowWarnings.push(detail as Record<string, unknown>);
+      }
+    };
     let calls = 0;
     window.fetch = (() => {
       calls += 1;
@@ -1273,18 +1281,85 @@ describe('collector latch release is module-owned (#6288)', () => {
     try {
       const parked = window.fetch(UMAMI_SEND_URL, collectorEventInit());
       void parked.catch(() => {});
-      const queued = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      for (let index = 0; index < COLLECTOR_QUEUE_LIMIT; index += 1) {
+        void window.fetch(UMAMI_SEND_URL, collectorEventInit()).catch(() => {});
+      }
       await drainPromiseHandlers();
-      assert.equal(calls, 1, 'the second write waits behind the parked request');
+      assert.equal(calls, 1, 'the queue is full behind one parked write');
+      assert.equal(overflowWarnings.length, 0, 'filling exactly to the bound must not overflow');
+      assert.ok(
+        fakeTimers.timers.some((timer) => timer.delay === LATCH_DEADLINE_MS && !timer.cancelled),
+        'a latch timer exists, and this test deliberately never fires it',
+      );
 
-      const latch = deadlines.find((deadline) => deadline.ms === LATCH_DEADLINE_MS);
-      assert.ok(latch, 'the native path must retain a 25s latch signal outside the fetch wrapper');
-      latch.controller.abort(createNativeTimeoutError());
+      now += LATCH_DEADLINE_MS;
+      const extra = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      await drainPromiseHandlers(() => calls >= 2, 'the stale latch must release without a timer callback');
 
-      await assert.rejects(parked, { name: 'TimeoutError' });
-      await drainPromiseHandlers(() => calls === 2, 'the queued write reaches the network');
-      assert.equal((await queued).status, 200);
+      const parkedError = await parked.then(() => null, (reason: unknown) => reason);
+      assert.equal((parkedError as Error | null)?.name, 'TimeoutError');
+      assert.deepEqual(
+        collectorFailureFromError(parkedError),
+        { kind: 'timeout', raced: true },
+        'the withheld-timer pump must classify the abandoned write as raced',
+      );
+      assert.equal((await extra).status, 200, 'the write that would have overflowed is delivered');
+      assert.equal(overflowWarnings.length, 0, 'a stale latch must not shed the enqueue that woke it');
     } finally {
+      Date.now = originalNow;
+      console.warn = originalWarn;
+      fakeTimers.restore();
+      if (timeoutDescriptor) Object.defineProperty(AbortSignal, 'timeout', timeoutDescriptor);
+    }
+  });
+
+  it('does not release a fresh in-flight slot just because the queue is full (#6947)', { timeout: 10_000 }, async () => {
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
+    Object.defineProperty(AbortSignal, 'timeout', {
+      configurable: true,
+      value: () => new AbortController().signal,
+    });
+    const fakeTimers = installFakeTimers();
+    let now = 1_700_000_000_000;
+    const originalNow = Date.now;
+    Date.now = () => now;
+    const originalWarn = console.warn;
+    const overflowWarnings: Array<Record<string, unknown>> = [];
+    console.warn = (...args: unknown[]) => {
+      const detail = args[1];
+      if (detail && typeof detail === 'object' && (detail as { failureKind?: unknown }).failureKind === 'queue-overflow') {
+        overflowWarnings.push(detail as Record<string, unknown>);
+      }
+    };
+    let calls = 0;
+    window.fetch = (() => {
+      calls += 1;
+      return calls === 1 ? parkForever() : Promise.resolve(collectorResponse(true, 200));
+    }) as typeof window.fetch;
+    installCollectorFetchGate();
+
+    try {
+      const parked = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void parked.catch(() => {});
+      for (let index = 0; index < COLLECTOR_QUEUE_LIMIT; index += 1) {
+        void window.fetch(UMAMI_SEND_URL, collectorEventInit()).catch(() => {});
+      }
+      await drainPromiseHandlers();
+      now += LATCH_DEADLINE_MS - 1;
+      const extra = window.fetch(UMAMI_SEND_URL, collectorEventInit());
+      void extra.catch(() => {});
+      await drainPromiseHandlers(
+        () => overflowWarnings.length > 0,
+        'a write that arrives before the latch deadline must still overflow',
+      );
+      assert.equal(calls, 1, 'the in-flight slot must stay parked until the latch deadline');
+      assert.equal(
+        await Promise.race([parked.then(() => 'settled'), Promise.resolve('pending')]),
+        'pending',
+        'the parked write must not be force-expired before the latch deadline',
+      );
+    } finally {
+      Date.now = originalNow;
       console.warn = originalWarn;
       fakeTimers.restore();
       if (timeoutDescriptor) Object.defineProperty(AbortSignal, 'timeout', timeoutDescriptor);


### PR DESCRIPTION
## Summary

- `queue-overflow` on WORLDMONITOR-YD survived the #6288 latch because Chromium intensive throttling can withhold a 25s `setTimeout` (and `AbortSignal.timeout`, which uses the same scheduler) across an entire 60s health window. The queue is already full when the window opens and never drains, so the overflow write reports `writeCount` well below 50.
- The overflow enqueue is itself a JavaScript turn, so `Date.now()` still advances. Enqueue now force-expires an in-flight write whose wall-clock age has already passed the 25s latch, then drains, **before** applying `COLLECTOR_QUEUE_LIMIT`.
- Keep the module-owned `setTimeout` latch for visible pages where timers still fire. Do not move the latch onto `AbortSignal.timeout` — that is throttled the same way and cannot pump these windows.

Fixes #6947
Fixes WORLDMONITOR-YD

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: analytics collector transport

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

Not applicable: this changes collector transport behavior only and does not publish or change documentation claims.

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key

## Screenshots

Not applicable.