### PR TITLE
fix(agents): serve site-wide .md twins, not one sampled URL

### DIFF
--- a/api/_md-url-twin.ts
+++ b/api/_md-url-twin.ts
@@ -14,7 +14,18 @@ import { getPublicCorsHeaders } from './_cors.js';
 
 export const MD_TWIN_LOOP_HEADER = 'x-wm-md-twin';
 const MAX_TWIN_CHARS = 80_000;
+const MAX_TWIN_BYTES = 80_000;
 const SIBLING_FETCH_TIMEOUT_MS = 8_000;
+const SIBLING_USER_AGENT = 'WorldMonitor-MarkdownTwin/1.0';
+const FORWARDED_RESPONSE_HEADERS = [
+  'allow',
+  'location',
+  'retry-after',
+  'www-authenticate',
+  'x-ratelimit-limit',
+  'x-ratelimit-remaining',
+  'x-ratelimit-reset',
+] as const;
 
 export function isMarkdownTwinPath(pathname: string): boolean {
   return (
@@ -144,6 +155,62 @@ function headingFromPath(pathname: string): string {
   return leaf.replace(/[-_]+/g, ' ');
 }
 
+async function readSiblingBody(response: Response): Promise<string> {
+  const declaredLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_TWIN_BYTES) {
+    try {
+      void response.body?.cancel('Sibling response exceeds the markdown twin byte limit').catch(() => {});
+    } catch {
+      // The declared size is already enough to reject the response.
+    }
+    throw new Error('Sibling response exceeds the markdown twin byte limit');
+  }
+
+  if (!response.body) return '';
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_TWIN_BYTES) {
+        try {
+          void reader.cancel('Sibling response exceeds the markdown twin byte limit').catch(() => {});
+        } catch {
+          // The stream may already be errored; the size failure is authoritative.
+        }
+        throw new Error('Sibling response exceeds the markdown twin byte limit');
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+function forwardedResponseHeaders(response: Response): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const name of FORWARDED_RESPONSE_HEADERS) {
+    const value = response.headers.get(name);
+    if (value) headers[name] = value;
+  }
+  return headers;
+}
+
 export async function buildMarkdownTwinResponse(
   req: Request,
   markdownPath: string,
@@ -181,19 +248,14 @@ export async function buildMarkdownTwinResponse(
   siblingUrl.search = new URL(req.url).search;
 
   const outbound = new Headers();
-  const ua = req.headers.get('user-agent');
-  outbound.set('user-agent', ua && ua.length >= 10 ? ua : 'WorldMonitor-MarkdownTwin/1.0');
+  outbound.set('user-agent', SIBLING_USER_AGENT);
   outbound.set(MD_TWIN_LOOP_HEADER, '1');
   outbound.set('accept', 'text/html, application/json;q=0.9, text/plain;q=0.8, */*;q=0.1');
-  for (const headerName of ['authorization', 'x-worldmonitor-key', 'x-api-key', 'cookie']) {
-    const value = req.headers.get(headerName);
-    if (value) outbound.set(headerName, value);
-  }
 
   let siblingRes: Response;
   try {
     siblingRes = await fetchImpl(siblingUrl, {
-      method: 'GET',
+      method: req.method,
       headers: outbound,
       redirect: 'manual',
       signal: AbortSignal.timeout(SIBLING_FETCH_TIMEOUT_MS),
@@ -214,35 +276,57 @@ export async function buildMarkdownTwinResponse(
     });
   }
 
-  const contentType = siblingRes.headers.get('content-type') ?? '';
-  const raw = await siblingRes.text();
+  const isFailure = !siblingRes.ok;
+  const siblingStatus = isFailure ? siblingRes.status : 200;
+  const responseHeaders: Record<string, string> = {
+    ...(isFailure ? { 'Cache-Control': 'no-store' } : {}),
+    ...forwardedResponseHeaders(siblingRes),
+  };
+
+  if (req.method === 'HEAD') {
+    return new Response(null, {
+      status: siblingStatus,
+      headers: markdownHeaders(req, markdownPath, responseHeaders),
+    });
+  }
+
+  if (siblingStatus === 304) {
+    return new Response(null, {
+      status: siblingStatus,
+      headers: markdownHeaders(req, markdownPath, responseHeaders),
+    });
+  }
+
   const heading = headingFromPath(sibling);
   let markdown: string;
+  try {
+    const contentType = siblingRes.headers.get('content-type') ?? '';
+    const raw = await readSiblingBody(siblingRes);
 
-  if (/markdown|text\/plain/i.test(contentType) && /^# /m.test(raw)) {
-    markdown = raw.slice(0, MAX_TWIN_CHARS);
-  } else if (/json/i.test(contentType) || raw.trim().startsWith('{') || raw.trim().startsWith('[')) {
-    markdown = jsonToMarkdown(raw, heading);
-  } else if (/html/i.test(contentType) || /<html|<body|<title/i.test(raw)) {
-    markdown = htmlToMarkdown(raw, heading);
-  } else if (raw.trim().length === 0) {
-    markdown = `# ${heading}\n`;
-  } else {
-    markdown = /^# /m.test(raw) ? raw.slice(0, MAX_TWIN_CHARS) : `# ${heading}\n\n${raw}`.slice(0, MAX_TWIN_CHARS);
+    if (/markdown|text\/plain/i.test(contentType) && /^# /m.test(raw)) {
+      markdown = raw.slice(0, MAX_TWIN_CHARS);
+    } else if (/json/i.test(contentType) || raw.trim().startsWith('{') || raw.trim().startsWith('[')) {
+      markdown = jsonToMarkdown(raw, heading);
+    } else if (/html/i.test(contentType) || /<html|<body|<title/i.test(raw)) {
+      markdown = htmlToMarkdown(raw, heading);
+    } else if (raw.trim().length === 0) {
+      markdown = `# ${heading}\n`;
+    } else {
+      markdown = /^# /m.test(raw) ? raw.slice(0, MAX_TWIN_CHARS) : `# ${heading}\n\n${raw}`.slice(0, MAX_TWIN_CHARS);
+    }
+
+    if (!/^# /m.test(markdown)) {
+      markdown = `# ${heading}\n\n${markdown}`;
+    }
+  } catch {
+    return new Response(`# ${heading}\n\nThe sibling page at \`${sibling}\` could not be read.\n`, {
+      status: 502,
+      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
+    });
   }
 
-  if (!/^# /m.test(markdown)) {
-    markdown = `# ${heading}\n\n${markdown}`;
-  }
-
-  const status = siblingRes.status === 404 || siblingRes.status === 410 ? siblingRes.status : 200;
-
-  return new Response(req.method === 'HEAD' ? null : markdown, {
-    status,
-    headers: markdownHeaders(
-      req,
-      markdownPath,
-      status >= 400 ? { 'Cache-Control': 'no-store' } : {},
-    ),
+  return new Response(markdown, {
+    status: siblingStatus,
+    headers: markdownHeaders(req, markdownPath, responseHeaders),
   });
 }

--- a/api/_md-url-twin.ts
+++ b/api/_md-url-twin.ts
@@ -1,0 +1,248 @@
+/**
+ * Markdown URL-fallback twins for agent-readiness scanners.
+ *
+ * The protocol is site-wide: GET /{page} has a twin at GET /{page}.md with
+ * text/markdown (or a heading-led non-HTML body). Static files under public/
+ * win. Everything else is generated from the sibling URL.
+ *
+ * Loop-prevention: sibling fetches send x-wm-md-twin so a .md handler never
+ * fetches another .md handler.
+ */
+
+// @ts-expect-error — JS module, no declaration file
+import { getPublicCorsHeaders } from './_cors.js';
+
+export const MD_TWIN_LOOP_HEADER = 'x-wm-md-twin';
+const MAX_TWIN_CHARS = 80_000;
+const SIBLING_FETCH_TIMEOUT_MS = 8_000;
+
+export function isMarkdownTwinPath(pathname: string): boolean {
+  return (
+    pathname.startsWith('/') &&
+    pathname.endsWith('.md') &&
+    pathname.length > 4 &&
+    !pathname.includes('..') &&
+    !pathname.includes('//') &&
+    !pathname.includes('\\')
+  );
+}
+
+export function siblingPathFromMarkdown(markdownPath: string): string | null {
+  if (!isMarkdownTwinPath(markdownPath)) return null;
+  if (markdownPath.startsWith('/api/md-twin')) return null;
+  const sibling = markdownPath.slice(0, -3);
+  return sibling.length > 0 ? sibling : null;
+}
+
+export function sanitizeMarkdownTwinPath(raw: string): string | null {
+  let candidate = raw.trim();
+  if (!candidate.startsWith('/')) candidate = `/${candidate}`;
+  if (!candidate.endsWith('.md')) candidate += '.md';
+  if (!isMarkdownTwinPath(candidate)) return null;
+  if (candidate.startsWith('/api/md-twin')) return null;
+  return candidate;
+}
+
+export function resolveMarkdownTwinPath(req: Request): string | null {
+  const url = new URL(req.url);
+  const pathname = url.pathname;
+  if (pathname === '/api/md-twin' || pathname === '/api/md-twin/') {
+    const queryPath = url.searchParams.get('path') ?? url.searchParams.get('mdPath');
+    if (!queryPath || queryPath === '$1') return null;
+    return sanitizeMarkdownTwinPath(queryPath);
+  }
+  if (isMarkdownTwinPath(pathname)) return pathname;
+  return null;
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#(\d+);/g, (_, code) => {
+      const n = Number(code);
+      return Number.isFinite(n) && n >= 32 ? String.fromCharCode(n) : '';
+    });
+}
+
+function stripTags(value: string): string {
+  return decodeHtmlEntities(value.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim());
+}
+
+export function htmlToMarkdown(html: string, fallbackTitle: string): string {
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = stripTags(titleMatch?.[1] ?? '') || fallbackTitle;
+
+  const body = html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<noscript[\s\S]*?<\/noscript>/gi, ' ');
+
+  const main = body.match(/<main\b[\s\S]*?<\/main>/i)?.[0] ?? body;
+
+  let text = main
+    .replace(/<h1\b[^>]*>([\s\S]*?)<\/h1>/gi, (_m, inner: string) => `\n\n# ${stripTags(inner)}\n\n`)
+    .replace(/<h2\b[^>]*>([\s\S]*?)<\/h2>/gi, (_m, inner: string) => `\n\n## ${stripTags(inner)}\n\n`)
+    .replace(/<h3\b[^>]*>([\s\S]*?)<\/h3>/gi, (_m, inner: string) => `\n\n### ${stripTags(inner)}\n\n`)
+    .replace(/<h4\b[^>]*>([\s\S]*?)<\/h4>/gi, (_m, inner: string) => `\n\n#### ${stripTags(inner)}\n\n`)
+    .replace(/<h5\b[^>]*>([\s\S]*?)<\/h5>/gi, (_m, inner: string) => `\n\n##### ${stripTags(inner)}\n\n`)
+    .replace(/<h6\b[^>]*>([\s\S]*?)<\/h6>/gi, (_m, inner: string) => `\n\n###### ${stripTags(inner)}\n\n`)
+    .replace(
+      /<a\b[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
+      (_m, href: string, inner: string) => {
+        const label = stripTags(inner) || href;
+        return `[${label}](${href})`;
+      },
+    )
+    .replace(/<li\b[^>]*>([\s\S]*?)<\/li>/gi, (_m, inner: string) => `\n- ${stripTags(inner)}`)
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n\n')
+    .replace(/<\/div>/gi, '\n')
+    .replace(/<[^>]+>/g, ' ');
+
+  text = decodeHtmlEntities(text)
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+
+  if (!/^# /m.test(text)) {
+    text = text.length > 0 ? `# ${title}\n\n${text}` : `# ${title}`;
+  }
+
+  return text.slice(0, MAX_TWIN_CHARS);
+}
+
+function jsonToMarkdown(raw: string, heading: string): string {
+  let pretty = raw.trim();
+  try {
+    pretty = JSON.stringify(JSON.parse(raw) as unknown, null, 2);
+  } catch {
+    // Keep the original text when the body is not JSON.
+  }
+  return `# ${heading}\n\n\`\`\`json\n${pretty}\n\`\`\``.slice(0, MAX_TWIN_CHARS);
+}
+
+function markdownHeaders(req: Request, markdownPath: string, extra: Record<string, string> = {}): Record<string, string> {
+  const origin = new URL(req.url).origin;
+  return {
+    'Content-Type': 'text/markdown; charset=utf-8',
+    'X-Content-Type-Options': 'nosniff',
+    'Cache-Control': 'public, max-age=3600',
+    Link: `<${origin}${markdownPath}>; rel="canonical"`,
+    ...getPublicCorsHeaders('GET, HEAD, OPTIONS'),
+    ...extra,
+  };
+}
+
+function headingFromPath(pathname: string): string {
+  const leaf = pathname.split('/').filter(Boolean).pop() ?? pathname;
+  return leaf.replace(/[-_]+/g, ' ');
+}
+
+export async function buildMarkdownTwinResponse(
+  req: Request,
+  markdownPath: string,
+  fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<Response> {
+  const corsHeaders = getPublicCorsHeaders('GET, HEAD, OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    return new Response('# Method not allowed\n', {
+      status: 405,
+      headers: markdownHeaders(req, markdownPath, { Allow: 'GET, HEAD, OPTIONS' }),
+    });
+  }
+
+  if (req.headers.get(MD_TWIN_LOOP_HEADER) === '1') {
+    return new Response('# Not found\n', {
+      status: 404,
+      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
+    });
+  }
+
+  const sibling = siblingPathFromMarkdown(markdownPath);
+  if (!sibling) {
+    return new Response('# Not found\n', {
+      status: 404,
+      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
+    });
+  }
+
+  const siblingUrl = new URL(sibling, req.url);
+  siblingUrl.search = new URL(req.url).search;
+
+  const outbound = new Headers();
+  const ua = req.headers.get('user-agent');
+  outbound.set('user-agent', ua && ua.length >= 10 ? ua : 'WorldMonitor-MarkdownTwin/1.0');
+  outbound.set(MD_TWIN_LOOP_HEADER, '1');
+  outbound.set('accept', 'text/html, application/json;q=0.9, text/plain;q=0.8, */*;q=0.1');
+  for (const headerName of ['authorization', 'x-worldmonitor-key', 'x-api-key', 'cookie']) {
+    const value = req.headers.get(headerName);
+    if (value) outbound.set(headerName, value);
+  }
+
+  let siblingRes: Response;
+  try {
+    siblingRes = await fetchImpl(siblingUrl, {
+      method: 'GET',
+      headers: outbound,
+      redirect: 'manual',
+      signal: AbortSignal.timeout(SIBLING_FETCH_TIMEOUT_MS),
+    });
+  } catch {
+    return new Response(`# ${headingFromPath(sibling)}\n\nThe sibling page at \`${sibling}\` could not be fetched.\n`, {
+      status: 502,
+      headers: markdownHeaders(req, markdownPath, { 'Cache-Control': 'no-store' }),
+    });
+  }
+
+  const location = siblingRes.headers.get('location');
+  if (siblingRes.status >= 300 && siblingRes.status < 400 && location) {
+    const body = `# ${headingFromPath(sibling)}\n\nThis resource redirects to [${location}](${location}).\n`;
+    return new Response(req.method === 'HEAD' ? null : body, {
+      status: 200,
+      headers: markdownHeaders(req, markdownPath),
+    });
+  }
+
+  const contentType = siblingRes.headers.get('content-type') ?? '';
+  const raw = await siblingRes.text();
+  const heading = headingFromPath(sibling);
+  let markdown: string;
+
+  if (/markdown|text\/plain/i.test(contentType) && /^# /m.test(raw)) {
+    markdown = raw.slice(0, MAX_TWIN_CHARS);
+  } else if (/json/i.test(contentType) || raw.trim().startsWith('{') || raw.trim().startsWith('[')) {
+    markdown = jsonToMarkdown(raw, heading);
+  } else if (/html/i.test(contentType) || /<html|<body|<title/i.test(raw)) {
+    markdown = htmlToMarkdown(raw, heading);
+  } else if (raw.trim().length === 0) {
+    markdown = `# ${heading}\n`;
+  } else {
+    markdown = /^# /m.test(raw) ? raw.slice(0, MAX_TWIN_CHARS) : `# ${heading}\n\n${raw}`.slice(0, MAX_TWIN_CHARS);
+  }
+
+  if (!/^# /m.test(markdown)) {
+    markdown = `# ${heading}\n\n${markdown}`;
+  }
+
+  const status = siblingRes.status === 404 || siblingRes.status === 410 ? siblingRes.status : 200;
+
+  return new Response(req.method === 'HEAD' ? null : markdown, {
+    status,
+    headers: markdownHeaders(
+      req,
+      markdownPath,
+      status >= 400 ? { 'Cache-Control': 'no-store' } : {},
+    ),
+  });
+}

--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -554,7 +554,14 @@
     {
       "path": "api/not-found.ts",
       "category": "ops-admin",
-      "reason": "Structured JSON 404 responder for unmatched /api/* paths (mounted by api/[...notfound].ts). Fixed-shape error envelope for agents/scanners in place of Vercel's native text/plain NOT_FOUND; not a product API.",
+      "reason": "Structured JSON 404 responder for unmatched /api/* paths (mounted by api/[...notfound].ts). Fixed-shape error envelope for agents/scanners in place of Vercel's native text/plain NOT_FOUND; unmatched GET/HEAD /api/*.md probes are answered as heading-led text/markdown twins instead. Not a product API.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/md-twin.ts",
+      "category": "non-json",
+      "reason": "Agent markdown URL-fallback generator. AfterFiles rewrite of unmatched /{page}.md (static files and /docs/* still win) returns heading-led text/markdown from the sibling page — not a JSON data API.",
       "owner": "@SebastienMelki",
       "removal_issue": null
     },

--- a/api/md-twin.ts
+++ b/api/md-twin.ts
@@ -1,0 +1,30 @@
+/**
+ * Generic markdown URL-fallback handler.
+ *
+ * Vercel afterFiles rewrites unmatched `/{page}.md` (except static files,
+ * /docs/*, /index.md, and /api/*) here. The handler fetches the sibling page
+ * and returns heading-led text/markdown so agent-readiness scanners that
+ * probe arbitrary content URLs get a .md twin, not a JSON/HTML 404.
+ */
+
+import {
+  buildMarkdownTwinResponse,
+  resolveMarkdownTwinPath,
+} from './_md-url-twin';
+
+export const config = { runtime: 'edge' };
+
+export default async function handler(req: Request): Promise<Response> {
+  const markdownPath = resolveMarkdownTwinPath(req);
+  if (!markdownPath) {
+    return new Response('# Not found\n\nNo markdown twin path was provided.\n', {
+      status: 404,
+      headers: {
+        'Content-Type': 'text/markdown; charset=utf-8',
+        'Cache-Control': 'no-store',
+        'Access-Control-Allow-Origin': '*',
+      },
+    });
+  }
+  return buildMarkdownTwinResponse(req, markdownPath);
+}

--- a/api/not-found.ts
+++ b/api/not-found.ts
@@ -17,8 +17,9 @@ export const config = { runtime: 'edge' };
 
 // @ts-expect-error — JS module, no declaration file
 import { getPublicCorsHeaders } from './_cors.js';
+import { buildMarkdownTwinResponse, isMarkdownTwinPath } from './_md-url-twin';
 
-export default function handler(req: Request): Response {
+export default function handler(req: Request): Response | Promise<Response> {
   const corsHeaders = getPublicCorsHeaders('GET, POST, OPTIONS');
 
   if (req.method === 'OPTIONS') {
@@ -32,6 +33,16 @@ export default function handler(req: Request): Response {
       return req.url;
     }
   })();
+
+  // Unmatched /api/*.md is a markdown URL-fallback probe, not a missing JSON
+  // RPC. Serve a heading-led text/markdown twin of the sibling path instead of
+  // the structured JSON 404 (static public/api/*.md files still win first).
+  if (
+    isMarkdownTwinPath(pathname) &&
+    (req.method === 'GET' || req.method === 'HEAD')
+  ) {
+    return buildMarkdownTwinResponse(req, pathname);
+  }
 
   const body = {
     error: {

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,6 +38,10 @@ const LEGACY_DASHBOARD_ROOT_QUERY_KEYS = ['lat', 'lon', 'zoom', 'view', 'timeRan
 //   keyless, advertised as service-meta in /.well-known/api-catalog). Agents
 //   evaluating the product are a primary audience; an agent-journey run (#4854)
 //   got 403 here and concluded the endpoint didn't exist.
+// - /api/download.md: static markdown twin of GET /api/download for
+//   markdown-URL-fallback crawlers. Same /api/* bot-gate problem as
+//   /api/llms.txt — without this bypass, orank/agent scanners that request
+//   the .md twin receive JSON 403 instead of text/markdown.
 const PUBLIC_API_PATHS = new Set([
   '/api/version',
   '/api/health',
@@ -45,6 +49,7 @@ const PUBLIC_API_PATHS = new Set([
   '/api/internal/brief-why-matters',
   '/api/llms.txt',
   '/api/product-catalog',
+  '/api/download.md',
 ]);
 
 const SOCIAL_IMAGE_UA =

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,10 +38,11 @@ const LEGACY_DASHBOARD_ROOT_QUERY_KEYS = ['lat', 'lon', 'zoom', 'view', 'timeRan
 //   keyless, advertised as service-meta in /.well-known/api-catalog). Agents
 //   evaluating the product are a primary audience; an agent-journey run (#4854)
 //   got 403 here and concluded the endpoint didn't exist.
-// - /api/download.md: static markdown twin of GET /api/download for
-//   markdown-URL-fallback crawlers. Same /api/* bot-gate problem as
-//   /api/llms.txt — without this bypass, orank/agent scanners that request
-//   the .md twin receive JSON 403 instead of text/markdown.
+// - /api/download.md: curated static markdown twin of GET /api/download.
+//   Kept on the exact allowlist so a future glob refactor cannot drop the
+//   sampled URL. All other GET/HEAD /api/**/*.md twins bypass via
+//   isPublicApiMarkdownTwin() below — the protocol is site-wide .md twins,
+//   not one sampled path.
 const PUBLIC_API_PATHS = new Set([
   '/api/version',
   '/api/health',
@@ -51,6 +52,13 @@ const PUBLIC_API_PATHS = new Set([
   '/api/product-catalog',
   '/api/download.md',
 ]);
+
+function isPublicApiMarkdownTwin(pathname: string, method: string): boolean {
+  if (method !== 'GET' && method !== 'HEAD') return false;
+  if (!pathname.startsWith('/api/') || !pathname.endsWith('.md')) return false;
+  if (pathname.includes('..') || pathname.includes('//')) return false;
+  return pathname.length > '/api/.md'.length;
+}
 
 const SOCIAL_IMAGE_UA =
   /Slack-ImgProxy|Slackbot|twitterbot|facebookexternalhit|linkedinbot|telegrambot|whatsapp|discordbot|redditbot/i;
@@ -344,7 +352,7 @@ ${AI_CRAWLER_VARIANT_LINKS}
   }
 
   // Public endpoints bypass all bot filtering
-  if (PUBLIC_API_PATHS.has(path)) {
+  if (PUBLIC_API_PATHS.has(path) || isPublicApiMarkdownTwin(path, request.method)) {
     return;
   }
 

--- a/public/api/download.md
+++ b/public/api/download.md
@@ -1,0 +1,34 @@
+# World Monitor desktop downloads
+
+`GET /api/download` redirects to the latest GitHub Release asset for the World Monitor desktop app. This markdown twin documents the redirect so agents can read it without following a binary `302`.
+
+One published binary serves every in-app variant. `variant` is an identity hint, not an asset selector. An unknown `platform` or unsupported `variant` redirects to the GitHub releases page instead of guessing an installer.
+
+## Query parameters
+
+- **`platform`** (required for a binary): one of the platform ids below.
+- **`variant`** (optional): `full`, `world`, `tech`, `finance`, `commodity`, `energy`, or `happy`. Every supported value resolves to the same World Monitor artifact.
+
+## Platforms
+
+| `platform` | Asset |
+|---|---|
+| `windows-exe` | Windows `.exe` installer (`_x64-setup.exe`) |
+| `windows-msi` | Windows `.msi` installer (`_x64_en-US.msi`) |
+| `macos-arm64` | macOS Apple Silicon `.dmg` (`_aarch64.dmg`) |
+| `macos-x64` | macOS Intel `.dmg` (`_x64.dmg`) |
+| `linux-appimage` | Linux x64 AppImage (`_amd64.AppImage`) |
+| `linux-appimage-arm64` | Linux ARM64 AppImage (`_aarch64.AppImage`) |
+
+## Examples
+
+- [Windows .exe](https://worldmonitor.app/api/download?platform=windows-exe)
+- [macOS Apple Silicon](https://worldmonitor.app/api/download?platform=macos-arm64)
+- [macOS Intel](https://worldmonitor.app/api/download?platform=macos-x64)
+- [Linux AppImage](https://worldmonitor.app/api/download?platform=linux-appimage)
+
+## Related
+
+- Latest GitHub release: https://github.com/koala73/worldmonitor/releases/latest
+- Version API: https://worldmonitor.app/api/version
+- Homepage markdown twin: https://worldmonitor.app/index.md

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -101,6 +101,10 @@ import {
 import { timingSafeEqual } from './_shared/internal-auth';
 import type { ServerOptions } from '../src/generated/server/worldmonitor/seismology/v1/service_server';
 import { validateGeneratedRequest } from './request-validator';
+import {
+  buildMarkdownTwinResponse,
+  isMarkdownTwinPath,
+} from '../api/_md-url-twin';
 
 export const serverOptions: ServerOptions = {
   onError: mapErrorToResponse,
@@ -738,6 +742,22 @@ export function createDomainGateway(
   const router = createRouter(routes);
 
   return async function handler(originalRequest: Request, ctx?: GatewayCtx): Promise<Response> {
+    const originalPathname = new URL(originalRequest.url).pathname;
+
+    // Vercel resolves versioned API paths such as
+    // `/api/forecast/v1/get-forecast-scorecard.md` to the more-specific
+    // `api/<domain>/v1/[rpc].ts` function before the root API catch-all. Handle
+    // markdown probes here, before auth and RPC dispatch, so every dynamic
+    // domain gateway follows the same site-wide `.md` twin contract without a
+    // broad rewrite that would shadow the real endpoints (#4724).
+    if (
+      originalPathname.startsWith('/api/') &&
+      isMarkdownTwinPath(originalPathname) &&
+      (originalRequest.method === 'GET' || originalRequest.method === 'HEAD')
+    ) {
+      return buildMarkdownTwinResponse(originalRequest, originalPathname);
+    }
+
     let request = stripClientUserIdHeader(originalRequest);
     const rawPathname = new URL(request.url).pathname;
     const pathname = rawPathname.length > 1 ? rawPathname.replace(/\/+$/, '') : rawPathname;

--- a/tests/api-not-found.test.mjs
+++ b/tests/api-not-found.test.mjs
@@ -35,4 +35,26 @@ describe('api/not-found.ts — structured JSON 404 for unmatched /api/* paths', 
     const res = handler(new Request(`${URL_BASE}/api/x`, { method: 'GET' }));
     assert.match(res.headers.get('cache-control') ?? '', /no-store/);
   });
+
+  it('answers GET /api/*.md as heading-led markdown, not JSON 404', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input) => {
+      const url = String(input);
+      assert.match(url, /\/api\/health$/);
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    try {
+      const res = await handler(new Request(`${URL_BASE}/api/health.md`, { method: 'GET' }));
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') ?? '', /text\/markdown/);
+      const body = await res.text();
+      assert.match(body, /^# /m);
+      assert.doesNotMatch(body, /<html/i);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -40,7 +40,7 @@ const frontendDockerfileSource = readFileSync(resolve(__dirname, '../docker/Dock
 const dockerignoreSource = readFileSync(resolve(__dirname, '../.dockerignore'), 'utf-8');
 const vercelIgnoreSource = readFileSync(resolve(__dirname, '../scripts/vercel-ignore.sh'), 'utf-8');
 const variantDashboardSource = readFileSync(resolve(__dirname, '../src/config/variant-dashboard-html.ts'), 'utf-8');
-const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|countries|chokepoints|crises|tools|research|reference|changelog|sources|use-cases|src|tmp|server|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|robots\\.www\\.txt|robots\\.variant\\.txt|robots\\.api\\.txt|sitemap\\.xml|schemamap\\.xml|sandbox|llms\\.txt|llms-full\\.txt|llms\\*\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|developers\\.md|developers/llms\\.txt|mcp-server\\.md|openapi\\.md|sdks\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
+const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|countries|chokepoints|crises|tools|research|reference|changelog|sources|use-cases|src|tmp|server|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|robots\\.www\\.txt|robots\\.variant\\.txt|robots\\.api\\.txt|sitemap\\.xml|schemamap\\.xml|sandbox|llms\\.txt|llms-full\\.txt|llms\\*\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|developers\\.md|developers/llms\\.txt|mcp-server\\.md|openapi\\.md|sdks\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant|.*\\.md$).*)';
 const GLOBAL_SECURITY_HEADER_SOURCE = '/((?!docs|embed|embed\\.html).*)';
 const APP_ROOT_HOST_PATTERN = '^(?:(?:www|tech|finance|commodity|happy|energy)\\.)?worldmonitor\\.app$';
 const WEBMCP_PRODUCTION_HOST_PATTERN = '^(?:www|tech|finance|commodity|happy|energy)\\.worldmonitor\\.app$';
@@ -1303,13 +1303,14 @@ describe('deploy/API CORS guardrails', () => {
     ]);
     const apiCorsRules = vercelConfig.headers
       .filter((entry) => entry.source.startsWith('/api'))
+      .filter((entry) => !entry.source.endsWith('.md'))
       .filter((entry) => entry.headers?.some((header) => corsHeaderKeys.has(header.key.toLowerCase())))
       .map((entry) => entry.source);
 
     assert.deepEqual(
       apiCorsRules,
       [],
-      'API CORS must be emitted by handlers so credentialed requests get origin-specific ACAO plus ACAC=true.'
+      'JSON API CORS must be emitted by handlers so credentialed requests get origin-specific ACAO plus ACAC=true. Static /api/*.md twins are public agent documents and may set ACAO * in vercel.json.'
     );
   });
 });
@@ -2851,6 +2852,49 @@ describe('agent readiness: /api/download.md URL twin', () => {
       SPA_HTML_CACHE_SOURCE.startsWith('/((?!api|'),
       '/api/* (including /api/download.md) must stay outside the HTML-cache catch-all'
     );
+  });
+});
+
+// orank "Markdown URL fallback" is site-wide (`/docs/auth` → `/docs/auth.md`),
+// not a single sampled URL. Static public/*.md files still win (afterFiles).
+// /docs/:match* stays first so Mintlify keeps /docs/*.md. /index.md stays
+// ahead of the generic fallback. /api/*.md is excluded from this rewrite so
+// the filesystem catch-all (api/[...notfound].ts) can emit markdown without
+// reintroducing a shadowing /api/:path* rewrite (#4724).
+describe('agent readiness: generic markdown URL-fallback rewrite', () => {
+  const mdTwinRewrite = vercelConfig.rewrites.find((r) =>
+    typeof r.destination === 'string' && r.destination.startsWith('/api/md-twin')
+  );
+  const rewriteIndex = (source) => vercelConfig.rewrites.findIndex((r) => r.source === source);
+
+  it('rewrites unmatched /{page}.md to /api/md-twin after docs and /index.md', () => {
+    assert.ok(mdTwinRewrite, 'expected a generic /{page}.md → /api/md-twin rewrite');
+    assert.match(mdTwinRewrite.source, /api\//, 'rewrite must exclude /api/*.md (handled by the not-found catch-all)');
+    assert.match(mdTwinRewrite.source, /mdPath|path/, 'rewrite must capture the sibling path');
+    const mdIdx = vercelConfig.rewrites.indexOf(mdTwinRewrite);
+    assert.ok(mdIdx > rewriteIndex('/docs/:match*'), '/docs/:match* must stay ahead of the generic .md fallback');
+    assert.ok(mdIdx > rewriteIndex('/index.md'), '/index.md → /home.md must stay ahead of the generic .md fallback');
+  });
+
+  it('does not reintroduce a shadowing /api/:path* → /api/not-found rewrite', () => {
+    const shadow = (vercelConfig.rewrites ?? []).find((r) =>
+      r.destination === '/api/not-found' && /^\/api\/(?::[^/]*\*|\(\.\*\))$/.test(r.source ?? '')
+    );
+    assert.equal(shadow, undefined, 'do not add /api/:path* → /api/not-found; it shadows [rpc].ts gateways (#4724)');
+  });
+
+  it('sends content-page .md twins to the generator, not the dashboard shell', () => {
+    assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/dashboard.md' })?.destination, '/api/md-twin?path=:mdPath');
+    assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/stocks/AAPL.md' })?.destination, '/api/md-twin?path=:mdPath');
+    assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/docs/auth.md' })?.destination, 'https://worldmonitor.mintlify.dev/docs/:match*');
+    assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/index.md' })?.destination, '/home.md');
+    assert.equal(firstRewriteFor({ host: 'www.worldmonitor.app', path: '/api/health.md' }), null);
+  });
+
+  it('keeps HTML-cache catch-all from applying to generated .md twins', () => {
+    assert.ok(SPA_HTML_CACHE_SOURCE.includes('|.*\\.md$'), 'HTML cache catch-all must exclude every *.md path');
+    assert.equal(sourceToRegExp(SPA_HTML_CACHE_SOURCE).test('/dashboard.md'), false);
+    assert.equal(sourceToRegExp(SPA_HTML_CACHE_SOURCE).test('/dashboard'), true);
   });
 });
 

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -97,9 +97,10 @@ const getHeadersForSource = (sourcePath) => {
 };
 
 // Convert a vercel.json `source` (the path-to-regexp subset used in this file)
-// into a RegExp: literal segments, inline regex groups `(...)` kept raw, and
-// `:name*` catch-all params. Lets tests evaluate which rules match a concrete
-// URL instead of only asserting on a rule in isolation.
+// into a RegExp: literal segments, inline regex groups `(...)` kept raw,
+// `:name(regex)` custom matchers, and `:name*` catch-all params. Lets tests
+// evaluate which rules match a concrete URL instead of only asserting on a
+// rule in isolation.
 const sourceToRegExp = (source) => {
   let out = '';
   for (let i = 0; i < source.length; i++) {
@@ -119,7 +120,20 @@ const sourceToRegExp = (source) => {
     } else if (ch === ':') {
       let j = i + 1;
       while (j < source.length && /[A-Za-z0-9_]/.test(source[j])) j++;
-      if (source[j] === '*') {
+      if (source[j] === '(') {
+        // `:name(regex)` custom matcher — drop the name, keep the group.
+        let depth = 0;
+        let k = j;
+        for (; k < source.length; k++) {
+          if (source[k] === '(') depth++;
+          else if (source[k] === ')') {
+            depth--;
+            if (depth === 0) break;
+          }
+        }
+        out += source.slice(j, k + 1);
+        i = k;
+      } else if (source[j] === '*') {
         out = out.replace(/\/$/, '');
         out += '(?:/.*)?';
         i = j;
@@ -2870,7 +2884,12 @@ describe('agent readiness: generic markdown URL-fallback rewrite', () => {
   it('rewrites unmatched /{page}.md to /api/md-twin after docs and /index.md', () => {
     assert.ok(mdTwinRewrite, 'expected a generic /{page}.md → /api/md-twin rewrite');
     assert.match(mdTwinRewrite.source, /api\//, 'rewrite must exclude /api/*.md (handled by the not-found catch-all)');
-    assert.match(mdTwinRewrite.source, /mdPath|path/, 'rewrite must capture the sibling path');
+    assert.match(mdTwinRewrite.source, /:mdPath|:path/, 'rewrite must capture the sibling path as a Vercel :param');
+    assert.doesNotMatch(
+      mdTwinRewrite.source,
+      /\(\?</,
+      'PCRE named groups are not Vercel :params; destination :mdPath would fail deploy (invalid-route-destination-segment)',
+    );
     const mdIdx = vercelConfig.rewrites.indexOf(mdTwinRewrite);
     assert.ok(mdIdx > rewriteIndex('/docs/:match*'), '/docs/:match* must stay ahead of the generic .md fallback');
     assert.ok(mdIdx > rewriteIndex('/index.md'), '/index.md → /home.md must stay ahead of the generic .md fallback');

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -2814,7 +2814,47 @@ describe('agent readiness: auth.md walkthrough', () => {
     assert.equal(dashboardShadow('/auth.md'), undefined, '/auth.md must serve the real file, not the dashboard');
     assert.ok(SPA_HTML_CACHE_SOURCE.includes('|auth\\.md|'), 'HTML cache catch-all must keep excluding /auth.md');
   });
+});
 
+// orank "Markdown URL fallback": homepage /index.md already returns markdown,
+// but the scanner sampled GET /api/download as the content page and then
+// requested /api/download.md. That path used to hit api/[...notfound].ts as
+// JSON 404. Cloudflare Markdown for Agents cannot fill this gap — it converts
+// HTML only when Accept: text/markdown, and /api/download is a 302, not HTML.
+describe('agent readiness: /api/download.md URL twin', () => {
+  const downloadMdPath = resolve(__dirname, '../public/api/download.md');
+  const downloadMd = readFileSync(downloadMdPath, 'utf-8');
+
+  it('publishes heading-led markdown at public/api/download.md', () => {
+    assert.ok(existsSync(downloadMdPath), 'expected public/api/download.md (markdown twin of GET /api/download)');
+    assert.match(downloadMd, /^# /m, '/api/download.md must open with a heading so scanners accept a non-HTML body');
+    assert.match(downloadMd, /platform=windows-exe/);
+    assert.match(downloadMd, /platform=macos-arm64/);
+    assert.match(downloadMd, /platform=linux-appimage/);
+  });
+
+  it('serves /api/download.md as markdown with CORS and a self-canonical Link', () => {
+    assert.equal(getHeaderValueForSource('/api/download.md', 'Content-Type'), 'text/markdown; charset=utf-8');
+    assert.equal(getHeaderValueForSource('/api/download.md', 'Access-Control-Allow-Origin'), '*');
+    assert.equal(
+      getHeaderValueForSource('/api/download.md', 'Link'),
+      '<https://www.worldmonitor.app/api/download.md>; rel="canonical"'
+    );
+  });
+
+  it('is not rewritten to the dashboard shell', () => {
+    const dashboardShadow = (path) => vercelConfig.rewrites.find((r) =>
+      r.destination === DASHBOARD_HTML_DESTINATION && sourceToRegExp(r.source).test(path)
+    );
+    assert.equal(dashboardShadow('/api/download.md'), undefined, '/api/download.md must serve the static twin, not the dashboard');
+    assert.ok(
+      SPA_HTML_CACHE_SOURCE.startsWith('/((?!api|'),
+      '/api/* (including /api/download.md) must stay outside the HTML-cache catch-all'
+    );
+  });
+});
+
+describe('agent readiness: remaining markdown twins', () => {
   // pricing.md and support.md are advertised in api-catalog service-meta and
   // llms.txt (#4854/#4857), agents.md is the agent-discovery entry point
   // (#4952), so they get the same three-way pinning as auth.md:

--- a/tests/gateway-markdown-twin-routing.test.mts
+++ b/tests/gateway-markdown-twin-routing.test.mts
@@ -1,0 +1,74 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { createDomainGateway } from '../server/gateway.ts';
+
+function makeGateway(onRpcDispatch: () => void) {
+  return createDomainGateway([
+    {
+      method: 'GET',
+      path: '/api/forecast/v1/get-forecast-scorecard',
+      handler: async () => {
+        onRpcDispatch();
+        return Response.json({ source: 'rpc' });
+      },
+    },
+    {
+      method: 'GET',
+      path: '/api/seismology/v1/list-earthquakes',
+      handler: async () => {
+        onRpcDispatch();
+        return Response.json({ source: 'rpc' });
+      },
+    },
+  ]);
+}
+
+describe('dynamic API gateway markdown twins', () => {
+  for (const markdownPath of [
+    '/api/forecast/v1/get-forecast-scorecard.md',
+    '/api/v2/shipping/get-port-congestion.md',
+  ]) {
+    it(`routes ${markdownPath} to its sibling twin before RPC dispatch`, async () => {
+      let rpcDispatches = 0;
+      const gateway = makeGateway(() => {
+        rpcDispatches += 1;
+      });
+      const originalFetch = globalThis.fetch;
+      let fetchedPathname = '';
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        fetchedPathname = new URL(String(input)).pathname;
+        return Response.json({ source: 'sibling' });
+      }) as typeof fetch;
+
+      try {
+        const res = await gateway(new Request(`https://worldmonitor.app${markdownPath}`, {
+          headers: { 'User-Agent': 'ExampleCrawler/1.0' },
+        }));
+
+        assert.equal(res.status, 200);
+        assert.match(res.headers.get('content-type') ?? '', /text\/markdown/);
+        assert.equal(fetchedPathname, markdownPath.slice(0, -3));
+        assert.equal(rpcDispatches, 0, 'the .md segment must not be dispatched as an RPC name');
+        assert.match(await res.text(), /^# /m);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  }
+
+  it('keeps the unsuffixed API path on the normal RPC route', async () => {
+    let rpcDispatches = 0;
+    const gateway = makeGateway(() => {
+      rpcDispatches += 1;
+    });
+
+    const res = await gateway(new Request(
+      'https://worldmonitor.app/api/seismology/v1/list-earthquakes',
+    ));
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { source: 'rpc' });
+    assert.equal(rpcDispatches, 1);
+  });
+});

--- a/tests/md-url-twin.test.mjs
+++ b/tests/md-url-twin.test.mjs
@@ -1,0 +1,98 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import handler from '../api/md-twin.ts';
+import {
+  MD_TWIN_LOOP_HEADER,
+  buildMarkdownTwinResponse,
+  htmlToMarkdown,
+  isMarkdownTwinPath,
+  resolveMarkdownTwinPath,
+  siblingPathFromMarkdown,
+} from '../api/_md-url-twin.ts';
+
+describe('markdown URL-fallback helpers', () => {
+  it('accepts /{page}.md paths and maps them to the sibling', () => {
+    assert.equal(isMarkdownTwinPath('/dashboard.md'), true);
+    assert.equal(isMarkdownTwinPath('/stocks/AAPL.md'), true);
+    assert.equal(isMarkdownTwinPath('/api/health.md'), true);
+    assert.equal(isMarkdownTwinPath('/dashboard'), false);
+    assert.equal(isMarkdownTwinPath('/../etc.md'), false);
+    assert.equal(siblingPathFromMarkdown('/dashboard.md'), '/dashboard');
+    assert.equal(siblingPathFromMarkdown('/api/health.md'), '/api/health');
+  });
+
+  it('resolves /api/md-twin?path= to a sanitized .md path', () => {
+    const req = new Request('https://www.worldmonitor.app/api/md-twin?path=dashboard');
+    assert.equal(resolveMarkdownTwinPath(req), '/dashboard.md');
+    const evil = new Request('https://www.worldmonitor.app/api/md-twin?path=https://evil.example/x');
+    assert.equal(resolveMarkdownTwinPath(evil), null);
+  });
+
+  it('converts HTML to heading-led markdown', () => {
+    const md = htmlToMarkdown(
+      '<html><head><title>Dashboard</title></head><body><h1>Live map</h1><p>Ships and jets.</p></body></html>',
+      'fallback',
+    );
+    assert.match(md, /^# /m);
+    assert.match(md, /Live map/);
+    assert.match(md, /Ships and jets/);
+    assert.doesNotMatch(md, /<html/i);
+  });
+});
+
+describe('api/md-twin.ts', () => {
+  it('returns heading-led markdown for a 200 HTML sibling', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input, init) => {
+      const url = new URL(String(input));
+      assert.equal(url.pathname, '/dashboard');
+      assert.equal(init?.headers instanceof Headers ? init.headers.get(MD_TWIN_LOOP_HEADER) : null, '1');
+      return new Response('<html><title>World Monitor</title><h1>Dashboard</h1><p>Live globe.</p></html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      });
+    });
+    try {
+      const res = await handler(new Request('https://www.worldmonitor.app/api/md-twin?path=dashboard'));
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') ?? '', /text\/markdown/);
+      assert.equal(res.headers.get('access-control-allow-origin'), '*');
+      const body = await res.text();
+      assert.match(body, /^# /m);
+      assert.match(body, /Dashboard|World Monitor/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('documents a 302 sibling as heading-led markdown', async () => {
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/download.md'),
+      '/api/download.md',
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://github.com/koala73/worldmonitor/releases/latest' },
+        }),
+    );
+    assert.equal(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /^# /m);
+    assert.match(body, /github\.com\/koala73\/worldmonitor\/releases\/latest/);
+  });
+
+  it('does not recurse when the loop header is present', async () => {
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/dashboard.md', {
+        headers: { [MD_TWIN_LOOP_HEADER]: '1' },
+      }),
+      '/dashboard.md',
+      async () => {
+        throw new Error('sibling fetch must not run');
+      },
+    );
+    assert.equal(res.status, 404);
+    assert.match(await res.text(), /^# /m);
+  });
+});

--- a/tests/md-url-twin.test.mjs
+++ b/tests/md-url-twin.test.mjs
@@ -77,9 +77,159 @@ describe('api/md-twin.ts', () => {
         }),
     );
     assert.equal(res.status, 200);
+    assert.equal(res.headers.get('location'), null);
+    assert.equal(res.headers.get('cache-control'), 'public, max-age=3600');
     const body = await res.text();
     assert.match(body, /^# /m);
     assert.match(body, /github\.com\/koala73\/worldmonitor\/releases\/latest/);
+  });
+
+  it('preserves a bodyless 304 sibling', async () => {
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/dashboard.md'),
+      '/dashboard.md',
+      async () => new Response(null, { status: 304, headers: { etag: 'dashboard-v1' } }),
+    );
+
+    assert.equal(res.status, 304);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    assert.equal(await res.text(), '');
+  });
+
+  it('uses an anonymous internal identity for the sibling request', async () => {
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/api/latest-brief.md', {
+        headers: {
+          authorization: 'Bearer secret',
+          cookie: 'wm_session=secret',
+          'user-agent': 'Googlebot/2.1',
+          'x-api-key': 'api-secret',
+          'x-worldmonitor-key': 'wm-secret',
+        },
+      }),
+      '/api/latest-brief.md',
+      async (_input, init) => {
+        const headers = new Headers(init?.headers);
+        assert.equal(headers.get('user-agent'), 'WorldMonitor-MarkdownTwin/1.0');
+        assert.equal(headers.get(MD_TWIN_LOOP_HEADER), '1');
+        assert.equal(headers.get('authorization'), null);
+        assert.equal(headers.get('cookie'), null);
+        assert.equal(headers.get('x-api-key'), null);
+        assert.equal(headers.get('x-worldmonitor-key'), null);
+        return new Response('# Public brief\n');
+      },
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('cache-control'), 'public, max-age=3600');
+  });
+
+  for (const { status, headers = {}, expectedHeader, expectedValue } of [
+    {
+      status: 401,
+      headers: { 'www-authenticate': 'Bearer realm="worldmonitor"' },
+      expectedHeader: 'www-authenticate',
+      expectedValue: 'Bearer realm="worldmonitor"',
+    },
+    { status: 403 },
+    {
+      status: 429,
+      headers: { 'retry-after': '17' },
+      expectedHeader: 'retry-after',
+      expectedValue: '17',
+    },
+    { status: 500 },
+  ]) {
+    it(`preserves a ${status} sibling as a non-cacheable response`, async () => {
+      const res = await buildMarkdownTwinResponse(
+        new Request('https://www.worldmonitor.app/api/health.md'),
+        '/api/health.md',
+        async () => new Response('upstream failure', { status, headers }),
+      );
+
+      assert.equal(res.status, status);
+      assert.equal(res.headers.get('cache-control'), 'no-store');
+      if (expectedHeader) assert.equal(res.headers.get(expectedHeader), expectedValue);
+      assert.match(await res.text(), /^# health/m);
+    });
+  }
+
+  it('rejects an oversized declared sibling body without reading it', async () => {
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/dashboard.md'),
+      '/dashboard.md',
+      async () => new Response('small', { headers: { 'content-length': '80001' } }),
+    );
+
+    assert.equal(res.status, 502);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    assert.match(await res.text(), /could not be read/);
+  });
+
+  it('cancels a streamed sibling body that exceeds the byte cap', async () => {
+    let canceled = false;
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(80_001));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/dashboard.md'),
+      '/dashboard.md',
+      async () => new Response(body),
+    );
+
+    assert.equal(res.status, 502);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    assert.equal(canceled, true);
+  });
+
+  it('maps sibling body-stream failures to a non-cacheable 502', async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        controller.error(new Error('body failed'));
+      },
+    });
+
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/dashboard.md'),
+      '/dashboard.md',
+      async () => new Response(body),
+    );
+
+    assert.equal(res.status, 502);
+    assert.equal(res.headers.get('cache-control'), 'no-store');
+    assert.match(await res.text(), /could not be read/);
+  });
+
+  it('uses sibling HEAD and never reads a response body', async () => {
+    const unreadableBody = {
+      getReader() {
+        throw new Error('HEAD must not read the body');
+      },
+    };
+    const siblingResponse = {
+      body: unreadableBody,
+      headers: new Headers(),
+      ok: true,
+      status: 200,
+    };
+
+    const res = await buildMarkdownTwinResponse(
+      new Request('https://www.worldmonitor.app/dashboard.md', { method: 'HEAD' }),
+      '/dashboard.md',
+      async (_input, init) => {
+        assert.equal(init?.method, 'HEAD');
+        return siblingResponse;
+      },
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), '');
   });
 
   it('does not recurse when the loop header is present', async () => {

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -304,6 +304,36 @@ describe('middleware /api/download.md — markdown-URL-fallback crawlers reach t
   });
 });
 
+// The protocol is site-wide `/{page}` → `/{page}.md`, not one sampled URL.
+// GET/HEAD /api/**/*.md must pass the bot gate; POST must not inherit that bypass.
+describe('middleware /api/*.md — site-wide markdown URL-fallback twins bypass the bot gate', () => {
+  const CRAWLER_UAS = [
+    { label: 'ClaudeBot', ua: 'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)' },
+    { label: 'python-requests', ua: 'python-requests/2.31' },
+    { label: 'empty UA', ua: '' },
+  ];
+
+  for (const path of ['/api/health.md', '/api/v1/foo.md', '/api/download.md']) {
+    for (const { label, ua } of CRAWLER_UAS) {
+      it(`passes ${label} through to GET ${path}`, () => {
+        const res = call(path, ua);
+        assert.equal(res, undefined, `${path} must pass through the bot gate for markdown-fallback crawlers`);
+      });
+    }
+  }
+
+  it('still 403s a crawler on POST /api/health.md (bypass is GET/HEAD only)', () => {
+    const url = 'https://www.worldmonitor.app/api/health.md';
+    const req = new Request(url, {
+      method: 'POST',
+      headers: { 'user-agent': 'CCBot/2.0 (https://commoncrawl.org/faq/)' },
+    });
+    const res = middleware(req);
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 403);
+  });
+});
+
 // ── /api/product-catalog public-pricing bypass ──────────────────────────────
 // The keyless read-only pricing catalog is advertised as service-meta in
 // /.well-known/api-catalog; agents evaluating the product are its primary

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -211,6 +211,7 @@ describe('middleware PUBLIC_API_PATHS — secret-authed internal endpoints bypas
     '/api/internal/brief-why-matters',
     '/api/llms.txt',
     '/api/product-catalog',
+    '/api/download.md',
   ];
 
   for (const path of ALLOWED_PATHS) {
@@ -270,6 +271,34 @@ describe('middleware /api/llms.txt — AI crawlers reach the agent-discovery fil
 
   it('still 403s a crawler on a sibling /api path (bypass is exact, not a prefix)', () => {
     const res = call('/api/llms', 'CCBot/2.0 (https://commoncrawl.org/faq/)');
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 403);
+  });
+});
+
+// ── /api/download.md markdown-URL-fallback bypass ────────────────────────────
+// Homepage download badges are sampled as a "content page". Agent-readiness
+// scanners then request /api/download.md. The twin is a static file under
+// public/api/, so it lives in the /api/* namespace where BOT_UA 403s crawlers
+// unless this path is on PUBLIC_API_PATHS.
+
+describe('middleware /api/download.md — markdown-URL-fallback crawlers reach the twin', () => {
+  const CRAWLER_UAS = [
+    { label: 'ClaudeBot', ua: 'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)' },
+    { label: 'python-requests', ua: 'python-requests/2.31' },
+    { label: 'curl UA', ua: 'curl/8.7.1' },
+    { label: 'empty UA', ua: '' },
+  ];
+
+  for (const { label, ua } of CRAWLER_UAS) {
+    it(`passes ${label} through to /api/download.md`, () => {
+      const res = call('/api/download.md', ua);
+      assert.equal(res, undefined, '/api/download.md must pass through the bot gate for markdown-fallback crawlers');
+    });
+  }
+
+  it('still 403s a crawler on GET /api/download (bypass is exact, not a prefix)', () => {
+    const res = call('/api/download', 'CCBot/2.0 (https://commoncrawl.org/faq/)');
     assert.ok(res instanceof Response);
     assert.equal(res.status, 403);
   });

--- a/vercel.json
+++ b/vercel.json
@@ -192,6 +192,15 @@
       ]
     },
     {
+      "source": "/api/download.md",
+      "headers": [
+        { "key": "Content-Type", "value": "text/markdown; charset=utf-8" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" },
+        { "key": "Link", "value": "<https://www.worldmonitor.app/api/download.md>; rel=\"canonical\"" }
+      ]
+    },
+    {
       "source": "/blog/rss.xml",
       "headers": [
         { "key": "Link", "value": "<https://www.worldmonitor.app/blog/rss.xml>; rel=\"canonical\"" },

--- a/vercel.json
+++ b/vercel.json
@@ -66,6 +66,7 @@
     { "source": "/", "has": [{ "type": "query", "key": "mode", "value": "agent" }], "destination": "/agent-view.json" },
     { "source": "/", "has": [{ "type": "host", "value": "^(?:www\\.)?worldmonitor\\.app$" }], "destination": "/pro/welcome.html" },
     { "source": "/index.md", "destination": "/home.md" },
+    { "source": "/((?!api/)(?<mdPath>.+)).md", "destination": "/api/md-twin?path=:mdPath" },
     { "source": "/pro", "destination": "/pro/index.html" },
     { "source": "/mcp", "destination": "/api/mcp" },
     { "source": "/a2a", "destination": "/api/a2a" },
@@ -635,7 +636,7 @@
       ]
     },
     {
-      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|countries|chokepoints|crises|tools|research|reference|changelog|sources|use-cases|src|tmp|server|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|robots\\.www\\.txt|robots\\.variant\\.txt|robots\\.api\\.txt|sitemap\\.xml|schemamap\\.xml|sandbox|llms\\.txt|llms-full\\.txt|llms\\*\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|developers\\.md|developers/llms\\.txt|mcp-server\\.md|openapi\\.md|sdks\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
+      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|countries|chokepoints|crises|tools|research|reference|changelog|sources|use-cases|src|tmp|server|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|robots\\.www\\.txt|robots\\.variant\\.txt|robots\\.api\\.txt|sitemap\\.xml|schemamap\\.xml|sandbox|llms\\.txt|llms-full\\.txt|llms\\*\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|pricing\\.md|support\\.md|ai-search\\.md|agents\\.md|developers\\.md|developers/llms\\.txt|mcp-server\\.md|openapi\\.md|sdks\\.md|agent\\.txt|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant|.*\\.md$).*)",
       "headers": [
         { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" }
       ]

--- a/vercel.json
+++ b/vercel.json
@@ -66,7 +66,7 @@
     { "source": "/", "has": [{ "type": "query", "key": "mode", "value": "agent" }], "destination": "/agent-view.json" },
     { "source": "/", "has": [{ "type": "host", "value": "^(?:www\\.)?worldmonitor\\.app$" }], "destination": "/pro/welcome.html" },
     { "source": "/index.md", "destination": "/home.md" },
-    { "source": "/((?!api/)(?<mdPath>.+)).md", "destination": "/api/md-twin?path=:mdPath" },
+    { "source": "/:mdPath((?!api/).+).md", "destination": "/api/md-twin?path=:mdPath" },
     { "source": "/pro", "destination": "/pro/index.html" },
     { "source": "/mcp", "destination": "/api/mcp" },
     { "source": "/a2a", "destination": "/api/a2a" },


### PR DESCRIPTION
## Summary

The markdown URL-fallback protocol is **site-wide**: every content page `/{page}` needs a twin at `/{page}.md` (`text/markdown` or a heading-led non-HTML body). Cloudflare Markdown for Agents does **not** implement this — it only converts HTML when `Accept: text/markdown` is sent, and it never creates `/{page}.md` URLs. Fixing only the scanner’s sampled path (`/api/download.md`) would fail the next sample.

This PR keeps curated static twins (including `public/api/download.md` for the 302 download redirect) and adds a **generic fallback**:

- Static `public/**/*.md` still wins (afterFiles).
- `/docs/:match*` still proxies to Mintlify first, so `/docs/foo.md` stays on the docs host.
- `/index.md` still rewrites to `/home.md`.
- Unmatched `/{page}.md` rewrites to `/api/md-twin`, which fetches the sibling page and returns heading-led markdown (HTML → markdown, JSON → fenced JSON, 302 → redirect note).
- Unmatched `GET/HEAD /api/*.md` is handled in `api/not-found.ts` (no `/api/:path*` rewrite — that would shadow `[rpc].ts`, #4724).
- Middleware bypasses the `/api/*` bot gate for **every** `GET/HEAD /api/**/*.md`, not just `/api/download.md`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: agent-readiness markdown URL fallback

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [x] N/A — no methodology, proto, Redis-key, or generated-docs claims changed

## Verification

Focused tests passed:

- `npx tsx --test tests/md-url-twin.test.mjs tests/api-not-found.test.mjs tests/api-notfound-catchall.test.mjs tests/middleware-bot-gate.test.mts tests/deploy-config.test.mjs`
- `npm run lint:api-contract`

Not yet proved: production `GET https://worldmonitor.app/{any-content-page}.md` after deploy.
