### PR TITLE
fix: guard the tender cache clear and filter injected-script noise

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -56,6 +56,13 @@ export const MARKETING_IGNORE_ERRORS: RegExp[] = [
   // rejection always belongs to an extension injected into the page
   // (WORLDMONITOR-ZX).
   /runtime\.sendMessage\(\)/,
+  // Zalo's in-app browser (Vietnam's dominant messaging app) injects a JS
+  // bridge that references `zaloJSV2` before the host app defines it. Same
+  // class as the `WeixinJSBridge` entry in the dashboard array: a named
+  // in-app-browser global. Our source contains no `zaloJSV2` identifier at
+  // all, so this can never come from our own bundle, minified or not
+  // (WORLDMONITOR-102).
+  /\bzaloJSV2\b/,
 ];
 
 /** Sentry's own hashed SDK chunk — infrastructure, never evidence of our code. */
@@ -72,6 +79,13 @@ const BARE_SYMBOL_MESSAGE = /^[a-zA-Z_$]+$/;
  */
 const MODULE_LOAD_FAILURE =
   /(?:Failed to fetch|error loading) dynamically imported module|Importing a module script failed|Importing binding name '[^']*' is not found/i;
+/**
+ * Runaway recursion, in every browser phrasing (Chrome/Safari "Maximum call
+ * stack size exceeded", Firefox "too much recursion"). Deliberately NOT in
+ * `MARKETING_IGNORE_ERRORS`: our own React bundle can absolutely recurse
+ * infinitely, and suppressing this by message alone would hide it.
+ */
+const STACK_OVERFLOW = /Maximum call stack size exceeded|too much recursion/i;
 
 /**
  * Stack-gated suppressors for messages that our own minified bundle COULD
@@ -110,6 +124,17 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
   // our own code — which rides a `/pro/assets/*.js` frame — still surfaces
   // (WORLDMONITOR-15).
   if (!hasFirstParty && MODULE_LOAD_FAILURE.test(msg)) return null;
+
+  // Injected-script recursion. The observed events (Chrome Mobile iOS) report
+  // frames on the prerendered document itself — `https://www.worldmonitor.app/`
+  // at lines that fall inside `<script type="application/ld+json">` blocks,
+  // which are inert data and cannot execute. The document therefore holds no
+  // executable inline JS at those offsets, so the recursion belongs to a script
+  // an in-app browser injected, not to us; our own code always rides a
+  // `/pro/assets/*.js` frame. Gated on `!hasFirstParty` so a genuine render
+  // loop in this bundle — the realistic first-party cause — still pages
+  // (WORLDMONITOR-103).
+  if (!hasFirstParty && STACK_OVERFLOW.test(msg)) return null;
 
   return event;
 }

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -3837,8 +3837,27 @@ export class DataLoaderManager implements AppModule {
     this.globalTenderFilters = {};
     const procurementPanel = this.ctx.panels['global-procurement'] as GlobalProcurementPanel | undefined;
     procurementPanel?.clear();
-    const { clearGlobalTenderCache } = await import('@/services/global-tenders');
-    clearGlobalTenderCache();
+    // The only call site is fire-and-forget — `void this.dataLoader
+    // .clearGlobalTenders()` in App.ts on the premium->free transition — so an
+    // unguarded rejection here does not degrade one panel, it lands as an
+    // unhandled rejection (WORLDMONITOR-100, reported by Sentry with mechanism
+    // `onunhandledrejection`).
+    //
+    // Swallowing does NOT weaken the "Pro data must not survive a downgrade"
+    // guarantee this method exists to enforce. Everything user-visible — the
+    // generation bump, the filter reset, the panel clear — already ran above,
+    // synchronously, before the import. And the cache this clears lives on the
+    // module's own `tenderBreaker` (`persistCache: false`, so in-memory only):
+    // if the import fails the module never evaluated in this page, so there is
+    // no breaker and no cached Pro data to clear; if it ever did evaluate, the
+    // specifier resolves from the module registry and cannot fail. A failure
+    // here therefore implies an empty cache, not an unclearable one.
+    try {
+      const { clearGlobalTenderCache } = await import('@/services/global-tenders');
+      clearGlobalTenderCache();
+    } catch (e) {
+      console.warn('[App] Global tender cache clear failed:', e);
+    }
   }
 
   async loadBisData(): Promise<void> {

--- a/tests/global-tenders-clear-unhandled-rejection.test.mts
+++ b/tests/global-tenders-clear-unhandled-rejection.test.mts
@@ -1,0 +1,143 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+/**
+ * WORLDMONITOR-100 — `TypeError: n is not a function. (In 'n()', 'n' is
+ * undefined)`, Safari, culprit `clearGlobalTenders(assets/main-*)`, Sentry
+ * mechanism `auto.browser.global_handlers.onunhandledrejection`.
+ *
+ * `DataLoader.clearGlobalTenders` ends in a dynamic `import()` whose resolved
+ * binding it calls immediately. Its ONLY call site is fire-and-forget —
+ * `void this.dataLoader.clearGlobalTenders()` in `src/App.ts`, on the
+ * premium->free entitlement transition — so nothing attaches a rejection
+ * handler. Any failure in that import therefore escapes as an unhandled
+ * rejection instead of degrading a single panel, which is exactly the
+ * mechanism Sentry recorded.
+ *
+ * `src/app/data-loader.ts` cannot be imported under Node (it pulls Vite-only
+ * `@/workers/ml.worker?worker` specifiers), so this asserts the guard
+ * structurally, over the real parsed AST rather than a regex over source text.
+ * The fixture cases below are the anti-vacuity controls: they prove the
+ * checker actually discriminates guarded from unguarded, so a broken checker
+ * cannot make the production assertion pass by accident.
+ */
+
+/** True when `node` sits inside a `try` block without crossing a function boundary. */
+function insideTryBlock(node: ts.Node): boolean {
+  let prev: ts.Node = node;
+  for (let p: ts.Node | undefined = node.parent; p; prev = p, p = p.parent) {
+    if (ts.isTryStatement(p) && p.tryBlock === prev) return true;
+    // A `try` outside an intervening function does not protect this call: the
+    // inner function's rejection is delivered to ITS caller, not to that try.
+    if (ts.isFunctionLike(p)) return false;
+  }
+  return false;
+}
+
+/** Every dynamic `import()` inside the named method, with its guarded-ness. */
+function dynamicImportsIn(source: string, methodName: string): { specifier: string; guarded: boolean }[] {
+  const sf = ts.createSourceFile('probe.ts', source, ts.ScriptTarget.Latest, true);
+  const found: { specifier: string; guarded: boolean }[] = [];
+
+  const enclosingMethodName = (n: ts.Node): string | null => {
+    for (let p: ts.Node | undefined = n.parent; p; p = p.parent) {
+      if (ts.isMethodDeclaration(p) || ts.isFunctionDeclaration(p)) return p.name?.getText() ?? null;
+    }
+    return null;
+  };
+
+  const walk = (n: ts.Node): void => {
+    if (ts.isCallExpression(n) && n.expression.kind === ts.SyntaxKind.ImportKeyword) {
+      if (enclosingMethodName(n) === methodName) {
+        found.push({
+          specifier: n.arguments[0]?.getText().replace(/['"]/g, '') ?? '',
+          guarded: insideTryBlock(n),
+        });
+      }
+    }
+    ts.forEachChild(n, walk);
+  };
+  walk(sf);
+  return found;
+}
+
+describe('AST checker controls (anti-vacuity)', () => {
+  it('reports an unguarded dynamic import as unguarded', () => {
+    const found = dynamicImportsIn(
+      `class C { async m() { const { x } = await import('@/mod'); x(); } }`,
+      'm',
+    );
+    assert.equal(found.length, 1);
+    assert.equal(found[0].guarded, false);
+  });
+
+  it('reports a try-wrapped dynamic import as guarded', () => {
+    const found = dynamicImportsIn(
+      `class C { async m() { try { const { x } = await import('@/mod'); x(); } catch {} } }`,
+      'm',
+    );
+    assert.equal(found.length, 1);
+    assert.equal(found[0].guarded, true);
+  });
+
+  // The `catch` block is NOT a guard for anything it contains, and a `try` that
+  // sits outside an intervening function does not protect the inner call.
+  it('does not count a try that is separated by a function boundary', () => {
+    const found = dynamicImportsIn(
+      `class C { async m() { try { setTimeout(async () => { await import('@/mod'); }); } catch {} } }`,
+      'm',
+    );
+    assert.equal(found.length, 1);
+    assert.equal(found[0].guarded, false, 'an inner arrow function must not inherit the outer try');
+  });
+});
+
+describe('clearGlobalTenders cannot reject into the void call site (WORLDMONITOR-100)', () => {
+  const loader = readFileSync(resolve(root, 'src/app/data-loader.ts'), 'utf8');
+
+  it('guards its dynamic import of @/services/global-tenders', () => {
+    const found = dynamicImportsIn(loader, 'clearGlobalTenders');
+    assert.equal(found.length, 1, 'expected exactly one dynamic import in clearGlobalTenders');
+    assert.equal(found[0].specifier, '@/services/global-tenders');
+    assert.equal(
+      found[0].guarded,
+      true,
+      'clearGlobalTenders is called as `void ...()`; an unguarded import() rejection ' +
+        'becomes an unhandled rejection (WORLDMONITOR-100)',
+    );
+  });
+
+  // Pins the premise the guard rests on. If a future refactor gives the call
+  // site its own rejection handler, this test's rationale changes and should be
+  // re-derived rather than silently kept.
+  it('is still invoked fire-and-forget, with no rejection handler', () => {
+    const app = readFileSync(resolve(root, 'src/App.ts'), 'utf8');
+    assert.match(
+      app,
+      /void this\.dataLoader\.clearGlobalTenders\(\);/,
+      'expected the fire-and-forget call site that makes the guard necessary',
+    );
+    assert.doesNotMatch(app, /clearGlobalTenders\(\)\s*\.\s*catch/);
+  });
+
+  // The user-visible half of the downgrade guarantee must stay ahead of the
+  // import, so a swallowed import failure can never leave Pro data on screen.
+  it('clears the panel before the guarded import, not after', () => {
+    const body = loader.slice(loader.indexOf('async clearGlobalTenders('));
+    const end = body.indexOf('\n  async ', 1);
+    const method = body.slice(0, end === -1 ? body.length : end);
+    assert.ok(
+      method.indexOf('procurementPanel?.clear()') < method.indexOf('await import('),
+      'the panel clear must run before the import that can fail',
+    );
+    assert.ok(method.indexOf('this.globalTenderFilters = {}') < method.indexOf('await import('));
+  });
+});

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -58,6 +58,19 @@ describe('marketing ignoreErrors', () => {
     assert.equal(isIgnored('Error', 'Invalid call to runtime.sendMessage(). Tab not found.'), true);
   });
 
+  it('drops the Zalo in-app-browser bridge global (WORLDMONITOR-102)', () => {
+    // Verbatim production value; Safari phrases a missing global this way.
+    assert.equal(isIgnored('ReferenceError', "Can't find variable: zaloJSV2"), true);
+    // Chrome/Edge phrasing for the same missing global.
+    assert.equal(isIgnored('ReferenceError', 'zaloJSV2 is not defined'), true);
+  });
+
+  // Positive control for the `\b` bounds on the Zalo entry: the pattern must
+  // key on the identifier, not on a substring that a longer word contains.
+  it('keeps an error that merely mentions a similar word', () => {
+    assert.equal(isIgnored('ReferenceError', "Can't find variable: zaloJSV2Extended"), false);
+  });
+
   // Positive control: the array must not have grown a pattern broad enough to
   // swallow an ordinary marketing-bundle bug.
   it('keeps a genuine first-party error message', () => {
@@ -140,6 +153,52 @@ describe('marketingBeforeSend — stale chunk after deploy', () => {
     const kept = event("Cannot read properties of undefined (reading 'plan')", [
       '/pro/assets/index-a1b2c3.js',
     ]);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+});
+
+describe('marketingBeforeSend — injected-script recursion', () => {
+  it('drops the document-framed stack overflow (WORLDMONITOR-103)', () => {
+    // Verbatim production event: Chrome Mobile iOS, every frame on the
+    // prerendered document, whose reported lines sit inside inert JSON-LD.
+    assert.equal(
+      marketingBeforeSend(event('Maximum call stack size exceeded.', [
+        'https://www.worldmonitor.app/',
+        'https://www.worldmonitor.app/',
+      ])),
+      null,
+    );
+  });
+
+  it('drops the Chrome and Firefox phrasings', () => {
+    for (const value of ['Maximum call stack size exceeded', 'too much recursion']) {
+      assert.equal(
+        marketingBeforeSend(event(value, ['https://www.worldmonitor.app/'])),
+        null,
+        `expected ${value} dropped`,
+      );
+    }
+  });
+
+  // Positive control for the `!hasFirstParty` gate. A render loop inside our
+  // own bundle is the realistic first-party cause of this exact message and
+  // must still page; delete the gate and this goes red.
+  it('keeps a stack overflow that carries a marketing-bundle frame', () => {
+    const kept = event('Maximum call stack size exceeded.', [
+      '/pro/assets/index-a1b2c3.js',
+    ]);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  it('keeps a stack overflow that carries a source-mapped frame', () => {
+    const kept = event('too much recursion', ['pro-test/src/WelcomeApp.tsx']);
+    assert.equal(marketingBeforeSend(kept), kept);
+  });
+
+  // Positive control that the recursion pattern is not broad enough to swallow
+  // an ordinary frameless crash from this bundle.
+  it('keeps an unrelated frameless error', () => {
+    const kept = event('Dodo checkout session could not be created');
     assert.equal(marketingBeforeSend(kept), kept);
   });
 });


### PR DESCRIPTION
## Summary

Three issues from the 2026-08-19 Sentry triage. One is a real first-party defect: a premium→free downgrade could emit an unhandled promise rejection. Two are injected-script noise the marketing surface was still reporting because the dashboard's filters do not apply to it.

Neither change alters what a user sees. The first removes a spurious error report on a path whose user-visible work had already completed; the other two stop other people's scripts from being filed as our crashes.

Related: #6943 (the PR that introduced the marketing policy these two entries extend).

## The unhandled rejection (WORLDMONITOR-100)

`DataLoader.clearGlobalTenders` ended in a dynamic `import()` whose resolved binding it called immediately, unguarded. Its only call site is fire-and-forget — `void this.dataLoader.clearGlobalTenders()` at `src/App.ts:2060`, on the premium→free entitlement transition — so nothing attaches a rejection handler and any failure there escapes as an unhandled rejection instead of degrading one panel. That matches the mechanism Sentry recorded (`onunhandledrejection`). An AST scan found this was 1 of only 6 unguarded dynamic imports out of 31 in the file.

**On root cause, precisely:** read from the deployed bundle the frame is `const{clearGlobalTenderCache:n}=await C(...);n()`. Both candidate explanations were checked against production rather than assumed, and both are ruled out — the deployed `global-tenders-BezROVVy.js` *does* export `clearGlobalTenderCache`, and the sibling `n()` inside that chunk resolves to `getRpcBaseUrl`, a hoisted function declaration that can never be undefined. So what emptied the binding on that one page is **not** established from a single event. What is established is the call path that turns any such failure into an unhandled rejection, and that is what this fixes.

**Why swallowing is safe here.** This method exists to enforce "Pro data must not survive a downgrade", so a bare `catch` deserves scrutiny. It does not weaken that guarantee:

- Everything user-visible — the generation bump, the filter reset, the panel clear — already runs synchronously *above* the import. A test pins that ordering.
- The cache being cleared lives on the module's own `tenderBreaker`, which is `persistCache: false` (in-memory only). If the import fails, the module never evaluated in this page, so there is no breaker and no cached Pro data. If it ever did evaluate, the specifier resolves from the module registry and cannot fail.

A failure here therefore implies an empty cache, not an unclearable one.

## The two filtered issues

| Issue | Message | Where it goes | Why |
|---|---|---|---|
| WORLDMONITOR-102 | `Can't find variable: zaloJSV2` | `ignoreErrors` | Zalo's in-app browser injects a JS bridge referencing `zaloJSV2` before defining it. The identifier appears nowhere in our source except the dashboard's own suppressor (`src/bootstrap/sentry-init.ts:102`), so it cannot come from our bundle. Bounded with `\b` so a longer identifier containing it still reports. |
| WORLDMONITOR-103 | `Maximum call stack size exceeded.` | `beforeSend`, behind `!hasFirstParty` | Generic runtime message our own React bundle can genuinely produce, so message-only filtering would blind the surface to its own most likely crash. |

The evidence that 103 is not ours is not visible in the diff: every reported frame lands on the prerendered document at lines 187, 194, 195 and 224 — and all four sit inside `<script type="application/ld+json">` blocks in the served HTML. JSON-LD is inert data and cannot execute, so the document holds no first-party JS at those offsets. Our own code always rides a `/pro/assets/*.js` frame.

Worth flagging for review: this deliberately **diverges** from the dashboard, which carries a bare `/too much recursion/` in `ignoreErrors` (line 101). Copying that would reintroduce exactly the blind spot the marketing policy was written to avoid, so both recursion phrasings are stack-gated here instead.

## Validation

- **Mutation swept, 8/8 mutants killed.** Reverting the `try/catch` to its original shape turns the new test red; so does moving the import behind an inner function boundary (a merely *nearby* `try` must not count) and moving the panel clear after the import. On the filter side: deleting either pattern, dropping the `\b` bounds, deleting the recursion gate, dropping its `!hasFirstParty` guard, and narrowing the phrasing each turn the suite red.
- **Both gates carry positive controls**, so neither can pass on absence: a first-party-framed stack overflow and a source-mapped one must still page, and the AST checker is proven to discriminate guarded from unguarded using inline fixtures rather than production code.
- `src/app/data-loader.ts` cannot be imported under Node (Vite-only `@/workers/ml.worker?worker` specifiers), so the regression test asserts the guard over the real parsed TypeScript AST rather than a regex over source text.
- 762 tests pass across every Sentry suite and every suite that reads `data-loader.ts`. `tsc --noEmit` clean at the root and in `pro-test`; biome clean; all pre-push gates green.

One caveat: the marketing filters only take effect once this deploys, so WORLDMONITOR-102 and -103 can regress from events arriving before then. That is the intended behavior of a plain resolve, not a pin.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
