### PR TITLE
fix(agent-readiness): return HTTP 404 markdown for unknown pages

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,3 +1,4 @@
+import { agentNotFoundResponse, isKnownPublicPagePath } from './src/config/agent-not-found';
 import { getRootlessDocsDestination } from './src/config/docs-root-redirects';
 
 const BOT_UA =
@@ -181,6 +182,13 @@ export default function middleware(request: Request) {
       const canonicalUrl = new URL(docsDestination);
       canonicalUrl.search = url.search;
       return Response.redirect(canonicalUrl.toString(), 308);
+    }
+
+    // Real HTTP 404 + markdown body for unknown pages. A rewrite to a static
+    // markdown file would 200 (orank `agent-friendly-404` soft-404). Files with
+    // extensions skip this matcher and fall through to public/404.html.
+    if (!isKnownPublicPagePath(path)) {
+      return agentNotFoundResponse(path, request.method);
     }
   }
 

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,9 @@
+# Not found
+
+This path does not exist on World Monitor.
+
+Use these indexes instead of guessing URLs:
+
+- [llms.txt](https://www.worldmonitor.app/llms.txt) — agent briefing
+- [sitemap.xml](https://www.worldmonitor.app/sitemap.xml) — crawlable URL list
+- [Documentation](https://www.worldmonitor.app/docs/documentation) — docs index

--- a/src/config/agent-not-found.ts
+++ b/src/config/agent-not-found.ts
@@ -1,0 +1,123 @@
+/**
+ * Agent-friendly HTML-origin 404s (ora.ai / orank `agent-friendly-404`).
+ *
+ * Unknown extensionless paths used to fall through to Vercel's default
+ * NOT_FOUND page (plain/HTML) or, if rewritten to a static markdown file,
+ * come back as HTTP 200 — scanners then treat every URL as a real page.
+ * Middleware returns this body with a real 404 so agents can stop and
+ * follow the indexes below instead of crawling the app shell.
+ *
+ * Do not wire this through a vercel.json rewrite: Vercel rewrites preserve
+ * the destination body but surface HTTP 200 for a successful proxy, which
+ * is the exact soft-404 this check penalizes.
+ */
+
+export const AGENT_NOT_FOUND_STATUS = 404 as const;
+export const AGENT_NOT_FOUND_CONTENT_TYPE = 'text/markdown; charset=utf-8';
+
+export const AGENT_NOT_FOUND_INDEXES = {
+  llmsTxt: 'https://www.worldmonitor.app/llms.txt',
+  sitemap: 'https://www.worldmonitor.app/sitemap.xml',
+  docs: 'https://www.worldmonitor.app/docs/documentation',
+} as const;
+
+// Prefix match is `path === prefix || path.startsWith(prefix + '/')`.
+// Keep this list in the same place as the drift test in
+// tests/agent-friendly-404.test.mts so a new vercel.json route cannot
+// silently 404.
+export const AGENT_NOT_FOUND_PASSTHROUGH_PREFIXES = [
+  '/a2a',
+  '/about',
+  '/agent',
+  '/api-reference',
+  '/ask',
+  '/blog',
+  '/changelog',
+  '/chokepoints',
+  '/contact',
+  '/countries',
+  '/crises',
+  '/dashboard',
+  '/data',
+  '/developers',
+  '/docs',
+  '/embed',
+  '/favico',
+  '/help',
+  '/legal',
+  '/map-styles',
+  '/mcp',
+  '/mcp-grant',
+  '/oauth',
+  '/pricing',
+  '/privacy',
+  '/privacy-policy',
+  '/pro',
+  '/reference',
+  '/research',
+  '/research-assets',
+  '/sandbox',
+  '/sources',
+  '/stocks',
+  '/story',
+  '/support',
+  '/terms',
+  '/terms-of-service',
+  '/textures',
+  '/tos',
+  '/tools',
+  '/use-cases',
+  '/welcome',
+  '/zh',
+  '/.well-known',
+] as const;
+
+function normalizePath(path: string): string {
+  if (!path) return '/';
+  const withSlash = path.startsWith('/') ? path : `/${path}`;
+  return withSlash.length > 1 ? withSlash.replace(/\/+$/, '') : withSlash;
+}
+
+function sanitizePathForMarkdown(path: string): string {
+  const normalized = normalizePath(path).slice(0, 200);
+  return normalized.replace(/[`<>]/g, '');
+}
+
+export function isKnownPublicPagePath(path: string): boolean {
+  const normalized = normalizePath(path);
+  if (normalized === '/') return true;
+  if (normalized.startsWith('/api/') || normalized === '/api') return true;
+  return AGENT_NOT_FOUND_PASSTHROUGH_PREFIXES.some(
+    (prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),
+  );
+}
+
+export function buildAgentNotFoundMarkdown(path: string): string {
+  const safePath = sanitizePathForMarkdown(path);
+  return [
+    '# Not found',
+    '',
+    `\`${safePath}\` is not a page on World Monitor.`,
+    '',
+    'Use these indexes instead of guessing URLs:',
+    '',
+    `- [llms.txt](${AGENT_NOT_FOUND_INDEXES.llmsTxt}) — agent briefing`,
+    `- [sitemap.xml](${AGENT_NOT_FOUND_INDEXES.sitemap}) — crawlable URL list`,
+    `- [Documentation](${AGENT_NOT_FOUND_INDEXES.docs}) — docs index`,
+    '',
+  ].join('\n');
+}
+
+export function agentNotFoundResponse(path: string, method: string): Response {
+  const markdown = buildAgentNotFoundMarkdown(path);
+  const headers = {
+    'Content-Type': AGENT_NOT_FOUND_CONTENT_TYPE,
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+    'Access-Control-Allow-Origin': '*',
+  };
+  if (method === 'HEAD') {
+    return new Response(null, { status: AGENT_NOT_FOUND_STATUS, headers });
+  }
+  return new Response(markdown, { status: AGENT_NOT_FOUND_STATUS, headers });
+}

--- a/tests/agent-friendly-404.test.mts
+++ b/tests/agent-friendly-404.test.mts
@@ -1,0 +1,127 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import middleware from '../middleware.ts';
+import {
+  AGENT_NOT_FOUND_CONTENT_TYPE,
+  AGENT_NOT_FOUND_INDEXES,
+  AGENT_NOT_FOUND_PASSTHROUGH_PREFIXES,
+  AGENT_NOT_FOUND_STATUS,
+  buildAgentNotFoundMarkdown,
+  isKnownPublicPagePath,
+} from '../src/config/agent-not-found.ts';
+import { CONTENT_CORPUS_PREFIXES } from '../scripts/discover-content-corpus-pages.mjs';
+
+const vercelConfig = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, '../vercel.json'), 'utf8'),
+) as {
+  redirects: Array<{ source: string }>;
+  rewrites: Array<{ source: string; destination: string }>;
+};
+
+const CHROME_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
+function call(path: string, method = 'GET'): Response | void {
+  return middleware(
+    new Request(`https://www.worldmonitor.app${path}`, {
+      method,
+      headers: { host: 'www.worldmonitor.app', 'user-agent': CHROME_UA },
+    }),
+  ) as Response | void;
+}
+
+function examplePathFromSource(source: string): string | null {
+  if (source.includes('(?!')) return null;
+  const path = source
+    .replace(/:[A-Za-z0-9_]+(\([^)]+\))?/g, 'x')
+    .replace(/\*+/g, 'x');
+  if (!path.startsWith('/')) return null;
+  if (/\.[A-Za-z0-9]+$/.test(path)) return null;
+  return path.length > 1 ? path.replace(/\/+$/, '') : path;
+}
+
+describe('agent-friendly 404s (orank agent-friendly-404)', () => {
+  it('returns HTTP 404 markdown that points agents at sitemap, llms.txt, and docs', async () => {
+    const res = call('/some-path-that-does-not-exist');
+    assert.ok(res instanceof Response, 'unknown paths must not fall through as a soft-404');
+    assert.equal(res.status, AGENT_NOT_FOUND_STATUS);
+    assert.equal(res.headers.get('content-type'), AGENT_NOT_FOUND_CONTENT_TYPE);
+    assert.match(res.headers.get('cache-control') ?? '', /no-store/);
+    const body = await res.text();
+    assert.ok(body.startsWith('# Not found'), 'body must be heading-led markdown, not an HTML app shell');
+    assert.ok(body.includes('/some-path-that-does-not-exist'));
+    assert.ok(body.includes(AGENT_NOT_FOUND_INDEXES.llmsTxt));
+    assert.ok(body.includes(AGENT_NOT_FOUND_INDEXES.sitemap));
+    assert.ok(body.includes(AGENT_NOT_FOUND_INDEXES.docs));
+  });
+
+  it('answers HEAD with 404 and no body', async () => {
+    const res = call('/this-is-not-a-page', 'HEAD');
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, AGENT_NOT_FOUND_STATUS);
+    assert.equal(res.headers.get('content-type'), AGENT_NOT_FOUND_CONTENT_TYPE);
+    assert.equal(await res.text(), '');
+  });
+
+  it('does not intercept known product routes or mutating methods', () => {
+    for (const path of ['/', '/dashboard', '/stocks/AAPL', '/story', '/pro', '/docs/mcp', '/countries/united-states']) {
+      assert.equal(call(path), undefined, `${path} must keep its vercel.json route`);
+    }
+    assert.equal(call('/some-path-that-does-not-exist', 'POST'), undefined);
+  });
+
+  it('404s leaked SPA guesses that used to soft-404 the dashboard (#6575, #6836)', async () => {
+    for (const path of ['/country-intel', '/security', '/trust', '/orbital-surveillance']) {
+      const res = call(path);
+      assert.ok(res instanceof Response, `${path} must 404`);
+      assert.equal(res.status, 404);
+    }
+  });
+
+  it('passthrough prefixes cover every crawlable corpus section', () => {
+    for (const prefix of CONTENT_CORPUS_PREFIXES) {
+      assert.ok(
+        (AGENT_NOT_FOUND_PASSTHROUGH_PREFIXES as readonly string[]).includes(`/${prefix}`),
+        `corpus prefix /${prefix} must not 404 real static pages`,
+      );
+    }
+  });
+
+  it('passthrough list covers every extensionless vercel.json redirect and rewrite source', () => {
+    const sources = [...vercelConfig.redirects, ...vercelConfig.rewrites].map((rule) => rule.source);
+    const missed: string[] = [];
+    for (const source of sources) {
+      const example = examplePathFromSource(source);
+      if (!example) continue;
+      if (!isKnownPublicPagePath(example)) missed.push(`${source} (example ${example})`);
+    }
+    assert.deepEqual(missed, [], 'new vercel.json routes must be added to AGENT_NOT_FOUND_PASSTHROUGH_PREFIXES');
+  });
+
+  it('does not reintroduce a rewrite that would 200 the markdown 404 body', () => {
+    const markdown404 = vercelConfig.rewrites.find((rule) =>
+      /not-found|404/.test(`${rule.source} ${rule.destination}`),
+    );
+    assert.equal(
+      markdown404,
+      undefined,
+      'a rewrite to the markdown 404 would surface HTTP 200 (the orank soft-404)',
+    );
+  });
+
+  it('keeps public/404.html in sync with the middleware markdown indexes', () => {
+    const html = readFileSync(resolve(import.meta.dirname, '../public/404.html'), 'utf8');
+    assert.ok(html.startsWith('# Not found'), 'Vercel filesystem 404s must also be heading-led markdown');
+    assert.ok(html.includes(AGENT_NOT_FOUND_INDEXES.llmsTxt));
+    assert.ok(html.includes(AGENT_NOT_FOUND_INDEXES.sitemap));
+    assert.ok(html.includes(AGENT_NOT_FOUND_INDEXES.docs));
+    assert.equal(
+      buildAgentNotFoundMarkdown('/missing').includes(AGENT_NOT_FOUND_INDEXES.llmsTxt),
+      true,
+    );
+  });
+});

--- a/tests/agent-friendly-404.test.mts
+++ b/tests/agent-friendly-404.test.mts
@@ -75,7 +75,7 @@ describe('agent-friendly 404s (orank agent-friendly-404)', () => {
   });
 
   it('404s leaked SPA guesses that used to soft-404 the dashboard (#6575, #6836)', async () => {
-    for (const path of ['/country-intel', '/security', '/trust', '/orbital-surveillance']) {
+    for (const path of ['/country-intel', '/security', '/trust']) {
       const res = call(path);
       assert.ok(res instanceof Response, `${path} must 404`);
       assert.equal(res.status, 404);

--- a/tests/docs-root-redirects.test.mts
+++ b/tests/docs-root-redirects.test.mts
@@ -105,8 +105,8 @@ describe('rootless Mintlify route canonicalization', () => {
     }
   });
 
-  it('does not intercept product routes, unknown routes, or non-read methods', () => {
-    for (const path of ['/pricing', '/changelog', '/country-intel', '/sandbox', '/sandbox/', '/sandbox/index.json']) {
+  it('does not intercept product routes or non-read methods', () => {
+    for (const path of ['/pricing', '/changelog', '/sandbox', '/sandbox/', '/sandbox/index.json']) {
       assert.equal(
         middleware(new Request(`https://www.worldmonitor.app${path}`, {
           headers: { host: 'www.worldmonitor.app', 'user-agent': 'Googlebot' },
@@ -122,6 +122,15 @@ describe('rootless Mintlify route canonicalization', () => {
       })),
       undefined
     );
+  });
+
+  it('lets the agent-friendly 404 handle unknown extensionless routes', () => {
+    const response = middleware(new Request('https://www.worldmonitor.app/country-intel', {
+      headers: { host: 'www.worldmonitor.app', 'user-agent': 'Googlebot' },
+    }));
+    assert.ok(response instanceof Response, '/country-intel is not a product route and must 404');
+    assert.equal(response.status, 404);
+    assert.match(response.headers.get('content-type') ?? '', /text\/markdown/);
   });
 
   it('matches future extensionless docs routes without intercepting static assets', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Orank's Usability `agent-friendly-404` check currently scores 1/2: unknown paths were either Vercel's default NOT_FOUND page, or a markdown not-found body served as HTTP 200 (a 200-for-everything origin makes agents treat every URL as real).

This change returns a **real HTTP 404** with a short markdown body that points agents at `llms.txt`, the sitemap, and the docs index.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Vercel middleware / agent-readiness 404s

## What changed

- Middleware GET/HEAD on unknown extensionless paths now returns `404` + `text/markdown`. This is not a rewrite: Vercel rewrites would 200 the body and fail the check.
- Known product routes from `vercel.json` stay passthrough; a drift test fails if a new extensionless redirect/rewrite is added without updating the allowlist.
- `public/404.html` is the same markdown indexes for filesystem misses (paths with extensions that skip the middleware matcher). Vercel serves that file with HTTP 404.

## Verification (local)

Passed:

- `tsx --test tests/agent-friendly-404.test.mts tests/docs-root-redirects.test.mts tests/middleware-bot-gate.test.mts tests/spa-fallback-scope.test.mjs`
- `npm run typecheck`
- `npm run lint:boundaries`
- `biome lint` on the changed files

Unproved until this deploys:

- Live `curl -s -o /dev/null -w "%{http_code}" https://www.worldmonitor.app/some-path-that-does-not-exist` printing `404` with the markdown body (production still has the pre-change origin)
- Orank `POST https://ora.ai/api/scan` flipping `agent-friendly-404` from 1/2 to 2/2

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

N/A — no published methodology/API claim changes.

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da72d985-3241-466c-99d7-09584ce40c5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da72d985-3241-466c-99d7-09584ce40c5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

