### PR TITLE
fix(ci): fail closed on git/4xx and surface unread deploy warnings

### DIFF
--- a/.github/workflows/postmerge-deploy-monitor.yml
+++ b/.github/workflows/postmerge-deploy-monitor.yml
@@ -52,5 +52,5 @@ jobs:
           # Pick up commits merged since the checkout so the convex=false skip
           # proof diffs the head the API reports, not the SHA the checkout was
           # created at. Same shape as seed-freshness-monitor.yml's drift step.
-          git fetch --quiet origin main || true
+          git fetch --quiet origin main
           node scripts/check-postmerge-deploys.mjs

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -151,6 +151,30 @@ export function isRetryableGhFailure(error) {
   return true;
 }
 
+const GITHUB_READ_SOURCE = 'github-api';
+
+function markGithubReadFailure(error) {
+  const marked = error instanceof Error ? error : new Error(String(error));
+  marked.githubReadSource = GITHUB_READ_SOURCE;
+  return marked;
+}
+
+function isGithubReadFailure(error) {
+  return error instanceof Error && error.githubReadSource === GITHUB_READ_SOURCE;
+}
+
+function isProvenGithubTransportFailure(message) {
+  return /\b(?:tls|x509|eof)\b|certificate|dial tcp|lookup .*no such host|no such host|connection (?:reset|refused|closed|aborted)|network is unreachable|no route to host|context deadline exceeded|i\/o timeout|operation timed out|temporary failure in name resolution/i.test(message);
+}
+
+function readGithub(gh, args) {
+  try {
+    return gh(args);
+  } catch (error) {
+    throw markGithubReadFailure(error);
+  }
+}
+
 /**
  * After the retry budget, is this throw GitHub-record unreadability rather
  * than a local proof failure or a GitHub answer?
@@ -161,23 +185,16 @@ export function isRetryableGhFailure(error) {
  * burn the job) but they are still unreadability.
  */
 export function isGithubRecordUnreadability(error) {
-  if (!error) return false;
+  if (!isGithubReadFailure(error)) return false;
   if (error.code === 'ENOENT') return false;
-  const message = error instanceof Error ? error.message : String(error);
-  if (
-    message === 'the deployed baseline SHA is missing'
-    || message === 'the deploy trigger path list is missing'
-    || message.startsWith('git ')
-  ) {
-    return false;
-  }
+  const message = error.message;
   if (error.timedOut === true) return true;
   const status = message.match(/\(HTTP (\d{3})\)/);
   if (status) {
     const code = Number(status[1]);
-    return code === 408 || code === 429 || code >= 500;
+    return code >= 500;
   }
-  return true;
+  return isProvenGithubTransportFailure(message);
 }
 
 function sleepSync(ms) {
@@ -213,11 +230,11 @@ function runGh(args) {
   if (result.signal) {
     const error = new Error(`gh ${args.join(' ')} timed out`);
     error.timedOut = true;
-    throw error;
+    throw markGithubReadFailure(error);
   }
-  if (result.error) throw result.error;
+  if (result.error) throw markGithubReadFailure(result.error);
   if (result.status !== 0) {
-    throw new Error(`gh ${args.join(' ')} failed (${result.status}): ${String(result.stderr).trim()}`);
+    throw markGithubReadFailure(new Error(`gh ${args.join(' ')} failed (${result.status}): ${String(result.stderr).trim()}`));
   }
   return result.stdout;
 }
@@ -239,7 +256,7 @@ export function readNewestRun({ gh, repository, workflowFile, now, noRunWindowMs
     'branch=main',
     'per_page=100',
   ].join('&');
-  const payload = JSON.parse(gh([
+  const payload = JSON.parse(readGithub(gh, [
     'api',
     `repos/${repository}/actions/workflows/${workflowFile}/runs?${query}`,
   ]));
@@ -315,7 +332,7 @@ export function readNewestRun({ gh, repository, workflowFile, now, noRunWindowMs
  * (runs 31323075509 / 31323823825).
  */
 export function readRunJobs({ gh, repository, runId, runAttempt }) {
-  const payload = JSON.parse(gh([
+  const payload = JSON.parse(readGithub(gh, [
     'api',
     `repos/${repository}/actions/runs/${runId}/attempts/${runAttempt}/jobs`,
   ]));

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -28,11 +28,15 @@
 //
 // DIRECTION OF FAILURE
 //
-// Every case where the record is missing, unreadable, ambiguous or truncated
-// resolves away from "healthy". A scanner whose unmatched case means HEALTHY
-// is the same defect in a new place.
+// A verified failed deploy is ALARM and fails the job. GitHub transport
+// unreadability after the retry budget (TLS, DNS, timeout, 5xx) is UNKNOWN:
+// visible as an Actions warning, never a claim that a deploy failed, and it
+// does not fail the job. Local proof failures (git, missing `gh`) and GitHub
+// 4xx answers are ALARM and still fail the job. An unmatched case that means
+// HEALTHY is the same defect in a new place.
 
 import { spawnSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
 
 import { isMainModule } from './lib/main-module.mjs';
 import { REPOSITORY, readArgument } from './railway-cli.mjs';
@@ -139,6 +143,35 @@ export function isRetryableGhFailure(error) {
   // gh itself missing (ENOENT) will never succeed on a retry.
   if (error.code === 'ENOENT') return false;
   const message = error instanceof Error ? error.message : String(error);
+  const status = message.match(/\(HTTP (\d{3})\)/);
+  if (status) {
+    const code = Number(status[1]);
+    return code === 408 || code === 429 || code >= 500;
+  }
+  return true;
+}
+
+/**
+ * After the retry budget, is this throw GitHub-record unreadability rather
+ * than a local proof failure or a GitHub answer?
+ *
+ * Only unreadability becomes UNKNOWN (a non-failing Actions warning). git
+ * throws, a missing `gh` binary, and HTTP 4xx answers are ALARM so the
+ * monitor still fails closed for those. Timeouts are not retried (they would
+ * burn the job) but they are still unreadability.
+ */
+export function isGithubRecordUnreadability(error) {
+  if (!error) return false;
+  if (error.code === 'ENOENT') return false;
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    message === 'the deployed baseline SHA is missing'
+    || message === 'the deploy trigger path list is missing'
+    || message.startsWith('git ')
+  ) {
+    return false;
+  }
+  if (error.timedOut === true) return true;
   const status = message.match(/\(HTTP (\d{3})\)/);
   if (status) {
     const code = Number(status[1]);
@@ -319,7 +352,7 @@ export function diffTouchesPath({ git, parentSha, headSha, pathPrefix }) {
  *
  * Path-filtered workflows can be dormant indefinitely. Their age alone says
  * nothing about health; the trigger-path tree diff says whether a newer deploy
- * was required. A read failure throws so the caller reports UNKNOWN, never OK.
+ * was required. A read failure throws so the caller reports ALARM, never OK.
  */
 export function diffTouchesPaths({ git, baseSha, headSha, paths }) {
   if (typeof baseSha !== 'string' || baseSha.length === 0) {
@@ -510,9 +543,9 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequir
 /**
  * Run the whole monitor for every monitored workflow and return the report.
  *
- * `io` bundles the injected side effects: `gh`, `git`, `now`. Every unreadable
- * record becomes UNKNOWN so it stays visible without being mistaken for a
- * failed deploy.
+ * `io` bundles the injected side effects: `gh`, `git`, `now`. GitHub
+ * transport unreadability becomes UNKNOWN. git/4xx/ENOENT throws become
+ * ALARM so they still fail the job.
  */
 export function checkPostmergeDeploys({ repository, gh, git, now = Date.now() }) {
   const results = [];
@@ -558,16 +591,18 @@ export function checkPostmergeDeploys({ repository, gh, git, now = Date.now() })
     } catch (error) {
       // #6479: one unreadable record used to abort the whole walk, so a
       // transient failure on the FIRST workflow hid a genuinely red deploy on
-      // the second. Every workflow gets its own verdict; an unread one is
-      // UNKNOWN, which is not healthy but is also not a claim that a deploy
-      // failed — the monitor never saw the record.
+      // the second. Every workflow gets its own verdict. GitHub transport
+      // unreadability is UNKNOWN (not a failed deploy). git, missing gh, and
+      // HTTP 4xx answers are ALARM so they still fail the job.
+      const detail = `the record could not be read: ${error instanceof Error ? error.message : String(error)}`;
+      const unread = isGithubRecordUnreadability(error);
       results.push({
         workflow: workflow.file,
         displayName: workflow.displayName,
-        state: 'UNKNOWN',
-        verdict: 'READ_FAILED',
+        state: unread ? 'UNKNOWN' : 'ALARM',
+        verdict: unread ? 'READ_FAILED' : 'READ_UNPROVEN',
         runId: null,
-        detail: `the record could not be read: ${error instanceof Error ? error.message : String(error)}`,
+        detail,
       });
     }
   }
@@ -578,17 +613,24 @@ export function checkPostmergeDeploys({ repository, gh, git, now = Date.now() })
  * Split the results into the two things a notification must not conflate: a
  * deploy that failed, and a record that could not be read. (#6479)
  *
- * Only deploy alarms exit non-zero. An unreadable record remains a visible
- * warning, because "Convex Deploy did not deploy" and "we could not reach the
- * GitHub API" call for opposite responses.
+ * Only ALARM results exit non-zero. GitHub transport unreadability remains a
+ * visible warning, because "Convex Deploy did not deploy" and "we could not
+ * reach the GitHub API" call for opposite responses. git/4xx/ENOENT are
+ * ALARM with verdict READ_UNPROVEN so they are not filed as a failed deploy.
  */
 export function summarizeResults(results) {
   const alarms = results.filter((result) => result.state === 'ALARM');
   const unknowns = results.filter((result) => result.state === 'UNKNOWN');
+  const deployAlarms = alarms.filter((result) => result.verdict !== 'READ_UNPROVEN');
+  const proofAlarms = alarms.filter((result) => result.verdict === 'READ_UNPROVEN');
   const lines = [];
-  if (alarms.length > 0) {
-    lines.push(`Post-merge deploy monitor found ${alarms.length} workflow(s) that did not deploy:`);
-    for (const alarm of alarms) lines.push(`- ${alarm.displayName} [${alarm.verdict}] ${alarm.detail}`);
+  if (deployAlarms.length > 0) {
+    lines.push(`Post-merge deploy monitor found ${deployAlarms.length} workflow(s) that did not deploy:`);
+    for (const alarm of deployAlarms) lines.push(`- ${alarm.displayName} [${alarm.verdict}] ${alarm.detail}`);
+  }
+  if (proofAlarms.length > 0) {
+    lines.push(`Post-merge deploy monitor could not prove ${proofAlarms.length} workflow(s) — git, gh, or a GitHub 4xx answer failed, not a transport outage:`);
+    for (const alarm of proofAlarms) lines.push(`- ${alarm.displayName} [${alarm.verdict}] ${alarm.detail}`);
   }
   if (unknowns.length > 0) {
     lines.push(`Post-merge deploy monitor could not be read for ${unknowns.length} workflow(s) — this is a read failure, not a failed deploy:`);
@@ -600,6 +642,44 @@ export function summarizeResults(results) {
     lines,
     exitCode: alarms.length > 0 ? 1 : 0,
   };
+}
+
+export function formatResultMark(state) {
+  if (state === 'OK') return 'ok';
+  if (state === 'UNKNOWN') return 'warn';
+  return 'ERROR';
+}
+
+export function githubWarningAnnotations(results) {
+  return results
+    .filter((result) => result.state === 'UNKNOWN')
+    .map((result) => (
+      `::warning title=Post-merge deploy record unread::${result.displayName} [${result.verdict}] ${result.detail}`
+    ));
+}
+
+/**
+ * Make UNKNOWN visible on a green Actions job: a `::warning::` annotation
+ * plus the existing summary lines on `$GITHUB_STEP_SUMMARY`. Plain stdout
+ * `warn:` on an exit-0 job is easy to miss.
+ */
+export function writeUnknownVisibility({
+  results,
+  summary,
+  stderr = (...args) => console.error(...args),
+  env = process.env,
+  appendFile = appendFileSync,
+}) {
+  for (const line of githubWarningAnnotations(results)) stderr(line);
+  const summaryPath = env.GITHUB_STEP_SUMMARY;
+  if (typeof summaryPath !== 'string' || summaryPath.length === 0 || summary.lines.length === 0) {
+    return;
+  }
+  try {
+    appendFile(summaryPath, `${summary.lines.join('\n')}\n`);
+  } catch {
+    stderr('::warning::Could not write GitHub step summary');
+  }
 }
 
 async function main() {
@@ -628,12 +708,13 @@ async function main() {
     console.log(JSON.stringify({ repository, results }, null, 2));
   } else {
     for (const result of results) {
-      const mark = result.state === 'OK' ? 'ok' : result.state === 'UNKNOWN' ? 'warn' : 'ERROR';
+      const mark = formatResultMark(result.state);
       console.log(`postmerge-deploy ${mark}: ${result.displayName} [${result.verdict}] ${result.detail}`);
     }
   }
 
   const summary = summarizeResults(results);
+  writeUnknownVisibility({ results, summary });
   for (const line of summary.lines) console.error(line);
   process.exitCode = summary.exitCode;
 }

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -538,6 +538,13 @@ describe('post-merge deploy monitor — read-path resilience (#6479)', () => {
     + 'Get "https://api.github.com/repos/koala73/worldmonitor/actions/runs/30741257511/attempts/1/jobs": '
     + 'tls: failed to verify certificate: x509: certificate is not valid for any names, but wanted to match api.github.com';
 
+  function githubReadFailure(message, properties = {}) {
+    const error = new Error(message);
+    error.githubReadSource = 'github-api';
+    Object.assign(error, properties);
+    return error;
+  }
+
   describe('classifies which gh failures are worth retrying', () => {
     it('retries a transport error that never got an HTTP answer', () => {
       assert.equal(isRetryableGhFailure(new Error(TLS_STDERR)), true);
@@ -586,11 +593,10 @@ describe('post-merge deploy monitor — read-path resilience (#6479)', () => {
 
   describe('classifies which throws are GitHub unreadability', () => {
     it('treats transport, timeout, and 5xx as unreadability', () => {
-      assert.equal(isGithubRecordUnreadability(new Error(TLS_STDERR)), true);
-      const timedOut = new Error('gh api repos/x/actions/runs timed out');
-      timedOut.timedOut = true;
+      assert.equal(isGithubRecordUnreadability(githubReadFailure(TLS_STDERR)), true);
+      const timedOut = githubReadFailure('gh api repos/x/actions/runs timed out', { timedOut: true });
       assert.equal(isGithubRecordUnreadability(timedOut), true);
-      assert.equal(isGithubRecordUnreadability(new Error('gh: Server Error (HTTP 503)')), true);
+      assert.equal(isGithubRecordUnreadability(githubReadFailure('gh: Server Error (HTTP 503)')), true);
     });
 
     it('treats git, missing gh, and HTTP 4xx as proof failures', () => {
@@ -599,9 +605,9 @@ describe('post-merge deploy monitor — read-path resilience (#6479)', () => {
       const missing = new Error('spawn gh ENOENT');
       missing.code = 'ENOENT';
       assert.equal(isGithubRecordUnreadability(missing), false);
-      for (const status of [400, 401, 403, 404, 410, 422]) {
+      for (const status of [400, 401, 403, 404, 408, 410, 422, 429]) {
         assert.equal(
-          isGithubRecordUnreadability(new Error(`gh: Not Found (HTTP ${status})`)),
+          isGithubRecordUnreadability(githubReadFailure(`gh: Not Found (HTTP ${status})`)),
           false,
           `HTTP ${status} is an answer`,
         );
@@ -801,6 +807,60 @@ describe('post-merge deploy monitor — read-path resilience (#6479)', () => {
         assert.equal(entry.state, 'ALARM');
         assert.equal(entry.verdict, 'READ_UNPROVEN');
       }
+      assert.equal(summarizeResults(results).exitCode, 1);
+    });
+
+    it('fails closed for exhausted 4xx, parser, auth, and local proof errors', () => {
+      for (const status of [408, 429]) {
+        let calls = 0;
+        const results = checkPostmergeDeploys({
+          repository: 'koala73/worldmonitor',
+          gh: createRetryingGh({
+            gh: () => {
+              calls += 1;
+              throw new Error(`gh: transient response (HTTP ${status})`);
+            },
+            attempts: 1,
+            sleep: () => {},
+          }),
+          git: () => '',
+          now: NOW,
+        });
+        assert.equal(
+          calls,
+          MONITORED_WORKFLOWS.length * 2,
+          `HTTP ${status} must exhaust its retry budget before each workflow alarms`,
+        );
+        assert.ok(results.every((entry) => entry.state === 'ALARM' && entry.verdict === 'READ_UNPROVEN'));
+        assert.equal(summarizeResults(results).exitCode, 1);
+      }
+
+      for (const gh of [
+        () => '{not json',
+        () => JSON.stringify({ workflow_runs: {} }),
+        () => { throw new Error('gh auth login required'); },
+      ]) {
+        const results = checkPostmergeDeploys({
+          repository: 'koala73/worldmonitor',
+          gh,
+          git: () => '',
+          now: NOW,
+        });
+        assert.ok(results.every((entry) => entry.state === 'ALARM' && entry.verdict === 'READ_UNPROVEN'));
+        assert.equal(summarizeResults(results).exitCode, 1);
+      }
+
+      const gitProcessError = new Error('spawn git EACCES');
+      gitProcessError.code = 'EACCES';
+      const results = checkPostmergeDeploys({
+        repository: 'koala73/worldmonitor',
+        gh: ghFleet({}),
+        git: () => { throw gitProcessError; },
+        now: NOW,
+      });
+      const proofFailures = results.filter((entry) => entry.verdict === 'READ_UNPROVEN');
+      assert.ok(proofFailures.length > 0, 'a non-ENOENT git process failure must not become UNKNOWN');
+      assert.ok(proofFailures.every((entry) => entry.state === 'ALARM'));
       assert.equal(summarizeResults(results).exitCode, 1);
     });
 

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -1,9 +1,8 @@
 // #6376 — a failing post-merge deploy must produce an alarm that does not
 // depend on someone opening the Actions tab. The deploy gate cannot require
 // push-only workflows, so the alarm is a scheduled monitor reading each
-// workflow's run history on main. Like check-railway-reconcile-age.mjs, every
-// case where the record is missing or unreadable resolves AWAY from healthy —
-// an unmatched case meaning HEALTHY is the exact shape of the defect.
+// workflow's run history on main. GitHub transport unreadability is a
+// warning, not a healthy pass; git/4xx/ENOENT still fail the job.
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
@@ -15,11 +14,15 @@ import {
   createRetryingGh,
   diffTouchesPath,
   diffTouchesPaths,
+  formatResultMark,
+  githubWarningAnnotations,
+  isGithubRecordUnreadability,
   isRetryableGhFailure,
   judgeWorkflow,
   readNewestRun,
   readRunJobs,
   summarizeResults,
+  writeUnknownVisibility,
 } from '../scripts/check-postmerge-deploys.mjs';
 
 const NOW = Date.parse('2026-08-10T12:00:00Z');
@@ -581,6 +584,31 @@ describe('post-merge deploy monitor — read-path resilience (#6479)', () => {
     });
   });
 
+  describe('classifies which throws are GitHub unreadability', () => {
+    it('treats transport, timeout, and 5xx as unreadability', () => {
+      assert.equal(isGithubRecordUnreadability(new Error(TLS_STDERR)), true);
+      const timedOut = new Error('gh api repos/x/actions/runs timed out');
+      timedOut.timedOut = true;
+      assert.equal(isGithubRecordUnreadability(timedOut), true);
+      assert.equal(isGithubRecordUnreadability(new Error('gh: Server Error (HTTP 503)')), true);
+    });
+
+    it('treats git, missing gh, and HTTP 4xx as proof failures', () => {
+      assert.equal(isGithubRecordUnreadability(new Error('git diff --name-only abc origin/main failed (128): not a tree')), false);
+      assert.equal(isGithubRecordUnreadability(new Error('the deployed baseline SHA is missing')), false);
+      const missing = new Error('spawn gh ENOENT');
+      missing.code = 'ENOENT';
+      assert.equal(isGithubRecordUnreadability(missing), false);
+      for (const status of [400, 401, 403, 404, 410, 422]) {
+        assert.equal(
+          isGithubRecordUnreadability(new Error(`gh: Not Found (HTTP ${status})`)),
+          false,
+          `HTTP ${status} is an answer`,
+        );
+      }
+    });
+  });
+
   describe('retries the read before giving up', () => {
     it('recovers from a transient failure without surfacing it', async () => {
       const calls = [];
@@ -719,6 +747,98 @@ describe('post-merge deploy monitor — read-path resilience (#6479)', () => {
       assert.equal(summary.alarms.length, 0, 'an unread record is not a failed deploy');
       assert.equal(summary.unknowns.length, 1);
       assert.match(summary.lines.join('\n'), /could not be read|READ_FAILED/);
+    });
+
+    it('fails the monitor for git and GitHub 4xx throws, not only for deploy ALARMs', () => {
+      const gitThrow = checkPostmergeDeploys({
+        repository: 'koala73/worldmonitor',
+        gh: ghFleet({}),
+        git: (args) => {
+          throw new Error(`git ${args.join(' ')} failed (128): not a tree`);
+        },
+        now: NOW,
+      });
+      const proofFailed = gitThrow.filter((entry) => entry.verdict === 'READ_UNPROVEN');
+      assert.ok(proofFailed.length >= 1, 'path-filtered workflows must ALARM when git cannot prove the trigger tree');
+      for (const entry of proofFailed) {
+        assert.equal(entry.state, 'ALARM');
+        assert.match(entry.detail, /not a tree/);
+      }
+      const gitSummary = summarizeResults(gitThrow);
+      assert.equal(gitSummary.exitCode, 1);
+      assert.match(gitSummary.lines.join('\n'), /could not prove|READ_UNPROVEN/);
+
+      const gh = ghFleet({ unreadable: 'convex-deploy.yml' });
+      const answered = checkPostmergeDeploys({
+        repository: 'koala73/worldmonitor',
+        gh: (args) => {
+          const joined = args.join(' ');
+          if (joined.includes('workflows/convex-deploy.yml/runs')) {
+            throw new Error('gh: Not Found (HTTP 404)');
+          }
+          return gh(args);
+        },
+        git: () => '',
+        now: NOW,
+      });
+      const convex = answered.find((entry) => entry.workflow === 'convex-deploy.yml');
+      assert.equal(convex.state, 'ALARM');
+      assert.equal(convex.verdict, 'READ_UNPROVEN');
+      assert.equal(summarizeResults(answered).exitCode, 1);
+    });
+
+    it('fails the monitor when gh itself is missing', () => {
+      const missing = new Error('spawn gh ENOENT');
+      missing.code = 'ENOENT';
+      const results = checkPostmergeDeploys({
+        repository: 'koala73/worldmonitor',
+        gh: () => { throw missing; },
+        git: () => '',
+        now: NOW,
+      });
+      assert.equal(results.length, MONITORED_WORKFLOWS.length);
+      for (const entry of results) {
+        assert.equal(entry.state, 'ALARM');
+        assert.equal(entry.verdict, 'READ_UNPROVEN');
+      }
+      assert.equal(summarizeResults(results).exitCode, 1);
+    });
+
+    it('emits Actions warning annotations for UNKNOWN without failing the job', () => {
+      const results = [
+        { workflow: 'convex-deploy.yml', displayName: 'Convex Deploy', state: 'UNKNOWN', verdict: 'READ_FAILED', detail: TLS_STDERR },
+        { workflow: 'deploy-worker.yml', displayName: 'Deploy Worker', state: 'OK', verdict: 'DEPLOYED', detail: 'run 900 deployed' },
+      ];
+      assert.equal(formatResultMark('UNKNOWN'), 'warn');
+      assert.equal(formatResultMark('ALARM'), 'ERROR');
+      const annotations = githubWarningAnnotations(results);
+      assert.equal(annotations.length, 1);
+      assert.match(annotations[0], /^::warning title=Post-merge deploy record unread::Convex Deploy/);
+      const stderr = [];
+      const files = new Map();
+      writeUnknownVisibility({
+        results,
+        summary: summarizeResults(results),
+        stderr: (line) => { stderr.push(line); },
+        env: { GITHUB_STEP_SUMMARY: '/tmp/postmerge-step-summary' },
+        appendFile: (path, text) => { files.set(path, `${files.get(path) ?? ''}${text}`); },
+      });
+      assert.equal(stderr.length, 1);
+      assert.match(stderr[0], /^::warning title=Post-merge deploy record unread::/);
+      assert.match(files.get('/tmp/postmerge-step-summary'), /could not be read|READ_FAILED/);
+    });
+
+    it('reports a fleet of UNKNOWN records without failing the monitor', () => {
+      const summary = summarizeResults(MONITORED_WORKFLOWS.map((workflow) => ({
+        workflow: workflow.file,
+        displayName: workflow.displayName,
+        state: 'UNKNOWN',
+        verdict: 'READ_FAILED',
+        detail: TLS_STDERR,
+      })));
+      assert.equal(summary.exitCode, 0, 'a GitHub outage must not look like a failed deploy');
+      assert.equal(summary.unknowns.length, MONITORED_WORKFLOWS.length);
+      assert.equal(githubWarningAnnotations(summary.unknowns).length, MONITORED_WORKFLOWS.length);
     });
 
     // The reporting half of the incident: the notification must name the

--- a/tests/postmerge-deploy-monitor-workflow.test.mjs
+++ b/tests/postmerge-deploy-monitor-workflow.test.mjs
@@ -39,7 +39,8 @@ describe('post-merge deploy monitor workflow', () => {
   it('invokes the checker without a green-main gate or workflow_run trigger', () => {
     const runStep = workflow.jobs.monitor.steps.find((step) => step.name === 'Check post-merge deploys reached production');
     assert.ok(runStep, 'workflow must define the checker step');
-    assert.match(runStep.run, /git fetch --quiet origin main/);
+    const fetchLine = runStep.run.split(/\r?\n/).find((line) => line.includes('git fetch'));
+    assert.equal(fetchLine?.trim(), 'git fetch --quiet origin main', 'proof-ref refresh must fail the job when it cannot run');
     assert.match(runStep.run, /node scripts\/check-postmerge-deploys\.mjs/);
     assert.doesNotMatch(runStep.run, /gate/);
     // The seed-freshness green-main gate must NOT appear here: gating on main


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #6952. GitHub transport unreadability still does not fail the scheduled Post-merge Deploy Monitor. Local proof failures and GitHub answers do, and UNKNOWN results are visible on a green Actions job.

- **#2** git throws, a missing `gh` binary, and HTTP 4xx become `ALARM`/`READ_UNPROVEN` and exit 1. TLS/DNS/timeout/5xx after retries stay `UNKNOWN`/`READ_FAILED` and exit 0.
- **#3** UNKNOWN emits `::warning title=Post-merge deploy record unread::` and writes the monitor summary to `$GITHUB_STEP_SUMMARY`.
- **#1** keeps the #6952 product choice (do not page a GitHub outage as a failed deploy). The silent-pass is addressed by the Actions warning channel, matching the npm-audit outage precedent.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Post-merge Deploy Monitor (`scripts/check-postmerge-deploys.mjs`)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key

N/A — this PR does not publish or change documentation claims.

Verified locally: 43 focused monitor and workflow contract tests (pass), architectural boundary lint.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cc25503-e9b5-4eaa-8ba1-e9361f0fa66f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cc25503-e9b5-4eaa-8ba1-e9361f0fa66f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

