### PR TITLE
fix(bundle-runner): a partial publish must not advance the due-ness clock (#6960)

### DIFF
--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -34,7 +34,11 @@
 import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { GRACEFUL_FETCH_FAILURE_EXIT_CODE, loadEnvFile } from './_seed-utils.mjs';
+import {
+  BUNDLE_COMPLETION_META_KEY_ENV,
+  GRACEFUL_FETCH_FAILURE_EXIT_CODE,
+  loadEnvFile,
+} from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -134,13 +138,10 @@ async function writeBundleHeartbeat(label) {
  * the legacy `seed-meta:<key>` read.
  *
  * `completionMetaKey` applies the same rule to the canonical clock (#6960).
- * runSeed publishes the canonical key BEFORE its extra-key loop and writes the
- * canonical seed-meta AFTER it, so a CONTRACT VIOLATION exit inside that loop
- * leaves an advanced canonical `fetchedAt` with no seed-meta write. Since the
- * canonical envelope is the due-ness clock, the failed run would otherwise buy
- * itself a full interval of silence. Declaring the canonical seed-meta as the
- * completion attestation closes that: it is written last, so an older one
- * belongs to a prior run.
+ * The bundle passes a dedicated marker key to runSeed, which writes it only
+ * after the canonical envelope, every extra key, post-publish hooks, and
+ * freshness bookkeeping finish. Its fetchedAt must equal the canonical
+ * envelope timestamp, binding the proof to one exact run.
  *
  * Only sections that declare it are affected. Most canonical-clock members
  * publish no seed-meta at all, and requiring an attestation from them would
@@ -173,12 +174,11 @@ export async function readSectionFreshness(section, readKey = readRedisKey) {
       if (!section.completionMetaKey) return { fetchedAt: _seed.fetchedAt };
       const completionRaw = await readKey(section.completionMetaKey);
       const completion = unwrapEnvelope(completionRaw).data;
-      // Absent is due, not fresh: the completion key outlives the canonical key
-      // by construction (writeFreshnessMetadata floors its TTL at max(7d,
-      // ttlSeconds) >= the canonical ttlSeconds), so it can only be missing
-      // because the run never reached the write.
+      // Absent is due, not fresh: runSeed writes this marker with
+      // max(7d, ttlSeconds), so it cannot expire before the canonical key after
+      // a completed run. Missing means the run never reached the final write.
       if (!Number.isFinite(completion?.fetchedAt)) return null;
-      if (completion.fetchedAt < _seed.fetchedAt) return null;
+      if (completion.fetchedAt !== _seed.fetchedAt) return null;
       return { fetchedAt: _seed.fetchedAt };
     }
     // Version migrations can opt out of the legacy seed-meta fallback. A
@@ -281,7 +281,7 @@ function streamLines(stream, onLine) {
   stream.on('error', (err) => onLine(`<stdio error: ${err.message}>`));
 }
 
-function spawnSeed(scriptPath, { timeoutMs, label, bundleStartedAtMs }) {
+function spawnSeed(scriptPath, { timeoutMs, label, bundleStartedAtMs, completionMetaKey }) {
   return new Promise((resolve) => {
     const t0 = Date.now();
     // Capture the child's structured `seed_complete` event if emitted, so
@@ -300,6 +300,7 @@ function spawnSeed(scriptPath, { timeoutMs, label, bundleStartedAtMs }) {
       env: {
         ...process.env,
         BUNDLE_RUN_STARTED_AT_MS: String(bundleStartedAtMs ?? Date.now()),
+        [BUNDLE_COMPLETION_META_KEY_ENV]: completionMetaKey || '',
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -375,7 +376,6 @@ function spawnSeed(scriptPath, { timeoutMs, label, bundleStartedAtMs }) {
  *   script: string,
  *   seedMetaKey?: string,    // legacy (pre-contract); reads `seed-meta:<key>`
  *   freshnessMetaKey?: string, // authoritative explicit seed-meta key
- *   completionMetaKey?: string, // optional completed-run key paired with freshnessMetaKey
  *   canonicalKey?: string,   // PR 2+: reads envelope from the canonical data key
  *   completionMetaKey?: string, // full key written LAST by the run; must not
  *                               // predate the clock it attests (#6960)
@@ -404,6 +404,19 @@ export function disabledMembersFromEnv(label, env = process.env) {
 }
 
 export async function runBundle(label, sections, opts = {}) {
+  for (const section of sections) {
+    if (
+      section.canonicalKey
+      && !section.freshnessMetaKey
+      && section.completionMetaKey
+      && !section.completionMetaKey.startsWith('seed-completion:')
+    ) {
+      throw new Error(
+        `[Bundle:${label}] section '${section.label}' canonical completionMetaKey must use `
+        + `the dedicated seed-completion: namespace, got '${section.completionMetaKey}'`,
+      );
+    }
+  }
   const missingEnvBySection = new Map();
   for (const section of sections) {
     if (section.requiredEnv == null) continue;
@@ -620,7 +633,12 @@ export async function runBundle(label, sections, opts = {}) {
       continue;
     }
 
-    const result = await spawnSeed(scriptPath, { timeoutMs: timeout, label: section.label, bundleStartedAtMs: t0 });
+    const result = await spawnSeed(scriptPath, {
+      timeoutMs: timeout,
+      label: section.label,
+      bundleStartedAtMs: t0,
+      completionMetaKey: section.freshnessMetaKey ? '' : section.completionMetaKey,
+    });
     if (result.ok) {
       console.log(`  [${section.label}] Done (${result.elapsed}s)`);
       // Bundle-level per-section summary — emitted from parent stdout so

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -132,6 +132,19 @@ async function writeBundleHeartbeat(label) {
  * prior run and cannot attest a newer pre-publication heartbeat. Otherwise
  * prefer envelope-form data when `canonicalKey` is declared, then fall back to
  * the legacy `seed-meta:<key>` read.
+ *
+ * `completionMetaKey` applies the same rule to the canonical clock (#6960).
+ * runSeed publishes the canonical key BEFORE its extra-key loop and writes the
+ * canonical seed-meta AFTER it, so a CONTRACT VIOLATION exit inside that loop
+ * leaves an advanced canonical `fetchedAt` with no seed-meta write. Since the
+ * canonical envelope is the due-ness clock, the failed run would otherwise buy
+ * itself a full interval of silence. Declaring the canonical seed-meta as the
+ * completion attestation closes that: it is written last, so an older one
+ * belongs to a prior run.
+ *
+ * Only sections that declare it are affected. Most canonical-clock members
+ * publish no seed-meta at all, and requiring an attestation from them would
+ * mark them due on every tick — the #6806 failure this must not reintroduce.
  */
 export async function readSectionFreshness(section, readKey = readRedisKey) {
   if (section.freshnessMetaKey) {
@@ -156,7 +169,18 @@ export async function readSectionFreshness(section, readKey = readRedisKey) {
   if (section.canonicalKey) {
     const raw = await readKey(section.canonicalKey);
     const { _seed } = unwrapEnvelope(raw);
-    if (_seed?.fetchedAt) return { fetchedAt: _seed.fetchedAt };
+    if (_seed?.fetchedAt) {
+      if (!section.completionMetaKey) return { fetchedAt: _seed.fetchedAt };
+      const completionRaw = await readKey(section.completionMetaKey);
+      const completion = unwrapEnvelope(completionRaw).data;
+      // Absent is due, not fresh: the completion key outlives the canonical key
+      // by construction (writeFreshnessMetadata floors its TTL at max(7d,
+      // ttlSeconds) >= the canonical ttlSeconds), so it can only be missing
+      // because the run never reached the write.
+      if (!Number.isFinite(completion?.fetchedAt)) return null;
+      if (completion.fetchedAt < _seed.fetchedAt) return null;
+      return { fetchedAt: _seed.fetchedAt };
+    }
     // Version migrations can opt out of the legacy seed-meta fallback. A
     // fresh meta entry for the old version must never suppress the first
     // publish of a newly required canonical envelope.
@@ -353,6 +377,8 @@ function spawnSeed(scriptPath, { timeoutMs, label, bundleStartedAtMs }) {
  *   freshnessMetaKey?: string, // authoritative explicit seed-meta key
  *   completionMetaKey?: string, // optional completed-run key paired with freshnessMetaKey
  *   canonicalKey?: string,   // PR 2+: reads envelope from the canonical data key
+ *   completionMetaKey?: string, // full key written LAST by the run; must not
+ *                               // predate the clock it attests (#6960)
  *   requireCanonical?: boolean, // do not fall back to legacy meta when canonical is absent
  *   intervalMs: number,
  *   timeoutMs?: number,

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1968,6 +1968,10 @@ export function raceFetchDeadline(promise, ms, label) {
   return Promise.race([promise, guard]).finally(() => clearTimeout(timer));
 }
 
+// Set by _bundle-runner for canonical-clock members that need proof that every
+// publish side effect completed. Standalone seed runs leave it unset.
+export const BUNDLE_COMPLETION_META_KEY_ENV = 'WM_BUNDLE_COMPLETION_META_KEY';
+
 export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}) {
   const {
     validateFn,
@@ -1998,6 +2002,32 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     fetchPhaseTimeoutMs,   // hard ceiling on the fetch phase; defaults to lockTtlMs + margin (#4786)
   } = opts;
   const contractMode = typeof declareRecords === 'function';
+  if (extraKeys && !Array.isArray(extraKeys)) {
+    console.error(`  CONTRACT VIOLATION: ${domain}:${resource} extraKeys must be an array`);
+    process.exit(1);
+  }
+  if (afterPublish && typeof afterPublish !== 'function') {
+    console.error(`  CONTRACT VIOLATION: ${domain}:${resource} afterPublish must be a function`);
+    process.exit(1);
+  }
+  if (afterFreshness && typeof afterFreshness !== 'function') {
+    console.error(`  CONTRACT VIOLATION: ${domain}:${resource} afterFreshness must be a function`);
+    process.exit(1);
+  }
+  const bundleCompletionMetaKey = String(process.env[BUNDLE_COMPLETION_META_KEY_ENV] ?? '').trim();
+  if (bundleCompletionMetaKey) {
+    if (!contractMode) {
+      console.error(`  CONTRACT VIOLATION: ${domain}:${resource} bundle completion attestation requires contract mode`);
+      process.exit(1);
+    }
+    if (!bundleCompletionMetaKey.startsWith('seed-completion:')) {
+      console.error(
+        `  CONTRACT VIOLATION: ${domain}:${resource} bundle completion key must use the dedicated `
+        + `seed-completion: namespace, got ${bundleCompletionMetaKey}`,
+      );
+      process.exit(1);
+    }
+  }
   if (contractMode) {
     // Soft-warn (PR 2) on other mandatory contract fields; PR 3 hard-aborts.
     const missing = [];
@@ -2577,6 +2607,28 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
         runId,
         freshnessMeta: meta,
       });
+    }
+
+    // This is the final required Redis write for an attested bundle member.
+    // It deliberately does not run on fetch failure, contract retry, or
+    // validation-skip paths. Bind it to the canonical envelope timestamp so a
+    // marker from any other run cannot attest this publish.
+    if (bundleCompletionMetaKey) {
+      if (meta == null) {
+        throw new Error(`${domain}:${resource} freshness metadata write failed before completion attestation`);
+      }
+      if (!Number.isFinite(envelopeMeta?.fetchedAt)) {
+        throw new Error(`${domain}:${resource} canonical envelope timestamp missing before completion attestation`);
+      }
+      await writeExtraKey(
+        bundleCompletionMetaKey,
+        {
+          fetchedAt: envelopeMeta.fetchedAt,
+          completedAt: Date.now(),
+          runId,
+        },
+        Math.max(7 * 24 * 60 * 60, ttlSeconds || 0),
+      );
     }
 
     const durationMs = Date.now() - startMs;

--- a/scripts/seed-bundle-canada.mjs
+++ b/scripts/seed-bundle-canada.mjs
@@ -54,7 +54,7 @@ const CANADA_SECTIONS = [
   { label: 'BC-Open511', script: 'seed-open511.mjs', seedMetaKey: 'seed-meta:infra:bc-open511', canonicalKey: 'infra:bc-open511:v1', intervalMs: 30 * MIN, timeoutMs: 120_000 },
   // Emergency alerts stay at 15 minutes: the payload is tiny and the whole point
   // of the layer is timeliness.
-  { label: 'Alberta-Emergency-Alert', script: 'seed-alberta-emergency-alert.mjs', seedMetaKey: 'seed-meta:alerts:alberta-aea', canonicalKey: 'alerts:canada:alberta-aea:v1', intervalMs: 15 * MIN, timeoutMs: 60_000 },
+  { label: 'Alberta-Emergency-Alert', script: 'seed-alberta-emergency-alert.mjs', seedMetaKey: 'seed-meta:alerts:alberta-aea', canonicalKey: 'alerts:canada:alberta-aea:v1', completionMetaKey: 'seed-meta:alerts:alberta-aea', intervalMs: 15 * MIN, timeoutMs: 60_000 },
   // OGL-BC GeoJSON evacuation Alert/Order polygons. The seeder writes a
   // province snapshot, then rebuilds the same canadaAlerts union as Alberta.
   { label: 'BC-Emergency-Info', script: 'seed-bc-emergency-info.mjs', seedMetaKey: 'seed-meta:alerts:bc-emergency-info', canonicalKey: 'alerts:canada:bc-evacuation:v1', intervalMs: 15 * MIN, timeoutMs: 60_000, dependsOn: ['Alberta-Emergency-Alert'] },

--- a/scripts/seed-bundle-canada.mjs
+++ b/scripts/seed-bundle-canada.mjs
@@ -45,7 +45,7 @@ const CANADA_SECTIONS = [
   // plus a possible 60s wait on the per-host 10-calls/60s token bucket. 240s
   // covers that with margin — if the limiter sleeps past the timeout the section
   // is SIGTERM'd, which is a HARD failure rather than runSeed's graceful path.
-  { label: 'Provincial-511', script: 'seed-provincial-511.mjs', seedMetaKey: 'seed-meta:infra:ontario-511', canonicalKey: 'infra:ontario-511:v1', intervalMs: 15 * MIN, timeoutMs: 240_000 },
+  { label: 'Provincial-511', script: 'seed-provincial-511.mjs', seedMetaKey: 'seed-meta:infra:ontario-511', canonicalKey: 'infra:ontario-511:v1', completionMetaKey: 'seed-completion:infra:ontario-511', intervalMs: 15 * MIN, timeoutMs: 240_000 },
   // 3.62MB body, not strictly valid JSON, sanitized then parsed. Road
   // restrictions are construction permits, not live incidents.
   { label: 'Toronto-Roads', script: 'seed-toronto-road-restrictions.mjs', seedMetaKey: 'seed-meta:infra:toronto-roads', canonicalKey: 'infra:toronto-roads:v1', intervalMs: 2 * HOUR, timeoutMs: 180_000 },
@@ -54,11 +54,11 @@ const CANADA_SECTIONS = [
   { label: 'BC-Open511', script: 'seed-open511.mjs', seedMetaKey: 'seed-meta:infra:bc-open511', canonicalKey: 'infra:bc-open511:v1', intervalMs: 30 * MIN, timeoutMs: 120_000 },
   // Emergency alerts stay at 15 minutes: the payload is tiny and the whole point
   // of the layer is timeliness.
-  { label: 'Alberta-Emergency-Alert', script: 'seed-alberta-emergency-alert.mjs', seedMetaKey: 'seed-meta:alerts:alberta-aea', canonicalKey: 'alerts:canada:alberta-aea:v1', completionMetaKey: 'seed-meta:alerts:alberta-aea', intervalMs: 15 * MIN, timeoutMs: 60_000 },
+  { label: 'Alberta-Emergency-Alert', script: 'seed-alberta-emergency-alert.mjs', seedMetaKey: 'seed-meta:alerts:alberta-aea', canonicalKey: 'alerts:canada:alberta-aea:v1', completionMetaKey: 'seed-completion:alerts:alberta-aea', intervalMs: 15 * MIN, timeoutMs: 60_000 },
   // OGL-BC GeoJSON evacuation Alert/Order polygons. The seeder writes a
   // province snapshot, then rebuilds the same canadaAlerts union as Alberta.
-  { label: 'BC-Emergency-Info', script: 'seed-bc-emergency-info.mjs', seedMetaKey: 'seed-meta:alerts:bc-emergency-info', canonicalKey: 'alerts:canada:bc-evacuation:v1', intervalMs: 15 * MIN, timeoutMs: 60_000, dependsOn: ['Alberta-Emergency-Alert'] },
-  { label: 'SaskAlert', script: 'seed-saskalert.mjs', seedMetaKey: 'seed-meta:alerts:saskalert', canonicalKey: 'alerts:canada:saskalert:v1', intervalMs: 15 * MIN, timeoutMs: 60_000, dependsOn: ['BC-Emergency-Info'] },
+  { label: 'BC-Emergency-Info', script: 'seed-bc-emergency-info.mjs', seedMetaKey: 'seed-meta:alerts:bc-emergency-info', canonicalKey: 'alerts:canada:bc-evacuation:v1', completionMetaKey: 'seed-completion:alerts:bc-emergency-info', intervalMs: 15 * MIN, timeoutMs: 60_000, dependsOn: ['Alberta-Emergency-Alert'] },
+  { label: 'SaskAlert', script: 'seed-saskalert.mjs', seedMetaKey: 'seed-meta:alerts:saskalert', canonicalKey: 'alerts:canada:saskalert:v1', completionMetaKey: 'seed-completion:alerts:saskalert', intervalMs: 15 * MIN, timeoutMs: 60_000, dependsOn: ['BC-Emergency-Info'] },
   // Unofficial mobile JSON. 404 / shape-break degrades to sourceState
   // 'unavailable' and keeps last-good; it never raises SEED_ERROR.
   { label: 'VIA-Rail-Live', script: 'seed-viarail-live.mjs', seedMetaKey: 'seed-meta:transit:viarail-live', canonicalKey: 'transit:viarail:live', intervalMs: 15 * MIN, timeoutMs: 60_000 },

--- a/scripts/seed-bundle-climate.mjs
+++ b/scripts/seed-bundle-climate.mjs
@@ -2,7 +2,7 @@
 import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 
 await runBundle('climate', [
-  { label: 'Natural-Events', script: 'seed-natural-events.mjs', seedMetaKey: 'natural:events', canonicalKey: 'natural:events:v1', completionMetaKey: 'seed-meta:natural:events', intervalMs: 3 * HOUR, timeoutMs: 180_000 },
+  { label: 'Natural-Events', script: 'seed-natural-events.mjs', seedMetaKey: 'natural:events', canonicalKey: 'natural:events:v1', completionMetaKey: 'seed-completion:natural:events', intervalMs: 3 * HOUR, timeoutMs: 180_000 },
   { label: 'Zone-Normals', script: 'seed-climate-zone-normals.mjs', seedMetaKey: 'climate:zone-normals', canonicalKey: 'climate:zone-normals:v1', intervalMs: 30 * DAY, timeoutMs: 600_000 },
   { label: 'Anomalies', script: 'seed-climate-anomalies.mjs', seedMetaKey: 'climate:anomalies', canonicalKey: 'climate:anomalies:v2', intervalMs: 3 * HOUR, timeoutMs: 300_000 },
   { label: 'Disasters', script: 'seed-climate-disasters.mjs', seedMetaKey: 'climate:disasters', canonicalKey: 'climate:disasters:v1', intervalMs: 6 * HOUR, timeoutMs: 180_000 },

--- a/scripts/seed-bundle-climate.mjs
+++ b/scripts/seed-bundle-climate.mjs
@@ -2,7 +2,7 @@
 import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 
 await runBundle('climate', [
-  { label: 'Natural-Events', script: 'seed-natural-events.mjs', seedMetaKey: 'natural:events', canonicalKey: 'natural:events:v1', intervalMs: 3 * HOUR, timeoutMs: 180_000 },
+  { label: 'Natural-Events', script: 'seed-natural-events.mjs', seedMetaKey: 'natural:events', canonicalKey: 'natural:events:v1', completionMetaKey: 'seed-meta:natural:events', intervalMs: 3 * HOUR, timeoutMs: 180_000 },
   { label: 'Zone-Normals', script: 'seed-climate-zone-normals.mjs', seedMetaKey: 'climate:zone-normals', canonicalKey: 'climate:zone-normals:v1', intervalMs: 30 * DAY, timeoutMs: 600_000 },
   { label: 'Anomalies', script: 'seed-climate-anomalies.mjs', seedMetaKey: 'climate:anomalies', canonicalKey: 'climate:anomalies:v2', intervalMs: 3 * HOUR, timeoutMs: 300_000 },
   { label: 'Disasters', script: 'seed-climate-disasters.mjs', seedMetaKey: 'climate:disasters', canonicalKey: 'climate:disasters:v1', intervalMs: 6 * HOUR, timeoutMs: 180_000 },

--- a/scripts/seed-bundle-derived-signals.mjs
+++ b/scripts/seed-bundle-derived-signals.mjs
@@ -3,8 +3,8 @@ import { runBundle, MIN, HOUR } from './_bundle-runner.mjs';
 import { CHINA_DECISION_SIGNALS_KEY } from './seed-china-decision-signals.mjs';
 
 await runBundle('derived-signals', [
-  { label: 'Correlation', script: 'seed-correlation.mjs', seedMetaKey: 'correlation:cards', canonicalKey: 'correlation:cards-bootstrap:v1', completionMetaKey: 'seed-meta:correlation:cards', intervalMs: 5 * MIN, timeoutMs: 60_000 },
-  { label: 'Cross-Source-Signals', script: 'seed-cross-source-signals.mjs', seedMetaKey: 'intelligence:cross-source-signals', canonicalKey: 'intelligence:cross-source-signals:v1', intervalMs: 15 * MIN, timeoutMs: 120_000 },
+  { label: 'Correlation', script: 'seed-correlation.mjs', seedMetaKey: 'correlation:cards', canonicalKey: 'correlation:cards-bootstrap:v1', completionMetaKey: 'seed-completion:correlation:cards', intervalMs: 5 * MIN, timeoutMs: 60_000 },
+  { label: 'Cross-Source-Signals', script: 'seed-cross-source-signals.mjs', seedMetaKey: 'intelligence:cross-source-signals', canonicalKey: 'intelligence:cross-source-signals:v1', completionMetaKey: 'seed-completion:intelligence:cross-source-signals', intervalMs: 15 * MIN, timeoutMs: 120_000 },
   // Gate on the completion marker written only after the canonical archive,
   // compact bootstrap projection, and per-source health records all succeed.
   // A partial cohort therefore retries on the next bundle tick.
@@ -13,7 +13,7 @@ await runBundle('derived-signals', [
   // environment where only the shared exit is configured -- even though the
   // seeder would have run with no degradation.
   { label: 'Cross-Strait-Activity', script: 'seed-cross-strait-activity.mjs', seedMetaKey: 'military:cross-strait-activity:complete', intervalMs: 3 * HOUR, timeoutMs: 300_000, requiredEnv: [['JAPAN_MOD_PROXY_URL', 'PROXY_URL']] },
-  { label: 'China-Decision-Signals', script: 'seed-china-decision-signals.mjs', seedMetaKey: 'intelligence:china-decision-signals', canonicalKey: CHINA_DECISION_SIGNALS_KEY, intervalMs: 15 * MIN, timeoutMs: 90_000 },
+  { label: 'China-Decision-Signals', script: 'seed-china-decision-signals.mjs', seedMetaKey: 'intelligence:china-decision-signals', canonicalKey: CHINA_DECISION_SIGNALS_KEY, completionMetaKey: 'seed-completion:intelligence:china-decision-signals', intervalMs: 15 * MIN, timeoutMs: 90_000 },
   { label: 'Regional-Snapshots', script: 'seed-regional-snapshots.mjs', seedMetaKey: 'intelligence:regional-snapshots', intervalMs: 6 * HOUR, timeoutMs: 180_000 },
 ], {
   // Railway kills cron containers at 10 minutes. Defer sections whose full

--- a/scripts/seed-bundle-derived-signals.mjs
+++ b/scripts/seed-bundle-derived-signals.mjs
@@ -3,7 +3,7 @@ import { runBundle, MIN, HOUR } from './_bundle-runner.mjs';
 import { CHINA_DECISION_SIGNALS_KEY } from './seed-china-decision-signals.mjs';
 
 await runBundle('derived-signals', [
-  { label: 'Correlation', script: 'seed-correlation.mjs', seedMetaKey: 'correlation:cards', canonicalKey: 'correlation:cards-bootstrap:v1', intervalMs: 5 * MIN, timeoutMs: 60_000 },
+  { label: 'Correlation', script: 'seed-correlation.mjs', seedMetaKey: 'correlation:cards', canonicalKey: 'correlation:cards-bootstrap:v1', completionMetaKey: 'seed-meta:correlation:cards', intervalMs: 5 * MIN, timeoutMs: 60_000 },
   { label: 'Cross-Source-Signals', script: 'seed-cross-source-signals.mjs', seedMetaKey: 'intelligence:cross-source-signals', canonicalKey: 'intelligence:cross-source-signals:v1', intervalMs: 15 * MIN, timeoutMs: 120_000 },
   // Gate on the completion marker written only after the canonical archive,
   // compact bootstrap projection, and per-source health records all succeed.

--- a/scripts/seed-bundle-energy-sources.mjs
+++ b/scripts/seed-bundle-energy-sources.mjs
@@ -4,10 +4,10 @@ import { runBundle, DAY } from './_bundle-runner.mjs';
 await runBundle('energy-sources', [
   { label: 'GIE-Gas-Storage', script: 'seed-gie-gas-storage.mjs', seedMetaKey: 'economic:eu-gas-storage', canonicalKey: 'economic:eu-gas-storage:v1', intervalMs: DAY, timeoutMs: 180_000 },
   { label: 'Gas-Storage-Countries', script: 'seed-gas-storage-countries.mjs', seedMetaKey: 'energy:gas-storage-countries', intervalMs: DAY, timeoutMs: 600_000 },
-  { label: 'JODI-Gas', script: 'seed-jodi-gas.mjs', seedMetaKey: 'energy:jodi-gas', canonicalKey: 'energy:jodi-gas:v1:_countries', intervalMs: 35 * DAY, timeoutMs: 600_000 },
+  { label: 'JODI-Gas', script: 'seed-jodi-gas.mjs', seedMetaKey: 'energy:jodi-gas', canonicalKey: 'energy:jodi-gas:v1:_countries', completionMetaKey: 'seed-meta:energy:jodi-gas', intervalMs: 35 * DAY, timeoutMs: 600_000 },
   { label: 'JODI-Oil', script: 'seed-jodi-oil.mjs', seedMetaKey: 'energy:jodi-oil', canonicalKey: 'energy:jodi-oil:v1:_countries', intervalMs: 35 * DAY, timeoutMs: 600_000 },
   { label: 'OWID-Energy-Mix', script: 'seed-owid-energy-mix.mjs', seedMetaKey: 'economic:owid-energy-mix', intervalMs: 35 * DAY, timeoutMs: 600_000 },
-  { label: 'IEA-Oil-Stocks', script: 'seed-iea-oil-stocks.mjs', seedMetaKey: 'energy:iea-oil-stocks', canonicalKey: 'energy:iea-oil-stocks:v1:index', intervalMs: 40 * DAY, timeoutMs: 300_000 },
+  { label: 'IEA-Oil-Stocks', script: 'seed-iea-oil-stocks.mjs', seedMetaKey: 'energy:iea-oil-stocks', canonicalKey: 'energy:iea-oil-stocks:v1:index', completionMetaKey: 'seed-meta:energy:iea-oil-stocks', intervalMs: 40 * DAY, timeoutMs: 300_000 },
   { label: 'EIA-Petroleum', script: 'seed-eia-petroleum.mjs', seedMetaKey: 'energy:eia-petroleum', canonicalKey: 'energy:eia-petroleum:v1', intervalMs: DAY, timeoutMs: 90_000 },
   { label: 'IEA-Crisis-Policies', script: 'seed-energy-crisis-policies.mjs', seedMetaKey: 'energy:crisis-policies', canonicalKey: 'energy:crisis-policies:v1', intervalMs: 7 * DAY, timeoutMs: 120_000 },
   // SPR-Policies: static registry (data lives in scripts/data/spr-policies.json), TTL 400d

--- a/scripts/seed-bundle-energy-sources.mjs
+++ b/scripts/seed-bundle-energy-sources.mjs
@@ -4,10 +4,10 @@ import { runBundle, DAY } from './_bundle-runner.mjs';
 await runBundle('energy-sources', [
   { label: 'GIE-Gas-Storage', script: 'seed-gie-gas-storage.mjs', seedMetaKey: 'economic:eu-gas-storage', canonicalKey: 'economic:eu-gas-storage:v1', intervalMs: DAY, timeoutMs: 180_000 },
   { label: 'Gas-Storage-Countries', script: 'seed-gas-storage-countries.mjs', seedMetaKey: 'energy:gas-storage-countries', intervalMs: DAY, timeoutMs: 600_000 },
-  { label: 'JODI-Gas', script: 'seed-jodi-gas.mjs', seedMetaKey: 'energy:jodi-gas', canonicalKey: 'energy:jodi-gas:v1:_countries', completionMetaKey: 'seed-meta:energy:jodi-gas', intervalMs: 35 * DAY, timeoutMs: 600_000 },
+  { label: 'JODI-Gas', script: 'seed-jodi-gas.mjs', seedMetaKey: 'energy:jodi-gas', canonicalKey: 'energy:jodi-gas:v1:_countries', completionMetaKey: 'seed-completion:energy:jodi-gas', intervalMs: 35 * DAY, timeoutMs: 600_000 },
   { label: 'JODI-Oil', script: 'seed-jodi-oil.mjs', seedMetaKey: 'energy:jodi-oil', canonicalKey: 'energy:jodi-oil:v1:_countries', intervalMs: 35 * DAY, timeoutMs: 600_000 },
   { label: 'OWID-Energy-Mix', script: 'seed-owid-energy-mix.mjs', seedMetaKey: 'economic:owid-energy-mix', intervalMs: 35 * DAY, timeoutMs: 600_000 },
-  { label: 'IEA-Oil-Stocks', script: 'seed-iea-oil-stocks.mjs', seedMetaKey: 'energy:iea-oil-stocks', canonicalKey: 'energy:iea-oil-stocks:v1:index', completionMetaKey: 'seed-meta:energy:iea-oil-stocks', intervalMs: 40 * DAY, timeoutMs: 300_000 },
+  { label: 'IEA-Oil-Stocks', script: 'seed-iea-oil-stocks.mjs', seedMetaKey: 'energy:iea-oil-stocks', canonicalKey: 'energy:iea-oil-stocks:v1:index', completionMetaKey: 'seed-completion:energy:iea-oil-stocks', intervalMs: 40 * DAY, timeoutMs: 300_000 },
   { label: 'EIA-Petroleum', script: 'seed-eia-petroleum.mjs', seedMetaKey: 'energy:eia-petroleum', canonicalKey: 'energy:eia-petroleum:v1', intervalMs: DAY, timeoutMs: 90_000 },
   { label: 'IEA-Crisis-Policies', script: 'seed-energy-crisis-policies.mjs', seedMetaKey: 'energy:crisis-policies', canonicalKey: 'energy:crisis-policies:v1', intervalMs: 7 * DAY, timeoutMs: 120_000 },
   // SPR-Policies: static registry (data lives in scripts/data/spr-policies.json), TTL 400d

--- a/scripts/seed-bundle-health.mjs
+++ b/scripts/seed-bundle-health.mjs
@@ -2,9 +2,9 @@
 import { runBundle, HOUR, DAY } from './_bundle-runner.mjs';
 
 await runBundle('health', [
-  { label: 'China-Coverage', script: 'seed-china-coverage-health.mjs', seedMetaKey: 'health:china-coverage', canonicalKey: 'health:china-coverage:v1', intervalMs: HOUR, timeoutMs: 120_000 },
+  { label: 'China-Coverage', script: 'seed-china-coverage-health.mjs', seedMetaKey: 'health:china-coverage', canonicalKey: 'health:china-coverage:v1', completionMetaKey: 'seed-completion:health:china-coverage', intervalMs: HOUR, timeoutMs: 120_000 },
   { label: 'Air-Quality', script: 'seed-health-air-quality.mjs', seedMetaKey: 'health:air-quality', intervalMs: HOUR, timeoutMs: 600_000 },
   { label: 'Disease-Outbreaks', script: 'seed-disease-outbreaks.mjs', seedMetaKey: 'health:disease-outbreaks', canonicalKey: 'health:disease-outbreaks:v1', intervalMs: DAY, timeoutMs: 300_000 },
-  { label: 'VPD-Tracker', script: 'seed-vpd-tracker.mjs', seedMetaKey: 'health:vpd-tracker', canonicalKey: 'health:vpd-tracker:realtime:v1', completionMetaKey: 'seed-meta:health:vpd-tracker', intervalMs: DAY, timeoutMs: 300_000 },
+  { label: 'VPD-Tracker', script: 'seed-vpd-tracker.mjs', seedMetaKey: 'health:vpd-tracker', canonicalKey: 'health:vpd-tracker:realtime:v1', completionMetaKey: 'seed-completion:health:vpd-tracker', intervalMs: DAY, timeoutMs: 300_000 },
   { label: 'Displacement', script: 'seed-displacement-summary.mjs', seedMetaKey: 'displacement:summary', intervalMs: DAY, timeoutMs: 300_000 },
 ]);

--- a/scripts/seed-bundle-health.mjs
+++ b/scripts/seed-bundle-health.mjs
@@ -5,6 +5,6 @@ await runBundle('health', [
   { label: 'China-Coverage', script: 'seed-china-coverage-health.mjs', seedMetaKey: 'health:china-coverage', canonicalKey: 'health:china-coverage:v1', intervalMs: HOUR, timeoutMs: 120_000 },
   { label: 'Air-Quality', script: 'seed-health-air-quality.mjs', seedMetaKey: 'health:air-quality', intervalMs: HOUR, timeoutMs: 600_000 },
   { label: 'Disease-Outbreaks', script: 'seed-disease-outbreaks.mjs', seedMetaKey: 'health:disease-outbreaks', canonicalKey: 'health:disease-outbreaks:v1', intervalMs: DAY, timeoutMs: 300_000 },
-  { label: 'VPD-Tracker', script: 'seed-vpd-tracker.mjs', seedMetaKey: 'health:vpd-tracker', canonicalKey: 'health:vpd-tracker:realtime:v1', intervalMs: DAY, timeoutMs: 300_000 },
+  { label: 'VPD-Tracker', script: 'seed-vpd-tracker.mjs', seedMetaKey: 'health:vpd-tracker', canonicalKey: 'health:vpd-tracker:realtime:v1', completionMetaKey: 'seed-meta:health:vpd-tracker', intervalMs: DAY, timeoutMs: 300_000 },
   { label: 'Displacement', script: 'seed-displacement-summary.mjs', seedMetaKey: 'displacement:summary', intervalMs: DAY, timeoutMs: 300_000 },
 ]);

--- a/scripts/seed-bundle-macro.mjs
+++ b/scripts/seed-bundle-macro.mjs
@@ -4,10 +4,10 @@ import { CHINA_MACRO_CACHE_KEY } from './_china-macro-contract.mjs';
 import { EDUCATION_SECTION_TIMEOUT_MS } from './seed-education-attainment.mjs';
 
 const EDUCATION_PRIORITY_UTC_DAY = 0;
-const EDUCATION_SECTION = { label: 'Education-Attainment', script: 'seed-education-attainment.mjs', seedMetaKey: 'resilience:education-attainment', canonicalKey: 'resilience:education-attainment:v1', intervalMs: 7 * DAY, timeoutMs: EDUCATION_SECTION_TIMEOUT_MS };
+const EDUCATION_SECTION = { label: 'Education-Attainment', script: 'seed-education-attainment.mjs', seedMetaKey: 'resilience:education-attainment', canonicalKey: 'resilience:education-attainment:v1', completionMetaKey: 'seed-completion:resilience:education-attainment', intervalMs: 7 * DAY, timeoutMs: EDUCATION_SECTION_TIMEOUT_MS };
 
 const MACRO_SECTIONS = [
-  { label: 'BIS-Data', script: 'seed-bis-data.mjs', seedMetaKey: 'economic:bis', canonicalKey: 'economic:bis:policy:v1', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
+  { label: 'BIS-Data', script: 'seed-bis-data.mjs', seedMetaKey: 'economic:bis', canonicalKey: 'economic:bis:policy:v1', completionMetaKey: 'seed-completion:economic:bis', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
   // Bank of Russia official RUB rates + key policy rate. Three sequential cbr.ru
   // calls (daily table, prior day for change1d, KeyRate SOAP history); the two
   // required ones use withRetry(fn, 1, 2000) = 2 attempts x 15s + 2s backoff, so
@@ -16,12 +16,12 @@ const MACRO_SECTIONS = [
   // ddos-guard — aborts through runSeed's graceful last-good path rather than
   // being SIGTERM'd here, which the runner counts as a hard section failure.
   // 300_000 matches the peer sections and leaves the publish phase headroom.
-  { label: 'CBR-Rates', script: 'seed-cbr-rates.mjs', seedMetaKey: 'economic:cbr-rates', canonicalKey: 'economic:cbr-rates:v1', intervalMs: DAY, timeoutMs: 300_000 },
+  { label: 'CBR-Rates', script: 'seed-cbr-rates.mjs', seedMetaKey: 'economic:cbr-rates', canonicalKey: 'economic:cbr-rates:v1', completionMetaKey: 'seed-completion:economic:cbr-rates', intervalMs: DAY, timeoutMs: 300_000 },
   // Bank of Canada Valet (CAD FX + overnight target + 2/5/10y yields) and
   // Statistics Canada WDS (same-day cube radar + CPI/LFS for the CA overlay).
   // Independent clocks: Valet is recent=1, WDS is the seeder UTC date path.
-  { label: 'BoC-Valet', script: 'seed-boc-valet.mjs', seedMetaKey: 'economic:boc-valet', canonicalKey: 'economic:boc-valet:v1', intervalMs: DAY, timeoutMs: 120_000 },
-  { label: 'StatCan-WDS', script: 'seed-statcan-wds.mjs', seedMetaKey: 'economic:statcan-wds', canonicalKey: 'economic:statcan-wds:v1', intervalMs: DAY, timeoutMs: 120_000 },
+  { label: 'BoC-Valet', script: 'seed-boc-valet.mjs', seedMetaKey: 'economic:boc-valet', canonicalKey: 'economic:boc-valet:v1', completionMetaKey: 'seed-completion:economic:boc-valet', intervalMs: DAY, timeoutMs: 120_000 },
+  { label: 'StatCan-WDS', script: 'seed-statcan-wds.mjs', seedMetaKey: 'economic:statcan-wds', canonicalKey: 'economic:statcan-wds:v1', completionMetaKey: 'seed-completion:economic:statcan-wds', intervalMs: DAY, timeoutMs: 120_000 },
   // Official-source requests are sequential and bounded per host. Blocked
   // PBoC/GACC candidates stay explicitly unavailable rather than using proxies.
   { label: 'China-Macro', script: 'seed-china-macro.mjs', seedMetaKey: 'economic:china-macro', freshnessMetaKey: 'seed-meta:economic:china-macro-transport', completionMetaKey: 'seed-meta:economic:china-macro-complete', canonicalKey: CHINA_MACRO_CACHE_KEY, requireCanonical: true, intervalMs: 36 * HOUR, timeoutMs: 240_000 },
@@ -30,12 +30,12 @@ const MACRO_SECTIONS = [
   // a 400ms same-host cadence. The section is independent from macro sources:
   // failures retain the last valid policy event set through runSeed.
   { label: 'China-Policy-Events', script: 'seed-china-policy-events.mjs', seedMetaKey: 'china:policy-events', canonicalKey: 'china:policy-events:v1', intervalMs: 6 * HOUR, timeoutMs: 220_000 },
-  { label: 'BIS-Extended', script: 'seed-bis-extended.mjs', seedMetaKey: 'economic:bis-extended', canonicalKey: 'economic:bis:dsr:v1', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
-  { label: 'BLS-Series', script: 'seed-bls-series.mjs', seedMetaKey: 'economic:bls-series', canonicalKey: 'bls:series:v1', intervalMs: DAY, timeoutMs: 120_000 },
+  { label: 'BIS-Extended', script: 'seed-bis-extended.mjs', seedMetaKey: 'economic:bis-extended', canonicalKey: 'economic:bis:dsr:v1', completionMetaKey: 'seed-completion:economic:bis-extended', intervalMs: 12 * HOUR, timeoutMs: 300_000 },
+  { label: 'BLS-Series', script: 'seed-bls-series.mjs', seedMetaKey: 'economic:bls-series', canonicalKey: 'bls:series:v1', completionMetaKey: 'seed-completion:economic:bls-series', intervalMs: DAY, timeoutMs: 120_000 },
   // SGE SHAU/SHAG daily PM benchmarks joined only to the already-seeded
   // commodity and FX snapshots. The seeder fails closed unless the deployment
   // has explicitly activated the documented redistribution/display license.
-  { label: 'Physical-Premiums', script: 'seed-physical-premiums.mjs', seedMetaKey: 'market:physical-premium', canonicalKey: 'market:physical-premium:v1', intervalMs: DAY, timeoutMs: 120_000 },
+  { label: 'Physical-Premiums', script: 'seed-physical-premiums.mjs', seedMetaKey: 'market:physical-premium', canonicalKey: 'market:physical-premium:v1', completionMetaKey: 'seed-completion:market:physical-premium', intervalMs: DAY, timeoutMs: 120_000 },
   { label: 'Eurostat', script: 'seed-eurostat-country-data.mjs', seedMetaKey: 'economic:eurostat-country-data', canonicalKey: 'economic:eurostat-country-data:v1', intervalMs: DAY, timeoutMs: 300_000 },
   { label: 'Eurostat-HousePrices', script: 'seed-eurostat-house-prices.mjs', seedMetaKey: 'economic:eurostat-house-prices', canonicalKey: 'economic:eurostat:house-prices:v1', intervalMs: 7 * DAY, timeoutMs: 300_000 },
   { label: 'Eurostat-GovDebtQ', script: 'seed-eurostat-gov-debt-q.mjs', seedMetaKey: 'economic:eurostat-gov-debt-q', canonicalKey: 'economic:eurostat:gov-debt-q:v1', intervalMs: 2 * DAY, timeoutMs: 300_000 },

--- a/scripts/seed-bundle-market-backup.mjs
+++ b/scripts/seed-bundle-market-backup.mjs
@@ -3,7 +3,7 @@ import { runBundle, MIN } from './_bundle-runner.mjs';
 
 await runBundle('market-backup', [
   { label: 'Crypto-Quotes', script: 'seed-crypto-quotes.mjs', seedMetaKey: 'market:crypto', canonicalKey: 'market:crypto:v1', intervalMs: 5 * MIN, timeoutMs: 120_000 },
-  { label: 'Hyperliquid-Flow', script: 'seed-hyperliquid-flow.mjs', seedMetaKey: 'market:hyperliquid-flow', canonicalKey: 'market:hyperliquid:flow:v1', intervalMs: 5 * MIN, timeoutMs: 60_000 },
+  { label: 'Hyperliquid-Flow', script: 'seed-hyperliquid-flow.mjs', seedMetaKey: 'market:hyperliquid-flow', canonicalKey: 'market:hyperliquid:flow:v1', completionMetaKey: 'seed-completion:market:hyperliquid-flow', intervalMs: 5 * MIN, timeoutMs: 60_000 },
   { label: 'Stablecoin-Markets', script: 'seed-stablecoin-markets.mjs', seedMetaKey: 'market:stablecoins', canonicalKey: 'market:stablecoins:v1', intervalMs: 10 * MIN, timeoutMs: 120_000 },
   { label: 'ETF-Flows', script: 'seed-etf-flows.mjs', seedMetaKey: 'market:etf-flows', canonicalKey: 'market:etf-flows:v1', intervalMs: 15 * MIN, timeoutMs: 120_000 },
   { label: 'Market-Correlation-Series', script: 'seed-market-correlation-series.mjs', seedMetaKey: 'market:correlation-series', canonicalKey: 'market:correlation-series:v1', intervalMs: 15 * MIN, timeoutMs: 210_000 },
@@ -15,7 +15,7 @@ await runBundle('market-backup', [
   // through the edge hop.
   { label: 'China-Stock-Connect', script: 'seed-china-stock-connect.mjs', seedMetaKey: 'market:china-stock-connect', canonicalKey: 'market:china:stock-connect:v1', intervalMs: 60 * MIN, timeoutMs: 200_000 },
   { label: 'Gulf-Quotes', script: 'seed-gulf-quotes.mjs', seedMetaKey: 'market:gulf-quotes', canonicalKey: 'market:gulf-quotes:v1', intervalMs: 10 * MIN, timeoutMs: 120_000 },
-  { label: 'Token-Panels', script: 'seed-token-panels.mjs', seedMetaKey: 'market:token-panels', canonicalKey: 'market:defi-tokens:v1', completionMetaKey: 'seed-meta:market:token-panels', intervalMs: 30 * MIN, timeoutMs: 120_000 },
+  { label: 'Token-Panels', script: 'seed-token-panels.mjs', seedMetaKey: 'market:token-panels', canonicalKey: 'market:defi-tokens:v1', completionMetaKey: 'seed-completion:market:token-panels', intervalMs: 30 * MIN, timeoutMs: 120_000 },
   // SPDR GLD publishes holdings once daily (~16:30 ET). 2h cadence = retries on Cloudflare blocks + catches late publish.
   { label: 'Gold-ETF-Flows', script: 'seed-gold-etf-flows.mjs', seedMetaKey: 'market:gold-etf-flows', canonicalKey: 'market:gold-etf-flows:v1', intervalMs: 120 * MIN, timeoutMs: 60_000 },
   // IMF IFS publishes monthly with ~2-3 month lag. Daily cadence is plenty.

--- a/scripts/seed-bundle-market-backup.mjs
+++ b/scripts/seed-bundle-market-backup.mjs
@@ -15,7 +15,7 @@ await runBundle('market-backup', [
   // through the edge hop.
   { label: 'China-Stock-Connect', script: 'seed-china-stock-connect.mjs', seedMetaKey: 'market:china-stock-connect', canonicalKey: 'market:china:stock-connect:v1', intervalMs: 60 * MIN, timeoutMs: 200_000 },
   { label: 'Gulf-Quotes', script: 'seed-gulf-quotes.mjs', seedMetaKey: 'market:gulf-quotes', canonicalKey: 'market:gulf-quotes:v1', intervalMs: 10 * MIN, timeoutMs: 120_000 },
-  { label: 'Token-Panels', script: 'seed-token-panels.mjs', seedMetaKey: 'market:token-panels', canonicalKey: 'market:defi-tokens:v1', intervalMs: 30 * MIN, timeoutMs: 120_000 },
+  { label: 'Token-Panels', script: 'seed-token-panels.mjs', seedMetaKey: 'market:token-panels', canonicalKey: 'market:defi-tokens:v1', completionMetaKey: 'seed-meta:market:token-panels', intervalMs: 30 * MIN, timeoutMs: 120_000 },
   // SPDR GLD publishes holdings once daily (~16:30 ET). 2h cadence = retries on Cloudflare blocks + catches late publish.
   { label: 'Gold-ETF-Flows', script: 'seed-gold-etf-flows.mjs', seedMetaKey: 'market:gold-etf-flows', canonicalKey: 'market:gold-etf-flows:v1', intervalMs: 120 * MIN, timeoutMs: 60_000 },
   // IMF IFS publishes monthly with ~2-3 month lag. Daily cadence is plenty.

--- a/scripts/seed-bundle-relay-backup.mjs
+++ b/scripts/seed-bundle-relay-backup.mjs
@@ -4,7 +4,7 @@ import { runBundle, MIN, HOUR, DAY } from './_bundle-runner.mjs';
 await runBundle('relay-backup', [
   { label: 'Climate-News', script: 'seed-climate-news.mjs', seedMetaKey: 'climate:news-intelligence', canonicalKey: 'climate:news-intelligence:v1', intervalMs: 30 * MIN, timeoutMs: 240_000 },
   { label: 'USA-Spending', script: 'seed-usa-spending.mjs', seedMetaKey: 'economic:spending', canonicalKey: 'economic:spending:v1', intervalMs: HOUR, timeoutMs: 120_000 },
-  { label: 'Global-Tenders', script: 'seed-global-tenders.mjs', seedMetaKey: 'economic:global-tenders', canonicalKey: 'economic:global-tenders:v1', intervalMs: HOUR, timeoutMs: 180_000 },
+  { label: 'Global-Tenders', script: 'seed-global-tenders.mjs', seedMetaKey: 'economic:global-tenders', canonicalKey: 'economic:global-tenders:v1', completionMetaKey: 'seed-completion:economic:global-tenders', intervalMs: HOUR, timeoutMs: 180_000 },
   { label: 'UCDP-Events', script: 'seed-ucdp-events.mjs', seedMetaKey: 'conflict:ucdp-events', intervalMs: 6 * HOUR, timeoutMs: 300_000 },
   { label: 'WB-Indicators', script: 'seed-wb-indicators.mjs', seedMetaKey: 'economic:worldbank-techreadiness:v1', intervalMs: DAY, timeoutMs: 300_000 },
 ]);

--- a/tests/bundle-completion-attestation.test.mjs
+++ b/tests/bundle-completion-attestation.test.mjs
@@ -1,0 +1,307 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { basename, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { readSectionFreshness } from '../scripts/_bundle-runner.mjs';
+import { listBundleFiles } from './helpers/bundle-section-parser.mjs';
+import {
+  extractAttestationBundleSections,
+  inspectRunSeedCalls,
+} from './helpers/seed-bundle-attestation-parser.mjs';
+
+const SCRIPTS_DIR = fileURLToPath(new URL('../scripts/', import.meta.url));
+const COMPLETION_KEY_PREFIX = 'seed-completion:';
+
+function virtualFiles(entries) {
+  const files = new Map(Object.entries(entries));
+  return (path) => {
+    if (!files.has(path)) throw new Error(`missing virtual file ${path}`);
+    return files.get(path);
+  };
+}
+
+test('a partial publish cannot advance the canonical due-ness clock (#6960)', async () => {
+  const canonicalPublishedAt = Date.now();
+  const previousCompletionAt = canonicalPublishedAt - 40 * 24 * 60 * 60 * 1000;
+  const freshness = await readSectionFreshness({
+    canonicalKey: 'energy:iea-oil-stocks:v1:index',
+    completionMetaKey: 'seed-completion:energy:iea-oil-stocks',
+  }, async (key) => {
+    if (key === 'energy:iea-oil-stocks:v1:index') {
+      return { _seed: { fetchedAt: canonicalPublishedAt }, data: {} };
+    }
+    if (key === 'seed-completion:energy:iea-oil-stocks') {
+      return { fetchedAt: previousCompletionAt };
+    }
+    return null;
+  });
+  assert.equal(freshness, null);
+});
+
+test('a validation skip cannot turn shared seed-meta into completion proof (#6960)', async () => {
+  const partialPublishAt = Date.now();
+  const freshness = await readSectionFreshness({
+    canonicalKey: 'energy:jodi-gas:v1:_countries',
+    seedMetaKey: 'energy:jodi-gas',
+    completionMetaKey: 'seed-completion:energy:jodi-gas',
+  }, async (key) => {
+    if (key === 'energy:jodi-gas:v1:_countries') {
+      return { _seed: { fetchedAt: partialPublishAt }, data: {} };
+    }
+    if (key === 'seed-meta:energy:jodi-gas') {
+      // A later validation-skip mirrors the partial canonical timestamp here.
+      return { fetchedAt: partialPublishAt, recordCount: 1 };
+    }
+    return null;
+  });
+  assert.equal(freshness, null, 'only the dedicated final marker can attest completion');
+});
+
+test('a completed run passes the canonical clock through unchanged (#6960)', async () => {
+  const canonicalPublishedAt = Date.now() - 60 * 60 * 1000;
+  const freshness = await readSectionFreshness({
+    canonicalKey: 'energy:iea-oil-stocks:v1:index',
+    completionMetaKey: 'seed-completion:energy:iea-oil-stocks',
+  }, async (key) => {
+    if (key === 'energy:iea-oil-stocks:v1:index') {
+      return { _seed: { fetchedAt: canonicalPublishedAt }, data: {} };
+    }
+    if (key === 'seed-completion:energy:iea-oil-stocks') {
+      return { fetchedAt: canonicalPublishedAt, completedAt: canonicalPublishedAt + 6_900 };
+    }
+    return null;
+  });
+  assert.deepEqual(freshness, { fetchedAt: canonicalPublishedAt });
+});
+
+test('a completion marker for a different canonical run does not attest freshness', async () => {
+  const canonicalPublishedAt = Date.now();
+  const freshness = await readSectionFreshness({
+    canonicalKey: 'test:canonical:v1',
+    completionMetaKey: 'seed-completion:test:canonical',
+  }, async (key) => (
+    key === 'test:canonical:v1'
+      ? { _seed: { fetchedAt: canonicalPublishedAt }, data: {} }
+      : { fetchedAt: canonicalPublishedAt + 1 }
+  ));
+  assert.equal(freshness, null);
+});
+
+test('a section without a completion key still reads the canonical clock alone (#6960)', async () => {
+  const reads = [];
+  const publishedAt = Date.now();
+  const freshness = await readSectionFreshness({
+    canonicalKey: 'infra:ontario-511:v1',
+    seedMetaKey: 'infra:ontario-511',
+  }, async (key) => {
+    reads.push(key);
+    if (key === 'infra:ontario-511:v1') return { _seed: { fetchedAt: publishedAt }, data: {} };
+    return null;
+  });
+  assert.deepEqual(freshness, { fetchedAt: publishedAt });
+  assert.deepEqual(reads, ['infra:ontario-511:v1']);
+});
+
+test('runSeed extraKeys discovery handles shorthand, named objects, and spreads', () => {
+  const readSource = virtualFiles({
+    '/virtual/seed.mjs': `
+      import { runSeed } from './_seed-utils.mjs';
+      const extraKeys = [];
+      const shared = { extraKeys };
+      const options = { ...shared, ttlSeconds: 60 };
+      runSeed('d', 'r', 'd:r:v1', fetcher, options);
+    `,
+  });
+  assert.deepEqual(inspectRunSeedCalls('/virtual/seed.mjs', readSource), [{
+    hasExtraKeys: true,
+    hasPostCanonicalWork: true,
+  }]);
+});
+
+test('runSeed extraKeys discovery resolves imported options', () => {
+  const readSource = virtualFiles({
+    '/virtual/seed.mjs': `
+      import { runSeed } from './_seed-utils.mjs';
+      import { seedOptions } from './options.mjs';
+      runSeed('d', 'r', 'd:r:v1', fetcher, seedOptions);
+    `,
+    '/virtual/options.mjs': `
+      const extraKeys = [];
+      export const seedOptions = { extraKeys };
+    `,
+  });
+  assert.deepEqual(inspectRunSeedCalls('/virtual/seed.mjs', readSource), [{
+    hasExtraKeys: true,
+    hasPostCanonicalWork: true,
+  }]);
+});
+
+test('runSeed discovery resolves named aliases and namespace imports', () => {
+  const readSource = virtualFiles({
+    '/virtual/aliased.mjs': `
+      import { runSeed as seed } from './_seed-utils.mjs';
+      seed('d', 'r', 'd:r:v1', fetcher, { afterPublish() {} });
+    `,
+    '/virtual/namespaced.mjs': `
+      import * as seedUtils from './_seed-utils.mjs';
+      seedUtils.runSeed('d', 'r', 'd:r:v1', fetcher, { afterFreshness: async () => {} });
+    `,
+  });
+  assert.equal(inspectRunSeedCalls('/virtual/aliased.mjs', readSource)[0].hasPostCanonicalWork, true);
+  assert.equal(inspectRunSeedCalls('/virtual/namespaced.mjs', readSource)[0].hasPostCanonicalWork, true);
+});
+
+test('runSeed extraKeys discovery fails closed on unresolved options', () => {
+  const readSource = virtualFiles({
+    '/virtual/seed.mjs': `
+      import { runSeed } from './_seed-utils.mjs';
+      runSeed('d', 'r', 'd:r:v1', fetcher, makeOptions());
+    `,
+  });
+  assert.throws(
+    () => inspectRunSeedCalls('/virtual/seed.mjs', readSource),
+    /runSeed options are not statically resolvable/,
+  );
+});
+
+test('runSeed discovery fails closed without an import binding', () => {
+  const readSource = virtualFiles({
+    '/virtual/seed.mjs': `runSeed('d', 'r', 'd:r:v1', fetcher, {});`,
+  });
+  assert.throws(
+    () => inspectRunSeedCalls('/virtual/seed.mjs', readSource),
+    /no statically identifiable runSeed import/,
+  );
+});
+
+test('runSeed discovery fails closed on malformed post-canonical options', () => {
+  const readSource = virtualFiles({
+    '/virtual/extra-keys.mjs': `
+      import { runSeed } from './_seed-utils.mjs';
+      runSeed('d', 'r', 'd:r:v1', fetcher, { extraKeys: {} });
+    `,
+    '/virtual/hook.mjs': `
+      import { runSeed } from './_seed-utils.mjs';
+      runSeed('d', 'r', 'd:r:v1', fetcher, { afterPublish: true });
+    `,
+  });
+  assert.throws(
+    () => inspectRunSeedCalls('/virtual/extra-keys.mjs', readSource),
+    /extraKeys must resolve to an array/,
+  );
+  assert.throws(
+    () => inspectRunSeedCalls('/virtual/hook.mjs', readSource),
+    /afterPublish must resolve to a function/,
+  );
+});
+
+test('bundle member discovery resolves imported manifests', () => {
+  const readSource = virtualFiles({
+    '/virtual/bundle.mjs': `
+      import { MEMBERS } from './members.mjs';
+      runBundle('test', MEMBERS);
+    `,
+    '/virtual/members.mjs': `
+      export const MEMBERS = [{
+        label: 'Imported',
+        script: 'seed-imported.mjs',
+        canonicalKey: 'test:imported:v1',
+        completionMetaKey: 'seed-completion:test:imported',
+        intervalMs: 60,
+      }];
+    `,
+  });
+  assert.deepEqual(extractAttestationBundleSections('/virtual/bundle.mjs', readSource), [{
+    label: 'Imported',
+    script: 'seed-imported.mjs',
+    hasCanonicalKey: true,
+    hasFreshnessMetaKey: false,
+    completionMetaKey: 'seed-completion:test:imported',
+  }]);
+});
+
+test('bundle member discovery follows runtime truthiness for freshness defaults', () => {
+  const readSource = virtualFiles({
+    '/virtual/bundle.mjs': `
+      const defaults = { freshnessMetaKey: undefined };
+      runBundle('test', [{
+        ...defaults,
+        label: 'Falsy Freshness',
+        script: 'seed-falsy.mjs',
+        canonicalKey: 'test:falsy:v1',
+        intervalMs: 60,
+      }]);
+    `,
+  });
+  assert.deepEqual(extractAttestationBundleSections('/virtual/bundle.mjs', readSource), [{
+    label: 'Falsy Freshness',
+    script: 'seed-falsy.mjs',
+    hasCanonicalKey: true,
+    hasFreshnessMetaKey: false,
+    completionMetaKey: null,
+  }]);
+});
+
+const COMPLETION_ATTESTATION_EXEMPT = new Map([
+  [
+    'seed-bundle-static-ref-heavy.mjs:Arms-Suppliers:seed-defense-industrial-suppliers.mjs',
+    'The #6893 chunked sweep stays due until its own terminal marker is written.',
+  ],
+]);
+
+function attestationIdentity(bundleName, section) {
+  return `${bundleName}:${section.label}:${section.script}`;
+}
+
+test('an exemption identity does not cover a same-label different seeder', () => {
+  const identity = attestationIdentity('seed-bundle-static-ref-heavy.mjs', {
+    label: 'Arms-Suppliers',
+    script: 'seed-unrelated.mjs',
+  });
+  assert.equal(COMPLETION_ATTESTATION_EXEMPT.has(identity), false);
+});
+
+test('every canonical-clock bundle member with post-canonical work has exact completion attestation (#6960)', () => {
+  for (const [identity, reason] of COMPLETION_ATTESTATION_EXEMPT) {
+    assert.ok(identity.split(':').length >= 3, `invalid exemption identity: ${identity}`);
+    assert.ok(reason.trim().length > 0, `${identity}: exemption needs a reason`);
+  }
+
+  const matchedExemptions = new Map(
+    [...COMPLETION_ATTESTATION_EXEMPT.keys()].map((identity) => [identity, 0]),
+  );
+  const offenders = [];
+  let inspected = 0;
+
+  for (const bundlePath of listBundleFiles(SCRIPTS_DIR)) {
+    const bundleName = basename(bundlePath);
+    const sections = extractAttestationBundleSections(bundlePath);
+    if (sections == null) continue;
+    assert.ok(sections.length > 0, `${bundleName}: no runtime members were resolved`);
+
+    for (const section of sections) {
+      if (!section.hasCanonicalKey || section.hasFreshnessMetaKey) continue;
+      const calls = inspectRunSeedCalls(join(SCRIPTS_DIR, section.script));
+      if (!calls.some((call) => call.hasPostCanonicalWork)) continue;
+      inspected++;
+
+      const identity = attestationIdentity(bundleName, section);
+      if (COMPLETION_ATTESTATION_EXEMPT.has(identity)) {
+        matchedExemptions.set(identity, matchedExemptions.get(identity) + 1);
+        continue;
+      }
+      if (!section.completionMetaKey?.startsWith(COMPLETION_KEY_PREFIX)) {
+        offenders.push(`${identity} -> ${section.completionMetaKey ?? 'missing'}`);
+      }
+    }
+  }
+
+  assert.ok(inspected > 0, 'the closed-world audit inspected no at-risk members');
+  assert.deepEqual(offenders, [], 'at-risk members need a dedicated completion marker');
+  assert.deepEqual(
+    [...matchedExemptions],
+    [...COMPLETION_ATTESTATION_EXEMPT.keys()].map((identity) => [identity, 1]),
+    'every exemption must match exactly one at-risk runtime member',
+  );
+});

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -8,19 +8,12 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, writeFileSync, unlinkSync, readFileSync, readdirSync } from 'node:fs';
+import { mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { GRACEFUL_FETCH_FAILURE_EXIT_CODE } from '../scripts/_seed-utils.mjs';
 import { DAY, readSectionFreshness, bundleHeartbeatKey, BUNDLE_HEARTBEAT_TTL_SECONDS } from '../scripts/_bundle-runner.mjs';
-import {
-  countSectionAnchors,
-  countSectionScriptKeys,
-  extractBundleSections,
-  listBundleFiles,
-  stripLineComments,
-} from './helpers/bundle-section-parser.mjs';
 import {
   SUPERSEDED_KEY_TTL_SECONDS,
   atomicSwitch,
@@ -153,163 +146,6 @@ test('a missing completion marker keeps an explicit-freshness section due', asyn
     return null;
   });
   assert.equal(freshness, null);
-});
-
-// #6960. runSeed publishes the canonical key BEFORE the extra-key loop and
-// writes the canonical seed-meta AFTER it, so the three CONTRACT VIOLATION exits
-// inside that loop leave a canonical envelope with an ADVANCED fetchedAt and no
-// seed-meta write at all. The canonical envelope is this section's due-ness
-// clock, so the failed run buys itself a full interval of silence — 40 days for
-// IEA-Oil-Stocks, which is how energy:oil-stocks-analysis:v1 was allowed to
-// expire unnoticed. seed-meta is written last, so it is the completion
-// attestation: an older one belongs to a prior run.
-test('a partial publish cannot advance the canonical due-ness clock (#6960)', async () => {
-  const canonicalPublishedAt = Date.now();
-  const previousCompletionAt = canonicalPublishedAt - 40 * 24 * 60 * 60 * 1000;
-  const freshness = await readSectionFreshness({
-    canonicalKey: 'energy:iea-oil-stocks:v1:index',
-    seedMetaKey: 'energy:iea-oil-stocks',
-    completionMetaKey: 'seed-meta:energy:iea-oil-stocks',
-  }, async (key) => {
-    if (key === 'energy:iea-oil-stocks:v1:index') {
-      return { _seed: { fetchedAt: canonicalPublishedAt }, data: {} };
-    }
-    if (key === 'seed-meta:energy:iea-oil-stocks') {
-      return { fetchedAt: previousCompletionAt };
-    }
-    return null;
-  });
-  assert.equal(freshness, null, 'a canonical clock newer than its completion must read as due');
-});
-
-test('a completion marker lost to TTL keeps a canonical-clock section due (#6960)', async () => {
-  // The exact production state on 2026-08-19: canonical republished 08-12,
-  // seed-meta never written by that run and the 07-10 one already expired.
-  const freshness = await readSectionFreshness({
-    canonicalKey: 'energy:iea-oil-stocks:v1:index',
-    seedMetaKey: 'energy:iea-oil-stocks',
-    completionMetaKey: 'seed-meta:energy:iea-oil-stocks',
-  }, async (key) => {
-    if (key === 'energy:iea-oil-stocks:v1:index') {
-      return { _seed: { fetchedAt: Date.now() }, data: {} };
-    }
-    return null;
-  });
-  assert.equal(freshness, null, 'an absent completion cannot attest a canonical publish');
-});
-
-// Positive control. Without this, the two tests above would still pass if the
-// canonical branch simply returned null for every attested section.
-test('a completed run passes the canonical clock through unchanged (#6960)', async () => {
-  const canonicalPublishedAt = Date.now() - 60 * 60 * 1000;
-  const completedAt = canonicalPublishedAt + 6_900; // measured IEA gap: +6.9s
-  const freshness = await readSectionFreshness({
-    canonicalKey: 'energy:iea-oil-stocks:v1:index',
-    seedMetaKey: 'energy:iea-oil-stocks',
-    completionMetaKey: 'seed-meta:energy:iea-oil-stocks',
-  }, async (key) => {
-    if (key === 'energy:iea-oil-stocks:v1:index') {
-      return { _seed: { fetchedAt: canonicalPublishedAt }, data: {} };
-    }
-    if (key === 'seed-meta:energy:iea-oil-stocks') {
-      return { fetchedAt: completedAt };
-    }
-    return null;
-  });
-  assert.deepEqual(freshness, { fetchedAt: canonicalPublishedAt });
-});
-
-// A section that declares no completionMetaKey must keep reading the canonical
-// envelope alone. 85 of the 93 canonical-clock members are in that group, and
-// 8 of them publish a canonical envelope with no seed-meta at all — requiring an
-// attestation from them would mark them due on every tick (#6806's failure).
-test('a section without a completion key still reads the canonical clock alone (#6960)', async () => {
-  const reads = [];
-  const publishedAt = Date.now();
-  const freshness = await readSectionFreshness({
-    canonicalKey: 'infra:ontario-511:v1',
-    seedMetaKey: 'infra:ontario-511',
-  }, async (key) => {
-    reads.push(key);
-    if (key === 'infra:ontario-511:v1') return { _seed: { fetchedAt: publishedAt }, data: {} };
-    return null;
-  });
-  assert.deepEqual(freshness, { fetchedAt: publishedAt });
-  assert.deepEqual(reads, ['infra:ontario-511:v1'], 'no extra read when nothing is declared');
-});
-
-// Closed-world gate for #6960. The population is DERIVED, not listed: any bundle
-// member whose seeder passes extraKeys to runSeed and whose due-ness comes from
-// the canonical envelope has a window between the canonical publish and the
-// seed-meta write in which a CONTRACT VIOLATION exit leaves an advanced clock
-// and no attestation. A new member inheriting that shape must fail here rather
-// than silently buy itself a full interval of silence.
-//
-// Exemptions are named with a reason, so removing the reason removes the
-// exemption.
-const COMPLETION_ATTESTATION_EXEMPT = new Map([
-  ['Arms-Suppliers',
-   'the #6893 chunked sweep is deliberately due every tick until the sweep '
-   + 'completes, and its declared seedMetaKey is an extraKey meta written INSIDE '
-   + 'the loop, which cannot attest that the loop finished'],
-]);
-
-test('every canonical-clock section with extraKeys attests completion (#6960)', () => {
-  const scriptFiles = readdirSync(SCRIPTS_DIR).filter((f) => f.endsWith('.mjs'));
-  const seedersWithExtraKeys = new Set(
-    scriptFiles.filter((f) => /(?<![\w$])extraKeys\s*:/.test(readFileSync(join(SCRIPTS_DIR, f), 'utf8'))),
-  );
-  assert.ok(
-    seedersWithExtraKeys.size > 0,
-    'discovery found no seeder passing extraKeys — the scan is broken, not the repo clean',
-  );
-
-  const offenders = [];
-  let inspected = 0;
-
-  for (const bundlePath of listBundleFiles(SCRIPTS_DIR)) {
-    const name = basename(bundlePath);
-    const raw = readFileSync(bundlePath, 'utf-8');
-    const src = stripLineComments(raw);
-    // A section this gate cannot read is a section it cannot vouch for, and a
-    // dropped section is a false PASS. Prove nothing vanished — across the
-    // comment strip, and between the anchor scan and the extractor.
-    assert.equal(
-      countSectionScriptKeys(src), countSectionScriptKeys(raw),
-      `${name}: a \`script:\` key disappeared when comments were stripped`,
-    );
-    const sections = extractBundleSections(raw);
-    assert.equal(
-      sections.length, countSectionAnchors(src),
-      `${name}: extractor returned ${sections.length} of ${countSectionAnchors(src)} section anchors`,
-    );
-    assert.equal(
-      sections.length, countSectionScriptKeys(src),
-      `${name}: extractor returned ${sections.length} sections for ${countSectionScriptKeys(src)} \`script:\` keys`,
-    );
-
-    for (const section of sections) {
-      if (!seedersWithExtraKeys.has(section.script)) continue;
-      // Only the canonical branch is exposed. A declared freshnessMetaKey takes
-      // its own path, which already enforces completion.
-      if (!section.hasCanonicalKey || section.hasFreshnessMetaKey) continue;
-      inspected++;
-      if (section.hasCompletionMetaKey) continue;
-      if (COMPLETION_ATTESTATION_EXEMPT.has(section.label)) continue;
-      offenders.push(`${name}: ${section.label}`);
-    }
-  }
-
-  assert.ok(
-    inspected > 0,
-    'no canonical-clock section with extraKeys was inspected — the gate is vacuous',
-  );
-  assert.deepEqual(
-    offenders, [],
-    'these sections let a partial publish advance their due-ness clock unattested. '
-    + "Declare completionMetaKey (runSeed's own seed-meta:<domain>:<resource>, the write "
-    + 'that lands AFTER the extra-key loop) or add a reasoned exemption.',
-  );
 });
 
 function runBundleWith(sections, opts = {}, env = {}) {
@@ -1282,6 +1118,50 @@ test('injects BUNDLE_RUN_STARTED_AT_MS env into child; value is within run bound
     // child ran before `after`. So: before - tolerance <= injected <= after.
     assert.ok(injected >= before - 5000 && injected <= after,
       `injected=${injected} out of bounds [${before - 5000}, ${after}]`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('injects only canonical-clock completion markers into child seeders', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-completion-env.mjs',
+    `console.log('COMPLETION=' + JSON.stringify(process.env.WM_BUNDLE_COMPLETION_META_KEY || ''));\n`,
+  );
+  try {
+    const canonical = await runBundleWith([{
+      label: 'CANONICAL',
+      script: '_bundle-fixture-completion-env.mjs',
+      canonicalKey: 'test:canonical:v1',
+      completionMetaKey: 'seed-completion:test:canonical',
+      intervalMs: 1,
+      timeoutMs: 5000,
+    }]);
+    assert.equal(canonical.code, 0);
+    assert.match(canonical.stdout, /COMPLETION="seed-completion:test:canonical"/);
+
+    const explicitFreshness = await runBundleWith([{
+      label: 'EXPLICIT',
+      script: '_bundle-fixture-completion-env.mjs',
+      canonicalKey: 'test:explicit:v1',
+      freshnessMetaKey: 'seed-meta:test:transport',
+      completionMetaKey: 'seed-meta:test:complete',
+      intervalMs: 1,
+      timeoutMs: 5000,
+    }]);
+    assert.equal(explicitFreshness.code, 0);
+    assert.match(explicitFreshness.stdout, /COMPLETION=""/);
+
+    const sharedCanonicalMeta = await runBundleWith([{
+      label: 'INVALID',
+      script: '_bundle-fixture-completion-env.mjs',
+      canonicalKey: 'test:invalid:v1',
+      completionMetaKey: 'seed-meta:test:invalid',
+      intervalMs: 1,
+      timeoutMs: 5000,
+    }]);
+    assert.notEqual(sharedCanonicalMeta.code, 0);
+    assert.match(sharedCanonicalMeta.stderr, /must use the dedicated seed-completion: namespace/);
   } finally {
     cleanup();
   }

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -8,12 +8,19 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
+import { mkdirSync, writeFileSync, unlinkSync, readFileSync, readdirSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { GRACEFUL_FETCH_FAILURE_EXIT_CODE } from '../scripts/_seed-utils.mjs';
 import { DAY, readSectionFreshness, bundleHeartbeatKey, BUNDLE_HEARTBEAT_TTL_SECONDS } from '../scripts/_bundle-runner.mjs';
+import {
+  countSectionAnchors,
+  countSectionScriptKeys,
+  extractBundleSections,
+  listBundleFiles,
+  stripLineComments,
+} from './helpers/bundle-section-parser.mjs';
 import {
   SUPERSEDED_KEY_TTL_SECONDS,
   atomicSwitch,
@@ -146,6 +153,163 @@ test('a missing completion marker keeps an explicit-freshness section due', asyn
     return null;
   });
   assert.equal(freshness, null);
+});
+
+// #6960. runSeed publishes the canonical key BEFORE the extra-key loop and
+// writes the canonical seed-meta AFTER it, so the three CONTRACT VIOLATION exits
+// inside that loop leave a canonical envelope with an ADVANCED fetchedAt and no
+// seed-meta write at all. The canonical envelope is this section's due-ness
+// clock, so the failed run buys itself a full interval of silence — 40 days for
+// IEA-Oil-Stocks, which is how energy:oil-stocks-analysis:v1 was allowed to
+// expire unnoticed. seed-meta is written last, so it is the completion
+// attestation: an older one belongs to a prior run.
+test('a partial publish cannot advance the canonical due-ness clock (#6960)', async () => {
+  const canonicalPublishedAt = Date.now();
+  const previousCompletionAt = canonicalPublishedAt - 40 * 24 * 60 * 60 * 1000;
+  const freshness = await readSectionFreshness({
+    canonicalKey: 'energy:iea-oil-stocks:v1:index',
+    seedMetaKey: 'energy:iea-oil-stocks',
+    completionMetaKey: 'seed-meta:energy:iea-oil-stocks',
+  }, async (key) => {
+    if (key === 'energy:iea-oil-stocks:v1:index') {
+      return { _seed: { fetchedAt: canonicalPublishedAt }, data: {} };
+    }
+    if (key === 'seed-meta:energy:iea-oil-stocks') {
+      return { fetchedAt: previousCompletionAt };
+    }
+    return null;
+  });
+  assert.equal(freshness, null, 'a canonical clock newer than its completion must read as due');
+});
+
+test('a completion marker lost to TTL keeps a canonical-clock section due (#6960)', async () => {
+  // The exact production state on 2026-08-19: canonical republished 08-12,
+  // seed-meta never written by that run and the 07-10 one already expired.
+  const freshness = await readSectionFreshness({
+    canonicalKey: 'energy:iea-oil-stocks:v1:index',
+    seedMetaKey: 'energy:iea-oil-stocks',
+    completionMetaKey: 'seed-meta:energy:iea-oil-stocks',
+  }, async (key) => {
+    if (key === 'energy:iea-oil-stocks:v1:index') {
+      return { _seed: { fetchedAt: Date.now() }, data: {} };
+    }
+    return null;
+  });
+  assert.equal(freshness, null, 'an absent completion cannot attest a canonical publish');
+});
+
+// Positive control. Without this, the two tests above would still pass if the
+// canonical branch simply returned null for every attested section.
+test('a completed run passes the canonical clock through unchanged (#6960)', async () => {
+  const canonicalPublishedAt = Date.now() - 60 * 60 * 1000;
+  const completedAt = canonicalPublishedAt + 6_900; // measured IEA gap: +6.9s
+  const freshness = await readSectionFreshness({
+    canonicalKey: 'energy:iea-oil-stocks:v1:index',
+    seedMetaKey: 'energy:iea-oil-stocks',
+    completionMetaKey: 'seed-meta:energy:iea-oil-stocks',
+  }, async (key) => {
+    if (key === 'energy:iea-oil-stocks:v1:index') {
+      return { _seed: { fetchedAt: canonicalPublishedAt }, data: {} };
+    }
+    if (key === 'seed-meta:energy:iea-oil-stocks') {
+      return { fetchedAt: completedAt };
+    }
+    return null;
+  });
+  assert.deepEqual(freshness, { fetchedAt: canonicalPublishedAt });
+});
+
+// A section that declares no completionMetaKey must keep reading the canonical
+// envelope alone. 85 of the 93 canonical-clock members are in that group, and
+// 8 of them publish a canonical envelope with no seed-meta at all — requiring an
+// attestation from them would mark them due on every tick (#6806's failure).
+test('a section without a completion key still reads the canonical clock alone (#6960)', async () => {
+  const reads = [];
+  const publishedAt = Date.now();
+  const freshness = await readSectionFreshness({
+    canonicalKey: 'infra:ontario-511:v1',
+    seedMetaKey: 'infra:ontario-511',
+  }, async (key) => {
+    reads.push(key);
+    if (key === 'infra:ontario-511:v1') return { _seed: { fetchedAt: publishedAt }, data: {} };
+    return null;
+  });
+  assert.deepEqual(freshness, { fetchedAt: publishedAt });
+  assert.deepEqual(reads, ['infra:ontario-511:v1'], 'no extra read when nothing is declared');
+});
+
+// Closed-world gate for #6960. The population is DERIVED, not listed: any bundle
+// member whose seeder passes extraKeys to runSeed and whose due-ness comes from
+// the canonical envelope has a window between the canonical publish and the
+// seed-meta write in which a CONTRACT VIOLATION exit leaves an advanced clock
+// and no attestation. A new member inheriting that shape must fail here rather
+// than silently buy itself a full interval of silence.
+//
+// Exemptions are named with a reason, so removing the reason removes the
+// exemption.
+const COMPLETION_ATTESTATION_EXEMPT = new Map([
+  ['Arms-Suppliers',
+   'the #6893 chunked sweep is deliberately due every tick until the sweep '
+   + 'completes, and its declared seedMetaKey is an extraKey meta written INSIDE '
+   + 'the loop, which cannot attest that the loop finished'],
+]);
+
+test('every canonical-clock section with extraKeys attests completion (#6960)', () => {
+  const scriptFiles = readdirSync(SCRIPTS_DIR).filter((f) => f.endsWith('.mjs'));
+  const seedersWithExtraKeys = new Set(
+    scriptFiles.filter((f) => /(?<![\w$])extraKeys\s*:/.test(readFileSync(join(SCRIPTS_DIR, f), 'utf8'))),
+  );
+  assert.ok(
+    seedersWithExtraKeys.size > 0,
+    'discovery found no seeder passing extraKeys — the scan is broken, not the repo clean',
+  );
+
+  const offenders = [];
+  let inspected = 0;
+
+  for (const bundlePath of listBundleFiles(SCRIPTS_DIR)) {
+    const name = basename(bundlePath);
+    const raw = readFileSync(bundlePath, 'utf-8');
+    const src = stripLineComments(raw);
+    // A section this gate cannot read is a section it cannot vouch for, and a
+    // dropped section is a false PASS. Prove nothing vanished — across the
+    // comment strip, and between the anchor scan and the extractor.
+    assert.equal(
+      countSectionScriptKeys(src), countSectionScriptKeys(raw),
+      `${name}: a \`script:\` key disappeared when comments were stripped`,
+    );
+    const sections = extractBundleSections(raw);
+    assert.equal(
+      sections.length, countSectionAnchors(src),
+      `${name}: extractor returned ${sections.length} of ${countSectionAnchors(src)} section anchors`,
+    );
+    assert.equal(
+      sections.length, countSectionScriptKeys(src),
+      `${name}: extractor returned ${sections.length} sections for ${countSectionScriptKeys(src)} \`script:\` keys`,
+    );
+
+    for (const section of sections) {
+      if (!seedersWithExtraKeys.has(section.script)) continue;
+      // Only the canonical branch is exposed. A declared freshnessMetaKey takes
+      // its own path, which already enforces completion.
+      if (!section.hasCanonicalKey || section.hasFreshnessMetaKey) continue;
+      inspected++;
+      if (section.hasCompletionMetaKey) continue;
+      if (COMPLETION_ATTESTATION_EXEMPT.has(section.label)) continue;
+      offenders.push(`${name}: ${section.label}`);
+    }
+  }
+
+  assert.ok(
+    inspected > 0,
+    'no canonical-clock section with extraKeys was inspected — the gate is vacuous',
+  );
+  assert.deepEqual(
+    offenders, [],
+    'these sections let a partial publish advance their due-ness clock unattested. '
+    + "Declare completionMetaKey (runSeed's own seed-meta:<domain>:<resource>, the write "
+    + 'that lands AFTER the extra-key loop) or add a reasoned exemption.',
+  );
 });
 
 function runBundleWith(sections, opts = {}, env = {}) {

--- a/tests/helpers/bundle-section-parser.mjs
+++ b/tests/helpers/bundle-section-parser.mjs
@@ -331,11 +331,27 @@ export function extractBundleSections(rawBundleSrc) {
     const hasShorthandTimeout = /[{,]\s*timeoutMs\s*[,}]/.test(block);
     const hasSpread = /\.\.\./.test(block);
     if (timeoutMatches.length > 1 || hasShorthandTimeout || hasSpread) continue;
+    // Freshness-resolution keys, for gates that reason about which clock a
+    // section is due from (#6960). `has*` is separate from the literal because
+    // a section may declare the key as an identifier (`canonicalKey:
+    // CHINA_MACRO_CACHE_KEY`) — absent and declared-as-a-variable are different
+    // answers, and conflating them would let a gate skip a section it should
+    // have judged.
+    const literal = (name) =>
+      block.match(new RegExp(`(?<![\\w$])${name}:\\s*['"]([^'"]+)['"]`))?.[1] ?? null;
+    const declared = (name) => new RegExp(`(?<![\\w$])${name}:`).test(block);
     sections.push({
       label,
       script: scriptM[1],
       intervalMsExpr: intervalM[1].trim(),
       timeoutMsExpr: timeoutMatches.length === 1 ? timeoutMatches[0][1].trim() : null,
+      seedMetaKey: literal('seedMetaKey'),
+      canonicalKey: literal('canonicalKey'),
+      freshnessMetaKey: literal('freshnessMetaKey'),
+      completionMetaKey: literal('completionMetaKey'),
+      hasCanonicalKey: declared('canonicalKey'),
+      hasFreshnessMetaKey: declared('freshnessMetaKey'),
+      hasCompletionMetaKey: declared('completionMetaKey'),
     });
   }
   return sections;

--- a/tests/helpers/bundle-section-parser.mjs
+++ b/tests/helpers/bundle-section-parser.mjs
@@ -331,27 +331,11 @@ export function extractBundleSections(rawBundleSrc) {
     const hasShorthandTimeout = /[{,]\s*timeoutMs\s*[,}]/.test(block);
     const hasSpread = /\.\.\./.test(block);
     if (timeoutMatches.length > 1 || hasShorthandTimeout || hasSpread) continue;
-    // Freshness-resolution keys, for gates that reason about which clock a
-    // section is due from (#6960). `has*` is separate from the literal because
-    // a section may declare the key as an identifier (`canonicalKey:
-    // CHINA_MACRO_CACHE_KEY`) — absent and declared-as-a-variable are different
-    // answers, and conflating them would let a gate skip a section it should
-    // have judged.
-    const literal = (name) =>
-      block.match(new RegExp(`(?<![\\w$])${name}:\\s*['"]([^'"]+)['"]`))?.[1] ?? null;
-    const declared = (name) => new RegExp(`(?<![\\w$])${name}:`).test(block);
     sections.push({
       label,
       script: scriptM[1],
       intervalMsExpr: intervalM[1].trim(),
       timeoutMsExpr: timeoutMatches.length === 1 ? timeoutMatches[0][1].trim() : null,
-      seedMetaKey: literal('seedMetaKey'),
-      canonicalKey: literal('canonicalKey'),
-      freshnessMetaKey: literal('freshnessMetaKey'),
-      completionMetaKey: literal('completionMetaKey'),
-      hasCanonicalKey: declared('canonicalKey'),
-      hasFreshnessMetaKey: declared('freshnessMetaKey'),
-      hasCompletionMetaKey: declared('completionMetaKey'),
     });
   }
   return sections;

--- a/tests/helpers/seed-bundle-attestation-parser.mjs
+++ b/tests/helpers/seed-bundle-attestation-parser.mjs
@@ -1,0 +1,408 @@
+import { readFileSync } from 'node:fs';
+import { dirname, extname, resolve } from 'node:path';
+import ts from 'typescript';
+
+const UNKNOWN = Symbol('unknown-static-value');
+const FUNCTION = Symbol('static-function');
+
+function sourceFile(filePath, readSource) {
+  const source = readSource(filePath);
+  return ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+}
+
+function modulePath(fromFile, specifier) {
+  if (!specifier.startsWith('.')) return null;
+  const candidate = resolve(dirname(fromFile), specifier);
+  if (extname(candidate)) return candidate;
+  return `${candidate}.mjs`;
+}
+
+function propertyName(node) {
+  if (ts.isIdentifier(node) || ts.isStringLiteralLike(node) || ts.isNumericLiteral(node)) {
+    return node.text;
+  }
+  throw new Error(`computed property names are not statically resolvable`);
+}
+
+function findVariable(sf, name) {
+  let found = null;
+  const visit = (node) => {
+    if (found) return;
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === name) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return found;
+}
+
+function findFunctionReturn(sf, name) {
+  for (const statement of sf.statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.name?.text === name && statement.body) {
+      return statement.body.statements.find(ts.isReturnStatement)?.expression ?? null;
+    }
+  }
+  const declaration = findVariable(sf, name);
+  const initializer = declaration?.initializer && unwrapExpression(declaration.initializer);
+  if (!initializer || (!ts.isArrowFunction(initializer) && !ts.isFunctionExpression(initializer))) return null;
+  if (!ts.isBlock(initializer.body)) return initializer.body;
+  return initializer.body.statements.find(ts.isReturnStatement)?.expression ?? null;
+}
+
+function findImport(sf, localName) {
+  for (const statement of sf.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteralLike(statement.moduleSpecifier)) continue;
+    const clause = statement.importClause;
+    if (!clause) continue;
+    if (clause.name?.text === localName) {
+      return { importedName: 'default', specifier: statement.moduleSpecifier.text };
+    }
+    const bindings = clause.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      if (element.name.text === localName) {
+        return {
+          importedName: element.propertyName?.text ?? element.name.text,
+          specifier: statement.moduleSpecifier.text,
+        };
+      }
+    }
+  }
+  return null;
+}
+
+function findImportedCallBindings(sf, importedName, moduleSuffix) {
+  const identifiers = new Set();
+  const namespaces = new Set();
+  for (const statement of sf.statements) {
+    if (!ts.isImportDeclaration(statement) || !ts.isStringLiteralLike(statement.moduleSpecifier)) continue;
+    if (!statement.moduleSpecifier.text.endsWith(moduleSuffix)) continue;
+    const bindings = statement.importClause?.namedBindings;
+    if (bindings && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        if ((element.propertyName?.text ?? element.name.text) === importedName) {
+          identifiers.add(element.name.text);
+        }
+      }
+    } else if (bindings && ts.isNamespaceImport(bindings)) {
+      namespaces.add(bindings.name.text);
+    }
+  }
+  return { identifiers, namespaces };
+}
+
+function findDefaultExport(sf) {
+  for (const statement of sf.statements) {
+    if (ts.isExportAssignment(statement) && !statement.isExportEquals) return statement.expression;
+  }
+  return null;
+}
+
+function unwrapExpression(node) {
+  let current = node;
+  while (
+    ts.isParenthesizedExpression(current)
+    || ts.isAsExpression(current)
+    || ts.isSatisfiesExpression(current)
+    || ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function resolveIdentifierValue(name, context) {
+  const seenKey = `${context.filePath}::${name}`;
+  if (context.seen.has(seenKey)) {
+    throw new Error(`${context.filePath}: cyclic static reference ${name}`);
+  }
+  const seen = new Set(context.seen).add(seenKey);
+  const local = findVariable(context.sf, name);
+  if (local?.initializer) {
+    return resolveValue(local.initializer, { ...context, seen });
+  }
+  if (context.sf.statements.some(
+    (statement) => ts.isFunctionDeclaration(statement) && statement.name?.text === name,
+  )) return FUNCTION;
+
+  const imported = findImport(context.sf, name);
+  if (!imported) return UNKNOWN;
+  const targetPath = modulePath(context.filePath, imported.specifier);
+  if (!targetPath) return UNKNOWN;
+  const targetSf = sourceFile(targetPath, context.readSource);
+  const targetContext = { ...context, filePath: targetPath, sf: targetSf, seen };
+  if (imported.importedName === 'default') {
+    const exported = findDefaultExport(targetSf);
+    if (!exported) return UNKNOWN;
+    return resolveValue(exported, targetContext);
+  }
+  return resolveIdentifierValue(imported.importedName, targetContext);
+}
+
+function resolveObject(node, context) {
+  const result = new Map();
+  const valueNeeded = new Set([
+    'label',
+    'script',
+    'canonicalKey',
+    'freshnessMetaKey',
+    'completionMetaKey',
+    'extraKeys',
+    'afterPublish',
+    'afterFreshness',
+  ]);
+  for (const property of node.properties) {
+    if (ts.isSpreadAssignment(property)) {
+      const spread = resolveValue(property.expression, context);
+      if (!(spread instanceof Map)) {
+        throw new Error(`${context.filePath}: object spread is not statically resolvable`);
+      }
+      for (const [key, value] of spread) result.set(key, value);
+      continue;
+    }
+    if (ts.isPropertyAssignment(property)) {
+      const name = propertyName(property.name);
+      result.set(name, valueNeeded.has(name) ? resolveValue(property.initializer, context) : UNKNOWN);
+      continue;
+    }
+    if (ts.isShorthandPropertyAssignment(property)) {
+      const name = property.name.text;
+      result.set(name, valueNeeded.has(name) ? resolveIdentifierValue(name, context) : UNKNOWN);
+      continue;
+    }
+    if (ts.isMethodDeclaration(property)) {
+      result.set(propertyName(property.name), FUNCTION);
+      continue;
+    }
+    if (ts.isGetAccessorDeclaration(property) || ts.isSetAccessorDeclaration(property)) {
+      result.set(propertyName(property.name), UNKNOWN);
+      continue;
+    }
+    throw new Error(`${context.filePath}: unsupported object property in static configuration`);
+  }
+  return result;
+}
+
+function resolveArray(node, context) {
+  const result = [];
+  for (const element of node.elements) {
+    if (ts.isSpreadElement(element)) {
+      const spread = resolveValue(element.expression, context);
+      if (!Array.isArray(spread)) {
+        throw new Error(`${context.filePath}: array spread is not statically resolvable`);
+      }
+      result.push(...spread);
+      continue;
+    }
+    result.push(resolveValue(element, context));
+  }
+  return result;
+}
+
+function resolveValue(rawNode, context) {
+  const node = unwrapExpression(rawNode);
+  if (ts.isObjectLiteralExpression(node)) return resolveObject(node, context);
+  if (ts.isArrayLiteralExpression(node)) return resolveArray(node, context);
+  if (ts.isStringLiteralLike(node)) return node.text;
+  if (ts.isNumericLiteral(node)) return Number(node.text);
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return false;
+  if (node.kind === ts.SyntaxKind.NullKeyword) return null;
+  if (ts.isIdentifier(node) && node.text === 'undefined') return undefined;
+  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) return FUNCTION;
+  if (ts.isIdentifier(node)) return resolveIdentifierValue(node.text, context);
+  if (ts.isConditionalExpression(node)) {
+    const whenTrue = resolveValue(node.whenTrue, context);
+    const whenFalse = resolveValue(node.whenFalse, context);
+    if (Array.isArray(whenTrue) && Array.isArray(whenFalse)) {
+      const identity = (value) => value instanceof Map
+        ? `${String(value.get('label'))}:${String(value.get('script'))}`
+        : String(value);
+      const trueMembers = [...whenTrue].map(identity).sort();
+      const falseMembers = [...whenFalse].map(identity).sort();
+      if (JSON.stringify(trueMembers) === JSON.stringify(falseMembers)) return whenTrue;
+    }
+    return UNKNOWN;
+  }
+  // Array filter/slice preserve a declared manifest's possible members, and
+  // map preserves whether runSeed's extraKeys option is an array. The audit
+  // needs membership/type, not the transformed element values.
+  if (
+    ts.isCallExpression(node)
+    && ts.isPropertyAccessExpression(node.expression)
+    && ['filter', 'slice', 'map'].includes(node.expression.name.text)
+  ) {
+    const receiver = resolveValue(node.expression.expression, context);
+    if (Array.isArray(receiver)) return receiver;
+  }
+  if (
+    ts.isCallExpression(node)
+    && ts.isPropertyAccessExpression(node.expression)
+    && ts.isIdentifier(node.expression.expression)
+    && node.expression.expression.text === 'Object'
+    && node.expression.name.text === 'freeze'
+    && node.arguments[0]
+  ) {
+    return resolveValue(node.arguments[0], context);
+  }
+  if (
+    ts.isCallExpression(node)
+    && ts.isPropertyAccessExpression(node.expression)
+    && ts.isIdentifier(node.expression.expression)
+    && node.expression.expression.text === 'Object'
+    && node.expression.name.text === 'values'
+  ) {
+    return [];
+  }
+  if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)) {
+    const returned = findFunctionReturn(context.sf, node.expression.text);
+    if (returned) return resolveValue(returned, context);
+  }
+  return UNKNOWN;
+}
+
+function findCalls(sf, name) {
+  const calls = [];
+  const visit = (node) => {
+    if (
+      ts.isCallExpression(node)
+      && ts.isIdentifier(node.expression)
+      && node.expression.text === name
+    ) {
+      calls.push(node);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return calls;
+}
+
+function findImportedCalls(sf, importedName, moduleSuffix) {
+  const { identifiers, namespaces } = findImportedCallBindings(sf, importedName, moduleSuffix);
+  if (identifiers.size === 0 && namespaces.size === 0) {
+    const unboundCalls = findCalls(sf, importedName);
+    if (unboundCalls.length > 0) {
+      throw new Error(`${sf.fileName}: no statically identifiable ${importedName} import`);
+    }
+    return [];
+  }
+  const calls = [];
+  const visit = (node) => {
+    if (ts.isCallExpression(node)) {
+      if (ts.isIdentifier(node.expression) && identifiers.has(node.expression.text)) {
+        calls.push(node);
+      } else if (
+        ts.isPropertyAccessExpression(node.expression)
+        && node.expression.name.text === importedName
+        && ts.isIdentifier(node.expression.expression)
+        && namespaces.has(node.expression.expression.text)
+      ) {
+        calls.push(node);
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return calls;
+}
+
+function contextFor(filePath, readSource) {
+  return {
+    filePath,
+    readSource,
+    sf: sourceFile(filePath, readSource),
+    seen: new Set(),
+  };
+}
+
+export function inspectRunSeedCalls(filePath, readSource = (path) => readFileSync(path, 'utf8')) {
+  const context = contextFor(filePath, readSource);
+  return findImportedCalls(context.sf, 'runSeed', '_seed-utils.mjs').map((call) => {
+    const optionsNode = call.arguments[4];
+    if (!optionsNode) return { hasExtraKeys: false, hasPostCanonicalWork: false };
+    const options = resolveValue(optionsNode, context);
+    if (!(options instanceof Map)) {
+      throw new Error(`${filePath}: runSeed options are not statically resolvable`);
+    }
+    const extraKeys = options.get('extraKeys');
+    const afterPublish = options.get('afterPublish');
+    const afterFreshness = options.get('afterFreshness');
+    for (const [name, value] of [['extraKeys', extraKeys], ['afterPublish', afterPublish], ['afterFreshness', afterFreshness]]) {
+      if (options.has(name) && value === UNKNOWN) {
+        throw new Error(`${filePath}: runSeed ${name} is not statically resolvable`);
+      }
+    }
+    if (extraKeys && !Array.isArray(extraKeys)) {
+      throw new Error(`${filePath}: runSeed extraKeys must resolve to an array`);
+    }
+    if (afterPublish && afterPublish !== FUNCTION) {
+      throw new Error(`${filePath}: runSeed afterPublish must resolve to a function`);
+    }
+    if (afterFreshness && afterFreshness !== FUNCTION) {
+      throw new Error(`${filePath}: runSeed afterFreshness must resolve to a function`);
+    }
+    const hasExtraKeys = Boolean(extraKeys);
+    return {
+      hasExtraKeys,
+      hasPostCanonicalWork: hasExtraKeys || Boolean(afterPublish) || Boolean(afterFreshness),
+    };
+  });
+}
+
+export function extractAttestationBundleSections(
+  filePath,
+  readSource = (path) => readFileSync(path, 'utf8'),
+) {
+  const context = contextFor(filePath, readSource);
+  const calls = findCalls(context.sf, 'runBundle');
+  if (calls.length === 0) return null;
+  if (calls.length !== 1) {
+    throw new Error(`${filePath}: expected exactly one runBundle call, found ${calls.length}`);
+  }
+  const sectionValue = calls[0].arguments[1]
+    ? resolveValue(calls[0].arguments[1], context)
+    : UNKNOWN;
+  if (!Array.isArray(sectionValue) || sectionValue.length === 0) {
+    throw new Error(`${filePath}: runBundle member array is empty or not statically resolvable`);
+  }
+  const resolvedSections = sectionValue.map((section, index) => {
+    if (!(section instanceof Map)) {
+      throw new Error(`${filePath}: member ${index + 1} is not a statically resolvable object`);
+    }
+    const label = section.get('label');
+    const script = section.get('script');
+    if (typeof label !== 'string' || typeof script !== 'string') {
+      throw new Error(`${filePath}: member ${index + 1} needs literal label and script values`);
+    }
+    const canonicalKey = section.get('canonicalKey');
+    const freshnessMetaKey = section.get('freshnessMetaKey');
+    const completionMetaKey = section.get('completionMetaKey');
+    for (const [name, value] of [
+      ['canonicalKey', canonicalKey],
+      ['freshnessMetaKey', freshnessMetaKey],
+      ['completionMetaKey', completionMetaKey],
+    ]) {
+      if (section.has(name) && value === UNKNOWN) {
+        throw new Error(`${filePath}: ${label} ${name} is not statically resolvable`);
+      }
+    }
+    if (completionMetaKey != null && typeof completionMetaKey !== 'string') {
+      throw new Error(`${filePath}: ${label} completionMetaKey is not statically resolvable`);
+    }
+    return {
+      label,
+      script,
+      hasCanonicalKey: Boolean(canonicalKey),
+      hasFreshnessMetaKey: Boolean(freshnessMetaKey),
+      completionMetaKey: typeof completionMetaKey === 'string' ? completionMetaKey : null,
+    };
+  });
+  // Rotating bundles concatenate complementary slices of one manifest. Static
+  // member analysis ignores order, so collapse the duplicate superset created
+  // by resolving each dynamic slice to its receiver.
+  return [...new Map(
+    resolvedSections.map((section) => [`${section.label}:${section.script}`, section]),
+  ).values()];
+}

--- a/tests/seed-utils-meta-write-degrades.test.mjs
+++ b/tests/seed-utils-meta-write-degrades.test.mjs
@@ -99,6 +99,154 @@ function metaSetAttempts(resource) {
   ).length;
 }
 
+test('successful bundled run writes the dedicated completion marker last', async () => {
+  const originalFetchForCompletion = globalThis.fetch;
+  const events = [];
+  process.env.WM_BUNDLE_COMPLETION_META_KEY = 'seed-completion:test:ordered';
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url);
+    const body = opts?.body ? JSON.parse(opts.body) : null;
+    calls.push({ u, body });
+    if (u.includes('/get/')) return jsonResponse({ result: JSON.stringify(CANONICAL_ENVELOPE) });
+    if (u.endsWith('/pipeline')) return jsonResponse(body.map(() => ({ result: 1 })));
+    if (Array.isArray(body) && body[0] === 'SET') events.push(body[1]);
+    return jsonResponse({ result: 'OK' });
+  };
+
+  try {
+    const { exitCode, threw } = await runWithExitTrap(() =>
+      runSeed('test', 'ordered', 'test:ordered:v1', async () => ({ items: [1] }), {
+        validateFn: (data) => data.items.length > 0,
+        ttlSeconds: 3600,
+        declareRecords: (data) => data.items.length,
+        sourceVersion: 'test-v1',
+        schemaVersion: 1,
+        maxStaleMin: 720,
+        extraKeys: [{
+          key: 'test:ordered:extra:v1',
+          transform: (data) => data.items,
+          declareRecords: (items) => items.length,
+        }],
+        afterFreshness: async () => { events.push('afterFreshness'); },
+      }),
+    );
+
+    assert.equal(threw, null);
+    assert.equal(exitCode, 0);
+    const completionIndex = events.indexOf('seed-completion:test:ordered');
+    assert.ok(completionIndex > events.indexOf('test:ordered:v1'));
+    assert.ok(completionIndex > events.indexOf('test:ordered:extra:v1'));
+    assert.ok(completionIndex > events.indexOf('seed-meta:test:ordered'));
+    assert.ok(completionIndex > events.indexOf('afterFreshness'));
+
+    const canonicalSet = calls.find((call) => call.body?.[0] === 'SET' && call.body[1] === 'test:ordered:v1');
+    const completionSet = calls.find((call) => call.body?.[0] === 'SET' && call.body[1] === 'seed-completion:test:ordered');
+    assert.ok(completionSet, 'completion marker must be written');
+    assert.equal(
+      JSON.parse(completionSet.body[2]).fetchedAt,
+      JSON.parse(canonicalSet.body[2])._seed.fetchedAt,
+      'completion must identify the exact canonical run it attests',
+    );
+  } finally {
+    delete process.env.WM_BUNDLE_COMPLETION_META_KEY;
+    globalThis.fetch = originalFetchForCompletion;
+  }
+});
+
+test('validation skip never refreshes the dedicated completion marker', async () => {
+  const originalFetchForCompletion = globalThis.fetch;
+  process.env.WM_BUNDLE_COMPLETION_META_KEY = 'seed-completion:test:skip';
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url);
+    const body = opts?.body ? JSON.parse(opts.body) : null;
+    calls.push({ u, body });
+    if (u.includes('/get/')) return jsonResponse({ result: JSON.stringify(CANONICAL_ENVELOPE) });
+    if (u.endsWith('/pipeline')) return jsonResponse(body.map(() => ({ result: 1 })));
+    return jsonResponse({ result: 'OK' });
+  };
+
+  try {
+    const { exitCode, threw } = await runWithExitTrap(() =>
+      runSeed('test', 'skip', 'test:skip:v1', async () => ({ items: [] }), {
+        validateFn: () => false,
+        ttlSeconds: 3600,
+        declareRecords: () => 1,
+        sourceVersion: 'test-v1',
+        schemaVersion: 1,
+        maxStaleMin: 720,
+      }),
+    );
+    assert.equal(threw, null);
+    assert.equal(exitCode, 0);
+    assert.ok(calls.some((call) => call.body?.[1] === 'seed-meta:test:skip'));
+    assert.equal(calls.some((call) => call.body?.[1] === 'seed-completion:test:skip'), false);
+  } finally {
+    delete process.env.WM_BUNDLE_COMPLETION_META_KEY;
+    globalThis.fetch = originalFetchForCompletion;
+  }
+});
+
+test('completion marker write failure rejects the seed after retries', async () => {
+  const originalFetchForCompletion = globalThis.fetch;
+  process.env.WM_BUNDLE_COMPLETION_META_KEY = 'seed-completion:test:write-failure';
+  globalThis.fetch = async (url, opts = {}) => {
+    const u = String(url);
+    const body = opts?.body ? JSON.parse(opts.body) : null;
+    calls.push({ u, body });
+    if (u.includes('/get/')) return jsonResponse({ result: JSON.stringify(CANONICAL_ENVELOPE) });
+    if (u.endsWith('/pipeline')) return jsonResponse(body.map(() => ({ result: 1 })));
+    if (Array.isArray(body) && body[0] === 'SET' && body[1] === 'seed-completion:test:write-failure') {
+      throw abortError();
+    }
+    return jsonResponse({ result: 'OK' });
+  };
+
+  try {
+    const { exitCode, threw } = await runWithExitTrap(() =>
+      runSeed('test', 'write-failure', 'test:write-failure:v1', async () => ({ items: [1] }), {
+        validateFn: (data) => data.items.length > 0,
+        ttlSeconds: 3600,
+        declareRecords: (data) => data.items.length,
+        sourceVersion: 'test-v1',
+        schemaVersion: 1,
+        maxStaleMin: 720,
+      }),
+    );
+    assert.equal(exitCode, null);
+    assert.equal(threw?.name, 'AbortError', 'a missing final attestation must reject the bundled seed');
+    assert.ok(
+      calls.filter((call) => call.body?.[1] === 'seed-completion:test:write-failure').length >= 3,
+      'the completion marker write must exhaust its retry budget before failing',
+    );
+  } finally {
+    delete process.env.WM_BUNDLE_COMPLETION_META_KEY;
+    globalThis.fetch = originalFetchForCompletion;
+  }
+});
+
+test('malformed post-canonical options fail before the canonical publish', async () => {
+  for (const options of [{ extraKeys: {} }, { afterPublish: true }, { afterFreshness: true }]) {
+    calls.length = 0;
+    const { exitCode, threw } = await runWithExitTrap(() =>
+      runSeed('test', 'invalid-options', 'test:invalid-options:v1', async () => ({ items: [1] }), {
+        ...options,
+        validateFn: (data) => data.items.length > 0,
+        ttlSeconds: 3600,
+        declareRecords: (data) => data.items.length,
+        sourceVersion: 'test-v1',
+        schemaVersion: 1,
+        maxStaleMin: 720,
+      }),
+    );
+    assert.equal(threw, null);
+    assert.equal(exitCode, 1);
+    assert.equal(
+      calls.some((call) => call.body?.[0] === 'SET' && call.body[1] === 'test:invalid-options:v1'),
+      false,
+    );
+  }
+});
+
 test('validate-skip path: seed-meta mirror write exhausting retries degrades to exit 0, not FATAL', async () => {
   const { exitCode, threw } = await runWithExitTrap(() =>
     runSeed('test', 'meta-degrade-skip', 'test:meta-degrade-skip:v1',


### PR DESCRIPTION
## Summary

Closes #6960.

A seed run that published its canonical key and then failed during an extra-key write or lifecycle hook could advance the bundle due-ness clock without completing the run. The next bundle tick then treated that partial run as fresh and could stay silent for a full interval.

Canonical-clock bundle members with post-publication work now require a dedicated `seed-completion:*` marker from the same run. `runSeed` writes that marker last—after canonical publication, every extra key, `afterPublish`, freshness bookkeeping, and `afterFreshness` succeed. A missing marker or a marker whose `fetchedAt` does not exactly match the canonical envelope keeps the section due.

## Why a dedicated marker

The shared `seed-meta` key is operational freshness metadata, not completion proof. Validation-skip and preservation paths can refresh or mirror it without completing a publication cohort. Reusing it would allow an incomplete retry to attest itself.

The completion marker has one purpose and one invariant:

```text
canonical._seed.fetchedAt == seed-completion.fetchedAt
```

It is never written on validation skips, preservation-only retries, malformed option failures, or failed post-publication work. A marker write failure fails the seed after bounded retries instead of reporting a completed run.

## Closed-world coverage

The repository gate derives the at-risk population from the actual bundle and seeder code. It resolves:

- imported bundle manifests and their runtime member transforms;
- inline, shorthand, named, spread, and imported `runSeed` options;
- named aliases and namespace imports of `runSeed`;
- `extraKeys`, `afterPublish`, and `afterFreshness` as post-canonical work;
- declared freshness values by runtime truthiness.

Unresolved or malformed shapes fail closed. Exemptions use the exact bundle, label, and script identity, require a reason, and must match exactly one member. `Arms-Suppliers` remains the single explicit exemption because its chunked sweep is intentionally due every tick until the sweep completes.

All 23 canonical-clock members with post-publication work now declare dedicated completion keys.

## Verification

- Completion-attestation and seed metadata failure paths: 26 passed.
- Bundle runner behavior, including timeout and deferral paths: 41 passed.
- Bundle admission and parser contracts: 35 passed.
- Seed descriptor contract: 40 passed.
- Extra-key, preservation, and empty-data seed utility tests: 27 passed.
- Relay tests that timed out under broad local concurrency: 25 passed when run serially.
- Isolated Pro build succeeded; generated Sentry chunk contract: 8 passed.
- Browser TypeScript and API TypeScript checks passed.
- Repository lint passed with its existing warnings; all 15 changed files are clean under focused Biome lint.
- The mandatory pre-push hook passed 67 changed tests and every repository push gate.

The top-level build stopped before bundling because the trusted worktree contains local `VITE_` credential names and the repository correctly blocks exposing them. Those credentials were not changed or bypassed.

## Post-Deploy Monitoring & Validation

- **Window:** observe the first scheduled run of each affected bundle and the following interval.
- **Success:** each completed member writes `seed-completion:*` with the exact canonical `fetchedAt`; the following tick skips only when that matching marker exists.
- **Failure signals:** repeated due runs, completion-marker write failures, contract violations, or affected datasets remaining `STALE_SEED` after a successful source fetch.
- **Where:** Railway seed-bundle logs plus `/api/health` seed status for the affected datasets.
- **Owner:** WorldMonitor on-call.
- **Rollback:** revert this PR if completion-marker writes cause repeated bundle failures; missing markers fail safe by making work due again.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
