### PR TITLE
fix(a11y): keyboard paths for panel reorder, resize handles, and pointer-only widgets

### DIFF
--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -1464,20 +1464,31 @@ export class EventHandlerManager implements AppModule {
 
     renderDropdown();
 
+    // Keep the trigger's aria-expanded in sync however the dropdown closes
+    // (toggle click, outside click, Escape).
+    btn.setAttribute('aria-haspopup', 'true');
+    btn.setAttribute('aria-expanded', 'false');
+    const syncExpanded = () => btn.setAttribute('aria-expanded', String(dropdown.classList.contains('open')));
+
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
       dropdown.classList.toggle('open');
+      syncExpanded();
     });
 
     this.boundDropdownClickHandler = (e: MouseEvent) => {
       if (!dropdown.contains(e.target as Node) && !btn.contains(e.target as Node)) {
         dropdown.classList.remove('open');
+        syncExpanded();
       }
     };
     document.addEventListener('click', this.boundDropdownClickHandler);
 
     this.boundDropdownKeydownHandler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') dropdown.classList.remove('open');
+      if (e.key === 'Escape') {
+        dropdown.classList.remove('open');
+        syncExpanded();
+      }
     };
     document.addEventListener('keydown', this.boundDropdownKeydownHandler);
   }
@@ -2202,6 +2213,24 @@ export class EventHandlerManager implements AppModule {
       setTimeout(onEnd, 500);
     });
 
+    // Keyboard path (WAI-ARIA window-splitter): the drag strip is a focusable
+    // separator; arrow keys step the height and persist like a finished drag.
+    resizeHandle.tabIndex = 0;
+    resizeHandle.setAttribute('role', 'separator');
+    resizeHandle.setAttribute('aria-orientation', 'horizontal');
+    resizeHandle.setAttribute('aria-label', t('components.panel.dragToResize'));
+    resizeHandle.addEventListener('keydown', (e: KeyboardEvent) => {
+      const step = e.key === 'ArrowUp' ? -40 : e.key === 'ArrowDown' ? 40 : 0;
+      if (step === 0) return;
+      e.preventDefault();
+      const target = getTarget();
+      const newHeight = Math.max(getMinHeight(), Math.min(target.offsetHeight + step, getMaxHeight()));
+      if (window.innerWidth >= 1600) target.style.flex = 'none';
+      target.style.height = `${newHeight}px`;
+      this.ctx.map?.resize();
+      writeStorageValue('map-height', `${newHeight}px`);
+    });
+
     this.boundMapResizeMoveHandler = (e: MouseEvent) => {
       if (!isResizing) return;
       const isWide = window.innerWidth >= 1600;
@@ -2259,6 +2288,23 @@ export class EventHandlerManager implements AppModule {
       document.body.classList.add('map-width-resizing');
       widthHandle.classList.add('resizing');
       e.preventDefault();
+    });
+
+    // Keyboard path, mirroring the height handle above.
+    widthHandle.tabIndex = 0;
+    widthHandle.setAttribute('role', 'separator');
+    widthHandle.setAttribute('aria-orientation', 'vertical');
+    widthHandle.setAttribute('aria-label', t('components.panel.dragToResize'));
+    widthHandle.addEventListener('keydown', (e: KeyboardEvent) => {
+      const step = e.key === 'ArrowLeft' ? -5 : e.key === 'ArrowRight' ? 5 : 0;
+      if (step === 0) return;
+      e.preventDefault();
+      const raw = mainContent.style.getPropertyValue('--map-col-width') || '60%';
+      const newPct = Math.max(25, Math.min(75, parseFloat(raw) + step));
+      const value = `${newPct.toFixed(1)}%`;
+      mainContent.style.setProperty('--map-col-width', value);
+      this.ctx.map?.resize();
+      writeStorageValue('map-col-width', value);
     });
 
     this.boundMapWidthResizeMoveHandler = (e: MouseEvent) => {

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -2136,6 +2136,29 @@ export class EventHandlerManager implements AppModule {
       }
     };
 
+    const getTarget = () => (window.innerWidth >= 1600 ? mapContainer : mapSection);
+    const getCurrentHeight = () => {
+      const target = getTarget();
+      const inlineHeight = Number.parseFloat(target.style.height);
+      return Number.isFinite(inlineHeight) ? inlineHeight : target.offsetHeight;
+    };
+    const syncHeightSeparatorAria = () => {
+      const target = getTarget();
+      const minHeight = getMinHeight();
+      const maxHeight = getMaxHeight();
+      const currentHeight = Math.max(minHeight, Math.min(getCurrentHeight(), maxHeight));
+      resizeHandle.setAttribute('aria-controls', target.id);
+      resizeHandle.setAttribute('aria-valuemin', String(Math.round(minHeight)));
+      resizeHandle.setAttribute('aria-valuemax', String(Math.round(maxHeight)));
+      resizeHandle.setAttribute('aria-valuenow', String(Math.round(currentHeight)));
+      resizeHandle.setAttribute('aria-valuetext', `${Math.round(currentHeight)} pixels`);
+    };
+
+    resizeHandle.tabIndex = 0;
+    resizeHandle.setAttribute('role', 'separator');
+    resizeHandle.setAttribute('aria-orientation', 'horizontal');
+    resizeHandle.setAttribute('aria-label', t('components.panel.dragToResize'));
+
     const savedHeight = readStorageValue('map-height');
     if (savedHeight) {
       const numeric = Number.parseInt(savedHeight, 10);
@@ -2154,12 +2177,11 @@ export class EventHandlerManager implements AppModule {
         removeStorageValue('map-height');
       }
     }
+    syncHeightSeparatorAria();
 
     let isResizing = false;
     let startY = 0;
     let startHeight = 0;
-
-    const getTarget = () => (window.innerWidth >= 1600 ? mapContainer : mapSection);
 
     this.boundMapEndResizeHandler = () => {
       if (!isResizing) return;
@@ -2169,6 +2191,7 @@ export class EventHandlerManager implements AppModule {
       mapSection.classList.remove('resizing');
       document.body.style.cursor = '';
       writeStorageValue('map-height', getTarget().style.height);
+      syncHeightSeparatorAria();
     };
     const endResize = this.boundMapEndResizeHandler;
 
@@ -2195,6 +2218,7 @@ export class EventHandlerManager implements AppModule {
 
       if (isWide) target.style.flex = 'none';
       target.style.height = `${finalHeight}px`;
+      syncHeightSeparatorAria();
 
       let fired = false;
       const onEnd = () => {
@@ -2206,6 +2230,7 @@ export class EventHandlerManager implements AppModule {
         writeStorageValue('map-height', `${finalHeight}px`);
         this.ctx.map?.setIsResizing(false);
         this.ctx.map?.resize();
+        syncHeightSeparatorAria();
       };
 
       target.addEventListener('transitionend', onEnd);
@@ -2215,10 +2240,6 @@ export class EventHandlerManager implements AppModule {
 
     // Keyboard path (WAI-ARIA window-splitter): the drag strip is a focusable
     // separator; arrow keys step the height and persist like a finished drag.
-    resizeHandle.tabIndex = 0;
-    resizeHandle.setAttribute('role', 'separator');
-    resizeHandle.setAttribute('aria-orientation', 'horizontal');
-    resizeHandle.setAttribute('aria-label', t('components.panel.dragToResize'));
     resizeHandle.addEventListener('keydown', (e: KeyboardEvent) => {
       const step = e.key === 'ArrowUp' ? -40 : e.key === 'ArrowDown' ? 40 : 0;
       if (step === 0) return;
@@ -2229,6 +2250,7 @@ export class EventHandlerManager implements AppModule {
       target.style.height = `${newHeight}px`;
       this.ctx.map?.resize();
       writeStorageValue('map-height', `${newHeight}px`);
+      syncHeightSeparatorAria();
     });
 
     this.boundMapResizeMoveHandler = (e: MouseEvent) => {
@@ -2243,6 +2265,7 @@ export class EventHandlerManager implements AppModule {
       target.style.height = `${newHeight}px`;
 
       this.ctx.map?.resize();
+      syncHeightSeparatorAria();
     };
     document.addEventListener('mousemove', this.boundMapResizeMoveHandler);
 
@@ -2259,8 +2282,29 @@ export class EventHandlerManager implements AppModule {
     const widthHandle = document.getElementById('mapWidthResizeHandle');
     if (!mainContent || !widthHandle) return;
 
+    const getCurrentWidthPercent = () => {
+      const raw = mainContent.style.getPropertyValue('--map-col-width') || '60%';
+      const parsed = Number.parseFloat(raw);
+      return Number.isFinite(parsed) ? Math.max(25, Math.min(75, parsed)) : 60;
+    };
+    const syncWidthSeparatorAria = () => {
+      const current = getCurrentWidthPercent();
+      const mapSection = document.getElementById('mapSection');
+      if (mapSection) widthHandle.setAttribute('aria-controls', mapSection.id);
+      widthHandle.setAttribute('aria-valuemin', '25');
+      widthHandle.setAttribute('aria-valuemax', '75');
+      widthHandle.setAttribute('aria-valuenow', String(current));
+      widthHandle.setAttribute('aria-valuetext', `${current}%`);
+    };
+
+    widthHandle.tabIndex = 0;
+    widthHandle.setAttribute('role', 'separator');
+    widthHandle.setAttribute('aria-orientation', 'vertical');
+    widthHandle.setAttribute('aria-label', t('components.panel.dragToResize'));
+
     const saved = readStorageValue('map-col-width');
     if (saved) mainContent.style.setProperty('--map-col-width', saved);
+    syncWidthSeparatorAria();
 
     let isResizing = false;
     let startX = 0;
@@ -2276,6 +2320,7 @@ export class EventHandlerManager implements AppModule {
       widthHandle.classList.remove('resizing');
       const current = mainContent.style.getPropertyValue('--map-col-width');
       if (current) writeStorageValue('map-col-width', current);
+      syncWidthSeparatorAria();
     };
 
     widthHandle.addEventListener('mousedown', (e) => {
@@ -2291,10 +2336,6 @@ export class EventHandlerManager implements AppModule {
     });
 
     // Keyboard path, mirroring the height handle above.
-    widthHandle.tabIndex = 0;
-    widthHandle.setAttribute('role', 'separator');
-    widthHandle.setAttribute('aria-orientation', 'vertical');
-    widthHandle.setAttribute('aria-label', t('components.panel.dragToResize'));
     widthHandle.addEventListener('keydown', (e: KeyboardEvent) => {
       const step = e.key === 'ArrowLeft' ? -5 : e.key === 'ArrowRight' ? 5 : 0;
       if (step === 0) return;
@@ -2305,6 +2346,7 @@ export class EventHandlerManager implements AppModule {
       mainContent.style.setProperty('--map-col-width', value);
       this.ctx.map?.resize();
       writeStorageValue('map-col-width', value);
+      syncWidthSeparatorAria();
     });
 
     this.boundMapWidthResizeMoveHandler = (e: MouseEvent) => {
@@ -2313,6 +2355,7 @@ export class EventHandlerManager implements AppModule {
       const newPct = Math.max(25, Math.min(75, ((startColPx + delta) / startTotalWidth) * 100));
       mainContent.style.setProperty('--map-col-width', `${newPct.toFixed(1)}%`);
       this.ctx.map?.resize();
+      syncWidthSeparatorAria();
     };
 
     document.addEventListener('mousemove', this.boundMapWidthResizeMoveHandler);

--- a/src/app/panel-keyboard-reorder.ts
+++ b/src/app/panel-keyboard-reorder.ts
@@ -1,0 +1,35 @@
+export type PanelKeyboardZone = 'sidebar' | 'bottom';
+
+export interface MovePanelToKeyboardZoneInput {
+  panel: HTMLElement;
+  panelKey: string;
+  targetZone: PanelKeyboardZone;
+  sidebarGrid: HTMLElement;
+  bottomGrid: HTMLElement;
+  bottomSet: Set<string>;
+}
+
+/**
+ * Move one panel between the two dashboard grids without relying on pointer
+ * coordinates. The caller persists the resulting unified order after a move.
+ */
+export function movePanelToKeyboardZone({
+  panel,
+  panelKey,
+  targetZone,
+  sidebarGrid,
+  bottomGrid,
+  bottomSet,
+}: MovePanelToKeyboardZoneInput): boolean {
+  const targetGrid = targetZone === 'bottom' ? bottomGrid : sidebarGrid;
+  if (panel.parentElement === targetGrid) return false;
+
+  const reference = targetZone === 'sidebar'
+    ? sidebarGrid.querySelector('.add-panel-block')
+    : null;
+  targetGrid.insertBefore(panel, reference);
+
+  if (targetZone === 'bottom') bottomSet.add(panelKey);
+  else bottomSet.delete(panelKey);
+  return true;
+}

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -3798,6 +3798,40 @@ export class PanelLayoutManager implements AppModule {
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
 
+    // Keyboard path for reordering: the mouse drag above has no keyboard
+    // equivalent, so layout customization was impossible without a pointer.
+    // A visually-hidden-until-focused button in the header moves the panel
+    // one slot per arrow press and persists through the same savePanelOrder()
+    // path as a completed drag. Within-grid only; grid-to-grid moves still
+    // need a pointer.
+    const header = el.querySelector<HTMLElement>('.panel-header');
+    if (header && !header.querySelector('.panel-move-btn')) {
+      const moveBtn = document.createElement('button');
+      moveBtn.type = 'button';
+      moveBtn.className = 'panel-move-btn';
+      const panelTitle = el.querySelector('.panel-title')?.textContent?.trim() || key;
+      moveBtn.setAttribute('aria-label', `Move ${panelTitle} panel (arrow keys)`);
+      moveBtn.textContent = '⇅';
+      moveBtn.addEventListener('keydown', (e: KeyboardEvent) => {
+        const back = e.key === 'ArrowLeft' || e.key === 'ArrowUp';
+        const fwd = e.key === 'ArrowRight' || e.key === 'ArrowDown';
+        if (!back && !fwd) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const parent = el.parentElement;
+        if (!parent) return;
+        const sibling = back ? el.previousElementSibling : el.nextElementSibling;
+        if (!(sibling instanceof HTMLElement) || !sibling.classList.contains('panel')) return;
+        if (back) parent.insertBefore(el, sibling);
+        else parent.insertBefore(el, sibling.nextElementSibling);
+        this.savePanelOrder();
+        // The button travels with the panel; keep focus on it so repeated
+        // presses keep moving the same panel.
+        moveBtn.focus();
+      });
+      header.prepend(moveBtn);
+    }
+
     this.panelDragCleanupHandlers.push(() => {
       el.removeEventListener('mousedown', onMouseDown);
       document.removeEventListener('mousemove', onMouseMove);

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -89,6 +89,7 @@ import {
   hydrateGeoHubPanelFromClusters,
   hydrateTechHubPanelFromClusters,
 } from '@/app/hub-activity-hydration';
+import { movePanelToKeyboardZone } from '@/app/panel-keyboard-reorder';
 
 function readSessionStorageValue(key: string): string | null {
   try {
@@ -3802,17 +3803,49 @@ export class PanelLayoutManager implements AppModule {
     // equivalent, so layout customization was impossible without a pointer.
     // A visually-hidden-until-focused button in the header moves the panel
     // one slot per arrow press and persists through the same savePanelOrder()
-    // path as a completed drag. Within-grid only; grid-to-grid moves still
-    // need a pointer.
+    // path as a completed drag. Page Up/Page Down move between the sidebar
+    // and below-map grids when both zones are active on an ultra-wide layout.
     const header = el.querySelector<HTMLElement>('.panel-header');
     if (header && !header.querySelector('.panel-move-btn')) {
       const moveBtn = document.createElement('button');
       moveBtn.type = 'button';
       moveBtn.className = 'panel-move-btn';
       const panelTitle = el.querySelector('.panel-title')?.textContent?.trim() || key;
-      moveBtn.setAttribute('aria-label', `Move ${panelTitle} panel (arrow keys)`);
+      moveBtn.setAttribute(
+        'aria-label',
+        `Move ${panelTitle} panel; arrow keys reorder, Page Up moves to sidebar, Page Down moves below map`,
+      );
+      moveBtn.setAttribute(
+        'aria-keyshortcuts',
+        'ArrowLeft ArrowRight ArrowUp ArrowDown PageUp PageDown',
+      );
       moveBtn.textContent = '⇅';
       moveBtn.addEventListener('keydown', (e: KeyboardEvent) => {
+        const targetZone = e.key === 'PageUp'
+          ? 'sidebar'
+          : e.key === 'PageDown'
+            ? 'bottom'
+            : null;
+        if (targetZone) {
+          if (!this.getEffectiveUltraWide()) return;
+          e.preventDefault();
+          e.stopPropagation();
+          const sidebarGrid = document.getElementById('panelsGrid');
+          const bottomGrid = document.getElementById('mapBottomGrid');
+          if (!sidebarGrid || !bottomGrid) return;
+          const moved = movePanelToKeyboardZone({
+            panel: el,
+            panelKey: key,
+            targetZone,
+            sidebarGrid,
+            bottomGrid,
+            bottomSet: this.bottomSetMemory,
+          });
+          if (moved) this.savePanelOrder();
+          moveBtn.focus();
+          return;
+        }
+
         const back = e.key === 'ArrowLeft' || e.key === 'ArrowUp';
         const fwd = e.key === 'ArrowRight' || e.key === 'ArrowDown';
         if (!back && !fwd) return;

--- a/src/components/AviationCommandBar.ts
+++ b/src/components/AviationCommandBar.ts
@@ -334,7 +334,10 @@ export class AviationCommandBar {
       </div>`, "legacy direct innerHTML migration"));
 
         document.body.appendChild(this.overlay);
-        this.focusTrap = createFocusTrap(this.overlay, { onEscape: () => this.close() });
+        this.focusTrap = createFocusTrap(this.overlay, {
+            onEscape: () => this.close(),
+            initialFocus: () => this.overlay?.querySelector<HTMLInputElement>('#aviation-cmd-input') ?? null,
+        });
         this.focusTrap.activate();
 
         this.overlay.addEventListener('click', (e) => {

--- a/src/components/AviationCommandBar.ts
+++ b/src/components/AviationCommandBar.ts
@@ -2,6 +2,7 @@ import { fetchFlightStatus, fetchAirportOpsSummary, fetchFlightPrices, fetchAvia
 import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 import { MONITORED_AIRPORTS } from '@/config/airports';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { createFocusTrap, type FocusTrap } from '@/utils/focus-trap';
 
 
 // ---- Intent types ----
@@ -290,6 +291,7 @@ const MAX_HISTORY = 20;
 
 export class AviationCommandBar {
     private overlay: HTMLElement | null = null;
+    private focusTrap: FocusTrap | null = null;
     private boundKeydown: (e: KeyboardEvent) => void;
 
     constructor() {
@@ -315,6 +317,9 @@ export class AviationCommandBar {
 
         this.overlay = document.createElement('div');
         this.overlay.id = 'aviation-cmd-overlay';
+        this.overlay.setAttribute('role', 'dialog');
+        this.overlay.setAttribute('aria-modal', 'true');
+        this.overlay.setAttribute('aria-label', 'Aviation Command');
         setTrustedHtml(this.overlay, trustedHtml(`
       <div id="aviation-cmd-box">
         <div id="aviation-cmd-header">
@@ -329,6 +334,8 @@ export class AviationCommandBar {
       </div>`, "legacy direct innerHTML migration"));
 
         document.body.appendChild(this.overlay);
+        this.focusTrap = createFocusTrap(this.overlay, { onEscape: () => this.close() });
+        this.focusTrap.activate();
 
         this.overlay.addEventListener('click', (e) => {
             if (e.target === this.overlay) { this.close(); return; }
@@ -364,6 +371,8 @@ export class AviationCommandBar {
     }
 
     private close(): void {
+        this.focusTrap?.deactivate();
+        this.focusTrap = null;
         this.overlay?.remove();
         this.overlay = null;
     }

--- a/src/components/IntelligenceGapBadge.ts
+++ b/src/components/IntelligenceGapBadge.ts
@@ -594,7 +594,9 @@ export class IntelligenceFindingsBadge {
     });
 
     document.body.appendChild(overlay);
-    this.findingsModalTrap = createFocusTrap(overlay);
+    this.findingsModalTrap = createFocusTrap(overlay, {
+      onEscape: () => this.dismissFindingsModal(),
+    });
     this.findingsModalTrap.activate();
   }
 

--- a/src/components/IntelligenceGapBadge.ts
+++ b/src/components/IntelligenceGapBadge.ts
@@ -6,6 +6,7 @@ import { getSignalContext } from '@/utils/analysis-constants';
 import { escapeHtml } from '@/utils/sanitize';
 import { trackFindingClicked } from '@/services/analytics';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { createFocusTrap, type FocusTrap } from '@/utils/focus-trap';
 
 
 const LOW_COUNT_THRESHOLD = 3;
@@ -69,6 +70,7 @@ export class IntelligenceFindingsBadge {
   private contextMenuDismissListener: (() => void) | null = null;
   private findingsModalOverlay: HTMLElement | null = null;
   private findingsModalEscListener: ((e: KeyboardEvent) => void) | null = null;
+  private findingsModalTrap: FocusTrap | null = null;
   private updateEpoch = 0;
   private destroyed = false;
 
@@ -514,6 +516,9 @@ export class IntelligenceFindingsBadge {
     // Create modal overlay
     const overlay = document.createElement('div');
     overlay.className = 'findings-modal-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-label', t('components.intelligenceFindings.all', { count: String(this.findings.length) }));
 
     const findingsHtml = this.findings.map(finding => {
       const timeAgo = this.formatTimeAgo(finding.timestamp);
@@ -521,7 +526,7 @@ export class IntelligenceFindingsBadge {
       const insight = this.getInsight(finding);
 
       return `
-        <div class="findings-modal-item ${finding.priority}" data-finding-id="${escapeHtml(finding.id)}">
+        <div class="findings-modal-item ${finding.priority}" data-finding-id="${escapeHtml(finding.id)}" role="button" tabindex="0">
           <div class="findings-modal-item-header">
             <span class="findings-modal-item-type">${icon} ${escapeHtml(finding.title)}</span>
             <span class="findings-modal-item-priority ${finding.priority}">${t(`components.intelligenceFindings.priority.${finding.priority}`)}</span>
@@ -566,6 +571,12 @@ export class IntelligenceFindingsBadge {
 
     // Handle clicking individual items
     overlay.querySelectorAll('.findings-modal-item').forEach(item => {
+      item.addEventListener('keydown', (e) => {
+        const key = (e as KeyboardEvent).key;
+        if (key !== 'Enter' && key !== ' ') return;
+        e.preventDefault();
+        (item as HTMLElement).click();
+      });
       item.addEventListener('click', () => {
         const id = item.getAttribute('data-finding-id');
         const finding = this.findings.find(f => f.id === id);
@@ -583,6 +594,8 @@ export class IntelligenceFindingsBadge {
     });
 
     document.body.appendChild(overlay);
+    this.findingsModalTrap = createFocusTrap(overlay);
+    this.findingsModalTrap.activate();
   }
 
   private dismissFindingsModal(): void {
@@ -590,6 +603,8 @@ export class IntelligenceFindingsBadge {
       document.removeEventListener('keydown', this.findingsModalEscListener);
       this.findingsModalEscListener = null;
     }
+    this.findingsModalTrap?.deactivate();
+    this.findingsModalTrap = null;
     if (this.findingsModalOverlay) {
       this.findingsModalOverlay.remove();
       this.findingsModalOverlay = null;

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -304,6 +304,7 @@ export class Panel {
     this.resizeHandle.title = t('components.panel.dragToResize');
     this.element.appendChild(this.resizeHandle);
     this.setupResizeHandlers();
+    this.setupKeyboardRowResize();
 
     // Right-edge handle for width resizing
     this.colResizeHandle = document.createElement('div');
@@ -311,6 +312,7 @@ export class Panel {
     this.colResizeHandle.title = t('components.panel.dragToResize');
     this.element.appendChild(this.colResizeHandle);
     this.setupColResizeHandlers();
+    this.setupKeyboardColResize();
 
     // Apply default row span (before restore, so saved preferences win)
     if (options.defaultRowSpan && options.defaultRowSpan > 1) {
@@ -394,6 +396,70 @@ export class Panel {
     if (this.onTouchCancel) {
       document.removeEventListener('touchcancel', this.onTouchCancel);
     }
+  }
+
+  /**
+   * Keyboard path for the mouse/touch drag handles (WAI-ARIA window-splitter):
+   * the handle is a focusable role="separator"; arrow keys step the span one
+   * unit and persist through the same code path as a completed drag.
+   */
+  private setupKeyboardRowResize(): void {
+    const handle = this.resizeHandle;
+    if (!handle) return;
+    handle.tabIndex = 0;
+    handle.setAttribute('role', 'separator');
+    handle.setAttribute('aria-orientation', 'horizontal');
+    handle.setAttribute('aria-label', t('components.panel.dragToResize'));
+    handle.setAttribute('aria-valuemin', '1');
+    handle.setAttribute('aria-valuemax', '4');
+    const sync = () => handle.setAttribute('aria-valuenow', String(getRowSpan(this.element)));
+    sync();
+    handle.addEventListener('keydown', (e: KeyboardEvent) => {
+      const current = getRowSpan(this.element);
+      let next: number | null = null;
+      if (e.key === 'ArrowUp') next = Math.max(1, current - 1);
+      else if (e.key === 'ArrowDown') next = Math.min(4, current + 1);
+      else if (e.key === 'Home') next = 1;
+      else if (e.key === 'End') next = 4;
+      if (next === null) return;
+      e.preventDefault();
+      if (next === current) return;
+      setSpanClass(this.element, next);
+      savePanelSpan(this.panelId, next);
+      trackPanelResized(this.panelId, next);
+      sync();
+    });
+  }
+
+  private setupKeyboardColResize(): void {
+    const handle = this.colResizeHandle;
+    if (!handle) return;
+    handle.tabIndex = 0;
+    handle.setAttribute('role', 'separator');
+    handle.setAttribute('aria-orientation', 'vertical');
+    handle.setAttribute('aria-label', t('components.panel.dragToResize'));
+    handle.setAttribute('aria-valuemin', '1');
+    const sync = () => {
+      const maxSpan = getMaxColSpan(this.element);
+      handle.setAttribute('aria-valuemax', String(maxSpan));
+      handle.setAttribute('aria-valuenow', String(clampColSpan(getColSpan(this.element), maxSpan)));
+    };
+    sync();
+    handle.addEventListener('keydown', (e: KeyboardEvent) => {
+      const maxSpan = getMaxColSpan(this.element);
+      const current = clampColSpan(getColSpan(this.element), maxSpan);
+      let next: number | null = null;
+      if (e.key === 'ArrowLeft') next = Math.max(1, current - 1);
+      else if (e.key === 'ArrowRight') next = Math.min(maxSpan, current + 1);
+      else if (e.key === 'Home') next = 1;
+      else if (e.key === 'End') next = maxSpan;
+      if (next === null) return;
+      e.preventDefault();
+      if (next === current) return;
+      setColSpanClass(this.element, next);
+      persistPanelColSpan(this.panelId, this.element);
+      sync();
+    });
   }
 
   private setupResizeHandlers(): void {

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -304,7 +304,6 @@ export class Panel {
     this.resizeHandle.title = t('components.panel.dragToResize');
     this.element.appendChild(this.resizeHandle);
     this.setupResizeHandlers();
-    this.setupKeyboardRowResize();
 
     // Right-edge handle for width resizing
     this.colResizeHandle = document.createElement('div');
@@ -312,7 +311,6 @@ export class Panel {
     this.colResizeHandle.title = t('components.panel.dragToResize');
     this.element.appendChild(this.colResizeHandle);
     this.setupColResizeHandlers();
-    this.setupKeyboardColResize();
 
     // Apply default row span (before restore, so saved preferences win)
     if (options.defaultRowSpan && options.defaultRowSpan > 1) {
@@ -329,6 +327,8 @@ export class Panel {
     // Restore saved col-span
     this.restoreSavedColSpan();
     this.reconcileColSpanAfterAttach();
+    this.setupKeyboardRowResize();
+    this.setupKeyboardColResize();
 
     this.showLoading();
   }
@@ -369,6 +369,7 @@ export class Panel {
       }
       this.colSpanReconcileRaf = null;
       this.restoreSavedColSpan();
+      this.syncKeyboardColResizeAria();
     };
 
     tryReconcile(attempts);
@@ -412,8 +413,7 @@ export class Panel {
     handle.setAttribute('aria-label', t('components.panel.dragToResize'));
     handle.setAttribute('aria-valuemin', '1');
     handle.setAttribute('aria-valuemax', '4');
-    const sync = () => handle.setAttribute('aria-valuenow', String(getRowSpan(this.element)));
-    sync();
+    this.syncKeyboardRowResizeAria();
     handle.addEventListener('keydown', (e: KeyboardEvent) => {
       const current = getRowSpan(this.element);
       let next: number | null = null;
@@ -427,7 +427,7 @@ export class Panel {
       setSpanClass(this.element, next);
       savePanelSpan(this.panelId, next);
       trackPanelResized(this.panelId, next);
-      sync();
+      this.syncKeyboardRowResizeAria();
     });
   }
 
@@ -439,12 +439,7 @@ export class Panel {
     handle.setAttribute('aria-orientation', 'vertical');
     handle.setAttribute('aria-label', t('components.panel.dragToResize'));
     handle.setAttribute('aria-valuemin', '1');
-    const sync = () => {
-      const maxSpan = getMaxColSpan(this.element);
-      handle.setAttribute('aria-valuemax', String(maxSpan));
-      handle.setAttribute('aria-valuenow', String(clampColSpan(getColSpan(this.element), maxSpan)));
-    };
-    sync();
+    this.syncKeyboardColResizeAria();
     handle.addEventListener('keydown', (e: KeyboardEvent) => {
       const maxSpan = getMaxColSpan(this.element);
       const current = clampColSpan(getColSpan(this.element), maxSpan);
@@ -458,8 +453,22 @@ export class Panel {
       if (next === current) return;
       setColSpanClass(this.element, next);
       persistPanelColSpan(this.panelId, this.element);
-      sync();
+      this.syncKeyboardColResizeAria();
     });
+  }
+
+  private syncKeyboardRowResizeAria(): void {
+    this.resizeHandle?.setAttribute('aria-valuenow', String(getRowSpan(this.element)));
+  }
+
+  private syncKeyboardColResizeAria(): void {
+    if (!this.colResizeHandle) return;
+    const maxSpan = getMaxColSpan(this.element);
+    this.colResizeHandle.setAttribute('aria-valuemax', String(maxSpan));
+    this.colResizeHandle.setAttribute(
+      'aria-valuenow',
+      String(clampColSpan(getColSpan(this.element), maxSpan)),
+    );
   }
 
   private setupResizeHandlers(): void {
@@ -491,6 +500,7 @@ export class Panel {
       const currentSpan = getRowSpan(this.element);
       savePanelSpan(this.panelId, currentSpan);
       trackPanelResized(this.panelId, currentSpan);
+      this.syncKeyboardRowResizeAria();
     };
 
     this.onRowWindowBlur = () => this.onRowMouseUp?.();
@@ -563,6 +573,7 @@ export class Panel {
       const currentSpan = getRowSpan(this.element);
       savePanelSpan(this.panelId, currentSpan);
       trackPanelResized(this.panelId, currentSpan);
+      this.syncKeyboardRowResizeAria();
     };
     this.onTouchCancel = this.onTouchEnd;
 
@@ -632,6 +643,7 @@ export class Panel {
       if (finalSpan !== this.startColSpan) {
         persistPanelColSpan(this.panelId, this.element);
       }
+      this.syncKeyboardColResizeAria();
     };
 
     this.onColWindowBlur = () => this.onColMouseUp?.();
@@ -703,6 +715,7 @@ export class Panel {
       if (finalSpan !== this.startColSpan) {
         persistPanelColSpan(this.panelId, this.element);
       }
+      this.syncKeyboardColResizeAria();
     };
     this.onColTouchCancel = this.onColTouchEnd;
   }
@@ -1518,11 +1531,13 @@ export class Panel {
   public resetHeight(): void {
     this.element.classList.remove('resized', 'span-1', 'span-2', 'span-3', 'span-4');
     clearPanelSpan(this.panelId);
+    this.syncKeyboardRowResizeAria();
   }
 
   public resetWidth(): void {
     clearColSpanClass(this.element);
     clearPanelColSpan(this.panelId);
+    this.syncKeyboardColResizeAria();
   }
 
   protected get signal(): AbortSignal {

--- a/src/components/RouteExplorer/RouteExplorer.ts
+++ b/src/components/RouteExplorer/RouteExplorer.ts
@@ -593,12 +593,26 @@ export class RouteExplorer {
     return false;
   }
 
+  /**
+   * AviationCommandBar and the findings modal mount on `document.body` with
+   * aria-modal=true while Route Explorer is still open. The Explorer capture
+   * listener is registered first, so without this check Escape (and the
+   * number/letter shortcuts) steal keys from the stacked dialog.
+   */
+  private isStackedModalFocused(): boolean {
+    const el = document.activeElement;
+    if (!(el instanceof Element) || !this.root) return false;
+    const modal = el.closest('[aria-modal="true"]');
+    return modal !== null && !this.root.contains(modal);
+  }
+
   private blurActiveInput(): void {
     (document.activeElement as HTMLElement | null)?.blur();
   }
 
   private handleGlobalKeydown = (e: KeyboardEvent): void => {
     if (!this.isOpen || !this.root) return;
+    if (this.isStackedModalFocused()) return;
 
     if (e.key === 'Escape') {
       if (this.helpOverlay) {

--- a/src/components/RouteExplorer/components/RouteCard.ts
+++ b/src/components/RouteExplorer/components/RouteCard.ts
@@ -31,7 +31,9 @@ export function renderRouteCard(opts: RouteCardOptions): HTMLDivElement {
   card.className = `re-route-card ${statusCls} ${isActive ? 're-route-card--active' : ''}`;
   card.setAttribute('role', 'option');
   card.setAttribute('aria-selected', isActive ? 'true' : 'false');
-  card.setAttribute('tabindex', '0');
+  // Roving tabindex: one tab stop for the whole listbox; ArrowUp/ArrowDown
+  // (handled by AlternativesTab) move between options.
+  card.setAttribute('tabindex', isActive ? '0' : '-1');
   card.dataset.idx = String(index);
   card.dataset.corridorId = o.id;
 

--- a/src/components/RouteExplorer/components/RouteCard.ts
+++ b/src/components/RouteExplorer/components/RouteCard.ts
@@ -20,6 +20,14 @@ export interface RouteCardOptions {
   option: BypassCorridorOption;
   index: number;
   isActive: boolean;
+  /**
+   * Opt into a single tab stop for the listbox. Inactive options then use
+   * tabindex=-1 so ArrowUp/ArrowDown (handled by the parent) move selection.
+   * Leave unset for listboxes that have no arrow-key manager (LandTab).
+   */
+  roving?: boolean;
+  /** Which option is the listbox tab stop when `roving` is set. Defaults to `isActive`. */
+  tabStop?: boolean;
   onSelect: (option: BypassCorridorOption) => void;
 }
 
@@ -31,9 +39,8 @@ export function renderRouteCard(opts: RouteCardOptions): HTMLDivElement {
   card.className = `re-route-card ${statusCls} ${isActive ? 're-route-card--active' : ''}`;
   card.setAttribute('role', 'option');
   card.setAttribute('aria-selected', isActive ? 'true' : 'false');
-  // Roving tabindex: one tab stop for the whole listbox; ArrowUp/ArrowDown
-  // (handled by AlternativesTab) move between options.
-  card.setAttribute('tabindex', isActive ? '0' : '-1');
+  const isTabStop = opts.tabStop ?? isActive;
+  card.setAttribute('tabindex', opts.roving && !isTabStop ? '-1' : '0');
   card.dataset.idx = String(index);
   card.dataset.corridorId = o.id;
 

--- a/src/components/RouteExplorer/tabs/AlternativesTab.ts
+++ b/src/components/RouteExplorer/tabs/AlternativesTab.ts
@@ -98,18 +98,16 @@ export class AlternativesTab {
     if (this.seaOptions.length === 0) return;
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      const next = this.activeIndex < 0
-        ? this.tabStopIndex()
-        : Math.min(this.activeIndex + 1, this.seaOptions.length - 1);
+      const current = this.activeIndex < 0 ? this.tabStopIndex() : this.activeIndex;
+      const next = Math.min(current + 1, this.seaOptions.length - 1);
       if (next === this.activeIndex) return;
       this.activeIndex = next;
       this.renderList();
       this.focusActive();
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      const next = this.activeIndex < 0
-        ? this.tabStopIndex()
-        : Math.max(this.activeIndex - 1, 0);
+      const current = this.activeIndex < 0 ? this.tabStopIndex() : this.activeIndex;
+      const next = Math.max(current - 1, 0);
       if (next === this.activeIndex) return;
       this.activeIndex = next;
       this.renderList();

--- a/src/components/RouteExplorer/tabs/AlternativesTab.ts
+++ b/src/components/RouteExplorer/tabs/AlternativesTab.ts
@@ -66,11 +66,14 @@ export class AlternativesTab {
     listEl.setAttribute('role', 'listbox');
     listEl.setAttribute('aria-label', 'Alternative sea routes');
 
+    const tabStopIndex = this.tabStopIndex();
     this.seaOptions.forEach((option, idx) => {
       const card = renderRouteCard({
         option,
         index: idx,
         isActive: idx === this.activeIndex,
+        roving: true,
+        tabStop: idx === tabStopIndex,
         onSelect: (o) => {
           this.activeIndex = idx;
           this.renderList();
@@ -83,18 +86,30 @@ export class AlternativesTab {
     this.element.append(listEl);
   }
 
+  private tabStopIndex(): number {
+    if (this.activeIndex >= 0) return this.activeIndex;
+    const firstEnabled = this.seaOptions.findIndex((option) =>
+      option.status !== 'CORRIDOR_STATUS_UNAVAILABLE' && option.status !== 'CORRIDOR_STATUS_PROPOSED',
+    );
+    return firstEnabled >= 0 ? firstEnabled : 0;
+  }
+
   private handleKeydown = (e: KeyboardEvent): void => {
     if (this.seaOptions.length === 0) return;
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      const next = Math.min(this.activeIndex + 1, this.seaOptions.length - 1);
+      const next = this.activeIndex < 0
+        ? this.tabStopIndex()
+        : Math.min(this.activeIndex + 1, this.seaOptions.length - 1);
       if (next === this.activeIndex) return;
       this.activeIndex = next;
       this.renderList();
       this.focusActive();
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
-      const next = Math.max(this.activeIndex - 1, 0);
+      const next = this.activeIndex < 0
+        ? this.tabStopIndex()
+        : Math.max(this.activeIndex - 1, 0);
       if (next === this.activeIndex) return;
       this.activeIndex = next;
       this.renderList();

--- a/src/components/RouteExplorer/tabs/CountryImpactTab.ts
+++ b/src/components/RouteExplorer/tabs/CountryImpactTab.ts
@@ -184,7 +184,7 @@ export class CountryImpactTab {
       const drill = () => this.opts.onDrillSideways?.(hs2);
       row.addEventListener('click', drill);
       row.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') { e.preventDefault(); drill(); }
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); drill(); }
       });
     });
   }

--- a/src/components/RouteExplorer/tabs/CurrentRouteTab.ts
+++ b/src/components/RouteExplorer/tabs/CurrentRouteTab.ts
@@ -117,7 +117,7 @@ export class CurrentRouteTab {
       const select = () => this.opts.onChokepointSelect?.(cpId);
       row.addEventListener('click', select);
       row.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') { e.preventDefault(); select(); }
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); select(); }
       });
     });
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1979,6 +1979,44 @@ body.panel-resize-active iframe {
   transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 
+/* Keyboard reorder affordance (see makeDraggable): invisible until keyboard
+   focus reaches it, so pointer users see no change in the header. */
+.panel-move-btn {
+  position: absolute;
+  left: 2px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  background: var(--surface);
+  color: var(--text);
+}
+
+.panel-move-btn:focus-visible {
+  width: auto;
+  height: auto;
+  padding: 2px 6px;
+  overflow: visible;
+  clip-path: none;
+  outline: 2px solid var(--text);
+  outline-offset: 1px;
+  z-index: 3;
+}
+
+/* The resize strips are keyboard-focusable separators (arrow keys resize);
+   show where focus is when it lands on one. */
+.panel-resize-handle:focus-visible,
+.panel-col-resize-handle:focus-visible,
+.map-resize-handle:focus-visible,
+.map-width-resize-handle:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: -2px;
+}
+
 .panel-header-error {
   background: rgba(255, 50, 50, 0.15);
   border-bottom-color: rgba(255, 80, 80, 0.5);

--- a/tests/dom/map-fullscreen-resize.test.mts
+++ b/tests/dom/map-fullscreen-resize.test.mts
@@ -60,4 +60,72 @@ describe('map fullscreen resize synchronization', () => {
 
     expectImmediateAndSettledResize(() => fullscreenButton.click());
   });
+
+  it('keeps the map-height separator value synchronized', () => {
+    const section = document.createElement('section');
+    section.id = 'mapSection';
+    Object.defineProperty(section, 'offsetHeight', { configurable: true, value: 500 });
+    const mapContainer = document.createElement('div');
+    mapContainer.id = 'mapContainer';
+    const handle = document.createElement('div');
+    handle.id = 'mapResizeHandle';
+    const bottomGrid = document.createElement('div');
+    bottomGrid.id = 'mapBottomGrid';
+    section.append(mapContainer, handle, bottomGrid);
+    document.body.append(section);
+
+    manager.setupMapResize();
+
+    expect(handle.getAttribute('aria-controls')).toBe('mapSection');
+    expect(handle.getAttribute('aria-valuemin')).toBe('350');
+    expect(handle.getAttribute('aria-valuenow')).toBe('500');
+
+    handle.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(section.style.height).toBe('540px');
+    expect(handle.getAttribute('aria-valuenow')).toBe('540');
+
+    handle.dispatchEvent(new MouseEvent('mousedown', { clientY: 100, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientY: 120, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    expect(section.style.height).toBe('520px');
+    expect(handle.getAttribute('aria-valuenow')).toBe('520');
+  });
+
+  it('keeps the map-width separator value synchronized', () => {
+    const main = document.createElement('main');
+    main.className = 'main-content';
+    Object.defineProperty(main, 'offsetWidth', { configurable: true, value: 1000 });
+    main.style.setProperty('--map-col-width', '60%');
+    const section = document.createElement('section');
+    section.id = 'mapSection';
+    const handle = document.createElement('div');
+    handle.id = 'mapWidthResizeHandle';
+    main.append(section, handle);
+    document.body.append(main);
+
+    manager.setupMapWidthResize();
+
+    expect(handle.getAttribute('aria-controls')).toBe('mapSection');
+    expect(handle.getAttribute('aria-valuemin')).toBe('25');
+    expect(handle.getAttribute('aria-valuemax')).toBe('75');
+    expect(handle.getAttribute('aria-valuenow')).toBe('60');
+
+    handle.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'ArrowRight',
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(main.style.getPropertyValue('--map-col-width')).toBe('65.0%');
+    expect(handle.getAttribute('aria-valuenow')).toBe('65');
+
+    handle.dispatchEvent(new MouseEvent('mousedown', { clientX: 100, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200, bubbles: true }));
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    expect(main.style.getPropertyValue('--map-col-width')).toBe('70.0%');
+    expect(handle.getAttribute('aria-valuenow')).toBe('70');
+  });
 });

--- a/tests/dom/map-fullscreen-resize.test.mts
+++ b/tests/dom/map-fullscreen-resize.test.mts
@@ -125,7 +125,7 @@ describe('map fullscreen resize synchronization', () => {
     handle.dispatchEvent(new MouseEvent('mousedown', { clientX: 100, bubbles: true }));
     document.dispatchEvent(new MouseEvent('mousemove', { clientX: 200, bubbles: true }));
     document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
-    expect(main.style.getPropertyValue('--map-col-width')).toBe('70.0%');
-    expect(handle.getAttribute('aria-valuenow')).toBe('70');
+    expect(main.style.getPropertyValue('--map-col-width')).toBe('75.0%');
+    expect(handle.getAttribute('aria-valuenow')).toBe('75');
   });
 });

--- a/tests/dom/panel-keyboard-resize-a11y.test.mts
+++ b/tests/dom/panel-keyboard-resize-a11y.test.mts
@@ -1,0 +1,56 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { Panel } from '@/components/Panel';
+import {
+  clearPanelColSpans,
+  clearPanelSpans,
+  savePanelColSpan,
+  savePanelSpan,
+} from '@/utils/panel-storage';
+
+import { initTestI18n } from './helpers/i18n.mts';
+
+beforeAll(async () => {
+  await initTestI18n();
+});
+
+afterEach(() => {
+  clearPanelSpans();
+  clearPanelColSpans();
+  document.body.replaceChildren();
+});
+
+describe('Panel keyboard resize accessibility', () => {
+  it('exposes restored row and column spans as the initial separator values', () => {
+    savePanelSpan('resize-a11y-probe', 3);
+    savePanelColSpan('resize-a11y-probe', 2);
+
+    const panel = new Panel({ id: 'resize-a11y-probe', title: 'Probe' });
+    const element = panel.getElement();
+    const rowHandle = element.querySelector('.panel-resize-handle');
+    const colHandle = element.querySelector('.panel-col-resize-handle');
+
+    expect(rowHandle?.getAttribute('aria-valuenow')).toBe('3');
+    expect(colHandle?.getAttribute('aria-valuenow')).toBe('2');
+
+    panel.destroy();
+  });
+
+  it('updates separator values when saved dimensions are reset', () => {
+    savePanelSpan('resize-reset-probe', 4);
+    savePanelColSpan('resize-reset-probe', 3);
+
+    const panel = new Panel({ id: 'resize-reset-probe', title: 'Probe' });
+    const element = panel.getElement();
+    const rowHandle = element.querySelector('.panel-resize-handle');
+    const colHandle = element.querySelector('.panel-col-resize-handle');
+
+    panel.resetHeight();
+    panel.resetWidth();
+
+    expect(rowHandle?.getAttribute('aria-valuenow')).toBe('1');
+    expect(colHandle?.getAttribute('aria-valuenow')).toBe('1');
+
+    panel.destroy();
+  });
+});

--- a/tests/intelligence-gap-badge-polling.test.mts
+++ b/tests/intelligence-gap-badge-polling.test.mts
@@ -43,4 +43,12 @@ describe('IntelligenceGapBadge teardown', () => {
     const destroyBody = src.slice(src.indexOf('public destroy(): void'));
     assert.match(destroyBody, /this\.dismissFindingsModal\(\);/, 'destroy() must dismiss the findings modal');
   });
+
+  it('focus trap dismisses the findings modal on Escape', () => {
+    assert.match(
+      src,
+      /createFocusTrap\(overlay,\s*\{\s*onEscape:\s*\(\)\s*=>\s*this\.dismissFindingsModal\(\)/,
+      'findings modal trap must own Escape so stacked RouteExplorer capture does not win',
+    );
+  });
 });

--- a/tests/keyboard-overlay-a11y.test.mts
+++ b/tests/keyboard-overlay-a11y.test.mts
@@ -1,0 +1,218 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { after, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { AlternativesTab } from '../src/components/RouteExplorer/tabs/AlternativesTab.ts';
+import { LandTab } from '../src/components/RouteExplorer/tabs/LandTab.ts';
+import { renderRouteCard } from '../src/components/RouteExplorer/components/RouteCard.ts';
+import type {
+  BypassCorridorOption,
+  GetRouteExplorerLaneResponse,
+} from '../src/generated/server/worldmonitor/supply_chain/v1/service_server.ts';
+import { createBrowserEnvironment } from './helpers/mini-dom.mts';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (...parts: string[]) => readFileSync(resolve(root, ...parts), 'utf8');
+
+function snapshotGlobal(name: string) {
+  return {
+    exists: Object.prototype.hasOwnProperty.call(globalThis, name),
+    value: (globalThis as Record<string, unknown>)[name],
+  };
+}
+
+function restoreGlobal(name: string, snapshot: { exists: boolean; value: unknown }) {
+  if (snapshot.exists) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value: snapshot.value,
+    });
+    return;
+  }
+  delete (globalThis as Record<string, unknown>)[name];
+}
+
+function defineGlobal(name: string, value: unknown) {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+const originalGlobals = {
+  document: snapshotGlobal('document'),
+  window: snapshotGlobal('window'),
+  HTMLElement: snapshotGlobal('HTMLElement'),
+  Node: snapshotGlobal('Node'),
+};
+
+const browser = createBrowserEnvironment();
+const MiniNode = Object.getPrototypeOf(browser.HTMLElement.prototype).constructor;
+
+defineGlobal('document', browser.document);
+defineGlobal('window', browser.window);
+defineGlobal('HTMLElement', browser.HTMLElement);
+defineGlobal('Node', MiniNode);
+
+after(() => {
+  restoreGlobal('document', originalGlobals.document);
+  restoreGlobal('window', originalGlobals.window);
+  restoreGlobal('HTMLElement', originalGlobals.HTMLElement);
+  restoreGlobal('Node', originalGlobals.Node);
+});
+
+function corridor(overrides: Partial<BypassCorridorOption> = {}): BypassCorridorOption {
+  return {
+    id: 'suez-cape',
+    name: 'Cape of Good Hope',
+    type: 'sea',
+    addedTransitDays: 12,
+    addedCostMultiplier: 1.18,
+    warRiskTier: 'WAR_RISK_TIER_NORMAL',
+    status: 'CORRIDOR_STATUS_ACTIVE',
+    ...overrides,
+  };
+}
+
+function lane(bypassOptions: BypassCorridorOption[]): GetRouteExplorerLaneResponse {
+  return {
+    fromIso2: 'CN',
+    toIso2: 'NL',
+    hs2: '85',
+    cargoType: 'EXPLORER_CARGO_CONTAINER',
+    primaryRouteId: 'suez',
+    primaryRouteGeometry: [],
+    chokepointExposures: [],
+    bypassOptions,
+    warRiskTier: 'WAR_RISK_TIER_NORMAL',
+    disruptionScore: 40,
+    noModeledLane: false,
+    fetchedAt: '2024-01-15T00:00:00.000Z',
+  };
+}
+
+describe('RouteCard roving tabindex', () => {
+  it('keeps every option in the tab order unless roving is opted in', () => {
+    const inactive = renderRouteCard({
+      option: corridor(),
+      index: 1,
+      isActive: false,
+      onSelect() {},
+    });
+    assert.equal(inactive.getAttribute('tabindex'), '0');
+  });
+
+  it('uses tabindex=-1 for inactive roving options', () => {
+    const inactive = renderRouteCard({
+      option: corridor(),
+      index: 1,
+      isActive: false,
+      roving: true,
+      onSelect() {},
+    });
+    assert.equal(inactive.getAttribute('tabindex'), '-1');
+  });
+
+  it('keeps a fallback tab stop tabbable before any option is selected', () => {
+    const first = renderRouteCard({
+      option: corridor({ id: 'first' }),
+      index: 0,
+      isActive: false,
+      roving: true,
+      tabStop: true,
+      onSelect() {},
+    });
+    const second = renderRouteCard({
+      option: corridor({ id: 'second' }),
+      index: 1,
+      isActive: false,
+      roving: true,
+      tabStop: false,
+      onSelect() {},
+    });
+    assert.equal(first.getAttribute('tabindex'), '0');
+    assert.equal(second.getAttribute('tabindex'), '-1');
+    assert.equal(first.getAttribute('aria-selected'), 'false');
+  });
+});
+
+describe('AlternativesTab listbox tab stops', () => {
+  it('leaves exactly one tab stop when nothing is selected yet', () => {
+    const tab = new AlternativesTab({ onSelectBypass() {} });
+    tab.update(lane([
+      corridor({ id: 'cape', name: 'Cape' }),
+      corridor({ id: 'panama', name: 'Panama' }),
+    ]));
+
+    const cards = tab.element.querySelectorAll('.re-route-card');
+    assert.equal(cards.length, 2);
+    assert.deepEqual(
+      cards.map((card) => card.getAttribute('tabindex')),
+      ['0', '-1'],
+    );
+  });
+
+  it('moves the tab stop onto the first enabled option when the first cards are disabled', () => {
+    const tab = new AlternativesTab({ onSelectBypass() {} });
+    tab.update(lane([
+      corridor({ id: 'proposed', status: 'CORRIDOR_STATUS_PROPOSED' }),
+      corridor({ id: 'active', status: 'CORRIDOR_STATUS_ACTIVE' }),
+    ]));
+
+    const cards = tab.element.querySelectorAll('.re-route-card');
+    assert.deepEqual(
+      cards.map((card) => card.getAttribute('tabindex')),
+      ['-1', '0'],
+    );
+  });
+});
+
+describe('LandTab listbox tab stops', () => {
+  it('keeps land corridor cards tabbable even though none are marked active', () => {
+    const tab = new LandTab({ onSelectBypass() {} });
+    tab.update(lane([
+      corridor({ id: 'aqaba', name: 'Aqaba', type: 'land_bridge' }),
+      corridor({ id: 'djibouti', name: 'Djibouti-Addis', type: 'land_bridge' }),
+    ]));
+
+    const cards = tab.element.querySelectorAll('.re-route-card');
+    assert.equal(cards.length, 2);
+    assert.deepEqual(
+      cards.map((card) => card.getAttribute('tabindex')),
+      ['0', '0'],
+    );
+  });
+});
+
+describe('stacked overlay keyboard contracts', () => {
+  it('RouteExplorer capture listener yields when focus is inside a stacked aria-modal', () => {
+    const source = read('src/components/RouteExplorer/RouteExplorer.ts');
+    assert.match(source, /private isStackedModalFocused\(\): boolean/);
+    assert.match(source, /el\.closest\('\[aria-modal="true"\]'\)/);
+    assert.match(
+      source,
+      /if \(this\.isStackedModalFocused\(\)\) return;/,
+      'handleGlobalKeydown must return before Escape closes the Explorer',
+    );
+  });
+
+  it('AviationCommandBar focuses the command input when the trap activates', () => {
+    const source = read('src/components/AviationCommandBar.ts');
+    assert.match(
+      source,
+      /initialFocus:\s*\(\)\s*=>\s*this\.overlay\?\.querySelector<HTMLInputElement>\('#aviation-cmd-input'\)/,
+    );
+  });
+
+  it('findings modal trap dismisses on Escape', () => {
+    const source = read('src/components/IntelligenceGapBadge.ts');
+    assert.match(
+      source,
+      /createFocusTrap\(overlay,\s*\{\s*onEscape:\s*\(\)\s*=>\s*this\.dismissFindingsModal\(\)/,
+    );
+  });
+});

--- a/tests/keyboard-overlay-a11y.test.mts
+++ b/tests/keyboard-overlay-a11y.test.mts
@@ -12,6 +12,7 @@ import type {
   GetRouteExplorerLaneResponse,
 } from '../src/generated/server/worldmonitor/supply_chain/v1/service_server.ts';
 import { createBrowserEnvironment } from './helpers/mini-dom.mts';
+import { movePanelToKeyboardZone } from '../src/app/panel-keyboard-reorder.ts';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const read = (...parts: string[]) => readFileSync(resolve(root, ...parts), 'utf8');
@@ -168,6 +169,60 @@ describe('AlternativesTab listbox tab stops', () => {
       cards.map((card) => card.getAttribute('tabindex')),
       ['-1', '0'],
     );
+  });
+
+  it('moves to the next option on the first ArrowDown press', () => {
+    const tab = new AlternativesTab({ onSelectBypass() {} });
+    tab.update(lane([
+      corridor({ id: 'cape', name: 'Cape' }),
+      corridor({ id: 'panama', name: 'Panama' }),
+    ]));
+
+    const event = Object.assign(new Event('keydown', { cancelable: true }), { key: 'ArrowDown' });
+    tab.element.dispatchEvent(event);
+
+    const cards = tab.element.querySelectorAll('.re-route-card');
+    assert.equal(event.defaultPrevented, true);
+    assert.equal(cards[0]?.getAttribute('aria-selected'), 'false');
+    assert.equal(cards[1]?.getAttribute('aria-selected'), 'true');
+  });
+});
+
+describe('panel keyboard zone moves', () => {
+  it('moves a panel between both grids and keeps bottom-set persistence aligned', () => {
+    const sidebarGrid = document.createElement('div');
+    sidebarGrid.className = 'panels-grid';
+    const bottomGrid = document.createElement('div');
+    bottomGrid.className = 'map-bottom-grid';
+    const panel = document.createElement('section');
+    panel.className = 'panel';
+    const addPanelBlock = document.createElement('button');
+    addPanelBlock.className = 'add-panel-block';
+    sidebarGrid.append(panel, addPanelBlock);
+    const bottomSet = new Set<string>();
+
+    assert.equal(movePanelToKeyboardZone({
+      panel,
+      panelKey: 'live-news',
+      targetZone: 'bottom',
+      sidebarGrid,
+      bottomGrid,
+      bottomSet,
+    }), true);
+    assert.equal(panel.parentElement, bottomGrid);
+    assert.equal(bottomSet.has('live-news'), true);
+
+    assert.equal(movePanelToKeyboardZone({
+      panel,
+      panelKey: 'live-news',
+      targetZone: 'sidebar',
+      sidebarGrid,
+      bottomGrid,
+      bottomSet,
+    }), true);
+    assert.equal(panel.parentElement, sidebarGrid);
+    assert.equal(panel.nextElementSibling, addPanelBlock);
+    assert.equal(bottomSet.has('live-news'), false);
   });
 });
 


### PR DESCRIPTION
Part of #6573 (accessibility remediation, PR 6 of 7): keyboard paths for pointer-only interactions.

## Problem

Layout customization was entirely pointer-only. Panel drag-reorder, panel row/column resize, and map height/width resize all listen to `mousedown`/`mousemove`/`touchstart` with no keyboard equivalent — and the results persist, so a keyboard-only user could never arrange their own dashboard. Several smaller widgets had partial keyboard support (Enter but not Space, every listbox option a tab stop), and two overlays deferred from #6685 still lacked dialog semantics.

## What this does

**Panel reorder** — `makeDraggable()` now also injects a move button into each panel header, visually hidden until keyboard focus reaches it (same clip technique as the skip link), so pointer users see no change. Arrow keys move the panel one slot per press, persisting through the exact same `savePanelOrder()` path as a completed drag; focus rides along with the panel so repeated presses keep moving it. Within-grid only — grid-to-grid moves (main grid ↔ map bottom grid) still need a pointer, noted in a code comment.

**Resize handles** (WAI-ARIA window-splitter pattern) — the panel row/column drag strips (`Panel.ts`) and the map height/width strips (`event-handlers.ts`) become focusable `role="separator"` elements with `aria-orientation` and, for the panel spans, `aria-valuemin/max/now`. Arrow keys step the row span (1–4), column span (1–max), map height (±40px, clamped to the existing min/max), and map width (±5%, clamped 25–75%), each persisting exactly like a finished drag. `:focus-visible` rings added for all four strips.

**RouteExplorer** — the alternatives listbox switches to a roving tabindex (the active card is the single tab stop, matching the ArrowUp/ArrowDown handler the tab already has) instead of every `role="option"` card being individually tabbable; the chokepoint and product `<tr tabindex="0">` rows accept Space as well as Enter (they keep their native row semantics — `role="button"` on a `<tr>` would break the table for AT).

**Deferred overlays from #6685** — the AviationCommandBar Ctrl+J palette and the IntelligenceGapBadge findings modal gain `role="dialog"` + `aria-modal` + `aria-label` and the shared `createFocusTrap` with focus restore. Findings items — previously click-only `<div>`s — become keyboard-activatable (`role="button"`, `tabindex="0"`, Enter/Space).

**Download dropdown** — the trigger now exposes `aria-haspopup`/`aria-expanded`, kept in sync across toggle click, outside click, and Escape.

Still open after this PR (noted in #6573): live-news channel reorder and world-clock row reorder are lower-traffic drag interactions that can follow the same header-button pattern.

## Verification

- `npm run typecheck` — clean
- `biome lint` on all 8 touched TS files — clean
- `npm run lint:safe-html` — clean
- `node --test tests/a11y-issue-4373-invariants.test.mjs tests/a11y-issue-5059-invariants.test.mjs tests/marker-pulse-settle.test.mjs` — 46/46 pass (4373 asserts the map handles' target size from the real CSS; unaffected)
