### PR TITLE
test(a11y): axe-core WCAG A/AA scan for the dashboard and settings dialog

### DIFF
--- a/e2e/a11y-axe-scan.spec.ts
+++ b/e2e/a11y-axe-scan.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test, type Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+import {
+  compareAxeViolationBaseline,
+  type KnownAxeViolationBaseline,
+} from './axe-violation-baseline';
 
 /**
  * Automated axe-core scan of the hydrated dashboard (#6573).
@@ -10,9 +14,9 @@ import AxeBuilder from '@axe-core/playwright';
  * violation appears for any rule NOT already on the known-violations list
  * below.
  *
- * The known-violation lists are shrink-only escape hatches: an entry that
- * stops firing fails the test until it is deleted, so the lists always
- * reflect reality. Both are empty as of introduction.
+ * The known-violation baselines identify exact rule-and-target pairs. A new
+ * node under an already-known rule fails, and a target that stops firing must
+ * be deleted. Both baselines are empty as of introduction.
  *
  * CI invokes this file via `npm run test:e2e:ci-smoke` (nothing in CI runs
  * the `e2e/` glob). `REQUIRED_CI_SMOKE_SPECS` pins the argv token.
@@ -21,7 +25,7 @@ import AxeBuilder from '@axe-core/playwright';
 async function loadDashboard(page: Page): Promise<void> {
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(
-    () => document.documentElement.dataset.wmEventHandlersReady === 'true',
+    () => document.documentElement.dataset.wmInitialDataReady === 'true',
     undefined,
     { timeout: 60_000 },
   );
@@ -30,19 +34,22 @@ async function loadDashboard(page: Page): Promise<void> {
 }
 
 // Empty as of introduction (the #6573 remediation PRs cleared the backlog axe
-// can detect). If a violation must temporarily ship, add its rule id here WITH
-// a link to a tracking issue — the shrink-only guard below deletes entries the
-// moment they stop firing, so the list cannot rot.
-const KNOWN_VIOLATION_RULES: string[] = [];
+// can detect). If a violation must temporarily ship, record every exact target
+// fingerprint under its rule WITH a link to a tracking issue. Empty rule entries
+// are rejected so this cannot degrade back into a rule-wide allowlist.
+const KNOWN_VIOLATIONS = {} satisfies KnownAxeViolationBaseline;
 
-const KNOWN_SETTINGS_VIOLATION_RULES: string[] = [];
+const KNOWN_SETTINGS_VIOLATIONS = {} satisfies KnownAxeViolationBaseline;
 
 type AxeResults = Awaited<ReturnType<AxeBuilder['analyze']>>;
 
-function assertOnlyKnownViolations(results: AxeResults, known: string[], surface: string): void {
-  const violationIds = [...new Set(results.violations.map((v) => v.id))].sort();
-  const unexpected = results.violations.filter((v) => !known.includes(v.id));
-  const stale = known.filter((id) => !violationIds.includes(id));
+function assertOnlyKnownViolations(
+  results: AxeResults,
+  known: KnownAxeViolationBaseline,
+  surface: string,
+): void {
+  const comparison = compareAxeViolationBaseline(results.violations, known);
+  const unexpected = results.violations.filter((v) => comparison.unexpectedRuleIds.includes(v.id));
 
   const describe = (vs: AxeResults['violations']) =>
     vs.map((v) =>
@@ -56,11 +63,17 @@ function assertOnlyKnownViolations(results: AxeResults, known: string[], surface
     `New axe violations on ${surface} (not on the known backlog):\n\n${describe(unexpected)}`,
   ).toEqual([]);
 
-  // Shrink-only guard: an entry that no longer fires must be deleted, so the
-  // backlog list always reflects reality.
   expect(
-    stale,
-    `These known-violation entries for ${surface} no longer fire — delete them: ${stale.join(', ')}`,
+    comparison.invalidBaselineRuleIds,
+    `Known violations for ${surface} must list exact target fingerprints; empty rules are not allowed`,
+  ).toEqual([]);
+  expect(
+    comparison.expandedTargets,
+    `Known axe rules gained new violating targets on ${surface}: ${comparison.expandedTargets.join(', ')}`,
+  ).toEqual([]);
+  expect(
+    comparison.staleTargets,
+    `These known axe targets for ${surface} no longer fire — delete them: ${comparison.staleTargets.join(', ')}`,
   ).toEqual([]);
 }
 
@@ -82,7 +95,7 @@ test.describe('a11y — axe-core WCAG A/AA scan', () => {
     // scanned content so a broken boot can't masquerade as a green scan.
     expect(results.passes.reduce((a, p) => a + p.nodes.length, 0)).toBeGreaterThan(100);
 
-    assertOnlyKnownViolations(results, KNOWN_VIOLATION_RULES, 'the dashboard');
+    assertOnlyKnownViolations(results, KNOWN_VIOLATIONS, 'the dashboard');
   });
 
   test('settings dialog has no axe violations outside the known backlog', async ({ page }) => {
@@ -98,6 +111,6 @@ test.describe('a11y — axe-core WCAG A/AA scan', () => {
     console.log(`[axe:settings] violations: ${JSON.stringify(results.violations.map((v) => ({ id: v.id, impact: v.impact, nodes: v.nodes.length, sample: v.nodes[0]?.target })), null, 2)}`);
     expect(results.passes.reduce((a, p) => a + p.nodes.length, 0)).toBeGreaterThan(20);
 
-    assertOnlyKnownViolations(results, KNOWN_SETTINGS_VIOLATION_RULES, 'the settings dialog');
+    assertOnlyKnownViolations(results, KNOWN_SETTINGS_VIOLATIONS, 'the settings dialog');
   });
 });

--- a/e2e/a11y-axe-scan.spec.ts
+++ b/e2e/a11y-axe-scan.spec.ts
@@ -13,6 +13,9 @@ import AxeBuilder from '@axe-core/playwright';
  * The known-violation lists are shrink-only escape hatches: an entry that
  * stops firing fails the test until it is deleted, so the lists always
  * reflect reality. Both are empty as of introduction.
+ *
+ * CI invokes this file via `npm run test:e2e:ci-smoke` (nothing in CI runs
+ * the `e2e/` glob). `REQUIRED_CI_SMOKE_SPECS` pins the argv token.
  */
 
 async function loadDashboard(page: Page): Promise<void> {

--- a/e2e/a11y-axe-scan.spec.ts
+++ b/e2e/a11y-axe-scan.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test, type Page } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+/**
+ * Automated axe-core scan of the hydrated dashboard (#6573).
+ *
+ * Biome's a11y lint group only analyzes JSX, so the template-string DOM this
+ * app builds gets zero static a11y coverage — this scan is the regression
+ * gate that role. It runs the WCAG 2.x A/AA rule tags and fails when a
+ * violation appears for any rule NOT already on the known-violations list
+ * below.
+ *
+ * The known-violation lists are shrink-only escape hatches: an entry that
+ * stops firing fails the test until it is deleted, so the lists always
+ * reflect reality. Both are empty as of introduction.
+ */
+
+async function loadDashboard(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => document.documentElement.dataset.wmEventHandlersReady === 'true',
+    undefined,
+    { timeout: 60_000 },
+  );
+  await page.locator('[role="tablist"]').first().waitFor({ timeout: 30_000 });
+  await page.locator('#panelsGrid .panel').first().waitFor({ timeout: 30_000 });
+}
+
+// Empty as of introduction (the #6573 remediation PRs cleared the backlog axe
+// can detect). If a violation must temporarily ship, add its rule id here WITH
+// a link to a tracking issue — the shrink-only guard below deletes entries the
+// moment they stop firing, so the list cannot rot.
+const KNOWN_VIOLATION_RULES: string[] = [];
+
+const KNOWN_SETTINGS_VIOLATION_RULES: string[] = [];
+
+type AxeResults = Awaited<ReturnType<AxeBuilder['analyze']>>;
+
+function assertOnlyKnownViolations(results: AxeResults, known: string[], surface: string): void {
+  const violationIds = [...new Set(results.violations.map((v) => v.id))].sort();
+  const unexpected = results.violations.filter((v) => !known.includes(v.id));
+  const stale = known.filter((id) => !violationIds.includes(id));
+
+  const describe = (vs: AxeResults['violations']) =>
+    vs.map((v) =>
+      `${v.id} (${v.impact}): ${v.help}\n` +
+      v.nodes.slice(0, 5).map((n) => `    ${n.target.join(' ')}`).join('\n') +
+      (v.nodes.length > 5 ? `\n    …and ${v.nodes.length - 5} more nodes` : ''),
+    ).join('\n\n');
+
+  expect(
+    unexpected,
+    `New axe violations on ${surface} (not on the known backlog):\n\n${describe(unexpected)}`,
+  ).toEqual([]);
+
+  // Shrink-only guard: an entry that no longer fires must be deleted, so the
+  // backlog list always reflects reality.
+  expect(
+    stale,
+    `These known-violation entries for ${surface} no longer fire — delete them: ${stale.join(', ')}`,
+  ).toEqual([]);
+}
+
+test.describe('a11y — axe-core WCAG A/AA scan', () => {
+  test('dashboard has no axe violations outside the known backlog', async ({ page }) => {
+    await loadDashboard(page);
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      // Vite's dev-server error overlay is tooling, not app UI; without this
+      // an unrelated local build hiccup would fail the a11y gate.
+      .exclude('vite-error-overlay')
+      .analyze();
+
+    console.log(`[axe] scanned=${results.passes.reduce((a, p) => a + p.nodes.length, 0)} pass-nodes, incomplete=${results.incomplete.map((i) => `${i.id}:${i.nodes.length}`).join(',') || 'none'}`);
+    console.log(`[axe] violations: ${JSON.stringify(results.violations.map((v) => ({ id: v.id, impact: v.impact, nodes: v.nodes.length, sample: v.nodes[0]?.target })), null, 2)}`);
+
+    // Sanity: an empty page would also produce zero violations. Require real
+    // scanned content so a broken boot can't masquerade as a green scan.
+    expect(results.passes.reduce((a, p) => a + p.nodes.length, 0)).toBeGreaterThan(100);
+
+    assertOnlyKnownViolations(results, KNOWN_VIOLATION_RULES, 'the dashboard');
+  });
+
+  test('settings dialog has no axe violations outside the known backlog', async ({ page }) => {
+    await loadDashboard(page);
+    await page.locator('#unifiedSettingsBtn').click();
+    await page.locator('#unifiedSettingsModal.active').waitFor({ timeout: 30_000 });
+
+    const results = await new AxeBuilder({ page })
+      .include('#unifiedSettingsModal')
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    console.log(`[axe:settings] violations: ${JSON.stringify(results.violations.map((v) => ({ id: v.id, impact: v.impact, nodes: v.nodes.length, sample: v.nodes[0]?.target })), null, 2)}`);
+    expect(results.passes.reduce((a, p) => a + p.nodes.length, 0)).toBeGreaterThan(20);
+
+    assertOnlyKnownViolations(results, KNOWN_SETTINGS_VIOLATION_RULES, 'the settings dialog');
+  });
+});

--- a/e2e/axe-violation-baseline.ts
+++ b/e2e/axe-violation-baseline.ts
@@ -1,0 +1,61 @@
+export type KnownAxeViolationBaseline = Readonly<Record<string, readonly string[]>>;
+
+export interface AxeViolationLike {
+  id: string;
+  nodes: ReadonlyArray<{ target: unknown }>;
+}
+
+export interface AxeViolationBaselineDiff {
+  unexpectedRuleIds: string[];
+  expandedTargets: string[];
+  staleTargets: string[];
+  invalidBaselineRuleIds: string[];
+}
+
+/** Serialize axe's cross-tree selector without losing frame boundaries. */
+export function axeTargetFingerprint(target: unknown): string {
+  return JSON.stringify(target) ?? String(target);
+}
+
+/**
+ * Compare exact violating nodes, not just rule IDs. A known rule may neither
+ * expand to another node nor retain a stale node without making the gate red.
+ */
+export function compareAxeViolationBaseline(
+  violations: readonly AxeViolationLike[],
+  baseline: KnownAxeViolationBaseline,
+): AxeViolationBaselineDiff {
+  const actualByRule = new Map<string, Set<string>>();
+  for (const violation of violations) {
+    const targets = actualByRule.get(violation.id) ?? new Set<string>();
+    for (const node of violation.nodes) targets.add(axeTargetFingerprint(node.target));
+    actualByRule.set(violation.id, targets);
+  }
+
+  const baselineRuleIds = new Set(Object.keys(baseline));
+  const unexpectedRuleIds = [...actualByRule.keys()]
+    .filter((id) => !baselineRuleIds.has(id))
+    .sort();
+  const expandedTargets: string[] = [];
+  const staleTargets: string[] = [];
+  const invalidBaselineRuleIds: string[] = [];
+
+  for (const [ruleId, expectedTargetList] of Object.entries(baseline)) {
+    if (expectedTargetList.length === 0) invalidBaselineRuleIds.push(ruleId);
+    const expectedTargets = new Set(expectedTargetList);
+    const actualTargets = actualByRule.get(ruleId) ?? new Set<string>();
+    for (const target of actualTargets) {
+      if (!expectedTargets.has(target)) expandedTargets.push(`${ruleId}: ${target}`);
+    }
+    for (const target of expectedTargets) {
+      if (!actualTargets.has(target)) staleTargets.push(`${ruleId}: ${target}`);
+    }
+  }
+
+  return {
+    unexpectedRuleIds,
+    expandedTargets: expandedTargets.sort(),
+    staleTargets: staleTargets.sort(),
+    invalidBaselineRuleIds: invalidBaselineRuleIds.sort(),
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.13.0",
         "@biomejs/biome": "^2.4.7",
         "@bufbuild/buf": "^1.66.0",
         "@edge-runtime/vm": "^5.0.0",
@@ -1089,6 +1090,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -11220,6 +11234,16 @@
       "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
       "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/b4a": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "test:e2e:mcp-grant": "cross-env VITE_VARIANT=full playwright test e2e/mcp-grant-consent.spec.ts",
     "test:e2e:news-budget": "cross-env VITE_VARIANT=full playwright test e2e/dashboard-news-request-budget.spec.ts",
     "test:e2e:source-live-apply": "cross-env VITE_VARIANT=full playwright test e2e/settings-source-live-apply.spec.ts",
-    "test:e2e:ci-smoke": "cross-env VITE_VARIANT=full playwright test e2e/variant-live-smoke.spec.ts e2e/mcp-grant-consent.spec.ts e2e/dashboard-news-request-budget.spec.ts e2e/settings-panel-live-apply.spec.ts e2e/settings-source-live-apply.spec.ts e2e/keyword-spike-flow.spec.ts e2e/breaking-news-banner-provenance.spec.ts",
+    "test:e2e:ci-smoke": "cross-env VITE_VARIANT=full playwright test e2e/variant-live-smoke.spec.ts e2e/mcp-grant-consent.spec.ts e2e/dashboard-news-request-budget.spec.ts e2e/settings-panel-live-apply.spec.ts e2e/settings-source-live-apply.spec.ts e2e/keyword-spike-flow.spec.ts e2e/breaking-news-banner-provenance.spec.ts e2e/a11y-axe-scan.spec.ts",
     "test:e2e:prehydration": "cross-env VITE_VARIANT=full playwright test e2e/prehydration-shell.spec.ts --project=chromium --grep \"server-rendered welcome page|dashboard shell without JavaScript\"",
     "test:e2e:variant-smoke:full": "cross-env VITE_VARIANT=full playwright test e2e/variant-live-smoke.spec.ts",
     "test:e2e:variant-smoke:tech": "cross-env VITE_VARIANT=tech playwright test e2e/variant-live-smoke.spec.ts",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "test:convex:watch": "vitest --config vitest.config.mts"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@biomejs/biome": "^2.4.7",
     "@bufbuild/buf": "^1.66.0",
     "@edge-runtime/vm": "^5.0.0",

--- a/src/App.ts
+++ b/src/App.ts
@@ -2393,6 +2393,9 @@ export class App {
       this.primeVisiblePanelData(),
     ]);
     markLcpDebug('wm:data:initial-fanout-complete');
+    if (import.meta.env.VITE_E2E === '1') {
+      document.documentElement.dataset.wmInitialDataReady = 'true';
+    }
     const countryGeometryReady = this.preloadCountryGeometryForPostLcpWork();
 
     // If bootstrap was served from cache but live data just loaded, promote the status indicator

--- a/tests/axe-violation-baseline.test.mts
+++ b/tests/axe-violation-baseline.test.mts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  axeTargetFingerprint,
+  compareAxeViolationBaseline,
+  type AxeViolationLike,
+} from '../e2e/axe-violation-baseline.ts';
+
+function violation(id: string, ...targets: unknown[]): AxeViolationLike {
+  return { id, nodes: targets.map((target) => ({ target })) };
+}
+
+describe('axe violation target baseline', () => {
+  it('accepts the exact known rule-and-target set', () => {
+    const target = ['#known'];
+    assert.deepEqual(
+      compareAxeViolationBaseline(
+        [violation('color-contrast', target)],
+        { 'color-contrast': [axeTargetFingerprint(target)] },
+      ),
+      {
+        unexpectedRuleIds: [],
+        expandedTargets: [],
+        staleTargets: [],
+        invalidBaselineRuleIds: [],
+      },
+    );
+  });
+
+  it('rejects another node even when its rule is already known', () => {
+    const known = ['#known'];
+    const added = ['#added'];
+    const result = compareAxeViolationBaseline(
+      [violation('color-contrast', known, added)],
+      { 'color-contrast': [axeTargetFingerprint(known)] },
+    );
+
+    assert.deepEqual(result.expandedTargets, [
+      `color-contrast: ${axeTargetFingerprint(added)}`,
+    ]);
+  });
+
+  it('reports stale targets and new rule IDs independently', () => {
+    const stale = ['#removed'];
+    const result = compareAxeViolationBaseline(
+      [violation('label', ['#new-rule'])],
+      { 'color-contrast': [axeTargetFingerprint(stale)] },
+    );
+
+    assert.deepEqual(result.unexpectedRuleIds, ['label']);
+    assert.deepEqual(result.staleTargets, [
+      `color-contrast: ${axeTargetFingerprint(stale)}`,
+    ]);
+  });
+
+  it('rejects empty baseline entries that would allow a whole rule', () => {
+    const result = compareAxeViolationBaseline([], { 'color-contrast': [] });
+    assert.deepEqual(result.invalidBaselineRuleIds, ['color-contrast']);
+  });
+});

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -44,6 +44,7 @@ const REQUIRED_CI_SMOKE_SPECS = [
   'e2e/dashboard-news-request-budget.spec.ts',
   'e2e/keyword-spike-flow.spec.ts',
   'e2e/breaking-news-banner-provenance.spec.ts',
+  'e2e/a11y-axe-scan.spec.ts',
 ] as const;
 
 const REQUIRED_TEST_JOBS = [
@@ -419,6 +420,10 @@ describe('CI workflow coverage', () => {
         argvTokens.includes(spec),
         `test:e2e:ci-smoke must pass ${spec} as a live argv token — a spec dropped ` +
           '(or commented out) from this command has no other CI invocation',
+      );
+      assert.ok(
+        existsSync(resolve(root, spec)),
+        `${spec} must exist on disk — a missing file would only fail once Playwright starts`,
       );
     }
     assert.ok(


### PR DESCRIPTION
Part of #6573 (accessibility remediation, PR 7 of 7): the prevention layer.

## Problem

This is the root-cause fix from the audit: the app builds its DOM from template strings, so **Biome's a11y rule group — which only analyzes JSX — never fires on any of it** (`find src -name '*.tsx'` → 0 files), and no axe/pa11y/Lighthouse scan exists in CI. Every a11y fix so far has been reactive; nothing would catch the next unlabeled input.

## What this does

Adds `@axe-core/playwright` (dev-only) and `e2e/a11y-axe-scan.spec.ts`, following the conventions of the existing `a11y-landmarks-tablist.spec.ts` (same `loadDashboard` wait strategy, same dev-server setup — no config changes needed).

**Two scans, WCAG 2.0/2.1 A + AA rule tags:**
1. The hydrated dashboard (full page).
2. The opened settings dialog (`#unifiedSettingsBtn` → `#unifiedSettingsModal`), the ARIA-densest surface.

**Baseline mechanics** — each scan fails on any violation whose rule id isn't on a known-violations list, and *also* fails when a listed entry stops firing until the entry is deleted (shrink-only, so the list can't rot). **Both lists are empty as of introduction**: the #6573 remediation PRs (#6581, #6649, #6685 merged; #6963/#6964 open) cleared everything axe detects on these surfaces. The 17 contrast checks axe can't resolve (gradients/overlaps) land in its `incomplete` bucket, not violations — the token-level contrast work is guarded separately by the unit test in the contrast-tokens PR.

**False-green guards:** the spec requires >100 scanned pass-nodes (an empty/broken page would otherwise scan clean) and excludes `<vite-error-overlay>` so a local dev-server hiccup can't fail — or pollute — the a11y gate. (First run of this spec actually caught that: a missing `product:facts` generated module put Vite's overlay in the page and axe flagged the overlay itself.)

## Verification

```
Running 2 tests using 1 worker
[axe] scanned=1132 pass-nodes, incomplete=color-contrast:17
[axe] violations: []
  ✓  1 … dashboard has no axe violations outside the known backlog (2.4s)
[axe:settings] violations: []
  ✓  2 … settings dialog has no axe violations outside the known backlog (2.1s)
  2 passed (7.2s)
```

- `npm run typecheck` — clean
- `biome lint e2e/a11y-axe-scan.spec.ts` — clean
