### PR TITLE
fix(install): handle npm 12 allow-scripts in nested installs

### DIFF
--- a/blog-site/package.json
+++ b/blog-site/package.json
@@ -2,6 +2,9 @@
   "name": "blog-site",
   "type": "module",
   "version": "0.0.1",
+  "allowScripts": {
+    "esbuild": true
+  },
   "engines": {
     "node": ">=22.12.0"
   },

--- a/blog-site/package.json
+++ b/blog-site/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "version": "0.0.1",
   "allowScripts": {
-    "esbuild": true
+    "esbuild": true,
+    "fsevents": false
   },
   "engines": {
     "node": ">=22.12.0"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,16 @@
   "license": "AGPL-3.0-only",
   "allowScripts": {
     "@bufbuild/buf": true,
+    "@vaadin/vaadin-usage-statistics": false,
+    "browser-tabs-lock": false,
+    "bufferutil": false,
+    "core-js": false,
+    "es5-ext": false,
     "esbuild": true,
-    "sharp": true
+    "fsevents": false,
+    "protobufjs": false,
+    "sharp": true,
+    "utf-8-validate": false
   },
   "type": "module",
   "scripts": {
@@ -67,7 +75,7 @@
     "build:sitemap": "node scripts/build-sitemap.mjs",
     "build:sitemap:check": "npm run build:crawlable-corpus && node scripts/build-sitemap.mjs --check",
     "verify:sitemaps": "node scripts/verify-sitemaps.mjs",
-    "build:pro": "cd pro-test && npm ci --prefer-offline && npm run build",
+    "build:pro": "cross-env npm_config_allow_scripts= npm --prefix pro-test ci --prefer-offline && npm --prefix pro-test run build",
     "build:openapi": "node -e \"require('fs').cpSync('docs/api/worldmonitor.openapi.yaml', 'public/openapi.yaml')\" && node scripts/build-openapi-json.mjs",
     "gen:openapi:security": "node scripts/openapi-inject-security.mjs",
     "gen:openapi:examples": "node scripts/openapi-inject-examples.mjs",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "private": true,
   "version": "2.10.0",
   "license": "AGPL-3.0-only",
+  "allowScripts": {
+    "@bufbuild/buf": true,
+    "esbuild": true,
+    "sharp": true
+  },
   "type": "module",
   "scripts": {
     "lint": "biome lint ./src ./server ./api ./tests ./e2e ./scripts ./middleware.ts && npm run lint:safe-html",
@@ -54,7 +59,7 @@
     "dev:happy": "cross-env VITE_VARIANT=happy vite",
     "dev:commodity": "cross-env VITE_VARIANT=commodity vite",
     "dev:energy": "cross-env VITE_VARIANT=energy vite",
-    "postinstall": "npm run inventory:facts && cd blog-site && npm ci --prefer-offline",
+    "postinstall": "npm run inventory:facts && cross-env npm_config_allow_scripts= npm --prefix blog-site ci --prefer-offline",
     "prebuild:blog": "npm run product:facts",
     "build:blog": "npm run build:blog:raw",
     "build:blog:raw": "cd blog-site && npm run build && rm -rf ../public/blog && mkdir -p ../public/blog && cp -r dist/* ../public/blog/",

--- a/pro-test/package.json
+++ b/pro-test/package.json
@@ -2,6 +2,15 @@
   "name": "worldmonitor-pro",
   "private": true,
   "version": "0.1.0",
+  "allowScripts": {
+    "@clerk/shared": false,
+    "browser-tabs-lock": false,
+    "bufferutil": false,
+    "core-js": false,
+    "esbuild": true,
+    "fsevents": false,
+    "utf-8-validate": false
+  },
   "type": "module",
   "scripts": {
     "dev": "vite --port=3000",

--- a/scripts/bootstrap-worktree.mjs
+++ b/scripts/bootstrap-worktree.mjs
@@ -256,6 +256,13 @@ export function installDependencies({
   return result;
 }
 
+/**
+ * Builds the child npm environment without the parent's project-scoped script policy.
+ *
+ * @param {NodeJS.ProcessEnv} environment Parent process environment.
+ * @param {string} cacheDir Shared npm cache directory.
+ * @returns {NodeJS.ProcessEnv} Environment for a project-scoped child npm install.
+ */
 export function createInstallEnvironment(environment, cacheDir) {
   return {
     ...Object.fromEntries(

--- a/scripts/bootstrap-worktree.mjs
+++ b/scripts/bootstrap-worktree.mjs
@@ -245,10 +245,7 @@ export function installDependencies({
 
   const result = spawnSync('npm', args, {
     cwd: rootDir,
-    env: {
-      ...process.env,
-      npm_config_cache: cacheDir,
-    },
+    env: createInstallEnvironment(process.env, cacheDir),
     stdio: 'inherit',
   });
 
@@ -257,6 +254,15 @@ export function installDependencies({
   }
 
   return result;
+}
+
+export function createInstallEnvironment(environment, cacheDir) {
+  return {
+    ...Object.fromEntries(
+      Object.entries(environment).filter(([key]) => key !== 'npm_config_allow_scripts'),
+    ),
+    npm_config_cache: cacheDir,
+  };
 }
 
 // Relative, so git resolves it against whichever worktree the hook runs from.

--- a/tests/bootstrap-worktree-env.test.mjs
+++ b/tests/bootstrap-worktree-env.test.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createInstallEnvironment } from '../scripts/bootstrap-worktree.mjs';
+
+describe('worktree bootstrap install environment', () => {
+  it('does not pass inherited allow-scripts policy to child npm installs', () => {
+    const environment = createInstallEnvironment(
+      {
+        npm_config_allow_scripts: 'local-package',
+        PATH: '/usr/bin',
+      },
+      '/tmp/npm-cache',
+    );
+
+    assert.deepEqual(environment, {
+      npm_config_cache: '/tmp/npm-cache',
+      PATH: '/usr/bin',
+    });
+  });
+});

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -391,10 +391,11 @@ describe('crawlable content corpus deployment contracts', () => {
       );
       // The ordering checks above only prove the STRING is chained. Without this,
       // build:pro could be rewritten to a no-op and every assertion here stays
-      // green while the deploy quietly stops producing /pro.
+      // green while the deploy quietly stops producing /pro. Accept either
+      // `cd pro-test && npm run build` or `npm --prefix pro-test run build`.
       assert.match(
         packageJson.scripts['build:pro'],
-        /cd pro-test\b[\s\S]*npm run build\b/,
+        /(?:cd pro-test\b[\s\S]*npm run build\b|npm --prefix pro-test run build\b)/,
         'build:pro must actually run pro-test\'s build, not just exist as a chained name'
       );
       assert.ok(


### PR DESCRIPTION
## Summary

Cloning the repository and running `npm install` failed with `EALLOWSCRIPTS` when npm 12 exported a user-level `allow-scripts` setting into the root lifecycle environment. The nested `npm ci` commands treated that inherited value as a forbidden project-scoped CLI policy.

This change:

- clears the inherited policy at repository-owned nested npm boundaries
- defines project-specific `allowScripts` policies for the root, blog, and Pro packages
- uses bare package names so approved `esbuild`, `@bufbuild/buf`, and `sharp` versions remain allowed after dependency updates
- explicitly denies the remaining known nonessential install scripts
- prevents worktree bootstrap installs from forwarding the inherited policy

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [x] Config / Settings
- [x] Other: dependency installation and worktree bootstrap

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant (full production build: `npm run build`)
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (not applicable, no UI changes)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (not applicable)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (not applicable)

## Verification

- `npm install`
- `npm run typecheck`
- `npm run build` (full variant)
- `npm run build:pro`
- `node --test tests/bootstrap-worktree-env.test.mjs tests/bootstrap-worktree.test.mjs` (30 passed)
- `npm install-scripts ls` for root, `blog-site`, and `pro-test` (no unreviewed scripts)

## Documentation Alignment Checklist

N/A. This PR does not publish or change documentation claims.

- [ ] Claim ledger attached or linked (not applicable)
- [ ] All required Audit Council role signoffs attached (not applicable)
- [ ] Generated docs regenerated from proto where applicable (not applicable)
- [ ] Fixture-backed examples recomputed (not applicable)
- [ ] Redis writers/readers enumerated for every documented key (not applicable)

## Screenshots

Not applicable. This change has no UI impact.

