### PR TITLE
fix(webmcp): split malformed open_search_result keys from expired ones

### DIFF
--- a/src/services/webmcp.ts
+++ b/src/services/webmcp.ts
@@ -71,6 +71,7 @@ export interface DashboardSearchResponse {
 }
 
 export type DashboardSearchOpenReason =
+  | 'malformed_arguments'
   | 'invalid_or_expired_key'
   | 'search_state_changed'
   | 'result_no_longer_available'
@@ -161,6 +162,7 @@ const DASHBOARD_SEARCH_SCOPES = new Set<DashboardSearchScope>([
   'all', 'signals', 'map', 'panels', 'actions',
 ]);
 const DASHBOARD_SEARCH_OPEN_REASONS = new Set<DashboardSearchOpenReason>([
+  'malformed_arguments',
   'invalid_or_expired_key',
   'search_state_changed',
   'result_no_longer_available',
@@ -679,7 +681,7 @@ export function buildWebMcpTools(
           return boundSearchOpenResult({
             ok: false,
             status: 'denied',
-            reason: 'invalid_or_expired_key',
+            reason: 'malformed_arguments',
           });
         }
         const resultKey = typeof args.resultKey === 'string' ? args.resultKey : '';
@@ -687,7 +689,7 @@ export function buildWebMcpTools(
           return boundSearchOpenResult({
             ok: false,
             status: 'denied',
-            reason: 'invalid_or_expired_key',
+            reason: 'malformed_arguments',
           });
         }
         return boundSearchOpenResult(await app.openSearchResult(resultKey));

--- a/tests/webmcp.test.mjs
+++ b/tests/webmcp.test.mjs
@@ -487,7 +487,7 @@ describe('webmcp.ts: native tool execution and telemetry', () => {
     assert.deepEqual(denied, {
       ok: false,
       status: 'denied',
-      reason: 'invalid_or_expired_key',
+      reason: 'malformed_arguments',
     });
     assert.deepEqual(openCalls, []);
     assert.deepEqual(events.at(-1), {
@@ -647,7 +647,7 @@ describe('webmcp.ts: native tool execution and telemetry', () => {
     assert.deepEqual(await open.execute({ resultKey: 'fabricated-result-key' }), {
       ok: false,
       status: 'denied',
-      reason: 'invalid_or_expired_key',
+      reason: 'malformed_arguments',
     });
     assert.equal(bindingCalls, reasons.length + 1);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`open_search_result` used `invalid_or_expired_key` for extra properties and non-`sr_` keys as well as for truly stale search keys. Agents could not tell a fixable argument error from a cache miss, so retry logic could re-run `search_dashboard` unnecessarily.

This change returns `malformed_arguments` for extra keys and pattern failures. `invalid_or_expired_key` is reserved for well-formed keys that the opener rejects (missing, expired, or unknown binding reasons).

This was a pre-existing issue called out in the review of #6962; the same overload exists on `main`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: browser WebMCP `open_search_result` denial reasons

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked — N/A (no published docs on `main` list these denial reasons)
- [ ] All required Audit Council role signoffs attached — N/A
- [ ] Generated docs regenerated from proto where applicable — N/A
- [ ] Fixture-backed examples recomputed — N/A
- [ ] Redis writers/readers enumerated for every documented key — N/A

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a same-origin WebMCP tool reason string; it does not change server APIs, seeds, or auth.

Healthy signal: extra-key and malformed-key `open_search_result` calls return `reason: malformed_arguments` without invoking `openSearchResult`. Well-formed unknown keys still return `invalid_or_expired_key`.

Failure signal: agents retry `search_dashboard` after extra-property denials, or well-formed stale keys start returning `malformed_arguments`.

Rollback: revert this commit.

## Screenshots

Not applicable (non-UI contract change). Verification is the focused WebMCP unit tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5c7c9f3-0d2c-4401-baf0-95c15b0923d4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5c7c9f3-0d2c-4401-baf0-95c15b0923d4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

