### PR TITLE
fix(sentry): filter two third-party noise signatures without a new blind spot

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -246,6 +246,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /\bcrusoe is not defined\b/, // WORLDMONITOR-R3 — injected userscript reference, anonymous-frames-only stack
       /\bvc_request_action is not defined\b/, // WORLDMONITOR-RB — Samsung Internet / Tizen smart-view-cast global injection
       /\bmainWorldSdk is not defined\b/, // WORLDMONITOR-TG — browser extension SDK injected into the page main world references its global before define; not in our bundle (Edge 148/Windows, anonymous-frames-only stack)
+      /\bextDomain is not defined\b/, // WORLDMONITOR-105 — same class as mainWorldSdk: extension content script reads its own `extDomain` global before define; absent from src/, api/, public/ and index.html (Chrome 151/Windows, three `<anonymous>:1` frames and nothing else)
       /navigationPerformanceLoggerJavascriptInterface/,
       /jQuery is not defined/,
       /illegal UTF-16 sequence/,
@@ -880,6 +881,20 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
         || /Cannot inject key into script value/.test(msg)
         || /Connection lost while action was in flight/.test(msg)
         || /WEBGLRenderPipeline.*Link error/.test(msg)
+        // Firefox's window.onerror wording when a script throws a bare primitive
+        // (`throw undefined` / `throw null`) instead of an Error. The whole stack
+        // is the DOCUMENT url (`https://www.worldmonitor.app/#moments` at line 0),
+        // so there is no script file to attribute it to at all. Our bundle never
+        // throws a bare primitive — `throw undefined|null|void 0` appears nowhere
+        // in src/, shared/ or api/ (pinned by the source-level invariant test in
+        // tests/sentry-beforesend.test.mjs), and a rethrow (`throw err`) of a
+        // primitive caught from a third party still leaves the rethrowing
+        // first-party frame on the stack, which fails this block's
+        // `!hasFirstParty` gate and surfaces normally. Restricted to the only two
+        // thrown values we can prove are not ours — `undefined` and `null`; every
+        // other one, `uncaught exception: [object Object]` included, still reports
+        // (WORLDMONITOR-106 — Firefox 153 / Windows).
+        || /^uncaught exception: (?:undefined|null)$/.test(msg)
       )) return null;
       // `SyntaxError: Invalid or unexpected token` (and the Unexpected token/keyword/EOF
       // family) surfacing THROUGH the deck.gl/maplibre WebGL init path. Our compiled,

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isDebugBearRumScriptFrame } from '../src/bootstrap/debugbear-rum.ts';
 import { isIosLikeUserAgent } from '../src/bootstrap/platform-ua.ts';
@@ -1610,5 +1610,152 @@ describe('bare "Failed to fetch" is decided by host, not stack shape (WORLDMONIT
       !/panel-storage|widget-store/.test(mainSrc),
       'sentry-init.ts must not key suppression on Vite chunk names',
     );
+  });
+});
+
+// ─── WORLDMONITOR-105: extDomain extension-global ReferenceError ───────────
+//
+// A browser extension injected into the page's main world references its own
+// `extDomain` global before defining it. The production event (Chrome 151 /
+// Windows, 2026-08-19) carries three `<anonymous>:1` frames and nothing else.
+// `extDomain` appears nowhere in src/, api/, public/ or index.html, so the
+// message can never originate from our own bundle — same disposition as the
+// `mainWorldSdk`, `hackLocationFailed` and `userScripts` entries above.
+describe('ignoreErrors — extDomain extension global (WORLDMONITOR-105)', () => {
+  const PROD_MSG = 'extDomain is not defined';
+  const pattern = ignoreErrors.find(p => p instanceof RegExp && /extDomain/.test(p.source));
+
+  it('defines an extDomain ignore pattern', () => {
+    assert.ok(pattern, 'an /extDomain/ ignoreErrors pattern must exist');
+  });
+
+  it('suppresses the production "extDomain is not defined" message', () => {
+    assert.ok(isIgnored(PROD_MSG), `ignoreErrors must drop: ${PROD_MSG}`);
+  });
+
+  it('is scoped so a longer first-party identifier still surfaces', () => {
+    // The `\b...\b` anchors keep the pattern from swallowing a real
+    // `extDomainResolver is not defined` bug in our own code.
+    assert.ok(!isIgnored('extDomainResolver is not defined'),
+      'pattern must not swallow a longer identifier with the same prefix');
+    assert.ok(!isIgnored('myExtDomain is not defined'),
+      'pattern must not swallow a longer identifier with the same suffix');
+  });
+});
+
+// ─── WORLDMONITOR-106: Firefox `uncaught exception: undefined` ─────────────
+//
+// Firefox's window.onerror wording when a script throws a bare primitive
+// (`throw undefined` / `throw null`). The production event (Firefox 153 /
+// Windows, 2026-08-19) has one frame — the DOCUMENT url
+// `https://www.worldmonitor.app/#moments` at line 0 — so there is no script
+// file to attribute it to at all.
+//
+// Our bundle never throws a bare primitive: `throw undefined` / `throw null`
+// appear nowhere in src/, shared/ or api/, and every rethrow (`throw err`)
+// re-raises a caught value from a first-party frame, which would put that
+// frame on the stack and fail the `!hasFirstParty` gate. So this goes in
+// beforeSend with stack-gating rather than ignoreErrors: the wording is
+// engine-generic enough that a first-party origin must still surface.
+describe('beforeSend — Firefox bare-primitive throw (WORLDMONITOR-106)', () => {
+  const docFrame = { filename: 'https://www.worldmonitor.app/#moments', lineno: 0 };
+
+  it('suppresses "uncaught exception: undefined" with no first-party frame', () => {
+    assert.equal(
+      beforeSend(makeEvent('uncaught exception: undefined', 'Error', [docFrame])),
+      null,
+      'a bare-primitive throw with only a document-URL frame must be dropped',
+    );
+  });
+
+  it('suppresses the null variant too', () => {
+    assert.equal(
+      beforeSend(makeEvent('uncaught exception: null', 'Error', [docFrame])),
+      null,
+      'Firefox emits the same wording for `throw null`',
+    );
+  });
+
+  it('PRESERVES the same message when a first-party frame is present', () => {
+    const event = makeEvent('uncaught exception: undefined', 'Error', [
+      docFrame,
+      firstPartyFrame(),
+    ]);
+    assert.ok(
+      beforeSend(event) !== null,
+      'a first-party frame means our code rethrew it — must surface',
+    );
+  });
+
+  it('PRESERVES a thrown object, which names a real injector or a real bug', () => {
+    assert.ok(
+      beforeSend(makeEvent('uncaught exception: [object Object]', 'Error', [docFrame])) !== null,
+      'only the bare undefined/null primitives are provably not ours',
+    );
+  });
+
+  // The trailing `[^A-Za-z0-9_]|$` is what stops `throw nullValue` /
+  // `throw undefinedThing` from matching, and accepting end-of-line there is what
+  // catches an ASI-terminated `throw undefined` with no semicolon — requiring `;`
+  // would let exactly the statement this invariant exists to forbid slip past.
+  const BARE_PRIMITIVE_THROW = /throw\s+(?:undefined|null|void 0)(?:[^A-Za-z0-9_]|$)/m;
+
+  /**
+   * Source with comments removed. Load-bearing, not tidiness: the beforeSend
+   * policy EXPLAINS this rule in prose, and that prose necessarily contains the
+   * very statement being banned (`throw undefined` / `throw null`). Scanning raw
+   * text makes the explanation trip its own rule. Same reason the `.cause`
+   * invariant above strips comments before matching.
+   */
+  const stripComments = (src) => src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[ \t]*\/\/.*$/gm, '');
+
+  /** Every .ts/.mts/.tsx file under `dir`, recursively. */
+  const walk = (dir) => readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) return e.name === 'node_modules' ? [] : walk(full);
+    return /\.(?:m?ts|tsx)$/.test(e.name) ? [full] : [];
+  });
+
+  it('the bundle never throws a bare primitive', () => {
+    // The source-level invariant the suppression rests on, asserted here so it
+    // cannot silently stop being true.
+    const offenders = [];
+    for (const rel of ['../src', '../shared', '../api']) {
+      for (const file of walk(resolve(__dirname, rel))) {
+        const code = stripComments(readFileSync(file, 'utf-8'));
+        if (BARE_PRIMITIVE_THROW.test(code)) offenders.push(file);
+      }
+    }
+    assert.deepEqual(offenders, [],
+      `bare-primitive throw found — the WORLDMONITOR-106 suppression is no longer safe:\n${offenders.join('\n')}`);
+  });
+
+  it('the invariant actually fires on the statements it forbids', () => {
+    // A source scan that matches nothing is indistinguishable from a source scan
+    // that is silently broken. Positive controls, so the test above is known to
+    // have teeth — including the semicolon-less ASI form.
+    for (const forbidden of ['throw undefined;', 'throw undefined', 'throw null;', 'throw null', 'throw void 0;']) {
+      assert.ok(BARE_PRIMITIVE_THROW.test(forbidden), `pattern must catch: ${forbidden}`);
+    }
+    for (const allowed of ['throw nullValue;', 'throw undefinedThing;', 'throw err;', 'throw new Error("x");']) {
+      assert.ok(!BARE_PRIMITIVE_THROW.test(allowed), `pattern must NOT catch: ${allowed}`);
+    }
+  });
+
+  it('the scan reaches real files, and comment-stripping is what keeps it green', () => {
+    // Two ways the invariant could pass vacuously, both closed here: a walk that
+    // returns nothing, and a scan that would fail if it did NOT strip comments.
+    const files = ['../src', '../shared', '../api'].flatMap(rel => walk(resolve(__dirname, rel)));
+    assert.ok(files.length > 100, `walk must reach the real tree, got ${files.length} files`);
+    assert.ok(files.some(f => f.endsWith('bootstrap/sentry-init.ts')), 'walk must include sentry-init.ts');
+
+    const raw = readFileSync(resolve(__dirname, '../src/bootstrap/sentry-init.ts'), 'utf-8');
+    assert.ok(BARE_PRIMITIVE_THROW.test(raw),
+      'the policy comment is expected to contain the banned statement — if it stops doing so, '
+      + 'this control no longer proves comment-stripping is load-bearing');
+    assert.ok(!BARE_PRIMITIVE_THROW.test(stripComments(raw)),
+      'stripping comments must clear it');
   });
 });


### PR DESCRIPTION
## Summary

Two Sentry issues from the 2026-08-20 triage stop reaching the inbox, without costing us the ability to see the same message when it *is* ours. Both are third-party in origin; the interesting part is that they need two different mechanisms, and picking the convenient one for the second would have created exactly the observability blind spot this file keeps warning about.

`WORLDMONITOR-105` — `extDomain is not defined` (Chrome 151 / Windows). An extension content script reads its own global before defining it. The event has three `<anonymous>:1` frames and nothing else. `extDomain` appears nowhere in `src/`, `api/`, `public/` or `index.html`, so this can never come from our bundle — the same standing as the existing `mainWorldSdk`, `hackLocationFailed` and `userScripts` entries, and it joins them in `ignoreErrors`.

`WORLDMONITOR-106` — `uncaught exception: undefined` (Firefox 153 / Windows). This is Firefox's `window.onerror` wording when a script throws a bare primitive instead of an `Error`. The whole stack is the *document* URL (`https://www.worldmonitor.app/#moments`, line 0), so there is no script file to attribute it to at all.

## The mechanism split is the decision to review

`106` is the one that could have gone wrong. It looks like an `ignoreErrors` entry, and putting it there would have been one line instead of fifteen.

`ignoreErrors` matches the exception `value` with **no access to stack frames**. `uncaught exception: undefined` is engine-generated wording, not a vendor-specific string — so an `ignoreErrors` entry would suppress it identically whether it came from an injected script or from our own minified bundle. That is a permanent blind spot for a real first-party crash.

So it goes in `beforeSend`, inside the existing `hasAnyStack && !hasFirstParty` block, scoped to the only two thrown values we can prove are not ours:

| thrown value | disposition | why |
|---|---|---|
| `undefined`, `null` | suppressed when no first-party frame | our bundle never throws a bare primitive |
| `[object Object]`, anything else | always reports | names a real injector, or a real bug |
| any of the above **with** a first-party frame | always reports | a rethrow (`throw err`) keeps our frame on the stack |

## Making the safety argument checkable

The suppression is only sound while "our bundle never throws a bare primitive" stays true, so the test asserts it directly — walking `src/`, `shared/` and `api/` and failing if `throw undefined|null|void 0` ever lands — instead of leaving it in a comment that ages badly.

Reviewing that test found three ways it could have passed while proving nothing. Each is now closed and each has its own control, because a source-scanning guard that matches nothing looks identical to one that is silently broken:

- **It has to strip comments.** The `beforeSend` policy *explains* this rule, so its prose contains the banned statement and tripped the scan. Same reason the neighbouring `.cause` invariant strips comments. A control now asserts both directions — raw matches, stripped does not — so the stripping can't quietly stop being load-bearing.
- **It must not require a trailing `;`.** The first draft did, which would have let an ASI-terminated `throw undefined` through — precisely the statement being forbidden.
- **It has to be shown to reach real files.** A walk returning nothing passes identically, so a control pins the file count and names `sentry-init.ts`.

## Validation

- Both filters were **proven red before green**, each with negative controls: the same message with a first-party frame still reports, `extDomainResolver` / `myExtDomain` still report, thrown objects still report.
- The bare-primitive invariant was **mutation-tested** — injecting `throw undefined` (semicolon-less, the form the first draft would have missed) into `src/services/font-settings.ts` turned it red, naming the file; reverted, green again.
- `tsx --test tests/sentry-beforesend.test.mjs` → **268 pass / 0 fail**. `tsc --noEmit` and `biome check` clean. All pre-push gates passed.

No visual evidence: this is error-reporting policy with no user-facing surface.

## Out-of-band state

`WORLDMONITOR-105` and `-106` were resolved in Sentry during the triage, plainly (`{"status":"resolved"}`, no `statusDetails` pin — verified by read-back). They regress on the next matching event, which is the intent. Until this deploys, clients on the current release still lack these filters, so a recurrence before merge would reopen them — that is accurate signal, not the filter failing.

The same triage pass also stripped an `inCommit` pin from `WORLDMONITOR-ZS`, which was muting it silently.

## Related

Two findings from the same triage, neither addressed here:

- Related: #6968
- Related: #6969

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
