### PR TITLE
fix(railway): activate seed-bundle-static-ref-heavy so the deploy-health monitor stops failing closed

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -1020,24 +1020,24 @@ only its prior section and its original fetch timestamp. The 20-day eligibility
 window keeps the 30-day data TTL alive while the observation-year content clock
 detects old source material.
 
-### Bundle 3 heavy: seed-bundle-static-ref-heavy (planned, #6806)
+### Bundle 3 heavy: seed-bundle-static-ref-heavy (live, #6806)
 
 Arms-Suppliers (460s worst case) and Military-Bases (410s) cannot share a 570s
 tick — Railway kills a cron container at 10 minutes, so that ceiling is not
 negotiable. They CAN share a bundle: the runner defers whichever loses the tick
 to the next daily fire, and at 10-day and 30-day cadences a one-day deferral
 costs nothing. One service carries all three heavy members instead of three
-1-section services, because Railway caps a project at 100 and the fleet is at 81.
+1-section services, because Railway caps a project at 100 and the fleet is at 82.
 
 | Setting | Value |
 |---|---|
 | **Service name** | `seed-bundle-static-ref-heavy` |
 | **Start command** | `node scripts/seed-bundle-static-ref-heavy.mjs` |
 | **Cron schedule** | `0 4 * * *` (daily 04:00 UTC, staggered off leftover's 03:00) |
-| **Lifecycle** | `planned` until provisioned |
-| **Members** | Mineral-Production (180s / 60d), Arms-Suppliers (450s / 10d), Military-Bases (400s / 30d) |
+| **Lifecycle** | active — service `6285c37b-1327-46f1-bfd0-7454612764fb`, provisioned 2026-08-19, first tick published `bundle:heartbeat:static-ref-heavy` at 2026-08-20T04:01:04Z |
+| **Members** | Mineral-Production (180s / 60d), Arms-Suppliers (370s / 14d), Military-Bases (400s / 30d) |
 | **Wall-time budget** | `maxBundleMs: 570_000` |
-| **Required variable** | none (`USPTO_API_KEY` stays on leftover; R2 vars are project-level, confirm at provision) |
+| **Required variable** | `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `CLOUDFLARE_R2_ACCOUNT_ID` and one of `CLOUDFLARE_R2_TOKEN` / `CLOUDFLARE_API_TOKEN`. `USPTO_API_KEY` stays on leftover. The R2 pair is NOT optional here: `scripts/data/military-bases-final.json` is gitignored and the service has no volume, so without it Military-Bases falls back to the published version and exits non-zero once that is past its 30-day interval (#6845). |
 | **Heartbeat** | `bundle:heartbeat:static-ref-heavy` |
 
 **The lead slot rotates by day and that is load-bearing.** A member that never
@@ -1055,10 +1055,19 @@ device for the same reason.
 Start commands in this table keep the `scripts/` prefix so they match the other
 bundle rows and the registry-coverage grep. Railway's actual start command is
 `node seed-bundle-static-ref-heavy.mjs` because `deployMode:
-nixpacks-root-scripts` sets `rootDirectory` to `scripts/`. Clone
-`seed-bundle-static-ref`; do not reuse service id
+nixpacks-root-scripts` sets `rootDirectory` to `scripts/`. It was cloned from
+`seed-bundle-static-ref` and carries its own service id
+`6285c37b-1327-46f1-bfd0-7454612764fb`, not leftover's
 `4dd3934d-e5f7-4af8-b34b-c1796226800b`. The 04:00 stagger is intentional — a
 400s job at 03:00 would contend Redis / R2 / upstreams with leftover.
+
+Provisioning a repository-backed service is only half the job: it must also be
+enrolled in `scripts/railway-native-autodeploy-fleet.json` and lose its
+`lifecycle: planned` row, or `Railway Native Deploy Health` fails closed with
+`unexpected repository service(s)` and stops checking the whole fleet. Set
+`source.checkSuites` to `false` at the same time — a clone inherits Railway's
+`true` default, and wait-for-CI reads the head commit's entire check suite, so
+any red check anywhere strands this service's builds.
 
 ### Bundle 4: seed-bundle-resilience
 

--- a/scripts/railway-native-autodeploy-fleet.json
+++ b/scripts/railway-native-autodeploy-fleet.json
@@ -117,6 +117,10 @@
       "name": "seed-bundle-static-ref"
     },
     {
+      "id": "6285c37b-1327-46f1-bfd0-7454612764fb",
+      "name": "seed-bundle-static-ref-heavy"
+    },
+    {
       "id": "12e8e87d-1214-4ba3-a813-709f279a5ba9",
       "name": "seed-chokepoint-exposure"
     },

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -325,8 +325,16 @@
   {
     "entry": "scripts/seed-bundle-static-ref-heavy.mjs",
     "deployMode": "nixpacks-root-scripts",
-    "lifecycle": "planned",
     "service": "seed-bundle-static-ref-heavy",
+    "requiredEnv": [
+      "UPSTASH_REDIS_REST_URL",
+      "UPSTASH_REDIS_REST_TOKEN",
+      "CLOUDFLARE_R2_ACCOUNT_ID",
+      [
+        "CLOUDFLARE_R2_TOKEN",
+        "CLOUDFLARE_API_TOKEN"
+      ]
+    ],
     "watchPatterns": [
       "scripts/_bundle-runner.mjs",
       "scripts/_defense-industrial-source.mjs",

--- a/tests/railway-deploy-drift-workflow.test.mjs
+++ b/tests/railway-deploy-drift-workflow.test.mjs
@@ -321,14 +321,15 @@ describe('Railway Native Deploy Health workflow', () => {
       assert.match(healthyDrift.stdout, /Every service this repository deploys is running/);
       assert.match(
         healthyDrift.stderr,
-        // 81 since seed-bundle-canada was provisioned; still one fleet page.
-        /Read 81 service histories in 1 fleet page\(s\) \(81 records\), 0 direct fallback\(s\)\./,
+        // 82 since seed-bundle-static-ref-heavy was provisioned; FLEET_PAGE_SIZE
+        // is 500, so it is still one fleet page.
+        /Read 82 service histories in 1 fleet page\(s\) \(82 records\), 0 direct fallback\(s\)\./,
       );
       const queries = readFileSync(fixture.queryLog, 'utf8').trim().split('\n');
       assert.equal(
         queries.filter((query) => query === 'ViewerDeploymentConfig').length,
-        81,
-        'the config audit must reuse the deployment projection instead of reading 81 services twice',
+        82,
+        'the config audit must reuse the deployment projection instead of reading 82 services twice',
       );
       assert.equal(queries.filter((query) => query === 'FleetDeployments').length, 1);
 

--- a/tests/railway-fleet-deployments.test.mjs
+++ b/tests/railway-fleet-deployments.test.mjs
@@ -133,19 +133,21 @@ describe('immutable native-autodeploy fleet', () => {
     source: { repo, image: null },
   });
 
-  it('ships the exact 81-service fleet accepted by the terminal production run', () => {
-    // 80 -> 81: seed-bundle-canada was provisioned after that reconciliation
-    // (service 0a4b8757, cron */5). The roster is not a baseline to be quieted —
-    // every mismatch is red — but it must list every repo-backed service, or a
-    // service whose GitHub source detaches vanishes before repository filtering
-    // and both read-only monitors report healthy. An active registry row that is
-    // absent here fails the Viewer projection audit, so the two move together.
+  it('ships the exact 82-service fleet accepted by the terminal production run', () => {
+    // 80 -> 81 -> 82: seed-bundle-canada (service 0a4b8757, cron */5) and then
+    // seed-bundle-static-ref-heavy (service 6285c37b, cron 0 4 * * *) were
+    // provisioned after that reconciliation. The roster is not a baseline to be
+    // quieted — every mismatch is red — but it must list every repo-backed
+    // service, or a service whose GitHub source detaches vanishes before
+    // repository filtering and both read-only monitors report healthy. An
+    // active registry row that is absent here fails the Viewer projection
+    // audit, so the two move together.
     // NOTE: acceptedHead/acceptedRunId still name the pre-provisioning run; a
     // fresh reconciliation should re-stamp them.
     const fleet = readExpectedRepositoryFleet();
-    assert.equal(fleet.length, 81);
-    assert.equal(new Set(fleet.map((service) => service.id)).size, 81);
-    assert.equal(new Set(fleet.map((service) => service.name)).size, 81);
+    assert.equal(fleet.length, 82);
+    assert.equal(new Set(fleet.map((service) => service.id)).size, 82);
+    assert.equal(new Set(fleet.map((service) => service.name)).size, 82);
     assert.deepEqual(
       fleet.map((service) => service.name),
       [...fleet.map((service) => service.name)].sort(),

--- a/tests/railway-watch-path-audit.test.mjs
+++ b/tests/railway-watch-path-audit.test.mjs
@@ -823,15 +823,17 @@ describe('planned Railway service lifecycle', () => {
       // planned would exempt the one service most likely to drift — six member
       // scripts behind a single */5 cron — from the watch-path and deploy-drift
       // checks that exist to catch exactly that.
-      // seed-bundle-static-ref-heavy (#6806) is planned until the Railway clone
-      // exists. ONE service carries Arms-Suppliers, Military-Bases and
-      // Mineral-Production; the two 1-section siblings it replaced were never
-      // provisioned. Flip off planned only after provision.
+      // seed-bundle-static-ref-heavy is deliberately ABSENT now: #6889 landed it
+      // planned until the Railway clone existed, and service
+      // 6285c37b-1327-46f1-bfd0-7454612764fb now runs
+      // `node seed-bundle-static-ref-heavy.mjs` on cron 0 4 * * *. ONE service
+      // carries Arms-Suppliers, Military-Bases and Mineral-Production, so
+      // leaving it planned would exempt three low-cadence members behind a
+      // single daily cron from the watch-path and deploy-drift checks.
       'seed-crypto-sectors',
       'seed-market-quotes',
       'seed-service-statuses',
       'seed-weather-alerts',
-      'seed-bundle-static-ref-heavy',
     ].sort();
     const plannedEntries = RAILWAY_SERVICE_REGISTRY.filter(
       (entry) => entry.lifecycle === 'planned',

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -702,11 +702,25 @@ describe('scheduled seed freshness monitor', () => {
         assert.equal(entry.cutover?.firstScheduledRunAt, expiresAt);
         assert.equal(entry.cutover?.probeKey, probeKey);
         const service = readRailwayServices().find((item) => item.service === serviceName);
-        assert.equal(service?.cronSchedule, cron);
-        assert.equal(service?.lifecycle, 'planned');
+        // Prove the row EXISTS before asserting a field is absent from it —
+        // `Object.hasOwn({}, 'lifecycle')` is false for a deleted row too, so
+        // the absence assertion below would pass vacuously without this.
+        assert.ok(service, `${serviceName} must remain in the Railway registry`);
+        assert.equal(service.cronSchedule, cron);
+        // ACTIVE, not planned. Service 6285c37b was provisioned on
+        // 2026-08-19 and published bundle:heartbeat:static-ref-heavy at
+        // 2026-08-20T04:01:04Z, so `planned` — which removes the entry from the
+        // live audit AND from `--apply` — would exempt a running daily cron
+        // from the watch-path and deploy-drift checks. Asserting the ABSENCE of
+        // the field is what stops it being reinstated to quiet a red gate.
+        assert.equal(
+          Object.hasOwn(service, 'lifecycle'),
+          false,
+          `${serviceName} is provisioned and must not carry a lifecycle field`,
+        );
       }
       // The consolidation is the point: Railway caps a project at 100 services
-      // and the fleet is at 81. Three low-cadence members do not get three.
+      // and the fleet is at 82. Three low-cadence members do not get three.
       for (const retired of ['seed-bundle-arms-suppliers', 'seed-bundle-military-bases']) {
         assert.equal(
           readRailwayServices().find((item) => item.service === retired),


### PR DESCRIPTION
## The failure

`Railway Native Deploy Health` has been red on every six-hourly run:

```
unexpected repository service(s): seed-bundle-static-ref-heavy
Error: Process completed with exit code 1
```

That is the guard working, not a false alarm. `selectExpectedRepositoryServices`
(`scripts/railway-cli.mjs:257`) proves the **complete** live repository fleet against
`scripts/railway-native-autodeploy-fleet.json` *before* any drift check, so a repo-backed
Railway service that is not enrolled is a hard error — otherwise a service whose GitHub
source detaches vanishes before repository filtering and both read-only monitors report
healthy.

#6889 landed the row as `lifecycle: planned` precisely so it stayed out of the live audit
until the Railway service existed. It exists now, so the row has to say so.

## The service is live and working

| | |
|---|---|
| Service id | `6285c37b-1327-46f1-bfd0-7454612764fb` |
| Builder / root | NIXPACKS, `rootDirectory` `scripts` |
| Start command | `node seed-bundle-static-ref-heavy.mjs` |
| Cron | `0 4 * * *` |
| Watch patterns | 20, already byte-identical to the registry |
| First tick | `bundle:heartbeat:static-ref-heavy` published **2026-08-20T04:01:04Z** |

The heartbeat was read from production Redis, not inferred from a green badge.

## Activation touches six contracts, not one

Each independently refuses to let a live service go unwatched:

| Contract | Change |
|---|---|
| `scripts/railway-services.json` | drop `lifecycle`, add `requiredEnv` |
| `scripts/railway-native-autodeploy-fleet.json` | enrol the real service id; 81 → 82 |
| `tests/railway-watch-path-audit.test.mjs` | remove from the expected-planned list |
| `tests/railway-fleet-deployments.test.mjs` | count tripwire 81 → 82 |
| `tests/railway-deploy-drift-workflow.test.mjs` | two further hardcoded 81s |
| `tests/seed-freshness-monitor.test.mjs` | asserted `lifecycle === 'planned'` |

`planned` is not cosmetic: it removes an entry from the live audit **and** from `--apply`.
Leaving it planned would exempt three low-cadence members behind a single daily cron from
the watch-path and deploy-drift checks that exist to catch exactly that.

The planned-list and lifecycle assertions assert **absence** rather than being deleted —
asserting that the field is gone is what stops `planned` being reinstated later to quiet a
red gate. Both were mutation-tested: re-adding `"lifecycle": "planned"` turns each red.

## On `requiredEnv`

The R2 pair is load-bearing here, which the runbook had as "project-level, confirm at
provision". `scripts/data/military-bases-final.json` is gitignored (`.gitignore:93`) and
the service has no volume, so `seed-military-bases.mjs:699` reaching R2 is the **only**
path to the corpus; without it the section falls back to the published active version and
exits non-zero once that is past its 30-day interval (#6845). Declared as an any-of group
because the code reads `CLOUDFLARE_R2_TOKEN || CLOUDFLARE_API_TOKEN`. All four variables
are present on the live service.

The count tripwires move to 82 and stay one fleet page — `FLEET_PAGE_SIZE` is 500.

`acceptedHead`/`acceptedRunId` still name the pre-provisioning reconciliation; I did not
invent new values for them. A fresh reconciliation should re-stamp them.

## Verification

- 475 tests across the eight Railway / bundle / freshness suites, `tsc --noEmit` clean, `docs:check` OK.
- The real check against production, which is what actually matters:

```
RAILWAY_PROJECT_ID=… node scripts/check-railway-deploy-drift.mjs --audit-deployment-config
…
Read 82 service histories in 1 fleet page(s) (500 records), 2 direct fallback(s).
Railway deploy-drift check: … services=82 {"CURRENT_FOR_CLOSURE":80,"AHEAD_LINEAGE_UNPROVEN":2}
```

instead of dying at the fleet guard. (The two `AHEAD_LINEAGE_UNPROVEN` are the ordinary
head race — `main` advanced three commits during the run.)

## ⚠️ What this un-blinds — the workflow is still red after this merge

The run aborted at the fleet guard, so **nothing downstream was ever evaluated**. With the
guard passing, the config audit reports five drifted services — one of them this one, four
of them pre-existing and previously invisible:

| Service | Drift | Introduced by |
|---|---|---|
| `seed-bundle-static-ref-heavy` | `source checkSuites true != false` | the clone itself |
| `ais-relay` | 3 watch paths missing | #6922 |
| `seed-bundle-canada` | 5 watch paths missing | #6900 |
| `seed-bundle-macro` | 2 watch paths missing | #6931 |
| `seed-bundle-static-ref` | 3 watch paths missing | #6935 |

All five need a **Railway-side edit, not a repository change** — the registry is already
correct in every case, and the reconciler's mutation job is still gated on
`vars.RAILWAY_RECONCILE_CUTOVER_ACTIVE` pending #6378, so registry → Railway sync is manual
today. **They are not fixed here.**

The `checkSuites` one is the sharpest: a cloned service inherits Railway's `true` default,
and wait-for-CI reads the head commit's **entire** check suite, so any red check anywhere
refuses this service's builds. It is the only one of 82 repo-backed services still at
`true`. The four watch-path gaps are the "merged is not ran" failure mode — a change to
only those files will not rebuild the service, and the cron keeps running the previous
image, green.

https://claude.ai/code/session_01MfTRr5dn3GM7WgyGto9Xgy
