### PR TITLE
fix(aviation): raise the AviationStack cache TTL past the poll cadence that defeated it

### DIFF
--- a/server/worldmonitor/aviation/v1/get-carrier-ops.ts
+++ b/server/worldmonitor/aviation/v1/get-carrier-ops.ts
@@ -9,7 +9,10 @@ import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { parseStringArray, DEFAULT_WATCHED_AIRPORTS } from './_shared';
 import { listAirportFlights } from './list-airport-flights';
 
-const CACHE_TTL = 300;
+// 15min, matching list-airport-flights — see the TTL note there. This route is
+// the more expensive of the two: every miss fans out to listAirportFlights once
+// PER AIRPORT, so one uncached request is N paid AviationStack calls, not one.
+const CACHE_TTL = 900;
 
 export async function getCarrierOps(
     ctx: ServerContext,

--- a/server/worldmonitor/aviation/v1/list-airport-flights.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-flights.ts
@@ -12,7 +12,13 @@ import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
 import { aviationStackBudgetMonth, reserveAviationStackCalls } from './_avstack-budget';
 
-const CACHE_TTL = 300;
+// 15min. Held at 300s until Aug 2026, when a scraper polling every ~5.7min
+// converted this endpoint to a ~100% cache-miss rate: 504 of 504 requests on a
+// single day went upstream because each poll landed just after the 300s key
+// expired. Any TTL at or below a caller's polling interval buys nothing — it
+// only guarantees the paid call. 900s breaks that resonance for any poller
+// faster than 15min, and departure boards do not move meaningfully inside it.
+const CACHE_TTL = 900;
 // Always fetch a full page upstream and cache it once per airport+direction,
 // then slice to the caller's requested limit in memory. Threading req.limit
 // into the cache key (and the upstream query) meant limit 30 vs 31 vs 50 were

--- a/tests/aviation-cache-ttl-poll-resonance.test.mts
+++ b/tests/aviation-cache-ttl-poll-resonance.test.mts
@@ -1,0 +1,176 @@
+/**
+ * AviationStack cache TTL must outlast a polling client's interval.
+ *
+ * August 2026: a scraper polling `list-airport-flights` and `get-carrier-ops`
+ * every ~5.7 minutes drove both to a ~100% cache-miss rate — 504 of 504
+ * requests in one day went upstream — because the Redis TTL was 300s and every
+ * poll landed just after the key expired. Measured cost was ~1,000 paid
+ * AviationStack calls/day, ~43% of total spend, on top of a 50k/mo plan.
+ *
+ * The failure is not "the TTL is a wrong number", it is "the TTL is shorter
+ * than the interval of the clients that actually call this endpoint", which
+ * makes the cache buy nothing while still costing a paid call. So these tests
+ * assert the TTL written to Redis clears the observed poll cadence, not that it
+ * equals any particular constant — a later bump stays green, a regression to
+ * 300s (or anything under the cadence) goes red.
+ *
+ * The assertions read the TTL off the actual `SET ... EX` the handler issues,
+ * so they fail if the constant is lowered OR if a refactor stops threading it
+ * through to the Redis write.
+ */
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import { listAirportFlights } from '../server/worldmonitor/aviation/v1/list-airport-flights.ts';
+import { getCarrierOps } from '../server/worldmonitor/aviation/v1/get-carrier-ops.ts';
+
+/**
+ * The cadence that broke production, rounded up. A TTL at or below this leaves
+ * a client polling this fast paying for every single request.
+ */
+const OBSERVED_POLL_INTERVAL_SECONDS = 6 * 60;
+
+const ENV_KEYS = [
+  'AVIATIONSTACK_MONTHLY_BUDGET',
+  'AVIATIONSTACK_REQUEST_BUDGET',
+  'UPSTASH_REDIS_REST_TOKEN',
+  'UPSTASH_REDIS_REST_URL',
+  'WS_RELAY_URL',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'redis-token';
+  process.env.WS_RELAY_URL = 'https://relay.test';
+  process.env.AVIATIONSTACK_MONTHLY_BUDGET = '0';
+});
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = originalFetch;
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  originalEnv.clear();
+});
+
+type PositiveWrite = { key: string; ttlSeconds: number };
+
+/**
+ * Relay always answers with a healthy zero-row page, which is the shape
+ * cachedFetchJson stores positively. Negative sentinels are filtered out — they
+ * carry a deliberately short TTL and are not what this test is about.
+ */
+function installFetchMock() {
+  const positiveWrites: PositiveWrite[] = [];
+
+  mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+
+    if (url.startsWith('https://redis.test/get/')) {
+      return new Response(JSON.stringify({ result: null }), { status: 200 });
+    }
+
+    if (url === 'https://redis.test/pipeline') {
+      const commands = JSON.parse(String(init?.body ?? '[]')) as unknown[][];
+      return new Response(JSON.stringify(commands.map(() => ({ result: 1 }))), { status: 200 });
+    }
+
+    if (url === 'https://redis.test/') {
+      const [verb, key, payload, ex, ttl] = JSON.parse(String(init?.body ?? '[]')) as string[];
+      if (verb === 'SET' && ex === 'EX' && payload !== '"__WM_NEG__"' && !payload.includes('__WM_NEG__')) {
+        positiveWrites.push({ key, ttlSeconds: Number(ttl) });
+      }
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    }
+
+    if (url.startsWith('https://relay.test/aviationstack')) {
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }
+
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+
+  return positiveWrites;
+}
+
+function ctxFor(path: string) {
+  return { request: new Request(`https://worldmonitor.app${path}`), pathParams: {}, headers: {} };
+}
+
+function assertOutlastsPolling(write: PositiveWrite | undefined, label: string) {
+  assert.ok(write, `${label}: expected a positive Redis SET carrying a TTL`);
+  assert.ok(
+    write.ttlSeconds > OBSERVED_POLL_INTERVAL_SECONDS,
+    `${label}: cached for ${write.ttlSeconds}s, which does not outlast the `
+    + `${OBSERVED_POLL_INTERVAL_SECONDS}s polling cadence observed in production — `
+    + 'every poll would miss and buy a paid AviationStack call',
+  );
+}
+
+describe('aviation cache TTL vs. client poll cadence', () => {
+  it('caches an airport flight board past the observed poll interval', async () => {
+    const writes = installFetchMock();
+
+    const response = await listAirportFlights(ctxFor('/api/aviation/v1/list-airport-flights?airport=AAA'), {
+      airport: 'AAA',
+      direction: 'FLIGHT_DIRECTION_DEPARTURE',
+      limit: 30,
+    });
+
+    assert.equal(response.source, 'aviationstack', 'precondition: handler took the positive-cache path');
+    assertOutlastsPolling(
+      writes.find((w) => w.key.startsWith('aviation:flights:AAA:')),
+      'list-airport-flights',
+    );
+  });
+
+  it('caches a carrier-ops aggregate past the observed poll interval', async () => {
+    const writes = installFetchMock();
+
+    const response = await getCarrierOps(ctxFor('/api/aviation/v1/get-carrier-ops?airports=BBB&airports=CCC'), {
+      airports: ['BBB', 'CCC'],
+      minFlights: 0,
+    });
+
+    assert.equal(response.source, 'aviationstack', 'precondition: handler took the positive-cache path');
+    assertOutlastsPolling(
+      writes.find((w) => w.key.startsWith('aviation:carrier-ops:')),
+      'get-carrier-ops',
+    );
+  });
+
+  /**
+   * get-carrier-ops is the expensive one: a miss fans out to listAirportFlights
+   * once per airport, so its aggregate TTL expiring early re-buys N airports at
+   * once. Its TTL must not be shorter than the per-airport TTL underneath it,
+   * or the aggregate churns while its own inputs are still warm.
+   */
+  it('does not expire the carrier-ops aggregate before the airport boards it is built from', async () => {
+    const writes = installFetchMock();
+
+    await getCarrierOps(ctxFor('/api/aviation/v1/get-carrier-ops?airports=DDD'), {
+      airports: ['DDD'],
+      minFlights: 0,
+    });
+
+    const aggregate = writes.find((w) => w.key.startsWith('aviation:carrier-ops:'));
+    const child = writes.find((w) => w.key.startsWith('aviation:flights:DDD:'));
+    assert.ok(aggregate, 'expected a carrier-ops aggregate write');
+    assert.ok(child, 'expected a per-airport child write');
+    assert.ok(
+      aggregate.ttlSeconds >= child.ttlSeconds,
+      `carrier-ops aggregate TTL (${aggregate.ttlSeconds}s) is shorter than its child `
+      + `airport TTL (${child.ttlSeconds}s) — the aggregate would re-fan-out while its inputs are still cached`,
+    );
+  });
+});


### PR DESCRIPTION
fix(aviation): raise the AviationStack cache TTL past the poll cadence that defeated it

`list-airport-flights` and `get-carrier-ops` cached for 300s. A scraper polling
both every ~5.7 minutes turned that into a ~100% cache-miss rate: every poll
landed just after the key expired, so the cache bought nothing and each request
still paid for an AviationStack call.

Measured on the AviationStack-billing routes:

| window     | requests/day | misses/day | p50 latency |
|------------|--------------|------------|-------------|
| Aug 2–5    | ~690         | ~115 (17%) | 0 ms        |
| Aug 6–19   | ~570         | ~530 (93%) | 1700 ms     |

On Aug 13–17 the miss rate for the scraper's own traffic was exact: 504/504,
508/508, 505/506. It costs ~1,000 paid calls/day — about 43% of total spend
against a 50,000/mo plan the account is already over (July counter: 50,427).

`get-carrier-ops` is the expensive half. Each miss fans out to
`listAirportFlights` once PER AIRPORT, so one uncached request is N paid calls,
not one.

Raising both to 900s breaks the resonance for any client polling faster than
15 minutes. Departure boards and carrier delay aggregates do not move
meaningfully inside that window, and the seeded map/health path is unaffected —
it reads `aviation:delays:intl:v3`, which this does not touch.

`tests/aviation-cache-ttl-poll-resonance.test.mts` locks it. The assertions read
the TTL off the actual `SET ... EX` the handler issues and compare it against
the poll cadence observed in production, rather than against a constant — a
later bump stays green, a regression under the cadence goes red. Mutation-
checked: setting either constant back to 300 turns both tests red with the
production failure message. A third test asserts the carrier-ops aggregate never
expires before the airport boards it is built from, so the aggregate cannot
churn while its own inputs are still warm.

Does not change the HTTP `Cache-Control` floor (`max-age=300`, `slow-browser`
tier) — that is a separate layer, and `server/__tests__/gateway-no-store-cache-floor.test.ts`
still pins it.

Refs the AviationStack overage on the 2026-07-25 → 2026-08-24 cycle.

Claude-Session: https://claude.ai/code/session_01P9aU8VB3ufQktUyXCsMVHC

https://claude.ai/code/session_01P9aU8VB3ufQktUyXCsMVHC
