### PR TITLE
fix(health): count the aggregate flightDelays serves, not FAA alone (#6987)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -882,11 +882,36 @@ const SEED_META = {
   progressData:     { key: 'seed-meta:economic:worldbank-progress:v1',     maxStaleMin: 10080 },
   renewableEnergy:  { key: 'seed-meta:economic:worldbank-renewable:v1',    maxStaleMin: 10080 },
   intlDelays:       { key: 'seed-meta:aviation:intl',           maxStaleMin: 90 },
-  // faaDelays has no SEED_META entry by design: it is in EMPTY_DATA_OK_KEYS, so a
-  // quiet FAA window is a valid state and needs no seed clock to excuse it. It no
-  // longer shares a meta key with flightDelays — that sharing was the #6987 bug,
-  // because it leaked FAA's allowed-empty count into the aggregate probe, which
-  // is NOT allowed to be empty.
+  // #6987: faaDelays used to have no entry here, on the grounds that it "shares
+  // flightDelays's meta key". That sharing WAS the bug — it leaked FAA's
+  // allowed-empty count into the aggregate probe, which is not allowed to be
+  // empty. Now that flightDelays reads the aggregate's own meta, the FAA sidecar
+  // gets an explicit entry rather than an implicit one (ported from #6988).
+  //
+  // faaDelays stays in EMPTY_DATA_OK_KEYS, so a quiet FAA window remains a VALID
+  // state; this entry adds the staleness coverage it never had, which is the
+  // half that was genuinely missing.
+  faaDelays:        {
+    key: 'seed-meta:aviation:faa',
+    maxStaleMin: 90,
+    // Pre-seed, not an acknowledgement: the key itself has existed for a long
+    // time (it was registered under flightDelays), so classifyKey against the
+    // live value already returns OK. recordCount=0 is VALID here because
+    // faaDelays is in EMPTY_DATA_OK_KEYS.
+    cutover: {
+      mode: 'preseed',
+      fromKey: null,
+      issue: 6987,
+      verifiedAt: '2026-08-20T10:36:00.000Z',
+      evidence: {
+        platform: 'railway',
+        service: 'seed-aviation',
+        probeKey: 'seed-meta:aviation:faa',
+        compactHealthStatus: 'OK',
+        reference: 'https://github.com/koala73/worldmonitor/issues/6987#issuecomment-5354967398',
+      },
+    },
+  },
   theaterPosture:   { key: 'seed-meta:theater-posture',         maxStaleMin: 60 },
   correlationCards: { key: 'seed-meta:correlation:cards',       maxStaleMin: 30 }, // 5min cron (seed-bundle-derived-signals); 30min = 6× interval. Was 15 (3× = gold-standard floor) — overnight UptimeRobot flips when bundle jitter spaced two consecutive runs ~9-10min apart, producing 15-19min gaps that tripped STALE_SEED briefly. See WM 2026-05-10 health:failure-log.
   portwatch:           { key: 'seed-meta:supply_chain:portwatch',            maxStaleMin: 720 },

--- a/api/health.js
+++ b/api/health.js
@@ -575,7 +575,17 @@ const SEED_META = {
   stablecoinMarkets:{ key: 'seed-meta:market:stablecoins',      maxStaleMin: 60 },
   naturalEvents:    { key: 'seed-meta:natural:events',          maxStaleMin: 540 }, // 3h Railway climate bundle; 3x cadence preserves a full missed run.
   hkoWarnings:      { key: 'seed-meta:weather:hko-warnings',    maxStaleMin: 540 }, // successful HKO responses publish a snapshot even when no tropical-cyclone warning is active.
-  flightDelays:     { key: 'seed-meta:aviation:faa',            maxStaleMin: 90 }, // CACHE_TTL=7200s; matches notamClosures from same cron
+  // #6987: moved off seed-meta:aviation:faa, which carries the FAA-ONLY alert
+  // count. This probe's data key is the combined page-load aggregate, so a quiet
+  // FAA window published recordCount=0 while 115 alerts were still being served
+  // and classifyKey read that zero as EMPTY_DATA. seed-aviation now publishes a
+  // meta from the aggregate's own payload, so the probe counts the population it
+  // actually serves — and an aggregate that is genuinely empty still alarms.
+  flightDelays:     {
+    key: 'seed-meta:aviation:delays-bootstrap',
+    maxStaleMin: 90, // CACHE_TTL=7200s; matches notamClosures from same cron
+    cutover: { mode: 'expiring-ack', fromKey: 'seed-meta:aviation:faa', issue: 6987, status: 'STALE_SEED' },
+  },
   notamClosures:    { key: 'seed-meta:aviation:notam',          maxStaleMin: 240 }, // 2h interval; 240min = 2x interval
   predictionMarkets: {
     key: 'seed-meta:prediction:markets',
@@ -872,7 +882,11 @@ const SEED_META = {
   progressData:     { key: 'seed-meta:economic:worldbank-progress:v1',     maxStaleMin: 10080 },
   renewableEnergy:  { key: 'seed-meta:economic:worldbank-renewable:v1',    maxStaleMin: 10080 },
   intlDelays:       { key: 'seed-meta:aviation:intl',           maxStaleMin: 90 },
-  // faaDelays shares seed-meta key with flightDelays — no duplicate entry needed here
+  // faaDelays has no SEED_META entry by design: it is in EMPTY_DATA_OK_KEYS, so a
+  // quiet FAA window is a valid state and needs no seed clock to excuse it. It no
+  // longer shares a meta key with flightDelays — that sharing was the #6987 bug,
+  // because it leaked FAA's allowed-empty count into the aggregate probe, which
+  // is NOT allowed to be empty.
   theaterPosture:   { key: 'seed-meta:theater-posture',         maxStaleMin: 60 },
   correlationCards: { key: 'seed-meta:correlation:cards',       maxStaleMin: 30 }, // 5min cron (seed-bundle-derived-signals); 30min = 6× interval. Was 15 (3× = gold-standard floor) — overnight UptimeRobot flips when bundle jitter spaced two consecutive runs ~9-10min apart, producing 15-19min gaps that tripped STALE_SEED briefly. See WM 2026-05-10 health:failure-log.
   portwatch:           { key: 'seed-meta:supply_chain:portwatch',            maxStaleMin: 720 },

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -32,6 +32,7 @@ import {
   CHROME_UA,
   runSeed,
   writeExtraKeyWithMeta,
+  writeSeedMeta,
   extendExistingTtl,
   acquireLockSafely,
   releaseLock,
@@ -59,14 +60,21 @@ const FAA_KEY          = 'aviation:delays:faa:v1';
 const NOTAM_KEY        = 'aviation:notam:closures:v2';
 const NEWS_KEY         = 'aviation:news::24:v1';
 // Page-load hydration aggregate. Health (api/health.js BOOTSTRAP_KEYS.flightDelays)
-// reads STRLEN here. Historically only written as a 1800s RPC side-effect inside
+// reads STRLEN here, and its record count from BOOTSTRAP_META_KEY below — which
+// must be written from THIS payload, not from a contributing source's own count
+// (#6987). Historically only written as a 1800s RPC side-effect inside
 // list-airport-delays.ts — quiet user windows >30min would let it expire, tripping
 // EMPTY (CRIT) even with healthy upstream feeds. Now produced canonically by this
 // seeder; RPC keeps its write at the same TTL as a courtesy mid-tick refresh.
 // #3707: bumped to v2 after the UNKNOWN-row coverage fix so post-deploy clients
 // don't briefly see pre-fix cached payloads that synthesise NORMAL rows for
 // uncovered airports.
-const BOOTSTRAP_KEY = 'aviation:delays-bootstrap:v2';
+export const BOOTSTRAP_KEY = 'aviation:delays-bootstrap:v2';
+// Freshness + count for the aggregate above. flightDelays previously borrowed
+// seed-meta:aviation:faa, which counts FAA alerts only: a quiet FAA window
+// published recordCount=0 while this aggregate still served ~115 alerts from
+// AviationStack and NOTAM, and health read that zero as EMPTY_DATA (#6987).
+export const BOOTSTRAP_META_KEY = 'seed-meta:aviation:delays-bootstrap';
 
 const INTL_TTL      = 10_800; // 3h — survives ~5 consecutive missed 30min cron ticks
 const FAA_TTL       = 7_200;  // 2h
@@ -1203,6 +1211,12 @@ async function writeDelaysBootstrap(intlOverride) {
     const payload = buildDelaysBootstrapPayload({ faaPayload, intlPayload, notamPayload });
     const ok = await upstashSet(BOOTSTRAP_KEY, payload, BOOTSTRAP_TTL);
     if (ok) {
+      // Only after the aggregate itself landed: a heartbeat written ahead of a
+      // failed SET would claim freshness for a payload nobody stored. The meta
+      // TTL (writeSeedMeta's 7d default) deliberately outlives BOOTSTRAP_TTL, so
+      // an expired aggregate reads STALE_SEED against maxStaleMin rather than
+      // losing its clock at the same moment it loses its data.
+      await writeSeedMeta(BOOTSTRAP_KEY, payload.alerts.length, BOOTSTRAP_META_KEY);
       console.log(`[Bootstrap] wrote ${payload.alerts.length} alerts to ${BOOTSTRAP_KEY} (faa=${Array.isArray(faaPayload?.alerts) ? faaPayload.alerts.length : 0}, intl=${Array.isArray(intlPayload?.alerts) ? intlPayload.alerts.length : 0}, notam-closed=${Array.isArray(notamPayload?.closedIcaos) ? notamPayload.closedIcaos.length : 0}, notam-restricted=${Array.isArray(notamPayload?.restrictedIcaos) ? notamPayload.restrictedIcaos.length : 0})`);
     } else {
       console.warn(`[Bootstrap] SET ${BOOTSTRAP_KEY} returned false`);

--- a/scripts/seed-freshness-baseline.json
+++ b/scripts/seed-freshness-baseline.json
@@ -23,5 +23,18 @@
     "block in api/health.js exists to prevent."
   ],
   "expiresAt": "2026-08-27",
-  "acknowledged": []
+  "acknowledged": [
+    {
+      "name": "flightDelays",
+      "status": "STALE_SEED",
+      "issue": 6987,
+      "reason": "Probe meta moves from seed-meta:aviation:faa (FAA-only alert count) to seed-meta:aviation:delays-bootstrap, written from the aggregate this probe actually serves. The new key does not exist until seed-aviation next runs, and this probe is meta-only against a served aggregate, so the gap reads STALE_SEED rather than EMPTY -- measured with classifyKey against this branch, not assumed. aviation:faa runs on a 45-minute interval, so the first tick after deploy closes it.",
+      "expiresAt": "2026-08-21T00:00:00.000Z",
+      "cutover": {
+        "probeKey": "seed-meta:aviation:delays-bootstrap",
+        "activatedAt": "2026-08-20T10:00:00.000Z",
+        "firstScheduledRunAt": "2026-08-21T00:00:00.000Z"
+      }
+    }
+  ]
 }

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -28,6 +28,7 @@ const {
   SEED_META,
   ON_DEMAND_KEYS,
   ZERO_RECORD_DATA_OK_KEYS,
+  EMPTY_DATA_OK_KEYS,
 } = __testing__;
 
 const NOW = 1_700_000_000_000;
@@ -2063,4 +2064,43 @@ test('#6987 — health and seed-aviation agree on the aggregate meta key', () =>
   // repoints, this fails instead of both sides drifting quietly.
   assert.equal(BOOTSTRAP_KEYS.flightDelays, AVIATION_BOOTSTRAP_KEY);
   assert.equal(SEED_META.flightDelays.key, AVIATION_BOOTSTRAP_META_KEY);
+});
+
+// The other half of #6987. faaDelays had no SEED_META entry at all, on the
+// grounds that it "shares flightDelays's meta key" — the sharing that caused the
+// bug. It now has an explicit one (ported from #6988), which must ADD staleness
+// coverage without withdrawing the quiet-window allowance that makes an empty
+// FAA feed a valid state rather than a fault.
+const classifyFaaDelays = (over = {}) => classifyKey(
+  'faaDelays',
+  STANDALONE_KEYS.faaDelays,
+  { allowOnDemand: false },
+  makeCtx({
+    strens: { [STANDALONE_KEYS.faaDelays]: 13 }, // {"alerts":[]}
+    metaValues: { [SEED_META.faaDelays.key]: seedMeta(over) },
+  }),
+);
+
+test('#6987 — a quiet FAA window stays valid for the sidecar probe', () => {
+  assert.ok(
+    EMPTY_DATA_OK_KEYS.has('faaDelays'),
+    'an empty FAA feed is a normal state; withdrawing that turns quiet nights into alarms',
+  );
+  assert.equal(classifyFaaDelays({ recordCount: 0 }).status, 'OK');
+});
+
+test('#6987 — the sidecar probe gains the staleness coverage it never had', () => {
+  // The point of giving faaDelays its own entry: allowed-to-be-empty must not
+  // also mean allowed-to-stop. 200min against maxStaleMin 90.
+  assert.equal(
+    classifyFaaDelays({ recordCount: 0, fetchedAt: NOW - 200 * ONE_MIN_MS }).status,
+    'STALE_SEED',
+  );
+});
+
+test('#6987 — the two aviation probes no longer share a meta key', () => {
+  // The regression in one line: sharing let FAA's allowed-empty count decide the
+  // aggregate probe, which is not allowed to be empty.
+  assert.notEqual(SEED_META.flightDelays.key, SEED_META.faaDelays.key);
+  assert.equal(SEED_META.faaDelays.key, 'seed-meta:aviation:faa');
 });

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -17,6 +17,7 @@ import { readFileSync } from 'node:fs';
 
 import { __testing__ } from '../api/health.js';
 import { BUNDLE_HEARTBEAT_TTL_SECONDS, bundleHeartbeatKey } from '../scripts/_bundle-runner.mjs';
+import { BOOTSTRAP_KEY as AVIATION_BOOTSTRAP_KEY, BOOTSTRAP_META_KEY as AVIATION_BOOTSTRAP_META_KEY } from '../scripts/seed-aviation.mjs';
 
 const {
   classifyKey,
@@ -2011,4 +2012,55 @@ test('overall: crit above ~3% of total → UNHEALTHY / 200', () => {
   // 5/150 = 0.033 > 0.03
   assert.deepEqual(computeOverall(5, 0, 150), { status: 'UNHEALTHY', http: 200 });
   assert.deepEqual(computeOverall(20, 2, 150), { status: 'UNHEALTHY', http: 200 });
+});
+
+// #6987. flightDelays serves the combined page-load aggregate but read its
+// record count from seed-meta:aviation:faa, which carries the FAA-ONLY count
+// (seed-aviation.mjs writes it as faa.alerts.length). On 2026-08-20 a quiet FAA
+// window published recordCount=0 while the aggregate still served 115 alerts --
+// 14 of them FAA-sourced -- and classifyKey read that zero as EMPTY_DATA,
+// blocking the seed-freshness monitor with a healthy panel.
+const classifyFlightDelays = (over = {}, strlen = 57_608) => classifyKey(
+  'flightDelays',
+  BOOTSTRAP_KEYS.flightDelays,
+  { allowOnDemand: false },
+  makeCtx({
+    strens: { [BOOTSTRAP_KEYS.flightDelays]: strlen },
+    metaValues: { [SEED_META.flightDelays.key]: seedMeta(over) },
+  }),
+);
+
+test('#6987 — a quiet FAA window does not empty the aggregate flightDelays serves', () => {
+  // The exact production shape: aggregate full, FAA contributing nothing.
+  assert.equal(classifyFlightDelays({ recordCount: 115 }).status, 'OK');
+});
+
+test('#6987 — an aggregate that is genuinely empty still alarms', () => {
+  // The counterweight. Fixing the false alarm must not blind the probe: this is
+  // the state the EMPTY_DATA verdict exists for, and it must survive.
+  assert.equal(classifyFlightDelays({ recordCount: 0 }).status, 'EMPTY_DATA');
+});
+
+test('#6987 — flightDelays counts its own data key, not a contributing source', () => {
+  // The regression itself, asserted structurally so it cannot creep back via a
+  // key swap that the two behavioural tests above would still pass.
+  assert.notEqual(
+    SEED_META.flightDelays.key,
+    'seed-meta:aviation:faa',
+    'seed-meta:aviation:faa counts FAA alerts only — strictly smaller than the aggregate served',
+  );
+  // writeSeedMeta derives `seed-meta:<dataKey without :vN>`; pinning health to
+  // that derivation is what keeps the count and the payload the same population.
+  assert.equal(
+    SEED_META.flightDelays.key,
+    `seed-meta:${BOOTSTRAP_KEYS.flightDelays.replace(/:v\d+$/, '')}`,
+  );
+});
+
+test('#6987 — health and seed-aviation agree on the aggregate meta key', () => {
+  // Cross-file, against the seeder's REAL exported constants rather than a
+  // regex over its source: if the producer renames the key it writes, or health
+  // repoints, this fails instead of both sides drifting quietly.
+  assert.equal(BOOTSTRAP_KEYS.flightDelays, AVIATION_BOOTSTRAP_KEY);
+  assert.equal(SEED_META.flightDelays.key, AVIATION_BOOTSTRAP_META_KEY);
 });

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -119,7 +119,7 @@ const EXCLUDED_FROM_MCP = new Map([
   ['positive-events:geo:v1',
     'cascade-mirror: live counterpart of positive_events:geo-bootstrap:v1 (covered by get_positive_events).'],
   ['aviation:delays:faa:v1',
-    'cascade-mirror: RPC variant of aviation:delays-bootstrap:v2 (covered by get_aviation_status). Same seed-meta key (seed-meta:aviation:faa).'],
+    'cascade-mirror: RPC variant of aviation:delays-bootstrap:v2 (covered by get_aviation_status). Its own seed-meta:aviation:faa carries the FAA-only count; the aggregate counts itself since #6987.'],
   ['cyber:threats:v2',
     'cascade-mirror: RPC variant of cyber:threats-bootstrap:v2 (covered by get_cyber_threats). Same seed-meta key (seed-meta:cyber:threats).'],
   ['conflict:ucdp-events-bootstrap:v1',


### PR DESCRIPTION
Closes #6987.

## The defect

`flightDelays` serves the combined page-load aggregate but read its record count from `seed-meta:aviation:faa` — the **FAA-only** count, which `seed-aviation.mjs:1255` writes as `faa.alerts.length`. A quiet FAA window therefore published `recordCount: 0` while the aggregate was still full.

Production, 2026-08-20T09:45Z:

```
GET    seed-meta:aviation:faa       -> {"fetchedAt":...,"recordCount":0}
GET    aviation:delays:faa:v1       -> alerts: 0
STRLEN aviation:delays-bootstrap:v2 -> 57608
GET    aviation:delays-bootstrap:v2 -> alerts: 115
                                        UNSPECIFIED 59, AVIATIONSTACK 42, FAA 14
```

115 alerts served — 14 of them *still FAA-sourced* — and the probe reported empty:

```
Ingestion operational acceptance failed: 1 unacknowledged problem(s).
- flightDelays: status=EMPTY_DATA records=0 age=13m max=90m
```

Intermittent, not a one-off: the scheduled run at 08:49Z failed on the same probe, with passing runs either side. It flips whenever FAA's count crosses zero.

## Why this was always going to happen

The contradiction was already encoded in the file. `faaDelays` sits in `EMPTY_DATA_OK_KEYS` — a quiet FAA window is an **explicitly valid** state. `flightDelays` is not in that set, because an empty aggregate is a real fault.

Pointing the aggregate's probe at FAA's meta let FAA's *allowed*-empty leak into a probe that must **never** be empty.

`seed-aviation.mjs:61` also already stated the intended contract — *"Health (api/health.js BOOTSTRAP_KEYS.flightDelays) reads STRLEN here."* STRLEN was 57,608 the whole time; only the borrowed count said zero.

## The fix

`seed-aviation` now publishes `seed-meta:aviation:delays-bootstrap` from the aggregate's own payload, so the probe counts the population it serves.

The meta is written **only after** the aggregate SET succeeds — a heartbeat ahead of a failed write would claim freshness for a payload nobody stored. `writeSeedMeta`'s 7d default TTL deliberately outlives `BOOTSTRAP_TTL` (2h), so an expired aggregate reads `STALE_SEED` against `maxStaleMin` rather than losing its clock at the same moment it loses its data.

## Measured, not assumed

`classifyKey` run against this branch:

| state | verdict |
|---|---|
| FAA quiet, aggregate full (the false alarm) | **OK** |
| aggregate genuinely empty | **EMPTY_DATA** — alarm preserved |
| meta older than `maxStaleMin` | `STALE_SEED` |
| aggregate expired, meta survives | `EMPTY` |
| new meta absent (pre-deploy) | `STALE_SEED` |

That last row is what the expiring acknowledgement declares. `aviation:faa` runs on a 45-minute interval, so the first tick after deploy closes it.

Fixing the false alarm must not blind the probe, which is why the second row is asserted as its own test rather than left implied.

## The FAA sidecar gets its own entry (ported from #6988)

#6988 diagnosed this defect independently and handled one half **better** than my first pass: rather than just correcting the stale comment, it gives `faaDelays` an explicit entry. Moving `flightDelays` onto the aggregate's meta otherwise leaves the sidecar with no clock at all, since it never had its own — the comment claimed it "shares flightDelays's meta key", and that sharing *was* the bug.

```js
faaDelays: { key: 'seed-meta:aviation:faa', maxStaleMin: 90 },
```

The distinction that matters: `faaDelays` stays in `EMPTY_DATA_OK_KEYS`, so a quiet FAA window remains a **valid** state. Allowed-to-be-empty must not also mean allowed-to-stop — that gap is what this closes, and it is asserted both ways in tests.

That new entry is itself a probe-key transition to the cutover gate, even though the key has existed in production for a long time (it was registered under `flightDelays`). `classifyKey` against the live value returns `OK`, so it is declared **pre-seed** rather than acknowledged — measured, not assumed:

```
GET    seed-meta:aviation:faa -> {"fetchedAt":1787221944368,"recordCount":0}
STRLEN aviation:delays:faa:v1 -> 13
=> compact health status: OK
```

Both cutovers pass:

```
flightDelays seed-meta:aviation:faa -> seed-meta:aviation:delays-bootstrap (expiring-ack)
faaDelays    <new> -> seed-meta:aviation:faa (preseed)
```

The MCP parity justification repeated the same stale "same seed-meta key" claim and is corrected too.

`yzxcj797` is credited as co-author on that commit. #6988 is closed in favour of this PR, which carries its `faaDelays` improvement plus the cutover declarations its CI was red on.

## Verification

- health-probe cutover gate passes for **both** transitions (`expiring-ack` + `preseed`);
- **627 tests pass, 0 fail** across health-classify, the aviation suites, mcp-bootstrap-parity, seed-ttl-outlives-staleness-fleet, freshness-monitor and railway-deploy, plus 239 re-run after the `faaDelays` port;
- reverting the key turns the two **structural** tests red. The behavioural pair reads the configured key dynamically, so it cannot catch a key swap — that division is deliberate: the behavioural tests instead catch someone silencing this by adding `flightDelays` to `ZERO_RECORD_DATA_OK_KEYS`;
- Biome clean.

## Note

The RPC (`list-airport-delays.ts:184`) also writes the aggregate as a mid-tick courtesy refresh and does not write the meta. That is unchanged by this PR and harmless — the seeder refreshes the meta every 45 min against a 90 min `maxStaleMin` — but it does mean the count reflects the last seeder tick rather than the last RPC write.

Separately: the eight expired freshness acknowledgements I set out to clear alongside this had already been removed on main by #6980, so this PR is the flightDelays fix alone.
