### PR TITLE
fix(aviation): make the AviationStack budget cap actually bind, and bound the carrier-ops fan-out

### DIFF
--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -1342,28 +1342,51 @@ export async function intlIsFresh() {
   }
 }
 
-// Monthly AviationStack budget backstop. Mirrors reserveAviationStackCalls() in
-// server/worldmonitor/aviation/v1/_avstack-budget.ts — SAME Redis key + env
-// names so the seeder and the request-time RPCs share one counter and one hard
-// ceiling. Keep the two in lockstep. 'seed' kind reserves against the full
-// AVIATIONSTACK_MONTHLY_BUDGET; request-time stops earlier (see
-// _avstack-budget.ts), reserving headroom for this curated feed.
+// Billing-cycle AviationStack budget backstop. Mirrors
+// reserveAviationStackCalls() in server/worldmonitor/aviation/v1/_avstack-budget.ts
+// — SAME Redis key + env names so the seeder and the request-time RPCs share
+// one counter and one hard ceiling. Keep the two in lockstep. 'seed' kind
+// reserves against the full AVIATIONSTACK_MONTHLY_BUDGET; request-time stops
+// earlier (see _avstack-budget.ts), reserving headroom for this curated feed.
+//
+// This seeder is the bulk spender: AVIATIONSTACK_LIST.length (56) paid calls
+// per sweep, ~24 sweeps/day under the 55min freshness gate — ~40.3k of the 48k
+// default over a 30-day cycle, ~41.7k over a 31-day one. If that stops fitting
+// the plan, the sweep cadence is the lever, not this ceiling.
 export function avstackMonthlyBudget() {
-  return nonNegativeEnv('AVIATIONSTACK_MONTHLY_BUDGET', 130_000);
+  return nonNegativeEnv('AVIATIONSTACK_MONTHLY_BUDGET', 48_000);
+}
+
+const DEFAULT_CYCLE_RESET_DAY = 25;
+
+// Clamped to 1..28 so a cycle opens in every month — an anniversary of 29-31
+// would silently skip February and hand out a double-length allowance.
+function cycleResetDay() {
+  const raw = Number(process.env.AVIATIONSTACK_CYCLE_RESET_DAY?.trim());
+  if (!Number.isInteger(raw) || raw < 1 || raw > 28) return DEFAULT_CYCLE_RESET_DAY;
+  return raw;
 }
 
 /**
- * Redis counter key for the current UTC billing month.
+ * Redis counter key for the current UTC BILLING CYCLE, named by its start date.
+ *
+ * The window is the invoice's, not the calendar's — AviationStack bills from an
+ * anniversary day (the 25th on this account), so a `<YYYY-MM>` key kept the cap
+ * refusing calls into a fresh allowance and zeroing itself mid-cycle.
  *
  * The server-side reserver in server/worldmonitor/aviation/v1/_avstack-budget.ts
- * builds the SAME key; if the two ever drift, the shared monthly ceiling splits
- * into two independent counters and silently doubles AviationStack spend.
- * Exported so that agreement can be asserted by comparing the two functions'
- * output rather than by grepping both files for `getUTCMonth()`.
+ * builds the SAME key; if the two ever drift, the shared ceiling splits into two
+ * independent counters and silently doubles AviationStack spend. Exported so
+ * that agreement can be asserted by comparing the two functions' output rather
+ * than by grepping both files for `getUTCMonth()`.
  */
 export function avstackBudgetKey(now = new Date()) {
-  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
-  return `aviation:avstack:calls:${ym}`;
+  const resetDay = cycleResetDay();
+  const monthOffset = now.getUTCDate() >= resetDay ? 0 : -1;
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + monthOffset, resetDay));
+  const pad = (n) => String(n).padStart(2, '0');
+  const cycle = `${start.getUTCFullYear()}-${pad(start.getUTCMonth() + 1)}-${pad(start.getUTCDate())}`;
+  return `aviation:avstack:calls:${cycle}`;
 }
 
 export async function reserveAviationStackBudget(count) {

--- a/server/worldmonitor/aviation/v1/_avstack-budget.ts
+++ b/server/worldmonitor/aviation/v1/_avstack-budget.ts
@@ -1,22 +1,33 @@
 import { runRedisPipeline } from '../../../_shared/redis';
 
-// ---------- AviationStack monthly call budget ----------
+// ---------- AviationStack billing-cycle call budget ----------
 //
-// Hard ceiling on PAID AviationStack calls per calendar month, shared across
+// Hard ceiling on PAID AviationStack calls per BILLING CYCLE, shared across
 // every call site (the request-time RPC layer + scripts/seed-aviation.mjs).
-// All callers INCRBY the same Redis counter `aviation:avstack:calls:<YYYY-MM>`
-// (UTC) and refuse to call upstream once their ceiling is reached, so total
-// spend can never exceed the plan no matter how much user traffic or how many
-// cron ticks arrive.
+// All callers INCRBY the same Redis counter
+// `aviation:avstack:calls:<YYYY-MM-DD>` (UTC, the cycle's start date) and
+// refuse to call upstream once their ceiling is reached, so total spend can
+// never exceed the plan no matter how much user traffic or how many cron ticks
+// arrive.
+//
+// The window is the invoice's, not the calendar's. AviationStack bills from an
+// anniversary day (the 25th on this account), so the counter used to key on
+// `<YYYY-MM>` while the invoice ran the 25th → 24th. That mismatch makes the
+// cap wrong in BOTH directions: it keeps refusing calls into the first days of
+// a fresh allowance, and it zeroes itself a week into a cycle that is already
+// partly spent. AVIATIONSTACK_CYCLE_RESET_DAY moves the anniversary.
 //
 // Two ceilings against ONE counter so user-panel traffic can't starve the
 // curated seeder (the seeder feeds the map + health; request-time is a panel
 // nicety):
-//   - request-time calls stop at AVIATIONSTACK_REQUEST_BUDGET (default 85k)
+//   - request-time calls stop at AVIATIONSTACK_REQUEST_BUDGET (default 7k)
 //   - all calls (incl. seeder) stop at AVIATIONSTACK_MONTHLY_BUDGET (default
-//     130k) — the gap reserves headroom for the seeder.
-// Defaults sum under a 135k plan with margin. Set MONTHLY budget to 0 to
-// disable the cap entirely (legacy behaviour).
+//     48k) — the gap reserves headroom for the seeder.
+// Defaults sit under a 50,000/cycle plan. Note the seeder alone needs ~40.3k
+// (56 airports x 24 sweeps x 30d) and ~41.7k on a 31-day cycle, so the reserved
+// gap is deliberately most of the budget and the real headroom is thin —
+// lowering the seeder's sweep cadence is the lever if that stops fitting.
+// Set MONTHLY budget to 0 to disable the cap entirely (legacy behaviour).
 //
 // IMPORTANT: keep the key format + env names in lockstep with the duplicate
 // implementation in scripts/seed-aviation.mjs (the seeder is plain .mjs and
@@ -24,19 +35,42 @@ import { runRedisPipeline } from '../../../_shared/redis';
 // same Upstash instance, so they share the counter; preview deploys are
 // key-prefixed and bill separately, which is fine.
 
-export function aviationStackBudgetMonth(now = new Date()): string {
-  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
-  return ym;
+const DEFAULT_CYCLE_RESET_DAY = 25;
+
+// Clamped to 1..28 so a cycle opens in every month — an anniversary of 29-31
+// would silently skip February and hand out a double-length allowance.
+function cycleResetDay(): number {
+  const raw = Number(process.env.AVIATIONSTACK_CYCLE_RESET_DAY?.trim());
+  if (!Number.isInteger(raw) || raw < 1 || raw > 28) return DEFAULT_CYCLE_RESET_DAY;
+  return raw;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * UTC start date of the billing cycle containing `now`, as `YYYY-MM-DD`.
+ *
+ * On or after the anniversary day we are in the cycle that opened this month;
+ * before it, we are still inside the one that opened last month. `Date.UTC`
+ * normalises month -1 into the previous December, so January is not special.
+ */
+export function aviationStackBudgetCycle(now = new Date()): string {
+  const resetDay = cycleResetDay();
+  const monthOffset = now.getUTCDate() >= resetDay ? 0 : -1;
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + monthOffset, resetDay));
+  return `${start.getUTCFullYear()}-${pad(start.getUTCMonth() + 1)}-${pad(start.getUTCDate())}`;
 }
 
 // Exported so a test can prove this agrees with the seeder's avstackBudgetKey:
-// a drift between the two splits the shared monthly ceiling into two counters
-// and silently doubles AviationStack spend.
+// a drift between the two splits the shared ceiling into two counters and
+// silently doubles AviationStack spend.
 export function avstackBudgetKey(now = new Date()): string {
-  return `aviation:avstack:calls:${aviationStackBudgetMonth(now)}`;
+  return `aviation:avstack:calls:${aviationStackBudgetCycle(now)}`;
 }
 
-const AVSTACK_BUDGET_TTL = 40 * 24 * 60 * 60; // 40d — outlives the month; next month uses a new key
+const AVSTACK_BUDGET_TTL = 40 * 24 * 60 * 60; // 40d — outlives the longest cycle; the next cycle uses a new key
 
 function intEnv(name: string, fallback: number): number {
   const value = process.env[name]?.trim();
@@ -46,13 +80,13 @@ function intEnv(name: string, fallback: number): number {
 }
 
 /**
- * Reserve `count` AviationStack calls against the monthly budget. Returns true
+ * Reserve `count` AviationStack calls against the billing-cycle budget. Returns true
  * if the caller may proceed with the upstream call(s), false if doing so would
  * breach the ceiling for this `kind` (caller should serve last-good/empty).
  *
  * Fail-open: if Redis is unreachable we allow the call. The seeder — the bulk
  * spender — is independently bounded by its freshness gate, and failing closed
- * would blank the panel on every Redis blip. The 5k margin under a 135k plan
+ * would blank the panel on every Redis blip. The 2k margin under a 50k plan
  * absorbs the slack.
  */
 export async function reserveAviationStackCalls(
@@ -60,11 +94,11 @@ export async function reserveAviationStackCalls(
   kind: 'request' | 'seed',
 ): Promise<boolean> {
   if (count <= 0) return true;
-  const hardCap = intEnv('AVIATIONSTACK_MONTHLY_BUDGET', 130_000);
+  const hardCap = intEnv('AVIATIONSTACK_MONTHLY_BUDGET', 48_000);
   if (hardCap <= 0) return true; // cap disabled
   const ceiling = kind === 'seed'
     ? hardCap
-    : Math.min(hardCap, intEnv('AVIATIONSTACK_REQUEST_BUDGET', 85_000));
+    : Math.min(hardCap, intEnv('AVIATIONSTACK_REQUEST_BUDGET', 7_000));
 
   const key = avstackBudgetKey();
   try {
@@ -81,7 +115,7 @@ export async function reserveAviationStackCalls(
       if (!Number.isFinite(refundedTotal)) {
         console.warn(`[Aviation] AviationStack ${kind} budget refund failed for ${count} call(s); counter may be inflated`);
       }
-      console.warn(`[Aviation] AviationStack ${kind} call blocked — monthly budget reached (${total - count}/${ceiling})`);
+      console.warn(`[Aviation] AviationStack ${kind} call blocked — cycle budget reached (${total - count}/${ceiling})`);
       return false;
     }
     return true;

--- a/server/worldmonitor/aviation/v1/_shared.ts
+++ b/server/worldmonitor/aviation/v1/_shared.ts
@@ -25,6 +25,18 @@ export const FAA_URL = 'https://nasstatus.faa.gov/api/airport-status-information
 export const AVIATIONSTACK_URL = 'https://api.aviationstack.com/v1/flights';
 export const ICAO_NOTAM_URL = 'https://dataservices.icao.int/api/notams-realtime-list';
 export const DEFAULT_WATCHED_AIRPORTS = ['IST', 'ESB', 'SAW', 'LHR', 'FRA', 'CDG'];
+
+// Shared by every route that turns a caller-supplied airport code into a PAID
+// AviationStack call. Rejecting non-IATA input before the fetch bounds cache-key
+// cardinality and stops arbitrary strings being used to probe upstream.
+export const IATA_RE = /^[A-Z]{3}$/;
+
+// Ceiling on how many airports one request may fan out to. get-carrier-ops
+// issues one paid AviationStack call PER AIRPORT, and `parseStringArray` puts no
+// bound on the list, so `?airports=A,B,...` was an unauthenticated multiplier on
+// spend — 26 codes meant 26 paid calls from one anonymous request. Sized to
+// DEFAULT_WATCHED_AIRPORTS so the full watched set still resolves in one call.
+export const MAX_AIRPORTS_PER_REQUEST = DEFAULT_WATCHED_AIRPORTS.length;
 const BATCH_CONCURRENCY = 10;
 const MIN_FLIGHTS_FOR_CLOSURE = 10;
 const RESOLVED_STATUSES = new Set(['cancelled', 'landed', 'active', 'arrived', 'diverted']);

--- a/server/worldmonitor/aviation/v1/get-carrier-ops.ts
+++ b/server/worldmonitor/aviation/v1/get-carrier-ops.ts
@@ -6,7 +6,12 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { cachedFetchJson } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
-import { parseStringArray, DEFAULT_WATCHED_AIRPORTS } from './_shared';
+import {
+    parseStringArray,
+    DEFAULT_WATCHED_AIRPORTS,
+    IATA_RE,
+    MAX_AIRPORTS_PER_REQUEST,
+} from './_shared';
 import { listAirportFlights } from './list-airport-flights';
 
 // 15min, matching list-airport-flights — see the TTL note there. This route is
@@ -19,10 +24,26 @@ export async function getCarrierOps(
     req: GetCarrierOpsRequest,
 ): Promise<GetCarrierOpsResponse> {
     const rawAirports = parseStringArray(req.airports);
-    const airports = rawAirports.length > 0 ? rawAirports.map(a => a.toUpperCase()) : DEFAULT_WATCHED_AIRPORTS.slice(0, 3);
-    const minFlights = req.minFlights ?? 3;
-    const cacheKey = `aviation:carrier-ops:${airports.sort().join(',')}:v1`;
     const now = Date.now();
+
+    // Every airport in this list becomes its own PAID AviationStack call below,
+    // and `parseStringArray` bounds neither the length nor the shape of what a
+    // caller sends. Unbounded, `?airports=A,B,...,Z` was an anonymous multiplier
+    // on spend — 26 codes, 26 paid calls, one request. Validate then truncate:
+    //   - non-IATA codes are rejected outright rather than dropped, so a typo
+    //     surfaces instead of silently returning a different airport set (and so
+    //     arbitrary strings cannot inflate cache-key cardinality);
+    //   - the survivors are capped, matching how list-airport-flights clamps
+    //     `limit` rather than erroring.
+    const requested = rawAirports.map(a => a.toUpperCase());
+    if (requested.some(a => !IATA_RE.test(a))) {
+        return { carriers: [], source: 'invalid', updatedAt: now };
+    }
+    const airports = (requested.length > 0 ? requested : DEFAULT_WATCHED_AIRPORTS.slice(0, 3))
+        .slice(0, MAX_AIRPORTS_PER_REQUEST);
+
+    const minFlights = req.minFlights ?? 3;
+    const cacheKey = `aviation:carrier-ops:${[...airports].sort().join(',')}:v1`;
     let unavailableSource = 'unavailable';
 
     try {

--- a/server/worldmonitor/aviation/v1/get-flight-status.ts
+++ b/server/worldmonitor/aviation/v1/get-flight-status.ts
@@ -7,7 +7,7 @@ import type {
 import { cachedFetchJson } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
-import { aviationStackBudgetMonth, reserveAviationStackCalls } from './_avstack-budget';
+import { aviationStackBudgetCycle, reserveAviationStackCalls } from './_avstack-budget';
 
 const CACHE_TTL = 120; // 2 minutes
 
@@ -61,7 +61,7 @@ export async function getFlightStatus(
         .replace(/^([A-Z]{2,3})0+(\d+)$/, '$1$2');
     const date = req.date || new Date().toISOString().slice(0, 10);
     const origin = req.origin?.toUpperCase() || '';
-    const cacheKey = `aviation:status:${flightNumber}:${date}:${origin}:v1:${aviationStackBudgetMonth()}`;
+    const cacheKey = `aviation:status:${flightNumber}:${date}:${origin}:v1:${aviationStackBudgetCycle()}`;
     const now = Date.now();
 
     if (!flightNumber || flightNumber.length > 10) {

--- a/server/worldmonitor/aviation/v1/list-airport-flights.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-flights.ts
@@ -9,8 +9,8 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { cachedFetchJson } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
-import { getRelayBaseUrl, getRelayHeaders } from './_shared';
-import { aviationStackBudgetMonth, reserveAviationStackCalls } from './_avstack-budget';
+import { getRelayBaseUrl, getRelayHeaders, IATA_RE } from './_shared';
+import { aviationStackBudgetCycle, reserveAviationStackCalls } from './_avstack-budget';
 
 // 15min. Held at 300s until Aug 2026, when a scraper polling every ~5.7min
 // converted this endpoint to a ~100% cache-miss rate: 504 of 504 requests on a
@@ -25,7 +25,6 @@ const CACHE_TTL = 900;
 // separate PAID AviationStack calls for identical data — a cache-key explosion
 // that multiplied spend. The page covers any limit ≤ 100.
 const UPSTREAM_PAGE = 100;
-const IATA_RE = /^[A-Z]{3}$/;
 
 interface AVSFlight {
     flight?: { iata?: string; icao?: string; codeshared?: { flight_iata?: string; airline_iata?: string }[] };
@@ -126,7 +125,7 @@ export async function listAirportFlights(
 
     // Cache key is limit-independent (see UPSTREAM_PAGE) — one upstream call
     // serves every limit for this airport+direction.
-    const cacheKey = `aviation:flights:${airport}:${direction}:v2:${aviationStackBudgetMonth()}`;
+    const cacheKey = `aviation:flights:${airport}:${direction}:v2:${aviationStackBudgetCycle()}`;
     let unavailableSource = 'unavailable';
 
     try {

--- a/tests/aviation-budget-cap.test.mjs
+++ b/tests/aviation-budget-cap.test.mjs
@@ -19,7 +19,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  aviationStackBudgetMonth,
+  aviationStackBudgetCycle,
   avstackBudgetKey as serverAvstackBudgetKey,
 } from '../server/worldmonitor/aviation/v1/_avstack-budget.ts';
 import { avstackBudgetKey as seederAvstackBudgetKey } from '../scripts/seed-aviation.mjs';
@@ -127,10 +127,10 @@ describe('aviation budget: call sites are wired to the cap', () => {
   it('list-airport-flights reserves budget and quantizes the limit out of the cache key', () => {
     const src = read('server/worldmonitor/aviation/v1/list-airport-flights.ts');
     assert.match(src, /reserveAviationStackCalls\(1, 'request'\)/);
-    assert.match(src, /aviationStackBudgetMonth\(\)/);
+    assert.match(src, /aviationStackBudgetCycle\(\)/);
     // Cache key must NOT vary by limit (was the spend-multiplying explosion).
     assert.doesNotMatch(src, /aviation:flights:\$\{airport\}:\$\{direction\}:\$\{limit\}/);
-    assert.match(src, /aviation:flights:\$\{airport\}:\$\{direction\}:v2:\$\{aviationStackBudgetMonth\(\)\}/);
+    assert.match(src, /aviation:flights:\$\{airport\}:\$\{direction\}:v2:\$\{aviationStackBudgetCycle\(\)\}/);
     // Upstream always fetches a fixed page, then slices in memory.
     assert.match(src, /limit:\s*String\(UPSTREAM_PAGE\)/);
     assert.match(src, /flights\.slice\(0, limit\)/);
@@ -139,7 +139,7 @@ describe('aviation budget: call sites are wired to the cap', () => {
   it('get-flight-status reserves budget before the upstream call and negative-caches relay errors', () => {
     const src = read('server/worldmonitor/aviation/v1/get-flight-status.ts');
     assert.match(src, /reserveAviationStackCalls\(1, 'request'\)/);
-    assert.match(src, /aviation:status:\$\{flightNumber\}:\$\{date\}:\$\{origin\}:v1:\$\{aviationStackBudgetMonth\(\)\}/);
+    assert.match(src, /aviation:status:\$\{flightNumber\}:\$\{date\}:\$\{origin\}:v1:\$\{aviationStackBudgetCycle\(\)\}/);
     assert.match(src, /Flight status relay fetch failed/);
     assert.match(src, /unavailableSource = 'error';\n\s+return null;/);
   });
@@ -148,10 +148,10 @@ describe('aviation budget: call sites are wired to the cap', () => {
     const src = read('scripts/seed-aviation.mjs');
     assert.match(src, /reserveAviationStackBudget\(AVIATIONSTACK_LIST\.length\)/);
     // Same Redis key format as the server helper — they MUST share the counter.
-    assert.match(src, /aviation:avstack:calls:\$\{ym\}/);
+    assert.match(src, /aviation:avstack:calls:\$\{cycle\}/);
   });
 
-  it('server and seeder count against the identical monthly budget key', () => {
+  it('server and seeder count against the identical cycle budget key', () => {
     // Drift here splits the shared ceiling into two independent counters and
     // silently doubles AviationStack spend. Run both key builders over the same
     // instants instead of grepping both files for `getUTCMonth()` — which
@@ -166,24 +166,96 @@ describe('aviation budget: call sites are wired to the cap', () => {
     }
   });
 
-  it('rolls the budget key over on the UTC month boundary, not the local one', () => {
+  it('rolls the budget key on the billing anniversary, not the calendar month', () => {
+    // The bug this replaces: the counter keyed on <YYYY-MM> while AviationStack
+    // invoices the 25th → 24th. A calendar key keeps refusing calls into the
+    // first days of a fresh allowance AND zeroes itself a week into a cycle
+    // that is already partly spent — wrong in both directions.
+    for (const key of [serverAvstackBudgetKey, seederAvstackBudgetKey]) {
+      // The calendar month turns over here; the cycle must NOT.
+      assert.equal(key(new Date('2026-07-31T23:59:59.999Z')), 'aviation:avstack:calls:2026-07-25');
+      assert.equal(key(new Date('2026-08-01T00:00:00.000Z')), 'aviation:avstack:calls:2026-07-25');
+      // The cycle turns over here; the calendar month does not.
+      assert.equal(key(new Date('2026-08-24T23:59:59.999Z')), 'aviation:avstack:calls:2026-07-25');
+      assert.equal(key(new Date('2026-08-25T00:00:00.000Z')), 'aviation:avstack:calls:2026-08-25');
+    }
+  });
+
+  it('rolls on the UTC anniversary, not the local one', () => {
     // A local-time boundary would roll early or late for the deployment region
-    // and hand a fresh month's quota to the tail of the previous month.
-    const lastInstantOfJan = new Date('2026-01-31T23:59:59.999Z');
-    const firstInstantOfFeb = new Date('2026-02-01T00:00:00.000Z');
-    assert.equal(serverAvstackBudgetKey(lastInstantOfJan), 'aviation:avstack:calls:2026-01');
-    assert.equal(serverAvstackBudgetKey(firstInstantOfFeb), 'aviation:avstack:calls:2026-02');
-    assert.equal(seederAvstackBudgetKey(lastInstantOfJan), 'aviation:avstack:calls:2026-01');
-    assert.equal(seederAvstackBudgetKey(firstInstantOfFeb), 'aviation:avstack:calls:2026-02');
+    // and hand a fresh cycle's quota to the tail of the previous one.
+    assert.equal(serverAvstackBudgetKey(new Date('2026-08-24T23:59:59.999Z')), 'aviation:avstack:calls:2026-07-25');
+    assert.equal(seederAvstackBudgetKey(new Date('2026-08-24T23:59:59.999Z')), 'aviation:avstack:calls:2026-07-25');
   });
 
-  it('zero-pads single-digit months so keys sort chronologically', () => {
-    assert.equal(aviationStackBudgetMonth(new Date('2026-09-15T00:00:00Z')), '2026-09');
+  it('carries a cycle that opened in the previous year back across January', () => {
+    // Date.UTC(y, -1, 25) must normalise to the previous December, not throw or
+    // clamp — otherwise every January restarts the counter mid-cycle.
+    for (const key of [serverAvstackBudgetKey, seederAvstackBudgetKey]) {
+      assert.equal(key(new Date('2026-01-24T12:00:00Z')), 'aviation:avstack:calls:2025-12-25');
+      assert.equal(key(new Date('2026-01-25T00:00:00Z')), 'aviation:avstack:calls:2026-01-25');
+    }
   });
 
-  it('request cache keys carry the budget month so denials expire at rollover', () => {
-    assert.match(read('server/worldmonitor/aviation/v1/list-airport-flights.ts'), /aviationStackBudgetMonth\(\)/);
-    assert.match(read('server/worldmonitor/aviation/v1/get-flight-status.ts'), /aviationStackBudgetMonth\(\)/);
+  it('zero-pads single-digit months and days so keys sort chronologically', () => {
+    assert.equal(aviationStackBudgetCycle(new Date('2026-09-26T00:00:00Z')), '2026-09-25');
+    assert.equal(aviationStackBudgetCycle(new Date('2026-10-01T00:00:00Z')), '2026-09-25');
+  });
+
+  it('opens a cycle in February, which an anniversary above 28 would skip', () => {
+    // A reset day of 29-31 has no February instant to land on. Both sides clamp
+    // to the 25th default rather than silently running a double-length cycle.
+    const prior = process.env.AVIATIONSTACK_CYCLE_RESET_DAY;
+    process.env.AVIATIONSTACK_CYCLE_RESET_DAY = '31';
+    try {
+      for (const key of [serverAvstackBudgetKey, seederAvstackBudgetKey]) {
+        assert.equal(key(new Date('2026-02-26T00:00:00Z')), 'aviation:avstack:calls:2026-02-25');
+      }
+    } finally {
+      if (prior === undefined) delete process.env.AVIATIONSTACK_CYCLE_RESET_DAY;
+      else process.env.AVIATIONSTACK_CYCLE_RESET_DAY = prior;
+    }
+  });
+
+  it('honours a configured anniversary day on both sides', () => {
+    const prior = process.env.AVIATIONSTACK_CYCLE_RESET_DAY;
+    process.env.AVIATIONSTACK_CYCLE_RESET_DAY = '5';
+    try {
+      for (const key of [serverAvstackBudgetKey, seederAvstackBudgetKey]) {
+        assert.equal(key(new Date('2026-08-04T23:59:59Z')), 'aviation:avstack:calls:2026-07-05');
+        assert.equal(key(new Date('2026-08-05T00:00:00Z')), 'aviation:avstack:calls:2026-08-05');
+      }
+    } finally {
+      if (prior === undefined) delete process.env.AVIATIONSTACK_CYCLE_RESET_DAY;
+      else process.env.AVIATIONSTACK_CYCLE_RESET_DAY = prior;
+    }
+  });
+
+  it('sizes both default ceilings under the 50k plan, with the seeder reserved', () => {
+    // The old defaults (130k hard / 85k request) were sized for a 135k plan the
+    // account does not have, so the cap never fired. These must stay under the
+    // real plan, and the request ceiling must stay well below the hard one or
+    // panel traffic starves the curated seeder.
+    const src = read('server/worldmonitor/aviation/v1/_avstack-budget.ts');
+    const hardCap = Number(/AVIATIONSTACK_MONTHLY_BUDGET', ([\d_]+)\)/.exec(src)?.[1].replace(/_/g, ''));
+    const requestCap = Number(/AVIATIONSTACK_REQUEST_BUDGET', ([\d_]+)\)/.exec(src)?.[1].replace(/_/g, ''));
+    const seederDefault = Number(
+      /AVIATIONSTACK_MONTHLY_BUDGET', ([\d_]+)\)/.exec(read('scripts/seed-aviation.mjs'))?.[1].replace(/_/g, ''),
+    );
+
+    assert.ok(hardCap > 0 && hardCap <= 50_000, `hard cap ${hardCap} must sit under the 50,000/cycle plan`);
+    assert.equal(seederDefault, hardCap, 'seeder mirror must default to the same hard cap');
+    assert.ok(requestCap < hardCap, `request ceiling ${requestCap} must leave the seeder headroom under ${hardCap}`);
+    // 56 airports x 24 sweeps x 30d — what the seeder structurally needs.
+    assert.ok(
+      hardCap - requestCap >= 40_320,
+      `only ${hardCap - requestCap} reserved for the seeder, which needs ~40,320/cycle`,
+    );
+  });
+
+  it('request cache keys carry the budget cycle so denials expire at rollover', () => {
+    assert.match(read('server/worldmonitor/aviation/v1/list-airport-flights.ts'), /aviationStackBudgetCycle\(\)/);
+    assert.match(read('server/worldmonitor/aviation/v1/get-flight-status.ts'), /aviationStackBudgetCycle\(\)/);
   });
 
   it('seeder freshness gate is clamped below the health staleness window', () => {

--- a/tests/aviation-carrier-ops-fanout-cap.test.mts
+++ b/tests/aviation-carrier-ops-fanout-cap.test.mts
@@ -1,0 +1,150 @@
+/**
+ * get-carrier-ops must not let one request buy an unbounded number of paid
+ * AviationStack calls.
+ *
+ * The route fans out to `listAirportFlights` once PER AIRPORT, and
+ * `parseStringArray` puts no bound on `req.airports` — it just splits a comma
+ * separated string. So `?airports=A,B,...,Z` was 26 paid AviationStack calls
+ * from a single anonymous request, against a 50,000/cycle plan.
+ *
+ * These tests count the actual relay calls the handler issues, so they fail if
+ * the cap is removed, raised past the ceiling, or applied after the fan-out
+ * instead of before it.
+ */
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import { getCarrierOps } from '../server/worldmonitor/aviation/v1/get-carrier-ops.ts';
+import {
+  DEFAULT_WATCHED_AIRPORTS,
+  MAX_AIRPORTS_PER_REQUEST,
+} from '../server/worldmonitor/aviation/v1/_shared.ts';
+
+const ENV_KEYS = [
+  'AVIATIONSTACK_MONTHLY_BUDGET',
+  'AVIATIONSTACK_REQUEST_BUDGET',
+  'UPSTASH_REDIS_REST_TOKEN',
+  'UPSTASH_REDIS_REST_URL',
+  'WS_RELAY_URL',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'redis-token';
+  process.env.WS_RELAY_URL = 'https://relay.test';
+  process.env.AVIATIONSTACK_MONTHLY_BUDGET = '0';
+});
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = originalFetch;
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  originalEnv.clear();
+});
+
+/** Records every AviationStack relay URL the handler reaches for. */
+function installFetchMock() {
+  const relayUrls: string[] = [];
+
+  mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+
+    // Every cache read misses, so each airport that survives the cap issues a
+    // real relay call — the thing being counted.
+    if (url.startsWith('https://redis.test/get/')) {
+      return new Response(JSON.stringify({ result: null }), { status: 200 });
+    }
+    if (url === 'https://redis.test/pipeline') {
+      const commands = JSON.parse(String(init?.body ?? '[]')) as unknown[][];
+      return new Response(JSON.stringify(commands.map(() => ({ result: 1 }))), { status: 200 });
+    }
+    if (url === 'https://redis.test/') {
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    }
+    if (url.startsWith('https://relay.test/aviationstack')) {
+      relayUrls.push(url);
+      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+
+  return relayUrls;
+}
+
+function ctxFor(airports: string[]) {
+  const query = airports.map((a) => `airports=${a}`).join('&');
+  return { request: new Request(`https://worldmonitor.app/api/aviation/v1/get-carrier-ops?${query}`), pathParams: {}, headers: {} };
+}
+
+/** 26 distinct valid IATA-shaped codes — the original amplification example. */
+const TWENTY_SIX = Array.from({ length: 26 }, (_, i) => `${String.fromCharCode(65 + i)}AA`);
+
+describe('get-carrier-ops paid fan-out is bounded', () => {
+  it('buys at most MAX_AIRPORTS_PER_REQUEST calls no matter how many airports are asked for', async () => {
+    const relayUrls = installFetchMock();
+
+    await getCarrierOps(ctxFor(TWENTY_SIX), { airports: TWENTY_SIX, minFlights: 0 });
+
+    assert.ok(
+      relayUrls.length <= MAX_AIRPORTS_PER_REQUEST,
+      `26 airports bought ${relayUrls.length} paid AviationStack calls; cap is ${MAX_AIRPORTS_PER_REQUEST}`,
+    );
+    assert.equal(relayUrls.length, MAX_AIRPORTS_PER_REQUEST, 'cap should be applied by truncation, not by dropping the request');
+  });
+
+  it('still serves the full default watched set in one request', async () => {
+    const relayUrls = installFetchMock();
+
+    const response = await getCarrierOps(ctxFor(DEFAULT_WATCHED_AIRPORTS), {
+      airports: DEFAULT_WATCHED_AIRPORTS,
+      minFlights: 0,
+    });
+
+    assert.equal(response.source, 'aviationstack', 'the documented watched set must not be truncated into a partial');
+    assert.equal(relayUrls.length, DEFAULT_WATCHED_AIRPORTS.length);
+  });
+
+  it('rejects a malformed airport code before buying anything', async () => {
+    const relayUrls = installFetchMock();
+
+    const response = await getCarrierOps(ctxFor(['IST', 'NOT-AN-IATA']), {
+      airports: ['IST', 'NOT-AN-IATA'],
+      minFlights: 0,
+    });
+
+    assert.equal(response.source, 'invalid');
+    assert.deepEqual(response.carriers, []);
+    assert.equal(relayUrls.length, 0, 'a malformed code must not reach the paid API at all');
+  });
+
+  it('does not let arbitrary strings through as cache-key material', async () => {
+    const relayUrls = installFetchMock();
+
+    // Long junk would otherwise become part of `aviation:carrier-ops:<...>:v1`.
+    const junk = Array.from({ length: 40 }, (_, i) => `junk-${i}`);
+    const response = await getCarrierOps(ctxFor(junk), { airports: junk, minFlights: 0 });
+
+    assert.equal(response.source, 'invalid');
+    assert.equal(relayUrls.length, 0);
+  });
+
+  it('falls back to the default subset only when the caller supplied nothing', async () => {
+    const relayUrls = installFetchMock();
+
+    const response = await getCarrierOps(ctxFor([]), { airports: [], minFlights: 0 });
+
+    assert.equal(response.source, 'aviationstack');
+    assert.ok(relayUrls.length > 0 && relayUrls.length <= MAX_AIRPORTS_PER_REQUEST);
+  });
+});


### PR DESCRIPTION
fix(aviation): make the AviationStack budget cap actually bind, and bound the carrier-ops fan-out

Two reasons the existing spend guard never stopped the overage on the
2026-07-25 → 2026-08-24 cycle (53,042 calls against a 50,000 plan).

**1. It was sized for a plan this account does not have.**

`AVIATIONSTACK_MONTHLY_BUDGET` defaulted to 130,000 and
`AVIATIONSTACK_REQUEST_BUDGET` to 85,000, with a comment saying they "sum under
a 135k plan with margin". Neither env var is set anywhere, so both defaults were
live and the ceiling sat at 2.6x the real plan. The guard has been decorative
since it shipped. Now 48,000 / 7,000.

The reserved gap is deliberately most of the budget: the seeder needs ~40,320
calls/cycle (56 airports x 24 sweeps x 30d), ~41,664 on a 31-day cycle. That
leaves the request-time ceiling as the tight one, which is correct — request
traffic is the volatile, abusable half. It also means real headroom is thin, and
the seeder's sweep cadence is the next lever if it stops fitting. Stated in the
docblock rather than left to be rediscovered.

**2. It measured the wrong window.**

The counter keyed on the UTC calendar month (`aviation:avstack:calls:2026-08`)
while AviationStack invoices from an anniversary day — the 25th on this account.
That is wrong in both directions: the cap keeps refusing calls into the first
days of a fresh allowance, and it zeroes itself a week into a cycle that is
already partly spent. A correctly-sized cap on a calendar key would have gone
dark from Aug 20 to Sep 1 while the plan reset on Aug 25.

`aviationStackBudgetMonth()` becomes `aviationStackBudgetCycle()`, returning the
cycle's UTC start date, so the key is now `aviation:avstack:calls:2026-07-25`.
`AVIATIONSTACK_CYCLE_RESET_DAY` (default 25) moves the anniversary and is
clamped to 1-28 — 29-31 has no February instant to land on and would hand out a
double-length cycle. The seeder's mirrored implementation moves in lockstep;
`tests/aviation-budget-cap.test.mjs` proves the two agree by running both key
builders over the same instants, including the January case where `Date.UTC(y,
-1, 25)` must normalise back into the previous December.

**3. `get-carrier-ops` let one anonymous request buy unbounded calls.**

It fans out to `listAirportFlights` once PER AIRPORT, and `parseStringArray`
bounds neither the length nor the shape of `req.airports` — it just splits on
commas. `?airports=A,B,...,Z` was 26 paid AviationStack calls from a single
unauthenticated request, and arbitrary strings became `aviation:carrier-ops:*`
cache-key material. Now malformed codes are rejected outright (`source:
'invalid'`, matching the sibling route's vocabulary) before anything is bought,
and the survivors are capped at `MAX_AIRPORTS_PER_REQUEST` — sized to
`DEFAULT_WATCHED_AIRPORTS` so the full watched set still resolves in one request.

`IATA_RE` moves to `_shared.ts` rather than being copied, so the two routes
cannot drift on what counts as a valid code.

Tests: `tests/aviation-carrier-ops-fanout-cap.test.mts` counts the actual relay
calls the handler issues, so it fails if the cap is removed, raised, or applied
after the fan-out instead of before it. Mutation-checked both guards — deleting
the `.slice()` reds it with "26 airports bought 26 paid AviationStack calls; cap
is 6", and pinning `monthOffset = 0` plus restoring the 130k default reds 7
budget tests. 43 aviation tests pass, typecheck clean.

One migration note: switching key format restarts the counter at 0 for the
current cycle, so the cap will not fire for its remaining days. It aligns
cleanly from the Aug 25 rollover. To carry the spent balance over, SET
`aviation:avstack:calls:2026-07-25` to the dashboard's cycle-to-date figure.

Stacked on #6991 (cache TTL 900s).

Claude-Session: https://claude.ai/code/session_01P9aU8VB3ufQktUyXCsMVHC

https://claude.ai/code/session_01P9aU8VB3ufQktUyXCsMVHC
