### PR TITLE
fix(insights): name what the lead gate rejected, and resample before demoting

### DIFF
--- a/scripts/_insights-brief.mjs
+++ b/scripts/_insights-brief.mjs
@@ -356,7 +356,17 @@ export function composeSynthesizedBriefResult(rawText, topStories, opts = {}) {
   const validatorMode = opts.validatorMode === 'shadow' ? 'shadow' : 'enforce';
   const sanitize = typeof opts.sanitizeTitle === 'function' ? opts.sanitizeTitle : (t) => t;
   const sourceFromStory = typeof opts.sourceFromStory === 'function' ? opts.sourceFromStory : () => null;
-  const reject = (rejection) => ({ brief: null, rejection });
+  // `detail` carries WHAT tripped the gate, not just which gate. Both
+  // validators already return the offending token sequence; discarding it left
+  // production able to say only that the lead was rejected, never why — while
+  // the sibling summary gate two hundred lines away has always logged
+  // `invented "talks" not in headline` (seed-insights.mjs). Same field, same
+  // use.
+  const reject = (rejection, detail = null) => ({
+    brief: null,
+    rejection,
+    rejectionDetail: Array.isArray(detail) && detail.length > 0 ? detail.join(' ') : null,
+  });
 
   if (!Array.isArray(topStories) || topStories.length === 0) return reject(BRIEF_REJECTIONS.NO_TOP_STORIES);
   // Editorial gate: same bar the legacy pickBriefCluster enforced. The caller
@@ -444,8 +454,12 @@ export function composeSynthesizedBriefResult(rawText, topStories, opts = {}) {
     const sentenceValidation = validateNoHallucinatedProperNouns(attributed, scopedGround);
     const factValidation = validateNoHallucinatedFacts(attributed, scopedGround);
     if (validatorMode === 'enforce') {
-      if (!sentenceValidation.ok) return reject(BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
-      if (!factValidation.ok) return reject(BRIEF_REJECTIONS.LEAD_NUMERIC_FACT);
+      if (!sentenceValidation.ok) {
+        return reject(BRIEF_REJECTIONS.LEAD_PROPER_NOUN, sentenceValidation.hallucinated);
+      }
+      if (!factValidation.ok) {
+        return reject(BRIEF_REJECTIONS.LEAD_NUMERIC_FACT, factValidation.hallucinated);
+      }
     }
   }
   if (!checkLeadGrounding({ lead: leadCheck.text }, groundingStories, topStories.length)) {
@@ -494,5 +508,6 @@ export function composeSynthesizedBriefResult(rawText, topStories, opts = {}) {
   return {
     brief: { lead: leadCheck.text, lines, sources, hallucinatedLines, strippedCitations, sourceAttributions },
     rejection: null,
+    rejectionDetail: null,
   };
 }

--- a/scripts/_insights-synthesis-diagnostics.mjs
+++ b/scripts/_insights-synthesis-diagnostics.mjs
@@ -128,6 +128,8 @@ export function resolveInsightsSynthesis(options = {}) {
   return {
     composed,
     parsedSynthesis,
+    // What the gate rejected, when it said so. Null for every non-gate stage.
+    failureDetail: composeResult?.rejectionDetail ?? null,
     failureCode: classifyInsightsSynthesisFailure({
       hasBriefCluster,
       synthesisResult,

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -478,7 +478,27 @@ async function callLLM(headline, options = {}) {
   let firstFaulted = null;
   const rejectedResult = () => firstRejected ?? firstFaulted;
 
-  for (const provider of LLM_PROVIDERS) {
+  // A gate rejection is not evidence that the PROVIDER is unhealthy — it says
+  // this SAMPLE was unusable. Advancing on it demotes the chain to a weaker
+  // model, which is less likely to produce a grounded lead than a second sample
+  // from the stronger one, so the strictness of an editorial gate was buying
+  // worse published prose.
+  //
+  // Measured on seed-insights 2026-08-20 before this change: of 9 gate
+  // rejections, the fallback rescued 2 and the other 7 reached the
+  // single-headline brief anyway, while 5 of 14 shipped briefs came from
+  // google/gemma-4-26b-a4b-it:free rather than deepseek-v4-flash. So the
+  // demotion mostly did not save the run, and when it did it shipped the weaker
+  // writer.
+  //
+  // Resample the SAME provider once, then fall through to the rest of the chain
+  // exactly as before. Transport failures still advance immediately — withRetry
+  // already covers transient ones, and a provider that is genuinely down should
+  // not be asked twice.
+  const queue = [...LLM_PROVIDERS];
+  const resampled = new Set();
+  while (queue.length > 0) {
+    const provider = queue.shift();
     const envVal = process.env[provider.envKey];
     if (!envVal) continue;
 
@@ -571,6 +591,15 @@ async function callLLM(headline, options = {}) {
           record(false, { ...usage, model: json.model || model, reason: 'validate_reject' });
           if (faulted) { if (!firstFaulted) firstFaulted = candidate; }
           else if (!firstRejected) firstRejected = candidate;
+          // One resample before demoting (see the queue comment above). A
+          // FAULTED acceptor is excluded deliberately: that fault is in our own
+          // gate, not in the sample, so a second identical call would throw
+          // identically and only burn budget.
+          if (!faulted && !resampled.has(provider.name)) {
+            resampled.add(provider.name);
+            queue.unshift(provider);
+            console.warn(`  ${provider.name}: resampling once before falling back to a weaker model`);
+          }
           continue;
         }
       }
@@ -848,11 +877,12 @@ async function fetchInsights() {
         userPrompt: synthesisUserPrompt(topStories),
         maxTokens: 900,
         // A model whose output trips the editorial gates must not strand the
-        // run — keep the chain moving to one that passes.
+        // run. callLLM resamples this model once before demoting to a weaker
+        // one, so a single unusable sample no longer costs the better writer.
         accept: composeFromText,
       })
     : null;
-  const { composed, failureCode } = resolveInsightsSynthesis({
+  const { composed, failureCode, failureDetail } = resolveInsightsSynthesis({
     synthesisResult,
     topStories,
     ...synthesisComposerOptions,
@@ -884,7 +914,8 @@ async function fetchInsights() {
     console.log(`  Brief synthesized (top-${topStories.length}) via ${briefProvider} (${briefModel})`);
   } else {
     console.warn(
-      `  [brief_synthesis] rejected (${synthesisFailureCode || INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER}) — `
+      `  [brief_synthesis] rejected (${synthesisFailureCode || INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER})`
+      + `${failureDetail ? ` on "${failureDetail}"` : ''} — `
       + 'falling back to single-headline brief',
     );
     const legacy = await generateLegacySingleHeadlineBrief(topStories, {

--- a/tests/seed-insights-brief.test.mjs
+++ b/tests/seed-insights-brief.test.mjs
@@ -580,6 +580,29 @@ describe('composeSynthesizedBriefResult names which gate rejected (#5947)', () =
     assert.equal(out.rejection, BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
   });
 
+  it('names the proper noun it rejected, not just the gate', () => {
+    // Production could say a lead was rejected but never WHAT tripped it, so
+    // deciding whether a rejection was a real hallucination or a grounding
+    // false-positive meant guessing. The validator has always returned the
+    // offending sequence; the gate discarded it. The sibling summary gate has
+    // logged `invented "talks" not in headline` since #6109 — same field.
+    const out = compose('Bloomberg reported apple prices rose sharply in Chile last quarter [1].');
+    assert.equal(out.rejection, BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
+    assert.equal(
+      out.rejectionDetail,
+      'bloomberg',
+      'the rejection must carry the offending sequence so the log can name it',
+    );
+  });
+
+  it('carries no detail when the brief is accepted', () => {
+    // Shape stability: a caller reading rejectionDetail must not have to guard
+    // against it being stale from a previous compose.
+    const out = compose('According to Reuters, apple prices rose sharply in Chile last quarter [1].');
+    assert.equal(out.rejection, null);
+    assert.equal(out.rejectionDetail, null);
+  });
+
   it('still rejects a corroborating source the prompt never showed', () => {
     // The fixture's `sources` carries 'AP News', but synthesisUserPrompt renders
     // only primarySource plus a publisher COUNT. Grounding the rest of the

--- a/tests/seed-insights-llm-retry.test.mjs
+++ b/tests/seed-insights-llm-retry.test.mjs
@@ -319,7 +319,47 @@ describe('seed-insights callLLM output acceptance (#6001)', () => {
     assert.ok(result, 'an accepted provider result must be returned');
     assert.equal(result.provider, 'groq');
     assert.equal(result.text, LONG_BRIEF);
-    assert.equal(seen.length, 4, 'paid, fixed free, backup, and Groq providers must be attempted');
+
+    // #6001's guarantee, unchanged: a gate rejection must not strand the run on
+    // the primary — the chain still reaches a provider that composes.
+    assert.ok(
+      seen.some((url) => url.includes('groq')),
+      'the chain must still advance past a provider whose output the gates reject',
+    );
+
+    // Added later: it advances only AFTER resampling the same provider once. A
+    // gate rejection says the SAMPLE was unusable, not that the provider is
+    // unhealthy, and demoting on the first one shipped the weaker writer —
+    // measured on 2026-08-20, 5 of 14 published briefs came from the free model
+    // while only 2 of 9 demotions actually rescued the run.
+    //
+    // Asserted as a SHAPE, not a count: each rejecting provider is sampled
+    // twice consecutively, the accepting one exactly once. A bare length check
+    // would pass just as happily if the retries landed on the wrong provider.
+    const providerOf = (url) => (url.includes('groq') ? 'groq' : 'openrouter');
+    const attempts = seen.map(providerOf);
+    assert.equal(attempts.at(-1), 'groq', 'the accepting provider ends the walk');
+    assert.equal(
+      attempts.filter((p) => p === 'groq').length,
+      1,
+      'a provider that passes on its first sample is never resampled',
+    );
+    assert.equal(
+      attempts.filter((p) => p === 'openrouter').length,
+      6,
+      'each of the three rejecting openrouter providers is sampled exactly twice',
+    );
+    assert.equal(seen.length, 7);
+
+    // The resample must be the SAME endpoint, back to back — a retry that
+    // silently moved to the next model would satisfy the counts above.
+    const rejecting = seen.slice(0, 6);
+    for (let i = 0; i < rejecting.length; i += 2) {
+      assert.equal(
+        rejecting[i], rejecting[i + 1],
+        `resample ${i / 2 + 1} must re-ask the same provider, not the next one`,
+      );
+    }
   });
 
   it('returns the last attempt when every provider is rejected, so the failure stays classifiable', async () => {


### PR DESCRIPTION
`newsInsights` has been flipping to `SEED_ERROR` on `INSIGHTS_SYNTHESIS_LEAD_PROPER_NOUN`. Two problems, one of which was only visible because of the other.

## What the data says

Measured on the `seed-insights` service, 2026-08-20, over one log window:

| | count |
|---|---|
| successful syntheses | 14 |
| rejections | 12 |
| — `LEAD_PROPER_NOUN` | **8 — 67% of rejections** |
| — `MISSING_CLUSTER` | 3 |
| — `LEAD_NUMERIC_FACT` | 1 |

and what actually shipped:

```
9 via openrouter (deepseek/deepseek-v4-flash)
5 via openrouter-free (google/gemma-4-26b-a4b-it:free)   ← 36% of published briefs
```

So ~46% of synthesis attempts are rejected, two-thirds of them by one gate, and more than a third of published briefs are written by the free model.

## A — the gate would not say what it rejected

`validateNoHallucinatedProperNouns` returns the offending sequence (`shared/brief-llm-core.js:917`). `composeSynthesizedBriefResult` threw it away:

```js
if (!sentenceValidation.ok) return reject(BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
```

Production could therefore say a lead was rejected but never *which noun*, making "real hallucination" and "grounding false-positive" indistinguishable without guessing.

Its **sibling** gate, on the same validator two hundred lines away, has always done this properly:

```
[brief_hallucination ENFORCE] dropped LLM summary: invented "talks" not in headline; fell back to headline
```

Same field, same use. `reject()` now carries a bounded detail, the classifier surfaces it as `failureDetail`, and the seeder prints it:

```
[brief_synthesis] rejected (INSIGHTS_SYNTHESIS_LEAD_PROPER_NOUN) on "…" — falling back to single-headline brief
```

**This is a prerequisite, not a fix.** The remaining rejections cannot be diagnosed until the next occurrence names itself.

## B — a quality gate was demoting the model

`callLLM` advanced to the next provider on gate rejection (`seed-insights.mjs:571`, `continue`), so the paid model writing one ungrounded lead handed the run to a weaker one. The strictness of an editorial gate was buying *worse* published prose.

A gate rejection is not evidence the **provider** is unhealthy — it says this **sample** was unusable. And the demotion mostly did not even rescue the run: of 9 gate rejections, the fallback rescued **2**, while the other **7** reached the single-headline brief anyway.

The provider walk now resamples the same provider once before advancing.

- **Transport failures still advance immediately.** `withRetry` already covers transient ones, and a provider that is genuinely down should not be asked twice.
- **A faulted acceptor is excluded deliberately.** That fault is in our own gate, not in the sample, so a second identical call would throw identically and only burn budget.

## #6001's guarantee is preserved

That test encodes a deliberate, measured decision — *"openrouter composed 2/6, groq 6/6, yet production only ever asked openrouter"* — so the chain must still advance past a rejecting provider. It does, and that is still asserted.

The test now pins the fuller contract as a **shape**, not a count: each rejecting provider sampled exactly twice **back-to-back on the same endpoint**, the accepting provider exactly once, and the walk still ending on the one that composes. A bare `seen.length === 7` would have passed just as happily with the retries landing on the wrong provider.

## Verification

Both changes mutation-checked:

- discarding the detail again → `✖ names the proper noun it rejected, not just the gate`
- removing the resample → `✖ each of the three rejecting openrouter providers is sampled exactly twice`

**192 tests pass, 0 fail** across the insights brief, freshness, credibility, llm-retry, telemetry, brief-contract, corroboration and loader suites. Biome clean.

## Deliberately not included

**Why those 8 leads were rejected.** That is what A exists to find out. Inventing a cause before the log can name one is how the previous round of this went wrong — #6915 masked outlet names on solid evidence, and these 8 are what remains, whose cause is not yet observable. Once a rejection lands with its noun attached, the follow-up is straightforward.
