### PR TITLE
test(dom): set a 15s testTimeout and stop billing data-loader transform to the first test

### DIFF
--- a/tests/dom/firms-timeout-lock-recovery.test.mts
+++ b/tests/dom/firms-timeout-lock-recovery.test.mts
@@ -6,6 +6,16 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { AppContext } from '@/app/app-context';
 
+// #6984 / #6677: this file's single test used to pay for the data-loader
+// module graph's transform (data-loader.ts plus the i18n locale glob and
+// generated clients) inside its testTimeout. Under load that lands just
+// over the 5000ms vitest default — a false red on a green tree. Importing
+// the graph at module scope moves the transform cost into the file's
+// import phase, which vitest does not bill to any testTimeout. The
+// AbortSignal.timeout spy below still wraps the RPC deadline that fires
+// during the test, not during this import.
+await import('@/app/data-loader');
+
 describe('FIRMS timeout lock recovery (#6770)', () => {
   it('releases the fires key after the RPC deadline and permits a retry', async () => {
     const timeoutControllers: AbortController[] = [];

--- a/tests/dom/global-procurement-data-loader.test.mts
+++ b/tests/dom/global-procurement-data-loader.test.mts
@@ -17,6 +17,14 @@ vi.mock('@/services/global-tenders', () => ({
   fetchGlobalTenders: procurementMocks.fetchGlobalTenders,
 }));
 
+// #6984 / #6677: the first case in this file used to pay for the data-loader
+// module graph's transform inside its testTimeout, which under load lands
+// just over the 5000ms vitest default and false-reds the file. Importing
+// the graph once at module scope moves that cost into the file's import
+// phase, which vitest does not bill to any testTimeout. The vi.mock calls
+// above still apply to every later import of `@/services/global-tenders`.
+await import('@/app/data-loader');
+
 function response(total = 0): ListGlobalTendersResponse {
   return {
     tenders: [],

--- a/tests/prepush-changed-tests.test.mjs
+++ b/tests/prepush-changed-tests.test.mjs
@@ -294,6 +294,15 @@ describe('partition stays in step with the vitest DOM project', () => {
       /VITEST_MAX_THREADS must be a positive integer/,
     );
   });
+
+  test('the DOM project sets an explicit testTimeout above vitest\'s 5000ms default', () => {
+    // #6984: nobody chose 5000 — it is vitest's built-in default. Several DOM
+    // files pay a large module-graph transform to the first test, which under
+    // load lands just over 5000ms and false-reds an unrelated push. Pinning
+    // the resolved config (not the source text) is what keeps the next
+    // #6677-class file from silently inheriting the default again.
+    assert.equal(defaultConfig.testTimeout, 15_000);
+  });
 });
 
 describe('runner dispatch', () => {

--- a/vitest.dom.config.mts
+++ b/vitest.dom.config.mts
@@ -46,6 +46,14 @@ export default defineConfig({
     // contributor named after the repo's more common convention — the exact
     // never-reported-test failure this directory exists to prevent.
     include: ['tests/dom/**/*.test.{mts,mjs}'],
+    // #6984: vitest's 5000ms default is not a budget anyone chose. Several
+    // DOM files pay a large module-graph transform to the first test
+    // (`@/app/data-loader`, story-data, economic), and under load that lands
+    // a few milliseconds over 5000 — a false red on a green tree that can
+    // fail the pre-push hook. 15000ms is a load margin for the suite; it is
+    // not a license for a test to sit on a real timer. Files that still take
+    // ~5s should move the transform into the import phase (see #6677).
+    testTimeout: 15_000,
     // Every test file installs its own listeners on a shared `document`;
     // isolate so a leaked listener cannot reach across files.
     isolate: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #6984. The 5000ms `Test timed out` false red is back in two files #6677 never named, because the suite still inherited vitest's default `testTimeout` and those files still billed a large module-graph transform to the first test.

Two parts, matching the issue:

1. **Set an explicit `testTimeout: 15_000` in `vitest.dom.config.mts`.** Nobody chose 5000 — it is vitest's default. The resolved config is pinned in `tests/prepush-changed-tests.test.mjs` so the next file cannot silently inherit 5000 again.
2. **Move the ~5s off the test body.** Characterization on this tree: the FIRMS case and the first procurement case took 1260ms / 1306ms, while the second procurement case (same file, transform cache warm) took 51ms. Not a real timer — `AbortSignal.timeout` is mocked and aborted on a microtask, and `fetchGlobalTenders` is mocked. The wait is the `@/app/data-loader` graph (plus i18n glob and generated clients), same class as #6677. Importing that graph at module scope moves the cost into the file's import phase, which vitest does not bill to any `testTimeout`. After the change: 8ms / 55ms / 51ms.

A timeout bump alone would hide the next file that sits at ~5s; the pre-import is what makes these cases finish in tens of ms like the rest of the DOM suite.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: vitest DOM test harness (`tests/dom/`, `vitest.dom.config.mts`)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked (N/A — test harness only)
- [ ] All required Audit Council role signoffs attached (N/A)
- [ ] Generated docs regenerated from proto where applicable (N/A)
- [ ] Fixture-backed examples recomputed (N/A)
- [ ] Redis writers/readers enumerated for every documented key (N/A)

## Verification

- Config pin: `npx tsx --test tests/prepush-changed-tests.test.mjs` — 29 passed, including `testTimeout === 15000` (failed first while the value was unset).
- Focused DOM cases: FIRMS 1260ms → 8ms; first procurement 1306ms → 55ms; second procurement stayed ~51ms.
- Full `npm run test:dom`: 52 files, 426 tests passed in 11.65s. FIRMS 9ms and procurement 55ms/51ms in the full suite.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This change only affects the vitest DOM test harness (`testTimeout` and two test-file import sites). It does not alter production runtime, Edge APIs, or seeders.

Failure signal if it regresses: `Test timed out in 5000ms` (or a future default) on `tests/dom/firms-timeout-lock-recovery.test.mts` or `tests/dom/global-procurement-data-loader.test.mts` during `npm run test:dom` or the pre-push DOM partition, on a tree that does not import those modules.

## Known Residuals

Code review (`ce-code-review` run `20260820-132610-e7297128`): **Actionable findings: none.** Advisory notes demoted to residuals:

- The 15s suite timeout is a load margin, not a license for a real 5–15s wait. Other DOM files that still first-import a heavy graph inside `it()` rely on that margin until they get the #6677 hoist.
- The config pin does not lock the per-file `await import('@/app/data-loader')`. A source-grep of that token would be brittle; characterization timings are the current proof.
- #6984 also recorded the second procurement case at 5003ms, which is not first-test transform. The 15s timeout covers CPU-stretch of later cases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e7c4bfe-fbce-46e7-a7fb-7ed63afdbd29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e7c4bfe-fbce-46e7-a7fb-7ed63afdbd29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

