### PR TITLE
fix(agent-readiness): restore human HTML 404; keep markdown for agents

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-import { agentNotFoundResponse, isKnownPublicPagePath } from './src/config/agent-not-found';
+import { isKnownPublicPagePath, originNotFoundResponse } from './src/config/agent-not-found';
 import { getRootlessDocsDestination } from './src/config/docs-root-redirects';
 
 const BOT_UA =
@@ -197,11 +197,12 @@ export default function middleware(request: Request) {
       return Response.redirect(canonicalUrl.toString(), 308);
     }
 
-    // Real HTTP 404 + markdown body for unknown pages. A rewrite to a static
-    // markdown file would 200 (orank `agent-friendly-404` soft-404). Files with
-    // extensions skip this matcher and fall through to public/404.html.
+    // Real HTTP 404 for unknown pages. Agents get markdown (orank
+    // `agent-friendly-404`); browsers that send Accept: text/html get HTML.
+    // A rewrite to a static file would 200. Files with extensions skip this
+    // matcher and fall through to public/404.html.
     if (!isKnownPublicPagePath(path)) {
-      return agentNotFoundResponse(path, request.method);
+      return originNotFoundResponse(path, request);
     }
   }
 

--- a/public/404.html
+++ b/public/404.html
@@ -1,9 +1,32 @@
-# Not found
-
-This path does not exist on World Monitor.
-
-Use these indexes instead of guessing URLs:
-
-- [llms.txt](https://www.worldmonitor.app/llms.txt) — agent briefing
-- [sitemap.xml](https://www.worldmonitor.app/sitemap.xml) — crawlable URL list
-- [Documentation](https://www.worldmonitor.app/docs/documentation) — docs index
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex">
+  <title>Page not found — World Monitor</title>
+  <style>
+    body { background: #0a0f0a; color: #e0e0e0; font-family: system-ui;
+           display: flex; align-items: center; justify-content: center;
+           min-height: 100vh; margin: 0; }
+    .c { text-align: center; padding: 2rem; max-width: 36rem; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+    p { color: #888; font-size: 0.9rem; }
+    a { color: #4ade80; }
+    code { color: #e0e0e0; }
+    nav { margin-top: 1.25rem; }
+    nav a { margin: 0 0.5rem; }
+  </style>
+</head>
+<body>
+  <div class="c">
+    <h1>Page not found</h1>
+    <p>This path is not a page on World Monitor.</p>
+    <nav>
+      <a href="/dashboard">Dashboard</a>
+      <a href="/docs/documentation">Docs</a>
+      <a href="/">Home</a>
+    </nav>
+  </div>
+</body>
+</html>

--- a/src/config/agent-not-found.ts
+++ b/src/config/agent-not-found.ts
@@ -1,24 +1,32 @@
 /**
- * Agent-friendly HTML-origin 404s (ora.ai / orank `agent-friendly-404`).
+ * Origin 404s for unknown HTML-site paths.
  *
- * Unknown extensionless paths used to fall through to Vercel's default
- * NOT_FOUND page (plain/HTML) or, if rewritten to a static markdown file,
- * come back as HTTP 200 — scanners then treat every URL as a real page.
- * Middleware returns this body with a real 404 so agents can stop and
- * follow the indexes below instead of crawling the app shell.
+ * Agents (curl, SDKs, Accept: text/markdown, missing Accept) get a real
+ * HTTP 404 with heading-led markdown pointing at llms.txt / sitemap / docs
+ * (ora.ai / orank `agent-friendly-404`). Browsers that send Accept: text/html
+ * get a human HTML 404 — #6955 served the agent body to everyone and replaced
+ * public/404.html with markdown.
  *
- * Do not wire this through a vercel.json rewrite: Vercel rewrites preserve
- * the destination body but surface HTTP 200 for a successful proxy, which
- * is the exact soft-404 this check penalizes.
+ * Do not wire the agent body through a vercel.json rewrite: Vercel rewrites
+ * preserve the destination body but surface HTTP 200 for a successful proxy,
+ * which is the exact soft-404 the scanner penalizes. Files with extensions
+ * skip the middleware matcher and fall through to public/404.html.
  */
 
 export const AGENT_NOT_FOUND_STATUS = 404 as const;
 export const AGENT_NOT_FOUND_CONTENT_TYPE = 'text/markdown; charset=utf-8';
+export const HUMAN_NOT_FOUND_CONTENT_TYPE = 'text/html; charset=utf-8';
 
 export const AGENT_NOT_FOUND_INDEXES = {
   llmsTxt: 'https://www.worldmonitor.app/llms.txt',
   sitemap: 'https://www.worldmonitor.app/sitemap.xml',
   docs: 'https://www.worldmonitor.app/docs/documentation',
+} as const;
+
+export const HUMAN_NOT_FOUND_LINKS = {
+  home: '/',
+  dashboard: '/dashboard',
+  docs: '/docs/documentation',
 } as const;
 
 // Prefix match is `path === prefix || path.startsWith(prefix + '/')`.
@@ -87,6 +95,54 @@ function sanitizePathForMarkdown(path: string): string {
   return normalized.replace(/[`<>]/g, '');
 }
 
+function sanitizePathForHtml(path: string): string {
+  return escapeHtml(normalizePath(path).slice(0, 200));
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function acceptQuality(header: string | null | undefined, type: string): number | null {
+  if (header == null) return null;
+  const trimmed = header.trim();
+  if (!trimmed) return null;
+  const wanted = type.toLowerCase();
+  const [wantedMain] = wanted.split('/');
+  let best: number | null = null;
+  for (const rawPart of trimmed.split(',')) {
+    const tokens = rawPart.split(';').map((part) => part.trim().toLowerCase()).filter(Boolean);
+    const media = tokens[0];
+    if (!media) continue;
+    // curl's default Accept is */* — do not treat that as text/html.
+    if (media === '*/*') continue;
+    const [main, sub] = media.split('/');
+    if (media !== wanted && !(main === wantedMain && sub === '*')) continue;
+    const qToken = tokens.find((token) => token.startsWith('q='));
+    const q = qToken ? Number(qToken.slice(2)) : 1;
+    if (!Number.isFinite(q) || q < 0) continue;
+    if (best === null || q > best) best = q;
+  }
+  return best;
+}
+
+/**
+ * True when the request should get the agent markdown 404.
+ * Browsers send Accept: text/html; curl and SDKs send a catch-all Accept or omit it.
+ */
+export function prefersAgentNotFound(acceptHeader: string | null | undefined): boolean {
+  const htmlQ = acceptQuality(acceptHeader, 'text/html');
+  const markdownQ = acceptQuality(acceptHeader, 'text/markdown');
+  if (markdownQ !== null && markdownQ > (htmlQ ?? -1)) return true;
+  if (htmlQ !== null && htmlQ > 0) return false;
+  return true;
+}
+
 export function isKnownPublicPagePath(path: string): boolean {
   const normalized = normalizePath(path);
   if (normalized === '/') return true;
@@ -112,16 +168,78 @@ export function buildAgentNotFoundMarkdown(path: string): string {
   ].join('\n');
 }
 
-export function agentNotFoundResponse(path: string, method: string): Response {
-  const markdown = buildAgentNotFoundMarkdown(path);
-  const headers = {
-    'Content-Type': AGENT_NOT_FOUND_CONTENT_TYPE,
+export function buildHumanNotFoundHtml(path?: string): string {
+  const pathLine = path
+    ? `<p><code>${sanitizePathForHtml(path)}</code> is not a page on World Monitor.</p>`
+    : '<p>This path is not a page on World Monitor.</p>';
+  return [
+    '<!DOCTYPE html>',
+    '<html lang="en">',
+    '<head>',
+    '  <meta charset="UTF-8">',
+    '  <meta name="viewport" content="width=device-width, initial-scale=1.0">',
+    '  <meta name="robots" content="noindex">',
+    '  <title>Page not found — World Monitor</title>',
+    '  <style>',
+    '    body { background: #0a0f0a; color: #e0e0e0; font-family: system-ui;',
+    '           display: flex; align-items: center; justify-content: center;',
+    '           min-height: 100vh; margin: 0; }',
+    '    .c { text-align: center; padding: 2rem; max-width: 36rem; }',
+    '    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }',
+    '    p { color: #888; font-size: 0.9rem; }',
+    '    a { color: #4ade80; }',
+    '    code { color: #e0e0e0; }',
+    '    nav { margin-top: 1.25rem; }',
+    '    nav a { margin: 0 0.5rem; }',
+    '  </style>',
+    '</head>',
+    '<body>',
+    '  <div class="c">',
+    '    <h1>Page not found</h1>',
+    `    ${pathLine}`,
+    '    <nav>',
+    `      <a href="${HUMAN_NOT_FOUND_LINKS.dashboard}">Dashboard</a>`,
+    `      <a href="${HUMAN_NOT_FOUND_LINKS.docs}">Docs</a>`,
+    `      <a href="${HUMAN_NOT_FOUND_LINKS.home}">Home</a>`,
+    '    </nav>',
+    '  </div>',
+    '</body>',
+    '</html>',
+    '',
+  ].join('\n');
+}
+
+function notFoundHeaders(contentType: string, cors: boolean): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Content-Type': contentType,
     'Cache-Control': 'no-store',
     'X-Content-Type-Options': 'nosniff',
-    'Access-Control-Allow-Origin': '*',
   };
+  if (cors) headers['Access-Control-Allow-Origin'] = '*';
+  return headers;
+}
+
+export function agentNotFoundResponse(path: string, method: string): Response {
+  const markdown = buildAgentNotFoundMarkdown(path);
+  const headers = notFoundHeaders(AGENT_NOT_FOUND_CONTENT_TYPE, true);
   if (method === 'HEAD') {
     return new Response(null, { status: AGENT_NOT_FOUND_STATUS, headers });
   }
   return new Response(markdown, { status: AGENT_NOT_FOUND_STATUS, headers });
+}
+
+export function humanNotFoundResponse(path: string, method: string): Response {
+  const html = buildHumanNotFoundHtml(path);
+  const headers = notFoundHeaders(HUMAN_NOT_FOUND_CONTENT_TYPE, false);
+  if (method === 'HEAD') {
+    return new Response(null, { status: AGENT_NOT_FOUND_STATUS, headers });
+  }
+  return new Response(html, { status: AGENT_NOT_FOUND_STATUS, headers });
+}
+
+export function originNotFoundResponse(path: string, request: Request): Response {
+  if (prefersAgentNotFound(request.headers.get('accept'))) {
+    return agentNotFoundResponse(path, request.method);
+  }
+  return humanNotFoundResponse(path, request.method);
 }

--- a/tests/agent-friendly-404.test.mts
+++ b/tests/agent-friendly-404.test.mts
@@ -9,8 +9,11 @@ import {
   AGENT_NOT_FOUND_INDEXES,
   AGENT_NOT_FOUND_PASSTHROUGH_PREFIXES,
   AGENT_NOT_FOUND_STATUS,
+  HUMAN_NOT_FOUND_CONTENT_TYPE,
   buildAgentNotFoundMarkdown,
+  buildHumanNotFoundHtml,
   isKnownPublicPagePath,
+  prefersAgentNotFound,
 } from '../src/config/agent-not-found.ts';
 import { CONTENT_CORPUS_PREFIXES } from '../scripts/discover-content-corpus-pages.mjs';
 
@@ -24,12 +27,23 @@ const vercelConfig = JSON.parse(
 const CHROME_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
   '(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+const CHROME_ACCEPT =
+  'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8';
+const CURL_UA = 'curl/8.4.0';
 
-function call(path: string, method = 'GET'): Response | void {
+function call(
+  path: string,
+  init: { method?: string; ua?: string; accept?: string } = {},
+): Response | void {
+  const headers: Record<string, string> = {
+    host: 'www.worldmonitor.app',
+    'user-agent': init.ua ?? CURL_UA,
+  };
+  if (init.accept !== undefined) headers.accept = init.accept;
   return middleware(
     new Request(`https://www.worldmonitor.app${path}`, {
-      method,
-      headers: { host: 'www.worldmonitor.app', 'user-agent': CHROME_UA },
+      method: init.method ?? 'GET',
+      headers,
     }),
   ) as Response | void;
 }
@@ -44,9 +58,24 @@ function examplePathFromSource(source: string): string | null {
   return path.length > 1 ? path.replace(/\/+$/, '') : path;
 }
 
+describe('prefersAgentNotFound (content negotiation)', () => {
+  it('treats browser Accept: text/html as a human 404', () => {
+    assert.equal(prefersAgentNotFound(CHROME_ACCEPT), false);
+    assert.equal(prefersAgentNotFound('text/html'), false);
+  });
+
+  it('treats curl */*, missing Accept, and text/markdown as agent 404s', () => {
+    assert.equal(prefersAgentNotFound('*/*'), true);
+    assert.equal(prefersAgentNotFound(null), true);
+    assert.equal(prefersAgentNotFound(''), true);
+    assert.equal(prefersAgentNotFound('text/markdown'), true);
+    assert.equal(prefersAgentNotFound('text/html;q=0.8, text/markdown'), true);
+  });
+});
+
 describe('agent-friendly 404s (orank agent-friendly-404)', () => {
   it('returns HTTP 404 markdown that points agents at sitemap, llms.txt, and docs', async () => {
-    const res = call('/some-path-that-does-not-exist');
+    const res = call('/some-path-that-does-not-exist', { accept: '*/*' });
     assert.ok(res instanceof Response, 'unknown paths must not fall through as a soft-404');
     assert.equal(res.status, AGENT_NOT_FOUND_STATUS);
     assert.equal(res.headers.get('content-type'), AGENT_NOT_FOUND_CONTENT_TYPE);
@@ -59,24 +88,59 @@ describe('agent-friendly 404s (orank agent-friendly-404)', () => {
     assert.ok(body.includes(AGENT_NOT_FOUND_INDEXES.docs));
   });
 
-  it('answers HEAD with 404 and no body', async () => {
-    const res = call('/this-is-not-a-page', 'HEAD');
+  it('answers agent HEAD with 404 markdown and no body', async () => {
+    const res = call('/this-is-not-a-page', { method: 'HEAD', accept: '*/*' });
     assert.ok(res instanceof Response);
     assert.equal(res.status, AGENT_NOT_FOUND_STATUS);
     assert.equal(res.headers.get('content-type'), AGENT_NOT_FOUND_CONTENT_TYPE);
     assert.equal(await res.text(), '');
   });
 
+  it('serves browsers an HTML 404 instead of the agent markdown body', async () => {
+    const res = call('/some-path-that-does-not-exist', {
+      ua: CHROME_UA,
+      accept: CHROME_ACCEPT,
+    });
+    assert.ok(res instanceof Response, 'humans must still get a real HTTP 404, not a soft-404 SPA');
+    assert.equal(res.status, AGENT_NOT_FOUND_STATUS);
+    assert.equal(res.headers.get('content-type'), HUMAN_NOT_FOUND_CONTENT_TYPE);
+    const body = await res.text();
+    assert.match(body, /<!DOCTYPE html>/i);
+    assert.match(body, /<html/i);
+    assert.match(body, /Page not found/i);
+    assert.doesNotMatch(body, /^# Not found/m);
+    assert.ok(body.includes('/dashboard'));
+    assert.ok(body.includes(AGENT_NOT_FOUND_INDEXES.docs.replace('https://www.worldmonitor.app', '')));
+  });
+
+  it('answers browser HEAD with 404 HTML and no body', async () => {
+    const res = call('/this-is-not-a-page', {
+      method: 'HEAD',
+      ua: CHROME_UA,
+      accept: CHROME_ACCEPT,
+    });
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, AGENT_NOT_FOUND_STATUS);
+    assert.equal(res.headers.get('content-type'), HUMAN_NOT_FOUND_CONTENT_TYPE);
+    assert.equal(await res.text(), '');
+  });
+
+  it('HTML-escapes a hostile path in the human 404 body', () => {
+    const body = buildHumanNotFoundHtml('/<script>alert(1)</script>');
+    assert.ok(body.includes('&lt;script&gt;'));
+    assert.doesNotMatch(body, /<script>alert\(1\)<\/script>/);
+  });
+
   it('does not intercept known product routes or mutating methods', () => {
     for (const path of ['/', '/dashboard', '/stocks/AAPL', '/story', '/pro', '/docs/mcp', '/countries/united-states']) {
-      assert.equal(call(path), undefined, `${path} must keep its vercel.json route`);
+      assert.equal(call(path, { accept: '*/*' }), undefined, `${path} must keep its vercel.json route`);
     }
-    assert.equal(call('/some-path-that-does-not-exist', 'POST'), undefined);
+    assert.equal(call('/some-path-that-does-not-exist', { method: 'POST', accept: '*/*' }), undefined);
   });
 
   it('404s leaked SPA guesses that used to soft-404 the dashboard (#6575, #6836)', async () => {
     for (const path of ['/country-intel', '/security', '/trust']) {
-      const res = call(path);
+      const res = call(path, { accept: '*/*' });
       assert.ok(res instanceof Response, `${path} must 404`);
       assert.equal(res.status, 404);
     }
@@ -113,12 +177,14 @@ describe('agent-friendly 404s (orank agent-friendly-404)', () => {
     );
   });
 
-  it('keeps public/404.html in sync with the middleware markdown indexes', () => {
+  it('keeps public/404.html as the human HTML filesystem 404', () => {
     const html = readFileSync(resolve(import.meta.dirname, '../public/404.html'), 'utf8');
-    assert.ok(html.startsWith('# Not found'), 'Vercel filesystem 404s must also be heading-led markdown');
-    assert.ok(html.includes(AGENT_NOT_FOUND_INDEXES.llmsTxt));
-    assert.ok(html.includes(AGENT_NOT_FOUND_INDEXES.sitemap));
-    assert.ok(html.includes(AGENT_NOT_FOUND_INDEXES.docs));
+    assert.equal(html, buildHumanNotFoundHtml());
+    assert.match(html, /<!DOCTYPE html>/i, 'Vercel filesystem 404s must be a human HTML page');
+    assert.match(html, /Page not found/i);
+    assert.ok(html.includes('/dashboard'));
+    assert.ok(html.includes('/docs/documentation'));
+    assert.doesNotMatch(html, /^# Not found/m);
     assert.equal(
       buildAgentNotFoundMarkdown('/missing').includes(AGENT_NOT_FOUND_INDEXES.llmsTxt),
       true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[#6955](https://github.com/koala73/worldmonitor/pull/6955) returned a real HTTP 404 for unknown pages, which is the right agent-readiness fix, but it served the **agent markdown body to every client** — including browsers — and replaced `public/404.html` with that same markdown.

This restores content negotiation:

- **Agents** (`Accept: */*`, missing `Accept`, or `Accept: text/markdown`) still get HTTP 404 + heading-led markdown pointing at `llms.txt`, the sitemap, and docs (`agent-friendly-404`).
- **Humans** (`Accept: text/html`, as browsers send) get a real HTML 404 with Dashboard / Docs / Home links.
- `public/404.html` is that human page again, for filesystem misses that skip the middleware matcher.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Vercel middleware / origin 404s

## What changed

- `prefersAgentNotFound()` keys off `Accept` (not User-Agent). Curl/SDK catch-all `*/*` stays on the agent body; Chrome-style `text/html` gets HTML.
- Middleware unknown-path 404s dispatch through `originNotFoundResponse()`.
- `public/404.html` is generated from the same human HTML builder (drift-tested).

## Verification (local)

Passed:

- `tsx --test tests/agent-friendly-404.test.mts tests/docs-root-redirects.test.mts tests/middleware-bot-gate.test.mts tests/spa-fallback-scope.test.mjs` (109/109)
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run lint:boundaries`
- `biome lint` on the changed files

Unproved until this deploys:

- Live browser visit to a missing www path rendering the HTML 404
- Live `curl` of the same path still returning `404` + `text/markdown`
- Orank `agent-friendly-404` remaining 2/2

## Screenshots

Human HTML 404 (`public/404.html`):

[Human HTML 404 page](https://cursor.com/agents/bc-d30ef876-7488-4389-8c85-20f90cf43d22/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhuman_404_static_page.webp)

Middleware human 404 for `/this-page-does-not-exist`:

[Human 404 with requested path](https://cursor.com/agents/bc-d30ef876-7488-4389-8c85-20f90cf43d22/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhuman_404_middleware_path.webp)

[human_404_page_links.mp4](https://cursor.com/agents/bc-d30ef876-7488-4389-8c85-20f90cf43d22/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhuman_404_page_links.mp4)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

N/A — no published methodology/API claim changes.

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d30ef876-7488-4389-8c85-20f90cf43d22?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d30ef876-7488-4389-8c85-20f90cf43d22&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

