### PR TITLE
fix(sources): clarify country filter coverage

### DIFF
--- a/scripts/crawlable-sources-page.mjs
+++ b/scripts/crawlable-sources-page.mjs
@@ -773,6 +773,7 @@ ${domainCards}
           <button type="button" class="reset-filter" data-source-filter="all">Reset</button>
         </div>
         <div class="catalog-meta"><p id="source-results" aria-live="polite">${sourceStats.providerCount} providers shown</p><a href="${withUtmSource('/docs/source-attribution', 'seo-sources')}">Open the host-by-host ledger <span aria-hidden="true">↗</span></a></div>
+        <p class="catalog-country-note" id="source-country-note" aria-live="polite" hidden></p>
         <div class="provider-grid" id="source-catalog" data-source-catalog>
 ${providerCards}
         </div>
@@ -868,6 +869,7 @@ ${providerCards}
       .catalog-meta { padding: 15px 2px; display: flex; justify-content: space-between; gap: 20px; align-items: center; }
       .catalog-meta p { margin: 0; font: 10px ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .06em; text-transform: uppercase; }
       .catalog-meta a { font-size: 12px; }
+      .catalog-country-note { max-width: 75ch; margin: 0 2px 15px; color: var(--muted); font-size: 13px; line-height: 1.6; }
       .provider-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border-left: 1px solid var(--line); border-top: 1px solid var(--line); }
       .provider-card { min-width: 0; min-height: 180px; padding: 18px; display: flex; flex-direction: column; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: rgba(9,13,11,.48); }
       .provider-card:hover { background: var(--panel-2); }
@@ -907,6 +909,7 @@ ${providerCards}
       }));
       const filterButtons = [...document.querySelectorAll('[data-source-filter]')];
       const results = document.getElementById('source-results');
+      const countryNote = document.getElementById('source-country-note');
       const noResults = document.getElementById('source-no-results');
       const applyFilters = () => {
         const query = search.value.trim().toLowerCase();
@@ -921,6 +924,12 @@ ${providerCards}
           if (!card.hidden) visible += 1;
         }
         results.textContent = visible + (visible === 1 ? ' provider shown' : ' providers shown');
+        const showCountryNote = country.value !== 'all' && country.value !== 'intl';
+        const nextCountryNote = showCountryNote
+          ? 'This list shows monitored sources based in the selected country or region. Sources based elsewhere also cover it.'
+          : '';
+        if (countryNote.textContent !== nextCountryNote) countryNote.textContent = nextCountryNote;
+        if (countryNote.hidden === showCountryNote) countryNote.hidden = !showCountryNote;
         noResults.hidden = visible !== 0;
         for (const button of filterButtons) {
           const selected = button.dataset.sourceFilter !== 'all' && button.dataset.sourceFilter === domain.value;

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -853,6 +853,8 @@ describe('crawlable corpus generator', () => {
       );
       resetButton.click();
       const countrySelect = window.document.getElementById('source-country');
+      const countryNote = window.document.getElementById('source-country-note');
+      assert.equal(countryNote.hidden, true, 'country coverage note must stay hidden without a country filter');
       countrySelect.value = 'hu';
       countrySelect.dispatchEvent(new window.Event('change'));
       assert.equal(
@@ -865,7 +867,29 @@ describe('crawlable corpus generator', () => {
         window.document.querySelector('.provider-card[data-provider="24.hu"] .provider-country')?.textContent,
         'Hungary',
       );
+      assert.equal(countryNote.hidden, false, 'country selection must show the coverage clarification');
+      assert.equal(
+        countryNote.textContent,
+        'This list shows monitored sources based in the selected country or region. Sources based elsewhere also cover it.',
+      );
+      for (const country of ['us', 'eu']) {
+        countrySelect.value = country;
+        countrySelect.dispatchEvent(new window.Event('change'));
+        assert.equal(countryNote.hidden, false, `${country} selection must show the coverage clarification`);
+        assert.equal(
+          countryNote.textContent,
+          'This list shows monitored sources based in the selected country or region. Sources based elsewhere also cover it.',
+        );
+      }
+      countrySelect.value = 'intl';
+      countrySelect.dispatchEvent(new window.Event('change'));
+      assert.equal(countryNote.hidden, true, 'international selection must hide the coverage clarification');
+      assert.equal(countryNote.textContent, '', 'international selection must clear the coverage clarification');
+      countrySelect.value = 'eu';
+      countrySelect.dispatchEvent(new window.Event('change'));
       resetButton.click();
+      assert.equal(countryNote.hidden, true, 'reset must hide the country coverage clarification');
+      assert.equal(countryNote.textContent, '', 'reset must clear the country coverage clarification');
       const searchInput = window.document.getElementById('source-search');
       searchInput.value = 'Hyperliquid';
       searchInput.dispatchEvent(new window.Event('input'));


### PR DESCRIPTION
## Summary

Selecting a country or region in the source catalog could imply that only the listed publishers cover that place. The catalog now explains that the filter shows where monitored sources are based and that sources based elsewhere may also provide coverage. The clarification stays hidden for the unfiltered and International views.

## Validation

- `node --import tsx --test tests/crawlable-corpus.test.mjs` (24 tests passed)
- `npm run typecheck`
- `npm run lint`
- `npm run sources:check`
- `npm run build:crawlable-corpus`
- Browser checks at desktop and mobile widths: India shows the note above the provider grid; International hides it; no overflow or console errors were found.

## Post-deploy validation

No additional operational monitoring is required because this change only affects static catalog copy. In the first post-deploy smoke check, select India and International on `/sources/#catalog`; roll back if the note is missing for India, appears for International, or overlaps the provider list.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
