### PR TITLE
fix(sources): keep country filter note on one line

### DIFF
--- a/scripts/crawlable-sources-page.mjs
+++ b/scripts/crawlable-sources-page.mjs
@@ -909,7 +909,7 @@ ${providerCards}
       .catalog-meta { padding: 15px 2px; display: flex; justify-content: space-between; gap: 20px; align-items: center; }
       .catalog-meta p { margin: 0; font: 10px ui-monospace, SFMono-Regular, Menlo, monospace; letter-spacing: .06em; text-transform: uppercase; }
       .catalog-meta a { font-size: 12px; }
-      .catalog-country-note { max-width: 75ch; margin: 0 2px 15px; color: var(--muted); font-size: 13px; line-height: 1.6; }
+      .catalog-country-note { margin: 0 2px 15px; color: var(--muted); font-size: 13px; line-height: 1.6; }
       .provider-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); border-left: 1px solid var(--line); border-top: 1px solid var(--line); }
       .provider-card { min-width: 0; min-height: 180px; padding: 18px; display: flex; flex-direction: column; border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); background: rgba(9,13,11,.48); }
       .provider-card:hover { background: var(--panel-2); }

--- a/tests/crawlable-corpus.test.mjs
+++ b/tests/crawlable-corpus.test.mjs
@@ -311,6 +311,25 @@ describe('sources catalog provider names', () => {
   });
 });
 
+const SOURCE_COUNTRY_FILTER_NOTE = (
+  'This list shows monitored sources based in the selected country or region. Sources based elsewhere also cover it.'
+);
+
+describe('sources catalog country note layout', () => {
+  it('does not cap the country filter note below the sentence length', () => {
+    const src = readFileSync(join(repoRoot, 'scripts/crawlable-sources-page.mjs'), 'utf8');
+    const rule = src.match(/\.catalog-country-note \{([^}]+)\}/)?.[1];
+    assert.ok(rule, 'sources page must style the country coverage note');
+    const maxWidth = rule.match(/max-width:\s*([^;]+)/)?.[1]?.trim();
+    if (!maxWidth) return;
+    const chMatch = maxWidth.match(/^(\d+(?:\.\d+)?)ch$/);
+    assert.ok(
+      chMatch && Number(chMatch[1]) >= SOURCE_COUNTRY_FILTER_NOTE.length,
+      `country note max-width ${maxWidth} wraps a ${SOURCE_COUNTRY_FILTER_NOTE.length}-character sentence on a full-width catalog; omit max-width or size it to the sentence`,
+    );
+  });
+});
+
 function isJsonLdType(value, expectedType) {
   const type = value?.['@type'];
   return type === expectedType || (Array.isArray(type) && type.includes(expectedType));
@@ -914,18 +933,12 @@ describe('crawlable corpus generator', () => {
         'Origin: Hungary',
       );
       assert.equal(countryNote.hidden, false, 'country selection must show the coverage clarification');
-      assert.equal(
-        countryNote.textContent,
-        'This list shows monitored sources based in the selected country or region. Sources based elsewhere also cover it.',
-      );
+      assert.equal(countryNote.textContent, SOURCE_COUNTRY_FILTER_NOTE);
       for (const country of ['us', 'eu']) {
         countrySelect.value = country;
         countrySelect.dispatchEvent(new window.Event('change'));
         assert.equal(countryNote.hidden, false, `${country} selection must show the coverage clarification`);
-        assert.equal(
-          countryNote.textContent,
-          'This list shows monitored sources based in the selected country or region. Sources based elsewhere also cover it.',
-        );
+        assert.equal(countryNote.textContent, SOURCE_COUNTRY_FILTER_NOTE);
       }
       countrySelect.value = 'intl';
       countrySelect.dispatchEvent(new window.Event('change'));

--- a/tests/ucdp-seed-resilience.test.mjs
+++ b/tests/ucdp-seed-resilience.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { discoverVersion as discoverStandaloneUcdpVersion } from '../scripts/seed-ucdp-events.mjs';
 
@@ -22,7 +22,12 @@ const SOURCE_SCAN_IGNORED_DIRS = new Set([
 ]);
 
 function shouldScanSourceDir(path) {
-  return !SOURCE_SCAN_IGNORED_DIRS.has(path);
+  if (SOURCE_SCAN_IGNORED_DIRS.has(path)) return false;
+  // Parallel tests create short-lived repo-root fixtures such as
+  // tmp-times-of-india-feed-test. Those are never source, and they can
+  // vanish between readdir and descent (ENOENT under --test-concurrency).
+  const top = path.split(/[\\/]/)[0];
+  return top !== 'tmp' && !top.startsWith('tmp-');
 }
 
 function sourceFilesContaining(rootDir, needle) {
@@ -30,7 +35,14 @@ function sourceFilesContaining(rootDir, needle) {
   const stack = [rootDir];
   while (stack.length > 0) {
     const dir = stack.pop();
-    for (const entry of readdirSync(dir)) {
+    let entries;
+    try {
+      entries = readdirSync(dir);
+    } catch (err) {
+      if (err?.code === 'ENOENT') continue;
+      throw err;
+    }
+    for (const entry of entries) {
       const path = join(dir, entry);
       // The parallel test runner churns short-lived fixtures under scripts/
       // (bundle-runner, seed-utils-sigterm-cleanup), so a file readdirSync
@@ -217,6 +229,20 @@ describe('UCDP version selection prefers the newest release', () => {
 
   it('all UCDP Redis writers are covered by this guard', () => {
     assert.deepEqual(ucdpRedisWriterPaths(), EXPECTED_UCDP_WRITER_PATHS);
+  });
+
+  it('does not treat ephemeral repo-root tmp fixtures as UCDP writers', () => {
+    const fixtureDir = 'tmp-ucdp-writer-scan-test';
+    mkdirSync(fixtureDir, { recursive: true });
+    writeFileSync(
+      join(fixtureDir, 'fake-writer.mjs'),
+      `envelopeWrite('${UCDP_REDIS_KEY}', '{}');\n`,
+    );
+    try {
+      assert.deepEqual(ucdpRedisWriterPaths(), EXPECTED_UCDP_WRITER_PATHS);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
   });
 
   it('standalone cron discovery also requires non-empty Result for the same Redis key', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The country-of-origin clarification on `/sources/` wrapped onto two lines even when the catalog had unused width. The note used `max-width: 75ch` (about 615px), which is shorter than the 113-character sentence.

This change removes that cap so the sentence sits on one line at catalog width. Narrow viewports still wrap naturally.

A follow-up commit stops the UCDP writer scan from walking ephemeral `tmp-*` fixtures. Parallel `test:data` runs were deleting those directories between `readdir` and descent, which crashed `unit` with `ENOENT` and failed `gate`.

Production catalog at 1440px, India origin selected:

**Before (2 line boxes, max-width 615px, height 42px):**
[Country note wrapping on two lines](https://cursor.com/agents/bc-e4702464-244c-498a-9e54-331a7f3b87dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcountry_note_production_before_catalog.png)

**After removing the cap (1 line box, max-width none, height 21px):**
[Country note on one line](https://cursor.com/agents/bc-e4702464-244c-498a-9e54-331a7f3b87dd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcountry_note_production_after_catalog.png)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: `/sources/` marketing catalog; unit-test scanner flake

## Checklist

- [x] Tested against the live `/sources/` catalog CSS and the generated page styles
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`) — CSS/test-only change
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [x] N/A — this PR does not publish or change documentation claims

## Screenshots

See before/after catalog captures above.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4702464-244c-498a-9e54-331a7f3b87dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4702464-244c-498a-9e54-331a7f3b87dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

