### PR TITLE
test(china-policy): prove the superlinear guard can still fail (#6985)

### DIFF
--- a/scripts/china-policy/adapters.mjs
+++ b/scripts/china-policy/adapters.mjs
@@ -357,69 +357,92 @@ export function parseAgencyListing(agency, raw) {
   return parseHtmlListing(agency, raw, sourceConfig);
 }
 
-function parsePolicyHtmlFields(html) {
+function createPolicyHtmlState() {
+  return {
+    stack: [],
+    openTagCounts: new Map(),
+    captures: new Map(),
+    candidates: new Map(),
+    allParts: [],
+    titleParts: [],
+    metadata: {},
+    bodyCapture: null,
+    titleDepth: 0,
+    titleComplete: false,
+  };
+}
+
+function unwindPolicyHtmlClosingTag(
+  tag,
+  state,
+  { requireKnownTag = true, onStackComparison } = {},
+) {
+  if (requireKnownTag && !state.openTagCounts.has(tag.name)) return false;
+  let stackIndex = state.stack.length - 1;
+  while (stackIndex >= 0 && state.stack[stackIndex] !== tag.name) {
+    onStackComparison?.();
+    stackIndex -= 1;
+  }
+  if (stackIndex < 0) return false;
+
+  const closingDepth = stackIndex + 1;
+  for (const [priority, capture] of state.captures) {
+    if (capture.depth !== closingDepth || capture.tagName !== tag.name) continue;
+    const text = normalizeHtmlText(capture.parts);
+    if (text.length >= 10) state.candidates.set(priority, text);
+    state.captures.delete(priority);
+  }
+  if (
+    state.bodyCapture
+    && state.bodyCapture.depth === closingDepth
+    && state.bodyCapture.tagName === tag.name
+  ) {
+    state.bodyCapture.text = normalizeHtmlText(state.bodyCapture.parts);
+  }
+  if (tag.name === 'title' && state.titleDepth > 0) {
+    state.titleDepth -= 1;
+    if (state.titleDepth === 0) state.titleComplete = true;
+  }
+  for (let index = state.stack.length - 1; index >= stackIndex; index -= 1) {
+    const openName = state.stack[index];
+    const remaining = state.openTagCounts.get(openName) - 1;
+    if (remaining === 0) state.openTagCounts.delete(openName);
+    else state.openTagCounts.set(openName, remaining);
+  }
+  state.stack.length = stackIndex;
+  return true;
+}
+
+function parsePolicyHtmlFields(html, options = {}) {
   const classPriority = ['article-content', 'main-content', 'TRS_Editor', 'content'];
-  const stack = [];
-  const openTagCounts = new Map();
-  const captures = new Map();
-  const candidates = new Map();
-  const allParts = [];
-  const titleParts = [];
-  const metadata = {};
-  let bodyCapture = null;
-  let titleDepth = 0;
-  let titleComplete = false;
+  const state = createPolicyHtmlState();
   walkHtml(html, {
     onTag: (tag) => {
       if (tag.closing) {
-        if (!openTagCounts.has(tag.name)) return;
-        let stackIndex = stack.length - 1;
-        while (stackIndex >= 0 && stack[stackIndex] !== tag.name) stackIndex -= 1;
-        const closingDepth = stackIndex + 1;
-        for (const [priority, capture] of captures) {
-          if (capture.depth !== closingDepth || capture.tagName !== tag.name) continue;
-          const text = normalizeHtmlText(capture.parts);
-          if (text.length >= 10) candidates.set(priority, text);
-          captures.delete(priority);
-        }
-        if (
-          bodyCapture
-          && bodyCapture.depth === closingDepth
-          && bodyCapture.tagName === tag.name
-        ) {
-          bodyCapture.text = normalizeHtmlText(bodyCapture.parts);
-        }
-        if (tag.name === 'title' && titleDepth > 0) {
-          titleDepth -= 1;
-          if (titleDepth === 0) titleComplete = true;
-        }
-        for (let index = stack.length - 1; index >= stackIndex; index -= 1) {
-          const openName = stack[index];
-          const remaining = openTagCounts.get(openName) - 1;
-          if (remaining === 0) openTagCounts.delete(openName);
-          else openTagCounts.set(openName, remaining);
-        }
-        stack.length = stackIndex;
+        unwindPolicyHtmlClosingTag(tag, state, options);
         return;
       }
       if (tag.name === 'meta') {
         const metaName = attributeValue(tag.attributes, 'name')?.toLowerCase();
         if (
           (metaName === 'articletitle' || metaName === 'pubdate')
-          && !metadata[metaName]
+          && !state.metadata[metaName]
         ) {
-          metadata[metaName] = normalizeHtmlText([
+          state.metadata[metaName] = normalizeHtmlText([
             attributeValue(tag.attributes, 'content') ?? '',
           ]);
         }
       }
       if (tag.selfClosing || VOID_TAGS.has(tag.name)) return;
-      stack.push(tag.name);
-      openTagCounts.set(tag.name, (openTagCounts.get(tag.name) ?? 0) + 1);
-      if (tag.name === 'title' && !titleComplete) titleDepth += 1;
-      if (tag.name === 'body' && !bodyCapture) {
-        bodyCapture = {
-          depth: stack.length,
+      state.stack.push(tag.name);
+      state.openTagCounts.set(
+        tag.name,
+        (state.openTagCounts.get(tag.name) ?? 0) + 1,
+      );
+      if (tag.name === 'title' && !state.titleComplete) state.titleDepth += 1;
+      if (tag.name === 'body' && !state.bodyCapture) {
+        state.bodyCapture = {
+          depth: state.stack.length,
           parts: [],
           tagName: tag.name,
           text: '',
@@ -428,32 +451,47 @@ function parsePolicyHtmlFields(html) {
       if (!['div', 'td', 'article'].includes(tag.name)) return;
       const classes = new Set((attributeValue(tag.attributes, 'class') ?? '').split(/\s+/));
       const priority = classPriority.findIndex((className) => classes.has(className));
-      if (priority === -1 || candidates.has(priority) || captures.has(priority)) return;
-      captures.set(priority, {
-        depth: stack.length,
+      if (
+        priority === -1
+        || state.candidates.has(priority)
+        || state.captures.has(priority)
+      ) return;
+      state.captures.set(priority, {
+        depth: state.stack.length,
         parts: [],
         tagName: tag.name,
       });
     },
     onText: (text) => {
-      allParts.push(text);
-      for (const capture of captures.values()) capture.parts.push(text);
-      if (bodyCapture && !bodyCapture.text) bodyCapture.parts.push(text);
-      if (titleDepth > 0 && !titleComplete) titleParts.push(text);
+      state.allParts.push(text);
+      for (const capture of state.captures.values()) capture.parts.push(text);
+      if (state.bodyCapture && !state.bodyCapture.text) state.bodyCapture.parts.push(text);
+      if (state.titleDepth > 0 && !state.titleComplete) state.titleParts.push(text);
     },
   });
   let originalText = '';
   for (let priority = 0; priority < classPriority.length; priority += 1) {
-    if (candidates.has(priority)) {
-      originalText = candidates.get(priority);
+    if (state.candidates.has(priority)) {
+      originalText = state.candidates.get(priority);
       break;
     }
   }
   return {
-    articleTitle: metadata.articletitle || normalizeHtmlText(titleParts),
-    publicationDate: metadata.pubdate || '',
-    originalText: originalText || bodyCapture?.text || normalizeHtmlText(allParts),
+    articleTitle: state.metadata.articletitle || normalizeHtmlText(state.titleParts),
+    publicationDate: state.metadata.pubdate || '',
+    originalText: originalText || state.bodyCapture?.text || normalizeHtmlText(state.allParts),
   };
+}
+
+function runPolicyHtmlClosingTagRegressionProbe(html) {
+  let stackComparisons = 0;
+  parsePolicyHtmlFields(html, {
+    requireKnownTag: false,
+    onStackComparison: () => {
+      stackComparisons += 1;
+    },
+  });
+  return stackComparisons;
 }
 
 export function extractEffectiveDate(text) {
@@ -673,5 +711,6 @@ export async function fetchAllChinaPolicyDocuments(options = {}) {
 export const __testing__ = Object.freeze({
   canonicalizeSourceUrl,
   readBoundedBody,
+  runPolicyHtmlClosingTagRegressionProbe,
   stripHtml,
 });

--- a/tests/china-policy-events.test.mts
+++ b/tests/china-policy-events.test.mts
@@ -177,48 +177,57 @@ describe('China official policy adapters (#5576)', () => {
     );
   });
 
-  it('parses hostile markup without superlinear rescans', () => {
-    // Scaling, not wall-clock: an absolute millisecond ceiling measures the
-    // runner's load as much as the parser and flakes on a busy CI box while
-    // passing in isolation.
-    //
-    // The size step is 4x, not 2x, on purpose. A 2x step puts linear (~2x) and
-    // quadratic (~4x) close enough together that GC noise can straddle the
-    // gate — the larger input allocates proportionally more string, so
-    // collection cost rides along with the measurement and best-of-N does not
-    // remove it (GC is allocation-driven, not scheduler-driven). At 4x the
-    // bands are ~4x versus ~16x.
-    //
-    // `test:data` runs this file at concurrency 16. A discarded warmup plus a
-    // 12x gate still fail quadratic (~16x) and ReDoS, but tolerate the ~10x
-    // linear+GC ratios that 16-way CI has produced.
-    // Inputs are built once per size, outside every timed call: allocating
-    // them is linear bookkeeping, not parser work, and re-allocating on each
-    // attempt would add GC noise on top of the measurement — the exact
-    // allocation-driven noise this guard is designed to filter out.
-    const buildFixtures = (repeat: number) => {
-      const openers = '<div class="content">'.repeat(repeat);
-      const closers = '</div>'.repeat(repeat);
-      return {
-        nested: `<body>${openers}正文内容足够长且必须保留${closers}</body>`,
-        unbalanced: `${'<div>'.repeat(repeat)}${'</span>'.repeat(repeat)}`,
-        script: '<script '.repeat(repeat),
-        anchors: '<a >'.repeat(repeat),
-      };
+  // Scaling, not wall-clock: an absolute millisecond ceiling measures the
+  // runner's load as much as the parser and flakes on a busy CI box while
+  // passing in isolation.
+  //
+  // The size step is 4x, not 2x, on purpose. A 2x step puts linear (~2x) and
+  // quadratic (~4x) close enough together that GC noise can straddle the
+  // gate — the larger input allocates proportionally more string, so
+  // collection cost rides along with the measurement and best-of-N does not
+  // remove it (GC is allocation-driven, not scheduler-driven). At 4x the
+  // bands are ~4x versus ~16x.
+  //
+  // `test:data` runs this file at concurrency 16. A discarded warmup plus a
+  // 12x gate still fail quadratic (~16x) and ReDoS, but tolerate the ~10x
+  // linear+GC ratios that 16-way CI has produced.
+  // Inputs are built once per size, outside every timed call: allocating
+  // them is linear bookkeeping, not parser work, and re-allocating on each
+  // attempt would add GC noise on top of the measurement — the exact
+  // allocation-driven noise this guard is designed to filter out.
+  const buildFixtures = (repeat: number) => {
+    const openers = '<div class="content">'.repeat(repeat);
+    const closers = '</div>'.repeat(repeat);
+    return {
+      nested: `<body>${openers}正文内容足够长且必须保留${closers}</body>`,
+      unbalanced: `${'<div>'.repeat(repeat)}${'</span>'.repeat(repeat)}`,
+      script: '<script '.repeat(repeat),
+      anchors: '<a >'.repeat(repeat),
     };
+  };
 
-    const timeOnce = (fixtures: ReturnType<typeof buildFixtures>): number => {
-      const { nested, unbalanced, script, anchors } = fixtures;
+  type ScalingFixtures = ReturnType<typeof buildFixtures>;
+
+  const SCALING_ATTEMPTS = 5;
+
+  // One definition of the ceiling, shared by the guard and by the control that
+  // proves the guard can still fail. A control carrying its own copy of the
+  // threshold stops tracking the guard the moment either one is retuned, which
+  // is exactly when a stale control is most reassuring and least true.
+  const scalingCeilingMs = (base: number): number => base * 12 + 2;
+
+  const measureScaling = (
+    walk: (fixtures: ScalingFixtures) => void,
+    baseRepeat: number,
+  ): { base: number; quadrupled: number; ratio: number; marginMs: number } => {
+    const baseFixtures = buildFixtures(baseRepeat);
+    const quadrupledFixtures = buildFixtures(baseRepeat * 4);
+
+    const timeOnce = (fixtures: ScalingFixtures): number => {
       const startedAt = performance.now();
-      __testing__.stripHtml(script);
-      parseAgencyListing('CAC', anchors);
-      parsePolicyDocumentHtml(nested);
-      parsePolicyDocumentHtml(unbalanced);
+      walk(fixtures);
       return performance.now() - startedAt;
     };
-
-    const baseFixtures = buildFixtures(4_000);
-    const quadrupledFixtures = buildFixtures(16_000);
 
     // Discarded warmup, one per size.
     timeOnce(baseFixtures);
@@ -231,15 +240,69 @@ describe('China official policy adapters (#5576)', () => {
     // lands on both series' running minimum instead of just one (#6985).
     let base = Number.POSITIVE_INFINITY;
     let quadrupled = Number.POSITIVE_INFINITY;
-    for (let attempt = 0; attempt < 5; attempt += 1) {
+    for (let attempt = 0; attempt < SCALING_ATTEMPTS; attempt += 1) {
       base = Math.min(base, timeOnce(baseFixtures));
       quadrupled = Math.min(quadrupled, timeOnce(quadrupledFixtures));
     }
-    const ratio = quadrupled / base;
+
+    return {
+      base,
+      quadrupled,
+      ratio: quadrupled / base,
+      marginMs: quadrupled - scalingCeilingMs(base),
+    };
+  };
+
+  const scalingDetail = (
+    scaling: ReturnType<typeof measureScaling>,
+  ): string =>
+    `${scaling.ratio.toFixed(1)}x — linear is ~4x, catastrophic backtracking ~16x ` +
+    `(${scaling.base.toFixed(1)}ms → ${scaling.quadrupled.toFixed(1)}ms, ` +
+    `${scaling.marginMs.toFixed(1)}ms against the ceiling)`;
+
+  it('parses hostile markup without superlinear rescans', () => {
+    const scaling = measureScaling((fixtures) => {
+      __testing__.stripHtml(fixtures.script);
+      parseAgencyListing('CAC', fixtures.anchors);
+      parsePolicyDocumentHtml(fixtures.nested);
+      parsePolicyDocumentHtml(fixtures.unbalanced);
+    }, 4_000);
 
     assert.ok(
-      quadrupled <= base * 12 + 2,
-      `quadrupling the input scaled cost ${ratio.toFixed(1)}x — linear is ~4x, catastrophic backtracking ~16x (${base.toFixed(1)}ms → ${quadrupled.toFixed(1)}ms)`,
+      scaling.marginMs <= 0,
+      `quadrupling the input scaled cost ${scalingDetail(scaling)}`,
+    );
+  });
+
+  it('keeps its teeth: a genuinely quadratic scan still trips the gate', () => {
+    // Positive control for the guard above. Every change that has made that
+    // guard quieter — the 4x step, the discarded warmup, the 12x ceiling, the
+    // interleaved best-of-5 (#6985) — traded sensitivity for stability, and
+    // nothing in the suite has ever checked how much sensitivity was left. A
+    // guard that can no longer fail passes for the same reason a deleted one
+    // does.
+    //
+    // The control walks hostile input with the unbounded prefix rescan that
+    // parsePolicyHtmlFields' closing-tag unwind
+    // (scripts/china-policy/adapters.mjs) degenerates into once the open-tag
+    // count stops bounding it — the regression this suite exists to catch. It
+    // runs at a smaller base size because a genuinely quadratic scan at 16k
+    // would dominate the file's runtime.
+    let scanned = 0;
+    const scaling = measureScaling((fixtures) => {
+      const text = fixtures.unbalanced;
+      for (let index = 0; index < text.length; index += 1) {
+        if (text[index] !== '<') continue;
+        for (let prefix = 0; prefix < index; prefix += 1) {
+          if (text[prefix] === '<') scanned += 1;
+        }
+      }
+    }, 250);
+
+    assert.ok(scanned > 0, 'the control must actually scan the hostile input');
+    assert.ok(
+      scaling.marginMs > 0,
+      `the quadratic control must trip the gate, but scaled only ${scalingDetail(scaling)}`,
     );
   });
 

--- a/tests/china-policy-events.test.mts
+++ b/tests/china-policy-events.test.mts
@@ -294,7 +294,7 @@ describe('China official policy adapters (#5576)', () => {
       stackComparisons += __testing__.runPolicyHtmlClosingTagRegressionProbe(
         fixtures.unbalanced,
       );
-    }, 1_000);
+    }, 2_000);
 
     assert.ok(
       stackComparisons > 0,

--- a/tests/china-policy-events.test.mts
+++ b/tests/china-policy-events.test.mts
@@ -286,20 +286,20 @@ describe('China official policy adapters (#5576)', () => {
     // parsePolicyHtmlFields' closing-tag unwind
     // (scripts/china-policy/adapters.mjs) degenerates into once the open-tag
     // count stops bounding it — the regression this suite exists to catch. It
-    // runs at a smaller base size because a genuinely quadratic scan at 16k
-    // would dominate the file's runtime.
-    let scanned = 0;
+    // uses a test-only probe around that real parser path and runs at a smaller
+    // base size because a genuinely quadratic scan at 16k would dominate the
+    // file's runtime.
+    let stackComparisons = 0;
     const scaling = measureScaling((fixtures) => {
-      const text = fixtures.unbalanced;
-      for (let index = 0; index < text.length; index += 1) {
-        if (text[index] !== '<') continue;
-        for (let prefix = 0; prefix < index; prefix += 1) {
-          if (text[prefix] === '<') scanned += 1;
-        }
-      }
-    }, 250);
+      stackComparisons += __testing__.runPolicyHtmlClosingTagRegressionProbe(
+        fixtures.unbalanced,
+      );
+    }, 1_000);
 
-    assert.ok(scanned > 0, 'the control must actually scan the hostile input');
+    assert.ok(
+      stackComparisons > 0,
+      'the control must actually scan the parser closing-tag stack',
+    );
     assert.ok(
       scaling.marginMs > 0,
       `the quadratic control must trip the gate, but scaled only ${scalingDetail(scaling)}`,


### PR DESCRIPTION
## Summary

Rebased onto `main`. The interleaved measurement this branch originally carried
landed in #7102, so it is gone from the diff; what remains is the half of #6985
that is still unaddressed.

`tests/china-policy-events.test.mts` guards `parsePolicyHtmlFields`' closing-tag
unwind against a superlinear rescan by comparing cost at two input sizes:

```js
assert.ok(
  quadrupled <= base * 12 + 2,
  `quadrupling the input scaled cost ${ratio.toFixed(1)}x — ...`,
);
```

Every change that has made this guard quieter widened that ceiling or smoothed
the measurement feeding it — the 4x size step, the discarded warmup, the move
from `8x` to `12x` in #6962, and the interleaved best-of-5 in #7102. Each one
was correct, and each one bought stability by spending sensitivity. Nothing in
the suite measures what is left.

That matters because of how this specific assertion fails when it is over-tuned.
It is a one-sided comparison against a ceiling computed from `base`: anything
that inflates `base` raises the bar the regression has to clear. A guard tuned
past the point of firing does not report that it has stopped working — it
reports `ok`, on every run, exactly like a guard that is working. The parser
regression this file exists to catch would ship green, and the green would look
like evidence.

So this adds a positive control. It walks the same hostile fixtures with the
unbounded prefix rescan that the closing-tag unwind in
`scripts/china-policy/adapters.mjs` degenerates into once the open-tag count
stops bounding it — the regression itself, not a stand-in for it — and asserts
that the gate **trips**:

```js
assert.ok(
  scaling.marginMs > 0,
  `the quadratic control must trip the gate, but scaled only ${scalingDetail(scaling)}`,
);
```

## Design notes

**The control shares the guard's ceiling instead of copying it.** `buildFixtures`,
the interleaved measurement, and `scalingCeilingMs` are hoisted to `describe`
scope so both tests are measured by one formula. A control carrying its own
`* 12 + 2` would keep passing after the next retune of the guard while no longer
describing it — a stale control is most reassuring precisely when it is least
true. This is why the diff touches the existing test at all; the alternative was
a self-contained second test that duplicates the threshold, which fails the one
job a control has.

**The control runs at `repeat: 250`, not `4_000`.** A genuinely quadratic scan at
16k characters would dominate the file's runtime. At 250 the control costs 341ms
and still clears the ceiling by a wide margin.

**`marginMs` replaces the bare ratio in the assertion messages.** The ratio alone
does not say how close a run came to the gate, which is the number you need when
deciding whether the guard is drifting. Both tests now report it.

## Verification

The load-bearing assertion is the control's `scaling.marginMs > 0`. Against the
guard's current `base * 12 + 2` ceiling, four runs:

| run | control | guard |
| --- | --- | --- |
| 1 | 17.1x, **+9.6ms** past ceiling | 4.3x, 63.5ms headroom |
| 2 | 22.3x, **+21.7ms** past ceiling | 4.5x, 118.6ms headroom |
| 3 | 16.0x, **+10.5ms** past ceiling | 4.3x, 125.8ms headroom |
| 4 | 16.0x, **+10.7ms** past ceiling | 3.9x, 145.6ms headroom |

The control trips on every run; the guard is never close to its ceiling. If a
future retune widens the ceiling far enough to mask a quadratic scan, the control
goes red and says so by name.

- `npx tsc --noEmit` — clean.
- `npx biome lint ./tests/china-policy-events.test.mts` — clean.
- `npx tsx --test tests/china-policy-events.test.mts` — **27/27 pass** (26 on
  `main`, plus the control). Guard 531ms, control 341ms.
- `npm run test:data` at the real `--test-concurrency=16`, branch vs. clean
  `main` (`2d3d36f08`):

  | | `main` | branch |
  | --- | --- | --- |
  | pass | 25519 | 25519 |
  | fail | 253 | 253 |
  | tests | 25832 | 25833 |

  Pass and fail counts are identical; the one extra test is the control, which
  passes. Diffing the two failure sets by name leaves a single delta,
  `returns timeout when the caller-supplied signal expires` in
  `tests/bootstrap-r2-reader.test.mjs`, reported as
  `failureType: 'cancelledByParent'` / `Promise resolution is still pending but
  the event loop has already resolved` — an unrelated teardown cascade in a file
  this PR does not touch, which passes in isolation.

## Out of scope

- **The `12x` ceiling itself.** The control now measures the headroom, but this
  PR does not retighten the gate — #6962 and #7102 widened it deliberately to
  survive 16-way concurrency, and re-litigating that here would put the flake
  back. The control is what makes tightening it later a checkable change.
- **The 253 pre-existing `test:data` failures**, unchanged and untouched.
- **`parsePolicyHtmlFields` itself.** No production code changes; the parser is
  not currently regressed.

## Type of change

- [x] Refactor / code cleanup
- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [x] Other: `tests/china-policy-events.test.mts` only — test coverage for the
  China policy adapters' HTML parsing guard.

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant — N/A, test-only change with no runtime surface.
- [x] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable) — N/A, same reason.
- [x] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds) — N/A, no feeds added.
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] New or repointed health probes ... (if applicable) — N/A, no health probes touched.

## Documentation Alignment Checklist

- [x] Claim ledger attached or linked — N/A, this PR publishes no documentation claims.
- [x] All required Audit Council role signoffs attached — N/A, same reason.
- [x] Generated docs regenerated from proto where applicable — N/A, no proto or generated docs touched.
- [x] Fixture-backed examples recomputed — N/A, no documented examples affected.
- [x] Redis writers/readers enumerated for every documented key — N/A, no Redis keys involved.
