### PR TITLE
fix(pro): keep checkout alive without AbortSignal.timeout

### DIFF
--- a/pro-test/src/components/PricingSection.tsx
+++ b/pro-test/src/components/PricingSection.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { motion } from 'motion/react';
 import { Check, ShieldCheck, ArrowRight, Zap, Loader2 } from 'lucide-react';
 import { startCheckout, subscribeCheckoutPhase, type CheckoutPhase } from '../services/checkout';
+import { createTimeoutSignal } from '../services/checkout-transport';
 import { CheckoutConsent } from './CheckoutConsent';
 import { t, tArray } from '../i18n';
 
@@ -34,7 +35,7 @@ function usePricingData(): Tier[] {
 
   useEffect(() => {
     let cancelled = false;
-    fetch(CATALOG_API, { signal: AbortSignal.timeout(5000) })
+    fetch(CATALOG_API, { signal: createTimeoutSignal(5000) })
       .then(res => res.ok ? res.json() : null)
       .then(data => {
         if (!cancelled && data?.tiers?.length) {

--- a/pro-test/src/services/checkout-transport.ts
+++ b/pro-test/src/services/checkout-transport.ts
@@ -42,13 +42,25 @@ export interface CreateCheckoutArgs {
   payload: unknown;
 }
 
+/**
+ * AbortSignal.timeout is Baseline 2024 (Chrome 103+). Chrome Mobile 101
+ * still reaches /pro (WORLDMONITOR-109) and throws TypeError before fetch.
+ * Same fallback as src/services/ollama-models.ts makeTimeout.
+ */
+export function createTimeoutSignal(ms: number): AbortSignal {
+  if (typeof AbortSignal.timeout === 'function') return AbortSignal.timeout(ms);
+  const ctrl = new AbortController();
+  setTimeout(() => ctrl.abort(), ms);
+  return ctrl.signal;
+}
+
 /** Browser-default deps; split out so tests can inject deterministic ones. */
 export function createDefaultCheckoutTransportDeps(): CreateCheckoutTransportDeps {
   return {
     fetch: (url, init) => globalThis.fetch(url, init),
     delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     generateIdempotencyKey: () => crypto.randomUUID(),
-    createTimeoutSignal: (ms) => AbortSignal.timeout(ms),
+    createTimeoutSignal,
   };
 }
 

--- a/src/services/checkout-transport.ts
+++ b/src/services/checkout-transport.ts
@@ -42,13 +42,25 @@ export interface CreateCheckoutArgs {
   payload: unknown;
 }
 
+/**
+ * AbortSignal.timeout is Baseline 2024 (Chrome 103+). Chrome Mobile 101
+ * still reaches /pro (WORLDMONITOR-109) and throws TypeError before fetch.
+ * Same fallback as src/services/ollama-models.ts makeTimeout.
+ */
+export function createTimeoutSignal(ms: number): AbortSignal {
+  if (typeof AbortSignal.timeout === 'function') return AbortSignal.timeout(ms);
+  const ctrl = new AbortController();
+  setTimeout(() => ctrl.abort(), ms);
+  return ctrl.signal;
+}
+
 /** Browser-default deps; split out so tests can inject deterministic ones. */
 export function createDefaultCheckoutTransportDeps(): CreateCheckoutTransportDeps {
   return {
     fetch: (url, init) => globalThis.fetch(url, init),
     delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     generateIdempotencyKey: () => crypto.randomUUID(),
-    createTimeoutSignal: (ms) => AbortSignal.timeout(ms),
+    createTimeoutSignal,
   };
 }
 

--- a/tests/checkout-transport.test.mts
+++ b/tests/checkout-transport.test.mts
@@ -22,10 +22,12 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   postCreateCheckout,
+  createDefaultCheckoutTransportDeps,
   RETRYABLE_CHECKOUT_STATUSES,
   CHECKOUT_RETRY_DELAY_MS,
   type CreateCheckoutTransportDeps,
 } from '../src/services/checkout-transport';
+import { createDefaultCheckoutTransportDeps as createProCheckoutTransportDeps } from '../pro-test/src/services/checkout-transport.ts';
 
 type FetchOutcome = { response: Response } | { throws: Error };
 
@@ -220,4 +222,68 @@ describe('postCreateCheckout transport', () => {
     assert.equal(calls.length, 2);
     assert.equal(signalsIssued, 2, 'each attempt needs its own timeout budget');
   });
+});
+
+/**
+ * WORLDMONITOR-109: Chrome Mobile 101 (and other Baseline-2024 gaps) has
+ * AbortSignal but not AbortSignal.timeout. Calling timeout() throws
+ * TypeError before fetch runs. Both /pro catalog fetch and pay-path
+ * transport must survive that gap and still abort after the budget.
+ */
+async function withMissingAbortSignalTimeout<T>(fn: () => T | Promise<T>): Promise<T> {
+  const original = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
+  Object.defineProperty(AbortSignal, 'timeout', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: undefined,
+  });
+  try {
+    return await fn();
+  } finally {
+    if (original) Object.defineProperty(AbortSignal, 'timeout', original);
+    else delete (AbortSignal as { timeout?: unknown }).timeout;
+  }
+}
+
+const TIMEOUT_HELPERS = [
+  { label: 'src checkout-transport', create: createDefaultCheckoutTransportDeps },
+  { label: '/pro checkout-transport', create: createProCheckoutTransportDeps },
+] as const;
+
+describe('createTimeoutSignal AbortSignal.timeout fallback (WORLDMONITOR-109)', () => {
+  for (const { label, create } of TIMEOUT_HELPERS) {
+    it(`${label} does not throw when AbortSignal.timeout is missing`, async () => {
+      await withMissingAbortSignalTimeout(() => {
+        const signal = create().createTimeoutSignal(5_000);
+        assert.equal(signal.aborted, false);
+        assert.equal(typeof signal.addEventListener, 'function');
+      });
+    });
+
+    it(`${label} still aborts after the timeout budget without AbortSignal.timeout`, async () => {
+      await withMissingAbortSignalTimeout(async () => {
+        const signal = create().createTimeoutSignal(25);
+        assert.equal(signal.aborted, false);
+        await new Promise((resolve) => setTimeout(resolve, 80));
+        assert.equal(signal.aborted, true);
+      });
+    });
+
+    it(`${label} uses native AbortSignal.timeout when it is a function`, () => {
+      const original = AbortSignal.timeout;
+      const seen: number[] = [];
+      AbortSignal.timeout = (ms) => {
+        seen.push(ms);
+        return original.call(AbortSignal, ms);
+      };
+      try {
+        const signal = create().createTimeoutSignal(1_234);
+        assert.deepEqual(seen, [1_234]);
+        assert.equal(signal.aborted, false);
+      } finally {
+        AbortSignal.timeout = original;
+      }
+    });
+  }
 });

--- a/tests/pro-pricing-billing-mode.test.mts
+++ b/tests/pro-pricing-billing-mode.test.mts
@@ -59,4 +59,17 @@ describe('PricingSection wiring (source contract)', () => {
     assert.ok(src.includes("pricing.billedMonthlyNote"),
       'billed-monthly note copy key missing');
   });
+
+  it('catalog fetch uses the checkout-transport timeout helper, not AbortSignal.timeout', () => {
+    const src = read('pro-test/src/components/PricingSection.tsx');
+    assert.equal(
+      src.includes('AbortSignal.timeout'),
+      false,
+      'WORLDMONITOR-109: catalog fetch must not call AbortSignal.timeout (Chrome 101 throws TypeError before fetch)',
+    );
+    assert.ok(
+      src.includes('createTimeoutSignal(5000)'),
+      'catalog fetch must reuse checkout-transport createTimeoutSignal',
+    );
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Chrome Mobile 101 on `/pro` threw `TypeError: AbortSignal.timeout is not a function` before the product-catalog fetch ran, so Sentry recorded an unhandled error even though static fallback prices still rendered. The same helper would have thrown on pay. Those browsers now get the existing `AbortController` + `setTimeout` fallback, so catalog fetch and create-checkout still start and still abort after the budget.

Fixes WORLDMONITOR-109 (event `fb6883936a934137ad90a9a476d1ff10`, Chrome Mobile 101 / Android 9 / Galaxy J4+).

Scoped to the `/pro` checkout path (`PricingSection` catalog fetch + `createTimeoutSignal` on both transport copies). Other client `AbortSignal.timeout` call sites are unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: `/pro` pricing catalog fetch and create-checkout transport timeout

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked — N/A
- [ ] All required Audit Council role signoffs attached — N/A
- [ ] Generated docs regenerated from proto where applicable — N/A
- [ ] Fixture-backed examples recomputed — N/A
- [ ] Redis writers/readers enumerated for every documented key — N/A

## Evidence

`npx tsx --test tests/checkout-transport.test.mts tests/pro-pricing-billing-mode.test.mts` — 23/23 pass, including Chrome-101-shaped `AbortSignal.timeout` absence (no throw, still aborts) on both transport copies, plus the PricingSection source contract.

`npx tsc --noEmit` — pass.

Unproved: live Chrome 101 device, production deploy, and other `/pro` timeouts (billing portal, teasers) left in scope-out.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06365919-27d8-4033-87a7-110aebde9e73?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06365919-27d8-4033-87a7-110aebde9e73&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

