### PR TITLE
fix(a11y): keyboard activation for click-only drill-in rows across 16 panels

### DIFF
--- a/src/components/CIIPanel.ts
+++ b/src/components/CIIPanel.ts
@@ -56,7 +56,10 @@ export class CIIPanel extends Panel {
     this.followedUnsubscribe = subscribeFollowed(() => {
       this.rerenderRows();
     });
-    bindActivationKeys(this.content, '.cii-country');
+    // Drill-in lives on `.cii-name`, not `.cii-country`. The row wraps
+    // Follow + Share buttons; role="button" on the wrapper trips axe
+    // nested-interactive (WCAG 4.1.2) and fails e2e/a11y-axe-scan.
+    bindActivationKeys(this.content, '.cii-name');
   }
 
   public setShareStoryHandler(handler: (code: string, name: string) => void): void {
@@ -135,11 +138,11 @@ export class CIIPanel extends Panel {
     // stopPropagation pattern in `bindShareButtons`).
     followHost.addEventListener('click', (e) => e.stopPropagation());
 
-    return h('div', { className: 'cii-country', role: 'button', tabindex: '0', dataset: { code: country.code } },
+    return h('div', { className: 'cii-country', dataset: { code: country.code } },
       followHost,
       h('div', { className: 'cii-header' },
         h('span', { className: 'cii-emoji' }, emoji),
-        h('span', { className: 'cii-name' }, country.name),
+        h('span', { className: 'cii-name', role: 'button', tabindex: '0' }, country.name),
         h('span', { className: 'cii-score' }, String(country.score)),
         this.buildTrendArrow(country.trend, country.change24h),
         shareBtn,

--- a/src/components/CIIPanel.ts
+++ b/src/components/CIIPanel.ts
@@ -15,6 +15,7 @@ import {
   partitionByFollowed,
   shouldRenderSectionLabels,
 } from './_cii-panel-partition';
+import { bindActivationKeys } from '@/utils/activation';
 
 export const CII_METHODOLOGY_HREF = '/docs/methodology/cii-risk-scores';
 
@@ -55,6 +56,7 @@ export class CIIPanel extends Panel {
     this.followedUnsubscribe = subscribeFollowed(() => {
       this.rerenderRows();
     });
+    bindActivationKeys(this.content, '.cii-country');
   }
 
   public setShareStoryHandler(handler: (code: string, name: string) => void): void {
@@ -133,7 +135,7 @@ export class CIIPanel extends Panel {
     // stopPropagation pattern in `bindShareButtons`).
     followHost.addEventListener('click', (e) => e.stopPropagation());
 
-    return h('div', { className: 'cii-country', dataset: { code: country.code } },
+    return h('div', { className: 'cii-country', role: 'button', tabindex: '0', dataset: { code: country.code } },
       followHost,
       h('div', { className: 'cii-header' },
         h('span', { className: 'cii-emoji' }, emoji),

--- a/src/components/ClimateAnomalyPanel.ts
+++ b/src/components/ClimateAnomalyPanel.ts
@@ -18,6 +18,17 @@ export class ClimateAnomalyPanel extends Panel {
       infoTooltip: t('components.climate.infoTooltip'),
     });
     this.showLoading(t('common.loadingClimateData'));
+    // Delegated click on the stable content node: setSafeContent debounces the
+    // DOM write by 150ms, so querySelectorAll after render would bind the
+    // loading placeholder and miss the flushed rows. bindActivationKeys'
+    // synthesized click then reaches this same handler.
+    this.content.addEventListener('click', (e) => {
+      const row = (e.target as HTMLElement | null)?.closest<HTMLElement>('.climate-row');
+      if (!row || !this.content.contains(row)) return;
+      const lat = Number(row.dataset.lat);
+      const lon = Number(row.dataset.lon);
+      if (Number.isFinite(lat) && Number.isFinite(lon)) this.onZoneClick?.(lat, lon);
+    });
     bindActivationKeys(this.content, '.climate-row');
   }
 
@@ -77,13 +88,5 @@ export class ClimateAnomalyPanel extends Panel {
         </table>
       </div>
     `);
-
-    this.content.querySelectorAll('.climate-row').forEach(el => {
-      el.addEventListener('click', () => {
-        const lat = Number((el as HTMLElement).dataset.lat);
-        const lon = Number((el as HTMLElement).dataset.lon);
-        if (Number.isFinite(lat) && Number.isFinite(lon)) this.onZoneClick?.(lat, lon);
-      });
-    });
   }
 }

--- a/src/components/ClimateAnomalyPanel.ts
+++ b/src/components/ClimateAnomalyPanel.ts
@@ -2,6 +2,7 @@ import { Panel } from './Panel';
 import { joinSafeHtml, safeHtml } from '@/utils/sanitize';
 import { type ClimateAnomaly, getSeverityIcon, formatDelta } from '@/services/climate';
 import { t } from '@/services/i18n';
+import { bindActivationKeys } from '@/utils/activation';
 
 export class ClimateAnomalyPanel extends Panel {
   private anomalies: ClimateAnomaly[] = [];
@@ -17,6 +18,7 @@ export class ClimateAnomalyPanel extends Panel {
       infoTooltip: t('components.climate.infoTooltip'),
     });
     this.showLoading(t('common.loadingClimateData'));
+    bindActivationKeys(this.content, '.climate-row');
   }
 
   public setZoneClickHandler(handler: (lat: number, lon: number) => void): void {
@@ -52,7 +54,7 @@ export class ClimateAnomalyPanel extends Panel {
       const sevClass = `severity-${a.severity}`;
       const rowClass = a.severity === 'extreme' ? ' climate-extreme-row' : '';
 
-      return safeHtml`<tr class="climate-row${rowClass}" data-lat="${a.lat}" data-lon="${a.lon}">
+      return safeHtml`<tr class="climate-row${rowClass}" data-lat="${a.lat}" data-lon="${a.lon}" tabindex="0">
         <td class="climate-zone"><span class="climate-icon">${icon}</span>${a.zone}</td>
         <td class="climate-num ${tempClass}">${formatDelta(a.tempDelta, '°C')}</td>
         <td class="climate-num ${precipClass}">${formatDelta(a.precipDelta, 'mm')}</td>

--- a/src/components/DisplacementPanel.ts
+++ b/src/components/DisplacementPanel.ts
@@ -7,6 +7,7 @@ import { renderFollowedOnlyChip, type FollowedOnlyChipHandle } from '@/utils/fol
 import { isFollowed, subscribe as subscribeFollowed } from '@/services/followed-countries';
 import { toIso2 } from '@/utils/country-codes';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { bindActivationKeys } from '@/utils/activation';
 
 
 type DisplacementTab = 'origins' | 'hosts';
@@ -46,6 +47,7 @@ export class DisplacementPanel extends Panel {
       }
     });
     this.mountFollowedOnlyChip();
+    bindActivationKeys(this.content, '.disp-row');
   }
 
   private mountFollowedOnlyChip(): void {
@@ -166,7 +168,7 @@ export class DisplacementPanel extends Panel {
           ? `<span class="disp-badge ${badgeCls}">${badgeLabel}</span>`
           : '';
 
-        return `<tr class="disp-row" data-lat="${c.lat || ''}" data-lon="${c.lon || ''}">
+        return `<tr class="disp-row" data-lat="${c.lat || ''}" data-lon="${c.lon || ''}" tabindex="0">
           <td class="disp-name">${escapeHtml(c.name)}</td>
           <td class="disp-status">${badgeHtml}</td>
           <td class="disp-count">${formatPopulation(count)}</td>

--- a/src/components/EnergyDisruptionsPanel.ts
+++ b/src/components/EnergyDisruptionsPanel.ts
@@ -14,6 +14,7 @@ import {
   type DisruptionStatus,
 } from '@/shared/disruption-timeline';
 import { SupplyChainServiceClient } from '@/services/generated-rpc-clients';
+import { bindActivationKeys } from '@/utils/activation';
 
 const getSupplyChainClient = createLazyClient(() => new SupplyChainServiceClient(getRpcBaseUrl(), {
   fetch: rpcFetch,
@@ -97,6 +98,7 @@ export class EnergyDisruptionsPanel extends Panel {
     // data-attributes, so it works regardless of whether the DOM has
     // flushed yet or has been re-rendered since the last filter change.
     this.content.addEventListener('click', this.handleContentClick);
+    bindActivationKeys(this.content, '.ed-row');
   }
 
   private handleContentClick = (e: Event): void => {
@@ -285,7 +287,7 @@ export class EnergyDisruptionsPanel extends Panel {
     const causeChain = e.causeChain.join(' → ') || '—';
 
     return `
-      <tr class="ed-row"
+      <tr class="ed-row" tabindex="0"
           data-event-id="${escapeHtml(e.id)}"
           data-asset-id="${escapeHtml(e.assetId)}"
           data-asset-type="${escapeHtml(e.assetType)}">

--- a/src/components/FuelShortagePanel.ts
+++ b/src/components/FuelShortagePanel.ts
@@ -147,8 +147,22 @@ export class FuelShortagePanel extends Panel {
     if (typeof window !== 'undefined') {
       window.addEventListener('energy:open-fuel-shortage-detail', this.openDetailHandler);
     }
+    this.content.addEventListener('click', this.handleContentClick);
     bindActivationKeys(this.content, '.fs-row');
   }
+
+  private handleContentClick = (e: Event): void => {
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+    if (target.closest('.fs-drawer-close')) {
+      this.closeDetail();
+      return;
+    }
+    const row = target.closest<HTMLTableRowElement>('tr.fs-row');
+    if (!row || !this.content.contains(row)) return;
+    const id = row.dataset.shortageId;
+    if (id) void this.loadDetail(id);
+  };
 
   public destroy(): void {
     if (typeof window !== 'undefined') {
@@ -308,22 +322,13 @@ export class FuelShortagePanel extends Panel {
         .fs-src-type-press { background: #555; color: #ccc; }
       </style>
     `, 'legacy Panel.setContent() migration'));
-
-    const table = this.element?.querySelector('.fs-table') as HTMLTableElement | null;
-    table?.querySelectorAll<HTMLTableRowElement>('tr.fs-row').forEach(tr => {
-      const id = tr.dataset.shortageId;
-      if (!id) return;
-      tr.addEventListener('click', () => void this.loadDetail(id));
-    });
-    const closeBtn = this.element?.querySelector<HTMLButtonElement>('.fs-drawer-close');
-    closeBtn?.addEventListener('click', () => this.closeDetail());
   }
 
   private renderRow(s: FuelShortageEntry): string {
     const glyph = PRODUCT_GLYPH[s.product] ?? '•';
     const quality = deriveShortageEvidenceQuality(s.evidence);
     return `
-      <tr class="fs-row" data-shortage-id="${escapeHtml(s.id)}" tabindex="0">
+      <tr class="fs-row" data-shortage-id="${escapeHtml(s.id)}" tabindex="${this.selectedId ? '-1' : '0'}">
         <td>
           <div class="fs-name">${glyph} ${escapeHtml(s.country)} · ${escapeHtml(s.product)}</div>
           <div class="fs-sub">${escapeHtml(s.causeChain.join(' · ') || '—')}</div>

--- a/src/components/FuelShortagePanel.ts
+++ b/src/components/FuelShortagePanel.ts
@@ -19,6 +19,7 @@ import {
   type RawFuelShortageRegistry,
 } from '@/shared/fuel-shortage-registry-store';
 import { SupplyChainServiceClient } from '@/services/generated-rpc-clients';
+import { bindActivationKeys } from '@/utils/activation';
 
 const getSupplyChainClient = createLazyClient(() => new SupplyChainServiceClient(getRpcBaseUrl(), {
   fetch: rpcFetch,
@@ -146,6 +147,7 @@ export class FuelShortagePanel extends Panel {
     if (typeof window !== 'undefined') {
       window.addEventListener('energy:open-fuel-shortage-detail', this.openDetailHandler);
     }
+    bindActivationKeys(this.content, '.fs-row');
   }
 
   public destroy(): void {
@@ -321,7 +323,7 @@ export class FuelShortagePanel extends Panel {
     const glyph = PRODUCT_GLYPH[s.product] ?? '•';
     const quality = deriveShortageEvidenceQuality(s.evidence);
     return `
-      <tr class="fs-row" data-shortage-id="${escapeHtml(s.id)}">
+      <tr class="fs-row" data-shortage-id="${escapeHtml(s.id)}" tabindex="0">
         <td>
           <div class="fs-name">${glyph} ${escapeHtml(s.country)} · ${escapeHtml(s.product)}</div>
           <div class="fs-sub">${escapeHtml(s.causeChain.join(' · ') || '—')}</div>

--- a/src/components/GeoHubsPanel.ts
+++ b/src/components/GeoHubsPanel.ts
@@ -3,6 +3,7 @@ import type { GeoHubActivity } from '@/services/geo-activity';
 import { escapeHtml, sanitizeUrl, unsafeRawHtml } from '@/utils/sanitize';
 import { t } from '@/services/i18n';
 import { getCSSColor } from '@/utils';
+import { bindActivationKeys } from '@/utils/activation';
 
 const COUNTRY_FLAGS: Record<string, string> = {
   'USA': '🇺🇸', 'Russia': '🇷🇺', 'China': '🇨🇳', 'UK': '🇬🇧', 'Belgium': '🇧🇪',
@@ -44,6 +45,7 @@ export class GeoHubsPanel extends Panel {
       }),
     });
     this.setupDelegatedListeners();
+    bindActivationKeys(this.content, '.geo-hub-item');
   }
 
   public setOnHubClick(handler: (hub: GeoHubActivity) => void): void {
@@ -80,7 +82,7 @@ export class GeoHubsPanel extends Panel {
       const topStory = hub.topStories[0];
 
       return `
-        <div class="geo-hub-item ${hub.activityLevel}" data-hub-id="${escapeHtml(hub.hubId)}" data-index="${index}">
+        <div class="geo-hub-item ${hub.activityLevel}" data-hub-id="${escapeHtml(hub.hubId)}" data-index="${index}" role="button" tabindex="0">
           <div class="hub-rank">${index + 1}</div>
           <span class="geo-hub-indicator ${hub.activityLevel}"></span>
           <div class="hub-info">

--- a/src/components/IntelligenceGapBadge.ts
+++ b/src/components/IntelligenceGapBadge.ts
@@ -7,6 +7,7 @@ import { escapeHtml } from '@/utils/sanitize';
 import { trackFindingClicked } from '@/services/analytics';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import { createFocusTrap, type FocusTrap } from '@/utils/focus-trap';
+import { bindActivationKeys } from '@/utils/activation';
 
 
 const LOW_COUNT_THRESHOLD = 3;
@@ -98,6 +99,7 @@ export class IntelligenceFindingsBadge {
     });
 
     // Event delegation for finding items, toggle, and "more" link
+    bindActivationKeys(this.dropdown, '.finding-item');
     this.dropdown.addEventListener('click', (e) => {
       const target = e.target as HTMLElement;
 
@@ -414,7 +416,7 @@ export class IntelligenceFindingsBadge {
       const insight = this.getInsight(finding);
 
       return `
-        <div class="finding-item ${priorityClass}" data-finding-id="${escapeHtml(finding.id)}">
+        <div class="finding-item ${priorityClass}" data-finding-id="${escapeHtml(finding.id)}" role="button" tabindex="0">
           <div class="finding-header">
             <span class="finding-type">${icon} ${escapeHtml(finding.title)}</span>
             <span class="finding-confidence ${priorityClass}">${t(`components.intelligenceFindings.priority.${finding.priority}`)}</span>

--- a/src/components/InvestmentsPanel.ts
+++ b/src/components/InvestmentsPanel.ts
@@ -10,6 +10,7 @@ import type {
 import { toUniqueSorted } from '@/utils';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
 import { t } from '@/services/i18n';
+import { bindActivationKeys } from '@/utils/activation';
 
 interface InvestmentFilters {
   investingCountry: GulfInvestorCountry | 'ALL';
@@ -80,6 +81,7 @@ export class InvestmentsPanel extends Panel {
     });
     this.onInvestmentClick = onInvestmentClick;
     this.setupEventDelegation();
+    bindActivationKeys(this.content, '.fdi-row');
     this.render();
   }
 
@@ -130,7 +132,7 @@ export class InvestmentsPanel extends Panel {
       const sectorLabel = getSectorLabel(inv.sector);
       const year = inv.yearAnnounced ?? inv.yearOperational ?? '—';
       return `
-        <div class="fdi-row" data-id="${escapeHtml(inv.id)}">
+        <div class="fdi-row" data-id="${escapeHtml(inv.id)}" role="button" tabindex="0">
           <div class="fdi-row-line1">
             <span class="fdi-flag">${flag}</span>
             <span class="fdi-asset-name">${escapeHtml(inv.assetName)}</span>

--- a/src/components/PipelineStatusPanel.ts
+++ b/src/components/PipelineStatusPanel.ts
@@ -201,8 +201,22 @@ export class PipelineStatusPanel extends Panel {
     if (typeof window !== 'undefined') {
       window.addEventListener('energy:open-pipeline-detail', this.openDetailHandler);
     }
+    this.content.addEventListener('click', this.handleContentClick);
     bindActivationKeys(this.content, '.pp-row');
   }
+
+  private handleContentClick = (e: Event): void => {
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+    if (target.closest('.pp-drawer-close')) {
+      this.closeDetail();
+      return;
+    }
+    const row = target.closest<HTMLTableRowElement>('tr.pp-row');
+    if (!row || !this.content.contains(row)) return;
+    const id = row.dataset.pipelineId;
+    if (id) void this.loadDetail(id);
+  };
 
   public destroy(): void {
     if (typeof window !== 'undefined') {
@@ -397,22 +411,13 @@ export class PipelineStatusPanel extends Panel {
         .pp-ev-item a:hover { text-decoration: underline; }
       </style>
     `, 'legacy Panel.setContent() migration'));
-
-    const table = this.element?.querySelector('.pp-table') as HTMLTableElement | null;
-    table?.querySelectorAll<HTMLTableRowElement>('tr.pp-row').forEach(tr => {
-      const id = tr.dataset.pipelineId;
-      if (!id) return;
-      tr.addEventListener('click', () => void this.loadDetail(id));
-    });
-    const closeBtn = this.element?.querySelector<HTMLButtonElement>('.pp-drawer-close');
-    closeBtn?.addEventListener('click', () => this.closeDetail());
   }
 
   private renderRow(p: PipelineEntry): string {
     const commodity = p.commodityType === 'gas' ? '⛽' : '🛢️';
     const route = `${escapeHtml(p.fromCountry)} → ${escapeHtml(p.toCountry)}`;
     return `
-      <tr class="pp-row" data-pipeline-id="${escapeHtml(p.id)}" tabindex="0">
+      <tr class="pp-row" data-pipeline-id="${escapeHtml(p.id)}" tabindex="${this.selectedId ? '-1' : '0'}">
         <td>
           <div class="pp-name">${commodity} ${escapeHtml(p.name)}</div>
           <div class="pp-sub">${escapeHtml(p.operator || '')}</div>

--- a/src/components/PipelineStatusPanel.ts
+++ b/src/components/PipelineStatusPanel.ts
@@ -22,6 +22,7 @@ import {
   type RawPipelineRegistry,
 } from '@/shared/pipeline-registry-store';
 import { SupplyChainServiceClient } from '@/services/generated-rpc-clients';
+import { bindActivationKeys } from '@/utils/activation';
 
 const getSupplyChainClient = createLazyClient(() => new SupplyChainServiceClient(getRpcBaseUrl(), {
   fetch: rpcFetch,
@@ -200,6 +201,7 @@ export class PipelineStatusPanel extends Panel {
     if (typeof window !== 'undefined') {
       window.addEventListener('energy:open-pipeline-detail', this.openDetailHandler);
     }
+    bindActivationKeys(this.content, '.pp-row');
   }
 
   public destroy(): void {
@@ -410,7 +412,7 @@ export class PipelineStatusPanel extends Panel {
     const commodity = p.commodityType === 'gas' ? '⛽' : '🛢️';
     const route = `${escapeHtml(p.fromCountry)} → ${escapeHtml(p.toCountry)}`;
     return `
-      <tr class="pp-row" data-pipeline-id="${escapeHtml(p.id)}">
+      <tr class="pp-row" data-pipeline-id="${escapeHtml(p.id)}" tabindex="0">
         <td>
           <div class="pp-name">${commodity} ${escapeHtml(p.name)}</div>
           <div class="pp-sub">${escapeHtml(p.operator || '')}</div>

--- a/src/components/RadiationWatchPanel.ts
+++ b/src/components/RadiationWatchPanel.ts
@@ -2,6 +2,7 @@ import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import type { RadiationObservation, RadiationWatchResult } from '@/services/radiation';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
+import { bindActivationKeys } from '@/utils/activation';
 
 export class RadiationWatchPanel extends Panel {
   private observations: RadiationObservation[] = [];
@@ -34,6 +35,7 @@ export class RadiationWatchPanel extends Panel {
       const lon = Number(row.dataset.lon);
       if (Number.isFinite(lat) && Number.isFinite(lon)) this.onLocationClick?.(lat, lon);
     });
+    bindActivationKeys(this.content, '.radiation-row');
   }
 
   public setLocationClickHandler(handler: (lat: number, lon: number) => void): void {
@@ -69,7 +71,7 @@ export class RadiationWatchPanel extends Panel {
         `<span class="radiation-badge radiation-freshness radiation-freshness-${obs.freshness}">${escapeHtml(obs.freshness)}</span>`,
       ].filter(Boolean).join('');
       return `
-        <tr class="radiation-row" data-lat="${obs.lat}" data-lon="${obs.lon}">
+        <tr class="radiation-row" data-lat="${obs.lat}" data-lon="${obs.lon}" tabindex="0">
           <td class="radiation-location">
             <div class="radiation-location-name">${escapeHtml(obs.location)}</div>
             <div class="radiation-location-meta">${escapeHtml(sourceLine)} · ${escapeHtml(t('components.radiationWatch.baseline', { value: baseline }))}</div>

--- a/src/components/StorageFacilityMapPanel.ts
+++ b/src/components/StorageFacilityMapPanel.ts
@@ -18,6 +18,7 @@ import {
   type RawStorageFacilityRegistry,
 } from '@/shared/storage-facility-registry-store';
 import { SupplyChainServiceClient } from '@/services/generated-rpc-clients';
+import { bindActivationKeys } from '@/utils/activation';
 
 const getSupplyChainClient = createLazyClient(() => new SupplyChainServiceClient(getRpcBaseUrl(), {
   fetch: rpcFetch,
@@ -191,6 +192,7 @@ export class StorageFacilityMapPanel extends Panel {
     if (typeof window !== 'undefined') {
       window.addEventListener('energy:open-storage-facility-detail', this.openDetailHandler);
     }
+    bindActivationKeys(this.content, '.sf-row');
   }
 
   public destroy(): void {
@@ -392,7 +394,7 @@ export class StorageFacilityMapPanel extends Panel {
     const glyph = TYPE_GLYPH[f.facilityType] ?? '🔹';
     const typeLabel = TYPE_LABEL[f.facilityType] ?? f.facilityType;
     return `
-      <tr class="sf-row" data-facility-id="${escapeHtml(f.id)}">
+      <tr class="sf-row" data-facility-id="${escapeHtml(f.id)}" tabindex="0">
         <td>
           <div class="sf-name">${glyph} ${escapeHtml(f.name)}</div>
           <div class="sf-sub">${escapeHtml(f.operator || '')}</div>

--- a/src/components/StorageFacilityMapPanel.ts
+++ b/src/components/StorageFacilityMapPanel.ts
@@ -192,8 +192,22 @@ export class StorageFacilityMapPanel extends Panel {
     if (typeof window !== 'undefined') {
       window.addEventListener('energy:open-storage-facility-detail', this.openDetailHandler);
     }
+    this.content.addEventListener('click', this.handleContentClick);
     bindActivationKeys(this.content, '.sf-row');
   }
+
+  private handleContentClick = (e: Event): void => {
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+    if (target.closest('.sf-drawer-close')) {
+      this.closeDetail();
+      return;
+    }
+    const row = target.closest<HTMLTableRowElement>('tr.sf-row');
+    if (!row || !this.content.contains(row)) return;
+    const id = row.dataset.facilityId;
+    if (id) void this.loadDetail(id);
+  };
 
   public destroy(): void {
     if (typeof window !== 'undefined') {
@@ -379,22 +393,13 @@ export class StorageFacilityMapPanel extends Panel {
         .sf-ev-item a:hover { text-decoration: underline; }
       </style>
     `, 'legacy Panel.setContent() migration'));
-
-    const table = this.element?.querySelector('.sf-table') as HTMLTableElement | null;
-    table?.querySelectorAll<HTMLTableRowElement>('tr.sf-row').forEach(tr => {
-      const id = tr.dataset.facilityId;
-      if (!id) return;
-      tr.addEventListener('click', () => void this.loadDetail(id));
-    });
-    const closeBtn = this.element?.querySelector<HTMLButtonElement>('.sf-drawer-close');
-    closeBtn?.addEventListener('click', () => this.closeDetail());
   }
 
   private renderRow(f: StorageFacilityEntry): string {
     const glyph = TYPE_GLYPH[f.facilityType] ?? '🔹';
     const typeLabel = TYPE_LABEL[f.facilityType] ?? f.facilityType;
     return `
-      <tr class="sf-row" data-facility-id="${escapeHtml(f.id)}" tabindex="0">
+      <tr class="sf-row" data-facility-id="${escapeHtml(f.id)}" tabindex="${this.selectedId ? '-1' : '0'}">
         <td>
           <div class="sf-name">${glyph} ${escapeHtml(f.name)}</div>
           <div class="sf-sub">${escapeHtml(f.operator || '')}</div>

--- a/src/components/StrategicPosturePanel.ts
+++ b/src/components/StrategicPosturePanel.ts
@@ -28,6 +28,7 @@ export class StrategicPosturePanel extends Panel {
       defaultRowSpan: 2,
     });
     this.init();
+    this.content.addEventListener('click', this.handleContentClick);
     bindActivationKeys(this.content, '.posture-theater');
   }
 
@@ -514,70 +515,65 @@ export class StrategicPosturePanel extends Panel {
     `;
 
     this.setSafeContent(unsafeRawHtml(html, 'legacy Panel.setContent() migration'));
-    this.attachEventListeners();
   }
 
-  private attachEventListeners(): void {
-    this.content.querySelector('.posture-refresh-btn')?.addEventListener('click', () => {
+  private handleContentClick = (e: Event): void => {
+    const target = e.target as HTMLElement | null;
+    if (!target) return;
+
+    if (target.closest('.posture-refresh-btn')) {
       this.refresh();
+      return;
+    }
+
+    const deduceBtn = target.closest<HTMLElement>('.posture-deduce-btn');
+    if (deduceBtn) {
+      e.stopPropagation();
+      try {
+        const theaterDataStr = deduceBtn.dataset.theater;
+        if (!theaterDataStr) return;
+
+        const p = JSON.parse(theaterDataStr);
+        const query = `What is the expected strategic impact of the current military posture in the ${p.shortName} theater?`;
+        let geoContext = `Theater: ${p.shortName} (${p.theaterName}). Military Assets: ${p.totalAircraft} aircraft, ${p.totalVessels} naval vessels. Readiness Level: ${p.postureLevel}. Assets breakdown: ${p.fighters} fighters, ${p.bombers} bombers, ${p.carriers} carriers, ${p.submarines} submarines. Focus/Target: ${p.targetNation || 'Unknown'}.`;
+
+        if (this.getLatestNews) {
+          const newsCtx = buildNewsContext(this.getLatestNews);
+          if (newsCtx) geoContext += `\n\n${newsCtx}`;
+        }
+
+        const detail: DeductContextDetail = { query, geoContext, autoSubmit: true };
+        document.dispatchEvent(new CustomEvent('wm:deduct-context', { detail }));
+      } catch (err) {
+        console.error('[StrategicPosturePanel] Failed to dispatch deduction event', err);
+      }
+      return;
+    }
+
+    const el = target.closest<HTMLElement>('.posture-theater');
+    if (!el || !this.content.contains(el)) return;
+
+    const lat = parseFloat(el.dataset.lat || '0');
+    const lon = parseFloat(el.dataset.lon || '0');
+    console.log('[StrategicPosturePanel] Theater clicked:', {
+      lat,
+      lon,
+      dataLat: el.dataset.lat,
+      dataLon: el.dataset.lon,
+      element: el.textContent?.slice(0, 30),
+      hasHandler: !!this.onLocationClick,
     });
-
-    const theaters = this.content.querySelectorAll('.posture-theater');
-    theaters.forEach((el) => {
-      el.addEventListener('click', (e) => {
-        // Prevent click if we clicked the deduce button specifically
-        if ((e.target as HTMLElement).closest('.posture-deduce-btn')) {
-          return;
-        }
-
-        const lat = parseFloat((el as HTMLElement).dataset.lat || '0');
-        const lon = parseFloat((el as HTMLElement).dataset.lon || '0');
-        console.log('[StrategicPosturePanel] Theater clicked:', {
-          lat,
-          lon,
-          dataLat: (el as HTMLElement).dataset.lat,
-          dataLon: (el as HTMLElement).dataset.lon,
-          element: (el as HTMLElement).textContent?.slice(0, 30),
-          hasHandler: !!this.onLocationClick,
-        });
-        if (this.onLocationClick && !Number.isNaN(lat) && !Number.isNaN(lon)) {
-          console.log('[StrategicPosturePanel] Calling onLocationClick with:', lat, lon);
-          this.onLocationClick(lat, lon);
-        } else {
-          console.warn('[StrategicPosturePanel] No handler or invalid coords!', {
-            hasHandler: !!this.onLocationClick,
-            lat,
-            lon,
-          });
-        }
+    if (this.onLocationClick && !Number.isNaN(lat) && !Number.isNaN(lon)) {
+      console.log('[StrategicPosturePanel] Calling onLocationClick with:', lat, lon);
+      this.onLocationClick(lat, lon);
+    } else {
+      console.warn('[StrategicPosturePanel] No handler or invalid coords!', {
+        hasHandler: !!this.onLocationClick,
+        lat,
+        lon,
       });
-    });
-
-    const deduceBtns = this.content.querySelectorAll('.posture-deduce-btn');
-    deduceBtns.forEach((btn) => {
-      btn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        try {
-          const theaterDataStr = (btn as HTMLElement).dataset.theater;
-          if (!theaterDataStr) return;
-
-          const p = JSON.parse(theaterDataStr);
-          const query = `What is the expected strategic impact of the current military posture in the ${p.shortName} theater?`;
-          let geoContext = `Theater: ${p.shortName} (${p.theaterName}). Military Assets: ${p.totalAircraft} aircraft, ${p.totalVessels} naval vessels. Readiness Level: ${p.postureLevel}. Assets breakdown: ${p.fighters} fighters, ${p.bombers} bombers, ${p.carriers} carriers, ${p.submarines} submarines. Focus/Target: ${p.targetNation || 'Unknown'}.`;
-
-          if (this.getLatestNews) {
-            const newsCtx = buildNewsContext(this.getLatestNews);
-            if (newsCtx) geoContext += `\n\n${newsCtx}`;
-          }
-
-          const detail: DeductContextDetail = { query, geoContext, autoSubmit: true };
-          document.dispatchEvent(new CustomEvent('wm:deduct-context', { detail }));
-        } catch (err) {
-          console.error('[StrategicPosturePanel] Failed to dispatch deduction event', err);
-        }
-      });
-    });
-  }
+    }
+  };
 
   public setLocationClickHandler(handler: (lat: number, lon: number) => void): void {
     console.log('[StrategicPosturePanel] setLocationClickHandler called, handler:', typeof handler);

--- a/src/components/StrategicPosturePanel.ts
+++ b/src/components/StrategicPosturePanel.ts
@@ -7,6 +7,7 @@ import { isDesktopRuntime } from '@/services/runtime';
 import { t } from '../services/i18n';
 import type { NewsItem, DeductContextDetail } from '@/types';
 import { buildNewsContext } from '@/utils/news-context';
+import { bindActivationKeys } from '@/utils/activation';
 
 export class StrategicPosturePanel extends Panel {
   private postures: TheaterPostureSummary[] = [];
@@ -27,6 +28,7 @@ export class StrategicPosturePanel extends Panel {
       defaultRowSpan: 2,
     });
     this.init();
+    bindActivationKeys(this.content, '.posture-theater');
   }
 
   private init(): void {
@@ -403,7 +405,7 @@ export class StrategicPosturePanel extends Panel {
       if (p.totalVessels > 0) chips.push(`<span class="posture-chip naval">⚓ ${p.totalVessels}</span>`);
 
       return `
-        <div class="posture-theater posture-compact" data-lat="${p.centerLat}" data-lon="${p.centerLon}" title="${t('components.strategicPosture.clickToView', { name: escapeHtml(displayName) })}">
+        <div class="posture-theater posture-compact" role="button" tabindex="0" data-lat="${p.centerLat}" data-lon="${p.centerLon}" title="${t('components.strategicPosture.clickToView', { name: escapeHtml(displayName) })}">
           <span class="posture-name">${escapeHtml(p.shortName)}</span>
           <div class="posture-chips">${chips.join('')}</div>
           ${this.getPostureBadge(p.postureLevel)}
@@ -441,7 +443,7 @@ export class StrategicPosturePanel extends Panel {
     const hasNaval = navalChips.length > 0;
 
     return `
-      <div class="posture-theater posture-expanded ${p.postureLevel}" data-lat="${p.centerLat}" data-lon="${p.centerLon}" title="${t('components.strategicPosture.clickToViewMap')}">
+      <div class="posture-theater posture-expanded ${p.postureLevel}" role="button" tabindex="0" data-lat="${p.centerLat}" data-lon="${p.centerLon}" title="${t('components.strategicPosture.clickToViewMap')}">
         <div class="posture-theater-header">
           <span class="posture-name">${escapeHtml(displayName)}</span>
           ${this.getPostureBadge(p.postureLevel)}

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -21,6 +21,7 @@ import type { CountryScore } from '@/services/country-instability';
 import { fetchCachedRiskScores, isElevatedCiiScore, toCountryScore, type CachedRiskScores } from '@/services/cached-risk-scores';
 import { getCachedPosture } from '@/services/cached-theater-posture';
 import { trustedHtml } from '@/utils/dom-utils';
+import { bindActivationKeys } from '@/utils/activation';
 
 type StrategicRiskDisplayLevel = 'critical' | 'high' | 'elevated' | 'normal' | 'low';
 type StrategicRiskDisplayBand = {
@@ -57,6 +58,7 @@ export class StrategicRiskPanel extends Panel {
       infoTooltip: t('components.strategicRisk.infoTooltip'),
     });
     this.init();
+    bindActivationKeys(this.content, '.risk-item-clickable, .risk-alert-clickable');
   }
 
   private async init(): Promise<void> {
@@ -407,7 +409,7 @@ export class StrategicRiskPanel extends Panel {
       const isConvergence = i === 0 && risk.startsWith('Convergence:') && topZone;
       if (isConvergence) {
         return `
-                <div class="risk-item risk-item-clickable" data-lat="${topZone.lat}" data-lon="${topZone.lon}">
+                <div class="risk-item risk-item-clickable" data-lat="${topZone.lat}" data-lon="${topZone.lon}" role="button" tabindex="0">
                   <span class="risk-rank">${i + 1}.</span>
                   <span class="risk-text">${escapeHtml(risk)}</span>
                   <span class="risk-location-icon">↗</span>
@@ -441,7 +443,7 @@ export class StrategicRiskPanel extends Panel {
       const hasLocation = alert.location?.lat && alert.location.lon;
       const clickableClass = hasLocation ? 'risk-alert-clickable' : '';
       const locationAttrs = hasLocation
-        ? `data-lat="${alert.location!.lat}" data-lon="${alert.location!.lon}"`
+        ? `data-lat="${alert.location!.lat}" data-lon="${alert.location!.lon}" role="button" tabindex="0"`
         : '';
 
       return `

--- a/src/components/TechHubsPanel.ts
+++ b/src/components/TechHubsPanel.ts
@@ -75,6 +75,14 @@ export class TechHubsPanel extends Panel {
         lowColor: getCSSColor('--text-dim'),
       }),
     });
+    // Delegated click survives Panel.setSafeContent's 150ms debounce; per-row
+    // binds after render target the stale (often empty) DOM.
+    this.content.addEventListener('click', (e) => {
+      const item = (e.target as HTMLElement | null)?.closest<HTMLElement>('.tech-hub-item');
+      if (!item || !this.content.contains(item)) return;
+      const hub = this.activities.find(a => a.hubId === item.dataset.hubId);
+      if (hub && this.onHubClick) this.onHubClick(hub);
+    });
     bindActivationKeys(this.content, '.tech-hub-item');
   }
 
@@ -130,19 +138,5 @@ export class TechHubsPanel extends Panel {
     }).join('');
 
     this.setSafeContent(unsafeRawHtml(html, 'legacy Panel.setContent() migration'));
-    this.bindEvents();
-  }
-
-  private bindEvents(): void {
-    const items = this.content.querySelectorAll<HTMLDivElement>('.tech-hub-item');
-    items.forEach((item) => {
-      item.addEventListener('click', () => {
-        const hubId = item.dataset.hubId;
-        const hub = this.activities.find(a => a.hubId === hubId);
-        if (hub && this.onHubClick) {
-          this.onHubClick(hub);
-        }
-      });
-    });
   }
 }

--- a/src/components/TechHubsPanel.ts
+++ b/src/components/TechHubsPanel.ts
@@ -3,6 +3,7 @@ import { t } from '@/services/i18n';
 import type { TechHubActivity } from '@/services/tech-activity';
 import { escapeHtml, sanitizeUrl, unsafeRawHtml } from '@/utils/sanitize';
 import { getCSSColor } from '@/utils';
+import { bindActivationKeys } from '@/utils/activation';
 
 const COUNTRY_FLAGS: Record<string, string> = {
   'USA': '🇺🇸', 'United States': '🇺🇸',
@@ -74,6 +75,7 @@ export class TechHubsPanel extends Panel {
         lowColor: getCSSColor('--text-dim'),
       }),
     });
+    bindActivationKeys(this.content, '.tech-hub-item');
   }
 
   public setOnHubClick(handler: (hub: TechHubActivity) => void): void {
@@ -102,7 +104,7 @@ export class TechHubsPanel extends Panel {
       const topStory = hub.topStories[0];
 
       return `
-        <div class="tech-hub-item ${hub.activityLevel}" data-hub-id="${escapeHtml(hub.hubId)}" data-index="${index}">
+        <div class="tech-hub-item ${hub.activityLevel}" data-hub-id="${escapeHtml(hub.hubId)}" data-index="${index}" role="button" tabindex="0">
           <div class="hub-rank">${index + 1}</div>
           <span class="hub-indicator ${hub.activityLevel}"></span>
           <div class="hub-info">

--- a/src/components/ThermalEscalationPanel.ts
+++ b/src/components/ThermalEscalationPanel.ts
@@ -2,6 +2,7 @@ import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import type { ThermalEscalationCluster, ThermalEscalationWatch } from '@/services/thermal-escalation';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
+import { bindActivationKeys } from '@/utils/activation';
 
 // P1: allowlists prevent unescaped API values from injecting into class attribute context
 const STATUS_CLASS: Record<string, string> = {
@@ -38,6 +39,7 @@ export class ThermalEscalationPanel extends Panel {
       const lon = Number(row.dataset.lon);
       if (Number.isFinite(lat) && Number.isFinite(lon)) this.onLocationClick?.(lat, lon);
     });
+    bindActivationKeys(this.content, '.te-card');
   }
 
   public setLocationClickHandler(handler: (lat: number, lon: number) => void): void {
@@ -123,7 +125,7 @@ export class ThermalEscalationPanel extends Panel {
     const age = formatAge(c.lastDetectedAt);
 
     return `
-      <div class="te-card te-card-${statusClass}" data-lat="${c.lat}" data-lon="${c.lon}">
+      <div class="te-card te-card-${statusClass}" data-lat="${c.lat}" data-lon="${c.lon}" role="button" tabindex="0">
         <div class="te-card-accent"></div>
         <div class="te-card-body">
           <div class="te-region">${escapeHtml(c.regionLabel)}</div>

--- a/src/components/UcdpEventsPanel.ts
+++ b/src/components/UcdpEventsPanel.ts
@@ -3,6 +3,7 @@ import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
 import type { UcdpGeoEvent, UcdpEventType } from '@/types';
 import { t } from '@/services/i18n';
 import type { UcdpTabAggregate } from '@/services/conflict';
+import { bindActivationKeys } from '@/utils/activation';
 
 // The panel's tabs are the three UCDP violence types. The projection keys its
 // aggregates by the proto enum, so map between them in exactly one place.
@@ -49,6 +50,7 @@ export class UcdpEventsPanel extends Panel {
         if (Number.isFinite(lat) && Number.isFinite(lon)) this.onEventClick?.(lat, lon);
       }
     });
+    bindActivationKeys(this.content, '.ucdp-row');
   }
 
   public setEventClickHandler(handler: (lat: number, lon: number) => void): void {
@@ -124,7 +126,7 @@ export class UcdpEventsPanel extends Panel {
           : '<span class="ucdp-deaths-zero">0</span>';
         const actors = `${escapeHtml(e.side_a)} vs ${escapeHtml(e.side_b)}`;
 
-        return `<tr class="ucdp-row" data-lat="${e.latitude}" data-lon="${e.longitude}">
+        return `<tr class="ucdp-row" data-lat="${e.latitude}" data-lon="${e.longitude}" tabindex="0">
           <td class="ucdp-country">${escapeHtml(e.country)}</td>
           <td class="ucdp-deaths">${deathsHtml}</td>
           <td class="ucdp-date">${e.date_start}</td>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -27872,3 +27872,26 @@ body.map-width-resizing {
   color: var(--text-dim, #9a9589);
   font-size: 12px;
 }
+
+/* Keyboard-activatable drill-in rows (#7023): visible focus for the
+   role="button" cards and tabindex'd table rows wired via bindActivationKeys. */
+.geo-hub-item:focus-visible,
+.tech-hub-item:focus-visible,
+.te-card:focus-visible,
+.fdi-row:focus-visible,
+.risk-item-clickable:focus-visible,
+.risk-alert-clickable:focus-visible,
+.posture-theater:focus-visible,
+.finding-item:focus-visible,
+.cii-country:focus-visible,
+.climate-row:focus-visible,
+.ucdp-row:focus-visible,
+.disp-row:focus-visible,
+.radiation-row:focus-visible,
+.fs-row:focus-visible,
+.pp-row:focus-visible,
+.sf-row:focus-visible,
+.ed-row:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: -2px;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -27883,7 +27883,7 @@ body.map-width-resizing {
 .risk-alert-clickable:focus-visible,
 .posture-theater:focus-visible,
 .finding-item:focus-visible,
-.cii-country:focus-visible,
+.cii-name:focus-visible,
 .climate-row:focus-visible,
 .ucdp-row:focus-visible,
 .disp-row:focus-visible,

--- a/src/utils/activation.ts
+++ b/src/utils/activation.ts
@@ -1,0 +1,26 @@
+/**
+ * Keyboard activation for click-target rows/cards built from template strings.
+ *
+ * Generalizes the pattern proven by market-chart-interactions.ts: the template
+ * gives the element `tabindex="0"` (plus `role="button"` where it isn't a
+ * table row — a role would override row semantics and break the table for AT,
+ * same call RouteExplorer's rows made in #6964), and one delegated keydown on
+ * the panel's stable content element turns Enter/Space into a click. The
+ * synthesized click routes through the panel's EXISTING click delegation, so
+ * activation behavior cannot drift between mouse and keyboard.
+ *
+ * Bind once on a stable container (panel content), not on re-rendered rows.
+ */
+export function bindActivationKeys(root: HTMLElement, selector: string): void {
+  root.addEventListener('keydown', (event: KeyboardEvent) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    const target = event.target as HTMLElement | null;
+    const el = target?.closest<HTMLElement>(selector);
+    if (!el || !root.contains(el)) return;
+    // Focus can only sit on the row itself or on a nested native control
+    // (link/button/input); nested controls keep their own Enter/Space.
+    if (target !== el) return;
+    event.preventDefault();
+    el.click();
+  });
+}

--- a/tests/a11y-cii-nested-interactive.test.mjs
+++ b/tests/a11y-cii-nested-interactive.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const panel = readFileSync(resolve(root, 'src/components/CIIPanel.ts'), 'utf8');
+const css = readFileSync(resolve(root, 'src/styles/main.css'), 'utf8');
+
+describe('CII country rows are not nested interactive', () => {
+  it('does not put role=button on .cii-country (hosts Follow + Share)', () => {
+    assert.doesNotMatch(
+      panel,
+      /className:\s*['"]cii-country['"][\s\S]{0,80}role:\s*['"]button['"]/,
+    );
+  });
+
+  it('puts role=button tabindex=0 on .cii-name and binds keys there', () => {
+    assert.match(
+      panel,
+      /className:\s*['"]cii-name['"],\s*role:\s*['"]button['"],\s*tabindex:\s*['"]0['"]/,
+    );
+    assert.match(panel, /bindActivationKeys\(\s*this\.content,\s*['"]\.cii-name['"]\s*\)/);
+  });
+
+  it('focus-visible outline targets .cii-name, not the wrapping row', () => {
+    assert.match(css, /\.cii-name:focus-visible/);
+    assert.doesNotMatch(css, /\.cii-country:focus-visible/);
+  });
+});

--- a/tests/activation.test.mts
+++ b/tests/activation.test.mts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { bindActivationKeys } from '../src/utils/activation.ts';
+import { createBrowserEnvironment, type MiniElement } from './helpers/mini-dom.mts';
+
+const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+const originalHTMLElement = Object.getOwnPropertyDescriptor(globalThis, 'HTMLElement');
+
+function installDom() {
+  const browser = createBrowserEnvironment();
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    writable: true,
+    value: browser.document,
+  });
+  Object.defineProperty(globalThis, 'HTMLElement', {
+    configurable: true,
+    writable: true,
+    value: browser.HTMLElement,
+  });
+  return browser.document;
+}
+
+function restoreDom(): void {
+  if (originalDocument) Object.defineProperty(globalThis, 'document', originalDocument);
+  else delete (globalThis as { document?: unknown }).document;
+  if (originalHTMLElement) Object.defineProperty(globalThis, 'HTMLElement', originalHTMLElement);
+  else delete (globalThis as { HTMLElement?: unknown }).HTMLElement;
+}
+
+afterEach(restoreDom);
+
+describe('bindActivationKeys', () => {
+  it('turns Enter/Space on a matching row into a click, ignoring other keys and non-rows', () => {
+    const document = installDom();
+    const content = document.createElement('div');
+    const handlers = new Map<string, EventListener>();
+    content.addEventListener = ((type: string, listener: EventListener) => {
+      handlers.set(type, listener);
+    }) as typeof content.addEventListener;
+
+    const row = document.createElement('div');
+    row.className = 'drill-row';
+    content.appendChild(row);
+    const outside = document.createElement('div');
+    content.appendChild(outside);
+
+    let clicks = 0;
+    (row as unknown as { click: () => void }).click = () => { clicks += 1; };
+    (outside as unknown as { click: () => void }).click = () => { clicks += 100; };
+
+    bindActivationKeys(content as unknown as HTMLElement, '.drill-row');
+
+    const dispatch = (target: MiniElement, key: string): Event => {
+      const event = new Event('keydown', { cancelable: true });
+      Object.defineProperties(event, {
+        target: { value: target },
+        key: { value: key },
+      });
+      handlers.get('keydown')?.(event);
+      return event;
+    };
+
+    const enter = dispatch(row, 'Enter');
+    const space = dispatch(row, ' ');
+    dispatch(row, 'Tab');
+    dispatch(outside, 'Enter');
+
+    assert.equal(clicks, 2);
+    assert.equal(enter.defaultPrevented, true);
+    assert.equal(space.defaultPrevented, true);
+  });
+
+  it('leaves keydown alone when focus is on a nested control inside the row', () => {
+    const document = installDom();
+    const content = document.createElement('div');
+    const handlers = new Map<string, EventListener>();
+    content.addEventListener = ((type: string, listener: EventListener) => {
+      handlers.set(type, listener);
+    }) as typeof content.addEventListener;
+
+    const row = document.createElement('div');
+    row.className = 'drill-row';
+    const nested = document.createElement('button');
+    row.appendChild(nested);
+    content.appendChild(row);
+
+    let rowClicks = 0;
+    (row as unknown as { click: () => void }).click = () => { rowClicks += 1; };
+
+    bindActivationKeys(content as unknown as HTMLElement, '.drill-row');
+
+    const event = new Event('keydown', { cancelable: true });
+    Object.defineProperties(event, {
+      target: { value: nested },
+      key: { value: 'Enter' },
+    });
+    handlers.get('keydown')?.(event);
+
+    assert.equal(rowClicks, 0);
+    assert.equal(event.defaultPrevented, false);
+  });
+});

--- a/tests/dom/panel-error-latch.test.mts
+++ b/tests/dom/panel-error-latch.test.mts
@@ -322,6 +322,18 @@ describe('CIIPanel recovery renders clear the error chip', () => {
     expect(internals(panel).content.querySelectorAll('.cii-country')).toHaveLength(2);
   });
 
+  it('country drill-in is on the name, not the row that wraps Follow/Share', () => {
+    panel.renderFromCached(cachedScores());
+    const row = internals(panel).content.querySelector('.cii-country');
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute('role')).toBeNull();
+    expect(row?.getAttribute('tabindex')).toBeNull();
+    const name = row?.querySelector('.cii-name');
+    expect(name?.getAttribute('role')).toBe('button');
+    expect(name?.getAttribute('tabindex')).toBe('0');
+    expect(row?.querySelector('.cii-share-btn')?.tagName).toBe('BUTTON');
+  });
+
   it('a watchlist re-render clears the chip left by a transient showError', () => {
     // Seed scores so the watchlist subscription has rows to repaint.
     panel.renderFromCached(cachedScores());


### PR DESCRIPTION
Part of #7023 (accessibility phase 2, PR 1 of 7): keyboard activation for click-only drill-in rows.

## Problem

The primary drill-in interaction of ~16 panels — jump to a map location, open a country view, expand a detail drawer — was a click handler on a generic `div`/`span`/`<tr>` with no role, no tabindex, and no keydown anywhere in the file. Keyboard users couldn't reach the rows at all, and assistive tech had no indication they were actionable. (`IntelligenceGapBadge`'s *modal* items were fixed in #6964; its inline dropdown list uses the same markup and was missed.)

## What this does

**New `src/utils/activation.ts`** — `bindActivationKeys(root, selector)`: one delegated keydown on the panel's stable content element that turns Enter/Space on a matching row into `el.click()`. The synthesized click routes through each panel's **existing** click delegation, so mouse and keyboard behavior can't drift; focus on a nested native control (link/button/input) is left alone. This generalizes the pattern `market-chart-interactions.ts` proved (and #6964 reused), and is unit-tested with the existing mini-dom harness (`tests/activation.test.mts`, 2 tests).

**Card/div rows** gain `role="button" tabindex="0"` (accessible name comes from their visible content) plus one binder call each: GeoHubs, TechHubs, ThermalEscalation, Investments FDI rows, StrategicRisk clickable risks + located alerts, StrategicPosture theaters (compact + expanded), IntelligenceGapBadge inline finding items, CII country rows.

**Table rows** gain `tabindex="0"` only — `role="button"` on a `<tr>` would override row semantics and break the table for AT, the same call RouteExplorer's rows made in #6964: ClimateAnomaly, UcdpEvents, Displacement, RadiationWatch, FuelShortage, PipelineStatus, StorageFacilityMap, EnergyDisruptions.

**CSS**: one grouped `:focus-visible` outline rule in `main.css` covering all 17 row classes, so the new tab stops are visibly focused.

Each panel change is two lines (template attribute + one `bindActivationKeys` call in the constructor); no behavior change for mouse users.

## Verification

- `npm run typecheck` — clean
- `biome lint` on all 18 touched files — clean; `lint:safe-html` — clean
- `tsx --test tests/activation.test.mts` — 2/2 pass
- `tsx --test tests/contrast.test.mts tests/market-chart-interactions.test.mts` — 13/13 pass
- `node --test tests/a11y-issue-*.test.mjs tests/marker-pulse-settle.test.mjs` — 46/46 pass
