### PR TITLE
fix(a11y): menu semantics for the map context menu, combobox semantics for search

### DIFF
--- a/src/components/MapContextMenu.ts
+++ b/src/components/MapContextMenu.ts
@@ -5,17 +5,29 @@ export interface MapContextMenuItem {
 
 let activeMenu: HTMLElement | null = null;
 let returnFocus: HTMLElement | null = null;
+let clickDismiss: AbortController | null = null;
 
 function menuItems(): HTMLElement[] {
   return activeMenu ? Array.from(activeMenu.querySelectorAll<HTMLElement>('.map-context-menu-item')) : [];
 }
 
+function menuContainsFocus(): boolean {
+  return !!activeMenu?.contains(document.activeElement);
+}
+
+function onMenuFocusIn(e: FocusEvent): void {
+  const target = e.target;
+  if (activeMenu && target instanceof Node && !activeMenu.contains(target)) {
+    dismissMapContextMenu();
+  }
+}
+
 function onMenuKeydown(e: KeyboardEvent): void {
-  if (e.key === 'Escape') {
+  if (e.key === 'Escape' || e.key === 'Tab') {
     dismissMapContextMenu();
     return;
   }
-  if (!activeMenu) return;
+  if (!activeMenu || !menuContainsFocus()) return;
 
   const items = menuItems();
   if (items.length === 0) return;
@@ -42,12 +54,22 @@ function onMenuKeydown(e: KeyboardEvent): void {
 export function dismissMapContextMenu(): void {
   if (activeMenu) {
     const hadFocus = activeMenu.contains(document.activeElement);
-    activeMenu.remove();
+    const menu = activeMenu;
+    clickDismiss?.abort();
+    clickDismiss = null;
+    menu.remove();
     activeMenu = null;
     document.removeEventListener('keydown', onMenuKeydown);
+    document.removeEventListener('focusin', onMenuFocusIn);
     // Removing the menu while focus was inside drops focus to <body>;
-    // hand it back to whatever had it before the menu opened.
-    if (hadFocus && returnFocus?.isConnected) returnFocus.focus();
+    // hand it back to whatever had it before the menu opened — unless
+    // another overlay already took focus (Cmd+K / search).
+    const active = document.activeElement;
+    const keepCurrent = active instanceof HTMLElement
+      && active.isConnected
+      && active !== document.body
+      && active !== menu;
+    if (hadFocus && !keepCurrent && returnFocus?.isConnected) returnFocus.focus();
     returnFocus = null;
   }
 }
@@ -71,10 +93,14 @@ export function showMapContextMenu(x: number, y: number, items: MapContextMenuIt
     el.addEventListener('click', (e) => { e.stopPropagation(); item.action(); dismissMapContextMenu(); });
     menu.append(el);
   });
+  clickDismiss = new AbortController();
+  const { signal } = clickDismiss;
   requestAnimationFrame(() => {
-    document.addEventListener('click', dismissMapContextMenu, { once: true });
+    if (signal.aborted || !activeMenu) return;
+    document.addEventListener('click', dismissMapContextMenu, { once: true, signal });
   });
   document.addEventListener('keydown', onMenuKeydown);
+  document.addEventListener('focusin', onMenuFocusIn);
   document.body.appendChild(menu);
   activeMenu = menu;
   // Menu pattern: focus moves into the menu on open; arrows walk the items.

--- a/src/components/MapContextMenu.ts
+++ b/src/components/MapContextMenu.ts
@@ -4,23 +4,60 @@ export interface MapContextMenuItem {
 }
 
 let activeMenu: HTMLElement | null = null;
+let returnFocus: HTMLElement | null = null;
 
-function onEscape(e: KeyboardEvent): void {
-  if (e.key === 'Escape') dismissMapContextMenu();
+function menuItems(): HTMLElement[] {
+  return activeMenu ? Array.from(activeMenu.querySelectorAll<HTMLElement>('.map-context-menu-item')) : [];
+}
+
+function onMenuKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape') {
+    dismissMapContextMenu();
+    return;
+  }
+  if (!activeMenu) return;
+
+  const items = menuItems();
+  if (items.length === 0) return;
+  const current = items.indexOf(document.activeElement as HTMLElement);
+
+  if (e.key === 'ArrowDown') {
+    e.preventDefault();
+    items[(current + 1) % items.length]?.focus();
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault();
+    items[(current - 1 + items.length) % items.length]?.focus();
+  } else if (e.key === 'Home') {
+    e.preventDefault();
+    items[0]?.focus();
+  } else if (e.key === 'End') {
+    e.preventDefault();
+    items[items.length - 1]?.focus();
+  } else if ((e.key === 'Enter' || e.key === ' ') && current >= 0) {
+    e.preventDefault();
+    items[current]?.click();
+  }
 }
 
 export function dismissMapContextMenu(): void {
   if (activeMenu) {
+    const hadFocus = activeMenu.contains(document.activeElement);
     activeMenu.remove();
     activeMenu = null;
-    document.removeEventListener('keydown', onEscape);
+    document.removeEventListener('keydown', onMenuKeydown);
+    // Removing the menu while focus was inside drops focus to <body>;
+    // hand it back to whatever had it before the menu opened.
+    if (hadFocus && returnFocus?.isConnected) returnFocus.focus();
+    returnFocus = null;
   }
 }
 
 export function showMapContextMenu(x: number, y: number, items: MapContextMenuItem[]): void {
   dismissMapContextMenu();
+  returnFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
   const menu = document.createElement('div');
   menu.className = 'map-context-menu';
+  menu.setAttribute('role', 'menu');
   const clampedX = Math.min(x, window.innerWidth - 200);
   const clampedY = Math.min(y, window.innerHeight - items.length * 32 - 8);
   menu.style.left = `${clampedX}px`;
@@ -28,6 +65,8 @@ export function showMapContextMenu(x: number, y: number, items: MapContextMenuIt
   items.forEach(item => {
     const el = document.createElement('div');
     el.className = 'map-context-menu-item';
+    el.setAttribute('role', 'menuitem');
+    el.tabIndex = -1;
     el.textContent = item.label;
     el.addEventListener('click', (e) => { e.stopPropagation(); item.action(); dismissMapContextMenu(); });
     menu.append(el);
@@ -35,7 +74,9 @@ export function showMapContextMenu(x: number, y: number, items: MapContextMenuIt
   requestAnimationFrame(() => {
     document.addEventListener('click', dismissMapContextMenu, { once: true });
   });
-  document.addEventListener('keydown', onEscape);
+  document.addEventListener('keydown', onMenuKeydown);
   document.body.appendChild(menu);
   activeMenu = menu;
+  // Menu pattern: focus moves into the menu on open; arrows walk the items.
+  menuItems()[0]?.focus();
 }

--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -120,6 +120,7 @@ export class SearchModal {
   private focusTrap: FocusTrap | null = null;
   private input: HTMLInputElement | null = null;
   private resultsList: HTMLElement | null = null;
+  private resultsObserver: MutationObserver | null = null;
   private chipsContainer: HTMLElement | null = null;
   private scopeContainer: HTMLElement | null = null;
   private closeTimeoutId: ReturnType<typeof setTimeout> | null = null;
@@ -400,6 +401,8 @@ export class SearchModal {
     if (this.overlay) {
       this.overlay.classList.remove('open');
       const remove = () => {
+        this.resultsObserver?.disconnect();
+        this.resultsObserver = null;
         this.overlay?.remove();
         this.overlay = null;
         this.input = null;
@@ -550,6 +553,22 @@ export class SearchModal {
     this.input = this.overlay.querySelector('.search-input');
     this.resultsList = this.overlay.querySelector('.search-results');
     this.scopeContainer = this.overlay.querySelector('.search-scope-rail');
+
+    // Combobox/listbox contract: results are options, arrow-key selection is
+    // reported through aria-activedescendant (see decorateResultOptions).
+    if (this.input && this.resultsList) {
+      this.resultsList.id = 'searchResultsListbox';
+      this.resultsList.setAttribute('role', 'listbox');
+      this.input.setAttribute('role', 'combobox');
+      this.input.setAttribute('aria-expanded', 'true');
+      this.input.setAttribute('aria-controls', 'searchResultsListbox');
+      this.input.setAttribute('aria-autocomplete', 'list');
+      // Every render path replaces the listbox's children wholesale; the
+      // observer re-applies option semantics without each path having to know.
+      this.resultsObserver?.disconnect();
+      this.resultsObserver = new MutationObserver(() => this.decorateResultOptions());
+      this.resultsObserver.observe(this.resultsList, { childList: true, subtree: true });
+    }
 
     this.input?.addEventListener('input', () => this.debouncedSearch());
     this.input?.addEventListener('keydown', (e) => this.handleKeydown(e));
@@ -1134,8 +1153,33 @@ export class SearchModal {
       el.classList.toggle('selected', i === this.selectedIndex);
     });
 
+    this.decorateResultOptions();
     const selected = this.resultsList.querySelector('.selected');
     selected?.scrollIntoView({ block: 'nearest' });
+  }
+
+  /**
+   * Apply option semantics to whatever the last render left in the listbox:
+   * each result becomes an id'd role="option" with aria-selected, section
+   * headers become presentational, and the input's aria-activedescendant
+   * tracks the visually selected row — without this, arrow keys move a CSS
+   * class that screen readers never hear about.
+   */
+  private decorateResultOptions(): void {
+    if (!this.resultsList || !this.input) return;
+    let selectedId = '';
+    this.resultsList.querySelectorAll('.search-result-item').forEach((el, i) => {
+      el.setAttribute('role', 'option');
+      if (!el.id) el.id = `search-option-${i}`;
+      const isSelected = el.classList.contains('selected');
+      el.setAttribute('aria-selected', String(isSelected));
+      if (isSelected) selectedId = el.id;
+    });
+    this.resultsList.querySelectorAll('.search-section-header').forEach((el) => {
+      el.setAttribute('role', 'presentation');
+    });
+    if (selectedId) this.input.setAttribute('aria-activedescendant', selectedId);
+    else this.input.removeAttribute('aria-activedescendant');
   }
 
   private selectResult(index: number): void {

--- a/src/components/SearchModal.ts
+++ b/src/components/SearchModal.ts
@@ -25,6 +25,7 @@ import {
   searchSourceItemsEqual,
   type SearchIndexQueryResult,
 } from '@/components/search-engine';
+import { decorateSearchResultOptions } from '@/components/search-result-options';
 import {
   searchMatchIdentity,
   type SearchCommandMatch,
@@ -1167,19 +1168,9 @@ export class SearchModal {
    */
   private decorateResultOptions(): void {
     if (!this.resultsList || !this.input) return;
-    let selectedId = '';
-    this.resultsList.querySelectorAll('.search-result-item').forEach((el, i) => {
-      el.setAttribute('role', 'option');
-      if (!el.id) el.id = `search-option-${i}`;
-      const isSelected = el.classList.contains('selected');
-      el.setAttribute('aria-selected', String(isSelected));
-      if (isSelected) selectedId = el.id;
+    decorateSearchResultOptions(this.resultsList, this.input, {
+      skipOptions: this.showingAllCommands,
     });
-    this.resultsList.querySelectorAll('.search-section-header').forEach((el) => {
-      el.setAttribute('role', 'presentation');
-    });
-    if (selectedId) this.input.setAttribute('aria-activedescendant', selectedId);
-    else this.input.removeAttribute('aria-activedescendant');
   }
 
   private selectResult(index: number): void {

--- a/src/components/search-result-options.ts
+++ b/src/components/search-result-options.ts
@@ -1,0 +1,30 @@
+export function decorateSearchResultOptions(
+  resultsList: HTMLElement,
+  input: HTMLElement,
+  options: { skipOptions?: boolean } = {},
+): void {
+  if (options.skipOptions) {
+    resultsList.querySelectorAll('.search-result-item').forEach((el) => {
+      el.removeAttribute('role');
+      el.removeAttribute('aria-selected');
+    });
+    resultsList.removeAttribute('role');
+    input.removeAttribute('aria-activedescendant');
+    return;
+  }
+
+  resultsList.setAttribute('role', 'listbox');
+  let selectedId = '';
+  resultsList.querySelectorAll('.search-result-item').forEach((el, i) => {
+    el.setAttribute('role', 'option');
+    if (!el.id) el.id = `search-option-${i}`;
+    const isSelected = el.classList.contains('selected');
+    el.setAttribute('aria-selected', String(isSelected));
+    if (isSelected) selectedId = el.id;
+  });
+  resultsList.querySelectorAll('.search-section-header').forEach((el) => {
+    el.setAttribute('role', 'presentation');
+  });
+  if (selectedId) input.setAttribute('aria-activedescendant', selectedId);
+  else input.removeAttribute('aria-activedescendant');
+}

--- a/src/styles/map-context-menu.css
+++ b/src/styles/map-context-menu.css
@@ -1,3 +1,6 @@
 .map-context-menu { position: fixed; z-index: 9999; background: var(--panel-bg); border: 1px solid var(--border); border-radius: 6px; padding: 4px 0; min-width: 180px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
 .map-context-menu-item { padding: 6px 12px; font-size: calc(0.82rem * var(--wm-panel-effective-scale, 1)); cursor: pointer; color: var(--text-primary); }
 .map-context-menu-item:hover { background: var(--hover-bg); }
+/* Arrow-key navigation moves real focus between menuitems; :focus (not
+   :focus-visible) because the focus is always programmatic/keyboard here. */
+.map-context-menu-item:focus { background: var(--hover-bg); outline: 2px solid var(--text); outline-offset: -2px; }

--- a/tests/map-context-menu-a11y.test.mts
+++ b/tests/map-context-menu-a11y.test.mts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { dismissMapContextMenu, showMapContextMenu } from '../src/components/MapContextMenu.ts';
+import { createBrowserEnvironment, MiniElement, MiniNode } from './helpers/mini-dom.mts';
+
+function withBrowserDom(fn: (rafQueue: FrameRequestCallback[]) => void): void {
+  const saved = (['document', 'window', 'Node', 'HTMLElement', 'requestAnimationFrame'] as const).map(
+    (name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)] as const,
+  );
+  const browser = createBrowserEnvironment();
+  const rafQueue: FrameRequestCallback[] = [];
+  const values: Record<string, unknown> = {
+    document: browser.document,
+    window: browser.window,
+    Node: MiniNode,
+    HTMLElement: MiniElement,
+    requestAnimationFrame(callback: FrameRequestCallback) {
+      rafQueue.push(callback);
+      return rafQueue.length;
+    },
+  };
+
+  for (const [name] of saved) {
+    Object.defineProperty(globalThis, name, { configurable: true, value: values[name] });
+  }
+
+  try {
+    fn(rafQueue);
+  } finally {
+    dismissMapContextMenu();
+    for (const [name, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else delete (globalThis as Record<string, unknown>)[name];
+    }
+  }
+}
+
+function press(key: string): Event & { defaultPrevented: boolean } {
+  const event = Object.assign(new Event('keydown', { bubbles: true, cancelable: true }), { key });
+  document.dispatchEvent(event);
+  return event as Event & { defaultPrevented: boolean };
+}
+
+function openTwoItemMenu(): { first: HTMLElement; invoker: HTMLElement } {
+  const invoker = document.createElement('button');
+  invoker.textContent = 'map';
+  document.body.appendChild(invoker);
+  invoker.focus();
+  showMapContextMenu(10, 10, [
+    { label: 'Country brief', action() {} },
+    { label: 'Copy coordinates', action() {} },
+  ]);
+  const items = document.querySelectorAll('.map-context-menu-item');
+  return {
+    first: items[0] as HTMLElement,
+    invoker,
+  };
+}
+
+describe('MapContextMenu keyboard ownership', () => {
+  it('does not steal ArrowDown after focus leaves the menu', () => {
+    withBrowserDom(() => {
+      const { first } = openTwoItemMenu();
+      assert.equal(document.activeElement, first);
+
+      const outsider = document.createElement('input');
+      document.body.appendChild(outsider);
+      outsider.focus();
+      assert.equal(document.activeElement, outsider);
+
+      const event = press('ArrowDown');
+      assert.equal(event.defaultPrevented, false);
+      assert.equal(document.activeElement, outsider);
+      assert.ok(document.querySelector('.map-context-menu'));
+    });
+  });
+
+  it('dismisses on Tab so the document listener does not linger', () => {
+    withBrowserDom(() => {
+      openTwoItemMenu();
+      assert.ok(document.querySelector('.map-context-menu'));
+
+      const event = press('Tab');
+      assert.equal(event.defaultPrevented, false);
+      assert.equal(document.querySelector('.map-context-menu'), null);
+
+      const outsider = document.createElement('input');
+      document.body.appendChild(outsider);
+      outsider.focus();
+      const later = press('ArrowDown');
+      assert.equal(later.defaultPrevented, false);
+    });
+  });
+
+  it('does not let an Escape-before-rAF click listener dismiss the next menu', () => {
+    withBrowserDom((rafQueue) => {
+      openTwoItemMenu();
+      press('Escape');
+      assert.equal(document.querySelector('.map-context-menu'), null);
+
+      while (rafQueue.length > 0) rafQueue.shift()?.(0);
+
+      openTwoItemMenu();
+      assert.ok(document.querySelector('.map-context-menu'));
+      document.dispatchEvent(new Event('click', { bubbles: true }));
+      assert.ok(
+        document.querySelector('.map-context-menu'),
+        'orphan click listener from the aborted open must not dismiss the new menu before its own rAF listener is armed',
+      );
+    });
+  });
+});

--- a/tests/search-debounce.test.mts
+++ b/tests/search-debounce.test.mts
@@ -76,3 +76,12 @@ test('flushPendingSearch runs handleSearch only when input changed since last se
 test('handleSearch records lastSearchedQuery so staleness can be detected (R4)', () => {
   assert.match(searchModalSrc, /this\.lastSearchedQuery = query/, 'handleSearch stores the searched query');
 });
+
+test('decorateResultOptions skips option stamping in the all-commands view', () => {
+  assert.match(searchModalSrc, /import \{ decorateSearchResultOptions \} from '@\/components\/search-result-options'/);
+  assert.match(
+    searchModalSrc,
+    /decorateSearchResultOptions\(this\.resultsList, this\.input, \{\s*skipOptions:\s*this\.showingAllCommands,?\s*\}\)/,
+    'all-commands view must not stamp role=option on command rows',
+  );
+});

--- a/tests/search-result-options.test.mts
+++ b/tests/search-result-options.test.mts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { decorateSearchResultOptions } from '../src/components/search-result-options.ts';
+import { createBrowserEnvironment, MiniElement, MiniNode } from './helpers/mini-dom.mts';
+
+function withBrowserDom(fn: () => void): void {
+  const saved = (['document', 'Node', 'HTMLElement'] as const).map(
+    (name) => [name, Object.getOwnPropertyDescriptor(globalThis, name)] as const,
+  );
+  const browser = createBrowserEnvironment();
+  const values: Record<string, unknown> = {
+    document: browser.document,
+    Node: MiniNode,
+    HTMLElement: MiniElement,
+  };
+
+  for (const [name] of saved) {
+    Object.defineProperty(globalThis, name, { configurable: true, value: values[name] });
+  }
+
+  try {
+    fn();
+  } finally {
+    for (const [name, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+      else delete (globalThis as Record<string, unknown>)[name];
+    }
+  }
+}
+
+describe('decorateSearchResultOptions', () => {
+  it('stamps listbox options and activedescendant on the selected row', () => {
+    withBrowserDom(() => {
+      const list = document.createElement('div');
+      const input = document.createElement('input');
+      const first = document.createElement('div');
+      first.className = 'search-result-item selected';
+      const second = document.createElement('div');
+      second.className = 'search-result-item';
+      list.append(first, second);
+
+      decorateSearchResultOptions(list, input);
+
+      assert.equal(list.getAttribute('role'), 'listbox');
+      assert.equal(first.getAttribute('role'), 'option');
+      assert.equal(first.getAttribute('aria-selected'), 'true');
+      assert.equal(second.getAttribute('aria-selected'), 'false');
+      assert.equal(input.getAttribute('aria-activedescendant'), first.id);
+    });
+  });
+
+  it('does not fake options when skipOptions is set (all-commands view)', () => {
+    withBrowserDom(() => {
+      const list = document.createElement('div');
+      list.setAttribute('role', 'listbox');
+      const input = document.createElement('input');
+      input.setAttribute('aria-activedescendant', 'search-option-0');
+      const command = document.createElement('div');
+      command.className = 'search-result-item command-item';
+      list.append(command);
+
+      decorateSearchResultOptions(list, input, { skipOptions: true });
+
+      assert.equal(command.getAttribute('role'), null);
+      assert.equal(list.getAttribute('role'), null);
+      assert.equal(input.getAttribute('aria-activedescendant'), null);
+    });
+  });
+});


### PR DESCRIPTION
Part of #7023 (accessibility phase 2, PR 3 of 7): proper ARIA widget semantics for the two worst offenders.

## Map context menu — was 100% mouse-exclusive

`MapContextMenu.ts` rendered plain divs with click handlers: no `role`, no focusability, no arrow keys — Escape-to-dismiss was the only key it understood, so every action the menu exposes (opened from country-intel right-clicks) was unreachable by keyboard.

It now implements the WAI-ARIA menu pattern:
- `role="menu"` container, `role="menuitem"` items with roving `tabindex="-1"`.
- Focus moves to the first item on open; ArrowUp/ArrowDown walk items (wrapping), Home/End jump, Enter/Space activate, Escape dismisses.
- Focus returns to the invoking element on dismiss (any dismiss path), instead of dropping to `<body>`.
- Focused items get a visible highlight (`:focus` rather than `:focus-visible` — focus here is always keyboard/programmatic).

## Search palette — selection was invisible to assistive tech

`SearchModal`'s ArrowUp/Down moved a `.selected` CSS class that screen readers never hear about; results were roleless divs (and the two `aria-label`s already written on command items were inert, since ARIA prohibits naming `role=generic` elements); the input had no combobox semantics.

- The input becomes a `role="combobox"` with `aria-expanded`, `aria-controls`, `aria-autocomplete="list"`.
- The results container becomes a `role="listbox"`; a `MutationObserver` re-applies option semantics after **every** render path (recents, tips, command list, search results, flights all replace the listbox wholesale), so no render site needs to know: each result gets an id + `role="option"` + `aria-selected`, section headers become presentational, and the input's `aria-activedescendant` tracks the visually selected row. `updateSelection()` refreshes the same decoration on every arrow press.
- The two previously dead `aria-label`s on command items now function, since the elements have a nameable role.
- The observer is disconnected in the overlay teardown.

The pattern mirrors the in-repo listbox precedents (`RouteExplorer`, `WatchlistEditor`).

## Verification

- `npm run typecheck` — clean; `biome lint` on both files — clean; `lint:safe-html` — clean
- Existing invariant suites unaffected (no CSS token or landmark changes)
