### PR TITLE
fix(a11y): scope="col" on all table column headers

### DIFF
--- a/src/components/BigMacPanel.ts
+++ b/src/components/BigMacPanel.ts
@@ -50,7 +50,7 @@ export class BigMacPanel extends Panel {
     const minCode = sorted[sorted.length - 1]?.code;
 
     const showWow = data.wowAvailable && data.wowAvgPct !== undefined;
-    const wowHeader = showWow ? `<th class="gb-cell">${t('panels.bigmacWow')}</th>` : '';
+    const wowHeader = showWow ? `<th scope="col" class="gb-cell">${t('panels.bigmacWow')}</th>` : '';
 
     const rows = sorted.map(c => {
       const cls = c.code === minCode ? 'gb-cheapest' : c.code === maxCode ? 'gb-priciest' : '';
@@ -88,8 +88,8 @@ export class BigMacPanel extends Panel {
         <div class="gb-scroll">
           <table class="gb-table">
             <thead><tr>
-              <th class="gb-item-col">${t('panels.bigmacCountry')}</th>
-              <th class="gb-cell">USD</th>
+              <th scope="col" class="gb-item-col">${t('panels.bigmacCountry')}</th>
+              <th scope="col" class="gb-cell">USD</th>
               ${wowHeader}
             </tr></thead>
             <tbody>${rows}</tbody>

--- a/src/components/ClimateAnomalyPanel.ts
+++ b/src/components/ClimateAnomalyPanel.ts
@@ -65,10 +65,10 @@ export class ClimateAnomalyPanel extends Panel {
         <table class="climate-table">
           <thead>
             <tr>
-              <th>${t('components.climate.zone')}</th>
-              <th>${t('components.climate.temp')}</th>
-              <th>${t('components.climate.precip')}</th>
-              <th>${t('components.climate.severityLabel')}</th>
+              <th scope="col">${t('components.climate.zone')}</th>
+              <th scope="col">${t('components.climate.temp')}</th>
+              <th scope="col">${t('components.climate.precip')}</th>
+              <th scope="col">${t('components.climate.severityLabel')}</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>

--- a/src/components/ConsumerPricesPanel.ts
+++ b/src/components/ConsumerPricesPanel.ts
@@ -422,7 +422,7 @@ export class ConsumerPricesPanel extends Panel {
       <table class="cp-global-table">
         <thead>
           <tr>
-            <th>Market</th><th>Index</th><th>WoW</th><th>Spread</th><th>Updated</th>
+            <th scope="col">Market</th><th scope="col">Index</th><th scope="col">WoW</th><th scope="col">Spread</th><th scope="col">Updated</th>
           </tr>
         </thead>
         <tbody>${rows}</tbody>
@@ -486,10 +486,10 @@ export class ConsumerPricesPanel extends Panel {
       <table class="cp-global-table cp-world-table">
         <thead>
           <tr>
-            <th>${escapeHtml(t('components.consumerPrices.world.country'))}</th>
-            <th>${escapeHtml(t('components.consumerPrices.world.inflationYoY'))}</th>
-            <th>${escapeHtml(t('components.consumerPrices.world.endOfPeriod'))}</th>
-            <th>${escapeHtml(t('components.consumerPrices.world.year'))}</th>
+            <th scope="col">${escapeHtml(t('components.consumerPrices.world.country'))}</th>
+            <th scope="col">${escapeHtml(t('components.consumerPrices.world.inflationYoY'))}</th>
+            <th scope="col">${escapeHtml(t('components.consumerPrices.world.endOfPeriod'))}</th>
+            <th scope="col">${escapeHtml(t('components.consumerPrices.world.year'))}</th>
           </tr>
         </thead>
         <tbody>${this.inflationTbodyHtml(visible)}</tbody>
@@ -564,11 +564,11 @@ export class ConsumerPricesPanel extends Panel {
       <table class="cp-table">
         <thead>
           <tr>
-            <th>Category</th>
-            <th>WoW</th>
-            <th>MoM</th>
-            <th>Trend</th>
-            <th>Coverage</th>
+            <th scope="col">Category</th>
+            <th scope="col">WoW</th>
+            <th scope="col">MoM</th>
+            <th scope="col">Trend</th>
+            <th scope="col">Coverage</th>
           </tr>
         </thead>
         <tbody>

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -3488,6 +3488,9 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     const node = document.createElement(tag);
     if (className) node.className = className;
     if (text) node.textContent = text;
+    if (tag === 'th') {
+      (node as HTMLTableCellElement).scope = 'col';
+    }
     return node;
   }
 

--- a/src/components/DisplacementPanel.ts
+++ b/src/components/DisplacementPanel.ts
@@ -177,9 +177,9 @@ export class DisplacementPanel extends Panel {
         <table class="disp-table">
           <thead>
             <tr>
-              <th>${t('components.displacement.country')}</th>
-              <th>${t('components.displacement.status')}</th>
-              <th>${t('components.displacement.count')}</th>
+              <th scope="col">${t('components.displacement.country')}</th>
+              <th scope="col">${t('components.displacement.status')}</th>
+              <th scope="col">${t('components.displacement.count')}</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>

--- a/src/components/ETFFlowsPanel.ts
+++ b/src/components/ETFFlowsPanel.ts
@@ -127,11 +127,11 @@ export class ETFFlowsPanel extends Panel {
           <table class="etf-table">
             <thead>
               <tr>
-                <th>${t('components.etfFlows.table.ticker')}</th>
-                <th>${t('components.etfFlows.table.issuer')}</th>
-                <th>${t('components.etfFlows.table.estFlow')}</th>
-                <th>${t('components.etfFlows.table.volume')}</th>
-                <th>${t('components.etfFlows.table.change')}</th>
+                <th scope="col">${t('components.etfFlows.table.ticker')}</th>
+                <th scope="col">${t('components.etfFlows.table.issuer')}</th>
+                <th scope="col">${t('components.etfFlows.table.estFlow')}</th>
+                <th scope="col">${t('components.etfFlows.table.volume')}</th>
+                <th scope="col">${t('components.etfFlows.table.change')}</th>
               </tr>
             </thead>
             <tbody>${rows}</tbody>

--- a/src/components/EconomicCalendarPanel.ts
+++ b/src/components/EconomicCalendarPanel.ts
@@ -222,9 +222,9 @@ export class EconomicCalendarPanel extends Panel {
         </colgroup>
         <thead>
           <tr style="font-size:calc(9px * var(--wm-panel-effective-scale, 1));font-weight:600;color:rgba(255,255,255,0.25);text-transform:uppercase;letter-spacing:0.06em">
-            <th style="text-align:left;padding:0 8px 8px 0;font-weight:600">EVENT</th>
-            <th style="padding:0 0 8px;font-weight:600"></th>
-            <th style="text-align:right;padding:0 0 8px;font-weight:600"></th>
+            <th scope="col" style="text-align:left;padding:0 8px 8px 0;font-weight:600">EVENT</th>
+            <th scope="col" style="padding:0 0 8px;font-weight:600"></th>
+            <th scope="col" style="text-align:right;padding:0 0 8px;font-weight:600"></th>
           </tr>
         </thead>
         <tbody>${emptyMsg}${bodyRows}</tbody>

--- a/src/components/EnergyComplexPanel.ts
+++ b/src/components/EnergyComplexPanel.ts
@@ -101,7 +101,7 @@ export class EnergyComplexPanel extends Panel {
       <div class="energy-tape-section" style="margin-top:8px">
         <div class="energy-section-title">IEA Oil Stocks — Days of Cover</div>
         <table class="oil-stocks-table">
-          <thead><tr><th>#</th><th>Ctry</th><th>Days</th><th>vs 90d</th></tr></thead>
+          <thead><tr><th scope="col">#</th><th scope="col">Ctry</th><th scope="col">Days</th><th scope="col">vs 90d</th></tr></thead>
           <tbody>${rows}</tbody>
         </table>
         <div class="oil-stocks-regional" style="margin-top:6px">
@@ -127,7 +127,7 @@ export class EnergyComplexPanel extends Panel {
       <div class="energy-tape-section" style="margin-top:8px">
         <div class="energy-section-title">LNG Vulnerability</div>
         <table class="oil-stocks-table">
-          <thead><tr><th>Country</th><th>LNG Share</th><th>LNG Imports</th></tr></thead>
+          <thead><tr><th scope="col">Country</th><th scope="col">LNG Share</th><th scope="col">LNG Imports</th></tr></thead>
           <tbody>${rows}</tbody>
         </table>
         <div class="indicator-date" style="margin-top:4px">Data: ${escapeHtml(d.dataMonth)} (JODI Gas)</div>

--- a/src/components/EnergyDisruptionsPanel.ts
+++ b/src/components/EnergyDisruptionsPanel.ts
@@ -218,11 +218,11 @@ export class EnergyDisruptionsPanel extends Panel {
         <table class="ed-table">
           <thead>
             <tr>
-              <th>Event</th>
-              <th>Asset</th>
-              <th>Window</th>
-              <th>Offline</th>
-              <th>Status</th>
+              <th scope="col">Event</th>
+              <th scope="col">Asset</th>
+              <th scope="col">Window</th>
+              <th scope="col">Offline</th>
+              <th scope="col">Status</th>
             </tr>
           </thead>
           <tbody>${rows || `<tr><td colspan="5" class="ed-empty">No events match the current filter.</td></tr>`}</tbody>

--- a/src/components/FuelPricesPanel.ts
+++ b/src/components/FuelPricesPanel.ts
@@ -86,9 +86,9 @@ export class FuelPricesPanel extends Panel {
         <div class="gb-scroll">
           <table class="gb-table">
             <thead><tr>
-              <th class="gb-item-col">${t('panels.fuelPricesCountry')}</th>
-              <th class="gb-cell">${t('panels.fuelPricesGasoline')}</th>
-              <th class="gb-cell">${t('panels.fuelPricesDiesel')}</th>
+              <th scope="col" class="gb-item-col">${t('panels.fuelPricesCountry')}</th>
+              <th scope="col" class="gb-cell">${t('panels.fuelPricesGasoline')}</th>
+              <th scope="col" class="gb-cell">${t('panels.fuelPricesDiesel')}</th>
             </tr></thead>
             <tbody>${rows}</tbody>
           </table>

--- a/src/components/FuelShortagePanel.ts
+++ b/src/components/FuelShortagePanel.ts
@@ -267,10 +267,10 @@ export class FuelShortagePanel extends Panel {
         <table class="fs-table">
           <thead>
             <tr>
-              <th>Country · Product</th>
-              <th>Since</th>
-              <th>Evidence</th>
-              <th>Severity</th>
+              <th scope="col">Country · Product</th>
+              <th scope="col">Since</th>
+              <th scope="col">Evidence</th>
+              <th scope="col">Severity</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>

--- a/src/components/FxPanel.ts
+++ b/src/components/FxPanel.ts
@@ -319,10 +319,10 @@ export class FxPanel extends Panel {
         <table class="fx-table">
           <thead>
             <tr>
-              <th class="fx-ccy">${t('components.fx.currency')}</th>
-              <th>${t('components.fx.yoy')}</th>
-              <th>${t('components.fx.drawdown')}</th>
-              <th class="fx-window">${t('components.fx.peakToTrough')}</th>
+              <th scope="col" class="fx-ccy">${t('components.fx.currency')}</th>
+              <th scope="col">${t('components.fx.yoy')}</th>
+              <th scope="col">${t('components.fx.drawdown')}</th>
+              <th scope="col" class="fx-window">${t('components.fx.peakToTrough')}</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>
@@ -358,9 +358,9 @@ export class FxPanel extends Panel {
           <table class="fx-table">
             <thead>
               <tr>
-                <th class="fx-ccy">${t('components.fx.currency')}</th>
-                <th>${t('components.fx.perUsd')}</th>
-                <th class="fx-inverse">${t('components.fx.usdPerUnit')}</th>
+                <th scope="col" class="fx-ccy">${t('components.fx.currency')}</th>
+                <th scope="col">${t('components.fx.perUsd')}</th>
+                <th scope="col" class="fx-inverse">${t('components.fx.usdPerUnit')}</th>
               </tr>
             </thead>
             <tbody>${rows}</tbody>
@@ -388,9 +388,9 @@ export class FxPanel extends Panel {
           <table class="fx-table">
             <thead>
               <tr>
-                <th class="fx-ccy">${t('components.fx.pair')}</th>
-                <th>${t('components.fx.rate')}</th>
-                <th>${t('components.fx.change1d')}</th>
+                <th scope="col" class="fx-ccy">${t('components.fx.pair')}</th>
+                <th scope="col">${t('components.fx.rate')}</th>
+                <th scope="col">${t('components.fx.change1d')}</th>
               </tr>
             </thead>
             <tbody>${rows}</tbody>
@@ -431,9 +431,9 @@ export class FxPanel extends Panel {
         <table class="fx-table">
           <thead>
             <tr>
-              <th class="fx-ccy">${t('components.fx.currency')}</th>
-              <th>${t('components.fx.rubPerUnit')}</th>
-              <th>${t('components.fx.change1d')}</th>
+              <th scope="col" class="fx-ccy">${t('components.fx.currency')}</th>
+              <th scope="col">${t('components.fx.rubPerUnit')}</th>
+              <th scope="col">${t('components.fx.change1d')}</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>

--- a/src/components/GroceryBasketPanel.ts
+++ b/src/components/GroceryBasketPanel.ts
@@ -46,7 +46,7 @@ export class GroceryBasketPanel extends Panel {
     const itemIds = countries[0]?.items?.map(i => i.itemId) ?? [];
 
     const headerCells = countries.map(c =>
-      `<th class="gb-country-header" title="${escapeHtml(c.name)}">${escapeHtml(c.flag)}<br><span class="gb-country-name">${escapeHtml(c.name)}</span></th>`
+      `<th scope="col" class="gb-country-header" title="${escapeHtml(c.name)}">${escapeHtml(c.flag)}<br><span class="gb-country-name">${escapeHtml(c.name)}</span></th>`
     ).join('');
 
     const rows = itemIds.map(itemId => {
@@ -100,7 +100,7 @@ export class GroceryBasketPanel extends Panel {
         ${wowSummary}
         <div class="gb-scroll">
           <table class="gb-table">
-            <thead><tr><th class="gb-item-col">${t('panels.groceryItem')}</th>${headerCells}</tr></thead>
+            <thead><tr><th scope="col" class="gb-item-col">${t('panels.groceryItem')}</th>${headerCells}</tr></thead>
             <tbody>${rows}${totalRow}</tbody>
           </table>
         </div>

--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -351,11 +351,11 @@ export class HeatmapPanel extends Panel {
     const table = `<div style="overflow-x:auto">
 <table style="width:100%;border-collapse:collapse;font-size:calc(11px * var(--wm-panel-effective-scale, 1))">
   <thead><tr style="color:var(--text-dim);border-bottom:1px solid var(--border)">
-    <th style="padding:3px 6px;text-align:left;font-weight:500">Sector</th>
-    <th style="padding:3px 6px;text-align:right;font-weight:500">Trail P/E</th>
-    <th style="padding:3px 6px;text-align:right;font-weight:500">Fwd P/E</th>
-    <th style="padding:3px 6px;text-align:right;font-weight:500">Beta</th>
-    <th style="padding:3px 6px;text-align:right;font-weight:500">YTD</th>
+    <th scope="col" style="padding:3px 6px;text-align:left;font-weight:500">Sector</th>
+    <th scope="col" style="padding:3px 6px;text-align:right;font-weight:500">Trail P/E</th>
+    <th scope="col" style="padding:3px 6px;text-align:right;font-weight:500">Fwd P/E</th>
+    <th scope="col" style="padding:3px 6px;text-align:right;font-weight:500">Beta</th>
+    <th scope="col" style="padding:3px 6px;text-align:right;font-weight:500">YTD</th>
   </tr></thead>
   <tbody>${tableRows}</tbody>
 </table></div>`;

--- a/src/components/PipelineStatusPanel.ts
+++ b/src/components/PipelineStatusPanel.ts
@@ -362,10 +362,10 @@ export class PipelineStatusPanel extends Panel {
         <table class="pp-table">
           <thead>
             <tr>
-              <th>Asset</th>
-              <th>From → To</th>
-              <th>Capacity</th>
-              <th>Status</th>
+              <th scope="col">Asset</th>
+              <th scope="col">From → To</th>
+              <th scope="col">Capacity</th>
+              <th scope="col">Status</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>

--- a/src/components/RadiationWatchPanel.ts
+++ b/src/components/RadiationWatchPanel.ts
@@ -122,11 +122,11 @@ export class RadiationWatchPanel extends Panel {
         <table class="radiation-table">
           <thead>
             <tr>
-              <th>${escapeHtml(t('components.radiationWatch.headers.station'))}</th>
-              <th>${escapeHtml(t('components.radiationWatch.headers.reading'))}</th>
-              <th>${escapeHtml(t('components.radiationWatch.headers.delta'))}</th>
-              <th>${escapeHtml(t('components.radiationWatch.headers.status'))}</th>
-              <th>${escapeHtml(t('components.radiationWatch.headers.observed'))}</th>
+              <th scope="col">${escapeHtml(t('components.radiationWatch.headers.station'))}</th>
+              <th scope="col">${escapeHtml(t('components.radiationWatch.headers.reading'))}</th>
+              <th scope="col">${escapeHtml(t('components.radiationWatch.headers.delta'))}</th>
+              <th scope="col">${escapeHtml(t('components.radiationWatch.headers.status'))}</th>
+              <th scope="col">${escapeHtml(t('components.radiationWatch.headers.observed'))}</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>

--- a/src/components/RouteExplorer/tabs/CountryImpactTab.ts
+++ b/src/components/RouteExplorer/tabs/CountryImpactTab.ts
@@ -169,7 +169,7 @@ export class CountryImpactTab {
     );
     return [
       '<table class="re-impact__products">',
-      '<thead><tr><th>HS4</th><th>Product</th><th>Value</th><th>Top Exporter</th><th>Chokepoint</th></tr></thead>',
+      '<thead><tr><th scope="col">HS4</th><th scope="col">Product</th><th scope="col">Value</th><th scope="col">Top Exporter</th><th scope="col">Chokepoint</th></tr></thead>',
       `<tbody>${rows.join('')}</tbody>`,
       '</table>',
     ].join('');

--- a/src/components/RouteExplorer/tabs/CurrentRouteTab.ts
+++ b/src/components/RouteExplorer/tabs/CurrentRouteTab.ts
@@ -103,7 +103,7 @@ export class CurrentRouteTab {
     );
     return [
       '<table class="re-current__chokepoints">',
-      '  <thead><tr><th>#</th><th>Chokepoint</th><th>Exposure</th></tr></thead>',
+      '  <thead><tr><th scope="col">#</th><th scope="col">Chokepoint</th><th scope="col">Exposure</th></tr></thead>',
       `  <tbody>${rows.join('')}</tbody>`,
       '</table>',
     ].join('\n');

--- a/src/components/SatelliteFiresPanel.ts
+++ b/src/components/SatelliteFiresPanel.ts
@@ -65,10 +65,10 @@ export class SatelliteFiresPanel extends Panel {
         <table class="fires-table">
           <thead>
             <tr>
-              <th>${t('components.satelliteFires.region')}</th>
-              <th>${t('components.satelliteFires.fires')}</th>
-              <th>${t('components.satelliteFires.high')}</th>
-              <th>FRP</th>
+              <th scope="col">${t('components.satelliteFires.region')}</th>
+              <th scope="col">${t('components.satelliteFires.fires')}</th>
+              <th scope="col">${t('components.satelliteFires.high')}</th>
+              <th scope="col">FRP</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>

--- a/src/components/StockAnalysisPanel.ts
+++ b/src/components/StockAnalysisPanel.ts
@@ -489,11 +489,11 @@ export class StockAnalysisPanel extends Panel {
       <table style="width:100%;border-collapse:collapse;font-size:calc(11px * var(--wm-panel-effective-scale, 1));margin-top:6px">
         <thead>
           <tr style="color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em;text-align:left">
-            <th style="padding:4px 6px;border-bottom:1px solid var(--border)">Name</th>
-            <th style="padding:4px 6px;border-bottom:1px solid var(--border)">Type</th>
-            <th style="padding:4px 6px;border-bottom:1px solid var(--border);text-align:right">Shares</th>
-            <th style="padding:4px 6px;border-bottom:1px solid var(--border);text-align:right">Value</th>
-            <th style="padding:4px 6px;border-bottom:1px solid var(--border)">Date</th>
+            <th scope="col" style="padding:4px 6px;border-bottom:1px solid var(--border)">Name</th>
+            <th scope="col" style="padding:4px 6px;border-bottom:1px solid var(--border)">Type</th>
+            <th scope="col" style="padding:4px 6px;border-bottom:1px solid var(--border);text-align:right">Shares</th>
+            <th scope="col" style="padding:4px 6px;border-bottom:1px solid var(--border);text-align:right">Value</th>
+            <th scope="col" style="padding:4px 6px;border-bottom:1px solid var(--border)">Date</th>
           </tr>
         </thead>
         <tbody>

--- a/src/components/StorageFacilityMapPanel.ts
+++ b/src/components/StorageFacilityMapPanel.ts
@@ -344,10 +344,10 @@ export class StorageFacilityMapPanel extends Panel {
         <table class="sf-table">
           <thead>
             <tr>
-              <th>Facility</th>
-              <th>Country · Type</th>
-              <th>Capacity</th>
-              <th>Status</th>
+              <th scope="col">Facility</th>
+              <th scope="col">Country · Type</th>
+              <th scope="col">Capacity</th>
+              <th scope="col">Status</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>

--- a/src/components/SupplyChainPanel.ts
+++ b/src/components/SupplyChainPanel.ts
@@ -296,7 +296,7 @@ export class SupplyChainPanel extends Panel {
         return `<tr><td>${escapeHtml(opt.name)}</td><td>${days}</td><td>${cost}</td><td>${escapeHtml(risk)}</td></tr>`;
       }).join('');
       return `<table class="sc-bypass-table">
-        <thead><tr><th>Corridor</th><th>+Days</th><th>+Cost</th><th>Risk</th></tr></thead>
+        <thead><tr><th scope="col">Corridor</th><th scope="col">+Days</th><th scope="col">+Cost</th><th scope="col">Risk</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>`;
     };
@@ -559,11 +559,11 @@ export class SupplyChainPanel extends Panel {
       <div class="trade-sector" style="font-weight:600;margin-bottom:4px">${t('components.supplyChain.corridorDisruption')}</div>
       <table class="sc-disruption-table">
         <thead><tr>
-          <th>${t('components.supplyChain.corridor')}</th>
-          <th>${t('components.supplyChain.vessels')}</th>
-          <th>${t('components.supplyChain.wowChange')}</th>
-          <th>${t('components.supplyChain.disruption')}</th>
-          <th>${t('components.supplyChain.risk')}</th>
+          <th scope="col">${t('components.supplyChain.corridor')}</th>
+          <th scope="col">${t('components.supplyChain.vessels')}</th>
+          <th scope="col">${t('components.supplyChain.wowChange')}</th>
+          <th scope="col">${t('components.supplyChain.disruption')}</th>
+          <th scope="col">${t('components.supplyChain.risk')}</th>
         </tr></thead>
         <tbody>${tableRows}</tbody>
       </table>
@@ -763,9 +763,9 @@ export class SupplyChainPanel extends Panel {
         <table>
           <thead>
             <tr>
-              <th>${t('components.supplyChain.mineral')}</th>
-              <th>${t('components.supplyChain.topProducers')}</th>
-              <th>HHI</th>
+              <th scope="col">${t('components.supplyChain.mineral')}</th>
+              <th scope="col">${t('components.supplyChain.topProducers')}</th>
+              <th scope="col">HHI</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>
@@ -797,10 +797,10 @@ export class SupplyChainPanel extends Panel {
       <table>
         <thead>
           <tr>
-            <th>${t('components.supplyChain.mineral')}</th>
-            <th>${t('components.supplyChain.topProducers')}</th>
-            <th>HHI</th>
-            <th>${t('components.supplyChain.risk')}</th>
+            <th scope="col">${t('components.supplyChain.mineral')}</th>
+            <th scope="col">${t('components.supplyChain.topProducers')}</th>
+            <th scope="col">HHI</th>
+            <th scope="col">${t('components.supplyChain.risk')}</th>
           </tr>
         </thead>
         <tbody>${rows}</tbody>

--- a/src/components/TradePolicyPanel.ts
+++ b/src/components/TradePolicyPanel.ts
@@ -231,9 +231,9 @@ export class TradePolicyPanel extends Panel {
       <table>
         <thead>
           <tr>
-            <th>Year</th>
-            <th>${t('components.tradePolicy.mfnAppliedRate')}</th>
-            <th>Sector</th>
+            <th scope="col">Year</th>
+            <th scope="col">${t('components.tradePolicy.mfnAppliedRate')}</th>
+            <th scope="col">Sector</th>
           </tr>
         </thead>
         <tbody>${rows}</tbody>
@@ -440,9 +440,9 @@ export class TradePolicyPanel extends Panel {
       <table>
         <thead>
           <tr>
-            <th>${t('components.tradePolicy.colDate')}</th>
-            <th>${t('components.tradePolicy.colMonthly')}</th>
-            <th>${t('components.tradePolicy.colFytd')}</th>
+            <th scope="col">${t('components.tradePolicy.colDate')}</th>
+            <th scope="col">${t('components.tradePolicy.colMonthly')}</th>
+            <th scope="col">${t('components.tradePolicy.colFytd')}</th>
           </tr>
         </thead>
         <tbody>${rows}</tbody>
@@ -504,10 +504,10 @@ export class TradePolicyPanel extends Panel {
     return `${scope}<div class="trade-tariffs-table">
       <table>
         <thead><tr>
-          <th>${t('components.tradePolicy.colReporter')}</th>
-          <th>${t('components.tradePolicy.colCommodity')}</th>
-          <th>${t('components.tradePolicy.colTradeValue')}</th>
-          <th>${t('components.tradePolicy.yoyChange')}</th>
+          <th scope="col">${t('components.tradePolicy.colReporter')}</th>
+          <th scope="col">${t('components.tradePolicy.colCommodity')}</th>
+          <th scope="col">${t('components.tradePolicy.colTradeValue')}</th>
+          <th scope="col">${t('components.tradePolicy.yoyChange')}</th>
         </tr></thead>
         <tbody>${rows}</tbody>
       </table>

--- a/src/components/UcdpEventsPanel.ts
+++ b/src/components/UcdpEventsPanel.ts
@@ -136,10 +136,10 @@ export class UcdpEventsPanel extends Panel {
         <table class="ucdp-table">
           <thead>
             <tr>
-              <th>${t('components.ucdpEvents.country')}</th>
-              <th>${t('components.ucdpEvents.deaths')}</th>
-              <th>${t('components.ucdpEvents.date')}</th>
-              <th>${t('components.ucdpEvents.actors')}</th>
+              <th scope="col">${t('components.ucdpEvents.country')}</th>
+              <th scope="col">${t('components.ucdpEvents.deaths')}</th>
+              <th scope="col">${t('components.ucdpEvents.date')}</th>
+              <th scope="col">${t('components.ucdpEvents.actors')}</th>
             </tr>
           </thead>
           <tbody>${rows}</tbody>

--- a/src/components/WatchlistTableView.ts
+++ b/src/components/WatchlistTableView.ts
@@ -173,7 +173,7 @@ export class WatchlistTableView<T> {
       const classAttr = classes.length ? ` class="${classes.join(' ')}"` : '';
       const sortAttr = sortKey ? ` data-sortkey="${escapeHtml(sortKey)}"` : '';
       const activeSortIndicator = sortKey && sortKey === this.state.sort ? ' ↓' : '';
-      return `<th${classAttr}${sortAttr}>${escapeHtml(col.label)}${activeSortIndicator}</th>`;
+      return `<th scope="col"${classAttr}${sortAttr}>${escapeHtml(col.label)}${activeSortIndicator}</th>`;
     }).join('');
     return `
       <div class="watchlist-table-view" data-watchlist-totalrows="${list.length}" data-watchlist-renderedrows="${this.getRenderedRowCount(list, start)}">

--- a/src/components/WsbTickerScannerPanel.ts
+++ b/src/components/WsbTickerScannerPanel.ts
@@ -140,12 +140,12 @@ export class WsbTickerScannerPanel extends Panel {
         <table style="width:100%;border-collapse:collapse;border-spacing:0">
           <thead>
             <tr style="border-bottom:1px solid var(--border)">
-              <th style="${headerStyle};text-align:right">#</th>
-              <th style="${headerStyle};text-align:left">Ticker</th>
-              <th style="${headerStyle};text-align:right" data-sort="mentionCount">Mentions${this._sortIndicator('mentionCount')}</th>
-              <th style="${headerStyle};text-align:right" data-sort="totalScore">Score${this._sortIndicator('totalScore')}</th>
-              <th style="${headerStyle};text-align:left" data-sort="velocityScore">Velocity${this._sortIndicator('velocityScore')}</th>
-              <th style="${headerStyle};text-align:left">Source</th>
+              <th scope="col" style="${headerStyle};text-align:right">#</th>
+              <th scope="col" style="${headerStyle};text-align:left">Ticker</th>
+              <th scope="col" style="${headerStyle};text-align:right" data-sort="mentionCount">Mentions${this._sortIndicator('mentionCount')}</th>
+              <th scope="col" style="${headerStyle};text-align:right" data-sort="totalScore">Score${this._sortIndicator('totalScore')}</th>
+              <th scope="col" style="${headerStyle};text-align:left" data-sort="velocityScore">Velocity${this._sortIndicator('velocityScore')}</th>
+              <th scope="col" style="${headerStyle};text-align:left">Source</th>
             </tr>
           </thead>
           <tbody>${rows || '<tr><td colspan="6" style="padding:16px;text-align:center;color:var(--text-dim);font-size:calc(12px * var(--wm-panel-effective-scale, 1))">No ticker data</td></tr>'}</tbody>

--- a/src/components/YieldCurvePanel.ts
+++ b/src/components/YieldCurvePanel.ts
@@ -167,7 +167,7 @@ function renderChart(current: YieldPoint[], prior: YieldPoint[], ecbRates: Recor
 }
 
 function renderTable(points: YieldPoint[]): string {
-  const headers = points.map(p => `<th style="font-size:calc(9px * var(--wm-panel-effective-scale, 1));font-weight:600;color:var(--text-dim);padding:4px 6px;text-align:center">${escapeHtml(p.tenor)}</th>`).join('');
+  const headers = points.map(p => `<th scope="col" style="font-size:calc(9px * var(--wm-panel-effective-scale, 1));font-weight:600;color:var(--text-dim);padding:4px 6px;text-align:center">${escapeHtml(p.tenor)}</th>`).join('');
   const cells = points.map(p => {
     const val = p.value !== null ? `${p.value.toFixed(2)}%` : 'N/A';
     return `<td style="font-size:calc(11px * var(--wm-panel-effective-scale, 1));color:var(--text);padding:4px 6px;text-align:center">${escapeHtml(val)}</td>`;

--- a/src/components/giving-renderer.ts
+++ b/src/components/giving-renderer.ts
@@ -155,8 +155,8 @@ function renderPlatforms(data: GivingSummary, translate: GivingTranslate): strin
     <table class="giving-table">
       <thead>
         <tr>
-          <th>${escapeHtml(translate('components.giving.platform'))}</th>
-          <th>${escapeHtml(translate('components.giving.benchmark'))}</th>
+          <th scope="col">${escapeHtml(translate('components.giving.platform'))}</th>
+          <th scope="col">${escapeHtml(translate('components.giving.benchmark'))}</th>
         </tr>
       </thead>
       <tbody>${rows}</tbody>

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -706,7 +706,7 @@ function initDiagnostics(): void {
         return `<tr class="diag-${cls}"><td>${escapeHtml(ts)}</td><td>${e.method}</td><td title="${escapeHtml(e.path)}">${escapeHtml(e.path)}</td><td>${e.status}</td><td>${e.durationMs}ms</td></tr>`;
       }).join('');
 
-      setTrustedHtml(trafficLogEl, trustedHtml(`<table class="diag-table"><thead><tr><th>${t('modals.settingsWindow.table.time')}</th><th>${t('modals.settingsWindow.table.method')}</th><th>${t('modals.settingsWindow.table.path')}</th><th>${t('modals.settingsWindow.table.status')}</th><th>${t('modals.settingsWindow.table.duration')}</th></tr></thead><tbody>${rows}</tbody></table>`, "legacy direct innerHTML migration"));
+      setTrustedHtml(trafficLogEl, trustedHtml(`<table class="diag-table"><thead><tr><th scope="col">${t('modals.settingsWindow.table.time')}</th><th scope="col">${t('modals.settingsWindow.table.method')}</th><th scope="col">${t('modals.settingsWindow.table.path')}</th><th scope="col">${t('modals.settingsWindow.table.status')}</th><th scope="col">${t('modals.settingsWindow.table.duration')}</th></tr></thead><tbody>${rows}</tbody></table>`, "legacy direct innerHTML migration"));
     } catch {
       setTrustedHtml(trafficLogEl, trustedHtml(`<p class="diag-empty">${t('modals.settingsWindow.sidecarUnreachable')}</p>`, "legacy direct innerHTML migration"));
     }

--- a/src/utils/export-report.ts
+++ b/src/utils/export-report.ts
@@ -116,7 +116,7 @@ function linkCell(title: unknown, link: unknown): string {
 
 function section(title: string, headers: string[], rows: string[][]): string {
   if (rows.length === 0) return '';
-  const head = headers.map((h) => `<th>${escapeReportHtml(h)}</th>`).join('');
+  const head = headers.map((h) => `<th scope="col">${escapeReportHtml(h)}</th>`).join('');
   const body = rows
     .map((cells) => `<tr>${cells.map((cell) => `<td>${cell}</td>`).join('')}</tr>`)
     .join('');

--- a/tests/a11y-table-scope-invariants.test.mjs
+++ b/tests/a11y-table-scope-invariants.test.mjs
@@ -1,0 +1,45 @@
+/**
+ * Regression guard for the table-header scope sweep (#7023 / PR 7030):
+ *   - Country Deep Dive builds thead cells via this.el('th'), so a literal
+ *     `<th` grep misses them unless el() sets scope="col".
+ *   - The settings traffic-log table is the remaining HTML-literal header
+ *     surface outside the dashboard panel sweep.
+ *
+ * Run: node --test tests/a11y-table-scope-invariants.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (...p) => readFileSync(resolve(__dirname, '..', ...p), 'utf-8');
+
+const cdp = read('src', 'components', 'CountryDeepDivePanel.ts');
+const settingsMain = read('src', 'settings-main.ts');
+
+describe('CountryDeepDivePanel DOM headers get column scope', () => {
+  it('el() assigns scope="col" on th nodes', () => {
+    const elFn = cdp.match(
+      /private el<K extends keyof HTMLElementTagNameMap>[\s\S]*?return node;\n  }/,
+    );
+    assert.ok(elFn, 'expected CountryDeepDivePanel.el() helper');
+    assert.match(elFn[0], /if \(tag === 'th'\)/);
+    assert.match(elFn[0], /\.scope = 'col'/);
+  });
+
+  it('does not create th nodes outside el()', () => {
+    assert.doesNotMatch(cdp, /createElement\(\s*['"]th['"]\s*\)/);
+  });
+});
+
+describe('settings traffic-log headers are scoped', () => {
+  it('diag-table thead headers include scope="col"', () => {
+    assert.match(
+      settingsMain,
+      /<table class="diag-table"><thead><tr>(?:<th scope="col">[^<]*<\/th>){5}<\/tr><\/thead>/,
+    );
+  });
+});

--- a/tests/a11y-table-scope-invariants.test.mjs
+++ b/tests/a11y-table-scope-invariants.test.mjs
@@ -23,7 +23,7 @@ const settingsMain = read('src', 'settings-main.ts');
 describe('CountryDeepDivePanel DOM headers get column scope', () => {
   it('el() assigns scope="col" on th nodes', () => {
     const elFn = cdp.match(
-      /private el<K extends keyof HTMLElementTagNameMap>[\s\S]*?return node;\n  }/,
+      /private el<K extends keyof HTMLElementTagNameMap>[\s\S]*?return node;\n {2}}/,
     );
     assert.ok(elFn, 'expected CountryDeepDivePanel.el() helper');
     assert.match(elFn[0], /if \(tag === 'th'\)/);


### PR DESCRIPTION
Part of #7023 (accessibility phase 2, PR 5 of 7).

146 `<th>` elements across 28 files carried **zero** `scope` attributes (and zero `<caption>`s), so screen readers had to infer header→cell association in every data table — SupplyChain corridors, FX, TradePolicy, ConsumerPrices, the watchlist table, UCDP events, and 22 more.

Every header cell in the codebase lives in a `<thead>` row as a column header (verified: no `<th>` appears inside a `<tbody>`), so this is a mechanical `scope="col"` sweep — 124 lines across 28 files, including the dynamically built watchlist sort headers and the HTML export report util. No visual or behavioral change.

Captions were considered and skipped: every table sits inside a panel whose title now provides the accessible context (level-2 heading as of #7029), so a caption would be duplicative.

## Verification
- `npm run typecheck` — clean
- `biome lint` across src/components — clean
- Verified no `<tbody>` header cells received a column scope