### PR TITLE
fix(a11y): keyboard reorder for world-clock cities and live-news channels

### DIFF
--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -924,6 +924,20 @@ export class LiveNewsPanel extends Panel {
     btn.textContent = this.getChannelDisplayName(channel);
 
     btn.style.cursor = 'grab';
+    // Keyboard parity for the mouse drag reorder in createChannelSwitcher:
+    // arrows move the focused channel one slot and persist through the same
+    // applyChannelOrderFromDom path a completed drag uses.
+    btn.addEventListener('keydown', (e) => {
+      const back = e.key === 'ArrowLeft';
+      const fwd = e.key === 'ArrowRight';
+      if (!back && !fwd) return;
+      e.preventDefault();
+      const sibling = back ? btn.previousElementSibling : btn.nextElementSibling;
+      if (!(sibling instanceof HTMLElement) || !sibling.classList.contains('live-channel-btn')) return;
+      btn.parentElement?.insertBefore(btn, back ? sibling : sibling.nextElementSibling);
+      this.applyChannelOrderFromDom();
+      btn.focus();
+    });
     btn.addEventListener('click', (e) => {
       if (this.suppressChannelClick) {
         e.preventDefault();
@@ -1180,9 +1194,14 @@ export class LiveNewsPanel extends Panel {
       <div class="live-offline live-offline-compact">
         <div class="offline-icon">📺</div>
         <div class="offline-text">${t('components.liveNews.notLive', { name: safeName })}</div>
-        <button class="offline-retry" onclick="this.closest('.panel').querySelector('.live-channel-btn.active')?.click()">${t('common.retry')}</button>
+        <button class="offline-retry" data-live-retry>${t('common.retry')}</button>
       </div>
     `, "legacy direct innerHTML migration"));
+    // The repo's last inline onclick= lived here (CSP unsafe-inline
+    // dependency); a bound listener retries the active channel instead.
+    this.content.querySelector('[data-live-retry]')?.addEventListener('click', () => {
+      void this.switchChannel(this.activeChannel);
+    });
   }
 
   private showEmbedError(channel: LiveChannel, errorCode: number): void {

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -931,9 +931,9 @@ export class LiveNewsPanel extends Panel {
       const back = e.key === 'ArrowLeft';
       const fwd = e.key === 'ArrowRight';
       if (!back && !fwd) return;
-      e.preventDefault();
       const sibling = back ? btn.previousElementSibling : btn.nextElementSibling;
       if (!(sibling instanceof HTMLElement) || !sibling.classList.contains('live-channel-btn')) return;
+      e.preventDefault();
       btn.parentElement?.insertBefore(btn, back ? sibling : sibling.nextElementSibling);
       this.applyChannelOrderFromDom();
       btn.focus();
@@ -1198,9 +1198,10 @@ export class LiveNewsPanel extends Panel {
       </div>
     `, "legacy direct innerHTML migration"));
     // The repo's last inline onclick= lived here (CSP unsafe-inline
-    // dependency); a bound listener retries the active channel instead.
+    // dependency). switchChannel no-ops when the id is already active, so
+    // retry must re-request playback for the current stream.
     this.content.querySelector('[data-live-retry]')?.addEventListener('click', () => {
-      void this.switchChannel(this.activeChannel);
+      this.requestPlaybackForActiveChannel();
     });
   }
 

--- a/src/components/WorldClockPanel.ts
+++ b/src/components/WorldClockPanel.ts
@@ -257,21 +257,25 @@ export class WorldClockPanel extends Panel {
     // one slot and persist through the same saveSelectedCities path.
     content.addEventListener('keydown', (e: KeyboardEvent) => {
       if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+      // A live pointer gesture owns selectedCities until mouseup.
+      if (this.dragCityId) return;
       const handle = (e.target as HTMLElement).closest('.wc-drag-handle');
       const row = handle?.closest('.wc-row') as HTMLElement | null;
       const cityId = row?.dataset.cityId;
-      if (!cityId) return;
-      e.preventDefault();
+      if (!cityId || !row) return;
       const fromIdx = this.selectedCities.indexOf(cityId);
       const toIdx = e.key === 'ArrowUp' ? fromIdx - 1 : fromIdx + 1;
       if (fromIdx === -1 || toIdx < 0 || toIdx >= this.selectedCities.length) return;
+      const sibling = e.key === 'ArrowUp' ? row.previousElementSibling : row.nextElementSibling;
+      if (!(sibling instanceof HTMLElement) || !sibling.classList.contains('wc-row')) return;
+      e.preventDefault();
       this.selectedCities.splice(fromIdx, 1);
       this.selectedCities.splice(toIdx, 0, cityId);
       saveSelectedCities(this.selectedCities);
-      this.renderClocks();
-      // renderClocks rebuilds the rows; put focus back on the moved handle
-      // so repeated presses keep moving the same city.
-      content.querySelector<HTMLElement>(`.wc-row[data-city-id="${cityId}"] .wc-drag-handle`)?.focus();
+      // Move the live row. renderClocks() is a 150ms setSafeContent rebuild and
+      // would destroy the focused handle before afterUpdate runs.
+      row.parentElement?.insertBefore(row, e.key === 'ArrowUp' ? sibling : sibling.nextElementSibling);
+      if (handle instanceof HTMLElement) handle.focus();
     });
 
     content.addEventListener('mousedown', (e: MouseEvent) => {

--- a/src/components/WorldClockPanel.ts
+++ b/src/components/WorldClockPanel.ts
@@ -252,6 +252,28 @@ export class WorldClockPanel extends Panel {
   private setupDragHandlers(): void {
     const content = this.content;
 
+    // Keyboard parity for the mouse drag below (same idiom as the panel
+    // reorder button from #6964): arrows on a focused handle move the row
+    // one slot and persist through the same saveSelectedCities path.
+    content.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+      const handle = (e.target as HTMLElement).closest('.wc-drag-handle');
+      const row = handle?.closest('.wc-row') as HTMLElement | null;
+      const cityId = row?.dataset.cityId;
+      if (!cityId) return;
+      e.preventDefault();
+      const fromIdx = this.selectedCities.indexOf(cityId);
+      const toIdx = e.key === 'ArrowUp' ? fromIdx - 1 : fromIdx + 1;
+      if (fromIdx === -1 || toIdx < 0 || toIdx >= this.selectedCities.length) return;
+      this.selectedCities.splice(fromIdx, 1);
+      this.selectedCities.splice(toIdx, 0, cityId);
+      saveSelectedCities(this.selectedCities);
+      this.renderClocks();
+      // renderClocks rebuilds the rows; put focus back on the moved handle
+      // so repeated presses keep moving the same city.
+      content.querySelector<HTMLElement>(`.wc-row[data-city-id="${cityId}"] .wc-drag-handle`)?.focus();
+    });
+
     content.addEventListener('mousedown', (e: MouseEvent) => {
       const handle = (e.target as HTMLElement).closest('.wc-drag-handle') as HTMLElement | null;
       if (!handle) return;
@@ -352,7 +374,7 @@ export class WorldClockPanel extends Panel {
       if (isHome) rowCls.push('wc-home');
       if (!isDay) rowCls.push('wc-night');
 
-      html += `<div class="${rowCls.join(' ')}" data-city-id="${city.id}"><div class="wc-drag-handle" title="Drag to reorder">\u22EE</div><div class="wc-info"><div class="wc-name">${city.city}${isHome ? '<span class="wc-home-tag">\u2302</span>' : ''}</div><div class="wc-detail"><span class="wc-exchange">${city.label}</span>${statusHtml}</div></div><div class="wc-clock"><div class="wc-time">${pad2(h)}:${pad2(m)}:${pad2(s)}</div><div class="wc-tz"><div class="wc-bar-wrap"><div class="wc-bar ${isDay ? 'day' : 'night'}" style="width:${pct.toFixed(1)}%"></div></div><span>${dayOfWeek} ${abbr}</span></div></div></div>`;
+      html += `<div class="${rowCls.join(' ')}" data-city-id="${city.id}"><div class="wc-drag-handle" role="button" tabindex="0" title="Drag to reorder" aria-label="Move ${city.city} (arrow keys)">\u22EE</div><div class="wc-info"><div class="wc-name">${city.city}${isHome ? '<span class="wc-home-tag">\u2302</span>' : ''}</div><div class="wc-detail"><span class="wc-exchange">${city.label}</span>${statusHtml}</div></div><div class="wc-clock"><div class="wc-time">${pad2(h)}:${pad2(m)}:${pad2(s)}</div><div class="wc-tz"><div class="wc-bar-wrap"><div class="wc-bar ${isDay ? 'day' : 'night'}" style="width:${pct.toFixed(1)}%"></div></div><span>${dayOfWeek} ${abbr}</span></div></div></div>`;
     }
     html += '</div>';
     // Cache handles only once the debounced write has actually committed —

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -2136,6 +2136,11 @@
   margin: -10px -4px;
 }
 
+.wc-drag-handle:focus-visible {
+  outline: 2px solid var(--text);
+  outline-offset: -2px;
+}
+
 .wc-drag-handle:hover {
   color: var(--text-dim);
 }

--- a/tests/dom/live-news-channel-keyboard-reorder.test.mts
+++ b/tests/dom/live-news-channel-keyboard-reorder.test.mts
@@ -1,0 +1,117 @@
+/**
+ * LiveNewsPanel channel keyboard reorder + offline retry.
+ *
+ * ArrowLeft/Right must persist through applyChannelOrderFromDom. Offline Retry
+ * must re-request playback for the already-active channel (switchChannel
+ * returns immediately on a matching id).
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LiveNewsPanel } from '@/components/LiveNewsPanel';
+import { STORAGE_KEYS } from '@/config';
+import * as liveMedia from '@/services/live-media-controller';
+
+import { initTestI18n } from './helpers/i18n.mts';
+
+beforeAll(async () => {
+  await initTestI18n();
+});
+
+const SEEDED_ORDER = ['bloomberg', 'sky', 'cnbc'] as const;
+
+let panel: LiveNewsPanel;
+
+function element(): HTMLElement {
+  return (panel as unknown as { element: HTMLElement }).element;
+}
+
+function content(): HTMLElement {
+  return (panel as unknown as { content: HTMLElement }).content;
+}
+
+function channelButtons(): HTMLButtonElement[] {
+  return Array.from(element().querySelectorAll<HTMLButtonElement>('.live-channel-btn'));
+}
+
+function channelIds(): string[] {
+  return channelButtons().map((btn) => btn.dataset.channelId ?? '');
+}
+
+function persistedOrder(): string[] {
+  const raw = localStorage.getItem(STORAGE_KEYS.liveChannels);
+  if (!raw) return [];
+  const parsed = JSON.parse(raw) as { order?: string[] };
+  return parsed.order ?? [];
+}
+
+function dispatchArrow(target: HTMLElement, key: 'ArrowLeft' | 'ArrowRight'): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem(
+    STORAGE_KEYS.liveChannels,
+    JSON.stringify({ order: [...SEEDED_ORDER], custom: [], displayNameOverrides: {} }),
+  );
+  panel = new LiveNewsPanel();
+  document.body.appendChild(element());
+});
+
+afterEach(() => {
+  panel.destroy();
+  document.body.innerHTML = '';
+});
+
+describe('LiveNewsPanel channel keyboard reorder', () => {
+  it('moves the focused channel one slot right and persists order', () => {
+    const buttons = channelButtons();
+    expect(buttons.map((btn) => btn.dataset.channelId)).toEqual([...SEEDED_ORDER]);
+    const first = buttons[0];
+    expect(first).toBeDefined();
+    first?.focus();
+
+    dispatchArrow(first as HTMLButtonElement, 'ArrowRight');
+
+    expect(channelIds()).toEqual(['sky', 'bloomberg', 'cnbc']);
+    expect(document.activeElement).toBe(first);
+    expect(persistedOrder()).toEqual(['sky', 'bloomberg', 'cnbc']);
+  });
+
+  it('leaves order unchanged on ArrowRight at the last channel and does not preventDefault', () => {
+    const last = channelButtons().at(-1);
+    expect(last).toBeDefined();
+    last?.focus();
+
+    const event = dispatchArrow(last as HTMLButtonElement, 'ArrowRight');
+
+    expect(channelIds()).toEqual([...SEEDED_ORDER]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+describe('LiveNewsPanel offline retry', () => {
+  it('re-requests playback for the already-active channel and has no inline onclick', () => {
+    const requestSpy = vi.spyOn(liveMedia, 'requestLiveMediaPlayback').mockImplementation(() => {});
+    const internals = panel as unknown as {
+      activeChannel: { id: string; name: string };
+      showOfflineMessage: (channel: { id: string; name: string }) => void;
+    };
+
+    internals.showOfflineMessage(internals.activeChannel);
+
+    const retry = content().querySelector<HTMLButtonElement>('[data-live-retry]');
+    expect(retry).not.toBeNull();
+    expect(retry?.getAttribute('onclick')).toBeNull();
+
+    retry?.click();
+
+    expect(requestSpy).toHaveBeenCalled();
+    const args = requestSpy.mock.calls[0];
+    expect(args?.[0]).toBe('live-news');
+    expect(args?.[1]).toBe(internals.activeChannel.id);
+  });
+});

--- a/tests/dom/live-news-channel-keyboard-reorder.test.mts
+++ b/tests/dom/live-news-channel-keyboard-reorder.test.mts
@@ -82,7 +82,8 @@ describe('LiveNewsPanel channel keyboard reorder', () => {
   });
 
   it('leaves order unchanged on ArrowRight at the last channel and does not preventDefault', () => {
-    const last = channelButtons().at(-1);
+    const buttons = channelButtons();
+    const last = buttons[buttons.length - 1];
     expect(last).toBeDefined();
     last?.focus();
 

--- a/tests/dom/world-clock-keyboard-reorder-a11y.test.mts
+++ b/tests/dom/world-clock-keyboard-reorder-a11y.test.mts
@@ -1,0 +1,120 @@
+/**
+ * WorldClockPanel keyboard reorder — ArrowUp/ArrowDown on the drag handle.
+ *
+ * The first implementation rebuilt rows through renderClocks() (150ms
+ * setSafeContent debounce) and focused the outgoing handle. Repeated arrows
+ * then missed the handle. These tests pin in-place move + focus identity.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WorldClockPanel } from '@/components/WorldClockPanel';
+
+import { initTestI18n } from './helpers/i18n.mts';
+
+beforeAll(async () => {
+  await initTestI18n();
+});
+
+const CONTENT_DEBOUNCE_MS = 150;
+const STORAGE_KEY = 'worldmonitor-world-clock-cities';
+const SEEDED_CITIES = ['london', 'tokyo', 'sydney'] as const;
+
+let panel: WorldClockPanel;
+
+function content(): HTMLElement {
+  return (panel as unknown as { content: HTMLElement }).content;
+}
+
+function rows(): HTMLElement[] {
+  return Array.from(content().querySelectorAll<HTMLElement>('.wc-row'));
+}
+
+function cityIds(): string[] {
+  return rows().map((row) => row.dataset.cityId ?? '');
+}
+
+function handleFor(cityId: string): HTMLElement | null {
+  return content().querySelector<HTMLElement>(`.wc-row[data-city-id="${cityId}"] .wc-drag-handle`);
+}
+
+function dispatchArrow(target: HTMLElement, key: 'ArrowUp' | 'ArrowDown'): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  target.dispatchEvent(event);
+  return event;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-05T14:30:00.000Z'));
+  localStorage.clear();
+  localStorage.setItem(STORAGE_KEY, JSON.stringify([...SEEDED_CITIES]));
+  panel = new WorldClockPanel();
+  document.body.appendChild((panel as unknown as { element: HTMLElement }).element);
+  vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+});
+
+afterEach(() => {
+  panel.destroy();
+  document.body.innerHTML = '';
+  vi.useRealTimers();
+});
+
+describe('WorldClockPanel keyboard reorder', () => {
+  it('moves the focused city one slot down and keeps handle focus on the same node', () => {
+    const londonHandle = handleFor('london');
+    expect(londonHandle).not.toBeNull();
+    londonHandle?.focus();
+    const beforeHandle = londonHandle as HTMLElement;
+
+    dispatchArrow(beforeHandle, 'ArrowDown');
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+
+    expect(cityIds()).toEqual(['tokyo', 'london', 'sydney']);
+    expect(handleFor('london')).toBe(beforeHandle);
+    expect(document.activeElement).toBe(beforeHandle);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]')).toEqual([
+      'tokyo',
+      'london',
+      'sydney',
+    ]);
+  });
+
+  it('keeps moving the same city on a second ArrowDown without re-tabbing', () => {
+    const londonHandle = handleFor('london');
+    expect(londonHandle).not.toBeNull();
+    londonHandle?.focus();
+
+    dispatchArrow(londonHandle as HTMLElement, 'ArrowDown');
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+    expect(document.activeElement).toBe(londonHandle);
+
+    dispatchArrow(document.activeElement as HTMLElement, 'ArrowDown');
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+
+    expect(cityIds()).toEqual(['tokyo', 'sydney', 'london']);
+    expect(document.activeElement).toBe(londonHandle);
+  });
+
+  it('leaves order unchanged on ArrowDown at the last city and does not preventDefault', () => {
+    const sydneyHandle = handleFor('sydney');
+    expect(sydneyHandle).not.toBeNull();
+    sydneyHandle?.focus();
+
+    const event = dispatchArrow(sydneyHandle as HTMLElement, 'ArrowDown');
+
+    expect(cityIds()).toEqual([...SEEDED_CITIES]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('moves the focused city one slot up', () => {
+    const tokyoHandle = handleFor('tokyo');
+    expect(tokyoHandle).not.toBeNull();
+    tokyoHandle?.focus();
+
+    dispatchArrow(tokyoHandle as HTMLElement, 'ArrowUp');
+
+    expect(cityIds()).toEqual(['tokyo', 'london', 'sydney']);
+    expect(document.activeElement).toBe(tokyoHandle);
+  });
+});


### PR DESCRIPTION
Part of #7023 (accessibility phase 2, PR 7 of 7): the last two mouse-only drag interactions, plus an inline-handler cleanup.

## What this does

**World clock rows** — reordering was a `mousedown`/`mousemove`/`mouseup` drag on a decorative `⋮` div. The handle is now a focusable `role="button"` with an accessible name ("Move London (arrow keys)"); ArrowUp/ArrowDown move the city one slot and persist through the **same** `saveSelectedCities()` path as a completed drag. `renderClocks()` rebuilds the rows, so focus is re-planted on the moved handle — repeated presses keep moving the same city. Focus ring added.

**Live news channels** — switching channels was already keyboard-fine (real buttons); only *reordering* was pointer-locked. ArrowLeft/ArrowRight on a focused channel button now move it one slot, persisting through the same `applyChannelOrderFromDom()` the mouse drag uses.

**Inline `onclick` removed** — the live-news offline retry button carried the repo's last inline handler (`onclick="this.closest('.panel')..."`), a CSP `unsafe-inline` dependency that silently no-oped if the active button was missing. It's now a bound listener that retries the active channel directly.

Both reorders follow the arrow-key idiom #6964 established for panel reordering, so the interaction language stays consistent.

## Verification
- `npm run typecheck` — clean; `biome lint` — clean; `lint:safe-html` — clean
- `node --test tests/a11y-issue-*.test.mjs tests/marker-pulse-settle.test.mjs` — 46/46 pass