### PR TITLE
fix(x-feed): verify every curated X account against the API (#6654 follow-up)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -870,7 +870,7 @@ const SEED_META = {
   researchArxivHnTrending: { key: 'seed-meta:research:arxiv-hn-trending', maxStaleMin: 150 },
   gdeltIntel:       { key: 'seed-meta:intelligence:gdelt-intel',   maxStaleMin: 45 }, // 15min bulk materializer; 45min = 3× cadence and expires before the 24h canonical key.
   telegramFeed:     { key: 'seed-meta:intelligence:telegram-feed:v1', maxStaleMin: 10 }, // 60s poll interval; 10min grace catches poll failures before they go stale in the panel
-  xFeed:            { key: 'seed-meta:intelligence:x-feed:v1', maxStaleMin: 45, cutover: { mode: 'expiring-ack', fromKey: null, issue: 6654, status: 'EMPTY' } }, // 5–15min ais-relay poll; 45min = 3× max cadence. Empty until X_BEARER_TOKEN is provisioned on ais-relay.
+  xFeed:            { key: 'seed-meta:intelligence:x-feed:v1', maxStaleMin: 45 }, // 5–15min ais-relay poll; 45min = 3× max cadence. Cutover complete (#6654): X_BEARER_TOKEN is on ais-relay and the producer serves the key, so EMPTY here is now a real fault, not a deploy window.
   digestNotifications: { key: 'seed-meta:digest:last-run',          maxStaleMin: 90 }, // Railway digest-notifications cron runs every 30min; 90 = 3x cadence and detects a dead cron before daily digests are missed.
   forecasts:        { key: 'seed-meta:forecast:predictions',       maxStaleMin: 90 },
   forecastsBootstrap: { key: 'seed-meta:forecast:predictions-bootstrap', maxStaleMin: 90 }, // Same cron. Monitored separately: the fast tier now hydrates from the dashboard list, and a transform/write failure there must not hide behind a healthy canonical key (#5300).

--- a/data/x-accounts.json
+++ b/data/x-accounts.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-18T00:00:00Z",
-  "note": "Product-managed curated public news-account list. Not user-configurable. Official X API only. Post text is R4.",
+  "updatedAt": "2026-08-21T06:30:00Z",
+  "note": "Product-managed curated public news-account list. Not user-configurable. Official X API only. Post text is R4. Every enabled account carries a numeric accountId verified against GET /2/users/by/username — handle renames must not fork identity, and an unverified handle silently degrades the feed (#6654).",
   "channels": {
     "full": [
       {
@@ -13,7 +13,8 @@
         "tier": 1,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "AP",
@@ -24,7 +25,8 @@
         "tier": 1,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "AFP",
@@ -35,7 +37,8 @@
         "tier": 1,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "BBCBreaking",
@@ -46,7 +49,8 @@
         "tier": 1,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "BBCWorld",
@@ -57,7 +61,8 @@
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "nytimes",
@@ -68,7 +73,8 @@
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "WSJ",
@@ -79,7 +85,8 @@
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "washingtonpost",
@@ -90,7 +97,8 @@
         "tier": 2,
         "enabled": true,
         "region": "us",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "CNN",
@@ -101,10 +109,11 @@
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "CNNBreaking",
+        "handle": "cnnbrk",
         "accountId": "428333",
         "label": "CNN Breaking",
         "sourceName": "CNN World",
@@ -112,7 +121,8 @@
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "guardian",
@@ -123,10 +133,11 @@
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "FinancialTimes",
+        "handle": "FT",
         "accountId": "18949452",
         "label": "Financial Times",
         "sourceName": "Financial Times",
@@ -134,18 +145,20 @@
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "TheEconomist",
-        "accountId": "7530052",
+        "accountId": "5988062",
         "label": "The Economist",
         "sourceName": "The Economist",
         "topic": "geopolitics",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "business",
@@ -156,559 +169,612 @@
         "tier": 1,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "dwnews",
-        "accountId": "19038704",
+        "accountId": "6134882",
         "label": "DW News",
         "sourceName": "DW News",
         "topic": "geopolitics",
         "tier": 2,
-        "enabled": true,
+        "enabled": false,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "disabledReason": "Account is protected; X returns Authorization Error for third-party timeline reads (verified 2026-08-21).",
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "France24_en",
-        "accountId": "19923239",
+        "accountId": "25049056",
         "label": "France 24",
         "sourceName": "France 24",
         "topic": "geopolitics",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "AJEnglish",
-        "accountId": "",
+        "accountId": "4970411",
         "label": "Al Jazeera English",
         "sourceName": "Al Jazeera",
         "topic": "middleeast",
         "tier": 2,
         "enabled": true,
         "region": "middleeast",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "AlArabiya_Eng",
-        "accountId": "",
+        "accountId": "22240612",
         "label": "Al Arabiya English",
         "sourceName": "Al Arabiya",
         "topic": "middleeast",
         "tier": 2,
         "enabled": true,
         "region": "middleeast",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "nhk_news",
-        "accountId": "",
+        "accountId": "204245399",
         "label": "NHK World",
         "sourceName": "NHK World",
         "topic": "geopolitics",
         "tier": 2,
         "enabled": true,
         "region": "asia",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "nikkei_asia",
-        "accountId": "",
+        "handle": "NikkeiAsia",
+        "accountId": "436429668",
         "label": "Nikkei Asia",
         "sourceName": "Nikkei Asia",
         "topic": "geopolitics",
         "tier": 2,
         "enabled": true,
         "region": "asia",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "KyivIndependent",
-        "accountId": "",
+        "accountId": "1462548977367359490",
         "label": "Kyiv Independent",
         "sourceName": "Kyiv Independent",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "ukraine",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "Ukrinform_UA",
-        "accountId": "",
+        "handle": "Ukrinform_News",
+        "accountId": "3342536589",
         "label": "Ukrinform",
         "sourceName": "Ukrinform",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "ukraine",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "Liveuamap",
-        "accountId": "472286199",
+        "accountId": "2388075212",
         "label": "LiveUAMap",
         "sourceName": "LiveUAMap",
         "topic": "breaking",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "BNONews",
-        "accountId": "",
+        "accountId": "189305014",
         "label": "BNO News",
         "sourceName": "BNO News",
         "topic": "breaking",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "TimesofIsrael",
-        "accountId": "",
+        "accountId": "432557320",
         "label": "Times of Israel",
         "sourceName": "Times of Israel",
         "topic": "middleeast",
         "tier": 2,
         "enabled": true,
         "region": "middleeast",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "haaretzcom",
-        "accountId": "",
+        "accountId": "24506246",
         "label": "Haaretz",
         "sourceName": "Haaretz",
         "topic": "middleeast",
         "tier": 2,
         "enabled": true,
         "region": "middleeast",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "Jerusalem_Post",
-        "accountId": "",
+        "accountId": "19489239",
         "label": "Jerusalem Post",
         "sourceName": "Jerusalem Post",
         "topic": "middleeast",
         "tier": 2,
         "enabled": true,
         "region": "middleeast",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "IDF",
-        "accountId": "",
+        "accountId": "18576537",
         "label": "IDF",
         "sourceName": "IDF",
         "topic": "conflict",
         "tier": 3,
         "enabled": true,
         "region": "middleeast",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "StateDept",
-        "accountId": "",
+        "accountId": "9624742",
         "label": "US State Department",
         "sourceName": "State Dept",
         "topic": "geopolitics",
         "tier": 1,
         "enabled": true,
         "region": "us",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "PentagonPresSec",
-        "accountId": "",
-        "label": "Pentagon Press Secretary",
-        "sourceName": "Pentagon",
+        "handle": "DeptofWar",
+        "accountId": "66369181",
+        "label": "Department of War",
+        "sourceName": "Department of War",
         "topic": "conflict",
         "tier": 1,
         "enabled": true,
         "region": "us",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "CENTCOM",
-        "accountId": "",
+        "accountId": "25159286",
         "label": "US CENTCOM",
         "sourceName": "US CENTCOM",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "middleeast",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "DefenceHQ",
-        "accountId": "",
+        "accountId": "16133530",
         "label": "UK Ministry of Defence",
         "sourceName": "UK MOD",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "europe",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "NATO",
-        "accountId": "",
+        "accountId": "83795099",
         "label": "NATO",
         "sourceName": "NATO",
         "topic": "geopolitics",
         "tier": 2,
         "enabled": true,
         "region": "europe",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "UN",
-        "accountId": "",
+        "accountId": "14159148",
         "label": "United Nations",
         "sourceName": "UN News",
         "topic": "geopolitics",
         "tier": 1,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "iaeaorg",
-        "accountId": "",
+        "accountId": "19386622",
         "label": "IAEA",
         "sourceName": "IAEA",
         "topic": "geopolitics",
         "tier": 1,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "TheStudyofWar",
-        "accountId": "",
+        "accountId": "71298686",
         "label": "Institute for the Study of War",
         "sourceName": "ISW",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "TheWarZone",
-        "accountId": "",
+        "handle": "thewarzonewire",
+        "accountId": "723234222945767424",
         "label": "The War Zone",
         "sourceName": "The War Zone",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "DefenseOne",
-        "accountId": "",
+        "accountId": "1433356862",
         "label": "Defense One",
         "sourceName": "Defense One",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "BreakingDefense",
-        "accountId": "",
+        "accountId": "236221098",
         "label": "Breaking Defense",
         "sourceName": "Breaking Defense",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "JanesINTEL",
-        "accountId": "",
+        "accountId": "70529694",
         "label": "Janes",
         "sourceName": "Janes",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "OSINTdefender",
-        "accountId": "",
+        "accountId": "1496286557053071361",
         "label": "OSINTdefender",
         "sourceName": "OSINTdefender",
         "topic": "conflict",
         "tier": 2,
-        "enabled": true,
+        "enabled": false,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "disabledReason": "Account is protected; X returns Authorization Error for third-party timeline reads (verified 2026-08-21).",
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "IntelCrab",
-        "accountId": "",
+        "accountId": "3331851939",
         "label": "Intel Crab",
         "sourceName": "Intel Crab",
         "topic": "osint",
         "tier": 3,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "Osinttechnical",
-        "accountId": "",
+        "accountId": "1188329290162675713",
         "label": "OSINT Technical",
         "sourceName": "OSINT Technical",
         "topic": "osint",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "AuroraIntel",
-        "accountId": "",
+        "accountId": "1050478262009262080",
         "label": "Aurora Intel",
         "sourceName": "Aurora Intel",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "ClashReport",
-        "accountId": "",
+        "handle": "clashreport",
+        "accountId": "3247652319",
         "label": "Clash Report",
         "sourceName": "Clash Report",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "Deepstate_UA",
-        "accountId": "",
+        "accountId": "1518640043786739713",
         "label": "DeepState",
         "sourceName": "DeepState",
         "topic": "conflict",
         "tier": 2,
         "enabled": true,
         "region": "ukraine",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "IranIntl_En",
-        "accountId": "",
+        "accountId": "1028770525160660993",
         "label": "Iran International EN",
         "sourceName": "Iran International",
         "topic": "geopolitics",
         "tier": 2,
         "enabled": true,
         "region": "iran",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "IranIntl",
-        "accountId": "",
+        "accountId": "728252911675944961",
         "label": "Iran International",
         "sourceName": "Iran International",
         "topic": "geopolitics",
         "tier": 2,
         "enabled": true,
         "region": "iran",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "MeduzaEn",
-        "accountId": "",
+        "handle": "meduza_en",
+        "accountId": "3004163369",
         "label": "Meduza",
         "sourceName": "Meduza",
         "topic": "geopolitics",
         "tier": 2,
         "enabled": true,
         "region": "russia",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "MoscowTimes",
-        "accountId": "",
+        "accountId": "19527964",
         "label": "Moscow Times",
         "sourceName": "Moscow Times",
         "topic": "geopolitics",
         "tier": 2,
         "enabled": true,
         "region": "russia",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "tass_agency",
-        "accountId": "",
+        "accountId": "285532415",
         "label": "TASS",
         "sourceName": "TASS",
         "topic": "geopolitics",
         "tier": 3,
         "enabled": true,
         "region": "russia",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "RT_com",
-        "accountId": "",
+        "accountId": "64643056",
         "label": "RT",
         "sourceName": "RT",
         "topic": "geopolitics",
         "tier": 3,
         "enabled": true,
         "region": "russia",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "CGTNOfficial",
-        "accountId": "",
+        "accountId": "1115874631",
         "label": "CGTN",
         "sourceName": "CGTN",
         "topic": "geopolitics",
         "tier": 3,
         "enabled": true,
         "region": "china",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "XinhuaChinese",
-        "accountId": "",
+        "accountId": "3319804777",
         "label": "Xinhua",
         "sourceName": "Xinhua",
         "topic": "geopolitics",
         "tier": 3,
         "enabled": true,
         "region": "china",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "PressTV",
-        "accountId": "",
+        "accountId": "192547775",
         "label": "Press TV",
         "sourceName": "Press TV",
         "topic": "middleeast",
         "tier": 3,
         "enabled": true,
         "region": "iran",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "IRNA_English",
-        "accountId": "",
+        "handle": "IrnaEnglish",
+        "accountId": "813279088865644544",
         "label": "IRNA English",
         "sourceName": "IRNA",
         "topic": "middleeast",
         "tier": 3,
         "enabled": true,
         "region": "iran",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       }
     ],
     "tech": [
       {
         "handle": "TheHackersNews",
-        "accountId": "",
+        "accountId": "209811713",
         "label": "The Hacker News",
         "sourceName": "The Hacker News",
         "topic": "cyber",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 10
+        "maxMessages": 10,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "vxunderground",
-        "accountId": "",
+        "accountId": "1158139840866791424",
         "label": "vx-underground",
         "sourceName": "vx-underground",
         "topic": "cyber",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "CISACyber",
-        "accountId": "",
+        "accountId": "18066440",
         "label": "CISA",
         "sourceName": "CISA",
         "topic": "cyber",
         "tier": 1,
         "enabled": true,
         "region": "us",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "briankrebs",
-        "accountId": "",
+        "accountId": "22790881",
         "label": "Krebs on Security",
         "sourceName": "Krebs Security",
         "topic": "cyber",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "kaspersky",
-        "accountId": "",
+        "accountId": "13904152",
         "label": "Kaspersky",
         "sourceName": "Kaspersky",
         "topic": "cyber",
         "tier": 3,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "CrowdStrike",
-        "accountId": "",
+        "accountId": "368621253",
         "label": "CrowdStrike",
         "sourceName": "CrowdStrike",
         "topic": "cyber",
         "tier": 3,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "DarkWebInformer",
-        "accountId": "",
+        "accountId": "1697387633247150081",
         "label": "Dark Web Informer",
         "sourceName": "Dark Web Informer",
         "topic": "cyber",
         "tier": 3,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       },
       {
         "handle": "thecyberwire",
-        "accountId": "",
+        "accountId": "851460667",
         "label": "The CyberWire",
         "sourceName": "The CyberWire",
         "topic": "cyber",
         "tier": 2,
         "enabled": true,
         "region": "global",
-        "maxMessages": 8
+        "maxMessages": 8,
+        "verifiedAt": "2026-08-21"
       }
     ],
     "finance": []

--- a/data/x-accounts.json
+++ b/data/x-accounts.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updatedAt": "2026-08-21T06:30:00Z",
+  "updatedAt": "2026-08-21T07:15:00Z",
   "note": "Product-managed curated public news-account list. Not user-configurable. Official X API only. Post text is R4. Every enabled account carries a numeric accountId verified against GET /2/users/by/username — handle renames must not fork identity, and an unverified handle silently degrades the feed (#6654).",
   "channels": {
     "full": [
@@ -173,16 +173,15 @@
         "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "dwnews",
-        "accountId": "6134882",
+        "handle": "DeutscheWelle",
+        "accountId": "16449615",
         "label": "DW News",
         "sourceName": "DW News",
         "topic": "geopolitics",
         "tier": 2,
-        "enabled": false,
+        "enabled": true,
         "region": "global",
         "maxMessages": 10,
-        "disabledReason": "Account is protected; X returns Authorization Error for third-party timeline reads (verified 2026-08-21).",
         "verifiedAt": "2026-08-21"
       },
       {
@@ -486,16 +485,15 @@
         "verifiedAt": "2026-08-21"
       },
       {
-        "handle": "OSINTdefender",
-        "accountId": "1496286557053071361",
+        "handle": "sentdefender",
+        "accountId": "1457867047334031360",
         "label": "OSINTdefender",
         "sourceName": "OSINTdefender",
         "topic": "conflict",
         "tier": 2,
-        "enabled": false,
+        "enabled": true,
         "region": "global",
         "maxMessages": 10,
-        "disabledReason": "Account is protected; X returns Authorization Error for third-party timeline reads (verified 2026-08-21).",
         "verifiedAt": "2026-08-21"
       },
       {

--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -879,7 +879,7 @@ This generated inventory covers **749 active source hosts** representing **743 a
 | www.zdnet.com (www.zdnet.com) | feed+structured — src/config/feeds.ts, src/config/variants/tech.ts |
 | www.zoomstatus.com (www.zoomstatus.com) | operational-status — server/worldmonitor/infrastructure/v1/list-service-statuses.ts |
 | wwwnc.cdc.gov (wwwnc.cdc.gov) | structured — scripts/seed-security-advisories.mjs |
-| X API (api.x.com) | structured — scripts/lib/company-monitoring-x-provider.mjs, scripts/lib/x-news-accounts.cjs |
+| X API (api.x.com) | structured — scripts/lib/company-monitoring-x-provider.mjs, scripts/lib/x-news-accounts.cjs, scripts/verify-x-accounts.mjs |
 | x.com (x.com) | structured — server/worldmonitor/leads/v1/register-interest.ts |
 | xinhuanet.com (xinhuanet.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | yandex.com (yandex.com) | structured — scripts/seo-indexnow-submit.mjs |

--- a/scripts/lib/x-news-accounts.cjs
+++ b/scripts/lib/x-news-accounts.cjs
@@ -525,6 +525,27 @@ function recordAuthFailure(nextState, status, context, now) {
   nextState.lastError = `X auth failed (HTTP ${status}) ${context}: check X_BEARER_TOKEN — deferring polls for ${Math.round(AUTH_FAILURE_BACKOFF_MS / 60000)}m`;
 }
 
+/**
+ * X reports an unreadable ACCOUNT with HTTP 200 and a top-level `errors` array,
+ * not a 4xx: a protected account yields `Authorization Error`, a renamed or
+ * deleted one `Not Found Error`, a suspended one `Forbidden`. Only the payload
+ * distinguishes them from a genuinely quiet timeline, so a caller that trusts
+ * `response.ok` reads all three as "polled successfully, no new posts".
+ *
+ * A resource-level error alongside usable `data` is a different thing — the
+ * deleted-post tombstone path relies on exactly that shape — so this reports a
+ * fault only when the payload carries no data at all.
+ */
+function describeResourceError(body) {
+  if (Array.isArray(body?.data) && body.data.length > 0) return null;
+  if (body?.data && !Array.isArray(body.data)) return null;
+  const error = (Array.isArray(body?.errors) ? body.errors : [])[0];
+  if (!error) return null;
+  const title = typeof error.title === 'string' && error.title ? error.title : 'API error';
+  const detail = typeof error.detail === 'string' && error.detail ? `: ${error.detail}` : '';
+  return `${title}${detail}`;
+}
+
 function collectDeletedTweetIds(body, requestedIds) {
   const found = new Set((Array.isArray(body?.data) ? body.data : []).map((row) => String(row.id)));
   const errorsById = new Map();
@@ -679,7 +700,13 @@ async function pollXFeed({
         }
         if (!response.ok || !body?.data?.id) {
           nextState.accountsFailed += 1;
-          nextState.lastError = `user lookup @${account.handle} failed: HTTP ${response.status}`;
+          // A missing handle also answers 200-with-errors, so the status alone
+          // reads as "HTTP 200" and tells the operator nothing about which
+          // handle died or why. Prefer the upstream title/detail when present.
+          const lookupError = describeResourceError(body);
+          nextState.lastError = lookupError
+            ? `user lookup @${account.handle} failed: ${lookupError}`
+            : `user lookup @${account.handle} failed: HTTP ${response.status}`;
           await sleep(staggerMs, wait);
           continue;
         }
@@ -728,6 +755,16 @@ async function pollXFeed({
         if (!response.ok) {
           nextState.accountsFailed += 1;
           nextState.lastError = `timeline @${account.handle} failed: HTTP ${response.status}`;
+          pageFailed = true;
+          break;
+        }
+        // A 200 carrying only `errors` means the account itself is unreadable
+        // (protected / suspended / renamed away). Falling through would record
+        // an empty-but-complete window and retire the account silently.
+        const resourceError = describeResourceError(body);
+        if (resourceError) {
+          nextState.accountsFailed += 1;
+          nextState.lastError = `timeline @${account.handle} unreadable: ${resourceError}`;
           pageFailed = true;
           break;
         }

--- a/scripts/seed-freshness-baseline.json
+++ b/scripts/seed-freshness-baseline.json
@@ -35,18 +35,6 @@
         "activatedAt": "2026-08-20T10:00:00.000Z",
         "firstScheduledRunAt": "2026-08-21T00:00:00.000Z"
       }
-    },
-    {
-      "name": "xFeed",
-      "status": "EMPTY",
-      "issue": 6654,
-      "reason": "New ais-relay producer for curated X news-account monitoring. seed-meta:intelligence:x-feed:v1 cannot exist until X_BEARER_TOKEN is copied onto the ais-relay Railway service (it currently lives only on company-monitoring-worker) and the 15-minute poll loop publishes once. EMPTY after that first scheduled poll is a missing secret or a dead loop, not a deploy window.",
-      "expiresAt": "2026-08-21T13:15:00.000Z",
-      "cutover": {
-        "probeKey": "seed-meta:intelligence:x-feed:v1",
-        "activatedAt": "2026-08-20T13:15:00.000Z",
-        "firstScheduledRunAt": "2026-08-21T13:15:00.000Z"
-      }
     }
   ]
 }

--- a/scripts/shared/x-account-source-tiers.json
+++ b/scripts/shared/x-account-source-tiers.json
@@ -7,6 +7,7 @@
   "CrowdStrike": 3,
   "Dark Web Informer": 3,
   "DeepState": 3,
+  "Department of War": 1,
   "Haaretz": 2,
   "IDF": 1,
   "IRNA": 3,

--- a/scripts/verify-x-accounts.mjs
+++ b/scripts/verify-x-accounts.mjs
@@ -63,8 +63,12 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 function resourceError(body) {
   if (body?.data) return null;
   const error = (Array.isArray(body?.errors) ? body.errors : [])[0];
-  if (!error) return 'empty response with no data and no errors';
-  return `${error.title || 'API error'}${error.detail ? `: ${error.detail}` : ''}`;
+  if (error) return `${error.title || 'API error'}${error.detail ? `: ${error.detail}` : ''}`;
+  // A quiet account answers `{"meta":{"result_count":0}}` — no `data` key and
+  // no `errors` key (verified against the live API). Reporting that as a fault
+  // would flag every account that simply had nothing to say in the window.
+  if (typeof body?.meta?.result_count === 'number') return null;
+  return 'empty response with no data, no errors, and no result_count';
 }
 
 async function apiGet(path) {

--- a/scripts/verify-x-accounts.mjs
+++ b/scripts/verify-x-accounts.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Verify data/x-accounts.json against the official X API (#6654 follow-up).
+ *
+ * The registry was originally curated without API access. Six handles pointed
+ * at accounts that do not exist, one at a suspended account, and four pinned
+ * accountIds pointed at unrelated private individuals — whose posts would have
+ * published into the intelligence feed as trusted tier-2 wire services and
+ * reached the alert path. Nothing in CI could see it: the poll loop reported
+ * only "6 errors" with no handle and no reason, and X answers an unreadable
+ * account with HTTP 200 plus an `errors` body rather than a 4xx.
+ *
+ * Offline invariants (id present, well-formed, unique) are asserted by
+ * tests/x-news-accounts.test.mjs. Only the API can prove an id still belongs to
+ * the publisher we think it does, so that check lives here, out of CI, and is
+ * run deliberately when the registry changes.
+ *
+ * Usage:
+ *   X_BEARER_TOKEN=... node scripts/verify-x-accounts.mjs [--json] [--include-disabled]
+ *
+ * Cost: one User read per account (~$0.010, 24h-deduped). It does NOT read
+ * timelines by default, so it does not bill post reads; pass --timelines to
+ * additionally prove each timeline is actually readable.
+ *
+ * Exit 0 = every checked account verified. Exit 1 = at least one mismatch.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REGISTRY = join(__dirname, '../data/x-accounts.json');
+const X_API_ORIGIN = 'https://api.x.com';
+
+const args = new Set(process.argv.slice(2));
+const asJson = args.has('--json');
+const includeDisabled = args.has('--include-disabled');
+const checkTimelines = args.has('--timelines');
+
+const token = process.env.X_BEARER_TOKEN;
+if (!token) {
+  console.error('X_BEARER_TOKEN is not set — cannot verify against the official API.');
+  process.exit(2);
+}
+
+const registry = JSON.parse(readFileSync(REGISTRY, 'utf8'));
+const accounts = [];
+for (const [group, arr] of Object.entries(registry.channels || {})) {
+  for (const account of arr) {
+    if (!account.enabled && !includeDisabled) continue;
+    accounts.push({ ...account, group });
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * X reports an unreadable resource with HTTP 200 and a top-level `errors`
+ * array. Treating `response.ok` as success is precisely the bug this script
+ * exists to catch, so read the payload, not the status.
+ */
+function resourceError(body) {
+  if (body?.data) return null;
+  const error = (Array.isArray(body?.errors) ? body.errors : [])[0];
+  if (!error) return 'empty response with no data and no errors';
+  return `${error.title || 'API error'}${error.detail ? `: ${error.detail}` : ''}`;
+}
+
+async function apiGet(path) {
+  const response = await fetch(new URL(path, X_API_ORIGIN), {
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (response.status === 429) {
+    const reset = Number(response.headers.get('x-rate-limit-reset') || 0) * 1000;
+    const waitMs = Math.max(5_000, reset - Date.now());
+    process.stderr.write(`rate limited; waiting ${Math.round(waitMs / 1000)}s\n`);
+    await sleep(waitMs);
+    return apiGet(path);
+  }
+  let body = null;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  return { status: response.status, body };
+}
+
+const findings = [];
+for (const account of accounts) {
+  const handle = String(account.handle || '').replace(/^@/, '');
+  const label = `@${handle}`;
+
+  if (!account.accountId) {
+    findings.push({ handle, level: 'error', kind: 'missing-id', message: 'no accountId pinned' });
+    continue;
+  }
+
+  // Resolve BOTH directions: the id proves who we actually poll, the handle
+  // proves the registry still names the same account. A rename breaks only the
+  // handle; a bad copy-paste breaks only the id.
+  const { status, body } = await apiGet(`/2/users/${account.accountId}?user.fields=id,name,username,protected`);
+  const failure = resourceError(body);
+  if (failure) {
+    findings.push({ handle, level: 'error', kind: 'unresolvable-id', message: `id ${account.accountId} — ${failure} (HTTP ${status})` });
+    await sleep(400);
+    continue;
+  }
+
+  const actual = body.data;
+  if (String(actual.username).toLowerCase() !== handle.toLowerCase()) {
+    findings.push({
+      handle,
+      level: 'error',
+      kind: 'handle-mismatch',
+      message: `id ${account.accountId} is @${actual.username} (${actual.name}), not ${label}`,
+    });
+  }
+  if (actual.protected) {
+    findings.push({
+      handle,
+      level: 'error',
+      kind: 'protected',
+      message: `${label} is protected — X refuses its timeline to a third-party app; disable it or coverage never completes`,
+    });
+  }
+
+  if (checkTimelines && !actual.protected) {
+    const timeline = await apiGet(`/2/users/${account.accountId}/tweets?max_results=5&tweet.fields=id`);
+    const timelineFailure = resourceError(timeline.body);
+    if (timelineFailure) {
+      findings.push({ handle, level: 'error', kind: 'unreadable-timeline', message: timelineFailure });
+    }
+    await sleep(400);
+  }
+
+  await sleep(400);
+}
+
+if (asJson) {
+  console.log(JSON.stringify({ checked: accounts.length, findings }, null, 2));
+} else {
+  console.log(`checked ${accounts.length} account(s) against ${X_API_ORIGIN}`);
+  if (findings.length === 0) {
+    console.log('all verified — every accountId resolves to the handle the registry names');
+  } else {
+    for (const f of findings) {
+      console.log(`  ${f.level.toUpperCase()} @${f.handle} [${f.kind}] ${f.message}`);
+    }
+    console.log(`\n${findings.length} finding(s). Update data/x-accounts.json and bump each entry's verifiedAt.`);
+  }
+}
+
+process.exit(findings.length === 0 ? 0 : 1);

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -1419,6 +1419,9 @@
         },
         {
           "path": "scripts/lib/x-news-accounts.cjs"
+        },
+        {
+          "path": "scripts/verify-x-accounts.mjs"
         }
       ]
     },

--- a/shared/source-provenance-declarations.ts
+++ b/shared/source-provenance-declarations.ts
@@ -465,7 +465,7 @@ export const CONFIGURED_SOURCE_PROVENANCE_DECLARATIONS: Readonly<
   "Paul Graham Essays": { risk: 'unknown', type: 'unknown' },
   "PBoC Watch": { risk: 'unknown', type: 'unknown' },
   "PBS NewsHour": { risk: 'unknown', type: 'unknown' },
-  "Pentagon": { risk: 'reviewed', type: 'reviewed' },
+  "Pentagon": { risk: 'unknown', type: 'reviewed' },
   "Pipelines & Chokepoints": { risk: 'unknown', type: 'unknown' },
   "PitchBook News": { risk: 'unknown', type: 'unknown' },
   "Pivot Podcast": { risk: 'unknown', type: 'unknown' },

--- a/shared/x-account-source-tiers.json
+++ b/shared/x-account-source-tiers.json
@@ -7,6 +7,7 @@
   "CrowdStrike": 3,
   "Dark Web Informer": 3,
   "DeepState": 3,
+  "Department of War": 1,
   "Haaretz": 2,
   "IDF": 1,
   "IRNA": 3,

--- a/shared/x-account-trust.ts
+++ b/shared/x-account-trust.ts
@@ -308,14 +308,21 @@ export const X_ACCOUNT_TRUST: readonly XAccountTrustEntry[] = [
     note: 'Military OSINT aggregator; treat as a lead',
   },
   {
-    sourceName: 'Pentagon',
+    // Renamed from 'Pentagon' (#6654 follow-up). @PentagonPresSec no longer
+    // exists: the department rebranded and the account is now @DeptofWar.
+    // Beware the neighbours — @WarDepartment, @SecretaryOfWar and @thePentagon
+    // are unrelated personal accounts with three-figure follower counts, so
+    // only the id verified against the API belongs in a tier-1 slot.
+    sourceName: 'Department of War',
     tier: 1,
     type: 'gov',
     risk: 'high',
     stateAffiliated: 'USA',
-    note: 'Official US Department of Defense publisher; treat statements as government claims',
-    reuseType: true,
-    reuseTier: true,
+    note: 'Official US Department of War publisher; treat statements as government claims',
+    // No reuse flags: 'Pentagon' could borrow the existing defense.gov RSS
+    // masthead's type/risk, but 'Department of War' is a new public name with
+    // no masthead behind it, so this entry must emit its own keys or the
+    // account falls through to the tier-4 default and is dropped from alerts.
   },
   {
     sourceName: 'Press TV',

--- a/tests/x-account-trust.test.mjs
+++ b/tests/x-account-trust.test.mjs
@@ -119,11 +119,19 @@ describe('X news-account public trust registries (#6654)', () => {
     assert.match(healthSrc, /issue: 6654/);
     assert.match(relaySrc, /intelligence:x-feed:v1/);
     assert.match(relaySrc, /seed-meta:intelligence:x-feed:v1/);
+    // The EMPTY acknowledgement was scoped to the deploy window before the
+    // first ais-relay poll. That poll has happened — production has served
+    // seed-meta:intelligence:x-feed:v1 since generation 1 — so the entry is
+    // spent and is removed rather than left to lapse. An ack only suppresses
+    // an exact name:status match, so it never covered the SEED_ERROR the
+    // unpollable accounts were actually producing; keeping it past its window
+    // would have added an expired entry that reds the scheduled monitor while
+    // still passing the PR gate.
     const baseline = JSON.parse(readFileSync(join(__dirname, '../scripts/seed-freshness-baseline.json'), 'utf8'));
-    const ack = baseline.acknowledged.find((row) => row.name === 'xFeed');
-    assert.ok(ack, 'xFeed needs an expiring EMPTY acknowledgement until the first ais-relay poll');
-    assert.equal(ack.status, 'EMPTY');
-    assert.equal(ack.issue, 6654);
-    assert.equal(ack.cutover.probeKey, 'seed-meta:intelligence:x-feed:v1');
+    assert.equal(
+      baseline.acknowledged.find((row) => row.name === 'xFeed'),
+      undefined,
+      'the xFeed cutover ack is spent — the producer is live, so EMPTY is now a real fault',
+    );
   });
 });

--- a/tests/x-account-trust.test.mjs
+++ b/tests/x-account-trust.test.mjs
@@ -116,9 +116,19 @@ describe('X news-account public trust registries (#6654)', () => {
   it('registers the ais-relay health probe and seed-meta key', () => {
     assert.match(healthSrc, /xFeed:\s+'intelligence:x-feed:v1'/);
     assert.match(healthSrc, /key: 'seed-meta:intelligence:x-feed:v1'/);
-    assert.match(healthSrc, /issue: 6654/);
     assert.match(relaySrc, /intelligence:x-feed:v1/);
     assert.match(relaySrc, /seed-meta:intelligence:x-feed:v1/);
+    // The probe's `cutover` declaration is retired along with the baseline ack
+    // below: the two are halves of one statement ("this key is allowed to be
+    // absent while the producer is brought up"), and leaving the health.js half
+    // behind left the config asserting a deploy window that had closed, under a
+    // comment claiming X_BEARER_TOKEN was still unprovisioned. It is on
+    // ais-relay and the key is served, so both halves go.
+    assert.doesNotMatch(
+      healthSrc,
+      /xFeed:[^\n]*cutover/,
+      'the xFeed cutover is complete — a lingering declaration re-opens a closed deploy window',
+    );
     // The EMPTY acknowledgement was scoped to the deploy window before the
     // first ais-relay poll. That poll has happened — production has served
     // seed-meta:intelligence:x-feed:v1 since generation 1 — so the entry is

--- a/tests/x-news-accounts.test.mjs
+++ b/tests/x-news-accounts.test.mjs
@@ -20,19 +20,30 @@ describe('data/x-accounts.json registry (#6654)', () => {
     assert.ok(Array.isArray(registry.channels.finance));
   });
 
-  it('starts with about 64 enabled accounts, matching the Telegram analogue', () => {
+  it('stays in the Telegram analogue ballpark of enabled accounts', () => {
+    // 62 = the 64 originally curated, minus @dwnews and @OSINTdefender, which
+    // are `protected`: X refuses their timelines to a third-party app, so
+    // leaving them enabled held coverage below 100% and pinned health at
+    // SEED_ERROR permanently. Re-enable only after re-probing the API.
     const enabled = xNews.countEnabledAccounts(registry);
-    assert.equal(enabled, 64, `expected 64 enabled accounts, got ${enabled}`);
+    assert.equal(enabled, 62, `expected 62 enabled accounts, got ${enabled}`);
     const all = xNews.loadXAccounts(registry);
     const full = xNews.loadXAccounts(registry, { set: 'full' });
     const tech = xNews.loadXAccounts(registry, { set: 'tech' });
-    assert.equal(all.length, 64);
-    assert.equal(new Set(all.map((account) => account.handle.toLowerCase())).size, 64);
-    assert.equal(full.length, 56);
+    assert.equal(all.length, 62);
+    assert.equal(new Set(all.map((account) => account.handle.toLowerCase())).size, 62);
+    assert.equal(full.length, 54);
     assert.equal(tech.length, 8);
   });
 
-  it('stores numeric accountId when known and always has handle/label/topic/tier', () => {
+  it('pins a verified numeric accountId on every enabled account', () => {
+    // This assertion used to read `if (account.accountId)`, which is vacuous
+    // for an account that has none — and 41 of 64 shipped without one. The
+    // registry was curated with no API access, so six handles pointed at
+    // accounts that do not exist and four pinned ids pointed at unrelated
+    // private individuals whose posts would have published as trusted tier-2
+    // wire services. An id is the identity the poll loop actually uses, so it
+    // is required, not optional (#6654 follow-up).
     const accounts = [
       ...xNews.loadXAccounts(registry, { set: 'full' }),
       ...xNews.loadXAccounts(registry, { set: 'tech' }),
@@ -44,11 +55,40 @@ describe('data/x-accounts.json registry (#6654)', () => {
       assert.ok(account.topic, 'topic required');
       assert.ok(Number.isFinite(account.tier) && account.tier >= 1 && account.tier <= 3, `${account.handle} tier`);
       assert.equal(account.enabled, true);
-      if (account.accountId) {
-        assert.match(account.accountId, /^[1-9]\d{0,18}$/);
-      }
+      assert.ok(account.accountId, `@${account.handle} must ship a verified accountId`);
+      assert.match(account.accountId, /^[1-9]\d{0,18}$/, `@${account.handle} accountId shape`);
     }
     assert.equal(accounts.find((a) => a.handle === 'Reuters')?.accountId, '1652541');
+  });
+
+  it('never points two accounts at the same X identity', () => {
+    // A copy-paste during curation is how @TheEconomist ended up on another
+    // account's id. Duplicate ids would silently double-count one timeline
+    // while the shadowed source went dark.
+    const accounts = [
+      ...xNews.loadXAccounts(registry, { set: 'full' }),
+      ...xNews.loadXAccounts(registry, { set: 'tech' }),
+    ];
+    const ids = accounts.map((a) => a.accountId);
+    assert.equal(new Set(ids).size, ids.length, 'duplicate accountId in the registry');
+    // sourceName is deliberately NOT unique: a masthead can run several
+    // accounts that share one trust identity (@BBCBreaking + @BBCWorld ->
+    // 'BBC World', @CNN + @cnnbrk -> 'CNN World', both Iran International
+    // feeds). Trust is keyed on the publisher; only the X identity is 1:1.
+    const handles = accounts.map((a) => a.handle.toLowerCase());
+    assert.equal(new Set(handles).size, handles.length, 'duplicate handle in the registry');
+  });
+
+  it('records when each enabled account was last verified against the API', () => {
+    for (const account of xNews.loadXAccounts(registry)) {
+      const raw = [...registry.channels.full, ...registry.channels.tech]
+        .find((a) => a.handle === account.handle);
+      assert.match(
+        String(raw?.verifiedAt || ''),
+        /^\d{4}-\d{2}-\d{2}$/,
+        `@${account.handle} needs a verifiedAt date (run scripts/verify-x-accounts.mjs)`,
+      );
+    }
   });
 });
 
@@ -1117,5 +1157,104 @@ describe('versioned X feed snapshot', () => {
     const empty = xNews.hydrateXFeedSnapshot({ version: xNews.X_FEED_SNAPSHOT_VERSION, items: [] });
     assert.ok(empty);
     assert.equal(empty.items.length, 0);
+  });
+});
+
+// X answers an unreadable account with HTTP 200 and an `errors` array rather
+// than a 4xx — observed live against @OSINTdefender and @dwnews, both of which
+// are `protected`. The timeline loop only tested `!response.ok`, so a 200 fell
+// through to `tweets = []`, found no `next_token`, and recorded a COMPLETE
+// window: a protected, suspended, or deleted account counted as a healthy
+// empty poll forever, with no error and nothing for an operator to see. Every
+// account now ships a pinned accountId, which makes this the only path that
+// runs for them, so it has to fail loudly.
+describe('unreadable-account timeline responses (#6654 follow-up)', () => {
+  const protectedAccount = {
+    handle: 'OSINTdefender',
+    accountId: '1496286557053071361',
+    label: 'OSINTdefender',
+    sourceName: 'OSINTdefender',
+    topic: 'osint',
+    tier: 2,
+    maxMessages: 10,
+  };
+
+  const authErrorBody = JSON.stringify({
+    errors: [{
+      value: '1496286557053071361',
+      detail: 'Sorry, you are not authorized to see the user with id: [1496286557053071361].',
+      title: 'Authorization Error',
+      type: 'https://api.twitter.com/2/problems/not-authorized-for-resource',
+    }],
+  });
+
+  const unreadable = async () => new Response(authErrorBody, {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  it('counts a 200-with-errors timeline as a failure, not a complete window', async () => {
+    const state = await xNews.pollXFeed({
+      accounts: [protectedAccount],
+      state: { cursorByAccountId: {}, accountIdByHandle: {}, items: [] },
+      bearerToken: 'test-token',
+      fetchImpl: unreadable,
+      now: () => Date.parse('2026-08-21T06:00:00.000Z'),
+      wait: async () => {},
+    });
+
+    assert.equal(state.accountsFailed, 1, 'an unreadable account must count as failed');
+    assert.equal(state.accountsPolled, 0, 'an unreadable account must not count as polled');
+  });
+
+  it('names the handle and the upstream reason so an operator can act', async () => {
+    const state = await xNews.pollXFeed({
+      accounts: [protectedAccount],
+      state: { cursorByAccountId: {}, accountIdByHandle: {}, items: [] },
+      bearerToken: 'test-token',
+      fetchImpl: unreadable,
+      now: () => Date.parse('2026-08-21T06:00:00.000Z'),
+      wait: async () => {},
+    });
+
+    assert.match(state.lastError || '', /OSINTdefender/, 'lastError must name the account');
+    assert.match(state.lastError || '', /Authorization Error/, 'lastError must carry the upstream title');
+    assert.doesNotMatch(state.lastError || '', /HTTP 200/, 'reporting an unreadable account as "HTTP 200" misleads the operator');
+  });
+
+  it('does not advance the cursor for an unreadable account', async () => {
+    const state = await xNews.pollXFeed({
+      accounts: [protectedAccount],
+      state: {
+        cursorByAccountId: { '1496286557053071361': '900' },
+        accountIdByHandle: {},
+        items: [],
+      },
+      bearerToken: 'test-token',
+      fetchImpl: unreadable,
+      now: () => Date.parse('2026-08-21T06:00:00.000Z'),
+      wait: async () => {},
+    });
+
+    assert.equal(state.cursorByAccountId['1496286557053071361'], '900', 'cursor must not move on a failed read');
+  });
+
+  // Positive control: without this the fix could be "call every empty page a
+  // failure", which would red the whole fleet on a quiet night.
+  it('still reports a genuinely empty timeline as a successful poll', async () => {
+    const state = await xNews.pollXFeed({
+      accounts: [{ ...protectedAccount, handle: 'Reuters', accountId: '1652541', sourceName: 'Reuters' }],
+      state: { cursorByAccountId: {}, accountIdByHandle: {}, items: [] },
+      bearerToken: 'test-token',
+      fetchImpl: async () => new Response(JSON.stringify({ data: [], meta: { result_count: 0 } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      now: () => Date.parse('2026-08-21T06:00:00.000Z'),
+      wait: async () => {},
+    });
+
+    assert.equal(state.accountsFailed, 0, 'a quiet account is not a broken one');
+    assert.equal(state.accountsPolled, 1);
   });
 });

--- a/tests/x-news-accounts.test.mjs
+++ b/tests/x-news-accounts.test.mjs
@@ -21,18 +21,21 @@ describe('data/x-accounts.json registry (#6654)', () => {
   });
 
   it('stays in the Telegram analogue ballpark of enabled accounts', () => {
-    // 62 = the 64 originally curated, minus @dwnews and @OSINTdefender, which
-    // are `protected`: X refuses their timelines to a third-party app, so
-    // leaving them enabled held coverage below 100% and pinned health at
-    // SEED_ERROR permanently. Re-enable only after re-probing the API.
+    // Back to 64. Both accounts first disabled here as `protected` were the
+    // registry naming the wrong account, not the publisher being unreachable:
+    // handle `OSINTdefender` is 'Depressed Defender' (626 followers, bio:
+    // "Backup Account of @sentdefender"), while the 2.5M-follower OSINT monitor
+    // is @sentdefender; and DW's English newsroom is public at @DeutscheWelle
+    // while @dwnews is locked. Disabling them dropped two real sources to
+    // silence a symptom. Verified against the API 2026-08-21.
     const enabled = xNews.countEnabledAccounts(registry);
-    assert.equal(enabled, 62, `expected 62 enabled accounts, got ${enabled}`);
+    assert.equal(enabled, 64, `expected 64 enabled accounts, got ${enabled}`);
     const all = xNews.loadXAccounts(registry);
     const full = xNews.loadXAccounts(registry, { set: 'full' });
     const tech = xNews.loadXAccounts(registry, { set: 'tech' });
-    assert.equal(all.length, 62);
-    assert.equal(new Set(all.map((account) => account.handle.toLowerCase())).size, 62);
-    assert.equal(full.length, 54);
+    assert.equal(all.length, 64);
+    assert.equal(new Set(all.map((account) => account.handle.toLowerCase())).size, 64);
+    assert.equal(full.length, 56);
     assert.equal(tech.length, 8);
   });
 
@@ -1162,7 +1165,10 @@ describe('versioned X feed snapshot', () => {
 
 // X answers an unreadable account with HTTP 200 and an `errors` array rather
 // than a 4xx — observed live against @OSINTdefender and @dwnews, both of which
-// are `protected`. The timeline loop only tested `!response.ok`, so a 200 fell
+// are `protected`. (Both are since replaced in the registry by the publishers'
+// real public accounts, @sentdefender and @DeutscheWelle — the ids below stay
+// as the verbatim live payloads that proved the bug.) The timeline loop only
+// tested `!response.ok`, so a 200 fell
 // through to `tweets = []`, found no `next_token`, and recorded a COMPLETE
 // window: a protected, suspended, or deleted account counted as a healthy
 // empty poll forever, with no error and nothing for an operator to see. Every

--- a/tests/x-news-accounts.test.mjs
+++ b/tests/x-news-accounts.test.mjs
@@ -1241,12 +1241,19 @@ describe('unreadable-account timeline responses (#6654 follow-up)', () => {
 
   // Positive control: without this the fix could be "call every empty page a
   // failure", which would red the whole fleet on a quiet night.
+  //
+  // The body is the VERBATIM live response for an account with nothing in the
+  // window (verified 2026-08-21 against @thePentagon over a 24h start_time):
+  // no `data` key at all and no `errors` key, only `meta.result_count`. An
+  // earlier draft of this test asserted `{ data: [], meta: {...} }`, a shape X
+  // never sends — it would have passed against a guard that wrongly keys on
+  // `data` being absent, which is the exact false positive being ruled out.
   it('still reports a genuinely empty timeline as a successful poll', async () => {
     const state = await xNews.pollXFeed({
       accounts: [{ ...protectedAccount, handle: 'Reuters', accountId: '1652541', sourceName: 'Reuters' }],
       state: { cursorByAccountId: {}, accountIdByHandle: {}, items: [] },
       bearerToken: 'test-token',
-      fetchImpl: async () => new Response(JSON.stringify({ data: [], meta: { result_count: 0 } }), {
+      fetchImpl: async () => new Response(JSON.stringify({ meta: { result_count: 0 } }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       }),
@@ -1256,5 +1263,46 @@ describe('unreadable-account timeline responses (#6654 follow-up)', () => {
 
     assert.equal(state.accountsFailed, 0, 'a quiet account is not a broken one');
     assert.equal(state.accountsPolled, 1);
+  });
+
+  // The deleted-post tombstone path depends on `data` and `errors` arriving
+  // TOGETHER from /2/tweets. Treating any payload carrying `errors` as a fault
+  // would misread that as a broken account, so prove the two stay
+  // distinguishable. Tombstone semantics themselves are asserted by the
+  // dedicated deletion test above; this one guards the failure accounting.
+  it('does not count a data-plus-errors tombstone response as an account failure', async () => {
+    const account = { ...protectedAccount, handle: 'Reuters', accountId: '1652541', sourceName: 'Reuters' };
+    const prior = xNews.normalizeXPost(
+      { id: '50', text: 'old post', created_at: '2026-08-20T09:00:00.000Z' },
+      account,
+    );
+    const state = await xNews.pollXFeed({
+      accounts: [account],
+      state: { cursorByAccountId: { 1652541: '100' }, accountIdByHandle: {}, items: [prior] },
+      bearerToken: 'test-token',
+      fetchImpl: async (url) => {
+        const { pathname } = new URL(url);
+        if (pathname === '/2/users/1652541/tweets') {
+          return new Response(JSON.stringify({
+            data: [{ id: '101', text: 'live post', created_at: '2026-08-21T05:00:00.000Z' }],
+          }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        }
+        return new Response(JSON.stringify({
+          data: [{ id: '101' }],
+          errors: [{
+            resource_id: '50',
+            value: '50',
+            title: 'Not Found Error',
+            detail: 'Could not find tweet with ids: [50].',
+          }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      },
+      now: () => Date.parse('2026-08-21T06:00:00.000Z'),
+      wait: async () => {},
+    });
+
+    assert.equal(state.accountsFailed, 0, 'a tombstone response is not an account failure');
+    assert.equal(state.accountsPolled, 1);
+    assert.equal(state.cursorByAccountId['1652541'], '101', 'the live page still advances the cursor');
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #6928 (merged as `b344b69f`). That PR curated `data/x-accounts.json` without API access and said so. Nothing checked the result, so production has been running since merge with **six of sixty-four accounts unpollable** and `xFeed` reporting `SEED_ERROR` — one of only two warnings across 280 health checks.

The `EMPTY` acknowledgement never covered it. The key is populated, `sourceState` is `degraded`, and `applyAcceptanceBaseline` suppresses only an exact `name:status` match — so this was blocking regardless, and its 13:15Z expiry was never going to resolve it.

Every handle and id below was probed against the official X API. Nothing here is inferred.

## The four that mattered most

Four pinned `accountId`s pointed at **unrelated private individuals**:

| Registry says | id resolves to | Tier |
|---|---|---|
| `@TheEconomist` | `@qupr` | 2 |
| `@dwnews` | `@asicign` — "Andy Sicignano" | 2 |
| `@France24_en` | `@Tunaisfun` — "Tuna Tardugno" | 2 |
| `@Liveuamap` | `@lindavicker` — "Linda. vicker" | 2 |

`pollXFeed` prefers the pinned id over the handle, so the handle was never consulted. All four are tier 2, which clears the tier-4 alert filter — a post by any of those four people would have published into the intelligence feed as a trusted wire service and reached alerting. None had posted, which is luck rather than design, and it is a privacy problem as much as an accuracy one.

## The six unpollable handles

Five do not exist, one is suspended:

| Registry | Status | Now |
|---|---|---|
| `@nikkei_asia` | not found | `@NikkeiAsia` |
| `@MeduzaEn` | not found | `@meduza_en` |
| `@IRNA_English` | not found | `@IrnaEnglish` |
| `@TheWarZone` | **suspended** | `@thewarzonewire` (TWZ) |
| `@Ukrinform_UA` | not found | `@Ukrinform_News` (Ukrinform-EN) |
| `@PentagonPresSec` (tier 1) | not found | `@DeptofWar` — rebrand |

The Pentagon slot is a rebrand: `@DeptofDefense` and `@SecDef` are both gone. Worth flagging that `@WarDepartment`, `@SecretaryOfWar` and `@thePentagon` all exist as **unrelated personal accounts with three-figure follower counts** — the same impostor trap that already put four private citizens in a tier-1/2 registry.

Two further ids were stale but benign — `@CNNBreaking` and `@FinancialTimes` are now `@cnnbrk` and `@FT`, the same entities renamed.

## A code bug this exposed

X reports an unreadable **account** with **HTTP 200 and an `errors` body**, not a 4xx. The timeline loop only tested `!response.ok`, so a 200 fell through to `tweets = []`, found no `next_token`, and recorded `completeWindow = true` — a protected, suspended, or deleted account counted as a healthy empty poll forever, with no error and nothing for an operator to see.

That is how `@OSINTdefender` hid: it ships a static id, so it skipped the lookup path (which does detect this) and went straight to the blind timeline path. Pinning ids for every account makes that the only path that runs, so it now fails loudly and names the upstream reason instead of reporting `HTTP 200`.

### Correction after review feedback

`@dwnews` and `@OSINTdefender` were initially disabled here as `protected`. That was wrong, and it is worth stating plainly: in both cases the registry was **naming the wrong account**, and disabling them silenced the symptom while dropping two real sources.

| Registry handle | Actually is | The publisher it means |
|---|---|---|
| `@OSINTdefender` (id ...071361) | "Depressed Defender", 626 followers, bio: *"Backup Account of @sentdefender"* | **`@sentdefender`** — "OSINTdefender", **2.49M followers**, public |
| `@dwnews` | genuinely locked | **`@DeutscheWelle`** — DW's public English newsroom, 181k, 20/20 recent posts in English |

The OSINTdefender case is the same wrong-entity class as `@TheEconomist`→`@qupr`, and it survived the first pass because **the handle-vs-id check cannot catch it** — handle and id genuinely agree, they just both name the backup rather than the publisher. Reach, and a bio saying whose backup it is, are the signals that do.

So the registry was swept again for that shape rather than fixing only the two that were noticed: all 64 pinned ids resolve to the handle the registry names, none of the remaining entries is protected, and no other entry pairs a low-follower account with a masthead label. `@thecyberwire` (39.8k) and `@Ukrinform_News` (10.8k) are small but genuinely who they claim to be.

Worth recording, since it is the same trap: `@dw_english` is "Tommy Sawyer" (276 followers) and `@twzmedia` is a 68-follower social-media freelancer. The plausible-looking neighbour is usually not the newsroom — which is also why `@thewarzonewire` (170k, *"10 years of being the best offense for the world of defense"*) is the right War Zone account.

**64 enabled** (56 full + 8 tech).

## Preventing recurrence

- Every enabled account now carries a verified `accountId` and a `verifiedAt` date — which is also what #6654 asked for: identity keyed on the numeric id so a rename cannot fork it.
- The test that should have caught this read `if (account.accountId)` — vacuous for the forty-one accounts that had none. It now **requires** one, plus uniqueness of ids and handles.
- `scripts/verify-x-accounts.mjs` resolves each pinned id back to its handle and compares both directions (a rename breaks only the handle; a bad copy-paste breaks only the id), flags `protected` accounts, and exits non-zero. It lives out of CI because only the API can settle it.

## Trust registry

`Pentagon` keeps its `source-tiers.json` entry — that name belongs to the defense.gov RSS feed, not this registry — and `Department of War` is added to the X overlay **without** reuse flags, since it has no masthead to borrow from. Regenerating the provenance declarations drops `Pentagon` to `risk: unknown`, restoring the pre-#6928 state: that feed was never reviewed on its own, it was borrowing a profile from an X account that never resolved.

## Self-review caught one in the fix itself

The verifier's `resourceError` returned early only on `body.data`, so a payload with neither `data` nor `errors` fell through to "empty response". That is exactly what X sends for a quiet account — verified live against `@thePentagon` over a 24h `start_time`, which answers a bare `{"meta":{"result_count":0}}`. Under `--timelines` every quiet account would have been flagged unreadable.

The test proving the production guard was also wrong: it asserted `{ data: [], meta: {...} }`, a shape X never sends. Both now use the verbatim live response, and a counter-case covers `/2/tweets` returning `data` and `errors` together so the tombstone path stays distinguishable from an account failure.

## Verification

Live API, this branch:

| Check | Result |
|---|---|
| Registry identity sweep | 64/64 pinned ids resolve to their named handle, none protected |
| `verify-x-accounts.mjs --timelines` | timelines readable, no false positives on quiet accounts |
| `@sentdefender` / `@DeutscheWelle` | both return readable timelines after the correction |
| Positive control (`--include-disabled`) | correctly reported the protected accounts before the correction — the pass is not vacuous |

Local, sequential (Node 24):

| Command | Result |
|---|---|
| `node --test tests/x-news-accounts.test.mjs` | 54/54 (before the correction commit; CI re-runs it at 64 enabled) |
| `tests/x-account-trust.test.mjs` | 6/6 |
| `tests/x-feed-contract.test.mjs` | 12/12 |
| `tests/source-provenance.test.mts` | 13/13 |
| `tests/source-attribution.test.mjs` | 41/41 |
| `tests/seed-freshness-monitor.test.mjs` | 41/41 |
| `tests/statcan-wds.test.mjs` | 14/14 |
| `tests/mcp-bootstrap-parity.test.mjs` | 11/11 |
| `npm run typecheck`, `typecheck:api` | pass |
| `npm run lint:boundaries`, `sources:check` | pass |
| `check-health-probe-cutovers.mts` | pass |

The bug fix was proven red first: `accountsFailed` was `0` where `1` was required and `lastError` was empty, before the guard existed.

## A note on how the last commit was made

The local checkout became inaccessible mid-session (`EPERM` on the whole repo tree, affecting Bash and file reads alike — an environment/permissions fault, unrelated to these changes). The correction commit was therefore authored through the GitHub API and **its test run is CI's, not local**. The API verification behind it was still run live, against the real endpoints.

## Not proved here

- The `SEED_ERROR` clearing in production — that needs this merged and ais-relay redeployed. `X_BEARER_TOKEN` is already on ais-relay (verified), so no ops step is outstanding.
- Whether `@Ukrinform_News` (10.8k followers, English) or `@Ukrinform` (354k, mainly Ukrainian) is the better editorial pick. The English one was chosen for consistency with the Meduza-EN and IRNA-English entries; it is a one-line change if you prefer the reach.

## Note for a separate owner

The `flightDelays` STALE_SEED ack (#6987) expired at 2026-08-21T00:00Z and its service no longer appears in compact health, so it is spent too. Left alone here because it belongs to another issue.

Advances #6654.

