### PR TITLE
fix(umami): size the collector pool instead of inheriting pg.Pool's 10

### DIFF
--- a/docker/umami/v320-compat.patch
+++ b/docker/umami/v320-compat.patch
@@ -40,7 +40,7 @@ index 6cdb33c..d6bee46 100644
  async function pagedQuery<T>(model: string, criteria: T, filters?: QueryFilters) {
    const { page = 1, pageSize, orderBy, sortDescending = false, search } = filters || {};
    const size = +pageSize || DEFAULT_PAGE_SIZE;
-@@ -540,6 +571,22 @@ function getSchema() {
+@@ -540,6 +571,46 @@ function getSchema() {
    return connectionUrl.searchParams.get('schema');
  }
  
@@ -52,12 +52,36 @@ index 6cdb33c..d6bee46 100644
 +// the acquisition wait turns pool exhaustion back into a fast, visible failure.
 +const DEFAULT_POOL_CONNECT_TIMEOUT_MS = 10000;
 +
-+function getPoolOptions() {
-+  const configured = Number(process.env.DATABASE_CONNECT_TIMEOUT_MS);
-+  const connectionTimeoutMillis =
-+    Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_POOL_CONNECT_TIMEOUT_MS;
++// The acquisition bound above made pool exhaustion VISIBLE; it did not make it
++// rarer. pg.Pool also defaults `max` to 10, and nothing here ever set it, so the
++// ceiling was an accident of the library rather than a sizing decision. Measured
++// 2026-08-21: umami held exactly 10 backends at peak and never more, while its
++// Postgres reported max_connections=500 with ~16 in use — the constraint was
++// entirely application-side. Meanwhile the collector saw HTTP 500s whose server
++// log is `timeout exceeded when trying to connect` from pg-pool, i.e. callers
++// giving up waiting for one of those 10 (WORLDMONITOR-YK, and the timeout and
++// queue-overflow siblings it backs up into).
++//
++// Sized deliberately, not maximally: 20 doubles headroom while still consuming
++// 4% of max_connections, so even a scaled-out umami cannot starve the database
++// or the retention service that shares it.
++const DEFAULT_POOL_MAX = 20;
 +
-+  return { connectionTimeoutMillis };
++// Annotated because this lands in a .ts file compiled by Next's build; bare
++// parameters would be implicit `any` and fail the image build under strict mode.
++function readPositiveIntEnv(name: string, fallback: number): number {
++  const configured = Number(process.env[name]);
++  return Number.isFinite(configured) && configured > 0 ? configured : fallback;
++}
++
++function getPoolOptions() {
++  return {
++    connectionTimeoutMillis: readPositiveIntEnv(
++      'DATABASE_CONNECT_TIMEOUT_MS',
++      DEFAULT_POOL_CONNECT_TIMEOUT_MS,
++    ),
++    max: readPositiveIntEnv('DATABASE_POOL_MAX', DEFAULT_POOL_MAX),
++  };
 +}
 +
  function getClient() {

--- a/tests/umami-runtime-remediation.test.mjs
+++ b/tests/umami-runtime-remediation.test.mjs
@@ -111,9 +111,21 @@ describe('Umami runtime remediation (#6024)', () => {
 
     assert.ok(declaration >= 0 && bodyEnd > declaration, 'getPoolOptions() missing from the patch');
 
-    const getPoolOptions = new Function(
-      `${addedSource.slice(declaration, bodyEnd)}\nreturn getPoolOptions;`,
-    )();
+    // The patch lands in a .ts file, so the helpers carry type annotations that
+    // `new Function` cannot parse. Strip only parameter and return-type
+    // annotations for primitives — deliberately narrow, so anything more exotic
+    // fails loudly here instead of being silently mangled into passing code.
+    const poolSource = addedSource
+      .slice(declaration, bodyEnd)
+      .replace(/:\s*(?:string|number|boolean)(?=\s*[,)])/g, '')
+      .replace(/\)\s*:\s*(?:string|number|boolean)\s*\{/g, ') {');
+
+    assert.ok(
+      !/:\s*(?:string|number|boolean)\s*[,)]/.test(poolSource),
+      'type-annotation stripping left annotations behind; the eval below would be testing mangled source',
+    );
+
+    const getPoolOptions = new Function(`${poolSource}\nreturn getPoolOptions;`)();
     const previous = process.env.DATABASE_CONNECT_TIMEOUT_MS;
 
     try {
@@ -138,6 +150,50 @@ describe('Umami runtime remediation (#6024)', () => {
         process.env.DATABASE_CONNECT_TIMEOUT_MS = previous;
       }
     }
+
+    // Pool SIZE, not just acquisition time. pg.Pool defaults `max` to 10 and
+    // nothing set it, so the ceiling was a library default rather than a sizing
+    // decision — measured 2026-08-21, umami sat at exactly 10 backends at peak
+    // while its Postgres allowed 500. Callers that could not get one of those 10
+    // surfaced as `timeout exceeded when trying to connect` and reached the
+    // browser as collector HTTP 500s (WORLDMONITOR-YK).
+    const previousMax = process.env.DATABASE_POOL_MAX;
+
+    try {
+      delete process.env.DATABASE_POOL_MAX;
+      const defaulted = getPoolOptions().max;
+      assert.equal(defaulted, 20, 'default pool size must be the deliberate value, not pg.Pool\'s 10');
+      // The regression that matters is silently falling back to the library
+      // default; assert the direction explicitly so a future edit to
+      // DEFAULT_POOL_MAX cannot quietly reintroduce the starved ceiling.
+      assert.ok(defaulted > 10, 'pool size must exceed the pg.Pool default that caused the starvation');
+
+      process.env.DATABASE_POOL_MAX = '35';
+      assert.equal(getPoolOptions().max, 35, 'operators must be able to raise the ceiling without a rebuild');
+
+      for (const invalid of ['0', '-1', 'abc', '']) {
+        process.env.DATABASE_POOL_MAX = invalid;
+        assert.equal(
+          getPoolOptions().max,
+          20,
+          `${JSON.stringify(invalid)} must fall back to the default — max:0 would make pg.Pool refuse every connection`,
+        );
+      }
+    } finally {
+      if (previousMax === undefined) {
+        delete process.env.DATABASE_POOL_MAX;
+      } else {
+        process.env.DATABASE_POOL_MAX = previousMax;
+      }
+    }
+
+    // Both bounds must survive together: an edit that returns only one of them
+    // silently restores the other's unsafe library default.
+    assert.deepEqual(
+      Object.keys(getPoolOptions()).sort(),
+      ['connectionTimeoutMillis', 'max'],
+      'getPoolOptions() must carry BOTH the acquisition bound and the pool size',
+    );
   });
 
   it('fails the image build when a PrismaPg pool loses its acquisition bound', () => {


### PR DESCRIPTION
## Summary

The Umami collector has been failing for a growing slice of sessions — six Sentry issues that are all one root cause: **umami's connection pool was capped at 10 by a library default nobody chose.**

`PrismaPg` forwards its options to `pg.Pool`, whose `max` defaults to 10. `getPoolOptions()` (added by #6057) set only `connectionTimeoutMillis`. That bound made pool exhaustion *visible* — it converted #6053's indefinite hangs into prompt failures — but it never made exhaustion rarer, because the pool size was still the library's default.

## Evidence (measured 2026-08-21)

**The trend is real, not a volume artifact:**

| | 08-08 | 08-19/20 |
|---|---|---|
| Sentry collector reports | 7/day | ~50/day |
| umami sessions | 18,881/day | 20,804/day |

Traffic grew 10%; failure reports grew ~7×.

**The pool is the constraint:**

- umami logs `Error: timeout exceeded when trying to connect` from `pg-pool/index.js:45` — the acquisition bound firing
- `pg_stat_activity` sampled repeatedly: umami held **exactly 10** backends at peak and **never more**
- its Postgres reports `max_connections=500` with ~16 in use — the ceiling is entirely application-side
- Railway is dropping umami logs (`Messages dropped: 1013`, 500/sec replica cap), so actual error volume exceeds what the log tail shows

**The client symptoms are downstream of the same wedge.** The collector serializes writes behind one in-flight slot, so server 500s and timeouts back the queue up until it sheds as `queue-overflow`.

## The change

`max: 20`, overridable via `DATABASE_POOL_MAX`. Sized deliberately rather than maximally: double the headroom while still consuming 4% of `max_connections`, so even a scaled-out umami cannot starve the database or the retention service sharing it.

## Verification

- Patch **hunk arithmetic validated** — the first edit left the header claiming 22 added lines against a 46-line body, which would have failed `git apply --check` and broken the image build
- Patch **re-applied against pinned upstream `2f6e2b5`** to confirm `git apply --check` passes and both adapters still carry `getPoolOptions()`
- New test proven to go **red** by reverting `DEFAULT_POOL_MAX` to 10
- Type annotations added to the new helper because it lands in a `.ts` file compiled by Next's build; the test harness now strips primitive annotations before `new Function`, with an assertion that the stripping did not silently no-op
- 270 tests pass (`umami-runtime-remediation`, `umami-retention-runner`, `umami-storage-monitor`, `deploy-config`)

## Deliberately NOT included

- **`statement_timeout` is still `0`**, so a slow query holds its connection indefinitely — the documented residual from #6053. This pool *also* serves dashboard reporting queries whose durations are unmeasured, and a blanket bound could cut off legitimate reports.
- **`pg_stat_statements` is not installed**, so pool time cannot be attributed to specific queries after the fact. Installing it is the prerequisite for sizing `statement_timeout` honestly, and is being handled separately.

## Open follow-up

- **#6970 shows no measurable effect yet.** It reached production 06:53 UTC today; over the following 4.7h the rates are unchanged (ZF 1.03→1.06/hr, YD 0.32→0.43/hr). n=5 and n=2 are far too small to call it failed — worth re-checking with a full day of data.
- **The `queue-overflow` sibling is not capacity-bound.** 42% of its windows report `writeCount==1` and 80% report ≤5 against a queue bound of 50 — a queue already full when the window opened. It should ease as the server stops 500ing; if it persists it is a separate defect.
