### PR TITLE
test(china-policy): interleave rescan-guard size measurements to survive concurrent load

### DIFF
--- a/tests/china-policy-events.test.mts
+++ b/tests/china-policy-events.test.mts
@@ -217,8 +217,18 @@ describe('China official policy adapters (#5576)', () => {
 
     timeAtSize(4_000, 1);
     timeAtSize(16_000, 1);
-    const base = timeAtSize(4_000, 5);
-    const quadrupled = timeAtSize(16_000, 5);
+    // Interleave the two sizes instead of measuring them sequentially:
+    // test:data runs 16 files concurrently, so a sequential 16k measurement
+    // can land in a busier window than the 4k one and inflate the ratio with
+    // no parser change (#6985 — observed 8.4x/9.0x flakes under load).
+    // Best-of-N per size still applies, but each attempt pairs the sizes, so
+    // a stall must hit the same attempt of the larger size N times to survive.
+    let base = Number.POSITIVE_INFINITY;
+    let quadrupled = Number.POSITIVE_INFINITY;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      base = Math.min(base, timeAtSize(4_000, 1));
+      quadrupled = Math.min(quadrupled, timeAtSize(16_000, 1));
+    }
     const ratio = quadrupled / base;
 
     assert.ok(


### PR DESCRIPTION
Fixes #6985.

## Problem

The *parses hostile markup without superlinear rescans* guard measured its two input sizes **sequentially**: best-of-5 at 4k, then best-of-5 at 16k. Best-of-N absorbs a stall *within* one size, but under the 16-way concurrent `test:data` run the 16k block can land in a busier scheduling window than the 4k block — the ratio inflates with no parser change. Observed twice on unrelated branches (8.4x, 9.0x against the 12x threshold); 26/26 pass in isolation every time.

## Fix

Exactly the interleaving the issue proposes: each of 5 attempts times 4k then 16k back-to-back, taking the per-size minimum across attempts. Both sizes now see the same load profile, so a stall must hit the same attempt of the larger size five times in a row to survive into the ratio. The warm-up calls, inputs, and the 12x threshold are unchanged — a genuinely backtracking parser (~16x) still fails the guard.

## Verification

- 3 consecutive isolated runs: 26/26 pass
- Run under parallel `tsx --test --test-concurrency=4` alongside 3 other suites: pass
- `biome lint` clean