### PR TITLE
fix(sentry): report err.name, not the minified constructor name

### DIFF
--- a/api/_sentry-common.js
+++ b/api/_sentry-common.js
@@ -72,7 +72,18 @@ function parseStack(stack) {
  */
 function buildEnvelope(err, ctx, runtimeCfg) {
   const errMsg = err instanceof Error ? err.message : String(err);
-  const errType = err instanceof Error ? err.constructor.name : 'Error';
+  // Prefer `err.name` over `err.constructor.name`. Both API bundles ship
+  // minified, so a custom error class's constructor name is a mangled
+  // identifier that changes whenever the bundle is rebuilt: `RpcValidationError`
+  // reached Sentry as type `At` (WORLDMONITOR-Y2, 2026-08-21), titling the issue
+  // `At: get-country-risk HTTP 400`. Every class here sets `this.name`
+  // explicitly, and `api/mcp/error-fingerprint.ts` already keys on it, so
+  // `err.name` is both stable across deploys and the value the code intends.
+  // Native errors are unaffected except DOMException, which reports its reason
+  // (`TimeoutError`) instead of the generic class — strictly more specific.
+  const errType = err instanceof Error
+    ? (err.name || err.constructor.name || 'Error')
+    : 'Error';
   const stack = err instanceof Error && err.stack ? err.stack : undefined;
   const eventId = crypto.randomUUID().replace(/-/g, '');
   const timestamp = new Date().toISOString();

--- a/api/_sentry-common.test.mjs
+++ b/api/_sentry-common.test.mjs
@@ -66,3 +66,196 @@ test('custom API Sentry transport can be exercised by clearing NODE_TEST_CONTEXT
   assert.equal(String(input), 'https://example.ingest.sentry.io/api/12345/envelope/');
   assert.equal(init?.headers?.['X-Sentry-Auth'], 'Sentry sentry_version=7, sentry_key=public');
 });
+
+// Regression: the edge/serverless bundles are minified, so a custom error
+// class's `constructor.name` is a mangled identifier that changes on every
+// build. Production proof (2026-08-21, WORLDMONITOR-Y2): `RpcValidationError`
+// — which sets `this.name = 'RpcValidationError'` — reported to Sentry as
+// exception type `At`, giving the issue the title `At: get-country-risk HTTP
+// 400`. Any Sentry search, alert, or saved query keyed on `error.type` stops
+// matching the moment the mangled name shifts.
+//
+// `err.name` is the value the class sets explicitly and is minification-proof;
+// `api/mcp/error-fingerprint.ts` already prefers it. The envelope builder must
+// agree.
+test('envelope exception type prefers err.name over the minifiable constructor name', async () => {
+  delete process.env.NODE_TEST_CONTEXT;
+  process.env.VITE_SENTRY_DSN = 'https://public@example.ingest.sentry.io/12345';
+
+  const fetchCalls = [];
+  globalThis.fetch = async (input, init) => {
+    fetchCalls.push({ input, init });
+    return new Response(null, { status: 200 });
+  };
+
+  const { makeCaptureSilentError } = await import(`./_sentry-common.js?test=${Date.now()}-${Math.random()}`);
+  const captureSilentError = makeCaptureSilentError({
+    runtime: 'edge',
+    platform: 'javascript',
+    logPrefix: '[sentry-test]',
+  });
+
+  // `At` stands in for the mangled class identifier the minifier emits.
+  class At extends Error {
+    constructor(label) {
+      super(`${label} HTTP 400`);
+      this.name = 'RpcValidationError';
+    }
+  }
+
+  await captureSilentError(new At('get-country-risk'));
+
+  assert.equal(fetchCalls.length, 1);
+  const body = fetchCalls[0].init.body;
+  const event = JSON.parse(String(body).split('\n')[2]);
+  const [value] = event.exception.values;
+  assert.equal(
+    value.type,
+    'RpcValidationError',
+    'exception type must come from err.name, which survives minification',
+  );
+  assert.equal(value.value, 'get-country-risk HTTP 400');
+});
+
+// A thrown value with no useful `name` must still report a type rather than an
+// empty string: an anonymous subclass, or an Error whose name was blanked.
+test('envelope exception type falls back when err.name is empty', async () => {
+  delete process.env.NODE_TEST_CONTEXT;
+  process.env.VITE_SENTRY_DSN = 'https://public@example.ingest.sentry.io/12345';
+
+  const fetchCalls = [];
+  globalThis.fetch = async (input, init) => {
+    fetchCalls.push({ input, init });
+    return new Response(null, { status: 200 });
+  };
+
+  const { makeCaptureSilentError } = await import(`./_sentry-common.js?test=${Date.now()}-${Math.random()}`);
+  const captureSilentError = makeCaptureSilentError({
+    runtime: 'edge',
+    platform: 'javascript',
+    logPrefix: '[sentry-test]',
+  });
+
+  class BlankNamed extends Error {}
+  const blank = new BlankNamed('no name set');
+  blank.name = '';
+
+  await captureSilentError(blank);
+
+  const event = JSON.parse(String(fetchCalls[0].init.body).split('\n')[2]);
+  assert.equal(event.exception.values[0].type, 'BlankNamed');
+});
+
+// Native errors already agree between `name` and `constructor.name`; the
+// change must not perturb them. DOMException is the one that actually shows up
+// in production (WORLDMONITOR-Z9/-ZM/-R2, AbortSignal.timeout on edge fetches).
+test('envelope exception type is unchanged for native error classes', async () => {
+  delete process.env.NODE_TEST_CONTEXT;
+  process.env.VITE_SENTRY_DSN = 'https://public@example.ingest.sentry.io/12345';
+
+  const fetchCalls = [];
+  globalThis.fetch = async (input, init) => {
+    fetchCalls.push({ input, init });
+    return new Response(null, { status: 200 });
+  };
+
+  const { makeCaptureSilentError } = await import(`./_sentry-common.js?test=${Date.now()}-${Math.random()}`);
+  const captureSilentError = makeCaptureSilentError({
+    runtime: 'edge',
+    platform: 'javascript',
+    logPrefix: '[sentry-test]',
+  });
+
+  await captureSilentError(new TypeError('bad input'));
+  await captureSilentError(new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+
+  const types = fetchCalls.map(
+    (call) => JSON.parse(String(call.init.body).split('\n')[2]).exception.values[0].type,
+  );
+  // DOMException carries its *reason* in `name` (TimeoutError), which is
+  // strictly more informative than the constructor name it replaces.
+  assert.deepEqual(types, ['TypeError', 'TimeoutError']);
+});
+
+// The `err.name` preference above is only an improvement while every custom
+// error class actually sets `this.name`. A subclass that omits it inherits
+// `Error.prototype.name === 'Error'` and silently reports the generic type —
+// the mangled-but-specific identifier it used to send is gone. All 19 classes
+// satisfy this today; this guard keeps the next one honest.
+test('every custom Error subclass sets this.name explicitly', async () => {
+  const { readdirSync, readFileSync } = await import('node:fs');
+  const { dirname, join, relative, resolve } = await import('node:path');
+  const { fileURLToPath } = await import('node:url');
+
+  const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+  // Walk in-process rather than shelling out to `rg`: ripgrep is not a declared
+  // dependency of this repo and nothing else in the suite requires it, so an
+  // ENOENT on a runner without it would be a false red rather than a finding.
+  const sourceFiles = function* walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) yield* walk(full);
+      else if (/\.(ts|js)$/.test(entry.name) && !/\.test\.|\.d\.ts$/.test(entry.name)) yield full;
+    }
+  };
+
+  // Body of a class declaration: from its opening line to the matching close.
+  // Brace-counting rather than a fixed line window, so a long constructor
+  // (or a class whose `this.name` sits below one) can't slip past.
+  const classBody = (source, startLine) => {
+    const lines = source.split('\n');
+    let depth = 0;
+    let started = false;
+    const body = [];
+    for (let i = startLine - 1; i < lines.length; i += 1) {
+      body.push(lines[i]);
+      for (const ch of lines[i]) {
+        if (ch === '{') { depth += 1; started = true; } else if (ch === '}') depth -= 1;
+      }
+      if (started && depth <= 0) break;
+    }
+    return body.join('\n');
+  };
+
+  const setsName = (body) => /\bthis\.name\s*=\s*['"`]/.test(body);
+
+  // Positive control: the detector must actually reject a class that omits
+  // `this.name`, otherwise a broken `setsName` would report a clean sweep.
+  assert.equal(
+    setsName('class Nameless extends Error {\n  constructor(m) { super(m); }\n}'),
+    false,
+    'detector is vacuous — it accepts a class that never assigns this.name',
+  );
+  assert.equal(
+    setsName("class Named extends Error {\n  constructor(m) { super(m); this.name = 'Named'; }\n}"),
+    true,
+    'detector is inverted — it rejects a class that does assign this.name',
+  );
+
+  const offenders = [];
+  let checked = 0;
+  const declaration = /class\s+(\w+Error)\s+extends\s+Error\b/;
+  for (const dir of ['api', 'server', 'shared']) {
+    for (const file of sourceFiles(join(repoRoot, dir))) {
+      const source = readFileSync(file, 'utf-8');
+      if (!declaration.test(source)) continue;
+      source.split('\n').forEach((text, index) => {
+        const className = text.match(declaration)?.[1];
+        if (!className) return;
+        checked += 1;
+        if (!setsName(classBody(source, index + 1))) {
+          offenders.push(`${className} (${relative(repoRoot, file)}:${index + 1})`);
+        }
+      });
+    }
+  }
+
+  assert.ok(checked >= 19, `expected to scan the known custom Error classes, scanned ${checked}`);
+  assert.deepEqual(
+    offenders,
+    [],
+    'these Error subclasses report type "Error" to Sentry — set this.name in the constructor',
+  );
+});


### PR DESCRIPTION
## Summary

Found during Sentry triage. `buildEnvelope` derived the reported exception type from **`err.constructor.name`** — a value the minifier owns.

Both `api/` bundles ship minified, so for every *custom* `Error` subclass that name is a mangled identifier. `RpcValidationError` reached Sentry as type **`At`**, which is why WORLDMONITOR-Y2 carries the title `At: get-country-risk HTTP 400`.

## Why this is worse than a bad title

The minifier reassigns short identifiers whenever the bundle changes. So the reported type is **not stable across deploys** — any Sentry search, alert, or saved query keyed on `error.type` silently stops matching after an unrelated deploy, with no error and no signal that it stopped.

The failure hides well:

- **Native errors are unaffected.** `Error`, `TypeError`, `DOMException` constructor names survive minification, so a spot-check of ordinary captures looks perfectly healthy.
- **It only bites the custom classes** — the 19 that carry the domain meaning (`ToolFetchError`, `BillingDenialError`, `McpSourceUnavailableError`, …). Exactly the ones worth querying.
- **`api/mcp` looked fine** because `mcpErrorFingerprint` supplies an explicit fingerprint, so grouping never depended on the broken type.

## The change

```js
- const errType = err instanceof Error ? err.constructor.name : 'Error';
+ const errType = err instanceof Error
+   ? (err.name || err.constructor.name || 'Error')
+   : 'Error';
```

`err.name` is assigned explicitly by all 19 custom subclasses, so it is both minification-proof and the value the code intends. `api/mcp/error-fingerprint.ts:34` already preferred `err.name` — the envelope builder was the inconsistent sibling, and this makes them agree.

## Verification

- **Test written first and confirmed red** against the old code, reproducing the exact production string: `expected 'RpcValidationError', actual 'At'`.
- **Audited every custom `Error` subclass** across `api/`, `server/`, `shared/` — all 19 assign `this.name`, so there is no case that silently degrades to the generic `'Error'`.
- **That invariant is now guarded repo-wide**, with a positive control asserting the detector rejects a class that omits `this.name` (a broken detector would otherwise report a clean sweep forever).
- **Guard mutation-verified**: deleting `this.name` from `api/mcp/source-unavailable.ts` turned it red naming the exact class and line; restoring turned it green.
- `api/_sentry-common.test.mjs` **6/6** · `tsc --noEmit` clean · `tests/sentry-beforesend` + `fetch-failure-attribution` **289/289**.
- `test:sidecar` 377/393 — the 16 failures are **pre-existing**, confirmed by re-running at baseline with this change stashed (same 16, all `ais-relay-*` / `product-catalog`, from `shared/inventory-facts.generated.json` missing in the worktree).

No visual evidence: this is server-side telemetry plumbing with no user-facing surface.

## Deliberate side effect

`DOMException` now reports its `name` (`TimeoutError`) rather than the generic class, so **WORLDMONITOR-Z9 / -ZM / -R2 regroup once** on deploy. This is an improvement — `TimeoutError` is the specific reason, and `api/user-prefs` already worked around the loss by setting an `error_name: TimeoutError` tag by hand. Captures with an explicit fingerprint (all of `api/mcp`) do not move.

## Note on the guard's implementation

It walks the tree in-process rather than shelling out to `ripgrep`. `rg` is not a declared dependency of this repo and nothing else in the suite requires it, so an `ENOENT` on a runner without it would surface as a false red rather than a finding.

## New concepts

**Minified `constructor.name` as an unstable identity.** `err.constructor.name` reads like a stable label but is a *build artifact* in any bundled code path — the minifier is free to rename it on every build. `err.name` is program data the class assigns, so it survives. The general rule: never derive a value that is **reported, grouped on, or queried** from an identifier the build toolchain is allowed to rewrite. The tell in production is an issue titled with a short CamelCase non-word — `At:`, `Xn:`, `qe:` — whose message still matches a known class's template.

**Anti-vacuity via positive control.** A guard that scans for offenders and asserts the list is empty passes identically whether the codebase is clean or the *detector* is broken. Asserting the detector rejects a known-bad input, and accepts a known-good one, separates those two states — which is why this guard carries both assertions plus a `checked >= 19` floor, so a scan that silently matches nothing fails instead of reporting success.
