### PR TITLE
perf(prepush): fetch lazily in the branch-contamination guard

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -80,19 +80,17 @@ if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; the
     BASE_REF="$PR_BASE_REF"
   fi
   BASE_REF="${BASE_REF:-main}"
-  # Refresh the remote-tracking ref before trusting it. A stacked branch's
-  # base may not be fetched locally at all yet, and even origin/main can be
-  # stale in a long-lived worktree — either way, counting against a stale
-  # ref reintroduces the exact false-positive this guard is meant to avoid.
-  # A failed fetch (offline, network hiccup) is not fatal: fall through to
-  # whatever's already cached locally, same as before this change.
-  git fetch origin "$BASE_REF" --quiet 2>/dev/null || true
-  if ! git rev-parse --verify -q "origin/$BASE_REF" >/dev/null; then
-    echo "  Base ref 'origin/$BASE_REF' not resolvable, falling back to origin/main."
-    BASE_REF="main"
-    git fetch origin "$BASE_REF" --quiet 2>/dev/null || true
-  fi
-  COMMIT_COUNT=$(git rev-list --count "origin/$BASE_REF..HEAD" 2>/dev/null || echo 0)
+  # Lazy ahead-count (#6764): count against the CACHED remote-tracking ref
+  # and fetch only to disprove a suspected violation or resolve a base that
+  # was never fetched — a fetch can only shrink the count, so a cached pass
+  # is a real pass. Decision + fixtures live in scripts/prepush-attest.sh
+  # (`base-guard`), where tests/prepush-attest.test.mjs executes them against
+  # real git fixtures instead of grepping this hook.
+  GUARD_OUT=$(bash scripts/prepush-attest.sh base-guard "$BASE_REF" 20) || true
+  BASE_REF=$(printf '%s' "$GUARD_OUT" | cut -f1)
+  BASE_REF="${BASE_REF:-main}"
+  COMMIT_COUNT=$(printf '%s' "$GUARD_OUT" | cut -f2)
+  COMMIT_COUNT="${COMMIT_COUNT:-0}"
   if [ "$COMMIT_COUNT" -gt 20 ]; then
     echo ""
     echo "============================================================"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -86,11 +86,29 @@ if [ -n "$BRANCH" ] && [ "$BRANCH" != "main" ] && [ "$BRANCH" != "master" ]; the
   # is a real pass. Decision + fixtures live in scripts/prepush-attest.sh
   # (`base-guard`), where tests/prepush-attest.test.mjs executes them against
   # real git fixtures instead of grepping this hook.
-  GUARD_OUT=$(bash scripts/prepush-attest.sh base-guard "$BASE_REF" 20) || true
+  GUARD_STATUS=0
+  GUARD_OUT=$(bash scripts/prepush-attest.sh base-guard "$BASE_REF" 20) || GUARD_STATUS=$?
+  case "$GUARD_STATUS" in
+    0 | 3) ;;
+    *)
+      echo "ERROR: branch-contamination guard failed (status $GUARD_STATUS); refusing to push."
+      exit 1
+      ;;
+  esac
+  if ! printf '%s' "$GUARD_OUT" | awk -F '\t' '
+    NR != 1 { exit 1 }
+    NF != 2 || $1 == "" || $2 !~ /^[0-9]+$/ { exit 1 }
+    END { if (NR != 1) exit 1 }
+  ' >/dev/null; then
+    echo "ERROR: branch-contamination guard returned malformed output; refusing to push."
+    exit 1
+  fi
   BASE_REF=$(printf '%s' "$GUARD_OUT" | cut -f1)
-  BASE_REF="${BASE_REF:-main}"
   COMMIT_COUNT=$(printf '%s' "$GUARD_OUT" | cut -f2)
-  COMMIT_COUNT="${COMMIT_COUNT:-0}"
+  if [ "$GUARD_STATUS" -eq 3 ] && ! [ "$COMMIT_COUNT" -gt 20 ] 2>/dev/null; then
+    echo "ERROR: branch-contamination guard returned an inconsistent result; refusing to push."
+    exit 1
+  fi
   if [ "$COMMIT_COUNT" -gt 20 ]; then
     echo ""
     echo "============================================================"

--- a/scripts/prepush-attest.sh
+++ b/scripts/prepush-attest.sh
@@ -30,6 +30,7 @@
 #   bash scripts/prepush-attest.sh dirty                     # NUL list of offenders
 #   bash scripts/prepush-attest.sh cache-read   <file> <tree> <diff-resolved>
 #   bash scripts/prepush-attest.sh cache-write  <file> <tree> <diff-resolved> <attestable>
+#   bash scripts/prepush-attest.sh base-guard   <base-ref> [limit]  # "<base>\t<count>" on stdout
 #
 # Exit codes are three-valued on purpose. A gate that answers "no" and a gate
 # that could not run must never collapse into the same status as "yes":
@@ -41,9 +42,9 @@
 
 mode="${1:-}"
 case "$mode" in
-  changed | changed-live | drift | dirty | cache-read | cache-write) ;;
+  changed | changed-live | drift | dirty | cache-read | cache-write | base-guard) ;;
   *)
-    echo "usage: $0 <changed|changed-live|drift|dirty|cache-read|cache-write> [args]" >&2
+    echo "usage: $0 <changed|changed-live|drift|dirty|cache-read|cache-write|base-guard> [args]" >&2
     exit 2
     ;;
 esac
@@ -149,6 +150,63 @@ case "$mode" in
       found=1
     done
     [ "$found" -eq 0 ] || exit 3
+    ;;
+
+  base-guard)
+    # Branch-contamination ahead-count with a LAZY fetch (#6764). The hook
+    # used to `git fetch` unconditionally before counting — 2s warm, 72s cold,
+    # on every push — to protect a guard that almost never fires. Fetching can
+    # only move origin/<base> FORWARD, so `rev-list --count origin/<base>..HEAD`
+    # can only stay equal or SHRINK after a fetch. Therefore:
+    #
+    #   cached count <= limit  ->  post-fetch count <= limit. Same verdict,
+    #                              skip the network entirely.
+    #   cached count >  limit  ->  possibly a stale-ref false positive; fetch
+    #                              to DISPROVE the violation, then recount.
+    #   origin/<base> missing  ->  must fetch (first push of a stacked branch).
+    #
+    # Prints "<resolved-base>\t<count>". Exit 0 = within limit, 3 = violation
+    # confirmed against a freshly fetched ref. A failed fetch (offline) is not
+    # fatal: fall through to whatever is cached, as the hook always has.
+    base="${2:-}"
+    limit="${3:-20}"
+    [ -n "$base" ] || usage_error "<base-ref> [limit]"
+
+    fetch_base() {
+      # Bounded and tag-free: an unbounded fetch inside a hook is how a push
+      # hangs past its caller's budget.
+      if command -v timeout >/dev/null 2>&1; then
+        timeout 120 git fetch --no-tags origin "$1" --quiet 2>/dev/null || true
+      else
+        git fetch --no-tags origin "$1" --quiet 2>/dev/null || true
+      fi
+    }
+
+    count_ahead() {
+      git rev-list --count "origin/$1..HEAD" 2>/dev/null || echo 0
+    }
+
+    need_fetch=false
+    count=0
+    if ! git rev-parse --verify -q "origin/$base" >/dev/null; then
+      need_fetch=true
+    else
+      count=$(count_ahead "$base")
+      [ "$count" -gt "$limit" ] && need_fetch=true
+    fi
+
+    if [ "$need_fetch" = true ]; then
+      fetch_base "$base"
+      if ! git rev-parse --verify -q "origin/$base" >/dev/null; then
+        echo "base-guard: 'origin/$base' not resolvable, falling back to origin/main" >&2
+        base="main"
+        fetch_base "$base"
+      fi
+      count=$(count_ahead "$base")
+    fi
+
+    printf '%s\t%s\n' "$base" "$count"
+    [ "$count" -le "$limit" ] || exit 3
     ;;
 
   cache-read)

--- a/scripts/prepush-attest.sh
+++ b/scripts/prepush-attest.sh
@@ -157,10 +157,13 @@ case "$mode" in
     # used to `git fetch` unconditionally before counting — 2s warm, 72s cold,
     # on every push — to protect a guard that almost never fires. Fetching can
     # only move origin/<base> FORWARD, so `rev-list --count origin/<base>..HEAD`
-    # can only stay equal or SHRINK after a fetch. Therefore:
+    # can only stay equal or SHRINK after a fetch. That premise is safe for the
+    # protected main branch, but stacked bases and WM_BASE_REF may be
+    # force-rewritten. Those mutable bases must be refreshed before accepting a
+    # cached pass. Therefore:
     #
-    #   cached count <= limit  ->  post-fetch count <= limit. Same verdict,
-    #                              skip the network entirely.
+    #   cached count <= limit  ->  skip the network only for protected main;
+    #                              fetch mutable bases and recount.
     #   cached count >  limit  ->  possibly a stale-ref false positive; fetch
     #                              to DISPROVE the violation, then recount.
     #   origin/<base> missing  ->  must fetch (first push of a stacked branch).
@@ -175,10 +178,31 @@ case "$mode" in
     fetch_base() {
       # Bounded and tag-free: an unbounded fetch inside a hook is how a push
       # hangs past its caller's budget.
-      if command -v timeout >/dev/null 2>&1; then
-        timeout 120 git fetch --no-tags origin "$1" --quiet 2>/dev/null || true
+      # Node 24 is a repository requirement and is available on every supported
+      # developer machine. Keep the deadline in one portable implementation so
+      # macOS hosts do not silently fall back to an unbounded fetch.
+      if command -v node >/dev/null 2>&1; then
+        WM_PREPUSH_FETCH_BASE="$1" node - <<'NODE'
+const { spawnSync } = require('node:child_process');
+
+const configured = Number(process.env.WM_PREPUSH_FETCH_TIMEOUT_MS);
+const timeout = Number.isFinite(configured) && configured > 0 ? configured : 120_000;
+const result = spawnSync(
+  'git',
+  ['fetch', '--no-tags', 'origin', process.env.WM_PREPUSH_FETCH_BASE, '--quiet'],
+  { stdio: 'ignore', timeout, killSignal: 'SIGTERM' },
+);
+process.exit(result.error ? 1 : (result.status ?? 1));
+NODE
+      elif command -v timeout >/dev/null 2>&1; then
+        timeout 120 git fetch --no-tags origin "$1" --quiet 2>/dev/null
+      elif command -v gtimeout >/dev/null 2>&1; then
+        gtimeout 120 git fetch --no-tags origin "$1" --quiet 2>/dev/null
       else
-        git fetch --no-tags origin "$1" --quiet 2>/dev/null || true
+        # There is no safe way to invoke a fetch without a deadline. The
+        # caller intentionally treats this as a failed corrective fetch and
+        # evaluates whatever remote-tracking ref is already available.
+        return 1
       fi
     }
 
@@ -188,15 +212,36 @@ case "$mode" in
 
     need_fetch=false
     count=0
+    cache_safe=false
+    had_cached_ref=false
+    if [ "$base" = main ] && [ -z "${WM_BASE_REF:-}" ]; then
+      cache_safe=true
+    fi
     if ! git rev-parse --verify -q "origin/$base" >/dev/null; then
       need_fetch=true
     else
+      had_cached_ref=true
       count=$(count_ahead "$base")
-      [ "$count" -gt "$limit" ] && need_fetch=true
+      # A non-main PR base or explicit WM_BASE_REF can be rebased or
+      # force-pushed, so its cached relationship is not a sound pass even when
+      # the cached count is within the limit. The default protected main branch
+      # is the only relationship eligible for the lazy cached-pass shortcut.
+      if [ "$cache_safe" != true ] || [ "$count" -gt "$limit" ]; then
+        need_fetch=true
+      fi
     fi
 
     if [ "$need_fetch" = true ]; then
-      fetch_base "$base"
+      fetch_status=0
+      fetch_base "$base" || fetch_status=$?
+      # A mutable base with a cached ref cannot safely fall back to that stale
+      # value after a failed refresh: the whole reason to fetch was to rule out
+      # a force-rewrite. Preserve the historical fallback for an entirely
+      # unresolvable base, where there is no cached relationship to trust.
+      if [ "$cache_safe" != true ] && [ "$had_cached_ref" = true ] && [ "$fetch_status" -ne 0 ]; then
+        echo "base-guard: could not refresh mutable 'origin/$base'" >&2
+        exit 1
+      fi
       if ! git rev-parse --verify -q "origin/$base" >/dev/null; then
         echo "base-guard: 'origin/$base' not resolvable, falling back to origin/main" >&2
         base="main"

--- a/tests/prepush-attest.test.mjs
+++ b/tests/prepush-attest.test.mjs
@@ -490,3 +490,125 @@ describe('pre-push wiring: the hook must consume these decisions', () => {
     lacks(/find api\/ -name "\*\.js"/, 'working-tree globs rediscover ignored sidecar bundles');
   });
 });
+
+describe('base-guard fetches lazily and only to disprove a violation (#6764)', () => {
+  // The old hook fetched origin on EVERY push (2s warm, 72s cold) to protect
+  // a guard that almost never fires. base-guard counts against the cached
+  // remote-tracking ref and fetches only when that cached count already looks
+  // like a violation (or the ref is missing) — sound because a fetch can only
+  // move origin/<base> forward, so the ahead-count can only shrink.
+  //
+  // Every case runs the real script with a stub `git` first on PATH that logs
+  // fetch invocations before delegating to the real binary, so "no fetch
+  // happened" is an executed fact, not a source grep.
+  const REAL_GIT = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
+
+  function makeCloneWithOrigin({ aheadCommits = 1 } = {}) {
+    const root = mkdtempSync(join(tmpdir(), 'wm-base-guard-'));
+    fixtures.push(root);
+    const origin = join(root, 'origin.git');
+    const clone = join(root, 'clone');
+    execFileSync('git', ['init', '--quiet', '--bare', '--initial-branch=main', origin], { env: isolatedGitEnv(), encoding: 'utf8' });
+    execFileSync('git', ['clone', '--quiet', origin, clone], { env: isolatedGitEnv(), encoding: 'utf8' });
+    git(clone, ['config', 'user.email', 'base-guard@example.invalid']);
+    git(clone, ['config', 'user.name', 'Base Guard Fixture']);
+    write(clone, 'README.md', 'base\n');
+    git(clone, ['add', '-A']);
+    git(clone, ['commit', '--quiet', '-m', 'base']);
+    git(clone, ['push', '--quiet', 'origin', 'main']);
+    git(clone, ['checkout', '--quiet', '-b', 'feature']);
+    for (let i = 0; i < aheadCommits; i += 1) {
+      write(clone, 'work.txt', `work ${i}\n`);
+      git(clone, ['add', '-A']);
+      git(clone, ['commit', '--quiet', '-m', `work ${i}`]);
+    }
+    // A fetch-logging git shim, first on PATH for the script under test only.
+    const stubDir = join(root, 'stub-bin');
+    const fetchLog = join(root, 'fetch.log');
+    mkdirSync(stubDir, { recursive: true });
+    writeFileSync(
+      join(stubDir, 'git'),
+      `#!/bin/sh\nif [ "$1" = fetch ]; then echo fetch >> "${fetchLog}"; fi\nexec "${REAL_GIT}" "$@"\n`,
+      { mode: 0o755 },
+    );
+    return { clone, stubDir, fetchLog };
+  }
+
+  function baseGuard({ clone, stubDir }, args) {
+    let status = 0;
+    let stdout = '';
+    try {
+      stdout = execFileSync('bash', [SCRIPT, 'base-guard', ...args], {
+        cwd: clone,
+        env: isolatedGitEnv({ PATH: `${stubDir}:${process.env.PATH}` }),
+        encoding: 'utf8',
+      });
+    } catch (err) {
+      status = err.status;
+      stdout = err.stdout ?? '';
+    }
+    const [base, count] = stdout.trim().split('\t');
+    return { status, base, count: Number(count) };
+  }
+
+  function fetchCount(fixture) {
+    try {
+      return readFileSync(fixture.fetchLog, 'utf8').split('\n').filter(Boolean).length;
+    } catch {
+      return 0;
+    }
+  }
+
+  test('a cached ahead-count within the limit performs NO fetch', () => {
+    const fixture = makeCloneWithOrigin({ aheadCommits: 1 });
+    const result = baseGuard(fixture, ['main', '20']);
+    assert.equal(result.status, 0);
+    assert.equal(result.base, 'main');
+    assert.equal(result.count, 1);
+    assert.equal(fetchCount(fixture), 0, 'the common path must pay no network');
+  });
+
+  test('a genuine violation still fails, after a corrective fetch confirmed it', () => {
+    const fixture = makeCloneWithOrigin({ aheadCommits: 25 });
+    const result = baseGuard(fixture, ['main', '20']);
+    assert.equal(result.status, 3, 'exit 3 = violation, distinct from pass and from usage error');
+    assert.equal(result.count, 25);
+    assert.ok(fetchCount(fixture) >= 1, 'a suspected violation must be re-checked against a fresh ref');
+  });
+
+  test('a stale-ref false positive passes after the corrective fetch (the case the old unconditional fetch existed for)', () => {
+    const fixture = makeCloneWithOrigin({ aheadCommits: 25 });
+    const { clone } = fixture;
+    // Land the 25 commits on origin/main (they ARE main now), then branch one
+    // commit past them — but rewind the local remote-tracking ref so the
+    // cached count reads 26 while the true count is 1.
+    git(clone, ['push', '--quiet', 'origin', 'feature:main']);
+    write(clone, 'tip.txt', 'tip\n');
+    git(clone, ['add', '-A']);
+    git(clone, ['commit', '--quiet', '-m', 'tip']);
+    const staleBase = git(clone, ['rev-list', '--max-parents=0', 'HEAD']).trim();
+    git(clone, ['update-ref', 'refs/remotes/origin/main', staleBase]);
+
+    const result = baseGuard(fixture, ['main', '20']);
+    assert.equal(result.status, 0, 'must not false-positive against the stale ref');
+    assert.equal(result.count, 1);
+    assert.ok(fetchCount(fixture) >= 1);
+  });
+
+  test('a base with no local remote-tracking ref fetches and resolves', () => {
+    const fixture = makeCloneWithOrigin({ aheadCommits: 1 });
+    git(fixture.clone, ['update-ref', '-d', 'refs/remotes/origin/main']);
+    const result = baseGuard(fixture, ['main', '20']);
+    assert.equal(result.status, 0);
+    assert.equal(result.count, 1);
+    assert.ok(fetchCount(fixture) >= 1);
+  });
+
+  test('an unresolvable base falls back to origin/main, like the hook always did', () => {
+    const fixture = makeCloneWithOrigin({ aheadCommits: 1 });
+    const result = baseGuard(fixture, ['no-such-base', '20']);
+    assert.equal(result.status, 0);
+    assert.equal(result.base, 'main', 'the resolved base is reported so the hook can use it');
+    assert.equal(result.count, 1);
+  });
+});

--- a/tests/prepush-attest.test.mjs
+++ b/tests/prepush-attest.test.mjs
@@ -539,7 +539,7 @@ describe('base-guard fetches lazily and only to disprove a violation (#6764)', (
     let status = 0;
     let stdout = '';
     try {
-      stdout = execFileSync('bash', [SCRIPT, 'base-guard', ...args], {
+      stdout = execFileSync('/bin/bash', [SCRIPT, 'base-guard', ...args], {
         cwd: clone,
         env: isolatedGitEnv({ PATH: path, ...extraEnv }),
         encoding: 'utf8',
@@ -649,7 +649,7 @@ describe('base-guard fetches lazily and only to disprove a violation (#6764)', (
       const path = makeTimeoutlessPath(fixture);
       const started = Date.now();
       const result = baseGuard(fixture, ['main', '20'], {
-        path: `${path}:/bin`,
+        path,
         WM_PREPUSH_FETCH_TIMEOUT_MS: '200',
       });
 

--- a/tests/prepush-attest.test.mjs
+++ b/tests/prepush-attest.test.mjs
@@ -493,15 +493,16 @@ describe('pre-push wiring: the hook must consume these decisions', () => {
 
 describe('base-guard fetches lazily and only to disprove a violation (#6764)', () => {
   // The old hook fetched origin on EVERY push (2s warm, 72s cold) to protect
-  // a guard that almost never fires. base-guard counts against the cached
-  // remote-tracking ref and fetches only when that cached count already looks
-  // like a violation (or the ref is missing) — sound because a fetch can only
-  // move origin/<base> forward, so the ahead-count can only shrink.
+  // a guard that almost never fires. base-guard keeps the zero-fetch shortcut
+  // for protected main, but refreshes mutable stacked bases before accepting a
+  // cached pass. A suspected violation (or missing ref) is fetched and
+  // recounted as well.
   //
   // Every case runs the real script with a stub `git` first on PATH that logs
   // fetch invocations before delegating to the real binary, so "no fetch
   // happened" is an executed fact, not a source grep.
   const REAL_GIT = execFileSync('sh', ['-c', 'command -v git'], { encoding: 'utf8' }).trim();
+  const REAL_NODE = process.execPath;
 
   function makeCloneWithOrigin({ aheadCommits = 1 } = {}) {
     const root = mkdtempSync(join(tmpdir(), 'wm-base-guard-'));
@@ -531,16 +532,16 @@ describe('base-guard fetches lazily and only to disprove a violation (#6764)', (
       `#!/bin/sh\nif [ "$1" = fetch ]; then echo fetch >> "${fetchLog}"; fi\nexec "${REAL_GIT}" "$@"\n`,
       { mode: 0o755 },
     );
-    return { clone, stubDir, fetchLog };
+    return { root, clone, stubDir, fetchLog };
   }
 
-  function baseGuard({ clone, stubDir }, args) {
+  function baseGuard({ clone, stubDir }, args, { path = `${stubDir}:${process.env.PATH}`, ...extraEnv } = {}) {
     let status = 0;
     let stdout = '';
     try {
       stdout = execFileSync('bash', [SCRIPT, 'base-guard', ...args], {
         cwd: clone,
-        env: isolatedGitEnv({ PATH: `${stubDir}:${process.env.PATH}` }),
+        env: isolatedGitEnv({ PATH: path, ...extraEnv }),
         encoding: 'utf8',
       });
     } catch (err) {
@@ -559,6 +560,24 @@ describe('base-guard fetches lazily and only to disprove a violation (#6764)', (
     }
   }
 
+  function makeTimeoutlessPath({ root, fetchLog }) {
+    const stubDir = join(root, 'timeoutless-bin');
+    mkdirSync(stubDir, { recursive: true });
+    writeFileSync(
+      join(stubDir, 'git'),
+      `#!/bin/sh\n` +
+        `if [ "$1" = fetch ]; then echo fetch >> "${fetchLog}"; exec /bin/sleep 1000; fi\n` +
+        `exec "${REAL_GIT}" "$@"\n`,
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      join(stubDir, 'node'),
+      `#!/bin/sh\nexec "${REAL_NODE}" "$@"\n`,
+      { mode: 0o755 },
+    );
+    return stubDir;
+  }
+
   test('a cached ahead-count within the limit performs NO fetch', () => {
     const fixture = makeCloneWithOrigin({ aheadCommits: 1 });
     const result = baseGuard(fixture, ['main', '20']);
@@ -566,6 +585,22 @@ describe('base-guard fetches lazily and only to disprove a violation (#6764)', (
     assert.equal(result.base, 'main');
     assert.equal(result.count, 1);
     assert.equal(fetchCount(fixture), 0, 'the common path must pay no network');
+  });
+
+  test('a force-rewritten stacked base refreshes a cached pass before accepting it', () => {
+    const fixture = makeCloneWithOrigin({ aheadCommits: 25 });
+    const { clone } = fixture;
+    git(clone, ['push', '--quiet', 'origin', 'feature:stacked']);
+    const cachedBase = git(clone, ['rev-parse', 'feature~1']).trim();
+    git(clone, ['update-ref', 'refs/remotes/origin/stacked', cachedBase]);
+
+    const rewrittenBase = git(clone, ['rev-parse', 'feature~25']).trim();
+    git(clone, ['push', '--quiet', '--force', 'origin', `${rewrittenBase}:stacked`]);
+
+    const result = baseGuard(fixture, ['stacked', '20']);
+    assert.equal(result.status, 3, 'a mutable base must be checked against its live ref');
+    assert.equal(result.count, 25);
+    assert.ok(fetchCount(fixture) >= 1, 'stacked bases must refresh even when the cached count passes');
   });
 
   test('a genuine violation still fails, after a corrective fetch confirmed it', () => {
@@ -602,6 +637,33 @@ describe('base-guard fetches lazily and only to disprove a violation (#6764)', (
     assert.equal(result.status, 0);
     assert.equal(result.count, 1);
     assert.ok(fetchCount(fixture) >= 1);
+  });
+
+  test('fetches stay bounded when neither timeout nor gtimeout is on PATH', () => {
+    for (const [label, aheadCommits, removeRef] of [
+      ['cached violation', 25, false],
+      ['missing remote-tracking ref', 1, true],
+    ]) {
+      const fixture = makeCloneWithOrigin({ aheadCommits });
+      if (removeRef) git(fixture.clone, ['update-ref', '-d', 'refs/remotes/origin/main']);
+      const path = makeTimeoutlessPath(fixture);
+      const started = Date.now();
+      const result = baseGuard(fixture, ['main', '20'], {
+        path: `${path}:/bin`,
+        WM_PREPUSH_FETCH_TIMEOUT_MS: '200',
+      });
+
+      const elapsed = Date.now() - started;
+      assert.ok(elapsed < 3000, `${label} must return after the portable deadline`);
+      assert.ok(fetchCount(fixture) >= 1, `${label} must exercise the corrective fetch (result=${JSON.stringify(result)})`);
+      if (removeRef) {
+        assert.equal(result.status, 0);
+        assert.equal(result.base, 'main');
+      } else {
+        assert.equal(result.status, 3);
+        assert.equal(result.count, 25);
+      }
+    }
   });
 
   test('an unresolvable base falls back to origin/main, like the hook always did', () => {

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -91,6 +91,7 @@ function makeFixture({
   branchFiles = {},
   scriptsCjs = true,
   failAttestMode = null,
+  baseGuardResponse = null,
   proTestNodeModules = true,
 } = {}) {
   const id = fixtureCount++;
@@ -108,12 +109,23 @@ function makeFixture({
   }
   // Fault injection: make one attest mode fail while its siblings still work,
   // so the hook's handling of a broken enumeration can be executed rather than
-  // reasoned about.
-  if (failAttestMode) {
+  // reasoned about. The base-guard response injection exercises the hook
+  // boundary separately: helper status and output are both untrusted inputs.
+  if (failAttestMode || baseGuardResponse) {
+    const injectedBaseGuard = baseGuardResponse
+      ? `if [ "$1" = base-guard ]; then\n` +
+        (baseGuardResponse.stdout
+          ? `  printf '%b\\n' ${JSON.stringify(baseGuardResponse.stdout)}\n`
+          : '') +
+        `  exit ${baseGuardResponse.status};\nfi\n`
+      : '';
     writeFileSync(
       join(root, 'scripts', 'prepush-attest.sh'),
       `#!/usr/bin/env bash\n` +
-        `if [ "$1" = ${JSON.stringify(failAttestMode)} ]; then exit 1; fi\n` +
+        injectedBaseGuard +
+        (failAttestMode
+          ? `if [ "$1" = ${JSON.stringify(failAttestMode)} ]; then exit 1; fi\n`
+          : '') +
         `exec bash ${JSON.stringify(join(REPO_ROOT, 'scripts', 'prepush-attest.sh'))} "$@"\n`,
     );
   }
@@ -158,6 +170,7 @@ function makeFixture({
     git(['add', '-A']);
     git(['commit', '--quiet', '-m', 'branch work']);
   }
+  if (baseGuardResponse) git(['switch', '--quiet', '-c', 'feature']);
 
   const run = (extraEnv = {}) => {
     let status = 0;
@@ -535,6 +548,45 @@ describe('a broken enumeration blocks the push, it does not empty the list', () 
       assert.equal(fixture.cached(), null);
     });
   }
+});
+
+describe('a broken base guard blocks the push, it does not default to zero', () => {
+  const cases = [
+    ['status 1', { status: 1, stdout: '' }],
+    ['status 2', { status: 2, stdout: '' }],
+    ['empty output', { status: 0, stdout: '' }],
+    ['missing tab field', { status: 0, stdout: 'main' }],
+    ['multiple records', { status: 0, stdout: 'main\t0\nmain\t0' }],
+    ['non-numeric count', { status: 0, stdout: 'main\tnot-a-count' }],
+  ];
+
+  for (const [label, baseGuardResponse] of cases) {
+    test(`${label} refuses the push and does not cache`, () => {
+      const fixture = makeFixture({
+        branchFiles: { 'tests/base-guard.test.mjs': 'x\n' },
+        baseGuardResponse,
+      });
+
+      const { status, stdout, invocations } = fixture.run();
+      assert.equal(status, 1, stdout);
+      assert.match(stdout, /branch-contamination guard/);
+      assert.deepEqual(tsxRuns(invocations), []);
+      assert.equal(fixture.cached(), null, 'a failed guard must not mint an attestation');
+    });
+  }
+
+  test('status 3 with a valid record preserves the contamination verdict', () => {
+    const fixture = makeFixture({
+      branchFiles: { 'tests/base-guard.test.mjs': 'x\n' },
+      baseGuardResponse: { status: 3, stdout: 'main\t21' },
+    });
+
+    const { status, stdout, invocations } = fixture.run();
+    assert.equal(status, 1, stdout);
+    assert.match(stdout, /21 commits ahead of origin\/main/);
+    assert.deepEqual(tsxRuns(invocations), []);
+    assert.equal(fixture.cached(), null);
+  });
 });
 
 function npmRuns(invocations) {


### PR DESCRIPTION
Fixes #6764.

## What this does

The hook fetched origin on **every** push before any gate ran (2.1s warm / 71.9s cold, measured in the issue) purely so the ">20 commits ahead" contamination guard couldn't false-positive against a stale remote-tracking ref. Per the issue's inversion argument — a fetch can only move `origin/<base>` *forward*, so the ahead-count can only *shrink* — a cached pass is a real pass, and only a cached failure needs the network to rule out staleness.

- New **`base-guard <base-ref> [limit]`** mode in `scripts/prepush-attest.sh` (per that file's charter: decisions live where a test can execute them, not inline in the hook). It counts against the cached `origin/<base>` first and fetches only when the cached count already exceeds the limit or the ref doesn't resolve; falls back to `origin/main` exactly like the hook did; prints `<resolved-base>\t<count>` and uses the file's three-valued exit convention (0 pass / 3 violation).
- The fetch is now **bounded** (`timeout 120` when available) and **tag-free** (`--no-tags`) — the issue's "unbounded fetch inside a hook" landmine.
- The hook consumes the reported base + count and keeps its exact error message; `WM_BASE_REF` and the PR-base override path are untouched (they resolve before the guard).

## Verification — all six acceptance criteria, executed not grepped

Five new fixtures in `tests/prepush-attest.test.mjs`, each driving the real script against a real clone+origin pair with a **fetch-logging `git` shim first on PATH**, so "no fetch happened" is an executed fact:

1. cached ahead-count ≤ limit → pass with **zero** `git fetch` invocations
2. genuinely 25 ahead → still fails (exit 3), after a corrective fetch confirmed it
3. stale-ref false positive (true count 1, cached ref rewound to read 26) → **passes** after the corrective fetch — the case the unconditional fetch existed to protect
4. no local remote-tracking ref → fetches and resolves
5. unresolvable base → falls back to `origin/main`, resolved base reported

Suite: 40/40 pass (35 existing + 5 new). `bash -n` on both shell files; biome clean.
