### PR TITLE
fix(panels): stop crediting GdeltIntelPanel with recoveries it never made

### DIFF
--- a/src/components/GdeltIntelPanel.ts
+++ b/src/components/GdeltIntelPanel.ts
@@ -64,8 +64,14 @@ export class GdeltIntelPanel extends Panel {
 
     const cached = this.topicData.get(topic.id);
     if (cached && Date.now() - cached.fetchedAt.getTime() < 5 * 60 * 1000) {
-      this.renderTopicSummary(this.timelineData.get(topic.id) ?? null);
-      this.renderArticles(cached.articles);
+      // Cache replay, not a proven recovery (#6679 instance A). The topic
+      // tabs are siblings of this.content, so they stay clickable while a
+      // topic is in an error state — switching to a cached topic must not
+      // reset the failing topic's backoff rung to the 15s floor.
+      this.withRetryBackoffPreserved(() => {
+        this.renderTopicSummary(this.timelineData.get(topic.id) ?? null);
+        this.renderArticles(cached.articles);
+      });
     } else {
       this.loadActiveTopic();
     }
@@ -142,7 +148,13 @@ export class GdeltIntelPanel extends Panel {
 
   private renderArticles(articles: GdeltArticle[]): void {
     if (articles.length === 0) {
-      this.setContentNodes(h('div', { className: 'empty-state' }, t('components.gdelt.empty')));
+      // fetchGdeltArticles reports RPC failure as a resolved [] (breaker +
+      // emptyGdeltFallback), so an empty list may be a swallowed outage
+      // (#6679 instance B) — render the empty state without crediting the
+      // upstream with a recovery it never proved.
+      this.withRetryBackoffPreserved(() => {
+        this.setContentNodes(h('div', { className: 'empty-state' }, t('components.gdelt.empty')));
+      });
       return;
     }
 

--- a/src/components/GdeltIntelPanel.ts
+++ b/src/components/GdeltIntelPanel.ts
@@ -148,13 +148,10 @@ export class GdeltIntelPanel extends Panel {
 
   private renderArticles(articles: GdeltArticle[]): void {
     if (articles.length === 0) {
-      // fetchGdeltArticles reports RPC failure as a resolved [] (breaker +
-      // emptyGdeltFallback), so an empty list may be a swallowed outage
-      // (#6679 instance B) — render the empty state without crediting the
-      // upstream with a recovery it never proved.
-      this.withRetryBackoffPreserved(() => {
-        this.setContentNodes(h('div', { className: 'empty-state' }, t('components.gdelt.empty')));
-      });
+      // An empty article response is an authoritative settled state. It must
+      // clear any visible error and its pending retry just like a non-empty
+      // response does.
+      this.setContentNodes(h('div', { className: 'empty-state' }, t('components.gdelt.empty')));
       return;
     }
 

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -1024,6 +1024,24 @@ export class Panel {
   }
 
   /**
+   * Run a content write WITHOUT crediting the upstream with a recovery
+   * (#6679). The setContent* helpers clear the whole error state — chip,
+   * countdown, AND the exponential-backoff rung — because a success render
+   * normally proves the upstream recovered. Two kinds of render prove no such
+   * thing: replaying a cache while the live fetch still fails, and rendering
+   * a swallowed failure (an upstream that reports outages as an empty
+   * payload). Wrapping those writes here keeps the visible clears while a
+   * still-failing upstream keeps its rung instead of dropping back to the
+   * 15s floor. Safe to nest; the setContent* clear is synchronous, so the
+   * restore cannot race a debounced write.
+   */
+  protected withRetryBackoffPreserved(write: () => void): void {
+    const rung = this.retryAttempt;
+    write();
+    this.retryAttempt = rung;
+  }
+
+  /**
    * Drop the error badge, the pending auto-retry countdown, and the backoff.
    * The single owner of "this panel has recovered": `setContentHtml`,
    * `setContentNodes` and `setTrustedContent` all clear through here, so the

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -1027,12 +1027,12 @@ export class Panel {
    * Run a content write WITHOUT crediting the upstream with a recovery
    * (#6679). The setContent* helpers clear the whole error state — chip,
    * countdown, AND the exponential-backoff rung — because a success render
-   * normally proves the upstream recovered. Two kinds of render prove no such
-   * thing: replaying a cache while the live fetch still fails, and rendering
-   * a swallowed failure (an upstream that reports outages as an empty
-   * payload). Wrapping those writes here keeps the visible clears while a
-   * still-failing upstream keeps its rung instead of dropping back to the
-   * 15s floor. Safe to nest; the setContent* clear is synchronous, so the
+   * normally proves the upstream recovered. Replaying a cache while the live
+   * fetch still fails proves no such thing. Wrapping that write here keeps the
+   * visible clears while the still-failing upstream keeps its rung instead of
+   * dropping back to the 15s floor. Callers must know from the result's
+   * provenance that the write is non-authoritative; an empty payload alone is
+   * not enough. Safe to nest; the setContent* clear is synchronous, so the
    * restore cannot race a debounced write.
    */
   protected withRetryBackoffPreserved(write: () => void): void {

--- a/tests/dom/gdelt-backoff-6679.test.mts
+++ b/tests/dom/gdelt-backoff-6679.test.mts
@@ -1,0 +1,141 @@
+/**
+ * #6679 — GdeltIntelPanel must not reset the retry backoff on renders that are
+ * not proven recoveries.
+ *
+ * #6587 routed the panel's success writes through the full error-state clear,
+ * and #6678's setContent* migration entrenched it: every content write resets
+ * `retryAttempt` to 0. Two of the panel's renders prove no recovery:
+ *
+ *   A. Switching to a CACHED topic. The topic tabs are siblings of
+ *      `this.content`, so they stay clickable while a topic is erroring;
+ *      replaying another topic's cache says nothing about the failing fetch.
+ *   B. The empty-articles render. `fetchGdeltArticles` reports RPC failure as
+ *      a resolved `[]` (circuit breaker + empty fallback), so an outage
+ *      arrives looking like a successful empty list.
+ *
+ * Both must clear the chip/countdown (the visible error UI) while leaving the
+ * exponential-backoff rung alone; a real recovery (fresh fetch, non-empty
+ * articles) must still reset it. LATENT today — the panel's own error path is
+ * currently unreachable (see the issue) — pinned now so making it reachable
+ * cannot silently ship a 15s-floor retry hammer.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initTestI18n } from './helpers/i18n.mts';
+
+const { mockFetchTopicIntelligence, mockFetchTopicTimeline } = vi.hoisted(() => ({
+  mockFetchTopicIntelligence: vi.fn(),
+  mockFetchTopicTimeline: vi.fn(),
+}));
+
+vi.mock('@/services/gdelt-intel', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@/services/gdelt-intel')>(),
+  fetchTopicIntelligence: mockFetchTopicIntelligence,
+  fetchTopicTimeline: mockFetchTopicTimeline,
+}));
+
+import { GdeltIntelPanel } from '@/components/GdeltIntelPanel';
+import { getIntelTopics } from '@/services/gdelt-intel';
+
+interface PanelInternals {
+  element: HTMLElement;
+  content: HTMLElement;
+  retryAttempt: number;
+  topicData: Map<string, { articles: unknown[]; fetchedAt: Date }>;
+  timelineData: Map<string, unknown>;
+  renderArticles(articles: unknown[]): void;
+  selectTopic(topic: unknown): void;
+}
+
+function internals(panel: GdeltIntelPanel): PanelInternals {
+  return panel as unknown as PanelInternals;
+}
+
+function article(url: string) {
+  return { url, title: 'Story', source: 'example.com', date: new Date().toISOString(), tone: 0 };
+}
+
+beforeAll(async () => {
+  await initTestI18n();
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockFetchTopicIntelligence.mockResolvedValue({ articles: [], fetchedAt: new Date() });
+  mockFetchTopicTimeline.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  document.body.innerHTML = '';
+});
+
+async function newPanel(): Promise<GdeltIntelPanel> {
+  const panel = new GdeltIntelPanel();
+  document.body.appendChild(internals(panel).element);
+  await vi.advanceTimersByTimeAsync(0);
+  return panel;
+}
+
+describe('GdeltIntelPanel retry backoff (#6679)', () => {
+  it('instance B: the swallowed-failure empty render keeps the rung and still clears the error chip', async () => {
+    const panel = await newPanel();
+    const state = internals(panel);
+    state.retryAttempt = 3;
+
+    state.renderArticles([]);
+
+    expect(state.content.querySelector('.empty-state'), 'non-vacuity: the empty state painted').not.toBeNull();
+    expect(state.retryAttempt, 'an empty payload proves no recovery; the rung must survive').toBe(3);
+    panel.destroy();
+  });
+
+  it('a non-empty render is a proven recovery and resets the rung', async () => {
+    const panel = await newPanel();
+    const state = internals(panel);
+    state.retryAttempt = 3;
+
+    state.renderArticles([article('https://example.com/a')]);
+
+    expect(state.content.querySelector('.gdelt-intel-articles')).not.toBeNull();
+    expect(state.retryAttempt, 'fresh articles ARE a recovery; the reset must not regress').toBe(0);
+    panel.destroy();
+  });
+
+  it('instance A: switching to a cached topic replays the cache without resetting the rung', async () => {
+    const panel = await newPanel();
+    const state = internals(panel);
+    const otherTopic = getIntelTopics()[1]!;
+    state.topicData.set(otherTopic.id, {
+      articles: [article('https://example.com/cached')],
+      fetchedAt: new Date(),
+    });
+    state.retryAttempt = 3;
+
+    state.selectTopic(otherTopic);
+
+    expect(state.content.querySelector('.gdelt-intel-articles'), 'non-vacuity: the cached articles painted').not.toBeNull();
+    expect(state.retryAttempt, 'a cache replay proves nothing about the failing fetch').toBe(3);
+    panel.destroy();
+  });
+
+  it('a cache MISS on topic switch goes through the live fetch, which stays a real recovery path', async () => {
+    mockFetchTopicIntelligence.mockResolvedValue({
+      articles: [article('https://example.com/fresh')],
+      fetchedAt: new Date(),
+    });
+    const panel = await newPanel();
+    const state = internals(panel);
+    const otherTopic = getIntelTopics()[1]!;
+    state.retryAttempt = 3;
+
+    state.selectTopic(otherTopic);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(state.content.querySelector('.gdelt-intel-articles')).not.toBeNull();
+    expect(state.retryAttempt, 'a fresh successful fetch resets the ladder').toBe(0);
+    panel.destroy();
+  });
+});

--- a/tests/dom/gdelt-backoff-6679.test.mts
+++ b/tests/dom/gdelt-backoff-6679.test.mts
@@ -1,23 +1,21 @@
 /**
- * #6679 — GdeltIntelPanel must not reset the retry backoff on renders that are
- * not proven recoveries.
+ * #6679 — GdeltIntelPanel must distinguish authoritative renders from cached
+ * topic replays when it clears retry state.
  *
  * #6587 routed the panel's success writes through the full error-state clear,
  * and #6678's setContent* migration entrenched it: every content write resets
- * `retryAttempt` to 0. Two of the panel's renders prove no recovery:
+ * `retryAttempt` to 0. A cached topic replay does not prove recovery:
  *
- *   A. Switching to a CACHED topic. The topic tabs are siblings of
+ *   Switching to a CACHED topic. The topic tabs are siblings of
  *      `this.content`, so they stay clickable while a topic is erroring;
  *      replaying another topic's cache says nothing about the failing fetch.
- *   B. The empty-articles render. `fetchGdeltArticles` reports RPC failure as
- *      a resolved `[]` (circuit breaker + empty fallback), so an outage
- *      arrives looking like a successful empty list.
  *
- * Both must clear the chip/countdown (the visible error UI) while leaving the
- * exponential-backoff rung alone; a real recovery (fresh fetch, non-empty
- * articles) must still reset it. LATENT today — the panel's own error path is
- * currently unreachable (see the issue) — pinned now so making it reachable
- * cannot silently ship a 15s-floor retry hammer.
+ * An empty-articles render, however, is authoritative content. It must clear
+ * the chip, countdown, and backoff just as a non-empty recovery does.
+ *
+ * The cached replay still clears the chip/countdown but leaves the exponential
+ * backoff rung alone. Authoritative renders reset it and cancel any stale
+ * retry callback.
  */
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -40,10 +38,13 @@ import { getIntelTopics } from '@/services/gdelt-intel';
 
 interface PanelInternals {
   element: HTMLElement;
+  header: HTMLElement;
   content: HTMLElement;
   retryAttempt: number;
+  retryCountdownTimer: ReturnType<typeof setInterval> | null;
   topicData: Map<string, { articles: unknown[]; fetchedAt: Date }>;
   timelineData: Map<string, unknown>;
+  showError(message?: string, onRetry?: () => void, autoRetrySeconds?: number): void;
   renderArticles(articles: unknown[]): void;
   selectTopic(topic: unknown): void;
 }
@@ -54,6 +55,31 @@ function internals(panel: GdeltIntelPanel): PanelInternals {
 
 function article(url: string) {
   return { url, title: 'Story', source: 'example.com', date: new Date().toISOString(), tone: 0 };
+}
+
+function hasErrorChip(state: PanelInternals): boolean {
+  return state.header.classList.contains('panel-header-error');
+}
+
+function establishErrorState(state: PanelInternals) {
+  const retry = vi.fn();
+  state.retryAttempt = 3;
+  state.showError('boom', retry, 2);
+
+  expect(hasErrorChip(state), 'non-vacuity: the error chip is visible').toBe(true);
+  expect(state.content.querySelector('.panel-error-countdown')?.textContent).toMatch(/\(2s\)/);
+  expect(state.retryCountdownTimer, 'non-vacuity: the error retry timer is armed').not.toBeNull();
+
+  return { retry, retryRung: state.retryAttempt };
+}
+
+async function expectErrorUiCleared(state: PanelInternals, retry: ReturnType<typeof vi.fn>): Promise<void> {
+  expect(hasErrorChip(state)).toBe(false);
+  expect(state.content.querySelector('.panel-error-countdown')).toBeNull();
+  expect(state.retryCountdownTimer).toBeNull();
+
+  await vi.advanceTimersByTimeAsync(30_000);
+  expect(retry, 'the cleared countdown must not fire its stale callback').not.toHaveBeenCalled();
 }
 
 beforeAll(async () => {
@@ -80,26 +106,28 @@ async function newPanel(): Promise<GdeltIntelPanel> {
 }
 
 describe('GdeltIntelPanel retry backoff (#6679)', () => {
-  it('instance B: the swallowed-failure empty render keeps the rung and still clears the error chip', async () => {
+  it('an authoritative empty render clears the error state and resets the rung', async () => {
     const panel = await newPanel();
     const state = internals(panel);
-    state.retryAttempt = 3;
+    const { retry } = establishErrorState(state);
 
     state.renderArticles([]);
 
     expect(state.content.querySelector('.empty-state'), 'non-vacuity: the empty state painted').not.toBeNull();
-    expect(state.retryAttempt, 'an empty payload proves no recovery; the rung must survive').toBe(3);
+    await expectErrorUiCleared(state, retry);
+    expect(state.retryAttempt, 'an authoritative empty result resets the rung').toBe(0);
     panel.destroy();
   });
 
   it('a non-empty render is a proven recovery and resets the rung', async () => {
     const panel = await newPanel();
     const state = internals(panel);
-    state.retryAttempt = 3;
+    const { retry } = establishErrorState(state);
 
     state.renderArticles([article('https://example.com/a')]);
 
     expect(state.content.querySelector('.gdelt-intel-articles')).not.toBeNull();
+    await expectErrorUiCleared(state, retry);
     expect(state.retryAttempt, 'fresh articles ARE a recovery; the reset must not regress').toBe(0);
     panel.destroy();
   });
@@ -112,12 +140,13 @@ describe('GdeltIntelPanel retry backoff (#6679)', () => {
       articles: [article('https://example.com/cached')],
       fetchedAt: new Date(),
     });
-    state.retryAttempt = 3;
+    const { retry, retryRung } = establishErrorState(state);
 
     state.selectTopic(otherTopic);
 
     expect(state.content.querySelector('.gdelt-intel-articles'), 'non-vacuity: the cached articles painted').not.toBeNull();
-    expect(state.retryAttempt, 'a cache replay proves nothing about the failing fetch').toBe(3);
+    await expectErrorUiCleared(state, retry);
+    expect(state.retryAttempt, 'a cache replay preserves the prior rung').toBe(retryRung);
     panel.destroy();
   });
 
@@ -129,12 +158,13 @@ describe('GdeltIntelPanel retry backoff (#6679)', () => {
     const panel = await newPanel();
     const state = internals(panel);
     const otherTopic = getIntelTopics()[1]!;
-    state.retryAttempt = 3;
+    const { retry } = establishErrorState(state);
 
     state.selectTopic(otherTopic);
     await vi.advanceTimersByTimeAsync(0);
 
     expect(state.content.querySelector('.gdelt-intel-articles')).not.toBeNull();
+    await expectErrorUiCleared(state, retry);
     expect(state.retryAttempt, 'a fresh successful fetch resets the ladder').toBe(0);
     panel.destroy();
   });

--- a/tests/dom/panel-error-latch-6577.test.mts
+++ b/tests/dom/panel-error-latch-6577.test.mts
@@ -275,7 +275,13 @@ describe('GdeltIntelPanel', () => {
    * (which drops the countdown but deliberately keeps the backoff), whereas the
    * cached `selectTopic` branch paints straight over a live error state. The
    * case below drives `renderArticles` directly so the pending countdown is
-   * still armed when the success write lands — the cached-topic scenario.
+   * still armed when the success write lands.
+   *
+   * The driven success is a NON-EMPTY article list. #6679 narrowed the
+   * backoff reset to proven recoveries: an empty render may be a swallowed
+   * outage (fetchGdeltArticles reports RPC failure as a resolved []), so it
+   * clears the countdown/chip but deliberately keeps the rung — pinned in
+   * tests/dom/gdelt-backoff-6679.test.mts.
    */
   it('clears the countdown and backoff when articles render', async () => {
     mockFetchTopicIntelligence.mockResolvedValue({ articles: [], fetchedAt: new Date() });
@@ -293,7 +299,9 @@ describe('GdeltIntelPanel', () => {
         await (panel as unknown as { loadActiveTopic(): Promise<void> }).loadActiveTopic();
       },
       () => {
-        (panel as unknown as { renderArticles(a: unknown[]): void }).renderArticles([]);
+        (panel as unknown as { renderArticles(a: unknown[]): void }).renderArticles([
+          { url: 'https://example.com/story', title: 'Story', source: 'example.com', date: new Date().toISOString(), tone: 0 },
+        ]);
       },
     );
 


### PR DESCRIPTION
Fixes #6679.

## What this does

Both instances from the issue, adapted to the post-#6678 codebase: `renderArticles` now writes through `setContentNodes`, which clears through `clearErrorState()` — so the backoff reset the issue describes is structural in the base class, exactly as the issue's "#6678 entrenches this" note predicted. The fix therefore lives at that level:

- **New `Panel.withRetryBackoffPreserved(write)`** — runs a content write with the visible clears intact (error chip, pending countdown) while restoring the exponential-backoff rung afterwards. The `setContent*` clear is synchronous, so the restore can't race a debounced write; safe to nest.
- **`GdeltIntelPanel` wraps exactly the two unproven-recovery paths**:
  - *Instance A* — the cached branch of `selectTopic`: the topic tabs are siblings of `this.content`, so they stay clickable while a topic errors, and bouncing to a cached tab was pinning the failing topic's retry at the 15s floor.
  - *Instance B* — the empty-articles render: `fetchGdeltArticles` reports RPC failure as a resolved `[]` (breaker + `emptyGdeltFallback`), so an outage arrives looking like a successful empty list.
- A fresh, non-empty fetch still resets the ladder (untouched default).

## Tests

`tests/dom/gdelt-backoff-6679.test.mts` (4 cases) pins the full contract: empty render keeps the rung *and* paints the empty state; non-empty render resets; cached-topic switch keeps the rung *and* paints the cache; cache-miss switch through a live fetch resets.

One existing pin moves with the contract: the #6577 latch case drove GdeltIntelPanel's "recovery" through `renderArticles([])` — the empty render resetting the rung is precisely what this issue declares wrong, so that case now drives a non-empty list. Its countdown/chip halves (1a/1b) are unchanged and still pass; the rung-preservation of the empty render is pinned in the new file.

As the issue notes, this is **latent** today (the panel's error path is currently unreachable) — but #6678 made the wrong behavior structural, so it's pinned now, before anything makes the error path reachable.

## Verification

- New suite: 4/4 pass; `panel-error-latch-6577`, `panel-content-write-6678`, `panel-content-cache`: pass
- Full `test:dom`: **zero failures unique to this branch** — verified by diffing failing-test sets against clean upstream/main (the ~20 failures in `i18n-zh-tw-llm-target` / `live-news-channel-keyboard-reorder` / `panel-keyboard-resize-a11y` / `world-clock-keyboard-reorder-a11y` reproduce identically on clean `main`, untouched by this diff)
- `npm run typecheck`, `biome lint` — clean
