### PR TITLE
fix(umami): stop the retention alarm firing on a timer instead of on failure

### DIFF
--- a/.github/workflows/umami-storage-monitor.yml
+++ b/.github/workflows/umami-storage-monitor.yml
@@ -97,7 +97,7 @@ jobs:
           set -euo pipefail
           mkdir -p .cache
           railway deployment list --project "$RAILWAY_PROJECT_ID" --environment production \
-            --service umami-retention --limit 200 --json > .cache/railway-retention-deployments.json
+            --service umami-retention --limit 1000 --json > .cache/railway-retention-deployments.json
 
       - name: Check the retention runner is retiring rows
         if: ${{ !cancelled() }}

--- a/docs/analytics-collector-operations.md
+++ b/docs/analytics-collector-operations.md
@@ -407,7 +407,7 @@ To read what the last tick actually did:
 
 ```
 railway deployment list --project "$RAILWAY_PROJECT_ID" --environment production \
-  --service umami-retention --limit 200 --json
+  --service umami-retention --limit 1000 --json
 ```
 
 Every push to `main` writes a `SKIPPED` refusal ("No changes to watched files")
@@ -416,6 +416,29 @@ record is almost never the tick. Take the newest record whose status is a
 *running* one, then read that deployment's logs. A healthy tick logs `BEGIN`,
 `DELETE <n>`, `COMMIT` per statement; a locked-out tick logs the skip message
 and exits 0.
+
+### `HISTORY_WINDOW_SATURATED` — the runner is invisible, not dead
+
+If the alarm reports this verdict, **check the tick logs before touching
+Postgres.** Refusals accrued at ~29.5/day through August, so a window of N
+records only reaches back N/29.5 days. On 2026-08-22 the active deployment was
+5.5 days old and healthy — 71 of 71 scheduled ticks fired, zero errors — but sat
+at index 206 behind 206 refusals, so a 200-record window could not see it and
+the alarm read as if retention had died.
+
+`--limit 1000` (the CLI maximum) buys ~34 days. When even that saturates, the
+deciding record is *older than the window*, not missing:
+
+```
+# authoritative pointer to the active deployment, immune to refusal depth
+railway logs --project "$RAILWAY_PROJECT_ID" --environment production \
+  --service umami-retention
+```
+
+A redeploy also clears it by minting a fresh record at index 0. The Railway
+GraphQL field `serviceInstance.latestDeployment` names the active deployment
+directly and would remove this depth limit permanently; the CLI exposes no
+equivalent (`railway status --json` returns only `{id, name}` per service).
 
 The runtime-image migration and the retention runner are separate gates. Do
 not start retention until the composite-index migration has succeeded and the

--- a/scripts/check-umami-retention-runner.mjs
+++ b/scripts/check-umami-retention-runner.mjs
@@ -30,14 +30,21 @@ import {
 
 export const RETENTION_RUNNER_SERVICE = 'umami-retention';
 
-// Deep enough that ordinary push traffic cannot bury the record that decides
-// health. A cron tick does NOT create a deployment record — it re-runs the
-// active one — so the record we need is written only by a deploy or redeploy
-// and can be days old while the service is perfectly healthy. Meanwhile every
-// push to main writes a SKIPPED refusal for this service ("No changes to
-// watched files"), so refusals accumulate and the record we want sinks. Depth
-// is the only defence, and it costs the same single CLI call either way.
-export const RETENTION_HISTORY_WINDOW = 200;
+// A cron tick does NOT create a deployment record — it re-runs the active one —
+// so the record that decides health is written only by a deploy or redeploy and
+// can be days old while the service is perfectly healthy. Meanwhile every push
+// to main writes a SKIPPED refusal for this service ("No changes to watched
+// files"), so refusals accumulate and the record we want sinks.
+//
+// Depth alone cannot fix that. Refusals arrived at ~29.5/day through August, so
+// a window of N records is exhausted after N/29.5 days: the old window of 200
+// lasted 6.8 days, and on 2026-08-22 the active deployment — 5.5 days old and
+// healthy, 71 of 71 ticks fired that day — sat at index 206 and went unseen.
+// Any constant is a false alarm on a schedule; this is the CLI's maximum
+// (`railway deployment list --limit`, max 1000), which costs the same single
+// call and buys ~34 days, and `HISTORY_WINDOW_SATURATED` below reports honestly
+// when even that is not enough instead of blaming the database.
+export const RETENTION_HISTORY_WINDOW = 1000;
 
 export function normalizeDeploymentRows(payload) {
   if (Array.isArray(payload)) return payload;
@@ -52,7 +59,7 @@ export function normalizeDeploymentRows(payload) {
  * Fails closed: anything this cannot read, recognise, or prove is alarming.
  * A silent pass here re-creates the exact failure it exists to catch.
  */
-export function evaluateRetentionRunner(payload) {
+export function evaluateRetentionRunner(payload, historyWindow = RETENTION_HISTORY_WINDOW) {
   const rows = normalizeDeploymentRows(payload);
   if (rows === null) {
     return {
@@ -92,6 +99,32 @@ export function evaluateRetentionRunner(payload) {
 
   if (!running) {
     const refusals = ordered.filter((row) => row?.status === REJECTED_STATUS).length;
+    // Reaching the requested depth means the read was TRUNCATED: the deciding
+    // record may sit one past the edge, which is exactly what happened on
+    // 2026-08-22 (active deployment at index 206, window 200, runner healthy).
+    // A short history is the whole history, so there "nothing ever ran" is a
+    // fact about the runner rather than about how far we looked.
+    //
+    // Both stay alarming — neither observes the runner — but they demand
+    // opposite responses, so they must not share a verdict. Calling a saturated
+    // window NO_RUNNING_DEPLOYMENT sends the operator to Postgres to investigate
+    // a database that is fine.
+    const saturated = Number.isFinite(historyWindow) && ordered.length >= historyWindow;
+    if (saturated) {
+      return {
+        verdict: 'HISTORY_WINDOW_SATURATED',
+        alarming: true,
+        // Report the counted refusals rather than asserting every record is one:
+        // this branch only requires that no record REACHED a running state, and a
+        // window full of FAILED builds satisfies that too. Saying "all N were
+        // refusals" there would be false, in the one sentence an operator reads.
+        detail: `none of the ${ordered.length} records read reached a running state `
+          + `(${refusals} were ${REJECTED_STATUS} refusals) and the read filled its `
+          + `${historyWindow}-record window, so the deployment that decides health is older `
+          + 'than the window rather than absent — widen --limit (Railway CLI max 1000) or '
+          + 'redeploy the service to mint a fresh record',
+      };
+    }
     return {
       verdict: 'NO_RUNNING_DEPLOYMENT',
       alarming: true,
@@ -190,9 +223,18 @@ async function main() {
     // expired token, an API blip, a renamed service, a status we do not model.
     // Both fail the run, but telling an operator "Postgres will fill" when the
     // truth is "the token expired" is how an alarm loses its audience.
+    const unobserved = `Could not establish whether ${RETENTION_RUNNER_SERVICE} is retiring rows, `
+      + 'so it is unobserved.';
     const consequence = result.verdict === 'CRASHED'
       ? `The ${RETENTION_RUNNER_SERVICE} cron service is failing, so Umami Postgres will fill until it is fixed.`
-      : `Could not establish whether ${RETENTION_RUNNER_SERVICE} is retiring rows, so it is unobserved.`;
+      : result.verdict === 'HISTORY_WINDOW_SATURATED'
+        // Deliberately does NOT say the runner is failing. This verdict means the
+        // read could not see far enough, and the runner is usually healthy when
+        // it fires — check the tick logs before touching Postgres.
+        ? `${unobserved} This is a read-depth limit, not evidence the runner is broken: `
+          + `confirm with \`railway logs\` on the active ${RETENTION_RUNNER_SERVICE} deployment `
+          + 'before treating it as an outage.'
+        : unobserved;
     console.error(`::error::${result.verdict}: ${result.detail}. ${consequence}`);
     process.exitCode = 1;
   }

--- a/tests/umami-retention-runner.test.mjs
+++ b/tests/umami-retention-runner.test.mjs
@@ -202,6 +202,93 @@ describe('Umami retention runner check (#6375)', () => {
     assert.match(missing.stderr, /not found/);
   });
 
+
+  // 2026-08-22 production incident: the alarm fired NO_RUNNING_DEPLOYMENT
+  // reading "none of the newest 200 records reached a running state (200 were
+  // SKIPPED refusals)" while `umami-retention` was perfectly healthy — 71 of 71
+  // scheduled ticks fired that day, zero errors, the newest at 06:52:59Z
+  // retiring rows normally.
+  //
+  // The runner was invisible, not dead. Its active deployment sat at index 206
+  // of the recency-ordered history; the window read 200. Refusals accrue at
+  // ~29.5/day (one per push to main), so ANY fixed window N is exhausted after
+  // N/29.5 days — 200 lasted 6.8 — while a healthy deployment routinely lives
+  // longer than that. The old comment here called depth "the only defence";
+  // depth alone guarantees a false alarm on a schedule.
+  //
+  // Both states must keep alarming: neither one observes the runner. But they
+  // demand opposite responses — one says "the retention runner is dead, Postgres
+  // will fill", the other says "widen the window" — so they must not share a
+  // verdict.
+  it('separates a saturated window from a runner that genuinely never ran', () => {
+    const refusals = (count) => Array.from({ length: count }, (_, index) => record({
+      id: `skip-${index}`,
+      status: 'SKIPPED',
+      // Newest first; one per ~49 minutes, the observed push cadence.
+      createdAt: new Date(Date.parse('2026-08-22T06:00:00.000Z') - index * 2_940_000).toISOString(),
+    }));
+
+    // Window filled to the requested depth: the deciding record may sit just
+    // past the edge, exactly as it did in production.
+    const saturated = evaluateRetentionRunner(refusals(RETENTION_HISTORY_WINDOW));
+    assert.equal(saturated.verdict, 'HISTORY_WINDOW_SATURATED');
+    assert.equal(saturated.alarming, true, 'a window we cannot see past is still unobserved');
+    assert.match(
+      saturated.detail,
+      /window/i,
+      'the operator must be told the window is the problem, not the database',
+    );
+
+    // Short of the requested depth: this IS the service's entire history, so
+    // "nothing ever ran" is a fact about the runner rather than the window.
+    const complete = evaluateRetentionRunner(refusals(RETENTION_HISTORY_WINDOW - 1));
+    assert.equal(complete.verdict, 'NO_RUNNING_DEPLOYMENT');
+    assert.equal(complete.alarming, true);
+
+    // A saturated window that DOES contain a running record is not saturated in
+    // any way that matters — the record it needed is present.
+    const saturatedButAnswered = [
+      ...refusals(RETENTION_HISTORY_WINDOW - 1),
+      record({ id: 'tick', status: 'SUCCESS', createdAt: '2026-01-01T00:00:00.000Z' }),
+    ];
+    assert.equal(evaluateRetentionRunner(saturatedButAnswered).verdict, 'HEALTHY');
+    assert.equal(evaluateRetentionRunner(saturatedButAnswered).deploymentId, 'tick');
+  });
+
+  it('names the window in the saturated alarm so the remedy is unambiguous', () => {
+    const refusals = Array.from({ length: RETENTION_HISTORY_WINDOW }, (_, index) => record({
+      id: `skip-${index}`,
+      status: 'SKIPPED',
+      createdAt: new Date(Date.parse('2026-08-22T06:00:00.000Z') - index * 2_940_000).toISOString(),
+    }));
+    const cli = runCli(refusals);
+
+    assert.equal(cli.status, 1, 'saturation must still fail the run — the runner is unobserved');
+    assert.match(cli.stdout, /HISTORY_WINDOW_SATURATED/);
+    // The operator consequence must not claim the database is filling: that was
+    // the misdiagnosis this verdict exists to prevent.
+    assert.doesNotMatch(cli.stderr, /will fill/);
+    assert.match(cli.stderr, /unobserved/);
+  });
+
+  // The saturation branch triggers on "no record REACHED a running state", which
+  // a window of FAILED builds satisfies just as well as a window of refusals.
+  // An earlier draft of the detail asserted "all N records read were SKIPPED
+  // refusals" — false in exactly that case, in the one sentence an operator
+  // reads at 03:00. The count must be counted, never assumed.
+  it('counts refusals rather than asserting every saturating record is one', () => {
+    const failedBuilds = Array.from({ length: RETENTION_HISTORY_WINDOW }, (_, index) => record({
+      id: `failed-${index}`,
+      status: 'FAILED',
+      createdAt: new Date(Date.parse('2026-08-22T06:00:00.000Z') - index * 2_940_000).toISOString(),
+    }));
+
+    const result = evaluateRetentionRunner(failedBuilds);
+    assert.equal(result.verdict, 'HISTORY_WINDOW_SATURATED');
+    assert.equal(result.alarming, true);
+    assert.match(result.detail, /\(0 were SKIPPED refusals\)/, 'zero refusals must report as zero');
+    assert.doesNotMatch(result.detail, /all \d+ records read were SKIPPED/);
+  });
   it('reads the runner history deeply enough to see past push refusals', () => {
     const readStep = steps.find((step) => /railway deployment list/.test(step.run ?? ''));
 


### PR DESCRIPTION
## Summary

The Umami Storage Monitor paged this morning:

> `NO_RUNNING_DEPLOYMENT: none of the newest 200 records reached a running state (200 were SKIPPED refusals)` — *Could not establish whether umami-retention is retiring rows, so it is unobserved.*

**The runner was healthy.** From its Railway deployment logs on 2026-08-22: **71 of 71 scheduled ticks fired**, zero error lines, the newest at 06:52:59Z running `BEGIN ×8 / DELETE ×6 / COMMIT ×8`, `nextCronRunAt` on schedule. `umami-retention` was **invisible, not dead**.

## Why it fired

A cron tick creates **no** deployment record — it re-runs the active one — so the record that decides health is written only on deploy/redeploy. Meanwhile every push to `main` writes a `SKIPPED` "No changes to watched files" refusal that pushes it further down the list.

| | measured |
|---|---|
| refusal rate | **29.5/day** |
| reach of an N-record window | **N / 29.5 days** → 200 = **6.8 days** |
| active deployment age | **5.5 days** |
| its index in the list | **206** — six past the edge |

So the alarm was a false positive **on a schedule**, not on failure. It fired the moment refusals crossed 200; commit velocity picked the date.

The old comment in this file read *"Depth is the only defence."* That premise is the bug: any constant N is exhausted on a timer, so the alarm eventually fires on a perfectly healthy service. A guard that must cry wolf on a clock trains its operator to ignore it — which is the failure mode this monitor was written to prevent.

## The change

**1. Window 200 → 1000** (the Railway CLI maximum). Same single call, ~1.5 MB, ~34 days of reach instead of 6.8. This alone is only a later cliff, which is why it isn't the whole fix.

**2. New verdict `HISTORY_WINDOW_SATURATED`** — the structural half. Rows returned *reaching* the requested limit means the read was **truncated**, and the deciding record may sit one past the edge. Fewer rows means the whole history was seen, so "nothing ran" is a fact about the runner.

Both still alarm and still fail the job — neither observes the runner — but they demand opposite responses, so they no longer share a verdict. Its operator consequence deliberately does **not** say "Postgres will fill"; it points at the tick logs. That sentence was the misdiagnosis.

## Validation

Verified against the **real production payload at both limits**, not fixtures:

| | records | verdict |
|---|---|---|
| `--limit 200` | 200, all `SKIPPED` | `HISTORY_WINDOW_SATURATED`, remedy named |
| `--limit 1000` | 497 (488 SKIPPED, 8 REMOVED, 1 SUCCESS) | **`HEALTHY`, exit 0** |

The healthy verdict names deployment `9074ef97-1ebb-4d26-8381-f7fd1754c399` — the same record Railway's `serviceInstance.latestDeployment` independently reports as active.

The saturation branch is **mutation-tested both ways**: forcing it `false` reddens the saturation tests, forcing it `true` reddens the genuine-never-ran case. Neither direction is vacuous.

Review also caught a bug in my own alarm text: the detail asserted *"all N records read were SKIPPED refusals"* when the branch only requires that none reached a *running* state — a window of `FAILED` builds would have printed a false sentence in the one line an operator reads at 03:00. Refusals are now counted rather than assumed, with a test pinning the zero-refusal case.

78 tests pass (`umami-retention-runner`, `umami-storage-monitor`, `railway-fleet-deployments`); `tsc --noEmit` clean. The existing tests already pin the workflow `--limit` and the runbook command to `RETENTION_HISTORY_WINDOW`, so all three move together.

No visual evidence: this is a CI alarm with no user-facing surface.

## Deliberately not included

Railway's GraphQL `serviceInstance.latestDeployment` names the active deployment with **no depth limit** and would remove this cliff permanently — it is how I found the record in the first place. The CLI exposes no equivalent (`railway status --json` returns only `{id, name}` per service), so adopting it means adding raw GraphQL plus environment/service IDs to a production monitoring workflow. That is a larger change than this alarm warranted; the runbook now documents it as the follow-up.

## New concepts

**A guard whose input window is consumed by unrelated traffic fires on a clock, not on failure.** The health signal here (a deploy record) is written rarely, while noise (push refusals) is written constantly into the same list — so a fixed-size read is a countdown, and its expiry date is set by commit velocity. Whenever a check reads "the newest N of X" and the thing it needs is *not* the thing that dominates X, N is a timer. The fix is to select by **identity** (ask which deployment is active) rather than by **position**; when the API cannot express identity, the check must at minimum be able to tell "I saw everything" from "I ran out of window."

**Truncation is a distinct verdict from absence.** `[]` after reading the whole history and `[]` after filling your buffer look identical at the call site but mean opposite things — one is evidence about the system, the other is evidence about your instrument. A check that collapses them will confidently report a database emergency when the real answer is "look further." Detecting it costs one comparison — `rowsReturned >= limitRequested` — and the value is entirely in the operator's next action, not in the exit code, since both still fail closed.
