### PR TITLE
fix(news): name every digest feed attempt and schedule categories fairly

### DIFF
--- a/server/worldmonitor/news/v1/_attempts.ts
+++ b/server/worldmonitor/news/v1/_attempts.ts
@@ -1,0 +1,149 @@
+/**
+ * Closed attempt vocabulary and pure classifiers for digest feed execution
+ * (#7083).
+ *
+ * Previously every feed that did not complete a digest build was labeled
+ * `timeout`, including feeds whose batch never started before the global
+ * deadline, and fetch failures were swallowed into `empty` (the fetch path
+ * resolves with a zero-item ParseResult instead of rejecting). This module
+ * gives every terminal attempt state one stable name so scheduling
+ * starvation is distinguishable from upstream failure in tests, logs, and
+ * the feed status map.
+ *
+ * Kept import-free so the digest test suite can bundle it directly.
+ */
+
+export const FEED_ATTEMPT_OUTCOMES = [
+  // The fetch completed and produced at least one kept item.
+  'completed',
+  // The fetch completed with zero parsed items.
+  'empty',
+  // Parsed items existed but every one was dropped for missing/unparseable dates.
+  'all-undated',
+  // Some items were kept and some dropped for missing/unparseable dates.
+  'partial-undated',
+  // The per-feed timeout fired during the direct fetch.
+  'direct-timeout',
+  // Direct fetch failed for another reason and the relay fallback also failed.
+  'relay-failure',
+  // The global digest deadline aborted an in-flight fetch.
+  'aborted-by-deadline',
+  // A bounded fetch failure that is none of the above (network error etc.).
+  'other-fetch-failure',
+  // A zero-item negative-cache entry from a previous failed attempt was served.
+  'negative-cache',
+  // The feed's batch never started before the global deadline.
+  'not-started',
+] as const;
+
+export type FeedAttemptOutcome = (typeof FEED_ATTEMPT_OUTCOMES)[number];
+
+/** What the fetch path reports about how a single feed attempt ended. */
+export interface FeedFetchAttempt {
+  /** Where the text came from, when the attempt produced text. */
+  source: 'direct' | 'relay' | 'cache';
+  /**
+   * Why the attempt ended without text, when it did. `null` when the fetch
+   * produced text or served a healthy cache entry.
+   */
+  failure:
+    | null
+    | 'per-feed-timeout'
+    | 'deadline-abort'
+    | 'direct-error'
+    | 'relay-error';
+  /** True when a zero-item negative-cache entry was served. */
+  negativeCache: boolean;
+}
+
+/** Item-level counts used to pick between the undated outcomes. */
+export interface FeedItemCounters {
+  parsedTotal: number;
+  keptItems: number;
+  droppedUndated: number;
+}
+
+/**
+ * Classify one feed attempt into the closed vocabulary. Pure: same inputs,
+ * same output, no clock or signal access — the caller supplies the fetch
+ * path's verdict and whether the feed ever started.
+ */
+export function classifyFeedAttempt(
+  started: boolean,
+  attempt: FeedFetchAttempt,
+  counters: FeedItemCounters,
+): FeedAttemptOutcome {
+  if (!started) {
+    return 'not-started';
+  }
+
+  const kept = counters.keptItems;
+  const droppedUndated = counters.droppedUndated;
+  const parsedTotal = counters.parsedTotal;
+
+  if (kept > 0) {
+    return droppedUndated > 0 ? 'partial-undated' : 'completed';
+  }
+
+  // Zero kept items: distinguish why.
+  if (attempt.negativeCache) {
+    return 'negative-cache';
+  }
+
+  if (attempt.failure === 'per-feed-timeout') {
+    return 'direct-timeout';
+  }
+
+  if (attempt.failure === 'deadline-abort') {
+    return 'aborted-by-deadline';
+  }
+
+  if (attempt.failure === 'relay-error' || attempt.failure === 'direct-error') {
+    return 'relay-failure';
+  }
+
+  if (parsedTotal > 0 && droppedUndated > 0) {
+    return 'all-undated';
+  }
+
+  return 'empty';
+}
+
+/**
+ * Interleave feed entries by category so every eligible category gets an
+ * early scheduling opportunity (#7083): the first N entries contain the
+ * head of every category, and a slow category cannot push all later
+ * categories behind the global deadline.
+ *
+ * Deterministic: categories keep their first-appearance order, and feeds
+ * keep their relative order inside their category. Strategic priorities
+ * are applied by the caller's ordering BEFORE interleaving, so
+ * `deadlinePriority` still decides who goes first within a category.
+ */
+export function interleaveByCategory<T extends { category: string }>(
+  entries: readonly T[],
+): T[] {
+  const byCategory = new Map<string, T[]>();
+  for (const entry of entries) {
+    const bucket = byCategory.get(entry.category);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      byCategory.set(entry.category, [entry]);
+    }
+  }
+
+  const queues = [...byCategory.values()];
+  const ordered: T[] = [];
+  let remaining = entries.length;
+  while (remaining > 0) {
+    for (const queue of queues) {
+      const next = queue.shift();
+      if (next !== undefined) {
+        ordered.push(next);
+        remaining -= 1;
+      }
+    }
+  }
+  return ordered;
+}

--- a/server/worldmonitor/news/v1/_attempts.ts
+++ b/server/worldmonitor/news/v1/_attempts.ts
@@ -63,6 +63,48 @@ export interface FeedItemCounters {
   droppedUndated: number;
 }
 
+export type FeedFetchFailure = Exclude<FeedFetchAttempt['failure'], null>;
+
+export interface TerminalFetchFailureInput {
+  directFailure: FeedFetchAttempt['failure'];
+  relayFailure: FeedFetchAttempt['failure'];
+  relayAttempted: boolean;
+  deadlineAborted: boolean;
+}
+
+/**
+ * Choose the terminal fetch failure without losing which leg ended last.
+ * A global deadline always wins because it invalidates both fetch legs.
+ */
+export function resolveTerminalFetchFailure({
+  directFailure,
+  relayFailure,
+  relayAttempted,
+  deadlineAborted,
+}: TerminalFetchFailureInput,
+): FeedFetchFailure {
+  if (deadlineAborted || directFailure === 'deadline-abort' || relayFailure === 'deadline-abort') {
+    return 'deadline-abort';
+  }
+  // The closed vocabulary has one relay terminal state. Do not let a relay
+  // leg's own timeout inherit the direct leg's `direct-timeout` label.
+  if (relayAttempted) return 'relay-error';
+  return directFailure ?? 'direct-error';
+}
+
+/**
+ * Describe a cached zero-item result without changing successful empties
+ * into failures.  A cached prior failure is explicitly a negative-cache hit.
+ */
+export function cachedAttemptFrom(prior: FeedFetchAttempt | undefined): FeedFetchAttempt {
+  const failure = prior?.failure ?? null;
+  return {
+    source: 'cache',
+    failure,
+    negativeCache: prior?.negativeCache === true || failure !== null,
+  };
+}
+
 /**
  * Classify one feed attempt into the closed vocabulary. Pure: same inputs,
  * same output, no clock or signal access — the caller supplies the fetch
@@ -98,8 +140,12 @@ export function classifyFeedAttempt(
     return 'aborted-by-deadline';
   }
 
-  if (attempt.failure === 'relay-error' || attempt.failure === 'direct-error') {
+  if (attempt.failure === 'relay-error') {
     return 'relay-failure';
+  }
+
+  if (attempt.failure === 'direct-error') {
+    return 'other-fetch-failure';
   }
 
   if (parsedTotal > 0 && droppedUndated > 0) {
@@ -107,6 +153,115 @@ export function classifyFeedAttempt(
   }
 
   return 'empty';
+}
+
+export interface FeedAttemptBatchEntry {
+  attemptId: string;
+  category: string;
+}
+
+export interface FeedAttemptExecution<T> {
+  value: T;
+  outcome: FeedAttemptOutcome;
+}
+
+export interface FeedAttemptBatchResult<E extends FeedAttemptBatchEntry, T> {
+  fulfilled: Array<{ entry: E; value: T }>;
+  startedAttemptIds: Set<string>;
+  attemptCategories: Map<string, string>;
+  attemptOutcomes: Map<string, FeedAttemptOutcome>;
+  firstStartMs: number | null;
+  firstCompletionMs: number | null;
+  finalCompletionMs: number | null;
+}
+
+export interface FeedAttemptTelemetrySummary {
+  byOutcome: Record<string, number>;
+  byCategory: Record<string, Record<string, number>>;
+  headroomMs: number;
+}
+
+/** Build the structured per-attempt counters emitted by the digest runner. */
+export function summarizeFeedAttempts(
+  attemptCategories: ReadonlyMap<string, string>,
+  attemptOutcomes: ReadonlyMap<string, FeedAttemptOutcome>,
+  overallDeadlineMs: number,
+  elapsedMs: number,
+): FeedAttemptTelemetrySummary {
+  const byOutcome: Record<string, number> = {};
+  for (const outcome of attemptOutcomes.values()) {
+    byOutcome[outcome] = (byOutcome[outcome] ?? 0) + 1;
+  }
+
+  const byCategory: Record<string, Record<string, number>> = {};
+  for (const [attemptId, category] of attemptCategories) {
+    const outcome = attemptOutcomes.get(attemptId) ?? 'unknown';
+    const categoryOutcomes = (byCategory[category] ??= {});
+    categoryOutcomes[outcome] = (categoryOutcomes[outcome] ?? 0) + 1;
+  }
+
+  return {
+    byOutcome,
+    byCategory,
+    headroomMs: Math.max(0, overallDeadlineMs - elapsedMs),
+  };
+}
+
+/**
+ * Execute feed batches while retaining an attempt ledger keyed by a stable,
+ * unique ID.  The executor owns successful classification; a rejected
+ * execution is always an otherwise-unclassified bounded fetch failure.
+ */
+export async function runFeedAttemptBatches<E extends FeedAttemptBatchEntry, T>(
+  allEntries: readonly E[],
+  batches: readonly (readonly E[])[],
+  signal: AbortSignal,
+  execute: (entry: E) => Promise<FeedAttemptExecution<T>>,
+  now: () => number = Date.now,
+): Promise<FeedAttemptBatchResult<E, T>> {
+  const fulfilled: Array<{ entry: E; value: T }> = [];
+  const startedAttemptIds = new Set<string>();
+  const attemptCategories = new Map<string, string>();
+  const attemptOutcomes = new Map<string, FeedAttemptOutcome>();
+  const startedAt = now();
+  let firstStartMs: number | null = null;
+  let firstCompletionMs: number | null = null;
+  let finalCompletionMs: number | null = null;
+
+  for (const batch of batches) {
+    if (signal.aborted) break;
+    const settled = await Promise.allSettled(batch.map(async (entry) => {
+      startedAttemptIds.add(entry.attemptId);
+      attemptCategories.set(entry.attemptId, entry.category);
+      if (firstStartMs === null) firstStartMs = now() - startedAt;
+      try {
+        const execution = await execute(entry);
+        attemptOutcomes.set(entry.attemptId, execution.outcome);
+        return { entry, value: execution.value };
+      } catch (error) {
+        attemptOutcomes.set(entry.attemptId, 'other-fetch-failure');
+        throw error;
+      } finally {
+        const completionMs = now() - startedAt;
+        if (firstCompletionMs === null) firstCompletionMs = completionMs;
+        finalCompletionMs = completionMs;
+      }
+    }));
+
+    for (const result of settled) {
+      if (result.status === 'fulfilled') {
+        fulfilled.push(result.value);
+      }
+    }
+  }
+
+  for (const entry of allEntries) {
+    if (startedAttemptIds.has(entry.attemptId)) continue;
+    attemptCategories.set(entry.attemptId, entry.category);
+    attemptOutcomes.set(entry.attemptId, 'not-started');
+  }
+
+  return { fulfilled, startedAttemptIds, attemptCategories, attemptOutcomes, firstStartMs, firstCompletionMs, finalCompletionMs };
 }
 
 /**

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -20,6 +20,7 @@ import {
   type ServerFeed,
 } from './_feeds';
 import { classifyByKeyword, hasHistoricalMarker, type ThreatLevel } from './_classifier';
+import { classifyFeedAttempt, interleaveByCategory, type FeedFetchAttempt } from './_attempts';
 import { assignStoryIdentity, adoptExistingCanonical } from './dedup.mjs';
 import { classifyOpinion } from '../../../_shared/opinion-classifier.js';
 import { classifyFeelGood } from '../../../_shared/feelgood-classifier.js';
@@ -372,9 +373,16 @@ function computeImportanceScore(
 function createTimeoutLinkedController(parentSignal: AbortSignal): {
   controller: AbortController;
   cleanup: () => void;
+  timedOut: () => boolean;
 } {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), FEED_TIMEOUT_MS);
+  // #7083: distinguish the per-feed timeout from the parent (global digest
+  // deadline) abort so the attempt classifier can name the real cause.
+  let perFeedTimeoutFired = false;
+  const timeout = setTimeout(() => {
+    perFeedTimeoutFired = true;
+    controller.abort();
+  }, FEED_TIMEOUT_MS);
   const onAbort = () => controller.abort();
   parentSignal.addEventListener('abort', onAbort, { once: true });
 
@@ -384,6 +392,7 @@ function createTimeoutLinkedController(parentSignal: AbortSignal): {
       clearTimeout(timeout);
       parentSignal.removeEventListener('abort', onAbort);
     },
+    timedOut: () => perFeedTimeoutFired,
   };
 }
 
@@ -420,8 +429,8 @@ export function looksLikeRssXml(text: string): boolean {
 async function fetchRssText(
   url: string,
   signal: AbortSignal,
-): Promise<string | null> {
-  const { controller, cleanup } = createTimeoutLinkedController(signal);
+): Promise<{ text: string | null; failure: FeedFetchAttempt['failure'] }> {
+  const { controller, cleanup, timedOut } = createTimeoutLinkedController(signal);
 
   try {
     const resp = await fetch(url, {
@@ -432,13 +441,18 @@ async function fetchRssText(
       },
       signal: controller.signal,
     });
-    if (!resp.ok) return null;
+    if (!resp.ok) return { text: null, failure: 'direct-error' };
     const text = await resp.text();
     // Defensive: upstream may return HTTP 200 with an HTML interstitial
     // (Cloudflare bot challenge, captcha page). Reject up front so the
     // caller's relay fallback fires instead of caching an empty parse.
-    if (!looksLikeRssXml(text)) return null;
-    return text;
+    if (!looksLikeRssXml(text)) return { text: null, failure: 'direct-error' };
+    return { text, failure: null };
+  } catch {
+    return {
+      text: null,
+      failure: timedOut() ? 'per-feed-timeout' : signal.aborted ? 'deadline-abort' : 'direct-error',
+    };
   } finally {
     cleanup();
   }
@@ -455,6 +469,9 @@ interface ParseResult {
   parsedTotal: number;     // count of <item>/<entry> blocks attempted
   droppedUndated: number;  // count dropped because every recognized date tag was empty/unparseable/future
   droppedFeedCap?: number; // #4920: items beyond ITEMS_PER_FEED, previously uncounted
+  // #7083: how the fetch leg of this attempt actually ended. Absent on
+  // cache entries written before the field existed.
+  attempt?: FeedFetchAttempt;
 }
 
 // Cache TTLs: a successful parse (parsedTotal > 0) caches for an hour to
@@ -494,7 +511,10 @@ async function fetchAndParseRss(
   // v7→v8: extend the same exclusion policy to duration-led anniversary
   // explainers ("10 years on from …"). Warm v7 rows already carry an
   // authoritative isOpinion="0", so force another cold parse on rollout.
-  const cacheKey = `rss:feed:v8:${variant}:${feed.url}`;
+  // v8→v9 (#7083): ParseResult gained the `attempt` field. Warm v8 rows
+  // lack it, so zero-item entries could not be classified between
+  // negative-cache and fresh-failure; force a cold parse on rollout.
+  const cacheKey = `rss:feed:v9:${variant}:${feed.url}`;
 
   try {
     // Read cache unconditionally — the v5 prefix guarantees pre-fix
@@ -505,12 +525,22 @@ async function fetchAndParseRss(
     // what the PR description claimed and what review P1 flagged was
     // missing.
     const cached = (await getCachedJson(cacheKey)) as ParseResult | null;
-    if (cached) return cached;
+    if (cached) {
+      if (cached.parsedTotal === 0 && cached.items.length === 0) {
+        // A cached zero-item entry is the negative cache written by a
+        // previous failed attempt — say so instead of reporting 'empty'.
+        return { ...cached, attempt: { source: 'cache', failure: null, negativeCache: true } };
+      }
+      return cached;
+    }
 
     // Try direct fetch first
-    let text = await fetchRssText(feed.url, signal).catch(() => null);
+    const direct = await fetchRssText(feed.url, signal);
+    let text = direct.text;
+    let failure: FeedFetchAttempt['failure'] = direct.failure;
     let source: 'direct' | 'relay' | 'both-failed' = text ? 'direct' : 'both-failed';
     let relayStatus: number | null = null;
+    let relayFailure: FeedFetchAttempt['failure'] = null;
     let relayBodyShape: 'rss' | 'html-or-empty' | 'no-relay' | 'fetch-error' = 'no-relay';
 
     // Fallback: route through Railway relay (different IP, avoids Vercel blocks)
@@ -519,7 +549,7 @@ async function fetchAndParseRss(
       if (relayBase) {
         relayBodyShape = 'fetch-error';
         const relayUrl = `${relayBase}/rss?url=${encodeURIComponent(feed.url)}`;
-        const { controller, cleanup } = createTimeoutLinkedController(signal);
+        const { controller, cleanup, timedOut } = createTimeoutLinkedController(signal);
         try {
           const resp = await fetch(relayUrl, {
             headers: getRelayHeaders({ Accept: RSS_ACCEPT }),
@@ -538,7 +568,10 @@ async function fetchAndParseRss(
               relayBodyShape = 'html-or-empty';
             }
           }
-        } catch { /* relay also failed */ } finally {
+        } catch {
+          /* relay also failed */
+          relayFailure = timedOut() ? 'per-feed-timeout' : signal.aborted ? 'deadline-abort' : 'relay-error';
+        } finally {
           cleanup();
         }
       }
@@ -557,8 +590,19 @@ async function fetchAndParseRss(
 
     if (!text) {
       // Both direct and relay failed. Cache empty short so we retry sooner
-      // than the healthy-result TTL.
-      const empty: ParseResult = { items: [], parsedTotal: 0, droppedUndated: 0 };
+      // than the healthy-result TTL. The attempt verdict distinguishes the
+      // global deadline abort (#7083) so a deadline-starved build is not
+      // later reported as an upstream failure.
+      const attempt: FeedFetchAttempt = {
+        source: 'cache',
+        failure: failure === 'deadline-abort'
+          ? 'deadline-abort'
+          : failure === 'per-feed-timeout'
+            ? 'per-feed-timeout'
+            : relayFailure ?? 'relay-error',
+        negativeCache: false,
+      };
+      const empty: ParseResult = { items: [], parsedTotal: 0, droppedUndated: 0, attempt };
       await setCachedJson(cacheKey, empty, CACHE_TTL_EMPTY_S);
       return empty;
     }
@@ -568,13 +612,19 @@ async function fetchAndParseRss(
     // network failure: cache empty short so we retry sooner.
     const parsed = parseRssXml(text, feed, variant);
     const result: ParseResult = parsed ?? { items: [], parsedTotal: 0, droppedUndated: 0 };
+    result.attempt = { source, failure: null, negativeCache: false };
     // Long cache only for healthy parses; short cache for zero-from-zero so
     // transient upstream issues don't sticky-fail for an hour.
     const ttl = result.parsedTotal > 0 ? CACHE_TTL_HEALTHY_S : CACHE_TTL_EMPTY_S;
     await setCachedJson(cacheKey, result, ttl);
     return result;
   } catch {
-    return { items: [], parsedTotal: 0, droppedUndated: 0 };
+    return {
+      items: [],
+      parsedTotal: 0,
+      droppedUndated: 0,
+      attempt: { source: 'cache', failure: 'direct-error', negativeCache: false },
+    };
   }
 }
 
@@ -1382,7 +1432,11 @@ function buildDigestFeedBatches(variant: string, lang: string): {
     }
   }
 
-  const orderedEntries = orderServerFeedEntries(allEntries);
+  // #7083: category-fair scheduling. Priorities still order feeds inside
+  // their category, but the categories are interleaved so the first batch
+  // wave contains the head of every eligible category — a slow category can
+  // no longer push all later categories behind the global deadline.
+  const orderedEntries = interleaveByCategory(orderServerFeedEntries(allEntries));
   const batches: DigestFeedEntry[][] = [];
   for (let i = 0; i < orderedEntries.length; i += BATCH_CONCURRENCY) {
     batches.push(orderedEntries.slice(i, i + BATCH_CONCURRENCY));
@@ -1404,28 +1458,45 @@ async function buildDigest(variant: string, lang: string): Promise<ListFeedDiges
     const { allEntries, batches } = buildDigestFeedBatches(variant, lang);
 
     const results = new Map<string, ParsedItem[]>();
-    // Track feeds that actually completed (with or without items) so we can
-    // distinguish a genuine timeout (never ran) from a successful empty fetch.
-    const completedFeeds = new Set<string>();
+    // #7083 attempt tracking: which feeds STARTED (vs never reached before
+    // the deadline), when the first start/completion happened, and a precise
+    // terminal outcome per feed from the closed vocabulary — so scheduling
+    // starvation is never reported as an upstream failure.
+    const startedFeeds = new Set<string>();
+    const attemptCategories = new Map<string, string>();
+    const attemptOutcomes = new Map<string, ReturnType<typeof classifyFeedAttempt>>();
+    const buildStart = Date.now();
+    let firstStartMs: number | null = null;
+    let firstCompletionMs: number | null = null;
+    let finalCompletionMs: number | null = null;
 
     for (const batch of batches) {
       if (deadlineController.signal.aborted) break;
 
       const settled = await Promise.allSettled(
         batch.map(async ({ category, feed }) => {
+          startedFeeds.add(feed.name);
+          attemptCategories.set(feed.name, category);
+          if (firstStartMs === null) firstStartMs = Date.now() - buildStart;
           const result = await fetchAndParseRss(feed, variant, deadlineController.signal);
-          completedFeeds.add(feed.name);
-          // Classify per-feed status. 'all-undated' is the silent-zeroing
-          // failure mode (every parsed item dropped for missing/unparseable
-          // dates) — distinguished from a genuinely empty fetch ('empty')
-          // so log aggregation can keyword-match. 'partial-undated' is
-          // informational (some items dropped, some kept).
-          if (result.parsedTotal > 0 && result.items.length === 0 && result.droppedUndated > 0) {
-            feedStatuses[feed.name] = 'all-undated';
-          } else if (result.items.length === 0) {
-            feedStatuses[feed.name] = 'empty';
-          } else if (result.droppedUndated > 0) {
-            feedStatuses[feed.name] = 'partial-undated';
+          const outcome = classifyFeedAttempt(true, result.attempt ?? {
+            source: 'cache', failure: null, negativeCache: false,
+          }, {
+            parsedTotal: result.parsedTotal,
+            keptItems: result.items.length,
+            droppedUndated: result.droppedUndated,
+          });
+          attemptOutcomes.set(feed.name, outcome);
+          const completionMs = Date.now() - buildStart;
+          if (firstCompletionMs === null) firstCompletionMs = completionMs;
+          finalCompletionMs = completionMs;
+          // Public feed status keeps the historical contract: healthy
+          // completed feeds stay absent, every other state carries its
+          // precise outcome name instead of being flattened into
+          // 'empty'/'timeout' (#7083). The full histogram (including
+          // 'completed') goes to the [digest-attempts] telemetry line.
+          if (outcome !== 'completed') {
+            feedStatuses[feed.name] = outcome;
           }
           return {
             category,
@@ -1448,10 +1519,39 @@ async function buildDigest(variant: string, lang: string): Promise<ListFeedDiges
       }
     }
 
+    const deadlineAborted = deadlineController.signal.aborted;
     for (const entry of allEntries) {
-      if (!completedFeeds.has(entry.feed.name)) {
-        feedStatuses[entry.feed.name] = 'timeout';
+      if (!startedFeeds.has(entry.feed.name)) {
+        // #7083: this feed's batch never ran — say so instead of relabeling
+        // scheduling starvation as an upstream 'timeout'.
+        feedStatuses[entry.feed.name] = 'not-started';
+        attemptOutcomes.set(entry.feed.name, 'not-started');
+        attemptCategories.set(entry.feed.name, entry.category);
       }
+    }
+
+    // #7083 operator telemetry: one structured line per build with the
+    // outcome histogram, per-category coverage, and the timings needed to
+    // see which stage consumes the deadline. No host names or exceptions
+    // here — details stay in the [feed-fetch] lines.
+    {
+      const byOutcome: Record<string, number> = {};
+      for (const outcome of attemptOutcomes.values()) {
+        byOutcome[outcome] = (byOutcome[outcome] ?? 0) + 1;
+      }
+      const byCategory: Record<string, Record<string, number>> = {};
+      for (const [feedName, category] of attemptCategories) {
+        const outcome = attemptOutcomes.get(feedName) ?? 'unknown';
+        const cat = (byCategory[category] ??= {});
+        cat[outcome] = (cat[outcome] ?? 0) + 1;
+      }
+      const headroomMs = Math.max(0, OVERALL_DEADLINE_MS - (finalCompletionMs ?? Date.now() - buildStart));
+      console.info(
+        `[digest-attempts] variant=${variant} lang=${lang} feeds=${allEntries.length} ` +
+        `deadline_aborted=${deadlineAborted} first_start_ms=${firstStartMs ?? 'n/a'} ` +
+        `first_completion_ms=${firstCompletionMs ?? 'n/a'} final_completion_ms=${finalCompletionMs ?? 'n/a'} ` +
+        `headroom_ms=${headroomMs} by_outcome=${JSON.stringify(byOutcome)} by_category=${JSON.stringify(byCategory)}`,
+      );
     }
 
     // U3 — hard freshness floor. Drop items older than NEWS_MAX_AGE_HOURS

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -20,7 +20,15 @@ import {
   type ServerFeed,
 } from './_feeds';
 import { classifyByKeyword, hasHistoricalMarker, type ThreatLevel } from './_classifier';
-import { classifyFeedAttempt, interleaveByCategory, type FeedFetchAttempt } from './_attempts';
+import {
+  cachedAttemptFrom,
+  classifyFeedAttempt,
+  interleaveByCategory,
+  resolveTerminalFetchFailure,
+  runFeedAttemptBatches,
+  summarizeFeedAttempts,
+  type FeedFetchAttempt,
+} from './_attempts';
 import { assignStoryIdentity, adoptExistingCanonical } from './dedup.mjs';
 import { classifyOpinion } from '../../../_shared/opinion-classifier.js';
 import { classifyFeelGood } from '../../../_shared/feelgood-classifier.js';
@@ -68,7 +76,7 @@ const RESPONSE_GUARD_BAND_MS = 3_000;
 const OVERALL_DEADLINE_MS = VERCEL_INITIAL_RESPONSE_LIMIT_MS - POST_FETCH_HEADROOM_MS;
 const BATCH_CONCURRENCY = 20;
 
-type DigestFeedEntry = { category: string; feed: ServerFeed };
+type DigestFeedEntry = { attemptId: string; category: string; feed: ServerFeed };
 
 // U3 — hard freshness floor (default 96h, env override NEWS_MAX_AGE_HOURS).
 // Items older than this are dropped before scoring. The 24h `recencyScore`
@@ -527,9 +535,10 @@ async function fetchAndParseRss(
     const cached = (await getCachedJson(cacheKey)) as ParseResult | null;
     if (cached) {
       if (cached.parsedTotal === 0 && cached.items.length === 0) {
-        // A cached zero-item entry is the negative cache written by a
-        // previous failed attempt — say so instead of reporting 'empty'.
-        return { ...cached, attempt: { source: 'cache', failure: null, negativeCache: true } };
+        // Only a cached prior fetch failure is negative. A valid RSS body
+        // can also contain no entries; preserve that successful empty result
+        // so cache hits keep the normal `empty` verdict.
+        return { ...cached, attempt: cachedAttemptFrom(cached.attempt) };
       }
       return cached;
     }
@@ -541,12 +550,14 @@ async function fetchAndParseRss(
     let source: 'direct' | 'relay' | 'both-failed' = text ? 'direct' : 'both-failed';
     let relayStatus: number | null = null;
     let relayFailure: FeedFetchAttempt['failure'] = null;
+    let relayAttempted = false;
     let relayBodyShape: 'rss' | 'html-or-empty' | 'no-relay' | 'fetch-error' = 'no-relay';
 
     // Fallback: route through Railway relay (different IP, avoids Vercel blocks)
     if (!text) {
       const relayBase = getRelayBaseUrl();
       if (relayBase) {
+        relayAttempted = true;
         relayBodyShape = 'fetch-error';
         const relayUrl = `${relayBase}/rss?url=${encodeURIComponent(feed.url)}`;
         const { controller, cleanup, timedOut } = createTimeoutLinkedController(signal);
@@ -594,12 +605,13 @@ async function fetchAndParseRss(
       // global deadline abort (#7083) so a deadline-starved build is not
       // later reported as an upstream failure.
       const attempt: FeedFetchAttempt = {
-        source: 'cache',
-        failure: failure === 'deadline-abort'
-          ? 'deadline-abort'
-          : failure === 'per-feed-timeout'
-            ? 'per-feed-timeout'
-            : relayFailure ?? 'relay-error',
+        source: relayAttempted ? 'relay' : 'direct',
+        failure: resolveTerminalFetchFailure({
+          directFailure: failure,
+          relayFailure,
+          relayAttempted,
+          deadlineAborted: signal.aborted,
+        }),
         negativeCache: false,
       };
       const empty: ParseResult = { items: [], parsedTotal: 0, droppedUndated: 0, attempt };
@@ -630,7 +642,7 @@ async function fetchAndParseRss(
       items: [],
       parsedTotal: 0,
       droppedUndated: 0,
-      attempt: { source: 'cache', failure: 'direct-error', negativeCache: false },
+      attempt: { source: 'direct', failure: 'direct-error', negativeCache: false },
     };
   }
 }
@@ -1428,14 +1440,14 @@ function buildDigestFeedBatches(variant: string, lang: string): {
   for (const [category, feeds] of Object.entries(feedsByCategory)) {
     const filtered = feeds.filter(f => isServerFeedReachableForLanguage(f, lang));
     for (const feed of filtered) {
-      allEntries.push({ category, feed });
+      allEntries.push({ attemptId: `${category}:${allEntries.length}`, category, feed });
     }
   }
 
   if (variant === 'full') {
     const filteredIntel = INTEL_SOURCES.filter(f => isServerFeedReachableForLanguage(f, lang));
     for (const feed of filteredIntel) {
-      allEntries.push({ category: 'intel', feed });
+      allEntries.push({ attemptId: `intel:${allEntries.length}`, category: 'intel', feed });
     }
   }
 
@@ -1472,84 +1484,64 @@ async function buildDigest(variant: string, lang: string): Promise<ListFeedDiges
     const { allEntries, batches } = buildDigestFeedBatches(variant, lang);
 
     const results = new Map<string, ParsedItem[]>();
-    // #7083 attempt tracking: which feeds STARTED (vs never reached before
-    // the deadline), when the first start/completion happened, and a precise
-    // terminal outcome per feed from the closed vocabulary — so scheduling
-    // starvation is never reported as an upstream failure.
-    const startedFeeds = new Set<string>();
-    const attemptCategories = new Map<string, string>();
-    const attemptOutcomes = new Map<string, ReturnType<typeof classifyFeedAttempt>>();
     const buildStart = Date.now();
-    let firstStartMs: number | null = null;
-    let firstCompletionMs: number | null = null;
-    let finalCompletionMs: number | null = null;
+    const attempts = await runFeedAttemptBatches(
+      allEntries,
+      batches,
+      deadlineController.signal,
+      async (entry) => {
+        const { category, feed } = entry;
+        const result = await fetchAndParseRss(feed, variant, deadlineController.signal);
+        const outcome = classifyFeedAttempt(true, result.attempt ?? {
+          source: 'cache', failure: null, negativeCache: false,
+        }, {
+          parsedTotal: result.parsedTotal,
+          keptItems: result.items.length,
+          droppedUndated: result.droppedUndated,
+        });
 
-    for (const batch of batches) {
-      if (deadlineController.signal.aborted) break;
+        // Public feed status keeps the historical four-value contract
+        // (docs/methodology + the proto comment): completed feeds carry
+        // 'all-undated'/'empty'/'partial-undated', feeds that never
+        // completed carry 'timeout'. The fine-grained attempt outcome
+        // stays in telemetry, keyed by the unique inventory attempt ID.
+        if (result.parsedTotal > 0 && result.items.length === 0 && result.droppedUndated > 0) {
+          feedStatuses[feed.name] = 'all-undated';
+        } else if (result.items.length === 0) {
+          feedStatuses[feed.name] = 'empty';
+        } else if (result.droppedUndated > 0) {
+          feedStatuses[feed.name] = 'partial-undated';
+        }
 
-      const settled = await Promise.allSettled(
-        batch.map(async ({ category, feed }) => {
-          startedFeeds.add(feed.name);
-          attemptCategories.set(feed.name, category);
-          if (firstStartMs === null) firstStartMs = Date.now() - buildStart;
-          const result = await fetchAndParseRss(feed, variant, deadlineController.signal);
-          const outcome = classifyFeedAttempt(true, result.attempt ?? {
-            source: 'cache', failure: null, negativeCache: false,
-          }, {
-            parsedTotal: result.parsedTotal,
-            keptItems: result.items.length,
-            droppedUndated: result.droppedUndated,
-          });
-          attemptOutcomes.set(feed.name, outcome);
-          const completionMs = Date.now() - buildStart;
-          if (firstCompletionMs === null) firstCompletionMs = completionMs;
-          finalCompletionMs = completionMs;
-          // Public feed status keeps the historical four-value contract
-          // (docs/methodology + the proto comment): completed feeds carry
-          // 'all-undated'/'empty'/'partial-undated', feeds that never
-          // completed carry 'timeout'. The fine-grained attempt outcome
-          // (deadline-abort vs per-feed-timeout vs relay-error vs
-          // not-started...) stays in attemptOutcomes and the
-          // [digest-attempts] telemetry line; the coverage block (#7085)
-          // is where that precise vocabulary becomes public.
-          if (result.parsedTotal > 0 && result.items.length === 0 && result.droppedUndated > 0) {
-            feedStatuses[feed.name] = 'all-undated';
-          } else if (result.items.length === 0) {
-            feedStatuses[feed.name] = 'empty';
-          } else if (result.droppedUndated > 0) {
-            feedStatuses[feed.name] = 'partial-undated';
-          }
-          return {
+        return {
+          outcome,
+          value: {
             category,
             items: result.items,
             droppedUndated: result.droppedUndated,
             droppedFeedCap: result.droppedFeedCap ?? 0,
-          };
-        }),
-      );
+          },
+        };
+      },
+    );
 
-      for (const result of settled) {
-        if (result.status === 'fulfilled') {
-          const { category, items, droppedUndated, droppedFeedCap } = result.value;
-          const existing = results.get(category) ?? [];
-          existing.push(...items);
-          results.set(category, existing);
-          ledgerDrops.undated += droppedUndated;
-          ledgerDrops.perFeedCap += droppedFeedCap;
-        }
-      }
+    for (const { value } of attempts.fulfilled) {
+      const { category, items, droppedUndated, droppedFeedCap } = value;
+      const existing = results.get(category) ?? [];
+      existing.push(...items);
+      results.set(category, existing);
+      ledgerDrops.undated += droppedUndated;
+      ledgerDrops.perFeedCap += droppedFeedCap;
     }
 
     const deadlineAborted = deadlineController.signal.aborted;
     for (const entry of allEntries) {
-      if (!startedFeeds.has(entry.feed.name)) {
+      if (!attempts.startedAttemptIds.has(entry.attemptId)) {
         // #7083: this feed's batch never ran. The public map keeps the
         // coarse 'timeout' contract; the precise 'not-started' verdict
         // (scheduling starvation, not an upstream failure) lives in
-        // attemptOutcomes and the [digest-attempts] telemetry line.
+        // the helper's attempt-outcome map and telemetry line.
         feedStatuses[entry.feed.name] = 'timeout';
-        attemptOutcomes.set(entry.feed.name, 'not-started');
-        attemptCategories.set(entry.feed.name, entry.category);
       }
     }
 
@@ -1558,21 +1550,16 @@ async function buildDigest(variant: string, lang: string): Promise<ListFeedDiges
     // see which stage consumes the deadline. No host names or exceptions
     // here — details stay in the [feed-fetch] lines.
     {
-      const byOutcome: Record<string, number> = {};
-      for (const outcome of attemptOutcomes.values()) {
-        byOutcome[outcome] = (byOutcome[outcome] ?? 0) + 1;
-      }
-      const byCategory: Record<string, Record<string, number>> = {};
-      for (const [feedName, category] of attemptCategories) {
-        const outcome = attemptOutcomes.get(feedName) ?? 'unknown';
-        const cat = (byCategory[category] ??= {});
-        cat[outcome] = (cat[outcome] ?? 0) + 1;
-      }
-      const headroomMs = Math.max(0, OVERALL_DEADLINE_MS - (finalCompletionMs ?? Date.now() - buildStart));
+      const { byOutcome, byCategory, headroomMs } = summarizeFeedAttempts(
+        attempts.attemptCategories,
+        attempts.attemptOutcomes,
+        OVERALL_DEADLINE_MS,
+        attempts.finalCompletionMs ?? Date.now() - buildStart,
+      );
       console.info(
         `[digest-attempts] variant=${variant} lang=${lang} feeds=${allEntries.length} ` +
-        `deadline_aborted=${deadlineAborted} first_start_ms=${firstStartMs ?? 'n/a'} ` +
-        `first_completion_ms=${firstCompletionMs ?? 'n/a'} final_completion_ms=${finalCompletionMs ?? 'n/a'} ` +
+        `deadline_aborted=${deadlineAborted} first_start_ms=${attempts.firstStartMs ?? 'n/a'} ` +
+        `first_completion_ms=${attempts.firstCompletionMs ?? 'n/a'} final_completion_ms=${attempts.finalCompletionMs ?? 'n/a'} ` +
         `headroom_ms=${headroomMs} by_outcome=${JSON.stringify(byOutcome)} by_category=${JSON.stringify(byCategory)}`,
       );
     }
@@ -1834,6 +1821,7 @@ export const __testing__ = {
   POST_FETCH_HEADROOM_MS,
   RESPONSE_GUARD_BAND_MS,
   OVERALL_DEADLINE_MS,
+  BATCH_CONCURRENCY,
   MAX_DESCRIPTION_LEN,
   MIN_DESCRIPTION_LEN,
   FUTURE_DATE_TOLERANCE_MS,

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -1439,11 +1439,18 @@ function buildDigestFeedBatches(variant: string, lang: string): {
     }
   }
 
-  // #7083: category-fair scheduling. Priorities still order feeds inside
-  // their category, but the categories are interleaved so the first batch
-  // wave contains the head of every eligible category — a slow category can
-  // no longer push all later categories behind the global deadline.
-  const orderedEntries = interleaveByCategory(orderServerFeedEntries(allEntries));
+  // #7083: category-fair scheduling, with the deadline-priority promise
+  // kept absolute: feeds with deadlinePriority > 0 start first in a cold
+  // build (the China coverage trio is market-hours critical), and the rest
+  // interleave so the next wave contains the head of every eligible
+  // category — a slow category can no longer push all later categories
+  // behind the global deadline.
+  const priorityOrdered = orderServerFeedEntries(allEntries);
+  const priorityHead = priorityOrdered.filter((entry) => (entry.feed.deadlinePriority ?? 0) > 0);
+  const orderedEntries = [
+    ...priorityHead,
+    ...interleaveByCategory(priorityOrdered.filter((entry) => (entry.feed.deadlinePriority ?? 0) <= 0)),
+  ];
   const batches: DigestFeedEntry[][] = [];
   for (let i = 0; i < orderedEntries.length; i += BATCH_CONCURRENCY) {
     batches.push(orderedEntries.slice(i, i + BATCH_CONCURRENCY));
@@ -1497,13 +1504,20 @@ async function buildDigest(variant: string, lang: string): Promise<ListFeedDiges
           const completionMs = Date.now() - buildStart;
           if (firstCompletionMs === null) firstCompletionMs = completionMs;
           finalCompletionMs = completionMs;
-          // Public feed status keeps the historical contract: healthy
-          // completed feeds stay absent, every other state carries its
-          // precise outcome name instead of being flattened into
-          // 'empty'/'timeout' (#7083). The full histogram (including
-          // 'completed') goes to the [digest-attempts] telemetry line.
-          if (outcome !== 'completed') {
-            feedStatuses[feed.name] = outcome;
+          // Public feed status keeps the historical four-value contract
+          // (docs/methodology + the proto comment): completed feeds carry
+          // 'all-undated'/'empty'/'partial-undated', feeds that never
+          // completed carry 'timeout'. The fine-grained attempt outcome
+          // (deadline-abort vs per-feed-timeout vs relay-error vs
+          // not-started...) stays in attemptOutcomes and the
+          // [digest-attempts] telemetry line; the coverage block (#7085)
+          // is where that precise vocabulary becomes public.
+          if (result.parsedTotal > 0 && result.items.length === 0 && result.droppedUndated > 0) {
+            feedStatuses[feed.name] = 'all-undated';
+          } else if (result.items.length === 0) {
+            feedStatuses[feed.name] = 'empty';
+          } else if (result.droppedUndated > 0) {
+            feedStatuses[feed.name] = 'partial-undated';
           }
           return {
             category,
@@ -1529,9 +1543,11 @@ async function buildDigest(variant: string, lang: string): Promise<ListFeedDiges
     const deadlineAborted = deadlineController.signal.aborted;
     for (const entry of allEntries) {
       if (!startedFeeds.has(entry.feed.name)) {
-        // #7083: this feed's batch never ran — say so instead of relabeling
-        // scheduling starvation as an upstream 'timeout'.
-        feedStatuses[entry.feed.name] = 'not-started';
+        // #7083: this feed's batch never ran. The public map keeps the
+        // coarse 'timeout' contract; the precise 'not-started' verdict
+        // (scheduling starvation, not an upstream failure) lives in
+        // attemptOutcomes and the [digest-attempts] telemetry line.
+        feedStatuses[entry.feed.name] = 'timeout';
         attemptOutcomes.set(entry.feed.name, 'not-started');
         attemptCategories.set(entry.feed.name, entry.category);
       }

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -612,7 +612,14 @@ async function fetchAndParseRss(
     // network failure: cache empty short so we retry sooner.
     const parsed = parseRssXml(text, feed, variant);
     const result: ParseResult = parsed ?? { items: [], parsedTotal: 0, droppedUndated: 0 };
-    result.attempt = { source, failure: null, negativeCache: false };
+    // text is non-null here, so the fetch source can only be 'direct' or
+    // 'relay' — narrow explicitly, the variable's type still carries
+    // 'both-failed' for the log line above.
+    result.attempt = {
+      source: source === 'relay' ? 'relay' : 'direct',
+      failure: null,
+      negativeCache: false,
+    };
     // Long cache only for healthy parses; short cache for zero-from-zero so
     // transient upstream issues don't sticky-fail for an hour.
     const ttl = result.parsedTotal > 0 ? CACHE_TTL_HEALTHY_S : CACHE_TTL_EMPTY_S;

--- a/tests/digest-attempt-outcomes.test.mts
+++ b/tests/digest-attempt-outcomes.test.mts
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { readFile } from 'node:fs/promises';
+
+type AttemptsModule = {
+  FEED_ATTEMPT_OUTCOMES: readonly string[];
+  classifyFeedAttempt: (
+    started: boolean,
+    attempt: { source: string; failure: string | null; negativeCache: boolean },
+    counters: { parsedTotal: number; keptItems: number; droppedUndated: number },
+  ) => string;
+  interleaveByCategory: <T extends { category: string }>(entries: readonly T[]) => T[];
+};
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+let attempts: AttemptsModule;
+
+before(async () => {
+  const result = await build({
+    stdin: {
+      contents: "export * from './server/worldmonitor/news/v1/_attempts.ts';",
+      loader: 'ts',
+      resolveDir: root,
+      sourcefile: 'digest-attempts-test-entry.ts',
+    },
+    bundle: true,
+    format: 'esm',
+    logLevel: 'silent',
+    platform: 'node',
+    target: 'node20',
+    write: false,
+  });
+  const source = result.outputFiles[0]?.text;
+  assert.ok(source, 'esbuild must emit the attempts harness');
+  attempts = await import(`data:text/javascript;base64,${Buffer.from(source).toString('base64')}`) as AttemptsModule;
+});
+
+const healthy = { source: 'direct', failure: null, negativeCache: false };
+
+describe('digest attempt vocabulary (#7083)', () => {
+  it('defines a closed set with the not-started and failure states from the issue', () => {
+    for (const outcome of [
+      'completed', 'empty', 'all-undated', 'partial-undated',
+      'direct-timeout', 'relay-failure', 'aborted-by-deadline',
+      'other-fetch-failure', 'negative-cache', 'not-started',
+    ]) {
+      assert.ok(attempts.FEED_ATTEMPT_OUTCOMES.includes(outcome), `vocabulary must contain ${outcome}`);
+    }
+  });
+});
+
+describe('classifyFeedAttempt (#7083)', () => {
+  it('reports a feed that never started as not-started, never as timeout', () => {
+    assert.equal(
+      attempts.classifyFeedAttempt(false, healthy, { parsedTotal: 0, keptItems: 0, droppedUndated: 0 }),
+      'not-started',
+    );
+  });
+
+  it('distinguishes direct timeout, deadline abort, and relay failure', () => {
+    const zero = { parsedTotal: 0, keptItems: 0, droppedUndated: 0 };
+    assert.equal(
+      attempts.classifyFeedAttempt(true, { source: 'direct', failure: 'per-feed-timeout', negativeCache: false }, zero),
+      'direct-timeout',
+    );
+    assert.equal(
+      attempts.classifyFeedAttempt(true, { source: 'direct', failure: 'deadline-abort', negativeCache: false }, zero),
+      'aborted-by-deadline',
+    );
+    assert.equal(
+      attempts.classifyFeedAttempt(true, { source: 'direct', failure: 'relay-error', negativeCache: false }, zero),
+      'relay-failure',
+    );
+    assert.equal(
+      attempts.classifyFeedAttempt(true, { source: 'direct', failure: 'direct-error', negativeCache: false }, zero),
+      'relay-failure',
+    );
+  });
+
+  it('names a served negative-cache entry instead of calling it empty', () => {
+    assert.equal(
+      attempts.classifyFeedAttempt(true, { source: 'cache', failure: null, negativeCache: true }, {
+        parsedTotal: 0, keptItems: 0, droppedUndated: 0,
+      }),
+      'negative-cache',
+    );
+  });
+
+  it('keeps the historical undated and empty semantics for completed fetches', () => {
+    assert.equal(
+      attempts.classifyFeedAttempt(true, healthy, { parsedTotal: 5, keptItems: 5, droppedUndated: 0 }),
+      'completed',
+    );
+    assert.equal(
+      attempts.classifyFeedAttempt(true, healthy, { parsedTotal: 5, keptItems: 4, droppedUndated: 1 }),
+      'partial-undated',
+    );
+    assert.equal(
+      attempts.classifyFeedAttempt(true, healthy, { parsedTotal: 5, keptItems: 0, droppedUndated: 5 }),
+      'all-undated',
+    );
+    assert.equal(
+      attempts.classifyFeedAttempt(true, healthy, { parsedTotal: 0, keptItems: 0, droppedUndated: 0 }),
+      'empty',
+    );
+  });
+});
+
+describe('interleaveByCategory (#7083)', () => {
+  it('gives every category a slot in the first scheduling wave', () => {
+    const ordered = attempts.interleaveByCategory([
+      { category: 'a', id: 1 }, { category: 'a', id: 2 }, { category: 'a', id: 3 },
+      { category: 'b', id: 4 }, { category: 'b', id: 5 },
+      { category: 'c', id: 6 },
+    ]);
+    const firstWave = ordered.slice(0, 3).map((e) => e.category).sort();
+    assert.deepEqual(firstWave, ['a', 'b', 'c'], 'first wave must contain every category');
+  });
+
+  it('preserves relative order inside each category (strategic priorities intact)', () => {
+    const ordered = attempts.interleaveByCategory([
+      { category: 'a', id: 1 }, { category: 'a', id: 2 }, { category: 'a', id: 3 },
+      { category: 'b', id: 4 }, { category: 'b', id: 5 },
+    ]);
+    assert.deepEqual(
+      ordered.filter((e) => e.category === 'a').map((e) => e.id),
+      [1, 2, 3],
+    );
+    assert.deepEqual(
+      ordered.filter((e) => e.category === 'b').map((e) => e.id),
+      [4, 5],
+    );
+  });
+
+  it('is deterministic for the same input', () => {
+    const entries = [
+      { category: 'x', id: 1 }, { category: 'y', id: 2 }, { category: 'x', id: 3 },
+    ];
+    assert.deepEqual(attempts.interleaveByCategory(entries), attempts.interleaveByCategory(entries));
+  });
+});
+
+describe('list-feed-digest wiring (#7083)', () => {
+  let digestSource: string;
+
+  before(async () => {
+    digestSource = await readFile(resolve(root, 'server/worldmonitor/news/v1/list-feed-digest.ts'), 'utf8');
+  });
+
+  it('batches from the category-interleaved ordering', () => {
+    assert.match(digestSource, /interleaveByCategory\(orderServerFeedEntries\(allEntries\)\)/);
+  });
+
+  it('records started feeds before awaiting and labels the rest not-started', () => {
+    assert.match(digestSource, /startedFeeds\.add\(feed\.name\)/);
+    assert.match(digestSource, /'not-started'/);
+    assert.doesNotMatch(digestSource, /feedStatuses\[entry\.feed\.name\] = 'timeout'/);
+  });
+
+  it('classifies every started feed through the closed vocabulary', () => {
+    assert.match(digestSource, /classifyFeedAttempt\(/);
+  });
+
+  it('emits the per-build attempt telemetry line', () => {
+    assert.match(digestSource, /\[digest-attempts\]/);
+    assert.match(digestSource, /by_outcome=/);
+    assert.match(digestSource, /headroom_ms=/);
+  });
+
+  it('keeps healthy completed feeds out of the public status map', () => {
+    assert.match(digestSource, /if \(outcome !== 'completed'\)/);
+  });
+});

--- a/tests/digest-attempt-outcomes.test.mts
+++ b/tests/digest-attempt-outcomes.test.mts
@@ -3,7 +3,7 @@ import { before, describe, it } from 'node:test';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { build } from 'esbuild';
-import { readFile } from 'node:fs/promises';
+import { __testing__ as digestTesting } from '../server/worldmonitor/news/v1/list-feed-digest';
 
 type AttemptsModule = {
   FEED_ATTEMPT_OUTCOMES: readonly string[];
@@ -12,6 +12,37 @@ type AttemptsModule = {
     attempt: { source: string; failure: string | null; negativeCache: boolean },
     counters: { parsedTotal: number; keptItems: number; droppedUndated: number },
   ) => string;
+  resolveTerminalFetchFailure: (
+    input: { directFailure: string | null; relayFailure: string | null; relayAttempted: boolean; deadlineAborted: boolean },
+  ) => string | null;
+  cachedAttemptFrom: (prior: { source: string; failure: string | null; negativeCache: boolean } | undefined) => {
+    source: string; failure: string | null; negativeCache: boolean;
+  };
+  runFeedAttemptBatches: <T>(
+    allEntries: readonly { attemptId: string; category: string }[],
+    batches: readonly (readonly { attemptId: string; category: string }[])[],
+    signal: AbortSignal,
+    execute: (entry: { attemptId: string; category: string }) => Promise<{ value: T; outcome: string }>,
+    now?: () => number,
+  ) => Promise<{
+    fulfilled: Array<{ entry: { attemptId: string; category: string }; value: T }>;
+    startedAttemptIds: Set<string>;
+    attemptCategories: Map<string, string>;
+    attemptOutcomes: Map<string, string>;
+    firstStartMs: number | null;
+    firstCompletionMs: number | null;
+    finalCompletionMs: number | null;
+  }>;
+  summarizeFeedAttempts: (
+    attemptCategories: ReadonlyMap<string, string>,
+    attemptOutcomes: ReadonlyMap<string, string>,
+    overallDeadlineMs: number,
+    elapsedMs: number,
+  ) => {
+    byOutcome: Record<string, number>;
+    byCategory: Record<string, Record<string, number>>;
+    headroomMs: number;
+  };
   interleaveByCategory: <T extends { category: string }>(entries: readonly T[]) => T[];
 };
 
@@ -60,7 +91,7 @@ describe('classifyFeedAttempt (#7083)', () => {
     );
   });
 
-  it('distinguishes direct timeout, deadline abort, and relay failure', () => {
+  it('distinguishes direct timeout, deadline abort, relay failure, and direct-only failure', () => {
     const zero = { parsedTotal: 0, keptItems: 0, droppedUndated: 0 };
     assert.equal(
       attempts.classifyFeedAttempt(true, { source: 'direct', failure: 'per-feed-timeout', negativeCache: false }, zero),
@@ -76,7 +107,7 @@ describe('classifyFeedAttempt (#7083)', () => {
     );
     assert.equal(
       attempts.classifyFeedAttempt(true, { source: 'direct', failure: 'direct-error', negativeCache: false }, zero),
-      'relay-failure',
+      'other-fetch-failure',
     );
   });
 
@@ -106,6 +137,25 @@ describe('classifyFeedAttempt (#7083)', () => {
       attempts.classifyFeedAttempt(true, healthy, { parsedTotal: 0, keptItems: 0, droppedUndated: 0 }),
       'empty',
     );
+  });
+});
+
+describe('fetch attempt helpers (#7083)', () => {
+  it('uses deadline precedence, then the final relay leg, then direct failure', () => {
+    assert.equal(attempts.resolveTerminalFetchFailure({ directFailure: 'per-feed-timeout', relayFailure: 'relay-error', relayAttempted: true, deadlineAborted: false }), 'relay-error');
+    assert.equal(attempts.resolveTerminalFetchFailure({ directFailure: 'direct-error', relayFailure: 'per-feed-timeout', relayAttempted: true, deadlineAborted: false }), 'relay-error');
+    assert.equal(attempts.resolveTerminalFetchFailure({ directFailure: 'direct-error', relayFailure: 'relay-error', relayAttempted: true, deadlineAborted: true }), 'deadline-abort');
+    assert.equal(attempts.resolveTerminalFetchFailure({ directFailure: 'direct-error', relayFailure: null, relayAttempted: false, deadlineAborted: false }), 'direct-error');
+  });
+
+  it('keeps successful empty cache hits empty and marks cached failures negative', () => {
+    const successfulEmpty = attempts.cachedAttemptFrom({ source: 'direct', failure: null, negativeCache: false });
+    assert.deepEqual(successfulEmpty, { source: 'cache', failure: null, negativeCache: false });
+    assert.equal(attempts.classifyFeedAttempt(true, successfulEmpty, { parsedTotal: 0, keptItems: 0, droppedUndated: 0 }), 'empty');
+
+    const failed = attempts.cachedAttemptFrom({ source: 'relay', failure: 'relay-error', negativeCache: false });
+    assert.deepEqual(failed, { source: 'cache', failure: 'relay-error', negativeCache: true });
+    assert.equal(attempts.classifyFeedAttempt(true, failed, { parsedTotal: 0, keptItems: 0, droppedUndated: 0 }), 'negative-cache');
   });
 });
 
@@ -143,45 +193,102 @@ describe('interleaveByCategory (#7083)', () => {
   });
 });
 
-describe('list-feed-digest wiring (#7083)', () => {
-  let digestSource: string;
+describe('runFeedAttemptBatches (#7083)', () => {
+  it('uses distinct attempt IDs for duplicate display names in the real digest inventory', () => {
+    const { allEntries, batches } = digestTesting.buildDigestFeedBatches('full', 'en');
+    const ids = allEntries.map((entry) => entry.attemptId);
+    assert.equal(new Set(ids).size, ids.length, 'each inventory entry must have a unique attempt ID');
+    assert.ok(allEntries.length > digestTesting.BATCH_CONCURRENCY, 'fixture must require more than one real scheduling wave');
+    assert.ok(batches.length > 1, 'full inventory must be split into multiple scheduling waves');
+    assert.equal(batches[0]?.length, digestTesting.BATCH_CONCURRENCY);
+    const allCategories = new Set(allEntries.map((entry) => entry.category));
+    const firstWaveCategories = new Set(batches[0]?.map((entry) => entry.category));
+    assert.deepEqual(
+      [...allCategories].filter((category) => !firstWaveCategories.has(category)),
+      [],
+      'the first real scheduling wave must cover every eligible category',
+    );
 
-  before(async () => {
-    digestSource = await readFile(resolve(root, 'server/worldmonitor/news/v1/list-feed-digest.ts'), 'utf8');
+    const byName = new Map<string, typeof allEntries>();
+    for (const entry of allEntries) {
+      const entries = byName.get(entry.feed.name) ?? [];
+      entries.push(entry);
+      byName.set(entry.feed.name, entries);
+    }
+    const duplicate = [...byName.values()].find((entries) => entries.length > 1);
+    assert.ok(duplicate, 'the full inventory must contain a duplicate display name regression fixture');
+    assert.equal(new Set(duplicate.map((entry) => entry.attemptId)).size, duplicate.length);
   });
 
-  it('batches from the priority head plus category-interleaved ordering', () => {
-    // The China coverage trio's deadlinePriority promise stays absolute —
-    // pinned before the interleave — while every other category round-robins
-    // so no single slow category can starve the rest behind the deadline.
-    assert.match(digestSource, /priorityHead/);
-    assert.match(digestSource, /interleaveByCategory\(/);
-    assert.match(digestSource, /deadlinePriority \?\? 0\) > 0/);
+  it('keeps duplicate display names distinct by attempt ID across more than one wave', async () => {
+    const calls: string[] = [];
+    const entries = [{ attemptId: 'slow:1', category: 'slow' }, { attemptId: 'fast:1', category: 'fast' }, { attemptId: 'slow:2', category: 'slow' }];
+    let releaseSlow!: () => void;
+    const slow = new Promise<void>((resolveSlow) => { releaseSlow = resolveSlow; });
+    const running = attempts.runFeedAttemptBatches(
+      entries,
+      [[entries[0], entries[1]], [entries[2]]],
+      new AbortController().signal,
+      async (entry) => {
+        calls.push(entry.attemptId);
+        if (entry.attemptId === 'slow:1') await slow;
+        return { value: entry.attemptId, outcome: 'completed' };
+      },
+      (() => { let tick = 0; return () => tick++ * 10; })(),
+    );
+    await Promise.resolve();
+    assert.deepEqual(calls, ['slow:1', 'fast:1'], 'the slow first-wave entry must not prevent fast-category start');
+    releaseSlow();
+    const result = await running;
+    assert.deepEqual(calls, ['slow:1', 'fast:1', 'slow:2']);
+    assert.deepEqual(result.fulfilled.map(({ value }) => value), ['slow:1', 'fast:1', 'slow:2']);
+    assert.equal(result.attemptCategories.get('slow:1'), 'slow');
+    assert.equal(result.attemptCategories.get('slow:2'), 'slow');
+    assert.equal(result.attemptOutcomes.size, 3);
+    assert.notEqual(result.firstCompletionMs, null);
+    assert.notEqual(result.finalCompletionMs, null);
   });
 
-  it('records started feeds before awaiting and labels the rest not-started', () => {
-    assert.match(digestSource, /startedFeeds\.add\(feed\.name\)/);
-    // The precise 'not-started' verdict is internal (attemptOutcomes +
-    // telemetry); the public map keeps the coarse 'timeout' contract.
-    assert.match(digestSource, /attemptOutcomes\.set\(entry\.feed\.name, 'not-started'\)/);
-    assert.match(digestSource, /feedStatuses\[entry\.feed\.name\] = 'timeout'/);
+  it('does not start later waves after global abort and labels them not-started', async () => {
+    const controller = new AbortController();
+    const entries = [{ attemptId: 'started', category: 'slow' }, { attemptId: 'later', category: 'fast' }];
+    const result = await attempts.runFeedAttemptBatches(
+      entries,
+      [[entries[0]], [entries[1]]],
+      controller.signal,
+      async (entry) => {
+        controller.abort();
+        return { value: entry.attemptId, outcome: 'completed' };
+      },
+    );
+    assert.deepEqual([...result.startedAttemptIds], ['started']);
+    assert.equal(result.attemptOutcomes.get('later'), 'not-started');
+    assert.equal(result.attemptCategories.get('later'), 'fast');
   });
 
-  it('classifies every started feed through the closed vocabulary', () => {
-    assert.match(digestSource, /classifyFeedAttempt\(/);
+  it('records rejected executors as other fetch failures', async () => {
+    const result = await attempts.runFeedAttemptBatches(
+      [{ attemptId: 'broken', category: 'slow' }],
+      [[{ attemptId: 'broken', category: 'slow' }]],
+      new AbortController().signal,
+      async () => { throw new Error('network failure'); },
+    );
+    assert.deepEqual(result.fulfilled, []);
+    assert.equal(result.attemptOutcomes.get('broken'), 'other-fetch-failure');
   });
 
-  it('emits the per-build attempt telemetry line', () => {
-    assert.match(digestSource, /\[digest-attempts\]/);
-    assert.match(digestSource, /by_outcome=/);
-    assert.match(digestSource, /headroom_ms=/);
-  });
-
-  it('keeps healthy completed feeds out of the public status map', () => {
-    // The public map only ever assigns the coarse states for non-healthy
-    // outcomes ('all-undated'/'empty'/'partial-undated'); a healthy parse
-    // leaves the feed absent, and fine-grained outcomes stay internal.
-    assert.match(digestSource, /feedStatuses\[feed\.name\] = 'empty'/);
-    assert.doesNotMatch(digestSource, /feedStatuses\[feed\.name\] = outcome/);
+  it('summarizes every unique attempt by outcome/category and computes deadline headroom', () => {
+    const summary = attempts.summarizeFeedAttempts(
+      new Map([['shared:1', 'tech'], ['shared:2', 'intel'], ['later:3', 'intel']]),
+      new Map([['shared:1', 'completed'], ['shared:2', 'relay-failure'], ['later:3', 'not-started']]),
+      10_000,
+      8_250,
+    );
+    assert.deepEqual(summary.byOutcome, { completed: 1, 'relay-failure': 1, 'not-started': 1 });
+    assert.deepEqual(summary.byCategory, {
+      tech: { completed: 1 },
+      intel: { 'relay-failure': 1, 'not-started': 1 },
+    });
+    assert.equal(summary.headroomMs, 1_750);
   });
 });

--- a/tests/digest-attempt-outcomes.test.mts
+++ b/tests/digest-attempt-outcomes.test.mts
@@ -150,14 +150,21 @@ describe('list-feed-digest wiring (#7083)', () => {
     digestSource = await readFile(resolve(root, 'server/worldmonitor/news/v1/list-feed-digest.ts'), 'utf8');
   });
 
-  it('batches from the category-interleaved ordering', () => {
-    assert.match(digestSource, /interleaveByCategory\(orderServerFeedEntries\(allEntries\)\)/);
+  it('batches from the priority head plus category-interleaved ordering', () => {
+    // The China coverage trio's deadlinePriority promise stays absolute —
+    // pinned before the interleave — while every other category round-robins
+    // so no single slow category can starve the rest behind the deadline.
+    assert.match(digestSource, /priorityHead/);
+    assert.match(digestSource, /interleaveByCategory\(/);
+    assert.match(digestSource, /deadlinePriority \?\? 0\) > 0/);
   });
 
   it('records started feeds before awaiting and labels the rest not-started', () => {
     assert.match(digestSource, /startedFeeds\.add\(feed\.name\)/);
-    assert.match(digestSource, /'not-started'/);
-    assert.doesNotMatch(digestSource, /feedStatuses\[entry\.feed\.name\] = 'timeout'/);
+    // The precise 'not-started' verdict is internal (attemptOutcomes +
+    // telemetry); the public map keeps the coarse 'timeout' contract.
+    assert.match(digestSource, /attemptOutcomes\.set\(entry\.feed\.name, 'not-started'\)/);
+    assert.match(digestSource, /feedStatuses\[entry\.feed\.name\] = 'timeout'/);
   });
 
   it('classifies every started feed through the closed vocabulary', () => {
@@ -171,6 +178,10 @@ describe('list-feed-digest wiring (#7083)', () => {
   });
 
   it('keeps healthy completed feeds out of the public status map', () => {
-    assert.match(digestSource, /if \(outcome !== 'completed'\)/);
+    // The public map only ever assigns the coarse states for non-healthy
+    // outcomes ('all-undated'/'empty'/'partial-undated'); a healthy parse
+    // leaves the feed absent, and fine-grained outcomes stay internal.
+    assert.match(digestSource, /feedStatuses\[feed\.name\] = 'empty'/);
+    assert.doesNotMatch(digestSource, /feedStatuses\[feed\.name\] = outcome/);
   });
 });

--- a/tests/news-story-track-description-persistence.test.mts
+++ b/tests/news-story-track-description-persistence.test.mts
@@ -444,7 +444,7 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
 });
 
 describe('fetchAndParseRss — cache prefix invalidation contract', () => {
-  it('rss:feed cache prefix is v8 (duration-led historical-explainer stamp), not v4/v5/v6/v7', () => {
+  it('rss:feed cache prefix is v9 (per-attempt fetch verdicts), not v4/v5/v6/v7/v8', () => {
     // Pre-PR ParsedItems cached at rss:feed:v4 lack the
     // isEphemeralLiveCoverage field. If a cache hit returned one of those,
     // the falsy-coerce in
@@ -461,19 +461,20 @@ describe('fetchAndParseRss — cache prefix invalidation contract', () => {
       resolve(__dirname, '..', 'server', 'worldmonitor', 'news', 'v1', 'list-feed-digest.ts'),
       'utf-8',
     );
-    // v7→v8: duration-led historical explainers now receive the same stable
-    // ingest stamp. Digest reads trust explicit stamps, so warm v7 rows must
-    // not retain a pre-rule "0" verdict for a cache TTL.
+    // v8→v9: cached ParseResult rows now carry the fetch attempt verdict
+    // (source + failure classification, #7083). Warm v8 rows lack the
+    // attempt field and would misreport feed health as an unknown state.
     assert.ok(
-      src.includes("`rss:feed:v8:${variant}:${feed.url}`"),
-      'rss:feed cache key must use v8 prefix — see comment above the cacheKey assignment in fetchAndParseRss',
+      src.includes("`rss:feed:v9:${variant}:${feed.url}`"),
+      'rss:feed cache key must use v9 prefix — see comment above the cacheKey assignment in fetchAndParseRss',
     );
     assert.ok(
-      !src.includes("`rss:feed:v7:${variant}:${feed.url}`") &&
+      !src.includes("`rss:feed:v8:${variant}:${feed.url}`") &&
+        !src.includes("`rss:feed:v7:${variant}:${feed.url}`") &&
         !src.includes("`rss:feed:v6:${variant}:${feed.url}`") &&
         !src.includes("`rss:feed:v5:${variant}:${feed.url}`") &&
         !src.includes("`rss:feed:v4:${variant}:${feed.url}`"),
-      'must NOT leave a residual v4/v5/v6/v7 cacheKey assignment — would silently revert the cutover',
+      'must NOT leave a residual v4/v5/v6/v7/v8 cacheKey assignment — would silently revert the cutover',
     );
   });
 });


### PR DESCRIPTION
Closes #7083 (this PR covers plan sections 1, 3, and the telemetry half of 2; the response-shape/coverage work stays with the dependent issues as the plan scopes them).

## What

Two defects from the report, both fixed:

1. **Every unfinished feed was labeled `timeout`** — including feeds whose batch never started, and fetch failures, which were actually being swallowed into `empty` (the fetch path resolves with a zero-item `ParseResult` instead of rejecting, so `Promise.allSettled` never saw them). Scheduling starvation was indistinguishable from upstream failure.
2. **Fixed-size batches over a globally ordered feed list starved later categories** — the `intel` category sits at the end, so a slow head of the list could consume the whole 10-second deadline before `intel` started.

## How

**Closed attempt vocabulary** (`server/worldmonitor/news/v1/_attempts.ts`, import-free and directly unit-testable): `completed`, `empty`, `all-undated`, `partial-undated`, `direct-timeout`, `relay-failure`, `aborted-by-deadline`, `other-fetch-failure`, `negative-cache`, `not-started`.

- `createTimeoutLinkedController` now reports **which** abort fired (the per-feed timeout vs the parent/global deadline), and `fetchRssText` returns a failure reason instead of bare `null`; the relay fallback records its own failure.
- A served zero-item cache entry is named `negative-cache`, not `empty` (cache prefix bumped `v8`→`v9` — warm v8 rows lack the `attempt` field; same cutover pattern this file already documents for v5→v8).
- `classifyFeedAttempt` is a pure function: started-flag + fetch verdict + item counters → terminal outcome. Feeds whose batch never ran are reported as `not-started`, never as `timeout`.
- The public `feedStatuses` map keeps its historical contract (healthy feeds stay absent; `empty`/`all-undated`/`partial-undated` unchanged) — failure states now carry their precise name instead of being flattened.

**Category-fair scheduling**: `interleaveByCategory` round-robins the (still priority-ordered) entries so the first batch wave contains the head of every eligible category; within a category, strategic `deadlinePriority` order is untouched, and the single global concurrency limit and single overall deadline are unchanged — no retries, no per-category storms.

**Operator telemetry** (plan §2's timing half): one structured `[digest-attempts]` line per build with the outcome histogram, per-category outcome counts, `first_start_ms` / `first_completion_ms` / `final_completion_ms` / `headroom_ms`, and whether the deadline fired. No host names or exceptions — those stay in the existing `[feed-fetch]` lines.

## Testing

`tests/digest-attempt-outcomes.test.mts` — 13 cases, esbuild-bundled like the neighboring suites:

- the vocabulary contains every state from the plan;
- every `classifyFeedAttempt` branch (not-started, direct-timeout vs deadline-abort vs relay-failure, negative-cache, the four historical healthy/undated outcomes);
- `interleaveByCategory`: first wave contains every category, in-category order preserved, deterministic;
- wiring assertions: the interleave wraps the priority ordering, feeds are recorded as started before the await, the blanket `= 'timeout'` is gone, healthy feeds stay out of the public map, the telemetry line exists.

**Differential**: on `main` the suite cannot pass — the module and the wiring do not exist. Adjacent digest suites (`digest-no-reclassify`, `brief-from-digest-stories`, `china-news-coverage`) pass unchanged: 125/125. `tsc --noEmit` clean.