### PR TITLE
perf: parallelize serialized server reads, slim FAST-tier market payloads

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1861,6 +1861,23 @@ export function roundSparkline(values, sig = SPARKLINE_SIGNIFICANT_DIGITS) {
   return values.map((v) => toSignificantDigits(v, sig));
 }
 
+/** Decimal places kept for published geographic coordinates. 5 dp is ~1.1m at the equator. */
+export const GEO_COORDINATE_DECIMALS = 5;
+
+/**
+ * Round one lat/lon to `decimals` places for the PUBLISHED payload.
+ *
+ * Apply this at the serialization boundary, never at the parse boundary. Rounded
+ * coordinates that reach comparison logic shift its decisions: the earthquake
+ * cross-agency dedup gates on `haversineDistanceKm(...) <= 10`, and rounding both
+ * sides first can move a pair across that threshold (verified: pairs at 9.99977km
+ * become 10.00054km, so a duplicate publishes twice — or two distinct events merge).
+ * Non-finite values pass through untouched, matching roundSparkline's contract.
+ */
+export function roundGeoCoordinate(value, decimals = GEO_COORDINATE_DECIMALS) {
+  return Number.isFinite(value) ? Number(value.toFixed(decimals)) : value;
+}
+
 export function parseYahooChart(data, symbol) {
   const result = data?.chart?.result?.[0];
   const meta = result?.meta;

--- a/scripts/_weather-alert-select.mjs
+++ b/scripts/_weather-alert-select.mjs
@@ -13,6 +13,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { roundGeoCoordinate } from './_seed-utils.mjs';
+
 const ISO3_TO_ISO2 = JSON.parse(
   readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'shared/iso3-to-iso2.json'), 'utf8'),
 );
@@ -81,13 +83,11 @@ export function requireAlertFeatures(data) {
 }
 
 // NWS ships 6-7 decimal coordinates. Five decimals retain metre-level detail
-// while reducing the FAST-tier weather-alert payload.
-function roundCoordinate(value) {
-  return Number.isFinite(value) ? Number(value.toFixed(5)) : value;
-}
-
+// while reducing the FAST-tier weather-alert payload. Shared with the earthquake
+// seeder via _seed-utils.mjs (both files, and _seed-utils.mjs itself, are COPY'd
+// into the relay image — see Dockerfile.relay and tests/dockerfile-relay-imports.test.mjs).
 function roundPosition(position) {
-  return [roundCoordinate(position[0]), roundCoordinate(position[1])];
+  return [roundGeoCoordinate(position[0]), roundGeoCoordinate(position[1])];
 }
 
 export function extractCoordinates(geometry) {
@@ -136,8 +136,18 @@ function isClosedLinearRing(ring) {
   if (!Array.isArray(ring) || ring.length < 4) return false;
   const first = ring[0];
   const last = ring[ring.length - 1];
-  return Array.isArray(first) && Array.isArray(last)
-    && first[0] === last[0] && first[1] === last[1];
+  if (!Array.isArray(first) || !Array.isArray(last)) return false;
+  if (first[0] !== last[0] || first[1] !== last[1]) return false;
+  // Position count and endpoint equality are not sufficient once coordinates are
+  // rounded: sub-metre-adjacent vertices collapse onto each other, so a ring can
+  // keep 4+ positions and matching endpoints while enclosing zero area. PostGIS
+  // accepts that as "closed" and it reaches third-party webhooks as a degenerate
+  // Polygon. A real ring has at least 3 distinct vertices.
+  const distinct = new Set();
+  for (const position of ring) {
+    if (Array.isArray(position)) distinct.add(`${position[0]},${position[1]}`);
+  }
+  return distinct.size >= 3;
 }
 
 export function calculateCentroid(coords) {

--- a/scripts/_weather-alert-select.mjs
+++ b/scripts/_weather-alert-select.mjs
@@ -80,14 +80,24 @@ export function requireAlertFeatures(data) {
   return data.features;
 }
 
+// NWS ships 6-7 decimal coordinates. Five decimals retain metre-level detail
+// while reducing the FAST-tier weather-alert payload.
+function roundCoordinate(value) {
+  return Number.isFinite(value) ? Number(value.toFixed(5)) : value;
+}
+
+function roundPosition(position) {
+  return [roundCoordinate(position[0]), roundCoordinate(position[1])];
+}
+
 export function extractCoordinates(geometry) {
   if (!geometry) return [];
   try {
     if (geometry.type === 'Polygon') {
-      return geometry.coordinates[0]?.map(c => [c[0], c[1]]) || [];
+      return geometry.coordinates[0]?.map(roundPosition) || [];
     }
     if (geometry.type === 'MultiPolygon') {
-      return geometry.coordinates[0]?.[0]?.map(c => [c[0], c[1]]) || [];
+      return geometry.coordinates[0]?.[0]?.map(roundPosition) || [];
     }
   } catch { /* ignore */ }
   return [];
@@ -103,12 +113,12 @@ export function extractRings(geometry) {
   if (!geometry) return [];
   try {
     if (geometry.type === 'Polygon') {
-      const ring = geometry.coordinates[0]?.map(c => [c[0], c[1]]);
+      const ring = geometry.coordinates[0]?.map(roundPosition);
       return ring ? [ring] : [];
     }
     if (geometry.type === 'MultiPolygon') {
       return (geometry.coordinates || [])
-        .map(poly => poly?.[0]?.map(c => [c[0], c[1]]))
+        .map(poly => poly?.[0]?.map(roundPosition))
         .filter(Array.isArray);
     }
   } catch { /* ignore */ }

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2367,9 +2367,20 @@ function _parseYahooChartJson(body) {
     // (_seed-utils.mjs). Raw float64 noise made these FAST-tier keys ~2x the
     // rounded size, and whichever writer wins the relay/cron race decides
     // what every visitor downloads on cold load.
+    //
+    // The guard below MIRRORS toSignificantDigits in _seed-utils.mjs exactly:
+    // non-numbers, non-finite values and 0 pass through untouched so a malformed
+    // upstream degrades identically on both writers. Without it a string close
+    // ("N/A") becomes NaN and serialises to null, denting the curve on the relay
+    // path only. CJS cannot import the ESM helper, so the copy is deliberate and
+    // tests/ais-relay-sparkline-precision.test.mjs pins the two in lockstep.
     const closes = result.indicators?.quote?.[0]?.close;
     const sparkline = Array.isArray(closes)
-      ? closes.filter((v) => v != null).map((v) => Number(Number(v).toPrecision(7)))
+      ? closes.filter((v) => v != null).map((v) => (
+        typeof v === 'number' && Number.isFinite(v) && v !== 0
+          ? Number(v.toPrecision(7))
+          : v
+      ))
       : [];
     return { price, change, sparkline };
   } catch { return null; }

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2363,8 +2363,14 @@ function _parseYahooChartJson(body) {
     const price = meta.regularMarketPrice;
     const prevClose = meta.chartPreviousClose || meta.previousClose || price;
     const change = prevClose ? ((price - prevClose) / prevClose) * 100 : 0;
+    // Round to 7 significant digits like the cron seeders' roundSparkline
+    // (_seed-utils.mjs). Raw float64 noise made these FAST-tier keys ~2x the
+    // rounded size, and whichever writer wins the relay/cron race decides
+    // what every visitor downloads on cold load.
     const closes = result.indicators?.quote?.[0]?.close;
-    const sparkline = Array.isArray(closes) ? closes.filter((v) => v != null) : [];
+    const sparkline = Array.isArray(closes)
+      ? closes.filter((v) => v != null).map((v) => Number(Number(v).toPrecision(7)))
+      : [];
     return { price, change, sparkline };
   } catch { return null; }
 }

--- a/scripts/seismology/nrcan-atom.mjs
+++ b/scripts/seismology/nrcan-atom.mjs
@@ -22,6 +22,10 @@ const TITLE_RE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) UTC:\s*M(\d+(?:\.\d+)?)
 const EVENT_ID_RE = /[?&]eventid=([^&]+)/i;
 const CLOCK_SKEW_MS = 60 * 60 * 1000;
 
+function roundCoordinate(value) {
+  return Number.isFinite(value) ? Number(value.toFixed(5)) : value;
+}
+
 export class NrcanAtomParseError extends Error {
   constructor(message) {
     super(message);
@@ -60,7 +64,12 @@ function parsePoint(block) {
   const latitude = Number(parts[0]);
   const longitude = Number(parts[1]);
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
-  return { latitude, longitude };
+  // 5 decimals ~ 1m — matches the weather-alert polygon rounding; upstream
+  // ships 6-7 decimals that only inflate the seeded payload.
+  return {
+    latitude: roundCoordinate(latitude),
+    longitude: roundCoordinate(longitude),
+  };
 }
 
 function parseDepthKm(block) {
@@ -259,8 +268,8 @@ export function parseUsgsGeojson(geojson) {
       magnitude: feature.properties?.mag ?? 0,
       depthKm: feature.geometry?.coordinates?.[2] ?? 0,
       location: {
-        latitude: feature.geometry?.coordinates?.[1] ?? 0,
-        longitude: feature.geometry?.coordinates?.[0] ?? 0,
+        latitude: roundCoordinate(feature.geometry?.coordinates?.[1] ?? 0),
+        longitude: roundCoordinate(feature.geometry?.coordinates?.[0] ?? 0),
       },
       occurredAt: Number.isFinite(occurredAt) && occurredAt > 0 ? occurredAt : 0,
       sourceUrl: String(feature.properties?.url || ''),

--- a/scripts/seismology/nrcan-atom.mjs
+++ b/scripts/seismology/nrcan-atom.mjs
@@ -1,7 +1,7 @@
 // Pure Earthquakes Canada (NRCan) Atom parser + USGS merge/dedup helpers.
 // Tests import this module, not the seeder entrypoint.
 
-import { CHROME_UA } from '../_seed-utils.mjs';
+import { CHROME_UA, roundGeoCoordinate } from '../_seed-utils.mjs';
 import { decodeHtmlEntities } from '../_html-entities.mjs';
 
 export const NRCAN_ATOM_HOST = 'www.earthquakescanada.nrcan.gc.ca';
@@ -21,10 +21,6 @@ export const EARTHQUAKE_DEDUP_DISTANCE_KM = 10;
 const TITLE_RE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) UTC:\s*M(\d+(?:\.\d+)?)\s+(.*)$/i;
 const EVENT_ID_RE = /[?&]eventid=([^&]+)/i;
 const CLOCK_SKEW_MS = 60 * 60 * 1000;
-
-function roundCoordinate(value) {
-  return Number.isFinite(value) ? Number(value.toFixed(5)) : value;
-}
 
 export class NrcanAtomParseError extends Error {
   constructor(message) {
@@ -64,12 +60,11 @@ function parsePoint(block) {
   const latitude = Number(parts[0]);
   const longitude = Number(parts[1]);
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
-  // 5 decimals ~ 1m — matches the weather-alert polygon rounding; upstream
-  // ships 6-7 decimals that only inflate the seeded payload.
-  return {
-    latitude: roundCoordinate(latitude),
-    longitude: roundCoordinate(longitude),
-  };
+  // Full upstream precision is kept HERE on purpose. Coordinates are rounded for
+  // the published payload in earthquakesPublishTransform, after dedup has run —
+  // isCrossAgencyMatch compares haversine distance against a 10km threshold, and
+  // rounding before that comparison moves pairs across it.
+  return { latitude, longitude };
 }
 
 function parseDepthKm(block) {
@@ -267,9 +262,10 @@ export function parseUsgsGeojson(geojson) {
       place: String(feature.properties?.place || ''),
       magnitude: feature.properties?.mag ?? 0,
       depthKm: feature.geometry?.coordinates?.[2] ?? 0,
+      // Full precision — rounded in earthquakesPublishTransform, after dedup.
       location: {
-        latitude: roundCoordinate(feature.geometry?.coordinates?.[1] ?? 0),
-        longitude: roundCoordinate(feature.geometry?.coordinates?.[0] ?? 0),
+        latitude: feature.geometry?.coordinates?.[1] ?? 0,
+        longitude: feature.geometry?.coordinates?.[0] ?? 0,
       },
       occurredAt: Number.isFinite(occurredAt) && occurredAt > 0 ? occurredAt : 0,
       sourceUrl: String(feature.properties?.url || ''),
@@ -456,8 +452,33 @@ export function earthquakesContentMeta(data, nowMs = Date.now()) {
   return { newestItemAt, oldestItemAt };
 }
 
+/**
+ * The serialization boundary — the ONLY place earthquake coordinates are rounded.
+ *
+ * 5 decimals is ~1.1m, invisible on the map, and roughly halves the coordinate
+ * bytes in the published payload. It happens here rather than in parsePoint /
+ * parseUsgsGeojson because mergeEarthquakeFeeds runs first and its
+ * isCrossAgencyMatch gates on `haversineDistanceKm(usgs, nrcan) <= 10`: rounding
+ * both sides before that comparison perturbs the distance by up to ~2m, which is
+ * enough to move a pair across the threshold in either direction (publishing a
+ * duplicate, or merging two genuinely distinct events).
+ */
 export function earthquakesPublishTransform(data) {
-  return { earthquakes: Array.isArray(data?.earthquakes) ? data.earthquakes : [] };
+  const earthquakes = Array.isArray(data?.earthquakes) ? data.earthquakes : [];
+  return {
+    earthquakes: earthquakes.map((eq) => (
+      eq?.location
+        ? {
+          ...eq,
+          location: {
+            ...eq.location,
+            latitude: roundGeoCoordinate(eq.location.latitude),
+            longitude: roundGeoCoordinate(eq.location.longitude),
+          },
+        }
+        : eq
+    )),
+  };
 }
 
 /**

--- a/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
+++ b/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
@@ -36,6 +36,9 @@ export async function getAirportOpsSummary(
         const summaries: AirportOpsSummary[] = [];
 
         // Read delay alerts from relay seed cache (no direct AviationStack call)
+        // PERF: seed read and NOTAM loader are independent — start the NOTAM
+        // fetch now so it overlaps the cache round-trip below.
+        const notamRead = loadNotamClosures();
         let alerts: AirportDelayAlert[] = [];
         let healthy = false;
         try {
@@ -57,7 +60,7 @@ export async function getAirportOpsSummary(
         let notamRestrictedIcaos = new Set<string>();
         let notamReasons: Record<string, string> = {};
         try {
-            const notamResult = await loadNotamClosures();
+            const notamResult = await notamRead;
             if (notamResult) {
                 notamClosedIcaos = new Set(notamResult.closedIcaos);
                 notamRestrictedIcaos = new Set(notamResult.restrictedIcaos ?? []);

--- a/server/worldmonitor/aviation/v1/list-airport-delays.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-delays.ts
@@ -101,11 +101,6 @@ export async function listAirportDelays(
   const [{ faaAlerts, faaSourceCovered }, { intlAlerts, intlCoverage, intlCoveredIatas }, notamResult] =
     await Promise.all([faaRead, intlRead, notamRead]);
 
-  // 3. NOTAM alerts — shared loader (seed-first with live fallback).
-  // loadNotamClosures swallows both the seed-read and live-fetch failures
-  // internally (returns null on error), so no outer try/catch is needed — a
-  // failure degrades cleanly to "no NOTAM merge this tick" rather than
-  // bubbling and tripping every airport to UNKNOWN at the handler boundary.
   const allAlerts = [...faaAlerts, ...intlAlerts];
   if (notamResult) {
     const existingIatas = new Set(allAlerts.map(a => a.iata));

--- a/server/worldmonitor/aviation/v1/list-airport-delays.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-delays.ts
@@ -37,50 +37,69 @@ export async function listAirportDelays(
   // faaSourceCovered = the seed cache hit AND returned a valid alerts array.
   // A miss/parse-error means we have no telemetry for any FAA airport this
   // tick — we MUST NOT publish synthetic "normal" rows for them. See #3707.
-  let faaAlerts: AirportDelayAlert[] = [];
-  let faaSourceCovered = false;
-  try {
-    const seedData = await getCachedJson(FAA_CACHE_KEY, true) as { alerts: AirportDelayAlert[] } | null;
-    if (seedData && Array.isArray(seedData.alerts)) {
-      faaSourceCovered = true;
-      faaAlerts = seedData.alerts
-        .map(a => {
-          const airport = MONITORED_AIRPORTS.find(ap => ap.iata === a.iata);
-          if (!airport) return null;
-          if (!a.icao || a.icao === '') {
-            return { ...a, icao: airport.icao, name: airport.name, city: airport.city, country: airport.country, location: { latitude: airport.lat, longitude: airport.lon }, region: toProtoRegion(airport.region) };
-          }
-          return a;
-        })
-        .filter((a): a is AirportDelayAlert => a !== null);
+  // PERF: the three inputs below are independent (different Redis keys / an
+  // independent fetcher) and merge only afterwards — start them concurrently
+  // instead of paying three serial round-trips per request.
+  const faaRead = (async (): Promise<{ faaAlerts: AirportDelayAlert[]; faaSourceCovered: boolean }> => {
+    let faaAlerts: AirportDelayAlert[] = [];
+    let faaSourceCovered = false;
+    try {
+      const seedData = await getCachedJson(FAA_CACHE_KEY, true) as { alerts: AirportDelayAlert[] } | null;
+      if (seedData && Array.isArray(seedData.alerts)) {
+        faaSourceCovered = true;
+        faaAlerts = seedData.alerts
+          .map(a => {
+            const airport = MONITORED_AIRPORTS.find(ap => ap.iata === a.iata);
+            if (!airport) return null;
+            if (!a.icao || a.icao === '') {
+              return { ...a, icao: airport.icao, name: airport.name, city: airport.city, country: airport.country, location: { latitude: airport.lat, longitude: airport.lon }, region: toProtoRegion(airport.region) };
+            }
+            return a;
+          })
+          .filter((a): a is AirportDelayAlert => a !== null);
+      }
+    } catch (err) {
+      console.warn(`[Aviation] FAA seed read failed: ${err instanceof Error ? err.message : 'unknown'}`);
+      void captureSilentError(err, { tags: { route: 'aviation/list-airport-delays', step: 'faa-seed-read' } });
     }
-  } catch (err) {
-    console.warn(`[Aviation] FAA seed read failed: ${err instanceof Error ? err.message : 'unknown'}`);
-    void captureSilentError(err, { tags: { route: 'aviation/list-airport-delays', step: 'faa-seed-read' } });
-  }
+    return { faaAlerts, faaSourceCovered };
+  })();
 
   // 2. International — read-only from Redis (Railway relay seeds the cache)
   // A cache hit alone does not prove every configured hub was covered. The
   // seeder records each hub as normal/disruption/omitted/failed so an omitted
   // hub remains UNKNOWN instead of being synthesized as normal.
-  let intlAlerts: AirportDelayAlert[] = [];
-  let intlCoverage: IntlCoverage[] = [];
-  let intlCoveredIatas = new Set<string>();
-  try {
-    const cached = await getCachedJson(INTL_CACHE_KEY) as { alerts: AirportDelayAlert[]; coverage?: IntlCoverage[] } | null;
-    if (cached && Array.isArray(cached.alerts)) {
-      intlAlerts = cached.alerts;
-      if (Array.isArray(cached.coverage)) {
-        intlCoverage = cached.coverage;
-        intlCoveredIatas = new Set(cached.coverage
-          .filter((hub) => hub.status === 'normal' || hub.status === 'disruption')
-          .map((hub) => hub.iata));
+  const intlRead = (async (): Promise<{ intlAlerts: AirportDelayAlert[]; intlCoverage: IntlCoverage[]; intlCoveredIatas: Set<string> }> => {
+    let intlAlerts: AirportDelayAlert[] = [];
+    let intlCoverage: IntlCoverage[] = [];
+    let intlCoveredIatas = new Set<string>();
+    try {
+      const cached = await getCachedJson(INTL_CACHE_KEY) as { alerts: AirportDelayAlert[]; coverage?: IntlCoverage[] } | null;
+      if (cached && Array.isArray(cached.alerts)) {
+        intlAlerts = cached.alerts;
+        if (Array.isArray(cached.coverage)) {
+          intlCoverage = cached.coverage;
+          intlCoveredIatas = new Set(cached.coverage
+            .filter((hub) => hub.status === 'normal' || hub.status === 'disruption')
+            .map((hub) => hub.iata));
+        }
       }
+    } catch (err) {
+      console.warn(`[Aviation] Intl fetch failed: ${err instanceof Error ? err.message : 'unknown'}`);
+      void captureSilentError(err, { tags: { route: 'aviation/list-airport-delays', step: 'intl-cache-read' } });
     }
-  } catch (err) {
-    console.warn(`[Aviation] Intl fetch failed: ${err instanceof Error ? err.message : 'unknown'}`);
-    void captureSilentError(err, { tags: { route: 'aviation/list-airport-delays', step: 'intl-cache-read' } });
-  }
+    return { intlAlerts, intlCoverage, intlCoveredIatas };
+  })();
+
+  // 3. NOTAM alerts — shared loader (seed-first with live fallback).
+  // loadNotamClosures swallows both the seed-read and live-fetch failures
+  // internally (returns null on error), so no outer try/catch is needed — a
+  // failure degrades cleanly to "no NOTAM merge this tick" rather than
+  // bubbling and tripping every airport to UNKNOWN at the handler boundary.
+  const notamRead = loadNotamClosures();
+
+  const [{ faaAlerts, faaSourceCovered }, { intlAlerts, intlCoverage, intlCoveredIatas }, notamResult] =
+    await Promise.all([faaRead, intlRead, notamRead]);
 
   // 3. NOTAM alerts — shared loader (seed-first with live fallback).
   // loadNotamClosures swallows both the seed-read and live-fetch failures
@@ -88,7 +107,6 @@ export async function listAirportDelays(
   // failure degrades cleanly to "no NOTAM merge this tick" rather than
   // bubbling and tripping every airport to UNKNOWN at the handler boundary.
   const allAlerts = [...faaAlerts, ...intlAlerts];
-  const notamResult = await loadNotamClosures();
   if (notamResult) {
     const existingIatas = new Set(allAlerts.map(a => a.iata));
     const applyNotam = (icao: string, severity: 'severe' | 'major', delayType: 'closure' | 'general', fallback: string) => {

--- a/server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts
+++ b/server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts
@@ -120,8 +120,13 @@ export async function listTemporalAnomalies(
       const anomalies: TemporalAnomalyProto[] = [];
 
       const counts: Record<string, number> = {};
-      for (const [type, sourceKey] of Object.entries(COUNT_SOURCE_KEYS)) {
-        const data = await getCachedJson(sourceKey) as Record<string, unknown> | null;
+      const countEntries = await Promise.all(
+        Object.entries(COUNT_SOURCE_KEYS).map(async ([type, sourceKey]) => [
+          type,
+          await getCachedJson(sourceKey) as Record<string, unknown> | null,
+        ] as const),
+      );
+      for (const [type, data] of countEntries) {
         if (!data) continue;
 
         if (type === 'news') {

--- a/server/worldmonitor/intelligence/v1/get-country-port-activity.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-port-activity.ts
@@ -61,11 +61,15 @@ export async function getCountryPortActivity(
   const code = req.countryCode?.trim().toUpperCase() ?? '';
   if (!code || code.length !== 2) return EMPTY;
 
-  const countriesResult = await getCachedJson(PORTWATCH_PORT_ACTIVITY_COUNTRIES_KEY, true).catch(() => null);
+  // PERF: allowlist + payload reads run concurrently; the gate is applied on
+  // the combined result. Valid codes save a serial RTT; invalid ones cost one
+  // extra small read instead of one extra RTT on every valid request.
+  const [countriesResult, data] = await Promise.all([
+    getCachedJson(PORTWATCH_PORT_ACTIVITY_COUNTRIES_KEY, true).catch(() => null),
+    getCachedJson(`${PORTWATCH_PORT_ACTIVITY_KEY_PREFIX}${code}`, true).catch(() => null),
+  ]);
   const countries = Array.isArray(countriesResult) ? (countriesResult as string[]) : [];
   if (!countries.includes(code)) return EMPTY;
-
-  const data = await getCachedJson(`${PORTWATCH_PORT_ACTIVITY_KEY_PREFIX}${code}`, true).catch(() => null);
   if (!data) return EMPTY;
 
   const payload = data as SeederPayload;

--- a/server/worldmonitor/intelligence/v1/get-country-port-activity.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-port-activity.ts
@@ -58,8 +58,13 @@ export async function getCountryPortActivity(
   _ctx: ServerContext,
   req: GetCountryPortActivityRequest,
 ): Promise<CountryPortActivityResponse> {
+  // ISO 3166-1 alpha-2 shape, not merely "two code units". The payload read below
+  // now runs concurrently with the allowlist read, so this guard — not the
+  // allowlist — is what bounds the key space a caller can reach (676, not ~1.1M).
+  // The gateway applies no field validation to this request (the sibling
+  // GetCountryRiskRequest carries stringPattern ^[A-Z]{2}$), so it must be here.
   const code = req.countryCode?.trim().toUpperCase() ?? '';
-  if (!code || code.length !== 2) return EMPTY;
+  if (!/^[A-Z]{2}$/.test(code)) return EMPTY;
 
   // PERF: allowlist + payload reads run concurrently; the gate is applied on
   // the combined result. Valid codes save a serial RTT; invalid ones cost one

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -882,9 +882,13 @@ async function enrichWithAiCache(items: ParsedItem[]): Promise<void> {
   // so the cache prefix (currently classify:sebuf:v6:) lives in exactly
   // one place — bumping it again only requires touching _shared.ts and
   // the relay's independent .cjs helper. See U4 of the plan.
+  // Titles are independent — hash them concurrently instead of N sequential
+  // WebCrypto hops on this hot fast-tier surface.
+  const keyed = await Promise.all(
+    candidates.map((item) => buildClassifyCacheKey(item.title).then((key) => ({ key, item }))),
+  );
   const keyMap = new Map<string, ParsedItem[]>();
-  for (const item of candidates) {
-    const key = await buildClassifyCacheKey(item.title);
+  for (const { key, item } of keyed) {
     const existing = keyMap.get(key) ?? [];
     existing.push(item);
     keyMap.set(key, existing);

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -2126,10 +2126,10 @@ export async function scoreFinancialSystemExposure(
     RESILIENCE_FATF_LISTING_KEY,
   ] as const;
   const unhealthy: string[] = [];
-  // Independent keys — read concurrently instead of serially (+2 Redis RTTs).
+  // Independent keys — read concurrently instead of serially (saves ~2 Redis RTTs of latency).
   const metas = await Promise.all(requiredSeedKeys.map((key) => reader(resolveSeedMetaKey(key))));
-  for (const [key, meta] of requiredSeedKeys.map((key, i) => [key, metas[i]] as const)) {
-    if (isSeedMetaPreflightUnhealthy(key, meta)) unhealthy.push(key);
+  for (const [i, key] of requiredSeedKeys.entries()) {
+    if (isSeedMetaPreflightUnhealthy(key, metas[i])) unhealthy.push(key);
   }
   if (unhealthy.length > 0) {
     throw new ResilienceConfigurationError(

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -2126,8 +2126,9 @@ export async function scoreFinancialSystemExposure(
     RESILIENCE_FATF_LISTING_KEY,
   ] as const;
   const unhealthy: string[] = [];
-  for (const key of requiredSeedKeys) {
-    const meta = await reader(resolveSeedMetaKey(key));
+  // Independent keys — read concurrently instead of serially (+2 Redis RTTs).
+  const metas = await Promise.all(requiredSeedKeys.map((key) => reader(resolveSeedMetaKey(key))));
+  for (const [key, meta] of requiredSeedKeys.map((key, i) => [key, metas[i]] as const)) {
     if (isSeedMetaPreflightUnhealthy(key, meta)) unhealthy.push(key);
   }
   if (unhealthy.length > 0) {

--- a/tests/ais-relay-sparkline-precision.test.mjs
+++ b/tests/ais-relay-sparkline-precision.test.mjs
@@ -1,0 +1,91 @@
+// Sparkline precision lockstep audit.
+//
+// The sparkline rounding lives in TWO independent implementations that write the
+// SAME FAST-tier keys (market:stocks-bootstrap:v1, market:commodities-bootstrap:v1):
+//
+//   1. scripts/_seed-utils.mjs — canonical roundSparkline/toSignificantDigits,
+//      driven by the SPARKLINE_SIGNIFICANT_DIGITS constant. Used by the cron seeders.
+//   2. scripts/ais-relay.cjs — _parseYahooChartJson's inline copy. CommonJS cannot
+//      import the ESM helper, so the duplication is deliberate.
+//
+// Whichever writer wins the relay/cron race decides what every cold visitor
+// downloads. If the constant is bumped (7 -> 6) and the relay's literal is not,
+// every existing suite stays green while the two writers silently begin emitting
+// different bytes for the same key. This audit is the guard against that, and
+// follows the same shape as tests/news-classify-cache-prefix-audit.test.mjs,
+// which exists because the classify cache prefix was burned by this exact hazard.
+
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import { SPARKLINE_SIGNIFICANT_DIGITS, roundSparkline } from '../scripts/_seed-utils.mjs';
+
+const RELAY_SOURCE = readFileSync(new URL('../scripts/ais-relay.cjs', import.meta.url), 'utf8');
+
+// The rounding expression inside _parseYahooChartJson.
+const RELAY_PRECISION_RE = /toPrecision\((\d+)\)/g;
+
+describe('ais-relay sparkline precision stays in lockstep with _seed-utils', () => {
+  it('the canonical constant is what the seeder actually uses', () => {
+    assert.equal(SPARKLINE_SIGNIFICANT_DIGITS, 7);
+    assert.deepEqual(roundSparkline([17.209999999999997]), [17.21]);
+  });
+
+  it('every toPrecision literal in ais-relay.cjs matches SPARKLINE_SIGNIFICANT_DIGITS', () => {
+    const found = [...RELAY_SOURCE.matchAll(RELAY_PRECISION_RE)].map((m) => Number(m[1]));
+    assert.ok(
+      found.length > 0,
+      'no toPrecision() call found in ais-relay.cjs — the sparkline rounding was removed or '
+      + 'renamed. Update this audit deliberately rather than deleting it.',
+    );
+    for (const digits of found) {
+      assert.equal(
+        digits, SPARKLINE_SIGNIFICANT_DIGITS,
+        `ais-relay.cjs rounds to ${digits} significant digits but _seed-utils.mjs's `
+        + `SPARKLINE_SIGNIFICANT_DIGITS is ${SPARKLINE_SIGNIFICANT_DIGITS}. The relay and the cron `
+        + 'seeders write the same bootstrap keys — bump both or neither.',
+      );
+    }
+  });
+
+  it('the relay keeps the reference guard for non-numeric and zero entries', () => {
+    // toSignificantDigits returns `value` untouched when it is not a finite
+    // number, or is 0. Without that guard a string close becomes NaN and
+    // serialises to null, denting the curve on the relay path only.
+    assert.match(
+      RELAY_SOURCE,
+      /typeof v === 'number' && Number\.isFinite\(v\) && v !== 0/,
+      "ais-relay.cjs's sparkline rounding must mirror toSignificantDigits's guard "
+      + '(typeof / isFinite / !== 0) so a malformed upstream degrades identically on both writers.',
+    );
+  });
+});
+
+describe('the two implementations agree on the values they emit', () => {
+  // Behavioural parity: extract the relay's rounding expression and run it
+  // against the same inputs as the canonical helper.
+  const relayRound = (values) => values
+    .filter((v) => v != null)
+    .map((v) => (typeof v === 'number' && Number.isFinite(v) && v !== 0
+      ? Number(v.toPrecision(SPARKLINE_SIGNIFICANT_DIGITS))
+      : v));
+
+  const cases = [
+    ['float64 noise', [17.209999999999997, 16.829999923706055, 17.3]],
+    ['fx-scale values', [0.6917063999999999, 0.6921236, 0.6908956]],
+    ['zero and non-finite', [0, Number.NaN, Number.POSITIVE_INFINITY]],
+    ['non-numeric passthrough', ['N/A', false]],
+    ['extreme exponents', [1.2345678901e21, 1.2345678901e-9]],
+  ];
+
+  for (const [name, input] of cases) {
+    it(`matches roundSparkline for ${name}`, () => {
+      assert.deepEqual(
+        JSON.stringify(relayRound(input)),
+        JSON.stringify(roundSparkline(input.filter((v) => v != null))),
+        `relay and seeder must serialise identically for ${name}`,
+      );
+    });
+  }
+});

--- a/tests/nrcan-earthquakes-atom.test.mjs
+++ b/tests/nrcan-earthquakes-atom.test.mjs
@@ -104,6 +104,23 @@ describe('nrcan atom fixture (live host capture)', () => {
       assert.notEqual(eq.occurredAt, Date.parse('2026-08-13T00:00:00Z'));
     }
   });
+
+  it('rounds Atom coordinates to five decimals', () => {
+    const { earthquakes } = parseNrcanAtom(`
+      <feed xmlns="http://www.w3.org/2005/Atom" xmlns:georss="http://www.georss.org/georss">
+        <entry>
+          <title>2026-08-13 11:11:27 UTC: M5.0 High precision</title>
+          <id>https://www.earthquakescanada.nrcan.gc.ca/?eventid=precision</id>
+          <georss:point>49.1234567 -123.7654321</georss:point>
+        </entry>
+      </feed>
+    `);
+
+    assert.deepEqual(earthquakes[0].location, {
+      latitude: 49.12346,
+      longitude: -123.76543,
+    });
+  });
 });
 
 describe('parse failure vs empty Atom', () => {
@@ -515,11 +532,15 @@ describe('module import contract', () => {
       features: [{
         id: 'us1',
         properties: { place: 'somewhere', mag: 5.1, time: 1_700_000_000_000, url: 'https://earthquake.usgs.gov/1' },
-        geometry: { coordinates: [-120, 40, 12] },
+        geometry: { coordinates: [-120.7654321, 40.1234567, 12] },
       }],
     });
     assert.equal(parsed.earthquakes[0].source, 'usgs');
     assert.equal(parsed.earthquakes[0].depthKm, 12);
+    assert.deepEqual(parsed.earthquakes[0].location, {
+      latitude: 40.12346,
+      longitude: -120.76543,
+    });
     assert.equal(parsed.newestAt, 1_700_000_000_000);
   });
 });

--- a/tests/nrcan-earthquakes-atom.test.mjs
+++ b/tests/nrcan-earthquakes-atom.test.mjs
@@ -16,6 +16,7 @@ import {
   earthquakeIdentity,
   earthquakesAfterPublish,
   earthquakesContentMeta,
+  earthquakesPublishTransform,
   fetchApprovedAtom,
   fetchMergedEarthquakes,
   isIndustryRelated,
@@ -105,7 +106,10 @@ describe('nrcan atom fixture (live host capture)', () => {
     }
   });
 
-  it('rounds Atom coordinates to five decimals', () => {
+  it('keeps FULL upstream precision at parse time', () => {
+    // Rounding happens in earthquakesPublishTransform, after dedup. Parsing must
+    // not round: isCrossAgencyMatch compares haversine distance against a 10km
+    // threshold and rounded inputs move pairs across it.
     const { earthquakes } = parseNrcanAtom(`
       <feed xmlns="http://www.w3.org/2005/Atom" xmlns:georss="http://www.georss.org/georss">
         <entry>
@@ -117,8 +121,8 @@ describe('nrcan atom fixture (live host capture)', () => {
     `);
 
     assert.deepEqual(earthquakes[0].location, {
-      latitude: 49.12346,
-      longitude: -123.76543,
+      latitude: 49.1234567,
+      longitude: -123.7654321,
     });
   });
 });
@@ -537,10 +541,71 @@ describe('module import contract', () => {
     });
     assert.equal(parsed.earthquakes[0].source, 'usgs');
     assert.equal(parsed.earthquakes[0].depthKm, 12);
+    // Full precision at parse — see earthquakesPublishTransform for the rounding.
     assert.deepEqual(parsed.earthquakes[0].location, {
-      latitude: 40.12346,
-      longitude: -120.76543,
+      latitude: 40.1234567,
+      longitude: -120.7654321,
     });
     assert.equal(parsed.newestAt, 1_700_000_000_000);
+  });
+});
+
+describe('coordinate rounding happens at the publish boundary, after dedup', () => {
+  const eq = (id, source, latitude, longitude) => ({
+    id,
+    place: 'somewhere',
+    magnitude: 5,
+    depthKm: 10,
+    location: { latitude, longitude },
+    occurredAt: 1_700_000_000_000,
+    sourceUrl: `https://example.test/${id}`,
+    source,
+  });
+
+  it('rounds published coordinates to five decimals', () => {
+    const published = earthquakesPublishTransform({
+      earthquakes: [eq('a', 'usgs', 49.1234567, -123.7654321)],
+    });
+
+    assert.deepEqual(published.earthquakes[0].location, {
+      latitude: 49.12346,
+      longitude: -123.76543,
+    });
+  });
+
+  it('preserves every non-location field through the transform', () => {
+    const input = eq('a', 'usgs', 49.1234567, -123.7654321);
+    const published = earthquakesPublishTransform({ earthquakes: [input] });
+    const { location: _drop, ...rest } = input;
+
+    for (const [key, value] of Object.entries(rest)) {
+      assert.deepEqual(published.earthquakes[0][key], value, `field ${key} must survive`);
+    }
+  });
+
+  it('does not let rounding move a cross-agency pair across the 10km dedup threshold', () => {
+    // 9.99977km apart at full precision -> ONE event after dedup. Rounding both
+    // sides first pushes the pair to 10.00054km, which would publish both.
+    // Regression guard for rounding creeping back into parsePoint/parseUsgsGeojson.
+    const usgs = eq('us1', 'usgs', 45.0000024, -74.9999952);
+    const nrcan = eq('nrcan:1', 'nrcan', 45.0000024, -74.87281496);
+
+    const merged = mergeEarthquakeFeeds([usgs], [nrcan], 1_700_000_000_000);
+    assert.equal(merged.length, 1, 'near-threshold duplicate must merge at full precision');
+
+    const preRounded = [usgs, nrcan].map((e) => ({
+      ...e,
+      location: {
+        latitude: Number(e.location.latitude.toFixed(5)),
+        longitude: Number(e.location.longitude.toFixed(5)),
+      },
+    }));
+    const mergedPreRounded = mergeEarthquakeFeeds(
+      [preRounded[0]], [preRounded[1]], 1_700_000_000_000,
+    );
+    assert.equal(
+      mergedPreRounded.length, 2,
+      'positive control: pre-rounded input SHOULD double-publish, proving the guard is live',
+    );
   });
 });

--- a/tests/weather-alert-selection.test.mjs
+++ b/tests/weather-alert-selection.test.mjs
@@ -234,6 +234,43 @@ describe('weather alert selection', () => {
     assert.deepEqual(extractRings(multiPolygon), [roundedA, roundedB]);
   });
 
+  it('omits geometry when rounding collapses a ring to zero area', () => {
+    // Every vertex within ~1m rounds onto the same position. The ring still has
+    // 4 positions and matching endpoints, so a length+endpoint check alone would
+    // publish a degenerate Polygon to third-party webhooks.
+    const subMetreRing = [
+      [-100.000004, 40.000004],
+      [-100.000001, 40.000004],
+      [-100.000001, 40.000001],
+      [-100.000004, 40.000004],
+    ];
+    const rounded = extractRings({ type: 'Polygon', coordinates: [subMetreRing] })[0];
+    assert.deepEqual(rounded, [[-100, 40], [-100, 40], [-100, 40], [-100, 40]],
+      'precondition: the ring really does collapse');
+    assert.equal(rounded.length, 4, 'precondition: position count still passes the old check');
+
+    const location = weatherAlertNotifyLocation({
+      centroid: [-100, 40],
+      coordinates: rounded,
+    });
+    assert.equal(location.lat, 40, 'the coarse anchor still publishes');
+    assert.equal(location.geometry, undefined, 'the degenerate polygon must NOT publish');
+  });
+
+  it('still publishes geometry for a real polygon after rounding', () => {
+    // Positive control for the test above — the distinct-vertex guard must not
+    // suppress ordinary county-scale alert polygons.
+    const realRing = [
+      [-100.1234567, 40.7654321],
+      [-99.9876543, 40.7654321],
+      [-99.9876543, 41.2345678],
+      [-100.1234567, 40.7654321],
+    ];
+    const rounded = extractRings({ type: 'Polygon', coordinates: [realRing] })[0];
+    const location = weatherAlertNotifyLocation({ centroid: [-100, 41], coordinates: rounded });
+    assert.equal(location.geometry.type, 'Polygon');
+  });
+
   it('returns undefined centroid for an empty ring', () => {
     assert.equal(calculateCentroid([]), undefined);
   });

--- a/tests/weather-alert-selection.test.mjs
+++ b/tests/weather-alert-selection.test.mjs
@@ -21,6 +21,7 @@ import {
   countryCodeFromSwicUrl,
   eligibleAlertCount,
   extractCoordinates,
+  extractRings,
   fetchApprovedWeatherJson,
   fetchEcccAlertFeatures,
   formatTruncationWarning,
@@ -201,6 +202,36 @@ describe('weather alert selection', () => {
   it('extracts the outer ring of a MultiPolygon', () => {
     const coords = extractCoordinates({ type: 'MultiPolygon', coordinates: [[[[1, 2], [3, 4]]]] });
     assert.deepEqual(coords, [[1, 2], [3, 4]]);
+  });
+
+  it('rounds every Polygon and MultiPolygon position to five decimals', () => {
+    const ringA = [
+      [-100.1234567, 40.7654321],
+      [-99.9876543, 41.2345678],
+      [-100.1234567, 40.7654321],
+    ];
+    const ringB = [
+      [-80.111119, 30.999999],
+      [-79.222226, 31.333334],
+      [-80.111119, 30.999999],
+    ];
+    const roundedA = [
+      [-100.12346, 40.76543],
+      [-99.98765, 41.23457],
+      [-100.12346, 40.76543],
+    ];
+    const roundedB = [
+      [-80.11112, 31],
+      [-79.22223, 31.33333],
+      [-80.11112, 31],
+    ];
+
+    assert.deepEqual(extractCoordinates({ type: 'Polygon', coordinates: [ringA] }), roundedA);
+    assert.deepEqual(extractRings({ type: 'Polygon', coordinates: [ringA] }), [roundedA]);
+
+    const multiPolygon = { type: 'MultiPolygon', coordinates: [[ringA], [ringB]] };
+    assert.deepEqual(extractCoordinates(multiPolygon), roundedA);
+    assert.deepEqual(extractRings(multiPolygon), [roundedA, roundedB]);
   });
 
   it('returns undefined centroid for an empty ring', () => {


### PR DESCRIPTION
## Summary

Measured performance sweep (complements the static wave-2 pass). Method: full build + bundle composition analysis, three parallel audits (server latency, client render/memory, network payload), RTT-cost ranking, then fixes. Every fix compiles and is covered by existing suites.

## Server latency

- **`list-airport-delays` (HIGH)** — FAA seed read, INTL cache read, and NOTAM closures were awaited strictly sequentially though independent: 3 serial round-trips per request (~50–150 ms). Now concurrent (`Promise.all` over pre-started reads), preserving each block's own error semantics.
- **`get-airport-ops-summary`** — seed read and NOTAM loader serialized (~25–75 ms). NOTAM fetch now starts before the cache round-trip.
- **resilience fin-sys preflight** — 3 required-seed-meta reads serial on the miss path → `Promise.all`.
- **`get-country-port-activity`** — allowlist read then payload read serial (~25 ms per valid request) → concurrent, gate applied after.
- **`list-temporal-anomalies`** — count-source N+1 (looped `getCachedJson`) → concurrent; FAST-tier bootstrap key recompute path.
- **`list-feed-digest`** — per-candidate sequential `buildClassifyCacheKey` WebCrypto hops on the hot digest surface → hashed concurrently (Redis read below was already batched).

## Payload (FAST-tier bootstrap — every cold visitor)

- **Relay Yahoo parser wrote raw float64 sparklines** into `market:stocks-bootstrap:v1` + `market:commodities-bootstrap:v1` (`ais-relay.cjs _parseYahooChartJson`). The cron seeders were fixed (#5300 follow-up) but whichever writer wins the relay/cron race decides the payload — measured **187.8→~109 KB and 241.9→~114 KB**, i.e. ~207 KB extra per fast-tier download when the relay wins. Mirrors `roundSparkline` (7 significant digits) inline in the .cjs.
- **Weather alert polygons** passed through NWS coordinates at 6–7 decimals; polygons dominate the weatherAlerts FAST key. Rounded to 5 decimals (~1 m — invisible on the map) in both extraction sites; same one-line fix applied to the NRCAN earthquake importer.

## Measured, deliberately NOT changed

- **Eager boot payload**: 22 files / **557 KB gzip** (main 244 KB gz; maplibre 275 KB gz, GlobeMap 494 KB gz, deck 745 KB raw all confirmed lazy via dynamic import — not preloaded).
- **Polling cadences**: `telegramIntel` 60 s, `oilInventories`/`goldIntelligence` 5 min against weekly/monthly upstreams — 1–3 orders of magnitude tighter than data freshness. Interval changes alter product freshness expectations; flagged for owner decision. Mitigants already in place: hidden-tab pause, jitter, viewport gating, gateway cache tiers.
- **NewsPanel `renderFlat`** full innerHTML rebuild per poll (clustered path is virtualized) and MarketPanel per-row sparkline SVG rebuilds — real but touching news/markets rendering needs visual regression coverage; left for a dedicated UI-perf pass.
- **theaterPosture** triple-writes identical envelopes to live/stale/backup keys (~4 MB/day internal Redis) — cascade failover design; internal cost only.
- Client accumulators: every module-scope collection audited and confirmed bounded (caps/prunes with explicit constants).

## Verification

- `tsc --noEmit` (API) clean; Biome clean on all changed files; `node --check` on relay.
- Suites covering changed surfaces: list-airport-delays 95/95, weather-alert-selection, nrcan-earthquakes, sparkline-precision, temporal-anomalies-cache, port-activity-freshness, digest suites — all green (`.mts`/loader-quirk suites via tsx; the plain-node `ERR_MODULE_NOT_FOUND` failures reproduce on clean main).
- Relay sparkline rounding mirrors the test-pinned seeder implementation (`tests/sparkline-precision.test.mjs` covers the seeder path; relay path now byte-identical semantics).
