### PR TITLE
docs(sentry): correct the auth-drift capture's false escalation claim

### DIFF
--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -233,8 +233,16 @@ export default async function handler(
       // client retry recovers cleanly. Keeping the capture at error
       // drowned real bugs in the dashboard while delivering no operational
       // signal beyond "drift happened" (already evident from the warning
-      // bucket). A genuine systemic drift incident would still surface
-      // because volume would escalate and reopen the archived issue.
+      // bucket). A genuine systemic drift incident surfaces only because the
+      // QK bucket is archived `until_escalating` — Sentry's forecast reopens
+      // it when volume departs baseline. That mode is load-bearing for this
+      // downgrade, not incidental: QK sat on `archived_forever` (which opts
+      // OUT of escalation detection) from 2026-05 and absorbed a 13.6x ramp
+      // — 8 ev/wk to 109 ev/wk across 344 users, peaking the week of
+      // 2026-07-20 — with no reopen and no notification. Nobody diagnosed
+      // that spike; it self-resolved and its root cause is still unknown.
+      // Re-archiving as anything that cannot reopen silently deletes the
+      // only escalation path this `warning` level leaves.
       if (kind === 'UNAUTHENTICATED') {
         if (session.acceptedWithinClockTolerance) {
           console.warn(


### PR DESCRIPTION
## Summary

The Convex auth-drift capture in `api/user-prefs.ts` runs at `level: 'warning'` instead of `error`. That downgrade was justified in-comment by a guarantee that did not hold: *"A genuine systemic drift incident would still surface because volume would escalate and reopen the archived issue."*

`WORLDMONITOR-QK` was archived **`archived_forever`**, which opts out of Sentry's escalation detection entirely. No volume could reopen it. The downgrade's only remaining escalation path did not exist, and the comment asserted otherwise — so anyone reasoning about alert coverage from this code would have concluded the bucket was watched when it was silent.

It had already failed in production. QK absorbed a **13.6x ramp** with no reopen and no notification:

| week starting | events |
|---|---:|
| 2026-05-25 | 8 |
| 2026-06-15 | 26 |
| 2026-07-06 | 52 |
| **2026-07-20** | **109** (peak, silent) |
| 2026-08-03 | 9 |
| 2026-08-17 | 5 |

362 events / **344 distinct users** lifetime, max 3 events per user — a broad population taking 401s on `/api/user-prefs`, not one user in a retry loop.

**The operative fix is not in this diff.** QK has been re-archived `archived_until_escalating` in Sentry (verified by read-back — see the concept note below for why the write needs care). This PR is the repo-side half: the comment now records what the archive actually does, so the mute mode reads as load-bearing for the level downgrade rather than an incidental detail. The POST branch defers to this comment and needed no change; `grep` confirms the false claim appears nowhere else.

The spike self-resolved and its root cause is still unknown — the decay window rules out the PR that timing would suggest. Tracked separately.

Related: #7092, #7093

## Validation

`npm run typecheck:api` passes. No behavior change — this commit edits only a comment block, so there is nothing runnable to exercise beyond the type gate.

## New concepts

**When you downgrade an alert's severity, the mute mode becomes the escalation path — and must be verified, not assumed.**

Dropping a capture from `error` to `warning` is a deliberate trade: you accept that nobody looks at it day to day, in exchange for a promise that a real incident will still break through. That promise has to be carried by something. Here it was carried by the issue's archive mode, which lives in a system outside the repo — so the code and the guarantee could drift apart silently, and did.

Sentry's archive modes are not interchangeable, and the difference is invisible in the field most audits read:

| substatus | `statusDetails` | reopens on escalation? |
|---|---|---|
| `archived_forever` | `{}` | **no — opts out** |
| `archived_until_escalating` | `{}` | yes (forecast-based) |
| `archived_until_condition_met` | `{ignoreCount, ignoreWindow}` | yes (threshold) |

Two of the three report an empty `statusDetails`, so an audit keyed on "is `statusDetails` non-empty" scores a permanent mute as clean. The mode lives in **`substatus`**. Reading the wrong field is what let QK ramp 13.6x unnoticed.

A second trap when fixing one: changing `substatus` requires a real status *transition*. Writing the target state directly onto an already-archived issue returns success and does nothing.

```bash
# Returns HTTP 200 and silently no-ops — substatus is unchanged.
PUT /issues/<id>/  {"status":"ignored","substatus":"archived_until_escalating"}

# Works: transition out, then back in, then read substatus back to confirm.
PUT /issues/<id>/  {"status":"unresolved"}
PUT /issues/<id>/  {"status":"ignored","substatus":"archived_until_escalating"}
GET /issues/<id>/  -> verify substatus, because the write's own 200 proves nothing
```

The boundary: this applies when severity is downgraded but the signal still matters. A capture that is genuinely worthless should be deleted at the source or filtered before send — leaving it muted-but-alive means you are still paying to store it while relying on an escalation path you now have to keep correct.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
