### PR TITLE
fix: replace 'as any' on Convex mutation names with typed api.* handles

### DIFF
--- a/server/worldmonitor/leads/v1/register-interest.ts
+++ b/server/worldmonitor/leads/v1/register-interest.ts
@@ -5,6 +5,7 @@
  */
 
 import { ConvexHttpClient } from 'convex/browser';
+import { api } from '../../../../convex/_generated/api';
 import type {
   ServerContext,
   RegisterInterestRequest,
@@ -339,7 +340,7 @@ export async function registerInterest(
   }
 
   const client = new ConvexHttpClient(convexUrl);
-  const result = (await client.mutation('registerInterest:register' as any, {
+  const result = (await client.mutation(api.registerInterest.register, {
     email,
     source: safeSource,
     appVersion: safeAppVersion,

--- a/server/worldmonitor/leads/v1/submit-contact.ts
+++ b/server/worldmonitor/leads/v1/submit-contact.ts
@@ -6,6 +6,7 @@
 
 import { ConvexHttpClient } from 'convex/browser';
 import { ConvexError } from 'convex/values';
+import { api } from '../../../../convex/_generated/api';
 import type {
   ServerContext,
   SubmitContactRequest,
@@ -180,7 +181,7 @@ export async function submitContact(
 
   const client = new ConvexHttpClient(convexUrl);
   try {
-    await client.mutation('contactMessages:submit' as any, {
+    await client.mutation(api.contactMessages.submit, {
       name: safeName,
       email: email.trim(),
       organization: safeOrg,


### PR DESCRIPTION
## Summary
- `server/worldmonitor/leads/v1/submit-contact.ts` and `register-interest.ts` called Convex mutations by string name with an `as any` cast (`'contactMessages:submit' as any`, `'registerInterest:register' as any`), bypassing Convex's generated types entirely.
- A renamed mutation would fail silently at runtime instead of being caught at compile time.
- Replaced both with the typed handles from the generated API: `api.contactMessages.submit` and `api.registerInterest.register`.

Fixes #3253.

## Test plan
- [x] `tsc --noEmit` — zero errors across the full codebase (ran on a fresh `npm install`, verified `node_modules/.bin/tsc` was actually present before trusting the result).
- [x] Confirmed both exported mutation names still match: `export const submit = mutation({...})` in `convex/contactMessages.ts`, `export const register = mutation({...})` in `convex/registerInterest.ts`.
- Scope kept minimal per the issue — only the `as any` on the mutation name was touched; the pre-existing `as ConvexRegisterResult` result-type cast in `register-interest.ts` was left alone since it's outside what #3253 asked for.
