### PR TITLE
test(china-policy): interleave size measurements to fix concurrency flake

### DIFF
--- a/tests/china-policy-events.test.mts
+++ b/tests/china-policy-events.test.mts
@@ -192,17 +192,23 @@ describe('China official policy adapters (#5576)', () => {
     // `test:data` runs this file at concurrency 16. A discarded warmup plus a
     // 12x gate still fail quadratic (~16x) and ReDoS, but tolerate the ~10x
     // linear+GC ratios that 16-way CI has produced.
-    const timeOnce = (repeat: number): number => {
+    // Inputs are built once per size, outside every timed call: allocating
+    // them is linear bookkeeping, not parser work, and re-allocating on each
+    // attempt would add GC noise on top of the measurement — the exact
+    // allocation-driven noise this guard is designed to filter out.
+    const buildFixtures = (repeat: number) => {
       const openers = '<div class="content">'.repeat(repeat);
       const closers = '</div>'.repeat(repeat);
-      const nested = `<body>${openers}正文内容足够长且必须保留${closers}</body>`;
-      const unbalanced = `${'<div>'.repeat(repeat)}${'</span>'.repeat(repeat)}`;
-      const script = '<script '.repeat(repeat);
-      const anchors = '<a >'.repeat(repeat);
+      return {
+        nested: `<body>${openers}正文内容足够长且必须保留${closers}</body>`,
+        unbalanced: `${'<div>'.repeat(repeat)}${'</span>'.repeat(repeat)}`,
+        script: '<script '.repeat(repeat),
+        anchors: '<a >'.repeat(repeat),
+      };
+    };
 
-      // Inputs are built once, outside the timed region: allocating them is
-      // linear bookkeeping, not parser work, and including it would flatter a
-      // superlinear parser at large sizes.
+    const timeOnce = (fixtures: ReturnType<typeof buildFixtures>): number => {
+      const { nested, unbalanced, script, anchors } = fixtures;
       const startedAt = performance.now();
       __testing__.stripHtml(script);
       parseAgencyListing('CAC', anchors);
@@ -211,9 +217,12 @@ describe('China official policy adapters (#5576)', () => {
       return performance.now() - startedAt;
     };
 
+    const baseFixtures = buildFixtures(4_000);
+    const quadrupledFixtures = buildFixtures(16_000);
+
     // Discarded warmup, one per size.
-    timeOnce(4_000);
-    timeOnce(16_000);
+    timeOnce(baseFixtures);
+    timeOnce(quadrupledFixtures);
 
     // Interleaved, not sequential: timing all of base then all of quadrupled
     // concentrates any transient runner stall into whichever series happens
@@ -223,8 +232,8 @@ describe('China official policy adapters (#5576)', () => {
     let base = Number.POSITIVE_INFINITY;
     let quadrupled = Number.POSITIVE_INFINITY;
     for (let attempt = 0; attempt < 5; attempt += 1) {
-      base = Math.min(base, timeOnce(4_000));
-      quadrupled = Math.min(quadrupled, timeOnce(16_000));
+      base = Math.min(base, timeOnce(baseFixtures));
+      quadrupled = Math.min(quadrupled, timeOnce(quadrupledFixtures));
     }
     const ratio = quadrupled / base;
 

--- a/tests/china-policy-events.test.mts
+++ b/tests/china-policy-events.test.mts
@@ -192,7 +192,7 @@ describe('China official policy adapters (#5576)', () => {
     // `test:data` runs this file at concurrency 16. A discarded warmup plus a
     // 12x gate still fail quadratic (~16x) and ReDoS, but tolerate the ~10x
     // linear+GC ratios that 16-way CI has produced.
-    const timeAtSize = (repeat: number, attempts: number): number => {
+    const timeOnce = (repeat: number): number => {
       const openers = '<div class="content">'.repeat(repeat);
       const closers = '</div>'.repeat(repeat);
       const nested = `<body>${openers}正文内容足够长且必须保留${closers}</body>`;
@@ -203,22 +203,29 @@ describe('China official policy adapters (#5576)', () => {
       // Inputs are built once, outside the timed region: allocating them is
       // linear bookkeeping, not parser work, and including it would flatter a
       // superlinear parser at large sizes.
-      let best = Number.POSITIVE_INFINITY;
-      for (let attempt = 0; attempt < attempts; attempt += 1) {
-        const startedAt = performance.now();
-        __testing__.stripHtml(script);
-        parseAgencyListing('CAC', anchors);
-        parsePolicyDocumentHtml(nested);
-        parsePolicyDocumentHtml(unbalanced);
-        best = Math.min(best, performance.now() - startedAt);
-      }
-      return best;
+      const startedAt = performance.now();
+      __testing__.stripHtml(script);
+      parseAgencyListing('CAC', anchors);
+      parsePolicyDocumentHtml(nested);
+      parsePolicyDocumentHtml(unbalanced);
+      return performance.now() - startedAt;
     };
 
-    timeAtSize(4_000, 1);
-    timeAtSize(16_000, 1);
-    const base = timeAtSize(4_000, 5);
-    const quadrupled = timeAtSize(16_000, 5);
+    // Discarded warmup, one per size.
+    timeOnce(4_000);
+    timeOnce(16_000);
+
+    // Interleaved, not sequential: timing all of base then all of quadrupled
+    // concentrates any transient runner stall into whichever series happens
+    // to be running, which can push the ratio over the gate on a loaded box
+    // even though neither size is actually slow. Alternating means a stall
+    // lands on both series' running minimum instead of just one (#6985).
+    let base = Number.POSITIVE_INFINITY;
+    let quadrupled = Number.POSITIVE_INFINITY;
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      base = Math.min(base, timeOnce(4_000));
+      quadrupled = Math.min(quadrupled, timeOnce(16_000));
+    }
     const ratio = quadrupled / base;
 
     assert.ok(


### PR DESCRIPTION
## Summary
- `parses hostile markup without superlinear rescans` measured all 5 attempts at the base (4,000) size, then all 5 attempts at the quadrupled (16,000) size, sequentially.
- Under `test:data`'s concurrency-16 runner, a transient scheduler stall lands entirely inside whichever series happens to be running at that moment, inflating the `quadrupled/base` ratio past the 12x gate even when neither size is actually slow — a flake, not a real regression.
- Extracted the per-call timing into `timeOnce(repeat)` and interleaved the attempts loop (`base` then `quadrupled`, repeated) so a stall's cost lands on both series' running minimum instead of being concentrated in one, per the issue's proposed fix.

Fixes #6985.

## Test plan
- [x] `tsc --noEmit` — zero errors.
- [x] `tsx --test tests/china-policy-events.test.mts` in isolation — 26/26 pass, target test at 521ms.
- [x] Full `npm run test:data` (real concurrency-16, matching the flake's actual conditions) — target test still passes at 804ms, well under the `base*12+2` gate. The China-policy suites (`China official policy adapters`, `China policy taxonomy...`, `China policy event provenance...`, `China policy production registration`) all pass with no failures.
- Note: that same full run surfaces a large number of unrelated failures elsewhere in the suite (AIS websocket reconnect, GitHub Actions workflow coverage, Docker credential checks, docs-stats API inventory, etc.) — these appear to be pre-existing local-environment gaps (missing Redis/Convex/GitHub-token setup that CI provides), not caused by this change. Flagging for visibility rather than silently omitting it; happy to investigate further if that's actually in scope.
- Did not add the issue's optional third size (64k) — kept the PR to exactly what the acceptance criteria requires.
