### PR TITLE
fix(redis-rest): send a real 413 instead of destroying the socket on oversized bodies

### DIFF
--- a/docker/redis-rest-proxy.mjs
+++ b/docker/redis-rest-proxy.mjs
@@ -10,9 +10,10 @@
  *   POST /multi-exec                  → JSON body [["CMD1",...], ["CMD2",...]]
  *
  * Env:
- *   REDIS_URL  - Redis connection string (default: redis://redis:6379)
- *   SRH_TOKEN  - Bearer token for auth (default: none)
- *   PORT       - Listen port (default: 80)
+ *   REDIS_URL          - Redis connection string (default: redis://redis:6379)
+ *   SRH_TOKEN          - Bearer token for auth (default: none)
+ *   PORT               - Listen port (default: 80)
+ *   SRH_MAX_BODY_BYTES - Max request body size in bytes (default: 8 MB)
  */
 
 import http from 'node:http';
@@ -78,7 +79,16 @@ async function runCommand(args) {
   return client.sendCommand([cmd, ...cmdArgs.map(String)]);
 }
 
-const MAX_BODY_BYTES = 1024 * 1024; // 1 MB
+const MAX_BODY_BYTES = parseInt(process.env.SRH_MAX_BODY_BYTES, 10) || 8 * 1024 * 1024; // 8 MB
+
+// Distinguished from a generic Error so the handler below can reply with a
+// real 413 instead of the catch-all 500 path.
+class PayloadTooLargeError extends Error {
+  constructor() {
+    super('Request body too large');
+    this.name = 'PayloadTooLargeError';
+  }
+}
 
 async function readBody(req) {
   const chunks = [];
@@ -86,8 +96,13 @@ async function readBody(req) {
   for await (const chunk of req) {
     totalLength += chunk.length;
     if (totalLength > MAX_BODY_BYTES) {
-      req.destroy();
-      throw new Error('Request body too large');
+      // Don't req.destroy() here: that tears down the underlying socket
+      // before a response can be written, so the client sees a raw
+      // transport error (EPIPE / "other side closed") instead of an HTTP
+      // status. Just stop reading and let the handler send a real 413;
+      // Node closes the connection on its own once res.end() runs without
+      // the request body having been fully drained.
+      throw new PayloadTooLargeError();
     }
     chunks.push(chunk);
   }
@@ -197,6 +212,11 @@ const server = http.createServer(async (req, res) => {
     res.writeHead(404);
     res.end(JSON.stringify({ error: 'Not found' }));
   } catch (err) {
+    if (err instanceof PayloadTooLargeError) {
+      res.writeHead(413);
+      res.end(JSON.stringify({ error: err.message }));
+      return;
+    }
     res.writeHead(500);
     res.end(JSON.stringify({ error: err.message }));
   }

--- a/tests/redis-rest-proxy-body-limit.test.mjs
+++ b/tests/redis-rest-proxy-body-limit.test.mjs
@@ -1,0 +1,89 @@
+// Same constraint as redis-rest-proxy-url-masking.test.mjs: docker/redis-rest-proxy.mjs
+// connects to Redis and calls server.listen() as a top-level side effect on
+// import, so readBody can't be imported directly. Extract its real source
+// (plus the PayloadTooLargeError class and MAX_BODY_BYTES it closes over)
+// via regex and eval it standalone instead.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const proxySrc = readFileSync(resolve(here, '../docker/redis-rest-proxy.mjs'), 'utf8');
+
+const maxBodyLine = proxySrc.match(/const MAX_BODY_BYTES = [^\n]+/)?.[0];
+const errorClassSrc = proxySrc.match(/class PayloadTooLargeError[\s\S]*?\n\}/)?.[0];
+const readBodySrc = proxySrc.match(/async function readBody\([\s\S]*?\n\}/)?.[0];
+
+function buildReadBody(envOverride) {
+  const prev = process.env.SRH_MAX_BODY_BYTES;
+  if (envOverride === undefined) delete process.env.SRH_MAX_BODY_BYTES;
+  else process.env.SRH_MAX_BODY_BYTES = String(envOverride);
+  try {
+    // eslint-disable-next-line no-new-func
+    return new Function(
+      `${maxBodyLine}\n${errorClassSrc}\n${readBodySrc}\nreturn { readBody, PayloadTooLargeError, MAX_BODY_BYTES };`,
+    )();
+  } finally {
+    if (prev === undefined) delete process.env.SRH_MAX_BODY_BYTES;
+    else process.env.SRH_MAX_BODY_BYTES = prev;
+  }
+}
+
+function fakeReq(chunks, { onDestroy } = {}) {
+  return {
+    destroy: () => { onDestroy?.(); },
+    async *[Symbol.asyncIterator]() {
+      for (const chunk of chunks) yield Buffer.from(chunk);
+    },
+  };
+}
+
+describe('redis-rest-proxy body size limit (#7099)', () => {
+  it('all three extraction targets are defined in redis-rest-proxy.mjs', () => {
+    assert.ok(maxBodyLine, 'MAX_BODY_BYTES not found');
+    assert.ok(errorClassSrc, 'PayloadTooLargeError not found');
+    assert.ok(readBodySrc, 'readBody not found');
+  });
+
+  it('defaults MAX_BODY_BYTES to 8 MB when SRH_MAX_BODY_BYTES is unset', () => {
+    const { MAX_BODY_BYTES } = buildReadBody(undefined);
+    assert.equal(MAX_BODY_BYTES, 8 * 1024 * 1024);
+  });
+
+  it('honors SRH_MAX_BODY_BYTES when set', () => {
+    const { MAX_BODY_BYTES } = buildReadBody(2_000_000);
+    assert.equal(MAX_BODY_BYTES, 2_000_000);
+  });
+
+  it('resolves normally for a body under the limit', async () => {
+    const { readBody } = buildReadBody(1_000);
+    const result = await readBody(fakeReq(['hello ', 'world']));
+    assert.equal(result, 'hello world');
+  });
+
+  it('throws PayloadTooLargeError, not a generic Error, for an oversized body', async () => {
+    const { readBody, PayloadTooLargeError } = buildReadBody(10);
+    await assert.rejects(
+      readBody(fakeReq(['this is way more than ten bytes'])),
+      PayloadTooLargeError,
+    );
+  });
+
+  it('never calls req.destroy() on an oversized body (regression guard for #7099)', async () => {
+    const { readBody } = buildReadBody(10);
+    let destroyed = false;
+    await assert.rejects(
+      readBody(fakeReq(['this is way more than ten bytes'], { onDestroy: () => { destroyed = true; } })),
+    );
+    assert.equal(destroyed, false, 'readBody must not kill the socket before a response can be written');
+  });
+
+  it('the request handler replies 413 for PayloadTooLargeError instead of falling through to 500 (regression guard)', () => {
+    assert.match(
+      proxySrc,
+      /if \(err instanceof PayloadTooLargeError\)\s*\{\s*res\.writeHead\(413\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `readBody()` in `docker/redis-rest-proxy.mjs` called `req.destroy()` when a request body exceeded `MAX_BODY_BYTES` (1MB). Destroying the request tears down the underlying HTTP/1 socket before a response can be written, so the client sees a raw transport error (`fetch failed (cause: write EPIPE)` / `other side closed`) instead of an HTTP status — obscuring the actual disagreement and getting misdiagnosed as unrelated connectivity issues.
- The 1MB limit was also below the seeders' own ~5MB canonical payload cap (`capCanonicalPayload`), so legitimate `seed-fire-detections` traffic was rejected outright even before the socket-handling problem.

## Changes
- Raised the default limit to 8MB, configurable via `SRH_MAX_BODY_BYTES` (documented in the file's header comment).
- Replaced `req.destroy()` with a distinguishable `PayloadTooLargeError`; the request handler now replies `413` with a JSON error body instead of falling through to the generic 500 path.
- Added `tests/redis-rest-proxy-body-limit.test.mjs`, following the same regex-extraction pattern as the existing `redis-rest-proxy-url-masking.test.mjs` (this file connects to Redis and calls `server.listen()` as an import-time side effect, so it can't be imported directly in a unit test).

Fixes #7099.

## Test plan
- [x] `tsc --noEmit` — zero errors.
- [x] New unit tests (7 cases: default/configurable limit, normal body resolves, oversized body throws the distinguished error type, `req.destroy()` is never called, and a source-level regression guard that the handler actually wires `PayloadTooLargeError` to `413`) — all pass, alongside the existing `redis-rest-proxy-url-masking.test.mjs` (13/13 total).
- [x] Beyond the unit tests: wrote a standalone script that wraps the extracted `readBody`/`PayloadTooLargeError` logic in a real `http.Server` and sends an actual oversized `POST` over a real TCP socket. Confirmed the client now receives a clean `413` with a JSON body (`{"error":"Request body too large"}`) instead of a transport-level exception, and that a normal small request still returns `200`. This directly reproduces and disproves the exact client-visible symptom described in the issue.
