### PR TITLE
fix(canada): send Alberta 511 the api key the vendor now requires

### DIFF
--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -373,7 +373,8 @@
     "requiredEnv": [
       "UPSTASH_REDIS_REST_URL",
       "UPSTASH_REDIS_REST_TOKEN",
-      "MANITOBA_511_KEY"
+      "MANITOBA_511_KEY",
+      "ALBERTA_511_KEY"
     ],
     "watchPatterns": [
       "scripts/_511-rate-limit.mjs",

--- a/scripts/seed-provincial-511.mjs
+++ b/scripts/seed-provincial-511.mjs
@@ -6,9 +6,11 @@
 // Seeds Ontario 511 (events/alerts/roadconditions), Alberta 511 events and
 // alerts, and Manitoba 511 events and alerts. One process ticks all three
 // jurisdictions, so they clear on the same tick. Manitoba requires
-// MANITOBA_511_KEY via loadEnvFile; an unset key skips that jurisdiction,
-// preserves last-good without rewriting freshness, and lets fetchedAt age into
-// an actionable health failure. Do not add Canada loops to ais-relay.cjs.
+// MANITOBA_511_KEY and Alberta requires ALBERTA_511_KEY via loadEnvFile (Alberta
+// began enforcing keys 2026-08-19, answering an unkeyed GET with HTTP 400
+// "Invalid Key"); an unset key skips that jurisdiction, preserves last-good
+// without rewriting freshness, and lets fetchedAt age into an actionable health
+// failure. Do not add Canada loops to ais-relay.cjs.
 // Each fetch goes through acquire511Slot(hostname) inside the adapter
 // (511on.ca, 511.alberta.ca, and www.manitoba511.ca are separate 10/60 buckets).
 
@@ -48,6 +50,11 @@ function readManitoba511Key() {
   return typeof raw === 'string' && raw.trim() ? raw.trim() : '';
 }
 
+function readAlberta511Key() {
+  const raw = process.env.ALBERTA_511_KEY;
+  return typeof raw === 'string' && raw.trim() ? raw.trim() : '';
+}
+
 async function fetchOntario511() {
   const envelope = await fetchVendor511(ONTARIO_511, {
     userAgent: CHROME_UA,
@@ -66,9 +73,27 @@ async function fetchOntario511() {
 }
 
 async function fetchAlberta511() {
+  // 511.alberta.ca began enforcing api keys around 2026-08-19: an unkeyed GET
+  // now answers `HTTP 400 {"Message":"Invalid Key"}` on both resources. It reads
+  // like a malformed request rather than an auth failure, which is why the
+  // seeder kept "succeeding" — Ontario and Manitoba published while Alberta
+  // silently preserved last-good for 88 hours.
+  //
+  // Same contract as Manitoba: an unset key is NOT an outage. The jurisdiction
+  // is simply not configured, so it preserves last-good and stays quiet. A key
+  // that is present and REJECTED is a different thing and still fails loudly
+  // through the ordinary fetch path.
+  const key = readAlberta511Key();
+  if (!key) {
+    const err = new Error('Alberta 511: not configured (ALBERTA_511_KEY missing); keeping last-good');
+    err.notConfigured = true;
+    err.nonRetryable = true;
+    throw err;
+  }
   const envelope = await fetchVendor511(ALBERTA_511, {
     userAgent: CHROME_UA,
     staggerMs: STAGGER_MS,
+    key,
   });
   if (!isCompleteVendor511(envelope, ALBERTA_511)) {
     const failed = envelope.failedResources?.join(', ') || 'incomplete';
@@ -144,6 +169,7 @@ async function fetchProvincial511Tick() {
     _ontarioFailed: !ontario,
     _albertaFailed: !alberta,
     _manitobaFailed: !manitoba,
+    _albertaNotConfigured: Boolean(albertaErr?.notConfigured),
     _manitobaNotConfigured: Boolean(manitobaErr?.notConfigured),
   };
 }
@@ -167,6 +193,11 @@ async function preserveAlberta() {
 }
 
 async function publishAlbertaFromTick(data) {
+  if (data?._albertaNotConfigured) {
+    console.warn('  Alberta 511: not configured; preserving last-good while freshness metadata ages');
+    await preserveAlberta();
+    return;
+  }
   if (!data || data._albertaFailed) {
     console.warn('  Alberta 511: preserving last-good (fetch failed this tick)');
     await preserveAlberta();

--- a/tests/provincial-511.test.mjs
+++ b/tests/provincial-511.test.mjs
@@ -821,6 +821,81 @@ test('manitobaRoads publishes, so its cutover acknowledgement is gone and the pr
   assert.match(health, /manitobaRoads:\s+'infra:manitoba-511:v1'/);
 });
 
+// 511.alberta.ca began enforcing api keys around 2026-08-19, answering an
+// unkeyed GET with `HTTP 400 {"Message":"Invalid Key"}` on both resources. It
+// reads as a malformed request rather than an auth failure, and because
+// fetchProvincial511Tick only throws when ALL THREE jurisdictions fail, the
+// bundle kept reporting `status=OK records=400` while Alberta silently
+// preserved last-good for 88 hours.
+test('Alberta 511 sends its key on every resource', async () => {
+  const seen = [];
+  const fetchFn = async (url) => {
+    seen.push(String(url));
+    return jsonResponse([]);
+  };
+
+  await fetchVendor511(ALBERTA_511, { key: 'ab-test-key', fetchFn, staggerMs: 0 });
+
+  assert.equal(seen.length, ALBERTA_511.resources.length, 'every resource is requested');
+  for (const url of seen) {
+    assert.match(
+      url,
+      /[?&]key=ab-test-key(?:&|$)/,
+      `Alberta resource requested without its key: ${url.replace(/key=[^&]*/, 'key=REDACTED')}`,
+    );
+  }
+});
+
+// The negative half. Without this, passing `key: ''` (or dropping the option)
+// would still satisfy the assertion above by sending `key=` — which the vendor
+// rejects exactly like no key at all, and which would look configured.
+test('Alberta 511 sends no key parameter when none is configured', async () => {
+  const seen = [];
+  const fetchFn = async (url) => {
+    seen.push(String(url));
+    return jsonResponse([]);
+  };
+
+  await fetchVendor511(ALBERTA_511, { fetchFn, staggerMs: 0 });
+
+  assert.equal(seen.length, ALBERTA_511.resources.length);
+  for (const url of seen) {
+    assert.doesNotMatch(url, /[?&]key=/, `unconfigured Alberta must not send an empty key: ${url}`);
+  }
+});
+
+test('the seeder reads ALBERTA_511_KEY and treats an unset one as not-configured', () => {
+  // Mirrors the Manitoba contract deliberately: an unset key is NOT an outage,
+  // it is a jurisdiction nobody configured, so it preserves last-good and stays
+  // quiet. A key that is PRESENT and rejected still fails through the ordinary
+  // fetch path and ages into a real health failure.
+  const seeder = readFileSync(new URL('../scripts/seed-provincial-511.mjs', import.meta.url), 'utf8');
+  assert.match(seeder, /process\.env\.ALBERTA_511_KEY/);
+
+  const fetchAlberta = seeder.slice(
+    seeder.indexOf('async function fetchAlberta511'),
+    seeder.indexOf('async function fetchManitoba511'),
+  );
+  assert.match(fetchAlberta, /if \(!key\)/, 'an unset key short-circuits before the fetch');
+  assert.match(fetchAlberta, /notConfigured = true/);
+  assert.match(fetchAlberta, /key,/, 'the key is threaded into fetchVendor511');
+
+  // The publish path must distinguish not-configured from failed, or an unset
+  // key would log as a fetch failure and read like an outage.
+  const publishAlberta = seeder.slice(
+    seeder.indexOf('async function publishAlbertaFromTick'),
+    seeder.indexOf('async function publishManitobaEnvelope'),
+  );
+  assert.match(publishAlberta, /_albertaNotConfigured/);
+  assert.match(publishAlberta, /_albertaFailed/);
+});
+
+test('seeder and adapter never embed an Alberta credential', () => {
+  const seeder = readFileSync(new URL('../scripts/seed-provincial-511.mjs', import.meta.url), 'utf8');
+  assert.doesNotMatch(seeder, /ab-test-key/);
+  assert.doesNotMatch(ADAPTER_SOURCE, /ALBERTA_511_KEY\s*=\s*'[^']+'/);
+});
+
 test('seeder fixtures and adapter never embed a Manitoba credential', () => {
   const seeder = readFileSync(new URL('../scripts/seed-provincial-511.mjs', import.meta.url), 'utf8');
   assert.match(seeder, /process\.env\.MANITOBA_511_KEY/);

--- a/tests/seed-bundle-canada.test.mjs
+++ b/tests/seed-bundle-canada.test.mjs
@@ -250,8 +250,11 @@ test('is registered as an active service now that it is provisioned', () => {
   assert.ok(Array.isArray(entry.watchPatterns) && entry.watchPatterns.length > 0);
   assert.deepEqual(
     entry.requiredEnv,
-    ['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN', 'MANITOBA_511_KEY'],
-    'members publish through runSeed (Upstash REST pair); Manitoba 511 needs its Railway key',
+    ['UPSTASH_REDIS_REST_URL', 'UPSTASH_REDIS_REST_TOKEN', 'MANITOBA_511_KEY', 'ALBERTA_511_KEY'],
+    'members publish through runSeed (Upstash REST pair); Manitoba and Alberta 511 each '
+    + 'need their Railway key. Alberta was keyless until 2026-08-19, when the vendor began '
+    + 'answering an unkeyed GET with HTTP 400 "Invalid Key" and the jurisdiction went stale '
+    + 'for 88 hours while the bundle still reported OK.',
   );
 });
 


### PR DESCRIPTION
`511.alberta.ca` began enforcing api keys around 2026-08-19. Our unkeyed GET now fails on **both** resources:

```
GET https://511.alberta.ca/api/v2/get/event?format=json
HTTP 400 {"Message":"Invalid Key"}
```

**400, not 401/403** — so it reads as a malformed request rather than an auth failure. Ontario's identical keyless call still returns 200 with data, which made this look Alberta-specific rather than a contract change.

## Why it was silent for 88 hours

The seeder is partial-tolerant by design: `fetchProvincial511Tick` only throws when **all three** jurisdictions fail. So every tick published Ontario and Manitoba, preserved Alberta's last-good, and reported:

```
[Bundle:Canada] section=Provincial-511 status=OK durationMs=39120 records=400 state=OK
```

…while `albertaRoads` aged to **5,281 minutes** against a 45-minute budget. Health saw it; the bundle structurally could not. That tolerance is correct — it just means the bundle's `OK` is not evidence about any individual jurisdiction.

## The fix

`fetchVendor511` already supported `opts.key` and already redacts it from error messages — Alberta simply never passed one. It does now, reading `ALBERTA_511_KEY` exactly as Manitoba reads `MANITOBA_511_KEY`.

**An unset key is not treated as an outage.** That mirrors Manitoba deliberately, on the operator's call: an unconfigured jurisdiction means the system runs without that functionality, quietly, preserving last-good rather than alarming.

One distinction is kept inside that: a key that is **present and rejected** still fails through the ordinary fetch path into a real health failure. That is the exact shape that just cost 88 hours of silence, so it stays loud — "not configured" must not become a hiding place for "broken".

## Verified against the live vendor, before building on it

```
event   without key -> HTTP 400 {"Message": "Invalid Key"}
event   with key    -> HTTP 200, 286 records
alerts  without key -> HTTP 400 {"Message": "Invalid Key"}
alerts  with key    -> HTTP 200, 0 records (no active alerts)
```

Then end to end — running the seeder published **286 Alberta records** (191,567 bytes) with no `preserving last-good` warning, and production health went to **HEALTHY**, `albertaRoads` cleared, 280/284 OK.

## Tests

Behavioural where they can be. Two drive `fetchVendor511` through a stub transport and assert the key reaches the wire on every Alberta resource — plus the negative half: an unconfigured Alberta must send **no** `key=` parameter at all, because `key=` empty is rejected exactly like no key and would still look configured.

The seeder wiring is asserted by source inspection, matching the existing Manitoba tests, because the module cannot be imported without executing (`tests/provincial-511.test.mjs` pins that explicitly).

Mutation-checked: dropping `key,` from the `fetchVendor511` call fails `the key is threaded into fetchVendor511`.

**449 tests pass, 0 fail** across provincial-511, 511-rate-limit, open511, seed-bundle-canada, the Railway registry and watch-path audits, health-classify and the nixpacks import graph. Biome clean — the two warnings in `seed-bundle-canada.test.mjs` are pre-existing at lines 388/404, far from the three lines changed here.

## Deployment

`ALBERTA_511_KEY` is added to `seed-bundle-canada`'s `requiredEnv`, and the registry test pinning that list is updated with the *reason* rather than just the value.

The key is already set on the `seed-bundle-canada` Railway service (verified present, 32 chars), so this takes effect on the next tick after merge.
