### PR TITLE
chore: retire stale source annotations

### DIFF
--- a/scripts/enforce-panel-content-writes.mjs
+++ b/scripts/enforce-panel-content-writes.mjs
@@ -106,9 +106,11 @@ export const DIRECT_WRITE_PATTERNS = [
  * idiom inside a comment; scanning raw text counted 2, which would have let the
  * entry survive migration of the only real call.
  *
- * 41 entries / 91 call sites across 27 files. Every entry is a latent instance
- * of the #6557 latch for as long as it stays. The confirmed-defect subset was
- * tracked in #6577 and closed by #6587 (behaviour) + #6678 (this migration).
+ * The CLI derives and reports the current entry and call-site totals from the
+ * registry below; do not duplicate those shrinking counts in this comment.
+ * Every entry is a latent instance of the #6557 latch for as long as it stays.
+ * The confirmed-defect subset was tracked in #6577 and closed by #6587
+ * (behaviour) + #6678 (this migration).
  *
  * #6678 moved the five #6577 panels' SUCCESS writes onto the sanctioned helpers,
  * which is why three of them now read `x1` rather than `x2`: the surviving write

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -542,7 +542,7 @@ interface CountrySignals {
   sanctionsNewEntryCount: number;
   temporalAnomalyCount: number;
   temporalAnomalyCriticalCount: number;
-  // Phase 2 (CII unification) — military activity, gathered, not yet scored.
+  // Phase 2 (CII unification) — gathered here and scored in the security component below.
   militaryOwnFlights: number;
   militaryForeignFlights: number;
   militaryOwnVessels: number;

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -1320,7 +1320,6 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     // Late-import so non-energy variants can tree-shake these modules at
     // build time if the Atlas panels aren't bundled. Static imports are
     // safe here because all four stores are pure client caches.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     import('@/shared/pipeline-registry-store').then(({ getCachedPipelineRegistries }) => {
       const { gas, oil } = getCachedPipelineRegistries() as {
         gas: { pipelines?: Record<string, { fromCountry?: string; toCountry?: string; transitCountries?: string[]; name?: string; id?: string }> } | undefined;

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -4421,8 +4421,7 @@ export class MapComponent {
   }
 
   public setNewsLocations(_data: Array<{ lat: number; lon: number; title: string; threatLevel: string; timestamp?: Date }>): void {
-    // SVG fallback: news locations rendered as simple circles
-    // For now, skip on SVG map to keep mobile lightweight
+    // SVG/mobile fallback intentionally skips news locations to stay lightweight.
   }
 
   public setTechActivity(activities: TechHubActivity[]): void {

--- a/src/types/globe-gl.d.ts
+++ b/src/types/globe-gl.d.ts
@@ -3,7 +3,6 @@ declare module 'globe.gl' {
     [key: string]: unknown;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export interface GlobeInstance {
     pointOfView(pov?: { lat?: number; lng?: number; altitude?: number }, transitionMs?: number): { lat: number; lng: number; altitude: number };
     toGlobeCoords(x: number, y: number): { lat: number; lng: number } | null;

--- a/tests/seed-ttl-outlives-staleness-fleet.test.mjs
+++ b/tests/seed-ttl-outlives-staleness-fleet.test.mjs
@@ -61,12 +61,10 @@ const KNOWN_VIOLATIONS = new Set([
   // zero-fire run takes the RETRY path and does not advance seed-meta.fetchedAt — a tighter
   // gate would alarm every night.
   //
-  // The REAL defect is underneath and is tracked separately: wildfiresBootstrap is in
-  // EMPTY_DATA_OK_KEYS, so an ABSENT key + still-fresh seed-meta classifies as OK. In the
-  // very scenario its separate registration exists for (health.js:342 — "monitor it so
-  // canonical fallback cannot hide transform/write failures"), the panel is blank and the
-  // projection reports GREEN. Today the canonical's crit masks that; fixing the TTL would
-  // remove the mask AND the alarm.
+  // The compact projection is strict on disappearance: wildfiresBootstrap is also in
+  // MISSING_DATA_IS_FAILURE_KEYS, so an absent payload beside fresh seed metadata reports
+  // EMPTY. Keep both allowlist entries frozen together: raising either TTL would preserve
+  // old fire data through a failed producer cycle instead of making the vanished output loud.
   'seed-fire-detections.mjs',
   'seed-fire-detections.mjs::seed-meta:wildfire:fires-bootstrap',
   'seed-aaii-sentiment.mjs',

--- a/tests/source-comment-hygiene.test.mjs
+++ b/tests/source-comment-hygiene.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const source = (path) => readFileSync(join(ROOT, path), 'utf8');
+
+test('obsolete ESLint suppressions do not return', () => {
+  assert.doesNotMatch(
+    source('src/types/globe-gl.d.ts'),
+    /eslint-disable-next-line @typescript-eslint\/no-explicit-any\s+export interface GlobeInstance/,
+  );
+  assert.doesNotMatch(
+    source('src/components/CountryDeepDivePanel.ts'),
+    /eslint-disable-next-line @typescript-eslint\/no-require-imports\s+import\('@\/shared\/pipeline-registry-store'\)/,
+  );
+});
+
+test('source comments do not repeat retired claims or hand-maintained totals', () => {
+  assert.doesNotMatch(
+    source('tests/seed-ttl-outlives-staleness-fleet.test.mjs'),
+    /The REAL defect is underneath and is tracked separately/,
+  );
+  assert.doesNotMatch(
+    source('scripts/enforce-panel-content-writes.mjs'),
+    /\d+ entries \/ \d+ call sites across \d+ files/,
+  );
+  assert.doesNotMatch(
+    source('server/worldmonitor/intelligence/v1/get-risk-scores.ts'),
+    /military activity, gathered, not yet scored/,
+  );
+  assert.doesNotMatch(
+    source('src/components/Map.ts'),
+    /SVG fallback: news locations rendered as simple circles/,
+  );
+});


### PR DESCRIPTION
## Summary

Source annotations now match the behavior enforced by the codebase: maintainers no longer see inert lint exceptions, retired defect claims, or frozen registry totals presented as current truth. A focused source-hygiene test protects these exact annotations from drifting back.

## Validation

- Full pre-push gate passed, including frontend/API typechecks, architectural and safety lints, edge bundling, 91 server-handler tests, 6 changed-file tests, and 264 Edge Function tests.
- Focused health and hygiene checks passed: 13 tests across source annotations, TTL/staleness, health empty-data handling, and risk-score seeding; the panel-content guard and its 11 tests also passed.
- The broad `test:data` diagnostic run was stopped after more than ten minutes once unrelated test-only generated-artifact and high-concurrency AIS/relay timing failures made the result non-actionable; the missing generated artifacts were restored before the successful pre-push gate.

## Post-Deploy Monitoring & Validation

No additional operational monitoring is required: this PR changes source comments, removes inert lint directives, and adds a static regression test without modifying runtime behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
