### PR TITLE
fix(docs-stats): parse TIER_CACHE through freeze and JSDoc wrappers (#7115)

### DIFF
--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -354,10 +354,20 @@ function parseMcpAppsInventory({
 // some later block's closing brace and parsed that instead. Counting braces
 // bounds the body to the object actually declared. Safe here because these
 // blocks hold only header strings, which contain no braces.
+//
+// The `{` does not have to sit on the `=`. `Object.freeze({` and a JSDoc
+// `/** @type {const} */ (` assertion are wrappers around the same map; a
+// parser that demanded `= {` reported `could not parse TIER_CACHE` and took
+// Docker inventory generation offline (#7115). Skip comments, identifiers,
+// and grouping parens between `=` and the object. A JSDoc `{const}` is a
+// comment, not the literal — taking the first `{` after `=` would close on
+// that instead.
 function parseObjectBlockBody(source, declaration, label) {
-  const start = source.search(new RegExp(`${declaration}\\s*=\\s*\\{`));
-  if (start === -1) throw new Error(`docs-stats: could not parse ${label}`);
-  const open = source.indexOf('{', start);
+  const assignment = source.match(new RegExp(`${declaration}\\s*=`));
+  if (!assignment || assignment.index === undefined) {
+    throw new Error(`docs-stats: could not parse ${label}`);
+  }
+  const open = findAssignedObjectLiteralOpen(source, assignment.index + assignment[0].length, label);
   let depth = 0;
   for (let i = open; i < source.length; i += 1) {
     if (source[i] === '{') depth += 1;
@@ -367,6 +377,55 @@ function parseObjectBlockBody(source, declaration, label) {
     }
   }
   throw new Error(`docs-stats: could not parse ${label} (unbalanced braces)`);
+}
+
+function findAssignedObjectLiteralOpen(source, from, label) {
+  let i = from;
+  let state = 'code';
+  while (i < source.length) {
+    const character = source[i];
+    const next = source[i + 1];
+    if (state === 'line-comment') {
+      if (character === '\n') state = 'code';
+      i += 1;
+      continue;
+    }
+    if (state === 'block-comment') {
+      if (character === '*' && next === '/') {
+        state = 'code';
+        i += 2;
+        continue;
+      }
+      i += 1;
+      continue;
+    }
+    if (character === '/' && next === '/') {
+      state = 'line-comment';
+      i += 2;
+      continue;
+    }
+    if (character === '/' && next === '*') {
+      state = 'block-comment';
+      i += 2;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      i += 1;
+      continue;
+    }
+    if (character === '{') return i;
+    if (character === '(') {
+      i += 1;
+      continue;
+    }
+    if (/[A-Za-z_$]/.test(character)) {
+      i += 1;
+      while (i < source.length && /[A-Za-z0-9_$.]/.test(source[i])) i += 1;
+      continue;
+    }
+    throw new Error(`docs-stats: could not parse ${label}`);
+  }
+  throw new Error(`docs-stats: could not parse ${label}`);
 }
 
 function parseCacheHeaderMap(source, name) {

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -354,10 +354,14 @@ function parseMcpAppsInventory({
 // some later block's closing brace and parsed that instead. Counting braces
 // bounds the body to the object actually declared. Safe here because these
 // blocks hold only header strings, which contain no braces.
-// Skip wrappers (`Object.freeze(`, JSDoc `/** @type … */ (`) between `=` and
-// `{`; JSDoc braces are comments, not the literal (#7115).
+// Skip wrappers (`Object.freeze(`, `Object.seal(`, JSDoc `/** @type … */ (`)
+// between `=` and `{`; JSDoc braces are comments, not the literal (#7115).
+// Any other callee is a parse failure so a helper that transforms the object
+// cannot silently pass against the argument literal.
+const OBJECT_WRAPPER_IDENTIFIERS = new Set(['Object.freeze', 'Object.seal']);
+
 function parseObjectBlockBody(source, declaration, label) {
-  const assignment = source.match(new RegExp(`(?:export\\s+)?${declaration}\\s*=`));
+  const assignment = findLiveAssignment(source, declaration);
   if (!assignment || assignment.index === undefined) {
     throw new Error(`docs-stats: could not parse ${label}`);
   }
@@ -371,6 +375,30 @@ function parseObjectBlockBody(source, declaration, label) {
     }
   }
   throw new Error(`docs-stats: could not parse ${label} (unbalanced braces)`);
+}
+
+function findLiveAssignment(source, declaration) {
+  const assignment = new RegExp(`(?:export\\s+)?${declaration}\\s*=`, 'g');
+  let match;
+  while ((match = assignment.exec(source)) !== null) {
+    if (isCommentedSourceIndex(source, match.index)) continue;
+    return match;
+  }
+  return null;
+}
+
+// Line-prefix `//` (not `http://`) or an unclosed `/*` before the match.
+// First-match-wins would otherwise bind a leftover commented assignment and
+// parse that dead object — or fail — while a live wrapped constant sits below.
+function isCommentedSourceIndex(source, index) {
+  const before = source.slice(0, index);
+  const lastBlockOpen = before.lastIndexOf('/*');
+  const lastBlockClose = before.lastIndexOf('*/');
+  if (lastBlockOpen > lastBlockClose) return true;
+
+  const lineStart = source.lastIndexOf('\n', index - 1) + 1;
+  const prefix = source.slice(lineStart, index);
+  return /(?:^|[^:])\/\/(?!\/)/.test(prefix);
 }
 
 function skipLineAndBlockComments(source, i) {
@@ -406,7 +434,7 @@ function findAssignedObjectLiteralOpen(source, from, label) {
       continue;
     }
     const identifier = source.slice(i).match(/^[A-Za-z_$][\w$.]*/)?.[0];
-    if (identifier) {
+    if (identifier && OBJECT_WRAPPER_IDENTIFIERS.has(identifier)) {
       i += identifier.length;
       continue;
     }

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -18,6 +18,7 @@ import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, join } from 'node:path';
 import { buildSourceAttributionStats } from './source-attribution.mjs';
+import { extractAssignedObjectBlock } from './lib/js-source-structure.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 // #6702: tests that stage probe trees redirect the module at a throwaway
@@ -361,86 +362,11 @@ function parseMcpAppsInventory({
 const OBJECT_WRAPPER_IDENTIFIERS = new Set(['Object.freeze', 'Object.seal']);
 
 function parseObjectBlockBody(source, declaration, label) {
-  const assignment = findLiveAssignment(source, declaration);
-  if (!assignment || assignment.index === undefined) {
+  const body = extractAssignedObjectBlock(source, declaration, OBJECT_WRAPPER_IDENTIFIERS);
+  if (body === null) {
     throw new Error(`docs-stats: could not parse ${label}`);
   }
-  const open = findAssignedObjectLiteralOpen(source, assignment.index + assignment[0].length, label);
-  let depth = 0;
-  for (let i = open; i < source.length; i += 1) {
-    if (source[i] === '{') depth += 1;
-    else if (source[i] === '}') {
-      depth -= 1;
-      if (depth === 0) return source.slice(open + 1, i);
-    }
-  }
-  throw new Error(`docs-stats: could not parse ${label} (unbalanced braces)`);
-}
-
-function findLiveAssignment(source, declaration) {
-  const assignment = new RegExp(`(?:export\\s+)?${declaration}\\s*=`, 'g');
-  let match;
-  while ((match = assignment.exec(source)) !== null) {
-    if (isCommentedSourceIndex(source, match.index)) continue;
-    return match;
-  }
-  return null;
-}
-
-// Line-prefix `//` (not `http://`) or an unclosed `/*` before the match.
-// First-match-wins would otherwise bind a leftover commented assignment and
-// parse that dead object — or fail — while a live wrapped constant sits below.
-function isCommentedSourceIndex(source, index) {
-  const before = source.slice(0, index);
-  const lastBlockOpen = before.lastIndexOf('/*');
-  const lastBlockClose = before.lastIndexOf('*/');
-  if (lastBlockOpen > lastBlockClose) return true;
-
-  const lineStart = source.lastIndexOf('\n', index - 1) + 1;
-  const prefix = source.slice(lineStart, index);
-  return /(?:^|[^:])\/\/(?!\/)/.test(prefix);
-}
-
-function skipLineAndBlockComments(source, i) {
-  const character = source[i];
-  const next = source[i + 1];
-  if (character === '/' && next === '/') {
-    const newline = source.indexOf('\n', i + 2);
-    return newline === -1 ? source.length : newline + 1;
-  }
-  if (character === '/' && next === '*') {
-    const close = source.indexOf('*/', i + 2);
-    return close === -1 ? source.length : close + 2;
-  }
-  return i;
-}
-
-function findAssignedObjectLiteralOpen(source, from, label) {
-  let i = from;
-  while (i < source.length) {
-    const skipped = skipLineAndBlockComments(source, i);
-    if (skipped !== i) {
-      i = skipped;
-      continue;
-    }
-    const character = source[i];
-    if (/\s/.test(character)) {
-      i += 1;
-      continue;
-    }
-    if (character === '{') return i;
-    if (character === '(') {
-      i += 1;
-      continue;
-    }
-    const identifier = source.slice(i).match(/^[A-Za-z_$][\w$.]*/)?.[0];
-    if (identifier && OBJECT_WRAPPER_IDENTIFIERS.has(identifier)) {
-      i += identifier.length;
-      continue;
-    }
-    throw new Error(`docs-stats: could not parse ${label}`);
-  }
-  throw new Error(`docs-stats: could not parse ${label}`);
+  return body;
 }
 
 function parseCacheHeaderMap(source, name) {

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -354,16 +354,10 @@ function parseMcpAppsInventory({
 // some later block's closing brace and parsed that instead. Counting braces
 // bounds the body to the object actually declared. Safe here because these
 // blocks hold only header strings, which contain no braces.
-//
-// The `{` does not have to sit on the `=`. `Object.freeze({` and a JSDoc
-// `/** @type {const} */ (` assertion are wrappers around the same map; a
-// parser that demanded `= {` reported `could not parse TIER_CACHE` and took
-// Docker inventory generation offline (#7115). Skip comments, identifiers,
-// and grouping parens between `=` and the object. A JSDoc `{const}` is a
-// comment, not the literal — taking the first `{` after `=` would close on
-// that instead.
+// Skip wrappers (`Object.freeze(`, JSDoc `/** @type … */ (`) between `=` and
+// `{`; JSDoc braces are comments, not the literal (#7115).
 function parseObjectBlockBody(source, declaration, label) {
-  const assignment = source.match(new RegExp(`${declaration}\\s*=`));
+  const assignment = source.match(new RegExp(`(?:export\\s+)?${declaration}\\s*=`));
   if (!assignment || assignment.index === undefined) {
     throw new Error(`docs-stats: could not parse ${label}`);
   }
@@ -379,36 +373,29 @@ function parseObjectBlockBody(source, declaration, label) {
   throw new Error(`docs-stats: could not parse ${label} (unbalanced braces)`);
 }
 
+function skipLineAndBlockComments(source, i) {
+  const character = source[i];
+  const next = source[i + 1];
+  if (character === '/' && next === '/') {
+    const newline = source.indexOf('\n', i + 2);
+    return newline === -1 ? source.length : newline + 1;
+  }
+  if (character === '/' && next === '*') {
+    const close = source.indexOf('*/', i + 2);
+    return close === -1 ? source.length : close + 2;
+  }
+  return i;
+}
+
 function findAssignedObjectLiteralOpen(source, from, label) {
   let i = from;
-  let state = 'code';
   while (i < source.length) {
+    const skipped = skipLineAndBlockComments(source, i);
+    if (skipped !== i) {
+      i = skipped;
+      continue;
+    }
     const character = source[i];
-    const next = source[i + 1];
-    if (state === 'line-comment') {
-      if (character === '\n') state = 'code';
-      i += 1;
-      continue;
-    }
-    if (state === 'block-comment') {
-      if (character === '*' && next === '/') {
-        state = 'code';
-        i += 2;
-        continue;
-      }
-      i += 1;
-      continue;
-    }
-    if (character === '/' && next === '/') {
-      state = 'line-comment';
-      i += 2;
-      continue;
-    }
-    if (character === '/' && next === '*') {
-      state = 'block-comment';
-      i += 2;
-      continue;
-    }
     if (/\s/.test(character)) {
       i += 1;
       continue;
@@ -418,9 +405,9 @@ function findAssignedObjectLiteralOpen(source, from, label) {
       i += 1;
       continue;
     }
-    if (/[A-Za-z_$]/.test(character)) {
-      i += 1;
-      while (i < source.length && /[A-Za-z0-9_$.]/.test(source[i])) i += 1;
+    const identifier = source.slice(i).match(/^[A-Za-z_$][\w$.]*/)?.[0];
+    if (identifier) {
+      i += identifier.length;
       continue;
     }
     throw new Error(`docs-stats: could not parse ${label}`);

--- a/scripts/lib/js-source-structure.mjs
+++ b/scripts/lib/js-source-structure.mjs
@@ -243,6 +243,93 @@ function isTokenBoundedMatch(text, anchor, index) {
   return true;
 }
 
+function skipWhitespace(text, index) {
+  while (index < text.length && /\s/.test(text[index])) index += 1;
+  return index;
+}
+
+function readAssignedObjectShape(text, from, wrappers) {
+  let index = skipWhitespace(text, from);
+  if (text[index] !== '=') return null;
+
+  index = skipWhitespace(text, index + 1);
+  let parenthesisDepth = 0;
+  while (index < text.length) {
+    if (text[index] === '(') {
+      parenthesisDepth += 1;
+      index = skipWhitespace(text, index + 1);
+      continue;
+    }
+
+    const identifier = text.slice(index).match(/^[A-Za-z_$][\w$.]*/)?.[0];
+    if (identifier && wrappers.has(identifier)) {
+      index = skipWhitespace(text, index + identifier.length);
+      if (text[index] !== '(') return null;
+      parenthesisDepth += 1;
+      index = skipWhitespace(text, index + 1);
+      continue;
+    }
+
+    if (text[index] === '{') return { index, parenthesisDepth };
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Return the body of the object literal assigned to a code-level declaration.
+ *
+ * The right-hand side may contain grouping parentheses and explicitly allowed
+ * call wrappers. Wrapper calls must have a call opener and every opened
+ * parenthesis must close immediately after the object. Returns null for a
+ * missing, commented, string-contained, unknown, or malformed declaration.
+ *
+ * @param {string} source
+ * @param {string} declaration
+ * @param {Set<string>} wrappers
+ * @returns {string | null}
+ */
+export function extractAssignedObjectBlock(source, declaration, wrappers) {
+  const text = stripJsComments(source);
+  let shape = null;
+  let invalid = false;
+
+  walkCode(text, 0, (_character, index) => {
+    if (!text.startsWith(declaration, index) || !isTokenBoundedMatch(text, declaration, index)) return true;
+    shape = readAssignedObjectShape(text, index + declaration.length, wrappers);
+    if (!shape) invalid = true;
+    return false;
+  });
+
+  if (invalid || !shape) return null;
+
+  let bodyEnd = -1;
+  let braceDepth = 0;
+  walkCode(text, shape.index, (character, index) => {
+    if (character === '{') {
+      braceDepth += 1;
+    } else if (character === '}') {
+      braceDepth -= 1;
+      if (braceDepth === 0) {
+        bodyEnd = index;
+        return false;
+      }
+    }
+    return true;
+  });
+
+  if (bodyEnd === -1) return null;
+
+  let afterBody = skipWhitespace(text, bodyEnd + 1);
+  for (let depth = 0; depth < shape.parenthesisDepth; depth += 1) {
+    if (text[afterBody] !== ')') return null;
+    afterBody = skipWhitespace(text, afterBody + 1);
+  }
+
+  return text.slice(shape.index + 1, bodyEnd);
+}
+
 /**
  * Return the text between the balanced `open`/`close` delimiters that follow
  * the first code-level occurrence of `anchor`.

--- a/tests/docs-stats-bootstrap-cache.test.mts
+++ b/tests/docs-stats-bootstrap-cache.test.mts
@@ -162,13 +162,14 @@ describe('parseBootstrapCacheContract', () => {
     );
   });
 
-  for (const [label, from, to] of [
-    ['TIER_CACHE wrapped in Object.freeze', 'const TIER_CACHE = {', 'const TIER_CACHE = Object.freeze({'],
-    ['TIER_CACHE behind a JSDoc const assertion', 'const TIER_CACHE = {', 'const TIER_CACHE = /** @type {const} */ ({'],
-    ['TIER_CDN_CACHE wrapped in export and Object.freeze', 'const TIER_CDN_CACHE = {', 'export const TIER_CDN_CACHE = Object.freeze({'],
-  ] as [string, string, string][]) {
+  for (const [label, from, to, closeFrom, closeTo] of [
+    ['TIER_CACHE wrapped in Object.freeze', 'const TIER_CACHE = {', 'const TIER_CACHE = Object.freeze({', "  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',\n};", "  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',\n});"],
+    ['TIER_CACHE wrapped in Object.seal', 'const TIER_CACHE = {', 'const TIER_CACHE = Object.seal({', "  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',\n};", "  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',\n});"],
+    ['TIER_CACHE behind a JSDoc const assertion', 'const TIER_CACHE = {', 'const TIER_CACHE = /** @type {const} */ ({', "  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',\n};", "  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',\n});"],
+    ['TIER_CDN_CACHE wrapped in export and Object.freeze', 'const TIER_CDN_CACHE = {', 'export const TIER_CDN_CACHE = Object.freeze({', "  fast: 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',\n};", "  fast: 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',\n});"],
+  ] as [string, string, string, string, string][]) {
     it(`parses ${label}`, () => {
-      const source = SYNTHETIC_BOOTSTRAP.replace(from, to);
+      const source = SYNTHETIC_BOOTSTRAP.replace(from, to).replace(closeFrom, closeTo);
       assert.notEqual(source, SYNTHETIC_BOOTSTRAP, `fixture drift: ${from} not found`);
       const cache = parseBootstrapCacheContract(source);
       assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
@@ -195,6 +196,18 @@ describe('parseBootstrapCacheContract', () => {
     assert.throws(() => parseBootstrapCacheContract(source), /could not parse TIER_CACHE/);
   });
 
+  for (const [label, replacement] of [
+    ['an approved wrapper has no call opener', 'const TIER_CACHE = Object.freeze {'],
+    ['a grouping parenthesis is unclosed', 'const TIER_CACHE = ({'],
+    ['an approved wrapper call is unclosed', 'const TIER_CACHE = Object.freeze({'],
+  ] as [string, string][]) {
+    it(`throws when ${label}`, () => {
+      const source = SYNTHETIC_BOOTSTRAP.replace('const TIER_CACHE = {', replacement);
+      assert.notEqual(source, SYNTHETIC_BOOTSTRAP, 'fixture drift: TIER_CACHE opener not found');
+      assert.throws(() => parseBootstrapCacheContract(source), /could not parse TIER_CACHE/);
+    });
+  }
+
   it('parses TIER_CACHE when a line comment sits between = and {', () => {
     const source = SYNTHETIC_BOOTSTRAP.replace(
       'const TIER_CACHE = {',
@@ -214,6 +227,9 @@ describe('parseBootstrapCacheContract', () => {
     const source = leftover + SYNTHETIC_BOOTSTRAP.replace(
       'const TIER_CACHE = {',
       'const TIER_CACHE = Object.freeze({',
+    ).replace(
+      "  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',\n};",
+      "  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',\n});",
     );
     const cache = parseBootstrapCacheContract(source);
     assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
@@ -230,6 +246,15 @@ describe('parseBootstrapCacheContract', () => {
     const cache = parseBootstrapCacheContract(source);
     assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
     assert.equal(cache.tierCache.slow, 'max-age=300, stale-while-revalidate=600, stale-if-error=3600');
+  });
+
+  it('ignores comment-looking text inside a string before the live assignment', () => {
+    const source = SYNTHETIC_BOOTSTRAP.replace(
+      'const TIER_CACHE = {',
+      "const note = '//';\nconst TIER_CACHE = {",
+    );
+    const cache = parseBootstrapCacheContract(source);
+    assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
   });
 
   it('throws when a tier loses its entry', () => {
@@ -318,7 +343,7 @@ describe('parseBootstrapCacheContract', () => {
 
   it('throws on an unterminated object block instead of scanning to EOF', () => {
     const source = SYNTHETIC_BOOTSTRAP.replace('const TIER_CACHE = {', 'const TIER_CACHE = { {');
-    assert.throws(() => parseBootstrapCacheContract(source), /unbalanced braces/);
+    assert.throws(() => parseBootstrapCacheContract(source), /could not parse TIER_CACHE/);
   });
 
   it('throws when successCacheHeaders grows an undocumented literal state', () => {

--- a/tests/docs-stats-bootstrap-cache.test.mts
+++ b/tests/docs-stats-bootstrap-cache.test.mts
@@ -162,42 +162,20 @@ describe('parseBootstrapCacheContract', () => {
     );
   });
 
-  // #7115: Docker inventory generation failed with
-  // `could not parse TIER_CACHE in api/bootstrap.js` when the assignment was
-  // not a bare `= {`. The declaration still names the same map; only the
-  // wrapper changed. Accept the wrappers this file already uses elsewhere
-  // (`Object.freeze`, a JSDoc const assertion) so a formatter or a later
-  // hardening of the literal cannot take the generator offline.
-  it('parses TIER_CACHE when the object is wrapped in Object.freeze', () => {
-    const source = SYNTHETIC_BOOTSTRAP.replace(
-      'const TIER_CACHE = {',
-      'const TIER_CACHE = Object.freeze({',
-    );
-    assert.notEqual(source, SYNTHETIC_BOOTSTRAP, 'fixture drift: TIER_CACHE declaration not found');
-    const cache = parseBootstrapCacheContract(source);
-    assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
-    assert.equal(cache.tierCache.slow, 'max-age=300, stale-while-revalidate=600, stale-if-error=3600');
-  });
-
-  it('parses TIER_CACHE when a JSDoc const assertion sits between = and the object', () => {
-    const source = SYNTHETIC_BOOTSTRAP.replace(
-      'const TIER_CACHE = {',
-      'const TIER_CACHE = /** @type {const} */ ({',
-    );
-    assert.notEqual(source, SYNTHETIC_BOOTSTRAP, 'fixture drift: TIER_CACHE declaration not found');
-    const cache = parseBootstrapCacheContract(source);
-    assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
-  });
-
-  it('parses TIER_CDN_CACHE when export and Object.freeze wrap the literal', () => {
-    const source = SYNTHETIC_BOOTSTRAP.replace(
-      'const TIER_CDN_CACHE = {',
-      'export const TIER_CDN_CACHE = Object.freeze({',
-    );
-    assert.notEqual(source, SYNTHETIC_BOOTSTRAP, 'fixture drift: TIER_CDN_CACHE declaration not found');
-    const cache = parseBootstrapCacheContract(source);
-    assert.equal(cache.tierCdnCache.fast, 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900');
-  });
+  for (const [label, from, to] of [
+    ['TIER_CACHE wrapped in Object.freeze', 'const TIER_CACHE = {', 'const TIER_CACHE = Object.freeze({'],
+    ['TIER_CACHE behind a JSDoc const assertion', 'const TIER_CACHE = {', 'const TIER_CACHE = /** @type {const} */ ({'],
+    ['TIER_CDN_CACHE wrapped in export and Object.freeze', 'const TIER_CDN_CACHE = {', 'export const TIER_CDN_CACHE = Object.freeze({'],
+  ] as [string, string, string][]) {
+    it(`parses ${label}`, () => {
+      const source = SYNTHETIC_BOOTSTRAP.replace(from, to);
+      assert.notEqual(source, SYNTHETIC_BOOTSTRAP, `fixture drift: ${from} not found`);
+      const cache = parseBootstrapCacheContract(source);
+      assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
+      assert.equal(cache.tierCache.slow, 'max-age=300, stale-while-revalidate=600, stale-if-error=3600');
+      assert.equal(cache.tierCdnCache.fast, 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900');
+    });
+  }
 
   it('throws when a tier loses its entry', () => {
     const source = SYNTHETIC_BOOTSTRAP.replace(

--- a/tests/docs-stats-bootstrap-cache.test.mts
+++ b/tests/docs-stats-bootstrap-cache.test.mts
@@ -162,6 +162,43 @@ describe('parseBootstrapCacheContract', () => {
     );
   });
 
+  // #7115: Docker inventory generation failed with
+  // `could not parse TIER_CACHE in api/bootstrap.js` when the assignment was
+  // not a bare `= {`. The declaration still names the same map; only the
+  // wrapper changed. Accept the wrappers this file already uses elsewhere
+  // (`Object.freeze`, a JSDoc const assertion) so a formatter or a later
+  // hardening of the literal cannot take the generator offline.
+  it('parses TIER_CACHE when the object is wrapped in Object.freeze', () => {
+    const source = SYNTHETIC_BOOTSTRAP.replace(
+      'const TIER_CACHE = {',
+      'const TIER_CACHE = Object.freeze({',
+    );
+    assert.notEqual(source, SYNTHETIC_BOOTSTRAP, 'fixture drift: TIER_CACHE declaration not found');
+    const cache = parseBootstrapCacheContract(source);
+    assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
+    assert.equal(cache.tierCache.slow, 'max-age=300, stale-while-revalidate=600, stale-if-error=3600');
+  });
+
+  it('parses TIER_CACHE when a JSDoc const assertion sits between = and the object', () => {
+    const source = SYNTHETIC_BOOTSTRAP.replace(
+      'const TIER_CACHE = {',
+      'const TIER_CACHE = /** @type {const} */ ({',
+    );
+    assert.notEqual(source, SYNTHETIC_BOOTSTRAP, 'fixture drift: TIER_CACHE declaration not found');
+    const cache = parseBootstrapCacheContract(source);
+    assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
+  });
+
+  it('parses TIER_CDN_CACHE when export and Object.freeze wrap the literal', () => {
+    const source = SYNTHETIC_BOOTSTRAP.replace(
+      'const TIER_CDN_CACHE = {',
+      'export const TIER_CDN_CACHE = Object.freeze({',
+    );
+    assert.notEqual(source, SYNTHETIC_BOOTSTRAP, 'fixture drift: TIER_CDN_CACHE declaration not found');
+    const cache = parseBootstrapCacheContract(source);
+    assert.equal(cache.tierCdnCache.fast, 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900');
+  });
+
   it('throws when a tier loses its entry', () => {
     const source = SYNTHETIC_BOOTSTRAP.replace(
       "  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',\n};",

--- a/tests/docs-stats-bootstrap-cache.test.mts
+++ b/tests/docs-stats-bootstrap-cache.test.mts
@@ -177,6 +177,61 @@ describe('parseBootstrapCacheContract', () => {
     });
   }
 
+  it('throws when TIER_CACHE is wrapped in an unknown callee', () => {
+    const source = SYNTHETIC_BOOTSTRAP.replace(
+      'const TIER_CACHE = {',
+      'const TIER_CACHE = withDefaults({',
+    );
+    assert.notEqual(source, SYNTHETIC_BOOTSTRAP, 'fixture drift: TIER_CACHE opener not found');
+    assert.throws(() => parseBootstrapCacheContract(source), /could not parse TIER_CACHE/);
+  });
+
+  it('throws when Object.freeze is not followed by a call', () => {
+    const source = SYNTHETIC_BOOTSTRAP.replace(
+      'const TIER_CACHE = {',
+      'const TIER_CACHE = Object.freeze[',
+    );
+    assert.notEqual(source, SYNTHETIC_BOOTSTRAP, 'fixture drift: TIER_CACHE opener not found');
+    assert.throws(() => parseBootstrapCacheContract(source), /could not parse TIER_CACHE/);
+  });
+
+  it('parses TIER_CACHE when a line comment sits between = and {', () => {
+    const source = SYNTHETIC_BOOTSTRAP.replace(
+      'const TIER_CACHE = {',
+      'const TIER_CACHE = // note\n {',
+    );
+    assert.notEqual(source, SYNTHETIC_BOOTSTRAP, 'fixture drift: TIER_CACHE opener not found');
+    const cache = parseBootstrapCacheContract(source);
+    assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
+  });
+
+  it('ignores a commented leftover TIER_CACHE assignment', () => {
+    const leftover = `// const TIER_CACHE = {
+//   slow: 'max-age=1, stale-while-revalidate=1, stale-if-error=1',
+//   fast: 'max-age=1, stale-while-revalidate=1, stale-if-error=1',
+// };
+`;
+    const source = leftover + SYNTHETIC_BOOTSTRAP.replace(
+      'const TIER_CACHE = {',
+      'const TIER_CACHE = Object.freeze({',
+    );
+    const cache = parseBootstrapCacheContract(source);
+    assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
+    assert.equal(cache.tierCache.slow, 'max-age=300, stale-while-revalidate=600, stale-if-error=3600');
+  });
+
+  it('ignores a block-comment leftover TIER_CACHE assignment', () => {
+    const leftover = `/* const TIER_CACHE = {
+  slow: 'max-age=1, stale-while-revalidate=1, stale-if-error=1',
+  fast: 'max-age=1, stale-while-revalidate=1, stale-if-error=1',
+}; */
+`;
+    const source = leftover + SYNTHETIC_BOOTSTRAP;
+    const cache = parseBootstrapCacheContract(source);
+    assert.equal(cache.tierCache.fast, 'max-age=60, stale-while-revalidate=120, stale-if-error=900');
+    assert.equal(cache.tierCache.slow, 'max-age=300, stale-while-revalidate=600, stale-if-error=3600');
+  });
+
   it('throws when a tier loses its entry', () => {
     const source = SYNTHETIC_BOOTSTRAP.replace(
       "  fast: 'max-age=60, stale-while-revalidate=120, stale-if-error=900',\n};",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Docker inventory generation failed with `docs-stats: could not parse TIER_CACHE in api/bootstrap.js` when the cache map was assigned through `Object.freeze({` or a JSDoc `/** @type {const} */ (` assertion instead of a bare `= {`.

`parseObjectBlockBody` now walks from the first live (non-commented) declaration to the object literal. It skips line/block comments, grouping parens, and only `Object.freeze` / `Object.seal`. Missing, renamed, or unknown-callee constants still fail closed.

Fixes #7115.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: inventory facts / `scripts/docs-stats.mjs` (Docker `generate-inventory-facts` step)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`) — not required for this script-only change; focused `docs-stats` tests passed
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [x] N/A — this PR does not publish or change documentation claims

## Screenshots

N/A — parser/build-script change. Evidence is the focused `tests/docs-stats-bootstrap-cache.test.mts` run (58 passed), `tests/docs-stats-health-total.test.mts` (36 passed), plus `node scripts/docs-stats.mjs --check`.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this change only affects the docs-stats inventory parser used at Docker/CI inventory generation time, not a runtime API or dashboard path.

- **Healthy signal:** `node scripts/generate-inventory-facts.mjs` and `docs-stats --check` succeed on a fresh clone or Docker build.
- **Failure signal:** `inventory facts check FAILED: docs-stats: could not parse TIER_CACHE in api/bootstrap.js` during image build.
- **Rollback:** revert this PR if inventory generation starts failing on a legal `TIER_CACHE` shape.
- **Validation window:** first CI run and any Docker image rebuild after merge.
- **Owner:** whoever merges the PR.

## Known Residuals

- **P3 / advisory:** `isCommentedSourceIndex` can treat `/*` or `//` inside an earlier string as a real comment, same class as the existing `blankComments` helper on the health path. No current `TIER_CACHE` source looks like that.
- **P3 / testing:** `Object.seal({` is allowed by the wrapper allowlist but only `Object.freeze` is exercised as a happy path.
- **Unproved:** a full Docker image build was not run in this environment (Docker unavailable). Parser fixtures and `generate-inventory-facts` / `docs-stats --check` were run locally.

## Testing

- `node --import tsx --test tests/docs-stats-bootstrap-cache.test.mts` — 58 pass
- `node --import tsx --test tests/docs-stats-health-total.test.mts` — 36 pass
- `node scripts/generate-inventory-facts.mjs` and `node scripts/docs-stats.mjs --check` — OK

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03436-10c3-783c-827c-dc73291364ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03436-10c3-783c-827c-dc73291364ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

