### PR TITLE
chore(monitor): retire three acknowledgements production has satisfied

### DIFF
--- a/scripts/seed-freshness-baseline.json
+++ b/scripts/seed-freshness-baseline.json
@@ -23,42 +23,5 @@
     "block in api/health.js exists to prevent."
   ],
   "expiresAt": "2026-08-27",
-  "acknowledged": [
-    {
-      "name": "flightDelays",
-      "status": "STALE_SEED",
-      "issue": 6987,
-      "reason": "Probe meta moves from seed-meta:aviation:faa (FAA-only alert count) to seed-meta:aviation:delays-bootstrap, written from the aggregate this probe actually serves. The new key does not exist until seed-aviation next runs, and this probe is meta-only against a served aggregate, so the gap reads STALE_SEED rather than EMPTY -- measured with classifyKey against this branch, not assumed. aviation:faa runs on a 45-minute interval, so the first tick after deploy closes it.",
-      "expiresAt": "2026-08-21T00:00:00.000Z",
-      "cutover": {
-        "probeKey": "seed-meta:aviation:delays-bootstrap",
-        "activatedAt": "2026-08-20T10:00:00.000Z",
-        "firstScheduledRunAt": "2026-08-21T00:00:00.000Z"
-      }
-    },
-    {
-      "name": "tpsMci",
-      "status": "EMPTY",
-      "issue": 7035,
-      "reason": "New on-demand Toronto Police Open Data probe (tpsMci). seed-meta:safety:tps-mci cannot exist until the first on-demand fetch after deploy. EMPTY after that first scheduled window is a dead producer, not a deploy window.",
-      "expiresAt": "2026-08-22T04:05:00.000Z",
-      "cutover": {
-        "probeKey": "seed-meta:safety:tps-mci",
-        "activatedAt": "2026-08-21T04:05:00.000Z",
-        "firstScheduledRunAt": "2026-08-22T04:05:00.000Z"
-      }
-    },
-    {
-      "name": "tpsCallsAttended",
-      "status": "EMPTY",
-      "issue": 7036,
-      "reason": "New on-demand Toronto Police Open Data probe (tpsCallsAttended). seed-meta:safety:tps-calls-attended cannot exist until the first on-demand fetch after deploy. EMPTY after that first scheduled window is a dead producer, not a deploy window.",
-      "expiresAt": "2026-08-22T04:05:00.000Z",
-      "cutover": {
-        "probeKey": "seed-meta:safety:tps-calls-attended",
-        "activatedAt": "2026-08-21T04:05:00.000Z",
-        "firstScheduledRunAt": "2026-08-22T04:05:00.000Z"
-      }
-    }
-  ]
+  "acknowledged": []
 }


### PR DESCRIPTION
The seed-freshness monitor named these on every run:

```
- recovered: flightDelays:STALE_SEED no longer reported; remove it from scripts/seed-freshness-baseline.json (#6987).
- recovered: tpsMci:EMPTY no longer reported; remove it from scripts/seed-freshness-baseline.json (#7035).
- recovered: tpsCallsAttended:EMPTY no longer reported; remove it from scripts/seed-freshness-baseline.json (#7036).
```

All three expired days ago — `flightDelays` on 2026-08-21, the two TPS probes on 2026-08-22 — and each now reports a status its acknowledgement does not name. None was suppressing anything: the pass line already read `0 acknowledged` with them still in the file.

## Removed rather than re-dated

Each covered a cutover that has since completed:

| probe | why it is spent |
|---|---|
| `flightDelays` | the probe moved onto `seed-meta:aviation:delays-bootstrap` and the aggregate publishes its own meta (#6987), closing the `STALE_SEED` window |
| `tpsMci` | now publishes; `EMPTY` is not what it reports |
| `tpsCallsAttended` | same |

An expired acknowledgement is worse than none. It is noise on every run, and the next real problem on one of these probes would arrive next to three lines telling an operator to ignore something.

Clearing them also retires the baseline-wide **2026-08-27** expiry as a live deadline: `expired` is only evaluated when `acknowledged` is non-empty, so an empty list cannot trip it.

## Deliberately not included

The `cutover: { mode: 'expiring-ack', … }` declarations these three carry in `api/health.js`.

That looks like the matching half to remove, and it is not. `api/health.js` holds **~13** such declarations against a baseline that held **3** — so a declaration outliving its acknowledgement is this repo's steady state, not a leftover. `check-health-probe-cutovers.mts` only consults them when a probe key actually changes, which is why the gate passes here.

Removing them would be a separate change needing its own per-probe argument, and removing only these three would make the file *less* consistent, not more.

## Verification

```
Ingestion operational acceptance passed at 2026-08-24T17:54:46Z:
no unacknowledged health problems (0 acknowledged)
MONITOR_EXIT=0
```

No recovered lines remain. Health-probe cutover gate passes. **190 tests pass, 0 fail** across seed-freshness-monitor, seed-freshness-workflow, health-classify and the relay boot guard. Biome clean.

Production health at time of writing: **HEALTHY**, 280/284 OK, with the four remaining all by design — two on-demand probes, `crossStraitActivityJapanMod` (explicit `SOURCE_BLOCKED` carve-out) and `displacementPrev` (`OK_CASCADE`).
