### PR TITLE
perf(dashboard): early-paint the world brief for cold visitors (#7118)

### DIFF
--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -129,20 +129,60 @@ export class InsightsPanel extends Panel {
   }
 
   /**
-   * #4890: early-paint the persisted World Brief at construction time so the
-   * LCP text block exists at shell paint instead of after the full insights
-   * pipeline. Generation guards on BOTH sides of the async cache read keep
-   * this from clobbering a real updateInsights() pass that races the
-   * IndexedDB read (updateInsights bumps updateGeneration synchronously on
-   * entry, so a stale early paint can never land on top of real content).
+   * #4928 external review: the synthesis cites up to 8 stories — a 6-source
+   * cap orphaned [7]/[8]. Cap to the payload's own citation index space
+   * (bounded at BRIEF_CACHE_MAX_SOURCES defensively). Shared by every path
+   * that renders a server brief so the citation bound cannot drift between
+   * the early paint (#7118) and the full render.
+   */
+  private static serverBriefSources(insights: ServerInsights): BriefSource[] {
+    return collectBriefSources(
+      insights.worldBriefSources ?? [],
+      Math.min(
+        InsightsPanel.BRIEF_CACHE_MAX_SOURCES,
+        Math.max(6, insights.worldBriefSources?.length ?? 6),
+      ),
+    );
+  }
+
+  /**
+   * #4890: early-paint the World Brief at construction time so the LCP text
+   * block exists at shell paint instead of after the full insights pipeline.
+   * Generation guards on BOTH sides of the async cache read keep this from
+   * clobbering a real updateInsights() pass that races the IndexedDB read
+   * (updateInsights bumps updateGeneration synchronously on entry, so a stale
+   * early paint can never land on top of real content).
+   *
+   * #7118: the persistent cache only exists for REPEAT visitors, so before
+   * this the early paint did nothing on a cold visit — the brief waited for
+   * the whole pipeline and became the field LCP element at p75 ~3.5s (#7113,
+   * docs/perf/field-lcp-dashboard-2026-08-24.md). `insights` rides the FAST
+   * bootstrap tier (api/_bootstrap-tier-keys.js), so on a cold visit the
+   * brief is usually already hydrated — fall back to it. The cache is still
+   * preferred: it is the cheaper read and needs no bootstrap round trip.
    */
   private async paintCachedBriefEarly(): Promise<void> {
     if (this.updateGeneration > 0) return;
     await this.loadBriefFromCache();
-    if (this.updateGeneration > 0 || !this.cachedBrief) return;
+    if (this.updateGeneration > 0) return;
+
+    let brief = this.cachedBrief;
+    let sources = this.cachedBriefSources;
+    if (!brief) {
+      // getServerInsights() is synchronous and memoises on success, so this
+      // opens no new race window and does not deprive the later
+      // updateInsights() pass of the payload.
+      const server = getServerInsights();
+      if (server?.worldBrief) {
+        brief = server.worldBrief;
+        sources = InsightsPanel.serverBriefSources(server);
+      }
+    }
+    if (!brief) return;
+
     this.setDataBadge('cached');
     this.setSafeContent(unsafeRawHtml(
-      this.renderWorldBrief(this.cachedBrief, this.cachedBriefSources),
+      this.renderWorldBrief(brief, sources),
       'renderWorldBrief formats and links the cached summary (#4890 early brief paint)',
     ));
   }
@@ -317,6 +357,21 @@ export class InsightsPanel extends Panel {
 
       // Sentiment classification uses positional indexing — must happen AFTER re-sort
       const titles = sortedStories.slice(0, 5).map(s => s.primaryTitle);
+
+      // #7118: the brief is already in hand, so paint it BEFORE the sentiment
+      // worker round trip rather than after. classifySentiment can cost
+      // seconds on first use while the ONNX model loads, and the brief is the
+      // field LCP element on ~38% of desktop /dashboard views (#7113). The
+      // full render below supersedes this; Panel drops a debounced
+      // setSafeContent write that has not committed yet, so when sentiment
+      // resolves inside the debounce window this paint costs nothing.
+      if (serverInsights.worldBrief) {
+        this.setSafeContent(unsafeRawHtml(
+          this.renderWorldBrief(serverInsights.worldBrief, InsightsPanel.serverBriefSources(serverInsights)),
+          'renderWorldBrief formats and links the server summary (#7118 pre-sentiment paint)',
+        ));
+      }
+
       let sentiments: Array<{ label: string; score: number }> | null = null;
       if (mlWorker.isAvailable) {
         sentiments = await mlWorker.classifySentiment(titles).catch(() => null);
@@ -530,13 +585,7 @@ export class InsightsPanel extends Panel {
     insights: ServerInsights,
     sentiments: Array<{ label: string; score: number }> | null,
   ): void {
-    // #4928 external review: the synthesis cites up to 8 stories — a
-    // 6-source cap orphaned [7]/[8]. Cap to the payload's own citation
-    // index space (bounded at 12 defensively).
-    const worldBriefSources = collectBriefSources(
-      insights.worldBriefSources ?? [],
-      Math.min(12, Math.max(6, insights.worldBriefSources?.length ?? 6)),
-    );
+    const worldBriefSources = InsightsPanel.serverBriefSources(insights);
     const briefHtml = insights.worldBrief
       ? this.renderWorldBrief(insights.worldBrief, worldBriefSources, this.renderBriefExtras(insights))
       : '';

--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -10,7 +10,7 @@ import { getTheaterPostureSummaries } from '@/services/military-surge';
 import { getCachedPosture } from '@/services/cached-theater-posture';
 import { isMobileDevice } from '@/utils';
 import { escapeHtml, sanitizeUrl, unsafeRawHtml } from '@/utils/sanitize';
-import { collectBriefSources, normalizeCachedBriefSources, renderBriefSourcesFooter, type BriefSource } from '@/utils/brief-sources';
+import { collectBriefCitationSources, collectBriefSources, normalizeCachedBriefSources, renderBriefSourcesFooter, type BriefSource } from '@/utils/brief-sources';
 import { formatIntelBrief } from '@/utils/format-intel-brief';
 import { SITE_VARIANT } from '@/config';
 import { deletePersistentCache, getPersistentCache, setPersistentCache } from '@/services/persistent-cache';
@@ -136,7 +136,7 @@ export class InsightsPanel extends Panel {
    * the early paint (#7118) and the full render.
    */
   private static serverBriefSources(insights: ServerInsights): BriefSource[] {
-    return collectBriefSources(
+    return collectBriefCitationSources(
       insights.worldBriefSources ?? [],
       Math.min(
         InsightsPanel.BRIEF_CACHE_MAX_SOURCES,

--- a/src/utils/brief-sources.ts
+++ b/src/utils/brief-sources.ts
@@ -42,6 +42,21 @@ export function collectBriefSources(
   return collectInsightSources(candidates, maxSources);
 }
 
+/**
+ * Preserve the producer's positional citation slots. The seeded World Brief
+ * assigns source n to citation [n], including an empty-url fallback when a
+ * story has no usable link. Citation rendering must retain those slots even
+ * when the footer later filters sources for display.
+ */
+export function collectBriefCitationSources(
+  candidates: BriefSourceCandidate[],
+  maxSources = DEFAULT_MAX_SOURCES,
+): BriefSource[] {
+  return candidates.slice(0, Math.max(0, maxSources)).map((candidate) =>
+    normalizeInsightSource(candidate, { allowEmptyUrl: true }) ?? { title: '', source: '', url: '' },
+  );
+}
+
 export function normalizeCachedBriefSources(
   cacheData: { sources?: BriefSourceCandidate[] } | undefined,
   maxSources = DEFAULT_MAX_SOURCES,

--- a/tests/dom/insights-brief-cold-early-paint.test.mts
+++ b/tests/dom/insights-brief-cold-early-paint.test.mts
@@ -64,6 +64,7 @@ import type { ServerInsights } from '@/services/insights-loader';
 const CONTENT_DEBOUNCE_MS = 150;
 
 const BRIEF = 'SITUATION NOW\nRussian strikes on Kyiv continued for a third night [1].';
+const BRIEF_WITH_SOURCE_GAP = 'SITUATION NOW\nReuters reported the second source event [2].';
 
 function serverInsights(overrides: Partial<ServerInsights> = {}): ServerInsights {
   return {
@@ -122,6 +123,33 @@ describe('cold-visitor early brief paint (#7118)', () => {
     const brief = contentOf(panel).querySelector('.insights-brief-text');
     expect(brief, 'the cold visitor must get the bootstrap brief at construction time').not.toBeNull();
     expect(brief?.textContent).toContain('Russian strikes on Kyiv');
+    panel.destroy();
+  });
+
+  it('preserves source positions for citations when an earlier source has no URL', async () => {
+    mockGetPersistentCache.mockResolvedValue(null);
+    mockGetServerInsights.mockReturnValue(serverInsights({
+      worldBrief: BRIEF_WITH_SOURCE_GAP,
+      worldBriefSources: [
+        { title: 'Missing-link source', source: 'Unknown', url: '' },
+        { title: 'Reuters report', source: 'Reuters', url: 'https://example.com/second' },
+      ],
+    }));
+    mockClassifySentiment.mockResolvedValue(null);
+
+    const panel = new InsightsPanel();
+    await flushEarlyPaint();
+
+    const earlyCitation = contentOf(panel).querySelector<HTMLAnchorElement>('.cb-citation');
+    expect(earlyCitation?.textContent).toBe('[2]');
+    expect(earlyCitation?.href).toBe('https://example.com/second');
+
+    await panel.updateInsights([]);
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+
+    const fullCitation = contentOf(panel).querySelector<HTMLAnchorElement>('.cb-citation');
+    expect(fullCitation?.textContent).toBe('[2]');
+    expect(fullCitation?.href).toBe('https://example.com/second');
     panel.destroy();
   });
 

--- a/tests/dom/insights-brief-cold-early-paint.test.mts
+++ b/tests/dom/insights-brief-cold-early-paint.test.mts
@@ -1,0 +1,249 @@
+/**
+ * #7118: cold visitors must get the World Brief from the bootstrap payload.
+ *
+ * The World Brief is the field LCP element on ~38% of /dashboard desktop views
+ * and paints at p75 ~3.5s, against ~0.8s for the bootstrap skeleton copy it
+ * displaces — two thirds of the field LCP regression diagnosed in #7113
+ * (docs/perf/field-lcp-dashboard-2026-08-24.md).
+ *
+ * #4890 added an early paint, but it reads ONLY the IndexedDB persistent
+ * cache, so it helps repeat visitors and does nothing for cold ones — even
+ * though `insights` rides the FAST bootstrap tier
+ * (api/_bootstrap-tier-keys.js:61,180) and `getServerInsights()` already has
+ * `worldBrief` in hand.
+ *
+ * These are behavioural tests, not source greps: they construct the panel and
+ * assert on rendered DOM. Lives under tests/dom/ because `Panel` needs a DOM
+ * and `@/services/i18n`'s `import.meta.glob` graph, both unreachable from the
+ * `tsx --test` profile.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { initTestI18n } from './helpers/i18n.mts';
+
+const {
+  mockGetPersistentCache,
+  mockSetPersistentCache,
+  mockDeletePersistentCache,
+  mockGetServerInsights,
+  mockFetchServerInsights,
+  mockClassifySentiment,
+  mlWorkerStub,
+} = vi.hoisted(() => {
+  const mockClassifySentiment = vi.fn();
+  return {
+    mockGetPersistentCache: vi.fn(),
+    mockSetPersistentCache: vi.fn(),
+    mockDeletePersistentCache: vi.fn(),
+    mockGetServerInsights: vi.fn(),
+    mockFetchServerInsights: vi.fn(),
+    mockClassifySentiment,
+    mlWorkerStub: { isAvailable: true, classifySentiment: mockClassifySentiment },
+  };
+});
+
+vi.mock('@/services/persistent-cache', () => ({
+  getPersistentCache: mockGetPersistentCache,
+  setPersistentCache: mockSetPersistentCache,
+  deletePersistentCache: mockDeletePersistentCache,
+  deletePersistentCacheByPrefix: vi.fn(),
+}));
+
+vi.mock('@/services/insights-loader', () => ({
+  getServerInsights: mockGetServerInsights,
+  fetchServerInsights: mockFetchServerInsights,
+  MAX_AGE_MS: 3_600_000,
+}));
+
+vi.mock('@/services/ml-worker', () => ({ mlWorker: mlWorkerStub }));
+
+import { InsightsPanel } from '@/components/InsightsPanel';
+import type { ServerInsights } from '@/services/insights-loader';
+
+const CONTENT_DEBOUNCE_MS = 150;
+
+const BRIEF = 'SITUATION NOW\nRussian strikes on Kyiv continued for a third night [1].';
+
+function serverInsights(overrides: Partial<ServerInsights> = {}): ServerInsights {
+  return {
+    worldBrief: BRIEF,
+    worldBriefSources: [{ title: 'Reuters report', source: 'Reuters', url: 'https://example.com/a' }],
+    briefProvider: 'test',
+    status: 'ok',
+    topStories: [],
+    generatedAt: new Date().toISOString(),
+    clusterCount: 3,
+    multiSourceCount: 2,
+    fastMovingCount: 1,
+    ...overrides,
+  } as ServerInsights;
+}
+
+function contentOf(panel: object): HTMLElement {
+  return (panel as unknown as { content: HTMLElement }).content;
+}
+
+/** Let the constructor's floating early-paint promise settle, then commit the debounce. */
+async function flushEarlyPaint(): Promise<void> {
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
+  vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+}
+
+beforeAll(async () => {
+  await initTestI18n();
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockGetPersistentCache.mockReset();
+  mockSetPersistentCache.mockReset().mockResolvedValue(undefined);
+  mockDeletePersistentCache.mockReset().mockResolvedValue(undefined);
+  mockGetServerInsights.mockReset();
+  mockFetchServerInsights.mockReset();
+  mockClassifySentiment.mockReset();
+  mlWorkerStub.isAvailable = true;
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.useRealTimers();
+});
+
+describe('cold-visitor early brief paint (#7118)', () => {
+  it('paints the bootstrap world brief when the persistent cache is empty', async () => {
+    // A cold visitor: nothing in IndexedDB, but the FAST bootstrap tier landed.
+    mockGetPersistentCache.mockResolvedValue(null);
+    mockGetServerInsights.mockReturnValue(serverInsights());
+
+    const panel = new InsightsPanel();
+    await flushEarlyPaint();
+
+    const brief = contentOf(panel).querySelector('.insights-brief-text');
+    expect(brief, 'the cold visitor must get the bootstrap brief at construction time').not.toBeNull();
+    expect(brief?.textContent).toContain('Russian strikes on Kyiv');
+    panel.destroy();
+  });
+
+  it('still prefers the persistent cache when one exists', async () => {
+    mockGetPersistentCache.mockResolvedValue({
+      data: { summary: 'CACHED BRIEF from the previous visit.', sources: [] },
+      updatedAt: Date.now(),
+    });
+    mockGetServerInsights.mockReturnValue(serverInsights());
+
+    const panel = new InsightsPanel();
+    await flushEarlyPaint();
+
+    const text = contentOf(panel).querySelector('.insights-brief-text')?.textContent ?? '';
+    expect(text, 'the cache read must win — it is the cheaper path and #4890 owns it').toContain('CACHED BRIEF');
+    expect(mockGetServerInsights, 'no bootstrap read is needed once the cache hits').not.toHaveBeenCalled();
+    panel.destroy();
+  });
+
+  it('paints nothing when the cache misses and the bootstrap payload has not landed', async () => {
+    mockGetPersistentCache.mockResolvedValue(null);
+    mockGetServerInsights.mockReturnValue(null);
+
+    const panel = new InsightsPanel();
+    await flushEarlyPaint();
+
+    expect(contentOf(panel).querySelector('.insights-brief-text')).toBeNull();
+    panel.destroy();
+  });
+
+  it('does not clobber a real update that started during the async cache read', async () => {
+    let releaseCache!: (value: null) => void;
+    mockGetPersistentCache.mockReturnValue(new Promise<null>((res) => { releaseCache = res; }));
+    mockGetServerInsights.mockReturnValue(serverInsights());
+
+    const panel = new InsightsPanel();
+    // A real update pass starts while the early paint is awaiting the cache.
+    void panel.updateInsights([]);
+    releaseCache(null);
+    await flushEarlyPaint();
+
+    // The early paint must have bailed on the post-await generation re-check
+    // rather than landing stale brief-only content over the real pass.
+    const badge = (panel as unknown as { element: HTMLElement }).element
+      .querySelector('.panel-data-badge')?.textContent ?? '';
+    expect(badge.toLowerCase()).not.toContain('cached');
+    panel.destroy();
+  });
+});
+
+describe('server render does not hold the brief behind sentiment (#7118)', () => {
+  it('paints the brief before ML sentiment classification resolves', async () => {
+    mockGetPersistentCache.mockResolvedValue(null);
+    // The bootstrap payload lands BETWEEN panel construction and the first
+    // update — a real cold sequence, and the only one that isolates this
+    // paint from the constructor's early paint (#7118 U1). Without the
+    // `Once`, the early paint would satisfy the assertion and the test would
+    // pass no matter what updateFromServer does.
+    mockGetServerInsights.mockReturnValueOnce(null).mockReturnValue(serverInsights());
+
+    let releaseSentiment!: (value: null) => void;
+    mockClassifySentiment.mockReturnValue(new Promise<null>((res) => { releaseSentiment = res; }));
+
+    const panel = new InsightsPanel();
+    await flushEarlyPaint();
+    expect(
+      contentOf(panel).querySelector('.insights-brief-text'),
+      'guard: the constructor must NOT have painted, or this test proves nothing',
+    ).toBeNull();
+
+    // updateInsights → updateFromServer, which awaits classifySentiment.
+    const pending = panel.updateInsights([]);
+    for (let i = 0; i < 20; i += 1) await Promise.resolve();
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+
+    const brief = contentOf(panel).querySelector('.insights-brief-text');
+    expect(brief, 'the brief is already in hand — it must not wait on the sentiment worker').not.toBeNull();
+    expect(brief?.textContent).toContain('Russian strikes on Kyiv');
+
+    releaseSentiment(null);
+    await pending;
+    panel.destroy();
+  });
+
+  it('shows the brief, not a progress bar, while a REFRESH waits on sentiment', async () => {
+    // updateFromServer already calls setProgress() twice before the sentiment
+    // await, so a refresh replaces live content with a progress bar no matter
+    // what this test does. The pre-sentiment paint therefore never costs the
+    // user rendered content — it upgrades that window from a progress bar to
+    // the brief. Pin that, so a future change cannot turn this into the
+    // content-clobbering refetch bug tests/dom/china-panel-refetch.test.mts
+    // guards the China panels against.
+    mockGetPersistentCache.mockResolvedValue(null);
+    mockGetServerInsights.mockReturnValue(serverInsights());
+    mockClassifySentiment.mockResolvedValue(null);
+
+    const panel = new InsightsPanel();
+    await flushEarlyPaint();
+
+    // First pass renders fully.
+    await panel.updateInsights([]);
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+    expect(contentOf(panel).querySelector('.insights-stats')).not.toBeNull();
+
+    // Refresh, with sentiment now hanging.
+    let releaseSentiment!: (value: null) => void;
+    mockClassifySentiment.mockReturnValue(new Promise<null>((res) => { releaseSentiment = res; }));
+    const pending = panel.updateInsights([]);
+    for (let i = 0; i < 20; i += 1) await Promise.resolve();
+    vi.advanceTimersByTime(CONTENT_DEBOUNCE_MS);
+
+    expect(
+      contentOf(panel).querySelector('.insights-brief-text'),
+      'the refresh window must show the brief',
+    ).not.toBeNull();
+    expect(
+      contentOf(panel).querySelector('.insights-progress'),
+      'the brief must have superseded the progress bar, not landed beside it',
+    ).toBeNull();
+
+    releaseSentiment(null);
+    await pending;
+    panel.destroy();
+  });
+});

--- a/tests/insights-brief-early-paint.test.mts
+++ b/tests/insights-brief-early-paint.test.mts
@@ -38,7 +38,7 @@ describe('InsightsPanel early cached-brief paint (#4890)', () => {
     );
     assert.match(
       method,
-      /await this\.loadBriefFromCache\(\);[\s\S]*?if \(this\.updateGeneration > 0 \|\| !this\.cachedBrief\) return;/,
+      /await this\.loadBriefFromCache\(\);\s*if \(this\.updateGeneration > 0\) return;/,
       'must re-check updateGeneration AFTER the async cache read — updateInsights() may have started during the await',
     );
     assert.match(
@@ -48,8 +48,40 @@ describe('InsightsPanel early cached-brief paint (#4890)', () => {
     );
     assert.match(
       method,
-      /this\.renderWorldBrief\(this\.cachedBrief, this\.cachedBriefSources\)/,
+      /this\.renderWorldBrief\(brief, sources\)/,
       'the early paint must reuse renderWorldBrief (it formats and links the cached summary)',
+    );
+  });
+
+  // #7118: the cache-only early paint helped repeat visitors and did nothing
+  // on a cold visit, so the brief still became the field LCP element at
+  // p75 ~3.5s (#7113). Behavioural coverage lives in
+  // tests/dom/insights-brief-cold-early-paint.test.mts; this pins the ordering
+  // contract the DOM test cannot see — that the cache is tried FIRST and the
+  // bootstrap read only happens on a miss.
+  it('falls back to the hydrated bootstrap brief only after the cache misses (#7118)', () => {
+    const method = sliceBetween('private async paintCachedBriefEarly()', 'private extractISQInput');
+    assert.match(
+      method,
+      /await this\.loadBriefFromCache\(\);[\s\S]*?if \(!brief\) \{[\s\S]*?getServerInsights\(\)/,
+      'the bootstrap read must sit behind the cache miss — the cache is the cheaper path and #4890 owns it',
+    );
+    assert.match(
+      method,
+      /sources = InsightsPanel\.serverBriefSources\(server\)/,
+      'the server fallback must use the shared citation bound, not a fresh literal that can drift from renderServerInsights',
+    );
+  });
+
+  it('does not hold the server brief behind the sentiment worker (#7118)', () => {
+    const method = sliceBetween('private async updateFromServer(', 'private async updateFromClient(');
+    const paintIdx = method.indexOf("#7118 pre-sentiment paint");
+    const sentimentIdx = method.indexOf('await mlWorker.classifySentiment');
+    assert.notEqual(paintIdx, -1, 'updateFromServer must paint the brief before classifying sentiment');
+    assert.notEqual(sentimentIdx, -1, 'slice must still contain the sentiment await');
+    assert.ok(
+      paintIdx < sentimentIdx,
+      'the brief paint must come BEFORE the sentiment await — classifySentiment can cost seconds while the ONNX model loads',
     );
   });
 


### PR DESCRIPTION
Closes #7118. Implements the ~⅔ half of the field LCP regression diagnosed in #7113 (#7114 is the verdict doc).

## The gap

The World Brief is the field LCP element on ~38% of `/dashboard` desktop views and paints at **p75 ≈ 3.5 s**, against ≈0.8 s for the bootstrap skeleton copy it displaces.

`insights` already rides the **fast** bootstrap tier (`api/_bootstrap-tier-keys.js:61,180`), so the brief is in hand early. Two places threw that away:

| | Before | After |
|---|---|---|
| `paintCachedBriefEarly()` (#4890) | Read **only** the IndexedDB cache, which exists for repeat visitors. A cold visitor got nothing until the whole pipeline resolved. | Falls back to `getServerInsights()` on a cache miss. The cache still wins when present — cheaper read, no bootstrap payload needed. |
| `updateFromServer()` | Held the brief behind `await mlWorker.classifySentiment(...)`, which can cost seconds on first use while the ONNX model loads. | Paints the brief **before** that await. The full render supersedes it. |

Both server-brief paths now share `serverBriefSources()`, so the #4928 citation bound cannot drift between the early paint and the full render.

## Measured before-state

Instrumented a real cold load via `page.addInitScript` (marks in ms from navigation start):

```
fcp                     300
insightsContent in DOM 1006   ← panel mounts, shows progress
briefText in DOM       1334   ← same instant as stats: no separate early paint
statsInDom             1334
```

The brief and the stats land together — the #4890 early paint contributed nothing on that load, which is exactly what #7118 describes. (This machine is far faster than p75; it shows the *shape*, not the magnitude.)

## Tests

`tests/dom/insights-brief-cold-early-paint.test.mts` is **behavioural** — it constructs the panel and asserts on rendered DOM, not on source text.

Both production changes were **mutated away individually** and each killed its own test:

- remove the pre-sentiment paint → only "paints the brief before ML sentiment classification resolves" fails
- remove the server fallback → "paints the bootstrap world brief when the persistent cache is empty" fails

Three control cases keep the suite from going vacuous: the cache still wins when present, nothing paints when both sources miss, and the early paint still bails when a real update races the cache read. The cold-sequence test asserts the constructor did **not** paint before exercising `updateFromServer`, so it cannot pass by accident.

A sixth test pins that the pre-sentiment paint **supersedes the progress bar `setProgress` already wrote** — so a refresh never loses rendered content. That is the regression `tests/dom/china-panel-refetch.test.mts` guards the China panels against, and it was the one real risk in this diff.

## Verification — this cannot be verified in the lab

**64 of 65** DebugBear lab runs on `/dashboard` desktop report `largestContentfulPaint` exactly equal to `firstContentfulPaint`: the synthetic run settles before the brief renders, so lab LCP is structurally blind to this. Verify against the DebugBear `rumPageViews` LCP-element breakdown — either the `#insightsContent` cohort's p75 falls from ~3506 ms, or its share of LCP attributions falls because the skeleton wins again at ≈0.8 s. CrUX needs ~28 days to reflect it.

Method, API recipes, and five traps that silently return wrong data: `docs/perf/field-lcp-dashboard-2026-08-24.md` (#7114).

## Local verification

`test:dom` **462/462 pass** (full suite), `tsc --noEmit` clean, `biome lint` clean on the changed files, `enforce-panel-content-writes` and `enforce-safe-html` pass, and the full pre-push gate passed.

Two notes for the reviewer:

1. The code comments reference `docs/perf/field-lcp-dashboard-2026-08-24.md`, which lands with #7114 — a forward reference until that merges.
2. No `ce-code-review` subagent pass was run (subagent dispatch is disabled in this session). I reviewed the diff myself; the refresh-clobber risk it surfaced is the sixth test above.

https://claude.ai/code/session_016y1NdeysF21ktmaayUWXNp
