### PR TITLE
fix(guards): harden symlinked CI gate entrypoints

### DIFF
--- a/scripts/check-local-secret-dumps.mjs
+++ b/scripts/check-local-secret-dumps.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process';
 import { readFileSync, readdirSync } from 'node:fs';
-import { pathToFileURL } from 'node:url';
+
+import { isMainModule } from './lib/main-module.mjs';
 
 export const FORBIDDEN_LOCAL_ENV_DUMPS = [
   '.env.vercel-backup',
@@ -175,11 +176,7 @@ export function runLocalSecretDumpCheck(
   }
 }
 
-const isDirectRun = process.argv[1]
-  ? import.meta.url === pathToFileURL(process.argv[1]).href
-  : false;
-
-if (isDirectRun) {
+if (isMainModule(import.meta.url, process.argv[1])) {
   try {
     const prePushFlagIndex = process.argv.indexOf('--pre-push');
     const prePushInput = prePushFlagIndex >= 0 ? readFileSync(0, 'utf8') : '';

--- a/scripts/check-vite-env-secrets.mjs
+++ b/scripts/check-vite-env-secrets.mjs
@@ -2,7 +2,8 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+
+import { isMainModule } from './lib/main-module.mjs';
 
 const VITE_ENV_NAME = /^VITE_[A-Za-z0-9_]+$/;
 const SECRET_NAME = /(?:api_?key|access_?token|secret|token|password|private_?key|credential)/i;
@@ -76,8 +77,7 @@ export function runViteEnvSecretGuard(rootDir = process.cwd(), options = {}) {
   }
 }
 
-const isDirectRun = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
-if (isDirectRun) {
+if (isMainModule(import.meta.url, process.argv[1])) {
   try {
     runViteEnvSecretGuard(process.cwd(), { failOnLocal: process.argv.includes('--strict-local') });
   } catch (error) {

--- a/scripts/enforce-panel-content-writes.mjs
+++ b/scripts/enforce-panel-content-writes.mjs
@@ -30,7 +30,9 @@
 
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+
+import { isMainModule } from './lib/main-module.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -349,6 +351,6 @@ function main() {
   );
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isMainModule(import.meta.url, process.argv[1])) {
   main();
 }

--- a/scripts/enforce-safe-html.mjs
+++ b/scripts/enforce-safe-html.mjs
@@ -2,7 +2,9 @@
 import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+
+import { isMainModule } from './lib/main-module.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
@@ -206,6 +208,6 @@ function main() {
   process.exitCode = 1;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isMainModule(import.meta.url, process.argv[1])) {
   main();
 }

--- a/tests/main-module-gates.test.mjs
+++ b/tests/main-module-gates.test.mjs
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MAIN_MODULE_HELPER = join(REPO_ROOT, 'scripts/lib/main-module.mjs');
+const INLINE_MAIN_GUARD = /(?:import\.meta\.url\s*===\s*pathToFileURL\s*\(\s*process\.argv\s*\[\s*1\s*\]\s*\)\.href|pathToFileURL\s*\(\s*process\.argv\s*\[\s*1\s*\]\s*\)\.href\s*===\s*import\.meta\.url)/;
+
+const GATES = [
+  {
+    file: 'scripts/enforce-safe-html.mjs',
+    setup(root) {
+      mkdirSync(join(root, 'src'), { recursive: true });
+      writeFileSync(
+        join(root, 'src/fixture.ts'),
+        'const element = document.createElement("div");\nelement.innerHTML = userHtml;\n',
+      );
+    },
+    expected: /Direct innerHTML\/outerHTML assignment is blocked/,
+  },
+  {
+    file: 'scripts/enforce-panel-content-writes.mjs',
+    setup(root) {
+      mkdirSync(join(root, 'src/components'), { recursive: true });
+      writeFileSync(
+        join(root, 'src/components/FailingPanel.ts'),
+        'class FailingPanel extends Panel { render() { this.content.appendChild(document.createElement("div")); } }\n',
+      );
+    },
+    expected: /Panel content-write guard failed/,
+  },
+  {
+    file: 'scripts/check-local-secret-dumps.mjs',
+    setup(root) {
+      writeFileSync(join(root, '.env.vercel-backup'), 'do-not-use\n');
+    },
+    expected: /local environment dump files are present/,
+  },
+  {
+    file: 'scripts/check-vite-env-secrets.mjs',
+    setup(root) {
+      writeFileSync(join(root, '.env.example'), 'VITE_SERVICE_TOKEN=do-not-use\n');
+    },
+    expected: /VITE_SERVICE_TOKEN/,
+  },
+];
+
+function createSymlinkedGateFixture(gate) {
+  const root = mkdtempSync(join(tmpdir(), 'wm-main-module-gate-'));
+  const scriptPath = join(root, gate.file);
+  mkdirSync(dirname(scriptPath), { recursive: true });
+  mkdirSync(join(root, 'scripts/lib'), { recursive: true });
+  copyFileSync(join(REPO_ROOT, gate.file), scriptPath);
+  copyFileSync(MAIN_MODULE_HELPER, join(root, 'scripts/lib/main-module.mjs'));
+  gate.setup(root);
+
+  const linkedRoot = join(root, 'linked-checkout');
+  symlinkSync(root, linkedRoot, 'dir');
+  return { root, linkedScript: join(linkedRoot, gate.file) };
+}
+
+function newlyAddedGateFiles() {
+  const files = new Set();
+  const gitCommands = [
+    ['diff', '--name-only', '--diff-filter=A', 'origin/main...HEAD', '--', 'scripts'],
+    ['diff', '--cached', '--name-only', '--diff-filter=A', '--', 'scripts'],
+    ['diff', '--name-only', '--diff-filter=A', '--', 'scripts'],
+    ['ls-files', '--others', '--exclude-standard', '--', 'scripts'],
+  ];
+
+  for (const args of gitCommands) {
+    try {
+      for (const file of execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' }).split(/\r?\n/)) {
+        if (/^scripts\/(?:enforce|check|audit)-[^/]+\.mjs$/.test(file)) files.add(file);
+      }
+    } catch {
+      // A source archive or shallow checkout may not have the comparison ref.
+    }
+  }
+
+  return [...files].sort();
+}
+
+describe('CI gate main-module guards (#7122)', () => {
+  it('requires every affected gate to use the shared realpath-safe helper', () => {
+    for (const gate of GATES) {
+      const source = readFileSync(join(REPO_ROOT, gate.file), 'utf8');
+      assert.match(
+        source,
+        /import \{ isMainModule \} from ['"]\.\/lib\/main-module\.mjs['"];?/,
+        `${gate.file} must import scripts/lib/main-module.mjs`,
+      );
+      assert.match(
+        source,
+        /isMainModule\(import\.meta\.url, process\.argv\[1\]\)/,
+        `${gate.file} must use isMainModule for its entrypoint`,
+      );
+      assert.doesNotMatch(
+        source,
+        /import\.meta\.url\s*===\s*pathToFileURL\(process\.argv\[1\]\)\.href/,
+        `${gate.file} must not use the symlink-unsafe inline entrypoint check`,
+      );
+    }
+  });
+
+  it('rejects the symlink-unsafe inline guard in newly added gate CLIs', () => {
+    for (const file of newlyAddedGateFiles()) {
+      const source = readFileSync(join(REPO_ROOT, file), 'utf8');
+      assert.doesNotMatch(
+        source,
+        INLINE_MAIN_GUARD,
+        `${file} must use scripts/lib/main-module.mjs instead of an inline entrypoint check`,
+      );
+    }
+  });
+
+  it('recognizes both comparison directions of the inline guard', () => {
+    assert.match(
+      'import.meta.url === pathToFileURL(process.argv[1]).href',
+      INLINE_MAIN_GUARD,
+    );
+    assert.match(
+      'pathToFileURL(process.argv[1]).href === import.meta.url',
+      INLINE_MAIN_GUARD,
+    );
+  });
+
+  it('keeps the new-gate policy test non-vacuous with unsafe and safe fixtures', () => {
+    for (const source of [
+      'if (import.meta.url === pathToFileURL(process.argv[1]).href) main();',
+      'if (pathToFileURL(process.argv[1]).href === import.meta.url) main();',
+    ]) {
+      assert.match(source, INLINE_MAIN_GUARD);
+    }
+    assert.doesNotMatch(
+      "import { isMainModule } from './lib/main-module.mjs';\nif (isMainModule(import.meta.url, process.argv[1])) main();",
+      INLINE_MAIN_GUARD,
+    );
+  });
+
+  it('executes every affected gate through a symlinked checkout', (t) => {
+    for (const gate of GATES) {
+      let fixture;
+      try {
+        fixture = createSymlinkedGateFixture(gate);
+      } catch (error) {
+        if (error?.code === 'EPERM' || error?.code === 'EACCES') {
+          t.skip('symlink creation is unavailable in this environment');
+          return;
+        }
+        throw error;
+      }
+
+      try {
+        const result = spawnSync(process.execPath, [fixture.linkedScript], {
+          cwd: fixture.root,
+          encoding: 'utf8',
+        });
+        const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+
+        assert.equal(result.status, 1, `${gate.file} must fail its fixture through a symlink`);
+        assert.match(output, gate.expected, `${gate.file} did not report its fixture failure`);
+        assert.notEqual(output.trim(), '', `${gate.file} silently exited without running`);
+      } finally {
+        rmSync(fixture.root, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -99,13 +99,17 @@ function makeFixture({
   const env = hookEnv(bin);
   const git = (args) => execFileSync('git', args, { cwd: root, env, encoding: 'utf8' });
 
-  for (const dir of ['.husky', 'scripts', 'tests', 'node_modules']) {
+  for (const dir of ['.husky', 'scripts', 'scripts/lib', 'tests', 'node_modules']) {
     mkdirSync(join(root, dir), { recursive: true });
   }
   copyFileSync(HOOK, join(root, '.husky', 'pre-push'));
   for (const script of ['prepush-admission.mjs', 'prepush-attest.sh', 'prepush-changed-tests.sh']) {
     copyFileSync(join(REPO_ROOT, 'scripts', script), join(root, 'scripts', script));
   }
+  copyFileSync(
+    join(REPO_ROOT, 'scripts', 'lib', 'main-module.mjs'),
+    join(root, 'scripts', 'lib', 'main-module.mjs'),
+  );
   // Fault injection: make one attest mode fail while its siblings still work,
   // so the hook's handling of a broken enumeration can be executed rather than
   // reasoned about.
@@ -226,7 +230,7 @@ function pushWithPoisonedSharedHooksPath() {
   git(main, ['config', 'user.name', 'Prepush Hook Fixture']);
   git(main, ['remote', 'add', 'origin', remote]);
 
-  for (const dir of ['.husky', 'scripts', 'node_modules']) {
+  for (const dir of ['.husky', 'scripts', 'scripts/lib', 'node_modules']) {
     mkdirSync(join(main, dir), { recursive: true });
   }
   copyFileSync(HOOK, join(main, '.husky', 'pre-push'));
@@ -239,6 +243,10 @@ function pushWithPoisonedSharedHooksPath() {
   ]) {
     copyFileSync(join(REPO_ROOT, 'scripts', script), join(main, 'scripts', script));
   }
+  copyFileSync(
+    join(REPO_ROOT, 'scripts', 'lib', 'main-module.mjs'),
+    join(main, 'scripts', 'lib', 'main-module.mjs'),
+  );
   writeFileSync(join(main, 'package.json'), '{"name":"fixture"}\n');
   writeFileSync(join(main, 'README.md'), 'base\n');
   git(main, ['add', '-A']);


### PR DESCRIPTION
## Summary

Four security and CI gates could report a clean exit without running when invoked through a symlinked checkout. They now use the shared realpath-safe entrypoint helper, so the gates execute and report their actual result in that environment.

The regression suite runs each gate through a symlinked path with a deliberately failing fixture, and prevents the known unsafe inline guard from returning in newly added gate CLIs.

Fixes #7122

## Validation

- `node --test tests/main-module-gates.test.mjs tests/safe-html-guard.test.mjs tests/local-secret-dumps-check.test.mjs tests/vite-env-secret-guard.test.mjs` (33 passed)
- `npm run typecheck`
- `npm run lint` (passes; existing diagnostics remain)
- Pre-push checks: API typecheck, Unicode safety, all applicable guard checks, changed-test execution, and version check passed.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this change affects local and CI guard entrypoints only, not deployed runtime code. The next CI or pre-push execution should emit each gate's result; a zero-output exit from a symlinked invocation is the failure signal.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/MODEL_SLUG-GPT--5-black)
