### PR TITLE
fix(route-explorer): reset loading state on close

### DIFF
--- a/src/components/RouteExplorer/RouteExplorer.ts
+++ b/src/components/RouteExplorer/RouteExplorer.ts
@@ -141,6 +141,7 @@ export class RouteExplorer {
   public close(): void {
     if (!this.isOpen || !this.root) return;
     this.generationId++;
+    this.isLoading = false;
     if (this.debounceTimer) { clearTimeout(this.debounceTimer); this.debounceTimer = null; }
     document.removeEventListener('keydown', this.handleGlobalKeydown, { capture: true });
     this.helpOverlay?.element.remove();

--- a/tests/dom/route-explorer-loading.test.mts
+++ b/tests/dom/route-explorer-loading.test.mts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { GetRouteExplorerLaneResponse } from '@/generated/server/worldmonitor/supply_chain/v1/service_server';
+
+const {
+  fetchRouteExplorerLane,
+  fetchRouteImpact,
+  getResilienceScore,
+  getAuthState,
+  hasPremiumAccess,
+  track,
+  trackGateHit,
+} = vi.hoisted(() => ({
+  fetchRouteExplorerLane: vi.fn(),
+  fetchRouteImpact: vi.fn(),
+  getResilienceScore: vi.fn(),
+  getAuthState: vi.fn(() => ({ user: null, isPending: false })),
+  hasPremiumAccess: vi.fn(() => true),
+  track: vi.fn(),
+  trackGateHit: vi.fn(),
+}));
+
+vi.mock('@/services/supply-chain', () => ({
+  fetchRouteExplorerLane,
+  fetchRouteImpact,
+}));
+
+vi.mock('@/services/resilience', () => ({ getResilienceScore }));
+vi.mock('@/services/auth-state', () => ({ getAuthState }));
+vi.mock('@/services/panel-gating', () => ({ hasPremiumAccess }));
+vi.mock('@/services/analytics', () => ({ track, trackGateHit }));
+
+import { RouteExplorer } from '@/components/RouteExplorer/RouteExplorer';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function laneFixture(): GetRouteExplorerLaneResponse {
+  return {
+    fromIso2: 'US',
+    toIso2: 'DE',
+    hs2: '27',
+    cargoType: 'EXPLORER_CARGO_CONTAINER',
+    primaryRouteId: '',
+    primaryRouteGeometry: [],
+    chokepointExposures: [],
+    bypassOptions: [],
+    warRiskTier: 'WAR_RISK_TIER_NORMAL',
+    disruptionScore: 12,
+    estTransitDaysRange: { min: 14, max: 18 },
+    estFreightUsdPerTeuRange: { min: 1800, max: 2400 },
+    noModeledLane: false,
+    fetchedAt: '2026-08-24T00:00:00.000Z',
+  };
+}
+
+describe('RouteExplorer loading lifecycle', () => {
+  let explorer: RouteExplorer;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.replaceChildren();
+    window.history.replaceState({}, '', '/?explorer=from:US,to:DE,hs:27');
+    fetchRouteExplorerLane.mockReset();
+    fetchRouteImpact.mockReset();
+    getResilienceScore.mockReset();
+    track.mockReset();
+    trackGateHit.mockReset();
+    explorer = new RouteExplorer();
+  });
+
+  afterEach(() => {
+    if (explorer.isOpenNow()) explorer.close();
+    document.body.replaceChildren();
+    vi.useRealTimers();
+  });
+
+  it('clears loading across close-before-settle and reopen', async () => {
+    const firstLoad = deferred<GetRouteExplorerLaneResponse>();
+    const secondLoad = deferred<GetRouteExplorerLaneResponse>();
+    fetchRouteExplorerLane
+      .mockReturnValueOnce(firstLoad.promise)
+      .mockReturnValueOnce(secondLoad.promise);
+
+    explorer.open();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(fetchRouteExplorerLane).toHaveBeenCalledOnce();
+    expect(explorer.isLoading).toBe(true);
+    expect(document.querySelector('.re-content__loading')).not.toBeNull();
+
+    explorer.close();
+    expect(explorer.isLoading).toBe(false);
+    explorer.open();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(fetchRouteExplorerLane).toHaveBeenCalledTimes(2);
+    expect(explorer.isLoading).toBe(true);
+    expect(document.querySelector('.re-content__loading')).not.toBeNull();
+
+    firstLoad.resolve(laneFixture());
+    await vi.runAllTimersAsync();
+
+    expect(explorer.isOpenNow()).toBe(true);
+    expect(explorer.isLoading).toBe(true);
+    expect(document.querySelector('.re-content__loading')).not.toBeNull();
+
+    secondLoad.resolve(laneFixture());
+    await vi.runAllTimersAsync();
+
+    expect(explorer.isLoading).toBe(false);
+    expect(document.querySelector('.re-content__loading')).toBeNull();
+    expect(document.querySelector('.re-current__summary')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closing and reopening Route Explorer while its lane request was pending could leave the modal stuck on the loading state, so the next open never recovered. Closing now clears the loading state when it invalidates the pending generation, while late responses remain ignored for the reopened generation. The DOM regression test holds both requests open, settles the stale one while reopened, and verifies the second request controls final rendering.

Fixes #7124.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Route Explorer client lifecycle

## Validation

- Red-before-fix proof: the new regression failed on the original `origin/main` because `isLoading` remained `true` after close and reopen.
- `node_modules/.bin/vitest run --config vitest.dom.config.mts tests/dom/route-explorer-loading.test.mts` — passed.
- Full DOM suite — 61 files, 464 tests passed.
- `npm run --silent typecheck`, `npm run --silent typecheck:dom-tests`, `npm run --silent lint:boundaries`, `npm run --silent lint`, and Biome checks — passed.
- `npm run --silent test:data` remains red in this checkout for unrelated baseline/environment issues, including missing `public/product-facts.json` and AIS relay timeouts.
- The issue's cited `docs/plans/simplification-audit-counts.sh` was not present in this checkout, so that count gate could not run.

## Post-Deploy Monitoring & Validation

No backend or persistent-data path changed, so no ongoing operational monitor is required. After deployment, a quick browser check should open Route Explorer, close it while loading, reopen it, and confirm that the reopened request can finish and render normally.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/MODEL_SLUG-GPT_5-000000)
