### PR TITLE
fix(military): make vessel cache cadence single-owner

### DIFF
--- a/src/services/military-vessels.ts
+++ b/src/services/military-vessels.ts
@@ -15,9 +15,6 @@ import {
 } from './maritime';
 import { fetchUSNIFleetReport, mergeUSNIWithAIS } from './usni-fleet';
 
-// Cache for API responses
-let vesselCache: { data: MilitaryVessel[]; timestamp: number } | null = null;
-
 // In-memory vessel tracking
 const trackedVessels = new Map<string, MilitaryVessel>();
 const vesselHistory = new Map<string, { positions: [number, number][]; lastUpdate: number }>();
@@ -35,7 +32,7 @@ const breaker = createCircuitBreaker<{ vessels: MilitaryVessel[]; clusters: Mili
   name: 'Military Vessel Tracking',
   maxFailures: 3,
   cooldownMs: 5 * 60 * 1000,
-  cacheTtlMs: 10 * 60 * 1000,
+  cacheTtlMs: 30 * 1000,
   persistCache: true,
   revivePersistedData: (data) => ({
     ...data,
@@ -416,10 +413,9 @@ function processAisPosition(data: AisPositionData): void {
   const previousSize = trackedVessels.size;
   trackedVessels.set(mmsi, vessel);
 
-  // Clear stale caches when first vessels arrive or when we hit significant milestones
-  // This ensures cached empty results don't block fresh data
+  // Clear the breaker cache when first vessels arrive or when we hit significant milestones.
+  // This ensures cached empty results don't block fresh data.
   if (previousSize === 0 || (trackedVessels.size === 10 && previousSize < 10)) {
-    vesselCache = null;
     breaker.clearCache();
   }
 
@@ -519,10 +515,9 @@ startVesselHistoryCleanup();
 export function initMilitaryVesselStream(): void {
   if (isTracking) return;
 
-  // Invalidate in-memory caches when stream starts — real-time AIS data
+  // Invalidate the breaker's in-memory cache when the stream starts — real-time AIS data
   // replaces them within seconds. Do NOT clear persistent storage here:
   // a concurrent execute() may be hydrating from it to serve instant data.
-  vesselCache = null;
   breaker.clearMemoryCache();
 
   // Register callback with shared AIS stream
@@ -556,9 +551,6 @@ export function getMilitaryVesselStatus(): { connected: boolean; vessels: number
   };
 }
 
-// Cache TTL
-const CACHE_TTL = 30 * 1000; // 30 seconds
-
 /**
  * Main function to get military vessels
  */
@@ -568,28 +560,15 @@ export async function fetchMilitaryVessels(): Promise<{
 }> {
 
   return breaker.execute(async () => {
-    let vessels: MilitaryVessel[] = [];
-
-    // Check cache first, but still run USNI merge so output is consistent.
-    if (vesselCache && Date.now() - vesselCache.timestamp < CACHE_TTL) {
-      vessels = vesselCache.data;
-    } else {
-      // Initialize stream if not running
-      if (!isTracking && isAisConfigured()) {
-        initMilitaryVesselStream();
-      }
-
-      // Clean up old data
-      cleanup();
-
-      // Convert tracked vessels to array
-      vessels = Array.from(trackedVessels.values());
-
-      // Only cache non-empty results - empty results due to timing shouldn't block future calls
-      if (vessels.length > 0) {
-        vesselCache = { data: vessels, timestamp: Date.now() };
-      }
+    // Initialize stream if not running
+    if (!isTracking && isAisConfigured()) {
+      initMilitaryVesselStream();
     }
+
+    // Clean up old data and take the current tracking snapshot. The breaker
+    // owns the single 30-second refresh cadence for this payload.
+    cleanup();
+    const vessels = Array.from(trackedVessels.values());
 
     // Generate AIS-only clusters
     const aisClusters = clusterVessels(vessels);

--- a/tests/military-vessels-cache.test.mjs
+++ b/tests/military-vessels-cache.test.mjs
@@ -1,0 +1,54 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const source = readFileSync(resolve(root, 'src/services/military-vessels.ts'), 'utf8');
+const circuitBreakerUrl = pathToFileURL(resolve(root, 'src/utils/circuit-breaker.ts')).href;
+
+describe('military vessel refresh cadence', () => {
+  it('uses one 30-second breaker cache for AIS vessel snapshots', () => {
+    assert.match(
+      source,
+      /cacheTtlMs:\s*30\s*\*\s*1000/,
+      'the breaker must own the 30-second vessel refresh cadence',
+    );
+    assert.doesNotMatch(
+      source,
+      /vesselCache|CACHE_TTL/,
+      'the service must not retain a second in-memory vessel cache',
+    );
+  });
+
+  it('refreshes the breaker-backed snapshot after its cache window expires', async () => {
+    const { clearAllCircuitBreakers, createCircuitBreaker } = await import(
+      `${circuitBreakerUrl}?t=${Date.now()}-military-vessels-cache`,
+    );
+    const breaker = createCircuitBreaker({
+      name: 'Military Vessel Refresh Cadence Test',
+      cacheTtlMs: 30,
+      persistCache: false,
+    });
+    let refreshCount = 0;
+
+    try {
+      const fetchSnapshot = async () => ({ snapshot: ++refreshCount });
+      const fallback = { snapshot: 0 };
+
+      assert.deepEqual(await breaker.execute(fetchSnapshot, fallback), { snapshot: 1 });
+      assert.deepEqual(await breaker.execute(fetchSnapshot, fallback), { snapshot: 1 });
+      assert.equal(refreshCount, 1, 'a fresh breaker cache entry must avoid a second refresh');
+
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 40));
+      assert.deepEqual(
+        await breaker.execute(fetchSnapshot, fallback, { staleRefreshMode: 'await' }),
+        { snapshot: 2 },
+      );
+      assert.equal(refreshCount, 2, 'an expired breaker cache entry must refresh the snapshot');
+    } finally {
+      clearAllCircuitBreakers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Military vessel snapshots now refresh on the intended 30-second cadence. Previously, the 30-second service cache was nested behind a 10-minute circuit-breaker cache, so live AIS updates could remain hidden for up to 10 minutes.

The circuit breaker is now the single cache owner, and stream-start and milestone invalidation still clear that cache when fresh AIS data arrives.

Fixes #7123

## Tests

- `node --test tests/military-vessels-cache.test.mjs` — 2 passed, including an expiry/refresh regression check.
- `npm run typecheck` — passed.
- Pre-push gates — passed, including boundary, safe-HTML, premium-fetch, and 264 edge tests.
- The broader `npm run test:data` run still reports unrelated local fixture and AIS relay timing/auth-guard failures; no failure was in the changed service or focused regression test.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![HARNESS](https://img.shields.io/badge/MODEL_SLUG-GPT-5-000000)
