### PR TITLE
perf(dashboard): bound the SVG map's HTML overlay markers — the desktop DOM bimodality is a renderer fallback (#7112)

### DIFF
--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -32,6 +32,7 @@ type HarnessWindow = Window & {
   __mobileMapIntegrationHarness?: {
     ready: boolean;
     seedOverlayMarkerStress: (perFeed: number) => void;
+    seedTimeFilteredEarthquakes: (recent: number, stale: number) => void;
     getOverlayMarkerCount: () => number;
     getOverlayMarkerClassCount: (selector: string) => number;
     getOverlayBudgetState: () => BudgetState;
@@ -176,5 +177,47 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
       .filter((value) => Number.isFinite(value));
     expect(magnitudes.length).toBeGreaterThan(0);
     expect(Math.min(...magnitudes)).toBeGreaterThan(1.5);
+  });
+  test('budgets the time-filtered slice, not the whole feed', async ({ page }) => {
+    await page.goto('/tests/mobile-map-integration-harness.html');
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+
+    // 40 recent low-magnitude events behind 2,000 stale high-magnitude ones.
+    // The render loop only draws the 40; a budget planned over the unfiltered
+    // 2,040 would rank the stale ones first, spend its whole share on them and
+    // draw a handful of the 40 — or none.
+    const RECENT = 40;
+    await page.evaluate(
+      (recent) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.seedTimeFilteredEarthquakes(
+          recent,
+          2000,
+        ),
+      RECENT,
+    );
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayMarkerClassCount(
+              '.earthquake-marker',
+            ),
+          ),
+        { timeout: 15000 },
+      )
+      .toBe(RECENT);
+
+    // Nothing was withheld: 40 in-window events sit well under the per-group cap.
+    const state = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState(),
+    );
+    expect(state.truncated.natural).toBeUndefined();
   });
 });

--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -21,6 +21,9 @@ import { expect, test, type Page } from '@playwright/test';
 
 const DESKTOP_TOTAL = 800;
 const DESKTOP_PER_LAYER = 300;
+// MAP_OVERLAY_MARKER_BUDGET_MOBILE — the branch `isMobile` selects.
+const MOBILE_TOTAL = 400;
+const MOBILE_PER_LAYER = 150;
 const STRESS_PER_FEED = 2000;
 const DASHBOARD_MAX_DOM_NODES = 12000;
 // Chromium's renderer-wide metric includes a small amount of browser-owned
@@ -58,6 +61,8 @@ type BudgetState = {
   truncated: Record<string, { shown: number; total: number }>;
   /** Trimmed layers with no toggle row to disclose the cut on; see #7112. */
   undisclosed: string[];
+  /** Overlay rebuild count, for the duplicate-rebuild assertion. */
+  renders: number;
 };
 
 type HarnessWindow = Window & {
@@ -71,6 +76,8 @@ type HarnessWindow = Window & {
     getOverlayMarkerCount: () => number;
     getOverlayMarkerClassCount: (selector: string) => number;
     getOverlayPositionSignature: (selector: string) => string;
+    seedWeatherAlerts: (withCentroid: number, withoutCentroid: number) => void;
+    forceRender: () => void;
     getKeptHotspotCoords: () => Coord[];
     getSeededHotspotCoords: () => Coord[];
     getOverlayBudgetState: () => BudgetState;
@@ -345,6 +352,165 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
     await expect(badge).toHaveText(`${state.truncated.military!.shown}/${state.truncated.military!.total}`);
 
     expect(pageErrors).toEqual([]);
+  });
+
+  test('applies the tighter mobile ceiling when the renderer is on its mobile branch', async ({ page }) => {
+    // The desktop tests above all run `isMobile: false`, so without this the
+    // mobile budget constant is referenced by the code and asserted by nothing.
+    await page.goto('/tests/mobile-map-integration-harness.html?mobile=1');
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+
+    await page.evaluate(
+      (perFeed) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.seedOverlayMarkerStress(perFeed),
+      STRESS_PER_FEED,
+    );
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => {
+            const harness = (window as HarnessWindow).__mobileMapIntegrationHarness!;
+            return (
+              harness.getOverlayMarkerClassCount('.military-vessel-marker') > 0 &&
+              harness.getOverlayMarkerClassCount('.military-flight-marker') > 0
+            );
+          }),
+        { timeout: 15000 },
+      )
+      .toBe(true);
+
+    const state = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState(),
+    );
+    const counts = await page.evaluate(() => {
+      const harness = (window as HarnessWindow).__mobileMapIntegrationHarness!;
+      return {
+        overlayChildren: harness.getOverlayMarkerCount(),
+        vessels: harness.getOverlayMarkerClassCount('.military-vessel-marker'),
+        flights: harness.getOverlayMarkerClassCount('.military-flight-marker'),
+      };
+    });
+
+    // The mobile ceilings, and — the point of the test — NOT the desktop ones:
+    // a component that ignored isMobile would sit under 800/300 and pass every
+    // assertion that only bounded from above by the desktop numbers.
+    expect(state.rendered).toBeLessThanOrEqual(MOBILE_TOTAL);
+    expect(counts.overlayChildren).toBeLessThanOrEqual(MOBILE_TOTAL);
+    expect(counts.vessels).toBeLessThanOrEqual(MOBILE_PER_LAYER);
+    expect(counts.flights).toBeLessThanOrEqual(MOBILE_PER_LAYER);
+    expect(counts.vessels).toBeGreaterThan(0);
+    expect(counts.flights).toBeGreaterThan(0);
+    // Strictly tighter than desktop would have been on the same seed, so this
+    // cannot pass with the desktop budget selected.
+    expect(counts.vessels + counts.flights).toBeGreaterThan(MOBILE_TOTAL / 4);
+    expect(counts.vessels + counts.flights).toBeLessThan(DESKTOP_TOTAL);
+    expect(state.undisclosed).toEqual([]);
+  });
+
+  test('does not budget weather alerts that can never be drawn', async ({ page }) => {
+    await page.goto('/tests/mobile-map-integration-harness.html');
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+
+    // 400 renderable alerts past the 300 per-layer cap, behind 1,000 that have no
+    // `centroid`. The render loop can only ever draw the 400.
+    const RENDERABLE = 400;
+    await page.evaluate(
+      (renderable) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.seedWeatherAlerts(renderable, 1000),
+      RENDERABLE,
+    );
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayMarkerClassCount(
+              '.weather-marker',
+            ),
+          ),
+        { timeout: 15000 },
+      )
+      .toBeGreaterThan(0);
+
+    const state = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState(),
+    );
+
+    // The badge must count what was renderable, not what arrived. Budgeting the
+    // raw feed would report 1,400 here and tell the user 300/1400 when 1,000 of
+    // those were never going to appear under any budget.
+    expect(state.truncated.weather?.total).toBe(RENDERABLE);
+    expect(state.truncated.weather?.shown).toBe(DESKTOP_PER_LAYER);
+  });
+
+  test('does not rebuild again when another render already re-planned the new view', async ({ page }) => {
+    await page.goto('/tests/mobile-map-integration-harness.html');
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+
+    // Truncation must exist, or the replan is skipped outright and this passes
+    // for the wrong reason.
+    await page.evaluate(
+      (count) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.seedOverlayViewportStress(count),
+      2000,
+    );
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            Object.keys(
+              (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState()
+                .truncated,
+            ).length,
+          ),
+        { timeout: 15000 },
+      )
+      .toBeGreaterThan(0);
+    await page.waitForTimeout(1200);
+
+    const before = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState().renders,
+    );
+    expect(before).toBeGreaterThan(0);
+
+    // Pan (starts the settle timer), then land a render inside the settle window
+    // — which is what production does constantly, since every data setter calls
+    // render(). That render re-plans for the new viewport, so by the time the
+    // timer fires the plan is no longer stale and a rebuild cannot change a
+    // marker. A timer that fires unconditionally rebuilds the whole dynamic
+    // layer a second time for a viewport it already planned.
+    await page.evaluate(() => {
+      const harness = (window as HarnessWindow).__mobileMapIntegrationHarness!;
+      harness.setOverlayViewport(-30, 60);
+      harness.forceRender();
+    });
+
+    await page.waitForTimeout(2500);
+    const after = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState().renders,
+    );
+
+    // Exactly one rebuild for the new viewport — the one the in-window render
+    // already performed.
+    expect(after).toBe(before + 1);
   });
 
   test('keeps the highest-magnitude earthquakes when the natural feed is cut', async ({ page }) => {

--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -27,13 +27,37 @@ const DASHBOARD_MAX_DOM_NODES = 12000;
 // bookkeeping beyond the document nodes returned by querySelectorAll('*').
 const DASHBOARD_MAX_RENDERER_NODES = 15000;
 const DASHBOARD_MAX_LISTENERS = 1500;
-const DASHBOARD_MAX_NODE_VARIANCE = 500;
-const DASHBOARD_MAX_RENDERER_NODE_VARIANCE = 2000;
-const DASHBOARD_MAX_LISTENER_VARIANCE = 200;
+// Where the pan/zoom test asks the map to look. Nothing special about it beyond
+// being far from the default centre in both axes.
+const VIEW_TARGET = { lat: -55, lon: 125 };
+// The 300 survivors of 2,000 globe-spread markers, ranked by nearness, sit well
+// inside this. Thresholds are deliberately loose against the measured values
+// (kept mean ~30 deg vs seeded mean ~95 deg) so the test pins the BEHAVIOUR —
+// survivors cluster on the requested centre — not a fixed spiral layout.
+const VIEW_CENTRED_MAX_MEAN_DEGREES = 55;
+const VIEW_CENTRED_MEAN_RATIO = 0.65;
+const VIEW_CENTRED_MAX_WORST_DEGREES = 110;
+
+type Coord = { lat: number; lon: number };
+
+/** Great-circle separation in degrees. Mirrors what proximityRank orders by. */
+function angularDistanceDegrees(a: Coord, b: Coord): number {
+  const rad = Math.PI / 180;
+  const cos =
+    Math.sin(a.lat * rad) * Math.sin(b.lat * rad) +
+    Math.cos(a.lat * rad) * Math.cos(b.lat * rad) * Math.cos((a.lon - b.lon) * rad);
+  return Math.acos(Math.min(1, Math.max(-1, cos))) / rad;
+}
+
+function meanAngularDistance(points: Coord[], focus: Coord): number {
+  return points.reduce((sum, point) => sum + angularDistanceDegrees(point, focus), 0) / points.length;
+}
 
 type BudgetState = {
   rendered: number;
   truncated: Record<string, { shown: number; total: number }>;
+  /** Trimmed layers with no toggle row to disclose the cut on; see #7112. */
+  undisclosed: string[];
 };
 
 type HarnessWindow = Window & {
@@ -47,6 +71,8 @@ type HarnessWindow = Window & {
     getOverlayMarkerCount: () => number;
     getOverlayMarkerClassCount: (selector: string) => number;
     getOverlayPositionSignature: (selector: string) => string;
+    getKeptHotspotCoords: () => Coord[];
+    getSeededHotspotCoords: () => Coord[];
     getOverlayBudgetState: () => BudgetState;
   };
 };
@@ -100,7 +126,10 @@ async function readDashboardDomMetrics(page: Page): Promise<{
 
 test.describe('SVG map overlay marker budget (#7112)', () => {
   test('keeps the full dashboard DOM and listener counts bounded across cold loads', async ({ browser }) => {
-    test.setTimeout(90000);
+    // Three sequential COLD dashboard boots, each with its own 2s settle. On a
+    // loaded CI box that runs past 90s for reasons unrelated to what is being
+    // measured, so the budget is sized to the work rather than to a fast machine.
+    test.setTimeout(240000);
     const samples: Array<Awaited<ReturnType<typeof readDashboardDomMetrics>>> = [];
 
     for (let attempt = 0; attempt < 3; attempt += 1) {
@@ -122,25 +151,32 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
     const domNodes = samples.map((sample) => sample.domNodes);
     const rendererNodes = samples.map((sample) => sample.rendererNodes);
     const listeners = samples.map((sample) => sample.listeners);
-    const range = (values: number[]): number => Math.max(...values) - Math.min(...values);
 
-    // #7112 acceptance: this is the real /dashboard document, not only the
-    // harness overlay root. The repeated fresh contexts catch cold-load drift;
-    // the stated ceilings and tolerances are the production guardrail from the
-    // issue investigation (12k document nodes / 15k renderer nodes / 1.5k
-    // listeners).
+    // A general /dashboard DOM guardrail, NOT the #7112 acceptance evidence.
+    // installLocalOnlyNetwork() aborts every off-origin request, so the live
+    // feeds that produced the 2,088-marker measurement never arrive and these
+    // ceilings would hold with the overlay budget deleted. The budget's teeth
+    // are in the harness tests below, which seed the feeds directly.
+    //
+    // What this test does buy: the whole real document (not just the overlay
+    // root) stays inside the production guardrail from the issue investigation,
+    // and repeated fresh contexts catch cold-load drift.
     expect(Math.max(...domNodes)).toBeLessThanOrEqual(DASHBOARD_MAX_DOM_NODES);
     expect(Math.max(...rendererNodes)).toBeLessThanOrEqual(DASHBOARD_MAX_RENDERER_NODES);
     expect(Math.max(...listeners)).toBeLessThanOrEqual(DASHBOARD_MAX_LISTENERS);
-    expect(range(domNodes)).toBeLessThanOrEqual(DASHBOARD_MAX_NODE_VARIANCE);
-    // Performance.getMetrics().Nodes is renderer-wide and includes transient
-    // browser-owned nodes, so it has a wider explicit tolerance than the live
-    // dashboard document count.
-    expect(range(rendererNodes)).toBeLessThanOrEqual(DASHBOARD_MAX_RENDERER_NODE_VARIANCE);
-    expect(range(listeners)).toBeLessThanOrEqual(DASHBOARD_MAX_LISTENER_VARIANCE);
+
+    // Ceilings only — the run-to-run RANGE of these counters is deliberately not
+    // asserted. `Performance.getMetrics()` reports Nodes and JSEventListeners
+    // renderer-wide INCLUDING detached objects still awaiting GC (the same fact
+    // that explains this issue's ~11-bytes-per-node puzzle), so a range assertion
+    // is really an assertion about when the collector ran. Measured: the previous
+    // tolerances failed on an unmodified tree in consecutive runs — document-node
+    // range 999 against a 500 cap, renderer-node range 2813 against 2000 — so they
+    // reported GC timing as a regression. The ceilings above hold across the same
+    // runs and are what the guardrail is actually for.
   });
 
-  test('replans proximity-ranked markers after a pan and zoom transform', async ({ page }) => {
+  test('re-ranks the kept markers onto the new view centre after a pan and zoom', async ({ page }) => {
     await page.goto('/tests/mobile-map-integration-harness.html');
     await expect
       .poll(
@@ -166,37 +202,58 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
       )
       .toBe(true);
 
-    const initial = await page.evaluate(() =>
-      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayPositionSignature('.hotspot'),
-    );
-    await page.evaluate(() =>
-      (window as HarnessWindow).__mobileMapIntegrationHarness!.setOverlayViewport(-55, 125),
-    );
-    await expect
-      .poll(
-        async () =>
-          page.evaluate((previous) =>
-            (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayPositionSignature('.hotspot') !== previous,
-          initial),
-        { timeout: 15000 },
-      )
-      .toBe(true);
-
-    const afterPan = await page.evaluate(() =>
-      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayPositionSignature('.hotspot'),
-    );
+    // Zoom BEFORE panning. The wrong inverse transform this test exists to catch
+    // (`width / (2 * zoom) - pan.x`) is identical to the right one at zoom 1, so
+    // an assertion made at the default zoom cannot see it.
     await page.evaluate(() =>
       (window as HarnessWindow).__mobileMapIntegrationHarness!.setOverlayZoom(4),
     );
+    await page.evaluate(
+      (target) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.setOverlayViewport(
+          target.lat,
+          target.lon,
+        ),
+      VIEW_TARGET,
+    );
+
+    // The re-plan is debounced to the settle (OVERLAY_BUDGET_REPLAN_SETTLE_MS),
+    // so poll rather than reading once.
     await expect
       .poll(
-        async () =>
-          page.evaluate((previous) =>
-            (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayPositionSignature('.hotspot') !== previous,
-          afterPan),
-        { timeout: 15000 },
+        async () => {
+          const kept = await page.evaluate(() =>
+            (window as HarnessWindow).__mobileMapIntegrationHarness!.getKeptHotspotCoords(),
+          );
+          return kept.length > 0 ? meanAngularDistance(kept, VIEW_TARGET) : Number.POSITIVE_INFINITY;
+        },
+        { timeout: 20000 },
       )
-      .toBe(true);
+      .toBeLessThan(VIEW_CENTRED_MAX_MEAN_DEGREES);
+
+    const kept = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getKeptHotspotCoords(),
+    );
+    const seeded = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getSeededHotspotCoords(),
+    );
+
+    expect(kept.length).toBe(DESKTOP_PER_LAYER);
+    expect(seeded.length).toBeGreaterThan(kept.length);
+
+    // The load-bearing assertion: the survivors are the ones NEAR the requested
+    // centre, not merely a different subset than before. A centre computed from
+    // the wrong inverse transform still changes the set on every pan and zoom —
+    // it just clusters it on a point the user is not looking at — so "the
+    // signature changed" is satisfied by the bug and cannot stand in for this.
+    const keptMean = meanAngularDistance(kept, VIEW_TARGET);
+    const seededMean = meanAngularDistance(seeded, VIEW_TARGET);
+    expect(keptMean).toBeLessThan(seededMean * VIEW_CENTRED_MEAN_RATIO);
+
+    // And no survivor is far from the view: a cut ranked on the wrong centre
+    // keeps its own near neighbours, which are this centre's far ones.
+    const worst = Math.max(...kept.map((spot) => angularDistanceDegrees(spot, VIEW_TARGET)));
+    expect(worst).toBeLessThan(VIEW_CENTRED_MAX_WORST_DEGREES);
   });
 
   test('bounds the overlay marker count against feeds far past production volume', async ({ page }) => {
@@ -279,6 +336,10 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
     expect(state.truncated.military?.total).toBe(STRESS_PER_FEED * 2);
     expect(state.truncated.military?.shown).toBeLessThan(STRESS_PER_FEED * 2);
     expect(state.truncated.natural?.total).toBe(STRESS_PER_FEED);
+    // Every trimmed layer must have a toggle row to show its count on. A layer
+    // reported here was cut with nowhere to disclose it, which is
+    // indistinguishable from missing data for the user (#7112).
+    expect(state.undisclosed).toEqual([]);
 
     const badge = page.locator('.layer-toggle-row[data-layer="military"] .layer-truncation-count');
     await expect(badge).toHaveText(`${state.truncated.military!.shown}/${state.truncated.military!.total}`);

--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -24,6 +24,9 @@ const DESKTOP_PER_LAYER = 300;
 // MAP_OVERLAY_MARKER_BUDGET_MOBILE — the branch `isMobile` selects.
 const MOBILE_TOTAL = 400;
 const MOBILE_PER_LAYER = 150;
+// MapComponent.MAX_CONCURRENT_MAP_FLASHES — news flashes are overlay children
+// created outside the marker budget, so they carry their own ceiling.
+const MAX_CONCURRENT_FLASHES = 12;
 const STRESS_PER_FEED = 2000;
 const DASHBOARD_MAX_DOM_NODES = 12000;
 // Chromium's renderer-wide metric includes a small amount of browser-owned
@@ -78,6 +81,9 @@ type HarnessWindow = Window & {
     getOverlayPositionSignature: (selector: string) => string;
     seedWeatherAlerts: (withCentroid: number, withoutCentroid: number) => void;
     forceRender: () => void;
+    burstFlashes: (count: number) => void;
+    getActiveFlashCount: () => number;
+    getFlashNodeCount: () => number;
     getKeptHotspotCoords: () => Coord[];
     getSeededHotspotCoords: () => Coord[];
     getOverlayBudgetState: () => BudgetState;
@@ -511,6 +517,103 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
     // Exactly one rebuild for the new viewport — the one the in-window render
     // already performed.
     expect(after).toBe(before + 1);
+  });
+
+  test('reports every trimmed layer as undisclosed when the map has no toggle rail', async ({ page }) => {
+    // The embed surface: src/embed/panels/map.ts builds MapContainer with
+    // `chrome: false`, so no #layerToggles rail is ever created and no
+    // `shown/total` badge has anywhere to go.
+    await page.goto('/tests/mobile-map-integration-harness.html?chrome=0');
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+
+    await expect(page.locator('#layerToggles')).toHaveCount(0);
+
+    await page.evaluate(
+      (perFeed) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.seedOverlayMarkerStress(perFeed),
+      STRESS_PER_FEED,
+    );
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            Object.keys(
+              (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState()
+                .truncated,
+            ).length,
+          ),
+        { timeout: 15000 },
+      )
+      .toBeGreaterThan(0);
+
+    const state = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState(),
+    );
+
+    // The markers ARE capped here — that part works. What must not happen is the
+    // budget state claiming the cut was disclosed: with no rail, every trimmed
+    // layer is undisclosed, and an empty array would report full disclosure while
+    // the embed silently withholds markers.
+    expect(Object.keys(state.truncated).length).toBeGreaterThan(0);
+    expect(state.undisclosed.sort()).toEqual(Object.keys(state.truncated).sort());
+    expect(state.rendered).toBeLessThanOrEqual(DESKTOP_TOTAL);
+  });
+
+  test('bounds concurrent news flashes, which are overlay children outside the budget', async ({ page }) => {
+    await page.goto('/tests/mobile-map-integration-harness.html');
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+
+    // A full overlay first, so this measures the composed DOM the ceiling claim
+    // is about rather than flashes on an empty map.
+    await page.evaluate(
+      (perFeed) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.seedOverlayMarkerStress(perFeed),
+      STRESS_PER_FEED,
+    );
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayMarkerClassCount(
+              '.military-vessel-marker',
+            ),
+          ),
+        { timeout: 15000 },
+      )
+      .toBeGreaterThan(0);
+
+    // 300 flashes with a long duration, so none expire mid-measurement — the
+    // burst shape flashMapForNews() actually produces on load. Burst and measure
+    // in ONE evaluate: renderOverlays() clears #mapOverlays wholesale, so a render
+    // landing between the two would empty the flashes and make this pass for a
+    // reason that has nothing to do with the ceiling.
+    const flashes = await page.evaluate((count) => {
+      const harness = (window as HarnessWindow).__mobileMapIntegrationHarness!;
+      harness.burstFlashes(count);
+      return {
+        active: harness.getActiveFlashCount(),
+        nodes: harness.getFlashNodeCount(),
+        overlayChildren: harness.getOverlayMarkerCount(),
+      };
+    }, 300);
+
+    expect(flashes.active).toBeLessThanOrEqual(MAX_CONCURRENT_FLASHES);
+    // The evicted ones must actually leave the DOM, not just the bookkeeping.
+    expect(flashes.nodes).toBe(flashes.active);
+    // The composed ceiling: budgeted markers plus the bounded flash exemption.
+    expect(flashes.overlayChildren).toBeLessThanOrEqual(DESKTOP_TOTAL + MAX_CONCURRENT_FLASHES);
   });
 
   test('keeps the highest-magnitude earthquakes when the natural feed is cut', async ({ page }) => {

--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -82,6 +82,7 @@ type HarnessWindow = Window & {
     seedWeatherAlerts: (withCentroid: number, withoutCentroid: number) => void;
     forceRender: () => void;
     burstFlashes: (count: number) => void;
+    clearOverlayFeeds: () => void;
     getActiveFlashCount: () => number;
     getFlashNodeCount: () => number;
     getKeptHotspotCoords: () => Coord[];
@@ -563,6 +564,28 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
     expect(Object.keys(state.truncated).length).toBeGreaterThan(0);
     expect(state.undisclosed.sort()).toEqual(Object.keys(state.truncated).sort());
     expect(state.rendered).toBeLessThanOrEqual(DESKTOP_TOTAL);
+
+    // Honest private state is necessary but not sufficient: the person looking at
+    // the embed must be able to SEE that the map is partial. With no toggle rail
+    // to badge, the compact summary is the only disclosure surface there is.
+    const summary = page.locator('.map-truncation-summary');
+    await expect(summary).toHaveCount(1);
+    const shown = Object.values(state.truncated).reduce((sum, counts) => sum + counts.shown, 0);
+    const total = Object.values(state.truncated).reduce((sum, counts) => sum + counts.total, 0);
+    await expect(summary).toHaveText(`${shown}/${total} markers`);
+    expect(shown).toBeLessThan(total);
+    await expect(summary).toBeVisible();
+
+    // Idempotent: another render must update the one node, not append a second.
+    await page.evaluate(() => (window as HarnessWindow).__mobileMapIntegrationHarness!.forceRender());
+    await expect(summary).toHaveCount(1);
+
+    // ...and it must disappear once nothing is being withheld, rather than
+    // stranding a stale count over a complete map.
+    await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.clearOverlayFeeds(),
+    );
+    await expect(page.locator('.map-truncation-summary')).toHaveCount(0);
   });
 
   test('bounds concurrent news flashes, which are overlay children outside the budget', async ({ page }) => {
@@ -609,11 +632,55 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
       };
     }, 300);
 
-    expect(flashes.active).toBeLessThanOrEqual(MAX_CONCURRENT_FLASHES);
+    // EXACTLY the cap, not `<=`. Every assertion here is satisfied by zero —
+    // 0 <= 12, 0 === 0, and 0 is under the overlay ceiling — so a flashLocation()
+    // that early-returned on every call (no container size, unprojectable point)
+    // would have made this test green while creating no flashes at all. 300 calls
+    // with valid coordinates must leave the ceiling exactly full.
+    expect(flashes.active).toBe(MAX_CONCURRENT_FLASHES);
     // The evicted ones must actually leave the DOM, not just the bookkeeping.
-    expect(flashes.nodes).toBe(flashes.active);
+    expect(flashes.nodes).toBe(MAX_CONCURRENT_FLASHES);
     // The composed ceiling: budgeted markers plus the bounded flash exemption.
     expect(flashes.overlayChildren).toBeLessThanOrEqual(DESKTOP_TOTAL + MAX_CONCURRENT_FLASHES);
+    // ...and the flashes really are on top of a full overlay, so this measures the
+    // composed DOM rather than flashes on an empty map.
+    expect(flashes.overlayChildren).toBeGreaterThan(MAX_CONCURRENT_FLASHES);
+  });
+
+  test('clears live flash timers and nodes when the map is destroyed', async ({ page }) => {
+    await page.goto('/tests/mobile-map-integration-harness.html');
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+
+    // Long-duration flashes so they are unambiguously still live at teardown —
+    // otherwise natural expiry, not destroy(), would be what cleared them.
+    const before = await page.evaluate(() => {
+      const harness = (window as HarnessWindow).__mobileMapIntegrationHarness!;
+      harness.burstFlashes(5);
+      return { active: harness.getActiveFlashCount(), nodes: harness.getFlashNodeCount() };
+    });
+
+    // Active precondition: without this the assertions below pass on a map that
+    // never had a flash to clear.
+    expect(before.active).toBe(5);
+    expect(before.nodes).toBe(5);
+
+    const after = await page.evaluate(() => {
+      const harness = (window as HarnessWindow).__mobileMapIntegrationHarness!;
+      harness.destroyMap();
+      return { active: harness.getActiveFlashCount(), nodes: harness.getFlashNodeCount() };
+    });
+
+    // destroy() must clear the tracking AND remove the nodes. A leaked expiry
+    // timer would later fire `flash.remove()` against a torn-down instance, and
+    // leaked nodes outlive the renderer that owns them.
+    expect(after.active).toBe(0);
+    expect(after.nodes).toBe(0);
   });
 
   test('keeps the highest-magnitude earthquakes when the natural feed is cut', async ({ page }) => {

--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 /**
  * #7112 — the SVG renderer's HTML overlay must stay bounded.
@@ -22,6 +22,14 @@ import { expect, test } from '@playwright/test';
 const DESKTOP_TOTAL = 800;
 const DESKTOP_PER_LAYER = 300;
 const STRESS_PER_FEED = 2000;
+const DASHBOARD_MAX_DOM_NODES = 12000;
+// Chromium's renderer-wide metric includes a small amount of browser-owned
+// bookkeeping beyond the document nodes returned by querySelectorAll('*').
+const DASHBOARD_MAX_RENDERER_NODES = 15000;
+const DASHBOARD_MAX_LISTENERS = 1500;
+const DASHBOARD_MAX_NODE_VARIANCE = 500;
+const DASHBOARD_MAX_RENDERER_NODE_VARIANCE = 2000;
+const DASHBOARD_MAX_LISTENER_VARIANCE = 200;
 
 type BudgetState = {
   rendered: number;
@@ -32,14 +40,165 @@ type HarnessWindow = Window & {
   __mobileMapIntegrationHarness?: {
     ready: boolean;
     seedOverlayMarkerStress: (perFeed: number) => void;
+    seedOverlayViewportStress: (count: number) => void;
+    setOverlayViewport: (lat: number, lon: number) => void;
+    setOverlayZoom: (zoom: number) => void;
     seedTimeFilteredEarthquakes: (recent: number, stale: number) => void;
     getOverlayMarkerCount: () => number;
     getOverlayMarkerClassCount: (selector: string) => number;
+    getOverlayPositionSignature: (selector: string) => string;
     getOverlayBudgetState: () => BudgetState;
   };
 };
 
+async function installLocalOnlyNetwork(page: Page): Promise<void> {
+  await page.route(/^https?:\/\/(?!(127\.0\.0\.1:4173|localhost:4173)(?:\/|$)).*/i, (route) => {
+    return route.abort('blockedbyclient');
+  });
+}
+
+async function loadColdDashboard(page: Page): Promise<void> {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.addInitScript(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem('worldmonitor-variant', 'full');
+  });
+  await installLocalOnlyNetwork(page);
+  await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => document.documentElement.dataset.wmEventHandlersReady === 'true');
+  await expect(page.locator('#mapContainer')).toBeVisible({ timeout: 30000 });
+  // Let the same local-only boot window settle on every fresh context before
+  // collecting the renderer metrics.
+  await page.waitForTimeout(2000);
+}
+
+async function readDashboardDomMetrics(page: Page): Promise<{
+  domNodes: number;
+  rendererNodes: number;
+  listeners: number;
+}> {
+  const domNodes = await page.evaluate(() => document.querySelectorAll('*').length);
+  const session = await page.context().newCDPSession(page);
+  try {
+    await session.send('Performance.enable');
+    const result = await session.send('Performance.getMetrics');
+    const value = (name: string): number => {
+      const metric = result.metrics.find((entry: { name: string; value: number }) => entry.name === name);
+      if (!metric || !Number.isFinite(metric.value)) throw new Error(`Missing Chromium metric: ${name}`);
+      return metric.value;
+    };
+    return {
+      domNodes,
+      rendererNodes: value('Nodes'),
+      listeners: value('JSEventListeners'),
+    };
+  } finally {
+    await session.detach().catch(() => {});
+  }
+}
+
 test.describe('SVG map overlay marker budget (#7112)', () => {
+  test('keeps the full dashboard DOM and listener counts bounded across cold loads', async ({ browser }) => {
+    test.setTimeout(90000);
+    const samples: Array<Awaited<ReturnType<typeof readDashboardDomMetrics>>> = [];
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const context = await browser.newContext({
+        viewport: { width: 1440, height: 900 },
+        colorScheme: 'dark',
+        locale: 'en-US',
+        timezoneId: 'UTC',
+      });
+      const page = await context.newPage();
+      try {
+        await loadColdDashboard(page);
+        samples.push(await readDashboardDomMetrics(page));
+      } finally {
+        await context.close();
+      }
+    }
+
+    const domNodes = samples.map((sample) => sample.domNodes);
+    const rendererNodes = samples.map((sample) => sample.rendererNodes);
+    const listeners = samples.map((sample) => sample.listeners);
+    const range = (values: number[]): number => Math.max(...values) - Math.min(...values);
+
+    // #7112 acceptance: this is the real /dashboard document, not only the
+    // harness overlay root. The repeated fresh contexts catch cold-load drift;
+    // the stated ceilings and tolerances are the production guardrail from the
+    // issue investigation (12k document nodes / 15k renderer nodes / 1.5k
+    // listeners).
+    expect(Math.max(...domNodes)).toBeLessThanOrEqual(DASHBOARD_MAX_DOM_NODES);
+    expect(Math.max(...rendererNodes)).toBeLessThanOrEqual(DASHBOARD_MAX_RENDERER_NODES);
+    expect(Math.max(...listeners)).toBeLessThanOrEqual(DASHBOARD_MAX_LISTENERS);
+    expect(range(domNodes)).toBeLessThanOrEqual(DASHBOARD_MAX_NODE_VARIANCE);
+    // Performance.getMetrics().Nodes is renderer-wide and includes transient
+    // browser-owned nodes, so it has a wider explicit tolerance than the live
+    // dashboard document count.
+    expect(range(rendererNodes)).toBeLessThanOrEqual(DASHBOARD_MAX_RENDERER_NODE_VARIANCE);
+    expect(range(listeners)).toBeLessThanOrEqual(DASHBOARD_MAX_LISTENER_VARIANCE);
+  });
+
+  test('replans proximity-ranked markers after a pan and zoom transform', async ({ page }) => {
+    await page.goto('/tests/mobile-map-integration-harness.html');
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+
+    await page.evaluate(
+      (count) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.seedOverlayViewportStress(count),
+      2000,
+    );
+    await expect
+      .poll(
+        async () =>
+          page.evaluate((expected) => {
+            const harness = (window as HarnessWindow).__mobileMapIntegrationHarness!;
+            return harness.getOverlayMarkerClassCount('.hotspot') === expected;
+          }, DESKTOP_PER_LAYER),
+        { timeout: 15000 },
+      )
+      .toBe(true);
+
+    const initial = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayPositionSignature('.hotspot'),
+    );
+    await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.setOverlayViewport(-55, 125),
+    );
+    await expect
+      .poll(
+        async () =>
+          page.evaluate((previous) =>
+            (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayPositionSignature('.hotspot') !== previous,
+          initial),
+        { timeout: 15000 },
+      )
+      .toBe(true);
+
+    const afterPan = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayPositionSignature('.hotspot'),
+    );
+    await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.setOverlayZoom(4),
+    );
+    await expect
+      .poll(
+        async () =>
+          page.evaluate((previous) =>
+            (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayPositionSignature('.hotspot') !== previous,
+          afterPan),
+        { timeout: 15000 },
+      )
+      .toBe(true);
+  });
+
   test('bounds the overlay marker count against feeds far past production volume', async ({ page }) => {
     const pageErrors: string[] = [];
     page.on('pageerror', (error) => pageErrors.push(error.message));

--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -1,0 +1,180 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * #7112 — the SVG renderer's HTML overlay must stay bounded.
+ *
+ * `MapComponent` is the desktop renderer whenever the client has no hardware
+ * WebGL2 context (`MapContainer.shouldUseDeckGL` -> `hasWebGLSupport` rejects
+ * SwiftShader by name), which is the normal state of a synthetic lab runner and
+ * of any GPU-blocklisted browser. It rebuilds every overlay marker on every
+ * render, and each marker carries its own `click` listener — so before the
+ * budget an uncapped AIS feed set the DOM size outright: 2,088 overlay markers
+ * measured on production, 17.4k renderer nodes / 2.8k listeners at rest and
+ * 49.7k / 21.5k mid-rebuild, against 7.6k / 736 on the DeckGL path.
+ *
+ * The ceiling is `MAP_OVERLAY_MARKER_BUDGET_DESKTOP` = { perLayer: 300,
+ * total: 800 } (see src/utils/globe-marker-budget.ts). This spec seeds feeds an
+ * order of magnitude past anything production has produced and asserts the
+ * ceiling holds, that the budget cut the biggest feed rather than starving the
+ * small ones, and that the cut is disclosed on the layer row.
+ */
+
+const DESKTOP_TOTAL = 800;
+const DESKTOP_PER_LAYER = 300;
+const STRESS_PER_FEED = 2000;
+
+type BudgetState = {
+  rendered: number;
+  truncated: Record<string, { shown: number; total: number }>;
+};
+
+type HarnessWindow = Window & {
+  __mobileMapIntegrationHarness?: {
+    ready: boolean;
+    seedOverlayMarkerStress: (perFeed: number) => void;
+    getOverlayMarkerCount: () => number;
+    getOverlayMarkerClassCount: (selector: string) => number;
+    getOverlayBudgetState: () => BudgetState;
+  };
+};
+
+test.describe('SVG map overlay marker budget (#7112)', () => {
+  test('bounds the overlay marker count against feeds far past production volume', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await page.goto('/tests/mobile-map-integration-harness.html');
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+
+    // Sanity: without the stress feeds the harness renders a handful of markers,
+    // so a later assertion of "<= 800" cannot pass merely because nothing rendered.
+    const baseline = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayMarkerCount(),
+    );
+    expect(baseline).toBeGreaterThan(0);
+    expect(baseline).toBeLessThan(DESKTOP_TOTAL);
+
+    await page.evaluate(
+      (perFeed) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.seedOverlayMarkerStress(perFeed),
+      STRESS_PER_FEED,
+    );
+
+    // Each setter triggers its own render() and render() is rate-limited, so the
+    // three seeded feeds land over successive passes. Wait for the settled state
+    // — all three present — before asserting the ceiling, or the assertion could
+    // pass on a pass that simply had not rendered the later feeds yet.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => {
+            const harness = (window as HarnessWindow).__mobileMapIntegrationHarness!;
+            return (
+              harness.getOverlayMarkerClassCount('.military-vessel-marker') > 0 &&
+              harness.getOverlayMarkerClassCount('.military-flight-marker') > 0 &&
+              harness.getOverlayMarkerClassCount('.earthquake-marker') > 0
+            );
+          }),
+        { timeout: 15000 },
+      )
+      .toBe(true);
+
+    const state = await page.evaluate(() =>
+      (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState(),
+    );
+    const counts = await page.evaluate(() => {
+      const harness = (window as HarnessWindow).__mobileMapIntegrationHarness!;
+      return {
+        overlayChildren: harness.getOverlayMarkerCount(),
+        vessels: harness.getOverlayMarkerClassCount('.military-vessel-marker'),
+        flights: harness.getOverlayMarkerClassCount('.military-flight-marker'),
+        quakes: harness.getOverlayMarkerClassCount('.earthquake-marker'),
+      };
+    });
+
+    // 6,000 seeded markers (3 feeds x 2,000) must not become 6,000 DOM markers.
+    expect(counts.vessels + counts.flights + counts.quakes).toBeLessThanOrEqual(DESKTOP_TOTAL);
+    // Hotspots are budgeted too, so the whole overlay — not just the seeded
+    // feeds — sits under the total.
+    expect(counts.overlayChildren).toBeLessThanOrEqual(DESKTOP_TOTAL);
+    expect(state.rendered).toBeLessThanOrEqual(DESKTOP_TOTAL);
+
+    // Per-group ceiling, and the fair share must actually be handed out rather
+    // than one feed eating the whole total.
+    expect(counts.vessels).toBeLessThanOrEqual(DESKTOP_PER_LAYER);
+    expect(counts.flights).toBeLessThanOrEqual(DESKTOP_PER_LAYER);
+    expect(counts.quakes).toBeLessThanOrEqual(DESKTOP_PER_LAYER);
+    expect(counts.vessels).toBeGreaterThan(0);
+    expect(counts.flights).toBeGreaterThan(0);
+    expect(counts.quakes).toBeGreaterThan(0);
+
+    // Withholding is disclosed, not silent.
+    expect(state.truncated.military?.total).toBe(STRESS_PER_FEED * 2);
+    expect(state.truncated.military?.shown).toBeLessThan(STRESS_PER_FEED * 2);
+    expect(state.truncated.natural?.total).toBe(STRESS_PER_FEED);
+
+    const badge = page.locator('.layer-toggle-row[data-layer="military"] .layer-truncation-count');
+    await expect(badge).toHaveText(`${state.truncated.military!.shown}/${state.truncated.military!.total}`);
+
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('keeps the highest-magnitude earthquakes when the natural feed is cut', async ({ page }) => {
+    await page.goto('/tests/mobile-map-integration-harness.html');
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+        { timeout: 30000 },
+      )
+      .toBe(true);
+
+    await page.evaluate(
+      (perFeed) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.seedOverlayMarkerStress(perFeed),
+      STRESS_PER_FEED,
+    );
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayMarkerClassCount(
+              '.earthquake-marker',
+            ),
+          ),
+        { timeout: 15000 },
+      )
+      .toBeGreaterThan(0);
+    // The cut only happens once the feed is over the fair share, which is what
+    // makes the magnitude assertion below meaningful rather than vacuous.
+    const naturalTruncation = await page.evaluate(
+      () =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState().truncated
+          .natural,
+    );
+    expect(naturalTruncation?.total).toBe(STRESS_PER_FEED);
+    expect(naturalTruncation!.shown).toBeLessThan(STRESS_PER_FEED);
+
+    // The seed spreads magnitudes 1.0-6.9 across the feed. A cut that fell on
+    // raw feed order would keep magnitude 1.0 markers; ranking by magnitude must
+    // not. `.earthquake-marker` carries its magnitude in the title text.
+    const titles = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('#mapOverlays .earthquake-marker')).map(
+        (element) => (element as HTMLElement).title,
+      ),
+    );
+    expect(titles.length).toBeGreaterThan(0);
+    const magnitudes = titles
+      .map((title) => Number(/M\s*([0-9.]+)/.exec(title)?.[1] ?? Number.NaN))
+      .filter((value) => Number.isFinite(value));
+    expect(magnitudes.length).toBeGreaterThan(0);
+    expect(Math.min(...magnitudes)).toBeGreaterThan(1.5);
+  });
+});

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -51,6 +51,7 @@ import {
   type GlobeLayerTruncation,
   type GlobeMarkerGroup,
 } from '@/utils/globe-marker-budget';
+import { renderLayerTruncationBadges } from '@/utils/layer-truncation-badge';
 import type { FeatureCollection, Geometry } from 'geojson';
 import type { MapLayers, Hotspot, MilitaryFlight, MilitaryVessel, MilitaryVesselCluster, NaturalEvent, InternetOutage, CyberThreat, SocialUnrestEvent, UcdpGeoEvent, MilitaryBase, GammaIrradiator, Spaceport, EconomicCenter, StrategicWaterway, CriticalMineralProject, AIDataCenter, UnderseaCable, Pipeline, CableAdvisory, RepairShip, AisDisruptionEvent, AisDensityZone, AisDisruptionType } from '@/types';
 import type { Earthquake } from '@/services/earthquakes';
@@ -2900,26 +2901,7 @@ export class GlobeMap {
   private updateLayerTruncationLabels(): void {
     const root = this.layerTogglesEl;
     if (!root) return;
-    for (const row of Array.from(root.querySelectorAll<HTMLElement>('.layer-toggle-row'))) {
-      const layer = row.getAttribute('data-layer');
-      const counts = layer ? this.markerTruncation[layer] : undefined;
-      const existing = row.querySelector<HTMLElement>('.layer-truncation-count');
-      if (!counts) { existing?.remove(); continue; }
-      const badge = existing ?? document.createElement('span');
-      if (!existing) {
-        badge.className = 'layer-truncation-count';
-        // Sibling of the <label>, not a child: inside it, every click on the
-        // badge would toggle the layer off. `.layer-explain-btn` sits outside
-        // the label for the same reason.
-        row.appendChild(badge);
-      }
-      badge.textContent = `${counts.shown}/${counts.total}`;
-      // Untranslated literal: a new i18n key is a ~29-file change across locales,
-      // and the badge itself is numeric. Real key tracked as follow-up.
-      // Says "nearest this view" rather than "highest priority" because that is
-      // what the ranking actually does for layers with no severity of their own.
-      badge.title = `Showing ${counts.shown} of ${counts.total} markers — the most significant, and those nearest the current view. The globe caps markers per layer to keep interaction responsive; rotate or zoom to bring others in.`;
-    }
+    renderLayerTruncationBadges(root, this.markerTruncation, 'rotate');
   }
 
   /**

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -265,6 +265,10 @@ export class MapComponent {
   // updateLayerTruncationLabels().
   private overlayUndisclosedTruncation: string[] = [];
   private renderedOverlayMarkerCount = 0;
+  // #7112: how many times renderOverlays() has rebuilt the overlay, surfaced
+  // through getOverlayMarkerBudgetState() so a test can assert that a view
+  // another render already re-planned is not rebuilt again.
+  private overlayRenderCount = 0;
   private lastTruncationLabelKey = '';
   private labelVisibilityScheduled = false;
   private pendingLabelVisibilityZoom = 1;
@@ -1766,6 +1770,7 @@ export class MapComponent {
     aircraft: readonly PositionSample[];
     protests: readonly SocialUnrestEvent[];
     conflictEvents: readonly AcledConflictEvent[];
+    weather: readonly WeatherAlert[];
   } {
     const withinTimeRange = <T extends { occurredAt: number }>(items: readonly T[]): readonly T[] => (
       this.state.timeRange === 'all'
@@ -1795,6 +1800,15 @@ export class MapComponent {
         ? this.protests.filter((event) => event.eventType === 'riot' || event.severity === 'high')
         : [],
       conflictEvents: withinTimeRange(layers.conflicts ? this.conflictEvents : []),
+      // `centroid` is optional on WeatherAlert and the render loop skips an alert
+      // without one, so an alert that can never become a marker must not be
+      // budgeted: it would inflate the `weather` group that fairShareCap sizes
+      // every other layer against, and overstate `total` in the shown/total badge
+      // with markers that were never renderable. Same plan/loop agreement rule as
+      // the earthquake slice (3356f19c8) — this is the only other feed with a
+      // per-marker data precondition; the `newsCount === 0` skips sit on exempt
+      // groups, which are outside the budget entirely.
+      weather: layers.weather ? this.weatherAlerts.filter((alert) => alert.centroid) : [],
     };
   }
 
@@ -1839,7 +1853,7 @@ export class MapComponent {
       add('natural', this.naturalEvents);
     }
     if (layers.economic) add('economic', ECONOMIC_CENTERS);
-    if (layers.weather) add('weather', this.weatherAlerts);
+    if (layers.weather) add('weather', slices.weather);
     if (layers.radiationWatch) add('radiationWatch', this.radiationObservations);
     if (layers.outages) add('outages', this.outages);
     if (layers.cables) {
@@ -1991,11 +2005,15 @@ export class MapComponent {
   /** Markers this render pass drew, and what the budget withheld (#7112). */
   public getOverlayMarkerBudgetState(): {
     rendered: number;
+    renders: number;
     truncated: Record<string, GlobeLayerTruncation>;
     undisclosed: string[];
   } {
     return {
       rendered: this.renderedOverlayMarkerCount,
+      // Overlay rebuild count. Lets a test assert that a view which another
+      // render already re-planned does not get rebuilt a second time.
+      renders: this.overlayRenderCount,
       truncated: this.overlayMarkerTruncation,
       // Layers trimmed with no toggle row to show a `shown/total` badge on.
       // Should be empty for any layer this variant's picker exposes.
@@ -2004,6 +2022,7 @@ export class MapComponent {
   }
 
   private renderOverlays(projection: d3.GeoProjection): void {
+    this.overlayRenderCount += 1;
     setTrustedHtml(this.overlays, trustedHtml('', "legacy direct innerHTML migration"));
     this.labelVisibilityScheduled = false;
     const slices = this.overlayFeedSlices();
@@ -2299,10 +2318,9 @@ export class MapComponent {
 
     // Weather Alerts (severity icons)
     if (this.state.layers.weather) {
-      this.weatherAlerts.forEach((alert) => {
+      slices.weather.forEach((alert) => {
         if (this.isOverlayMarkerCut(alert)) return;
-        if (!alert.centroid) return;
-        const pos = projection(alert.centroid);
+        const pos = projection(alert.centroid as [number, number]);
         if (!pos) return;
 
         const div = document.createElement('div');
@@ -4397,18 +4415,7 @@ export class MapComponent {
     const { width, height } = this.getKnownContainerSize();
     this.clampPan(width, height);
     const zoom = this.state.zoom;
-    // Only when something is actually being withheld: with nothing truncated the
-    // selection is view-independent, so a rebuild cannot change a single marker
-    // and would be pure churn on the very path this feature exists to make
-    // cheaper. Same guard, and same reason, as GlobeMap.reselectMarkersForViewport.
-    const overlayBudgetViewportChanged =
-      this.initialDynamicRendered &&
-      Object.keys(this.overlayMarkerTruncation).length > 0 &&
-      (this.lastOverlayBudgetViewport.width !== width ||
-        this.lastOverlayBudgetViewport.height !== height ||
-        this.lastOverlayBudgetViewport.zoom !== zoom ||
-        this.lastOverlayBudgetViewport.panX !== this.state.pan.x ||
-        this.lastOverlayBudgetViewport.panY !== this.state.pan.y);
+    const overlayBudgetViewportChanged = this.overlayBudgetPlanIsStale(width, height);
 
     // With transform-origin: 0 0, we need to offset to keep center in view
     // Formula: translate first to re-center, then scale
@@ -4473,8 +4480,37 @@ export class MapComponent {
     this.overlayBudgetReplanTimer = setTimeout(() => {
       this.overlayBudgetReplanTimer = null;
       if (this.destroyed) return;
+      // Re-test rather than firing unconditionally. A render triggered by
+      // anything else during the settle window — every setX() data setter calls
+      // render(), and feeds stream continuously — has already re-planned for the
+      // current viewport, so the plan is no longer stale and this timer would
+      // schedule a second full renderDynamicLayers() pass that cannot change a
+      // marker. That duplicate is the exact churn this debounce exists to remove.
+      const { width, height } = this.getKnownContainerSize();
+      if (!this.overlayBudgetPlanIsStale(width, height)) return;
       this.scheduleRender();
     }, MapComponent.OVERLAY_BUDGET_REPLAN_SETTLE_MS);
+  }
+
+  /**
+   * True when the stored budget plan was computed for a different viewport than
+   * the current one, AND re-planning could actually change what is drawn.
+   *
+   * The truncation test is the load-bearing half: with nothing withheld the
+   * selection is view-independent, so a rebuild cannot change a single marker and
+   * would be pure churn on the very path this feature exists to make cheaper.
+   * Same guard, and same reason, as GlobeMap.reselectMarkersForViewport.
+   */
+  private overlayBudgetPlanIsStale(width: number, height: number): boolean {
+    return (
+      this.initialDynamicRendered &&
+      Object.keys(this.overlayMarkerTruncation).length > 0 &&
+      (this.lastOverlayBudgetViewport.width !== width ||
+        this.lastOverlayBudgetViewport.height !== height ||
+        this.lastOverlayBudgetViewport.zoom !== this.state.zoom ||
+        this.lastOverlayBudgetViewport.panX !== this.state.pan.x ||
+        this.lastOverlayBudgetViewport.panY !== this.state.pan.y)
+    );
   }
 
   private shouldUpdateLabelVisibility(): boolean {

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -279,6 +279,16 @@ export class MapComponent {
   // written — lets applyTransform() skip same-value setProperty calls that
   // would restyle every marker on every render pass.
   private lastOverlayVarZoom = '';
+  // The overlay budget is planned for the transformed viewport. Keep the last
+  // planned transform so pan/zoom can request one coalesced rebuild instead of
+  // leaving the previous view's nearest markers on screen.
+  private lastOverlayBudgetViewport = {
+    width: Number.NaN,
+    height: Number.NaN,
+    zoom: Number.NaN,
+    panX: Number.NaN,
+    panY: Number.NaN,
+  };
   // Desktop measures label overlap from the start; mobile defers until the first
   // interaction. The effective value is set in the constructor (= !this.isMobile);
   // false here documents the mobile-off default.
@@ -1880,9 +1890,9 @@ export class MapComponent {
     // drops whatever is furthest from what the user is looking at instead of
     // whatever happens to sort last. See proximityRank.
     const { width, height } = this.getKnownContainerSize();
-    const centre = projection.invert?.([width / 2, height / 2]);
+    const centre = this.getOverlayBudgetCentre(projection, width, height);
     const nearestFirst = proximityRank<unknown>(
-      { lat: centre?.[1] ?? 0, lng: centre?.[0] ?? 0 },
+      centre,
       overlayMarkerPosition,
     );
     for (const group of groups) {
@@ -1907,7 +1917,36 @@ export class MapComponent {
     this.overlayMarkerCut = cut;
     this.overlayMarkerTruncation = truncated;
     this.renderedOverlayMarkerCount = markers.length;
+    this.lastOverlayBudgetViewport = {
+      width,
+      height,
+      zoom: this.state.zoom,
+      panX: this.state.pan.x,
+      panY: this.state.pan.y,
+    };
     this.updateLayerTruncationLabels();
+  }
+
+  /**
+   * Return the geographic point currently at the screen centre.
+   *
+   * The SVG projection is transformed by CSS after it produces marker
+   * coordinates. Inverting the untransformed screen centre therefore ranks the
+   * old map centre after a pan or zoom. Undo the same translate/scale that
+   * applyTransform() applies before asking d3 for the geographic coordinate.
+   */
+  private getOverlayBudgetCentre(
+    projection: d3.GeoProjection,
+    width: number,
+    height: number,
+  ): LatLng {
+    const zoom = Math.max(this.state.zoom, Number.EPSILON);
+    const rawCentre = [
+      width / (2 * zoom) - this.state.pan.x,
+      height / (2 * zoom) - this.state.pan.y,
+    ] as [number, number];
+    const centre = projection.invert?.(rawCentre);
+    return { lat: centre?.[1] ?? 0, lng: centre?.[0] ?? 0 };
   }
 
   /** True when this render pass withheld `marker` under the overlay budget (#7112). */
@@ -4366,6 +4405,13 @@ export class MapComponent {
     const { width, height } = this.getKnownContainerSize();
     this.clampPan(width, height);
     const zoom = this.state.zoom;
+    const overlayBudgetViewportChanged =
+      this.initialDynamicRendered &&
+      (this.lastOverlayBudgetViewport.width !== width ||
+        this.lastOverlayBudgetViewport.height !== height ||
+        this.lastOverlayBudgetViewport.zoom !== zoom ||
+        this.lastOverlayBudgetViewport.panX !== this.state.pan.x ||
+        this.lastOverlayBudgetViewport.panY !== this.state.pan.y);
 
     // With transform-origin: 0 0, we need to offset to keep center in view
     // Formula: translate first to re-center, then scale
@@ -4400,7 +4446,9 @@ export class MapComponent {
     if (this.shouldUpdateLabelVisibility()) this.updateLabelVisibility(zoom);
     const zoomVisibilityChanged = this.updateZoomLayerVisibility();
     this.emitStateChange();
-    if (rebuildOnZoomVisibilityChange && zoomVisibilityChanged) this.scheduleRender();
+    if ((rebuildOnZoomVisibilityChange && zoomVisibilityChanged) || overlayBudgetViewportChanged) {
+      this.scheduleRender();
+    }
   }
 
   private shouldUpdateLabelVisibility(): boolean {

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -157,6 +157,10 @@ export class MapComponent {
   // fling coalesces into ONE rebuild; short enough that the badge's "pan or zoom
   // to bring others in" is true promptly once the user stops.
   private static readonly OVERLAY_BUDGET_REPLAN_SETTLE_MS = 200;
+  // #7112: ceiling on concurrent news flashes. They are `#mapOverlays` children
+  // created outside the marker budget, so this is what keeps the overlay's total
+  // node count bounded rather than "bounded plus however much news arrived".
+  private static readonly MAX_CONCURRENT_MAP_FLASHES = 12;
   private static readonly LAYER_ZOOM_THRESHOLDS: Partial<
     Record<keyof MapLayers, { minZoom: number; showLabels?: number }>
   > = {
@@ -260,6 +264,10 @@ export class MapComponent {
   private overlayMarkerCut: Set<unknown> = new Set();
   // Pending settle-debounced budget re-plan; see scheduleOverlayBudgetReplan().
   private overlayBudgetReplanTimer: ReturnType<typeof setTimeout> | null = null;
+  // Live news-flash nodes -> their expiry timer, insertion-ordered so the oldest
+  // can be evicted when MAX_CONCURRENT_MAP_FLASHES is reached. Also lets destroy()
+  // clear timers that would otherwise fire against a torn-down instance.
+  private readonly activeFlashes = new Map<HTMLElement, ReturnType<typeof setTimeout>>();
   private overlayMarkerTruncation: Record<string, GlobeLayerTruncation> = {};
   // Truncated layer keys with no toggle row to disclose them on; see
   // updateLayerTruncationLabels().
@@ -435,6 +443,11 @@ export class MapComponent {
       clearTimeout(this.overlayBudgetReplanTimer);
       this.overlayBudgetReplanTimer = null;
     }
+    for (const [flash, timer] of this.activeFlashes) {
+      clearTimeout(timer);
+      flash.remove();
+    }
+    this.activeFlashes.clear();
     window.removeEventListener('theme-changed', this.handleThemeChange);
     document.removeEventListener('visibilitychange', this.boundVisibilityHandler);
     if (this.resizeObserver) {
@@ -1986,17 +1999,34 @@ export class MapComponent {
    * a newly-added rowless layer trips the guard test instead of going quiet.
    */
   private updateLayerTruncationLabels(): void {
+    const root = this.container.querySelector<HTMLElement>('#layerToggles');
+
+    if (!root) {
+      // No toggle rail exists at all. `chrome: false` builds one of these on
+      // purpose (src/embed/panels/map.ts) — an embed has no controls — so there
+      // is nowhere for any `shown/total` badge to go and EVERY trimmed layer is
+      // undisclosed. Recording the honest set matters more here than anywhere
+      // else: returning early without touching it left
+      // getOverlayMarkerBudgetState().undisclosed reading `[]`, i.e. reporting
+      // full disclosure while the embed silently withheld markers, and any test
+      // asserting `undisclosed` is empty passed for that reason rather than
+      // because the cut was shown.
+      //
+      // Recomputed on every pass rather than latched: the key latch below only
+      // advances when badges were actually written, so a map that never has a
+      // rail would otherwise keep a stale set once truncation changed or cleared.
+      this.overlayUndisclosedTruncation = Object.keys(this.overlayMarkerTruncation);
+      return;
+    }
+
     const key = Object.entries(this.overlayMarkerTruncation)
       .map(([layer, counts]) => `${layer}:${counts.shown}/${counts.total}`)
       .sort()
       .join(',');
+    // Same key means the same truncation, so the badges and the undisclosed set
+    // are both already correct. Latching only after the write above is what lets
+    // a render that ran before the rail existed be redone once it appears.
     if (key === this.lastTruncationLabelKey) return;
-
-    const root = this.container.querySelector<HTMLElement>('#layerToggles');
-    // Latch only once the badges were actually written. Latching first would
-    // let a render that ran before the toggle rail existed record the key and
-    // then skip the write forever, because the next identical key short-circuits.
-    if (!root) return;
     this.lastTruncationLabelKey = key;
     const { undisclosed } = renderLayerTruncationBadges(root, this.overlayMarkerTruncation, 'pan');
     this.overlayUndisclosedTruncation = undisclosed;
@@ -4053,10 +4083,48 @@ export class MapComponent {
     flash.style.top = `${pos[1]}px`;
     flash.style.setProperty('--flash-duration', `${durationMs}ms`);
     this.appendOverlay(flash);
+    this.trackFlash(flash, durationMs);
+  }
 
-    window.setTimeout(() => {
+  /**
+   * Holds concurrent news flashes to a fixed ceiling (#7112).
+   *
+   * A flash is a `#mapOverlays` child like every budgeted marker, but it is
+   * created outside planOverlayMarkerBudget() — so without a bound of its own it
+   * is simply unbounded DOM on the overlay the budget exists to cap. The comment
+   * above records the real volume: flashMapForNews() fires "in bursts across load
+   * passes (hundreds of calls shortly after load)", and each node lives
+   * `durationMs`, so hundreds can coexist with a full 800-marker overlay and the
+   * stated whole-overlay ceiling stops being true.
+   *
+   * A separate bounded exemption rather than a budget group, because a flash is
+   * transient decoration on a news item, not a feed the fair-share cap should be
+   * sized against: making it compete would let a news burst evict real markers.
+   * Newest wins — an old flash is nearly expired anyway, and dropping the newest
+   * would hide the item that just arrived.
+   */
+  private trackFlash(flash: HTMLElement, durationMs: number): void {
+    const expire = setTimeout(() => {
+      this.activeFlashes.delete(flash);
       flash.remove();
     }, durationMs);
+    this.activeFlashes.set(flash, expire);
+
+    while (this.activeFlashes.size > MapComponent.MAX_CONCURRENT_MAP_FLASHES) {
+      // Map iteration is insertion-ordered, so this is the oldest live flash.
+      const [oldest, oldestTimer] = this.activeFlashes.entries().next().value as [
+        HTMLElement,
+        ReturnType<typeof setTimeout>,
+      ];
+      clearTimeout(oldestTimer);
+      this.activeFlashes.delete(oldest);
+      oldest.remove();
+    }
+  }
+
+  /** Live news flashes, so a test can prove the ceiling holds. */
+  public getActiveFlashCount(): number {
+    return this.activeFlashes.size;
   }
 
   public initEscalationGetters(): void {

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -58,6 +58,11 @@ import type { CountryClickPayload } from './DeckGLMap';
 import { t } from '@/services/i18n';
 import type { ScenarioVisualState } from '@/config/scenario-templates';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { renderLayerTruncationBadges } from '@/utils/layer-truncation-badge';
+import {
+  overlayMarkerPosition,
+  projectionPointAtScreenCentre,
+} from '@/utils/overlay-marker-geometry';
 import {
   MAP_OVERLAY_MARKER_BUDGET_DESKTOP,
   MAP_OVERLAY_MARKER_BUDGET_MOBILE,
@@ -128,27 +133,6 @@ interface WorldTopology extends Topology {
 }
 
 /**
- * Reads a marker's coordinates across every feed shape `renderOverlays` iterates
- * (#7112): most expose `lon`/`lat`, webcams use `lng`, Iran events use the long
- * spellings, earthquakes and ACLED events nest them under `location`, and
- * conflict zones carry a `[lon, lat]` `center` tuple. A shape with none of them
- * yields NaN, which `proximityRank` already sorts last rather than poisoning the
- * comparator — the same outcome as the render loops, which skip a null position.
- */
-function overlayMarkerPosition(marker: unknown): LatLng {
-  const m = marker as {
-    lat?: number; lon?: number; lng?: number;
-    latitude?: number; longitude?: number;
-    location?: { latitude?: number; longitude?: number } | null;
-    center?: readonly [number, number];
-  };
-  return {
-    lat: m.lat ?? m.latitude ?? m.location?.latitude ?? m.center?.[1] ?? Number.NaN,
-    lng: m.lon ?? m.lng ?? m.longitude ?? m.location?.longitude ?? m.center?.[0] ?? Number.NaN,
-  };
-}
-
-/**
  * The AI data centres the SVG overlay actually draws (>=10k GPUs). Hoisted to
  * module scope so the overlay marker budget (#7112) plans on exactly the list
  * the render loop iterates, rather than on a superset that would spend fair
@@ -168,6 +152,11 @@ export class MapComponent {
   // the count), so after the attention window the pulses are switched off via
   // the .markers-settled class. Any overlay re-render re-arms the window.
   private static readonly MARKER_SETTLE_MS = 6000;
+  // #7112: how long the view must be still before the overlay marker budget is
+  // re-planned for the new centre. Longer than a frame so a drag or an inertia
+  // fling coalesces into ONE rebuild; short enough that the badge's "pan or zoom
+  // to bring others in" is true promptly once the user stops.
+  private static readonly OVERLAY_BUDGET_REPLAN_SETTLE_MS = 200;
   private static readonly LAYER_ZOOM_THRESHOLDS: Partial<
     Record<keyof MapLayers, { minZoom: number; showLabels?: number }>
   > = {
@@ -269,7 +258,12 @@ export class MapComponent {
   // NOT in the plan simply never appears here and renders in full. That makes a
   // plan/render mismatch fail safe (an unbudgeted layer, not a blank one).
   private overlayMarkerCut: Set<unknown> = new Set();
+  // Pending settle-debounced budget re-plan; see scheduleOverlayBudgetReplan().
+  private overlayBudgetReplanTimer: ReturnType<typeof setTimeout> | null = null;
   private overlayMarkerTruncation: Record<string, GlobeLayerTruncation> = {};
+  // Truncated layer keys with no toggle row to disclose them on; see
+  // updateLayerTruncationLabels().
+  private overlayUndisclosedTruncation: string[] = [];
   private renderedOverlayMarkerCount = 0;
   private lastTruncationLabelKey = '';
   private labelVisibilityScheduled = false;
@@ -432,6 +426,10 @@ export class MapComponent {
     if (this.markerSettleTimer !== null) {
       clearTimeout(this.markerSettleTimer);
       this.markerSettleTimer = null;
+    }
+    if (this.overlayBudgetReplanTimer !== null) {
+      clearTimeout(this.overlayBudgetReplanTimer);
+      this.overlayBudgetReplanTimer = null;
     }
     window.removeEventListener('theme-changed', this.handleThemeChange);
     document.removeEventListener('visibilitychange', this.boundVisibilityHandler);
@@ -1829,10 +1827,10 @@ export class MapComponent {
       add('conflicts', CONFLICT_ZONES);
       add('conflicts', slices.conflictEvents, { rank: (m) => (m as AcledConflictEvent).fatalities ?? 0 });
     }
-    // Planned on the whole feed rather than the mobile-trimmed slice the loop
-    // iterates. The trim only ever removes markers, so planning the superset
-    // can render fewer than the cap but never more — and both feeds rank so the
-    // markers the trim keeps are the ones the budget keeps too.
+    // The mobile-trimmed slice, i.e. exactly what the loop iterates. Planning the
+    // untrimmed field here would spend this layer's fair share on events the
+    // MOBILE_MAX_IRAN_EVENTS cut then discards — the same slice/loop mismatch
+    // that 3356f19c8 fixed for earthquakes.
     if (layers.iranAttacks) add('iranAttacks', slices.iranEvents);
     if (layers.hotspots) add('hotspots', this.hotspots);
     if (this.isLayerZoomVisible('bases')) add('bases', this.getMilitaryBasesForRender());
@@ -1940,12 +1938,7 @@ export class MapComponent {
     width: number,
     height: number,
   ): LatLng {
-    const zoom = Math.max(this.state.zoom, Number.EPSILON);
-    const rawCentre = [
-      width / (2 * zoom) - this.state.pan.x,
-      height / (2 * zoom) - this.state.pan.y,
-    ] as [number, number];
-    const centre = projection.invert?.(rawCentre);
+    const centre = projection.invert?.(projectionPointAtScreenCentre(width, height, this.state.pan));
     return { lat: centre?.[1] ?? 0, lng: centre?.[0] ?? 0 };
   }
 
@@ -1969,6 +1962,14 @@ export class MapComponent {
    * globe does — a ceiling the user cannot see is indistinguishable from missing
    * data. Skipped when nothing changed: this runs on every render pass, and the
    * writes would restyle the toggle rows each time (#5080).
+   *
+   * A layer the budget trimmed that has no toggle row in this variant's picker
+   * (`fires` outside the energy variant, `webcams`, `radiationWatch`,
+   * `spaceports`) has nowhere to show a badge. Those stay budgeted — an
+   * unbounded feed is what #7112 is about, and `toMapFires` caps nothing — but
+   * the cut is recorded on `overlayUndisclosedTruncation` and surfaced through
+   * getOverlayMarkerBudgetState() rather than vanishing, so it is assertable and
+   * a newly-added rowless layer trips the guard test instead of going quiet.
    */
   private updateLayerTruncationLabels(): void {
     const key = Object.entries(this.overlayMarkerTruncation)
@@ -1983,32 +1984,23 @@ export class MapComponent {
     // then skip the write forever, because the next identical key short-circuits.
     if (!root) return;
     this.lastTruncationLabelKey = key;
-    for (const row of Array.from(root.querySelectorAll<HTMLElement>('.layer-toggle-row'))) {
-      const layer = row.dataset.layer;
-      const counts = layer ? this.overlayMarkerTruncation[layer] : undefined;
-      const existing = row.querySelector<HTMLElement>('.layer-truncation-count');
-      if (!counts) { existing?.remove(); continue; }
-      const badge = existing ?? document.createElement('span');
-      if (!existing) {
-        // Sibling of the toggle button, not a child: inside it every click on
-        // the badge would toggle the layer off.
-        badge.className = 'layer-truncation-count';
-        row.appendChild(badge);
-      }
-      badge.textContent = `${counts.shown}/${counts.total}`;
-      // Untranslated literal, matching GlobeMap.updateLayerTruncationLabels — a
-      // new i18n key is a ~29-file change across locales and the badge itself is
-      // numeric. Tracked as the same follow-up.
-      badge.title = `Showing ${counts.shown} of ${counts.total} markers — the most significant, and those nearest the current view. The map caps markers per layer to keep interaction responsive; pan or zoom to bring others in.`;
-    }
+    const { undisclosed } = renderLayerTruncationBadges(root, this.overlayMarkerTruncation, 'pan');
+    this.overlayUndisclosedTruncation = undisclosed;
   }
 
   /** Markers this render pass drew, and what the budget withheld (#7112). */
   public getOverlayMarkerBudgetState(): {
     rendered: number;
     truncated: Record<string, GlobeLayerTruncation>;
+    undisclosed: string[];
   } {
-    return { rendered: this.renderedOverlayMarkerCount, truncated: this.overlayMarkerTruncation };
+    return {
+      rendered: this.renderedOverlayMarkerCount,
+      truncated: this.overlayMarkerTruncation,
+      // Layers trimmed with no toggle row to show a `shown/total` badge on.
+      // Should be empty for any layer this variant's picker exposes.
+      undisclosed: this.overlayUndisclosedTruncation,
+    };
   }
 
   private renderOverlays(projection: d3.GeoProjection): void {
@@ -4405,8 +4397,13 @@ export class MapComponent {
     const { width, height } = this.getKnownContainerSize();
     this.clampPan(width, height);
     const zoom = this.state.zoom;
+    // Only when something is actually being withheld: with nothing truncated the
+    // selection is view-independent, so a rebuild cannot change a single marker
+    // and would be pure churn on the very path this feature exists to make
+    // cheaper. Same guard, and same reason, as GlobeMap.reselectMarkersForViewport.
     const overlayBudgetViewportChanged =
       this.initialDynamicRendered &&
+      Object.keys(this.overlayMarkerTruncation).length > 0 &&
       (this.lastOverlayBudgetViewport.width !== width ||
         this.lastOverlayBudgetViewport.height !== height ||
         this.lastOverlayBudgetViewport.zoom !== zoom ||
@@ -4446,9 +4443,38 @@ export class MapComponent {
     if (this.shouldUpdateLabelVisibility()) this.updateLabelVisibility(zoom);
     const zoomVisibilityChanged = this.updateZoomLayerVisibility();
     this.emitStateChange();
-    if ((rebuildOnZoomVisibilityChange && zoomVisibilityChanged) || overlayBudgetViewportChanged) {
+    if (rebuildOnZoomVisibilityChange && zoomVisibilityChanged) {
       this.scheduleRender();
+    } else if (overlayBudgetViewportChanged) {
+      this.scheduleOverlayBudgetReplan();
     }
+  }
+
+  /**
+   * Re-plan the overlay budget once the view stops moving (#7112).
+   *
+   * applyTransform() runs on every mousemove/touchmove/wheel and on each frame
+   * of the touch-inertia loop. Re-planning from there directly would put a full
+   * renderDynamicLayers() pass — which wipes and rebuilds cables, pipelines,
+   * conflicts, AIS density, clusters AND every overlay marker with a fresh
+   * click listener — on the interaction path at up to 1000/MIN_RENDER_INTERVAL_MS
+   * per second, where a pan used to be a pure CSS transform with no DOM work at
+   * all. It would also re-arm armMarkerSettle() continuously, holding every
+   * marker in the infinite-pulse state (and its compositing layer, #4669) for
+   * the whole gesture.
+   *
+   * So coalesce to the settle instead, which is what GlobeMap does by re-selecting
+   * on the controls 'end' event rather than during the drag. The markers on
+   * screen stay correct for the pre-gesture POV while the finger is down and
+   * are re-ranked once, when the user stops.
+   */
+  private scheduleOverlayBudgetReplan(): void {
+    if (this.overlayBudgetReplanTimer !== null) clearTimeout(this.overlayBudgetReplanTimer);
+    this.overlayBudgetReplanTimer = setTimeout(() => {
+      this.overlayBudgetReplanTimer = null;
+      if (this.destroyed) return;
+      this.scheduleRender();
+    }, MapComponent.OVERLAY_BUDGET_REPLAN_SETTLE_MS);
   }
 
   private shouldUpdateLabelVisibility(): boolean {
@@ -4617,10 +4643,9 @@ export class MapComponent {
     const { width, height } = this.readContainerSize();
     const projection = this.getProjection(width, height);
     if (!projection.invert) return null;
-    const zoom = this.state.zoom;
-    const centerX = width / (2 * zoom) - this.state.pan.x;
-    const centerY = height / (2 * zoom) - this.state.pan.y;
-    const coords = projection.invert([centerX, centerY]);
+    const coords = projection.invert(
+      projectionPointAtScreenCentre(width, height, this.state.pan),
+    );
     if (!coords) return null;
     return { lon: coords[0], lat: coords[1] };
   }

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -2016,6 +2016,7 @@ export class MapComponent {
       // advances when badges were actually written, so a map that never has a
       // rail would otherwise keep a stale set once truncation changed or cleared.
       this.overlayUndisclosedTruncation = Object.keys(this.overlayMarkerTruncation);
+      this.renderCompactTruncationSummary();
       return;
     }
 
@@ -2030,6 +2031,57 @@ export class MapComponent {
     this.lastTruncationLabelKey = key;
     const { undisclosed } = renderLayerTruncationBadges(root, this.overlayMarkerTruncation, 'pan');
     this.overlayUndisclosedTruncation = undisclosed;
+  }
+
+  /**
+   * The one disclosure a chrome-less map can still make (#7112).
+   *
+   * `chrome: false` (src/embed/panels/map.ts) deliberately builds no controls, so
+   * there is no toggle row to hang a per-layer `shown/total` badge on. Recording
+   * the undisclosed set above makes the state honest, but the person looking at
+   * the embed still sees a partial map and no reason for it — and "a ceiling the
+   * user cannot see is indistinguishable from missing data" is the whole argument
+   * the per-layer badge rests on.
+   *
+   * So state the total, compactly, inside the map itself. Deliberately NOT a
+   * control: no click target, no toggle, nothing that reintroduces the chrome the
+   * embed opted out of — just the count and a `title` carrying the explanation.
+   * Idempotent (one node, updated in place) and removed the moment nothing is
+   * being withheld, so it cannot accumulate across renders or outlive the cut.
+   *
+   * Only for the no-rail case. A map that HAS a rail but whose trimmed layer has
+   * no row in that variant's picker is the separate problem tracked in #7144;
+   * fixing it with a second, parallel disclosure surface would be the wrong shape.
+   */
+  private renderCompactTruncationSummary(): void {
+    const entries = Object.values(this.overlayMarkerTruncation);
+    const existing = this.container.querySelector<HTMLElement>('.map-truncation-summary');
+
+    if (entries.length === 0) {
+      existing?.remove();
+      return;
+    }
+
+    const shown = entries.reduce((sum, counts) => sum + counts.shown, 0);
+    const total = entries.reduce((sum, counts) => sum + counts.total, 0);
+    const summary = existing ?? document.createElement('div');
+    if (!existing) {
+      summary.className = 'map-truncation-summary';
+      // The summary is absolutely positioned, and MapComponent does not own the
+      // container's CSS — an embed host supplies it. `.map-container` happens to
+      // be `position: relative`, but a static container would let the summary
+      // escape to some ancestor and land anywhere on the host page. Establish the
+      // containing block once, on creation only, so this costs a style resolution
+      // the first time a chrome-less map is over budget and never again.
+      if (getComputedStyle(this.container).position === 'static') {
+        this.container.style.position = 'relative';
+      }
+      this.container.appendChild(summary);
+    }
+    summary.textContent = `${shown}/${total} markers`;
+    // Untranslated literal, matching the per-layer badge and its existing i18n
+    // follow-up.
+    summary.title = `Showing ${shown} of ${total} markers — the most significant, and those nearest the current view. The map caps markers per layer to keep interaction responsive; pan or zoom to bring others in.`;
   }
 
   /** Markers this render pass drew, and what the budget withheld (#7112). */

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -1743,7 +1743,51 @@ export class MapComponent {
    * a layer it can see. The plan is stored as the set of markers to WITHHOLD, so
    * a feed absent from the plan renders in full rather than disappearing.
    */
-  private planOverlayMarkerBudget(projection: d3.GeoProjection): void {
+  /**
+   * The exact slice of each filtered feed that `renderOverlays` will draw.
+   *
+   * The budget plan and the render loops MUST agree on these (#7112). Planning
+   * on the unfiltered field instead would let the budget spend its fair share
+   * on markers the loop then filters away: a 24-hour time filter over a
+   * 2,000-event earthquake feed would keep the 300 largest of all time, most of
+   * them outside the window, and render a fraction of what the ceiling allows.
+   */
+  private overlayFeedSlices(): {
+    quakes: readonly Earthquake[];
+    iranEvents: readonly IranEvent[];
+    aircraft: readonly PositionSample[];
+    protests: readonly SocialUnrestEvent[];
+    conflictEvents: readonly AcledConflictEvent[];
+  } {
+    const withinTimeRange = <T extends { occurredAt: number }>(items: readonly T[]): readonly T[] => (
+      this.state.timeRange === 'all'
+        ? items
+        : items.filter((item) => item.occurredAt >= Date.now() - this.getTimeRangeMs())
+    );
+    const filteredQuakes = withinTimeRange(this.earthquakes);
+    return {
+      quakes: this.isMobile
+        ? filteredQuakes.filter((eq) => eq.magnitude >= MapComponent.MOBILE_MIN_EARTHQUAKE_MAGNITUDE)
+        : filteredQuakes,
+      iranEvents: this.isMobile
+        ? this.iranEvents.slice(0, MapComponent.MOBILE_MAX_IRAN_EVENTS)
+        : this.iranEvents,
+      // Already capped at 200 by the render loop; planned on the same slice so
+      // the budget cannot spend share on the 201st position onwards.
+      aircraft: this.aircraftPositions.slice(0, 200),
+      // Only riots and high-severity unrest reach the map; the rest stay in the
+      // CII analysis. Budgeting the full feed would cut the ones that render.
+      protests: this.protests.filter(
+        (event) => event.eventType === 'riot' || event.severity === 'high',
+      ),
+      conflictEvents: withinTimeRange(this.conflictEvents),
+    };
+  }
+
+  private planOverlayMarkerBudget(
+    projection: d3.GeoProjection,
+    slices: ReturnType<MapComponent['overlayFeedSlices']>,
+  ): void {
     const groups: GlobeMarkerGroup<unknown>[] = [];
     const add = (
       layer: string,
@@ -1767,17 +1811,17 @@ export class MapComponent {
     if (layers.irradiators) add('irradiators', GAMMA_IRRADIATORS);
     if (layers.conflicts) {
       add('conflicts', CONFLICT_ZONES);
-      add('conflicts', this.conflictEvents, { rank: (m) => (m as AcledConflictEvent).fatalities ?? 0 });
+      add('conflicts', slices.conflictEvents, { rank: (m) => (m as AcledConflictEvent).fatalities ?? 0 });
     }
     // Planned on the whole feed rather than the mobile-trimmed slice the loop
     // iterates. The trim only ever removes markers, so planning the superset
     // can render fewer than the cap but never more — and both feeds rank so the
     // markers the trim keeps are the ones the budget keeps too.
-    if (layers.iranAttacks) add('iranAttacks', this.iranEvents);
+    if (layers.iranAttacks) add('iranAttacks', slices.iranEvents);
     if (layers.hotspots) add('hotspots', this.hotspots);
     if (this.isLayerZoomVisible('bases')) add('bases', this.getMilitaryBasesForRender());
     if (layers.natural) {
-      add('natural', this.earthquakes, { rank: (m) => (m as Earthquake).magnitude ?? 0 });
+      add('natural', slices.quakes, { rank: (m) => (m as Earthquake).magnitude ?? 0 });
       add('natural', this.naturalEvents);
     }
     if (layers.economic) add('economic', ECONOMIC_CENTERS);
@@ -1800,10 +1844,10 @@ export class MapComponent {
     if (layers.financialCenters) add('financialCenters', FINANCIAL_CENTERS);
     if (layers.centralBanks) add('centralBanks', CENTRAL_BANKS);
     if (layers.commodityHubs) add('commodityHubs', COMMODITY_HUBS);
-    if (layers.protests) add('protests', this.protests);
+    if (layers.protests) add('protests', slices.protests);
     if (layers.flights) {
       add('flights', this.flightDelays);
-      add('flights', this.aircraftPositions);
+      add('flights', slices.aircraft);
     }
     if (layers.military) {
       add('military', this.militaryFlights);
@@ -1922,7 +1966,8 @@ export class MapComponent {
   private renderOverlays(projection: d3.GeoProjection): void {
     setTrustedHtml(this.overlays, trustedHtml('', "legacy direct innerHTML migration"));
     this.labelVisibilityScheduled = false;
-    this.planOverlayMarkerBudget(projection);
+    const slices = this.overlayFeedSlices();
+    this.planOverlayMarkerBudget(projection, slices);
     const fragment = document.createDocumentFragment();
     const previousTarget = this.overlayAppendTarget;
     this.overlayAppendTarget = fragment;
@@ -2029,15 +2074,12 @@ export class MapComponent {
 
         this.appendOverlay(clickArea);
       });
-      this.renderConflictEventMarkers(projection);
+      this.renderConflictEventMarkers(projection, slices.conflictEvents);
     }
 
     // Iran events (severity-colored circles matching DeckGL layer)
     if (this.state.layers.iranAttacks && this.iranEvents.length > 0) {
-      const iranEventsForRender = this.isMobile
-        ? this.iranEvents.slice(0, MapComponent.MOBILE_MAX_IRAN_EVENTS)
-        : this.iranEvents;
-      iranEventsForRender.forEach((ev) => {
+      slices.iranEvents.forEach((ev) => {
         if (this.isOverlayMarkerCut(ev)) return;
         const pos = projection([ev.longitude, ev.latitude]);
         if (!pos || !Number.isFinite(pos[0]) || !Number.isFinite(pos[1])) return;
@@ -2140,12 +2182,7 @@ export class MapComponent {
     // Earthquakes (magnitude-based sizing) - part of NATURAL layer
     if (this.state.layers.natural) {
       console.log('[Map] Rendering earthquakes. Total:', this.earthquakes.length, 'Layer enabled:', this.state.layers.natural);
-      const filteredQuakes = this.state.timeRange === 'all'
-        ? this.earthquakes
-        : this.earthquakes.filter((eq) => eq.occurredAt >= Date.now() - this.getTimeRangeMs());
-      const quakesForRender = this.isMobile
-        ? filteredQuakes.filter((eq) => eq.magnitude >= MapComponent.MOBILE_MIN_EARTHQUAKE_MAGNITUDE)
-        : filteredQuakes;
+      const quakesForRender = slices.quakes;
       console.log('[Map] After time/mobile filter:', quakesForRender.length, 'earthquakes. TimeRange:', this.state.timeRange);
       let rendered = 0;
       quakesForRender.forEach((eq) => {
@@ -2984,11 +3021,7 @@ export class MapComponent {
     // Protests / Social Unrest Events (severity colors + icons) - with clustering
     // Filter to show only significant events on map (all events still used for CII analysis)
     if (this.state.layers.protests) {
-      const significantProtests = this.keepBudgetedMarkers(this.protests).filter((event) => {
-        // Only show riots and high severity (red markers)
-        // All protests still counted in CII analysis
-        return event.eventType === 'riot' || event.severity === 'high';
-      });
+      const significantProtests = this.keepBudgetedMarkers(slices.protests);
 
       const clusterRadius = this.state.zoom >= 4 ? 12 : this.state.zoom >= 3 ? 20 : 35;
       const clusters = this.clusterMarkers(significantProtests, projection, clusterRadius, p => p.country);
@@ -3093,7 +3126,7 @@ export class MapComponent {
 
     // Aircraft positions (simplified dots in SVG fallback, limited to 200)
     if (this.state.layers.flights) {
-      this.aircraftPositions.slice(0, 200).forEach((ac) => {
+      slices.aircraft.forEach((ac) => {
         if (this.isOverlayMarkerCut(ac)) return;
         const pt = projection([ac.lon, ac.lat]);
         if (!pt) return;
@@ -3464,11 +3497,11 @@ export class MapComponent {
     }, MapComponent.MARKER_SETTLE_MS);
   }
 
-  private renderConflictEventMarkers(projection: d3.GeoProjection): void {
-    const budgetedEvents = this.keepBudgetedMarkers(this.conflictEvents);
-    const visibleEvents = this.state.timeRange === 'all'
-      ? budgetedEvents
-      : budgetedEvents.filter((event) => event.occurredAt >= Date.now() - this.getTimeRangeMs());
+  private renderConflictEventMarkers(
+    projection: d3.GeoProjection,
+    conflictEvents: readonly AcledConflictEvent[],
+  ): void {
+    const visibleEvents = this.keepBudgetedMarkers(conflictEvents);
     const clusters = this.clusterMarkers(
       visibleEvents
         .map((event) => ({

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -1931,10 +1931,13 @@ export class MapComponent {
       .sort()
       .join(',');
     if (key === this.lastTruncationLabelKey) return;
-    this.lastTruncationLabelKey = key;
 
     const root = this.container.querySelector<HTMLElement>('#layerToggles');
+    // Latch only once the badges were actually written. Latching first would
+    // let a render that ran before the toggle rail existed record the key and
+    // then skip the write forever, because the next identical key short-circuits.
     if (!root) return;
+    this.lastTruncationLabelKey = key;
     for (const row of Array.from(root.querySelectorAll<HTMLElement>('.layer-toggle-row'))) {
       const layer = row.dataset.layer;
       const counts = layer ? this.overlayMarkerTruncation[layer] : undefined;

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -59,6 +59,15 @@ import { t } from '@/services/i18n';
 import type { ScenarioVisualState } from '@/config/scenario-templates';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import {
+  MAP_OVERLAY_MARKER_BUDGET_DESKTOP,
+  MAP_OVERLAY_MARKER_BUDGET_MOBILE,
+  proximityRank,
+  selectGlobeMarkers,
+  type GlobeLayerTruncation,
+  type GlobeMarkerGroup,
+  type LatLng,
+} from '@/utils/globe-marker-budget';
+import {
   getLayerExplanation,
   hasCuratedLayerExplanation,
   isLayerExecutable,
@@ -117,6 +126,38 @@ interface WorldTopology extends Topology {
     countries: GeometryCollection;
   };
 }
+
+/**
+ * Reads a marker's coordinates across every feed shape `renderOverlays` iterates
+ * (#7112): most expose `lon`/`lat`, webcams use `lng`, Iran events use the long
+ * spellings, earthquakes and ACLED events nest them under `location`, and
+ * conflict zones carry a `[lon, lat]` `center` tuple. A shape with none of them
+ * yields NaN, which `proximityRank` already sorts last rather than poisoning the
+ * comparator — the same outcome as the render loops, which skip a null position.
+ */
+function overlayMarkerPosition(marker: unknown): LatLng {
+  const m = marker as {
+    lat?: number; lon?: number; lng?: number;
+    latitude?: number; longitude?: number;
+    location?: { latitude?: number; longitude?: number } | null;
+    center?: readonly [number, number];
+  };
+  return {
+    lat: m.lat ?? m.latitude ?? m.location?.latitude ?? m.center?.[1] ?? Number.NaN,
+    lng: m.lon ?? m.lng ?? m.longitude ?? m.location?.longitude ?? m.center?.[0] ?? Number.NaN,
+  };
+}
+
+/**
+ * The AI data centres the SVG overlay actually draws (>=10k GPUs). Hoisted to
+ * module scope so the overlay marker budget (#7112) plans on exactly the list
+ * the render loop iterates, rather than on a superset that would spend fair
+ * share on markers that were never going to appear.
+ */
+const MIN_AI_DATA_CENTER_GPU_COUNT = 10000;
+const RENDERABLE_AI_DATA_CENTERS = AI_DATA_CENTERS.filter(
+  (dc) => (dc.chipCount || 0) >= MIN_AI_DATA_CENTER_GPU_COUNT,
+);
 
 export class MapComponent {
   private static readonly MOBILE_MIN_EARTHQUAKE_MAGNITUDE = 5;
@@ -223,6 +264,14 @@ export class MapComponent {
   private readonly isMobile: boolean;
   private readonly canToggleLayer: NonNullable<MapComponentOptions['canToggleLayer']>;
   private overlayAppendTarget: ParentNode | null = null;
+  // #7112 overlay marker budget. `overlayMarkerCut` holds the marker objects
+  // this render pass withheld; it is consulted by identity, so a feed that is
+  // NOT in the plan simply never appears here and renders in full. That makes a
+  // plan/render mismatch fail safe (an unbudgeted layer, not a blank one).
+  private overlayMarkerCut: Set<unknown> = new Set();
+  private overlayMarkerTruncation: Record<string, GlobeLayerTruncation> = {};
+  private renderedOverlayMarkerCount = 0;
+  private lastTruncationLabelKey = '';
   private labelVisibilityScheduled = false;
   private pendingLabelVisibilityZoom = 1;
   private lastContainerSize = { width: 0, height: 0 };
@@ -1604,7 +1653,9 @@ export class MapComponent {
   // Generic marker clustering - groups markers within pixelRadius into clusters
   // groupKey function ensures only items with same key can cluster (e.g., same city)
   private clusterMarkers<T extends { lat: number; lon: number }>(
-    items: T[],
+    // readonly so a budget-filtered feed (#7112) can be passed straight in
+    // without a defensive copy; the body only reads from it.
+    items: readonly T[],
     projection: d3.GeoProjection,
     pixelRadius: number,
     getGroupKey?: (item: T) => string
@@ -1675,9 +1726,203 @@ export class MapComponent {
     return Boolean(this.layerZoomOverrides[layer]) || this.state.zoom >= thresholds.minZoom;
   }
 
+  /**
+   * Chooses which overlay markers this render pass is allowed to create (#7112).
+   *
+   * `renderOverlays` rebuilds every HTML marker from scratch on every render, and
+   * each marker is a `<div>` with its own `click` listener. With an uncapped feed
+   * that makes both the live DOM size and the renderer's detached-node count a
+   * function of upstream traffic: production measured 2,088 overlay markers on a
+   * desktop cold load (1,502 of them military vessels), 17.4k renderer nodes and
+   * 2.8k listeners at rest, spiking to 49.7k / 21.5k while a rebuild's previous
+   * generation waited for GC. Desktop reaches this path whenever the client has
+   * no hardware WebGL2 context, which is the normal state of a lab runner.
+   *
+   * The selection is the globe's (#5368) — same module, same ceilings, so a
+   * client that falls back from Deck to SVG does not silently change how much of
+   * a layer it can see. The plan is stored as the set of markers to WITHHOLD, so
+   * a feed absent from the plan renders in full rather than disappearing.
+   */
+  private planOverlayMarkerBudget(projection: d3.GeoProjection): void {
+    const groups: GlobeMarkerGroup<unknown>[] = [];
+    const add = (
+      layer: string,
+      markers: readonly unknown[],
+      // Only the tuning knobs, mirroring GlobeMap.flushMarkers: spreading a full
+      // Partial would let a caller overwrite the layer/markers just set.
+      extra: Pick<Partial<GlobeMarkerGroup<unknown>>, 'rank' | 'exempt'> = {},
+    ): void => { if (markers.length) groups.push({ layer, markers, ...extra }); };
+
+    const layers = this.state.layers;
+    if (layers.waterways) add('waterways', STRATEGIC_WATERWAYS);
+    if (layers.ais) {
+      add('ais', this.aisDisruptions);
+      add('ais', PORTS);
+    }
+    if (layers.cyberThreats && SITE_VARIANT !== 'tech') add('cyberThreats', this.aptGroups);
+    // The zoom gates below mirror the render conditions exactly: a group that
+    // is planned but not rendered would spend fair share it never uses, and
+    // tighten the cap on the layers that do render.
+    if (this.isLayerZoomVisible('nuclear')) add('nuclear', NUCLEAR_FACILITIES);
+    if (layers.irradiators) add('irradiators', GAMMA_IRRADIATORS);
+    if (layers.conflicts) {
+      add('conflicts', CONFLICT_ZONES);
+      add('conflicts', this.conflictEvents, { rank: (m) => (m as AcledConflictEvent).fatalities ?? 0 });
+    }
+    // Planned on the whole feed rather than the mobile-trimmed slice the loop
+    // iterates. The trim only ever removes markers, so planning the superset
+    // can render fewer than the cap but never more — and both feeds rank so the
+    // markers the trim keeps are the ones the budget keeps too.
+    if (layers.iranAttacks) add('iranAttacks', this.iranEvents);
+    if (layers.hotspots) add('hotspots', this.hotspots);
+    if (this.isLayerZoomVisible('bases')) add('bases', this.getMilitaryBasesForRender());
+    if (layers.natural) {
+      add('natural', this.earthquakes, { rank: (m) => (m as Earthquake).magnitude ?? 0 });
+      add('natural', this.naturalEvents);
+    }
+    if (layers.economic) add('economic', ECONOMIC_CENTERS);
+    if (layers.weather) add('weather', this.weatherAlerts);
+    if (layers.radiationWatch) add('radiationWatch', this.radiationObservations);
+    if (layers.outages) add('outages', this.outages);
+    if (layers.cables) {
+      add('cables', this.cableAdvisories);
+      add('cables', this.repairShips);
+    }
+    if (layers.datacenters) add('datacenters', RENDERABLE_AI_DATA_CENTERS);
+    if (layers.spaceports) add('spaceports', SPACEPORTS);
+    if (layers.minerals) add('minerals', CRITICAL_MINERALS);
+    if (layers.startupHubs) add('startupHubs', STARTUP_HUBS);
+    if (layers.cloudRegions) add('cloudRegions', CLOUD_REGIONS);
+    if (layers.techHQs) add('techHQs', TECH_HQS);
+    if (layers.accelerators) add('accelerators', ACCELERATORS);
+    if (layers.techEvents) add('techEvents', this.techEvents);
+    if (layers.stockExchanges) add('stockExchanges', STOCK_EXCHANGES);
+    if (layers.financialCenters) add('financialCenters', FINANCIAL_CENTERS);
+    if (layers.centralBanks) add('centralBanks', CENTRAL_BANKS);
+    if (layers.commodityHubs) add('commodityHubs', COMMODITY_HUBS);
+    if (layers.protests) add('protests', this.protests);
+    if (layers.flights) {
+      add('flights', this.flightDelays);
+      add('flights', this.aircraftPositions);
+    }
+    if (layers.military) {
+      add('military', this.militaryFlights);
+      add('military', this.militaryFlightClusters);
+      // Carriers first: AIS is the largest feed on the page and the one the
+      // ceiling actually bites on (1,502 of 2,088 markers measured).
+      add('military', this.militaryVessels, {
+        rank: (m) => ((m as MilitaryVessel).vesselType === 'carrier' ? 1 : 0),
+      });
+      add('military', this.militaryVesselClusters);
+    }
+    if (layers.fires) {
+      add('fires', this.firmsFireData, { rank: (m) => (m as { brightness?: number }).brightness ?? 0 });
+    }
+    if (layers.webcams && this.state.zoom >= 2) add('webcams', this.webcamData);
+    // Variant hub overlays have no layer-toggle row, so a truncation here would
+    // have nowhere to be disclosed — exempt like the globe's `news` group. Both
+    // are bounded by the hub registry, not by an upstream feed.
+    if (SITE_VARIANT === 'tech') add('techHubs', this.techActivities, { exempt: true });
+    if (SITE_VARIANT === 'full') add('geoHubs', this.geoActivities, { exempt: true });
+
+    // Layers with no severity signal rank by nearness to the centre of the
+    // current view rather than by raw feed order, so a capped reference layer
+    // drops whatever is furthest from what the user is looking at instead of
+    // whatever happens to sort last. See proximityRank.
+    const { width, height } = this.getKnownContainerSize();
+    const centre = projection.invert?.([width / 2, height / 2]);
+    const nearestFirst = proximityRank<unknown>(
+      { lat: centre?.[1] ?? 0, lng: centre?.[0] ?? 0 },
+      overlayMarkerPosition,
+    );
+    for (const group of groups) {
+      if (group.exempt) continue;
+      if (group.rank) group.tieBreak = nearestFirst;
+      else group.rank = nearestFirst;
+    }
+
+    const budget = this.isMobile
+      ? MAP_OVERLAY_MARKER_BUDGET_MOBILE
+      : MAP_OVERLAY_MARKER_BUDGET_DESKTOP;
+    const { markers, truncated } = selectGlobeMarkers(groups, budget);
+
+    const kept = new Set(markers);
+    const cut = new Set<unknown>();
+    for (const group of groups) {
+      if (group.exempt) continue;
+      for (const marker of group.markers) {
+        if (!kept.has(marker)) cut.add(marker);
+      }
+    }
+    this.overlayMarkerCut = cut;
+    this.overlayMarkerTruncation = truncated;
+    this.renderedOverlayMarkerCount = markers.length;
+    this.updateLayerTruncationLabels();
+  }
+
+  /** True when this render pass withheld `marker` under the overlay budget (#7112). */
+  private isOverlayMarkerCut(marker: unknown): boolean {
+    return this.overlayMarkerCut.size > 0 && this.overlayMarkerCut.has(marker);
+  }
+
+  /**
+   * The same decision applied to a whole feed, for the paths that cluster their
+   * input before producing markers — clustering is many-to-one, so the cut has
+   * to happen on the way in or it cannot bound the markers on the way out.
+   */
+  private keepBudgetedMarkers<T>(markers: readonly T[]): readonly T[] {
+    if (this.overlayMarkerCut.size === 0) return markers;
+    return markers.filter((marker) => !this.overlayMarkerCut.has(marker));
+  }
+
+  /**
+   * Discloses a capped layer as `shown/total` on its toggle row, the way the
+   * globe does — a ceiling the user cannot see is indistinguishable from missing
+   * data. Skipped when nothing changed: this runs on every render pass, and the
+   * writes would restyle the toggle rows each time (#5080).
+   */
+  private updateLayerTruncationLabels(): void {
+    const key = Object.entries(this.overlayMarkerTruncation)
+      .map(([layer, counts]) => `${layer}:${counts.shown}/${counts.total}`)
+      .sort()
+      .join(',');
+    if (key === this.lastTruncationLabelKey) return;
+    this.lastTruncationLabelKey = key;
+
+    const root = this.container.querySelector<HTMLElement>('#layerToggles');
+    if (!root) return;
+    for (const row of Array.from(root.querySelectorAll<HTMLElement>('.layer-toggle-row'))) {
+      const layer = row.dataset.layer;
+      const counts = layer ? this.overlayMarkerTruncation[layer] : undefined;
+      const existing = row.querySelector<HTMLElement>('.layer-truncation-count');
+      if (!counts) { existing?.remove(); continue; }
+      const badge = existing ?? document.createElement('span');
+      if (!existing) {
+        // Sibling of the toggle button, not a child: inside it every click on
+        // the badge would toggle the layer off.
+        badge.className = 'layer-truncation-count';
+        row.appendChild(badge);
+      }
+      badge.textContent = `${counts.shown}/${counts.total}`;
+      // Untranslated literal, matching GlobeMap.updateLayerTruncationLabels — a
+      // new i18n key is a ~29-file change across locales and the badge itself is
+      // numeric. Tracked as the same follow-up.
+      badge.title = `Showing ${counts.shown} of ${counts.total} markers — the most significant, and those nearest the current view. The map caps markers per layer to keep interaction responsive; pan or zoom to bring others in.`;
+    }
+  }
+
+  /** Markers this render pass drew, and what the budget withheld (#7112). */
+  public getOverlayMarkerBudgetState(): {
+    rendered: number;
+    truncated: Record<string, GlobeLayerTruncation>;
+  } {
+    return { rendered: this.renderedOverlayMarkerCount, truncated: this.overlayMarkerTruncation };
+  }
+
   private renderOverlays(projection: d3.GeoProjection): void {
     setTrustedHtml(this.overlays, trustedHtml('', "legacy direct innerHTML migration"));
     this.labelVisibilityScheduled = false;
+    this.planOverlayMarkerBudget(projection);
     const fragment = document.createDocumentFragment();
     const previousTarget = this.overlayAppendTarget;
     this.overlayAppendTarget = fragment;
@@ -1701,6 +1946,7 @@ export class MapComponent {
     // Nuclear facilities (always HTML - shapes convey status)
     if (this.state.layers.nuclear && this.isLayerZoomVisible('nuclear')) {
       NUCLEAR_FACILITIES.forEach((facility) => {
+        if (this.isOverlayMarkerCut(facility)) return;
         const pos = projection([facility.lon, facility.lat]);
         if (!pos) return;
 
@@ -1729,6 +1975,7 @@ export class MapComponent {
     // Gamma irradiators (IAEA DIIF) - no labels, click to see details
     if (this.state.layers.irradiators) {
       GAMMA_IRRADIATORS.forEach((irradiator) => {
+        if (this.isOverlayMarkerCut(irradiator)) return;
         const pos = projection([irradiator.lon, irradiator.lat]);
         if (!pos) return;
 
@@ -1756,6 +2003,7 @@ export class MapComponent {
     // Conflict zone click areas
     if (this.state.layers.conflicts) {
       CONFLICT_ZONES.forEach((zone) => {
+        if (this.isOverlayMarkerCut(zone)) return;
         const centerPos = projection(zone.center as [number, number]);
         if (!centerPos) return;
 
@@ -1790,6 +2038,7 @@ export class MapComponent {
         ? this.iranEvents.slice(0, MapComponent.MOBILE_MAX_IRAN_EVENTS)
         : this.iranEvents;
       iranEventsForRender.forEach((ev) => {
+        if (this.isOverlayMarkerCut(ev)) return;
         const pos = projection([ev.longitude, ev.latitude]);
         if (!pos || !Number.isFinite(pos[0]) || !Number.isFinite(pos[1])) return;
 
@@ -1823,6 +2072,7 @@ export class MapComponent {
     // Hotspots (always HTML - level colors and BREAKING badges)
     if (this.state.layers.hotspots) {
       this.hotspots.forEach((spot) => {
+        if (this.isOverlayMarkerCut(spot)) return;
         const pos = projection([spot.lon, spot.lat]);
         if (!pos) return;
 
@@ -1857,6 +2107,7 @@ export class MapComponent {
     // Military bases (always HTML - nation colors matter)
     if (this.state.layers.bases && this.isLayerZoomVisible('bases')) {
       this.getMilitaryBasesForRender().forEach((base) => {
+        if (this.isOverlayMarkerCut(base)) return;
         const pos = projection([base.lon, base.lat]);
         if (!pos) return;
 
@@ -1898,6 +2149,7 @@ export class MapComponent {
       console.log('[Map] After time/mobile filter:', quakesForRender.length, 'earthquakes. TimeRange:', this.state.timeRange);
       let rendered = 0;
       quakesForRender.forEach((eq) => {
+        if (this.isOverlayMarkerCut(eq)) return;
         const pos = projection([eq.location?.longitude ?? 0, eq.location?.latitude ?? 0]);
         if (!pos) {
           console.log('[Map] Earthquake position null for:', eq.place, eq.location?.longitude, eq.location?.latitude);
@@ -1938,6 +2190,7 @@ export class MapComponent {
     // Economic Centers (always HTML - emoji icons for type distinction)
     if (this.state.layers.economic) {
       ECONOMIC_CENTERS.forEach((center) => {
+        if (this.isOverlayMarkerCut(center)) return;
         const pos = projection([center.lon, center.lat]);
         if (!pos) return;
 
@@ -1970,6 +2223,7 @@ export class MapComponent {
     // Weather Alerts (severity icons)
     if (this.state.layers.weather) {
       this.weatherAlerts.forEach((alert) => {
+        if (this.isOverlayMarkerCut(alert)) return;
         if (!alert.centroid) return;
         const pos = projection(alert.centroid);
         if (!pos) return;
@@ -2002,6 +2256,7 @@ export class MapComponent {
 
     if (this.state.layers.radiationWatch) {
       this.radiationObservations.forEach((observation) => {
+        if (this.isOverlayMarkerCut(observation)) return;
         const pos = projection([observation.lon, observation.lat]);
         if (!pos) return;
 
@@ -2036,6 +2291,7 @@ export class MapComponent {
     // Internet Outages (severity colors)
     if (this.state.layers.outages) {
       this.outages.forEach((outage) => {
+        if (this.isOverlayMarkerCut(outage)) return;
         const pos = projection([outage.lon, outage.lat]);
         if (!pos) return;
 
@@ -2072,6 +2328,7 @@ export class MapComponent {
     // Cable advisories & repair ships
     if (this.state.layers.cables) {
       this.cableAdvisories.forEach((advisory) => {
+        if (this.isOverlayMarkerCut(advisory)) return;
         const pos = projection([advisory.lon, advisory.lat]);
         if (!pos) return;
 
@@ -2105,6 +2362,7 @@ export class MapComponent {
       });
 
       this.repairShips.forEach((ship) => {
+        if (this.isOverlayMarkerCut(ship)) return;
         const pos = projection([ship.lon, ship.lat]);
         if (!pos) return;
 
@@ -2138,10 +2396,11 @@ export class MapComponent {
       });
     }
 
-    // AI Data Centers (always HTML - 🖥️ icons, filter to ≥10k GPUs)
-    const MIN_GPU_COUNT = 10000;
+    // AI Data Centers (always HTML - icons; RENDERABLE_AI_DATA_CENTERS is the
+    // >=10k-GPU list, shared with the overlay budget plan)
     if (this.state.layers.datacenters) {
-      AI_DATA_CENTERS.filter(dc => (dc.chipCount || 0) >= MIN_GPU_COUNT).forEach((dc) => {
+      RENDERABLE_AI_DATA_CENTERS.forEach((dc) => {
+        if (this.isOverlayMarkerCut(dc)) return;
         const pos = projection([dc.lon, dc.lat]);
         if (!pos) return;
 
@@ -2174,6 +2433,7 @@ export class MapComponent {
     // Spaceports (🚀 icon)
     if (this.state.layers.spaceports) {
       SPACEPORTS.forEach((port) => {
+        if (this.isOverlayMarkerCut(port)) return;
         const pos = projection([port.lon, port.lat]);
         if (!pos) return;
 
@@ -2210,6 +2470,7 @@ export class MapComponent {
     // Critical Minerals (💎 icon)
     if (this.state.layers.minerals) {
       CRITICAL_MINERALS.forEach((mine) => {
+        if (this.isOverlayMarkerCut(mine)) return;
         const pos = projection([mine.lon, mine.lat]);
         if (!pos) return;
 
@@ -2249,6 +2510,7 @@ export class MapComponent {
     // Startup Hubs (🚀 icon by tier)
     if (this.state.layers.startupHubs) {
       STARTUP_HUBS.forEach((hub) => {
+        if (this.isOverlayMarkerCut(hub)) return;
         const pos = projection([hub.lon, hub.lat]);
         if (!pos) return;
 
@@ -2287,6 +2549,7 @@ export class MapComponent {
     // Cloud Regions (☁️ icons by provider)
     if (this.state.layers.cloudRegions) {
       CLOUD_REGIONS.forEach((region) => {
+        if (this.isOverlayMarkerCut(region)) return;
         const pos = projection([region.lon, region.lat]);
         if (!pos) return;
 
@@ -2329,7 +2592,7 @@ export class MapComponent {
       // Cluster radius depends on zoom - tighter clustering when zoomed out
       const clusterRadius = this.state.zoom >= 4 ? 15 : this.state.zoom >= 3 ? 25 : 40;
       // Group by city to prevent clustering companies from different cities
-      const clusters = this.clusterMarkers(TECH_HQS, projection, clusterRadius, hq => hq.city);
+      const clusters = this.clusterMarkers(this.keepBudgetedMarkers(TECH_HQS), projection, clusterRadius, hq => hq.city);
 
       clusters.forEach((cluster) => {
         if (cluster.items.length === 0) return;
@@ -2397,6 +2660,7 @@ export class MapComponent {
     // Accelerators (🎯 icons)
     if (this.state.layers.accelerators) {
       ACCELERATORS.forEach((acc) => {
+        if (this.isOverlayMarkerCut(acc)) return;
         const pos = projection([acc.lon, acc.lat]);
         if (!pos) return;
 
@@ -2437,7 +2701,7 @@ export class MapComponent {
       const { width: mapWidth, height: mapHeight } = this.getKnownContainerSize();
 
       // Map events to have lon property for clustering, filter visible
-      const visibleEvents = this.techEvents
+      const visibleEvents = this.keepBudgetedMarkers(this.techEvents)
         .map(e => ({ ...e, lon: e.lng }))
         .filter(e => {
           const pos = projection([e.lon, e.lat]);
@@ -2494,6 +2758,7 @@ export class MapComponent {
     // Stock Exchanges (🏛️ icon by tier)
     if (this.state.layers.stockExchanges) {
       STOCK_EXCHANGES.forEach((exchange) => {
+        if (this.isOverlayMarkerCut(exchange)) return;
         const pos = projection([exchange.lon, exchange.lat]);
         if (!pos || !Number.isFinite(pos[0]) || !Number.isFinite(pos[1])) return;
 
@@ -2531,6 +2796,7 @@ export class MapComponent {
     // Financial Centers (💰 icon by type)
     if (this.state.layers.financialCenters) {
       FINANCIAL_CENTERS.forEach((center) => {
+        if (this.isOverlayMarkerCut(center)) return;
         const pos = projection([center.lon, center.lat]);
         if (!pos || !Number.isFinite(pos[0]) || !Number.isFinite(pos[1])) return;
 
@@ -2568,6 +2834,7 @@ export class MapComponent {
     // Central Banks (🏛️ icon by type)
     if (this.state.layers.centralBanks) {
       CENTRAL_BANKS.forEach((bank) => {
+        if (this.isOverlayMarkerCut(bank)) return;
         const pos = projection([bank.lon, bank.lat]);
         if (!pos || !Number.isFinite(pos[0]) || !Number.isFinite(pos[1])) return;
 
@@ -2605,6 +2872,7 @@ export class MapComponent {
     // Commodity Hubs (⛽ icon by type)
     if (this.state.layers.commodityHubs) {
       COMMODITY_HUBS.forEach((hub) => {
+        if (this.isOverlayMarkerCut(hub)) return;
         const pos = projection([hub.lon, hub.lat]);
         if (!pos || !Number.isFinite(pos[0]) || !Number.isFinite(pos[1])) return;
 
@@ -2716,7 +2984,7 @@ export class MapComponent {
     // Protests / Social Unrest Events (severity colors + icons) - with clustering
     // Filter to show only significant events on map (all events still used for CII analysis)
     if (this.state.layers.protests) {
-      const significantProtests = this.protests.filter((event) => {
+      const significantProtests = this.keepBudgetedMarkers(this.protests).filter((event) => {
         // Only show riots and high severity (red markers)
         // All protests still counted in CII analysis
         return event.eventType === 'riot' || event.severity === 'high';
@@ -2782,6 +3050,7 @@ export class MapComponent {
     // Flight Delays (delay severity colors + ✈️ icons)
     if (this.state.layers.flights) {
       this.flightDelays.forEach((delay) => {
+        if (this.isOverlayMarkerCut(delay)) return;
         const pos = projection([delay.lon, delay.lat]);
         if (!pos) return;
 
@@ -2825,6 +3094,7 @@ export class MapComponent {
     // Aircraft positions (simplified dots in SVG fallback, limited to 200)
     if (this.state.layers.flights) {
       this.aircraftPositions.slice(0, 200).forEach((ac) => {
+        if (this.isOverlayMarkerCut(ac)) return;
         const pt = projection([ac.lon, ac.lat]);
         if (!pt) return;
 
@@ -2860,6 +3130,7 @@ export class MapComponent {
     if (this.state.layers.military) {
       // Render individual flights
       this.militaryFlights.forEach((flight) => {
+        if (this.isOverlayMarkerCut(flight)) return;
         const pos = projection([flight.lon, flight.lat]);
         if (!pos) return;
 
@@ -2928,6 +3199,7 @@ export class MapComponent {
 
       // Render flight clusters
       this.militaryFlightClusters.forEach((cluster) => {
+        if (this.isOverlayMarkerCut(cluster)) return;
         const pos = projection([cluster.lon, cluster.lat]);
         if (!pos) return;
 
@@ -2963,6 +3235,7 @@ export class MapComponent {
       // Military Vessels (warships, carriers, submarines)
       // Render individual vessels
       this.militaryVessels.forEach((vessel) => {
+        if (this.isOverlayMarkerCut(vessel)) return;
         const pos = projection([vessel.lon, vessel.lat]);
         if (!pos) return;
 
@@ -3030,6 +3303,7 @@ export class MapComponent {
 
       // Render vessel clusters
       this.militaryVesselClusters.forEach((cluster) => {
+        if (this.isOverlayMarkerCut(cluster)) return;
         const pos = projection([cluster.lon, cluster.lat]);
         if (!pos) return;
 
@@ -3066,6 +3340,7 @@ export class MapComponent {
     // Natural Events (NASA EONET) - part of NATURAL layer
     if (this.state.layers.natural) {
       this.naturalEvents.forEach((event) => {
+        if (this.isOverlayMarkerCut(event)) return;
         const pos = projection([event.lon, event.lat]);
         if (!pos) return;
 
@@ -3111,6 +3386,7 @@ export class MapComponent {
     // Satellite Fires (NASA FIRMS) - separate fires layer
     if (this.state.layers.fires) {
       this.firmsFireData.forEach((fire) => {
+        if (this.isOverlayMarkerCut(fire)) return;
         const pos = projection([fire.lon, fire.lat]);
         if (!pos) return;
 
@@ -3137,6 +3413,7 @@ export class MapComponent {
         nature: '#96ceb4', beach: '#f4a460', water: '#4169e1', other: '#888888',
       };
       this.webcamData.forEach((cam) => {
+        if (this.isOverlayMarkerCut(cam)) return;
         const pos = projection([cam.lng, cam.lat]);
         if (!pos || !Number.isFinite(pos[0]) || !Number.isFinite(pos[1])) return;
         const isCluster = 'count' in cam;
@@ -3188,9 +3465,10 @@ export class MapComponent {
   }
 
   private renderConflictEventMarkers(projection: d3.GeoProjection): void {
+    const budgetedEvents = this.keepBudgetedMarkers(this.conflictEvents);
     const visibleEvents = this.state.timeRange === 'all'
-      ? this.conflictEvents
-      : this.conflictEvents.filter((event) => event.occurredAt >= Date.now() - this.getTimeRangeMs());
+      ? budgetedEvents
+      : budgetedEvents.filter((event) => event.occurredAt >= Date.now() - this.getTimeRangeMs());
     const clusters = this.clusterMarkers(
       visibleEvents
         .map((event) => ({
@@ -3404,6 +3682,7 @@ export class MapComponent {
 
   private renderWaterways(projection: d3.GeoProjection): void {
     STRATEGIC_WATERWAYS.forEach((waterway) => {
+      if (this.isOverlayMarkerCut(waterway)) return;
       const pos = projection([waterway.lon, waterway.lat]);
       if (!pos) return;
 
@@ -3434,6 +3713,7 @@ export class MapComponent {
 
   private renderAisDisruptions(projection: d3.GeoProjection): void {
     this.aisDisruptions.forEach((event) => {
+      if (this.isOverlayMarkerCut(event)) return;
       const pos = projection([event.lon, event.lat]);
       if (!pos) return;
 
@@ -3495,6 +3775,7 @@ export class MapComponent {
 
   private renderPorts(projection: d3.GeoProjection): void {
     PORTS.forEach((port) => {
+      if (this.isOverlayMarkerCut(port)) return;
       const pos = projection([port.lon, port.lat]);
       if (!pos) return;
 
@@ -3537,6 +3818,7 @@ export class MapComponent {
 
   private renderAPTMarkers(projection: d3.GeoProjection): void {
     this.aptGroups.forEach((apt) => {
+      if (this.isOverlayMarkerCut(apt)) return;
       const pos = projection([apt.lon, apt.lat]);
       if (!pos) return;
 

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -1764,23 +1764,29 @@ export class MapComponent {
         ? items
         : items.filter((item) => item.occurredAt >= Date.now() - this.getTimeRangeMs())
     );
-    const filteredQuakes = withinTimeRange(this.earthquakes);
+    // Each feed is emptied when its layer is off before any filtering runs, so
+    // this method costs no more per render than the guarded blocks it replaced.
+    // renderOverlays is on the pan/zoom path.
+    const layers = this.state.layers;
+    const activeQuakes = layers.natural ? this.earthquakes : [];
+    const activeIranEvents = layers.iranAttacks ? this.iranEvents : [];
+    const filteredQuakes = withinTimeRange(activeQuakes);
     return {
       quakes: this.isMobile
         ? filteredQuakes.filter((eq) => eq.magnitude >= MapComponent.MOBILE_MIN_EARTHQUAKE_MAGNITUDE)
         : filteredQuakes,
       iranEvents: this.isMobile
-        ? this.iranEvents.slice(0, MapComponent.MOBILE_MAX_IRAN_EVENTS)
-        : this.iranEvents,
+        ? activeIranEvents.slice(0, MapComponent.MOBILE_MAX_IRAN_EVENTS)
+        : activeIranEvents,
       // Already capped at 200 by the render loop; planned on the same slice so
       // the budget cannot spend share on the 201st position onwards.
-      aircraft: this.aircraftPositions.slice(0, 200),
+      aircraft: layers.flights ? this.aircraftPositions.slice(0, 200) : [],
       // Only riots and high-severity unrest reach the map; the rest stay in the
       // CII analysis. Budgeting the full feed would cut the ones that render.
-      protests: this.protests.filter(
-        (event) => event.eventType === 'riot' || event.severity === 'high',
-      ),
-      conflictEvents: withinTimeRange(this.conflictEvents),
+      protests: layers.protests
+        ? this.protests.filter((event) => event.eventType === 'riot' || event.severity === 'high')
+        : [],
+      conflictEvents: withinTimeRange(layers.conflicts ? this.conflictEvents : []),
     };
   }
 

--- a/src/e2e/mobile-map-integration-harness.ts
+++ b/src/e2e/mobile-map-integration-harness.ts
@@ -21,6 +21,7 @@ type MobileMapIntegrationHarness = {
   seedWeatherAlerts: (withCentroid: number, withoutCentroid: number) => void;
   forceRender: () => void;
   burstFlashes: (count: number) => void;
+  clearOverlayFeeds: () => void;
   getActiveFlashCount: () => number;
   getFlashNodeCount: () => number;
   getKeptHotspotCoords: () => Array<{ lat: number; lon: number }>;
@@ -451,6 +452,22 @@ window.__mobileMapIntegrationHarness = {
     for (let index = 0; index < count; index += 1) {
       map.flashLocation(((index * 7) % 170) - 85, ((index * 13) % 358) - 179, 60000);
     }
+  },
+  // #7112: drop the seeded feeds so nothing is over budget any more — proves the
+  // disclosure is removed when the cut clears, not stranded over a complete map.
+  clearOverlayFeeds: () => {
+    const internals = map as unknown as {
+      hotspots: unknown[];
+      state: { layers: Record<string, boolean> };
+    };
+    internals.hotspots = [];
+    map.setMilitaryVessels([] as never, []);
+    map.setMilitaryFlights([] as never, []);
+    map.setEarthquakes([] as never);
+    map.setWeatherAlerts([] as never);
+    internals.state.layers.military = false;
+    internals.state.layers.natural = false;
+    map.render();
   },
   getActiveFlashCount: () => map.getActiveFlashCount(),
   getFlashNodeCount: () =>

--- a/src/e2e/mobile-map-integration-harness.ts
+++ b/src/e2e/mobile-map-integration-harness.ts
@@ -18,10 +18,13 @@ type MobileMapIntegrationHarness = {
   getOverlayMarkerCount: () => number;
   getOverlayMarkerClassCount: (selector: string) => number;
   getOverlayPositionSignature: (selector: string) => string;
+  seedWeatherAlerts: (withCentroid: number, withoutCentroid: number) => void;
+  forceRender: () => void;
   getKeptHotspotCoords: () => Array<{ lat: number; lon: number }>;
   getSeededHotspotCoords: () => Array<{ lat: number; lon: number }>;
   getOverlayBudgetState: () => {
     rendered: number;
+    renders: number;
     truncated: Record<string, { shown: number; total: number }>;
     undisclosed: string[];
   };
@@ -175,13 +178,19 @@ const layers = {
 
 await initI18n();
 
+// #7112: `?mobile=1` builds the component on its mobile branch, which selects
+// MAP_OVERLAY_MARKER_BUDGET_MOBILE (150/400) instead of the desktop 300/800.
+// Without this the mobile ceiling has no test at all — every harness page runs
+// `isMobile: false`, so the branch in planOverlayMarkerBudget is never taken.
+const isMobileHarness = new URLSearchParams(window.location.search).get('mobile') === '1';
+
 const map = new MapComponent(app, {
   zoom: 2.7,
   pan: { x: 0, y: 0 },
   view: 'global',
   layers,
   timeRange: 'all',
-});
+}, { isMobile: isMobileHarness });
 
 let ready = false;
 let fallbackInjected = false;
@@ -386,6 +395,47 @@ window.__mobileMapIntegrationHarness = {
   // wrong inverse transform also changes the set. These expose the geography of
   // the surviving hotspots so a test can assert the kept set actually clusters
   // on the requested view centre.
+  // #7112: WeatherAlert.centroid is optional and the render loop skips an alert
+  // without one, so an alert that can never be drawn must not be budgeted or
+  // counted in the shown/total badge.
+  seedWeatherAlerts: (withCentroid: number, withoutCentroid: number) => {
+    const alerts = [
+      ...Array.from({ length: withCentroid }, (_, index) => ({
+        id: `wx-centroid-${index}`,
+        event: 'Severe Thunderstorm Warning',
+        severity: 'Severe',
+        headline: `Renderable alert ${index}`,
+        description: '',
+        areaDesc: '',
+        onset: new Date(0),
+        expires: new Date(0),
+        coordinates: [],
+        centroid: [((index * 13) % 358) - 179, ((index * 7) % 170) - 85],
+      })),
+      ...Array.from({ length: withoutCentroid }, (_, index) => ({
+        id: `wx-no-centroid-${index}`,
+        event: 'Flood Watch',
+        severity: 'Moderate',
+        headline: `Unrenderable alert ${index}`,
+        description: '',
+        areaDesc: '',
+        onset: new Date(0),
+        expires: new Date(0),
+        coordinates: [],
+        // no centroid — cannot be projected, so never becomes a marker
+      })),
+    ];
+    const internals = map as unknown as { state: { layers: Record<string, boolean> } };
+    internals.state.layers.weather = true;
+    map.setWeatherAlerts(alerts as never);
+    map.render();
+  },
+  // #7112: renderOverlays() passes, so a test can assert that a settled view does
+  // NOT trigger another full rebuild.
+  // Stands in for the data setters that call render() continuously in production
+  // (setEarthquakes, setMilitaryVessels, ...), so a test can land a render inside
+  // the budget replan's settle window.
+  forceRender: () => map.render(),
   getKeptHotspotCoords: () => {
     const internals = map as unknown as {
       hotspots: Array<{ lat: number; lon: number }>;

--- a/src/e2e/mobile-map-integration-harness.ts
+++ b/src/e2e/mobile-map-integration-harness.ts
@@ -10,6 +10,10 @@ type MobileMapIntegrationHarness = {
   getDynamicLayerChildCount: () => number;
   getInitialDynamicRendered: () => boolean;
   getWrapperTransform: () => string;
+  seedOverlayMarkerStress: (perFeed: number) => void;
+  getOverlayMarkerCount: () => number;
+  getOverlayMarkerClassCount: (selector: string) => number;
+  getOverlayBudgetState: () => { rendered: number; truncated: Record<string, { shown: number; total: number }> };
   getPopupRect: () => {
     left: number;
     top: number;
@@ -252,6 +256,66 @@ window.__mobileMapIntegrationHarness = {
     Boolean((map as unknown as { initialDynamicRendered?: boolean }).initialDynamicRendered),
   getWrapperTransform: () =>
     (document.querySelector('.map-wrapper') as HTMLElement | null)?.style.transform ?? '',
+  // #7112: drives the overlay marker budget with feeds far larger than anything
+  // production has produced, so the ceiling is exercised rather than assumed.
+  seedOverlayMarkerStress: (perFeed: number) => {
+    const spread = (index: number): { lat: number; lon: number } => ({
+      // A deterministic spiral, so markers are spread across the projection
+      // instead of stacking on one pixel (which would make the proximity
+      // tie-break meaningless and let clustering hide the count).
+      lat: ((index * 7) % 170) - 85,
+      lon: ((index * 13) % 358) - 179,
+    });
+    const vessels = Array.from({ length: perFeed }, (_, index) => ({
+      id: `stress-vessel-${index}`,
+      mmsi: String(200000000 + index),
+      name: `Stress Vessel ${index}`,
+      vesselType: index % 100 === 0 ? 'carrier' : 'destroyer',
+      operator: 'usn',
+      operatorCountry: 'US',
+      ...spread(index),
+      heading: index % 360,
+      speed: 12,
+      lastAisUpdate: new Date(0),
+      confidence: 'high',
+    }));
+    const flights = Array.from({ length: perFeed }, (_, index) => ({
+      id: `stress-flight-${index}`,
+      callsign: `STRESS${index}`,
+      hexCode: (index + 0x100000).toString(16),
+      aircraftType: 'fighter',
+      operator: 'usaf',
+      operatorCountry: 'US',
+      ...spread(index + 3),
+      altitude: 30000,
+      heading: index % 360,
+      speed: 400,
+      onGround: false,
+      lastSeen: new Date(0),
+    }));
+    const quakes = Array.from({ length: perFeed }, (_, index) => ({
+      id: `stress-quake-${index}`,
+      magnitude: 1 + (index % 60) / 10,
+      place: `Stress Quake ${index}`,
+      occurredAt: 0,
+      location: { latitude: spread(index + 5).lat, longitude: spread(index + 5).lon },
+    }));
+
+    const mapInternals = map as unknown as {
+      state: { layers: Record<string, boolean> };
+    };
+    mapInternals.state.layers.military = true;
+    mapInternals.state.layers.natural = true;
+    map.setMilitaryVessels(vessels as never, []);
+    map.setMilitaryFlights(flights as never, []);
+    map.setEarthquakes(quakes as never);
+    map.render();
+  },
+  getOverlayMarkerCount: () =>
+    document.getElementById('mapOverlays')?.childElementCount ?? -1,
+  getOverlayMarkerClassCount: (selector: string) =>
+    document.getElementById('mapOverlays')?.querySelectorAll(selector).length ?? -1,
+  getOverlayBudgetState: () => map.getOverlayMarkerBudgetState(),
   getPopupRect: () => {
     const element = document.querySelector('.map-popup') as HTMLElement | null;
     if (!element) return null;

--- a/src/e2e/mobile-map-integration-harness.ts
+++ b/src/e2e/mobile-map-integration-harness.ts
@@ -20,6 +20,9 @@ type MobileMapIntegrationHarness = {
   getOverlayPositionSignature: (selector: string) => string;
   seedWeatherAlerts: (withCentroid: number, withoutCentroid: number) => void;
   forceRender: () => void;
+  burstFlashes: (count: number) => void;
+  getActiveFlashCount: () => number;
+  getFlashNodeCount: () => number;
   getKeptHotspotCoords: () => Array<{ lat: number; lon: number }>;
   getSeededHotspotCoords: () => Array<{ lat: number; lon: number }>;
   getOverlayBudgetState: () => {
@@ -182,7 +185,12 @@ await initI18n();
 // MAP_OVERLAY_MARKER_BUDGET_MOBILE (150/400) instead of the desktop 300/800.
 // Without this the mobile ceiling has no test at all — every harness page runs
 // `isMobile: false`, so the branch in planOverlayMarkerBudget is never taken.
-const isMobileHarness = new URLSearchParams(window.location.search).get('mobile') === '1';
+const harnessParams = new URLSearchParams(window.location.search);
+const isMobileHarness = harnessParams.get('mobile') === '1';
+// #7112: `?chrome=0` reproduces the embed surface (src/embed/panels/map.ts builds
+// MapContainer with `chrome: false`), which has no #layerToggles rail and so no
+// place to show a shown/total badge.
+const chromeHarness = harnessParams.get('chrome') !== '0';
 
 const map = new MapComponent(app, {
   zoom: 2.7,
@@ -190,7 +198,7 @@ const map = new MapComponent(app, {
   view: 'global',
   layers,
   timeRange: 'all',
-}, { isMobile: isMobileHarness });
+}, { isMobile: isMobileHarness, chrome: chromeHarness });
 
 let ready = false;
 let fallbackInjected = false;
@@ -436,6 +444,17 @@ window.__mobileMapIntegrationHarness = {
   // (setEarthquakes, setMilitaryVessels, ...), so a test can land a render inside
   // the budget replan's settle window.
   forceRender: () => map.render(),
+  // #7112: news flashes are #mapOverlays children created outside the marker
+  // budget. flashMapForNews() fires them "in bursts across load passes (hundreds
+  // of calls shortly after load)", so the burst is what the ceiling must survive.
+  burstFlashes: (count: number) => {
+    for (let index = 0; index < count; index += 1) {
+      map.flashLocation(((index * 7) % 170) - 85, ((index * 13) % 358) - 179, 60000);
+    }
+  },
+  getActiveFlashCount: () => map.getActiveFlashCount(),
+  getFlashNodeCount: () =>
+    document.getElementById('mapOverlays')?.querySelectorAll('.map-flash').length ?? -1,
   getKeptHotspotCoords: () => {
     const internals = map as unknown as {
       hotspots: Array<{ lat: number; lon: number }>;

--- a/src/e2e/mobile-map-integration-harness.ts
+++ b/src/e2e/mobile-map-integration-harness.ts
@@ -11,9 +11,13 @@ type MobileMapIntegrationHarness = {
   getInitialDynamicRendered: () => boolean;
   getWrapperTransform: () => string;
   seedOverlayMarkerStress: (perFeed: number) => void;
+  seedOverlayViewportStress: (count: number) => void;
+  setOverlayViewport: (lat: number, lon: number) => void;
+  setOverlayZoom: (zoom: number) => void;
   seedTimeFilteredEarthquakes: (recent: number, stale: number) => void;
   getOverlayMarkerCount: () => number;
   getOverlayMarkerClassCount: (selector: string) => number;
+  getOverlayPositionSignature: (selector: string) => string;
   getOverlayBudgetState: () => { rendered: number; truncated: Record<string, { shown: number; total: number }> };
   getPopupRect: () => {
     left: number;
@@ -312,6 +316,29 @@ window.__mobileMapIntegrationHarness = {
     map.setEarthquakes(quakes as never);
     map.render();
   },
+  // #7112: create one over-budget, proximity-ranked feed so pan/zoom can prove
+  // that the selected marker set follows the transformed viewport centre.
+  seedOverlayViewportStress: (count: number) => {
+    const hotspots = Array.from({ length: count }, (_, index) => ({
+      id: `viewport-hotspot-${index}`,
+      name: `Viewport Hotspot ${index}`,
+      lat: ((index * 7) % 170) - 85,
+      lon: ((index * 13) % 358) - 179,
+      keywords: ['viewport'],
+      level: 'low' as const,
+      description: 'Viewport budget stress marker',
+      status: 'monitoring',
+    }));
+    const mapInternals = map as unknown as {
+      hotspots: typeof hotspots;
+      state: { layers: Record<string, boolean> };
+    };
+    mapInternals.hotspots = hotspots;
+    mapInternals.state.layers.hotspots = true;
+    map.render();
+  },
+  setOverlayViewport: (lat: number, lon: number) => map.setCenter(lat, lon),
+  setOverlayZoom: (zoom: number) => map.setZoom(zoom),
   // #7112: the budget plan must be computed over the SAME time-filtered slice
   // the render loop iterates. The stale events here carry the HIGHEST
   // magnitudes, so a plan that ranked the unfiltered feed would spend its whole
@@ -343,6 +370,11 @@ window.__mobileMapIntegrationHarness = {
     document.getElementById('mapOverlays')?.childElementCount ?? -1,
   getOverlayMarkerClassCount: (selector: string) =>
     document.getElementById('mapOverlays')?.querySelectorAll(selector).length ?? -1,
+  getOverlayPositionSignature: (selector: string) =>
+    Array.from(document.querySelectorAll<HTMLElement>(`#mapOverlays ${selector}`))
+      .map((element) => `${element.style.left},${element.style.top}`)
+      .sort()
+      .join('|'),
   getOverlayBudgetState: () => map.getOverlayMarkerBudgetState(),
   getPopupRect: () => {
     const element = document.querySelector('.map-popup') as HTMLElement | null;

--- a/src/e2e/mobile-map-integration-harness.ts
+++ b/src/e2e/mobile-map-integration-harness.ts
@@ -11,6 +11,7 @@ type MobileMapIntegrationHarness = {
   getInitialDynamicRendered: () => boolean;
   getWrapperTransform: () => string;
   seedOverlayMarkerStress: (perFeed: number) => void;
+  seedTimeFilteredEarthquakes: (recent: number, stale: number) => void;
   getOverlayMarkerCount: () => number;
   getOverlayMarkerClassCount: (selector: string) => number;
   getOverlayBudgetState: () => { rendered: number; truncated: Record<string, { shown: number; total: number }> };
@@ -310,6 +311,33 @@ window.__mobileMapIntegrationHarness = {
     map.setMilitaryFlights(flights as never, []);
     map.setEarthquakes(quakes as never);
     map.render();
+  },
+  // #7112: the budget plan must be computed over the SAME time-filtered slice
+  // the render loop iterates. The stale events here carry the HIGHEST
+  // magnitudes, so a plan that ranked the unfiltered feed would spend its whole
+  // fair share on events the 24h filter then discards.
+  seedTimeFilteredEarthquakes: (recent: number, stale: number) => {
+    const now = Date.now();
+    const quakes = [
+      ...Array.from({ length: stale }, (_, index) => ({
+        id: `stale-quake-${index}`,
+        magnitude: 6 + (index % 30) / 100,
+        place: `Stale Quake ${index}`,
+        occurredAt: now - 30 * 24 * 60 * 60 * 1000,
+        location: { latitude: ((index * 7) % 170) - 85, longitude: ((index * 13) % 358) - 179 },
+      })),
+      ...Array.from({ length: recent }, (_, index) => ({
+        id: `recent-quake-${index}`,
+        magnitude: 1 + (index % 30) / 100,
+        place: `Recent Quake ${index}`,
+        occurredAt: now - 60 * 1000,
+        location: { latitude: ((index * 11) % 170) - 85, longitude: ((index * 17) % 358) - 179 },
+      })),
+    ];
+    const mapInternals = map as unknown as { state: { layers: Record<string, boolean> } };
+    mapInternals.state.layers.natural = true;
+    map.setEarthquakes(quakes as never);
+    map.setTimeRange('24h');
   },
   getOverlayMarkerCount: () =>
     document.getElementById('mapOverlays')?.childElementCount ?? -1,

--- a/src/e2e/mobile-map-integration-harness.ts
+++ b/src/e2e/mobile-map-integration-harness.ts
@@ -18,7 +18,13 @@ type MobileMapIntegrationHarness = {
   getOverlayMarkerCount: () => number;
   getOverlayMarkerClassCount: (selector: string) => number;
   getOverlayPositionSignature: (selector: string) => string;
-  getOverlayBudgetState: () => { rendered: number; truncated: Record<string, { shown: number; total: number }> };
+  getKeptHotspotCoords: () => Array<{ lat: number; lon: number }>;
+  getSeededHotspotCoords: () => Array<{ lat: number; lon: number }>;
+  getOverlayBudgetState: () => {
+    rendered: number;
+    truncated: Record<string, { shown: number; total: number }>;
+    undisclosed: string[];
+  };
   getPopupRect: () => {
     left: number;
     top: number;
@@ -375,6 +381,24 @@ window.__mobileMapIntegrationHarness = {
       .map((element) => `${element.style.left},${element.style.top}`)
       .sort()
       .join('|'),
+  // #7112: the budget's proximity ranking is a claim about WHICH markers survive,
+  // not merely that the set changes on pan/zoom — a centre computed from the
+  // wrong inverse transform also changes the set. These expose the geography of
+  // the surviving hotspots so a test can assert the kept set actually clusters
+  // on the requested view centre.
+  getKeptHotspotCoords: () => {
+    const internals = map as unknown as {
+      hotspots: Array<{ lat: number; lon: number }>;
+      overlayMarkerCut: Set<unknown>;
+    };
+    return internals.hotspots
+      .filter((spot) => !internals.overlayMarkerCut.has(spot))
+      .map((spot) => ({ lat: spot.lat, lon: spot.lon }));
+  },
+  getSeededHotspotCoords: () => {
+    const internals = map as unknown as { hotspots: Array<{ lat: number; lon: number }> };
+    return internals.hotspots.map((spot) => ({ lat: spot.lat, lon: spot.lon }));
+  },
   getOverlayBudgetState: () => map.getOverlayMarkerBudgetState(),
   getPopupRect: () => {
     const element = document.querySelector('.map-popup') as HTMLElement | null;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -13693,6 +13693,30 @@ a.prediction-link:hover {
  * "shown/total" for layers the globe's marker budget is trimming (#5368).
  * Muted and right-aligned: it reports a limit, it is not a call to action.
  */
+/* #7112: the marker-budget disclosure for maps with no layer-toggle rail —
+   `chrome: false` embeds. The per-layer `shown/total` badge needs a toggle row to
+   sit on; this states the same fact for the whole overlay when no row exists.
+   Informational only: pointer-events stay on so the title tooltip works, but it
+   is not a control and must not read as one. */
+.map-truncation-summary {
+  position: absolute;
+  bottom: 6px;
+  left: 6px;
+  z-index: 60;
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.4;
+  white-space: nowrap;
+  /* Theme tokens, not hardcoded colours: an embed inherits the host page's
+     theme and a fixed white would vanish on the light one. */
+  color: var(--text-dim);
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  cursor: help;
+  pointer-events: auto;
+}
+
 .layer-truncation-count {
   margin-left: auto;
   font-size: calc(8px * var(--wm-panel-effective-scale, 1));

--- a/src/utils/globe-marker-budget.ts
+++ b/src/utils/globe-marker-budget.ts
@@ -16,6 +16,11 @@
  *
  * This module is deliberately free of DOM and three.js imports so the real
  * selection function can be unit-tested directly against real payload shapes.
+ *
+ * It is shared with the SVG/D3 renderer (`MapComponent.renderOverlays`), which
+ * has the same shape of problem for a different reason (#7112) — see
+ * `MAP_OVERLAY_MARKER_BUDGET_DESKTOP` below. The names keep the `Globe` prefix
+ * they were introduced with; the selection itself is renderer-agnostic.
  */
 
 /** A single layer's contribution to the globe, before budgeting. */
@@ -84,6 +89,33 @@ export const GLOBE_MARKER_BUDGET_MOBILE: GlobeMarkerBudget = { perLayer: 150, to
 
 /** Desktop's default view is 2,319 markers today, so this cuts it ~2.9x. */
 export const GLOBE_MARKER_BUDGET_DESKTOP: GlobeMarkerBudget = { perLayer: 300, total: 800 };
+
+/**
+ * The same selection, applied to the SVG/D3 renderer's HTML overlay (#7112).
+ *
+ * `MapComponent` is not only the mobile renderer: `MapContainer.shouldUseDeckGL`
+ * falls back to it on any desktop client without a hardware WebGL2 context
+ * (`hasWebGLSupport` rejects SwiftShader/llvmpipe by name), which is the normal
+ * state of a synthetic lab runner. There each marker is an absolutely-positioned
+ * `<div>` carrying its own `click` listener, and `renderOverlays` rebuilds the
+ * whole set on every render — so an uncapped feed sets both the live DOM size
+ * and, through the rebuild churn, the renderer's detached-node count.
+ *
+ * Measured on production 2026-08-24, desktop viewport, default layers, SVG
+ * fallback: 2,088 overlay markers (1,502 military vessels, 293 military
+ * flights, 147 earthquakes), 17.4k renderer nodes and 2.8k listeners at rest,
+ * peaking at 49.7k nodes / 21.5k listeners mid-rebuild. The DeckGL path on the
+ * same page carries 7.6k nodes / 736 listeners because its vessels are a single
+ * WebGL draw call.
+ *
+ * Deliberately the same numbers as the globe: both renderers pay per DOM marker,
+ * and two different ceilings for the same layer set would be a surprise when a
+ * client falls back between them.
+ */
+export const MAP_OVERLAY_MARKER_BUDGET_DESKTOP: GlobeMarkerBudget = { perLayer: 300, total: 800 };
+
+/** Mobile always uses the SVG renderer, so it keeps the tighter mobile ceiling. */
+export const MAP_OVERLAY_MARKER_BUDGET_MOBILE: GlobeMarkerBudget = { perLayer: 150, total: 400 };
 
 /**
  * Largest per-group cap `c <= max` for which `sum(min(len_i, c)) <= total`.

--- a/src/utils/layer-truncation-badge.ts
+++ b/src/utils/layer-truncation-badge.ts
@@ -1,0 +1,71 @@
+/**
+ * The `shown/total` badge every renderer uses to disclose a marker budget cut.
+ *
+ * Quietly dropping 2,000 conflict events off a monitoring product would
+ * misrepresent the data, so the withholding is stated in the panel that controls
+ * it (#5368 for the globe, #7112 for the SVG overlay). Both renderers reached
+ * that conclusion independently and grew a near-identical 20-line copy of the
+ * DOM write, down to a duplicated 40-word title string with one word changed —
+ * which is how two renderers drift into disclosing different things about the
+ * same cut. One implementation, one wording, one place to fix.
+ *
+ * Kept out of `globe-marker-budget.ts` on purpose: that module is deliberately
+ * free of DOM imports so the selection algorithm can be unit-tested directly.
+ */
+import type { GlobeLayerTruncation } from './globe-marker-budget';
+
+/** How the renderer's viewport moves, for the badge's "… to bring others in". */
+export type TruncationMoveVerb = 'pan' | 'rotate';
+
+export interface TruncationBadgeResult {
+  /** Layer keys that had a toggle row and now carry a badge. */
+  disclosed: string[];
+  /**
+   * Layer keys the budget trimmed that have NO toggle row in this picker, so the
+   * cut could not be disclosed anywhere. Returned rather than silently dropped:
+   * a trimmed layer the user cannot see the count for is indistinguishable from
+   * missing data, and the caller needs to be able to assert on the set.
+   */
+  undisclosed: string[];
+}
+
+/**
+ * Writes/removes `.layer-truncation-count` badges on `root`'s toggle rows.
+ *
+ * Idempotent: reuses an existing badge, removes it when the layer is no longer
+ * truncated, so repeated calls converge rather than accumulating nodes.
+ */
+export function renderLayerTruncationBadges(
+  root: HTMLElement,
+  truncation: Readonly<Record<string, GlobeLayerTruncation>>,
+  moveVerb: TruncationMoveVerb,
+): TruncationBadgeResult {
+  const disclosed: string[] = [];
+  const rowLayers = new Set<string>();
+
+  for (const row of Array.from(root.querySelectorAll<HTMLElement>('.layer-toggle-row'))) {
+    const layer = row.dataset.layer;
+    if (layer) rowLayers.add(layer);
+    const counts = layer ? truncation[layer] : undefined;
+    const existing = row.querySelector<HTMLElement>('.layer-truncation-count');
+    if (!counts) { existing?.remove(); continue; }
+    const badge = existing ?? document.createElement('span');
+    if (!existing) {
+      // Sibling of the toggle control, not a child: inside it, every click on
+      // the badge would toggle the layer off. `.layer-explain-btn` sits outside
+      // the label for the same reason.
+      badge.className = 'layer-truncation-count';
+      row.appendChild(badge);
+    }
+    badge.textContent = `${counts.shown}/${counts.total}`;
+    // Untranslated literal: a new i18n key is a ~29-file change across locales,
+    // and the badge itself is numeric. Real key tracked as follow-up.
+    // Says "nearest this view" rather than "highest priority" because that is
+    // what the ranking actually does for layers with no severity of their own.
+    badge.title = `Showing ${counts.shown} of ${counts.total} markers — the most significant, and those nearest the current view. The map caps markers per layer to keep interaction responsive; ${moveVerb} or zoom to bring others in.`;
+    if (layer) disclosed.push(layer);
+  }
+
+  const undisclosed = Object.keys(truncation).filter((layer) => !rowLayers.has(layer));
+  return { disclosed, undisclosed };
+}

--- a/src/utils/overlay-marker-geometry.ts
+++ b/src/utils/overlay-marker-geometry.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure geometry the SVG map's overlay marker budget depends on (#7112).
+ *
+ * Split out of `MapComponent` for the same reason `globe-marker-budget.ts` is:
+ * both functions are total, DOM-free and easy to get subtly wrong, so they are
+ * unit-tested directly against real payload shapes and the renderer's own
+ * transform algebra rather than through a browser harness that can only observe
+ * that "something changed".
+ */
+import type { LatLng } from './globe-marker-budget';
+
+/**
+ * Reads a marker's coordinates across every feed shape `renderOverlays` iterates
+ * (#7112): most expose `lon`/`lat`, webcams use `lng`, Iran events use the long
+ * spellings, earthquakes and ACLED events nest them under `location`, conflict
+ * zones carry a `[lon, lat]` `center` tuple and weather alerts a `[lon, lat]`
+ * `centroid`. A shape with none of them yields NaN, which `proximityRank`
+ * already sorts last rather than poisoning the comparator — the same outcome as
+ * the render loops, which skip a null position.
+ *
+ * Every branch here is load-bearing: a feed whose position cannot be read ranks
+ * -Infinity for the WHOLE layer, so the proximity cut silently degenerates to
+ * raw feed order — the outcome `proximityRank`'s own docstring calls
+ * indefensible. `overlay-marker-geometry.test.mts` pins one real payload per
+ * shape so a new feed with a fifth spelling fails loudly instead.
+ */
+export function overlayMarkerPosition(marker: unknown): LatLng {
+  const m = marker as {
+    lat?: number; lon?: number; lng?: number;
+    latitude?: number; longitude?: number;
+    location?: { latitude?: number; longitude?: number } | null;
+    center?: readonly [number, number];
+    centroid?: readonly [number, number];
+  };
+  return {
+    lat: m.lat ?? m.latitude ?? m.location?.latitude ?? m.center?.[1] ?? m.centroid?.[1] ?? Number.NaN,
+    lng: m.lon ?? m.lng ?? m.longitude ?? m.location?.longitude ?? m.center?.[0] ?? m.centroid?.[0] ?? Number.NaN,
+  };
+}
+
+/**
+ * The projection coordinate currently sitting at the screen centre (#7112).
+ *
+ * `applyTransform` writes `translate(tx,ty) scale(zoom)` with
+ * `tx = (width/2)(1-zoom) + pan.x*zoom` onto the wrapper, so a wrapper-local
+ * point `x` lands at screen `tx + zoom*x`. Solving `tx + zoom*x = width/2`
+ * gives `x = width/2 - pan.x` — the zoom cancels. `setCenter` derives the same
+ * identity from the other direction ("pan = width/2 - pos, independent of
+ * zoom") and is the round-trip inverse of this function.
+ *
+ * Dividing by zoom here (as this and `getCenter` both once did) puts the point
+ * a full viewport off-screen at zoom 4, which for the marker budget means
+ * ranking every proximity-ordered layer against a location the user is not
+ * looking at.
+ */
+export function projectionPointAtScreenCentre(
+  width: number,
+  height: number,
+  pan: { x: number; y: number },
+): [number, number] {
+  return [width / 2 - pan.x, height / 2 - pan.y];
+}

--- a/tests/map-mobile-feature-caps.test.mjs
+++ b/tests/map-mobile-feature-caps.test.mjs
@@ -29,9 +29,14 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
     // invariant is unchanged and still asserted, just in its new home.
     const slices = sliceBetween('private overlayFeedSlices(): {', 'private planOverlayMarkerBudget(');
 
-    const timeFilterIdx = slices.indexOf('const filteredQuakes = withinTimeRange(this.earthquakes);');
+    const timeFilterIdx = slices.indexOf('const filteredQuakes = withinTimeRange(activeQuakes);');
     const mobileFilterIdx = slices.indexOf('quakes: this.isMobile');
 
+    assert.match(
+      slices,
+      /const activeQuakes = layers\.natural \? this\.earthquakes : \[\];/,
+      'a layer that is off must contribute no markers before any filtering runs',
+    );
     assert.ok(timeFilterIdx >= 0, 'earthquake time-range filter should exist');
     assert.ok(mobileFilterIdx > timeFilterIdx, 'mobile cutoff should run after the time-range filter');
     assert.match(
@@ -74,7 +79,7 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
     const slices = sliceBetween('private overlayFeedSlices(): {', 'private planOverlayMarkerBudget(');
     assert.match(
       slices,
-      /iranEvents: this\.isMobile\s*\?\s*this\.iranEvents\.slice\(0, MapComponent\.MOBILE_MAX_IRAN_EVENTS\)\s*:\s*this\.iranEvents,/,
+      /iranEvents: this\.isMobile\s*\?\s*activeIranEvents\.slice\(0, MapComponent\.MOBILE_MAX_IRAN_EVENTS\)\s*:\s*activeIranEvents,/,
       'mobile path must cap Iran events at the named 50-event threshold and desktop must keep the full list',
     );
 

--- a/tests/map-mobile-feature-caps.test.mjs
+++ b/tests/map-mobile-feature-caps.test.mjs
@@ -24,43 +24,73 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
   });
 
   it('applies the mobile M5.0 earthquake cutoff after the time-range filter and before marker DOM creation', () => {
-    const block = sliceBetween('// Earthquakes (magnitude-based sizing)', '// Economic Centers');
+    // The caps moved out of renderOverlays into overlayFeedSlices() (#7112) so
+    // the marker budget plans on exactly the slice the loops draw. The ordering
+    // invariant is unchanged and still asserted, just in its new home.
+    const slices = sliceBetween('private overlayFeedSlices(): {', 'private planOverlayMarkerBudget(');
 
-    const timeFilterIdx = block.indexOf('const filteredQuakes =');
-    const mobileFilterIdx = block.indexOf('const quakesForRender = this.isMobile');
-    const markerLoopIdx = block.indexOf('quakesForRender.forEach((eq) => {');
-    const markerDomIdx = block.indexOf("document.createElement('div')");
+    const timeFilterIdx = slices.indexOf('const filteredQuakes = withinTimeRange(this.earthquakes);');
+    const mobileFilterIdx = slices.indexOf('quakes: this.isMobile');
 
     assert.ok(timeFilterIdx >= 0, 'earthquake time-range filter should exist');
     assert.ok(mobileFilterIdx > timeFilterIdx, 'mobile cutoff should run after the time-range filter');
-    assert.ok(markerLoopIdx > mobileFilterIdx, 'marker loop should use the capped render list');
-    assert.ok(markerDomIdx > markerLoopIdx, 'mobile cutoff should run before marker DOM creation');
     assert.match(
-      block,
+      slices,
       /filteredQuakes\.filter\(\(eq\) => eq\.magnitude >= MapComponent\.MOBILE_MIN_EARTHQUAKE_MAGNITUDE\)/,
       'mobile path must filter earthquakes at the named M5.0 threshold',
     );
-    assert.match(block, /: filteredQuakes;/, 'desktop path must keep the full time-range-filtered list');
+    assert.match(slices, /: filteredQuakes,/, 'desktop path must keep the full time-range-filtered list');
+
+    // The slice is computed once, before any marker is built, and both the
+    // budget plan and the render loop read that same slice — planning on the
+    // raw field instead would spend the layer's share on events the cutoff
+    // discards and render none of the ones that survive it (#7112).
+    const overlays = sliceBetween(
+      'private renderOverlays(projection: d3.GeoProjection): void {',
+      'private renderConflictEventMarkers(',
+    );
+    const slicesIdx = overlays.indexOf('const slices = this.overlayFeedSlices();');
+    const planIdx = overlays.indexOf('this.planOverlayMarkerBudget(projection, slices);');
+    const markerLoopIdx = overlays.indexOf('quakesForRender.forEach((eq) => {');
+    const markerDomIdx = overlays.indexOf("document.createElement('div')");
+
+    assert.ok(slicesIdx >= 0, 'renderOverlays should derive its feed slices once');
+    assert.ok(planIdx > slicesIdx, 'the marker budget should be planned from those slices');
+    assert.ok(markerLoopIdx > planIdx, 'marker loop should run after the budget plan');
+    assert.ok(markerDomIdx > slicesIdx, 'mobile cutoff should run before marker DOM creation');
+    assert.match(
+      overlays,
+      /const quakesForRender = slices\.quakes;/,
+      'the earthquake loop must iterate the shared slice',
+    );
+    assert.match(
+      sliceBetween('private planOverlayMarkerBudget(', 'private isOverlayMarkerCut('),
+      /add\('natural', slices\.quakes,/,
+      'the budget must plan on the same earthquake slice the loop draws',
+    );
   });
 
   it('applies the mobile Iran event cap before projection and marker DOM creation', () => {
-    const block = sliceBetween('// Iran events (severity-colored circles matching DeckGL layer)', '// Hotspots');
+    const slices = sliceBetween('private overlayFeedSlices(): {', 'private planOverlayMarkerBudget(');
+    assert.match(
+      slices,
+      /iranEvents: this\.isMobile\s*\?\s*this\.iranEvents\.slice\(0, MapComponent\.MOBILE_MAX_IRAN_EVENTS\)\s*:\s*this\.iranEvents,/,
+      'mobile path must cap Iran events at the named 50-event threshold and desktop must keep the full list',
+    );
 
-    const capIdx = block.indexOf('const iranEventsForRender = this.isMobile');
-    const loopIdx = block.indexOf('iranEventsForRender.forEach((ev) => {');
+    const block = sliceBetween('// Iran events (severity-colored circles matching DeckGL layer)', '// Hotspots');
+    const loopIdx = block.indexOf('slices.iranEvents.forEach((ev) => {');
     const projectionIdx = block.indexOf('const pos = projection([ev.longitude, ev.latitude])');
     const markerDomIdx = block.indexOf("document.createElement('div')");
 
-    assert.ok(capIdx >= 0, 'Iran render list should be capped on mobile');
-    assert.ok(loopIdx > capIdx, 'Iran marker loop should use the capped render list');
+    assert.ok(loopIdx >= 0, 'Iran marker loop should use the capped render slice');
     assert.ok(projectionIdx > loopIdx, 'Iran cap should run before per-event projection');
     assert.ok(markerDomIdx > projectionIdx, 'Iran cap should run before marker DOM creation');
     assert.match(
-      block,
-      /this\.iranEvents\.slice\(0, MapComponent\.MOBILE_MAX_IRAN_EVENTS\)/,
-      'mobile path must cap Iran events at the named 50-event threshold',
+      sliceBetween('private planOverlayMarkerBudget(', 'private isOverlayMarkerCut('),
+      /add\('iranAttacks', slices\.iranEvents\);/,
+      'the budget must plan on the same Iran slice the loop draws',
     );
-    assert.match(block, /: this\.iranEvents;/, 'desktop path must keep the full Iran event list');
   });
 
   it('keeps label overlap measurement disabled on mobile until movement or zoom needs it', () => {

--- a/tests/map-overlay-budget-disclosure.test.mjs
+++ b/tests/map-overlay-budget-disclosure.test.mjs
@@ -1,0 +1,184 @@
+/**
+ * #7112 — every layer the SVG overlay marker budget can trim needs somewhere to
+ * say so.
+ *
+ * `updateLayerTruncationLabels` writes a `shown/total` badge onto
+ * `.layer-toggle-row[data-layer="<key>"]`. `createLayerToggles` builds those rows
+ * from a per-variant list, while `planOverlayMarkerBudget` budgets from the layer
+ * STATE. The two are unrelated code, so a layer can be switched on by a variant's
+ * default map layers, be budgeted, be trimmed — and have no row to disclose the
+ * cut on. Silent withholding on a monitoring product is indistinguishable from
+ * missing data, and the trimmed layer still spends fair share out of the global
+ * total, tightening the cap on the layers that DO disclose.
+ *
+ * That is not hypothetical: the commodity variant turns `fires` and `minerals` on
+ * (COMMODITY_MAP_LAYERS) and has no `commodityLayers` picker list, so it falls
+ * through to `fullLayers`, which lists neither. This pins the relationship for
+ * every variant so the next one fails here instead of in production.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const read = (rel) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
+const mapSrc = read('../src/components/Map.ts');
+const panelsSrc = read('../src/config/panels.ts');
+
+function sliceBetween(src, start, end) {
+  const startIdx = src.indexOf(start);
+  assert.ok(startIdx >= 0, `anchor not found: ${start}`);
+  const endIdx = src.indexOf(end, startIdx + 1);
+  assert.ok(endIdx > startIdx, `end anchor not found after start: ${end}`);
+  return src.slice(startIdx, endIdx);
+}
+
+/**
+ * Accepted disclosure gaps. Each is a UI gap worth closing (give the layer a
+ * row), not a property worth keeping — shrinking this map is progress. They stay
+ * budgeted because the DOM ceiling is the point of #7112 and none of these feeds
+ * is bounded upstream (`toMapFires` caps nothing), and their cut is reported via
+ * `getOverlayMarkerBudgetState().undisclosed` rather than vanishing.
+ */
+const DECLARED_GAPS = new Map([
+  ['commodity:fires', 'commodity has no picker list of its own; falls through to fullLayers'],
+  ['commodity:minerals', 'commodity has no picker list of its own; falls through to fullLayers'],
+  ['commodity:commodityHubs', 'commodity has no picker list of its own; falls through to fullLayers'],
+]);
+
+/** Variant -> the createLayerToggles list it actually uses. */
+const VARIANT_PICKER_LIST = {
+  full: 'fullLayers',
+  tech: 'techLayers',
+  finance: 'financeLayers',
+  happy: 'happyLayers',
+  energy: 'energyLayers',
+  // No `commodityLayers` exists; createLayerToggles' ternary falls through.
+  commodity: 'fullLayers',
+};
+
+/** Variant -> the panels.ts default map-layer state it boots with. */
+const VARIANT_LAYER_STATE = {
+  full: 'FULL_MAP_LAYERS',
+  tech: 'TECH_MAP_LAYERS',
+  finance: 'FINANCE_MAP_LAYERS',
+  happy: 'HAPPY_MAP_LAYERS',
+  energy: 'ENERGY_MAP_LAYERS',
+  commodity: 'COMMODITY_MAP_LAYERS',
+};
+
+const planBlock = sliceBetween(
+  mapSrc,
+  'private planOverlayMarkerBudget(',
+  'private getOverlayBudgetCentre(',
+);
+const togglesBlock = sliceBetween(
+  mapSrc,
+  'private createLayerToggles(): HTMLElement {',
+  'private clearLayerExplanationOutsideClickHandler(',
+);
+
+/** Layer keys the budget plan can produce a truncation entry for. */
+function plannedLayers() {
+  const layers = new Set();
+  for (const match of planBlock.matchAll(/add\(\s*'([A-Za-z]+)'[^;]*/g)) {
+    // `exempt: true` groups sit outside the budget entirely, so they can never
+    // appear in the truncation record and need no row.
+    if (/exempt:\s*true/.test(match[0])) continue;
+    layers.add(match[1]);
+  }
+  return layers;
+}
+
+/** Layer keys one named picker list declares. */
+function pickerLayersFor(listName) {
+  const marker = `const ${listName}: (keyof MapLayers)[] = [`;
+  const body = sliceBetween(togglesBlock, marker, '];').slice(marker.length);
+  const layers = new Set();
+  // Strip line comments first: several carry prose containing apostrophes.
+  for (const [, key] of body.replace(/\/\/[^\n]*/g, '').matchAll(/'([A-Za-z]+)'/g)) layers.add(key);
+  return layers;
+}
+
+/** Layer keys a variant's default state switches ON at boot. */
+function defaultOnLayersFor(stateName) {
+  const body = sliceBetween(panelsSrc, `const ${stateName}: MapLayers = {`, '\n};');
+  const layers = new Set();
+  for (const [, key] of body.matchAll(/^\s*([A-Za-z]+):\s*true\b/gm)) layers.add(key);
+  return layers;
+}
+
+describe('SVG overlay marker budget disclosure (#7112)', () => {
+  it('parses the plan, every picker list and every layer-state map', () => {
+    // Vacuity guard: each of the three sources must be non-trivially populated,
+    // or the real checks below pass by finding nothing.
+    const planned = plannedLayers();
+    assert.ok(planned.size > 20, `plan parsed as ${planned.size} layers`);
+    for (const list of new Set(Object.values(VARIANT_PICKER_LIST))) {
+      assert.ok(pickerLayersFor(list).size > 3, `${list} parsed as near-empty`);
+    }
+    for (const state of Object.values(VARIANT_LAYER_STATE)) {
+      assert.ok(defaultOnLayersFor(state).size > 3, `${state} parsed as near-empty`);
+    }
+    // Positive controls: budgeted, default-on and rowed in the full variant, so a
+    // regex that silently stopped matching fails here first.
+    for (const layer of ['natural', 'weather', 'economic']) {
+      assert.ok(planned.has(layer), `${layer} must be budgeted`);
+      assert.ok(defaultOnLayersFor('FULL_MAP_LAYERS').has(layer), `${layer} must default on`);
+      assert.ok(pickerLayersFor('fullLayers').has(layer), `${layer} must have a row`);
+    }
+    // Negative control: exempt groups must not count as budgeted.
+    assert.ok(!planned.has('techHubs') && !planned.has('geoHubs'));
+  });
+
+  it('gives every budgeted, default-on layer a row to disclose its cut on', () => {
+    const planned = plannedLayers();
+    const undeclared = [];
+    for (const [variant, stateName] of Object.entries(VARIANT_LAYER_STATE)) {
+      const rows = pickerLayersFor(VARIANT_PICKER_LIST[variant]);
+      for (const layer of defaultOnLayersFor(stateName)) {
+        if (!planned.has(layer) || rows.has(layer)) continue;
+        if (DECLARED_GAPS.has(`${variant}:${layer}`)) continue;
+        undeclared.push(`${variant}:${layer}`);
+      }
+    }
+    assert.deepEqual(
+      undeclared,
+      [],
+      'budgeted and on by default with no toggle row to disclose a cut. Give it a ' +
+        'row, mark the group exempt, or add it to DECLARED_GAPS with a reason: ' +
+        undeclared.join(', '),
+    );
+  });
+
+  it('keeps DECLARED_GAPS honest — no stale entries', () => {
+    const planned = plannedLayers();
+    const stale = [];
+    for (const key of DECLARED_GAPS.keys()) {
+      const [variant, layer] = key.split(':');
+      const stateName = VARIANT_LAYER_STATE[variant];
+      assert.ok(stateName, `DECLARED_GAPS names an unknown variant: ${variant}`);
+      const stillGapped =
+        planned.has(layer) &&
+        defaultOnLayersFor(stateName).has(layer) &&
+        !pickerLayersFor(VARIANT_PICKER_LIST[variant]).has(layer);
+      if (!stillGapped) stale.push(key);
+    }
+    assert.deepEqual(stale, [], `no longer a gap — drop from DECLARED_GAPS: ${stale.join(', ')}`);
+  });
+
+  it('routes undisclosed truncation into the public budget state rather than dropping it', () => {
+    // The mechanism the assertions above assume: without this the set would be
+    // computed and thrown away, and `undisclosed` would always read empty.
+    assert.match(
+      mapSrc,
+      /this\.overlayUndisclosedTruncation = undisclosed;/,
+      'updateLayerTruncationLabels must record what it could not disclose',
+    );
+    assert.match(
+      mapSrc,
+      /undisclosed: this\.overlayUndisclosedTruncation,/,
+      'getOverlayMarkerBudgetState must expose it',
+    );
+  });
+});

--- a/tests/map-svg-zoom-layer-dom.test.mjs
+++ b/tests/map-svg-zoom-layer-dom.test.mjs
@@ -81,9 +81,19 @@ describe('SVG map zoom-hidden layer DOM allocation', () => {
 
     assert.match(applyBody, /rebuildOnZoomVisibilityChange = true/);
     assert.match(applyBody, /const zoomVisibilityChanged = this\.updateZoomLayerVisibility\(\)/);
+    // The zoom-visibility rebuild keeps its own branch. #7112's overlay budget
+    // replan is deliberately the ELSE arm: a pass that already rebuilds must not
+    // schedule a second one, and the replan must go through the settle-debounced
+    // scheduleOverlayBudgetReplan() rather than reaching scheduleRender() from
+    // the pan/touchmove/wheel path directly.
     assert.match(
       applyBody,
-      /if \(rebuildOnZoomVisibilityChange && zoomVisibilityChanged\) this\.scheduleRender\(\)/,
+      /if \(rebuildOnZoomVisibilityChange && zoomVisibilityChanged\) \{\s*this\.scheduleRender\(\);\s*\} else if \(overlayBudgetViewportChanged\) \{\s*this\.scheduleOverlayBudgetReplan\(\);\s*\}/,
+    );
+    assert.equal(
+      (applyBody.match(/this\.scheduleRender\(\)/g) ?? []).length,
+      1,
+      'applyTransform must reach scheduleRender() exactly once, on the zoom-visibility branch only',
     );
     assert.ok(mapSrc.includes("SVG_MARKER_DOM_ZOOM_LAYERS = new Set<keyof MapLayers>(['bases', 'nuclear'])"));
     assert.match(updateBody, /let visibilityChanged = false/);

--- a/tests/overlay-marker-geometry.test.mts
+++ b/tests/overlay-marker-geometry.test.mts
@@ -1,0 +1,116 @@
+/**
+ * #7112 — the two pure functions the SVG overlay marker budget rests on.
+ *
+ * Both were shipped wrong once and neither failure was visible to the browser
+ * harness, which is why they are pinned here:
+ *
+ *  - `projectionPointAtScreenCentre` divided by zoom, putting the proximity
+ *    focus a full viewport off-screen at zoom 4. The e2e test covering it only
+ *    asserted that the marker set CHANGED after a pan/zoom, which is true of a
+ *    wrong centre too.
+ *  - `overlayMarkerPosition` had no branch for a weather alert's `centroid`, so
+ *    the entire weather layer scored -Infinity and its proximity cut silently
+ *    degenerated to raw feed order.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  overlayMarkerPosition,
+  projectionPointAtScreenCentre,
+} from '../src/utils/overlay-marker-geometry.ts';
+import { proximityRank } from '../src/utils/globe-marker-budget.ts';
+
+/**
+ * The wrapper transform MapComponent.applyTransform() actually writes:
+ * `translate(tx,ty) scale(zoom)` with transform-origin 0 0, so a wrapper-local
+ * point `x` paints at `tx + zoom*x`. Reimplemented from the renderer rather than
+ * from the function under test, so the two have to agree independently.
+ */
+function screenCoordOf(projected: number, extent: number, zoom: number, pan: number): number {
+  const translate = (extent / 2) * (1 - zoom) + pan * zoom;
+  return translate + zoom * projected;
+}
+
+describe('projectionPointAtScreenCentre (#7112)', () => {
+  it('names the point that actually paints at the centre of the viewport, at every zoom', () => {
+    const width = 1440;
+    const height = 900;
+    for (const zoom of [1, 1.5, 2, 4, 10]) {
+      for (const pan of [{ x: 0, y: 0 }, { x: 100, y: -60 }, { x: -320, y: 240 }]) {
+        const [px, py] = projectionPointAtScreenCentre(width, height, pan);
+        assert.equal(
+          screenCoordOf(px, width, zoom, pan.x),
+          width / 2,
+          `projected x ${px} should paint at the horizontal centre at zoom ${zoom}`,
+        );
+        assert.equal(
+          screenCoordOf(py, height, zoom, pan.y),
+          height / 2,
+          `projected y ${py} should paint at the vertical centre at zoom ${zoom}`,
+        );
+      }
+    }
+  });
+
+  it('is the exact inverse of the pan setCenter() computes', () => {
+    // setCenter derives `pan = width/2 - pos (independent of zoom)`. Round-tripping
+    // any projected point through that pan must return the same point.
+    const width = 1440;
+    const height = 900;
+    for (const pos of [[0, 0], [620, 300], [1439, 899], [-40, 12]] as const) {
+      const pan = { x: width / 2 - pos[0], y: height / 2 - pos[1] };
+      assert.deepEqual(projectionPointAtScreenCentre(width, height, pan), [pos[0], pos[1]]);
+    }
+  });
+
+  it('rejects the divide-by-zoom form this function replaced', () => {
+    // The regression, stated as a value: at zoom 4 the old expression named a
+    // point one full viewport width off-screen to the left of the viewport.
+    const width = 1440;
+    const zoom = 4;
+    const panX = 100;
+    const wrong = width / (2 * zoom) - panX;
+    assert.equal(screenCoordOf(wrong, width, zoom, panX), -1440);
+    assert.notEqual(projectionPointAtScreenCentre(width, 900, { x: panX, y: 0 })[0], wrong);
+  });
+});
+
+/**
+ * One real payload shape per feed `renderOverlays` iterates. A feed whose
+ * position cannot be read ranks -Infinity for its WHOLE layer, so a missing
+ * branch here is a silent ranking failure, not a crash.
+ */
+const FEED_SHAPES: Array<[string, unknown, [number, number]]> = [
+  ['vessel / flight / base / hotspot (lon,lat)', { lon: 12, lat: 34 }, [34, 12]],
+  ['webcam (lng)', { lng: 12, lat: 34 }, [34, 12]],
+  ['tech event (lng, null location)', { lng: 12, lat: 34, location: null }, [34, 12]],
+  ['iran event (longitude/latitude)', { longitude: 12, latitude: 34 }, [34, 12]],
+  ['earthquake (location.*)', { location: { longitude: 12, latitude: 34 } }, [34, 12]],
+  ['acled event (location.*)', { location: { longitude: 12, latitude: 34 }, fatalities: 3 }, [34, 12]],
+  ['conflict zone (center tuple)', { center: [12, 34] as const }, [34, 12]],
+  ['weather alert (centroid tuple)', { centroid: [12, 34] as const, severity: 'Severe' }, [34, 12]],
+];
+
+describe('overlayMarkerPosition (#7112)', () => {
+  for (const [name, marker, [lat, lng]] of FEED_SHAPES) {
+    it(`reads ${name}`, () => {
+      assert.deepEqual(overlayMarkerPosition(marker), { lat, lng });
+    });
+  }
+
+  it('yields NaN for an unrecognised shape rather than a wrong coordinate', () => {
+    const pos = overlayMarkerPosition({ id: 'no-geometry' });
+    assert.ok(Number.isNaN(pos.lat) && Number.isNaN(pos.lng));
+  });
+
+  it('lets every feed shape rank against a real focus instead of collapsing to -Infinity', () => {
+    // The weather regression in one assertion: a layer whose position cannot be
+    // read scores -Infinity for every member, so proximityRank cannot order it
+    // and the cut falls back to the raw feed order it exists to replace.
+    const rank = proximityRank<unknown>({ lat: 34, lng: 12 }, overlayMarkerPosition);
+    for (const [name, marker] of FEED_SHAPES) {
+      assert.notEqual(rank(marker), -Infinity, `${name} must be rankable`);
+    }
+    assert.equal(rank({ id: 'no-geometry' }), -Infinity);
+  });
+});


### PR DESCRIPTION
Closes #7112.

## What the bimodality actually is

The heavy and light states are **two different map renderers**, not two states of one.

`MapContainer.shouldUseDeckGL()` (`src/components/MapContainer.ts:313`) falls back to the SVG `MapComponent` whenever `hasWebGLSupport()` is false — and that helper rejects a software rasterizer by name (`swiftshader`, `llvmpipe`, `softpipe`, `src/components/MapContainer.ts:290`). That is the normal state of a synthetic lab runner, and of any GPU-blocklisted browser. So a desktop `/dashboard` load lands on Deck **or** on the SVG renderer, and only the SVG renderer draws markers as DOM.

Measured on production 2026-08-24, 1920x1080, cold profile, default layers, 45 s settle, CDP `Performance.getMetrics()`:

| renderer | overlay markers | renderer nodes | JS listeners | `document.documentElement.outerHTML` |
|---|---|---|---|---|
| `deckgl-mode` (hardware WebGL2) | 0 | 7,631 | 736 | 292,841 |
| `svg-mode` (no WebGL2) | 2,088 | 17,429 | 2,753 | 2,300,456 |

and mid-rebuild the SVG path peaked at **49,731 nodes / 21,511 listeners** in the same session.

That maps straight onto the issue's two bands: the light band (7.6k–10.9k nodes / 930–1,322 listeners) is Deck, the heavy band (12.5k–36.9k / 1,704–8,377) is the SVG fallback plus its rebuild churn. There is "almost nothing in between" because there is nothing in between two renderers.

**The named code path (acceptance criterion 1).** `MapComponent.renderOverlays` rebuilds every HTML marker from scratch on every render and attaches a fresh `click` listener per marker, uncapped. Attributed by wrapping `EventTarget.prototype.addEventListener` on production and grouping registrations by call site:

| marker | listeners registered | detached at read | source |
|---|---|---|---|
| `.military-vessel-marker` | 7,789 | 6,283 | `src/components/Map.ts:3279` |
| `.military-flight-marker` | 3,796 | 3,504 | `src/components/Map.ts:3174` |
| `.earthquake-marker` | 1,470 | 1,323 | `src/components/Map.ts:2197` |
| `.weather-marker` | 528 | 480 | `src/components/Map.ts:2271` |
| `.hotspot` | 406 | 377 | `src/components/Map.ts:2125` |

1,502 of the 2,088 live markers were military AIS vessels — the same uncapped feed as #5375, reached through a different render path than the one that issue and #5371 covered.

### The ~9 bytes-per-node puzzle, resolved

DebugBear's `nodes` / `jsEventListeners` come from CDP `Performance.getMetrics()`, which counts **every node alive in the renderer, including detached ones awaiting GC**. `outerHtmlLength` only serializes the live tree. Each `renderOverlays` pass wipes `#mapOverlays` and rebuilds it, so several marker generations are counted at once while only one is serialized. Reproduced directly: within one session nodes went 5,359 → 19,077 (+13,718) while `outerHtmlLength` moved 1,876,188 → 2,028,173 (+151,985) — 11 bytes per added node, the issue's figure.

This also explains the two things the issue could not: the weak `r(nodes, TBT)`, because the churn is spread across the boot window rather than concentrated in one long task, and mobile's flat 2,370–4,438 nodes, because mobile is always the SVG renderer but `FULL_MOBILE_MAP_LAYERS` turns `military` off (#5375).

## The fix

Applies the globe's existing marker budget (#5368 / #5371) to the SVG overlay — same module, same ceilings, so a client that falls back between renderers does not silently change how much of a layer it can see.

- `src/utils/globe-marker-budget.ts` — adds `MAP_OVERLAY_MARKER_BUDGET_DESKTOP` `{perLayer: 300, total: 800}` and `_MOBILE` `{perLayer: 150, total: 400}`. No change to the selection algorithm; the existing 344-line test suite covers it.
- `MapComponent.planOverlayMarkerBudget()` — builds one `GlobeMarkerGroup` per feed, ranks by severity where there is one (vessel carrier, earthquake magnitude, fire brightness, ACLED fatalities) and by `proximityRank` to the projection's view centre otherwise, then stores the set of markers to **withhold**. A feed absent from the plan renders in full, so a plan/render mismatch is a missing ceiling, never a blank layer.
- Each feed loop gains a one-line guard; the four clustering paths filter their input instead, since clustering is many-to-one and a cut on the way out cannot bound it.
- `MapComponent.overlayFeedSlices()` is the single source of truth for the five feeds whose rendered set differs from the stored field (earthquakes, Iran events, aircraft positions, protests, ACLED events). The plan and the loops read the same slice.
- Truncation is disclosed as a `shown/total` badge on the layer toggle row, reusing the globe's `.layer-truncation-count` styling.

### Effect

Harness measurement, 2,000 markers seeded per feed across 3 feeds, identical page otherwise:

| | without budget | with budget |
|---|---|---|
| overlay markers | 6,001 | 799 |
| live DOM nodes | 18,303 | 2,697 |
| JS listeners | 6,061 | 1,161 |
| renderer nodes after 4 rebuilds | 60,200 | 21,704 |

On the production default view this takes the overlay from 2,088 markers to at most 800.

## Testing

`e2e/map-overlay-marker-budget.spec.ts` — three tests against the real `MapComponent` in the existing map harness. Each was mutation-tested by neutering the code it guards:

| test | asserts | fails as | 
|---|---|---|
| bounds the overlay marker count | 6,001 seeded markers render at most 800, per-group at most 300, every feed keeps a share, hotspots survive whole, badge shows `shown/total` | `6000 > 800` |
| keeps the highest-magnitude earthquakes | the cut is by magnitude, not feed order | min magnitude `1` vs `> 1.5` |
| budgets the time-filtered slice | 40 recent events behind 2,000 stale higher-magnitude ones all render | `0` of `40` |

The third one found a real defect in my own first commit and is fixed in `3356f19c8`: planning over `this.earthquakes` while the loop draws a 24 h slice spends the layer's whole share on out-of-window events and renders **none** of the in-window ones.

Also run: `test:dom` (59 files / 456 tests), `test:data` (26,144 tests), the map/globe unit tests (238), and `e2e/mobile-map-popup.spec.ts` + `e2e/map-harness.spec.ts` + `e2e/mobile-map-native.spec.ts` + `e2e/collapsed-map-first-paint.spec.ts`.

Pre-existing failures, verified identical on a clean tree at the same commit (6 e2e, 2 unit): `mobile-map-native` (4), `collapsed-map-first-paint` (1), `map-harness` pulse (1), `china-policy-events` regex timing (load-sensitive), `pro-sentry-chunk` (needs `public/pro/assets`, gitignored and built at deploy).

`tests/map-mobile-feature-caps.test.mjs` asserts source ordering inside `renderOverlays`, so moving the mobile caps into `overlayFeedSlices()` broke it. Repointed at the new home in `3aaff4936`, keeping the ordering invariant and adding the one the move exists to guarantee — that the plan and the loop consume the same slice.

## Behaviour change to be aware of

Reference layers are now budgeted, matching the globe. With many layers stacked a user can see fewer markers than before; the cut is by nearness to the view centre, and the toggle row discloses `shown/total`. On the default desktop view only `military` and `natural` are large enough to be trimmed.

## Post-Deploy Monitoring & Validation

- **Watch:** DebugBear project 103025, page 693053 (`dash desktop`), metrics `nodes` and `jsEventListeners`, daily ~07:03–07:06 UTC.
- **Healthy signal:** the heavy band disappears. Every desktop run should land under ~12k nodes / ~1.5k listeners; the previous 12.5k–36.9k / 1,704–8,377 band should have no members. Mobile (693052) should be unchanged at 2,370–4,438 / 366–497 — it is the control.
- **Also watch:** CrUX INP p75 for `/dashboard` (257 ms at filing, against an origin p75 of 143 ms). This is a plausible contributor, not a proven cause, so treat an improvement as confirmation and no movement as "the listener count was not the binding constraint" — not as a failed deploy.
- **Failure signal:** users reporting missing map markers, or a `shown/total` badge appearing on a layer that was never large (would mean the fair-share cap is biting somewhere unintended). Sentry: any new `MapComponent`-framed error.
- **Window / owner:** 7 days of scheduled runs, @koala73.
- **Rollback:** revert this branch. The change is confined to `MapComponent`'s overlay path plus two additive constants; the DeckGL and globe renderers are untouched.

## Known residuals

- **Code review:** run inline by the author rather than through `ce-code-review`'s subagent fleet (agent dispatch was disabled for this session). Three defects were found and fixed that way — the slice-alignment bug (`3356f19c8`), the truncation-label latch ordering and the unconditional feed filtering (`3aaff4936`, `4dac3b551`). A fleet review before merge would still be worthwhile.
- **Not fixed here:** the rebuild churn itself. `renderOverlays` still destroys and recreates every marker on every render; the budget makes each generation 2.6x smaller but does not make the rebuild incremental. Worth a separate issue if the node count stays higher than expected.
- The `shown/total` badge title is an untranslated literal, matching `GlobeMap.updateLayerTruncationLabels` and its existing i18n follow-up.

---
🤖 Compound Engineered with [Claude Code](https://claude.com/claude-code) (Opus 5)

https://claude.ai/code/session_01RF8nHCScZjvkRPTK8KLzb6
