### PR TITLE
fix(hooks): test the npm install marker, not the directory, in pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -345,8 +345,15 @@ if [ -L node_modules ]; then
   echo "ERROR: node_modules is a symlink. Copy, hardlink, or npm ci — never symlink."
   exit 1
 fi
-if [ ! -d node_modules ]; then
-  echo "node_modules missing, running npm ci..."
+# Test the install MARKER, not the directory. `-d` is satisfied by an empty
+# node_modules/ — which a half-finished install, an interrupted npm ci, or a
+# `mkdir node_modules` leaves behind — so the gate would skip the install and
+# then die later on a missing binary (`sh: tsc: command not found`), pointing
+# at the wrong thing. npm writes .package-lock.json only on a completed install,
+# which is exactly the check shouldInstallDependencies() in
+# scripts/bootstrap-worktree.mjs already uses. Keep the two in agreement.
+if [ ! -f node_modules/.package-lock.json ]; then
+  echo "node_modules missing or incomplete, running npm ci..."
   npm ci --cache "$npm_config_cache" --prefer-offline || exit 1
 fi
 
@@ -629,7 +636,8 @@ if [ -n "$PRO_BUILT_OUTPUT_TEST" ]; then
     echo "ERROR: pro-test/node_modules is a symlink. Copy, hardlink, or npm ci — never symlink."
     exit 1
   fi
-  if [ ! -d pro-test/node_modules ]; then
+  # Marker, not directory — see the root node_modules check above.
+  if [ ! -f pro-test/node_modules/.package-lock.json ]; then
     (cd pro-test && npm ci --cache "$npm_config_cache" --prefer-offline) || exit 1
   fi
   (cd pro-test && npm run build >/dev/null) || {
@@ -743,7 +751,8 @@ if [ "$RUN_ALL" = true ] || path_matches '^pro-test/|^convex/config/productCatal
     echo "ERROR: pro-test/node_modules is a symlink. Copy, hardlink, or npm ci — never symlink."
     exit 1
   fi
-  if [ ! -d pro-test/node_modules ]; then
+  # Marker, not directory — see the root node_modules check above.
+  if [ ! -f pro-test/node_modules/.package-lock.json ]; then
     echo "  Installing pro-test deps..."
     (cd pro-test && npm ci --cache "$npm_config_cache" --prefer-offline) || exit 1
   fi

--- a/tests/prepush-hook-gate.test.mjs
+++ b/tests/prepush-hook-gate.test.mjs
@@ -102,6 +102,11 @@ function makeFixture({
   for (const dir of ['.husky', 'scripts', 'scripts/lib', 'tests', 'node_modules']) {
     mkdirSync(join(root, dir), { recursive: true });
   }
+  // Simulate a COMPLETED install, not merely a present directory. npm writes
+  // .package-lock.json only when an install finishes, and the gate keys on that
+  // marker — an empty node_modules/ is the half-installed state it must catch.
+  // node_modules/ is gitignored above so this stays invisible to `dirty`.
+  writeFileSync(join(root, 'node_modules', '.package-lock.json'), '{}\n');
   copyFileSync(HOOK, join(root, '.husky', 'pre-push'));
   for (const script of ['prepush-admission.mjs', 'prepush-attest.sh', 'prepush-changed-tests.sh']) {
     copyFileSync(join(REPO_ROOT, 'scripts', script), join(root, 'scripts', script));
@@ -123,7 +128,7 @@ function makeFixture({
   }
   writeFileSync(join(root, 'package.json'), '{"name":"fixture"}\n');
   writeFileSync(join(root, 'README.md'), 'base\n');
-  writeFileSync(join(root, '.gitignore'), 'public/pro/\n');
+  writeFileSync(join(root, '.gitignore'), 'public/pro/\nnode_modules/\n');
   // RUN_ALL fires the CJS syntax check, which iterates `scripts/*.cjs`.
   if (scriptsCjs) writeFileSync(join(root, 'scripts', 'noop.cjs'), 'module.exports = {};\n');
 
@@ -136,6 +141,7 @@ function makeFixture({
   // invisible to `dirty`).
   if (proTestNodeModules) {
     mkdirSync(join(root, 'pro-test', 'node_modules'), { recursive: true });
+    writeFileSync(join(root, 'pro-test', 'node_modules', '.package-lock.json'), '{}\n');
   }
   for (const [path, contents] of Object.entries({
     'src/config/products.generated.ts': 'export const PRODUCTS = [];\n',
@@ -254,6 +260,7 @@ function pushWithPoisonedSharedHooksPath() {
   git(main, ['push', '--quiet', '--set-upstream', 'origin', 'main']);
   git(main, ['worktree', 'add', '--quiet', '-b', 'feature', worktree]);
   mkdirSync(join(worktree, 'node_modules'), { recursive: true });
+  writeFileSync(join(worktree, 'node_modules', '.package-lock.json'), '{}\n');
   writeFileSync(join(worktree, 'README.md'), 'feature\n');
   git(worktree, ['add', 'README.md']);
   git(worktree, ['commit', '--quiet', '-m', 'feature']);


### PR DESCRIPTION
## The bug

`.husky/pre-push` decides whether to install deps with:

```sh
if [ ! -d node_modules ]; then
```

`-d` is satisfied by an **empty** `node_modules/`. So on a half-installed tree the gate skips `npm ci`, runs anyway, and dies much later inside the typecheck step with `sh: tsc: command not found` — which reads as a deep, late failure and points at entirely the wrong thing.

An empty `node_modules/` is not hypothetical. An interrupted `npm ci`, a partial install, or a bare `mkdir node_modules` all leave one.

Found in a worktree that had exactly that state — `node_modules/` present, **zero entries**. It only avoided the confusing failure because that worktree is nested inside the main checkout, so Node's module resolution walked up and silently used the parent's dependencies:

```
require.resolve('tsx')
  -> /Users/…/worldmonitor/node_modules/tsx/package.json   # the parent's, not the worktree's
```

A worktree created *outside* the main checkout would have sailed past the check and hit the misleading failure.

## The fix

Test the install **marker** instead of the directory. npm writes `node_modules/.package-lock.json` only on a completed install.

This is not a new idea — `shouldInstallDependencies()` in `scripts/bootstrap-worktree.mjs:209` **already** checks exactly that:

```js
return forceInstall || !existsSync(resolve(rootDir, 'node_modules/.package-lock.json'));
```

Two implementations of the same question had drifted apart; this aligns the hook to the one that was already correct. Applied at all three sites (root, plus both `pro-test` blocks).

## Verification

| state | old check | new check |
|---|---|---|
| empty `node_modules/` | skips install (**bug**) | installs |
| completed install (marker present) | skips | skips (no churn) |

`bash -n .husky/pre-push` clean. The symlink guards immediately above each site are untouched — they exist because of a real incident where a symlinked `node_modules` had its **shared target** deleted by the hook, and this change doesn't weaken them.

## Not in scope

The recurring `core.hooksPath` absolute-path misconfiguration is a separate, already-documented problem (this is at least its sixth recurrence, with an unidentified writer). It is local git config, not repo state, so there is nothing to change here.

https://claude.ai/code/session_0184u5A5PXeTVco6AerjAnNR
