### PR TITLE
fix(infrastructure): preserve last-good temporal anomalies

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -786,7 +786,7 @@ const SEED_META = {
   militaryCii:      { key: 'seed-meta:intelligence:military-cii',  maxStaleMin: 45 }, // seed-military-cii cron ~10min; 45 = generous grace (relay-dependent; preserve-last-good runs still refresh meta)
   defensePatents:   { key: 'seed-meta:military:defense-patents',  maxStaleMin: 25200 },
   satellites:       { key: 'seed-meta:intelligence:satellites',    maxStaleMin: 240 }, // CelesTrak every 120min; 240min = absorbs one missed cycle
-  temporalAnomalies:{ key: 'seed-meta:temporal:anomalies',          maxStaleMin: 45 }, // rebuild-stamped ONLY (TEMPORAL_ANOMALIES_REBUILD_AFTER_MS=20min in infrastructure/v1/_shared.ts) — traffic no longer refreshes it, so a stale stamp means a stalled producer, not a traffic lull; 45min leaves ~2.25x margin (one missed cycle). Data TTL is 60min so health reaches STALE_SEED before EMPTY
+  temporalAnomalies:{ key: 'seed-meta:temporal:anomalies',          maxStaleMin: 45 }, // rebuild-stamped ONLY (TEMPORAL_ANOMALIES_REBUILD_AFTER_MS=20min in infrastructure/v1/_shared.ts) — only producer-route traffic can rebuild and refresh this request-driven stamp, so a traffic lull can age it past 45min; 45min leaves ~2.25x margin. Data TTL is 60min so health reaches STALE_SEED before EMPTY
   weatherAlerts:    { key: 'seed-meta:weather:alerts',             maxStaleMin: 45 }, // relay loop every 15min; 45 = 3× interval (was 30 = 2×, too tight on relay hiccup)
   canadaRoads:      {
     key: 'seed-meta:infra:ontario-511',

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -1233,8 +1233,8 @@ Temporal anomaly watch: current event counts vs day-of-week and seasonal baselin
 
 - **API endpoints:** none (MCP-only; the REST baseline endpoints are write-through and excluded from parity).
 - **Access:** `free-account` — callable by any signed-in account; free accounts spend the daily free allowance, Pro calls spend the daily quota. Accepts the universal `summary` argument.
-- **Kind:** cache read — sub-second response from Redis bootstrap cache.
-- **Freshness budget:** up to **45 min** before `stale: true` is flagged. The snapshot is rebuilt on demand when it is older than 20 min, and `cached_at` tracks that rebuild — not the time of your request — so it advances in ~20-minute steps rather than reading "just now" on every call. A rebuild is triggered by an incoming request, so a genuinely traffic-free period can let the budget lapse.
+- **Kind:** cache-only read — sub-second response from Redis bootstrap cache. MCP calls do not invoke the producer or trigger a rebuild.
+- **Freshness budget:** up to **45 min** before `stale: true` is flagged. Only traffic to the underlying producer route/RPC (`GET /api/infrastructure/v1/list-temporal-anomalies`) triggers an on-demand rebuild once the snapshot is older than 20 min. `cached_at` records that rebuild — not the time of the MCP call — so it advances only when the producer route rebuilds the snapshot. With no traffic to that route, the request-driven stamp can age past the budget.
 
 <CodeGroup>
 

--- a/docs/zh/mcp-tools-reference.mdx
+++ b/docs/zh/mcp-tools-reference.mdx
@@ -1012,8 +1012,8 @@ curl -s https://worldmonitor.app/mcp \
 | `limit` | number | 将异常列表限制为最多这么多项（默认 30，传 0 表示不限）。 |
 
 - **API 端点：** 无（仅 MCP；底层 REST 基线端点为写穿式，已从对等性检查中排除）。
-- **类型：** 缓存读取 — 来自 Redis 引导缓存的亚秒级响应。
-- **新鲜度预算：** 标记 `stale: true` 前最多 **45 分钟**（生产者每小时刷新，并由 infra seeder 保持热度）。
+- **类型：** 仅缓存读取 — 从 Redis 引导缓存亚秒级返回。MCP 调用不会调用生产者，也不会触发重建。
+- **新鲜度预算：** 标记 `stale: true` 前最多 **45 分钟**。只有底层生产者路由/RPC（`GET /api/infrastructure/v1/list-temporal-anomalies`）收到流量时，才会在快照超过 20 分钟后按需重建。`cached_at` 记录该次重建的时间，而不是 MCP 调用时间，因此仅在生产者路由重建快照时推进。如果该路由没有流量，这个请求驱动的时间戳可能超过新鲜度预算。
 
 <CodeGroup>
 

--- a/server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts
+++ b/server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts
@@ -163,6 +163,15 @@ export async function listTemporalAnomalies(
       }
 
       const typesWithCounts = trackedTypes.filter(t => counts[t] !== undefined);
+      if (typesWithCounts.length === 0) {
+        // A lock only grants rebuild ownership; it does not make an empty set of
+        // upstream reads publishable. Preserve the last-good snapshot without
+        // advancing any baseline or freshness clock. On a cold miss, return the
+        // canonical empty response but leave Redis untouched so health continues
+        // to report the producer as unavailable.
+        if (cached) return cached;
+        return { anomalies: [], trackedTypes: [], computedAt: '' };
+      }
 
       const baselines = await Promise.all(
         typesWithCounts.map(t =>

--- a/tests/temporal-anomalies-cache.test.mts
+++ b/tests/temporal-anomalies-cache.test.mts
@@ -20,7 +20,10 @@ import { listTemporalAnomalies } from '../server/worldmonitor/infrastructure/v1/
  */
 async function runWithRedisStub(
   keyValues: Record<string, unknown>,
-  { lockGranted = true }: { lockGranted?: boolean } = {},
+  {
+    lockGranted = true,
+    failedPostKeys = [],
+  }: { lockGranted?: boolean; failedPostKeys?: string[] } = {},
 ) {
   const originalFetch = globalThis.fetch;
   const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
@@ -48,6 +51,9 @@ async function runWithRedisStub(
         }
       } catch { /* leave undefined; assertions below surface it */ }
       calls.push({ method: 'POST', key, recordCount });
+      if (failedPostKeys.includes(key)) {
+        return Response.json({ error: `forced POST failure for ${key}` }, { status: 500 });
+      }
       return Response.json({ result: lockGranted ? 'OK' : null });
     }
     const key = decodeURIComponent(new URL(String(input)).pathname.replace('/get/', ''));
@@ -126,6 +132,7 @@ describe('temporal anomalies cache freshness', () => {
     // lock SET alone satisfies it.
     const { calls } = await runWithRedisStub({
       'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+      'news:insights:v1': { topStories: [{ id: 'a' }] },
     });
 
     const writes = calls.filter((c) => c.method === 'POST');
@@ -139,23 +146,41 @@ describe('temporal anomalies cache freshness', () => {
     );
   });
 
-  it('stamps the coverage it ACHIEVED, not the coverage it configured', async () => {
-    // recordCount used to come from trackedTypes — the constant
-    // Object.keys(COUNT_SOURCE_KEYS) — so it reported 2 even with zero inputs
-    // read. Nothing branches on it today (no consumer sets minRecordCount), but
-    // a coverage floor added later would be born unable to fire.
-    // Both count sources absent -> achieved coverage is 0.
-    const { calls } = await runWithRedisStub({
-      'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+  it('preserves the last-good snapshot and writes nothing when count-source coverage is zero', async () => {
+    const stale = freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000);
+    const { response, calls } = await runWithRedisStub({
+      'temporal:anomalies:v1': stale,
       // news:insights:v1 and wildfire:fires:v1 deliberately absent
     });
 
-    const stamp = calls.find((c) => c.method === 'POST' && c.key === 'seed-meta:temporal:anomalies');
-    assert.ok(stamp, 'rebuild must still stamp seed-meta');
-    assert.equal(
-      stamp.recordCount, 0,
-      `zero count sources read must stamp recordCount 0, got ${stamp.recordCount}`,
+    assert.deepEqual(response, stale, 'zero coverage must preserve the usable last-good snapshot');
+    assert.deepEqual(
+      calls.filter((c) => c.method === 'POST' && c.key !== 'baseline:lock'),
+      [],
+      'zero coverage must not write baselines, publish an empty snapshot, or stamp seed-meta',
     );
+  });
+
+  it('returns the canonical empty response without publishing when zero coverage has no fallback', async () => {
+    const { response, calls } = await runWithRedisStub({});
+
+    assert.deepEqual(response, { anomalies: [], trackedTypes: [], computedAt: '' });
+    assert.deepEqual(
+      calls.filter((c) => c.method === 'POST' && c.key !== 'baseline:lock'),
+      [],
+      'a cold zero-coverage rebuild must not write baselines, a snapshot, or seed-meta',
+    );
+  });
+
+  it('stamps the partial coverage it ACHIEVED, not the coverage it configured', async () => {
+    const { calls } = await runWithRedisStub({
+      'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+      'news:insights:v1': { topStories: [{ id: 'a' }] },
+      // wildfire:fires:v1 deliberately absent
+    });
+
+    const stamp = calls.find((c) => c.method === 'POST' && c.key === 'seed-meta:temporal:anomalies');
+    assert.equal(stamp?.recordCount, 1, 'one source read must stamp recordCount 1');
   });
 
   it('stamps full coverage when both count sources are present', async () => {
@@ -169,6 +194,83 @@ describe('temporal anomalies cache freshness', () => {
 
     const stamp = calls.find((c) => c.method === 'POST' && c.key === 'seed-meta:temporal:anomalies');
     assert.equal(stamp?.recordCount, 2, 'both sources read must stamp recordCount 2');
+  });
+
+  it('does not stamp seed-meta when snapshot publication fails', async () => {
+    const stale = freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000);
+    const baseline = {
+      mean: 1,
+      m2: 0,
+      sampleCount: 1,
+      lastUpdated: new Date().toISOString(),
+    };
+    const baselineKey = makeBaselineKeyV2(
+      'news',
+      'global',
+      new Date().getUTCDay(),
+      new Date().getUTCMonth() + 1,
+    );
+    const { calls } = await runWithRedisStub(
+      {
+        'temporal:anomalies:v1': stale,
+        'news:insights:v1': { topStories: [{ id: 'a' }] },
+        [baselineKey]: baseline,
+      },
+      { failedPostKeys: ['temporal:anomalies:v1'] },
+    );
+
+    assert.ok(
+      calls.some((c) => c.method === 'POST' && c.key === 'temporal:anomalies:v1'),
+      'the test must exercise a failed snapshot publication',
+    );
+    assert.equal(
+      calls.some((c) => c.method === 'POST' && c.key === 'seed-meta:temporal:anomalies'),
+      false,
+      'seed-meta must describe a published snapshot, never a failed publication',
+    );
+  });
+
+  it('warns with the exact due-baseline failure count while the snapshot still publishes', async () => {
+    const baselineKey = makeBaselineKeyV2(
+      'news',
+      'global',
+      new Date().getUTCDay(),
+      new Date().getUTCMonth() + 1,
+    );
+    const dueBaseline = {
+      mean: 1,
+      m2: 0,
+      sampleCount: 1,
+      lastUpdated: new Date(Date.now() - BASELINE_SAMPLE_INTERVAL_MS - 60_000).toISOString(),
+    };
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => { warnings.push(args); };
+
+    try {
+      const { calls } = await runWithRedisStub(
+        {
+          'news:insights:v1': { topStories: [{ id: 'a' }] },
+          [baselineKey]: dueBaseline,
+        },
+        { failedPostKeys: [baselineKey] },
+      );
+
+      assert.ok(
+        calls.some((c) => c.method === 'POST' && c.key === 'temporal:anomalies:v1'),
+        'a failed baseline write must not prevent snapshot publication',
+      );
+      assert.ok(
+        calls.some((c) => c.method === 'POST' && c.key === 'seed-meta:temporal:anomalies'),
+        'a successfully published snapshot must still stamp seed-meta',
+      );
+      assert.ok(
+        warnings.some(([message]) => message === '[TemporalBaseline] 1/1 baseline writes failed'),
+        `missing exact baseline warning; saw ${JSON.stringify(warnings)}`,
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 
   it('does not fold a new baseline sample when one was taken recently', async () => {


### PR DESCRIPTION
## Summary

Zero-source temporal-anomaly rebuilds now preserve the last-good snapshot instead of replacing it with an empty, freshly stamped result. Cold misses return the canonical empty response without writing Redis, so health continues to report missing producer coverage. Failure-path tests now cover snapshot publication and baseline-write accounting, while the English and Chinese MCP docs state that only producer-route traffic can rebuild the cache.

Related: #7136

## Validation

- Normal pre-push gate passed, including browser and API typechecks, boundary checks, server tests, changed tests, Edge tests, and Markdown/MDX lint.
- Temporal-anomalies cache suite: 14 passed, 0 failed.
- MCP, health, and docs suites: 43 passed, 0 failed.
- The broad data suite completed 26,187 tests with no assertion failures; its command exited nonzero only because the clean worktree lacked the ignored `public/pro/assets` build output. The missing-artifact failure reproduced alone and did not affect the changed suite.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
