### PR TITLE
test(pro): dist-gate the Sentry chunk split contract like its siblings

### DIFF
--- a/tests/pro-sentry-chunk.test.mjs
+++ b/tests/pro-sentry-chunk.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { guardProBuiltOutput, shouldSkipProBuiltOutput } from './_lib/pro-built-output.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PRO_DIR = resolve(__dirname, '..', 'public', 'pro');
@@ -31,7 +32,8 @@ function entryChunksFor(html) {
     .filter((name) => !/^sentry-/.test(name));
 }
 
-describe('pro Sentry chunk split contract (#5019)', () => {
+describe('pro Sentry chunk split contract (#5019)', { skip: shouldSkipProBuiltOutput() }, () => {
+  guardProBuiltOutput();
   const sentryChunks = readdirSync(ASSETS_DIR).filter((f) => /^sentry-[A-Za-z0-9_-]+\.js$/.test(f));
   const indexHtml = readFileSync(resolve(PRO_DIR, 'index.html'), 'utf8');
   const welcomeHtml = readFileSync(resolve(PRO_DIR, 'welcome.html'), 'utf8');


### PR DESCRIPTION
Fixes #7143.

tests/pro-sentry-chunk.test.mjs read \public/pro/assets\ at \describe()\ construction time, before any test could even run. \public/pro/\ has been gitignored build output since #6898 -- on a clean checkout that hasn't run \
pm run build:pro\, this threw an ENOENT instead of skipping, unlike its sibling built-output suites (pro-critical-css, pro-welcome-prerender, dashboard-eager-chunks, etc.), which all gate on the shared \	ests/_lib/built-output-guard.mjs\ primitive via the /pro-specific \	ests/_lib/pro-built-output.mjs\ wrapper.

Wired in the exact same pattern rather than reinventing it: \describe(..., { skip: shouldSkipProBuiltOutput() }, () => { guardProBuiltOutput(); ... })\.

## Verification (not just inspection)

- On this (unbuilt) checkout, the unfixed file crashes with exactly the reported ENOENT (\scandir '.../public/pro/assets'\).
- The fixed file skips cleanly (0 failures) on the same unbuilt tree.
- \WM_EXPECT_BUILT_OUTPUT=1\ against the same unbuilt tree fails loudly with a descriptive message naming the missing path and the rebuild command, instead of silently skipping -- so CI (which sets this after building /pro) can never mask a broken build as a pass.
- The diff only wraps the existing assertions in the skip guard -- none of the assertion logic changed, so built-tree behavior is unaffected by construction.

## Scope note

Left \	ests/dashboard-build-guards.test.mjs\ unchanged. Its assertions test the shared primitive itself and specific CI-sequencing contracts; I didn't find an existing registry-style hook to attach per-suite coverage to without inventing new structure for it. Happy to revisit if there's a specific extension point in mind.