### PR TITLE
refactor(redis): collapse cachedFetchJson / cachedFetchJsonWithMeta into one implementation

### DIFF
--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -796,69 +796,8 @@ export async function cachedFetchJson<T extends object>(
   negativeTtlSeconds = 120,
   opts?: CachedFetchOpts,
 ): Promise<T | null> {
-  const cached = await readCachedJson(key);
-  if (cached.status === 'hit') {
-    if (cached.value === NEG_SENTINEL) return null;
-    return cached.value as T;
-  }
-  const localPositive = readLocalPositiveFallback(key);
-  if (localPositive !== undefined) return localPositive as T;
-  const hadCacheReadError = cached.status === 'error';
-  if (cached.status === 'error') {
-    logCacheReadError(key, cached.error);
-    if (hasLocalNegativeCooldown(key)) return null;
-  }
-  // Unavailable backoff (cacheFetcherErrors: false path): rethrow without
-  // hitting upstream again until the short isolate-local window expires.
-  if (hasLocalUnavailableBackoff(key)) {
-    throw new Error(`cachedFetchJson unavailable backoff active for "${key}"`);
-  }
-
-  const existing = inflight.get(key);
-  if (existing) return existing as Promise<T | null>;
-
-  const timeoutMs = opts?.timeoutMs ?? fetcherTimeoutDefaultMs;
-  const promise = withFetcherTimeout(fetcher(), key, timeoutMs, 'cachedFetchJson')
-    .then(async (result) => {
-      if (result != null) {
-        const noStoreReason = getRpcNoStoreReasonFromPayload(result, { includeAvailableFalse: false });
-        if (noStoreReason) {
-          armLocalNegativeCooldown(key, negativeTtlSeconds);
-          await setCachedJson(key, NEG_SENTINEL, negativeTtlSeconds);
-        } else {
-          const wrote = await setCachedJson(key, result, ttlSeconds);
-          // Remote Redis write/read failures should not force every caller back
-          // upstream while the isolate is still warm. Sidecar/local mode skips
-          // this bridge because hasRemoteRedisConfig() is false there.
-          if (hadCacheReadError || (!wrote && hasRemoteRedisConfig())) {
-            armLocalPositiveFallback(key, result, ttlSeconds);
-          }
-        }
-      } else {
-        armLocalNegativeCooldown(key, negativeTtlSeconds);
-        await setCachedJson(key, NEG_SENTINEL, negativeTtlSeconds);
-      }
-      return result;
-    })
-    .catch(async (err: unknown) => {
-      if (opts?.cacheFetcherErrors !== false) {
-        const errorTtlSeconds = effectiveFetchErrorNegativeTtlSeconds(negativeTtlSeconds);
-        armLocalNegativeCooldown(key, errorTtlSeconds);
-        await setCachedJson(key, NEG_SENTINEL, errorTtlSeconds);
-        console.warn(`[redis] cachedFetchJson fetcher failed for "${key}":`, errMsg(err));
-      } else {
-        // No Redis NEG_SENTINEL — keep definitive-invalid distinct — but still
-        // rate-limit retries with a short local-only unavailable backoff.
-        armLocalUnavailableBackoff(key, FETCH_ERROR_UNAVAILABLE_BACKOFF_SECONDS);
-      }
-      throw err;
-    })
-    .finally(() => {
-      inflight.delete(key);
-    });
-
-  inflight.set(key, promise);
-  return promise;
+  const result = await cachedFetchJsonCore(key, ttlSeconds, fetcher, negativeTtlSeconds, opts, 'cachedFetchJson');
+  return result.data;
 }
 
 /**
@@ -927,6 +866,25 @@ export async function cachedFetchJsonWithMeta<T extends object>(
   negativeTtlSeconds = 120,
   opts?: CachedFetchWithMetaOpts,
 ): Promise<{ data: T | null; source: 'cache' | 'fresh' | 'skipped'; leader: boolean }> {
+  return cachedFetchJsonCore(key, ttlSeconds, fetcher, negativeTtlSeconds, opts, 'cachedFetchJsonWithMeta');
+}
+
+// Shared implementation behind cachedFetchJson / cachedFetchJsonWithMeta.
+// cachedFetchJson is the WithMeta behavior with every WithMeta-only opt left
+// at its default (no inflightKey override, no shouldFetch gate, no
+// per-fetch usage telemetry, cacheFailures/isCallerLocalError unset) and
+// { data, source, leader } narrowed down to plain `data`. `callerName`
+// keeps the timeout/backoff/log messages attributed to whichever public
+// entry point the caller actually used, matching withFetcherTimeout's
+// existing per-caller message convention.
+async function cachedFetchJsonCore<T extends object>(
+  key: string,
+  ttlSeconds: number,
+  fetcher: () => Promise<T | null>,
+  negativeTtlSeconds: number,
+  opts: CachedFetchWithMetaOpts | undefined,
+  callerName: 'cachedFetchJson' | 'cachedFetchJsonWithMeta',
+): Promise<{ data: T | null; source: 'cache' | 'fresh' | 'skipped'; leader: boolean }> {
   const cached = await readCachedJson(key);
   if (cached.status === 'hit') {
     if (cached.value === NEG_SENTINEL) return { data: null, source: 'cache', leader: false };
@@ -940,7 +898,7 @@ export async function cachedFetchJsonWithMeta<T extends object>(
     if (hasLocalNegativeCooldown(key)) return { data: null, source: 'cache', leader: false };
   }
   if (hasLocalUnavailableBackoff(key)) {
-    throw new Error(`cachedFetchJsonWithMeta unavailable backoff active for "${key}"`);
+    throw new Error(`${callerName} unavailable backoff active for "${key}"`);
   }
 
   const inflightKey = opts?.inflightKey ?? key;
@@ -969,7 +927,7 @@ export async function cachedFetchJsonWithMeta<T extends object>(
   let cacheStatus: 'miss' | 'neg-sentinel' = 'miss';
 
   const timeoutMs = opts?.timeoutMs ?? fetcherTimeoutDefaultMs;
-  const promise = withFetcherTimeout(fetcher(), key, timeoutMs, 'cachedFetchJsonWithMeta')
+  const promise = withFetcherTimeout(fetcher(), key, timeoutMs, callerName)
     .then(async (result) => {
       // Only count an upstream call as a 200 when it actually returned data.
       // A null result triggers the neg-sentinel branch below — these are
@@ -1017,7 +975,7 @@ export async function cachedFetchJsonWithMeta<T extends object>(
         const errorTtlSeconds = effectiveFetchErrorNegativeTtlSeconds(negativeTtlSeconds);
         armLocalNegativeCooldown(key, errorTtlSeconds);
         await setCachedJson(key, NEG_SENTINEL, errorTtlSeconds);
-        console.warn(`[redis] cachedFetchJsonWithMeta fetcher failed for "${key}":`, errMsg(err));
+        console.warn(`[redis] ${callerName} fetcher failed for "${key}":`, errMsg(err));
       } else {
         armLocalUnavailableBackoff(key, FETCH_ERROR_UNAVAILABLE_BACKOFF_SECONDS);
       }

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -796,7 +796,15 @@ export async function cachedFetchJson<T extends object>(
   negativeTtlSeconds = 120,
   opts?: CachedFetchOpts,
 ): Promise<T | null> {
-  const result = await cachedFetchJsonCore(key, ttlSeconds, fetcher, negativeTtlSeconds, opts, 'cachedFetchJson');
+  // Rebuild the public option shape so structurally assignable objects cannot
+  // leak cachedFetchJsonWithMeta-only fields into the shared implementation.
+  const coreOpts = opts === undefined
+    ? undefined
+    : {
+        timeoutMs: opts.timeoutMs,
+        cacheFetcherErrors: opts.cacheFetcherErrors,
+      };
+  const result = await cachedFetchJsonCore(key, ttlSeconds, fetcher, negativeTtlSeconds, coreOpts, 'cachedFetchJson');
   return result.data;
 }
 

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -819,6 +819,203 @@ describe('negative-result caching', { concurrency: 1 }, () => {
     }
   });
 
+  it('cachedFetchJson ignores WithMeta-only fields on a superset options object', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      USAGE_TELEMETRY: undefined,
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const originalWarn = console.warn;
+
+    const writes = [];
+    const warnings = [];
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) return jsonResponse({ result: undefined });
+      if (isSetRequest(url, init)) {
+        writes.push(parseSetRequest(url, init));
+        return jsonResponse({ result: 'OK' });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+    console.warn = (...args) => { warnings.push(args); };
+
+    let shouldFetchCalls = 0;
+    let callerLocalChecks = 0;
+    let usageWaits = 0;
+    const supersetOpts = {
+      timeoutMs: 500,
+      cacheFetcherErrors: true,
+      shouldFetch: () => {
+        shouldFetchCalls += 1;
+        return true;
+      },
+      cacheFailures: false,
+      inflightKey: 'plain:test:shared-inflight-key',
+      isCallerLocalError: () => {
+        callerLocalChecks += 1;
+        return true;
+      },
+      usage: {
+        provider: 'plain-helper-regression',
+        ctx: {
+          waitUntil() {
+            usageWaits += 1;
+          },
+        },
+      },
+    };
+
+    try {
+      let releaseFetchers;
+      const fetcherGate = new Promise((resolvePromise) => {
+        releaseFetchers = resolvePromise;
+      });
+      const first = redis.cachedFetchJson(
+        'plain:test:first',
+        300,
+        async () => {
+          await fetcherGate;
+          return { value: 'first' };
+        },
+        60,
+        supersetOpts,
+      );
+      const second = redis.cachedFetchJson(
+        'plain:test:second',
+        300,
+        async () => {
+          await fetcherGate;
+          return { value: 'second' };
+        },
+        60,
+        supersetOpts,
+      );
+
+      await new Promise((resolvePromise) => setImmediate(resolvePromise));
+      releaseFetchers();
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+
+      assert.deepEqual(firstResult, { value: 'first' });
+      assert.deepEqual(
+        secondResult,
+        { value: 'second' },
+        'plain calls with distinct keys must not share a WithMeta inflightKey',
+      );
+
+      const nullResult = await redis.cachedFetchJson(
+        'plain:test:null',
+        300,
+        async () => null,
+        60,
+        supersetOpts,
+      );
+      assert.equal(nullResult, null);
+
+      const rejection = new Error('plain superset rejection');
+      await assert.rejects(
+        () => redis.cachedFetchJson(
+          'plain:test:rejection',
+          300,
+          async () => {
+            throw rejection;
+          },
+          60,
+          supersetOpts,
+        ),
+        (error) => {
+          assert.strictEqual(error, rejection, 'plain helper must propagate the original fetcher error');
+          return true;
+        },
+      );
+
+      const writesByKey = new Map(writes.map((write) => [write.key, write]));
+      const nullWrite = writesByKey.get('plain:test:null');
+      const rejectionWrite = writesByKey.get('plain:test:rejection');
+      assert.ok(nullWrite, 'plain null results must keep legacy negative caching');
+      assert.ok(rejectionWrite, 'plain fetcher errors must keep legacy negative caching');
+      assert.equal(JSON.parse(nullWrite.value), '__WM_NEG__');
+      assert.equal(JSON.parse(rejectionWrite.value), '__WM_NEG__');
+      assert.equal(shouldFetchCalls, 0, 'plain helper must not evaluate WithMeta shouldFetch');
+      assert.equal(callerLocalChecks, 0, 'plain helper must not evaluate WithMeta isCallerLocalError');
+      assert.equal(usageWaits, 0, 'plain helper must not emit WithMeta usage telemetry');
+      assert.deepEqual(warnings, [[
+        '[redis] cachedFetchJson fetcher failed for "plain:test:rejection":',
+        'plain superset rejection',
+      ]]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      console.warn = originalWarn;
+      restoreEnv();
+    }
+  });
+
+  it('keeps rejected-fetcher warnings attributed to each public cache helper', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const originalWarn = console.warn;
+    const warnings = [];
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) return jsonResponse({ result: undefined });
+      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+    console.warn = (...args) => { warnings.push(args); };
+
+    try {
+      const plainError = new Error('plain helper rejected');
+      await assert.rejects(
+        () => redis.cachedFetchJson(
+          'warn:test:plain',
+          300,
+          async () => {
+            throw plainError;
+          },
+        ),
+        (error) => {
+          assert.strictEqual(error, plainError);
+          return true;
+        },
+      );
+
+      const metaError = new Error('meta helper rejected');
+      await assert.rejects(
+        () => redis.cachedFetchJsonWithMeta(
+          'warn:test:meta',
+          300,
+          async () => {
+            throw metaError;
+          },
+        ),
+        (error) => {
+          assert.strictEqual(error, metaError);
+          return true;
+        },
+      );
+
+      assert.deepEqual(warnings, [
+        ['[redis] cachedFetchJson fetcher failed for "warn:test:plain":', 'plain helper rejected'],
+        ['[redis] cachedFetchJsonWithMeta fetcher failed for "warn:test:meta":', 'meta helper rejected'],
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      console.warn = originalWarn;
+      restoreEnv();
+    }
+  });
+
   it('retries fetcher errors when error negative caching is disabled', async () => {
     const redis = await importRedisFresh();
     const restoreEnv = withEnv({


### PR DESCRIPTION
Fixes #7128.

## What

`cachedFetchJson` and `cachedFetchJsonWithMeta` had near-duplicated bodies: cache read, local-positive/negative fallback checks, unavailable-backoff gate, inflight coalescing, `withFetcherTimeout` call, then/catch handling for `setCachedJson` + negative-sentinel writes. `cachedFetchJsonWithMeta` is a strict superset (`inflightKey` override, `shouldFetch` gate, usage telemetry, `cacheFailures`/`isCallerLocalError`) of what `cachedFetchJson` does with everything at its default.

Extracted the WithMeta body into a private `cachedFetchJsonCore(..., callerName)` and made both public functions thin wrappers around it:
- `cachedFetchJson` calls it with every WithMeta-only opt left unset and returns just `.data`.
- `cachedFetchJsonWithMeta` passes its opts through unchanged.

`callerName` keeps the timeout/backoff/log messages attributed to whichever entry point the caller actually used, mirroring `withFetcherTimeout`'s existing per-caller message convention (it already took a `callerName: 'cachedFetchJson' | 'cachedFetchJsonWithMeta'` param before this change) rather than introducing a new pattern.

No call-site changes — both exported names, signatures, and return shapes are unchanged, matching the acceptance criteria.

## Verification

Not just written-and-assumed-correct:

- `tsc --noEmit` clean.
- The existing `tests/redis-caching.test.mjs` suite (4135 lines, the closest thing this codebase has to the "characterization tests" the issue calls for) passes unchanged: 78/78, including a test that asserts the literal `[redis] cachedFetchJson fetcher failed for "..."` log line — direct proof the per-caller message attribution survived the merge, not just the return values.
- Ran every other test file that exercises these two functions (`aviation-cache-ttl-poll-resonance`, `enrichment-caching`, `market-quotes-seed-first`, `news-digest-methodology-parity`, `news-digest-timeout-budget`, `news-rss-pubdate-required`, `resilience-ranking`, `search-flight-prices-fail-closed`, `mcp-api-parity`): 245 tests total across all of them, 0 failures.
- **Negative control**: temporarily mislabeled both wrappers' `callerName` argument to the wrong function name and reran `redis-caching.test.mjs` — it caught the mistake immediately and precisely (asserted timeout message mismatch: expected `"cachedFetchJson timeout after 50ms..."`, got `"cachedFetchJsonWithMeta timeout after 50ms..."`), confirming the suite has real teeth for exactly the highest-risk part of this refactor (message byte-identity), not just superficial pass-through. Reverted the mislabel before committing.

Net diff: -42 lines (66 deleted, 24 inserted).
