### PR TITLE
fix(widget): sandbox trusts localhost referrer regardless of its own origin

### DIFF
--- a/public/wm-widget-sandbox.html
+++ b/public/wm-widget-sandbox.html
@@ -37,7 +37,16 @@
       var url = new URL(origin);
       var isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
       if ((url.protocol === 'http:' || url.protocol === 'https:') && isLocalhost) {
-        return true;
+        // This file ships byte-for-byte to production via public/ (no build
+        // step, no dev/prod flag available at request time), so a bare
+        // localhost-referrer check would let anyone running their own local
+        // HTTP server embed the production sandbox and receive widget HTML.
+        // Require the sandbox's OWN window.location to also be localhost --
+        // an attacker's page can set document.referrer freely, but cannot
+        // make worldmonitor.app's real production deployment of this exact
+        // file report its own origin as localhost.
+        var selfHostname = window.location.hostname;
+        return selfHostname === 'localhost' || selfHostname === '127.0.0.1';
       }
       if (url.protocol !== 'https:') {
         return false;

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1454,6 +1454,98 @@ describe('PRO widget — store and sanitizer', () => {
     assert.deepEqual(spoofed.writes, []);
   });
 
+  it('widget sandbox trusts a localhost referrer only when the sandbox itself is also running on localhost', () => {
+    // This file (public/wm-widget-sandbox.html) ships byte-for-byte to
+    // production -- there is no build-time dev/prod flag available inside
+    // it. Anyone can run their own local HTTP server and set
+    // document.referrer to http://localhost freely, so trusting that
+    // referrer alone would let such a page embed the PRODUCTION sandbox
+    // and receive real widget HTML. The fix requires window.location
+    // (the sandbox's own, unspoofable origin) to also be localhost.
+    const script = sandbox.match(/<script>\r?\n([\s\S]*?)\r?\n<\/script>/)?.[1];
+    assert.ok(script, 'sandbox inline script not found');
+
+    function runSandboxAt(selfHostname, referrer) {
+      const readyMessages = [];
+      const writes = [];
+      const listeners = new Map();
+      const parent = {
+        postMessage(payload, targetOrigin) {
+          readyMessages.push({ payload, targetOrigin });
+        },
+      };
+      function FakeEventTarget() {}
+      FakeEventTarget.prototype.addEventListener = (type, listener) => {
+        listeners.set(type, listener);
+      };
+      function FakeEvent() {}
+      FakeEvent.prototype.stopImmediatePropagation = () => {};
+      const sandboxWindow = new FakeEventTarget();
+      sandboxWindow.location = { hash: '#id=wm-1&token=test-token', hostname: selfHostname };
+      sandboxWindow.parent = parent;
+      const context = {
+        URL,
+        URLSearchParams,
+        Event: FakeEvent,
+        EventTarget: FakeEventTarget,
+        document: {
+          referrer,
+          open() {},
+          write(html) {
+            writes.push(html);
+          },
+          close() {},
+        },
+        window: sandboxWindow,
+      };
+      vm.runInNewContext(script, context);
+      const message = listeners.get('message');
+      assert.equal(typeof message, 'function', 'message listener must be registered');
+      return { parent, readyMessages, writes, message };
+    }
+
+    // Production sandbox (window.location.hostname === worldmonitor.app)
+    // embedded by a page whose referrer claims http://localhost: must be
+    // rejected outright, both for the initial readiness ping and for a
+    // forged wm-html delivery attempt.
+    const prodAgainstLocalhostReferrer = runSandboxAt('worldmonitor.app', 'http://localhost:5173/dashboard');
+    assert.deepEqual(
+      prodAgainstLocalhostReferrer.readyMessages,
+      [],
+      'production sandbox must not send the readiness ping to a localhost-claiming referrer',
+    );
+    prodAgainstLocalhostReferrer.message({
+      data: { type: 'wm-html', id: 'wm-1', token: 'test-token', html: '<p>should not render</p>' },
+      origin: 'http://localhost:5173',
+      source: prodAgainstLocalhostReferrer.parent,
+    });
+    assert.deepEqual(
+      prodAgainstLocalhostReferrer.writes,
+      [],
+      'production sandbox must not accept HTML claiming to come from localhost',
+    );
+
+    // Same check for 127.0.0.1.
+    const prodAgainst127Referrer = runSandboxAt('worldmonitor.app', 'http://127.0.0.1:5173/dashboard');
+    assert.deepEqual(prodAgainst127Referrer.readyMessages, []);
+
+    // Legitimate local dev: both the sandbox page itself and the embedding
+    // page run on localhost (e.g. `npm run dev`). This must keep working.
+    const devSandbox = runSandboxAt('localhost', 'http://localhost:5173/dashboard');
+    assert.equal(devSandbox.readyMessages.length, 1, 'dev sandbox on localhost must still trust a localhost parent');
+    assert.equal(devSandbox.readyMessages[0].targetOrigin, 'http://localhost:5173');
+    devSandbox.message({
+      data: { type: 'wm-html', id: 'wm-1', token: 'test-token', html: '<p>dev ok</p>' },
+      origin: 'http://localhost:5173',
+      source: devSandbox.parent,
+    });
+    assert.deepEqual(devSandbox.writes, ['<p>dev ok</p>']);
+
+    // 127.0.0.1 sandbox self-origin (some dev setups bind there instead).
+    const dev127Sandbox = runSandboxAt('127.0.0.1', 'http://127.0.0.1:5173/dashboard');
+    assert.equal(dev127Sandbox.readyMessages.length, 1, '127.0.0.1 dev sandbox must trust a 127.0.0.1 parent');
+  });
+
   it('widget sandbox blocks beforeunload without breaking normal events before widget execution', () => {
     const script = sandbox.match(/<script>\r?\n([\s\S]*?)\r?\n<\/script>/)?.[1];
     assert.ok(script, 'sandbox inline script not found');


### PR DESCRIPTION
Fixes #7055.

## What

`public/wm-widget-sandbox.html`'s `isAllowedParentOrigin()` unconditionally trusted any `http://localhost` or `http://127.0.0.1` parent origin, with no gating on whether the sandbox is actually running in a dev environment. Since this file ships byte-for-byte to production via `public/` (no bundler processing, no build-time dev/prod flag available inside it), anyone running their own local HTTP server could set `document.referrer` to `http://localhost:*`, embed the **production** sandbox, and receive real PRO widget HTML over `postMessage`.

## Fix

Gated the localhost/127.0.0.1 referrer trust on the sandbox's own `window.location.hostname` also being localhost/127.0.0.1. An attacker's page can set `document.referrer` freely, but it cannot make `worldmonitor.app`'s real production deployment of this exact static file report its own `window.location` as localhost -- so the production loophole closes while local dev (where both the sandbox iframe and the embedding page genuinely run on `localhost`) keeps working unchanged.

## Scope note -- the other two files named in the issue

The issue also flagged `postMessage(data, '*')` in `src/utils/widget-sanitizer.ts:154` and the `parentOrigin || '*'` fallback in `src/embed/embed-credential.ts:57`. Neither needed a change:

- `widget-sanitizer.ts:154`: the target iframe uses `sandbox="allow-scripts"` **without** `allow-same-origin` (confirmed at `widget-sanitizer.ts:205`), so its origin is opaque -- there is no concrete origin a parent could target even if it wanted to. `'*'` is the only deliverable target here (this is already explained in a comment directly above the call). Security for this direction is enforced sandbox-side, by the `isAllowedParentOrigin` check this PR fixes, plus the per-widget id/token match.
- `embed-credential.ts:57`: the `'*'`-eligible message is only the outbound `{source, type: 'ready'}` handshake ping, which carries no secret. The actual credential intake (`onMessage`) already validates both `event.source === host.parent` and `event.origin === parentOrigin` (when a parent origin is resolvable) before accepting a key.

Narrowing the fix to the one file with a real gap, rather than changing the other two's already-reasoned wildcard usage, seemed like the right scope.

## How did you test this code?

Added a new test (`tests/widget-builder.test.mjs`, "widget sandbox trusts a localhost referrer only when the sandbox itself is also running on localhost") that runs the actual sandbox script via `vm.runInNewContext`, reusing the existing `runSandbox`-style harness already in this file:
- production `window.location.hostname` (`worldmonitor.app`) + a `http://localhost` / `http://127.0.0.1` referrer: readiness ping is now withheld and a forged `wm-html` delivery is rejected (previously both succeeded -- verified as a negative control: this exact assertion fails on the unfixed source, confirming the test catches the real gap).
- dev `window.location.hostname` (`localhost` / `127.0.0.1`) + a matching localhost referrer: unchanged, still trusted, so local dev isn't broken.

Ran the full `tests/widget-builder.test.mjs` file (215/215 passing) and the full `node --test` suite across `tests/*.test.mjs` / `tests/*.test.mts` for regressions.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (Anthropic), operating unsupervised on an open-ended "find and fix issues" session against the repo owner's fork. No human directed this specific fix.
- Skills invoked: none.
- The issue's own suggested diff for this file (`import.meta.env.DEV`) doesn't apply here -- `public/` files are copied verbatim by Vite, not processed, so there's no build-time env substitution available inside this specific static HTML file. Traced through the actual data flow (referrer validation in the sandbox, the opaque-origin iframe in `widget-sanitizer.ts`, the credential handshake in `embed-credential.ts`) to find that only one of the three flagged files had a real, fixable gap, and that the fix needed a different mechanism (the sandbox's own origin, not a dev flag) than what the issue proposed.
- No customer data, tickets, or internal information was used; all reasoning is from public repository source and the public linked issue.
