### PR TITLE
fix(sanctions): read SEMA's renamed bilingual field tags

### DIFF
--- a/scripts/_sema-sanctions.mjs
+++ b/scripts/_sema-sanctions.mjs
@@ -23,13 +23,53 @@ export const SANCTIONS_MAX_CONTENT_AGE_MIN = 30 * DAY_MIN;
 
 const CLOCK_SKEW_MS = 60 * 60 * 1000;
 
-function xmlText(block, tag) {
-  const match = String(block).match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, 'i'));
-  if (!match) return '';
-  return decodeHtmlEntities(match[1])
-    .replace(/\u00a0/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
+// Global Affairs Canada renamed every field tag to a bilingual hyphenated form
+// (2026-08): `<Country>` became `<Country-Pays>`, `<Schedule>` became
+// `<Schedule-Annexe>`, and so on. `<record>` itself was untouched, so the block
+// scan kept finding all 5,690 entries while every field read empty — each record
+// then failed the `legalName` check and was dropped, producing SEMA_EMPTY on
+// every run with Canada contributing 0 of 20,558 merged entries.
+//
+// Candidates are listed rather than derived. Two of the renames are not a
+// mechanical suffix: `TitleOrShip` became `TitleOrShipType-...`, so the ENGLISH
+// half changed too, and a prefix rule that stretched far enough to cover it
+// would also let `<Item>` match an unrelated `<ItemNote>`. The old names are
+// kept first: an upstream rename can be reverted or served inconsistently, and
+// dropping them would trade this outage for its mirror image.
+const SEMA_FIELD_TAGS = Object.freeze({
+  Country:       Object.freeze(['Country', 'Country-Pays']),
+  LastName:      Object.freeze(['LastName', 'LastName-NomDeFamille']),
+  GivenName:     Object.freeze(['GivenName', 'GivenName-Prenom']),
+  EntityOrShip:  Object.freeze(['EntityOrShip', 'EntityOrShip-EntiteOuNavire']),
+  ShipIMONumber: Object.freeze(['ShipIMONumber', 'ShipIMONumber-NumeroOMIDuNavire']),
+  Aliases:       Object.freeze(['Aliases', 'Aliases-Alias']),
+  Item:          Object.freeze(['Item', 'Item-NumeroDarticle']),
+  DateOfListing: Object.freeze(['DateOfListing', 'DateOfListing-DateDinscription']),
+  Schedule:      Object.freeze(['Schedule', 'Schedule-Annexe']),
+  TitleOrShip:   Object.freeze(['TitleOrShip', 'TitleOrShipType-TitreOuTypeDeNavire']),
+});
+
+/**
+ * Read a field by its logical name, trying each spelling the feed has used.
+ *
+ * `<Country>` cannot match inside `<Country-Pays>` — the regex requires the
+ * closing angle bracket immediately after the name — so the candidates cannot
+ * shadow one another and order only decides which wins when a block somehow
+ * carries both.
+ */
+function xmlText(block, field) {
+  const candidates = SEMA_FIELD_TAGS[field] || [field];
+  const text = String(block);
+  for (const tag of candidates) {
+    const match = text.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, 'i'));
+    if (!match) continue;
+    const value = decodeHtmlEntities(match[1])
+      .replace(/\u00a0/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (value) return value;
+  }
+  return '';
 }
 
 function uniqueSorted(values) {

--- a/tests/sema-sanctions.test.mjs
+++ b/tests/sema-sanctions.test.mjs
@@ -59,6 +59,85 @@ const serviceSrc = readFileSync(
   'utf8',
 );
 
+// Global Affairs Canada renamed every SEMA field tag to a bilingual hyphenated
+// form. `<record>` still matches, so parseSemaXml finds 5,690 blocks and returns
+// ZERO records — every field reads empty, legalName is blank, and every block is
+// dropped. Production reported `SEMA fetch failed: SEMA_EMPTY` on every 6-hourly
+// run while OFAC carried the whole list (0 of 20,558 entries from Canada).
+//
+// Every other fixture in this file uses the OLD tags, which is why the suite
+// stayed green while the live parse was dead. These blocks are copied verbatim
+// from the live feed on 2026-08-25.
+const SEMA_BILINGUAL_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<data-set xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<record>
+		<Country-Pays>Belarus / Bélarus</Country-Pays>
+		<LastName-NomDeFamille>Atabekov</LastName-NomDeFamille>
+		<GivenName-Prenom>Khazalbek Bakhtibekovich</GivenName-Prenom>
+		<Schedule-Annexe>1, Part 1</Schedule-Annexe>
+		<Item-NumeroDarticle>1</Item-NumeroDarticle>
+		<DateOfListing-DateDinscription>2020-09-28</DateOfListing-DateDinscription>
+	</record>
+	<record>
+		<Country-Pays>Russia / Russie</Country-Pays>
+		<EntityOrShip-EntiteOuNavire>Balitiyskiy III</EntityOrShip-EntiteOuNavire>
+		<TitleOrShipType-TitreOuTypeDeNavire>General Cargo/Multi Purpose | Cargo classique/navire polyvalent</TitleOrShipType-TitreOuTypeDeNavire>
+		<ShipIMONumber-NumeroOMIDuNavire>7612448</ShipIMONumber-NumeroOMIDuNavire>
+		<Schedule-Annexe>1.1</Schedule-Annexe>
+		<Item-NumeroDarticle>1</Item-NumeroDarticle>
+		<DateOfListing-DateDinscription>2025-02-21</DateOfListing-DateDinscription>
+	</record>
+	<record>
+		<Country-Pays>Belarus / Bélarus</Country-Pays>
+		<EntityOrShip-EntiteOuNavire>Belaeronavigatsia Republican Unitary Air Navigation Services Enterprise</EntityOrShip-EntiteOuNavire>
+		<Schedule-Annexe>1, Part 2</Schedule-Annexe>
+		<Item-NumeroDarticle>1</Item-NumeroDarticle>
+		<DateOfListing-DateDinscription>2021-06-17</DateOfListing-DateDinscription>
+	</record>
+</data-set>`;
+
+describe('SEMA bilingual field tags (Global Affairs Canada 2026-08 rename)', () => {
+  it('parses records whose fields carry the hyphenated bilingual tag names', () => {
+    const { records } = parseSemaXml(SEMA_BILINGUAL_XML);
+    assert.equal(records.length, 3, 'every block must yield a record, not be dropped for a blank name');
+  });
+
+  it('reads each renamed field, not just enough of them to survive', () => {
+    // A fix that only mapped Country/LastName/GivenName would satisfy the count
+    // assertion above while silently dropping schedule, listing date and IMO.
+    const { records } = parseSemaXml(SEMA_BILINGUAL_XML);
+    const byName = new Map(records.map((r) => [r.name, r]));
+
+    const person = byName.get('Khazalbek Bakhtibekovich Atabekov');
+    assert.ok(person, 'GivenName-Prenom + LastName-NomDeFamille compose the legal name');
+    assert.equal(person.entityType, 'SANCTIONS_ENTITY_TYPE_INDIVIDUAL');
+    assert.match(person.note, /Schedule 1, Part 1/, 'Schedule-Annexe must be read');
+    assert.notEqual(person.effectiveAt, '0', 'DateOfListing-DateDinscription must be read');
+
+    const vessel = byName.get('Balitiyskiy III');
+    assert.ok(vessel, 'EntityOrShip-EntiteOuNavire must be read');
+    assert.equal(vessel.entityType, 'SANCTIONS_ENTITY_TYPE_VESSEL',
+      'ShipIMONumber-NumeroOMIDuNavire must be read, or a vessel is typed as an entity');
+    assert.ok(vessel._identifiers.includes('imo:7612448'));
+    assert.match(vessel.note, /General Cargo/, 'TitleOrShipType-TitreOuTypeDeNavire must be read');
+
+    const entity = byName.get('Belaeronavigatsia Republican Unitary Air Navigation Services Enterprise');
+    assert.ok(entity, 'an entity with no IMO and no person name must still parse');
+    assert.equal(entity.entityType, 'SANCTIONS_ENTITY_TYPE_ENTITY');
+  });
+
+  it('still parses the pre-rename tags', () => {
+    // The rename is upstream and could be reverted or served inconsistently;
+    // dropping the old names would trade one outage for another.
+    const legacy = '<record><Country>Belarus / Bélarus</Country><LastName>One</LastName>'
+      + '<GivenName>Person</GivenName><Schedule>1, Part 1</Schedule><Item>1</Item>'
+      + '<DateOfListing>2021-06-17</DateOfListing></record>';
+    const { records } = parseSemaXml(legacy);
+    assert.equal(records.length, 1);
+    assert.equal(records[0].name, 'Person One');
+  });
+});
+
 describe('SEMA fixture parse', () => {
   it('maps individuals, entities, ships, aliases, IMO, and publication dates', () => {
     const { records, publishedAtMs } = parseSemaXml(fixtureXml);


### PR DESCRIPTION
Fixes the `sanctionsPressure` SEED_ERROR.

Global Affairs Canada renamed **every** SEMA field tag to a bilingual hyphenated form. `<record>` itself was untouched, so the block scan kept finding all 5,690 entries while every *field* read empty — each record then failed the `legalName` check and was dropped:

```
SEMA fetch failed: SEMA_EMPTY
Merged: 20558 total (19500 SDN + 1058 consolidated + 0 SEMA)
```

Canada contributed **0 of 20,558** merged entries on every 6-hourly run.

## Transport was ruled out first

The live URL answers **HTTP 200 with 2.88 MB in ~15s**, against a 45s `SEMA_TIMEOUT_MS` and an 8 MB `SEMA_MAX_BYTES`. Neither guard fired; the fetch was always fine and the parse was always empty.

## What changed upstream

```
<Country>        ->  <Country-Pays>
<LastName>       ->  <LastName-NomDeFamille>
<GivenName>      ->  <GivenName-Prenom>
<EntityOrShip>   ->  <EntityOrShip-EntiteOuNavire>
<ShipIMONumber>  ->  <ShipIMONumber-NumeroOMIDuNavire>
<Aliases>        ->  <Aliases-Alias>
<Item>           ->  <Item-NumeroDarticle>
<DateOfListing>  ->  <DateOfListing-DateDinscription>
<Schedule>       ->  <Schedule-Annexe>
<TitleOrShip>    ->  <TitleOrShipType-TitreOuTypeDeNavire>
```

`xmlText` now resolves a logical field name against the spellings the feed has used.

**Candidates are listed, not derived.** Two renames are not a mechanical suffix — `TitleOrShip` became `TitleOrShip**Type**-…`, so the English half changed too — and a prefix rule loose enough to catch that would also let `<Item>` match an unrelated `<ItemNote>`. `<Country>` cannot match inside `<Country-Pays>` because the regex demands the closing bracket immediately after the name, so candidates cannot shadow each other.

**The old names are kept, first in the list.** An upstream rename can be reverted or served inconsistently across mirrors; dropping them would trade this outage for its mirror image.

## Why CI never caught it

Every existing fixture in `tests/sema-sanctions.test.mjs` uses the pre-rename tags, so the suite stayed green while the live parse returned nothing. The new fixtures are copied **verbatim from the live feed** — an individual, a vessel and an entity — and fail without this change.

## Verified end to end against the live feed

Not just the fixtures — the real 2.88 MB document:

| | parsed | raw tags in XML |
|---|---|---|
| records | **5,690** (was 0) | 5,690 `<record>` |
| with IMO | 731 | 731 `<ShipIMONumber-…>` |
| with Schedule | 5,361 | 5,361 `<Schedule-Annexe>` |

3,514 individual / 1,445 entity / 731 vessel. Newest listing 2026-08-13, oldest 2008-09-04.

The per-field counts matching the raw tag counts is the part that matters: it shows every field is read, not merely enough to clear the name check. One test asserts exactly that, because a fix mapping only Country/LastName/GivenName would satisfy a record count while silently losing schedule, listing date and IMO.

**99 tests pass, 0 fail** across sema, sanctions-pressure, sanctions-seed-unit, sanctions-source-recovery and lookup-entity-cache. Biome clean — the two warnings in the test file are pre-existing at lines 542/820, outside the added hunk.
