### PR TITLE
test(rpc): cover lazy client shim edge cases and getRpcErrorStatusCode

### DIFF
--- a/tests/generated-rpc-clients.test.mts
+++ b/tests/generated-rpc-clients.test.mts
@@ -99,7 +99,7 @@ test('lazy generated RPC client memoizes in-flight constructor load', async () =
   assert.equal(loadCalls, 1);
 });
 
-test('lazy generated RPC client is not treated as a thenable', async () => {
+test('lazy generated RPC client is not treated as a thenable', { timeout: 1_000 }, async () => {
   class TestClient {
     async ping(): Promise<string> {
       return 'pong';
@@ -108,6 +108,8 @@ test('lazy generated RPC client is not treated as a thenable', async () => {
 
   const LazyTestClient = createLazyRpcClientConstructor<TestClient>(async () => TestClient);
   const client = new LazyTestClient('https://example.test');
+
+  assert.equal(Reflect.get(client, 'then'), undefined);
 
   const resolved = await Promise.resolve(client);
   assert.equal(resolved, client);

--- a/tests/generated-rpc-clients.test.mts
+++ b/tests/generated-rpc-clients.test.mts
@@ -65,6 +65,81 @@ test('lazy generated RPC client retries after a rejected constructor load', asyn
   assert.equal(attempts, 2);
 });
 
+test('lazy generated RPC client memoizes in-flight constructor load', async () => {
+  let loadCalls = 0;
+  let resolveLoad!: (ctor: new (baseURL: string) => { ping(): Promise<string> }) => void;
+  const loadDeferred = new Promise<new (baseURL: string) => { ping(): Promise<string> }>((resolve) => {
+    resolveLoad = resolve;
+  });
+
+  class TestClient {
+    constructor(private readonly baseURL: string) {}
+
+    async ping(): Promise<string> {
+      return 'pong:' + this.baseURL;
+    }
+  }
+
+  const LazyTestClient = createLazyRpcClientConstructor<TestClient>(async () => {
+    loadCalls += 1;
+    return loadDeferred;
+  });
+
+  const client = new LazyTestClient('https://example.test');
+  const first = client.ping();
+  const second = client.ping();
+
+  assert.equal(loadCalls, 1);
+
+  resolveLoad(TestClient);
+
+  const [firstResult, secondResult] = await Promise.all([first, second]);
+  assert.equal(firstResult, 'pong:https://example.test');
+  assert.equal(secondResult, 'pong:https://example.test');
+  assert.equal(loadCalls, 1);
+});
+
+test('lazy generated RPC client is not treated as a thenable', async () => {
+  class TestClient {
+    async ping(): Promise<string> {
+      return 'pong';
+    }
+  }
+
+  const LazyTestClient = createLazyRpcClientConstructor<TestClient>(async () => TestClient);
+  const client = new LazyTestClient('https://example.test');
+
+  const resolved = await Promise.resolve(client);
+  assert.equal(resolved, client);
+
+  const awaited = await client;
+  assert.equal(awaited, client);
+});
+
+test('lazy generated RPC client forwards signal through method call options', async () => {
+  const controller = new AbortController();
+
+  class TestClient {
+    async fetchData(
+      _request: { id: number },
+      options?: { signal?: AbortSignal; headers?: Record<string, string> },
+    ): Promise<{ signal?: AbortSignal; headers?: Record<string, string> }> {
+      return { signal: options?.signal, headers: options?.headers };
+    }
+  }
+
+  const LazyTestClient = createLazyRpcClientConstructor<TestClient>(async () => TestClient);
+  const client = new LazyTestClient('https://example.test');
+
+  const result = await client.fetchData({ id: 1 }, {
+    signal: controller.signal,
+    headers: { 'X-Call': 'one' },
+  });
+
+  assert.equal(result.signal, controller.signal);
+  assert.deepEqual(result.headers, { 'X-Call': 'one' });
+});
+
 test('lazy generated RPC client ignores symbol lookups without loading constructor', () => {
   let attempts = 0;
 

--- a/tests/rpc-client.test.mts
+++ b/tests/rpc-client.test.mts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getRpcErrorStatusCode } from '../src/services/rpc-client';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('getRpcErrorStatusCode returns numeric statusCode from object errors', () => {
+  assert.equal(getRpcErrorStatusCode({ statusCode: 404 }), 404);
+  assert.equal(getRpcErrorStatusCode({ statusCode: 403, message: 'forbidden' }), 403);
+});
+
+test('getRpcErrorStatusCode returns undefined for non-object inputs', () => {
+  assert.equal(getRpcErrorStatusCode(null), undefined);
+  assert.equal(getRpcErrorStatusCode(undefined), undefined);
+  assert.equal(getRpcErrorStatusCode('error'), undefined);
+  assert.equal(getRpcErrorStatusCode(500), undefined);
+});
+
+test('getRpcErrorStatusCode returns undefined when statusCode is missing or non-numeric', () => {
+  assert.equal(getRpcErrorStatusCode({}), undefined);
+  assert.equal(getRpcErrorStatusCode({ statusCode: '404' }), undefined);
+  assert.equal(getRpcErrorStatusCode({ statusCode: null }), undefined);
+});
+
+test('economic deploy-skew fallback branches on getRpcErrorStatusCode 404', () => {
+  const source = readFileSync(resolve(root, 'src/services/economic/index.ts'), 'utf8');
+  const catchBlock = source.slice(source.indexOf('async () => {'), source.indexOf('}, emptyFredBatchFallback'));
+
+  assert.match(
+    catchBlock,
+    /getRpcErrorStatusCode\(err\) === 404/,
+    'fetchFredData must use duck-typed 404 detection for deploy-skew fallback',
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up test coverage for the lazy RPC client shim from #4542 (issue #4551).

Adds the four missing test areas called out in the adversarial review:

- **Concurrency / in-flight memoization** — two simultaneous calls during a single load invoke `loadConstructor()` exactly once.
- **Thenable safety** — `Promise.resolve(client)` and `await client` resolve to the proxy without hanging or recursion (`then === undefined` guard).
- **`signal` forwarding** — `AbortSignal` passes through method call options alongside `headers`.
- **`getRpcErrorStatusCode` unit tests** — numeric `statusCode`, missing/non-numeric `statusCode`, and non-object inputs; plus a source guard that `fetchFredData` branches on `getRpcErrorStatusCode(err) === 404` for deploy-skew fallback.

Closes #4551.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [x] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: RPC client test coverage (`tests/generated-rpc-clients.test.mts`, `tests/rpc-client.test.mts`)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`) — N/A (test-only change; no production code touched)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [x] N/A — no documentation claims changed

## Verification

```bash
npx tsx --test tests/generated-rpc-clients.test.mts tests/rpc-client.test.mts
```

10/10 tests pass (6 lazy-shim + 4 rpc-client).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d10faa40-9091-42ae-82cd-941aa74407bb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d10faa40-9091-42ae-82cd-941aa74407bb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

