### PR TITLE
fix(news): align seeder StoryPhase with feed digest (#7154)

### DIFF
--- a/Dockerfile.digest-notifications
+++ b/Dockerfile.digest-notifications
@@ -74,6 +74,9 @@ COPY shared/url-classifier.js ./shared/
 # brief-filter.js and digest compose paths import ephemeral-live-classifier.js
 # to drop expiring WATCH LIVE / live-event programming from delayed briefs.
 COPY shared/ephemeral-live-classifier.js shared/ephemeral-live-classifier.d.ts ./shared/
+# seed-digest-notifications.mjs imports shared/story-phase.js for the
+# notification-path phase derivation and digest email badge rendering.
+COPY shared/story-phase.js shared/story-phase.d.ts ./shared/
 # brief-filter.js imports diplomacy-keywords.json (canonical lead-coherence
 # keyword set). seed-digest-notifications.mjs ALSO imports it directly.
 # Without this COPY, the cron crashes at startup with ERR_MODULE_NOT_FOUND

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -238,6 +238,8 @@
       "shared/publisher-families.d.ts",
       "shared/publisher-families.js",
       "shared/stocks.json",
+      "shared/story-phase.d.ts",
+      "shared/story-phase.js",
       "shared/ticker-extract.d.ts",
       "shared/ticker-extract.js",
       "shared/url-classifier.js"

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -42,6 +42,10 @@ const { normalizeResendSender } = require('./lib/resend-from.cjs');
 import { readRawJsonFromUpstash, redisPipeline } from '../api/_upstash-json.js';
 import { classifyFeelGood } from '../server/_shared/feelgood-classifier.js';
 import { classifyEphemeralLiveCoverage } from '../shared/ephemeral-live-classifier.js';
+import {
+  deriveNotificationStoryPhase,
+  formatStoryPhaseBadge,
+} from '../shared/story-phase.js';
 import { shouldDropOpinionTrack } from './lib/digest-opinion-track-filter.mjs';
 import {
   composeBriefFromDigestStories,
@@ -542,18 +546,12 @@ function flatArrayToObject(flat) {
   return obj;
 }
 
-function derivePhase(track) {
-  const mentionCount = parseInt(track.mentionCount ?? '1', 10);
-  const firstSeen = parseInt(track.firstSeen ?? '0', 10);
-  const lastSeen = parseInt(track.lastSeen ?? String(Date.now()), 10);
-  const now = Date.now();
-  const ageH = (now - firstSeen) / 3600000;
-  const silenceH = (now - lastSeen) / 3600000;
-  if (silenceH > 24) return 'fading';
-  if (mentionCount >= 3 && ageH >= 12) return 'sustained';
-  if (mentionCount >= 2) return 'developing';
-  if (ageH < 2) return 'breaking';
-  return 'unknown';
+function derivePhase(track, nowMs = Date.now()) {
+  return deriveNotificationStoryPhase({
+    mentionCount: parseInt(track.mentionCount ?? '1', 10),
+    firstSeen: parseInt(track.firstSeen ?? '0', 10),
+    lastSeen: parseInt(track.lastSeen ?? String(nowMs), 10),
+  }, nowMs);
 }
 
 function matchesSensitivity(ruleSensitivity, severity) {
@@ -1083,12 +1081,12 @@ function formatDigestHtml(stories, nowMs) {
   const highCount = buckets.high.length;
 
   const SEVERITY_BORDER = { critical: '#ef4444', high: '#f97316', medium: '#eab308' };
-  const PHASE_COLOR = { breaking: '#ef4444', developing: '#f97316', sustained: '#60a5fa', fading: '#555' };
 
   function storyCard(s) {
     const borderColor = SEVERITY_BORDER[s.severity] ?? '#4ade80';
-    const phaseColor = PHASE_COLOR[s.phase] ?? '#888';
-    const phaseCap = s.phase ? s.phase.charAt(0).toUpperCase() + s.phase.slice(1) : '';
+    const phaseBadge = formatStoryPhaseBadge(s.phase);
+    const phaseColor = phaseBadge?.color;
+    const phaseCap = phaseBadge?.label ?? '';
     const srcText = s.sources.length > 0
       ? s.sources.slice(0, 3).join(', ') + (s.sources.length > 3 ? ` +${s.sources.length - 3}` : '')
       : '';
@@ -1106,7 +1104,7 @@ function formatDigestHtml(stories, nowMs) {
       snippetEl = `<div style="margin-top: 6px; font-size: 12px; color: #999; line-height: 1.45;">${escapeHtml(trimmed)}</div>`;
     }
     const meta = [
-      phaseCap ? `<span style="font-size: 10px; color: ${phaseColor}; text-transform: uppercase; letter-spacing: 1px; font-weight: 700;">${phaseCap}</span>` : '',
+      phaseBadge ? `<span style="font-size: 10px; color: ${phaseColor}; text-transform: uppercase; letter-spacing: 1px; font-weight: 700;">${phaseCap}</span>` : '',
       srcText ? `<span style="font-size: 11px; color: #555;">${escapeHtml(srcText)}</span>` : '',
     ].filter(Boolean).join('<span style="color: #333; margin: 0 6px;">&bull;</span>');
     return `<div style="background: #111; border: 1px solid #1a1a1a; border-left: 3px solid ${borderColor}; padding: 12px 16px; margin-bottom: 8px;">${titleEl}${snippetEl}${meta ? `<div style="margin-top: 6px;">${meta}</div>` : ''}</div>`;

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -48,6 +48,7 @@ import { assignStoryIdentity, adoptExistingCanonical } from './dedup.mjs';
 import { classifyOpinion } from '../../../_shared/opinion-classifier.js';
 import { classifyFeelGood } from '../../../_shared/feelgood-classifier.js';
 import { classifyEphemeralLiveCoverage } from '../../../../shared/ephemeral-live-classifier.js';
+import { deriveCoreStoryPhase } from '../../../../shared/story-phase.js';
 import { buildTickerDictionary, extractTickers } from '../../../../shared/ticker-extract.js';
 import stocksData from '../../../../shared/stocks.json';
 import { buildClassifyCacheKey } from '../../intelligence/v1/_shared';
@@ -1249,8 +1250,10 @@ interface StoryTrack {
  *      lastSeen is `now` — a story that stopped being covered is absent from the
  *      cycle and never reaches this function. Silence, the one signal that does
  *      identify a fading story, is only visible where the non-serving population
- *      is in scope: scripts/seed-digest-notifications.mjs derives its own phase
- *      over the accumulator and already treats >24h of silence as fading.
+ *      is in scope: scripts/seed-digest-notifications.mjs calls
+ *      deriveNotificationStoryPhase() from shared/story-phase.js, which
+ *      applies the same core mention-count/age rules documented here and
+ *      additionally treats >24h of silence as fading.
  *
  * The STORY_PHASE_FADING wire value is retained for compatibility and is still
  * handled by consumers (the client alert gate suppresses it), but this handler
@@ -1260,9 +1263,9 @@ interface StoryTrack {
  * `nowMs` is injectable so the phase boundaries are testable without a live clock.
  */
 function derivePhase(track: StoryTrack, nowMs: number = Date.now()): ProtoStoryPhase {
-  const ageMs = nowMs - track.firstSeen;
-  if (track.mentionCount <= 1) return 'STORY_PHASE_BREAKING';
-  if (track.mentionCount <= 5 && ageMs < 2 * 60 * 60 * 1000) return 'STORY_PHASE_DEVELOPING';
+  const phase = deriveCoreStoryPhase(track, nowMs);
+  if (phase === 'breaking') return 'STORY_PHASE_BREAKING';
+  if (phase === 'developing') return 'STORY_PHASE_DEVELOPING';
   return 'STORY_PHASE_SUSTAINED';
 }
 

--- a/shared/story-phase.d.ts
+++ b/shared/story-phase.d.ts
@@ -1,0 +1,22 @@
+export type StoryPhase = 'breaking' | 'developing' | 'sustained' | 'fading';
+
+export declare const STORY_PHASES: readonly StoryPhase[];
+
+export declare const PHASE_COLOR: Readonly<Record<StoryPhase, string>>;
+
+export declare function isStoryPhase(phase: unknown): phase is StoryPhase;
+
+export declare function deriveCoreStoryPhase(
+  track: { mentionCount?: number; firstSeen: number },
+  nowMs?: number,
+): 'breaking' | 'developing' | 'sustained';
+
+export declare function deriveNotificationStoryPhase(
+  track: { mentionCount?: number; firstSeen: number; lastSeen: number },
+  nowMs?: number,
+): StoryPhase;
+
+export declare function formatStoryPhaseBadge(
+  phase: unknown,
+  options?: { strict?: boolean },
+): { label: string; color: string } | null;

--- a/shared/story-phase.js
+++ b/shared/story-phase.js
@@ -1,0 +1,84 @@
+/**
+ * Shared StoryPhase derivation for the feed digest and notification seeder.
+ *
+ * Core mention-count/age rules are identical across both surfaces. The
+ * notification cron may additionally label >24h of silence as `fading`
+ * because it reads the accumulator population, not just the current cycle.
+ */
+
+/** @typedef {'breaking' | 'developing' | 'sustained' | 'fading'} StoryPhase */
+
+export const STORY_PHASES = Object.freeze(
+  /** @type {readonly StoryPhase[]} */ ([
+    'breaking',
+    'developing',
+    'sustained',
+    'fading',
+  ]),
+);
+
+export const PHASE_COLOR = Object.freeze({
+  breaking: '#ef4444',
+  developing: '#f97316',
+  sustained: '#60a5fa',
+  fading: '#555',
+});
+
+const HOUR_MS = 60 * 60 * 1000;
+const DEVELOPING_MAX_AGE_MS = 2 * HOUR_MS;
+const FADING_SILENCE_MS = 24 * HOUR_MS;
+
+/**
+ * @param {unknown} phase
+ * @returns {phase is StoryPhase}
+ */
+export function isStoryPhase(phase) {
+  return typeof phase === 'string' && Object.hasOwn(PHASE_COLOR, phase);
+}
+
+/**
+ * Core lifecycle phase from mention count and story age.
+ *
+ * @param {{ mentionCount?: number; firstSeen: number }} track
+ * @param {number} [nowMs]
+ * @returns {'breaking' | 'developing' | 'sustained'}
+ */
+export function deriveCoreStoryPhase(track, nowMs = Date.now()) {
+  const mentionCount = track.mentionCount ?? 1;
+  const ageMs = nowMs - track.firstSeen;
+  if (mentionCount <= 1) return 'breaking';
+  if (mentionCount <= 5 && ageMs < DEVELOPING_MAX_AGE_MS) return 'developing';
+  return 'sustained';
+}
+
+/**
+ * Notification-path phase: silence-aware wrapper around the shared core rules.
+ *
+ * @param {{ mentionCount?: number; firstSeen: number; lastSeen: number }} track
+ * @param {number} [nowMs]
+ * @returns {StoryPhase}
+ */
+export function deriveNotificationStoryPhase(track, nowMs = Date.now()) {
+  const silenceMs = nowMs - track.lastSeen;
+  if (silenceMs > FADING_SILENCE_MS) return 'fading';
+  return deriveCoreStoryPhase(track, nowMs);
+}
+
+/**
+ * @param {unknown} phase
+ * @param {{ strict?: boolean }} [options]
+ * @returns {{ label: string; color: string } | null}
+ */
+export function formatStoryPhaseBadge(phase, options = {}) {
+  if (!phase) return null;
+  if (!isStoryPhase(phase)) {
+    if (options.strict) {
+      throw new Error(`unmodelled story phase: ${String(phase)}`);
+    }
+    return null;
+  }
+  return {
+    label: phase.charAt(0).toUpperCase() + phase.slice(1),
+    color: PHASE_COLOR[phase],
+  };
+}

--- a/tests/story-phase-fading-semantics.test.mts
+++ b/tests/story-phase-fading-semantics.test.mts
@@ -311,8 +311,8 @@ describe('#7081 finding 3 — fading is not observable at this call site', () =>
   it('the seeder, which CAN see silence, already has a working fading rule', () => {
     const seeder = readFileSync(
       resolve(__dirname, '..', 'scripts', 'seed-digest-notifications.mjs'), 'utf-8');
-    assert.match(seeder, /silenceH\s*>\s*24\)\s*return 'fading'/,
-      'the notification seeder derives fading from silence over the accumulator population');
+    assert.match(seeder, /deriveNotificationStoryPhase/,
+      'the notification seeder derives fading via shared/story-phase.js');
   });
 });
 

--- a/tests/story-phase-seeder-parity.test.mts
+++ b/tests/story-phase-seeder-parity.test.mts
@@ -1,0 +1,201 @@
+/**
+ * StoryPhase seeder parity — issue #7154.
+ *
+ * Locks the notification seeder to the shared core rules used by the feed
+ * digest, keeps the intentional silence→fading extension, and rejects
+ * off-enum phase badges in digest email HTML.
+ *
+ * Run: npx tsx --test tests/story-phase-seeder-parity.test.mts
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { __testing__ } from '../server/worldmonitor/news/v1/list-feed-digest.ts';
+import {
+  STORY_PHASES,
+  deriveCoreStoryPhase,
+  deriveNotificationStoryPhase,
+  formatStoryPhaseBadge,
+  isStoryPhase,
+} from '../shared/story-phase.js';
+
+const { derivePhase: deriveFeedPhase } = __testing__;
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOUR = 60 * 60 * 1000;
+const NOW = 1_800_000_000_000;
+
+const PROTO_TO_CLIENT = {
+  STORY_PHASE_BREAKING: 'breaking',
+  STORY_PHASE_DEVELOPING: 'developing',
+  STORY_PHASE_SUSTAINED: 'sustained',
+} as const;
+
+function feedClientPhase(
+  mentionCount: number,
+  ageMs: number,
+  lastSeenAgoMs = 0,
+): string {
+  const phase = deriveFeedPhase({
+    firstSeen: NOW - ageMs,
+    lastSeen: NOW - lastSeenAgoMs,
+    mentionCount,
+    sourceCount: 1,
+  }, NOW);
+  return PROTO_TO_CLIENT[phase as keyof typeof PROTO_TO_CLIENT];
+}
+
+function seederPhase(
+  mentionCount: number,
+  ageMs: number,
+  lastSeenAgoMs = 0,
+): string {
+  return deriveNotificationStoryPhase({
+    mentionCount,
+    firstSeen: NOW - ageMs,
+    lastSeen: NOW - lastSeenAgoMs,
+  }, NOW);
+}
+
+describe('#7154 shared core phase — closed enum', () => {
+  it('enumerates only modelled StoryPhase values', () => {
+    assert.deepEqual([...STORY_PHASES], ['breaking', 'developing', 'sustained', 'fading']);
+    for (const phase of STORY_PHASES) {
+      assert.equal(isStoryPhase(phase), true);
+    }
+    assert.equal(isStoryPhase('unknown'), false);
+  });
+
+  it('deriveCoreStoryPhase never returns unknown', () => {
+    const cases = [
+      { mentionCount: 0, ageMs: 0 },
+      { mentionCount: 1, ageMs: 5 * HOUR },
+      { mentionCount: 2, ageMs: 1 },
+      { mentionCount: 5, ageMs: 2 * HOUR - 1 },
+      { mentionCount: 5, ageMs: 2 * HOUR },
+      { mentionCount: 6, ageMs: 1 },
+      { mentionCount: 40, ageMs: 9 * HOUR },
+      { mentionCount: 1700, ageMs: 200 * HOUR },
+    ];
+    for (const c of cases) {
+      const phase = deriveCoreStoryPhase({
+        mentionCount: c.mentionCount,
+        firstSeen: NOW - c.ageMs,
+      }, NOW);
+      assert.ok(isStoryPhase(phase), `core phase must be modelled, got ${phase}`);
+      assert.notEqual(phase, 'fading', 'core rules must not emit fading');
+    }
+  });
+});
+
+describe('#7154 regression — single-mention aged story is breaking, not unknown', () => {
+  it('mentionCount <= 1, age >= 2h, silence <= 24h → breaking', () => {
+    const phase = seederPhase(1, 3 * HOUR, 1 * HOUR);
+    assert.equal(phase, 'breaking');
+    assert.notEqual(phase, 'unknown');
+  });
+
+  it('agrees with the feed digest for the same track (excluding fading)', () => {
+    const phase = seederPhase(1, 3 * HOUR, 1 * HOUR);
+    const feedPhase = feedClientPhase(1, 3 * HOUR, 1 * HOUR);
+    assert.equal(phase, feedPhase);
+  });
+
+  it('MUTATION: the pre-#7154 fallthrough would have been off-enum', () => {
+    // Documents the removed bug: old seeder returned 'unknown' here.
+    const legacyBugPhase = 'unknown';
+    assert.equal(isStoryPhase(legacyBugPhase), false);
+    assert.throws(
+      () => formatStoryPhaseBadge(legacyBugPhase, { strict: true }),
+      /unmodelled story phase: unknown/,
+    );
+    assert.equal(formatStoryPhaseBadge(legacyBugPhase), null,
+      'non-strict renderer omits the badge instead of painting UNKNOWN grey');
+  });
+});
+
+describe('#7154 parity — seeder core rules match feed digest (non-fading)', () => {
+  const grid = [
+    { mentionCount: 1, ageMs: 0 },
+    { mentionCount: 1, ageMs: 5 * HOUR },
+    { mentionCount: 2, ageMs: 1 },
+    { mentionCount: 5, ageMs: 2 * HOUR - 1 },
+    { mentionCount: 5, ageMs: 2 * HOUR },
+    { mentionCount: 6, ageMs: 1 },
+    { mentionCount: 40, ageMs: 9 * HOUR },
+    { mentionCount: 30, ageMs: 120 * HOUR, lastSeenAgoMs: 0 },
+  ];
+
+  for (const c of grid) {
+    it(`mentionCount=${c.mentionCount}, ageMs=${c.ageMs} → ${feedClientPhase(c.mentionCount, c.ageMs, c.lastSeenAgoMs ?? 0)}`, () => {
+      const feedPhase = feedClientPhase(c.mentionCount, c.ageMs, c.lastSeenAgoMs ?? 0);
+      const notificationPhase = seederPhase(c.mentionCount, c.ageMs, c.lastSeenAgoMs ?? 0);
+      assert.equal(notificationPhase, feedPhase);
+    });
+  }
+});
+
+describe('#7154 intentional divergence — silence >24h is fading in notifications only', () => {
+  it('notification path labels >24h silence as fading', () => {
+    assert.equal(seederPhase(10, 48 * HOUR, 25 * HOUR), 'fading');
+  });
+
+  it('feed digest cannot observe silence and never emits fading', () => {
+    const phase = deriveFeedPhase({
+      firstSeen: NOW - 48 * HOUR,
+      lastSeen: NOW - 25 * HOUR,
+      mentionCount: 10,
+      sourceCount: 1,
+    }, NOW);
+    assert.notEqual(phase, 'STORY_PHASE_FADING');
+    assert.equal(PROTO_TO_CLIENT[phase as keyof typeof PROTO_TO_CLIENT], 'sustained');
+  });
+
+  it('seeder source delegates to shared/story-phase.js', () => {
+    const seeder = readFileSync(
+      resolve(__dirname, '..', 'scripts', 'seed-digest-notifications.mjs'),
+      'utf-8',
+    );
+    assert.match(seeder, /deriveNotificationStoryPhase/);
+    assert.doesNotMatch(seeder, /return 'unknown'/);
+    assert.doesNotMatch(seeder, /PHASE_COLOR\[s\.phase\] \?\? '#888'/);
+  });
+});
+
+describe('#7154 digest email renderer — closed phase badge set', () => {
+  it('formats every modelled phase', () => {
+    for (const phase of STORY_PHASES) {
+      const badge = formatStoryPhaseBadge(phase, { strict: true });
+      assert.ok(badge);
+      assert.equal(badge.label, phase.charAt(0).toUpperCase() + phase.slice(1));
+      assert.match(badge.color, /^#[0-9a-f]{3,6}$/i);
+    }
+  });
+
+  it('fails loudly on unmodelled phases in strict mode', () => {
+    for (const bad of ['unknown', 'STORY_PHASE_BREAKING', 'breaking ']) {
+      assert.throws(
+        () => formatStoryPhaseBadge(bad, { strict: true }),
+        /unmodelled story phase/,
+        `strict mode must reject ${JSON.stringify(bad)}`,
+      );
+    }
+    assert.equal(formatStoryPhaseBadge('', { strict: true }), null,
+      'empty phase omits the badge');
+  });
+
+  it('omits the badge for unmodelled phases in the email path', () => {
+    assert.equal(formatStoryPhaseBadge('unknown'), null);
+    const htmlSnippet = (phase: string) => {
+      const badge = formatStoryPhaseBadge(phase);
+      return badge
+        ? `<span>${badge.label.toUpperCase()}</span>`
+        : '';
+    };
+    assert.equal(htmlSnippet('unknown'), '');
+    assert.match(htmlSnippet('breaking'), /BREAKING/);
+    assert.doesNotMatch(htmlSnippet('unknown'), /UNKNOWN/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #7154 by extracting `shared/story-phase.js` so the notification seeder and feed digest share the same mention-count/age phase rules. The seeder keeps its intentional `>24h` silence → `fading` extension but no longer returns off-enum `'unknown'`.

Digest email badges now omit unmodelled phases instead of rendering grey **UNKNOWN** copy.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [x] News panels / RSS feeds
- [x] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: digest notification seeder + email renderer

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

N/A — no methodology or API contract docs changed.

## Verification

- `npx tsx --test tests/story-phase-seeder-parity.test.mts` (19 tests, including mutation-checked regression for the removed `'unknown'` fallthrough)
- `npx tsx --test tests/story-phase-fading-semantics.test.mts` (39 tests)
- `npm run typecheck`
- `npm run typecheck:api`

## Key behavior changes

| Case | Before | After |
| --- | --- | --- |
| `mentionCount <= 1`, age ≥ 2h, silence ≤ 24h | seeder: `unknown` (email badge **UNKNOWN**) | `breaking` (matches feed digest) |
| `mentionCount 2–5`, age thresholds | seeder used different sustained/developing bars | converged to feed digest rules |
| silence > 24h | `fading` | unchanged (intentional notification-only path) |
| off-enum phase in email HTML | grey `#888` fallback | badge omitted; strict tests fail on unmodelled values |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8134e1f3-fffb-4784-a741-205677c13652?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8134e1f3-fffb-4784-a741-205677c13652&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

