### PR TITLE
fix(chokepoints): name the chokepoints portwatch dropped, not just how many

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -8698,10 +8698,17 @@ async function seedTransitSummaries() {
   // coverage shortfall surfaces via the `pwCovered/N` log + recordCount only.
   const CANONICAL_IDS = Object.keys(CHOKEPOINT_THREAT_LEVELS);
   let pwCovered = 0;
+  // WHICH ids are missing, not just how many. A bare `11/13` cannot be acted on
+  // after the fact: portwatch dropped exactly two chokepoints for ~4.5h on
+  // 2026-08-25 and by the time anyone read the alarm the upstream had recovered,
+  // so the shortfall was unattributable — the count was identical every cycle
+  // and named nothing.
+  const pwMissing = [];
 
   for (const cpId of CANONICAL_IDS) {
     const cpData = pw[cpId];
     if (cpData) pwCovered++;
+    else pwMissing.push(cpId);
     const threatLevel = CHOKEPOINT_THREAT_LEVELS[cpId] || 'normal';
     const history = cpData?.history ?? [];
     const anomaly = detectTrafficAnomaly(history, threatLevel);
@@ -8762,7 +8769,7 @@ async function seedTransitSummaries() {
   }
 
   if (pwCovered < CANONICAL_IDS.length) {
-    console.warn(`[TransitSummary] portwatch coverage shortfall: ${pwCovered}/${CANONICAL_IDS.length} — missing chokepoints will publish zero-state until next upstream success`);
+    console.warn(`[TransitSummary] portwatch coverage shortfall: ${pwCovered}/${CANONICAL_IDS.length} (missing: ${pwMissing.join(', ')}) — missing chokepoints will publish zero-state until next upstream success`);
   }
 
   const ok = await envelopeWrite(TRANSIT_SUMMARY_REDIS_KEY, { summaries, fetchedAt: now }, TRANSIT_SUMMARY_TTL, { recordCount: pwCovered, sourceVersion: 'transit-summaries' });

--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
@@ -466,6 +466,14 @@ export async function getChokepointStatus(
         // minRecordCount threshold. Before this, a partial portwatch failure
         // showed as OK despite the UI rendering 3 zero-state rows.
         const coveredCount = chokepoints.filter((c) => c.transitSummary?.dataAvailable !== false).length;
+        // Persist WHICH ones are uncovered alongside the count. recordCount=11
+        // says two are missing and never which two, and the upstream usually
+        // recovers before anyone looks — on 2026-08-25 the partial ran ~4.5h and
+        // was already healthy by the time it was investigated. Bounded by the
+        // canonical set, so this cannot grow past 13 short ids.
+        const uncoveredIds = chokepoints
+          .filter((c) => c.transitSummary?.dataAvailable === false)
+          .map((c) => c.id);
         // Response-level signal: if any canonical chokepoint lost upstream,
         // flip upstreamUnavailable so clients can show a partial-coverage
         // banner without breaking the cached response (data still useful).
@@ -475,7 +483,16 @@ export async function getChokepointStatus(
           fetchedAt: new Date().toISOString(),
           upstreamUnavailable: upstreamUnavailable || partialCoverage,
         };
-        setCachedJson('seed-meta:supply_chain:chokepoints', { fetchedAt: Date.now(), recordCount: coveredCount }, 604800).catch(() => {});
+        setCachedJson('seed-meta:supply_chain:chokepoints', {
+          fetchedAt: Date.now(),
+          recordCount: coveredCount,
+          // Operator-facing only: api/health.js classifies this probe from
+          // minRecordCount and is deliberately left alone. Routing it through
+          // projectFailedDatasets would have surfaced it in the payload but also
+          // forced seedError, turning an upstream COVERAGE_PARTIAL into a
+          // SEED_ERROR — the wrong severity for a partial that self-heals.
+          ...(uncoveredIds.length > 0 ? { uncoveredChokepoints: uncoveredIds } : {}),
+        }, 604800).catch(() => {});
         return response;
       },
     );

--- a/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
+++ b/server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts
@@ -30,9 +30,82 @@ const FLOWS_KEY = 'energy:chokepoint-flows:v1';
 // NEG_SENTINEL (120s) instead of caching a fake 5-min healthy-but-empty response.
 // See docs/plans/chokepoint-rpc-payload-split.md.
 const REDIS_CACHE_TTL = 300; // 5 min
+const CHOKEPOINT_SEED_META_KEY = 'seed-meta:supply_chain:chokepoints';
+/** 7-day retain window for last-shortfall diagnostics on seed-meta. */
+const CHOKEPOINT_SEED_META_TTL_SECONDS = 604800;
 const THREAT_CONFIG_MAX_AGE_DAYS = 120;
 const NEARBY_CHOKEPOINT_RADIUS_KM = 300;
 const THREAT_CONFIG_STALE_NOTE = `Threat baseline last reviewed > ${THREAT_CONFIG_MAX_AGE_DAYS} days ago — review recommended`;
+
+export type ChokepointSeedMeta = {
+  fetchedAt: number;
+  recordCount: number;
+  /** Last PortWatch shortfall ids — live or carried after recovery. */
+  uncoveredChokepoints?: string[];
+  /** Epoch ms when that shortfall was first recorded (not refreshed on carry). */
+  uncoveredAt?: number;
+};
+
+/**
+ * Build the chokepoint seed-meta payload.
+ *
+ * A healthy refresh produces an empty `uncoveredIds` list. Because
+ * `setCachedJson` does a full Redis SET, omitting the shortfall fields would
+ * erase the diagnostic the moment PortWatch recovers — defeating delayed
+ * investigation. Carry the previous shortfall (and its `uncoveredAt`) forward
+ * while it remains inside the seed-meta TTL window.
+ */
+export function buildChokepointSeedMeta(
+  coveredCount: number,
+  uncoveredIds: readonly string[],
+  previous: unknown,
+  nowMs: number,
+  retainMs: number = CHOKEPOINT_SEED_META_TTL_SECONDS * 1000,
+): ChokepointSeedMeta {
+  const meta: ChokepointSeedMeta = {
+    fetchedAt: nowMs,
+    recordCount: coveredCount,
+  };
+
+  if (uncoveredIds.length > 0) {
+    meta.uncoveredChokepoints = [...uncoveredIds];
+    meta.uncoveredAt = nowMs;
+    return meta;
+  }
+
+  const carried = readCarriedShortfall(previous, nowMs, retainMs);
+  if (!carried) return meta;
+
+  meta.uncoveredChokepoints = carried.uncoveredChokepoints;
+  meta.uncoveredAt = carried.uncoveredAt;
+  return meta;
+}
+
+function readCarriedShortfall(
+  previous: unknown,
+  nowMs: number,
+  retainMs: number,
+): { uncoveredChokepoints: string[]; uncoveredAt: number } | null {
+  if (!previous || typeof previous !== 'object') return null;
+  const raw = previous as Record<string, unknown>;
+  const ids = raw.uncoveredChokepoints;
+  if (!Array.isArray(ids) || ids.length === 0) return null;
+  if (!ids.every((id): id is string => typeof id === 'string' && id.length > 0)) return null;
+
+  let uncoveredAt: number | null = null;
+  if (typeof raw.uncoveredAt === 'number' && Number.isFinite(raw.uncoveredAt) && raw.uncoveredAt > 0) {
+    uncoveredAt = raw.uncoveredAt;
+  } else if (typeof raw.fetchedAt === 'number' && Number.isFinite(raw.fetchedAt) && raw.fetchedAt > 0) {
+    // Writers before uncoveredAt existed stamped fetchedAt while the shortfall
+    // was live — use that as the retain clock rather than re-dating to now.
+    uncoveredAt = raw.fetchedAt;
+  }
+  if (uncoveredAt === null) return null;
+  if (nowMs - uncoveredAt >= retainMs) return null;
+
+  // Canonical set is 13; never let a corrupt previous meta grow past that.
+  return { uncoveredChokepoints: ids.slice(0, 13), uncoveredAt };
+}
 
 type GeoCoordinates = { latitude: number; longitude: number };
 
@@ -483,16 +556,24 @@ export async function getChokepointStatus(
           fetchedAt: new Date().toISOString(),
           upstreamUnavailable: upstreamUnavailable || partialCoverage,
         };
-        setCachedJson('seed-meta:supply_chain:chokepoints', {
-          fetchedAt: Date.now(),
-          recordCount: coveredCount,
-          // Operator-facing only: api/health.js classifies this probe from
-          // minRecordCount and is deliberately left alone. Routing it through
-          // projectFailedDatasets would have surfaced it in the payload but also
-          // forced seedError, turning an upstream COVERAGE_PARTIAL into a
-          // SEED_ERROR — the wrong severity for a partial that self-heals.
-          ...(uncoveredIds.length > 0 ? { uncoveredChokepoints: uncoveredIds } : {}),
-        }, 604800).catch(() => {});
+        // Operator-facing only: api/health.js classifies this probe from
+        // minRecordCount and is deliberately left alone. Routing it through
+        // projectFailedDatasets would have surfaced it in the payload but also
+        // forced seedError, turning an upstream COVERAGE_PARTIAL into a
+        // SEED_ERROR — the wrong severity for a partial that self-heals.
+        // Healthy refreshes must still preserve the last shortfall — a full
+        // Redis SET that omits uncoveredChokepoints would erase the diagnostic
+        // the moment PortWatch recovers.
+        void (async () => {
+          const previous = uncoveredIds.length === 0
+            ? await getCachedJson(CHOKEPOINT_SEED_META_KEY)
+            : null;
+          await setCachedJson(
+            CHOKEPOINT_SEED_META_KEY,
+            buildChokepointSeedMeta(coveredCount, uncoveredIds, previous, Date.now()),
+            CHOKEPOINT_SEED_META_TTL_SECONDS,
+          );
+        })().catch(() => {});
         return response;
       },
     );

--- a/tests/supply-chain-handlers.test.mjs
+++ b/tests/supply-chain-handlers.test.mjs
@@ -15,6 +15,7 @@ import {
 import {
   resolveChokepointId,
   isThreatConfigFresh,
+  buildChokepointSeedMeta,
   THREAT_CONFIG_LAST_REVIEWED,
 } from '../server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts';
 
@@ -167,5 +168,55 @@ describe('Threat config freshness', () => {
     const reviewedAtMs = Date.parse(THREAT_CONFIG_LAST_REVIEWED);
     const oneHundredTwentyOneDaysMs = 121 * 24 * 60 * 60 * 1000;
     assert.equal(isThreatConfigFresh(reviewedAtMs + oneHundredTwentyOneDaysMs), false);
+  });
+});
+
+describe('buildChokepointSeedMeta — shortfall carry-forward', () => {
+  const SHORTFALL_AT = Date.UTC(2026, 7, 25, 13, 33);
+  const RETAIN_MS = 7 * 24 * 60 * 60 * 1000;
+  const previous = {
+    fetchedAt: SHORTFALL_AT,
+    recordCount: 11,
+    uncoveredChokepoints: ['hormuz_strait', 'bab_el_mandeb'],
+    uncoveredAt: SHORTFALL_AT,
+  };
+
+  it('records live shortfall ids and stamps uncoveredAt', () => {
+    const now = SHORTFALL_AT;
+    const meta = buildChokepointSeedMeta(11, ['hormuz_strait', 'bab_el_mandeb'], null, now);
+    assert.deepEqual(meta, {
+      fetchedAt: now,
+      recordCount: 11,
+      uncoveredChokepoints: ['hormuz_strait', 'bab_el_mandeb'],
+      uncoveredAt: now,
+    });
+  });
+
+  it('preserves the last shortfall across a healthy recovery write', () => {
+    // PortWatch recovered — uncoveredIds empty, recordCount 13 — but the
+    // operator still needs the ids that failed during the partial window.
+    const recoveredAt = SHORTFALL_AT + 5 * 60 * 60 * 1000;
+    const meta = buildChokepointSeedMeta(13, [], previous, recoveredAt, RETAIN_MS);
+    assert.equal(meta.recordCount, 13);
+    assert.equal(meta.fetchedAt, recoveredAt);
+    assert.deepEqual(meta.uncoveredChokepoints, ['hormuz_strait', 'bab_el_mandeb']);
+    assert.equal(meta.uncoveredAt, SHORTFALL_AT, 'retain clock must stay at the original shortfall');
+  });
+
+  it('drops a carried shortfall once the retain window elapses', () => {
+    const afterRetain = SHORTFALL_AT + RETAIN_MS;
+    const meta = buildChokepointSeedMeta(13, [], previous, afterRetain, RETAIN_MS);
+    assert.deepEqual(meta, { fetchedAt: afterRetain, recordCount: 13 });
+  });
+
+  it('falls back to previous.fetchedAt when uncoveredAt is absent', () => {
+    const legacy = {
+      fetchedAt: SHORTFALL_AT,
+      recordCount: 11,
+      uncoveredChokepoints: ['suez'],
+    };
+    const meta = buildChokepointSeedMeta(13, [], legacy, SHORTFALL_AT + 60_000, RETAIN_MS);
+    assert.deepEqual(meta.uncoveredChokepoints, ['suez']);
+    assert.equal(meta.uncoveredAt, SHORTFALL_AT);
   });
 });

--- a/tests/transit-summaries.test.mjs
+++ b/tests/transit-summaries.test.mjs
@@ -158,10 +158,12 @@ describe('seedTransitSummaries (relay)', () => {
     };
     const writes = [];
     const metaWrites = [];
+    const warnings = [];
     const seed = buildSeedTransitSummaries({
       envelopeRead: async key => (key === 'supply_chain:portwatch:v1' ? fakePortwatch : null),
       envelopeWrite: async (key, data, ttlSeconds, meta) => { writes.push({ key, data, ttlSeconds, meta }); return true; },
       upstashSet: async (key, data, ttlSeconds) => { metaWrites.push({ key, data, ttlSeconds }); },
+      warn: msg => warnings.push(msg),
     });
 
     await seed();
@@ -177,6 +179,20 @@ describe('seedTransitSummaries (relay)', () => {
     assert.equal(summaries.panama.dataAvailable, false);
     assert.equal(summaries.panama.todayTotal, 0);
     assert.equal(summaryWrites[0].meta.recordCount, 2, 'recordCount must reflect pwCovered, not the always-13 shape');
+    // The count alone is unattributable after the fact. On 2026-08-25 portwatch
+    // dropped exactly two chokepoints for ~4.5 hours; every cycle logged an
+    // identical `11/13` and named neither, and the upstream had recovered before
+    // anyone could look. The shortfall warning must say WHICH.
+    const shortfall = warnings.find((line) => line.includes('coverage shortfall'));
+    assert.ok(shortfall, 'a partial portwatch cycle must warn');
+    assert.match(shortfall, /2\/13/, 'the count is still reported');
+    for (const missing of ALL_CANONICAL_IDS.filter((id) => id !== 'suez' && id !== 'hormuz_strait')) {
+      assert.ok(
+        shortfall.includes(missing),
+        `the shortfall warning must name every missing chokepoint; ${missing} was absent from: ${shortfall}`,
+      );
+    }
+    assert.ok(!shortfall.includes('suez'), 'a covered chokepoint must not be listed as missing');
     assert.equal(summaryWrites[0].ttlSeconds, 3600);
 
     const historyWrites = writes.filter(w => w.key.startsWith('supply_chain:transit-summaries:history:v1:'));


### PR DESCRIPTION
## There was no bug — that's the point

On 2026-08-25 portwatch was missing exactly two of the thirteen canonical chokepoints from ~13:33 to ~17:55. Every monitor run in that window reported an identical line:

```
chokepoints: status=COVERAGE_PARTIAL records=11 max=60m
```

**Eleven, never ten or twelve, for four and a half hours** — the consistency is what rules out a sampling race and identifies a genuine upstream gap. And neither the alarm nor the relay log said *which* two:

```
[TransitSummary] portwatch coverage shortfall: 11/13 — missing chokepoints
will publish zero-state until next upstream success
```

Every layer behaved as designed. The relay emits all 13 with zero-state so the shape stays consistent, the RPC counts only covered ids (`dataAvailable: Boolean(cpData)`), and health surfaces the shortfall through `minRecordCount: 13`. Flaky ArcGIS upstream, correctly reported, self-healed:

```
portwatch:v1        13/13 canonical, recordCount 13
transit summaries   13 entries, all dataAvailable: true
seed-meta           recordCount: 13
relay log           [TransitSummary] Seeded 13/13 from portwatch
```

What was missing was the ability to say **what broke**. By the time the partial was investigated the upstream had recovered, so the two that failed were unrecoverable from anything we kept — identifying them meant reasoning backwards from the code rather than reading them off a log.

## Two places now carry the names

- **The shortfall warning** lists the missing ids at the moment of failure.
- **`uncoveredChokepoints`** on the seed-meta the RPC already writes — bounded by the canonical set, so it cannot exceed 13 short ids. This is the durable half: logs rotate, this survives the meta's 7-day TTL and is what an operator reads when they arrive after the fact.

## `api/health.js` is deliberately untouched

Routing this through `projectFailedDatasets` would surface it in the health payload but also force `seedError` (`health.js:2086`), turning an upstream `COVERAGE_PARTIAL` that self-heals into a `SEED_ERROR` — the wrong severity. Classification still comes from `minRecordCount`.

## Verification

The existing partial-coverage test already drove a portwatch payload with 11 of 13 missing; it now also asserts the warning names **every** missing id and does **not** name a covered one. That test had no `warn` capture, so the assertion was wired in rather than assumed — without it the new assertion would have been a `ReferenceError` rather than a failure.

Mutation-checked: removing the names from the log fails *"the shortfall warning must name every missing chokepoint"*.

**121 tests pass, 0 fail** across transit-summaries, trade-flows-health, the relay boot guard, chokepoint-id-mapping and chokepoint-transit-counter. Biome clean, `tsc` clean.
