### PR TITLE
fix(news): seed-digest-notifications derivePhase no longer leaks 'unknown'

### DIFF
--- a/Dockerfile.digest-notifications
+++ b/Dockerfile.digest-notifications
@@ -48,6 +48,7 @@ RUN npm ci --prefix scripts --omit=dev
 # Digest cron + shared script helpers it imports via createRequire.
 COPY scripts/seed-digest-notifications.mjs ./scripts/
 COPY scripts/_digest-markdown.mjs ./scripts/
+COPY scripts/_digest-notification-phase.mjs ./scripts/
 COPY scripts/lib/ ./scripts/lib/
 # Sprint 1 / U4 operator one-shot — `clearDeliveredEntry` primitive
 # pairs with the delivered-log writer in scripts/lib/digest-delivered-

--- a/scripts/_digest-notification-phase.mjs
+++ b/scripts/_digest-notification-phase.mjs
@@ -1,0 +1,46 @@
+/**
+ * #7154: shared, testable home for the digest-notification seeder's story
+ * phase derivation and its badge color map. Both were previously inline in
+ * seed-digest-notifications.mjs, which unconditionally runs main() at
+ * import time (a real cron job hitting Redis) -- extracting them here lets
+ * the derivation logic be unit tested without spawning that script.
+ *
+ * derivePhase's branches intentionally differ from the feed digest's
+ * derivePhase (server/worldmonitor/news/v1/list-feed-digest.ts) for
+ * `sustained` vs `developing` -- that divergence predates this file and is
+ * tracked separately in #7154; this extraction does not change it.
+ */
+
+/** @typedef {'breaking' | 'developing' | 'sustained' | 'fading'} DigestPhase */
+
+/** @type {ReadonlyArray<DigestPhase>} */
+export const DIGEST_PHASES = ['breaking', 'developing', 'sustained', 'fading'];
+
+/** @type {Readonly<Record<DigestPhase, string>>} */
+export const PHASE_COLOR = {
+  breaking: '#ef4444',
+  developing: '#f97316',
+  sustained: '#60a5fa',
+  fading: '#555',
+};
+
+/**
+ * @param {{ mentionCount?: string | number; firstSeen?: string | number; lastSeen?: string | number }} track
+ * @returns {DigestPhase}
+ */
+export function derivePhase(track) {
+  const mentionCount = parseInt(track.mentionCount ?? '1', 10);
+  const firstSeen = parseInt(track.firstSeen ?? '0', 10);
+  const lastSeen = parseInt(track.lastSeen ?? String(Date.now()), 10);
+  const now = Date.now();
+  const ageH = (now - firstSeen) / 3600000;
+  const silenceH = (now - lastSeen) / 3600000;
+  if (silenceH > 24) return 'fading';
+  if (mentionCount >= 3 && ageH >= 12) return 'sustained';
+  if (mentionCount >= 2) return 'developing';
+  // mentionCount <= 1 falls through here regardless of age once the silence
+  // and mention-count gates above are cleared. The feed digest treats every
+  // mentionCount <= 1 story as 'breaking' unconditionally, so match that
+  // instead of falling through to an off-enum 'unknown' (#7154).
+  return 'breaking';
+}

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -176,6 +176,7 @@
       "api/_seed-envelope.js",
       "api/_upstash-json.js",
       "scripts/_digest-markdown.mjs",
+      "scripts/_digest-notification-phase.mjs",
       "scripts/clear-delivered-entry.mjs",
       "scripts/lib/_upstash-pipeline.mjs",
       "scripts/lib/brief-compose.mjs",

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -90,6 +90,7 @@ import {
 import { stripSourceSuffix } from './lib/brief-dedup-jaccard.mjs';
 import { writeReplayLog } from './lib/brief-dedup-replay-log.mjs';
 import { readStoryTracksChunked } from './lib/story-track-batch-reader.mjs';
+import { derivePhase, PHASE_COLOR } from './_digest-notification-phase.mjs';
 import {
   aggregateResults as aggregateDeliveredResults,
   writeDeliveredEntry,
@@ -540,20 +541,6 @@ function flatArrayToObject(flat) {
     obj[flat[i]] = flat[i + 1];
   }
   return obj;
-}
-
-function derivePhase(track) {
-  const mentionCount = parseInt(track.mentionCount ?? '1', 10);
-  const firstSeen = parseInt(track.firstSeen ?? '0', 10);
-  const lastSeen = parseInt(track.lastSeen ?? String(Date.now()), 10);
-  const now = Date.now();
-  const ageH = (now - firstSeen) / 3600000;
-  const silenceH = (now - lastSeen) / 3600000;
-  if (silenceH > 24) return 'fading';
-  if (mentionCount >= 3 && ageH >= 12) return 'sustained';
-  if (mentionCount >= 2) return 'developing';
-  if (ageH < 2) return 'breaking';
-  return 'unknown';
 }
 
 function matchesSensitivity(ruleSensitivity, severity) {
@@ -1083,7 +1070,6 @@ function formatDigestHtml(stories, nowMs) {
   const highCount = buckets.high.length;
 
   const SEVERITY_BORDER = { critical: '#ef4444', high: '#f97316', medium: '#eab308' };
-  const PHASE_COLOR = { breaking: '#ef4444', developing: '#f97316', sustained: '#60a5fa', fading: '#555' };
 
   function storyCard(s) {
     const borderColor = SEVERITY_BORDER[s.severity] ?? '#4ade80';

--- a/tests/digest-notification-phase.test.mjs
+++ b/tests/digest-notification-phase.test.mjs
@@ -1,0 +1,107 @@
+// #7154: derivePhase in seed-digest-notifications.mjs (extracted to
+// scripts/_digest-notification-phase.mjs) could fall through to 'unknown',
+// an off-enum value that isn't a valid StoryPhase. That value reached the
+// digest email renderer's PHASE_COLOR lookup, which silently fell back to
+// a grey badge reading the literal word "UNKNOWN" — the email was sent
+// looking handled while nothing had actually decided "UNKNOWN" was
+// acceptable copy.
+//
+// derivePhase is imported directly here (not via seed-digest-notifications.mjs
+// itself, which unconditionally runs main() -- a real Redis-backed cron job --
+// at module import time).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { derivePhase, DIGEST_PHASES, PHASE_COLOR } from '../scripts/_digest-notification-phase.mjs';
+
+const HOUR = 3600000;
+
+function trackAt({ mentionCount, ageHours, silenceHours }) {
+  const now = Date.now();
+  return {
+    mentionCount: String(mentionCount),
+    firstSeen: String(now - ageHours * HOUR),
+    lastSeen: String(now - silenceHours * HOUR),
+  };
+}
+
+describe('derivePhase — branch enumeration (#7154)', () => {
+  it('returns fading when silence exceeds 24h, regardless of mention count or age', () => {
+    assert.equal(derivePhase(trackAt({ mentionCount: 10, ageHours: 100, silenceHours: 25 })), 'fading');
+    assert.equal(derivePhase(trackAt({ mentionCount: 1, ageHours: 1, silenceHours: 24.01 })), 'fading');
+  });
+
+  it('returns sustained when mentionCount >= 3 and age >= 12h and silence <= 24h', () => {
+    assert.equal(derivePhase(trackAt({ mentionCount: 3, ageHours: 12, silenceHours: 1 })), 'sustained');
+    assert.equal(derivePhase(trackAt({ mentionCount: 9, ageHours: 200, silenceHours: 0 })), 'sustained');
+  });
+
+  it('returns developing when mentionCount >= 2 but the sustained gate is not met', () => {
+    assert.equal(derivePhase(trackAt({ mentionCount: 2, ageHours: 1, silenceHours: 0 })), 'developing');
+    // mentionCount 2 with high age still fails the mentionCount >= 3 sustained gate.
+    assert.equal(derivePhase(trackAt({ mentionCount: 2, ageHours: 200, silenceHours: 0 })), 'developing');
+  });
+
+  it('returns breaking for mentionCount <= 1, for every age and silence within the silence gate', () => {
+    // This is the regression case: previously only ageH < 2 returned
+    // 'breaking' here, and ageH >= 2 fell through to 'unknown'.
+    assert.equal(derivePhase(trackAt({ mentionCount: 1, ageHours: 0, silenceHours: 0 })), 'breaking');
+    assert.equal(derivePhase(trackAt({ mentionCount: 1, ageHours: 1.9, silenceHours: 0 })), 'breaking');
+    assert.equal(derivePhase(trackAt({ mentionCount: 1, ageHours: 2, silenceHours: 0 })), 'breaking');
+    assert.equal(derivePhase(trackAt({ mentionCount: 0, ageHours: 500, silenceHours: 24 })), 'breaking');
+    assert.equal(derivePhase(trackAt({ mentionCount: 1, ageHours: 5, silenceHours: 12 })), 'breaking');
+  });
+
+  it('never returns a value outside DIGEST_PHASES across the full branch space (mutation-checked)', () => {
+    const mentionCounts = [0, 1, 2, 3, 4];
+    const ages = [0, 1, 1.9, 2, 5, 11, 12, 13, 200];
+    const silences = [0, 5, 23, 24, 24.5, 100];
+    for (const mentionCount of mentionCounts) {
+      for (const ageHours of ages) {
+        for (const silenceHours of silences) {
+          const phase = derivePhase(trackAt({ mentionCount, ageHours, silenceHours }));
+          assert.ok(
+            DIGEST_PHASES.includes(phase),
+            `derivePhase({mentionCount:${mentionCount}, ageHours:${ageHours}, silenceHours:${silenceHours}}) ` +
+            `returned ${JSON.stringify(phase)}, not one of ${JSON.stringify(DIGEST_PHASES)}`,
+          );
+        }
+      }
+    }
+  });
+});
+
+describe('derivePhase — agreement with the feed digest (#7154)', () => {
+  it('agrees with list-feed-digest.ts derivePhase for mentionCount <= 1 (feed digest: unconditionally breaking)', () => {
+    // list-feed-digest.ts: `if (track.mentionCount <= 1) return 'STORY_PHASE_BREAKING';`
+    // -- unconditional on age. The seeder must agree for every age within
+    // its own silence gate.
+    for (const ageHours of [0, 1, 2, 10, 50, 23.9]) {
+      assert.equal(
+        derivePhase(trackAt({ mentionCount: 1, ageHours, silenceHours: 1 })),
+        'breaking',
+        `mentionCount<=1 at ageHours=${ageHours} must agree with the feed digest's unconditional 'breaking'`,
+      );
+    }
+  });
+});
+
+describe('PHASE_COLOR — closed badge map (#7154)', () => {
+  it('has exactly one entry per DIGEST_PHASES value, no more and no fewer', () => {
+    assert.deepEqual(Object.keys(PHASE_COLOR).sort(), [...DIGEST_PHASES].sort());
+  });
+
+  it('every derivePhase output resolves to a real PHASE_COLOR entry, not the ?? "#888" unmodelled fallback', () => {
+    // Proves the renderer's `PHASE_COLOR[s.phase] ?? '#888'` fallback can
+    // never fire for a derivePhase() output -- the failure mode this issue
+    // reports (grey badge, literal "UNKNOWN" text) requires s.phase to be a
+    // key absent from PHASE_COLOR, which this shows is unreachable.
+    for (const phase of DIGEST_PHASES) {
+      assert.ok(
+        Object.prototype.hasOwnProperty.call(PHASE_COLOR, phase),
+        `PHASE_COLOR is missing an entry for reachable phase ${JSON.stringify(phase)}`,
+      );
+      assert.notEqual(PHASE_COLOR[phase], undefined);
+    }
+  });
+});

--- a/tests/story-phase-fading-semantics.test.mts
+++ b/tests/story-phase-fading-semantics.test.mts
@@ -309,9 +309,16 @@ describe('#7081 finding 3 — fading is not observable at this call site', () =>
   });
 
   it('the seeder, which CAN see silence, already has a working fading rule', () => {
+    // #7154 lifted the seeder's derivePhase into scripts/_digest-notification-phase.mjs
+    // so it can be unit tested without importing the cron entrypoint. The rule is still
+    // the seeder's -- assert it still reaches for it, then assert the rule itself.
     const seeder = readFileSync(
       resolve(__dirname, '..', 'scripts', 'seed-digest-notifications.mjs'), 'utf-8');
-    assert.match(seeder, /silenceH\s*>\s*24\)\s*return 'fading'/,
+    assert.match(seeder, /import \{[^}]*derivePhase[^}]*\} from '\.\/_digest-notification-phase\.mjs'/,
+      'the seeder still derives its story phase from the extracted module');
+    const phase = readFileSync(
+      resolve(__dirname, '..', 'scripts', '_digest-notification-phase.mjs'), 'utf-8');
+    assert.match(phase, /silenceH\s*>\s*24\)\s*return 'fading'/,
       'the notification seeder derives fading from silence over the accumulator population');
   });
 });


### PR DESCRIPTION
Fixes #7154.

## What

`derivePhase` in `scripts/seed-digest-notifications.mjs` fell through to the literal string `'unknown'` when `mentionCount <= 1`, `age >= 2h`, and `silence <= 24h` -- an ordinary state (a story seen once, a couple hours ago, still inside the silence window), not an error path. `'unknown'` isn't a `StoryPhase` value.

That value reaches the digest email's `PHASE_COLOR[s.phase] ?? '#888'` lookup, which silently falls back to a grey color for the missing key and renders a badge reading the literal word **UNKNOWN**. The fallback makes the email look handled; nothing actually decided "UNKNOWN" was acceptable copy to send a subscriber.

## Fix

The feed digest (`list-feed-digest.ts`) already treats every `mentionCount <= 1` story as `breaking` unconditionally. `derivePhase` now returns `'breaking'` for this fallthrough instead of `'unknown'`, matching that treatment (per the issue's own recommendation).

## Testability refactor

Extracted `derivePhase` and its `PHASE_COLOR` map into `scripts/_digest-notification-phase.mjs`, matching this repo's existing `scripts/_*.mjs` helper-module convention. `seed-digest-notifications.mjs` unconditionally runs `main()` (a real Redis-backed cron) at import time, so there was no way to unit test `derivePhase` in isolation before -- that's why this bug shipped with no direct test coverage.

Added the new file to `Dockerfile.digest-notifications`'s COPY list and `railway-services.json`'s `watchPatterns`, since it's now a separate file the cron imports (COPY addition verified against `tests/dockerfile-digest-notifications-imports.test.mjs`; the `watchPatterns` addition is pattern-matched against the sibling `_digest-markdown.mjs` entry -- I don't have Railway CLI access locally to run the live drift audit).

## Testing

- `tests/digest-notification-phase.test.mjs` (new): enumerates every `derivePhase` branch, including a mutation-checked sweep across a `mentionCount x age x silence` grid asserting the output is always a real `StoryPhase`; asserts agreement with the feed digest's unconditional `breaking` for `mentionCount <= 1` across a range of ages; asserts `PHASE_COLOR` has exactly one entry per phase (closing the badge map so the `?? '#888'` fallback this issue reports can never fire for a `derivePhase()` output).
- Verified as a negative control: reverted just the `derivePhase` fix (kept the extraction) and reran -- exactly the 3 tests tied to the `mentionCount <= 1` fallthrough fail with the reported `'unknown'` value, the other 5 (fading/sustained/developing branches, PHASE_COLOR shape) are unaffected.
- `tests/dockerfile-digest-notifications-imports.test.mjs`: 5/5 passing with the new COPY line; confirmed via negative control (reverting just the COPY line) that this guard *should* catch a missing COPY -- see scope note below.
- `node --check` on both changed script files: clean.

## Scope note

The `sustained`/`developing` threshold divergence between this seeder and the feed digest (also flagged in #7154) is left as-is. It's undocumented drift, not obviously wrong, and picking a "correct" shared threshold is a product call this fix can't settle on its own.

## Unrelated finding, not fixed here

While negative-control-testing the Dockerfile COPY guard, I found `tests/dockerfile-digest-notifications-imports.test.mjs` (and likely its siblings sharing `tests/_lib/import-graph-walk.mjs`, plus `tests/railway-watch-path-audit.test.mjs`) silently no-ops its core BFS check on Windows: the containment check `resolved.startsWith(root + '/')` hardcodes a forward slash, which never matches `path.resolve()`'s backslash-separated output on Windows, so the walk terminates after the entrypoint and the "every transitively-imported file is COPY'd" assertion passes vacuously regardless of actual coverage. I manually verified my COPY addition is correct by reading `parseDockerfileCopy`'s output directly rather than trusting the guard. Not fixing this here since it's unrelated to #7154 and affects shared test infrastructure across multiple guards -- planning a separate, focused PR for it.
