### PR TITLE
fix(test): Dockerfile-COPY guards silently no-op on Windows dev machines

### DIFF
--- a/tests/_lib/import-graph-walk.mjs
+++ b/tests/_lib/import-graph-walk.mjs
@@ -12,7 +12,7 @@
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { isBuiltin } from 'node:module';
-import { dirname, extname, join, relative, resolve, sep } from 'node:path';
+import { dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 
 // Per-file strip/extract cache. The container guards walk overlapping graphs
 // repeatedly — resolveRuntimeSurface alone re-walks each service's graph up to
@@ -242,6 +242,26 @@ export function resolveNodeRelative(fromFile, relImport, exts = NODE_SOURCE_EXTS
     if (existsSync(abs + ext)) return abs + ext;
   }
   return null;
+}
+
+/**
+ * Express `absolutePath` relative to `root`, forward-slash-separated
+ * regardless of host OS -- Dockerfile COPY sources and the container guards'
+ * tracked-prefix lists (e.g. `scripts/`) are always POSIX-style. Returns
+ * null when `absolutePath` is not inside `root`.
+ *
+ * Used by the relay and digest-notifications Dockerfile guards in place of
+ * their former inline `resolved.startsWith(root + '/') ? resolved.slice(...)
+ * : null` check, which hardcoded a forward slash. path.resolve() returns
+ * backslash-separated paths on Windows, so that check never matched there:
+ * both guards' BFS terminated after the entrypoint and their "every
+ * transitively-imported file is COPY'd" assertions passed vacuously,
+ * regardless of actual Dockerfile coverage, on any Windows dev machine.
+ */
+export function relativeToRepoRoot(root, absolutePath) {
+  const rel = relative(root, absolutePath);
+  if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) return null;
+  return rel.split(sep).join('/');
 }
 
 // tsx-style resolution: extension guessing (including TypeScript), directory

--- a/tests/_lib/import-graph-walk.mjs
+++ b/tests/_lib/import-graph-walk.mjs
@@ -22,6 +22,7 @@ import { dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node
 // mtime+size so a test that rewrites a fixture between walks still sees the
 // fresh content, while unchanged files pay stripComments/extractEdges once.
 const sourceCache = new Map();
+const nativePathSemantics = { relative, isAbsolute, sep };
 
 function cachedSourceEntry(path) {
   const stat = statSync(path);
@@ -258,10 +259,10 @@ export function resolveNodeRelative(fromFile, relImport, exts = NODE_SOURCE_EXTS
  * transitively-imported file is COPY'd" assertions passed vacuously,
  * regardless of actual Dockerfile coverage, on any Windows dev machine.
  */
-export function relativeToRepoRoot(root, absolutePath) {
-  const rel = relative(root, absolutePath);
-  if (rel === '' || rel.startsWith('..') || isAbsolute(rel)) return null;
-  return rel.split(sep).join('/');
+export function relativeToRepoRoot(root, absolutePath, pathSemantics = nativePathSemantics) {
+  const rel = pathSemantics.relative(root, absolutePath);
+  if (rel === '' || rel.startsWith('..') || pathSemantics.isAbsolute(rel)) return null;
+  return rel.split(pathSemantics.sep).join('/');
 }
 
 // tsx-style resolution: extension guessing (including TypeScript), directory

--- a/tests/dockerfile-digest-notifications-imports.test.mjs
+++ b/tests/dockerfile-digest-notifications-imports.test.mjs
@@ -28,7 +28,7 @@ import { fileURLToPath } from 'node:url';
 // Shared scanner/resolver (comment-stripping tokenizer + edge extraction) —
 // one home for the machinery this guard previously copied from the relay
 // test; see tests/_lib/import-graph-walk.mjs (#5231 review follow-up).
-import { collectRelativeImports, parseDockerfileCopy, resolveNodeRelative } from './_lib/import-graph-walk.mjs';
+import { collectRelativeImports, parseDockerfileCopy, relativeToRepoRoot, resolveNodeRelative } from './_lib/import-graph-walk.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -78,6 +78,43 @@ function isCovered(coverage, relPath) {
 // Extension candidates for this image: the digest cron's graph spans .ts
 // modules under server/_shared/, unlike the relay's .mjs/.cjs-only graph.
 const DIGEST_RESOLVE_EXTS = ['.mjs', '.cjs', '.js', '.ts'];
+
+// relativeToRepoRoot backs the BFS containment check both this guard and
+// dockerfile-relay-imports.test.mjs run below. It replaced an inline
+// `resolved.startsWith(root + '/')` check that hardcoded a forward slash --
+// path.resolve() returns backslash-separated paths on Windows, so that
+// check never matched there, and the BFS below silently terminated after
+// the entrypoint with zero files ever flagged as missing, regardless of
+// actual Dockerfile coverage. Unit-tested here directly since neither
+// guard's Dockerfile-driven walk would fail loudly if this regressed back
+// to a platform-specific check -- it would just go quiet again.
+describe('relativeToRepoRoot', () => {
+  it('returns a forward-slash-separated path for a file under root', () => {
+    const target = resolve(root, 'scripts', 'seed-digest-notifications.mjs');
+    assert.equal(relativeToRepoRoot(root, target), 'scripts/seed-digest-notifications.mjs');
+  });
+
+  it('returns a forward-slash-separated path for a nested file under root', () => {
+    const target = resolve(root, 'scripts', 'lib', 'digest-delivered-log.mjs');
+    assert.equal(relativeToRepoRoot(root, target), 'scripts/lib/digest-delivered-log.mjs');
+  });
+
+  it('returns null for a path outside root', () => {
+    const outside = resolve(root, '..', 'some-sibling-dir', 'file.mjs');
+    assert.equal(relativeToRepoRoot(root, outside), null);
+  });
+
+  it('returns null for root itself', () => {
+    assert.equal(relativeToRepoRoot(root, root), null);
+  });
+
+  it('never returns a path containing a backslash, regardless of host path.sep', () => {
+    const target = resolve(root, 'server', '_shared', 'brief-render.js');
+    const result = relativeToRepoRoot(root, target);
+    assert.ok(result, 'expected a non-null result for a file under root');
+    assert.ok(!result.includes('\\'), `result should be forward-slash-only, got ${JSON.stringify(result)}`);
+  });
+});
 
 describe('Dockerfile.digest-notifications — transitive-import closure', () => {
   const dockerfile = resolve(root, 'Dockerfile.digest-notifications');
@@ -150,9 +187,7 @@ describe('Dockerfile.digest-notifications — transitive-import closure', () => 
       for (const rel of collectRelativeImports(file)) {
         const resolved = resolveNodeRelative(file, rel, DIGEST_RESOLVE_EXTS);
         if (!resolved) continue;
-        const relToRoot = resolved.startsWith(root + '/')
-          ? resolved.slice(root.length + 1)
-          : null;
+        const relToRoot = relativeToRepoRoot(root, resolved);
         if (!relToRoot) continue;
         const tracked = TRACKED_PREFIXES.some((p) => relToRoot.startsWith(p));
         if (!tracked) continue;

--- a/tests/dockerfile-digest-notifications-imports.test.mjs
+++ b/tests/dockerfile-digest-notifications-imports.test.mjs
@@ -23,7 +23,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname, resolve, win32 } from 'node:path';
 import { fileURLToPath } from 'node:url';
 // Shared scanner/resolver (comment-stripping tokenizer + edge extraction) —
 // one home for the machinery this guard previously copied from the relay
@@ -97,6 +97,13 @@ describe('relativeToRepoRoot', () => {
   it('returns a forward-slash-separated path for a nested file under root', () => {
     const target = resolve(root, 'scripts', 'lib', 'digest-delivered-log.mjs');
     assert.equal(relativeToRepoRoot(root, target), 'scripts/lib/digest-delivered-log.mjs');
+  });
+
+  it('normalizes Windows paths deterministically on every host', () => {
+    assert.equal(
+      relativeToRepoRoot('C:\\repo', 'C:\\repo\\scripts\\file.mjs', win32),
+      'scripts/file.mjs',
+    );
   });
 
   it('returns null for a path outside root', () => {

--- a/tests/dockerfile-relay-imports.test.mjs
+++ b/tests/dockerfile-relay-imports.test.mjs
@@ -17,7 +17,7 @@ import { fileURLToPath } from 'node:url';
 // Shared scanner/resolver (comment-stripping tokenizer + edge extraction) —
 // one home for the machinery this guard previously hand-rolled; see
 // tests/_lib/import-graph-walk.mjs (#5231 review follow-up).
-import { collectRelativeImports, parseDockerfileCopy, resolveNodeRelative } from './_lib/import-graph-walk.mjs';
+import { collectRelativeImports, parseDockerfileCopy, relativeToRepoRoot, resolveNodeRelative } from './_lib/import-graph-walk.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -85,7 +85,7 @@ describe('Dockerfile.relay — transitive-import closure', () => {
       for (const rel of collectRelativeImports(file)) {
         const resolved = resolveNodeRelative(file, rel);
         if (!resolved) continue;
-        const relToRoot = resolved.startsWith(root + '/') ? resolved.slice(root.length + 1) : null;
+        const relToRoot = relativeToRepoRoot(root, resolved);
         if (!relToRoot || !relToRoot.startsWith('scripts/')) continue;
         if (!copied.has(relToRoot)) {
           missing.push(`${relToRoot} (imported by ${file.slice(root.length + 1)})`);


### PR DESCRIPTION
## What

`tests/dockerfile-digest-notifications-imports.test.mjs` and `tests/dockerfile-relay-imports.test.mjs` both compute a resolved import's path relative to the repo root with:

```js
resolved.startsWith(root + '/') ? resolved.slice(root.length + 1) : null
```

`path.resolve()` returns backslash-separated paths on Windows, so this check never matches there. Every resolved import in the BFS walk gets treated as "outside root" and silently dropped -- the walk terminates after the entrypoint, visits nothing else, and the "every transitively-imported file is COPY'd" assertion passes **vacuously**, regardless of whether the Dockerfile's COPY list is actually correct.

I found this by accident while verifying an unrelated fix (#7154): the digest-notifications guard passed with my Dockerfile COPY addition, and I wanted to confirm it would also *fail* without that addition (negative control) -- it didn't. It passed either way.

Both guards' own header comments describe a real production incident this machinery exists specifically to prevent (2026-04-14→16, a missing COPY line for a transitive `_seed-utils.mjs` import caused a 32h outage). On Windows, they currently provide none of that protection.

## Confirmation

Deliberately removed a real COPY line from each Dockerfile and reran the guards:

- **Before this fix**: both guards passed unchanged with the line removed.
- **After this fix**: both correctly failed, naming the exact real dependents:
  ```
  Dockerfile.digest-notifications is missing COPY lines for:
    scripts/_digest-markdown.mjs (imported by scripts\seed-digest-notifications.mjs)
    scripts/_digest-markdown.mjs (imported by scripts\lib\email-summary-html.mjs)
  ```
  ```
  Dockerfile.relay is missing COPY lines for:
    scripts/_proxy-utils.cjs (imported by scripts\ais-relay.cjs)
    scripts/_proxy-utils.cjs (imported by scripts\_seed-utils.mjs)
  ```

## Fix

`walkContainerGraph` (the shared BFS `tests/resilience-validation-import-graph.test.mjs` uses) already gets this right -- its `inside()` helper uses `path.sep` instead of a hardcoded `/`. The two Dockerfile-COPY guards predate that consolidation and kept their own inline, unconsolidated copy of the check, matching this shared module's own stated design ("A fix to an extraction edge case lands here once and covers all three [guards]").

Added `relativeToRepoRoot(root, absolutePath)` to `tests/_lib/import-graph-walk.mjs`: forward-slash-normalized regardless of host OS (Dockerfile COPY sources and the guards' tracked-prefix lists are always POSIX-style), using `path.relative()`'s result (checking for a leading `..` or an absolute result, rather than a hardcoded separator) to detect "outside root". Both guards now call it instead of their own inline check.

## Testing

- Unit tests for the new helper appended to `dockerfile-digest-notifications-imports.test.mjs` (no dedicated self-test file exists for this shared module -- its functions are otherwise tested indirectly through the consumer guards, so this follows that convention): a file directly under root, a nested file, a path outside root, root itself, and an explicit "no backslash in the result" assertion.
- Negative-control-verified: reverted just the helper back to the hardcoded-slash check and reran -- exactly the 3 new unit tests that assert forward-slash output fail (the containment-only cases, path-outside-root and root-itself, pass either way since they don't depend on separator handling).
- Full regression run across all four consumers of `tests/_lib/import-graph-walk.mjs` I could exercise locally (`dockerfile-digest-notifications-imports`, `dockerfile-relay-imports`, `nixpacks-seeder-import-graph`, `resilience-validation-import-graph`): 191/191 passing, no change in behavior beyond the two guards this PR targets.
- `tests/railway-watch-path-audit.test.mjs` also imports from this module but has a large number of pre-existing, unrelated failures on this Windows machine (confirmed identical with and without this change, via `git stash`) -- untouched by this PR, out of scope.
- `node --check` on all three changed files: clean.
