### PR TITLE
fix(aviation): don't attribute unfetched airports to aviationstack

### DIFF
--- a/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
+++ b/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
@@ -74,6 +74,15 @@ export async function getAirportOpsSummary(
             const isRestricted = notamRestrictedIcaos.has(airport.icao);
             const notamText = notamReasons[airport.icao];
 
+            // healthy = the seed cache read succeeded overall. alert = this
+            // specific airport had a row in that seed. healthy-but-no-alert
+            // means the airport isn't covered by the paid AviationStack feed
+            // this tick (e.g. #7106: ESB/SAW are watched but never seeded) —
+            // that must not be reported the same as a verified "normal"
+            // reading. See #3707 (list-airport-delays.ts): refuse to render
+            // uncovered airports as healthy.
+            const hasDelayData = healthy && alert !== undefined;
+
             const delayPct = alert?.delayedFlightsPct ?? 0;
             const avgDelay = alert?.avgDelayMinutes ?? 0;
             const cancelledFlights = alert?.cancelledFlights ?? 0;
@@ -91,7 +100,13 @@ export async function getAirportOpsSummary(
                 sevOrder.indexOf(delaySev),
                 sevOrder.indexOf(notamFloor),
             )] ?? 'normal';
-            const severity = `FLIGHT_DELAY_SEVERITY_${sevStr.toUpperCase()}` as FlightDelaySeverity;
+            // A NOTAM closure/restriction is independently-sourced real signal,
+            // so it still surfaces (sevStr above 'normal') even with no delay
+            // feed data for this airport. Only suppress the fabricated NORMAL
+            // when nothing — neither AviationStack nor NOTAM — actually says so.
+            const severity = (!hasDelayData && sevStr === 'normal')
+                ? 'FLIGHT_DELAY_SEVERITY_UNKNOWN' as FlightDelaySeverity
+                : `FLIGHT_DELAY_SEVERITY_${sevStr.toUpperCase()}` as FlightDelaySeverity;
 
             const notamFlags: string[] = [];
             if (isClosed) notamFlags.push('CLOSED');
@@ -115,7 +130,7 @@ export async function getAirportOpsSummary(
                 notamFlags,
                 severity,
                 topDelayReasons,
-                source: healthy ? 'aviationstack' : 'degraded',
+                source: hasDelayData ? 'aviationstack' : (healthy ? 'unknown' : 'degraded'),
                 updatedAt: now,
             });
         }

--- a/tests/get-airport-ops-summary-coverage.test.mjs
+++ b/tests/get-airport-ops-summary-coverage.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * Tests for server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
+ *
+ * Regression coverage for #7106: DEFAULT_WATCHED_AIRPORTS includes ESB and
+ * SAW, but the paid AviationStack seed feed (aviation:delays:intl:v3) never
+ * covers them. The handler used a response-level "did the cache read
+ * succeed" flag to stamp every row's `source`, so an airport with no entry
+ * in the seed's `alerts` array was still reported as
+ * `source: 'aviationstack', severity: NORMAL` — indistinguishable from a
+ * genuinely calm, actually-covered airport. Same #3707 class of bug as
+ * list-airport-delays.ts (see list-airport-delays.test.mjs): absence of
+ * telemetry must not render as verified health.
+ *
+ * Run with: npm run test:data -- --test-name-pattern='airport ops summary'
+ */
+
+import { describe, it, before, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+let getAirportOpsSummary;
+const cacheStore = new Map();
+const originalFetch = globalThis.fetch;
+
+before(async () => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://stub-upstash.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'stub-token';
+
+  mock.method(globalThis, 'fetch', async (url, _init) => {
+    const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.href : url.url;
+    const getMatch = urlStr.match(/\/get\/([^/?#]+)$/);
+    if (getMatch) {
+      const key = decodeURIComponent(getMatch[1]);
+      if (cacheStore.has(key)) {
+        const stored = cacheStore.get(key);
+        return new Response(JSON.stringify({ result: JSON.stringify(stored) }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({ result: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (urlStr.includes('/set/')) {
+      return new Response(JSON.stringify({ result: 'OK' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return originalFetch(url, _init);
+  });
+
+  const mod = await import('../server/worldmonitor/aviation/v1/get-airport-ops-summary.ts');
+  getAirportOpsSummary = mod.getAirportOpsSummary;
+});
+
+beforeEach(() => {
+  cacheStore.clear();
+  // ICAO_API_KEY unset → loadNotamClosures returns null → no NOTAM merge.
+  delete process.env.ICAO_API_KEY;
+  delete process.env.SEED_FALLBACK_NOTAM;
+});
+
+// LHR is a stable member of the paid AviationStack seed feed; ESB/SAW are
+// watched by default but not seeded (the #7106 gap). If the seeder's
+// coverage ever changes, swap samples — the assertions are structural.
+const COVERED_SAMPLE = 'LHR';
+const UNCOVERED_SAMPLES = ['ESB', 'SAW'];
+
+describe('getAirportOpsSummary handler — coverage gating (#7106)', () => {
+  it('seed cache MISS entirely → every default airport is degraded, not fabricated NORMAL', async () => {
+    // No cache set.
+    const resp = await getAirportOpsSummary({}, {});
+    assert.ok(Array.isArray(resp.summaries) && resp.summaries.length > 0, 'must return some rows');
+
+    for (const s of resp.summaries) {
+      assert.equal(s.source, 'degraded',
+        `airport ${s.iata}: source must be 'degraded' when the seed cache read fails entirely (was: ${s.source})`);
+    }
+  });
+
+  it('seed cache HIT with alerts for some airports → covered airport gets aviationstack/NORMAL, uncovered gets unknown/UNKNOWN', async () => {
+    cacheStore.set('aviation:delays:intl:v3', {
+      alerts: [
+        {
+          iata: COVERED_SAMPLE,
+          delayedFlightsPct: 0,
+          avgDelayMinutes: 0,
+          cancelledFlights: 0,
+          totalFlights: 40,
+        },
+      ],
+    });
+
+    const resp = await getAirportOpsSummary({}, {});
+
+    const covered = resp.summaries.find(s => s.iata === COVERED_SAMPLE);
+    assert.ok(covered, `must include ${COVERED_SAMPLE} row`);
+    assert.equal(covered.source, 'aviationstack',
+      `${COVERED_SAMPLE}: has a real alert row — source must be aviationstack`);
+    assert.equal(covered.severity, 'FLIGHT_DELAY_SEVERITY_NORMAL');
+
+    for (const iata of UNCOVERED_SAMPLES) {
+      const row = resp.summaries.find(s => s.iata === iata);
+      assert.ok(row, `must include ${iata} row (in DEFAULT_WATCHED_AIRPORTS)`);
+      assert.equal(row.source, 'unknown',
+        `${iata}: seed cache hit but has no alert entry — source must be 'unknown', not 'aviationstack' (#7106)`);
+      assert.equal(row.severity, 'FLIGHT_DELAY_SEVERITY_UNKNOWN',
+        `${iata}: no delay telemetry at all — must not be reported as NORMAL (#7106)`);
+    }
+
+    // Critically: no uncovered airport claims the aviationstack source.
+    const falselyAttributed = resp.summaries.filter(
+      s => UNCOVERED_SAMPLES.includes(s.iata) && s.source === 'aviationstack',
+    );
+    assert.equal(falselyAttributed.length, 0,
+      'no uncovered airport may be attributed to aviationstack');
+  });
+
+  it('an empty-but-present alerts array still distinguishes covered-and-calm from uncovered', async () => {
+    // A cache hit whose alerts array is empty (no active delays anywhere)
+    // still must not blanket-stamp every airport as verified 'aviationstack'
+    // -- only the covered ones may be, and here none has a row at all, so
+    // every default airport is uncovered-but-cache-reachable.
+    cacheStore.set('aviation:delays:intl:v3', { alerts: [] });
+
+    const resp = await getAirportOpsSummary({}, {});
+    for (const iata of UNCOVERED_SAMPLES) {
+      const row = resp.summaries.find(s => s.iata === iata);
+      assert.equal(row.source, 'unknown');
+      assert.equal(row.severity, 'FLIGHT_DELAY_SEVERITY_UNKNOWN');
+    }
+  });
+});


### PR DESCRIPTION
## What

`get-airport-ops-summary` stamped every row's `source` from a response-level "did the seed cache read succeed" flag (`healthy`), not from whether that specific airport actually had an entry in the seed's `alerts` array.

`DEFAULT_WATCHED_AIRPORTS = ['IST', 'ESB', 'SAW', 'LHR', 'FRA', 'CDG']`, but the paid AviationStack feed (`scripts/seed-aviation.mjs`'s `AVIATIONSTACK_LIST`) only queries IST/LHR/FRA/CDG -- ESB (Ankara) and SAW (Istanbul-Sabiha) are never fetched, even though both are present in `MONITORED_AIRPORTS`. For those two, `alerts.find(a => a.iata === airport.iata)` always returns `undefined`, every delay metric zero-fills via `??`, and:

```ts
source: healthy ? 'aviationstack' : 'degraded',
```

`healthy` only reflects whether the seed cache read succeeded *at all* (i.e. some airport had data) -- so ESB/SAW permanently reported `source: 'aviationstack', severity: NORMAL` regardless of real conditions. A ground stop at Sabiha Gökçen would render as calm, attributed to a feed that was never actually asked about it.

## Fix

Added a per-row `hasDelayData` check (`healthy && alert !== undefined`), matching this repo's existing #3707 pattern in `list-airport-delays.ts` ("refuse to render uncovered airports as healthy"):

- `source`: `hasDelayData ? 'aviationstack' : (healthy ? 'unknown' : 'degraded')` -- distinguishes "real data", "cache reachable but this airport not covered", and "cache unreachable entirely" (unchanged for the last case).
- `severity`: only forced to `FLIGHT_DELAY_SEVERITY_UNKNOWN` when there's *no* signal at all (`!hasDelayData && sevStr === 'normal'`) -- an independently-sourced NOTAM closure/restriction still surfaces normally, since that's real information regardless of AviationStack coverage.

## Testing

- New `tests/get-airport-ops-summary-coverage.test.mjs` (3 tests), structured like `list-airport-delays.test.mjs`: stubs the Upstash REST fetch boundary and invokes the real handler.
- **Negative control**: reverted just the source change, reran -- reproduces the exact reported symptom (`ESB`/`SAW` get `source: 'aviationstack'` from a cache hit that has no entry for them). Restored the fix, clean again.
- Full aviation suite after restoring the fix: `list-airport-delays`, `aviation-premium-bearer-wiring`, `aviation-live-routes-require-auth`, `aviation-carrier-ops-fanout-cap`, plus the new file -- **31/31 passing**, 8 suites.
- `tsc --noEmit`: clean.

Fixes #7106 via the recommended Option 1 (Honest-UNKNOWN) from the issue.
