### PR TITLE
fix(mcp): uppercase country before the intel-history RPCs

### DIFF
--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -425,6 +425,26 @@ function addStringParam(query: URLSearchParams, name: string, value: unknown): v
   if (typeof value === 'string' && value.trim()) query.set(name, value.trim());
 }
 
+/**
+ * Normalize an intel-history `country` filter to the case its route demands.
+ *
+ * The generated validator enabled by GHSA-cmj5-cfhr-w964 requires
+ * `^([A-Z]{2})?$`, and the tool schemas only *document* uppercase — a JSON
+ * Schema `description` cannot enforce it, so an LLM sending `"ua"` earns a 400
+ * round-trip (WORLDMONITOR-10R / -10Q). #7105 fixed the same defect for the
+ * dashboard panel; the `country_code` tools here already normalize at their
+ * call sites, and these three took the differently-named `country`.
+ *
+ * Returns undefined for anything blank so an omitted filter stays omitted: the
+ * pattern makes the field optional, and sending `""` would turn "search every
+ * country" into an explicit empty filter.
+ */
+function normalizeIntelHistoryCountry(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const code = value.trim().toUpperCase();
+  return code === '' ? undefined : code;
+}
+
 function procurementPageSize(value: unknown): number {
   return Number.isInteger(value) && (value as number) > 0
     ? Math.min(PROCUREMENT_TOOL_MAX_PAGE_SIZE, value as number)
@@ -2201,7 +2221,7 @@ export const RPC_TOOLS: ToolDef[] = [
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _execute: async (params, base, context, execution) => {
       const url = `${base}/api/intelligence/v1/search-intel-history`;
-      const body = JSON.stringify({ query: params.query, domain: params.domain, country: params.country, from: params.from, to: params.to, limit: Math.min(Number(params.limit ?? MCP_HISTORY_SEARCH_MAX_LIMIT), MCP_HISTORY_SEARCH_MAX_LIMIT) });
+      const body = JSON.stringify({ query: params.query, domain: params.domain, country: normalizeIntelHistoryCountry(params.country), from: params.from, to: params.to, limit: Math.min(Number(params.limit ?? MCP_HISTORY_SEARCH_MAX_LIMIT), MCP_HISTORY_SEARCH_MAX_LIMIT) });
       const auth = await buildAuthHeaders(context, 'POST', url, body);
       // Budget covers one embeddings round-trip (4 s) plus the store read (5 s).
       const response = await fetch(url, {
@@ -2251,7 +2271,7 @@ export const RPC_TOOLS: ToolDef[] = [
       // here turns an opaque downstream failure into an actionable message and
       // saves the round-trip; the handler stays the enforcing authority.
       const domain = typeof params.domain === 'string' ? params.domain.trim() : '';
-      const country = typeof params.country === 'string' ? params.country.trim() : '';
+      const country = normalizeIntelHistoryCountry(params.country) ?? '';
       if (!domain && !country) {
         throw new Error('get_intel_timeline requires at least one of domain ("conflict", "military", or "energy") or country (ISO 3166-1 alpha-2) — those are the two indexed scopes on the history store.');
       }
@@ -2310,7 +2330,7 @@ export const RPC_TOOLS: ToolDef[] = [
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _execute: async (params, base, context, execution) => {
       const url = `${base}/api/intelligence/v1/get-similar-events`;
-      const body = JSON.stringify({ situation: params.situation, domain: params.domain, country: params.country, limit: Math.min(Number(params.limit ?? MCP_HISTORY_PRECEDENT_MAX_LIMIT), MCP_HISTORY_PRECEDENT_MAX_LIMIT) });
+      const body = JSON.stringify({ situation: params.situation, domain: params.domain, country: normalizeIntelHistoryCountry(params.country), limit: Math.min(Number(params.limit ?? MCP_HISTORY_PRECEDENT_MAX_LIMIT), MCP_HISTORY_PRECEDENT_MAX_LIMIT) });
       const auth = await buildAuthHeaders(context, 'POST', url, body);
       // Budget covers one embeddings round-trip (4 s) plus the store read (5 s).
       const response = await fetch(url, {

--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -19,6 +19,7 @@ import {
 } from '../downstream';
 import { evaluateFreshness } from '../freshness';
 import { McpSourceUnavailableError } from '../source-unavailable';
+import { normalizeCountry } from '../../../server/_shared/intel-history-client';
 import {
   collectInsightSources,
   insightsSnapshotRejection,
@@ -425,25 +426,13 @@ function addStringParam(query: URLSearchParams, name: string, value: unknown): v
   if (typeof value === 'string' && value.trim()) query.set(name, value.trim());
 }
 
-/**
- * Normalize an intel-history `country` filter to the case its route demands.
- *
- * The generated validator enabled by GHSA-cmj5-cfhr-w964 requires
- * `^([A-Z]{2})?$`, and the tool schemas only *document* uppercase — a JSON
- * Schema `description` cannot enforce it, so an LLM sending `"ua"` earns a 400
- * round-trip (WORLDMONITOR-10R / -10Q). #7105 fixed the same defect for the
- * dashboard panel; the `country_code` tools here already normalize at their
- * call sites, and these three took the differently-named `country`.
- *
- * Returns undefined for anything blank so an omitted filter stays omitted: the
- * pattern makes the field optional, and sending `""` would turn "search every
- * country" into an explicit empty filter.
- */
-function normalizeIntelHistoryCountry(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const code = value.trim().toUpperCase();
-  return code === '' ? undefined : code;
-}
+// Intel-history `country` filters are normalized through the canonical
+// `normalizeCountry` (server/_shared/intel-history-client.ts): the generated
+// validator enabled by GHSA-cmj5-cfhr-w964 requires `^([A-Z]{2})?$`, and an
+// LLM sending "ua" earned a 400 round-trip (WORLDMONITOR-10R / -10Q). At the
+// POST call sites below, `|| undefined` keeps a blank/non-string filter
+// omitted — the pattern makes the field optional, and sending "" would turn
+// "search every country" into an explicit empty filter.
 
 function procurementPageSize(value: unknown): number {
   return Number.isInteger(value) && (value as number) > 0
@@ -2221,7 +2210,7 @@ export const RPC_TOOLS: ToolDef[] = [
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _execute: async (params, base, context, execution) => {
       const url = `${base}/api/intelligence/v1/search-intel-history`;
-      const body = JSON.stringify({ query: params.query, domain: params.domain, country: normalizeIntelHistoryCountry(params.country), from: params.from, to: params.to, limit: Math.min(Number(params.limit ?? MCP_HISTORY_SEARCH_MAX_LIMIT), MCP_HISTORY_SEARCH_MAX_LIMIT) });
+      const body = JSON.stringify({ query: params.query, domain: params.domain, country: normalizeCountry(params.country) || undefined, from: params.from, to: params.to, limit: Math.min(Number(params.limit ?? MCP_HISTORY_SEARCH_MAX_LIMIT), MCP_HISTORY_SEARCH_MAX_LIMIT) });
       const auth = await buildAuthHeaders(context, 'POST', url, body);
       // Budget covers one embeddings round-trip (4 s) plus the store read (5 s).
       const response = await fetch(url, {
@@ -2271,7 +2260,7 @@ export const RPC_TOOLS: ToolDef[] = [
       // here turns an opaque downstream failure into an actionable message and
       // saves the round-trip; the handler stays the enforcing authority.
       const domain = typeof params.domain === 'string' ? params.domain.trim() : '';
-      const country = normalizeIntelHistoryCountry(params.country) ?? '';
+      const country = normalizeCountry(params.country);
       if (!domain && !country) {
         throw new Error('get_intel_timeline requires at least one of domain ("conflict", "military", or "energy") or country (ISO 3166-1 alpha-2) — those are the two indexed scopes on the history store.');
       }
@@ -2330,7 +2319,7 @@ export const RPC_TOOLS: ToolDef[] = [
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
     _execute: async (params, base, context, execution) => {
       const url = `${base}/api/intelligence/v1/get-similar-events`;
-      const body = JSON.stringify({ situation: params.situation, domain: params.domain, country: normalizeIntelHistoryCountry(params.country), limit: Math.min(Number(params.limit ?? MCP_HISTORY_PRECEDENT_MAX_LIMIT), MCP_HISTORY_PRECEDENT_MAX_LIMIT) });
+      const body = JSON.stringify({ situation: params.situation, domain: params.domain, country: normalizeCountry(params.country) || undefined, limit: Math.min(Number(params.limit ?? MCP_HISTORY_PRECEDENT_MAX_LIMIT), MCP_HISTORY_PRECEDENT_MAX_LIMIT) });
       const auth = await buildAuthHeaders(context, 'POST', url, body);
       // Budget covers one embeddings round-trip (4 s) plus the store read (5 s).
       const response = await fetch(url, {

--- a/tests/mcp-intel-history-country-normalization.test.mts
+++ b/tests/mcp-intel-history-country-normalization.test.mts
@@ -1,0 +1,157 @@
+/**
+ * Country codes sent by the MCP intel-history tools must survive the
+ * generated validation layer regardless of input case.
+ *
+ * History: the 2026-08-01 security fix (GHSA-cmj5-cfhr-w964) enabled
+ * generated request validation, whose intel-history rules demand
+ * `^([A-Z]{2})?$`. #7105 fixed this defect for the dashboard deep-dive panel
+ * (`src/app/country-intel.ts`) and its commit message notes the siblings are
+ * tracked separately — the MCP surface is one of them. Eight `country_code`
+ * tools in `api/mcp/registry/rpc-tools.ts` already normalize at their call
+ * sites; the three intel-history tools take `country` instead and forwarded
+ * it verbatim, so an LLM sending the documented-but-unenforced lowercase code
+ * got a 400 round-trip (WORLDMONITOR-10R, -10Q, 2026-08-26).
+ *
+ * `get_procurement_opportunities` also forwards a raw `country`, but
+ * `listGlobalTenders` carries no case rule — verified against the real
+ * validator below so this suite states the boundary rather than assuming it.
+ *
+ * Two halves, both load-bearing:
+ *  1. Runtime: the REAL generated validator rejects lowercase and accepts
+ *     uppercase for every intel-history RPC — so this test cannot outlive the
+ *     constraint it guards.
+ *  2. Behavioural: each tool's outbound request is captured and asserted to
+ *     carry the uppercased code. An omitted country must stay omitted: the
+ *     pattern makes the field optional, and forcing an empty string would
+ *     widen "search every country" into an explicit filter.
+ */
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TOOL_REGISTRY } from '../api/mcp/registry/index.ts';
+import { validateGeneratedRequest } from '../server/request-validator.ts';
+
+const BASE_URL = 'https://worldmonitor.app';
+const HMAC_SECRET = 'test-secret-mcp-intel-history-country-case';
+const AUTH = { kind: 'pro', userId: 'user_intel_history_country_case', mcpTokenId: 'mcp_token_10r' } as const;
+const originalFetch = globalThis.fetch;
+const originalHmacSecret = process.env.MCP_INTERNAL_HMAC_SECRET;
+
+// buildAuthHeaders signs every outbound intel-history request, so without a
+// secret each tool throws before the fetch and the country assertions would go
+// red for a reason that has nothing to do with case normalization.
+beforeEach(() => {
+  process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalHmacSecret === undefined) {
+    delete process.env.MCP_INTERNAL_HMAC_SECRET;
+  } else {
+    process.env.MCP_INTERNAL_HMAC_SECRET = originalHmacSecret;
+  }
+});
+
+/** The generated RPC methods the three intel-history tools call. */
+const INTEL_HISTORY_RPCS = ['searchIntelHistory', 'getIntelTimeline', 'getSimilarEvents'];
+
+/** A request body that is otherwise valid for every method above. */
+function baseRequest(country: string) {
+  return { query: 'artillery strikes near Kharkiv', situation: 'a'.repeat(20), domain: 'conflict', country };
+}
+
+describe('generated validation vs. MCP intel-history country codes', () => {
+  for (const method of INTEL_HISTORY_RPCS) {
+    it(`${method}: rejects lowercase, accepts uppercase`, () => {
+      const lower = validateGeneratedRequest(method, baseRequest('ua'));
+      assert.ok(
+        lower && lower.some((v) => v.field === 'country'),
+        `${method} accepted a lowercase code — if the validator relaxed, `
+        + 'this suite is guarding a constraint that no longer exists',
+      );
+      assert.equal(
+        validateGeneratedRequest(method, baseRequest('UA')),
+        undefined,
+        `${method} must accept an uppercase code`,
+      );
+    });
+  }
+
+  // Boundary control: the sibling raw `country` forward in
+  // get_procurement_opportunities is deliberately left alone. If this route
+  // ever gains the case rule, this goes red and that call site needs the fix.
+  it('listGlobalTenders carries no case rule, so its raw forward is safe', () => {
+    assert.equal(validateGeneratedRequest('listGlobalTenders', { country: 'ua' }), undefined);
+  });
+});
+
+function rpcTool(name: string) {
+  const tool = TOOL_REGISTRY.find((candidate) => candidate.name === name);
+  assert.ok(tool, `${name} must be registered`);
+  assert.equal(typeof tool._execute, 'function', `${name} must be an RPC tool`);
+  return tool;
+}
+
+/** Run one tool against a stub and return the country it actually sent. */
+async function sentCountry(toolName: string, params: Record<string, unknown>) {
+  const requests: Array<{ url: string; init: RequestInit }> = [];
+  globalThis.fetch = (async (input: string | URL | Request, init: RequestInit = {}) => {
+    requests.push({ url: String(input), init });
+    return new Response(
+      JSON.stringify({ records: [], partial: false, upstreamUnavailable: false }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  }) as typeof fetch;
+
+  await rpcTool(toolName)._execute!(params, BASE_URL, AUTH, {});
+  assert.equal(requests.length, 1, `${toolName} must make exactly one outbound request`);
+  const [captured] = requests;
+  // Two transports: search/similar POST a JSON body, timeline uses the query
+  // string. Read whichever this tool used so the assertion is transport-blind.
+  if (captured!.init.method === 'POST') {
+    return (JSON.parse(String(captured!.init.body)) as { country?: unknown }).country;
+  }
+  const found = new URL(captured!.url).searchParams.get('country');
+  return found === null ? undefined : found;
+}
+
+const TOOL_CASES = [
+  { toolName: 'search_intel_history', params: { query: 'artillery strikes near Kharkiv' } },
+  { toolName: 'get_intel_timeline', params: { domain: 'conflict' } },
+  { toolName: 'get_similar_events', params: { situation: 'a naval blockade closes a grain corridor' } },
+] as const;
+
+describe('MCP intel-history tools normalize country before the RPC', () => {
+  for (const { toolName, params } of TOOL_CASES) {
+    it(`${toolName} uppercases a lowercase country`, async () => {
+      assert.equal(await sentCountry(toolName, { ...params, country: 'ua' }), 'UA');
+    });
+
+    it(`${toolName} passes an already-uppercase country through unchanged`, async () => {
+      assert.equal(await sentCountry(toolName, { ...params, country: 'UA' }), 'UA');
+    });
+
+    it(`${toolName} trims surrounding whitespace`, async () => {
+      assert.equal(await sentCountry(toolName, { ...params, country: '  ua  ' }), 'UA');
+    });
+
+    it(`${toolName} leaves an omitted country omitted`, async () => {
+      assert.equal(await sentCountry(toolName, { ...params }), undefined);
+    });
+
+    it(`${toolName} treats a blank country as omitted, not as an empty filter`, async () => {
+      assert.equal(await sentCountry(toolName, { ...params, country: '   ' }), undefined);
+    });
+  }
+
+  // get_intel_timeline's scope guard rejects an unscoped read before the
+  // fetch. A country that is blank after trimming is not a scope, so the
+  // guard must still fire rather than sending an empty filter downstream.
+  it('get_intel_timeline still rejects a blank country as unscoped', async () => {
+    await assert.rejects(
+      () => sentCountry('get_intel_timeline', { country: '   ' }),
+      /requires at least one of domain/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Extends #7105 to the MCP surface. That PR fixed this exact defect for the dashboard deep-dive panel and its commit message notes the siblings are tracked separately — this is one of them.

The generated validator enabled on 2026-08-01 by GHSA-cmj5-cfhr-w964 demands `^([A-Z]{2})?$` for the intel-history `country` field. The tool schemas only **document** uppercase — a JSON Schema `description` cannot enforce it — so an LLM caller sending `"ua"` earned a 400 round-trip.

## Evidence

Verified against the real validator rather than assumed:

```
searchIntelHistory lower: [{"field":"country",
                           "description":"string must match pattern ^([A-Z]{2})?$"}]
searchIntelHistory UPPER: undefined      (same for getIntelTimeline, getSimilarEvents)
```

Observed in production as `WORLDMONITOR-10R` (`search_intel_history`) and `-10Q` (`get_intel_timeline`), 2026-08-26.

## Scope

Narrower than "the MCP surface": the eight `country_code` tools in this file **already** uppercase at their call sites. Only these three take the differently-named `country` and forwarded it verbatim.

`get_procurement_opportunities` also forwards a raw `country`, but `listGlobalTenders` carries no case rule — checked against the validator and pinned with a control test, so if that route ever gains one the suite says so instead of the call site quietly rotting.

## Approach

Normalizes at the three call sites only, following #7105's discipline (it deliberately avoided a blanket uppercase of the shared variable). Blank returns `undefined` so an omitted filter stays omitted: the pattern makes the field optional, and sending `""` would widen "search every country" into an explicit empty filter. `get_intel_timeline`'s scope guard still rejects a blank country as unscoped — covered by a test.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Other: MCP intel-history tools

## Checklist

- [x] No API keys or secrets committed
- [x] Focused tests: `tests/mcp-intel-history-country-normalization.test.mts` (20 pass)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)
- [x] `npm run lint:api-contract` clean (156 api/ files, 120 manifest entries)

## Testing

Two-layered like #7105's, so neither half can go vacuous alone:

1. **Runtime** — drives the REAL generated validator and proves lowercase is rejected and uppercase accepted, so the suite cannot outlive the constraint it guards.
2. **Behavioural** — captures each tool's outbound request, transport-blind across the POST-body and query-string tools.

Confirmed red first — and the first red was partly a harness artifact (a missing `MCP_INTERNAL_HMAC_SECRET` made every case throw before the fetch), so the harness was fixed to produce a **behavioural** red: 8 failures, exactly the case/trim/blank cases, with uppercase-passthrough and omitted already passing.

Mutation-checked per call site: 20/20 baseline → 17/20, 17/20, 18/20 → 20/20 restored.

Broader sweep across 20 MCP/Sentry suites: **305/305, exit 0.**

## Note for reviewers

Touches `api/mcp/registry/rpc-tools.ts`, which open PR #7091 also modifies. No line overlap — #7091's hunks run 57–1215 (news digests / country brief); this PR adds a helper at ~428 and edits the intel-history tools at ~2200+. They merge cleanly in either order.

## Documentation Alignment Checklist

- [x] N/A — the tool descriptions already documented uppercase; this makes the behaviour match the doc
