### PR TITLE
fix(mcp): preserve proto violations on the observed-downstream path

### DIFF
--- a/api/mcp/billing-denial.ts
+++ b/api/mcp/billing-denial.ts
@@ -68,7 +68,7 @@ export type RpcValidationViolation = {
 // (larger or hostile bodies still truncate and never leak raw content); the
 // surviving projection stays capped independently by MAX_VALIDATION_VIOLATIONS
 // and the per-field length limits below.
-const MAX_VALIDATION_BODY_BYTES = 16384;
+export const MAX_VALIDATION_BODY_BYTES = 16384;
 const MAX_VALIDATION_VIOLATIONS = 8;
 const MAX_VIOLATION_FIELD_LEN = 64;
 const MAX_VIOLATION_DESCRIPTION_LEN = 200;
@@ -126,26 +126,17 @@ function sanitizeViolationDescription(value: unknown): string | null {
 }
 
 /**
- * Extract proto/sebuf `ValidationError.violations` from a sibling 400 body.
- * Only `{field, description}` pairs survive, each length-bounded and
- * character-restricted. Malformed JSON, HTML, oversized leftovers, unknown
- * keys, and credential-like text are dropped — never copied into the error.
+ * Project an already-parsed sibling 400 body down to its safe proto/sebuf
+ * `ValidationError.violations`. Only `{field, description}` pairs survive,
+ * each length-bounded and character-restricted. Unknown keys, non-string
+ * values, and credential-like text are dropped — never copied into the error.
+ *
+ * Kept separate from the reading helper so every caller that has already
+ * consumed the body (a sibling classifier can only read it once) projects it
+ * through this exact function rather than reimplementing the sanitizing —
+ * that divergence is what let the observed-downstream path drop violations.
  */
-export async function extractSafeRpcViolations(
-  response: ToolFetchResponse,
-): Promise<readonly RpcValidationViolation[]> {
-  const type = (response.headers?.get('Content-Type') ?? '').toLowerCase();
-  if (type.includes('html')) return [];
-
-  const detail = await readBoundedResponseText(response, MAX_VALIDATION_BODY_BYTES);
-  if (!detail) return [];
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(detail);
-  } catch {
-    return [];
-  }
+export function parseSafeRpcViolations(parsed: unknown): readonly RpcValidationViolation[] {
   if (!parsed || typeof parsed !== 'object' || !('violations' in parsed)) return [];
   const raw = (parsed as { violations: unknown }).violations;
   if (!Array.isArray(raw)) return [];
@@ -161,6 +152,27 @@ export async function extractSafeRpcViolations(
     violations.push({ field, description });
   }
   return violations;
+}
+
+/**
+ * Extract proto/sebuf `ValidationError.violations` from a sibling 400 body.
+ * Malformed JSON, HTML, and oversized leftovers are dropped; whatever parses
+ * is projected through {@link parseSafeRpcViolations}.
+ */
+export async function extractSafeRpcViolations(
+  response: ToolFetchResponse,
+): Promise<readonly RpcValidationViolation[]> {
+  const type = (response.headers?.get('Content-Type') ?? '').toLowerCase();
+  if (type.includes('html')) return [];
+
+  const detail = await readBoundedResponseText(response, MAX_VALIDATION_BODY_BYTES);
+  if (!detail) return [];
+
+  try {
+    return parseSafeRpcViolations(JSON.parse(detail));
+  } catch {
+    return [];
+  }
 }
 
 /**

--- a/api/mcp/downstream.ts
+++ b/api/mcp/downstream.ts
@@ -205,7 +205,13 @@ async function classifyFailure(
     };
   }
 
-  if (type.includes('json')) {
+  const hasJsonContentType = type.includes('json');
+  // Match extractSafeRpcViolations for proto 400s: generated responses are
+  // JSON, but a missing or generic content type must not discard an otherwise
+  // safe validation envelope. HTML remains an explicit rejection, and the
+  // relaxed gate never classifies gateway codes on non-JSON responses.
+  const mayContainValidationBody = response.status === 400 && !type.includes('html');
+  if (hasJsonContentType || mayContainValidationBody) {
     try {
       const parsed = JSON.parse(detail) as { code?: unknown; error?: unknown };
       // A coded gateway rejection is not a proto validation failure: keep the
@@ -215,22 +221,26 @@ async function classifyFailure(
       // classify as the default code anyway, so treating it as coded would
       // discard the violations of a `{"code":null,"violations":[...]}` body.
       const coded = parsed.code ?? parsed.error;
-      const violations = response.status === 400 && (coded === undefined || coded === null)
+      const violations = mayContainValidationBody && (coded === undefined || coded === null)
         ? parseSafeRpcViolations(parsed)
         : [];
-      return {
-        errorCode: violations.length > 0
-          ? 'rpc_validation'
-          : safeGatewayErrorCode(coded, response.status),
-        marker: 'json_error',
-        violations,
-      };
+      if (violations.length > 0 || hasJsonContentType) {
+        return {
+          errorCode: violations.length > 0
+            ? 'rpc_validation'
+            : safeGatewayErrorCode(coded, response.status),
+          marker: 'json_error',
+          violations,
+        };
+      }
     } catch {
-      return {
-        errorCode: defaultSafeErrorCode(response.status),
-        marker: 'json_error',
-        violations: [],
-      };
+      if (hasJsonContentType) {
+        return {
+          errorCode: defaultSafeErrorCode(response.status),
+          marker: 'json_error',
+          violations: [],
+        };
+      }
     }
   }
 

--- a/api/mcp/downstream.ts
+++ b/api/mcp/downstream.ts
@@ -1,4 +1,11 @@
-import { BillingDenialError, RpcValidationError, throwIfBillingDenial } from './billing-denial';
+import {
+  BillingDenialError,
+  MAX_VALIDATION_BODY_BYTES,
+  RpcValidationError,
+  parseSafeRpcViolations,
+  throwIfBillingDenial,
+} from './billing-denial';
+import type { RpcValidationViolation } from './billing-denial';
 import { readBoundedResponseText } from './bounded-body';
 import { emitTelemetry } from './telemetry';
 import type {
@@ -168,33 +175,61 @@ function safeGatewayErrorCode(value: unknown, status: number): string {
   return SAFE_GATEWAY_ERROR_MESSAGES.get(normalized) ?? defaultSafeErrorCode(status);
 }
 
+type DownstreamFailure = {
+  errorCode: string;
+  marker: DownstreamResponseMarker;
+  violations: readonly RpcValidationViolation[];
+};
+
 async function classifyFailure(
   response: ToolFetchResponse,
-): Promise<{ errorCode: string; marker: DownstreamResponseMarker }> {
+): Promise<DownstreamFailure> {
   if (response.status === 405) {
-    return { errorCode: 'method_not_allowed', marker: 'method_not_allowed' };
+    return { errorCode: 'method_not_allowed', marker: 'method_not_allowed', violations: [] };
   }
 
   const type = contentType(response);
-  const detail = await readBoundedResponseText(response, 4096);
+  // A sibling body can only be read once, so this single read has to serve
+  // both classifications. A proto/sebuf 400 carries its field violations in
+  // the body and a dozen localized descriptions already overflow 4 KB, so
+  // that status reads the validation budget; every other status keeps the
+  // tighter cap. Neither path lets raw text escape — only the closed set of
+  // gateway codes and the sanitized `{field, description}` pairs do.
+  const budget = response.status === 400 ? MAX_VALIDATION_BODY_BYTES : 4096;
+  const detail = await readBoundedResponseText(response, budget);
   if (!detail) {
     return {
       errorCode: defaultSafeErrorCode(response.status),
       marker: 'empty_error',
+      violations: [],
     };
   }
 
   if (type.includes('json')) {
     try {
       const parsed = JSON.parse(detail) as { code?: unknown; error?: unknown };
+      // A coded gateway rejection is not a proto validation failure: keep the
+      // recognised code and leave the violation list empty so the caller stays
+      // on the ToolFetchError contract.
+      // Absent AND explicit-null both mean "no gateway code": a null would
+      // classify as the default code anyway, so treating it as coded would
+      // discard the violations of a `{"code":null,"violations":[...]}` body.
+      const coded = parsed.code ?? parsed.error;
+      const violations = response.status === 400 && (coded === undefined || coded === null)
+        ? parseSafeRpcViolations(parsed)
+        : [];
       return {
-        errorCode: safeGatewayErrorCode(parsed.code ?? parsed.error, response.status),
+        errorCode: violations.length > 0
+          ? 'rpc_validation'
+          : safeGatewayErrorCode(coded, response.status),
         marker: 'json_error',
+        violations,
       };
     } catch {
       return {
         errorCode: defaultSafeErrorCode(response.status),
         marker: 'json_error',
+        violations: [],
       };
     }
   }
@@ -202,6 +237,7 @@ async function classifyFailure(
   return {
     errorCode: defaultSafeErrorCode(response.status),
     marker: type.includes('html') ? 'html_error' : 'other',
+    violations: [],
   };
 }
 
@@ -279,6 +315,14 @@ export async function assertMcpToolFetchOk(
     failure.errorCode,
     failure.marker,
   );
+  // Parity with assertToolFetchOk: a proto/sebuf 400 names the offending
+  // field, and dispatch turns that into JSON-RPC -32602 "Invalid params" with
+  // `error.data.violations`. Collapsing it into ToolFetchError reported the
+  // caller's own bad argument as -32603 "Internal error" and dropped the one
+  // detail that says which argument (WORLDMONITOR-10R / 10Q).
+  if (failure.violations.length > 0) {
+    throw new RpcValidationError(operation, failure.violations);
+  }
   throw new ToolFetchError(
     operation,
     response.status,

--- a/tests/mcp-rpc-validation-error.test.mjs
+++ b/tests/mcp-rpc-validation-error.test.mjs
@@ -251,3 +251,161 @@ describe('downstreamErrorTags for RpcValidationError', () => {
     assert.ok(!JSON.stringify(tags).includes('countryCode is required'));
   });
 });
+
+// WORLDMONITOR-10R / 10Q — the observed-downstream sibling of
+// assertToolFetchOk must preserve proto violations too. Both helpers front
+// the same sebuf routes, but only assertToolFetchOk extracted
+// `{violations}`; assertMcpToolFetchOk classified the same body through
+// `parsed.code ?? parsed.error`, found neither key, and collapsed every
+// proto 400 to `upstream_http_error` -> -32603. The violation list is in the
+// body (response_marker is literally `json_error`) and was thrown away, so a
+// caller's own bad argument was reported as an internal server error.
+//
+// The 400 here is stubbed, so this suite asserts the ENVELOPE for any proto
+// rejection and stays independent of which argument caused it — the arguments
+// below are deliberately valid.
+describe('MCP RPC ValidationError preservation on the observed-downstream path', () => {
+  const OBSERVED_TOOLS = [
+    {
+      tool: 'search_intel_history',
+      args: { query: 'artillery strikes near Kharkiv', country: 'UA' },
+      route: /\/api\/intelligence\/v1\/search-intel-history/,
+      violations: [{ field: 'country', description: 'value does not match regex pattern `^([A-Z]{2})?$`' }],
+    },
+    {
+      tool: 'get_intel_timeline',
+      args: { domain: 'conflict', country: 'UA' },
+      route: /\/api\/intelligence\/v1\/get-intel-timeline/,
+      violations: [{ field: 'country', description: 'value does not match regex pattern `^([A-Z]{2})?$`' }],
+    },
+    {
+      tool: 'get_similar_events',
+      args: { situation: 'a naval blockade closes a grain corridor', country: 'UA' },
+      route: /\/api\/intelligence\/v1\/get-similar-events/,
+      violations: [{ field: 'country', description: 'value does not match regex pattern `^([A-Z]{2})?$`' }],
+    },
+  ];
+
+  it('registry still exposes every tool this contract covers', () => {
+    for (const { tool } of OBSERVED_TOOLS) {
+      assert.ok(
+        TOOL_REGISTRY.some((entry) => entry.name === tool),
+        `${tool} missing from the registry`,
+      );
+    }
+  });
+
+  for (const { tool, args, route, violations } of OBSERVED_TOOLS) {
+    it(`${tool} 400 returns JSON-RPC -32602 with data.violations`, async () => {
+      const res = await callTool(tool, args, async (input) => {
+        const url = String(typeof input === 'string' ? input : input.url);
+        assert.match(url, route);
+        return json400(violations);
+      });
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.error?.code, -32602, `${tool} must report invalid params, not an internal error`);
+      assert.equal(body.error?.message, 'Invalid params');
+      assert.deepEqual(body.error?.data?.violations, violations);
+      assert.equal(body.result, undefined);
+    });
+  }
+
+  it('untrusted 400 bodies on the observed path stay on the generic -32603 fallback', async () => {
+    const res = await callTool(
+      'search_intel_history',
+      { query: 'artillery strikes near Kharkiv' },
+      async () => new Response('<html>wm_live_secret</html>', {
+        status: 400,
+        headers: { 'Content-Type': 'text/html' },
+      }),
+    );
+    const body = await res.json();
+    assert.equal(body.error?.code, -32603);
+    assert.equal(body.error?.message, 'Internal error: data fetch failed');
+    assert.equal(body.error?.data, undefined);
+    assert.ok(!JSON.stringify(body).includes('wm_live_secret'));
+    assert.ok(!JSON.stringify(body).includes('<html>'));
+  });
+
+  // A gateway 400 that carries a recognised `code` is NOT a proto validation
+  // rejection; it must keep the ToolFetchError classification rather than be
+  // re-read as an empty violation list and downgraded to a generic failure.
+  it('a coded gateway 400 keeps its safe code and stays off the -32602 path', async () => {
+    const res = await callTool(
+      'search_intel_history',
+      { query: 'artillery strikes near Kharkiv' },
+      async () => new Response(JSON.stringify({ code: 'rate_limited' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const body = await res.json();
+    assert.equal(body.error?.code, -32603);
+    assert.equal(body.error?.data, undefined);
+  });
+
+  // An explicit-null `code`/`error` alongside violations must not read as a
+  // coded gateway rejection: null classifies as the default code anyway, so
+  // treating it as coded would silently discard the field detail.
+  it('a null gateway code still yields -32602 with data.violations', async () => {
+    const violations = [{ field: 'country', description: 'country is invalid' }];
+    const res = await callTool(
+      'search_intel_history',
+      { query: 'artillery strikes near Kharkiv' },
+      async () => new Response(JSON.stringify({ code: null, error: null, violations }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602);
+    assert.deepEqual(body.error?.data?.violations, violations);
+  });
+
+  it('non-validation HTTP errors on the observed path stay on -32603', async () => {
+    const res = await callTool(
+      'get_intel_timeline',
+      { domain: 'conflict' },
+      async () => new Response(JSON.stringify({ message: 'upstream exploded' }), {
+        status: 502,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    const body = await res.json();
+    assert.equal(body.error?.code, -32603);
+    assert.equal(body.error?.data, undefined);
+    assert.ok(!JSON.stringify(body).includes('upstream exploded'));
+  });
+
+  it('telemetry still classifies the observed validation path as client_4xx', async () => {
+    process.env.MCP_TELEMETRY = 'true';
+    const captured = [];
+    const originalLog = console.log;
+    console.log = (line) => captured.push(line);
+    try {
+      await callTool(
+        'search_intel_history',
+        { query: 'artillery strikes near Kharkiv', country: 'UA' },
+        async () => json400([{ field: 'country', description: 'country is invalid' }]),
+      );
+    } finally {
+      console.log = originalLog;
+    }
+    const toolEvent = captured.find((line) => line && line.tag === 'mcp.toolcall');
+    assert.equal(toolEvent?.ok, false);
+    assert.equal(toolEvent?.error_kind, 'client_4xx');
+    assert.equal(toolEvent?.tool, 'search_intel_history');
+
+    // The downstream observation is the whole point of this helper: it must
+    // survive the new branch, and it must name the validation rejection
+    // instead of the opaque upstream_http_error it used to report.
+    const downstreamEvent = captured.find((line) => line && line.tag === 'mcp.downstream');
+    assert.equal(downstreamEvent?.ok, false);
+    assert.equal(downstreamEvent?.status, 400);
+    assert.equal(downstreamEvent?.error_code, 'rpc_validation');
+    assert.equal(downstreamEvent?.response_marker, 'json_error');
+    assert.equal(downstreamEvent?.downstream_operation, 'search-intel-history');
+    assert.ok(!JSON.stringify(downstreamEvent).includes('country is invalid'));
+  });
+});

--- a/tests/mcp-rpc-validation-error.test.mjs
+++ b/tests/mcp-rpc-validation-error.test.mjs
@@ -4,6 +4,7 @@
 // generic -32603 "Internal error: data fetch failed".
 import { afterEach, describe, it } from 'node:test';
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
 
 import { TOOL_REGISTRY } from '../api/mcp/registry/index.ts';
 import { dispatchToolsCall } from '../api/mcp/dispatch.ts';
@@ -286,6 +287,20 @@ describe('MCP RPC ValidationError preservation on the observed-downstream path',
     },
   ];
 
+  // Bidirectional guard: every tool whose _execute calls assertMcpToolFetchOk
+  // must appear here, so adding an eighth observed caller fails until its
+  // envelope contract is pinned, and removing one prunes the list. The static
+  // scan is safe because rpc-tools.ts is plain TS with a single helper name;
+  // only the three intel-history tools get envelope tests below (they share
+  // one classification branch), the rest are pinned by name.
+  const ALL_OBSERVED_TOOLS = [
+    ...OBSERVED_TOOLS.map(({ tool }) => tool),
+    'get_defense_industrial_base',
+    'get_china_decision_signals',
+    'get_wto_trade_flows',
+    'get_world_brief',
+  ];
+
   it('registry still exposes every tool this contract covers', () => {
     for (const { tool } of OBSERVED_TOOLS) {
       assert.ok(
@@ -295,6 +310,21 @@ describe('MCP RPC ValidationError preservation on the observed-downstream path',
     }
   });
 
+  it('every assertMcpToolFetchOk call site in the registry is covered by this contract', () => {
+    const source = readFileSync(new URL('../api/mcp/registry/rpc-tools.ts', import.meta.url), 'utf8');
+    const scanned = new Set();
+    for (const match of source.matchAll(/assertMcpToolFetchOk\(/g)) {
+      const before = source.slice(0, match.index);
+      const nameAt = before.lastIndexOf("name: '");
+      assert.notEqual(nameAt, -1, 'assertMcpToolFetchOk call site must follow a tool name literal');
+      scanned.add(source.slice(nameAt + 7, source.indexOf("'", nameAt + 7)));
+    }
+    assert.deepEqual(
+      [...scanned].sort(),
+      [...ALL_OBSERVED_TOOLS].sort(),
+      'the assertMcpToolFetchOk call sites and this contract diverged — pin the new site or prune the list',
+    );
+  });
   for (const { tool, args, route, violations } of OBSERVED_TOOLS) {
     it(`${tool} 400 returns JSON-RPC -32602 with data.violations`, async () => {
       const res = await callTool(tool, args, async (input) => {
@@ -361,6 +391,33 @@ describe('MCP RPC ValidationError preservation on the observed-downstream path',
     const body = await res.json();
     assert.equal(body.error?.code, -32602);
     assert.deepEqual(body.error?.data?.violations, violations);
+  });
+
+  // The 16 KB-on-400 budget exists because a dozen localized descriptions
+  // overflow the flat 4 KB classification cap; this is the observed-downstream
+  // twin of the direct-path >4 KB tests above. Reverting classifyFailure's
+  // status-keyed budget to a constant 4096 turns this red via mid-JSON
+  // truncation collapsing the list into -32603.
+  it('keeps a >4 KB violations body inside the -32602 contract on the observed path', async () => {
+    const violations = Array.from({ length: 14 }, (_, i) => ({
+      field: `field_${i}`,
+      description: 'x'.repeat(400),
+    }));
+    const body = JSON.stringify({ violations });
+    assert.ok(utf8Bytes(body) > 4096 && utf8Bytes(body) <= VALIDATION_BODY_BUDGET_BYTES);
+
+    const res = await callTool(
+      'search_intel_history',
+      { query: 'artillery strikes near Kharkiv', country: 'UA' },
+      async () => json400Response(body),
+    );
+    assert.equal(res.status, 200);
+    const parsed = await res.json();
+    assert.equal(parsed.error.code, -32602, 'a large proto 400 must stay invalid-params on the observed path');
+    assert.equal(parsed.error.data.violations.length, 8,
+      'the MAX_VALIDATION_VIOLATIONS cap still applies to the larger body');
+    assert.deepEqual(parsed.error.data.violations[0], { field: 'field_0', description: 'x'.repeat(200) });
+    assert.equal(parsed.result, undefined);
   });
 
   it('non-validation HTTP errors on the observed path stay on -32603', async () => {

--- a/tests/mcp-rpc-validation-error.test.mjs
+++ b/tests/mcp-rpc-validation-error.test.mjs
@@ -393,6 +393,18 @@ describe('MCP RPC ValidationError preservation on the observed-downstream path',
     assert.deepEqual(body.error?.data?.violations, violations);
   });
 
+  it('a JSON validation body without a JSON content type still yields -32602', async () => {
+    const violations = [{ field: 'country', description: 'country is invalid' }];
+    const res = await callTool(
+      'search_intel_history',
+      { query: 'artillery strikes near Kharkiv' },
+      async () => new Response(JSON.stringify({ violations }), { status: 400 }),
+    );
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602);
+    assert.deepEqual(body.error?.data?.violations, violations);
+  });
+
   // The 16 KB-on-400 budget exists because a dozen localized descriptions
   // overflow the flat 4 KB classification cap; this is the observed-downstream
   // twin of the direct-path >4 KB tests above. Reverting classifyFailure's


### PR DESCRIPTION
## Summary

Found during a Sentry triage sweep. `assertToolFetchOk` extracts proto/sebuf `{violations}` from a 400 and throws `RpcValidationError`, which dispatch turns into JSON-RPC `-32602 "Invalid params"` with `error.data.violations`. Its telemetry-carrying sibling `assertMcpToolFetchOk` never got that branch: it classifies via `parsed.code ?? parsed.error`, finds neither key in a `{violations:[...]}` body, and collapses to `upstream_http_error` → `-32603 "Internal error"`.

On the seven tool call sites that use the observed helper, a caller's own bad argument was therefore reported as an internal server error, and the one field naming **which** argument was discarded — while the body detail was demonstrably present.

## Evidence

`WORLDMONITOR-10R` (`search_intel_history`) and `-10Q` (`get_intel_timeline`), 2026-08-26. Event tags:

```
downstream_status          400
downstream_error_code      upstream_http_error
downstream_response_marker json_error      <- the body WAS json with detail in it
```

No field named anywhere on the event. `downstreamErrorTags` already had an `RpcValidationError` arm returning `rpc_validation`, so the Sentry tag path needed no change — further evidence that only the throw site was missing.

## Approach

- Split the sanitizing projection out of `extractSafeRpcViolations` into a pure `parseSafeRpcViolations`, so both helpers run the exact same field/description bounds. A second copy would reintroduce the divergence this PR repairs.
- A sibling body can only be read **once**, so `classifyFailure` now reads the 16 KB validation budget on 400 (4 KB elsewhere) in a single read and returns violations alongside the classification.
- `assertMcpToolFetchOk` throws `RpcValidationError` when any survive.
- A coded gateway 400 (`{code:'rate_limited'}`) deliberately keeps the `ToolFetchError` contract. Absent **and** explicit-null both count as "no code" — a null classifies as the default code anyway, so treating it as coded would discard the violations of a `{"code":null,"violations":[...]}` body.

## Scope note

This makes 400s diagnosable; it does not stop them. The lowercase-country cause is fixed independently in #7170.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Other: MCP downstream error classification

## Checklist

- [x] No API keys or secrets committed
- [x] Focused tests: `tests/mcp-rpc-validation-error.test.mjs` (20 pass), confirmed red first (`-32603 !== -32602`; telemetry `upstream_http_error` vs `rpc_validation`)
- [x] TypeScript compiles without errors (`npx tsc --noEmit`)

## Testing

New observed-path suite covering all three intel-history tools plus negative controls: HTML bodies and coded 400s stay on `-32603`, no untrusted text reaches the envelope, and the downstream telemetry observation must survive the new branch reporting `rpc_validation`. The null-code branch is mutation-checked — reverting the guard turns its test red.

Broader sweep across 20 MCP/Sentry suites: **305/305, exit 0.**

## Documentation Alignment Checklist

- [x] N/A — no documentation claims changed
