### PR TITLE
test(pro): dist-gate pro-sentry-chunk with the shared /pro guard

### DIFF
--- a/tests/pro-sentry-chunk.test.mjs
+++ b/tests/pro-sentry-chunk.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { guardProBuiltOutput, shouldSkipProBuiltOutput } from './_lib/pro-built-output.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PRO_DIR = resolve(__dirname, '..', 'public', 'pro');
@@ -31,7 +32,14 @@ function entryChunksFor(html) {
     .filter((name) => !/^sentry-/.test(name));
 }
 
-describe('pro Sentry chunk split contract (#5019)', () => {
+// Dist-gated via the shared /pro guard (#7143): public/pro/ is gitignored and
+// produced by `npm run build:pro`, so on an unbuilt tree this suite SKIPS
+// instead of ENOENT-ing during suite construction — unless
+// WM_EXPECT_BUILT_OUTPUT=1 (CI builds /pro immediately before test:data),
+// which turns absence into a named failure so CI can never silently skip it.
+// Same idiom as the 16 other suites on tests/_lib/pro-built-output.mjs.
+describe('pro Sentry chunk split contract (#5019)', { skip: shouldSkipProBuiltOutput() }, () => {
+  guardProBuiltOutput();
   const sentryChunks = readdirSync(ASSETS_DIR).filter((f) => /^sentry-[A-Za-z0-9_-]+\.js$/.test(f));
   const indexHtml = readFileSync(resolve(PRO_DIR, 'index.html'), 'utf8');
   const welcomeHtml = readFileSync(resolve(PRO_DIR, 'welcome.html'), 'utf8');


### PR DESCRIPTION
Fixes #7143.

## What this does

`tests/pro-sentry-chunk.test.mjs` read `public/pro/assets` in its `describe` body, so any tree that hadn't built `/pro` hard-failed with a bare ENOENT during suite construction — the lone red suite in an otherwise green local `test:data`.

Rather than hand-rolling the presence check the issue sketched, the file now delegates to **`tests/_lib/pro-built-output.mjs`** — the shared `/pro` guard that 16 other suites already use, whose marker choice (`welcome.html`, written last by the prerender) and delegation to the built-output primitive are already pinned by `dashboard-build-guards.test.mjs`'s *“wires the /pro guard to the shared primitive”* case. That satisfies the issue's third item structurally: this file is now inside the exact wiring that test defends.

## Verification — all four acceptance criteria executed

- **Unbuilt tree**: exit 0, suite reported `# SKIP` (not 0-tests-silently)
- **Unbuilt tree + `WM_EXPECT_BUILT_OUTPUT=1`**: exit 1 with a message naming `public/pro/assets`… `Run \`npm run build:pro\` first` — not a bare ENOENT
- **Built tree** (ran `npm run build:pro`): 8/8 pass unchanged, with and without the flag
- **Mutation check**: removing the built `sentry-*.js` chunk turns the suite red (exit 1), restored → green — the skip path cannot mask a real regression

`biome lint` clean.