### PR TITLE
test(temp): make temp dirs self-cleaning so tests stop leaking $TMPDIR

### DIFF
--- a/tests/agent-pr-snapshot.test.mjs
+++ b/tests/agent-pr-snapshot.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
+  
   readFileSync,
   symlinkSync,
   writeFileSync,
@@ -22,6 +22,7 @@ import {
   parsePrNumber,
   readCachedSnapshot,
 } from '../scripts/agent-pr-snapshot.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 const oid = character => character.repeat(40);
 
@@ -127,7 +128,7 @@ describe('agent PR snapshot', () => {
   });
 
   it('reports a base fetch timeout distinctly after using the network budget', () => {
-    const cacheDir = mkdtempSync(join(tmpdir(), 'wm-agent-pr-timeout-'));
+    const cacheDir = createTempDir('wm-agent-pr-timeout-');
     const headOid = oid('a');
     const baseOid = oid('b');
     let fetchOptions;
@@ -158,7 +159,7 @@ describe('agent PR snapshot', () => {
   });
 
   it('keeps the snapshot when the PR head remote cannot be read', () => {
-    const cacheDir = mkdtempSync(join(tmpdir(), 'wm-agent-pr-remote-'));
+    const cacheDir = createTempDir('wm-agent-pr-remote-');
     const headOid = oid('a');
     const runner = (file, args) => {
       const command = args.join(' ');
@@ -294,7 +295,7 @@ describe('agent PR snapshot', () => {
   });
 
   it('writes a head-OID cache and serves it without another GitHub query', () => {
-    const cacheDir = mkdtempSync(join(tmpdir(), 'wm-agent-pr-cache-'));
+    const cacheDir = createTempDir('wm-agent-pr-cache-');
     const headOid = oid('a');
     const baseOid = oid('b');
     const pullRequestBaseOid = oid('c');
@@ -449,7 +450,7 @@ describe('agent PR snapshot', () => {
   });
 
   it('rejects a symlinked cache root', () => {
-    const parent = mkdtempSync(join(tmpdir(), 'wm-agent-pr-symlink-'));
+    const parent = createTempDir('wm-agent-pr-symlink-');
     const target = join(parent, 'target');
     const cacheDir = join(parent, 'cache');
     mkdirSync(target, { mode: 0o700 });

--- a/tests/agent-preflight.test.mjs
+++ b/tests/agent-preflight.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  mkdtempSync,
+  
   mkdirSync,
   writeFileSync,
 } from 'node:fs';
@@ -20,8 +20,9 @@ import {
   runAgentPreflight,
   supportedNode,
 } from '../scripts/agent-preflight.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
-const makeRoot = () => mkdtempSync(join(tmpdir(), 'wm-agent-preflight-'));
+const makeRoot = () => createTempDir('wm-agent-preflight-');
 const currentMajor = process.versions.node.split('.')[0];
 const headOid = 'a'.repeat(40);
 

--- a/tests/bootstrap-worktree.test.mjs
+++ b/tests/bootstrap-worktree.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
 import {
   existsSync,
-  mkdtempSync,
+  
   mkdirSync,
   readFileSync,
   readlinkSync,
@@ -24,8 +24,9 @@ import {
   parseArgs,
   shouldInstallDependencies,
 } from '../scripts/bootstrap-worktree.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
-const makeTempDir = (prefix = 'wm-worktree-bootstrap-') => mkdtempSync(join(tmpdir(), prefix));
+const makeTempDir = (prefix = 'wm-worktree-bootstrap-') => createTempDir(prefix);
 const quiet = () => {};
 
 describe('worktree bootstrap helper', () => {

--- a/tests/bundle-section-parser.test.mjs
+++ b/tests/bundle-section-parser.test.mjs
@@ -10,7 +10,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -21,6 +21,7 @@ import {
   resolveExpr,
   stripLineComments,
 } from './helpers/bundle-section-parser.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 // ── Resolver ─────────────────────────────────────────────────────────────
 
@@ -73,7 +74,7 @@ test('resolver: follows a relative named import to a sibling module', () => {
   // that section at all. The cycle guard must key on the FILE, not its
   // directory, or importing from a sibling in the same folder looks like a
   // self-reference and resolves to null.
-  const dir = mkdtempSync(join(tmpdir(), 'wm-bundle-parser-'));
+  const dir = createTempDir('wm-bundle-parser-');
   const bundlePath = join(dir, 'seed-bundle-sample.mjs');
   writeFileSync(join(dir, 'seed-thing.mjs'), 'export const THING_TIMEOUT_MS = 300_000;\n');
   const src = "import { THING_TIMEOUT_MS } from './seed-thing.mjs';\n";
@@ -85,7 +86,7 @@ test('resolver: follows a relative named import to a sibling module', () => {
 });
 
 test('resolver: follows a renamed named import', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'wm-bundle-parser-'));
+  const dir = createTempDir('wm-bundle-parser-');
   const bundlePath = join(dir, 'seed-bundle-sample.mjs');
   writeFileSync(join(dir, 'seed-thing.mjs'), 'export const RAW_MS = 120_000;\n');
   const src = "import { RAW_MS as SECTION_MS } from './seed-thing.mjs';\n";
@@ -94,7 +95,7 @@ test('resolver: follows a renamed named import', () => {
 });
 
 test('resolver: a bare package specifier is not followed', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'wm-bundle-parser-'));
+  const dir = createTempDir('wm-bundle-parser-');
   const bundlePath = join(dir, 'seed-bundle-sample.mjs');
   const src = "import { SOME_MS } from 'some-package';\n";
   writeFileSync(bundlePath, src);
@@ -304,7 +305,7 @@ test('stripLineComments: division and keyword-prefixed regexes stay intact', () 
 
 test('resolver: follows a named import from a default-plus-named statement', () => {
   // `import def, { X } from './y.mjs'` used to be invisible to the resolver.
-  const dir = mkdtempSync(join(tmpdir(), 'wm-bundle-parser-'));
+  const dir = createTempDir('wm-bundle-parser-');
   const bundlePath = join(dir, 'seed-bundle-sample.mjs');
   writeFileSync(join(dir, 'seed-thing.mjs'), 'export const THING_MS = 90_000;\n');
   const src = "import defaultThing from './other.mjs';\nimport base, { THING_MS } from './seed-thing.mjs';\n";
@@ -313,7 +314,7 @@ test('resolver: follows a named import from a default-plus-named statement', () 
 });
 
 test('resolver: follows an `export { X } from` re-export', () => {
-  const dir = mkdtempSync(join(tmpdir(), 'wm-bundle-parser-'));
+  const dir = createTempDir('wm-bundle-parser-');
   const bundlePath = join(dir, 'seed-bundle-sample.mjs');
   writeFileSync(join(dir, 'origin.mjs'), 'export const ORIGIN_MS = 45_000;\n');
   writeFileSync(join(dir, 'middle.mjs'), "export { ORIGIN_MS as SHARED_MS } from './origin.mjs';\n");

--- a/tests/china-decision-parity-audit.test.mjs
+++ b/tests/china-decision-parity-audit.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
@@ -21,6 +21,7 @@ import {
   resolveChinaParityExitCode,
   summarizeChinaDecisionGroups,
 } from '../scripts/audit-china-decision-parity.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..');
 const ROUTE = '/api/intelligence/v1/get-china-decision-signals';
@@ -629,7 +630,7 @@ describe('China decision-signal audit CLI (#5643)', () => {
     // no-ops through a symlink: exit 0, zero output, indistinguishable from a
     // clean audit. `/tmp` -> `/private/tmp` on macOS makes that a normal way to
     // invoke a script, not a corner case.
-    const base = realpathSync(mkdtempSync(join(tmpdir(), 'parity-mainguard-')));
+    const base = realpathSync(createTempDir('parity-mainguard-'));
     const realDir = join(base, 'real');
     mkdirSync(realDir);
     const realScript = join(realDir, 'audit.mjs');

--- a/tests/docker-sidecar-auth-config.test.mjs
+++ b/tests/docker-sidecar-auth-config.test.mjs
@@ -1,9 +1,10 @@
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import test from 'node:test';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 const root = resolve(import.meta.dirname, '..');
 
@@ -12,7 +13,7 @@ function readProjectFile(path) {
 }
 
 function runRealIpRenderer(value) {
-  const tempDir = mkdtempSync(join(tmpdir(), 'worldmonitor-realip-'));
+  const tempDir = createTempDir('worldmonitor-realip-');
   const outputPath = resolve(tempDir, 'nginx-realip.conf');
   const env = { ...process.env };
 

--- a/tests/docker-sidecar-auth-config.test.mjs
+++ b/tests/docker-sidecar-auth-config.test.mjs
@@ -1,10 +1,10 @@
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import test from 'node:test';
-import { createTempDir } from './helpers/temp-dir.mjs';
+import { createTempDir, removeTempDir } from './helpers/temp-dir.mjs';
 
 const root = resolve(import.meta.dirname, '..');
 
@@ -32,7 +32,7 @@ function runRealIpRenderer(value) {
   return {
     ...result,
     outputPath,
-    cleanup: () => rmSync(tempDir, { force: true, recursive: true }),
+    cleanup: () => removeTempDir(tempDir),
   };
 }
 

--- a/tests/helpers/chat-analyst-panel-harness.mjs
+++ b/tests/helpers/chat-analyst-panel-harness.mjs
@@ -1,10 +1,10 @@
 import { build } from 'esbuild';
-import { rmSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createBrowserEnvironment } from './runtime-config-panel-harness.mjs';
-import { createTempDir } from './temp-dir.mjs';
+import { createTempDir, removeTempDir } from './temp-dir.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..', '..');
@@ -159,7 +159,7 @@ async function loadChatAnalystPanel() {
   return {
     ChatAnalystPanel: mod.ChatAnalystPanel,
     cleanupBundle() {
-      rmSync(tempDir, { recursive: true, force: true });
+      removeTempDir(tempDir);
     },
   };
 }

--- a/tests/helpers/chat-analyst-panel-harness.mjs
+++ b/tests/helpers/chat-analyst-panel-harness.mjs
@@ -1,9 +1,10 @@
 import { build } from 'esbuild';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createBrowserEnvironment } from './runtime-config-panel-harness.mjs';
+import { createTempDir } from './temp-dir.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..', '..');
@@ -37,7 +38,7 @@ function defineGlobal(name, value) {
 }
 
 async function loadChatAnalystPanel() {
-  const tempDir = mkdtempSync(join(tmpdir(), 'wm-chat-analyst-panel-'));
+  const tempDir = createTempDir('wm-chat-analyst-panel-');
   const outfile = join(tempDir, 'ChatAnalystPanel.bundle.mjs');
 
   const stubModules = new Map([

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -1,9 +1,10 @@
 import { build } from 'esbuild';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createBrowserEnvironment } from './runtime-config-panel-harness.mjs';
+import { createTempDir } from './temp-dir.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..', '..');
@@ -46,7 +47,7 @@ async function loadCountryDeepDivePanel(options = {}) {
     fetchedAt: '',
     stages: [],
   });
-  const tempDir = mkdtempSync(join(tmpdir(), 'wm-country-deep-dive-'));
+  const tempDir = createTempDir('wm-country-deep-dive-');
   const outfile = join(tempDir, 'CountryDeepDivePanel.bundle.mjs');
   const resilienceWidgetStub = resilienceWidgetMode === 'import-reject'
     ? `

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -1,10 +1,10 @@
 import { build } from 'esbuild';
-import { rmSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createBrowserEnvironment } from './runtime-config-panel-harness.mjs';
-import { createTempDir } from './temp-dir.mjs';
+import { createTempDir, removeTempDir } from './temp-dir.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..', '..');
@@ -346,7 +346,7 @@ async function loadCountryDeepDivePanel(options = {}) {
   return {
     CountryDeepDivePanel: mod.CountryDeepDivePanel,
     cleanupBundle() {
-      rmSync(tempDir, { recursive: true, force: true });
+      removeTempDir(tempDir);
     },
   };
 }

--- a/tests/helpers/minimal-panel-harness.mjs
+++ b/tests/helpers/minimal-panel-harness.mjs
@@ -7,12 +7,12 @@
 // in-memory file rather than a real source file.
 
 import { build } from 'esbuild';
-import { rmSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createBrowserEnvironment } from './runtime-config-panel-harness.mjs';
-import { createTempDir } from './temp-dir.mjs';
+import { createTempDir, removeTempDir } from './temp-dir.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..', '..');
@@ -189,7 +189,7 @@ async function loadMinimalPanel() {
     getConstructorRunCount: () => mod.constructorRunCount,
     resetConstructorRunCount: mod.resetConstructorRunCount,
     cleanupBundle() {
-      rmSync(tempDir, { recursive: true, force: true });
+      removeTempDir(tempDir);
     },
   };
 }

--- a/tests/helpers/minimal-panel-harness.mjs
+++ b/tests/helpers/minimal-panel-harness.mjs
@@ -7,11 +7,12 @@
 // in-memory file rather than a real source file.
 
 import { build } from 'esbuild';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createBrowserEnvironment } from './runtime-config-panel-harness.mjs';
+import { createTempDir } from './temp-dir.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..', '..');
@@ -44,7 +45,7 @@ function defineGlobal(name, value) {
 }
 
 async function loadMinimalPanel() {
-  const tempDir = mkdtempSync(join(tmpdir(), 'wm-minimal-panel-'));
+  const tempDir = createTempDir('wm-minimal-panel-');
   const outfile = join(tempDir, 'MinimalPanel.bundle.mjs');
 
   // Virtual entry source — defines a minimal `extends Panel` subclass that

--- a/tests/helpers/runtime-config-panel-harness.mjs
+++ b/tests/helpers/runtime-config-panel-harness.mjs
@@ -1,11 +1,11 @@
 import { build } from 'esbuild';
-import { rmSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { createBrowserEnvironment } from './mini-dom.mts';
-import { createTempDir } from './temp-dir.mjs';
+import { createTempDir, removeTempDir } from './temp-dir.mjs';
 
 export { createBrowserEnvironment };
 
@@ -233,7 +233,7 @@ async function loadRuntimeConfigPanel() {
   return {
     RuntimeConfigPanel: mod.RuntimeConfigPanel,
     cleanupBundle() {
-      rmSync(tempDir, { recursive: true, force: true });
+      removeTempDir(tempDir);
     },
   };
 }

--- a/tests/helpers/runtime-config-panel-harness.mjs
+++ b/tests/helpers/runtime-config-panel-harness.mjs
@@ -1,10 +1,11 @@
 import { build } from 'esbuild';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { createBrowserEnvironment } from './mini-dom.mts';
+import { createTempDir } from './temp-dir.mjs';
 
 export { createBrowserEnvironment };
 
@@ -37,7 +38,7 @@ function createRuntimeState() {
 }
 
 async function loadRuntimeConfigPanel() {
-  const tempDir = mkdtempSync(join(tmpdir(), 'wm-runtime-config-panel-'));
+  const tempDir = createTempDir('wm-runtime-config-panel-');
   const outfile = join(tempDir, 'RuntimeConfigPanel.bundle.mjs');
 
   const stubModules = new Map([

--- a/tests/helpers/temp-dir.mjs
+++ b/tests/helpers/temp-dir.mjs
@@ -1,0 +1,91 @@
+// Temp directories that clean themselves up.
+//
+// Tests and scripts across this repo call `mkdtempSync(join(tmpdir(), '...'))`
+// and then delete the directory at the end of the test body. That shape leaks
+// in three ways, all of which were found accumulating in a developer's
+// `$TMPDIR` (~40,000 directories, oldest from May):
+//
+//   1. No delete at all — `mkdtempSync` imported, `rmSync` never was.
+//   2. A cleanup list that only some call sites register with. The worst case
+//      had 17 `makeTempDir()` calls and one `fixtures.push()`, so 16 leaked
+//      while `rmSync` sat in the file looking like cleanup existed.
+//   3. Delete placed after the assertions, so a FAILING test leaks. Shared
+//      harnesses with this shape leak once per failing consumer.
+//
+// `createTempDir` removes all three by construction: the directory is
+// registered for deletion at the moment it is created, so there is no second
+// call site to forget and no code path that skips it.
+//
+// Pass the `node:test` context `t` whenever one is in scope — cleanup then
+// runs at the end of that test, keeping runs isolated from each other. Without
+// `t` (module scope, shared harnesses, plain scripts) it falls back to a
+// process-exit sweep, which still covers thrown assertions and early returns.
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/** Directories awaiting the process-exit sweep. */
+const pending = new Set();
+let sweepInstalled = false;
+
+function installSweep() {
+  if (sweepInstalled) return;
+  sweepInstalled = true;
+  // 'exit' only permits synchronous work, which is why this uses rmSync.
+  process.on('exit', () => {
+    for (const dir of pending) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // Best effort: a temp dir we cannot remove must not mask the real
+        // exit code or the assertion failure that got us here.
+      }
+    }
+    pending.clear();
+  });
+}
+
+/**
+ * Create a temp directory under the OS temp dir that deletes itself.
+ *
+ * @param {string} prefix `mkdtemp` prefix, e.g. `'wm-seed-env-'`. Keep the
+ *   trailing dash so the random suffix stays readable.
+ * @param {{ after?: (fn: () => void) => void }} [t] `node:test` context. When
+ *   given, cleanup runs via `t.after()` at the end of that test instead of at
+ *   process exit.
+ * @returns {string} Absolute path to the new directory.
+ */
+export function createTempDir(prefix, t) {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  if (t && typeof t.after === 'function') {
+    t.after(() => {
+      pending.delete(dir);
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // See above — cleanup must never change a test's verdict.
+      }
+    });
+    return dir;
+  }
+  installSweep();
+  pending.add(dir);
+  return dir;
+}
+
+/**
+ * Delete a directory from `createTempDir` early, before its scheduled sweep.
+ * Only needed by tests that assert on the directory being gone.
+ *
+ * @param {string} dir Path previously returned by `createTempDir`.
+ */
+export function removeTempDir(dir) {
+  pending.delete(dir);
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** Directories still awaiting cleanup. Exposed for this helper's own tests. */
+export function pendingTempDirCount() {
+  return pending.size;
+}

--- a/tests/inventory-count-contracts.test.mjs
+++ b/tests/inventory-count-contracts.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -10,6 +10,7 @@ import {
   auditInventoryCountContracts,
   validateInventoryContractRegistry,
 } from '../scripts/check-inventory-count-contracts.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -72,7 +73,7 @@ function fixtureContract({ action = 'replace', classifications = ['parity'] } = 
 }
 
 function auditFixture(source, contractOptions) {
-  const rootDir = mkdtempSync(join(tmpdir(), 'wm-inventory-count-contract-'));
+  const rootDir = createTempDir('wm-inventory-count-contract-');
   writeFileSync(join(rootDir, 'fixture.test.mjs'), source);
   return auditInventoryCountContracts({ rootDir, contracts: fixtureContract(contractOptions) });
 }
@@ -325,7 +326,7 @@ describe('extensible inventory count contract audit', () => {
   });
 
   it('fails closed when a registered surface is missing', () => {
-    const rootDir = mkdtempSync(join(tmpdir(), 'wm-inventory-count-contract-missing-'));
+    const rootDir = createTempDir('wm-inventory-count-contract-missing-');
     const result = auditInventoryCountContracts({ rootDir, contracts: fixtureContract() });
     assert.ok(codes(result).includes('missing-surface'));
   });

--- a/tests/local-secret-dumps-check.test.mjs
+++ b/tests/local-secret-dumps-check.test.mjs
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
 import {
-  mkdtempSync,
+  
   symlinkSync,
   unlinkSync,
   writeFileSync,
@@ -16,8 +16,9 @@ import {
   findPushedSecretDumps,
   runLocalSecretDumpCheck,
 } from '../scripts/check-local-secret-dumps.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
-const makeTempRepo = () => mkdtempSync(join(tmpdir(), 'wm-env-dump-check-'));
+const makeTempRepo = () => createTempDir('wm-env-dump-check-');
 const guardScriptPath = fileURLToPath(
   new URL('../scripts/check-local-secret-dumps.mjs', import.meta.url),
 );

--- a/tests/openapi-capacity-report.test.mjs
+++ b/tests/openapi-capacity-report.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
@@ -20,6 +20,7 @@ import {
   sectionBreakdown,
   unreferencedComponentSchemas,
 } from '../scripts/openapi-capacity-report.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 // The <= 950,000-byte guard in tests/openapi-json-dedup.test.mjs only speaks the
 // moment it breaks. #4852, the food-stocks operation and the
@@ -439,7 +440,7 @@ describe('CLI', () => {
     });
 
   it('writes the report to --out, stdout and the job summary, and exits 0', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'wm-openapi-capacity-'));
+    const dir = createTempDir('wm-openapi-capacity-');
     const outPath = join(dir, 'capacity.json');
     const summaryPath = join(dir, 'summary.md');
 

--- a/tests/pro-test-vite-cache.test.mjs
+++ b/tests/pro-test-vite-cache.test.mjs
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { createHash } from 'node:crypto';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
@@ -10,6 +10,7 @@ import {
   hashLockfile,
   resolveProTestViteCacheDir,
 } from '../scripts/pro-test-vite-cache.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 describe('pro-test vite cacheDir (#6766)', () => {
   it('honours WM_PRO_TEST_VITE_CACHE over git and lockfile', () => {
@@ -65,7 +66,7 @@ describe('pro-test vite cacheDir (#6766)', () => {
   });
 
   it('falls back to the per-package vite cache when git is unavailable', () => {
-    const root = mkdtempSync(join(tmpdir(), 'wm-pro-test-vite-'));
+    const root = createTempDir('wm-pro-test-vite-');
     const resolved = resolveProTestViteCacheDir({
       env: {},
       proTestRoot: root,
@@ -76,7 +77,7 @@ describe('pro-test vite cacheDir (#6766)', () => {
   });
 
   it('reads package-lock.json from the pro-test root when contents are not injected', () => {
-    const root = mkdtempSync(join(tmpdir(), 'wm-pro-test-lock-'));
+    const root = createTempDir('wm-pro-test-lock-');
     const lockfile = '{"fromDisk":true}\n';
     writeFileSync(join(root, 'package-lock.json'), lockfile);
     const resolved = resolveProTestViteCacheDir({
@@ -91,7 +92,7 @@ describe('pro-test vite cacheDir (#6766)', () => {
   });
 
   it('does not point cacheDir at node_modules or a symlink of it', () => {
-    const root = mkdtempSync(join(tmpdir(), 'wm-pro-test-nosym-'));
+    const root = createTempDir('wm-pro-test-nosym-');
     mkdirSync(join(root, 'node_modules'));
     const resolved = resolveProTestViteCacheDir({
       env: {},

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1,10 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { createTempDir } from './helpers/temp-dir.mjs';
+import { createTempDir, removeTempDir } from './helpers/temp-dir.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -85,7 +85,7 @@ async function importPatchedTsModule(relPath, replacements) {
   return {
     module,
     cleanup() {
-      rmSync(tempDir, { recursive: true, force: true });
+      removeTempDir(tempDir);
     },
   };
 }

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1,9 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -76,7 +77,7 @@ async function importPatchedTsModule(relPath, replacements) {
     return targetPath ? `from '${pathToFileURL(targetPath).href}'` : match;
   });
 
-  const tempDir = mkdtempSync(join(tmpdir(), 'wm-ts-module-'));
+  const tempDir = createTempDir('wm-ts-module-');
   const tempPath = join(tempDir, basename(sourcePath));
   writeFileSync(tempPath, source);
 

--- a/tests/sebuf-query-param-contract.test.mjs
+++ b/tests/sebuf-query-param-contract.test.mjs
@@ -1,11 +1,12 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 
 import { collectQueryParamContractViolations } from '../scripts/lib/sebuf-query-param-contract.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const apiDir = resolve(root, 'docs/api');
@@ -35,7 +36,7 @@ const OPENAPI_NOOP_PARAMS = [
 ];
 
 function fixture() {
-  const root = mkdtempSync(join(tmpdir(), 'wm-sebuf-query-'));
+  const root = createTempDir('wm-sebuf-query-');
   mkdirSync(join(root, 'proto/worldmonitor/demo/v1'), { recursive: true });
   mkdirSync(join(root, 'server/worldmonitor/demo/v1'), { recursive: true });
   return root;

--- a/tests/seed-env-hermeticity.test.mjs
+++ b/tests/seed-env-hermeticity.test.mjs
@@ -34,7 +34,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -42,6 +42,7 @@ import { glob } from 'node:fs/promises';
 
 import { isTestRuntime } from '../scripts/_seed-utils.mjs';
 import { stripJsComments } from '../scripts/lib/js-source-structure.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SEED_UTILS_URL = pathToFileURL(join(REPO_ROOT, 'scripts', '_seed-utils.mjs')).href;
@@ -60,7 +61,7 @@ const envFileBody = (url) => `# fixture\nUPSTASH_REDIS_REST_URL=${url}\nUPSTASH_
  * list reached for.
  */
 function makeFixtureCheckout({ withLocalEnvFile, nested = false, only = null }) {
-  const outer = mkdtempSync(join(tmpdir(), 'wm-seed-env-'));
+  const outer = createTempDir('wm-seed-env-');
   // The fixture checkout sits INSIDE a temp dir that also holds a .env.local,
   // so every case doubles as a check that resolution stops at the checkout
   // boundary. `loadEnvFile` used to probe `<checkout>/../.env.local` and really

--- a/tests/temp-dir-helper.test.mjs
+++ b/tests/temp-dir-helper.test.mjs
@@ -1,0 +1,100 @@
+// Guards tests/helpers/temp-dir.mjs.
+//
+// The point of the helper is that cleanup survives a THROWN test. Asserting
+// that from inside a passing test proves nothing, so the exception cases run
+// in child processes whose temp-dir paths are printed on stdout and checked
+// from here after the child has exited.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createTempDir, pendingTempDirCount, removeTempDir } from './helpers/temp-dir.mjs';
+
+const helperUrl = new URL('./helpers/temp-dir.mjs', import.meta.url).href;
+
+/** Run `body` in a child node process; return {stdout, status}. */
+function runChild(body) {
+  const source = `import { createTempDir } from ${JSON.stringify(helperUrl)};\n${body}`;
+  const result = execFileSync(
+    process.execPath,
+    ['--input-type=module', '--eval', source],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] , env: { ...process.env } },
+  );
+  return result.trim();
+}
+
+/** Same, but the child is expected to exit non-zero. */
+function runFailingChild(body) {
+  const source = `import { createTempDir } from ${JSON.stringify(helperUrl)};\n${body}`;
+  try {
+    execFileSync(process.execPath, ['--input-type=module', '--eval', source], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { stdout: '', threw: false };
+  } catch (error) {
+    return { stdout: String(error.stdout ?? '').trim(), threw: true };
+  }
+}
+
+describe('createTempDir', () => {
+  it('creates a usable directory', (t) => {
+    const dir = createTempDir('wm-temp-helper-basic-', t);
+    writeFileSync(join(dir, 'probe.txt'), 'ok');
+    assert.ok(existsSync(join(dir, 'probe.txt')));
+  });
+
+  it('removes the directory when the test context ends', () => {
+    // Capture the path from a nested test run so we can assert after it ends.
+    let captured;
+    const fakeContext = {
+      hooks: [],
+      after(fn) {
+        this.hooks.push(fn);
+      },
+    };
+    captured = createTempDir('wm-temp-helper-ctx-', fakeContext);
+    assert.ok(existsSync(captured), 'directory should exist before cleanup');
+    assert.equal(fakeContext.hooks.length, 1, 'cleanup must be registered at creation');
+    for (const fn of fakeContext.hooks) fn();
+    assert.equal(existsSync(captured), false, 'directory should be gone after t.after ran');
+  });
+
+  it('registers for the exit sweep when no test context is given', () => {
+    const before = pendingTempDirCount();
+    const dir = createTempDir('wm-temp-helper-sweep-');
+    assert.equal(pendingTempDirCount(), before + 1);
+    removeTempDir(dir);
+    assert.equal(pendingTempDirCount(), before, 'removeTempDir must deregister');
+    assert.equal(existsSync(dir), false);
+  });
+
+  it('cleans up after a child process exits normally', () => {
+    const dir = runChild(
+      "const d = createTempDir('wm-temp-helper-child-'); console.log(d);",
+    );
+    assert.ok(dir.length > 0, 'child should print the temp dir path');
+    assert.equal(existsSync(dir), false, `child temp dir leaked: ${dir}`);
+  });
+
+  it('cleans up even when the child THROWS', () => {
+    const { stdout, threw } = runFailingChild(
+      "const d = createTempDir('wm-temp-helper-throw-'); console.log(d); throw new Error('boom');",
+    );
+    assert.equal(threw, true, 'child was supposed to fail');
+    assert.ok(stdout.length > 0, 'child should have printed the path before throwing');
+    assert.equal(existsSync(stdout), false, `temp dir leaked on throw: ${stdout}`);
+  });
+
+  it('cleans up when the child exits non-zero without throwing', () => {
+    const { stdout } = runFailingChild(
+      "const d = createTempDir('wm-temp-helper-exit1-'); console.log(d); process.exitCode = 1;",
+    );
+    assert.ok(stdout.length > 0);
+    assert.equal(existsSync(stdout), false, `temp dir leaked on exit 1: ${stdout}`);
+  });
+});

--- a/tests/temp-dir-helper.test.mjs
+++ b/tests/temp-dir-helper.test.mjs
@@ -7,8 +7,8 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { existsSync, writeFileSync } from 'node:fs';
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -49,15 +49,16 @@ describe('createTempDir', () => {
   });
 
   it('removes the directory when the test context ends', () => {
-    // Capture the path from a nested test run so we can assert after it ends.
-    let captured;
+    // Drive the t.after path with a stand-in context so the registered hook can
+    // be fired here and its effect asserted — a real `t` would only run its
+    // hooks after this test had already returned.
     const fakeContext = {
       hooks: [],
       after(fn) {
         this.hooks.push(fn);
       },
     };
-    captured = createTempDir('wm-temp-helper-ctx-', fakeContext);
+    const captured = createTempDir('wm-temp-helper-ctx-', fakeContext);
     assert.ok(existsSync(captured), 'directory should exist before cleanup');
     assert.equal(fakeContext.hooks.length, 1, 'cleanup must be registered at creation');
     for (const fn of fakeContext.hooks) fn();
@@ -96,5 +97,64 @@ describe('createTempDir', () => {
     );
     assert.ok(stdout.length > 0);
     assert.equal(existsSync(stdout), false, `temp dir leaked on exit 1: ${stdout}`);
+  });
+});
+
+/**
+ * Find `rmSync(<v>, …)` where `<v>` came from `createTempDir`. That deletes the
+ * directory but leaves its path registered in the exit sweep, so the sweep
+ * retries an already-gone path forever. `removeTempDir` deregisters; a bare
+ * `rmSync` does not.
+ *
+ * @param {string} source File contents.
+ * @returns {string[]} Names of the offending variables.
+ */
+function findStaleRegistrations(source) {
+  const owned = new Set(
+    [...source.matchAll(/(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*createTempDir\(/g)].map(m => m[1]),
+  );
+  if (!owned.size) return [];
+  return [...source.matchAll(/\brmSync\(\s*([A-Za-z_$][\w$]*)\s*[,)]/g)]
+    .map(m => m[1])
+    .filter(name => owned.has(name));
+}
+
+describe('no stale exit-sweep registrations', () => {
+  // Positive controls first: a scan that only ever asserts "nothing found"
+  // passes just as happily when the detector is broken as when the repo is clean.
+  it('DETECTS a bare rmSync on a createTempDir result', () => {
+    const bad = "const dir = createTempDir('x-');\nrmSync(dir, { recursive: true, force: true });";
+    assert.deepEqual(findStaleRegistrations(bad), ['dir']);
+  });
+
+  it('DETECTS it inside a cleanup callback', () => {
+    const bad = "const tempDir = createTempDir('x-');\nreturn { cleanup() { rmSync(tempDir, { force: true }); } };";
+    assert.deepEqual(findStaleRegistrations(bad), ['tempDir']);
+  });
+
+  it('ACCEPTS removeTempDir, and ignores rmSync on unrelated paths', () => {
+    const good = "const dir = createTempDir('x-');\nrmSync(someOtherPath, { force: true });\nremoveTempDir(dir);";
+    assert.deepEqual(findStaleRegistrations(good), []);
+  });
+
+  it('finds none in the repo', () => {
+    const files = execSync(
+      "grep -rl 'createTempDir' tests scripts --include='*.mjs' --include='*.mts' --include='*.js' 2>/dev/null || true",
+      { encoding: 'utf8', cwd: fileURLToPath(new URL('..', import.meta.url)), maxBuffer: 1 << 24 },
+    ).trim().split('\n').filter(Boolean);
+
+    assert.ok(files.length >= 6, `expected the helper to have consumers, found ${files.length}`);
+
+    const offenders = [];
+    for (const rel of files) {
+      // This file's positive controls are deliberately-bad source held in string
+      // literals; the detector cannot tell them from real code, and should not.
+      if (rel.endsWith('tests/temp-dir-helper.test.mjs')) continue;
+      const abs = fileURLToPath(new URL(`../${rel}`, import.meta.url));
+      for (const name of findStaleRegistrations(readFileSync(abs, 'utf8'))) {
+        offenders.push(`${rel}: rmSync(${name}) — use removeTempDir(${name})`);
+      }
+    }
+    assert.deepEqual(offenders, [], `stale registrations:\n${offenders.join('\n')}`);
   });
 });

--- a/tests/vite-env-secret-guard.test.mjs
+++ b/tests/vite-env-secret-guard.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -8,8 +8,9 @@ import {
   findViteSecretEnvVars,
   runViteEnvSecretGuard,
 } from '../scripts/check-vite-env-secrets.mjs';
+import { createTempDir } from './helpers/temp-dir.mjs';
 
-const makeTempRepo = () => mkdtempSync(join(tmpdir(), 'wm-vite-env-guard-'));
+const makeTempRepo = () => createTempDir('wm-vite-env-guard-');
 
 describe('VITE secret environment guard (#5213)', () => {
   it('identifies secret-looking client-prefixed variables without flagging public browser configuration', () => {


### PR DESCRIPTION
## Problem

Test temp directories accumulate without bound in `$TMPDIR`. On a dev machine this reached **~40,000 directories**, oldest from May. A single `node --test` run over the 14 affected files creates **4,026** of them.

The second-order cost was worse than the disk: Spotlight was indexing `~/tmp` (948,438 items — 7.7× the rest of the home directory combined), which pegged `mds_stores` at a full core continuously.

## Three shapes, one root cause

| | shape | files |
|---|---|---|
| 1 | No cleanup at all — `mkdtempSync` imported, `rmSync` never was | 9 |
| 2 | Cleanup list only one call site registers with | 1 |
| 3 | Cleanup after the assertions, so a **failing** test leaks | 8 |

Shape 2 is `tests/bootstrap-worktree.test.mjs`, and it's the interesting one — it *has* `rmSync`:

```
17  makeTempDir() call sites      (lines 33…390)
 1  fixtures.push(base)           (line 391)
    for (const dir of fixtures) rmSync(...)   (line 355)
```

The array cleanup iterates receives exactly one push. The other 16 are never registered. `rmSync` being present in the file is what makes this invisible to a casual grep.

Shape 3 includes four shared panel harnesses under `tests/helpers/`, so every consuming test inherited the leak on failure.

## Fix

`createTempDir(prefix, t)` registers cleanup **at the moment the directory is created**. That removes all three shapes by construction: there is no second call site to forget, and no code path that skips it.

- With a `node:test` context → `t.after()`, so cleanup is scoped to that test and runs keep each other isolated.
- Without one (module scope, shared harnesses, plain scripts) → a process-exit sweep, which still covers thrown assertions and early returns.

28 call sites across 18 files. `bootstrap-worktree` needed a single edit — all 17 of its sites route through one factory.

## Verification

**Behaviour unchanged.** Per-file pass/fail, before vs after, all 14 files:

```
13 files fully green (252 tests)
redis-caching  0/78  ← unchanged; pre-existing ERR_MODULE_NOT_FOUND on
                       server/_shared/seed-envelope in an unbootstrapped
                       worktree, unrelated to this change
```

**Leak fixed**, measured per-prefix to avoid contamination from other sessions running tests concurrently on the same machine:

```
wm-env-dump-check-*            before=264  after=264   (8 tests)
wm-inventory-count-contract-*  before=616  after=616   (25 tests)
```

Zero new directories. Full-suite delta was +32 vs the baseline's +4,026, and that residue traced to `wm-ts-module-` / `wm-prepush-hook-` from other sessions, not from anything converted here.

**The new tests can fail.** Breaking the helper's sweep registration turns 4 of 6 red:

```
✖ registers for the exit sweep when no test context is given
✖ cleans up after a child process exits normally
✖ cleans up even when the child THROWS
✖ cleans up when the child exits non-zero without throwing
```

The exception cases run the throwing code in **child processes** that print their temp path before dying, so cleanup-on-failure is observed from outside rather than asserted from inside a test that passed anyway.

## Out of scope

`.tmpXXXXXX` directories in the same `$TMPDIR` are **not from this repo**. They match the Rust `tempfile` crate's default `Builder` exactly — `lib.rs:231` prefix `".tmp"`, `lib.rs:195` `NUM_RAND_CHARS = 6`, empty suffix. Every `mkdtemp` call in this repo uses a named prefix, and no Node dependency uses `.tmp` either (Convex uses `"convex"`, Playwright `"playwright-tracing-"`). `tempfile 3.26.0` is in `src-tauri/Cargo.lock`.

https://claude.ai/code/session_01XaJtVVyMAyvFewmzgT74vq
