### PR TITLE
test(pro): dist-gate Sentry chunk assets exactly

### DIFF
--- a/tests/dashboard-build-guards.test.mjs
+++ b/tests/dashboard-build-guards.test.mjs
@@ -175,6 +175,28 @@ describe('built-output guard contract', () => {
       /guardBuiltOutput\(PRO_BUILT_MARKER/,
       'guardProBuiltOutput must ask the shared primitive about the /pro marker',
     );
+
+    const sentrySource = readFileSync(resolve(repoRoot, 'tests/pro-sentry-chunk.test.mjs'), 'utf8');
+    assert.match(
+      sentrySource,
+      /from '\.\/_lib\/built-output-guard\.mjs'/,
+      'the pro Sentry chunk suite must use the shared built-output primitive',
+    );
+    assert.match(
+      sentrySource,
+      /skip: shouldSkipBuiltOutput\(ASSETS_DIR\)/,
+      'the pro Sentry chunk suite must skip specifically when public/pro/assets is absent',
+    );
+    assert.match(
+      sentrySource,
+      /guardBuiltOutput\(ASSETS_DIR, undefined, REBUILD_HINT\)/,
+      'the pro Sentry chunk suite must fail closed on the same assets path when CI expects built output',
+    );
+    assert.match(
+      sentrySource,
+      /Run `npm run build:pro` first/,
+      'the pro Sentry chunk failure must name the /pro build command',
+    );
   });
 
   it('keeps the /pro build-output existence check in the freshness workflow', () => {

--- a/tests/pro-sentry-chunk.test.mjs
+++ b/tests/pro-sentry-chunk.test.mjs
@@ -3,10 +3,12 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { guardBuiltOutput, shouldSkipBuiltOutput } from './_lib/built-output-guard.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PRO_DIR = resolve(__dirname, '..', 'public', 'pro');
 const ASSETS_DIR = resolve(PRO_DIR, 'assets');
+const REBUILD_HINT = 'Run `npm run build:pro` first';
 
 // The pro-test build injects this nonce onto its static <link>/<script> tags
 // (STATIC_SCRIPT_NONCE in pro-test/vite.config.ts) so the strict CSP admits the
@@ -31,7 +33,9 @@ function entryChunksFor(html) {
     .filter((name) => !/^sentry-/.test(name));
 }
 
-describe('pro Sentry chunk split contract (#5019)', () => {
+describe('pro Sentry chunk split contract (#5019)', { skip: shouldSkipBuiltOutput(ASSETS_DIR) }, () => {
+  guardBuiltOutput(ASSETS_DIR, undefined, REBUILD_HINT);
+
   const sentryChunks = readdirSync(ASSETS_DIR).filter((f) => /^sentry-[A-Za-z0-9_-]+\.js$/.test(f));
   const indexHtml = readFileSync(resolve(PRO_DIR, 'index.html'), 'utf8');
   const welcomeHtml = readFileSync(resolve(PRO_DIR, 'welcome.html'), 'utf8');


### PR DESCRIPTION
Fixes #7143.

`tests/pro-sentry-chunk.test.mjs` was reading `public/pro/assets` during suite construction and throwing a bare ENOENT on an unbuilt tree.

This change uses the shared built-output primitive directly against `ASSETS_DIR`:

- unbuilt local trees skip the suite cleanly;
- `WM_EXPECT_BUILT_OUTPUT=1` fails closed and names the actual missing `public/pro/assets` path plus `npm run build:pro`;
- built-tree assertions are otherwise unchanged;
- `tests/dashboard-build-guards.test.mjs` now pins this suite's wiring to the shared guard, the exact assets path, and rebuild hint.

This intentionally targets `ASSETS_DIR` rather than the broader `/pro` welcome-page marker so the failure satisfies #7143's acceptance requirement and cannot turn a missing assets directory into a later `readdirSync` ENOENT.

Validation performed here: inspected the final branch diff against current `main`; only the two intended test files changed. Full runtime verification is left to the repository CI because this chat environment cannot execute the repository checkout.