### PR TITLE
fix(cross-strait): stamp lastAttemptAt so a failing source dates its own verdict

### DIFF
--- a/scripts/cross-strait-activity/adapters.mjs
+++ b/scripts/cross-strait-activity/adapters.mjs
@@ -2104,6 +2104,10 @@ export function buildCrossStraitActivitySnapshot({
       transportStatus: mndOutcome?.ok ? 'fresh' : 'error',
       requestCount: mndOutcome?.requestCount ?? 0,
       errorCodes: mndOutcome?.errorCodes ?? [],
+      // WHEN this verdict was produced. lastSuccessAt is retained across failing
+      // runs by design, so on its own an errored record cannot say whether the
+      // seeder just ran or stopped running days ago — see the japan-mod note.
+      lastAttemptAt: generatedAt,
       lastSuccessAt: mndOutcome?.ok
         ? generatedAt
         : latestSourceSuccess(previousSnapshot, 'taiwan-mnd'),
@@ -2134,6 +2138,16 @@ export function buildCrossStraitActivitySnapshot({
         ? { proxyControlProbe: japanOutcome.proxyControlProbe }
         : {}),
       errorCodes: japanOutcome?.errorCodes ?? [],
+      // The per-source key publishes this object alone — the snapshot's
+      // generatedAt never reaches it — so a failing record carried only a
+      // lastSuccessAt that is deliberately NOT re-dated on failure. On
+      // 2026-08-26 japan-mod had been erroring for 6.8 days behind a rejected
+      // proxy credential, and the stored record could not distinguish "the
+      // seeder ran 60 minutes ago and the upstream refused it" from "the seeder
+      // has been dead for a week": both look like error + a week-old success.
+      // Answering it required reading Railway logs. Stamping the attempt makes
+      // the record self-sufficient.
+      lastAttemptAt: generatedAt,
       lastSuccessAt: japanOutcome?.ok
         ? generatedAt
         : previousJapanSource?.lastSuccessAt ?? latestSourceSuccess(previousSnapshot, 'japan-mod'),

--- a/tests/cross-strait-activity.test.mts
+++ b/tests/cross-strait-activity.test.mts
@@ -1761,6 +1761,17 @@ describe('quantified cross-Strait activity (#5575)', () => {
     // control tunnel is transport telemetry, not a Japan MOD request.
     assert.equal(japan?.requestCount, 2);
     assert.equal(japan?.lastSuccessAt, null);
+    // A failing source must still date its own attempt. The per-source Redis key
+    // publishes this object alone, so without lastAttemptAt an errored record is
+    // identical whether the seeder ran seconds ago or died days ago — the exact
+    // ambiguity that made the 2026-08-26 japan-mod proxy outage unreadable from
+    // stored state (it took Railway logs to establish the seeder was still live).
+    assert.equal(
+      japan?.lastAttemptAt,
+      snapshot.generatedAt,
+      'a failing run must stamp lastAttemptAt with this run time',
+    );
+    assert.notEqual(japan?.lastAttemptAt, japan?.lastSuccessAt);
   });
 
   it('uses the configured proxy tunnel for the Japan MOD control probe', async () => {


### PR DESCRIPTION
## The outage is a credential, not a bug

`crossStraitActivityJapanMod` has read `SEED_ERROR` since **2026-08-19T23:45:10Z — 6.8 days**. Reproduced live against the current configuration, using the repo's own `parseProxyConfig` + `proxyConnectTunnel`:

```
parsed host : gate.decodo.com
has auth    : true
CONNECT     : FAILED
  message   : Proxy CONNECT: HTTP/1.1 407 Proxy Authentication Required
```

The direct path takes HTTP 403 (Japan MOD refuses the datacenter range) and the proxy fallback is rejected at CONNECT. **This clears when the Decodo credential is renewed — nothing in this PR restores the feed.**

## What this PR fixes is that the record couldn't be read

The per-source key publishes the source object **alone** — the snapshot's `generatedAt` never reaches it — and `lastSuccessAt` is deliberately retained across failing runs rather than re-dated. So the published record was:

```
transportStatus     error
lastSuccessAt       2026-08-19T23:45:10.517Z   (163h ago)
proxyFailureReason  PROXY_AUTH_FAILED
```

That is **identical** whether the seeder ran sixty seconds ago and the upstream refused it, or the seeder had been dead for a week. Those two states need opposite responses — renew a credential vs. resurrect a service — and the record chose neither. Settling it required Railway logs:

```
[Cross-Strait-Activity] Skipped, last seeded 60min ago (interval: 180min)
```

Both source records now stamp `lastAttemptAt: generatedAt`. `taiwan-mnd` gets it too — same shape, same ambiguity, and a field present on only one of two sibling records is a field nobody trusts.

## Verification

The assertion goes on the **existing** proxy-forbidden test, which already drove a failing run and asserted `lastSuccessAt === null` — precisely the state that needed a companion timestamp.

Mutation-checked: removing the japan-mod stamp fails *"a failing run must stamp lastAttemptAt with this run time"*.

**124 tests pass, 0 fail** across cross-strait-activity, its shipping and production-registration suites, and cross-strait-entity-decode. Biome clean.

## Action still needed

The Decodo proxy credential must be renewed or rotated for the feed to recover.
