### PR TITLE
fix(stock-connect): date the content token from the exchanges that answered

### DIFF
--- a/scripts/seed-china-stock-connect.mjs
+++ b/scripts/seed-china-stock-connect.mjs
@@ -65,8 +65,30 @@ export function chinaStockConnectContentMeta(snapshot) {
   // to be able to raise the alarm on its own.
   const dates = [snapshot?.northbound?.tradeDate, snapshot?.margin?.tradeDate]
     .filter((value) => typeof value === 'string' && value !== '');
-  if (dates.length === 0) return tokensToContentMeta([]);
-  return tokensToContentMeta([dates.reduce((a, b) => (a < b ? a : b))]);
+  if (dates.length > 0) {
+    return tokensToContentMeta([dates.reduce((a, b) => (a < b ? a : b))]);
+  }
+  // Both headline dates gone means an EXCHANGE went dark, not a series: the
+  // combined date is null the instant either exchange is missing
+  // (combineByTradeDate -> EXCHANGE_UNAVAILABLE), and one exchange failing takes
+  // BOTH series down together, so the series-level fallback above has nothing
+  // left to land on. Fall through to the exchanges that DID answer.
+  //
+  // Without this, 2026-08-26 published sse-northbound at that day's session
+  // (turnover Y119.8bn) while SZSE sat behind a rejected proxy credential, and
+  // health read STALE_CONTENT "no dated item; scored stale" — pointing at a
+  // frozen upstream when nothing was frozen. The partial is already reported,
+  // by status: degraded and by the per-source EXCHANGE_UNAVAILABLE reason;
+  // content-age answers a different question, whether the data still advances.
+  //
+  // Still the OLDEST, so the freeze guard is unchanged: a source that stops
+  // advancing drags the token back however fresh its siblings are.
+  const sourceDates = (Array.isArray(snapshot?.sources) ? snapshot.sources : [])
+    .filter((source) => source?.transportStatus === 'ok')
+    .map((source) => source?.tradeDate)
+    .filter((value) => typeof value === 'string' && value !== '');
+  if (sourceDates.length === 0) return tokensToContentMeta([]);
+  return tokensToContentMeta([sourceDates.reduce((a, b) => (a < b ? a : b))]);
 }
 
 export async function buildChinaStockConnectSeedSnapshot({

--- a/tests/china-stock-connect.test.mts
+++ b/tests/china-stock-connect.test.mts
@@ -621,6 +621,55 @@ describe('China Stock Connect northbound + margin (#6155)', () => {
       assert.equal(partial.newestItemAt, Date.parse('2026-08-04T00:00:00.000Z'));
       assert.equal(chinaStockConnectContentMeta({}), null);
     });
+
+    it('anchors on the answering exchanges when one exchange takes both series down', () => {
+      // The series-level fallback above assumes ONE series lost its date. An
+      // exchange going dark is different: combineByTradeDate nulls the combined
+      // date the instant either exchange is missing, so a single failed exchange
+      // empties northbound AND margin together and leaves that fallback nothing
+      // to land on. Observed 2026-08-26 — SSE published that day's session while
+      // SZSE sat behind a rejected proxy credential, and health read
+      // STALE_CONTENT "no dated item" with nothing actually frozen.
+      const exchangeDown = chinaStockConnectContentMeta({
+        northbound: { tradeDate: null },
+        margin: { tradeDate: null },
+        sources: [
+          { id: 'sse-northbound', transportStatus: 'ok', tradeDate: '2026-08-26' },
+          { id: 'sse-margin', transportStatus: 'ok', tradeDate: '2026-08-25' },
+          { id: 'szse-northbound', transportStatus: 'error', tradeDate: null },
+          { id: 'szse-margin', transportStatus: 'error', tradeDate: null },
+        ],
+      });
+      // Oldest of the answering sources — the freeze guard is unchanged.
+      assert.equal(exchangeDown.newestItemAt, Date.parse('2026-08-25T00:00:00.000Z'));
+
+      // A source that stops advancing still drags the token back, even while a
+      // sibling is current: partial coverage must not become a freeze blindspot.
+      const frozenSurvivor = chinaStockConnectContentMeta({
+        northbound: { tradeDate: null },
+        margin: { tradeDate: null },
+        sources: [
+          { id: 'sse-northbound', transportStatus: 'ok', tradeDate: '2026-08-26' },
+          { id: 'sse-margin', transportStatus: 'ok', tradeDate: '2026-06-01' },
+          { id: 'szse-northbound', transportStatus: 'error', tradeDate: null },
+        ],
+      });
+      assert.equal(frozenSurvivor.newestItemAt, Date.parse('2026-06-01T00:00:00.000Z'));
+
+      // A failed source must never date the token — otherwise a total outage
+      // that retained a stale tradeDate would publish as fresh content.
+      assert.equal(
+        chinaStockConnectContentMeta({
+          northbound: { tradeDate: null },
+          margin: { tradeDate: null },
+          sources: [
+            { id: 'sse-northbound', transportStatus: 'error', tradeDate: '2026-08-26' },
+            { id: 'szse-northbound', transportStatus: 'error', tradeDate: '2026-08-26' },
+          ],
+        }),
+        null,
+      );
+    });
   });
 
   describe('request discipline', () => {


### PR DESCRIPTION
`chinaStockConnect` reads `STALE_CONTENT` — *"no dated item; scored stale"* — while SSE is publishing the current session.

## The evidence

```
sse-northbound   ok      tradeDate=2026-08-26   turnover ¥119.8bn
sse-margin       ok      tradeDate=2026-08-25
szse-northbound  error   errorCode=HTTP_407  fallbackReason=ETIMEDOUT
szse-margin      error   errorCode=HTTP_407

seed-meta: newestItemAt=null, maxContentAgeMin=20160  →  STALE_CONTENT
```

**Nothing is frozen.** SZSE sits behind a rejected proxy credential — the direct leg times out, the proxy leg returns 407 — and the content-age token has no date to carry, so a partial-coverage outage reports as stale data. An operator triaging `STALE_CONTENT` goes looking for a dead upstream feed; the actual fault is a proxy credential.

## The series fallback was supposed to cover this

Its own test says so:

> *"A series with no date at all falls back to the one that has one; the missing series is already reported unavailable and degrades status."*

That holds when **one series** loses its date. An **exchange** going dark is a different shape: `combineByTradeDate` nulls the combined date the instant either exchange is missing (`adapters.mjs:803` — the `EXCHANGE_UNAVAILABLE` early return carries no `tradeDate` at all), and one failed exchange empties `northbound` **and** `margin` together. Both headline dates go null in the same run, and the fallback has nothing left to land on.

## The fix

The token now falls through to the sources that answered, **still anchored on the oldest**. The freeze guard the original comment was written to protect is unchanged — a source that stops advancing drags the token back however fresh its siblings are — and in the healthy case the value is identical, since the oldest of the two combined series and the oldest of the four answering sources are the same date.

Only `transportStatus === 'ok'` sources may date the token. A failed source that retained a stale `tradeDate` must never make the content look fresh; that is the one way this fallback could have turned a total outage into a green light, and it has its own test.

Partial coverage is still reported — `status: degraded`, the per-source `EXCHANGE_UNAVAILABLE` reason, and `chinaCoverage`. Content-age answers a different question: whether the data still advances.

## Verification

Mutation-checked: dropping the `transportStatus` filter fails the outage test.

**185 tests pass, 0 fail** across china-stock-connect, china-coverage-health and health-classify. Biome clean.

## This fixes the misclassification, not the outage

SZSE recovers when the **Decodo proxy credential is renewed** — the same credential that has `crossStraitActivityJapanMod` down 6.8 days (#7177). `SZSE_PROXY_URL` is unset, so SZSE falls back to the shared `PROXY_URL`: same host, same auth.
