### PR TITLE
fix(fred): retry the direct leg on a transient 5xx instead of dropping the series

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1268,6 +1268,46 @@ export function isTransientProxyError(message) {
 
 const FRED_JSON_HEADERS = { Accept: 'application/json', 'User-Agent': CHROME_UA };
 
+// FRED's own edge returns sporadic 5xx on individual series. Observed
+// 2026-08-26: four consecutive 24/24 runs, then `FRED T10Y2Y: fetch failed —
+// direct: HTTP 502` and the same for UNRATE, publishing 22/24 — enough to trip
+// health's minRecordCount of 24 for the whole hour. Both series answered 200
+// when queried directly minutes later, and adjacent runs fetched them fine.
+//
+// Deliberately status-only, and deliberately NOT reusing isTransientProxyError:
+// that predicate also matches timeouts and socket tears, and a direct leg that
+// timed out has already burned its 20s budget — retrying it would double the
+// worst case inside runSeed's fetch-phase deadline for a leg that is plainly
+// broken. A 5xx fails fast, so this retry costs a few hundred milliseconds.
+const FRED_DIRECT_ATTEMPTS = 2;
+function isRetriableFredStatus(status) {
+  return Number.isInteger(status) && status >= 500 && status <= 599;
+}
+
+// Direct FRED fetch with a bounded retry on a fast-failing 5xx. Shared by the
+// proxy-fallback path and the no-proxy path: a transient 502 is transient
+// regardless of which leg reached it, and having only one of the two retry is
+// how the asymmetry below went unnoticed — the proxy leg already retried three
+// times while its own fallback got a single attempt.
+async function fredDirectFetchJson(url) {
+  let lastError;
+  for (let attempt = 1; attempt <= FRED_DIRECT_ATTEMPTS; attempt += 1) {
+    try {
+      const r = await fetch(url, { headers: FRED_JSON_HEADERS, signal: AbortSignal.timeout(20_000) });
+      if (r.ok) return await r.json();
+      throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
+    } catch (error) {
+      lastError = error;
+      if (attempt < FRED_DIRECT_ATTEMPTS && isRetriableFredStatus(error?.status)) {
+        await new Promise((resolve) => setTimeout(resolve, 350 * attempt + Math.random() * 250));
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw lastError;
+}
+
 // Fetch JSON from a FRED URL, routing through proxy when available.
 // Proxy-first: FRED consistently blocks/throttles Railway datacenter IPs,
 // so try proxy first to avoid 20s timeout on every direct attempt.
@@ -1291,16 +1331,12 @@ export async function fredFetchJson(url, proxyAuth) {
     }
     console.warn(`  [fredFetch] proxy failed after retries (${lastProxyErr?.message}) — retrying direct`);
     try {
-      const r = await fetch(url, { headers: FRED_JSON_HEADERS, signal: AbortSignal.timeout(20_000) });
-      if (r.ok) return r.json();
-      throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
+      return await fredDirectFetchJson(url);
     } catch (directErr) {
       throw Object.assign(new Error(`direct: ${directErr.message}`), { cause: directErr });
     }
   }
-  const r = await fetch(url, { headers: FRED_JSON_HEADERS, signal: AbortSignal.timeout(20_000) });
-  if (r.ok) return r.json();
-  throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
+  return fredDirectFetchJson(url);
 }
 
 // Fetch JSON from an IMF DataMapper URL, direct-first with proxy fallback.

--- a/tests/fred-proxy-transient-classify.test.mjs
+++ b/tests/fred-proxy-transient-classify.test.mjs
@@ -14,6 +14,55 @@ import { CHROME_UA, fredFetchJson, isTransientProxyError } from '../scripts/_see
 
 const originalFetch = globalThis.fetch;
 
+// The direct leg is the LAST leg — when it drops a series, that series is gone
+// for the whole cycle. On 2026-08-26 FRED returned `direct: HTTP 502` for
+// T10Y2Y and UNRATE, publishing 22/24 and tripping health's minRecordCount of
+// 24, while four adjacent runs fetched 24/24 and both series answered 200 when
+// queried moments later. The proxy leg already retried three times; its own
+// fallback got exactly one attempt.
+test('direct FRED leg retries a transient 5xx instead of dropping the series', async (t) => {
+  t.after(() => { globalThis.fetch = originalFetch; });
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) return { ok: false, status: 502, json: async () => ({}) };
+    return { ok: true, status: 200, json: async () => ({ observations: [{ date: '2026-08-25', value: '0.47' }] }) };
+  };
+  const out = await fredFetchJson('https://api.stlouisfed.org/fred/series/observations?series_id=T10Y2Y');
+  assert.equal(calls, 2, 'a 502 must be retried once');
+  assert.equal(out.observations[0].value, '0.47');
+});
+
+test('direct FRED leg does NOT retry a 4xx — a bad series id never fixes itself', async (t) => {
+  t.after(() => { globalThis.fetch = originalFetch; });
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return { ok: false, status: 400, json: async () => ({}) };
+  };
+  await assert.rejects(
+    () => fredFetchJson('https://api.stlouisfed.org/fred/series/observations?series_id=NOPE'),
+    /HTTP 400/,
+  );
+  assert.equal(calls, 1, 'a 4xx must fail fast, not burn a retry');
+});
+
+test('direct FRED leg does NOT retry a timeout — it has already burned its budget', async (t) => {
+  t.after(() => { globalThis.fetch = originalFetch; });
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    throw Object.assign(new Error('The operation was aborted due to timeout'), { name: 'TimeoutError' });
+  };
+  await assert.rejects(
+    () => fredFetchJson('https://api.stlouisfed.org/fred/series/observations?series_id=T10Y2Y'),
+    /timeout/i,
+  );
+  // Retrying a 20s timeout would double the worst case inside runSeed's
+  // fetch-phase deadline for a leg that is plainly broken.
+  assert.equal(calls, 1, 'a timeout must not be retried on the direct leg');
+});
+
 test('fredFetchJson direct FRED fallback sends a User-Agent header', async (t) => {
   t.after(() => { globalThis.fetch = originalFetch; });
   let seenHeaders = null;


### PR DESCRIPTION
`fredRatesSeeder` reads `COVERAGE_PARTIAL` at 22/24. The payload names the casualties itself — `missingSeriesIds: ['T10Y2Y', 'UNRATE']` — and the seeder logs say why:

```
FRED series: 24/24
FRED series: 24/24
FRED series: 24/24
FRED series: 24/24
FRED series: 21/24
FRED T10Y2Y: fetch failed — direct: HTTP 502
FRED UNRATE: fetch failed — direct: HTTP 502
FRED series: 22/24
```

**Nothing is wrong with either series.** Queried directly minutes later, both answered 200 — `T10Y2Y` latest 2026-08-25 (0.47), `UNRATE` latest 2026-07-01 (4.1) — and four adjacent runs fetched 24/24. FRED's edge returns sporadic 5xx on individual series, and health's `minRecordCount: 24` turns one such blip into an hour of `COVERAGE_PARTIAL`.

## The asymmetry

In `fredFetchJson`, the **proxy leg retries three times with backoff** and its own **direct fallback got exactly one attempt**:

```js
for (let attempt = 1; attempt <= 3; attempt++) {   // proxy: 3 tries
  try { return await httpsProxyFetchJson(url, proxyAuth); } catch { … }
}
// …then, once:
const r = await fetch(url, …);
if (r.ok) return r.json();
throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
```

The direct leg is the **last** leg — when it drops a series, that series is gone for the cycle — so the leg with no second chance was the one that most needed it. Both the proxy-fallback path and the no-proxy path now share one helper, because a transient 502 is transient regardless of which leg reached it, and having only one of the two retry is how this stayed invisible.

## Two deliberate non-retries, both tested

| case | behavior | why |
|---|---|---|
| **4xx** | fail fast | a bad series id or rejected key never fixes itself; a retry only delays a real error |
| **timeout** | fail fast | `isTransientProxyError` *would* classify it transient, but a direct leg that timed out already spent its 20s budget — retrying doubles the worst case inside `runSeed`'s fetch-phase deadline for a leg that is plainly broken |

Restricting the retry to a fast-failing **status** keeps the added cost at a few hundred milliseconds, which matters because `FRED_CONCURRENCY` is sized (12 — two waves for 24 series) to stay inside that same deadline.

## Verification

Mutation-checked: setting `FRED_DIRECT_ATTEMPTS` to 1 fails *"a 502 must be retried once"*.

**28 tests pass, 0 fail** across fred-proxy-transient-classify, seed-economy-fred-concurrency, seeder-content-age-coverage, and the WTO resilience suite that shares this helper. Biome clean.
