### PR TITLE
test(map): guard that a drag costs O(1) overlay rebuilds, not one per pointer event (#7145)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -614,9 +614,11 @@ jobs:
       # One invocation for all three smoke specs: each `playwright test` run
       # boots its own vite dev server (reuseExistingServer is false), so three
       # separate steps paid three boots; the specs are independent and share
-      # VITE_VARIANT=full. The set includes the news-budget guard (#5376) and
-      # both bootstrap request-budget guards (#7046 energy on-demand, #7045 U5
-      # hydration reuse) — named explicitly because nothing in CI runs the e2e/
+      # VITE_VARIANT=full. The set includes the news-budget guard (#5376), both
+      # bootstrap request-budget guards (#7046 energy on-demand, #7045 U5
+      # hydration reuse) and the SVG overlay marker budget (#7112/#7134/#7145,
+      # which pins that a drag costs O(1) overlay rebuilds rather than one per
+      # pointer event) — named explicitly because nothing in CI runs the e2e/
       # glob, and a regression guard no job invokes reports green while the
       # regression ships.
       - run: npm run test:e2e:ci-smoke

--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -217,15 +217,32 @@ async function readWrapperTransform(page: Page): Promise<string> {
  * a correct tree's rebuild count (measured: 5, then 8, at 4 workers). The map
  * listens for `mousemove` on `document`, so a dispatched event reaches exactly
  * the same handler and the same `applyTransform()` call as a driven one.
+ *
+ * Returns how many steps observed the wrapper WITHOUT `.markers-settled`. The
+ * sample is taken in the page, immediately before each move is dispatched, so it
+ * reads the state ~one interval after the previous move — late enough for that
+ * move's rebuild to have landed, and with no CDP round-trip to race the 200 ms
+ * settle timer. Sampling here, rather than counting class transitions from a
+ * MutationObserver, is deliberate: `armMarkerSettle()` strips the class on every
+ * rebuild but only re-adds it MARKER_SETTLE_MS later, so under a per-event
+ * rebuild the class goes absent once and stays absent — a transition counter
+ * saturates at 1 and cannot tell one rebuild from twenty.
  */
-async function dragMapAcross(page: Page): Promise<void> {
+async function dragMapAcross(page: Page): Promise<{ stepsUnsettled: number }> {
   await page.mouse.move(DRAG_ORIGIN.x, DRAG_ORIGIN.y);
   await page.mouse.down();
-  await page.evaluate(
+  const stepsUnsettled = await page.evaluate(
     ({ origin, steps, intervalMs, dx, dy }) =>
-      new Promise<void>((resolve) => {
+      new Promise<number>((resolve, reject) => {
+        const wrapper = document.querySelector('.map-wrapper');
+        if (!wrapper) {
+          reject(new Error('Missing .map-wrapper to sample marker settle state'));
+          return;
+        }
         let step = 0;
+        let unsettled = 0;
         const tick = (): void => {
+          if (!wrapper.classList.contains('markers-settled')) unsettled += 1;
           step += 1;
           document.dispatchEvent(
             new MouseEvent('mousemove', {
@@ -234,8 +251,12 @@ async function dragMapAcross(page: Page): Promise<void> {
               clientY: origin.y + step * dy,
             }),
           );
-          if (step >= steps) resolve();
-          else setTimeout(tick, intervalMs);
+          if (step >= steps) {
+            setTimeout(() => {
+              if (!wrapper.classList.contains('markers-settled')) unsettled += 1;
+              resolve(unsettled);
+            }, intervalMs);
+          } else setTimeout(tick, intervalMs);
         };
         setTimeout(tick, intervalMs);
       }),
@@ -248,38 +269,7 @@ async function dragMapAcross(page: Page): Promise<void> {
     },
   );
   await page.mouse.up();
-}
-
-type UnsettleProbeWindow = Window & { __wmMarkerUnsettles?: number };
-
-/**
- * Start counting transitions OUT of `.markers-settled`. `armMarkerSettle()` strips
- * the class at the end of every `renderOverlays()` pass, so this is the
- * DOM-observable half of the same property: a gesture that rebuilds per pointer
- * event holds every marker in the infinite-pulse state — and its compositing
- * layer (#4669) — for the whole drag.
- *
- * Counted rather than sampled at drag end on purpose. A read taken there races
- * the OVERLAY_BUDGET_REPLAN_SETTLE_MS timer, which is only 200 ms behind the last
- * move; the transition count is settled-state history and cannot race it.
- */
-async function watchMarkerUnsettles(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const wrapper = document.querySelector('.map-wrapper');
-    if (!wrapper) throw new Error('Missing .map-wrapper to observe for marker settle state');
-    const probe = window as UnsettleProbeWindow;
-    probe.__wmMarkerUnsettles = 0;
-    let settled = wrapper.classList.contains('markers-settled');
-    new MutationObserver(() => {
-      const nowSettled = wrapper.classList.contains('markers-settled');
-      if (settled && !nowSettled) probe.__wmMarkerUnsettles = (probe.__wmMarkerUnsettles ?? 0) + 1;
-      settled = nowSettled;
-    }).observe(wrapper, { attributes: true, attributeFilter: ['class'] });
-  });
-}
-
-async function readMarkerUnsettles(page: Page): Promise<number> {
-  return page.evaluate(() => (window as UnsettleProbeWindow).__wmMarkerUnsettles ?? 0);
+  return { stepsUnsettled };
 }
 
 test.describe('SVG map overlay marker budget (#7112)', () => {
@@ -699,9 +689,8 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
     const before = (await readOverlayBudget(page)).renders;
     expect(before).toBeGreaterThan(0);
     const transformBefore = await readWrapperTransform(page);
-    await watchMarkerUnsettles(page);
 
-    await dragMapAcross(page);
+    const { stepsUnsettled } = await dragMapAcross(page);
     await page.waitForTimeout(REPLAN_SETTLE_MS + 1500);
 
     // Positive control. A drag that never reached the map's `mousedown` handler —
@@ -718,10 +707,18 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
     expect(rebuilds).toBeGreaterThanOrEqual(1);
     expect(rebuilds).toBeLessThanOrEqual(MAX_DRAG_REBUILDS);
 
-    // The `armMarkerSettle()` half, in the DOM the user actually sees.
-    const unsettles = await readMarkerUnsettles(page);
-    expect(unsettles).toBeGreaterThanOrEqual(1);
-    expect(unsettles).toBeLessThanOrEqual(MAX_DRAG_REBUILDS);
+    // The `armMarkerSettle()` half, in the DOM the user actually sees. The
+    // wrapper entered the drag settled and no rebuild happens until the gesture
+    // ends, so every in-gesture sample must still see `.markers-settled`. Under
+    // the regression the first rebuild strips it within ~100 ms and it stays
+    // stripped for the rest of the drag — every marker held in the infinite-pulse
+    // state, and its compositing layer with it (#4669) — so this reads ~24.
+    //
+    // Strict 0, with no slack: a mid-drag rebuild is exactly the thing being
+    // ruled out. It shares the failure mode of MAX_DRAG_REBUILDS above — a runner
+    // that stalls a step gap past the 200 ms settle breaks both — and the remedy
+    // is the same one, fix the step timing rather than widen the tolerance.
+    expect(stepsUnsettled).toBe(0);
 
     // ...and the pulse is released again once that single rebuild lands, rather
     // than being re-armed indefinitely. The window is MARKER_SETTLE_MS measured

--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -46,10 +46,24 @@ const VIEW_CENTRED_MAX_WORST_DEGREES = 110;
 
 // #7145 — a drag must cost O(1) overlay rebuilds, not one per pointer event.
 // `applyTransform()` runs on every `mousemove`, so a real gesture is many events
-// spread over wall-clock time. Spacing the steps is load-bearing: a single
-// `page.mouse.move(x, y, { steps })` dispatches its steps back-to-back inside one
-// frame, where `scheduleRender()`'s own coalescing collapses even a per-event
-// rebuild to one and the regression is invisible.
+// spread over wall-clock time. Spacing the steps is load-bearing in BOTH
+// directions, and getting either wrong makes the test worthless:
+//
+//   too fast — a single `page.mouse.move(x, y, { steps })` dispatches its steps
+//   back-to-back inside one frame, where `scheduleRender()`'s own coalescing
+//   collapses even a per-event rebuild to one and the regression is invisible;
+//
+//   too slow — any gap longer than OVERLAY_BUDGET_REPLAN_SETTLE_MS fires the
+//   debounce mid-drag, which is correct behaviour but costs an extra rebuild.
+//
+// So the steps are timed from INSIDE the page (see dragMapAcross), not from the
+// test process. Measured on CI at 4 workers: driving them over CDP round-trips
+// produced 5 and 8 rebuilds on a correct tree, because a round-trip under load
+// routinely exceeds the 200 ms window. Page-side timing does not have that
+// problem on the fixed tree, where the drag leaves the main thread idle — a pan
+// is a pure CSS transform with no DOM work. It is only the regression that makes
+// the main thread busy, and there the rebuild count is set by
+// MIN_RENDER_INTERVAL_MS rather than by the gaps, so the separation holds.
 const DRAG_MOVE_STEPS = 24;
 const DRAG_STEP_INTERVAL_MS = 60;
 const DRAG_STEP_DX = 10;
@@ -62,12 +76,14 @@ const REPLAN_SETTLE_MS = 200;
 // MapComponent.MARKER_SETTLE_MS — how long after the last overlay rebuild the
 // wrapper gets `.markers-settled` and the marker pulses stop (#4669).
 const MARKER_SETTLE_MS = 6000;
-// Measured: 1 rebuild for the whole gesture on the fixed tree, 19 with the
-// replan called straight off the interaction path (the bug costs one rebuild per
-// MIN_RENDER_INTERVAL_MS of gesture, so it scales with drag duration). The slack
-// covers a CI stall longer than the 200 ms settle landing mid-drag and splitting
-// the coalesced rebuild in two; it is nowhere near the mutant, so this ceiling is
-// not a near-miss on the regression it exists to catch.
+// Measured with the page-side drag above: 1 rebuild for the whole gesture on the
+// fixed tree, 15 with the replan called straight off the interaction path (the
+// bug costs one rebuild per MIN_RENDER_INTERVAL_MS of gesture, so it scales with
+// drag duration). The slack covers a runner starving the page long enough for one
+// or two step gaps to overshoot the 200 ms settle and split the coalesced rebuild;
+// it is nowhere near the mutant, so this ceiling is not a near-miss on the
+// regression it exists to catch. Raising it to cover a flake would be — if this
+// ever needs more than 3, the step timing is wrong, not the ceiling.
 const MAX_DRAG_REBUILDS = 3;
 
 type Coord = { lat: number; lon: number };
@@ -190,17 +206,47 @@ async function readWrapperTransform(page: Page): Promise<string> {
 }
 
 /**
- * A real pointer drag: one `mousemove` per step, spaced in wall-clock time, so
+ * A pointer drag: one `mousemove` per step, spaced in wall-clock time, so
  * `applyTransform()` runs once per event across many frames — the only shape in
  * which an O(N) replan is distinguishable from an O(1) one.
+ *
+ * The press and release are real CDP input; neither is timing-sensitive. The
+ * moves are dispatched and timed inside the page instead, because the test
+ * process cannot time them reliably: a CDP round-trip on a loaded CI runner
+ * overshoots the 200 ms settle window, firing the debounce mid-drag and inflating
+ * a correct tree's rebuild count (measured: 5, then 8, at 4 workers). The map
+ * listens for `mousemove` on `document`, so a dispatched event reaches exactly
+ * the same handler and the same `applyTransform()` call as a driven one.
  */
 async function dragMapAcross(page: Page): Promise<void> {
   await page.mouse.move(DRAG_ORIGIN.x, DRAG_ORIGIN.y);
   await page.mouse.down();
-  for (let step = 1; step <= DRAG_MOVE_STEPS; step += 1) {
-    await page.mouse.move(DRAG_ORIGIN.x + step * DRAG_STEP_DX, DRAG_ORIGIN.y + step * DRAG_STEP_DY);
-    await page.waitForTimeout(DRAG_STEP_INTERVAL_MS);
-  }
+  await page.evaluate(
+    ({ origin, steps, intervalMs, dx, dy }) =>
+      new Promise<void>((resolve) => {
+        let step = 0;
+        const tick = (): void => {
+          step += 1;
+          document.dispatchEvent(
+            new MouseEvent('mousemove', {
+              bubbles: true,
+              clientX: origin.x + step * dx,
+              clientY: origin.y + step * dy,
+            }),
+          );
+          if (step >= steps) resolve();
+          else setTimeout(tick, intervalMs);
+        };
+        setTimeout(tick, intervalMs);
+      }),
+    {
+      origin: DRAG_ORIGIN,
+      steps: DRAG_MOVE_STEPS,
+      intervalMs: DRAG_STEP_INTERVAL_MS,
+      dx: DRAG_STEP_DX,
+      dy: DRAG_STEP_DY,
+    },
+  );
   await page.mouse.up();
 }
 

--- a/e2e/map-overlay-marker-budget.spec.ts
+++ b/e2e/map-overlay-marker-budget.spec.ts
@@ -44,6 +44,32 @@ const VIEW_CENTRED_MAX_MEAN_DEGREES = 55;
 const VIEW_CENTRED_MEAN_RATIO = 0.65;
 const VIEW_CENTRED_MAX_WORST_DEGREES = 110;
 
+// #7145 — a drag must cost O(1) overlay rebuilds, not one per pointer event.
+// `applyTransform()` runs on every `mousemove`, so a real gesture is many events
+// spread over wall-clock time. Spacing the steps is load-bearing: a single
+// `page.mouse.move(x, y, { steps })` dispatches its steps back-to-back inside one
+// frame, where `scheduleRender()`'s own coalescing collapses even a per-event
+// rebuild to one and the regression is invisible.
+const DRAG_MOVE_STEPS = 24;
+const DRAG_STEP_INTERVAL_MS = 60;
+const DRAG_STEP_DX = 10;
+const DRAG_STEP_DY = 5;
+// Left of centre in the harness viewport, clear of the control rail, legend and
+// time slider that `shouldIgnoreInteractionStart` refuses to start a drag from.
+const DRAG_ORIGIN = { x: 300, y: 400 };
+// MapComponent.OVERLAY_BUDGET_REPLAN_SETTLE_MS.
+const REPLAN_SETTLE_MS = 200;
+// MapComponent.MARKER_SETTLE_MS — how long after the last overlay rebuild the
+// wrapper gets `.markers-settled` and the marker pulses stop (#4669).
+const MARKER_SETTLE_MS = 6000;
+// Measured: 1 rebuild for the whole gesture on the fixed tree, 19 with the
+// replan called straight off the interaction path (the bug costs one rebuild per
+// MIN_RENDER_INTERVAL_MS of gesture, so it scales with drag duration). The slack
+// covers a CI stall longer than the 200 ms settle landing mid-drag and splitting
+// the coalesced rebuild in two; it is nowhere near the mutant, so this ceiling is
+// not a near-miss on the regression it exists to catch.
+const MAX_DRAG_REBUILDS = 3;
+
 type Coord = { lat: number; lon: number };
 
 /** Great-circle separation in degrees. Mirrors what proximityRank orders by. */
@@ -71,6 +97,7 @@ type BudgetState = {
 type HarnessWindow = Window & {
   __mobileMapIntegrationHarness?: {
     ready: boolean;
+    getWrapperTransform: () => string;
     seedOverlayMarkerStress: (perFeed: number) => void;
     seedOverlayViewportStress: (count: number) => void;
     setOverlayViewport: (lat: number, lon: number) => void;
@@ -136,6 +163,77 @@ async function readDashboardDomMetrics(page: Page): Promise<{
   } finally {
     await session.detach().catch(() => {});
   }
+}
+
+/** Ready-gated harness boot, shared by the #7145 interaction tests. */
+async function openOverlayHarness(page: Page): Promise<void> {
+  await page.goto('/tests/mobile-map-integration-harness.html');
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => Boolean((window as HarnessWindow).__mobileMapIntegrationHarness?.ready)),
+      { timeout: 30000 },
+    )
+    .toBe(true);
+}
+
+async function readOverlayBudget(page: Page): Promise<BudgetState> {
+  return page.evaluate(() =>
+    (window as HarnessWindow).__mobileMapIntegrationHarness!.getOverlayBudgetState(),
+  );
+}
+
+async function readWrapperTransform(page: Page): Promise<string> {
+  return page.evaluate(() =>
+    (window as HarnessWindow).__mobileMapIntegrationHarness!.getWrapperTransform(),
+  );
+}
+
+/**
+ * A real pointer drag: one `mousemove` per step, spaced in wall-clock time, so
+ * `applyTransform()` runs once per event across many frames — the only shape in
+ * which an O(N) replan is distinguishable from an O(1) one.
+ */
+async function dragMapAcross(page: Page): Promise<void> {
+  await page.mouse.move(DRAG_ORIGIN.x, DRAG_ORIGIN.y);
+  await page.mouse.down();
+  for (let step = 1; step <= DRAG_MOVE_STEPS; step += 1) {
+    await page.mouse.move(DRAG_ORIGIN.x + step * DRAG_STEP_DX, DRAG_ORIGIN.y + step * DRAG_STEP_DY);
+    await page.waitForTimeout(DRAG_STEP_INTERVAL_MS);
+  }
+  await page.mouse.up();
+}
+
+type UnsettleProbeWindow = Window & { __wmMarkerUnsettles?: number };
+
+/**
+ * Start counting transitions OUT of `.markers-settled`. `armMarkerSettle()` strips
+ * the class at the end of every `renderOverlays()` pass, so this is the
+ * DOM-observable half of the same property: a gesture that rebuilds per pointer
+ * event holds every marker in the infinite-pulse state — and its compositing
+ * layer (#4669) — for the whole drag.
+ *
+ * Counted rather than sampled at drag end on purpose. A read taken there races
+ * the OVERLAY_BUDGET_REPLAN_SETTLE_MS timer, which is only 200 ms behind the last
+ * move; the transition count is settled-state history and cannot race it.
+ */
+async function watchMarkerUnsettles(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const wrapper = document.querySelector('.map-wrapper');
+    if (!wrapper) throw new Error('Missing .map-wrapper to observe for marker settle state');
+    const probe = window as UnsettleProbeWindow;
+    probe.__wmMarkerUnsettles = 0;
+    let settled = wrapper.classList.contains('markers-settled');
+    new MutationObserver(() => {
+      const nowSettled = wrapper.classList.contains('markers-settled');
+      if (settled && !nowSettled) probe.__wmMarkerUnsettles = (probe.__wmMarkerUnsettles ?? 0) + 1;
+      settled = nowSettled;
+    }).observe(wrapper, { attributes: true, attributeFilter: ['class'] });
+  });
+}
+
+async function readMarkerUnsettles(page: Page): Promise<number> {
+  return page.evaluate(() => (window as UnsettleProbeWindow).__wmMarkerUnsettles ?? 0);
 }
 
 test.describe('SVG map overlay marker budget (#7112)', () => {
@@ -518,6 +616,100 @@ test.describe('SVG map overlay marker budget (#7112)', () => {
     // Exactly one rebuild for the new viewport — the one the in-window render
     // already performed.
     expect(after).toBe(before + 1);
+  });
+
+  test('coalesces a pointer drag into one overlay rebuild, not one per move event', async ({ page }) => {
+    // #7145. #7134 moved the budget replan off the interaction path and behind a
+    // settle debounce; nothing asserted the property it exists for. Before it,
+    // `applyTransform()` called `scheduleRender()` directly from every
+    // `mousemove`/`touchmove`/`wheel` and every touch-inertia frame, so a
+    // one-second drag ran roughly ten full `renderDynamicLayers()` passes — each
+    // wiping and rebuilding cables, pipelines, conflicts, AIS density, clusters
+    // and every overlay marker with a fresh `click` listener — where a pan had
+    // been a pure CSS transform with no DOM work at all.
+    await openOverlayHarness(page);
+
+    // Truncation must be live, or `overlayBudgetPlanIsStale()` short-circuits on
+    // its truncation guard and the drag is free for a reason this test is not
+    // measuring. (That guard has its own test below.)
+    await page.evaluate(
+      (count) =>
+        (window as HarnessWindow).__mobileMapIntegrationHarness!.seedOverlayViewportStress(count),
+      STRESS_PER_FEED,
+    );
+    await expect
+      .poll(async () => Object.keys((await readOverlayBudget(page)).truncated).length, {
+        timeout: 15000,
+      })
+      .toBeGreaterThan(0);
+
+    // Let the seed render's marker pulse expire first. That both quiesces the
+    // render counter and puts the wrapper in the settled state, so every
+    // un-settle counted below belongs to the gesture.
+    await expect(page.locator('.map-wrapper')).toHaveClass(/markers-settled/, {
+      timeout: MARKER_SETTLE_MS + 4000,
+    });
+
+    const before = (await readOverlayBudget(page)).renders;
+    expect(before).toBeGreaterThan(0);
+    const transformBefore = await readWrapperTransform(page);
+    await watchMarkerUnsettles(page);
+
+    await dragMapAcross(page);
+    await page.waitForTimeout(REPLAN_SETTLE_MS + 1500);
+
+    // Positive control. A drag that never reached the map's `mousedown` handler —
+    // wrong coordinates, a control swallowing the press — would satisfy every
+    // count below by doing nothing at all.
+    expect(await readWrapperTransform(page)).not.toBe(transformBefore);
+
+    const rebuilds = (await readOverlayBudget(page)).renders - before;
+    // The load-bearing pair, and the reason this asserts a COUNT rather than that
+    // "a rebuild happened": a per-frame rebuild satisfies the second. The lower
+    // bound keeps the settle replan alive — a build that simply stopped
+    // re-planning would meet the ceiling by never rebuilding, leaving the
+    // pre-gesture view's nearest markers on screen for good.
+    expect(rebuilds).toBeGreaterThanOrEqual(1);
+    expect(rebuilds).toBeLessThanOrEqual(MAX_DRAG_REBUILDS);
+
+    // The `armMarkerSettle()` half, in the DOM the user actually sees.
+    const unsettles = await readMarkerUnsettles(page);
+    expect(unsettles).toBeGreaterThanOrEqual(1);
+    expect(unsettles).toBeLessThanOrEqual(MAX_DRAG_REBUILDS);
+
+    // ...and the pulse is released again once that single rebuild lands, rather
+    // than being re-armed indefinitely. The window is MARKER_SETTLE_MS measured
+    // from the settle-debounced rebuild, not from the end of the drag.
+    await expect(page.locator('.map-wrapper')).toHaveClass(/markers-settled/, {
+      timeout: MARKER_SETTLE_MS + REPLAN_SETTLE_MS + 4000,
+    });
+  });
+
+  test('does not rebuild the overlay at all when a drag pans a view with nothing truncated', async ({ page }) => {
+    // #7145, the other half. `overlayBudgetPlanIsStale()` requires truncation
+    // before it will call a moved viewport stale. It reads like a redundant fast
+    // path, which makes it the easier of the two edits to lose: drop it and every
+    // pan ends in a full `renderDynamicLayers()` pass that cannot change a single
+    // marker, because with nothing withheld the selection is view-independent.
+    await openOverlayHarness(page);
+
+    // No stress seed — the harness's own feed is a single hotspot, far inside the
+    // budget. Wait out the settle so the render counter is quiescent before the
+    // baseline is taken.
+    await expect(page.locator('.map-wrapper')).toHaveClass(/markers-settled/, {
+      timeout: MARKER_SETTLE_MS + 4000,
+    });
+
+    const before = await readOverlayBudget(page);
+    expect(before.renders).toBeGreaterThan(0);
+    expect(Object.keys(before.truncated)).toEqual([]);
+    const transformBefore = await readWrapperTransform(page);
+
+    await dragMapAcross(page);
+    await page.waitForTimeout(REPLAN_SETTLE_MS + 1500);
+
+    expect(await readWrapperTransform(page)).not.toBe(transformBefore);
+    expect((await readOverlayBudget(page)).renders).toBe(before.renders);
   });
 
   test('reports every trimmed layer as undisclosed when the map has no toggle rail', async ({ page }) => {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "test:e2e:mcp-grant": "cross-env VITE_VARIANT=full playwright test e2e/mcp-grant-consent.spec.ts",
     "test:e2e:news-budget": "cross-env VITE_VARIANT=full playwright test e2e/dashboard-news-request-budget.spec.ts",
     "test:e2e:source-live-apply": "cross-env VITE_VARIANT=full playwright test e2e/settings-source-live-apply.spec.ts",
-    "test:e2e:ci-smoke": "cross-env VITE_VARIANT=full playwright test e2e/variant-live-smoke.spec.ts e2e/mcp-grant-consent.spec.ts e2e/dashboard-news-request-budget.spec.ts e2e/bootstrap-request-budget.spec.ts e2e/bootstrap-hydration-request-budget.spec.ts e2e/settings-panel-live-apply.spec.ts e2e/settings-source-live-apply.spec.ts e2e/keyword-spike-flow.spec.ts e2e/breaking-news-banner-provenance.spec.ts e2e/a11y-axe-scan.spec.ts",
+    "test:e2e:ci-smoke": "cross-env VITE_VARIANT=full playwright test e2e/variant-live-smoke.spec.ts e2e/mcp-grant-consent.spec.ts e2e/dashboard-news-request-budget.spec.ts e2e/bootstrap-request-budget.spec.ts e2e/bootstrap-hydration-request-budget.spec.ts e2e/settings-panel-live-apply.spec.ts e2e/settings-source-live-apply.spec.ts e2e/keyword-spike-flow.spec.ts e2e/breaking-news-banner-provenance.spec.ts e2e/a11y-axe-scan.spec.ts e2e/map-overlay-marker-budget.spec.ts",
     "test:e2e:prehydration": "cross-env VITE_VARIANT=full playwright test e2e/prehydration-shell.spec.ts --project=chromium --grep \"server-rendered welcome page|dashboard shell without JavaScript\"",
     "test:e2e:variant-smoke:full": "cross-env VITE_VARIANT=full playwright test e2e/variant-live-smoke.spec.ts",
     "test:e2e:variant-smoke:tech": "cross-env VITE_VARIANT=tech playwright test e2e/variant-live-smoke.spec.ts",


### PR DESCRIPTION
Closes #7145.

#7134 put the SVG overlay marker budget replan behind a settle debounce so a pan or zoom stops triggering a full `renderDynamicLayers()` pass per interaction frame. Nothing asserted that property — the test added alongside it pins the *settle-window duplicate*, and the interaction path itself had no regression guard at all.

Two edits would silently restore the O(N) behaviour and no test would notice:

- moving the replan back out of the `else if` arm in `applyTransform()`
- dropping the `Object.keys(this.overlayMarkerTruncation).length > 0` half of `overlayBudgetPlanIsStale()` — the easier mistake, because it reads like a redundant fast path

Each new test kills one of them. No production code is touched.

## What the tests do

Both drive a drag of 24 `mousemove` steps spaced 60 ms apart, so `applyTransform()` runs once per event across many frames.

**1. `coalesces a pointer drag into one overlay rebuild, not one per move event`**
Seeds `seedOverlayViewportStress(2000)` so a layer is genuinely truncated and the replan path is live, waits out `.markers-settled` to quiesce the render counter, drags, then asserts `getOverlayMarkerBudgetState().renders` moved by a small constant. Also counts transitions out of `.markers-settled` via a `MutationObserver` — the `armMarkerSettle()` half, in the DOM the user sees — and asserts the pulse is released again after the single rebuild.

**2. `does not rebuild the overlay at all when a drag pans a view with nothing truncated`**
Same drag on the unseeded harness, where nothing is truncated. Asserts `renders` is **unchanged**: with nothing withheld the selection is view-independent, so a rebuild cannot change a single marker.

## The step timing is the whole test, and CI proved it

Spacing is load-bearing in **both** directions:

- **too fast** — a single `page.mouse.move(x, y, { steps })` dispatches its steps back-to-back inside one frame, where `scheduleRender()`'s own coalescing collapses even a per-event rebuild to one and the regression is invisible;
- **too slow** — any gap longer than `OVERLAY_BUDGET_REPLAN_SETTLE_MS` (200 ms) fires the debounce mid-drag, which is *correct* behaviour but costs an extra rebuild.

The first version of this PR spaced the steps with `page.mouse.move` + `waitForTimeout`. It passed locally and **went red the moment the spec was enrolled in CI**: 5 rebuilds, then 8 on retry, on a correct tree at 4 workers, because a CDP round-trip under load routinely overshoots the 200 ms window. Raising the ceiling would have been the wrong fix — 8 is already close to the mutant's 15.

`9caeea37` moves the timing **inside the page**: the moves are dispatched from a page-side timer, with the press and release left on real CDP input (neither is timing-sensitive). The map listens for `mousemove` on `document`, so the events reach exactly the same handler and the same `applyTransform()` call. The asymmetry is what makes it hold — on a correct tree the drag leaves the main thread idle (a pan is a pure CSS transform with no DOM work), so the gaps stay inside the window; only the regression makes the thread busy, and there the rebuild count is set by `MIN_RENDER_INTERVAL_MS` rather than by the gaps.

## Shape notes

- Both assert the **count**, never "something changed" or "a rebuild happened" — a per-frame rebuild satisfies those, and two tests in this area have already shipped green with the bug present (#7134's pan/zoom test asserted only that the marker set differed; the first settle-window test passed with its own mutant alive).
- Test 1 asserts a **lower bound as well as a ceiling**. A build that simply stopped re-planning would meet the ceiling by never rebuilding, leaving the pre-gesture view's nearest markers on screen for good.
- Both assert the wrapper transform actually changed — a positive control, so a drag that never reached the map's `mousedown` handler fails loudly instead of satisfying every count by doing nothing.
- The settled-state transitions are **counted, not sampled at drag end**: a read taken there races the 200 ms settle timer.
- The ceiling is 3, not the "1, allow 2" the issue suggested. Correct behaviour measures 1; 3 buys one or two overshooting gaps' worth of tolerance. It is deliberately *not* a knob to widen on a flake — if this ever needs more than 3, the step timing is wrong, not the ceiling, and the comment above it says so.

## The spec was never in CI

`e2e/map-overlay-marker-budget.spec.ts` had **never been in a CI invocation**. Nothing runs the `e2e/` glob — `test:e2e:ci-smoke` names its specs one by one — so the #7112 budget guards, #7134's settle-window guard and the two new #7145 drag guards all reported green from a job that never executed them. That is the exact failure the comment above that workflow step already warns about ("a regression guard no job invokes reports green while the regression ships").

`063838e2` enrols the file. Cost: **~50 s** for all 13 tests on a step that already boots one shared vite dev server. This widens the diff beyond what #7145 asked for — flagging it rather than burying it — but without it the rest of the PR is decorative, and it is what caught the timing bug above within one push.

## Testing

`VITE_VARIANT=full npx playwright test e2e/map-overlay-marker-budget.spec.ts` — **13 passed (48.7s)**, the full file including the 11 pre-existing tests, under the exact variant CI uses.

Mutation-proven **after** the timing rewrite, each mutant applied to `src/components/Map.ts` and reverted:

| Mutation | Result |
|---|---|
| `scheduleRender()` called straight from the `overlayBudgetViewportChanged` branch | ❌ red — `rebuilds` **15**, ceiling 3 |
| truncation guard dropped from `overlayBudgetPlanIsStale()` | ❌ red — `renders` 2 → **3** on a view with nothing truncated |
| `scheduleOverlayBudgetReplan()` made a no-op | ❌ red — `rebuilds` **0**, lower bound 1 |

Unmutated: exactly **1** rebuild for the whole gesture.

`npx tsc --noEmit` and `npx biome lint ./e2e` both clean.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — this PR adds two Playwright specs and enrols an existing spec file in CI; no shipped code changes. The signal to watch is CI itself:

- **Healthy:** the `variant-smoke-full` job's ci-smoke step gains ~50 s and stays green.
- **Failure signal:** if `coalesces a pointer drag into one overlay rebuild` reports a `rebuilds` value between 4 and ~10, read it as a *timing* failure first (the runner starved the page and gaps overshot 200 ms), not a product regression — a real regression scales with drag duration and lands near 15. Fix the step timing, not the ceiling.
- **Rollback trigger:** if the newly-enrolled spec proves flaky in the required gate rather than catching a real regression, revert `063838e2` alone; the guards stay in the tree and the other commits are unaffected.
- **Window / owner:** the next few merges to `main`, PR author.

## Review notes

`ce-code-review` was not run: this session is configured not to dispatch subagents, which that skill requires. Substituted a manual full-diff scan (`git diff origin/main`), plus the mutation matrix above as the correctness evidence.
