### PR TITLE
fix(map): give the commodity SVG picker rows for fires/minerals/commodityHubs

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -614,12 +614,30 @@ export class MapComponent {
       'weather', 'fires',                     // operational risk
       'economic',                             // infrastructure context
     ];
+    // Commodity variant — SVG/mobile fallback. Only include keys that actually
+    // render in this file (miningSites/processingPlants/commodityPorts/climate/
+    // tradeRoutes/resilienceScore/dayNight do not, so they're omitted). Mirrors
+    // VARIANT_LAYER_ORDER.commodity in src/config/map-layer-definitions.ts but
+    // filtered to the SVG-capable subset. COMMODITY_MAP_LAYERS turns all eleven
+    // on; MAX_SVG_LAYERS = 9 then disables the last two active buttons on first
+    // load (outages, sanctions in this order). They stay in the picker so a
+    // later trim still discloses, instead of spending overlay fair-share with
+    // no row (#7144). fires is unbounded (toMapFires caps nothing) and must
+    // keep a row — it is the feed #7112 exists to bound.
+    const commodityLayers: (keyof MapLayers)[] = [
+      'commodityHubs', 'minerals',                    // commodity identity
+      'pipelines', 'waterways', 'ais',                // logistics
+      'economic', 'fires',                            // markets + FIRMS
+      'natural', 'weather',                           // operational risk
+      'outages', 'sanctions',                         // disruption context
+    ];
     // Filter sunset and renderer-incompatible layers so the SVG/mobile picker
     // cannot expose a toggle whose layer has no SVG paint path.
     const layers = (SITE_VARIANT === 'tech' ? techLayers
                  : SITE_VARIANT === 'finance' ? financeLayers
                  : SITE_VARIANT === 'happy' ? happyLayers
                  : SITE_VARIANT === 'energy' ? energyLayers
+                 : SITE_VARIANT === 'commodity' ? commodityLayers
                  : fullLayers).filter((key) => !isSunsetLayer(key) && isLayerExecutable(key, 'svg'));
     const MAX_SVG_LAYERS = 9;
     const enforceLayerLimit = () => {
@@ -1991,7 +2009,7 @@ export class MapComponent {
    * writes would restyle the toggle rows each time (#5080).
    *
    * A layer the budget trimmed that has no toggle row in this variant's picker
-   * (`fires` outside the energy variant, `webcams`, `radiationWatch`,
+   * (`fires` outside the energy/commodity variants, `webcams`, `radiationWatch`,
    * `spaceports`) has nowhere to show a badge. Those stay budgeted — an
    * unbounded feed is what #7112 is about, and `toMapFires` caps nothing — but
    * the cut is recorded on `overlayUndisclosedTruncation` and surfaced through

--- a/tests/map-overlay-budget-disclosure.test.mjs
+++ b/tests/map-overlay-budget-disclosure.test.mjs
@@ -11,10 +11,11 @@
  * missing data, and the trimmed layer still spends fair share out of the global
  * total, tightening the cap on the layers that DO disclose.
  *
- * That is not hypothetical: the commodity variant turns `fires` and `minerals` on
- * (COMMODITY_MAP_LAYERS) and has no `commodityLayers` picker list, so it falls
- * through to `fullLayers`, which lists neither. This pins the relationship for
- * every variant so the next one fails here instead of in production.
+ * #7144 closed the live case: commodity now has its own `commodityLayers` picker
+ * list, so `fires` / `minerals` / `commodityHubs` (all default-on in
+ * COMMODITY_MAP_LAYERS, none of them in `fullLayers`) get rows the badge can
+ * write onto. This pins the relationship for every variant so the next gap
+ * fails here instead of in production.
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -39,12 +40,11 @@ function sliceBetween(src, start, end) {
  * budgeted because the DOM ceiling is the point of #7112 and none of these feeds
  * is bounded upstream (`toMapFires` caps nothing), and their cut is reported via
  * `getOverlayMarkerBudgetState().undisclosed` rather than vanishing.
+ *
+ * Empty after #7144: commodity now has `commodityLayers`. Keep the map so the
+ * stale-entry arm still exercises, and so the next gap has a place.
  */
-const DECLARED_GAPS = new Map([
-  ['commodity:fires', 'commodity has no picker list of its own; falls through to fullLayers'],
-  ['commodity:minerals', 'commodity has no picker list of its own; falls through to fullLayers'],
-  ['commodity:commodityHubs', 'commodity has no picker list of its own; falls through to fullLayers'],
-]);
+const DECLARED_GAPS = new Map();
 
 /** Variant -> the createLayerToggles list it actually uses. */
 const VARIANT_PICKER_LIST = {
@@ -53,8 +53,7 @@ const VARIANT_PICKER_LIST = {
   finance: 'financeLayers',
   happy: 'happyLayers',
   energy: 'energyLayers',
-  // No `commodityLayers` exists; createLayerToggles' ternary falls through.
-  commodity: 'fullLayers',
+  commodity: 'commodityLayers',
 };
 
 /** Variant -> the panels.ts default map-layer state it boots with. */
@@ -180,5 +179,33 @@ describe('SVG overlay marker budget disclosure (#7112)', () => {
       /undisclosed: this\.overlayUndisclosedTruncation,/,
       'getOverlayMarkerBudgetState must expose it',
     );
+  });
+
+  it('gives commodity toggle rows for fires/minerals/commodityHubs so a shown/total badge can render (#7144)', () => {
+    // The live gap: COMMODITY_MAP_LAYERS turns these on, fullLayers lists none
+    // of them, and without a commodityLayers list the ternary fell through.
+    const defaultOn = defaultOnLayersFor('COMMODITY_MAP_LAYERS');
+    const rows = pickerLayersFor('commodityLayers');
+    const planned = plannedLayers();
+    for (const layer of ['fires', 'minerals', 'commodityHubs']) {
+      assert.ok(defaultOn.has(layer), `${layer} must stay default-on for commodity`);
+      assert.ok(planned.has(layer), `${layer} must stay budgeted`);
+      assert.ok(rows.has(layer), `commodityLayers must include ${layer}`);
+    }
+    assert.match(
+      togglesBlock,
+      /SITE_VARIANT === 'commodity' \? commodityLayers/,
+      'createLayerToggles must select commodityLayers, not fall through to fullLayers',
+    );
+
+    // The badge writer keys off `.layer-toggle-row[data-layer="<key>"]`. Both
+    // halves of that contract have to hold or a row exists and still cannot
+    // carry shown/total.
+    assert.match(togglesBlock, /row\.className = 'layer-toggle-row'/);
+    assert.match(togglesBlock, /row\.dataset\.layer = layer/);
+    const badgeSrc = read('../src/utils/layer-truncation-badge.ts');
+    assert.match(badgeSrc, /root\.querySelectorAll<HTMLElement>\('\.layer-toggle-row'\)/);
+    assert.match(badgeSrc, /row\.dataset\.layer/);
+    assert.match(badgeSrc, /badge\.textContent = `\$\{counts\.shown\}\/\$\{counts\.total\}`/);
   });
 });


### PR DESCRIPTION
## Summary

The commodity variant turns `fires`, `minerals` and `commodityHubs` on in `COMMODITY_MAP_LAYERS`, but `MapComponent.createLayerToggles()` had no `commodityLayers` list and fell through to `fullLayers`, which lists none of them. The SVG overlay marker budget (#7112 / #7134) could therefore trim those feeds with no `.layer-toggle-row[data-layer=...]` for the `shown/total` badge — silent missing data. `fires` is the important one: `toMapFires()` applies no cap.

This is option 1 from #7144: give commodity its own SVG picker list.

- Add `commodityLayers` as the SVG-capable subset of `VARIANT_LAYER_ORDER.commodity` (same pattern as `energyLayers`: omit keys that do not paint in `Map.ts`).
- Route `SITE_VARIANT === 'commodity'` to that list so a trimmed layer always has a row.
- Leave `MAX_SVG_LAYERS = 9` (no measurement to justify raising it) and leave `COMMODITY_MAP_LAYERS` unchanged (DeckGL already has these rows via `getLayersForVariant`).
- Product call on the 9: list order keeps `commodityHubs`, `minerals`, `fires` in the first nine default-on buttons. `outages` and `sanctions` stay in the picker so a later trim still discloses; `enforceLayerLimit` disables them on first desktop-SVG load.

`DECLARED_GAPS` in the disclosure guard is now empty.

Closes #7144

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [x] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other:

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [x] Tested commodity picker routing via `tests/map-overlay-budget-disclosure.test.mjs`
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked (N/A — no published docs claims)
- [ ] All required Audit Council role signoffs attached (N/A)
- [ ] Generated docs regenerated from proto where applicable (N/A)
- [ ] Fixture-backed examples recomputed (N/A)
- [ ] Redis writers/readers enumerated for every documented key (N/A)

## Tests

```
node --test tests/map-overlay-budget-disclosure.test.mjs
```

5/5 pass, including the new assertion that commodity has toggle rows for `fires` / `minerals` / `commodityHubs` and that the badge writer keys off `.layer-toggle-row[data-layer]`.

Also: `npx biome check` on the two files, `npm run typecheck`.