### PR TITLE
fix(infra): stamp temporal-anomalies content age from upstream payloads

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -790,7 +790,7 @@ const SEED_META = {
   militaryCii:      { key: 'seed-meta:intelligence:military-cii',  maxStaleMin: 45 }, // seed-military-cii cron ~10min; 45 = generous grace (relay-dependent; preserve-last-good runs still refresh meta)
   defensePatents:   { key: 'seed-meta:military:defense-patents',  maxStaleMin: 25200 },
   satellites:       { key: 'seed-meta:intelligence:satellites',    maxStaleMin: 240 }, // CelesTrak every 120min; 240min = absorbs one missed cycle
-  temporalAnomalies:{ key: 'seed-meta:temporal:anomalies',          maxStaleMin: 45 }, // rebuild-stamped ONLY (TEMPORAL_ANOMALIES_REBUILD_AFTER_MS=20min in infrastructure/v1/_shared.ts) — only producer-route traffic can rebuild and refresh this request-driven stamp, so a traffic lull can age it past 45min; 45min leaves ~2.25x margin. Data TTL is 60min so health reaches STALE_SEED before EMPTY
+  temporalAnomalies:{ key: 'seed-meta:temporal:anomalies',          maxStaleMin: 45 }, // rebuild-stamped ONLY (TEMPORAL_ANOMALIES_REBUILD_AFTER_MS=20min in infrastructure/v1/_shared.ts) — only producer-route traffic can rebuild and refresh this request-driven stamp, so a traffic lull can age it past 45min; 45min leaves ~2.25x margin. Data TTL is 60min so health reaches STALE_SEED before EMPTY. Content freshness is a separate clock: the producer stamps newestItemAt/maxContentAgeMin from the news+FIRMS payloads (TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN); a frozen-but-200 upstream keeps fetchedAt fresh and reads STALE_CONTENT.
   weatherAlerts:    { key: 'seed-meta:weather:alerts',             maxStaleMin: 45 }, // relay loop every 15min; 45 = 3× interval (was 30 = 2×, too tight on relay hiccup)
   canadaRoads:      {
     key: 'seed-meta:infra:ontario-511',

--- a/api/mcp/freshness.ts
+++ b/api/mcp/freshness.ts
@@ -58,6 +58,25 @@ export function evaluateFreshness(
       stale ||= recordCount == null || recordCount < check.minRecordCount;
     }
 
+    // House-standard content-age contract (#3845 / #7141). Presence of
+    // maxContentAgeMin on seed-meta is the opt-in signal, matching
+    // api/health.js classifyKey: a fresh fetchedAt with stale observations
+    // is stale. Without this branch MCP answers stale:false for the exact
+    // key health calls STALE_CONTENT — the #6080 divergence on this
+    // simpler newestItemAt clock.
+    if (meta && typeof meta === 'object' && 'maxContentAgeMin' in meta) {
+      const maxContentAgeMin = (meta as { maxContentAgeMin?: unknown }).maxContentAgeMin;
+      if (typeof maxContentAgeMin === 'number' && Number.isFinite(maxContentAgeMin)) {
+        const newestRaw = (meta as { newestItemAt?: unknown }).newestItemAt;
+        const newestItemAt = typeof newestRaw === 'number' && Number.isFinite(newestRaw)
+          ? newestRaw
+          : null;
+        const contentAgeMin = newestItemAt == null ? null : Math.round((now - newestItemAt) / 60_000);
+        const isFutureDated = contentAgeMin != null && contentAgeMin < 0;
+        stale ||= contentAgeMin == null || isFutureDated || contentAgeMin > maxContentAgeMin;
+      }
+    }
+
     if (check.requireContentFreshness) {
       // Same assessor api/health.js uses, so the two surfaces cannot drift on
       // parsing, on the fail-closed rules, or on re-aging: the producer's

--- a/api/mcp/registry/analysis-tools.ts
+++ b/api/mcp/registry/analysis-tools.ts
@@ -851,7 +851,7 @@ export const ANALYSIS_TOOLS: ToolDef[] = [
         { key: 'seed-meta:military-surges', maxStaleMin: 30 },
         { key: 'seed-meta:cable-health', maxStaleMin: 90 },
         { key: 'seed-meta:infra:outages', maxStaleMin: 30 },
-        { key: 'seed-meta:temporal:anomalies', maxStaleMin: 45 },
+        { key: 'seed-meta:temporal:anomalies', maxStaleMin: 45 }, // liveness 45min; content-age is stamped on the same key (newestItemAt) and evaluated by evaluateFreshness
         { key: 'seed-meta:thermal:escalation', maxStaleMin: 360 },
         { key: 'seed-meta:supply_chain:shipping_stress', maxStaleMin: 45 },
       ];

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -2710,7 +2710,7 @@ export const CACHE_TOOLS: ToolDef[] = [
     },
     _cacheKeys: ['temporal:anomalies:v1'],
     _cacheLabels: { 'temporal:anomalies:v1': 'snapshot' },
-    _freshnessChecks: [{ key: 'seed-meta:temporal:anomalies', maxStaleMin: 45 }],
+    _freshnessChecks: [{ key: 'seed-meta:temporal:anomalies', maxStaleMin: 45 }], // liveness 45min; content-age is stamped on the same key (newestItemAt) and evaluated by evaluateFreshness
     _apiPaths: [],
   },
 

--- a/server/worldmonitor/infrastructure/v1/_shared.ts
+++ b/server/worldmonitor/infrastructure/v1/_shared.ts
@@ -155,7 +155,12 @@ function firesContentClock(
   skewLimit: number,
 ): TemporalAnomaliesContentAge | null | undefined {
   if (data == null || typeof data !== 'object' || Array.isArray(data)) return undefined;
-  const fires = (data as { fireDetections?: unknown }).fireDetections;
+  const payload = data as { fireDetections?: unknown; _firmsState?: unknown };
+  // Canonical wildfire merge preserves `_firmsState: 'failed'` when CWFIS/BC
+  // still publish. That is Canada-only coverage, not a skippable empty FIRMS
+  // window — returning undefined here lets a live news clock hide the outage.
+  if (payload._firmsState === 'failed') return null;
+  const fires = payload.fireDetections;
   if (!Array.isArray(fires) || fires.length === 0) {
     // A live FIRMS 1-day window can be empty in the monitored regions. That is
     // "no satellite observations right now", not "we cannot date this".
@@ -174,8 +179,8 @@ function firesContentClock(
     if (ts != null) timestamps.push(ts);
   }
   if (firmsRows === 0) {
-    // Agency-only payload: satellite_fires has nothing to date. Skip rather
-    // than clock off ignition dates that can be days old on ongoing fires.
+    // Agency-only payload without an explicit FIRMS failure: skip rather than
+    // clock off ignition dates that can be days old on ongoing fires.
     return undefined;
   }
   if (timestamps.length === 0) return null;

--- a/server/worldmonitor/infrastructure/v1/_shared.ts
+++ b/server/worldmonitor/infrastructure/v1/_shared.ts
@@ -196,9 +196,14 @@ function firesContentClock(
  * frozen news feed, and vice versa. See CONCEPTS.md "Content-Age Contract" and
  * docs/solutions/design-patterns/multi-source-freshness-clock-must-reduce-with-min.md.
  *
- * Returns null when no contributing source is datable, or when a contributing
- * source has items that cannot be dated. The writer stamps `newestItemAt: null`
- * in that case, which classifyKey reads as STALE_CONTENT.
+ * Returns null when no contributing source is datable, when a contributing
+ * source has items that cannot be dated, or when a configured COUNT_SOURCE_KEYS
+ * source was not read this cycle. A present source may still skip (empty FIRMS
+ * window / agency-only). An *absent* configured source must not: the remaining
+ * live clock would otherwise stamp fresh content for partial coverage, and no
+ * temporal-anomalies consumer sets minRecordCount. The writer stamps
+ * `newestItemAt: null` in the fail-closed case, which classifyKey reads as
+ * STALE_CONTENT.
  */
 export function temporalAnomaliesContentMeta(
   sources: { news?: unknown; satellite_fires?: unknown },
@@ -207,10 +212,11 @@ export function temporalAnomaliesContentMeta(
   const skewLimit = nowMs + CONTENT_AGE_CLOCK_SKEW_MS;
   const clocks: TemporalAnomaliesContentAge[] = [];
   for (const clock of [
-    sources.news !== undefined ? newsContentClock(sources.news, skewLimit) : undefined,
+    // Missing configured source → null (fail closed), not undefined (skip).
+    sources.news !== undefined ? newsContentClock(sources.news, skewLimit) : null,
     sources.satellite_fires !== undefined
       ? firesContentClock(sources.satellite_fires, skewLimit)
-      : undefined,
+      : null,
   ]) {
     if (clock === undefined) continue;
     if (clock === null) return null;

--- a/server/worldmonitor/infrastructure/v1/_shared.ts
+++ b/server/worldmonitor/infrastructure/v1/_shared.ts
@@ -65,15 +65,158 @@ export const TEMPORAL_ANOMALIES_TTL = 3600;
  * Changing this without moving those consumers' maxStaleMin is a monitoring change,
  * not just a caching one. See tests/temporal-anomalies-cache.test.mts.
  *
- * KNOWN LIMIT — this is a rebuild clock, not a content clock. A "successful rebuild"
- * only means the reads from COUNT_SOURCE_KEYS resolved; it does not check whether
- * those upstream sources actually advanced. If news:insights:v1 or wildfire:fires:v1
- * freezes, this route keeps stamping fresh every cycle and the monitor stays green.
- * Moving the stamp off request traffic closed the larger hole (traffic alone used to
- * keep it green), but detecting a frozen UPSTREAM needs a content clock — compare the
- * sources' own timestamps, not merely the success of reading them.
+ * fetchedAt on seed-meta:temporal:anomalies is this rebuild clock. The CONTENT
+ * clock is newestItemAt / maxContentAgeMin, derived from the upstream payloads
+ * themselves (see temporalAnomaliesContentMeta). A frozen-but-200 news or FIRMS
+ * feed keeps fetchedAt fresh every cycle; only the observation dates go stale.
  */
 export const TEMPORAL_ANOMALIES_REBUILD_AFTER_MS = 20 * 60 * 1000;
+
+/**
+ * Content-age budget for `seed-meta:temporal:anomalies`.
+ *
+ * Sized from the slower upstream's publication calendar, not the 20-minute
+ * rebuild cadence. FIRMS area queries use a 1-day window (`/1` in
+ * seed-fire-detections.mjs) and NRT files reset at midnight UTC with 3–6h to
+ * accumulate; 48h is 2× that window plus the midnight lag. News top-stories
+ * are ranked by importance, not recency, so a live digest can still cite
+ * stories many hours old — 48h absorbs that without becoming the 12-month
+ * blind spot #3845 documented.
+ *
+ * Health liveness (`fetchedAt` vs maxStaleMin: 45) remains the rebuild clock.
+ */
+export const TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN = 48 * 60;
+
+/** Matches scripts/_content-age-helpers.mjs CLOCK_SKEW_TOLERANCE_MS. */
+const CONTENT_AGE_CLOCK_SKEW_MS = 60 * 60 * 1000;
+
+export interface TemporalAnomaliesContentAge {
+  newestItemAt: number;
+  oldestItemAt: number;
+}
+
+function parseObservationMs(value: unknown, skewLimit: number): number | null {
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0 || value > skewLimit) return null;
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const ts = Date.parse(value);
+    if (!Number.isFinite(ts) || ts <= 0 || ts > skewLimit) return null;
+    return ts;
+  }
+  return null;
+}
+
+function reduceTimestamps(timestamps: number[]): TemporalAnomaliesContentAge | null {
+  if (timestamps.length === 0) return null;
+  let newest = timestamps[0]!;
+  let oldest = timestamps[0]!;
+  for (const ts of timestamps) {
+    if (ts > newest) newest = ts;
+    if (ts < oldest) oldest = ts;
+  }
+  return { newestItemAt: newest, oldestItemAt: oldest };
+}
+
+function newsContentClock(
+  data: unknown,
+  skewLimit: number,
+): TemporalAnomaliesContentAge | null | undefined {
+  if (data == null || typeof data !== 'object' || Array.isArray(data)) return undefined;
+  const payload = data as Record<string, unknown>;
+  const timestamps: number[] = [];
+  const stories = payload.topStories;
+  if (Array.isArray(stories)) {
+    for (const story of stories) {
+      if (!story || typeof story !== 'object') continue;
+      const row = story as Record<string, unknown>;
+      for (const field of ['pubDate', 'publishedAt', 'date', 'lastUpdated'] as const) {
+        const ts = parseObservationMs(row[field], skewLimit);
+        if (ts != null) timestamps.push(ts);
+      }
+    }
+  }
+  const range = payload.sourceAgeRange;
+  if (range && typeof range === 'object' && !Array.isArray(range)) {
+    const window = range as Record<string, unknown>;
+    const newest = parseObservationMs(window.newestMs, skewLimit);
+    const oldest = parseObservationMs(window.oldestMs, skewLimit);
+    if (newest != null) timestamps.push(newest);
+    if (oldest != null) timestamps.push(oldest);
+  }
+  // A contributing news payload with nothing datable is indistinguishable from
+  // a frozen feed whose items lost their timestamps. Fail closed.
+  return reduceTimestamps(timestamps);
+}
+
+function firesContentClock(
+  data: unknown,
+  skewLimit: number,
+): TemporalAnomaliesContentAge | null | undefined {
+  if (data == null || typeof data !== 'object' || Array.isArray(data)) return undefined;
+  const fires = (data as { fireDetections?: unknown }).fireDetections;
+  if (!Array.isArray(fires) || fires.length === 0) {
+    // A live FIRMS 1-day window can be empty in the monitored regions. That is
+    // "no satellite observations right now", not "we cannot date this".
+    return undefined;
+  }
+  const timestamps: number[] = [];
+  let firmsRows = 0;
+  for (const fire of fires) {
+    if (!fire || typeof fire !== 'object') continue;
+    const row = fire as Record<string, unknown>;
+    const source = row.source;
+    const isFirms = source == null || source === '' || source === 'firms';
+    if (!isFirms) continue;
+    firmsRows += 1;
+    const ts = parseObservationMs(row.detectedAt, skewLimit);
+    if (ts != null) timestamps.push(ts);
+  }
+  if (firmsRows === 0) {
+    // Agency-only payload: satellite_fires has nothing to date. Skip rather
+    // than clock off ignition dates that can be days old on ongoing fires.
+    return undefined;
+  }
+  if (timestamps.length === 0) return null;
+  return reduceTimestamps(timestamps);
+}
+
+/**
+ * Content-age of a temporal-anomalies rebuild from the upstream payloads that
+ * actually contributed a count this cycle.
+ *
+ * Two independently-failing sources (`news:insights:v1`, `wildfire:fires:v1`).
+ * One clock per source, reduced with min() — a live fires feed must not hide a
+ * frozen news feed, and vice versa. See CONCEPTS.md "Content-Age Contract" and
+ * docs/solutions/design-patterns/multi-source-freshness-clock-must-reduce-with-min.md.
+ *
+ * Returns null when no contributing source is datable, or when a contributing
+ * source has items that cannot be dated. The writer stamps `newestItemAt: null`
+ * in that case, which classifyKey reads as STALE_CONTENT.
+ */
+export function temporalAnomaliesContentMeta(
+  sources: { news?: unknown; satellite_fires?: unknown },
+  nowMs = Date.now(),
+): TemporalAnomaliesContentAge | null {
+  const skewLimit = nowMs + CONTENT_AGE_CLOCK_SKEW_MS;
+  const clocks: TemporalAnomaliesContentAge[] = [];
+  for (const clock of [
+    sources.news !== undefined ? newsContentClock(sources.news, skewLimit) : undefined,
+    sources.satellite_fires !== undefined
+      ? firesContentClock(sources.satellite_fires, skewLimit)
+      : undefined,
+  ]) {
+    if (clock === undefined) continue;
+    if (clock === null) return null;
+    clocks.push(clock);
+  }
+  if (clocks.length === 0) return null;
+  return {
+    newestItemAt: Math.min(...clocks.map((clock) => clock.newestItemAt)),
+    oldestItemAt: Math.min(...clocks.map((clock) => clock.oldestItemAt)),
+  };
+}
 
 /**
  * How often a rebuild folds a new sample into the `baseline:v2:*` running mean.

--- a/server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts
+++ b/server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts
@@ -18,9 +18,11 @@ import {
   TEMPORAL_ANOMALIES_KEY,
   TEMPORAL_ANOMALIES_TTL,
   TEMPORAL_ANOMALIES_REBUILD_AFTER_MS,
+  TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN,
   BASELINE_SAMPLE_INTERVAL_MS,
   BASELINE_LOCK_KEY,
   BASELINE_LOCK_TTL,
+  temporalAnomaliesContentMeta,
   type BaselineEntry,
 } from './_shared';
 
@@ -95,12 +97,20 @@ async function tryAcquireLock(): Promise<boolean> {
 async function writeTemporalAnomaliesSeedMeta(
   snapshot: AnomalySnapshot,
   coveredSourceCount: number,
+  contentAge: { newestItemAt: number | null; oldestItemAt: number | null },
 ): Promise<boolean> {
   return setCachedJson('seed-meta:temporal:anomalies', {
     fetchedAt: Date.now(),
     recordCount: Number.isFinite(coveredSourceCount)
       ? coveredSourceCount
       : (Array.isArray(snapshot.anomalies) ? snapshot.anomalies.length : 0),
+    // Presence of maxContentAgeMin is the opt-in signal classifyKey and
+    // evaluateFreshness both honor. newestItemAt may be explicit null when
+    // the contributing payloads were undatable — that is STALE_CONTENT,
+    // not a skipped contract.
+    newestItemAt: contentAge.newestItemAt,
+    oldestItemAt: contentAge.oldestItemAt,
+    maxContentAgeMin: TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN,
   }, 604800).catch(() => false);
 }
 
@@ -137,6 +147,7 @@ export async function listTemporalAnomalies(
       const anomalies: TemporalAnomalyProto[] = [];
 
       const counts: Record<string, number> = {};
+      const countPayloads: { news?: unknown; satellite_fires?: unknown } = {};
       const countEntries = await Promise.all(
         Object.entries(COUNT_SOURCE_KEYS).map(async ([type, sourceKey]) => [
           type,
@@ -145,6 +156,9 @@ export async function listTemporalAnomalies(
       );
       for (const [type, data] of countEntries) {
         if (!data) continue;
+        if (type === 'news' || type === 'satellite_fires') {
+          countPayloads[type] = data;
+        }
 
         if (type === 'news') {
           const stories = (data as { topStories?: unknown[] })?.topStories;
@@ -262,7 +276,12 @@ export async function listTemporalAnomalies(
         // away — so surface it with a grep-able marker rather than discarding it.
         // typesWithCounts is the sources that actually returned a count this
         // rebuild — the achieved coverage, not the configured one.
-        const stamped = await writeTemporalAnomaliesSeedMeta(snapshot, typesWithCounts.length);
+        const contentAge = temporalAnomaliesContentMeta(countPayloads, now.getTime());
+        const stamped = await writeTemporalAnomaliesSeedMeta(
+          snapshot,
+          typesWithCounts.length,
+          contentAge ?? { newestItemAt: null, oldestItemAt: null },
+        );
         if (!stamped) {
           console.warn(
             '[TemporalAnomalies] seed-meta stamp FAILED after a successful publish; '

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -664,6 +664,42 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(freshness.stale, false);
   });
 
+  // Health classifyKey fail-closes these same arms (#3596 / #3845). Without
+  // these cases MCP can regress to stale:false while health stays STALE_CONTENT.
+  it('evaluateFreshness marks content-age stale when newestItemAt is null (#7141)', () => {
+    const now = Date.UTC(2026, 7, 27, 12, 0, 0);
+    const freshness = evaluateFreshness(
+      [{ key: 'seed-meta:temporal:anomalies', maxStaleMin: 45 }],
+      [{
+        fetchedAt: now - 5 * 60_000,
+        recordCount: 2,
+        newestItemAt: null,
+        maxContentAgeMin: 48 * 60,
+      }],
+      now,
+    );
+
+    assert.equal(freshness.stale, true, 'undatable content must not read stale:false');
+    assert.equal(freshness.cached_at, new Date(now - 5 * 60_000).toISOString());
+  });
+
+  it('evaluateFreshness marks content-age stale when newestItemAt is in the future (#7141)', () => {
+    const now = Date.UTC(2026, 7, 27, 12, 0, 0);
+    const freshness = evaluateFreshness(
+      [{ key: 'seed-meta:temporal:anomalies', maxStaleMin: 45 }],
+      [{
+        fetchedAt: now - 5 * 60_000,
+        recordCount: 2,
+        newestItemAt: now + 60 * 60_000,
+        maxContentAgeMin: 48 * 60,
+      }],
+      now,
+    );
+
+    assert.equal(freshness.stale, true, 'future-dated content must not read stale:false');
+    assert.equal(freshness.cached_at, new Date(now - 5 * 60_000).toISOString());
+  });
+
   it('get_chokepoint_status declares the PortWatch 174-country freshness floor', async () => {
     const { CACHE_TOOLS } = await import(`../api/mcp/registry/cache-tools.ts?t=${Date.now()}`);
     const tool = CACHE_TOOLS.find((candidate) => candidate.name === 'get_chokepoint_status');

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -631,6 +631,39 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(freshness.cached_at, new Date(now - 12 * 60 * 60_000).toISOString());
   });
 
+  it('evaluateFreshness marks content-age stale even when fetchedAt is fresh (#7141)', () => {
+    const now = Date.UTC(2026, 7, 27, 12, 0, 0);
+    const freshness = evaluateFreshness(
+      [{ key: 'seed-meta:temporal:anomalies', maxStaleMin: 45 }],
+      [{
+        fetchedAt: now - 5 * 60_000,
+        recordCount: 2,
+        newestItemAt: now - 72 * 60 * 60_000,
+        maxContentAgeMin: 48 * 60,
+      }],
+      now,
+    );
+
+    assert.equal(freshness.stale, true, 'a frozen-but-200 feed must not read stale:false');
+    assert.equal(freshness.cached_at, new Date(now - 5 * 60_000).toISOString());
+  });
+
+  it('evaluateFreshness stays fresh when content-age is inside budget', () => {
+    const now = Date.UTC(2026, 7, 27, 12, 0, 0);
+    const freshness = evaluateFreshness(
+      [{ key: 'seed-meta:temporal:anomalies', maxStaleMin: 45 }],
+      [{
+        fetchedAt: now - 5 * 60_000,
+        recordCount: 2,
+        newestItemAt: now - 20 * 60_000,
+        maxContentAgeMin: 48 * 60,
+      }],
+      now,
+    );
+
+    assert.equal(freshness.stale, false);
+  });
+
   it('get_chokepoint_status declares the PortWatch 174-country freshness floor', async () => {
     const { CACHE_TOOLS } = await import(`../api/mcp/registry/cache-tools.ts?t=${Date.now()}`);
     const tool = CACHE_TOOLS.find((candidate) => candidate.name === 'get_chokepoint_status');

--- a/tests/temporal-anomalies-cache.test.mts
+++ b/tests/temporal-anomalies-cache.test.mts
@@ -731,6 +731,7 @@ describe('temporal anomalies frozen-but-200 feed (#7141)', () => {
   });
 
   it('stamps newestItemAt null when a contributing payload is undatable', async () => {
+    const now = Date.now();
     const { calls } = await runWithRedisStub({
       'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
       'news:insights:v1': { topStories: [{ id: 'a' }] },
@@ -741,9 +742,35 @@ describe('temporal anomalies frozen-but-200 feed (#7141)', () => {
     assert.equal(meta.newestItemAt, null);
     assert.equal(meta.maxContentAgeMin, TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN);
     assert.equal(
-      classifyTemporalMeta(meta, Date.now()).status,
+      classifyTemporalMeta(meta, now).status,
       'STALE_CONTENT',
       'undatable contributing payloads fail closed, matching runSeed contentMeta null',
+    );
+    assert.equal(
+      evaluateFreshness([temporalAnomaliesCheck()], [meta], now).stale,
+      true,
+      'MCP must not answer stale:false for the key health calls STALE_CONTENT',
+    );
+  });
+
+  it('a future-dated newestItemAt does not read green on health or MCP', () => {
+    const now = Date.now();
+    const meta = {
+      fetchedAt: now - 5 * 60_000,
+      recordCount: 2,
+      newestItemAt: now + 60 * 60_000,
+      maxContentAgeMin: TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN,
+    };
+
+    assert.equal(
+      classifyTemporalMeta(meta, now).status,
+      'STALE_CONTENT',
+      'future-dated observations are suspicious data, not fresh data',
+    );
+    assert.equal(
+      evaluateFreshness([temporalAnomaliesCheck()], [meta], now).stale,
+      true,
+      'MCP must not answer stale:false for the key health calls STALE_CONTENT',
     );
   });
 

--- a/tests/temporal-anomalies-cache.test.mts
+++ b/tests/temporal-anomalies-cache.test.mts
@@ -567,6 +567,7 @@ describe('temporal anomalies content-age extractor (#7141)', () => {
     const firmsAt = NOW - 20 * 60_000;
     const agencyAt = NOW - 10 * 24 * HOUR_MS;
     const meta = temporalAnomaliesContentMeta({
+      news: liveNews(NOW, 8 * 60_000),
       satellite_fires: {
         fireDetections: [
           { id: 'cwfis-1', source: 'cwfis', detectedAt: agencyAt },
@@ -618,10 +619,25 @@ describe('temporal anomalies content-age extractor (#7141)', () => {
           { id: 'real', pubDate: new Date(real).toISOString() },
         ],
       },
+      // Present empty FIRMS window still skips; this isolates the news skew rule.
+      satellite_fires: { fireDetections: [], pagination: { totalCount: 0 } },
     }, NOW);
 
     assert.ok(meta);
     assert.equal(meta.newestItemAt, real);
+  });
+
+  it('fails closed when a configured COUNT_SOURCE_KEYS read is missing', () => {
+    assert.equal(
+      temporalAnomaliesContentMeta({ news: liveNews(NOW, 8 * 60_000) }, NOW),
+      null,
+      'live news plus absent wildfire must not stamp a news-only content clock',
+    );
+    assert.equal(
+      temporalAnomaliesContentMeta({ satellite_fires: liveFires(NOW, 10 * 60_000) }, NOW),
+      null,
+      'live fires plus absent news must not stamp a fires-only content clock',
+    );
   });
 });
 
@@ -735,6 +751,7 @@ describe('temporal anomalies frozen-but-200 feed (#7141)', () => {
     const { calls } = await runWithRedisStub({
       'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
       'news:insights:v1': { topStories: [{ id: 'a' }] },
+      'wildfire:fires:v1': liveFires(),
     });
 
     const meta = seedMetaStamp(calls)?.value as Record<string, unknown> | undefined;
@@ -771,6 +788,35 @@ describe('temporal anomalies frozen-but-200 feed (#7141)', () => {
       evaluateFreshness([temporalAnomaliesCheck()], [meta], now).stale,
       true,
       'MCP must not answer stale:false for the key health calls STALE_CONTENT',
+    );
+  });
+
+  it('fails closed on health and MCP when one configured source is absent', async () => {
+    const now = Date.now();
+    const { calls } = await runWithRedisStub({
+      'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+      'news:insights:v1': liveNews(now, 20 * 60_000),
+      // wildfire:fires:v1 deliberately absent
+    });
+
+    const meta = seedMetaStamp(calls)?.value as Record<string, unknown> | undefined;
+    assert.ok(meta, 'precondition: rebuild stamped seed-meta');
+    assert.equal(meta.recordCount, 1, 'achieved coverage stays 1');
+    assert.equal(
+      meta.newestItemAt,
+      null,
+      'the remaining live source must not stamp a fresh content clock',
+    );
+
+    assert.equal(
+      classifyTemporalMeta(meta, now).status,
+      'STALE_CONTENT',
+      'health must fail closed on incomplete configured-source coverage',
+    );
+    assert.equal(
+      evaluateFreshness([temporalAnomaliesCheck()], [meta], now).stale,
+      true,
+      'MCP must fail closed on the same incomplete coverage',
     );
   });
 

--- a/tests/temporal-anomalies-cache.test.mts
+++ b/tests/temporal-anomalies-cache.test.mts
@@ -2,11 +2,15 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import { __testing__ } from '../api/health.js';
+import { evaluateFreshness } from '../api/mcp/freshness.ts';
+import { CACHE_TOOLS } from '../api/mcp/registry/cache-tools.ts';
 import {
   TEMPORAL_ANOMALIES_TTL,
   TEMPORAL_ANOMALIES_REBUILD_AFTER_MS,
+  TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN,
   BASELINE_SAMPLE_INTERVAL_MS,
   makeBaselineKeyV2,
+  temporalAnomaliesContentMeta,
 } from '../server/worldmonitor/infrastructure/v1/_shared.ts';
 import { listTemporalAnomalies } from '../server/worldmonitor/infrastructure/v1/list-temporal-anomalies.ts';
 
@@ -28,7 +32,7 @@ async function runWithRedisStub(
   const originalFetch = globalThis.fetch;
   const originalUrl = process.env.UPSTASH_REDIS_REST_URL;
   const originalToken = process.env.UPSTASH_REDIS_REST_TOKEN;
-  const calls: { method: string; key: string; recordCount?: number }[] = [];
+  const calls: { method: string; key: string; recordCount?: number; value?: unknown }[] = [];
 
   process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
@@ -38,19 +42,22 @@ async function runWithRedisStub(
       // not in the URL path — matching on the URL would silently match nothing.
       let key = '';
       let recordCount: number | undefined;
+      let value: unknown;
       try {
         const cmd = JSON.parse(String(init.body ?? '[]'));
         if (Array.isArray(cmd)) {
           key = String(cmd[1] ?? '');
-          // cmd[2] is the JSON-encoded value; capture recordCount so coverage
-          // assertions can check WHAT was written, not just that a write happened.
+          // cmd[2] is the JSON-encoded value; capture the written seed-meta so
+          // content-age assertions can check WHAT was stamped, not just that
+          // a write happened.
           const written = JSON.parse(String(cmd[2] ?? 'null'));
+          value = written;
           if (written && typeof written.recordCount === 'number') {
             recordCount = written.recordCount;
           }
         }
       } catch { /* leave undefined; assertions below surface it */ }
-      calls.push({ method: 'POST', key, recordCount });
+      calls.push({ method: 'POST', key, recordCount, value });
       if (failedPostKeys.includes(key)) {
         return Response.json({ error: `forced POST failure for ${key}` }, { status: 500 });
       }
@@ -77,6 +84,58 @@ const freshSnapshot = (ageMs = 0) => ({
   trackedTypes: ['news', 'satellite_fires'],
   computedAt: new Date(Date.now() - ageMs).toISOString(),
 });
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function liveNews(now = Date.now(), ageMs = 10 * 60_000) {
+  const newest = now - ageMs;
+  return {
+    topStories: [{ id: 'a', pubDate: new Date(newest).toISOString() }],
+    sourceAgeRange: { newestMs: newest, oldestMs: newest },
+  };
+}
+
+function liveFires(now = Date.now(), ageMs = 15 * 60_000, totalCount = 5) {
+  return {
+    fireDetections: [{ id: 'fire-1', source: 'firms', detectedAt: now - ageMs }],
+    pagination: { nextCursor: '', totalCount },
+  };
+}
+
+function frozenNews(now = Date.now(), ageMs = 72 * HOUR_MS) {
+  return liveNews(now, ageMs);
+}
+
+function frozenFires(now = Date.now(), ageMs = 72 * HOUR_MS, totalCount = 5) {
+  return liveFires(now, ageMs, totalCount);
+}
+
+function seedMetaStamp(calls: { method: string; key: string; value?: unknown }[]) {
+  return calls.find((call) => call.method === 'POST' && call.key === 'seed-meta:temporal:anomalies');
+}
+
+function temporalAnomaliesCheck() {
+  const tool = CACHE_TOOLS.find((candidate) => candidate.name === 'get_temporal_anomalies');
+  assert.ok(tool, 'get_temporal_anomalies must exist');
+  const check = tool._freshnessChecks?.find((candidate) => candidate.key === 'seed-meta:temporal:anomalies');
+  assert.ok(check, 'get_temporal_anomalies must declare the temporal-anomalies freshness check');
+  return check;
+}
+
+function classifyTemporalMeta(meta: Record<string, unknown>, now: number) {
+  return __testing__.classifyKey(
+    'temporalAnomalies',
+    'temporal:anomalies:v1',
+    { allowOnDemand: true },
+    {
+      keyStrens: new Map([['temporal:anomalies:v1', 96]]),
+      keyErrors: new Map(),
+      keyMetaValues: new Map([['seed-meta:temporal:anomalies', JSON.stringify(meta)]]),
+      keyMetaErrors: new Map(),
+      now,
+    },
+  );
+}
 
 describe('temporal anomalies cache freshness', () => {
   it('rebuilds often enough that the health stale budget has real margin', () => {
@@ -132,7 +191,7 @@ describe('temporal anomalies cache freshness', () => {
     // lock SET alone satisfies it.
     const { calls } = await runWithRedisStub({
       'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
-      'news:insights:v1': { topStories: [{ id: 'a' }] },
+      'news:insights:v1': liveNews(),
     });
 
     const writes = calls.filter((c) => c.method === 'POST');
@@ -175,7 +234,7 @@ describe('temporal anomalies cache freshness', () => {
   it('stamps the partial coverage it ACHIEVED, not the coverage it configured', async () => {
     const { calls } = await runWithRedisStub({
       'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
-      'news:insights:v1': { topStories: [{ id: 'a' }] },
+      'news:insights:v1': liveNews(),
       // wildfire:fires:v1 deliberately absent
     });
 
@@ -188,12 +247,19 @@ describe('temporal anomalies cache freshness', () => {
     // stamp is always 0.
     const { calls } = await runWithRedisStub({
       'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
-      'news:insights:v1': { topStories: [{ id: 'a' }] },
-      'wildfire:fires:v1': { fireDetections: [], pagination: { totalCount: 5 } },
+      'news:insights:v1': liveNews(),
+      'wildfire:fires:v1': liveFires(),
     });
 
     const stamp = calls.find((c) => c.method === 'POST' && c.key === 'seed-meta:temporal:anomalies');
     assert.equal(stamp?.recordCount, 2, 'both sources read must stamp recordCount 2');
+    const meta = stamp?.value as { maxContentAgeMin?: number; newestItemAt?: number } | undefined;
+    assert.equal(
+      meta?.maxContentAgeMin,
+      TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN,
+      'a successful rebuild must opt into the content-age contract',
+    );
+    assert.equal(typeof meta?.newestItemAt, 'number', 'datable live sources must stamp a newestItemAt');
   });
 
   it('does not stamp seed-meta when snapshot publication fails', async () => {
@@ -213,7 +279,7 @@ describe('temporal anomalies cache freshness', () => {
     const { calls } = await runWithRedisStub(
       {
         'temporal:anomalies:v1': stale,
-        'news:insights:v1': { topStories: [{ id: 'a' }] },
+        'news:insights:v1': liveNews(),
         [baselineKey]: baseline,
       },
       { failedPostKeys: ['temporal:anomalies:v1'] },
@@ -250,7 +316,7 @@ describe('temporal anomalies cache freshness', () => {
     try {
       const { calls } = await runWithRedisStub(
         {
-          'news:insights:v1': { topStories: [{ id: 'a' }] },
+          'news:insights:v1': liveNews(),
           [baselineKey]: dueBaseline,
         },
         { failedPostKeys: [baselineKey] },
@@ -283,8 +349,8 @@ describe('temporal anomalies cache freshness', () => {
     };
     const { calls } = await runWithRedisStub({
       'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
-      'news:insights:v1': { topStories: [{ id: 'a' }] },
-      'wildfire:fires:v1': { fireDetections: [], pagination: { totalCount: 5 } },
+      'news:insights:v1': liveNews(),
+      'wildfire:fires:v1': liveFires(),
       ...Object.fromEntries(
         ['news', 'satellite_fires'].map((t) => [
           makeBaselineKeyV2(t, 'global', new Date().getUTCDay(), new Date().getUTCMonth() + 1),
@@ -318,8 +384,8 @@ describe('temporal anomalies cache freshness', () => {
     };
     const { calls } = await runWithRedisStub({
       'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
-      'news:insights:v1': { topStories: [{ id: 'a' }] },
-      'wildfire:fires:v1': { fireDetections: [], pagination: { totalCount: 5 } },
+      'news:insights:v1': liveNews(),
+      'wildfire:fires:v1': liveFires(),
       ...Object.fromEntries(
         ['news', 'satellite_fires'].map((t) => [
           makeBaselineKeyV2(t, 'global', new Date().getUTCDay(), new Date().getUTCMonth() + 1),
@@ -344,8 +410,8 @@ describe('temporal anomalies cache freshness', () => {
     };
     const { calls } = await runWithRedisStub({
       'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
-      'news:insights:v1': { topStories: [{ id: 'a' }] },
-      'wildfire:fires:v1': { fireDetections: [], pagination: { totalCount: 5 } },
+      'news:insights:v1': liveNews(),
+      'wildfire:fires:v1': liveFires(),
       ...Object.fromEntries(
         ['news', 'satellite_fires'].map((t) => [
           makeBaselineKeyV2(t, 'global', new Date().getUTCDay(), new Date().getUTCMonth() + 1),
@@ -392,7 +458,11 @@ describe('temporal anomalies cache freshness', () => {
     // `pagination`. Counting the array would report the cap as the fire volume.
     const FIRMS_TOTAL = 21_600;
     const firesPayload = {
-      fireDetections: Array.from({ length: 10 }, (_, index) => ({ id: `fire-${index}` })),
+      fireDetections: Array.from({ length: 10 }, (_, index) => ({
+        id: `fire-${index}`,
+        source: 'firms',
+        detectedAt: Date.now() - 10 * 60_000,
+      })),
       pagination: { nextCursor: '', totalCount: FIRMS_TOTAL },
     };
     // stdDev 100 around a mean of 1000: both the correct count (21,600) and the buggy one (10)
@@ -425,5 +495,215 @@ describe('temporal anomalies cache freshness', () => {
       if (originalToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
       else process.env.UPSTASH_REDIS_REST_TOKEN = originalToken;
     }
+  });
+});
+
+describe('temporal anomalies content-age extractor (#7141)', () => {
+  const NOW = Date.parse('2026-08-27T12:00:00.000Z');
+
+  it('reduces independently-failing sources with min, not max', () => {
+    const newsAge = 72 * HOUR_MS;
+    const firesAge = 10 * 60_000;
+    const meta = temporalAnomaliesContentMeta({
+      news: frozenNews(NOW, newsAge),
+      satellite_fires: liveFires(NOW, firesAge),
+    }, NOW);
+
+    assert.ok(meta, 'both sources datable');
+    assert.equal(
+      meta.newestItemAt,
+      NOW - newsAge,
+      'frozen news must win over live fires — max() would hide the freeze',
+    );
+  });
+
+  it('a live news clock must not hide frozen FIRMS detections', () => {
+    const newsAge = 8 * 60_000;
+    const firesAge = 72 * HOUR_MS;
+    const meta = temporalAnomaliesContentMeta({
+      news: liveNews(NOW, newsAge),
+      satellite_fires: frozenFires(NOW, firesAge),
+    }, NOW);
+
+    assert.ok(meta);
+    assert.equal(meta.newestItemAt, NOW - firesAge);
+  });
+
+  it('skips an empty FIRMS window rather than failing the news clock', () => {
+    const newsAge = 12 * 60_000;
+    const meta = temporalAnomaliesContentMeta({
+      news: liveNews(NOW, newsAge),
+      satellite_fires: { fireDetections: [], pagination: { totalCount: 0 } },
+    }, NOW);
+
+    assert.ok(meta);
+    assert.equal(meta.newestItemAt, NOW - newsAge);
+  });
+
+  it('fails closed when a contributing news payload has items but no dates', () => {
+    const meta = temporalAnomaliesContentMeta({
+      news: { topStories: [{ id: 'a' }] },
+      satellite_fires: liveFires(NOW),
+    }, NOW);
+
+    assert.equal(meta, null, 'undatable news items are STALE_CONTENT, not skipped');
+  });
+
+  it('ignores agency ignition dates when FIRMS rows are present', () => {
+    const firmsAt = NOW - 20 * 60_000;
+    const agencyAt = NOW - 10 * 24 * HOUR_MS;
+    const meta = temporalAnomaliesContentMeta({
+      satellite_fires: {
+        fireDetections: [
+          { id: 'cwfis-1', source: 'cwfis', detectedAt: agencyAt },
+          { id: 'firms-1', source: 'firms', detectedAt: firmsAt },
+        ],
+      },
+    }, NOW);
+
+    assert.ok(meta);
+    assert.equal(meta.newestItemAt, firmsAt);
+  });
+
+  it('drops future-dated observations beyond the 1h clock-skew tolerance', () => {
+    const real = NOW - 30 * 60_000;
+    const future = NOW + 2 * HOUR_MS;
+    const meta = temporalAnomaliesContentMeta({
+      news: {
+        topStories: [
+          { id: 'future', pubDate: new Date(future).toISOString() },
+          { id: 'real', pubDate: new Date(real).toISOString() },
+        ],
+      },
+    }, NOW);
+
+    assert.ok(meta);
+    assert.equal(meta.newestItemAt, real);
+  });
+});
+
+describe('temporal anomalies frozen-but-200 feed (#7141)', () => {
+  it('stamps content age from the payloads, not the rebuild clock', async () => {
+    const now = Date.now();
+    const frozenAge = 72 * HOUR_MS;
+    const { calls } = await runWithRedisStub({
+      'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+      'news:insights:v1': frozenNews(now, frozenAge),
+      'wildfire:fires:v1': liveFires(now, 12 * 60_000),
+    });
+
+    const stamp = seedMetaStamp(calls);
+    const meta = stamp?.value as {
+      fetchedAt?: number;
+      newestItemAt?: number;
+      maxContentAgeMin?: number;
+    } | undefined;
+    assert.ok(meta, 'rebuild must stamp seed-meta');
+    assert.equal(typeof meta.fetchedAt, 'number');
+    assert.ok(
+      Math.abs((meta.fetchedAt ?? 0) - now) < 5_000,
+      'fetchedAt is the rebuild clock and stays fresh on a frozen feed',
+    );
+    assert.equal(meta.maxContentAgeMin, TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN);
+    assert.ok(
+      Math.abs((meta.newestItemAt ?? 0) - (now - frozenAge)) < 5_000,
+      `newestItemAt must be the frozen news observation, not rebuild time; got ${meta.newestItemAt}`,
+    );
+  });
+
+  it('a frozen-but-200 feed does not read green on health or MCP', async () => {
+    const now = Date.now();
+    const frozenAge = 72 * HOUR_MS;
+    const { calls } = await runWithRedisStub({
+      'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+      'news:insights:v1': frozenNews(now, frozenAge),
+      'wildfire:fires:v1': liveFires(now, 12 * 60_000),
+    });
+
+    const meta = seedMetaStamp(calls)?.value as Record<string, unknown> | undefined;
+    assert.ok(meta, 'precondition: rebuild stamped seed-meta');
+
+    const health = classifyTemporalMeta(meta, now);
+    assert.equal(
+      health.status,
+      'STALE_CONTENT',
+      'health must not stay OK when upstream observations are past the content budget',
+    );
+
+    const mcp = evaluateFreshness([temporalAnomaliesCheck()], [meta], now);
+    assert.equal(
+      mcp.stale,
+      true,
+      'MCP must not answer stale:false for the key health calls STALE_CONTENT',
+    );
+  });
+
+  it('stays green on both surfaces when observations are inside the content budget', async () => {
+    const now = Date.now();
+    const { calls } = await runWithRedisStub({
+      'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+      'news:insights:v1': liveNews(now, 20 * 60_000),
+      'wildfire:fires:v1': liveFires(now, 25 * 60_000),
+    });
+
+    const meta = seedMetaStamp(calls)?.value as Record<string, unknown> | undefined;
+    assert.ok(meta, 'precondition: rebuild stamped seed-meta');
+
+    const health = classifyTemporalMeta(meta, now);
+    assert.equal(health.status, 'OK', 'live payloads must not false-alarm as STALE_CONTENT');
+    assert.equal(
+      evaluateFreshness([temporalAnomaliesCheck()], [meta], now).stale,
+      false,
+      'MCP must stay fresh when content is inside budget',
+    );
+  });
+
+  it('stamps newestItemAt null when a contributing payload is undatable', async () => {
+    const { calls } = await runWithRedisStub({
+      'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+      'news:insights:v1': { topStories: [{ id: 'a' }] },
+    });
+
+    const meta = seedMetaStamp(calls)?.value as Record<string, unknown> | undefined;
+    assert.ok(meta);
+    assert.equal(meta.newestItemAt, null);
+    assert.equal(meta.maxContentAgeMin, TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN);
+    assert.equal(
+      classifyTemporalMeta(meta, Date.now()).status,
+      'STALE_CONTENT',
+      'undatable contributing payloads fail closed, matching runSeed contentMeta null',
+    );
+  });
+
+  it('diverges again if the content-age trio is dropped from the stamp', async () => {
+    const now = Date.now();
+    const { calls } = await runWithRedisStub({
+      'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+      'news:insights:v1': frozenNews(now, 72 * HOUR_MS),
+      'wildfire:fires:v1': liveFires(now, 12 * 60_000),
+    });
+
+    const stamped = seedMetaStamp(calls)?.value as Record<string, unknown> | undefined;
+    assert.ok(stamped);
+    const livenessOnly = {
+      fetchedAt: stamped.fetchedAt,
+      recordCount: stamped.recordCount,
+    };
+
+    assert.equal(
+      classifyTemporalMeta(livenessOnly, now).status,
+      'OK',
+      'without the content-age trio the rebuild clock reads green — the #7141 gap',
+    );
+    assert.equal(
+      evaluateFreshness([temporalAnomaliesCheck()], [livenessOnly], now).stale,
+      false,
+      'MCP liveness-only is also green, proving the trio is what closes the gap',
+    );
+    assert.equal(
+      classifyTemporalMeta(stamped, now).status,
+      'STALE_CONTENT',
+      'while the stamped trio still alarms',
+    );
   });
 });

--- a/tests/temporal-anomalies-cache.test.mts
+++ b/tests/temporal-anomalies-cache.test.mts
@@ -110,6 +110,20 @@ function frozenFires(now = Date.now(), ageMs = 72 * HOUR_MS, totalCount = 5) {
   return liveFires(now, ageMs, totalCount);
 }
 
+/** Canonical wildfire merge when FIRMS is down and CWFIS/BC still publish. */
+function canadaOnlyDegradedFires(now = Date.now()) {
+  return {
+    fireDetections: [
+      { id: 'cwfis-1', source: 'cwfis', detectedAt: now - 30 * 60_000 },
+      { id: 'bc-1', source: 'bc', detectedAt: now - 20 * 60_000 },
+    ],
+    _firmsState: 'failed',
+    _firmsErrorCode: 'FIRMS_SOURCE_FAILED',
+    _cwfisState: 'ok',
+    _bcState: 'ok',
+  };
+}
+
 function seedMetaStamp(calls: { method: string; key: string; value?: unknown }[]) {
   return calls.find((call) => call.method === 'POST' && call.key === 'seed-meta:temporal:anomalies');
 }
@@ -565,6 +579,35 @@ describe('temporal anomalies content-age extractor (#7141)', () => {
     assert.equal(meta.newestItemAt, firmsAt);
   });
 
+  it('fails closed on an explicit FIRMS failure even when CWFIS/BC still publish', () => {
+    const newsAge = 12 * 60_000;
+    const meta = temporalAnomaliesContentMeta({
+      news: liveNews(NOW, newsAge),
+      satellite_fires: canadaOnlyDegradedFires(NOW),
+    }, NOW);
+
+    assert.equal(
+      meta,
+      null,
+      'Canada-only degraded payload must fail closed, not skip so live news looks fresh',
+    );
+  });
+
+  it('still skips an agency-only payload that does not declare a FIRMS failure', () => {
+    const newsAge = 12 * 60_000;
+    const meta = temporalAnomaliesContentMeta({
+      news: liveNews(NOW, newsAge),
+      satellite_fires: {
+        fireDetections: [
+          { id: 'cwfis-1', source: 'cwfis', detectedAt: NOW - 30 * 60_000 },
+        ],
+      },
+    }, NOW);
+
+    assert.ok(meta);
+    assert.equal(meta.newestItemAt, NOW - newsAge);
+  });
+
   it('drops future-dated observations beyond the 1h clock-skew tolerance', () => {
     const real = NOW - 30 * 60_000;
     const future = NOW + 2 * HOUR_MS;
@@ -655,6 +698,35 @@ describe('temporal anomalies frozen-but-200 feed (#7141)', () => {
       evaluateFreshness([temporalAnomaliesCheck()], [meta], now).stale,
       false,
       'MCP must stay fresh when content is inside budget',
+    );
+  });
+
+  it('a Canada-only degraded FIRMS payload does not read green on seed-meta, health, or MCP', async () => {
+    const now = Date.now();
+    const { calls } = await runWithRedisStub({
+      'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+      'news:insights:v1': liveNews(now, 12 * 60_000),
+      'wildfire:fires:v1': canadaOnlyDegradedFires(now),
+    });
+
+    const meta = seedMetaStamp(calls)?.value as Record<string, unknown> | undefined;
+    assert.ok(meta, 'rebuild must stamp seed-meta for the degraded Canada-only payload');
+    assert.equal(
+      meta.newestItemAt,
+      null,
+      'explicit FIRMS failure must stamp newestItemAt null, not the live news clock',
+    );
+    assert.equal(meta.maxContentAgeMin, TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN);
+
+    assert.equal(
+      classifyTemporalMeta(meta, now).status,
+      'STALE_CONTENT',
+      'health must fail closed when worldwide FIRMS coverage is missing',
+    );
+    assert.equal(
+      evaluateFreshness([temporalAnomaliesCheck()], [meta], now).stale,
+      true,
+      'MCP must not answer stale:false for the Canada-only degraded payload',
     );
   });
 

--- a/tests/temporal-anomalies-cache.test.mts
+++ b/tests/temporal-anomalies-cache.test.mts
@@ -124,6 +124,14 @@ function canadaOnlyDegradedFires(now = Date.now()) {
   };
 }
 
+/** FIRMS rows present, but none carry a usable `detectedAt`. */
+function undatableFires(totalCount = 5) {
+  return {
+    fireDetections: [{ id: 'fire-1', source: 'firms' }],
+    pagination: { nextCursor: '', totalCount },
+  };
+}
+
 function seedMetaStamp(calls: { method: string; key: string; value?: unknown }[]) {
   return calls.find((call) => call.method === 'POST' && call.key === 'seed-meta:temporal:anomalies');
 }
@@ -563,6 +571,15 @@ describe('temporal anomalies content-age extractor (#7141)', () => {
     assert.equal(meta, null, 'undatable news items are STALE_CONTENT, not skipped');
   });
 
+  it('fails closed when FIRMS rows exist but none have a usable detectedAt', () => {
+    const meta = temporalAnomaliesContentMeta({
+      news: liveNews(NOW),
+      satellite_fires: undatableFires(),
+    }, NOW);
+
+    assert.equal(meta, null, 'undatable FIRMS rows are STALE_CONTENT, not skipped');
+  });
+
   it('ignores agency ignition dates when FIRMS rows are present', () => {
     const firmsAt = NOW - 20 * 60_000;
     const agencyAt = NOW - 10 * 24 * HOUR_MS;
@@ -817,6 +834,31 @@ describe('temporal anomalies frozen-but-200 feed (#7141)', () => {
       evaluateFreshness([temporalAnomaliesCheck()], [meta], now).stale,
       true,
       'MCP must fail closed on the same incomplete coverage',
+    );
+  });
+
+  it('stamps newestItemAt null when FIRMS rows have no usable detectedAt', async () => {
+    const now = Date.now();
+    const { calls } = await runWithRedisStub({
+      'temporal:anomalies:v1': freshSnapshot(TEMPORAL_ANOMALIES_REBUILD_AFTER_MS + 60_000),
+      'news:insights:v1': liveNews(now),
+      'wildfire:fires:v1': undatableFires(),
+    });
+
+    const meta = seedMetaStamp(calls)?.value as Record<string, unknown> | undefined;
+    assert.ok(meta, 'rebuild must stamp seed-meta');
+    assert.equal(meta.newestItemAt, null);
+    assert.equal(meta.maxContentAgeMin, TEMPORAL_ANOMALIES_MAX_CONTENT_AGE_MIN);
+
+    assert.equal(
+      classifyTemporalMeta(meta, now).status,
+      'STALE_CONTENT',
+      'undatable FIRMS rows fail closed on health even when news is live',
+    );
+    assert.equal(
+      evaluateFreshness([temporalAnomaliesCheck()], [meta], now).stale,
+      true,
+      'MCP must not answer stale:false for undatable FIRMS',
     );
   });
 


### PR DESCRIPTION
## Summary

`seed-meta:temporal:anomalies` was a rebuild clock. A successful rebuild only meant `COUNT_SOURCE_KEYS` resolved, so a frozen-but-200 `news:insights:v1` or `wildfire:fires:v1` feed kept `fetchedAt` fresh and all three consumers green:

- `api/health.js`
- `api/mcp/registry/analysis-tools.ts`
- `api/mcp/registry/cache-tools.ts`

This follows the seeder-liveness vs content-age split from #3845 / #3851:

1. **Seeder liveness** — `fetchedAt` vs `maxStaleMin` (did the rebuild run?)
2. **Content age** — `newestItemAt` vs `maxContentAgeMin` (did the observations advance?)

The producer now stamps `newestItemAt` / `oldestItemAt` / `maxContentAgeMin` from the upstream payloads. Per-source clocks reduce with **min**, so a live fires feed cannot hide frozen news (and vice versa). `evaluateFreshness` honors that trio the same way `classifyKey` does, so MCP cannot answer `stale: false` for a key health calls `STALE_CONTENT`.

Budget is 48h, sized from FIRMS' 1-day window plus the midnight NRT lag — not from the 20-minute rebuild cadence.

Closes #7141

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`) — `/api/health`, MCP `get_temporal_anomalies` / analysis digest freshness
- [x] Other: `list-temporal-anomalies` seed-meta stamp

## Tests

- `tests/temporal-anomalies-cache.test.mts` — extractor min-reduction, frozen-but-200 does not read green on health or MCP, live payloads stay OK, dropping the trio re-opens the gap
- `tests/mcp.test.mjs` — `evaluateFreshness` marks content-age stale when `fetchedAt` is fresh
- Existing temporal-anomalies cache / health-content-age / PortWatch parity suites still pass
- `npm run typecheck:api` clean