### PR TITLE
fix(mcp): point get_market_data at the keys its seeders actually write

### DIFF
--- a/api/mcp/prompts/index.ts
+++ b/api/mcp/prompts/index.ts
@@ -108,7 +108,10 @@ export const PROMPT_REGISTRY: McpPromptDef[] = [
       {
         tool: 'get_market_data',
         args: { asset_class: ['equity', 'commodity', 'crypto'] },
-        jmespath: '{equity: data."stocks-bootstrap".quotes[*].{symbol: symbol, changePercent: changePercent}, commodity: data."commodities-bootstrap".quotes[*].{symbol: symbol, changePercent: changePercent}, crypto: data.crypto.quotes[*].{symbol: symbol, changePercent: changePercent}}',
+        // The served key is `change` and it is already a percent; the
+        // projection renames it so the agent reading the result cannot mistake
+        // it for an absolute price delta.
+        jmespath: '{equity: data."stocks-bootstrap".quotes[*].{symbol: symbol, changePercent: change}, commodity: data."commodities-bootstrap".quotes[*].{symbol: symbol, changePercent: change}, crypto: data.crypto.quotes[*].{symbol: symbol, changePercent: change}}',
         purpose: 'Per-asset-class quote pairs (symbol + changePercent only). Skip ETF flows / sectors / Gulf / fear-greed — they belong in a deeper drill-down, not a session-opening read.',
       },
     ],

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -468,7 +468,10 @@ export const CACHE_TOOLS: ToolDef[] = [
       crypto: {
         type: ['object', 'null'],
         properties: {
-          quotes: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, price: { type: 'number' }, change: { type: 'number', description: 'Percent change vs prior close.' } } } },
+          // Crypto trades continuously, so there is no prior close to compare
+          // against: scripts/seed-crypto-quotes.mjs carries the provider's
+          // rolling percent_change_24h straight into `change`.
+          quotes: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, price: { type: 'number' }, change: { type: 'number', description: 'Percent change over the trailing 24 hours (crypto trades continuously; this is not a prior-close comparison).' } } } },
         },
       },
       sectors: {

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -423,11 +423,17 @@ export const CACHE_TOOLS: ToolDef[] = [
       },
       required: [],
     },
+    // Every quote list serves `change` (a PERCENT — the seeders
+    // normalise Finnhub `dp` / Alpha Vantage / Yahoo through
+    // scripts/shared/market-quote-provider.mjs) and ETF rows serve `estFlow`.
+    // This schema previously advertised `changePercent` and `flow`, which no
+    // producer has ever written, so every agent projecting per the hint got
+    // null for each row. Keep these names pinned to the seeders.
     outputSchema: cacheEnvelope({
       'stocks-bootstrap': {
         type: ['object', 'null'],
         properties: {
-          quotes: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, price: { type: 'number' }, changePercent: { type: 'number' } } } },
+          quotes: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, price: { type: 'number' }, change: { type: 'number', description: 'Percent change vs prior close.' } } } },
           finnhubSkipped: { type: 'boolean' },
           skipReason: { type: 'string' },
           rateLimited: { type: 'boolean' },
@@ -436,7 +442,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       'commodities-bootstrap': {
         type: ['object', 'null'],
         properties: {
-          quotes: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, price: { type: 'number' }, changePercent: { type: 'number' } } } },
+          quotes: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, price: { type: 'number' }, change: { type: 'number', description: 'Percent change vs prior close.' } } } },
         },
       },
       'physical-premium': {
@@ -462,13 +468,13 @@ export const CACHE_TOOLS: ToolDef[] = [
       crypto: {
         type: ['object', 'null'],
         properties: {
-          quotes: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, price: { type: 'number' }, changePercent: { type: 'number' } } } },
+          quotes: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, price: { type: 'number' }, change: { type: 'number', description: 'Percent change vs prior close.' } } } },
         },
       },
       sectors: {
         type: ['object', 'null'],
         properties: {
-          sectors: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, name: { type: 'string' }, changePercent: { type: 'number' } } } },
+          sectors: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, name: { type: 'string' }, change: { type: 'number', description: 'Percent change vs prior close.' } } } },
           valuations: { type: ['object', 'array', 'null'] },
           valuationCoverage: {
             type: ['object', 'null'],
@@ -535,14 +541,14 @@ export const CACHE_TOOLS: ToolDef[] = [
         properties: {
           timestamp: { type: ['string', 'number', 'null'] },
           summary: { type: ['object', 'null'] },
-          etfs: { type: 'array', items: { type: 'object', properties: { ticker: { type: 'string' }, flow: { type: 'number' } } } },
+          etfs: { type: 'array', items: { type: 'object', properties: { ticker: { type: 'string' }, estFlow: { type: 'number', description: 'Estimated net USD flow (volume x price heuristic).' } } } },
           rateLimited: { type: 'boolean' },
         },
       },
       'gulf-quotes': {
         type: ['object', 'null'],
         properties: {
-          quotes: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, price: { type: 'number' }, changePercent: { type: 'number' } } } },
+          quotes: { type: 'array', items: { type: 'object', properties: { symbol: { type: 'string' }, price: { type: 'number' }, change: { type: 'number', description: 'Percent change vs prior close.' } } } },
           rateLimited: { type: 'boolean' },
         },
       },

--- a/api/mcp/ui/market-radar-app.ts
+++ b/api/mcp/ui/market-radar-app.ts
@@ -6,10 +6,10 @@
 //
 // Tool result shape (cache tool — content[0].text JSON, freshness envelope):
 //   { cached_at, stale, data: {
-//       "stocks-bootstrap": { quotes: [{ symbol, price, changePercent }] },
+//       "stocks-bootstrap": { quotes: [{ symbol, price, change }] },
 //       "commodities-bootstrap": { quotes: [...] }, "crypto": { quotes: [...] },
 //       "gulf-quotes": { quotes: [...] },
-//       "sectors": { sectors: [{ symbol, name, changePercent }] },
+//       "sectors": { sectors: [{ symbol, name, change }] },
 //       "fear-greed": { composite: { score, label, previous } } } }
 // Any label may be absent (asset_class / symbols filters narrow the bundle).
 //
@@ -102,7 +102,10 @@ const RENDER = `
         var price = num(it.price);
         tbl.appendChild(el("span", "qprice",
           price == null ? "—" : price.toLocaleString(undefined, { maximumFractionDigits: 2 })));
-        var chg = num(it.changePercent);
+        // The served percent key is "change". No seeder writes
+        // changePercent, so reading it rendered the em-dash in every row.
+        // NOTE: no backticks here -- this string is a template literal.
+        var chg = num(it.change);
         var cell = el("span", "qchg", pctText(chg));
         if (chg != null) cell.style.color = chg >= 0 ? cssVar("--up") : cssVar("--down");
         tbl.appendChild(cell);

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -730,6 +730,7 @@
       "scripts/shared/china-corporate-disclosure-policy.js",
       "scripts/shared/crypto.json",
       "scripts/shared/defi-tokens.json",
+      "scripts/shared/etf-flow-provider.mjs",
       "scripts/shared/etfs.json",
       "scripts/shared/gulf.json",
       "scripts/shared/other-tokens.json",

--- a/scripts/seed-etf-flows.mjs
+++ b/scripts/seed-etf-flows.mjs
@@ -3,6 +3,7 @@
 import { loadEnvFile, loadSharedConfig, runSeed } from './_seed-utils.mjs';
 import { fetchYahooJson } from './_yahoo-fetch.mjs';
 import { fetchAvBulkQuotes } from './_shared-av.mjs';
+import { parseEtfChartData, toSeedEtfFlow } from './shared/etf-flow-provider.mjs';
 
 const etfConfig = loadSharedConfig('etfs.json');
 
@@ -16,52 +17,6 @@ const ETF_LIST = etfConfig.btcSpot;
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
-}
-
-function parseEtfChartData(chart, ticker, issuer) {
-  const result = chart?.chart?.result?.[0];
-  if (!result) return null;
-
-  const quote = result.indicators?.quote?.[0];
-  const closes = quote?.close || [];
-  const volumes = quote?.volume || [];
-
-  // Filter closes and volumes TOGETHER so price and volume always come from
-  // the same bar — Yahoo routinely nulls one but not the other, and pairing
-  // today's volume with yesterday's close fabricated false flows.
-  const alignedBars = closes
-    .map((p, i) => ({ p, v: volumes[i] }))
-    .filter(({ p, v }) => p != null && v != null);
-  const validCloses = alignedBars.map(({ p }) => p);
-  const validVolumes = alignedBars.map(({ v }) => v);
-
-  if (validCloses.length < 2) return null;
-
-  const latestPrice = validCloses[validCloses.length - 1];
-  const prevPrice = validCloses[validCloses.length - 2];
-  const priceChange = prevPrice ? ((latestPrice - prevPrice) / prevPrice) * 100 : 0;
-
-  const latestVolume = validVolumes.length > 0 ? validVolumes[validVolumes.length - 1] : 0;
-  const avgVolume =
-    validVolumes.length > 1
-      ? validVolumes.slice(0, -1).reduce((a, b) => a + b, 0) / (validVolumes.length - 1)
-      : latestVolume;
-
-  const volumeRatio = avgVolume > 0 ? latestVolume / avgVolume : 1;
-  const direction = priceChange > 0.1 ? 'inflow' : priceChange < -0.1 ? 'outflow' : 'neutral';
-  const estFlowMagnitude = latestVolume * latestPrice * (priceChange > 0 ? 1 : -1) * 0.1;
-
-  return {
-    ticker,
-    issuer,
-    price: +latestPrice.toFixed(2),
-    priceChange: +priceChange.toFixed(2),
-    volume: latestVolume,
-    avgVolume: Math.round(avgVolume),
-    volumeRatio: +volumeRatio.toFixed(2),
-    direction,
-    estFlow: Math.round(estFlowMagnitude),
-  };
 }
 
 async function fetchEtfFlows() {
@@ -78,12 +33,10 @@ async function fetchEtfFlows() {
       const av = avData.get(ticker);
       if (!av) continue;
       const { price, change: priceChange, volume } = av;
-      const direction = priceChange > 0.1 ? 'inflow' : priceChange < -0.1 ? 'outflow' : 'neutral';
-      const estFlow = Math.round(volume * price * (priceChange > 0 ? 1 : -1) * 0.1);
       // avgVolume and volumeRatio require 5-day history not available from REALTIME_BULK_QUOTES
-      etfs.push({ ticker, issuer, price: +price.toFixed(2), priceChange: +priceChange.toFixed(2), volume, avgVolume: 0, volumeRatio: 0, direction, estFlow });
+      etfs.push(toSeedEtfFlow({ ticker, issuer, price, priceChange, volume }));
       covered.add(ticker);
-      console.log(`  [AV] ${ticker}: $${price.toFixed(2)} (${direction})`);
+      console.log(`  [AV] ${ticker}: $${price.toFixed(2)} (${etfs.at(-1).direction})`);
     }
   }
 
@@ -154,15 +107,17 @@ export function declareRecords(data) {
   return Array.isArray(data?.etfs) ? data.etfs.length : 0;
 }
 
-runSeed('market', 'etf-flows', CANONICAL_KEY, fetchEtfFlows, {
-  validateFn: validate,
-  ttlSeconds: CACHE_TTL,
-  sourceVersion: 'alphavantage+yahoo-chart-5d',
+if (process.argv[1]?.endsWith('seed-etf-flows.mjs')) {
+  runSeed('market', 'etf-flows', CANONICAL_KEY, fetchEtfFlows, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: 'alphavantage+yahoo-chart-5d',
 
-  declareRecords,
-  schemaVersion: 1,
-  maxStaleMin: 60,
-}).catch((err) => {
-  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
-  process.exit(1);
-});
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 60,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/shared/etf-flow-provider.mjs
+++ b/scripts/shared/etf-flow-provider.mjs
@@ -1,0 +1,71 @@
+/**
+ * Pure ETF-flow normalization shared by the Railway seeder and contract tests.
+ */
+
+/**
+ * @param {{ ticker: string; issuer: string; price: number; priceChange: number; volume: number; avgVolume?: number; volumeRatio?: number }} input
+ */
+export function toSeedEtfFlow({
+  ticker,
+  issuer,
+  price,
+  priceChange,
+  volume,
+  avgVolume = 0,
+  volumeRatio = 0,
+}) {
+  const direction = priceChange > 0.1 ? 'inflow' : priceChange < -0.1 ? 'outflow' : 'neutral';
+  const estFlow = Math.round(volume * price * (priceChange > 0 ? 1 : -1) * 0.1);
+  return {
+    ticker,
+    issuer,
+    price: +price.toFixed(2),
+    priceChange: +priceChange.toFixed(2),
+    volume,
+    avgVolume: Math.round(avgVolume),
+    volumeRatio: +volumeRatio.toFixed(2),
+    direction,
+    estFlow,
+  };
+}
+
+export function parseEtfChartData(chart, ticker, issuer) {
+  const result = chart?.chart?.result?.[0];
+  if (!result) return null;
+
+  const quote = result.indicators?.quote?.[0];
+  const closes = quote?.close || [];
+  const volumes = quote?.volume || [];
+
+  // Filter closes and volumes TOGETHER so price and volume always come from
+  // the same bar — Yahoo routinely nulls one but not the other, and pairing
+  // today's volume with yesterday's close fabricated false flows.
+  const alignedBars = closes
+    .map((p, i) => ({ p, v: volumes[i] }))
+    .filter(({ p, v }) => p != null && v != null);
+  const validCloses = alignedBars.map(({ p }) => p);
+  const validVolumes = alignedBars.map(({ v }) => v);
+
+  if (validCloses.length < 2) return null;
+
+  const latestPrice = validCloses[validCloses.length - 1];
+  const prevPrice = validCloses[validCloses.length - 2];
+  const priceChange = prevPrice ? ((latestPrice - prevPrice) / prevPrice) * 100 : 0;
+
+  const latestVolume = validVolumes.length > 0 ? validVolumes[validVolumes.length - 1] : 0;
+  const avgVolume =
+    validVolumes.length > 1
+      ? validVolumes.slice(0, -1).reduce((a, b) => a + b, 0) / (validVolumes.length - 1)
+      : latestVolume;
+
+  const volumeRatio = avgVolume > 0 ? latestVolume / avgVolume : 1;
+  return toSeedEtfFlow({
+    ticker,
+    issuer,
+    price: latestPrice,
+    priceChange,
+    volume: latestVolume,
+    avgVolume,
+    volumeRatio,
+  });
+}

--- a/tests/helpers/mcp-producer-fixtures.mjs
+++ b/tests/helpers/mcp-producer-fixtures.mjs
@@ -1,0 +1,57 @@
+import { toSeedEtfFlow } from '../../scripts/shared/etf-flow-provider.mjs';
+import { toSeedQuote } from '../../scripts/shared/market-quote-provider.mjs';
+
+/**
+ * Overlay deterministic outputs from the real market seed mappers onto the
+ * captured market bundle. The capture remains useful for broad shape/render
+ * coverage, while these rows make schema and JMESPath checks fail if a mapper
+ * stops emitting the fields the MCP surface promises.
+ */
+export function buildProducerBackedMarketFixture(captured) {
+  const fixture = structuredClone(captured);
+  const quoteLists = [
+    ['stocks-bootstrap', 'quotes'],
+    ['commodities-bootstrap', 'quotes'],
+    ['crypto', 'quotes'],
+    ['gulf-quotes', 'quotes'],
+  ];
+
+  for (const [section, list] of quoteLists) {
+    const rows = fixture.data?.[section]?.[list];
+    if (!Array.isArray(rows)) continue;
+    fixture.data[section][list] = rows.map((row, index) => ({
+      ...row,
+      ...toSeedQuote(
+        row.symbol,
+        { price: 100 + index, change: index % 2 === 0 ? 1.25 : -0.75, sparkline: [99 + index, 100 + index] },
+        { name: row.name, display: row.display },
+      ),
+    }));
+  }
+
+  const sectors = fixture.data?.sectors?.sectors;
+  if (Array.isArray(sectors)) {
+    fixture.data.sectors.sectors = sectors.map((row, index) => ({
+      ...row,
+      change: index % 2 === 0 ? 1.1 : -0.6,
+    }));
+  }
+
+  const etfs = fixture.data?.['etf-flows']?.etfs;
+  if (Array.isArray(etfs)) {
+    fixture.data['etf-flows'].etfs = etfs.map((row, index) => ({
+      ...row,
+      ...toSeedEtfFlow({
+        ticker: row.ticker,
+        issuer: row.issuer,
+        price: 40 + index,
+        priceChange: index % 2 === 0 ? 2.5 : -1.5,
+        volume: 1_000_000 + index * 10_000,
+        avgVolume: 900_000 + index * 10_000,
+        volumeRatio: 1.1,
+      }),
+    }));
+  }
+
+  return fixture;
+}

--- a/tests/market-quote-provider-seeder.test.mjs
+++ b/tests/market-quote-provider-seeder.test.mjs
@@ -12,6 +12,7 @@ import {
   hasSufficientFreshQuoteCoverage,
   toSeedQuote,
 } from '../scripts/shared/market-quote-provider.mjs';
+import { toSeedEtfFlow } from '../scripts/shared/etf-flow-provider.mjs';
 
 const ORIGINAL_FETCH = globalThis.fetch;
 const ORIGINAL_ENV = {
@@ -33,6 +34,22 @@ describe('toSeedQuote', () => {
     assert.deepEqual(
       toSeedQuote('AAPL', { price: 1, change: 2, sparkline: [1, 2] }, { name: 'Apple', display: 'AAPL' }),
       { symbol: 'AAPL', name: 'Apple', display: 'AAPL', price: 1, change: 2, sparkline: [1, 2] },
+    );
+  });
+});
+
+describe('toSeedEtfFlow', () => {
+  it('publishes the authoritative estFlow field from deterministic inputs', () => {
+    assert.deepEqual(
+      toSeedEtfFlow({
+        ticker: 'IBIT', issuer: 'BlackRock', price: 40, priceChange: 2.5,
+        volume: 1_000_000, avgVolume: 900_000, volumeRatio: 1.11,
+      }),
+      {
+        ticker: 'IBIT', issuer: 'BlackRock', price: 40, priceChange: 2.5,
+        volume: 1_000_000, avgVolume: 900_000, volumeRatio: 1.11,
+        direction: 'inflow', estFlow: 4_000_000,
+      },
     );
   });
 });

--- a/tests/mcp-market-radar-app-render.test.mts
+++ b/tests/mcp-market-radar-app-render.test.mts
@@ -1,0 +1,125 @@
+// End-to-end render of the `get_market_data` MCP App shell against the real
+// captured tool response.
+//
+// The Market Radar widget read `it.changePercent` off every quote row
+// while every seeder writes `change`, so all 40 change cells rendered the
+// em-dash placeholder `pctText(null)` returns — symbols and prices looked
+// perfect, which is why nothing noticed. No suite rendered the widget, so the
+// only signals were a schema that agreed with the bug and a prompt that
+// repeated it.
+//
+// This drives the genuine emitted shell: the same HTML `resources/read` serves,
+// the same postMessage handshake a host performs, and the committed fixture
+// captured from the production MCP endpoint. A field-name drift between the
+// widget and its producer shows up here as a column of placeholders.
+
+import { describe, it, before, after } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { Window } from 'happy-dom';
+
+import { MARKET_RADAR_APP_HTML } from '../api/mcp/ui/market-radar-app';
+
+const FIXTURE = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures', 'jmespath-samples', 'fat-get-market-data.response.json',
+);
+
+// The widget's own placeholder for a value it could not read (shell.ts pctText).
+const PLACEHOLDER = '—';
+
+let win: any;
+let doc: any;
+
+function textOf(selector: string): string[] {
+  return [...doc.querySelectorAll(selector)].map((n: any) => String(n.textContent));
+}
+
+describe('api/mcp/ui/market-radar-app.ts — renders the captured get_market_data response', () => {
+  before(async () => {
+    const fixture = JSON.parse(readFileSync(FIXTURE, 'utf8'));
+
+    win = new Window({ url: 'https://worldmonitor.app/' });
+    win.document.write(MARKET_RADAR_APP_HTML);
+    await win.happyDOM.waitUntilComplete();
+
+    // happy-dom does not execute a <script> introduced by document.write, so
+    // run the served script text itself — the real bridge + renderBody, not a
+    // reimplementation of them.
+    const script = win.document.querySelector('script');
+    assert.ok(script && script.textContent.length > 0, 'app shell must ship an inline bridge script');
+    win.eval(script.textContent);
+    await win.happyDOM.waitUntilComplete();
+
+    // The bridge captures `window.parent` inside its own realm and drops any
+    // message whose source is not that object, so the host handshake has to be
+    // impersonated with the in-realm reference (the outer handle is a
+    // different proxy and would be silently ignored).
+    const hostWindow = win.eval('window.parent');
+    win.dispatchEvent(new win.MessageEvent('message', {
+      data: {
+        jsonrpc: '2.0',
+        method: 'ui/notifications/tool-result',
+        params: { result: { structuredContent: fixture } },
+      },
+      source: hostWindow,
+    }));
+    await win.happyDOM.waitUntilComplete();
+    doc = win.document;
+  });
+
+  after(async () => {
+    await win?.happyDOM?.close();
+  });
+
+  // Guards the harness itself: if the handshake ever stops rendering, the
+  // assertions below would pass vacuously over an empty node list.
+  it('renders every quote group from the fixture', () => {
+    assert.equal(doc.getElementById('card').style.display, 'block', 'card must be revealed on a tool result');
+    assert.equal(
+      doc.querySelectorAll('.mgroup').length, 5,
+      'fixture carries equities, commodities, crypto, Gulf and sectors',
+    );
+    assert.equal(textOf('.qsym').length, 40, 'fixture renders 40 quote rows across the five groups');
+    assert.equal(textOf('.qsym')[0], 'AAPL');
+  });
+
+  it('renders a real percent in every change cell (never the null placeholder)', () => {
+    const changes = textOf('.qchg');
+    assert.ok(changes.length > 0, 'no change cells rendered — harness broken, not a passing assertion');
+    const placeholders = changes.filter((t) => t === PLACEHOLDER);
+    assert.deepEqual(
+      placeholders, [],
+      `${placeholders.length} of ${changes.length} change cells rendered "${PLACEHOLDER}". The widget is ` +
+      'reading a quote key the seeders do not write (schema and widget once said changePercent; ' +
+      'every producer writes change).',
+    );
+    for (const text of changes) {
+      assert.match(
+        text, /^[+-]?\d+\.\d{2}%$/,
+        `change cell "${text}" is not a signed percent — pctText did not receive a number`,
+      );
+    }
+  });
+
+  it('renders prices and the Fear & Greed composite, proving the whole payload is reachable', () => {
+    const groups = [...doc.querySelectorAll('.mgroup')];
+    assert.deepEqual(
+      groups.map((g: any) => g.querySelector('.sec-label').textContent),
+      ['Equities', 'Commodities', 'Crypto', 'Gulf', 'Sectors'],
+    );
+    // Sector rows are performance-only — the seeder writes {symbol, name,
+    // change} with no price, so a placeholder there is the correct render, not
+    // drift. Every other group is priced.
+    for (const group of groups.slice(0, 4)) {
+      const label = group.querySelector('.sec-label').textContent;
+      const prices = [...group.querySelectorAll('.qprice')].map((n: any) => String(n.textContent));
+      assert.ok(prices.length > 0, `${label} group rendered no rows`);
+      assert.deepEqual(prices.filter((t) => t === PLACEHOLDER), [], `every ${label} row must render a price`);
+    }
+    assert.match(doc.getElementById('fg-score').textContent, /^\d+$/, 'fear-greed composite score must render');
+    assert.ok(doc.getElementById('fg-label').textContent.length > 0, 'fear-greed label must render');
+  });
+});

--- a/tests/mcp-market-radar-app-render.test.mts
+++ b/tests/mcp-market-radar-app-render.test.mts
@@ -21,6 +21,7 @@ import path from 'node:path';
 import { Window } from 'happy-dom';
 
 import { MARKET_RADAR_APP_HTML } from '../api/mcp/ui/market-radar-app';
+import { buildProducerBackedMarketFixture } from './helpers/mcp-producer-fixtures.mjs';
 
 const FIXTURE = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -39,7 +40,7 @@ function textOf(selector: string): string[] {
 
 describe('api/mcp/ui/market-radar-app.ts — renders the captured get_market_data response', () => {
   before(async () => {
-    const fixture = JSON.parse(readFileSync(FIXTURE, 'utf8'));
+    const fixture = buildProducerBackedMarketFixture(JSON.parse(readFileSync(FIXTURE, 'utf8')));
 
     win = new Window({ url: 'https://worldmonitor.app/' });
     win.document.write(MARKET_RADAR_APP_HTML);
@@ -62,7 +63,10 @@ describe('api/mcp/ui/market-radar-app.ts — renders the captured get_market_dat
       data: {
         jsonrpc: '2.0',
         method: 'ui/notifications/tool-result',
-        params: { result: { structuredContent: fixture } },
+        // Production dispatch sends the JSON payload as content[0].text.
+        // Keep this harness on that wire path so structuredContent shortcuts
+        // cannot hide a real response-decoding regression.
+        params: { result: { content: [{ type: 'text', text: JSON.stringify(fixture) }] } },
       },
       source: hostWindow,
     }));

--- a/tests/mcp-output-schema-coverage.test.mjs
+++ b/tests/mcp-output-schema-coverage.test.mjs
@@ -7,7 +7,12 @@
 //   2. Every fixture in tests/fixtures/jmespath-samples/ validates against the
 //      schema declared by the tool that produced it. Drift between declared
 //      schema and the real response shape fails the test by tool name.
-//   3. tools/list emits outputSchema on every advertised tool — surfacing the
+//   3. The reverse direction of 2: no tool may declare a list-item field that
+//      is absent from every captured row. Schema validation alone cannot see
+//      this — `properties` without `required` admits a payload that omits a
+//      declared key, which is how get_market_data advertised `changePercent`
+//      while every seeder wrote `change`.
+//   4. tools/list emits outputSchema on every advertised tool — surfacing the
 //      field at the wire boundary in addition to the in-process registry.
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
@@ -211,7 +216,118 @@ describe('api/mcp.ts — per-tool outputSchema coverage (v1.7.0)', () => {
       );
       assert.equal(market.probability, undefined, `${bucket} must not advertise the drifted probability field`);
     }
+
+    // get_market_data advertised `changePercent` on all five quote
+    // lists and `flow` on ETF rows; the seeders write `change` (a percent --
+    // scripts/shared/market-quote-provider.mjs maps Finnhub `dp`) and
+    // `estFlow` (scripts/seed-etf-flows.mjs). Every agent projecting per the
+    // schema's own hint got null for every row.
+    const marketData = dataProperties('get_market_data');
+    const quoteLists = [
+      ['stocks-bootstrap', 'quotes'],
+      ['commodities-bootstrap', 'quotes'],
+      ['crypto', 'quotes'],
+      ['gulf-quotes', 'quotes'],
+      ['sectors', 'sectors'],
+    ];
+    for (const [section, list] of quoteLists) {
+      const row = marketData[section].properties[list].items.properties;
+      assert.ok(row.change, `${section}.${list}[] must declare the served \`change\` key`);
+      assert.equal(
+        row.changePercent, undefined,
+        `${section}.${list}[] must not advertise the drifted changePercent field`,
+      );
+    }
+    const etfRow = marketData['etf-flows'].properties.etfs.items.properties;
+    assert.ok(etfRow.estFlow, 'etf-flows.etfs[] must declare the served `estFlow` key');
+    assert.equal(etfRow.flow, undefined, 'etf-flows.etfs[] must not advertise the drifted flow field');
   });
+
+  // --------------------------------------------------------------------
+  // Test 2c — no declared list-item field is absent from EVERY captured row
+  // --------------------------------------------------------------------
+  // Test 2 validates the fixture against the schema, which is a one-way check:
+  // JSON Schema `properties` without `required` admits a payload that omits a
+  // declared key entirely, so "schema promises changePercent, seeder writes
+  // change" validated clean in both directions for this tool's whole life.
+  //
+  // This is the missing direction. Scoped to ARRAY ROWS because list rows are
+  // homogeneous -- a declared row field served on 0 of N rows is a phantom the
+  // agent will project to null, whereas envelope-level flags (`rateLimited`,
+  // `currentValuationCount`, `unavailable`) are legitimately omit-when-absent
+  // and are deliberately not covered here.
+  //
+  // Pre-existing phantoms outside this fix's blast radius are listed explicitly
+  // rather than silently skipped, so the count can only go down. Each is the
+  // same defect class -- schema key never written by the producer:
+  const KNOWN_PHANTOM_ROW_FIELDS = new Set([
+    // Serves `locationName` (+ latitude/longitude) -- scripts/seed-iran-events.mjs.
+    'get_conflict_events.data.iran-events.events[].country',
+    'get_conflict_events.data.iran-events.events[].location',
+    // Serves staticBaseline/dynamicScore/combinedScore, never a flat `score`.
+    'get_conflict_events.data.scores.ciiScores[].score',
+    // Baseline rows serve id/name/mbd/lat/lon; `relayId` is also read by the
+    // tool's own `chokepoint` filter, so aligning it is a behaviour decision,
+    // not a rename.
+    'get_chokepoint_status.data.chokepoint-baselines.chokepoints[].relayId',
+  ]);
+
+  // Walks the schema alongside the values actually observed at each node, so
+  // the row check runs wherever a fixture supplies rows -- not just at paths
+  // this test hardcodes.
+  function collectPhantomRowFields(schema, values, path, out) {
+    if (!schema || typeof schema !== 'object') return;
+    const objects = values.filter((v) => v && typeof v === 'object' && !Array.isArray(v));
+    const arrays = values.filter(Array.isArray);
+
+    if (schema.properties && objects.length > 0) {
+      for (const [key, subSchema] of Object.entries(schema.properties)) {
+        const observed = objects.map((o) => o[key]).filter((v) => v !== undefined && v !== null);
+        if (observed.length > 0) collectPhantomRowFields(subSchema, observed, `${path}.${key}`, out);
+      }
+    }
+    if (schema.items && arrays.length > 0) {
+      const rows = arrays.flat().filter((r) => r && typeof r === 'object' && !Array.isArray(r));
+      if (rows.length === 0) return;
+      const served = new Set();
+      for (const row of rows) for (const key of Object.keys(row)) served.add(key);
+      for (const key of Object.keys(schema.items.properties ?? {})) {
+        if (!served.has(key)) out.push({ field: `${path}[].${key}`, rows: rows.length });
+      }
+      collectPhantomRowFields(schema.items, rows, `${path}[]`, out);
+    }
+  }
+
+  for (const { file, tool: toolName } of FIXTURES) {
+    it(`${toolName} declares no list-item field that is absent from every captured row (${file})`, () => {
+      const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
+      const fixture = JSON.parse(
+        readFileSync(path.join(fixtureDir, 'fixtures', 'jmespath-samples', file), 'utf8'),
+      );
+      const tool = mod.__testing__.TOOL_REGISTRY.find(t => t.name === toolName);
+      assert.ok(tool, `tool ${toolName} not found in registry`);
+
+      const found = [];
+      collectPhantomRowFields(tool.outputSchema, [fixture], toolName, found);
+      const unexpected = found.filter(({ field }) => !KNOWN_PHANTOM_ROW_FIELDS.has(field));
+      assert.deepEqual(
+        unexpected.map(({ field, rows }) => `${field} (served on 0 of ${rows} rows)`),
+        [],
+        `${toolName} advertises row fields the captured payload never serves — an agent projecting ` +
+        'them gets null for every row. Align the schema to the producer, or the producer to the schema.',
+      );
+
+      // A fixed phantom must leave the allowlist, or the list rots into cover
+      // for the next regression.
+      const stillListed = new Set(found.map(({ field }) => field));
+      const staleAllowlist = [...KNOWN_PHANTOM_ROW_FIELDS]
+        .filter(field => field.startsWith(`${toolName}.`) && !stillListed.has(field));
+      assert.deepEqual(
+        staleAllowlist, [],
+        'KNOWN_PHANTOM_ROW_FIELDS entries are no longer phantom — delete them from the allowlist',
+      );
+    });
+  }
 
   // --------------------------------------------------------------------
   // Test 3 — outputSchema is emitted on the wire for every tool in tools/list

--- a/tests/mcp-output-schema-coverage.test.mjs
+++ b/tests/mcp-output-schema-coverage.test.mjs
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 import { validate } from './helpers/json-schema-mini.mjs';
+import { buildProducerBackedMarketFixture } from './helpers/mcp-producer-fixtures.mjs';
 
 const VALID_KEY = 'wm_test_key_output_schema';
 const originalEnv = { ...process.env };
@@ -111,6 +112,18 @@ describe('api/mcp.ts — per-tool outputSchema coverage (v1.7.0)', () => {
       assert.deepEqual(errors, [], `fixture ${file} fails schema:\n  ${errors.join('\n  ')}`);
     });
   }
+
+  it('get_market_data schema validates a deterministic producer-backed fixture', () => {
+    const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
+    const captured = JSON.parse(readFileSync(
+      path.join(fixtureDir, 'fixtures', 'jmespath-samples', 'fat-get-market-data.response.json'),
+      'utf8',
+    ));
+    const tool = mod.__testing__.TOOL_REGISTRY.find(t => t.name === 'get_market_data');
+    assert.ok(tool, 'tool get_market_data not found in registry');
+    const errors = validate(tool.outputSchema, buildProducerBackedMarketFixture(captured));
+    assert.deepEqual(errors, [], `producer-backed market fixture fails schema:\n  ${errors.join('\n  ')}`);
+  });
 
   it('interactive cache-tool schemas declare the authoritative fields consumed by their apps', () => {
     const dataProperties = (toolName) => {

--- a/tests/mcp-prompts.test.mjs
+++ b/tests/mcp-prompts.test.mjs
@@ -27,6 +27,9 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import jmespath from 'jmespath';
 
 import {
@@ -314,6 +317,94 @@ describe('api/mcp.ts — prompts capability + JMESPath-vs-schema parity', () => 
         }
       }
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // Phase 2 — evaluate the JMESPath against a real captured response
+  // -------------------------------------------------------------------------
+  // The parity test above is prompt-vs-SCHEMA, which is not enough on its
+  // own: get_market_data's schema advertised `changePercent` while every
+  // seeder wrote `change`, so the prompt and the schema agreed on a key the
+  // payload never carried and this suite stayed green while the shipped
+  // market-open-prep projection returned changePercent:null for all 29 rows.
+  //
+  // Running the expression against the committed fixture closes the loop:
+  // prompt -> schema -> actual bytes. A projected column that is null on every
+  // row is the exact signature of a field-name drift.
+  const FIXTURE_BY_TOOL = {
+    get_market_data: 'fat-get-market-data.response.json',
+    get_conflict_events: 'medium-get-conflict-events.response.json',
+    get_chokepoint_status: 'thin-get-chokepoint-status.response.json',
+  };
+
+  // Report every array-of-objects column whose value is null/undefined on all
+  // rows. Rows are homogeneous, so an all-null column means the projection is
+  // reading a key the payload does not have — not that the data is sparse.
+  //
+  // Caveat for a future fixture recapture: a field that is genuinely null on
+  // every captured row would also land here. Check the producer before
+  // relaxing anything — the far likelier cause is a renamed key.
+  function collectDeadColumns(value, path, out) {
+    if (Array.isArray(value)) {
+      const rows = value.filter((r) => r && typeof r === 'object' && !Array.isArray(r));
+      if (rows.length === 0) return;
+      for (const key of new Set(rows.flatMap((r) => Object.keys(r)))) {
+        const column = rows.map((r) => r[key]);
+        if (column.every((v) => v == null)) out.push(`${path}[].${key} (null on all ${rows.length} rows)`);
+        else collectDeadColumns(column.filter((v) => v != null), `${path}[].${key}`, out);
+      }
+      return;
+    }
+    if (value && typeof value === 'object') {
+      for (const [key, sub] of Object.entries(value)) collectDeadColumns(sub, `${path}.${key}`, out);
+    }
+  }
+
+  it('every prompt step JMESPath projects live values when evaluated against the captured fixture', () => {
+    const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'jmespath-samples');
+    let covered = 0;
+
+    for (const prompt of PROMPT_REGISTRY) {
+      for (const [i, step] of prompt.steps.entries()) {
+        const file = FIXTURE_BY_TOOL[step.tool];
+        if (!file) continue;
+        covered++;
+        const fixture = JSON.parse(readFileSync(path.join(fixtureDir, file), 'utf8'));
+        const label = `prompt "${prompt.name}" step ${i + 1} (${step.tool})`;
+
+        const projected = jmespath.search(fixture, step.jmespath);
+        assert.ok(
+          projected != null,
+          `${label}: JMESPath "${step.jmespath}" projected null from ${file} — the expression matches nothing in a real response`,
+        );
+
+        // A drifted SECTION name (data."stocks-bootstrapp") collapses its whole
+        // branch to null rather than to a column of nulls, so the row walk below
+        // would never see it. Checked only at the top level: a nested null is
+        // ordinary sparse data, a null the prompt asked for by name is not.
+        if (!Array.isArray(projected) && typeof projected === 'object') {
+          const emptyBranches = Object.entries(projected)
+            .filter(([, v]) => v == null)
+            .map(([k]) => k);
+          assert.deepEqual(
+            emptyBranches, [],
+            `${label}: JMESPath "${step.jmespath}" projected null for ${emptyBranches.join(', ')} against ` +
+            `${file} — that path does not exist in a real response`,
+          );
+        }
+
+        const dead = [];
+        collectDeadColumns(projected, 'result', dead);
+        assert.deepEqual(
+          dead, [],
+          `${label}: JMESPath "${step.jmespath}" projects columns that are null on every row of ${file}. ` +
+          'The prompt is reading a field name the payload does not serve — align the projection with the ' +
+          "producer's keys (and fix the tool's outputSchema if it advertises the same phantom).",
+        );
+      }
+    }
+
+    assert.ok(covered > 0, 'no prompt step mapped to a captured fixture — FIXTURE_BY_TOOL has gone stale');
   });
 });
 

--- a/tests/mcp-prompts.test.mjs
+++ b/tests/mcp-prompts.test.mjs
@@ -35,6 +35,7 @@ import jmespath from 'jmespath';
 import {
   BASE_URL,
 } from './helpers/mcp-pro-deps.mjs';
+import { buildProducerBackedMarketFixture } from './helpers/mcp-producer-fixtures.mjs';
 
 const originalFetch = globalThis.fetch;
 const originalEnv = { ...process.env };
@@ -337,6 +338,44 @@ describe('api/mcp.ts — prompts capability + JMESPath-vs-schema parity', () => 
     get_chokepoint_status: 'thin-get-chokepoint-status.response.json',
   };
 
+  // The prompt registry spans more tools than the retained captures above.
+  // Keep deterministic, representative producer-shaped fixtures for every
+  // remaining tool so a new prompt step cannot silently disappear from this
+  // contract gate. These values only need to exercise the declared JMESPath
+  // branches; the captured fixtures remain the broad payload proof.
+  const FIXTURE_BUILDERS = {
+    get_country_risk: () => ({
+      cii: 42,
+      components: { unrest: 10, conflict: 20, security: 30, news: 40 },
+      travelAdvisory: { level: '2' },
+      sanctionsExposure: [],
+    }),
+    get_country_brief: () => ({ country_code: 'DE', brief: 'Stable growth with moderate external risks.' }),
+    get_country_macro: () => ({
+      cached_at: '2026-08-27T00:00:00.000Z',
+      stale: false,
+      data: {
+        macro: { countries: { DE: { inflationPct: 2.1 } } },
+        growth: { countries: { DE: { gdpGrowthPct: 1.2 } } },
+        labor: { countries: { DE: { unemploymentPct: 5.9 } } },
+      },
+    }),
+    get_energy_intelligence: () => ({
+      cached_at: '2026-08-27T00:00:00.000Z',
+      stale: false,
+      data: {
+        disruptions: { events: [{ id: 'disruption-1', countries: ['DE'], severity: 'medium' }] },
+        'fuel-shortages': { shortages: [{ country: 'DE', product: 'diesel', status: 'watch' }] },
+        'crisis-policies': { policies: [{ country: 'DE', policy: 'reserve release' }] },
+      },
+    }),
+    get_news_intelligence: () => ({
+      cached_at: '2026-08-27T00:00:00.000Z',
+      stale: false,
+      data: { insights: { topStories: [{ primaryTitle: 'Market alert', primarySource: 'Wire', isAlert: true }] } },
+    }),
+  };
+
   // Report every array-of-objects column whose value is null/undefined on all
   // rows. Rows are homogeneous, so an all-null column means the projection is
   // reading a key the payload does not have — not that the data is sparse.
@@ -362,49 +401,65 @@ describe('api/mcp.ts — prompts capability + JMESPath-vs-schema parity', () => 
 
   it('every prompt step JMESPath projects live values when evaluated against the captured fixture', () => {
     const fixtureDir = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures', 'jmespath-samples');
+    const totalSteps = PROMPT_REGISTRY.reduce((count, prompt) => count + prompt.steps.length, 0);
     let covered = 0;
+    const uncovered = [];
 
     for (const prompt of PROMPT_REGISTRY) {
       for (const [i, step] of prompt.steps.entries()) {
         const file = FIXTURE_BY_TOOL[step.tool];
-        if (!file) continue;
+        const sources = file
+          ? [{ fixture: JSON.parse(readFileSync(path.join(fixtureDir, file), 'utf8')), label: file }]
+          : FIXTURE_BUILDERS[step.tool]
+            ? [{ fixture: FIXTURE_BUILDERS[step.tool](), label: 'producer-backed fixture' }]
+            : [];
+        if (sources.length === 0) {
+          uncovered.push(`prompt "${prompt.name}" step ${i + 1} (${step.tool})`);
+          continue;
+        }
         covered++;
-        const fixture = JSON.parse(readFileSync(path.join(fixtureDir, file), 'utf8'));
-        const label = `prompt "${prompt.name}" step ${i + 1} (${step.tool})`;
 
-        const projected = jmespath.search(fixture, step.jmespath);
-        assert.ok(
-          projected != null,
-          `${label}: JMESPath "${step.jmespath}" projected null from ${file} — the expression matches nothing in a real response`,
-        );
+        for (const { fixture: rawFixture, label: fixtureLabel } of sources) {
+          const fixture = step.tool === 'get_market_data'
+            ? buildProducerBackedMarketFixture(rawFixture)
+            : rawFixture;
+          const label = `prompt "${prompt.name}" step ${i + 1} (${step.tool})`;
 
-        // A drifted SECTION name (data."stocks-bootstrapp") collapses its whole
-        // branch to null rather than to a column of nulls, so the row walk below
-        // would never see it. Checked only at the top level: a nested null is
-        // ordinary sparse data, a null the prompt asked for by name is not.
-        if (!Array.isArray(projected) && typeof projected === 'object') {
-          const emptyBranches = Object.entries(projected)
-            .filter(([, v]) => v == null)
-            .map(([k]) => k);
+          const projected = jmespath.search(fixture, step.jmespath);
+          assert.ok(
+            projected != null,
+            `${label}: JMESPath "${step.jmespath}" projected null from ${fixtureLabel} — the expression matches nothing in a real response`,
+          );
+
+          // A drifted SECTION name (data."stocks-bootstrapp") collapses its whole
+          // branch to null rather than to a column of nulls, so the row walk below
+          // would never see it. Checked only at the top level: a nested null is
+          // ordinary sparse data, a null the prompt asked for by name is not.
+          if (!Array.isArray(projected) && typeof projected === 'object') {
+            const emptyBranches = Object.entries(projected)
+              .filter(([, v]) => v == null)
+              .map(([k]) => k);
+            assert.deepEqual(
+              emptyBranches, [],
+              `${label}: JMESPath "${step.jmespath}" projected null for ${emptyBranches.join(', ')} against ` +
+              `${fixtureLabel} — that path does not exist in a real response`,
+            );
+          }
+
+          const dead = [];
+          collectDeadColumns(projected, 'result', dead);
           assert.deepEqual(
-            emptyBranches, [],
-            `${label}: JMESPath "${step.jmespath}" projected null for ${emptyBranches.join(', ')} against ` +
-            `${file} — that path does not exist in a real response`,
+            dead, [],
+            `${label}: JMESPath "${step.jmespath}" projects columns that are null on every row of ${fixtureLabel}. ` +
+            'The prompt is reading a field name the payload does not serve — align the projection with the ' +
+            "producer's keys (and fix the tool's outputSchema if it advertises the same phantom).",
           );
         }
-
-        const dead = [];
-        collectDeadColumns(projected, 'result', dead);
-        assert.deepEqual(
-          dead, [],
-          `${label}: JMESPath "${step.jmespath}" projects columns that are null on every row of ${file}. ` +
-          'The prompt is reading a field name the payload does not serve — align the projection with the ' +
-          "producer's keys (and fix the tool's outputSchema if it advertises the same phantom).",
-        );
       }
     }
 
-    assert.ok(covered > 0, 'no prompt step mapped to a captured fixture — FIXTURE_BY_TOOL has gone stale');
+    assert.deepEqual(uncovered, [], `prompt steps without a fixture or producer-backed builder:\n  ${uncovered.join('\n  ')}`);
+    assert.equal(covered, totalSteps, 'every prompt step must be exercised by a fixture or producer-backed builder');
   });
 });
 


### PR DESCRIPTION
## Summary

Anyone who asked `get_market_data` for price changes got `null` on every row, and the Market Radar app rendered a dash where each percentage should have been. That has been true since the tool shipped.

The `outputSchema` advertised `changePercent` on all five quote lists and `flow` on ETF rows. No producer has ever written either name: the seeders normalise every provider to `change` — a percent, via `scripts/shared/market-quote-provider.mjs` mapping Finnhub's `dp` — and `scripts/seed-etf-flows.mjs` writes `estFlow`.

| Section | Advertised | Actually served |
|---|---|---|
| `stocks-bootstrap.quotes[]` | `changePercent` | `change` |
| `commodities-bootstrap.quotes[]` | `changePercent` | `change` |
| `crypto.quotes[]` | `changePercent` | `change` |
| `gulf-quotes.quotes[]` | `changePercent` | `change` |
| `sectors.sectors[]` | `changePercent` | `change` |
| `etf-flows.etfs[]` | `flow` | `estFlow` |

Two shipped surfaces repeated the same phantom keys, so this was never documentation-only:

- The **Market Radar** MCP App read `it.changePercent`, so all 40 change cells rendered the em-dash `pctText(null)` returns. Symbols and prices were fine, which is why it read as missing upstream data rather than a bug.
- The **`market-open-prep`** prompt shipped a JMESPath projecting `changePercent: changePercent` — null for all 29 equity rows and every commodity and crypto row.

The published docs were already correct (`docs/mcp-jmespath.mdx` uses `chg:change`), which is the tell: they were written against real responses, while the schema, the widget, and the prompt were written against an assumed shape and then agreed with each other.

## Why nothing caught it

Every existing check ran in one direction.

- **Fixture vs schema** validated the captured production response against the schema — but JSON Schema `properties` without `required` admits a payload that omits a declared key entirely, so a phantom validates clean.
- **Prompt vs schema** compared the prompt's field names against the schema — which agreed with the bug.

Nothing compared the schema to the actual bytes, and nothing rendered the widget.

## Closing the loop

Three tests, each confirmed red against the pre-fix code before the fix was written:

1. **Schema vs payload** (`mcp-output-schema-coverage`) — no declared list-item field may be absent from every captured row. Runs over all three committed fixtures, so it guards every tool that has one.
2. **Prompt vs payload** (`mcp-prompts`) — evaluates each prompt's JMESPath against the matching fixture. Fails on an all-null projected column, and on a projected key whose whole branch is null, which is how a drifted *section* name would present. This is the "full path-level eval against fixtures" the file's own header had carried as a follow-up.
3. **Widget vs payload** (`mcp-market-radar-app-render.test.mts`, new) — drives the emitted app shell under happy-dom through the real `ui/notifications/tool-result` handshake and requires a signed percent in every change cell. Before the fix it reported 40 of 40 cells as the placeholder.

## Two scope calls worth a reviewer's attention

**Three more phantoms, found but not fixed.** The new invariant surfaced the same defect in two other tools. They are listed in an explicit allowlist with their real keys rather than folded into this PR, and a companion assertion fails if an entry stops being phantom, so the list cannot rot into cover for a future regression.

| Tool | Advertised | Actually served |
|---|---|---|
| `get_conflict_events` | `scores.ciiScores[].score` | `staticBaseline` / `dynamicScore` / `combinedScore` |
| `get_conflict_events` | `iran-events.events[].country`, `.location` | `locationName` + `latitude` / `longitude` |
| `get_chokepoint_status` | `chokepoint-baselines.chokepoints[].relayId` | `id` / `name` / `mbd` / `lat` / `lon` |

The first two are one-line aligns. `relayId` is not: the tool's own `chokepoint` filter reads it too (`cache-tools.ts:2347`), so aligning it is a behaviour decision rather than a rename.

**The ETF row stays minimal on purpose.** Declaring the full nine-field ETF row would be more useful to an agent, but `describe_tool(get_market_data)` has an 8192-byte output budget and already sat near 7400 — the expansion pushed it to 8200 and the tool's own description silently became a `_budget_exceeded` envelope. This PR keeps the rename plus a short description; headroom is now 517 bytes. Worth knowing that this tool is roughly one added paragraph from breaking that budget again.

## Validation

- `tests/mcp*` — 1345 pass, 0 fail. The MCP-adjacent suites (`docs-mcp`, `llms-txt-mcp-tools`, `gateway-internal-mcp`, `pro-mcp-token`, `sec-corporate-intel-mcp`) — 113 pass, 0 fail.
- `typecheck:api` and biome clean on the changed files.
- All three new tests were run against the unfixed code first and observed failing for the intended reason; the section-drift assertion was additionally verified by temporarily corrupting a section name in the prompt.
- The new render test lives at the top level rather than under `tests/dom/`, matching `tests/demographics-capability-render.test.mts`: it constructs its own `Window` and never touches DOM globals, so it belongs to the node test runner and avoids the vitest routing trap documented in `docs/solutions/test-failures/pre-push-fed-vitest-dom-tests-to-the-node-test-runner.md`.

No live MCP call was made against production — the OAuth token for the World Monitor MCP server had expired mid-session — so every claim above is grounded in the committed production-captured fixture and the producer source rather than a fresh prod probe.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
