### PR TITLE
fix(climate): drop Cloudflare-blocked Inside Climate News feed

### DIFF
--- a/docs/climate-variant-full.md
+++ b/docs/climate-variant-full.md
@@ -211,7 +211,6 @@ message IceTrendPoint {
 - NOAA Climate News: `https://www.noaa.gov/taxonomy/term/28/rss`
 - Phys.org Earth Science: `https://phys.org/rss-feed/earth-news/earth-sciences/`
 - Copernicus/ECMWF: `https://atmosphere.copernicus.eu/rss`
-- Inside Climate News: `https://insideclimatenews.org/feed/`
 - Climate Central: `https://www.climatecentral.org/rss`
 
 **Redis key:** `climate:news-intelligence:v1`

--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -12,7 +12,7 @@ The inventory is **generated, not hand-written**: `scripts/source-attribution.mj
 ## Observed Source Inventory
 
 {/* BEGIN GENERATED SOURCE ATTRIBUTION */}
-This generated inventory covers **753 active source hosts** representing **746 active providers** (**322 structured/API**, **463 feed**, and **30 operational-status** hosts). It is derived from source declarations in `scripts/`, `server/`, `api/`, and `src/`. Each row shows the configured provider identity and where the source is referenced. Syndication transports such as FeedBurner and Google News remain listed as hosts and are not counted as publishers.
+This generated inventory covers **752 active source hosts** representing **745 active providers** (**321 structured/API**, **463 feed**, and **30 operational-status** hosts). It is derived from source declarations in `scripts/`, `server/`, `api/`, and `src/`. Each row shows the configured provider identity and where the source is referenced. Syndication transports such as FeedBurner and Google News remain listed as hosts and are not counted as publishers.
 
 | Provider | Observed surface |
 | --- | --- |
@@ -325,7 +325,7 @@ This generated inventory covers **753 active source hosts** representing **746 a
 | index.hu (index.hu) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | indianexpress.com (indianexpress.com) | feed — src/config/feeds.ts |
 | indiatodaylive.akamaized.net (indiatodaylive.akamaized.net) | feed — src/components/LiveNewsPanel.ts |
-| insideclimatenews.org (insideclimatenews.org) | structured — scripts/seed-climate-news.mjs |
+| insideclimatenews.org (insideclimatenews.org) | Excluded / candidate — No current fetch observed |
 | insightcrime.org (insightcrime.org) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | Interfax (interfax.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | Interfax (www.interfax.ru) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |

--- a/scripts/_climate-news-helpers.mjs
+++ b/scripts/_climate-news-helpers.mjs
@@ -48,7 +48,7 @@ export function climateNewsContentMeta(data, nowMs = Date.now()) {
 /**
  * Sprint 3a pilot threshold (7 days). Climate news from the listed feeds
  * (Carbon Brief, Guardian Environment, NASA EO, UNEP, Phys.org, Copernicus,
- * Inside Climate News, Climate Central, ReliefWeb) collectively publish daily
+ * Climate Central, ReliefWeb) collectively publish daily
  * to multiple-times-per-day. A 7-day budget tolerates a major holiday weekend
  * across all sources without paging on normal cadence — and trips on a real
  * upstream-aggregator outage where every feed's parse silently breaks.

--- a/scripts/seed-climate-news.mjs
+++ b/scripts/seed-climate-news.mjs
@@ -13,7 +13,10 @@ const CACHE_TTL = 5400; // 90min = 3× 30-min relay interval (gold standard: TTL
 const MAX_ITEMS = 100;
 const RSS_MAX_BYTES = 500_000;
 
-const FEEDS = [
+// 8 sources after #4714. One investigative outlet's official WordPress /feed
+// is Cloudflare-gated (HTTP 403 on every Railway run); there is no official
+// ungated mirror, and WAF/bot-detection evasion is out of scope.
+export const CLIMATE_NEWS_FEEDS = [
   { sourceName: 'Carbon Brief', url: 'https://www.carbonbrief.org/feed' },
   { sourceName: 'The Guardian Environment', url: 'https://www.theguardian.com/environment/climate-crisis/rss' },
   { sourceName: 'ReliefWeb Disasters', isApi: true },
@@ -21,9 +24,9 @@ const FEEDS = [
   { sourceName: 'UNEP', url: 'https://www.unep.org/rss.xml' },
   { sourceName: 'Phys.org Earth Science', url: 'https://phys.org/rss-feed/earth-news/earth-sciences/' },
   { sourceName: 'Copernicus Climate', url: 'https://climate.copernicus.eu/rss.xml' },
-  { sourceName: 'Inside Climate News', url: 'https://insideclimatenews.org/feed/' },
   { sourceName: 'Climate Central', url: 'https://www.climatecentral.org/rss' },
 ];
+const FEEDS = CLIMATE_NEWS_FEEDS;
 
 function stableHash(str) {
   let h = 0;
@@ -197,7 +200,7 @@ if (isMain) {
   runSeed('climate', 'news-intelligence', CANONICAL_KEY, fetchClimateNews, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
-  sourceVersion: 'climate-rss-v1',
+  sourceVersion: 'climate-rss-v2',
   recordCount: (data) => data?.items?.length || 0,
 
   declareRecords,

--- a/scripts/source-origin.mjs
+++ b/scripts/source-origin.mjs
@@ -287,7 +287,6 @@ const HOST_ORIGINS = Object.freeze({
   'humanprogress.org': 'US',
   'inc42.com': 'IN',
   'indianexpress.com': 'IN',
-  'insideclimatenews.org': 'US',
   'insightcrime.org': 'US',
   'ipinfo.io': 'US',
   'islandtimes.org': 'PW',

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -5001,15 +5001,10 @@
       "host": "insideclimatenews.org",
       "provider": "insideclimatenews.org",
       "kind": "structured",
-      "observed": true,
+      "observed": false,
       "license": "Provider terms for this upstream API/dataset; verify before redistribution",
       "attribution": "Credit insideclimatenews.org and link to the original upstream API/dataset.",
-      "status": "terms-review",
-      "references": [
-        {
-          "path": "scripts/seed-climate-news.mjs"
-        }
-      ]
+      "status": "excluded"
     },
     {
       "host": "insightcrime.org",

--- a/tests/climate-news-feeds.test.mjs
+++ b/tests/climate-news-feeds.test.mjs
@@ -1,0 +1,79 @@
+// Focused regression for koala73/worldmonitor#4714.
+//
+// Inside Climate News' official WordPress feed (insideclimatenews.org/feed/)
+// sits behind Cloudflare bot-management and returned HTTP 403 on 100% of
+// Climate-News Railway runs. The issue forbids WAF/bot-detection evasion;
+// the official feed's atom:link rel="self" is that same origin, and no
+// ungated official mirror (FeedBurner, JSON Feed, etc.) exists. Option 2
+// drops the source (9 → 8 feeds). This test pins the remaining list so the
+// blocked host cannot silently return.
+//
+// Seam: CLIMATE_NEWS_FEEDS is exported from the seeder (guarded by isMain
+// so importing it here does not trigger a real seed run).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { CLIMATE_NEWS_FEEDS } from '../scripts/seed-climate-news.mjs';
+
+const SEEDER_SOURCE = readFileSync(new URL('../scripts/seed-climate-news.mjs', import.meta.url), 'utf8');
+const VARIANT_DOCS = readFileSync(new URL('../docs/climate-variant-full.md', import.meta.url), 'utf8');
+const ATTRIBUTION_DOCS = readFileSync(new URL('../docs/source-attribution.mdx', import.meta.url), 'utf8');
+const ATTRIBUTION_MANIFEST = JSON.parse(
+  readFileSync(new URL('../shared/source-attribution-manifest.json', import.meta.url), 'utf8'),
+);
+
+const EXPECTED_SOURCE_NAMES = [
+  'Carbon Brief',
+  'The Guardian Environment',
+  'ReliefWeb Disasters',
+  'NASA Earth Observatory',
+  'UNEP',
+  'Phys.org Earth Science',
+  'Copernicus Climate',
+  'Climate Central',
+];
+
+describe('seed-climate-news feed list (#4714)', () => {
+  it('has eight sources and does not include Cloudflare-blocked Inside Climate News', () => {
+    assert.equal(CLIMATE_NEWS_FEEDS.length, 8);
+    assert.deepEqual(
+      CLIMATE_NEWS_FEEDS.map((feed) => feed.sourceName),
+      EXPECTED_SOURCE_NAMES,
+    );
+    assert.ok(
+      !CLIMATE_NEWS_FEEDS.some((feed) => /inside\s*climate/i.test(feed.sourceName)),
+      'Inside Climate News must not remain in the climate-news seeder',
+    );
+  });
+
+  it('does not reintroduce the Cloudflare-gated ICN host', () => {
+    // A URL literal would also re-register the host in the source-attribution
+    // scan (scripts/, not comments-exempt). Keep the hostname out of the seeder.
+    assert.doesNotMatch(SEEDER_SOURCE, /insideclimatenews\.org/i);
+    assert.doesNotMatch(SEEDER_SOURCE, /Inside Climate News/);
+  });
+
+  it('keeps remaining feeds as HTTPS URLs or the ReliefWeb API adapter', () => {
+    for (const feed of CLIMATE_NEWS_FEEDS) {
+      if (feed.isApi) {
+        assert.equal(feed.sourceName, 'ReliefWeb Disasters');
+        assert.equal(feed.url, undefined);
+        continue;
+      }
+      assert.match(feed.url, /^https:\/\//);
+    }
+  });
+
+  it('retires the ICN host in the source-attribution ledger instead of leaving a stale observed row', () => {
+    const entry = ATTRIBUTION_MANIFEST.entries.find((row) => row.host === 'insideclimatenews.org');
+    assert.ok(entry, 'historical credit for the retired host must remain in the ledger');
+    assert.equal(entry.observed, false);
+    assert.equal(entry.status, 'excluded');
+    assert.equal(entry.references, undefined);
+    assert.match(ATTRIBUTION_DOCS, /insideclimatenews\.org \(insideclimatenews\.org\) \| Excluded \/ candidate — No current fetch observed/);
+    assert.doesNotMatch(VARIANT_DOCS, /insideclimatenews\.org/);
+    assert.doesNotMatch(VARIANT_DOCS, /Inside Climate News/);
+  });
+});


### PR DESCRIPTION
## What

Drop Inside Climate News from the climate-news seeder. The official WordPress feed is behind Cloudflare bot-management and returns HTTP 403 on every Railway Climate-News run, so ICN content never reaches `climate:news-intelligence`.

The remaining 8 sources already oversupply the 100-item cap, so section volume stays intact while the per-run 403 error log goes away.

## Why this option

Issue #4714 allows either a non-Cloudflare official/mirror ICN feed, or dropping the source. I checked the official feed: `atom:link rel="self"` is `https://insideclimatenews.org/feed/`. WordPress aliases (`/feed/rss`, `/?feed=rss2`, `/feed/atom`) are the same origin. There is no official FeedBurner, JSON Feed, or other ungated ICN mirror.

WAF/bot-detection evasion is out of scope, so the source is removed rather than scraped around Cloudflare.

## Changes

- Remove ICN from `scripts/seed-climate-news.mjs` (export `CLIMATE_NEWS_FEEDS`, 9 → 8 feeds, bump `sourceVersion` to `climate-rss-v2`)
- Retire `insideclimatenews.org` in the source-attribution ledger (`observed: false`, `status: excluded`) and regenerate docs counts (753 → 752 active hosts, 746 → 745 providers)
- Drop the unused `.org` origin override
- Update climate-news helper/docs source lists
- Pin the remaining feed list and the retired ledger row in `tests/climate-news-feeds.test.mjs`

## How verified

- `node --test tests/climate-news-feeds.test.mjs tests/climate-news-entity-decode.test.mjs tests/climate-news-content-age.test.mjs`
- `node --test tests/source-attribution.test.mjs tests/source-catalog-syndication.test.mjs`
- `node --input-type=module -e "import { checkSourceAttribution } from './scripts/source-attribution.mjs'; …"` (clean: 752 active hosts / 745 providers)
- `tsc --noEmit`

Closes #4714
