### PR TITLE
fix(map): make filtered webcam markers clickable

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -172,6 +172,7 @@ import { fetchWebcamImage } from '@/services/webcams';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import { summarizeRenderTiming, formatRenderTiming } from '@/components/map/render-timing';
 import { DeferredHeavyCommit } from '@/components/map/deferred-layer-commit';
+import { dispatchWebcamLayerClick, resolveWebcamStreamUrl, type WebcamLeafLike } from '@/components/map/webcam-click';
 import {
   type BBox,
   type BoundedFeature,
@@ -2293,6 +2294,9 @@ export class DeckGLMap {
         getFillColor: (d) => ('count' in d ? [0, 212, 255, 180] : [255, 215, 0, 200]) as [number, number, number, number],
         radiusUnits: 'pixels',
         pickable: true,
+        // Consume the pick (return true) so MapboxOverlay onClick → handleClick
+        // does not double-fire. Cluster vs leaf is routed in handleWebcamLayerClick.
+        onClick: (info) => this.handleWebcamLayerClick(info),
       }));
     }
 
@@ -5285,8 +5289,8 @@ export class DeckGLMap {
       return;
     }
 
-    if (layerId === 'webcam-layer' && !('count' in info.object)) {
-      this.showWebcamClickPopup(info.object as WebcamEntry, info.x, info.y);
+    if (layerId === 'webcam-layer') {
+      this.handleWebcamLayerClick(info);
       return;
     }
 
@@ -5406,7 +5410,24 @@ export class DeckGLMap {
     }
   }
 
-  private async showWebcamClickPopup(webcam: WebcamEntry, x: number, y: number): Promise<void> {
+  /**
+   * Layer-level webcam pick. Returns true so deck.gl consumes the event and the
+   * global MapboxOverlay handler does not run a second time (#3877 / #4230).
+   * Clusters zoom in instead of opening a tab per camera.
+   */
+  private handleWebcamLayerClick(info: PickingInfo): boolean {
+    return dispatchWebcamLayerClick(info.object, {
+      onLeaf: (webcam) => {
+        this.showWebcamClickPopup(webcam, info.x, info.y);
+      },
+      onCluster: (cluster) => {
+        const currentZoom = this.maplibreMap?.getZoom() ?? this.state.zoom;
+        this.setCenter(cluster.lat, cluster.lng, Math.min(currentZoom + 2, 14));
+      },
+    });
+  }
+
+  private async showWebcamClickPopup(webcam: WebcamLeafLike, x: number, y: number): Promise<void> {
     // Remove any existing popup
     this.container.querySelector('.deckgl-webcam-popup')?.remove();
 
@@ -5428,12 +5449,20 @@ export class DeckGLMap {
     popup.appendChild(locationEl);
 
     const id = webcam.webcamId;
-
-    // Fetch playerUrl for when user pins
-    const imageData = await fetchWebcamImage(id).catch(() => null);
+    const streamUrl = resolveWebcamStreamUrl(webcam);
+    if (streamUrl) {
+      const link = document.createElement('a');
+      link.className = 'deckgl-webcam-popup-link';
+      link.href = streamUrl;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      link.textContent = 'Open on Windy \u2197';
+      popup.appendChild(link);
+    }
 
     const pinBtn = document.createElement('button');
     pinBtn.className = 'webcam-pin-btn';
+    let imageData: Awaited<ReturnType<typeof fetchWebcamImage>> | null = null;
     if (isPinned(id)) {
       pinBtn.classList.add('webcam-pin-btn--pinned');
       pinBtn.textContent = '\u{1F4CC} Pinned';
@@ -5469,7 +5498,16 @@ export class DeckGLMap {
     const autoDismiss = setTimeout(cleanup, 8000);
     setTimeout(() => document.addEventListener('click', closeHandler), 0);
 
+    // Show immediately so a slow image fetch cannot look like a dead click.
     this.container.appendChild(popup);
+
+    imageData = await fetchWebcamImage(id).catch(() => null);
+    if (!popup.isConnected) return;
+
+    if (imageData?.windyUrl) {
+      const existing = popup.querySelector<HTMLAnchorElement>('.deckgl-webcam-popup-link');
+      if (existing) existing.href = imageData.windyUrl;
+    }
   }
 
   // Utility methods

--- a/src/components/map/webcam-click.ts
+++ b/src/components/map/webcam-click.ts
@@ -1,0 +1,109 @@
+/**
+ * Click routing for the global-view webcam ScatterplotLayer (#3877).
+ *
+ * The layer mixes individual cameras (`WebcamEntry`) with server-side clusters
+ * (`WebcamCluster`). Leaf clicks must open the public stream in a new tab and
+ * consume the deck.gl pick so the MapboxOverlay `onClick` does not double-fire.
+ * Cluster clicks must never spawn N tabs — callers zoom/expand instead.
+ *
+ * Discriminate on the `_kind` tag stamped at `setWebcams` ingestion, with a
+ * `'count' in obj` fallback for untagged objects. Do not cast a cluster to a
+ * leaf: `webcamId` is undefined on clusters and would fetch/open garbage.
+ */
+
+export interface WebcamLeafLike {
+  _kind?: 'webcam';
+  webcamId: string;
+  title: string;
+  lat: number;
+  lng: number;
+  category: string;
+  country: string;
+}
+
+export interface WebcamClusterLike {
+  _kind?: 'webcam-cluster';
+  lat: number;
+  lng: number;
+  count: number;
+}
+
+export const WEBCAM_STREAM_OPEN_FEATURES = 'noopener,noreferrer';
+
+export type OpenWindowFn = (url: string, target?: string, features?: string) => unknown;
+
+export function isWebcamClusterMarker(obj: unknown): obj is WebcamClusterLike {
+  if (obj === null || typeof obj !== 'object') return false;
+  const rec = obj as Record<string, unknown>;
+  if (rec._kind === 'webcam-cluster') return true;
+  if (rec._kind === 'webcam') return false;
+  return typeof rec.count === 'number' && typeof rec.webcamId !== 'string';
+}
+
+export function isWebcamLeafMarker(obj: unknown): obj is WebcamLeafLike {
+  if (obj === null || typeof obj !== 'object') return false;
+  const rec = obj as Record<string, unknown>;
+  if (rec._kind === 'webcam') return typeof rec.webcamId === 'string';
+  if (rec._kind === 'webcam-cluster') return false;
+  return typeof rec.webcamId === 'string' && typeof rec.count !== 'number';
+}
+
+export function resolveWebcamStreamUrl(
+  webcam: Pick<WebcamLeafLike, 'webcamId'>,
+  image?: { playerUrl?: string; windyUrl?: string } | null,
+): string | null {
+  const fromImage = (image?.windyUrl || '').trim();
+  if (fromImage) return fromImage;
+  const id = webcam.webcamId?.trim();
+  if (!id) return null;
+  return `https://www.windy.com/webcams/${encodeURIComponent(id)}`;
+}
+
+export function openWebcamStreamInNewTab(
+  url: string | null | undefined,
+  openWindow: OpenWindowFn | undefined = defaultOpenWindow(),
+): boolean {
+  if (!url || !openWindow) return false;
+  openWindow(url, '_blank', WEBCAM_STREAM_OPEN_FEATURES);
+  return true;
+}
+
+export type WebcamLayerClickKind = 'leaf' | 'cluster' | 'none';
+
+export function webcamLayerClickKind(obj: unknown): WebcamLayerClickKind {
+  if (isWebcamClusterMarker(obj)) return 'cluster';
+  if (isWebcamLeafMarker(obj)) return 'leaf';
+  return 'none';
+}
+
+export interface WebcamLayerClickHandlers {
+  openWindow?: OpenWindowFn;
+  onLeaf: (webcam: WebcamLeafLike) => void;
+  onCluster: (cluster: WebcamClusterLike) => void;
+}
+
+/**
+ * Route a webcam-layer pick. Returns true when the event was consumed so the
+ * caller can `return true` from the layer `onClick` (same contract as the
+ * energy pipeline / storage layer handlers).
+ */
+export function dispatchWebcamLayerClick(
+  obj: unknown,
+  handlers: WebcamLayerClickHandlers,
+): boolean {
+  if (isWebcamClusterMarker(obj)) {
+    handlers.onCluster(obj);
+    return true;
+  }
+  if (isWebcamLeafMarker(obj)) {
+    openWebcamStreamInNewTab(resolveWebcamStreamUrl(obj), handlers.openWindow ?? defaultOpenWindow());
+    handlers.onLeaf(obj);
+    return true;
+  }
+  return false;
+}
+
+function defaultOpenWindow(): OpenWindowFn | undefined {
+  if (typeof window === 'undefined' || typeof window.open !== 'function') return undefined;
+  return (url, target, features) => window.open(url, target, features);
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4228,6 +4228,18 @@ body.live-news-fullscreen-active .panels-grid > *:not(.live-news-fullscreen) {
   margin-bottom: 6px;
 }
 
+.deckgl-webcam-popup-link {
+  display: block;
+  margin: 4px 0;
+  color: var(--accent, #00d4ff);
+  font-size: calc(0.75rem * var(--wm-panel-effective-scale, 1));
+  text-decoration: none;
+}
+
+.deckgl-webcam-popup-link:hover {
+  text-decoration: underline;
+}
+
 /* News Items */
 .item {
   padding: 8px 0;

--- a/tests/webcam-layer-click.test.mjs
+++ b/tests/webcam-layer-click.test.mjs
@@ -1,0 +1,159 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  WEBCAM_STREAM_OPEN_FEATURES,
+  dispatchWebcamLayerClick,
+  isWebcamClusterMarker,
+  isWebcamLeafMarker,
+  openWebcamStreamInNewTab,
+  resolveWebcamStreamUrl,
+  webcamLayerClickKind,
+} from '../src/components/map/webcam-click.ts';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const deckGLMapSrc = readFileSync(join(root, 'src', 'components', 'DeckGLMap.ts'), 'utf-8');
+
+const leaf = {
+  _kind: 'webcam',
+  webcamId: 'abc/123',
+  title: 'Harbour Cam',
+  lat: 51.5,
+  lng: -0.1,
+  category: 'city',
+  country: 'GB',
+};
+
+const cluster = {
+  _kind: 'webcam-cluster',
+  lat: 51.5,
+  lng: -0.1,
+  count: 12,
+};
+
+describe('webcam layer click routing (#3877)', () => {
+  it('narrows leaf vs cluster on _kind without treating a cluster as a leaf', () => {
+    assert.equal(isWebcamLeafMarker(leaf), true);
+    assert.equal(isWebcamClusterMarker(leaf), false);
+    assert.equal(isWebcamLeafMarker(cluster), false);
+    assert.equal(isWebcamClusterMarker(cluster), true);
+    assert.equal(webcamLayerClickKind(leaf), 'leaf');
+    assert.equal(webcamLayerClickKind(cluster), 'cluster');
+    assert.equal(webcamLayerClickKind(null), 'none');
+    assert.equal(webcamLayerClickKind({ lat: 1, lng: 2 }), 'none');
+  });
+
+  it('falls back to count/webcamId when _kind is missing', () => {
+    assert.equal(isWebcamLeafMarker({ webcamId: 'x', lat: 0, lng: 0 }), true);
+    assert.equal(isWebcamClusterMarker({ count: 4, lat: 0, lng: 0 }), true);
+    assert.equal(isWebcamLeafMarker({ webcamId: 'x', count: 4, lat: 0, lng: 0 }), false);
+    assert.equal(isWebcamClusterMarker({ webcamId: 'x', count: 4, lat: 0, lng: 0 }), false);
+  });
+
+  it('resolves a public stream URL and no-ops when the id is missing', () => {
+    assert.equal(
+      resolveWebcamStreamUrl(leaf),
+      'https://www.windy.com/webcams/abc%2F123',
+    );
+    assert.equal(
+      resolveWebcamStreamUrl(leaf, { windyUrl: 'https://www.windy.com/webcams/abc/123' }),
+      'https://www.windy.com/webcams/abc/123',
+    );
+    assert.equal(resolveWebcamStreamUrl({ webcamId: '' }), null);
+    assert.equal(resolveWebcamStreamUrl({ webcamId: '   ' }), null);
+  });
+
+  it('opens the stream in a new tab with noopener,noreferrer and skips empty URLs', () => {
+    const calls = [];
+    const openWindow = (url, target, features) => {
+      calls.push({ url, target, features });
+    };
+
+    assert.equal(openWebcamStreamInNewTab(resolveWebcamStreamUrl(leaf), openWindow), true);
+    assert.equal(openWebcamStreamInNewTab(null, openWindow), false);
+    assert.equal(openWebcamStreamInNewTab('', openWindow), false);
+
+    assert.deepEqual(calls, [{
+      url: 'https://www.windy.com/webcams/abc%2F123',
+      target: '_blank',
+      features: WEBCAM_STREAM_OPEN_FEATURES,
+    }]);
+  });
+
+  it('opens one tab for a leaf click and none for a cluster click', () => {
+    const opens = [];
+    const leaves = [];
+    const clusters = [];
+    const handlers = {
+      openWindow: (url, target, features) => {
+        opens.push({ url, target, features });
+      },
+      onLeaf: (webcam) => {
+        leaves.push(webcam.webcamId);
+      },
+      onCluster: (group) => {
+        clusters.push(group.count);
+      },
+    };
+
+    assert.equal(dispatchWebcamLayerClick(leaf, handlers), true);
+    assert.equal(dispatchWebcamLayerClick(cluster, handlers), true);
+    assert.equal(dispatchWebcamLayerClick({ lat: 0, lng: 0 }, handlers), false);
+
+    assert.equal(opens.length, 1);
+    assert.equal(opens[0].target, '_blank');
+    assert.equal(opens[0].features, WEBCAM_STREAM_OPEN_FEATURES);
+    assert.deepEqual(leaves, ['abc/123']);
+    assert.deepEqual(clusters, [12]);
+  });
+
+  it('does not throw when a leaf has no stream URL', () => {
+    const opens = [];
+    assert.equal(
+      dispatchWebcamLayerClick(
+        { _kind: 'webcam', webcamId: '', title: '', lat: 0, lng: 0, category: '', country: '' },
+        {
+          openWindow: (url) => {
+            opens.push(url);
+          },
+          onLeaf: () => {},
+          onCluster: () => {
+            throw new Error('cluster handler must not run for a leaf');
+          },
+        },
+      ),
+      true,
+    );
+    assert.equal(opens.length, 0);
+  });
+});
+
+describe('DeckGLMap webcam-layer wiring (#3877)', () => {
+  it('gives webcam-layer an onClick that consumes the event', () => {
+    const layerMatch = deckGLMapSrc.match(
+      /\/\/ Webcam layer \(server-side clustered markers\)[\s\S]*?id: 'webcam-layer',[\s\S]*?\}\)\);/,
+    );
+    assert.ok(layerMatch, 'webcam-layer ScatterplotLayer should still exist');
+    assert.match(layerMatch[0], /onClick:\s*\(info\)\s*=>\s*this\.handleWebcamLayerClick\(info\)/);
+  });
+
+  it('routes webcam-layer clicks through the cluster/leaf helper and returns true', () => {
+    const handlerMatch = deckGLMapSrc.match(
+      /private handleWebcamLayerClick\(info: PickingInfo\): boolean \{[\s\S]*?^\s{2}\}/m,
+    );
+    assert.ok(handlerMatch, 'handleWebcamLayerClick should exist');
+    assert.match(handlerMatch[0], /dispatchWebcamLayerClick/);
+    assert.match(handlerMatch[0], /return dispatchWebcamLayerClick/);
+    assert.match(handlerMatch[0], /onCluster:/);
+    assert.doesNotMatch(handlerMatch[0], /as WebcamEntry/);
+  });
+
+  it('keeps the global handleClick webcam branch from double-firing via the same helper', () => {
+    assert.match(
+      deckGLMapSrc,
+      /if \(layerId === 'webcam-layer'\) \{\s*this\.handleWebcamLayerClick\(info\);\s*return;/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #3877. Follow-up to closed #4230 (do not revive that patch).

## Why #4230 was not enough

Greptile rejected the first #4230 revision for missing the cluster guard, missing `return true`, and an unsafe `as WebcamEntry` cast of `WebcamCluster`. A later commit added the guard + consume, but the PR was still closed as redundant: current `main` already routes `webcam-layer` picks through `handleClick` → `showWebcamClickPopup`.

That popup still did not satisfy the issue:

- it never opened the stream URL (`window.open` / `target=_blank`)
- it waited on `fetchWebcamImage` before mounting, so a slow image fetch made marker clicks look dead
- cluster clicks were a no-op (and must not open N tabs)

## This PR

- Type-safe leaf vs cluster routing in `src/components/map/webcam-click.ts` using the `_kind` tag stamped at `setWebcams` (with a `count`/`webcamId` fallback). No cluster→leaf cast.
- Layer-level `onClick` on `webcam-layer` **returns `true`** so MapboxOverlay `onClick` → `handleClick` does not double-fire (same contract as the energy pipeline/storage layers).
- **Leaf click:** `window.open(url, '_blank', 'noopener,noreferrer')` plus the existing pin popup, now with an `Open on Windy` link (`rel="noopener noreferrer"`). Popup mounts immediately; image fetch is async.
- **Cluster click:** zoom in toward the cluster (`setCenter` +2, cap 14). Documented: expand, do not open a tab per camera.
- Missing URL: no-op, no throw.
- Search-to-watch / pin path unchanged.

## Tests

`tests/webcam-layer-click.test.mjs` covers:

- `_kind` and fallback discriminators (cluster is never treated as a leaf)
- URL resolution + `noopener,noreferrer`
- one tab for a leaf, zero tabs for a cluster
- DeckGLMap wiring: layer `onClick` → `handleWebcamLayerClick` → `dispatchWebcamLayerClick` / `return true`

```
npx tsx --test tests/webcam-layer-click.test.mjs
```

9 passed.

## Notes

Cluster policy: zoom/expand (not a picker). GlobeMap still has its own picker; this change is the DeckGL global-view filter layer from the issue.
