### PR TITLE
fix(seeds): clamp extra-key seed-meta TTL to the data key's lifetime

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -655,7 +655,7 @@ export async function writeFreshnessMetadata(
   }
   // Use the data TTL if it exceeds 7 days so monthly/annual seeds don't lose
   // their meta key before the health check maxStaleMin threshold is reached.
-  const metaTtl = Math.max(86400 * 7, ttlSeconds || 0);
+  const metaTtl = resolveSeedMetaTtl(undefined, ttlSeconds);
   // Retry transient Redis failures: this SET runs bare on runSeed's
   // validate-skip path, where an unretried Upstash abort escaped to the
   // seeder's top-level catch as `FATAL: The operation was aborted due to
@@ -1025,6 +1025,34 @@ export function extraKeyPayloadBytes(key, data, envelopeMeta) {
   return Buffer.byteLength(serializeExtraKeyValue(key, data, envelopeMeta), 'utf8');
 }
 
+/**
+ * Floor for every seed-meta TTL. A meta key must survive its data key's
+ * disappearance so health can report STALE_SEED (present-but-stale) rather than
+ * losing the heartbeat at the same moment as the payload — see the "seed-meta
+ * outlives its data key" note in api/health.js's absence branch.
+ */
+export const SEED_META_MIN_TTL_SECONDS = 86400 * 7;
+
+/**
+ * The meta TTL for a data key written with `dataTtlSeconds`.
+ *
+ * The floor alone is not enough once a data key outlives 7 days: health reads
+ * freshness from seed-meta and falls through to plain OK when the meta is gone
+ * but the data key still has bytes, so a meta that expires FIRST makes the
+ * STALE_SEED alarm unreachable for the remainder of the data key's life. The
+ * clamp is the same one `writeFreshnessMetadata` has always applied to the
+ * canonical key; extra keys need it for the same reason.
+ *
+ * An explicit `metaTtlSeconds` still wins, so the parameter keeps meaning what
+ * it says. The three seeders that already pass one (seed-jodi-gas,
+ * seed-natural-events, seed-defense-industrial-suppliers) pass their own data
+ * TTL — the value this would have computed — so they are byte-identical either
+ * way; the override exists for a future caller that needs a different one.
+ */
+export function resolveSeedMetaTtl(metaTtlSeconds, dataTtlSeconds) {
+  return metaTtlSeconds ?? Math.max(SEED_META_MIN_TTL_SECONDS, dataTtlSeconds || 0);
+}
+
 export async function writeSeedMeta(dataKey, recordCount, metaKeyOverride, metaTtlSeconds, coverage, extra) {
   const { url, token } = getRedisCredentials();
   const metaKey = metaKeyOverride || `seed-meta:${dataKey.replace(/:v\d+$/, '')}`;
@@ -1040,7 +1068,9 @@ export async function writeSeedMeta(dataKey, recordCount, metaKeyOverride, metaT
       if (value !== undefined) meta[key] = value;
     }
   }
-  const metaTtl = metaTtlSeconds ?? 86400 * 7;
+  // No data TTL is in scope here — callers that know one resolve it through
+  // `resolveSeedMetaTtl` before calling. Bare floor otherwise.
+  const metaTtl = resolveSeedMetaTtl(metaTtlSeconds);
   const resp = await fetch(url, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': CHROME_UA },
@@ -1060,7 +1090,10 @@ export async function writeSeedMeta(dataKey, recordCount, metaKeyOverride, metaT
 
 export async function writeExtraKeyWithMeta(key, data, ttl, recordCount, metaKeyOverride, metaTtlSeconds, coverage) {
   await writeExtraKey(key, data, ttl);
-  return writeSeedMeta(key, recordCount, metaKeyOverride, metaTtlSeconds, coverage);
+  // The data TTL is right here, so the meta never has to be the shorter of the
+  // two. seed-economy's four EIA weekly keys (21d data, 14d health budget) rode
+  // the bare 7d default and went silent-OK for the 14 days in between.
+  return writeSeedMeta(key, recordCount, metaKeyOverride, resolveSeedMetaTtl(metaTtlSeconds, ttl), coverage);
 }
 
 // Detailed counterpart to extendExistingTtl. Results stay aligned to the input
@@ -2575,7 +2608,9 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
             ek.key,
             ekEnvelope?.recordCount ?? 0,
             ek.metaKey,
-            ek.metaTtlSeconds,
+            // Same data TTL the writeExtraKey above just used, so a long-lived
+            // extra key can't outlive the meta that reports on it.
+            resolveSeedMetaTtl(ek.metaTtlSeconds, ek.ttl || ttlSeconds),
             ek.coverage,
             metaExtra,
           );

--- a/tests/seed-utils-meta-ttl-outlives-data.test.mjs
+++ b/tests/seed-utils-meta-ttl-outlives-data.test.mjs
@@ -1,0 +1,109 @@
+// Regression test: a seed-meta key must never expire BEFORE the data key it
+// vouches for.
+//
+// api/health.js decides freshness from `seed-meta:<domain>:<resource>` and
+// falls through to plain OK when that key is absent but the data key still has
+// bytes (classifyKey's `seedStale === true` arm at api/health.js:2336 is the
+// only STALE_SEED path, and a missing meta yields `seedStale: null`). So a meta
+// TTL shorter than the data TTL does not merely lose a heartbeat — it makes the
+// STALE_SEED alarm UNREACHABLE for the whole gap, and the first signal an
+// operator gets is the day the data key itself expires into a crit EMPTY.
+//
+// That is exactly what seed-economy's four EIA weekly keys shipped with:
+// 21-day data TTL, default 7-day meta TTL, 14-day health budget. A dead EIA
+// fetch read OK from day 7 to day 21, then flipped straight to EMPTY, and the
+// 14-day warn in between could never fire.
+//
+// `writeFreshnessMetadata` has clamped its own meta writes to
+// `Math.max(7d, dataTtl)` for exactly this reason; these two extra-key paths
+// did not. The assertion below is the invariant, not the constant: it holds for
+// every caller regardless of the TTLs they choose.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+
+const { writeExtraKeyWithMeta, resolveSeedMetaTtl, SEED_META_MIN_TTL_SECONDS } =
+  await import('../scripts/_seed-utils.mjs');
+
+const originalFetch = globalThis.fetch;
+
+/** seed-economy.mjs CRUDE_INVENTORIES_TTL / NAT_GAS_TTL / SPR_TTL / REFINERY_INPUTS_TTL. */
+const EIA_WEEKLY_DATA_TTL = 1_814_400; // 21 days
+/** api/health.js SEED_META.crudeInventories.maxStaleMin, in seconds. */
+const EIA_HEALTH_BUDGET_SECONDS = 20160 * 60; // 14 days
+
+let sets;
+
+function ttlOf(command) {
+  const exIndex = command.indexOf('EX');
+  return exIndex === -1 ? null : command[exIndex + 1];
+}
+
+beforeEach(() => {
+  sets = [];
+  globalThis.fetch = async (url, opts = {}) => {
+    const command = opts?.body ? JSON.parse(opts.body) : null;
+    if (Array.isArray(command) && command[0] === 'SET') sets.push(command);
+    return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test('writeExtraKeyWithMeta: seed-meta outlives the data key it vouches for', async () => {
+  await writeExtraKeyWithMeta(
+    'economic:crude-inventories:v1',
+    { weeks: [{ period: '2026-08-21', value: 1 }] },
+    EIA_WEEKLY_DATA_TTL,
+    1,
+  );
+
+  const dataSet = sets.find((c) => c[1] === 'economic:crude-inventories:v1');
+  const metaSet = sets.find((c) => c[1] === 'seed-meta:economic:crude-inventories');
+  assert.ok(dataSet, 'data key was written');
+  assert.ok(metaSet, 'seed-meta key was written');
+
+  assert.equal(ttlOf(dataSet), EIA_WEEKLY_DATA_TTL);
+  assert.ok(
+    ttlOf(metaSet) >= ttlOf(dataSet),
+    `seed-meta TTL (${ttlOf(metaSet)}s) must be >= the data TTL (${ttlOf(dataSet)}s) — `
+    + 'otherwise health reads OK on data the meta can no longer describe',
+  );
+  assert.ok(
+    ttlOf(metaSet) >= EIA_HEALTH_BUDGET_SECONDS,
+    `seed-meta TTL (${ttlOf(metaSet)}s) must outlast the health staleness budget `
+    + `(${EIA_HEALTH_BUDGET_SECONDS}s) so STALE_SEED can actually fire`,
+  );
+});
+
+test('writeExtraKeyWithMeta: short data TTLs keep the 7-day meta floor', async () => {
+  await writeExtraKeyWithMeta('market:gold-extended:v1', { rows: [] }, 600, 0);
+
+  const metaSet = sets.find((c) => c[1] === 'seed-meta:market:gold-extended');
+  assert.ok(metaSet, 'seed-meta key was written');
+  // The floor is what lets health report STALE_SEED on a key whose data expired
+  // hours ago (api/health.js:2280) — a data-TTL-only meta would vanish with it.
+  assert.equal(ttlOf(metaSet), SEED_META_MIN_TTL_SECONDS);
+});
+
+test('writeExtraKeyWithMeta: an explicit metaTtlSeconds still wins', async () => {
+  // The clamp is a DEFAULT, not an override: the parameter keeps meaning what
+  // it says for any caller that needs a TTL of its own.
+  await writeExtraKeyWithMeta('intel:cross-strait:v1', { x: 1 }, 600, 1, undefined, 300);
+
+  const metaSet = sets.find((c) => c[1] === 'seed-meta:intel:cross-strait');
+  assert.ok(metaSet, 'seed-meta key was written');
+  assert.equal(ttlOf(metaSet), 300);
+});
+
+test('resolveSeedMetaTtl: floor, clamp, and explicit override', () => {
+  assert.equal(resolveSeedMetaTtl(undefined, 600), SEED_META_MIN_TTL_SECONDS);
+  assert.equal(resolveSeedMetaTtl(undefined, EIA_WEEKLY_DATA_TTL), EIA_WEEKLY_DATA_TTL);
+  assert.equal(resolveSeedMetaTtl(undefined, undefined), SEED_META_MIN_TTL_SECONDS);
+  assert.equal(resolveSeedMetaTtl(300, EIA_WEEKLY_DATA_TTL), 300);
+});


### PR DESCRIPTION
## The bug

A `seed-meta:*` key that expires **before** the data key it vouches for does not just lose a heartbeat — it disarms the alarm.

`api/health.js` reads freshness from seed-meta, and `classifyKey`'s only `STALE_SEED` path is `seedStale === true` (`api/health.js:2336`). A missing meta yields `seedStale: null`, so a data key that still has bytes falls straight through to plain `OK`.

`seed-economy`'s four EIA weekly keys shipped exactly that shape — 21-day data TTL (`scripts/seed-economy.mjs:24,26,28,29`), `writeSeedMeta`'s bare 7-day default, and a 14-day health budget (`api/health.js:1071-1074`):

| day | meta | data | verdict |
|---|---|---|---|
| 0–7 | present, aging | present | OK |
| 7–21 | **expired** | present | **OK — silent, on data up to 21 days stale** |
| 21 | expired | expired | EMPTY (crit) |

The 14-day `STALE_SEED` warn in the middle could **never fire**. The first signal an operator got was a day-21 critical, two weeks after the seeder actually stopped.

Realistic trigger: the EIA writes are conditional on validation (`seed-economy.mjs:660-683`), so an EIA endpoint break stops these four metas while the rest of `seed-economy` keeps running green.

## The fix

`writeFreshnessMetadata` has clamped the canonical key's meta to `Math.max(7d, dataTtl)` since it was written, for exactly this reason (`_seed-utils.mjs:655`). The two extra-key paths never did.

Single-sources that rule as `resolveSeedMetaTtl(metaTtlSeconds, dataTtlSeconds)` and applies it everywhere a data TTL is actually in scope:

- `writeExtraKeyWithMeta` — the four EIA call sites and ~30 others
- `runSeed`'s contract-mode `extraKeys` meta write (`ek.ttl || ttlSeconds`, mirroring the `writeExtraKey` right above it)
- `writeFreshnessMetadata` now reuses the shared constant instead of its own inline `Math.max`

## Blast radius: the four EIA keys only

- Callers with a data TTL under 7 days keep the existing floor — `Math.max(7d, ttl)` is unchanged for them. Scanned every `writeExtraKeyWithMeta` caller and every `extraKeys` entry; `seed-economy`'s four 21-day keys are the only ones above the floor.
- An explicit `metaTtlSeconds` still wins, so the parameter keeps meaning what it says. The three seeders that pass one (`seed-jodi-gas:346`, `seed-natural-events:519,529`, `seed-defense-industrial-suppliers:81`) already pass their own data TTL — the value the clamp would compute — so they are byte-identical.
- The clamp is idempotent, so the double pass through `writeSeedMeta` is a no-op.
- Direction is safe: meta ≥ data TTL means meta always outlives its data key, which is the invariant `api/health.js:2280` already documents ("seed-meta outlives its data key").

## Test

`tests/seed-utils-meta-ttl-outlives-data.test.mjs` asserts the **invariant, not the constant**: for any data TTL, the seed-meta `SET`'s `EX` must be `>=` the data `SET`'s `EX`. Plus the 7-day floor and explicit-override arms.

Confirmed red before the fix:

```
AssertionError: seed-meta TTL (604800s) must be >= the data TTL (1814400s)
```

Green after, along with all 158 tests in the `tests/seed-utils*` + `resilience-seed-meta-preflight` suites and the four TTL-adjacent suites.

## Not fixed here

The mismatch was found alongside a claim that this fires a *false EMPTY alarm a week early*. It does not — the data key outlives the meta, so `hasData` stays true and the verdict is silent `OK`. The defect is the unreachable alarm, which is what this PR fixes.

https://claude.ai/code/session_014bGakreTrnGzZ2HSK2soK2
