### PR TITLE
fix(market): echo the requesting caller's name on a shared backtest cache hit

### DIFF
--- a/server/worldmonitor/market/v1/backtest-stock.ts
+++ b/server/worldmonitor/market/v1/backtest-stock.ts
@@ -358,7 +358,15 @@ export const backtestStock: MarketServiceHandler['backtestStock'] = async (
     if (quotaHold.reservation && (definitiveInvalidSymbol || result.source !== 'fresh' || !result.leader)) {
       await quotaHold.reservation.rollback();
     }
-    if (result.data) return result.data;
+    // `name` is a caller-supplied display label, not part of the computation,
+    // which is why it is deliberately absent from `cacheKey` — two callers
+    // watching one ticker should share a single Yahoo fetch. But the shared
+    // BODY carries whichever label populated the entry first, so without this
+    // re-stamp caller B gets caller A's spelling echoed back. Custom watchlist
+    // entries make differing names for one symbol reachable in production.
+    // Same `req.name || symbol` rule the fresh-compute and unavailable paths
+    // use, so a caller's echo never depends on who warmed the cache.
+    if (result.data) return { ...result.data, name: req.name || symbol };
   } catch (err) {
     if (quotaHold.reservation) {
       await quotaHold.reservation.rollback();

--- a/tests/stock-backtest.test.mts
+++ b/tests/stock-backtest.test.mts
@@ -390,6 +390,97 @@ describe('backtestStock provider-work quota', () => {
     assert.equal(redisFetch.redis.get(backtestStockProviderQuotaKey('user_pro')), undefined);
   });
 
+  // `name` is a caller-supplied display label, and the cache key is only
+  // symbol + window — deliberately, so two callers watching the same ticker
+  // share one Yahoo fetch. That sharing must not extend to the label: whoever
+  // populated the entry first would otherwise have their spelling echoed back
+  // at every later caller. Custom watchlist entries make differing labels for
+  // one symbol reachable in production (src/services/stock-backtest.ts:24-27
+  // sends each target's own name).
+  it('echoes the requesting caller name on an entry cached by another caller', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    const redisFetch = createRedisAwareBacktestFetch(mockChartPayload());
+    globalThis.fetch = redisFetch.fetch;
+    const cachedByFirstCaller = {
+      available: true,
+      symbol: 'AAPL',
+      name: 'Apple Inc.',
+      display: 'AAPL',
+      currency: 'USD',
+      evalWindowDays: 10,
+      evaluationsRun: 1,
+      actionableEvaluations: 1,
+      winRate: 50,
+      directionAccuracy: 50,
+      avgSimulatedReturnPct: 1,
+      cumulativeSimulatedReturnPct: 1,
+      latestSignal: 'buy',
+      latestSignalScore: 1,
+      summary: 'cached',
+      generatedAt: '2026-08-20T00:00:00.000Z',
+      evaluations: [],
+      engineVersion: STOCK_BACKTEST_ENGINE_VERSION,
+      ratingBasis: STOCK_BACKTEST_RATING_BASIS,
+    };
+    redisFetch.redis.set(stockBacktestCacheKey('AAPL', 10), JSON.stringify(cachedByFirstCaller));
+
+    const response = await backtestStock(makeBacktestCtx('user_pro'), {
+      symbol: 'AAPL',
+      name: 'Apple Computer',
+      evalWindowDays: 10,
+    });
+
+    // Served from the shared entry — no second Yahoo fetch...
+    assert.equal(response.summary, 'cached');
+    assert.equal(redisFetch.yahooCallCount(), 0);
+    // ...but labelled with THIS caller's name.
+    assert.equal(response.name, 'Apple Computer');
+    // The shared entry itself stays canonical; the re-stamp is per-response.
+    assert.equal(
+      JSON.parse(redisFetch.redis.get(stockBacktestCacheKey('AAPL', 10)) || '{}').name,
+      'Apple Inc.',
+    );
+  });
+
+  it('falls back to the symbol when a cache-hit caller sends no name', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    const redisFetch = createRedisAwareBacktestFetch(mockChartPayload());
+    globalThis.fetch = redisFetch.fetch;
+    redisFetch.redis.set(stockBacktestCacheKey('AAPL', 10), JSON.stringify({
+      available: true,
+      symbol: 'AAPL',
+      name: 'Apple Inc.',
+      display: 'AAPL',
+      currency: 'USD',
+      evalWindowDays: 10,
+      evaluationsRun: 1,
+      actionableEvaluations: 1,
+      winRate: 50,
+      directionAccuracy: 50,
+      avgSimulatedReturnPct: 1,
+      cumulativeSimulatedReturnPct: 1,
+      latestSignal: 'buy',
+      latestSignalScore: 1,
+      summary: 'cached',
+      generatedAt: '2026-08-20T00:00:00.000Z',
+      evaluations: [],
+      engineVersion: STOCK_BACKTEST_ENGINE_VERSION,
+      ratingBasis: STOCK_BACKTEST_RATING_BASIS,
+    }));
+
+    const response = await backtestStock(makeBacktestCtx('user_pro'), {
+      symbol: 'AAPL',
+      evalWindowDays: 10,
+    } as never);
+
+    // Same rule the fresh-compute and unavailable paths already apply
+    // (`req.name || symbol`), so a caller's echo does not depend on whether
+    // someone else happened to warm the cache first.
+    assert.equal(response.name, 'AAPL');
+  });
+
   it('returns a deterministic 429 with reset guidance when the daily budget is exceeded', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';


### PR DESCRIPTION
## The bug

`stockBacktestCacheKey` is symbol + `evalWindowDays` only (`backtest-stock.ts:43`) — deliberately, since `name` is a caller-supplied display label that has no bearing on the computation, and two callers watching one ticker should share a single Yahoo fetch against a daily provider budget.

But the cached **body** carries `name: req.name || symbol` from whoever populated it (`:313`), and the handler returned that body verbatim (`:361`). So caller B watching `AAPL` as "Apple Computer" got caller A's "Apple Inc." echoed back at them.

Reachable in production: `src/services/stock-backtest.ts:24-27` sends each watchlist target's own `name`, and custom watchlist entries (`getStockAnalysisTargets` → `resolved.customEntries`) can carry different labels for the same symbol.

Severity is low — it's a display label for a public ticker, not private data and not a wrong number — but the response is answering a question the caller didn't ask.

## The fix

Re-stamp `name` from the live request rather than widening the cache key:

```ts
if (result.data) return { ...result.data, name: req.name || symbol };
```

**Why not add `name` to the key:** it would fragment a 900s cache entry per label spelling and multiply Yahoo fetches against `BACKTEST_STOCK_DAILY_PROVIDER_QUOTA_LIMIT`, all for a field that does not change a single number in the response. The label is the only thing that differs, so the label is the only thing to fix.

The re-stamp uses the same `req.name || symbol` rule the fresh-compute (`:313`) and unavailable (`:260`, `:370`) paths already apply, so a caller's echo no longer depends on who warmed the cache. On the fresh path it is a no-op.

## Deliberately unchanged

The durable snapshot store keeps one label per symbol. `listStoredStockBacktests` takes symbols only (`list-stored-stock-backtests.ts:15`) and has no per-caller name to re-stamp, so first-writer-wins is the correct behaviour there. Same for the symbol-keyed historical analysis ledger.

## Tests

Both in `tests/stock-backtest.test.mts`, both confirmed red before the fix:

- a caller reading an entry another caller cached gets **its own** label, no second Yahoo fetch, and the shared Redis entry stays canonical
- a caller sending no name falls back to the symbol rather than inheriting the cached label

Full `tests/stock-backtest.test.mts` (16), `tests/premium-stock-gateway.test.mts` + `tests/mcp-api-parity.test.mjs` (47), and `tsc --noEmit` all clean.

https://claude.ai/code/session_014bGakreTrnGzZ2HSK2soK2
