### PR TITLE
fix(chat-analyst): refund quota for unserved requests

### DIFF
--- a/api/chat-analyst.ts
+++ b/api/chat-analyst.ts
@@ -78,26 +78,70 @@ function directLlmQuotaError(
   });
 }
 
-function prependSseEvents(events: Array<Record<string, unknown>>, stream: ReadableStream<Uint8Array>): ReadableStream<Uint8Array> {
+function prependSseEvents(
+  events: Array<Record<string, unknown>>,
+  stream: ReadableStream<Uint8Array>,
+  rollbackUnservedQuota: () => Promise<void>,
+): ReadableStream<Uint8Array> {
   const enc = new TextEncoder();
   const prefixes = events.map((e) => enc.encode(`data: ${JSON.stringify(e)}\n\n`));
   let innerReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let outerCancelled = false;
+  let answerCompleted = false;
   return new ReadableStream<Uint8Array>({
     async start(controller) {
-      for (const p of prefixes) controller.enqueue(p);
-      innerReader = stream.getReader();
-      while (true) {
-        const { done, value } = await innerReader.read();
-        if (done) { controller.close(); return; }
-        controller.enqueue(value);
+      const decoder = new TextDecoder();
+      let buffered = '';
+      const observeCompletion = (value: Uint8Array) => {
+        buffered += decoder.decode(value, { stream: true });
+        const lines = buffered.split('\n');
+        buffered = lines.pop() ?? '';
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const event = JSON.parse(line.slice(6)) as { done?: unknown };
+            if (event.done === true) answerCompleted = true;
+          } catch {
+            // The inner stream owns malformed-event handling. This wrapper only
+            // needs to know whether a terminal answer was served.
+          }
+        }
+      };
+
+      try {
+        for (const p of prefixes) controller.enqueue(p);
+        innerReader = stream.getReader();
+        while (true) {
+          const { done, value } = await innerReader.read();
+          if (done) break;
+          observeCompletion(value);
+          controller.enqueue(value);
+        }
+        if (!answerCompleted) await rollbackUnservedQuota();
+        if (!outerCancelled) controller.close();
+      } catch (err) {
+        await rollbackUnservedQuota();
+        if (!outerCancelled) controller.error(err);
       }
     },
-    cancel() { innerReader?.cancel(); },
+    async cancel(reason) {
+      outerCancelled = true;
+      await Promise.allSettled([
+        innerReader?.cancel(reason),
+        answerCompleted ? Promise.resolve() : rollbackUnservedQuota(),
+      ]);
+    },
   });
 }
 
 export default async function handler(req: Request): Promise<Response> {
   const corsHeaders = getCorsHeaders(req) as Record<string, string>;
+  let rollbackQuota: (() => Promise<void>) | null = null;
+  const rollbackUnservedQuota = async () => {
+    const rollback = rollbackQuota;
+    rollbackQuota = null;
+    if (rollback) await rollback();
+  };
 
   if (req.method === 'OPTIONS') {
     return new Response(null, {
@@ -148,22 +192,6 @@ export default async function handler(req: Request): Promise<Response> {
       }
       return json({ error: 'Pro subscription required' }, 403, corsHeaders);
     }
-    if (!premiumIdentity.quotaExempt && premiumIdentity.directLlmDailyLimit !== null) {
-      const reservation = await reserveDirectLlmQuota({
-        userId: premiumIdentity.userId,
-        limit: premiumIdentity.directLlmDailyLimit,
-        pipeline: (cmds) => runRedisPipeline(cmds, true),
-      });
-      if (!reservation.ok) {
-        return directLlmQuotaError(
-          reservation.reason === 'cap-exceeded' ? 429 : 503,
-          reservation.retryAfterSec,
-          corsHeaders,
-          reservation.floor ?? DIRECT_LLM_DAILY_QUOTA_LIMIT,
-        );
-      }
-    }
-
     // Streaming LLM endpoint — the rate-limit IS the abuse defence (each
     // call hits a frontier model). This route doesn't go through gateway
     // checkEndpointRateLimit, so opt into fail-closed explicitly: a Redis
@@ -206,6 +234,28 @@ export default async function handler(req: Request): Promise<Response> {
       })
       .filter((m) => m.content.length > 0);
 
+    // Spend quota only after the request has passed every body-level gate.
+    // The fail-closed request rate limit above still protects malformed input,
+    // while invalid JSON and empty queries cannot consume a subscriber's daily
+    // LLM allowance. Hold the rollback until the SSE stream proves it served a
+    // complete answer; upstream failures and client aborts release the slot.
+    if (!premiumIdentity.quotaExempt && premiumIdentity.directLlmDailyLimit !== null) {
+      const reservation = await reserveDirectLlmQuota({
+        userId: premiumIdentity.userId,
+        limit: premiumIdentity.directLlmDailyLimit,
+        pipeline: (cmds) => runRedisPipeline(cmds, true),
+      });
+      if (!reservation.ok) {
+        return directLlmQuotaError(
+          reservation.reason === 'cap-exceeded' ? 429 : 503,
+          reservation.retryAfterSec,
+          corsHeaders,
+          reservation.floor ?? DIRECT_LLM_DAILY_QUOTA_LIMIT,
+        );
+      }
+      rollbackQuota = reservation.rollback;
+    }
+
     // Build retrieval query with current turn FIRST so its keywords fill the
     // extraction cap before prior-turn terms. This ensures pivot words like
     // "Germany" in "What about Germany?" are never crowded out by a long
@@ -240,6 +290,7 @@ export default async function handler(req: Request): Promise<Response> {
         ...buildActionEvents(query).map((a) => ({ action: a })),
       ],
       llmStream,
+      rollbackUnservedQuota,
     );
 
     return new Response(stream, {
@@ -252,6 +303,7 @@ export default async function handler(req: Request): Promise<Response> {
       },
     });
   } catch (err) {
+    await rollbackUnservedQuota();
     captureSilentError(err, { tags: { route: 'api/chat-analyst', step: 'pre-stream' } });
     return json({ error: 'service_unavailable' }, 503, corsHeaders);
   }

--- a/api/chat-analyst.ts
+++ b/api/chat-analyst.ts
@@ -87,26 +87,31 @@ function prependSseEvents(
   const prefixes = events.map((e) => enc.encode(`data: ${JSON.stringify(e)}\n\n`));
   let innerReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
   let outerCancelled = false;
-  let answerCompleted = false;
+  let answerProduced = false;
   return new ReadableStream<Uint8Array>({
     async start(controller) {
       const decoder = new TextDecoder();
       let buffered = '';
-      const observeCompletion = (value: Uint8Array) => {
+      const observeAnswer = (value: Uint8Array) => {
         buffered += decoder.decode(value, { stream: true });
         const lines = buffered.split('\n');
         buffered = lines.pop() ?? '';
         for (const line of lines) {
           if (!line.startsWith('data: ')) continue;
           try {
-            const event = JSON.parse(line.slice(6)) as { done?: unknown };
-            if (event.done === true) answerCompleted = true;
+            const event = JSON.parse(line.slice(6)) as { delta?: unknown; done?: unknown };
+            if ((typeof event.delta === 'string' && event.delta.length > 0) || event.done === true) {
+              answerProduced = true;
+            }
           } catch {
             // The inner stream owns malformed-event handling. This wrapper only
-            // needs to know whether a terminal answer was served.
+            // needs to know whether answer content was served.
           }
         }
       };
+      const rollbackIfUnserved = () => (
+        answerProduced ? Promise.resolve() : rollbackUnservedQuota()
+      );
 
       try {
         for (const p of prefixes) controller.enqueue(p);
@@ -114,13 +119,13 @@ function prependSseEvents(
         while (true) {
           const { done, value } = await innerReader.read();
           if (done) break;
-          observeCompletion(value);
+          observeAnswer(value);
           controller.enqueue(value);
         }
-        if (!answerCompleted) await rollbackUnservedQuota();
+        await rollbackIfUnserved();
         if (!outerCancelled) controller.close();
       } catch (err) {
-        await rollbackUnservedQuota();
+        await rollbackIfUnserved();
         if (!outerCancelled) controller.error(err);
       }
     },
@@ -128,7 +133,7 @@ function prependSseEvents(
       outerCancelled = true;
       await Promise.allSettled([
         innerReader?.cancel(reason),
-        answerCompleted ? Promise.resolve() : rollbackUnservedQuota(),
+        answerProduced ? Promise.resolve() : rollbackUnservedQuota(),
       ]);
     },
   });
@@ -237,8 +242,9 @@ export default async function handler(req: Request): Promise<Response> {
     // Spend quota only after the request has passed every body-level gate.
     // The fail-closed request rate limit above still protects malformed input,
     // while invalid JSON and empty queries cannot consume a subscriber's daily
-    // LLM allowance. Hold the rollback until the SSE stream proves it served a
-    // complete answer; upstream failures and client aborts release the slot.
+    // LLM allowance. Hold the rollback until the SSE stream serves answer
+    // content; failures and client aborts before the first delta release the
+    // slot, while a delivered partial answer remains charged.
     if (!premiumIdentity.quotaExempt && premiumIdentity.directLlmDailyLimit !== null) {
       const reservation = await reserveDirectLlmQuota({
         userId: premiumIdentity.userId,

--- a/server/__tests__/chat-analyst-quota.test.ts
+++ b/server/__tests__/chat-analyst-quota.test.ts
@@ -181,7 +181,23 @@ describe("api/chat-analyst direct LLM quota lifecycle", () => {
     expect(quotaCounter).toBe(0);
   });
 
-  test("a client abort before the terminal answer rolls quota back", async () => {
+  test("a client abort before answer content rolls quota back", async () => {
+    let cancelCalled = false;
+    callLlmReasoningStream.mockReturnValue(new ReadableStream<Uint8Array>({
+      start() {},
+      cancel() {
+        cancelCalled = true;
+      },
+    }));
+
+    const response = await handler(analystRequest(JSON.stringify({ query: "What changed?" })));
+    await response.body?.cancel("client disconnected");
+
+    expect(cancelCalled).toBe(true);
+    expect(quotaCounter).toBe(0);
+  });
+
+  test("a client abort after answer content keeps the quota charge", async () => {
     let cancelCalled = false;
     callLlmReasoningStream.mockReturnValue(new ReadableStream<Uint8Array>({
       start(controller) {
@@ -196,6 +212,15 @@ describe("api/chat-analyst direct LLM quota lifecycle", () => {
     await response.body?.cancel("client disconnected");
 
     expect(cancelCalled).toBe(true);
-    expect(quotaCounter).toBe(0);
+    expect(quotaCounter).toBe(1);
+  });
+
+  test("an incomplete stream after answer content keeps the quota charge", async () => {
+    callLlmReasoningStream.mockReturnValue(llmEvents([{ delta: "Partial answer" }]));
+
+    const response = await handler(analystRequest(JSON.stringify({ query: "What changed?" })));
+    await response.text();
+
+    expect(quotaCounter).toBe(1);
   });
 });

--- a/server/__tests__/chat-analyst-quota.test.ts
+++ b/server/__tests__/chat-analyst-quota.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const resolvePremiumCallerIdentity = vi.fn();
+vi.mock("../_shared/premium-check", () => ({
+  resolvePremiumCallerIdentity: (...args: unknown[]) => resolvePremiumCallerIdentity(...args),
+}));
+
+vi.mock("../_shared/entitlement-check", () => ({
+  renderBillingVerificationDenial: () => null,
+}));
+
+const checkRateLimit = vi.fn();
+vi.mock("../_shared/rate-limit", () => ({
+  checkRateLimit: (...args: unknown[]) => checkRateLimit(...args),
+}));
+
+vi.mock("../_shared/redis", () => ({
+  runRedisPipeline: vi.fn(),
+}));
+
+let quotaCounter = 0;
+const reserveDirectLlmQuota = vi.fn();
+vi.mock("../_shared/direct-llm-quota", () => ({
+  DIRECT_LLM_DAILY_QUOTA_LIMIT: 500,
+  reserveDirectLlmQuota: (...args: unknown[]) => reserveDirectLlmQuota(...args),
+}));
+
+const assembleAnalystContext = vi.fn();
+vi.mock("../worldmonitor/intelligence/v1/chat-analyst-context", () => ({
+  assembleAnalystContext: (...args: unknown[]) => assembleAnalystContext(...args),
+}));
+
+vi.mock("../worldmonitor/intelligence/v1/chat-analyst-prompt", () => ({
+  buildAnalystSystemPrompt: () => "system prompt",
+}));
+
+vi.mock("../worldmonitor/intelligence/v1/chat-analyst-actions", () => ({
+  buildActionEvents: () => [],
+}));
+
+const callLlmReasoningStream = vi.fn();
+vi.mock("../_shared/llm", () => ({
+  callLlmReasoningStream: (...args: unknown[]) => callLlmReasoningStream(...args),
+}));
+
+vi.mock("../_shared/llm-sanitize.js", () => ({
+  sanitizeForPrompt: (value: string) => value.trim(),
+}));
+
+vi.mock("../../api/_cors.js", () => ({
+  getCorsHeaders: () => ({ "Access-Control-Allow-Origin": "https://worldmonitor.app" }),
+}));
+
+vi.mock("../../api/_sentry-edge.js", () => ({
+  captureSilentError: vi.fn(),
+}));
+
+import handler from "../../api/chat-analyst";
+
+const encoder = new TextEncoder();
+
+function analystRequest(body: BodyInit): Request {
+  return new Request("https://api.worldmonitor.app/api/chat-analyst", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer premium-token",
+      "Content-Type": "application/json",
+      Origin: "https://worldmonitor.app",
+    },
+    body,
+  });
+}
+
+function llmEvents(events: Array<Record<string, unknown>>): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+beforeEach(() => {
+  quotaCounter = 0;
+  resolvePremiumCallerIdentity.mockReset().mockResolvedValue({
+    isPremium: true,
+    userId: "user_pro",
+    kind: "bearer",
+    quotaExempt: false,
+    directLlmDailyLimit: 500,
+  });
+  checkRateLimit.mockReset().mockResolvedValue(null);
+  assembleAnalystContext.mockReset().mockResolvedValue({
+    activeSources: ["Brief"],
+    degraded: false,
+  });
+  callLlmReasoningStream.mockReset().mockReturnValue(llmEvents([
+    { delta: "answer" },
+    { done: true },
+  ]));
+  reserveDirectLlmQuota.mockReset().mockImplementation(async () => {
+    quotaCounter += 1;
+    let rolledBack = false;
+    return {
+      ok: true,
+      newCount: quotaCounter,
+      rollback: async () => {
+        if (rolledBack) return;
+        rolledBack = true;
+        quotaCounter -= 1;
+      },
+    };
+  });
+});
+
+describe("api/chat-analyst direct LLM quota lifecycle", () => {
+  test("malformed JSON does not reserve quota", async () => {
+    const response = await handler(analystRequest("{"));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid JSON body" });
+    expect(reserveDirectLlmQuota).not.toHaveBeenCalled();
+    expect(quotaCounter).toBe(0);
+  });
+
+  test.each(["", "   "])("query %j does not reserve quota", async (query) => {
+    const response = await handler(analystRequest(JSON.stringify({ query })));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "query is required" });
+    expect(reserveDirectLlmQuota).not.toHaveBeenCalled();
+    expect(quotaCounter).toBe(0);
+  });
+
+  test("a completed answer reserves quota exactly once", async () => {
+    const response = await handler(analystRequest(JSON.stringify({ query: "What changed?" })));
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain('data: {"done":true}');
+    expect(reserveDirectLlmQuota).toHaveBeenCalledTimes(1);
+    expect(quotaCounter).toBe(1);
+  });
+
+  test("an upstream failure after reservation rolls quota back", async () => {
+    callLlmReasoningStream.mockReturnValue(llmEvents([{ error: "llm_unavailable" }]));
+
+    const response = await handler(analystRequest(JSON.stringify({ query: "What changed?" })));
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain('data: {"error":"llm_unavailable"}');
+    expect(reserveDirectLlmQuota).toHaveBeenCalledTimes(1);
+    expect(quotaCounter).toBe(0);
+  });
+
+  test("a thrown upstream stream failure rolls quota back", async () => {
+    callLlmReasoningStream.mockReturnValue(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error("provider stream failed"));
+      },
+    }));
+
+    const response = await handler(analystRequest(JSON.stringify({ query: "What changed?" })));
+
+    await expect(response.text()).rejects.toThrow("provider stream failed");
+    expect(reserveDirectLlmQuota).toHaveBeenCalledTimes(1);
+    expect(quotaCounter).toBe(0);
+  });
+
+  test("a pre-stream dependency failure after reservation rolls quota back", async () => {
+    assembleAnalystContext.mockRejectedValue(new Error("context unavailable"));
+
+    const response = await handler(analystRequest(JSON.stringify({ query: "What changed?" })));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "service_unavailable" });
+    expect(reserveDirectLlmQuota).toHaveBeenCalledTimes(1);
+    expect(quotaCounter).toBe(0);
+  });
+
+  test("a client abort before the terminal answer rolls quota back", async () => {
+    let cancelCalled = false;
+    callLlmReasoningStream.mockReturnValue(new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"delta":"partial"}\n\n'));
+      },
+      cancel() {
+        cancelCalled = true;
+      },
+    }));
+
+    const response = await handler(analystRequest(JSON.stringify({ query: "What changed?" })));
+    await response.body?.cancel("client disconnected");
+
+    expect(cancelCalled).toBe(true);
+    expect(quotaCounter).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Pro subscribers no longer lose a daily analyst slot when a request has malformed JSON, an empty query, an upstream failure, or an aborted response before any answer content is served. Body validation now completes before quota reservation, while the existing fail-closed request rate limit still protects invalid traffic. After reservation, the slot is retained once the SSE stream delivers answer content; failures and aborts before the first answer delta use the reservation's idempotent rollback. This also prevents partial-generation cancellations from bypassing the daily quota.

Fixes #7201.

## Validation

- Proof-first regression run: 5 expected failures before implementation.
- `vitest run server/__tests__/chat-analyst-quota.test.ts`: 10 passed.
- `tsx --test --test-reporter=dot tests/chat-analyst.test.mts`: passed.
- `npm run typecheck:api` and `npm run lint:boundaries`: passed.
- Pre-push gates: API typecheck, boundary/rate-limit/premium-fetch checks, Edge bundles, 91 server tests, and 264 Edge tests passed.
- Code review: no remaining actionable or residual findings.

## Post-Deploy Monitoring & Validation

- Search Sentry and Vercel logs for `route:api/chat-analyst`, `llm_unavailable`, and `[llm-stream:` errors.
- With a disposable Pro test account, confirm malformed JSON and empty/whitespace queries return 400 without changing `llm:direct-usage:<userId>:<UTC-date>`.
- Confirm one completed analyst answer increments the counter once. Confirm a provider failure or client abort before the first answer delta returns the counter to its prior value, while an abort after answer content remains charged.
- Healthy signal: no increase in analyst 503s or stream truncations, and quota usage matches requests that delivered answer content.
- Failure trigger: delivered answers are refunded, failures or aborts before answer content remain charged, or counters become negative. Mitigation: revert these commits and inspect the SSE event and rollback logs before retrying.
- Validation window and owner: first 24 hours after deployment, owned by the deployer/on-call maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
