### PR TITLE
fix(ci): base the health-probe cutover gate on the tree it actually tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,8 +241,35 @@ jobs:
           python3 scripts/convert-zh-tw.py --check
       - name: Enforce health-probe cutovers
         env:
-          HEALTH_PROBE_CUTOVER_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
-        run: node --import tsx scripts/check-health-probe-cutovers.mts "$HEALTH_PROBE_CUTOVER_BASE"
+          # NOT github.event.pull_request.base.sha. GitHub pins that SHA when the
+          # PR is opened and never advances it as main moves, but actions/checkout
+          # builds refs/pull/N/merge — this PR merged onto main's CURRENT tip. So
+          # the pinned SHA diffs today's tree against a base that can be weeks old,
+          # and every probe added to main after the PR opened reads as brand-new
+          # on every run, re-litigating a cutover the PR never touched. That stays
+          # invisible until the probe's acknowledgement is legitimately pruned —
+          # then the PR fails outright demanding an entry nobody should restore,
+          # owned by an issue that is already closed (#7021 on tpsMci/#7035).
+          #
+          # The merge commit's FIRST parent is the base tip this tree was merged
+          # onto, so it tracks what is actually under test. The pre-push hook
+          # compares against origin/main for the same reason.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PUSH_BEFORE: ${{ github.event.before }}
+        run: |
+          if [ -n "$BASE_REF" ]; then
+            if git rev-parse --verify --quiet HEAD^2 >/dev/null 2>&1; then
+              base="$(git rev-parse HEAD^1)"
+            else
+              # Unmergeable PR: checkout fell back to the head commit, whose
+              # first parent is the PR's own history, not the base branch.
+              base="origin/$BASE_REF"
+            fi
+          else
+            base="$PUSH_BEFORE"
+          fi
+          echo "health-probe cutover base: $base"
+          node --import tsx scripts/check-health-probe-cutovers.mts "$base"
       - name: OpenAPI bundle capacity (#6558)
         # The <= 950,000-byte scanner guard lives in
         # tests/openapi-json-dedup.test.mjs and stays the gate. This step

--- a/tests/seed-freshness-monitor.test.mjs
+++ b/tests/seed-freshness-monitor.test.mjs
@@ -1032,6 +1032,33 @@ describe('scheduled seed freshness monitor', () => {
           /node --import tsx scripts\/check-health-probe-cutovers\.mts origin\/main/,
         );
       });
+
+      // #7021 — the pre-push hook above compares against origin/main, but CI
+      // compared against `github.event.pull_request.base.sha`. GitHub PINS that
+      // SHA when the PR is opened and never advances it as main moves, while
+      // actions/checkout builds refs/pull/N/merge — the PR merged onto main's
+      // CURRENT tip. So the gate diffs today's tree against a base that can be
+      // weeks old: every probe added to main after the PR opened reads as
+      // brand-new on every run, re-litigating a cutover the PR never touched.
+      // That is latent until the probe's acknowledgement is legitimately pruned,
+      // at which point the PR fails outright demanding an entry nobody should
+      // restore. #7021 died exactly this way on tpsMci (#7035) once #7120
+      // retired the acknowledgement, naming a closed issue as its owner.
+      //
+      // The merge ref's FIRST parent is the base tip the tree was merged onto,
+      // so it cannot drift away from what is actually being tested.
+      it('bases the cutover diff on the merged tree, not the pinned base.sha', () => {
+        const workflow = readFileSync(TEST_WORKFLOW_URL, 'utf8');
+
+        // Matches the interpolation, not the prose: the step's own comment names
+        // the rejected expression to explain why it is rejected.
+        assert.doesNotMatch(
+          workflow,
+          /\$\{\{\s*github\.event\.pull_request\.base\.sha/,
+          'pull_request.base.sha is pinned at PR creation, so it re-litigates every probe added after the PR opened',
+        );
+        assert.match(workflow, /git rev-parse HEAD\^1/);
+      });
     });
   });
 


### PR DESCRIPTION
## The bug

The health-probe cutover gate compared the candidate tree against `github.event.pull_request.base.sha`. GitHub pins that SHA when the PR is opened and never advances it as `main` moves — but `actions/checkout` builds `refs/pull/N/merge`, the PR merged onto main's **current** tip.

So the gate diffed two commits that can be weeks apart. Every probe added to main *after* the PR opened read as brand-new on every run, re-litigating a cutover the PR never touched.

Latent while the probe's acknowledgement is still in the baseline. **Fatal once that acknowledgement is legitimately pruned.**

## How it surfaced

#7021 was opened 2026-08-20. Then:

| date | event |
|---|---|
| 08-21 | #7034 adds `tpsMci` with `cutover: { mode: 'expiring-ack', issue: 7035 }` |
| 08-24 | #7120 retires the acknowledgement — correctly; #7035 asked for exactly that |
| 08-27 | every #7021 run fails |

```
Health probe tpsMci needs an expiring acknowledgement for
seed-meta:safety:tps-mci owned by #7035
```

An unactionable error: it names a **closed** issue and demands a baseline entry nobody should restore.

**~40 open PRs** carry a `base.sha` predating #7034 and were queued behind the same wall. #7022 escaped only because it had taken main into its branch — which is what refreshes `base.sha`.

## The fix

The merge commit's **first parent** is the base tip the tree was merged onto, so it tracks what is actually under test and cannot drift. Verified against the real PR 7021 merge ref:

```
$ git rev-list --parents -n 1 refs/pull/7021/merge
97bf698ab  e3fe1c8f3  ff53450a3
           ^base tip  ^PR head
```

`e3fe1c8f3` is main's tip (and contains `tpsMci`); the pinned `base.sha` was still `05c199d06` from 08-20. That divergence is the whole bug.

The pre-push hook already compares against `origin/main` for the same reason — this puts CI on the same footing.

Fallbacks: `origin/<base ref>` when the PR is unmergeable and checkout has no merge commit to read; `github.event.before` on push.

## Verification

Same tree, the two bases:

```
$ HEALTH_PROBE_CUTOVER_BASE=05c199d06 npx tsx scripts/check-health-probe-cutovers.mts
Health probe tpsMci needs an expiring acknowledgement for seed-meta:safety:tps-mci owned by #7035

$ HEALTH_PROBE_CUTOVER_BASE=e3fe1c8f3 npx tsx scripts/check-health-probe-cutovers.mts
Health-probe cutover check passed: no new or repointed probes since e3fe1c8f3.
```

**Not vacuous.** Injecting a probe with no cutover declaration still fails under the new base:

```
Health probe bogusNewProbe (<new> -> seed-meta:bogus:new-probe) needs machine-readable
pre-seed evidence, a durable activation marker, or an expiring acknowledgement
```

**Guard test** added to `tests/seed-freshness-monitor.test.mjs`, next to the existing workflow/pre-push wiring assertion. Proven red before the fix, and red again on mutation (restoring the pinned expression):

```
✖ bases the cutover diff on the merged tree, not the pinned base.sha
  AssertionError: pull_request.base.sha is pinned at PR creation, so it
  re-litigates every probe added after the PR opened
```

It matches the workflow-expression interpolation rather than the bare string, so the step's own comment can still name the rejected expression to explain why it is rejected.

**Suites:** `seed-freshness-monitor` 42/42, `ci-workflow-coverage` 30/30, `deploy-config` 233/233. Biome clean. Workflow YAML parses; the `unit` job keeps `fetch-depth: 0`, which the first-parent read depends on.

## Scope

`.github/workflows/security-audit.yml` also uses `pull_request.base.sha`, deliberately left alone — it wants "what this PR changed" against its own base, which is different semantics from "what is already on main".

#7021 is separately unblocked by updating its branch (`base.sha` refreshed `05c199d06` → `016419170`); this change is what stops the other ~38 from hitting the same wall.

https://claude.ai/code/session_01BoB4YQxGbS6ESTDRJ5Ns7f
