### PR TITLE
fix(test): shape the country prompt fixtures like the real responses

### DIFF
--- a/tests/mcp-prompts.test.mjs
+++ b/tests/mcp-prompts.test.mjs
@@ -344,13 +344,48 @@ describe('api/mcp.ts — prompts capability + JMESPath-vs-schema parity', () => 
   // contract gate. These values only need to exercise the declared JMESPath
   // branches; the captured fixtures remain the broad payload proof.
   const FIXTURE_BUILDERS = {
+    // Mirrors the GetCountryRiskResponse the handler actually returns
+    // (server/worldmonitor/intelligence/v1/get-country-risk.ts:76-85), NOT the
+    // pre-#7189 shape: `cii` is an OBJECT whose `combinedScore` is the headline
+    // number, the four contributions live under `cii.components` with their
+    // historical names, and advisoryLevel/sanctionsActive/sanctionsCount/
+    // upstreamUnavailable are top-level siblings. Writing this fixture from an
+    // older outputSchema is what made every field project null.
     get_country_risk: () => ({
-      cii: 42,
-      components: { unrest: 10, conflict: 20, security: 30, news: 40 },
-      travelAdvisory: { level: '2' },
-      sanctionsExposure: [],
+      countryCode: 'DE',
+      countryName: 'Germany',
+      cii: {
+        region: 'DE',
+        combinedScore: 42.5,
+        staticBaseline: 38,
+        dynamicScore: 4.5,
+        trend: 'TREND_DIRECTION_RISING',
+        components: {
+          ciiContribution: 10,
+          geoConvergence: 20,
+          militaryActivity: 30,
+          newsActivity: 40,
+        },
+        computedAt: 1717200000000,
+        methodologyVersion: 'v3',
+        eventMultiplier: 1,
+        advisoryLevel: 'caution',
+        advisoryProvenance: 'live',
+      },
+      advisoryLevel: 'caution',
+      sanctionsActive: true,
+      sanctionsCount: 3,
+      fetchedAt: 1717200000000,
+      upstreamUnavailable: false,
     }),
-    get_country_brief: () => ({ country_code: 'DE', brief: 'Stable growth with moderate external risks.' }),
+    // `country_code` is the INPUT parameter name; the response echoes it back
+    // as `countryCode` alongside `countryName` (rpc-tools.ts get_country_brief
+    // outputSchema). Naming the fixture key after the input is what broke this.
+    get_country_brief: () => ({
+      countryCode: 'DE',
+      countryName: 'Germany',
+      brief: 'Stable growth with moderate external risks.',
+    }),
     get_country_macro: () => ({
       cached_at: '2026-08-27T00:00:00.000Z',
       stale: false,


### PR DESCRIPTION
## Summary

`unit` has been red on `main` since #7189, which fails the required `gate` check on **every open PR** — including ones whose own tests all pass. This unblocks them.

The failing assertion is genuine, but the fixtures are what's wrong, not the code under test. `FIXTURE_BUILDERS.get_country_risk` was hand-written to the *pre-#7189* outputSchema — a shape the handler has never returned:

| Fixture claimed | Handler actually returns |
|---|---|
| `cii: 42` (a bare number) | `cii` is an **object** carrying `combinedScore`, `trend`, `components` |
| `components` at top level | nested under `cii.components`, with the historical `ciiContribution` / `geoConvergence` / `militaryActivity` / `newsActivity` keys |
| `travelAdvisory`, `sanctionsExposure` | top-level `advisoryLevel`, `sanctionsActive`, `sanctionsCount`, `upstreamUnavailable` |

So the `country-briefing` prompt's JMESPath projected `null` for all seven fields and the gate fired. `get_country_brief` had the same mistake in miniature: the fixture keyed the country as `country_code`, which is the **input** parameter name — the response echoes it back as `countryCode`.

The prompt, the tool `outputSchema`, and the producer all already agree with each other. Only the fixtures disagreed.

## Which side is the source of truth

Worth being explicit, since "make the test pass" could have been done from the wrong end — rewriting the prompt to match a fabricated fixture would have shipped a projection that returns all-nulls to real MCP clients.

I checked the direction against the producer and the published contract, not against the expression being tested:

- `server/worldmonitor/intelligence/v1/get-country-risk.ts:76-85` returns `{ countryCode, countryName, cii, advisoryLevel, sanctionsActive, sanctionsCount, fetchedAt, upstreamUnavailable }`.
- `public/sandbox/get-country-risk.json`, derived from the published OpenAPI contract, shows `cii` as an object with `combinedScore: 42.5` and a `components` block.

Both match the prompt. Hence the fixtures move, and they now mirror the wire rather than the assertion.

This is the same drift class the test file's own comment documents (`get_market_data` advertising `changePercent` while every seeder wrote `change`) — the gate is doing its job; it was just handed a fabricated payload for these two steps.

## Validation

- Reproduced on a clean worktree off `origin/main` with **zero** local changes, confirming it is main's breakage and not any one PR's.
- Red → green: `tests/mcp-prompts.test.mjs` goes 13 pass / 1 fail → **14 pass / 0 fail**.
- Stash-out / stash-in round trip confirms this diff is what flips it, rather than something ambient.
- `tests/mcp-output-schema-coverage.test.mjs` — the OpenAPI-parity guard that fails the build if a schema property stops existing on the wire — stays green: **42/42** together.

Test-only change; no runtime code touched.

Related: #7189

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
