### PR TITLE
fix(sentry): fingerprint host-attributed fetch failures by host

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -428,10 +428,38 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // bucket, `api.worldmonitor.app`) are intentionally NOT in the set so a
       // real basemap / API regression is never silently dropped
       // (WORLDMONITOR-NE/NF, WORLDMONITOR-QG).
+      //
+      // Surviving events are additionally FINGERPRINTED by host. Suppression
+      // already read the host; grouping did not, and Sentry groups these on the
+      // stack — which `fetch-failure-attribution.ts` establishes is identical
+      // for every fetch failure (all frames are `window.fetch` wrappers; the
+      // async boundary drops the calling frame). So every host that survives the
+      // allowlist landed in ONE issue, titled after whichever host arrived last.
+      // WORLDMONITOR-ZG held all three populations at once (2026-08-27 triage,
+      // 32 events): 21 bare pre-attribution `Failed to fetch`, 8
+      // `api.worldmonitor.app` from a real ~90s origin blip on 2026-08-16, and 3
+      // `motramby.com` adware-beacon failures on 2026-08-27. The origin failures
+      // — the exact population the attribution work existed to surface — were
+      // unreadable under an adware title.
+      //
+      // The split is by OWNERSHIP, not by raw host: each of our own hosts keeps
+      // its own issue, while every foreign host collapses into a single
+      // `third-party` bucket. Adware and tracker domains rotate, so bucketing
+      // them bounds cardinality at (our hosts + 1) instead of leaving it open to
+      // one new issue per injected domain.
       if (isHostScopedFetchFailure) {
         const hostMatch = msg.match(/^(?:TypeError: )?(?:Failed to fetch|NetworkError when attempting to fetch resource\.?) \(([^)]+)\)$/);
         const host = hostMatch?.[1];
         if (host && THIRD_PARTY_FETCH_HOST_ALLOWLIST.has(host)) return null;
+        if (host) {
+          // Anchored at the end so a lookalike (`worldmonitor.app.evil.example`)
+          // is foreign. `pub-*.r2.dev` is the raw R2 bucket behind the basemaps:
+          // documented as never-used-in-code, but deliberately absent from the
+          // suppression allowlist so a basemap regression surfaces — which means
+          // it also needs its own group, not the third-party bin.
+          const isOwnHost = /(?:^|\.)worldmonitor\.app$/.test(host) || /\.r2\.dev$/.test(host);
+          event.fingerprint = ['fetch-failure', isOwnHost ? host : 'third-party'];
+        }
       }
       // Suppress Three.js/globe.gl TypeError crashes in main bundle (reading 'type'/'pathType'/'count'/'__globeObjType' on undefined during WebGL traversal/raycast).
       // __globeObjType is exclusively set by three-globe on its own objects and we have no user onClick/onHover handler, so it is always globe.gl internal even when the stack shows the bundled main chunk (WORLDMONITOR-ME).

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -453,11 +453,18 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
         if (host && THIRD_PARTY_FETCH_HOST_ALLOWLIST.has(host)) return null;
         if (host) {
           // Anchored at the end so a lookalike (`worldmonitor.app.evil.example`)
-          // is foreign. `pub-*.r2.dev` is the raw R2 bucket behind the basemaps:
-          // documented as never-used-in-code, but deliberately absent from the
-          // suppression allowlist so a basemap regression surfaces — which means
-          // it also needs its own group, not the third-party bin.
-          const isOwnHost = /(?:^|\.)worldmonitor\.app$/.test(host) || /\.r2\.dev$/.test(host);
+          // is foreign. The R2 bucket is matched EXACTLY, not by `.r2.dev`
+          // suffix: `r2.dev` is Cloudflare's shared public-bucket domain, so
+          // every account gets a `pub-<id>.r2.dev` host. A suffix match would
+          // hand each foreign tenant its own raw-host fingerprint — reopening
+          // the unbounded cardinality this bucket exists to close, and dressing
+          // an unrelated bucket up as a first-party incident. Our own bucket
+          // still needs naming here because it is deliberately absent from the
+          // suppression allowlist (WORLDMONITOR-NE/NF) so a basemap regression
+          // surfaces, and it must surface as itself rather than in the
+          // third-party bin. Kept in step with `docs/maps-and-geocoding.mdx`.
+          const isOwnHost = /(?:^|\.)worldmonitor\.app$/.test(host)
+            || host === 'pub-8ace9f6a86d74cb2bd5eb1de5590dd9e.r2.dev';
           event.fingerprint = ['fetch-failure', isOwnHost ? host : 'third-party'];
         }
       }

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -1759,3 +1759,82 @@ describe('beforeSend — Firefox bare-primitive throw (WORLDMONITOR-106)', () =>
       'stripping comments must clear it');
   });
 });
+
+// ─── WORLDMONITOR-ZG grouping: host-attributed fetch failures must not share ──
+// ─── one issue with third-party beacons ───────────────────────────────────────
+//
+// `fetch-failure-attribution.ts` put the host in the MESSAGE, and the allowlist
+// block above uses it to decide suppression. Grouping was never updated, and
+// Sentry groups these on the stack — which the attribution module's own
+// docstring establishes is identical for every fetch failure (all frames are
+// `window.fetch` wrappers; the async boundary drops the caller).
+//
+// Measured consequence (2026-08-27 triage of WORLDMONITOR-ZG, 32 events):
+//   21 x bare `Failed to fetch`         (pre-attribution builds)
+//    8 x `api.worldmonitor.app`         (a real ~90s origin blip, 2026-08-16)
+//    3 x `motramby.com`                 (injected adware beacon, 2026-08-27)
+// all in ONE issue, titled after whichever host arrived last. The eight
+// first-party origin failures — the exact population the whole attribution
+// effort existed to surface — were invisible under an adware title.
+//
+// The split is by OWNERSHIP, not by raw host: every foreign host collapses into
+// a single `third-party` bucket so a rotating adware domain cannot explode
+// issue cardinality, while each of our own hosts keeps its own issue.
+describe('host-attributed fetch failures are fingerprinted by host (WORLDMONITOR-ZG)', () => {
+  const zgStack = [
+    { filename: '/lpMwA9KpC6pf.js', lineno: 0, function: null },
+    { filename: '/lpMwA9KpC6pf.js', lineno: 0, function: 't' },
+    { filename: '/assets/widget-store-DbqgxtxV.js', lineno: 0, function: 'Pn.window.fetch' },
+    { filename: '/assets/analytics-DdK2NArM.js', lineno: 0, function: 'c' },
+  ];
+
+  it('gives a first-party origin failure its own fingerprint', () => {
+    const event = beforeSend(makeEvent('Failed to fetch (api.worldmonitor.app)', 'TypeError', zgStack));
+    assert.ok(event !== null, 'an origin outage must never be suppressed');
+    assert.deepEqual(event.fingerprint, ['fetch-failure', 'api.worldmonitor.app']);
+  });
+
+  it('gives the self-hosted PMTiles bucket its own fingerprint', () => {
+    // Deliberately absent from the suppression allowlist (WORLDMONITOR-NE/NF),
+    // so a basemap regression must also be readable on its own.
+    const event = beforeSend(makeEvent('Failed to fetch (pub-8ace9f6a86d74cb2bd.r2.dev)', 'TypeError', zgStack));
+    assert.ok(event !== null);
+    assert.deepEqual(event.fingerprint, ['fetch-failure', 'pub-8ace9f6a86d74cb2bd.r2.dev']);
+  });
+
+  it('collapses every foreign host into one bounded bucket', () => {
+    // Adware/tracker domains rotate. Bucketing them keeps cardinality at
+    // (our hosts + 1) instead of unbounded.
+    const adware = beforeSend(makeEvent('Failed to fetch (motramby.com)', 'TypeError', zgStack));
+    const other = beforeSend(makeEvent('Failed to fetch (a8f3c1e9.example-tracker.net)', 'TypeError', zgStack));
+    assert.ok(adware !== null && other !== null);
+    assert.deepEqual(adware.fingerprint, ['fetch-failure', 'third-party']);
+    assert.deepEqual(other.fingerprint, adware.fingerprint,
+      'two rotating foreign hosts must land in the SAME issue');
+  });
+
+  it('does not separate the first-party bucket from the third-party one by accident', () => {
+    // Positive control for the ownership predicate: a host that merely CONTAINS
+    // our domain is not ours.
+    const spoof = beforeSend(makeEvent('Failed to fetch (worldmonitor.app.evil.example)', 'TypeError', zgStack));
+    assert.ok(spoof !== null);
+    assert.deepEqual(spoof.fingerprint, ['fetch-failure', 'third-party']);
+  });
+
+  it('leaves suppression verdicts unchanged', () => {
+    assert.equal(beforeSend(makeEvent('Failed to fetch (abacus.worldmonitor.app)', 'TypeError', zgStack)), null);
+    assert.equal(beforeSend(makeEvent('Failed to fetch (data.debugbear.com)', 'TypeError', zgStack)), null);
+  });
+
+  it('leaves events that are not host-attributed fetch failures ungrouped', () => {
+    // A still-bare `Failed to fetch` carries no host, so there is nothing
+    // honest to fingerprint on — it must keep Sentry's default grouping.
+    const bare = beforeSend(makeEvent('Failed to fetch', 'TypeError', zgStack));
+    assert.ok(bare !== null);
+    assert.equal(bare.fingerprint, undefined);
+
+    const unrelated = beforeSend(makeEvent('Something else broke', 'Error', zgStack));
+    assert.ok(unrelated !== null);
+    assert.equal(unrelated.fingerprint, undefined);
+  });
+});

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -1796,10 +1796,22 @@ describe('host-attributed fetch failures are fingerprinted by host (WORLDMONITOR
 
   it('gives the self-hosted PMTiles bucket its own fingerprint', () => {
     // Deliberately absent from the suppression allowlist (WORLDMONITOR-NE/NF),
-    // so a basemap regression must also be readable on its own.
-    const event = beforeSend(makeEvent('Failed to fetch (pub-8ace9f6a86d74cb2bd.r2.dev)', 'TypeError', zgStack));
+    // so a basemap regression must also be readable on its own. The exact
+    // bucket, per docs/maps-and-geocoding.mdx.
+    const event = beforeSend(makeEvent('Failed to fetch (pub-8ace9f6a86d74cb2bd5eb1de5590dd9e.r2.dev)', 'TypeError', zgStack));
     assert.ok(event !== null);
-    assert.deepEqual(event.fingerprint, ['fetch-failure', 'pub-8ace9f6a86d74cb2bd.r2.dev']);
+    assert.deepEqual(event.fingerprint, ['fetch-failure', 'pub-8ace9f6a86d74cb2bd5eb1de5590dd9e.r2.dev']);
+  });
+
+  it('does not hand every Cloudflare R2 tenant a first-party group', () => {
+    // `r2.dev` is a SHARED suffix — any Cloudflare account gets a `pub-<id>.r2.dev`
+    // bucket. Matching it by suffix would give each foreign tenant its own raw-host
+    // fingerprint, reopening the unbounded cardinality the third-party bucket
+    // exists to close, and dressing an unrelated bucket up as our incident
+    // (greptile review, PR #7228).
+    const foreign = beforeSend(makeEvent('Failed to fetch (pub-0000000000000000000000000000000.r2.dev)', 'TypeError', zgStack));
+    assert.ok(foreign !== null);
+    assert.deepEqual(foreign.fingerprint, ['fetch-failure', 'third-party']);
   });
 
   it('collapses every foreign host into one bounded bucket', () => {


### PR DESCRIPTION
## Summary

A real ~90-second `api.worldmonitor.app` origin outage was invisible in Sentry — buried in an issue titled after an adware domain. `fetch-failure-attribution.ts` puts the fetch target's host in the message and `beforeSend` reads that host to decide suppression, but grouping was never updated. Sentry groups these on the stack, which that module's own docstring establishes is identical for every fetch failure (all frames are `window.fetch` wrappers; the async boundary drops the calling frame). Every host that survived the allowlist therefore landed in one issue, titled after whichever host arrived last.

WORLDMONITOR-ZG held three unrelated populations at once — all 32 of its events, censused during the 2026-08-27 triage:

| Events | Message | What it actually was |
|---|---|---|
| 21 | `Failed to fetch` | pre-attribution builds, 08-14 → 08-16 |
| 8 | `Failed to fetch (api.worldmonitor.app)` | a real origin blip, 08-16 17:47–17:49Z |
| 3 | `Failed to fetch (motramby.com)` | injected adware beacon, 08-27 |

Surviving host-attributed failures now set `event.fingerprint`. The split is by **ownership**, not by raw host: each of our own hosts keeps its own issue, while every foreign host collapses into a single `third-party` bucket. Adware and tracker domains rotate, so bucketing them bounds cardinality at (our hosts + 1) rather than leaving it open to one new issue per injected domain. The ownership test is anchored at the end, so a lookalike like `worldmonitor.app.evil.example` stays foreign.

Suppression verdicts are untouched — the allowlist still decides what is dropped, and a still-bare `Failed to fetch` carries no host, so it keeps Sentry's default grouping rather than being fingerprinted on a guess. One intended side effect: Chrome's `Failed to fetch (<host>)` and Firefox's `NetworkError ... (<host>)` for the same host now merge into one issue, which is the same failure seen through two engines.

Fixes WORLDMONITOR-ZG

## Validation

`tsx --test tests/sentry-beforesend.test.mjs` — **274 pass, 0 fail**. Six new tests; the four asserting fingerprints were confirmed red against pre-fix code before the change landed. `tsc --noEmit` and `biome check` clean, and the pre-push gate (266 further tests) passed.

No visual surface — this changes Sentry issue grouping only, so there is nothing to screenshot. WORLDMONITOR-ZG was resolved plainly in Sentry during the same triage, so the next event lands in the new per-host groups instead of reopening the fused issue.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
