### PR TITLE
fix(bootstrap): stop reporting the slow tier settled before it is even requested

### DIFF
--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -66,6 +66,13 @@ let lastHydrationState: BootstrapHydrationState = {
 let bootstrapGeneration = 0;
 let activeSlowCtrl: AbortController | null = null;
 let slowTierSettled: Promise<void> | null = null;
+/**
+ * Resolver for the slow-tier reservation held across a bootstrap. Non-null only
+ * while a bootstrap is in flight and has not yet handed its checkpoint over to
+ * the real scheduled fetch. Every exit path from fetchBootstrapData must call
+ * it, or awaiters of the reservation hang forever.
+ */
+let releaseReservedSlowTier: (() => void) | null = null;
 let bootstrapTransferRumTier: BootstrapTransferRumTier | null = null;
 let bootstrapTransferRumReported = false;
 let bootstrapTransferRumReporter = reportBootstrapTransferRum;
@@ -501,6 +508,20 @@ function scheduleSlowTierFetch(generation: number, onSlowSettled?: () => void): 
   });
 }
 
+/**
+ * True once the slow tier for the in-flight bootstrap has settled.
+ *
+ * `slowTierSettled` is null in two very different situations: no bootstrap is
+ * running at all, and a bootstrap IS running but has not scheduled its slow
+ * tier yet (it is only scheduled after the fast tier commits). Treating both as
+ * "settled" made this fail open: a caller landing in the second window got an
+ * instant `true` for a slow tier that had not even been requested. App.ts gates
+ * viewportHydrationReady + its scroll listener on this checkpoint precisely so
+ * an early scroll cannot consume the consume-once hydration keys before they
+ * arrive, so opening that gate early wasted the ~500 KB slow tier. The
+ * reservation installed by fetchBootstrapData now covers the whole bootstrap,
+ * leaving null to mean only "nothing in flight".
+ */
 export async function waitForBootstrapSlowTier(timeoutMs = 0): Promise<boolean> {
   const pending = slowTierSettled;
   if (!pending) return true;
@@ -525,6 +546,10 @@ export function cancelBootstrapSlowTier(): void {
   bootstrapGeneration += 1;
   activeSlowCtrl?.abort();
   activeSlowCtrl = null;
+  // Resolve before dropping the reference: a caller that already captured this
+  // checkpoint would otherwise await a promise nothing can settle.
+  releaseReservedSlowTier?.();
+  releaseReservedSlowTier = null;
   slowTierSettled = null;
 }
 
@@ -546,7 +571,23 @@ export async function fetchBootstrapData(onSlowSettled?: () => void): Promise<vo
 
   activeSlowCtrl?.abort();
   activeSlowCtrl = null;
-  slowTierSettled = null;
+  // Release any reservation from a superseded bootstrap before replacing it,
+  // so an awaiter still holding that generation's checkpoint is not stranded.
+  releaseReservedSlowTier?.();
+  // Reserve the checkpoint for the WHOLE bootstrap rather than only from the
+  // moment the slow tier is scheduled. Between here and that hand-off the slow
+  // tier has not settled, and a null would tell waitForBootstrapSlowTier
+  // otherwise — the fail-open that let App.ts open viewport hydration before
+  // the slow tier was even requested.
+  slowTierSettled = new Promise<void>((resolve) => {
+    releaseReservedSlowTier = resolve;
+  });
+  const reservation = releaseReservedSlowTier;
+  const releaseReservation = (): void => {
+    if (releaseReservedSlowTier === reservation) releaseReservedSlowTier = null;
+    reservation?.();
+  };
+  let handedOffToSlowFetch = false;
   hydrationCache.clear();
   lastHydrationState = {
     source: 'none',
@@ -572,18 +613,29 @@ export async function fetchBootstrapData(onSlowSettled?: () => void): Promise<vo
     desktop ? BOOTSTRAP_TIER_TIMEOUT_MS.desktop.fast : BOOTSTRAP_TIER_TIMEOUT_MS.web.fast,
   );
   try {
-    const fastState = await fetchTier('fast', fastCtrl.signal, isCurrentGeneration);
-    if (!isCurrentGeneration()) return;
-    lastHydrationState = {
-      source: combineHydrationSources([fastState, lastHydrationState.tiers.slow]),
-      tiers: { fast: fastState, slow: lastHydrationState.tiers.slow },
-    };
-  } finally {
-    clearTimeout(fastTimeout);
-  }
+    try {
+      const fastState = await fetchTier('fast', fastCtrl.signal, isCurrentGeneration);
+      if (!isCurrentGeneration()) return;
+      lastHydrationState = {
+        source: combineHydrationSources([fastState, lastHydrationState.tiers.slow]),
+        tiers: { fast: fastState, slow: lastHydrationState.tiers.slow },
+      };
+    } finally {
+      clearTimeout(fastTimeout);
+    }
 
-  if (!isCurrentGeneration()) return;
-  slowTierSettled = scheduleSlowTierFetch(generation, onSlowSettled);
+    if (!isCurrentGeneration()) return;
+    const scheduled = scheduleSlowTierFetch(generation, onSlowSettled);
+    slowTierSettled = scheduled;
+    handedOffToSlowFetch = true;
+    // Callers that captured the reservation before this hand-off must observe
+    // the REAL settle, not resolve early, so chain it rather than releasing now.
+    void scheduled.then(releaseReservation, releaseReservation);
+  } finally {
+    // Every other way out — a superseded generation, or a throw from the fast
+    // tier — leaves nothing that will ever settle, so release immediately.
+    if (!handedOffToSlowFetch) releaseReservation();
+  }
 }
 
 export const __testing__ = {

--- a/tests/bootstrap-runtime.test.mts
+++ b/tests/bootstrap-runtime.test.mts
@@ -99,6 +99,72 @@ describe('Frontend bootstrap runtime behavior', () => {
     }
   });
 
+  it('does not report the slow tier settled while a bootstrap is still in flight', async () => {
+    // fetchBootstrapData clears slowTierSettled up front and only assigns it
+    // once the fast tier has committed. waitForBootstrapSlowTier opens with
+    // `if (!pending) return true`, so during that window "not scheduled yet"
+    // was indistinguishable from "already done" and the wait no-opped.
+    //
+    // App.ts awaits this checkpoint before setting viewportHydrationReady and
+    // registering the scroll listener, precisely so an early scroll cannot
+    // consume the consume-once slow-tier hydration keys before they land
+    // (getHydratedData deletes on read). A fail-open here opens that gate early
+    // whenever Phase 6 wins the race against fast-tier completion — panels then
+    // fall back to per-panel RPCs that never re-read the late payload, wasting
+    // the ~500 KB slow tier. Surfaced as the #5876 e2e flaking under CI load.
+    const requests = installFetchStub();
+    const boot = fetchBootstrapData();
+
+    await tick();
+    assert.equal(tierRequests(requests, 'fast').length, 1, 'fast tier should be in flight');
+    assert.equal(tierRequests(requests, 'slow').length, 0, 'slow tier must not be scheduled yet');
+
+    // The bootstrap is running and the slow tier has NOT settled, so a bounded
+    // wait must report "not settled" rather than clearing instantly.
+    assert.equal(
+      await waitForBootstrapSlowTier(50),
+      false,
+      'the checkpoint must not clear before the slow tier has even been scheduled',
+    );
+
+    // Let the boot finish so the suite leaves no in-flight state behind.
+    tierRequests(requests, 'fast')[0]!.deferred.resolve(jsonResponse({ fastKey: 'fast' }));
+    await boot;
+    await tick();
+    tierRequests(requests, 'slow')[0]!.deferred.resolve(jsonResponse({ slowKey: 'slow' }));
+    assert.equal(await waitForBootstrapSlowTier(100), true, 'a settled slow tier still clears');
+  });
+
+  it('releases a superseded bootstrap checkpoint instead of stranding its awaiters', async () => {
+    // The reservation must be resolved on EVERY path out of fetchBootstrapData,
+    // not just the happy one. waitForBootstrapSlowTier captures `pending` at
+    // call time, so an awaiter can be holding a generation's promise when a
+    // newer bootstrap supersedes it and that generation returns early without
+    // ever scheduling a slow tier. Leaving that promise unresolved would turn
+    // the old fail-open into a permanent hang for waitForBootstrapSlowTier(0)
+    // callers (CorrelationPanel awaits with no timeout).
+    const requests = installFetchStub();
+    const firstBoot = fetchBootstrapData();
+    await tick();
+
+    // Capture the checkpoint belonging to the FIRST generation, mid-flight.
+    const captured = waitForBootstrapSlowTier(0);
+
+    // A second bootstrap supersedes it; the first generation now returns early.
+    const secondBoot = fetchBootstrapData();
+    await tick();
+    tierRequests(requests, 'fast')[0]!.deferred.resolve(jsonResponse({ a: 1 }));
+    tierRequests(requests, 'fast')[1]!.deferred.resolve(jsonResponse({ b: 2 }));
+    await firstBoot.catch(() => {});
+    await secondBoot.catch(() => {});
+
+    const outcome = await Promise.race([
+      captured.then(() => 'resolved' as const),
+      new Promise<'hung'>((resolve) => setTimeout(() => resolve('hung'), 250)),
+    ]);
+    assert.equal(outcome, 'resolved', 'a superseded generation must not strand slow-tier awaiters');
+  });
+
   it('returns after the fast tier and starts the slow tier only after fast state is committed', async () => {
     const requests = installFetchStub();
     let callbackState = getBootstrapHydrationState();


### PR DESCRIPTION
## The bug

`waitForBootstrapSlowTier` opens with:

```ts
const pending = slowTierSettled;
if (!pending) return true;   // "not started yet" read as "already done"
```

But `slowTierSettled` is null in **two very different states**:

1. no bootstrap is running at all, and
2. a bootstrap **is** running but has not scheduled its slow tier yet.

`fetchBootstrapData` nulls it up front (`src/services/bootstrap.ts`) and only assigns it *after the fast tier commits*, via `scheduleSlowTierFetch`. Any caller landing in that window got an instant `true` for a slow tier that had not even been requested. **It failed open.**

## Why it matters in production

`App.ts` awaits this checkpoint before setting `viewportHydrationReady` and registering the scroll listener, and states the hazard directly:

> `// Registering earlier lets a captured descendant scroll consume hydration keys before they arrive.`

Slow-tier hydration keys are **consume-once** — `getHydratedData` deletes on read. When the gate opens before the slow tier is in flight, an early scroll can consume keys that have not landed. The affected panels then fall back to per-panel RPCs that never re-read the late payload, wasting the ~500 KB slow-tier bootstrap that the same comment says the await exists to protect.

Because it is an ordering race between fast-tier completion and App.ts's Phase 6 — not a wall-clock timeout — it surfaces under load and is invisible on an unloaded machine.

## The fix

Reserve the checkpoint for the **whole** bootstrap, so `null` once again means only "nothing in flight".

The reservation is released on **every** exit path, which is the part that needs care:

| Path | Handling |
|---|---|
| Superseded generation (`!isCurrentGeneration()`) | released in `finally` |
| Throw out of the fast tier | released in `finally` |
| `cancelBootstrapSlowTier()` | released before dropping the reference |
| Success | **chained** to the scheduled fetch, not released at hand-off |

The success path matters: a caller that captured the reservation *before* the hand-off must observe the **real** settle, so it is chained via `scheduled.then(release, release)` rather than resolved when the promise is swapped.

Missing any one of those paths would convert the fail-open into a **permanent hang** for the timeout-less callers — `CorrelationPanel` awaits with `timeoutMs = 0`. Both halves are covered by tests, so neither can regress silently.

## Behaviour change, stated plainly

Callers landing in the reservation window now **wait** where they previously returned instantly. That is the point of the fix — `App.ts` waits up to its existing bounded 3.5s (8.5s desktop), which its own comment notes is off the LCP critical path. The bounded-timeout path is unchanged; only the fail-open is removed.

## How it was found and confirmed

Via the #5876 e2e flaking on PR #7215's CI: *"the early scroll must not schedule or replay a viewport trigger across readiness"* — expected 0 marks, received 1.

It reproduces deterministically by stalling the test before its scroll. The mechanism was then **confirmed against instrumentation rather than inferred**: with the slow response held open indefinitely *and* the wait's timeout overridden to 60s, the checkpoint still reported `{settled: true}` — an outcome only the `!pending` branch can produce.

That also **ruled out** the bounded 3.5s timeout, which was the first and wrong suspect. Recording that here because the two produce an identical symptom and the next person to look at this will start with the same hypothesis.

**The e2e spec was a true positive all along.** It is unchanged by this PR.

## Testing

- Two new tests in `tests/bootstrap-runtime.test.mts`, both proven red before the fix:
  - the checkpoint must not clear while a bootstrap is in flight and the slow tier is unscheduled;
  - a **superseded** generation must not strand its awaiters (guards the hang the fix could otherwise introduce).
- One earlier draft of the second test was discarded rather than shipped: it asserted a "fast tier fails" path, but `fetchTier` swallows that failure and the boot still schedules the slow tier, so it was red for the wrong reason and would have locked in a false belief.
- `tests/bootstrap-runtime` + `bootstrap` + `bootstrap-demoted-consumers` + `bootstrap-hydration-reuse`: **69 pass, 0 fail**.
- `npm run test:dom`: **538 pass** across 70 files.
- `npm run typecheck` clean; biome clean on both changed files (the 2 remaining warnings in `bootstrap.ts` are pre-existing `useDefaultParameterLast` on `encodedBytes`, unchanged on main).
- The originating e2e, **unmodified**: 3/3 passes locally via `--repeat-each=3`.

## Post-Deploy Monitoring & Validation

**What to watch:** the `wm:data:slow-tier-wait-end` LCP debug mark now carries a meaningful `settled` flag. Before this change it reported `true` whenever the wait no-opped; it should now report `true` only when the slow tier genuinely settled, and `false` when the bounded timeout elapsed.

**Healthy signal:** unchanged LCP and no rise in per-panel RPC volume for slow-tier-backed panels (stablecoins, ETF flows, gulf economies). If anything, per-panel fallback fetches should *drop*, since panels stop racing the hydration keys.

**Failure signal / rollback trigger:** a regression in dashboard LCP or `INITIAL_FANOUT_COMPLETE` timing would mean the newly-correct wait is holding boot longer than intended on real networks — the bounded 3.5s cap should prevent that, but it is the thing to watch. Rollback is a clean revert of this commit; no data or schema migration is involved.

**Validation window / owner:** first 24h of dashboard traffic post-merge, PR author.

https://claude.ai/code/session_01BXfWXtgbEcJg61Tif7pK33
