### PR TITLE
fix(agent-card): derive advertised tool count

### DIFF
--- a/.github/workflows/pro-bundle-freshness.yml
+++ b/.github/workflows/pro-bundle-freshness.yml
@@ -18,7 +18,9 @@ name: Pro bundle freshness
 on:
   pull_request:
     paths:
+      - 'api/mcp/registry/**'
       - 'convex/config/productCatalog.ts'
+      - 'public/.well-known/agent-card.json'
       - 'scripts/generate-product-config.mjs'
       - 'scripts/generate-public-product-facts.mjs'
       - 'shared/content-attribution.ts'
@@ -71,6 +73,8 @@ jobs:
           # gitignored, and `git diff --exit-code` on an untracked path exits 0,
           # so listing it reads as coverage while never being able to fail.
           # tests/public-product-facts.test.mjs is what actually guards it.
+          # public/.well-known/agent-card.json is tracked and rewritten by the
+          # same generator, so a stale committed catalog size must fail here.
           if ! git diff --exit-code \
             api/_product-catalog.generated.js \
             pro-test/index.html \
@@ -78,6 +82,7 @@ jobs:
             pro-test/src/generated/tiers.json \
             pro-test/src/locales/ \
             pro-test/welcome.html \
+            public/.well-known/agent-card.json \
             scripts/shared/product-catalog.generated.json \
             scripts/shared/product-facts.generated.json \
             shared/product-catalog.generated.json \

--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -23,7 +23,7 @@
     {
       "id": "route-to-tool",
       "name": "Capability discovery and tool routing",
-      "description": "Describe the intelligence data you need in plain language; returns the best-fit WorldMonitor MCP tools (from the live 42-tool catalog) plus the MCP/REST endpoints and auth needed to call them.",
+      "description": "Describe the intelligence data you need in plain language; returns the best-fit WorldMonitor MCP tools (from the live 68-tool catalog) plus the MCP/REST endpoints and auth needed to call them.",
       "tags": ["discovery", "routing", "mcp", "geopolitics", "markets", "supply-chain"],
       "examples": [
         "Which tool gives live shipping chokepoint status?",

--- a/scripts/generate-public-product-facts.mjs
+++ b/scripts/generate-public-product-facts.mjs
@@ -238,6 +238,24 @@ for (const [path, groups] of applicationJsonLdGroups) {
   transform(path, (source) => rewriteApplicationJsonLd(source, groups));
 }
 
+// Keep the hand-authored A2A routing copy's catalog total derived from the
+// registry. The rest of the description is editorial, but a stale number
+// would misrepresent what agents can discover through MCP.
+transform('public/.well-known/agent-card.json', (source) => {
+  const card = JSON.parse(source);
+  const routingSkill = card.skills?.find((skill) => skill.id === 'route-to-tool');
+  if (!routingSkill?.description) {
+    throw new Error('agent-card routing skill must have a description');
+  }
+  if ([...routingSkill.description.matchAll(/\b\d+-tool catalog\b/g)].length !== 1) {
+    throw new Error('agent-card routing skill must advertise exactly one N-tool catalog');
+  }
+  if ([...source.matchAll(/\b\d+-tool catalog\b/g)].length !== 1) {
+    throw new Error('agent-card must contain exactly one N-tool catalog claim');
+  }
+  return source.replace(/\b\d+-tool catalog\b/, `${TOOL_REGISTRY.length}-tool catalog`);
+});
+
 // The server card is the machine-readable tool catalog consumed by docs-stats
 // and external MCP discovery. Generate it from the same registry as the count
 // so adding tools cannot leave a syntactically valid but incomplete card.

--- a/tests/product-catalog-freshness.test.mjs
+++ b/tests/product-catalog-freshness.test.mjs
@@ -413,6 +413,9 @@ describe('Product catalog freshness', () => {
     const currentSharedCatalog = readFileSync(join(ROOT, 'shared/product-catalog.generated.json'), 'utf8');
     const currentRelayCatalog = readFileSync(join(ROOT, 'scripts/shared/product-catalog.generated.json'), 'utf8');
     const currentPublicFacts = readFileSync(join(ROOT, 'public/product-facts.json'), 'utf8');
+    // Tracked A2A card is a product:facts emit target; snapshot before regen
+    // so a concurrent rewrite cannot hide a stale committed catalog size.
+    const currentAgentCard = readFileSync(join(ROOT, 'public/.well-known/agent-card.json'), 'utf8');
     const currentRelayFacts = readFileSync(join(ROOT, 'scripts/shared/product-facts.generated.json'), 'utf8');
     const currentRelayInventory = readFileSync(join(ROOT, 'scripts/shared/inventory-facts.generated.json'), 'utf8');
     const currentEdgeInventory = readFileSync(join(ROOT, 'api/_inventory-facts.generated.js'), 'utf8');
@@ -429,6 +432,7 @@ describe('Product catalog freshness', () => {
     const freshSharedCatalog = readFileSync(join(ROOT, 'shared/product-catalog.generated.json'), 'utf8');
     const freshRelayCatalog = readFileSync(join(ROOT, 'scripts/shared/product-catalog.generated.json'), 'utf8');
     const freshPublicFacts = readFileSync(join(ROOT, 'public/product-facts.json'), 'utf8');
+    const freshAgentCard = readFileSync(join(ROOT, 'public/.well-known/agent-card.json'), 'utf8');
     const freshRelayFacts = readFileSync(join(ROOT, 'scripts/shared/product-facts.generated.json'), 'utf8');
     const freshRelayInventory = readFileSync(join(ROOT, 'scripts/shared/inventory-facts.generated.json'), 'utf8');
     const freshEdgeInventory = readFileSync(join(ROOT, 'api/_inventory-facts.generated.js'), 'utf8');
@@ -442,6 +446,7 @@ describe('Product catalog freshness', () => {
     assert.equal(currentSharedCatalog, freshSharedCatalog, 'product-catalog.generated.json is stale — run: npm run product:facts');
     assert.equal(currentRelayCatalog, freshRelayCatalog, 'scripts/shared product catalog is stale — run: npm run product:facts');
     assert.equal(currentPublicFacts, freshPublicFacts, 'product-facts.json is stale — run: npm run product:facts');
+    assert.equal(currentAgentCard, freshAgentCard, 'public/.well-known/agent-card.json is stale — run: npm run product:facts');
     assert.equal(currentRelayFacts, freshRelayFacts, 'scripts/shared product facts are stale — run: npm run product:facts');
     assert.equal(currentRelayInventory, freshRelayInventory, 'Railway inventory facts are stale — run: npm run inventory:facts');
     assert.equal(currentEdgeInventory, freshEdgeInventory, 'Edge inventory facts are stale — run: npm run inventory:facts');

--- a/tests/public-product-facts.test.mjs
+++ b/tests/public-product-facts.test.mjs
@@ -77,6 +77,14 @@ function inventoryStatsFromAttributionFixture(fixtureRoot, warnings) {
 
 const registryToolNames = () => TOOL_REGISTRY.map((tool) => tool.name);
 const registryToolCount = () => TOOL_REGISTRY.length;
+const advertisedAgentCardToolCount = () => {
+  const routingSkill = readJson('public/.well-known/agent-card.json').skills
+    ?.find((skill) => skill.id === 'route-to-tool');
+  assert.ok(routingSkill?.description, 'A2A routing skill must have a description');
+  const count = routingSkill.description.match(/\b(\d+)-tool catalog\b/);
+  assert.ok(count, 'A2A routing skill must advertise an N-tool catalog');
+  return Number.parseInt(count[1], 10);
+};
 const displayPrice = (price) => (Number.isInteger(price) ? String(price) : price.toFixed(2));
 
 const REQUIRED_ACQUISITION_CLAIM_ROOTS = [
@@ -456,6 +464,10 @@ describe('public product facts generation contract', () => {
       assert.equal(plan.availability, 'https://schema.org/InStock');
       assert.equal(plan.url, stableFacts.product.pricingUrl);
     }
+  });
+
+  it('keeps the A2A routing card tool count aligned with the live registry', () => {
+    assert.equal(advertisedAgentCardToolCount(), registryToolCount());
   });
 
   it('removes stale waitlist lifecycle terms from current acquisition surfaces', () => {


### PR DESCRIPTION
## Summary

The A2A discovery card now reports the same current MCP tool total as the registry, so agents are not directed to an obsolete catalog size. Product-facts generation derives the count and fails loudly if the routing claim disappears or becomes ambiguous. A direct parity test reads the published card and `TOOL_REGISTRY`; it was observed red at 42 vs 68 before the fix. Audit of public agent-discovery surfaces and current docs found no other numeric tool-count claim.

Fixes #7208

## Validation

- `NODE_OPTIONS=--no-experimental-webstorage node --import tsx --test tests/public-product-facts.test.mjs`
- `npm run product:facts:check`
- `npm run typecheck`
- `npm run lint` (completed with only existing warning-level diagnostics outside this diff)
- `npm run lint:boundaries`

## Post-Deploy Monitoring & Validation

- Owner and window: release operator during the first production deployment after merge.
- Check: request `/.well-known/agent-card.json` and `/.well-known/mcp/server-card.json` from production.
- Healthy signal: the A2A card advertises the same tool total as the MCP server card tool array; this revision expects 68.
- Logs and metrics: no additional dashboard is needed because this is a static public discovery artifact with no request-specific runtime path.
- Failure and mitigation: if the served card still says 42 or the counts differ, rebuild from the merged commit and redeploy or invalidate the stale artifact. Roll back this commit only if parity cannot be restored promptly.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)