### PR TITLE
fix(rpc): report actual cache hit state

### DIFF
--- a/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
+++ b/server/worldmonitor/aviation/v1/get-airport-ops-summary.ts
@@ -166,6 +166,8 @@ export async function getAirportOpsSummary(
             }
         }
 
+        // This endpoint composes a fresh response from independent delay and
+        // NOTAM seed reads. A seed-cache hit is not a response-cache hit.
         return { summaries, cacheHit: false };
     } catch (err) {
         console.warn(`[Aviation] GetAirportOpsSummary failed: ${err instanceof Error ? err.message : err}`);

--- a/server/worldmonitor/aviation/v1/get-flight-status.ts
+++ b/server/worldmonitor/aviation/v1/get-flight-status.ts
@@ -4,7 +4,7 @@ import type {
     GetFlightStatusResponse,
     FlightInstance,
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJsonWithMeta } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { getRelayBaseUrl, getRelayHeaders, requireLiveAviationAccess } from './_shared';
 import { aviationStackBudgetCycle, reserveAviationStackCalls } from './_avstack-budget';
@@ -75,7 +75,7 @@ export async function getFlightStatus(
     let unavailableSource = 'unavailable';
 
     try {
-        const result = await cachedFetchJson<{ flights: FlightInstance[]; source: 'aviationstack' }>(
+        const result = await cachedFetchJsonWithMeta<{ flights: FlightInstance[]; source: 'aviationstack' }>(
             cacheKey, CACHE_TTL, async () => {
                 const relayBase = getRelayBaseUrl();
                 if (!relayBase) {
@@ -117,19 +117,19 @@ export async function getFlightStatus(
             }
         );
 
-        if (!result) {
+        if (!result.data) {
             markNoCacheResponse(ctx.request);
             return {
                 flights: [],
                 source: unavailableSource,
-                cacheHit: false,
+                cacheHit: result.source === 'cache',
             };
         }
 
         return {
-            flights: result.flights,
-            source: result.source,
-            cacheHit: false,
+            flights: result.data.flights,
+            source: result.data.source,
+            cacheHit: result.source === 'cache',
         };
     } catch (err) {
         console.warn(`[Aviation] GetFlightStatus failed for ${flightNumber}: ${err instanceof Error ? err.message : err}`);

--- a/server/worldmonitor/imagery/v1/search-imagery.ts
+++ b/server/worldmonitor/imagery/v1/search-imagery.ts
@@ -4,7 +4,7 @@ import type {
   SearchImageryResponse,
   ImageryScene,
 } from '../../../../src/generated/server/worldmonitor/imagery/v1/service_server';
-import { cachedFetchJson } from '../../../_shared/redis';
+import { cachedFetchJsonWithMeta } from '../../../_shared/redis';
 import { CHROME_UA } from '../../../_shared/constants';
 
 const STAC_SEARCH = 'https://earth-search.aws.element84.com/v1/search';
@@ -123,7 +123,7 @@ export async function searchImagery(
   const key = cacheKey(snappedBbox, datetime, req.source, limit);
 
   try {
-    const result = await cachedFetchJson<{ scenes: ImageryScene[]; totalResults: number }>(
+    const result = await cachedFetchJsonWithMeta<{ scenes: ImageryScene[]; totalResults: number }>(
       key,
       CACHE_TTL,
       async () => {
@@ -177,10 +177,14 @@ export async function searchImagery(
       },
     );
 
-    if (result) {
-      return { scenes: result.scenes, totalResults: result.totalResults, cacheHit: true };
+    if (result.data) {
+      return {
+        scenes: result.data.scenes,
+        totalResults: result.data.totalResults,
+        cacheHit: result.source === 'cache',
+      };
     }
-    return { scenes: [], totalResults: 0, cacheHit: false };
+    return { scenes: [], totalResults: 0, cacheHit: result.source === 'cache' };
   } catch (err) {
     console.warn(`[Imagery] Search failed: ${err instanceof Error ? err.message : 'unknown'}`);
     return { scenes: [], totalResults: 0, cacheHit: false };

--- a/tests/aviation-cache-poison.test.mts
+++ b/tests/aviation-cache-poison.test.mts
@@ -55,6 +55,7 @@ afterEach(() => {
 });
 
 function installFetchMock(options: FetchMockOptions = {}) {
+  const cache = new Map<string, string>();
   const calls = {
     relayUrls: [] as string[],
     redisSets: [] as RedisSetCommand[],
@@ -66,7 +67,8 @@ function installFetchMock(options: FetchMockOptions = {}) {
     const url = String(input);
 
     if (url.startsWith('https://redis.test/get/')) {
-      return new Response(JSON.stringify({ result: null }), { status: 200 });
+      const key = decodeURIComponent(url.slice('https://redis.test/get/'.length));
+      return new Response(JSON.stringify({ result: cache.get(key) ?? null }), { status: 200 });
     }
 
     if (url === 'https://redis.test/pipeline') {
@@ -90,6 +92,7 @@ function installFetchMock(options: FetchMockOptions = {}) {
     if (url === 'https://redis.test/') {
       const command = JSON.parse(String(init?.body ?? '[]')) as RedisSetCommand;
       calls.redisSets.push(command);
+      cache.set(command[1], command[2]);
       return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
     }
 
@@ -196,6 +199,26 @@ describe('aviation cache poison prevention', () => {
     assert.equal(calls.relayUrls.length, 1);
     assertOnlyNegativeSentinels(calls);
     assertNoCacheSideChannel(request);
+  });
+
+  it('reports a repeated negative flight-status result as a cache hit', async () => {
+    process.env.WS_RELAY_URL = 'https://relay.test';
+    const calls = installFetchMock({ relay: 'http-503' });
+    const request = { flightNumber: 'TK1952', date: '2026-07-09', origin: '' };
+
+    const cold = await getFlightStatus(
+      ctxFor(requestFor('/api/aviation/v1/get-flight-status?flight_number=TK1952&date=2026-07-09')),
+      request,
+    );
+    const warm = await getFlightStatus(
+      ctxFor(requestFor('/api/aviation/v1/get-flight-status?flight_number=TK1952&date=2026-07-09')),
+      request,
+    );
+
+    assert.equal(cold.cacheHit, false);
+    assert.equal(warm.cacheHit, true);
+    assert.equal(calls.relayUrls.length, 1, 'the cached negative result must not retry the relay');
+    assertOnlyNegativeSentinels(calls);
   });
 
   it('keeps a healthy AviationStack zero-row response positive-cacheable', async () => {

--- a/tests/get-airport-ops-summary-coverage.test.mjs
+++ b/tests/get-airport-ops-summary-coverage.test.mjs
@@ -140,6 +140,8 @@ describe('getAirportOpsSummary — coverage gating (#7106)', () => {
 
     const response = await getAirportOpsSummary({}, { airports: 'LHR' });
     const lhr = summaryFor(response, 'LHR');
+    assert.equal(response.cacheHit, false,
+      'the response is composed from independent seed reads, not served from a response cache');
     assert.equal(lhr.source, 'aviationstack');
     assert.equal(lhr.delayPct, 35);
     assert.equal(lhr.avgDelayMinutes, 60);

--- a/tests/rpc-cache-hit.test.mts
+++ b/tests/rpc-cache-hit.test.mts
@@ -54,7 +54,11 @@ function jsonResponse(payload: unknown): Response {
 
 function installFetchMock(options: FetchMockOptions = {}) {
   const cache = new Map<string, string>();
-  const calls = { relay: 0, stac: 0 };
+  const calls = {
+    relay: 0,
+    stac: 0,
+    redisSets: [] as RedisSetCommand[],
+  };
 
   mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -67,6 +71,7 @@ function installFetchMock(options: FetchMockOptions = {}) {
     if (url === 'https://redis.test/') {
       const command = JSON.parse(String(init?.body ?? '[]')) as RedisSetCommand;
       assert.equal(command[0], 'SET');
+      calls.redisSets.push(command);
       cache.set(command[1], command[2]);
       return jsonResponse({ result: 'OK' });
     }
@@ -101,6 +106,29 @@ function installFetchMock(options: FetchMockOptions = {}) {
   });
 
   return calls;
+}
+
+function redisPayloads(calls: ReturnType<typeof installFetchMock>): unknown[] {
+  return calls.redisSets.map(([, , payload]) => JSON.parse(payload));
+}
+
+function assertOnlyNegativeSentinels(calls: ReturnType<typeof installFetchMock>) {
+  const payloads = redisPayloads(calls);
+  assert.ok(payloads.length > 0, 'expected at least one Redis SET');
+  assert.deepEqual([...new Set(payloads)], ['__WM_NEG__']);
+}
+
+function assertPositiveFlightCache(calls: ReturnType<typeof installFetchMock>) {
+  const payloads = redisPayloads(calls);
+  assert.ok(payloads.length > 0, 'expected at least one Redis SET');
+  for (const payload of payloads) {
+    assert.notEqual(payload, '__WM_NEG__', 'live lookup must not write a negative sentinel');
+    assert.equal(typeof payload, 'object');
+    assert.ok(payload !== null);
+    const record = payload as { flights?: unknown; source?: unknown };
+    assert.equal(record.source, 'aviationstack');
+    assert.ok(Array.isArray(record.flights) && record.flights.length > 0);
+  }
 }
 
 function flightContext() {
@@ -146,6 +174,11 @@ describe('RPC cache-hit reporting', { concurrency: 1 }, () => {
     assert.equal(cold.cacheHit, false);
     assert.equal(warm.cacheHit, true);
     assert.equal(calls.stac, 1, 'the cached failure must not retry STAC');
+    assert.deepEqual(cold.scenes, []);
+    assert.equal(cold.totalResults, 0);
+    assert.deepEqual(warm.scenes, []);
+    assert.equal(warm.totalResults, 0);
+    assertOnlyNegativeSentinels(calls);
   });
 
   it('reports a live flight lookup as a miss and its immediate repeat as a hit', async () => {
@@ -158,5 +191,10 @@ describe('RPC cache-hit reporting', { concurrency: 1 }, () => {
     assert.equal(cold.cacheHit, false);
     assert.equal(warm.cacheHit, true);
     assert.equal(calls.relay, 1, 'the repeat must use the cached flight result');
+    assert.ok(cold.flights.length > 0);
+    assert.equal(cold.source, 'aviationstack');
+    assert.ok(warm.flights.length > 0);
+    assert.equal(warm.source, 'aviationstack');
+    assertPositiveFlightCache(calls);
   });
 });

--- a/tests/rpc-cache-hit.test.mts
+++ b/tests/rpc-cache-hit.test.mts
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it, mock } from 'node:test';
+
+import { getFlightStatus } from '../server/worldmonitor/aviation/v1/get-flight-status.ts';
+import { searchImagery } from '../server/worldmonitor/imagery/v1/search-imagery.ts';
+
+const ENV_KEYS = [
+  'AVIATIONSTACK_MONTHLY_BUDGET',
+  'LOCAL_API_MODE',
+  'UPSTASH_REDIS_REST_TOKEN',
+  'UPSTASH_REDIS_REST_URL',
+  'VERCEL_ENV',
+  'VERCEL_GIT_COMMIT_SHA',
+  'WORLDMONITOR_VALID_KEYS',
+  'WS_RELAY_URL',
+] as const;
+
+const originalEnv = new Map<string, string | undefined>();
+const originalFetch = globalThis.fetch;
+
+type RedisSetCommand = ['SET', string, string, 'EX', string];
+type FetchMockOptions = { stac?: 'network-error' };
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    originalEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'redis-token';
+  process.env.VERCEL_ENV = 'production';
+  process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+  process.env.WS_RELAY_URL = 'https://relay.test';
+  process.env.AVIATIONSTACK_MONTHLY_BUDGET = '0';
+});
+
+afterEach(() => {
+  mock.restoreAll();
+  globalThis.fetch = originalFetch;
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  originalEnv.clear();
+});
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function installFetchMock(options: FetchMockOptions = {}) {
+  const cache = new Map<string, string>();
+  const calls = { relay: 0, stac: 0 };
+
+  mock.method(globalThis, 'fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+
+    if (url.startsWith('https://redis.test/get/')) {
+      const key = decodeURIComponent(url.slice('https://redis.test/get/'.length));
+      return jsonResponse({ result: cache.get(key) ?? null });
+    }
+
+    if (url === 'https://redis.test/') {
+      const command = JSON.parse(String(init?.body ?? '[]')) as RedisSetCommand;
+      assert.equal(command[0], 'SET');
+      cache.set(command[1], command[2]);
+      return jsonResponse({ result: 'OK' });
+    }
+
+    if (url === 'https://earth-search.aws.element84.com/v1/search') {
+      calls.stac += 1;
+      if (options.stac === 'network-error') throw new Error('STAC unavailable');
+      return jsonResponse({
+        features: [{
+          id: 'sentinel-2-scene',
+          properties: { datetime: '2026-08-01T00:00:00Z', constellation: 'sentinel-2' },
+          geometry: { type: 'Point', coordinates: [0, 0] },
+        }],
+        numberMatched: 1,
+      });
+    }
+
+    if (url.startsWith('https://relay.test/aviationstack')) {
+      calls.relay += 1;
+      return jsonResponse({
+        data: [{
+          flight: { iata: 'TK1952' },
+          airline: { iata: 'TK', icao: 'THY', name: 'Turkish Airlines' },
+          departure: { iata: 'IST', icao: 'LTFM', airport: 'Istanbul', scheduled: '2026-08-01T10:00:00Z' },
+          arrival: { iata: 'AMS', icao: 'EHAM', airport: 'Amsterdam', scheduled: '2026-08-01T13:00:00Z' },
+          flight_status: 'active',
+        }],
+      });
+    }
+
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+
+  return calls;
+}
+
+function flightContext() {
+  return {
+    request: new Request('https://worldmonitor.app/api/aviation/v1/get-flight-status?flight_number=TK1952&date=2026-08-01', {
+      headers: { 'X-WorldMonitor-Key': 'test-key' },
+    }),
+    pathParams: {},
+    headers: {},
+  };
+}
+
+describe('RPC cache-hit reporting', { concurrency: 1 }, () => {
+  it('reports a fresh imagery search as a miss and its immediate repeat as a hit', async () => {
+    const calls = installFetchMock();
+    const request = {
+      bbox: '0,0,1,1',
+      datetime: '2026-07-25T00:00:00Z/2026-08-01T00:00:00Z',
+      source: 'sentinel-2',
+      limit: 5,
+    };
+
+    const cold = await searchImagery({} as never, request);
+    const warm = await searchImagery({} as never, request);
+
+    assert.equal(cold.cacheHit, false);
+    assert.equal(warm.cacheHit, true);
+    assert.equal(calls.stac, 1, 'the repeat must use the cached STAC result');
+  });
+
+  it('reports a cached imagery failure as a hit without retrying STAC', async () => {
+    const calls = installFetchMock({ stac: 'network-error' });
+    const request = {
+      bbox: '0,0,1,1',
+      datetime: '2026-07-25T00:00:00Z/2026-08-01T00:00:00Z',
+      source: 'sentinel-2',
+      limit: 5,
+    };
+
+    const cold = await searchImagery({} as never, request);
+    const warm = await searchImagery({} as never, request);
+
+    assert.equal(cold.cacheHit, false);
+    assert.equal(warm.cacheHit, true);
+    assert.equal(calls.stac, 1, 'the cached failure must not retry STAC');
+  });
+
+  it('reports a live flight lookup as a miss and its immediate repeat as a hit', async () => {
+    const calls = installFetchMock();
+    const request = { flightNumber: 'TK1952', date: '2026-08-01', origin: '' };
+
+    const cold = await getFlightStatus(flightContext(), request);
+    const warm = await getFlightStatus(flightContext(), request);
+
+    assert.equal(cold.cacheHit, false);
+    assert.equal(warm.cacheHit, true);
+    assert.equal(calls.relay, 1, 'the repeat must use the cached flight result');
+  });
+});


### PR DESCRIPTION
## Summary

Cold imagery and flight-status RPC responses now report `cache_hit: false`, while an immediate response-cache reuse reports `true`. This also covers cached negative results, so a response that avoids a second upstream call is reported accurately. Airport operations continues to report `false` because it composes a new response from independent seed reads rather than serving a response cache.

Fixes #7205

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: RPC cache telemetry

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [x] No API keys or secrets committed
- [x] API TypeScript compiles without errors (`npm run typecheck:api`)

## Documentation Alignment Checklist

- [x] N/A - no published documentation, proto schema, generated API, or Redis-key contract changed

## Validation

- `node --import tsx --test tests/rpc-cache-hit.test.mts tests/aviation-cache-poison.test.mts tests/get-airport-ops-summary-coverage.test.mjs` -> 20 passed, 0 failed
- `npm run typecheck:api` -> passed
- `npm run lint:boundaries` -> passed

## Post-Deploy Monitoring & Validation

- Observe `cache_hit` on `search-imagery` and `get-flight-status` across cold and immediate-repeat requests for 24 hours.
- Expected: cold responses report `false`; repeated positive and negative cached responses report `true` with no second STAC or AviationStack relay call.
- Investigate if a fresh upstream request reports `true`, or a repeated cached request reports `false` or produces another upstream call. Roll back this commit if the response telemetry does not match those source states.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
