### PR TITLE
perf(prepush): per-gate green cache keyed on each gate's own inputs

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -386,11 +386,11 @@ TYPECHECK_INPUTS=(src shared tests e2e types scripts middleware.ts index.html vi
 TYPECHECK_API_INPUTS=(api server shared src/generated scripts middleware.ts 'tsconfig*.json' package.json package-lock.json)
 LINT_MD_INPUTS=(':(glob)**/*.md' '.markdownlint*' package.json)
 # `make generate` also runs every OpenAPI injector, and those injectors
-# read shared generation contracts. Listing only
+# read shared and gateway-adjacent generation contracts. Listing only
 # scripts/generate-request-validation.mjs made an injector-only amend
-# keep the previous key and skip regeneration (#7236). `scripts` and
-# `shared` are sound supersets (worst case a spurious re-run).
-PROTO_INPUTS=(proto Makefile scripts src/generated docs/api shared)
+# keep the previous key and skip regeneration (#7236). These are sound
+# supersets of the generator inputs (worst case a spurious re-run).
+PROTO_INPUTS=(proto Makefile scripts src/generated docs/api shared server src/shared)
 PRO_TEST_INPUTS=(pro-test convex/config/productCatalog.ts scripts/generate-product-config.mjs src/config/products.generated.ts src/config/product-ids.generated.ts)
 
 # A fresh worktree's install is part of the expensive phase too. Keep it under

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -353,6 +353,41 @@ PREPUSH_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/de
 }
 PREPUSH_ADMISSION_LEASE=$(node scripts/prepush-admission.mjs acquire "$PREPUSH_COMMON_DIR" "$$") || exit 1
 
+# Per-gate green cache (#6765). The whole-tree cache above is all-or-nothing —
+# any byte anywhere in the tree invalidates every gate, so it never hits in a
+# merge/amend/re-push loop. Each expensive gate below is ALSO keyed on the
+# worktree bytes of its own declared inputs: a docs-only amend re-pays the
+# markdown lint and nothing else. Read/write decisions live in
+# scripts/prepush-attest.sh (gate-read / gate-write), where
+# tests/prepush-attest.test.mjs executes them against real git fixtures;
+# writes are refused unless the branch diff resolved AND the worktree is
+# byte-identical to HEAD — the same attestation rules as the whole-tree cache.
+# Stored under the COMMON git dir so worktrees with identical inputs share hits.
+GATE_INPUT_CACHE="$PREPUSH_COMMON_DIR/wm-prepush-gate-cache"
+
+gate_cached() {
+  local gate="$1"; shift
+  bash "$ATTEST" gate-read "$GATE_INPUT_CACHE" "$gate" "$DIFF_RESOLVED" -- "$@"
+}
+
+# Never fails the push: a refused write only means the next run re-pays.
+gate_mark_green() {
+  local gate="$1"; shift
+  bash "$ATTEST" gate-write "$GATE_INPUT_CACHE" "$gate" "$DIFF_RESOLVED" "$ATTESTABLE" -- "$@" >/dev/null || true
+}
+
+# Declared inputs per gate, as git pathspecs. SUPERSETS of what a gate reads
+# are sound (worst case a spurious re-run); subsets are not (a false skip) —
+# when in doubt, widen. Only side-effect-free gates are cacheable; the proto
+# and pro-test gates regenerate their own CHECKED outputs in place (byte-
+# identical on a green run), so those outputs are part of their keys — a
+# hand-edit to src/generated must change the key and re-run the gate.
+TYPECHECK_INPUTS=(src shared tests e2e types scripts middleware.ts index.html vite.config.ts 'tsconfig*.json' package.json package-lock.json)
+TYPECHECK_API_INPUTS=(api server shared src/generated scripts middleware.ts 'tsconfig*.json' package.json package-lock.json)
+LINT_MD_INPUTS=(':(glob)**/*.md' '.markdownlint*' package.json)
+PROTO_INPUTS=(proto Makefile scripts/generate-request-validation.mjs src/generated docs/api)
+PRO_TEST_INPUTS=(pro-test convex/config/productCatalog.ts scripts/generate-product-config.mjs src/config/products.generated.ts src/config/product-ids.generated.ts)
+
 # A fresh worktree's install is part of the expensive phase too. Keep it under
 # the shared lease so several new worktrees cannot all run npm ci at once.
 # Symlinking node_modules is known-broken here: a later cleanup can delete
@@ -374,8 +409,13 @@ if [ ! -f node_modules/.package-lock.json ]; then
 fi
 
 if changed '^(src/|tests/|e2e/|middleware|index\.html|vite\.config|scripts/|types/)'; then
-  echo "Running type check..."
-  npm run typecheck || exit 1
+  if gate_cached typecheck "${TYPECHECK_INPUTS[@]}"; then
+    echo "Type check skipped (these exact inputs already passed; rm $GATE_INPUT_CACHE/typecheck to force)."
+  else
+    echo "Running type check..."
+    npm run typecheck || exit 1
+    gate_mark_green typecheck "${TYPECHECK_INPUTS[@]}"
+  fi
 else
   echo "Type check skipped (no frontend-surface changes)."
 fi
@@ -383,8 +423,13 @@ fi
 if changed '^(api/|server/|scripts/|middleware|src/generated/)'; then
   # tsconfig.api.json includes api, src/generated, AND server — a generated
   # client/contract change alone can break API compilation.
-  echo "Running API type check..."
-  npm run typecheck:api || exit 1
+  if gate_cached typecheck-api "${TYPECHECK_API_INPUTS[@]}"; then
+    echo "API type check skipped (these exact inputs already passed; rm $GATE_INPUT_CACHE/typecheck-api to force)."
+  else
+    echo "Running API type check..."
+    npm run typecheck:api || exit 1
+    gate_mark_green typecheck-api "${TYPECHECK_API_INPUTS[@]}"
+  fi
 else
   echo "API type check skipped (no api/server/scripts/src-generated changes)."
 fi
@@ -679,7 +724,12 @@ fi
 
 echo "Running markdown lint..."
 if path_matches '\.(md|mdx)$' || [ "$RUN_ALL" = true ]; then
-  npm run lint:md || exit 1
+  if gate_cached lint-md "${LINT_MD_INPUTS[@]}"; then
+    echo "  Skipped (markdown inputs unchanged since last green run)."
+  else
+    npm run lint:md || exit 1
+    gate_mark_green lint-md "${LINT_MD_INPUTS[@]}"
+  fi
 else
   echo "  Skipped (no markdown changes)."
 fi
@@ -713,26 +763,31 @@ if git diff --name-only origin/main -- proto/ src/generated/ docs/api/ scripts/g
   # not on PATH) still runs `make generate` cleanly because the
   # Makefile's own plugin-executable guard fires there.
   if command -v buf &>/dev/null && { command -v protoc-gen-ts-client &>/dev/null || [ -x "$HOME/go/bin/protoc-gen-ts-client" ]; }; then
-    make generate
-    if ! git diff --exit-code src/generated/ docs/api/; then
-      echo ""
-      echo "============================================================"
-      echo "ERROR: Proto-generated code is out of date."
-      echo "Run 'make generate' locally and commit the updated files."
-      echo "============================================================"
-      exit 1
+    if gate_cached proto-freshness "${PROTO_INPUTS[@]}"; then
+      echo "Proto-generated code is up to date (inputs unchanged since last green run)."
+    else
+      make generate
+      if ! git diff --exit-code src/generated/ docs/api/; then
+        echo ""
+        echo "============================================================"
+        echo "ERROR: Proto-generated code is out of date."
+        echo "Run 'make generate' locally and commit the updated files."
+        echo "============================================================"
+        exit 1
+      fi
+      UNTRACKED=$(git ls-files --others --exclude-standard src/generated/ docs/api/)
+      if [ -n "$UNTRACKED" ]; then
+        echo ""
+        echo "============================================================"
+        echo "ERROR: Untracked generated files found:"
+        echo "$UNTRACKED"
+        echo "Run 'make generate' locally and commit the new files."
+        echo "============================================================"
+        exit 1
+      fi
+      echo "Proto-generated code is up to date."
+      gate_mark_green proto-freshness "${PROTO_INPUTS[@]}"
     fi
-    UNTRACKED=$(git ls-files --others --exclude-standard src/generated/ docs/api/)
-    if [ -n "$UNTRACKED" ]; then
-      echo ""
-      echo "============================================================"
-      echo "ERROR: Untracked generated files found:"
-      echo "$UNTRACKED"
-      echo "Run 'make generate' locally and commit the new files."
-      echo "============================================================"
-      exit 1
-    fi
-    echo "Proto-generated code is up to date."
   else
     echo "WARNING: buf or protoc plugins not installed, skipping proto freshness check."
     echo "  Install with: make install-buf install-plugins"
@@ -759,64 +814,69 @@ echo "Running pro-test build + generated config freshness check..."
 # pro-test/src/generated/tiers.json. public/pro/ is gitignored since #6898 and
 # can never appear in a branch delta, so it is no longer a trigger path.
 if [ "$RUN_ALL" = true ] || path_matches '^pro-test/|^convex/config/productCatalog\.ts$|^scripts/generate-product-config\.mjs$'; then
-  npx tsx scripts/generate-product-config.mjs >/dev/null || {
-    echo "ERROR: product config generation failed"
-    exit 1
-  }
-  if [ -L pro-test/node_modules ]; then
-    echo "ERROR: pro-test/node_modules is a symlink. Copy, hardlink, or npm ci — never symlink."
-    exit 1
-  fi
-  # Marker, not directory — see the root node_modules check above.
-  if [ ! -f pro-test/node_modules/.package-lock.json ]; then
-    echo "  Installing pro-test deps..."
-    (cd pro-test && npm ci --cache "$npm_config_cache" --prefer-offline) || exit 1
-  fi
-  # Point Vite's default cacheDir (pro-test/node_modules/.vite) at a
-  # lockfile-sharded directory under the shared git-common-dir. Do not
-  # edit pro-test/vite.config.ts here: that path trips this gate. The
-  # .vite link is a cache dir, not a node_modules symlink. Serialize
-  # concurrent writes with flock.
-  if [ -n "$PREPUSH_COMMON_DIR" ]; then
-    _lock_hash=$(sha256sum < pro-test/package-lock.json 2>/dev/null | cut -c1-12)
-    [ -n "$_lock_hash" ] || _lock_hash=nolock
-    _vite_cache="$PREPUSH_COMMON_DIR/wm-vite-cache/pro-test-${_lock_hash}"
-    mkdir -p "$_vite_cache"
-    if [ -d pro-test/node_modules ] && [ ! -e pro-test/node_modules/.vite ]; then
-      ln -s "$_vite_cache" pro-test/node_modules/.vite
+  if gate_cached pro-test-build "${PRO_TEST_INPUTS[@]}"; then
+    echo "  Skipped (pro-test inputs unchanged since last green run; rm $GATE_INPUT_CACHE/pro-test-build to force)."
+  else
+    npx tsx scripts/generate-product-config.mjs >/dev/null || {
+      echo "ERROR: product config generation failed"
+      exit 1
+    }
+    if [ -L pro-test/node_modules ]; then
+      echo "ERROR: pro-test/node_modules is a symlink. Copy, hardlink, or npm ci — never symlink."
+      exit 1
     fi
-    if command -v flock >/dev/null 2>&1; then
-      exec 9>"$PREPUSH_COMMON_DIR/wm-vite-cache/pro-test.build.lock"
-      if ! flock -w 180 9; then
-        echo "ERROR: could not lock shared pro-test vite cache"
-        exit 1
+    # Marker, not directory — see the root node_modules check above.
+    if [ ! -f pro-test/node_modules/.package-lock.json ]; then
+      echo "  Installing pro-test deps..."
+      (cd pro-test && npm ci --cache "$npm_config_cache" --prefer-offline) || exit 1
+    fi
+    # Point Vite's default cacheDir (pro-test/node_modules/.vite) at a
+    # lockfile-sharded directory under the shared git-common-dir. Do not
+    # edit pro-test/vite.config.ts here: that path trips this gate. The
+    # .vite link is a cache dir, not a node_modules symlink. Serialize
+    # concurrent writes with flock.
+    if [ -n "$PREPUSH_COMMON_DIR" ]; then
+      _lock_hash=$(sha256sum < pro-test/package-lock.json 2>/dev/null | cut -c1-12)
+      [ -n "$_lock_hash" ] || _lock_hash=nolock
+      _vite_cache="$PREPUSH_COMMON_DIR/wm-vite-cache/pro-test-${_lock_hash}"
+      mkdir -p "$_vite_cache"
+      if [ -d pro-test/node_modules ] && [ ! -e pro-test/node_modules/.vite ]; then
+        ln -s "$_vite_cache" pro-test/node_modules/.vite
+      fi
+      if command -v flock >/dev/null 2>&1; then
+        exec 9>"$PREPUSH_COMMON_DIR/wm-vite-cache/pro-test.build.lock"
+        if ! flock -w 180 9; then
+          echo "ERROR: could not lock shared pro-test vite cache"
+          exit 1
+        fi
       fi
     fi
+    (cd pro-test && npm run build >/dev/null) || {
+      echo "ERROR: pro-test build failed"
+      exit 1
+    }
+    # Paths must all exist: `git diff` exits 128 on an unknown path, which this
+    # check cannot tell apart from a real diff, so a generated file that is later
+    # deleted silently converts the gate into "always fails". #5672 removed
+    # api/_product-fallback-prices.js and left it listed here, which blocked every
+    # push touching pro-test/ or public/pro/ until it was noticed. Keep this list
+    # in step with what scripts/generate-product-config.mjs actually writes.
+    if ! git diff --exit-code src/config/products.generated.ts src/config/product-ids.generated.ts pro-test/src/generated/tiers.json pro-test/src/locales/; then
+      echo ""
+      echo "============================================================"
+      echo "ERROR: product catalog, generated config, or pro locales is stale."
+      echo "public/pro/ itself is built on deploy (#6898) and is not checked here,"
+      echo "but the generated config it compiles against is still committed."
+      echo "Fix:"
+      echo "  npx tsx scripts/generate-product-config.mjs"
+      echo "  git add src/config/products.generated.ts src/config/product-ids.generated.ts pro-test/src/generated/tiers.json pro-test/src/locales/"
+      echo "  git commit --amend --no-edit"
+      echo "============================================================"
+      exit 1
+    fi
+    echo "  pro-test builds and its generated config is up to date."
+    gate_mark_green pro-test-build "${PRO_TEST_INPUTS[@]}"
   fi
-  (cd pro-test && npm run build >/dev/null) || {
-    echo "ERROR: pro-test build failed"
-    exit 1
-  }
-  # Paths must all exist: `git diff` exits 128 on an unknown path, which this
-  # check cannot tell apart from a real diff, so a generated file that is later
-  # deleted silently converts the gate into "always fails". #5672 removed
-  # api/_product-fallback-prices.js and left it listed here, which blocked every
-  # push touching pro-test/ or public/pro/ until it was noticed. Keep this list
-  # in step with what scripts/generate-product-config.mjs actually writes.
-  if ! git diff --exit-code src/config/products.generated.ts src/config/product-ids.generated.ts pro-test/src/generated/tiers.json pro-test/src/locales/; then
-    echo ""
-    echo "============================================================"
-    echo "ERROR: product catalog, generated config, or pro locales is stale."
-    echo "public/pro/ itself is built on deploy (#6898) and is not checked here,"
-    echo "but the generated config it compiles against is still committed."
-    echo "Fix:"
-    echo "  npx tsx scripts/generate-product-config.mjs"
-    echo "  git add src/config/products.generated.ts src/config/product-ids.generated.ts pro-test/src/generated/tiers.json pro-test/src/locales/"
-    echo "  git commit --amend --no-edit"
-    echo "============================================================"
-    exit 1
-  fi
-  echo "  pro-test builds and its generated config is up to date."
 else
   echo "  Skipped (no pro-test/, product catalog, or product-config generator changes in branch)."
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -385,7 +385,12 @@ gate_mark_green() {
 TYPECHECK_INPUTS=(src shared tests e2e types scripts middleware.ts index.html vite.config.ts 'tsconfig*.json' package.json package-lock.json)
 TYPECHECK_API_INPUTS=(api server shared src/generated scripts middleware.ts 'tsconfig*.json' package.json package-lock.json)
 LINT_MD_INPUTS=(':(glob)**/*.md' '.markdownlint*' package.json)
-PROTO_INPUTS=(proto Makefile scripts/generate-request-validation.mjs src/generated docs/api)
+# `make generate` also runs every OpenAPI injector, and those injectors
+# read shared generation contracts. Listing only
+# scripts/generate-request-validation.mjs made an injector-only amend
+# keep the previous key and skip regeneration (#7236). `scripts` and
+# `shared` are sound supersets (worst case a spurious re-run).
+PROTO_INPUTS=(proto Makefile scripts src/generated docs/api shared)
 PRO_TEST_INPUTS=(pro-test convex/config/productCatalog.ts scripts/generate-product-config.mjs src/config/products.generated.ts src/config/product-ids.generated.ts)
 
 # A fresh worktree's install is part of the expensive phase too. Keep it under
@@ -574,7 +579,7 @@ DOM_TESTS_CHANGED=("${_collected[@]}")
 # Same convention as the invariant lints above, which each fire on their own
 # implementation script.
 if path_matches '^(\.husky/pre-push|scripts/prepush-admission\.mjs|scripts/prepush-changed-tests\.sh|scripts/prepush-attest\.sh|vitest\.dom\.config\.mts|package\.json)$'; then
-  for contract_test in tests/prepush-admission.test.mjs tests/prepush-changed-tests.test.mjs tests/prepush-attest.test.mjs; do
+  for contract_test in tests/prepush-admission.test.mjs tests/prepush-changed-tests.test.mjs tests/prepush-attest.test.mjs tests/prepush-proto-freshness-inputs.test.mjs; do
     [ -f "$contract_test" ] || continue
     already_listed=false
     for listed in "${TESTS_CHANGED[@]}"; do
@@ -742,7 +747,7 @@ else
 fi
 
 echo "Running proto freshness check..."
-if git diff --name-only origin/main -- proto/ src/generated/ docs/api/ scripts/generate-request-validation.mjs Makefile | grep -q .; then
+if git diff --name-only origin/main -- "${PROTO_INPUTS[@]}" | grep -q .; then
   # Only prepend $HOME/go/bin when buf is NOT already resolvable on the
   # caller's PATH. An unconditional prepend would shadow a developer's
   # preferred `buf` (e.g. Homebrew) with a potentially stale

--- a/scripts/prepush-attest.sh
+++ b/scripts/prepush-attest.sh
@@ -31,6 +31,8 @@
 #   bash scripts/prepush-attest.sh cache-read   <file> <tree> <diff-resolved>
 #   bash scripts/prepush-attest.sh cache-write  <file> <tree> <diff-resolved> <attestable>
 #   bash scripts/prepush-attest.sh base-guard   <base-ref> [limit]  # "<base>\t<count>" on stdout
+#   bash scripts/prepush-attest.sh gate-read    <cache-dir> <gate> <diff-resolved> -- <pathspec>...
+#   bash scripts/prepush-attest.sh gate-write   <cache-dir> <gate> <diff-resolved> <attestable> -- <pathspec>...
 #
 # Exit codes are three-valued on purpose. A gate that answers "no" and a gate
 # that could not run must never collapse into the same status as "yes":
@@ -42,9 +44,9 @@
 
 mode="${1:-}"
 case "$mode" in
-  changed | changed-live | drift | dirty | cache-read | cache-write | base-guard) ;;
+  changed | changed-live | drift | dirty | cache-read | cache-write | base-guard | gate-read | gate-write) ;;
   *)
-    echo "usage: $0 <changed|changed-live|drift|dirty|cache-read|cache-write|base-guard> [args]" >&2
+    echo "usage: $0 <changed|changed-live|drift|dirty|cache-read|cache-write|base-guard|gate-read|gate-write> [args]" >&2
     exit 2
     ;;
 esac
@@ -252,6 +254,118 @@ NODE
 
     printf '%s\t%s\n' "$base" "$count"
     [ "$count" -le "$limit" ] || exit 3
+    ;;
+
+  gate-read | gate-write)
+    # Per-gate green cache (#6765). The whole-tree cache above is all-or-
+    # nothing: any byte anywhere invalidates every gate, so it never hits in
+    # a merge/amend loop. These modes key ONE gate on the WORKTREE bytes of
+    # ITS declared inputs — the bytes the gate actually executes — so a
+    # docs-only amend re-pays the markdown lint and nothing else.
+    #
+    # Key = hash of (gate name + sorted input paths + each path's worktree
+    # blob hash). Inputs are enumerated with `ls-files -z -co
+    # --exclude-standard`: tracked AND untracked-unignored files both count
+    # (a brand-new source file is an input change), gitignored build output
+    # does not, and -z means a unicode/backslash/newline path can never be
+    # C-quoted into a name that silently drops out of the key — the same
+    # class of hole the `changed` modes close above.
+    #
+    # The refusal rules deliberately mirror cache-write below:
+    #   * diff-resolved != true  -> no read, no write. The tree hash covers
+    #     content-derived plan inputs but a blind RUN_ALL run must not trust
+    #     or mint attestations (same reasoning as cache-read/cache-write).
+    #   * attestable != true     -> no write. The key hashes worktree bytes,
+    #     but the push ships HEAD; only when the two are byte-identical does
+    #     "this gate passed on these bytes" also vouch for what is pushed.
+    cache_dir="${2:-}"
+    gate="${3:-}"
+    diff_resolved="${4:-}"
+    if [ "$mode" = gate-write ]; then
+      attestable="${5:-}"
+      shift 5
+    else
+      shift 4
+    fi
+    [ "${1:-}" = "--" ] && shift
+    [ -n "$cache_dir" ] && [ -n "$gate" ] && [ -n "$diff_resolved" ] && [ "$#" -gt 0 ] ||
+      usage_error "<cache-dir> <gate> <diff-resolved> [<attestable>] -- <pathspec>..."
+    case "$gate" in
+      *[!a-z0-9-]*)
+        # The gate name becomes a file name inside cache_dir; anything
+        # outside [a-z0-9-] could traverse or collide.
+        echo "gate name must be [a-z0-9-]: $gate" >&2
+        exit 2
+        ;;
+    esac
+
+    gate_key() {
+      # Streams through temp files: bash variables cannot hold NUL, and
+      # every intermediate here is NUL-delimited by construction. Blob
+      # hashing is bulk (`--stdin-paths`, one git exec for the whole set);
+      # that interface is newline-delimited, so the rare legal path that
+      # CONTAINS a newline is hashed individually via argv instead of being
+      # mangled into two names that match nothing — the same class of hole
+      # the -z reads above exist to close.
+      local tmpdir status=0
+      tmpdir="$(mktemp -d)" || return 1
+      if ! git ls-files -z -co --exclude-standard -- "$@" > "$tmpdir/all" 2>/dev/null; then
+        rm -rf "$tmpdir"; return 1
+      fi
+      : > "$tmpdir/paths"
+      : > "$tmpdir/bulk_paths"
+      local f
+      while IFS= read -r -d '' f; do
+        # ls-files -c also lists files deleted from the worktree; a missing
+        # file simply drops out of the manifest, which changes the key.
+        [ -f "$f" ] || continue
+        printf '%s\0' "$f" >> "$tmpdir/paths"
+        case "$f" in
+          *$'\n'*) ;;
+          *) printf '%s\n' "$f" >> "$tmpdir/bulk_paths" ;;
+        esac
+      done < "$tmpdir/all"
+      if ! git hash-object --stdin-paths < "$tmpdir/bulk_paths" > "$tmpdir/bulk_hashes" 2>/dev/null; then
+        rm -rf "$tmpdir"; return 1
+      fi
+      (
+        exec 3< "$tmpdir/bulk_hashes"
+        printf 'gate\0%s\0' "$gate"
+        while IFS= read -r -d '' f; do
+          printf '%s\0' "$f"
+          case "$f" in
+            *$'\n'*) git hash-object -- "$f" || exit 1 ;;
+            *) IFS= read -r h <&3 || exit 1; printf '%s\n' "$h" ;;
+          esac
+        done < "$tmpdir/paths"
+      ) > "$tmpdir/manifest" || status=1
+      if [ "$status" -eq 0 ]; then
+        git hash-object --stdin < "$tmpdir/manifest" || status=1
+      fi
+      rm -rf "$tmpdir"
+      return "$status"
+    }
+
+    if [ "$diff_resolved" != true ]; then
+      [ "$mode" = gate-write ] && echo "not caching $gate: the branch diff could not be resolved."
+      exit 3
+    fi
+
+    key="$(gate_key "$@")" || exit 1
+    [ -n "$key" ] || exit 1
+
+    if [ "$mode" = gate-read ]; then
+      [ -f "$cache_dir/$gate" ] || exit 3
+      grep -qxF "$key" "$cache_dir/$gate" 2>/dev/null || exit 3
+    else
+      [ -n "$attestable" ] || usage_error "<cache-dir> <gate> <diff-resolved> <attestable> -- <pathspec>..."
+      if [ "$attestable" != true ]; then
+        echo "not caching $gate: the worktree is not byte-identical to HEAD."
+        exit 3
+      fi
+      mkdir -p "$cache_dir" || exit 1
+      printf '%s\n' "$key" > "$cache_dir/$gate" || exit 1
+    fi
     ;;
 
   cache-read)

--- a/src/App.ts
+++ b/src/App.ts
@@ -325,6 +325,7 @@ export class App {
   private visiblePanelPrimeRetryAt = new Map<string, number>();
   private visiblePanelPrimeRaf: number | null = null;
   private viewportHydrationReady = false;
+  private viewportHydrationReadyAt = 0;
   private followedCountriesCapDropToastTimer: number | null = null;
   private bootstrapHydrationState: BootstrapHydrationState = getBootstrapHydrationState();
   private cachedModeBannerEl: HTMLElement | null = null;
@@ -346,6 +347,13 @@ export class App {
   };
   private readonly handleViewportPrime = (event?: Event): void => {
     if (!this.viewportHydrationReady || this.state.isDestroyed) return;
+    if (
+      event &&
+      this.viewportHydrationReadyAt > 0 &&
+      event.timeStamp < this.viewportHydrationReadyAt
+    ) {
+      return;
+    }
     if (
       event?.type === 'scroll' &&
       event.target instanceof Element &&
@@ -2473,6 +2481,10 @@ export class App {
     // (3.5 s browser / 8.5 s desktop). (#4512)
     await slowTierReady;
     if (this.state.isDestroyed) return;
+    this.viewportHydrationReadyAt = typeof performance !== 'undefined' &&
+      typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
     this.viewportHydrationReady = true;
     // Register viewport triggers only after the slow bootstrap tier settles.
     // Scrolls before this point are covered by the initial fan-out below, which
@@ -3015,6 +3027,7 @@ export class App {
     this.tierPreferenceHandoff.clear();
     this.pendingPreferenceHandoffGeneration = undefined;
     this.viewportHydrationReady = false;
+    this.viewportHydrationReadyAt = 0;
     cancelBootstrapSlowTier();
     window.removeEventListener('scroll', this.handleViewportPrime, { capture: true });
     window.removeEventListener('resize', this.handleViewportPrime);

--- a/tests/app-destroy-lifecycle.test.mjs
+++ b/tests/app-destroy-lifecycle.test.mjs
@@ -92,11 +92,21 @@ describe('App.destroy lifecycle cleanup contract', () => {
     );
 
     const slowTierAwait = appSrc.indexOf('await slowTierReady;');
+    const readyTimestamp = appSrc.indexOf('this.viewportHydrationReadyAt = typeof performance');
+    const readyFlag = appSrc.indexOf('this.viewportHydrationReady = true;', readyTimestamp);
     const scrollRegistration = appSrc.indexOf("window.addEventListener('scroll', this.handleViewportPrime");
     assert.notEqual(slowTierAwait, -1, 'could not locate the slow-tier readiness checkpoint');
     assert.ok(
       scrollRegistration > slowTierAwait,
       'captured descendant scrolls must not trigger hydration before the slow tier settles',
+    );
+    assert.ok(
+      readyTimestamp > slowTierAwait && readyTimestamp < scrollRegistration,
+      'viewport hydration must stamp the readiness time before registering scroll listeners',
+    );
+    assert.ok(
+      readyFlag > readyTimestamp && readyFlag < scrollRegistration,
+      'viewport hydration readiness must open after the readiness timestamp is captured',
     );
   });
 
@@ -116,6 +126,12 @@ describe('App.destroy lifecycle cleanup contract', () => {
     assert.match(handler, /event\?\.type === 'scroll'/);
     assert.match(handler, /event\.target instanceof Element/);
     assert.match(handler, /!event\.target\.matches\('\.main-content, \.panels-grid'\)/);
+    const staleEventGuard = handler.indexOf('event.timeStamp < this.viewportHydrationReadyAt');
+    const rafSchedule = handler.indexOf('this.visiblePanelPrimeRaf = window.requestAnimationFrame(');
+    assert.ok(
+      staleEventGuard >= 0 && staleEventGuard < rafSchedule,
+      'scroll events created before slow-tier readiness must not replay viewport hydration afterward',
+    );
     assert.match(handler, /this\.visiblePanelPrimeRaf = window\.requestAnimationFrame\(/);
     assert.match(handler, /this\.visiblePanelPrimeRaf = null;/);
     assert.match(handler, /void this\.primeVisiblePanelData\(\);/);
@@ -126,6 +142,11 @@ describe('App.destroy lifecycle cleanup contract', () => {
       body,
       /if \(this\.visiblePanelPrimeRaf !== null\) \{\s*window\.cancelAnimationFrame\(this\.visiblePanelPrimeRaf\);\s*this\.visiblePanelPrimeRaf = null;\s*\}/,
       'destroy() must cancel a queued frame before it can hydrate a disposed App',
+    );
+    assert.match(
+      body,
+      /this\.viewportHydrationReady = false;\s*this\.viewportHydrationReadyAt = 0;/,
+      'destroy() must reset the viewport hydration readiness timestamp',
     );
 
     const afterPanelMounted = methodBody(panelLayoutSrc, 'private afterPanelMounted(key: string, panel: Panel): void');

--- a/tests/prepush-attest.test.mjs
+++ b/tests/prepush-attest.test.mjs
@@ -24,7 +24,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, test } from 'node:test';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -672,5 +672,100 @@ describe('base-guard fetches lazily and only to disprove a violation (#6764)', (
     assert.equal(result.status, 0);
     assert.equal(result.base, 'main', 'the resolved base is reported so the hook can use it');
     assert.equal(result.count, 1);
+  });
+});
+
+describe('per-gate cache keys one gate on its own worktree inputs (#6765)', () => {
+  // The whole-tree cache never hits in a merge/amend loop — any byte anywhere
+  // invalidates every gate. gate-read/gate-write key ONE gate on the worktree
+  // bytes of its declared inputs. Every case executes the real script against
+  // a real repo; the refusal rules mirror cache-read/cache-write.
+  function makeGateRepo() {
+    const root = makeRepo({
+      baseFiles: {
+        'docs/readme.md': 'docs\n',
+        'docs/café notes.md': 'unicode path\n',
+        'src/app.ts': 'code\n',
+      },
+    });
+    return { root, cache: join(root, '.git', 'wm-prepush-gate-cache') };
+  }
+
+  const gateRead = (fx, gate, diffResolved, specs) =>
+    attest(fx.root, ['gate-read', fx.cache, gate, diffResolved, '--', ...specs]).status;
+  const gateWrite = (fx, gate, diffResolved, attestable, specs) =>
+    attest(fx.root, ['gate-write', fx.cache, gate, diffResolved, attestable, '--', ...specs]).status;
+
+  test('hit: an unchanged input set read back after a green write', () => {
+    const fx = makeGateRepo();
+    assert.equal(gateRead(fx, 'lint-md', 'true', ['docs']), 3, 'no entry yet -> miss');
+    assert.equal(gateWrite(fx, 'lint-md', 'true', 'true', ['docs']), 0);
+    assert.equal(gateRead(fx, 'lint-md', 'true', ['docs']), 0, 'identical inputs -> hit');
+  });
+
+  test('miss: changing a declared input (including a unicode-named one) invalidates the gate', () => {
+    const fx = makeGateRepo();
+    gateWrite(fx, 'lint-md', 'true', 'true', ['docs']);
+    write(fx.root, 'docs/café notes.md', 'edited\n');
+    assert.equal(gateRead(fx, 'lint-md', 'true', ['docs']), 3, 'a C-quotable path must still be part of the key');
+  });
+
+  test('no cross-gate invalidation: changing gate B inputs leaves gate A green', () => {
+    const fx = makeGateRepo();
+    gateWrite(fx, 'typecheck', 'true', 'true', ['src']);
+    write(fx.root, 'docs/readme.md', 'changed\n');
+    assert.equal(gateRead(fx, 'typecheck', 'true', ['src']), 0, 'docs edits must not re-pay the typecheck');
+    assert.equal(gateRead(fx, 'typecheck', 'true', ['docs']), 3, 'same gate, different input set -> different key');
+  });
+
+  test('untracked-but-unignored files are inputs; gitignored output is not', () => {
+    const fx = makeGateRepo();
+    gateWrite(fx, 'lint-md', 'true', 'true', ['docs']);
+    write(fx.root, 'docs/new-page.md', 'brand new\n');
+    assert.equal(gateRead(fx, 'lint-md', 'true', ['docs']), 3, 'a NEW file is an input change');
+    rmSync(join(fx.root, 'docs/new-page.md'));
+    assert.equal(gateRead(fx, 'lint-md', 'true', ['docs']), 0, 'removing it restores the key');
+    write(fx.root, '.gitignore', 'docs/generated/\n');
+    git(fx.root, ['add', '.gitignore']);
+    git(fx.root, ['commit', '--quiet', '-m', 'ignore output']);
+    gateWrite(fx, 'lint-md', 'true', 'true', ['docs']);
+    write(fx.root, 'docs/generated/out.md', 'build output\n');
+    assert.equal(gateRead(fx, 'lint-md', 'true', ['docs']), 0, 'ignored build output must not churn the key');
+  });
+
+  test('refusals mirror the whole-tree cache: dirty worktree cannot write, unresolved diff can neither write nor read', () => {
+    const fx = makeGateRepo();
+    const refused = attest(fx.root, ['gate-write', fx.cache, 'lint-md', 'true', 'false', '--', 'docs']);
+    assert.equal(refused.status, 3);
+    assert.match(refused.stdout, /not byte-identical/);
+    assert.equal(existsSync(join(fx.cache, 'lint-md')), false, 'a refused write must leave no entry');
+
+    assert.equal(gateWrite(fx, 'lint-md', 'false', 'true', ['docs']), 3, 'RUN_ALL runs must not mint entries');
+    gateWrite(fx, 'lint-md', 'true', 'true', ['docs']);
+    assert.equal(gateRead(fx, 'lint-md', 'false', ['docs']), 3, 'a blind run must not trust entries either');
+  });
+
+  test('a second worktree with identical bytes shares the hit through the common cache dir', () => {
+    const fx = makeGateRepo();
+    gateWrite(fx, 'typecheck', 'true', 'true', ['src']);
+    const second = join(fx.root, '..', `${fx.root.split('/').pop()}-wt2`);
+    git(fx.root, ['worktree', 'add', '--detach', '--quiet', second, 'main']);
+    fixtures.push(second);
+    // The hook derives the cache dir from --git-common-dir, which resolves to
+    // the SAME location from both worktrees; here that dir is passed
+    // explicitly, so assert the resolution too.
+    const commonFromSecond = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+      cwd: second, env: isolatedGitEnv(), encoding: 'utf8',
+    }).trim();
+    // realpath both sides: macOS reports /var as /private/var.
+    assert.equal(realpathSync(commonFromSecond), realpathSync(join(fx.root, '.git')));
+    const status = attest(second, ['gate-read', fx.cache, 'typecheck', 'true', '--', 'src']).status;
+    assert.equal(status, 0, 'identical input bytes in a sibling worktree must hit');
+  });
+
+  test('a gate name that could escape the cache dir is a usage error', () => {
+    const fx = makeGateRepo();
+    assert.equal(gateWrite(fx, '../evil', 'true', 'true', ['docs']), 2);
+    assert.equal(existsSync(join(fx.root, '.git', 'evil')), false);
   });
 });

--- a/tests/prepush-proto-freshness-inputs.test.mjs
+++ b/tests/prepush-proto-freshness-inputs.test.mjs
@@ -1,0 +1,187 @@
+// Regression for the proto-freshness per-gate cache (#7236 P1).
+//
+// `make generate` is not just `buf generate` + request-validation. It also
+// runs every OpenAPI injector, and those injectors read shared generation
+// contracts. If PROTO_INPUTS or the proto trigger omit those files, a green
+// proto run can be amended with an injector/contract edit and the hook will
+// skip `make generate`, pushing stale docs/api.
+//
+// This suite scrapes the Makefile recipe and the hook. It does not run
+// `make generate`. Coverage is checked with the same `git ls-files` pathspec
+// enumeration the gate key uses.
+
+import { strict as assert } from 'node:assert';
+import { after, describe, test } from 'node:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MAKEFILE = readFileSync(join(ROOT, 'Makefile'), 'utf8').replace(/\r\n/g, '\n');
+const HOOK = readFileSync(join(ROOT, '.husky', 'pre-push'), 'utf8').replace(/\r\n/g, '\n');
+
+function extractGenerateRecipe() {
+  const match = MAKEFILE.match(/^generate:.*?\n((?:\t[^\n]*\n|#[^\n]*\n|\s*\n)+)/m);
+  if (!match) throw new Error('generate target not found in Makefile');
+  return match[0];
+}
+
+function extractBashArray(source, name) {
+  const match = source.match(new RegExp(`${name}=\\(([\\s\\S]*?)\\)`));
+  if (!match) throw new Error(`${name} array not found`);
+  return [...match[1].matchAll(/'(?:\\.|[^'])*'|"(?:\\.|[^"])*"|[^\s]+/g)]
+    .map((token) => token[0].replace(/^['"]|['"]$/g, ''));
+}
+
+function extractGenerateScripts(recipe) {
+  return [...recipe.matchAll(/node\s+(scripts\/\S+\.mjs)/g)].map((match) => match[1]);
+}
+
+function walkScriptReads(absPath, inputs, seen = new Set()) {
+  if (seen.has(absPath) || !existsSync(absPath)) return;
+  seen.add(absPath);
+  const source = readFileSync(absPath, 'utf8');
+  for (const match of source.matchAll(/['"]((?:shared|scripts)\/[^'"]+)['"]/g)) {
+    const rel = match[1];
+    const abs = join(ROOT, rel);
+    if (!existsSync(abs)) continue;
+    inputs.add(rel);
+    if (/\.(mjs|js|ts)$/.test(rel)) walkScriptReads(abs, inputs, seen);
+  }
+  for (const match of source.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
+    const resolved = resolve(dirname(absPath), match[1]);
+    for (const candidate of [resolved, `${resolved}.mjs`, `${resolved}.js`, `${resolved}.ts`]) {
+      if (!existsSync(candidate) || !candidate.startsWith(`${ROOT}/`)) continue;
+      const rel = relative(ROOT, candidate);
+      if (!rel.startsWith('scripts/') && !rel.startsWith('shared/')) continue;
+      inputs.add(rel);
+      walkScriptReads(candidate, inputs, seen);
+    }
+  }
+}
+
+function generateConsumedPaths() {
+  const scripts = extractGenerateScripts(extractGenerateRecipe());
+  const inputs = new Set(scripts);
+  for (const script of scripts) {
+    walkScriptReads(join(ROOT, script), inputs);
+  }
+  return [...inputs].sort();
+}
+
+function filesCoveredByPathspecs(pathspecs) {
+  const out = execFileSync('git', ['ls-files', '-co', '--exclude-standard', '--', ...pathspecs], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+  return new Set(out.split('\n').filter(Boolean));
+}
+
+const GIT_LOCAL_ENV_VARS = execFileSync('git', ['rev-parse', '--local-env-vars'], {
+  encoding: 'utf8',
+})
+  .trim()
+  .split('\n');
+
+function isolatedGitEnv() {
+  const env = { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' };
+  for (const name of GIT_LOCAL_ENV_VARS) delete env[name];
+  return env;
+}
+
+function makeProtoInputRepo() {
+  const root = mkdtempSync(join(tmpdir(), 'wm-proto-freshness-'));
+  const git = (args) => execFileSync('git', args, { cwd: root, env: isolatedGitEnv(), encoding: 'utf8' });
+  const write = (rel, contents) => {
+    const target = join(root, rel);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, contents);
+  };
+  git(['init', '--quiet', '--initial-branch=main', '.']);
+  git(['config', 'user.email', 'proto-freshness@example.invalid']);
+  git(['config', 'user.name', 'Proto Freshness Fixture']);
+  write('proto/service.proto', 'syntax = "proto3";\n');
+  write('Makefile', 'generate:\n\t@true\n');
+  write('scripts/generate-request-validation.mjs', 'export {}\n');
+  write('scripts/openapi-inject-security.mjs', 'export const injector = 1;\n');
+  write('src/generated/client.ts', 'export {}\n');
+  write('docs/api/worldmonitor.openapi.yaml', 'openapi: 3.1.0\n');
+  write('shared/openapi-filter-param-contracts.json', '{}\n');
+  git(['add', '-A']);
+  git(['commit', '--quiet', '-m', 'base']);
+  const cache = join(root, '.git', 'wm-prepush-gate-cache');
+  const attest = (mode) => {
+    try {
+      execFileSync(
+        'bash',
+        [join(ROOT, 'scripts', 'prepush-attest.sh'), mode, cache, 'proto-freshness', 'true', ...(mode === 'gate-write' ? ['true'] : []), '--', ...extractBashArray(HOOK, 'PROTO_INPUTS')],
+        { cwd: root, env: isolatedGitEnv(), encoding: 'utf8' },
+      );
+      return 0;
+    } catch (error) {
+      return error.status;
+    }
+  };
+  return { root, write, attest };
+}
+
+describe('proto-freshness inputs cover every make generate script and shared contract', () => {
+  const protoInputs = extractBashArray(HOOK, 'PROTO_INPUTS');
+  const consumed = generateConsumedPaths();
+  const covered = filesCoveredByPathspecs(protoInputs);
+
+  test('Makefile generate invokes more than request-validation', () => {
+    assert.ok(
+      consumed.some((path) => path.startsWith('scripts/openapi-inject-')),
+      'generate recipe must still run OpenAPI injectors — otherwise this suite is testing the wrong contract',
+    );
+    assert.ok(
+      consumed.some((path) => path.startsWith('shared/') || path.startsWith('scripts/lib/')),
+      'at least one injector must still read a shared generation contract',
+    );
+  });
+
+  test('PROTO_INPUTS pathspecs cover every generate script and shared contract it reads', () => {
+    const missing = consumed.filter((path) => !covered.has(path));
+    assert.deepEqual(
+      missing,
+      [],
+      `PROTO_INPUTS omits generate inputs (false skip / stale docs/api):\n${missing.map((path) => `  ${path}`).join('\n')}`,
+    );
+  });
+
+  test('the proto trigger uses PROTO_INPUTS so an injector-only edit cannot skip the gate', () => {
+    const start = HOOK.indexOf('Running proto freshness check');
+    assert.ok(start >= 0, 'pre-push hook must contain the proto-freshness block');
+    const block = HOOK.slice(start, start + 2500);
+    assert.match(
+      block,
+      /git diff --name-only origin\/main -- "\$\{PROTO_INPUTS\[@\]\}"/,
+      'proto trigger must reuse PROTO_INPUTS; a second hardcoded path list can omit an injector again',
+    );
+  });
+
+  const fixtures = [];
+  after(() => {
+    for (const root of fixtures) rmSync(root, { recursive: true, force: true });
+  });
+
+  test('editing an OpenAPI injector invalidates a previously green proto-freshness key', () => {
+    const fx = makeProtoInputRepo();
+    fixtures.push(fx.root);
+    assert.equal(fx.attest('gate-write'), 0);
+    assert.equal(fx.attest('gate-read'), 0, 'identical inputs must hit');
+    fx.write('scripts/openapi-inject-security.mjs', 'export const injector = 2;\n');
+    assert.equal(fx.attest('gate-read'), 3, 'an injector amend must miss so make generate runs again');
+  });
+
+  test('editing a shared generation contract invalidates a previously green proto-freshness key', () => {
+    const fx = makeProtoInputRepo();
+    fixtures.push(fx.root);
+    assert.equal(fx.attest('gate-write'), 0);
+    fx.write('shared/openapi-filter-param-contracts.json', '{"changed":true}\n');
+    assert.equal(fx.attest('gate-read'), 3, 'a shared-contract amend must miss so make generate runs again');
+  });
+});

--- a/tests/prepush-proto-freshness-inputs.test.mjs
+++ b/tests/prepush-proto-freshness-inputs.test.mjs
@@ -1,10 +1,10 @@
 // Regression for the proto-freshness per-gate cache (#7236 P1).
 //
 // `make generate` is not just `buf generate` + request-validation. It also
-// runs every OpenAPI injector, and those injectors read shared generation
-// contracts. If PROTO_INPUTS or the proto trigger omit those files, a green
-// proto run can be amended with an injector/contract edit and the hook will
-// skip `make generate`, pushing stale docs/api.
+// runs every OpenAPI injector, and those injectors read shared and
+// gateway-adjacent generation contracts. If PROTO_INPUTS or the proto trigger
+// omit those files, a green proto run can be amended with an injector/contract
+// edit and the hook will skip `make generate`, pushing stale docs/api.
 //
 // This suite scrapes the Makefile recipe and the hook. It does not run
 // `make generate`. Coverage is checked with the same `git ls-files` pathspec
@@ -43,7 +43,7 @@ function walkScriptReads(absPath, inputs, seen = new Set()) {
   if (seen.has(absPath) || !existsSync(absPath)) return;
   seen.add(absPath);
   const source = readFileSync(absPath, 'utf8');
-  for (const match of source.matchAll(/['"]((?:shared|scripts)\/[^'"]+)['"]/g)) {
+  for (const match of source.matchAll(/['"]((?:shared|scripts|server|src\/shared)\/[^'"]+)['"]/g)) {
     const rel = match[1];
     const abs = join(ROOT, rel);
     if (!existsSync(abs)) continue;
@@ -55,7 +55,12 @@ function walkScriptReads(absPath, inputs, seen = new Set()) {
     for (const candidate of [resolved, `${resolved}.mjs`, `${resolved}.js`, `${resolved}.ts`]) {
       if (!existsSync(candidate) || !candidate.startsWith(`${ROOT}/`)) continue;
       const rel = relative(ROOT, candidate);
-      if (!rel.startsWith('scripts/') && !rel.startsWith('shared/')) continue;
+      if (
+        !rel.startsWith('scripts/')
+        && !rel.startsWith('shared/')
+        && !rel.startsWith('server/')
+        && !rel.startsWith('src/shared/')
+      ) continue;
       inputs.add(rel);
       walkScriptReads(candidate, inputs, seen);
     }
@@ -109,6 +114,10 @@ function makeProtoInputRepo() {
   write('src/generated/client.ts', 'export {}\n');
   write('docs/api/worldmonitor.openapi.yaml', 'openapi: 3.1.0\n');
   write('shared/openapi-filter-param-contracts.json', '{}\n');
+  write('server/gateway.ts', 'export const PUBLIC_NO_AUTH_RPC_PATHS = new Set<string>();\n');
+  write('server/_shared/entitlement-check.ts', 'export const ENDPOINT_ENTITLEMENTS = new Map<string, number>();\n');
+  write('server/_shared/idempotency.ts', 'export const IDEMPOTENCY_EXEMPT_RPC_PATHS = new Set<string>();\n');
+  write('src/shared/premium-paths.ts', 'export const PREMIUM_RPC_PATHS = new Set<string>();\n');
   git(['add', '-A']);
   git(['commit', '--quiet', '-m', 'base']);
   const cache = join(root, '.git', 'wm-prepush-gate-cache');
@@ -127,7 +136,7 @@ function makeProtoInputRepo() {
   return { root, write, attest };
 }
 
-describe('proto-freshness inputs cover every make generate script and shared contract', () => {
+describe('proto-freshness inputs cover every make generate script and generation contract', () => {
   const protoInputs = extractBashArray(HOOK, 'PROTO_INPUTS');
   const consumed = generateConsumedPaths();
   const covered = filesCoveredByPathspecs(protoInputs);
@@ -141,9 +150,13 @@ describe('proto-freshness inputs cover every make generate script and shared con
       consumed.some((path) => path.startsWith('shared/') || path.startsWith('scripts/lib/')),
       'at least one injector must still read a shared generation contract',
     );
+    assert.ok(
+      consumed.some((path) => path.startsWith('server/') || path.startsWith('src/shared/')),
+      'at least one injector helper must still read a gateway-adjacent generation contract',
+    );
   });
 
-  test('PROTO_INPUTS pathspecs cover every generate script and shared contract it reads', () => {
+  test('PROTO_INPUTS pathspecs cover every generate script and generation contract it reads', () => {
     const missing = consumed.filter((path) => !covered.has(path));
     assert.deepEqual(
       missing,
@@ -183,5 +196,13 @@ describe('proto-freshness inputs cover every make generate script and shared con
     assert.equal(fx.attest('gate-write'), 0);
     fx.write('shared/openapi-filter-param-contracts.json', '{"changed":true}\n');
     assert.equal(fx.attest('gate-read'), 3, 'a shared-contract amend must miss so make generate runs again');
+  });
+
+  test('editing a gateway-adjacent generation contract invalidates a previously green proto-freshness key', () => {
+    const fx = makeProtoInputRepo();
+    fixtures.push(fx.root);
+    assert.equal(fx.attest('gate-write'), 0);
+    fx.write('server/gateway.ts', 'export const PUBLIC_NO_AUTH_RPC_PATHS = new Set<string>(["/api/probe"]);\n');
+    assert.equal(fx.attest('gate-read'), 3, 'a gateway-contract amend must miss so make generate runs again');
   });
 });


### PR DESCRIPTION
Fixes #6765. Follow-up to #7054 in the same file family.

## What this does

**New `gate-read` / `gate-write` modes in `scripts/prepush-attest.sh`** (per the issue's hard constraint 3 — decisions live where tests can execute them):

- Key = hash of (gate name + sorted input paths + each path's **worktree** blob hash). Enumeration is `git ls-files -z -co --exclude-standard`, so untracked-but-unignored files count as inputs (a brand-new source file is an input change), gitignored build output does not, and a unicode/backslash/newline path can never be C-quoted into a name that drops out of the key — the same hole class the file's `changed` modes close. Hashing is bulk (`--stdin-paths`, one git exec per gate) with a per-file argv fallback for the rare legal path containing a newline (that interface is newline-delimited).
- **Refusals mirror the whole-tree rules** (hard constraint 1): unresolved branch diff → neither read nor write; worktree not byte-identical to HEAD → no write. A refused write leaves no entry.
- Entries live under `--git-common-dir`/`wm-prepush-gate-cache/`, so **all worktrees with identical inputs share hits** (the acceptance item where most of the value is).

**The hook wires five gates**: `typecheck`, `typecheck:api`, `lint:md`, proto freshness, and the pro-test build. On the side-effect constraint (hard constraint 2): the proto and pro-test gates mutate only their own **checked** outputs, which are byte-identical on a green run — and those outputs are **part of their keys**, so a hand-edit to `src/generated/` changes the key and re-runs the gate rather than being skipped over. Input sets are documented supersets; `package.json`/lockfile/tsconfigs sit in the typecheck keys so the `RUN_ALL`-on-config-change case cannot false-skip.

## Acceptance criteria

- **Docs-only amend re-push skips pro-test, proto, and both typechecks, re-runs only the markdown lint** — the four skipped gates' inputs are untouched by a docs edit; only `lint-md`'s key (which includes `**/*.md`) changes. Gate independence is pinned by the no-cross-gate-invalidation fixture.
- **Per-gate invalidation** — fixture: changing gate B's inputs leaves gate A's entry green; same gate with a different input set misses.
- **Never skipped on a run cache-write would refuse** — both refusal fixtures (unresolved diff: no read *and* no write; dirty worktree: no write, no entry file created).
- **No side-effecting gate skipped unsafely** — outputs-in-key design above.
- **Cross-worktree sharing** — fixture adds a second `git worktree`, asserts `--git-common-dir` resolves to the shared location and the read hits from the sibling.
- **Measured**: a cache hit costs 0.9s (typecheck key, the largest input walk), 0.17s (lint:md), 0.08s (pro-test) on this repo — against the 7.1–54.9s gates it skips (the issue's own table). A docs-only amend's gate bill drops from ~150s to the markdown lint plus ~1.3s of key checks.

## Verification

- `tests/prepush-attest.test.mjs`: **49/49** (42 existing + 7 new fixtures, including a unicode-named input file and gate-name path-escape rejection)
- `bash -n` on both shell files; `biome lint` on the test — clean
- `tests/prepush-hook-gate.test.mjs`: failing set is **identical by name on clean main** (those cases drive the full hook and need `gh`/network; env-dependent, untouched by this diff)
