### PR TITLE
fix(payments): coerce Dodo webhook amounts (WORLDMONITOR-114)

### DIFF
--- a/convex/__tests__/coerceAmount.test.ts
+++ b/convex/__tests__/coerceAmount.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { coerceAmount } from "../payments/subscriptionHelpers";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("coerceAmount", () => {
+  test("passes through a finite number", () => {
+    expect(coerceAmount(1999)).toBe(1999);
+    expect(coerceAmount(0)).toBe(0);
+    expect(coerceAmount(-50)).toBe(-50);
+  });
+
+  test("parses a numeric string (Dodo dispute payloads send amount as string)", () => {
+    expect(coerceAmount("9999")).toBe(9999);
+    expect(coerceAmount(" 1999 ")).toBe(1999);
+    expect(coerceAmount("12.5")).toBe(12.5);
+  });
+
+  test("returns 0 for missing or empty values", () => {
+    expect(coerceAmount(undefined)).toBe(0);
+    expect(coerceAmount(null)).toBe(0);
+    expect(coerceAmount("")).toBe(0);
+    expect(coerceAmount("   ")).toBe(0);
+  });
+
+  test("warns and returns 0 for non-numeric garbage", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(coerceAmount("not-an-amount")).toBe(0);
+    expect(coerceAmount(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(coerceAmount({ cents: 9999 })).toBe(0);
+    expect(coerceAmount(true)).toBe(0);
+
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -2766,6 +2766,51 @@ describe("webhook processWebhookEvent", () => {
     expect(events[0].status).toBe(expectedStatus);
   });
 
+  // WORLDMONITOR-114 — Dodo dispute payloads type `amount` as a string and omit
+  // `total_amount`. Inserting that string into paymentEvents.amount (v.number)
+  // rejected the mutation before this coerce.
+  test("dispute.opened with string amount and no total_amount persists a numeric amount", async () => {
+    const t = convexTest(schema, modules);
+
+    const payload = {
+      type: "dispute.opened",
+      business_id: "biz_test",
+      timestamp: "2026-03-21T10:00:00Z",
+      data: {
+        payload_type: "Dispute",
+        dispute_id: "dp_string_amount",
+        payment_id: "pay_string_amount",
+        currency: "USD",
+        amount: "9999",
+        customer: {
+          customer_id: "cust_test_001",
+          email: "test@example.com",
+          name: "Test User",
+        },
+        metadata: { wm_user_id: "test-user-001" },
+      },
+    };
+    await processEvent(t, "wh_dispute_string_amount", "dispute.opened", payload, BASE_TIMESTAMP);
+
+    const events = await t.run(async (ctx) => ctx.db.query("paymentEvents").collect());
+    expect(events).toHaveLength(1);
+    expect(events[0].amount).toBe(9999);
+    expect(events[0].status).toBe("dispute_opened");
+    expect(events[0].dodoPaymentId).toBe("pay_string_amount");
+  });
+
+  test("payment.succeeded with string total_amount persists a numeric amount", async () => {
+    const t = convexTest(schema, modules);
+
+    const payload = makePaymentPayload("payment.succeeded", { total_amount: "1999" });
+    await processEvent(t, "wh_payment_string_amount", "payment.succeeded", payload, BASE_TIMESTAMP);
+
+    const events = await t.run(async (ctx) => ctx.db.query("paymentEvents").collect());
+    expect(events).toHaveLength(1);
+    expect(events[0].amount).toBe(1999);
+    expect(events[0].status).toBe("succeeded");
+  });
+
   test("out-of-order events are rejected", async () => {
     const t = convexTest(schema, modules);
 

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -374,10 +374,14 @@ describe("webhook processWebhookEvent", () => {
         payload_type: "Refund",
         payment_id: "pay_refund_001",
         subscription_id: "sub_test_001",
-        total_amount: 1999,
+        total_amount: "1999",
       }),
       BASE_TIMESTAMP + 300000,
     );
+
+    const events = await t.run(async (ctx) => ctx.db.query("paymentEvents").collect());
+    expect(events).toHaveLength(1);
+    expect(events[0].amount).toBe(1999);
 
     const refundAlerts = errorSpy.mock.calls
       .map((call) => String(call[0]))
@@ -2809,6 +2813,19 @@ describe("webhook processWebhookEvent", () => {
     expect(events).toHaveLength(1);
     expect(events[0].amount).toBe(1999);
     expect(events[0].status).toBe("succeeded");
+  });
+
+  test("payment.succeeded with a non-numeric total_amount persists 0 and warns", async () => {
+    const t = convexTest(schema, modules);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const payload = makePaymentPayload("payment.succeeded", { total_amount: "not-an-amount" });
+    await processEvent(t, "wh_payment_invalid_amount", "payment.succeeded", payload, BASE_TIMESTAMP);
+
+    const events = await t.run(async (ctx) => ctx.db.query("paymentEvents").collect());
+    expect(events).toHaveLength(1);
+    expect(events[0].amount).toBe(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("[coerceAmount] non-numeric amount"));
   });
 
   test("out-of-order events are rejected", async () => {

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -360,6 +360,7 @@ describe("webhook processWebhookEvent", () => {
     );
 
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     // Full refund on the now-active sub. Before the fix the leftover
     // cancelledAt short-circuited classifyRefundAlert to `already-cancelled`
@@ -374,7 +375,8 @@ describe("webhook processWebhookEvent", () => {
         payload_type: "Refund",
         payment_id: "pay_refund_001",
         subscription_id: "sub_test_001",
-        total_amount: "1999",
+        total_amount: "not-an-amount",
+        amount: "1999",
       }),
       BASE_TIMESTAMP + 300000,
     );
@@ -382,6 +384,10 @@ describe("webhook processWebhookEvent", () => {
     const events = await t.run(async (ctx) => ctx.db.query("paymentEvents").collect());
     expect(events).toHaveLength(1);
     expect(events[0].amount).toBe(1999);
+    const amountWarnings = warnSpy.mock.calls
+      .map((call) => String(call[0]))
+      .filter((message) => message.includes("[coerceAmount] non-numeric amount"));
+    expect(amountWarnings).toHaveLength(1);
 
     const refundAlerts = errorSpy.mock.calls
       .map((call) => String(call[0]))
@@ -2770,11 +2776,12 @@ describe("webhook processWebhookEvent", () => {
     expect(events[0].status).toBe(expectedStatus);
   });
 
-  // WORLDMONITOR-114 — Dodo dispute payloads type `amount` as a string and omit
-  // `total_amount`. Inserting that string into paymentEvents.amount (v.number)
-  // rejected the mutation before this coerce.
-  test("dispute.opened with string amount and no total_amount persists a numeric amount", async () => {
+  // WORLDMONITOR-114 — Dodo dispute payloads type `amount` as a string.
+  // A malformed `total_amount` must fall through to it before paymentEvents
+  // validates its numeric amount field.
+  test("dispute.opened falls back to a string amount when total_amount is invalid", async () => {
     const t = convexTest(schema, modules);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const payload = {
       type: "dispute.opened",
@@ -2785,6 +2792,7 @@ describe("webhook processWebhookEvent", () => {
         dispute_id: "dp_string_amount",
         payment_id: "pay_string_amount",
         currency: "USD",
+        total_amount: "not-an-amount",
         amount: "9999",
         customer: {
           customer_id: "cust_test_001",
@@ -2801,6 +2809,7 @@ describe("webhook processWebhookEvent", () => {
     expect(events[0].amount).toBe(9999);
     expect(events[0].status).toBe("dispute_opened");
     expect(events[0].dodoPaymentId).toBe("pay_string_amount");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("[coerceAmount] non-numeric amount"));
   });
 
   test("payment.succeeded with string total_amount persists a numeric amount", async () => {
@@ -2815,12 +2824,31 @@ describe("webhook processWebhookEvent", () => {
     expect(events[0].status).toBe("succeeded");
   });
 
-  test("payment.succeeded with a non-numeric total_amount persists 0 and warns", async () => {
+  test("payment.succeeded falls back to a valid amount when total_amount is non-numeric", async () => {
     const t = convexTest(schema, modules);
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    const payload = makePaymentPayload("payment.succeeded", { total_amount: "not-an-amount" });
+    const payload = makePaymentPayload("payment.succeeded", {
+      total_amount: "not-an-amount",
+      amount: "1999",
+    });
     await processEvent(t, "wh_payment_invalid_amount", "payment.succeeded", payload, BASE_TIMESTAMP);
+
+    const events = await t.run(async (ctx) => ctx.db.query("paymentEvents").collect());
+    expect(events).toHaveLength(1);
+    expect(events[0].amount).toBe(1999);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("[coerceAmount] non-numeric amount"));
+  });
+
+  test("payment.succeeded with no usable amount persists 0 and warns", async () => {
+    const t = convexTest(schema, modules);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const payload = makePaymentPayload("payment.succeeded", {
+      total_amount: "not-an-amount",
+      amount: "also-not-an-amount",
+    });
+    await processEvent(t, "wh_payment_no_usable_amount", "payment.succeeded", payload, BASE_TIMESTAMP);
 
     const events = await t.run(async (ctx) => ctx.db.query("paymentEvents").collect());
     expect(events).toHaveLength(1);

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -170,7 +170,27 @@ export function coerceAmount(value: unknown): number {
   return 0;
 }
 
+function isUsableAmount(value: unknown): boolean {
+  return (
+    (typeof value === "number" && Number.isFinite(value))
+    || (typeof value === "string"
+      && value.trim() !== ""
+      && Number.isFinite(Number(value)))
+  );
+}
+
 function webhookAmount(data: Pick<DodoPaymentData, "total_amount" | "amount">): number {
+  if (isUsableAmount(data.total_amount)) return coerceAmount(data.total_amount);
+
+  if (isUsableAmount(data.amount)) {
+    // Preserve diagnostics for an invalid primary value while using the valid
+    // fallback Dodo also supplies on some webhook payloads.
+    if (data.total_amount !== undefined && data.total_amount !== null) {
+      coerceAmount(data.total_amount);
+    }
+    return coerceAmount(data.amount);
+  }
+
   return coerceAmount(data.total_amount ?? data.amount);
 }
 
@@ -1796,12 +1816,13 @@ export async function handlePaymentOrRefundEvent(
   // caller is gated by the webhook switch's routed-event cases, and an
   // unexpected value throws (loudly) in derivePaymentEventStatus.
   const status = derivePaymentEventStatus(eventType as RoutedPaymentEvent, data);
+  const amount = webhookAmount(data);
 
   await ctx.db.insert("paymentEvents", {
     userId,
     dodoPaymentId: data.payment_id,
     type,
-    amount: webhookAmount(data),
+    amount,
     currency: data.currency ?? "USD",
     status,
     dodoSubscriptionId: data.subscription_id ?? undefined,
@@ -1838,7 +1859,7 @@ export async function handlePaymentOrRefundEvent(
       subCancelledAt: sub?.cancelledAt,
       subRawPayload: sub?.rawPayload,
       subUserId: sub?.userId,
-      refundAmount: webhookAmount(data),
+      refundAmount: amount,
     });
     if (decision.kind === "alert") {
       console.error(

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -52,8 +52,10 @@ interface DodoSubscriptionData {
 interface DodoPaymentData {
   payment_id: string;
   customer?: DodoCustomer;
-  total_amount?: number;
-  amount?: number;
+  // Dodo payment payloads typically send these as numbers; dispute payloads
+  // type `amount` as a string (SDK `disputes.retrieve` / webhook `Dispute`).
+  total_amount?: number | string;
+  amount?: number | string;
   currency?: string;
   subscription_id?: string;
   metadata?: Record<string, string>;
@@ -139,6 +141,37 @@ export function isNewerEvent(
   incomingTimestamp: number,
 ): boolean {
   return incomingTimestamp > existingUpdatedAt;
+}
+
+/**
+ * Coerces a Dodo webhook amount into a finite number for `paymentEvents.amount`.
+ *
+ * Dispute payloads send `amount` as a string (`"9999"`). Missing or invalid
+ * values become `0`; non-numeric garbage is not accepted silently.
+ */
+export function coerceAmount(value: unknown): number {
+  if (value === undefined || value === null) return 0;
+  if (typeof value === "number") {
+    if (Number.isFinite(value)) return value;
+    console.warn(`[coerceAmount] non-finite amount ${String(value)}; persisting 0`);
+    return 0;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return 0;
+    const parsed = Number(trimmed);
+    if (Number.isFinite(parsed)) return parsed;
+    console.warn(
+      `[coerceAmount] non-numeric amount ${JSON.stringify(value)}; persisting 0`,
+    );
+    return 0;
+  }
+  console.warn(`[coerceAmount] unexpected amount type ${typeof value}; persisting 0`);
+  return 0;
+}
+
+function webhookAmount(data: Pick<DodoPaymentData, "total_amount" | "amount">): number {
+  return coerceAmount(data.total_amount ?? data.amount);
 }
 
 // Delay for the second, race-covering entitlement cache sync (#4770 review):
@@ -1768,7 +1801,7 @@ export async function handlePaymentOrRefundEvent(
     userId,
     dodoPaymentId: data.payment_id,
     type,
-    amount: data.total_amount ?? data.amount ?? 0,
+    amount: webhookAmount(data),
     currency: data.currency ?? "USD",
     status,
     dodoSubscriptionId: data.subscription_id ?? undefined,
@@ -1805,7 +1838,7 @@ export async function handlePaymentOrRefundEvent(
       subCancelledAt: sub?.cancelledAt,
       subRawPayload: sub?.rawPayload,
       subUserId: sub?.userId,
-      refundAmount: data.total_amount ?? data.amount ?? 0,
+      refundAmount: webhookAmount(data),
     });
     if (decision.kind === "alert") {
       console.error(
@@ -1932,7 +1965,7 @@ export async function handleDisputeEvent(
     userId,
     dodoPaymentId: data.payment_id,
     type: "charge", // disputes are related to charges
-    amount: data.total_amount ?? data.amount ?? 0,
+    amount: webhookAmount(data),
     currency: data.currency ?? "USD",
     status: disputeStatus,
     dodoSubscriptionId: data.subscription_id ?? undefined,

--- a/tests/china-policy-events.test.mts
+++ b/tests/china-policy-events.test.mts
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
-import { performance } from 'node:perf_hooks';
 import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { validateDecisionSignalProvenance } from '../shared/decision-signal-provenance';
@@ -179,7 +178,13 @@ describe('China official policy adapters (#5576)', () => {
 
   // Scaling, not wall-clock: an absolute millisecond ceiling measures the
   // runner's load as much as the parser and flakes on a busy CI box while
-  // passing in isolation.
+  // passing in isolation. `process.cpuUsage()` is the clock for the same
+  // reason — `performance.now()` includes time this process was descheduled
+  // under `test:data`'s 16-way oversubscription, which compresses a genuine
+  // quadratic toward the linear band (observed 9.5x wall-clock on a loaded
+  // GitHub runner) even though the parser's own CPU still scales ~14x.
+  // CPU time still counts this process's GC; it just stops charging the
+  // parser for a sibling worker's slice.
   //
   // The size step is 4x, not 2x, on purpose. A 2x step puts linear (~2x) and
   // quadratic (~4x) close enough together that GC noise can straddle the
@@ -189,7 +194,7 @@ describe('China official policy adapters (#5576)', () => {
   // bands are ~4x versus ~16x.
   //
   // `test:data` runs this file at concurrency 16. A discarded warmup plus a
-  // 12x gate still fail quadratic (~16x) and ReDoS, but tolerate the ~10x
+  // 12x gate still fail quadratic (~14–16x) and ReDoS, but tolerate the ~10x
   // linear+GC ratios that 16-way CI has produced.
   // Inputs are built once per size, outside every timed call: allocating
   // them is linear bookkeeping, not parser work, and re-allocating on each
@@ -224,9 +229,10 @@ describe('China official policy adapters (#5576)', () => {
     const quadrupledFixtures = buildFixtures(baseRepeat * 4);
 
     const timeOnce = (fixtures: ScalingFixtures): number => {
-      const startedAt = performance.now();
+      const startedAt = process.cpuUsage();
       walk(fixtures);
-      return performance.now() - startedAt;
+      const used = process.cpuUsage(startedAt);
+      return (used.user + used.system) / 1000;
     };
 
     // Discarded warmup, one per size.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes production Convex mutation `payments/webhookMutations:processWebhookEvent` failing on Dodo dispute webhooks because `paymentEvents.amount` is `v.number()` and Dodo sends dispute `amount` as a string (`"9999"`).

Sentry: [WORLDMONITOR-114](https://elie-habib.sentry.io/issues/7697061080/)

Dodo's dispute API types `amount` as `string`. `handleDisputeEvent` inserted `data.total_amount ?? data.amount ?? 0` without coercing, so a string hit the schema validator. `DodoPaymentData` previously typed both fields as `number`, so TypeScript did not catch it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Convex payments webhooks (`paymentEvents` insert)

## What changed

- Added shared `coerceAmount()` that accepts a number or numeric string, returns `0` for missing/invalid values, and warns on non-numeric garbage.
- Used it at both `paymentEvents` write sites (`handleDisputeEvent` and `handlePaymentOrRefundEvent`) and the refund-alert amount path.
- Widened `DodoPaymentData.amount` / `total_amount` to `number | string`.
- Dispute status mapping and entitlement side-effects are unchanged.

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npx tsc --noEmit -p convex/tsconfig.json`; CI `typecheck` green)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked — N/A
- [ ] All required Audit Council role signoffs attached — N/A
- [ ] Generated docs regenerated from proto where applicable — N/A
- [ ] Fixture-backed examples recomputed — N/A
- [ ] Redis writers/readers enumerated for every documented key — N/A

## Verification

- Focused unit tests for `coerceAmount`.
- Webhook harness: `dispute.opened` with `amount: "9999"` and no `total_amount` persists `amount: 9999`.
- Sibling `payment.succeeded` path with string `total_amount` also persists a number.
- CI on `e0e49a5ef`: required `unit`, `typecheck`, `biome`, `convex-tests`, and `gate` are green. Mergeable.

Fixes WORLDMONITOR-114

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d6bab1b-7640-49b1-af9a-6684389b63fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d6bab1b-7640-49b1-af9a-6684389b63fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

