### PR TITLE
fix(sentry): drop wallet-extension JSON-RPC rejections on the marketing surface

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -38,6 +38,13 @@ interface PolicyException {
 export interface PolicyEvent {
   exception?: { values?: PolicyException[] };
   tags?: Record<string, string | number | boolean | undefined>;
+  /**
+   * Where Sentry parks the rejected value when a promise rejects with a
+   * non-Error: `eventFromUnknownInput` synthesises the exception and copies the
+   * original object to `extra.__serialized__`. It is the only surviving
+   * evidence of what actually rejected, because such an event carries no stack.
+   */
+  extra?: { __serialized__?: Record<string, unknown> };
 }
 
 const SAFE_MARKETING_PATH = /^\/(?:pro\/?)?$/;
@@ -202,6 +209,21 @@ const PARSE_FAILURE = /^(?:Unexpected token|Unexpected identifier|Invalid or une
 const THIRD_PARTY_SDK_LOAD_ACTIONS = new Set(['load-clerk', 'load-clerk-for-nav', 'open-sign-in']);
 
 /**
+ * Sentry's synthetic message for a promise that rejected with a plain object.
+ * There is no Error, so the event carries `stacktrace: null` — which is why the
+ * `!hasFirstParty` gate every other rule leans on is useless here: OUR plain
+ * object and an extension's both arrive frameless.
+ */
+const PLAIN_OBJECT_REJECTION = /^Object captured as promise rejection with keys:/;
+/**
+ * JSON-RPC 2.0's reserved error block (§5.1). An injected EIP-1193 wallet
+ * provider (MetaMask et al.) rejects with `{code: -32603, message: "Internal
+ * JSON-RPC error."}` straight into `onunhandledrejection`.
+ */
+const JSON_RPC_RESERVED_MIN = -32768;
+const JSON_RPC_RESERVED_MAX = -32000;
+
+/**
  * Stack-gated suppressors for messages that our own minified bundle COULD
  * produce, so they must not go in `MARKETING_IGNORE_ERRORS` (which matches on
  * message text alone, with no access to frames).
@@ -291,6 +313,37 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
       && PARSE_FAILURE.test(msg)
       && typeof action === 'string'
       && THIRD_PARTY_SDK_LOAD_ACTIONS.has(action)) return null;
+
+  // A browser wallet extension rejecting an EIP-1193 call into the page's
+  // `onunhandledrejection`. The dashboard has dropped this shape since #4005
+  // with a bare `/^Object captured as promise rejection with keys:/` in
+  // `ignoreErrors`; the marketing bundle runs a separate client, which is the
+  // same gap that let WORLDMONITOR-15/-102/-108/-10N/-10T through
+  // (WORLDMONITOR-107).
+  //
+  // The dashboard's wording-only entry is NOT safe to copy here. This React
+  // bundle can itself reject with a plain object, and a synthetic rejection has
+  // no stack, so `!hasFirstParty` — load-bearing for every rule above — cannot
+  // separate ours from an extension's. The JSON-RPC reserved code range is the
+  // discriminator instead, and it is structural rather than a wording
+  // heuristic: `pro-test/src` contains no JSON-RPC client at all (it speaks
+  // REST to our API and to Clerk), so a `-32768..-32000` code can only have
+  // come from an injected provider. Same shape of argument as
+  // THIRD_PARTY_SDK_LOAD_ACTIONS above — name what proves third-party origin
+  // rather than pattern-matching prose — and
+  // `tests/pro-sentry-filter-policy.test.mts` fails if a JSON-RPC client is
+  // ever added to this surface, rather than letting the rule silently widen.
+  //
+  // Deliberately narrow: EIP-1193's own `4001` (user rejected the request) is
+  // outside the reserved range and keeps reporting, as does any `{code,
+  // message}` our own code rejects with.
+  const rejected = event.extra?.__serialized__;
+  const rejectedCode = rejected?.code;
+  if (PLAIN_OBJECT_REJECTION.test(msg)
+      && typeof rejectedCode === 'number'
+      && Number.isInteger(rejectedCode)
+      && rejectedCode >= JSON_RPC_RESERVED_MIN
+      && rejectedCode <= JSON_RPC_RESERVED_MAX) return null;
 
   return event;
 }

--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -334,9 +334,20 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
   // `tests/pro-sentry-filter-policy.test.mts` fails if a JSON-RPC client is
   // ever added to this surface, rather than letting the rule silently widen.
   //
-  // Deliberately narrow: EIP-1193's own `4001` (user rejected the request) is
-  // outside the reserved range and keeps reporting, as does any `{code,
-  // message}` our own code rejects with.
+  // Deliberately narrow on the CODE: EIP-1193's own `4001` (user rejected the
+  // request) is outside the reserved range and keeps reporting, as does any
+  // non-integer, string, or absent code.
+  //
+  // The payload's own `message` is deliberately NOT consulted, so
+  // `{code: -32603, message: 'checkout failed'}` is dropped too (raised in
+  // review, PR #7241). Requiring the literal "Internal JSON-RPC error." would
+  // reintroduce the wording heuristic this rule exists to avoid: wallets emit
+  // many different strings inside the reserved block (-32002 "Request already
+  // pending", provider-specific texts), so matching on message would shrink
+  // coverage and break on the next wallet. The reserved range is
+  // protocol-defined; the message is free text. What licenses ignoring it is
+  // the JSON-RPC-free invariant above — no first-party code on this surface can
+  // mint a -32768..-32000 code at all, whatever message it pairs with.
   const rejected = event.extra?.__serialized__;
   const rejectedCode = rejected?.code;
   if (PLAIN_OBJECT_REJECTION.test(msg)

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -492,3 +492,88 @@ describe('policy wiring', () => {
     assert.deepEqual(offenders, []);
   });
 });
+
+// ─── WORLDMONITOR-107: wallet-extension JSON-RPC rejection ────────────────────
+//
+// `{code: -32603, message: "Internal JSON-RPC error."}` rejected into
+// `onunhandledrejection` on `https://www.worldmonitor.app/`. Sentry has no
+// Error to work with, so it synthesises
+// `UnhandledRejection: Object captured as promise rejection with keys: code, message`
+// with `stacktrace: null` and stores the object at `extra.__serialized__`.
+//
+// The dashboard has dropped this shape since #4005 via a bare
+// `/^Object captured as promise rejection with keys:/` in `ignoreErrors`. The
+// marketing bundle runs a separate client, which is the same gap that let
+// WORLDMONITOR-15/-102/-108/-10N/-10T through — but the dashboard's wording-only
+// entry is NOT safe to copy here: this React bundle can itself reject with a
+// plain object, and a synthetic rejection has no stack, so `!hasFirstParty`
+// cannot tell ours from an extension's.
+//
+// The JSON-RPC reserved error range is the discriminator instead, and it is
+// structural rather than a wording heuristic: `pro-test/src` holds no JSON-RPC
+// client at all (it speaks REST to our API and to Clerk), so a payload carrying
+// a −32768..−32000 `code` can only come from an injected EIP-1193 wallet
+// provider. Same design as THIRD_PARTY_SDK_LOAD_ACTIONS above — name the thing
+// that proves third-party origin, don't pattern-match the prose.
+describe('marketing beforeSend — wallet JSON-RPC rejection (WORLDMONITOR-107)', () => {
+  const rejection = (code: unknown): PolicyEvent => ({
+    exception: {
+      values: [{
+        type: 'UnhandledRejection',
+        value: 'Object captured as promise rejection with keys: code, message',
+      }],
+    },
+    extra: { __serialized__: { code, message: 'Internal JSON-RPC error.' } },
+  });
+
+  it('drops the verbatim production event', () => {
+    assert.equal(marketingBeforeSend(rejection(-32603)), null);
+  });
+
+  it('drops the rest of the JSON-RPC reserved range', () => {
+    // -32000 (server error) and -32700 (parse error) bound the reserved block;
+    // wallets use several of them (4001 user-rejected is NOT in this range and
+    // is deliberately left reporting).
+    for (const code of [-32000, -32700, -32768]) {
+      assert.equal(marketingBeforeSend(rejection(code)), null, `code ${code}`);
+    }
+  });
+
+  it('KEEPS a plain-object rejection whose code is outside the reserved range', () => {
+    // Positive control: our own bundle rejecting with `{code, message}` — an
+    // HTTP status, an app error code, EIP-1193's own 4001 — must still report.
+    for (const code of [500, 4001, -1, 0]) {
+      assert.ok(marketingBeforeSend(rejection(code)) !== null, `code ${code}`);
+    }
+  });
+
+  it('KEEPS the rejection when no serialized code is present at all', () => {
+    // Absence of evidence is not evidence of an extension.
+    assert.ok(marketingBeforeSend(rejection(undefined)) !== null);
+    assert.ok(marketingBeforeSend(rejection('-32603')) !== null, 'string code is not proof');
+    assert.ok(marketingBeforeSend({
+      exception: { values: [{ type: 'UnhandledRejection', value: 'Object captured as promise rejection with keys: code, message' }] },
+    }) !== null, 'no extra at all');
+  });
+
+  it('KEEPS an unrelated message even with a reserved-range code', () => {
+    // The rule needs BOTH halves; a real first-party error that happens to
+    // carry a JSON-RPC-shaped code must not be swallowed by the range alone.
+    assert.ok(marketingBeforeSend({
+      exception: { values: [{ type: 'TypeError', value: 'Cannot read properties of undefined (reading "plan")' }] },
+      extra: { __serialized__: { code: -32603, message: 'Internal JSON-RPC error.' } },
+    }) !== null);
+  });
+
+  it('pins the marketing bundle as JSON-RPC-free, which is what licenses the rule', () => {
+    // If a JSON-RPC client is ever added to this surface, the reserved-range
+    // discriminator stops proving third-party origin and this suppression must
+    // be re-derived. Fails loudly instead of silently widening.
+    const files = readdirSync(resolve(root, 'pro-test/src'), { recursive: true, encoding: 'utf-8' })
+      .filter((f) => /\.(ts|tsx)$/.test(f) && !f.includes('sentry-filter-policy'))
+      .map((f) => readFileSync(resolve(root, 'pro-test/src', f), 'utf-8'))
+      .join('\n');
+    assert.ok(!/jsonrpc|JSON-RPC|json_rpc/i.test(files),
+      'a JSON-RPC client on the marketing surface invalidates the WORLDMONITOR-107 rule');
+  });
+});

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -556,24 +556,106 @@ describe('marketing beforeSend — wallet JSON-RPC rejection (WORLDMONITOR-107)'
     }) !== null, 'no extra at all');
   });
 
-  it('KEEPS an unrelated message even with a reserved-range code', () => {
+  it('KEEPS an unrelated EXCEPTION VALUE even with a reserved-range code', () => {
     // The rule needs BOTH halves; a real first-party error that happens to
     // carry a JSON-RPC-shaped code must not be swallowed by the range alone.
+    // "Message" here means the synthetic exception value Sentry built — NOT the
+    // rejected payload's own `message`, which the next test pins separately.
     assert.ok(marketingBeforeSend({
       exception: { values: [{ type: 'TypeError', value: 'Cannot read properties of undefined (reading "plan")' }] },
       extra: { __serialized__: { code: -32603, message: 'Internal JSON-RPC error.' } },
     }) !== null);
   });
 
+  it('ignores the PAYLOAD message entirely — the code is the whole discriminator', () => {
+    // Asked for in review (PR #7241): `{code: -32603, message: 'checkout
+    // failed'}` IS dropped, and that is deliberate. Requiring the literal
+    // "Internal JSON-RPC error." would reintroduce exactly the wording
+    // heuristic this rule was designed to avoid — wallets emit many different
+    // strings inside the reserved block (-32002 "Request already pending", and
+    // provider-specific texts), so a message match would shrink coverage and
+    // break on the next wallet. The reserved range is protocol-defined; the
+    // message is free text.
+    //
+    // What licenses ignoring it is the JSON-RPC-free invariant below: no
+    // first-party code on this surface can mint a -32768..-32000 code at all,
+    // whatever message it pairs with. Pinned so a later "fix" toward
+    // message-matching has to argue with a red test.
+    for (const message of ['checkout failed', '', 'Internal JSON-RPC error.', 'user rejected']) {
+      assert.equal(
+        marketingBeforeSend({
+          exception: {
+            values: [{
+              type: 'UnhandledRejection',
+              value: 'Object captured as promise rejection with keys: code, message',
+            }],
+          },
+          extra: { __serialized__: { code: -32603, message } },
+        }),
+        null,
+        `payload message ${JSON.stringify(message)} must not change the verdict`,
+      );
+    }
+  });
+
+  /**
+   * Every first-party source file the marketing bundle can execute.
+   *
+   * `pro-test/src` alone is NOT the bundle's boundary: `App.tsx` and `main.tsx`
+   * import leaf modules out of the repo-root `shared/` tree, so a scan stopping
+   * at `pro-test/src` stays green on JSON-RPC introduced there (greptile
+   * review, PR #7241). The out-of-tree imports are RESOLVED from the source
+   * rather than hardcoded, so a new one is covered the day it is added instead
+   * of silently widening the suppression it licenses.
+   *
+   * Third-party package code is deliberately out of scope: `node_modules` is
+   * neither reviewable nor stable enough to assert on, and the only SDK this
+   * surface loads is Clerk, which is REST. A dependency that both spoke
+   * JSON-RPC and rejected a reserved-range `{code}` into the page's
+   * `onunhandledrejection` would defeat the rule — an accepted, named limit of
+   * the tripwire rather than an oversight.
+   */
+  function marketingFirstPartySources(): { rel: string; code: string }[] {
+    const seen = new Map<string, string>();
+    for (const f of readdirSync(resolve(root, 'pro-test/src'), { recursive: true, encoding: 'utf-8' })) {
+      if (!/\.(ts|tsx)$/.test(f)) continue;
+      const rel = `pro-test/src/${f}`;
+      seen.set(rel, readFileSync(resolve(root, rel), 'utf-8'));
+    }
+    // `from '../../shared/<mod>'` → `shared/<mod>.ts`. The shared modules in use
+    // today are import-free leaves, so one hop is the whole closure; one that
+    // grew imports of its own would need this widened, which is what the
+    // reachability test below exists to keep visible.
+    for (const code of [...seen.values()]) {
+      for (const m of code.matchAll(/from '\.\.\/\.\.\/(shared\/[\w./-]+)'/g)) {
+        const rel = `${m[1]}.ts`;
+        if (!seen.has(rel)) seen.set(rel, readFileSync(resolve(root, rel), 'utf-8'));
+      }
+    }
+    return [...seen].map(([rel, code]) => ({ rel, code }));
+  }
+
   it('pins the marketing bundle as JSON-RPC-free, which is what licenses the rule', () => {
     // If a JSON-RPC client is ever added to this surface, the reserved-range
     // discriminator stops proving third-party origin and this suppression must
     // be re-derived. Fails loudly instead of silently widening.
-    const files = readdirSync(resolve(root, 'pro-test/src'), { recursive: true, encoding: 'utf-8' })
-      .filter((f) => /\.(ts|tsx)$/.test(f) && !f.includes('sentry-filter-policy'))
-      .map((f) => readFileSync(resolve(root, 'pro-test/src', f), 'utf-8'))
-      .join('\n');
-    assert.ok(!/jsonrpc|JSON-RPC|json_rpc/i.test(files),
+    const offenders = marketingFirstPartySources()
+      .filter((f) => !f.rel.includes('sentry-filter-policy'))
+      .filter((f) => /jsonrpc|JSON-RPC|json_rpc/i.test(f.code))
+      .map((f) => f.rel);
+    assert.deepEqual(offenders, [],
       'a JSON-RPC client on the marketing surface invalidates the WORLDMONITOR-107 rule');
+  });
+
+  it('the JSON-RPC scan reaches the whole bundle, shared/ included', () => {
+    // Two ways the invariant above could pass vacuously: a walk that returns
+    // nothing, and a walk that stops at `pro-test/src` — the exact hole this
+    // pass closed. Both are pinned here, so the scan is known to have teeth.
+    const files = marketingFirstPartySources().map((f) => f.rel);
+    assert.ok(files.length > 20, `walk must reach the real tree, got ${files.length} files`);
+    assert.ok(files.includes('pro-test/src/App.tsx'), 'walk must include the app root');
+    const shared = files.filter((f) => f.startsWith('shared/'));
+    assert.ok(shared.length >= 3,
+      `walk must follow the out-of-tree imports, got ${JSON.stringify(shared)}`);
   });
 });


### PR DESCRIPTION
## Summary

A crypto-wallet browser extension was filing error-level Sentry issues against our homepage. WORLDMONITOR-107 is `{code: -32603, message: "Internal JSON-RPC error."}` — the canonical EIP-1193 provider failure — rejected straight into `onunhandledrejection` on `https://www.worldmonitor.app/`. Sentry has no `Error` to work with, so it synthesises `UnhandledRejection: Object captured as promise rejection with keys: code, message` with `stacktrace: null` and parks the object at `extra.__serialized__`.

The dashboard has dropped this shape since #4005 via a bare `/^Object captured as promise rejection with keys:/` in `ignoreErrors`. `/` renders from the marketing bundle, which runs a **separate** `@sentry/react` client — the same gap that already let WORLDMONITOR-15, -102, -108, -10N and -10T through. Both events carried `sentry.javascript.react` with a null release, the documented tell for a marketing-surface event.

**The dashboard's entry is not safe to copy here**, and that is the whole design problem. Every other rule in `marketingBeforeSend` leans on `!hasFirstParty`, but a synthetic rejection has no stack at all — so our own React bundle rejecting with a plain object and an extension doing it arrive *identically* frameless. The gate would have been decorative.

Gate on JSON-RPC 2.0's reserved error block instead. That is structural rather than a wording heuristic: `pro-test/src` contains no JSON-RPC client at all — it speaks REST to our API and to Clerk — so a `-32768..-32000` code can only have come from an injected provider. It is the same shape of argument as the existing `THIRD_PARTY_SDK_LOAD_ACTIONS` allowlist in that file: name the thing that proves third-party origin, rather than pattern-matching prose.

| Rejected payload | Verdict |
|---|---|
| `{code: -32603}` (wallet internal error) | dropped |
| `{code: -32000 … -32768}` (rest of reserved block) | dropped |
| `{code: 4001}` (EIP-1193 *user rejected*) | **kept** — outside the reserved block |
| `{code: 500}`, `{code: -1}`, `{code: 0}` | **kept** — could be ours |
| `{code: "-32603"}` (string) | **kept** — a coerced payload is not proof |
| no `extra` at all | **kept** |
| a different *exception value* + a reserved code | **kept** — the rule needs both halves |
| `{code: -32603, message: "checkout failed"}` | **dropped** — the payload's own `message` is free text and is never read |

Note the last two rows: only the **code** discriminates. Requiring the literal `"Internal JSON-RPC error."` would reintroduce exactly the wording heuristic this design avoids — wallets emit many different strings inside the reserved block (`-32002` "Request already pending", provider-specific texts), so a message match would shrink coverage and break on the next wallet.

A test pins the JSON-RPC-free invariant across every first-party file the bundle can execute — `pro-test/src` **plus the `shared/` modules `App.tsx` and `main.tsx` import**, resolved from the source rather than hardcoded, so a new out-of-tree import is covered the day it lands. A second test pins that walk's reachability so it cannot quietly regress to the narrower boundary or pass vacuously. `node_modules` is a named, deliberate exclusion: it is neither reviewable nor stable enough to assert on, and the only SDK this surface loads is Clerk, which is REST.

Fixes WORLDMONITOR-107

## Validation

`tsx --test tests/pro-sentry-filter-policy.test.mts` — **52 pass, 0 fail**. Eight new tests. The two suppression cases were confirmed red against pre-fix code; the KEEP cases are positive controls that go red if the range bound or the exception-value half is removed. The widened invariant was mutation-proven rather than assumed green: appending a `jsonrpc` marker to `shared/content-attribution.ts` turns it red (51/52), and reverting restores 52/52 — the previous `pro-test/src`-only scan would have stayed green through that. Root `tsc --noEmit` clean; `pro-test`'s own bare `tsc` reports five errors in `src/sentry.ts` that are **byte-identical on the unmodified tree** (verified in a second worktree at `origin/main`) — pre-existing, untouched here. Full pre-push gate passed, including the `build:pro` step that compiles this bundle.

No visual surface — this changes Sentry ingestion only.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)

