### PR TITLE
fix(feeds): escape CDATA terminators in FwdStart RSS (#7206)

### DIFF
--- a/api/fwdstart.js
+++ b/api/fwdstart.js
@@ -11,6 +11,20 @@ export const config = { runtime: 'edge' };
 const CACHE_KEY = 'fwdstart:archive-items:v1';
 const CACHE_TTL_SECONDS = 1800;
 
+// XML 1.0 disallows most C0 controls; keep tab/LF/CR. Also drop DEL.
+const ILLEGAL_XML_CHARS = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+
+/**
+ * Wrap scraped text in a CDATA section. Split on `]]>` so an upstream
+ * terminator cannot close the section early (#7206).
+ */
+export function cdata(s) {
+  const cleaned = String(s ?? '').replace(ILLEGAL_XML_CHARS, '');
+  // `]]>` → `]]]]><![CDATA[>` so the terminator is split across sections
+  // and the literal `]]>` survives when CDATA bodies are concatenated.
+  return `<![CDATA[${cleaned.split(']]>').join(']]]]><![CDATA[>')}]]>`;
+}
+
 /** Fetch the archive page and extract post items. Throws on upstream failure. */
 async function scrapeArchiveItems() {
   const response = await fetch('https://www.fwdstart.me/archive', {
@@ -105,11 +119,11 @@ export default async function handler(req, ctx) {
     // Build RSS XML
     const rssItems = items.slice(0, 30).map(item => `
     <item>
-      <title><![CDATA[${item.title}]]></title>
+      <title>${cdata(item.title)}</title>
       <link>${item.link}</link>
       <guid>${item.link}</guid>
       <pubDate>${new Date(item.date).toUTCString()}</pubDate>
-      <description><![CDATA[${item.description}]]></description>
+      <description>${cdata(item.description)}</description>
       <source url="https://www.fwdstart.me">FwdStart Newsletter</source>
     </item>`).join('');
 

--- a/tests/fwdstart-cdata.test.mjs
+++ b/tests/fwdstart-cdata.test.mjs
@@ -1,0 +1,99 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { XMLValidator } from 'fast-xml-parser';
+
+// #7206: scraped title/description are interpolated into CDATA without escaping
+// the terminator. A `]]>` in upstream text must not break the feed XML.
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_ENV = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+function restoreEnvironment() {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_ENV.url == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_ENV.url;
+  if (ORIGINAL_ENV.token == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_ENV.token;
+}
+
+/** Concatenate every CDATA section inside an element body. */
+function cdataText(elementXml) {
+  const parts = [];
+  const re = /<!\[CDATA\[([\s\S]*?)\]\]>/g;
+  let match;
+  while ((match = re.exec(elementXml)) !== null) parts.push(match[1]);
+  return parts.join('');
+}
+
+function titleFromRss(rss) {
+  const item = rss.match(/<item>[\s\S]*?<\/item>/);
+  assert.ok(item, 'feed must contain an <item>');
+  const title = item[0].match(/<title>([\s\S]*?)<\/title>/);
+  assert.ok(title, 'item must contain a <title>');
+  return cdataText(title[1]);
+}
+
+function descriptionFromRss(rss) {
+  const item = rss.match(/<item>[\s\S]*?<\/item>/);
+  assert.ok(item, 'feed must contain an <item>');
+  const description = item[0].match(/<description>([\s\S]*?)<\/description>/);
+  assert.ok(description, 'item must contain a <description>');
+  return cdataText(description[1]);
+}
+
+const DANGEROUS_TITLE = 'Before ]]> After title here';
+const DANGEROUS_DESCRIPTION = 'Description with ]]> terminator sequence and padding';
+
+const ARCHIVE_HTML = `
+<div class="embla__slide">
+  <a href="/p/cdata-break"></a>
+  <img alt="${DANGEROUS_TITLE}" />
+  <span>Jan 12, 2026</span>
+  <div class="line-clamp-3"><span>${DANGEROUS_DESCRIPTION}</span></div>
+</div>
+`;
+
+function installStub() {
+  globalThis.fetch = async (input, init) => {
+    const url = String(input);
+    if (url.startsWith('https://redis.example.test/get/')) {
+      return new Response(JSON.stringify({ result: null }), { status: 200 });
+    }
+    if (url === 'https://redis.example.test/pipeline') {
+      return new Response(JSON.stringify([{ result: 'OK' }, { result: 'OK' }]), { status: 200 });
+    }
+    if (url.startsWith('https://www.fwdstart.me/')) {
+      return new Response(ARCHIVE_HTML, { status: 200 });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  };
+}
+
+const request = () => new Request('https://worldmonitor.app/api/fwdstart');
+
+test('title containing ]]> still yields well-formed RSS with the literal preserved', async (t) => {
+  t.after(restoreEnvironment);
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  installStub();
+
+  const { default: handler } = await import('../api/fwdstart.js');
+  const res = await handler(request(), undefined);
+  assert.equal(res.status, 200);
+  const rss = await res.text();
+
+  const validation = XMLValidator.validate(rss);
+  assert.equal(validation, true, `feed must be well-formed XML; got ${JSON.stringify(validation)}`);
+  assert.equal(titleFromRss(rss), DANGEROUS_TITLE);
+  assert.equal(descriptionFromRss(rss), DANGEROUS_DESCRIPTION);
+});
+
+test('cdata() splits the terminator and strips illegal control characters', async () => {
+  const { cdata } = await import('../api/fwdstart.js');
+  assert.equal(cdata('a]]>b'), '<![CDATA[a]]]]><![CDATA[>b]]>');
+  assert.equal(cdata('safe'), '<![CDATA[safe]]>');
+  assert.equal(cdata('x\x00y\x08z'), '<![CDATA[xyz]]>');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#7206](https://github.com/koala73/worldmonitor/issues/7206): `api/fwdstart.js` interpolated scraped newsletter title/description into CDATA without escaping `]]>`, which closes the section early and can break the RSS feed (and treat trailing text as markup).

- Added exported `cdata()` helper that strips XML-illegal control characters and splits `]]>` across adjacent CDATA sections (`]]]]><![CDATA[>`).
- Wired both `<title>` and `<description>` through the helper.
- Added failing-first coverage in `tests/fwdstart-cdata.test.mjs` (well-formed XML + literal `]]>` preserved).

### Sibling audit

Repo sweep for `<![CDATA[${...}]>` builders found **only** `api/fwdstart.js` among API/server handlers that emit XML/RSS from scraped or constructed text. `api/rss-proxy.js` is passthrough of upstream bytes (different trust model). `api/story.js` already HTML-escapes via `esc()` on its HTML path. No additional sibling fixes required; nothing filed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [x] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other:

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked — N/A
- [ ] All required Audit Council role signoffs attached — N/A
- [ ] Generated docs regenerated from proto where applicable — N/A
- [ ] Fixture-backed examples recomputed — N/A
- [ ] Redis writers/readers enumerated for every documented key — N/A

## Verification

```text
node --test tests/fwdstart-cdata.test.mjs tests/fwdstart-cache.test.mjs
# 6 pass, 0 fail
```

First CI run: `variant-smoke-full` failed on an unrelated energy map bootstrap timeout (`e2e/bootstrap-request-budget.spec.ts` waiting for pipeline layer data). Diff only touches `api/fwdstart.js` + focused tests; retriggered with an empty commit.

## Screenshots

N/A (API/XML feed change; covered by focused tests)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efa89955-78e0-482a-94b7-17a91b263cb0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efa89955-78e0-482a-94b7-17a91b263cb0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

