### PR TITLE
fix(api): Google Translate CORS allowlist and readable origin_403 (#6411)

### DIFF
--- a/api/_cors.js
+++ b/api/_cors.js
@@ -5,18 +5,6 @@ const ALLOWED_ORIGIN_PATTERNS = [
   //   worldmonitor-<hash>-eliewm.vercel.app        (deployment URL)
   // Tight on purpose: never a bare *.vercel.app (this is a security allowlist).
   /^https:\/\/worldmonitor-[a-z0-9-]+-eliewm\.vercel\.app$/,
-  // Google Translate proxy hosts our dashboard at
-  //   https://www-worldmonitor-app.translate.goog
-  // (dots in the real hostname become hyphens). Readers there cannot mint a
-  // session today because the origin matches none of the first-party patterns,
-  // so every credentialed API call fails (#6411).
-  //
-  // Policy: admit these origins for anonymous dashboard reads. SameSite=Lax
-  // session cookies are not sent on cross-site fetches from translate.goog, so
-  // existing first-party auth cookies do not ride along; the client falls back
-  // to the freely-mintable anonymous wms_ header token. Do NOT widen this to
-  // bare *.translate.goog — only WorldMonitor's rewritten hostnames.
-  /^https:\/\/(?:[a-z0-9-]+-)*worldmonitor-app\.translate\.goog$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
   /^tauri:\/\/localhost$/,
@@ -95,8 +83,33 @@ function originForAllowlistMatch(origin) {
   }
 }
 
+/**
+ * Google Translate rewrites `https://www.worldmonitor.app` to
+ * `https://www-worldmonitor-app.translate.goog` (`.` → `-`, and literal `-` →
+ * `--`). Suffix-matching the encoded label would admit
+ * `evil--worldmonitor-app.translate.goog` (`evil-worldmonitor.app`). Decode
+ * first, then require the reconstructed host to be `worldmonitor.app` or a
+ * subdomain (#6411 review).
+ */
+function isWorldMonitorGoogleTranslateOrigin(origin) {
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== 'https:') return false;
+    const host = url.hostname.replace(/\.+$/, '');
+    const suffix = '.translate.goog';
+    if (!host.endsWith(suffix)) return false;
+    const encoded = host.slice(0, -suffix.length);
+    if (!encoded || encoded.includes('.')) return false;
+    const decoded = encoded.replace(/--/g, '\0').replace(/-/g, '.').replace(/\0/g, '-');
+    return decoded === 'worldmonitor.app' || decoded.endsWith('.worldmonitor.app');
+  } catch {
+    return false;
+  }
+}
+
 function isAllowedOrigin(origin) {
   if (!origin) return false;
+  if (isWorldMonitorGoogleTranslateOrigin(origin)) return true;
   const candidate = originForAllowlistMatch(origin);
   return ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(candidate));
 }
@@ -124,6 +137,10 @@ export function getCorsHeaders(req, methods = 'GET, OPTIONS') {
  * arrived"). Echo the request Origin with credentials so a credentials:include
  * fetch can read the status. Safe only for refusal bodies — never use this for
  * successful authenticated responses (#6411).
+ *
+ * Preflight (OPTIONS) for disallowed origins must also use these headers (or
+ * the browser never sends the POST). On api.worldmonitor.app the Cloudflare
+ * Worker mirrors this: echo on OPTIONS / denial statuses, allowlist on success.
  */
 export function getOriginDeniedCorsHeaders(req, methods = 'GET, OPTIONS') {
   const origin = req.headers.get('origin') || '';

--- a/api/_cors.js
+++ b/api/_cors.js
@@ -5,6 +5,18 @@ const ALLOWED_ORIGIN_PATTERNS = [
   //   worldmonitor-<hash>-eliewm.vercel.app        (deployment URL)
   // Tight on purpose: never a bare *.vercel.app (this is a security allowlist).
   /^https:\/\/worldmonitor-[a-z0-9-]+-eliewm\.vercel\.app$/,
+  // Google Translate proxy hosts our dashboard at
+  //   https://www-worldmonitor-app.translate.goog
+  // (dots in the real hostname become hyphens). Readers there cannot mint a
+  // session today because the origin matches none of the first-party patterns,
+  // so every credentialed API call fails (#6411).
+  //
+  // Policy: admit these origins for anonymous dashboard reads. SameSite=Lax
+  // session cookies are not sent on cross-site fetches from translate.goog, so
+  // existing first-party auth cookies do not ride along; the client falls back
+  // to the freely-mintable anonymous wms_ header token. Do NOT widen this to
+  // bare *.translate.goog — only WorldMonitor's rewritten hostnames.
+  /^https:\/\/(?:[a-z0-9-]+-)*worldmonitor-app\.translate\.goog$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
   /^tauri:\/\/localhost$/,
@@ -63,8 +75,30 @@ const EXPOSED_HEADERS = [
   'X-Military-Bbox',
 ].join(', ');
 
+/**
+ * Browsers occasionally emit the FQDN form of a hostname (trailing DNS dot),
+ * e.g. `https://tech.worldmonitor.app.`. Allowlist patterns are anchored at `$`,
+ * so that form would otherwise be refused even though it is first-party (#6411).
+ * Normalize only for matching; callers still echo the raw Origin into ACAO
+ * because browsers compare ACAO to the request Origin byte-for-byte.
+ */
+function originForAllowlistMatch(origin) {
+  if (!origin) return '';
+  try {
+    const url = new URL(origin);
+    const host = url.hostname.replace(/\.+$/, '');
+    if (!host || host === url.hostname) return origin;
+    url.hostname = host;
+    return url.origin;
+  } catch {
+    return origin;
+  }
+}
+
 function isAllowedOrigin(origin) {
-  return Boolean(origin) && ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(origin));
+  if (!origin) return false;
+  const candidate = originForAllowlistMatch(origin);
+  return ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(candidate));
 }
 
 export function getCorsHeaders(req, methods = 'GET, OPTIONS') {
@@ -72,6 +106,29 @@ export function getCorsHeaders(req, methods = 'GET, OPTIONS') {
   const allowOrigin = isAllowedOrigin(origin) ? origin : 'https://worldmonitor.app';
   return {
     'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Methods': methods,
+    'Access-Control-Allow-Headers': ALLOWED_HEADERS,
+    'Access-Control-Expose-Headers': EXPOSED_HEADERS,
+    'Access-Control-Max-Age': '3600',
+    'Vary': 'Origin',
+  };
+}
+
+/**
+ * CORS headers for an explicit origin refusal.
+ *
+ * `getCorsHeaders` falls back to `https://worldmonitor.app` for disallowed
+ * origins, which makes a 403 opaque to the calling browser (same class of blind
+ * spot as WORLDMONITOR-WG: the client cannot tell "refused" from "never
+ * arrived"). Echo the request Origin with credentials so a credentials:include
+ * fetch can read the status. Safe only for refusal bodies — never use this for
+ * successful authenticated responses (#6411).
+ */
+export function getOriginDeniedCorsHeaders(req, methods = 'GET, OPTIONS') {
+  const origin = req.headers.get('origin') || '';
+  return {
+    'Access-Control-Allow-Origin': origin || 'https://worldmonitor.app',
     'Access-Control-Allow-Credentials': 'true',
     'Access-Control-Allow-Methods': methods,
     'Access-Control-Allow-Headers': ALLOWED_HEADERS,

--- a/api/_cors.test.mjs
+++ b/api/_cors.test.mjs
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import test from 'node:test';
-import { getCorsHeaders, getPublicCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { getCorsHeaders, getPublicCorsHeaders, getOriginDeniedCorsHeaders, isDisallowedOrigin } from './_cors.js';
 
 function makeRequest(origin) {
   const headers = new Headers();
@@ -28,12 +28,65 @@ test('allows desktop Tauri origins', () => {
   }
 });
 
+test('allows Google Translate proxy origins of worldmonitor.app (#6411)', () => {
+  const origins = [
+    'https://www-worldmonitor-app.translate.goog',
+    'https://worldmonitor-app.translate.goog',
+    'https://tech-worldmonitor-app.translate.goog',
+  ];
+
+  for (const origin of origins) {
+    const req = makeRequest(origin);
+    assert.equal(isDisallowedOrigin(req), false, `translate origin should be allowed: ${origin}`);
+    const cors = getCorsHeaders(req);
+    assert.equal(cors['Access-Control-Allow-Origin'], origin);
+    assert.equal(cors['Access-Control-Allow-Credentials'], 'true');
+  }
+});
+
+test('rejects unrelated translate.goog hosts', () => {
+  const req = makeRequest('https://evil-example-com.translate.goog');
+  assert.equal(isDisallowedOrigin(req), true);
+});
+
+test('allows trailing-dot FQDN form of first-party origins (#6411)', () => {
+  const origins = [
+    'https://worldmonitor.app.',
+    'https://tech.worldmonitor.app.',
+    'https://www.worldmonitor.app.',
+  ];
+
+  for (const origin of origins) {
+    const req = makeRequest(origin);
+    assert.equal(isDisallowedOrigin(req), false, `FQDN origin should be allowed: ${origin}`);
+    // ACAO must echo the raw Origin (including the trailing dot) — browsers
+    // compare byte-for-byte against the request Origin.
+    const cors = getCorsHeaders(req);
+    assert.equal(cors['Access-Control-Allow-Origin'], origin);
+  }
+});
+
+test('rejects trailing-dot form of unrelated origins', () => {
+  const req = makeRequest('https://evil.example.com.');
+  assert.equal(isDisallowedOrigin(req), true);
+});
+
 test('rejects unrelated external origins', () => {
   const req = makeRequest('https://evil.example.com');
   assert.equal(isDisallowedOrigin(req), true);
   const cors = getCorsHeaders(req);
   assert.equal(cors['Access-Control-Allow-Origin'], 'https://worldmonitor.app');
   assert.equal(cors['Access-Control-Allow-Credentials'], 'true');
+});
+
+test('getOriginDeniedCorsHeaders echoes the refused Origin so the client can read 403 (#6411)', () => {
+  const origin = 'https://evil.example.com';
+  const req = makeRequest(origin);
+  const denied = getOriginDeniedCorsHeaders(req, 'POST, OPTIONS');
+  assert.equal(denied['Access-Control-Allow-Origin'], origin);
+  assert.equal(denied['Access-Control-Allow-Credentials'], 'true');
+  assert.equal(denied['Access-Control-Allow-Methods'], 'POST, OPTIONS');
+  assert.equal(denied['Vary'], 'Origin');
 });
 
 test('requests without origin remain allowed', () => {

--- a/api/_cors.test.mjs
+++ b/api/_cors.test.mjs
@@ -45,8 +45,16 @@ test('allows Google Translate proxy origins of worldmonitor.app (#6411)', () => 
 });
 
 test('rejects unrelated translate.goog hosts', () => {
-  const req = makeRequest('https://evil-example-com.translate.goog');
-  assert.equal(isDisallowedOrigin(req), true);
+  const rejected = [
+    'https://evil-example-com.translate.goog',
+    // Google encodes literal hyphens as `--`. evil-worldmonitor.app must NOT
+    // match a naive *-worldmonitor-app.translate.goog suffix check (#6411).
+    'https://evil--worldmonitor-app.translate.goog',
+    'https://notworldmonitor-app.translate.goog',
+  ];
+  for (const origin of rejected) {
+    assert.equal(isDisallowedOrigin(makeRequest(origin)), true, `must reject ${origin}`);
+  }
 });
 
 test('allows trailing-dot FQDN form of first-party origins (#6411)', () => {

--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -3,7 +3,7 @@
 // caller submits legacy tester keys during migration, those keys are moved into
 // short-lived HttpOnly cookies so they stop living in JS-readable storage.
 
-import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { getCorsHeaders, getOriginDeniedCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { timingSafeEqualSecret, timingSafeIncludes } from './_crypto.js';
 import { checkRateLimit } from './_rate-limit.js';
 import { issueSessionToken, validateSessionToken } from './_session.js';
@@ -167,8 +167,15 @@ export default async function handler(req, ctx) {
     return response;
   };
 
+  // Build CORS before the origin gate. A bare 403 without ACAO matching the
+  // request Origin is opaque to the browser (credentials:include fetch throws
+  // a network error), so the client cannot tell "refused" from "never arrived"
+  // — the same blind spot as WORLDMONITOR-WG (#6411). Disallowed origins get
+  // refusal-specific headers that echo their Origin; allowed origins use the
+  // normal credentialed helper below.
   if (isDisallowedOrigin(req)) {
-    const response = new Response('Forbidden', { status: 403 });
+    const deniedCors = getOriginDeniedCorsHeaders(req, 'POST, OPTIONS');
+    const response = new Response('Forbidden', { status: 403, headers: deniedCors });
     emitWmSessionUsage(ctx, req, response, startedAt, 'origin_403');
     return response;
   }

--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -167,12 +167,17 @@ export default async function handler(req, ctx) {
     return response;
   };
 
-  // Build CORS before the origin gate. A bare 403 without ACAO matching the
-  // request Origin is opaque to the browser (credentials:include fetch throws
-  // a network error), so the client cannot tell "refused" from "never arrived"
-  // — the same blind spot as WORLDMONITOR-WG (#6411). Disallowed origins get
-  // refusal-specific headers that echo their Origin; allowed origins use the
-  // normal credentialed helper below.
+  // Preflight must succeed even for origins we refuse on POST — otherwise the
+  // browser never sends the actual request and the client sees a network error
+  // instead of a readable 403 (#6411). Allowed origins get normal CORS;
+  // disallowed origins get refusal-specific headers that echo their Origin.
+  if (req.method === 'OPTIONS') {
+    const preflight = isDisallowedOrigin(req)
+      ? getOriginDeniedCorsHeaders(req, 'POST, OPTIONS')
+      : getCorsHeaders(req, 'POST, OPTIONS');
+    return new Response(null, { status: 204, headers: preflight });
+  }
+
   if (isDisallowedOrigin(req)) {
     const deniedCors = getOriginDeniedCorsHeaders(req, 'POST, OPTIONS');
     const response = new Response('Forbidden', { status: 403, headers: deniedCors });
@@ -181,10 +186,6 @@ export default async function handler(req, ctx) {
   }
 
   const cors = getCorsHeaders(req, 'POST, OPTIONS');
-
-  if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: cors });
-  }
 
   if (req.method !== 'POST') {
     return respond({ error: 'Method not allowed' }, 405, cors, 'method_not_allowed');

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -315,6 +315,36 @@ test('Disallowed origin gets 403', async () => {
   assert.equal(resp.status, 403);
 });
 
+test('Disallowed origin 403 echoes the request Origin so the client can read it (#6411)', async () => {
+  const origin = 'https://evil.example.com';
+  const resp = await handler(makeReq('POST', { origin }));
+  assert.equal(resp.status, 403);
+  assert.equal(resp.headers.get('access-control-allow-origin'), origin);
+  assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+  assert.equal(await resp.text(), 'Forbidden');
+});
+
+test('Google Translate proxy origin can mint an anonymous session (#6411)', async () => {
+  const origin = 'https://www-worldmonitor-app.translate.goog';
+  const resp = await handler(makeReq('POST', { origin }));
+  assert.equal(resp.status, 200);
+  assert.equal(resp.headers.get('access-control-allow-origin'), origin);
+  const body = await resp.json();
+  assert.equal(body.ok, true);
+  assert.match(body.token, /^wms_/);
+  assert.equal(typeof body.exp, 'number');
+});
+
+test('Trailing-dot FQDN first-party origin can mint a session (#6411)', async () => {
+  const origin = 'https://tech.worldmonitor.app.';
+  const resp = await handler(makeReq('POST', { origin }));
+  assert.equal(resp.status, 200);
+  assert.equal(resp.headers.get('access-control-allow-origin'), origin);
+  const body = await resp.json();
+  assert.equal(body.ok, true);
+  assert.match(body.token, /^wms_/);
+});
+
 test('No origin (curl) is allowed (rate limit + token TTL are the throttles)', async () => {
   const resp = await handler(makeReq('POST', {}));
   assert.equal(resp.status, 200);

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -310,6 +310,14 @@ test('GET method is rejected with 405', async () => {
   assert.equal(resp.status, 405);
 });
 
+test('Disallowed origin OPTIONS preflight succeeds with echoed Origin (#6411)', async () => {
+  const origin = 'https://evil.example.com';
+  const resp = await handler(makeReq('OPTIONS', { origin }));
+  assert.equal(resp.status, 204);
+  assert.equal(resp.headers.get('access-control-allow-origin'), origin);
+  assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+});
+
 test('Disallowed origin gets 403', async () => {
   const resp = await handler(makeReq('POST', { origin: 'https://evil.example.com' }));
   assert.equal(resp.status, 403);

--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -666,7 +666,7 @@ This generated inventory covers **752 active source hosts** representing **745 a
 | World Monitor hosted API (api.worldmonitor.app) | structured — api/a2a.ts, api/internal/mcp-grant-mint.ts, api/mcp/downstream.ts, api/mcp/skill-extension/generated.ts, +19 more |
 | World Monitor proxy (proxy.worldmonitor.app) | structured — api/widget-agent.ts, scripts/seed-security-advisories.mjs, src/utils/proxy.ts |
 | World Monitor web app (worldmonitor.app) | feed+structured — api/_agent-metadata.ts, api/a2a.ts, api/ask.ts, api/fwdstart.js, +41 more |
-| World Monitor web app (www.worldmonitor.app) | structured — api/a2a.ts, api/ask.ts, api/mcp/skill-extension/generated.ts, api/not-found.ts, +16 more |
+| World Monitor web app (www.worldmonitor.app) | structured — api/_cors.js, api/a2a.ts, api/ask.ts, api/mcp/skill-extension/generated.ts, +17 more |
 | WorldMonitor test origin (worldmonitor.invalid) | structured — src/shared/public-rpc-cache.ts |
 | worldmonitor.mintlify.dev (worldmonitor.mintlify.dev) | structured — api/docs-mcp.ts |
 | wublockchain.com (wublockchain.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |

--- a/server/cors.ts
+++ b/server/cors.ts
@@ -12,6 +12,10 @@ const PRODUCTION_PATTERNS: RegExp[] = [
   //   worldmonitor-<hash>-eliewm.vercel.app        (deployment URL)
   // Tight on purpose: never a bare *.vercel.app (this is a security allowlist).
   /^https:\/\/worldmonitor-[a-z0-9-]+-eliewm\.vercel\.app$/,
+  // Google Translate proxy of our dashboard (#6411). Keep in sync with
+  // api/_cors.js and workers/api-cors-preflight — anonymous readers only;
+  // SameSite=Lax keeps first-party auth cookies off this cross-site origin.
+  /^https:\/\/(?:[a-z0-9-]+-)*worldmonitor-app\.translate\.goog$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
   /^tauri:\/\/localhost$/,
@@ -71,8 +75,28 @@ const EXPOSED_HEADERS = [
   'X-Military-Bbox',
 ].join(', ');
 
+/**
+ * Strip trailing DNS dots before allowlist match so
+ * `https://tech.worldmonitor.app.` is treated as first-party (#6411).
+ * Matching only — ACAO still echoes the raw Origin.
+ */
+function originForAllowlistMatch(origin: string): string {
+  if (!origin) return '';
+  try {
+    const url = new URL(origin);
+    const host = url.hostname.replace(/\.+$/, '');
+    if (!host || host === url.hostname) return origin;
+    url.hostname = host;
+    return url.origin;
+  } catch {
+    return origin;
+  }
+}
+
 export function isAllowedOrigin(origin: string): boolean {
-  return Boolean(origin) && ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(origin));
+  if (!origin) return false;
+  const candidate = originForAllowlistMatch(origin);
+  return ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(candidate));
 }
 
 export function getCorsHeaders(req: Request): Record<string, string> {
@@ -80,6 +104,24 @@ export function getCorsHeaders(req: Request): Record<string, string> {
   const allowOrigin = isAllowedOrigin(origin) ? origin : 'https://worldmonitor.app';
   return {
     'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Credentials': 'true',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': ALLOWED_HEADERS,
+    'Access-Control-Expose-Headers': EXPOSED_HEADERS,
+    'Access-Control-Max-Age': '3600',
+    'Vary': 'Origin',
+  };
+}
+
+/**
+ * Echo the caller's Origin on an explicit origin_403 so credentials:include
+ * fetches can read the status instead of seeing an opaque network failure.
+ * Refusal bodies only — keep in sync with api/_cors.js (#6411).
+ */
+export function getOriginDeniedCorsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get('origin') || '';
+  return {
+    'Access-Control-Allow-Origin': origin || 'https://worldmonitor.app',
     'Access-Control-Allow-Credentials': 'true',
     'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
     'Access-Control-Allow-Headers': ALLOWED_HEADERS,

--- a/server/cors.ts
+++ b/server/cors.ts
@@ -12,10 +12,6 @@ const PRODUCTION_PATTERNS: RegExp[] = [
   //   worldmonitor-<hash>-eliewm.vercel.app        (deployment URL)
   // Tight on purpose: never a bare *.vercel.app (this is a security allowlist).
   /^https:\/\/worldmonitor-[a-z0-9-]+-eliewm\.vercel\.app$/,
-  // Google Translate proxy of our dashboard (#6411). Keep in sync with
-  // api/_cors.js and workers/api-cors-preflight — anonymous readers only;
-  // SameSite=Lax keeps first-party auth cookies off this cross-site origin.
-  /^https:\/\/(?:[a-z0-9-]+-)*worldmonitor-app\.translate\.goog$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
   /^tauri:\/\/localhost$/,
@@ -93,8 +89,31 @@ function originForAllowlistMatch(origin: string): string {
   }
 }
 
+/**
+ * Decode Google Translate's hostname rewrite and require the reconstructed
+ * host to be worldmonitor.app / *.worldmonitor.app. Suffix-matching the
+ * encoded label would admit evil--worldmonitor-app.translate.goog (#6411).
+ * Keep in sync with api/_cors.js and workers/api-cors-preflight.
+ */
+function isWorldMonitorGoogleTranslateOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== 'https:') return false;
+    const host = url.hostname.replace(/\.+$/, '');
+    const suffix = '.translate.goog';
+    if (!host.endsWith(suffix)) return false;
+    const encoded = host.slice(0, -suffix.length);
+    if (!encoded || encoded.includes('.')) return false;
+    const decoded = encoded.replace(/--/g, '\0').replace(/-/g, '.').replace(/\0/g, '-');
+    return decoded === 'worldmonitor.app' || decoded.endsWith('.worldmonitor.app');
+  } catch {
+    return false;
+  }
+}
+
 export function isAllowedOrigin(origin: string): boolean {
   if (!origin) return false;
+  if (isWorldMonitorGoogleTranslateOrigin(origin)) return true;
   const candidate = originForAllowlistMatch(origin);
   return ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(candidate));
 }

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -10,7 +10,7 @@
  */
 
 import { createRouter, type RouteDescriptor } from './router';
-import { getCorsHeaders, isDisallowedOrigin, isAllowedOrigin } from './cors';
+import { getCorsHeaders, getOriginDeniedCorsHeaders, isDisallowedOrigin, isAllowedOrigin } from './cors';
 import { isPublicSharedRpcRequest } from '../src/shared/public-rpc-cache';
 import { PRO_FRESH_CACHE_RPC_PATHS } from '../src/shared/pro-fresh-rpc';
 // @ts-expect-error — JS module, no declaration file
@@ -878,12 +878,17 @@ export function createDomainGateway(
       })());
     }
 
-    // Origin check — skip CORS headers for disallowed origins
+    // Origin check — refuse with readable CORS so the browser can surface the
+    // 403 instead of an opaque network error (#6411). Success paths still use
+    // getCorsHeaders (canonical fallback for strangers).
     if (isDisallowedOrigin(request)) {
       emitRequest(403, 'origin_403', null);
       return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
         status: 403,
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...getOriginDeniedCorsHeaders(request),
+        },
       });
     }
 

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -878,27 +878,15 @@ export function createDomainGateway(
       })());
     }
 
-    // Origin check — refuse with readable CORS so the browser can surface the
-    // 403 instead of an opaque network error (#6411). Success paths still use
-    // getCorsHeaders (canonical fallback for strangers).
-    if (isDisallowedOrigin(request)) {
-      emitRequest(403, 'origin_403', null);
-      return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
-        status: 403,
-        headers: {
-          'Content-Type': 'application/json',
-          ...getOriginDeniedCorsHeaders(request),
-        },
-      });
-    }
-
     // Fail closed on CORS-header generation errors. Previous behaviour fell
     // back to a wildcard ACAO, which converted the allowlist into wildcard
     // CORS on the error path. Now we omit CORS headers and surface a 500
     // so the browser blocks any cross-origin read. See issue #3705.
     let corsHeaders: Record<string, string>;
     try {
-      corsHeaders = getCorsHeaders(request);
+      corsHeaders = isDisallowedOrigin(request)
+        ? getOriginDeniedCorsHeaders(request)
+        : getCorsHeaders(request);
     } catch (err) {
       // Pass the Sentry delivery promise through ctx.waitUntil so the
       // Vercel Edge isolate survives long enough to actually flush the
@@ -921,10 +909,25 @@ export function createDomainGateway(
       });
     }
 
-    // OPTIONS preflight
+    // OPTIONS preflight must succeed even for origins we refuse on the actual
+    // request — otherwise the browser never sends POST/GET and origin_403 is
+    // an opaque network error (#6411).
     if (request.method === 'OPTIONS') {
       emitRequest(204, 'preflight', null);
       return new Response(null, { status: 204, headers: corsHeaders });
+    }
+
+    // Origin check — refuse with readable CORS so the browser can surface the
+    // 403 instead of an opaque network error (#6411).
+    if (isDisallowedOrigin(request)) {
+      emitRequest(403, 'origin_403', null);
+      return new Response(JSON.stringify({ error: 'Origin not allowed' }), {
+        status: 403,
+        headers: {
+          'Content-Type': 'application/json',
+          ...corsHeaders,
+        },
+      });
     }
 
     // ----------------------------------------------------------------------

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -13990,6 +13990,9 @@
       "status": "excluded",
       "references": [
         {
+          "path": "api/_cors.js"
+        },
+        {
           "path": "api/a2a.ts"
         },
         {

--- a/tests/cors-fail-closed.test.mts
+++ b/tests/cors-fail-closed.test.mts
@@ -114,6 +114,11 @@ describe('isAllowedOrigin — Vercel preview allowlist (eliewm team scope)', () 
     ['hash deployment URL', 'https://worldmonitor-abc123def456-eliewm.vercel.app'],
     ['apex production origin', 'https://worldmonitor.app'],
     ['production subdomain', 'https://tech.worldmonitor.app'],
+    ['trailing-dot FQDN apex (#6411)', 'https://worldmonitor.app.'],
+    ['trailing-dot FQDN subdomain (#6411)', 'https://tech.worldmonitor.app.'],
+    ['Google Translate www proxy (#6411)', 'https://www-worldmonitor-app.translate.goog'],
+    ['Google Translate apex proxy (#6411)', 'https://worldmonitor-app.translate.goog'],
+    ['Google Translate tech proxy (#6411)', 'https://tech-worldmonitor-app.translate.goog'],
   ];
 
   const REJECTED = [
@@ -122,6 +127,8 @@ describe('isAllowedOrigin — Vercel preview allowlist (eliewm team scope)', () 
     ['bare worldmonitor vercel.app (no scope segment)', 'https://worldmonitor.vercel.app'],
     ['suffix-spoofed eliewm origin', 'https://worldmonitor-git-feature-eliewm.vercel.app.evil.com'],
     ['dead personal-scope preview (post-migration)', 'https://worldmonitor-feature-elie-abc123.vercel.app'],
+    ['unrelated translate.goog host', 'https://evil-example-com.translate.goog'],
+    ['trailing-dot unrelated origin', 'https://evil.example.com.'],
   ];
 
   for (const [label, origin] of ALLOWED) {
@@ -188,7 +195,36 @@ describe('IETF RateLimit headers are readable across every CORS surface', () => 
   }
 });
 
-describe('CORS triplet parity — eliewm preview pattern stays tight in all three twins', () => {
+describe('CORS triplet parity — Google Translate + trailing-dot helpers stay in sync (#6411)', () => {
+  const TWINS = [
+    '../server/cors.ts',
+    '../api/_cors.js',
+    '../workers/api-cors-preflight/src/index.js',
+  ];
+
+  for (const rel of TWINS) {
+    it(`${rel} admits WorldMonitor Google Translate proxy hosts`, async () => {
+      const source = await readFile(new URL(rel, import.meta.url), 'utf8');
+      assert.ok(
+        source.includes('(?:[a-z0-9-]+-)*worldmonitor-app\\.translate\\.goog'),
+        `${rel} must allow *-worldmonitor-app.translate.goog readers with the scoped pattern`,
+      );
+    });
+
+    it(`${rel} normalizes trailing-dot FQDN origins before matching`, async () => {
+      const source = await readFile(new URL(rel, import.meta.url), 'utf8');
+      assert.ok(
+        source.includes('originForAllowlistMatch'),
+        `${rel} must share the trailing-dot normalizer name`,
+      );
+      assert.ok(
+        source.includes('hostname.replace(/\\.+$/, \'\')'),
+        `${rel} must strip trailing DNS dots on the hostname`,
+      );
+    });
+  }
+});
+
   // Root cause of the original 403s was twins drifting. THREE surfaces gate
   // Vercel-preview CORS and must move together; guard each for:
   // (1) the eliewm-scoped preview pattern is present, and
@@ -239,6 +275,11 @@ describe('CORS Worker superset invariant — edge allowlist ⊇ function allowli
     'https://worldmonitor.app',
     'https://www.worldmonitor.app',
     'https://tech.worldmonitor.app',
+    'https://worldmonitor.app.',
+    'https://tech.worldmonitor.app.',
+    'https://www-worldmonitor-app.translate.goog',
+    'https://worldmonitor-app.translate.goog',
+    'https://tech-worldmonitor-app.translate.goog',
     'https://worldmonitor-git-feature-eliewm.vercel.app',
     'https://worldmonitor-abc123def456-eliewm.vercel.app',
     'tauri://localhost',
@@ -249,6 +290,7 @@ describe('CORS Worker superset invariant — edge allowlist ⊇ function allowli
     'https://worldmonitor-git-feature-attacker.vercel.app',
     'https://worldmonitor-feature-elie-abc123.vercel.app',
     'https://evil.com',
+    'https://evil-example-com.translate.goog',
   ];
 
   for (const origin of PROD_ORIGINS) {

--- a/tests/cors-fail-closed.test.mts
+++ b/tests/cors-fail-closed.test.mts
@@ -225,6 +225,7 @@ describe('CORS triplet parity — Google Translate + trailing-dot helpers stay i
   }
 });
 
+describe('CORS triplet parity — eliewm preview pattern stays tight in all three twins', () => {
   // Root cause of the original 403s was twins drifting. THREE surfaces gate
   // Vercel-preview CORS and must move together; guard each for:
   // (1) the eliewm-scoped preview pattern is present, and

--- a/tests/cors-fail-closed.test.mts
+++ b/tests/cors-fail-closed.test.mts
@@ -128,6 +128,7 @@ describe('isAllowedOrigin — Vercel preview allowlist (eliewm team scope)', () 
     ['suffix-spoofed eliewm origin', 'https://worldmonitor-git-feature-eliewm.vercel.app.evil.com'],
     ['dead personal-scope preview (post-migration)', 'https://worldmonitor-feature-elie-abc123.vercel.app'],
     ['unrelated translate.goog host', 'https://evil-example-com.translate.goog'],
+    ['hyphen-encoded lookalike translate host', 'https://evil--worldmonitor-app.translate.goog'],
     ['trailing-dot unrelated origin', 'https://evil.example.com.'],
   ];
 
@@ -203,11 +204,19 @@ describe('CORS triplet parity — Google Translate + trailing-dot helpers stay i
   ];
 
   for (const rel of TWINS) {
-    it(`${rel} admits WorldMonitor Google Translate proxy hosts`, async () => {
+    it(`${rel} decodes Google Translate hosts before allowlisting`, async () => {
       const source = await readFile(new URL(rel, import.meta.url), 'utf8');
       assert.ok(
-        source.includes('(?:[a-z0-9-]+-)*worldmonitor-app\\.translate\\.goog'),
-        `${rel} must allow *-worldmonitor-app.translate.goog readers with the scoped pattern`,
+        source.includes('isWorldMonitorGoogleTranslateOrigin'),
+        `${rel} must share the Translate decode helper`,
+      );
+      assert.ok(
+        source.includes('replace(/--/g,'),
+        `${rel} must decode Google's -- hyphen escape before matching`,
+      );
+      assert.ok(
+        !source.includes('(?:[a-z0-9-]+-)*worldmonitor-app\\.translate\\.goog'),
+        `${rel} must not use the suffix-only Translate pattern (hyphen bypass)`,
       );
     });
 
@@ -292,6 +301,7 @@ describe('CORS Worker superset invariant — edge allowlist ⊇ function allowli
     'https://worldmonitor-feature-elie-abc123.vercel.app',
     'https://evil.com',
     'https://evil-example-com.translate.goog',
+    'https://evil--worldmonitor-app.translate.goog',
   ];
 
   for (const origin of PROD_ORIGINS) {

--- a/workers/api-cors-preflight/index.test.mjs
+++ b/workers/api-cors-preflight/index.test.mjs
@@ -58,6 +58,9 @@ test('isAllowedOrigin accepts Google Translate proxy origins of worldmonitor.app
   assert.equal(isAllowedOrigin('https://worldmonitor-app.translate.goog'), true);
   assert.equal(isAllowedOrigin('https://tech-worldmonitor-app.translate.goog'), true);
   assert.equal(isAllowedOrigin('https://evil-example-com.translate.goog'), false);
+  // `--` is Google's encoding of a literal hyphen — must not suffix-match.
+  assert.equal(isAllowedOrigin('https://evil--worldmonitor-app.translate.goog'), false);
+  assert.equal(isAllowedOrigin('https://notworldmonitor-app.translate.goog'), false);
 });
 
 test('isAllowedOrigin accepts Vercel preview deploys under the eliewm team scope (mirrors api/_cors.js)', () => {
@@ -169,15 +172,17 @@ test('OPTIONS preflight to /api/product-catalog preserves the endpoint-owned DEL
   }
 });
 
-test('OPTIONS preflight from disallowed origin still sets ACAC but echoes fallback origin', async () => {
+test('OPTIONS preflight from disallowed origin echoes the request Origin (#6411)', async () => {
+  const evil = 'https://evil.com';
   const req = makeRequest('OPTIONS', 'https://api.worldmonitor.app/api/bootstrap', {
-    Origin: 'https://evil.com',
+    Origin: evil,
   });
   const resp = await worker.fetch(req);
   assert.equal(resp.status, 204);
-  assert.equal(resp.headers.get('access-control-allow-origin'), CANONICAL_FALLBACK);
-  // Browser sees fallback origin != evil.com → rejects. ACAC: true is still
-  // set because it must be a paired invariant with origin-specific ACAO.
+  // Preflight must echo the caller so the browser will send the actual request;
+  // the POST/GET response still uses the allowlist (canonical fallback) except
+  // on explicit 401/403 refusals.
+  assert.equal(resp.headers.get('access-control-allow-origin'), evil);
   assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
 });
 

--- a/workers/api-cors-preflight/index.test.mjs
+++ b/workers/api-cors-preflight/index.test.mjs
@@ -47,6 +47,19 @@ test('isAllowedOrigin accepts apex worldmonitor.app and subdomains', () => {
   assert.equal(isAllowedOrigin('https://commodity.worldmonitor.app'), true);
 });
 
+test('isAllowedOrigin accepts trailing-dot FQDN first-party origins (#6411)', () => {
+  assert.equal(isAllowedOrigin('https://worldmonitor.app.'), true);
+  assert.equal(isAllowedOrigin('https://tech.worldmonitor.app.'), true);
+  assert.equal(isAllowedOrigin('https://www.worldmonitor.app.'), true);
+});
+
+test('isAllowedOrigin accepts Google Translate proxy origins of worldmonitor.app (#6411)', () => {
+  assert.equal(isAllowedOrigin('https://www-worldmonitor-app.translate.goog'), true);
+  assert.equal(isAllowedOrigin('https://worldmonitor-app.translate.goog'), true);
+  assert.equal(isAllowedOrigin('https://tech-worldmonitor-app.translate.goog'), true);
+  assert.equal(isAllowedOrigin('https://evil-example-com.translate.goog'), false);
+});
+
 test('isAllowedOrigin accepts Vercel preview deploys under the eliewm team scope (mirrors api/_cors.js)', () => {
   // The project deploys previews under the "eliewm" Vercel team scope, so URLs
   // end in `-eliewm.vercel.app` (git-branch alias AND hash deployment forms).

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -31,6 +31,10 @@ const ALLOWED_ORIGIN_PATTERNS = [
   //   worldmonitor-git-<branch>-eliewm.vercel.app / worldmonitor-<hash>-eliewm.vercel.app
   // Mirror of api/_cors.js + server/cors.ts (see superset note above).
   /^https:\/\/worldmonitor-[a-z0-9-]+-eliewm\.vercel\.app$/,
+  // Google Translate proxy of our dashboard (#6411). Mirror api/_cors.js —
+  // Worker allowlist must stay a superset or preflights echo the canonical
+  // fallback and translated readers stay dark.
+  /^https:\/\/(?:[a-z0-9-]+-)*worldmonitor-app\.translate\.goog$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
   /^tauri:\/\/localhost$/,
@@ -101,8 +105,27 @@ function hasPublicCorsPolicy(pathname) {
   return PUBLIC_CORS_PREFIXES.some((p) => pathname.startsWith(p));
 }
 
+/**
+ * Strip trailing DNS dots before allowlist match (#6411). Keep in sync with
+ * api/_cors.js / server/cors.ts. ACAO still echoes the raw Origin.
+ */
+function originForAllowlistMatch(origin) {
+  if (!origin) return '';
+  try {
+    const url = new URL(origin);
+    const host = url.hostname.replace(/\.+$/, '');
+    if (!host || host === url.hostname) return origin;
+    url.hostname = host;
+    return url.origin;
+  } catch {
+    return origin;
+  }
+}
+
 export function isAllowedOrigin(origin) {
-  return Boolean(origin) && ALLOWED_ORIGIN_PATTERNS.some((p) => p.test(origin));
+  if (!origin) return false;
+  const candidate = originForAllowlistMatch(origin);
+  return ALLOWED_ORIGIN_PATTERNS.some((p) => p.test(candidate));
 }
 
 export { hasPublicCorsPolicy };

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -31,10 +31,6 @@ const ALLOWED_ORIGIN_PATTERNS = [
   //   worldmonitor-git-<branch>-eliewm.vercel.app / worldmonitor-<hash>-eliewm.vercel.app
   // Mirror of api/_cors.js + server/cors.ts (see superset note above).
   /^https:\/\/worldmonitor-[a-z0-9-]+-eliewm\.vercel\.app$/,
-  // Google Translate proxy of our dashboard (#6411). Mirror api/_cors.js —
-  // Worker allowlist must stay a superset or preflights echo the canonical
-  // fallback and translated readers stay dark.
-  /^https:\/\/(?:[a-z0-9-]+-)*worldmonitor-app\.translate\.goog$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
   /^tauri:\/\/localhost$/,
@@ -122,16 +118,36 @@ function originForAllowlistMatch(origin) {
   }
 }
 
+/**
+ * Decode Google Translate hostname rewrite; require reconstructed host to be
+ * worldmonitor.app / *.worldmonitor.app. Keep in sync with api/_cors.js (#6411).
+ */
+function isWorldMonitorGoogleTranslateOrigin(origin) {
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== 'https:') return false;
+    const host = url.hostname.replace(/\.+$/, '');
+    const suffix = '.translate.goog';
+    if (!host.endsWith(suffix)) return false;
+    const encoded = host.slice(0, -suffix.length);
+    if (!encoded || encoded.includes('.')) return false;
+    const decoded = encoded.replace(/--/g, '\0').replace(/-/g, '.').replace(/\0/g, '-');
+    return decoded === 'worldmonitor.app' || decoded.endsWith('.worldmonitor.app');
+  } catch {
+    return false;
+  }
+}
+
 export function isAllowedOrigin(origin) {
   if (!origin) return false;
+  if (isWorldMonitorGoogleTranslateOrigin(origin)) return true;
   const candidate = originForAllowlistMatch(origin);
   return ALLOWED_ORIGIN_PATTERNS.some((p) => p.test(candidate));
 }
 
 export { hasPublicCorsPolicy };
 
-export function buildCorsHeaders(origin) {
-  const allowOrigin = isAllowedOrigin(origin) ? origin : 'https://worldmonitor.app';
+function corsHeaderBag(allowOrigin) {
   return {
     'Access-Control-Allow-Origin': allowOrigin,
     // Required because the app fetch interceptor sends credentials: 'include'
@@ -145,6 +161,32 @@ export function buildCorsHeaders(origin) {
     'Access-Control-Max-Age': '3600',
     'Vary': 'Origin',
   };
+}
+
+export function buildCorsHeaders(origin) {
+  const allowOrigin = isAllowedOrigin(origin) ? origin : 'https://worldmonitor.app';
+  return corsHeaderBag(allowOrigin);
+}
+
+/**
+ * OPTIONS preflight for disallowed origins must echo the request Origin so the
+ * browser will send the actual request. Otherwise origin_403 stays an opaque
+ * network error (#6411). Success responses still use the allowlist via
+ * buildCorsHeaders / buildResponseCorsHeaders.
+ */
+export function buildPreflightCorsHeaders(origin) {
+  return corsHeaderBag(origin || 'https://worldmonitor.app');
+}
+
+/**
+ * Stamp CORS onto an origin response. Allowed origins are echoed; disallowed
+ * origins get a readable ACAO only on explicit auth/origin refusals so the
+ * client can observe 401/403, while successful bodies stay opaque.
+ */
+export function buildResponseCorsHeaders(origin, status) {
+  if (isAllowedOrigin(origin)) return buildCorsHeaders(origin);
+  if (status === 401 || status === 403) return buildPreflightCorsHeaders(origin);
+  return buildCorsHeaders(origin);
 }
 
 function mergeHeaderNames(...values) {
@@ -181,11 +223,14 @@ const STORY_FETCH_OPTIONS = {
 // The single origin path: fetch Vercel, stamp the Worker's canonical CORS onto the response, and
 // preserve the bootstrap route's function-owned exposed headers. Shared by the normal pass-through
 // AND the U-K4 hedge, so there is exactly one origin+CORS implementation to keep correct.
-async function passThroughToOrigin(request, url, corsHeaders) {
+async function passThroughToOrigin(request, url, corsHeadersForStatus) {
   try {
     const response = url.pathname === '/api/story'
       ? await fetch(request, STORY_FETCH_OPTIONS)
       : await fetch(request);
+    const corsHeaders = typeof corsHeadersForStatus === 'function'
+      ? corsHeadersForStatus(response.status)
+      : corsHeadersForStatus;
     const newHeaders = new Headers(response.headers);
     const originExposedHeaders = newHeaders.get('Access-Control-Expose-Headers');
     const originVary = newHeaders.get('Vary');
@@ -209,6 +254,9 @@ async function passThroughToOrigin(request, url, corsHeaders) {
       headers: newHeaders,
     });
   } catch (err) {
+    const corsHeaders = typeof corsHeadersForStatus === 'function'
+      ? corsHeadersForStatus(502)
+      : corsHeadersForStatus;
     return new Response(JSON.stringify({ error: 'Origin unavailable' }), {
       status: 502,
       headers: { 'Content-Type': 'application/json', ...corsHeaders },
@@ -239,26 +287,26 @@ export default {
     }
 
     const origin = request.headers.get('Origin') || '';
-    const corsHeaders = buildCorsHeaders(origin);
-
-    // OPTIONS preflight — return immediately, skip Vercel.
-    // The browser's CORS gate is the preflight response, not the actual
-    // request response, so this is the load-bearing branch.
+    // OPTIONS must echo the request Origin even when disallowed so the browser
+    // will send the actual request; otherwise origin_403 is an opaque network
+    // error (#6411). Non-OPTIONS responses still use the allowlist, with a
+    // readable echo only on 401/403 refusals.
     if (request.method === 'OPTIONS') {
-      return new Response(null, { status: 204, headers: corsHeaders });
+      return new Response(null, { status: 204, headers: buildPreflightCorsHeaders(origin) });
     }
 
+    const corsForStatus = (status) => buildResponseCorsHeaders(origin, status);
     // The single origin path for this request. maybeServeBootstrapFromKv (U-K4) may invoke it once
     // internally when it hedges/falls back; every other request runs it directly below. Either way
     // origin is fetched at most once.
-    const fetchOrigin = () => passThroughToOrigin(request, url, corsHeaders);
+    const fetchOrigin = () => passThroughToOrigin(request, url, corsForStatus);
 
     // KV serving (U-K4, #5338): for a public-tier bootstrap GET with BOOTSTRAP_KV_SERVE on, serve
     // the tier straight from KV (never touching Vercel/Redis). A slow KV read is hedged against
     // origin and any non-servable outcome uses the origin response — strictly additive (KTD3), so
     // the worst case is today's behaviour. Returns null for non-servable requests (flag off, not a
     // bootstrap GET), which then run the normal pass-through. Inert until the flag is flipped.
-    const bootstrapKv = await maybeServeBootstrapFromKv(request, url, env, ctx, corsHeaders, fetchOrigin);
+    const bootstrapKv = await maybeServeBootstrapFromKv(request, url, env, ctx, buildCorsHeaders(origin), fetchOrigin);
     if (bootstrapKv) return bootstrapKv;
 
     // All other methods/paths — pass through to Vercel with the Worker's canonical CORS stamped.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#6411](https://github.com/koala73/worldmonitor/issues/6411): readers opening the dashboard through Google Translate (and a rare trailing-dot FQDN first-party form) could not mint an anonymous `wm-session`, and disallowed-origin `403`s were opaque to the browser.

### Policy

- **Admit** Google Translate proxy origins only after decoding the hostname rewrite (`.` → `-`, literal `-` → `--`) and confirming the reconstructed host is `worldmonitor.app` or `*.worldmonitor.app`.
- Reject lookalikes such as `evil--worldmonitor-app.translate.goog` (`evil-worldmonitor.app`).
- SameSite=Lax keeps existing first-party auth cookies off that cross-site origin; the client uses the freely-mintable anonymous `wms_` header token.
- Normalize trailing DNS dots before allowlist match so `https://tech.worldmonitor.app.` is treated as first-party; ACAO still echoes the raw Origin.

### Readable `origin_403`

- OPTIONS preflight for disallowed origins echoes the request Origin (wm-session, gateway, Cloudflare Worker) so the browser sends the actual request.
- POST/GET refusals use `getOriginDeniedCorsHeaders` / Worker `buildResponseCorsHeaders` (401/403 only) so credentials:include clients can read the status.
- Successful responses for strangers still get the canonical ACAO fallback.

### Changes

- Sync allowlist + Translate decode + trailing-dot normalizer across `api/_cors.js`, `server/cors.ts`, and `workers/api-cors-preflight`.
- Refresh source-attribution inventory for new `api/_cors.js` first-party host refs (CI postinstall gate).
- Tests for Translate hosts (including hyphen bypass), trailing-dot FQDN, readable 403, preflight, and triplet parity.

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck:api`)
- [x] Focused CORS / wm-session / Worker / fail-closed tests pass locally

## Test plan

- [x] `node --test api/_cors.test.mjs api/wm-session.test.mjs workers/api-cors-preflight/index.test.mjs` (66 pass)
- [x] `node --import tsx --test tests/cors-fail-closed.test.mts` (61 pass)
- [x] `npm run typecheck:api`
- [x] `node scripts/generate-inventory-facts.mjs` / source-attribution refresh
- [ ] Confirm CI green

## Documentation Alignment Checklist

- [x] N/A — no documentation claim changes (attribution inventory regen only)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37bf86ed-e8df-495d-bbf2-f7ff4b6266b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37bf86ed-e8df-495d-bbf2-f7ff4b6266b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

