### PR TITLE
fix(ops): report PUBLISH_BLOCKED when a coverage gate refuses to publish

### DIFF
--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -38,6 +38,7 @@ import {
   BUNDLE_COMPLETION_META_KEY_ENV,
   GRACEFUL_FETCH_FAILURE_EXIT_CODE,
   loadEnvFile,
+  PUBLISH_BLOCKED_EXIT_CODE,
 } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
@@ -362,6 +363,17 @@ function spawnSeed(scriptPath, { timeoutMs, label, bundleStartedAtMs, completion
           status: 'GRACEFUL_FAIL',
           reason: `graceful fetch failure (exit ${GRACEFUL_FETCH_FAILURE_EXIT_CODE})`,
         });
+      } else if (code === PUBLISH_BLOCKED_EXIT_CODE) {
+        // #6396: exit 0 must mean "the keys were written". A member whose
+        // coverage gate refused to publish — after preserving the last-good
+        // TTL — signals it with this dedicated code so the summary can never
+        // report OK for a section that wrote no seed-meta.
+        settle({
+          elapsed,
+          ok: false,
+          status: 'PUBLISH_BLOCKED',
+          reason: `coverage gate refused to publish (exit ${PUBLISH_BLOCKED_EXIT_CODE})`,
+        });
       } else {
         settle({ elapsed, ok: false, reason: `exit ${code ?? 'null'}${signal ? ` (signal ${signal})` : ''}` });
       }
@@ -565,7 +577,7 @@ export async function runBundle(label, sections, opts = {}) {
     ))))
     : null;
 
-  let ran = 0, skipped = 0, deferred = 0, failed = 0, gracefulFailed = 0, stalled = 0;
+  let ran = 0, skipped = 0, deferred = 0, failed = 0, gracefulFailed = 0, stalled = 0, publishBlocked = 0;
 
   let disabled = 0;
   for (const section of sections) {
@@ -672,6 +684,7 @@ export async function runBundle(label, sections, opts = {}) {
       // "Deploy Crashed!") over a benign per-member skip. Track it separately so
       // only HARD failures gate the exit code; the skip stays fully logged above.
       if (status === 'GRACEFUL_FAIL') gracefulFailed++;
+      else if (status === 'PUBLISH_BLOCKED') publishBlocked++;
       else failed++;
     }
   }
@@ -683,7 +696,11 @@ export async function runBundle(label, sections, opts = {}) {
   // rides along at the tail for the same reason: it is the starvation signal
   // #6562 item 4 exists to surface.
   const disabledField = disabled > 0 ? ` disabled:${disabled}` : '';
-  console.log(`[Bundle:${label}] Finished in ${totalSec}s, ran:${ran} skipped:${skipped} deferred:${deferred}${disabledField} failed:${failed} graceful:${gracefulFailed} stalled:${stalled}`);
+  // publish_blocked appends ONLY when non-zero, like `disabled:` above, so
+  // the documented summary line stays byte-identical for bundles without gate
+  // refusals (#6396).
+  const publishBlockedField = publishBlocked > 0 ? ` publish_blocked:${publishBlocked}` : '';
+  console.log(`[Bundle:${label}] Finished in ${totalSec}s, ran:${ran} skipped:${skipped} deferred:${deferred}${disabledField} failed:${failed} graceful:${gracefulFailed} stalled:${stalled}${publishBlockedField}`);
   // A tick that completed no section while deferring a due one accomplished
   // nothing AND shed work. Deferral only pays for itself if the deferred
   // section runs on a later tick, so this state repeating is a stalled
@@ -727,6 +744,13 @@ export async function runBundle(label, sections, opts = {}) {
     // does not paint CRASHED and fire a spurious alert. Real staleness is caught
     // independently by the /api/health freshness monitor keyed on seed-meta TTL.
     console.log(`[Bundle:${label}] ${gracefulFailed} graceful fetch skip(s), no hard failures — no data lost, exiting 0 (not a crash)`);
+  }
+  if (failed === 0 && publishBlocked > 0) {
+    // #6396: a gate refusal is not a crash — the member verified preservation
+    // of the last-good snapshot before exiting, and the freshness monitor
+    // alarms if the refusal persists. What changed versus the old exit-0
+    // silence is that the per-section line and summary now say so.
+    console.log(`[Bundle:${label}] ${publishBlocked} publish-blocked section(s) preserved last-good and wrote no seed keys — exiting 0; the freshness monitor owns the alarm`);
   }
   process.exit(failed > 0 || starvedTick || stalled > 0 ? 1 : 0);
 }

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -724,6 +724,7 @@ export async function runBundle(label, sections, opts = {}) {
   // with a graceful skip, where real work published and one source blipped. A
   // tick that published NOTHING has no successful work to vouch for it.
   const starvedTick = ran === 0 && deferred > 0;
+  const exitsNonZero = failed > 0 || starvedTick || stalled > 0;
   if (starvedTick) {
     console.error(
       `[Bundle:${label}] ran:0 while ${deferred} due section(s) were deferred — this tick published nothing and shed work. `
@@ -745,12 +746,12 @@ export async function runBundle(label, sections, opts = {}) {
     // independently by the /api/health freshness monitor keyed on seed-meta TTL.
     console.log(`[Bundle:${label}] ${gracefulFailed} graceful fetch skip(s), no hard failures — no data lost, exiting 0 (not a crash)`);
   }
-  if (failed === 0 && publishBlocked > 0) {
+  if (!exitsNonZero && publishBlocked > 0) {
     // #6396: a gate refusal is not a crash — the member verified preservation
     // of the last-good snapshot before exiting, and the freshness monitor
     // alarms if the refusal persists. What changed versus the old exit-0
     // silence is that the per-section line and summary now say so.
     console.log(`[Bundle:${label}] ${publishBlocked} publish-blocked section(s) preserved last-good and wrote no seed keys — exiting 0; the freshness monitor owns the alarm`);
   }
-  process.exit(failed > 0 || starvedTick || stalled > 0 ? 1 : 0);
+  process.exit(exitsNonZero ? 1 : 0);
 }

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -778,6 +778,12 @@ export const PERMANENT_4XX_STATUSES = new Set([400, 401, 403, 404, 410, 413, 422
 // generic crash.
 export const GRACEFUL_FETCH_FAILURE_EXIT_CODE = 75;
 
+// #6396: the seeder fetched its data but its coverage gate refused to publish
+// (and preserved the last-good TTL instead). Distinct from EX_TEMPFAIL so the
+// bundle runner can report PUBLISH_BLOCKED rather than OK for a section whose
+// entire purpose — writing the seed keys — did not happen.
+export const PUBLISH_BLOCKED_EXIT_CODE = 76;
+
 // Cap upstream Retry-After hints so a stuck/abusive header can't park the
 // bundle past its section timeoutMs. Mirrors _yahoo-fetch.mjs convention.
 const MAX_RETRY_AFTER_MS = 60_000;

--- a/scripts/seed-jodi-oil.mjs
+++ b/scripts/seed-jodi-oil.mjs
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 
 import {
   loadEnvFile,
+  PUBLISH_BLOCKED_EXIT_CODE,
   CHROME_UA,
   getRedisCredentials,
   acquireLockSafely,
@@ -587,7 +588,11 @@ async function main() {
       } else {
         console.warn('  COVERAGE GATE: no last-good snapshot exists to preserve');
       }
-      return;
+      // #6396: the gate refused to publish, so exit 0 would make the bundle
+      // report OK for a section whose seed keys were not written. Signal the
+      // dedicated outcome; main()'s finally still releases the lock on this
+      // return path.
+      return { publishBlocked: true };
     }
 
     console.log(chinaCoverage.ok
@@ -643,7 +648,9 @@ async function main() {
 
 const isMain = process.argv[1]?.endsWith('seed-jodi-oil.mjs');
 if (isMain) {
-  main().catch(err => {
+  main().then((outcome) => {
+    if (outcome?.publishBlocked) process.exit(PUBLISH_BLOCKED_EXIT_CODE);
+  }).catch(err => {
     console.error(err);
     process.exit(1);
   });

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -176,6 +176,38 @@ function runBundleWith(sections, opts = {}, env = {}) {
   });
 }
 
+function runBundleWithVirtualClock(sections, opts = {}, clockOffsetsMs = [], env = {}) {
+  const runPath = join(FIXTURES_DIR, `_bundle-runner-test-run-${randomUUID()}.mjs`);
+  const fixtureSections = sections.map((section) => ({
+    ...section,
+    script: fixtureScript(section.script),
+  }));
+  writeFileSync(
+    runPath,
+    `import { runBundle } from '../_bundle-runner.mjs';\n`
+    + `const realNow = Date.now;\n`
+    + `const baseNow = realNow();\n`
+    + `const offsets = ${JSON.stringify(clockOffsetsMs)};\n`
+    + `let idx = 0;\n`
+    + `Date.now = () => baseNow + (offsets[Math.min(idx++, offsets.length - 1)] ?? 0);\n`
+    + `await runBundle('test', ${JSON.stringify(fixtureSections)}, ${JSON.stringify(opts)});\n`,
+  );
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [runPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ...env },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => { stdout += c; });
+    child.stderr.on('data', (c) => { stderr += c; });
+    child.on('close', (code) => {
+      try { unlinkSync(runPath); } catch {}
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
 function writeFixture(name, body) {
   const path = join(FIXTURES_DIR, name);
   writeFileSync(path, body);
@@ -1056,6 +1088,36 @@ test('a coverage-gate refusal reports PUBLISH_BLOCKED, never OK (#6396)', async 
     assert.doesNotMatch(stdout, /graceful:1/);
   } finally {
     cleanup();
+  }
+});
+
+test('a publish-blocked section does not claim exit 0 when the tick starves due work', async () => {
+  const cleanupBlocked = writeFixture(
+    '_bundle-fixture-publish-blocked-starves.mjs',
+    `console.error('COVERAGE GATE FAILED: china-missing (dataMonth=missing)');\nprocess.exit(${PUBLISH_BLOCKED_EXIT_CODE});\n`,
+  );
+  const cleanupLate = writeFixture('_bundle-fixture-publish-blocked-late.mjs', `console.log('late-ran');\n`);
+  try {
+    const { code, stdout, stderr } = await runBundleWithVirtualClock(
+      [
+        { label: 'GATED', script: '_bundle-fixture-publish-blocked-starves.mjs', intervalMs: 1, timeoutMs: 5_000 },
+        { label: 'LATE', script: '_bundle-fixture-publish-blocked-late.mjs', intervalMs: 1, timeoutMs: 5_000 },
+      ],
+      { maxBundleMs: 30_000 },
+      [0, 0, 0, 100, 16_000, 16_000],
+    );
+    assert.equal(code, 1, 'publish-blocked work must not mask deferred due work');
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:1 failed:0 graceful:0 stalled:0 publish_blocked:1/);
+    assert.match(
+      stderr,
+      /\[Bundle:test\] ran:0 while 1 due section\(s\) were deferred/,
+      `expected the starvation explanation; stderr:\n${stderr}`,
+    );
+    assert.doesNotMatch(stdout, /publish-blocked section\(s\).*exiting 0/);
+    assert.doesNotMatch(stdout, /late-ran/);
+  } finally {
+    cleanupBlocked();
+    cleanupLate();
   }
 });
 

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -12,7 +12,7 @@ import { mkdirSync, writeFileSync, unlinkSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { GRACEFUL_FETCH_FAILURE_EXIT_CODE } from '../scripts/_seed-utils.mjs';
+import { GRACEFUL_FETCH_FAILURE_EXIT_CODE, PUBLISH_BLOCKED_EXIT_CODE } from '../scripts/_seed-utils.mjs';
 import { DAY, readSectionFreshness, bundleHeartbeatKey, BUNDLE_HEARTBEAT_TTL_SECONDS } from '../scripts/_bundle-runner.mjs';
 import {
   SUPERSEDED_KEY_TTL_SECONDS,
@@ -1028,6 +1028,50 @@ test('graceful-only fetch failure exits 0 (no data lost) but still logs the skip
     assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:0 failed:0 graceful:1/);
     assert.match(stdout, /\[Bundle:test\] 1 graceful fetch skip\(s\), no hard failures — no data lost, exiting 0/);
     assert.doesNotMatch(combined, /\[Bundle:test\] section=GRACEFUL status=OK/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('a coverage-gate refusal reports PUBLISH_BLOCKED, never OK (#6396)', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-publish-blocked.mjs',
+    `console.error('COVERAGE GATE FAILED: china-missing (dataMonth=missing)');\nconsole.log('Extended TTL on 52 key(s)');\nprocess.exit(${PUBLISH_BLOCKED_EXIT_CODE});\n`,
+  );
+  try {
+    const { code, stdout, stderr } = await runBundleWith([
+      { label: 'GATED', script: '_bundle-fixture-publish-blocked.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    const combined = stdout + stderr;
+    // The gate refused to publish and preserved the last-good TTL: not a
+    // crash (the freshness monitor owns the staleness alarm), but the summary
+    // must never be able to say OK for a section that wrote no seed keys.
+    assert.equal(code, 0, 'publish-blocked-only tick preserves last-good and is not a crash');
+    assert.match(combined, /\[GATED\] COVERAGE GATE FAILED: china-missing/);
+    assert.match(combined, new RegExp(`Failed after .*s: coverage gate refused to publish \\(exit ${PUBLISH_BLOCKED_EXIT_CODE}\\)`));
+    assert.match(combined, new RegExp(`\\[Bundle:test\\] section=GATED status=PUBLISH_BLOCKED .*reason=coverage gate refused to publish \\(exit ${PUBLISH_BLOCKED_EXIT_CODE}\\)`));
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:0 failed:0 graceful:0 stalled:0 publish_blocked:1/);
+    assert.match(stdout, /\[Bundle:test\] 1 publish-blocked section\(s\) preserved last-good and wrote no seed keys/);
+    assert.doesNotMatch(combined, /\[Bundle:test\] section=GATED status=OK/);
+    assert.doesNotMatch(stdout, /graceful:1/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('bundles without gate refusals keep a byte-identical summary line', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-ok-member.mjs',
+    `console.log('seeded');\n`,
+  );
+  try {
+    const { code, stdout } = await runBundleWith([
+      { label: 'OKMEMBER', script: '_bundle-fixture-ok-member.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    assert.equal(code, 0);
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:1 skipped:0 deferred:0 failed:0 graceful:0 stalled:0$/m);
+    // publish_blocked is appended only when non-zero, exactly like disabled:.
+    assert.doesNotMatch(stdout, /publish_blocked/);
   } finally {
     cleanup();
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The bundle runner mapped child exit 0 to `status=OK`, so `seed-jodi-oil`'s coverage-gate path — which logs `COVERAGE GATE FAILED`, extends the last-good TTL, and returns — produced a healthy-looking section whose entire purpose, publishing `seed-meta:energy:jodi-oil`, did not happen (#6396). The identical `china-missing` condition was previously classified two different ways across the two JODI members, one of them silently.

This continues the fix from #6865 (author `@yzxcj797`). That PR is still open but `CONFLICTING` against current `main`. Maintainer push to the fork head failed here: the GitHub App lacks `workflows` permission, and rebasing onto current `main` brings workflow-file history the App cannot update on `yzxcj797/worldmonitor`. This branch is that same commit rebased onto current `main` (conflict resolved by keeping `BUNDLE_COMPLETION_META_KEY_ENV` and adding `PUBLISH_BLOCKED_EXIT_CODE`).

- `PUBLISH_BLOCKED_EXIT_CODE = 76` joins `GRACEFUL_FETCH_FAILURE_EXIT_CODE = 75` in `_seed-utils.mjs` (single source of truth; `exit 0` keeps meaning "the keys were written").
- The runner maps exit 76 to `status=PUBLISH_BLOCKED` with reason `coverage gate refused to publish (exit 76)`, counts it in a `publish_blocked` summary field appended **only when non-zero** (like `disabled:`), and explains the tick on stdout.
- `seed-jodi-oil`'s gate now signals the outcome via `main()`'s return value, so the `finally` block still releases the lock before `process.exit(76)` — no lock leak.
- Exit-code semantics: a gate refusal is not a crash — the member verified preservation of the last-good snapshot, and the freshness monitor owns the staleness alarm — but it can no longer masquerade as `OK`.
- `seed-jodi-gas` no longer has a refusing gate (it publishes the other countries and carries the China diagnostic), so the historical two-way split cannot recur.

## Type of change

- [x] Bug fix
- [x] CI / Build / Infrastructure

## Affected areas

- [x] Other: seed bundle runner / JODI oil seeder

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`) — N/A surface is plain `.mjs`; biome check clean on the four touched files
- [ ] Tested on worldmonitor.app variant — N/A: cron/bundle-runner contract exercised by tests

## Documentation Alignment Checklist

- Claim ledger: N/A
- Audit Council signoffs: N/A

## Testing

- `node --test tests/bundle-runner.test.mjs` — 43/43, including:
  - `a coverage-gate refusal reports PUBLISH_BLOCKED, never OK (#6396)`
  - `bundles without gate refusals keep a byte-identical summary line`
- `node --test tests/jodi-oil-seed.test.mjs` — 64/64
- `biome check` on the four changed files — clean
- `git diff --check` — clean

Fixes #6396
Related: #6865

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c5271f7-7596-4690-a29b-f02733322f17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c5271f7-7596-4690-a29b-f02733322f17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

