### PR TITLE
fix(markets): refresh aged sector YTD/3Y/5Y metrics when v7 covers all symbols

### DIFF
--- a/scripts/_yahoo-sector-valuations.cjs
+++ b/scripts/_yahoo-sector-valuations.cjs
@@ -26,8 +26,13 @@ const BATCH_MIN_BUDGET_MS = 2_000;
 // exits and DEFAULT_MAX_EXIT_ATTEMPTS was unreachable in production -- the cap
 // that actually bound rotation was this budget, not the attempt count. 30s fits
 // four and still leaves half the 60s valuation budget for the quoteSummary tier,
-// which only runs for symbols the batch failed to cover.
+// which covers symbols the batch missed and age-triggered return-metric refreshes.
 const BATCH_BUDGET_MS = 30_000;
+// v7 never returns ytd/3Y/5Y; those only arrive from quoteSummary. Once v7 covers
+// every symbol, quoteSummary would otherwise never run and the last-good metrics
+// snapshot freezes. Refresh when that snapshot is older than this age (or was
+// never stamped), still bounded by the valuation budget.
+const METRICS_REFRESH_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 // Yahoo's quote fundamentals cache is populated PER RESIDENTIAL EXIT IP: across
 // 10 rotated Decodo exits, 7 answered HTTP 200 while omitting trailingPE for a
 // stable subset of sector ETFs and 3 served it.
@@ -649,6 +654,39 @@ function mergeReturnMetrics(freshVals, lastGoodValuations) {
     if (used) usedSymbols.push(s);
   }
   return usedSymbols;
+}
+
+function hasLiveReturnMetrics(valuation) {
+  return Boolean(
+    valuation
+    && valuation.ytdReturn != null
+    && valuation.threeYearReturn != null
+    && valuation.fiveYearReturn != null,
+  );
+}
+
+function metricsRefreshDue(metricsFetchedAt, nowMs, maxAgeMs = METRICS_REFRESH_MAX_AGE_MS) {
+  if (!Number.isFinite(metricsFetchedAt)) return true;
+  if (!Number.isFinite(nowMs) || !Number.isFinite(maxAgeMs)) return true;
+  return (nowMs - metricsFetchedAt) >= maxAgeMs;
+}
+
+/** Overlay quoteSummary fields onto a v7 hit without discarding live core PE/beta. */
+function applyQuoteSummaryValuation(existing, parsed, source) {
+  if (!parsed || typeof parsed !== 'object') {
+    return existing || null;
+  }
+  if (!existing) {
+    return { ...parsed, ...(source ? { source } : {}) };
+  }
+  const next = { ...existing };
+  for (const key of ['ytdReturn', 'threeYearReturn', 'fiveYearReturn']) {
+    if (parsed[key] != null) next[key] = parsed[key];
+  }
+  for (const key of ['trailingPE', 'forwardPE', 'beta']) {
+    if (next[key] == null && parsed[key] != null) next[key] = parsed[key];
+  }
+  return next;
 }
 
 // The shape every published valuation must have. Consumers (MarketPanel's
@@ -1753,41 +1791,14 @@ async function collectSectorValuations({
   const valuationDiagnostics = v7Result.diagnostics || [];
   for (const source of v7Result.valuationSources || []) valuationSources.add(source);
 
-  // Tier 2: reserve the last-good read until every current valuation tier has
-  // run. Otherwise a complete v7 failure followed by quoteSummary fallback
-  // data can overwrite the previous snapshot before its return metrics are
-  // available to merge.
+  // Read last-good before quoteSummary so an age-triggered metrics refresh can
+  // see metricsFetchedAt. Persistence still waits until after merges below —
+  // an early read cannot re-date borrowed data.
   let lastGood = null;
   let lastGoodFetchedAt = null;
   let lastGoodMetricsFetchedAt = null;
   let lastGoodMetricsUsed = [];
   let lastGoodValuationSymbols = [];
-
-  // Tier 3: v10/quoteSummary for symbols v7 didn't cover
-  for (const symbol of symbols) {
-    if (v7Vals[symbol]) continue;
-    if (deadlineAt != null && now() >= deadlineAt) {
-      valuationDiagnostics.push({
-        symbol,
-        outcomes: [{ route: 'quoteSummary', attempts: 0, responseClass: 'deadline_exceeded', failure: 'valuation_budget_exceeded' }],
-      });
-      continue;
-    }
-    const detailed = typeof fetchValueDetailed === 'function'
-      ? await fetchValueDetailed(symbol, { deadlineAt })
-      : null;
-    const raw = detailed?.value ?? (detailed ? null : await fetchValue(symbol));
-    const parsed = parseValue(raw);
-    if (parsed) {
-      v7Vals[symbol] = { ...parsed, ...(raw?.source ? { source: raw.source } : {}) };
-      if (raw?.source) valuationSources.add(raw.source);
-    }
-    if (detailed?.diagnostics) {
-      valuationDiagnostics.push({ symbol, outcomes: detailed.diagnostics });
-    }
-    const remainingMs = deadlineAt == null ? DEFAULT_REQUEST_SPACING_MS : Math.max(0, deadlineAt - now());
-    if (remainingMs > 0) await sleepFn(Math.min(DEFAULT_REQUEST_SPACING_MS, remainingMs));
-  }
 
   if (typeof upstashGet === 'function') {
     try {
@@ -1804,6 +1815,47 @@ async function collectSectorValuations({
         failure: boundedFailure(error?.message || error?.name),
       });
     }
+  }
+
+  const metricsAgeAnchor = Number.isFinite(lastGoodMetricsFetchedAt)
+    ? lastGoodMetricsFetchedAt
+    : null;
+  // Only an existing snapshot can freeze return metrics. With no last-good yet,
+  // quoteSummary stays coverage-only; the next cycle (after a core persist)
+  // treats a missing metricsFetchedAt as due and fills ytd/3Y/5Y.
+  const refreshReturnMetrics = lastGood != null
+    && metricsRefreshDue(metricsAgeAnchor, now());
+
+  // Tier 3: v10/quoteSummary for symbols v7 didn't cover, and for covered
+  // symbols whose return metrics are due for an age-triggered refresh.
+  for (const symbol of symbols) {
+    const existing = v7Vals[symbol];
+    const needsCoverage = !existing;
+    const needsMetricsRefresh = Boolean(existing)
+      && refreshReturnMetrics
+      && !hasLiveReturnMetrics(existing);
+    if (!needsCoverage && !needsMetricsRefresh) continue;
+    if (deadlineAt != null && now() >= deadlineAt) {
+      valuationDiagnostics.push({
+        symbol,
+        outcomes: [{ route: 'quoteSummary', attempts: 0, responseClass: 'deadline_exceeded', failure: 'valuation_budget_exceeded' }],
+      });
+      continue;
+    }
+    const detailed = typeof fetchValueDetailed === 'function'
+      ? await fetchValueDetailed(symbol, { deadlineAt })
+      : null;
+    const raw = detailed?.value ?? (detailed ? null : await fetchValue(symbol));
+    const parsed = parseValue(raw);
+    if (parsed) {
+      v7Vals[symbol] = applyQuoteSummaryValuation(existing, parsed, raw?.source);
+      if (raw?.source) valuationSources.add(raw.source);
+    }
+    if (detailed?.diagnostics) {
+      valuationDiagnostics.push({ symbol, outcomes: detailed.diagnostics });
+    }
+    const remainingMs = deadlineAt == null ? DEFAULT_REQUEST_SPACING_MS : Math.max(0, deadlineAt - now());
+    if (remainingMs > 0) await sleepFn(Math.min(DEFAULT_REQUEST_SPACING_MS, remainingMs));
   }
 
   const currentValuationCount = Object.keys(v7Vals).length;
@@ -1838,13 +1890,7 @@ async function collectSectorValuations({
 
   const hasCompleteReturnMetrics = currentValuationCount === symbols.length
     && symbols.length > 0
-    && symbols.every((symbol) => {
-      const valuation = currentValuations[symbol];
-      return valuation
-        && valuation.ytdReturn != null
-        && valuation.threeYearReturn != null
-        && valuation.fiveYearReturn != null;
-    });
+    && symbols.every((symbol) => hasLiveReturnMetrics(currentValuations[symbol]));
   const hasCompleteCoreCoverage = currentValuationCount === symbols.length
     && symbols.length > 0
     && symbols.every((symbol) => hasCoreValuation(currentValuations[symbol]));
@@ -2013,6 +2059,9 @@ module.exports = {
   fetchYahooV7QuoteDirect,
   fetchYahooV7QuoteProxy,
   mergeReturnMetrics,
+  metricsRefreshDue,
+  hasLiveReturnMetrics,
+  applyQuoteSummaryValuation,
   parseCurlResponse,
   parseV7Quote,
   parseV7QuoteBatch,
@@ -2023,4 +2072,5 @@ module.exports = {
   requestCurlText,
   LAST_GOOD_KEY,
   LAST_GOOD_TTL,
+  METRICS_REFRESH_MAX_AGE_MS,
 };

--- a/scripts/_yahoo-sector-valuations.cjs
+++ b/scripts/_yahoo-sector-valuations.cjs
@@ -665,6 +665,27 @@ function hasLiveReturnMetrics(valuation) {
   );
 }
 
+function parseReturnMetricValue(value) {
+  const candidate = typeof value === 'string' ? Number.parseFloat(value) : value;
+  return typeof candidate === 'number' && Number.isFinite(candidate) ? candidate : null;
+}
+
+function extractReturnMetrics(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const source = raw.value && typeof raw.value === 'object' && !Array.isArray(raw.value)
+    ? raw.value
+    : raw;
+  const metrics = {};
+  let hasMetric = false;
+  for (const key of ['ytdReturn', 'threeYearReturn', 'fiveYearReturn']) {
+    const value = parseReturnMetricValue(source[key]);
+    if (value == null) continue;
+    metrics[key] = value;
+    hasMetric = true;
+  }
+  return hasMetric ? metrics : null;
+}
+
 function metricsRefreshDue(metricsFetchedAt, nowMs, maxAgeMs = METRICS_REFRESH_MAX_AGE_MS) {
   if (!Number.isFinite(metricsFetchedAt)) return true;
   if (!Number.isFinite(nowMs) || !Number.isFinite(maxAgeMs)) return true;
@@ -1846,7 +1867,8 @@ async function collectSectorValuations({
       ? await fetchValueDetailed(symbol, { deadlineAt })
       : null;
     const raw = detailed?.value ?? (detailed ? null : await fetchValue(symbol));
-    const parsed = parseValue(raw);
+    const parsed = parseValue(raw)
+      || (needsMetricsRefresh ? extractReturnMetrics(raw) : null);
     if (parsed) {
       v7Vals[symbol] = applyQuoteSummaryValuation(existing, parsed, raw?.source);
       if (raw?.source) valuationSources.add(raw.source);
@@ -1914,9 +1936,21 @@ async function collectSectorValuations({
     // module writes satisfies, so it froze the key until its TTL expired.
     && lastGoodMetricsUsed.length === 0
     && lastGoodValuationSymbols.length === 0;
+  const hasAnyLiveReturnMetrics = Object.values(currentValuations).some((valuation) => (
+    valuation
+    && (
+      valuation.ytdReturn != null
+      || valuation.threeYearReturn != null
+      || valuation.fiveYearReturn != null
+    )
+  ));
+  const canPersistPartialReturnSnapshot = hasCompleteCoreCoverage
+    && !hasCompleteReturnMetrics
+    && hasAnyLiveReturnMetrics
+    && lastGoodValuationSymbols.length === 0;
   const shouldPersistLastGood = (
     hasCompleteReturnMetrics && lastGoodMetricsUsed.length === 0
-  ) || canPersistCoreSnapshot;
+  ) || canPersistCoreSnapshot || canPersistPartialReturnSnapshot;
   if (shouldPersistLastGood && typeof upstashSet === 'function') {
     try {
       const source = hasCompleteReturnMetrics ? valuations : currentValuations;
@@ -1931,7 +1965,7 @@ async function collectSectorValuations({
       );
       const previousMetricsFetchedAt = Number.isFinite(lastGoodMetricsFetchedAt)
         ? lastGoodMetricsFetchedAt
-        : lastGoodFetchedAt;
+        : null;
       const metricsFetchedAt = hasCompleteReturnMetrics ? now() : previousMetricsFetchedAt;
       const ok = await upstashSet(LAST_GOOD_KEY, {
         valuations: snapshotValuations,

--- a/tests/sector-valuations.test.mjs
+++ b/tests/sector-valuations.test.mjs
@@ -7,6 +7,7 @@ import {
   collectSectorValuations,
   collectV7Valuations,
   mergeReturnMetrics,
+  METRICS_REFRESH_MAX_AGE_MS,
   parseV7Quote,
 } from '../scripts/_yahoo-sector-valuations.cjs';
 
@@ -451,11 +452,130 @@ describe('sector valuation collection', () => {
   });
 
   it('records authenticated v7 coverage and explicit last-good metric provenance', async () => {
+    const nowMs = 1_700_000_000_000;
     const result = await collectSectorValuations({
       symbols: ['XLK'],
-      fetchValue: async () => { throw new Error('v10 must not run for a v7 success'); },
+      fetchValue: async () => { throw new Error('v10 must not run for a v7 success with fresh metrics'); },
       parseValue: (raw) => raw,
       sleepFn: async () => {},
+      now: () => nowMs,
+      v7UserAgent: 'test-agent',
+      v7Client: {
+        fetchV7Detailed: async () => ({
+          kind: 'success',
+          value: {
+            trailingPE: 25,
+            forwardPE: 22,
+            beta: 1.1,
+            ytdReturn: null,
+            threeYearReturn: null,
+            fiveYearReturn: null,
+            source: 'yahoo_v7_quote_authenticated_direct',
+          },
+          diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'success' }],
+        }),
+      },
+      upstashGet: async () => ({
+        fetchedAt: nowMs,
+        metricsFetchedAt: nowMs,
+        valuations: { XLK: { ytdReturn: 0.08, threeYearReturn: 0.12, fiveYearReturn: 0.1 } },
+      }),
+      upstashSet: async () => {},
+    });
+
+    assert.equal(result.valuationCount, 1);
+    assert.deepEqual(result.valuations.XLK, {
+      trailingPE: 25,
+      forwardPE: 22,
+      beta: 1.1,
+      ytdReturn: 0.08,
+      threeYearReturn: 0.12,
+      fiveYearReturn: 0.1,
+    });
+    assert.deepEqual(result.lastGoodMetricsUsed, ['XLK']);
+    assert.equal(result.lastGoodFetchedAt, nowMs);
+    assert.deepEqual(result.valuationSources, ['yahoo_v7_quote_authenticated_direct']);
+  });
+
+  it('refreshes aged return metrics via quoteSummary even when v7 covered every symbol', async () => {
+    const nowMs = 1_700_000_000_000 + METRICS_REFRESH_MAX_AGE_MS + 1;
+    const v10Symbols = [];
+    let written = null;
+    const result = await collectSectorValuations({
+      symbols: ['XLK', 'XLF'],
+      fetchValue: async (symbol) => {
+        v10Symbols.push(symbol);
+        return {
+          value: {
+            trailingPE: 99,
+            forwardPE: 98,
+            beta: 9,
+            ytdReturn: symbol === 'XLK' ? 0.21 : 0.11,
+            threeYearReturn: symbol === 'XLK' ? 0.22 : 0.12,
+            fiveYearReturn: symbol === 'XLK' ? 0.23 : 0.13,
+          },
+          source: 'yahoo_quote_summary_authenticated',
+        };
+      },
+      parseValue: (raw) => raw?.value ?? null,
+      sleepFn: async () => {},
+      now: () => nowMs,
+      v7UserAgent: 'test-agent',
+      v7Client: {
+        fetchV7Detailed: async (symbol) => ({
+          kind: 'success',
+          value: {
+            trailingPE: symbol === 'XLK' ? 25 : 15,
+            forwardPE: symbol === 'XLK' ? 22 : 14,
+            beta: 1.1,
+            ytdReturn: null,
+            threeYearReturn: null,
+            fiveYearReturn: null,
+            source: 'yahoo_v7_quote_authenticated_direct',
+          },
+          diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'success' }],
+        }),
+      },
+      upstashGet: async () => ({
+        fetchedAt: 1_700_000_000_000,
+        metricsFetchedAt: 1_700_000_000_000,
+        valuations: {
+          XLK: { trailingPE: 24, forwardPE: 21, beta: 1.05, ytdReturn: 0.08, threeYearReturn: 0.12, fiveYearReturn: 0.1 },
+          XLF: { trailingPE: 14, forwardPE: 13, beta: 1.0, ytdReturn: 0.06, threeYearReturn: 0.11, fiveYearReturn: 0.09 },
+        },
+      }),
+      upstashSet: async (_key, value) => { written = value; return true; },
+    });
+
+    assert.deepEqual(v10Symbols, ['XLK', 'XLF'], 'aged metrics must force quoteSummary despite full v7 coverage');
+    assert.deepEqual(result.valuations.XLK, {
+      trailingPE: 25,
+      forwardPE: 22,
+      beta: 1.1,
+      ytdReturn: 0.21,
+      threeYearReturn: 0.22,
+      fiveYearReturn: 0.23,
+    });
+    assert.equal(result.valuations.XLF.ytdReturn, 0.11);
+    assert.equal(result.lastGoodMetricsUsed, undefined, 'live metrics refresh must not borrow last-good');
+    assert.ok(written, 'complete live metrics must advance the snapshot');
+    assert.equal(written.metricsFetchedAt, nowMs);
+    assert.equal(written.valuations.XLK.trailingPE, 25, 'v7 core must win over quoteSummary PE');
+    assert.equal(written.valuations.XLK.ytdReturn, 0.21);
+  });
+
+  it('skips quoteSummary metrics refresh while the snapshot metrics age is still fresh', async () => {
+    const nowMs = 1_700_000_000_000 + METRICS_REFRESH_MAX_AGE_MS - 1;
+    const v10Symbols = [];
+    await collectSectorValuations({
+      symbols: ['XLK'],
+      fetchValue: async (symbol) => {
+        v10Symbols.push(symbol);
+        throw new Error(`quoteSummary must not run while metrics are fresh: ${symbol}`);
+      },
+      parseValue: (raw) => raw,
+      sleepFn: async () => {},
+      now: () => nowMs,
       v7UserAgent: 'test-agent',
       v7Client: {
         fetchV7Detailed: async () => ({
@@ -474,32 +594,83 @@ describe('sector valuation collection', () => {
       },
       upstashGet: async () => ({
         fetchedAt: 1_700_000_000_000,
+        metricsFetchedAt: 1_700_000_000_000,
         valuations: { XLK: { ytdReturn: 0.08, threeYearReturn: 0.12, fiveYearReturn: 0.1 } },
       }),
       upstashSet: async () => {},
     });
 
-    assert.equal(result.valuationCount, 1);
-    assert.deepEqual(result.valuations.XLK, {
-      trailingPE: 25,
-      forwardPE: 22,
-      beta: 1.1,
-      ytdReturn: 0.08,
-      threeYearReturn: 0.12,
-      fiveYearReturn: 0.1,
+    assert.deepEqual(v10Symbols, [], 'fresh metricsFetchedAt must suppress the age-triggered refresh');
+  });
+
+  it('treats a core-only last-good snapshot as metrics-due on the next healthy v7 cycle', async () => {
+    const nowMs = 1_700_000_500_000;
+    const v10Symbols = [];
+    const result = await collectSectorValuations({
+      symbols: ['XLK'],
+      fetchValue: async (symbol) => {
+        v10Symbols.push(symbol);
+        return {
+          value: {
+            trailingPE: 99,
+            ytdReturn: 0.31,
+            threeYearReturn: 0.32,
+            fiveYearReturn: 0.33,
+          },
+          source: 'yahoo_quote_summary_authenticated',
+        };
+      },
+      parseValue: (raw) => raw?.value ?? null,
+      sleepFn: async () => {},
+      now: () => nowMs,
+      v7UserAgent: 'test-agent',
+      v7Client: {
+        fetchV7Detailed: async () => ({
+          kind: 'success',
+          value: {
+            trailingPE: 25,
+            forwardPE: 22,
+            beta: 1.1,
+            ytdReturn: null,
+            threeYearReturn: null,
+            fiveYearReturn: null,
+            source: 'yahoo_v7_quote_authenticated_direct',
+          },
+          diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'success' }],
+        }),
+      },
+      upstashGet: async () => ({
+        fetchedAt: 1_700_000_000_000,
+        // Core persist omitted metricsFetchedAt because returns were never live.
+        valuations: {
+          XLK: {
+            trailingPE: 24,
+            forwardPE: 21,
+            beta: 1.05,
+            ytdReturn: null,
+            threeYearReturn: null,
+            fiveYearReturn: null,
+          },
+        },
+      }),
+      upstashSet: async () => true,
     });
-    assert.deepEqual(result.lastGoodMetricsUsed, ['XLK']);
-    assert.equal(result.lastGoodFetchedAt, 1_700_000_000_000);
-    assert.deepEqual(result.valuationSources, ['yahoo_v7_quote_authenticated_direct']);
+
+    assert.deepEqual(v10Symbols, ['XLK']);
+    assert.equal(result.valuations.XLK.ytdReturn, 0.31);
+    assert.equal(result.valuations.XLK.trailingPE, 25);
+    assert.equal(result.lastGoodMetricsUsed, undefined);
   });
 
   it('persists a complete v7 valuation snapshot when return metrics are unavailable', async () => {
     let written = null;
+    const nowMs = 1_700_000_000_000;
     const result = await collectSectorValuations({
       symbols: ['XLK', 'XLF'],
-      fetchValue: async () => { throw new Error('v10 must not run for a v7 success'); },
+      fetchValue: async () => null,
       parseValue: (raw) => raw,
       sleepFn: async () => {},
+      now: () => nowMs,
       v7UserAgent: 'test-agent',
       v7Client: {
         fetchV7Detailed: async (symbol) => ({
@@ -516,14 +687,15 @@ describe('sector valuation collection', () => {
           diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'success' }],
         }),
       },
+      // No prior metrics stamp: quoteSummary is attempted, fails, then core persists.
       upstashGet: async () => null,
-      upstashSet: async (_key, value) => {
-        written = value;
-        return true;
-      },
+      upstashSet: async (_key, value) => { written = value; return true; },
     });
 
     assert.equal(result.valuationCount, 2);
+    assert.ok(written, 'core-complete v7 coverage must still persist when metrics stay null');
+    assert.equal(written.fetchedAt, nowMs);
+    assert.equal(written.metricsFetchedAt, undefined);
     // The snapshot keeps the canonical six-key shape with explicit nulls.
     // Stripping null keys makes a replayed record fail `=== null` guards in
     // MarketPanel and reach `undefined.toFixed()`.
@@ -654,11 +826,13 @@ describe('sector valuation collection', () => {
 
   it('refreshes a resident core-only snapshot instead of freezing until its TTL', async () => {
     let written = null;
+    const nowMs = 1_700_000_500_000;
     await collectSectorValuations({
       symbols: ['XLK', 'XLF'],
-      fetchValue: async () => { throw new Error('v10 must not run for a v7 success'); },
+      fetchValue: async () => null,
       parseValue: (raw) => raw,
       sleepFn: async () => {},
+      now: () => nowMs,
       v7UserAgent: 'test-agent',
       v7Client: {
         fetchV7Detailed: async (symbol) => ({
@@ -686,21 +860,22 @@ describe('sector valuation collection', () => {
         },
       }),
       upstashSet: async (_key, value) => { written = value; return true; },
-      now: () => 1_700_000_500_000,
     });
 
     assert.ok(written, 'a fully live core-complete run must refresh the snapshot');
-    assert.equal(written.fetchedAt, 1_700_000_500_000);
+    assert.equal(written.fetchedAt, nowMs);
     assert.equal(written.valuations.XLK.trailingPE, 26, 'fresh values replace stored ones');
   });
 
   it('preserves stored return metrics when a core-only run refreshes the snapshot', async () => {
     let written = null;
+    const nowMs = 1_700_000_000_000;
     await collectSectorValuations({
       symbols: ['XLK'],
-      fetchValue: async () => { throw new Error('v10 must not run for a v7 success'); },
+      fetchValue: async () => { throw new Error('v10 must not run for a v7 success with fresh metrics'); },
       parseValue: (raw) => raw,
       sleepFn: async () => {},
+      now: () => nowMs,
       v7UserAgent: 'test-agent',
       v7Client: {
         fetchV7Detailed: async () => ({
@@ -714,7 +889,8 @@ describe('sector valuation collection', () => {
         }),
       },
       upstashGet: async () => ({
-        fetchedAt: 1_700_000_000_000,
+        fetchedAt: nowMs,
+        metricsFetchedAt: nowMs,
         // Already carries return metrics AND core, so mergeReturnMetrics
         // borrows -> the run is not standing on its own data -> no rewrite.
         valuations: {
@@ -781,11 +957,13 @@ describe('sector valuation collection', () => {
 
   it('does not re-date borrowed last-good metrics after a partial run', async () => {
     let writes = 0;
+    const nowMs = 1_700_000_000_000;
     const result = await collectSectorValuations({
       symbols: ['XLK'],
-      fetchValue: async () => { throw new Error('v10 must not run for a v7 success'); },
+      fetchValue: async () => { throw new Error('v10 must not run for a v7 success with fresh metrics'); },
       parseValue: (raw) => raw,
       sleepFn: async () => {},
+      now: () => nowMs,
       v7UserAgent: 'test-agent',
       v7Client: {
         fetchV7Detailed: async () => ({
@@ -803,7 +981,8 @@ describe('sector valuation collection', () => {
         }),
       },
       upstashGet: async () => ({
-        fetchedAt: 1_700_000_000_000,
+        fetchedAt: nowMs,
+        metricsFetchedAt: nowMs,
         valuations: { XLK: { ytdReturn: 0.08, threeYearReturn: 0.12, fiveYearReturn: 0.1 } },
       }),
       upstashSet: async () => { writes++; },
@@ -813,7 +992,7 @@ describe('sector valuation collection', () => {
     assert.equal(writes, 0, 'borrowed metrics must not renew the last-good timestamp');
   });
 
-  it('loads last-good after quoteSummary fallback and preserves it when fallback fields are incomplete', async () => {
+  it('merges last-good return metrics when quoteSummary fallback fields are incomplete', async () => {
     let reads = 0;
     let writes = 0;
     const result = await collectSectorValuations({

--- a/tests/sector-valuations.test.mjs
+++ b/tests/sector-valuations.test.mjs
@@ -662,6 +662,205 @@ describe('sector valuation collection', () => {
     assert.equal(result.lastGoodMetricsUsed, undefined);
   });
 
+  it('keeps unstamped metrics due after a failed refresh writes core values', async () => {
+    const writes = [];
+    const firstCycle = await collectSectorValuations({
+      symbols: ['XLK'],
+      fetchValue: async () => null,
+      parseValue: (raw) => raw,
+      sleepFn: async () => {},
+      now: () => 1_700_000_500_000,
+      v7UserAgent: 'test-agent',
+      v7Client: {
+        fetchV7Detailed: async () => ({
+          kind: 'success',
+          value: {
+            trailingPE: 25,
+            forwardPE: 22,
+            beta: 1.1,
+            ytdReturn: null,
+            threeYearReturn: null,
+            fiveYearReturn: null,
+            source: 'yahoo_v7_quote_authenticated_direct',
+          },
+          diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'success' }],
+        }),
+      },
+      upstashGet: async () => ({
+        fetchedAt: 1_700_000_000_000,
+        valuations: {
+          XLK: {
+            trailingPE: 24,
+            forwardPE: 21,
+            beta: 1.05,
+            ytdReturn: null,
+            threeYearReturn: null,
+            fiveYearReturn: null,
+          },
+        },
+      }),
+      upstashSet: async (_key, value) => { writes.push(value); return true; },
+    });
+
+    assert.equal(firstCycle.valuations.XLK.ytdReturn, null);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].metricsFetchedAt, undefined, 'failed refresh must not make null return metrics look fresh');
+
+    const secondCycleQuoteSummaryCalls = [];
+    await collectSectorValuations({
+      symbols: ['XLK'],
+      fetchValue: async (symbol) => {
+        secondCycleQuoteSummaryCalls.push(symbol);
+        return null;
+      },
+      parseValue: (raw) => raw,
+      sleepFn: async () => {},
+      now: () => 1_700_000_800_000,
+      v7UserAgent: 'test-agent',
+      v7Client: {
+        fetchV7Detailed: async () => ({
+          kind: 'success',
+          value: {
+            trailingPE: 26,
+            forwardPE: 23,
+            beta: 1.2,
+            ytdReturn: null,
+            threeYearReturn: null,
+            fiveYearReturn: null,
+            source: 'yahoo_v7_quote_authenticated_direct',
+          },
+          diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'success' }],
+        }),
+      },
+      upstashGet: async () => writes[0],
+      upstashSet: async () => true,
+    });
+
+    assert.deepEqual(secondCycleQuoteSummaryCalls, ['XLK'], 'unstamped metrics must retry on the next cycle');
+  });
+
+  it('accepts return-only quoteSummary values during a metrics refresh', async () => {
+    const nowMs = 1_700_000_000_000 + METRICS_REFRESH_MAX_AGE_MS + 1;
+    let written = null;
+    const result = await collectSectorValuations({
+      symbols: ['XLK'],
+      fetchValue: async () => ({
+        value: {
+          ytdReturn: '0.41',
+          threeYearReturn: 0.42,
+          fiveYearReturn: 0.43,
+        },
+        source: 'yahoo_quote_summary_authenticated',
+      }),
+      parseValue: (raw) => {
+        const value = raw?.value;
+        if (!value) return null;
+        return value.trailingPE == null && value.forwardPE == null ? null : value;
+      },
+      sleepFn: async () => {},
+      now: () => nowMs,
+      v7UserAgent: 'test-agent',
+      v7Client: {
+        fetchV7Detailed: async () => ({
+          kind: 'success',
+          value: {
+            trailingPE: 25,
+            forwardPE: 22,
+            beta: 1.1,
+            ytdReturn: null,
+            threeYearReturn: null,
+            fiveYearReturn: null,
+            source: 'yahoo_v7_quote_authenticated_direct',
+          },
+          diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'success' }],
+        }),
+      },
+      upstashGet: async () => ({
+        fetchedAt: 1_700_000_000_000,
+        metricsFetchedAt: 1_700_000_000_000,
+        valuations: {
+          XLK: {
+            trailingPE: 24,
+            forwardPE: 21,
+            beta: 1.05,
+            ytdReturn: 0.08,
+            threeYearReturn: 0.12,
+            fiveYearReturn: 0.1,
+          },
+        },
+      }),
+      upstashSet: async (_key, value) => { written = value; return true; },
+    });
+
+    assert.deepEqual(result.valuations.XLK, {
+      trailingPE: 25,
+      forwardPE: 22,
+      beta: 1.1,
+      ytdReturn: 0.41,
+      threeYearReturn: 0.42,
+      fiveYearReturn: 0.43,
+    });
+    assert.equal(written.metricsFetchedAt, nowMs);
+  });
+
+  it('persists partial live return refreshes without advancing metric freshness', async () => {
+    const nowMs = 1_700_000_000_000 + METRICS_REFRESH_MAX_AGE_MS + 1;
+    let written = null;
+    const result = await collectSectorValuations({
+      symbols: ['XLK'],
+      fetchValue: async () => ({
+        value: {
+          ytdReturn: 0.51,
+          threeYearReturn: null,
+          fiveYearReturn: null,
+        },
+        source: 'yahoo_quote_summary_authenticated',
+      }),
+      parseValue: (raw) => raw?.value ?? null,
+      sleepFn: async () => {},
+      now: () => nowMs,
+      v7UserAgent: 'test-agent',
+      v7Client: {
+        fetchV7Detailed: async () => ({
+          kind: 'success',
+          value: {
+            trailingPE: 25,
+            forwardPE: 22,
+            beta: 1.1,
+            ytdReturn: null,
+            threeYearReturn: null,
+            fiveYearReturn: null,
+            source: 'yahoo_v7_quote_authenticated_direct',
+          },
+          diagnostics: [{ route: 'v7Quote', transport: 'direct', responseClass: 'success' }],
+        }),
+      },
+      upstashGet: async () => ({
+        fetchedAt: 1_700_000_000_000,
+        metricsFetchedAt: 1_700_000_000_000,
+        valuations: {
+          XLK: {
+            trailingPE: 24,
+            forwardPE: 21,
+            beta: 1.05,
+            ytdReturn: 0.08,
+            threeYearReturn: 0.12,
+            fiveYearReturn: 0.1,
+          },
+        },
+      }),
+      upstashSet: async (_key, value) => { written = value; return true; },
+    });
+
+    assert.equal(result.valuations.XLK.ytdReturn, 0.51);
+    assert.equal(result.valuations.XLK.threeYearReturn, 0.12);
+    assert.equal(result.valuations.XLK.fiveYearReturn, 0.1);
+    assert.ok(written, 'partial live return metrics must be saved');
+    assert.equal(written.valuations.XLK.ytdReturn, 0.51);
+    assert.equal(written.valuations.XLK.threeYearReturn, 0.12);
+    assert.equal(written.metricsFetchedAt, 1_700_000_000_000, 'partial freshness cannot advance the all-metrics clock');
+  });
+
   it('persists a complete v7 valuation snapshot when return metrics are unavailable', async () => {
     let written = null;
     const nowMs = 1_700_000_000_000;
@@ -864,6 +1063,7 @@ describe('sector valuation collection', () => {
 
     assert.ok(written, 'a fully live core-complete run must refresh the snapshot');
     assert.equal(written.fetchedAt, nowMs);
+    assert.equal(written.metricsFetchedAt, undefined, 'core-only refresh must not stamp return metric freshness');
     assert.equal(written.valuations.XLK.trailingPE, 26, 'fresh values replace stored ones');
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #6280. Once v7 covers every sector ETF, `quoteSummary` never ran, so `ytdReturn` / `threeYearReturn` / `fiveYearReturn` were served forever from `market:sectors:valuations:last-good` and `metricsFetchedAt` stopped advancing.

This implements option 1 from the issue: when a last-good snapshot exists and `metricsFetchedAt` is missing or older than 6 hours, run the quoteSummary tier for covered symbols that still lack live return metrics (still bounded by the existing valuation budget). Overlay keeps live v7 PE/beta and only fills return metrics from summary.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [x] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Railway market seeder (`scripts/_yahoo-sector-valuations.cjs`)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [ ] Claim ledger attached or linked
- [ ] All required Audit Council role signoffs attached
- [ ] Generated docs regenerated from proto where applicable
- [ ] Fixture-backed examples recomputed
- [ ] Redis writers/readers enumerated for every documented key

N/A — no documentation claim changes.

## Verification

- `node --test tests/sector-valuations.test.mjs tests/yahoo-sector-valuations.test.mjs` → 126 pass / 0 fail

[Sector metrics refresh unit tests](https://cursor.com/agents/bc-7f58aea5-bc37-49a1-aad2-a24e43f9a407/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsector_metrics_refresh_tests.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f58aea5-bc37-49a1-aad2-a24e43f9a407?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f58aea5-bc37-49a1-aad2-a24e43f9a407&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

