### PR TITLE
fix(insights): make the gate resample a different draft, not the same one twice

### DIFF
--- a/scripts/_insights-brief.mjs
+++ b/scripts/_insights-brief.mjs
@@ -73,6 +73,44 @@ export const BRIEF_REJECTIONS = Object.freeze({
  * independent reporting signal — corroboration as a hard requirement, not a
  * tiebreaker.
  */
+// Turn a gate rejection into a bounded correction the NEXT sample can obey.
+//
+// The gates were a filter with no feedback path: the rejection named what was
+// wrong (#6995) and the information went only to the log, so the retry got the
+// identical prompt. At temperature 0.1 with a story set that rotates over
+// hours, the identical prompt returns the identical draft — measured on
+// 2026-08-28 as 25 consecutive INSIGHTS_SYNTHESIS_LEAD_PROPER_NOUN rejections
+// on the same phrase, every cycle for four hours, while the brief served an
+// aging LKG. Telling the model what was rejected is the missing half of the
+// gate: rejection becomes repair.
+//
+// The detail is bounded and whitespace-flattened before it is quoted back:
+// it is model-authored text going into a prompt, not a log, but the same
+// no-unbounded-payload rule applies.
+const REJECTION_FEEDBACK_MAX_DETAIL_CHARS = 80;
+
+export function synthesisRejectionFeedback(rejection) {
+  const code = rejection?.code;
+  if (!code) return null;
+  const detail = typeof rejection?.detail === 'string'
+    ? rejection.detail.replace(/\s+/g, ' ').trim().slice(0, REJECTION_FEEDBACK_MAX_DETAIL_CHARS)
+    : '';
+  switch (code) {
+    case BRIEF_REJECTIONS.LEAD_PROPER_NOUN:
+    case BRIEF_REJECTIONS.LEAD_NUMERIC_FACT:
+      if (detail) {
+        return `Correction: your previous draft was rejected because "${detail}" does not appear in any story its sentence cited. Remove it, or move that claim into a sentence that cites the story stating it.`;
+      }
+      return 'Correction: your previous draft was rejected because a lead claim was not supported by the stories its sentence cited. Every name, place and number must appear in a cited story.';
+    case BRIEF_REJECTIONS.LEAD_UNCITED:
+      return 'Correction: your previous draft was rejected because a lead sentence carried no citation. End every lead sentence with the bracket number(s) of the stories it draws from.';
+    case BRIEF_REJECTIONS.PARSE:
+      return 'Correction: your previous response was not the required JSON shape. Respond with the JSON object ONLY — no markdown fences, no commentary.';
+    default:
+      return 'Correction: your previous draft was rejected by an editorial gate. Follow the rules exactly: cite every claim, and use only facts present in the numbered story text.';
+  }
+}
+
 export function pickBriefCluster(topStories) {
   if (!Array.isArray(topStories)) return null;
   return topStories.find(isBriefLeadEligible) ?? null;

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -30,6 +30,7 @@ import {
   briefUserPrompt,
   synthesisSystemPrompt,
   synthesisUserPrompt,
+  synthesisRejectionFeedback,
 } from './_insights-brief.mjs';
 import {
   INSIGHTS_COMPOSER_THREW,
@@ -423,6 +424,8 @@ const LLM_PROVIDERS = [
 // provider's Retry-After (429/503) instead of dropping straight to the next
 // provider, but never sleep/fetch past the remaining call budget.
 const INSIGHTS_LLM_MAX_RETRIES = 2;
+const INSIGHTS_LLM_TEMPERATURE = 0.1;
+const INSIGHTS_LLM_RESAMPLE_TEMPERATURE = 0.7;
 const INSIGHTS_LLM_RETRY_BASE_MS = 1_000;
 const INSIGHTS_LLM_RETRY_AFTER_MAX_MS = 10_000;
 const INSIGHTS_LLM_CALL_BUDGET_MS = 60_000;
@@ -458,6 +461,16 @@ async function callLLM(headline, options = {}) {
   const promptChars = (systemPrompt?.length ?? 0) + (userPrompt?.length ?? 0);
   const events = [];
   let attemptIndex = 0;
+  // 0.1 keeps the first sample stable and cheap to reason about. But after a
+  // gate rejection, determinism is the enemy: the same prompt at the same
+  // temperature returns the same draft, so #6995's resample-once was a second
+  // identical call — 25 consecutive identical rejections on 2026-08-28 proved
+  // it. Once any sample has been gate-rejected, later samples run hot enough
+  // to actually vary, and carry the gate's correction (options.rejectionFeedback)
+  // appended to the user prompt. Both persist past the resample into the rest
+  // of the provider chain: a weaker model needs the correction more, not less.
+  let samplingTemperature = INSIGHTS_LLM_TEMPERATURE;
+  let gateFeedbackNote = null;
 
   // #6001: the chain used to fall through on TRANSPORT failures only. A model
   // that reliably returns well-formed text the brief composer then rejects on
@@ -525,10 +538,10 @@ async function callLLM(headline, options = {}) {
             model,
             messages: [
               { role: 'system', content: systemPrompt },
-              { role: 'user', content: userPrompt },
+              { role: 'user', content: gateFeedbackNote ? `${userPrompt}\n\n${gateFeedbackNote}` : userPrompt },
             ],
             max_tokens: maxTokens,
-            temperature: 0.1,
+            temperature: samplingTemperature,
             ...provider.extraBody,
           }),
           signal: AbortSignal.timeout(Math.max(1, Math.min(provider.timeout, usable))),
@@ -591,6 +604,16 @@ async function callLLM(headline, options = {}) {
           record(false, { ...usage, model: json.model || model, reason: 'validate_reject' });
           if (faulted) { if (!firstFaulted) firstFaulted = candidate; }
           else if (!firstRejected) firstRejected = candidate;
+          if (!faulted) {
+            // A FAULTED acceptor teaches the sampler nothing — the fault is in
+            // our own gate, so neither the temperature bump nor a correction
+            // note applies.
+            samplingTemperature = INSIGHTS_LLM_RESAMPLE_TEMPERATURE;
+            const feedback = typeof options.rejectionFeedback === 'function'
+              ? options.rejectionFeedback()
+              : null;
+            if (typeof feedback === 'string' && feedback.trim()) gateFeedbackNote = feedback.trim();
+          }
           // One resample before demoting (see the queue comment above). A
           // FAULTED acceptor is excluded deliberately: that fault is in our own
           // gate, not in the sample, so a second identical call would throw
@@ -864,8 +887,16 @@ async function fetchInsights() {
     sanitizeTitle,
     sourceFromStory: briefSourceFromStory,
   };
-  const composeFromText = (text) =>
-    composeInsightsSynthesis(text, topStories, synthesisComposerOptions).brief;
+  // The accept callback used to swallow WHY composition failed; the rejection
+  // code and detail are exactly what the resample needs to not repeat itself.
+  let lastSynthesisRejection = null;
+  const composeFromText = (text) => {
+    const result = composeInsightsSynthesis(text, topStories, synthesisComposerOptions);
+    lastSynthesisRejection = result?.brief
+      ? null
+      : { code: result?.rejection ?? null, detail: result?.rejectionDetail ?? null };
+    return result?.brief ?? null;
+  };
 
   // #6001: L1 may now walk the whole provider chain, and L2 below makes a
   // SECOND callLLM. Stamp the run's LLM start so L2 gets only the remainder —
@@ -878,8 +909,11 @@ async function fetchInsights() {
         maxTokens: 900,
         // A model whose output trips the editorial gates must not strand the
         // run. callLLM resamples this model once before demoting to a weaker
-        // one, so a single unusable sample no longer costs the better writer.
+        // one, so a single unusable sample no longer costs the better writer —
+        // and the resample carries the gate's correction plus real sampling
+        // variance, so it is a different draft rather than the same one twice.
         accept: composeFromText,
+        rejectionFeedback: () => synthesisRejectionFeedback(lastSynthesisRejection),
       })
     : null;
   const { composed, failureCode, failureDetail } = resolveInsightsSynthesis({

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -458,7 +458,6 @@ async function callLLM(headline, options = {}) {
   // llm_call telemetry (#4944 U5): one event per provider OUTCOME (the
   // withRetry duration covers in-provider retries), unified with the
   // Vercel-side stream via scripts/lib/llm-telemetry.cjs.
-  const promptChars = (systemPrompt?.length ?? 0) + (userPrompt?.length ?? 0);
   const events = [];
   let attemptIndex = 0;
   // 0.1 keeps the first sample stable and cheap to reason about. But after a
@@ -517,11 +516,19 @@ async function callLLM(headline, options = {}) {
 
     const apiUrl = provider.apiUrlFn ? provider.apiUrlFn(envVal) : provider.apiUrl;
     const model = typeof provider.model === 'function' ? provider.model() : provider.model;
+    // Captured per attempt, BEFORE the request: a correction collected during
+    // this attempt's rejection belongs to the NEXT request. The request body
+    // and the telemetry both derive from this one variable, so the recorded
+    // promptChars is the size of what was actually sent — a corrected resample
+    // is larger than the base prompt, and the events must say so (#7248
+    // review: every event recorded the base-only size).
+    const effectiveUserPrompt = gateFeedbackNote ? `${userPrompt}\n\n${gateFeedbackNote}` : userPrompt;
+    const attemptPromptChars = (systemPrompt?.length ?? 0) + effectiveUserPrompt.length;
     const t0 = Date.now();
     const record = (ok, extra = {}) => {
       events.push(buildLlmCallEvent({
         provider: provider.name, model, stage: 'seed-insights', ok,
-        durationMs: Date.now() - t0, promptChars, maxTokens,
+        durationMs: Date.now() - t0, promptChars: attemptPromptChars, maxTokens,
         fallbackIndex: attemptIndex++,
         ...extra,
       }));
@@ -538,7 +545,7 @@ async function callLLM(headline, options = {}) {
             model,
             messages: [
               { role: 'system', content: systemPrompt },
-              { role: 'user', content: gateFeedbackNote ? `${userPrompt}\n\n${gateFeedbackNote}` : userPrompt },
+              { role: 'user', content: effectiveUserPrompt },
             ],
             max_tokens: maxTokens,
             temperature: samplingTemperature,
@@ -776,6 +783,39 @@ export function normalizeDigestItemsForInsights(items) {
   })).filter(item => item.title.length > 10);
 }
 
+/**
+ * Acceptance gate for the synthesis provider walk. Exported so the composer-
+ * fault contract is directly testable — the #7248 review found the contained
+ * composer sentinel riding the ordinary-rejection path, and the fix lived in
+ * an inline closure no test could reach.
+ *
+ * Contract:
+ *   - editorial rejection -> returns null and records {code, detail} for the
+ *     resample-feedback path;
+ *   - composer FAULT (the contained INSIGHTS_COMPOSER_THREW sentinel) ->
+ *     THROWS, so callLLM takes its faulted-acceptor path: no temperature bump,
+ *     no correction note, no resample. The sample may have been fine; the
+ *     fault is in OUR gate. resolveInsightsSynthesis still classifies the run
+ *     as COMPOSER_ERROR from its own contained composer call.
+ */
+export function createSynthesisAcceptor(topStories, composerOptions) {
+  let lastSynthesisRejection = null;
+  return {
+    accept: (text) => {
+      const result = composeInsightsSynthesis(text, topStories, composerOptions);
+      if (result?.rejection === INSIGHTS_COMPOSER_THREW) {
+        lastSynthesisRejection = null;
+        throw new Error(`composer fault: ${INSIGHTS_COMPOSER_THREW}`);
+      }
+      lastSynthesisRejection = result?.brief
+        ? null
+        : { code: result?.rejection ?? null, detail: result?.rejectionDetail ?? null };
+      return result?.brief ?? null;
+    },
+    lastRejection: () => lastSynthesisRejection,
+  };
+}
+
 async function fetchInsights() {
   const digest = await readOrWarmDigest('en');
   if (!digest) {
@@ -887,16 +927,7 @@ async function fetchInsights() {
     sanitizeTitle,
     sourceFromStory: briefSourceFromStory,
   };
-  // The accept callback used to swallow WHY composition failed; the rejection
-  // code and detail are exactly what the resample needs to not repeat itself.
-  let lastSynthesisRejection = null;
-  const composeFromText = (text) => {
-    const result = composeInsightsSynthesis(text, topStories, synthesisComposerOptions);
-    lastSynthesisRejection = result?.brief
-      ? null
-      : { code: result?.rejection ?? null, detail: result?.rejectionDetail ?? null };
-    return result?.brief ?? null;
-  };
+  const { accept: composeFromText, lastRejection } = createSynthesisAcceptor(topStories, synthesisComposerOptions);
 
   // #6001: L1 may now walk the whole provider chain, and L2 below makes a
   // SECOND callLLM. Stamp the run's LLM start so L2 gets only the remainder —
@@ -913,7 +944,7 @@ async function fetchInsights() {
         // and the resample carries the gate's correction plus real sampling
         // variance, so it is a different draft rather than the same one twice.
         accept: composeFromText,
-        rejectionFeedback: () => synthesisRejectionFeedback(lastSynthesisRejection),
+        rejectionFeedback: () => synthesisRejectionFeedback(lastRejection()),
       })
     : null;
   const { composed, failureCode, failureDetail } = resolveInsightsSynthesis({

--- a/tests/seed-insights-brief.test.mjs
+++ b/tests/seed-insights-brief.test.mjs
@@ -9,6 +9,7 @@ import {
   composeSynthesizedBrief,
   composeSynthesizedBriefResult,
   BRIEF_REJECTIONS,
+  synthesisRejectionFeedback,
 } from '../scripts/_insights-brief.mjs';
 
 describe('pickBriefCluster', () => {
@@ -1016,5 +1017,33 @@ describe('coordinating and is grammar in the composer (AE2, AE4, AE7)', () => {
     );
     assert.equal(out.brief, null);
     assert.equal(out.rejection, BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
+  });
+});
+
+
+describe('synthesisRejectionFeedback', () => {
+  it('quotes the rejected phrase back with the repair instruction', () => {
+    const note = synthesisRejectionFeedback({
+      code: BRIEF_REJECTIONS.LEAD_PROPER_NOUN,
+      detail: 'strait of hormuz',
+    });
+    assert.match(note, /"strait of hormuz"/);
+    assert.match(note, /cites the story stating it/);
+  });
+
+  it('bounds and flattens a hostile detail before quoting it into a prompt', () => {
+    const note = synthesisRejectionFeedback({
+      code: BRIEF_REJECTIONS.LEAD_NUMERIC_FACT,
+      detail: `x${'y'.repeat(500)}\nline2\tline3`,
+    });
+    assert.ok(note.length < 300, 'the correction stays bounded');
+    assert.ok(!note.includes('\n'), 'newlines are flattened');
+  });
+
+  it('maps parse and uncited rejections to their own corrections, and null to null', () => {
+    assert.match(synthesisRejectionFeedback({ code: BRIEF_REJECTIONS.PARSE }), /JSON object ONLY/);
+    assert.match(synthesisRejectionFeedback({ code: BRIEF_REJECTIONS.LEAD_UNCITED }), /bracket number/);
+    assert.equal(synthesisRejectionFeedback(null), null);
+    assert.equal(synthesisRejectionFeedback({}), null);
   });
 });

--- a/tests/seed-insights-llm-retry.test.mjs
+++ b/tests/seed-insights-llm-retry.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { callLLM, __setInsightsLlmTransportForTests } from '../scripts/seed-insights.mjs';
+import { callLLM, createSynthesisAcceptor, __setInsightsLlmTransportForTests } from '../scripts/seed-insights.mjs';
 
 const LONG_BRIEF = 'Insights brief succeeded with more than enough narrative content to pass.';
 
@@ -433,6 +433,99 @@ describe('seed-insights callLLM output acceptance (#6001)', () => {
     assert.equal(feedbackCalls, 0, 'the feedback hook is rejection-only');
   });
 
+  it('an acceptor FAULT never heats the sampler, consults feedback, or resamples', async () => {
+    // #7248 review: the composer contains its own exceptions and reports a
+    // sentinel rejection, which rode the ordinary-rejection path — heating the
+    // sampler and appending a generic correction for a bug in OUR gate. The
+    // caller now re-throws on the sentinel; this pins callLLM's side of the
+    // contract for any throwing acceptor.
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    delete process.env.OLLAMA_API_URL;
+
+    const bodies = [];
+    let feedbackCalls = 0;
+    __setInsightsLlmTransportForTests({
+      fetch: async (url, init) => {
+        bodies.push({ url: String(url), body: JSON.parse(init.body) });
+        return okResponse(LONG_BRIEF);
+      },
+    });
+
+    const result = await callLLM(null, {
+      systemPrompt: 'sys',
+      userPrompt: 'user',
+      accept: () => {
+        // Fault only for openrouter-family attempts; groq's sample is accepted.
+        if (bodies.at(-1).url.includes('openrouter')) throw new Error('composer fault: composer-threw');
+        return { composed: true };
+      },
+      rejectionFeedback: () => { feedbackCalls += 1; return 'never'; },
+    });
+
+    assert.ok(result, 'the chain still lands on the provider whose sample is accepted');
+    assert.equal(result.provider, 'groq');
+    // No resample: each faulting provider is asked exactly once. Three
+    // openrouter-family providers + groq = 4 calls, not 7.
+    assert.equal(bodies.length, 4, 'a faulted acceptor never earns a resample');
+    for (const { body } of bodies) {
+      assert.equal(body.temperature, 0.1, 'a fault in our own gate must not heat the sampler');
+      assert.equal(body.messages[1].content, 'user', 'no correction is appended for our own fault');
+    }
+    assert.equal(feedbackCalls, 0, 'the feedback hook is for editorial rejections only');
+  });
+
+  it('telemetry records the size of the corrected prompt, not the base one', async () => {
+    // #7248 review: promptChars was computed once from the base prompts, so
+    // every corrected resample recorded an undersized event.
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'axiom-test-token';
+    delete process.env.OLLAMA_API_URL;
+    const originalFetch = globalThis.fetch;
+
+    try {
+      const telemetryBatches = [];
+      // Provider calls go through the transport hook; the Axiom POST uses the
+      // global fetch, so the two streams are separable.
+      globalThis.fetch = async (_url, init) => {
+        telemetryBatches.push(JSON.parse(init.body));
+        return { ok: true, status: 200, json: async () => ({}) };
+      };
+      __setInsightsLlmTransportForTests({
+        fetch: async (url) => okResponse(String(url).includes('openrouter') ? `${LONG_BRIEF} REJECT_ME` : LONG_BRIEF),
+      });
+
+      const FEEDBACK = 'Correction: drop the ungrounded phrase.';
+      await callLLM(null, {
+        systemPrompt: 'sys',
+        userPrompt: 'user',
+        accept: (text) => (text.includes('REJECT_ME') ? null : { composed: true }),
+        rejectionFeedback: () => FEEDBACK,
+      });
+      // emitLlmEvents is fire-and-forget; give the microtask queue a beat.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const events = telemetryBatches.flat();
+      assert.ok(events.length >= 2, 'the walk must emit one event per attempt');
+      const base = 'sys'.length + 'user'.length;
+      const corrected = 'sys'.length + `user\n\n${FEEDBACK}`.length;
+      assert.equal(events[0].prompt_chars, base, 'the first attempt sends the base prompt');
+      for (const event of events.slice(1)) {
+        assert.equal(
+          event.prompt_chars,
+          corrected,
+          'every attempt after the rejection records the corrected prompt it actually sent',
+        );
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+      delete process.env.USAGE_TELEMETRY;
+      delete process.env.AXIOM_API_TOKEN;
+    }
+  });
+
   it('returns the last attempt when every provider is rejected, so the failure stays classifiable', async () => {
     process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
     process.env.GROQ_API_KEY = 'groq-test-key';
@@ -516,5 +609,60 @@ describe('seed-insights callLLM output acceptance (#6001)', () => {
 
     const result = await callLLM(null, { systemPrompt: 'sys', userPrompt: 'user', accept: () => null });
     assert.match(result.text, /PRIMARY/, 'the last provider would misattribute the failure stage');
+  });
+});
+
+
+describe('createSynthesisAcceptor (composer-fault contract, #7248 review)', () => {
+  const STORY = {
+    primaryTitle: 'Regional apple prices rose sharply in Chile last quarter, growers say',
+    primarySource: 'Reuters',
+    primaryLink: 'http://apple',
+    sources: ['Reuters', 'AP News'],
+    memberTitles: ['Regional apple prices rose sharply in Chile last quarter, growers say'],
+  };
+  const RAW = JSON.stringify({
+    lead: 'Prices rose sharply in Chile last quarter [1].',
+    lines: [{ n: 1, text: 'Regional apple prices rose sharply in Chile [1]' }],
+  });
+
+  it('THROWS on a contained composer fault instead of reporting a rejection', () => {
+    // sanitizeTitle throwing makes the composer itself fault; the composer
+    // contains it and reports the sentinel. The acceptor must convert that
+    // back into a throw so callLLM takes its faulted path — no temperature
+    // bump, no correction, no resample — rather than treating our own bug as
+    // an editorial verdict on the sample.
+    const { accept, lastRejection } = createSynthesisAcceptor([STORY], {
+      validatorMode: 'enforce',
+      briefCluster: STORY,
+      sanitizeTitle: () => { throw new Error('composer bug'); },
+    });
+    assert.throws(() => accept(RAW), /composer fault/);
+    assert.equal(lastRejection(), null, 'a fault is not a rejection the feedback path may quote');
+  });
+
+  it('returns null and records the code on an editorial rejection', () => {
+    const { accept, lastRejection } = createSynthesisAcceptor([STORY], {
+      validatorMode: 'enforce',
+      briefCluster: STORY,
+    });
+    const bad = JSON.stringify({
+      lead: 'Prices rose sharply in Venezuela last quarter [1].',
+      lines: [{ n: 1, text: 'Regional apple prices rose sharply in Chile [1]' }],
+    });
+    assert.equal(accept(bad), null);
+    assert.equal(lastRejection().code, 'lead-proper-noun');
+    assert.match(lastRejection().detail, /venezuela/);
+  });
+
+  it('returns the brief and clears the rejection on success', () => {
+    const { accept, lastRejection } = createSynthesisAcceptor([STORY], {
+      validatorMode: 'enforce',
+      briefCluster: STORY,
+    });
+    const brief = accept(RAW);
+    assert.ok(brief);
+    assert.match(brief.lead, /Chile/);
+    assert.equal(lastRejection(), null);
   });
 });

--- a/tests/seed-insights-llm-retry.test.mjs
+++ b/tests/seed-insights-llm-retry.test.mjs
@@ -362,6 +362,77 @@ describe('seed-insights callLLM output acceptance (#6001)', () => {
     }
   });
 
+  it('a gate-rejected sample raises the temperature and appends the rejection feedback', async () => {
+    // 2026-08-28: 25 consecutive identical LEAD_PROPER_NOUN rejections over four
+    // hours. temperature was pinned at 0.1 and the retry got the identical
+    // prompt, so #6995's resample-once was the same draft twice. The resample is
+    // only real if the second sample differs: hotter, and told what was wrong.
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    delete process.env.OLLAMA_API_URL;
+
+    const bodies = [];
+    __setInsightsLlmTransportForTests({
+      fetch: async (url, init) => {
+        bodies.push(JSON.parse(init.body));
+        return okResponse(String(url).includes('openrouter') ? `${LONG_BRIEF} REJECT_ME` : LONG_BRIEF);
+      },
+    });
+
+    const FEEDBACK = 'Correction: your previous draft was rejected because "strait of hormuz" does not appear in any story its sentence cited.';
+    const result = await callLLM(null, {
+      systemPrompt: 'sys',
+      userPrompt: 'user',
+      accept: (text) => (text.includes('REJECT_ME') ? null : { composed: true }),
+      rejectionFeedback: () => FEEDBACK,
+    });
+    assert.ok(result, 'the chain still lands on an accepting provider');
+
+    // First sample: cold and unannotated — the baseline behaviour is untouched.
+    assert.equal(bodies[0].temperature, 0.1, 'the first sample stays at the base temperature');
+    assert.equal(bodies[0].messages[1].content, 'user', 'the first sample carries no correction');
+
+    // Every sample after the first rejection: hot, and corrected.
+    for (let i = 1; i < bodies.length; i += 1) {
+      assert.equal(bodies[i].temperature, 0.7, `sample ${i} after a rejection must actually vary`);
+      assert.ok(
+        bodies[i].messages[1].content.endsWith(FEEDBACK),
+        `sample ${i} must carry the gate's correction appended to the user prompt`,
+      );
+      assert.ok(
+        bodies[i].messages[1].content.startsWith('user'),
+        'the correction is appended, never a replacement for the prompt',
+      );
+    }
+  });
+
+  it('an accepted first sample never raises the temperature or consults the feedback hook', async () => {
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    delete process.env.GROQ_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+
+    const bodies = [];
+    let feedbackCalls = 0;
+    __setInsightsLlmTransportForTests({
+      fetch: async (_url, init) => {
+        bodies.push(JSON.parse(init.body));
+        return okResponse(LONG_BRIEF);
+      },
+    });
+
+    const result = await callLLM(null, {
+      systemPrompt: 'sys',
+      userPrompt: 'user',
+      accept: () => ({ composed: true }),
+      rejectionFeedback: () => { feedbackCalls += 1; return 'never'; },
+    });
+    assert.ok(result);
+    assert.equal(bodies.length, 1);
+    assert.equal(bodies[0].temperature, 0.1);
+    assert.equal(bodies[0].messages[1].content, 'user');
+    assert.equal(feedbackCalls, 0, 'the feedback hook is rejection-only');
+  });
+
   it('returns the last attempt when every provider is rejected, so the failure stays classifiable', async () => {
     process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
     process.env.GROQ_API_KEY = 'groq-test-key';


### PR DESCRIPTION
Part 1 of the newsInsights convergence package (diagnosed after the 2026-08-28 incident; parts 2–5 follow as separate PRs).

## The incident

`newsInsights` spent 03:50–08:00 at `SEED_ERROR`: **25 consecutive `INSIGHTS_SYNTHESIS_LEAD_PROPER_NOUN` rejections, every one on the same phrase** ("strait of hormuz"), while the brief served an aging LKG. The model was not hallucinating — the digest carries the phrase verbatim — it cited a story that doesn't contain it, and the citation-scoped gate **correctly** rejected the draft.

## Why it repeated 25 times

Nothing about the retry could produce a different draft:

- temperature was pinned at **0.1**, so the resample #6995 added was the same deterministic draw a second time;
- the rejection detail #6995 extracted went **only to the log** — the retry got the byte-identical prompt.

Every prior fix in this file's history (#6109, #6119, #6798, #6915, #6995) refined the gate against **false positives**. This incident is a **true positive**, and true positives cannot be fixed in the gate: they need the retry to converge.

## The fix — two mechanisms, both rejection-scoped

**1. Heat after rejection.** After any gate rejection, later samples run at 0.7 instead of 0.1. A resample is only a resample if the second draw can differ. The baseline first sample is untouched.

**2. Feed the rejection back.** `synthesisRejectionFeedback` maps the bounded `{code, detail}` the composer already produces into a correction appended to the user prompt:

> *Correction: your previous draft was rejected because "strait of hormuz" does not appear in any story its sentence cited. Remove it, or move that claim into a sentence that cites the story stating it.*

Rejection becomes repair instead of filtration.

Both persist past the single resample into the rest of the provider chain — a weaker model needs the correction more, not less. A **faulted** acceptor (our own gate threw) triggers neither: that fault is in our code, and a hotter retry would teach the sampler nothing.

The detail is whitespace-flattened and bounded to 80 chars before being quoted into a prompt.

## Verification

Mutation-checked twice — removing the temperature bump fails *"sample 1 after a rejection must actually vary"*; removing the prompt append fails *"sample 1 must carry the gate's correction appended to the user prompt"*.

**115 tests pass, 0 fail** across seed-insights-llm-retry, seed-insights-brief, seed-insights-freshness, and insights-synthesis-diagnostics. Biome clean.
