### PR TITLE
fix(e2e): stabilize energy map harness layer poll (#7249)

### DIFF
--- a/e2e/bootstrap-request-budget.spec.ts
+++ b/e2e/bootstrap-request-budget.spec.ts
@@ -20,6 +20,8 @@ type EnergyMapHarnessWindow = Window & {
   __mapHarness?: {
     ready: boolean;
     variant: string;
+    seedAllDynamicData: () => void;
+    setLayersForSnapshot: (enabledLayers: string[]) => void;
     getLayerDataCount: (layerId: string) => number;
   };
 };
@@ -66,13 +68,28 @@ async function expectPopulatedEnergyMapLayers(page: Page): Promise<void> {
     const harness = (window as EnergyMapHarnessWindow).__mapHarness;
     return harness?.ready && harness.variant === 'energy';
   }), { timeout: 45_000 }).toBe(true);
-  await expect.poll(() => page.evaluate(() => {
+
+  // Energy harness boots with nearly every map layer on. getLayerDataCount()
+  // rebuilds the full DeckGL stack on each poll (~60 layers). Under
+  // variant-smoke-full CI load that single evaluate can take most of a 20s
+  // expect.poll budget (or hang the Playwright protocol) even when counts
+  // are already correct — see issue #7249 traces. Narrow to the two layers
+  // under contract, matching e2e/map-harness.spec.ts's snapshot pattern.
+  await page.evaluate(() => {
     const harness = (window as EnergyMapHarnessWindow).__mapHarness;
-    return {
-      pipelines: harness?.getLayerDataCount('pipelines-layer') ?? 0,
-      storage: harness?.getLayerDataCount('storage-facilities-layer') ?? 0,
-    };
-  }), { timeout: 20_000 }).toEqual({ pipelines: 2, storage: 1 });
+    harness?.seedAllDynamicData();
+    harness?.setLayersForSnapshot(['pipelines', 'storageFacilities']);
+  });
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const harness = (window as EnergyMapHarnessWindow).__mapHarness;
+      return {
+        pipelines: harness?.getLayerDataCount('pipelines-layer') ?? 0,
+        storage: harness?.getLayerDataCount('storage-facilities-layer') ?? 0,
+      };
+    });
+  }, { timeout: 30_000 }).toEqual({ pipelines: 2, storage: 1 });
 }
 
 test.describe('bootstrap request budget (#7046)', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `variant-smoke-full` flaked on `bootstrap-request-budget` when `expectPopulatedEnergyMapLayers()` polled `getLayerDataCount` against the full energy harness (~60 DeckGL layers).
- CI traces from #7249 show the seeded counts were already `{ pipelines: 2, storage: 1 }`; the evaluate itself stalled past the 20s `expect.poll` under parallel CI load (retry evaluate ~19s).
- Narrow to `pipelines` + `storageFacilities` (and re-seed) before polling, matching `e2e/map-harness.spec.ts` snapshot pattern. Keep the contract: energy startup still requests each registry once and map layers show seeded counts.

Fixes #7249

## Type of change

- [x] Bug fix

## Affected areas

- [x] Other: e2e / energy map harness assertion

## Test plan

- [x] Characterized from CI Playwright traces (attempt + retry): layer counts correct; evaluate latency/hang is the failure mode
- [x] Local: `VITE_VARIANT=full playwright test e2e/bootstrap-request-budget.spec.ts -g "energy startup"` — 5/5 passes (~9–11s)
- [x] Local: full `bootstrap-request-budget.spec.ts` — 4/4 passed
- [ ] Confirm `variant-smoke-full` / `test:e2e:ci-smoke` green on this PR

## Evidence

CI failure artifact (`playwright-ci-smoke-33155240051-1`): first layer-count evaluate already returned `{pipelines:2,storage:1}`, then poll timed out waiting on that evaluate; retry evaluate alone took ~18.7s against the full layer stack.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44451a4e-2dee-47e5-8574-6e7e859cf765?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44451a4e-2dee-47e5-8574-6e7e859cf765&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

