### PR TITLE
fix(insights): drop a failing lead sentence instead of rejecting the whole brief

### DIFF
--- a/e2e/bootstrap-request-budget.spec.ts
+++ b/e2e/bootstrap-request-budget.spec.ts
@@ -20,6 +20,8 @@ type EnergyMapHarnessWindow = Window & {
   __mapHarness?: {
     ready: boolean;
     variant: string;
+    seedAllDynamicData: () => void;
+    setLayersForSnapshot: (enabledLayers: string[]) => void;
     getLayerDataCount: (layerId: string) => number;
   };
 };
@@ -66,13 +68,28 @@ async function expectPopulatedEnergyMapLayers(page: Page): Promise<void> {
     const harness = (window as EnergyMapHarnessWindow).__mapHarness;
     return harness?.ready && harness.variant === 'energy';
   }), { timeout: 45_000 }).toBe(true);
-  await expect.poll(() => page.evaluate(() => {
+
+  // Energy harness boots with nearly every map layer on. getLayerDataCount()
+  // rebuilds the full DeckGL stack on each poll (~60 layers). Under
+  // variant-smoke-full CI load that single evaluate can take most of a 20s
+  // expect.poll budget (or hang the Playwright protocol) even when counts
+  // are already correct — see issue #7249 traces. Narrow to the two layers
+  // under contract, matching e2e/map-harness.spec.ts's snapshot pattern.
+  await page.evaluate(() => {
     const harness = (window as EnergyMapHarnessWindow).__mapHarness;
-    return {
-      pipelines: harness?.getLayerDataCount('pipelines-layer') ?? 0,
-      storage: harness?.getLayerDataCount('storage-facilities-layer') ?? 0,
-    };
-  }), { timeout: 20_000 }).toEqual({ pipelines: 2, storage: 1 });
+    harness?.seedAllDynamicData();
+    harness?.setLayersForSnapshot(['pipelines', 'storageFacilities']);
+  });
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const harness = (window as EnergyMapHarnessWindow).__mapHarness;
+      return {
+        pipelines: harness?.getLayerDataCount('pipelines-layer') ?? 0,
+        storage: harness?.getLayerDataCount('storage-facilities-layer') ?? 0,
+      };
+    });
+  }, { timeout: 30_000 }).toEqual({ pipelines: 2, storage: 1 });
 }
 
 test.describe('bootstrap request budget (#7046)', () => {

--- a/scripts/_insights-brief.mjs
+++ b/scripts/_insights-brief.mjs
@@ -505,7 +505,21 @@ export function composeSynthesizedBriefResult(rawText, topStories, opts = {}) {
   const publishedLead = droppedLeadSentences === 0
     ? leadCheck.text
     : survivingSentences.join(' ');
-  if (!checkLeadGrounding({ lead: publishedLead }, groundingStories, topStories.length)) {
+  // #7253 review (both reviewers, independently): the aggregate anchor check
+  // demands 2 combined hits on a corpus with >=4 anchor tokens — calibrated
+  // for a FULL lead. When the repair dropped a sentence, the drop may have
+  // taken the second anchor with it, and rejecting the fully-gated survivor
+  // here would defeat the repair in exactly the case it exists for. A
+  // shortened lead is held to requirement 1 (>=1 corpus anchor in the
+  // published text — the anti-mush floor) plus a combined threshold of 1;
+  // an intact lead keeps the original bar.
+  const grounded = checkLeadGrounding(
+    { lead: publishedLead },
+    groundingStories,
+    topStories.length,
+    droppedLeadSentences > 0 ? { combinedThreshold: 1 } : {},
+  );
+  if (!grounded) {
     return reject(BRIEF_REJECTIONS.LEAD_GROUNDING);
   }
 

--- a/scripts/_insights-brief.mjs
+++ b/scripts/_insights-brief.mjs
@@ -429,17 +429,39 @@ export function composeSynthesizedBriefResult(rawText, topStories, opts = {}) {
     .split(/(?<=[.!?])\s+/)
     .filter((sentence) => sentence.trim().length > 0);
   if (leadSentences.length === 0) return reject(BRIEF_REJECTIONS.LEAD_EMPTY);
+  // Repair, don't reject (2026-08-28). One ungrounded noun in one lead sentence
+  // used to reject the ENTIRE synthesis — lead and all story lines — and fall
+  // back to the single-headline brief, which loses to the LKG, so one bad noun
+  // cost a whole cycle of fresh content (25 consecutive cycles, in the incident
+  // that motivated this). Meanwhile the per-story line gate below has always
+  // repaired: a hallucinated line is substituted with its headline, never
+  // fatal. The same policy now applies here: a failing sentence is DROPPED and
+  // the brief rejects only when no sentence survives. Every surviving sentence
+  // passed every gate, so publishing them is editorially identical to
+  // publishing the shorter draft the model could have written.
+  //
+  // The rejection code and detail of the FIRST drop are preserved for the
+  // no-survivors rejection and surfaced alongside the repaired brief, so the
+  // resample-feedback path upstream can still tell the model what to fix.
+  const survivingSentences = [];
+  let droppedLeadSentences = 0;
+  let firstDrop = null;
+  const dropSentence = (rejection, detail = null) => {
+    droppedLeadSentences += 1;
+    if (!firstDrop) firstDrop = { rejection, detail };
+  };
   for (const sentence of leadSentences) {
     const cited = [...sentence.matchAll(/\[(\d{1,3})\]/g)]
       .map((match) => Number.parseInt(match[1], 10))
       .filter((n) => n >= 1 && n <= topStories.length);
-    // Contract: every claim is cited. An uncited sentence is unverifiable.
-    if (cited.length === 0) return reject(BRIEF_REJECTIONS.LEAD_UNCITED);
+    // Contract: every claim is cited. An uncited sentence is unverifiable —
+    // and unpublishable, in every validator mode.
+    if (cited.length === 0) { dropSentence(BRIEF_REJECTIONS.LEAD_UNCITED); continue; }
     const scopedGround = cited.map((n) => storyGroundText(topStories[n - 1])).join(' — ');
     // Fail CLOSED on empty ground. Both validators return ok:true for an empty
     // ground string, so an untitled cluster would accept every proper noun and
     // every number in the sentence — a dead gate that looks like a healthy one.
-    if (!scopedGround.trim()) return reject(BRIEF_REJECTIONS.LEAD_GROUNDING);
+    if (!scopedGround.trim()) { dropSentence(BRIEF_REJECTIONS.LEAD_GROUNDING); continue; }
     // The lead may NAME the outlets of the stories it cites — the prompt showed
     // it those labels. Blank them so they ground nothing else, scoped to the
     // cited stories so one story's outlet cannot license a claim about another.
@@ -448,21 +470,42 @@ export function composeSynthesizedBriefResult(rawText, topStories, opts = {}) {
       cited.map((n) => topStories[n - 1]?.primarySource),
     );
     const attributed = attribution.text;
-    if (attribution.matches > 0) sourceAttributions++;
-    // Both validators still run before either can reject, so shadow mode
+    // Both validators still run before either can drop, so shadow mode
     // observes exactly what it observed before the reasons were split out.
     const sentenceValidation = validateNoHallucinatedProperNouns(attributed, scopedGround);
     const factValidation = validateNoHallucinatedFacts(attributed, scopedGround);
     if (validatorMode === 'enforce') {
       if (!sentenceValidation.ok) {
-        return reject(BRIEF_REJECTIONS.LEAD_PROPER_NOUN, sentenceValidation.hallucinated);
+        dropSentence(BRIEF_REJECTIONS.LEAD_PROPER_NOUN, sentenceValidation.hallucinated);
+        continue;
       }
       if (!factValidation.ok) {
-        return reject(BRIEF_REJECTIONS.LEAD_NUMERIC_FACT, factValidation.hallucinated);
+        dropSentence(BRIEF_REJECTIONS.LEAD_NUMERIC_FACT, factValidation.hallucinated);
+        continue;
       }
     }
+    // Attribution is an accept-side counter; a dropped sentence's outlet naming
+    // never reached a reader, so only survivors count.
+    if (attribution.matches > 0) sourceAttributions++;
+    survivingSentences.push(sentence);
   }
-  if (!checkLeadGrounding({ lead: leadCheck.text }, groundingStories, topStories.length)) {
+  if (survivingSentences.length === 0) {
+    // Total failure classifies exactly as before: the first failing sentence's
+    // code and detail.
+    return reject(
+      firstDrop?.rejection ?? BRIEF_REJECTIONS.LEAD_EMPTY,
+      firstDrop?.detail ?? null,
+    );
+  }
+  // Publishing view. Byte-identical to leadCheck.text when nothing was dropped.
+  // When a sentence WAS dropped, the lead is rebuilt from the gate-view
+  // sentences, whose only divergence from the original text is the mid-clause
+  // dotted-acronym collapse ("U.S." -> "US") — the exact style the system
+  // prompt mandates, so the rebuild cannot introduce a style the prompt forbids.
+  const publishedLead = droppedLeadSentences === 0
+    ? leadCheck.text
+    : survivingSentences.join(' ');
+  if (!checkLeadGrounding({ lead: publishedLead }, groundingStories, topStories.length)) {
     return reject(BRIEF_REJECTIONS.LEAD_GROUNDING);
   }
 
@@ -506,7 +549,21 @@ export function composeSynthesizedBriefResult(rawText, topStories, opts = {}) {
   });
 
   return {
-    brief: { lead: leadCheck.text, lines, sources, hallucinatedLines, strippedCitations, sourceAttributions },
+    brief: {
+      lead: publishedLead,
+      lines,
+      sources,
+      hallucinatedLines,
+      strippedCitations,
+      sourceAttributions,
+      droppedLeadSentences,
+      // What the first dropped sentence tripped on, for the repair log and the
+      // resample-feedback path — null on a clean compose.
+      droppedLeadRejection: firstDrop?.rejection ?? null,
+      droppedLeadDetail: (Array.isArray(firstDrop?.detail) && firstDrop.detail.length > 0)
+        ? firstDrop.detail.join(' ')
+        : null,
+    },
     rejection: null,
     rejectionDetail: null,
   };

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -898,6 +898,11 @@ async function fetchInsights() {
     if (composed.strippedCitations > 0) {
       console.warn(`  [brief_citation ENFORCE] stripped ${composed.strippedCitations} out-of-range citation(s)`);
     }
+    if (composed.droppedLeadSentences > 0) {
+      // Bounded vocabulary only — the detail may quote model output, and this
+      // line reaches Railway logs, so name the gate, not the text.
+      console.warn(`  [brief_repair ${BRIEF_VALIDATOR_MODE.toUpperCase()}] dropped ${composed.droppedLeadSentences} lead sentence(s) (first: ${composed.droppedLeadRejection}) — published the surviving lead`);
+    }
     if (composed.hallucinatedLines > 0) {
       console.warn(`  [brief_hallucination ${BRIEF_VALIDATOR_MODE.toUpperCase()}] ${composed.hallucinatedLines}/${topStories.length} synthesis lines flagged`);
     }

--- a/scripts/shared/brief-llm-core.d.ts
+++ b/scripts/shared/brief-llm-core.d.ts
@@ -69,6 +69,7 @@ export function checkLeadGrounding(
   synthesis: { lead?: string; threads?: Array<{ tag?: string; teaser?: string }> },
   stories: Array<{ headline?: string }>,
   storyCap?: number,
+  opts?: { combinedThreshold?: number | null },
 ): boolean;
 export function leadGroundsAgainstStory(lead: string, headline: string): boolean;
 export function verifyCitationIndexes(

--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -1307,7 +1307,7 @@ export function groundingTokenSet(text) {
 // edge-safe module — callers with a different cap pass it explicitly.
 const DEFAULT_GROUNDING_STORY_CAP = 8;
 
-export function checkLeadGrounding(synthesis, stories, storyCap = DEFAULT_GROUNDING_STORY_CAP) {
+export function checkLeadGrounding(synthesis, stories, storyCap = DEFAULT_GROUNDING_STORY_CAP, { combinedThreshold = null } = {}) {
   if (!Array.isArray(stories) || stories.length === 0) return true;
 
   const storyTokens = new Set();
@@ -1355,7 +1355,14 @@ export function checkLeadGrounding(synthesis, stories, storyCap = DEFAULT_GROUND
       combinedTokens.add(w);
     }
   }
-  const threshold = storyTokens.size >= 4 ? 2 : 1;
+  // combinedThreshold override (#7253 review): the 2-hit requirement is
+  // calibrated for a FULL 2-3 sentence lead. A lead the repair path shortened
+  // may have lost the sentence that carried the second anchor, so its caller
+  // passes 1 — requirement 1 above still stands unconditionally, which is what
+  // keeps an anchor-free mush lead rejected even at the relaxed threshold.
+  const threshold = Number.isInteger(combinedThreshold) && combinedThreshold > 0
+    ? combinedThreshold
+    : (storyTokens.size >= 4 ? 2 : 1);
   let combinedHits = 0;
   for (const tok of storyTokens) {
     if (combinedTokens.has(tok)) {

--- a/shared/brief-llm-core.d.ts
+++ b/shared/brief-llm-core.d.ts
@@ -69,6 +69,7 @@ export function checkLeadGrounding(
   synthesis: { lead?: string; threads?: Array<{ tag?: string; teaser?: string }> },
   stories: Array<{ headline?: string }>,
   storyCap?: number,
+  opts?: { combinedThreshold?: number | null },
 ): boolean;
 export function leadGroundsAgainstStory(lead: string, headline: string): boolean;
 export function verifyCitationIndexes(

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -1307,7 +1307,7 @@ export function groundingTokenSet(text) {
 // edge-safe module — callers with a different cap pass it explicitly.
 const DEFAULT_GROUNDING_STORY_CAP = 8;
 
-export function checkLeadGrounding(synthesis, stories, storyCap = DEFAULT_GROUNDING_STORY_CAP) {
+export function checkLeadGrounding(synthesis, stories, storyCap = DEFAULT_GROUNDING_STORY_CAP, { combinedThreshold = null } = {}) {
   if (!Array.isArray(stories) || stories.length === 0) return true;
 
   const storyTokens = new Set();
@@ -1355,7 +1355,14 @@ export function checkLeadGrounding(synthesis, stories, storyCap = DEFAULT_GROUND
       combinedTokens.add(w);
     }
   }
-  const threshold = storyTokens.size >= 4 ? 2 : 1;
+  // combinedThreshold override (#7253 review): the 2-hit requirement is
+  // calibrated for a FULL 2-3 sentence lead. A lead the repair path shortened
+  // may have lost the sentence that carried the second anchor, so its caller
+  // passes 1 — requirement 1 above still stands unconditionally, which is what
+  // keeps an anchor-free mush lead rejected even at the relaxed threshold.
+  const threshold = Number.isInteger(combinedThreshold) && combinedThreshold > 0
+    ? combinedThreshold
+    : (storyTokens.size >= 4 ? 2 : 1);
   let combinedHits = 0;
   for (const tok of storyTokens) {
     if (combinedTokens.has(tok)) {

--- a/tests/brief-contract.test.mjs
+++ b/tests/brief-contract.test.mjs
@@ -265,7 +265,7 @@ describe('brief-contract wiring (source-textual)', () => {
 
 // ── #4928 review-round additions ───────────────────────────────────────────
 
-import { composeSynthesizedBrief } from '../scripts/_insights-brief.mjs';
+import { BRIEF_REJECTIONS, composeSynthesizedBrief } from '../scripts/_insights-brief.mjs';
 
 describe('composeSynthesizedBrief (functional L1 coverage, #4928 review)', () => {
   const CORROBORATED = [
@@ -389,7 +389,11 @@ describe('citation-scoped composer gates (#4928 external review)', () => {
   ];
   const passOpts = { validatorMode: 'enforce', sourceFromStory: (s) => ({ title: s.primaryTitle, source: s.primarySource, url: s.primaryLink }) };
 
-  it('REGRESSION: a lead sentence attributing story-2 facts to [1] is rejected (misattribution)', () => {
+  it('REGRESSION: a lead sentence attributing story-2 facts to [1] is dropped (misattribution)', () => {
+    // Repair policy (2026-08-28): the misattributed sentence must never reach a
+    // reader. The cited Iran sentence passed every gate, so it still publishes —
+    // the #4928 property is "Turkey facts bound to [1] do not ship", not
+    // "the whole brief is discarded".
     const misattributed = JSON.stringify({
       lead: 'Turkey hikes interest rates to 50% in a dramatic move [1]. Iran threatens the Strait of Hormuz [1].',
       lines: [
@@ -397,11 +401,16 @@ describe('citation-scoped composer gates (#4928 external review)', () => {
         { n: 2, text: 'Turkey raises interest rates to 50% [2].' },
       ],
     });
-    assert.equal(composeSynthesizedBrief(misattributed, STORIES2, passOpts), null,
-      'Turkey facts cited to [1] (Iran) must fail citation-scoped validation');
+    const out = composeSynthesizedBrief(misattributed, STORIES2, passOpts);
+    assert.notEqual(out, null, 'the grounded Iran sentence still publishes');
+    assert.ok(!out.lead.includes('Turkey'), 'Turkey facts cited to [1] never ship');
+    assert.match(out.lead, /Iran threatens the Strait of Hormuz \[1\]/);
+    assert.equal(out.droppedLeadSentences, 1);
+    assert.equal(out.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
+    assert.equal(out.droppedLeadDetail, 'turkey');
   });
 
-  it('REGRESSION: an uncited lead sentence rejects the synthesis (every claim cited)', () => {
+  it('REGRESSION: an uncited lead sentence is dropped (every claim cited)', () => {
     const uncited = JSON.stringify({
       lead: 'Iran threatens the Strait of Hormuz [1]. Markets everywhere are nervous about what comes next.',
       lines: [
@@ -409,7 +418,12 @@ describe('citation-scoped composer gates (#4928 external review)', () => {
         { n: 2, text: 'Turkey raises interest rates to 50% [2].' },
       ],
     });
-    assert.equal(composeSynthesizedBrief(uncited, STORIES2, passOpts), null);
+    const out = composeSynthesizedBrief(uncited, STORIES2, passOpts);
+    assert.notEqual(out, null, 'the cited sentence still publishes');
+    assert.ok(!out.lead.includes('Markets everywhere'), 'the uncited sentence never publishes');
+    assert.match(out.lead, /Iran threatens the Strait of Hormuz \[1\]/);
+    assert.equal(out.droppedLeadSentences, 1);
+    assert.equal(out.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_UNCITED);
   });
 
   it('REGRESSION: a line carrying the WRONG in-range citation is rewritten to its own [n]', () => {
@@ -507,16 +521,26 @@ describe('fragmented-cluster leads (#6001)', () => {
 
   const DOHA = 'Israel and Hamas resumed indirect talks in Doha [2].';
 
-  it('rejects the merged Kyiv claim when it cites only one of the two slots', () => {
-    // The exact production rejection: nouns ["kyiv"], cited [3]. "Kyiv" is
+  it('drops the merged Kyiv claim when it cites only one of the two slots', () => {
+    // The exact production drop: nouns ["kyiv"], cited [3]. "Kyiv" is
     // absent from story 3 ("Ukrainian capital") and present only in story 7.
+    // The Doha sentence is independently grounded, so the brief survives.
     const out = compose(`Russia struck Kyiv with missiles and drones, killing at least 9 [3]. ${DOHA}`);
-    assert.equal(out, null, 'a fact drawn from an uncited sibling must not ship');
+    assert.notEqual(out, null, 'the grounded Doha sentence still publishes');
+    assert.ok(!out.lead.includes('Kyiv'), 'a fact drawn from an uncited sibling must not ship');
+    assert.match(out.lead, /Doha \[2\]/);
+    assert.equal(out.droppedLeadSentences, 1);
+    assert.equal(out.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
+    assert.equal(out.droppedLeadDetail, 'kyiv');
   });
 
-  it('rejects a sibling-only numeric fact when proper nouns are grounded', () => {
+  it('drops a sibling-only numeric fact when proper nouns are grounded', () => {
     const out = compose(`Russia struck the Ukrainian capital, killing nine [3]. ${DOHA}`);
-    assert.equal(out, null, 'a casualty count drawn from an uncited sibling must not ship');
+    assert.notEqual(out, null, 'the grounded Doha sentence still publishes');
+    assert.ok(!out.lead.includes('nine'), 'a casualty count drawn from an uncited sibling must not ship');
+    assert.match(out.lead, /Doha \[2\]/);
+    assert.equal(out.droppedLeadSentences, 1);
+    assert.equal(out.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_NUMERIC_FACT);
   });
 
   it('accepts a sibling numeric fact once both fragments are cited', () => {
@@ -530,19 +554,37 @@ describe('fragmented-cluster leads (#6001)', () => {
     assert.match(out.lead, /\[3\]\[7\]/, 'both citations survive verification');
   });
 
-  it('still rejects a claim whose facts come from an UNCITED story (#4928)', () => {
+  it('still drops a claim whose facts come from an UNCITED story (#4928)', () => {
     // The misattribution #4928 exists to stop. Chile is genuinely IN the
     // corpus (story 4), so corpus-wide grounding would wave this through —
     // but the claim binds to [6] (Venezuela). Citation-scoped grounding is
-    // the only thing that catches it, and #6001 must not relax it.
+    // the only thing that catches it, and #6001 must not relax it. The
+    // property is that Chile never publishes, not that Doha is discarded too.
     const out = compose(`A magnitude 6.8 earthquake struck northern Chile [6]. ${DOHA}`);
-    assert.equal(out, null, '#4928 misattribution protection must survive #6001');
+    assert.notEqual(out, null, 'the grounded Doha sentence still publishes');
+    assert.ok(!out.lead.includes('Chile'), '#4928 misattribution protection must survive #6001');
+    assert.match(out.lead, /Doha \[2\]/);
+    assert.equal(out.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
+    assert.equal(out.droppedLeadDetail, 'chile');
   });
 
-  it('rejects an invented proper noun even when every slot is cited', () => {
+  it('drops an invented proper noun even when every slot is cited', () => {
     const allCited = STORIES6001.map((_, i) => `[${i + 1}]`).join('');
     const out = compose(`Belarus opened a second front against Latvia ${allCited}. ${DOHA}`);
-    assert.equal(out, null, 'citing everything must not launder a hallucination');
+    assert.notEqual(out, null, 'the grounded Doha sentence still publishes');
+    assert.ok(!out.lead.includes('Belarus'), 'citing everything must not launder a hallucination');
+    assert.ok(!out.lead.includes('Latvia'));
+    assert.match(out.lead, /Doha \[2\]/);
+    assert.equal(out.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
+    assert.equal(out.droppedLeadDetail, 'belarus');
+  });
+
+  it('still rejects the whole brief when every lead sentence fails', () => {
+    // Total-failure classification is unchanged: no survivors → null. The
+    // single-sentence Macron hallucination above this suite also stays a
+    // whole-brief reject — only a neighbour that passed every gate publishes.
+    const out = compose('Belarus opened a second front against Latvia [1]. Markets may react next week.');
+    assert.equal(out, null, 'no surviving sentence must still reject the synthesis');
   });
 
   it('system prompt tells the model to cite EVERY story a claim draws from', () => {

--- a/tests/seed-insights-brief.test.mjs
+++ b/tests/seed-insights-brief.test.mjs
@@ -207,7 +207,10 @@ describe('composeSynthesizedBrief lead sentence boundaries (#5947)', () => {
     assert.match(composed.lead, /U\.S\. embassies/, 'the published lead keeps its original text');
   });
 
-  it('still rejects a genuinely uncited lead sentence', () => {
+  it('drops a genuinely uncited lead sentence and publishes the cited remainder', () => {
+    // Repair policy (2026-08-28): the unverifiable sentence must never reach a
+    // reader — but the cited sentence passed every gate, and rejecting the whole
+    // brief over its neighbour cost a full cycle of fresh content.
     const uncited = JSON.stringify({
       lead: 'The GCC condemned Iranian attacks on Kuwait [1]. Analysts expect further escalation soon.',
       lines: [
@@ -215,7 +218,12 @@ describe('composeSynthesizedBrief lead sentence boundaries (#5947)', () => {
         { n: 2, text: 'U.S. embassies urge citizens to consider leaving the region [2]' },
       ],
     });
-    assert.equal(composeSynthesizedBrief(uncited, topStories, { validatorMode: 'enforce' }), null);
+    const composed = composeSynthesizedBrief(uncited, topStories, { validatorMode: 'enforce' });
+    assert.notEqual(composed, null, 'one bad sentence must not cost the whole brief');
+    assert.ok(!composed.lead.includes('Analysts expect'), 'the uncited sentence never publishes');
+    assert.match(composed.lead, /GCC condemned Iranian attacks/);
+    assert.equal(composed.droppedLeadSentences, 1);
+    assert.equal(composed.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_UNCITED);
   });
 
   it('still rejects a hallucinated proper noun in a cited sentence', () => {
@@ -275,22 +283,35 @@ describe('composeSynthesizedBrief acronym boundaries fail closed (#5947 review)'
     { n: 2, text: 'U.S. Embassies urge citizens to consider leaving the region [2]' },
   ];
 
-  it('rejects a claim whose proper nouns come from a story it does not cite', () => {
+  it('drops a claim whose proper nouns come from a story it does not cite', () => {
     // "the U.S." is attributed to [1], which never mentions the US. A merged
-    // validation unit would let it ground against [2] instead.
+    // validation unit would let it ground against [2] instead — and under the
+    // repair policy that merge bug would surface as "U.S." REACHING the
+    // published lead, which is exactly what this asserts against.
     const misattributed = JSON.stringify({
       lead: 'GCC states condemned Iranian attacks on Kuwait [1], and warnings were issued by the U.S. Embassies urged citizens to leave the region [2].',
       lines,
     });
-    assert.equal(composeSynthesizedBrief(misattributed, topStories, { validatorMode: 'enforce' }), null);
+    const composed = composeSynthesizedBrief(misattributed, topStories, { validatorMode: 'enforce' });
+    assert.notEqual(composed, null, 'the grounded sentence still publishes');
+    assert.ok(!composed.lead.includes('U.S.'), 'the misattributed claim never publishes');
+    assert.ok(!composed.lead.includes('warnings were issued'));
+    assert.match(composed.lead, /Embassies urged citizens/);
+    assert.equal(composed.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
   });
 
-  it('rejects an uncited sentence that follows an acronym-terminated sentence', () => {
+  it('drops an uncited sentence that follows an acronym-terminated sentence', () => {
+    // A merge bug would let the uncited fragment ride inside the cited [2]
+    // sentence and publish; asserting its absence keeps that regression caught.
     const uncitedMiddle = JSON.stringify({
       lead: 'GCC states condemned Iranian attacks on Kuwait [1]. Meanwhile pressure mounted on the U.S. Embassies urged citizens to leave the region [2].',
       lines,
     });
-    assert.equal(composeSynthesizedBrief(uncitedMiddle, topStories, { validatorMode: 'enforce' }), null);
+    const composed = composeSynthesizedBrief(uncitedMiddle, topStories, { validatorMode: 'enforce' });
+    assert.notEqual(composed, null);
+    assert.ok(!composed.lead.includes('Meanwhile pressure'), 'the uncited fragment never publishes');
+    assert.match(composed.lead, /GCC states condemned/);
+    assert.equal(composed.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_UNCITED);
   });
 
   it('keeps a genuine sentence boundary after a terminal acronym', () => {
@@ -349,14 +370,21 @@ describe('composeSynthesizedBrief acronym followed by its citation (#5947)', () 
     assert.match(composed.lead, /U\.S\. \[2\]/, 'the published lead keeps its original punctuation');
   });
 
-  it('still rejects an uncited sentence after an acronym that carries its citation', () => {
+  it('still drops an uncited sentence after an acronym that carries its citation', () => {
     // The merge must join the fragment to its OWN citation only. A following
-    // sentence with no citation of its own stays a separate unit and rejects.
+    // sentence with no citation of its own stays a separate unit — dropped,
+    // never smuggled into the cited unit and published.
     const trailingUncited = JSON.stringify({
       lead: 'GCC states condemned Iranian attacks on Kuwait [1]. Citizens were urged to leave by the U.S. [2]. Analysts expect further escalation soon.',
       lines,
     });
-    assert.equal(composeSynthesizedBrief(trailingUncited, topStories, { validatorMode: 'enforce' }), null);
+    const composed = composeSynthesizedBrief(trailingUncited, topStories, { validatorMode: 'enforce' });
+    assert.notEqual(composed, null);
+    assert.ok(!composed.lead.includes('Analysts expect'), 'the uncited sentence never publishes');
+    // The rebuilt lead carries the collapse's dot-free acronym — the exact
+    // style the system prompt mandates ("US", never "U.S.").
+    assert.match(composed.lead, /Citizens were urged to leave by the US \[2\]/);
+    assert.equal(composed.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_UNCITED);
   });
 
   // Scoping must be pinned by a DISCRIMINATING pair, not a lone rejection.
@@ -371,11 +399,14 @@ describe('composeSynthesizedBrief acronym followed by its citation (#5947)', () 
       lead: 'GCC states condemned Iranian attacks on Kuwait [1]. The region was pressured by the U.S. [1].',
       lines,
     });
-    assert.equal(
-      composeSynthesizedBrief(misattributed, topStories, { validatorMode: 'enforce' }),
-      null,
+    const composed = composeSynthesizedBrief(misattributed, topStories, { validatorMode: 'enforce' });
+    assert.notEqual(composed, null);
+    assert.ok(
+      !composed.lead.includes('pressured by the U.S.'),
       'story 1 never mentions the US — collapsing must not let it ground against story 2',
     );
+    assert.equal(composed.droppedLeadSentences, 1);
+    assert.equal(composed.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
   });
 
   it('scopes the collapsed acronym to the story it cites (positive)', () => {
@@ -383,11 +414,15 @@ describe('composeSynthesizedBrief acronym followed by its citation (#5947)', () 
       lead: 'GCC states condemned Iranian attacks on Kuwait [1]. The region was pressured by the U.S. [2].',
       lines,
     });
+    const composed = composeSynthesizedBrief(grounded, topStories, { validatorMode: 'enforce' });
     assert.notEqual(
-      composeSynthesizedBrief(grounded, topStories, { validatorMode: 'enforce' }),
+      composed,
       null,
       'identical text citing [2] must pass — only the citation index differs',
     );
+    // The discriminating variable is the citation index alone: flipping it must
+    // flip the drop count, not merely the null-ness of the result.
+    assert.equal(composed.droppedLeadSentences, 0);
   });
 
   // Cross-model adversarial review (Codex) broke the first version of this fix,
@@ -404,11 +439,13 @@ describe('composeSynthesizedBrief acronym followed by its citation (#5947)', () 
       lead: 'Citizens were urged to leave the region by the U.S. [1] GCC states condemned Iranian attacks on Kuwait [2].',
       lines,
     });
-    assert.equal(
-      composeSynthesizedBrief(unioned, topStories, { validatorMode: 'enforce' }),
-      null,
-      'a bare marker mid-lead must stay a boundary — merging would union {1,2}',
+    const composed = composeSynthesizedBrief(unioned, topStories, { validatorMode: 'enforce' });
+    assert.notEqual(composed, null);
+    assert.ok(
+      !composed.lead.includes('U.S.'),
+      'a bare marker mid-lead must stay a boundary — merging would union {1,2} and publish the US claim',
     );
+    assert.equal(composed.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_UNCITED);
   });
 
   it('does not merge on an adjacent citation run that does not close the sentence', () => {
@@ -416,7 +453,10 @@ describe('composeSynthesizedBrief acronym followed by its citation (#5947)', () 
       lead: 'Citizens were urged to leave the region by the U.S. [1][2] GCC states condemned Iranian attacks on Kuwait [2].',
       lines,
     });
-    assert.equal(composeSynthesizedBrief(adjacentUnioned, topStories, { validatorMode: 'enforce' }), null);
+    const composed = composeSynthesizedBrief(adjacentUnioned, topStories, { validatorMode: 'enforce' });
+    assert.notEqual(composed, null);
+    assert.ok(!composed.lead.includes('U.S.'), 'the unclosed run must not license the US claim');
+    assert.equal(composed.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_UNCITED);
   });
 
   it('accepts an adjacent citation run that does close the sentence', () => {
@@ -463,11 +503,14 @@ describe('composeSynthesizedBrief acronym followed by its citation (#5947)', () 
         lead: 'Chile reported grower losses [1].\nApple cut its regional orders [1].',
         lines,
       });
-      assert.equal(
-        composeSynthesizedBrief(smuggled, topStories, { validatorMode: 'enforce' }),
-        null,
+      const composed = composeSynthesizedBrief(smuggled, topStories, { validatorMode: 'enforce' });
+      assert.notEqual(composed, null);
+      assert.ok(
+        !composed.lead.includes('Apple'),
         '"apple" the fruit must not license "Apple" the company via a newline',
       );
+      assert.match(composed.lead, /Chile reported grower losses/);
+      assert.equal(composed.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_PROPER_NOUN);
     });
 
     it('rejects a lead smuggling a capital past a lowercase abbreviation', () => {
@@ -495,7 +538,10 @@ describe('composeSynthesizedBrief acronym followed by its citation (#5947)', () 
       lead: 'GCC states condemned Iranian attacks on Kuwait [1]. The region was pressured by the U.S. [2026].',
       lines,
     });
-    assert.equal(composeSynthesizedBrief(bracketedYear, topStories, { validatorMode: 'enforce' }), null);
+    const composed = composeSynthesizedBrief(bracketedYear, topStories, { validatorMode: 'enforce' });
+    assert.notEqual(composed, null);
+    assert.ok(!composed.lead.includes('pressured'), 'the year-bracketed fragment stays uncited and never publishes');
+    assert.equal(composed.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_UNCITED);
   });
 
   it('stays closed when an out-of-range marker is stripped down to a bare one', () => {
@@ -505,7 +551,10 @@ describe('composeSynthesizedBrief acronym followed by its citation (#5947)', () 
       lead: 'Citizens were urged to leave the region by the U.S. [999] [2] GCC states condemned Iranian attacks on Kuwait [1].',
       lines,
     });
-    assert.equal(composeSynthesizedBrief(strippedToBare, topStories, { validatorMode: 'enforce' }), null);
+    const composed = composeSynthesizedBrief(strippedToBare, topStories, { validatorMode: 'enforce' });
+    assert.notEqual(composed, null);
+    assert.ok(!composed.lead.includes('U.S.'), 'the stripped bare marker must not collapse — the US claim stays uncited and unpublished');
+    assert.equal(composed.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_UNCITED);
   });
 });
 
@@ -818,8 +867,18 @@ describe('composeSynthesizedBriefResult names which gate rejected (#5947)', () =
     assert.equal(untitled.rejection, BRIEF_REJECTIONS.LEAD_GROUNDING);
   });
 
-  it('names an uncited lead sentence', () => {
+  it('names an uncited lead sentence on the repaired brief', () => {
     const out = compose('Prices rose sharply in Chile last quarter [1]. Analysts expect more increases ahead.');
+    assert.notEqual(out.brief, null, 'the cited sentence still publishes');
+    assert.ok(!out.brief.lead.includes('Analysts expect'));
+    assert.equal(out.brief.droppedLeadRejection, BRIEF_REJECTIONS.LEAD_UNCITED);
+    assert.equal(out.rejection, null);
+  });
+
+  it('names the gate when every lead sentence fails', () => {
+    // The total-failure classification is unchanged by the repair policy: with
+    // no survivors, the FIRST failing sentence's code is the rejection.
+    const out = compose('Analysts expect more increases ahead. Markets may react next week.');
     assert.equal(out.brief, null);
     assert.equal(out.rejection, BRIEF_REJECTIONS.LEAD_UNCITED);
   });

--- a/tests/seed-insights-brief.test.mjs
+++ b/tests/seed-insights-brief.test.mjs
@@ -207,6 +207,68 @@ describe('composeSynthesizedBrief lead sentence boundaries (#5947)', () => {
     assert.match(composed.lead, /U\.S\. embassies/, 'the published lead keeps its original text');
   });
 
+  it('a repaired lead survives the aggregate anchor check when the drop took the second anchor (#7253 review)', () => {
+    // Both reviewers found this independently: checkLeadGrounding demands 2
+    // combined anchor hits on a corpus with >=4 anchor tokens — calibrated for
+    // a FULL lead. Here the hallucinated sentence carried the extra anchors;
+    // dropping it leaves a fully-gated survivor with exactly one ("Kuwait"),
+    // which the aggregate check then rejected, discarding the fresh synthesis
+    // the repair had just saved.
+    const richStories = [
+      {
+        primaryTitle: 'GCC condemns Iranian attacks on Kuwait',
+        primarySource: 'The National',
+        primaryLink: 'http://gcc',
+        sources: ['The National', 'Reuters'],
+        memberTitles: ['GCC condemns Iranian attacks on Kuwait'],
+      },
+      {
+        primaryTitle: 'Pakistan Floods Devastate Punjab Province Villages',
+        primarySource: 'Dawn',
+        primaryLink: 'http://floods',
+        sources: ['Dawn', 'BBC World'],
+        memberTitles: ['Pakistan Floods Devastate Punjab Province Villages'],
+      },
+    ];
+    const richLines = [
+      { n: 1, text: 'GCC condemns Iranian attacks on Kuwait [1]' },
+      { n: 2, text: 'Pakistan floods devastate Punjab villages [2]' },
+    ];
+    // Sentence 1 survives with ONE corpus anchor (Kuwait, via story 1).
+    // Sentence 2 invents Venezuela against story 2 and is dropped — taking
+    // Pakistan/Punjab, the anchors that would have satisfied threshold 2.
+    const repairedShort = JSON.stringify({
+      lead: 'Attacks were condemned in Kuwait [1]. Venezuela flooded Punjab villages [2].',
+      lines: richLines,
+    });
+    const composed = composeSynthesizedBrief(repairedShort, richStories, { validatorMode: 'enforce' });
+    assert.notEqual(composed, null, 'the shortened lead must not be re-rejected by the full-lead threshold');
+    assert.ok(!composed.lead.includes('Venezuela'), 'the invented claim still never publishes');
+    assert.match(composed.lead, /Kuwait \[1\]/);
+    assert.equal(composed.droppedLeadSentences, 1);
+
+    // The anti-mush floor is unconditional: a survivor with ZERO corpus
+    // anchors still rejects, dropped sentences or not. Requirement 1 is what
+    // the relaxed threshold deliberately does not touch.
+    const mushSurvivor = JSON.stringify({
+      lead: 'The situation worsened further overnight [1]. Venezuela flooded Punjab villages [2].',
+      lines: richLines,
+    });
+    const rejected = composeSynthesizedBriefResult(mushSurvivor, richStories, { validatorMode: 'enforce' });
+    assert.equal(rejected.brief, null);
+    assert.equal(rejected.rejection, BRIEF_REJECTIONS.LEAD_GROUNDING);
+
+    // An INTACT lead keeps the original two-hit bar: same corpus, no drops,
+    // single-anchor lead -> still rejected. The relaxation is drop-scoped.
+    const intactSingleAnchor = JSON.stringify({
+      lead: 'Attacks were widely and swiftly condemned across Kuwait [1].',
+      lines: richLines,
+    });
+    const intact = composeSynthesizedBriefResult(intactSingleAnchor, richStories, { validatorMode: 'enforce' });
+    assert.equal(intact.brief, null, 'no drop happened, so the full-lead threshold still applies');
+    assert.equal(intact.rejection, BRIEF_REJECTIONS.LEAD_GROUNDING);
+  });
+
   it('drops a genuinely uncited lead sentence and publishes the cited remainder', () => {
     // Repair policy (2026-08-28): the unverifiable sentence must never reach a
     // reader — but the cited sentence passed every gate, and rejecting the whole

--- a/tests/seed-insights-freshness.test.mjs
+++ b/tests/seed-insights-freshness.test.mjs
@@ -410,8 +410,17 @@ test('the composer rejection reason reaches the failure code through the real se
     resolve('Prices rose sharply in Chile by 42 percent last quarter [1].').failureCode,
     INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_NUMERIC_FACT,
   );
+  // Repair policy (2026-08-28): one uncited sentence beside a cited one is
+  // dropped, not fatal — the seam reports success with the drop surfaced on the
+  // composed brief. The failure CODE path for uncited leads is pinned by the
+  // all-sentences-fail case below.
+  const repaired = resolve('Prices rose sharply in Chile last quarter [1]. Analysts expect more ahead.');
+  assert.equal(repaired.failureCode, null, 'a repairable lead is not a failure');
+  assert.ok(repaired.composed);
+  assert.ok(!repaired.composed.lead.includes('Analysts expect'));
+  assert.equal(repaired.composed.droppedLeadSentences, 1);
   assert.equal(
-    resolve('Prices rose sharply in Chile last quarter [1]. Analysts expect more ahead.').failureCode,
+    resolve('Analysts expect more ahead. Markets may move next week.').failureCode,
     INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_UNCITED,
   );
   assert.equal(


### PR DESCRIPTION
Part 2 of the newsInsights convergence package (#7248 is part 1).

## One bad noun cost a whole cycle of fresh content

One ungrounded noun in one lead sentence rejected the **entire** synthesis — lead and all eight story lines — and fell back to the single-headline brief, which loses to the LKG. In the 2026-08-28 incident that meant 25 consecutive cycles serving an aging brief over a single miscited phrase.

The repair pattern already existed **ten lines below**:

```js
// lead (before): one ungrounded noun → reject EVERYTHING
if (!sentenceValidation.ok) return reject(BRIEF_REJECTIONS.LEAD_PROPER_NOUN, …);

// per-story line (always): same failure → substitute the headline, keep going
if (!validation.ok) { hallucinatedLines++; return { n, text: `${headline} [${n}]` }; }
```

The lead now gets the same policy: a failing sentence is **dropped**, and the brief rejects only when no sentence survives. Every surviving sentence passed every gate — publishing them is editorially identical to publishing the shorter draft the model could have written.

## Preserved, deliberately

- **Total failure classifies exactly as before** — no survivors → the first failing sentence's code and detail become the rejection, so the failure-code vocabulary reaching seed-meta and health is unchanged.
- **The first drop's code/detail ride on the composed brief** (`droppedLeadRejection` / `droppedLeadDetail`) — visible in the Railway log (`[brief_repair]`) and available to #7248's resample-feedback path.
- **Shadow mode** still observes without dropping on the validator gates; uncited and empty-ground drops apply in every mode, as their rejections always did.
- **Byte-identical output when nothing is dropped.** A rebuilt lead differs only by the mid-clause dotted-acronym collapse ("U.S." → "US") — the exact style the system prompt mandates.
- `sourceAttributions` counts only survivors — a dropped sentence's outlet naming never reached a reader.

## The 11 rewritten tests

They asserted the **mechanism** (whole-brief rejection) rather than the **property** (the bad sentence never reaches a reader). Each now asserts the property: offending fragment absent from the published lead, surviving text present, gate named in `droppedLeadRejection`. This keeps their adversarial teeth — the merge/smuggle regressions they pin would now surface as the offending text *reaching* the published lead, which is precisely what the rewritten assertions catch.

## Verification

Mutation-checked in both directions: reverting the repair fails **3** tests; removing the gate (publishing the bad sentence) fails **13**. The suite defends both halves — the repair *and* the property it must not weaken.

**120 tests pass, 0 fail** across seed-insights-brief, seed-insights-freshness, seed-insights-llm-retry, and brief-synthesis-reuse. Biome clean.
