### PR TITLE
fix(insights): stop paying for a synthesis that has failed identically three times

### DIFF
--- a/scripts/_insights-synthesis-diagnostics.mjs
+++ b/scripts/_insights-synthesis-diagnostics.mjs
@@ -48,30 +48,43 @@ const BREAKER_INELIGIBLE_CODES = new Set([
 ]);
 export const INSIGHTS_BREAKER_MIN_CONSECUTIVE = 3;
 
-// Order-sensitive on purpose: the prompt renders stories in order, so a
-// reorder IS a different synthesis input.
-export function insightsStoriesSignature(topStories) {
-  if (!Array.isArray(topStories) || topStories.length === 0) return null;
-  const titles = topStories.map((story) => String(story?.primaryTitle ?? ''));
-  if (titles.every((title) => title === '')) return null;
-  return createHash('sha256').update(titles.join('\u0000')).digest('hex').slice(0, 12);
+// Signature over the RENDERED prompts, not their ingredients (#7255 review,
+// both reviewers): the first version hashed only story titles, but the user
+// prompt also renders each story's outlet label and publisher count, and the
+// system prompt renders the current date — so a prompt that had actually
+// changed could keep the breaker open. Hashing what the model is sent covers
+// every input by construction, and the date inside the system prompt gives an
+// open breaker a natural re-arm at UTC midnight: suppression can never outlive
+// the day it was justified on.
+export function insightsSynthesisSignature(systemPrompt, userPrompt) {
+  const system = typeof systemPrompt === 'string' ? systemPrompt : '';
+  const user = typeof userPrompt === 'string' ? userPrompt : '';
+  if (system === '' && user === '') return null;
+  return createHash('sha256').update(`${system}\u0000${user}`).digest('hex').slice(0, 12);
 }
 
 export function shouldSkipInsightsSynthesis({
   previousMeta,
-  storiesSignature,
+  synthesisSignature,
   minConsecutive = INSIGHTS_BREAKER_MIN_CONSECUTIVE,
 } = {}) {
-  if (typeof storiesSignature !== 'string' || storiesSignature.length === 0) return false;
+  if (typeof synthesisSignature !== 'string' || synthesisSignature.length === 0) return false;
   const previous = previousMeta && typeof previousMeta === 'object' ? previousMeta : null;
   if (!previous) return false;
-  const failures = Number.isInteger(previous.consecutiveFailures) ? previous.consecutiveFailures : 0;
+  // The PER-SIGNATURE counter, not the producer-wide consecutiveFailures
+  // (#7255 review): three provider outages followed by one gate rejection
+  // left the wide counter over the threshold, so the breaker opened after a
+  // SINGLE matching failure. sameSignatureFailures increments only while the
+  // (code, detail, signature) triple repeats exactly and resets on any change
+  // — including a changed rejection detail, because a model producing a
+  // DIFFERENT wrong draft is converging, and retrying it has value.
+  const failures = Number.isInteger(previous.sameSignatureFailures) ? previous.sameSignatureFailures : 0;
   if (failures < minConsecutive) return false;
   const code = previous.lastSynthesisFailureCode;
   if (typeof code !== 'string' || code.length === 0) return false;
   if (!Object.values(INSIGHTS_SYNTHESIS_FAILURE_CODES).includes(code)) return false;
   if (BREAKER_INELIGIBLE_CODES.has(code)) return false;
-  return previous.failedStoriesSignature === storiesSignature;
+  return previous.failedStoriesSignature === synthesisSignature;
 }
 
 // This map refines only the final gate stage. Missing-cluster and parse

--- a/scripts/_insights-synthesis-diagnostics.mjs
+++ b/scripts/_insights-synthesis-diagnostics.mjs
@@ -42,9 +42,12 @@ export const INSIGHTS_COMPOSER_THREW = 'composer-threw';
 //     there is no spend to save.
 //   - The signature must match exactly. Any change in the top stories —
 //     ordering included, since ordering changes the prompt — re-arms synthesis.
-const BREAKER_INELIGIBLE_CODES = new Set([
-  INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
-  INSIGHTS_SYNTHESIS_FAILURE_CODES.MISSING_CLUSTER,
+const BREAKER_ELIGIBLE_CODES = new Set([
+  INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_EMPTY,
+  INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_UNCITED,
+  INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_PROPER_NOUN,
+  INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_NUMERIC_FACT,
+  INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_GROUNDING,
 ]);
 export const INSIGHTS_BREAKER_MIN_CONSECUTIVE = 3;
 
@@ -82,8 +85,7 @@ export function shouldSkipInsightsSynthesis({
   if (failures < minConsecutive) return false;
   const code = previous.lastSynthesisFailureCode;
   if (typeof code !== 'string' || code.length === 0) return false;
-  if (!Object.values(INSIGHTS_SYNTHESIS_FAILURE_CODES).includes(code)) return false;
-  if (BREAKER_INELIGIBLE_CODES.has(code)) return false;
+  if (!BREAKER_ELIGIBLE_CODES.has(code)) return false;
   return previous.failedStoriesSignature === synthesisSignature;
 }
 

--- a/scripts/_insights-synthesis-diagnostics.mjs
+++ b/scripts/_insights-synthesis-diagnostics.mjs
@@ -89,6 +89,25 @@ export function shouldSkipInsightsSynthesis({
   return previous.failedStoriesSignature === synthesisSignature;
 }
 
+// Operator-facing warning for an open breaker. Uses sameSignatureFailures —
+// the count that actually armed the skip — never producer-wide
+// consecutiveFailures, which provider noise can inflate past the threshold
+// while only three matching prompt/failure repeats opened the breaker
+// (#7255 review).
+export function formatInsightsBreakerOpenWarning(previousMeta) {
+  const previous = previousMeta && typeof previousMeta === 'object' ? previousMeta : {};
+  const code = typeof previous.lastSynthesisFailureCode === 'string'
+    && previous.lastSynthesisFailureCode.length > 0
+    ? previous.lastSynthesisFailureCode
+    : 'unknown';
+  const repeats = Number.isInteger(previous.sameSignatureFailures) && previous.sameSignatureFailures > 0
+    ? previous.sameSignatureFailures
+    : 0;
+  return `  [brief_synthesis] breaker open: ${code} `
+    + `x${repeats} on an unchanged story set — `
+    + 'skipping synthesis spend until the stories change';
+}
+
 // This map refines only the final gate stage. Missing-cluster and parse
 // failures are classified by the earlier stage checks below.
 const INSIGHTS_GATE_REASON_CODES = new Map([

--- a/scripts/_insights-synthesis-diagnostics.mjs
+++ b/scripts/_insights-synthesis-diagnostics.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { isBriefLeadEligible } from './_clustering.mjs';
 import {
   BRIEF_REJECTIONS,
@@ -24,6 +25,54 @@ export const INSIGHTS_SYNTHESIS_FAILURE_CODES = Object.freeze({
 // Local sentinel for "the composer threw". The composer never returns it, so
 // it stays outside the BRIEF_REJECTIONS vocabulary.
 export const INSIGHTS_COMPOSER_THREW = 'composer-threw';
+
+// ---------------------------------------------------------------- breaker ---
+// Cross-cycle repeat breaker (2026-08-28). The seeder retried an identical
+// failing synthesis every cycle for four hours — 25 consecutive
+// LEAD_PROPER_NOUN rejections on the same phrase against the same story set,
+// each burning paid provider calls to produce nothing. The resample-feedback
+// and lead-repair changes make an identical repeat much rarer; this is the
+// backstop for whatever residue remains: when the SAME gate failure has
+// repeated against the SAME story set, skip the spend until the stories change.
+//
+// Deliberately narrow:
+//   - PROVIDER never trips it — a transport outage is not deterministic, and
+//     the chain itself varies between cycles.
+//   - MISSING_CLUSTER never trips it — no LLM call happens on that path, so
+//     there is no spend to save.
+//   - The signature must match exactly. Any change in the top stories —
+//     ordering included, since ordering changes the prompt — re-arms synthesis.
+const BREAKER_INELIGIBLE_CODES = new Set([
+  INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
+  INSIGHTS_SYNTHESIS_FAILURE_CODES.MISSING_CLUSTER,
+]);
+export const INSIGHTS_BREAKER_MIN_CONSECUTIVE = 3;
+
+// Order-sensitive on purpose: the prompt renders stories in order, so a
+// reorder IS a different synthesis input.
+export function insightsStoriesSignature(topStories) {
+  if (!Array.isArray(topStories) || topStories.length === 0) return null;
+  const titles = topStories.map((story) => String(story?.primaryTitle ?? ''));
+  if (titles.every((title) => title === '')) return null;
+  return createHash('sha256').update(titles.join('\u0000')).digest('hex').slice(0, 12);
+}
+
+export function shouldSkipInsightsSynthesis({
+  previousMeta,
+  storiesSignature,
+  minConsecutive = INSIGHTS_BREAKER_MIN_CONSECUTIVE,
+} = {}) {
+  if (typeof storiesSignature !== 'string' || storiesSignature.length === 0) return false;
+  const previous = previousMeta && typeof previousMeta === 'object' ? previousMeta : null;
+  if (!previous) return false;
+  const failures = Number.isInteger(previous.consecutiveFailures) ? previous.consecutiveFailures : 0;
+  if (failures < minConsecutive) return false;
+  const code = previous.lastSynthesisFailureCode;
+  if (typeof code !== 'string' || code.length === 0) return false;
+  if (!Object.values(INSIGHTS_SYNTHESIS_FAILURE_CODES).includes(code)) return false;
+  if (BREAKER_INELIGIBLE_CODES.has(code)) return false;
+  return previous.failedStoriesSignature === storiesSignature;
+}
 
 // This map refines only the final gate stage. Missing-cluster and parse
 // failures are classified by the earlier stage checks below.

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -925,7 +925,7 @@ async function fetchInsights() {
   if (synthesisBreakerOpen) {
     console.warn(
       `  [brief_synthesis] breaker open: ${previousFreshnessMeta?.lastSynthesisFailureCode} `
-      + `x${previousFreshnessMeta?.consecutiveFailures} on an unchanged story set — `
+      + `x${previousFreshnessMeta?.sameSignatureFailures} on an unchanged story set — `
       + 'skipping synthesis spend until the stories change',
     );
   }

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -37,7 +37,7 @@ import {
   classifyInsightsSynthesisFailure,
   composeInsightsSynthesis,
   resolveInsightsSynthesis,
-  insightsStoriesSignature,
+  insightsSynthesisSignature,
   shouldSkipInsightsSynthesis,
 } from './_insights-synthesis-diagnostics.mjs';
 export {
@@ -225,6 +225,21 @@ export function buildInsightsFreshnessMetaPatch({
   const boundedSignature = typeof storiesSignature === 'string' && storiesSignature.length > 0
     ? storiesSignature.slice(0, 16)
     : null;
+  // Per-signature repeat counter (#7255 review). consecutiveFailures counts
+  // every degraded run producer-wide, so provider noise inflated it past the
+  // breaker threshold before a gate failure ever repeated. This counter
+  // increments only while the (code, detail, signature) triple repeats
+  // EXACTLY, and resets to 1 on any change.
+  const previousSameSignature = Number.isInteger(previous.sameSignatureFailures) && previous.sameSignatureFailures > 0
+    ? previous.sameSignatureFailures
+    : 0;
+  const failureCodeForMeta = normalizedFailureCode || INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER;
+  const repeatsPrevious = previousSameSignature > 0 || previous.lastSynthesisFailureCode
+    ? failureCodeForMeta === previous.lastSynthesisFailureCode
+      && (boundedDetail ?? null) === (previous.lastSynthesisFailureDetail ?? null)
+      && boundedSignature !== null
+      && boundedSignature === (previous.failedStoriesSignature ?? null)
+    : false;
 
   if (outcome === INSIGHTS_RUN_OUTCOMES.PUBLISHED) {
     return {
@@ -232,6 +247,7 @@ export function buildInsightsFreshnessMetaPatch({
       lastSuccessAt: now,
       servedGeneratedAt: servedAt,
       consecutiveFailures: 0,
+      sameSignatureFailures: 0,
       lastSynthesisFailureCode: normalizedFailureCode,
       lastSynthesisFailureDetail: null,
       failedStoriesSignature: null,
@@ -244,7 +260,10 @@ export function buildInsightsFreshnessMetaPatch({
     lastSuccessAt: Number.isFinite(previous.lastSuccessAt) ? previous.lastSuccessAt : null,
     servedGeneratedAt: servedAt,
     consecutiveFailures: Math.min(INSIGHTS_MAX_CONSECUTIVE_FAILURES, previousFailures + 1),
-    lastSynthesisFailureCode: normalizedFailureCode || INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
+    sameSignatureFailures: repeatsPrevious
+      ? Math.min(INSIGHTS_MAX_CONSECUTIVE_FAILURES, previousSameSignature + 1)
+      : 1,
+    lastSynthesisFailureCode: failureCodeForMeta,
     lastSynthesisFailureDetail: boundedDetail,
     failedStoriesSignature: boundedSignature,
     briefEligibleClusters: eligibleClusters,
@@ -894,10 +913,14 @@ async function fetchInsights() {
   // resample/repair machinery has already had its chance on each. Re-arms the
   // moment the story set (and therefore the prompt) changes.
   const previousFreshnessMeta = await readExistingSeedMeta('news', 'insights');
-  const storiesSignature = insightsStoriesSignature(topStories);
+  // The signature hashes the exact prompts callLLM is about to send — computed
+  // here, passed there, one source of truth.
+  const synthesisSystem = synthesisSystemPrompt(new Date().toISOString().split('T')[0]);
+  const synthesisUser = synthesisUserPrompt(topStories);
+  const storiesSignature = insightsSynthesisSignature(synthesisSystem, synthesisUser);
   const synthesisBreakerOpen = hasBriefCluster && shouldSkipInsightsSynthesis({
     previousMeta: previousFreshnessMeta,
-    storiesSignature,
+    synthesisSignature: storiesSignature,
   });
   if (synthesisBreakerOpen) {
     console.warn(
@@ -908,8 +931,8 @@ async function fetchInsights() {
   }
   const synthesisResult = hasBriefCluster && !synthesisBreakerOpen
     ? await callLLM(null, {
-        systemPrompt: synthesisSystemPrompt(new Date().toISOString().split('T')[0]),
-        userPrompt: synthesisUserPrompt(topStories),
+        systemPrompt: synthesisSystem,
+        userPrompt: synthesisUser,
         maxTokens: 900,
         // A model whose output trips the editorial gates must not strand the
         // run. callLLM resamples this model once before demoting to a weaker
@@ -917,6 +940,7 @@ async function fetchInsights() {
         accept: composeFromText,
       })
     : null;
+  let breakerCarriedDetail = null;
   const { composed, failureCode, failureDetail } = synthesisBreakerOpen
     ? { composed: null, failureCode: null, failureDetail: null }
     : resolveInsightsSynthesis({
@@ -935,6 +959,14 @@ async function fetchInsights() {
     synthesisFailureCode = normalizeInsightsFailureCode(previousFreshnessMeta?.lastSynthesisFailureCode)
       ?? INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER;
     status = 'degraded';
+    // Carry the standing detail too: a skipped run repeats the previous
+    // failure identically, and the per-signature counter downstream matches on
+    // (code, detail, signature) — a null detail here would read as a CHANGED
+    // failure, reset the counter, and flap the breaker open/closed every other
+    // run.
+    breakerCarriedDetail = typeof previousFreshnessMeta?.lastSynthesisFailureDetail === 'string'
+      ? previousFreshnessMeta.lastSynthesisFailureDetail
+      : null;
   } else if (composed) {
     worldBrief = composed.lead;
     briefStoryLines = composed.lines;
@@ -1084,7 +1116,7 @@ async function fetchInsights() {
         {
           outcome: INSIGHTS_RUN_OUTCOMES.LKG_PRESERVED,
           failureCode: synthesisFailureCode || INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
-          failureDetail,
+          failureDetail: breakerCarriedDetail ?? failureDetail,
           storiesSignature,
           briefEligibleClusters,
         },
@@ -1095,7 +1127,7 @@ async function fetchInsights() {
   return decorateInsightsRun(payload, {
     outcome: status === 'ok' ? INSIGHTS_RUN_OUTCOMES.PUBLISHED : INSIGHTS_RUN_OUTCOMES.DEGRADED,
     failureCode: synthesisFailureCode,
-    failureDetail,
+    failureDetail: breakerCarriedDetail ?? failureDetail,
     storiesSignature,
     briefEligibleClusters,
   });

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -39,6 +39,7 @@ import {
   resolveInsightsSynthesis,
   insightsSynthesisSignature,
   shouldSkipInsightsSynthesis,
+  formatInsightsBreakerOpenWarning,
 } from './_insights-synthesis-diagnostics.mjs';
 export {
   INSIGHTS_COMPOSER_THREW,
@@ -923,11 +924,7 @@ async function fetchInsights() {
     synthesisSignature: storiesSignature,
   });
   if (synthesisBreakerOpen) {
-    console.warn(
-      `  [brief_synthesis] breaker open: ${previousFreshnessMeta?.lastSynthesisFailureCode} `
-      + `x${previousFreshnessMeta?.sameSignatureFailures} on an unchanged story set — `
-      + 'skipping synthesis spend until the stories change',
-    );
+    console.warn(formatInsightsBreakerOpenWarning(previousFreshnessMeta));
   }
   const synthesisResult = hasBriefCluster && !synthesisBreakerOpen
     ? await callLLM(null, {

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -37,6 +37,8 @@ import {
   classifyInsightsSynthesisFailure,
   composeInsightsSynthesis,
   resolveInsightsSynthesis,
+  insightsStoriesSignature,
+  shouldSkipInsightsSynthesis,
 } from './_insights-synthesis-diagnostics.mjs';
 export {
   INSIGHTS_COMPOSER_THREW,
@@ -197,6 +199,8 @@ export function buildInsightsFreshnessMetaPatch({
   previousMeta,
   outcome,
   failureCode = null,
+  failureDetail = null,
+  storiesSignature = null,
   nowMs = Date.now(),
   servedGeneratedAt = null,
   briefEligibleClusters = null,
@@ -212,6 +216,16 @@ export function buildInsightsFreshnessMetaPatch({
   const normalizedFailureCode = failureCode == null ? null : normalizeInsightsFailureCode(failureCode);
   const eligibleClusters = normalizeBriefEligibleClusters(briefEligibleClusters);
 
+  // Bounded breaker inputs (see shouldSkipInsightsSynthesis): what failed and
+  // against which story set. Cleared on publish so a stale pair can never
+  // suppress a later synthesis of a genuinely different run.
+  const boundedDetail = typeof failureDetail === 'string' && failureDetail.length > 0
+    ? failureDetail.replace(/\s+/g, ' ').trim().slice(0, 80)
+    : null;
+  const boundedSignature = typeof storiesSignature === 'string' && storiesSignature.length > 0
+    ? storiesSignature.slice(0, 16)
+    : null;
+
   if (outcome === INSIGHTS_RUN_OUTCOMES.PUBLISHED) {
     return {
       lastAttemptAt: now,
@@ -219,6 +233,8 @@ export function buildInsightsFreshnessMetaPatch({
       servedGeneratedAt: servedAt,
       consecutiveFailures: 0,
       lastSynthesisFailureCode: normalizedFailureCode,
+      lastSynthesisFailureDetail: null,
+      failedStoriesSignature: null,
       briefEligibleClusters: eligibleClusters,
     };
   }
@@ -229,6 +245,8 @@ export function buildInsightsFreshnessMetaPatch({
     servedGeneratedAt: servedAt,
     consecutiveFailures: Math.min(INSIGHTS_MAX_CONSECUTIVE_FAILURES, previousFailures + 1),
     lastSynthesisFailureCode: normalizedFailureCode || INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
+    lastSynthesisFailureDetail: boundedDetail,
+    failedStoriesSignature: boundedSignature,
     briefEligibleClusters: eligibleClusters,
   };
 }
@@ -871,7 +889,24 @@ async function fetchInsights() {
   // SECOND callLLM. Stamp the run's LLM start so L2 gets only the remainder —
   // otherwise two full 60s budgets could outlast the 120s seed lock.
   const llmRunStartedAtMs = Date.now();
-  const synthesisResult = hasBriefCluster
+  // Repeat breaker: same gate failure, same story set, three cycles running —
+  // a fourth identical paid call cannot succeed where three did not, and the
+  // resample/repair machinery has already had its chance on each. Re-arms the
+  // moment the story set (and therefore the prompt) changes.
+  const previousFreshnessMeta = await readExistingSeedMeta('news', 'insights');
+  const storiesSignature = insightsStoriesSignature(topStories);
+  const synthesisBreakerOpen = hasBriefCluster && shouldSkipInsightsSynthesis({
+    previousMeta: previousFreshnessMeta,
+    storiesSignature,
+  });
+  if (synthesisBreakerOpen) {
+    console.warn(
+      `  [brief_synthesis] breaker open: ${previousFreshnessMeta?.lastSynthesisFailureCode} `
+      + `x${previousFreshnessMeta?.consecutiveFailures} on an unchanged story set — `
+      + 'skipping synthesis spend until the stories change',
+    );
+  }
+  const synthesisResult = hasBriefCluster && !synthesisBreakerOpen
     ? await callLLM(null, {
         systemPrompt: synthesisSystemPrompt(new Date().toISOString().split('T')[0]),
         userPrompt: synthesisUserPrompt(topStories),
@@ -882,14 +917,25 @@ async function fetchInsights() {
         accept: composeFromText,
       })
     : null;
-  const { composed, failureCode, failureDetail } = resolveInsightsSynthesis({
-    synthesisResult,
-    topStories,
-    ...synthesisComposerOptions,
-  });
+  const { composed, failureCode, failureDetail } = synthesisBreakerOpen
+    ? { composed: null, failureCode: null, failureDetail: null }
+    : resolveInsightsSynthesis({
+      synthesisResult,
+      topStories,
+      ...synthesisComposerOptions,
+    });
   synthesisFailureCode = failureCode;
 
-  if (composed) {
+  if (synthesisBreakerOpen) {
+    // Preserve the TRUE cause. Classifying this run's null synthesisResult
+    // would report PROVIDER — but no provider was asked; the standing failure
+    // is whatever kept failing before the breaker opened. L2 is skipped as
+    // well: it is a second paid call, and the LKG it would lose to is already
+    // being served.
+    synthesisFailureCode = normalizeInsightsFailureCode(previousFreshnessMeta?.lastSynthesisFailureCode)
+      ?? INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER;
+    status = 'degraded';
+  } else if (composed) {
     worldBrief = composed.lead;
     briefStoryLines = composed.lines;
     worldBriefSources = composed.sources;
@@ -1038,6 +1084,8 @@ async function fetchInsights() {
         {
           outcome: INSIGHTS_RUN_OUTCOMES.LKG_PRESERVED,
           failureCode: synthesisFailureCode || INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
+          failureDetail,
+          storiesSignature,
           briefEligibleClusters,
         },
       );
@@ -1047,6 +1095,8 @@ async function fetchInsights() {
   return decorateInsightsRun(payload, {
     outcome: status === 'ok' ? INSIGHTS_RUN_OUTCOMES.PUBLISHED : INSIGHTS_RUN_OUTCOMES.DEGRADED,
     failureCode: synthesisFailureCode,
+    failureDetail,
+    storiesSignature,
     briefEligibleClusters,
   });
 }
@@ -1077,6 +1127,8 @@ export function insightsFreshnessPatchArgs(data, outcome, previousMeta, nowMs = 
     previousMeta,
     outcome,
     failureCode: runMeta?.failureCode,
+    failureDetail: runMeta?.failureDetail ?? null,
+    storiesSignature: runMeta?.storiesSignature ?? null,
     nowMs,
     servedGeneratedAt: data?.generatedAt,
     briefEligibleClusters: runMeta?.briefEligibleClusters ?? null,

--- a/tests/seed-insights-freshness.test.mjs
+++ b/tests/seed-insights-freshness.test.mjs
@@ -621,6 +621,9 @@ test('the breaker opens on the per-signature counter, never the producer-wide on
   for (const code of [
     INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
     INSIGHTS_SYNTHESIS_FAILURE_CODES.MISSING_CLUSTER,
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.PARSE,
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.GATE,
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.COMPOSER_ERROR,
   ]) {
     assert.equal(
       shouldSkipInsightsSynthesis({
@@ -629,6 +632,23 @@ test('the breaker opens on the per-signature counter, never the producer-wide on
       }),
       false,
       `${code} must never open the breaker`,
+    );
+  }
+
+  for (const code of [
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_EMPTY,
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_UNCITED,
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_PROPER_NOUN,
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_NUMERIC_FACT,
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_GROUNDING,
+  ]) {
+    assert.equal(
+      shouldSkipInsightsSynthesis({
+        previousMeta: meta({ lastSynthesisFailureCode: code }),
+        synthesisSignature: sig,
+      }),
+      true,
+      `${code} can open the breaker after repeated identical gate failures`,
     );
   }
 

--- a/tests/seed-insights-freshness.test.mjs
+++ b/tests/seed-insights-freshness.test.mjs
@@ -10,11 +10,14 @@ import {
   validateInsightsPayload,
 } from '../scripts/seed-insights.mjs';
 import {
+  INSIGHTS_BREAKER_MIN_CONSECUTIVE,
   INSIGHTS_COMPOSER_THREW,
   INSIGHTS_SYNTHESIS_FAILURE_CODES,
   classifyInsightsSynthesisFailure,
   composeInsightsSynthesis,
+  insightsStoriesSignature,
   resolveInsightsSynthesis,
+  shouldSkipInsightsSynthesis,
 } from '../scripts/_insights-synthesis-diagnostics.mjs';
 import { BRIEF_REJECTIONS } from '../scripts/_insights-brief.mjs';
 import { __testing__ as healthTesting } from '../api/health.js';
@@ -555,4 +558,130 @@ test('a rejected synthesized brief keeps a successful legacy fallback degraded',
     resolveInsightsFallbackStatus({ synthesisFailureCode: null, legacyStatus: 'ok' }),
     'ok',
   );
+});
+
+
+// ---------------------------------------------------------------- breaker ---
+// 2026-08-28: 25 consecutive identical gate rejections, one paid call every
+// cycle for four hours, against a story set that never changed. The breaker is
+// the backstop behind the resample-feedback and lead-repair changes: same gate
+// failure + same story set + three cycles running => skip the spend.
+
+const SIGNED_STORIES = [
+  { primaryTitle: 'Nepal floods kill hundreds' },
+  { primaryTitle: 'Russia strikes Ukrainian ports' },
+];
+
+test('insightsStoriesSignature is stable, order-sensitive, and null on empty', () => {
+  const sig = insightsStoriesSignature(SIGNED_STORIES);
+  assert.match(sig, /^[0-9a-f]{12}$/);
+  assert.equal(insightsStoriesSignature(SIGNED_STORIES), sig, 'same stories, same signature');
+  assert.notEqual(
+    insightsStoriesSignature([...SIGNED_STORIES].reverse()),
+    sig,
+    'the prompt renders stories in order, so a reorder IS a different input',
+  );
+  assert.equal(insightsStoriesSignature([]), null);
+  assert.equal(insightsStoriesSignature(undefined), null);
+  assert.equal(insightsStoriesSignature([{ primaryTitle: '' }]), null, 'all-empty titles sign nothing');
+});
+
+test('the breaker opens only on a repeated gate failure against the same story set', () => {
+  const sig = insightsStoriesSignature(SIGNED_STORIES);
+  const meta = (over = {}) => ({
+    consecutiveFailures: INSIGHTS_BREAKER_MIN_CONSECUTIVE,
+    lastSynthesisFailureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_PROPER_NOUN,
+    failedStoriesSignature: sig,
+    ...over,
+  });
+
+  assert.equal(shouldSkipInsightsSynthesis({ previousMeta: meta(), storiesSignature: sig }), true);
+
+  // Below the threshold: the resample/repair machinery still gets its chances.
+  assert.equal(
+    shouldSkipInsightsSynthesis({
+      previousMeta: meta({ consecutiveFailures: INSIGHTS_BREAKER_MIN_CONSECUTIVE - 1 }),
+      storiesSignature: sig,
+    }),
+    false,
+  );
+
+  // A changed story set re-arms synthesis — that is the whole exit condition.
+  assert.equal(
+    shouldSkipInsightsSynthesis({
+      previousMeta: meta(),
+      storiesSignature: insightsStoriesSignature([...SIGNED_STORIES].reverse()),
+    }),
+    false,
+  );
+
+  // PROVIDER is transport, not determinism; MISSING_CLUSTER never spends.
+  for (const code of [
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
+    INSIGHTS_SYNTHESIS_FAILURE_CODES.MISSING_CLUSTER,
+  ]) {
+    assert.equal(
+      shouldSkipInsightsSynthesis({
+        previousMeta: meta({ lastSynthesisFailureCode: code }),
+        storiesSignature: sig,
+      }),
+      false,
+      `${code} must never open the breaker`,
+    );
+  }
+
+  // Pre-rollout metas carry no signature; absent evidence must not skip spend.
+  assert.equal(
+    shouldSkipInsightsSynthesis({
+      previousMeta: meta({ failedStoriesSignature: undefined }),
+      storiesSignature: sig,
+    }),
+    false,
+  );
+  // A garbage code (not in the vocabulary) must not open it either.
+  assert.equal(
+    shouldSkipInsightsSynthesis({
+      previousMeta: meta({ lastSynthesisFailureCode: 'INSIGHTS_SYNTHESIS_SOMETHING_NEW' }),
+      storiesSignature: sig,
+    }),
+    false,
+  );
+  assert.equal(shouldSkipInsightsSynthesis({ previousMeta: null, storiesSignature: sig }), false);
+  assert.equal(shouldSkipInsightsSynthesis({ previousMeta: meta(), storiesSignature: null }), false);
+});
+
+test('a failed run persists the breaker pair; a publish clears it', () => {
+  const sig = insightsStoriesSignature(SIGNED_STORIES);
+  const failed = buildInsightsFreshnessMetaPatch({
+    previousMeta: { consecutiveFailures: 2 },
+    outcome: 'degraded',
+    failureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_PROPER_NOUN,
+    failureDetail: '  strait   of\nhormuz  ',
+    storiesSignature: sig,
+  });
+  assert.equal(failed.failedStoriesSignature, sig);
+  assert.equal(failed.lastSynthesisFailureDetail, 'strait of hormuz', 'detail is flattened and bounded');
+  assert.equal(failed.consecutiveFailures, 3);
+
+  const published = buildInsightsFreshnessMetaPatch({
+    previousMeta: failed,
+    outcome: 'published',
+    storiesSignature: sig,
+  });
+  assert.equal(published.failedStoriesSignature, null, 'a publish clears the pair');
+  assert.equal(published.lastSynthesisFailureDetail, null);
+  assert.equal(published.consecutiveFailures, 0);
+});
+
+test('the run-meta seam projects detail and signature into the patch args', () => {
+  const sig = insightsStoriesSignature(SIGNED_STORIES);
+  const decorated = decorateInsightsRun({ generatedAt: '2026-08-28T10:00:00.000Z' }, {
+    outcome: 'degraded',
+    failureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_PROPER_NOUN,
+    failureDetail: 'strait of hormuz',
+    storiesSignature: sig,
+  });
+  const args = insightsFreshnessPatchArgs(decorated, 'degraded', {});
+  assert.equal(args.failureDetail, 'strait of hormuz');
+  assert.equal(args.storiesSignature, sig);
 });

--- a/tests/seed-insights-freshness.test.mjs
+++ b/tests/seed-insights-freshness.test.mjs
@@ -15,7 +15,7 @@ import {
   INSIGHTS_SYNTHESIS_FAILURE_CODES,
   classifyInsightsSynthesisFailure,
   composeInsightsSynthesis,
-  insightsStoriesSignature,
+  insightsSynthesisSignature,
   resolveInsightsSynthesis,
   shouldSkipInsightsSynthesis,
 } from '../scripts/_insights-synthesis-diagnostics.mjs';
@@ -564,58 +564,60 @@ test('a rejected synthesized brief keeps a successful legacy fallback degraded',
 // ---------------------------------------------------------------- breaker ---
 // 2026-08-28: 25 consecutive identical gate rejections, one paid call every
 // cycle for four hours, against a story set that never changed. The breaker is
-// the backstop behind the resample-feedback and lead-repair changes: same gate
-// failure + same story set + three cycles running => skip the spend.
+// the backstop behind the resample-feedback and lead-repair changes.
+//
+// #7255 review hardened both halves: the signature hashes the RENDERED prompts
+// (titles alone missed outlet labels, publisher counts, and the date), and the
+// threshold reads a PER-SIGNATURE repeat counter (the producer-wide
+// consecutiveFailures let provider noise arm the breaker for a single gate
+// failure).
 
-const SIGNED_STORIES = [
-  { primaryTitle: 'Nepal floods kill hundreds' },
-  { primaryTitle: 'Russia strikes Ukrainian ports' },
-];
+const SYS = 'system prompt for 2026-08-28';
+const USER = 'Stories:\n1. Nepal floods kill hundreds (Reuters, 3 sources)\n\nCompile the world brief JSON.';
 
-test('insightsStoriesSignature is stable, order-sensitive, and null on empty', () => {
-  const sig = insightsStoriesSignature(SIGNED_STORIES);
+test('insightsSynthesisSignature hashes the rendered prompts, so ANY prompt change re-arms', () => {
+  const sig = insightsSynthesisSignature(SYS, USER);
   assert.match(sig, /^[0-9a-f]{12}$/);
-  assert.equal(insightsStoriesSignature(SIGNED_STORIES), sig, 'same stories, same signature');
-  assert.notEqual(
-    insightsStoriesSignature([...SIGNED_STORIES].reverse()),
-    sig,
-    'the prompt renders stories in order, so a reorder IS a different input',
-  );
-  assert.equal(insightsStoriesSignature([]), null);
-  assert.equal(insightsStoriesSignature(undefined), null);
-  assert.equal(insightsStoriesSignature([{ primaryTitle: '' }]), null, 'all-empty titles sign nothing');
+  assert.equal(insightsSynthesisSignature(SYS, USER), sig, 'same prompts, same signature');
+  // The three inputs the title-only signature missed (#7255 review):
+  assert.notEqual(insightsSynthesisSignature('system prompt for 2026-08-29', USER), sig, 'the date is in the system prompt — UTC midnight re-arms');
+  assert.notEqual(insightsSynthesisSignature(SYS, USER.replace('Reuters', 'AP News')), sig, 'an outlet change is a prompt change');
+  assert.notEqual(insightsSynthesisSignature(SYS, USER.replace('3 sources', '4 sources')), sig, 'a publisher-count change is a prompt change');
+  assert.equal(insightsSynthesisSignature('', ''), null);
 });
 
-test('the breaker opens only on a repeated gate failure against the same story set', () => {
-  const sig = insightsStoriesSignature(SIGNED_STORIES);
+test('the breaker opens on the per-signature counter, never the producer-wide one', () => {
+  const sig = insightsSynthesisSignature(SYS, USER);
   const meta = (over = {}) => ({
-    consecutiveFailures: INSIGHTS_BREAKER_MIN_CONSECUTIVE,
+    consecutiveFailures: 10,
+    sameSignatureFailures: INSIGHTS_BREAKER_MIN_CONSECUTIVE,
     lastSynthesisFailureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_PROPER_NOUN,
     failedStoriesSignature: sig,
     ...over,
   });
 
-  assert.equal(shouldSkipInsightsSynthesis({ previousMeta: meta(), storiesSignature: sig }), true);
+  assert.equal(shouldSkipInsightsSynthesis({ previousMeta: meta(), synthesisSignature: sig }), true);
 
-  // Below the threshold: the resample/repair machinery still gets its chances.
+  // Provider noise inflating the WIDE counter must not arm the breaker for a
+  // single matching gate failure — the exact defect the review found.
   assert.equal(
     shouldSkipInsightsSynthesis({
-      previousMeta: meta({ consecutiveFailures: INSIGHTS_BREAKER_MIN_CONSECUTIVE - 1 }),
-      storiesSignature: sig,
+      previousMeta: meta({ consecutiveFailures: 10, sameSignatureFailures: 1 }),
+      synthesisSignature: sig,
     }),
     false,
+    'one matching failure after unrelated noise must not open the breaker',
   );
 
-  // A changed story set re-arms synthesis — that is the whole exit condition.
   assert.equal(
     shouldSkipInsightsSynthesis({
       previousMeta: meta(),
-      storiesSignature: insightsStoriesSignature([...SIGNED_STORIES].reverse()),
+      synthesisSignature: insightsSynthesisSignature(SYS, `${USER} changed`),
     }),
     false,
+    'a changed prompt re-arms synthesis',
   );
 
-  // PROVIDER is transport, not determinism; MISSING_CLUSTER never spends.
   for (const code of [
     INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER,
     INSIGHTS_SYNTHESIS_FAILURE_CODES.MISSING_CLUSTER,
@@ -623,35 +625,70 @@ test('the breaker opens only on a repeated gate failure against the same story s
     assert.equal(
       shouldSkipInsightsSynthesis({
         previousMeta: meta({ lastSynthesisFailureCode: code }),
-        storiesSignature: sig,
+        synthesisSignature: sig,
       }),
       false,
       `${code} must never open the breaker`,
     );
   }
 
-  // Pre-rollout metas carry no signature; absent evidence must not skip spend.
+  // Pre-rollout metas lack the per-signature counter; absent evidence must
+  // not skip spend.
   assert.equal(
     shouldSkipInsightsSynthesis({
-      previousMeta: meta({ failedStoriesSignature: undefined }),
-      storiesSignature: sig,
+      previousMeta: meta({ sameSignatureFailures: undefined }),
+      synthesisSignature: sig,
     }),
     false,
   );
-  // A garbage code (not in the vocabulary) must not open it either.
-  assert.equal(
-    shouldSkipInsightsSynthesis({
-      previousMeta: meta({ lastSynthesisFailureCode: 'INSIGHTS_SYNTHESIS_SOMETHING_NEW' }),
-      storiesSignature: sig,
-    }),
-    false,
-  );
-  assert.equal(shouldSkipInsightsSynthesis({ previousMeta: null, storiesSignature: sig }), false);
-  assert.equal(shouldSkipInsightsSynthesis({ previousMeta: meta(), storiesSignature: null }), false);
+  assert.equal(shouldSkipInsightsSynthesis({ previousMeta: null, synthesisSignature: sig }), false);
+  assert.equal(shouldSkipInsightsSynthesis({ previousMeta: meta(), synthesisSignature: null }), false);
+});
+
+test('the per-signature counter increments only on an EXACT repeat and resets on any change', () => {
+  const sig = insightsSynthesisSignature(SYS, USER);
+  const fail = (previousMeta, over = {}) => buildInsightsFreshnessMetaPatch({
+    previousMeta,
+    outcome: 'degraded',
+    failureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_PROPER_NOUN,
+    failureDetail: 'strait of hormuz',
+    storiesSignature: sig,
+    ...over,
+  });
+
+  // Identical triple: 1 -> 2 -> 3.
+  let meta = fail({});
+  assert.equal(meta.sameSignatureFailures, 1);
+  meta = fail(meta);
+  assert.equal(meta.sameSignatureFailures, 2);
+  meta = fail(meta);
+  assert.equal(meta.sameSignatureFailures, 3);
+
+  // Provider noise in between: wide counter keeps climbing, per-signature
+  // counter RESETS — three noise failures then one gate failure reads 1.
+  let noisy = buildInsightsFreshnessMetaPatch({ previousMeta: {}, outcome: 'degraded', failureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER });
+  noisy = buildInsightsFreshnessMetaPatch({ previousMeta: noisy, outcome: 'degraded', failureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER });
+  noisy = buildInsightsFreshnessMetaPatch({ previousMeta: noisy, outcome: 'degraded', failureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.PROVIDER });
+  assert.ok(noisy.consecutiveFailures >= 3, 'the wide counter sees the noise');
+  const afterNoise = fail(noisy);
+  assert.equal(afterNoise.sameSignatureFailures, 1, 'a first gate failure after noise starts at 1');
+
+  // A changed rejection DETAIL is a different (converging) failure: reset.
+  const changedDetail = fail(meta, { failureDetail: 'some other phrase' });
+  assert.equal(changedDetail.sameSignatureFailures, 1, 'a model producing a different wrong draft is converging — retry has value');
+
+  // A changed signature resets too.
+  const changedSig = fail(meta, { storiesSignature: insightsSynthesisSignature(SYS, `${USER}!`) });
+  assert.equal(changedSig.sameSignatureFailures, 1);
+
+  // A publish clears everything.
+  const published = buildInsightsFreshnessMetaPatch({ previousMeta: meta, outcome: 'published', storiesSignature: sig });
+  assert.equal(published.sameSignatureFailures, 0);
+  assert.equal(published.failedStoriesSignature, null);
 });
 
 test('a failed run persists the breaker pair; a publish clears it', () => {
-  const sig = insightsStoriesSignature(SIGNED_STORIES);
+  const sig = insightsSynthesisSignature(SYS, USER);
   const failed = buildInsightsFreshnessMetaPatch({
     previousMeta: { consecutiveFailures: 2 },
     outcome: 'degraded',
@@ -674,7 +711,7 @@ test('a failed run persists the breaker pair; a publish clears it', () => {
 });
 
 test('the run-meta seam projects detail and signature into the patch args', () => {
-  const sig = insightsStoriesSignature(SIGNED_STORIES);
+  const sig = insightsSynthesisSignature(SYS, USER);
   const decorated = decorateInsightsRun({ generatedAt: '2026-08-28T10:00:00.000Z' }, {
     outcome: 'degraded',
     failureCode: INSIGHTS_SYNTHESIS_FAILURE_CODES.LEAD_PROPER_NOUN,

--- a/tests/seed-insights-freshness.test.mjs
+++ b/tests/seed-insights-freshness.test.mjs
@@ -15,6 +15,7 @@ import {
   INSIGHTS_SYNTHESIS_FAILURE_CODES,
   classifyInsightsSynthesisFailure,
   composeInsightsSynthesis,
+  formatInsightsBreakerOpenWarning,
   insightsSynthesisSignature,
   resolveInsightsSynthesis,
   shouldSkipInsightsSynthesis,
@@ -663,6 +664,19 @@ test('the breaker opens on the per-signature counter, never the producer-wide on
   );
   assert.equal(shouldSkipInsightsSynthesis({ previousMeta: null, synthesisSignature: sig }), false);
   assert.equal(shouldSkipInsightsSynthesis({ previousMeta: meta(), synthesisSignature: null }), false);
+
+  // Inflated wide counter: operator-facing log must report the three matching
+  // repeats that armed the breaker, not consecutiveFailures after provider noise.
+  const warning = formatInsightsBreakerOpenWarning(meta({
+    consecutiveFailures: 10,
+    sameSignatureFailures: INSIGHTS_BREAKER_MIN_CONSECUTIVE,
+  }));
+  assert.match(warning, /INSIGHTS_SYNTHESIS_LEAD_PROPER_NOUN x3 /);
+  assert.equal(
+    warning.includes('x10'),
+    false,
+    'an open breaker must not report the noise-inflated wide counter',
+  );
 });
 
 test('the per-signature counter increments only on an EXACT repeat and resets on any change', () => {


### PR DESCRIPTION
Part 3 of the newsInsights convergence package (#7248 resample-feedback, #7253 lead repair).

## Four hours of paid calls that could not succeed

During the 2026-08-28 incident the seeder retried an identical failing synthesis every cycle: **25 consecutive `INSIGHTS_SYNTHESIS_LEAD_PROPER_NOUN` rejections on the same phrase against a story set that never changed**, each cycle burning paid provider calls — plus the L2 fallback call — to produce nothing the LKG wasn't already serving.

#7248 and #7253 make an identical repeat much rarer; this is the backstop for whatever residue remains: **same gate failure + same story set + 3 cycles running → skip the spend** until the stories change. No L1 call, and no L2 call either — L2 is a second paid call whose output loses to the LKG already being served.

## Deliberately narrow — each edge has its own test

| condition | breaker | why |
|---|---|---|
| `PROVIDER` failures | never opens | transport is not deterministic; the chain varies between cycles |
| `MISSING_CLUSTER` | never opens | no LLM call happens on that path — no spend to save |
| story set changed (ordering included) | re-arms instantly | the prompt renders stories in order, so a reorder *is* a different input |
| pre-rollout meta (no signature) | never opens | absent evidence must not skip spend |
| unknown failure code | never opens | vocabulary-checked |

## A skipped run reports the true cause

Classifying the run's null `synthesisResult` would say `PROVIDER` — but no provider was asked. A breaker-skipped run carries forward the **previous** failure code, so health keeps showing what actually kept failing while the spend stops.

## State

Lives in the seed-meta the seeder already writes: `lastSynthesisFailureDetail` (flattened, bounded 80 chars) and `failedStoriesSignature` (12-hex over ordered primary titles). A successful publish clears both, so a stale pair can never suppress a later synthesis of a genuinely different run.

## Verification

Mutation-checked twice: disabling the breaker fails the open-conditions test; removing the PROVIDER guard fails *"INSIGHTS_SYNTHESIS_PROVIDER must never open the breaker"*.

**123 tests pass, 0 fail** across seed-insights-freshness, seed-insights-brief, seed-insights-llm-retry, and brief-synthesis-reuse. Biome clean.
