### PR TITLE
fix(alerts): give each country its own weather notification slots

### DIFF
--- a/scripts/_weather-alert-select.mjs
+++ b/scripts/_weather-alert-select.mjs
@@ -394,6 +394,128 @@ export function mergeAlertSources(parts = {}, { totalLimit = MAX_ALERTS, perSour
   return sortBySeverityThenStable(kept).slice(0, totalLimit);
 }
 
+/**
+ * Slot B helper: derive a coalesce-family key from an NWS VTEC string.
+ *
+ * NWS VTEC format (https://www.weather.gov/vtec/):
+ *   /O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/
+ *    │  │   │   │  │  │
+ *    │  │   │   │  │  └── event tracking number (per-office, per-phenomenon, per-significance)
+ *    │  │   │   │  └───── significance: W=warning, A=watch, Y=advisory, etc.
+ *    │  │   │   └──────── phenomenon: SV=severe thunderstorm, TO=tornado, FF=flash flood, etc.
+ *    │  │   └──────────── forecast office (4-letter ICAO)
+ *    │  └──────────────── action: NEW, CON (continued), CAN (cancel), EXP (expired), etc.
+ *    └─────────────────── product status: O=operational, T=test, E=exercise, X=experimental
+ *
+ * The (office, phenomenon, significance, eventID) tuple identifies one logical
+ * event across adjacent zones — exactly what we want to coalesce. We drop the
+ * action so NEW + CON + CAN bulletins for the same event also collapse.
+ *
+ * Returns a stable family key like "nws:KSGF.SV.W.0034" or undefined if the
+ * VTEC string is missing or malformed.
+ *
+ * Lives here rather than in ais-relay.cjs so the notification selection below
+ * (and its tests) can call the REAL parser instead of a copy.
+ */
+export function deriveWeatherCoalesceKey(vtec) {
+  if (typeof vtec !== 'string') return undefined;
+  const m = vtec.match(/\/[OTEX]\.[A-Z]+\.([A-Z]{4})\.([A-Z]{2})\.([A-Z])\.(\d{4})\./);
+  if (!m) return undefined;
+  return `nws:${m[1]}.${m[2]}.${m[3]}.${m[4]}`;
+}
+
+/**
+ * Notification family identity for one alert: the VTEC-derived coalesce key
+ * when the source publishes VTEC, else a stable per-alert identity prefixed by
+ * source so a VTEC-less ECCC/SWIC id cannot collide with an NWS one.
+ */
+export function weatherAlertFamilyKey(alert) {
+  return deriveWeatherCoalesceKey(alert?.vtec)
+    ?? `${alert?.source || 'weather'}:${alert?.id || alert?.headline || alert?.event || ''}`;
+}
+
+export const WEATHER_NOTIFY_HIGH_SEVERITIES = Object.freeze(['Extreme', 'Severe']);
+
+// Notification slots are PER COUNTRY, not global. The original cap was 3 and
+// global, which was the same thing when NWS was the only source: "top 3 by
+// severity" and "top 3 for the only audience" coincided. They stopped
+// coinciding at the second source. 3 is kept as the per-audience budget, so a
+// subscriber scoped to any one country sees the same volume as before.
+export const WEATHER_NOTIFY_SLOTS_PER_COUNTRY = 3;
+// Hard ceiling on one tick's publishes, so the fan-out below cannot become
+// unbounded as sources are added under #6271. Pinned to MAX_ALERTS because that
+// is already the arithmetic maximum — the payload holds at most MAX_ALERTS
+// alerts and each publishes at most once — so this bound holds no matter how
+// many countries or sources appear, and never re-breaks the per-country
+// guarantee by biting before every country has been served. Round-robin fill
+// (below) spends it breadth-first, so if it ever did bite it would only cost
+// depth slots, never a country's first slot (#7243).
+export const WEATHER_NOTIFY_MAX_PER_TICK = MAX_ALERTS;
+
+// Alerts whose countryCode is missing/unusable reach only rules with no
+// country scope (see isPermissiveUnattributedEvent in notification-relay.cjs),
+// so they are a distinct audience and get their own bucket rather than
+// competing for a real country's slots.
+const UNATTRIBUTED_NOTIFY_BUCKET = Symbol('unattributed');
+
+/**
+ * Pick the alerts one weather seed tick publishes as weather_alert
+ * notifications.
+ *
+ * Two rules, both about not silently dropping an audience:
+ *
+ * 1. Distinct FAMILIES only. A naive `slice(0, N)` over the raw list loses
+ *    events, because three adjacent-zone bulletins for one VTEC family
+ *    collapse to a single notification at the publisher while a fourth
+ *    genuinely distinct family at index 3+ is never considered (PR #3467
+ *    review, Slot B).
+ *
+ * 2. Slots are partitioned PER COUNTRY, then filled round-robin. A globally
+ *    severity-sorted budget can be spent entirely inside one country — on
+ *    2026-08-28 nine VTEC-less SWIC Swiss thunderstorms (nine distinct
+ *    families) led the sort and took every slot, and
+ *    `eventMatchesCountryScope` then dropped the tick for every CA- and
+ *    US-scoped rule despite 15 active alerts each in the same payload. This
+ *    is the notification-layer counterpart of the PER_SOURCE_FLOOR that
+ *    mergeAlertSources applies to the payload (#6627, #7243).
+ *
+ * Round-robin — every country's slot 1 before any country's slot 2 — rather
+ * than "one per country, then fill the remainder by severity": a severity fill
+ * would hand the surplus straight back to the country that already leads the
+ * sort, which is both the original starvation and nine notifications for one
+ * Swiss subscriber.
+ */
+export function selectWeatherNotificationAlerts(alerts, {
+  slotsPerCountry = WEATHER_NOTIFY_SLOTS_PER_COUNTRY,
+  maxPerTick = WEATHER_NOTIFY_MAX_PER_TICK,
+} = {}) {
+  const highSeverity = (Array.isArray(alerts) ? alerts : [])
+    .filter((a) => WEATHER_NOTIFY_HIGH_SEVERITIES.includes(a?.severity));
+
+  // Insertion order of the Map is severity order, so round-robin visits the
+  // most severe country first on every pass — deterministic and stable.
+  const byCountry = new Map();
+  const seenFamilyKeys = new Set();
+  for (const alert of sortBySeverityThenStable(highSeverity)) {
+    const familyKey = weatherAlertFamilyKey(alert);
+    if (seenFamilyKeys.has(familyKey)) continue;
+    seenFamilyKeys.add(familyKey);
+    const bucket = weatherAlertNotifyCountryCode(alert) ?? UNATTRIBUTED_NOTIFY_BUCKET;
+    const existing = byCountry.get(bucket);
+    if (existing) existing.push(alert);
+    else byCountry.set(bucket, [alert]);
+  }
+
+  const selected = [];
+  for (let slot = 0; slot < slotsPerCountry && selected.length < maxPerTick; slot += 1) {
+    for (const queue of byCountry.values()) {
+      if (selected.length >= maxPerTick) break;
+      if (slot < queue.length) selected.push(queue[slot]);
+    }
+  }
+  return sortBySeverityThenStable(selected);
+}
+
 export function carryFailedWeatherAlertSources(previousAlerts, failedSources = []) {
   const alerts = Array.isArray(previousAlerts) ? previousAlerts : [];
   const failed = new Set(

--- a/scripts/_weather-alert-select.mjs
+++ b/scripts/_weather-alert-select.mjs
@@ -425,13 +425,38 @@ export function deriveWeatherCoalesceKey(vtec) {
 }
 
 /**
- * Notification family identity for one alert: the VTEC-derived coalesce key
- * when the source publishes VTEC, else a stable per-alert identity prefixed by
- * source so a VTEC-less ECCC/SWIC id cannot collide with an NWS one.
+ * Notification family identity for one alert — the single notion of "family"
+ * shared by the selection below and by the publisher's SET NX dedup key. When
+ * the two disagree, the selector's per-country guarantee is silently undone by
+ * publisher dedup, which is exactly how #7243 survived its first fix.
+ *
+ * NWS publishes VTEC, so its family is the VTEC tuple (adjacent-zone bulletins
+ * for one storm collapse). VTEC-less sources fall back to
+ * `source:country:title`:
+ *
+ *  - `country` is required. SWIC titles are generic WMO event names — the live
+ *    2026-08-28 payload carries "Forestfire", "Heavy rain", and one alert
+ *    titled literally "CAP Alert" — so without it two countries share a dedup
+ *    key and only the first SET NX wins.
+ *  - `title`, NOT the id. SWIC and ECCC ids embed a timestamp and a message
+ *    sequence (`2.49.0.0.398.0-20260828-101702-0470417-00-EN`), so the same
+ *    logical alert arrives with a new id on every CAP update; an id-keyed
+ *    family would re-notify each tick instead of coalescing. Titles are also
+ *    what the pre-#7243 publisher hashed, so cross-tick behaviour is unchanged
+ *    apart from the added country partition.
+ *  - `source` keeps a VTEC-less ECCC id from colliding with an NWS one on the
+ *    shared weather:alerts:v1 path.
+ *
+ * The trade-off is deliberate: 19 identically-titled Kazakh wildfires are ONE
+ * family, which is both what a subscriber wants and what frees that country's
+ * remaining slots for a genuinely different hazard.
  */
 export function weatherAlertFamilyKey(alert) {
-  return deriveWeatherCoalesceKey(alert?.vtec)
-    ?? `${alert?.source || 'weather'}:${alert?.id || alert?.headline || alert?.event || ''}`;
+  const vtecKey = deriveWeatherCoalesceKey(alert?.vtec);
+  if (vtecKey) return vtecKey;
+  const source = alert?.source || 'weather';
+  const country = weatherAlertNotifyCountryCode(alert) ?? '';
+  return `${source}:${country}:${alert?.headline || alert?.event || alert?.id || ''}`;
 }
 
 export const WEATHER_NOTIFY_HIGH_SEVERITIES = Object.freeze(['Extreme', 'Severe']);

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -751,33 +751,6 @@ function marketAlertCoalesceKey(assetClass, identifier, direction, severity) {
   return `market:${assetClass}:${stableIdentifier}:${direction}:${severity}`;
 }
 
-/**
- * Slot B helper: derive a coalesce-family key from an NWS VTEC string.
- *
- * NWS VTEC format (https://www.weather.gov/vtec/):
- *   /O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/
- *    │  │   │   │  │  │
- *    │  │   │   │  │  └── event tracking number (per-office, per-phenomenon, per-significance)
- *    │  │   │   │  └───── significance: W=warning, A=watch, Y=advisory, etc.
- *    │  │   │   └──────── phenomenon: SV=severe thunderstorm, TO=tornado, FF=flash flood, etc.
- *    │  │   └──────────── forecast office (4-letter ICAO)
- *    │  └──────────────── action: NEW, CON (continued), CAN (cancel), EXP (expired), etc.
- *    └─────────────────── product status: O=operational, T=test, E=exercise, X=experimental
- *
- * The (office, phenomenon, significance, eventID) tuple identifies one logical
- * event across adjacent zones — exactly what we want to coalesce. We drop the
- * action so NEW + CON + CAN bulletins for the same event also collapse.
- *
- * Returns a stable family key like "nws:KSGF.SV.W.0034" or undefined if the
- * VTEC string is missing or malformed.
- */
-function deriveWeatherCoalesceKey(vtec) {
-  if (typeof vtec !== 'string') return undefined;
-  const m = vtec.match(/\/[OTEX]\.[A-Z]+\.([A-Z]{4})\.([A-Z]{2})\.([A-Z])\.(\d{4})\./);
-  if (!m) return undefined;
-  return `nws:${m[1]}.${m[2]}.${m[3]}.${m[4]}`;
-}
-
 function nwsVtec(p) {
   const vtec = Array.isArray(p?.parameters?.VTEC) ? p.parameters.VTEC[0] : undefined;
   return vtec;
@@ -5212,6 +5185,7 @@ async function seedWeatherAlerts() {
       NWS_HOST,
       SWIC_MAX_BYTES,
       WEATHER_ALERTS_SOURCE_VERSION,
+      deriveWeatherCoalesceKey,
       fetchApprovedWeatherJson,
       fetchEcccAlertFeatures,
       fetchSwicAlertCatalog,
@@ -5220,6 +5194,7 @@ async function seedWeatherAlerts() {
       requireAlertFeatures,
       selectEcccAlerts,
       selectSwicAlerts,
+      selectWeatherNotificationAlerts,
       weatherAlertNotifyCountryCode,
       weatherAlertNotifyLocation,
       weatherAlertNotifySource,
@@ -5358,28 +5333,11 @@ async function seedWeatherAlerts() {
         : { sourceState: 'ok' }),
     }, 604800);
     console.log(`[Weather] Seeded ${alerts.length} alerts (nws=${nwsAlerts.length} eccc=${ecccAlerts.length} swic=${swicAlerts.length}, redis: ${ok1 && ok2 ? 'OK' : 'PARTIAL'}) in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
-    const highSeverityAlerts = alerts.filter(a => a.severity === 'Extreme' || a.severity === 'Severe');
-    // Pick up to 3 DISTINCT event families before publishing. The naive
-    // `slice(0, 3)` would silently lose distinct families: if the first 3 raw
-    // alerts are adjacent-zone duplicates for one VTEC family (one storm
-    // crossing 3 counties), the publisher-side dedup collapses them to 1
-    // notification and a 4th genuinely-distinct family (tornado / flood /
-    // different storm) sitting at index 3+ would NEVER be considered.
-    // Dedupe by coalesceKey FIRST, then take the top 3 distinct families.
-    // Slot B regression fix from PR #3467 review.
-    const seenFamilyKeys = new Set();
-    const distinctFamilyAlerts = [];
-    for (const a of highSeverityAlerts) {
-      // Family key: prefer VTEC-derived coalesce key; fall back to a stable
-      // identity from the alert so VTEC-less / ECCC alerts still deduplicate
-      // against themselves.
-      const familyKey = deriveWeatherCoalesceKey(a.vtec)
-        ?? `${a.source || 'weather'}:${a.id || a.headline || a.event || ''}`;
-      if (seenFamilyKeys.has(familyKey)) continue;
-      seenFamilyKeys.add(familyKey);
-      distinctFamilyAlerts.push(a);
-      if (distinctFamilyAlerts.length >= 3) break;
-    }
+    // Which high-severity alerts this tick notifies on. Distinct families,
+    // partitioned per country so a single-country burst cannot spend every
+    // slot (#7243). Selection rules live in _weather-alert-select.mjs so they
+    // are unit-testable without booting the relay.
+    const distinctFamilyAlerts = selectWeatherNotificationAlerts(alerts);
     for (const a of distinctFamilyAlerts) {
       // Slot B: derive a coalesceKey from the NWS VTEC string (when present)
       // so adjacent-zone bulletins for the same logical event collapse to one

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5185,7 +5185,6 @@ async function seedWeatherAlerts() {
       NWS_HOST,
       SWIC_MAX_BYTES,
       WEATHER_ALERTS_SOURCE_VERSION,
-      deriveWeatherCoalesceKey,
       fetchApprovedWeatherJson,
       fetchEcccAlertFeatures,
       fetchSwicAlertCatalog,
@@ -5195,6 +5194,7 @@ async function seedWeatherAlerts() {
       selectEcccAlerts,
       selectSwicAlerts,
       selectWeatherNotificationAlerts,
+      weatherAlertFamilyKey,
       weatherAlertNotifyCountryCode,
       weatherAlertNotifyLocation,
       weatherAlertNotifySource,
@@ -5339,11 +5339,13 @@ async function seedWeatherAlerts() {
     // are unit-testable without booting the relay.
     const distinctFamilyAlerts = selectWeatherNotificationAlerts(alerts);
     for (const a of distinctFamilyAlerts) {
-      // Slot B: derive a coalesceKey from the NWS VTEC string (when present)
-      // so adjacent-zone bulletins for the same logical event collapse to one
-      // notification per user. Falls back to title-based dedup when VTEC is
-      // absent (ECCC, rare advisory types, or missing parameters).
-      const coalesceKey = deriveWeatherCoalesceKey(a.vtec);
+      // The SAME family key the selector partitioned by. Publishing a narrower
+      // key (VTEC only) let publishNotificationEvent fall back to its global
+      // `weather_alert:<title>` dedup hash for every VTEC-less SWIC/ECCC
+      // alert, so two countries sharing a generic WMO title ("Heavy rain",
+      // "Forestfire") collided on SET NX and only the first survived —
+      // recreating the #7243 starvation one layer below the selector.
+      const coalesceKey = weatherAlertFamilyKey(a);
       const countryCode = weatherAlertNotifyCountryCode(a);
       publishNotificationEvent({
         eventType: 'weather_alert',

--- a/tests/notification-relay-coalesce-key.test.mjs
+++ b/tests/notification-relay-coalesce-key.test.mjs
@@ -476,13 +476,17 @@ describe('ais-relay weather publisher — coalesceKey threading', () => {
     );
   });
 
-  it('publishNotificationEvent call passes coalesceKey when derivable from VTEC', () => {
-    // Spread-conditional: only includes the field when the parser returned a value,
+  it('publishNotificationEvent call passes the shared weather family key as coalesceKey', () => {
+    // Spread-conditional: only includes the field when the key is non-empty,
     // so undefined isn't sent over the wire.
+    // Narrowing this to deriveWeatherCoalesceKey(a.vtec) left every VTEC-less
+    // SWIC/ECCC alert on publishNotificationEvent's global `weather_alert:
+    // <title>` dedup hash, so two countries sharing a generic WMO title
+    // collided on SET NX (#7243).
     assert.match(
       aisRelaySrc,
-      /coalesceKey\s*=\s*deriveWeatherCoalesceKey\(a\.vtec\)/,
-      'weather publisher must derive coalesceKey via deriveWeatherCoalesceKey(a.vtec)',
+      /coalesceKey\s*=\s*weatherAlertFamilyKey\(a\)/,
+      'weather publisher must key dedup on the same family key the selector partitions by',
     );
     assert.match(
       aisRelaySrc,
@@ -527,21 +531,33 @@ describe('ais-relay weather publisher — coalesceKey threading', () => {
     );
   });
 
-  it('family-key fallback is source-prefixed so VTEC-less sources cannot collide', () => {
+  it('family-key fallback is source- and country-scoped so VTEC-less alerts cannot collide', () => {
     // A hardcoded `nws:fallback:` prefix would swallow SWIC rows into an NWS
     // family when ids overlap on the shared weather:alerts:v1 path.
-    assert.equal(weatherAlertFamilyKey({ source: 'swic', id: '123' }), 'swic:123');
-    assert.equal(weatherAlertFamilyKey({ source: 'eccc', id: '123' }), 'eccc:123');
+    assert.equal(
+      weatherAlertFamilyKey({ source: 'swic', countryCode: 'CH', headline: 'Heavy rain' }),
+      'swic:CH:Heavy rain',
+    );
     assert.notEqual(
-      weatherAlertFamilyKey({ source: 'swic', id: '123' }),
-      weatherAlertFamilyKey({ source: 'nws', id: '123' }),
+      weatherAlertFamilyKey({ source: 'swic', countryCode: 'CH', headline: 'Heavy rain' }),
+      weatherAlertFamilyKey({ source: 'swic', countryCode: 'IN', headline: 'Heavy rain' }),
+      'the same generic WMO title in two countries must be two families',
+    );
+    assert.notEqual(
+      weatherAlertFamilyKey({ source: 'swic', countryCode: 'CA', headline: 'Storm' }),
+      weatherAlertFamilyKey({ source: 'eccc', countryCode: 'CA', headline: 'Storm' }),
+      'two authorities for one country must not share a family',
     );
     assert.equal(
-      weatherAlertFamilyKey({ source: 'nws', id: 'x', vtec: '/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/' }),
+      weatherAlertFamilyKey({ source: 'nws', countryCode: 'US', headline: 'x', vtec: '/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/' }),
       'nws:KSGF.SV.W.0034',
-      'VTEC wins over the id fallback when present',
+      'VTEC wins over the title fallback when present',
     );
-    assert.equal(weatherAlertFamilyKey({ headline: 'no id' }), 'weather:no id');
+    assert.equal(
+      weatherAlertFamilyKey({ source: 'swic', countryCode: 'KZ', id: 'only-an-id' }),
+      'swic:KZ:only-an-id',
+      'a titleless alert still gets a usable family rather than an empty key',
+    );
     assert.doesNotMatch(
       weatherSelectSrc,
       /nws:fallback:/,

--- a/tests/notification-relay-coalesce-key.test.mjs
+++ b/tests/notification-relay-coalesce-key.test.mjs
@@ -6,9 +6,9 @@
  * relay scripts are runtime side-effect modules with no exports — the same
  * pattern used by tests/notification-relay-effective-sensitivity.test.mjs.
  *
- * The actual VTEC parser (deriveWeatherCoalesceKey in ais-relay.cjs) is
- * exercised here too via a minimal re-implementation extracted from the
- * source. If the source diverges, this test will fail and force an update.
+ * The VTEC parser (deriveWeatherCoalesceKey) and the notification family/slot
+ * selection live in scripts/_weather-alert-select.mjs and are imported and
+ * exercised directly here — no re-implementation.
  *
  * See docs/archive/plans/forbid-realtime-all-events.md "Out of scope: Slot B".
  *
@@ -32,6 +32,11 @@ const seedAviationSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'seed-a
 const regionalAlertEmitterSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'regional-snapshot', 'alert-emitter.mjs'), 'utf-8');
 const notificationDedupSrc = readFileSync(resolve(__dirname, '..', 'scripts', 'shared', 'notification-dedup.cjs'), 'utf-8');
 const notificationDedup = require('../scripts/shared/notification-dedup.cjs');
+const {
+  deriveWeatherCoalesceKey,
+  weatherAlertFamilyKey,
+  selectWeatherNotificationAlerts,
+} = await import('../scripts/_weather-alert-select.mjs');
 
 describe('notification-relay checkDedup — Slot B coalesce key', () => {
   it('checkDedup signature accepts an optional coalesceKey parameter', () => {
@@ -384,15 +389,10 @@ describe('seed-aviation publishNotificationEvent — Slot B publisher dedup', ()
   });
 });
 
-describe('ais-relay deriveWeatherCoalesceKey — VTEC parser', () => {
-  // Mini re-implementation that mirrors the source. If the parser shape changes,
-  // both this test fixture and the source need updating in lockstep.
-  function deriveWeatherCoalesceKey(vtec) {
-    if (typeof vtec !== 'string') return undefined;
-    const m = vtec.match(/\/[OTEX]\.[A-Z]+\.([A-Z]{4})\.([A-Z]{2})\.([A-Z])\.(\d{4})\./);
-    if (!m) return undefined;
-    return `nws:${m[1]}.${m[2]}.${m[3]}.${m[4]}`;
-  }
+describe('deriveWeatherCoalesceKey — VTEC parser', () => {
+  // The REAL parser, imported from scripts/_weather-alert-select.mjs. It used
+  // to be re-implemented here from the ais-relay source, which meant the test
+  // could not fail when the parser changed — only when the copy drifted.
 
   it('parses a typical NEW Severe Thunderstorm Warning VTEC into a stable family key', () => {
     const vtec = '/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/';
@@ -491,20 +491,33 @@ describe('ais-relay weather publisher — coalesceKey threading', () => {
     );
   });
 
-  it('selects 3 DISTINCT families before slicing — distinct families never lost (PR #3467 review P1)', () => {
+  it('selects DISTINCT families before slicing — distinct families never lost (PR #3467 review P1)', () => {
     // Without this: if the first 3 raw alerts are 3 adjacent zones of one VTEC
     // family, publisher dedup collapses them to 1 notification AND a 4th
     // genuinely-distinct family at index 3+ is never considered. Net silent
-    // loss of legit events. Fix: dedupe BY family key FIRST, then take top 3.
-    assert.match(
-      aisRelaySrc,
-      /seenFamilyKeys\s*=\s*new Set\(\)/,
-      'publisher must build a Set of seen family keys before publishing',
-    );
-    assert.match(
-      aisRelaySrc,
-      /distinctFamilyAlerts/,
-      'publisher must accumulate distinct-family alerts (not raw .slice(0, 3))',
+    // loss of legit events. Fix: dedupe BY family key FIRST, then slice.
+    // Exercised against the real selector rather than the relay source text.
+    const zone = (id) => ({
+      id,
+      source: 'nws',
+      countryCode: 'US',
+      severity: 'Extreme',
+      event: 'Severe thunderstorm warning',
+      vtec: '/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/',
+    });
+    const tornado = {
+      id: 'tornado',
+      source: 'nws',
+      countryCode: 'US',
+      severity: 'Extreme',
+      event: 'Tornado warning',
+      vtec: '/O.NEW.KSGF.TO.W.0034.250427T1257Z-250427T1330Z/',
+    };
+    const selected = selectWeatherNotificationAlerts([zone('z1'), zone('z2'), zone('z3'), tornado]);
+    assert.deepEqual(
+      selected.map((a) => a.id),
+      ['z1', 'tornado'],
+      'three adjacent zones must collapse to one slot so the 4th distinct family is still reached',
     );
     // The naive `for (const a of highSeverityAlerts.slice(0, 3))` ordering is the bug; assert it's gone.
     assert.doesNotMatch(
@@ -512,17 +525,25 @@ describe('ais-relay weather publisher — coalesceKey threading', () => {
       /for\s*\(const\s+a\s+of\s+highSeverityAlerts\.slice\(0,\s*3\)\)/,
       'publisher must NOT iterate highSeverityAlerts.slice(0, 3) directly — that loses distinct families',
     );
-    // Family-key fallback uses source + a stable per-alert identity so VTEC-less
-    // NWS/ECCC/SWIC alerts still dedupe against themselves without colliding
-    // across authorities. A hardcoded `nws:fallback:` prefix would swallow SWIC
-    // rows into an NWS family when ids overlap.
-    assert.match(
-      aisRelaySrc,
-      /deriveWeatherCoalesceKey\(a\.vtec\)\s*\n?\s*\?\?\s*`\$\{a\.source \|\| 'weather'\}:\$\{a\.id/,
-      'family-key fallback must include source plus a stable per-alert identity (id || headline || event)',
+  });
+
+  it('family-key fallback is source-prefixed so VTEC-less sources cannot collide', () => {
+    // A hardcoded `nws:fallback:` prefix would swallow SWIC rows into an NWS
+    // family when ids overlap on the shared weather:alerts:v1 path.
+    assert.equal(weatherAlertFamilyKey({ source: 'swic', id: '123' }), 'swic:123');
+    assert.equal(weatherAlertFamilyKey({ source: 'eccc', id: '123' }), 'eccc:123');
+    assert.notEqual(
+      weatherAlertFamilyKey({ source: 'swic', id: '123' }),
+      weatherAlertFamilyKey({ source: 'nws', id: '123' }),
     );
+    assert.equal(
+      weatherAlertFamilyKey({ source: 'nws', id: 'x', vtec: '/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/' }),
+      'nws:KSGF.SV.W.0034',
+      'VTEC wins over the id fallback when present',
+    );
+    assert.equal(weatherAlertFamilyKey({ headline: 'no id' }), 'weather:no id');
     assert.doesNotMatch(
-      aisRelaySrc,
+      weatherSelectSrc,
       /nws:fallback:/,
       'family-key fallback must not hardcode an NWS prefix on the shared weather:alerts:v1 path',
     );

--- a/tests/weather-alert-notify-fanout.test.mjs
+++ b/tests/weather-alert-notify-fanout.test.mjs
@@ -19,28 +19,37 @@
 
 import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import { describe, it } from 'node:test';
 
 import {
   WEATHER_NOTIFY_MAX_PER_TICK,
   WEATHER_NOTIFY_SLOTS_PER_COUNTRY,
   selectWeatherNotificationAlerts,
+  weatherAlertFamilyKey,
   weatherAlertNotifyCountryCode,
 } from '../scripts/_weather-alert-select.mjs';
+
+const require = createRequire(import.meta.url);
+const { buildDedupMaterial } = require('../scripts/shared/notification-dedup.cjs');
 
 const AIS_RELAY_SOURCE = readFileSync(
   new URL('../scripts/ais-relay.cjs', import.meta.url),
   'utf8',
 );
 
-function notifyAlert({ source, countryCode, id, severity, event, vtec }) {
+function notifyAlert({ source, countryCode, id, severity, event, headline, vtec }) {
   return {
     id,
     source,
     countryCode,
     severity,
     event,
-    headline: `${event} ${id}`,
+    // SWIC/ECCC headlines are generic event names repeated verbatim across
+    // every alert of that type — the live payload carries 19 Kazakh rows all
+    // titled "Forestfire". Default to that shape rather than a per-id title,
+    // which would make every fixture row look like its own family.
+    headline: headline ?? event,
     ...(vtec ? { vtec } : {}),
   };
 }
@@ -59,11 +68,23 @@ function productionShape20260828() {
     alerts.push(notifyAlert({
       source: 'swic',
       countryCode: 'CH',
-      id: `swic-ch-${i}`,
+      // CAP ids embed a timestamp and a message sequence, so they differ per
+      // row even for one storm system; the shared title is what identifies it.
+      id: `2.49.0.0.756.0-20260828-10170${i}-0470417-00-EN`,
       severity: 'Extreme',
       event: 'Violent thunderstorm',
     }));
   }
+  // Two further Swiss hazards, so CH has three genuinely distinct families and
+  // can still exercise the full per-country budget.
+  alerts.push(notifyAlert({
+    source: 'swic', countryCode: 'CH', id: 'swic-ch-rain', severity: 'Extreme', event: 'Heavy rain',
+  }));
+  alerts.push(notifyAlert({
+    source: 'swic', countryCode: 'CH', id: 'swic-ch-wind', severity: 'Extreme', event: 'Wind',
+  }));
+  // Deliberately shares CH's "Heavy rain" title: generic WMO event names
+  // repeat across countries, and before #7243 that collided in publisher dedup.
   alerts.push(notifyAlert({
     source: 'swic',
     countryCode: 'IN',
@@ -130,17 +151,19 @@ describe('weather_alert notification fan-out — per-country slots (#7243)', () 
 
   it('bounds the whole tick at WEATHER_NOTIFY_MAX_PER_TICK', () => {
     // 30 countries x 5 distinct Extreme families each = 150 candidates, far
-    // above anything the 50-alert payload can actually hold.
+    // above anything the 50-alert payload can actually hold. Distinct hazard
+    // names per row, or they would coalesce into one family per country and
+    // never approach the ceiling.
     const many = [];
     for (let c = 0; c < 30; c += 1) {
       const countryCode = `${String.fromCharCode(65 + Math.floor(c / 26))}${String.fromCharCode(65 + (c % 26))}`;
-      for (let i = 0; i < 5; i += 1) {
+      for (const event of ['Storm', 'Flood', 'Wind', 'Snow', 'Fire']) {
         many.push(notifyAlert({
           source: 'swic',
           countryCode,
-          id: `swic-${c}-${i}`,
+          id: `swic-${c}-${event}`,
           severity: 'Extreme',
-          event: 'Storm',
+          event,
         }));
       }
     }
@@ -216,12 +239,15 @@ describe('weather_alert notification fan-out — per-country slots (#7243)', () 
     // weatherAlertNotifyCountryCode() returns undefined for these; downstream
     // they only reach unscoped rules, so they must neither consume CH's slots
     // nor be starved by CH.
+    // Four DISTINCT hazards per bucket — same-titled rows coalesce into one
+    // family, so distinct titles are what make this a slot-contention test.
+    const hazards = ['Storm', 'Flood', 'Wind', 'Snow'];
     const alerts = [
-      ...Array.from({ length: 4 }, (_, i) => notifyAlert({
-        source: 'swic', countryCode: 'CH', id: `ch-${i}`, severity: 'Extreme', event: 'Storm',
+      ...hazards.map((event, i) => notifyAlert({
+        source: 'swic', countryCode: 'CH', id: `ch-${i}`, severity: 'Extreme', event,
       })),
-      ...Array.from({ length: 4 }, (_, i) => notifyAlert({
-        source: 'swic', countryCode: '', id: `unattributed-${i}`, severity: 'Extreme', event: 'Storm',
+      ...hazards.map((event, i) => notifyAlert({
+        source: 'swic', countryCode: '', id: `unattributed-${i}`, severity: 'Extreme', event,
       })),
     ];
     const selected = selectWeatherNotificationAlerts(alerts);
@@ -251,6 +277,100 @@ describe('weather_alert notification fan-out — per-country slots (#7243)', () 
       notifyAlert({ source: 'swic', countryCode: 'CH', id: 'ch-extreme', severity: 'Extreme', event: 'Storm' }),
     ]);
     assert.deepEqual(selected.map((a) => a.id), ['ch-extreme', 'ca-severe']);
+  });
+
+  it('does not let two countries with the same headline collide in publisher dedup', () => {
+    // The selector can hand the publisher one alert per country and STILL lose
+    // every country but one: publishNotificationEvent keys its SET NX dedup on
+    // buildDedupMaterial(eventType, title, coalesceKey), which falls back to
+    // `weather_alert:<title>` whenever coalesceKey is absent — i.e. for every
+    // VTEC-less SWIC/ECCC alert. SWIC titles are generic event names ("Heavy
+    // rain", "Forestfire", and one live alert titled literally "CAP Alert"),
+    // so two countries collide on the title hash and only the first SET NX
+    // wins. That recreates the #7243 starvation one layer down.
+    const chRain = notifyAlert({
+      source: 'swic', countryCode: 'CH', id: 'ch-rain', severity: 'Extreme', event: 'Heavy rain',
+    });
+    const inRain = notifyAlert({
+      source: 'swic', countryCode: 'IN', id: 'in-rain', severity: 'Extreme', event: 'Heavy rain',
+    });
+    chRain.headline = 'Heavy rain';
+    inRain.headline = 'Heavy rain';
+    // Positive control for the trap itself: with no coalesceKey — what the
+    // relay passed for every VTEC-less alert before this fix — they collide.
+    assert.equal(
+      buildDedupMaterial('weather_alert', chRain.headline, undefined),
+      buildDedupMaterial('weather_alert', inRain.headline, undefined),
+      'sanity: the title-hash fallback is what makes two countries collide',
+    );
+    const material = (a) => buildDedupMaterial('weather_alert', a.headline, weatherAlertFamilyKey(a));
+    assert.notEqual(
+      material(chRain),
+      material(inRain),
+      'a Swiss and an Indian "Heavy rain" must not share a publisher dedup key',
+    );
+  });
+
+  it('coalesces same-headline alerts within one country to a single family', () => {
+    // Live payload 2026-08-28: 19 Kazakh high-severity alerts ALL titled
+    // "Forestfire". Keying the family on the raw alert id would treat them as
+    // 19 families and burn all 3 KZ slots on one wildfire event; the ids also
+    // embed a CAP timestamp (2.49.0.0.398.0-20260828-101702-0470417-00-EN), so
+    // every CAP update would re-notify. Coalesce on (source, country, title)
+    // instead: one family, freeing KZ's other slots for other hazards.
+    const forestFires = Array.from({ length: 19 }, (_, i) => notifyAlert({
+      source: 'swic',
+      countryCode: 'KZ',
+      id: `2.49.0.0.398.0-20260828-10170${i}-0470417-00-EN`,
+      severity: 'Extreme',
+      event: 'Forestfire',
+    }));
+    for (const a of forestFires) a.headline = 'Forestfire';
+    const flood = notifyAlert({
+      source: 'swic', countryCode: 'KZ', id: 'kz-flood', severity: 'Extreme', event: 'Flood',
+    });
+    flood.headline = 'Flood';
+    const selected = selectWeatherNotificationAlerts([...forestFires, flood]);
+    assert.deepEqual(
+      selected.map((a) => a.headline),
+      ['Forestfire', 'Flood'],
+      '19 identically-titled Kazakh wildfires are one family, and the flood must still get a slot',
+    );
+  });
+
+  it('keeps a VTEC-less family key stable across CAP updates of the same alert', () => {
+    // SWIC/ECCC ids carry a timestamp and a message sequence, so the same
+    // logical alert arrives with a new id on every update. An id-keyed family
+    // would re-notify each tick; the 1800s dedup TTL only helps if the key
+    // survives the update.
+    const first = notifyAlert({
+      source: 'swic',
+      countryCode: 'KZ',
+      id: '2.49.0.0.398.0-20260828-101702-0470417-00-EN',
+      severity: 'Extreme',
+      event: 'Forestfire',
+    });
+    const updated = notifyAlert({
+      source: 'swic',
+      countryCode: 'KZ',
+      id: '2.49.0.0.398.0-20260828-111702-0470417-01-EN',
+      severity: 'Extreme',
+      event: 'Forestfire',
+    });
+    first.headline = 'Forestfire';
+    updated.headline = 'Forestfire';
+    assert.equal(weatherAlertFamilyKey(first), weatherAlertFamilyKey(updated));
+  });
+
+  it('ais-relay publishes the shared family key as the coalesceKey', () => {
+    // The selector and the publisher must agree on what a family is. When they
+    // disagree the selector's per-country guarantee is undone by the
+    // publisher's title-hash dedup.
+    assert.match(
+      AIS_RELAY_SOURCE,
+      /const coalesceKey = weatherAlertFamilyKey\(a\);/,
+      'the publisher must key dedup on the same family key the selector partitions by',
+    );
   });
 
   it('ais-relay delegates weather notification selection to the shared module', () => {

--- a/tests/weather-alert-notify-fanout.test.mjs
+++ b/tests/weather-alert-notify-fanout.test.mjs
@@ -1,0 +1,268 @@
+/**
+ * #7243 — weather_alert notification fan-out must not starve non-winning
+ * countries.
+ *
+ * `seedWeatherAlerts` published the globally severity-sorted top-3 distinct
+ * families per 15-min tick. Downstream, `eventMatchesCountryScope`
+ * (scripts/notification-relay.cjs) drops any event whose payload.countryCode
+ * falls outside a rule's country list — so when all three global winners
+ * belonged to one country, every subscriber scoped to any other country got
+ * nothing that tick, even with active Extreme/Severe alerts for their country
+ * sitting in the very same payload.
+ *
+ * The payload layer already solved this shape: mergeAlertSources' PER_SOURCE_FLOOR
+ * (#6627) exists so no source can starve another out of the 50-alert cache.
+ * These tests pin the notification-layer equivalent.
+ *
+ * Run: node --test tests/weather-alert-notify-fanout.test.mjs
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import {
+  WEATHER_NOTIFY_MAX_PER_TICK,
+  WEATHER_NOTIFY_SLOTS_PER_COUNTRY,
+  selectWeatherNotificationAlerts,
+  weatherAlertNotifyCountryCode,
+} from '../scripts/_weather-alert-select.mjs';
+
+const AIS_RELAY_SOURCE = readFileSync(
+  new URL('../scripts/ais-relay.cjs', import.meta.url),
+  'utf8',
+);
+
+function notifyAlert({ source, countryCode, id, severity, event, vtec }) {
+  return {
+    id,
+    source,
+    countryCode,
+    severity,
+    event,
+    headline: `${event} ${id}`,
+    ...(vtec ? { vtec } : {}),
+  };
+}
+
+/**
+ * The 2026-08-28 production shape, reduced to its starving core: nine SWIC
+ * Swiss thunderstorms sorted ahead of every Canadian and US Severe alert.
+ * SWIC carries no VTEC, so `deriveWeatherCoalesceKey` returns undefined and
+ * each Swiss row falls back to its own unique `swic:<id>` family key — nine
+ * DISTINCT families, not one coalesced storm. All three global slots went to
+ * Switzerland; CA and US subscribers received nothing.
+ */
+function productionShape20260828() {
+  const alerts = [];
+  for (let i = 0; i < 9; i += 1) {
+    alerts.push(notifyAlert({
+      source: 'swic',
+      countryCode: 'CH',
+      id: `swic-ch-${i}`,
+      severity: 'Extreme',
+      event: 'Violent thunderstorm',
+    }));
+  }
+  alerts.push(notifyAlert({
+    source: 'swic',
+    countryCode: 'IN',
+    id: 'swic-in-0',
+    severity: 'Extreme',
+    event: 'Heavy rain',
+  }));
+  for (let i = 0; i < 15; i += 1) {
+    alerts.push(notifyAlert({
+      source: 'eccc',
+      countryCode: 'CA',
+      id: `eccc-ca-${i}`,
+      severity: 'Severe',
+      event: 'Winter storm warning',
+    }));
+  }
+  for (let i = 0; i < 15; i += 1) {
+    alerts.push(notifyAlert({
+      source: 'nws',
+      countryCode: 'US',
+      id: `nws-us-${i}`,
+      severity: 'Severe',
+      event: 'Severe thunderstorm warning',
+      vtec: `/O.NEW.KSGF.SV.W.${String(i).padStart(4, '0')}.250427T1257Z-250427T1330Z/`,
+    }));
+  }
+  return alerts;
+}
+
+const countriesOf = (selected) => selected.map((a) => weatherAlertNotifyCountryCode(a));
+
+describe('weather_alert notification fan-out — per-country slots (#7243)', () => {
+  it('notifies CA, US and IN subscribers even when the global severity head is all CH', () => {
+    // Pre-fix this returned three Swiss thunderstorms and nothing else, so
+    // eventMatchesCountryScope dropped the whole tick for every ['CA'] and
+    // ['US'] rule despite 15 active alerts each in the same payload.
+    const selected = selectWeatherNotificationAlerts(productionShape20260828());
+    const countries = new Set(countriesOf(selected));
+    assert.ok(countries.has('CA'), 'a CA-scoped rule must receive at least one alert this tick');
+    assert.ok(countries.has('US'), 'a US-scoped rule must receive at least one alert this tick');
+    assert.ok(countries.has('IN'), 'an IN-scoped rule must receive at least one alert this tick');
+    assert.ok(countries.has('CH'), 'CH must keep its own slots');
+  });
+
+  it('caps each country at WEATHER_NOTIFY_SLOTS_PER_COUNTRY distinct families', () => {
+    // The old global 3 was really "3 for the only audience" — it was written
+    // when NWS was the only source. The budget is kept per audience: a Swiss
+    // subscriber must not get nine notifications just because nine Swiss
+    // storms happen to lead the global sort.
+    const selected = selectWeatherNotificationAlerts(productionShape20260828());
+    const perCountry = new Map();
+    for (const code of countriesOf(selected)) {
+      perCountry.set(code, (perCountry.get(code) ?? 0) + 1);
+    }
+    for (const [code, count] of perCountry) {
+      assert.ok(
+        count <= WEATHER_NOTIFY_SLOTS_PER_COUNTRY,
+        `${code} took ${count} slots, above the ${WEATHER_NOTIFY_SLOTS_PER_COUNTRY} per-country cap`,
+      );
+    }
+    assert.equal(perCountry.get('CH'), WEATHER_NOTIFY_SLOTS_PER_COUNTRY);
+    assert.equal(perCountry.get('IN'), 1, 'IN only has one high-severity family to give');
+  });
+
+  it('bounds the whole tick at WEATHER_NOTIFY_MAX_PER_TICK', () => {
+    // 30 countries x 5 distinct Extreme families each = 150 candidates, far
+    // above anything the 50-alert payload can actually hold.
+    const many = [];
+    for (let c = 0; c < 30; c += 1) {
+      const countryCode = `${String.fromCharCode(65 + Math.floor(c / 26))}${String.fromCharCode(65 + (c % 26))}`;
+      for (let i = 0; i < 5; i += 1) {
+        many.push(notifyAlert({
+          source: 'swic',
+          countryCode,
+          id: `swic-${c}-${i}`,
+          severity: 'Extreme',
+          event: 'Storm',
+        }));
+      }
+    }
+    const selected = selectWeatherNotificationAlerts(many);
+    assert.ok(
+      selected.length <= WEATHER_NOTIFY_MAX_PER_TICK,
+      `tick published ${selected.length}, above the ${WEATHER_NOTIFY_MAX_PER_TICK} ceiling`,
+    );
+    assert.ok(selected.length > 3, 'the ceiling must sit above the old global 3-slot cap');
+  });
+
+  it('spends the global ceiling across countries, not down one country', () => {
+    // A ceiling reached by draining the highest-severity country first is the
+    // original bug with a bigger number. Every country must be served once
+    // before any country takes a second slot.
+    const many = [];
+    for (let c = 0; c < WEATHER_NOTIFY_MAX_PER_TICK + 10; c += 1) {
+      const countryCode = `${String.fromCharCode(65 + Math.floor(c / 26))}${String.fromCharCode(65 + (c % 26))}`;
+      many.push(notifyAlert({
+        source: 'swic',
+        countryCode,
+        id: `swic-${c}-0`,
+        // The first country is strictly more severe than every other, so a
+        // severity-greedy fill would hand it slots the rest never see.
+        severity: c === 0 ? 'Extreme' : 'Severe',
+        event: 'Storm',
+      }));
+      many.push(notifyAlert({
+        source: 'swic',
+        countryCode,
+        id: `swic-${c}-1`,
+        severity: c === 0 ? 'Extreme' : 'Severe',
+        event: 'Flood',
+      }));
+    }
+    const selected = selectWeatherNotificationAlerts(many);
+    const perCountry = new Map();
+    for (const code of countriesOf(selected)) {
+      perCountry.set(code, (perCountry.get(code) ?? 0) + 1);
+    }
+    assert.equal(selected.length, WEATHER_NOTIFY_MAX_PER_TICK, 'the ceiling must be reached');
+    assert.equal(
+      perCountry.size,
+      WEATHER_NOTIFY_MAX_PER_TICK,
+      'a saturated tick must serve one distinct country per slot, not stack slots on the most severe country',
+    );
+  });
+
+  it('still coalesces one VTEC family spanning adjacent zones into one slot', () => {
+    // Slot B (PR #3467): three adjacent-zone bulletins for one storm collapse
+    // to one notification, so a fourth distinct family must still be reached.
+    const sameFamily = ['nws-a', 'nws-b', 'nws-c'].map((id) => notifyAlert({
+      source: 'nws',
+      countryCode: 'US',
+      id,
+      severity: 'Extreme',
+      event: 'Severe thunderstorm warning',
+      vtec: '/O.NEW.KSGF.SV.W.0034.250427T1257Z-250427T1330Z/',
+    }));
+    const other = notifyAlert({
+      source: 'nws',
+      countryCode: 'US',
+      id: 'nws-tornado',
+      severity: 'Extreme',
+      event: 'Tornado warning',
+      vtec: '/O.NEW.KSGF.TO.W.0034.250427T1257Z-250427T1330Z/',
+    });
+    const selected = selectWeatherNotificationAlerts([...sameFamily, other]);
+    assert.deepEqual(selected.map((a) => a.id), ['nws-a', 'nws-tornado']);
+  });
+
+  it("gives country-less alerts their own bucket, not the winning country's", () => {
+    // weatherAlertNotifyCountryCode() returns undefined for these; downstream
+    // they only reach unscoped rules, so they must neither consume CH's slots
+    // nor be starved by CH.
+    const alerts = [
+      ...Array.from({ length: 4 }, (_, i) => notifyAlert({
+        source: 'swic', countryCode: 'CH', id: `ch-${i}`, severity: 'Extreme', event: 'Storm',
+      })),
+      ...Array.from({ length: 4 }, (_, i) => notifyAlert({
+        source: 'swic', countryCode: '', id: `unattributed-${i}`, severity: 'Extreme', event: 'Storm',
+      })),
+    ];
+    const selected = selectWeatherNotificationAlerts(alerts);
+    const unattributed = selected.filter((a) => weatherAlertNotifyCountryCode(a) === undefined);
+    assert.equal(unattributed.length, WEATHER_NOTIFY_SLOTS_PER_COUNTRY);
+    assert.equal(selected.length - unattributed.length, WEATHER_NOTIFY_SLOTS_PER_COUNTRY);
+  });
+
+  it('ignores Moderate and Minor alerts entirely', () => {
+    const selected = selectWeatherNotificationAlerts([
+      notifyAlert({ source: 'nws', countryCode: 'US', id: 'm1', severity: 'Moderate', event: 'Advisory' }),
+      notifyAlert({ source: 'nws', countryCode: 'US', id: 'm2', severity: 'Minor', event: 'Statement' }),
+      notifyAlert({ source: 'nws', countryCode: 'US', id: 'x1', severity: 'Extreme', event: 'Tornado' }),
+    ]);
+    assert.deepEqual(selected.map((a) => a.id), ['x1']);
+  });
+
+  it('returns [] for a non-array or empty input', () => {
+    assert.deepEqual(selectWeatherNotificationAlerts(undefined), []);
+    assert.deepEqual(selectWeatherNotificationAlerts(null), []);
+    assert.deepEqual(selectWeatherNotificationAlerts([]), []);
+  });
+
+  it('emits in severity order so the most dangerous alert publishes first', () => {
+    const selected = selectWeatherNotificationAlerts([
+      notifyAlert({ source: 'eccc', countryCode: 'CA', id: 'ca-severe', severity: 'Severe', event: 'Storm' }),
+      notifyAlert({ source: 'swic', countryCode: 'CH', id: 'ch-extreme', severity: 'Extreme', event: 'Storm' }),
+    ]);
+    assert.deepEqual(selected.map((a) => a.id), ['ch-extreme', 'ca-severe']);
+  });
+
+  it('ais-relay delegates weather notification selection to the shared module', () => {
+    assert.match(
+      AIS_RELAY_SOURCE,
+      /const distinctFamilyAlerts = selectWeatherNotificationAlerts\(alerts\);/,
+      'the relay must call the shared selector, not re-implement a slot cap inline',
+    );
+    assert.doesNotMatch(
+      AIS_RELAY_SOURCE,
+      /distinctFamilyAlerts\.length >= 3/,
+      'the inline global 3-slot cap must be gone from the relay',
+    );
+  });
+});


### PR DESCRIPTION
Closes #7243.

## Problem

`seedWeatherAlerts` published the globally severity-sorted top-3 distinct families per 15-min tick. Downstream, `eventMatchesCountryScope` (`scripts/notification-relay.cjs:806`) drops any event whose `payload.countryCode` falls outside a rule's country list — so when all three global winners belonged to one country, **every subscriber scoped to any other country received nothing that tick**, even with active Extreme/Severe alerts for their country sitting in the very same payload.

Production, 2026-08-28: 50 alerts across 6 countries (`US 15 | CA 15 | CH 11 | CN 4 | KZ 4 | IN 1`), 40 of them Extreme/Severe, with nine consecutive Swiss SWIC thunderstorms at the head of the sort. SWIC carries no VTEC, so `deriveWeatherCoalesceKey` returns `undefined` and each Swiss row falls back to its own unique `swic:<id>` family key — nine *distinct* families, not one coalesced storm. All three slots went to Switzerland.

## Fix

The 3-slot cap was written when NWS was the only source, where "top 3 by severity" and "top 3 for the only audience" were the same thing. They stopped coinciding at the second source.

This keeps **3 as the per-country budget** — a country-scoped subscriber sees exactly the volume it saw before — and fills **round-robin**: every country's slot 1 before any country's slot 2. Country-less alerts (which reach only unscoped rules) get their own bucket rather than competing for a real country's slots.

This is the notification-layer counterpart of the `PER_SOURCE_FLOOR` that `mergeAlertSources` already applies to the payload (#6627).

Round-robin rather than the issue's literal "one per country, then fill the remainder by severity": a severity fill hands the surplus straight back to the country that already leads the sort — which is both the original starvation *and* nine notifications for one Swiss subscriber. A mutation test pins this (below).

### Bound

`WEATHER_NOTIFY_MAX_PER_TICK` is pinned to `MAX_ALERTS` because that is already the arithmetic maximum: the payload holds at most `MAX_ALERTS` alerts and each publishes at most once. So the bound holds however many CAP sources #6271 adds, and round-robin spends it breadth-first — the ceiling can only ever cost depth slots, never a country's first slot. The reasoning is in a comment next to the constant.

**Volume note for review:** a subscriber with **no** country scope goes from ≤3 weather notifications per tick to ≈ (countries × 3) — about 17 on the 2026-08-28 payload. Scoped subscribers are unchanged at ≤3. `publishNotificationEvent`'s 1800s dedup still prevents re-notifying the same family across ticks.

### Second half: publisher dedup (review finding, d4c0dc235)

Per-country selection alone was not enough. `publishNotificationEvent` keys its `SET NX` dedup on `buildDedupMaterial(eventType, title, coalesceKey)`, which falls back to `weather_alert:<title>` when `coalesceKey` is absent — and the publish loop derived `coalesceKey` from `a.vtec` alone, so every VTEC-less SWIC/ECCC alert took that fallback. Two countries sharing a generic WMO title collided on the title hash and only the first `SET NX` won: the same starvation, one layer below the selector.

The live payload rules out keying on the alert id:

```
19 × KZ high-severity alerts, ALL titled "Forestfire"
 1 × HR alert titled literally "CAP Alert"
swic id: 2.49.0.0.398.0-20260828-101702-0470417-00-EN
eccc id: 524321292007221780202608180501_fea1-2456
```

Those ids embed a CAP timestamp and message sequence, so the same logical alert arrives with a **new id on every update** — id-keying would defeat the 1800s dedup TTL and re-notify every tick.

`weatherAlertFamilyKey` is therefore the one notion of family shared by selector and publisher: VTEC when present, else `source:country:title`. Country partitions the generic titles; title (not id) keeps a CAP update coalescing and preserves the pre-#7243 cross-tick behaviour, which was already title-hashed. Coalescing same-titled alerts within a country is the point, not a side effect — 19 identically-titled Kazakh wildfires are one event to a subscriber, and collapsing them frees that country's other two slots for a different hazard.

**Deploy note:** dedup keys change shape for VTEC-less alerts, so the first tick after rollout may re-notify families whose old-format key is still live.

### Refactor

Selection moves out of `ais-relay.cjs` into `scripts/_weather-alert-select.mjs` (next to `mergeAlertSources`) so it is unit-testable without booting the relay. `deriveWeatherCoalesceKey` moves with it. `tests/notification-relay-coalesce-key.test.mjs` previously re-implemented that parser inline — a test that could only fail when the *copy* drifted, never when the parser did — and now imports and exercises the real one.

## Verification

`tests/weather-alert-notify-fanout.test.mjs` is built from the 2026-08-28 shape and was asserted **red against the extracted-but-unfixed selector** (extraction landed first as a behaviour-preserving refactor, so the red is a real behavioural failure, not a missing import):

```
✖ notifies CA, US and IN subscribers even when the global severity head is all CH
  AssertionError: a CA-scoped rule must receive at least one alert this tick
✖ caps each country at WEATHER_NOTIFY_SLOTS_PER_COUNTRY distinct families
✖ bounds the whole tick at WEATHER_NOTIFY_MAX_PER_TICK
✖ spends the global ceiling across countries, not down one country
✖ gives country-less alerts their own bucket, not the winning country's
→ 5 fail / 10
```

Green after the fix (10/10). Two mutations re-red it:

| Mutation | Tests caught |
|---|---|
| Collapse the per-country buckets into one global bucket | 5 |
| Swap round-robin for "one per country, then severity fill" | per-country cap + unattributed bucket |
| Drop `country` from the family key | 7 |
| Key the family on `id` instead of `title` | 2 (incl. CAP-update stability) |

Gates:
- `tests/weather-alert-notify-fanout.test.mjs` + `weather-alert-selection` + `notification-relay-coalesce-key` + `notification-relay-country-filter` + `dockerfile-relay-imports` — 133/133 green
- `npm run test:data` — 27143/27173; the 7 failures are this worktree's missing `node_modules/.bin/tsx` and generated artifacts (`ERR_MODULE_NOT_FOUND`, `spawnSync … ENOENT`), all in `company-monitoring-*`, `digest-lastgood-script`, `i18n-zh-tw-catalogue`, `prepush-changed-tests` — none touch weather
- `npm run typecheck` clean, `biome lint` clean on changed files, `npm run docs:check` OK

https://claude.ai/code/session_01TtX81ERoKAXnHGBrDNEPiV
