### PR TITLE
fix(gateway): classify missing MCP HMAC secret as config telemetry

### DIFF
--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -86,6 +86,11 @@ export type RequestReason =
   // is unavailable so an atomic claim can't be made. Distinct from auth_401
   // so a Redis outage is not conflated with genuine signature/auth failures.
   | 'replay_cache_unavailable'
+  // Missing MCP_INTERNAL_HMAC_SECRET on a request that presented an internal
+  // MCP signature. HTTP remains 500 CONFIGURATION; this reason keeps a
+  // deploy/config incident out of caller-auth dashboards. Distinct from
+  // auth_401, which still covers malformed or invalid signatures.
+  | 'hmac_secret_unconfigured'
   | 'unknown_route'
   | 'method_not_allowed'
   | 'cors_error'

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -1034,7 +1034,10 @@ export function createDomainGateway(
         // CONFIGURATION so operators see it; legacy wm_ key path is
         // unaffected because we only enter this branch when the caller
         // explicitly tried to use the internal-MCP route.
-        emitRequest(500, 'auth_401', null);
+        // Telemetry must not use auth_401 here: that reason is for caller
+        // authentication failure, and a missing HMAC secret is a deploy
+        // configuration incident (#7277).
+        emitRequest(500, 'hmac_secret_unconfigured', null);
         return new Response(
           JSON.stringify({ error: 'CONFIGURATION', detail: 'MCP_INTERNAL_HMAC_SECRET not configured' }),
           { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -56,6 +56,7 @@ let lastHandlerRequest = null;
 // Map<key, expiryMs> — models Redis EX-based expiry so tests can exercise
 // TTL-vs-acceptance-window interactions, not just presence/absence.
 let replayCacheKeys = new Map();
+let axiomEvents = [];
 
 function makeGateway() {
   return createDomainGateway([
@@ -165,6 +166,11 @@ function installFetchStub(opts = {}) {
       const ent = overrideEntitlement ? overrideEntitlement(body.userId) : entitlementForUser(body.userId);
       return new Response(JSON.stringify(ent), { status: 200, headers: { 'Content-Type': 'application/json' } });
     }
+    if (typeof url === 'string' && url.includes('api.axiom.co')) {
+      const body = init?.body ? JSON.parse(String(init.body)) : [];
+      for (const ev of body) axiomEvents.push(ev);
+      return new Response('{}', { status: 200 });
+    }
     // Anything else — fail loudly so tests can't silently depend on the network.
     throw new Error(`unexpected fetch in test: ${url}`);
   };
@@ -182,9 +188,28 @@ function disableRedisForLegacyGatewayCheck() {
   delete process.env.UPSTASH_REDIS_REST_TOKEN;
 }
 
+function makeRecordingCtx() {
+  const pending = [];
+  const ctx = { waitUntil: (p) => { pending.push(p); } };
+  async function settled() {
+    let prev = -1;
+    while (pending.length !== prev) {
+      prev = pending.length;
+      await Promise.allSettled(pending.slice(0, prev));
+    }
+  }
+  return { ctx, settled };
+}
+
+function enableGatewayTelemetry() {
+  process.env.USAGE_TELEMETRY = '1';
+  process.env.AXIOM_API_TOKEN = 'test-token';
+}
+
 beforeEach(() => {
   lastHandlerRequest = null;
   replayCacheKeys = new Map();
+  axiomEvents = [];
   process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
   process.env.CONVEX_SITE_URL = CONVEX_SITE;
   process.env.CONVEX_SERVER_SHARED_SECRET = CONVEX_SECRET;
@@ -800,6 +825,66 @@ describe('gateway internal-MCP HMAC verify — error paths', () => {
       const j = await res.json().catch(() => ({}));
       assert.notEqual(j.error, 'CONFIGURATION', 'no CONFIGURATION error on legacy path');
     }
+  });
+});
+
+// ===========================================================================
+// TELEMETRY — missing HMAC config vs malformed signature (#7277)
+// ===========================================================================
+describe('gateway internal-MCP — usage telemetry reasons', () => {
+  it('missing MCP_INTERNAL_HMAC_SECRET emits hmac_secret_unconfigured, not auth_401', async () => {
+    delete process.env.MCP_PRO_GRANT_HMAC_SECRET;
+    delete process.env.MCP_INTERNAL_HMAC_SECRET;
+    enableGatewayTelemetry();
+    const handler = makeGateway();
+    const recorder = makeRecordingCtx();
+    const req = new Request('https://example.test/api/news/v1/summarize-article', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [INTERNAL_MCP_SIG_HEADER]: '1700000000.AAAA',
+        [INTERNAL_MCP_USER_ID_HEADER]: PRO_USER_ID,
+      },
+      body: JSON.stringify({ x: 1 }),
+    });
+    const res = await handler(req, recorder.ctx);
+    assert.equal(res.status, 500);
+    assert.deepEqual(await res.json(), {
+      error: 'CONFIGURATION',
+      detail: 'MCP_INTERNAL_HMAC_SECRET not configured',
+    });
+    await recorder.settled();
+    assert.equal(axiomEvents.length, 1, 'exactly one request event');
+    assert.equal(axiomEvents[0].status, 500);
+    assert.equal(axiomEvents[0].reason, 'hmac_secret_unconfigured');
+    assert.notEqual(axiomEvents[0].reason, 'auth_401');
+    assert.equal(
+      JSON.stringify(axiomEvents[0]).includes(HMAC_SECRET),
+      false,
+      'telemetry must not include the HMAC secret',
+    );
+  });
+
+  it('malformed signature still emits auth_401', async () => {
+    enableGatewayTelemetry();
+    const handler = makeGateway();
+    const recorder = makeRecordingCtx();
+    const req = new Request('https://example.test/api/news/v1/summarize-article', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [INTERNAL_MCP_SIG_HEADER]: 'notanumber.AAAA',
+        [INTERNAL_MCP_USER_ID_HEADER]: PRO_USER_ID,
+      },
+      body: JSON.stringify({ x: 1 }),
+    });
+    const res = await handler(req, recorder.ctx);
+    assert.equal(res.status, 401);
+    assert.deepEqual(await res.json(), { error: 'invalid_internal_mcp_signature' });
+    await recorder.settled();
+    assert.equal(axiomEvents.length, 1, 'exactly one request event');
+    assert.equal(axiomEvents[0].status, 401);
+    assert.equal(axiomEvents[0].reason, 'auth_401');
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #7277. When an internal MCP signature is presented but `MCP_INTERNAL_HMAC_SECRET` is missing, the gateway still returns `500 CONFIGURATION` with the same body. The usage-telemetry reason for that path is now `hmac_secret_unconfigured` instead of `auth_401`, so a deploy/config incident is not counted as caller authentication failure.

Malformed or invalid signatures still emit `auth_401`.

Closes #7277.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: gateway usage telemetry (`wm_api_usage` request reason)

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`) — `npm run typecheck:api` passed
- [ ] New or repointed health probes have a completed Railway-side pre-seed, a one-way durable activation marker for an intentionally gated producer, or an owner-bound baseline acknowledgement with an entry-level `expiresAt` bounded to the first scheduled cron window (if applicable)

## Documentation Alignment Checklist

- [x] N/A — this PR does not publish or change documentation claims

## Screenshots

N/A — telemetry classification change. Focused proof: `tests/gateway-internal-mcp.test.mjs` (`gateway internal-MCP — usage telemetry reasons`) plus the existing 500 CONFIGURATION and malformed-signature cases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42e8cbd6-ebad-40f5-b84e-e6d15fe36c63?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42e8cbd6-ebad-40f5-b84e-e6d15fe36c63&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

