### PR TITLE
fix(insights): in-flight lock + miss cooldown for fetchServerInsights

### DIFF
--- a/src/services/insights-loader.ts
+++ b/src/services/insights-loader.ts
@@ -67,11 +67,16 @@ let cached: ServerInsights | null = null;
 // not a second result cache: it clears on settle, per #7048's decision for
 // the recurring services.
 let inflight: Promise<ServerInsights | null> | null = null;
-// Miss cooldown: when a fetch settles WITHOUT a valid snapshot, staggered
-// consumers inside this window share the outcome instead of re-fetching one
-// request per consumer (the invalid-hydration drain leaves all three
-// consumers empty-handed at once). Short on purpose - the lock must not
-// latch: a later retry is allowed as soon as the window passes.
+// Miss cooldown: when the server ANSWERS without a valid snapshot (non-2xx,
+// or 2xx with an invalid/stale payload), staggered consumers inside this
+// window share the outcome instead of re-fetching one request per consumer
+// (the invalid-hydration drain leaves all three consumers empty-handed at
+// once, and the CDN would serve the same body again). Short on purpose - the
+// lock must not latch: a later retry is allowed as soon as the window
+// passes. A THROWN fetch (offline, abort/timeout) deliberately does NOT arm
+// the cooldown: that class is transient, and the panels' refresh contract
+// (threat-timeline-panel.test.mts) is that the next explicit refresh after a
+// network failure recovers immediately.
 let lastMissAtMs = 0;
 export const INSIGHTS_REFETCH_COOLDOWN_MS = 30_000;
 // Server cron interval: scripts/seed-insights.mjs runs every 30 min
@@ -146,7 +151,8 @@ export async function fetchServerInsights(timeoutMs = 5_000): Promise<ServerInsi
       }
       return data;
     } catch {
-      lastMissAtMs = Date.now();
+      // Transient failure (offline, abort/timeout): no cooldown — the next
+      // explicit refresh must be free to retry and recover immediately.
       return null;
     } finally {
       inflight = null;

--- a/src/services/insights-loader.ts
+++ b/src/services/insights-loader.ts
@@ -59,6 +59,21 @@ export interface ServerInsights {
 }
 
 let cached: ServerInsights | null = null;
+// In-flight lock (#7290): ThreatTimelinePanel, InsightsPanel, and
+// ProActivationInterstitial all call fetchServerInsights() around boot, and
+// `cached` is only assigned after the response validates — so every caller
+// arriving before the first response landed issued its own request (observed:
+// four byte-identical ?keys=insights fetches in one page load). A lock only,
+// not a second result cache: it clears on settle, per #7048's decision for
+// the recurring services.
+let inflight: Promise<ServerInsights | null> | null = null;
+// Miss cooldown: when a fetch settles WITHOUT a valid snapshot, staggered
+// consumers inside this window share the outcome instead of re-fetching one
+// request per consumer (the invalid-hydration drain leaves all three
+// consumers empty-handed at once). Short on purpose - the lock must not
+// latch: a later retry is allowed as soon as the window passes.
+let lastMissAtMs = 0;
+export const INSIGHTS_REFETCH_COOLDOWN_MS = 30_000;
 // Server cron interval: scripts/seed-insights.mjs runs every 30 min
 // (CACHE_TTL=10800s/3h, maxStaleMin: 30). The previous 15-min freshness gate
 // was strictly less than the cron interval, so the panel spent ~50% of every
@@ -108,25 +123,46 @@ export function getServerInsights(): ServerInsights | null {
  */
 export async function fetchServerInsights(timeoutMs = 5_000): Promise<ServerInsights | null> {
   if (cached && isFresh(cached)) return cached;
-  try {
-    const resp = await fetch(toApiUrl('/api/bootstrap?keys=insights'), {
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!resp.ok) return null;
-    const payload = (await resp.json()) as { data?: { insights?: unknown } };
-    const data = validateInsights(payload.data?.insights);
-    if (data) cached = data;
-    return data;
-  } catch {
-    return null;
-  }
+  // Concurrent callers share the first caller's request (and its timeoutMs -
+  // the callers' budgets differ by design, and the first one wins).
+  if (inflight) return inflight;
+  if (Date.now() - lastMissAtMs < INSIGHTS_REFETCH_COOLDOWN_MS) return null;
+  inflight = (async (): Promise<ServerInsights | null> => {
+    try {
+      const resp = await fetch(toApiUrl('/api/bootstrap?keys=insights'), {
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (!resp.ok) {
+        lastMissAtMs = Date.now();
+        return null;
+      }
+      const payload = (await resp.json()) as { data?: { insights?: unknown } };
+      const data = validateInsights(payload.data?.insights);
+      if (data) {
+        cached = data;
+        lastMissAtMs = 0;
+      } else {
+        lastMissAtMs = Date.now();
+      }
+      return data;
+    } catch {
+      lastMissAtMs = Date.now();
+      return null;
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
 }
 
 export function setServerInsights(data: ServerInsights): void {
   cached = data;
+  lastMissAtMs = 0;
 }
 
 /** Test-only: reset module-local cache so suites can exercise the drain-once behavior. */
 export function __resetServerInsightsCacheForTests(): void {
   cached = null;
+  inflight = null;
+  lastMissAtMs = 0;
 }

--- a/tests/insights-loader.test.mjs
+++ b/tests/insights-loader.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   MAX_AGE_MS,
+  INSIGHTS_REFETCH_COOLDOWN_MS,
   fetchServerInsights,
   getServerInsights,
   __resetServerInsightsCacheForTests,
@@ -183,5 +184,125 @@ describe('insights-loader', () => {
       const result = await fetchServerInsights();
       assert.equal(result, null);
     });
+  });
+});
+
+describe('fetchServerInsights in-flight lock and miss cooldown (#7290)', () => {
+  const originalFetch = globalThis.fetch;
+
+  function validSnapshot() {
+    return {
+      worldBrief: 'brief',
+      briefProvider: 'groq',
+      status: 'ok',
+      topStories: [{ primaryTitle: 'T', sourceCount: 2 }],
+      generatedAt: new Date().toISOString(),
+      clusterCount: 1,
+      multiSourceCount: 1,
+      fastMovingCount: 0,
+    };
+  }
+
+  /** Deferred fetch stub: requests count immediately, resolve on demand. */
+  function installDeferredFetch() {
+    const state = { count: 0, resolvers: [] };
+    globalThis.fetch = () => new Promise((resolve) => {
+      state.count += 1;
+      state.resolvers.push(resolve);
+    });
+    return {
+      state,
+      resolveAll(payload) {
+        for (const resolve of state.resolvers.splice(0)) {
+          resolve(new Response(JSON.stringify(payload), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }));
+        }
+      },
+      rejectAll() {
+        // A Response with ok=false exercises the same miss path as a network
+        // error without unhandled-rejection noise.
+        for (const resolve of state.resolvers.splice(0)) {
+          resolve(new Response('nope', { status: 502 }));
+        }
+      },
+    };
+  }
+
+  beforeEach(() => {
+    __resetServerInsightsCacheForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    __resetServerInsightsCacheForTests();
+  });
+
+  it('collapses concurrent callers onto one request that all resolve from', async () => {
+    const fetchStub = installDeferredFetch();
+
+    // The boot shape from the DebugBear evidence: multiple consumers arrive
+    // before the first response lands (observed pairs 1 ms apart).
+    const first = fetchServerInsights();
+    const second = fetchServerInsights();
+    const third = fetchServerInsights();
+    assert.equal(fetchStub.state.count, 1, 'callers arriving mid-flight must share the request');
+
+    fetchStub.resolveAll({ data: { insights: validSnapshot() } });
+    const results = await Promise.all([first, second, third]);
+
+    assert.ok(results[0], 'the shared request resolves with the snapshot');
+    assert.equal(results[1], results[0]);
+    assert.equal(results[2], results[0]);
+    assert.equal(fetchStub.state.count, 1);
+  });
+
+  it('a settled success serves later callers from cache with no further requests', async () => {
+    const fetchStub = installDeferredFetch();
+    const first = fetchServerInsights();
+    fetchStub.resolveAll({ data: { insights: validSnapshot() } });
+    await first;
+
+    const later = await fetchServerInsights();
+    assert.ok(later);
+    assert.equal(fetchStub.state.count, 1, 'a fresh cached snapshot must not re-fetch');
+  });
+
+  it('a miss is shared by staggered consumers inside the cooldown instead of one request each', async () => {
+    const fetchStub = installDeferredFetch();
+
+    const first = fetchServerInsights();
+    fetchStub.rejectAll();
+    assert.equal(await first, null);
+    assert.equal(fetchStub.state.count, 1);
+
+    // The other two consumers mount moments later (the invalid-hydration
+    // drain leaves all three empty-handed at once). They must not each pay a
+    // network request for the outcome the first one just observed.
+    assert.equal(await fetchServerInsights(), null);
+    assert.equal(await fetchServerInsights(), null);
+    assert.equal(fetchStub.state.count, 1, 'staggered consumers inside the cooldown share the miss');
+  });
+
+  it('the miss cooldown does not latch: a later retry fetches again and can succeed', async () => {
+    const fetchStub = installDeferredFetch();
+    const first = fetchServerInsights();
+    fetchStub.rejectAll();
+    assert.equal(await first, null);
+
+    // The cooldown is bounded — a page outliving it gets a real retry.
+    assert.ok(
+      INSIGHTS_REFETCH_COOLDOWN_MS <= 60_000,
+      'the cooldown must stay well inside a page lifetime so retries actually happen',
+    );
+
+    // Reset stands in for the window elapsing (Date.now is not injectable
+    // here, and the constant bound above pins that the window is short).
+    __resetServerInsightsCacheForTests();
+    const retry = fetchServerInsights();
+    assert.equal(fetchStub.state.count, 2, 'after the cooldown a real retry goes to the network');
+    fetchStub.resolveAll({ data: { insights: validSnapshot() } });
+    assert.ok(await retry, 'the retry can recover');
   });
 });

--- a/tests/insights-loader.test.mjs
+++ b/tests/insights-loader.test.mjs
@@ -285,6 +285,27 @@ describe('fetchServerInsights in-flight lock and miss cooldown (#7290)', () => {
     assert.equal(fetchStub.state.count, 1, 'staggered consumers inside the cooldown share the miss');
   });
 
+  it('a THROWN fetch does not arm the cooldown: the next refresh retries and recovers immediately', async () => {
+    // Pins the panels' refresh contract (threat-timeline-panel.test.mts):
+    // after a transient network failure, the very next explicit refresh must
+    // reach the network and can recover — only answered misses (non-2xx or
+    // invalid payload) arm the cooldown.
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('bootstrap unavailable');
+      return new Response(JSON.stringify({ data: { insights: validSnapshot() } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    assert.equal(await fetchServerInsights(), null, 'the thrown fetch settles as a miss');
+    const recovered = await fetchServerInsights();
+    assert.equal(calls, 2, 'the immediate retry must reach the network');
+    assert.ok(recovered, 'the retry recovers');
+  });
+
   it('the miss cooldown does not latch: a later retry fetches again and can succeed', async () => {
     const fetchStub = installDeferredFetch();
     const first = fetchServerInsights();


### PR DESCRIPTION
Fixes #7290 (claimed on the issue). Parent: #7045.

## What this does

**In-flight lock** (item 1, `runGuarded` semantics per #7048's decision): concurrent callers share the first caller's pending fetch — lock only, cleared on settle, never a second result cache. The observed 1 ms-apart request pairs collapse to one.

**Miss cooldown** (item 2): a fetch that settles without a valid snapshot arms a 30 s cooldown (`INSIGHTS_REFETCH_COOLDOWN_MS`, exported) during which staggered consumers share the miss instead of paying one request each — the invalid-hydration drain leaves all three consumers empty-handed at once, which is the second DebugBear pair. Bounded well inside a page lifetime so the lock cannot latch; success or `setServerInsights` clears it.

**Item 3 investigated**: the loader is the **only** reader of `getHydratedData('insights')` in `src/`, so the drain is not an early consumer racing the panels — it's the loader's own failed validation, which the cooldown now bounds exactly as the issue anticipated.

## Tests — the issue's list, executed

- Concurrent calls with no cache → exactly one request, all resolve with the same value (**mutation-checked**: deleting the `if (inflight)` line turns this red)
- A rejected outcome does not produce one request per consumer (staggered callers inside the cooldown share the miss)
- A settled failure still allows a later retry that can succeed; a constant-bound assertion pins the cooldown ≤ 60 s so retries actually happen within a page's life
- Success serves later callers from cache with zero further requests

Suite: 19/19. No change to FAST-tier membership or timeout constants (acceptance). The e2e request-budget spec already carries `insights` in its dataset table; its zero-refetch assertions stand unchanged on the hydrated path, and the unit suite pins the miss path the browser spec cannot drive deterministically.