### PR TITLE
fix(health): keep JODI payloads through the 40-day stale gate

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1173,12 +1173,12 @@ const SEED_META = {
   // later as a generic STALE_SEED. Content age is producer-declared
   // (newestItemAt/maxContentAgeMin in seed-meta) — a frozen upstream file
   // reads STALE_CONTENT rather than passing as fresh.
-  jodiOil:              { key: 'seed-meta:energy:jodi-oil',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // monthly cron on 25th; 40d threshold matches 35d TTL + 5d buffer
+  jodiOil:              { key: 'seed-meta:energy:jodi-oil',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // monthly 35d cadence; 40d = cadence + 5d late-publisher grace. Data/meta TTL is 70d (2× cadence) so last-good outlives this gate and one missed monthly publish.
   ieaOilStocks:         { key: 'seed-meta:energy:iea-oil-stocks',        maxStaleMin: 60 * 24 * 40 }, // monthly cron on 15th; 40d threshold = TTL_SECONDS
   oilStocksAnalysis:    { key: 'seed-meta:energy:oil-stocks-analysis',   maxStaleMin: 60 * 24 * 50 }, // afterPublish of ieaOilStocks; 50d = matches seed-meta TTL (exceeds 40d data TTL)
   eiaPetroleum:         { key: 'seed-meta:energy:eia-petroleum',         maxStaleMin: 4320 }, // daily bundle cron (seed-bundle-energy-sources); 72h = 3× interval, well under 7d data TTL
-  jodiGas:              { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // monthly cron on 25th; 40d threshold matches 35d TTL + 5d buffer
-  lngVulnerability:     { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // written by jodi-gas seeder afterPublish; shares seed-meta key
+  jodiGas:              { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // monthly 35d cadence; 40d = cadence + 5d late-publisher grace. Data/meta TTL is 70d (2× cadence) so last-good outlives this gate and one missed monthly publish.
+  lngVulnerability:     { key: 'seed-meta:energy:jodi-gas',               maxStaleMin: 60 * 24 * 40, chinaRow: true }, // written by jodi-gas seeder afterPublish; shares seed-meta key and the 70d GAS_TTL
   chokepointBaselines:  { key: 'seed-meta:energy:chokepoint-baselines', maxStaleMin: 60 * 24 * 400 }, // 400 days
   // maxStaleMin is 120d = 2x the 60-day bundle interval, matching the repo's
   // 2-3x norm. The data is annual but the PUBLISHER runs every 60 days, so the

--- a/scripts/seed-jodi-gas.mjs
+++ b/scripts/seed-jodi-gas.mjs
@@ -28,7 +28,7 @@ const inflateRawAsync = promisify(inflateRaw);
 export const CANONICAL_KEY = 'energy:jodi-gas:v1:_countries';
 export const KEY_PREFIX = 'energy:jodi-gas:v1:';
 export const LNG_VULNERABILITY_KEY = 'energy:lng-vulnerability:v1';
-export const GAS_TTL = 3_024_000;
+export const GAS_TTL = 70 * 24 * 3600; // 70 days: 2× 35d cadence so one missed monthly publish still serves last-good through the 40d STALE_SEED window (#7273)
 
 const ZIP_URL = 'https://www.jodidata.org/jodi-publisher/gas/17/GAS_world_NewFormat.zip';
 const CSV_FILENAME = 'STAGING_world_NewFormat.csv';
@@ -371,7 +371,7 @@ if (isMain) {
 
     declareRecords,
     schemaVersion: 1,
-    maxStaleMin: 57600,
+    maxStaleMin: 40 * 24 * 60, // 40d: 35d cadence + 5d late-publisher grace; must stay below GAS_TTL (#7273)
     sourceVersion: 'jodi-gas-v1',
   });
 }

--- a/scripts/seed-jodi-oil.mjs
+++ b/scripts/seed-jodi-oil.mjs
@@ -38,7 +38,7 @@ const JODI_MEASUREMENT_FIELDS = require('./shared/jodi-measurement-fields.json')
 
 export const CANONICAL_KEY = 'energy:jodi-oil:v1:_countries';
 export const COUNTRY_KEY_PREFIX = 'energy:jodi-oil:v1:';
-export const JODI_TTL = 3_024_000; // 35 days
+export const JODI_TTL = 70 * 24 * 3600; // 70 days: 2× 35d cadence so one missed monthly publish still serves last-good through the 40d STALE_SEED window (#7273)
 const META_KEY = 'seed-meta:energy:jodi-oil';
 const LOCK_DOMAIN = 'energy:jodi-oil';
 const LOCK_TTL_MS = 10 * 60 * 1000;

--- a/tests/jodi-oil-seed.test.mjs
+++ b/tests/jodi-oil-seed.test.mjs
@@ -56,8 +56,8 @@ describe('CANONICAL_KEY contract', () => {
     assert.equal(COUNTRY_KEY_PREFIX, 'energy:jodi-oil:v1:');
   });
 
-  it('JODI_TTL is 35 days in seconds', () => {
-    assert.equal(JODI_TTL, 35 * 24 * 3600);
+  it('JODI_TTL is 70 days in seconds', () => {
+    assert.equal(JODI_TTL, 70 * 24 * 3600);
   });
 });
 

--- a/tests/jodi-ttl-outlives-staleness.test.mjs
+++ b/tests/jodi-ttl-outlives-staleness.test.mjs
@@ -1,0 +1,218 @@
+// JODI oil/gas data TTL must OUTLIVE the 40-day health STALE_SEED gate, and
+// must cover one missed monthly publisher cycle (#7273).
+//
+// The defect: both seeders wrote a 35-day TTL while /api/health waited 40 days
+// before calling the seeder stale, and the energy-sources bundle also throttles
+// JODI at 35 days. One missed monthly publish therefore erased the payload at
+// day 35 (EMPTY, crit) before health was willing to warn (STALE_SEED).
+//
+// The co-pin:
+//   cadence        35d  (bundle intervalMs)
+//   maxStaleMin    40d  (35d cadence + 5d late-publisher grace)
+//   data/meta TTL  70d  (2× cadence: last-good survives one missed monthly publish)
+//
+// Escalation with data still served:
+//   day 0–40   OK (or STALE_CONTENT if the upstream file is frozen)
+//   day 40–70  STALE_SEED
+//   day 70+    EMPTY
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { JODI_TTL } from '../scripts/seed-jodi-oil.mjs';
+import { GAS_TTL } from '../scripts/seed-jodi-gas.mjs';
+import {
+  MAX_JODI_CONTENT_AGE_MIN,
+  MAX_JODI_GAS_CONTENT_AGE_MIN,
+} from '../scripts/shared/jodi-content-age.mjs';
+import { monthPeriodEnd } from '../scripts/shared/jodi-demand-change.mjs';
+import { __testing__ } from '../api/health.js';
+import {
+  extractBundleSections,
+  resolveExpr,
+} from './helpers/bundle-section-parser.mjs';
+
+const { classifyKey, STANDALONE_KEYS, SEED_META } = __testing__;
+
+const DAY_SECONDS = 24 * 3600;
+const DAY_MIN = 24 * 60;
+const ONE_MIN_MS = 60_000;
+const CADENCE_DAYS = 35;
+const CADENCE_SECONDS = CADENCE_DAYS * DAY_SECONDS;
+const NOW = Date.parse('2026-08-28T00:00:00.000Z');
+
+const CHINA_ROW = {
+  ok: false,
+  reason: 'china-missing',
+  dataMonth: null,
+  ageMonths: null,
+  unavailableSince: Date.parse('2026-06-01T00:00:00.000Z'),
+};
+
+const JODI_CHECKS = [
+  { name: 'jodiOil', ttl: JODI_TTL, contentBudget: MAX_JODI_CONTENT_AGE_MIN },
+  { name: 'jodiGas', ttl: GAS_TTL, contentBudget: MAX_JODI_GAS_CONTENT_AGE_MIN },
+  { name: 'lngVulnerability', ttl: GAS_TTL, contentBudget: MAX_JODI_GAS_CONTENT_AGE_MIN },
+];
+
+function classify(name, {
+  ageMin,
+  present = true,
+  newestMonth = '2026-07',
+  maxContentAgeMin,
+} = {}) {
+  const dataKey = STANDALONE_KEYS[name];
+  const metaKey = SEED_META[name].key;
+  const check = JODI_CHECKS.find((row) => row.name === name);
+  return classifyKey(name, dataKey, {}, {
+    keyStrens: new Map(present ? [[dataKey, 4096]] : []),
+    keyErrors: new Map(),
+    keyMetaValues: new Map([[metaKey, JSON.stringify({
+      fetchedAt: NOW - ageMin * ONE_MIN_MS,
+      recordCount: 57,
+      newestItemAt: Date.parse(monthPeriodEnd(newestMonth)),
+      oldestItemAt: Date.parse(monthPeriodEnd('2024-01')),
+      maxContentAgeMin: maxContentAgeMin ?? check.contentBudget,
+      chinaRow: CHINA_ROW,
+    })]]),
+    keyMetaErrors: new Map(),
+    now: NOW,
+  });
+}
+
+function jodiBundleIntervals() {
+  const bundleSrc = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', 'scripts', 'seed-bundle-energy-sources.mjs'),
+    'utf8',
+  );
+  const wanted = new Map([
+    ['JODI-Gas', 'seed-jodi-gas.mjs'],
+    ['JODI-Oil', 'seed-jodi-oil.mjs'],
+  ]);
+  const found = [];
+  for (const section of extractBundleSections(bundleSrc)) {
+    const script = wanted.get(section.label);
+    if (script !== section.script) continue;
+    found.push({
+      label: section.label,
+      intervalMs: resolveExpr(bundleSrc, section.intervalMsExpr),
+    });
+  }
+  return found;
+}
+
+test('JODI oil, gas, and LNG data TTLs outlive the 40-day STALE_SEED gate', () => {
+  for (const { name, ttl } of JODI_CHECKS) {
+    const maxStaleSeconds = SEED_META[name].maxStaleMin * 60;
+    assert.ok(
+      ttl > maxStaleSeconds,
+      `${name} TTL (${ttl}s) must exceed health maxStaleMin `
+        + `(${SEED_META[name].maxStaleMin}min = ${maxStaleSeconds}s), or the payload `
+        + 'expires before STALE_SEED can fire and a late publisher reports EMPTY',
+    );
+  }
+});
+
+test('JODI TTLs cover one missed 35-day publisher cycle', () => {
+  // Bundle cadence is 35d. A missed monthly publish means the next successful
+  // write is ~70d after the last one. Last-good must still be on the key when
+  // health starts warning at 40d, and through that missed cycle.
+  assert.ok(
+    JODI_TTL >= 2 * CADENCE_SECONDS,
+    `JODI_TTL (${JODI_TTL}s) must cover at least two 35-day cadences (${2 * CADENCE_SECONDS}s)`,
+  );
+  assert.ok(
+    GAS_TTL >= 2 * CADENCE_SECONDS,
+    `GAS_TTL (${GAS_TTL}s) must cover at least two 35-day cadences (${2 * CADENCE_SECONDS}s)`,
+  );
+});
+
+test('the energy-sources bundle still throttles both JODI members at 35 days', () => {
+  const intervals = jodiBundleIntervals();
+  assert.equal(intervals.length, 2, 'expected JODI-Gas and JODI-Oil bundle sections');
+  for (const { label, intervalMs } of intervals) {
+    assert.equal(
+      intervalMs,
+      CADENCE_SECONDS * 1000,
+      `${label} cadence drifted from the 35-day monthly throttle`,
+    );
+  }
+});
+
+test('oil and gas write seed-meta with the same TTL as the data keys', () => {
+  const oilSrc = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', 'scripts', 'seed-jodi-oil.mjs'),
+    'utf8',
+  );
+  assert.match(
+    oilSrc,
+    /SET',\s*META_KEY,\s*JSON\.stringify\(metaPayload\),\s*'EX',\s*JODI_TTL/,
+    'oil seed-meta must use JODI_TTL, not a shorter default that expires before STALE_SEED',
+  );
+
+  const gasSrc = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', 'scripts', 'seed-jodi-gas.mjs'),
+    'utf8',
+  );
+  assert.match(
+    gasSrc,
+    /ttlSeconds:\s*GAS_TTL/,
+    'gas canonical TTL must stay pinned to GAS_TTL',
+  );
+  assert.match(
+    gasSrc,
+    /metaTtlSeconds:\s*GAS_TTL/,
+    'gas seed-meta must use GAS_TTL so the heartbeat outlives the 40-day gate',
+  );
+});
+
+test('the 35–40 day boundary keeps last-good and does not report EMPTY', () => {
+  // Day 37: past the 35d cadence, still inside the 40d grace. Data is present
+  // because TTL is 70d. Health must not jump to EMPTY.
+  const ageMin = 37 * DAY_MIN;
+  for (const { name } of JODI_CHECKS) {
+    const entry = classify(name, { ageMin });
+    assert.equal(
+      entry.status,
+      'OK',
+      `${name} at day 37 (data present, seed inside 40d grace) must stay OK, got ${entry.status}`,
+    );
+    assert.deepEqual(entry.chinaRow, CHINA_ROW, `${name} must keep the China-row diagnostic`);
+  }
+});
+
+test('a missed monthly publish reads STALE_SEED while last-good is still served', () => {
+  // Day 41: past the 40d gate, well inside the 70d TTL. This is the warning
+  // window a 35d TTL made unreachable (payload already gone at day 35).
+  const ageMin = 40 * DAY_MIN + 1;
+  for (const { name, ttl } of JODI_CHECKS) {
+    assert.ok(
+      ttl > ageMin * 60,
+      `${name} TTL must still hold the payload when STALE_SEED fires`,
+    );
+    const entry = classify(name, { ageMin });
+    assert.equal(
+      entry.status,
+      'STALE_SEED',
+      `${name} at day 40+1min with data present must be STALE_SEED, got ${entry.status}`,
+    );
+    assert.deepEqual(entry.chinaRow, CHINA_ROW, `${name} must keep the China-row diagnostic`);
+  }
+});
+
+test('a frozen upstream file still reads STALE_CONTENT when the seeder itself is on time', () => {
+  // Content-age is a different clock. Pinning TTL/health must not swallow a
+  // frozen JODI file into OK or EMPTY while seed-meta is fresh.
+  const frozenMonth = '2025-11';
+  for (const { name } of JODI_CHECKS) {
+    const entry = classify(name, { ageMin: 60, newestMonth: frozenMonth });
+    assert.equal(
+      entry.status,
+      'STALE_CONTENT',
+      `${name} with a frozen file and a fresh seed must stay STALE_CONTENT, got ${entry.status}`,
+    );
+    assert.deepEqual(entry.chinaRow, CHINA_ROW, `${name} must keep the China-row diagnostic`);
+  }
+});

--- a/tests/seed-ttl-outlives-staleness-fleet.test.mjs
+++ b/tests/seed-ttl-outlives-staleness-fleet.test.mjs
@@ -100,7 +100,6 @@ const KNOWN_VIOLATIONS = new Set([
   'seed-imf-labor.mjs',
   'seed-imf-macro.mjs',
   'seed-iran-events.mjs',
-  'seed-jodi-gas.mjs',
   'seed-market-quotes.mjs',
   'seed-portwatch-chokepoints-ref.mjs',
   'seed-portwatch-disruptions.mjs',

--- a/tests/seeder-canonical-ttl-vs-cron.test.mjs
+++ b/tests/seeder-canonical-ttl-vs-cron.test.mjs
@@ -94,7 +94,7 @@ const KNOWN_VIOLATIONS = {
   'Ocean-Ice:seed-climate-ocean-ice.mjs': '24h TTL vs 24h cron (1×)',
 
   // ── Energy ──
-  'JODI-Gas:seed-jodi-gas.mjs': '35d TTL vs 35d cron (1×)',
+  'JODI-Gas:seed-jodi-gas.mjs': '70d TTL vs 35d cron (2×) — one missed-cycle buffer; 3× would be 105d',
 
   // ── Portwatch ──
   'PW-Disruptions:seed-portwatch-disruptions.mjs': '2h TTL vs 1h cron (2×) — borderline',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

JODI oil/gas data and seed-meta expired at 35 days while health waited 40 days before `STALE_SEED`. A dead or late monthly publisher therefore became `EMPTY` at day 35; the warning window never existed.

This co-pins the clocks:

| Clock | Value | Role |
| --- | --- | --- |
| Bundle cadence | 35d | Unchanged monthly throttle |
| Health `maxStaleMin` | 40d | 35d cadence + 5d late-publisher grace |
| Data + meta TTL | 70d | 2× cadence so last-good outlives the gate and one missed monthly publish |

Ordered escalation with last-good still served: OK through day 40, `STALE_SEED` from day 40–70, `EMPTY` only after TTL. Content-age (`STALE_CONTENT`) and China-row diagnostics are unchanged.

`seed-jodi-gas.mjs` is removed from the TTL-vs-staleness fleet allowlist. The 3×-cadence cron guard still records JODI-Gas at 2× (70d vs 35d); that is a separate ratchet and not required to restore `STALE_SEED`.

Fixes #7273

## Type of change

- [x] Bug fix

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: JODI oil/gas seeders, seed-meta TTL, health stale gate

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant — N/A: seeder TTL / health classifier contract; next `seed-bundle-energy-sources` run rewrites keys with the 70d TTL
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`) — N/A surface is `.mjs` seeders + `api/health.js`; biome check clean on the touched files

## Documentation Alignment Checklist

- Claim ledger: N/A
- Audit Council signoffs: N/A

## Testing

Confirmed red before the TTL bump:

```
jodiOil TTL (3024000s) must exceed health maxStaleMin (57600min = 3456000s)
JODI_TTL (3024000s) must cover at least two 35-day cadences (6048000s)
```

Green after:

- `tests/jodi-ttl-outlives-staleness.test.mjs` — 35–40 day boundary stays OK with last-good; day 40+1min is `STALE_SEED` not `EMPTY`; frozen file still `STALE_CONTENT`; China-row preserved on `jodiOil`, `jodiGas`, `lngVulnerability`
- `tests/seed-ttl-outlives-staleness-fleet.test.mjs` — `seed-jodi-gas.mjs` retired from `KNOWN_VIOLATIONS`
- `tests/seeder-canonical-ttl-vs-cron.test.mjs` — allowlist justification updated to 2×
- `tests/jodi-oil-seed.test.mjs`, `tests/jodi-gas-seed.test.mjs`, `tests/china-energy-coverage.test.mjs`
- `biome check` on the seven touched files; `git diff --check` clean

**Deploy note:** existing Redis keys keep their remaining 35d TTL until the next successful JODI seed rewrite. The ordered `STALE_SEED` window applies to payloads published after deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4586296-0e1d-4126-8238-77deb7540738?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4586296-0e1d-4126-8238-77deb7540738&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

