### PR TITLE
fix(gateway): reject unsupported POST-to-GET compatibility bodies instead of silently dropping fields

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -1648,6 +1648,13 @@ export function createDomainGateway(
       if (isPostToGetCompatibleBodySize(request.headers)) {
         const url = new URL(request.url);
         let oversizedKey: string | null = null;
+        // Key whose value has no query-parameter representation (object, null,
+        // or an array with a non-scalar member) — or '' when the body parses
+        // but is not a JSON object at all. Such a body is rejected whole:
+        // converting the representable subset and dropping the rest would let
+        // a stale client believe a discarded filter was applied (#7276), so a
+        // mixed body is never partially applied.
+        let unsupportedKey: string | null = null;
         try {
           const bodyText = await request.clone().text();
           if (new TextEncoder().encode(bodyText).byteLength >= POST_TO_GET_MAX_BODY_BYTES) {
@@ -1660,16 +1667,51 @@ export function createDomainGateway(
           const body = JSON.parse(bodyText);
           const isScalar = (x: unknown): x is string | number | boolean =>
             typeof x === 'string' || typeof x === 'number' || typeof x === 'boolean';
-          for (const [k, v] of Object.entries(body as Record<string, unknown>)) {
-            if (Array.isArray(v)) {
-              if (v.length > POST_TO_GET_MAX_ARRAY_VALUES_PER_KEY) {
-                oversizedKey = k;
+          if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+            unsupportedKey = '';
+          } else {
+            // Validate everything before applying anything, so url stays
+            // untouched unless the entire body converts.
+            const entries = Object.entries(body as Record<string, unknown>);
+            for (const [k, v] of entries) {
+              if (Array.isArray(v)) {
+                if (v.length > POST_TO_GET_MAX_ARRAY_VALUES_PER_KEY) {
+                  oversizedKey = k;
+                  break;
+                }
+                if (!v.every(isScalar)) {
+                  unsupportedKey = k;
+                  break;
+                }
+              } else if (!isScalar(v)) {
+                unsupportedKey = k;
                 break;
               }
-              v.forEach((item) => { if (isScalar(item)) url.searchParams.append(k, String(item)); });
-            } else if (isScalar(v)) url.searchParams.set(k, String(v));
+            }
+            if (oversizedKey === null && unsupportedKey === null) {
+              for (const [k, v] of entries) {
+                if (Array.isArray(v)) v.forEach((item) => url.searchParams.append(k, String(item)));
+                else url.searchParams.set(k, String(v));
+              }
+            }
           }
-        } catch { /* non-JSON body — preserve legacy POST→GET fallback */ }
+        } catch {
+          // Malformed/non-JSON (including empty) bodies keep the legacy
+          // fallback: the POST converts to a parameterless GET. Stale clients
+          // POST empty bodies to GET-only RPC routes, and since JSON.parse
+          // threw, nothing was applied — all-or-nothing still holds.
+        }
+        if (unsupportedKey !== null) {
+          emitRequest(400, 'malformed_request', null);
+          return new Response(JSON.stringify({
+            error: 'Unsupported value for POST compatibility parameter',
+            ...(unsupportedKey === '' ? {} : { parameter: unsupportedKey }),
+            supported: 'a JSON object whose values are scalars or arrays of scalars',
+          }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json', ...corsHeaders },
+          });
+        }
         if (oversizedKey !== null) {
           emitRequest(400, 'malformed_request', null);
           return new Response(JSON.stringify({

--- a/tests/gateway-post-to-get-body.test.mts
+++ b/tests/gateway-post-to-get-body.test.mts
@@ -1,0 +1,213 @@
+/**
+ * #7276 — the POST→GET compatibility path silently dropped non-scalar body
+ * fields.
+ *
+ * Scalars and scalar-array members became query parameters, but object
+ * values and non-scalar array members were skipped without any signal — a
+ * stale client could send `{filter: {region: 'eu'}}`, get a 200, and believe
+ * its filter was applied while the endpoint returned the unfiltered dataset.
+ *
+ * The gateway now validates the whole parsed body before applying anything:
+ * any unsupported value rejects the request with 400 and NO query parameter
+ * from that body is applied (a mixed body must not be partially applied).
+ * Non-JSON (including empty) bodies keep the legacy parameterless-GET
+ * fallback, and the #3550 byte / array-count caps are unchanged.
+ */
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { createDomainGateway } from '../server/gateway.ts';
+import type { RouteDescriptor } from '../server/router.ts';
+
+const originalValidKeys = process.env.WORLDMONITOR_VALID_KEYS;
+const TEST_KEY = 'post-to-get-body-test-key';
+// Fictional path on purpose: nothing in ENDPOINT_RATE_POLICIES matches it,
+// so the gateway pipeline runs without a Redis stub.
+const LIST_PATH = '/api/testdomain/v1/list-things';
+
+afterEach(() => {
+  if (originalValidKeys == null) delete process.env.WORLDMONITOR_VALID_KEYS;
+  else process.env.WORLDMONITOR_VALID_KEYS = originalValidKeys;
+});
+
+function createGateway(seenQueries: string[]) {
+  const routes: RouteDescriptor[] = [
+    {
+      method: 'GET',
+      path: LIST_PATH,
+      handler: async (req) => {
+        seenQueries.push(new URL(req.url).search);
+        return new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    },
+  ];
+  return createDomainGateway(routes);
+}
+
+function makePost(body: string): Request {
+  process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
+  return new Request(`https://worldmonitor.app${LIST_PATH}`, {
+    method: 'POST',
+    body,
+    headers: {
+      Origin: 'https://worldmonitor.app',
+      'X-WorldMonitor-Key': TEST_KEY,
+      // undici does not auto-attach Content-Length on constructed Requests,
+      // and isPostToGetCompatibleBodySize gates the compat path on it.
+      'Content-Length': String(new TextEncoder().encode(body).byteLength),
+    },
+  });
+}
+
+describe('gateway POST→GET compatibility body handling (#7276)', () => {
+  it('still converts a scalar-only body to query parameters', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    const res = await gateway(makePost(JSON.stringify({ a: 1, b: 'x', c: true })));
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(seen, ['?a=1&b=x&c=true']);
+  });
+
+  it('still converts scalar array members to repeated query parameters', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    const res = await gateway(makePost(JSON.stringify({ ids: ['1', '2'], q: 'oil' })));
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(seen, ['?ids=1&ids=2&q=oil']);
+  });
+
+  it('rejects an object value with 400 instead of silently dropping it', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    const res = await gateway(
+      makePost(JSON.stringify({ filter: { region: 'eu' } })),
+    );
+
+    assert.equal(res.status, 400, 'a dropped filter must not masquerade as an applied one');
+    const payload = (await res.json()) as { error: string; parameter?: string };
+    assert.match(payload.error, /unsupported/i);
+    assert.equal(payload.parameter, 'filter');
+    assert.deepEqual(seen, [], 'the handler must not run for a rejected body');
+  });
+
+  it('does not partially apply a mixed body (scalars before the offending key)', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    const res = await gateway(
+      makePost(JSON.stringify({ q: 'oil', filter: { region: 'eu' }, limit: 5 })),
+    );
+
+    assert.equal(res.status, 400);
+    assert.deepEqual(seen, [], 'no parameter from a rejected body may reach the handler');
+  });
+
+  it('rejects a non-scalar array member with 400', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    const res = await gateway(
+      makePost(JSON.stringify({ ids: ['1', { nested: true }] })),
+    );
+
+    assert.equal(res.status, 400);
+    assert.equal(((await res.json()) as { parameter?: string }).parameter, 'ids');
+    assert.deepEqual(seen, []);
+  });
+
+  it('rejects a null value with 400 (null is not representable as a query scalar)', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    const res = await gateway(makePost(JSON.stringify({ region: null })));
+
+    assert.equal(res.status, 400);
+    assert.deepEqual(seen, []);
+  });
+
+  it('rejects a valid-JSON body that is not an object (top-level array)', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    const res = await gateway(makePost(JSON.stringify(['1', '2'])));
+
+    assert.equal(res.status, 400);
+    assert.deepEqual(seen, []);
+  });
+
+  it('rejects a valid-JSON body that is not an object (top-level string)', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    // Pre-#7276 this leaked index→character pairs into the query string.
+    const res = await gateway(makePost(JSON.stringify('abc')));
+
+    assert.equal(res.status, 400);
+    assert.deepEqual(seen, []);
+  });
+
+  it('keeps the legacy parameterless-GET fallback for a malformed-JSON body', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    const res = await gateway(makePost('{oops'));
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(seen, [''], 'malformed JSON converts to a GET with no parameters');
+  });
+
+  it('keeps the legacy parameterless-GET fallback for an empty body', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    const res = await gateway(makePost(''));
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(seen, ['']);
+  });
+
+  it('keeps the #3550 array-count cap with its existing response shape', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    const res = await gateway(
+      makePost(JSON.stringify({ ids: Array.from({ length: 201 }, (_, i) => String(i)) })),
+    );
+
+    assert.equal(res.status, 400);
+    const payload = (await res.json()) as { parameter?: string; maxValues?: number };
+    assert.equal(payload.parameter, 'ids');
+    assert.equal(payload.maxValues, 200);
+    assert.deepEqual(seen, []);
+  });
+
+  it('keeps the #3550 byte cap when Content-Length understates the body', async () => {
+    const seen: string[] = [];
+    const gateway = createGateway(seen);
+
+    process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
+    const body = JSON.stringify({ a: 'x'.repeat(1_048_576) });
+    const res = await gateway(
+      new Request(`https://worldmonitor.app${LIST_PATH}`, {
+        method: 'POST',
+        body,
+        headers: {
+          Origin: 'https://worldmonitor.app',
+          'X-WorldMonitor-Key': TEST_KEY,
+          'Content-Length': '64',
+        },
+      }),
+    );
+
+    assert.equal(res.status, 400);
+    assert.deepEqual(seen, []);
+  });
+});


### PR DESCRIPTION
Fixes #7276

## Problem

The POST→GET compatibility path converted scalars and scalar array members to query parameters but **silently skipped** object values and non-scalar array members. A stale client sending `{filter: {region: 'eu'}}` got a 200 with the unfiltered dataset. A top-level non-object JSON body was worse: `"abc"` leaked `Object.entries` index→character pairs (`?0=a&1=b&2=c`) into the query string.

## Fix (acceptance-criteria mapping)

- **Return 400 on any unsupported non-scalar value** — object, `null`, non-scalar array member, or a parsed body that is not a JSON object. The response names the offending `parameter` and states what is `supported`.
- **No partial application of a mixed body** — the conversion now validates the entire parsed body first and only then applies parameters; `url.searchParams` stays untouched unless everything converts. Verified by a test where scalars precede the offending key and the handler observes no parameters.
- **Malformed/non-JSON fallback decided and documented** — kept: a body `JSON.parse` rejects (including the empty body stale clients POST to GET-only RPC routes) converts to a parameterless GET. Since nothing parses, nothing can be partially applied — all-or-nothing holds. Documented in the catch block.
- **Byte and array-count caps kept** — the ≥1 MB inner re-measure (Content-Length understatement) and the 200-values-per-key cap keep their existing 400 shapes, each pinned by a test.

## Tests

New `tests/gateway-post-to-get-body.test.mts` (12 tests) drives `createDomainGateway` with a fictional GET-only route and asserts the exact query string the handler observes:

- Preserved behavior (passed pre-fix): scalar body → params, scalar arrays → repeated params, malformed-JSON and empty-body legacy fallback, both #3550 caps.
- New behavior (failed pre-fix, 6/12): object value → 400 naming the parameter; mixed body → 400 with handler never invoked; non-scalar array member → 400; `null` value → 400; top-level array and top-level string bodies → 400.
- Mutation check: reverting the object-value rejection (drop-and-continue) turns the suite red (9/12).
- `npm run typecheck` clean, biome clean; sibling gateway suites (`cdn-origin-policy`, `markdown-twin-routing`, `rpc-no-store-contract`, `required-bbox`) all green (38/38).