### PR TITLE
fix(mcp): make quota rejection recovery an atomic floor-guarded clamp

### DIFF
--- a/api/mcp/quota.ts
+++ b/api/mcp/quota.ts
@@ -73,6 +73,23 @@ export function resolvePlanDrivenMcpAllowance(
   return mcpCallsPerDay;
 }
 
+/**
+ * Atomic floor-guarded rejection recovery (#7272). KEYS[1] = daily counter,
+ * ARGV[1] = the resolved limit. Clamps the counter to the limit only while
+ * it is above it, preserving the key's TTL; at or below the limit it changes
+ * nothing. Returns the pre-clamp count (callers treat the reply as
+ * best-effort). Same EVAL-through-pipeline idiom as the free-account
+ * allowance reservation.
+ */
+const REJECTION_RECOVERY_SCRIPT = `
+local c = tonumber(redis.call('GET', KEYS[1]) or '0')
+local limit = tonumber(ARGV[1])
+if c > limit then
+  redis.call('SET', KEYS[1], tostring(limit), 'KEEPTTL')
+end
+return {c}
+`;
+
 export async function reserveQuota(
   userId: string,
   pipeline: PipelineFn,
@@ -120,55 +137,44 @@ export async function reserveQuota(
   };
 
   if (limit !== null && newCount > limit) {
-    // Reject and roll back immediately so the floor stays at the limit
-    // (or wherever concurrent rollbacks land it).
-    await rollback();
-
-    // Counter-clamp (F4): if multiple DECR rollbacks have failed during
-    // a Redis hiccup, the counter can overshoot indefinitely (e.g. land
-    // at 2x the limit). Without clamping, every subsequent INCR for the
-    // rest of the UTC day yields >limit → the user is locked out until
-    // the 48h key TTL expires. The clamp target is the RESOLVED limit,
-    // not the plan default — clamping a 250/day caller down to 50 would
-    // hand them 200 free calls on the next Redis hiccup.
+    // Rejection recovery + counter-clamp (F4), atomically (#7272).
     //
-    // After the rollback, peek at the post-DECR count via a single
-    // best-effort INCR-then-DECR pair — if it's STILL above the limit,
-    // we know the rollback didn't land. Force a defensive
-    // `SET key <limit> KEEPTTL` so the next legitimate INCR (next UTC
-    // day OR next request after the hiccup) starts at limit+1 → 429,
-    // not limit+N → 429-forever.
+    // The old recovery ran three separate best-effort steps — own DECR,
+    // an INCR/DECR probe, then `overshoot` blind DECRs. The probe's
+    // aggregate included OTHER requests' still-live increments, so one
+    // rejection's clamp could absorb a concurrent rejection's increment;
+    // when that request then ran its own DECR, the counter landed BELOW
+    // the limit and admitted extra paid calls.
     //
-    // Why use INCR-then-DECR instead of GET? Keeps the helper to the
-    // same pipeline contract (the tests' makePipelineMock supports
-    // INCR/DECR/EXPIRE only) and avoids adding a new verb. The probe
-    // costs one round-trip but only on the rejection path.
-    if (newCount > limit + 1) {
-      try {
-        const probe = await pipeline([['INCR', key], ['DECR', key]]);
-        const probeIncrRaw = probe?.[0]?.result;
-        const postRollbackCount = typeof probeIncrRaw === 'number' ? probeIncrRaw - 1 : Number.NaN;
-        if (Number.isFinite(postRollbackCount) && postRollbackCount > limit) {
-          // Rollback chain has overshot — force the counter back to the
-          // limit via SET KEEPTTL. This is fail-soft: a concurrent INCR
-          // immediately after this SET will land at limit+1 and 429
-          // normally, which is the desired behavior.
-          //
-          // Use DECR repeatedly as the pipeline-supported clamp (avoids
-          // adding a new verb to test mocks). DECR N times where N is
-          // the overshoot delta. Cap at 100 DECRs to bound the worst-
-          // case round-trip cost.
-          const overshoot = postRollbackCount - limit;
-          const decrs = Math.min(overshoot, 100);
-          const clamp = Array.from({ length: decrs }, () => ['DECR', key] as Array<string | number>);
-          // Best-effort: failure here is the cost-protection-correct
-          // direction (counter stays high → users 429, no DoS exposure).
-          await pipeline(clamp).catch(() => {});
-        }
-      } catch {
-        // Probe failed — leave counter as-is. Worst case the user 429s
-        // until UTC midnight; never under-cap, never DoS exposure.
-      }
+    // The single EVAL below replaces all three steps: clamp to the
+    // resolved limit only while the counter is above it. This both undoes
+    // this request's own increment (it is part of the amount above the
+    // limit) and heals any overshoot left by previously FAILED rollbacks
+    // (a Redis hiccup can strand the counter at 2x the limit, which would
+    // otherwise 429 the user until the 48h key TTL). Because the script
+    // is atomic and floor-guarded, no interleaving of concurrent
+    // rejections can take the counter below the limit — a request whose
+    // increment was already absorbed by another rejection's clamp sees
+    // `counter <= limit` and changes nothing.
+    //
+    // The clamp target is the RESOLVED limit, not the plan default —
+    // clamping a 250/day caller down to 50 would hand them 200 free
+    // calls on the next Redis hiccup. Admitted reservations are
+    // untouched: their `rollback` stays an owner-owned single DECR, and
+    // a charged counter at/below the limit is never modified here.
+    try {
+      // Best-effort: failure leaves the counter high, which is the
+      // cost-protection-correct direction (user 429s, no free calls).
+      await pipeline([[
+        'EVAL',
+        REJECTION_RECOVERY_SCRIPT,
+        1,
+        key,
+        limit,
+      ]]);
+    } catch {
+      // Recovery failed — leave counter as-is. Worst case the user 429s
+      // until UTC midnight; never under-cap, never DoS exposure.
     }
 
     return { ok: false, reason: 'cap-exceeded', floor: limit };

--- a/tests/helpers/mcp-pro-deps.mjs
+++ b/tests/helpers/mcp-pro-deps.mjs
@@ -76,6 +76,13 @@ export function makePipelineMock({ initialCount = 0, throwOnIncr = false, throwO
               : Math.max(0, freeLastActivityExpiresAt - Date.now()),
           ],
         });
+      } else if (cmd[0] === 'EVAL' && Number(cmd[2]) === 1) {
+        // #7272 rejection recovery: atomic floor-guarded clamp. ARGV[1] is
+        // the resolved limit; the counter only moves while it is above it.
+        const limit = Number(cmd[4]);
+        const before = counter;
+        if (Number.isFinite(limit) && counter > limit) counter = limit;
+        out.push({ result: [before] });
       } else if (cmd[0] === 'INCR') {
         counter += 1;
         out.push({ result: counter });

--- a/tests/mcp-quota-concurrent.test.mjs
+++ b/tests/mcp-quota-concurrent.test.mjs
@@ -12,13 +12,12 @@
 // Case 2 — F4 overshoot recovery. With the counter pre-seeded ABOVE the
 // cap (a Redis-hiccup scenario where a prior burst's DECR rollbacks
 // failed and left the counter stuck high), a single over-cap call must
-// drive the counter back DOWN to the cap via the F4 INCR-DECR probe +
-// clamp loop in `reserveQuota`. Without the clamp the user would be
-// 429-locked until the 48 h key TTL. Single-call by design: the F4
-// clamp is sized per-rejection (`Math.min(overshoot, 100)` DECRs), so
-// stacking concurrent rejections each issue their own full clamp pass
-// and over-correct the counter below the cap. That stacked-clamp
-// behaviour is a separate concern and isn't asserted here.
+// drive the counter back DOWN to the cap via the atomic floor-guarded
+// recovery EVAL in `reserveQuota` (#7272). Without the clamp the user
+// would be 429-locked until the 48 h key TTL. Since #7272 stacked
+// concurrent rejections are safe too (the clamp never moves a counter
+// at/below the cap); that cell is asserted by
+// mcp-quota-rejection-clamp.test.mjs.
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import { strict as assert } from 'node:assert';
@@ -120,13 +119,11 @@ describe('api/mcp.ts — concurrent quota reservation (strict clamp)', () => {
   // cap to simulate the scenario the clamp loop is designed for: a prior
   // burst's DECR rollbacks failed and left the counter stuck high.
   // One over-cap tools/call must trigger:
-  //   (1) INCR → newCount = overshoot+1 (above cap+1, so probe runs)
-  //   (2) rollback DECR → counter back to seed
-  //   (3) probe INCR+DECR → reads postRollbackCount = seed
-  //   (4) clamp `seed - cap` DECRs → counter ends at cap exactly
+  //   (1) INCR → newCount = seed+1 (above cap, so recovery runs)
+  //   (2) recovery EVAL sees counter > cap → clamps to cap atomically
   // The discriminating signal is `pipe.count === QUOTA_LIMIT`. Removing
-  // the clamp loop leaves the counter at the seed value (e.g. 80) and
-  // fails this assertion by exact diff.
+  // the clamp leaves the counter at the seed value (e.g. 80) and fails
+  // this assertion by exact diff.
   const PRESEED_OVERSHOOT = 30;
 
   it(`with counter pre-seeded at ${QUOTA_LIMIT + PRESEED_OVERSHOOT} (above cap), a single tools/call drives the F4 clamp; counter converges to exactly ${QUOTA_LIMIT}`, async () => {

--- a/tests/mcp-quota-rejection-clamp.test.mjs
+++ b/tests/mcp-quota-rejection-clamp.test.mjs
@@ -1,0 +1,149 @@
+// #7272 — the rejection clamp could undercount concurrent rollbacks.
+//
+// The old recovery ran three separate best-effort steps (own DECR, an
+// INCR/DECR probe, then `overshoot` blind DECRs). The probe's aggregate
+// included OTHER requests' still-live increments, so one request's clamp
+// could absorb a concurrent rejection's increment — and when that request
+// then performed its own DECR rollback, the counter landed BELOW the limit
+// and admitted extra paid MCP calls. Recovery is now a single atomic
+// floor-guarded EVAL: clamp to the resolved limit only while the counter is
+// above it, so no request can push the counter below the floor and no
+// request ever removes another request's increment.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { makePipelineMock } from './helpers/mcp-pro-deps.mjs';
+
+const originalEnv = { ...process.env };
+
+// Mirrors the hardcoded PRO_DAILY_QUOTA_LIMIT (see mcp-quota-concurrent
+// header for why the literal is intentional).
+const QUOTA_LIMIT = 50;
+
+describe('api/mcp/quota.ts — rejection recovery never undercounts the floor (#7272)', () => {
+  let reserveQuota;
+
+  beforeEach(async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://stub.upstash';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'stub';
+    ({ reserveQuota } = await import(`../api/mcp/quota.ts?t=${Date.now()}-${Math.random()}`));
+  });
+
+  afterEach(() => {
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('two concurrent rejections on an overshot counter: floor never falls below the limit', async () => {
+    // The issue's interleaving: counter stuck at 52 (prior failed rollbacks),
+    // A and B both increment, and each performs its own recovery. The old
+    // clamp counted B's still-live increment as overshoot, then B rolled its
+    // own increment back — landing the counter below 50.
+    const pipe = makePipelineMock({ initialCount: QUOTA_LIMIT + 2 });
+
+    const [a, b] = await Promise.all([
+      reserveQuota('user-a-and-b', pipe.pipeline),
+      reserveQuota('user-a-and-b', pipe.pipeline),
+    ]);
+
+    assert.equal(a.ok, false);
+    assert.equal(b.ok, false);
+    assert.equal(a.reason, 'cap-exceeded');
+    assert.equal(b.reason, 'cap-exceeded');
+    assert.equal(
+      pipe.count, QUOTA_LIMIT,
+      `counter must land exactly at the limit, never below; observed ${pipe.count}`,
+    );
+  });
+
+  it('ten concurrent rejections on an overshot counter converge on exactly the limit', async () => {
+    const pipe = makePipelineMock({ initialCount: QUOTA_LIMIT + 7 });
+
+    const results = await Promise.all(Array.from(
+      { length: 10 },
+      () => reserveQuota('user-burst', pipe.pipeline),
+    ));
+
+    for (const res of results) {
+      assert.equal(res.ok, false);
+      assert.equal(res.reason, 'cap-exceeded');
+    }
+    assert.equal(pipe.count, QUOTA_LIMIT, `observed ${pipe.count}`);
+  });
+
+  it('clamp target is the resolved plan limit, not the 50/day default', async () => {
+    const pipe = makePipelineMock({ initialCount: 280 });
+
+    const res = await reserveQuota('user-pro-biz', pipe.pipeline, 250);
+
+    assert.equal(res.ok, false);
+    assert.equal(res.reason, 'cap-exceeded');
+    assert.equal(res.floor, 250);
+    assert.equal(pipe.count, 250, 'clamping a 250/day caller to 50 would hand out free calls');
+  });
+
+  it('a single rejection at exactly the limit leaves the counter at the limit', async () => {
+    const pipe = makePipelineMock({ initialCount: QUOTA_LIMIT });
+
+    const res = await reserveQuota('user-at-cap', pipe.pipeline);
+
+    assert.equal(res.ok, false);
+    assert.equal(res.reason, 'cap-exceeded');
+    assert.equal(pipe.count, QUOTA_LIMIT);
+  });
+
+  it('recovery failure overshoots, never undershoots (fail-closed direction)', async () => {
+    // Every recovery attempt fails: the increment stays charged and the
+    // caller still gets a cap rejection. High counter = 429s, no free calls.
+    const pipe = makePipelineMock({
+      initialCount: QUOTA_LIMIT + 2,
+      throwOnEval: true,
+      decrFails: true,
+    });
+
+    const res = await reserveQuota('user-hiccup', pipe.pipeline);
+
+    assert.equal(res.ok, false);
+    assert.equal(res.reason, 'cap-exceeded');
+    assert.ok(
+      pipe.count >= QUOTA_LIMIT,
+      `counter must not undershoot the floor on recovery failure; observed ${pipe.count}`,
+    );
+  });
+
+  it('reservation failure stays fail-closed (redis-unavailable, nothing dispatched)', async () => {
+    const pipe = makePipelineMock({ throwOnIncr: true });
+
+    const res = await reserveQuota('user-down', pipe.pipeline);
+
+    assert.equal(res.ok, false);
+    assert.equal(res.reason, 'redis-unavailable');
+    assert.equal(pipe.count, 0);
+  });
+
+  it('unlimited plans still meter without ever rejecting or clamping', async () => {
+    const pipe = makePipelineMock({ initialCount: 100_000 });
+
+    const res = await reserveQuota('user-enterprise', pipe.pipeline, null);
+
+    assert.equal(res.ok, true);
+    assert.equal(pipe.count, 100_001, 'metering is not optional on unlimited plans');
+    const verbs = pipe.ops.flat().map((cmd) => cmd[0]);
+    assert.ok(!verbs.includes('EVAL'), 'no recovery/clamp may run for an unlimited plan');
+  });
+
+  it('admitted reservations keep their own idempotent rollback', async () => {
+    const pipe = makePipelineMock({ initialCount: 10 });
+
+    const res = await reserveQuota('user-ok', pipe.pipeline);
+
+    assert.equal(res.ok, true);
+    assert.equal(pipe.count, 11);
+    await res.rollback();
+    await res.rollback();
+    assert.equal(pipe.count, 10, 'rollback runs exactly once');
+  });
+});


### PR DESCRIPTION
Fixes #7272

## Problem

Rejection recovery ran three separate best-effort steps — the request's own `DECR`, an `INCR`/`DECR` probe, then `overshoot` blind `DECR`s. The probe's aggregate included **other requests' still-live increments**, so in the issue's interleaving (counter overshot to 52, A and B both increment, A clamps an overshoot that includes B's live +1, B then rolls back) the counter landed below the limit and admitted extra paid MCP calls.

## Fix (acceptance-criteria mapping)

- **Atomic, owner-safe recovery** — the three steps are replaced by one `EVAL` (the same EVAL-through-pipeline idiom `reserveFreeAccountAllowance` already uses): clamp the counter to the **resolved** limit only while it is above it, `KEEPTTL`. It undoes the rejected request's own increment (part of the amount above the limit) and heals residue from previously failed rollbacks (the F4 lockout case). Because the script is atomic and floor-guarded, no interleaving of concurrent rejections can take the counter below the limit — a request whose increment was already absorbed by another rejection's clamp sees `counter <= limit` and changes nothing. The safety invariant is that the counter never drops below the true charged count: admissions require `INCR <= limit`, so charged ≤ limit always, and the clamp never sets below the limit.
- **Fail-closed preserved** — reservation `INCR` failure still returns `redis-unavailable` with nothing dispatched; recovery failure leaves the counter high (429s, never free calls). Both pinned by tests.
- **Deterministic concurrent test with an overshot counter** — new `tests/mcp-quota-rejection-clamp.test.mjs` (8 tests) drives `reserveQuota` directly: the issue's two-rejection interleaving at seed limit+2 and a ten-rejection burst at seed limit+7 both assert the counter lands **exactly** at the limit, never below. Pre-fix, both fail (counter 48/49-style undercount); the six invariant tests (plan-limit clamp target, at-cap rejection, fail-closed cells, unlimited metering, idempotent admitted rollback) pass before and after.
- **Plan-driven limits and unlimited metering unchanged** — clamp target is the resolved limit (280→250 test), `null` plans still meter without rejecting or ever issuing the recovery EVAL, admitted reservations keep their owner-owned single-DECR `rollback`.

## Test-harness changes

- `tests/helpers/mcp-pro-deps.mjs`: `makePipelineMock` emulates the new 1-key recovery EVAL (keyed on numkeys, like the existing 3-key free-account EVAL emulation); `throwOnEval` covers its failure path.
- `tests/mcp-quota-concurrent.test.mjs`: updated the two comments that described the old probe/DECR-loop mechanics and the (now fixed) stacked-clamp under-correction; both its tests pass unchanged, including the strict 80-concurrent floor test.

## Verification

- Failing-first: the two concurrency tests fail pre-fix with the exact undercount.
- Mutation check: replacing the recovery EVAL with a plain own-DECR (no clamp) turns 4 tests red across the new suite and the existing F4 convergence tests.
- Full quota + free-account + save-to-storage family: 91/91. `tests/mcp.test.mjs`: 173/173. `npm run typecheck` and biome clean.