### PR TITLE
fix(military): avoid bbox caching global seed snapshots

### DIFF
--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -259,6 +259,49 @@ export async function setCachedJson(key: string, value: unknown, ttlSeconds: num
   }
 }
 
+/**
+ * First-writer-wins JSON publish. Uses SET NX EX so concurrent isolates cannot
+ * overwrite a key the other already persisted. Returns true only when this
+ * caller created the key; false means the key already existed or the write
+ * could not be confirmed. Callers that need the persisted winner must GET
+ * after this and fail closed on a miss.
+ */
+export async function setCachedJsonIfAbsent(key: string, value: unknown, ttlSeconds: number, raw = false): Promise<boolean> {
+  if (process.env.LOCAL_API_MODE === 'tauri-sidecar') {
+    const { sidecarCacheSetIfAbsent } = await import('./sidecar-cache');
+    return sidecarCacheSetIfAbsent(key, value, ttlSeconds);
+  }
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return false;
+  try {
+    const finalKey = raw ? key : prefixKey(key);
+    const resp = await fetch(`${url}/`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'worldmonitor-server/1.0 (redis)',
+      },
+      body: JSON.stringify(['SET', finalKey, JSON.stringify(value), 'EX', String(ttlSeconds), 'NX']),
+      signal: AbortSignal.timeout(REDIS_PIPELINE_TIMEOUT_MS),
+    });
+    const data = (await resp.json().catch(() => null)) as {
+      result?: string | null;
+      error?: string;
+    } | null;
+    if (!resp.ok || data?.error) {
+      console.warn(`[redis] setCachedJsonIfAbsent failed:`, data?.error ?? `HTTP ${resp.status}`);
+      return false;
+    }
+    return data?.result === 'OK';
+  } catch (err) {
+    console.warn('[redis] setCachedJsonIfAbsent failed:', errMsg(err));
+    return false;
+  }
+}
+
 /** Read a bounded Redis list whose members are independently JSON encoded. */
 export async function readCachedJsonList(
   key: string,

--- a/server/_shared/sidecar-cache.ts
+++ b/server/_shared/sidecar-cache.ts
@@ -74,6 +74,13 @@ export function sidecarCacheGet(key: string): unknown | null {
   return JSON.parse(entry.value);
 }
 
+export function sidecarCacheSetIfAbsent(key: string, value: unknown, ttlSeconds: number): boolean {
+  const existing = store.get(key);
+  if (existing && existing.expiresAt > Date.now()) return false;
+  sidecarCacheSet(key, value, ttlSeconds);
+  return true;
+}
+
 export function sidecarCacheSet(key: string, value: unknown, ttlSeconds: number): void {
   const clamped = Math.max(MIN_TTL_S, Math.min(MAX_TTL_S, ttlSeconds));
   const json = JSON.stringify(value);

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -9,7 +9,7 @@ import type {
 
 import { isMilitaryCallsign, isMilitaryHex, detectAircraftType, UPSTREAM_TIMEOUT_MS } from './_shared';
 import { hasFiniteRequestBounds, normalizeBounds, type RequestBounds } from './_bounds';
-import { cachedFetchJson, getRawJson, readCachedJson, setCachedJson } from '../../../_shared/redis';
+import { cachedFetchJson, getRawJson, readCachedJson, setCachedJson, setCachedJsonIfAbsent } from '../../../_shared/redis';
 import { markNoCacheResponse } from '../../../_shared/response-headers';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 import {
@@ -335,15 +335,23 @@ async function fetchStableLiveSeedSnapshot(): Promise<LiveSeedRead> {
   }
 
   if (stableLiveSeedSnapshotInflight) return stableLiveSeedSnapshotInflight;
-  const promise = (async () => {
+  const promise = (async (): Promise<LiveSeedRead> => {
     const seeded = await fetchLiveSeedSnapshot();
     if (seeded.status !== 'hit') return seeded;
-    await setCachedJson(
+    // First writer publishes the cursor source; losers must adopt that
+    // persisted snapshot. Returning the local read after an unconfirmed
+    // write lets the next numeric page slice a different isolate's snapshot.
+    await setCachedJsonIfAbsent(
       STABLE_LIVE_SNAPSHOT_CACHE_KEY,
       { flights: seeded.flights, coverage: seeded.coverage },
       REDIS_CACHE_TTL,
     );
-    return seeded;
+    const persisted = await readCachedJson(STABLE_LIVE_SNAPSHOT_CACHE_KEY);
+    if (persisted.status === 'hit') {
+      const snapshot = parseStableLiveSeedSnapshot(persisted.value);
+      if (snapshot) return { status: 'hit', ...snapshot };
+    }
+    return { status: 'error' };
   })().finally(() => {
     stableLiveSeedSnapshotInflight = null;
   });

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -268,15 +268,23 @@ function seedPayloadToProto(raw: SeedPayload | null): ListMilitaryFlightsRespons
 }
 
 const LIVE_SEED_NEG_TTL_MS = 30_000;
+// Preserve one unpaginated seed snapshot across a bounded cursor traversal
+// without introducing a Redis entry per bbox. The seed root remains the source
+// of truth; this only avoids slicing a different root update on page two.
+const LIVE_SEED_SNAPSHOT_CACHE_TTL_MS = 120_000;
 let liveSeedNegUntil = 0;
 let liveSeedNegStatus: 'miss' | 'error' = 'miss';
 type LiveSeedRead =
   | { status: 'hit'; flights: ListMilitaryFlightsResponse['flights']; coverage: SeedCoverage }
   | { status: 'miss' | 'error' };
 let liveSeedReadPromise: Promise<LiveSeedRead> | null = null;
+let liveSeedSnapshotLocalCache: { result: Extract<LiveSeedRead, { status: 'hit' }>; expiresAt: number } | null = null;
 
 async function fetchLiveSeedSnapshot(): Promise<LiveSeedRead> {
   const now = Date.now();
+  const local = liveSeedSnapshotLocalCache;
+  if (local && local.expiresAt > now) return local.result;
+  liveSeedSnapshotLocalCache = null;
   if (now < liveSeedNegUntil) return { status: liveSeedNegStatus };
   if (liveSeedReadPromise) return liveSeedReadPromise;
 
@@ -297,7 +305,9 @@ async function fetchLiveSeedSnapshot(): Promise<LiveSeedRead> {
     // An absent field predates the producer stamping coverage; regional is the
     // conservative reading, and it is what the payload actually covered then.
     const coverage: SeedCoverage = payload?.coverage === 'global' ? 'global' : 'regional';
-    return { status: 'hit', flights, coverage };
+    const result = { status: 'hit' as const, flights, coverage };
+    liveSeedSnapshotLocalCache = { result, expiresAt: Date.now() + LIVE_SEED_SNAPSHOT_CACHE_TTL_MS };
+    return result;
   })();
   try {
     return await liveSeedReadPromise;
@@ -328,6 +338,7 @@ export function _resetStaleNegativeCacheForTests(): void {
   liveSeedNegUntil = 0;
   liveSeedNegStatus = 'miss';
   liveSeedReadPromise = null;
+  liveSeedSnapshotLocalCache = null;
   staleNegUntil = 0;
   staleSnapshotLocalCache = null;
   staleSnapshotInflight = null;
@@ -458,6 +469,26 @@ export async function listMilitaryFlights(
     if (!hasFiniteRequestBounds(req)) return emptyResponse();
     const requestBounds = normalizeBounds(req);
 
+    // The live seed is the source of truth for an authoritatively covered
+    // snapshot. Its value is independent of this request's bbox, so returning
+    // it through the bbox-keyed provider cache would duplicate the same full
+    // snapshot under every viewport key. Read first, THEN judge coverage: the
+    // declared coverage belongs to the payload, not this module's constants.
+    const seeded = await fetchLiveSeedSnapshot();
+    if (seeded.status === 'error') {
+      // A Redis command/read failure is not proof the snapshot is missing.
+      // Throw before any provider call so the catch can consult stale data
+      // without turning a Redis outage into per-bbox OpenSky fanout.
+      throw new Error('military live seed read failed');
+    }
+    if (seeded.status === 'hit' && seedCovers(seeded.coverage, requestBounds)) {
+      return paginateResponseForCaller(ctx, seeded.flights, [], requestBounds, req);
+    }
+
+    // A miss, or a hit whose coverage does not contain this request (for
+    // example, a regional snapshot asked about the Americas), needs
+    // request-specific recovery. That response is genuinely bbox-dependent.
+
     // Quantize bbox to a 1° grid so nearby map views share cache entries.
     // Precise coordinates caused near-zero hit rate since every pan/zoom created a unique key.
     // Key by the quantized bbox only. The cached value is the complete
@@ -470,33 +501,6 @@ export async function listMilitaryFlights(
       cacheKey,
       REDIS_CACHE_TTL,
       async () => {
-        // The scheduled seeder is the single routine authenticated OpenSky
-        // writer. Cache its unpaginated regional snapshot under the existing
-        // bbox key so every cursor reads one stable version. Requests outside
-        // the producer's declared coverage continue to request-specific
-        // recovery instead of receiving a falsely authoritative empty result.
-        // The producer deliberately preserves its last-good snapshot during an
-        // upstream outage. Keep serving that snapshot (with each flight's old
-        // lastSeenAt intact) while seed health reports the stale fetchedAt;
-        // reopening per-viewer OpenSky recovery here recreates the credit fanout.
-        // Read first, THEN judge coverage: what the snapshot covers is a property
-        // of the payload (the producer stamps it), not of this module's constants.
-        const seeded = await fetchLiveSeedSnapshot();
-        if (seeded.status === 'error') {
-          // A Redis command/read failure is not proof the snapshot is
-          // missing. Throw before any provider call so cachedFetchJson's
-          // bounded negative path prevents per-bbox OpenSky amplification.
-          // The outer catch consults the 24h stale key before giving up.
-          throw new Error('military live seed read failed');
-        }
-        if (seeded.status === 'hit' && seedCovers(seeded.coverage, requestBounds)) {
-          return { flights: seeded.flights, clusters: [], pagination: undefined };
-        }
-        // A miss, or a hit whose coverage does not contain this request (a
-        // regional snapshot asked about the Americas), falls through to
-        // request-specific recovery rather than returning a falsely
-        // authoritative empty.
-
         if (redistributableOnly) return null;
 
         const isSidecar = (process.env.LOCAL_API_MODE || '').includes('sidecar');

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -20,6 +20,7 @@ import {
 const REDIS_CACHE_KEY = 'military:flights:v1';
 const REDIS_CACHE_TTL = 600; // 10 min — reduce upstream API pressure
 const REDIS_STALE_KEY = 'military:flights:stale:v1';
+const STABLE_LIVE_SNAPSHOT_CACHE_KEY = 'military:flights:stable-live:v1';
 const STABLE_STALE_CACHE_KEY = 'military:flights:stable-stale:v1';
 const STALE_SNAPSHOT_CACHE_TTL = 120; // Bind a bounded cursor traversal to one snapshot.
 const STALE_SNAPSHOT_NEG_TTL = 30;
@@ -268,23 +269,16 @@ function seedPayloadToProto(raw: SeedPayload | null): ListMilitaryFlightsRespons
 }
 
 const LIVE_SEED_NEG_TTL_MS = 30_000;
-// Preserve one unpaginated seed snapshot across a bounded cursor traversal
-// without introducing a Redis entry per bbox. The seed root remains the source
-// of truth; this only avoids slicing a different root update on page two.
-const LIVE_SEED_SNAPSHOT_CACHE_TTL_MS = 120_000;
 let liveSeedNegUntil = 0;
 let liveSeedNegStatus: 'miss' | 'error' = 'miss';
 type LiveSeedRead =
   | { status: 'hit'; flights: ListMilitaryFlightsResponse['flights']; coverage: SeedCoverage }
   | { status: 'miss' | 'error' };
 let liveSeedReadPromise: Promise<LiveSeedRead> | null = null;
-let liveSeedSnapshotLocalCache: { result: Extract<LiveSeedRead, { status: 'hit' }>; expiresAt: number } | null = null;
+let stableLiveSeedSnapshotInflight: Promise<LiveSeedRead> | null = null;
 
 async function fetchLiveSeedSnapshot(): Promise<LiveSeedRead> {
   const now = Date.now();
-  const local = liveSeedSnapshotLocalCache;
-  if (local && local.expiresAt > now) return local.result;
-  liveSeedSnapshotLocalCache = null;
   if (now < liveSeedNegUntil) return { status: liveSeedNegStatus };
   if (liveSeedReadPromise) return liveSeedReadPromise;
 
@@ -305,15 +299,56 @@ async function fetchLiveSeedSnapshot(): Promise<LiveSeedRead> {
     // An absent field predates the producer stamping coverage; regional is the
     // conservative reading, and it is what the payload actually covered then.
     const coverage: SeedCoverage = payload?.coverage === 'global' ? 'global' : 'regional';
-    const result = { status: 'hit' as const, flights, coverage };
-    liveSeedSnapshotLocalCache = { result, expiresAt: Date.now() + LIVE_SEED_SNAPSHOT_CACHE_TTL_MS };
-    return result;
+    return { status: 'hit', flights, coverage };
   })();
   try {
     return await liveSeedReadPromise;
   } finally {
     liveSeedReadPromise = null;
   }
+}
+
+interface StableLiveSeedSnapshot {
+  flights: ListMilitaryFlightsResponse['flights'];
+  coverage: SeedCoverage;
+}
+
+function parseStableLiveSeedSnapshot(value: unknown): StableLiveSeedSnapshot | null {
+  if (!value || typeof value !== 'object') return null;
+  const snapshot = value as Partial<StableLiveSeedSnapshot>;
+  if (
+    !Array.isArray(snapshot.flights)
+    || (snapshot.coverage !== 'global' && snapshot.coverage !== 'regional')
+  ) return null;
+  return { flights: snapshot.flights, coverage: snapshot.coverage };
+}
+
+// Cursors are numeric offsets, so every covered live-seed request must page
+// against one shared snapshot rather than isolate-local state. This fixed key
+// replaces the former one-copy-per-bbox cache while retaining its 10-minute
+// traversal window. It never receives provider recovery data.
+async function fetchStableLiveSeedSnapshot(): Promise<LiveSeedRead> {
+  const cached = await readCachedJson(STABLE_LIVE_SNAPSHOT_CACHE_KEY);
+  if (cached.status === 'hit') {
+    const snapshot = parseStableLiveSeedSnapshot(cached.value);
+    if (snapshot) return { status: 'hit', ...snapshot };
+  }
+
+  if (stableLiveSeedSnapshotInflight) return stableLiveSeedSnapshotInflight;
+  const promise = (async () => {
+    const seeded = await fetchLiveSeedSnapshot();
+    if (seeded.status !== 'hit') return seeded;
+    await setCachedJson(
+      STABLE_LIVE_SNAPSHOT_CACHE_KEY,
+      { flights: seeded.flights, coverage: seeded.coverage },
+      REDIS_CACHE_TTL,
+    );
+    return seeded;
+  })().finally(() => {
+    stableLiveSeedSnapshotInflight = null;
+  });
+  stableLiveSeedSnapshotInflight = promise;
+  return promise;
 }
 
 // Negative cache for the stale Redis read — mirrors the legacy
@@ -338,7 +373,7 @@ export function _resetStaleNegativeCacheForTests(): void {
   liveSeedNegUntil = 0;
   liveSeedNegStatus = 'miss';
   liveSeedReadPromise = null;
-  liveSeedSnapshotLocalCache = null;
+  stableLiveSeedSnapshotInflight = null;
   staleNegUntil = 0;
   staleSnapshotLocalCache = null;
   staleSnapshotInflight = null;
@@ -472,9 +507,10 @@ export async function listMilitaryFlights(
     // The live seed is the source of truth for an authoritatively covered
     // snapshot. Its value is independent of this request's bbox, so returning
     // it through the bbox-keyed provider cache would duplicate the same full
-    // snapshot under every viewport key. Read first, THEN judge coverage: the
-    // declared coverage belongs to the payload, not this module's constants.
-    const seeded = await fetchLiveSeedSnapshot();
+    // snapshot under every viewport key. Use one shared stable snapshot before
+    // judging payload-declared coverage so numeric cursors survive another
+    // edge isolate without making provider recovery globally cacheable.
+    const seeded = await fetchStableLiveSeedSnapshot();
     if (seeded.status === 'error') {
       // A Redis command/read failure is not proof the snapshot is missing.
       // Throw before any provider call so the catch can consult stale data

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -2546,7 +2546,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     };
   }
 
-  it('caches the seeded snapshot per bbox before any OpenSky fetch', async () => {
+  it('serves a global seed across distinct bboxes without writing duplicate provider cache snapshots', async () => {
     const { module, cleanup } = await importListMilitaryFlights();
     const restoreEnv = withEnv({
       UPSTASH_REDIS_REST_URL: 'https://redis.test',
@@ -2557,14 +2557,15 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       VERCEL_GIT_COMMIT_SHA: undefined,
     });
     const originalFetch = globalThis.fetch;
-    const redisKeys = [];
+    const redisGetKeys = [];
+    const redisSetKeys = [];
     let openskyCalls = 0;
 
     globalThis.fetch = async (url, init) => {
       const raw = String(url);
       if (raw.includes('/get/')) {
         const key = decodeURIComponent(raw.split('/get/')[1] || '');
-        redisKeys.push(key);
+        redisGetKeys.push(key);
         if (key === 'military:flights:v1') {
           return jsonResponse({
             result: JSON.stringify({
@@ -2577,15 +2578,19 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
                   lon: 10.2,
                   sourceMeta: { source: 'adsb.lol' },
                 },
-                { id: 'seed-out', callsign: 'RCH302', lat: 22.2, lon: 10.2 },
+                { id: 'seed-americas', callsign: 'RCH302', lat: 40.2, lon: -99.8 },
               ],
+              coverage: 'global',
               fetchedAt: Date.now(),
             }),
           });
         }
         return jsonResponse({ result: null });
       }
-      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (isSetRequest(url, init)) {
+        redisSetKeys.push(parseSetRequest(url, init).key);
+        return jsonResponse({ result: 'OK' });
+      }
       if (raw.includes('/opensky') || raw.includes('opensky-network.org')) {
         openskyCalls += 1;
         return jsonResponse({ states: [] });
@@ -2594,16 +2599,27 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     };
 
     try {
-      const result = await module.listMilitaryFlights(
-        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
-        seededRequest,
+      const [europe, americas] = await Promise.all([
+        module.listMilitaryFlights(
+          { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+          seededRequest,
+        ),
+        module.listMilitaryFlights(
+          { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+          americasRequest,
+        ),
+      ]);
+      assert.deepEqual(redisGetKeys, ['military:flights:v1']);
+      assert.deepEqual(
+        redisSetKeys.filter((key) => key.startsWith('military:flights:v1:')),
+        [],
+        'a global seed must never be copied into a bbox-specific provider cache entry',
       );
-      assert.match(redisKeys[0], /^military:flights:v1:/, 'the stable bbox snapshot cache must be checked first');
-      assert.equal(redisKeys[1], 'military:flights:v1', 'a bbox cache miss must read the canonical seed');
       assert.equal(openskyCalls, 0, 'live seed coverage should prevent an OpenSky fetch');
-      assert.deepEqual(result.flights.map((flight) => flight.id), ['adsb-ae0301']);
-      assert.equal(result.flights[0].hexCode, 'AE0301');
-      assert.equal(result.flights[0].source, 'adsb.lol');
+      assert.deepEqual(europe.flights.map((flight) => flight.id), ['adsb-ae0301']);
+      assert.equal(europe.flights[0].hexCode, 'AE0301');
+      assert.equal(europe.flights[0].source, 'adsb.lol');
+      assert.deepEqual(americas.flights.map((flight) => flight.id), ['seed-americas']);
     } finally {
       cleanup();
       globalThis.fetch = originalFetch;
@@ -2659,7 +2675,11 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       assert.deepEqual(result.flights.map((flight) => flight.id), ['wing-1', 'adsb-1']);
       assert.deepEqual(result.flights.map((flight) => flight.source), ['wingbits', 'adsb.lol']);
       assert.deepEqual(result.pagination, { nextCursor: '', totalCount: 2 });
-      assert.match(redisKeys[0], /:redistributable$/, 'API results must not share a cache entry with the product fallback policy');
+      assert.deepEqual(
+        redisKeys,
+        ['military:flights:v1'],
+        'an authoritative seed should be filtered for the caller without a provider cache entry',
+      );
     } finally {
       cleanup();
       globalThis.fetch = originalFetch;
@@ -2755,8 +2775,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
         { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
         seededRequest,
       );
-      assert.match(redisKeys[0], /^military:flights:v1:/);
-      assert.equal(redisKeys[1], 'military:flights:v1');
+      assert.deepEqual(redisKeys, ['military:flights:v1']);
       assert.equal(openskyCalls, 0);
       assert.deepEqual(result, { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } });
     } finally {
@@ -2848,8 +2867,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
         { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
         seededRequest,
       );
-      assert.match(redisKeys[0], /^military:flights:v1:/);
-      assert.equal(redisKeys[1], 'military:flights:v1');
+      assert.equal(redisKeys[0], 'military:flights:v1');
       assert.equal(openskyCalls, 0, 'Redis read failure must fail closed instead of amplifying OpenSky');
       assert.deepEqual(result, { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } });
     } finally {
@@ -2900,7 +2918,6 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     try {
       const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
       const first = await module.listMilitaryFlights(ctx, { ...seededRequest, pageSize: 1, cursor: '' });
-      module._resetStaleNegativeCacheForTests();
       const second = await module.listMilitaryFlights(ctx, {
         ...seededRequest,
         pageSize: 1,
@@ -3534,15 +3551,22 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     const originalFetch = globalThis.fetch;
     let liveSeedReads = 0;
     let openskyCalls = 0;
+    const providerCache = new Map();
+    const providerCacheWrites = [];
 
     globalThis.fetch = async (url, init) => {
       const raw = String(url);
       if (raw.includes('/get/')) {
         const key = decodeURIComponent(raw.split('/get/')[1] || '');
         if (key === 'military:flights:v1') liveSeedReads += 1;
-        return jsonResponse({ result: null });
+        return jsonResponse({ result: providerCache.get(key) ?? null });
       }
-      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (isSetRequest(url, init)) {
+        const { key, value } = parseSetRequest(url, init);
+        providerCache.set(key, value);
+        providerCacheWrites.push(key);
+        return jsonResponse({ result: 'OK' });
+      }
       if (raw.includes('/opensky')) {
         openskyCalls += 1;
         return jsonResponse({
@@ -3553,7 +3577,11 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     };
 
     try {
-      const result = await module.listMilitaryFlights(
+      const first = await module.listMilitaryFlights(
+        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+        request,
+      );
+      const second = await module.listMilitaryFlights(
         { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
         request,
       );
@@ -3561,8 +3589,75 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       // but a MISS must still fall through, or a cold seed would render the
       // whole surface permanently empty.
       assert.equal(liveSeedReads, 1, 'the global snapshot must be consulted before provider recovery');
-      assert.equal(openskyCalls, 1, 'a snapshot miss must still reach request-specific recovery');
-      assert.deepEqual(result.flights.map((flight) => flight.id), ['OUTSIDE-REGION']);
+      assert.equal(openskyCalls, 1, 'a snapshot miss must cache and reuse request-specific recovery');
+      assert.deepEqual(
+        providerCacheWrites,
+        ['military:flights:v1:10:10:11:11::'],
+        'provider recovery must remain under the exact quantized bbox key',
+      );
+      assert.deepEqual(first.flights.map((flight) => flight.id), ['OUTSIDE-REGION']);
+      assert.deepEqual(second.flights.map((flight) => flight.id), ['OUTSIDE-REGION']);
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('never reuses a provider recovery payload across distinct bboxes after a seed miss', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const providerCache = new Map();
+    const providerCacheWrites = [];
+    let openskyCalls = 0;
+    const otherRequest = { swLat: 40, swLon: -100, neLat: 41, neLon: -99 };
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        return jsonResponse({ result: providerCache.get(key) ?? null });
+      }
+      if (isSetRequest(url, init)) {
+        const { key, value } = parseSetRequest(url, init);
+        providerCache.set(key, value);
+        providerCacheWrites.push(key);
+        return jsonResponse({ result: 'OK' });
+      }
+      if (raw.includes('/opensky')) {
+        openskyCalls += 1;
+        const params = new URL(raw).searchParams;
+        const isAmericas = Number(params.get('lamin')) > 30;
+        return jsonResponse({
+          states: [isAmericas
+            ? ['bbox-b', 'RCH402', null, null, null, -99.5, 40.5, 20000, false, 300, 90]
+            : ['bbox-a', 'RCH401', null, null, null, 10.5, 10.5, 20000, false, 300, 90]],
+        });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
+      const a = await module.listMilitaryFlights(ctx, request);
+      const b = await module.listMilitaryFlights(ctx, otherRequest);
+
+      assert.deepEqual(a.flights.map((flight) => flight.id), ['BBOX-A']);
+      assert.deepEqual(b.flights.map((flight) => flight.id), ['BBOX-B']);
+      assert.equal(openskyCalls, 2, 'each bbox must recover independently after a seed miss');
+      assert.deepEqual(
+        providerCacheWrites,
+        ['military:flights:v1:10:10:11:11::', 'military:flights:v1:40:-100:41:-99::'],
+        'a bbox-independent key would poison the second viewport with the first recovery payload',
+      );
     } finally {
       cleanup();
       globalThis.fetch = originalFetch;
@@ -3743,7 +3838,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
 
     try {
       const result = await module.listMilitaryFlights({}, request);
-      assert.equal(redisGetCalls, 1, 'an uncovered bbox should read only its quantized cache');
+      assert.equal(redisGetCalls, 2, 'an uncovered bbox should read the live seed before its quantized cache');
       assert.equal(openskyCalls, 0, 'cache hit should avoid upstream fetch');
       assert.deepEqual(
         result.flights.map((flight) => flight.id),

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -3039,7 +3039,8 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
   });
 
   it('fails closed when stable snapshot publication or readback cannot be confirmed', async () => {
-    const { module, cleanup } = await importListMilitaryFlights();
+    const firstIsolate = await importListMilitaryFlights();
+    const secondIsolate = await importListMilitaryFlights();
     const restoreEnv = withEnv({
       UPSTASH_REDIS_REST_URL: 'https://redis.test',
       UPSTASH_REDIS_REST_TOKEN: 'token',
@@ -3058,7 +3059,10 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
         if (key === 'military:flights:v1') {
           return jsonResponse({
             result: JSON.stringify({
-              flights: [{ id: 'unpersisted', callsign: 'RCH900', lat: 20.2, lon: 10.2 }],
+              flights: [
+                { id: 'unpersisted-a', callsign: 'RCH900', lat: 20.2, lon: 10.2 },
+                { id: 'unpersisted-b', callsign: 'RCH901', lat: 20.3, lon: 10.3 },
+              ],
               coverage: 'global',
               fetchedAt: Date.now(),
             }),
@@ -3081,18 +3085,39 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     };
 
     try {
-      const result = await module.listMilitaryFlights(
-        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
-        seededRequest,
-      );
+      const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
+      const result = await firstIsolate.module.listMilitaryFlights(ctx, {
+        ...seededRequest,
+        pageSize: 1,
+        cursor: '',
+      });
       assert.deepEqual(
         result.flights.map((flight) => flight.id),
         [],
         'an unpersisted local snapshot must not become a cursor source',
       );
+      assert.equal(
+        result.pagination?.nextCursor,
+        '',
+        'unconfirmed publication must fail closed before a numeric cursor is emitted',
+      );
       assert.equal(openskyCalls, 0, 'failed publication must fail closed instead of opening OpenSky');
+
+      const continued = await secondIsolate.module.listMilitaryFlights(ctx, {
+        ...seededRequest,
+        pageSize: 1,
+        cursor: '1',
+      });
+      assert.deepEqual(
+        continued.flights.map((flight) => flight.id),
+        [],
+        'another isolate must not continue an unconfirmed snapshot at a numeric cursor',
+      );
+      assert.equal(continued.pagination?.nextCursor, '');
+      assert.equal(openskyCalls, 0);
     } finally {
-      cleanup();
+      firstIsolate.cleanup();
+      secondIsolate.cleanup();
       globalThis.fetch = originalFetch;
       restoreEnv();
     }

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -105,7 +105,19 @@ function isSetRequest(_url, init) {
 
 function parseSetRequest(_url, init) {
   const body = JSON.parse(String(init.body));
-  return { key: body[1], value: body[2], ttlSeconds: Number(body[4]) };
+  return {
+    key: body[1],
+    value: body[2],
+    ttlSeconds: Number(body[4]),
+    nx: body.includes('NX'),
+  };
+}
+
+function applySetToStore(store, url, init) {
+  const { key, value, nx } = parseSetRequest(url, init);
+  if (nx && store.has(key)) return jsonResponse({ result: null });
+  store.set(key, value);
+  return jsonResponse({ result: 'OK' });
 }
 
 describe('redis caching behavior', { concurrency: 1 }, () => {
@@ -2560,6 +2572,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     const originalFetch = globalThis.fetch;
     const redisGetKeys = [];
     const redisSetKeys = [];
+    const store = new Map();
     let openskyCalls = 0;
 
     globalThis.fetch = async (url, init) => {
@@ -2586,11 +2599,11 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
             }),
           });
         }
-        return jsonResponse({ result: null });
+        return jsonResponse({ result: store.get(key) ?? null });
       }
       if (isSetRequest(url, init)) {
         redisSetKeys.push(parseSetRequest(url, init).key);
-        return jsonResponse({ result: 'OK' });
+        return applySetToStore(store, url, init);
       }
       if (raw.includes('/opensky') || raw.includes('opensky-network.org')) {
         openskyCalls += 1;
@@ -2649,6 +2662,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     });
     const originalFetch = globalThis.fetch;
     const redisKeys = [];
+    const store = new Map();
 
     globalThis.fetch = async (url, init) => {
       const raw = String(url);
@@ -2669,9 +2683,9 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
             }),
           });
         }
-        return jsonResponse({ result: null });
+        return jsonResponse({ result: store.get(key) ?? null });
       }
-      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (isSetRequest(url, init)) return applySetToStore(store, url, init);
       throw new Error(`Unexpected fetch URL: ${raw}`);
     };
 
@@ -2687,7 +2701,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       assert.deepEqual(result.pagination, { nextCursor: '', totalCount: 2 });
       assert.deepEqual(
         redisKeys,
-        [stableLiveCacheKey, 'military:flights:v1'],
+        [stableLiveCacheKey, 'military:flights:v1', stableLiveCacheKey],
         'an authoritative seed should be filtered for the caller without a provider cache entry',
       );
     } finally {
@@ -2759,6 +2773,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     });
     const originalFetch = globalThis.fetch;
     const redisKeys = [];
+    const store = new Map();
     let openskyCalls = 0;
 
     globalThis.fetch = async (url, init) => {
@@ -2766,17 +2781,18 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       if (raw.includes('/get/')) {
         const key = decodeURIComponent(raw.split('/get/')[1] || '');
         redisKeys.push(key);
-        return jsonResponse({
-          result: key === 'military:flights:v1'
-            ? JSON.stringify({ flights: [], fetchedAt: Date.now() })
-            : null,
-        });
+        if (key === 'military:flights:v1') {
+          return jsonResponse({
+            result: JSON.stringify({ flights: [], fetchedAt: Date.now() }),
+          });
+        }
+        return jsonResponse({ result: store.get(key) ?? null });
       }
       if (raw.includes('/opensky') || raw.includes('opensky-network.org')) {
         openskyCalls += 1;
         return jsonResponse({ states: [] });
       }
-      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (isSetRequest(url, init)) return applySetToStore(store, url, init);
       throw new Error(`Unexpected fetch URL: ${raw}`);
     };
 
@@ -2785,7 +2801,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
         { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
         seededRequest,
       );
-      assert.deepEqual(redisKeys, [stableLiveCacheKey, 'military:flights:v1']);
+      assert.deepEqual(redisKeys, [stableLiveCacheKey, 'military:flights:v1', stableLiveCacheKey]);
       assert.equal(openskyCalls, 0);
       assert.deepEqual(result, { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } });
     } finally {
@@ -2917,11 +2933,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
         }
         return jsonResponse({ result: store.get(key) ?? null });
       }
-      if (isSetRequest(url, init)) {
-        const { key, value } = parseSetRequest(url, init);
-        store.set(key, value);
-        return jsonResponse({ result: 'OK' });
-      }
+      if (isSetRequest(url, init)) return applySetToStore(store, url, init);
       throw new Error(`Unexpected fetch URL: ${raw}`);
     };
 
@@ -2950,6 +2962,142 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     }
   });
 
+  it('publishes the stable live snapshot first-writer-wins and returns the persisted winner', async () => {
+    const firstIsolate = await importListMilitaryFlights();
+    const secondIsolate = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const store = new Map();
+    let rootReads = 0;
+    let releaseRoot;
+    const rootGate = new Promise((resolveGate) => { releaseRoot = resolveGate; });
+    const setBodies = [];
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === 'military:flights:v1') {
+          rootReads += 1;
+          const flights = rootReads === 1
+            ? [
+              { id: 'seed-a', callsign: 'RCH501', lat: 20.2, lon: 10.2 },
+              { id: 'seed-b', callsign: 'RCH502', lat: 20.3, lon: 10.3 },
+            ]
+            : [{ id: 'seed-new', callsign: 'RCH599', lat: 20.4, lon: 10.4 }];
+          await rootGate;
+          return jsonResponse({ result: JSON.stringify({ flights, coverage: 'global', fetchedAt: Date.now() }) });
+        }
+        return jsonResponse({ result: store.get(key) ?? null });
+      }
+      if (isSetRequest(url, init)) {
+        setBodies.push(JSON.parse(String(init.body)));
+        return applySetToStore(store, url, init);
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
+      const firstPromise = firstIsolate.module.listMilitaryFlights(ctx, { ...seededRequest, pageSize: 1, cursor: '' });
+      const secondPromise = secondIsolate.module.listMilitaryFlights(ctx, { ...seededRequest, pageSize: 1, cursor: '' });
+      for (let ticks = 0; ticks < 20 && rootReads < 2; ticks += 1) {
+        await new Promise((resolveTick) => setImmediate(resolveTick));
+      }
+      assert.equal(rootReads, 2, 'both isolates must miss the cold stable key and read the rotating root');
+      releaseRoot();
+      const [first, second] = await Promise.all([firstPromise, secondPromise]);
+      const continuation = await secondIsolate.module.listMilitaryFlights(ctx, {
+        ...seededRequest,
+        pageSize: 1,
+        cursor: first.pagination?.nextCursor ?? '',
+      });
+
+      assert.ok(setBodies.every((body) => body.includes('NX')), 'stable snapshot publication must use SET NX EX');
+      assert.ok(setBodies.length >= 2, 'the losing isolate must still attempt SET NX');
+      assert.deepEqual(first.flights.map((flight) => flight.id), ['seed-a']);
+      assert.deepEqual(
+        second.flights.map((flight) => flight.id),
+        ['seed-a'],
+        'the losing isolate must return the persisted winner, not its later root snapshot',
+      );
+      assert.deepEqual(continuation.flights.map((flight) => flight.id), ['seed-b']);
+    } finally {
+      firstIsolate.cleanup();
+      secondIsolate.cleanup();
+      releaseRoot?.();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('fails closed when stable snapshot publication or readback cannot be confirmed', async () => {
+    const { module, cleanup } = await importListMilitaryFlights();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      LOCAL_API_MODE: undefined,
+      WS_RELAY_URL: 'wss://relay.test',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    let openskyCalls = 0;
+
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/')[1] || '');
+        if (key === 'military:flights:v1') {
+          return jsonResponse({
+            result: JSON.stringify({
+              flights: [{ id: 'unpersisted', callsign: 'RCH900', lat: 20.2, lon: 10.2 }],
+              coverage: 'global',
+              fetchedAt: Date.now(),
+            }),
+          });
+        }
+        return jsonResponse({ result: null });
+      }
+      if (isSetRequest(url, init)) {
+        return {
+          ok: false,
+          status: 503,
+          async json() { return null; },
+        };
+      }
+      if (raw.includes('/opensky') || raw.includes('opensky-network.org')) {
+        openskyCalls += 1;
+        return jsonResponse({ states: [] });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      const result = await module.listMilitaryFlights(
+        { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
+        seededRequest,
+      );
+      assert.deepEqual(
+        result.flights.map((flight) => flight.id),
+        [],
+        'an unpersisted local snapshot must not become a cursor source',
+      );
+      assert.equal(openskyCalls, 0, 'failed publication must fail closed instead of opening OpenSky');
+    } finally {
+      cleanup();
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
   // A viewport over North America — outside BOTH of the regional bboxes the
   // producer queried before #6222, so under the old coverage list it fell
   // through to per-viewer authenticated OpenSky recovery.
@@ -2971,6 +3119,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       VERCEL_GIT_COMMIT_SHA: undefined,
     });
     const originalFetch = globalThis.fetch;
+    const store = new Map();
     let openskyCalls = 0;
 
     globalThis.fetch = async (url, init) => {
@@ -2987,9 +3136,9 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
             }),
           });
         }
-        return jsonResponse({ result: null });
+        return jsonResponse({ result: store.get(key) ?? null });
       }
-      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (isSetRequest(url, init)) return applySetToStore(store, url, init);
       if (raw.includes('/opensky')) {
         openskyCalls += 1;
         return jsonResponse({ states: [] });
@@ -3032,6 +3181,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       VERCEL_GIT_COMMIT_SHA: undefined,
     });
     const originalFetch = globalThis.fetch;
+    const store = new Map();
     let openskyCalls = 0;
 
     globalThis.fetch = async (url, init) => {
@@ -3049,9 +3199,9 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
             }),
           });
         }
-        return jsonResponse({ result: null });
+        return jsonResponse({ result: store.get(key) ?? null });
       }
-      if (isSetRequest(url, init)) return jsonResponse({ result: 'OK' });
+      if (isSetRequest(url, init)) return applySetToStore(store, url, init);
       if (raw.includes('/opensky')) {
         openskyCalls += 1;
         return jsonResponse({
@@ -4330,6 +4480,65 @@ describe('setCachedJson wire shape and failure reporting', { concurrency: 1 }, (
       const [msg, detail] = warnings[0];
       assert.match(String(msg), /setCachedJson failed/);
       assert.equal(detail, 'HTTP 503', 'warn payload should name the HTTP status');
+    } finally {
+      globalThis.fetch = originalFetch;
+      console.warn = originalWarn;
+      restoreEnv();
+    }
+  });
+
+  it('emits POST / with body ["SET", key, value, "EX", String(ttl), "NX"]', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const captured = [];
+    globalThis.fetch = async (url, init) => {
+      captured.push({ url: String(url), init });
+      return jsonResponse({ result: 'OK' });
+    };
+
+    try {
+      const key = 'military:flights:stable-live:v1';
+      const value = { flights: [{ id: 'a' }], coverage: 'global' };
+      const ttl = 600;
+      const created = await redis.setCachedJsonIfAbsent(key, value, ttl);
+
+      assert.equal(created, true, 'SET NX should report creation when Redis returns OK');
+      assert.equal(captured.length, 1, 'exactly one Redis write should be issued');
+      assert.deepEqual(
+        JSON.parse(String(captured[0].init.body)),
+        ['SET', key, JSON.stringify(value), 'EX', String(ttl), 'NX'],
+        'body must carry SET NX EX verbatim',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('returns false without warning when SET NX loses to an existing key', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+    const originalWarn = console.warn;
+    const warnings = [];
+    console.warn = (...args) => { warnings.push(args); };
+    globalThis.fetch = async () => jsonResponse({ result: null });
+
+    try {
+      const created = await redis.setCachedJsonIfAbsent('k', { v: 1 }, 30);
+      assert.equal(created, false, 'an existing key must not look like a successful create');
+      assert.equal(warnings.length, 0, 'losing SET NX is expected and must not warn');
     } finally {
       globalThis.fetch = originalFetch;
       console.warn = originalWarn;

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -2509,6 +2509,7 @@ describe('aviation aircraft provider priority', { concurrency: 1 }, () => {
 });
 
 describe('military flights bbox behavior', { concurrency: 1 }, () => {
+  const stableLiveCacheKey = 'military:flights:stable-live:v1';
   const stableStaleCacheKey = 'military:flights:stable-stale:v1';
 
   async function importListMilitaryFlights() {
@@ -2609,11 +2610,20 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
           americasRequest,
         ),
       ]);
-      assert.deepEqual(redisGetKeys, ['military:flights:v1']);
+      assert.equal(
+        redisGetKeys.filter((key) => key === 'military:flights:v1').length,
+        1,
+        'concurrent covered requests should share one canonical seed read',
+      );
       assert.deepEqual(
         redisSetKeys.filter((key) => key.startsWith('military:flights:v1:')),
         [],
         'a global seed must never be copied into a bbox-specific provider cache entry',
+      );
+      assert.deepEqual(
+        redisSetKeys,
+        [stableLiveCacheKey],
+        'concurrent global seed requests should publish one shared cursor snapshot',
       );
       assert.equal(openskyCalls, 0, 'live seed coverage should prevent an OpenSky fetch');
       assert.deepEqual(europe.flights.map((flight) => flight.id), ['adsb-ae0301']);
@@ -2677,7 +2687,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
       assert.deepEqual(result.pagination, { nextCursor: '', totalCount: 2 });
       assert.deepEqual(
         redisKeys,
-        ['military:flights:v1'],
+        [stableLiveCacheKey, 'military:flights:v1'],
         'an authoritative seed should be filtered for the caller without a provider cache entry',
       );
     } finally {
@@ -2775,7 +2785,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
         { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
         seededRequest,
       );
-      assert.deepEqual(redisKeys, ['military:flights:v1']);
+      assert.deepEqual(redisKeys, [stableLiveCacheKey, 'military:flights:v1']);
       assert.equal(openskyCalls, 0);
       assert.deepEqual(result, { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } });
     } finally {
@@ -2867,7 +2877,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
         { request: new Request('https://wm.test/api/military/v1/list-military-flights') },
         seededRequest,
       );
-      assert.equal(redisKeys[0], 'military:flights:v1');
+      assert.deepEqual(redisKeys.slice(0, 2), [stableLiveCacheKey, 'military:flights:v1']);
       assert.equal(openskyCalls, 0, 'Redis read failure must fail closed instead of amplifying OpenSky');
       assert.deepEqual(result, { flights: [], clusters: [], pagination: { nextCursor: '', totalCount: 0 } });
     } finally {
@@ -2877,8 +2887,8 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
     }
   });
 
-  it('keeps cursor pagination on one seeded snapshot while the root rotates', async () => {
-    const { module, cleanup } = await importListMilitaryFlights();
+  it('keeps seeded cursor pagination on a shared snapshot across edge isolates while the root rotates', async () => {
+    const firstIsolate = await importListMilitaryFlights();
     const restoreEnv = withEnv({
       UPSTASH_REDIS_REST_URL: 'https://redis.test',
       UPSTASH_REDIS_REST_TOKEN: 'token',
@@ -2917,17 +2927,24 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
 
     try {
       const ctx = { request: new Request('https://wm.test/api/military/v1/list-military-flights') };
-      const first = await module.listMilitaryFlights(ctx, { ...seededRequest, pageSize: 1, cursor: '' });
-      const second = await module.listMilitaryFlights(ctx, {
+      const first = await firstIsolate.module.listMilitaryFlights(ctx, { ...seededRequest, pageSize: 1, cursor: '' });
+      assert.ok(store.has(stableLiveCacheKey), 'page one must publish a shared stable seed snapshot');
+
+      // Importing through another temporary module simulates a different edge
+      // isolate with no process-local state. If it rereads the mutable root,
+      // the next numeric offset would slice `seed-new` instead of `seed-b`.
+      const secondIsolate = await importListMilitaryFlights();
+      const second = await secondIsolate.module.listMilitaryFlights(ctx, {
         ...seededRequest,
         pageSize: 1,
         cursor: first.pagination?.nextCursor ?? '',
       });
+      secondIsolate.cleanup();
       assert.deepEqual(first.flights.map((flight) => flight.id), ['seed-a']);
       assert.deepEqual(second.flights.map((flight) => flight.id), ['seed-b']);
-      assert.equal(rootReads, 1, 'continuation pages must stay on the cached unpaginated snapshot');
+      assert.equal(rootReads, 1, 'continuation pages must not reread the mutable seed root');
     } finally {
-      cleanup();
+      firstIsolate.cleanup();
       globalThis.fetch = originalFetch;
       restoreEnv();
     }
@@ -3838,7 +3855,7 @@ describe('military flights bbox behavior', { concurrency: 1 }, () => {
 
     try {
       const result = await module.listMilitaryFlights({}, request);
-      assert.equal(redisGetCalls, 2, 'an uncovered bbox should read the live seed before its quantized cache');
+      assert.equal(redisGetCalls, 3, 'an uncovered bbox should read the stable and live seeds before its quantized cache');
       assert.equal(openskyCalls, 0, 'cache hit should avoid upstream fetch');
       assert.deepEqual(
         result.flights.map((flight) => flight.id),


### PR DESCRIPTION
Fixes #6242

## Root cause

Covered live seed snapshots were returned from the bbox-keyed provider cache callback, duplicating the same full snapshot for every requested viewport.

A bbox-independent replacement key would be unsafe because a seed miss or uncovered regional snapshot falls through to bbox-specific provider recovery. Reusing that provider response globally could return the wrong viewport data.

## Change

- Read the live seed and inspect its payload-declared coverage before entering the provider cache.
- Return authoritative covered seed data directly, filtered and paginated for the caller, with no bbox Redis provider-cache write.
- Bind numeric cursors to one fixed shared military:flights:stable-live:v1 snapshot for the existing 600-second live window, so later pages work across edge isolates.
- Keep miss and uncovered-regional recovery in the existing bbox-keyed cache path.

## Tests

- Rewrote the old per-bbox seed-cache test for concurrent global-seed requests across distinct bboxes.
- Added a two-isolate seed-cursor regression test with a rotating root snapshot.
- Added seed-miss bbox-cache reuse and cross-bbox cache-poisoning coverage.
- Retained coverage, stale fallback, Redis error, pagination, and redistributable-only coverage.

## Validation

- node --import tsx --test tests/redis-caching.test.mjs
- npm run typecheck:api
- npm run lint:boundaries
- git diff --check

Residual behavior is intentionally unchanged for seed read errors, stale fallback, negative caching, provider failures, and redistributable-only requests.