### PR TITLE
fix(insights): share one in-flight request across concurrent insights consumers

### DIFF
--- a/e2e/bootstrap-hydration-request-budget.spec.ts
+++ b/e2e/bootstrap-hydration-request-budget.spec.ts
@@ -654,6 +654,17 @@ test.describe('bootstrap tier failure and rolling-deploy budgets (#7045 U5)', ()
       ).toBeGreaterThan(0);
     }
 
+    // ...but "available" is not "unbounded". `toBeGreaterThan(0)` above is
+    // equally satisfied by the four duplicate `?keys=insights` 200s DebugBear
+    // caught in analysis 86622879 — two of them 1 ms apart, before
+    // insights-loader gained its in-flight lock (#7290). Both consumers above
+    // (the mounted panel and the repeat consumer) demand insights on this path,
+    // so one shared flight is the whole budget.
+    expect(
+      log.counts.insights ?? 0,
+      'concurrent insights consumers must share one on-demand request (#7290)',
+    ).toBe(1);
+
     // The abort must not cost the slow tier its reuse contract.
     for (const dataset of HYDRATION_DATASETS.filter((entry) => entry.tier === 'slow')) {
       expect(

--- a/src/services/insights-loader.ts
+++ b/src/services/insights-loader.ts
@@ -59,6 +59,8 @@ export interface ServerInsights {
 }
 
 let cached: ServerInsights | null = null;
+/** Shared in-flight request, cleared on settle. See fetchServerInsights (#7290). */
+let inFlight: Promise<ServerInsights | null> | null = null;
 // Server cron interval: scripts/seed-insights.mjs runs every 30 min
 // (CACHE_TTL=10800s/3h, maxStaleMin: 30). The previous 15-min freshness gate
 // was strictly less than the cron interval, so the panel spent ~50% of every
@@ -108,6 +110,22 @@ export function getServerInsights(): ServerInsights | null {
  */
 export async function fetchServerInsights(timeoutMs = 5_000): Promise<ServerInsights | null> {
   if (cached && isFresh(cached)) return cached;
+  // In-flight lock, not a result cache (#7290). `cached` is only assigned once
+  // the response has parsed and validated, so without this every caller landing
+  // inside the flight window passed the guard above and issued its own request.
+  // Three components call this independently — ThreatTimelinePanel,
+  // InsightsPanel, ProActivationInterstitial — and DebugBear analysis 86622879
+  // caught four 200s for the same 11,382-byte body, two of them 1 ms apart, for
+  // a key that already rides the FAST bootstrap payload.
+  //
+  // The lock must clear on EVERY exit, success or not: latching a failure here
+  // would permanently strand the panel this on-demand path exists to recover.
+  if (inFlight) return inFlight;
+  inFlight = requestServerInsights(timeoutMs).finally(() => { inFlight = null; });
+  return inFlight;
+}
+
+async function requestServerInsights(timeoutMs: number): Promise<ServerInsights | null> {
   try {
     const resp = await fetch(toApiUrl('/api/bootstrap?keys=insights'), {
       signal: AbortSignal.timeout(timeoutMs),
@@ -129,4 +147,5 @@ export function setServerInsights(data: ServerInsights): void {
 /** Test-only: reset module-local cache so suites can exercise the drain-once behavior. */
 export function __resetServerInsightsCacheForTests(): void {
   cached = null;
+  inFlight = null;
 }

--- a/tests/insights-loader.test.mjs
+++ b/tests/insights-loader.test.mjs
@@ -176,6 +176,70 @@ describe('insights-loader', () => {
       assert.equal(result, null);
     });
 
+    it('REGRESSION: concurrent callers share one in-flight request (#7290)', async () => {
+      // Three components call fetchServerInsights() independently:
+      // ThreatTimelinePanel:55, InsightsPanel:278, ProActivationInterstitial:1172.
+      // `cached` is only assigned after the response parses, so before #7290
+      // every caller arriving inside the flight window passed the freshness
+      // guard and issued its own request. DebugBear analysis 86622879 caught
+      // four 200s for the same 11,382-byte body, two of them 1 ms apart.
+      const valid = makeValidInsights();
+      let fetchCount = 0;
+      let release;
+      const gate = new Promise((resolve) => { release = resolve; });
+      globalThis.fetch = async () => {
+        fetchCount++;
+        await gate;
+        return new Response(JSON.stringify({ data: { insights: valid } }), { status: 200 });
+      };
+
+      const flights = [fetchServerInsights(), fetchServerInsights(), fetchServerInsights()];
+      release();
+      const results = await Promise.all(flights);
+
+      assert.equal(fetchCount, 1, 'concurrent callers must share one network request');
+      for (const result of results) {
+        assert.ok(result, 'every concurrent caller resolves with the payload');
+        assert.equal(result?.worldBrief, 'Test brief');
+      }
+    });
+
+    it('a failed flight does not latch — a later call retries (#7290)', async () => {
+      // The lock must be an in-flight lock, not a negative result cache.
+      // Latching here would permanently strand the panel that #4487 added the
+      // on-demand path to recover.
+      const valid = makeValidInsights();
+      let fetchCount = 0;
+      globalThis.fetch = async () => {
+        fetchCount++;
+        if (fetchCount === 1) return new Response('upstream down', { status: 503 });
+        return new Response(JSON.stringify({ data: { insights: valid } }), { status: 200 });
+      };
+
+      assert.equal(await fetchServerInsights(), null, 'first flight fails');
+      const recovered = await fetchServerInsights();
+      assert.ok(recovered, 'second call retries rather than replaying the failure');
+      assert.equal(fetchCount, 2);
+    });
+
+    it('a rejected payload does not latch — a later call retries (#7290)', async () => {
+      // A 200 that fails validation is the drain-once hazard the loader's own
+      // doc comment describes; it must not be cached as either a success or a
+      // permanent failure.
+      const valid = makeValidInsights();
+      let fetchCount = 0;
+      globalThis.fetch = async () => {
+        fetchCount++;
+        const body = fetchCount === 1 ? { ...valid, topStories: [] } : valid;
+        return new Response(JSON.stringify({ data: { insights: body } }), { status: 200 });
+      };
+
+      assert.equal(await fetchServerInsights(), null, 'invalid payload rejected');
+      const recovered = await fetchServerInsights();
+      assert.ok(recovered, 'a later call refetches');
+      assert.equal(fetchCount, 2);
+    });
+
     it('returns null when payload validation fails (stale generatedAt)', async () => {
       const stale = { ...makeValidInsights(), generatedAt: new Date(Date.now() - MAX_AGE_MS - 60_000).toISOString() };
       globalThis.fetch = async () =>


### PR DESCRIPTION
## The bug

`fetchServerInsights()` guarded on a completed result but held no in-flight
promise:

```ts
if (cached && isFresh(cached)) return cached;   // only true AFTER a response validates
const resp = await fetch(toApiUrl('/api/bootstrap?keys=insights'), { ... });
```

`cached` is assigned at the end of the flight, so every caller arriving inside
the window passed the guard and issued its own request. Three components call it
independently — `ThreatTimelinePanel.ts:55`, `InsightsPanel.ts:278`,
`ProActivationInterstitial.ts:1172`.

## Production evidence

DebugBear desktop us-east, analysis `86622879` (2026-08-28 07:04 UTC),
`/analysis/86622879/requests` — four HTTP 200s, byte-identical bodies:

```
6077ms  bootstrap?keys=insights   7,201 B / 11,382 decoded / 240ms / 200
6078ms  bootstrap?keys=insights   6,222 B / 11,382 decoded / 562ms / 200   <- 1 ms after the first
7984ms  bootstrap?keys=insights   6,216 B / 11,382 decoded / 194ms / 200
7985ms  bootstrap?keys=insights   6,214 B / 11,382 decoded / 310ms / 200   <- 1 ms after the third
```

25,853 B per page load. The 1 ms spacing on both pairs is the missing lock.
Mobile `86622827` issued two more; `86478720` and `86412541` three each.

`insights` is a FAST-tier key with a first-paint justification in
`tests/fixtures/bootstrap-payload-budget.mjs`, so every one of these refetches a
payload the visitor already downloaded. Found while pulling the #7045 U5
production acceptance evidence.

## The fix

One shared in-flight promise, cleared on settle. It is an **in-flight lock, not
a result cache** — the distinction matters: latching a failure would permanently
strand the panel this on-demand path exists to recover (#4487), and
`ProActivationInterstitial` calls it fire-and-forget, so nothing upstream would
notice the strand.

## Tests

Three added to `tests/insights-loader.test.mjs`, all run against pre-fix code
first:

- **concurrent callers share one request** — red before the fix (`3 !== 1`),
  green after.
- **a failed flight does not latch** — a 503 then a 200 must produce two
  requests. Passes both before and after by design: it is the guard against the
  fix introducing a latch, not a repro of the bug.
- **a rejected payload does not latch** — same, for a 200 that fails validation
  (the drain-once hazard the loader's own doc comment describes).

The e2e abort-path budget in `e2e/bootstrap-hydration-request-budget.spec.ts`
already asserted the insights fallback was *available* (`> 0`) — which four
duplicates satisfy exactly as well as one. It now bounds it at 1. Mutation-checked:
with the lock line removed the browser spec fails with `Received: 2`; restored, it
passes.

## Verification

```
node --import tsx --test tests/insights-loader.test.mjs      18 pass, 0 fail
npx vitest run --config vitest.dom.config.mts \
  tests/dom/insights-brief-cold-early-paint.test.mts \
  tests/dom/late-mounted-panel-hydration.test.mts           10 pass, 0 fail
npx playwright test e2e/bootstrap-hydration-request-budget.spec.ts   9 passed
npm run typecheck                                            clean
npm run lint:boundaries                                      clean
```

## Post-deploy validation

Watch `/analysis/<id>/requests` on DebugBear pages `693053` and `693052` for
`bootstrap?keys=insights`: the count should be 0 on runs where the fast tier
completes and hydration is consumed, and at most 1 where it does not. Three
consecutive scheduled runs at ≤1 closes #7290. No rollback risk beyond a revert;
no schema or data change.

Refs #7290
Refs #7045

https://claude.ai/code/session_016Bb5Nry6FhHgwhHLraESFE
