### PR TITLE
obs(bootstrap): measure the payload the publisher actually ships against its byte budget

### DIFF
--- a/scripts/publish-bootstrap-tiers.mjs
+++ b/scripts/publish-bootstrap-tiers.mjs
@@ -2,6 +2,7 @@
 
 import { pathToFileURL } from 'node:url';
 
+import { bootstrapPayloadBudgetViolations } from '../shared/bootstrap-payload-budget.js';
 import {
   BOOTSTRAP_CACHE_KEYS,
   bootstrapTierKeyNames,
@@ -221,6 +222,7 @@ export async function publishBootstrapTier(tier, options = {}) {
     .sort((left, right) => right.bytes - left.bytes || left.key.localeCompare(right.key))
     .slice(0, PUBLISHER_LARGEST_KEY_LIMIT)
     .map(({ key, bytes }) => ({ key, bytes }));
+  const budget = evaluatePublishedPayloadBudget(tier, payloadLedger);
   const resolveStorage = options.resolveStorage
     ?? (storageEnv => resolveR2StorageConfig(storageEnv, { profile: 'bootstrap' }));
   const storage = resolveStorage(env);
@@ -247,8 +249,41 @@ export async function publishBootstrapTier(tier, options = {}) {
     bytes: write?.bytes ?? null,
     payloadBytes: payloadLedger.totalBytes,
     largestKeys,
+    budget,
     kv,
   };
+}
+
+/**
+ * Measure the payload that was actually published against the frozen ledger
+ * and the tier ceilings (#7288).
+ *
+ * The PR-time budget suite can only see tier MEMBERSHIP: it looks each key up
+ * in `CAPTURED_KEY_DECODED_BYTES`, so a key whose production row count doubles
+ * moves no number it reads, and its 5% per-key growth check runs against
+ * synthetic representative fixtures rather than production volume. Between the
+ * 2026-08-27 and 2026-08-28 scheduled DebugBear runs the slow tier grew
+ * +223,845 B decoded on desktop and +133,874 B on mobile with no membership
+ * change at all, pushing the mobile response past its 3,000 ms abort and
+ * re-triggering 130,357 B of the per-panel fallbacks #7048 removed.
+ *
+ * This is an OBSERVATION, never a gate. #7045's stop conditions forbid putting
+ * mutable production values into a pull-request pass/fail check, and refusing
+ * to publish over a size regression would take the dashboard down to prevent it
+ * being slow. The caller logs; the publish proceeds either way.
+ *
+ * A key with no entry in the frozen ledger is skipped by the evaluator rather
+ * than guessed at — the PR gate is what refuses an unmeasured key into a tier.
+ */
+export function evaluatePublishedPayloadBudget(tier, payloadLedger) {
+  const keyBytes = Object.fromEntries(
+    payloadLedger.keys.map(({ key, bytes }) => [key, bytes]),
+  );
+  const violations = bootstrapPayloadBudgetViolations(tier, {
+    totalBytes: payloadLedger.totalBytes,
+    keyBytes,
+  });
+  return { ok: violations.length === 0, violations };
 }
 
 /**
@@ -323,8 +358,18 @@ export async function runPublisherLoop(options = {}) {
         payloadBytes: result?.payloadBytes ?? null,
         missing: result?.missing ?? null,
         largestKeys: result?.largestKeys ?? [],
+        budget: result?.budget?.ok === false ? 'EXCEEDED' : 'ok',
         kv: kvStatus,
       });
+      // Separate from the info line above so a log-based alert can key on this
+      // string alone. The publish already succeeded; this is the drift signal
+      // no PR gate can produce (#7288).
+      if (result?.budget?.ok === false) {
+        logger.warn?.(
+          `[bootstrap-budget] tier=${tier} published payload exceeds its byte budget: `
+          + result.budget.violations.join('; '),
+        );
+      }
     } catch (error) {
       logger.warn?.(`[bootstrap-r2] publish failed tier=${tier}: ${error?.message ?? String(error)}`);
     } finally {

--- a/shared/bootstrap-payload-budget.js
+++ b/shared/bootstrap-payload-budget.js
@@ -1,0 +1,246 @@
+/**
+ * Frozen bootstrap byte ledger and the budget evaluator that reads it.
+ *
+ * Provenance: one complete, credential-free production response per tier,
+ * captured with `Origin: https://worldmonitor.app` on 2026-08-21 (#7046 /
+ * PR #7049). Both bodies parsed as `{ data, missing: [] }`. The response bytes
+ * and SHA-256 hashes are recorded below; payload values are deliberately not
+ * checked in.
+ *
+ * This lived in tests/fixtures/bootstrap-payload-budget.mjs until #7288. It
+ * moved here because the PR gate it backs can only see *membership*: it looks
+ * each key up in the frozen ledger below, so a key whose production row count
+ * doubles moves no number the suite reads. The publisher is the only place that
+ * sees the bytes actually shipped, and scripts/ may not import from tests/.
+ *
+ * The test fixture re-exports everything here, so there is still exactly one
+ * copy of these numbers.
+ *
+ * IMPORTANT: this module carries no production pass/fail authority. #7045
+ * forbids putting mutable production observations into a pull-request check;
+ * the publisher uses `bootstrapPayloadBudgetViolations` to LOG, never to abort
+ * a publish.
+ */
+
+export const PRODUCTION_CAPTURE = Object.freeze({
+  capturedAt: '2026-08-21T14:51:50Z',
+  origin: 'https://worldmonitor.app',
+  requestShape: 'GET https://api.worldmonitor.app/api/bootstrap?tier=<tier>&public=1',
+  completeness: 'Both responses were HTTP 200, parsed successfully, and declared missing: [].',
+  limitation: 'Single complete public capture; not the full daily #7047 U1/RUM baseline.',
+  tiers: Object.freeze({
+    fast: Object.freeze({
+      decodedBytes: 921_832,
+      sha256: '9723bf77e7a88323e58e747977c64d8ba1bcee77b72b9db06fe5d37c2773d3de',
+    }),
+    slow: Object.freeze({
+      decodedBytes: 1_977_154,
+      sha256: '0d4caebf63182d1f816ec41bfc47b0f5e30efc378722b0cab785ebd70d85bcdb',
+    }),
+  }),
+});
+
+export const CAPTURED_BASE_TIER_KEYS = Object.freeze({
+  fast: Object.freeze([
+    'earthquakes', 'outages', 'serviceStatuses', 'ddosAttacks', 'trafficAnomalies',
+    'marketQuotes', 'commodityQuotes', 'macroSignals', 'shippingRates', 'chokepoints',
+    'positiveGeoEvents', 'theaterPosture', 'riskScores', 'flightDelays', 'insights',
+    'predictions', 'temporalAnomalies', 'weatherAlerts', 'canadaAlerts', 'spending',
+    'gdeltIntel', 'correlationCards', 'forecasts', 'shippingStress', 'socialVelocity',
+    'wsbTickers',
+  ]),
+  slow: Object.freeze([
+    'sectors', 'etfFlows', 'bisPolicy', 'bisExchange', 'bisCredit', 'chinaMacro',
+    'chinaReleaseCalendar', 'chinaCorporateDisclosures', 'minerals', 'giving',
+    'climateAnomalies', 'climateDisasters', 'co2Monitoring', 'oceanIce', 'climateNews',
+    'radiationWatch', 'thermalEscalation', 'crossSourceSignals', 'wildfires',
+    'techReadiness', 'progressData', 'renewableEnergy', 'naturalEvents', 'cryptoQuotes',
+    'cryptoSectors', 'defiTokens', 'aiTokens', 'otherTokens', 'gulfQuotes',
+    'stablecoinMarkets', 'unrestEvents', 'ucdpEvents', 'techEvents',
+    'crossStraitActivity', 'securityAdvisories', 'customsRevenue', 'sanctionsPressure',
+    'consumerPricesOverview', 'consumerPricesCategories', 'consumerPricesMovers',
+    'consumerPricesSpread', 'groceryBasket', 'bigmac', 'fuelPrices', 'faoFoodPriceIndex',
+    'nationalDebt', 'euGasStorage', 'eurostatCountryData', 'marketImplications',
+    'fearGreedIndex', 'hyperliquidFlow', 'crudeInventories', 'natGasStorage',
+    'ecbFxRates', 'euFsi', 'pizzint', 'diseaseOutbreaks', 'economicStress',
+    'oilStocksAnalysis', 'lngVulnerability', 'pipelinesGas', 'pipelinesOil',
+    'storageFacilities', 'fuelShortages', 'energyCrisisPolicies', 'aaiiSentiment',
+    'breadthHistory',
+  ]),
+});
+
+/** Exact UTF-8 bytes of JSON.stringify(data[key]) from the frozen responses. */
+export const CAPTURED_KEY_DECODED_BYTES = Object.freeze({
+  earthquakes: 48_361,
+  outages: 3_702,
+  serviceStatuses: 6_583,
+  ddosAttacks: 744,
+  trafficAnomalies: 3_045,
+  marketQuotes: 296_547,
+  commodityQuotes: 116_985,
+  macroSignals: 3_112,
+  shippingRates: 8_180,
+  chokepoints: 13_837,
+  positiveGeoEvents: 25_682,
+  theaterPosture: 1_302,
+  riskScores: 10_352,
+  flightDelays: 57_826,
+  insights: 10_115,
+  predictions: 24_493,
+  temporalAnomalies: 98,
+  weatherAlerts: 52_633,
+  canadaAlerts: 61_389,
+  spending: 4_762,
+  gdeltIntel: 24_612,
+  correlationCards: 87_842,
+  forecasts: 40_048,
+  shippingStress: 4_288,
+  socialVelocity: 10_574,
+  wsbTickers: 4_275,
+  sectors: 4_086,
+  etfFlows: 1_848,
+  bisPolicy: 1_395,
+  bisExchange: 1_354,
+  bisCredit: 1_310,
+  chinaMacro: 44_014,
+  chinaReleaseCalendar: 58_122,
+  chinaCorporateDisclosures: 18_932,
+  minerals: 2_132,
+  giving: 12_544,
+  climateAnomalies: 5_031,
+  climateDisasters: 21_205,
+  co2Monitoring: 822,
+  oceanIce: 970,
+  climateNews: 51_058,
+  radiationWatch: 5_727,
+  thermalEscalation: 18_616,
+  crossSourceSignals: 9_057,
+  wildfires: 165_622,
+  techReadiness: 45_451,
+  progressData: 6_791,
+  renewableEnergy: 1_893,
+  naturalEvents: 200_792,
+  cryptoQuotes: 9_713,
+  cryptoSectors: 414,
+  defiTokens: 831,
+  aiTokens: 885,
+  otherTokens: 848,
+  gulfQuotes: 47_557,
+  stablecoinMarkets: 1_550,
+  unrestEvents: 85_902,
+  ucdpEvents: 130_821,
+  techEvents: 34_580,
+  crossStraitActivity: 13_601,
+  securityAdvisories: 70_091,
+  customsRevenue: 6_124,
+  sanctionsPressure: 17_603,
+  consumerPricesOverview: 1_216,
+  consumerPricesCategories: 1_074,
+  consumerPricesMovers: 892,
+  consumerPricesSpread: 825,
+  groceryBasket: 52_344,
+  bigmac: 9_506,
+  fuelPrices: 11_592,
+  faoFoodPriceIndex: 1_285,
+  nationalDebt: 45_401,
+  euGasStorage: 452,
+  eurostatCountryData: 2_197,
+  marketImplications: 5_963,
+  fearGreedIndex: 2_557,
+  hyperliquidFlow: 55_977,
+  crudeInventories: 558,
+  natGasStorage: 519,
+  ecbFxRates: 514,
+  euFsi: 13_146,
+  pizzint: 3_495,
+  diseaseOutbreaks: 68_863,
+  economicStress: 620,
+  oilStocksAnalysis: 4_057,
+  lngVulnerability: 2_501,
+  pipelinesGas: 193_403,
+  pipelinesOil: 221_043,
+  storageFacilities: 113_540,
+  fuelShortages: 22_020,
+  energyCrisisPolicies: 28_423,
+  aaiiSentiment: 4_623,
+  breadthHistory: 8_059,
+});
+
+// Absolute final ceilings are the required reductions applied to the complete
+// capture, not to a hand-picked subset: FAST <= 80%, SLOW <= 75% of base.
+export const FINAL_TIER_DECODED_BYTE_CEILINGS = Object.freeze({
+  fast: 737_465,
+  slow: 1_482_865,
+});
+
+export const BOOTSTRAP_PAYLOAD_BUDGET_MANIFEST = Object.freeze({
+  version: 1,
+  capturedAt: PRODUCTION_CAPTURE.capturedAt,
+  tiers: Object.freeze({
+    fast: Object.freeze({
+      preChangeCeilingBytes: PRODUCTION_CAPTURE.tiers.fast.decodedBytes,
+      finalTargetBytes: FINAL_TIER_DECODED_BYTE_CEILINGS.fast,
+      minimumCapturedKeyCount: CAPTURED_BASE_TIER_KEYS.fast.length,
+      materialGrowthRatio: 0.05,
+      materialGrowthFloorBytes: 2_048,
+      reviewedExceptions: Object.freeze({}),
+    }),
+    slow: Object.freeze({
+      preChangeCeilingBytes: PRODUCTION_CAPTURE.tiers.slow.decodedBytes,
+      finalTargetBytes: FINAL_TIER_DECODED_BYTE_CEILINGS.slow,
+      minimumCapturedKeyCount: CAPTURED_BASE_TIER_KEYS.slow.length,
+      materialGrowthRatio: 0.05,
+      materialGrowthFloorBytes: 2_048,
+      reviewedExceptions: Object.freeze({}),
+    }),
+  }),
+});
+
+export function bootstrapPayloadBudgetViolations(tier, ledger) {
+  const budget = BOOTSTRAP_PAYLOAD_BUDGET_MANIFEST.tiers[tier];
+  if (!budget) throw new TypeError(`Unknown bootstrap budget tier: ${tier}`);
+  const violations = [];
+  if (ledger.totalBytes > budget.finalTargetBytes) {
+    violations.push(
+      `${tier} aggregate ${ledger.totalBytes} B exceeds final target ${budget.finalTargetBytes} B`,
+    );
+  }
+
+  for (const [key, bytes] of Object.entries(ledger.keyBytes)) {
+    const capturedBytes = CAPTURED_KEY_DECODED_BYTES[key];
+    if (!Number.isInteger(capturedBytes)) continue;
+    const materialGrowth = Math.max(
+      budget.materialGrowthFloorBytes,
+      Math.ceil(capturedBytes * budget.materialGrowthRatio),
+    );
+    if (bytes <= capturedBytes + materialGrowth) continue;
+
+    const exception = budget.reviewedExceptions[key];
+    if (
+      exception
+      && typeof exception.rationale === 'string'
+      && exception.rationale.trim().length > 0
+      && Number.isInteger(exception.ceilingBytes)
+      && bytes <= exception.ceilingBytes
+    ) {
+      continue;
+    }
+    violations.push(
+      `${tier}.${key} ${bytes} B exceeds captured ${capturedBytes} B by material threshold ${materialGrowth} B without a reviewed exception`,
+    );
+  }
+  return violations;
+}
+
+export function tierPayloadBytesFromLedger(keys) {
+  let bytes = Buffer.byteLength('{"data":{', 'utf8');
+  keys.forEach((key, index) => {
+    const valueBytes = CAPTURED_KEY_DECODED_BYTES[key];
+    if (!Number.isInteger(valueBytes) || valueBytes < 0) {
+      throw new Error(`No production byte evidence for bootstrap key: ${key}`);
+    }
+    if (index > 0) bytes += 1;
+    bytes += Buffer.byteLength(JSON.stringify(key), 'utf8') + 1 + valueBytes;
+  });
+  return bytes + Buffer.byteLength('},"missing":[]}', 'utf8');
+}

--- a/tests/fixtures/bootstrap-payload-budget.mjs
+++ b/tests/fixtures/bootstrap-payload-budget.mjs
@@ -13,6 +13,31 @@
  * tests instead of being replaced by a generic stub.
  */
 
+import {
+  BOOTSTRAP_PAYLOAD_BUDGET_MANIFEST,
+  CAPTURED_BASE_TIER_KEYS,
+  CAPTURED_KEY_DECODED_BYTES,
+  FINAL_TIER_DECODED_BYTE_CEILINGS,
+  PRODUCTION_CAPTURE,
+  bootstrapPayloadBudgetViolations,
+  tierPayloadBytesFromLedger,
+} from '../../shared/bootstrap-payload-budget.js';
+
+// The frozen ledger, the ceilings and the evaluator moved to shared/ in #7288 so
+// the publisher can measure the bytes it actually ships against the same
+// numbers. They are re-exported here unchanged: this module stays the single
+// import site for the budget suite, and there is still only one copy of the
+// captured values.
+export {
+  BOOTSTRAP_PAYLOAD_BUDGET_MANIFEST,
+  CAPTURED_BASE_TIER_KEYS,
+  CAPTURED_KEY_DECODED_BYTES,
+  FINAL_TIER_DECODED_BYTE_CEILINGS,
+  PRODUCTION_CAPTURE,
+  bootstrapPayloadBudgetViolations,
+  tierPayloadBytesFromLedger,
+};
+
 export const ENERGY_ON_DEMAND_KEYS = Object.freeze([
   'pipelinesGas',
   'pipelinesOil',
@@ -50,180 +75,6 @@ export const FAST_FIRST_PAINT_JUSTIFICATION = Object.freeze({
   shippingRates: 'Supply-chain first-wave rates.',
   shippingStress: 'Supply-chain first-wave stress.',
   socialVelocity: 'Retained once the 20% target is met to avoid another default dashboard request.',
-});
-
-export const PRODUCTION_CAPTURE = Object.freeze({
-  capturedAt: '2026-08-21T14:51:50Z',
-  origin: 'https://worldmonitor.app',
-  requestShape: 'GET https://api.worldmonitor.app/api/bootstrap?tier=<tier>&public=1',
-  completeness: 'Both responses were HTTP 200, parsed successfully, and declared missing: [].',
-  limitation: 'Single complete public capture; not the full daily #7047 U1/RUM baseline.',
-  tiers: Object.freeze({
-    fast: Object.freeze({
-      decodedBytes: 921_832,
-      sha256: '9723bf77e7a88323e58e747977c64d8ba1bcee77b72b9db06fe5d37c2773d3de',
-    }),
-    slow: Object.freeze({
-      decodedBytes: 1_977_154,
-      sha256: '0d4caebf63182d1f816ec41bfc47b0f5e30efc378722b0cab785ebd70d85bcdb',
-    }),
-  }),
-});
-
-export const CAPTURED_BASE_TIER_KEYS = Object.freeze({
-  fast: Object.freeze([
-    'earthquakes', 'outages', 'serviceStatuses', 'ddosAttacks', 'trafficAnomalies',
-    'marketQuotes', 'commodityQuotes', 'macroSignals', 'shippingRates', 'chokepoints',
-    'positiveGeoEvents', 'theaterPosture', 'riskScores', 'flightDelays', 'insights',
-    'predictions', 'temporalAnomalies', 'weatherAlerts', 'canadaAlerts', 'spending',
-    'gdeltIntel', 'correlationCards', 'forecasts', 'shippingStress', 'socialVelocity',
-    'wsbTickers',
-  ]),
-  slow: Object.freeze([
-    'sectors', 'etfFlows', 'bisPolicy', 'bisExchange', 'bisCredit', 'chinaMacro',
-    'chinaReleaseCalendar', 'chinaCorporateDisclosures', 'minerals', 'giving',
-    'climateAnomalies', 'climateDisasters', 'co2Monitoring', 'oceanIce', 'climateNews',
-    'radiationWatch', 'thermalEscalation', 'crossSourceSignals', 'wildfires',
-    'techReadiness', 'progressData', 'renewableEnergy', 'naturalEvents', 'cryptoQuotes',
-    'cryptoSectors', 'defiTokens', 'aiTokens', 'otherTokens', 'gulfQuotes',
-    'stablecoinMarkets', 'unrestEvents', 'ucdpEvents', 'techEvents',
-    'crossStraitActivity', 'securityAdvisories', 'customsRevenue', 'sanctionsPressure',
-    'consumerPricesOverview', 'consumerPricesCategories', 'consumerPricesMovers',
-    'consumerPricesSpread', 'groceryBasket', 'bigmac', 'fuelPrices', 'faoFoodPriceIndex',
-    'nationalDebt', 'euGasStorage', 'eurostatCountryData', 'marketImplications',
-    'fearGreedIndex', 'hyperliquidFlow', 'crudeInventories', 'natGasStorage',
-    'ecbFxRates', 'euFsi', 'pizzint', 'diseaseOutbreaks', 'economicStress',
-    'oilStocksAnalysis', 'lngVulnerability', 'pipelinesGas', 'pipelinesOil',
-    'storageFacilities', 'fuelShortages', 'energyCrisisPolicies', 'aaiiSentiment',
-    'breadthHistory',
-  ]),
-});
-
-/** Exact UTF-8 bytes of JSON.stringify(data[key]) from the frozen responses. */
-export const CAPTURED_KEY_DECODED_BYTES = Object.freeze({
-  earthquakes: 48_361,
-  outages: 3_702,
-  serviceStatuses: 6_583,
-  ddosAttacks: 744,
-  trafficAnomalies: 3_045,
-  marketQuotes: 296_547,
-  commodityQuotes: 116_985,
-  macroSignals: 3_112,
-  shippingRates: 8_180,
-  chokepoints: 13_837,
-  positiveGeoEvents: 25_682,
-  theaterPosture: 1_302,
-  riskScores: 10_352,
-  flightDelays: 57_826,
-  insights: 10_115,
-  predictions: 24_493,
-  temporalAnomalies: 98,
-  weatherAlerts: 52_633,
-  canadaAlerts: 61_389,
-  spending: 4_762,
-  gdeltIntel: 24_612,
-  correlationCards: 87_842,
-  forecasts: 40_048,
-  shippingStress: 4_288,
-  socialVelocity: 10_574,
-  wsbTickers: 4_275,
-  sectors: 4_086,
-  etfFlows: 1_848,
-  bisPolicy: 1_395,
-  bisExchange: 1_354,
-  bisCredit: 1_310,
-  chinaMacro: 44_014,
-  chinaReleaseCalendar: 58_122,
-  chinaCorporateDisclosures: 18_932,
-  minerals: 2_132,
-  giving: 12_544,
-  climateAnomalies: 5_031,
-  climateDisasters: 21_205,
-  co2Monitoring: 822,
-  oceanIce: 970,
-  climateNews: 51_058,
-  radiationWatch: 5_727,
-  thermalEscalation: 18_616,
-  crossSourceSignals: 9_057,
-  wildfires: 165_622,
-  techReadiness: 45_451,
-  progressData: 6_791,
-  renewableEnergy: 1_893,
-  naturalEvents: 200_792,
-  cryptoQuotes: 9_713,
-  cryptoSectors: 414,
-  defiTokens: 831,
-  aiTokens: 885,
-  otherTokens: 848,
-  gulfQuotes: 47_557,
-  stablecoinMarkets: 1_550,
-  unrestEvents: 85_902,
-  ucdpEvents: 130_821,
-  techEvents: 34_580,
-  crossStraitActivity: 13_601,
-  securityAdvisories: 70_091,
-  customsRevenue: 6_124,
-  sanctionsPressure: 17_603,
-  consumerPricesOverview: 1_216,
-  consumerPricesCategories: 1_074,
-  consumerPricesMovers: 892,
-  consumerPricesSpread: 825,
-  groceryBasket: 52_344,
-  bigmac: 9_506,
-  fuelPrices: 11_592,
-  faoFoodPriceIndex: 1_285,
-  nationalDebt: 45_401,
-  euGasStorage: 452,
-  eurostatCountryData: 2_197,
-  marketImplications: 5_963,
-  fearGreedIndex: 2_557,
-  hyperliquidFlow: 55_977,
-  crudeInventories: 558,
-  natGasStorage: 519,
-  ecbFxRates: 514,
-  euFsi: 13_146,
-  pizzint: 3_495,
-  diseaseOutbreaks: 68_863,
-  economicStress: 620,
-  oilStocksAnalysis: 4_057,
-  lngVulnerability: 2_501,
-  pipelinesGas: 193_403,
-  pipelinesOil: 221_043,
-  storageFacilities: 113_540,
-  fuelShortages: 22_020,
-  energyCrisisPolicies: 28_423,
-  aaiiSentiment: 4_623,
-  breadthHistory: 8_059,
-});
-
-// Absolute final ceilings are the required reductions applied to the complete
-// capture, not to a hand-picked subset: FAST <= 80%, SLOW <= 75% of base.
-export const FINAL_TIER_DECODED_BYTE_CEILINGS = Object.freeze({
-  fast: 737_465,
-  slow: 1_482_865,
-});
-
-export const BOOTSTRAP_PAYLOAD_BUDGET_MANIFEST = Object.freeze({
-  version: 1,
-  capturedAt: PRODUCTION_CAPTURE.capturedAt,
-  tiers: Object.freeze({
-    fast: Object.freeze({
-      preChangeCeilingBytes: PRODUCTION_CAPTURE.tiers.fast.decodedBytes,
-      finalTargetBytes: FINAL_TIER_DECODED_BYTE_CEILINGS.fast,
-      minimumCapturedKeyCount: CAPTURED_BASE_TIER_KEYS.fast.length,
-      materialGrowthRatio: 0.05,
-      materialGrowthFloorBytes: 2_048,
-      reviewedExceptions: Object.freeze({}),
-    }),
-    slow: Object.freeze({
-      preChangeCeilingBytes: PRODUCTION_CAPTURE.tiers.slow.decodedBytes,
-      finalTargetBytes: FINAL_TIER_DECODED_BYTE_CEILINGS.slow,
-      minimumCapturedKeyCount: CAPTURED_BASE_TIER_KEYS.slow.length,
-      materialGrowthRatio: 0.05,
-      materialGrowthFloorBytes: 2_048,
-      reviewedExceptions: Object.freeze({}),
-    }),
-  }),
 });
 
 export const REPRESENTATIVE_FIXTURE_CONTRACTS = Object.freeze({
@@ -356,42 +207,6 @@ export function assertRepresentativeBootstrapFixtures(fixtures = REPRESENTATIVE_
   }
 }
 
-export function bootstrapPayloadBudgetViolations(tier, ledger) {
-  const budget = BOOTSTRAP_PAYLOAD_BUDGET_MANIFEST.tiers[tier];
-  if (!budget) throw new TypeError(`Unknown bootstrap budget tier: ${tier}`);
-  const violations = [];
-  if (ledger.totalBytes > budget.finalTargetBytes) {
-    violations.push(
-      `${tier} aggregate ${ledger.totalBytes} B exceeds final target ${budget.finalTargetBytes} B`,
-    );
-  }
-
-  for (const [key, bytes] of Object.entries(ledger.keyBytes)) {
-    const capturedBytes = CAPTURED_KEY_DECODED_BYTES[key];
-    if (!Number.isInteger(capturedBytes)) continue;
-    const materialGrowth = Math.max(
-      budget.materialGrowthFloorBytes,
-      Math.ceil(capturedBytes * budget.materialGrowthRatio),
-    );
-    if (bytes <= capturedBytes + materialGrowth) continue;
-
-    const exception = budget.reviewedExceptions[key];
-    if (
-      exception
-      && typeof exception.rationale === 'string'
-      && exception.rationale.trim().length > 0
-      && Number.isInteger(exception.ceilingBytes)
-      && bytes <= exception.ceilingBytes
-    ) {
-      continue;
-    }
-    violations.push(
-      `${tier}.${key} ${bytes} B exceeds captured ${capturedBytes} B by material threshold ${materialGrowth} B without a reviewed exception`,
-    );
-  }
-  return violations;
-}
-
 /**
  * Adds current representative-payload growth to the captured membership
  * candidate. The real publisher ledger is supplied by the caller so the
@@ -423,17 +238,4 @@ export function buildBootstrapPayloadBudgetCandidate(tier, keys, representativeL
       + Math.max(0, representativeLedger.totalBytes - baseline.totalBytes),
     keyBytes,
   };
-}
-
-export function tierPayloadBytesFromLedger(keys) {
-  let bytes = Buffer.byteLength('{"data":{', 'utf8');
-  keys.forEach((key, index) => {
-    const valueBytes = CAPTURED_KEY_DECODED_BYTES[key];
-    if (!Number.isInteger(valueBytes) || valueBytes < 0) {
-      throw new Error(`No production byte evidence for bootstrap key: ${key}`);
-    }
-    if (index > 0) bytes += 1;
-    bytes += Buffer.byteLength(JSON.stringify(key), 'utf8') + 1 + valueBytes;
-  });
-  return bytes + Buffer.byteLength('},"missing":[]}', 'utf8');
 }

--- a/tests/publish-bootstrap-tiers.test.mjs
+++ b/tests/publish-bootstrap-tiers.test.mjs
@@ -160,6 +160,66 @@ describe('publishBootstrapTier', () => {
     assert.equal(JSON.stringify(result.largestKeys).includes('xxxxxx'), false);
   });
 
+  // #7288: the PR gate can only see tier MEMBERSHIP. It looks each key up in
+  // the frozen 2026-08-21 ledger, so a key whose production row count doubles
+  // moves no number the budget suite reads. Between the 08-27 and 08-28
+  // scheduled runs the slow tier grew +223,845 B decoded on desktop and
+  // +133,874 B on mobile with no membership change, pushing mobile past its
+  // 3,000 ms abort. The publisher is the only place that sees the bytes
+  // actually shipped.
+  it('reports a clean byte budget for a payload inside its ceilings (#7288)', async () => {
+    const result = await publishBootstrapTier('fast', {
+      env: TEST_ENV,
+      resolveRegistry: () => ({ fast: { marketQuotes: 'markets:quotes' } }),
+      fetchFn: async () => pipelineResponse([raw({ quotes: [] })]),
+      resolveStorage: () => ({ mode: 's3' }),
+      putObject: async () => ({ bytes: 10 }),
+    });
+
+    assert.equal(result.budget.ok, true);
+    assert.deepEqual(result.budget.violations, []);
+  });
+
+  it('reports a per-key violation when a shipped key outgrows its captured bytes (#7288)', async () => {
+    // marketQuotes was captured at 296,547 B. The manifest's material threshold
+    // is 5% of that, so an order-of-magnitude row-count growth inside one key —
+    // exactly the drift that is invisible to membership — must be named.
+    const bloated = { quotes: Array.from({ length: 20_000 }, (_, index) => ({
+      symbol: `WM${index}`, name: `Representative Equity ${index}`, price: 1000 + index, change: 0.1,
+    })) };
+    const result = await publishBootstrapTier('fast', {
+      env: TEST_ENV,
+      resolveRegistry: () => ({ fast: { marketQuotes: 'markets:quotes' } }),
+      fetchFn: async () => pipelineResponse([raw(bloated)]),
+      resolveStorage: () => ({ mode: 's3' }),
+      putObject: async () => ({ bytes: 10 }),
+    });
+
+    assert.equal(result.budget.ok, false);
+    assert.match(
+      result.budget.violations.join('\n'),
+      /fast\.marketQuotes \d+ B exceeds captured 296547 B/,
+    );
+  });
+
+  it('publishes the payload even when the budget is exceeded (#7288)', async () => {
+    // #7045 forbids turning a mutable production observation into a pass/fail
+    // gate. A budget breach is an alert; refusing to publish would take the
+    // dashboard down over a size regression.
+    let puts = 0;
+    const bloated = { quotes: Array.from({ length: 20_000 }, (_, index) => ({ symbol: `WM${index}` })) };
+    const result = await publishBootstrapTier('fast', {
+      env: TEST_ENV,
+      resolveRegistry: () => ({ fast: { marketQuotes: 'markets:quotes' } }),
+      fetchFn: async () => pipelineResponse([raw(bloated)]),
+      resolveStorage: () => ({ mode: 's3' }),
+      putObject: async () => { puts += 1; return { bytes: 10 }; },
+    });
+
+    assert.equal(puts, 1, 'a budget breach must not block the publish');
+    assert.equal(result.budget.ok, false);
+  });
+
   it('performs no PUT when Redis assembly fails', async () => {
     let puts = 0;
     await assert.rejects(publishBootstrapTier('slow', {
@@ -211,6 +271,36 @@ describe('runPublisherLoop', () => {
     assert.equal(maxActive, 1);
     assert.deepEqual(calls.map(([tier]) => tier), ['fast', 'slow', 'fast', 'fast', 'fast', 'fast']);
     assert.deepEqual(calls.map(([, at]) => at), [0, 30_000, 120_000, 240_000, 360_000, 480_000]);
+  });
+
+  it('warns loudly on a byte-budget violation and stays quiet otherwise (#7288)', async () => {
+    const warnings = [];
+    const infos = [];
+    const results = [
+      { tier: 'fast', generatedAt: 1, budget: { ok: true, violations: [] } },
+      {
+        tier: 'slow',
+        generatedAt: 2,
+        budget: { ok: false, violations: ['slow aggregate 2000000 B exceeds final target 1482865 B'] },
+      },
+    ];
+    let index = 0;
+    await runPublisherLoop({
+      publishTier: async () => results[index++],
+      now: () => 0,
+      sleep: async () => {},
+      maxPublishes: 2,
+      logger: {
+        info: (...args) => infos.push(args),
+        warn: (...args) => warnings.push(args),
+        error() {},
+      },
+    });
+
+    assert.equal(infos.length, 2, 'every publish still logs its normal line');
+    assert.equal(warnings.length, 1, 'only the violating publish warns');
+    assert.match(String(warnings[0][0]), /budget/i);
+    assert.match(String(warnings[0][0]), /exceeds final target/);
   });
 
   it('does not begin another publish after shutdown is requested', async () => {


### PR DESCRIPTION
## The gap

The PR-time budget suite can only see tier **membership**. `tierPayloadBytesFromLedger`
looks each key up in the ledger frozen from one production capture on 2026-08-21,
so a key whose production row count doubles moves no number it reads. The 5%
`materialGrowthRatio` check runs against `REPRESENTATIVE_BOOTSTRAP_PAYLOADS` —
synthetic fixtures with pinned record counts — not against production volume.

So the suite stays green at 9/9 while the payload it exists to bound grows
without limit.

## What it missed

Between the 08-27 and 08-28 scheduled DebugBear runs, with no membership change
on `main`:

| Run | page | slow decoded | duration | outcome |
|---|---|---:|---:|---|
| 08-27 `86545576` | desktop `693053` | 1,344,649 | 696 ms | complete |
| 08-28 `86622879` | desktop `693053` | **1,568,494** | 746 ms | complete |
| 08-27 `86545531` | mobile `693052` | 1,344,649 | 2,586 ms | complete |
| 08-28 `86622827` | mobile `693052` | **1,478,523** | **3,000 ms** | truncated at the deadline |

+223,845 B desktop, +133,874 B mobile in one day. Mobile crossed its 3,000 ms
abort, so the slow-tier hydration keys never landed and the panels went back to
their per-key endpoints — re-triggering the exact fallbacks #7048 removed:

```
 7789ms  bootstrap?tier=slow&public=1     311,701 B / 1,478,523 decoded / 3000ms / truncated
15099ms  list-fire-detections              17,541 B /   168,044 decoded /  734ms / 200
16386ms  list-natural-events?days=30      106,871 B /   367,463 decoded / 1162ms / 200
17671ms  bootstrap?keys=sanctionsPressure    5,945 B /    17,634 decoded /  470ms / 200
```

130,357 B of fallback transfer. The budget suite was green throughout.

## The change

The publisher is the only place that sees the bytes actually shipped, so it now
evaluates the real published ledger against the same ceilings and per-key frozen
values, returns `budget: { ok, violations }`, and emits a distinct
`[bootstrap-budget]` warning line an alert can key on:

```
[bootstrap-budget] tier=slow published payload exceeds its byte budget: slow.naturalEvents 412000 B exceeds captured 200792 B by material threshold 10040 B without a reviewed exception
```

**This is an observation, not a gate.** #7045's stop conditions forbid putting
mutable production values into a pull-request pass/fail check, and refusing to
publish over a size regression would take the dashboard down to prevent it being
slow. A breach warns; the publish proceeds. There is a test for exactly that.

The frozen ledger, ceilings, manifest and evaluator move to
`shared/bootstrap-payload-budget.js` because `scripts/` may not import from
`tests/` (the existing `publisher deployment boundaries` test enforces this, and
still passes). `tests/fixtures/bootstrap-payload-budget.mjs` re-exports them
unchanged — one copy of the captured numbers, and the budget suite is untouched.

## Tests

Four added to `tests/publish-bootstrap-tiers.test.mjs`, all four red before the
implementation:

- a payload inside its ceilings reports `budget.ok === true`;
- a `marketQuotes` grown from its captured 296,547 B is named in `violations` —
  the drift that is invisible to membership;
- a budget breach still performs its PUT (the not-a-gate guarantee);
- the publish loop warns exactly once, only for the violating tier, and still
  logs its normal info line for both.

## Verification

```
node --test tests/publish-bootstrap-tiers.test.mjs        18 pass, 0 fail  (14 pass / 4 fail before)
node --test tests/bootstrap-payload-budget.test.mjs        9 pass, 0 fail  (unchanged by the move)
node --import tsx --test tests/bootstrap.test.mjs         33 pass, 0 fail
npm run typecheck                                          clean
npm run typecheck:api                                      clean
npm run lint:boundaries                                    clean
```

Note: `node --test tests/bootstrap.test.mjs` without `--import tsx` fails to
resolve the `@/services` alias. That is pre-existing on `main` and unrelated to
this change, but the #7045 Verification Contract lists the command in its bare
form — worth correcting there.

## Post-deploy validation

Watch the publisher logs for `[bootstrap-budget]`. Expected: silent. If it fires,
the named key is the one to cap or paginate, and `budget.violations` says by how
much. Rollback is a clean revert; the publish path itself is unchanged.

Refs #7288
Refs #7045

https://claude.ai/code/session_016Bb5Nry6FhHgwhHLraESFE
