### PR TITLE
fix(aviation): normalize invalid passenger counts

### DIFF
--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -20,6 +20,7 @@ import {
 import { evaluateFreshness } from '../freshness';
 import { McpSourceUnavailableError } from '../source-unavailable';
 import { normalizeCountry } from '../../../server/_shared/intel-history-client';
+import { normalizePassengerCount } from '../../../server/_shared/passenger-count';
 import {
   collectInsightSources,
   INSIGHTS_MAX_SERVEABLE_AGE_MS,
@@ -2242,7 +2243,7 @@ export const RPC_TOOLS: ToolDef[] = [
         cabin_class: String(params.cabin_class ?? 'economy'),
         ...(params.max_stops ? { max_stops: String(params.max_stops) } : {}),
         ...(params.sort_by ? { sort_by: String(params.sort_by) } : {}),
-        passengers: String(Math.max(1, Math.min(Number(params.passengers ?? 1), 9))),
+        passengers: String(normalizePassengerCount(params.passengers)),
       });
       const url = `${base}/api/aviation/v1/search-google-flights?${qs}`;
       const auth = await buildAuthHeaders(context, 'GET', url, null);
@@ -2301,7 +2302,7 @@ export const RPC_TOOLS: ToolDef[] = [
         // upstream-empty-on-missing-cabin-class issue.
         cabin_class: String(params.cabin_class ?? 'economy'),
         sort_by_price: String(params.sort_by_price ?? false),
-        passengers: String(Math.max(1, Math.min(Number(params.passengers ?? 1), 9))),
+        passengers: String(normalizePassengerCount(params.passengers)),
       });
       const url = `${base}/api/aviation/v1/search-google-dates?${qs}`;
       const auth = await buildAuthHeaders(context, 'GET', url, null);

--- a/server/_shared/passenger-count.ts
+++ b/server/_shared/passenger-count.ts
@@ -1,0 +1,18 @@
+const DEFAULT_PASSENGER_COUNT = 1;
+const MIN_PASSENGER_COUNT = 1;
+const MAX_PASSENGER_COUNT = 9;
+
+/**
+ * Normalize passenger counts at request boundaries.
+ *
+ * Keeps malformed input from placing a non-finite value in an upstream URL or
+ * cache key while preserving the existing finite-value clamp semantics.
+ */
+export function normalizePassengerCount(value: unknown): number {
+  const parsed = Number(value ?? DEFAULT_PASSENGER_COUNT);
+  if (!Number.isFinite(parsed)) return DEFAULT_PASSENGER_COUNT;
+  return Math.max(
+    MIN_PASSENGER_COUNT,
+    Math.min(parsed, MAX_PASSENGER_COUNT),
+  );
+}

--- a/server/worldmonitor/aviation/v1/search-google-dates.ts
+++ b/server/worldmonitor/aviation/v1/search-google-dates.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 import { parseStringArray } from '../../../_shared/parse-string-array';
+import { normalizePassengerCount } from '../../../_shared/passenger-count';
 import { cachedFetchJson } from '../../../_shared/redis';
 
 // Medium-cache tier (10 min) — use cachedFetchJson for stampede protection.
@@ -28,7 +29,7 @@ export async function searchGoogleDates(
     return { dates: [], degraded: true, error: 'relay unavailable' };
   }
 
-  const passengers = Math.max(1, Math.min(req.passengers ?? 1, 9));
+  const passengers = normalizePassengerCount(req.passengers);
   const airlines = parseStringArray(req.airlines).sort();
   const params = new URLSearchParams({
     origin,

--- a/server/worldmonitor/aviation/v1/search-google-flights.ts
+++ b/server/worldmonitor/aviation/v1/search-google-flights.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { getRelayBaseUrl, getRelayHeaders } from '../../../_shared/relay';
 import { parseStringArray } from '../../../_shared/parse-string-array';
+import { normalizePassengerCount } from '../../../_shared/passenger-count';
 import { cachedFetchJson } from '../../../_shared/redis';
 
 const CACHE_TTL = 600;
@@ -27,7 +28,7 @@ export async function searchGoogleFlights(
   }
 
   // Clamp once so equivalent relay calls (e.g. passengers=99 → 9) share a cache entry.
-  const passengers = Math.max(1, Math.min(req.passengers ?? 1, 9));
+  const passengers = normalizePassengerCount(req.passengers);
   const airlines = parseStringArray(req.airlines);
   const params = new URLSearchParams({
     origin,

--- a/tests/google-flights.test.mts
+++ b/tests/google-flights.test.mts
@@ -8,6 +8,9 @@ process.env.RELAY_SHARED_SECRET = 'test-secret';
 
 const { searchGoogleFlights } = await import('../server/worldmonitor/aviation/v1/search-google-flights.ts');
 const { searchGoogleDates } = await import('../server/worldmonitor/aviation/v1/search-google-dates.ts');
+const { aviationHandler } = await import('../server/worldmonitor/aviation/v1/handler.ts');
+const { serverOptions } = await import('../server/gateway.ts');
+const { createAviationServiceRoutes } = await import('../src/generated/server/worldmonitor/aviation/v1/service_server.ts');
 
 type MockFn = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
@@ -207,5 +210,92 @@ describe('searchGoogleDates — multi-airline filtering', () => {
 
     assert.equal(result.degraded, false);
     assert.equal(result.dates.length, 1);
+  });
+});
+
+describe('Google Flights passenger normalization', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('defaults a non-finite flight-search passenger count before relay and cache use', async () => {
+    let capturedUrl = '';
+    mockFetch(async (input) => {
+      capturedUrl = urlOf(input);
+      return new Response(JSON.stringify({ flights: [] }), { status: 200 });
+    });
+
+    await searchGoogleFlights(mockCtx, {
+      origin: 'NAN',
+      destination: 'FIN',
+      departureDate: '2026-10-01',
+      airlines: [],
+      returnDate: '',
+      cabinClass: '',
+      maxStops: '',
+      departureWindow: '',
+      sortBy: '',
+      passengers: Number.NaN,
+    });
+
+    assert.equal(new URL(capturedUrl).searchParams.get('passengers'), '1');
+    assert.doesNotMatch(capturedUrl, /NaN/);
+  });
+
+  it('defaults a non-finite date-search passenger count before relay and cache use', async () => {
+    let capturedUrl = '';
+    mockFetch(async (input) => {
+      capturedUrl = urlOf(input);
+      return new Response(JSON.stringify({ dates: [], partial: false }), { status: 200 });
+    });
+
+    await searchGoogleDates(mockCtx, {
+      origin: 'NAN',
+      destination: 'FIN',
+      startDate: '2026-10-01',
+      endDate: '2026-10-08',
+      airlines: [],
+      isRoundTrip: false,
+      tripDuration: 0,
+      cabinClass: '',
+      maxStops: '',
+      departureWindow: '',
+      sortByPrice: false,
+      passengers: Number.NaN,
+    });
+
+    assert.equal(new URL(capturedUrl).searchParams.get('passengers'), '1');
+    assert.doesNotMatch(capturedUrl, /NaN/);
+  });
+
+  it('normalizes passengers=abc through both generated REST routes', async () => {
+    const capturedUrls: string[] = [];
+    mockFetch(async (input) => {
+      const url = urlOf(input);
+      capturedUrls.push(url);
+      const body = url.includes('search-dates')
+        ? { dates: [], partial: false }
+        : { flights: [] };
+      return new Response(JSON.stringify(body), { status: 200 });
+    });
+    const routes = createAviationServiceRoutes(aviationHandler, serverOptions);
+    const requests = [
+      '/api/aviation/v1/search-google-flights?origin=ABC&destination=DEF&departure_date=2026-11-01&passengers=abc',
+      '/api/aviation/v1/search-google-dates?origin=GHI&destination=JKL&start_date=2026-11-01&end_date=2026-11-08&passengers=abc',
+    ];
+
+    for (const requestPath of requests) {
+      const path = new URL(requestPath, 'https://worldmonitor.app').pathname;
+      const route = routes.find((candidate) => candidate.path === path);
+      assert.ok(route);
+      const response = await route.handler(new Request(`https://worldmonitor.app${requestPath}`));
+      assert.equal(response.status, 200);
+    }
+
+    assert.equal(capturedUrls.length, 2);
+    for (const url of capturedUrls) {
+      assert.equal(new URL(url).searchParams.get('passengers'), '1');
+      assert.doesNotMatch(url, /NaN/);
+    }
   });
 });

--- a/tests/mcp-flight-passenger-validation.test.mts
+++ b/tests/mcp-flight-passenger-validation.test.mts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { TOOL_REGISTRY } from '../api/mcp/registry/index.ts';
+
+const BASE_URL = 'https://worldmonitor.app';
+const AUTH = { kind: 'pro', userId: 'user_flight_passengers', mcpTokenId: 'mcp_flight_passengers' } as const;
+const originalFetch = globalThis.fetch;
+const originalHmacSecret = process.env.MCP_INTERNAL_HMAC_SECRET;
+
+const TOOL_CASES = [
+  {
+    name: 'search_flights',
+    params: { origin: 'JFK', destination: 'LHR', departure_date: '2026-09-01' },
+  },
+  {
+    name: 'search_flight_prices_by_date',
+    params: { origin: 'JFK', destination: 'LHR', start_date: '2026-09-01', end_date: '2026-09-08' },
+  },
+] as const;
+
+beforeEach(() => {
+  process.env.MCP_INTERNAL_HMAC_SECRET = 'test-secret-mcp-flight-passengers';
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalHmacSecret === undefined) {
+    delete process.env.MCP_INTERNAL_HMAC_SECRET;
+  } else {
+    process.env.MCP_INTERNAL_HMAC_SECRET = originalHmacSecret;
+  }
+});
+
+function rpcTool(name: string) {
+  const tool = TOOL_REGISTRY.find((candidate) => candidate.name === name);
+  assert.ok(tool, `${name} must be registered`);
+  assert.equal(typeof tool._execute, 'function', `${name} must be an RPC tool`);
+  return tool;
+}
+
+describe('MCP Google Flights passenger validation', () => {
+  for (const { name, params } of TOOL_CASES) {
+    it(`${name} keeps the existing numeric passenger schema`, () => {
+      assert.deepEqual(rpcTool(name).inputSchema.properties.passengers, {
+        type: 'number',
+        description: 'Number of passengers (1-9, default 1)',
+      });
+    });
+
+    for (const { passengers, expected } of [
+      { passengers: 'abc', expected: '1' },
+      { passengers: Number.NaN, expected: '1' },
+      { passengers: 0, expected: '1' },
+      { passengers: 10, expected: '9' },
+      { passengers: 1.5, expected: '1.5' },
+    ]) {
+      it(`${name} normalizes passengers=${String(passengers)} to ${expected}`, async () => {
+        let capturedUrl = '';
+        globalThis.fetch = (async (input: string | URL | Request) => {
+          capturedUrl = String(input);
+          return new Response(JSON.stringify({}), { status: 200 });
+        }) as typeof fetch;
+
+        await rpcTool(name)._execute!({ ...params, passengers }, BASE_URL, AUTH);
+        assert.equal(new URL(capturedUrl).searchParams.get('passengers'), expected);
+      });
+    }
+
+    it(`${name} defaults an omitted passenger count to 1`, async () => {
+      let capturedUrl = '';
+      globalThis.fetch = (async (input: string | URL | Request) => {
+        capturedUrl = String(input);
+        return new Response(JSON.stringify({}), { status: 200 });
+      }) as typeof fetch;
+
+      await rpcTool(name)._execute!(params, BASE_URL, AUTH);
+      assert.equal(new URL(capturedUrl).searchParams.get('passengers'), '1');
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Malformed passenger counts no longer reach the Google Flights relay or Redis cache keys as `NaN`. Both MCP flight tools and both REST handlers now use one finite-value normalizer, while valid finite inputs keep the existing `1..9` clamp behavior.

Regression coverage exercises each MCP tool, each server handler, and the generated REST route seam with `passengers=abc` and direct non-finite values.

## Validation

- 41 focused passenger and generated-request tests passed on the exact rebased tree.
- `npm run typecheck`, `npm run typecheck:api`, and `npm run lint:boundaries` passed.
- The full pre-push gate passed, including server-handler, changed-file, Edge Function, bundle, Unicode, proto-freshness, and version checks.
- `npm run test:data` was attempted separately but was interrupted after an unrelated worker did not terminate; it is not counted as passed.

## Post-Deploy Monitoring & Validation

- For the first 24 hours, WorldMonitor maintainers should check aviation relay logs for `passengers=NaN` on `search-google-flights` and `search-google-dates` and watch their error/degraded-response rates.
- Healthy: no relay request or cache-key diagnostic contains `passengers=NaN`, and success/error rates remain at baseline.
- Failure trigger: any new `passengers=NaN` occurrence or a material increase in aviation relay errors. Roll back this PR's commit and inspect the request parser and normalization call sites.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
