### PR TITLE
fix(military): report snapshot publication errors

### DIFF
--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -1,8 +1,6 @@
 import { unwrapEnvelope } from './seed-envelope';
 import { getRpcNoStoreReasonFromPayload } from './cache-contract';
 import { buildUpstreamEvent, getUsageScope, sendToAxiom } from './usage';
-// @ts-expect-error JavaScript module has no declaration file.
-import { captureSilentError } from '../../api/_sentry-edge.js';
 
 // Default Upstash REST timeouts are tuned for production (Vercel ↔ Upstash
 // same-datacenter latency is sub-50ms, 1.5s leaves >20× headroom). They
@@ -268,7 +266,13 @@ export async function setCachedJson(key: string, value: unknown, ttlSeconds: num
  * could not be confirmed. Callers that need the persisted winner must GET
  * after this and fail closed on a miss.
  */
-export async function setCachedJsonIfAbsent(key: string, value: unknown, ttlSeconds: number, raw = false): Promise<boolean> {
+export async function setCachedJsonIfAbsent(
+  key: string,
+  value: unknown,
+  ttlSeconds: number,
+  raw = false,
+  onError?: (error: unknown) => void,
+): Promise<boolean> {
   if (process.env.LOCAL_API_MODE === 'tauri-sidecar') {
     const { sidecarCacheSetIfAbsent } = await import('./sidecar-cache');
     return sidecarCacheSetIfAbsent(key, value, ttlSeconds);
@@ -299,9 +303,8 @@ export async function setCachedJsonIfAbsent(key: string, value: unknown, ttlSeco
     }
     return data?.result === 'OK';
   } catch (err) {
-    void captureSilentError(err, {
-      tags: { component: 'redis', operation: 'setCachedJsonIfAbsent' },
-    });
+    // sentry-coverage-ok: onError receives the original exception before the fail-closed return.
+    onError?.(err);
     console.warn('[redis] setCachedJsonIfAbsent failed:', errMsg(err));
     return false;
   }

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -1,6 +1,8 @@
 import { unwrapEnvelope } from './seed-envelope';
 import { getRpcNoStoreReasonFromPayload } from './cache-contract';
 import { buildUpstreamEvent, getUsageScope, sendToAxiom } from './usage';
+// @ts-expect-error JavaScript module has no declaration file.
+import { captureSilentError } from '../../api/_sentry-edge.js';
 
 // Default Upstash REST timeouts are tuned for production (Vercel ↔ Upstash
 // same-datacenter latency is sub-50ms, 1.5s leaves >20× headroom). They
@@ -297,8 +299,9 @@ export async function setCachedJsonIfAbsent(key: string, value: unknown, ttlSeco
     }
     return data?.result === 'OK';
   } catch (err) {
-    // sentry-coverage-ok: callers read back the persisted winner and fail
-    // closed when first-writer publication cannot be confirmed.
+    void captureSilentError(err, {
+      tags: { component: 'redis', operation: 'setCachedJsonIfAbsent' },
+    });
     console.warn('[redis] setCachedJsonIfAbsent failed:', errMsg(err));
     return false;
   }

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -297,6 +297,8 @@ export async function setCachedJsonIfAbsent(key: string, value: unknown, ttlSeco
     }
     return data?.result === 'OK';
   } catch (err) {
+    // sentry-coverage-ok: callers read back the persisted winner and fail
+    // closed when first-writer publication cannot be confirmed.
     console.warn('[redis] setCachedJsonIfAbsent failed:', errMsg(err));
     return false;
   }

--- a/server/worldmonitor/military/v1/list-military-flights.ts
+++ b/server/worldmonitor/military/v1/list-military-flights.ts
@@ -16,6 +16,8 @@ import {
   hasRedistributableProviderAttribution,
   requiresRedistributableProviders,
 } from '../../../_shared/provider-redistribution';
+// @ts-expect-error JavaScript module has no declaration file.
+import { captureSilentError } from '../../../../api/_sentry-edge.js';
 
 const REDIS_CACHE_KEY = 'military:flights:v1';
 const REDIS_CACHE_TTL = 600; // 10 min — reduce upstream API pressure
@@ -345,6 +347,15 @@ async function fetchStableLiveSeedSnapshot(): Promise<LiveSeedRead> {
       STABLE_LIVE_SNAPSHOT_CACHE_KEY,
       { flights: seeded.flights, coverage: seeded.coverage },
       REDIS_CACHE_TTL,
+      false,
+      (error) => {
+        void captureSilentError(error, {
+          tags: {
+            route: 'military/list-military-flights',
+            step: 'stable-live-snapshot-publish',
+          },
+        });
+      },
     );
     const persisted = await readCachedJson(STABLE_LIVE_SNAPSHOT_CACHE_KEY);
     if (persisted.status === 'hit') {

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -4569,6 +4570,51 @@ describe('setCachedJson wire shape and failure reporting', { concurrency: 1 }, (
       console.warn = originalWarn;
       restoreEnv();
     }
+  });
+
+  it('reports transport exceptions from first-writer Redis publication', () => {
+    const childEnv = {
+      ...process.env,
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VITE_SENTRY_DSN: 'https://public@sentry.test/42',
+      VERCEL_ENV: 'test',
+    };
+    delete childEnv.NODE_TEST_CONTEXT;
+
+    const childScript = `
+      import { setCachedJsonIfAbsent } from ${JSON.stringify(REDIS_MODULE_URL)};
+
+      const calls = [];
+      globalThis.fetch = async (url, init) => {
+        calls.push({ url: String(url), body: String(init?.body ?? '') });
+        if (String(url).startsWith('https://redis.test')) {
+          throw new Error('redis transport down');
+        }
+        return { ok: true, status: 200 };
+      };
+      console.warn = () => {};
+
+      const created = await setCachedJsonIfAbsent('k', { v: 1 }, 30);
+      process.stdout.write(JSON.stringify({ created, calls }));
+    `;
+
+    const child = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', '--input-type=module', '--eval', childScript],
+      { cwd: root, env: childEnv, encoding: 'utf8' },
+    );
+
+    assert.equal(child.status, 0, child.stderr);
+    const result = JSON.parse(child.stdout);
+    assert.equal(result.created, false, 'transport failure must remain fail-closed');
+    const sentryCalls = result.calls.filter(({ url }) => url.includes('/api/42/envelope/'));
+    assert.equal(sentryCalls.length, 1, 'transport exception must emit one Sentry event');
+
+    const event = JSON.parse(sentryCalls[0].body.trim().split('\n').at(-1));
+    assert.equal(event.exception.values[0].value, 'redis transport down');
+    assert.equal(event.tags.component, 'redis');
+    assert.equal(event.tags.operation, 'setCachedJsonIfAbsent');
   });
 });
 

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1,6 +1,5 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -4572,49 +4571,35 @@ describe('setCachedJson wire shape and failure reporting', { concurrency: 1 }, (
     }
   });
 
-  it('reports transport exceptions from first-writer Redis publication', () => {
-    const childEnv = {
-      ...process.env,
+  it('passes first-writer transport exceptions to the caller error reporter', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
       UPSTASH_REDIS_REST_URL: 'https://redis.test',
       UPSTASH_REDIS_REST_TOKEN: 'token',
-      VITE_SENTRY_DSN: 'https://public@sentry.test/42',
-      VERCEL_ENV: 'test',
-    };
-    delete childEnv.NODE_TEST_CONTEXT;
+    });
+    const originalFetch = globalThis.fetch;
+    const originalWarn = console.warn;
+    const reported = [];
+    globalThis.fetch = async () => { throw new Error('redis transport down'); };
+    console.warn = () => {};
 
-    const childScript = `
-      import { setCachedJsonIfAbsent } from ${JSON.stringify(REDIS_MODULE_URL)};
+    try {
+      const created = await redis.setCachedJsonIfAbsent(
+        'k',
+        { v: 1 },
+        30,
+        false,
+        (error) => { reported.push(error); },
+      );
 
-      const calls = [];
-      globalThis.fetch = async (url, init) => {
-        calls.push({ url: String(url), body: String(init?.body ?? '') });
-        if (String(url).startsWith('https://redis.test')) {
-          throw new Error('redis transport down');
-        }
-        return { ok: true, status: 200 };
-      };
-      console.warn = () => {};
-
-      const created = await setCachedJsonIfAbsent('k', { v: 1 }, 30);
-      process.stdout.write(JSON.stringify({ created, calls }));
-    `;
-
-    const child = spawnSync(
-      process.execPath,
-      ['--import', 'tsx', '--input-type=module', '--eval', childScript],
-      { cwd: root, env: childEnv, encoding: 'utf8' },
-    );
-
-    assert.equal(child.status, 0, child.stderr);
-    const result = JSON.parse(child.stdout);
-    assert.equal(result.created, false, 'transport failure must remain fail-closed');
-    const sentryCalls = result.calls.filter(({ url }) => url.includes('/api/42/envelope/'));
-    assert.equal(sentryCalls.length, 1, 'transport exception must emit one Sentry event');
-
-    const event = JSON.parse(sentryCalls[0].body.trim().split('\n').at(-1));
-    assert.equal(event.exception.values[0].value, 'redis transport down');
-    assert.equal(event.tags.component, 'redis');
-    assert.equal(event.tags.operation, 'setCachedJsonIfAbsent');
+      assert.equal(created, false, 'transport failure must remain fail-closed');
+      assert.equal(reported.length, 1, 'transport exception must reach the caller reporter');
+      assert.equal(reported[0]?.message, 'redis transport down');
+    } finally {
+      globalThis.fetch = originalFetch;
+      console.warn = originalWarn;
+      restoreEnv();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Report first-writer Redis publication transport errors to Sentry while preserving fail-closed snapshot publication and readback.

Keep `server/_shared/redis.ts` free of Edge-only imports. The military handler supplies the error reporter, so Railway seed containers retain their existing import closure.

Related: #6242
Related: #7304

## Validation

- The focused Redis failure-reporting group passed 6 of 6 tests.
- The Railway watch-path and container import-graph suites passed 112 of 112 tests.
- The pre-push gate passed, including 91 server tests and 87 changed-file tests.
- GitHub `unit`, `variant-smoke-full`, `gate`, and `monitor` checks passed. Vercel also succeeded.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
