### PR TITLE
fix(llm-health): unify provider derivation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,8 @@ WORKDIR /app
 # API server
 COPY --from=builder /app/src-tauri/sidecar/local-api-server.mjs ./local-api-server.mjs
 COPY --from=builder /app/src-tauri/sidecar/package.json ./package.json
+COPY --from=builder /app/shared/llm-health-providers.js ./shared/llm-health-providers.js
+ENV LOCAL_API_RESOURCE_DIR=/app
 
 # Minimal runtime node_modules — required by raw .js handlers that aren't
 # bundled by build-handlers.mjs. Without this the Node sidecar dispatches

--- a/docs/solutions/integration-issues/llm-health-provider-derivation-drift.md
+++ b/docs/solutions/integration-issues/llm-health-provider-derivation-drift.md
@@ -1,0 +1,75 @@
+---
+title: LLM health derives providers from credential presence
+date: 2026-08-28
+category: integration-issues
+module: llm-health
+problem_type: integration_issue
+component: service_object
+symptoms:
+  - "The desktop health indicator omitted Groq when GROQ_API_KEY did not start with gsk_"
+  - "Server LLM calls still used the same Groq key"
+root_cause: duplicated_policy
+resolution_type: code_change
+severity: medium
+related_components: [desktop, server, testing]
+tags: [llm, groq, health-check, desktop, sidecar, provider-parity]
+---
+
+# LLM health derives providers from credential presence
+
+## Decision
+
+The `gsk_` check was drift. It was not an intentional desktop security rule.
+
+`shared/llm-health-providers.js` is now the source of truth for provider health
+configuration. A non-empty `GROQ_API_KEY` enables the Groq origin on both the
+server and the desktop sidecar. The provider request validates the credential.
+The health check reports origin reachability only.
+
+## Why the prefix check was wrong
+
+The server accepted any non-empty `GROQ_API_KEY`. The desktop endpoint accepted
+only keys that started with `gsk_`. Both implementations arrived in the same
+repository snapshot, and the history has no reason for the extra desktop rule.
+
+A key prefix is not a reliable credential contract. A malformed or revoked key
+can have the expected prefix. A valid key can use a different format. The
+desktop already has a separate credential-validation endpoint for that question.
+
+## Shared provider shape
+
+The shared module returns entries with three fields:
+
+- `name` identifies the provider in the health response.
+- `url` is the origin that both processes probe.
+- `allowPrivateNetwork` permits configured local LLM origins in the sidecar.
+
+The sidecar endpoint and `warmHealthCache()` consume this list. This removes the
+duplicated Groq and OpenRouter conditions.
+
+## Dead startup probe
+
+The sidecar also probed configured providers after startup. The loop did not
+write a cache, and `/api/llm-health` ran new probes for every request. The
+startup result had no consumer, so the loop was deleted.
+
+## Verification
+
+The regression tests set `GROQ_API_KEY=groq-test-key`. The server cache and the
+desktop endpoint both report `https://api.groq.com` as available when the origin
+responds.
+
+Run these checks:
+
+```bash
+node_modules/.bin/tsx --test tests/llm-health.test.mts
+node --test src-tauri/sidecar/local-api-server.test.mjs
+npm run typecheck:api
+npm run test:sidecar
+```
+
+## Related
+
+- [A timeout that assumed a provider-routing pin the seeder never had](timeout-assumed-a-routing-pin-that-never-existed.md)
+  records the same rule: policy that must remain aligned across an import
+  boundary must live where both consumers can import it.

--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -51,7 +51,7 @@ This generated inventory covers **753 active source hosts** representing **744 a
 | api.fiscaldata.treasury.gov (api.fiscaldata.treasury.gov) | structured — scripts/seed-national-debt.mjs, scripts/seed-supply-chain-trade.mjs |
 | api.gdeltproject.org (api.gdeltproject.org) | structured — scripts/seed-gdelt-intel.mjs, scripts/seed-unrest-events.mjs |
 | api.github.com (api.github.com) | structured — api/_github-release.js, scripts/dispatch-stale-railway-reconcile.mjs, scripts/resolve-railway-reconcile-control.mjs, scripts/seed-research.mjs |
-| api.groq.com (api.groq.com) | structured — server/_shared/llm-health.ts |
+| api.groq.com (api.groq.com) | structured — shared/llm-health-providers.js |
 | api.iea.org (api.iea.org) | structured — scripts/seed-iea-oil-stocks.mjs |
 | api.imf.org (api.imf.org) | structured — scripts/_seed-utils.mjs, scripts/seed-gold-cb-reserves.mjs |
 | api.indexnow.org (api.indexnow.org) | structured — scripts/seo-indexnow-submit.mjs |

--- a/scripts/source-attribution.mjs
+++ b/scripts/source-attribution.mjs
@@ -876,13 +876,13 @@ const LOGICAL_ENTRIES = [
   },
 ];
 
-// A few seeders build a URL from a classification/configuration document and
-// therefore do not contain the provider host beside the eventual fetch call.
-// Keep those dynamic hosts explicit so the lexical pass still provides a
-// reviewable reference and the CI gate cannot silently drop them.  The file is
-// pinned but the line deliberately is not: a line pin hard-fails the whole scan
-// the moment an unrelated edit shifts it.
+// A few runtime paths build a URL from configuration or live outside the
+// scanner's ordinary source roots. Keep those hosts explicit so the lexical
+// pass still provides a reviewable reference and the CI gate cannot silently
+// drop them. The file is pinned but the line deliberately is not: a line pin
+// hard-fails the whole scan the moment an unrelated edit shifts it.
 const DYNAMIC_HOSTS = [
+  { host: 'api.groq.com', kind: 'structured', path: 'shared/llm-health-providers.js' },
   { host: 'www.swfinstitute.org', kind: 'structured', path: 'scripts/seed-sovereign-wealth.mjs' },
   { host: 'www.ifswf.org', kind: 'structured', path: 'scripts/seed-sovereign-wealth.mjs' },
   { host: 'www.visionofhumanity.org', kind: 'structured', path: 'scripts/seed-resilience-static.mjs' },

--- a/server/_shared/llm-health.ts
+++ b/server/_shared/llm-health.ts
@@ -9,6 +9,8 @@
 // The origin probe cannot answer (2): it GETs the bare origin, so a provider
 // that is up but does not serve the configured model ID still looks healthy.
 
+import { getConfiguredLlmHealthProviders } from '../../shared/llm-health-providers.js';
+
 const PROBE_TIMEOUT_MS = 2_000;
 const CACHE_TTL_MS = 60_000; // re-probe every 60s
 
@@ -275,22 +277,9 @@ export async function reprobeAll(): Promise<void> {
  * Fire-and-forget — does not block the caller.
  */
 export function warmHealthCache(): void {
-  const providerUrls: string[] = [];
-
-  const ollamaUrl = typeof process !== 'undefined'
-    ? (process.env?.OLLAMA_API_URL || process.env?.LLM_API_URL)
-    : undefined;
-  if (ollamaUrl) providerUrls.push(ollamaUrl);
-
-  if (typeof process !== 'undefined' && process.env?.GROQ_API_KEY) {
-    providerUrls.push('https://api.groq.com/openai/v1/chat/completions');
-  }
-  if (typeof process !== 'undefined' && process.env?.OPENROUTER_API_KEY) {
-    providerUrls.push('https://openrouter.ai/api/v1/chat/completions');
-  }
-
-  for (const url of providerUrls) {
-    void isProviderAvailable(url);
+  if (typeof process === 'undefined') return;
+  for (const provider of getConfiguredLlmHealthProviders(process.env)) {
+    void isProviderAvailable(provider.url);
   }
 }
 

--- a/shared/llm-health-providers.d.ts
+++ b/shared/llm-health-providers.d.ts
@@ -1,0 +1,9 @@
+export interface LlmHealthProvider {
+  name: 'ollama' | 'groq' | 'openrouter';
+  url: string;
+  allowPrivateNetwork: boolean;
+}
+
+export function getConfiguredLlmHealthProviders(
+  env: Readonly<Record<string, string | undefined>>,
+): LlmHealthProvider[];

--- a/shared/llm-health-providers.js
+++ b/shared/llm-health-providers.js
@@ -1,0 +1,47 @@
+const HOSTED_LLM_PROVIDERS = [
+  {
+    name: 'groq',
+    envKey: 'GROQ_API_KEY',
+    url: 'https://api.groq.com',
+    allowPrivateNetwork: false,
+  },
+  {
+    name: 'openrouter',
+    envKey: 'OPENROUTER_API_KEY',
+    url: 'https://openrouter.ai',
+    allowPrivateNetwork: false,
+  },
+];
+
+/**
+ * Derive the providers whose reachability should be reported.
+ * Credential presence enables hosted providers. Credential format is validated
+ * by the provider request, not guessed from a prefix at the health boundary.
+ */
+export function getConfiguredLlmHealthProviders(env) {
+  const providers = [];
+  const localUrl = env.OLLAMA_API_URL || env.LLM_API_URL;
+
+  if (localUrl) {
+    try {
+      providers.push({
+        name: 'ollama',
+        url: new URL(localUrl).origin,
+        allowPrivateNetwork: true,
+      });
+    } catch {
+      // Invalid local URLs are not probeable providers.
+    }
+  }
+
+  for (const provider of HOSTED_LLM_PROVIDERS) {
+    if (!env[provider.envKey]) continue;
+    providers.push({
+      name: provider.name,
+      url: provider.url,
+      allowPrivateNetwork: provider.allowPrivateNetwork,
+    });
+  }
+
+  return providers;
+}

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -827,7 +827,7 @@
       "status": "excluded",
       "references": [
         {
-          "path": "server/_shared/llm-health.ts"
+          "path": "shared/llm-health-providers.js"
         }
       ]
     },

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -9,7 +9,13 @@ import { isIP } from 'node:net';
 import { promisify } from 'node:util';
 import { brotliCompress, gzipSync } from 'node:zlib';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const sharedResourceRoot = process.env.LOCAL_API_RESOURCE_DIR
+  || path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const { getConfiguredLlmHealthProviders } = await import(
+  pathToFileURL(path.join(sharedResourceRoot, 'shared/llm-health-providers.js')).href
+);
 
 const brotliCompressAsync = promisify(brotliCompress);
 const DESKTOP_AUTH_SECRET_ENV = 'WM_DESKTOP_SHARED_SECRET';
@@ -1487,8 +1493,6 @@ async function dispatch(requestUrl, req, routes, context) {
       routes: routes.length,
     });
   }
-  // LLM health endpoint — mirrors probe logic from server/_shared/llm-health.ts.
-  // TODO: refactor to import getLlmHealthStatus() once handlers share a process-level module cache.
   if (requestUrl.pathname === '/api/llm-health') {
     const PROBE_TIMEOUT = 2000;
     async function probeOrigin(url, options = {}) {
@@ -1499,33 +1503,15 @@ async function dispatch(requestUrl, req, routes, context) {
         return false;
       }
     }
-    const providers = [];
-    const providerChecks = [];
-    const ollamaUrl = process.env.OLLAMA_API_URL || process.env.LLM_API_URL;
-    const groqKey = process.env.GROQ_API_KEY;
-    const openrouterKey = process.env.OPENROUTER_API_KEY;
-
-    if (ollamaUrl) {
-      try {
-        const origin = new URL(ollamaUrl).origin;
-        providerChecks.push(
-          probeOrigin(origin, { allowPrivateNetwork: true }).then((available) => ({ name: 'ollama', url: origin, available })),
-        );
-      } catch {}
-    }
-    if (groqKey?.startsWith('gsk_')) {
-      providerChecks.push(
-        probeOrigin('https://api.groq.com').then((available) => ({ name: 'groq', url: 'https://api.groq.com', available })),
-      );
-    }
-    if (openrouterKey) {
-      providerChecks.push(
-        probeOrigin('https://openrouter.ai').then((available) => ({ name: 'openrouter', url: 'https://openrouter.ai', available })),
-      );
-    }
-    if (providerChecks.length > 0) {
-      providers.push(...(await Promise.all(providerChecks)));
-    }
+    const providers = await Promise.all(
+      getConfiguredLlmHealthProviders(process.env).map(async (provider) => ({
+        name: provider.name,
+        url: provider.url,
+        available: await probeOrigin(provider.url, {
+          allowPrivateNetwork: provider.allowPrivateNetwork,
+        }),
+      })),
+    );
 
     const anyAvailable = providers.some(p => p.available);
     return json({ available: anyAvailable, providers, checkedAt: Date.now() });
@@ -1966,20 +1952,6 @@ export async function createLocalApiServer(options = {}) {
       }
 
       context.logger.log(`[local-api] listening on http://127.0.0.1:${boundPort} (apiDir=${context.apiDir}, routes=${routes.length}, cloudFallback=${context.cloudFallback})`);
-
-      // Warm LLM health cache in background (non-blocking)
-      (async () => {
-        const urls = [
-          process.env.OLLAMA_API_URL || process.env.LLM_API_URL,
-          process.env.GROQ_API_KEY ? 'https://api.groq.com' : null,
-          process.env.OPENROUTER_API_KEY ? 'https://openrouter.ai' : null,
-        ].filter(Boolean);
-        for (const url of urls) {
-          const allowPrivateNetwork = url === process.env.OLLAMA_API_URL || url === process.env.LLM_API_URL;
-          try { await fetchWithTimeout(url, { method: 'GET', allowPrivateNetwork }, 2000); } catch {}
-        }
-        if (urls.length) console.log(`[local-api] LLM health warmed for ${urls.length} provider(s)`);
-      })();
 
       return { port: boundPort };
     },

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import http, { createServer, request as httpRequest } from 'node:http';
 import https from 'node:https';
@@ -12,6 +13,11 @@ import path from 'node:path';
 import test from 'node:test';
 import { runInNewContext } from 'node:vm';
 import { createLocalApiServer, __testing__ } from './local-api-server.mjs';
+
+test('bundles the shared LLM health provider registry with the sidecar (#7126)', () => {
+  const config = JSON.parse(readFileSync(new URL('../tauri.conf.json', import.meta.url), 'utf8'));
+  assert.ok(config.bundle.resources.includes('../shared/llm-health-providers.js'));
+});
 
 test('keeps seed-owned defense snapshots cloud-preferred regardless of relay configuration', () => {
   assert.equal(__testing__.isCloudPreferred('/api/bootstrap'), true);
@@ -1323,6 +1329,50 @@ test('uses IPv4 sidecar fetch for allowed private-network LLM probes (#3549)', a
     assert.equal(sawOllamaProbe, true);
   } finally {
     http.request = originalHttpRequest;
+    for (const [key, value] of Object.entries(envSnapshot)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await app.close();
+    await localApi.cleanup();
+  }
+});
+
+test('reports Groq health for configured keys without a gsk_ prefix (#7126)', async () => {
+  const envSnapshot = {
+    GROQ_API_KEY: process.env.GROQ_API_KEY,
+    OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+    OLLAMA_API_URL: process.env.OLLAMA_API_URL,
+    LLM_API_URL: process.env.LLM_API_URL,
+  };
+  const restoreHttps = mockHttpsRequestOnce({
+    statusCode: 404,
+    headers: { 'content-type': 'application/json' },
+    body: '{}',
+  });
+
+  process.env.GROQ_API_KEY = 'groq-test-key';
+  delete process.env.OPENROUTER_API_KEY;
+  delete process.env.OLLAMA_API_URL;
+  delete process.env.LLM_API_URL;
+
+  const localApi = await setupApiDir({});
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() { }, warn() { }, error() { } },
+  });
+  const { port } = await app.start();
+
+  try {
+    const response = await getJsonViaHttp(`http://127.0.0.1:${port}/api/llm-health`);
+    assert.equal(response.status, 200);
+    assert.equal(response.json.available, true);
+    assert.deepEqual(response.json.providers, [
+      { name: 'groq', url: 'https://api.groq.com', available: true },
+    ]);
+  } finally {
+    restoreHttps();
     for (const [key, value] of Object.entries(envSnapshot)) {
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -16,7 +16,13 @@ import { createLocalApiServer, __testing__ } from './local-api-server.mjs';
 
 test('bundles the shared LLM health provider registry with the sidecar (#7126)', () => {
   const config = JSON.parse(readFileSync(new URL('../tauri.conf.json', import.meta.url), 'utf8'));
+  const dockerfile = readFileSync(new URL('../../Dockerfile', import.meta.url), 'utf8');
   assert.ok(config.bundle.resources.includes('../shared/llm-health-providers.js'));
+  assert.match(
+    dockerfile,
+    /COPY --from=builder \/app\/shared\/llm-health-providers\.js \.\/shared\/llm-health-providers\.js/,
+  );
+  assert.match(dockerfile, /^ENV LOCAL_API_RESOURCE_DIR=\/app$/m);
 });
 
 test('keeps seed-owned defense snapshots cloud-preferred regardless of relay configuration', () => {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -54,6 +54,7 @@
     ],
     "resources": [
       "../api",
+      "../shared/llm-health-providers.js",
       "sidecar/local-api-server.mjs",
       "sidecar/package.json",
       "sidecar/node",

--- a/tests/llm-health.test.mts
+++ b/tests/llm-health.test.mts
@@ -3,11 +3,13 @@ import { afterEach, describe, it } from 'node:test';
 
 import {
   __testing__,
+  getLlmHealthStatus,
   getLlmModelHealthStatus,
   isModelRejection,
   isModelUsable,
   recordModelFailure,
   recordModelSuccess,
+  warmHealthCache,
 } from '../server/_shared/llm-health.ts';
 
 const { MODEL_FAILURE_THRESHOLD, MODEL_QUARANTINE_MS } = __testing__;
@@ -26,10 +28,42 @@ const OPENAI_STYLE_UNKNOWN_MODEL = JSON.stringify({
 const OLLAMA_UNKNOWN_MODEL = JSON.stringify({ error: `model '${DEAD_MODEL}' not found, try pulling it first` });
 
 const originalDateNow = Date.now;
+const originalFetch = globalThis.fetch;
+const originalProviderEnv = {
+  GROQ_API_KEY: process.env.GROQ_API_KEY,
+  OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+  OLLAMA_API_URL: process.env.OLLAMA_API_URL,
+  LLM_API_URL: process.env.LLM_API_URL,
+};
 
 afterEach(() => {
   Date.now = originalDateNow;
+  globalThis.fetch = originalFetch;
+  for (const [key, value] of Object.entries(originalProviderEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   __testing__.reset();
+});
+
+describe('configured provider health', () => {
+  it('reports a configured non-gsk Groq key as available on the server (#7126)', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.OLLAMA_API_URL;
+    delete process.env.LLM_API_URL;
+
+    globalThis.fetch = async (input) => {
+      assert.equal(String(input), 'https://api.groq.com');
+      return new Response(null, { status: 404 });
+    };
+
+    warmHealthCache();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const status = getLlmHealthStatus();
+    assert.equal(status['https://api.groq.com']?.available, true);
+  });
 });
 
 describe('isModelRejection', () => {


### PR DESCRIPTION
## Why

Desktop health omitted Groq when a configured key did not start with `gsk_`, while the server still accepted and used the same key. The two surfaces can no longer disagree about whether Groq is configured.

## Scope

- Derive Ollama, Groq, and OpenRouter health providers from one shared registry.
- Bundle that registry with the Tauri and Docker sidecars and consume it from both runtimes.
- Track the shared Groq origin in the generated source-attribution inventory.
- Keep credential validation separate from origin reachability.
- Delete the sidecar startup probe because it did not populate a cache or feed any consumer.

## Tradeoffs

The sidecar now treats the shared registry as a required packaged resource and fails at startup if packaging omits it. This makes policy drift harder to reintroduce, but it makes the Tauri and Docker bundle entries part of the startup contract. Focused tests pin both entries.

Health remains an origin-reachability signal. It does not claim that a credential is valid or that a configured model exists.

## Blast Radius

The change affects the desktop LLM status endpoint, the Docker sidecar package, the server health cache warmer, and generated source-attribution output. Provider request routing, credential storage, secret validation, and completion calls are unchanged.

## Verification

- `node --test src-tauri/sidecar/local-api-server.test.mjs`: 64 passed.
- `node_modules/.bin/tsx --test tests/llm-health.test.mts`: 19 passed.
- `npm run test:sidecar`: 419 passed.
- `node --test tests/docker-sidecar-auth-config.test.mjs`: 11 passed.
- `node --test --test-name-pattern='Docker sidecar runtime guardrails' tests/deploy-config.test.mjs`: 2 passed.
- `node --test tests/source-attribution.test.mjs`: 44 passed.
- `node scripts/source-attribution.mjs --check`: passed.
- `node scripts/generate-inventory-facts.mjs --check`: passed.
- `npm run typecheck:api`: passed.
- `npm run lint:boundaries`: passed.
- Decision-record markdown lint and `git diff --check`: passed.

## Post-Deploy Monitoring & Validation

- Validate the first packaged desktop canary with a configured non-`gsk_` Groq key.
- Confirm `/api/llm-health` lists Groq once and reports the origin result shown by the desktop indicator.
- Watch Tauri and Docker sidecar startup logs for module-resolution failures involving `shared/llm-health-providers.js`.
- Treat a sidecar startup failure or a missing Groq entry as a rollback signal. Observe the canary and desktop error reports for 24 hours.

## Known Residuals

A signed release-mode Tauri package and a full Docker image were not built locally. Their resource contracts are covered by configuration and sidecar tests, and CI remains the release-build gate.

Fixes #7126.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
