### PR TITLE
fix(bootstrap): serve the public tier with the public header shape at the edge

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -16,6 +16,12 @@ on:
     paths:
       - 'workers/api-cors-preflight/**'
       - 'api/_bootstrap-public-tier.js'
+      # The deployed-URL guard and the contract it asserts. Without these, a change
+      # to the shared contract helper alone deploys nothing and runs no live smoke —
+      # so the half of "one definition, both sides" that runs against production
+      # would silently never be re-checked.
+      - 'tests/cors-preflight-live.test.mjs'
+      - 'tests/helpers/public-bootstrap-contract.mjs'
       - '.github/workflows/deploy-worker.yml'
   workflow_dispatch:
 

--- a/api/_bootstrap-public-tier.js
+++ b/api/_bootstrap-public-tier.js
@@ -1,13 +1,15 @@
 export const PUBLIC_BOOTSTRAP_TIERS = new Set(['fast', 'slow']);
 
 /**
- * Return the tier for the two fixed public bootstrap request shapes, else null.
- * This dependency-free helper is shared by the Vercel handler and Cloudflare
- * shadow Worker so their routing contract cannot drift independently.
+ * Return the tier for the two fixed public bootstrap URL shapes, else null.
+ * Method-agnostic: this is the URL half of the contract only.
+ *
+ * Split out from bootstrapTierFromPublicRequest so the Cloudflare Worker can ask
+ * the same question about a CORS preflight, whose own method is OPTIONS while the
+ * request it is clearing is a GET. Both callers must reach the same answer about
+ * which URLs are public, which is why this lives here rather than in the Worker.
  */
-export function bootstrapTierFromPublicRequest(req, parsedUrl = new URL(req.url)) {
-  if (req.method !== 'GET') return null;
-
+export function bootstrapTierFromPublicUrl(parsedUrl) {
   const pathname = parsedUrl.pathname.length > 1
     ? parsedUrl.pathname.replace(/\/+$/, '')
     : parsedUrl.pathname;
@@ -21,6 +23,16 @@ export function bootstrapTierFromPublicRequest(req, parsedUrl = new URL(req.url)
   if (tierParams.length !== 1 || publicParams.length !== 1 || publicParams[0] !== '1') return null;
 
   return PUBLIC_BOOTSTRAP_TIERS.has(tierParams[0]) ? tierParams[0] : null;
+}
+
+/**
+ * Return the tier for the two fixed public bootstrap request shapes, else null.
+ * This dependency-free helper is shared by the Vercel handler and Cloudflare
+ * shadow Worker so their routing contract cannot drift independently.
+ */
+export function bootstrapTierFromPublicRequest(req, parsedUrl = new URL(req.url)) {
+  if (req.method !== 'GET') return null;
+  return bootstrapTierFromPublicUrl(parsedUrl);
 }
 
 export function isPublicTierBootstrapRequest(req) {

--- a/api/bootstrap-auth.test.mjs
+++ b/api/bootstrap-auth.test.mjs
@@ -2,6 +2,10 @@ import { strict as assert } from 'node:assert';
 import test from 'node:test';
 import handler from './bootstrap.js';
 import { issueSessionToken } from './_session.js';
+import {
+  assertPublicBootstrapCorsHeaders,
+  assertPublicBootstrapSharedCacheHeaders,
+} from '../tests/helpers/public-bootstrap-contract.mjs';
 
 const ENTERPRISE_KEY = 'enterprise-bootstrap-test-key';
 const USER_KEY = 'wm_0123456789abcdef0123456789abcdef01234567';
@@ -198,21 +202,20 @@ function makePublicTierBootstrapRequest(tier = 'fast', headers = {}) {
   });
 }
 
+// Both delegate to tests/helpers/public-bootstrap-contract.mjs, which
+// tests/cors-preflight-live.test.mjs runs against a DEPLOYED URL. Keeping one
+// definition is the point: #7308 shipped because these assertions passed against
+// handler() while the edge served a different shape to real browsers.
 function assertSharedCacheHeaders(resp) {
-  // Tier responses intentionally avoid public/s-maxage in Cache-Control (CF in
-  // front of api.worldmonitor.app would mispin ACAO) and shield via Vercel's
-  // CDN-Cache-Control instead.
-  assert.ok(resp.headers.get('cdn-cache-control'));
-  assert.match(resp.headers.get('cdn-cache-control') || '', /\b(public|s-maxage)\b/i);
+  assertPublicBootstrapSharedCacheHeaders({ assert, resp });
 }
 
 function assertPublicCorsHeaders(resp) {
-  // Public seed payload → ACAO:* with no Vary: Origin and no credentials, so the
-  // shared CDN stores one entry per URL and no origin can pin an echoed ACAO.
-  assert.equal(resp.headers.get('access-control-allow-origin'), '*');
-  assert.equal(resp.headers.get('access-control-allow-credentials'), null);
+  assertPublicBootstrapCorsHeaders({ assert, resp });
+  // Tighter than the shared contract can be: this response is the handler's own
+  // output, with no platform-appended `Vary: accept-encoding` yet, so no Vary
+  // at all is the correct expectation here.
   assert.equal(resp.headers.get('vary'), null);
-  assert.equal(resp.headers.get('timing-allow-origin'), '*');
 }
 
 function assertNonSharedCacheHeaders(resp) {

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -90,9 +90,15 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // CLOUDFLARE_API_TOKEN fails it silently like the reconcile Worker's
     // missing secrets did.
     skipProofPath: null,
+    // MUST mirror the workflow's own `on.push.paths` exactly — this list is what
+    // decides whether a deploy was DUE, so anything the workflow deploys on but
+    // this list omits is a deploy the monitor cannot see fail. Pinned by
+    // 'monitored trigger paths mirror each workflow's own push filter'.
     triggerPaths: Object.freeze([
       'workers/api-cors-preflight/**',
       'api/_bootstrap-public-tier.js',
+      'tests/cors-preflight-live.test.mjs',
+      'tests/helpers/public-bootstrap-contract.mjs',
       '.github/workflows/deploy-worker.yml',
     ]),
     // Same dormant reasoning as the reconcile Worker: a healthy run can be

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -336,6 +336,13 @@ async function fetchTier(
     // public=1 gives the shared seed bundle a cache key distinct from the legacy
     // credentialed tier URL. credentials:'omit' also avoids sending cookies to
     // a route whose contract is explicitly public (see #5249).
+    //
+    // The omit is now load-bearing for CORS, not just cookie hygiene: since #7308
+    // this URL answers ACAO `*` with no Allow-Credentials from both the edge and
+    // the origin, which a browser refuses to hand to a credentialed request. Drop
+    // the omit here — or let the wm-session interceptor's `?? 'include'` default
+    // apply by taking this call out of isCredentiallessPublicDataRequest's exact
+    // shape — and hydration fails as an opaque console CORS error, not a test.
     const resp = await fetch(requestUrl, { signal, credentials: 'omit' });
     if (!resp.ok) {
       failedOutcome = 'http-error';

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -5,7 +5,9 @@
 // warning, not a healthy pass; git/4xx/ENOENT still fail the job.
 
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
+import { parse as parseYaml } from 'yaml';
 
 import {
   DEFAULT_NO_RUN_WINDOW_MS,
@@ -924,4 +926,45 @@ describe('post-merge deploy monitor — read-path resilience (#6479)', () => {
       assert.equal(summary.exitCode, 0);
     });
   });
+});
+
+// #7313 — the monitor's triggerPaths is a hand-copied mirror of each workflow's
+// own `on.push.paths`, and it is what decides whether a deploy was DUE. Widening
+// a workflow's filter without widening the copy leaves a class of pushes that
+// really do deploy but that the monitor believes deployed nothing — so a failed
+// or missing run there raises no alarm. The existing coverage could not catch
+// that: it spreads WORKER.triggerPaths into its own expectation, which asserts
+// the monitor agrees with itself, never that it agrees with the YAML.
+describe('monitored trigger paths mirror each workflow push filter', () => {
+  const workflowsDir = new URL('../.github/workflows/', import.meta.url);
+
+  /**
+   * Read `on.push.paths` from a workflow. Parsed with the YAML library rather
+   * than a regex: `on:` is the YAML 1.1 boolean `true` after parsing, and a
+   * hand-rolled scanner would have to re-implement quoting and comment rules
+   * the file is free to use.
+   */
+  function workflowPushPaths(file) {
+    const doc = parseYaml(readFileSync(new URL(file, workflowsDir), 'utf8'));
+    const on = doc.on ?? doc[true];
+    return on?.push?.paths ?? null;
+  }
+
+  for (const workflow of MONITORED_WORKFLOWS) {
+    if (!workflow.triggerPaths) continue;
+    it(`${workflow.file} declares the paths the monitor watches`, () => {
+      const declared = workflowPushPaths(workflow.file);
+      assert.ok(
+        Array.isArray(declared),
+        `${workflow.file} must declare on.push.paths for a triggerPaths entry to mirror`,
+      );
+      assert.deepEqual(
+        [...workflow.triggerPaths].sort(),
+        [...declared].sort(),
+        `${workflow.file}: the monitor's triggerPaths must match the workflow's own push filter. `
+        + 'A path the workflow deploys on but the monitor omits is a deploy it cannot see fail; '
+        + 'a path the monitor watches but the workflow ignores manufactures DEPLOY_DUE alarms.',
+      );
+    });
+  }
 });

--- a/tests/cors-preflight-live.test.mjs
+++ b/tests/cors-preflight-live.test.mjs
@@ -167,15 +167,15 @@ for (const tier of ['fast', 'slow']) {
     assertPublicBootstrapCorsHeaders({ assert, resp, label: `public ${tier} tier (source=${source || 'origin'})` });
 
     if (source === 'kv') {
-      // Deliberate, and asserted so it stays a decision: a Worker-generated
-      // Response is never stored by the Cloudflare cache, so this path has no
-      // CDN lifetime to declare — the POP-local KV read is the cache, bounded
-      // by the serving path's own staleness gate. Advertising a shared
-      // lifetime nothing honours would be worse than saying no-store.
+      // Deliberate, and asserted so it stays a decision. Rationale:
+      // workers/api-cors-preflight/src/kv-serve.js#serveFromKv.
       assert.match(
         resp.headers.get('cache-control') || '', /\bno-store\b/,
         'the KV-served tier is browser-no-store by design (the POP-local KV read is the cache)',
       );
+      // Note this branch is chosen by a header browser JS cannot read (it is not in the Worker's
+      // Expose-Headers). Fine from Node; a browser-context canary would silently take the origin
+      // branch and assert a CDN shield against KV-minted bytes.
       assert.equal(
         resp.headers.get('cdn-cache-control'), null,
         'a KV-minted response must not advertise a CDN lifetime no shared cache will honour',
@@ -186,6 +186,26 @@ for (const tier of ['fast', 'slow']) {
       // Worker's header rewrite intact.
       assertPublicBootstrapSharedCacheHeaders({ assert, resp, label: `public ${tier} tier via origin` });
     }
+  });
+
+  test(`OPTIONS public ${tier} bootstrap tier preflight matches its own GET`, { skip: !SHOULD_RUN }, async () => {
+    // The preflight and the response are one contract. Advertising
+    // Allow-Credentials on the leg that clears a request whose answer is ACAO `*`
+    // with no credentials is the same split #7308 was filed about.
+    const resp = await fetch(`https://api.worldmonitor.app/api/bootstrap?tier=${tier}&public=1`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: ORIGIN,
+        'User-Agent': BROWSER_UA,
+        'Access-Control-Request-Method': 'GET',
+      },
+    });
+    await resp.arrayBuffer();
+    assert.equal(resp.headers.get('access-control-allow-origin'), '*', `public ${tier} preflight ACAO must be '*'`);
+    assert.equal(
+      resp.headers.get('access-control-allow-credentials'), null,
+      `public ${tier} preflight must not advertise credentials for a public URL`,
+    );
   });
 }
 

--- a/tests/cors-preflight-live.test.mjs
+++ b/tests/cors-preflight-live.test.mjs
@@ -18,12 +18,20 @@
 //     allowed origin → browsers reject as mismatched).
 //   - Worker bypassed entirely (Vercel fallback served instead — would still
 //     pass on healthy days but blow up if/when the Worker is re-enabled).
+//   - The public bootstrap tier served with the credentialed header shape
+//     (#7308) — the origin's own guard cannot see this, because the bytes are
+//     minted at the edge and never pass through api/bootstrap.js.
 //
 // This test deliberately mirrors what a real browser does for CORS preflight,
 // so a failure here is a strong signal of a real user-facing outage.
 
 import { strict as assert } from 'node:assert';
 import test from 'node:test';
+
+import {
+  assertPublicBootstrapCorsHeaders,
+  assertPublicBootstrapSharedCacheHeaders,
+} from './helpers/public-bootstrap-contract.mjs';
 
 const BROWSER_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 const CRAWLER_UA = 'Twitterbot/1.0';
@@ -135,6 +143,48 @@ for (const url of ENDPOINTS) {
         acam.includes(required),
         `ACAM must include ${required}; got: ${acam.join(', ')}`,
       );
+    }
+  });
+}
+
+// The one guard that reads the bytes users actually receive on the public
+// bootstrap tiers. api/bootstrap-auth.test.mjs proves api/bootstrap.js builds
+// this shape; it calls handler() directly, so it is blind to everything the
+// edge does afterwards — the Worker's CORS stamp and, since #7292, a KV path
+// that mints the response at the POP without touching the handler at all.
+// #7308 lived in exactly that blind spot for weeks.
+for (const tier of ['fast', 'slow']) {
+  test(`GET public ${tier} bootstrap tier serves the public header shape through the edge`, { skip: !SHOULD_RUN }, async () => {
+    const url = `https://api.worldmonitor.app/api/bootstrap?tier=${tier}&public=1`;
+    // A browser UA is required or Cloudflare answers 403. The Origin is sent
+    // because that is what a real dashboard load does — and echoing it back
+    // instead of `*` is precisely the drift this asserts against.
+    const resp = await fetch(url, { headers: { Origin: ORIGIN, 'User-Agent': BROWSER_UA } });
+    await resp.arrayBuffer();
+    assert.equal(resp.status, 200, `public ${tier} tier should serve 200; got ${resp.status}`);
+
+    const source = resp.headers.get('x-worldmonitor-bootstrap-source');
+    assertPublicBootstrapCorsHeaders({ assert, resp, label: `public ${tier} tier (source=${source || 'origin'})` });
+
+    if (source === 'kv') {
+      // Deliberate, and asserted so it stays a decision: a Worker-generated
+      // Response is never stored by the Cloudflare cache, so this path has no
+      // CDN lifetime to declare — the POP-local KV read is the cache, bounded
+      // by the serving path's own staleness gate. Advertising a shared
+      // lifetime nothing honours would be worse than saying no-store.
+      assert.match(
+        resp.headers.get('cache-control') || '', /\bno-store\b/,
+        'the KV-served tier is browser-no-store by design (the POP-local KV read is the cache)',
+      );
+      assert.equal(
+        resp.headers.get('cdn-cache-control'), null,
+        'a KV-minted response must not advertise a CDN lifetime no shared cache will honour',
+      );
+    } else {
+      // Origin fallback (hedged/miss/stale, or the KV kill-switch): this one
+      // really does sit behind Vercel's CDN, so its shield must survive the
+      // Worker's header rewrite intact.
+      assertPublicBootstrapSharedCacheHeaders({ assert, resp, label: `public ${tier} tier via origin` });
     }
   });
 }

--- a/tests/helpers/public-bootstrap-contract.mjs
+++ b/tests/helpers/public-bootstrap-contract.mjs
@@ -1,0 +1,60 @@
+// The response contract for a `&public=1` bootstrap URL, in one place so the
+// handler-level guard and the deployed-URL guard cannot drift.
+//
+// api/bootstrap-auth.test.mjs proves api/bootstrap.js returns this shape by
+// calling handler() directly. That is necessary and not sufficient: three CORS
+// surfaces sit in front of api.worldmonitor.app, and the Cloudflare Worker
+// stamps its own headers onto the bytes users actually receive — including a
+// path (KV serving, #7292) that never reaches the handler at all. #7308 was
+// exactly that gap: the handler test was green while production served the
+// credentialed shape on a public URL. So the same assertions also run against a
+// deployed URL in tests/cors-preflight-live.test.mjs.
+
+/**
+ * The public shape: ACAO `*`, no Allow-Credentials, not keyed by Origin, and
+ * Timing-Allow-Origin for the bootstrap transfer RUM (#7047).
+ *
+ * `Vary` is asserted as "does not name Origin" rather than "absent" because
+ * Cloudflare appends `accept-encoding` for compression keying on the deployed
+ * path. Origin-keying is the load-bearing half — it is what turns one shared
+ * entry per URL into one per origin, and what lets a preview or embed origin
+ * pin an echoed ACAO onto a cached response. Callers that own the response
+ * outright (the handler test) additionally pin `Vary: null`.
+ *
+ * @param {{ assert: typeof import('node:assert').strict, resp: Response, label?: string }} args
+ */
+export function assertPublicBootstrapCorsHeaders({ assert, resp, label = 'public bootstrap' }) {
+  assert.equal(
+    resp.headers.get('access-control-allow-origin'), '*',
+    `${label}: ACAO must be '*' — an echoed origin re-keys a caller-invariant payload`,
+  );
+  assert.equal(
+    resp.headers.get('access-control-allow-credentials'), null,
+    `${label}: Allow-Credentials must be absent on an unauthenticated public payload`,
+  );
+  const varyNames = (resp.headers.get('vary') || '')
+    .split(',').map((name) => name.trim().toLowerCase()).filter(Boolean);
+  assert.equal(
+    varyNames.includes('origin'), false,
+    `${label}: Vary must not name Origin; got '${resp.headers.get('vary')}'`,
+  );
+  assert.equal(
+    resp.headers.get('timing-allow-origin'), '*',
+    `${label}: Timing-Allow-Origin must stay '*' for the bootstrap transfer RUM (#7047)`,
+  );
+}
+
+/**
+ * The shared-cache declaration for a `&public=1` URL served by the Vercel
+ * origin. Tier responses intentionally keep `public`/`s-maxage` OUT of
+ * Cache-Control (Cloudflare, in front of api.worldmonitor.app, ignores
+ * `Vary: Origin` and would mispin an echoed ACAO) and shield via
+ * CDN-Cache-Control instead, so that is the header this reads.
+ *
+ * @param {{ assert: typeof import('node:assert').strict, resp: Response, label?: string }} args
+ */
+export function assertPublicBootstrapSharedCacheHeaders({ assert, resp, label = 'public bootstrap' }) {
+  const cdn = resp.headers.get('cdn-cache-control');
+  assert.ok(cdn, `${label}: CDN-Cache-Control must declare the shared lifetime`);
+  assert.match(cdn, /\b(public|s-maxage)\b/i, `${label}: CDN-Cache-Control must be shared-cacheable; got '${cdn}'`);
+}

--- a/workers/api-cors-preflight/README.md
+++ b/workers/api-cors-preflight/README.md
@@ -83,18 +83,30 @@ a response no credential can change is what #7308 was filed about. Both edge
 paths use it: the KV-served bytes and the origin pass-through, so the shape does
 not depend on which one answered.
 
-Two deliberate carve-outs inside that exception:
+**Scope: the tier URLs only.** `api/bootstrap.js` returns the same public shape
+for three more auth kinds — `?keys=weatherAlerts&public=1` and the marked
+single-key on-demand URLs (`isPublicBootstrapKind`, api/bootstrap.js). Those are
+**not** covered here: the Worker still stamps its credentialed bag over them, so
+they carry `Allow-Credentials: true` and an Origin-echoed ACAO in production
+today. Matching the origin on those needs the `ON_DEMAND_KEYS` /
+`PUBLIC_WEATHER_BOOTSTRAP_KEY` membership sets at the edge (`?keys=markets&public=1`
+is *not* public and must not be widened), which is a larger change than #7308
+asked for and touches genuinely CDN-cached URLs. Tracked as follow-up — do not
+read this section as "the edge and origin shapes now agree everywhere."
 
-- **A disallowed Origin is never served from KV and keeps the credentialed
-  bag.** `api/bootstrap.js` refuses those with 403 before it reads a payload;
-  handing one ACAO `*` at the edge would widen access the origin denies.
+Two deliberate carve-outs inside the exception:
+
+- **A disallowed Origin keeps the credentialed bag — but is still served from
+  KV.** The header denial and the routing decision are separate. Its
+  canonical-fallback ACAO is what denies the browser read (not the origin's 403:
+  the public tier ships `CDN-Cache-Control: public, s-maxage=600`, so a warm CDN
+  entry answers before `isDisallowedOrigin` runs). Routing it off KV would buy
+  nothing — the same caller reads the same bytes by omitting the header — while
+  handing anyone a one-header lever for forcing Vercel/Redis load.
 - **The KV-served response stays `Cache-Control: no-store` with no
-  `CDN-Cache-Control`.** A Worker-generated `Response` is never stored by the
-  Cloudflare cache, so this path's shared lifetime is the POP-local KV read
-  (`TIER_CACHE_TTL_S`) bounded by `classifyKvEnvelope`'s staleness gate — not a
-  CDN entry. Declaring an `s-maxage` nothing honours would be worse than saying
-  `no-store`. The origin fallback for the same URL does sit behind Vercel's CDN
-  and keeps its `CDN-Cache-Control` shield untouched.
+  `CDN-Cache-Control`.** Rationale lives with the code it explains —
+  `src/kv-serve.js#serveFromKv`. The origin fallback for the same URL does sit
+  behind Vercel's CDN and keeps its `CDN-Cache-Control` shield untouched.
 
 `tests/cors-preflight-live.test.mjs` asserts all of this against a **deployed**
 URL. The handler-level guard in `api/bootstrap-auth.test.mjs` cannot: it calls

--- a/workers/api-cors-preflight/README.md
+++ b/workers/api-cors-preflight/README.md
@@ -92,7 +92,8 @@ they carry `Allow-Credentials: true` and an Origin-echoed ACAO in production
 today. Matching the origin on those needs the `ON_DEMAND_KEYS` /
 `PUBLIC_WEATHER_BOOTSTRAP_KEY` membership sets at the edge (`?keys=markets&public=1`
 is *not* public and must not be widened), which is a larger change than #7308
-asked for and touches genuinely CDN-cached URLs. Tracked as follow-up — do not
+asked for and touches genuinely CDN-cached URLs — where the `Vary: Origin` the
+Worker adds really does split the CDN entry per origin. Tracked as #7311; do not
 read this section as "the edge and origin shapes now agree everywhere."
 
 Two deliberate carve-outs inside the exception:

--- a/workers/api-cors-preflight/README.md
+++ b/workers/api-cors-preflight/README.md
@@ -58,7 +58,9 @@ npm run deploy
 cd workers/api-cors-preflight && npm test
 
 # Live smoke test against prod. Gated by env var so it doesn't run in PR gates
-# (false positives during deploys).
+# (false positives during deploys). Run this AFTER a Worker deploy: it is the
+# only guard that reads the bytes users receive, including the KV-served
+# bootstrap tiers that never reach api/bootstrap.js.
 LIVE_SMOKE=1 tsx --test tests/cors-preflight-live.test.mjs
 ```
 
@@ -69,6 +71,36 @@ The Worker's allowlist + Allow-Headers list **must be a superset of** what
 function would accept, the browser sees a mismatched origin echo and CORS
 rejects the request. Drift between the two is the load-bearing trap this
 package exists to make visible. Update both files together.
+
+### The public bootstrap tiers are the exception
+
+`GET /api/bootstrap?tier=<fast|slow>&public=1` is answered with the **public**
+shape — ACAO `*`, no `Access-Control-Allow-Credentials`, no `Vary: Origin` —
+mirroring `api/bootstrap.js#getPublicBootstrapHeaders()`. The payload is the
+shared seed bundle, identical for every caller, so keying it by Origin costs a
+cache entry per origin and buys nothing, and advertising credentialed access on
+a response no credential can change is what #7308 was filed about. Both edge
+paths use it: the KV-served bytes and the origin pass-through, so the shape does
+not depend on which one answered.
+
+Two deliberate carve-outs inside that exception:
+
+- **A disallowed Origin is never served from KV and keeps the credentialed
+  bag.** `api/bootstrap.js` refuses those with 403 before it reads a payload;
+  handing one ACAO `*` at the edge would widen access the origin denies.
+- **The KV-served response stays `Cache-Control: no-store` with no
+  `CDN-Cache-Control`.** A Worker-generated `Response` is never stored by the
+  Cloudflare cache, so this path's shared lifetime is the POP-local KV read
+  (`TIER_CACHE_TTL_S`) bounded by `classifyKvEnvelope`'s staleness gate — not a
+  CDN entry. Declaring an `s-maxage` nothing honours would be worse than saying
+  `no-store`. The origin fallback for the same URL does sit behind Vercel's CDN
+  and keeps its `CDN-Cache-Control` shield untouched.
+
+`tests/cors-preflight-live.test.mjs` asserts all of this against a **deployed**
+URL. The handler-level guard in `api/bootstrap-auth.test.mjs` cannot: it calls
+`handler()` directly, so it never sees what the edge does to the bytes
+afterwards. Both read the same assertions from
+`tests/helpers/public-bootstrap-contract.mjs`.
 
 ## Related learning
 

--- a/workers/api-cors-preflight/README.md
+++ b/workers/api-cors-preflight/README.md
@@ -58,9 +58,10 @@ npm run deploy
 cd workers/api-cors-preflight && npm test
 
 # Live smoke test against prod. Gated by env var so it doesn't run in PR gates
-# (false positives during deploys). Run this AFTER a Worker deploy: it is the
-# only guard that reads the bytes users receive, including the KV-served
-# bootstrap tiers that never reach api/bootstrap.js.
+# (false positives during deploys). CI already runs it after every Worker deploy
+# (the live-smoke job); run it by hand to check the currently-deployed Worker.
+# It is the only guard that reads the bytes users receive, including the
+# KV-served bootstrap tiers that never reach api/bootstrap.js.
 LIVE_SMOKE=1 tsx --test tests/cors-preflight-live.test.mjs
 ```
 
@@ -108,11 +109,16 @@ Two deliberate carve-outs inside the exception:
   `src/kv-serve.js#serveFromKv`. The origin fallback for the same URL does sit
   behind Vercel's CDN and keeps its `CDN-Cache-Control` shield untouched.
 
+Note the second carve-out means the browser cache directive for one URL differs
+by which path answered (`no-store` from KV, `TIER_CACHE[tier]` from the origin).
+The CORS shape is unified; caching deliberately is not.
+
 `tests/cors-preflight-live.test.mjs` asserts all of this against a **deployed**
-URL. The handler-level guard in `api/bootstrap-auth.test.mjs` cannot: it calls
-`handler()` directly, so it never sees what the edge does to the bytes
-afterwards. Both read the same assertions from
-`tests/helpers/public-bootstrap-contract.mjs`.
+URL, and the `live-smoke` job in `.github/workflows/deploy-worker.yml` runs it
+automatically after every Worker deploy. The handler-level guard in
+`api/bootstrap-auth.test.mjs` cannot: it calls `handler()` directly, so it never
+sees what the edge does to the bytes afterwards. Both read the same assertions
+from `tests/helpers/public-bootstrap-contract.mjs`.
 
 ## Related learning
 

--- a/workers/api-cors-preflight/index.test.mjs
+++ b/workers/api-cors-preflight/index.test.mjs
@@ -23,6 +23,11 @@
 import { strict as assert } from 'node:assert';
 import test from 'node:test';
 import worker, { isAllowedOrigin, buildCorsHeaders, hasPublicCorsPolicy } from './src/index.js';
+// One definition of the public `&public=1` response contract, shared with the
+// origin-handler guard (api/bootstrap-auth.test.mjs) and the deployed-URL guard
+// (tests/cors-preflight-live.test.mjs). #7308 was a drift bug; a second copy of
+// the contract here would be the same mistake in test form.
+import { assertPublicBootstrapCorsHeaders } from '../../tests/helpers/public-bootstrap-contract.mjs';
 
 function makeRequest(method, url, headers = {}) {
   return new Request(url, { method, headers });
@@ -528,33 +533,31 @@ test('502 fallback when origin throws still includes CORS headers', async () => 
 
 const PUBLIC_TIER_URL = 'https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1';
 
-function assertPublicBootstrapShape(resp, label) {
-  assert.equal(resp.headers.get('access-control-allow-origin'), '*', `${label}: ACAO must be *`);
-  assert.equal(resp.headers.get('access-control-allow-credentials'), null, `${label}: no Allow-Credentials`);
-  assert.equal(
-    (resp.headers.get('vary') || '').toLowerCase().split(',').map((s) => s.trim()).includes('origin'),
-    false,
-    `${label}: Vary must not name Origin; got ${resp.headers.get('vary')}`,
-  );
-}
+// The origin's real public-tier response shape, so these tests prove what the
+// Worker does to it rather than what a thin mock happened to omit. `Allow-
+// Credentials: true` is NOT something api/bootstrap.js sends on this URL — it is
+// here to exercise the Worker's delete branch, which must clear a credentials
+// header even if the origin ever supplied one, since ACAO `*` alongside it is
+// the pairing browsers reject outright.
+const PUBLIC_TIER_ORIGIN_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Credentials': 'true',
+  'Cache-Control': 'no-store',
+  'CDN-Cache-Control': 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
+  'Timing-Allow-Origin': '*',
+  Vary: 'accept-encoding',
+};
 
 test('public bootstrap tier pass-through keeps the origin public shape, not the credentialed bag', async () => {
   const original = globalThis.fetch;
   globalThis.fetch = async () => new Response('{"data":{},"missing":[]}', {
     status: 200,
-    headers: {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-      'Cache-Control': 'no-store',
-      'CDN-Cache-Control': 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
-      'Timing-Allow-Origin': '*',
-      Vary: 'accept-encoding',
-    },
+    headers: PUBLIC_TIER_ORIGIN_HEADERS,
   });
   try {
     const resp = await worker.fetch(makeRequest('GET', PUBLIC_TIER_URL, { Origin: KNOWN_GOOD }));
-    assertPublicBootstrapShape(resp, 'tier pass-through');
-    assert.equal(resp.headers.get('timing-allow-origin'), '*');
+    assertPublicBootstrapCorsHeaders({ assert, resp, label: 'tier pass-through' });
     // The origin's shared-cache declaration is the only CDN lifetime this path
     // has; the Worker must not drop it while rewriting CORS.
     assert.equal(
@@ -571,13 +574,33 @@ test('public bootstrap tier pass-through keeps the origin public shape, not the 
 
 test('public bootstrap tier pass-through with no Origin header is still the public shape', async () => {
   const original = globalThis.fetch;
-  globalThis.fetch = async () => new Response('{"data":{},"missing":[]}', { status: 200 });
+  globalThis.fetch = async () => new Response('{"data":{},"missing":[]}', {
+    status: 200,
+    headers: { 'Timing-Allow-Origin': '*' },
+  });
   try {
     const resp = await worker.fetch(makeRequest('GET', PUBLIC_TIER_URL));
-    assertPublicBootstrapShape(resp, 'no-Origin tier pass-through');
+    assertPublicBootstrapCorsHeaders({ assert, resp, label: 'no-Origin tier pass-through' });
     // Merging an absent origin Vary with an absent Worker Vary must leave the
     // header off entirely, not set it to the empty string.
     assert.equal(resp.headers.get('vary'), null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('a 502 on the public tier URL still carries the public shape', async () => {
+  // passThroughToOrigin's catch takes the non-function branch of its ternary
+  // whenever corsPolicy is the fixed public bag — the branch a real upstream
+  // outage on this URL would hit, and the one no other 502 test reaches.
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => { throw new Error('origin down'); };
+  try {
+    const resp = await worker.fetch(makeRequest('GET', PUBLIC_TIER_URL, { Origin: KNOWN_GOOD }));
+    assert.equal(resp.status, 502);
+    assert.equal(resp.headers.get('access-control-allow-origin'), '*');
+    assert.equal(resp.headers.get('access-control-allow-credentials'), null);
+    assert.equal(await resp.json().then((body) => body.error), 'Origin unavailable');
   } finally {
     globalThis.fetch = original;
   }
@@ -591,10 +614,49 @@ test('a disallowed Origin on the public tier URL keeps the credentialed fallback
   globalThis.fetch = async () => new Response('Forbidden', { status: 403 });
   try {
     const resp = await worker.fetch(makeRequest('GET', PUBLIC_TIER_URL, { Origin: 'https://evil.example' }));
-    assert.notEqual(resp.headers.get('access-control-allow-origin'), '*');
+    assert.equal(resp.status, 403);
+    assert.equal(resp.headers.get('access-control-allow-origin'), 'https://evil.example');
+    assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+    assert.match(resp.headers.get('vary') || '', /Origin/i);
   } finally {
     globalThis.fetch = original;
   }
+});
+
+test('the public tier preflight carries the public shape, matching its own GET', async () => {
+  // A split contract — Allow-Credentials: true on the preflight clearing a
+  // response that answers ACAO:* with no credentials — is the same mismatch
+  // #7308 fixed one layer down, and the pairing browsers reject.
+  const resp = await worker.fetch(makeRequest('OPTIONS', PUBLIC_TIER_URL, {
+    Origin: KNOWN_GOOD,
+    'Access-Control-Request-Method': 'GET',
+  }));
+  assert.equal(resp.status, 204);
+  assert.equal(resp.headers.get('access-control-allow-origin'), '*');
+  assert.equal(resp.headers.get('access-control-allow-credentials'), null);
+  assert.equal(resp.headers.get('vary'), null);
+});
+
+test('a preflight declaring a non-GET method on the public tier URL stays credentialed', async () => {
+  // Only the GET is the public contract; anything else would be answered by the
+  // credentialed handler, so its preflight must advertise that shape.
+  const resp = await worker.fetch(makeRequest('OPTIONS', PUBLIC_TIER_URL, {
+    Origin: KNOWN_GOOD,
+    'Access-Control-Request-Method': 'POST',
+  }));
+  assert.equal(resp.headers.get('access-control-allow-origin'), KNOWN_GOOD);
+  assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+});
+
+test('a disallowed Origin preflighting the public tier URL keeps the readable echo (#6411)', async () => {
+  // The echo is what lets the browser send the actual request and observe the
+  // origin's 403 instead of an opaque network error.
+  const resp = await worker.fetch(makeRequest('OPTIONS', PUBLIC_TIER_URL, {
+    Origin: 'https://evil.example',
+    'Access-Control-Request-Method': 'GET',
+  }));
+  assert.equal(resp.headers.get('access-control-allow-origin'), 'https://evil.example');
+  assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
 });
 
 test('the credentialed bootstrap URL (no public=1) keeps the Origin-echoing shape', async () => {

--- a/workers/api-cors-preflight/index.test.mjs
+++ b/workers/api-cors-preflight/index.test.mjs
@@ -515,3 +515,99 @@ test('502 fallback when origin throws still includes CORS headers', async () => 
     globalThis.fetch = original;
   }
 });
+
+// --- public bootstrap tier shape (#7308) ----------------------------------
+//
+// `/api/bootstrap?tier=<fast|slow>&public=1` is the one Worker-owned route
+// whose Vercel handler deliberately answers with the PUBLIC shape
+// (api/bootstrap.js#getPublicBootstrapHeaders: ACAO:*, no Allow-Credentials,
+// no Vary: Origin) so a single entry can answer every caller. Stamping the
+// Worker's credentialed bag over it re-keyed the response by Origin and put
+// Allow-Credentials: true on an unauthenticated payload that also carries
+// Timing-Allow-Origin: *.
+
+const PUBLIC_TIER_URL = 'https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1';
+
+function assertPublicBootstrapShape(resp, label) {
+  assert.equal(resp.headers.get('access-control-allow-origin'), '*', `${label}: ACAO must be *`);
+  assert.equal(resp.headers.get('access-control-allow-credentials'), null, `${label}: no Allow-Credentials`);
+  assert.equal(
+    (resp.headers.get('vary') || '').toLowerCase().split(',').map((s) => s.trim()).includes('origin'),
+    false,
+    `${label}: Vary must not name Origin; got ${resp.headers.get('vary')}`,
+  );
+}
+
+test('public bootstrap tier pass-through keeps the origin public shape, not the credentialed bag', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => new Response('{"data":{},"missing":[]}', {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Cache-Control': 'no-store',
+      'CDN-Cache-Control': 'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
+      'Timing-Allow-Origin': '*',
+      Vary: 'accept-encoding',
+    },
+  });
+  try {
+    const resp = await worker.fetch(makeRequest('GET', PUBLIC_TIER_URL, { Origin: KNOWN_GOOD }));
+    assertPublicBootstrapShape(resp, 'tier pass-through');
+    assert.equal(resp.headers.get('timing-allow-origin'), '*');
+    // The origin's shared-cache declaration is the only CDN lifetime this path
+    // has; the Worker must not drop it while rewriting CORS.
+    assert.equal(
+      resp.headers.get('cdn-cache-control'),
+      'public, s-maxage=600, stale-while-revalidate=120, stale-if-error=900',
+    );
+    assert.equal(resp.headers.get('vary'), 'accept-encoding');
+    assert.equal(resp.headers.get('access-control-allow-headers'), ACAH_EXPECTED);
+    assert.equal(resp.headers.get('access-control-expose-headers'), ACEH_EXPECTED);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('public bootstrap tier pass-through with no Origin header is still the public shape', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => new Response('{"data":{},"missing":[]}', { status: 200 });
+  try {
+    const resp = await worker.fetch(makeRequest('GET', PUBLIC_TIER_URL));
+    assertPublicBootstrapShape(resp, 'no-Origin tier pass-through');
+    // Merging an absent origin Vary with an absent Worker Vary must leave the
+    // header off entirely, not set it to the empty string.
+    assert.equal(resp.headers.get('vary'), null);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('a disallowed Origin on the public tier URL keeps the credentialed fallback echo', async () => {
+  // api/bootstrap.js rejects a disallowed Origin with 403 before it reads any
+  // payload. Handing that caller ACAO:* would make the seed bundle readable by
+  // a page the origin refuses, so the Worker must not widen it here.
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => new Response('Forbidden', { status: 403 });
+  try {
+    const resp = await worker.fetch(makeRequest('GET', PUBLIC_TIER_URL, { Origin: 'https://evil.example' }));
+    assert.notEqual(resp.headers.get('access-control-allow-origin'), '*');
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test('the credentialed bootstrap URL (no public=1) keeps the Origin-echoing shape', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => new Response('{"data":{},"missing":[]}', { status: 200 });
+  try {
+    const resp = await worker.fetch(
+      makeRequest('GET', 'https://api.worldmonitor.app/api/bootstrap?tier=fast', { Origin: KNOWN_GOOD }),
+    );
+    assert.equal(resp.headers.get('access-control-allow-origin'), KNOWN_GOOD);
+    assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+    assert.match(resp.headers.get('vary') || '', /Origin/i);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/workers/api-cors-preflight/kv-serve.test.mjs
+++ b/workers/api-cors-preflight/kv-serve.test.mjs
@@ -84,7 +84,65 @@ test('served CORS headers are identical to the origin pass-through the Worker wo
     assert.equal(served.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
     assert.equal(passthru.headers.get('X-Origin'), 'vercel');
     assert.deepEqual(corsOf(served), corsOf(passthru), 'CORS/Vary identical served vs pass-through');
-    assert.equal(served.headers.get('Access-Control-Allow-Credentials'), 'true');
+  } finally { restore(); }
+});
+
+// #7308: the served bytes must carry api/bootstrap.js's PUBLIC header shape
+// (getPublicBootstrapHeaders: ACAO:*, no Allow-Credentials, no Vary: Origin),
+// not the Worker's credentialed bag. The origin handler reaches that shape only
+// for public auth kinds, and `?tier=<t>&public=1` is exactly one of them; the
+// edge previously made no such distinction, so an unauthenticated seed payload
+// went out with Allow-Credentials: true alongside Timing-Allow-Origin: *.
+test('the KV-served public tier carries the origin public header shape (#7308)', async () => {
+  const restore = installFetch();
+  try {
+    const res = await worker.fetch(req(FAST_URL), makeEnv({ serve: 'all', kvValue: envelopeFor('fast') }), makeCtx().ctx);
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+    assert.equal(res.headers.get('Access-Control-Allow-Credentials'), null);
+    assert.equal(res.headers.get('Vary'), null, 'a caller-invariant payload must not be keyed by Origin');
+    assert.equal(res.headers.get('Timing-Allow-Origin'), '*');
+  } finally { restore(); }
+});
+
+test('a disallowed Origin is never answered from KV (the origin 403 still decides)', async () => {
+  // api/bootstrap.js#isDisallowedOrigin refuses these before reading a payload.
+  // Serving them the ACAO:* public shape from KV would hand the seed bundle to
+  // a page the origin rejects, so the edge falls through and lets it answer.
+  const restore = installFetch();
+  try {
+    const evil = new Request(FAST_URL, { method: 'GET', headers: { Origin: 'https://evil.example' } });
+    const res = await worker.fetch(evil, makeEnv({ serve: 'all', kvValue: envelopeFor('fast') }), makeCtx().ctx);
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), null, 'not served from KV');
+    assert.equal(res.headers.get('X-Origin'), 'vercel', 'reached origin');
+    assert.notEqual(res.headers.get('Access-Control-Allow-Origin'), '*');
+  } finally { restore(); }
+});
+
+test('no-Origin callers (curl, server-side, RUM beacons) are served the public shape from KV', async () => {
+  const restore = installFetch();
+  try {
+    const anon = new Request(FAST_URL, { method: 'GET' });
+    const res = await worker.fetch(anon, makeEnv({ serve: 'all', kvValue: envelopeFor('fast') }), makeCtx().ctx);
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+    assert.equal(res.headers.get('Vary'), null);
+  } finally { restore(); }
+});
+
+test('the KV-served tier stays browser-no-store — the POP-local KV read is the cache', async () => {
+  // Deliberate, and pinned so it reads as a decision rather than an omission:
+  // a Worker-generated Response is never stored by the Cloudflare cache, so the
+  // shared lifetime this path has is the KV read's own cacheTtl at the POP,
+  // bounded by classifyKvEnvelope's staleness gate. A CDN-Cache-Control here
+  // would advertise a shared lifetime nothing honours, and a browser max-age
+  // would let a cache replay masquerade as a fresh transfer sample in the
+  // bootstrap RUM (#7047) — the same reason the origin serves no-store today.
+  const restore = installFetch();
+  try {
+    const res = await worker.fetch(req(FAST_URL), makeEnv({ serve: 'all', kvValue: envelopeFor('fast') }), makeCtx().ctx);
+    assert.equal(res.headers.get('Cache-Control'), 'no-store');
+    assert.equal(res.headers.get('CDN-Cache-Control'), null);
   } finally { restore(); }
 });
 

--- a/workers/api-cors-preflight/kv-serve.test.mjs
+++ b/workers/api-cors-preflight/kv-serve.test.mjs
@@ -12,6 +12,8 @@ import test from 'node:test';
 
 import worker from './src/index.js';
 import { BOOTSTRAP_TIER_ENVELOPE_SCHEMA_VERSION, TIER_MAX_AGE_MS } from './src/kv-shadow.js';
+// Shared with the origin-handler and deployed-URL guards — see index.test.mjs.
+import { assertPublicBootstrapCorsHeaders } from '../../tests/helpers/public-bootstrap-contract.mjs';
 
 const FAST_URL = 'https://api.worldmonitor.app/api/bootstrap?tier=fast&public=1';
 const SLOW_URL = 'https://api.worldmonitor.app/api/bootstrap?tier=slow&public=1';
@@ -98,24 +100,59 @@ test('the KV-served public tier carries the origin public header shape (#7308)',
   try {
     const res = await worker.fetch(req(FAST_URL), makeEnv({ serve: 'all', kvValue: envelopeFor('fast') }), makeCtx().ctx);
     assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
-    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
-    assert.equal(res.headers.get('Access-Control-Allow-Credentials'), null);
+    assertPublicBootstrapCorsHeaders({ assert, resp: res, label: 'KV-served fast tier' });
     assert.equal(res.headers.get('Vary'), null, 'a caller-invariant payload must not be keyed by Origin');
-    assert.equal(res.headers.get('Timing-Allow-Origin'), '*');
   } finally { restore(); }
 });
 
-test('a disallowed Origin is never answered from KV (the origin 403 still decides)', async () => {
-  // api/bootstrap.js#isDisallowedOrigin refuses these before reading a payload.
-  // Serving them the ACAO:* public shape from KV would hand the seed bundle to
-  // a page the origin rejects, so the edge falls through and lets it answer.
+test('a disallowed Origin is still KV-served, but under the credentialed fallback bag', async () => {
+  // The header denial and the routing decision are separate. A disallowed Origin
+  // must not get ACAO:* — but it must still be answered from KV, or one bogus
+  // header on every request becomes a free lever for forcing Vercel/Redis load
+  // that the same caller could avoid entirely by omitting the header.
   const restore = installFetch();
   try {
     const evil = new Request(FAST_URL, { method: 'GET', headers: { Origin: 'https://evil.example' } });
     const res = await worker.fetch(evil, makeEnv({ serve: 'all', kvValue: envelopeFor('fast') }), makeCtx().ctx);
-    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), null, 'not served from KV');
-    assert.equal(res.headers.get('X-Origin'), 'vercel', 'reached origin');
-    assert.notEqual(res.headers.get('Access-Control-Allow-Origin'), '*');
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv', 'still served from KV');
+    assert.equal(res.headers.get('X-Origin'), null, 'origin was not enlisted');
+    assert.equal(
+      res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app',
+      'the canonical fallback echo is what denies the browser read',
+    );
+    assert.equal(res.headers.get('Access-Control-Allow-Credentials'), 'true');
+  } finally { restore(); }
+});
+
+test('the KV path never receives a status function it would spread into nothing', async () => {
+  // serveFromKv spreads its corsHeaders argument directly, so a status-function
+  // reaching it would produce a 200 with zero CORS headers — a silent fail-open
+  // into an unreadable cross-origin response. Pinned for whoever widens the
+  // predicate next: every KV-served response carries a real ACAO, allowed Origin
+  // or not.
+  const restore = installFetch();
+  try {
+    const env = makeEnv({ serve: 'all', get: async (tier) => envelopeFor(tier) });
+    for (const [label, request] of [
+      ['allowed Origin', req(FAST_URL)],
+      ['no Origin', new Request(FAST_URL, { method: 'GET' })],
+      ['disallowed Origin', new Request(FAST_URL, { method: 'GET', headers: { Origin: 'https://evil.example' } })],
+      ['allowed Origin, slow tier', req(SLOW_URL)],
+    ]) {
+      const res = await worker.fetch(request, env, makeCtx().ctx);
+      assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv', `${label}: served from KV`);
+      assert.ok(res.headers.get('Access-Control-Allow-Origin'), `${label}: has an ACAO`);
+    }
+  } finally { restore(); }
+});
+
+test('the KV-served slow tier carries the same public shape as fast', async () => {
+  const restore = installFetch();
+  try {
+    const res = await worker.fetch(req(SLOW_URL), makeEnv({ serve: 'all', get: async (tier) => envelopeFor(tier) }), makeCtx().ctx);
+    assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
+    assertPublicBootstrapCorsHeaders({ assert, resp: res, label: 'KV-served slow tier' });
+    assert.equal(res.headers.get('Vary'), null);
   } finally { restore(); }
 });
 
@@ -125,19 +162,14 @@ test('no-Origin callers (curl, server-side, RUM beacons) are served the public s
     const anon = new Request(FAST_URL, { method: 'GET' });
     const res = await worker.fetch(anon, makeEnv({ serve: 'all', kvValue: envelopeFor('fast') }), makeCtx().ctx);
     assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), 'kv');
-    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+    assertPublicBootstrapCorsHeaders({ assert, resp: res, label: 'no-Origin KV serve' });
     assert.equal(res.headers.get('Vary'), null);
   } finally { restore(); }
 });
 
 test('the KV-served tier stays browser-no-store — the POP-local KV read is the cache', async () => {
-  // Deliberate, and pinned so it reads as a decision rather than an omission:
-  // a Worker-generated Response is never stored by the Cloudflare cache, so the
-  // shared lifetime this path has is the KV read's own cacheTtl at the POP,
-  // bounded by classifyKvEnvelope's staleness gate. A CDN-Cache-Control here
-  // would advertise a shared lifetime nothing honours, and a browser max-age
-  // would let a cache replay masquerade as a fresh transfer sample in the
-  // bootstrap RUM (#7047) — the same reason the origin serves no-store today.
+  // Pinned so it reads as a decision rather than an omission. Rationale:
+  // src/kv-serve.js#serveFromKv.
   const restore = installFetch();
   try {
     const res = await worker.fetch(req(FAST_URL), makeEnv({ serve: 'all', kvValue: envelopeFor('fast') }), makeCtx().ctx);
@@ -152,6 +184,9 @@ test('serve=off (kill-switch): public-tier GET falls through to origin unchanged
     const res = await worker.fetch(req(FAST_URL), makeEnv({ serve: 'off', kvValue: envelopeFor('fast') }), makeCtx().ctx);
     assert.equal(res.headers.get('X-Origin'), 'vercel', 'reached origin');
     assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), null);
+    // The kill-switch changes which path answers, never the contract it answers with.
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+    assert.equal(res.headers.get('Access-Control-Allow-Credentials'), null);
   } finally { restore(); }
 });
 
@@ -184,6 +219,9 @@ test('every KV failure mode falls through to origin (never a served 5xx)', async
       assert.equal(res.status, 200, `${name}: still 200`);
       assert.equal(res.headers.get('X-Origin'), 'vercel', `${name}: reached origin`);
       assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), null, `${name}: not served from KV`);
+      // Absolute, not a same-shape comparison: which path answered must not change the contract.
+      assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*', `${name}: public shape`);
+      assert.equal(res.headers.get('Access-Control-Allow-Credentials'), null, `${name}: no credentials`);
     } finally { restore(); }
   }
 });
@@ -272,6 +310,9 @@ test('a hung KV read hedges to origin after the delay and records reason=hedged'
     assert.equal(res.headers.get('X-Origin'), 'vercel', 'hedge falls back to origin');
     assert.equal(res.headers.get('X-WorldMonitor-Bootstrap-Source'), null, 'not served from the hung KV');
     assert.equal(originCalls, 1, 'origin enlisted exactly once, at the hedge boundary');
+    // The header shape must not depend on which side won the race (#7308).
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+    assert.equal(res.headers.get('Access-Control-Allow-Credentials'), null);
     await Promise.all(waits);
     assert.equal(event.kv_outcome, 'fallback');
     assert.equal(event.kv_reason, 'hedged');

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -17,6 +17,7 @@
 //      ~/.claude/skills/worldmonitor-architecture-gotchas/reference/
 //        cloudflare-worker-overrides-vercel-cors-for-preflight.md
 
+import { bootstrapTierFromPublicRequest } from '../../../api/_bootstrap-public-tier.js';
 import { maybeShadowKvRead } from './kv-shadow.js';
 import { maybeServeBootstrapFromKv } from './kv-serve.js';
 
@@ -169,6 +170,48 @@ export function buildCorsHeaders(origin) {
 }
 
 /**
+ * The response shape `api/bootstrap.js` uses for a `&public=1` URL
+ * (`getPublicBootstrapHeaders()` -> `getPublicCorsHeaders()` + TAO): ACAO `*`,
+ * no `Access-Control-Allow-Credentials`, no `Vary: Origin`.
+ *
+ * The payload behind those URLs is the shared seed bundle — one answer for
+ * every caller — so keying it by Origin buys nothing and costs a cache entry
+ * per origin, while `Allow-Credentials: true` advertises credentialed access on
+ * a response no credential can change. The origin honours that distinction for
+ * public auth kinds; before #7308 the edge did not, and stamped its
+ * credentialed bag over both the KV-served bytes and the origin pass-through.
+ *
+ * Allow-Methods / Allow-Headers / Expose-Headers stay the Worker's own
+ * supersets (the origin publishes `GET, OPTIONS` and a narrower expose list);
+ * a superset is what this Worker's allowlist contract already promises
+ * everywhere else, and none of the three is part of the caching or credential
+ * question this shape answers.
+ */
+function buildPublicBootstrapCorsHeaders() {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': ALLOW_METHODS,
+    'Access-Control-Allow-Headers': ALLOW_HEADERS,
+    'Access-Control-Expose-Headers': EXPOSE_HEADERS,
+    'Access-Control-Max-Age': '3600',
+  };
+}
+
+/**
+ * Whether this request is one the origin would answer with the public shape.
+ *
+ * A disallowed Origin is excluded on purpose: `api/bootstrap.js` refuses those
+ * with 403 before it reads a payload (`isDisallowedOrigin`), so answering one
+ * with ACAO `*` would make the seed bundle readable by a page the origin turns
+ * away. Those requests keep the credentialed bag and reach the origin, which
+ * still owns the refusal.
+ */
+function servesPublicBootstrapShape(request, url, origin) {
+  if (bootstrapTierFromPublicRequest(request, url) === null) return false;
+  return !origin || isAllowedOrigin(origin);
+}
+
+/**
  * OPTIONS preflight for disallowed origins must echo the request Origin so the
  * browser will send the actual request. Otherwise origin_403 stays an opaque
  * network error (#6411). Success responses still use the allowlist via
@@ -237,7 +280,19 @@ async function passThroughToOrigin(request, url, corsHeadersForStatus) {
     for (const [k, v] of Object.entries(corsHeaders)) {
       newHeaders.set(k, v);
     }
-    newHeaders.set('Vary', mergeHeaderNames(originVary, corsHeaders.Vary));
+    // A shape that omits Allow-Credentials must actively clear one the origin
+    // supplied: setting ACAO `*` while leaving `Allow-Credentials: true` behind
+    // is the combination browsers reject outright.
+    if (!('Access-Control-Allow-Credentials' in corsHeaders)) {
+      newHeaders.delete('Access-Control-Allow-Credentials');
+    }
+    // The public bootstrap shape contributes no Vary at all. Merging two empty
+    // inputs yields '', and `set('Vary', '')` is a present-but-empty header
+    // rather than an absent one — enough to fail a contract check that reads
+    // "no Vary" as `null`, and a needless header on every such response.
+    const mergedVary = mergeHeaderNames(originVary, corsHeaders.Vary);
+    if (mergedVary) newHeaders.set('Vary', mergedVary);
+    else newHeaders.delete('Vary');
     // Bootstrap temporarily exposes U3a timing and cache-classifier headers.
     // Preserve only that route's function-owned additions while retaining
     // the Worker's canonical baseline. Replacing this header outright made
@@ -295,11 +350,19 @@ export default {
       return new Response(null, { status: 204, headers: buildPreflightCorsHeaders(origin) });
     }
 
-    const corsForStatus = (status) => buildResponseCorsHeaders(origin, status);
+    // `?tier=<fast|slow>&public=1` is answered by api/bootstrap.js with the public shape, so the
+    // edge reproduces it on BOTH paths (#7308). One shape for one URL: the KV-served bytes and the
+    // origin fallback answer the same request, and a response whose CORS/caching shape depends on
+    // which path happened to win the hedge is the harder thing to reason about, not the safer one.
+    // A fixed bag rather than a status-dependent builder — public is public at every status here.
+    const publicBootstrapShape = servesPublicBootstrapShape(request, url, origin);
+    const corsPolicy = publicBootstrapShape
+      ? buildPublicBootstrapCorsHeaders()
+      : (status) => buildResponseCorsHeaders(origin, status);
     // The single origin path for this request. maybeServeBootstrapFromKv (U-K4) may invoke it once
     // internally when it hedges/falls back; every other request runs it directly below. Either way
     // origin is fetched at most once.
-    const fetchOrigin = () => passThroughToOrigin(request, url, corsForStatus);
+    const fetchOrigin = () => passThroughToOrigin(request, url, corsPolicy);
 
     // KV serving (U-K4, #5338 / #7291): for a public-tier bootstrap GET with BOOTSTRAP_KV_SERVE
     // on, serve the tier straight from KV (never touching Vercel/Redis). A slow KV read is hedged
@@ -307,7 +370,12 @@ export default {
     // (KTD3), so the worst case is origin pass-through. Returns null for non-servable requests
     // (flag off, not a bootstrap GET), which then run the normal pass-through. Production is
     // BOOTSTRAP_KV_SERVE="all"; "slow" and "off" remain kill-switches.
-    const bootstrapKv = await maybeServeBootstrapFromKv(request, url, env, ctx, buildCorsHeaders(origin), fetchOrigin);
+    // Gated on publicBootstrapShape so a disallowed Origin is never answered from KV: the origin
+    // 403s it, and only the origin can (see servesPublicBootstrapShape). Every other non-servable
+    // request is filtered by maybeServeBootstrapFromKv's own predicate.
+    const bootstrapKv = publicBootstrapShape
+      ? await maybeServeBootstrapFromKv(request, url, env, ctx, corsPolicy, fetchOrigin)
+      : null;
     if (bootstrapKv) return bootstrapKv;
 
     // All other methods/paths — pass through to Vercel with the Worker's canonical CORS stamped.

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -379,10 +379,14 @@ export default {
     }
 
     // `?tier=<fast|slow>&public=1` is answered by api/bootstrap.js with the public shape, so the
-    // edge reproduces it on BOTH paths (#7308). One shape for one URL: the KV-served bytes and the
-    // origin fallback answer the same request, and a response whose CORS/caching shape depends on
-    // which path happened to win the hedge is the harder thing to reason about, not the safer one.
-    // A fixed bag rather than a status-dependent builder — public is public at every status here.
+    // edge reproduces it on BOTH paths (#7308). One CORS shape for one URL: the KV-served bytes and
+    // the origin fallback answer the same request, and a response whose CORS shape depends on which
+    // path won the hedge is the harder thing to reason about, not the safer one. A fixed bag rather
+    // than a status-dependent builder — public is public at every status here.
+    //
+    // Scoped to CORS on purpose. The browser CACHE directive still differs by path (KV `no-store`,
+    // origin `TIER_CACHE[tier]`) and that is deliberate, for reasons that belong to the KV path
+    // rather than this one — see kv-serve.js#serveFromKv. Do not read this as a caching invariant.
     const publicTier = bootstrapTierFromPublicRequest(request, url);
     const publicBootstrapShape = publicTier !== null && (!origin || isAllowedOrigin(origin));
     const corsPolicy = publicBootstrapShape

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -17,7 +17,7 @@
 //      ~/.claude/skills/worldmonitor-architecture-gotchas/reference/
 //        cloudflare-worker-overrides-vercel-cors-for-preflight.md
 
-import { bootstrapTierFromPublicRequest } from '../../../api/_bootstrap-public-tier.js';
+import { bootstrapTierFromPublicRequest, bootstrapTierFromPublicUrl } from '../../../api/_bootstrap-public-tier.js';
 import { maybeShadowKvRead } from './kv-shadow.js';
 import { maybeServeBootstrapFromKv } from './kv-serve.js';
 
@@ -186,6 +186,13 @@ export function buildCorsHeaders(origin) {
  * a superset is what this Worker's allowlist contract already promises
  * everywhere else, and none of the three is part of the caching or credential
  * question this shape answers.
+ *
+ * Reimplemented rather than imported from `api/_cors.js#getPublicCorsHeaders`,
+ * even though this file imports `api/_bootstrap-public-tier.js` two lines up:
+ * that module was kept dependency-free precisely so both sides could share it,
+ * while `api/_cors.js` reads `process.env.NODE_ENV` at module scope, and this
+ * Worker declares no `nodejs_compat` flag — importing it would throw at cold
+ * start for every request on api.worldmonitor.app.
  */
 function buildPublicBootstrapCorsHeaders() {
   return {
@@ -197,17 +204,35 @@ function buildPublicBootstrapCorsHeaders() {
   };
 }
 
+// A disallowed Origin is excluded from the public shape on purpose — both by the
+// preflight predicate below and by publicBootstrapShape in fetch(). api/bootstrap.js
+// refuses those with 403 (isDisallowedOrigin), so answering one with ACAO `*` would
+// make the seed bundle browser-readable to a page the origin turns away. Those
+// requests keep the credentialed bag, whose canonical-fallback ACAO is what actually
+// denies the read: the origin's 403 cannot be relied on for it, because the public
+// tier ships `CDN-Cache-Control: public, s-maxage=600` and a warm CDN entry answers
+// before isDisallowedOrigin ever runs.
+//
+// This is policy consistency with the origin, not an access-control boundary — the
+// payload is public, and any caller CORS refuses reads the same bytes server-side or
+// by omitting the Origin header. That is precisely why it must not cost anything to
+// enforce; see the KV routing note in fetch().
+
 /**
- * Whether this request is one the origin would answer with the public shape.
+ * Whether this OPTIONS request is the preflight for a public-tier bootstrap GET.
  *
- * A disallowed Origin is excluded on purpose: `api/bootstrap.js` refuses those
- * with 403 before it reads a payload (`isDisallowedOrigin`), so answering one
- * with ACAO `*` would make the seed bundle readable by a page the origin turns
- * away. Those requests keep the credentialed bag and reach the origin, which
- * still owns the refusal.
+ * The preflight leg has to agree with the response leg or the contract is split
+ * in half: advertising `Allow-Credentials: true` while clearing a request whose
+ * answer is ACAO `*` with no credentials is the same mismatch #7308 fixed one
+ * layer down, and it is the combination browsers reject when a caller does send
+ * credentials. The preflight's own method is OPTIONS, so the GET-gated request
+ * predicate cannot answer this — the URL shape plus `Access-Control-Request-Method`
+ * can. Anything other than a declared GET keeps the credentialed bag, as does a
+ * disallowed Origin, whose echo is load-bearing for observing origin_403 (#6411).
  */
-function servesPublicBootstrapShape(request, url, origin) {
-  if (bootstrapTierFromPublicRequest(request, url) === null) return false;
+function preflightsPublicBootstrapShape(request, url, origin) {
+  if (bootstrapTierFromPublicUrl(url) === null) return false;
+  if ((request.headers.get('Access-Control-Request-Method') || '').toUpperCase() !== 'GET') return false;
   return !origin || isAllowedOrigin(origin);
 }
 
@@ -347,7 +372,10 @@ export default {
     // error (#6411). Non-OPTIONS responses still use the allowlist, with a
     // readable echo only on 401/403 refusals.
     if (request.method === 'OPTIONS') {
-      return new Response(null, { status: 204, headers: buildPreflightCorsHeaders(origin) });
+      const headers = preflightsPublicBootstrapShape(request, url, origin)
+        ? buildPublicBootstrapCorsHeaders()
+        : buildPreflightCorsHeaders(origin);
+      return new Response(null, { status: 204, headers });
     }
 
     // `?tier=<fast|slow>&public=1` is answered by api/bootstrap.js with the public shape, so the
@@ -355,10 +383,14 @@ export default {
     // origin fallback answer the same request, and a response whose CORS/caching shape depends on
     // which path happened to win the hedge is the harder thing to reason about, not the safer one.
     // A fixed bag rather than a status-dependent builder — public is public at every status here.
-    const publicBootstrapShape = servesPublicBootstrapShape(request, url, origin);
+    const publicTier = bootstrapTierFromPublicRequest(request, url);
+    const publicBootstrapShape = publicTier !== null && (!origin || isAllowedOrigin(origin));
     const corsPolicy = publicBootstrapShape
       ? buildPublicBootstrapCorsHeaders()
       : (status) => buildResponseCorsHeaders(origin, status);
+    // KV always mints a 200, and serveFromKv spreads what it is handed — resolve the union here so
+    // the bag it receives is a bag, never a status function whose spread would yield no CORS at all.
+    const kvCorsHeaders = publicBootstrapShape ? corsPolicy : buildCorsHeaders(origin);
     // The single origin path for this request. maybeServeBootstrapFromKv (U-K4) may invoke it once
     // internally when it hedges/falls back; every other request runs it directly below. Either way
     // origin is fetched at most once.
@@ -370,11 +402,17 @@ export default {
     // (KTD3), so the worst case is origin pass-through. Returns null for non-servable requests
     // (flag off, not a bootstrap GET), which then run the normal pass-through. Production is
     // BOOTSTRAP_KV_SERVE="all"; "slow" and "off" remain kill-switches.
-    // Gated on publicBootstrapShape so a disallowed Origin is never answered from KV: the origin
-    // 403s it, and only the origin can (see servesPublicBootstrapShape). Every other non-servable
-    // request is filtered by maybeServeBootstrapFromKv's own predicate.
-    const bootstrapKv = publicBootstrapShape
-      ? await maybeServeBootstrapFromKv(request, url, env, ctx, corsPolicy, fetchOrigin)
+    //
+    // Gated on the tier predicate ALONE, deliberately — not on publicBootstrapShape. Which CORS bag
+    // a disallowed Origin gets is a header decision; whether its bytes come from KV is a routing
+    // one, and the two must not be fused. The KV bytes are caller-invariant, so serving them under
+    // the credentialed fallback bag denies the browser read just as effectively while keeping the
+    // request off Vercel/Redis. Gating the route instead would hand any unauthenticated caller an
+    // origin-forcing lever: one bogus `Origin:` header on every request re-opens exactly the Redis
+    // egress this path exists to eliminate, and buys nothing — the same caller reads the same bytes
+    // from KV by simply omitting the header.
+    const bootstrapKv = publicTier !== null
+      ? await maybeServeBootstrapFromKv(request, url, env, ctx, kvCorsHeaders, fetchOrigin)
       : null;
     if (bootstrapKv) return bootstrapKv;
 

--- a/workers/api-cors-preflight/src/kv-serve.js
+++ b/workers/api-cors-preflight/src/kv-serve.js
@@ -77,8 +77,17 @@ function recordServe(env, ctx, { tier, outcome, reason, durationMs, cf }) {
 function serveFromKv(env, ctx, { tier, body, cf, started, corsHeaders }) {
   recordServe(env, ctx, { tier, outcome: 'served', reason: null, durationMs: Date.now() - started, cf });
   // Mirror the headers the origin sets for this route (the Worker is the CORS source of truth, so
-  // corsHeaders is spread first). x-vercel-* / age are intentionally absent; the source marker
-  // makes a KV-served response identifiable in curl/devtools.
+  // corsHeaders is spread first). corsHeaders is the caller's PUBLIC bootstrap shape — ACAO:*, no
+  // Allow-Credentials, no Vary: Origin — matching what api/bootstrap.js returns for a `?public=1`
+  // tier URL; the credentialed bag here was #7308. x-vercel-* / age are intentionally absent; the
+  // source marker makes a KV-served response identifiable in curl/devtools.
+  //
+  // Cache-Control stays `no-store`, deliberately. A Worker-generated Response is never stored by
+  // the Cloudflare cache, so the shared lifetime this path has is the POP-local KV read
+  // (TIER_CACHE_TTL_S) bounded by classifyKvEnvelope's KTD4 staleness gate — not a CDN entry. A
+  // CDN-Cache-Control here would advertise a shared lifetime nothing honours, and a browser
+  // max-age would let a cache replay masquerade as a fresh transfer sample in the bootstrap RUM
+  // (#7047) — the same reason api/bootstrap.js serves no-store on this URL today.
   return new Response(body, {
     status: 200,
     headers: {
@@ -99,6 +108,10 @@ function serveFromKv(env, ctx, { tier, body, cf, started, corsHeaders }) {
  * KV is not servable / too slow, or null when this isn't a servable request at all (so the caller
  * runs its normal pass-through). fetchOrigin is the caller's single origin+CORS path — invoked at
  * most once here, so origin is fetched exactly once across the whole request. Never throws.
+ *
+ * corsHeaders must be the PUBLIC bootstrap shape (#7308). The caller decides that, because it is
+ * also the one that knows whether the request's Origin is allowed at all — a disallowed Origin is
+ * never routed here, so this function can spread what it is given without re-deciding.
  */
 export async function maybeServeBootstrapFromKv(request, url, env, ctx, corsHeaders, fetchOrigin) {
   if (!env?.BOOTSTRAP_KV) return null;

--- a/workers/api-cors-preflight/src/kv-serve.js
+++ b/workers/api-cors-preflight/src/kv-serve.js
@@ -87,7 +87,13 @@ function serveFromKv(env, ctx, { tier, body, cf, started, corsHeaders }) {
   // (TIER_CACHE_TTL_S) bounded by classifyKvEnvelope's KTD4 staleness gate — not a CDN entry. A
   // CDN-Cache-Control here would advertise a shared lifetime nothing honours, and a browser
   // max-age would let a cache replay masquerade as a fresh transfer sample in the bootstrap RUM
-  // (#7047) — the same reason api/bootstrap.js serves no-store on this URL today.
+  // (#7047).
+  //
+  // This DOES diverge from the origin fallback, which serves TIER_CACHE's `max-age=60` (fast) /
+  // `max-age=300` (slow) for the same URL — considered, not missed. Do not justify it by what
+  // production currently returns from the origin: that is also `no-store` today, but only because
+  // finishBootstrapR2ShadowResponse overrides it while BOOTSTRAP_R2_SHADOW_MEASURE=1, a temporary
+  // U3a flag. The reasons above stand on their own once that flag is off.
   return new Response(body, {
     status: 200,
     headers: {


### PR DESCRIPTION
## Summary

Anyone curling `api.worldmonitor.app/api/bootstrap?tier=fast&public=1` got back
`Access-Control-Allow-Credentials: true` and an Origin-echoed ACAO on an
unauthenticated seed payload that also carries `Timing-Allow-Origin: *` — while
the same URL straight off Vercel answered `ACAO: *` with no credentials header.
The edge and the origin disagreed about what the public bootstrap contract is.
They now agree.

The drift is older than it looked. `/api/bootstrap` is not in the Worker's
`PUBLIC_CORS_PATHS`, so `passThroughToOrigin` has always overwritten the origin's
public ACAO with the credentialed bag; #7292 only added `no-store` on top. So the
fix covers **both** edge paths — the KV-served bytes and the origin pass-through —
plus the OPTIONS preflight, and the shape no longer depends on which one answered.

## Design decisions worth a look

**The header decision and the routing decision are separate.** The first version of
this fix gated KV *serving* on origin-allowedness, which turned an unauthenticated
request header into a lever over origin cost: one bogus `Origin:` per request routed
the tier off KV and back onto Vercel/Redis — the exact egress #7292 exists to
remove — and bought nothing, since the same caller reads the same bytes by omitting
the header. A disallowed Origin is now still KV-served, under the credentialed
fallback bag whose canonical ACAO is what denies the browser read.

**That ACAO fallback is the actual denial mechanism, not the origin's 403.** The
public tier ships `CDN-Cache-Control: public, s-maxage=600`, so a warm CDN entry
answers a pass-through before `isDisallowedOrigin` ever runs. Worth knowing before
anyone deletes the fallback as redundant.

**`Cache-Control: no-store` on the KV path stays, deliberately.** A Worker-generated
`Response` is never stored by the Cloudflare cache, so there is no shared lifetime to
declare; the POP-local KV read bounded by `classifyKvEnvelope`'s staleness gate is
the cache. This does diverge from the origin fallback's `TIER_CACHE[tier]` browser
lifetime — the CORS shape is unified, caching deliberately is not, and both the code
and the README now say so rather than implying a caching invariant that does not hold.

**The preflight is part of the contract.** It was advertising `Allow-Credentials: true`
while clearing a GET that answers `ACAO: *` — the pairing browsers reject. It now
carries the public shape when it clears a GET from an allowed Origin; a non-GET
request method or a disallowed Origin keeps the credentialed echo (#6411).

## Why the existing guard never caught this

`api/bootstrap-auth.test.mjs` calls `handler()` directly, so it asserted the shape
the origin *builds* and could not see what the edge does to the bytes afterwards —
and since #7292 there is a path that mints the response at the POP without touching
the handler at all. Both guards now read the same assertions from
`tests/helpers/public-bootstrap-contract.mjs`, and `tests/cors-preflight-live.test.mjs`
runs them against a **deployed** URL. Its path filter in `deploy-worker.yml` was
missing that file and the helper, so a change to the shared contract deployed nothing
and re-checked nothing; both paths added.

## Validation

Ten tests go red against the pre-fix source and green after — pass-through,
no-Origin pass-through, 502, preflight, KV fast, KV slow, no-Origin KV, kill-switch,
every KV failure mode, and hedge fallback. Verified by overlaying the current test
files onto `280c4b541` and running them. Six further tests pin unchanged behaviour as
regression guards and correctly pass on both sides; they are not counted as proof.

Suites: 64/64 worker unit, 47/47 `api/bootstrap-auth`, 65/65 `cors-fail-closed`,
plus `publish-bootstrap-tiers`, `bootstrap-on-demand-cache-budget`, `deploy-config`,
`wm-session-auto-refresh` and `docs-stats-bootstrap-cache` green.

The deployed-URL guard currently **fails** against production on exactly this drift,
and goes green once the Worker deploys — that is the acceptance signal, and the
`live-smoke` job runs it automatically after every deploy.

## Scope

Deliberately limited to the tier URLs. `?keys=weatherAlerts&public=1` and the marked
single-key on-demand URLs reach the same public shape at the origin and are still
stamped with the credentialed bag at the edge. Those need the origin's
`ON_DEMAND_KEYS` / `PUBLIC_WEATHER_BOOTSTRAP_KEY` membership sets at the edge
(`?keys=marketQuotes&public=1` is not public — it 401s today), on genuinely
CDN-cached URLs where the added `Vary: Origin` really does split the entry per
origin. The Worker README says so explicitly rather than implying the shapes now
agree everywhere.

Also checked rather than assumed: #7046's acceptance bullet is not voided by the KV
path. `tests/bootstrap-on-demand-cache-budget.test.mts` iterates
`bootstrapTierKeyNames('on-demand')`, and KV serves only tier URLs.

**Not merge-and-forget:** #7308 stays open until the post-deploy live-smoke run
confirms the shape on the deployed edge.

## Related

- Related: #7308
- Related: #7311
- Related: #7292
- Related: #7047

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
