### PR TITLE
fix(classify-event): size the token budget for the reasoning fallback, not the primary

### DIFF
--- a/server/worldmonitor/intelligence/v1/classify-event.ts
+++ b/server/worldmonitor/intelligence/v1/classify-event.ts
@@ -86,7 +86,33 @@ Return: {"level":"...","category":"..."}`;
             { role: 'user', content: title },
           ],
           temperature: 0,
-          maxTokens: 50,
+          // Sized for the REASONING fallback, not the primary. DeepSeek answers
+          // this two-field JSON in ~10 tokens (4,264 successful calls over the
+          // 7 days to 2026-08-29: p50=10, p95=11, max=12), so the old ceiling of
+          // 50 was never close to binding for it — and a ceiling costs nothing
+          // when it is not reached.
+          //
+          // The Groq fallback is `openai/gpt-oss-*`, a reasoning model. Even at
+          // `reasoning_effort: 'low'` (#7289) it spends part of the budget on
+          // hidden reasoning before emitting content, so at 50 the JSON was cut
+          // mid-key — the literal returned content was `{"level":"` — and the
+          // validator below rejected it. Measured against the live API on eight
+          // headlines, driven through THIS file's own systemPrompt and
+          // VALID_LEVELS/VALID_CATEGORIES rather than a paraphrase of them:
+          //
+          //   max_tokens=50   no effort   0/8 valid   8 truncated  (pre-#7289)
+          //   max_tokens=50   low         5/8 valid   3 truncated  (#7289 alone)
+          //   max_tokens=120  low         7/8 valid   1 truncated
+          //   max_tokens=200  low         8/8 valid   0 truncated
+          //
+          // 120 was not enough: an "Analysis: why ..." explainer headline — the
+          // ambiguous `info` case the prompt spends its examples on — reasoned
+          // past it and returned the literal fragment `{"`.
+          //
+          // Do not "tidy" this back down to the primary's p95: that reintroduces
+          // a silent `classification: undefined` in exactly the primary-is-down
+          // scenario the fallback exists to cover.
+          maxTokens: 200,
           timeoutMs: UPSTREAM_TIMEOUT_MS,
           stage: 'classify-event',
           validate: (content) => {

--- a/tests/classify-event-token-headroom.test.mjs
+++ b/tests/classify-event-token-headroom.test.mjs
@@ -12,15 +12,16 @@
 // 2026-08-28T19:01:35Z: `validate_reject`, `tokens_completion: 50`, exactly
 // the ceiling.
 //
-// Measured against the live Groq API, six representative headlines from the
-// stage's own system prompt:
+// Measured against the live Groq API, eight representative headlines driven
+// through the stage's own system prompt and enums:
 //
-//   no reasoning control @ 50   0/6 valid   6 hit the cap   (pre-#7289)
-//   reasoning_effort low @ 50   4/6 valid   2 hit the cap   (the residue)
-//   reasoning_effort low @ 120  6/6 valid   0 hit the cap
+//   max_tokens=50   no effort   0/8 valid   8 truncated   (pre-#7289)
+//   max_tokens=50   low         5/8 valid   3 truncated   (the residue)
+//   max_tokens=120  low         7/8 valid   1 truncated
+//   max_tokens=200  low         8/8 valid   0 truncated
 //
 // The truncation is dispositive rather than inferred — the returned content
-// was the literal string `{"level":"`.
+// was the literal string `{"level":"`, and at 120 the fragment `{"`.
 //
 // Raising a `max_tokens` CEILING costs nothing for a model that answers in 10
 // tokens; it only changes who gets truncated. This is the fallback-only
@@ -37,11 +38,18 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SRC = resolve(root, 'server/worldmonitor/intelligence/v1/classify-event.ts');
 
 /**
- * Worst-case hidden-reasoning overhead observed from `gpt-oss-20b` at
- * `reasoning_effort: 'low'`, plus the ~12 tokens the JSON itself needs. The
- * floor is what the test enforces; the exact configured value may exceed it.
+ * The lowest budget MEASURED to truncate nothing — not a rounded-down
+ * guess at one.
+ *
+ * This started at 100 and was raised in review: the table above records
+ * `max_tokens=120` truncating 1 of 8, so any floor below 200 leaves the guard
+ * green on a value already shown to reintroduce the fallback failure it exists
+ * to prevent. A regression floor set beneath the evidence is not a floor.
+ *
+ * Raise it only alongside a fresh measurement; lower it only if a measurement
+ * shows a smaller budget is clean.
  */
-const MIN_HEADROOM_TOKENS = 100;
+const MIN_HEADROOM_TOKENS = 200;
 
 describe('classify-event token budget leaves room for a reasoning fallback', () => {
   const src = readFileSync(SRC, 'utf8');
@@ -52,7 +60,8 @@ describe('classify-event token budget leaves room for a reasoning fallback', () 
     const maxTokens = Number(m[1]);
     assert.ok(
       maxTokens >= MIN_HEADROOM_TOKENS,
-      `maxTokens=${maxTokens} truncates the Groq fallback mid-JSON — measured 4/6 valid at 50, 6/6 at 120`,
+      `maxTokens=${maxTokens} is below the measured-clean budget of ${MIN_HEADROOM_TOKENS}: `
+      + 'against the live API, 50 gave 5/8 valid (3 truncated) and 120 gave 7/8 (1 truncated)',
     );
   });
 

--- a/tests/classify-event-token-headroom.test.mjs
+++ b/tests/classify-event-token-headroom.test.mjs
@@ -1,0 +1,78 @@
+// `classify-event` must leave enough token budget for a REASONING fallback.
+//
+// The stage asks for a 2-field JSON object and ran on `maxTokens: 50`, which
+// is ample for the DeepSeek primary — 4,264 successful calls over the 7 days
+// to 2026-08-29 used p50=10, p95=11, max=12 completion tokens, never within
+// 38 of the ceiling.
+//
+// The Groq fallback is `openai/gpt-oss-*`, a REASONING model. Even with
+// `reasoning_effort: 'low'` (#7289) it still spends some of the budget on
+// hidden reasoning before emitting content, so at 50 the JSON is cut mid-key
+// and the validator — correctly — rejects it. Observed in production
+// 2026-08-28T19:01:35Z: `validate_reject`, `tokens_completion: 50`, exactly
+// the ceiling.
+//
+// Measured against the live Groq API, six representative headlines from the
+// stage's own system prompt:
+//
+//   no reasoning control @ 50   0/6 valid   6 hit the cap   (pre-#7289)
+//   reasoning_effort low @ 50   4/6 valid   2 hit the cap   (the residue)
+//   reasoning_effort low @ 120  6/6 valid   0 hit the cap
+//
+// The truncation is dispositive rather than inferred — the returned content
+// was the literal string `{"level":"`.
+//
+// Raising a `max_tokens` CEILING costs nothing for a model that answers in 10
+// tokens; it only changes who gets truncated. This is the fallback-only
+// scenario the fallback exists for: when the primary is down, a third of
+// classifications were silently degrading to `classification: undefined`.
+
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = resolve(root, 'server/worldmonitor/intelligence/v1/classify-event.ts');
+
+/**
+ * Worst-case hidden-reasoning overhead observed from `gpt-oss-20b` at
+ * `reasoning_effort: 'low'`, plus the ~12 tokens the JSON itself needs. The
+ * floor is what the test enforces; the exact configured value may exceed it.
+ */
+const MIN_HEADROOM_TOKENS = 100;
+
+describe('classify-event token budget leaves room for a reasoning fallback', () => {
+  const src = readFileSync(SRC, 'utf8');
+
+  it('requests enough tokens that a reasoning model can still close the JSON', () => {
+    const m = src.match(/maxTokens:\s*(\d+)/);
+    assert.ok(m, 'classify-event must declare an explicit maxTokens');
+    const maxTokens = Number(m[1]);
+    assert.ok(
+      maxTokens >= MIN_HEADROOM_TOKENS,
+      `maxTokens=${maxTokens} truncates the Groq fallback mid-JSON — measured 4/6 valid at 50, 6/6 at 120`,
+    );
+  });
+
+  it('still bounds the budget — this is headroom, not an open tap', () => {
+    // The stage returns {"level":"...","category":"..."} and nothing else. A
+    // ceiling that drifted into the thousands would stop being a guard against
+    // a runaway generation on ~4k calls/week.
+    const maxTokens = Number(src.match(/maxTokens:\s*(\d+)/)[1]);
+    assert.ok(maxTokens <= 256, `maxTokens=${maxTokens} is far past what a two-field JSON object needs`);
+  });
+
+  it('records why the ceiling is not simply the primary p95', () => {
+    // Without the rationale in-file the next person sees a 2-field JSON asking
+    // for 120 tokens against a p95 of 11 and "tidies" it back to 50,
+    // reintroducing the fallback truncation. Guarding the comment is cheap
+    // relative to re-diagnosing it from a single production event.
+    assert.match(
+      src,
+      /reasoning/i,
+      'the maxTokens choice must explain the reasoning-model headroom it exists for',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`classify-event` asked for a two-field JSON object on `maxTokens: 50`. That is ample for the DeepSeek primary — **4,264 successful calls over 7 days used p50=10, p95=11, max=12** completion tokens, never within 38 of the ceiling — so the limit was invisible until the fallback had to answer.

The Groq fallback is `openai/gpt-oss-*`, a **reasoning** model. #7289 gave it `reasoning_effort: 'low'`, which took this stage from total failure to mostly working, but `low` still reserves some budget for hidden reasoning and 50 tokens leaves no room for the JSON behind it.

Production caught the residue on **2026-08-28T19:01:35Z**: `validate_reject`, `tokens_completion: 50` — exactly the ceiling. The validator was right to reject; the content was cut mid-key.

## Measurement

Driven against the live Groq API through **this file's own `systemPrompt` and `VALID_LEVELS`/`VALID_CATEGORIES`**, not a paraphrase:

| `max_tokens` | reasoning | valid | truncated | |
|---|---|---|---|---|
| 50 | none | **0/8** | 8 | pre-#7289 |
| 50 | `low` | 5/8 | 3 | #7289 alone — the residue |
| 120 | `low` | 7/8 | 1 | first attempt, not enough |
| **200** | `low` | **8/8** | **0** | this PR |

120 was tried first and rejected on evidence: an *"Analysis: why the Sahel coup belt keeps widening"* headline — the ambiguous `info` case the prompt spends its examples on — reasoned past it and returned the fragment `{"`.

Worth recording how the first measurement went wrong: I initially probed with a **simplified** system prompt, which produced `"High"` / `"Geopolitics"` — a vocabulary and casing mismatch that looked like a model failure and had nothing to do with the bug. Re-running with the real 2,046-char prompt and the real enums gave the table above. A separate run showed `finish_reason: undefined` on every row, which was my probe swallowing an HTTP status, not a result — it was Groq rate-limiting my own probing.

## Why this is nearly free

`max_tokens` is a **ceiling, not a spend**. The primary answers in ~10 tokens and has never exceeded 12 across 4,264 calls, so raising the ceiling changes nothing for it — it only changes who gets truncated.

Blast radius is genuinely small: this path is reached only when the primary fails. But that is exactly the scenario the fallback exists for, and in it a third of classifications were silently degrading to `classification: undefined`.

## Guard

The new test enforces a floor (≥100) and a bound (≤256), and pins the rationale in-file. Without that last check the next reader sees 200 tokens requested against a primary p95 of 11 and tidies it back to 50, reintroducing the truncation from a single production event that would have to be re-diagnosed from scratch.

## Validation

`tsx --test tests/*classify*` — **192 pass, 0 fail**. `tsc --noEmit` and `biome check` clean; full pre-push gate passed. Live API confirms 8/8 with zero truncation at the shipped value, read from source rather than hardcoded in the probe.

Follow-up to #7289.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
