### PR TITLE
fix(sentry): treat document-URL-only stacks as injection on the marketing surface

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -177,9 +177,9 @@ const MODULE_LOAD_FAILURE =
  */
 const STACK_OVERFLOW = /Maximum call stack size exceeded|too much recursion/i;
 /**
- * A frame that is not a script file: the page document URL itself (`/pro`,
- * `https://www.worldmonitor.app/pro`) or any http(s) resource served without a
- * recognized script extension.
+ * A marketing document frame: `/`, `/pro`, or an absolute URL on any production,
+ * preview, or custom host with one of those paths. Query strings, hashes, and a
+ * trailing slash do not change the document identity.
  *
  * WebKit attributes a MAIN-world injected script — in-app-browser chrome,
  * WKUserScript content scripts, bookmarklets — to the DOCUMENT URL rather than
@@ -192,9 +192,8 @@ const STACK_OVERFLOW = /Maximum call stack size exceeded|too much recursion/i;
  * document URL too. So this is one necessary signal among several at the call
  * site, never the whole licence on its own.
  */
-const NON_SCRIPT_URL_FRAME = (filename: string) =>
-  !/\.(?:m|c)?[jt]sx?(?:[?#]|$)/.test(filename)
-  && (/^\/(?!\/)/.test(filename) || /^https?:\/\//.test(filename));
+const MARKETING_DOCUMENT_FRAME =
+  /^(?:https?:\/\/[^/?#]+)?\/(?:pro\/?)?(?:[?#]|$)/;
 
 /**
  * Safari's placeholder for a script it refuses to attribute to a real document
@@ -249,7 +248,8 @@ const JSON_RPC_RESERVED_MAX = -32000;
  * message text alone, with no access to frames).
  */
 export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
-  const msg = event.exception?.values?.[0]?.value ?? '';
+  const exceptionValues = event.exception?.values ?? [];
+  const msg = exceptionValues[0]?.value ?? '';
 
   // A message that is nothing but a 1-3 character identifier (`ga`, `Ba`) is an
   // injected in-app-browser/extension script rethrowing its own minified
@@ -260,7 +260,7 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
   // (WORLDMONITOR-ZZ, -ZW).
   if (msg.length <= 3 && BARE_SYMBOL_MESSAGE.test(msg)) return null;
 
-  const frames = event.exception?.values?.[0]?.stacktrace?.frames ?? [];
+  const frames = exceptionValues[0]?.stacktrace?.frames ?? [];
   const nonInfraFrames = frames.filter(
     (f) =>
       f.filename &&
@@ -325,7 +325,7 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
   // `TypeError`/`Error` families a first-party bug would raise, the empty stack
   // excludes every in-bundle `JSON.parse` (those carry the calling frame), and
   // `!hasFirstParty` excludes anything attributable to `/pro/assets/*.js`.
-  const excType = event.exception?.values?.[0]?.type ?? '';
+  const excType = exceptionValues[0]?.type ?? '';
   const action = event.tags?.action;
   if (!hasFirstParty
       && frames.length === 0
@@ -404,10 +404,11 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
   // have come from injected code. `tests/pro-sentry-filter-policy.test.mts`
   // pins that across all three file kinds, so the licence cannot rot.
   if ((excType === 'TypeError' || /^TypeError:/.test(msg))
+      && exceptionValues.length === 1
       && !hasFirstParty
       && /\bcontentWindow\b/.test(msg)
       && nonInfraFrames.length > 0
-      && nonInfraFrames.every((f) => NON_SCRIPT_URL_FRAME(f.filename ?? ''))) return null;
+      && nonInfraFrames.every((f) => MARKETING_DOCUMENT_FRAME.test(f.filename ?? ''))) return null;
 
   return event;
 }

--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -177,6 +177,24 @@ const MODULE_LOAD_FAILURE =
  */
 const STACK_OVERFLOW = /Maximum call stack size exceeded|too much recursion/i;
 /**
+ * A frame that is not a script file: the page document URL itself (`/pro`,
+ * `https://www.worldmonitor.app/pro`) or any http(s) resource served without a
+ * recognized script extension.
+ *
+ * WebKit attributes a MAIN-world injected script — in-app-browser chrome,
+ * WKUserScript content scripts, bookmarklets — to the DOCUMENT URL rather than
+ * to a distinct `.js` URL. Our own code never runs from such a URL: this
+ * bundle's entry is a hashed `/pro/assets/*.js` module chunk. So a stack whose
+ * every non-infra frame is a non-script URL is positive evidence of injection,
+ * not merely the absence of first-party evidence.
+ *
+ * Ported from the dashboard's WORLDMONITOR-V8 rule in `src/bootstrap/sentry-init.ts`.
+ */
+const NON_SCRIPT_URL_FRAME = (filename: string) =>
+  !/\.(?:m|c)?[jt]sx?(?:[?#]|$)/.test(filename)
+  && (/^\/(?!\/)/.test(filename) || /^https?:\/\//.test(filename));
+
+/**
  * Safari's placeholder for a script it refuses to attribute to a real document
  * URL — extension content scripts and injected `eval`/blob contexts. Every
  * frame of this bundle is served from an ordinary `https://` URL, so a masked
@@ -355,6 +373,32 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
       && Number.isInteger(rejectedCode)
       && rejectedCode >= JSON_RPC_RESERVED_MIN
       && rejectedCode <= JSON_RPC_RESERVED_MAX) return null;
+
+  // An injected script attributed to the document URL. Instagram's in-app
+  // browser was the observed case (WORLDMONITOR-115): its own chrome script
+  // dereferenced a null iframe — `null is not an object (evaluating
+  // 'e.contentWindow.postMessage')` — with every frame reading `/pro:1` /
+  // `/pro:37` and minified names (`T`, `w`, `i`, `sendMessageToIFrames`), plus
+  // breadcrumbs naming its bridge (`hxp-chat-suppression`, `IAB unified
+  // bridge`). None of those identifiers exists in either bundle.
+  //
+  // This ports the MECHANISM rather than another message. WORLDMONITOR-115 was
+  // the sixth instance of the same dashboard-filters-it / marketing-does-not
+  // gap (-15, -102, -108, -10N, -10T, -107) and every previous fix added one
+  // more string; a frame-shape rule retires the class instead of extending the
+  // list. It is safe here for a stronger reason than on the dashboard:
+  // `pro-test/src` holds no `contentWindow` reference at all, pinned by
+  // `tests/pro-sentry-filter-policy.test.mts`.
+  //
+  // Gated three ways so a real defect still surfaces: the TypeError family
+  // WebKit reports for these faults, `!hasFirstParty` (a genuine bug rides a
+  // `/pro/assets/*.js` frame), and a NON-EMPTY frame list — zero frames is not
+  // "all frames are non-script URLs", and the frameless cases belong to the
+  // rules above.
+  if ((excType === 'TypeError' || /^TypeError:/.test(msg))
+      && !hasFirstParty
+      && nonInfraFrames.length > 0
+      && nonInfraFrames.every((f) => NON_SCRIPT_URL_FRAME(f.filename ?? ''))) return null;
 
   return event;
 }

--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -183,12 +183,14 @@ const STACK_OVERFLOW = /Maximum call stack size exceeded|too much recursion/i;
  *
  * WebKit attributes a MAIN-world injected script — in-app-browser chrome,
  * WKUserScript content scripts, bookmarklets — to the DOCUMENT URL rather than
- * to a distinct `.js` URL. Our own code never runs from such a URL: this
- * bundle's entry is a hashed `/pro/assets/*.js` module chunk. So a stack whose
- * every non-infra frame is a non-script URL is positive evidence of injection,
- * not merely the absence of first-party evidence.
+ * to a distinct `.js` URL.
  *
- * Ported from the dashboard's WORLDMONITOR-V8 rule in `src/bootstrap/sentry-init.ts`.
+ * On the DASHBOARD that shape alone proves injection, because its entry is
+ * always a hashed `/assets/*.js` chunk (WORLDMONITOR-V8). It does NOT prove it
+ * here: these pages ship executable inline script (welcome.html's WebMCP
+ * bootstrap, prerender.mjs's DEFERRED_STYLES_SCRIPT), which lands on the
+ * document URL too. So this is one necessary signal among several at the call
+ * site, never the whole licence on its own.
  */
 const NON_SCRIPT_URL_FRAME = (filename: string) =>
   !/\.(?:m|c)?[jt]sx?(?:[?#]|$)/.test(filename)
@@ -374,29 +376,36 @@ export function marketingBeforeSend<T extends PolicyEvent>(event: T): T | null {
       && rejectedCode >= JSON_RPC_RESERVED_MIN
       && rejectedCode <= JSON_RPC_RESERVED_MAX) return null;
 
-  // An injected script attributed to the document URL. Instagram's in-app
-  // browser was the observed case (WORLDMONITOR-115): its own chrome script
-  // dereferenced a null iframe — `null is not an object (evaluating
-  // 'e.contentWindow.postMessage')` — with every frame reading `/pro:1` /
-  // `/pro:37` and minified names (`T`, `w`, `i`, `sendMessageToIFrames`), plus
-  // breadcrumbs naming its bridge (`hxp-chat-suppression`, `IAB unified
-  // bridge`). None of those identifiers exists in either bundle.
+  // An injected script attributed to the document URL, dereferencing an iframe
+  // this bundle does not have. Instagram's in-app browser was the observed case
+  // (WORLDMONITOR-115): its own chrome script threw `null is not an object
+  // (evaluating 'e.contentWindow.postMessage')` on `/pro`, with every frame
+  // reading `/pro:1` / `/pro:37` and minified names (`T`, `w`, `i`,
+  // `sendMessageToIFrames`), plus breadcrumbs naming its bridge
+  // (`hxp-chat-suppression`, `IAB unified bridge`).
   //
-  // This ports the MECHANISM rather than another message. WORLDMONITOR-115 was
-  // the sixth instance of the same dashboard-filters-it / marketing-does-not
-  // gap (-15, -102, -108, -10N, -10T, -107) and every previous fix added one
-  // more string; a frame-shape rule retires the class instead of extending the
-  // list. It is safe here for a stronger reason than on the dashboard:
-  // `pro-test/src` holds no `contentWindow` reference at all, pinned by
-  // `tests/pro-sentry-filter-policy.test.mts`.
+  // Scoped to `contentWindow`, NOT to the frame shape alone. The first draft of
+  // this rule suppressed ANY TypeError whose frames were all non-script URLs —
+  // a straight port of the dashboard's WORLDMONITOR-V8 rule. Review showed that
+  // port is unsound HERE, because the premise it rests on does not hold on this
+  // surface: the dashboard's entry really is always a hashed chunk, but the
+  // marketing pages ship executable INLINE script, which WebKit also attributes
+  // to the document URL —
   //
-  // Gated three ways so a real defect still surfaces: the TypeError family
-  // WebKit reports for these faults, `!hasFirstParty` (a genuine bug rides a
-  // `/pro/assets/*.js` frame), and a NON-EMPTY frame list — zero frames is not
-  // "all frames are non-script URLs", and the frameless cases belong to the
-  // rules above.
+  //   - `pro-test/welcome.html` — the WebMCP bootstrap IIFE
+  //   - `pro-test/prerender.mjs` — DEFERRED_STYLES_SCRIPT, whose
+  //     `setTimeout(a, 3000)` arm runs long after Sentry has initialised
+  //
+  // A TypeError thrown in either is first-party and indistinguishable from an
+  // injected one by frame shape, so the broad rule would have silently hidden
+  // real bugs. `contentWindow` is the discriminator instead: it appears nowhere
+  // on this surface — not in `pro-test/src`, and not in the inline scripts the
+  // original source scan did not read — so an error dereferencing one can only
+  // have come from injected code. `tests/pro-sentry-filter-policy.test.mts`
+  // pins that across all three file kinds, so the licence cannot rot.
   if ((excType === 'TypeError' || /^TypeError:/.test(msg))
       && !hasFirstParty
+      && /\bcontentWindow\b/.test(msg)
       && nonInfraFrames.length > 0
       && nonInfraFrames.every((f) => NON_SCRIPT_URL_FRAME(f.filename ?? ''))) return null;
 

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -709,10 +709,15 @@ describe('marketing beforeSend — document-URL frames (WORLDMONITOR-115)', () =
   });
 
   it('drops the same shape served from the absolute document URL', () => {
-    // WebKit sometimes reports the full URL rather than the path.
+    // WebKit sometimes reports the full URL rather than the path. The message
+    // still has to carry the contentWindow evidence — the frame shape alone is
+    // deliberately not enough on this surface.
     const abs = instagramFrames.map((f) =>
       f.filename === '/pro' ? { filename: 'https://www.worldmonitor.app/pro' } : f);
-    assert.equal(marketingBeforeSend(injected('undefined is not an object (evaluating \'s[e]\')', abs)), null);
+    assert.equal(
+      marketingBeforeSend(injected("undefined is not an object (evaluating 'e.contentWindow')", abs)),
+      null,
+    );
   });
 
   it('KEEPS the same message when a marketing bundle chunk is on the stack', () => {
@@ -721,6 +726,26 @@ describe('marketing beforeSend — document-URL frames (WORLDMONITOR-115)', () =
     // the rule and this goes red.
     const withOurs = [...instagramFrames, { filename: '/pro/assets/index-A1b2C3.js' }];
     assert.ok(marketingBeforeSend(injected('null is not an object (evaluating \'e.contentWindow.postMessage\')', withOurs)) !== null);
+  });
+
+  it('KEEPS a first-party inline-script TypeError on the same frames', () => {
+    // The control this rule most needs, and the one review caught missing.
+    // These pages ship executable INLINE script — welcome.html's WebMCP
+    // bootstrap and prerender.mjs's DEFERRED_STYLES_SCRIPT, whose
+    // `setTimeout(a, 3000)` arm runs long after Sentry initialises — and WebKit
+    // attributes those to the document URL exactly like an injected one. The
+    // first draft suppressed any TypeError with this frame shape and would have
+    // hidden them. `contentWindow` is what separates the two.
+    for (const value of [
+      "null is not an object (evaluating 'l.rel')",
+      "undefined is not an object (evaluating 'MONITORS.world')",
+      'links.querySelectorAll is not a function',
+    ]) {
+      assert.ok(
+        marketingBeforeSend(injected(value)) !== null,
+        `first-party inline-script error must survive: ${value}`,
+      );
+    }
   });
 
   it('KEEPS a non-TypeError with the same frames', () => {
@@ -745,12 +770,28 @@ describe('marketing beforeSend — document-URL frames (WORLDMONITOR-115)', () =
     assert.ok(marketingBeforeSend(injected('null is not an object (evaluating \'a.b\')', [])) !== null);
   });
 
-  it('pins the marketing bundle as contentWindow-free, which licenses the rule', () => {
-    const files = readdirSync(resolve(root, 'pro-test/src'), { recursive: true, encoding: 'utf-8' })
-      .filter((f) => /\.(ts|tsx)$/.test(f) && !f.includes('sentry-filter-policy'))
-      .map((f) => readFileSync(resolve(root, 'pro-test/src', f), 'utf-8'))
-      .join('\n');
-    assert.ok(!/contentWindow/.test(files),
-      'the marketing bundle now touches an iframe contentWindow — re-derive the WORLDMONITOR-115 rule');
+  it('pins the whole surface as contentWindow-free, inline scripts included', () => {
+    // Review caught that scanning `pro-test/src` alone is not the surface: the
+    // executable inline scripts live in welcome.html and prerender.mjs, and a
+    // scan that skips them cannot license a rule about first-party code.
+    const sources = [
+      ...readdirSync(resolve(root, 'pro-test/src'), { recursive: true, encoding: 'utf-8' })
+        .filter((f) => /\.(ts|tsx)$/.test(f) && !f.includes('sentry-filter-policy'))
+        .map((f) => `pro-test/src/${f}`),
+      'pro-test/welcome.html',
+      'pro-test/index.html',
+      'pro-test/prerender.mjs',
+    ];
+    const offenders = sources.filter((rel) => /contentWindow/.test(readFileSync(resolve(root, rel), 'utf-8')));
+    assert.deepEqual(offenders, [],
+      'the marketing surface now touches an iframe contentWindow — re-derive the WORLDMONITOR-115 rule');
+
+    // The scan must actually reach the inline-script files, or the assertion
+    // above passes for the wrong reason.
+    for (const rel of ['pro-test/welcome.html', 'pro-test/prerender.mjs']) {
+      const body = readFileSync(resolve(root, rel), 'utf-8');
+      assert.ok(body.length > 500, `${rel} did not resolve`);
+      assert.match(body, /<script|SCRIPT =/, `${rel} is expected to carry inline script`);
+    }
   });
 });

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -659,3 +659,98 @@ describe('marketing beforeSend — wallet JSON-RPC rejection (WORLDMONITOR-107)'
       `walk must follow the out-of-tree imports, got ${JSON.stringify(shared)}`);
   });
 });
+
+// ─── WORLDMONITOR-115: injected scripts attributed to the document URL ────────
+//
+// Instagram's in-app browser injects its own chrome into the page and its
+// script references a null iframe: `TypeError: null is not an object
+// (evaluating 'e.contentWindow.postMessage')`, on `https://www.worldmonitor.app/pro`,
+// browser tag `Instagram 435.1.0`, with breadcrumbs naming its own bridge
+// (`hxp-chat-suppression Sending message to native bridge` / `Message sent via
+// IAB unified bridge`).
+//
+// WebKit attributes a MAIN-world injected script to the DOCUMENT URL, not to a
+// distinct `.js` file — so every frame reads `/pro:1` / `/pro:37` with minified
+// names (`T`, `w`, `i`, `sendMessageToIFrames`). None of them is a
+// `/pro/assets/*.js` chunk, so `hasFirstParty` is already false; what was
+// missing is a rule that treats "all frames are non-script URLs" as positive
+// evidence of injection.
+//
+// The dashboard has carried exactly this rule since WORLDMONITOR-V8. Porting
+// the MECHANISM rather than the message is the point: this is the sixth
+// instance of the same dashboard-filters-it / marketing-does-not gap
+// (WORLDMONITOR-15, -102, -108, -10N, -10T, -107), and each previous fix added
+// one more string. A frame-shape rule retires the class.
+//
+// Safe here for a stronger reason than on the dashboard: `pro-test/src`
+// contains no `contentWindow` reference at all, so this bundle cannot touch an
+// iframe's content window — asserted below so the claim cannot rot.
+describe('marketing beforeSend — document-URL frames (WORLDMONITOR-115)', () => {
+  /** Verbatim frame shape from the production event. */
+  const instagramFrames = [
+    { filename: '/pro' },
+    { filename: '/pro' },
+    { filename: '/pro' },
+    { filename: '/pro' },
+    { filename: '[native code]' },
+    { filename: '/pro' },
+    { filename: '/pro' },
+  ];
+
+  const injected = (value: string, frames = instagramFrames): PolicyEvent => ({
+    exception: { values: [{ type: 'TypeError', value, stacktrace: { frames } }] },
+  });
+
+  it('drops the verbatim production event', () => {
+    assert.equal(
+      marketingBeforeSend(injected("null is not an object (evaluating 'e.contentWindow.postMessage')")),
+      null,
+    );
+  });
+
+  it('drops the same shape served from the absolute document URL', () => {
+    // WebKit sometimes reports the full URL rather than the path.
+    const abs = instagramFrames.map((f) =>
+      f.filename === '/pro' ? { filename: 'https://www.worldmonitor.app/pro' } : f);
+    assert.equal(marketingBeforeSend(injected('undefined is not an object (evaluating \'s[e]\')', abs)), null);
+  });
+
+  it('KEEPS the same message when a marketing bundle chunk is on the stack', () => {
+    // The load-bearing control. A real first-party TypeError rides
+    // /pro/assets/*.js and must still report — delete the hasFirstParty half of
+    // the rule and this goes red.
+    const withOurs = [...instagramFrames, { filename: '/pro/assets/index-A1b2C3.js' }];
+    assert.ok(marketingBeforeSend(injected('null is not an object (evaluating \'e.contentWindow.postMessage\')', withOurs)) !== null);
+  });
+
+  it('KEEPS a non-TypeError with the same frames', () => {
+    // Scoped to the family WebKit reports for injected-script faults; a
+    // first-party Error thrown from an inline handler is not covered.
+    const ev: PolicyEvent = {
+      exception: { values: [{ type: 'Error', value: 'checkout failed', stacktrace: { frames: instagramFrames } }] },
+    };
+    assert.ok(marketingBeforeSend(ev) !== null);
+  });
+
+  it('KEEPS a TypeError whose frames are real script files', () => {
+    // Absence of a `.js` frame is the evidence; a stack full of them is not
+    // injection, wherever it came from.
+    const scripts = [{ filename: 'https://cdn.example.com/widget.js' }, { filename: '/pro/assets/x-Ab12Cd.js' }];
+    assert.ok(marketingBeforeSend(injected('null is not an object (evaluating \'x.y\')', scripts)) !== null);
+  });
+
+  it('KEEPS a TypeError with no frames at all', () => {
+    // Zero frames is not "all frames are non-script URLs". Other rules own the
+    // frameless cases; this one must not quietly widen to them.
+    assert.ok(marketingBeforeSend(injected('null is not an object (evaluating \'a.b\')', [])) !== null);
+  });
+
+  it('pins the marketing bundle as contentWindow-free, which licenses the rule', () => {
+    const files = readdirSync(resolve(root, 'pro-test/src'), { recursive: true, encoding: 'utf-8' })
+      .filter((f) => /\.(ts|tsx)$/.test(f) && !f.includes('sentry-filter-policy'))
+      .map((f) => readFileSync(resolve(root, 'pro-test/src', f), 'utf-8'))
+      .join('\n');
+    assert.ok(!/contentWindow/.test(files),
+      'the marketing bundle now touches an iframe contentWindow — re-derive the WORLDMONITOR-115 rule');
+  });
+});

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -13,6 +13,50 @@ import {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
+const MARKETING_INLINE_SCRIPT_FILES = [
+  'pro-test/welcome.html',
+  'pro-test/index.html',
+  'pro-test/prerender.mjs',
+] as const;
+
+let marketingSourceCache: { rel: string; code: string }[] | undefined;
+
+/**
+ * Every first-party source file the marketing bundle can execute.
+ *
+ * `pro-test/src` alone is NOT the bundle's boundary: `App.tsx` and `main.tsx`
+ * import leaf modules out of the repo-root `shared/` tree, and the HTML and
+ * prerender entrypoints contain inline scripts. The out-of-tree imports are
+ * resolved from the source so a new one is covered when it is added.
+ *
+ * Third-party package code is deliberately out of scope: `node_modules` is
+ * neither reviewable nor stable enough to assert on.
+ */
+function marketingFirstPartySources(): { rel: string; code: string }[] {
+  if (marketingSourceCache) return marketingSourceCache;
+
+  const seen = new Map<string, string>();
+  for (const f of readdirSync(resolve(root, 'pro-test/src'), { recursive: true, encoding: 'utf-8' })) {
+    if (!/\.(ts|tsx)$/.test(f)) continue;
+    const rel = `pro-test/src/${f}`;
+    seen.set(rel, readFileSync(resolve(root, rel), 'utf-8'));
+  }
+  // `from '../../shared/<mod>'` → `shared/<mod>.ts`. The shared modules in use
+  // today are import-free leaves, so one hop is the whole closure; the
+  // reachability test below keeps that assumption visible.
+  for (const code of [...seen.values()]) {
+    for (const m of code.matchAll(/from '\.\.\/\.\.\/(shared\/[\w./-]+)'/g)) {
+      const rel = `${m[1]}.ts`;
+      if (!seen.has(rel)) seen.set(rel, readFileSync(resolve(root, rel), 'utf-8'));
+    }
+  }
+  for (const rel of MARKETING_INLINE_SCRIPT_FILES) {
+    seen.set(rel, readFileSync(resolve(root, rel), 'utf-8'));
+  }
+
+  marketingSourceCache = [...seen].map(([rel, code]) => ({ rel, code }));
+  return marketingSourceCache;
+}
 
 /**
  * The marketing surface (`/` and `/pro`) runs its own `@sentry/react` client,
@@ -598,43 +642,6 @@ describe('marketing beforeSend — wallet JSON-RPC rejection (WORLDMONITOR-107)'
     }
   });
 
-  /**
-   * Every first-party source file the marketing bundle can execute.
-   *
-   * `pro-test/src` alone is NOT the bundle's boundary: `App.tsx` and `main.tsx`
-   * import leaf modules out of the repo-root `shared/` tree, so a scan stopping
-   * at `pro-test/src` stays green on JSON-RPC introduced there (greptile
-   * review, PR #7241). The out-of-tree imports are RESOLVED from the source
-   * rather than hardcoded, so a new one is covered the day it is added instead
-   * of silently widening the suppression it licenses.
-   *
-   * Third-party package code is deliberately out of scope: `node_modules` is
-   * neither reviewable nor stable enough to assert on, and the only SDK this
-   * surface loads is Clerk, which is REST. A dependency that both spoke
-   * JSON-RPC and rejected a reserved-range `{code}` into the page's
-   * `onunhandledrejection` would defeat the rule — an accepted, named limit of
-   * the tripwire rather than an oversight.
-   */
-  function marketingFirstPartySources(): { rel: string; code: string }[] {
-    const seen = new Map<string, string>();
-    for (const f of readdirSync(resolve(root, 'pro-test/src'), { recursive: true, encoding: 'utf-8' })) {
-      if (!/\.(ts|tsx)$/.test(f)) continue;
-      const rel = `pro-test/src/${f}`;
-      seen.set(rel, readFileSync(resolve(root, rel), 'utf-8'));
-    }
-    // `from '../../shared/<mod>'` → `shared/<mod>.ts`. The shared modules in use
-    // today are import-free leaves, so one hop is the whole closure; one that
-    // grew imports of its own would need this widened, which is what the
-    // reachability test below exists to keep visible.
-    for (const code of [...seen.values()]) {
-      for (const m of code.matchAll(/from '\.\.\/\.\.\/(shared\/[\w./-]+)'/g)) {
-        const rel = `${m[1]}.ts`;
-        if (!seen.has(rel)) seen.set(rel, readFileSync(resolve(root, rel), 'utf-8'));
-      }
-    }
-    return [...seen].map(([rel, code]) => ({ rel, code }));
-  }
-
   it('pins the marketing bundle as JSON-RPC-free, which is what licenses the rule', () => {
     // If a JSON-RPC client is ever added to this surface, the reserved-range
     // discriminator stops proving third-party origin and this suppression must
@@ -654,39 +661,22 @@ describe('marketing beforeSend — wallet JSON-RPC rejection (WORLDMONITOR-107)'
     const files = marketingFirstPartySources().map((f) => f.rel);
     assert.ok(files.length > 20, `walk must reach the real tree, got ${files.length} files`);
     assert.ok(files.includes('pro-test/src/App.tsx'), 'walk must include the app root');
+    for (const rel of MARKETING_INLINE_SCRIPT_FILES) {
+      assert.ok(files.includes(rel), `walk must include ${rel}`);
+    }
     const shared = files.filter((f) => f.startsWith('shared/'));
     assert.ok(shared.length >= 3,
       `walk must follow the out-of-tree imports, got ${JSON.stringify(shared)}`);
+    const nestedSharedImports = marketingFirstPartySources()
+      .filter((f) => f.rel.startsWith('shared/'))
+      .flatMap((f) => [...f.code.matchAll(/(?:import|export).*from ['"](\.[^'"]+)['"]/g)]
+        .map((match) => `${f.rel}: ${match[1]}`));
+    assert.deepEqual(nestedSharedImports, [],
+      'shared leaves gained relative imports; make the source inventory recursive');
   });
 });
 
-// ─── WORLDMONITOR-115: injected scripts attributed to the document URL ────────
-//
-// Instagram's in-app browser injects its own chrome into the page and its
-// script references a null iframe: `TypeError: null is not an object
-// (evaluating 'e.contentWindow.postMessage')`, on `https://www.worldmonitor.app/pro`,
-// browser tag `Instagram 435.1.0`, with breadcrumbs naming its own bridge
-// (`hxp-chat-suppression Sending message to native bridge` / `Message sent via
-// IAB unified bridge`).
-//
-// WebKit attributes a MAIN-world injected script to the DOCUMENT URL, not to a
-// distinct `.js` file — so every frame reads `/pro:1` / `/pro:37` with minified
-// names (`T`, `w`, `i`, `sendMessageToIFrames`). None of them is a
-// `/pro/assets/*.js` chunk, so `hasFirstParty` is already false; what was
-// missing is a rule that treats "all frames are non-script URLs" as positive
-// evidence of injection.
-//
-// The dashboard has carried exactly this rule since WORLDMONITOR-V8. Porting
-// the MECHANISM rather than the message is the point: this is the sixth
-// instance of the same dashboard-filters-it / marketing-does-not gap
-// (WORLDMONITOR-15, -102, -108, -10N, -10T, -107), and each previous fix added
-// one more string. A frame-shape rule retires the class.
-//
-// Safe here for a stronger reason than on the dashboard: `pro-test/src`
-// contains no `contentWindow` reference at all, so this bundle cannot touch an
-// iframe's content window — asserted below so the claim cannot rot.
 describe('marketing beforeSend — document-URL frames (WORLDMONITOR-115)', () => {
-  /** Verbatim frame shape from the production event. */
   const instagramFrames = [
     { filename: '/pro' },
     { filename: '/pro' },
@@ -709,9 +699,6 @@ describe('marketing beforeSend — document-URL frames (WORLDMONITOR-115)', () =
   });
 
   it('drops the same shape served from the absolute document URL', () => {
-    // WebKit sometimes reports the full URL rather than the path. The message
-    // still has to carry the contentWindow evidence — the frame shape alone is
-    // deliberately not enough on this surface.
     const abs = instagramFrames.map((f) =>
       f.filename === '/pro' ? { filename: 'https://www.worldmonitor.app/pro' } : f);
     assert.equal(
@@ -720,22 +707,60 @@ describe('marketing beforeSend — document-URL frames (WORLDMONITOR-115)', () =
     );
   });
 
+  it('drops the same shape on every marketing document route variant', () => {
+    for (const filename of [
+      '/',
+      '/?utm_source=test',
+      '/pro/',
+      '/pro#pricing',
+      'https://preview.example.com/',
+      'https://custom.example.com/pro/?utm_source=test#pricing',
+    ]) {
+      assert.equal(marketingBeforeSend(injected(
+        "null is not an object (evaluating 'e.contentWindow.postMessage')",
+        [{ filename }],
+      )), null, filename);
+    }
+  });
+
+  it('drops a TypeError-prefixed value when Sentry omits the exception type', () => {
+    const ev: PolicyEvent = {
+      exception: {
+        values: [{
+          value: "TypeError: null is not an object (evaluating 'e.contentWindow.postMessage')",
+          stacktrace: { frames: instagramFrames },
+        }],
+      },
+    };
+    assert.equal(marketingBeforeSend(ev), null);
+  });
+
   it('KEEPS the same message when a marketing bundle chunk is on the stack', () => {
-    // The load-bearing control. A real first-party TypeError rides
-    // /pro/assets/*.js and must still report — delete the hasFirstParty half of
-    // the rule and this goes red.
     const withOurs = [...instagramFrames, { filename: '/pro/assets/index-A1b2C3.js' }];
     assert.ok(marketingBeforeSend(injected('null is not an object (evaluating \'e.contentWindow.postMessage\')', withOurs)) !== null);
   });
 
+  it('KEEPS a linked event with a first-party parent exception', () => {
+    const ev: PolicyEvent = {
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: "null is not an object (evaluating 'e.contentWindow.postMessage')",
+            stacktrace: { frames: instagramFrames },
+          },
+          {
+            type: 'Error',
+            value: 'checkout failed',
+            stacktrace: { frames: [{ filename: '/pro/assets/index-A1b2C3.js' }] },
+          },
+        ],
+      },
+    };
+    assert.ok(marketingBeforeSend(ev) !== null);
+  });
+
   it('KEEPS a first-party inline-script TypeError on the same frames', () => {
-    // The control this rule most needs, and the one review caught missing.
-    // These pages ship executable INLINE script — welcome.html's WebMCP
-    // bootstrap and prerender.mjs's DEFERRED_STYLES_SCRIPT, whose
-    // `setTimeout(a, 3000)` arm runs long after Sentry initialises — and WebKit
-    // attributes those to the document URL exactly like an injected one. The
-    // first draft suppressed any TypeError with this frame shape and would have
-    // hidden them. `contentWindow` is what separates the two.
     for (const value of [
       "null is not an object (evaluating 'l.rel')",
       "undefined is not an object (evaluating 'MONITORS.world')",
@@ -749,47 +774,51 @@ describe('marketing beforeSend — document-URL frames (WORLDMONITOR-115)', () =
   });
 
   it('KEEPS a non-TypeError with the same frames', () => {
-    // Scoped to the family WebKit reports for injected-script faults; a
-    // first-party Error thrown from an inline handler is not covered.
     const ev: PolicyEvent = {
-      exception: { values: [{ type: 'Error', value: 'checkout failed', stacktrace: { frames: instagramFrames } }] },
+      exception: {
+        values: [{
+          type: 'Error',
+          value: "null is not an object (evaluating 'e.contentWindow.postMessage')",
+          stacktrace: { frames: instagramFrames },
+        }],
+      },
     };
     assert.ok(marketingBeforeSend(ev) !== null);
   });
 
   it('KEEPS a TypeError whose frames are real script files', () => {
-    // Absence of a `.js` frame is the evidence; a stack full of them is not
-    // injection, wherever it came from.
     const scripts = [{ filename: 'https://cdn.example.com/widget.js' }, { filename: '/pro/assets/x-Ab12Cd.js' }];
-    assert.ok(marketingBeforeSend(injected('null is not an object (evaluating \'x.y\')', scripts)) !== null);
+    assert.ok(marketingBeforeSend(injected(
+      "null is not an object (evaluating 'e.contentWindow.postMessage')",
+      scripts,
+    )) !== null);
+  });
+
+  it('KEEPS the same message on extensionless non-document script URLs', () => {
+    for (const filename of ['/widget', 'https://cdn.example.com/widget']) {
+      assert.ok(marketingBeforeSend(injected(
+        "null is not an object (evaluating 'e.contentWindow.postMessage')",
+        [{ filename }],
+      )) !== null, filename);
+    }
   });
 
   it('KEEPS a TypeError with no frames at all', () => {
-    // Zero frames is not "all frames are non-script URLs". Other rules own the
-    // frameless cases; this one must not quietly widen to them.
-    assert.ok(marketingBeforeSend(injected('null is not an object (evaluating \'a.b\')', [])) !== null);
+    assert.ok(marketingBeforeSend(injected(
+      "null is not an object (evaluating 'e.contentWindow.postMessage')",
+      [],
+    )) !== null);
   });
 
   it('pins the whole surface as contentWindow-free, inline scripts included', () => {
-    // Review caught that scanning `pro-test/src` alone is not the surface: the
-    // executable inline scripts live in welcome.html and prerender.mjs, and a
-    // scan that skips them cannot license a rule about first-party code.
-    const sources = [
-      ...readdirSync(resolve(root, 'pro-test/src'), { recursive: true, encoding: 'utf-8' })
-        .filter((f) => /\.(ts|tsx)$/.test(f) && !f.includes('sentry-filter-policy'))
-        .map((f) => `pro-test/src/${f}`),
-      'pro-test/welcome.html',
-      'pro-test/index.html',
-      'pro-test/prerender.mjs',
-    ];
-    const offenders = sources.filter((rel) => /contentWindow/.test(readFileSync(resolve(root, rel), 'utf-8')));
+    const sources = marketingFirstPartySources()
+      .filter((f) => !f.rel.includes('sentry-filter-policy'));
+    const offenders = sources.filter((f) => /contentWindow/.test(f.code)).map((f) => f.rel);
     assert.deepEqual(offenders, [],
       'the marketing surface now touches an iframe contentWindow — re-derive the WORLDMONITOR-115 rule');
 
-    // The scan must actually reach the inline-script files, or the assertion
-    // above passes for the wrong reason.
     for (const rel of ['pro-test/welcome.html', 'pro-test/prerender.mjs']) {
-      const body = readFileSync(resolve(root, rel), 'utf-8');
+      const body = sources.find((f) => f.rel === rel)?.code ?? '';
       assert.ok(body.length > 500, `${rel} did not resolve`);
       assert.match(body, /<script|SCRIPT =/, `${rel} is expected to carry inline script`);
     }


### PR DESCRIPTION
## Summary

Instagram's in-app browser injects a script into `/pro` that dereferences a null iframe. WebKit attributes that script to the page document, so Sentry reported only `/pro` frames and no first-party bundle frame.

The marketing filter now drops this event only when it has one `TypeError`, the message names `contentWindow`, no first-party frame exists, and every usable frame points to `/` or `/pro`. Extensionless third-party scripts, first-party chunks, inline first-party errors, frameless events, non-`TypeError` events, and linked parent errors remain reportable.

The source invariant covers the TypeScript and TSX tree, direct `shared/` leaves, and all inline marketing entrypoints. It fails if a shared leaf gains another relative import, which forces the inventory to become recursive before the suppression can widen.

Fixes WORLDMONITOR-115

## Validation

- `tsx --test tests/pro-sentry-filter-policy.test.mts`: 64 passed, 0 failed.
- `npm run typecheck`: passed.
- `npm run lint:boundaries`: passed.
- The full pre-push gate passed, including the Pro build and generated-config freshness check.
- Formal correctness, testing, reliability, adversarial, maintainability, project-standards, prior-comments, and agent-native review found no remaining actionable issue.

## Post-Deploy Monitoring & Validation

- For 24 hours after production deployment, monitor Sentry marketing events for `contentWindow`, `sendMessageToIFrames`, and WORLDMONITOR-115 on `/pro`.
- Compare the marketing JavaScript error volume and checkout error volume with the prior 24-hour baseline.
- Healthy state: WORLDMONITOR-115 receives no new matching event, and first-party marketing and checkout errors remain at baseline.
- Failure state: the same injected event still arrives, a first-party error matches the filter, or marketing or checkout errors change materially. Revert this filter commit and re-derive the boundary from the captured event.
- Owner: `@koala73`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
