### PR TITLE
feat(webmcp): expose access context and open sign-in

### DIFF
--- a/docs/webmcp.mdx
+++ b/docs/webmcp.mdx
@@ -50,7 +50,7 @@ For discovery and read-only dashboard tools, use Chrome 149 or newer:
 1. Open `chrome://flags/#enable-webmcp-testing`.
 2. Set **WebMCP for testing** to **Enabled**.
 3. Relaunch Chrome completely.
-4. Start WorldMonitor locally. Open `/dashboard` for the eight-tool dashboard, not `/embed`. To inspect the static two-tool homepage, first run `npm run build:pro`, then open `/pro/welcome.html`. The local Vite route `/` loads the dashboard SPA; only production rewrites `/` to the welcome page.
+4. Start WorldMonitor locally. Open `/dashboard` for the ten-tool dashboard, not `/embed`. To inspect the static two-tool homepage, first run `npm run build:pro`, then open `/pro/welcome.html`. The local Vite route `/` loads the dashboard SPA; only production rewrites `/` to the welcome page.
 5. Confirm feature detection in DevTools:
 
 ```js
@@ -99,7 +99,7 @@ The static `https://www.worldmonitor.app/` welcome page registers two imperative
 
 ### Dashboard imperative tools
 
-Every dashboard variant registers the same eight imperative tools. Registration is stable across sign-in and entitlement changes; each invocation rechecks the live state.
+Every dashboard variant registers the same ten imperative tools. Registration is stable across sign-in and entitlement changes; each invocation rechecks the live state.
 
 On a browser that omits the target-side invocation signal, the reversible view-state tools still run: because such a browser cannot cancel them, an invocation you abort still completes and its visible dashboard change still lands. `openCountryBrief`, `set_map_layers`, and `open_search_result` reject as unavailable there instead. The country tool can consume daily LLM allowance after caller cancellation, while the layer tools persist selection beyond the session. See [Availability](#availability).
 
@@ -113,6 +113,8 @@ On a browser that omits the target-side invocation signal, the reversible view-s
 | `set_map_layers` | Required object `layers` with 1–10 boolean entries. Keys are 1–30 characters and match `^[a-z][A-Za-z0-9_-]*$`; no additional top-level properties. | Enables or disables allowed visible layers and returns a per-layer outcome. |
 | `search_dashboard` | Required string `query`, 1–160 characters. Optional `scope`: `all`, `signals`, `map`, `panels`, or `actions` (default `all`). Optional integer `limit`: 1–10 (default 8). No additional properties. | Read-only bounded search of current country, signal, map, panel, finance, and action indexes. Returned content is marked untrusted. |
 | `open_search_result` | Required string `resultKey`, pattern `^sr_[a-f0-9]{32}$`; no additional properties. | Opens one result previously returned on this page after rechecking availability, compatibility, auth, and entitlement. |
+| `get_access_context` | Empty object; no additional properties. | Read-only snapshot of whether this tab is signed out, still loading account state, or signed in, plus product tier, capability flags, panel and dashboard-tab limits, and whether the host can cancel tools. Contains no names, emails, account IDs, tokens, or session details. |
+| `open_sign_in` | Empty object; no additional properties. | Opens the existing Clerk sign-in dialog. Does not accept credentials, one-time codes, or provider choices. Returns a stable reason when Clerk is unavailable or the dialog is already open. |
 
 `search_dashboard` returns concise descriptors rather than raw hidden dashboard state. Its opaque result keys are one-use, expire after two minutes, are bounded to the most recent 64 entries, and are invalidated when relevant runtime, authentication, entitlement, variant, or widget access changes. A stale or invalid key is denied instead of being treated as a URL or command.
 
@@ -140,6 +142,8 @@ Discover the inventory only after the page has finished registering tools. Then 
 | Disable a currently enabled map layer | `get_dashboard_context` → `set_map_layers` | `get_dashboard_context` returns only enabled layer IDs. Pass one of those exact IDs to `set_map_layers`, and inspect every target result because one request can apply allowed layers and deny other layers. |
 | Find and enable a disabled map layer | `search_dashboard` with `scope: "map"` → present the exact result → `open_search_result` | Use the exact one-use `resultKey` returned by search. Use `set_map_layers` only when the person or trusted current state supplied the exact layer ID; never guess an ID. |
 | Open a country brief | `openCountryBrief` | Use an uppercase ISO alpha-2 code. This path can consume the signed-in person's daily LLM allowance and is unavailable when the browser cannot deliver target-side cancellation. |
+| Identify whether this tab is signed out, loading, or signed in | `get_access_context` | Use `accountState`, `clerk`, `productTier`, capability flags, and limits. The result never includes names, emails, account IDs, tokens, or session details. |
+| Open the existing sign-in dialog | `get_access_context` → `open_sign_in` when `accountState` is `signed_out` and `clerk` is not `unavailable` | `open_sign_in` never accepts credentials, one-time codes, or provider choices. If Clerk is unavailable or already open, use the returned reason. Do not collect a password or OTP through WebMCP. |
 | Search procurement | `get_dashboard_context` → open the enabled Global Procurement panel, or ask the person to enable it → discover `search_procurement` → invoke it | `open_dashboard_panel` cannot enable a disabled panel. The declarative tool exists only while the entitled form is connected, visible, data-ready, and idle. Its disappearance is a state change, not a registration failure. |
 
 Do not guess panel IDs, layer IDs, result keys, entitlements, or hidden data. Read the current page state, invoke one bounded action, inspect its result and visible effect, then continue.
@@ -175,6 +179,7 @@ WorldMonitor follows the browser's origin-isolated, same-origin model:
 - WorldMonitor does not grant WebMCP access to another origin with `fromOrigins`, `exposedTo`, or an iframe `allow="tools"` delegation.
 - `/embed` and `/embed.html` explicitly send `tools=()`. An embedded WorldMonitor panel must expose no WebMCP tools, even when its parent page has WebMCP access.
 - WebMCP uses the person's existing browser session. It does not accept a new API key through tool arguments or weaken panel and data entitlements.
+- `get_access_context` reports only account state, product tier, capability flags, and limits. It never includes names, emails, account IDs, tokens, or session details. `open_sign_in` opens the existing Clerk dialog and never accepts credentials.
 - Dashboard search results are treated as untrusted content and are revalidated before selection.
 - Dashboard operational telemetry is bounded: `webmcp-registered` records `toolCount`, `pageSurface`, and the API bucket; `webmcp-registration-failed` records the tool and a stable reason; `webmcp-tool-invoked` records the tool, outcome, and terminal reason. Dashboard search may additionally record query length, result count, and allowlisted result-type buckets. These WebMCP-specific custom properties must not include arguments, search text, result keys, returned content, URLs, tender content, or user identity. The events still use WorldMonitor's normal Umami page and session envelope, which includes page context and may be associated with the signed-in dashboard identity; the restricted path omits automatic content-attribution properties, not normal analytics session metadata.
 
@@ -312,6 +317,7 @@ Treat a WebMCP change as a public UI contract change, even when the implementati
 | `src/config/webmcp.ts` | Canonical homepage, dashboard, declarative, and per-variant inventories; shared schema and output budgets. |
 | `src/services/webmcp.ts` | Imperative tool descriptors, schemas, registration lifecycle, safe result/error boundaries, telemetry, and cancellation policy. |
 | `src/App.ts` and `src/app/webmcp-dashboard.ts` | Startup ordering, UI-readiness gate, teardown, dashboard context, and human-path action binding. |
+| `src/app/webmcp-access.ts` and `src/services/webmcp-access-snapshot.ts` | Live access-context reader, PII-free snapshot builder, and Clerk sign-in open. |
 | `src/app/webmcp-search-controller.ts` and `src/app/search-selection-dispatcher.ts` | Opaque search capabilities, invalidation, live-state revalidation, and visible result selection. |
 | `src/components/GlobalProcurementPanel.ts` | Conditional declarative `search_procurement` form, visible pending state, reset, cancellation, and bounded result. |
 | `pro-test/welcome.html` | Zero-import homepage registration for `launchWorldMonitor` and `getWorldMonitorMcpEndpoint`. |
@@ -334,6 +340,7 @@ npm run docs:check
   tests/webmcp-runtime.test.mjs \
   tests/webmcp-analytics-policy.test.mjs \
   tests/webmcp-evals.test.mjs \
+  tests/webmcp-access.test.mts \
   tests/deploy-config.test.mjs
 npm run typecheck
 ```

--- a/docs/zh/webmcp.mdx
+++ b/docs/zh/webmcp.mdx
@@ -50,7 +50,7 @@ Origin Trial 令牌有时限。发布检查必须验证实际部署的响应头�
 1. 打开 `chrome://flags/#enable-webmcp-testing`。
 2. 将 **WebMCP for testing** 设为 **Enabled**。
 3. 完全重新启动 Chrome。
-4. 本地启动 WorldMonitor。打开 `/dashboard` 检查含八个工具的仪表板；不要使用 `/embed`。若要检查含两个工具的静态首页，请先运行 `npm run build:pro`，再打开 `/pro/welcome.html`。本地 Vite 的 `/` 会加载仪表板 SPA，只有生产环境才把 `/` 重写到欢迎页。
+4. 本地启动 WorldMonitor。打开 `/dashboard` 检查含十个工具的仪表板；不要使用 `/embed`。若要检查含两个工具的静态首页，请先运行 `npm run build:pro`，再打开 `/pro/welcome.html`。本地 Vite 的 `/` 会加载仪表板 SPA，只有生产环境才把 `/` 重写到欢迎页。
 5. 在 DevTools 中确认特性检测：
 
 ```js
@@ -99,7 +99,7 @@ Chrome 149–151 虽已暴露 `registerTool()`，但调用已注册回调时只�
 
 ### 仪表板命令式工具
 
-六个仪表板变体都注册相同的八个命令式工具。登录和权益变化不会改变注册集合；每次调用都会重新检查实时状态。
+六个仪表板变体都注册相同的十个命令式工具。登录和权益变化不会改变注册集合；每次调用都会重新检查实时状态。
 
 在没有提供目标侧调用信号的浏览器上，可逆的视图状态工具仍会执行：由于此类浏览器无法取消它们，你中止的调用仍会执行完毕，其可见的仪表板变化也会生效。而 `openCountryBrief`、`set_map_layers` 与 `open_search_result` 会返回不可用。国家简报工具可能在调用方取消后继续消耗每日 LLM 额度，后两个工具则会把图层选择持久化并影响本次会话之外的状态。参见[可用性](#availability)。
 
@@ -113,6 +113,8 @@ Chrome 149–151 虽已暴露 `registerTool()`，但调用已注册回调时只�
 | `set_map_layers` | 必填对象 `layers`，含 1–10 个布尔项；键长 1–30，匹配 `^[a-z][A-Za-z0-9_-]*$`；顶层不允许其他属性。 | 启用或禁用允许的可见图层，并返回逐图层结果。 |
 | `search_dashboard` | 必填字符串 `query`，长度 1–160；可选 `scope` 为 `all`、`signals`、`map`、`panels`、`actions`，默认 `all`；可选整数 `limit` 为 1–10，默认 8；不允许其他属性。 | 只读、受限地搜索当前国家、信号、地图、面板、金融和动作索引；返回内容标记为不可信。 |
 | `open_search_result` | 必填字符串 `resultKey`，模式 `^sr_[a-f0-9]{32}$`；不允许其他属性。 | 重新检查可用性、兼容性、认证和权益后，打开本页此前返回的一项结果。 |
+| `get_access_context` | 空对象；不允许其他属性。 | 只读返回此标签页是已退出、仍在加载账户状态，还是已登录，以及产品档位、能力标志、面板与仪表板标签页限额，以及主机能否取消工具。不包含姓名、电子邮件、账户 ID、令牌或会话详情。 |
+| `open_sign_in` | 空对象；不允许其他属性。 | 打开本页现有的 Clerk 登录对话框。不接受凭据、一次性验证码或身份提供方选择。当 Clerk 不可用或对话框已打开时，返回稳定原因。 |
 
 `search_dashboard` 返回精简描述符，不暴露隐藏仪表板状态。不透明结果键只能使用一次，两分钟后过期，最多保留最近 64 个；相关运行时、认证、权益、变体或组件访问发生变化时也会失效。过期或无效键会被拒绝，不会被当作 URL 或命令执行。
 
@@ -140,6 +142,8 @@ Chrome 149–151 虽已暴露 `registerTool()`，但调用已注册回调时只�
 | 禁用当前已启用的地图图层 | `get_dashboard_context` → `set_map_layers` | `get_dashboard_context` 只返回已启用的图层 ID。把其中一个精确 ID 传给 `set_map_layers`；检查每个目标结果，因为同一请求可能应用允许的图层，同时拒绝其他图层。 |
 | 查找并启用已禁用的地图图层 | 使用 `scope: "map"` 调用 `search_dashboard` → 展示精确结果 → `open_search_result` | 使用搜索返回的精确一次性 `resultKey`。仅当用户或可信的当前状态提供了精确图层 ID 时，才使用 `set_map_layers`；不得猜测 ID。 |
 | 打开国家简报 | `openCountryBrief` | 使用大写 ISO alpha-2 代码。该路径可能消耗已登录用户的每日 LLM 配额；若浏览器不能提供目标侧取消，则该工具不可用。 |
+| 判断此标签页是已退出、仍在加载，还是已登录 | `get_access_context` | 使用 `accountState`、`clerk`、`productTier`、能力标志和限额。结果绝不包含姓名、电子邮件、账户 ID、令牌或会话详情。 |
+| 打开现有登录对话框 | 在 `accountState` 为 `signed_out` 且 `clerk` 不是 `unavailable` 时，使用 `get_access_context` → `open_sign_in` | `open_sign_in` 永不接受凭据、一次性验证码或身份提供方选择。若 Clerk 不可用或对话框已打开，使用返回的原因。不要通过 WebMCP 收集密码或 OTP。 |
 | 搜索采购机会 | `get_dashboard_context` → 打开已启用的全球采购面板，或请用户启用它 → 发现 `search_procurement` → 调用 | `open_dashboard_panel` 不能启用已禁用的面板。只有当有权益的表单已连接、可见、数据就绪且空闲时，该声明式工具才存在。工具消失表示状态变化，并非注册失败。 |
 
 不要猜测面板 ID、图层 ID、结果键、权益或隐藏数据。先读取当前页面状态，再调用一个受限操作，检查结果和可见效果，然后继续。
@@ -175,6 +179,7 @@ WorldMonitor 遵循浏览器的源隔离和同源模型：
 - WorldMonitor 不通过 `fromOrigins`、`exposedTo` 或 iframe 的 `allow="tools"` 委派向其他源开放 WebMCP。
 - `/embed` 和 `/embed.html` 明确发送 `tools=()`。即使父页面拥有 WebMCP，嵌入的 WorldMonitor 面板也不得暴露任何工具。
 - WebMCP 复用用户现有浏览器会话，不通过工具参数接受新的 API 密钥，也不会弱化面板和数据权益。
+- `get_access_context` 只报告账户状态、产品档位、能力标志和限额，绝不包含姓名、电子邮件、账户 ID、令牌或会话详情。`open_sign_in` 只打开现有 Clerk 对话框，永不接受凭据。
 - 仪表板搜索结果按不可信内容处理，并在选择前重新验证。
 - 仪表板运行遥测严格受限：`webmcp-registered` 记录 `toolCount`、`pageSurface` 和 API 类别；`webmcp-registration-failed` 记录工具及稳定原因；`webmcp-tool-invoked` 记录工具、结果和终态原因。仪表板搜索还可以记录查询长度、结果数及允许列表内的结果类型类别。这些 WebMCP 专用自定义属性不得包含参数、搜索文本、结果键、返回内容、URL、招标内容或用户身份。事件仍使用 WorldMonitor 常规的 Umami 页面与会话外层信息，其中包含页面上下文，并可能与已登录的仪表板身份关联；受限路径只会省略自动内容归因属性，不会移除常规分析会话元数据。
 
@@ -312,6 +317,7 @@ npm run test:e2e:webmcp:production
 | `src/config/webmcp.ts` | 规范的首页、仪表板、声明式和逐变体清单，以及共享 schema 和输出预算。 |
 | `src/services/webmcp.ts` | 命令式工具描述符、schema、注册生命周期、安全结果/错误边界、遥测和取消策略。 |
 | `src/App.ts` 和 `src/app/webmcp-dashboard.ts` | 启动顺序、UI 就绪门禁、销毁、仪表板上下文和人工路径操作绑定。 |
+| `src/app/webmcp-access.ts` 和 `src/services/webmcp-access-snapshot.ts` | 实时访问上下文读取、无个人身份信息的快照构建，以及 Clerk 登录打开。 |
 | `src/app/webmcp-search-controller.ts` 和 `src/app/search-selection-dispatcher.ts` | 不透明搜索能力、失效、实时状态复核和可见结果选择。 |
 | `src/components/GlobalProcurementPanel.ts` | 条件式声明工具 `search_procurement` 的表单、可见等待状态、重置、取消和受限结果。 |
 | `pro-test/welcome.html` | `launchWorldMonitor` 和 `getWorldMonitorMcpEndpoint` 的零导入首页注册。 |
@@ -334,6 +340,7 @@ npm run docs:check
   tests/webmcp-runtime.test.mjs \
   tests/webmcp-analytics-policy.test.mjs \
   tests/webmcp-evals.test.mjs \
+  tests/webmcp-access.test.mts \
   tests/deploy-config.test.mjs
 npm run typecheck
 ```

--- a/e2e/webmcp.spec.ts
+++ b/e2e/webmcp.spec.ts
@@ -318,17 +318,35 @@ test.describe('top-level WebMCP dashboard contract', () => {
       reason?: string;
       status?: string;
     };
-    if (accessAndSignIn.clerkModalPresent) {
-      expect(signInResult).toEqual(expect.objectContaining({
-        ok: true,
-        status: expect.stringMatching(/^(opened|already_open)$/),
-      }));
-    } else {
+    const accessSnapshot = accessAndSignIn.access as { clerk?: string };
+    const signInEvidence = {
+      clerk: accessSnapshot.clerk ?? null,
+      clerkModalPresent: accessAndSignIn.clerkModalPresent,
+      signInResult,
+    };
+    // Production must prove the real Clerk modal. The clerk_unavailable
+    // denial is only valid on the local Vite fixture, where Clerk is
+    // explicitly unconfigured (`clerk: unavailable`).
+    const unconfiguredLocalFixture =
+      !productionSmoke && accessSnapshot.clerk === 'unavailable';
+    if (unconfiguredLocalFixture) {
       expect(signInResult).toEqual({
         ok: false,
         status: 'denied',
         reason: 'clerk_unavailable',
       });
+      expect(accessAndSignIn.clerkModalPresent).toBe(false);
+    } else {
+      expect(
+        accessAndSignIn.clerkModalPresent,
+        productionSmoke
+          ? 'production smoke must open the real Clerk sign-in modal'
+          : 'configured Clerk must open the real sign-in modal',
+      ).toBe(true);
+      expect(signInResult).toEqual(expect.objectContaining({
+        ok: true,
+        status: expect.stringMatching(/^(opened|already_open)$/),
+      }));
     }
 
     const panelProbe = await page.evaluate(async (): Promise<MutationExecutionProbe> => {
@@ -469,6 +487,7 @@ test.describe('top-level WebMCP dashboard contract', () => {
           targetCancellationSupported: coldStart.targetCancellationSupported,
           ...panelProbe,
         },
+        signIn: { tool: 'open_sign_in', ...signInEvidence },
         ...(visibleMutation ? { visibleMutation: { tool: 'openSearch', ...visibleMutation } } : {}),
       },
     });

--- a/e2e/webmcp.spec.ts
+++ b/e2e/webmcp.spec.ts
@@ -8,11 +8,13 @@ const productionSmoke = process.env.WM_WEBMCP_PRODUCTION === '1';
 const deployedSha = process.env.WM_WEBMCP_DEPLOYED_SHA?.trim() || null;
 
 const DASHBOARD_TOOL_NAMES = [
+  'get_access_context',
   'get_dashboard_context',
   'openCountryBrief',
   'openSearch',
   'open_dashboard_panel',
   'open_search_result',
+  'open_sign_in',
   'search_dashboard',
   'set_map_layers',
   'set_map_view',
@@ -234,12 +236,99 @@ test.describe('top-level WebMCP dashboard contract', () => {
       expect(tool.description.length, `${tool.name} description budget`).toBeLessThanOrEqual(500);
       expect(tool.schema, `${tool.name} schema`).toMatchObject({ type: 'object' });
       expect(tool.annotations.readOnlyHint, `${tool.name} readOnlyHint`).toBe(
-        ['get_dashboard_context', 'search_dashboard'].includes(tool.name),
+        ['get_access_context', 'get_dashboard_context', 'search_dashboard'].includes(tool.name),
       );
       expect(
         Boolean(tool.annotations.untrustedContentHint),
         `${tool.name} untrustedContentHint`,
       ).toBe(tool.name === 'search_dashboard');
+    }
+
+    const accessContract = discoveredContracts.find((tool) => tool.name === 'get_access_context');
+    const signInContract = discoveredContracts.find((tool) => tool.name === 'open_sign_in');
+    expect(accessContract?.schema).toMatchObject({ type: 'object', additionalProperties: false });
+    expect(accessContract?.schema.properties ?? {}).toEqual({});
+    expect(signInContract?.schema).toMatchObject({ type: 'object', additionalProperties: false });
+    expect(Object.keys(signInContract?.schema.properties ?? {})).toEqual([]);
+    expect(JSON.stringify(signInContract?.schema ?? {})).not.toMatch(
+      /password|otp|one[-_]?time|credential|provider/i,
+    );
+
+    const accessAndSignIn = await page.evaluate(async () => {
+      type ExecutableModelContext = WebMCP.ModelContext & {
+        executeTool(
+          tool: WebMCP.RegisteredTool,
+          input: string,
+          options?: { signal?: AbortSignal },
+        ): Promise<unknown>;
+      };
+      const provider = document.modelContext as ExecutableModelContext | undefined;
+      if (!provider || typeof provider.executeTool !== 'function') {
+        throw new Error('Chrome WebMCP execution API is unavailable.');
+      }
+      const parseOutput = (value: unknown): unknown => {
+        if (typeof value !== 'string') return value;
+        try {
+          return JSON.parse(value);
+        } catch {
+          return value;
+        }
+      };
+      const tools = await provider.getTools();
+      const byName = new Map(tools.map((tool) => [tool.name, tool]));
+      const accessTool = byName.get('get_access_context');
+      const signInTool = byName.get('open_sign_in');
+      if (!accessTool || !signInTool) {
+        throw new Error('Expected access and sign-in tools were not discovered.');
+      }
+      const access = parseOutput(await provider.executeTool(accessTool, JSON.stringify({})));
+      let signInError: { message?: string; name?: string } | null = null;
+      let signInResult: unknown;
+      try {
+        signInResult = parseOutput(await provider.executeTool(signInTool, JSON.stringify({})));
+      } catch (error) {
+        signInError = {
+          name: error instanceof Error ? error.name : undefined,
+          message: error instanceof Error ? error.message : String(error),
+        };
+      }
+      return {
+        access,
+        clerkModalPresent: Boolean(document.querySelector(
+          '.cl-modalBackdrop, .cl-modal, [data-clerk-component="SignIn"]',
+        )),
+        signInError,
+        signInResult,
+      };
+    });
+    expect(accessAndSignIn.access).toEqual(expect.objectContaining({
+      accountState: expect.stringMatching(/^(signed_out|loading|signed_in)$/),
+      clerk: expect.stringMatching(/^(unavailable|loading|ready)$/),
+    }));
+    expect(JSON.stringify(accessAndSignIn.access)).not.toMatch(
+      /@|user_|pk_test_|sk_live_|Bearer |sessionId|"email"|"name"|"token"/i,
+    );
+    if (accessAndSignIn.signInError) {
+      throw new Error(
+        `open_sign_in must return a bounded result, not throw: ${accessAndSignIn.signInError.name}: ${accessAndSignIn.signInError.message}`,
+      );
+    }
+    const signInResult = accessAndSignIn.signInResult as {
+      ok?: boolean;
+      reason?: string;
+      status?: string;
+    };
+    if (accessAndSignIn.clerkModalPresent) {
+      expect(signInResult).toEqual(expect.objectContaining({
+        ok: true,
+        status: expect.stringMatching(/^(opened|already_open)$/),
+      }));
+    } else {
+      expect(signInResult).toEqual({
+        ok: false,
+        status: 'denied',
+        reason: 'clerk_unavailable',
+      });
     }
 
     const panelProbe = await page.evaluate(async (): Promise<MutationExecutionProbe> => {

--- a/src/App.ts
+++ b/src/App.ts
@@ -1983,7 +1983,7 @@ export class App {
         if (this.state.isDestroyed) {
           throw new DashboardBindingError('app_destroyed', 'Dashboard is no longer available.');
         }
-        return openWebMcpSignIn();
+        return openWebMcpSignIn(execution?.signal);
       },
     });
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -1976,6 +1976,7 @@ export class App {
         return getWebMcpAccessContext({
           enabledPanelUsed: countFreePanelCapUsage(this.state.panelSettings),
           dashboardTabCount: this.panelLayout.getDashboardTabCount(),
+          freeTierFallbackActive: this.freeTierGate.authSettleDeadlineExceeded,
         });
       },
       openSignIn: async (execution) => {

--- a/src/App.ts
+++ b/src/App.ts
@@ -27,6 +27,7 @@ import {
   shouldDeferFreeTierEnforcement,
   FREE_MAX_PANELS,
   FREE_MAX_SOURCES,
+  countFreePanelCapUsage,
 } from '@/config';
 import {
   sanitizeLayersForVariant,
@@ -172,6 +173,7 @@ import {
   WEBMCP_UI_READY_TIMEOUT_MS,
   waitForWebMcpUiReady,
 } from '@/app/webmcp-dashboard';
+import { getWebMcpAccessContext, openWebMcpSignIn } from '@/app/webmcp-access';
 import { runDashboardActionBinding } from '@/app/dashboard-action-binding';
 import { refreshDataFreshnessFromHealth } from '@/services/health-freshness';
 import { scheduleAfterFirstPaint } from '@/utils/after-paint';
@@ -1965,6 +1967,23 @@ export class App {
           () => this.waitForDashboardReady(true, execution?.signal),
           execution?.signal,
         );
+      },
+      getAccessContext: async (execution) => {
+        throwIfWebMcpAborted(execution?.signal);
+        if (this.state.isDestroyed) {
+          throw new DashboardBindingError('app_destroyed', 'Dashboard is no longer available.');
+        }
+        return getWebMcpAccessContext({
+          enabledPanelUsed: countFreePanelCapUsage(this.state.panelSettings),
+          dashboardTabCount: this.panelLayout.getDashboardTabCount(),
+        });
+      },
+      openSignIn: async (execution) => {
+        throwIfWebMcpAborted(execution?.signal);
+        if (this.state.isDestroyed) {
+          throw new DashboardBindingError('app_destroyed', 'Dashboard is no longer available.');
+        }
+        return openWebMcpSignIn();
       },
     });
 

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1213,9 +1213,9 @@ export class PanelLayoutManager implements AppModule {
   // Dashboard tabs — named, persistent panel workspaces
   // ============================================
 
-  /** Live dashboard-tab count for access-context limits. At least one workspace. */
+  /** Dashboard workspaces always include at least one tab. */
   public getDashboardTabCount(): number {
-    if (this.tabsState?.tabs.length) return this.tabsState.tabs.length;
+    if (this.tabsState) return Math.max(1, this.tabsState.tabs.length);
     const stored = loadTabsState();
     return stored?.tabs.length ?? 1;
   }

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1213,6 +1213,13 @@ export class PanelLayoutManager implements AppModule {
   // Dashboard tabs — named, persistent panel workspaces
   // ============================================
 
+  /** Live dashboard-tab count for access-context limits. At least one workspace. */
+  public getDashboardTabCount(): number {
+    if (this.tabsState?.tabs.length) return this.tabsState.tabs.length;
+    const stored = loadTabsState();
+    return stored?.tabs.length ?? 1;
+  }
+
   private initPanelTabs(): void {
     const mount = document.getElementById('panelTabsMount');
     if (!mount) return;

--- a/src/app/webmcp-access.ts
+++ b/src/app/webmcp-access.ts
@@ -83,7 +83,7 @@ export async function openWebMcpSignIn(signal?: AbortSignal): Promise<OpenSignIn
   }
 
   throwIfWebMcpAborted(signal);
-  const opened = await openSignInAndWait();
+  const opened = await raceWebMcpAbort(openSignInAndWait(signal), signal);
   if (!opened) return { ok: false, status: 'denied', reason: 'clerk_unavailable' };
   return { ok: true, status: 'opened' };
 }

--- a/src/app/webmcp-access.ts
+++ b/src/app/webmcp-access.ts
@@ -13,14 +13,19 @@ import { hasPremiumAccess } from '@/services/panel-gating';
 import {
   buildWebMcpAccessContext,
   resolveWebMcpOpenSignIn,
+  type OpenSignInDecision,
 } from '@/services/webmcp-access-snapshot';
 import type { AccessContextSnapshot, OpenSignInResult } from '@/services/webmcp';
 
-export {
-  ACCESS_CONTEXT_PRIVACY_KEYS,
-  buildWebMcpAccessContext,
-  resolveWebMcpOpenSignIn,
-} from '@/services/webmcp-access-snapshot';
+function currentOpenSignInDecision(loadFailed = false): OpenSignInDecision {
+  const clerkReady = isClerkReady();
+  return resolveWebMcpOpenSignIn({
+    clerkEnabled: isClerkAuthEnabled(),
+    clerkReady,
+    alreadyOpen: clerkReady && isClerkSignInOpen(),
+    loadFailed,
+  });
+}
 
 export function getWebMcpAccessContext(options: {
   enabledPanelUsed: number;
@@ -41,25 +46,18 @@ export function getWebMcpAccessContext(options: {
 }
 
 export async function openWebMcpSignIn(): Promise<OpenSignInResult> {
-  const decision = resolveWebMcpOpenSignIn({
-    clerkEnabled: isClerkAuthEnabled(),
-    clerkReady: isClerkReady(),
-    alreadyOpen: isClerkSignInOpen(),
-  });
+  let decision = currentOpenSignInDecision();
   if ('reason' in decision) return decision;
 
   if (decision.action === 'load_and_open') {
+    let loadFailed = false;
     try {
       await initClerk();
     } catch {
-      return { ok: false, status: 'denied', reason: 'clerk_unavailable' };
+      loadFailed = true;
     }
-    if (!isClerkReady()) {
-      return { ok: false, status: 'denied', reason: 'clerk_unavailable' };
-    }
-    if (isClerkSignInOpen()) {
-      return { ok: true, status: 'already_open', reason: 'already_open' };
-    }
+    decision = currentOpenSignInDecision(loadFailed || !isClerkReady());
+    if ('reason' in decision) return decision;
   }
 
   const opened = await openSignInAndWait();

--- a/src/app/webmcp-access.ts
+++ b/src/app/webmcp-access.ts
@@ -36,6 +36,7 @@ function currentOpenSignInDecision(loadFailed = false): OpenSignInDecision {
 export function getWebMcpAccessContext(options: {
   enabledPanelUsed: number;
   dashboardTabCount: number;
+  freeTierFallbackActive: boolean;
 }): AccessContextSnapshot {
   const auth = getAuthState();
   return buildWebMcpAccessContext({
@@ -48,6 +49,7 @@ export function getWebMcpAccessContext(options: {
     enabledPanelUsed: options.enabledPanelUsed,
     dashboardTabCount: options.dashboardTabCount,
     freePanelCap: FREE_MAX_PANELS,
+    freeTierFallbackActive: options.freeTierFallbackActive === true,
     dataExport: evaluateExportGate(auth).locked === false,
   });
 }

--- a/src/app/webmcp-access.ts
+++ b/src/app/webmcp-access.ts
@@ -1,3 +1,4 @@
+import { WEBMCP_UI_READY_TIMEOUT_MS } from '@/app/webmcp-dashboard';
 import { FREE_MAX_PANELS } from '@/config/panels';
 import { getAuthState } from '@/services/auth-state';
 import {
@@ -8,14 +9,19 @@ import {
   openSignInAndWait,
 } from '@/services/clerk';
 import { getEntitlementState } from '@/services/entitlements';
-import { evaluateTabCap } from '@/services/gates/export';
+import { evaluateExportGate, evaluateTabCap } from '@/services/gates/export';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import {
   buildWebMcpAccessContext,
   resolveWebMcpOpenSignIn,
   type OpenSignInDecision,
 } from '@/services/webmcp-access-snapshot';
-import type { AccessContextSnapshot, OpenSignInResult } from '@/services/webmcp';
+import {
+  raceWebMcpAbort,
+  throwIfWebMcpAborted,
+  type AccessContextSnapshot,
+  type OpenSignInResult,
+} from '@/services/webmcp';
 
 function currentOpenSignInDecision(loadFailed = false): OpenSignInDecision {
   const clerkReady = isClerkReady();
@@ -42,24 +48,41 @@ export function getWebMcpAccessContext(options: {
     enabledPanelUsed: options.enabledPanelUsed,
     dashboardTabCount: options.dashboardTabCount,
     freePanelCap: FREE_MAX_PANELS,
+    dataExport: evaluateExportGate(auth).locked === false,
   });
 }
 
-export async function openWebMcpSignIn(): Promise<OpenSignInResult> {
+async function loadClerkForSignIn(
+  signal?: AbortSignal,
+): Promise<'ready' | 'failed' | 'timeout'> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  // Do not abort or null Clerk's shared loadPromise — a cancelled or timed-out
+  // tool must leave an in-flight SDK load running for the rest of the tab.
+  const loaded = initClerk()
+    .then((): 'ready' => 'ready')
+    .catch((): 'failed' => 'failed');
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), WEBMCP_UI_READY_TIMEOUT_MS);
+  });
+  try {
+    return await raceWebMcpAbort(Promise.race([loaded, timeout]), signal);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+export async function openWebMcpSignIn(signal?: AbortSignal): Promise<OpenSignInResult> {
+  throwIfWebMcpAborted(signal);
   let decision = currentOpenSignInDecision();
   if ('reason' in decision) return decision;
 
   if (decision.action === 'load_and_open') {
-    let loadFailed = false;
-    try {
-      await initClerk();
-    } catch {
-      loadFailed = true;
-    }
-    decision = currentOpenSignInDecision(loadFailed || !isClerkReady());
+    const outcome = await loadClerkForSignIn(signal);
+    decision = currentOpenSignInDecision(outcome !== 'ready' || !isClerkReady());
     if ('reason' in decision) return decision;
   }
 
+  throwIfWebMcpAborted(signal);
   const opened = await openSignInAndWait();
   if (!opened) return { ok: false, status: 'denied', reason: 'clerk_unavailable' };
   return { ok: true, status: 'opened' };

--- a/src/app/webmcp-access.ts
+++ b/src/app/webmcp-access.ts
@@ -1,0 +1,68 @@
+import { FREE_MAX_PANELS } from '@/config/panels';
+import { getAuthState } from '@/services/auth-state';
+import {
+  initClerk,
+  isClerkAuthEnabled,
+  isClerkReady,
+  isClerkSignInOpen,
+  openSignInAndWait,
+} from '@/services/clerk';
+import { getEntitlementState } from '@/services/entitlements';
+import { evaluateTabCap } from '@/services/gates/export';
+import { hasPremiumAccess } from '@/services/panel-gating';
+import {
+  buildWebMcpAccessContext,
+  resolveWebMcpOpenSignIn,
+} from '@/services/webmcp-access-snapshot';
+import type { AccessContextSnapshot, OpenSignInResult } from '@/services/webmcp';
+
+export {
+  ACCESS_CONTEXT_PRIVACY_KEYS,
+  buildWebMcpAccessContext,
+  resolveWebMcpOpenSignIn,
+} from '@/services/webmcp-access-snapshot';
+
+export function getWebMcpAccessContext(options: {
+  enabledPanelUsed: number;
+  dashboardTabCount: number;
+}): AccessContextSnapshot {
+  const auth = getAuthState();
+  return buildWebMcpAccessContext({
+    auth,
+    clerkEnabled: isClerkAuthEnabled(),
+    clerkReady: isClerkReady(),
+    premiumAccess: hasPremiumAccess(auth),
+    entitlement: getEntitlementState(),
+    tabCap: evaluateTabCap(auth, options.dashboardTabCount),
+    enabledPanelUsed: options.enabledPanelUsed,
+    dashboardTabCount: options.dashboardTabCount,
+    freePanelCap: FREE_MAX_PANELS,
+  });
+}
+
+export async function openWebMcpSignIn(): Promise<OpenSignInResult> {
+  const decision = resolveWebMcpOpenSignIn({
+    clerkEnabled: isClerkAuthEnabled(),
+    clerkReady: isClerkReady(),
+    alreadyOpen: isClerkSignInOpen(),
+  });
+  if ('reason' in decision) return decision;
+
+  if (decision.action === 'load_and_open') {
+    try {
+      await initClerk();
+    } catch {
+      return { ok: false, status: 'denied', reason: 'clerk_unavailable' };
+    }
+    if (!isClerkReady()) {
+      return { ok: false, status: 'denied', reason: 'clerk_unavailable' };
+    }
+    if (isClerkSignInOpen()) {
+      return { ok: true, status: 'already_open', reason: 'already_open' };
+    }
+  }
+
+  const opened = await openSignInAndWait();
+  if (!opened) return { ok: false, status: 'denied', reason: 'clerk_unavailable' };
+  return { ok: true, status: 'opened' };
+}

--- a/src/config/webmcp.ts
+++ b/src/config/webmcp.ts
@@ -22,6 +22,8 @@ export const WEBMCP_SPA_TOOL = Object.freeze({
   setMapLayers: 'set_map_layers',
   searchDashboard: 'search_dashboard',
   openSearchResult: 'open_search_result',
+  getAccessContext: 'get_access_context',
+  openSignIn: 'open_sign_in',
 } as const);
 
 export const WEBMCP_SPA_TOOL_NAMES = [
@@ -33,6 +35,8 @@ export const WEBMCP_SPA_TOOL_NAMES = [
   WEBMCP_SPA_TOOL.setMapLayers,
   WEBMCP_SPA_TOOL.searchDashboard,
   WEBMCP_SPA_TOOL.openSearchResult,
+  WEBMCP_SPA_TOOL.getAccessContext,
+  WEBMCP_SPA_TOOL.openSignIn,
 ] as const;
 
 export const WEBMCP_DECLARATIVE_TOOL_NAMES = [

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -445,9 +445,13 @@ export function runClerkSurfaceOpen(
   }
 }
 
+function openLoadedClerkSignIn(): void {
+  clerkInstance?.openSignIn({ appearance: getAppearance() });
+}
+
 function openClerkSurface(action: 'open-sign-in' | 'open-sign-up'): void {
   const open = action === 'open-sign-in'
-    ? () => clerkInstance?.openSignIn({ appearance: getAppearance() })
+    ? openLoadedClerkSignIn
     : () => clerkInstance?.openSignUp({ appearance: getAppearance() });
   // Distinct reasons so Sentry can tell the "components not attached" race
   // (the surface open threw) apart from a "Clerk bundle never loaded" failure
@@ -480,7 +484,7 @@ export function isClerkReady(): boolean {
 
 /** True when Clerk's sign-in (or other auth) modal is already on screen. */
 export function isClerkSignInOpen(): boolean {
-  if (typeof document === 'undefined') return false;
+  if (!clerkInstance || typeof document === 'undefined') return false;
   try {
     return Boolean(document.querySelector(
       '.cl-modalBackdrop, .cl-modal, [data-clerk-component="SignIn"]',
@@ -491,9 +495,8 @@ export function isClerkSignInOpen(): boolean {
 }
 
 /**
- * Open the existing Clerk sign-in modal and wait for the UI-open retry.
  * Returns false when Clerk is disabled, failed to load, or the UI surface
- * could not attach. Does not accept credentials.
+ * could not attach.
  */
 export async function openSignInAndWait(): Promise<boolean> {
   if (!isClerkAuthEnabled()) return false;
@@ -514,7 +517,7 @@ export async function openSignInAndWait(): Promise<boolean> {
     let opened = false;
     runClerkSurfaceOpen(
       () => {
-        clerkInstance?.openSignIn({ appearance: getAppearance() });
+        openLoadedClerkSignIn();
         opened = true;
       },
       () => finish(false),

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -474,6 +474,61 @@ export function openSignIn(): void {
   openClerkSurface('open-sign-in');
 }
 
+export function isClerkReady(): boolean {
+  return clerkInstance !== null;
+}
+
+/** True when Clerk's sign-in (or other auth) modal is already on screen. */
+export function isClerkSignInOpen(): boolean {
+  if (typeof document === 'undefined') return false;
+  try {
+    return Boolean(document.querySelector(
+      '.cl-modalBackdrop, .cl-modal, [data-clerk-component="SignIn"]',
+    ));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Open the existing Clerk sign-in modal and wait for the UI-open retry.
+ * Returns false when Clerk is disabled, failed to load, or the UI surface
+ * could not attach. Does not accept credentials.
+ */
+export async function openSignInAndWait(): Promise<boolean> {
+  if (!isClerkAuthEnabled()) return false;
+  try {
+    await initClerk();
+  } catch {
+    return false;
+  }
+  if (!clerkInstance || typeof clerkInstance.openSignIn !== 'function') return false;
+
+  return await new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (ok: boolean): void => {
+      if (settled) return;
+      settled = true;
+      resolve(ok);
+    };
+    let opened = false;
+    runClerkSurfaceOpen(
+      () => {
+        clerkInstance?.openSignIn({ appearance: getAppearance() });
+        opened = true;
+      },
+      () => finish(false),
+      (cb) => {
+        scheduleNextFrame(() => {
+          cb();
+          if (opened) finish(true);
+        });
+      },
+    );
+    if (opened) finish(true);
+  });
+}
+
 /**
  * Open the Clerk sign-up modal.
  *

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -512,45 +512,112 @@ function scheduleClerkSurfaceRetry(cb: () => void): void {
   setTimeout(run, CLERK_SURFACE_RETRY_TIMEOUT_MS);
 }
 
+export interface WaitForClerkSurfaceOpenOptions {
+  /** When set, success means this predicate is true, not merely that open() did not throw. */
+  isOpen?: () => boolean;
+  signal?: AbortSignal;
+}
+
+function abortClerkSurfaceWait(signal?: AbortSignal): never {
+  signal?.throwIfAborted();
+  throw new DOMException('The operation was aborted.', 'AbortError');
+}
+
 /**
  * Wait until a Clerk surface open succeeds, persistently fails, or the wait
  * cap elapses. Settlement must not depend on rAF-only scheduling. Exported
  * so tests can drive the dual scheduler and wait cap without a Clerk instance.
+ *
+ * When `isOpen` is provided, a non-throwing `open()` is not enough: the
+ * waiter keeps polling until the surface is actually present or the cap
+ * elapses. An abort signal rejects without treating the surface as opened.
  */
 export function waitForClerkSurfaceOpen(
   open: () => void,
   waitCapMs = CLERK_SIGN_IN_OPEN_WAIT_MS,
   scheduleRetry: (cb: () => void) => void = scheduleClerkSurfaceRetry,
+  options?: WaitForClerkSurfaceOpenOptions,
 ): Promise<boolean> {
-  return new Promise<boolean>((resolve) => {
+  return new Promise<boolean>((resolve, reject) => {
     let settled = false;
+    let waitCap: ReturnType<typeof setTimeout> | undefined;
+    let presencePoll: ReturnType<typeof setTimeout> | undefined;
+    const signal = options?.signal;
+    const isOpen = options?.isOpen;
+
+    const cleanup = (): void => {
+      if (waitCap !== undefined) clearTimeout(waitCap);
+      if (presencePoll !== undefined) clearTimeout(presencePoll);
+      signal?.removeEventListener('abort', onAbort);
+    };
     const finish = (ok: boolean): void => {
       if (settled) return;
       settled = true;
+      cleanup();
       resolve(ok);
     };
-    let waitCap: ReturnType<typeof setTimeout> | undefined;
-    const settle = (ok: boolean): void => {
-      if (waitCap !== undefined) clearTimeout(waitCap);
-      finish(ok);
+    const failAbort = (): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      try {
+        abortClerkSurfaceWait(signal);
+      } catch (error) {
+        reject(error);
+      }
     };
-    waitCap = setTimeout(() => settle(false), waitCapMs);
+    const onAbort = (): void => {
+      failAbort();
+    };
+
+    if (signal?.aborted) {
+      failAbort();
+      return;
+    }
+    signal?.addEventListener('abort', onAbort, { once: true });
+
+    const surfaceReady = (): boolean => !isOpen || isOpen();
     let opened = false;
+    const tryFinishOpened = (): void => {
+      if (settled || !opened) return;
+      if (surfaceReady()) finish(true);
+    };
+    const pollForPresence = (): void => {
+      if (settled || !isOpen || presencePoll !== undefined) return;
+      presencePoll = setTimeout(() => {
+        presencePoll = undefined;
+        if (settled) return;
+        if (signal?.aborted) {
+          failAbort();
+          return;
+        }
+        tryFinishOpened();
+        if (!settled && opened) pollForPresence();
+      }, CLERK_SURFACE_RETRY_TIMEOUT_MS);
+    };
+
+    waitCap = setTimeout(() => finish(false), waitCapMs);
     runClerkSurfaceOpen(
       () => {
         open();
         opened = true;
       },
-      () => settle(false),
+      () => finish(false),
       (retryOpen) => {
         scheduleRetry(() => {
           if (settled) return;
+          if (signal?.aborted) {
+            failAbort();
+            return;
+          }
           retryOpen();
-          if (opened) settle(true);
+          tryFinishOpened();
+          if (!settled && opened && isOpen) pollForPresence();
         });
       },
     );
-    if (opened) settle(true);
+    tryFinishOpened();
+    if (!settled && opened && isOpen) pollForPresence();
   });
 }
 
@@ -558,15 +625,21 @@ export function waitForClerkSurfaceOpen(
  * Returns false when Clerk is disabled, failed to load, or the UI surface
  * could not attach.
  */
-export async function openSignInAndWait(): Promise<boolean> {
+export async function openSignInAndWait(signal?: AbortSignal): Promise<boolean> {
   if (!isClerkAuthEnabled()) return false;
   try {
     await initClerk();
   } catch {
     return false;
   }
+  if (signal?.aborted) abortClerkSurfaceWait(signal);
   if (!clerkInstance || typeof clerkInstance.openSignIn !== 'function') return false;
-  return waitForClerkSurfaceOpen(openLoadedClerkSignIn);
+  return waitForClerkSurfaceOpen(
+    openLoadedClerkSignIn,
+    CLERK_SIGN_IN_OPEN_WAIT_MS,
+    scheduleClerkSurfaceRetry,
+    { isOpen: isClerkSignInOpen, signal },
+  );
 }
 
 /**

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -494,6 +494,66 @@ export function isClerkSignInOpen(): boolean {
   }
 }
 
+const CLERK_SIGN_IN_OPEN_WAIT_MS = 2000;
+const CLERK_SURFACE_RETRY_TIMEOUT_MS = 50;
+
+/**
+ * Schedule a one-shot retry on the next animation frame when available, and
+ * always on a timeout so a background tab that never paints still retries.
+ */
+function scheduleClerkSurfaceRetry(cb: () => void): void {
+  let ran = false;
+  const run = (): void => {
+    if (ran) return;
+    ran = true;
+    cb();
+  };
+  if (typeof requestAnimationFrame === 'function') requestAnimationFrame(run);
+  setTimeout(run, CLERK_SURFACE_RETRY_TIMEOUT_MS);
+}
+
+/**
+ * Wait until a Clerk surface open succeeds, persistently fails, or the wait
+ * cap elapses. Settlement must not depend on rAF-only scheduling. Exported
+ * so tests can drive the dual scheduler and wait cap without a Clerk instance.
+ */
+export function waitForClerkSurfaceOpen(
+  open: () => void,
+  waitCapMs = CLERK_SIGN_IN_OPEN_WAIT_MS,
+  scheduleRetry: (cb: () => void) => void = scheduleClerkSurfaceRetry,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (ok: boolean): void => {
+      if (settled) return;
+      settled = true;
+      resolve(ok);
+    };
+    let waitCap: ReturnType<typeof setTimeout> | undefined;
+    const settle = (ok: boolean): void => {
+      if (waitCap !== undefined) clearTimeout(waitCap);
+      finish(ok);
+    };
+    waitCap = setTimeout(() => settle(false), waitCapMs);
+    let opened = false;
+    runClerkSurfaceOpen(
+      () => {
+        open();
+        opened = true;
+      },
+      () => settle(false),
+      (retryOpen) => {
+        scheduleRetry(() => {
+          if (settled) return;
+          retryOpen();
+          if (opened) settle(true);
+        });
+      },
+    );
+    if (opened) settle(true);
+  });
+}
+
 /**
  * Returns false when Clerk is disabled, failed to load, or the UI surface
  * could not attach.
@@ -506,30 +566,7 @@ export async function openSignInAndWait(): Promise<boolean> {
     return false;
   }
   if (!clerkInstance || typeof clerkInstance.openSignIn !== 'function') return false;
-
-  return await new Promise<boolean>((resolve) => {
-    let settled = false;
-    const finish = (ok: boolean): void => {
-      if (settled) return;
-      settled = true;
-      resolve(ok);
-    };
-    let opened = false;
-    runClerkSurfaceOpen(
-      () => {
-        openLoadedClerkSignIn();
-        opened = true;
-      },
-      () => finish(false),
-      (cb) => {
-        scheduleNextFrame(() => {
-          cb();
-          if (opened) finish(true);
-        });
-      },
-    );
-    if (opened) finish(true);
-  });
+  return waitForClerkSurfaceOpen(openLoadedClerkSignIn);
 }
 
 /**

--- a/src/services/webmcp-access-snapshot.ts
+++ b/src/services/webmcp-access-snapshot.ts
@@ -25,6 +25,7 @@ export interface WebMcpAccessContextInput {
   enabledPanelUsed: number;
   dashboardTabCount: number;
   freePanelCap: number;
+  dataExport: boolean;
 }
 
 export interface OpenSignInDecisionInput {
@@ -45,8 +46,9 @@ function nonNegativeCount(value: number): number {
 }
 
 /**
- * Bounded, PII-free access snapshot for WebMCP. Capability flags come from the
- * same entitlement and premium-access sources the dashboard uses.
+ * Bounded, PII-free access snapshot for WebMCP. apiAccess/mcpAccess stay
+ * fail-closed on the entitlement feature flags. dataExport is supplied by the
+ * live export-gate reader so it matches the dashboard export lock.
  */
 export function buildWebMcpAccessContext(
   input: WebMcpAccessContextInput,
@@ -63,16 +65,23 @@ export function buildWebMcpAccessContext(
   else if (input.auth.isPending) clerk = 'loading';
   else clerk = 'unavailable';
 
+  const entitlementUnknown = accountState === 'signed_in' && input.entitlement == null;
+
   let productTier: AccessContextSnapshot['productTier'];
-  if (accountState === 'loading') productTier = 'unknown';
-  else if (input.premiumAccess) productTier = 'pro';
-  else if (accountState === 'signed_in') productTier = 'free';
-  else productTier = 'anonymous';
+  if (accountState === 'loading' || (entitlementUnknown && !input.premiumAccess)) {
+    productTier = 'unknown';
+  } else if (input.premiumAccess) {
+    productTier = 'pro';
+  } else if (accountState === 'signed_in') {
+    productTier = 'free';
+  } else {
+    productTier = 'anonymous';
+  }
 
   const features = input.entitlement?.features;
-  const loading = accountState === 'loading';
-  const panelCap = loading || input.premiumAccess ? null : input.freePanelCap;
-  const tabCap = loading ? null : input.tabCap.cap;
+  const deferLimits = accountState === 'loading' || entitlementUnknown;
+  const panelCap = deferLimits || input.premiumAccess ? null : input.freePanelCap;
+  const tabCap = deferLimits ? null : input.tabCap.cap;
 
   return {
     accountState,
@@ -82,7 +91,7 @@ export function buildWebMcpAccessContext(
       premiumAccess: input.premiumAccess === true,
       apiAccess: features?.apiAccess === true,
       mcpAccess: features?.mcpAccess === true,
-      dataExport: features?.dataExport === true,
+      dataExport: input.dataExport === true,
     },
     limits: {
       enabledPanels: {
@@ -92,7 +101,7 @@ export function buildWebMcpAccessContext(
       dashboardTabs: {
         used: nonNegativeCount(input.dashboardTabCount),
         cap: tabCap,
-        canCreate: loading || input.tabCap.allowed,
+        canCreate: deferLimits || input.tabCap.allowed,
       },
     },
   };

--- a/src/services/webmcp-access-snapshot.ts
+++ b/src/services/webmcp-access-snapshot.ts
@@ -25,6 +25,8 @@ export interface WebMcpAccessContextInput {
   enabledPanelUsed: number;
   dashboardTabCount: number;
   freePanelCap: number;
+  /** True after FreeTierGate's AUTH_SETTLE_GRACE_MS backstop has fired. */
+  freeTierFallbackActive: boolean;
   dataExport: boolean;
 }
 
@@ -80,7 +82,11 @@ export function buildWebMcpAccessContext(
 
   const features = input.entitlement?.features;
   const deferLimits = accountState === 'loading' || entitlementUnknown;
-  const panelCap = deferLimits || input.premiumAccess ? null : input.freePanelCap;
+  // Panel enforcement stops deferring at the 8s backstop even when the
+  // Convex snapshot never arrives. Tab caps stay deferred: evaluateTabCap
+  // remains uncapped while features are still null.
+  const deferPanelCap = deferLimits && !input.freeTierFallbackActive;
+  const panelCap = deferPanelCap || input.premiumAccess ? null : input.freePanelCap;
   const tabCap = deferLimits ? null : input.tabCap.cap;
 
   return {

--- a/src/services/webmcp-access-snapshot.ts
+++ b/src/services/webmcp-access-snapshot.ts
@@ -1,0 +1,115 @@
+import type { AuthSession } from '@/services/auth-state';
+import type { EntitlementState } from '@/services/entitlements';
+import type { TabCapVerdict } from '@/services/gates/export-resolver';
+import type { AccessContextSnapshot } from '@/services/webmcp';
+
+/** Keys that must never appear on a WebMCP access snapshot or bounded result. */
+export const ACCESS_CONTEXT_PRIVACY_KEYS = [
+  'email',
+  'name',
+  'userId',
+  'id',
+  'token',
+  'sessionId',
+  'image',
+  'session',
+] as const;
+
+export interface WebMcpAccessContextInput {
+  auth: AuthSession;
+  clerkEnabled: boolean;
+  clerkReady: boolean;
+  premiumAccess: boolean;
+  entitlement: EntitlementState | null;
+  tabCap: TabCapVerdict;
+  enabledPanelUsed: number;
+  dashboardTabCount: number;
+  freePanelCap: number;
+}
+
+export interface OpenSignInDecisionInput {
+  clerkEnabled: boolean;
+  clerkReady: boolean;
+  alreadyOpen: boolean;
+  loadFailed?: boolean;
+}
+
+export type OpenSignInDecision =
+  | { action: 'open' }
+  | { action: 'load_and_open' }
+  | { ok: true; status: 'already_open'; reason: 'already_open' }
+  | { ok: false; status: 'denied'; reason: 'clerk_unavailable' };
+
+function nonNegativeCount(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+/**
+ * Bounded, PII-free access snapshot for WebMCP. Capability flags come from the
+ * same entitlement and premium-access sources the dashboard uses.
+ */
+export function buildWebMcpAccessContext(
+  input: WebMcpAccessContextInput,
+): AccessContextSnapshot {
+  const accountState = input.auth.isPending
+    ? 'loading'
+    : input.auth.user
+      ? 'signed_in'
+      : 'signed_out';
+
+  const clerk = !input.clerkEnabled
+    ? 'unavailable'
+    : input.clerkReady
+      ? 'ready'
+      : input.auth.isPending
+        ? 'loading'
+        : 'unavailable';
+
+  const productTier = accountState === 'loading'
+    ? 'unknown'
+    : input.premiumAccess
+      ? 'pro'
+      : accountState === 'signed_in'
+        ? 'free'
+        : 'anonymous';
+
+  const features = input.entitlement?.features;
+  const loading = accountState === 'loading';
+  const panelCap = loading || input.premiumAccess ? null : input.freePanelCap;
+  const tabCap = loading ? null : input.tabCap.cap;
+
+  return {
+    accountState,
+    clerk,
+    productTier,
+    capabilities: {
+      premiumAccess: input.premiumAccess === true,
+      apiAccess: features?.apiAccess === true,
+      mcpAccess: features?.mcpAccess === true,
+      dataExport: features?.dataExport === true,
+    },
+    limits: {
+      enabledPanels: {
+        used: nonNegativeCount(input.enabledPanelUsed),
+        cap: panelCap,
+      },
+      dashboardTabs: {
+        used: nonNegativeCount(input.dashboardTabCount),
+        cap: tabCap,
+        canCreate: loading || input.tabCap.allowed,
+      },
+    },
+  };
+}
+
+export function resolveWebMcpOpenSignIn(
+  input: OpenSignInDecisionInput,
+): OpenSignInDecision {
+  if (!input.clerkEnabled || input.loadFailed === true) {
+    return { ok: false, status: 'denied', reason: 'clerk_unavailable' };
+  }
+  if (input.alreadyOpen) {
+    return { ok: true, status: 'already_open', reason: 'already_open' };
+  }
+  return input.clerkReady ? { action: 'open' } : { action: 'load_and_open' };
+}

--- a/src/services/webmcp-access-snapshot.ts
+++ b/src/services/webmcp-access-snapshot.ts
@@ -57,21 +57,17 @@ export function buildWebMcpAccessContext(
       ? 'signed_in'
       : 'signed_out';
 
-  const clerk = !input.clerkEnabled
-    ? 'unavailable'
-    : input.clerkReady
-      ? 'ready'
-      : input.auth.isPending
-        ? 'loading'
-        : 'unavailable';
+  let clerk: AccessContextSnapshot['clerk'];
+  if (!input.clerkEnabled) clerk = 'unavailable';
+  else if (input.clerkReady) clerk = 'ready';
+  else if (input.auth.isPending) clerk = 'loading';
+  else clerk = 'unavailable';
 
-  const productTier = accountState === 'loading'
-    ? 'unknown'
-    : input.premiumAccess
-      ? 'pro'
-      : accountState === 'signed_in'
-        ? 'free'
-        : 'anonymous';
+  let productTier: AccessContextSnapshot['productTier'];
+  if (accountState === 'loading') productTier = 'unknown';
+  else if (input.premiumAccess) productTier = 'pro';
+  else if (accountState === 'signed_in') productTier = 'free';
+  else productTier = 'anonymous';
 
   const features = input.entitlement?.features;
   const loading = accountState === 'loading';

--- a/src/services/webmcp.ts
+++ b/src/services/webmcp.ts
@@ -16,6 +16,8 @@
 //   6. set_map_layers()           — changes allowed visible map layers.
 //   7. search_dashboard()         — searches the live dashboard index.
 //   8. open_search_result()       — selects an opaque, revalidated result.
+//   9. get_access_context()       — reads signed-out / loading / signed-in access.
+//  10. open_sign_in()            — opens the existing Clerk sign-in dialog.
 //
 // No tool is conditionally registered. Live controls re-check auth and
 // entitlement through the agent-bus applier on every invocation, so a single
@@ -71,6 +73,12 @@ export interface WebMcpAppBindings {
     resultKey: string,
     options?: WebMcpExecutionOptions,
   ): DashboardSearchOpenResult | Promise<DashboardSearchOpenResult>;
+  getAccessContext(
+    options?: WebMcpExecutionOptions,
+  ): AccessContextSnapshot | Promise<AccessContextSnapshot>;
+  openSignIn(
+    options?: WebMcpExecutionOptions,
+  ): OpenSignInResult | Promise<OpenSignInResult>;
 }
 
 export interface WebMcpExecutionOptions {
@@ -122,6 +130,31 @@ export interface DashboardContextSnapshot {
     enabled: string[];
   };
 }
+
+export type WebMcpAccountState = 'signed_out' | 'loading' | 'signed_in';
+export type WebMcpClerkState = 'unavailable' | 'loading' | 'ready';
+export type WebMcpProductTier = 'anonymous' | 'free' | 'pro' | 'unknown';
+
+export interface AccessContextSnapshot {
+  accountState: WebMcpAccountState;
+  clerk: WebMcpClerkState;
+  productTier: WebMcpProductTier;
+  capabilities: {
+    premiumAccess: boolean;
+    apiAccess: boolean;
+    mcpAccess: boolean;
+    dataExport: boolean;
+  };
+  limits: {
+    enabledPanels: { used: number; cap: number | null };
+    dashboardTabs: { used: number; cap: number | null; canCreate: boolean };
+  };
+}
+
+export type OpenSignInResult =
+  | { ok: true; status: 'opened' }
+  | { ok: true; status: 'already_open'; reason: 'already_open' }
+  | { ok: false; status: 'denied'; reason: 'clerk_unavailable' };
 
 export type DashboardActionStatus = 'applied' | 'denied' | 'invalid' | 'skipped';
 
@@ -219,14 +252,16 @@ const DASHBOARD_SEARCH_OPEN_REASONS = new Set<DashboardSearchOpenReason>([
 //     next human map move.
 //   - 'read-only': nothing to undo.
 //
-// Keyed by WebMcpSpaToolName, so adding a ninth tool without a policy entry is
+// Keyed by WebMcpSpaToolName, so adding a tool without a policy entry is
 // a TypeScript error. That is the forcing function: nothing ships unclassified.
 export const WEBMCP_TOOL_CANCELLATION_POLICY: Readonly<
   Record<WebMcpSpaToolName, 'read-only' | 'view-state' | 'cancellation-required'>
 > = Object.freeze({
   [WEBMCP_SPA_TOOL.getDashboardContext]: 'read-only',
+  [WEBMCP_SPA_TOOL.getAccessContext]: 'read-only',
   [WEBMCP_SPA_TOOL.searchDashboard]: 'read-only',
   [WEBMCP_SPA_TOOL.openSearch]: 'view-state',
+  [WEBMCP_SPA_TOOL.openSignIn]: 'view-state',
   [WEBMCP_SPA_TOOL.openDashboardPanel]: 'view-state',
   [WEBMCP_SPA_TOOL.setMapView]: 'view-state',
   [WEBMCP_SPA_TOOL.openCountryBrief]: 'cancellation-required',
@@ -286,6 +321,8 @@ const TOOL_FAILURE_MESSAGES: Record<WebMcpSpaToolName, string> = {
   set_map_layers: 'World Monitor could not update map layers.',
   search_dashboard: 'World Monitor could not search the dashboard.',
   open_search_result: 'World Monitor could not open that search result.',
+  get_access_context: 'World Monitor could not read access context.',
+  open_sign_in: 'World Monitor could not open sign-in.',
 };
 const UNSUPPORTED_MUTATION_MESSAGE =
   'This browser cannot cancel work already running in the page, so World Monitor '
@@ -596,6 +633,52 @@ function boundDashboardContext(snapshot: DashboardContextSnapshot): Record<strin
   return result;
 }
 
+const ACCOUNT_STATES = new Set<WebMcpAccountState>(['signed_out', 'loading', 'signed_in']);
+const CLERK_STATES = new Set<WebMcpClerkState>(['unavailable', 'loading', 'ready']);
+const PRODUCT_TIERS = new Set<WebMcpProductTier>(['anonymous', 'free', 'pro', 'unknown']);
+
+function oneOf<T extends string>(value: unknown, allowed: ReadonlySet<T>, fallback: T): T {
+  return typeof value === 'string' && allowed.has(value as T) ? value as T : fallback;
+}
+
+function optionalCap(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : null;
+}
+
+export function boundWebMcpAccessContext(
+  snapshot: AccessContextSnapshot,
+  targetCancellationSupported: boolean,
+): Record<string, unknown> {
+  const enabledPanels = snapshot.limits?.enabledPanels;
+  const dashboardTabs = snapshot.limits?.dashboardTabs;
+  return {
+    accountState: oneOf(snapshot.accountState, ACCOUNT_STATES, 'loading'),
+    clerk: oneOf(snapshot.clerk, CLERK_STATES, 'unavailable'),
+    productTier: oneOf(snapshot.productTier, PRODUCT_TIERS, 'unknown'),
+    capabilities: {
+      premiumAccess: snapshot.capabilities?.premiumAccess === true,
+      apiAccess: snapshot.capabilities?.apiAccess === true,
+      mcpAccess: snapshot.capabilities?.mcpAccess === true,
+      dataExport: snapshot.capabilities?.dataExport === true,
+    },
+    limits: {
+      enabledPanels: {
+        used: Math.max(0, Math.floor(boundedNumber(enabledPanels?.used))),
+        cap: optionalCap(enabledPanels?.cap),
+      },
+      dashboardTabs: {
+        used: Math.max(0, Math.floor(boundedNumber(dashboardTabs?.used))),
+        cap: optionalCap(dashboardTabs?.cap),
+        canCreate: dashboardTabs?.canCreate === true,
+      },
+    },
+    targetCancellationSupported: targetCancellationSupported === true,
+  };
+}
+
 function boundDashboardActionResult(result: DashboardActionResult): Record<string, unknown> & {
   ok: boolean;
   status: DashboardActionStatus;
@@ -657,6 +740,16 @@ function boundDashboardSearchResult(result: DashboardSearchResponse): DashboardS
     throw new SafeWebMcpError('Dashboard search result exceeded the safe output limit.');
   }
   return bounded;
+}
+
+function boundOpenSignInResult(result: OpenSignInResult): OpenSignInResult {
+  if (result?.ok === true && result.status === 'already_open') {
+    return { ok: true, status: 'already_open', reason: 'already_open' };
+  }
+  if (result?.ok === true && result.status === 'opened') {
+    return { ok: true, status: 'opened' };
+  }
+  return { ok: false, status: 'denied', reason: 'clerk_unavailable' };
 }
 
 function boundSearchOpenResult(result: DashboardSearchOpenResult): DashboardSearchOpenResult {
@@ -1011,6 +1104,42 @@ export function buildWebMcpTools(
           });
         }
         return boundSearchOpenResult(await app.openSearchResult(resultKey, extra));
+      }, trackEvent),
+    },
+    {
+      name: WEBMCP_SPA_TOOL.getAccessContext,
+      title: 'Get Access Context',
+      description:
+        'Read whether this tab is signed out, still loading account state, or signed in. Returns product tier, capability flags, panel and dashboard-tab limits, and whether the host can cancel tools. Contains no names, emails, account IDs, tokens, or session details.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      annotations: { readOnlyHint: true },
+      execute: withInvocationLogging(WEBMCP_SPA_TOOL.getAccessContext, async (_args, extra) => (
+        boundWebMcpAccessContext(await app.getAccessContext(extra), Boolean(extra?.signal))
+      ), trackEvent),
+    },
+    {
+      name: WEBMCP_SPA_TOOL.openSignIn,
+      title: 'Open Sign In',
+      description:
+        'Open the existing Clerk sign-in dialog on this page. Does not accept credentials, one-time codes, or provider choices. Returns a stable reason when Clerk is unavailable or the dialog is already open.',
+      inputSchema: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      annotations: { readOnlyHint: false },
+      execute: withInvocationLogging(WEBMCP_SPA_TOOL.openSignIn, async (args, extra) => {
+        if (!hasOnlyOwnKeys(args, [])) {
+          throw new SafeWebMcpError(
+            'open_sign_in does not accept credentials or other arguments.',
+            'validation',
+          );
+        }
+        return boundOpenSignInResult(await app.openSignIn(extra));
       }, trackEvent),
     },
   ];

--- a/tests/clerk-surface-open.test.mts
+++ b/tests/clerk-surface-open.test.mts
@@ -18,7 +18,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { runClerkSurfaceOpen } from '../src/services/clerk.ts';
+import { runClerkSurfaceOpen, waitForClerkSurfaceOpen } from '../src/services/clerk.ts';
 
 describe('runClerkSurfaceOpen', () => {
   it('opens once and never schedules a retry when the surface is ready', () => {
@@ -86,5 +86,56 @@ describe('runClerkSurfaceOpen', () => {
     );
     assert.equal(opens, 1, 'retry must be deferred, not run inline');
     assert.equal(typeof scheduled, 'function');
+  });
+});
+
+describe('waitForClerkSurfaceOpen', () => {
+  it('settles false when the first open throws and the retry scheduler never runs', async () => {
+    const result = await waitForClerkSurfaceOpen(
+      () => { throw new Error('Clerk was not loaded with Ui components'); },
+      25,
+      () => {},
+    );
+    assert.equal(result, false);
+  });
+
+  it('does not open after the wait cap has already settled', async () => {
+    let opens = 0;
+    let lateRetry: (() => void) | undefined;
+    const result = await waitForClerkSurfaceOpen(
+      () => {
+        opens += 1;
+        throw new Error('not ready');
+      },
+      20,
+      (cb) => { lateRetry = cb; },
+    );
+    assert.equal(result, false);
+    lateRetry?.();
+    assert.equal(opens, 1);
+  });
+
+  it('retries via setTimeout even when requestAnimationFrame never fires', async () => {
+    const previousRaf = Object.getOwnPropertyDescriptor(globalThis, 'requestAnimationFrame');
+    Object.defineProperty(globalThis, 'requestAnimationFrame', {
+      configurable: true,
+      writable: true,
+      value: () => 0,
+    });
+    try {
+      let opens = 0;
+      const opened = await waitForClerkSurfaceOpen(
+        () => {
+          opens += 1;
+          if (opens === 1) throw new Error('not ready');
+        },
+        500,
+      );
+      assert.equal(opens, 2);
+      assert.equal(opened, true);
+    } finally {
+      if (previousRaf) Object.defineProperty(globalThis, 'requestAnimationFrame', previousRaf);
+      else delete (globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+    }
   });
 });

--- a/tests/clerk-surface-open.test.mts
+++ b/tests/clerk-surface-open.test.mts
@@ -115,6 +115,70 @@ describe('waitForClerkSurfaceOpen', () => {
     assert.equal(opens, 1);
   });
 
+  it('does not report opened until isOpen is true', async () => {
+    let visible = false;
+    let sawPending = false;
+    const pending = waitForClerkSurfaceOpen(
+      () => {},
+      400,
+      (cb) => { setTimeout(cb, 15); },
+      { isOpen: () => visible },
+    );
+    const raced = await Promise.race([
+      pending.then((opened) => ({ opened })),
+      new Promise<{ pending: true }>((resolve) => {
+        setTimeout(() => resolve({ pending: true }), 40);
+      }),
+    ]);
+    if ('pending' in raced) {
+      sawPending = true;
+      visible = true;
+    }
+    assert.equal(sawPending, true);
+    assert.equal(await pending, true);
+  });
+
+  it('returns false when open succeeds but the modal never appears', async () => {
+    const result = await waitForClerkSurfaceOpen(
+      () => {},
+      30,
+      (cb) => { setTimeout(cb, 5); },
+      { isOpen: () => false },
+    );
+    assert.equal(result, false);
+  });
+
+  it('does not open when the signal is already aborted', async () => {
+    let opens = 0;
+    const controller = new AbortController();
+    controller.abort();
+    await assert.rejects(
+      waitForClerkSurfaceOpen(
+        () => { opens += 1; },
+        100,
+        () => {},
+        { signal: controller.signal },
+      ),
+      (error: unknown) => error instanceof Error && error.name === 'AbortError',
+    );
+    assert.equal(opens, 0);
+  });
+
+  it('rejects when the signal aborts before the modal is present', async () => {
+    const controller = new AbortController();
+    const pending = waitForClerkSurfaceOpen(
+      () => {},
+      400,
+      (cb) => { setTimeout(cb, 15); },
+      { isOpen: () => false, signal: controller.signal },
+    );
+    setTimeout(() => controller.abort(), 20);
+    await assert.rejects(
+      pending,
+      (error: unknown) => error instanceof Error && error.name === 'AbortError',
+    );
+  });
+
   it('retries via setTimeout even when requestAnimationFrame never fires', async () => {
     const previousRaf = Object.getOwnPropertyDescriptor(globalThis, 'requestAnimationFrame');
     Object.defineProperty(globalThis, 'requestAnimationFrame', {

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1884,6 +1884,21 @@ describe('security header guardrails', () => {
     assert.match(webMcpCancellationE2eSource, /window\.addEventListener\('unhandledrejection'/);
     assert.match(webMcpCancellationE2eSource, /lateLeakWindowMs/);
     assert.match(webMcpE2eSource, /headers\['origin-trial'\]/);
+    assert.match(
+      webMcpE2eSource,
+      /const unconfiguredLocalFixture =\s*!productionSmoke && accessSnapshot\.clerk === 'unavailable'/,
+      'clerk_unavailable is only valid on the local unconfigured Clerk fixture',
+    );
+    assert.match(
+      webMcpE2eSource,
+      /production smoke must open the real Clerk sign-in modal/,
+      'production WebMCP smoke must require the real Clerk modal',
+    );
+    assert.match(
+      webMcpE2eSource,
+      /signIn: \{ tool: 'open_sign_in'/,
+      'production smoke must attach open_sign_in modal evidence',
+    );
     assert.match(webMcpE2eSource, /testInfo\.outputPath\(name\)/);
     assert.match(webMcpE2eSource, /writeFile\(path/);
     assert.match(webMcpE2eSource, /testInfo\.attach\(name, \{ path/);

--- a/tests/dom/app-webmcp-country-cold-start.test.mts
+++ b/tests/dom/app-webmcp-country-cold-start.test.mts
@@ -43,6 +43,22 @@ describe('App WebMCP country binding cold start', () => {
         truncated: false,
       }),
       openSearchResult: async () => ({ ok: true, status: 'opened' }),
+      getAccessContext: async () => ({
+        accountState: 'signed_out',
+        clerk: 'unavailable',
+        productTier: 'anonymous',
+        capabilities: {
+          premiumAccess: false,
+          apiAccess: false,
+          mcpAccess: false,
+          dataExport: false,
+        },
+        limits: {
+          enabledPanels: { used: 1, cap: 40 },
+          dashboardTabs: { used: 1, cap: 3, canCreate: true },
+        },
+      }),
+      openSignIn: async () => ({ ok: false, status: 'denied', reason: 'clerk_unavailable' }),
     }, () => {});
 
     await expect(tools.find((tool) => tool.name === 'openCountryBrief')!.execute({ iso2: 'FR' }))
@@ -133,6 +149,22 @@ describe('App WebMCP country binding cold start', () => {
         truncated: false,
       }),
       openSearchResult: async () => ({ ok: true, status: 'opened' }),
+      getAccessContext: async () => ({
+        accountState: 'signed_out',
+        clerk: 'unavailable',
+        productTier: 'anonymous',
+        capabilities: {
+          premiumAccess: false,
+          apiAccess: false,
+          mcpAccess: false,
+          dataExport: false,
+        },
+        limits: {
+          enabledPanels: { used: 1, cap: 40 },
+          dashboardTabs: { used: 1, cap: 3, canCreate: true },
+        },
+      }),
+      openSignIn: async () => ({ ok: false, status: 'denied', reason: 'clerk_unavailable' }),
     };
     const countryTool = buildWebMcpTools(bindings, () => {})
       .find((tool) => tool.name === 'openCountryBrief');

--- a/tests/fixtures/webmcp/evals.v1.json
+++ b/tests/fixtures/webmcp/evals.v1.json
@@ -10,7 +10,9 @@
       "set_map_view",
       "set_map_layers",
       "search_dashboard",
-      "open_search_result"
+      "open_search_result",
+      "get_access_context",
+      "open_sign_in"
     ],
     "declarative": [
       "search_procurement"
@@ -39,7 +41,9 @@
         "set_map_layers",
         "search_dashboard",
         "open_search_result",
-        "search_procurement"
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
       ]
     },
     {
@@ -63,6 +67,60 @@
         "set_map_layers",
         "search_dashboard",
         "open_search_result",
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
+      ]
+    },
+    {
+      "id": "access_context_direct",
+      "category": "dashboard_context",
+      "promptKind": "direct",
+      "prompt": "Am I signed in on this tab, and what product tier and panel limits apply? Do not return any personal information.",
+      "expectedPlans": [
+        [
+          {
+            "tool": "get_access_context",
+            "arguments": {}
+          }
+        ]
+      ],
+      "forbiddenTools": [
+        "openCountryBrief",
+        "openSearch",
+        "get_dashboard_context",
+        "open_dashboard_panel",
+        "set_map_view",
+        "set_map_layers",
+        "search_dashboard",
+        "open_search_result",
+        "open_sign_in",
+        "search_procurement"
+      ]
+    },
+    {
+      "id": "access_context_ambiguous",
+      "category": "dashboard_context",
+      "promptKind": "ambiguous",
+      "prompt": "Can this account add another dashboard tab, or is the account state still loading?",
+      "expectedPlans": [
+        [
+          {
+            "tool": "get_access_context",
+            "arguments": {}
+          }
+        ]
+      ],
+      "forbiddenTools": [
+        "openCountryBrief",
+        "openSearch",
+        "get_dashboard_context",
+        "open_dashboard_panel",
+        "set_map_view",
+        "set_map_layers",
+        "search_dashboard",
+        "open_search_result",
+        "open_sign_in",
         "search_procurement"
       ]
     },
@@ -86,7 +144,9 @@
         "openSearch",
         "search_dashboard",
         "open_search_result",
-        "search_procurement"
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
       ]
     },
     {
@@ -129,7 +189,9 @@
         "openSearch",
         "search_dashboard",
         "open_search_result",
-        "search_procurement"
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
       ]
     },
     {
@@ -154,6 +216,34 @@
         "openSearch",
         "search_dashboard",
         "open_search_result",
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
+      ]
+    },
+    {
+      "id": "open_sign_in_direct",
+      "category": "dashboard_control",
+      "promptKind": "direct",
+      "prompt": "Open the existing Clerk sign-in dialog on this page. Do not send a password, one-time code, or provider choice.",
+      "expectedPlans": [
+        [
+          {
+            "tool": "open_sign_in",
+            "arguments": {}
+          }
+        ]
+      ],
+      "forbiddenTools": [
+        "openCountryBrief",
+        "openSearch",
+        "get_dashboard_context",
+        "get_access_context",
+        "open_dashboard_panel",
+        "set_map_view",
+        "set_map_layers",
+        "search_dashboard",
+        "open_search_result",
         "search_procurement"
       ]
     },
@@ -176,7 +266,9 @@
         "openSearch",
         "search_dashboard",
         "open_search_result",
-        "search_procurement"
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
       ]
     },
     {
@@ -210,7 +302,9 @@
       ],
       "forbiddenTools": [
         "openSearch",
-        "search_procurement"
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
       ]
     },
     {
@@ -233,7 +327,9 @@
         "openSearch",
         "open_dashboard_panel",
         "open_search_result",
-        "search_procurement"
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
       ]
     },
     {
@@ -263,7 +359,9 @@
         "openCountryBrief",
         "openSearch",
         "open_dashboard_panel",
-        "search_procurement"
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
       ]
     },
     {
@@ -288,7 +386,9 @@
       "forbiddenTools": [
         "openSearch",
         "search_dashboard",
-        "open_search_result"
+        "open_search_result",
+        "get_access_context",
+        "open_sign_in"
       ]
     },
     {
@@ -311,7 +411,9 @@
       "forbiddenTools": [
         "openSearch",
         "search_dashboard",
-        "open_search_result"
+        "open_search_result",
+        "get_access_context",
+        "open_sign_in"
       ]
     },
     {
@@ -331,7 +433,9 @@
         "set_map_layers",
         "search_dashboard",
         "open_search_result",
-        "search_procurement"
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
       ]
     },
     {
@@ -359,7 +463,9 @@
         "openCountryBrief",
         "openSearch",
         "open_dashboard_panel",
-        "search_procurement"
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
       ],
       "failure": {
         "atStep": 2,
@@ -397,7 +503,9 @@
         "openSearch",
         "search_dashboard",
         "open_search_result",
-        "search_procurement"
+        "search_procurement",
+        "get_access_context",
+        "open_sign_in"
       ],
       "failure": {
         "atStep": 2,
@@ -429,7 +537,9 @@
       "forbiddenTools": [
         "openSearch",
         "search_dashboard",
-        "open_search_result"
+        "open_search_result",
+        "get_access_context",
+        "open_sign_in"
       ],
       "failure": {
         "atStep": 1,

--- a/tests/webmcp-access.test.mts
+++ b/tests/webmcp-access.test.mts
@@ -41,6 +41,7 @@ function signedOutInput(
     enabledPanelUsed: 12,
     dashboardTabCount: 1,
     freePanelCap: FREE_MAX_PANELS,
+    freeTierFallbackActive: false,
     dataExport: false,
     ...overrides,
   };
@@ -186,6 +187,21 @@ describe('buildWebMcpAccessContext', () => {
     assert.equal(snapshot.accountState, 'signed_in');
     assert.equal(snapshot.productTier, 'unknown');
     assert.equal(snapshot.limits.enabledPanels.cap, null);
+    assert.equal(snapshot.limits.dashboardTabs.cap, null);
+    assert.equal(snapshot.limits.dashboardTabs.canCreate, true);
+  });
+
+  it('reports the free panel cap after the settle backstop when entitlement stays null', () => {
+    const snapshot = buildWebMcpAccessContext(signedOutInput({
+      auth: FREE_AUTH,
+      premiumAccess: false,
+      entitlement: null,
+      freeTierFallbackActive: true,
+      tabCap: { allowed: false, cap: FREE_TAB_CAP, reason: 'free_tier' },
+    }));
+    assert.equal(snapshot.accountState, 'signed_in');
+    assert.equal(snapshot.productTier, 'unknown');
+    assert.equal(snapshot.limits.enabledPanels.cap, FREE_MAX_PANELS);
     assert.equal(snapshot.limits.dashboardTabs.cap, null);
     assert.equal(snapshot.limits.dashboardTabs.canCreate, true);
   });

--- a/tests/webmcp-access.test.mts
+++ b/tests/webmcp-access.test.mts
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  ACCESS_CONTEXT_PRIVACY_KEYS,
+  buildWebMcpAccessContext,
+  resolveWebMcpOpenSignIn,
+} from '../src/services/webmcp-access-snapshot.ts';
+import { FREE_TAB_CAP } from '../src/services/gates/export-resolver.ts';
+import { boundWebMcpAccessContext } from '../src/services/webmcp.ts';
+
+const FREE_MAX_PANELS = 40;
+
+const SIGNED_OUT_AUTH = { user: null, isPending: false } as const;
+const LOADING_AUTH = { user: null, isPending: true } as const;
+const FREE_AUTH = {
+  user: {
+    id: 'user_secret_id',
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    image: 'https://example.com/ada.png',
+    role: 'free' as const,
+  },
+  isPending: false,
+};
+const PRO_AUTH = {
+  ...FREE_AUTH,
+  user: { ...FREE_AUTH.user, role: 'pro' as const },
+};
+
+function signedOutInput(
+  overrides: Partial<Parameters<typeof buildWebMcpAccessContext>[0]> = {},
+) {
+  return {
+    auth: SIGNED_OUT_AUTH,
+    clerkEnabled: true,
+    clerkReady: true,
+    premiumAccess: false,
+    entitlement: null,
+    tabCap: { allowed: true, cap: FREE_TAB_CAP, pendingActivation: false } as const,
+    enabledPanelUsed: 12,
+    dashboardTabCount: 1,
+    freePanelCap: FREE_MAX_PANELS,
+    ...overrides,
+  };
+}
+
+function assertNoPersonalInformation(value: unknown): void {
+  const serialized = JSON.stringify(value);
+  for (const key of ACCESS_CONTEXT_PRIVACY_KEYS) {
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(value as object, key),
+      false,
+      `access context must not expose ${key}`,
+    );
+  }
+  assert.doesNotMatch(serialized, /ada@example\.com/i);
+  assert.doesNotMatch(serialized, /Ada Lovelace/);
+  assert.doesNotMatch(serialized, /user_secret_id/);
+  assert.doesNotMatch(serialized, /pk_test_|sk_live_|Bearer /);
+}
+
+describe('buildWebMcpAccessContext', () => {
+  it('reports signed-out, ready Clerk, anonymous tier, and free limits', () => {
+    const snapshot = buildWebMcpAccessContext(signedOutInput());
+    assert.equal(snapshot.accountState, 'signed_out');
+    assert.equal(snapshot.clerk, 'ready');
+    assert.equal(snapshot.productTier, 'anonymous');
+    assert.deepEqual(snapshot.capabilities, {
+      premiumAccess: false,
+      apiAccess: false,
+      mcpAccess: false,
+      dataExport: false,
+    });
+    assert.deepEqual(snapshot.limits, {
+      enabledPanels: { used: 12, cap: FREE_MAX_PANELS },
+      dashboardTabs: { used: 1, cap: FREE_TAB_CAP, canCreate: true },
+    });
+    assertNoPersonalInformation(snapshot);
+  });
+
+  it('keeps loading and Clerk-unavailable states explicit', () => {
+    const loading = buildWebMcpAccessContext(signedOutInput({
+      auth: LOADING_AUTH,
+      clerkReady: false,
+    }));
+    assert.equal(loading.accountState, 'loading');
+    assert.equal(loading.clerk, 'loading');
+    assert.equal(loading.productTier, 'unknown');
+    assert.equal(loading.limits.enabledPanels.cap, null);
+    assert.equal(loading.limits.dashboardTabs.cap, null);
+    assert.equal(loading.limits.dashboardTabs.canCreate, true);
+
+    const unavailable = buildWebMcpAccessContext(signedOutInput({
+      clerkEnabled: false,
+      clerkReady: false,
+    }));
+    assert.equal(unavailable.accountState, 'signed_out');
+    assert.equal(unavailable.clerk, 'unavailable');
+    assert.equal(unavailable.productTier, 'anonymous');
+  });
+
+  it('treats a configured Clerk that failed to load as unavailable, not loading', () => {
+    const snapshot = buildWebMcpAccessContext(signedOutInput({
+      clerkEnabled: true,
+      clerkReady: false,
+      auth: SIGNED_OUT_AUTH,
+    }));
+    assert.equal(snapshot.accountState, 'signed_out');
+    assert.equal(snapshot.clerk, 'unavailable');
+  });
+
+  it('derives signed-in free and pro capability from the same entitlement source as the dashboard', () => {
+    const free = buildWebMcpAccessContext(signedOutInput({
+      auth: FREE_AUTH,
+      premiumAccess: false,
+      entitlement: {
+        planKey: 'free',
+        features: {
+          tier: 0,
+          apiAccess: false,
+          apiRateLimit: 0,
+          maxDashboards: FREE_TAB_CAP,
+          prioritySupport: false,
+          exportFormats: [],
+          mcpAccess: false,
+          dataExport: false,
+        },
+        validUntil: Date.now() + 60_000,
+      },
+      tabCap: { allowed: false, cap: FREE_TAB_CAP, reason: 'free_tier' },
+      enabledPanelUsed: 40,
+      dashboardTabCount: 3,
+    }));
+    assert.equal(free.accountState, 'signed_in');
+    assert.equal(free.productTier, 'free');
+    assert.equal(free.capabilities.premiumAccess, false);
+    assert.equal(free.limits.enabledPanels.cap, FREE_MAX_PANELS);
+    assert.equal(free.limits.dashboardTabs.canCreate, false);
+
+    const pro = buildWebMcpAccessContext(signedOutInput({
+      auth: PRO_AUTH,
+      premiumAccess: true,
+      entitlement: {
+        planKey: 'pro',
+        features: {
+          tier: 1,
+          apiAccess: true,
+          apiRateLimit: 60,
+          maxDashboards: -1,
+          prioritySupport: true,
+          exportFormats: ['csv', 'json', 'pdf'],
+          mcpAccess: true,
+          dataExport: true,
+        },
+        validUntil: Date.now() + 60_000,
+      },
+      tabCap: { allowed: true, cap: null, pendingActivation: false },
+      enabledPanelUsed: 80,
+      dashboardTabCount: 6,
+    }));
+    assert.equal(pro.accountState, 'signed_in');
+    assert.equal(pro.productTier, 'pro');
+    assert.deepEqual(pro.capabilities, {
+      premiumAccess: true,
+      apiAccess: true,
+      mcpAccess: true,
+      dataExport: true,
+    });
+    assert.equal(pro.limits.enabledPanels.cap, null);
+    assert.equal(pro.limits.dashboardTabs.cap, null);
+    assert.equal(pro.limits.dashboardTabs.canCreate, true);
+    assertNoPersonalInformation(free);
+    assertNoPersonalInformation(pro);
+  });
+
+  it('never copies personal fields even when a caller tries to inject them', () => {
+    const snapshot = buildWebMcpAccessContext(signedOutInput({
+      auth: FREE_AUTH,
+    }));
+    const bounded = boundWebMcpAccessContext({
+      ...snapshot,
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+      userId: 'user_secret_id',
+      token: 'sess_abc',
+      sessionId: 'sess_abc',
+    } as typeof snapshot & Record<string, string>, true);
+    assert.equal(snapshot.accountState, 'signed_in');
+    assertNoPersonalInformation(snapshot);
+    assertNoPersonalInformation(bounded);
+    assert.equal(bounded.targetCancellationSupported, true);
+    assert.equal(
+      Object.keys(bounded).sort().join(','),
+      [
+        'accountState',
+        'capabilities',
+        'clerk',
+        'limits',
+        'productTier',
+        'targetCancellationSupported',
+      ].sort().join(','),
+    );
+  });
+});
+
+describe('resolveWebMcpOpenSignIn', () => {
+  it('returns clerk_unavailable when Clerk is not configured or failed to load', () => {
+    assert.deepEqual(
+      resolveWebMcpOpenSignIn({ clerkEnabled: false, clerkReady: false, alreadyOpen: false }),
+      { ok: false, status: 'denied', reason: 'clerk_unavailable' },
+    );
+    assert.deepEqual(
+      resolveWebMcpOpenSignIn({ clerkEnabled: true, clerkReady: false, alreadyOpen: false, loadFailed: true }),
+      { ok: false, status: 'denied', reason: 'clerk_unavailable' },
+    );
+  });
+
+  it('returns already_open when the Clerk modal is already visible', () => {
+    assert.deepEqual(
+      resolveWebMcpOpenSignIn({ clerkEnabled: true, clerkReady: true, alreadyOpen: true }),
+      { ok: true, status: 'already_open', reason: 'already_open' },
+    );
+  });
+
+  it('asks the host to open the existing Clerk modal and never accepts credentials', () => {
+    assert.deepEqual(
+      resolveWebMcpOpenSignIn({ clerkEnabled: true, clerkReady: true, alreadyOpen: false }),
+      { action: 'open' },
+    );
+    assert.deepEqual(
+      resolveWebMcpOpenSignIn({ clerkEnabled: true, clerkReady: false, alreadyOpen: false }),
+      { action: 'load_and_open' },
+    );
+  });
+});

--- a/tests/webmcp-access.test.mts
+++ b/tests/webmcp-access.test.mts
@@ -41,6 +41,7 @@ function signedOutInput(
     enabledPanelUsed: 12,
     dashboardTabCount: 1,
     freePanelCap: FREE_MAX_PANELS,
+    dataExport: false,
     ...overrides,
   };
 }
@@ -158,6 +159,7 @@ describe('buildWebMcpAccessContext', () => {
       tabCap: { allowed: true, cap: null, pendingActivation: false },
       enabledPanelUsed: 80,
       dashboardTabCount: 6,
+      dataExport: true,
     }));
     assert.equal(pro.accountState, 'signed_in');
     assert.equal(pro.productTier, 'pro');
@@ -172,6 +174,90 @@ describe('buildWebMcpAccessContext', () => {
     assert.equal(pro.limits.dashboardTabs.canCreate, true);
     assertNoPersonalInformation(free);
     assertNoPersonalInformation(pro);
+  });
+
+  it('keeps a signed-in account visible while entitlement is still unknown', () => {
+    const snapshot = buildWebMcpAccessContext(signedOutInput({
+      auth: FREE_AUTH,
+      premiumAccess: false,
+      entitlement: null,
+      tabCap: { allowed: false, cap: FREE_TAB_CAP, reason: 'free_tier' },
+    }));
+    assert.equal(snapshot.accountState, 'signed_in');
+    assert.equal(snapshot.productTier, 'unknown');
+    assert.equal(snapshot.limits.enabledPanels.cap, null);
+    assert.equal(snapshot.limits.dashboardTabs.cap, null);
+    assert.equal(snapshot.limits.dashboardTabs.canCreate, true);
+  });
+
+  it('keeps productTier pro when premium access is already known and entitlement is still null', () => {
+    const snapshot = buildWebMcpAccessContext(signedOutInput({
+      auth: PRO_AUTH,
+      premiumAccess: true,
+      entitlement: null,
+    }));
+    assert.equal(snapshot.accountState, 'signed_in');
+    assert.equal(snapshot.productTier, 'pro');
+    assert.equal(snapshot.limits.enabledPanels.cap, null);
+    assert.equal(snapshot.limits.dashboardTabs.cap, null);
+  });
+
+  it('takes dataExport from the reader boolean, not the entitlement feature flag', () => {
+    const freeFeatures = {
+      tier: 0,
+      apiAccess: false,
+      apiRateLimit: 0,
+      maxDashboards: FREE_TAB_CAP,
+      prioritySupport: false,
+      exportFormats: [] as string[],
+      mcpAccess: false,
+    };
+    const unlockedDespiteMissingFlag = buildWebMcpAccessContext(signedOutInput({
+      auth: FREE_AUTH,
+      entitlement: {
+        planKey: 'free',
+        features: { ...freeFeatures, dataExport: false },
+        validUntil: Date.now() + 60_000,
+      },
+      dataExport: true,
+    }));
+    assert.equal(unlockedDespiteMissingFlag.capabilities.dataExport, true);
+    assert.equal(unlockedDespiteMissingFlag.capabilities.apiAccess, false);
+    assert.equal(unlockedDespiteMissingFlag.capabilities.mcpAccess, false);
+
+    const unlockedWhenFeatureOmitted = buildWebMcpAccessContext(signedOutInput({
+      auth: FREE_AUTH,
+      entitlement: {
+        planKey: 'free',
+        features: freeFeatures,
+        validUntil: Date.now() + 60_000,
+      },
+      dataExport: true,
+    }));
+    assert.equal(unlockedWhenFeatureOmitted.capabilities.dataExport, true);
+
+    const lockedDespiteFeature = buildWebMcpAccessContext(signedOutInput({
+      auth: PRO_AUTH,
+      premiumAccess: true,
+      entitlement: {
+        planKey: 'pro',
+        features: {
+          tier: 1,
+          apiAccess: false,
+          apiRateLimit: 60,
+          maxDashboards: -1,
+          prioritySupport: true,
+          exportFormats: ['csv', 'json', 'pdf'],
+          mcpAccess: true,
+          dataExport: true,
+        },
+        validUntil: Date.now() + 60_000,
+      },
+      dataExport: false,
+    }));
+    assert.equal(lockedDespiteFeature.capabilities.dataExport, false);
+    assert.equal(lockedDespiteFeature.capabilities.mcpAccess, true);
+    assert.equal(lockedDespiteFeature.capabilities.apiAccess, false);
   });
 
   it('never copies personal fields even when a caller tries to inject them', () => {

--- a/tests/webmcp-analytics-policy.test.mjs
+++ b/tests/webmcp-analytics-policy.test.mjs
@@ -63,6 +63,22 @@ function createBindings(overrides = {}) {
       truncated: false,
     }),
     openSearchResult: async () => ({ ok: true, status: 'opened' }),
+    getAccessContext: async () => ({
+      accountState: 'signed_out',
+      clerk: 'unavailable',
+      productTier: 'anonymous',
+      capabilities: {
+        premiumAccess: false,
+        apiAccess: false,
+        mcpAccess: false,
+        dataExport: false,
+      },
+      limits: {
+        enabledPanels: { used: 1, cap: 40 },
+        dashboardTabs: { used: 1, cap: 3, canCreate: true },
+      },
+    }),
+    openSignIn: async () => ({ ok: false, status: 'denied', reason: 'clerk_unavailable' }),
     ...overrides,
   };
 }

--- a/tests/webmcp-analytics-policy.test.mjs
+++ b/tests/webmcp-analytics-policy.test.mjs
@@ -184,7 +184,7 @@ describe('WebMCP analytics privacy policy', () => {
       collected.find(({ event }) => event === 'webmcp-registered'),
       {
         event: 'webmcp-registered',
-        data: { toolCount: 7, pageSurface: 'dashboard', api: 'document-current' },
+        data: { toolCount: 9, pageSurface: 'dashboard', api: 'document-current' },
       },
     );
     assert.deepEqual(

--- a/tests/webmcp-evals.test.mjs
+++ b/tests/webmcp-evals.test.mjs
@@ -178,8 +178,8 @@ describe('offline WebMCP prediction scorer', () => {
 
     assert.equal(report.status, 'passed');
     assert.deepEqual(report.summary, {
-      total: 15,
-      passed: 15,
+      total: 18,
+      passed: 18,
       failed: 0,
       unexpected: 0,
     });

--- a/tests/webmcp-evals.test.mjs
+++ b/tests/webmcp-evals.test.mjs
@@ -60,21 +60,21 @@ describe('offline WebMCP eval corpus', () => {
     const coverage = validateEvalFixture(fixture);
 
     assert.deepEqual(fixture.toolInventory.imperative, getProductionImperativeToolNames());
-    assert.equal(coverage.caseCount, 15);
+    assert.equal(coverage.caseCount, 18);
     assert.deepEqual(coverage.categoryCounts, {
-      dashboard_context: 2,
-      dashboard_control: 4,
+      dashboard_context: 4,
+      dashboard_control: 5,
       country_brief: 2,
       search_selection: 3,
       procurement: 3,
       negative: 1,
     });
-    assert.equal(coverage.directCount, 12);
-    assert.equal(coverage.ambiguousCount, 3);
+    assert.equal(coverage.directCount, 14);
+    assert.equal(coverage.ambiguousCount, 4);
     assert.equal(coverage.alternatePlanCaseCount, 2);
     assert.equal(coverage.failureCaseCount, 3);
     assert.equal(coverage.midChainFailureCaseCount, 2);
-    assert.equal(coverage.wrongToolNegativeCaseCount, 15);
+    assert.equal(coverage.wrongToolNegativeCaseCount, 18);
     assert.equal(coverage.symbolicBindingCount, 3);
   });
 

--- a/tests/webmcp-inventory.test.mts
+++ b/tests/webmcp-inventory.test.mts
@@ -69,6 +69,22 @@ function createBindings(overrides: Record<string, unknown> = {}) {
       truncated: false,
     }),
     openSearchResult: async () => ({ ok: true, status: 'opened' as const, type: 'country' }),
+    getAccessContext: async () => ({
+      accountState: 'signed_out' as const,
+      clerk: 'unavailable' as const,
+      productTier: 'anonymous' as const,
+      capabilities: {
+        premiumAccess: false,
+        apiAccess: false,
+        mcpAccess: false,
+        dataExport: false,
+      },
+      limits: {
+        enabledPanels: { used: 1, cap: 40 },
+        dashboardTabs: { used: 1, cap: 3, canCreate: true },
+      },
+    }),
+    openSignIn: async () => ({ ok: false as const, status: 'denied' as const, reason: 'clerk_unavailable' as const }),
     ...overrides,
   };
 }
@@ -82,6 +98,8 @@ const VALID_INPUTS: Record<string, Record<string, unknown>> = {
   set_map_layers: { layers: { weather: true } },
   search_dashboard: { query: 'germany' },
   open_search_result: { resultKey: `sr_${'a'.repeat(32)}` },
+  get_access_context: {},
+  open_sign_in: {},
 };
 
 interface HomepageTool {
@@ -103,6 +121,8 @@ const WEBMCP_MAINTAINER_SOURCES = [
   'src/services/webmcp.ts',
   'src/App.ts',
   'src/app/webmcp-dashboard.ts',
+  'src/app/webmcp-access.ts',
+  'src/services/webmcp-access-snapshot.ts',
   'src/app/webmcp-search-controller.ts',
   'src/app/search-selection-dispatcher.ts',
   'src/components/GlobalProcurementPanel.ts',
@@ -130,6 +150,7 @@ const WEBMCP_FOCUSED_VERIFICATION_TESTS = [
   'tests/webmcp-runtime.test.mjs',
   'tests/webmcp-analytics-policy.test.mjs',
   'tests/webmcp-evals.test.mjs',
+  'tests/webmcp-access.test.mts',
   'tests/deploy-config.test.mjs',
 ] as const;
 
@@ -405,7 +426,7 @@ describe('WebMCP imperative schema and budget contract', () => {
     }
   });
 
-  it('applies uniform metadata, schema, output, and error budgets to all eight tools', async () => {
+  it('applies uniform metadata, schema, output, and error budgets to all dashboard tools', async () => {
     const tools = buildWebMcpTools(createBindings(), () => {});
     for (const tool of tools) {
       assert.ok(tool.name.length <= WEBMCP_TOOL_BUDGETS.nameChars, `${tool.name}: name`);
@@ -439,6 +460,8 @@ describe('WebMCP imperative schema and budget contract', () => {
       applyDashboardAction: async () => { throw privateError; },
       searchDashboard: async () => { throw privateError; },
       openSearchResult: async () => { throw privateError; },
+      getAccessContext: async () => { throw privateError; },
+      openSignIn: async () => { throw privateError; },
     }), () => {});
     for (const tool of failing) {
       await assert.rejects(tool.execute(VALID_INPUTS[tool.name]!), (error: Error) => (

--- a/tests/webmcp-runtime.test.mjs
+++ b/tests/webmcp-runtime.test.mjs
@@ -57,6 +57,22 @@ function createBindings(overrides = {}) {
       truncated: false,
     }),
     openSearchResult: async () => ({ ok: true, status: 'opened' }),
+    getAccessContext: async () => ({
+      accountState: 'signed_out',
+      clerk: 'unavailable',
+      productTier: 'anonymous',
+      capabilities: {
+        premiumAccess: false,
+        apiAccess: false,
+        mcpAccess: false,
+        dataExport: false,
+      },
+      limits: {
+        enabledPanels: { used: 1, cap: 40 },
+        dashboardTabs: { used: 1, cap: 3, canCreate: true },
+      },
+    }),
+    openSignIn: async () => ({ ok: false, status: 'denied', reason: 'clerk_unavailable' }),
     ...overrides,
   };
 }
@@ -355,7 +371,7 @@ describe('WebMCP registry behavioral contract', () => {
 
     // Chrome through 151 passes no target-side signal. These tools only move
     // visible, reversible dashboard view state, so they run anyway rather than
-    // costing 6 of 8 tools on every browser that exists.
+    // costing 7 of 10 tools on every browser that exists.
     assert.deepEqual(
       await executeRegistered(provider, 'set_map_view', JSON.stringify({ view: 'eu' })),
       {

--- a/tests/webmcp-runtime.test.mjs
+++ b/tests/webmcp-runtime.test.mjs
@@ -147,7 +147,7 @@ describe('WebMCP registry behavioral contract', () => {
     assert.deepEqual(harness.events, [
       {
         event: 'webmcp-registered',
-        data: { toolCount: 8, pageSurface: 'dashboard', api: 'document-current' },
+        data: { toolCount: WEBMCP_SPA_TOOL_NAMES.length, pageSurface: 'dashboard', api: 'document-current' },
       },
       {
         event: 'webmcp-tool-invoked',
@@ -444,7 +444,7 @@ describe('WebMCP registry behavioral contract', () => {
     ]);
     assert.deepEqual(harness.events.at(-1), {
       event: 'webmcp-registered',
-      data: { toolCount: 3, pageSurface: 'dashboard', api: 'document-current' },
+      data: { toolCount: WEBMCP_SPA_TOOL_NAMES.length - failures.size, pageSurface: 'dashboard', api: 'document-current' },
     });
     assert.equal(JSON.stringify(harness.events).includes('detail'), false);
   });

--- a/tests/webmcp.test.mjs
+++ b/tests/webmcp.test.mjs
@@ -306,7 +306,7 @@ describe('webmcp.ts: current API contract', () => {
     assert.deepEqual(access.inputSchema.properties, {});
     assert.match(access.description, /no names, emails, account IDs, tokens/i);
 
-    const snapshot = await access.execute({});
+    const snapshot = await access.execute({}, { signal: new AbortController().signal });
     assert.equal(snapshot.accountState, 'signed_out');
     assert.equal(snapshot.clerk, 'unavailable');
     assert.equal(snapshot.productTier, 'anonymous');
@@ -318,15 +318,29 @@ describe('webmcp.ts: current API contract', () => {
     assert.equal(signIn.inputSchema.additionalProperties, false);
     assert.deepEqual(signIn.inputSchema.properties, {});
     assert.match(signIn.description, /does not accept credentials/i);
-    assert.deepEqual(await signIn.execute({}), {
+    assert.deepEqual(await signIn.execute({}, { signal: new AbortController().signal }), {
       ok: false,
       status: 'denied',
       reason: 'clerk_unavailable',
     });
     await assert.rejects(
-      () => signIn.execute({ password: 'secret', otp: '123456' }),
+      () => signIn.execute(
+        { password: 'secret', otp: '123456' },
+        { signal: new AbortController().signal },
+      ),
       (error) => error.name === 'WebMcpToolError'
         && /does not accept credentials/.test(error.message),
+    );
+  });
+
+  it('passes already_open sign-in results through unchanged', async () => {
+    const tools = buildWebMcpTools(createBindings({
+      openSignIn: async () => ({ ok: true, status: 'already_open', reason: 'already_open' }),
+    }), () => {});
+    const signIn = tools.find((tool) => tool.name === 'open_sign_in');
+    assert.deepEqual(
+      await signIn.execute({}, { signal: new AbortController().signal }),
+      { ok: true, status: 'already_open', reason: 'already_open' },
     );
   });
 
@@ -369,10 +383,9 @@ describe('webmcp.ts: current API contract', () => {
       (await tools.find(({ name }) => name === 'get_dashboard_context').execute({})).variant,
       'full',
     );
-    assert.equal(
-      (await tools.find(({ name }) => name === 'get_access_context').execute({})).accountState,
-      'signed_out',
-    );
+    const accessWithoutSignal = await tools.find(({ name }) => name === 'get_access_context').execute({});
+    assert.equal(accessWithoutSignal.accountState, 'signed_out');
+    assert.equal(accessWithoutSignal.targetCancellationSupported, false);
     assert.equal(
       (await tools.find(({ name }) => name === 'search_dashboard')
         .execute({ query: 'safe' })).resultCount,

--- a/tests/webmcp.test.mjs
+++ b/tests/webmcp.test.mjs
@@ -1680,7 +1680,11 @@ describe('webmcp App.ts binding invariants', () => {
       assert.equal(text.includes('waitForDashboardReady'), false, `${name} must not wait for the map`);
     }
     callByExpression(getAccessContext, appFile, 'getWebMcpAccessContext');
-    callByExpression(openSignIn, appFile, 'openWebMcpSignIn');
+    assertCallArguments(
+      callByExpression(openSignIn, appFile, 'openWebMcpSignIn'),
+      appFile,
+      ['execution?.signal'],
+    );
   });
 
   it('resolves UI readiness after Phase 4 and wakes pending tools during destroy cleanup', () => {

--- a/tests/webmcp.test.mjs
+++ b/tests/webmcp.test.mjs
@@ -1060,7 +1060,7 @@ describe('webmcp.ts: promise registration lifecycle', () => {
     await settlePromises();
     assert.deepEqual(harness.events, [{
       event: 'webmcp-registered',
-      data: { toolCount: 8, pageSurface: 'dashboard', api: 'document-current' },
+      data: { toolCount: DASHBOARD_TOOL_NAMES.length, pageSurface: 'dashboard', api: 'document-current' },
     }]);
 
     controller.abort();
@@ -1087,7 +1087,7 @@ describe('webmcp.ts: promise registration lifecycle', () => {
       },
       {
         event: 'webmcp-registered',
-        data: { toolCount: 7, pageSurface: 'dashboard', api: 'document-current' },
+        data: { toolCount: DASHBOARD_TOOL_NAMES.length - 1, pageSurface: 'dashboard', api: 'document-current' },
       },
     ]);
     assert.ok(!JSON.stringify(harness.events).includes('raw duplicate detail'));
@@ -1639,6 +1639,35 @@ describe('webmcp App.ts binding invariants', () => {
       appFile,
       ['true', 'execution?.signal'],
     );
+  });
+
+  it('reads access context and opens sign-in without waiting for map or UI ready', () => {
+    const accessImport = findNode(
+      appFile,
+      (node) => (
+        ts.isImportDeclaration(node)
+        && ts.isStringLiteral(node.moduleSpecifier)
+        && node.moduleSpecifier.text === '@/app/webmcp-access'
+      ),
+      'static @/app/webmcp-access import',
+    );
+    const importedNames = accessImport.importClause?.namedBindings?.elements
+      .map(({ name }) => name.text) ?? [];
+    assert.ok(importedNames.includes('getWebMcpAccessContext'));
+    assert.ok(importedNames.includes('openWebMcpSignIn'));
+
+    const getAccessContext = objectPropertyInitializer(bindings, appFile, 'getAccessContext');
+    const openSignIn = objectPropertyInitializer(bindings, appFile, 'openSignIn');
+    for (const [name, initializer] of [
+      ['getAccessContext', getAccessContext],
+      ['openSignIn', openSignIn],
+    ]) {
+      const text = initializer.getText(appFile);
+      assert.equal(text.includes('waitForUiReady'), false, `${name} must not wait for UI ready`);
+      assert.equal(text.includes('waitForDashboardReady'), false, `${name} must not wait for the map`);
+    }
+    callByExpression(getAccessContext, appFile, 'getWebMcpAccessContext');
+    callByExpression(openSignIn, appFile, 'openWebMcpSignIn');
   });
 
   it('resolves UI readiness after Phase 4 and wakes pending tools during destroy cleanup', () => {

--- a/tests/webmcp.test.mjs
+++ b/tests/webmcp.test.mjs
@@ -1680,6 +1680,10 @@ describe('webmcp App.ts binding invariants', () => {
       assert.equal(text.includes('waitForDashboardReady'), false, `${name} must not wait for the map`);
     }
     callByExpression(getAccessContext, appFile, 'getWebMcpAccessContext');
+    assert.match(
+      getAccessContext.getText(appFile),
+      /freeTierFallbackActive:\s*this\.freeTierGate\.authSettleDeadlineExceeded/,
+    );
     assertCallArguments(
       callByExpression(openSignIn, appFile, 'openWebMcpSignIn'),
       appFile,

--- a/tests/webmcp.test.mjs
+++ b/tests/webmcp.test.mjs
@@ -79,6 +79,22 @@ function createBindings(overrides = {}) {
       ok: true,
       status: 'opened',
     }),
+    getAccessContext: async () => ({
+      accountState: 'signed_out',
+      clerk: 'unavailable',
+      productTier: 'anonymous',
+      capabilities: {
+        premiumAccess: false,
+        apiAccess: false,
+        mcpAccess: false,
+        dataExport: false,
+      },
+      limits: {
+        enabledPanels: { used: 1, cap: 40 },
+        dashboardTabs: { used: 1, cap: 3, canCreate: true },
+      },
+    }),
+    openSignIn: async () => ({ ok: false, status: 'denied', reason: 'clerk_unavailable' }),
     ...overrides,
   };
 }
@@ -140,6 +156,8 @@ describe('webmcp.ts: current API contract', () => {
     assert.match(src, /name:\s*WEBMCP_SPA_TOOL\.setMapLayers/);
     assert.match(src, /name:\s*WEBMCP_SPA_TOOL\.searchDashboard/);
     assert.match(src, /name:\s*WEBMCP_SPA_TOOL\.openSearchResult/);
+    assert.match(src, /name:\s*WEBMCP_SPA_TOOL\.getAccessContext/);
+    assert.match(src, /name:\s*WEBMCP_SPA_TOOL\.openSignIn/);
   });
 
   it('classifies structured denials by exact reason codes', () => {
@@ -184,7 +202,7 @@ describe('webmcp.ts: current API contract', () => {
       assert.ok(tool.title.length > 0);
       assert.equal(
         tool.annotations?.readOnlyHint,
-        ['get_dashboard_context', 'search_dashboard'].includes(tool.name),
+        ['get_access_context', 'get_dashboard_context', 'search_dashboard'].includes(tool.name),
       );
       const properties = tool.inputSchema?.properties ?? {};
       for (const property of Object.values(properties)) {
@@ -278,6 +296,40 @@ describe('webmcp.ts: current API contract', () => {
     assert.equal(open.inputSchema.properties.resultKey.pattern, '^sr_[a-f0-9]{32}$');
   });
 
+  it('publishes a PII-free access snapshot and a credential-free sign-in opener', async () => {
+    const tools = buildWebMcpTools(createBindings(), () => {});
+    const access = tools.find((tool) => tool.name === 'get_access_context');
+    const signIn = tools.find((tool) => tool.name === 'open_sign_in');
+
+    assert.deepEqual(access.annotations, { readOnlyHint: true });
+    assert.equal(access.inputSchema.additionalProperties, false);
+    assert.deepEqual(access.inputSchema.properties, {});
+    assert.match(access.description, /no names, emails, account IDs, tokens/i);
+
+    const snapshot = await access.execute({});
+    assert.equal(snapshot.accountState, 'signed_out');
+    assert.equal(snapshot.clerk, 'unavailable');
+    assert.equal(snapshot.productTier, 'anonymous');
+    assert.equal(snapshot.targetCancellationSupported, true);
+    assert.equal(Object.prototype.hasOwnProperty.call(snapshot, 'email'), false);
+    assert.equal(Object.prototype.hasOwnProperty.call(snapshot, 'userId'), false);
+
+    assert.deepEqual(signIn.annotations, { readOnlyHint: false });
+    assert.equal(signIn.inputSchema.additionalProperties, false);
+    assert.deepEqual(signIn.inputSchema.properties, {});
+    assert.match(signIn.description, /does not accept credentials/i);
+    assert.deepEqual(await signIn.execute({}), {
+      ok: false,
+      status: 'denied',
+      reason: 'clerk_unavailable',
+    });
+    await assert.rejects(
+      () => signIn.execute({ password: 'secret', otp: '123456' }),
+      (error) => error.name === 'WebMcpToolError'
+        && /does not accept credentials/.test(error.message),
+    );
+  });
+
   it('runs reversible view-state tools and gates effects that can outlive cancellation', async () => {
     let mutationCalls = 0;
     const events = [];
@@ -298,6 +350,10 @@ describe('webmcp.ts: current API contract', () => {
         mutationCalls += 1;
         return { ok: true, status: 'opened' };
       },
+      openSignIn: async () => {
+        mutationCalls += 1;
+        return { ok: true, status: 'opened' };
+      },
     }), (event, data) => events.push({ event, data }));
     const validInputs = {
       openCountryBrief: { iso2: 'DE' },
@@ -306,11 +362,16 @@ describe('webmcp.ts: current API contract', () => {
       set_map_view: { view: 'eu' },
       set_map_layers: { layers: { conflicts: true } },
       open_search_result: { resultKey: `sr_${'a'.repeat(32)}` },
+      open_sign_in: {},
     };
 
     assert.equal(
       (await tools.find(({ name }) => name === 'get_dashboard_context').execute({})).variant,
       'full',
+    );
+    assert.equal(
+      (await tools.find(({ name }) => name === 'get_access_context').execute({})).accountState,
+      'signed_out',
     );
     assert.equal(
       (await tools.find(({ name }) => name === 'search_dashboard')
@@ -354,6 +415,7 @@ describe('webmcp.ts: current API contract', () => {
       set_map_view: appliedAction('set_view'),
       set_map_layers: denial,
       open_search_result: denial,
+      open_sign_in: { ok: true, status: 'opened' },
     };
     assert.deepEqual(
       Object.keys(expected).sort(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds two dashboard WebMCP tools so a browser agent can tell **signed out**, **loading**, and **signed in** apart, and can open the existing Clerk sign-in dialog without receiving credentials or personal information.

Closes #7322.

## Type of change

- [x] New feature
- [x] Documentation

## Affected areas

- [x] Other: WebMCP dashboard tools (`get_access_context`, `open_sign_in`)

## What changed

- `get_access_context` reports account state, Clerk availability, product tier, capability flags, panel/tab limits, and whether the host supports target-side cancellation.
- Capability flags come from the same `hasPremiumAccess` + Convex entitlement source the dashboard uses. `dataExport` follows the dashboard export gate (`evaluateExportGate`), not a raw feature-flag `=== true`.
- Signed-in sessions whose Convex entitlement row has not arrived yet report `productTier: unknown` and unset caps, matching the dashboard's deferred free-tier clamp. `accountState` stays `signed_in`.
- The snapshot never includes names, emails, account IDs, tokens, or session details.
- `open_sign_in` opens the existing Clerk modal only. Extra arguments (password, OTP, provider) are rejected. Clerk-unavailable and already-open states return stable reasons.
- `open_sign_in` honors the host AbortSignal and a 30s Clerk-load timeout without aborting the shared Clerk `loadPromise`.
- `open_sign_in` reports `opened` only after the Clerk modal is present in the DOM (same selector as the production smoke). A non-throwing `openSignIn()` is not enough. If the surface never appears within the wait cap, the tool returns `clerk_unavailable`. Abort during that wait rejects without reporting opened.
- Sign-out, subscription purchase, and account mutation stay out of scope.

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] `npm run lint:boundaries` passed locally

## Documentation Alignment Checklist

- [x] English and Chinese WebMCP guides updated together
- [x] Inventory, eval corpus, and focused verification list aligned
- [x] N/A for generated proto docs / Redis keys

## Test plan

- Focused Clerk/WebMCP unit tests: signed-out, loading, signed-in, Clerk-unavailable, signed-in entitlement-unknown boot window, export-gate `dataExport`, privacy stripping, credential-free `open_sign_in`, `already_open` passthrough, production no-signal `targetCancellationSupported: false`.
- `waitForClerkSurfaceOpen`: wait-cap settlement, dual rAF+timeout retry, no open after the cap, no `opened` until the modal predicate is true, `clerk_unavailable` when the modal never appears, abort before/during the wait.
- Inventory, eval, runtime, and docs-i18n contract tests.
- `npm run typecheck`, `npm run typecheck:api`, and `npm run lint:boundaries`.
- Browser: `open_sign_in` either opens the real Clerk modal or returns `clerk_unavailable` when Clerk is not configured. The tool never receives credentials.

## Known Residuals

- `clerk: unavailable` after a configured-but-failed idle Clerk load is intentional so agents do not wait forever. `open_sign_in` still force-loads via `load_and_open`.
- `already_open` stays `{ ok: true }` as the issue asked, and still matches any Clerk auth modal (not Sign In only).
- Extra `open_sign_in` keys throw `WebMcpToolError` rather than a structured `malformed_arguments` denial. Hosts that strip callback errors will not see a dedicated reason.
- Desktop `WORLDMONITOR_API_KEY` sessions can be `signed_out` with `productTier: pro` via `hasPremiumAccess`. That matches dashboard unlocking.
- No `entitlementsReady` field. `productTier: unknown` covers the signed-in Convex-pending window.
- Docs do not require a post-sign-in `get_access_context` reread. Eval `open_sign_in_direct` still forbids `get_access_context`.
- Live `getWebMcpAccessContext` composition is not imported under `tsx` (Clerk/panels). Coverage is the snapshot leaf plus App binding AST checks and e2e.
- `getDashboardTabCount` storage vs in-memory floor remains as specified for pre-UI-ready polls.
- If Clerk has already accepted `openSignIn()` when the host aborts, the modal can still appear. The tool rejects with `AbortError` and does not report `opened`.

## Post-Deploy Monitoring & Validation

- **Logs / search:** WebMCP analytics `webmcp-tool-invoked` for `get_access_context` and `open_sign_in`; Sentry tags `surface: clerk` / `action: open-sign-in`.
- **Healthy:** signed-in users during Convex boot report `productTier: unknown` rather than `free`; `open_sign_in` returns `opened` only when the Clerk modal is present, or `already_open` / `clerk_unavailable` within the wait cap; snapshots contain no email/name/userId/token fields.
- **Failure:** agents describing paying users as free during boot; `open_sign_in` hanging; `opened` returned with no modal; Clerk modal opening after a cancelled invocation; PII keys appearing on the access snapshot.
- **Window / owner:** first production traffic after merge on the dashboard SPA. Rollback is revert of this PR. Mitigation is disable the two new tool names from the SPA inventory if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d091696-b037-44ae-9bf8-52f4ebb56375?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d091696-b037-44ae-9bf8-52f4ebb56375&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

