### PR TITLE
fix(scripts): source-attribution CLI silently no-ops on Windows

### DIFF
--- a/scripts/source-attribution.mjs
+++ b/scripts/source-attribution.mjs
@@ -1805,6 +1805,6 @@ export function runSourceAttribution({
   return 0;
 }
 
-if (process.argv[1] && process.argv[1].endsWith('scripts/source-attribution.mjs')) {
+if (process.argv[1] && process.argv[1].replace(/\\/g, '/').endsWith('scripts/source-attribution.mjs')) {
   process.exitCode = runSourceAttribution({ args: process.argv.slice(2) });
 }


### PR DESCRIPTION
## Summary

On Windows, `process.argv[1]` is an absolute path with backslash separators
(e.g. `C:\Users\me\worldmonitor\scripts\source-attribution.mjs`), so this file's
entrypoint guard

    process.argv[1].endsWith('scripts/source-attribution.mjs')

is always false. The CLI body never executes: `node scripts/source-attribution.mjs --write`
prints nothing and exits 0, silently pretending to have succeeded.

## Why it matters

Because the manifest is never regenerated on Windows, `npm run inventory:facts` fails
during `postinstall`, `api/_inventory-facts.generated.js` is never produced, and
`npm run dev` dies with:

    [plugin:vite:import-analysis] Failed to resolve import
    "./_inventory-facts.generated.js" from "api/product-catalog.js"

That is exactly the failure reported in #6885, which was closed without a code change.
The guidance embedded in that failure's own error message tells the user to
"run node scripts/source-attribution.mjs --write" — the one command that cannot work
on the platform hitting the bug.

Net effect: the README Quick Start does not work on a clean Windows checkout.

## Same bug class as #7168

#7168 fixed the identical pattern in the Dockerfile-COPY guards — a `/`-assuming path
comparison that silently no-ops on Windows. This is that same bug, in the
source-attribution entrypoint guard.

## Fix

Normalise separators before the suffix comparison. No behaviour change on macOS/Linux,
where paths contain no backslashes and the `replace` is a no-op.

## Verification

Windows 11, Node v24.18.0, npm 11.16.0.

Before: `node scripts/source-attribution.mjs --write` produced no output, exited 0,
and left the manifest untouched.

After: the same command reports
`source-attribution: 578 active hosts across 574 providers` and writes the manifest;
`node scripts/generate-inventory-facts.mjs` then succeeds, and `npm run dev` starts cleanly.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: build/install tooling — `scripts/source-attribution.mjs` entrypoint guard

## Checklist

- [x] No API keys or secrets committed
- [x] Verified on Windows 11 / Node v24.18.0 / npm 11.16.0 (before/after output above)
- [ ] Tested on worldmonitor.app variant — N/A: build-time script, does not ship in any runtime variant
- [ ] Tested on tech.worldmonitor.app variant — N/A: same reason
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist — N/A: no feeds added
- [ ] TypeScript compiles without errors (`npm run typecheck`) — N/A: plain `.mjs` build script, not part of the TypeScript project
- [ ] Health probe pre-seed / activation marker — N/A: no probes touched

## Documentation Alignment Checklist

N/A — this PR does not publish or change any documentation claims.

## Screenshots

N/A — terminal output is included in the Verification section above.

## Note

Diagnosed and drafted with AI assistance (Claude), per CONTRIBUTING.md's AI-assisted
development policy. I reproduced the failure on my own Windows machine, confirmed the
root cause by printing the guard's comparison result, and can explain the change.