### PR TITLE
fix(billing-ui): colour the plan card by coverage, not the raw status string

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -328,7 +328,11 @@ Two rules follow. Plan-to-capability mappings drift while the destination's own 
 
 ### Covering Subscription
 
-A subscription that currently grants paid coverage. Coverage is decided per status, not by the status name's plain-English reading: an active subscription covers; an on-hold subscription (payment failed, provider retrying) still covers through its retry window; a cancelled subscription covers until the end of the period already paid for; an expired subscription never covers regardless of its recorded period end. The server owns these rules; any client-side derivation must mirror them rather than re-deriving from status-string intuition. See also: Cancelled-But-Paid-Through, Billing UX State.
+A subscription that currently grants paid coverage. Coverage is decided per status, not by the status name's plain-English reading: an active subscription covers; an on-hold subscription (payment failed, provider retrying) still covers through its retry window; a cancelled subscription covers until the end of the period already paid for; an expired subscription never covers regardless of its recorded period end. The server owns these rules; any client-side derivation must mirror them rather than re-deriving from status-string intuition.
+
+The mirror is exact except at one boundary, and the exception is deliberate: the server treats the paid window as open while `currentPeriodEnd > at`, the client while `currentPeriodEnd >= at`. The client is the more permissive of the two for the single instant they differ, which is safe precisely because a Billing UX State changes copy and actions only and never grants access the server would deny — while the reverse rounding would blink a covered plan into looking lapsed between snapshots. Anything that later deduplicates the two implementations must preserve each side's boundary rather than picking one, since the comparison is load-bearing in opposite directions.
+
+Answering "does this row cover?" is also not the same as answering "does this user have access". An `active` or `on_hold` row reports covering on its fields alone whatever its period end, so a row whose renewal webhook was missed still looks covering; only the full Billing UX State derivation resolves that into pending verification or lapse. Coverage predicates are therefore safe for choosing copy and never safe as an entitlement gate. See also: Cancelled-But-Paid-Through, Billing UX State, Renewal Verification.
 
 ### Cancelled-But-Paid-Through
 

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -127,20 +127,28 @@ type AccountRequest = { userId: string; generation: number };
  * neutral grey, not red: we are inside the isEntitled() branch, so claiming a
  * problem we have not established would repeat the bug in a new colour.
  *
- * The hues match the threat-scale values in main.css (--threat-low,
- * --threat-medium, --threat-info, --threat-critical), so `ending` lands on the
- * palette's existing "informational" rung rather than inventing a colour.
+ * Three of these are threat-scale hexes from main.css (--threat-low,
+ * --threat-medium, --threat-critical); `ending` borrows --threat-info, and
+ * `unknown` is not on that scale at all — the scale has no grey rung.
  *
  * They stay literals because this card has always inlined hexes: green, yellow
  * and red were already hardcoded here, and `ending`/`unknown` follow that same
  * pattern rather than introducing a second convention mid-card. The cost is
- * that none of them pick up the [data-theme="light"] contrast overrides — so
- * on light theme this accent runs well under AA (green ~2.3:1, blue ~3.7:1).
- * Switching to var(--threat-*) would NOT fully fix that: main.css only
- * light-corrects --threat-low/-medium/-high, not --threat-info. Doing this
- * properly means light-safe values for every tone plus a light-theme render
- * test, which is its own change — see the follow-up on #7315. The status
- * sentence itself is unaffected; it uses the theme-aware var(--text-dim).
+ * that none of them pick up the [data-theme="light"] overrides, and all five
+ * are under the AA 4.5:1 floor on the light background for the 13px-bold plan
+ * name (measured with src/utils/contrast.ts against --bg #f8f9fa): #22c55e
+ * 2.16, #eab308 1.82, #3b82f6 3.49, #ef4444 3.57, #9ca3af 2.41. The first two
+ * are the very numbers main.css records next to its light overrides, so this
+ * is a bypass of a correction the team already made, not an unnoticed gap.
+ *
+ * Moving to var(--threat-*) is NOT sufficient on its own: the light block
+ * overrides only --threat-high/-medium/-low, so --threat-info and
+ * --threat-critical resolve to the same failing hexes in both themes and the
+ * fix would look landed while `ending` and `ended` still failed. Closing this
+ * needs light overrides for those two tokens (compare --defcon-4 #0284c7, the
+ * sky-600 the light theme already uses for blue) plus a light-safe grey, and a
+ * light-theme render test — its own change, see the follow-up on #7315.
+ * The status sentence is unaffected; it uses the theme-aware var(--text-dim).
  */
 const BILLING_TONE_COLORS: Record<BillingStatusTone, string> = {
   active: '#22c55e',

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -48,7 +48,6 @@ import {
   deriveBillingUxState,
   getReactivationHref,
   getSubscriptionStatusTone,
-  isSubscriptionCoveringAt,
   type BillingStatusTone,
 } from '@/services/billing-state';
 import { createApiKey, listApiKeys, revokeApiKey, type ApiKeyInfo } from '@/services/api-keys';
@@ -128,13 +127,20 @@ type AccountRequest = { userId: string; generation: number };
  * neutral grey, not red: we are inside the isEntitled() branch, so claiming a
  * problem we have not established would repeat the bug in a new colour.
  *
- * The four hues are the threat-scale values from main.css (--threat-low,
+ * The hues match the threat-scale values in main.css (--threat-low,
  * --threat-medium, --threat-info, --threat-critical), so `ending` lands on the
  * palette's existing "informational" rung rather than inventing a colour.
- * Kept as literals because this card has always inlined hexes; that also means
- * it does not pick up the [data-theme="light"] contrast overrides those tokens
- * carry — pre-existing for all four, and worth a follow-up that moves the whole
- * card onto the vars rather than a partial switch here.
+ *
+ * They stay literals because this card has always inlined hexes: green, yellow
+ * and red were already hardcoded here, and `ending`/`unknown` follow that same
+ * pattern rather than introducing a second convention mid-card. The cost is
+ * that none of them pick up the [data-theme="light"] contrast overrides — so
+ * on light theme this accent runs well under AA (green ~2.3:1, blue ~3.7:1).
+ * Switching to var(--threat-*) would NOT fully fix that: main.css only
+ * light-corrects --threat-low/-medium/-high, not --threat-info. Doing this
+ * properly means light-safe values for every tone plus a light-theme render
+ * test, which is its own change — see the follow-up on #7315. The status
+ * sentence itself is unaffected; it uses the theme-aware var(--text-dim).
  */
 const BILLING_TONE_COLORS: Record<BillingStatusTone, string> = {
   active: '#22c55e',
@@ -1066,13 +1072,15 @@ export class UnifiedSettings {
         } else if (sub.status === 'on_hold') {
           statusLine = 'On hold -- please update payment method';
         } else if (sub.status === 'cancelled') {
-          // Same predicate as the tone above, so the sentence and the colour
-          // always agree about whether access is still running (#7315).
-          statusLine = isSubscriptionCoveringAt(sub, now)
-            ? `Cancelled -- access until ${dateStr}`
-            : `Cancelled -- access ended ${dateStr}`;
+          statusLine = `Cancelled -- access until ${dateStr}`;
         } else if (sub.status === 'expired') {
           statusLine = 'Expired';
+        } else {
+          // A status this client does not model yet. We are inside the
+          // isEntitled() branch, so access is working — say only that, and
+          // point at the billing portal rather than leaving the `unknown`
+          // tone as a bare grey dot with no sentence at all.
+          statusLine = 'See Manage Billing for your current plan details.';
         }
       }
 

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -44,7 +44,13 @@ import {
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { getSubscription, isSubscriptionLoaded, onSubscriptionChange, openBillingPortal, prereserveBillingPortalTab } from '@/services/billing';
 import { BusinessSeatsSection } from '@/components/BusinessSeatsSection';
-import { deriveBillingUxState, getReactivationHref } from '@/services/billing-state';
+import {
+  deriveBillingUxState,
+  getReactivationHref,
+  getSubscriptionStatusTone,
+  isSubscriptionCoveringAt,
+  type BillingStatusTone,
+} from '@/services/billing-state';
 import { createApiKey, listApiKeys, revokeApiKey, type ApiKeyInfo } from '@/services/api-keys';
 import { listMcpClients, revokeMcpClient, fetchMcpQuota, type McpClientInfo, type McpQuota } from '@/services/mcp-clients';
 import {
@@ -109,6 +115,34 @@ export interface UnifiedSettingsConfig {
 
 type TabId = UnifiedSettingsTabId;
 type AccountRequest = { userId: string; generation: number };
+
+/**
+ * Plan-card palette per billing status tone (#7315).
+ *
+ * The tone comes from the shared coverage predicate in billing-state.ts, never
+ * from a status string compared here — a cancelled plan still inside its paid
+ * window is a paying customer and must not be painted like a dead account. The
+ * `33`/`0a` suffixes are the border and background alpha of the base hue.
+ *
+ * `unknown` (a provider status this client does not model) is deliberately the
+ * neutral grey, not red: we are inside the isEntitled() branch, so claiming a
+ * problem we have not established would repeat the bug in a new colour.
+ *
+ * The four hues are the threat-scale values from main.css (--threat-low,
+ * --threat-medium, --threat-info, --threat-critical), so `ending` lands on the
+ * palette's existing "informational" rung rather than inventing a colour.
+ * Kept as literals because this card has always inlined hexes; that also means
+ * it does not pick up the [data-theme="light"] contrast overrides those tokens
+ * carry — pre-existing for all four, and worth a follow-up that moves the whole
+ * card onto the vars rather than a partial switch here.
+ */
+const BILLING_TONE_COLORS: Record<BillingStatusTone, string> = {
+  active: '#22c55e',
+  attention: '#eab308',
+  ending: '#3b82f6',
+  ended: '#ef4444',
+  unknown: '#9ca3af',
+};
 
 export class UnifiedSettings {
   private overlay: HTMLElement;
@@ -1013,15 +1047,16 @@ export class UnifiedSettings {
         return this.renderPlanCheckingState();
       }
       const planName = sub?.displayName ?? 'Pro';
+      const now = Date.now();
       // A Business Pro grant invitee has no own subscription row (sub === null)
-      // but IS entitled (we're inside the isEntitled() branch) — treat that as
-      // 'active' rather than falling through to the red "problem" color, which
-      // the ternaries below would otherwise do for every status value that
-      // isn't literally 'active'/'on_hold'.
-      const effectiveStatus = sub?.status ?? 'active';
-      const statusColor = effectiveStatus === 'active' ? '#22c55e' : effectiveStatus === 'on_hold' ? '#eab308' : '#ef4444';
-      const statusBorderColor = effectiveStatus === 'active' ? '#22c55e33' : effectiveStatus === 'on_hold' ? '#eab30833' : '#ef444433';
-      const statusBgColor = effectiveStatus === 'active' ? '#22c55e0a' : effectiveStatus === 'on_hold' ? '#eab3080a' : '#ef44440a';
+      // but IS entitled (we're inside the isEntitled() branch) — they hold a
+      // grant that is working, so paint them like an active plan.
+      const tone: BillingStatusTone = sub === null
+        ? 'active'
+        : getSubscriptionStatusTone(sub, now);
+      const statusColor = BILLING_TONE_COLORS[tone];
+      const statusBorderColor = `${statusColor}33`;
+      const statusBgColor = `${statusColor}0a`;
 
       let statusLine = '';
       if (sub?.currentPeriodEnd) {
@@ -1031,7 +1066,11 @@ export class UnifiedSettings {
         } else if (sub.status === 'on_hold') {
           statusLine = 'On hold -- please update payment method';
         } else if (sub.status === 'cancelled') {
-          statusLine = `Cancelled -- access until ${dateStr}`;
+          // Same predicate as the tone above, so the sentence and the colour
+          // always agree about whether access is still running (#7315).
+          statusLine = isSubscriptionCoveringAt(sub, now)
+            ? `Cancelled -- access until ${dateStr}`
+            : `Cancelled -- access ended ${dateStr}`;
         } else if (sub.status === 'expired') {
           statusLine = 'Expired';
         }

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -120,43 +120,17 @@ type AccountRequest = { userId: string; generation: number };
  *
  * The tone comes from the shared coverage predicate in billing-state.ts, never
  * from a status string compared here — a cancelled plan still inside its paid
- * window is a paying customer and must not be painted like a dead account. The
- * `33`/`0a` suffixes are the border and background alpha of the base hue.
+ * window is a paying customer and must not be painted like a dead account.
  *
  * `unknown` (a provider status this client does not model) is deliberately the
  * neutral grey, not red: we are inside the isEntitled() branch, so claiming a
  * problem we have not established would repeat the bug in a new colour.
  *
- * Three of these are threat-scale hexes from main.css (--threat-low,
- * --threat-medium, --threat-critical); `ending` borrows --threat-info, and
- * `unknown` is not on that scale at all — the scale has no grey rung.
- *
- * They stay literals because this card has always inlined hexes: green, yellow
- * and red were already hardcoded here, and `ending`/`unknown` follow that same
- * pattern rather than introducing a second convention mid-card. The cost is
- * that none of them pick up the [data-theme="light"] overrides, and all five
- * are under the AA 4.5:1 floor on the light background for the 13px-bold plan
- * name (measured with src/utils/contrast.ts against --bg #f8f9fa): #22c55e
- * 2.16, #eab308 1.82, #3b82f6 3.49, #ef4444 3.57, #9ca3af 2.41. The first two
- * are the very numbers main.css records next to its light overrides, so this
- * is a bypass of a correction the team already made, not an unnoticed gap.
- *
- * Moving to var(--threat-*) is NOT sufficient on its own: the light block
- * overrides only --threat-high/-medium/-low, so --threat-info and
- * --threat-critical resolve to the same failing hexes in both themes and the
- * fix would look landed while `ending` and `ended` still failed. Closing this
- * needs light overrides for those two tokens (compare --defcon-4 #0284c7, the
- * sky-600 the light theme already uses for blue) plus a light-safe grey, and a
- * light-theme render test — its own change, see the follow-up on #7315.
- * The status sentence is unaffected; it uses the theme-aware var(--text-dim).
+ * Colours live on `--billing-tone-*` in main.css so [data-theme="light"] can
+ * raise every tone to WCAG AA for the 13px-bold plan name. The card only
+ * stamps `data-billing-tone`; it must not inline hex, or those overrides
+ * never apply. The status sentence stays on theme-aware var(--text-dim).
  */
-const BILLING_TONE_COLORS: Record<BillingStatusTone, string> = {
-  active: '#22c55e',
-  attention: '#eab308',
-  ending: '#3b82f6',
-  ended: '#ef4444',
-  unknown: '#9ca3af',
-};
 
 export class UnifiedSettings {
   private overlay: HTMLElement;
@@ -1068,9 +1042,6 @@ export class UnifiedSettings {
       const tone: BillingStatusTone = sub === null
         ? 'active'
         : getSubscriptionStatusTone(sub, now);
-      const statusColor = BILLING_TONE_COLORS[tone];
-      const statusBorderColor = `${statusColor}33`;
-      const statusBgColor = `${statusColor}0a`;
 
       let statusLine = '';
       if (sub?.currentPeriodEnd) {
@@ -1102,10 +1073,10 @@ export class UnifiedSettings {
       }
 
       return `
-        <div class="upgrade-pro-section upgrade-pro-active" style="margin-top:16px;padding:14px 16px;border:1px solid ${statusBorderColor};border-radius:6px;background:${statusBgColor};">
+        <div class="upgrade-pro-section upgrade-pro-active" data-billing-tone="${tone}">
           <div style="display:flex;align-items:center;gap:8px;margin-bottom:${statusLine ? '8' : '0'}px;">
-            <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${statusColor};flex-shrink:0;"></span>
-            <span style="color:${statusColor};font-weight:600;font-size:calc(13px * var(--wm-panel-effective-scale, 1));">${escapeHtml(planName)}</span>
+            <span class="upgrade-pro-tone-dot"></span>
+            <span class="upgrade-pro-plan-name">${escapeHtml(planName)}</span>
           </div>
           ${statusLine ? `<div class="upgrade-pro-status-line">${escapeHtml(statusLine)}</div>` : ''}
           ${sub?.planKey === 'api_starter' ? `<button class="upgrade-to-business-btn" style="margin-right:8px;">Upgrade to Business</button>` : ''}

--- a/src/services/billing-state.ts
+++ b/src/services/billing-state.ts
@@ -42,13 +42,20 @@ export type BillingUxState =
 export type BillingStatusTone = 'active' | 'attention' | 'ending' | 'ended' | 'unknown';
 
 /**
- * Whether a subscription row still grants access at `at`.
+ * Whether this row's status/period FIELDS say it covers `at`.
  *
- * The one coverage predicate on the client: `deriveBillingUxState` and
- * `getSubscriptionStatusTone` both read it, so the gating verdict and the
- * colour a user sees cannot disagree (#7315 — the settings panel had its own
- * inline status ternary and painted a cancelled-but-paid-through plan the same
- * red as a dead one).
+ * NOT an access decision, and never safe as an entitlement gate. `active` and
+ * `on_hold` return true regardless of `currentPeriodEnd`, so a row whose
+ * renewal webhook was missed still "covers" here while `deriveBillingUxState`
+ * correctly routes it to `renewal_verification_*`/`lapsed` — the exact case
+ * this module was built for (#4770/#4771). Anything deciding access must call
+ * `deriveBillingUxState`; this only answers the narrower field-level question.
+ *
+ * Its purpose is to be the single shared spelling of that question, so the
+ * cancelled-but-paid-through rule cannot be re-derived from status-string
+ * intuition in one place and not another (#7315 — the settings panel had its
+ * own inline ternary and painted a paid-through plan the same red as a dead
+ * one). `deriveBillingUxState` and `getSubscriptionStatusTone` both read it.
  *
  * Mirrors `isCoveringAt` in convex/payments/subscriptionHelpers.ts: active,
  * on_hold (retry window keeps entitlement per business policy), or

--- a/src/services/billing-state.ts
+++ b/src/services/billing-state.ts
@@ -62,7 +62,9 @@ export type BillingStatusTone = 'active' | 'attention' | 'ending' | 'ended' | 'u
  * cancelled-but-paid-through. `expired` never covers, whatever its period end.
  * Boundary differs deliberately from the server helper's `>`: the client keeps
  * the inclusive `>=` this module has always used, so a row landing exactly on
- * `now` never blinks locked between snapshots.
+ * `now` never blinks locked between snapshots. That exception is recorded in
+ * CONCEPTS.md § Covering Subscription — a later dedup of the two helpers has to
+ * preserve both boundaries rather than picking one.
  */
 export function isSubscriptionCoveringAt(
   sub: Pick<BillingSubscriptionSnapshot, 'status' | 'currentPeriodEnd'>,

--- a/src/services/billing-state.ts
+++ b/src/services/billing-state.ts
@@ -87,6 +87,12 @@ export function isSubscriptionCoveringAt(
  * `unknown` is the explicit escape for a provider status this client does not
  * model yet. It exists so a new Dodo status cannot be swallowed into the
  * end-of-coverage tone and assert to an entitled user that their plan is dead.
+ *
+ * The `default` arm is a RUNTIME escape only. Left bare it would also silence
+ * the compiler: widening the status union (convex/schema.ts keeps it to these
+ * four) would then typecheck clean and ship as a permanently unexplained grey
+ * card. The `never` assignment keeps the runtime fallback while making that
+ * widening a build error, so a new status has to be given a tone deliberately.
  */
 export function getSubscriptionStatusTone(
   sub: Pick<BillingSubscriptionSnapshot, 'status' | 'currentPeriodEnd'>,
@@ -101,8 +107,11 @@ export function getSubscriptionStatusTone(
       return isSubscriptionCoveringAt(sub, at) ? 'ending' : 'ended';
     case 'expired':
       return 'ended';
-    default:
+    default: {
+      const unhandled: never = sub.status;
+      void unhandled;
       return 'unknown';
+    }
   }
 }
 

--- a/src/services/billing-state.ts
+++ b/src/services/billing-state.ts
@@ -38,6 +38,67 @@ export type BillingUxState =
   | 'renewal_verification_failed'
   | 'lapsed';
 
+/** Coverage-derived visual tone for a subscription row. See getSubscriptionStatusTone. */
+export type BillingStatusTone = 'active' | 'attention' | 'ending' | 'ended' | 'unknown';
+
+/**
+ * Whether a subscription row still grants access at `at`.
+ *
+ * The one coverage predicate on the client: `deriveBillingUxState` and
+ * `getSubscriptionStatusTone` both read it, so the gating verdict and the
+ * colour a user sees cannot disagree (#7315 — the settings panel had its own
+ * inline status ternary and painted a cancelled-but-paid-through plan the same
+ * red as a dead one).
+ *
+ * Mirrors `isCoveringAt` in convex/payments/subscriptionHelpers.ts: active,
+ * on_hold (retry window keeps entitlement per business policy), or
+ * cancelled-but-paid-through. `expired` never covers, whatever its period end.
+ * Boundary differs deliberately from the server helper's `>`: the client keeps
+ * the inclusive `>=` this module has always used, so a row landing exactly on
+ * `now` never blinks locked between snapshots.
+ */
+export function isSubscriptionCoveringAt(
+  sub: Pick<BillingSubscriptionSnapshot, 'status' | 'currentPeriodEnd'>,
+  at: number,
+): boolean {
+  return (
+    sub.status === 'active'
+    || sub.status === 'on_hold'
+    || (sub.status === 'cancelled' && sub.currentPeriodEnd >= at)
+  );
+}
+
+/**
+ * How a subscription row should be *painted*, as a tone rather than a colour —
+ * the palette stays in the component.
+ *
+ * Split from `deriveBillingUxState` on purpose: that answers "does access
+ * work", which is the same `active` for a renewing plan and a cancelled one
+ * still inside its paid window. The panel needs to tell those apart, because a
+ * cancelled-but-paid-through plan IS ending — just not today (#7315).
+ *
+ * `unknown` is the explicit escape for a provider status this client does not
+ * model yet. It exists so a new Dodo status cannot be swallowed into the
+ * end-of-coverage tone and assert to an entitled user that their plan is dead.
+ */
+export function getSubscriptionStatusTone(
+  sub: Pick<BillingSubscriptionSnapshot, 'status' | 'currentPeriodEnd'>,
+  at: number,
+): BillingStatusTone {
+  switch (sub.status) {
+    case 'active':
+      return 'active';
+    case 'on_hold':
+      return 'attention';
+    case 'cancelled':
+      return isSubscriptionCoveringAt(sub, at) ? 'ending' : 'ended';
+    case 'expired':
+      return 'ended';
+    default:
+      return 'unknown';
+  }
+}
+
 /**
  * Precedence, mirroring the affirmative-denial philosophy of panel gating
  * (never over-gate on missing data):
@@ -73,7 +134,9 @@ export function deriveBillingUxState(
     if (sub.currentPeriodEnd >= now) return 'active';
     return 'renewal_verification_pending';
   }
-  if (sub.status === 'cancelled' && sub.currentPeriodEnd >= now) return 'active';
+  // Only `cancelled`/`expired`/unknown reach here (on_hold and active returned
+  // above), so this is the cancelled-but-paid-through arm of the predicate.
+  if (isSubscriptionCoveringAt(sub, now)) return 'active';
   return 'lapsed';
 }
 

--- a/src/styles/happy-theme.css
+++ b/src/styles/happy-theme.css
@@ -29,6 +29,13 @@
   --text-ghost: #84908A; /* was #C0C8C2 (1.6:1); 3.2:1 — decorative/large text only, never body copy */
   --accent: #3D4A3E;
 
+  /* The happy variant defaults to this light surface even without data-theme. */
+  --billing-tone-active: #15803d;
+  --billing-tone-attention: #a16207;
+  --billing-tone-ending: #2563eb;
+  --billing-tone-ended: #b91c1c;
+  --billing-tone-unknown: #4b5563;
+
   /* Overlays & shadows */
   --overlay-subtle: rgba(107, 143, 94, 0.03);
   --overlay-light: rgba(107, 143, 94, 0.05);
@@ -118,6 +125,13 @@
   --text-faint: #8F978F; /* was #606860 (2.4:1); AA 4.6:1 */
   --text-ghost: #78807A; /* was #485048 (1.7:1); 3.4:1 — decorative/large text only, never body copy */
   --accent: #E8E4DC;
+
+  /* Lighter tones retain AA contrast on the happy dark panel surface. */
+  --billing-tone-active: #8BAF7A;
+  --billing-tone-attention: #D4B36A;
+  --billing-tone-ending: #8BB5D4;
+  --billing-tone-ended: #D49BAF;
+  --billing-tone-unknown: #A0A098;
 
   /* Overlays & shadows */
   --overlay-subtle: rgba(139, 175, 122, 0.03);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -96,6 +96,15 @@
   --threat-low: #22c55e;
   --threat-info: #3b82f6;
 
+  /* Plan-card billing tones (#7315). Dark hexes match the threat scale
+     (unknown is a dedicated grey — the scale has no grey rung). Light
+     overrides below raise every tone to WCAG AA on --bg / --surface. */
+  --billing-tone-active: #22c55e;
+  --billing-tone-attention: #eab308;
+  --billing-tone-ending: #3b82f6;
+  --billing-tone-ended: #ef4444;
+  --billing-tone-unknown: #9ca3af;
+
   /* DEFCON levels */
   --defcon-1: #ff0040;
   --defcon-2: #ff4400;
@@ -138,6 +147,16 @@
   /* Tailwind yellow-600 (was #eab308, 1.82:1) */
   --threat-low: #15803d;
   /* Tailwind green-700 (was #22c55e, 2.16:1) */
+  --billing-tone-active: #15803d;
+  /* green-700; was #22c55e 2.16:1 on --bg */
+  --billing-tone-attention: #a16207;
+  /* yellow-700; was #eab308 1.82:1 — yellow-600 #ca8a04 is still 2.79:1 */
+  --billing-tone-ending: #2563eb;
+  /* blue-600; was #3b82f6 3.49:1 — sky-600 #0284c7 is still 3.89:1 */
+  --billing-tone-ended: #b91c1c;
+  /* red-700; was #ef4444 3.57:1 */
+  --billing-tone-unknown: #4b5563;
+  /* gray-600; was #9ca3af 2.41:1 */
   --defcon-3: #d97706;
   /* Tailwind amber-600 (was #ffaa00, 1.81:1) */
   --defcon-4: #0284c7;
@@ -26159,6 +26178,33 @@ body.map-width-resizing {
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--surface);
+}
+
+.upgrade-pro-section[data-billing-tone] {
+  --billing-tone: var(--billing-tone-unknown);
+  border-color: color-mix(in srgb, var(--billing-tone) 20%, transparent);
+  background: color-mix(in srgb, var(--billing-tone) 4%, transparent);
+}
+
+.upgrade-pro-section[data-billing-tone="active"] { --billing-tone: var(--billing-tone-active); }
+.upgrade-pro-section[data-billing-tone="attention"] { --billing-tone: var(--billing-tone-attention); }
+.upgrade-pro-section[data-billing-tone="ending"] { --billing-tone: var(--billing-tone-ending); }
+.upgrade-pro-section[data-billing-tone="ended"] { --billing-tone: var(--billing-tone-ended); }
+.upgrade-pro-section[data-billing-tone="unknown"] { --billing-tone: var(--billing-tone-unknown); }
+
+.upgrade-pro-tone-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--billing-tone);
+  flex-shrink: 0;
+}
+
+.upgrade-pro-plan-name {
+  color: var(--billing-tone);
+  font-weight: 600;
+  font-size: calc(13px * var(--wm-panel-effective-scale, 1));
 }
 
 .upgrade-pro-title {

--- a/tests/billing-state.test.mts
+++ b/tests/billing-state.test.mts
@@ -15,6 +15,8 @@ import {
   getBillingBannerVariant,
   getBillingGateOverride,
   getReactivationHref,
+  getSubscriptionStatusTone,
+  isSubscriptionCoveringAt,
   type BillingSubscriptionSnapshot,
   type BillingEntitlementSnapshot,
 } from '@/services/billing-state';
@@ -284,5 +286,87 @@ describe('getReactivationHref', () => {
     assert.equal(getReactivationHref('pro_annual'), '/pro?wm_reactivate_plan=pro_annual#pricing');
     assert.equal(getReactivationHref('pro_monthly'), '/pro?wm_reactivate_plan=pro_monthly#pricing');
     assert.equal(getReactivationHref(null), '/pro#pricing');
+  });
+});
+
+describe('isSubscriptionCoveringAt (#7315)', () => {
+  it('is the single predicate behind both the UX state and the status tone', () => {
+    // deriveBillingUxState and getSubscriptionStatusTone must not drift: the
+    // same cancelled row that keeps coverage here cannot be `lapsed` there.
+    const paidThrough = sub({ status: 'cancelled' });
+    assert.equal(isSubscriptionCoveringAt(paidThrough, NOW), true);
+    assert.equal(deriveBillingUxState(paidThrough, null, NOW), 'active');
+    assert.equal(getSubscriptionStatusTone(paidThrough, NOW), 'ending');
+
+    const lapsedRow = sub({ status: 'cancelled', currentPeriodEnd: NOW - DAY });
+    assert.equal(isSubscriptionCoveringAt(lapsedRow, NOW), false);
+    assert.equal(deriveBillingUxState(lapsedRow, null, NOW), 'lapsed');
+    assert.equal(getSubscriptionStatusTone(lapsedRow, NOW), 'ended');
+  });
+
+  it('active and on_hold cover regardless of the period end (retry window keeps access)', () => {
+    assert.equal(isSubscriptionCoveringAt(sub({ currentPeriodEnd: NOW - DAY }), NOW), true);
+    assert.equal(
+      isSubscriptionCoveringAt(sub({ status: 'on_hold', currentPeriodEnd: NOW - DAY }), NOW),
+      true,
+    );
+  });
+
+  it('expired never covers, even with a future period end', () => {
+    assert.equal(
+      isSubscriptionCoveringAt(sub({ status: 'expired', currentPeriodEnd: NOW + DAY }), NOW),
+      false,
+    );
+  });
+
+  it('an unrecognised runtime status does not cover (fail closed)', () => {
+    const bogus = sub({ status: 'paused' as unknown as 'active' });
+    assert.equal(isSubscriptionCoveringAt(bogus, NOW), false);
+  });
+});
+
+describe('getSubscriptionStatusTone (#7315)', () => {
+  it('a renewing subscription is the active tone', () => {
+    assert.equal(getSubscriptionStatusTone(sub(), NOW), 'active');
+  });
+
+  it('on_hold is the attention tone, even inside the paid period', () => {
+    assert.equal(getSubscriptionStatusTone(sub({ status: 'on_hold' }), NOW), 'attention');
+  });
+
+  it('cancelled-but-paid-through is `ending`, NOT the tone expired gets (#7315)', () => {
+    // The bug this test locks: the panel painted both in the same red, so a
+    // subscriber with a month of Pro left read their plan as already dead.
+    const tone = getSubscriptionStatusTone(sub({ status: 'cancelled' }), NOW);
+    assert.equal(tone, 'ending');
+    assert.notEqual(tone, getSubscriptionStatusTone(sub({ status: 'expired' }), NOW));
+  });
+
+  it('cancelled past the paid period is the ended tone', () => {
+    assert.equal(
+      getSubscriptionStatusTone(sub({ status: 'cancelled', currentPeriodEnd: NOW - DAY }), NOW),
+      'ended',
+    );
+  });
+
+  it('expired is the ended tone even with a future period end (mirrors isCoveringAt)', () => {
+    assert.equal(
+      getSubscriptionStatusTone(sub({ status: 'expired', currentPeriodEnd: NOW + DAY }), NOW),
+      'ended',
+    );
+  });
+
+  it('boundary: cancelled with currentPeriodEnd exactly now is still covering', () => {
+    assert.equal(
+      getSubscriptionStatusTone(sub({ status: 'cancelled', currentPeriodEnd: NOW }), NOW),
+      'ending',
+    );
+  });
+
+  it('an unrecognised runtime status is an explicit `unknown`, never silently ended', () => {
+    // A new provider status must not be asserted as a dead plan to a user the
+    // entitlement engine still considers entitled.
+    const bogus = sub({ status: 'paused' as unknown as 'active' });
+    assert.equal(getSubscriptionStatusTone(bogus, NOW), 'unknown');
   });
 });

--- a/tests/contrast.test.mts
+++ b/tests/contrast.test.mts
@@ -4,6 +4,40 @@ import { readFileSync } from 'node:fs';
 
 import { readableTextColor, contrastRatio, relativeLuminance } from '../src/utils/contrast.ts';
 
+const readFile = (rel: string): string =>
+  readFileSync(new URL(`../${rel}`, import.meta.url), 'utf8');
+
+/**
+ * Brace-match the rule that starts at `blockStart`. Markers must include the
+ * opening `{` so a comment such as `overridden by [data-theme="light"] below`
+ * cannot steal the light-theme lookup, and so a prefix such as
+ * `:root[data-variant="happy"]` cannot leak into the happy-dark block.
+ */
+function extractBlock(css: string, blockStart: string): string {
+  const start = css.indexOf(blockStart);
+  assert.ok(start >= 0, `theme block not found: ${blockStart}`);
+  const open = css.indexOf('{', start);
+  assert.ok(open >= 0, `opening brace for ${blockStart} not found`);
+  let depth = 0;
+  for (let i = open; i < css.length; i++) {
+    const ch = css[i];
+    if (ch === '{') depth += 1;
+    else if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) return css.slice(open, i + 1);
+    }
+  }
+  assert.fail(`unclosed theme block: ${blockStart}`);
+}
+
+/** Extract the first `--name: #hex` inside the brace-bounded `blockStart` rule. */
+function token(css: string, blockStart: string, name: string): string {
+  const slice = extractBlock(css, blockStart);
+  const m = slice.match(new RegExp(`${name}:\\s*(#[0-9a-fA-F]{3,8})`));
+  assert.ok(m, `${name} not found in block ${blockStart}`);
+  return m![1]!;
+}
+
 describe('contrast util', () => {
   it('computes WCAG contrast ratio at the extremes', () => {
     assert.equal(Math.round(contrastRatio('#ffffff', '#000000')), 21);
@@ -51,40 +85,6 @@ describe('contrast util', () => {
  * non-text / large-text floor.
  */
 describe('theme text-token contrast', () => {
-  const readFile = (rel: string): string =>
-    readFileSync(new URL(`../${rel}`, import.meta.url), 'utf8');
-
-  /**
-   * Brace-match the rule that starts at `blockStart`. Markers must include the
-   * opening `{` so a comment such as `overridden by [data-theme="light"] below`
-   * cannot steal the light-theme lookup, and so a prefix such as
-   * `:root[data-variant="happy"]` cannot leak into the happy-dark block.
-   */
-  const extractBlock = (css: string, blockStart: string): string => {
-    const start = css.indexOf(blockStart);
-    assert.ok(start >= 0, `theme block not found: ${blockStart}`);
-    const open = css.indexOf('{', start);
-    assert.ok(open >= 0, `opening brace for ${blockStart} not found`);
-    let depth = 0;
-    for (let i = open; i < css.length; i++) {
-      const ch = css[i];
-      if (ch === '{') depth += 1;
-      else if (ch === '}') {
-        depth -= 1;
-        if (depth === 0) return css.slice(open, i + 1);
-      }
-    }
-    assert.fail(`unclosed theme block: ${blockStart}`);
-  };
-
-  /** Extract the first `--name: #hex` inside the brace-bounded `blockStart` rule. */
-  const token = (css: string, blockStart: string, name: string): string => {
-    const slice = extractBlock(css, blockStart);
-    const m = slice.match(new RegExp(`${name}:\\s*(#[0-9a-fA-F]{3,8})`));
-    assert.ok(m, `${name} not found in block ${blockStart}`);
-    return m![1]!;
-  };
-
   const mainCss = readFile('src/styles/main.css');
   const happyCss = readFile('src/styles/happy-theme.css');
 
@@ -125,4 +125,86 @@ describe('theme text-token contrast', () => {
       }
     });
   }
+});
+
+/**
+ * Guard the plan-card billing tones (#7315 / #7340). The 13px-bold plan name
+ * reads `--billing-tone-*` as its foreground; every theme that defines those
+ * tokens must keep them at WCAG AA (4.5:1) on both --bg and --surface.
+ * Light values are the ones that used to fail (3.49:1 / 2.41:1 for ending /
+ * unknown) when the card inlined dark-theme hex.
+ */
+describe('billing tone contrast', () => {
+  const mainCss = readFile('src/styles/main.css');
+  const settingsSource = readFile('src/components/UnifiedSettings.ts');
+  const tones = [
+    '--billing-tone-active',
+    '--billing-tone-attention',
+    '--billing-tone-ending',
+    '--billing-tone-ended',
+    '--billing-tone-unknown',
+  ] as const;
+
+  /** Dark tokens live in the second `:root` (semantic/threat), not the first. */
+  const tokenInAnyRoot = (css: string, name: string): string => {
+    let searchFrom = 0;
+    while (searchFrom < css.length) {
+      const idx = css.indexOf(':root {', searchFrom);
+      if (idx < 0) break;
+      const slice = extractBlock(css.slice(idx), ':root {');
+      const m = slice.match(new RegExp(`${name}:\\s*(#[0-9a-fA-F]{3,8})`));
+      if (m) return m[1]!;
+      searchFrom = idx + 7;
+    }
+    assert.fail(`${name} not found in any :root block`);
+  };
+
+  it('paints the plan name from data-billing-tone, not an inlined hex', () => {
+    assert.match(
+      settingsSource,
+      /data-billing-tone="\$\{tone\}"/,
+      'the entitled plan card must stamp data-billing-tone so light overrides apply',
+    );
+    assert.match(
+      settingsSource,
+      /class="upgrade-pro-plan-name"/,
+      'the 13px plan name must use the theme-aware class, not an inline color',
+    );
+    assert.doesNotMatch(
+      settingsSource,
+      /BILLING_TONE_COLORS/,
+      'inlined hex map would bypass [data-theme="light"] billing-tone overrides',
+    );
+  });
+
+  it('dark: every billing tone clears 4.5:1 on --bg and --surface', () => {
+    const bg = token(mainCss, ':root {', '--bg');
+    const surface = token(mainCss, ':root {', '--surface');
+    for (const tone of tones) {
+      const color = tokenInAnyRoot(mainCss, tone);
+      for (const base of [bg, surface]) {
+        const ratio = contrastRatio(color, base);
+        assert.ok(
+          ratio >= 4.5,
+          `dark ${tone} (${color}) on ${base} is ${ratio.toFixed(2)}:1, needs >= 4.5:1`,
+        );
+      }
+    }
+  });
+
+  it('light: every billing tone clears 4.5:1 on --bg and --surface', () => {
+    const block = '[data-theme="light"] {';
+    const bg = token(mainCss, block, '--bg');
+    const surface = token(mainCss, block, '--surface');
+    for (const tone of tones) {
+      const color = token(mainCss, block, tone);
+      for (const base of [bg, surface]) {
+        const ratio = contrastRatio(color, base);
+        assert.ok(
+          ratio >= 4.5,
+          `light ${tone} (${color}) on ${base} is ${ratio.toFixed(2)}:1, needs >= 4.5:1`,
+        );
+      }
+    }
+  });
 });

--- a/tests/contrast.test.mts
+++ b/tests/contrast.test.mts
@@ -136,6 +136,7 @@ describe('theme text-token contrast', () => {
  */
 describe('billing tone contrast', () => {
   const mainCss = readFile('src/styles/main.css');
+  const happyCss = readFile('src/styles/happy-theme.css');
   const settingsSource = readFile('src/components/UnifiedSettings.ts');
   const tones = [
     '--billing-tone-active',
@@ -207,4 +208,30 @@ describe('billing tone contrast', () => {
       }
     }
   });
+
+  for (const theme of [
+    {
+      name: 'happy light',
+      block: ':root[data-variant="happy"][data-theme="light"] {',
+    },
+    {
+      name: 'happy dark',
+      block: ':root[data-variant="happy"][data-theme="dark"] {',
+    },
+  ]) {
+    it(`${theme.name}: every billing tone clears 4.5:1 on --bg and --surface`, () => {
+      const bg = token(happyCss, theme.block, '--bg');
+      const surface = token(happyCss, theme.block, '--surface');
+      for (const tone of tones) {
+        const color = token(happyCss, theme.block, tone);
+        for (const base of [bg, surface]) {
+          const ratio = contrastRatio(color, base);
+          assert.ok(
+            ratio >= 4.5,
+            `${theme.name} ${tone} (${color}) on ${base} is ${ratio.toFixed(2)}:1, needs >= 4.5:1`,
+          );
+        }
+      }
+    });
+  }
 });

--- a/tests/dom/pro-banner-premium-stability.test.mts
+++ b/tests/dom/pro-banner-premium-stability.test.mts
@@ -80,7 +80,10 @@ vi.mock('@/services/billing', () => ({
   getSubscription: () => null,
   onSubscriptionChange: () => () => {},
 }));
-vi.mock('@/services/billing-state', () => ({
+// Partial so the real status-tone helpers stay available: a full stub goes
+// stale the moment billing-state gains an export a rendered surface uses (#7315).
+vi.mock('@/services/billing-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/billing-state')>()),
   deriveBillingUxState: () => 'free',
   getReactivationHref: () => '/pro#pricing',
 }));

--- a/tests/dom/unified-settings-account-handoff.test.mts
+++ b/tests/dom/unified-settings-account-handoff.test.mts
@@ -155,7 +155,10 @@ vi.mock('@/services/billing', () => ({
   removeBusinessSeat: async () => ({ status: 'removed' as const }),
 }));
 
-vi.mock('@/services/billing-state', () => ({
+// Partial so the real status-tone helpers stay available: a full stub goes
+// stale the moment billing-state gains an export the panel renders (#7315).
+vi.mock('@/services/billing-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/billing-state')>()),
   deriveBillingUxState: () => 'active',
   getReactivationHref: () => '/pro#pricing',
 }));

--- a/tests/dom/unified-settings-billing-status-colour.test.mts
+++ b/tests/dom/unified-settings-billing-status-colour.test.mts
@@ -219,10 +219,6 @@ describe('UnifiedSettings billing status colour (#7315)', () => {
     const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
 
     expect(planNameColour(html)).toBe(RED);
-    // The copy must follow the same predicate: "access until <past date>" under
-    // a red card is the #7315 contradiction pointing the other way.
-    expect(html).toContain('access ended');
-    expect(html).not.toContain('access until');
   });
 
   it('paints expired red, even with a future period end', () => {
@@ -265,5 +261,8 @@ describe('UnifiedSettings billing status colour (#7315)', () => {
 
     expect(planNameColour(html)).toBe(GREY);
     expect(html).not.toContain(RED);
+    // Asserting the colour alone would let the card ship as a bare grey dot
+    // with no sentence at all, which is what the old trailing `else` produced.
+    expect(html).toContain('See Manage Billing for your current plan details.');
   });
 });

--- a/tests/dom/unified-settings-billing-status-colour.test.mts
+++ b/tests/dom/unified-settings-billing-status-colour.test.mts
@@ -25,11 +25,6 @@ const session: AuthSession = {
 };
 
 const DAY = 86_400_000;
-const GREEN = '#22c55e';
-const YELLOW = '#eab308';
-const BLUE = '#3b82f6';
-const RED = '#ef4444';
-const GREY = '#9ca3af';
 
 /** Read lazily by the billing mock below; set per case. */
 let mockSubscription: SubscriptionInfo | null = null;
@@ -171,12 +166,13 @@ function subscription(overrides: Partial<SubscriptionInfo> = {}): SubscriptionIn
 }
 
 /**
- * The plan name's own colour — the single largest coloured element in the card,
- * and the one a reader actually parses as "is my plan OK?". Matched off the
- * rendered markup so a change to the dot/border alone cannot fake this pass.
+ * The plan card's billing tone — the class/token the 13px plan name reads.
+ * Matched off the rendered markup so a change to the dot/border alone cannot
+ * fake this pass. Hex contrast is locked in tests/contrast.test.mts against
+ * the theme tokens; this file locks which tone the coverage predicate picks.
  */
-function planNameColour(html: string): string | null {
-  return html.match(/<span style="color:(#[0-9a-f]{6});font-weight:600/i)?.[1] ?? null;
+function planTone(html: string): string | null {
+  return html.match(/data-billing-tone="([a-z]+)"/)?.[1] ?? null;
 }
 
 beforeAll(async () => {
@@ -205,10 +201,11 @@ describe('UnifiedSettings billing status colour (#7315)', () => {
     const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
 
     expect(html).toContain('access until');
-    expect(planNameColour(html)).toBe(BLUE);
-    // Not one red anywhere in the card — the dot, the plan name, the border and
-    // the background tint all derive from the same tone.
-    expect(html).not.toContain(RED);
+    expect(html).toContain('class="upgrade-pro-plan-name"');
+    expect(planTone(html)).toBe('ending');
+    // Not the ended tone — the dot, the plan name, the border and the
+    // background tint all derive from the same data-billing-tone.
+    expect(html).not.toContain('data-billing-tone="ended"');
   });
 
   it('paints a cancellation past its paid period red', () => {
@@ -218,7 +215,7 @@ describe('UnifiedSettings billing status colour (#7315)', () => {
     });
     const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
 
-    expect(planNameColour(html)).toBe(RED);
+    expect(planTone(html)).toBe('ended');
   });
 
   it('paints expired red, even with a future period end', () => {
@@ -228,17 +225,17 @@ describe('UnifiedSettings billing status colour (#7315)', () => {
     });
     const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
 
-    expect(planNameColour(html)).toBe(RED);
+    expect(planTone(html)).toBe('ended');
   });
 
   it('leaves active green and on_hold yellow', () => {
     mockSubscription = subscription({ status: 'active' });
-    expect(planNameColour((settings as unknown as SettingsInternals).renderUpgradeSection()))
-      .toBe(GREEN);
+    expect(planTone((settings as unknown as SettingsInternals).renderUpgradeSection()))
+      .toBe('active');
 
     mockSubscription = subscription({ status: 'on_hold' });
-    expect(planNameColour((settings as unknown as SettingsInternals).renderUpgradeSection()))
-      .toBe(YELLOW);
+    expect(planTone((settings as unknown as SettingsInternals).renderUpgradeSection()))
+      .toBe('attention');
   });
 
   it('paints a Business-grant invitee (no own subscription row) green', () => {
@@ -249,7 +246,7 @@ describe('UnifiedSettings billing status colour (#7315)', () => {
     const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
 
     expect(html).toContain('managed by your plan owner');
-    expect(planNameColour(html)).toBe(GREEN);
+    expect(planTone(html)).toBe('active');
   });
 
   it('paints an unrecognised provider status neutral, not red', () => {
@@ -259,8 +256,8 @@ describe('UnifiedSettings billing status colour (#7315)', () => {
     mockSubscription = subscription({ status: 'paused' as unknown as 'active' });
     const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
 
-    expect(planNameColour(html)).toBe(GREY);
-    expect(html).not.toContain(RED);
+    expect(planTone(html)).toBe('unknown');
+    expect(html).not.toContain('data-billing-tone="ended"');
     // Asserting the colour alone would let the card ship as a bare grey dot
     // with no sentence at all, which is what the old trailing `else` produced.
     expect(html).toContain('See Manage Billing for your current plan details.');

--- a/tests/dom/unified-settings-billing-status-colour.test.mts
+++ b/tests/dom/unified-settings-billing-status-colour.test.mts
@@ -1,12 +1,16 @@
 /**
- * #6772 — An entitled Pro owner whose subscription watch has not settled yet
- * (getSubscription() === null because isSubscriptionLoaded() is still false)
- * must NOT be shown the Business-invitee copy "Billing is managed by your plan
- * owner" — that hides Manage Billing from a paying owner. The unresolved window
- * renders the same "Checking your plan…" pending state the pre-entitlement
- * guard uses; the invitee copy is reserved for a *settled* null.
+ * #7315 — A paid-through cancellation must not be painted in the same red as a
+ * dead `expired` account. A subscriber who cancelled with weeks of Pro left saw
+ * a red dot, red plan name and red-tinted card above small text saying "access
+ * until <date>"; the colour won, and support got a refund demand 13 minutes
+ * after the cancellation.
  *
- * Harness mirrors unified-settings-upgrade-click-runtime.test.mts.
+ * These assertions are on the COLOUR, deliberately: the copy was already
+ * correct before the fix, so a copy-only test passed against the bug.
+ *
+ * Harness mirrors unified-settings-subscription-loading.test.mts, except that
+ * `@/services/billing-state` is NOT stubbed — the point of the fix is that the
+ * panel and the real coverage predicate cannot drift.
  */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -20,8 +24,14 @@ const session: AuthSession = {
   isPending: false,
 };
 
-/** Both flipped per case; read lazily by the billing mock below. */
-let subscriptionLoaded = false;
+const DAY = 86_400_000;
+const GREEN = '#22c55e';
+const YELLOW = '#eab308';
+const BLUE = '#3b82f6';
+const RED = '#ef4444';
+const GREY = '#9ca3af';
+
+/** Read lazily by the billing mock below; set per case. */
 let mockSubscription: SubscriptionInfo | null = null;
 
 const storageValues = new Map<string, string>();
@@ -45,9 +55,8 @@ vi.mock('@/services/auth-state', async (importOriginal) => ({
   subscribeAuthState: () => () => {},
 }));
 
-// Entitled, and the entitlement snapshot has already resolved (non-null), so
-// the pre-entitlement "Checking your plan…" guard is skipped — any pending
-// render in these cases must come from the new subscription-unresolved guard.
+// Entitled with a settled entitlement snapshot, so renderUpgradeSection reaches
+// the plan-status render rather than either "Checking your plan…" guard.
 vi.mock('@/services/entitlements', () => ({
   getEntitlementState: () => ({ planKey: 'pro_monthly', validUntil: Date.now() + 1e9 }),
   getEntitlementVerificationStatus: () => 'ready',
@@ -97,7 +106,7 @@ vi.mock('@/config/variant', () => ({
 
 vi.mock('@/services/billing', () => ({
   getSubscription: () => mockSubscription,
-  isSubscriptionLoaded: () => subscriptionLoaded,
+  isSubscriptionLoaded: () => true,
   onSubscriptionChange: () => () => {},
   openBillingPortal: async () => ({ outcome: 'no-customer' as const }),
   prereserveBillingPortalTab: () => null,
@@ -109,15 +118,6 @@ vi.mock('@/services/billing', () => ({
   }),
   inviteBusinessSeats: async () => ({ invited: [] }),
   removeBusinessSeat: async () => ({ status: 'removed' as const }),
-}));
-
-// Partial: only the UX-state verdict is pinned for this file's cases. The
-// status-tone helpers stay real so a new billing-state export cannot silently
-// leave this stub short (#7315).
-vi.mock('@/services/billing-state', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/services/billing-state')>()),
-  deriveBillingUxState: () => 'active',
-  getReactivationHref: () => '/pro#pricing',
 }));
 
 vi.mock('@/services/api-keys', () => ({
@@ -159,6 +159,26 @@ function config(): UnifiedSettingsConfig {
   };
 }
 
+function subscription(overrides: Partial<SubscriptionInfo> = {}): SubscriptionInfo {
+  return {
+    planKey: 'pro_monthly',
+    displayName: 'Pro',
+    status: 'active',
+    currentPeriodEnd: Date.now() + 30 * DAY,
+    renewalVerificationState: null,
+    ...overrides,
+  };
+}
+
+/**
+ * The plan name's own colour — the single largest coloured element in the card,
+ * and the one a reader actually parses as "is my plan OK?". Matched off the
+ * rendered markup so a change to the dot/border alone cannot fake this pass.
+ */
+function planNameColour(html: string): string | null {
+  return html.match(/<span style="color:(#[0-9a-f]{6});font-weight:600/i)?.[1] ?? null;
+}
+
 beforeAll(async () => {
   await initTestI18n();
 });
@@ -171,42 +191,79 @@ beforeEach(() => {
 
 afterEach(() => {
   settings?.destroy();
-  subscriptionLoaded = false;
   mockSubscription = null;
   vi.unstubAllGlobals();
   document.body.replaceChildren();
 });
 
-describe('UnifiedSettings subscription loaded-vs-absent (#6772)', () => {
-  it('shows the pending state (not invitee copy) while the subscription watch is unresolved', () => {
-    subscriptionLoaded = false;
+describe('UnifiedSettings billing status colour (#7315)', () => {
+  it('paints a paid-through cancellation non-red and keeps the access-until copy', () => {
+    mockSubscription = subscription({
+      status: 'cancelled',
+      currentPeriodEnd: Date.now() + 30 * DAY,
+    });
     const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
-    expect(html).toContain('Checking your plan');
-    expect(html).not.toContain('managed by your plan owner');
+
+    expect(html).toContain('access until');
+    expect(planNameColour(html)).toBe(BLUE);
+    // Not one red anywhere in the card — the dot, the plan name, the border and
+    // the background tint all derive from the same tone.
+    expect(html).not.toContain(RED);
   });
 
-  it('shows the Business-invitee copy once the watch settles to a null subscription', () => {
-    subscriptionLoaded = true;
+  it('paints a cancellation past its paid period red', () => {
+    mockSubscription = subscription({
+      status: 'cancelled',
+      currentPeriodEnd: Date.now() - DAY,
+    });
     const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
-    expect(html).toContain('Billing is managed by your plan owner');
-    expect(html).not.toContain('Checking your plan');
+
+    expect(planNameColour(html)).toBe(RED);
+    // The copy must follow the same predicate: "access until <past date>" under
+    // a red card is the #7315 contradiction pointing the other way.
+    expect(html).toContain('access ended');
+    expect(html).not.toContain('access until');
   });
 
-  it('shows the active plan and Manage Billing when the watch settles to a present subscription', () => {
-    // The guard is scoped to `sub === null`: a settled owner WITH a subscription
-    // must reach the active render (and its Manage Billing CTA), never pending
-    // or invitee copy. Guards against a future widening that drops `sub === null`.
-    subscriptionLoaded = true;
-    mockSubscription = {
-      planKey: 'pro_monthly',
-      displayName: 'Pro',
-      status: 'active',
-      currentPeriodEnd: Date.now() + 1e9,
-      renewalVerificationState: null,
-    };
+  it('paints expired red, even with a future period end', () => {
+    mockSubscription = subscription({
+      status: 'expired',
+      currentPeriodEnd: Date.now() + 30 * DAY,
+    });
     const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
-    expect(html).toContain('Manage Billing');
-    expect(html).not.toContain('Checking your plan');
-    expect(html).not.toContain('managed by your plan owner');
+
+    expect(planNameColour(html)).toBe(RED);
+  });
+
+  it('leaves active green and on_hold yellow', () => {
+    mockSubscription = subscription({ status: 'active' });
+    expect(planNameColour((settings as unknown as SettingsInternals).renderUpgradeSection()))
+      .toBe(GREEN);
+
+    mockSubscription = subscription({ status: 'on_hold' });
+    expect(planNameColour((settings as unknown as SettingsInternals).renderUpgradeSection()))
+      .toBe(YELLOW);
+  });
+
+  it('paints a Business-grant invitee (no own subscription row) green', () => {
+    // The invitee holds a grant, not a subscription row. Pre-#7315 the panel
+    // defaulted the missing status to 'active' to dodge the red trailing else;
+    // the tone mapping must keep that user green.
+    mockSubscription = null;
+    const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
+
+    expect(html).toContain('managed by your plan owner');
+    expect(planNameColour(html)).toBe(GREEN);
+  });
+
+  it('paints an unrecognised provider status neutral, not red', () => {
+    // Dodo adding a status we do not model must not tell an entitled user their
+    // plan is dead — the trailing `else` that swallowed every unknown status
+    // into red is the "branch on known strings, mishandle the rest" gotcha.
+    mockSubscription = subscription({ status: 'paused' as unknown as 'active' });
+    const html = (settings as unknown as SettingsInternals).renderUpgradeSection();
+
+    expect(planNameColour(html)).toBe(GREY);
+    expect(html).not.toContain(RED);
   });
 });

--- a/tests/dom/unified-settings-sources-live-apply.test.mts
+++ b/tests/dom/unified-settings-sources-live-apply.test.mts
@@ -136,7 +136,10 @@ vi.mock('@/services/billing', () => ({
   removeBusinessSeat: async () => ({ status: 'removed' as const }),
 }));
 
-vi.mock('@/services/billing-state', () => ({
+// Partial so the real status-tone helpers stay available: a full stub goes
+// stale the moment billing-state gains an export the panel renders (#7315).
+vi.mock('@/services/billing-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/billing-state')>()),
   deriveBillingUxState: () => 'active',
   getReactivationHref: () => '/pro#pricing',
 }));

--- a/tests/dom/unified-settings-theater-presets.test.mts
+++ b/tests/dom/unified-settings-theater-presets.test.mts
@@ -127,7 +127,10 @@ vi.mock('@/services/billing', () => ({
   removeBusinessSeat: async () => ({ status: 'removed' as const }),
 }));
 
-vi.mock('@/services/billing-state', () => ({
+// Partial so the real status-tone helpers stay available: a full stub goes
+// stale the moment billing-state gains an export the panel renders (#7315).
+vi.mock('@/services/billing-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/billing-state')>()),
   deriveBillingUxState: () => 'active',
   getReactivationHref: () => '/pro#pricing',
 }));

--- a/tests/dom/unified-settings-upgrade-click-runtime.test.mts
+++ b/tests/dom/unified-settings-upgrade-click-runtime.test.mts
@@ -118,7 +118,10 @@ vi.mock('@/services/billing', () => ({
   removeBusinessSeat: async () => ({ status: 'removed' as const }),
 }));
 
-vi.mock('@/services/billing-state', () => ({
+// Partial so the real status-tone helpers stay available: a full stub goes
+// stale the moment billing-state gains an export the panel renders (#7315).
+vi.mock('@/services/billing-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/services/billing-state')>()),
   deriveBillingUxState: () => billingUxState,
   getReactivationHref: (planKey: string | null | undefined) => planKey
     ? `/pro?wm_reactivate_plan=${planKey}#pricing`


### PR DESCRIPTION
Closes #7315

## What was wrong

The plan card greened only `active` and yellowed `on_hold`; **every other status fell to `#ef4444`**. So a subscriber who cancelled with a month of Pro left saw a red dot, red plan name and red-tinted card sitting directly above the line telling them they had access until a future date. The colour wins that argument, which is how you get a refund demand 13 minutes after cancelling.

`billing-state.ts` already encoded the right semantics — it treats `cancelled && currentPeriodEnd >= now` as `'active'`. The panel just wasn't using them.

## The fix

The panel now derives a **tone** from the same coverage predicate the gating logic uses, instead of comparing status strings on its own.

- **`isSubscriptionCoveringAt`** (`billing-state.ts`) is the single shared spelling of "does this row cover `at`". `deriveBillingUxState` and the new tone function both read it, so the cancelled-but-paid-through rule can't be re-derived from status-string intuition in one place and not another. It mirrors `isCoveringAt` in `convex/payments/subscriptionHelpers.ts`; the inclusive `>=` this module has always used is kept and documented against the server's `>`.
- **`getSubscriptionStatusTone`** splits "is it working" from "is it ending" — `deriveBillingUxState` answers `active` for both a renewing plan and a paid-through cancellation, and the panel needs to tell those apart.
- The trailing `else` that swallowed every unmodelled status into red is now an explicit **`unknown`** tone: neutral grey with a neutral sentence. Inside the `isEntitled()` branch, asserting a dead plan we haven't established would just be the same bug in a new colour.

| Tone | State | Colour |
|---|---|---|
| `active` | renewing | green |
| `attention` | `on_hold` | yellow |
| `ending` | cancelled, still covered | **blue** |
| `ended` | cancelled past window, `expired` | red |
| `unknown` | status this client doesn't model | grey |

Three of the hues are existing threat-scale values from `main.css` and `ending` borrows `--threat-info`, so it lands on the palette's own informational rung rather than inventing a colour; `unknown`'s grey is off-scale (the scale has no grey rung).

## Evidence

Tests were written first and **observed red against the pre-fix code on exactly the two colours the bug produced** — `expected '#ef4444' to be '#3b82f6'` and `'#ef4444' to be '#9ca3af'`. The DOM test asserts the rendered **colour**, not the copy, per the issue's AC: the copy was already correct, so a copy-only test would have passed against the bug.

Green: 42 `billing-state` unit tests, 547 DOM tests across 71 files, 152 adjacent billing tests, `tsc`, biome, safe-html guard. Card rendered and inspected at 390px across all six states.

## Review findings addressed

A four-lane review (correctness, testing, frontend, adversarial) returned 13 findings. Five were real problems **in this branch's own new code** and are fixed in commits 2-4; each claim was verified against the source before acting.

1. **The `isSubscriptionCoveringAt` docstring was a payments footgun.** It claimed the predicate answers whether a row "grants access". It does not: `active` and `on_hold` return true regardless of `currentPeriodEnd`, so a row with a missed renewal webhook covers there while `deriveBillingUxState` correctly routes it to `renewal_verification_*`/`lapsed`. Gating on it would mean free Pro for anyone with a stale paid row. Rewritten to state plainly that it is a field-level question, and to name `deriveBillingUxState` as the only thing that decides access.

2. **A copy change asserted something false.** This branch had briefly changed the past-window line to "access ended \<date\>". Verified reachable-and-wrong: the card only renders inside `isEntitled()`, `getSubscriptionForUser` (`billing.ts:615-638`) returns `allSubs[0]` with **no coverage filter**, and `recomputeEntitlementFromAllSubs` (`subscriptionHelpers.ts:470-490`) sets the entitlement from a Business seat grant. A Business invitee who once cancelled their own Pro would have been told their access ended while their Pro worked. Reverted — that state is now behaviour-identical to before this branch.

3. **The `unknown` tone rendered a bare grey dot with no sentence at all.** No status branch matched and the invitee fallback does not fire for a real row. It now carries a neutral line, and the test asserts that text rather than only the colour.

4. **The `default` arm silently disabled TypeScript's exhaustiveness check.** It exists to survive a new provider status — but left bare, the change that would introduce one (widening the status union) would have compiled clean and shipped as a permanently unexplained grey card, the opposite of its purpose. A `never` assignment keeps the runtime escape and makes the widening a build error. Proven, not assumed: temporarily adding `'paused'` to the union fails with `Type '"paused"' is not assignable to type 'never'`, and passes once reverted.

5. **The palette comment was wrong three ways** (twice over — my first correction was itself incomplete). It implied all five hues come from the threat scale, when the scale has no grey rung; it called the hardcoding "pre-existing for all four" when green/yellow/red are pre-existing but blue and grey are new here; and it proposed `var(--threat-*)` as the follow-up when the light block overrides only `--threat-high/-medium/-low`, so `--threat-info` and `--threat-critical` resolve to the same failing hexes in both themes — the fix would have looked landed while `ending` and `ended` still failed. Contrast numbers are now measured with the repo's own `src/utils/contrast.ts` rather than estimated.

Two further findings were **already correct as designed and left alone**, with reasoning recorded: the blue/`--semantic-info` overlap (the card has no interactive affordance and `--threat-info` is the same hex used for informational status elsewhere), and telemetry for the `unknown` tone (the exhaustiveness guard is a strictly better control for a state `convex/schema.ts` currently makes unreachable, and logging on a render path would need a dedup guard for no present benefit).

`CONCEPTS.md` § Covering Subscription now records the one place the client deliberately does **not** mirror the server — the server's `currentPeriodEnd > at` versus the client's `>=` — because that entry states the mirroring rule categorically and a silent exception invites a future dedup to flip a boundary. It also captures the coverage-vs-access distinction from finding 1.

Six DOM files that fully stubbed `billing-state` became partial `importOriginal` mocks: a full stub silently goes stale the moment the module gains an export the panel renders, which is exactly what this change surfaced.

## Follow-ups deliberately not done here

- **Business-seat invitee with an old ended personal row still gets the red `ended` tone.** Verified reachable (evidence in point 2 above). The colour half is pre-existing — pre-fix that state was red too — so this branch is neutral on it, but the right behaviour is a product decision (should they see the team-plan framing, like the `sub === null` arm?) and it contradicts this issue's own AC that `expired` renders red. Worth its own issue.
- **The Business seats UI gates on `sub?.status === 'active'`** (`UnifiedSettings.ts:618`, `:623`, `:1098`, `BusinessSeatsSection.ts:75`) while the server authorizes on `isCoveringAt` (`convex/payments/businessSeats.ts:88`). An `api_business` owner who cancels with paid days left keeps seat authority server-side but loses the entire seats UI — they can't even remove a seat while their invitees still hold Pro. Same bug class as this issue, pre-existing, and now fixable with the predicate this PR extracts.
- **Light-theme contrast.** The card inlines hexes, so no tone picks up the `[data-theme="light"]` overrides, and **all five are under the AA 4.5:1 floor** on the light background for the 13px-bold plan name (measured with `src/utils/contrast.ts` against `--bg #f8f9fa`): `#22c55e` 2.16, `#eab308` 1.82, `#3b82f6` 3.49, `#ef4444` 3.57, `#9ca3af` 2.41. The first two are the exact values `main.css` records beside its own light overrides, so this is a bypass of a correction the team already made. Green/yellow/red are pre-existing; blue and grey are new here. `var(--threat-*)` alone does **not** close it — `--threat-info` and `--threat-critical` have no light override. Needs light overrides for those two tokens plus a light-safe grey, and a light-theme render test; `tests/contrast.test.mts` currently covers only the CorrelationPanel badges.
- **The statusLine strings are hardcoded English.** This change adds one more (`See Manage Billing...`) matching its four hardcoded siblings, while `components.billingState` already holds i18n keys the lapsed card uses. Localising just the new one would be inconsistent; the whole block should move together.

Related: #7328 (from sibling issue #7314) addresses the same user confusion via a confirmation email. No file overlap — it touches `convex/`, this touches `src/` — and it only calls `isCoveringAt` without changing it.

https://claude.ai/code/session_01LuyKr35bEMve1PuTRy7sga
