### PR TITLE
feat(billing): end subscription coverage on refund without deleting the row

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -6601,24 +6601,65 @@ describe("payments billing endSubscriptionCoverageNow (refund cleanup)", () => {
     expect(sub!.currentPeriodEnd).toBe(endedAt);
   });
 
-  test("flips an active refunded sub to cancelled and stamps cancelledAt", async () => {
+  // A row that is still `active`/`on_hold` locally is still LIVE at Dodo. Ending
+  // its coverage here would diverge from the provider, and the next
+  // `subscription.renewed` would both rebill the customer and restore the
+  // refunded entitlement (handleSubscriptionRenewed patches status + period).
+  for (const status of ["active", "on_hold"] as const) {
+    test(`refuses a ${status} row until the provider cancellation lands`, async () => {
+      const t = convexTest(schema, modules);
+      await seedSubscription(t, {
+        planKey: "pro_monthly",
+        dodoProductId: PRO_PRODUCT_ID,
+        status,
+        currentPeriodEnd: NOW + 30 * DAY_MS,
+        suffix: `refund_cleanup_${status}`,
+      });
+
+      await expect(
+        t.mutation(internal.payments.billing.endSubscriptionCoverageNow, {
+          dodoSubscriptionId: `sub_billing_refund_cleanup_${status}`,
+          reason: "refunded before cancellation",
+        }),
+      ).rejects.toThrow(/still live at Dodo/);
+
+      // Untouched — no half-applied local divergence.
+      const sub = await readSub(t, `refund_cleanup_${status}`);
+      expect(sub!.status).toBe(status);
+      expect(sub!.currentPeriodEnd).toBe(NOW + 30 * DAY_MS);
+    });
+  }
+
+  test("keeps updatedAt monotonic when the row carries a future provider timestamp", async () => {
     const t = convexTest(schema, modules);
+    // Provider payload timestamps drive `updatedAt`, so clock skew can leave it
+    // ahead of Convex's own clock. Writing a lower value would drop the
+    // `isNewerEvent` fence and let a delayed lifecycle webhook clobber cleanup.
+    const futureStamp = NOW + 60_000;
     await seedSubscription(t, {
       planKey: "pro_monthly",
       dodoProductId: PRO_PRODUCT_ID,
-      status: "active",
+      status: "cancelled",
       currentPeriodEnd: NOW + 30 * DAY_MS,
-      suffix: "refund_cleanup_active",
+      suffix: "refund_cleanup_fence",
+    });
+    await t.run(async (ctx) => {
+      const sub = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_dodoSubscriptionId", (q) =>
+          q.eq("dodoSubscriptionId", "sub_billing_refund_cleanup_fence"),
+        )
+        .unique();
+      await ctx.db.patch(sub!._id, { updatedAt: futureStamp });
     });
 
     await t.mutation(internal.payments.billing.endSubscriptionCoverageNow, {
-      dodoSubscriptionId: "sub_billing_refund_cleanup_active",
-      reason: "refunded before cancellation",
+      dodoSubscriptionId: "sub_billing_refund_cleanup_fence",
+      reason: "refund cleanup under clock skew",
     });
 
-    const sub = await readSub(t, "refund_cleanup_active");
-    expect(sub!.status).toBe("cancelled");
-    expect(sub!.cancelledAt).toBeGreaterThanOrEqual(NOW);
+    const sub = await readSub(t, "refund_cleanup_fence");
+    expect(sub!.updatedAt).toBe(futureStamp);
     expect(sub!.currentPeriodEnd).toBeLessThanOrEqual(Date.now());
   });
 
@@ -6681,7 +6722,7 @@ describe("payments billing endSubscriptionCoverageNow (refund cleanup)", () => {
     await seedSubscription(t, {
       planKey: "pro_monthly",
       dodoProductId: PRO_PRODUCT_ID,
-      status: "active",
+      status: "cancelled",
       currentPeriodEnd: NOW - DAY_MS,
       suffix: "refund_cleanup_lease",
       renewalVerificationState: "pending",

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -6519,3 +6519,253 @@ describe("Pro activation — day-0 outcome rows (#5621)", () => {
     }
   });
 });
+
+describe("payments billing endSubscriptionCoverageNow (refund cleanup)", () => {
+  const PRO_PRODUCT_ID = PRODUCT_CATALOG.pro_monthly.dodoProductId!;
+
+  async function readSub(t: ReturnType<typeof convexTest>, suffix: string) {
+    return await t.run(async (ctx) =>
+      await ctx.db
+        .query("subscriptions")
+        .withIndex("by_dodoSubscriptionId", (q) =>
+          q.eq("dodoSubscriptionId", `sub_billing_${suffix}`),
+        )
+        .unique(),
+    );
+  }
+
+  async function readEntitlement(t: ReturnType<typeof convexTest>, userId = TEST_USER_ID) {
+    return await t.run(async (ctx) =>
+      await ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .first(),
+    );
+  }
+
+  test("ends coverage now on a refunded cancelled sub and downgrades to free", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRO_PRODUCT_ID,
+      status: "cancelled",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "refund_cleanup_basic",
+    });
+    const cancelledAt = NOW - DAY_MS;
+    await t.run(async (ctx) => {
+      const sub = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_dodoSubscriptionId", (q) =>
+          q.eq("dodoSubscriptionId", "sub_billing_refund_cleanup_basic"),
+        )
+        .unique();
+      await ctx.db.patch(sub!._id, { cancelledAt });
+      await upsertEntitlements(ctx, TEST_USER_ID, "pro_monthly", NOW + 30 * DAY_MS, NOW);
+    });
+
+    const result = await t.mutation(internal.payments.billing.endSubscriptionCoverageNow, {
+      dodoSubscriptionId: "sub_billing_refund_cleanup_basic",
+      reason: "full refund ref_test",
+    });
+
+    const sub = await readSub(t, "refund_cleanup_basic");
+    expect(sub!.status).toBe("cancelled");
+    expect(sub!.currentPeriodEnd).toBeLessThanOrEqual(Date.now());
+    // The original cancellation timestamp is history — never overwritten.
+    expect(sub!.cancelledAt).toBe(cancelledAt);
+
+    const entitlement = await readEntitlement(t);
+    expect(entitlement!.planKey).toBe("free");
+    expect(entitlement!.validUntil).toBeLessThanOrEqual(Date.now());
+    expect(result.entitlementAfter?.planKey).toBe("free");
+  });
+
+  test("never extends coverage on a sub whose period already ended", async () => {
+    const t = convexTest(schema, modules);
+    const endedAt = NOW - 5 * DAY_MS;
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRO_PRODUCT_ID,
+      status: "cancelled",
+      currentPeriodEnd: endedAt,
+      suffix: "refund_cleanup_no_extend",
+    });
+
+    await t.mutation(internal.payments.billing.endSubscriptionCoverageNow, {
+      dodoSubscriptionId: "sub_billing_refund_cleanup_no_extend",
+      reason: "refund on an already-lapsed sub",
+    });
+
+    const sub = await readSub(t, "refund_cleanup_no_extend");
+    expect(sub!.currentPeriodEnd).toBe(endedAt);
+  });
+
+  test("flips an active refunded sub to cancelled and stamps cancelledAt", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRO_PRODUCT_ID,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "refund_cleanup_active",
+    });
+
+    await t.mutation(internal.payments.billing.endSubscriptionCoverageNow, {
+      dodoSubscriptionId: "sub_billing_refund_cleanup_active",
+      reason: "refunded before cancellation",
+    });
+
+    const sub = await readSub(t, "refund_cleanup_active");
+    expect(sub!.status).toBe("cancelled");
+    expect(sub!.cancelledAt).toBeGreaterThanOrEqual(NOW);
+    expect(sub!.currentPeriodEnd).toBeLessThanOrEqual(Date.now());
+  });
+
+  test("keeps `expired` terminal instead of regressing it to cancelled", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRO_PRODUCT_ID,
+      status: "expired",
+      currentPeriodEnd: NOW - DAY_MS,
+      suffix: "refund_cleanup_expired",
+    });
+
+    await t.mutation(internal.payments.billing.endSubscriptionCoverageNow, {
+      dodoSubscriptionId: "sub_billing_refund_cleanup_expired",
+      reason: "refund after expiry",
+    });
+
+    const sub = await readSub(t, "refund_cleanup_expired");
+    expect(sub!.status).toBe("expired");
+    expect(sub!.cancelledAt).toBeUndefined();
+  });
+
+  test("preserves a complimentary floor that outlives the refund", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRO_PRODUCT_ID,
+      status: "cancelled",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "refund_cleanup_comp",
+    });
+    const compUntil = NOW + 90 * DAY_MS;
+    await t.run(async (ctx) => {
+      await ctx.db.insert("entitlements", {
+        userId: TEST_USER_ID,
+        planKey: "pro_monthly",
+        features: getFeaturesForPlan("pro_monthly"),
+        validUntil: NOW + 90 * DAY_MS,
+        compUntil,
+        updatedAt: NOW,
+      });
+    });
+
+    await t.mutation(internal.payments.billing.endSubscriptionCoverageNow, {
+      dodoSubscriptionId: "sub_billing_refund_cleanup_comp",
+      reason: "refund, goodwill comp stands",
+    });
+
+    // Coverage still ends, but the goodwill floor keeps the entitlement.
+    const sub = await readSub(t, "refund_cleanup_comp");
+    expect(sub!.currentPeriodEnd).toBeLessThanOrEqual(Date.now());
+    const entitlement = await readEntitlement(t);
+    expect(entitlement!.planKey).toBe("pro_monthly");
+    expect(entitlement!.compUntil).toBe(compUntil);
+  });
+
+  test("clears the renewal-verification lease so the UI stops showing 'verifying'", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRO_PRODUCT_ID,
+      status: "active",
+      currentPeriodEnd: NOW - DAY_MS,
+      suffix: "refund_cleanup_lease",
+      renewalVerificationState: "pending",
+    });
+    await t.run(async (ctx) => {
+      const sub = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_dodoSubscriptionId", (q) =>
+          q.eq("dodoSubscriptionId", "sub_billing_refund_cleanup_lease"),
+        )
+        .unique();
+      await ctx.db.patch(sub!._id, {
+        renewalVerificationAttemptAt: NOW,
+        reconcileFailureCount: 3,
+        reconcileNotFoundCount: 1,
+        lastReconcileAttemptAt: NOW,
+      });
+    });
+
+    await t.mutation(internal.payments.billing.endSubscriptionCoverageNow, {
+      dodoSubscriptionId: "sub_billing_refund_cleanup_lease",
+      reason: "refund cleanup on a stale-active row",
+    });
+
+    const sub = await readSub(t, "refund_cleanup_lease");
+    expect(sub!.renewalVerificationState).toBeUndefined();
+    expect(sub!.renewalVerificationAttemptAt).toBeUndefined();
+    expect(sub!.reconcileFailureCount).toBeUndefined();
+    expect(sub!.reconcileNotFoundCount).toBeUndefined();
+    expect(sub!.lastReconcileAttemptAt).toBeUndefined();
+  });
+
+  test("revokes Business Pro seat grants once the sub stops covering", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "api_business",
+      dodoProductId: PRODUCT_CATALOG.api_business.dodoProductId!,
+      status: "cancelled",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "refund_cleanup_seats",
+    });
+    const inviteeUserId = "user_billing_test_invitee";
+    await t.run(async (ctx) => {
+      await ctx.db.insert("businessProGrants", {
+        businessSubscriptionId: "sub_billing_refund_cleanup_seats",
+        ownerUserId: TEST_USER_ID,
+        inviteeEmail: "seat@example.com",
+        domain: "example.com",
+        inviteeUserId,
+        status: "accepted",
+        createdAt: NOW,
+        acceptedAt: NOW,
+        expiresAt: NOW + 30 * DAY_MS,
+      });
+      await upsertEntitlements(ctx, inviteeUserId, "pro_monthly", NOW + 30 * DAY_MS, NOW);
+    });
+
+    const result = await t.mutation(internal.payments.billing.endSubscriptionCoverageNow, {
+      dodoSubscriptionId: "sub_billing_refund_cleanup_seats",
+      reason: "refunded Business subscription",
+    });
+    expect(result.revokedSeats).toBe(1);
+    expect(result.failedSeats).toBe(0);
+
+    const grant = await t.run(async (ctx) =>
+      await ctx.db
+        .query("businessProGrants")
+        .withIndex("by_businessSubscriptionId", (q) =>
+          q.eq("businessSubscriptionId", "sub_billing_refund_cleanup_seats"),
+        )
+        .unique(),
+    );
+    expect(grant!.status).toBe("revoked");
+    const inviteeEntitlement = await readEntitlement(t, inviteeUserId);
+    expect(inviteeEntitlement!.planKey).toBe("free");
+  });
+
+  test("throws on an unknown dodoSubscriptionId", async () => {
+    const t = convexTest(schema, modules);
+    await expect(
+      t.mutation(internal.payments.billing.endSubscriptionCoverageNow, {
+        dodoSubscriptionId: "sub_does_not_exist",
+        reason: "typo",
+      }),
+    ).rejects.toThrow(/no subscription found/);
+  });
+});

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -3975,14 +3975,27 @@ export const grantComplimentaryEntitlement = internalMutation({
  * erasing the subscription. Reach for the delete only when the row's eventual
  * `subscription.expired` webhook would clobber a DIFFERENT active entitlement.
  *
+ * REQUIRES the provider cancellation to have landed first: the row must
+ * already be `cancelled` or `expired`. A still-`active`/`on_hold` row is LIVE
+ * at Dodo, and a refund does not cancel it — ending coverage locally would
+ * diverge from the provider until the next `subscription.renewed` rebilled the
+ * customer AND restored the refunded entitlement (`handleSubscriptionRenewed`
+ * patches status and period back). The local status is a trustworthy
+ * precondition because only the Dodo webhook (`handleSubscriptionCancelled`)
+ * and `applyDodoSubscriptionReconciliation` (which reads live remote state)
+ * ever write it. Cancel in Dodo first, let the webhook land, then run this.
+ *
  * Semantics:
  *   - `currentPeriodEnd` moves to now, never forward (an already-lapsed sub
  *     keeps its earlier end date — this can only take access away).
- *   - `expired` stays `expired`; it is already terminal and non-covering, so
- *     regressing it to `cancelled` would falsify the churn record. Everything
- *     else becomes `cancelled`.
+ *   - `status` is left as-is: both permitted statuses are already terminal,
+ *     and regressing `expired` to `cancelled` would falsify the churn record.
  *   - `cancelledAt` is stamped only if absent — the original cancellation
  *     timestamp is history and is never overwritten by cleanup.
+ *   - `updatedAt` never moves backward. Provider payload timestamps drive it,
+ *     so clock skew can leave it ahead of Convex's clock; lowering it would
+ *     drop the `isNewerEvent` fence and let a delayed lifecycle webhook
+ *     clobber this cleanup.
  *   - A complimentary floor (`compUntil`) still wins: `recomputeEntitlement-
  *     FromAllSubs` preserves goodwill grants, so the returned
  *     `entitlementAfter` may legitimately still be paid. Check it.
@@ -4009,21 +4022,37 @@ export const endSubscriptionCoverageNow = internalMutation({
       );
     }
 
+    // Provider cancellation is a hard precondition — see the header. An
+    // `active`/`on_hold` row is still live at Dodo, so ending coverage here
+    // would be silently undone (and the customer rebilled) by the next
+    // renewal. Refuse rather than write a local state the provider contradicts.
+    if (sub.status !== "cancelled" && sub.status !== "expired") {
+      throw new Error(
+        `[billing] endSubscriptionCoverageNow: subscription ${args.dodoSubscriptionId} is "${sub.status}" — still live at Dodo. ` +
+          `Cancel it in Dodo first and let the subscription.cancelled webhook land, then re-run.`,
+      );
+    }
+
     const now = Date.now();
     const before = {
       status: sub.status,
       currentPeriodEnd: sub.currentPeriodEnd,
       cancelledAt: sub.cancelledAt ?? null,
+      updatedAt: sub.updatedAt,
     };
     // Only ever shortens. Math.min keeps a sub that already lapsed at its real
     // end date so the churn record stays truthful.
     const currentPeriodEnd = Math.min(sub.currentPeriodEnd, now);
-    const status: SubscriptionStatus = sub.status === "expired" ? "expired" : "cancelled";
+    // Both permitted statuses are already terminal, so cleanup never restates
+    // them — `expired` in particular must not regress to `cancelled`.
+    const status: SubscriptionStatus = sub.status;
 
     await ctx.db.patch(sub._id, {
       status,
       currentPeriodEnd,
-      updatedAt: now,
+      // Never lower the ordering fence (see header): a provider-stamped
+      // updatedAt can sit ahead of Convex's clock under skew.
+      updatedAt: Math.max(sub.updatedAt, now),
       ...(status === "cancelled" ? { cancelledAt: sub.cancelledAt ?? now } : {}),
       // The row can no longer be in the stale-active set, so the reconciler's
       // backoff bookkeeping and the request-path renewal-verification lease are

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -25,6 +25,7 @@ import {
   isNewerEvent,
   recomputeEntitlementFromAllSubs,
   resolvePlanKey,
+  revokeBusinessProGrantsForSubscription,
   type SubscriptionStatus,
 } from "./subscriptionHelpers";
 
@@ -3951,6 +3952,145 @@ export const grantComplimentaryEntitlement = internalMutation({
       planKey: args.planKey,
       validUntil,
       compUntil,
+    };
+  },
+});
+
+/**
+ * Ends a subscription's paid coverage NOW, keeping the row as a `cancelled`
+ * churn record.
+ *
+ * Ops tool for the refund case. A Dodo refund does NOT revoke access: the
+ * `refund.succeeded` handler records the payment event and (only when the sub
+ * is still uncancelled) raises the ops alert in `classifyRefundAlert` —
+ * "entitlement remains active until manual cleanup" (subscriptionHelpers.ts).
+ * `subscription.cancelled` is also deliberately paid-through: entitlements
+ * stand until `currentPeriodEnd`. So a full refund of the CURRENT period
+ * leaves the customer holding a month of Pro they were paid back for, and a
+ * refund on an already-cancelled sub doesn't even alert. This mutation is that
+ * manual cleanup — it retires the coverage the refund reversed.
+ *
+ * Prefer this over `deleteSubscriptionByDodoId` for refunds: it preserves the
+ * churn record (winback scan, billing UI, revenue reporting) instead of
+ * erasing the subscription. Reach for the delete only when the row's eventual
+ * `subscription.expired` webhook would clobber a DIFFERENT active entitlement.
+ *
+ * Semantics:
+ *   - `currentPeriodEnd` moves to now, never forward (an already-lapsed sub
+ *     keeps its earlier end date — this can only take access away).
+ *   - `expired` stays `expired`; it is already terminal and non-covering, so
+ *     regressing it to `cancelled` would falsify the churn record. Everything
+ *     else becomes `cancelled`.
+ *   - `cancelledAt` is stamped only if absent — the original cancellation
+ *     timestamp is history and is never overwritten by cleanup.
+ *   - A complimentary floor (`compUntil`) still wins: `recomputeEntitlement-
+ *     FromAllSubs` preserves goodwill grants, so the returned
+ *     `entitlementAfter` may legitimately still be paid. Check it.
+ *
+ * Typical usage (CLI):
+ *   npx convex run 'payments/billing:endSubscriptionCoverageNow' \
+ *     '{"dodoSubscriptionId":"sub_XXX","reason":"full refund ref_YYY"}'
+ */
+export const endSubscriptionCoverageNow = internalMutation({
+  args: {
+    dodoSubscriptionId: v.string(),
+    reason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const sub = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_dodoSubscriptionId", (q) =>
+        q.eq("dodoSubscriptionId", args.dodoSubscriptionId),
+      )
+      .unique();
+    if (!sub) {
+      throw new Error(
+        `[billing] endSubscriptionCoverageNow: no subscription found with dodoSubscriptionId="${args.dodoSubscriptionId}"`,
+      );
+    }
+
+    const now = Date.now();
+    const before = {
+      status: sub.status,
+      currentPeriodEnd: sub.currentPeriodEnd,
+      cancelledAt: sub.cancelledAt ?? null,
+    };
+    // Only ever shortens. Math.min keeps a sub that already lapsed at its real
+    // end date so the churn record stays truthful.
+    const currentPeriodEnd = Math.min(sub.currentPeriodEnd, now);
+    const status: SubscriptionStatus = sub.status === "expired" ? "expired" : "cancelled";
+
+    await ctx.db.patch(sub._id, {
+      status,
+      currentPeriodEnd,
+      updatedAt: now,
+      ...(status === "cancelled" ? { cancelledAt: sub.cancelledAt ?? now } : {}),
+      // The row can no longer be in the stale-active set, so the reconciler's
+      // backoff bookkeeping and the request-path renewal-verification lease are
+      // both meaningless — clear them exactly as the reconciliation path does
+      // when a row leaves that set. Leaving `renewalVerificationState` behind
+      // would make the billing UI show "verifying your renewal" forever (#4771).
+      lastReconcileAttemptAt: undefined,
+      reconcileFailureCount: undefined,
+      reconcileNotFoundCount: undefined,
+      renewalVerificationState: undefined,
+      renewalVerificationAttemptAt: undefined,
+    });
+
+    // Business seats: the sub no longer covers, so its invitee grants must die
+    // with it. Same shared grant-walk the cancelled/expired webhook handlers
+    // use — per-invitee error isolation and the "team access ended" email
+    // included — called inline so seat revocation commits atomically with the
+    // coverage end rather than in a second transaction that could fail alone.
+    const { revoked: revokedSeats, failed: failedSeats } =
+      await revokeBusinessProGrantsForSubscription(ctx, args.dodoSubscriptionId, now);
+
+    await recomputeEntitlementFromAllSubs(ctx, sub.userId, now);
+    const entitlementAfter = await ctx.db
+      .query("entitlements")
+      .withIndex("by_userId", (q) => q.eq("userId", sub.userId))
+      .first();
+
+    console.log(
+      `[billing] endSubscriptionCoverageNow userId=${sub.userId} dodoSubscriptionId=${args.dodoSubscriptionId} ` +
+        `planKey=${sub.planKey} status=${before.status}→${status} ` +
+        `currentPeriodEnd=${new Date(before.currentPeriodEnd).toISOString()}→${new Date(currentPeriodEnd).toISOString()} ` +
+        `revokedSeats=${revokedSeats} failedSeats=${failedSeats} ` +
+        `entitlementAfter=${entitlementAfter?.planKey ?? "none"} reason="${args.reason}"`,
+    );
+
+    // Sync the edge cache so access actually stops now instead of drifting for
+    // up to ENTITLEMENT_CACHE_TTL_SECONDS (900s) on a stale Redis entry.
+    if (process.env.UPSTASH_REDIS_REST_URL && entitlementAfter) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.payments.cacheActions.syncEntitlementCache,
+        {
+          userId: sub.userId,
+          planKey: entitlementAfter.planKey,
+          features: entitlementAfter.features,
+          validUntil: entitlementAfter.validUntil,
+        },
+      );
+    }
+
+    return {
+      userId: sub.userId,
+      dodoSubscriptionId: args.dodoSubscriptionId,
+      planKey: sub.planKey,
+      before,
+      after: { status, currentPeriodEnd },
+      revokedSeats,
+      failedSeats,
+      entitlementAfter: entitlementAfter
+        ? {
+            planKey: entitlementAfter.planKey,
+            validUntil: entitlementAfter.validUntil,
+            ...(entitlementAfter.compUntil !== undefined
+              ? { compUntil: entitlementAfter.compUntil }
+              : {}),
+          }
+        : null,
     };
   },
 });

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -1437,8 +1437,12 @@ export async function handleSubscriptionOnHold(
  * subscription and recomputes each affected invitee. Pending grants are also
  * revoked so they cannot be accepted against a lapsed Business. Idempotent —
  * already-revoked/expired rows are skipped.
+ *
+ * Exported for `payments/billing:endSubscriptionCoverageNow`, which ends
+ * coverage from an ops action rather than a webhook and needs the identical
+ * grant-walk in its own transaction.
  */
-async function revokeBusinessProGrantsForSubscription(
+export async function revokeBusinessProGrantsForSubscription(
   ctx: MutationCtx,
   dodoSubscriptionId: string,
   eventTimestamp: number,


### PR DESCRIPTION
## Why

A Dodo refund does not revoke access, and nothing in the pipeline closes that gap.

- `refund.succeeded` records the payment event and raises an ops alert **only when the sub is still uncancelled** (`classifyRefundAlert`, `convex/payments/subscriptionHelpers.ts:1905`). A refund on an already-cancelled sub is classified `no-op` and alerts nobody.
- `subscription.cancelled` is deliberately paid-through — entitlements stand until `currentPeriodEnd`.

So a full refund of the current period leaves the customer holding a month of Pro they were paid back for. The code already says this out loud: *"entitlement remains active until manual cleanup"* (`subscriptionHelpers.ts:1870`) — but there was no tool for that cleanup. The only lever was `deleteSubscriptionByDodoId`, which erases the churn record (winback scan, billing UI, revenue reporting) just to achieve a downgrade.

Found live: customer `cus_0NkBO1***` was refunded in full today against the Aug-28 renewal, sub already `cancelled` in Dodo since Aug 28 — and Convex still granted `pro_monthly` through **2026-09-28**.

## What

`payments/billing:endSubscriptionCoverageNow` — an ops mutation that retires the coverage a refund reversed, keeping the row as a `cancelled` churn record.

| Behaviour | Why |
|---|---|
| `currentPeriodEnd` → now, via `Math.min` | Only ever shortens; an already-lapsed sub keeps its real end date, so this can only take access away |
| `expired` stays `expired` | Already terminal and non-covering; regressing it to `cancelled` would falsify the record |
| `cancelledAt` stamped only when absent | The original cancellation timestamp is history, not a cleanup field |
| Comp floor still wins | `recomputeEntitlementFromAllSubs` preserves goodwill grants; the return surfaces `entitlementAfter` so the operator can see it |
| Clears reconciler backoff + renewal-verification lease | A leftover `renewalVerificationState` would leave the billing UI showing "verifying your renewal" forever (#4771) |
| Revokes Business Pro seats inline | Same transaction, via the grant-walk the cancelled/expired handlers already share (exported for this) — so seat revocation cannot commit apart from the coverage end |
| Syncs the Redis entitlement cache | Access stops now instead of drifting up to 900s on a stale edge entry |

Usage:

```bash
npx convex run 'payments/billing:endSubscriptionCoverageNow' \
  '{"dodoSubscriptionId":"sub_XXX","reason":"full refund ref_YYY"}'
```

## Tests

Eight new tests in `convex/__tests__/billing.test.ts`: the downgrade to free, the no-extend floor, the active→cancelled flip, `expired` preservation, the comp floor, lease clearing, seat revocation with invitee downgrade, and the unknown-id throw.

Verified with teeth, not just green — three mutants planted in the implementation, each killed by exactly the test that should catch it:

| Mutant | Result |
|---|---|
| `Math.min(currentPeriodEnd, now)` → `currentPeriodEnd` | 3 failed |
| `cancelledAt ?? now` → `now` | 1 failed (the "never overwritten" assertion) |
| drop the `expired` guard | 1 failed (the terminal-status assertion) |

`billing` + `businessSeats` + `webhook` suites: 301 passed. `tsc --noEmit` and `biome check` clean.

## Note for the reviewer

Convex prod only picks this up on merge to `main` (`.github/workflows/convex-deploy.yml`). The refunded customer above stays entitled until then.

https://claude.ai/code/session_01Ak9LMRbEN17N7D2t2yW6qc
