### PR TITLE
fix(billing-ui): key the plan status colour on coverage, not the raw status string

### DIFF
--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -44,7 +44,7 @@ import {
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { getSubscription, isSubscriptionLoaded, onSubscriptionChange, openBillingPortal, prereserveBillingPortalTab } from '@/services/billing';
 import { BusinessSeatsSection } from '@/components/BusinessSeatsSection';
-import { deriveBillingUxState, getReactivationHref } from '@/services/billing-state';
+import { deriveBillingUxState, derivePlanStatusTone, getReactivationHref } from '@/services/billing-state';
 import { createApiKey, listApiKeys, revokeApiKey, type ApiKeyInfo } from '@/services/api-keys';
 import { listMcpClients, revokeMcpClient, fetchMcpQuota, type McpClientInfo, type McpQuota } from '@/services/mcp-clients';
 import {
@@ -1013,15 +1013,13 @@ export class UnifiedSettings {
         return this.renderPlanCheckingState();
       }
       const planName = sub?.displayName ?? 'Pro';
-      // A Business Pro grant invitee has no own subscription row (sub === null)
-      // but IS entitled (we're inside the isEntitled() branch) — treat that as
-      // 'active' rather than falling through to the red "problem" color, which
-      // the ternaries below would otherwise do for every status value that
-      // isn't literally 'active'/'on_hold'.
-      const effectiveStatus = sub?.status ?? 'active';
-      const statusColor = effectiveStatus === 'active' ? '#22c55e' : effectiveStatus === 'on_hold' ? '#eab308' : '#ef4444';
-      const statusBorderColor = effectiveStatus === 'active' ? '#22c55e33' : effectiveStatus === 'on_hold' ? '#eab30833' : '#ef444433';
-      const statusBgColor = effectiveStatus === 'active' ? '#22c55e0a' : effectiveStatus === 'on_hold' ? '#eab3080a' : '#ef44440a';
+      // Colour keys on coverage, not the raw status string (#7315): a
+      // cancelled-but-paid-through subscriber derives the ok tone, matching
+      // the "access until" copy below instead of contradicting it in red.
+      const statusTone = derivePlanStatusTone(sub, getEntitlementState(), Date.now());
+      const statusColor = statusTone === 'ok' ? '#22c55e' : statusTone === 'attention' ? '#eab308' : '#ef4444';
+      const statusBorderColor = `${statusColor}33`;
+      const statusBgColor = `${statusColor}0a`;
 
       let statusLine = '';
       if (sub?.currentPeriodEnd) {

--- a/src/services/billing-state.ts
+++ b/src/services/billing-state.ts
@@ -77,6 +77,39 @@ export function deriveBillingUxState(
   return 'lapsed';
 }
 
+/** Tone of the settings billing card's status indicator (#7315). */
+export type PlanStatusTone = 'ok' | 'attention' | 'problem';
+
+/**
+ * Derive the settings billing card's indicator tone.
+ *
+ * Keyed on COVERAGE, not the raw status string (#7315): the old raw-status
+ * ternary painted every status that wasn't literally 'active'/'on_hold' in
+ * the expired red — so a cancelled-but-paid-through subscriber saw a red
+ * card directly above copy saying "access until <date>", a documented
+ * refund-request generator.
+ *
+ *  - 'active' (and a missing row — a Business invitee inside an entitled
+ *    session) → 'ok', unchanged.
+ *  - 'on_hold' → 'attention', unchanged.
+ *  - 'expired' → 'problem': provider-confirmed end of coverage, unchanged.
+ *  - 'cancelled' and any unrecognised status → deriveBillingUxState decides.
+ *    That is the SAME predicate the banners and panel gating use
+ *    (cancelled-but-paid-through derives 'active'), so the card cannot
+ *    drift from the copy beside it, and an unknown status is handled
+ *    explicitly instead of silently falling to red.
+ */
+export function derivePlanStatusTone(
+  sub: BillingSubscriptionSnapshot | null,
+  ent: BillingEntitlementSnapshot | null,
+  now: number,
+): PlanStatusTone {
+  if (sub === null || sub.status === 'active') return 'ok';
+  if (sub.status === 'on_hold') return 'attention';
+  if (sub.status === 'expired') return 'problem';
+  return deriveBillingUxState(sub, ent, now) === 'active' ? 'ok' : 'problem';
+}
+
 // Per-state sessionStorage dismissal keys. Distinct keys so dismissing the
 // pending banner never suppresses a later failed banner. The bare
 // 'pf-banner-dismissed' value predates #4771 and must stay unchanged so

--- a/tests/billing-status-tone.test.mts
+++ b/tests/billing-status-tone.test.mts
@@ -1,0 +1,138 @@
+/**
+ * #7315 — the settings billing card painted a paid-through cancellation in
+ * the same red as a dead `expired` account.
+ *
+ * The colour ternary greened only `active` and yellowed `on_hold`; every
+ * other status fell to red — so `cancelled` with weeks of paid access left
+ * rendered a red dot and red plan name directly above copy saying
+ * "Cancelled -- access until <date>". The colour wins; that contradiction is
+ * a documented refund-request generator.
+ *
+ * The tone now comes from `derivePlanStatusTone`, which keys `cancelled`
+ * (and any unrecognised status) on COVERAGE via `deriveBillingUxState` — the
+ * same predicate billing-state.ts uses everywhere, so the card and the copy
+ * cannot drift.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  derivePlanStatusTone,
+  type BillingSubscriptionSnapshot,
+  type BillingEntitlementSnapshot,
+} from '@/services/billing-state';
+
+const NOW = 1_800_000_000_000; // fixed epoch ms
+const DAY = 86_400_000;
+
+function sub(overrides: Partial<BillingSubscriptionSnapshot> = {}): BillingSubscriptionSnapshot {
+  return {
+    status: 'active',
+    currentPeriodEnd: NOW + 30 * DAY,
+    renewalVerificationState: null,
+    ...overrides,
+  };
+}
+
+function ent(overrides: Partial<BillingEntitlementSnapshot> = {}): BillingEntitlementSnapshot {
+  return { planKey: 'pro', validUntil: NOW + 30 * DAY, ...overrides };
+}
+
+describe('derivePlanStatusTone (#7315)', () => {
+  it('a paid-through cancellation is NOT the problem tone', () => {
+    // The issue's reproduction: cancelled on 08-28 with validUntil 09-28
+    // emailed support 13 minutes later because the card was red.
+    const tone = derivePlanStatusTone(
+      sub({ status: 'cancelled', currentPeriodEnd: NOW + 30 * DAY }),
+      ent(),
+      NOW,
+    );
+    assert.equal(tone, 'ok', 'a fully-entitled cancellation must not render in expired red');
+  });
+
+  it('a paid-through cancellation stays non-red even when the entitlement snapshot is late', () => {
+    // billing-state.ts derives 'active' from the subscription row alone
+    // (cancelled-but-paid-through) — the tone must follow the same predicate.
+    const tone = derivePlanStatusTone(
+      sub({ status: 'cancelled', currentPeriodEnd: NOW + 30 * DAY }),
+      null,
+      NOW,
+    );
+    assert.equal(tone, 'ok');
+  });
+
+  it('a cancellation past its paid window is the problem tone', () => {
+    const tone = derivePlanStatusTone(
+      sub({ status: 'cancelled', currentPeriodEnd: NOW - DAY }),
+      ent({ validUntil: NOW - DAY }),
+      NOW,
+    );
+    assert.equal(tone, 'problem');
+  });
+
+  it('expired is the problem tone, as today', () => {
+    const tone = derivePlanStatusTone(
+      sub({ status: 'expired', currentPeriodEnd: NOW - DAY }),
+      ent({ validUntil: NOW - DAY }),
+      NOW,
+    );
+    assert.equal(tone, 'problem');
+  });
+
+  it('active is ok and on_hold is attention, as today', () => {
+    assert.equal(derivePlanStatusTone(sub(), ent(), NOW), 'ok');
+    assert.equal(derivePlanStatusTone(sub({ status: 'on_hold' }), ent(), NOW), 'attention');
+  });
+
+  it('a Business invitee (no own subscription row) keeps the ok tone', () => {
+    assert.equal(derivePlanStatusTone(null, ent(), NOW), 'ok');
+  });
+
+  it('an unrecognised status is explicit: coverage decides instead of silently falling to red', () => {
+    const unknown = sub({ status: 'paused' as BillingSubscriptionSnapshot['status'] });
+    assert.equal(
+      derivePlanStatusTone(unknown, ent(), NOW),
+      'ok',
+      'an unknown status on a fully-entitled account must not paint the card dead',
+    );
+    assert.equal(
+      derivePlanStatusTone(
+        sub({ status: 'paused' as BillingSubscriptionSnapshot['status'], currentPeriodEnd: NOW - DAY }),
+        ent({ validUntil: NOW - DAY }),
+        NOW,
+      ),
+      'problem',
+    );
+  });
+});
+
+describe('UnifiedSettings billing-card wiring (#7315)', () => {
+  // Source-text assertions, the same shape as billing-state-wiring.test.mts —
+  // UnifiedSettings pulls in the whole settings UI graph, so the pure logic
+  // lives in billing-state.ts and the component is pinned to consume it.
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const settingsSrc = readFileSync(
+    resolve(__dirname, '../src/components/UnifiedSettings.ts'),
+    'utf8',
+  );
+
+  it('the status colour comes from derivePlanStatusTone, not a raw-status ternary', () => {
+    assert.match(
+      settingsSrc,
+      /derivePlanStatusTone\(/,
+      'the billing card must derive its tone from the shared coverage predicate',
+    );
+    assert.doesNotMatch(
+      settingsSrc,
+      /effectiveStatus === 'active' \? '#22c55e'/,
+      'the raw-status colour ternary must be gone — it painted cancelled-but-covered in expired red',
+    );
+  });
+
+  it('keeps the access-until copy for cancellations', () => {
+    assert.match(settingsSrc, /Cancelled -- access until/);
+  });
+});


### PR DESCRIPTION
Fixes #7315

## Problem

`renderUpgradeSection`'s colour ternary greened only `active` and yellowed `on_hold` — everything else fell to `#ef4444`. A paid-through cancellation (fully entitled for weeks) rendered identically to a dead `expired` account: red dot, red plan name, red-tinted card, directly above copy correctly saying `Cancelled -- access until <date>`.

## Fix (acceptance-criteria mapping)

- **`cancelled` with `currentPeriodEnd` in the future renders non-red** — new `derivePlanStatusTone` in `billing-state.ts` returns `'ok'` (the same green as active), and the `access until` copy is untouched (pinned by a wiring test).
- **Reuses the existing coverage predicate** — the cancelled/unknown branch delegates to `deriveBillingUxState`, the predicate the banners and panel gating already use (`cancelled && currentPeriodEnd >= now` → `'active'`), so the panel and `billing-state.ts` cannot drift. It also works when the entitlement snapshot is late, because the predicate derives coverage from the subscription row alone.
- **The unknown-status case is explicit** — an unrecognised status is decided by coverage instead of silently falling into red (the "branch on known strings, mishandle the rest" shape the issue calls out). `expired` and cancelled-past-window stay red as today.

`billing-state.ts` is the module that already owns billing presentation mappings (banner tones), and it must stay a zero-import leaf — the helper adds no imports.

## Tests

New `tests/billing-status-tone.test.mts` (9 tests): the issue's exact reproduction (cancelled + 30 days of access → ok, with and without the entitlement snapshot), cancelled-past-window and expired stay problem, active/on_hold/invitee unchanged, unknown-status explicitness both ways, plus source-wiring assertions that UnifiedSettings consumes `derivePlanStatusTone` and the raw-status ternary is gone (same shape as `billing-state-wiring.test.mts`).

- Failing-first: the suite fails before the change (no export, red-for-cancelled).
- Mutation check: forcing the cancelled/unknown branch to `'problem'` turns 3 tests red.
- `npm run typecheck` clean, biome clean; `billing-state`, `billing-state-wiring`, and both unified-settings suites green.