### PR TITLE
fix(analytics): identify the queue-overflow residual as the #6968 visibility hold and mark it hiddenHold

### DIFF
--- a/src/services/analytics-collector-transport.ts
+++ b/src/services/analytics-collector-transport.ts
@@ -89,6 +89,28 @@ export type CollectorFailure = {
    *    when the bug is fixed (#6288).
    */
   raced?: boolean;
+  /**
+   * This overflow happened while the page was INACTIVE — the #6968
+   * visibility hold, not a parked transport.
+   *
+   * Only ever set on `kind: 'queue-overflow'`. `drainCollectorRequestQueue`
+   * deliberately dispatches nothing while the page is hidden, so a page that
+   * is hidden from install (session restore, prerender, a background-opened
+   * tab) fills the queue with NOTHING in flight and rejects every later
+   * write until it is focused or unloaded. That population is what kept
+   * WORLDMONITOR-YD firing at its pre-fix rate after #6288 (#6947): the
+   * module-owned deadline releases a parked transport, but here no transport
+   * ever ran, so no deadline fix can drain the queue. The state is by
+   * design and self-heals — visibilitychange→visible pumps the queue, and
+   * pagehide flushes it — which is exactly why it must not share a Sentry
+   * signature with the parked-latch incident that alarm exists to page on.
+   *
+   * A MARKER rather than a `kind`, like `raced` and `botFiltered`: every
+   * delivery policy (retry refusal, durable markers, health cohorts) keeps
+   * treating it as the dropped write it is; only the Sentry grouping and
+   * tags read it.
+   */
+  hiddenHold?: boolean;
 };
 
 export type CollectorRequestType = 'event' | 'identify';
@@ -794,6 +816,11 @@ function emitCollectorFailureToSentry(
         failure.kind,
         String(failure.status ?? 'none'),
         ...(failure.raced ? ['raced'] : []),
+        // A designed visibility hold (#6968) and a parked transport are the
+        // same `kind` but different incidents (#6947) — same reasoning as
+        // the raced segment above. The hold self-heals on focus/unload; the
+        // parked latch is the incident WORLDMONITOR-YD exists to page on.
+        ...(failure.hiddenHold ? ['hidden-hold'] : []),
       ],
       tags: {
         kind: 'analytics_collector_write_failed',
@@ -802,8 +829,14 @@ function emitCollectorFailureToSentry(
         requestType: request.requestType,
         healthCohort: cohort,
         raced: String(failure.raced ?? false),
+        hiddenHold: String(failure.hiddenHold ?? false),
         timeoutMechanism: request.timeoutMechanism,
         visibilityAtSend: request.visibilityAtSend ?? 'unknown',
+        // Visibility when the failure was RECORDED. visibilityAtSend is set
+        // at dispatch, which a queue-overflow never reaches — its absence is
+        // why #6947 needed a forensic build_sha reconstruction instead of a
+        // tag query.
+        pageVisibility: collectorVisibilityState(),
       },
       extra: diagnostics,
     }));
@@ -1300,7 +1333,13 @@ function flushCollectorQueueForUnload(): void {
 }
 
 function rejectOverflow(request: CollectorRequest): void {
-  const failure: CollectorFailure = { kind: 'queue-overflow' };
+  const failure: CollectorFailure = {
+    kind: 'queue-overflow',
+    // While the page is inactive the queue holds by design (#6968) — see the
+    // hiddenHold docblock. Read at rejection time: what matters is whether
+    // dispatch was gated when this entry was turned away.
+    ...(collectorPageActive ? {} : { hiddenHold: true }),
+  };
   recordCollectorOutcome(request, failure);
   const error = new CollectorDeliveryError(failure);
   request.reject(error);

--- a/tests/collector-hidden-hold-overflow.test.mts
+++ b/tests/collector-hidden-hold-overflow.test.mts
@@ -1,0 +1,232 @@
+import { describe, it, before, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * #6947 — WORLDMONITOR-YD (`queue-overflow`) survived the #6288 latch fix at
+ * its pre-fix rate: 28 post-fix events across 18 builds, 100% with a
+ * writeCount BELOW the 50-deep queue bound, 54% reporting a single write in
+ * the whole 60 s window. A window recording one write cannot have filled the
+ * queue — it was full when the window opened and never drained.
+ *
+ * The residual mechanism is none of the deadline candidates: it is the
+ * #6968 visibility hold. `drainCollectorRequestQueue` returns while the page
+ * is inactive, so a page that is hidden from install (session restore,
+ * prerender, a background-opened tab) NEVER dispatches anything — the
+ * consent-flush burst fills the queue with nothing in flight, and every
+ * later throttled-timer write rejects as queue-overflow until the tab is
+ * focused or unloaded. #6288's module-owned deadline releases a parked
+ * TRANSPORT; here no transport ever ran, so the fix could not move this
+ * population — exactly the flat pre/post rate the issue measured.
+ *
+ * That hold is deliberate (#6968: WebKit freezes hidden fetches), so the fix
+ * follows the `raced` precedent: mark overflow rejections that happen while
+ * the page is inactive with `hiddenHold`, give them their own Sentry
+ * fingerprint, and keep today's signature for a genuinely parked visible
+ * page — the incident WORLDMONITOR-YD exists to page on.
+ */
+
+const UMAMI_SEND_URL = 'https://abacus.worldmonitor.app/api/send';
+
+type WindowLifecycleHandler = (event?: { persisted?: boolean }) => void;
+
+const windowListeners: Record<string, WindowLifecycleHandler[]> = {};
+const documentListeners: Record<string, Array<() => void>> = {};
+let visibilityState: DocumentVisibilityState = 'visible';
+let underlyingFetch: typeof fetch = () => Promise.reject(new TypeError('no fetch stub installed'));
+
+before(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      fetch: (input: RequestInfo | URL, init?: RequestInit) => underlyingFetch(input, init),
+      addEventListener: (type: string, handler: WindowLifecycleHandler) => {
+        (windowListeners[type] ??= []).push(handler);
+      },
+      removeEventListener: () => {},
+    },
+  });
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: {
+      get visibilityState() { return visibilityState; },
+      addEventListener: (type: string, handler: () => void) => {
+        (documentListeners[type] ??= []).push(handler);
+      },
+      removeEventListener: () => {},
+    },
+  });
+});
+
+const {
+  COLLECTOR_QUEUE_LIMIT,
+  configureCollectorTransport,
+  installCollectorFetchGate,
+  resetCollectorTransportForTesting,
+  _setCollectorOutcomeObserverForTesting,
+  _setCollectorSentryEnqueueForTesting,
+  _setCollectorHealthReporterForTesting,
+} = await import('../src/services/analytics-collector-transport.ts');
+
+type CapturedSentryEvent = { message: string; context: Record<string, unknown> };
+
+function collectorEventInit(): RequestInit {
+  return {
+    method: 'POST',
+    body: JSON.stringify({ type: 'event', payload: { name: 'search-open' } }),
+  };
+}
+
+function collectorResponse(): Response {
+  const body = JSON.stringify({ cache: 'cache-id', sessionId: 'session-id', visitId: 'visit-id' });
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+    text: async () => body,
+    clone: () => collectorResponse(),
+  } as Response;
+}
+
+function setUpTransport(initialVisibility: DocumentVisibilityState): {
+  outcomes: Array<{ kind: string; hiddenHold: boolean | undefined }>;
+  sentryEvents: CapturedSentryEvent[];
+  dispatches: number[];
+} {
+  visibilityState = initialVisibility;
+  const outcomes: Array<{ kind: string; hiddenHold: boolean | undefined }> = [];
+  const sentryEvents: CapturedSentryEvent[] = [];
+  const dispatches: number[] = [];
+
+  configureCollectorTransport({
+    endpoint: UMAMI_SEND_URL,
+    isCriticalEvent: () => false,
+    onOutcome: (outcome) => {
+      if (outcome.failure) {
+        outcomes.push({
+          kind: outcome.failure.kind,
+          hiddenHold: (outcome.failure as { hiddenHold?: boolean }).hiddenHold,
+        });
+      }
+    },
+  });
+  _setCollectorOutcomeObserverForTesting(null);
+  _setCollectorHealthReporterForTesting(() => {});
+  _setCollectorSentryEnqueueForTesting((enqueue) => {
+    enqueue({
+      captureMessage: (message: string, context: Record<string, unknown>) => {
+        sentryEvents.push({ message, context });
+      },
+    } as never);
+  });
+  underlyingFetch = (() => {
+    dispatches.push(Date.now());
+    return Promise.resolve(collectorResponse());
+  }) as typeof fetch;
+  assert.ok(installCollectorFetchGate(), 'gate must install against the stub window');
+  return { outcomes, sentryEvents, dispatches };
+}
+
+/** Enqueue one collector write through the gate, consuming its rejections. */
+function issueWrite(): Promise<Response> {
+  const transport = (globalThis.window as { fetch: typeof fetch }).fetch(
+    UMAMI_SEND_URL,
+    collectorEventInit(),
+  ) as Promise<Response>;
+  transport.catch(() => {});
+  return transport;
+}
+
+function fireVisibilityChange(): void {
+  for (const handler of documentListeners.visibilitychange ?? []) handler();
+}
+
+async function drainMicrotasks(): Promise<void> {
+  for (let i = 0; i < 20; i++) await Promise.resolve();
+}
+
+describe('queue-overflow on an inactive page carries the hiddenHold marker (#6947)', { concurrency: false }, () => {
+  beforeEach(() => {
+    resetCollectorTransportForTesting();
+    for (const key of Object.keys(windowListeners)) delete windowListeners[key];
+    for (const key of Object.keys(documentListeners)) delete documentListeners[key];
+  });
+
+  afterEach(() => {
+    resetCollectorTransportForTesting();
+  });
+
+  it('a page hidden from install fills the queue with NOTHING in flight, and its overflows are marked hiddenHold', async () => {
+    const { outcomes, sentryEvents, dispatches } = setUpTransport('hidden');
+
+    // The consent-flush burst: fill the queue, then keep writing — the shape
+    // the issue measured (writeCount==1 windows are the later throttled
+    // timer writes, each rejected at a queue that was full before the
+    // window opened).
+    for (let i = 0; i < COLLECTOR_QUEUE_LIMIT + 3; i++) issueWrite();
+    await drainMicrotasks();
+
+    assert.equal(
+      dispatches.length, 0,
+      'nothing may dispatch while the page is hidden (#6968) — which is why no deadline fix can drain this queue',
+    );
+    const overflows = outcomes.filter((o) => o.kind === 'queue-overflow');
+    assert.equal(overflows.length, 3, 'each write beyond the bound rejects exactly one entry');
+    for (const overflow of overflows) {
+      assert.equal(
+        overflow.hiddenHold, true,
+        'an overflow while the page is inactive is the designed visibility hold, not a parked transport, and must say so',
+      );
+    }
+
+    assert.ok(sentryEvents.length >= 1, 'the overflow population stays observable');
+    for (const event of sentryEvents) {
+      const fingerprint = (event.context.fingerprint ?? []) as string[];
+      const tags = (event.context.tags ?? {}) as Record<string, string>;
+      assert.ok(
+        fingerprint.includes('hidden-hold'),
+        `hidden-hold overflow must group apart from the parked-latch incident; fingerprint=${JSON.stringify(fingerprint)}`,
+      );
+      assert.equal(tags.hiddenHold, 'true');
+      assert.equal(tags.pageVisibility, 'hidden');
+    }
+  });
+
+  it('becoming visible drains the held queue — the recovery door stays open', async () => {
+    const { dispatches } = setUpTransport('hidden');
+    for (let i = 0; i < 5; i++) issueWrite();
+    await drainMicrotasks();
+    assert.equal(dispatches.length, 0);
+
+    visibilityState = 'visible';
+    fireVisibilityChange();
+    await drainMicrotasks();
+
+    assert.ok(
+      dispatches.length >= 1,
+      'the first visibilitychange to visible must start pumping the held queue',
+    );
+  });
+
+  it('a genuinely parked VISIBLE page keeps the unmarked signature WORLDMONITOR-YD pages on', async () => {
+    const { outcomes, sentryEvents, dispatches } = setUpTransport('visible');
+    // The first dispatch parks forever — the true #6288-class incident.
+    underlyingFetch = (() => {
+      dispatches.push(Date.now());
+      return new Promise<Response>(() => {});
+    }) as typeof fetch;
+
+    for (let i = 0; i < COLLECTOR_QUEUE_LIMIT + 2; i++) issueWrite();
+    await drainMicrotasks();
+
+    assert.equal(dispatches.length, 1, 'the parked transport holds the single in-flight slot');
+    const overflows = outcomes.filter((o) => o.kind === 'queue-overflow');
+    assert.ok(overflows.length >= 1);
+    for (const overflow of overflows) {
+      assert.notEqual(overflow.hiddenHold, true, 'a visible parked page is the real incident and must not be reclassified');
+    }
+    for (const event of sentryEvents) {
+      const fingerprint = (event.context.fingerprint ?? []) as string[];
+      assert.ok(!fingerprint.includes('hidden-hold'));
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6947

## The code-level pass the issue asked for

The residual mechanism is **none of the three deadline candidates**. It is the #6968 visibility hold:

`drainCollectorRequestQueue` returns while the page is inactive (`if (!collectorPageActive) return`). A page that is **hidden from install** — session restore, prerender, a background-opened tab — therefore never dispatches anything: the consent-flush burst fills the 50-deep queue with **nothing in flight**, and every later write (hidden tabs get ~1 timer tick/min, matching the 54% `writeCount == 1` windows) rejects as `queue-overflow` until the tab is focused or unloaded.

This fits every measurement in the issue:
- **Why #6288 couldn't move it**: the module-owned deadline releases a parked *transport*. Here no transport ever ran — `collectorRequestInFlight` is false the whole time — so there is nothing for the deadline to release. Flat pre/post rate follows.
- **Why the queue is full at window-open and never drains**: it filled during the burst before any health window with rejections existed, and dispatch is gated on visibility, not on time.
- **Why the post-fix `writeCount` tail is gone**: visible pages' bursts now drain (the latch fix worked); what remains is exactly the never-visible population.

The recovery doors already exist and are pinned by test: `visibilitychange`→visible pumps the queue, and `pagehide` flushes it with keepalive — so the state is a *designed, self-healing hold*, not data loss.

## The fix

Following the `raced` precedent (a marker, not a `kind`):
- `CollectorFailure.hiddenHold` — set on `queue-overflow` recorded while the page is inactive.
- Its own Sentry fingerprint segment (`hidden-hold`) so the designed hold groups apart from the parked-latch incident WORLDMONITOR-YD exists to page on, plus `hiddenHold` and `pageVisibility` tags (`visibilityAtSend` is set at dispatch, which an overflow never reaches — the absence of any visibility field is why the issue needed a forensic `build_sha` reconstruction instead of a tag query).
- Delivery policies untouched: retry refusal, durable markers, health cohorts treat the marked failure exactly as before.

After this ships, WORLDMONITOR-YD events from current builds are genuinely parked visible pages; the hidden-hold population becomes its own queryable issue whose expected profile is 'clears on focus'.

## Tests

New `tests/collector-hidden-hold-overflow.test.mts` (3 tests):
1. **The issue's signature reproduced**: page hidden from install, queue filled past the bound → zero dispatches (proving no deadline can drain it), every overflow marked `hiddenHold: true`, Sentry events carry the `hidden-hold` fingerprint + tags. Failing-first: this test fails before the change.
2. **Recovery door**: flipping to visible + `visibilitychange` starts pumping the held queue (passes before and after — pins the existing door).
3. **The real incident keeps its signature**: a visible page with a parked transport overflowing stays unmarked (passes before and after).

- Mutation check: removing the marker assignment turns test 1 red.
- Full analytics family green: `analytics-beacon-rejection` + `collector-transport-rejection-identity` + `pro-timeout-signal` (97/97), `analytics-queue-capacity` + `analytics-collector-monitor` (19/19). `npm run typecheck` and biome clean.