### PR TITLE
fix(markets): carry gap-fetch failure provenance on the failure itself

### DIFF
--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -482,6 +482,8 @@ const LOCAL_FALLBACK_MAX_ENTRIES = 5000;
 const localNegativeUntil = new Map<string, number>();
 /** Per-key unavailable backoff used only when `cacheFetcherErrors: false` (no Redis NEG_SENTINEL). */
 const localUnavailableUntil = new Map<string, number>();
+/** Optional provenance tag stored when arming unavailable backoff (#6475). */
+const localUnavailableReason = new Map<string, string>();
 const localPositiveFallback = new Map<string, { value: unknown; expiresAt: number }>();
 
 function evictOldestLocalFallbackEntries<T>(map: Map<string, T>): void {
@@ -489,6 +491,7 @@ function evictOldestLocalFallbackEntries<T>(map: Map<string, T>): void {
     const oldestKey = map.keys().next().value;
     if (oldestKey === undefined) return;
     map.delete(oldestKey);
+    if (map === localUnavailableUntil) localUnavailableReason.delete(oldestKey);
   }
 }
 
@@ -509,8 +512,10 @@ function hasLocalNegativeCooldown(key: string): boolean {
   return false;
 }
 
-function armLocalUnavailableBackoff(key: string, ttlSeconds: number): void {
+function armLocalUnavailableBackoff(key: string, ttlSeconds: number, reasonTag?: string): void {
   localUnavailableUntil.set(key, Date.now() + ttlSeconds * 1000);
+  if (reasonTag !== undefined) localUnavailableReason.set(key, reasonTag);
+  else localUnavailableReason.delete(key);
   evictOldestLocalFallbackEntries(localUnavailableUntil);
 }
 
@@ -519,13 +524,19 @@ function hasLocalUnavailableBackoff(key: string): boolean {
   if (expiresAt === undefined) return false;
   if (expiresAt > Date.now()) return true;
   localUnavailableUntil.delete(key);
+  localUnavailableReason.delete(key);
   return false;
+}
+
+function localUnavailableBackoffReason(key: string): string | undefined {
+  return localUnavailableReason.get(key);
 }
 
 // Test-only: clear the short unavailable backoff so recovery paths can be exercised
 // without sleeping FETCH_ERROR_UNAVAILABLE_BACKOFF_SECONDS.
 export function __clearLocalUnavailableBackoffForTests(): void {
   localUnavailableUntil.clear();
+  localUnavailableReason.clear();
 }
 
 function effectiveRedisFailurePositiveTtlSeconds(ttlSeconds: number): number {
@@ -833,7 +844,7 @@ export class CachedFetchCancelledError extends Error {
  * generic reason.
  */
 export class CachedFetchUnavailableBackoffError extends Error {
-  constructor(message: string) {
+  constructor(message: string, readonly reasonTag?: string) {
     super(message);
     this.name = 'CachedFetchUnavailableBackoffError';
   }
@@ -895,6 +906,10 @@ function withFetcherTimeout<T>(promise: Promise<T>, key: string, timeoutMs: numb
 export interface CachedFetchOpts {
   timeoutMs?: number;
   cacheFetcherErrors?: boolean;
+  /** When arming isolate-local unavailable backoff, store this tag beside the key. */
+  unavailableBackoffReason?: (err: unknown) => string | undefined;
+  /** Override default arming (skip for caller cancel). Default: skip CachedFetchCancelledError only. */
+  shouldArmUnavailableBackoff?: (err: unknown) => boolean;
 }
 
 /**
@@ -921,6 +936,8 @@ export async function cachedFetchJson<T extends object>(
     : {
         timeoutMs: opts.timeoutMs,
         cacheFetcherErrors: opts.cacheFetcherErrors,
+        unavailableBackoffReason: opts.unavailableBackoffReason,
+        shouldArmUnavailableBackoff: opts.shouldArmUnavailableBackoff,
       };
   const result = await cachedFetchJsonCore(key, ttlSeconds, fetcher, negativeTtlSeconds, coreOpts, 'cachedFetchJson');
   return result.data;
@@ -1024,7 +1041,10 @@ async function cachedFetchJsonCore<T extends object>(
     if (hasLocalNegativeCooldown(key)) return { data: null, source: 'cache', leader: false };
   }
   if (hasLocalUnavailableBackoff(key)) {
-    throw new CachedFetchUnavailableBackoffError(`${callerName} unavailable backoff active for "${key}"`);
+    throw new CachedFetchUnavailableBackoffError(
+      `${callerName} unavailable backoff active for "${key}"`,
+      localUnavailableBackoffReason(key),
+    );
   }
 
   const inflightKey = opts?.inflightKey ?? key;
@@ -1102,11 +1122,17 @@ async function cachedFetchJsonCore<T extends object>(
         armLocalNegativeCooldown(key, errorTtlSeconds);
         await setCachedJson(key, NEG_SENTINEL, errorTtlSeconds);
         console.warn(`[redis] ${callerName} fetcher failed for "${key}":`, errMsg(err));
-      } else if (!(err instanceof CachedFetchCancelledError)) {
-        // A cancellation is the CALLER giving up, not the upstream failing —
-        // arming here would bill the next request's miss to a provider that
-        // was never allowed to answer (#6475).
-        armLocalUnavailableBackoff(key, FETCH_ERROR_UNAVAILABLE_BACKOFF_SECONDS);
+      } else {
+        const shouldArm = opts?.shouldArmUnavailableBackoff
+          ? opts.shouldArmUnavailableBackoff(err)
+          : !(err instanceof CachedFetchCancelledError);
+        if (shouldArm) {
+          // A cancellation (or deadline-bound timeout race) is the CALLER giving
+          // up, not the upstream failing — arming would bill the next request's
+          // miss to a provider that was never allowed to answer (#6475).
+          const reasonTag = opts?.unavailableBackoffReason?.(err);
+          armLocalUnavailableBackoff(key, FETCH_ERROR_UNAVAILABLE_BACKOFF_SECONDS, reasonTag);
+        }
       }
       throw err;
     })

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -811,6 +811,34 @@ export class CachedFetchTimeoutError extends Error {
   }
 }
 
+/**
+ * A fetcher throws this when its own CALLER cancelled the work (deadline,
+ * user abort) — as opposed to the upstream failing (#6475). The cache layer
+ * must not arm the local unavailable backoff for it: an upstream that was
+ * never allowed to answer has not been shown to be unavailable, and arming
+ * would make the NEXT caller's miss read as the provider's failure.
+ */
+export class CachedFetchCancelledError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CachedFetchCancelledError';
+  }
+}
+
+/**
+ * Identifies the local unavailable-backoff short-circuit without matching
+ * text (#6475): the fetcher was NOT run because a recent fetcher failure for
+ * this key armed the 3s backoff. Callers that classify failure provenance
+ * can attribute this to the earlier failure instead of falling through to a
+ * generic reason.
+ */
+export class CachedFetchUnavailableBackoffError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CachedFetchUnavailableBackoffError';
+  }
+}
+
 // Test-only: override the DEFAULT inflight timeout so unit tests can exercise
 // the timeout branch without sleeping for 30s. Per-call `opts.timeoutMs` still
 // wins. No production caller should ever invoke this.
@@ -996,7 +1024,7 @@ async function cachedFetchJsonCore<T extends object>(
     if (hasLocalNegativeCooldown(key)) return { data: null, source: 'cache', leader: false };
   }
   if (hasLocalUnavailableBackoff(key)) {
-    throw new Error(`${callerName} unavailable backoff active for "${key}"`);
+    throw new CachedFetchUnavailableBackoffError(`${callerName} unavailable backoff active for "${key}"`);
   }
 
   const inflightKey = opts?.inflightKey ?? key;
@@ -1074,7 +1102,10 @@ async function cachedFetchJsonCore<T extends object>(
         armLocalNegativeCooldown(key, errorTtlSeconds);
         await setCachedJson(key, NEG_SENTINEL, errorTtlSeconds);
         console.warn(`[redis] ${callerName} fetcher failed for "${key}":`, errMsg(err));
-      } else {
+      } else if (!(err instanceof CachedFetchCancelledError)) {
+        // A cancellation is the CALLER giving up, not the upstream failing —
+        // arming here would bill the next request's miss to a provider that
+        // was never allowed to answer (#6475).
         armLocalUnavailableBackoff(key, FETCH_ERROR_UNAVAILABLE_BACKOFF_SECONDS);
       }
       throw err;

--- a/server/worldmonitor/market/v1/_quote-provider.ts
+++ b/server/worldmonitor/market/v1/_quote-provider.ts
@@ -291,8 +291,12 @@ export class CascadeQuoteProvider implements MarketQuoteProvider {
     for (const provider of candidates) {
       // Caller cancellation, before or between attempts, ends the cascade
       // without a provider verdict — trying the next provider would spend
-      // budget on an answer nobody is waiting for (#6475).
-      if (signal?.aborted) return { status: 'cancelled' };
+      // budget on an answer nobody is waiting for (#6475). A rate_limited
+      // verdict already on record is preserved (same as the post-error break).
+      if (signal?.aborted) {
+        if (sawRateLimited) return { status: 'rate_limited' };
+        return { status: 'cancelled' };
+      }
       const outcome = await provider.fetchQuote(symbol, signal);
       if (outcome.status === 'cancelled') return outcome;
       if (outcome.status === 'ok') {

--- a/server/worldmonitor/market/v1/_quote-provider.ts
+++ b/server/worldmonitor/market/v1/_quote-provider.ts
@@ -38,6 +38,14 @@ export type QuoteProviderOutcome =
   | { status: 'ok'; quote: ProviderQuote }
   | { status: 'not_found' }
   | { status: 'rate_limited' }
+  /**
+   * The CALLER's signal aborted the attempt (#6475). Not a provider verdict:
+   * the provider was never allowed to answer, so this outcome must never be
+   * recorded, cached, or backed-off as the provider's failure. The adapter's
+   * own per-attempt timeout stays `error` — a provider that cannot answer in
+   * its budget is provider-attributable.
+   */
+  | { status: 'cancelled' }
   | { status: 'error'; message: string };
 
 export interface MarketQuoteProvider {
@@ -146,6 +154,7 @@ export class FinnhubQuoteProvider implements MarketQuoteProvider {
         },
       };
     } catch (err) {
+      if (requestSignal?.aborted) return { status: 'cancelled' };
       return { status: 'error', message: (err as Error).message || 'fetch failed' };
     } finally {
       attempt.cleanup();
@@ -236,6 +245,7 @@ export class AlphaVantageQuoteProvider implements MarketQuoteProvider {
         },
       };
     } catch (err) {
+      if (requestSignal?.aborted) return { status: 'cancelled' };
       return { status: 'error', message: (err as Error).message || 'fetch failed' };
     } finally {
       attempt.cleanup();
@@ -279,8 +289,12 @@ export class CascadeQuoteProvider implements MarketQuoteProvider {
     let lastError: QuoteProviderOutcome | null = null;
 
     for (const provider of candidates) {
-      if (signal?.aborted) return { status: 'error', message: 'request deadline exceeded' };
+      // Caller cancellation, before or between attempts, ends the cascade
+      // without a provider verdict — trying the next provider would spend
+      // budget on an answer nobody is waiting for (#6475).
+      if (signal?.aborted) return { status: 'cancelled' };
       const outcome = await provider.fetchQuote(symbol, signal);
+      if (outcome.status === 'cancelled') return outcome;
       if (outcome.status === 'ok') {
         // Observability without credentials: which authorized provider filled the gap.
         console.info(`[quote-provider] ${symbol} via ${provider.name}`);

--- a/server/worldmonitor/market/v1/list-market-quotes.ts
+++ b/server/worldmonitor/market/v1/list-market-quotes.ts
@@ -256,7 +256,21 @@ export class QuoteGapFetchFailureError extends Error {
 
 /** The recorded provider verdict a rejection carries, if it carries one. */
 function recordedReasonFromError(err: unknown): Reason | undefined {
-  return err instanceof QuoteGapFetchFailureError ? err.reason : undefined;
+  if (err instanceof QuoteGapFetchFailureError) return err.reason;
+  if (err instanceof CachedFetchUnavailableBackoffError && err.reasonTag) {
+    return err.reasonTag as Reason;
+  }
+  return undefined;
+}
+
+function shouldArmQuoteUnavailableBackoff(err: unknown, callRemainingMs: number): boolean {
+  if (err instanceof CachedFetchCancelledError) return false;
+  // On the deadline-bound path the inflight timeout is a backstop that must
+  // not arm backoff when it races a deadline abort (#6475).
+  if (err instanceof CachedFetchTimeoutError && callRemainingMs <= QUOTE_PROVIDER_CALL_BUDGET_MS) {
+    return false;
+  }
+  return true;
 }
 
 export function classifyGapFetchFailure(input: {
@@ -346,7 +360,12 @@ async function resolveMissingSymbols(missing: string[]): Promise<GapFetchResult>
           throw new QuoteGapFetchFailureError(reason, outcome.status === 'rate_limited' ? 'provider rate limited' : outcome.message);
         },
         QUOTE_NEGATIVE_TTL_SECONDS,
-        { timeoutMs: gapFetchCallTimeoutMs(remainingMs), cacheFetcherErrors: false },
+        {
+          timeoutMs: gapFetchCallTimeoutMs(remainingMs),
+          cacheFetcherErrors: false,
+          unavailableBackoffReason: recordedReasonFromError,
+          shouldArmUnavailableBackoff: (err) => shouldArmQuoteUnavailableBackoff(err, remainingMs),
+        },
       ), deadlineSignal);
 
       if (cached) quotes.set(symbol, cached);
@@ -363,7 +382,7 @@ async function resolveMissingSymbols(missing: string[]): Promise<GapFetchResult>
       const reason = err instanceof CachedFetchCancelledError
         ? REASON.budget
         : err instanceof CachedFetchUnavailableBackoffError
-          ? REASON.providerError
+          ? (err.reasonTag as Reason | undefined) ?? REASON.providerError
           : classifyGapFetchFailure({
               deadlineAborted: deadlineSignal.aborted,
               now,

--- a/server/worldmonitor/market/v1/list-market-quotes.ts
+++ b/server/worldmonitor/market/v1/list-market-quotes.ts
@@ -40,7 +40,7 @@ import {
   resolveMarketQuoteProvider,
   type ProviderQuote,
 } from './_quote-provider';
-import { CachedFetchTimeoutError, cachedFetchJson, readCachedJson } from '../../../_shared/redis';
+import { CachedFetchCancelledError, CachedFetchTimeoutError, CachedFetchUnavailableBackoffError, cachedFetchJson, readCachedJson } from '../../../_shared/redis';
 
 const BOOTSTRAP_KEY = 'market:stocks-bootstrap:v1';
 
@@ -239,6 +239,26 @@ export function gapFetchCallTimeoutMs(remainingMs: number): number {
  * `rateLimited` flag. At that instant we are out of budget either way, and the
  * next refresh re-attempts the symbol.
  */
+/**
+ * Provider failure carried AS the rejection (#6475), so the cause survives the
+ * shared inflight slot in `cachedFetchJson`: a caller that joins another
+ * request's in-flight lookup receives the leader's rejection with its own
+ * request-local `liveOutcomes` empty — before this, a real 429 seen by the
+ * leader reached the joiner as an anonymous Error and classified as
+ * PROVIDER_ERROR with `rateLimited: false`.
+ */
+export class QuoteGapFetchFailureError extends Error {
+  constructor(readonly reason: Reason, message: string) {
+    super(message);
+    this.name = 'QuoteGapFetchFailureError';
+  }
+}
+
+/** The recorded provider verdict a rejection carries, if it carries one. */
+function recordedReasonFromError(err: unknown): Reason | undefined {
+  return err instanceof QuoteGapFetchFailureError ? err.reason : undefined;
+}
+
 export function classifyGapFetchFailure(input: {
   deadlineAborted: boolean;
   now: number;
@@ -309,10 +329,21 @@ async function resolveMissingSymbols(missing: string[]): Promise<GapFetchResult>
             liveOutcomes.set(symbol, REASON.notFound);
             return null; // definitive — safe to negative-cache
           }
+          if (outcome.status === 'cancelled') {
+            // Our own cutoff — no provider verdict exists. The typed class
+            // tells the cache layer not to arm the unavailable backoff
+            // (#6475 item 1): an upstream that was never allowed to answer
+            // has not been shown unavailable, and arming would bill the NEXT
+            // request's miss to the provider.
+            throw new CachedFetchCancelledError(`quote lookup for ${symbol} cancelled by request deadline`);
+          }
           // Transient. Throwing with cacheFetcherErrors:false keeps it out of
           // Redis, so a provider blip cannot pin a real symbol as unavailable.
-          liveOutcomes.set(symbol, outcome.status === 'rate_limited' ? REASON.rateLimited : REASON.providerError);
-          throw new Error(outcome.status === 'rate_limited' ? 'provider rate limited' : outcome.message);
+          // The reason rides ON the rejection so a coalesced joiner (whose
+          // request-local liveOutcomes is empty) classifies it identically.
+          const reason = outcome.status === 'rate_limited' ? REASON.rateLimited : REASON.providerError;
+          liveOutcomes.set(symbol, reason);
+          throw new QuoteGapFetchFailureError(reason, outcome.status === 'rate_limited' ? 'provider rate limited' : outcome.message);
         },
         QUOTE_NEGATIVE_TTL_SECONDS,
         { timeoutMs: gapFetchCallTimeoutMs(remainingMs), cacheFetcherErrors: false },
@@ -322,12 +353,23 @@ async function resolveMissingSymbols(missing: string[]): Promise<GapFetchResult>
       else reasons.set(symbol, liveOutcomes.get(symbol) ?? REASON.notFound);
     } catch (err) {
       const now = Date.now();
-      const reason = classifyGapFetchFailure({
-        deadlineAborted: deadlineSignal.aborted,
-        now,
-        deadline,
-        recorded: liveOutcomes.get(symbol),
-      });
+      // A typed cancellation is our cutoff wherever it surfaced — including a
+      // joiner whose own deadline still had budget when the leader's cut the
+      // shared fetch (#6475 item 2). A typed backoff short-circuit means the
+      // provider was not contacted THIS time because a recent real failure
+      // armed the 3s backoff (cancellations no longer arm it), so charging
+      // the provider is honest. Everything else classifies on the recorded
+      // verdict, which now also rides on the rejection itself for joiners.
+      const reason = err instanceof CachedFetchCancelledError
+        ? REASON.budget
+        : err instanceof CachedFetchUnavailableBackoffError
+          ? REASON.providerError
+          : classifyGapFetchFailure({
+              deadlineAborted: deadlineSignal.aborted,
+              now,
+              deadline,
+              recorded: liveOutcomes.get(symbol) ?? recordedReasonFromError(err),
+            });
       reasons.set(symbol, reason);
       if (reason === REASON.rateLimited) rateLimited = true;
       // `marginMs` is how much of the window was left when a cutoff fired:

--- a/tests/market-quote-failure-provenance.test.mts
+++ b/tests/market-quote-failure-provenance.test.mts
@@ -39,6 +39,7 @@ import {
 import {
   CascadeQuoteProvider,
   FinnhubQuoteProvider,
+  AlphaVantageQuoteProvider,
 } from '../server/worldmonitor/market/v1/_quote-provider';
 
 const BOOTSTRAP_KEY = 'market:stocks-bootstrap:v1';
@@ -200,6 +201,24 @@ describe('gap-fetch failure provenance (#6475)', () => {
     assert.equal(harness.finnhubCalls.length, 1, 'a real provider failure keeps the backoff');
     assert.equal(reasonFor(second, 'MSFT'), 'MARKET_QUOTE_UNAVAILABLE_REASON_PROVIDER_ERROR');
   });
+
+  it('a second call after a real 429 preserves PROVIDER_RATE_LIMITED and rateLimited', async () => {
+    const harness = installHarness({ provider: { TSLA: { status: 429 } } });
+
+    const first = await listMarketQuotes(CTX, { symbols: ['TSLA'] });
+    assert.equal(reasonFor(first, 'TSLA'), 'MARKET_QUOTE_UNAVAILABLE_REASON_PROVIDER_RATE_LIMITED');
+    assert.equal(first.rateLimited, true);
+    assert.equal(harness.finnhubCalls.length, 1);
+
+    const second = await listMarketQuotes(CTX, { symbols: ['TSLA'] });
+    assert.equal(harness.finnhubCalls.length, 1, '429 backoff must absorb the immediate retry');
+    assert.equal(
+      reasonFor(second, 'TSLA'),
+      'MARKET_QUOTE_UNAVAILABLE_REASON_PROVIDER_RATE_LIMITED',
+      'backoff short-circuit must carry the rate-limit verdict, not PROVIDER_ERROR',
+    );
+    assert.equal(second.rateLimited, true);
+  });
 });
 
 describe('provider adapters report caller cancellation as its own outcome (#6475)', () => {
@@ -249,5 +268,39 @@ describe('provider adapters report caller cancellation as its own outcome (#6475
     controller.abort();
     const cascade = new CascadeQuoteProvider([new FinnhubQuoteProvider('key')]);
     assert.deepEqual(await cascade.fetchQuote('AAPL', controller.signal), { status: 'cancelled' });
+  });
+
+  it('preserves rate_limited when the caller aborts after an upstream 429', async () => {
+    const controller = new AbortController();
+    const finnhub = {
+      name: 'finnhub',
+      canQuote: () => true,
+      fetchQuote: async () => {
+        controller.abort(new DOMException('deadline', 'AbortError'));
+        return { status: 'rate_limited' } as const;
+      },
+    };
+    const second = {
+      name: 'second',
+      canQuote: () => true,
+      fetchQuote: async () => ({ status: 'not_found' } as const),
+    };
+
+    const cascade = new CascadeQuoteProvider([finnhub, second]);
+    assert.deepEqual(await cascade.fetchQuote('NVDA', controller.signal), { status: 'rate_limited' });
+  });
+
+  it('Alpha Vantage maps an aborted fetch to cancelled, never to error', async () => {
+    globalThis.fetch = ((_input: RequestInfo | URL, opts?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        opts?.signal?.addEventListener('abort', () => reject(opts.signal?.reason), { once: true });
+      })) as typeof fetch;
+
+    const controller = new AbortController();
+    const provider = new AlphaVantageQuoteProvider('key');
+    const pending = provider.fetchQuote('AAPL', controller.signal);
+    controller.abort(new DOMException('caller gone', 'AbortError'));
+
+    assert.deepEqual(await pending, { status: 'cancelled' });
   });
 });

--- a/tests/market-quote-failure-provenance.test.mts
+++ b/tests/market-quote-failure-provenance.test.mts
@@ -1,0 +1,253 @@
+/**
+ * #6475 — the gap fetch reconstructed WHY a lookup failed from clocks and a
+ * request-local side map, instead of carrying the cause on the failure itself.
+ *
+ * Two reachable mis-attributions, both billing the provider for something the
+ * provider never did:
+ *
+ *  1. Our own deadline cutoff armed `armLocalUnavailableBackoff` (any fetcher
+ *     rejection did). The NEXT request, same isolate, same symbol, within 3 s
+ *     hit the backoff throw before any provider call — and its catch saw a
+ *     fresh deadline and an empty side map, so it reported PROVIDER_ERROR for
+ *     a provider that was never contacted.
+ *  2. A caller that joined an in-flight lookup inherited the leader's
+ *     rejection with its OWN side map empty: a real 429 seen by the leader
+ *     reported PROVIDER_ERROR to the joiner, with `rateLimited: false`.
+ *
+ * Provenance is now typed and carried on the failure: the provider adapters
+ * report a caller cancellation as `status: 'cancelled'` (never an error), the
+ * fetcher throws typed errors carrying the recorded reason, and the cache
+ * layer refuses to arm the unavailable backoff for a cancellation — an
+ * upstream that was never allowed to answer has not been shown unavailable.
+ */
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import type {
+  ListMarketQuotesResponse,
+  ServerContext,
+} from '@/generated/server/worldmonitor/market/v1/service_server';
+import {
+  __clearLocalUnavailableBackoffForTests,
+  __resetKeyPrefixCacheForTests,
+} from '../server/_shared/redis';
+import {
+  __resetUpstreamDeadlineForTests,
+  __setUpstreamDeadlineForTests,
+  listMarketQuotes,
+} from '../server/worldmonitor/market/v1/list-market-quotes';
+import {
+  CascadeQuoteProvider,
+  FinnhubQuoteProvider,
+} from '../server/worldmonitor/market/v1/_quote-provider';
+
+const BOOTSTRAP_KEY = 'market:stocks-bootstrap:v1';
+const CTX = {} as ServerContext;
+
+const ORIGINAL_ENV = {
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  VERCEL_ENV: process.env.VERCEL_ENV,
+  LOCAL_API_MODE: process.env.LOCAL_API_MODE,
+  FINNHUB_API_KEY: process.env.FINNHUB_API_KEY,
+  ALPHA_VANTAGE_API_KEY: process.env.ALPHA_VANTAGE_API_KEY,
+};
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_WARN = console.warn;
+const ORIGINAL_INFO = console.info;
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  console.warn = ORIGINAL_WARN;
+  console.info = ORIGINAL_INFO;
+  for (const [name, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+  __resetKeyPrefixCacheForTests();
+  __clearLocalUnavailableBackoffForTests();
+  __resetUpstreamDeadlineForTests();
+});
+
+type ProviderReply = { status: number; body?: unknown; waitForAbort?: boolean; delayMs?: number };
+
+interface Harness {
+  finnhubCalls: string[];
+}
+
+/** Minimal copy of the seed-first harness: fake Upstash + fake Finnhub. */
+function installHarness(init: { provider?: Record<string, ProviderReply> } = {}): Harness {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+  process.env.VERCEL_ENV = 'production';
+  delete process.env.LOCAL_API_MODE;
+  process.env.FINNHUB_API_KEY = 'test-finnhub-key';
+  delete process.env.ALPHA_VANTAGE_API_KEY;
+  __resetKeyPrefixCacheForTests();
+
+  const provider = new Map(Object.entries(init.provider ?? {}));
+  const redis = new Map<string, unknown>();
+  // Seed-first contract: the gap fetch only runs for symbols the seeded
+  // bootstrap does not carry, so seed an unrelated symbol.
+  redis.set(BOOTSTRAP_KEY, {
+    quotes: [{ symbol: 'SPY', name: 'SPY', display: 'SPY', price: 100, change: 1, sparkline: [] }],
+    finnhubSkipped: false,
+    skipReason: '',
+    rateLimited: false,
+    unavailableSymbols: [],
+  });
+  const harness: Harness = { finnhubCalls: [] };
+
+  const json = (value: unknown, status = 200) =>
+    new Response(JSON.stringify(value), { status, headers: { 'Content-Type': 'application/json' } });
+
+  globalThis.fetch = (async (input: RequestInfo | URL, opts?: RequestInit) => {
+    const url = String(input);
+
+    if (url.startsWith('https://redis.example.test/get/')) {
+      const key = decodeURIComponent(url.slice('https://redis.example.test/get/'.length));
+      const value = redis.get(key);
+      return json({ result: value === undefined ? null : JSON.stringify(value) });
+    }
+    if (url === 'https://redis.example.test/') {
+      const [, key, value] = JSON.parse(String(opts?.body)) as [string, string, string];
+      redis.set(key, JSON.parse(value));
+      return json({ result: 'OK' });
+    }
+    if (url.startsWith('https://finnhub.io/api/v1/quote')) {
+      const symbol = decodeURIComponent(new URL(url).searchParams.get('symbol') ?? '');
+      harness.finnhubCalls.push(symbol);
+      const reply = provider.get(symbol);
+      if (!reply) return json({ c: 0, dp: 0, h: 0, l: 0 });
+      if (reply.waitForAbort) {
+        const signal = opts?.signal;
+        assert.ok(signal, 'deadline signal must reach the provider fetch');
+        return await new Promise<Response>((_resolve, reject) => {
+          const onAbort = () => reject(signal.reason);
+          if (signal.aborted) onAbort();
+          else signal.addEventListener('abort', onAbort, { once: true });
+        });
+      }
+      if (reply.delayMs) await new Promise((r) => setTimeout(r, reply.delayMs));
+      return json(reply.body ?? {}, reply.status);
+    }
+    throw new Error(`unexpected fetch in test: ${url}`);
+  }) as typeof fetch;
+
+  console.warn = () => {};
+  console.info = () => {};
+  return harness;
+}
+
+const reasonFor = (resp: ListMarketQuotesResponse, symbol: string) =>
+  resp.unavailableSymbols.find((u) => u.symbol === symbol)?.reason;
+
+describe('gap-fetch failure provenance (#6475)', () => {
+  it('a second call after our own cutoff still reports UPSTREAM_BUDGET_EXHAUSTED, not PROVIDER_ERROR, and actually reaches the provider', async () => {
+    const harness = installHarness({ provider: { AAPL: { waitForAbort: true } } });
+    __setUpstreamDeadlineForTests(60);
+
+    const first = await listMarketQuotes(CTX, { symbols: ['AAPL'] });
+    assert.equal(
+      reasonFor(first, 'AAPL'),
+      'MARKET_QUOTE_UNAVAILABLE_REASON_UPSTREAM_BUDGET_EXHAUSTED',
+      'the first call is cut by our own deadline',
+    );
+    assert.equal(harness.finnhubCalls.length, 1);
+
+    // Same warm isolate, same symbol, within the 3 s backoff the cutoff used
+    // to arm: pre-fix, the backoff throw was classified PROVIDER_ERROR for a
+    // provider that was never contacted, and the provider was NOT retried.
+    const second = await listMarketQuotes(CTX, { symbols: ['AAPL'] });
+    assert.equal(
+      harness.finnhubCalls.length, 2,
+      'our own cancellation must not arm the unavailable backoff — the retry must reach the provider',
+    );
+    assert.equal(
+      reasonFor(second, 'AAPL'),
+      'MARKET_QUOTE_UNAVAILABLE_REASON_UPSTREAM_BUDGET_EXHAUSTED',
+      'a lookup our deadline cut is never the provider\'s failure',
+    );
+  });
+
+  it('a joiner of an in-flight 429 lookup preserves the rate-limit cause and raises rateLimited', async () => {
+    installHarness({ provider: { NVDA: { status: 429, delayMs: 40 } } });
+
+    const [a, b] = await Promise.all([
+      listMarketQuotes(CTX, { symbols: ['NVDA'] }),
+      listMarketQuotes(CTX, { symbols: ['NVDA'] }),
+    ]);
+
+    for (const resp of [a, b]) {
+      assert.equal(
+        reasonFor(resp, 'NVDA'),
+        'MARKET_QUOTE_UNAVAILABLE_REASON_PROVIDER_RATE_LIMITED',
+        'the 429 is real for BOTH callers — the joiner must not downgrade it to PROVIDER_ERROR',
+      );
+      assert.equal(resp.rateLimited, true, 'the response-level flag must rise for both callers');
+    }
+  });
+
+  it('a genuine provider failure still arms the backoff and reports PROVIDER_ERROR', async () => {
+    const harness = installHarness({ provider: { MSFT: { status: 500 } } });
+
+    const first = await listMarketQuotes(CTX, { symbols: ['MSFT'] });
+    assert.equal(reasonFor(first, 'MSFT'), 'MARKET_QUOTE_UNAVAILABLE_REASON_PROVIDER_ERROR');
+
+    // The provider ANSWERED with a failure — the 3 s backoff is earned, and
+    // the immediate retry must be absorbed by it, still as the provider's.
+    const second = await listMarketQuotes(CTX, { symbols: ['MSFT'] });
+    assert.equal(harness.finnhubCalls.length, 1, 'a real provider failure keeps the backoff');
+    assert.equal(reasonFor(second, 'MSFT'), 'MARKET_QUOTE_UNAVAILABLE_REASON_PROVIDER_ERROR');
+  });
+});
+
+describe('provider adapters report caller cancellation as its own outcome (#6475)', () => {
+  it('Finnhub maps an aborted fetch to cancelled, never to error', async () => {
+    globalThis.fetch = ((_input: RequestInfo | URL, opts?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        opts?.signal?.addEventListener('abort', () => reject(opts.signal?.reason), { once: true });
+      })) as typeof fetch;
+
+    const controller = new AbortController();
+    const provider = new FinnhubQuoteProvider('key');
+    const pending = provider.fetchQuote('AAPL', controller.signal);
+    controller.abort(new DOMException('caller gone', 'AbortError'));
+
+    assert.deepEqual(await pending, { status: 'cancelled' });
+  });
+
+  it('the cascade stops on cancellation instead of consulting the next provider', async () => {
+    const controller = new AbortController();
+    let secondAsked = 0;
+    const first = {
+      name: 'first',
+      canQuote: () => true,
+      fetchQuote: async () => {
+        controller.abort(new DOMException('caller gone', 'AbortError'));
+        return { status: 'cancelled' } as const;
+      },
+    };
+    const second = {
+      name: 'second',
+      canQuote: () => true,
+      fetchQuote: async () => {
+        secondAsked += 1;
+        return { status: 'not_found' } as const;
+      },
+    };
+
+    const cascade = new CascadeQuoteProvider([first, second]);
+    const outcome = await cascade.fetchQuote('AAPL', controller.signal);
+
+    assert.deepEqual(outcome, { status: 'cancelled' });
+    assert.equal(secondAsked, 0, 'a cancelled caller must not spend the next provider\'s budget');
+  });
+
+  it('an already-aborted signal short-circuits the cascade as cancelled', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const cascade = new CascadeQuoteProvider([new FinnhubQuoteProvider('key')]);
+    assert.deepEqual(await cascade.fetchQuote('AAPL', controller.signal), { status: 'cancelled' });
+  });
+});


### PR DESCRIPTION
Fixes #6475 (items 1–3; 4–5 left for their own regression pass per the issue's own note on `redis.ts` blast radius)

## What changed

> The gap fetch reconstructs *why* a lookup failed from clocks and a request-local side map, instead of carrying the cause on the failure itself.

Provenance now rides on the types, at each of the three layers the issue names:

- **Adapters (item 3, the root)**: `QuoteProviderOutcome` gains `{ status: 'cancelled' }`, returned by Finnhub and Alpha Vantage when the **caller's** signal aborted. The adapter's own per-attempt 3 s timeout stays `'error'` — a provider that cannot answer inside its budget is provider-attributable. `CascadeQuoteProvider` returns `cancelled` on a pre-aborted signal and stops on a cancelled attempt instead of spending the next provider's budget on an answer nobody is waiting for.
- **Cache layer (item 1)**: the fetcher throws a typed `CachedFetchCancelledError` for a cancellation, and `cachedFetchJson`'s failure path **skips `armLocalUnavailableBackoff` for that class** — an upstream that was never allowed to answer has not been shown to be unavailable. Real provider failures keep arming it (pinned by a control test). The backoff short-circuit itself now throws `CachedFetchUnavailableBackoffError` (stable class, no message matching, per the issue's 'do not string-match' note) and the handler classifies it as the provider failure that armed it.
- **Handler (item 2)**: transient provider failures throw `QuoteGapFetchFailureError` carrying the recorded reason, so a caller that joined the shared in-flight lookup classifies the leader's rejection identically — including raising the response-level `rateLimited` flag on a real 429. A typed cancellation classifies as `UPSTREAM_BUDGET_EXHAUSTED` wherever it surfaces, covering the joiner whose own budget was still live when the leader's deadline cut the shared fetch.

## Tests (the issue's two named regressions, plus adapter cells)

New `tests/market-quote-failure-provenance.test.mts` (6 tests, mirroring the seed-first harness):
1. **Back-to-back calls with a stalled provider**: the second call still reports `UPSTREAM_BUDGET_EXHAUSTED` — and the assertion that catches the old behaviour at the mechanism: the second call **actually reaches the provider** (2 Finnhub calls), because our own cutoff no longer arms the backoff.
2. **Two concurrent calls joining one 429 lookup**: both report `PROVIDER_RATE_LIMITED` and both raise `resp.rateLimited`.
3. **Control**: a genuine HTTP 500 still arms the backoff (1 Finnhub call across two requests) and stays `PROVIDER_ERROR` — passes before and after, pinning that the fix does not soften real provider attribution.
4–6. Adapter cells: aborted Finnhub fetch → `cancelled` (never `error`); cascade stops on cancellation without consulting the next provider; pre-aborted signal short-circuits as `cancelled`.

- Failing-first: tests 1, 2, 4, 6 fail on main; 3 and 5 pass (controls).
- Mutation checks: reverting the backoff-arming skip turns test 1 red; dropping the reason carried on the rejection turns test 2 red.
- Sibling suites green: `market-quotes-seed-first` + `quote-provider-adapter` + `commodity-quotes` (75/75), `market-quote-refresh` + `-cache-keying` + `-provider-seeder` (32/32), plus redis-consumer smoke (aviation legs, FRED batch, custom watchlist — 20/20). `npm run typecheck` and biome clean.