### PR TITLE
feat(ops): deploy-relative per-route error-rate canary

### DIFF
--- a/.github/workflows/deploy-error-canary.yml
+++ b/.github/workflows/deploy-error-canary.yml
@@ -1,0 +1,36 @@
+name: Deploy Error Canary
+
+# Compares each top-traffic route's 4xx/5xx rate over the last 2 hours
+# against the same route's own 7-day baseline in wm_api_usage, and fails
+# when a route is a step change over itself (#7107). The 2026-08-01
+# validation deploy moved get-aircraft-details-batch from ~0% to ~100%
+# errors for three days (132k client-facing 400s) with no signal — this is
+# the alarm that catches that class within hours instead of weeks.
+#
+# Deliberately NOT gated on a green main (same reasoning as
+# analytics-collector-monitor.yml): production error rates are independent
+# of repo state, and a gate is one more way for this to go quiet.
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24'
+
+      - name: Compare post-deploy error rates against per-route baselines
+        env:
+          AXIOM_API_TOKEN: ${{ secrets.AXIOM_API_TOKEN }}
+        run: node scripts/deploy-error-canary.mjs

--- a/docs/source-attribution.mdx
+++ b/docs/source-attribution.mdx
@@ -84,7 +84,7 @@ This generated inventory covers **758 active source hosts** representing **748 a
 | astanatimes.com (astanatimes.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | AusTender (www.tenders.gov.au) | structured — scripts/seed-global-tenders.mjs |
 | av.alarabiya.net (av.alarabiya.net) | feed — src/components/LiveNewsPanel.ts |
-| Axiom telemetry (api.axiom.co) | structured — api/_usage-telemetry.js, scripts/lib/llm-telemetry.cjs, scripts/seed-forecasts.mjs, server/_shared/usage.ts |
+| Axiom telemetry (api.axiom.co) | structured — api/_usage-telemetry.js, scripts/deploy-error-canary.mjs, scripts/lib/llm-telemetry.cjs, scripts/seed-forecasts.mjs, +1 more |
 | AyiboPost (ayibopost.com) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | azertag.az (azertag.az) | feed — server/worldmonitor/news/v1/_feeds.ts, src/config/feeds.ts |
 | azure.status.microsoft (azure.status.microsoft) | operational-status — server/worldmonitor/infrastructure/v1/list-service-statuses.ts |

--- a/scripts/deploy-error-canary.mjs
+++ b/scripts/deploy-error-canary.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+/**
+ * Deploy-relative per-route error-rate canary (#7107).
+ *
+ * Why this exists: the 2026-08-01 09:57Z deploy of GHSA-cmj5-cfhr-w964 broke
+ * `get-aircraft-details-batch` for effectively every dashboard user — 132,500
+ * client-facing 400s over three days, 17k+ distinct IPs — and nothing
+ * alerted. The same deploy produced the lowercase-country-code failures
+ * (PR #7105) and an api_starter customer's 148 400s/day. All three were
+ * reconstructed forensically weeks later. A change that moves a route's 4xx
+ * rate from ~0% to ~100% of its traffic is invisible unless someone happens
+ * to query Axiom.
+ *
+ * This is the issue's "coarse version": run hourly, compare each of the
+ * top-N routes' 4xx/5xx rate in the CURRENT window (default: the last 2 h)
+ * against the same route's own BASELINE (default: the 7 days before the
+ * current window), and fail the job when a route is a step change over its
+ * own baseline. Window boundaries are printed on every alert so the finding
+ * is attributable to the deploys inside the current window. The data source
+ * is the same `wm_api_usage` dataset the gateway already ingests to.
+ *
+ * Detection is deliberately per-route-relative, not absolute: a route that
+ * is 1% errors every day never alerts at 2%, while a route that has been
+ * ~0% for a week alerts within one run of going to 100%. Guards against
+ * paging on noise:
+ *   - only the top `topRoutes` routes by current traffic are evaluated
+ *     (the issue's top-50), so long-tail probe scans cannot page;
+ *   - `minCurrentErrors` is an absolute floor — a 10-request route that
+ *     failed 8 times is somebody's typo, not an incident;
+ *   - the baseline rate is floored at `baselineRateFloor` before the
+ *     multiple is computed, so a zero-error week (or a brand-new route)
+ *     does not make any single error an infinite step.
+ *
+ * Alerting follows the repo's monitor pattern (analytics-collector-monitor):
+ * `::error` annotations + exit code 1, from a scheduled workflow.
+ */
+
+import { isMainModule } from './lib/main-module.mjs';
+
+const AXIOM_APL_URL = 'https://api.axiom.co/v1/datasets/_apl?format=legacy';
+
+export const DEFAULT_CANARY_OPTIONS = {
+  /** Evaluate only the busiest routes in the current window (issue: top-50). */
+  topRoutes: 50,
+  /** Current error rate must be at least this multiple of the baseline rate. */
+  rateMultiple: 10,
+  /** Floor applied to the baseline rate before the multiple is computed. */
+  baselineRateFloor: 0.005,
+  /** Absolute floor: fewer current-window errors than this never alerts. */
+  minCurrentErrors: 50,
+  /** And the failing share must be material on its own. */
+  minCurrentErrorRate: 0.2,
+};
+
+/** @typedef {{ route: string; total: number; errors: number }} RouteWindow */
+
+/**
+ * Pure detection core. `baseline` and `current` are per-route aggregates for
+ * the two windows; `windows` is carried through onto the report and alert
+ * summaries so every finding names the window it is attributed to.
+ */
+export function evaluateDeployCanary({ baseline, current, windows, options }) {
+  const opts = { ...DEFAULT_CANARY_OPTIONS, ...(options ?? {}) };
+  const baselineByRoute = new Map(baseline.map((row) => [row.route, row]));
+
+  const evaluated = [...current]
+    .sort((a, b) => b.total - a.total)
+    .slice(0, opts.topRoutes);
+
+  const alerts = [];
+  for (const row of evaluated) {
+    if (row.total <= 0) continue;
+    if (row.errors < opts.minCurrentErrors) continue;
+    const currentErrorRate = row.errors / row.total;
+    if (currentErrorRate < opts.minCurrentErrorRate) continue;
+
+    const base = baselineByRoute.get(row.route);
+    const baselineErrorRate = base && base.total > 0 ? base.errors / base.total : 0;
+    const flooredBaselineRate = Math.max(baselineErrorRate, opts.baselineRateFloor);
+    const rateMultiple = currentErrorRate / flooredBaselineRate;
+    if (rateMultiple < opts.rateMultiple) continue;
+
+    const windowNote = windows
+      ? ` in ${windows.current.from}..${windows.current.to} (baseline ${windows.baseline.from}..${windows.baseline.to})`
+      : '';
+    alerts.push({
+      route: row.route,
+      currentTotal: row.total,
+      currentErrors: row.errors,
+      currentErrorRate,
+      baselineErrorRate,
+      rateMultiple,
+      summary:
+        `${row.route}: ${row.errors}/${row.total} (${(currentErrorRate * 100).toFixed(1)}%) 4xx/5xx` +
+        `${windowNote} — ${rateMultiple.toFixed(0)}x its own baseline of ${(baselineErrorRate * 100).toFixed(2)}%`,
+    });
+  }
+
+  return { alerts, evaluatedRoutes: evaluated.length, windows: windows ?? null };
+}
+
+/** APL for one window's per-route totals and 4xx/5xx counts. */
+export function buildCanaryApl(window) {
+  return [
+    "['wm_api_usage']",
+    `| where _time >= datetime('${window.from}') and _time < datetime('${window.to}')`,
+    '| summarize total = count(), errors = countif(status >= 400) by route',
+  ].join('\n');
+}
+
+/**
+ * Run one window's aggregation against Axiom. `format=legacy` answers with
+ * `{ buckets: { totals: [{ group: { route }, aggregations: [...] }] } }`;
+ * the tabular shapes differ per format, so parse defensively and throw on
+ * anything unrecognizable — a monitor that silently reads zero rows would
+ * report permanent health, which is the #7107 failure mode itself.
+ */
+async function queryWindow(window, { token, fetchImpl = fetch }) {
+  const resp = await fetchImpl(AXIOM_APL_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      apl: buildCanaryApl(window),
+      startTime: window.from,
+      endTime: window.to,
+    }),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!resp.ok) {
+    throw new Error(`Axiom APL query failed: HTTP ${resp.status} ${await resp.text().catch(() => '')}`);
+  }
+  const payload = await resp.json();
+  const totals = payload?.buckets?.totals;
+  if (!Array.isArray(totals)) throw new Error('Axiom APL answer carried no buckets.totals');
+  return totals.map((row) => {
+    const aggs = Array.isArray(row?.aggregations) ? row.aggregations : [];
+    const byOp = new Map(aggs.map((a) => [a?.op, a?.value]));
+    return {
+      route: String(row?.group?.route ?? ''),
+      total: Number(byOp.get('total') ?? 0),
+      errors: Number(byOp.get('errors') ?? 0),
+    };
+  }).filter((row) => row.route !== '');
+}
+
+function isoHoursAgo(hours, now = Date.now()) {
+  return new Date(now - hours * 3_600_000).toISOString();
+}
+
+export async function runDeployErrorCanary({
+  token = process.env.AXIOM_API_TOKEN,
+  currentHours = 2,
+  baselineDays = 7,
+  fetchImpl = fetch,
+  log = console,
+} = {}) {
+  if (!token) {
+    // Config gap, not health: fail loudly so the workflow shows red instead
+    // of a permanently-green canary nobody configured (#7107's own lesson).
+    log.error('::error::deploy-error-canary: AXIOM_API_TOKEN is not set');
+    return { ok: false, reason: 'not-configured' };
+  }
+
+  const now = Date.now();
+  const windows = {
+    current: { from: isoHoursAgo(currentHours, now), to: new Date(now).toISOString() },
+    baseline: {
+      from: isoHoursAgo(currentHours + baselineDays * 24, now),
+      to: isoHoursAgo(currentHours, now),
+    },
+  };
+
+  const [baseline, current] = await Promise.all([
+    queryWindow(windows.baseline, { token, fetchImpl }),
+    queryWindow(windows.current, { token, fetchImpl }),
+  ]);
+
+  const report = evaluateDeployCanary({ baseline, current, windows });
+  log.log(
+    `deploy-error-canary: evaluated ${report.evaluatedRoutes} routes; ` +
+    `current ${windows.current.from}..${windows.current.to}, baseline ${baselineDays}d prior`,
+  );
+  for (const alert of report.alerts) {
+    log.error(`::error::deploy-error-canary: ${alert.summary}`);
+  }
+  if (report.alerts.length === 0) log.log('deploy-error-canary: no step-change routes');
+  return { ok: report.alerts.length === 0, report };
+}
+
+if (isMainModule(import.meta.url)) {
+  runDeployErrorCanary()
+    .then((result) => {
+      if (!result.ok) process.exitCode = 1;
+    })
+    .catch((err) => {
+      console.error(`::error::deploy-error-canary: ${err?.message ?? err}`);
+      process.exitCode = 1;
+    });
+}

--- a/shared/source-attribution-manifest.json
+++ b/shared/source-attribution-manifest.json
@@ -534,6 +534,9 @@
           "path": "api/_usage-telemetry.js"
         },
         {
+          "path": "scripts/deploy-error-canary.mjs"
+        },
+        {
           "path": "scripts/lib/llm-telemetry.cjs"
         },
         {

--- a/tests/deploy-error-canary.test.mjs
+++ b/tests/deploy-error-canary.test.mjs
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+/**
+ * #7107 — the 2026-08-01 validation deploy broke get-aircraft-details-batch
+ * for effectively every dashboard user (~132,500 client-facing 400s over
+ * three days, 17k+ distinct IPs) and nothing alerted, because no monitoring
+ * compares a route's error rate against its own pre-deploy baseline.
+ *
+ * evaluateDeployCanary is the pure detection core: given per-route
+ * {total, errors} aggregates for a baseline window and a current window, it
+ * flags routes whose current error rate is a step change over their own
+ * baseline. The acceptance shape from the issue:
+ *   - replaying Aug 1–3 (a route going from ~0 to >30k 400s/day) alerts,
+ *     attributed to the windows compared;
+ *   - normal daily variance on the same routes does not alert.
+ */
+import {
+  DEFAULT_CANARY_OPTIONS,
+  evaluateDeployCanary,
+  buildCanaryApl,
+} from '../scripts/deploy-error-canary.mjs';
+
+const ROUTE = '/api/military/v1/get-aircraft-details-batch';
+
+function windowRows(rows) {
+  return rows.map(([route, total, errors]) => ({ route, total, errors }));
+}
+
+describe('evaluateDeployCanary — the Aug 1–3 regression shape alerts', () => {
+  it('flags a route going from ~0% to ~100% errors at dashboard volume', () => {
+    // Baseline: seven healthy days, 40k requests, 0.1% 4xx noise.
+    const baseline = windowRows([[ROUTE, 40_000, 40]]);
+    // Current 2h window of Aug 1 traffic: ~2,900 400s (34,840/day pace).
+    const current = windowRows([[ROUTE, 3_000, 2_900]]);
+
+    const report = evaluateDeployCanary({ baseline, current });
+
+    assert.equal(report.alerts.length, 1, 'the regression must alert');
+    const alert = report.alerts[0];
+    assert.equal(alert.route, ROUTE);
+    assert.ok(alert.currentErrorRate > 0.9);
+    assert.ok(
+      alert.rateMultiple >= DEFAULT_CANARY_OPTIONS.rateMultiple,
+      'the alert carries how many times over baseline the route is',
+    );
+  });
+
+  it('flags a route with NO baseline traffic that ships broken (the new-route cell)', () => {
+    const baseline = windowRows([]);
+    const current = windowRows([[ROUTE, 1_000, 990]]);
+
+    const report = evaluateDeployCanary({ baseline, current });
+
+    assert.equal(report.alerts.length, 1, 'a route that never existed before the deploy still alerts');
+  });
+});
+
+describe('evaluateDeployCanary — normal variance stays quiet', () => {
+  it('does not alert on ordinary error-rate wobble at high traffic', () => {
+    const baseline = windowRows([[ROUTE, 40_000, 400]]); // 1%
+    const current = windowRows([[ROUTE, 3_000, 60]]); // 2%
+
+    assert.deepEqual(evaluateDeployCanary({ baseline, current }).alerts, []);
+  });
+
+  it('does not alert below the absolute error floor (tiny routes cannot page)', () => {
+    const baseline = windowRows([['/api/x', 20, 0]]);
+    const current = windowRows([['/api/x', 10, 8]]);
+
+    assert.deepEqual(evaluateDeployCanary({ baseline, current }).alerts, []);
+  });
+
+  it('does not alert on a healthy route that merely got busier', () => {
+    const baseline = windowRows([[ROUTE, 4_000, 4]]);
+    const current = windowRows([[ROUTE, 9_000, 12]]);
+
+    assert.deepEqual(evaluateDeployCanary({ baseline, current }).alerts, []);
+  });
+
+  it('caps evaluation to the top routes by current traffic', () => {
+    const baseline = [];
+    const current = [];
+    for (let i = 0; i < 80; i++) {
+      current.push({ route: `/api/r${i}`, total: 1_000 + i, errors: 990 });
+      baseline.push({ route: `/api/r${i}`, total: 10_000, errors: 10 });
+    }
+
+    const report = evaluateDeployCanary({
+      baseline,
+      current,
+      options: { ...DEFAULT_CANARY_OPTIONS, topRoutes: 50 },
+    });
+
+    assert.equal(report.evaluatedRoutes, 50, 'top-50 by current traffic, per the issue sketch');
+    assert.equal(report.alerts.length, 50);
+  });
+});
+
+describe('report attribution', () => {
+  it('names the windows compared so the alert is attributable to the deploy window', () => {
+    const report = evaluateDeployCanary({
+      baseline: windowRows([[ROUTE, 40_000, 40]]),
+      current: windowRows([[ROUTE, 3_000, 2_900]]),
+      windows: {
+        baseline: { from: '2026-07-25T00:00:00Z', to: '2026-08-01T08:00:00Z' },
+        current: { from: '2026-08-01T08:00:00Z', to: '2026-08-01T10:00:00Z' },
+      },
+    });
+
+    assert.equal(report.windows.current.from, '2026-08-01T08:00:00Z');
+    const line = report.alerts[0].summary;
+    assert.match(line, /get-aircraft-details-batch/);
+    assert.match(line, /2026-08-01T08:00:00Z/, 'the alert line must carry the window it is attributed to');
+  });
+});
+
+describe('buildCanaryApl', () => {
+  it('aggregates total and 4xx/5xx per route over the given window', () => {
+    const apl = buildCanaryApl({ from: '2026-08-01T08:00:00Z', to: '2026-08-01T10:00:00Z' });
+    assert.match(apl, /wm_api_usage/);
+    assert.match(apl, /status >= 400/);
+    assert.match(apl, /by route/);
+  });
+});


### PR DESCRIPTION
Fixes #7107

## What this is

The issue's 'coarse version', implemented exactly: hourly, top-50 routes by traffic, alert on a sustained (2-hour-window) step change of a route's 4xx/5xx rate over that route's **own** baseline, from the `wm_api_usage` data the gateway already ingests.

- `scripts/deploy-error-canary.mjs` — pure detection core (`evaluateDeployCanary`) + an Axiom APL wrapper (`summarize total=count(), errors=countif(status >= 400) by route` over two windows: last 2 h vs the 7 days before). Every alert line names the route, both windows, and the multiple over baseline, so a finding is attributable to the deploys inside the current window.
- `.github/workflows/deploy-error-canary.yml` — hourly cron + dispatch, `::error` annotations + red job on alert (the `analytics-collector-monitor` pattern, deliberately not gated on a green main). Needs the `AXIOM_API_TOKEN` secret; a missing token fails the job rather than reporting permanent green — a silently unconfigured canary is this issue's failure mode itself.

## Detection shape and noise guards

Per-route-relative: a route that is 1% errors every day never alerts at 2%, while a route that was ~0% for a week alerts within one run of going broken. Guards: top-N by current traffic (long-tail probe scans can't page), an absolute current-errors floor (50), a material-rate floor (20%), and a baseline-rate floor (0.5%) so a zero-error week — or a brand-new route — doesn't make a single error an infinite step while a new route shipping 100% broken still alerts.

## Acceptance mapping

- **Replaying the Aug 1–3 shape triggers an alert attributed to the deploy window** — test replays the exact profile (40k baseline requests at 0.1% → 2,900/3,000 400s in the 2 h window) and asserts the alert summary carries the window boundaries; the new-route-ships-broken cell is covered too.
- **Normal daily variance does not alert** — tests: 1%→2% wobble at volume, tiny routes below the absolute floor, and a healthy route that merely got busier all stay quiet; top-50 capping pinned.
- The secondary ask (deploy-time contract check that dominant callers satisfy new validation rules) is not in this PR — it is a CI-shape change worth its own discussion.

## Verification

- Failing-first: the suite fails before the script exists; mutation check: removing the rate-multiple gate turns the quiet-cell tests red.
- 8/8 tests green (`node --test tests/deploy-error-canary.test.mjs`), biome clean.
- I could not run the live Axiom query end-to-end (no telemetry credentials); the APL and the `format=legacy` response parsing follow the documented shape and the parser throws loudly on anything unrecognizable instead of reading zero rows as health. Happy to adjust to the actual response if a maintainer can run one dispatch.