### PR TITLE
perf(markets): defer the per-symbol v7 proxy leg to the exit-rotating batch

### DIFF
--- a/scripts/_yahoo-sector-valuations.cjs
+++ b/scripts/_yahoo-sector-valuations.cjs
@@ -477,6 +477,14 @@ async function collectV7Valuations(
   // keeps the leg: dropping it would remove that client's only proxy path.
   const deferProxyToBatch = typeof client?.fetchV7BatchAcrossExits === 'function'
     || typeof client?.fetchV7BatchDetailed === 'function';
+  const batchBudgetAvailable = () => deadlineAt == null || deadlineAt - now() >= BATCH_MIN_BUDGET_MS;
+  const recordPerSymbolV7Result = (symbol, result) => {
+    diagnostics.push({ symbol, outcomes: result?.diagnostics || [] });
+    if (result?.kind === 'success') {
+      freshVals[symbol] = result.value;
+      if (result.value?.source) valuationSources.add(result.value.source);
+    }
+  };
   for (const s of symbols) {
     let result;
     if (deadlineAt != null && now() >= deadlineAt) {
@@ -486,7 +494,10 @@ async function collectV7Valuations(
         diagnostics: [{ route: 'v7Quote', attempts: 0, responseClass: 'deadline_exceeded', failure: 'valuation_budget_exceeded' }],
       };
     } else if (client?.fetchV7Detailed) {
-      result = await client.fetchV7Detailed(s, { deadlineAt, skipProxy: deferProxyToBatch });
+      result = await client.fetchV7Detailed(s, {
+        deadlineAt,
+        skipProxy: deferProxyToBatch && batchBudgetAvailable(),
+      });
     } else {
       const direct = await fetchYahooV7QuoteDirect(s, { userAgent });
       const routeDiagnostics = [{
@@ -509,11 +520,7 @@ async function collectV7Valuations(
         result = { ...proxied, diagnostics: routeDiagnostics };
       }
     }
-    diagnostics.push({ symbol: s, outcomes: result?.diagnostics || [] });
-    if (result?.kind === 'success') {
-      freshVals[s] = result.value;
-      if (result.value?.source) valuationSources.add(result.value.source);
-    }
+    recordPerSymbolV7Result(s, result);
     const remainingMs = deadlineAt == null ? DEFAULT_REQUEST_SPACING_MS : Math.max(0, deadlineAt - now());
     if (remainingMs > 0) await sleepFn(Math.min(DEFAULT_REQUEST_SPACING_MS, remainingMs));
   }
@@ -537,16 +544,15 @@ async function collectV7Valuations(
   // and the remembered-exit recording live in exactly one place.
   const batchSymbols = symbols.filter((symbol) => !freshVals[symbol]);
   const rotatingBatch = typeof client?.fetchV7BatchAcrossExits === 'function';
-  if (
-    batchSymbols.length > 0
+  const batchShouldRun = batchSymbols.length > 0
     && (rotatingBatch || client?.fetchV7BatchDetailed)
     // Require a real slice of budget, not merely "not yet expired": this route
     // runs BEFORE the quoteSummary tier, so an uncapped slow batch would eat
     // the remainder and starve the alternative source entirely.
-    && (deadlineAt == null || deadlineAt - now() >= BATCH_MIN_BUDGET_MS)
-  ) {
+    && batchBudgetAvailable();
+  let batchError = null;
+  if (batchShouldRun) {
     let batchResult = null;
-    let batchError = null;
     try {
       const batchOptions = {
         deadlineAt: deadlineAt == null ? null : Math.min(deadlineAt, now() + BATCH_BUDGET_MS),
@@ -629,6 +635,41 @@ async function collectV7Valuations(
         };
         if (symbolSource) valuationSources.add(symbolSource);
       }
+    }
+  }
+  const proxyFallbackSymbols = symbols.filter((symbol) => !freshVals[symbol]);
+  if (
+    deferProxyToBatch
+    && proxyFallbackSymbols.length > 0
+    && client?.fetchV7Detailed
+    && (!batchShouldRun || batchError)
+  ) {
+    // The per-symbol loop skipped proxy expecting the batch tier, but the
+    // budget floor blocked it (or the batch threw). Fall back to the configured
+    // exit so symbols are not left with zero proxy recovery (#6279 review).
+    for (const s of proxyFallbackSymbols) {
+      if (deadlineAt != null && now() >= deadlineAt) {
+        const entry = diagnostics.find((item) => item.symbol === s);
+        const deadlineDiagnostic = {
+          route: 'v7Quote',
+          attempts: 0,
+          responseClass: 'deadline_exceeded',
+          failure: 'valuation_budget_exceeded',
+        };
+        if (entry) entry.outcomes.push(deadlineDiagnostic);
+        else diagnostics.push({ symbol: s, outcomes: [deadlineDiagnostic] });
+        continue;
+      }
+      const result = await client.fetchV7Detailed(s, { deadlineAt, skipProxy: false });
+      const entry = diagnostics.find((item) => item.symbol === s);
+      if (entry) entry.outcomes.push(...(result?.diagnostics || []));
+      else diagnostics.push({ symbol: s, outcomes: result?.diagnostics || [] });
+      if (result?.kind === 'success') {
+        freshVals[s] = result.value;
+        if (result.value?.source) valuationSources.add(result.value.source);
+      }
+      const remainingMs = deadlineAt == null ? DEFAULT_REQUEST_SPACING_MS : Math.max(0, deadlineAt - now());
+      if (remainingMs > 0) await sleepFn(Math.min(DEFAULT_REQUEST_SPACING_MS, remainingMs));
     }
   }
   return {

--- a/scripts/_yahoo-sector-valuations.cjs
+++ b/scripts/_yahoo-sector-valuations.cjs
@@ -46,8 +46,9 @@ const METRICS_REFRESH_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 // is metered and whose exhaustion has taken the seeder fleet down before.
 const DEFAULT_MAX_EXIT_ATTEMPTS = 4;
 // Where the BATCH TIER should start next: either the exit with the best full-set
-// coverage or the first exit after a fully exhausted search window. This does
-// not change the per-symbol tier above it, which still uses the configured exit.
+// coverage or the first exit after a fully exhausted search window. The batch
+// is the ONLY proxy path when it is available — the per-symbol tier defers its
+// proxy leg to it (#6279).
 const PREFERRED_EXIT_KEY = 'market:sectors:valuations:proxy-exit';
 const PREFERRED_EXIT_TTL = 24 * 3600;
 // Redis carries the preference across processes and restarts. This process-local
@@ -464,6 +465,18 @@ async function collectV7Valuations(
   const diagnostics = [];
   const valuationSources = new Set();
   let winningExitAttempt = null;
+  // With a batch fallback available, the per-symbol tier skips its proxy leg
+  // (#6279): the truncation it would be retrying is a property of the exit
+  // IP, and the per-symbol leg only ever reaches the CONFIGURED exit — so on
+  // a cycle whose pinned exit truncates, those requests are metered Decodo
+  // spend and BATCH_BUDGET_MS the rotating batch no longer has, for symbols
+  // they cannot recover. Uncovered symbols fall through to the batch below,
+  // the single proxy path with one exit policy — which is also the path that
+  // records and renews the remembered exit, so the recorder runs strictly
+  // more often than before. A narrower injected client with no batch method
+  // keeps the leg: dropping it would remove that client's only proxy path.
+  const deferProxyToBatch = typeof client?.fetchV7BatchAcrossExits === 'function'
+    || typeof client?.fetchV7BatchDetailed === 'function';
   for (const s of symbols) {
     let result;
     if (deadlineAt != null && now() >= deadlineAt) {
@@ -473,7 +486,7 @@ async function collectV7Valuations(
         diagnostics: [{ route: 'v7Quote', attempts: 0, responseClass: 'deadline_exceeded', failure: 'valuation_budget_exceeded' }],
       };
     } else if (client?.fetchV7Detailed) {
-      result = await client.fetchV7Detailed(s, { deadlineAt });
+      result = await client.fetchV7Detailed(s, { deadlineAt, skipProxy: deferProxyToBatch });
     } else {
       const direct = await fetchYahooV7QuoteDirect(s, { userAgent });
       const routeDiagnostics = [{
@@ -519,14 +532,9 @@ async function collectV7Valuations(
   // degrades to a single attempt on its own when no rotator is wired. It exists
   // for callers that inject a narrower client object (today: test doubles), so
   // that supplying only the older method still works.
-  // KNOWN GAP: the per-symbol loop above still reaches the proxy on the
-  // CONFIGURED exit, not the remembered one, so on a cycle whose pinned exit is
-  // truncating it spends a handful of proxy requests that cannot recover those
-  // symbols before this batch runs. Routing that leg through the remembered exit
-  // (or dropping it and letting everything uncovered fall to this batch) would
-  // remove the waste, but it would also stop the batch running on healthy
-  // cycles -- and the batch is what refreshes the remembered exit. That is a
-  // design change with its own failure modes, deliberately not bundled here.
+  // The per-symbol loop above deliberately never reaches the proxy when this
+  // batch exists (#6279) — this is the single proxy path, so the exit policy
+  // and the remembered-exit recording live in exactly one place.
   const batchSymbols = symbols.filter((symbol) => !freshVals[symbol]);
   const rotatingBatch = typeof client?.fetchV7BatchAcrossExits === 'function';
   if (
@@ -1201,6 +1209,11 @@ class YahooQuoteSummaryClient {
     // repeating it would re-read the same Railway IP that already came back
     // truncated, for no new information and one wasted request per exit.
     skipDirect = false,
+    // When set, stop after the direct leg: the caller has a batch fallback
+    // whose exit rotation is the only proxy path that can recover an
+    // exit-truncated response, so a proxy request here on the configured exit
+    // would be spent on symbols it cannot recover (#6279).
+    skipProxy = false,
   }) {
     const diagnostics = [];
     const direct = skipDirect
@@ -1225,6 +1238,14 @@ class YahooQuoteSummaryClient {
       }
     }
 
+    if (skipProxy) {
+      return {
+        ...attributedDirect,
+        diagnostics,
+        proxyAttempted: false,
+        proxyKind: 'skipped_for_batch',
+      };
+    }
     const proxy = proxyOverride == null ? this.resolveProxyString() : proxyOverride;
     if (!proxy) {
       return {
@@ -1317,7 +1338,7 @@ class YahooQuoteSummaryClient {
     return result.kind === 'success' ? result.value : null;
   }
 
-  async fetchV7Detailed(symbol, { deadlineAt = null } = {}) {
+  async fetchV7Detailed(symbol, { deadlineAt = null, skipProxy = false } = {}) {
     return this._fetchRoute('v7Quote', symbol, {
       buildUrl: (ticker, crumb) => {
         const query = new URLSearchParams({ symbols: ticker, crumb });
@@ -1326,6 +1347,7 @@ class YahooQuoteSummaryClient {
       parseResponse: parseV7Quote,
       source: 'yahoo_v7_quote_authenticated',
       deadlineAt,
+      skipProxy,
     });
   }
 
@@ -1760,9 +1782,8 @@ async function collectSectorValuations({
   // The BATCH TIER's next starting exit may be either the best full-set coverage
   // winner or the continuation after an exhausted window. A coverage winner
   // collapses the ~3.3-exit blind search to 1; a continuation ensures the next
-  // cycle explores new exits. This does not change the per-symbol tier below,
-  // which still uses the configured exit -- see the follow-up noted on that
-  // loop.
+  // cycle explores new exits. The per-symbol tier below defers its proxy leg
+  // to this batch whenever the client carries one (#6279).
   //
   // Only read it when something can act on it: a client without exit rotation
   // would spend a Redis round-trip per cycle on a value it cannot use.

--- a/tests/sector-valuations.test.mjs
+++ b/tests/sector-valuations.test.mjs
@@ -1529,12 +1529,9 @@ describe('proxy exit preference', () => {
     );
   });
 
-  it('deliberately leaves the per-symbol tier on the configured exit', async () => {
-    // Characterizes the KNOWN GAP documented in collectV7Valuations: the
-    // per-symbol tier is NOT given the remembered exit, because routing it there
-    // would stop the batch running on healthy cycles and the batch is what keeps
-    // the preference fresh. Pinning it means a future change in either direction
-    // is a visible decision rather than an accident. See issue #6279.
+  it('forwards skipProxy to the per-symbol tier when a batch fallback exists (#6279)', async () => {
+    // Proxy deferral is now the contract: the per-symbol tier must not spend
+    // configured-exit proxy when the batch can recover exit-truncated symbols.
     const perSymbolOptions = [];
     const client = rotatingClient({ goodExit: 7, symbols: ['XLK', 'SMH'] });
     const wrapped = {
@@ -1558,10 +1555,11 @@ describe('proxy exit preference', () => {
 
     assert.ok(perSymbolOptions.length > 0, 'the per-symbol tier ran');
     for (const options of perSymbolOptions) {
+      assert.equal(options?.skipProxy, true, 'batch-capable clients defer the per-symbol proxy leg');
       assert.equal(
         options?.startExitAttempt,
         undefined,
-        'the per-symbol tier receives no exit override today',
+        'the per-symbol tier still receives no exit override',
       );
     }
     assert.deepEqual(client.startsSeen, [7], 'only the batch consumes the remembered exit');

--- a/tests/yahoo-sector-valuations.test.mjs
+++ b/tests/yahoo-sector-valuations.test.mjs
@@ -1756,5 +1756,92 @@ describe('per-symbol v7 tier defers its proxy leg to the rotating batch (#6279)'
       'skipProxy must not touch the proxy',
     );
   });
+
+  it('falls back to per-symbol proxy when the batch budget gate blocks after deferral', async () => {
+    const start = Date.now();
+    let clock = start;
+    const deadlineAt = start + 2_500;
+    const harness = exitHarness({ badExits: [], truncated: ['XLK'], directTruncated: true });
+    const client = new YahooQuoteSummaryClient({
+      directRequest: async (url, options) => {
+        const result = await harness.directRequest(url, options);
+        clock = deadlineAt - 1_900;
+        return result;
+      },
+      proxyRequest: harness.proxyRequest,
+      resolveProxyString: () => 'exit-0',
+      resolveProxyStringForAttempt: (attempt) => `exit-${attempt}`,
+      sleepFn: async () => {},
+      logger: { warn: () => {} },
+    });
+
+    const result = await collectV7Valuations(['XLK'], {
+      client,
+      sleepFn: async () => {},
+      deadlineAt,
+      now: () => clock,
+    });
+
+    assert.ok(
+      singleSymbolProxyQuotes(harness).length >= 1,
+      'when batch cannot run, configured-exit proxy must recover direct failures',
+    );
+    assert.equal(result.valuations.XLK?.trailingPE, 31.2);
+  });
+
+  it('defers per-symbol proxy for fetchV7BatchDetailed-only injected clients', async () => {
+    const harness = exitHarness({ badExits: [], truncated: TRUNCATED, directTruncated: true });
+    const client = new YahooQuoteSummaryClient({
+      directRequest: harness.directRequest,
+      proxyRequest: harness.proxyRequest,
+      resolveProxyString: () => 'exit-0',
+      sleepFn: async () => {},
+      logger: { warn: () => {} },
+    });
+    let batchDetailedCalls = 0;
+    const narrowClient = {
+      fetchV7Detailed: (symbol, opts) => client.fetchV7Detailed(symbol, opts),
+      fetchV7BatchDetailed: async (symbols, opts) => {
+        batchDetailedCalls += 1;
+        return client.fetchV7BatchDetailed(symbols, opts);
+      },
+    };
+
+    const result = await collectV7Valuations(SECTORS, { client: narrowClient, sleepFn: async () => {} });
+
+    assert.deepEqual(
+      singleSymbolProxyQuotes(harness),
+      [],
+      'BatchDetailed-only clients still defer per-symbol proxy to the batch tier',
+    );
+    assert.ok(batchDetailedCalls >= 1, 'the batch fallback must run for uncovered symbols');
+    assert.deepEqual(Object.keys(result.valuations).sort(), ['XLF', 'XLK', 'XLV']);
+  });
+
+  it('falls back to per-symbol proxy when the rotating batch throws', async () => {
+    const harness = exitHarness({ badExits: [], truncated: ['XLK'], directTruncated: true });
+    const client = new YahooQuoteSummaryClient({
+      directRequest: harness.directRequest,
+      proxyRequest: harness.proxyRequest,
+      resolveProxyString: () => 'exit-0',
+      resolveProxyStringForAttempt: (attempt) => `exit-${attempt}`,
+      sleepFn: async () => {},
+      logger: { warn: () => {} },
+    });
+    const throwingClient = {
+      fetchV7Detailed: (symbol, opts) => client.fetchV7Detailed(symbol, opts),
+      fetchV7BatchAcrossExits: async () => {
+        throw new Error('batch boom');
+      },
+    };
+
+    const result = await collectV7Valuations(['XLK'], { client: throwingClient, sleepFn: async () => {} });
+
+    assert.ok(
+      singleSymbolProxyQuotes(harness).length >= 1,
+      'a thrown batch must not leave direct failures with zero proxy recovery',
+    );
+    assert.equal(result.valuations.XLK?.trailingPE, 31.2);
+  });
 });
 

--- a/tests/yahoo-sector-valuations.test.mjs
+++ b/tests/yahoo-sector-valuations.test.mjs
@@ -5,6 +5,7 @@ import { EventEmitter } from 'node:events';
 import {
   YahooQuoteSummaryClient,
   buildCurlConfig,
+  collectV7Valuations,
   buildSectorSeedMeta,
   buildSectorValuationCoverage,
   buildSectorValuationPublication,
@@ -1664,3 +1665,96 @@ describe('YahooQuoteSummaryClient exit rotation', () => {
     assert.equal(result.stopReason, 'single_exit');
   });
 });
+
+// #6279 -- the per-symbol tier's proxy leg always used the CONFIGURED exit,
+// never the remembered one. Yahoo's fundamentals cache is per exit IP and ~70%
+// of exits truncate XLK/XLV/XLY/SMH, so on a cycle whose pinned exit is a
+// truncating one those per-symbol proxy requests were spent on symbols they
+// could not recover -- metered Decodo bandwidth plus BATCH_BUDGET_MS the
+// rotating batch then no longer had. The per-symbol tier now skips its proxy
+// leg whenever the client has a batch fallback, making the rotating batch the
+// single proxy path (one exit policy) -- and since the batch is also what
+// records/renews the remembered exit, the recorder now runs strictly MORE
+// often, not less.
+describe('per-symbol v7 tier defers its proxy leg to the rotating batch (#6279)', () => {
+  const SECTORS = ['XLK', 'XLF', 'XLV'];
+  const TRUNCATED = ['XLK', 'XLV'];
+
+  const singleSymbolProxyQuotes = (harness) => harness.quoteRequests()
+    .filter((r) => r.transport === 'proxy' && symbolsFromQuoteUrl(r.url).length === 1);
+
+  it('spends zero per-symbol proxy requests; the rotating batch recovers the truncated symbols', async () => {
+    // Direct truncates XLK/XLV; the configured exit-0 (and exit-1) truncate
+    // them too -- the exact cycle the issue measures the waste on.
+    const harness = exitHarness({ badExits: ['exit-0', 'exit-1'], truncated: TRUNCATED });
+    const client = new YahooQuoteSummaryClient({
+      directRequest: harness.directRequest,
+      proxyRequest: harness.proxyRequest,
+      resolveProxyString: () => 'exit-0',
+      resolveProxyStringForAttempt: (attempt) => `exit-${attempt}`,
+      sleepFn: async () => {},
+      logger: { warn: () => {} },
+    });
+
+    const result = await collectV7Valuations(SECTORS, { client, sleepFn: async () => {} });
+
+    assert.deepEqual(
+      singleSymbolProxyQuotes(harness), [],
+      'the per-symbol tier must not spend proxy requests the batch exists to make unnecessary',
+    );
+    assert.deepEqual(
+      Object.keys(result.valuations).sort(), ['XLF', 'XLK', 'XLV'],
+      'every truncated symbol is recovered by the rotating batch',
+    );
+    assert.equal(
+      result.winningExitAttempt, 2,
+      'the single proxy path still records the exit preference',
+    );
+  });
+
+  it('keeps the per-symbol proxy leg for an injected client with no batch fallback', async () => {
+    // A narrower client (test doubles, older callers) has no batch to defer
+    // to -- dropping its proxy leg would remove its ONLY proxy path.
+    const harness = exitHarness({ badExits: [], truncated: TRUNCATED });
+    const client = new YahooQuoteSummaryClient({
+      directRequest: harness.directRequest,
+      proxyRequest: harness.proxyRequest,
+      resolveProxyString: () => 'exit-0',
+      sleepFn: async () => {},
+      logger: { warn: () => {} },
+    });
+    const narrowClient = {
+      fetchV7Detailed: (symbol, opts) => client.fetchV7Detailed(symbol, opts),
+    };
+
+    const result = await collectV7Valuations(SECTORS, { client: narrowClient, sleepFn: async () => {} });
+
+    assert.ok(
+      singleSymbolProxyQuotes(harness).length >= 1,
+      'without a batch fallback the per-symbol proxy leg must survive',
+    );
+    assert.deepEqual(Object.keys(result.valuations).sort(), ['XLF', 'XLK', 'XLV']);
+  });
+
+  it('fetchV7Detailed({ skipProxy: true }) fails over to nothing and says so in diagnostics', async () => {
+    const harness = exitHarness({ badExits: [], truncated: TRUNCATED });
+    const client = new YahooQuoteSummaryClient({
+      directRequest: harness.directRequest,
+      proxyRequest: harness.proxyRequest,
+      resolveProxyString: () => 'exit-0',
+      sleepFn: async () => {},
+      logger: { warn: () => {} },
+    });
+
+    const result = await client.fetchV7Detailed('XLK', { skipProxy: true });
+
+    assert.notEqual(result.kind, 'success');
+    assert.equal(result.proxyAttempted, false);
+    assert.equal(result.proxyKind, 'skipped_for_batch');
+    assert.equal(
+      harness.quoteRequests().filter((r) => r.transport === 'proxy').length, 0,
+      'skipProxy must not touch the proxy',
+    );
+  });
+});
+


### PR DESCRIPTION
Fixes #6279

## What changed

The issue's preferred variant ('Prefer dropping the per-symbol proxy leg over threading an override into it'): `collectV7Valuations` now passes `skipProxy: true` into `fetchV7Detailed` whenever the client carries a batch fallback (`fetchV7BatchAcrossExits` or `fetchV7BatchDetailed`). `_fetchRoute` stops after the direct leg and reports `proxyKind: 'skipped_for_batch'` in diagnostics, and every uncovered symbol falls through to the exit-rotating batch — the single proxy path with one exit policy.

## The 'why it was not bundled' concern

The issue flags that removing per-symbol proxy coverage could stop the batch running on healthy cycles, starving the remembered-exit refresh. In this variant the concern inverts: the batch (the only recorder, with its existing half-life TTL renewal in `persistPreferredExit`) now runs strictly **more** often — every direct-leg miss reaches it, not just the ones the configured exit also failed to recover. Cycles where the direct leg covers everything don't renew the preference, exactly as today.

A narrower injected client with no batch method (the older-caller/test-double case the code already documents) keeps the per-symbol proxy leg, since dropping it would remove that client's only proxy path — pinned by a test.

## Costs removed (the issue's two measured costs)

- **Requests**: zero per-symbol proxy quote requests per cycle against metered Decodo bandwidth (asserted directly: no single-symbol proxy URLs reach the transport).
- **Budget**: the ~7s/exit the per-symbol leg burned on a truncating pinned exit is returned to the rotating batch's `BATCH_BUDGET_MS`.

## Tests

Three new tests in `tests/yahoo-sector-valuations.test.mjs`, driving the real `YahooQuoteSummaryClient` through the existing `exitHarness` (direct truncates XLK/XLV; configured exit-0 and exit-1 truncate too):
1. Zero single-symbol proxy requests; the rotating batch recovers all symbols; `winningExitAttempt` still recorded (failing pre-fix).
2. A client with no batch fallback keeps its per-symbol proxy leg (passes pre- and post-fix — pins the safety rail).
3. `fetchV7Detailed({ skipProxy: true })` never touches the proxy and reports `skipped_for_batch` (failing pre-fix).

- Mutation check: dropping the `skipProxy` pass-through turns test 1 red.
- `yahoo-sector-valuations` + `sector-valuations` + `market-quote-provider-seeder`: 143/143. Biome: one pre-existing `useConst` warning in an untouched test, left alone.
- Stale comments describing the old two-path design (the KNOWN GAP block and both 'does not change the per-symbol tier' notes) updated to the new contract.