### PR TITLE
fix(tests): move the x-intel data-loader transform out of its testTimeout

### DIFF
--- a/tests/dom/x-intel-data-loader.test.mts
+++ b/tests/dom/x-intel-data-loader.test.mts
@@ -22,6 +22,19 @@ vi.mock('@/services/panel-gating', async (importOriginal) => ({
   hasPremiumAccess: () => true,
 }));
 
+// #6677: the first test in this file used to pay for the data-loader module
+// graph's transform (data-loader.ts plus the i18n locale glob and generated
+// clients) inside its testTimeout, because every case reaches the graph through
+// an `await import()` in the test body and the first one to run bears the cost.
+// Measured on a quiet machine that first case took 1637ms against the other
+// three at 1-3ms; under load it scales past the budget and fails while the rest
+// stay instant. Importing the graph at module scope moves the transform into
+// the file's import phase, which vitest does not bill to any testTimeout, and
+// leaves the in-test imports as cache hits. Same treatment as
+// firms-timeout-lock-recovery, global-procurement-data-loader and
+// data-loader-digest-coverage.
+await import('@/app/data-loader');
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((onResolve) => { resolve = onResolve; });


### PR DESCRIPTION
Refs #6677

## The defect

Every case in `tests/dom/x-intel-data-loader.test.mts` reaches `DataLoaderManager` through an `await import('@/app/data-loader')` **in the test body**, so whichever case runs first pays for that module graph's transform inside its own `testTimeout`.

Measured alone on a quiet machine:

| test | duration |
|---|---|
| `hydrates immediately and ignores a late live result after teardown` | **1637ms** |
| `keeps hydrated X panel data when the live fetch fails` | 3ms |
| `does not render expired hydrated post bodies after a live failure` | 1ms |
| `keeps a good live render when a later fetch fails` | 1ms |

The cost is the import, not the assertions — the other three hit the module cache. Under load the first case scales past the 15000ms budget and fails while its siblings stay instant, producing a false red that names a file unrelated to whatever is being pushed.

**This is not hypothetical.** It fired during an unrelated billing change with this machine at load average 36, blocked the pre-push hook, and passed 4/4 in isolation on the same tree. Its late promise resolution then leaked into the next test, so one timeout reported as two failures.

## The fix

A module-scope `await import('@/app/data-loader')`, which moves the transform into the file's import phase — vitest does not bill that to any `testTimeout` — and leaves the in-test imports as cache hits.

This is not a new idea: `firms-timeout-lock-recovery`, `global-procurement-data-loader` and `data-loader-digest-coverage` already carry it, and #6677 applied it to `story-data-cached-cii` and `fx-panel-data`. **This was the one data-loader test that missed the treatment.**

Before -> after, same machine:

| | before | after |
|---|---|---|
| first test | 1637ms | **6ms** |
| `tests` total | 1.64s | **12ms** |
| `import` phase | 48ms | 2.16s |

The timed portion drops ~270x. No behaviour change — the four assertions and their mocks are untouched.

## Sweep for the same class

I profiled the whole DOM suite rather than assume this was the only one. Every test over 300ms:

| test | duration | same bug? |
|---|---|---|
| `keyword-spike-evidence > counts one publisher once across its own feed labels` | 2141ms | **No — see below** |
| `notifications-settings-web-push > keeps web_push in the saved alert rule…` | 1080ms | No — 11th test in its file, real async work |
| `ml-worker-recovery > retries restoration and fails closed…` | 1016ms | No — deliberate retry timing |
| `sidecar-readiness > returns false when the sidecar never answers…` | 405ms | No — the timeout *is* the assertion |
| `late-mounted-panel-hydration` (x2) | 383/358ms | No |

x-intel was the only file with the transform-billed-to-first-test shape. The others put their cost in a mid-file test with static top-level imports, so their transform is already in the import phase.

## Follow-up worth filing: `keyword-spike-evidence` is now the highest-risk file

At **2141ms it is slower than x-intel ever was**, so it needs *less* load to blow the same budget. Root cause is different and I deliberately did not fix it here:

```ts
async function drainSpikeFor(term: RegExp): Promise<CorrelationSignal> {
  for (let attempt = 0; attempt < 80; attempt += 1) {
    ...
    await new Promise(resolve => setTimeout(resolve, 25));   // 80 x 25ms = 2000ms
  }
  throw new Error(...);
}
```

The positive uses return as soon as the signal appears. The one negative use — `await expect(drainSpikeFor(/kelmarq/i)).rejects.toThrow()` — can only conclude "no signal was emitted" by **exhausting all 80 attempts**, so it is guaranteed-2000ms by construction.

**Naively shortening that timeout would be worse than leaving it.** A negative assertion that waits a fixed period passes for the wrong reason under load: "the signal had not been emitted yet" is indistinguishable from "the signal was correctly suppressed." The sound fix is a positive control — ingest a second term that *should* spike, wait for that (fast), and only then assert the first term produced nothing. Once the control has been emitted the pipeline is known to have processed the batch, which makes the absence meaningful with no fixed wait at all.

That is a real test redesign needing knowledge of the trending pipeline's batching, so it belongs in its own change rather than riding along here.

Verified: 541 DOM tests across 70 files, biome clean.

https://claude.ai/code/session_01LuyKr35bEMve1PuTRy7sga
