### PR TITLE
fix(tests): prove the keyword-spike publisher gate with a control, not a timeout

### DIFF
--- a/tests/dom/keyword-spike-evidence.test.mts
+++ b/tests/dom/keyword-spike-evidence.test.mts
@@ -32,7 +32,7 @@ type SpikeData = CorrelationSignal['data'];
  * repeatedly and keep everything seen — a bare `drainTrendingSignals()` splices
  * the queue, so a non-matching signal drained on an early pass would be lost.
  */
-async function drainSpikeFor(term: RegExp): Promise<CorrelationSignal> {
+async function drainSpikesUntil(term: RegExp): Promise<CorrelationSignal[]> {
   const seen: CorrelationSignal[] = [];
   for (let attempt = 0; attempt < 80; attempt += 1) {
     seen.push(...drainTrendingSignals());
@@ -41,12 +41,28 @@ async function drainSpikeFor(term: RegExp): Promise<CorrelationSignal> {
         signal.type === 'keyword_spike' &&
         term.test(String((signal.data as SpikeData).term ?? '')),
     );
-    if (match) return match;
+    if (match) return seen;
     await new Promise(resolve => setTimeout(resolve, 25));
   }
   throw new Error(
     `[keyword-spike] no keyword_spike matching ${term} was emitted; saw ${JSON.stringify(seen.map(s => (s.data as SpikeData).term))}`,
   );
+}
+
+async function drainSpikeFor(term: RegExp): Promise<CorrelationSignal> {
+  const seen = await drainSpikesUntil(term);
+  return seen.find(
+    signal =>
+      signal.type === 'keyword_spike' &&
+      term.test(String((signal.data as SpikeData).term ?? '')),
+  )!;
+}
+
+function spikeTermsIn(signals: CorrelationSignal[], term: RegExp): string[] {
+  return signals
+    .filter(signal => signal.type === 'keyword_spike')
+    .map(signal => String((signal.data as SpikeData).term ?? ''))
+    .filter(value => term.test(value));
 }
 
 function dataOf(signal: CorrelationSignal): SpikeData {
@@ -419,17 +435,38 @@ describe('keyword_spike payload excludes unusable source names from the count', 
       autoSummarize: false,
     });
     const pubDate = new Date();
+    // Kelmarq arrives on five Reuters DESKS — one publisher wearing five feed
+    // labels — so the gate must reject it. Tessaline is the positive control in
+    // the SAME batch: same shape, same count, but three genuinely distinct
+    // publishers, so it must spike.
+    //
+    // The control is what makes Kelmarq's absence provable. Both terms are
+    // decided by the one synchronous checkForSpikes() pass inside
+    // ingestHeadlines, so the moment the control's signal lands, that pass has
+    // demonstrably run and Kelmarq's silence is a verdict rather than a race.
+    //
+    // Waiting a fixed period instead — which is what this test used to do, by
+    // letting an 80 x 25ms poll run to exhaustion — cannot distinguish "the
+    // gate rejected it" from "the pipeline had not got to it yet", so it would
+    // stay green if ingest broke entirely. It also cost a guaranteed 2000ms
+    // against a 15000ms budget, making it the slowest test in the DOM suite and
+    // the next one to fail under load (#6677).
     ingestHeadlines([
       { source: 'Reuters World', title: 'Ports brace for Kelmarq tariff review', link: 'https://example.com/k/1' },
       { source: 'Reuters US', title: 'Growers protest Kelmarq tariff schedule', link: 'https://example.com/k/2' },
       { source: 'Reuters Business', title: 'Retailers model Kelmarq tariff costs', link: 'https://example.com/k/3' },
       { source: 'Reuters Asia', title: 'Analysts weigh Kelmarq tariff fallout', link: 'https://example.com/k/4' },
       { source: 'Reuters Energy', title: 'Traders watch Kelmarq tariff deadline', link: 'https://example.com/k/5' },
+      { source: 'Reuters', title: 'Ports brace for Tessaline levy review', link: 'https://example.com/t/1' },
+      { source: 'AP', title: 'Growers protest Tessaline levy schedule', link: 'https://example.com/t/2' },
+      { source: 'BBC', title: 'Retailers model Tessaline levy costs', link: 'https://example.com/t/3' },
+      { source: 'AP', title: 'Analysts weigh Tessaline levy fallout', link: 'https://example.com/t/4' },
+      { source: 'BBC', title: 'Traders watch Tessaline levy deadline', link: 'https://example.com/t/5' },
     ].map(item => ({ ...item, pubDate })));
 
-    // Five Reuters desks are one publisher, so the two-publisher gate rejects
-    // the spike outright — no signal is emitted at all.
-    await expect(drainSpikeFor(/kelmarq/i)).rejects.toThrow();
+    const seen = await drainSpikesUntil(/tessaline/i);
+
+    expect(spikeTermsIn(seen, /kelmarq/i)).toEqual([]);
   });
 
   it('still counts genuinely independent publishers, and names them once each', async () => {


### PR DESCRIPTION
Refs #6677, #6428. Follow-up to #7350, which fixed the *other* slow DOM test; this was the one the sweep there identified as next to fail.

## Two defects, one cause

`counts one publisher once across its own feed labels` asserts that a single-publisher term emits **no** spike, and implemented that as:

```ts
await expect(drainSpikeFor(/kelmarq/i)).rejects.toThrow();
```

`drainSpikeFor` polls 80 times at 25ms. The only way it can conclude "no signal" is to **exhaust all 80 attempts**, so the test was guaranteed to burn 2000ms.

**The timing was the visible half.** The real defect is that a fixed-duration wait cannot distinguish:

- "the two-publisher gate rejected it" — what the test means to prove; from
- "the pipeline hadn't reached it yet" — which would also produce no signal.

So it would have stayed green **if ingest broke entirely**. An absence assertion with no positive control.

## Why I didn't just shorten the timeout

That was the obvious cheap fix and it makes things worse. It keeps the vacuous-pass hole and makes it *more* likely to fire: under load, "not emitted yet" starts reading as "correctly suppressed." A slow test that can't fail becomes a fast test that can't fail.

## The fix: a positive control in the same batch

Kelmarq still arrives on five Reuters desks — one publisher wearing five feed labels. **Tessaline** now rides in the *same* ingest batch: same count, same shape, but three genuinely distinct publishers, so it **must** spike.

Both terms are decided by the one synchronous `checkForSpikes()` pass inside `ingestHeadlines` — the gate at `trending-keywords.ts:410` compares distinct publisher families and `continue`s, so a rejected term never reaches `handleSpike` at all. The moment the control's signal lands, that pass has demonstrably run, and Kelmarq's silence is a **verdict rather than a race**. No fixed wait remains.

If the control ever fails to spike, `drainSpikesUntil` throws with the terms it saw — a loud failure, not a silent pass.

`drainSpikeFor` keeps its exact contract for the 27 positive cases; it's now a thin wrapper over `drainSpikesUntil`, which returns every signal drained on the way so an absence can be asserted against the same witnessed batch.

## Proven to still catch what it guards

An absence assertion is worth nothing unless it fails when the rule is removed, so I verified by mutation rather than assumption — two of them, since a single control can leave a gap:

| mutation | result |
|---|---|
| publisher-family counting replaced with label-keyed counting (**the actual #6428 regression this test exists for**) | ✗ `expected [ 'kelmarq' ] to deeply equal []` — 34ms |
| `MIN_SPIKE_SOURCE_COUNT` 2 → 1 (**gate removed entirely**) | ✗ `expected [ 'kelmarq' ] to deeply equal []` — 32ms |

Both mutations reverted; the diff is the test file only. Note the failures now arrive in ~30ms and name the problem, instead of surfacing as a 2s timeout.

## Cost

**2110ms → 27ms** (78x). It leaves the >300ms tier of the DOM suite entirely.

After this and #7350, the slowest remaining DOM tests are `notifications-settings-web-push` (~1.1s) and `ml-worker-recovery` (~1.0s), both doing genuine async work rather than paying transform cost or waiting out a timeout — comfortably inside the 15000ms budget.

Verified: 541 DOM tests across 70 files, `tsc`, biome clean.

https://claude.ai/code/session_01LuyKr35bEMve1PuTRy7sga
