### PR TITLE
perf(passkeys): keep the offer out of the first-paint bundle (fixes bundle:check on main)

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -65,7 +65,7 @@ import {
   markProActivationPending,
   ProActivationController,
 } from '@/app/pro-activation-controller';
-import { PasskeyOfferController } from '@/app/passkey-offer-controller';
+import { PasskeyOfferBoot } from '@/app/passkey-offer-boot';
 import { showCheckoutFailureBanner } from '@/components/checkout-failure-banner';
 import { PanelTabBar, tabCapGateCopy } from '@/components/PanelTabBar';
 import {
@@ -432,7 +432,7 @@ export class PanelLayoutManager implements AppModule {
   private scheduledLoadAllIdle: number | null = null;
   private responsiveZoneListener: ResponsiveZoneListener | null = null;
   private readonly proActivationController: ProActivationController;
-  private readonly passkeyOfferController: PasskeyOfferController;
+  private readonly passkeyOfferController: PasskeyOfferBoot;
 
   constructor(ctx: AppContext, callbacks: PanelLayoutManagerCallbacks) {
     this.ctx = ctx;
@@ -463,7 +463,9 @@ export class PanelLayoutManager implements AppModule {
       openAiAnalyst: () => this.revealAnalystPanel(),
       openSearch: callbacks.openSearch,
     });
-    this.passkeyOfferController = new PasskeyOfferController(ctx);
+    // Boot shim only — the controller, prompt, and passkey services load on
+    // demand, keeping ~12 KB out of the first-paint chunk (see #7353 follow-up).
+    this.passkeyOfferController = new PasskeyOfferBoot(ctx);
     if (returnedFromCheckout) {
       // Funnel (#4931): the purchase-complete signal on the client side.
       // Queued by the analytics facade until Umami loads after first paint.

--- a/src/app/passkey-offer-boot.ts
+++ b/src/app/passkey-offer-boot.ts
@@ -1,0 +1,85 @@
+import type { AppContext, AppModule } from '@/app/app-context';
+import { subscribeAuthState } from '@/services/auth-state';
+import { getClerk } from '@/services/clerk';
+
+/**
+ * Eager shim that keeps the passkey offer OUT of the first-paint bundle.
+ *
+ * The offer cannot fire until someone signs in, and the overwhelming majority
+ * of page loads never do — yet a static import pulled the controller, the
+ * prompt component, and the passkey services into the `main` chunk, costing
+ * ~12 KB on every first paint. This module is the small part that must be
+ * eager; everything else loads on demand.
+ *
+ * Two things have to stay eager for the feature to remain correct:
+ *
+ *   1. **The arming observation.** The detector may only arm on an
+ *      authoritative signed-out state (Clerk loaded, no session). If we waited
+ *      for an idle callback to subscribe, a user who signs in quickly would be
+ *      seen as already-signed-in with no prior signed-out observation, and
+ *      would never be offered. Subscribing here costs one listener.
+ *   2. **Nothing else.** The moment a signed-in transition arrives on an armed
+ *      shim, the real controller is imported and takes over permanently.
+ *
+ * The handoff replays the transition: `subscribeAuthState` fires the callback
+ * immediately on subscribe, so the controller sees the current session as soon
+ * as it attaches and evaluates it the same way it would have live.
+ */
+export class PasskeyOfferBoot implements AppModule {
+  private readonly ctx: AppContext;
+  private unsubscribe: (() => void) | null = null;
+  /** An authoritative signed-out state has been observed this page life. */
+  private armed = false;
+  private loading = false;
+  private destroyed = false;
+  private real: AppModule | null = null;
+
+  constructor(ctx: AppContext) {
+    this.ctx = ctx;
+  }
+
+  init(): void {
+    this.unsubscribe = subscribeAuthState(() => this.onAuthChange());
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.real?.destroy();
+    this.real = null;
+  }
+
+  private onAuthChange(): void {
+    if (this.real || this.loading || this.destroyed) return;
+    const clerk = getClerk() as { user?: { id?: string } | null } | null;
+    // Clerk absent means the SDK has not loaded (or failed to). A user-null
+    // reading then proves nothing about whether anyone is signed in, so it must
+    // not arm — see the controller's own KTD3c note.
+    if (!clerk) return;
+    if (!clerk.user?.id) { this.armed = true; return; }
+    // Signed in, and we saw them signed out first: this is a real sign-in, so
+    // the offer is now plausible and the real controller is worth its bytes.
+    if (this.armed) void this.load();
+  }
+
+  private async load(): Promise<void> {
+    this.loading = true;
+    try {
+      const { PasskeyOfferController } = await import('@/app/passkey-offer-controller');
+      if (this.destroyed) return;
+      // Stop shimming before the controller subscribes, so the two never race
+      // on the same emission.
+      this.unsubscribe?.();
+      this.unsubscribe = null;
+      const controller = new PasskeyOfferController(this.ctx, { preArmed: true });
+      this.real = controller;
+      controller.init();
+    } catch {
+      // A failed chunk fetch must not break the dashboard. The offer is a
+      // nice-to-have; leave the shim disarmed rather than retrying forever.
+    } finally {
+      this.loading = false;
+    }
+  }
+}

--- a/src/app/passkey-offer-controller.ts
+++ b/src/app/passkey-offer-controller.ts
@@ -166,6 +166,12 @@ const SUCCESS_LINGER_MS = 2600;
 
 export interface PasskeyOfferControllerOptions {
   storage?: OfferStorage;
+  /**
+   * The eager boot shim already observed an authoritative signed-out state and
+   * handed off on a real sign-in, so re-deriving it here would lose the arming
+   * and drop the very offer the handoff exists to deliver.
+   */
+  preArmed?: boolean;
   /** Injected in tests; production uses rAF. */
   scheduleFrame?: (cb: () => void) => void;
 }
@@ -194,7 +200,7 @@ export class PasskeyOfferController implements AppModule {
    * false}` — byte-identical to a real signed-out session — while keeping
    * subscribers queued for a retry.
    */
-  private armed = false;
+  private armed: boolean;
   private prompt: PasskeyOfferPrompt | null = null;
   private mountedIdentity: PasskeyIdentity | null = null;
   private acceptedThisMount = false;
@@ -221,6 +227,7 @@ export class PasskeyOfferController implements AppModule {
     this.storage = options.storage ?? safeLocalStorage();
     this.scheduleFrame = options.scheduleFrame
       ?? ((cb) => { if (typeof requestAnimationFrame === 'function') requestAnimationFrame(cb); else setTimeout(cb, 16); });
+    this.armed = options.preArmed === true;
   }
 
   init(): void {

--- a/tests/dom/passkey-offer-boot.test.mts
+++ b/tests/dom/passkey-offer-boot.test.mts
@@ -1,0 +1,154 @@
+/**
+ * Coverage for the eager boot shim (`src/app/passkey-offer-boot.ts`).
+ *
+ * The shim exists to keep ~12 KB of passkey code out of the first-paint chunk:
+ * the offer cannot fire until someone signs in, and most page loads never do.
+ * But deferring it introduces exactly one way to break the feature silently —
+ * losing the arming observation.
+ *
+ * The detector may only arm on an AUTHORITATIVE signed-out state (Clerk loaded,
+ * no session). So the shim must subscribe eagerly, not on idle: a user who
+ * signs in quickly would otherwise be seen as already-signed-in with no prior
+ * signed-out reading, and would never be offered. These tests pin that, plus
+ * the two states that must NOT arm.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let authListener: (() => void) | null = null;
+const state = { clerkLoaded: true, userId: null as string | null };
+
+vi.mock('@/services/auth-state', () => ({
+  subscribeAuthState: (cb: () => void) => { authListener = cb; return () => { authListener = null; }; },
+}));
+
+vi.mock('@/services/clerk', () => ({
+  getClerk: () => (state.clerkLoaded ? { user: state.userId ? { id: state.userId } : null } : null),
+}));
+
+const loaded = { count: 0, preArmed: [] as (boolean | undefined)[], destroyed: 0, inited: 0 };
+
+vi.mock('@/app/passkey-offer-controller', () => ({
+  PasskeyOfferController: class {
+    constructor(_ctx: unknown, opts?: { preArmed?: boolean }) {
+      loaded.count += 1;
+      loaded.preArmed.push(opts?.preArmed);
+    }
+    init() { loaded.inited += 1; }
+    destroy() { loaded.destroyed += 1; }
+  },
+}));
+
+import type { AppContext } from '@/app/app-context';
+import { PasskeyOfferBoot } from '@/app/passkey-offer-boot';
+
+const ctx = { isDesktopApp: false } as unknown as AppContext;
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  authListener = null;
+  state.clerkLoaded = true;
+  state.userId = null;
+  loaded.count = 0;
+  loaded.preArmed = [];
+  loaded.destroyed = 0;
+  loaded.inited = 0;
+});
+
+describe('PasskeyOfferBoot', () => {
+  it('subscribes eagerly, so a fast sign-in is still caught', () => {
+    const boot = new PasskeyOfferBoot(ctx);
+    boot.init();
+    // The whole point of an eager subscription: a listener exists before the
+    // user has had any chance to sign in.
+    expect(authListener).not.toBeNull();
+    boot.destroy();
+  });
+
+  it('loads nothing while the visitor stays signed out', async () => {
+    const boot = new PasskeyOfferBoot(ctx);
+    boot.init();
+    authListener?.();
+    await flush();
+    expect(loaded.count).toBe(0);
+    boot.destroy();
+  });
+
+  it('hands off on a real sign-in, pre-armed so the offer is not lost', async () => {
+    const boot = new PasskeyOfferBoot(ctx);
+    boot.init();
+
+    authListener?.();            // authoritative signed-out → arm
+    state.userId = 'user_abc';
+    authListener?.();            // sign-in → hand off
+    await flush();
+
+    expect(loaded.count).toBe(1);
+    expect(loaded.inited).toBe(1);
+    // Without preArmed the controller would re-derive arming from scratch,
+    // never see a signed-out state, and drop the very offer this handoff exists
+    // to deliver.
+    expect(loaded.preArmed).toEqual([true]);
+    boot.destroy();
+  });
+
+  it('does NOT hand off on a cold cookie hydration', async () => {
+    // No signed-out state was ever observed — this is a page load completing,
+    // not a sign-in, and is the case that would otherwise prompt every visit.
+    const boot = new PasskeyOfferBoot(ctx);
+    state.userId = 'user_abc';
+    boot.init();
+    authListener?.();
+    await flush();
+    expect(loaded.count).toBe(0);
+    boot.destroy();
+  });
+
+  it('does NOT arm on a user-null reading while Clerk is absent', async () => {
+    // A failed SDK load publishes a user-null state indistinguishable from a
+    // real signed-out session. Arming on it would fire the offer when the
+    // retry hydrates an existing cookie.
+    const boot = new PasskeyOfferBoot(ctx);
+    boot.init();
+    state.clerkLoaded = false;
+    authListener?.();            // looks signed out, but Clerk never loaded
+    state.clerkLoaded = true;
+    state.userId = 'user_abc';
+    authListener?.();            // retry succeeds and hydrates the cookie
+    await flush();
+    expect(loaded.count).toBe(0);
+    boot.destroy();
+  });
+
+  it('loads the controller at most once', async () => {
+    const boot = new PasskeyOfferBoot(ctx);
+    boot.init();
+    authListener?.();
+    state.userId = 'user_abc';
+    authListener?.();
+    await flush();
+    authListener?.();
+    await flush();
+    expect(loaded.count).toBe(1);
+    boot.destroy();
+  });
+
+  it('destroys the loaded controller when torn down', async () => {
+    const boot = new PasskeyOfferBoot(ctx);
+    boot.init();
+    authListener?.();
+    state.userId = 'user_abc';
+    authListener?.();
+    await flush();
+
+    boot.destroy();
+    expect(loaded.destroyed).toBe(1);
+  });
+
+  it('is safe to destroy before any handoff', () => {
+    const boot = new PasskeyOfferBoot(ctx);
+    boot.init();
+    expect(() => boot.destroy()).not.toThrow();
+    expect(loaded.count).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes `bundle:check` on `main`, which #7353 broke.

## Measured, not assumed

| Commit | main chunk | `bundle:check` |
|---|---|---|
| `3b36b90d` (immediately before the merge) | 860,591 B | **OK** |
| `e2d532a4` (#7353 merged) | 873,011 B | **FAILED** |
| this branch | **861,817 B** | **OK** |

So #7353 alone put **12.1 KB into the first-paint chunk** — for a feature that cannot fire until someone signs in, which the overwhelming majority of page loads never do. The right fix is to defer it, not to raise the budget, so **no snapshot change is included here**.

## What changed

`panel-layout` now constructs a small `PasskeyOfferBoot` instead of the controller. The shim keeps exactly one thing eager — the arming observation — and dynamically imports the controller, the prompt component, and the passkey services only once a real sign-in makes the offer plausible.

**Arming has to stay eager or the feature breaks silently.** The detector may only arm on an *authoritative* signed-out state (Clerk loaded, no session). Subscribing on an idle callback instead would mean a user who signs in quickly is first observed already-signed-in, with no prior signed-out reading — and is never offered. So the shim subscribes in `init()` and passes `preArmed: true` across the handoff.

Net: **−10.9 KB** from first paint. The feature now costs 1.2 KB over the pre-merge baseline instead of 12.1 KB.

## Tests

`tests/dom/passkey-offer-boot.test.mts` covers the handoff and, more importantly, the two states that must **not** trigger it:

- a cold cookie hydration (no signed-out state ever observed)
- a user-null reading taken while Clerk has not loaded — the failed-SDK-load case that is byte-identical to a real signed-out session

The `preArmed` assertion was verified to fail against a shim that drops the flag, so it is not a test that cannot fail. All 107 existing passkey tests still pass; `typecheck`, `typecheck:dom-tests`, `lint:boundaries`, `biome`, and `docs-stats` are clean.

## Why CI did not catch this on the original PR

Worth recording, because the gate worked exactly as designed and still let this through.

`bundle:check` runs inside the `unit` job and **passed on #7353**. That branch predated #7329, so its 12.1 KB was measured against a snapshot older than both changes and fit inside the 16.7 KB drift allowance. #7329 then merged, consuming part of that allowance, and #7353 landed on top — each PR green, `main` red.

A budget checked against a committed snapshot cannot see what merges alongside it. Nothing here fixes that; flagging it as a known property of the gate.
