### PR TITLE
fix(sentry): anchor the Java-bridge filter to Chromium's full sentence

### DIFF
--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -163,9 +163,18 @@ export const MARKETING_IGNORE_ERRORS: RegExp[] = [
   // `/pro/assets/*.js` — the observability blind spot this array exists to
   // avoid. Only the complete Chromium shape is third-party by construction, so
   // only that shape is suppressed; the method name varies per host-app bridge,
-  // so it is matched as an identifier rather than pinned to the one observed
+  // so it is matched by shape rather than pinned to the one observed
   // (PR #7354 review).
-  /^Error invoking [\w$]+: Java object is gone$/,
+  //
+  // The method slot is "anything but whitespace or a colon", NOT `[\w$]+`:
+  // Java identifiers are not ASCII-only (`@JavascriptInterface
+  // obtenirDonnées()` is legal, and Chromium emits the same sentence for it)
+  // while JavaScript's `\w` is, so an ASCII slot silently misses them. Widening
+  // it cannot loosen the rule — the envelope is anchored at both ends and the
+  // reason is fixed, so this matches only if our own bundle emits the whole
+  // Chromium sentence. Java method names hold no colon, so excluding one keeps
+  // the slot off the reason separator (PR #7356 review).
+  /^Error invoking [^\s:]+: Java object is gone$/,
   // iOS in-app WebView native bridge. The host app injects `sendDataToNative` /
   // `sendPageHideMessage` into the document and they dereference
   // `window.webkit.messageHandlers`, which only exists when a WKWebView host

--- a/pro-test/src/sentry-filter-policy.ts
+++ b/pro-test/src/sentry-filter-policy.ts
@@ -155,7 +155,17 @@ export const MARKETING_IGNORE_ERRORS: RegExp[] = [
   // clients, so the missing marketing copy is what let WORLDMONITOR-117 through
   // with three infra-only frames (the `/pro/assets/sentry-*.js` chunk plus two
   // `<anonymous>`), which `marketingBeforeSend`'s frame gates cannot act on.
-  /Java object is gone/,
+  //
+  // Anchored to the whole sentence, unlike the dashboard's bare
+  // `/Java object is gone/`. `ignoreErrors` is frame-blind, so an unanchored
+  // substring also drops any first-party message that happens to CONTAIN the
+  // phrase (`Our Java object is gone`) even when its stack points straight at
+  // `/pro/assets/*.js` — the observability blind spot this array exists to
+  // avoid. Only the complete Chromium shape is third-party by construction, so
+  // only that shape is suppressed; the method name varies per host-app bridge,
+  // so it is matched as an identifier rather than pinned to the one observed
+  // (PR #7354 review).
+  /^Error invoking [\w$]+: Java object is gone$/,
   // iOS in-app WebView native bridge. The host app injects `sendDataToNative` /
   // `sendPageHideMessage` into the document and they dereference
   // `window.webkit.messageHandlers`, which only exists when a WKWebView host

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -374,6 +374,17 @@ describe('marketing ignoreErrors — in-app-browser injected globals (2026-08-27
     assert.equal(isIgnored('Error', 'Error invoking getDeviceInfo: Java object is gone'), true);
   });
 
+  it('drops the envelope with a non-ASCII bridge method name', () => {
+    // Java identifiers are not ASCII-only — `@JavascriptInterface
+    // obtenirDonnées()` is legal and Chromium emits the same sentence for it.
+    // An `[\w$]+` slot silently misses these because JavaScript's `\w` is
+    // ASCII-only, which is what these controls exist to catch (PR #7356
+    // review).
+    assert.equal(isIgnored('Error', 'Error invoking obtenirDonnées: Java object is gone'), true);
+    assert.equal(isIgnored('Error', 'Error invoking 获取设备信息: Java object is gone'), true);
+    assert.equal(isIgnored('Error', 'Error invoking процесс: Java object is gone'), true);
+  });
+
   it('keeps a first-party message that merely CONTAINS the phrase', () => {
     // The control that matters, and the one an unanchored `/Java object is
     // gone/` fails: `ignoreErrors` is frame-blind, so a substring pattern drops

--- a/tests/pro-sentry-filter-policy.test.mts
+++ b/tests/pro-sentry-filter-policy.test.mts
@@ -374,9 +374,22 @@ describe('marketing ignoreErrors — in-app-browser injected globals (2026-08-27
     assert.equal(isIgnored('Error', 'Error invoking getDeviceInfo: Java object is gone'), true);
   });
 
+  it('keeps a first-party message that merely CONTAINS the phrase', () => {
+    // The control that matters, and the one an unanchored `/Java object is
+    // gone/` fails: `ignoreErrors` is frame-blind, so a substring pattern drops
+    // this even with a `/pro/assets/*.js` frame on the stack. Changing a word
+    // the pattern requires (`gateway` for `object`) does NOT exercise this —
+    // that control passes against the unanchored pattern too, so it can never
+    // fail (PR #7354 review).
+    assert.equal(isIgnored('Error', 'Our Java object is gone'), false);
+    assert.equal(isIgnored('Error', 'Session expired: Java object is gone'), false);
+    assert.equal(
+      isIgnored('Error', 'Error invoking foo: Java object is gone (retrying)'),
+      false,
+    );
+  });
+
   it('keeps other Java-flavoured messages so a real one still reports', () => {
-    // Only the exact Chromium sentence is third-party by construction; the
-    // word "Java" on its own is not a licence to suppress.
     assert.equal(isIgnored('Error', 'Java object is missing'), false);
     assert.equal(isIgnored('Error', 'Our Java gateway is gone'), false);
   });


### PR DESCRIPTION
Follow-up to #7354, which merged before this review finding could be addressed on its own branch.

`MARKETING_IGNORE_ERRORS` is frame-blind — Sentry's `InboundFilters` matches on message text with no access to the stack. So the unanchored `/Java object is gone/` #7354 added also dropped any **first-party** message that merely *contains* the phrase, even with a `/pro/assets/*.js` frame on the stack. `Our Java object is gone` was suppressed. This anchors to the complete Chromium sentence, keeping the method name an identifier so it still covers whichever `@JavascriptInterface` bridge the host app called.

## The controls it replaces could not fail

This is the real defect, and it is the reason the over-match shipped. Both original controls changed a word the pattern *requires*:

| Control | vs. unanchored `/Java object is gone/` | vs. anchored | Exercises the bug? |
|---|---|---|---|
| `Java object is missing` | not ignored ✅ | not ignored ✅ | **no** — passes either way |
| `Our Java gateway is gone` | not ignored ✅ | not ignored ✅ | **no** — passes either way |
| `Our Java object is gone` | **ignored ❌** | not ignored ✅ | **yes** |
| `Session expired: Java object is gone` | **ignored ❌** | not ignored ✅ | **yes** |
| `Error invoking foo: Java object is gone (retrying)` | **ignored ❌** | not ignored ✅ | **yes** |

A control that stays green against the broken pattern is not a control. All three new ones go red against it; both suppression cases (`enableButtonsClickedMetaDataLogging`, `getDeviceInfo`) stay green.

## Scope note

`src/bootstrap/sentry-init.ts:82` carries the same bare `/Java object is gone/` on the dashboard and has the identical latent over-match. Deliberately **not** touched here: it has been live since #4005 across a large issue population, so tightening it un-suppresses dashboard events and deserves its own change with its own Sentry read afterwards — not a drive-by in a marketing-surface PR.

## Validation

`tests/pro-sentry-filter-policy.test.mts` — 67 pass (was 66; one new control block). Verified the three new controls fail against the old pattern and pass against the new one before committing. `npx tsc --noEmit` clean, biome clean.

Related: #7354

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
