### PR TITLE
feat(passkeys): record why the offer did or did not appear

### DIFF
--- a/src/app/passkey-offer-boot.ts
+++ b/src/app/passkey-offer-boot.ts
@@ -1,6 +1,7 @@
 import type { AppContext, AppModule } from '@/app/app-context';
 import { subscribeAuthState } from '@/services/auth-state';
 import { getClerk } from '@/services/clerk';
+import { recordPasskeyOfferReason } from '@/utils/passkey-offer-trace';
 
 /**
  * Eager shim that keeps the passkey offer OUT of the first-paint bundle.
@@ -56,15 +57,25 @@ export class PasskeyOfferBoot implements AppModule {
     // Clerk absent means the SDK has not loaded (or failed to). A user-null
     // reading then proves nothing about whether anyone is signed in, so it must
     // not arm — see the controller's own KTD3c note.
-    if (!clerk) return;
-    if (!clerk.user?.id) { this.armed = true; return; }
+    if (!clerk) { recordPasskeyOfferReason('clerk-absent'); return; }
+    if (!clerk.user?.id) {
+      this.armed = true;
+      recordPasskeyOfferReason('signed-out-observed');
+      return;
+    }
     // Signed in, and we saw them signed out first: this is a real sign-in, so
     // the offer is now plausible and the real controller is worth its bytes.
-    if (this.armed) void this.load();
+    if (this.armed) { void this.load(); return; }
+    // Signed in with no prior signed-out observation — a cold cookie
+    // hydration. This is the branch that is otherwise completely invisible:
+    // the controller never loads, so controller-side instrumentation can never
+    // report it.
+    recordPasskeyOfferReason('cold-hydration-suppressed');
   }
 
   private async load(): Promise<void> {
     this.loading = true;
+    recordPasskeyOfferReason('import-started');
     try {
       const { PasskeyOfferController } = await import('@/app/passkey-offer-controller');
       if (this.destroyed) return;
@@ -78,6 +89,7 @@ export class PasskeyOfferBoot implements AppModule {
     } catch {
       // A failed chunk fetch must not break the dashboard. The offer is a
       // nice-to-have; leave the shim disarmed rather than retrying forever.
+      recordPasskeyOfferReason('import-failed');
     } finally {
       this.loading = false;
     }

--- a/src/app/passkey-offer-controller.ts
+++ b/src/app/passkey-offer-controller.ts
@@ -29,6 +29,7 @@ import {
   readPasskeySessionFacts,
 } from '@/services/passkeys';
 import { isModalOpen } from '@/utils/open-modal';
+import { recordPasskeyOfferReason } from '@/utils/passkey-offer-trace';
 
 /**
  * Drives the post-sign-in passkey offer.
@@ -294,6 +295,10 @@ export class PasskeyOfferController implements AppModule {
       },
       mount: (id) => this.mountPrompt(id),
     });
+    // Every result is a member of the closed trace vocabulary, so the gate that
+    // stopped the offer is recoverable in one console read instead of inferred
+    // from a later snapshot.
+    recordPasskeyOfferReason(result);
     // Come back when the overlay goes away. Every other non-mount result is
     // genuinely terminal for this emission.
     this.evaluationDeferredByOverlay = result === 'blocked-by-overlay';

--- a/src/utils/passkey-offer-trace.ts
+++ b/src/utils/passkey-offer-trace.ts
@@ -1,0 +1,121 @@
+/**
+ * A closed-vocabulary trace of why the passkey offer did or did not appear.
+ *
+ * When the offer fails to show, nothing today records which gate stopped it.
+ * The only available diagnosis was elimination from a snapshot taken later, and
+ * that is not proof: an empty ledger is equally consistent with a failed
+ * platform-authenticator probe, an overlay, a superseded identity, a lost
+ * single-flight claim, or a failed dynamic import. This records the outcome at
+ * the moment it happens instead.
+ *
+ * The instrumentation deliberately spans BOTH halves of the feature. The eager
+ * boot shim reports its own outcomes, because in the case we most need to
+ * diagnose — the controller never loading — controller-side instrumentation
+ * cannot run at all.
+ *
+ * ## The privacy constraint is the design
+ *
+ * Any same-origin script can read `window.__wmPasskeyOffer`, so the vocabulary
+ * is CLOSED: `recordPasskeyOfferReason` silently drops anything that is not a
+ * declared member. That is what makes it safe to expose — a future caller
+ * cannot smuggle an account key, Clerk id, session id, or raw error message
+ * through as a "reason", even by accident.
+ *
+ * Unlike `markLcpDebug`, this records unconditionally rather than behind an
+ * opt-in flag, because the thing being diagnosed is a once-per-account event
+ * that cannot be reproduced on demand — by the time you know you wanted the
+ * trace, the offer has been spent. The cost is one array push per auth
+ * emission, and no `performance.mark` is written, so the User Timing buffer
+ * that RUM and Sentry read stays clean.
+ */
+
+/**
+ * Every reason the offer can reach a decision, and nothing else.
+ *
+ * The first five are the eager shim's; the rest mirror
+ * `PasskeyEvaluationResult` in the controller.
+ */
+export const PASSKEY_OFFER_REASONS = [
+  // Boot shim
+  'clerk-absent',
+  'signed-out-observed',
+  'cold-hydration-suppressed',
+  'import-started',
+  'import-failed',
+  // Controller evaluation
+  'not-armed',
+  'not-ready',
+  'ineligible-environment',
+  'already-has-passkey',
+  'already-offered',
+  'no-platform-authenticator',
+  'blocked-by-overlay',
+  'superseded',
+  'mounted',
+] as const;
+
+export type PasskeyOfferReason = (typeof PASSKEY_OFFER_REASONS)[number];
+
+/** Bounded so a long-lived tab cannot grow the trace without limit. */
+export const TRACE_LIMIT = 24;
+
+const GLOBAL_KEY = '__wmPasskeyOffer';
+
+type TraceState = {
+  last?: PasskeyOfferReason;
+  trace: PasskeyOfferReason[];
+};
+
+function traceHost(): Record<string, unknown> | null {
+  return typeof window === 'undefined'
+    ? null
+    : (window as unknown as Record<string, unknown>);
+}
+
+function ensureState(): TraceState | null {
+  const host = traceHost();
+  if (!host) return null;
+  const existing = host[GLOBAL_KEY] as TraceState | undefined;
+  if (existing && Array.isArray(existing.trace)) return existing;
+  const created: TraceState = { trace: [] };
+  host[GLOBAL_KEY] = created;
+  return created;
+}
+
+/**
+ * Record one decision.
+ *
+ * Never throws and never records anything outside the vocabulary — both
+ * properties matter, because this is called from inside an auth listener and
+ * from a catch block.
+ */
+export function recordPasskeyOfferReason(reason: PasskeyOfferReason): void {
+  if (!PASSKEY_OFFER_REASONS.includes(reason)) return;
+  const state = ensureState();
+  if (!state) return;
+  state.trace.push(reason);
+  state.last = reason;
+  if (state.trace.length > TRACE_LIMIT) {
+    state.trace.splice(0, state.trace.length - TRACE_LIMIT);
+  }
+}
+
+/** The recorded sequence, oldest first. Empty when unavailable. */
+export function getPasskeyOfferTrace(): readonly PasskeyOfferReason[] {
+  const host = traceHost();
+  const state = host?.[GLOBAL_KEY] as TraceState | undefined;
+  return Array.isArray(state?.trace) ? state.trace : [];
+}
+
+/** The raw state, for the console one-liner. */
+export function readPasskeyOfferTrace(): TraceState | null {
+  const host = traceHost();
+  const state = host?.[GLOBAL_KEY] as TraceState | undefined;
+  return state && Array.isArray(state.trace) ? state : null;
+}
+
+/** Test-only reset. */
+export function resetPasskeyOfferTrace(): void {
+  const host = traceHost();
+  if (host) delete host[GLOBAL_KEY];
+}

--- a/tests/dom/passkey-offer-boot.test.mts
+++ b/tests/dom/passkey-offer-boot.test.mts
@@ -41,6 +41,7 @@ vi.mock('@/app/passkey-offer-controller', () => ({
 
 import type { AppContext } from '@/app/app-context';
 import { PasskeyOfferBoot } from '@/app/passkey-offer-boot';
+import { getPasskeyOfferTrace, resetPasskeyOfferTrace } from '@/utils/passkey-offer-trace';
 
 const ctx = { isDesktopApp: false } as unknown as AppContext;
 const flush = () => new Promise((r) => setTimeout(r, 0));
@@ -53,6 +54,7 @@ beforeEach(() => {
   loaded.preArmed = [];
   loaded.destroyed = 0;
   loaded.inited = 0;
+  resetPasskeyOfferTrace();
 });
 
 describe('PasskeyOfferBoot', () => {
@@ -150,5 +152,57 @@ describe('PasskeyOfferBoot', () => {
     boot.init();
     expect(() => boot.destroy()).not.toThrow();
     expect(loaded.count).toBe(0);
+  });
+});
+
+describe('diagnostic trace', () => {
+  it('records the cold-hydration suppression that is otherwise invisible', async () => {
+    // This is the whole reason the trace lives in the shim: the controller
+    // never loads on this path, so controller-side instrumentation could never
+    // report it, and the only prior diagnosis was inference from a snapshot.
+    const boot = new PasskeyOfferBoot(ctx);
+    state.userId = 'user_abc';
+    boot.init();
+    authListener?.();
+    await flush();
+    expect(getPasskeyOfferTrace()).toContain('cold-hydration-suppressed');
+    expect(loaded.count).toBe(0);
+    boot.destroy();
+  });
+
+  it('records the arming observation and the handoff, in order', async () => {
+    const boot = new PasskeyOfferBoot(ctx);
+    boot.init();
+    authListener?.();
+    state.userId = 'user_abc';
+    authListener?.();
+    await flush();
+    expect(getPasskeyOfferTrace()).toEqual(['signed-out-observed', 'import-started']);
+    boot.destroy();
+  });
+
+  it('records clerk-absent rather than staying silent', async () => {
+    const boot = new PasskeyOfferBoot(ctx);
+    state.clerkLoaded = false;
+    boot.init();
+    authListener?.();
+    await flush();
+    expect(getPasskeyOfferTrace()).toEqual(['clerk-absent']);
+    boot.destroy();
+  });
+
+  it('records nothing that is not a closed-vocabulary member', async () => {
+    const boot = new PasskeyOfferBoot(ctx);
+    boot.init();
+    authListener?.();
+    state.userId = 'user_abc';
+    authListener?.();
+    await flush();
+    // No account key, user id, or session id may ever reach the trace.
+    for (const entry of getPasskeyOfferTrace()) {
+      expect(entry).not.toContain('user_');
+      expect(entry).not.toContain('acct:');
+    }
+    boot.destroy();
   });
 });

--- a/tests/passkey-offer-trace.test.mts
+++ b/tests/passkey-offer-trace.test.mts
@@ -1,0 +1,99 @@
+/**
+ * Coverage for the passkey offer diagnostic trace
+ * (`src/utils/passkey-offer-trace.ts`).
+ *
+ * Why this exists: when the offer does not appear, there is currently no way to
+ * tell which gate stopped it. Reasoning by elimination from a later snapshot is
+ * not proof — an empty ledger is equally consistent with a failed platform
+ * probe, an overlay, a lost claim, or a failed dynamic import. This records the
+ * actual outcome as it happens.
+ *
+ * The privacy constraint is the whole design. The vocabulary is CLOSED: only
+ * fixed enum members are ever recorded. No account keys, Clerk ids, session
+ * ids, raw errors, or credential data — any same-origin script can read this.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PASSKEY_OFFER_REASONS,
+  getPasskeyOfferTrace,
+  readPasskeyOfferTrace,
+  recordPasskeyOfferReason,
+  resetPasskeyOfferTrace,
+  TRACE_LIMIT,
+} from '../src/utils/passkey-offer-trace.ts';
+
+function freshWindow(): Record<string, unknown> {
+  const g = globalThis as unknown as { window?: Record<string, unknown> };
+  g.window = {};
+  resetPasskeyOfferTrace();
+  return g.window;
+}
+
+describe('recordPasskeyOfferReason', () => {
+  it('records a reason and exposes it as the latest', () => {
+    freshWindow();
+    recordPasskeyOfferReason('not-armed');
+    assert.equal(readPasskeyOfferTrace()?.last, 'not-armed');
+  });
+
+  it('keeps the sequence in order, so the gate ordering is legible', () => {
+    freshWindow();
+    recordPasskeyOfferReason('signed-out-observed');
+    recordPasskeyOfferReason('import-started');
+    recordPasskeyOfferReason('mounted');
+    assert.deepEqual(getPasskeyOfferTrace(), ['signed-out-observed', 'import-started', 'mounted']);
+  });
+
+  it('bounds the trace so a long session cannot grow it without limit', () => {
+    freshWindow();
+    for (let i = 0; i < TRACE_LIMIT + 10; i += 1) recordPasskeyOfferReason('not-armed');
+    assert.equal(getPasskeyOfferTrace().length, TRACE_LIMIT);
+  });
+
+  it('never throws when there is no window (SSR, node test runners)', () => {
+    const g = globalThis as unknown as { window?: Record<string, unknown> };
+    const had = 'window' in g;
+    const prev = g.window;
+    delete g.window;
+    try {
+      assert.doesNotThrow(() => recordPasskeyOfferReason('mounted'));
+      assert.deepEqual(getPasskeyOfferTrace(), []);
+    } finally {
+      if (had) g.window = prev;
+    }
+  });
+});
+
+describe('the closed vocabulary', () => {
+  it('accepts every declared reason', () => {
+    freshWindow();
+    for (const reason of PASSKEY_OFFER_REASONS) {
+      assert.doesNotThrow(() => recordPasskeyOfferReason(reason));
+    }
+    assert.equal(getPasskeyOfferTrace().length, PASSKEY_OFFER_REASONS.length);
+  });
+
+  it('drops anything outside the vocabulary rather than recording it', () => {
+    // The guarantee that makes this safe to expose: a caller cannot smuggle an
+    // account key, session id, or error message through as a "reason".
+    freshWindow();
+    recordPasskeyOfferReason('acct:9xk2m' as never);
+    recordPasskeyOfferReason('user_2abcDEF' as never);
+    assert.deepEqual(getPasskeyOfferTrace(), []);
+    assert.equal(readPasskeyOfferTrace()?.last, undefined);
+  });
+
+  it('carries no free-form fields at all', () => {
+    freshWindow();
+    recordPasskeyOfferReason('already-offered');
+    const state = readPasskeyOfferTrace() as Record<string, unknown>;
+    // Only `last` and `trace` — adding a field here is how PII creeps in.
+    assert.deepEqual(Object.keys(state).sort(), ['last', 'trace']);
+    for (const entry of state.trace as string[]) {
+      assert.ok(PASSKEY_OFFER_REASONS.includes(entry as never));
+    }
+  });
+});


### PR DESCRIPTION
Observability only. **No behavior change** — every gate, threshold, and ordering is untouched.

## Why

When the passkey offer doesn't appear, there is currently nothing to read. The only available diagnosis was elimination from a snapshot taken afterwards — and I made exactly that mistake on production: an empty ledger *looked* like it proved the prompt never mounted. It doesn't. An empty ledger is equally consistent with a failed platform-authenticator probe, an overlay, a superseded identity, a lost single-flight claim, or a failed dynamic import.

This records the outcome when it happens instead of inferring it later.

## Instrumented in both halves — and the shim half is the point

In the case most in need of diagnosis the controller **never loads**, so controller-side instrumentation cannot run at all. `cold-hydration-suppressed` and `clerk-absent` are only observable from the eager boot shim.

| Source | Reasons |
|---|---|
| Boot shim | `clerk-absent`, `signed-out-observed`, `cold-hydration-suppressed`, `import-started`, `import-failed` |
| Controller | `not-armed`, `not-ready`, `ineligible-environment`, `already-has-passkey`, `already-offered`, `no-platform-authenticator`, `blocked-by-overlay`, `superseded`, `mounted` |

## The closed vocabulary is the design, not decoration

Any same-origin script can read `window.__wmPasskeyOffer`, so `recordPasskeyOfferReason()` **drops anything that is not a declared member**. A future caller cannot smuggle an account key, Clerk id, session id, or raw error message through as a "reason", even by accident. Tests assert this directly — including that the state object grows no free-form fields, which is how PII usually creeps into a debug surface.

Two properties fall out of the types:
- `PasskeyEvaluationResult` is assignable to `PasskeyOfferReason`, so adding an evaluation result without a vocabulary entry **fails typecheck**
- The trace is bounded at 24 entries, so a long-lived tab cannot grow it

## Why not opt-in like `markLcpDebug`

`markLcpDebug` is correctly opt-in — it sits on the boot critical path and would pollute the User Timing buffer. This is different: the thing being diagnosed is a **once-per-account event that cannot be reproduced on demand**. By the time you know you wanted the trace, the offer is spent.

Cost is one array push per auth emission, and **no `performance.mark` is written**, so the buffer RUM and Sentry read stays clean.

## Usage

```js
window.__wmPasskeyOffer   // → { last: 'cold-hydration-suppressed', trace: [...] }
```

## Verification

`bundle:check` **OK** (the fix from #7355 holds — the trace module is small and the controller half rides the already-lazy chunk). 126 passkey tests pass. `typecheck`, `typecheck:dom-tests`, `lint:boundaries`, `biome`, `docs-stats` all clean.

## Context

This is step 1 of the revised approach after a Codex review rejected my earlier proposal to relax the arming guard. That proposal rested on the ledger being a robust once-per-account cap; it isn't — it's origin-local and best-effort, so the arming guard is a genuine second anti-nag layer, and relaxing it would have prompted storage-disabled browsers on **every page load**. Instrument first, gather real evidence, then decide policy.
