### PR TITLE
fix(bootstrap): align public single-key edge headers

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - 'workers/api-cors-preflight/**'
       - 'api/_bootstrap-public-tier.js'
+      - 'api/_bootstrap-tier-keys.js'
       # The deployed-URL guard and the contract it asserts. Without these, a change
       # to the shared contract helper alone deploys nothing and runs no live smoke —
       # so the half of "one definition, both sides" that runs against production

--- a/api/_bootstrap-public-tier.js
+++ b/api/_bootstrap-public-tier.js
@@ -1,40 +1,77 @@
+import {
+  PUBLIC_WEATHER_BOOTSTRAP_KEY,
+  bootstrapTierKeyNames,
+} from './_bootstrap-tier-keys.js';
+
 export const PUBLIC_BOOTSTRAP_TIERS = new Set(['fast', 'slow']);
+const PUBLIC_ON_DEMAND_BOOTSTRAP_KEYS = new Set(bootstrapTierKeyNames('on-demand'));
 
 /**
- * Return the tier for the two fixed public bootstrap URL shapes, else null.
- * Method-agnostic: this is the URL half of the contract only.
+ * Classify the explicit public bootstrap URLs shared by the origin and Worker.
+ * The marker is public before auth because a CDN hit can answer first. Exact
+ * tier and single-key shapes keep the shared cache key space bounded.
  *
- * Split out from bootstrapTierFromPublicRequest so the Cloudflare Worker can ask
- * the same question about a CORS preflight, whose own method is OPTIONS while the
- * request it is clearing is a GET. Both callers must reach the same answer about
- * which URLs are public, which is why this lives here rather than in the Worker.
+ * @param {URL} parsedUrl
+ * @returns {{ authKind: 'public-tier', tier: string } | { authKind: 'public-weather' | 'public-on-demand', tier: null } | null}
  */
-export function bootstrapTierFromPublicUrl(parsedUrl) {
+export function classifyPublicBootstrapUrl(parsedUrl) {
   const pathname = parsedUrl.pathname.length > 1
     ? parsedUrl.pathname.replace(/\/+$/, '')
     : parsedUrl.pathname;
   if (pathname !== '/api/bootstrap') return null;
 
-  const params = Array.from(parsedUrl.searchParams.keys());
-  if (params.some((key) => key !== 'tier' && key !== 'public')) return null;
-
-  const tierParams = parsedUrl.searchParams.getAll('tier');
+  const paramNames = new Set(parsedUrl.searchParams.keys());
   const publicParams = parsedUrl.searchParams.getAll('public');
-  if (tierParams.length !== 1 || publicParams.length !== 1 || publicParams[0] !== '1') return null;
+  if (paramNames.size !== 2 || !paramNames.has('public')) return null;
+  if (publicParams.length !== 1 || publicParams[0] !== '1') return null;
 
-  return PUBLIC_BOOTSTRAP_TIERS.has(tierParams[0]) ? tierParams[0] : null;
+  if (paramNames.has('tier')) {
+    const tierParams = parsedUrl.searchParams.getAll('tier');
+    if (tierParams.length !== 1 || !PUBLIC_BOOTSTRAP_TIERS.has(tierParams[0])) return null;
+    return { authKind: 'public-tier', tier: tierParams[0] };
+  }
+
+  if (!paramNames.has('keys')) return null;
+  const keyParams = parsedUrl.searchParams.getAll('keys');
+  if (keyParams.length !== 1) return null;
+
+  const key = keyParams[0];
+  if (key === PUBLIC_WEATHER_BOOTSTRAP_KEY) {
+    return { authKind: 'public-weather', tier: null };
+  }
+  if (PUBLIC_ON_DEMAND_BOOTSTRAP_KEYS.has(key)) {
+    return { authKind: 'public-on-demand', tier: null };
+  }
+  return null;
+}
+
+/**
+ * @param {Request} req
+ * @param {URL} [parsedUrl]
+ */
+export function classifyPublicBootstrapRequest(req, parsedUrl = new URL(req.url)) {
+  if (req.method !== 'GET') return null;
+  return classifyPublicBootstrapUrl(parsedUrl);
 }
 
 /**
  * Return the tier for the two fixed public bootstrap request shapes, else null.
- * This dependency-free helper is shared by the Vercel handler and Cloudflare
- * shadow Worker so their routing contract cannot drift independently.
+ * This registry-backed helper is shared by the Vercel handler and Cloudflare
+ * Worker so their routing contract cannot drift independently.
  */
 export function bootstrapTierFromPublicRequest(req, parsedUrl = new URL(req.url)) {
-  if (req.method !== 'GET') return null;
-  return bootstrapTierFromPublicUrl(parsedUrl);
+  const publicBootstrap = classifyPublicBootstrapRequest(req, parsedUrl);
+  return publicBootstrap?.authKind === 'public-tier' ? publicBootstrap.tier : null;
 }
 
 export function isPublicTierBootstrapRequest(req) {
   return bootstrapTierFromPublicRequest(req) !== null;
+}
+
+export function isPublicWeatherBootstrapRequest(req) {
+  return classifyPublicBootstrapRequest(req)?.authKind === 'public-weather';
+}
+
+export function isPublicOnDemandBootstrapRequest(req) {
+  return classifyPublicBootstrapRequest(req)?.authKind === 'public-on-demand';
 }

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -2,7 +2,12 @@ import { waitUntil as vercelWaitUntil } from '@vercel/functions';
 
 import {
   PUBLIC_BOOTSTRAP_TIERS,
+  classifyPublicBootstrapRequest,
+} from './_bootstrap-public-tier.js';
+export {
+  isPublicOnDemandBootstrapRequest,
   isPublicTierBootstrapRequest,
+  isPublicWeatherBootstrapRequest,
 } from './_bootstrap-public-tier.js';
 import { getCorsHeaders, getPublicCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import {
@@ -48,7 +53,6 @@ const { cacheKeys: BOOTSTRAP_CACHE_KEYS } = resolveBootstrapRegistry({
 });
 const SLOW_KEYS = new Set(bootstrapTierKeyNames('slow', { iranEventsEnabled: IRAN_EVENTS_ENABLED }));
 const FAST_KEYS = new Set(bootstrapTierKeyNames('fast', { iranEventsEnabled: IRAN_EVENTS_ENABLED }));
-const ON_DEMAND_KEYS = new Set(bootstrapTierKeyNames('on-demand', { iranEventsEnabled: IRAN_EVENTS_ENABLED }));
 
 // Temporary #6659 cutover fallback. Keep the new multi-province aggregate
 // authoritative, but let bootstrap clients use the Alberta sibling first and
@@ -164,44 +168,6 @@ const ON_DEMAND_CACHE_PROFILES = {
   },
 };
 
-// The URL SHAPE shared by every marked single-key public read:
-// `GET /api/bootstrap?keys=<one>&public=1`, no other params, each appearing once.
-// Returns the requested key name, or null when the request is not that shape.
-//
-// GET only: a HEAD has no body to serve and must not mint a cacheable entry.
-//
-// The MEMBERSHIP test deliberately stays with each caller below. Which keys may
-// be served without credentials is the whole semantic difference between them,
-// and folding both allowlists into one here would silently widen each to the
-// other's keys — the shape is shared, the authorization is not.
-function publicSingleKeyBootstrapRequestKey(req) {
-  if (req.method !== 'GET') return null;
-
-  const url = new URL(req.url);
-  const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, '') : url.pathname;
-  if (pathname !== '/api/bootstrap') return null;
-
-  const params = Array.from(url.searchParams.keys());
-  if (params.some((key) => key !== 'keys' && key !== 'public')) return null;
-
-  const keyParams = url.searchParams.getAll('keys');
-  const publicParams = url.searchParams.getAll('public');
-  if (keyParams.length !== 1 || publicParams.length !== 1 || publicParams[0] !== '1') return null;
-
-  return keyParams[0];
-}
-
-// The explicitly-marked public weather URL: `?keys=weatherAlerts&public=1`.
-//
-// Same contract as its `?tier=fast|slow&public=1` and `?keys=<onDemand>&public=1`
-// siblings below: the payload is the shared production seed value, identical for
-// every caller, so the marker gives it its own CDN entry and the response is
-// public REGARDLESS of attached credentials — a CDN hit precedes handler auth,
-// so a credential-dependent answer at this URL could never be honored.
-export function isPublicWeatherBootstrapRequest(req) {
-  return publicSingleKeyBootstrapRequestKey(req) === PUBLIC_WEATHER_BOOTSTRAP_KEY;
-}
-
 // The legacy unmarked weather URL: `?keys=weatherAlerts` with no credentials.
 // Still anonymous and still serves the public payload — it is a documented
 // public path (docs/api-platform.mdx) and the only bootstrap read the map embed
@@ -214,11 +180,10 @@ export function isPublicWeatherBootstrapRequest(req) {
 // response on this URL no-store means the edge never holds an entry that can
 // answer for the origin, so an invalid key always reaches validateApiKey.
 //
-// Deliberately NOT built on publicSingleKeyBootstrapRequestKey above: this
-// predicate is the pre-#5386 one, kept verbatim. It accepts HEAD and tolerates
-// `?keys=weatherAlerts,` / whitespace forms that the marked shape rejects.
-// Reusing the stricter helper here would narrow which requests still reach the
-// documented anonymous path — a behavior change this fix does not intend.
+// Deliberately NOT built on the marked public classifier: this predicate is the
+// pre-#5386 one, kept verbatim. It accepts HEAD and tolerates whitespace forms
+// that the marked shape rejects. Reusing the strict classifier here would narrow
+// which requests still reach the documented anonymous path.
 export function isAnonymousWeatherBootstrapRequest(req) {
   if (req.method !== 'GET' && req.method !== 'HEAD') return false;
 
@@ -305,43 +270,6 @@ function finishBootstrapR2ShadowResponse(req, ctx, tier, response, redisDuration
   return response;
 }
 
-// An explicit public tier bootstrap read (?tier=fast|slow&public=1, no other
-// params) returns the shared
-// production seed payload — identical for every caller (see PR #4499 non-goals:
-// only static transforms like wildfire compaction / enrichmentMeta strip apply,
-// never per-user variance). The explicit marker gives the shared response its
-// own CDN cache key; the legacy ?tier=fast|slow URLs remain credentialed and
-// no-store, so a warmed public response cannot bypass their auth/CORS contract.
-// The public URL is public regardless of request credentials because a CDN hit
-// occurs before handler auth. Callers that need credential processing must use
-// the legacy URL. Scoped to the two fixed public shapes so the CDN key space
-// stays tiny and hit rate high.
-//
-// GET only: a HEAD here would still run the full registry Redis read to build a
-// body it must not return — the exact unshielded egress this path exists to
-// avoid. HEAD tier reads have no client and fall through to the no-store path.
-export { isPublicTierBootstrapRequest } from './_bootstrap-public-tier.js';
-
-// The on-demand counterpart to the tier URL above: `?keys=<name>&public=1` for a
-// SINGLE on-demand key. Same reasoning — the payload is the shared production
-// seed value, identical for every caller — so it gets its own CDN entry and the
-// same public contract regardless of attached credentials (a cache hit precedes
-// handler auth).
-//
-// Restricted to ONE key drawn from ON_DEMAND_KEYS, deliberately: an arbitrary
-// `?keys=a,b,c` would make the CDN key space combinatorial, and every distinct
-// combination is a cache MISS that re-reads the registry from Redis — the exact
-// amplification #5259/#5287 exist to prevent. One key per URL keeps the space at
-// |ON_DEMAND_KEYS| entries, each independently cached and each fetched only by
-// the clients that actually render it.
-//
-// The legacy multi-key `?keys=a,b` URL keeps working and stays credentialed +
-// no-store, so nothing that relies on it changes.
-export function isPublicOnDemandBootstrapRequest(req) {
-  const key = publicSingleKeyBootstrapRequestKey(req);
-  return key !== null && ON_DEMAND_KEYS.has(key);
-}
-
 const BOOTSTRAP_CREDENTIAL_COOKIES = new Set(['wm-session', 'wm-pro-key', 'wm-widget-key']);
 
 function hasBootstrapCredentialCookie(req) {
@@ -417,14 +345,9 @@ async function validateBootstrapAuth(req, cors) {
   const headerKey = getHeaderApiKey(req);
   // The explicit public URL must have one response contract for every request:
   // Vercel may serve it from cache before cookie/header auth reaches this code.
-  if (isPublicTierBootstrapRequest(req)) {
-    return { ok: true, kind: 'public-tier' };
-  }
-  if (isPublicOnDemandBootstrapRequest(req)) {
-    return { ok: true, kind: 'public-on-demand' };
-  }
-  if (isPublicWeatherBootstrapRequest(req)) {
-    return { ok: true, kind: 'public-weather' };
+  const publicBootstrap = classifyPublicBootstrapRequest(req);
+  if (publicBootstrap) {
+    return { ok: true, kind: publicBootstrap.authKind };
   }
   if (!headerKey && !hasBootstrapCredentialCookie(req)) {
     if (isAnonymousWeatherBootstrapRequest(req)) {

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -97,6 +97,7 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     triggerPaths: Object.freeze([
       'workers/api-cors-preflight/**',
       'api/_bootstrap-public-tier.js',
+      'api/_bootstrap-tier-keys.js',
       'tests/cors-preflight-live.test.mjs',
       'tests/helpers/public-bootstrap-contract.mjs',
       '.github/workflows/deploy-worker.yml',

--- a/tests/cors-preflight-live.test.mjs
+++ b/tests/cors-preflight-live.test.mjs
@@ -209,6 +209,47 @@ for (const tier of ['fast', 'slow']) {
   });
 }
 
+const PUBLIC_SINGLE_KEY_PROBES = [
+  ['weather', 'weatherAlerts'],
+  ['on-demand', 'forecasts'],
+];
+
+for (const [label, key] of PUBLIC_SINGLE_KEY_PROBES) {
+  const url = `https://api.worldmonitor.app/api/bootstrap?keys=${key}&public=1`;
+
+  test(`GET marked ${label} bootstrap serves the public header shape through the edge`, { skip: !SHOULD_RUN }, async () => {
+    const resp = await fetch(url, { headers: { Origin: ORIGIN, 'User-Agent': BROWSER_UA } });
+    await resp.arrayBuffer();
+    assert.equal(resp.status, 200, `marked ${label} bootstrap should serve 200; got ${resp.status}`);
+    assertPublicBootstrapCorsHeaders({ assert, resp, label: `marked ${label} bootstrap` });
+    assertPublicBootstrapSharedCacheHeaders({ assert, resp, label: `marked ${label} bootstrap` });
+  });
+
+  test(`OPTIONS marked ${label} bootstrap preflight matches its GET`, { skip: !SHOULD_RUN }, async () => {
+    const resp = await fetch(url, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: ORIGIN,
+        'User-Agent': BROWSER_UA,
+        'Access-Control-Request-Method': 'GET',
+      },
+    });
+    await resp.arrayBuffer();
+    assert.equal(resp.headers.get('access-control-allow-origin'), '*');
+    assert.equal(resp.headers.get('access-control-allow-credentials'), null);
+  });
+}
+
+test('GET marked non-public bootstrap key stays credentialed', { skip: !SHOULD_RUN }, async () => {
+  const resp = await fetch('https://api.worldmonitor.app/api/bootstrap?keys=marketQuotes&public=1', {
+    headers: { Origin: ORIGIN, 'User-Agent': BROWSER_UA },
+  });
+  await resp.arrayBuffer();
+  assert.equal(resp.status, 401);
+  assert.equal(resp.headers.get('access-control-allow-origin'), ORIGIN);
+  assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+});
+
 test('GET /api/story keeps cacheable crawler HTML isolated from browser redirects', { skip: !SHOULD_RUN }, async () => {
   // The unique query string guarantees a cold cache key. Both requests use the
   // exact same URL and run back-to-back from one runner, so a Worker that ignores

--- a/tests/cors-preflight-live.test.mjs
+++ b/tests/cors-preflight-live.test.mjs
@@ -18,9 +18,8 @@
 //     allowed origin → browsers reject as mismatched).
 //   - Worker bypassed entirely (Vercel fallback served instead — would still
 //     pass on healthy days but blow up if/when the Worker is re-enabled).
-//   - The public bootstrap tier served with the credentialed header shape
-//     (#7308) — the origin's own guard cannot see this, because the bytes are
-//     minted at the edge and never pass through api/bootstrap.js.
+//   - Public bootstrap URLs served with the credentialed header shape at the
+//     edge (#7308, #7311), which the origin's own guard cannot see.
 //
 // This test deliberately mirrors what a real browser does for CORS preflight,
 // so a failure here is a strong signal of a real user-facing outage.

--- a/tests/weather-public-bootstrap-url.test.mts
+++ b/tests/weather-public-bootstrap-url.test.mts
@@ -86,13 +86,6 @@ describe('weather bootstrap read targets the public CDN-shielded URL (#5386)', (
   });
 
   it('stays out of the on-demand tier, which would silently steal its cache profile', () => {
-    // api/bootstrap.js checks isPublicOnDemandBootstrapRequest BEFORE
-    // isPublicWeatherBootstrapRequest, and both match the same URL shape. If
-    // weatherAlerts were ever moved into ON_DEMAND_KEY_NAMES, the on-demand
-    // predicate would win and the response would silently inherit the slow-tier
-    // profile (browser max-age=300, CDN s-maxage=7200) instead of the fast one
-    // it is seeded for — a 2-hour edge TTL on a key its relay refreshes every
-    // 15 minutes. Nothing else would fail.
     assert.equal(
       BOOTSTRAP_TIERS[PUBLIC_WEATHER_BOOTSTRAP_KEY], 'fast',
       `${PUBLIC_WEATHER_BOOTSTRAP_KEY} must stay a fast-tier key; moving it to on-demand changes `

--- a/workers/api-cors-preflight/README.md
+++ b/workers/api-cors-preflight/README.md
@@ -73,38 +73,30 @@ function would accept, the browser sees a mismatched origin echo and CORS
 rejects the request. Drift between the two is the load-bearing trap this
 package exists to make visible. Update both files together.
 
-### The public bootstrap tiers are the exception
+### Explicit public bootstrap URLs are the exception
 
-`GET /api/bootstrap?tier=<fast|slow>&public=1` is answered with the **public**
-shape — ACAO `*`, no `Access-Control-Allow-Credentials`, no `Vary: Origin` —
-mirroring `api/bootstrap.js#getPublicBootstrapHeaders()`. The payload is the
-shared seed bundle, identical for every caller, so keying it by Origin costs a
-cache entry per origin and buys nothing, and advertising credentialed access on
-a response no credential can change is what #7308 was filed about. Both edge
-paths use it: the KV-served bytes and the origin pass-through, so the shape does
-not depend on which one answered.
+The origin and Worker share `classifyPublicBootstrapRequest()` for these URLs:
 
-**Scope: the tier URLs only.** `api/bootstrap.js` returns the same public shape
-for three more auth kinds — `?keys=weatherAlerts&public=1` and the marked
-single-key on-demand URLs (`isPublicBootstrapKind`, api/bootstrap.js). Those are
-**not** covered here: the Worker still stamps its credentialed bag over them, so
-they carry `Allow-Credentials: true` and an Origin-echoed ACAO in production
-today. Matching the origin on those needs the `ON_DEMAND_KEYS` /
-`PUBLIC_WEATHER_BOOTSTRAP_KEY` membership sets at the edge (`?keys=markets&public=1`
-is *not* public and must not be widened), which is a larger change than #7308
-asked for and touches genuinely CDN-cached URLs — where the `Vary: Origin` the
-Worker adds really does split the CDN entry per origin. Tracked as #7311; do not
-read this section as "the edge and origin shapes now agree everywhere."
+- `?tier=<fast|slow>&public=1`
+- `?keys=weatherAlerts&public=1`
+- `?keys=<on-demand key>&public=1`
+
+They return ACAO `*`, no `Access-Control-Allow-Credentials`, and no
+`Vary: Origin`. The payload is identical for every caller, so an Origin-specific
+cache entry buys nothing. The single-key classifier reads the generated
+bootstrap registry. A registry change therefore deploys the Worker through
+`api/_bootstrap-tier-keys.js`.
+
+The marker does not make an arbitrary key public. For example,
+`?keys=marketQuotes&public=1` stays credentialed and returns 401 without a key.
+The unmarked `?keys=weatherAlerts` URL also stays outside the edge classifier
+because its origin auth kind depends on attached credentials.
 
 Two deliberate carve-outs inside the exception:
 
-- **A disallowed Origin keeps the credentialed bag — but is still served from
-  KV.** The header denial and the routing decision are separate. Its
-  canonical-fallback ACAO is what denies the browser read (not the origin's 403:
-  the public tier ships `CDN-Cache-Control: public, s-maxage=600`, so a warm CDN
-  entry answers before `isDisallowedOrigin` runs). Routing it off KV would buy
-  nothing — the same caller reads the same bytes by omitting the header — while
-  handing anyone a one-header lever for forcing Vercel/Redis load.
+- **A disallowed Origin keeps the credentialed bag.** For tier URLs, the request
+  still uses KV. Header policy and routing remain separate, so an Origin header
+  cannot force Vercel or Redis work.
 - **The KV-served response stays `Cache-Control: no-store` with no
   `CDN-Cache-Control`.** Rationale lives with the code it explains —
   `src/kv-serve.js#serveFromKv`. The origin fallback for the same URL does sit

--- a/workers/api-cors-preflight/index.test.mjs
+++ b/workers/api-cors-preflight/index.test.mjs
@@ -673,3 +673,58 @@ test('the credentialed bootstrap URL (no public=1) keeps the Origin-echoing shap
     globalThis.fetch = original;
   }
 });
+
+const PUBLIC_SINGLE_KEY_URLS = [
+  ['weather', 'https://api.worldmonitor.app/api/bootstrap?keys=weatherAlerts&public=1'],
+  ['on-demand', 'https://api.worldmonitor.app/api/bootstrap?keys=forecasts&public=1'],
+];
+
+for (const [label, url] of PUBLIC_SINGLE_KEY_URLS) {
+  test(`marked ${label} bootstrap pass-through keeps the public shape`, async () => {
+    const original = globalThis.fetch;
+    globalThis.fetch = async () => new Response('{"data":{},"missing":[]}', {
+      status: 200,
+      headers: {
+        'Cache-Control': 'max-age=300',
+        'CDN-Cache-Control': 'public, s-maxage=600',
+        'Timing-Allow-Origin': '*',
+      },
+    });
+    try {
+      const resp = await worker.fetch(makeRequest('GET', url, { Origin: KNOWN_GOOD }));
+      assertPublicBootstrapCorsHeaders({ assert, resp, label: `${label} pass-through` });
+      assert.equal(resp.headers.get('cdn-cache-control'), 'public, s-maxage=600');
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  test(`marked ${label} bootstrap preflight matches its GET`, async () => {
+    const resp = await worker.fetch(makeRequest('OPTIONS', url, {
+      Origin: KNOWN_GOOD,
+      'Access-Control-Request-Method': 'GET',
+    }));
+    assert.equal(resp.status, 204);
+    assert.equal(resp.headers.get('access-control-allow-origin'), '*');
+    assert.equal(resp.headers.get('access-control-allow-credentials'), null);
+    assert.equal(resp.headers.get('vary'), null);
+  });
+}
+
+test('a marked non-public bootstrap key keeps the credentialed shape', async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = async () => new Response('{"error":"Invalid API key"}', { status: 401 });
+  try {
+    const resp = await worker.fetch(makeRequest(
+      'GET',
+      'https://api.worldmonitor.app/api/bootstrap?keys=marketQuotes&public=1',
+      { Origin: KNOWN_GOOD },
+    ));
+    assert.equal(resp.status, 401);
+    assert.equal(resp.headers.get('access-control-allow-origin'), KNOWN_GOOD);
+    assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+    assert.match(resp.headers.get('vary') || '', /Origin/i);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -17,7 +17,10 @@
 //      ~/.claude/skills/worldmonitor-architecture-gotchas/reference/
 //        cloudflare-worker-overrides-vercel-cors-for-preflight.md
 
-import { bootstrapTierFromPublicRequest, bootstrapTierFromPublicUrl } from '../../../api/_bootstrap-public-tier.js';
+import {
+  classifyPublicBootstrapRequest,
+  classifyPublicBootstrapUrl,
+} from '../../../api/_bootstrap-public-tier.js';
 import { maybeShadowKvRead } from './kv-shadow.js';
 import { maybeServeBootstrapFromKv } from './kv-serve.js';
 
@@ -231,7 +234,7 @@ function buildPublicBootstrapCorsHeaders() {
  * disallowed Origin, whose echo is load-bearing for observing origin_403 (#6411).
  */
 function preflightsPublicBootstrapShape(request, url, origin) {
-  if (bootstrapTierFromPublicUrl(url) === null) return false;
+  if (classifyPublicBootstrapUrl(url) === null) return false;
   if ((request.headers.get('Access-Control-Request-Method') || '').toUpperCase() !== 'GET') return false;
   return !origin || isAllowedOrigin(origin);
 }
@@ -378,17 +381,12 @@ export default {
       return new Response(null, { status: 204, headers });
     }
 
-    // `?tier=<fast|slow>&public=1` is answered by api/bootstrap.js with the public shape, so the
-    // edge reproduces it on BOTH paths (#7308). One CORS shape for one URL: the KV-served bytes and
-    // the origin fallback answer the same request, and a response whose CORS shape depends on which
-    // path won the hedge is the harder thing to reason about, not the safer one. A fixed bag rather
-    // than a status-dependent builder — public is public at every status here.
-    //
     // Scoped to CORS on purpose. The browser CACHE directive still differs by path (KV `no-store`,
     // origin `TIER_CACHE[tier]`) and that is deliberate, for reasons that belong to the KV path
     // rather than this one — see kv-serve.js#serveFromKv. Do not read this as a caching invariant.
-    const publicTier = bootstrapTierFromPublicRequest(request, url);
-    const publicBootstrapShape = publicTier !== null && (!origin || isAllowedOrigin(origin));
+    const publicBootstrap = classifyPublicBootstrapRequest(request, url);
+    const publicBootstrapShape = publicBootstrap !== null && (!origin || isAllowedOrigin(origin));
+    const publicTier = publicBootstrap?.authKind === 'public-tier' ? publicBootstrap.tier : null;
     const corsPolicy = publicBootstrapShape
       ? buildPublicBootstrapCorsHeaders()
       : (status) => buildResponseCorsHeaders(origin, status);


### PR DESCRIPTION
## Summary

Marked weather and on-demand bootstrap reads now keep the same public CORS contract at the Cloudflare edge that the Vercel origin already emits. Before this change, the Worker replaced `Access-Control-Allow-Origin: *` with the credentialed origin echo, added `Access-Control-Allow-Credentials: true`, and split CDN entries with `Vary: Origin`.

The edge and origin now use one exact registry-backed URL classifier. It accepts only the fixed public tier shape, `weatherAlerts`, and one registered on-demand key. Arbitrary marked keys such as `marketQuotes` stay credentialed.

Related: #7311

## Validation

- Regression proof before the fix had four expected Worker failures for weather and forecasts GET and preflight headers.
- Worker suite passed with 69 tests.
- Bootstrap auth suite passed with 47 tests.
- Focused weather, embed, and on-demand suites passed with 10 tests.
- Post-merge deploy monitor suite passed with 41 tests.
- Full data suite passed with 27,732 tests, 32 skipped tests, and no failures.
- Browser and API typechecks, import boundaries, lint, Biome, and the Wrangler dry-run passed.
- The repository pre-push gate passed.

Production behavior is not yet accepted. The Worker must deploy after merge.

## Post-Deploy Monitoring and Validation

- Watch `Deploy api-cors-preflight Worker` for the merge SHA.
- Require the workflow live-smoke job to pass after Worker propagation.
- Verify `weatherAlerts&public=1` and `forecasts&public=1` return 200 with `Access-Control-Allow-Origin: *`, no `Access-Control-Allow-Credentials`, no `Vary: Origin`, and the shared-cache headers.
- Verify `marketQuotes&public=1` remains 401 with the credentialed CORS shape.
- Treat an echoed origin or credentials on a public probe, or wildcard CORS on `marketQuotes`, as rollback signals.
- Roll back by reverting this change or deploying the previous Worker version.
- Keep #7311 open until the deployed live smoke passes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)