### PR TITLE
chore(bundle): re-baseline the dashboard budget snapshot (unblocks main)

### DIFF
--- a/scripts/shared/bundle-budgets.json
+++ b/scripts/shared/bundle-budgets.json
@@ -7,11 +7,11 @@
   "totalTolerancePct": 0.25,
   "totalToleranceBytes": 16384,
   "total": {
-    "raw": 1603179
+    "raw": 1620037
   },
   "chunks": {
     "analytics": {
-      "raw": 118604,
+      "raw": 119361,
       "files": 1
     },
     "cached-risk-scores": {
@@ -19,7 +19,7 @@
       "files": 1
     },
     "clerk": {
-      "raw": 16727,
+      "raw": 18223,
       "files": 1
     },
     "continuous": {
@@ -59,11 +59,11 @@
       "files": 1
     },
     "main": {
-      "raw": 855123,
+      "raw": 869445,
       "files": 1
     },
     "panel-gating": {
-      "raw": 2849,
+      "raw": 3132,
       "files": 1
     },
     "panels": {


### PR DESCRIPTION
Unblocks `main`, which `bundle:check` has been failing on.

## Measured before re-baselining

Built each commit in turn rather than reflexively raising the number:

| Commit | Initial payload | `bundle:check` |
|---|---|---|
| `d1b9d117` (before #7358) | 1581.3 KB | **OK** — 15.7 of 16.0 KB drift already used |
| `8a175422` (#7358) | 1582.1 KB | **FAILED** at 16.5 KB |
| `15548d1c` (current main) | 1582.1 KB | FAILED |

The tolerance was **already 98% consumed** and #7358 added 0.8 KB. This is cumulative drift across many merges against a snapshot that has not been regenerated since #7111 seeded it — not one feature's fault. The growth is shipped, intended work, which is exactly the case `npm run bundle:budgets` exists for.

Snapshot moves **1603179 → 1620037 bytes**: main +14.3 KB, clerk +1.5 KB, analytics +757 B, panel-gating +283 B.

## Regenerated the way the tool asks

The seeder warns that a build carrying `.env`/`.env.local` will not match CI. I moved both aside and rebuilt (`build:pro` then the dashboard build, mirroring the CI step order). The clean build produced the **identical** 1582.1 KB, confirming the env files were not affecting this surface — but the snapshot was seeded from the clean build regardless.

All three surfaces pass after: dashboard, pro, embed.

## Known gap this does not fix

Every PR measures against the **committed snapshot**, not post-merge main. So each PR is green while main drifts — which is how #7358 passed CI and main failed minutes later. **This is the second time it has happened today.**

Re-baselining buys back headroom but doesn't change that dynamic. Worth either re-baselining on a schedule, or gating against the merge base so a PR sees what it will actually land on top of. I have not done either here — flagging it rather than silently widening the tolerance again.
