### PR TITLE
feat(passkeys): offer to returning sessions, suppressed by account-scoped state

### DIFF
--- a/src/app/passkey-offer-boot.ts
+++ b/src/app/passkey-offer-boot.ts
@@ -1,33 +1,113 @@
 import type { AppContext, AppModule } from '@/app/app-context';
 import { subscribeAuthState } from '@/services/auth-state';
 import { getClerk } from '@/services/clerk';
+import {
+  createOfferMemory,
+  derivePasskeyAccountKey,
+  hasAccountOfferRecord,
+  hasBeenOffered,
+  type OfferMemory,
+  type OfferStorage,
+  safeLocalStorage,
+} from '@/services/passkey-offer-state';
 import { recordPasskeyOfferReason } from '@/utils/passkey-offer-trace';
 
 /**
  * Eager shim that keeps the passkey offer OUT of the first-paint bundle.
  *
- * The offer cannot fire until someone signs in, and the overwhelming majority
- * of page loads never do — yet a static import pulled the controller, the
- * prompt component, and the passkey services into the `main` chunk, costing
- * ~12 KB on every first paint. This module is the small part that must be
- * eager; everything else loads on demand.
+ * A static import pulled the controller, the prompt component, and the passkey
+ * services into the `main` chunk, costing ~12 KB on every first paint. This
+ * module is the small part that must be eager; everything else loads on demand.
  *
- * Two things have to stay eager for the feature to remain correct:
- *
- *   1. **The arming observation.** The detector may only arm on an
- *      authoritative signed-out state (Clerk loaded, no session). If we waited
- *      for an idle callback to subscribe, a user who signs in quickly would be
- *      seen as already-signed-in with no prior signed-out observation, and
- *      would never be offered. Subscribing here costs one listener.
- *   2. **Nothing else.** The moment a signed-in transition arrives on an armed
- *      shim, the real controller is imported and takes over permanently.
- *
- * The handoff replays the transition: `subscribeAuthState` fires the callback
- * immediately on subscribe, so the controller sees the current session as soon
- * as it attaches and evaluates it the same way it would have live.
+ * It also owns the reach decision, because that decision is what determines
+ * whether the chunk is worth fetching at all.
  */
+
+// ---------------------------------------------------------------------------
+// The load decision (pure, testable)
+// ---------------------------------------------------------------------------
+
+/** Everything the decision reads, resolved by the caller. */
+export interface BootDecisionInput {
+  /** Has the Clerk SDK loaded? A user-null reading is meaningless without it. */
+  clerkLoaded: boolean;
+  accountKey: string | null;
+  /** An authoritative signed-out state was seen earlier this page life. */
+  armed: boolean;
+  existingPasskeyCount: number;
+  /** Durable, account-scoped, server-backed. */
+  offeredOnAccount: boolean;
+  /** Local, origin-scoped, best effort. */
+  offeredLocally: boolean;
+}
+
+/**
+ * What the shim does with one auth emission.
+ *
+ * The two `load-*` members differ only in how the user arrived; both hand off
+ * to the same controller. Keeping them distinct is what makes the trace able to
+ * answer "was this a fresh sign-in or a returning session?" without a second
+ * signal.
+ */
+export type BootDecision =
+  | 'clerk-absent'
+  | 'signed-out-observed'
+  | 'already-has-passkey'
+  | 'already-offered-account'
+  | 'already-offered'
+  | 'load-sign-in'
+  | 'load-returning-session';
+
+/** Whether a decision means "fetch the controller chunk". */
+export function decisionLoads(decision: BootDecision): boolean {
+  return decision === 'load-sign-in' || decision === 'load-returning-session';
+}
+
+/**
+ * Decide from injected facts alone.
+ *
+ * Ordering is behavioural. Every suppression runs BEFORE either load branch, so
+ * a user who already has a passkey, or who has already been asked on any
+ * device, never pays for the dynamic import. That is what keeps the first-paint
+ * saving intact now that returning sessions are eligible: the chunk is fetched
+ * only for someone who is actually about to be offered.
+ *
+ * The durable check precedes the local one because it is the authoritative
+ * answer; the local tiers exist to answer the same question without a network
+ * round trip, not to overrule it.
+ */
+export function decideBootAction(input: BootDecisionInput): BootDecision {
+  // A user-null reading while the SDK is absent proves nothing about whether
+  // anyone is signed in, so it must not arm.
+  if (!input.clerkLoaded) return 'clerk-absent';
+  if (input.accountKey === null) return 'signed-out-observed';
+  if (input.existingPasskeyCount > 0) return 'already-has-passkey';
+  if (input.offeredOnAccount) return 'already-offered-account';
+  if (input.offeredLocally) return 'already-offered';
+  return input.armed ? 'load-sign-in' : 'load-returning-session';
+}
+
+// ---------------------------------------------------------------------------
+// The shim
+// ---------------------------------------------------------------------------
+
+/**
+ * A Clerk user, read through the narrow slice this shim needs.
+ *
+ * Deliberately NOT `countPasskeys` from `@/services/passkeys`: importing that
+ * module here would drag the whole passkey service back into the eager chunk
+ * and undo the split this file exists to create.
+ */
+type ShimUser = {
+  id?: string;
+  passkeys?: unknown;
+  unsafeMetadata?: Record<string, unknown> | null;
+} | null;
+
 export class PasskeyOfferBoot implements AppModule {
   private readonly ctx: AppContext;
+  private readonly storage: OfferStorage | null = safeLocalStorage();
+  private readonly memory: OfferMemory = createOfferMemory();
   private unsubscribe: (() => void) | null = null;
   /** An authoritative signed-out state has been observed this page life. */
   private armed = false;
@@ -40,6 +120,10 @@ export class PasskeyOfferBoot implements AppModule {
   }
 
   init(): void {
+    // Eagerly, not on idle: a user who signs in quickly would otherwise be seen
+    // as already-signed-in with no prior signed-out observation. That still
+    // yields an offer now, but it would be recorded as a returning session and
+    // arrive a beat later than the sign-in it belongs to.
     this.unsubscribe = subscribeAuthState(() => this.onAuthChange());
   }
 
@@ -53,24 +137,24 @@ export class PasskeyOfferBoot implements AppModule {
 
   private onAuthChange(): void {
     if (this.real || this.loading || this.destroyed) return;
-    const clerk = getClerk() as { user?: { id?: string } | null } | null;
-    // Clerk absent means the SDK has not loaded (or failed to). A user-null
-    // reading then proves nothing about whether anyone is signed in, so it must
-    // not arm — see the controller's own KTD3c note.
-    if (!clerk) { recordPasskeyOfferReason('clerk-absent'); return; }
-    if (!clerk.user?.id) {
-      this.armed = true;
-      recordPasskeyOfferReason('signed-out-observed');
-      return;
-    }
-    // Signed in, and we saw them signed out first: this is a real sign-in, so
-    // the offer is now plausible and the real controller is worth its bytes.
-    if (this.armed) { void this.load(); return; }
-    // Signed in with no prior signed-out observation — a cold cookie
-    // hydration. This is the branch that is otherwise completely invisible:
-    // the controller never loads, so controller-side instrumentation can never
-    // report it.
-    recordPasskeyOfferReason('cold-hydration-suppressed');
+    const user = (getClerk() as { user?: ShimUser } | null)?.user ?? null;
+    const accountKey = derivePasskeyAccountKey(user?.id ?? null);
+    const passkeys = user?.passkeys;
+
+    const decision = decideBootAction({
+      clerkLoaded: getClerk() !== null,
+      accountKey,
+      armed: this.armed,
+      existingPasskeyCount: Array.isArray(passkeys) ? passkeys.length : 0,
+      offeredOnAccount: hasAccountOfferRecord(user),
+      // NOT gated on a non-null handle: when localStorage throws on access
+      // `storage` is null, and gating here would discard the in-memory tier.
+      offeredLocally: hasBeenOffered(this.storage, this.memory, accountKey),
+    });
+
+    recordPasskeyOfferReason(decision);
+    if (decision === 'signed-out-observed') this.armed = true;
+    if (decisionLoads(decision)) void this.load();
   }
 
   private async load(): Promise<void> {
@@ -83,6 +167,9 @@ export class PasskeyOfferBoot implements AppModule {
       // on the same emission.
       this.unsubscribe?.();
       this.unsubscribe = null;
+      // The shim already ran every gate the controller's arming guard exists to
+      // enforce, so re-deriving it there would drop the very offer this handoff
+      // delivers.
       const controller = new PasskeyOfferController(this.ctx, { preArmed: true });
       this.real = controller;
       controller.init();

--- a/src/app/passkey-offer-controller.ts
+++ b/src/app/passkey-offer-controller.ts
@@ -10,12 +10,16 @@ import {
 import { subscribeAuthState } from '@/services/auth-state';
 import { getClerk } from '@/services/clerk';
 import {
+  type AccountOfferWriter,
   createOfferMemory,
   derivePasskeyAccountKey,
+  hasAccountOfferRecord,
   hasBeenOffered,
   type OfferMemory,
   type OfferStorage,
+  recordAccountOffer,
   recordOffered,
+  safeLocalStorage,
   shouldOfferPasskey,
 } from '@/services/passkey-offer-state';
 import {
@@ -191,15 +195,18 @@ export class PasskeyOfferController implements AppModule {
   private observedBanner: Element | null = null;
 
   /**
-   * Whether an authoritative signed-out state has been seen this page life.
+   * Whether this controller may evaluate at all.
    *
-   * This is the whole cookie-hydration guard. Auth state starts
-   * `{ user: null, isPending: true }` and becomes a user when an existing
-   * cookie hydrates, so a naive null-to-user detector fires on EVERY page load
-   * for an already-signed-in user. And "signed out" must be authoritative:
-   * a failed Clerk SDK load deliberately publishes `{user: null, isPending:
-   * false}` — byte-identical to a real signed-out session — while keeping
-   * subscribers queued for a retry.
+   * It no longer means "a sign-in transition happened". The boot shim decides
+   * reach now, and it hands off for a returning session too, so it constructs
+   * this controller `preArmed`. What remains here is the guard for a controller
+   * constructed directly: an authoritative signed-out state, where "signed out"
+   * must be vouched for by the SDK, because a failed Clerk load deliberately
+   * publishes `{user: null, isPending: false}` — byte-identical to a real
+   * signed-out session — while keeping subscribers queued for a retry.
+   *
+   * Repeat suppression does NOT rest on this flag. It rests on the three ledger
+   * tiers, the durable one of which is account-scoped and server-backed.
    */
   private armed: boolean;
   private prompt: PasskeyOfferPrompt | null = null;
@@ -281,10 +288,15 @@ export class PasskeyOfferController implements AppModule {
       readEnvironment: () => readPasskeyEnvironmentFacts(this.ctx.isDesktopApp),
       readIdentity: () => this.readIdentity(),
       passkeyCount: () => countPasskeys(getClerk()?.user as { passkeys?: unknown } | null),
+      // All three tiers. The durable one is checked here as well as in the boot
+      // shim because the controller can be constructed directly, and because a
+      // sibling device may have written it after this page loaded.
       // NOT gated on a non-null handle: when localStorage throws on access
       // `storage` is null, and gating here would discard the in-memory tier
       // that is the entire fallback (KTD3d).
-      alreadyOffered: (key) => hasBeenOffered(this.storage, this.memory, key),
+      alreadyOffered: (key) =>
+        hasAccountOfferRecord(getClerk()?.user as AccountOfferWriter | null)
+        || hasBeenOffered(this.storage, this.memory, key),
       platformAuthenticator: () => hasPlatformAuthenticator(),
       blockedByOverlay: () => this.blockedByOverlay(),
       deferFrame: () => new Promise<void>((resolve) => this.scheduleFrame(() => resolve())),
@@ -330,6 +342,11 @@ export class PasskeyOfferController implements AppModule {
     // The offer is spent at MOUNT, not at answer — otherwise closing the tab
     // with the card open earns a second offer.
     recordOffered(this.storage, this.memory, identity.accountKey);
+    // Not awaited: the local tiers above already suppress the repeat on this
+    // browser, so the card must not wait on a network write to appear. The
+    // durable tier is what carries the suppression to the user's other devices
+    // and to a browser that cannot keep localStorage at all.
+    void recordAccountOffer(getClerk()?.user as AccountOfferWriter | null);
     this.broadcastMounted(identity.accountKey);
     trackPasskeyOfferShown();
   }
@@ -512,15 +529,6 @@ export class PasskeyOfferController implements AppModule {
   private broadcastMounted(accountKey: string | null): void {
     if (!accountKey) return;
     try { this.channel?.postMessage({ accountKey }); } catch { /* channel closed */ }
-  }
-}
-
-/** `localStorage` when reachable. Null in private modes that throw on access. */
-function safeLocalStorage(): OfferStorage | null {
-  try {
-    return typeof localStorage !== 'undefined' ? localStorage : null;
-  } catch {
-    return null;
   }
 }
 

--- a/src/services/passkey-offer-state.ts
+++ b/src/services/passkey-offer-state.ts
@@ -14,9 +14,17 @@
  *   - Two tabs can both read an empty ledger and mount. A read-then-write is
  *     not an atomic claim.
  *
- * A true account-wide guarantee needs server-backed state, which would put a
- * write on the sign-in path for a cosmetic property of a prompt. Deliberately
- * not done.
+ * Those limits are why a THIRD tier exists below. `hasAccountOfferRecord` and
+ * `recordAccountOffer` keep the flag on the Clerk user itself, which is
+ * account-scoped and server-backed and therefore immune to all three.
+ * Production forced this. The offer only ever fired on a sign-in transition, so
+ * the whole already-signed-in population was never asked, and relaxing that
+ * guard is only safe once "already offered" survives a browser with storage
+ * disabled.
+ *
+ * The local tiers are not redundant with it. They answer synchronously, before
+ * any network read, which is what lets the eager boot shim skip its dynamic
+ * import outright on the common repeat visit.
  *
  * Every decision here is pure and every storage handle is injected, so the
  * tests need no jsdom and no globals.
@@ -143,6 +151,75 @@ function parseOfferRecord(raw: string): { at: number } | null {
     if (!parsed || typeof parsed !== 'object') return null;
     const at = (parsed as { at?: unknown }).at;
     return typeof at === 'number' && Number.isFinite(at) ? { at } : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The durable tier: account-scoped state on the Clerk user
+// ---------------------------------------------------------------------------
+
+/**
+ * Where the durable record lives inside `user.unsafeMetadata`.
+ *
+ * `unsafeMetadata` is user-writable by design, which is right for a cosmetic
+ * "we already asked" flag and wrong for anything security bearing. Forging it
+ * can only suppress an offer for the forger.
+ */
+export const ACCOUNT_OFFER_METADATA_KEY = 'wmPasskeyOfferedAt';
+
+/** The read side of the Clerk user this module touches. */
+export interface AccountOfferReader {
+  unsafeMetadata?: Record<string, unknown> | null;
+}
+
+/** The write side. Clerk's `User.update` resolves once the patch is persisted. */
+export interface AccountOfferWriter extends AccountOfferReader {
+  update?: (params: { unsafeMetadata: Record<string, unknown> }) => Promise<unknown>;
+}
+
+/** Whether this account has been offered on ANY device or origin. */
+export function hasAccountOfferRecord(user: AccountOfferReader | null | undefined): boolean {
+  const at = user?.unsafeMetadata?.[ACCOUNT_OFFER_METADATA_KEY];
+  return typeof at === 'number' && Number.isFinite(at) && at > 0;
+}
+
+/**
+ * Persist the durable record. Resolves to whether it actually landed.
+ *
+ * The spread is load bearing. Clerk REPLACES `unsafeMetadata` wholesale rather
+ * than merging, so writing a bare `{ [KEY]: ... }` would silently delete every
+ * other key the app or a future feature keeps there.
+ *
+ * Never throws and never rejects. This runs at mount, and a failed metadata
+ * write must not break a prompt already on screen. The local tiers still
+ * suppress the repeat on this browser, which is the pre-existing behaviour
+ * rather than a regression.
+ */
+export async function recordAccountOffer(user: AccountOfferWriter | null | undefined): Promise<boolean> {
+  if (!user || typeof user.update !== 'function') return false;
+  if (hasAccountOfferRecord(user)) return true;
+  try {
+    await user.update({
+      unsafeMetadata: { ...(user.unsafeMetadata ?? {}), [ACCOUNT_OFFER_METADATA_KEY]: Date.now() },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * `localStorage` when reachable, null in private modes that throw on ACCESS.
+ *
+ * Shared by the eager boot shim and the controller so both consult the same
+ * handle. Two independent helpers would be free to diverge on which failure
+ * modes degrade to null.
+ */
+export function safeLocalStorage(): OfferStorage | null {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
   } catch {
     return null;
   }

--- a/src/utils/passkey-offer-trace.ts
+++ b/src/utils/passkey-offer-trace.ts
@@ -32,14 +32,23 @@
 /**
  * Every reason the offer can reach a decision, and nothing else.
  *
- * The first five are the eager shim's; the rest mirror
- * `PasskeyEvaluationResult` in the controller.
+ * The first block is the eager shim's `BootDecision`; the rest mirror
+ * `PasskeyEvaluationResult` in the controller. Both halves pass their result
+ * straight to `recordPasskeyOfferReason`, whose parameter is this type, so
+ * adding a decision without a vocabulary entry fails typecheck at that call
+ * rather than silently recording nothing.
+ *
+ * `already-has-passkey` and `already-offered` are shared by both halves on
+ * purpose. The shim now checks them too, cheaply, so it can skip its dynamic
+ * import entirely rather than paying for a chunk that only bails out.
  */
 export const PASSKEY_OFFER_REASONS = [
   // Boot shim
   'clerk-absent',
   'signed-out-observed',
-  'cold-hydration-suppressed',
+  'already-offered-account',
+  'load-sign-in',
+  'load-returning-session',
   'import-started',
   'import-failed',
   // Controller evaluation

--- a/tests/dom/passkey-offer-boot.test.mts
+++ b/tests/dom/passkey-offer-boot.test.mts
@@ -6,24 +6,37 @@
  * But deferring it introduces exactly one way to break the feature silently —
  * losing the arming observation.
  *
- * The detector may only arm on an AUTHORITATIVE signed-out state (Clerk loaded,
- * no session). So the shim must subscribe eagerly, not on idle: a user who
- * signs in quickly would otherwise be seen as already-signed-in with no prior
- * signed-out reading, and would never be offered. These tests pin that, plus
- * the two states that must NOT arm.
+ * The shim also owns the reach decision, because that decision determines
+ * whether the chunk is worth fetching at all. It hands off both for a fresh
+ * sign-in and for a returning session, and runs every suppression BEFORE either
+ * one so a user who is not going to be offered never pays for the import.
+ *
+ * These tests pin that ordering, the three suppression tiers, and the states
+ * that must not arm.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let authListener: (() => void) | null = null;
-const state = { clerkLoaded: true, userId: null as string | null };
+const state = {
+  clerkLoaded: true,
+  userId: null as string | null,
+  passkeys: [] as unknown[],
+  unsafeMetadata: {} as Record<string, unknown>,
+};
 
 vi.mock('@/services/auth-state', () => ({
   subscribeAuthState: (cb: () => void) => { authListener = cb; return () => { authListener = null; }; },
 }));
 
 vi.mock('@/services/clerk', () => ({
-  getClerk: () => (state.clerkLoaded ? { user: state.userId ? { id: state.userId } : null } : null),
+  getClerk: () => (state.clerkLoaded
+    ? {
+        user: state.userId
+          ? { id: state.userId, passkeys: state.passkeys, unsafeMetadata: state.unsafeMetadata }
+          : null,
+      }
+    : null),
 }));
 
 const loaded = { count: 0, preArmed: [] as (boolean | undefined)[], destroyed: 0, inited: 0 };
@@ -41,6 +54,7 @@ vi.mock('@/app/passkey-offer-controller', () => ({
 
 import type { AppContext } from '@/app/app-context';
 import { PasskeyOfferBoot } from '@/app/passkey-offer-boot';
+import { derivePasskeyAccountKey, passkeyOfferStorageKey } from '@/services/passkey-offer-state';
 import { getPasskeyOfferTrace, resetPasskeyOfferTrace } from '@/utils/passkey-offer-trace';
 
 const ctx = { isDesktopApp: false } as unknown as AppContext;
@@ -50,6 +64,9 @@ beforeEach(() => {
   authListener = null;
   state.clerkLoaded = true;
   state.userId = null;
+  state.passkeys = [];
+  state.unsafeMetadata = {};
+  localStorage.clear();
   loaded.count = 0;
   loaded.preArmed = [];
   loaded.destroyed = 0;
@@ -94,22 +111,75 @@ describe('PasskeyOfferBoot', () => {
     boot.destroy();
   });
 
-  it('does NOT hand off on a cold cookie hydration', async () => {
-    // No signed-out state was ever observed — this is a page load completing,
-    // not a sign-in, and is the case that would otherwise prompt every visit.
+  it('DOES hand off for a returning session that has never been offered', async () => {
+    // The production regression. This user is already signed in on page load,
+    // so no signed-out state is ever observed. Under the old arming guard the
+    // shim stopped here and the entire already-signed-in population was never
+    // asked; the live trace read
+    // ['clerk-absent', 'cold-hydration-suppressed' x3].
     const boot = new PasskeyOfferBoot(ctx);
     state.userId = 'user_abc';
     boot.init();
     authListener?.();
     await flush();
+
+    expect(loaded.count).toBe(1);
+    expect(loaded.preArmed).toEqual([true]);
+    boot.destroy();
+  });
+
+  it('does NOT hand off when the account already carries the durable record', async () => {
+    // Server-backed suppression is what makes reaching returning sessions safe:
+    // it survives a browser that cannot keep localStorage, where the local
+    // tiers would re-offer on every single load.
+    const boot = new PasskeyOfferBoot(ctx);
+    state.userId = 'user_abc';
+    state.unsafeMetadata = { wmPasskeyOfferedAt: 1_700_000_000_000 };
+    boot.init();
+    authListener?.();
+    await flush();
+
     expect(loaded.count).toBe(0);
+    expect(getPasskeyOfferTrace()).toContain('already-offered-account');
+    boot.destroy();
+  });
+
+  it('does NOT pay for the import when the user already has a passkey', async () => {
+    // The check is in the shim rather than the controller so this user never
+    // fetches a ~12 KB chunk that would only bail out.
+    const boot = new PasskeyOfferBoot(ctx);
+    state.userId = 'user_abc';
+    state.passkeys = [{ id: 'pk_1' }];
+    boot.init();
+    authListener?.();
+    await flush();
+
+    expect(loaded.count).toBe(0);
+    expect(getPasskeyOfferTrace()).toContain('already-has-passkey');
+    boot.destroy();
+  });
+
+  it('does NOT hand off when the local ledger already holds the account', async () => {
+    const boot = new PasskeyOfferBoot(ctx);
+    state.userId = 'user_abc';
+    localStorage.setItem(
+      passkeyOfferStorageKey(derivePasskeyAccountKey('user_abc') as string),
+      JSON.stringify({ at: Date.now() }),
+    );
+    boot.init();
+    authListener?.();
+    await flush();
+
+    expect(loaded.count).toBe(0);
+    expect(getPasskeyOfferTrace()).toContain('already-offered');
     boot.destroy();
   });
 
   it('does NOT arm on a user-null reading while Clerk is absent', async () => {
     // A failed SDK load publishes a user-null state indistinguishable from a
-    // real signed-out session. Arming on it would fire the offer when the
-    // retry hydrates an existing cookie.
+    // real signed-out session. The retry that hydrates an existing cookie is a
+    // returning session, not a sign-in, and must be recorded as one — arming
+    // here would misattribute every Clerk load failure as a fresh sign-in.
     const boot = new PasskeyOfferBoot(ctx);
     boot.init();
     state.clerkLoaded = false;
@@ -118,7 +188,12 @@ describe('PasskeyOfferBoot', () => {
     state.userId = 'user_abc';
     authListener?.();            // retry succeeds and hydrates the cookie
     await flush();
-    expect(loaded.count).toBe(0);
+
+    expect(getPasskeyOfferTrace()).toEqual([
+      'clerk-absent',
+      'load-returning-session',
+      'import-started',
+    ]);
     boot.destroy();
   });
 
@@ -156,17 +231,16 @@ describe('PasskeyOfferBoot', () => {
 });
 
 describe('diagnostic trace', () => {
-  it('records the cold-hydration suppression that is otherwise invisible', async () => {
-    // This is the whole reason the trace lives in the shim: the controller
-    // never loads on this path, so controller-side instrumentation could never
-    // report it, and the only prior diagnosis was inference from a snapshot.
+  it('distinguishes a returning session from a fresh sign-in', async () => {
+    // The trace lives in the shim because on a suppressed path the controller
+    // never loads, so controller-side instrumentation could never report it.
+    // These two reasons are what let a live trace answer HOW the user arrived.
     const boot = new PasskeyOfferBoot(ctx);
     state.userId = 'user_abc';
     boot.init();
     authListener?.();
     await flush();
-    expect(getPasskeyOfferTrace()).toContain('cold-hydration-suppressed');
-    expect(loaded.count).toBe(0);
+    expect(getPasskeyOfferTrace()).toEqual(['load-returning-session', 'import-started']);
     boot.destroy();
   });
 
@@ -177,7 +251,7 @@ describe('diagnostic trace', () => {
     state.userId = 'user_abc';
     authListener?.();
     await flush();
-    expect(getPasskeyOfferTrace()).toEqual(['signed-out-observed', 'import-started']);
+    expect(getPasskeyOfferTrace()).toEqual(['signed-out-observed', 'load-sign-in', 'import-started']);
     boot.destroy();
   });
 

--- a/tests/passkey-offer-state.test.mts
+++ b/tests/passkey-offer-state.test.mts
@@ -20,10 +20,13 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  ACCOUNT_OFFER_METADATA_KEY,
   createOfferMemory,
   derivePasskeyAccountKey,
+  hasAccountOfferRecord,
   hasBeenOffered,
   passkeyOfferStorageKey,
+  recordAccountOffer,
   recordOffered,
   shouldOfferPasskey,
 } from '../src/services/passkey-offer-state.ts';
@@ -209,5 +212,63 @@ describe('shouldOfferPasskey', () => {
 
   it('does not offer when a ledger record exists, even with zero passkeys (AE6)', () => {
     assert.equal(shouldOfferPasskey({ ...OFFERABLE, alreadyOffered: true }), false);
+  });
+});
+
+describe('the durable account tier', () => {
+  it('reads a record written on any device', () => {
+    assert.equal(hasAccountOfferRecord({ unsafeMetadata: { [ACCOUNT_OFFER_METADATA_KEY]: 1 } }), true);
+  });
+
+  it('treats a missing, null, or non-numeric value as not offered', () => {
+    assert.equal(hasAccountOfferRecord(null), false);
+    assert.equal(hasAccountOfferRecord({}), false);
+    assert.equal(hasAccountOfferRecord({ unsafeMetadata: null }), false);
+    assert.equal(hasAccountOfferRecord({ unsafeMetadata: {} }), false);
+    assert.equal(hasAccountOfferRecord({ unsafeMetadata: { [ACCOUNT_OFFER_METADATA_KEY]: 'yes' } }), false);
+    assert.equal(hasAccountOfferRecord({ unsafeMetadata: { [ACCOUNT_OFFER_METADATA_KEY]: 0 } }), false);
+  });
+
+  it('PRESERVES every other unsafeMetadata key when writing', async () => {
+    // Clerk REPLACES unsafeMetadata wholesale rather than merging it, so a bare
+    // `{ [KEY]: ... }` patch would silently delete everything else the app
+    // keeps there. Nothing else in the suite would notice.
+    let patch: Record<string, unknown> | null = null;
+    const user = {
+      unsafeMetadata: { theme: 'dark', onboardingStep: 3 },
+      update: async (params: { unsafeMetadata: Record<string, unknown> }) => {
+        patch = params.unsafeMetadata;
+      },
+    };
+
+    assert.equal(await recordAccountOffer(user), true);
+    assert.equal(patch!.theme, 'dark');
+    assert.equal(patch!.onboardingStep, 3);
+    assert.equal(typeof patch![ACCOUNT_OFFER_METADATA_KEY], 'number');
+  });
+
+  it('resolves false rather than throwing when the write rejects', async () => {
+    // This runs at mount. A rejected metadata write must not break a prompt
+    // that is already on screen; the local tiers still suppress the repeat.
+    const user = {
+      unsafeMetadata: {},
+      update: async () => { throw new Error('network'); },
+    };
+    assert.equal(await recordAccountOffer(user), false);
+  });
+
+  it('resolves false when there is no user or no update method', async () => {
+    assert.equal(await recordAccountOffer(null), false);
+    assert.equal(await recordAccountOffer({ unsafeMetadata: {} }), false);
+  });
+
+  it('does not re-write a record that already exists', async () => {
+    let calls = 0;
+    const user = {
+      unsafeMetadata: { [ACCOUNT_OFFER_METADATA_KEY]: 42 },
+      update: async () => { calls += 1; },
+    };
+    assert.equal(await recordAccountOffer(user), true);
+    assert.equal(calls, 0);
   });
 });


### PR DESCRIPTION
The passkey offer shipped in #7353/#7355 and then reached nobody. It only ever fired on a sign-in *transition*, so the entire already-signed-in population was never asked.

## The evidence

The trace added in #7358 answered it in one read on production:

```js
window.__wmPasskeyOffer
// { trace: ["clerk-absent", "cold-hydration-suppressed",
//           "cold-hydration-suppressed", "cold-hydration-suppressed"],
//   last: "cold-hydration-suppressed" }
```

`signed-out-observed` never appears. The user was already signed in when the page loaded, the shim never armed, and the controller never even downloaded. This is what the instrumentation was built for; the previous diagnosis attempt was inference from a later snapshot, which is not proof.

## Why this is not just "delete the arming guard"

That exact proposal was reviewed and rejected earlier, correctly. It rested on the localStorage ledger being a robust once-per-account cap. It is not: it is origin-scoped and best effort, so it is defeated by private browsing, storage eviction, and the variant subdomains. On a browser with storage disabled a relaxed guard re-offers on **every page load**. The arming guard was a real second anti-nag layer, not redundancy.

So the guard can only be relaxed once something durable replaces it.

## The durable tier

`recordAccountOffer` writes `wmPasskeyOfferedAt` into Clerk's `user.unsafeMetadata`, which is account-scoped and server-backed. It survives private browsing, eviction, a second device, and every variant subdomain.

Verified against the **served** SDK rather than `node_modules`, because `vite.config.ts` strips the range prefix off `^6.13.0` and production therefore runs 6.13.0, not the lockfile's 6.25.6:

```
GET https://clerk.worldmonitor.app/npm/@clerk/clerk-js@6.13.0/dist/clerk.browser.js  200, 274,083 bytes

async update(e){ ... let t={...e, unsafeMetadata: e.unsafeMetadata ? r5(e.unsafeMetadata) : void 0}; ... }
```

`unsafeMetadata` is user-writable by design. That is right for a cosmetic "we already asked" flag and would be wrong for anything security bearing. Forging it can only suppress an offer for the forger.

The write is not awaited. The local tiers already suppress the repeat on this browser, so the card must not wait on a network round trip to appear, and a failed write must not break a prompt already on screen.

## The bundle saving survives

Reaching returning sessions means far more page loads are now candidates, which would normally undo #7355's ~12 KB first-paint split.

It does not, because the shim now runs **every suppression before either load branch**. `decideBootAction` is one pure function over injected facts, and the passkey-count and durable-record checks both read the already-hydrated `clerk.user`, costing nothing. The chunk is fetched only for a user who is actually about to be offered, which happens once per account ever.

The shim deliberately does not import `countPasskeys` from `@/services/passkeys`; that would drag the whole passkey service back into the eager chunk and undo the split this file exists to create.

`bundle:check` **OK**, 1590.8 KB against a 1589.0 KB snapshot, built with `.env`/`.env.local` moved outside the worktree so the measurement matches CI.

## The landmine, and the test that pins it

Clerk **replaces** `unsafeMetadata` wholesale rather than merging it. A bare `{ [KEY]: ... }` patch would silently delete every other key the app keeps there, and nothing else in the suite would notice. The write spreads the existing object, and one test asserts specifically that unrelated keys survive.

## Verification

135 passkey tests pass. Both of the changes that matter were mutation-checked against the committed tree, because a test that cannot fail has already cost this feature two wrong diagnoses:

| Mutation | Result |
|---|---|
| Restore the old suppression for returning sessions | 3 tests fail |
| Drop the `unsafeMetadata` spread | `PRESERVES every other unsafeMetadata key` fails |

`typecheck`, `lint:boundaries`, `biome`, `bundle:check` all clean.

Two tests that encoded the old policy were rewritten rather than deleted. `does NOT arm on a user-null reading while Clerk is absent` still pins a live invariant: a Clerk load failure followed by a successful retry must be recorded as a returning session, never misattributed as a fresh sign-in.

## Trace vocabulary

`cold-hydration-suppressed` is gone, since no path can now reach it. Added `already-offered-account`, `load-sign-in`, and `load-returning-session`; the last two are what let a live trace say *how* a user arrived without a second signal. The vocabulary stays closed, so no account key, Clerk id, or raw error can reach `window.__wmPasskeyOffer`.

## What a user sees

Anyone already signed in with no passkey gets asked once, on their next load after deploy. Anyone who has been asked before, on any device, is not asked again. Anyone who already has a passkey never downloads the code.

## Still open

Manual browser checks on a preview deploy: the credential ceremony itself, geometry at 320/390px, and VoiceOver. #7352 (pinning the Clerk SDK and UI versions) remains the reason a served-bundle check is needed for every Clerk API claim.

https://claude.ai/code/session_01ScduDZwAMEFm6FyHb7zgDH
