### PR TITLE
fix(passkeys): match the house card style and stop painting the SR announcement

### DIFF
--- a/src/components/PasskeyOfferPrompt.ts
+++ b/src/components/PasskeyOfferPrompt.ts
@@ -13,10 +13,18 @@ import { t } from '@/services/i18n';
  *     and without moving focus tells assistive technology the user entered a
  *     dialog, and then nothing does. This is a non-modal notification with
  *     actions, so it is a labelled `<aside>`.
- *   - **`aria-live` on a dedicated status node, never on the card.** A live
- *     region wrapping the whole interactive card re-announces the buttons and
- *     body copy on every state change. A separate, initially-empty node
- *     receives only the status sentence, so exactly the change is announced.
+ *   - **`aria-live` on dedicated nodes, never on the card.** A live region
+ *     wrapping the whole interactive card re-announces the buttons and body
+ *     copy on every state change. Two separate, initially-empty nodes each
+ *     receive one sentence, so exactly the change is announced. They are split
+ *     because their audiences differ: the arrival sentence restates the body
+ *     copy and is screen-reader only, while the status sentence is state
+ *     feedback nobody can infer from looking and is painted.
+ *
+ * Its styling follows `.update-toast`, the house pattern for an elevated
+ * notification with an action. The generic surface/border/accent tokens are the
+ * wrong choice here — `--accent` is `#fff` in the dark theme, which rendered
+ * the primary button as white text on white.
  */
 
 /** The five states the card can be in. Terminal timing differs by state. */
@@ -29,6 +37,8 @@ export interface PasskeyOfferPromptOptions {
 
 export class PasskeyOfferPrompt {
   private readonly root: HTMLElement;
+  /** Screen-reader-only arrival sentence. Never painted. */
+  private readonly announce: HTMLElement;
   private readonly status: HTMLElement;
   private readonly acceptBtn: HTMLButtonElement;
   private readonly dismissBtn: HTMLButtonElement;
@@ -56,9 +66,20 @@ export class PasskeyOfferPrompt {
     body.className = 'passkey-offer-body';
     body.textContent = t('components.passkeyOffer.body');
 
-    // Empty on mount. An empty live region announces nothing, so arrival is
+    // Two live regions, because the two announcements have different audiences.
+    //
+    // The arrival sentence restates the body copy, so painting it put two
+    // sentences saying the same thing on one small card. It is screen-reader
+    // only. The status sentence is genuine state feedback nobody can infer from
+    // looking, so it is visible.
+    //
+    // Both start empty: an empty live region announces nothing, so arrival is
     // written on the next frame (see `announceOnMount`) — several screen
     // readers only announce mutations to a region that was already present.
+    this.announce = document.createElement('p');
+    this.announce.className = 'passkey-offer-announce';
+    this.announce.setAttribute('aria-live', 'polite');
+
     this.status = document.createElement('p');
     this.status.className = 'passkey-offer-status';
     this.status.setAttribute('aria-live', 'polite');
@@ -86,7 +107,7 @@ export class PasskeyOfferPrompt {
     this.closeBtn.addEventListener('click', this.handleDismiss);
 
     actions.append(this.dismissBtn, this.acceptBtn);
-    this.root.append(this.closeBtn, title, body, this.status, actions);
+    this.root.append(this.closeBtn, title, body, this.announce, this.status, actions);
   }
 
   /** The element to insert. The caller owns where it goes. */
@@ -108,7 +129,7 @@ export class PasskeyOfferPrompt {
   announceOnMount(schedule: (cb: () => void) => number = requestAnimationFrame): void {
     this.announceFrame = schedule(() => {
       this.announceFrame = null;
-      if (this.state === 'offered') this.status.textContent = t('components.passkeyOffer.announce');
+      if (this.state === 'offered') this.announce.textContent = t('components.passkeyOffer.announce');
     });
   }
 
@@ -130,6 +151,10 @@ export class PasskeyOfferPrompt {
     else this.root.removeAttribute('aria-busy');
 
     this.root.dataset.state = next;
+    // The arrival sentence is stale the moment a state exists. Clearing it
+    // announces nothing (an empty region is silent) but stops a screen reader
+    // reading "save a passkey to sign in faster" back alongside "passkey saved".
+    this.announce.textContent = '';
     this.status.textContent = statusTextFor(next);
   }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -28177,20 +28177,27 @@ body.map-width-resizing {
   }
 }
 
+/*
+ * Matches `.update-toast`, the house pattern for an elevated notification with
+ * an action: green-tinted dark gradient, green primary, panel-scaled type.
+ *
+ * The first cut used the generic `--surface-active` / `--border` / `--accent`
+ * tokens and rendered as a foreign white-on-white card, because `--accent` is
+ * `#fff` in the dark theme. Nothing generic reads as "our UI" here.
+ */
 .passkey-offer-prompt {
   position: fixed;
   left: 50%;
   bottom: calc(var(--wm-bottom-base) + var(--wm-bottom-banner) + 16px);
   transform: translateX(-50%);
   z-index: 10004; /* above .mobile-tab-bar (10003); it is an actionable prompt */
-  width: min(420px, calc(100vw - 32px));
+  width: min(400px, calc(100vw - 32px));
   box-sizing: border-box;
   padding: 14px 16px;
-  border: 1px solid var(--border);
+  border: 1px solid rgba(68, 255, 136, 0.25);
   border-radius: 10px;
-  background: var(--surface-active);
-  color: var(--text);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  background: linear-gradient(135deg, #1a2332 0%, #0f1923 100%);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(68, 255, 136, 0.08);
 }
 
 .passkey-offer-prompt[hidden] {
@@ -28199,68 +28206,116 @@ body.map-width-resizing {
 
 .passkey-offer-title {
   margin: 0 0 4px;
-  font-size: 14px;
+  padding-right: 20px; /* clear the close button */
+  font-size: calc(13px * var(--wm-panel-effective-scale, 1));
   font-weight: 600;
+  letter-spacing: 0.2px;
+  color: #e8e8e8;
 }
 
 .passkey-offer-body {
   margin: 0;
-  font-size: 13px;
-  line-height: 1.45;
-  color: var(--text-secondary);
+  font-size: calc(11px * var(--wm-panel-effective-scale, 1));
+  line-height: 1.5;
+  letter-spacing: 0.3px;
+  color: #888;
+}
+
+/*
+ * Screen-reader only. The arrival sentence must not be painted: it restates the
+ * body copy, and rendering both put two sentences saying the same thing on one
+ * small card.
+ */
+.passkey-offer-announce {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* Visible when non-empty; carries only the status sentence, never the body copy. */
 .passkey-offer-status {
   margin: 8px 0 0;
-  font-size: 12px;
-  color: var(--text-secondary);
+  font-size: calc(11px * var(--wm-panel-effective-scale, 1));
+  letter-spacing: 0.3px;
+  color: var(--green);
 }
 
 .passkey-offer-status:empty {
   margin: 0;
 }
 
+.passkey-offer-prompt[data-state="failed"] .passkey-offer-status {
+  color: #ff6b6b;
+}
+
 .passkey-offer-actions {
   display: flex;
   gap: 8px;
   justify-content: flex-end;
+  align-items: center;
   margin-top: 12px;
 }
 
 .passkey-offer-actions button {
-  padding: 7px 14px;
+  padding: 6px 14px;
   border-radius: 6px;
-  font-size: 13px;
+  font-size: calc(11px * var(--wm-panel-effective-scale, 1));
+  font-weight: 600;
+  letter-spacing: 0.3px;
   cursor: pointer;
+  transition: filter 0.15s, transform 0.15s;
 }
 
 .passkey-offer-actions button:disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: default;
 }
 
+.passkey-offer-actions button:not(:disabled):hover {
+  filter: brightness(1.15);
+}
+
+.passkey-offer-actions button:not(:disabled):active {
+  transform: scale(0.97);
+}
+
 .passkey-offer-accept {
-  border: 1px solid var(--accent, #2563eb);
-  background: var(--accent, #2563eb);
-  color: #fff;
+  border: none;
+  background: var(--green);
+  color: #0a0a0a;
 }
 
 .passkey-offer-dismiss {
-  border: 1px solid var(--border);
+  border: 1px solid rgba(255, 255, 255, 0.15);
   background: transparent;
-  color: var(--text-secondary);
+  color: #888;
 }
 
 .passkey-offer-close {
   position: absolute;
-  top: 6px;
+  top: 8px;
   right: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
   border: none;
-  background: transparent;
-  color: var(--text-dim);
-  font-size: 18px;
+  background: none;
+  color: #666;
+  font-size: calc(16px * var(--wm-panel-effective-scale, 1));
   line-height: 1;
-  padding: 4px 6px;
+  padding: 0;
   cursor: pointer;
+  transition: color 0.15s;
+}
+
+.passkey-offer-close:hover {
+  color: #e8e8e8;
 }

--- a/tests/dom/passkey-offer-prompt.test.mts
+++ b/tests/dom/passkey-offer-prompt.test.mts
@@ -38,6 +38,8 @@ const accept = (el: HTMLElement) => el.querySelector<HTMLButtonElement>('.passke
 const dismiss = (el: HTMLElement) => el.querySelector<HTMLButtonElement>('.passkey-offer-dismiss');
 const close = (el: HTMLElement) => el.querySelector<HTMLButtonElement>('.passkey-offer-close');
 const status = (el: HTMLElement) => el.querySelector<HTMLElement>('.passkey-offer-status');
+const announce = (el: HTMLElement) => el.querySelector<HTMLElement>('.passkey-offer-announce');
+const body = (el: HTMLElement) => el.querySelector<HTMLElement>('.passkey-offer-body');
 
 beforeEach(() => {
   document.body.replaceChildren();
@@ -96,8 +98,29 @@ describe('PasskeyOfferPrompt — accessibility', () => {
 
   it('announces arrival on a later frame, once the region already exists', () => {
     const { prompt, el } = mount();
-    expect(status(el)?.textContent).toBe('');
+    expect(announce(el)?.textContent).toBe('');
     prompt.announceOnMount(immediate);
+    expect(announce(el)?.textContent).not.toBe('');
+  });
+
+  it('does NOT paint the arrival sentence, which restates the body copy', () => {
+    // Shipped broken: the arrival sentence went into the VISIBLE status node,
+    // so the card showed two sentences saying the same thing.
+    const { prompt, el } = mount();
+    prompt.announceOnMount(immediate);
+
+    expect(status(el)?.textContent).toBe('');
+    const spoken = announce(el)?.textContent ?? '';
+    expect(spoken).not.toBe('');
+    expect(spoken).not.toBe(body(el)?.textContent);
+  });
+
+  it('drops the stale arrival sentence once a state exists', () => {
+    const { prompt, el } = mount();
+    prompt.announceOnMount(immediate);
+    prompt.setState('succeeded');
+
+    expect(announce(el)?.textContent).toBe('');
     expect(status(el)?.textContent).not.toBe('');
   });
 


### PR DESCRIPTION
#7363 made the offer appear. It appeared looking like someone else's component, with an unreadable primary button.

## Three defects

**The primary button was white text on white.**

```css
.passkey-offer-accept {
  background: var(--accent, #2563eb);
  color: #fff;
}
```

`--accent` is `#fff` in the dark theme, so the background resolved to white behind hardcoded white text. The `#2563eb` fallback was dead code from the start: a `var()` fallback fires only when the custom property is *undefined*, and this one never is. It reads as a safety net and is not one.

**The card painted the same sentence twice.** The arrival announcement, written for screen readers, went into the *visible* status node and restated the body copy directly beneath it. The component's own doc comment claimed that node "carries only the status sentence, never the body copy". It did not.

**Generic tokens made it foreign.** `--surface-active` and `--border` belong to no particular surface, so the result matched nothing else in the product.

## The fix

Restyled to `.update-toast`, the existing house pattern for an elevated notification with an action: green-tinted dark gradient, `--green` primary with near-black text, `--wm-panel-effective-scale` type sizing, and the same hover and active transitions. The failed state gets a red status line rather than the same muted grey as every other state.

The arrival announcement moves to its own visually-hidden live region. Screen readers still hear the card arrive; nothing duplicate is painted. It is cleared once a real state exists, so a stale "save a passkey to sign in faster" is not read back beside "passkey saved".

## What is deliberately NOT changed

The monospace face. It looks wrong for a dialog, but `--font-body-base` resolves to `var(--font-mono)` by default and `[data-font="system"]` lives on `<html>`, so the card was already inheriting the app's own body font. Overriding it here would have made this card the one thing on the page ignoring the user's font preference. Changing the product default is a separate decision.

## Verification

Rendered in Chrome against the real `main.css` across all four visual states, with the card positioned as it is in production so the absolutely-positioned close button resolves against the card rather than a harness wrapper.

| State | Result |
|---|---|
| offered | Green primary, dark label, readable. One sentence, not two |
| busy | Green status line, both actions disabled |
| succeeded | Green status line, accept disabled through the linger |
| failed | Red status line, accept disabled, dismiss still live |

Two new tests pin the regression directly. One asserts the arrival sentence is never written to the painted node and never equals the body copy; the other asserts it is dropped once a state exists. 70 passkey DOM tests pass.

`typecheck`, `biome`, and `bundle:check` (1610.6 KB) all clean.

## Still unverified

The credential ceremony itself, 320/390px geometry, and VoiceOver still need a real device. This PR changes only presentation, so #7363's logic is unaffected either way.

https://claude.ai/code/session_01ScduDZwAMEFm6FyHb7zgDH
