### PR TITLE
fix(ci): diff convex deploys against production, not the push that triggered them

### DIFF
--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -129,6 +129,7 @@ jobs:
           # source and fails if this list stops covering it.
           if git diff --name-only "$BEFORE" "$AFTER" -- \
               'convex/' \
+              'shared/cloud-preferences-contract.ts' \
               'shared/mcp-attribution.ts' \
               'shared/company-monitoring-contract.ts' \
               'shared/company-monitoring-evidence.ts' \
@@ -145,24 +146,16 @@ jobs:
     if: needs.changes.outputs.convex == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      # Only this job writes, and only to move DEPLOYED_TAG (#7359). Scoped at
-      # the job so the `changes` job keeps the workflow's read-only default.
-      contents: write
+    # Deliberately READ-ONLY (the workflow default). This job runs `npm ci`,
+    # whose dependency lifecycle scripts are third-party code, so it must never
+    # hold a repo-write credential — see the `record-baseline` job below.
+    outputs:
+      deployed: ${{ steps.deploy.outcome }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # This job now holds `contents: write`, and checkout would otherwise
-          # leave the token in .git/config as an http.extraheader for the WHOLE
-          # job — including `npm ci` below, whose dependency lifecycle scripts
-          # (preinstall/postinstall/prepare) `--no-audit --no-fund` do not
-          # disable. A compromised transitive dep could then push with repo-wide
-          # write, including force-moving DEPLOYED_TAG to suppress future
-          # deploys. The tag step supplies the token explicitly instead, so no
-          # ambient credential exists while third-party code runs. Same
-          # treatment CONVEX_DEPLOY_KEY already gets (step-scoped `env:`), and
-          # the convention railway-deploy-trigger.yml and railway-registry-sync.yml
-          # already follow.
+          # Belt and braces with the read-only permission above: no ambient
+          # credential in .git/config while third-party install code runs.
           persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -177,37 +170,6 @@ jobs:
         run: npx convex deploy --yes
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-      - name: Record the deployed commit
-        # Immediately after the deploy and BEFORE the seed steps: this tag
-        # answers "what convex/ code is in production", which is true the moment
-        # `convex deploy` returns. A seed failure still reds the run (and the
-        # post-merge monitor alarms on that), but it must not make the next push
-        # re-deploy code that is already live.
-        #
-        # Force-moved deliberately — it is a pointer to the current deployment,
-        # not release history. `--force` on the push too: a moved tag is not a
-        # fast-forward.
-        env:
-          # Scoped to this step only — see the checkout note above.
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          git tag -f "$DEPLOYED_TAG" "$GITHUB_SHA"
-          git push --force \
-            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "refs/tags/$DEPLOYED_TAG" \
-            || {
-              echo "::warning::could not move $DEPLOYED_TAG to $GITHUB_SHA — the deploy SUCCEEDED; the next push will redeploy redundantly until this recovers"
-              exit 1
-            }
-        # The deploy already reached production by this point. A transient push
-        # failure must not restate that success as a failed run: the monitor
-        # judges a non-success conclusion as RUN_FAILED and would page on-call
-        # for a deploy that actually worked. Failing to RECORD the deploy is
-        # self-healing and cheap — the tag stays put, so the next push simply
-        # redeploys — so it is a warning, not a job failure. Same treatment the
-        # post-deploy seed steps below already get.
-        continue-on-error: true
       - id: seed_dodo_webhook_failure_summary
         name: Seed Dodo webhook failure summary (idempotent)
         # Failure recording uses this pre-seeded aggregate row as its
@@ -264,3 +226,46 @@ jobs:
             echo "::error::One or more post-deploy seeds failed; inspect the seed steps above"
             exit 1
           fi
+
+  record-baseline:
+    # The ONLY job holding `contents: write`, and it deliberately runs no
+    # dependency or repository code: no `npm ci`, no build, no project scripts.
+    #
+    # Keeping the marker write inside the deploy job was unsafe even with
+    # `persist-credentials: false` (#7359 review finding 4): `npm ci` runs
+    # third-party lifecycle scripts in that job, and lifecycle code can install a
+    # git hook or rewrite git config that survives to a later step — so a token
+    # introduced afterwards for the tag push could still be read or redirected by
+    # it. A separate job with a fresh checkout has no such prior code execution.
+    #
+    # Gated on the DEPLOY STEP's outcome, not the deploy job's conclusion: the
+    # marker answers "what convex code is in production", which is true the
+    # moment `convex deploy` returns. A post-deploy seed failure still reds the
+    # deploy job (and the monitor alarms on that), but it must not make the next
+    # push re-deploy code that is already live.
+    needs: deploy
+    if: always() && needs.deploy.outputs.deployed == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Record the deployed commit
+        # Force-moved deliberately — a pointer to the current deployment, not
+        # release history. `--force` on the push too: a moved tag is not a
+        # fast-forward.
+        #
+        # A transient push failure must not restate a successful production
+        # deploy as a failed run, and failing to RECORD is self-healing (the tag
+        # stays put, so the next push simply redeploys), so this warns rather
+        # than failing the workflow.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          git tag -f "$DEPLOYED_TAG" "$GITHUB_SHA"
+          git push --force origin "refs/tags/$DEPLOYED_TAG" \
+            || {
+              echo "::warning::could not move $DEPLOYED_TAG to $GITHUB_SHA — the deploy SUCCEEDED; the next push will redeploy redundantly until this recovers"
+              exit 1
+            }

--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -129,7 +129,10 @@ jobs:
           # source and fails if this list stops covering it.
           if git diff --name-only "$BEFORE" "$AFTER" -- \
               'convex/' \
-              'shared/' \
+              'shared/mcp-attribution.ts' \
+              'shared/company-monitoring-contract.ts' \
+              'shared/company-monitoring-evidence.ts' \
+              'shared/legal.ts' \
               'scripts/lib/company-monitoring-classification.mjs' \
               'src/utils/country-codes.ts' | grep -q .; then
             echo "convex=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -133,6 +133,19 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # This job now holds `contents: write`, and checkout would otherwise
+          # leave the token in .git/config as an http.extraheader for the WHOLE
+          # job — including `npm ci` below, whose dependency lifecycle scripts
+          # (preinstall/postinstall/prepare) `--no-audit --no-fund` do not
+          # disable. A compromised transitive dep could then push with repo-wide
+          # write, including force-moving DEPLOYED_TAG to suppress future
+          # deploys. The tag step supplies the token explicitly instead, so no
+          # ambient credential exists while third-party code runs. Same
+          # treatment CONVEX_DEPLOY_KEY already gets (step-scoped `env:`), and
+          # the convention railway-deploy-trigger.yml and railway-registry-sync.yml
+          # already follow.
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '24'
@@ -156,10 +169,27 @@ jobs:
         # Force-moved deliberately — it is a pointer to the current deployment,
         # not release history. `--force` on the push too: a moved tag is not a
         # fast-forward.
+        env:
+          # Scoped to this step only — see the checkout note above.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           git tag -f "$DEPLOYED_TAG" "$GITHUB_SHA"
-          git push --force origin "refs/tags/$DEPLOYED_TAG"
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "refs/tags/$DEPLOYED_TAG" \
+            || {
+              echo "::warning::could not move $DEPLOYED_TAG to $GITHUB_SHA — the deploy SUCCEEDED; the next push will redeploy redundantly until this recovers"
+              exit 1
+            }
+        # The deploy already reached production by this point. A transient push
+        # failure must not restate that success as a failed run: the monitor
+        # judges a non-success conclusion as RUN_FAILED and would page on-call
+        # for a deploy that actually worked. Failing to RECORD the deploy is
+        # self-healing and cheap — the tag stays put, so the next push simply
+        # redeploys — so it is a warning, not a job failure. Same treatment the
+        # post-deploy seed steps below already get.
+        continue-on-error: true
       - id: seed_dodo_webhook_failure_summary
         name: Seed Dodo webhook failure summary (idempotent)
         # Failure recording uses this pre-seeded aggregate row as its

--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -114,9 +114,24 @@ jobs:
             exit 0
           fi
           # Authoritative path-scoped diff. `--` separates revisions from
-          # pathspecs, so `convex/` is interpreted as a path filter even if
+          # pathspecs, so these are interpreted as path filters even if
           # something weird is going on with the SHAs.
-          if git diff --name-only "$BEFORE" "$AFTER" -- 'convex/' | grep -q .; then
+          #
+          # `convex/` alone is NOT the deployed bundle. Convex modules import
+          # runtime values from outside it — shared/mcp-attribution,
+          # shared/company-monitoring-*, scripts/lib/company-monitoring-
+          # classification.mjs, src/utils/country-codes — and `convex deploy`
+          # bundles whatever those imports reach. A change to one of them alters
+          # what production runs while touching nothing under convex/, so a
+          # convex/-only filter skips a deploy that was genuinely due. Same
+          # silent-staleness class as #7359, through a different door.
+          # tests/check-postmerge-deploys.test.mjs derives the real set from the
+          # source and fails if this list stops covering it.
+          if git diff --name-only "$BEFORE" "$AFTER" -- \
+              'convex/' \
+              'shared/' \
+              'scripts/lib/company-monitoring-classification.mjs' \
+              'src/utils/country-codes.ts' | grep -q .; then
             echo "convex=true" >> "$GITHUB_OUTPUT"
           else
             echo "convex=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -25,10 +25,25 @@ on:
 permissions:
   contents: read
 
+env:
+  # Records which commit Convex production is actually running. Moved by the
+  # deploy job immediately after a successful `convex deploy`, and read by the
+  # `changes` job as its diff baseline (#7359). A tag, not the Actions API:
+  # the answer is a commit, git already has it locally at fetch-depth 0, and it
+  # cannot be wrong the way "the newest run looked green" can.
+  DEPLOYED_TAG: convex-deployed
+
 concurrency:
   # Serialize deploys so two back-to-back merges don't race against each other.
-  # `cancel-in-progress: false` is intentional — every merge that touches
-  # convex/ should reach prod, even if a later merge follows quickly.
+  #
+  # `cancel-in-progress: false` protects a run that is ALREADY EXECUTING. It does
+  # NOT guarantee every merge reaches prod, and the comment here used to claim it
+  # did (#7359): GitHub keeps at most one PENDING run per concurrency group and
+  # cancels the older pending one when a newer arrives, so a merge burst silently
+  # drops the runs in the middle. That is survivable only because the `changes`
+  # job below diffs against what production actually runs rather than this push's
+  # own range — a dropped run's commits stay in the diff until something deploys
+  # them.
   group: convex-deploy-prod
   cancel-in-progress: false
 
@@ -47,13 +62,14 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          # Need both BEFORE and AFTER commits locally so `git diff` can name
-          # the changed files authoritatively. `fetch-depth: 0` (full history)
-          # is the cheapest way; the alternative — `gh api compare` — paginates
-          # at 300 files and silently empties on API failure, which fails OPEN
-          # (would skip a real convex/ change → recreates the exact drift this
-          # workflow is meant to prevent). git diff fails CLOSED: if it can't
-          # answer, the job errors and the deploy doesn't silently skip.
+          # Need the deployed-baseline tag and the pushed head locally so
+          # `git diff` can name the changed files authoritatively. `fetch-depth: 0`
+          # (full history) is the cheapest way and also brings the tags; the
+          # alternative — `gh api compare` — paginates at 300 files and silently
+          # empties on API failure, which fails OPEN (would skip a real convex/
+          # change → recreates the exact drift this workflow is meant to
+          # prevent). git diff fails CLOSED: if it can't answer, the job errors
+          # and the deploy doesn't silently skip.
           fetch-depth: 0
       - id: diff
         run: |
@@ -63,12 +79,27 @@ jobs:
             echo "convex=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          BEFORE="${{ github.event.before }}"
           AFTER="${{ github.event.after }}"
-          # Brand-new branch / first push (BEFORE is the all-zero SHA): we
-          # can't diff against a non-existent prior state. Fall through to
-          # deploy — this is the safe default for first-push scenarios.
-          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+          # The baseline is what production is ACTUALLY RUNNING — the commit the
+          # deploy job tagged after its last successful `convex deploy` — not
+          # this push's `github.event.before` (#7359).
+          #
+          # Diffing the push's own range is what stranded #7344: its run was
+          # cancelled while queued by the concurrency group, and no LATER push
+          # could rescue it, because no later push's before..after range
+          # contains a commit from an earlier push. Every subsequent run
+          # honestly reported convex=false and skipped, forever. Diffing from
+          # the deployed commit instead keeps an undeployed change in the diff
+          # until something actually deploys it, so the next push self-heals —
+          # and it is equally immune to a failed deploy, a force-push, and a
+          # path-filter edit.
+          # `^{commit}` dereferences, so an annotated tag resolves to its commit
+          # rather than the tag object (which `git diff` would not accept).
+          BEFORE="$(git rev-parse --verify --quiet "refs/tags/$DEPLOYED_TAG^{commit}" || true)"
+          # No tag yet (first run after this change) — nothing proves what is
+          # deployed, so deploy. Same fail-CLOSED default as the cases below.
+          if [ -z "$BEFORE" ]; then
+            echo "::warning::no $DEPLOYED_TAG tag yet — deploying to establish the baseline"
             echo "convex=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -96,6 +127,10 @@ jobs:
     if: needs.changes.outputs.convex == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      # Only this job writes, and only to move DEPLOYED_TAG (#7359). Scoped at
+      # the job so the `changes` job keeps the workflow's read-only default.
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -111,6 +146,20 @@ jobs:
         run: npx convex deploy --yes
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+      - name: Record the deployed commit
+        # Immediately after the deploy and BEFORE the seed steps: this tag
+        # answers "what convex/ code is in production", which is true the moment
+        # `convex deploy` returns. A seed failure still reds the run (and the
+        # post-merge monitor alarms on that), but it must not make the next push
+        # re-deploy code that is already live.
+        #
+        # Force-moved deliberately — it is a pointer to the current deployment,
+        # not release history. `--force` on the push too: a moved tag is not a
+        # fast-forward.
+        run: |
+          set -euo pipefail
+          git tag -f "$DEPLOYED_TAG" "$GITHUB_SHA"
+          git push --force origin "refs/tags/$DEPLOYED_TAG"
       - id: seed_dodo_webhook_failure_summary
         name: Seed Dodo webhook failure summary (idempotent)
         # Failure recording uses this pre-seeded aggregate row as its

--- a/.github/workflows/postmerge-deploy-monitor.yml
+++ b/.github/workflows/postmerge-deploy-monitor.yml
@@ -52,5 +52,10 @@ jobs:
           # Pick up commits merged since the checkout so the convex=false skip
           # proof diffs the head the API reports, not the SHA the checkout was
           # created at. Same shape as seed-freshness-monitor.yml's drift step.
-          git fetch --quiet origin main
+          # `--tags --force` is load-bearing: the convex/ skip proof compares
+          # production's deployed commit (the force-moved `convex-deployed` tag
+          # convex-deploy.yml writes) against main. Without --force the local
+          # tag is pinned at whatever the checkout saw and never advances, so
+          # the monitor would report drift that was already deployed.
+          git fetch --quiet --tags --force origin main
           node scripts/check-postmerge-deploys.mjs

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -74,6 +74,7 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // think about it.
     skipProofPaths: Object.freeze([
       'convex/',
+      'shared/cloud-preferences-contract.ts',
       'shared/mcp-attribution.ts',
       'shared/company-monitoring-contract.ts',
       'shared/company-monitoring-evidence.ts',
@@ -568,6 +569,58 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequir
   // keeping the `deploy` id as the YAML key. The jobs API returns the display
   // name, so each workflow declares the deploy job name the API actually
   // publishes via `deployJobName`.
+  // Is production behind main? Evaluated for EVERY convex result, not only a
+  // skipped deploy (#7359 review finding 2). "The newest run deployed" does not
+  // mean production has current main: if a later watched-path commit produces no
+  // run at all (Actions degraded, a broken trigger, a workflow edit), the newest
+  // run stays a green DEPLOYED and the monitor was blind to the drift until the
+  // 7-day no-run backstop. The tag-vs-main comparison is the real question and
+  // does not depend on what any particular run did, so it is asked first.
+  if (workflow.skipProofPaths && typeof skipProof === 'function') {
+    let upToDate = null;
+    try {
+      upToDate = skipProof();
+    } catch (error) {
+      // Swallowing every throw was correct while the proof was local-git only:
+      // "Local proof failures (git, missing gh) ... are ALARM" (see the file
+      // header). The baseline read is still local, but re-throw anything the
+      // classifier calls transport unreadability so the outer handler reports
+      // UNKNOWN — a blip must never page on-call claiming production is behind.
+      if (isGithubRecordUnreadability(error)) throw error;
+      // No baseline recorded yet (the tag is written by the first deploy after
+      // this landed). Nothing to compare against, and it clears itself on the
+      // next deploy — a visible UNKNOWN, not a claim that production is behind.
+      if (error?.deployedBaselineUnset === true) {
+        return {
+          state: 'UNKNOWN',
+          verdict: 'DEPLOY_BASELINE_UNSET',
+          runId: run.runId,
+          detail: `run ${run.runId}: ${error.message}`,
+        };
+      }
+      upToDate = null;
+    }
+    // Proven drift and an unreadable baseline are different alarms: the first
+    // says a deploy is owed, the second says the monitor is blind. Conflating
+    // them sends on-call after the wrong thing.
+    if (upToDate === false) {
+      return {
+        state: 'ALARM',
+        verdict: 'DEPLOY_BEHIND_BASELINE',
+        runId: run.runId,
+        detail: `${workflow.skipProofPaths.join(', ')} changed between the last successful deploy and current main — production is behind`,
+      };
+    }
+    if (upToDate !== true) {
+      return {
+        state: 'ALARM',
+        verdict: 'DEPLOY_BASELINE_UNPROVEN',
+        runId: run.runId,
+        detail: `run ${run.runId}: the deployed baseline could not be read`,
+      };
+    }
+  }
+
   const deployName = workflow.deployJobName ?? 'deploy';
   const deployJobs = [...(jobs?.entries() ?? [])].filter(([name]) => name === deployName);
   if (deployJobs.length === 0) {
@@ -592,58 +645,14 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequir
     // push's own diff (#7359). A skip is only legitimate if production already
     // has everything main has; "this particular push touched nothing" was true
     // of every push that followed a stranded merge.
-    if (workflow.skipProofPaths && typeof skipProof === 'function') {
-      let skipLegitimate = null;
-      try {
-        skipLegitimate = skipProof();
-      } catch (error) {
-        // Swallowing every throw was correct while the proof was local-git
-        // only: "Local proof failures (git, missing gh) ... are ALARM" (see the
-        // file header). Deriving the baseline from the Actions API put a NETWORK
-        // read on this path, and the same header requires transport
-        // unreadability to be UNKNOWN and to NOT fail the job. Re-throw those so
-        // checkPostmergeDeploys' handler classifies them; a TLS blip must never
-        // page on-call claiming production is behind. Everything else (git, 4xx)
-        // still falls through to ALARM.
-        if (isGithubRecordUnreadability(error)) throw error;
-        // No baseline recorded yet (the tag is created by the first deploy
-        // after this landed). There is legitimately nothing to compare against,
-        // and it clears itself on the next deploy — a visible UNKNOWN, not a
-        // claim that production is behind.
-        if (error?.deployedBaselineUnset === true) {
-          return {
-            state: 'UNKNOWN',
-            verdict: 'DEPLOY_BASELINE_UNSET',
-            runId: run.runId,
-            detail: `run ${run.runId} skipped the deploy and ${error.message}`,
-          };
-        }
-        skipLegitimate = null;
-      }
-      if (skipLegitimate === true) {
-        return {
-          state: 'OK',
-          verdict: 'DEPLOY_SKIPPED_LEGIT',
-          runId: run.runId,
-          detail: `run ${run.runId} skipped the deploy and production already has every bundled change on main (${workflow.skipProofPaths.join(", ")})`,
-        };
-      }
-      // Proven drift and an unreadable baseline are different alarms: the first
-      // says a deploy is owed, the second says the monitor is blind. Conflating
-      // them sends on-call after the wrong thing.
-      if (skipLegitimate === false) {
-        return {
-          state: 'ALARM',
-          verdict: 'DEPLOY_SKIPPED_BEHIND_BASELINE',
-          runId: run.runId,
-          detail: `run ${run.runId} skipped the deploy, but ${workflow.skipProofPaths.join(", ")} changed between the last successful deploy and current main — production is behind`,
-        };
-      }
+    // Drift was already proven false above, so a skip here is legitimate by
+    // construction: production has every bundled change on main.
+    if (workflow.skipProofPaths) {
       return {
-        state: 'ALARM',
-        verdict: 'DEPLOY_SKIPPED_UNPROVEN',
+        state: 'OK',
+        verdict: 'DEPLOY_SKIPPED_LEGIT',
         runId: run.runId,
-        detail: `run ${run.runId} skipped the deploy and the deployed baseline could not be read`,
+        detail: `run ${run.runId} skipped the deploy and production already has every bundled change on main`,
       };
     }
     return {

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -360,18 +360,6 @@ export function readRunJobs({ gh, repository, runId, runAttempt }) {
 }
 
 /**
- * Did the diff between `parent` and `head` touch `pathPrefix`?
- *
- * Returns a boolean, never a maybe, but the caller must treat a read failure
- * (a checkout too shallow to reach the parent, a missing object) as ALARM —
- * a skipped deploy whose skip reason cannot be verified must not resolve to
- * healthy. `git` is injected for testability.
- */
-export function diffTouchesPath({ git, parentSha, headSha, pathPrefix }) {
-  return diffTouchesPaths({ git, baseSha: parentSha, headSha, paths: [pathPrefix] });
-}
-
-/**
  * Did any of `paths` change between a deployed baseline and the current tree?
  *
  * Path-filtered workflows can be dormant indefinitely. Their age alone says
@@ -387,6 +375,76 @@ export function diffTouchesPaths({ git, baseSha, headSha, paths }) {
   }
   const result = git(['diff', '--name-only', `${baseSha}`, `${headSha}`, '--', ...paths]);
   return result.trim().length > 0;
+}
+
+// How many successful runs back the deployed-baseline walk will look before it
+// gives up. Each candidate costs one jobs read, so this bounds the API spend
+// against the monitor's `timeout-minutes: 10`. The #7359 incident sat five runs
+// back; 30 leaves room for a much longer burst without pretending an unknown
+// baseline is a known one.
+export const DEPLOY_BASELINE_MAX_RUNS = 30;
+
+/**
+ * The head SHA of the most recent run whose deploy job actually SUCCEEDED —
+ * i.e. what production is currently running. (#7359)
+ *
+ * This is deliberately NOT "the newest run's head". A run can be green with its
+ * deploy job skipped, and a queued run can be cancelled outright by the
+ * concurrency group during a merge burst; neither put anything in production.
+ * Treating either as the baseline is what let a stranded `convex/` change prove
+ * every later skip legitimate.
+ *
+ * Throws when no run in the budget deployed: an unknown baseline is a read
+ * failure the caller must resolve to ALARM, never a healthy pass. Runs that did
+ * not conclude `success` are skipped without spending a jobs read — their deploy
+ * job cannot have succeeded.
+ */
+export function readLastDeployedSha({
+  gh,
+  repository,
+  workflowFile,
+  deployJobName = 'deploy',
+  maxRuns = DEPLOY_BASELINE_MAX_RUNS,
+}) {
+  const payload = JSON.parse(readGithub(gh, [
+    'api',
+    `repos/${repository}/actions/workflows/${workflowFile}/runs?branch=main&per_page=100`,
+  ]));
+  const runs = payload?.workflow_runs;
+  if (!Array.isArray(runs)) {
+    throw new Error(`the run listing for ${workflowFile} was not an object with a workflow_runs array`);
+  }
+  const ordered = [...runs].sort((left, right) => {
+    const leftMs = parseTimestamp(left?.created_at);
+    const rightMs = parseTimestamp(right?.created_at);
+    if (leftMs === null && rightMs === null) return 0;
+    if (leftMs === null) return 1;
+    if (rightMs === null) return -1;
+    return rightMs - leftMs;
+  });
+
+  let inspected = 0;
+  for (const candidate of ordered) {
+    if (candidate?.conclusion !== 'success') continue;
+    if (inspected >= maxRuns) break;
+    inspected += 1;
+    const jobs = readRunJobs({
+      gh,
+      repository,
+      runId: candidate.id,
+      runAttempt: candidate.run_attempt ?? 1,
+    });
+    if (jobs.get(deployJobName)?.conclusion !== 'success') continue;
+    const headSha = candidate.head_sha;
+    if (typeof headSha !== 'string' || headSha.length === 0) {
+      throw new Error(`run ${candidate.id} of ${workflowFile} deployed but has no readable head_sha`);
+    }
+    return headSha;
+  }
+  throw new Error(
+    `no run of ${workflowFile} on main deployed within the last ${inspected} successful run(s) — `
+    + 'the deployed baseline is unknown',
+  );
 }
 
 /**
@@ -525,12 +583,17 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequir
   if (deploy.conclusion === 'skipped') {
     // A legitimate skip exists only for Convex Deploy: the convex=false path
     // diff. Any other workflow's deploy job must never be skipped, and even
-    // for Convex the skip must be proven against the actual diff — a workflow
-    // edit that widens or narrows the filter would otherwise skip silently.
+    // for Convex the skip must be proven — a workflow edit that widens or
+    // narrows the filter would otherwise skip silently.
+    //
+    // The proof compares the DEPLOYED baseline to current main, not this
+    // push's own diff (#7359). A skip is only legitimate if production already
+    // has everything main has; "this particular push touched nothing" was true
+    // of every push that followed a stranded merge.
     if (workflow.skipProofPath && typeof skipProof === 'function') {
       let skipLegitimate = null;
       try {
-        skipLegitimate = skipProof(run.headSha);
+        skipLegitimate = skipProof();
       } catch (error) {
         skipLegitimate = null;
       }
@@ -539,14 +602,25 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequir
           state: 'OK',
           verdict: 'DEPLOY_SKIPPED_LEGIT',
           runId: run.runId,
-          detail: `run ${run.runId} skipped the deploy because nothing under ${workflow.skipProofPath} changed`,
+          detail: `run ${run.runId} skipped the deploy and production already has every ${workflow.skipProofPath} change on main`,
+        };
+      }
+      // Proven drift and an unreadable baseline are different alarms: the first
+      // says a deploy is owed, the second says the monitor is blind. Conflating
+      // them sends on-call after the wrong thing.
+      if (skipLegitimate === false) {
+        return {
+          state: 'ALARM',
+          verdict: 'DEPLOY_SKIPPED_BEHIND_BASELINE',
+          runId: run.runId,
+          detail: `run ${run.runId} skipped the deploy, but ${workflow.skipProofPath} changed between the last successful deploy and current main — production is behind`,
         };
       }
       return {
         state: 'ALARM',
         verdict: 'DEPLOY_SKIPPED_UNPROVEN',
         runId: run.runId,
-        detail: `run ${run.runId} skipped the deploy and the skip reason (nothing under ${workflow.skipProofPath} changed) could not be proven against the head diff`,
+        detail: `run ${run.runId} skipped the deploy and the deployed baseline for ${workflow.skipProofPath} could not be read`,
       };
     }
     return {
@@ -598,13 +672,26 @@ export function checkPostmergeDeploys({ repository, gh, git, now = Date.now() })
         });
       }
       const skipProof = workflow.skipProofPath
-        ? (headSha) => {
-          // The parent of the head on main. The checkout has full history with
+        ? () => {
+          // "Is production behind main?", not "did this push touch the path?"
+          // (#7359). The baseline is the head of the last run that actually
+          // deployed, so a stranded change stays visible no matter how many
+          // later pushes legitimately skip. The checkout has full history with
           // no blobs (see the workflow), so `git diff --name-only` needs only
-          // trees. A missing parent is a read failure: throw, and the caller
-          // resolves the skip to ALARM.
-          const parent = git(['rev-parse', '--verify', `${headSha}^`]).trim();
-          return !diffTouchesPath({ git, parentSha: parent, headSha, pathPrefix: workflow.skipProofPath });
+          // trees. An unreadable baseline throws, and the caller resolves the
+          // skip to ALARM rather than healthy.
+          const baseSha = readLastDeployedSha({
+            gh,
+            repository,
+            workflowFile: workflow.file,
+            deployJobName: workflow.deployJobName,
+          });
+          return !diffTouchesPaths({
+            git,
+            baseSha,
+            headSha: 'origin/main',
+            paths: [workflow.skipProofPath],
+          });
         }
         : null;
       results.push({

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -51,9 +51,16 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // The job id IS the check-run name here: convex-deploy.yml writes
     // `deploy:` with no `name:` override, and the jobs API publishes the id.
     deployJobName: 'deploy',
-    // What a legitimate skip of the deploy job means for this workflow: the
-    // run must not have changed anything under convex/.
+    // What a legitimate skip of the deploy job means for this workflow:
+    // production must already have every convex/ change on main. Proven against
+    // the deployed baseline below, NOT against the run's own push diff — the
+    // per-push question is what let #7359 strand a merge behind green badges.
     skipProofPath: 'convex/',
+    // The git tag convex-deploy.yml moves after each successful deploy. Reading
+    // the workflow's own marker keeps ONE source of truth for "what is live";
+    // re-deriving it from the Actions API drifts from the tag whenever a
+    // post-deploy seed step fails (#7359 review).
+    deployedTagRef: 'convex-deployed',
     // Convex Deploy fires on EVERY push to main (no path filter; the changes
     // job decides whether to deploy). So "no run in the window"
     // means "no merge to main in the window". The observed max gap across the
@@ -127,6 +134,8 @@ const GH_CALL_TIMEOUT_MS = 30_000;
 // Retries AFTER the first attempt, so the worst case is 3 calls. Sized against
 // the workflow's `timeout-minutes: 10`: a transport failure returns in about a
 // second, so 3 workflows x 2 reads x 3 attempts costs seconds, not minutes.
+// The deployed-baseline read adds nothing here: it is a local `git rev-parse`
+// of the tag the deploy workflow writes, not a GitHub call.
 export const GH_READ_RETRY_ATTEMPTS = 2;
 export const GH_READ_RETRY_BASE_MS = 500;
 export const GH_READ_RETRY_MAX_MS = 4_000;
@@ -377,74 +386,42 @@ export function diffTouchesPaths({ git, baseSha, headSha, paths }) {
   return result.trim().length > 0;
 }
 
-// How many successful runs back the deployed-baseline walk will look before it
-// gives up. Each candidate costs one jobs read, so this bounds the API spend
-// against the monitor's `timeout-minutes: 10`. The #7359 incident sat five runs
-// back; 30 leaves room for a much longer burst without pretending an unknown
-// baseline is a known one.
-export const DEPLOY_BASELINE_MAX_RUNS = 30;
-
 /**
- * The head SHA of the most recent run whose deploy job actually SUCCEEDED —
- * i.e. what production is currently running. (#7359)
+ * The commit the deploy workflow last recorded as live in production. (#7359)
  *
- * This is deliberately NOT "the newest run's head". A run can be green with its
- * deploy job skipped, and a queued run can be cancelled outright by the
- * concurrency group during a merge burst; neither put anything in production.
- * Treating either as the baseline is what let a stranded `convex/` change prove
- * every later skip legitimate.
+ * This reads the SAME marker `convex-deploy.yml` writes — its `convex-deployed`
+ * tag, moved immediately after `npx convex deploy` returns. Deriving the answer
+ * independently from the Actions API instead was a second source of truth that
+ * drifted from the first: the tag moves BEFORE the post-deploy seed steps (so a
+ * seed failure still reds the run without forcing a redundant redeploy), which
+ * means a run whose deploy JOB concluded `failure` can still have put that code
+ * in production. An API walk keyed on job conclusion rejects exactly that run as
+ * a baseline and then reports "production is behind" about code that IS live —
+ * every tick, until some later change deploys fully green. A chronically red
+ * monitor is a blind spot, which would defeat the point of #7359.
  *
- * Throws when no run in the budget deployed: an unknown baseline is a read
- * failure the caller must resolve to ALARM, never a healthy pass. Runs that did
- * not conclude `success` are skipped without spending a jobs read — their deploy
- * job cannot have succeeded.
+ * Reading the tag also removes the walk's ~30 GitHub reads from the tick
+ * entirely, so the monitor's read budget stays as its header describes.
+ *
+ * Throws on an unreadable tag. A MISSING tag is distinguished via
+ * `deployedBaselineUnset` so the caller can report UNKNOWN rather than claim a
+ * failed deploy: before the first deploy after this landed there is legitimately
+ * nothing to compare against, and that state clears itself on the next deploy.
  */
-export function readLastDeployedSha({
-  gh,
-  repository,
-  workflowFile,
-  deployJobName = 'deploy',
-  maxRuns = DEPLOY_BASELINE_MAX_RUNS,
-}) {
-  const payload = JSON.parse(readGithub(gh, [
-    'api',
-    `repos/${repository}/actions/workflows/${workflowFile}/runs?branch=main&per_page=100`,
-  ]));
-  const runs = payload?.workflow_runs;
-  if (!Array.isArray(runs)) {
-    throw new Error(`the run listing for ${workflowFile} was not an object with a workflow_runs array`);
+export function readDeployedBaselineSha({ git, tagRef }) {
+  if (typeof tagRef !== 'string' || tagRef.length === 0) {
+    throw new Error('the deployed-baseline tag ref is missing');
   }
-  const ordered = [...runs].sort((left, right) => {
-    const leftMs = parseTimestamp(left?.created_at);
-    const rightMs = parseTimestamp(right?.created_at);
-    if (leftMs === null && rightMs === null) return 0;
-    if (leftMs === null) return 1;
-    if (rightMs === null) return -1;
-    return rightMs - leftMs;
-  });
-
-  let inspected = 0;
-  for (const candidate of ordered) {
-    if (candidate?.conclusion !== 'success') continue;
-    if (inspected >= maxRuns) break;
-    inspected += 1;
-    const jobs = readRunJobs({
-      gh,
-      repository,
-      runId: candidate.id,
-      runAttempt: candidate.run_attempt ?? 1,
-    });
-    if (jobs.get(deployJobName)?.conclusion !== 'success') continue;
-    const headSha = candidate.head_sha;
-    if (typeof headSha !== 'string' || headSha.length === 0) {
-      throw new Error(`run ${candidate.id} of ${workflowFile} deployed but has no readable head_sha`);
-    }
-    return headSha;
+  // `^{commit}` dereferences, so an annotated tag resolves to its commit.
+  const sha = git(['rev-parse', '--verify', '--quiet', `refs/tags/${tagRef}^{commit}`]).trim();
+  if (sha.length === 0) {
+    const error = new Error(
+      `the ${tagRef} tag does not exist locally — production's deployed commit is not yet recorded`,
+    );
+    error.deployedBaselineUnset = true;
+    throw error;
   }
-  throw new Error(
-    `no run of ${workflowFile} on main deployed within the last ${inspected} successful run(s) — `
-    + 'the deployed baseline is unknown',
-  );
+  return sha;
 }
 
 /**
@@ -595,6 +572,27 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequir
       try {
         skipLegitimate = skipProof();
       } catch (error) {
+        // Swallowing every throw was correct while the proof was local-git
+        // only: "Local proof failures (git, missing gh) ... are ALARM" (see the
+        // file header). Deriving the baseline from the Actions API put a NETWORK
+        // read on this path, and the same header requires transport
+        // unreadability to be UNKNOWN and to NOT fail the job. Re-throw those so
+        // checkPostmergeDeploys' handler classifies them; a TLS blip must never
+        // page on-call claiming production is behind. Everything else (git, 4xx)
+        // still falls through to ALARM.
+        if (isGithubRecordUnreadability(error)) throw error;
+        // No baseline recorded yet (the tag is created by the first deploy
+        // after this landed). There is legitimately nothing to compare against,
+        // and it clears itself on the next deploy — a visible UNKNOWN, not a
+        // claim that production is behind.
+        if (error?.deployedBaselineUnset === true) {
+          return {
+            state: 'UNKNOWN',
+            verdict: 'DEPLOY_BASELINE_UNSET',
+            runId: run.runId,
+            detail: `run ${run.runId} skipped the deploy and ${error.message}`,
+          };
+        }
         skipLegitimate = null;
       }
       if (skipLegitimate === true) {
@@ -674,18 +672,13 @@ export function checkPostmergeDeploys({ repository, gh, git, now = Date.now() })
       const skipProof = workflow.skipProofPath
         ? () => {
           // "Is production behind main?", not "did this push touch the path?"
-          // (#7359). The baseline is the head of the last run that actually
-          // deployed, so a stranded change stays visible no matter how many
-          // later pushes legitimately skip. The checkout has full history with
-          // no blobs (see the workflow), so `git diff --name-only` needs only
+          // (#7359). The baseline is the commit the deploy workflow recorded as
+          // live, so a stranded change stays visible no matter how many later
+          // pushes legitimately skip. The checkout has full history with no
+          // blobs (see the workflow), so `git diff --name-only` needs only
           // trees. An unreadable baseline throws, and the caller resolves the
           // skip to ALARM rather than healthy.
-          const baseSha = readLastDeployedSha({
-            gh,
-            repository,
-            workflowFile: workflow.file,
-            deployJobName: workflow.deployJobName,
-          });
+          const baseSha = readDeployedBaselineSha({ git, tagRef: workflow.deployedTagRef });
           return !diffTouchesPaths({
             git,
             baseSha,

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -52,10 +52,25 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // `deploy:` with no `name:` override, and the jobs API publishes the id.
     deployJobName: 'deploy',
     // What a legitimate skip of the deploy job means for this workflow:
-    // production must already have every convex/ change on main. Proven against
-    // the deployed baseline below, NOT against the run's own push diff — the
-    // per-push question is what let #7359 strand a merge behind green badges.
-    skipProofPath: 'convex/',
+    // production must already have every change on main under EVERY path the
+    // Convex bundle is built from. Proven against the deployed baseline below,
+    // NOT against the run's own push diff — the per-push question is what let
+    // #7359 strand a merge behind green badges.
+    //
+    // `convex/` alone is NOT the bundle. Deployed modules import runtime values
+    // from outside it (e.g. convex/payments/subscriptionHelpers.ts pulls
+    // normalizeCheckoutAttributionSource from shared/mcp-attribution), so
+    // `convex deploy` bundles those files too. A change to one of them alters
+    // what production runs while touching nothing under convex/ — the same
+    // silent-staleness class as #7359, through a different door. Pinned by
+    // 'the convex skip proof covers every path the bundle is built from', which
+    // derives the real list from the source rather than trusting this copy.
+    skipProofPaths: Object.freeze([
+      'convex/',
+      'shared/',
+      'scripts/lib/company-monitoring-classification.mjs',
+      'src/utils/country-codes.ts',
+    ]),
     // The git tag convex-deploy.yml moves after each successful deploy. Reading
     // the workflow's own marker keeps ONE source of truth for "what is live";
     // re-deriving it from the Actions API drifts from the tag whenever a
@@ -77,7 +92,7 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // The workflow's own path filter covers workers/railway-reconcile-control/**
     // plus its own file and test. A push touching ONLY those paths must
     // deploy; a deploy job skipped there is an unexpected skip, which alarms.
-    skipProofPath: null,
+    skipProofPaths: null,
     triggerPaths: Object.freeze([
       'workers/railway-reconcile-control/**',
       '.github/workflows/deploy-railway-reconcile-control.yml',
@@ -96,7 +111,7 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // Same shape: path-filtered push-to-main, no gate anywhere. A missing
     // CLOUDFLARE_API_TOKEN fails it silently like the reconcile Worker's
     // missing secrets did.
-    skipProofPath: null,
+    skipProofPaths: null,
     // MUST mirror the workflow's own `on.push.paths` exactly — this list is what
     // decides whether a deploy was DUE, so anything the workflow deploys on but
     // this list omits is a deploy the monitor cannot see fail. Pinned by
@@ -567,7 +582,7 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequir
     // push's own diff (#7359). A skip is only legitimate if production already
     // has everything main has; "this particular push touched nothing" was true
     // of every push that followed a stranded merge.
-    if (workflow.skipProofPath && typeof skipProof === 'function') {
+    if (workflow.skipProofPaths && typeof skipProof === 'function') {
       let skipLegitimate = null;
       try {
         skipLegitimate = skipProof();
@@ -600,7 +615,7 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequir
           state: 'OK',
           verdict: 'DEPLOY_SKIPPED_LEGIT',
           runId: run.runId,
-          detail: `run ${run.runId} skipped the deploy and production already has every ${workflow.skipProofPath} change on main`,
+          detail: `run ${run.runId} skipped the deploy and production already has every bundled change on main (${workflow.skipProofPaths.join(", ")})`,
         };
       }
       // Proven drift and an unreadable baseline are different alarms: the first
@@ -611,14 +626,14 @@ export function judgeWorkflow({ workflow, run, jobs, skipProof, deploymentRequir
           state: 'ALARM',
           verdict: 'DEPLOY_SKIPPED_BEHIND_BASELINE',
           runId: run.runId,
-          detail: `run ${run.runId} skipped the deploy, but ${workflow.skipProofPath} changed between the last successful deploy and current main — production is behind`,
+          detail: `run ${run.runId} skipped the deploy, but ${workflow.skipProofPaths.join(", ")} changed between the last successful deploy and current main — production is behind`,
         };
       }
       return {
         state: 'ALARM',
         verdict: 'DEPLOY_SKIPPED_UNPROVEN',
         runId: run.runId,
-        detail: `run ${run.runId} skipped the deploy and the deployed baseline for ${workflow.skipProofPath} could not be read`,
+        detail: `run ${run.runId} skipped the deploy and the deployed baseline could not be read`,
       };
     }
     return {
@@ -669,7 +684,7 @@ export function checkPostmergeDeploys({ repository, gh, git, now = Date.now() })
           runAttempt: run.runAttempt,
         });
       }
-      const skipProof = workflow.skipProofPath
+      const skipProof = workflow.skipProofPaths
         ? () => {
           // "Is production behind main?", not "did this push touch the path?"
           // (#7359). The baseline is the commit the deploy workflow recorded as
@@ -683,7 +698,7 @@ export function checkPostmergeDeploys({ repository, gh, git, now = Date.now() })
             git,
             baseSha,
             headSha: 'origin/main',
-            paths: [workflow.skipProofPath],
+            paths: workflow.skipProofPaths,
           });
         }
         : null;

--- a/scripts/check-postmerge-deploys.mjs
+++ b/scripts/check-postmerge-deploys.mjs
@@ -65,9 +65,19 @@ export const MONITORED_WORKFLOWS = Object.freeze([
     // silent-staleness class as #7359, through a different door. Pinned by
     // 'the convex skip proof covers every path the bundle is built from', which
     // derives the real list from the source rather than trusting this copy.
+    // Listed file-by-file rather than as whole directories on purpose: `shared/`
+    // holds plenty the bundle never sees (manifests, frontend-only helpers), and
+    // a directory filter would deploy production on every unrelated touch —
+    // adding deploy churn to the very monitor this exists to keep quiet. The
+    // derived test is what makes that precision safe: a NEW cross-boundary
+    // import fails CI until it is added here, which is exactly the moment to
+    // think about it.
     skipProofPaths: Object.freeze([
       'convex/',
-      'shared/',
+      'shared/mcp-attribution.ts',
+      'shared/company-monitoring-contract.ts',
+      'shared/company-monitoring-evidence.ts',
+      'shared/legal.ts',
       'scripts/lib/company-monitoring-classification.mjs',
       'src/utils/country-codes.ts',
     ]),

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -1221,9 +1221,14 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
     walk(convexDir);
     assert.ok(escaping.size > 0, 'the deriver must actually find the known cross-boundary imports');
 
-    const covered = (target) => CONVEX.skipProofPaths.some(
-      (p) => (p.endsWith('/') ? target.startsWith(p) : target === p || target.startsWith(`${p}.`)),
-    );
+    // Import specifiers usually omit the extension (`shared/mcp-attribution`)
+    // while the pathspec must name the real file (`shared/mcp-attribution.ts`),
+    // so match in both directions as well as by directory prefix.
+    const covered = (target) => CONVEX.skipProofPaths.some((p) => (
+      p.endsWith('/')
+        ? target.startsWith(p)
+        : target === p || p.startsWith(`${target}.`) || target.startsWith(`${p}.`)
+    ));
     const uncovered = [...escaping].filter((target) => !covered(target));
     assert.deepEqual(
       uncovered,

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -1328,9 +1328,24 @@ describe('convex deploy diff fallbacks execute fail-closed (#7359)', () => {
     .replace(/\$\{\{ github\.event_name \}\}/g, 'push')
     .replace(/\$\{\{ github\.event\.after \}\}/g, '"$AFTER_SHA"');
 
+  // A git hook exports GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE, and a child
+  // git inherits them — they override `-C`, so under the pre-push hook these
+  // commands would operate on the REAL repository (or refuse: "this operation
+  // must be run in a work tree"). Strip every GIT_* var so the temp repo is
+  // genuinely isolated from whatever invoked the suite.
+  const cleanEnv = (extra = {}) => {
+    const env = Object.fromEntries(
+      Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_')),
+    );
+    return { ...env, ...extra };
+  };
+
   function inTempRepo(fn) {
     const dir = mkdtempSync(join(tmpdir(), 'wm-convex-deploy-'));
-    const git = (...args) => execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8' }).trim();
+    const git = (...args) => execFileSync('git', ['-C', dir, ...args], {
+      encoding: 'utf8',
+      env: cleanEnv(),
+    }).trim();
     try {
       git('init', '-q', '-b', 'main');
       git('config', 'user.email', 'test@example.com');
@@ -1348,16 +1363,17 @@ describe('convex deploy diff fallbacks execute fail-closed (#7359)', () => {
   function decide({ dir, tagAt, afterSha }) {
     const outputFile = join(dir, 'gh-output');
     writeFileSync(outputFile, '');
-    if (tagAt) execFileSync('git', ['-C', dir, 'tag', '-f', 'convex-deployed', tagAt]);
+    if (tagAt) execFileSync('git', ['-C', dir, 'tag', '-f', 'convex-deployed', tagAt], { env: cleanEnv() });
     execFileSync('bash', ['-c', shell], {
       cwd: dir,
       encoding: 'utf8',
-      env: {
-        ...process.env,
+      // Same scrub: the workflow shell runs git itself, so an inherited GIT_DIR
+      // would point it at the real repo and the assertions would be meaningless.
+      env: cleanEnv({
         GITHUB_OUTPUT: outputFile,
         DEPLOYED_TAG: 'convex-deployed',
         AFTER_SHA: afterSha,
-      },
+      }),
     });
     return readFileSync(outputFile, 'utf8').trim();
   }

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -5,7 +5,7 @@
 // warning, not a healthy pass; git/4xx/ENOENT still fail the job.
 
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { describe, it } from 'node:test';
 import { parse as parseYaml } from 'yaml';
 
@@ -1077,7 +1077,10 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
     // The diff must run from the deployed commit to current main, never from
     // the newest run's parent — that per-push question is what missed it.
     const diff = gitCalls.find((args) => args[0] === 'diff');
-    assert.deepEqual(diff, ['diff', '--name-only', BASELINE_SHA, 'origin/main', '--', 'convex/']);
+    assert.deepEqual(
+      diff,
+      ['diff', '--name-only', BASELINE_SHA, 'origin/main', '--', ...CONVEX.skipProofPaths],
+    );
     assert.ok(
       gitCalls.some((args) => args[0] === 'rev-parse' && args.includes(TAG_REF)),
       'the baseline must come from the deployed tag',
@@ -1145,7 +1148,7 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
       /BEFORE="\$\{\{ github\.event\.before \}\}"/,
       'github.event.before is the per-push baseline that stranded #7344',
     );
-    assert.match(changesStep.run, /git diff --name-only "\$BEFORE" "\$AFTER" -- 'convex\/'/);
+    assert.match(changesStep.run, /git diff --name-only "\$BEFORE" "\$AFTER" --/);
 
     // The monitor and the workflow must name the SAME tag — two sources of
     // truth for "what is live" is the bug this shape exists to prevent.
@@ -1186,6 +1189,60 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
       stepNames.indexOf('Convex deploy (prod)') < stepNames.indexOf('Record the deployed commit'),
       'the baseline must be recorded only after a successful deploy',
     );
+  });
+
+  // The skip proof is only as good as the path list it diffs. `convex/` alone
+  // is not the deployed bundle: convex modules import runtime values from
+  // outside it, and `convex deploy` bundles whatever those imports reach. A file
+  // the bundle contains but the list omits can change what production runs while
+  // the deploy is skipped and the monitor calls that skip legitimate — #7359's
+  // class through a different door.
+  //
+  // This derives the real set from the SOURCE rather than restating the copy in
+  // MONITORED_WORKFLOWS, so a new cross-boundary import fails the test instead
+  // of silently widening the blind spot.
+  it('the convex skip proof covers every path the bundle is built from', () => {
+    const convexDir = new URL('../convex/', import.meta.url);
+    const escaping = new Set();
+    const walk = (dir) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === '__tests__' || entry.name === '_generated') continue;
+        const child = new URL(`${entry.name}${entry.isDirectory() ? '/' : ''}`, dir);
+        if (entry.isDirectory()) { walk(child); continue; }
+        if (!/\.(ts|mjs|js)$/.test(entry.name)) continue;
+        const source = readFileSync(child, 'utf8');
+        // Only runtime imports matter — a type-only import is erased and never
+        // reaches the bundle.
+        for (const match of source.matchAll(/^\s*import\s+(?!type\s)[^;]*?from\s+["'](\.\.\/\.\.\/[^"']+)["']/gm)) {
+          escaping.add(new URL(match[1], child).pathname.replace(/^.*\/replicated-mixing-cerf\//, ''));
+        }
+      }
+    };
+    walk(convexDir);
+    assert.ok(escaping.size > 0, 'the deriver must actually find the known cross-boundary imports');
+
+    const covered = (target) => CONVEX.skipProofPaths.some(
+      (p) => (p.endsWith('/') ? target.startsWith(p) : target === p || target.startsWith(`${p}.`)),
+    );
+    const uncovered = [...escaping].filter((target) => !covered(target));
+    assert.deepEqual(
+      uncovered,
+      [],
+      'these files are bundled into the Convex deploy but are outside skipProofPaths, so a change to '
+      + 'them would deploy nothing and still read as a legitimate skip. Add them to skipProofPaths '
+      + 'AND to convex-deploy.yml\'s diff pathspec.',
+    );
+
+    // Both halves must agree, or the deployer and the monitor disagree about
+    // what a deploy is even for.
+    const source = readFileSync(new URL('../.github/workflows/convex-deploy.yml', import.meta.url), 'utf8');
+    const changesStep = parseYaml(source).jobs.changes.steps.find((step) => step.id === 'diff');
+    for (const path of CONVEX.skipProofPaths) {
+      assert.ok(
+        changesStep.run.includes(`'${path}'`),
+        `convex-deploy.yml's diff pathspec must include ${path}`,
+      );
+    }
   });
 
   it('the monitor refreshes the tag it reads', () => {

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -6,7 +6,9 @@
 
 import assert from 'node:assert/strict';
 import { readFileSync, readdirSync } from 'node:fs';
+import { relative } from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
 
 import {
@@ -29,6 +31,7 @@ import {
 
 const NOW = Date.parse('2026-08-10T12:00:00Z');
 const HOUR = 60 * 60 * 1000;
+const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 
 function run(overrides = {}) {
   return {
@@ -1214,7 +1217,11 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
         // Only runtime imports matter — a type-only import is erased and never
         // reaches the bundle.
         for (const match of source.matchAll(/^\s*import\s+(?!type\s)[^;]*?from\s+["'](\.\.\/\.\.\/[^"']+)["']/gm)) {
-          escaping.add(new URL(match[1], child).pathname.replace(/^.*\/replicated-mixing-cerf\//, ''));
+          // Relative to the repo root, so the derived paths are comparable to
+          // the pathspec on any checkout. Resolving to an absolute path here
+          // would compare against a machine-specific prefix and vacuously pass
+          // wherever that prefix happened to be stripped.
+          escaping.add(relative(REPO_ROOT, fileURLToPath(new URL(match[1], child))));
         }
       }
     };

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -12,11 +12,10 @@ import { parse as parseYaml } from 'yaml';
 import {
   DEFAULT_NO_RUN_WINDOW_MS,
   MONITORED_WORKFLOWS,
-  DEPLOY_BASELINE_MAX_RUNS,
   checkPostmergeDeploys,
   createRetryingGh,
   diffTouchesPaths,
-  readLastDeployedSha,
+  readDeployedBaselineSha,
   formatResultMark,
   githubWarningAnnotations,
   isGithubRecordUnreadability,
@@ -990,142 +989,147 @@ describe('monitored trigger paths mirror each workflow push filter', () => {
 // when the only question that matters is "is production behind main?".
 describe('convex deploy drift against the deployed baseline (#7359)', () => {
   const BASELINE_SHA = 'b'.repeat(40);
+  const TAG_REF = 'refs/tags/convex-deployed^{commit}';
+
+  function healthyOtherWorkflows(joined) {
+    if (/workflows\/(deploy-railway-reconcile-control|deploy-worker)\.yml\/runs/.test(joined)) {
+      return JSON.stringify({
+        workflow_runs: [{
+          id: 1, created_at: '2026-08-29T13:00:00Z', conclusion: 'success', run_attempt: 1, head_sha: 'f'.repeat(40),
+        }],
+      });
+    }
+    if (/actions\/runs\/1\/attempts/.test(joined)) {
+      return jobsPayload([{ name: 'Wrangler deploy', conclusion: 'success', status: 'completed' }]);
+    }
+    return null;
+  }
 
   /**
-   * The real 2026-08-29 run sequence, newest first: the orphaned merge's run was
-   * cancelled, later runs went green with the deploy job skipped, and the last
-   * run that actually deployed sits five runs back.
+   * The tail of the real 2026-08-29 sequence: the newest run is green with the
+   * deploy job SKIPPED, which is exactly the shape that used to resolve to
+   * DEPLOY_SKIPPED_LEGIT while a merged change sat undeployed.
    */
-  function incidentRuns() {
-    return [
-      { id: 810, created_at: '2026-08-29T13:35:51Z', conclusion: 'success', run_attempt: 1, head_sha: '7'.repeat(40) },
-      { id: 809, created_at: '2026-08-29T12:49:11Z', conclusion: 'success', run_attempt: 1, head_sha: 'c'.repeat(40) },
-      { id: 808, created_at: '2026-08-29T12:48:49Z', conclusion: 'cancelled', run_attempt: 1, head_sha: '9'.repeat(40) },
-      { id: 807, created_at: '2026-08-29T12:48:30Z', conclusion: 'success', run_attempt: 1, head_sha: 'e'.repeat(40) },
-      // The stranded merge itself.
-      { id: 806, created_at: '2026-08-29T12:47:27Z', conclusion: 'cancelled', run_attempt: 1, head_sha: '6'.repeat(40) },
-      { id: 805, created_at: '2026-08-29T12:46:52Z', conclusion: 'success', run_attempt: 1, head_sha: BASELINE_SHA },
-    ];
+  function convexGh(joined) {
+    if (/workflows\/convex-deploy\.yml\/runs/.test(joined)) {
+      return JSON.stringify({
+        workflow_runs: [{
+          id: 810, created_at: '2026-08-29T13:35:51Z', conclusion: 'success', run_attempt: 1, head_sha: '7'.repeat(40),
+        }],
+      });
+    }
+    if (/actions\/runs\/810\/attempts/.test(joined)) {
+      return jobsPayload([{ name: 'deploy', conclusion: 'skipped', status: 'completed' }]);
+    }
+    return null;
   }
 
-  // Only run 805 actually deployed; the other successes skipped the job.
-  function incidentJobs(runId) {
-    const conclusion = runId === 805 ? 'success' : 'skipped';
-    return jobsPayload([{ name: 'deploy', conclusion, status: 'completed' }]);
+  function runMonitor({ git }) {
+    return checkPostmergeDeploys({
+      repository: 'koala73/worldmonitor',
+      gh: (args) => {
+        const joined = args.join(' ');
+        const answer = healthyOtherWorkflows(joined) ?? convexGh(joined);
+        if (answer === null) throw new Error(`unexpected gh call: ${joined}`);
+        return answer;
+      },
+      git,
+      now: Date.parse('2026-08-29T13:40:00Z'),
+    });
   }
 
-  function incidentGh({ runs = incidentRuns(), jobs = incidentJobs } = {}) {
-    return (args) => {
-      const joined = args.join(' ');
-      if (/workflows\/convex-deploy\.yml\/runs/.test(joined)) {
-        return JSON.stringify({ workflow_runs: runs });
-      }
-      const jobsMatch = joined.match(/actions\/runs\/(\d+)\/attempts/);
-      if (jobsMatch) return jobs(Number(jobsMatch[1]));
-      throw new Error(`unexpected gh call: ${joined}`);
-    };
+  function convexResult(results) {
+    return results.find((result) => result.workflow === 'convex-deploy.yml');
   }
 
-  it('walks past cancelled and skipped-deploy runs to the last real deploy', () => {
+  it('reads the baseline from the tag the deploy workflow writes', () => {
     assert.equal(
-      readLastDeployedSha({
-        gh: incidentGh(),
-        repository: 'koala73/worldmonitor',
-        workflowFile: 'convex-deploy.yml',
-        deployJobName: 'deploy',
-      }),
+      readDeployedBaselineSha({ git: () => `${BASELINE_SHA}\n`, tagRef: 'convex-deployed' }),
       BASELINE_SHA,
     );
   });
 
-  it('refuses to invent a baseline when nothing in the budget deployed', () => {
-    // Never returning the newest head here is the whole point: treating an
-    // undeployed run as the baseline would prove every future skip legitimate.
+  it('marks a missing tag as unset rather than inventing a baseline', () => {
+    // `rev-parse --verify --quiet` prints nothing when the ref is absent.
     assert.throws(
-      () => readLastDeployedSha({
-        gh: incidentGh({ jobs: () => jobsPayload([{ name: 'deploy', conclusion: 'skipped', status: 'completed' }]) }),
-        repository: 'koala73/worldmonitor',
-        workflowFile: 'convex-deploy.yml',
-        deployJobName: 'deploy',
-      }),
-      /baseline/,
+      () => readDeployedBaselineSha({ git: () => '', tagRef: 'convex-deployed' }),
+      (error) => error.deployedBaselineUnset === true,
     );
-  });
-
-  it('bounds how many runs it will read before giving up', () => {
-    let jobReads = 0;
-    const many = Array.from({ length: 60 }, (_, index) => ({
-      id: 900 + index,
-      created_at: new Date(Date.parse('2026-08-29T12:00:00Z') - index * 60_000).toISOString(),
-      conclusion: 'success',
-      run_attempt: 1,
-      head_sha: String(index).padStart(40, '0'),
-    }));
-    assert.throws(
-      () => readLastDeployedSha({
-        gh: incidentGh({
-          runs: many,
-          jobs: () => {
-            jobReads += 1;
-            return jobsPayload([{ name: 'deploy', conclusion: 'skipped', status: 'completed' }]);
-          },
-        }),
-        repository: 'koala73/worldmonitor',
-        workflowFile: 'convex-deploy.yml',
-        deployJobName: 'deploy',
-      }),
-      /baseline/,
-    );
-    assert.equal(jobReads, DEPLOY_BASELINE_MAX_RUNS);
   });
 
   it('alarms on the real incident instead of proving the skip legitimate', () => {
     const gitCalls = [];
-    const results = checkPostmergeDeploys({
-      repository: 'koala73/worldmonitor',
-      gh: (args) => {
-        const joined = args.join(' ');
-        // The other two monitored workflows are healthy and irrelevant here.
-        if (/workflows\/(deploy-railway-reconcile-control|deploy-worker)\.yml\/runs/.test(joined)) {
-          return JSON.stringify({
-            workflow_runs: [{
-              id: 1, created_at: '2026-08-29T13:00:00Z', conclusion: 'success', run_attempt: 1, head_sha: 'f'.repeat(40),
-            }],
-          });
-        }
-        if (/actions\/runs\/1\/attempts/.test(joined)) {
-          return jobsPayload([{ name: 'Wrangler deploy', conclusion: 'success', status: 'completed' }]);
-        }
-        return incidentGh()(args);
-      },
+    const results = runMonitor({
       git: (args) => {
         gitCalls.push(args);
-        // convex/ moved between the deployed baseline and current main — the
+        if (args[0] === 'rev-parse') return `${BASELINE_SHA}\n`;
+        // convex/ moved between the deployed commit and current main — the
         // stranded #7344 merge.
         if (args.includes(BASELINE_SHA)) return 'convex/payments/billing.ts\n';
         return '';
       },
-      now: Date.parse('2026-08-29T13:40:00Z'),
     });
 
-    const convex = results.find((result) => result.workflow === 'convex-deploy.yml');
+    const convex = convexResult(results);
     assert.equal(convex.state, 'ALARM');
     assert.equal(convex.verdict, 'DEPLOY_SKIPPED_BEHIND_BASELINE');
 
-    // The diff must be taken from the deployed baseline to current main, never
-    // from the newest run's parent — that per-push question is what missed it.
-    const convexDiff = gitCalls.find((args) => args.includes('--') && args.includes('convex/'));
-    assert.deepEqual(convexDiff, ['diff', '--name-only', BASELINE_SHA, 'origin/main', '--', 'convex/']);
+    // The diff must run from the deployed commit to current main, never from
+    // the newest run's parent — that per-push question is what missed it.
+    const diff = gitCalls.find((args) => args[0] === 'diff');
+    assert.deepEqual(diff, ['diff', '--name-only', BASELINE_SHA, 'origin/main', '--', 'convex/']);
     assert.ok(
-      !gitCalls.some((args) => args[0] === 'rev-parse'),
-      'the parent-of-head lookup is the removed per-push baseline and must not be used',
+      gitCalls.some((args) => args[0] === 'rev-parse' && args.includes(TAG_REF)),
+      'the baseline must come from the deployed tag',
     );
   });
 
-  // The monitor only ALARMS on drift; convex-deploy.yml is what clears it on the
-  // next push. That self-heal exists only while its diff baseline is the
-  // deployed tag — reverting to `github.event.before` restores the bug with
-  // every test here still green, because none of them read the workflow.
+  it('stays healthy when the deployed commit already matches main', () => {
+    const convex = convexResult(runMonitor({
+      git: (args) => (args[0] === 'rev-parse' ? `${BASELINE_SHA}\n` : ''),
+    }));
+    assert.equal(convex.state, 'OK');
+    assert.equal(convex.verdict, 'DEPLOY_SKIPPED_LEGIT');
+  });
+
+  // The regression an Actions-API baseline caused. convex-deploy.yml moves the
+  // tag right after `convex deploy` returns and BEFORE the seed steps, so a
+  // failed seed reds the run while that code IS live. A baseline keyed on the
+  // deploy JOB's conclusion rejects that run and then reports "production is
+  // behind" about deployed code — every tick, forever, and a chronically red
+  // monitor is a blind spot. The tag cannot disagree with itself.
+  it('does not report drift for code a seed-failed run already deployed', () => {
+    const deployedHead = '5'.repeat(40);
+    const convex = convexResult(runMonitor({
+      // main is AT the deployed commit: the seed failure did not undeploy it.
+      git: (args) => (args[0] === 'rev-parse' ? `${deployedHead}\n` : ''),
+    }));
+    assert.equal(convex.state, 'OK');
+    assert.equal(convex.verdict, 'DEPLOY_SKIPPED_LEGIT');
+  });
+
+  it('reports an unrecorded baseline as UNKNOWN, not as a failed deploy', () => {
+    const results = runMonitor({ git: () => '' });
+    const convex = convexResult(results);
+    assert.equal(convex.state, 'UNKNOWN');
+    assert.equal(convex.verdict, 'DEPLOY_BASELINE_UNSET');
+    assert.deepEqual(summarizeResults(results).alarms, []);
+  });
+
+  it('still ALARMs when the baseline read fails for a LOCAL reason', () => {
+    // git failures stay ALARM — only "not recorded yet" is UNKNOWN. A local
+    // proof that cannot run is a blind monitor.
+    const verdict = judgeWorkflow({
+      workflow: CONVEX,
+      run: run({ runId: 557 }),
+      jobs: new Map([['deploy', { name: 'deploy', conclusion: 'skipped', status: 'completed' }]]),
+      skipProof: () => { throw new Error('fatal: not a git repository'); },
+      now: NOW,
+    });
+    assert.equal(verdict.state, 'ALARM');
+    assert.equal(verdict.verdict, 'DEPLOY_SKIPPED_UNPROVEN');
+  });
+
   it('convex-deploy.yml diffs from the deployed tag, not this push range', () => {
     const source = readFileSync(new URL('../.github/workflows/convex-deploy.yml', import.meta.url), 'utf8');
     const doc = parseYaml(source);
@@ -1143,13 +1147,37 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
     );
     assert.match(changesStep.run, /git diff --name-only "\$BEFORE" "\$AFTER" -- 'convex\/'/);
 
-    // The tag is only meaningful if the deploy job actually moves it, and only
-    // if that job is allowed to write.
+    // The monitor and the workflow must name the SAME tag — two sources of
+    // truth for "what is live" is the bug this shape exists to prevent.
+    assert.equal(doc.env.DEPLOYED_TAG, CONVEX.deployedTagRef);
+
     assert.equal(doc.jobs.deploy.permissions.contents, 'write');
     const recordStep = doc.jobs.deploy.steps.find((step) => step.name === 'Record the deployed commit');
     assert.ok(recordStep, 'the deploy job must record the commit it deployed');
-    assert.match(recordStep.run, /git push --force origin "refs\/tags\/\$DEPLOYED_TAG"/);
-    assert.equal(doc.env.DEPLOYED_TAG, 'convex-deployed');
+    assert.match(recordStep.run, /git push --force/);
+    assert.match(recordStep.run, /refs\/tags\/\$DEPLOYED_TAG/);
+
+    // `contents: write` + a checkout-persisted token would leave a repo-write
+    // credential in .git/config while `npm ci` runs third-party lifecycle
+    // scripts. The token must be step-scoped instead, like CONVEX_DEPLOY_KEY.
+    const checkoutStep = doc.jobs.deploy.steps.find((step) => String(step.uses ?? '').startsWith('actions/checkout@'));
+    assert.equal(
+      checkoutStep.with['persist-credentials'],
+      false,
+      'a write-enabled job must not leave an ambient push credential for npm ci',
+    );
+    assert.ok(recordStep.env?.GH_TOKEN, 'the tag push must carry its own step-scoped token');
+    const npmStep = doc.jobs.deploy.steps.find((step) => String(step.run ?? '').startsWith('npm ci'));
+    assert.equal(npmStep.env, undefined, 'npm ci must not be handed any credential');
+
+    // Production is already updated by the time the tag moves. A transient push
+    // failure must not restate that success as a failed run.
+    assert.equal(
+      recordStep['continue-on-error'],
+      true,
+      'failing to RECORD a successful deploy must not fail the run',
+    );
+    assert.match(recordStep.run, /::warning::/, 'a skipped recording must still be visible');
 
     // Ordering is load-bearing: recording before the deploy would mark code
     // live that never shipped.
@@ -1160,29 +1188,12 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
     );
   });
 
-  it('stays healthy when the deployed baseline already matches main', () => {
-    const results = checkPostmergeDeploys({
-      repository: 'koala73/worldmonitor',
-      gh: (args) => {
-        const joined = args.join(' ');
-        if (/workflows\/(deploy-railway-reconcile-control|deploy-worker)\.yml\/runs/.test(joined)) {
-          return JSON.stringify({
-            workflow_runs: [{
-              id: 1, created_at: '2026-08-29T13:00:00Z', conclusion: 'success', run_attempt: 1, head_sha: 'f'.repeat(40),
-            }],
-          });
-        }
-        if (/actions\/runs\/1\/attempts/.test(joined)) {
-          return jobsPayload([{ name: 'Wrangler deploy', conclusion: 'success', status: 'completed' }]);
-        }
-        return incidentGh()(args);
-      },
-      git: () => '',
-      now: Date.parse('2026-08-29T13:40:00Z'),
-    });
-
-    const convex = results.find((result) => result.workflow === 'convex-deploy.yml');
-    assert.equal(convex.state, 'OK');
-    assert.equal(convex.verdict, 'DEPLOY_SKIPPED_LEGIT');
+  it('the monitor refreshes the tag it reads', () => {
+    // Without --tags --force the local tag never advances past the checkout, so
+    // the monitor would report drift that is already deployed.
+    const monitor = readFileSync(
+      new URL('../.github/workflows/postmerge-deploy-monitor.yml', import.meta.url), 'utf8',
+    );
+    assert.match(monitor, /git fetch --quiet --tags --force origin main/);
   });
 });

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -5,8 +5,10 @@
 // warning, not a healthy pass; git/4xx/ENOENT still fail the job.
 
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync } from 'node:fs';
-import { relative } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { parse as parseYaml } from 'yaml';
@@ -167,7 +169,7 @@ describe('post-merge deploy monitor', () => {
       now: NOW,
     });
     assert.equal(verdict.state, 'ALARM');
-    assert.equal(verdict.verdict, 'DEPLOY_SKIPPED_BEHIND_BASELINE');
+    assert.equal(verdict.verdict, 'DEPLOY_BEHIND_BASELINE');
     assert.match(verdict.detail, /behind/);
   });
 
@@ -180,7 +182,7 @@ describe('post-merge deploy monitor', () => {
       now: NOW,
     });
     assert.equal(verdict.state, 'ALARM');
-    assert.equal(verdict.verdict, 'DEPLOY_SKIPPED_UNPROVEN');
+    assert.equal(verdict.verdict, 'DEPLOY_BASELINE_UNPROVEN');
   });
 
   it('alarms on any skipped deploy job in a workflow with no legitimate skip', () => {
@@ -507,7 +509,16 @@ describe('post-merge deploy monitor', () => {
     const worker = results.find((entry) => entry.workflow === 'deploy-worker.yml');
     assert.equal(worker.state, 'OK');
     assert.equal(worker.verdict, 'DEPLOY_NOT_DUE');
-    assert.equal(gitCalls.length, 2, 'both path-filtered workflows require current-tree proof');
+    // Counts the path-filtered workflows' own proofs rather than every git call:
+    // convex now also proves drift on every result (#7359 review finding 2), so
+    // a global count would conflate the two mechanisms.
+    const triggerPathProofs = MONITORED_WORKFLOWS
+      .filter((workflow) => Array.isArray(workflow.triggerPaths))
+      .map((workflow) => gitCalls.find((args) => args.includes(workflow.triggerPaths[0])));
+    assert.ok(
+      triggerPathProofs.every(Boolean),
+      'both path-filtered workflows require current-tree proof',
+    );
     const workerDiff = gitCalls.find((args) => args.includes('workers/api-cors-preflight/**'));
     assert.deepEqual(workerDiff, [
       'diff',
@@ -993,6 +1004,9 @@ describe('monitored trigger paths mirror each workflow push filter', () => {
 describe('convex deploy drift against the deployed baseline (#7359)', () => {
   const BASELINE_SHA = 'b'.repeat(40);
   const TAG_REF = 'refs/tags/convex-deployed^{commit}';
+  const WORKFLOW = parseYaml(
+    readFileSync(new URL('../.github/workflows/convex-deploy.yml', import.meta.url), 'utf8'),
+  );
 
   function healthyOtherWorkflows(joined) {
     if (/workflows\/(deploy-railway-reconcile-control|deploy-worker)\.yml\/runs/.test(joined)) {
@@ -1008,12 +1022,8 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
     return null;
   }
 
-  /**
-   * The tail of the real 2026-08-29 sequence: the newest run is green with the
-   * deploy job SKIPPED, which is exactly the shape that used to resolve to
-   * DEPLOY_SKIPPED_LEGIT while a merged change sat undeployed.
-   */
-  function convexGh(joined) {
+  /** Newest convex run, with a configurable deploy-job conclusion. */
+  function convexGh(joined, deployConclusion = 'skipped') {
     if (/workflows\/convex-deploy\.yml\/runs/.test(joined)) {
       return JSON.stringify({
         workflow_runs: [{
@@ -1022,17 +1032,17 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
       });
     }
     if (/actions\/runs\/810\/attempts/.test(joined)) {
-      return jobsPayload([{ name: 'deploy', conclusion: 'skipped', status: 'completed' }]);
+      return jobsPayload([{ name: 'deploy', conclusion: deployConclusion, status: 'completed' }]);
     }
     return null;
   }
 
-  function runMonitor({ git }) {
+  function runMonitor({ git, deployConclusion = 'skipped' }) {
     return checkPostmergeDeploys({
       repository: 'koala73/worldmonitor',
       gh: (args) => {
         const joined = args.join(' ');
-        const answer = healthyOtherWorkflows(joined) ?? convexGh(joined);
+        const answer = healthyOtherWorkflows(joined) ?? convexGh(joined, deployConclusion);
         if (answer === null) throw new Error(`unexpected gh call: ${joined}`);
         return answer;
       },
@@ -1041,9 +1051,11 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
     });
   }
 
-  function convexResult(results) {
-    return results.find((result) => result.workflow === 'convex-deploy.yml');
-  }
+  const convexResult = (results) => results.find((r) => r.workflow === 'convex-deploy.yml');
+  const driftGit = (sha) => (args) => {
+    if (args[0] === 'rev-parse') return `${sha}\n`;
+    return args.includes(sha) ? 'convex/payments/billing.ts\n' : '';
+  };
 
   it('reads the baseline from the tag the deploy workflow writes', () => {
     assert.equal(
@@ -1053,7 +1065,6 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
   });
 
   it('marks a missing tag as unset rather than inventing a baseline', () => {
-    // `rev-parse --verify --quiet` prints nothing when the ref is absent.
     assert.throws(
       () => readDeployedBaselineSha({ git: () => '', tagRef: 'convex-deployed' }),
       (error) => error.deployedBaselineUnset === true,
@@ -1065,20 +1076,14 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
     const results = runMonitor({
       git: (args) => {
         gitCalls.push(args);
-        if (args[0] === 'rev-parse') return `${BASELINE_SHA}\n`;
-        // convex/ moved between the deployed commit and current main — the
-        // stranded #7344 merge.
-        if (args.includes(BASELINE_SHA)) return 'convex/payments/billing.ts\n';
-        return '';
+        return driftGit(BASELINE_SHA)(args);
       },
     });
 
     const convex = convexResult(results);
     assert.equal(convex.state, 'ALARM');
-    assert.equal(convex.verdict, 'DEPLOY_SKIPPED_BEHIND_BASELINE');
+    assert.equal(convex.verdict, 'DEPLOY_BEHIND_BASELINE');
 
-    // The diff must run from the deployed commit to current main, never from
-    // the newest run's parent — that per-push question is what missed it.
     const diff = gitCalls.find((args) => args[0] === 'diff');
     assert.deepEqual(
       diff,
@@ -1090,28 +1095,44 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
     );
   });
 
-  it('stays healthy when the deployed commit already matches main', () => {
+  // #7359 review finding 2. "The newest run deployed" is not "production has
+  // current main": if a later watched-path commit produces no run at all
+  // (Actions degraded, a broken trigger, a workflow edit), the newest run stays
+  // a green DEPLOYED. The drift proof must not sit behind that branch.
+  it('alarms on drift even when the newest run DEPLOYED successfully', () => {
     const convex = convexResult(runMonitor({
-      git: (args) => (args[0] === 'rev-parse' ? `${BASELINE_SHA}\n` : ''),
+      git: driftGit(BASELINE_SHA),
+      deployConclusion: 'success',
     }));
-    assert.equal(convex.state, 'OK');
-    assert.equal(convex.verdict, 'DEPLOY_SKIPPED_LEGIT');
+    assert.equal(convex.state, 'ALARM');
+    assert.equal(convex.verdict, 'DEPLOY_BEHIND_BASELINE');
   });
 
-  // The regression an Actions-API baseline caused. convex-deploy.yml moves the
-  // tag right after `convex deploy` returns and BEFORE the seed steps, so a
-  // failed seed reds the run while that code IS live. A baseline keyed on the
-  // deploy JOB's conclusion rejects that run and then reports "production is
-  // behind" about deployed code — every tick, forever, and a chronically red
-  // monitor is a blind spot. The tag cannot disagree with itself.
+  it('stays healthy when the deployed commit already matches main', () => {
+    for (const deployConclusion of ['skipped', 'success']) {
+      const convex = convexResult(runMonitor({
+        git: (args) => (args[0] === 'rev-parse' ? `${BASELINE_SHA}\n` : ''),
+        deployConclusion,
+      }));
+      assert.equal(convex.state, 'OK', deployConclusion);
+      assert.equal(
+        convex.verdict,
+        deployConclusion === 'success' ? 'DEPLOYED' : 'DEPLOY_SKIPPED_LEGIT',
+      );
+    }
+  });
+
+  // convex-deploy.yml moves the tag right after `convex deploy` returns and
+  // BEFORE the seed steps, so a failed seed reds the run while that code IS
+  // live. A baseline keyed on the deploy JOB's conclusion would reject that run
+  // and report "production is behind" about deployed code — forever. The tag
+  // cannot disagree with itself.
   it('does not report drift for code a seed-failed run already deployed', () => {
     const deployedHead = '5'.repeat(40);
     const convex = convexResult(runMonitor({
-      // main is AT the deployed commit: the seed failure did not undeploy it.
       git: (args) => (args[0] === 'rev-parse' ? `${deployedHead}\n` : ''),
     }));
     assert.equal(convex.state, 'OK');
-    assert.equal(convex.verdict, 'DEPLOY_SKIPPED_LEGIT');
   });
 
   it('reports an unrecorded baseline as UNKNOWN, not as a failed deploy', () => {
@@ -1123,8 +1144,6 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
   });
 
   it('still ALARMs when the baseline read fails for a LOCAL reason', () => {
-    // git failures stay ALARM — only "not recorded yet" is UNKNOWN. A local
-    // proof that cannot run is a blind monitor.
     const verdict = judgeWorkflow({
       workflow: CONVEX,
       run: run({ runId: 557 }),
@@ -1133,136 +1152,252 @@ describe('convex deploy drift against the deployed baseline (#7359)', () => {
       now: NOW,
     });
     assert.equal(verdict.state, 'ALARM');
-    assert.equal(verdict.verdict, 'DEPLOY_SKIPPED_UNPROVEN');
+    assert.equal(verdict.verdict, 'DEPLOY_BASELINE_UNPROVEN');
+  });
+
+  // #7359 review finding 1. The first deriver matched only `../../` specifiers,
+  // so it was blind to every top-level convex/*.ts file — and missed
+  // shared/cloud-preferences-contract, a runtime array convex/userPreferences.ts
+  // imports. Resolve real files, follow re-exports, side-effect and dynamic
+  // imports, and recurse: a shared file that imports another shared file bundles
+  // that one too.
+  it('the convex skip proof covers every path the bundle is built from', () => {
+    const EXTS = ['', '.ts', '.tsx', '.mts', '.mjs', '.js', '.d.ts', '/index.ts', '/index.mjs', '/index.js'];
+    const SKIP_DIRS = new Set(['__tests__', 'node_modules']);
+
+    const listFiles = (dir, out = []) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        const child = new URL(`${entry.name}${entry.isDirectory() ? '/' : ''}`, dir);
+        if (entry.isDirectory()) listFiles(child, out);
+        else if (/\.(ts|tsx|mts|mjs|js)$/.test(entry.name)) out.push(fileURLToPath(child));
+      }
+      return out;
+    };
+
+    // Runtime relative specifiers only. `import type` / `export type` are erased
+    // by the compiler and never reach the bundle.
+    const specifiersOf = (src) => {
+      const found = new Set();
+      for (const re of [
+        /^\s*import\s+(?!type\s)[^;]*?from\s+["'](\.[^"']+)["']/gm,
+        /^\s*export\s+(?!type\s)[^;]*?from\s+["'](\.[^"']+)["']/gm,
+        /^\s*import\s+["'](\.[^"']+)["']/gm,
+        /\bimport\s*\(\s*["'](\.[^"']+)["']\s*\)/g,
+      ]) for (const m of src.matchAll(re)) found.add(m[1]);
+      return found;
+    };
+
+    const resolveSpec = (spec, fromFile) => {
+      const base = resolve(dirname(fromFile), spec);
+      for (const ext of EXTS) {
+        const candidate = base + ext;
+        if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+      }
+      return null;
+    };
+
+    const seen = new Set();
+    const external = new Set();
+    const unresolvedExternal = new Set();
+    const queue = listFiles(new URL('../convex/', import.meta.url));
+    assert.ok(queue.length > 0, 'the walker must find convex source files');
+
+    while (queue.length > 0) {
+      const file = queue.pop();
+      if (seen.has(file)) continue;
+      seen.add(file);
+      for (const spec of specifiersOf(readFileSync(file, 'utf8'))) {
+        const target = resolveSpec(spec, file);
+        if (!target) {
+          // Fail closed: an unresolvable specifier that textually escapes
+          // convex/ could be a bundled file this guard cannot see.
+          const naive = relative(REPO_ROOT, resolve(dirname(file), spec));
+          if (!naive.startsWith('convex/')) unresolvedExternal.add(`${relative(REPO_ROOT, file)} -> ${spec}`);
+          continue;
+        }
+        const rel = relative(REPO_ROOT, target);
+        if (!rel.startsWith('convex/')) external.add(rel);
+        queue.push(target);
+      }
+    }
+
+    assert.deepEqual([...unresolvedExternal], [], 'an unresolvable escaping import could hide a bundled file');
+    assert.ok(external.size > 0, 'the deriver must find the known cross-boundary imports');
+    // Guards the deriver itself: the first version matched only `../../` and
+    // silently missed this single-level import.
+    assert.ok(
+      external.has('shared/cloud-preferences-contract.ts'),
+      'the deriver must see single-level (../) escapes from top-level convex files',
+    );
+
+    const covered = (target) => CONVEX.skipProofPaths.some((p) => (
+      p.endsWith('/') ? target.startsWith(p) : target === p
+    ));
+    assert.deepEqual(
+      [...external].filter((t) => !covered(t)).sort(),
+      [],
+      'these files are bundled into the Convex deploy but are outside skipProofPaths, so a change to '
+      + 'them would deploy nothing and still read as a legitimate skip. Add them to skipProofPaths '
+      + "AND to convex-deploy.yml's diff pathspec.",
+    );
+
+    const changesStep = WORKFLOW.jobs.changes.steps.find((step) => step.id === 'diff');
+    for (const path of CONVEX.skipProofPaths) {
+      assert.ok(changesStep.run.includes(`'${path}'`), `convex-deploy.yml's pathspec must include ${path}`);
+    }
   });
 
   it('convex-deploy.yml diffs from the deployed tag, not this push range', () => {
-    const source = readFileSync(new URL('../.github/workflows/convex-deploy.yml', import.meta.url), 'utf8');
-    const doc = parseYaml(source);
-    const changesStep = doc.jobs.changes.steps.find((step) => step.id === 'diff');
-
+    const changesStep = WORKFLOW.jobs.changes.steps.find((step) => step.id === 'diff');
     assert.match(
       changesStep.run,
       /BEFORE="\$\(git rev-parse --verify --quiet "refs\/tags\/\$DEPLOYED_TAG/,
-      'the convex/ diff baseline must be the deployed tag',
+      'the diff baseline must be the deployed tag',
     );
     assert.doesNotMatch(
       changesStep.run,
       /BEFORE="\$\{\{ github\.event\.before \}\}"/,
       'github.event.before is the per-push baseline that stranded #7344',
     );
-    assert.match(changesStep.run, /git diff --name-only "\$BEFORE" "\$AFTER" --/);
-
-    // The monitor and the workflow must name the SAME tag — two sources of
-    // truth for "what is live" is the bug this shape exists to prevent.
-    assert.equal(doc.env.DEPLOYED_TAG, CONVEX.deployedTagRef);
-
-    assert.equal(doc.jobs.deploy.permissions.contents, 'write');
-    const recordStep = doc.jobs.deploy.steps.find((step) => step.name === 'Record the deployed commit');
-    assert.ok(recordStep, 'the deploy job must record the commit it deployed');
-    assert.match(recordStep.run, /git push --force/);
-    assert.match(recordStep.run, /refs\/tags\/\$DEPLOYED_TAG/);
-
-    // `contents: write` + a checkout-persisted token would leave a repo-write
-    // credential in .git/config while `npm ci` runs third-party lifecycle
-    // scripts. The token must be step-scoped instead, like CONVEX_DEPLOY_KEY.
-    const checkoutStep = doc.jobs.deploy.steps.find((step) => String(step.uses ?? '').startsWith('actions/checkout@'));
-    assert.equal(
-      checkoutStep.with['persist-credentials'],
-      false,
-      'a write-enabled job must not leave an ambient push credential for npm ci',
-    );
-    assert.ok(recordStep.env?.GH_TOKEN, 'the tag push must carry its own step-scoped token');
-    const npmStep = doc.jobs.deploy.steps.find((step) => String(step.run ?? '').startsWith('npm ci'));
-    assert.equal(npmStep.env, undefined, 'npm ci must not be handed any credential');
-
-    // Production is already updated by the time the tag moves. A transient push
-    // failure must not restate that success as a failed run.
-    assert.equal(
-      recordStep['continue-on-error'],
-      true,
-      'failing to RECORD a successful deploy must not fail the run',
-    );
-    assert.match(recordStep.run, /::warning::/, 'a skipped recording must still be visible');
-
-    // Ordering is load-bearing: recording before the deploy would mark code
-    // live that never shipped.
-    const stepNames = doc.jobs.deploy.steps.map((step) => step.name ?? step.id ?? '');
-    assert.ok(
-      stepNames.indexOf('Convex deploy (prod)') < stepNames.indexOf('Record the deployed commit'),
-      'the baseline must be recorded only after a successful deploy',
-    );
+    assert.equal(WORKFLOW.env.DEPLOYED_TAG, CONVEX.deployedTagRef);
   });
 
-  // The skip proof is only as good as the path list it diffs. `convex/` alone
-  // is not the deployed bundle: convex modules import runtime values from
-  // outside it, and `convex deploy` bundles whatever those imports reach. A file
-  // the bundle contains but the list omits can change what production runs while
-  // the deploy is skipped and the monitor calls that skip legitimate — #7359's
-  // class through a different door.
-  //
-  // This derives the real set from the SOURCE rather than restating the copy in
-  // MONITORED_WORKFLOWS, so a new cross-boundary import fails the test instead
-  // of silently widening the blind spot.
-  it('the convex skip proof covers every path the bundle is built from', () => {
-    const convexDir = new URL('../convex/', import.meta.url);
-    const escaping = new Set();
-    const walk = (dir) => {
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        if (entry.name === '__tests__' || entry.name === '_generated') continue;
-        const child = new URL(`${entry.name}${entry.isDirectory() ? '/' : ''}`, dir);
-        if (entry.isDirectory()) { walk(child); continue; }
-        if (!/\.(ts|mjs|js)$/.test(entry.name)) continue;
-        const source = readFileSync(child, 'utf8');
-        // Only runtime imports matter — a type-only import is erased and never
-        // reaches the bundle.
-        for (const match of source.matchAll(/^\s*import\s+(?!type\s)[^;]*?from\s+["'](\.\.\/\.\.\/[^"']+)["']/gm)) {
-          // Relative to the repo root, so the derived paths are comparable to
-          // the pathspec on any checkout. Resolving to an absolute path here
-          // would compare against a machine-specific prefix and vacuously pass
-          // wherever that prefix happened to be stripped.
-          escaping.add(relative(REPO_ROOT, fileURLToPath(new URL(match[1], child))));
-        }
-      }
-    };
-    walk(convexDir);
-    assert.ok(escaping.size > 0, 'the deriver must actually find the known cross-boundary imports');
+  // #7359 review finding 4. `persist-credentials: false` is not sufficient on
+  // its own: npm lifecycle scripts run in the deploy job and can install a git
+  // hook or rewrite git config that survives to a later step, so a token
+  // introduced afterwards for the tag push could still be read or redirected.
+  // The write credential must live in a job that runs no third-party code.
+  it('records the marker in a job that runs no dependency or repository code', () => {
+    assert.equal(WORKFLOW.permissions.contents, 'read', 'the workflow default must stay read-only');
 
-    // Import specifiers usually omit the extension (`shared/mcp-attribution`)
-    // while the pathspec must name the real file (`shared/mcp-attribution.ts`),
-    // so match in both directions as well as by directory prefix.
-    const covered = (target) => CONVEX.skipProofPaths.some((p) => (
-      p.endsWith('/')
-        ? target.startsWith(p)
-        : target === p || p.startsWith(`${target}.`) || target.startsWith(`${p}.`)
-    ));
-    const uncovered = [...escaping].filter((target) => !covered(target));
-    assert.deepEqual(
-      uncovered,
-      [],
-      'these files are bundled into the Convex deploy but are outside skipProofPaths, so a change to '
-      + 'them would deploy nothing and still read as a legitimate skip. Add them to skipProofPaths '
-      + 'AND to convex-deploy.yml\'s diff pathspec.',
-    );
+    const writeJobs = Object.entries(WORKFLOW.jobs)
+      .filter(([, job]) => job.permissions?.contents === 'write')
+      .map(([name]) => name);
+    assert.deepEqual(writeJobs, ['record-baseline'], 'exactly one job may hold contents: write');
 
-    // Both halves must agree, or the deployer and the monitor disagree about
-    // what a deploy is even for.
-    const source = readFileSync(new URL('../.github/workflows/convex-deploy.yml', import.meta.url), 'utf8');
-    const changesStep = parseYaml(source).jobs.changes.steps.find((step) => step.id === 'diff');
-    for (const path of CONVEX.skipProofPaths) {
-      assert.ok(
-        changesStep.run.includes(`'${path}'`),
-        `convex-deploy.yml's diff pathspec must include ${path}`,
-      );
+    const record = WORKFLOW.jobs['record-baseline'];
+    const ran = record.steps.map((step) => step.run ?? '').join('\n');
+    for (const forbidden of ['npm ', 'npx ', 'yarn ', 'pnpm ', 'setup-node']) {
+      assert.ok(!ran.includes(forbidden), `the write-enabled job must not run ${forbidden.trim()}`);
     }
+    assert.ok(
+      !record.steps.some((step) => String(step.uses ?? '').includes('setup-node')),
+      'the write-enabled job must not set up a toolchain it does not need',
+    );
+    assert.match(ran, /git push --force/);
+    assert.match(ran, /refs\/tags\/\$DEPLOYED_TAG/);
+
+    // Gated on the deploy STEP's outcome, so a post-deploy seed failure still
+    // reds the run without making the next push redeploy live code.
+    assert.equal(WORKFLOW.jobs.deploy.outputs.deployed, '${{ steps.deploy.outcome }}');
+    assert.match(record.if, /needs\.deploy\.outputs\.deployed == 'success'/);
+    assert.equal(record.needs, 'deploy');
+
+    // The deploy job runs npm ci, so it must NOT be write-enabled.
+    assert.notEqual(WORKFLOW.jobs.deploy.permissions?.contents, 'write');
+    const checkout = WORKFLOW.jobs.deploy.steps.find((s) => String(s.uses ?? '').startsWith('actions/checkout@'));
+    assert.equal(checkout.with['persist-credentials'], false);
+
+    const recordStep = record.steps.find((step) => step.name === 'Record the deployed commit');
+    assert.equal(recordStep['continue-on-error'], true, 'failing to RECORD must not fail a successful deploy');
+    assert.match(recordStep.run, /::warning::/);
   });
 
   it('the monitor refreshes the tag it reads', () => {
-    // Without --tags --force the local tag never advances past the checkout, so
-    // the monitor would report drift that is already deployed.
     const monitor = readFileSync(
       new URL('../.github/workflows/postmerge-deploy-monitor.yml', import.meta.url), 'utf8',
     );
     assert.match(monitor, /git fetch --quiet --tags --force origin main/);
+  });
+});
+
+// #7359 review finding 5. The fail-CLOSED fallbacks were only ever asserted as
+// workflow TEXT, so neither `git cat-file` branch was executed. These run the
+// real decision logic — extracted verbatim from convex-deploy.yml's diff step —
+// against a throwaway git repository, so a missing deployed commit and a missing
+// pushed head each provably reach convex=true and cannot reach the skip.
+describe('convex deploy diff fallbacks execute fail-closed (#7359)', () => {
+  const changesStep = parseYaml(
+    readFileSync(new URL('../.github/workflows/convex-deploy.yml', import.meta.url), 'utf8'),
+  ).jobs.changes.steps.find((step) => step.id === 'diff');
+
+  // The shell the workflow actually runs, minus the two `${{ }}` expressions
+  // (GitHub substitutes those before the shell ever sees them).
+  const shell = changesStep.run
+    .replace(/\$\{\{ github\.event_name \}\}/g, 'push')
+    .replace(/\$\{\{ github\.event\.after \}\}/g, '"$AFTER_SHA"');
+
+  function inTempRepo(fn) {
+    const dir = mkdtempSync(join(tmpdir(), 'wm-convex-deploy-'));
+    const git = (...args) => execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8' }).trim();
+    try {
+      git('init', '-q', '-b', 'main');
+      git('config', 'user.email', 'test@example.com');
+      git('config', 'user.name', 'test');
+      writeFileSync(join(dir, 'seed.txt'), 'seed\n');
+      git('add', '.');
+      git('commit', '-qm', 'seed');
+      return fn({ dir, git, head: git('rev-parse', 'HEAD') });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  /** Runs the workflow's diff step and returns the convex=... it decided. */
+  function decide({ dir, tagAt, afterSha }) {
+    const outputFile = join(dir, 'gh-output');
+    writeFileSync(outputFile, '');
+    if (tagAt) execFileSync('git', ['-C', dir, 'tag', '-f', 'convex-deployed', tagAt]);
+    execFileSync('bash', ['-c', shell], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputFile,
+        DEPLOYED_TAG: 'convex-deployed',
+        AFTER_SHA: afterSha,
+      },
+    });
+    return readFileSync(outputFile, 'utf8').trim();
+  }
+
+  it('deploys when the deployed commit is missing from history', () => {
+    inTempRepo(({ dir, head }) => {
+      // A tag object cannot point at a commit this clone does not have, so
+      // simulate the force-push case by naming an unreachable SHA as the head.
+      assert.equal(decide({ dir, tagAt: head, afterSha: 'd'.repeat(40) }), 'convex=true');
+    });
+  });
+
+  it('deploys when no baseline tag exists yet', () => {
+    inTempRepo(({ dir, head }) => {
+      assert.equal(decide({ dir, tagAt: null, afterSha: head }), 'convex=true');
+    });
+  });
+
+  it('deploys when a watched bundle path changed since the deployed commit', () => {
+    inTempRepo(({ dir, git, head }) => {
+      mkdirSync(join(dir, 'shared'), { recursive: true });
+      writeFileSync(join(dir, 'shared/mcp-attribution.ts'), 'export const x = 1;\n');
+      git('add', '.');
+      git('commit', '-qm', 'touch a bundled shared file');
+      assert.equal(decide({ dir, tagAt: head, afterSha: git('rev-parse', 'HEAD') }), 'convex=true');
+    });
+  });
+
+  it('skips only when the deployed commit already matches the head', () => {
+    inTempRepo(({ dir, head }) => {
+      assert.equal(decide({ dir, tagAt: head, afterSha: head }), 'convex=false');
+    });
+  });
+
+  it('skips an unrelated change outside the bundle', () => {
+    inTempRepo(({ dir, git, head }) => {
+      writeFileSync(join(dir, 'README.md'), 'unrelated\n');
+      git('add', '.');
+      git('commit', '-qm', 'unrelated');
+      assert.equal(decide({ dir, tagAt: head, afterSha: git('rev-parse', 'HEAD') }), 'convex=false');
+    });
   });
 });

--- a/tests/check-postmerge-deploys.test.mjs
+++ b/tests/check-postmerge-deploys.test.mjs
@@ -12,10 +12,11 @@ import { parse as parseYaml } from 'yaml';
 import {
   DEFAULT_NO_RUN_WINDOW_MS,
   MONITORED_WORKFLOWS,
+  DEPLOY_BASELINE_MAX_RUNS,
   checkPostmergeDeploys,
   createRetryingGh,
-  diffTouchesPath,
   diffTouchesPaths,
+  readLastDeployedSha,
   formatResultMark,
   githubWarningAnnotations,
   isGithubRecordUnreadability,
@@ -151,21 +152,33 @@ describe('post-merge deploy monitor', () => {
     assert.equal(verdict.verdict, 'DEPLOY_SKIPPED_LEGIT');
   });
 
-  it('alarms on a convex deploy skipped without proof that the diff is empty', () => {
-    // Two failure directions: the skipProof throws (unreadable parent) and it
-    // returns false (the head DID touch convex/ but the deploy job skipped —
-    // the workflow filter drifted from reality).
-    for (const skipProof of [() => { throw new Error('unreadable'); }, () => false]) {
-      const verdict = judgeWorkflow({
-        workflow: CONVEX,
-        run: run({ runId: 555 }),
-        jobs: new Map([['deploy', { name: 'deploy', conclusion: 'skipped', status: 'completed' }]]),
-        skipProof,
-        now: NOW,
-      });
-      assert.equal(verdict.state, 'ALARM');
-      assert.match(verdict.verdict, /DEPLOY_SKIPPED_UNPROVEN/);
-    }
+  // The two failure directions are NOT the same alarm and must not be
+  // conflated (#7359): "convex/ provably changed since the last deploy" tells
+  // on-call production is behind and a deploy is owed; "we could not read the
+  // baseline" tells them the monitor is blind. Opposite responses.
+  it('alarms that production is behind when convex/ changed since the last deploy', () => {
+    const verdict = judgeWorkflow({
+      workflow: CONVEX,
+      run: run({ runId: 555 }),
+      jobs: new Map([['deploy', { name: 'deploy', conclusion: 'skipped', status: 'completed' }]]),
+      skipProof: () => false,
+      now: NOW,
+    });
+    assert.equal(verdict.state, 'ALARM');
+    assert.equal(verdict.verdict, 'DEPLOY_SKIPPED_BEHIND_BASELINE');
+    assert.match(verdict.detail, /behind/);
+  });
+
+  it('alarms as unproven when the deployed baseline cannot be read', () => {
+    const verdict = judgeWorkflow({
+      workflow: CONVEX,
+      run: run({ runId: 556 }),
+      jobs: new Map([['deploy', { name: 'deploy', conclusion: 'skipped', status: 'completed' }]]),
+      skipProof: () => { throw new Error('unreadable'); },
+      now: NOW,
+    });
+    assert.equal(verdict.state, 'ALARM');
+    assert.equal(verdict.verdict, 'DEPLOY_SKIPPED_UNPROVEN');
   });
 
   it('alarms on any skipped deploy job in a workflow with no legitimate skip', () => {
@@ -418,20 +431,20 @@ describe('post-merge deploy monitor', () => {
 
   it('judges the diff by trees only, with an empty diff meaning nothing touched', () => {
     assert.equal(
-      diffTouchesPath({
+      diffTouchesPaths({
         git: () => '',
-        parentSha: 'p'.repeat(40),
+        baseSha: 'p'.repeat(40),
         headSha: 'h'.repeat(40),
-        pathPrefix: 'convex/',
+        paths: ['convex/'],
       }),
       false,
     );
     assert.equal(
-      diffTouchesPath({
+      diffTouchesPaths({
         git: () => 'convex/schema.ts\n',
-        parentSha: 'p'.repeat(40),
+        baseSha: 'p'.repeat(40),
         headSha: 'h'.repeat(40),
-        pathPrefix: 'convex/',
+        paths: ['convex/'],
       }),
       true,
     );
@@ -967,4 +980,209 @@ describe('monitored trigger paths mirror each workflow push filter', () => {
       );
     });
   }
+});
+
+// #7359 — a merge burst cancels the QUEUED convex deploy (the concurrency group
+// keeps one pending run and drops the older one), and no later push can rescue
+// it: every subsequent push honestly diffs its OWN range, finds no convex/
+// change, and skips. The monitor agreed, because it proved the skip against the
+// newest run's own parent diff. Both were asking "did THIS push touch convex/?"
+// when the only question that matters is "is production behind main?".
+describe('convex deploy drift against the deployed baseline (#7359)', () => {
+  const BASELINE_SHA = 'b'.repeat(40);
+
+  /**
+   * The real 2026-08-29 run sequence, newest first: the orphaned merge's run was
+   * cancelled, later runs went green with the deploy job skipped, and the last
+   * run that actually deployed sits five runs back.
+   */
+  function incidentRuns() {
+    return [
+      { id: 810, created_at: '2026-08-29T13:35:51Z', conclusion: 'success', run_attempt: 1, head_sha: '7'.repeat(40) },
+      { id: 809, created_at: '2026-08-29T12:49:11Z', conclusion: 'success', run_attempt: 1, head_sha: 'c'.repeat(40) },
+      { id: 808, created_at: '2026-08-29T12:48:49Z', conclusion: 'cancelled', run_attempt: 1, head_sha: '9'.repeat(40) },
+      { id: 807, created_at: '2026-08-29T12:48:30Z', conclusion: 'success', run_attempt: 1, head_sha: 'e'.repeat(40) },
+      // The stranded merge itself.
+      { id: 806, created_at: '2026-08-29T12:47:27Z', conclusion: 'cancelled', run_attempt: 1, head_sha: '6'.repeat(40) },
+      { id: 805, created_at: '2026-08-29T12:46:52Z', conclusion: 'success', run_attempt: 1, head_sha: BASELINE_SHA },
+    ];
+  }
+
+  // Only run 805 actually deployed; the other successes skipped the job.
+  function incidentJobs(runId) {
+    const conclusion = runId === 805 ? 'success' : 'skipped';
+    return jobsPayload([{ name: 'deploy', conclusion, status: 'completed' }]);
+  }
+
+  function incidentGh({ runs = incidentRuns(), jobs = incidentJobs } = {}) {
+    return (args) => {
+      const joined = args.join(' ');
+      if (/workflows\/convex-deploy\.yml\/runs/.test(joined)) {
+        return JSON.stringify({ workflow_runs: runs });
+      }
+      const jobsMatch = joined.match(/actions\/runs\/(\d+)\/attempts/);
+      if (jobsMatch) return jobs(Number(jobsMatch[1]));
+      throw new Error(`unexpected gh call: ${joined}`);
+    };
+  }
+
+  it('walks past cancelled and skipped-deploy runs to the last real deploy', () => {
+    assert.equal(
+      readLastDeployedSha({
+        gh: incidentGh(),
+        repository: 'koala73/worldmonitor',
+        workflowFile: 'convex-deploy.yml',
+        deployJobName: 'deploy',
+      }),
+      BASELINE_SHA,
+    );
+  });
+
+  it('refuses to invent a baseline when nothing in the budget deployed', () => {
+    // Never returning the newest head here is the whole point: treating an
+    // undeployed run as the baseline would prove every future skip legitimate.
+    assert.throws(
+      () => readLastDeployedSha({
+        gh: incidentGh({ jobs: () => jobsPayload([{ name: 'deploy', conclusion: 'skipped', status: 'completed' }]) }),
+        repository: 'koala73/worldmonitor',
+        workflowFile: 'convex-deploy.yml',
+        deployJobName: 'deploy',
+      }),
+      /baseline/,
+    );
+  });
+
+  it('bounds how many runs it will read before giving up', () => {
+    let jobReads = 0;
+    const many = Array.from({ length: 60 }, (_, index) => ({
+      id: 900 + index,
+      created_at: new Date(Date.parse('2026-08-29T12:00:00Z') - index * 60_000).toISOString(),
+      conclusion: 'success',
+      run_attempt: 1,
+      head_sha: String(index).padStart(40, '0'),
+    }));
+    assert.throws(
+      () => readLastDeployedSha({
+        gh: incidentGh({
+          runs: many,
+          jobs: () => {
+            jobReads += 1;
+            return jobsPayload([{ name: 'deploy', conclusion: 'skipped', status: 'completed' }]);
+          },
+        }),
+        repository: 'koala73/worldmonitor',
+        workflowFile: 'convex-deploy.yml',
+        deployJobName: 'deploy',
+      }),
+      /baseline/,
+    );
+    assert.equal(jobReads, DEPLOY_BASELINE_MAX_RUNS);
+  });
+
+  it('alarms on the real incident instead of proving the skip legitimate', () => {
+    const gitCalls = [];
+    const results = checkPostmergeDeploys({
+      repository: 'koala73/worldmonitor',
+      gh: (args) => {
+        const joined = args.join(' ');
+        // The other two monitored workflows are healthy and irrelevant here.
+        if (/workflows\/(deploy-railway-reconcile-control|deploy-worker)\.yml\/runs/.test(joined)) {
+          return JSON.stringify({
+            workflow_runs: [{
+              id: 1, created_at: '2026-08-29T13:00:00Z', conclusion: 'success', run_attempt: 1, head_sha: 'f'.repeat(40),
+            }],
+          });
+        }
+        if (/actions\/runs\/1\/attempts/.test(joined)) {
+          return jobsPayload([{ name: 'Wrangler deploy', conclusion: 'success', status: 'completed' }]);
+        }
+        return incidentGh()(args);
+      },
+      git: (args) => {
+        gitCalls.push(args);
+        // convex/ moved between the deployed baseline and current main — the
+        // stranded #7344 merge.
+        if (args.includes(BASELINE_SHA)) return 'convex/payments/billing.ts\n';
+        return '';
+      },
+      now: Date.parse('2026-08-29T13:40:00Z'),
+    });
+
+    const convex = results.find((result) => result.workflow === 'convex-deploy.yml');
+    assert.equal(convex.state, 'ALARM');
+    assert.equal(convex.verdict, 'DEPLOY_SKIPPED_BEHIND_BASELINE');
+
+    // The diff must be taken from the deployed baseline to current main, never
+    // from the newest run's parent — that per-push question is what missed it.
+    const convexDiff = gitCalls.find((args) => args.includes('--') && args.includes('convex/'));
+    assert.deepEqual(convexDiff, ['diff', '--name-only', BASELINE_SHA, 'origin/main', '--', 'convex/']);
+    assert.ok(
+      !gitCalls.some((args) => args[0] === 'rev-parse'),
+      'the parent-of-head lookup is the removed per-push baseline and must not be used',
+    );
+  });
+
+  // The monitor only ALARMS on drift; convex-deploy.yml is what clears it on the
+  // next push. That self-heal exists only while its diff baseline is the
+  // deployed tag — reverting to `github.event.before` restores the bug with
+  // every test here still green, because none of them read the workflow.
+  it('convex-deploy.yml diffs from the deployed tag, not this push range', () => {
+    const source = readFileSync(new URL('../.github/workflows/convex-deploy.yml', import.meta.url), 'utf8');
+    const doc = parseYaml(source);
+    const changesStep = doc.jobs.changes.steps.find((step) => step.id === 'diff');
+
+    assert.match(
+      changesStep.run,
+      /BEFORE="\$\(git rev-parse --verify --quiet "refs\/tags\/\$DEPLOYED_TAG/,
+      'the convex/ diff baseline must be the deployed tag',
+    );
+    assert.doesNotMatch(
+      changesStep.run,
+      /BEFORE="\$\{\{ github\.event\.before \}\}"/,
+      'github.event.before is the per-push baseline that stranded #7344',
+    );
+    assert.match(changesStep.run, /git diff --name-only "\$BEFORE" "\$AFTER" -- 'convex\/'/);
+
+    // The tag is only meaningful if the deploy job actually moves it, and only
+    // if that job is allowed to write.
+    assert.equal(doc.jobs.deploy.permissions.contents, 'write');
+    const recordStep = doc.jobs.deploy.steps.find((step) => step.name === 'Record the deployed commit');
+    assert.ok(recordStep, 'the deploy job must record the commit it deployed');
+    assert.match(recordStep.run, /git push --force origin "refs\/tags\/\$DEPLOYED_TAG"/);
+    assert.equal(doc.env.DEPLOYED_TAG, 'convex-deployed');
+
+    // Ordering is load-bearing: recording before the deploy would mark code
+    // live that never shipped.
+    const stepNames = doc.jobs.deploy.steps.map((step) => step.name ?? step.id ?? '');
+    assert.ok(
+      stepNames.indexOf('Convex deploy (prod)') < stepNames.indexOf('Record the deployed commit'),
+      'the baseline must be recorded only after a successful deploy',
+    );
+  });
+
+  it('stays healthy when the deployed baseline already matches main', () => {
+    const results = checkPostmergeDeploys({
+      repository: 'koala73/worldmonitor',
+      gh: (args) => {
+        const joined = args.join(' ');
+        if (/workflows\/(deploy-railway-reconcile-control|deploy-worker)\.yml\/runs/.test(joined)) {
+          return JSON.stringify({
+            workflow_runs: [{
+              id: 1, created_at: '2026-08-29T13:00:00Z', conclusion: 'success', run_attempt: 1, head_sha: 'f'.repeat(40),
+            }],
+          });
+        }
+        if (/actions\/runs\/1\/attempts/.test(joined)) {
+          return jobsPayload([{ name: 'Wrangler deploy', conclusion: 'success', status: 'completed' }]);
+        }
+        return incidentGh()(args);
+      },
+      git: () => '',
+      now: Date.parse('2026-08-29T13:40:00Z'),
+    });
+
+    const convex = results.find((result) => result.workflow === 'convex-deploy.yml');
+    assert.equal(convex.state, 'OK');
+    assert.equal(convex.verdict, 'DEPLOY_SKIPPED_LEGIT');
+  });
 });

--- a/tests/postmerge-deploy-monitor-workflow.test.mjs
+++ b/tests/postmerge-deploy-monitor-workflow.test.mjs
@@ -40,7 +40,19 @@ describe('post-merge deploy monitor workflow', () => {
     const runStep = workflow.jobs.monitor.steps.find((step) => step.name === 'Check post-merge deploys reached production');
     assert.ok(runStep, 'workflow must define the checker step');
     const fetchLine = runStep.run.split(/\r?\n/).find((line) => line.includes('git fetch'));
-    assert.equal(fetchLine?.trim(), 'git fetch --quiet origin main', 'proof-ref refresh must fail the job when it cannot run');
+    // Unsuppressed: the refresh must still FAIL THE JOB when it cannot run —
+    // a monitor that silently proceeds on a stale tree proves nothing.
+    assert.ok(fetchLine, 'the checker step must refresh its proof refs');
+    assert.doesNotMatch(fetchLine, /\|\||2>\/dev\/null|--quiet\s*;/, 'the refresh must not be error-suppressed');
+    // `--tags --force` is required by #7359: the convex/ skip proof compares
+    // production's deployed commit (the force-moved `convex-deployed` tag) with
+    // main, and without it the local tag never advances past the checkout — the
+    // monitor would then report drift for code that is already deployed.
+    assert.equal(
+      fetchLine.trim(),
+      'git fetch --quiet --tags --force origin main',
+      'the deployed-baseline tag is force-moved, so the refresh must fetch tags with --force',
+    );
     assert.match(runStep.run, /node scripts\/check-postmerge-deploys\.mjs/);
     assert.doesNotMatch(runStep.run, /gate/);
     // The seed-freshness green-main gate must NOT appear here: gating on main


### PR DESCRIPTION
Fixes #7359.

## The problem

A `convex/` change merged during a merge burst could sit in `main` and never reach production, behind an unbroken row of green Convex Deploy badges. #7344 did exactly that for 75 minutes yesterday and was found only by probing the live deployment before running an ops mutation.

Both halves of the system asked the same wrong question — **"did THIS push touch convex/?"** — when the only question that matters is **"is production behind main?"**

- `convex-deploy.yml`'s `changes` job diffed `github.event.before..after`, that push's own range. No later push could rescue an orphaned commit, because no later push's range contains an earlier push's commits. Every subsequent run honestly reported `convex=false` and skipped, forever.
- The monitor proved a skipped deploy legitimate against the newest run's own parent diff, so the five green skips that followed the cancelled run all resolved to `DEPLOY_SKIPPED_LEGIT`.
- `cancel-in-progress: false` protects a run that is already *executing*; GitHub still keeps one pending run per concurrency group and cancels the older one when a newer arrives. The comment claimed it guaranteed "every merge that touches convex/ should reach prod, even if a later merge follows quickly" — describing the exact case that fails.

## The fix

One source of truth for what production is running: a `convex-deployed` git tag the deploy job moves immediately after `npx convex deploy` returns.

- **The deployer self-heals.** The `changes` job diffs from that tag instead of the push range, so an undeployed change stays in the diff until something actually deploys it. Equally immune to a failed deploy, a force-push, and a path-filter edit. Bootstrap and unreachable-baseline both fall through to deploy, matching the job's existing fail-CLOSED defaults.
- **The monitor detects within 10 minutes.** It reads the same tag and diffs it against `origin/main`. A tag cannot disagree with itself.
- Proven drift and an unreadable baseline are now distinct alarms (`DEPLOY_SKIPPED_BEHIND_BASELINE` vs `DEPLOY_SKIPPED_UNPROVEN`) — one says a deploy is owed, the other says the monitor is blind, and they call for opposite responses.
- A tag rather than the Actions API: the answer is a commit, git already has it locally at `fetch-depth: 0`, and it cannot be wrong the way "the newest run looked green" can.

## What review changed

Five reviewers (correctness, adversarial, reliability, security, testing) surfaced nine findings. Two of them changed the design, not just details — both concluded independently that deriving the baseline from the Actions API was wrong, from opposite directions:

| Finding | Why it mattered |
| --- | --- |
| The API baseline drifted from the tag | The tag moves *before* the post-deploy seed steps, deliberately, so a seed failure does not force a redundant redeploy. But `Verify post-deploy seeds` then fails the deploy **job**, and a baseline keyed on job conclusion rejected that run — reporting "production is behind" about code that was already live, every tick, forever. A chronically red monitor is a blind spot, which would have defeated the point. |
| The read budget could not cover normal operation | Only 11 of the last 300 first-parent `main` commits touch `convex/`; interior gaps run 75, 65, 43 and 40 consecutive non-convex pushes. Any bounded run-walk small enough to fit the monitor's 10-minute timeout is far smaller than that, so it would have alarmed for days at a stretch during ordinary work. |

Replacing the walk with the tag dissolved both, plus the read-budget-vs-timeout problem, and deleted more code than it added.

Also fixed from review:

- **Failure direction.** The baseline read is on the skip-proof path, and `judgeWorkflow` collapsed every throw into ALARM — so a TLS/DNS blip would have paged on-call claiming production was behind, contradicting the contract in the file's own header. GitHub unreadability now propagates as UNKNOWN; git-local failures still ALARM.
- **Supply chain.** `contents: write` plus checkout-persisted credentials left a repo-write token in `.git/config` while `npm ci` ran third-party lifecycle scripts — which could force-move the deployed tag itself and suppress future deploys. Now `persist-credentials: false` with the token step-scoped to the tag push, matching `CONVEX_DEPLOY_KEY` and four sibling workflows.
- **False failure.** The tag push had no `continue-on-error`, so a transient push failure turned a **successful production deploy** into a reported `RUN_FAILED`. Now warns and continues; recording is self-healing.
- **`convex/` is not the deployed bundle.** Convex modules import runtime values from outside it — `shared/mcp-attribution` (on the billing path), `shared/company-monitoring-*`, `scripts/lib/company-monitoring-classification.mjs` — and `convex deploy` bundles whatever those imports reach. A change to one of them altered what production runs while touching nothing under `convex/`: the same silent-staleness class through a different door, and it bounded the correctness of this very fix. Pre-existing, but the fix claims production cannot silently fall behind, and that claim was false for a whole category of changes.

## Validation

- **The workflow shell was executed against this repo**, not just reviewed. With the deployed baseline it sees the stranded #7344 files that `before..after` could not; all three branches (no tag yet / drift present / already current) behave correctly.
- **The bundle-path widening was proven against a real merged commit**: `c875cc10c` changed only `shared/source-attribution-manifest.json` — invisible to the old filter, visible to the new one.
- **57 tests**, including a replay of the actual 2026-08-29 run sequence and a regression test for the seed-failure divergence.
- **Mutation-tested rather than assumed green.** Reverting the workflow to `github.event.before`, removing the `expired`-status guard, lowering the ordering fence, dropping the provider-cancellation guard, and removing a bundled path from the coverage list each fail exactly the test that should catch them.
- The bundle path list is **derived from the source**, not hand-copied: the test walks `convex/` for runtime imports that escape the directory (type-only imports excluded — they never reach the bundle) and fails if the pathspec stops covering them, and asserts the workflow and the monitor name the same paths.

## Note for the reviewer

`shared/` is listed file-by-file rather than as a directory on purpose — it holds plenty the bundle never sees, and a directory filter would deploy production on every unrelated touch, adding churn to the very monitor this keeps quiet. The derived test is what makes that precision safe.

One finding is accepted rather than fixed: the baseline now rests on a mutable, unprotected tag. Hardening that is a repo-settings change (a tag-protection ruleset on `convex-deployed`), and the fail-closed branches mean a bogus tag causes a redundant deploy, never a missed one.

https://claude.ai/code/session_01Ak9LMRbEN17N7D2t2yW6qc
