### PR TITLE
fix(entitlements): pin gate counts per (file, predicate) to catch same-kind drift

### DIFF
--- a/scripts/generate-entitlement-crosswalk.mjs
+++ b/scripts/generate-entitlement-crosswalk.mjs
@@ -254,7 +254,94 @@ export function classify(rule) {
   return hit ? hit[1] : null;
 }
 
-export { MAP, SITE_MAP };
+export { MAP, SITE_MAP, SITE_BASELINE };
+
+/**
+ * Compare observed (file::predicate) gate counts against the pinned baseline.
+ *
+ * Pure so the negative test can drive it directly. This is the guard that
+ * catches a SECOND gate of the SAME kind in the SAME file — the case (file,
+ * predicate) identity alone cannot see, demonstrated in review by adding an
+ * unrelated hasPremiumAccess() call to a file already mapped for it.
+ */
+export function diffSiteCounts(actual, baseline = SITE_BASELINE) {
+  const drift = [];
+  for (const k of new Set([...Object.keys(baseline), ...Object.keys(actual)])) {
+    const was = baseline[k] ?? 0, now = actual[k] ?? 0;
+    if (was !== now) drift.push({ key: k, was, now });
+  }
+  return drift;
+}
+
+// Site COUNT baseline. (file, predicate) identity still cannot tell a second
+// gate of the same kind in the same file from the first — review demonstrated
+// that by adding an unrelated hasPremiumAccess() call to panel-layout.ts and
+// watching the sweep stay green. Pinning the expected count closes it: any
+// added or removed gate changes a count and must be re-baselined deliberately.
+const SITE_BASELINE = {
+  "api/mcp-proxy.ts::isCallerPremium": 1,
+  "api/mcp/skill-extension/generated.ts::tier": 1,
+  "api/me/entitlement.ts::isCallerPremium": 1,
+  "api/notification-channels.ts::tier": 1,
+  "api/v2/shipping/webhooks/[subscriberId].ts::isCallerPremium": 1,
+  "api/v2/shipping/webhooks/[subscriberId]/[action].ts::isCallerPremium": 1,
+  "api/widget-agent.ts::tier": 1,
+  "convex/alertRules.ts::tier": 1,
+  "convex/apiKeys.ts::apiAccess": 1,
+  "convex/apiPlanLimitUsage.ts::apiAccess": 1,
+  "convex/apiPlanLimitUsage.ts::mcpAccess": 1,
+  "convex/apiPlanLimitUsage.ts::tier": 1,
+  "convex/companyMonitoring/_shared.ts::tier": 1,
+  "convex/companyMonitoring/accounts.ts::tier": 1,
+  "convex/followedCountries.ts::tier": 2,
+  "convex/http.ts::apiAccess": 1,
+  "convex/http.ts::mcpAccess": 1,
+  "convex/http.ts::tier": 3,
+  "convex/mcpProTokens.ts::tier": 1,
+  "convex/notificationChannels.ts::tier": 1,
+  "convex/payments/billing.ts::tier": 1,
+  "server/_shared/direct-llm-quota.ts::tier": 1,
+  "server/_shared/embed-entitlement.ts::apiAccess": 1,
+  "server/_shared/entitlement-check.ts::tier": 1,
+  "server/_shared/premium-check.ts::apiAccess": 1,
+  "server/_shared/premium-check.ts::isCallerPremium": 1,
+  "server/_shared/premium-check.ts::tier": 2,
+  "server/_shared/pro-entitlement.ts::tier": 1,
+  "server/_shared/pro-mcp-gate.ts::mcpAccess": 2,
+  "server/_shared/pro-mcp-gate.ts::tier": 1,
+  "server/gateway.ts::apiAccess": 3,
+  "server/gateway.ts::tier": 5,
+  "server/worldmonitor/economic/v1/get-national-debt.ts::isCallerPremium": 1,
+  "server/worldmonitor/intelligence/v1/deduct-situation.ts::isCallerPremium": 1,
+  "server/worldmonitor/intelligence/v1/get-country-intel-brief.ts::isCallerPremium": 1,
+  "server/worldmonitor/military/v1/list-military-bases.ts::tier": 1,
+  "server/worldmonitor/news/v1/summarize-article.ts::requiresPremium": 2,
+  "server/worldmonitor/sanctions/v1/list-sanctions-pressure.ts::isCallerPremium": 1,
+  "server/worldmonitor/supply-chain/v1/get-bypass-options.ts::isCallerPremium": 1,
+  "server/worldmonitor/supply-chain/v1/get-country-chokepoint-index.ts::isCallerPremium": 1,
+  "server/worldmonitor/supply-chain/v1/get-country-cost-shock.ts::isCallerPremium": 1,
+  "server/worldmonitor/supply-chain/v1/get-country-products.ts::isCallerPremium": 1,
+  "server/worldmonitor/supply-chain/v1/get-multi-sector-cost-shock.ts::isCallerPremium": 1,
+  "server/worldmonitor/supply-chain/v1/get-route-explorer-lane.ts::isCallerPremium": 1,
+  "server/worldmonitor/supply-chain/v1/get-route-impact.ts::isCallerPremium": 1,
+  "server/worldmonitor/supply-chain/v1/get-sector-dependency.ts::isCallerPremium": 1,
+  "server/worldmonitor/trade/v1/get-tariff-trends.ts::isCallerPremium": 1,
+  "server/worldmonitor/trade/v1/list-comtrade-flows.ts::isCallerPremium": 1,
+  "src/app/data-loader.ts::hasPremiumAccess": 10,
+  "src/app/event-handlers.ts::isProUser": 2,
+  "src/app/panel-layout.ts::hasPremiumAccess": 1,
+  "src/components/RegionalIntelligenceBoard.ts::hasPremiumAccess": 1,
+  "src/components/UnifiedSettings.ts::isProUser": 1,
+  "src/services/analysis-framework-store.ts::hasPremiumAccess": 1,
+  "src/services/correlation-engine/engine.ts::hasPremiumAccess": 1,
+  "src/services/economic/index.ts::hasPremiumAccess": 1,
+  "src/services/entitlements.ts::tier": 1,
+  "src/services/gates/export-resolver.ts::dataExport": 4,
+  "src/services/gates/export.ts::dataExport": 1,
+  "src/services/sanctions-pressure.ts::hasPremiumAccess": 1,
+  "src/services/supply-chain/index.ts::hasPremiumAccess": 8,
+  "src/settings-window.ts::isProUser": 1
+};
 
 const all = [...rules, ...sites];
 const caps = new Map(); const exclusions = []; const unmapped = [];
@@ -266,10 +353,15 @@ for (const r of all) {
   caps.get(v.cap).rules.push({ rule: r.rule, detail: r.detail, note: v.note });
 }
 
+const actualCounts = {};
+for (const st of sites) { const k = `${st.file}::${st.pred}`; actualCounts[k] = (actualCounts[k] || 0) + 1; }
+const countDrift = diffSiteCounts(actualCounts);
+
 const payload = {
   _generated: 'scripts/generate-entitlement-crosswalk.mjs — build artifact; do not edit',
   commit: (() => { try { return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim(); } catch { return null; } })(),
   missingSources,
+  countDrift,
   totals: { rawRules: all.length, capabilities: caps.size, exclusions: exclusions.length, unmappedGates: unmapped.length },
   capabilities: [...caps.values()].sort((a, b) => a.id.localeCompare(b.id)),
   exclusions,
@@ -281,7 +373,12 @@ const isCli = argv[1] && fileURLToPath(import.meta.url) === argv[1];
 if (!isCli) { /* imported as a library */ }
 else if (process.argv.includes('--check')) {
   const { rawRules, capabilities, exclusions: ex, unmappedGates } = payload.totals;
-  console.log(`raw rules ${rawRules} · capabilities ${capabilities} · exclusions ${ex} · unmappedGates ${unmappedGates}`);
+  console.log(`raw rules ${rawRules} · capabilities ${capabilities} · exclusions ${ex} · unmappedGates ${unmappedGates} · countDrift ${countDrift.length}`);
+  if (countDrift.length) {
+    console.error('\nGATE COUNT DRIFT — a gate was added or removed. Classify it, then re-baseline with --rebaseline:');
+    for (const d of countDrift) console.error(`  ${d.key}: expected ${d.was}, found ${d.now}`);
+    process.exit(1);
+  }
   if (missingSources.length) {
     console.error(`\nMISSING SOURCES (${missingSources.length}) — this tree does not match the generator's expectations:`);
     for (const m of missingSources) console.error(`  ${m}`);
@@ -296,6 +393,15 @@ else if (process.argv.includes('--check')) {
   process.exit(0);
 }
 
+else if (process.argv.includes('--rebaseline')) {
+  const counts = {};
+  for (const st of sites) { const k = `${st.file}::${st.pred}`; counts[k] = (counts[k] || 0) + 1; }
+  const self = fileURLToPath(import.meta.url);
+  const body = readFileSync(self, 'utf8');
+  const literal = JSON.stringify(counts, Object.keys(counts).sort(), 2);
+  writeFileSync(self, body.replace(/const SITE_BASELINE = [\s\S]*?;\n/, `const SITE_BASELINE = ${literal};\n`));
+  console.log(`re-baselined ${Object.keys(counts).length} (file, predicate) groups`);
+}
 else {
 mkdirSync(dirname(OUT), { recursive: true });
 writeFileSync(OUT, JSON.stringify(payload, null, 2) + '\n');

--- a/tests/entitlement-crosswalk-classifier.test.mjs
+++ b/tests/entitlement-crosswalk-classifier.test.mjs
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { SITE_MAP, classify } from '../scripts/generate-entitlement-crosswalk.mjs';
+import {
+  SITE_BASELINE,
+  SITE_MAP,
+  classify,
+  diffSiteCounts,
+} from '../scripts/generate-entitlement-crosswalk.mjs';
 
 // The crosswalk's checksum (`unmappedGates: 0`) is only worth something if an
 // unclassified gate can actually reach it. The first version keyed code sites on
@@ -65,6 +70,55 @@ describe('entitlement crosswalk classifier', () => {
       for (const p of v.preds ?? []) {
         assert.ok(KNOWN.has(p), `SITE_MAP ${re} lists unknown predicate "${p}"`);
       }
+    }
+  });
+});
+
+// (file, predicate) identity closed two holes but not the third: a SECOND gate
+// of the SAME kind in the SAME file is indistinguishable from the first. Review
+// demonstrated it by adding an unrelated hasPremiumAccess() call to
+// src/app/panel-layout.ts, already mapped for that predicate — the sweep went
+// 289 -> 290 rules and still reported 0 unmapped. Pinning the expected count per
+// (file, predicate) is what actually closes it.
+
+describe('entitlement crosswalk gate-count baseline', () => {
+  it('reports no drift when observed counts equal the baseline', () => {
+    assert.deepEqual(diffSiteCounts({ ...SITE_BASELINE }), []);
+  });
+
+  it('catches a SECOND gate of the same kind in the same file', () => {
+    const key = 'src/app/panel-layout.ts::hasPremiumAccess';
+    assert.ok(key in SITE_BASELINE, `${key} should be pinned in the baseline`);
+    const drift = diffSiteCounts({ ...SITE_BASELINE, [key]: SITE_BASELINE[key] + 1 });
+    assert.equal(drift.length, 1, 'an added same-kind gate must be reported');
+    assert.equal(drift[0].key, key);
+    assert.equal(drift[0].now, SITE_BASELINE[key] + 1);
+  });
+
+  it('catches a REMOVED gate as well as an added one', () => {
+    const key = Object.keys(SITE_BASELINE)[0];
+    const actual = { ...SITE_BASELINE };
+    delete actual[key];
+    const drift = diffSiteCounts(actual);
+    assert.equal(drift.length, 1);
+    assert.equal(drift[0].now, 0, 'a deleted gate must surface, not pass silently');
+  });
+
+  it('catches a gate in a file absent from the baseline', () => {
+    const drift = diffSiteCounts({ ...SITE_BASELINE, 'src/services/__new.ts::tier': 1 });
+    assert.equal(drift.length, 1);
+    assert.equal(drift[0].was, 0);
+  });
+
+  it('the pinned baseline is non-empty and well formed', () => {
+    const keys = Object.keys(SITE_BASELINE);
+    assert.ok(keys.length > 20, 'baseline should cover the real gate surface');
+    for (const k of keys) {
+      assert.match(k, /^[^:]+::[a-zA-Z]+$/, `baseline key "${k}" must be file::predicate`);
+      assert.ok(
+        Number.isInteger(SITE_BASELINE[k]) && SITE_BASELINE[k] > 0,
+        `count for ${k} must be a positive integer`,
+      );
     }
   });
 });


### PR DESCRIPTION
Third and final hole in the crosswalk checksum. Follows #7361 and #7365.

## The defect

#7365 keyed code sites on `(file, predicate)`. That closed two blind spots but not the third: **a second gate of the same kind in the same file is indistinguishable from the first** by that identity.

Reproduced by adding one unrelated call to `src/app/panel-layout.ts`, a file already mapped for `hasPremiumAccess`:

```js
function __unrelatedGate(){ if (!hasPremiumAccess()) return null; }
```

```
raw rules 290 · capabilities 44 · exclusions 60 · unmappedGates 0   ← exit 0
```

It inherited `limits.panels` silently — exactly the failure #7365 was meant to end.

## The fix

Pin the expected gate count per `(file, predicate)`. **62 groups pinned.** Any added *or removed* gate changes a count and fails `--check` until it is classified and re-baselined deliberately with `--rebaseline`.

```
GATE COUNT DRIFT — a gate was added or removed.
  src/app/panel-layout.ts::hasPremiumAccess: expected 1, found 2   ← exit 1
```

## Three rounds, for the reviewer's benefit

| PR | Site identity | Caught | Still missed |
|---|---|---|---|
| #7361 | filename | new files | any gate in a mapped file |
| #7365 | file + predicate | new predicate kinds | **same kind, same file** |
| this | + pinned counts | any added/removed gate | — |

Each round shipped believing the checksum was sound. Recording that here so the next person does not assume the current one is beyond attack either.

## The tests are load-bearing

`diffSiteCounts()` is exported as a pure function, so the negative test drives it directly instead of mutating the worktree. Five new cases:

- no drift when observed counts match the baseline
- **a second same-kind gate in the same file** — the case that defeated #7365
- a **removed** gate (a silent deletion is the same class of bug)
- a gate in a file absent from the baseline
- baseline well-formedness (`file::predicate` keys, positive integer counts)

**Neutering `diffSiteCounts` to return `[]` fails 3 of the 11 tests.** Checked, not assumed.

## All four vectors, verified on this branch

| Scenario | Result |
|---|---|
| Same file, same predicate | **exit 1** (was exit 0) |
| New file / predicate combo | exit 1 |
| Missing expected source | exit 2 |
| Clean tree | exit 0 — 289 rules / 44 capabilities |

## Deliberate trade-off

Legitimately adding a gate now requires a one-line `--rebaseline`. That is the cost of the checksum meaning something, and it should be a conscious choice rather than a surprise in someone's PR.

## Reviewer note

No entitlement decision changes. Totals are unchanged: 289 rules → 44 capabilities → 60 exclusions.

Credit: all three holes were found by adversarial review, not by me.

Refs #7361, #7365

https://claude.ai/code/session_01WrkDCXFv9iHNdtu8PgvbFZ
