### PR TITLE
fix(content): stop GEO credibility leaks (#7377)

### DIFF
--- a/blog-site/src/layouts/Base.astro
+++ b/blog-site/src/layouts/Base.astro
@@ -1,5 +1,6 @@
 ---
 import productFacts from '../../../shared/product-facts.generated.json';
+import { SOMEONE_CEO_URL } from '../../../shared/press';
 import TrackedProductLink from '../components/TrackedProductLink.astro';
 
 interface Props {
@@ -103,13 +104,15 @@ function stringifyJsonLd(value: Record<string, unknown>): string {
   <body>
     <header class="site-header">
       <nav>
-        <a href="/blog/" class="logo">
-          <img src="/favico/favicon-32x32.png" alt="World Monitor" width="28" height="28" class="logo-icon-img" />
+        <div class="logo">
+          <a href="/blog/" class="logo-mark" aria-label="World Monitor Blog — Home">
+            <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" class="logo-icon-img" />
+          </a>
           <div class="logo-text">
-            <span class="logo-name">WORLD MONITOR</span>
-            <span class="logo-sub">by Someone.ceo</span>
+            <a href="/blog/" class="logo-name">WORLD MONITOR</a>
+            <a href={SOMEONE_CEO_URL} class="logo-sub" rel="noopener noreferrer">by Someone.ceo</a>
           </div>
-        </a>
+        </div>
         <ul class="nav-links">
           <li><a href="/blog/">Blog</a></li>
           <li><a href="/blog/glossary/">Glossary</a></li>
@@ -148,7 +151,7 @@ function stringifyJsonLd(value: Record<string, unknown>): string {
           <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" class="footer-icon-img" />
           <div class="footer-brand-text">
             <span class="footer-name">WORLD MONITOR</span>
-            <span class="footer-sub">by Someone.ceo</span>
+            <a href={SOMEONE_CEO_URL} class="footer-sub" rel="noopener noreferrer">by Someone.ceo</a>
           </div>
         </div>
         <div class="footer-links">

--- a/blog-site/src/layouts/BlogPost.astro
+++ b/blog-site/src/layouts/BlogPost.astro
@@ -215,7 +215,20 @@ const faqLd = extractFaqLd(rawBody);
       <div class="meta">
         <time datetime={isoDate}>{formattedDate}</time>
         {showUpdated && <span> &middot; Updated <time datetime={isoModifiedDate}>{formattedModifiedDate}</time></span>}
-        {audience && <span> &middot; {audience}</span>}
+        {readingMinutes && <span> &middot; {readingMinutes} min read</span>}
+      </div>
+      {/* Byline sits above the H1 — audience stays front-matter / JSON-LD only (#7377). */}
+      <div class="author-bio author-bio--header">
+        <img src={avatarSrc} alt={authorName} width="48" height="48" class="author-avatar" loading="lazy" onerror="this.src='/favico/apple-touch-icon.png'" />
+        <div class="author-info">
+          <div class="author-name">
+            {resolvedAuthorUrl
+              ? <a href={resolvedAuthorUrl} rel="author">{authorName}</a>
+              : <span>{authorName}</span>
+            }
+          </div>
+          {resolvedAuthorBio && <div class="author-desc" set:html={resolvedAuthorBio} />}
+        </div>
       </div>
     </div>
     {heroImage && (
@@ -285,18 +298,6 @@ const faqLd = extractFaqLd(rawBody);
         >
           MCP Quickstart
         </TrackedProductLink>
-      </div>
-    </div>
-    <div class="author-bio">
-      <img src={avatarSrc} alt={authorName} width="48" height="48" class="author-avatar" loading="lazy" onerror="this.src='/favico/apple-touch-icon.png'" />
-      <div class="author-info">
-        <div class="author-name">
-          {resolvedAuthorUrl
-            ? <a href={resolvedAuthorUrl} rel="author">{authorName}</a>
-            : <span>{authorName}</span>
-          }
-        </div>
-        {resolvedAuthorBio && <div class="author-desc" set:html={resolvedAuthorBio} />}
       </div>
     </div>
   </article>

--- a/blog-site/src/pages/index.astro
+++ b/blog-site/src/pages/index.astro
@@ -102,10 +102,11 @@ const jsonLd = {
               />
             </picture>
           )}
-          <div class="tag">
-            {post.data.pinned && <span class="pin">Pinned</span>}
-            {post.data.audience}
-          </div>
+          {post.data.pinned && (
+            <div class="tag">
+              <span class="pin">Pinned</span>
+            </div>
+          )}
           <h2>{post.data.title}</h2>
           <p>{post.data.description}</p>
           <div class="meta">

--- a/blog-site/src/styles/global.css
+++ b/blog-site/src/styles/global.css
@@ -75,9 +75,14 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   font-weight: 700;
   font-size: 0.875rem;
   letter-spacing: -0.01em;
+}
+
+.site-header .logo-mark {
+  display: flex;
+  color: inherit;
   transition: opacity 0.2s;
 }
-.site-header .logo:hover { opacity: 0.8; color: var(--wm-text); }
+.site-header .logo-mark:hover { opacity: 0.8; }
 
 .site-header .logo .logo-icon-img {
   width: 32px;
@@ -96,7 +101,10 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   font-size: 0.8rem;
   letter-spacing: 0.02em;
   line-height: 1;
+  color: var(--wm-text);
+  transition: opacity 0.2s;
 }
+.site-header .logo .logo-name:hover { opacity: 0.8; }
 
 .site-header .logo .logo-sub {
   font-family: var(--font-mono);
@@ -106,7 +114,9 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   letter-spacing: 0.1em;
   line-height: 1;
   margin-top: 3px;
+  transition: color 0.2s;
 }
+.site-header .logo .logo-sub:hover { color: var(--wm-text); }
 
 .site-header .nav-links {
   display: flex;
@@ -184,7 +194,9 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   color: var(--wm-muted);
   text-transform: uppercase;
   letter-spacing: 2px;
+  transition: color 0.2s;
 }
+.site-footer .footer-sub:hover { color: var(--wm-text); }
 
 .site-footer .footer-links {
   display: flex;
@@ -684,6 +696,11 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   background: rgba(255,255,255,0.04);
   border: 1px solid rgba(255,255,255,0.08);
   border-radius: 10px;
+}
+
+.author-bio--header {
+  margin: 0 0 2rem;
+  max-width: none;
 }
 
 .author-avatar {

--- a/blog-site/src/styles/global.css
+++ b/blog-site/src/styles/global.css
@@ -357,6 +357,8 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   font-weight: 700;
   color: var(--wm-text);
   margin-bottom: 0.625rem;
+  /* Replaces the former always-present .tag top spacer after audience removal (#7377). */
+  padding-top: 1.25rem;
   line-height: 1.35;
   letter-spacing: -0.01em;
 }

--- a/blog-site/src/styles/global.css
+++ b/blog-site/src/styles/global.css
@@ -357,10 +357,13 @@ img { max-width: 100%; height: auto; border-radius: var(--radius); }
   font-weight: 700;
   color: var(--wm-text);
   margin-bottom: 0.625rem;
-  /* Replaces the former always-present .tag top spacer after audience removal (#7377). */
-  padding-top: 1.25rem;
   line-height: 1.35;
   letter-spacing: -0.01em;
+}
+
+.post-card:not(.pinned) h2 {
+  /* Replaces the former always-present .tag top spacer after audience removal (#7377). */
+  padding-top: 1.25rem;
 }
 
 .post-card p {

--- a/docs/about.mdx
+++ b/docs/about.mdx
@@ -1,17 +1,17 @@
 ---
 title: "About World Monitor: open-source OSINT dashboard"
-description: "The story behind World Monitor, the open-source real-time global intelligence dashboard built by Anghami co-founder Elie Habib and used in 170+ countries."
+description: "The story behind World Monitor, the open-source real-time global intelligence dashboard built by Anghami co-founder Elie Habib and used in 190+ countries."
 ---
 
 World Monitor is a free, real-time global intelligence dashboard. It fuses a broad catalog of live data feeds — conflict events, military flights, ship movements, satellite fire detections, market data, shipping chokepoints, internet outages, cyber signals, and natural disasters — into a single live map of the world, with AI analysis layered on top. The core dashboard is open to everyone, with no signup.
 
 ## Origin
 
-{/* REVIEW: traction figures below are sourced from press coverage (Jan–2026 onward) and the live GitHub count at time of writing. Refresh to current numbers before or after merge if you want them exact. */}
+{/* Traction: 2M+ users cited from Silicon Canals; country reach matches homepage/llms.txt (190+); GitHub stars render live via shields.io (GitHub API). */}
 
 World Monitor began in January 2026 as a weekend project. Elie Habib — co-founder and CEO of the music-streaming platform Anghami — built the first version in a matter of days to see whether a day's worth of chaotic geopolitical news could be made legible on one map. He posted it once and moved on.
 
-It didn't stay quiet. As global events escalated through 2026, the dashboard reached hundreds of thousands of users in its first week and has since grown to millions of people across more than 170 countries — most of them well outside the usual intelligence-tooling audience. It is now one of the most-starred open-source OSINT projects on GitHub, with 81,508 stars.
+It didn't stay quiet. As global events escalated through 2026, the dashboard reached hundreds of thousands of users in its first week and has since grown to [2M+ people](https://siliconcanals.com/sc-n-anghami-ceos-side-project-world-monitor-now-has-2-million-users-tracking-conflicts-in-real-time/) across 190+ countries — most of them well outside the usual intelligence-tooling audience. It is now one of the most-starred open-source OSINT projects on GitHub ([![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor)](https://github.com/koala73/worldmonitor/stargazers)).
 
 ## What makes it different
 

--- a/docs/zh/about.mdx
+++ b/docs/zh/about.mdx
@@ -1,17 +1,17 @@
 ---
 title: "关于 World Monitor：开源 OSINT 仪表盘"
-description: "深入了解 World Monitor 背后的故事：由 Anghami 联合创始人 Elie Habib 独立打造的开源实时全球情报仪表盘，目前已被 170 多个国家的记者、分析师、研究人员与政策制定者使用，聚合冲突、航运、能源与市场信号，让开源情报（OSINT）与地缘政治监测触手可及。"
+description: "深入了解 World Monitor 背后的故事：由 Anghami 联合创始人 Elie Habib 独立打造的开源实时全球情报仪表盘，目前已被 190+ 个国家的记者、分析师、研究人员与政策制定者使用，聚合冲突、航运、能源与市场信号，让开源情报（OSINT）与地缘政治监测触手可及。"
 ---
 
 World Monitor 是一个免费的实时全球情报仪表盘。它将丰富的实时数据源——冲突事件、军用航班、船舶动向、卫星火点探测、市场数据、航运咽喉要道、互联网中断、网络信号和自然灾害——融合到一张实时的世界地图上，并在其上叠加 AI 分析。核心仪表盘对所有人开放，无需注册。
 
 ## 起源
 
-{/* REVIEW: traction figures below are sourced from press coverage (Jan–2026 onward) and the live GitHub count at time of writing. Refresh to current numbers before or after merge if you want them exact. */}
+{/* Traction: 2M+ 用户引自 Silicon Canals；国家覆盖与首页/llms.txt 一致（190+）；GitHub 星标通过 shields.io（GitHub API）实时渲染。 */}
 
 World Monitor 始于 2026 年 1 月的一个周末项目。Elie Habib——音乐流媒体平台 Anghami 的联合创始人兼 CEO——在短短几天内构建了第一个版本，以验证能否将一天纷乱的地缘政治新闻在一张地图上呈现得清晰易读。他公开发布了一次，随后便将注意力转向别处。
 
-但它并未就此沉寂。随着 2026 年全球局势不断升级，该仪表盘在第一周就触达了数十万用户，此后更增长到遍布 170 多个国家的数百万人——其中大多数人远非通常的情报工具用户群体。如今它已是 GitHub 上星标最多的开源 OSINT 项目之一，拥有 81,508 个星标。
+但它并未就此沉寂。随着 2026 年全球局势不断升级，该仪表盘在第一周就触达了数十万用户，此后更增长到遍布 [190+ 个国家的 200 万+ 用户](https://siliconcanals.com/sc-n-anghami-ceos-side-project-world-monitor-now-has-2-million-users-tracking-conflicts-in-real-time/)——其中大多数人远非通常的情报工具用户群体。如今它已是 GitHub 上星标最多的开源 OSINT 项目之一（[![GitHub Repo stars](https://img.shields.io/github/stars/koala73/worldmonitor)](https://github.com/koala73/worldmonitor/stargazers)）。
 
 ## 它的独特之处
 

--- a/pro-test/src/App.tsx
+++ b/pro-test/src/App.tsx
@@ -40,6 +40,8 @@ import { appendStoredContentAttributionToUrl } from '../../shared/content-attrib
 import { isInternalSourceTag } from '../../shared/referral-namespaces';
 import { readMcpAttributionFromSearch } from '../../shared/mcp-attribution';
 import { LegalFooterNav } from './components/LegalFooterNav';
+import { PressFooterNav } from './components/PressFooterNav';
+import { ABOUT_DOCS_PATH, SOMEONE_CEO_URL } from '../../shared/press';
 
 const API_BASE = 'https://api.worldmonitor.app/api';
 const TURNSTILE_SITE_KEY = '0x4AAAAAACnaYgHIyxclu8Tj';
@@ -1352,13 +1354,20 @@ const EnterprisePage = () => (
       <div className="flex flex-col md:flex-row items-center justify-between max-w-7xl mx-auto text-xs text-wm-muted font-mono">
         <div className="flex items-center gap-3 mb-4 md:mb-0">
           <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" loading="lazy" className="rounded-full" />
-          <div className="flex flex-col">
+          <div className="flex flex-col text-left">
             <span className="font-display font-bold text-sm leading-none tracking-tight text-wm-text">WORLD MONITOR</span>
-            <span className="text-[9px] uppercase tracking-[2px] opacity-60 mt-0.5">by Someone.ceo</span>
+            <a
+              href={SOMEONE_CEO_URL}
+              className="text-[9px] uppercase tracking-[2px] opacity-60 mt-0.5 hover:opacity-100 hover:text-wm-text transition-colors"
+              rel="noopener noreferrer"
+            >
+              by Someone.ceo
+            </a>
           </div>
         </div>
         <div className="flex items-center gap-6">
           <a href={DASHBOARD_PATH} className="hover:text-wm-text transition-colors">Dashboard</a>
+          <a href={ABOUT_DOCS_PATH} className="hover:text-wm-text transition-colors">About</a>
           <a href="https://www.worldmonitor.app/blog/" className="hover:text-wm-text transition-colors">Blog</a>
           <a href="https://www.worldmonitor.app/docs" className="hover:text-wm-text transition-colors">Docs</a>
           <a href="https://status.worldmonitor.app/" target="_blank" rel="noreferrer" className="hover:text-wm-text transition-colors">Status</a>
@@ -1368,6 +1377,7 @@ const EnterprisePage = () => (
         </div>
         <span className="text-[10px] opacity-40 mt-4 md:mt-0">&copy; {new Date().getFullYear()} WorldMonitor</span>
       </div>
+      <PressFooterNav />
       {/* This is the pricing page — the footer a buyer sees on the way to
           checkout — so the documents they are agreeing to have to be one click
           from here, not one FAQ answer deep (#6976). */}

--- a/pro-test/src/components/Footer.tsx
+++ b/pro-test/src/components/Footer.tsx
@@ -1,18 +1,27 @@
 import { DASHBOARD_PATH } from '../routes';
+import { ABOUT_DOCS_PATH, SOMEONE_CEO_URL } from '../../../shared/press';
 import { LegalFooterNav } from './LegalFooterNav';
+import { PressFooterNav } from './PressFooterNav';
 
 export const Footer = () => (
   <footer className="border-t border-wm-border bg-[#020202] pt-8 pb-12 px-6 text-center">
     <div className="flex flex-col md:flex-row items-center justify-between max-w-7xl mx-auto text-xs text-wm-muted font-mono">
       <div className="flex items-center gap-3 mb-4 md:mb-0">
         <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" loading="lazy" className="rounded-full" />
-        <div className="flex flex-col">
+        <div className="flex flex-col text-left">
           <span className="font-display font-bold text-sm leading-none tracking-tight text-wm-text">WORLD MONITOR</span>
-          <span className="text-[9px] uppercase tracking-[2px] opacity-60 mt-0.5">by Someone.ceo</span>
+          <a
+            href={SOMEONE_CEO_URL}
+            className="text-[9px] uppercase tracking-[2px] opacity-60 mt-0.5 hover:opacity-100 hover:text-wm-text transition-colors"
+            rel="noopener noreferrer"
+          >
+            by Someone.ceo
+          </a>
         </div>
       </div>
       <div className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
         <a href={DASHBOARD_PATH} className="hover:text-wm-text transition-colors">Dashboard</a>
+        <a href={ABOUT_DOCS_PATH} className="hover:text-wm-text transition-colors">About</a>
         <a href="/sources/?utm_source=welcome-footer" className="hover:text-wm-text transition-colors">Sources</a>
         <a href="/countries/" className="hover:text-wm-text transition-colors">Countries</a>
         <a href="/chokepoints/" className="hover:text-wm-text transition-colors">Chokepoints</a>
@@ -27,6 +36,7 @@ export const Footer = () => (
       </div>
       <span className="text-[10px] opacity-40 mt-4 md:mt-0" suppressHydrationWarning>&copy; {new Date().getFullYear()} WorldMonitor</span>
     </div>
+    <PressFooterNav />
     <LegalFooterNav />
   </footer>
 );

--- a/pro-test/src/components/Logo.tsx
+++ b/pro-test/src/components/Logo.tsx
@@ -1,14 +1,23 @@
 import { Globe, Activity } from 'lucide-react';
+import { SOMEONE_CEO_URL } from '../../../shared/press';
 
 export const Logo = () => (
-  <a href="https://worldmonitor.app" className="flex items-center gap-2 hover:opacity-80 transition-opacity" aria-label="World Monitor — Home">
-    <div className="relative w-8 h-8 rounded-full bg-wm-card border border-wm-border flex items-center justify-center overflow-hidden">
+  <div className="flex items-center gap-2">
+    <a href="https://worldmonitor.app" className="relative w-8 h-8 rounded-full bg-wm-card border border-wm-border flex items-center justify-center overflow-hidden hover:opacity-80 transition-opacity" aria-label="World Monitor — Home">
       <Globe className="w-5 h-5 text-wm-blue opacity-50 absolute" aria-hidden="true" />
       <Activity className="w-6 h-6 text-wm-green absolute z-10" aria-hidden="true" />
-    </div>
+    </a>
     <div className="flex flex-col">
-      <span className="font-display font-bold text-sm leading-none tracking-tight">WORLD MONITOR</span>
-      <span className="text-[9px] text-wm-muted font-mono uppercase tracking-widest leading-none mt-1">by Someone.ceo</span>
+      <a href="https://worldmonitor.app" className="font-display font-bold text-sm leading-none tracking-tight hover:opacity-80 transition-opacity">
+        WORLD MONITOR
+      </a>
+      <a
+        href={SOMEONE_CEO_URL}
+        className="text-[9px] text-wm-muted font-mono uppercase tracking-widest leading-none mt-1 hover:text-wm-text transition-colors"
+        rel="noopener noreferrer"
+      >
+        by Someone.ceo
+      </a>
     </div>
-  </a>
+  </div>
 );

--- a/pro-test/src/components/PressFooterNav.tsx
+++ b/pro-test/src/components/PressFooterNav.tsx
@@ -1,0 +1,28 @@
+import { PRESS_LINKS } from '../../../shared/press';
+
+/**
+ * "In the press" row for marketing footers (#7377).
+ *
+ * Press URLs previously lived only in `/world-monitor.md` and `/docs/about`
+ * while the homepage asserted "as featured in WIRED" beside an uncited 2M
+ * figure. One shared list keeps footers and agent briefings aligned.
+ */
+export const PressFooterNav = () => (
+  <nav
+    aria-label="In the press"
+    className="max-w-7xl mx-auto mt-4 flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-[11px] text-wm-muted font-mono"
+  >
+    <span className="uppercase tracking-[2px] opacity-60">In the press</span>
+    {PRESS_LINKS.map(link => (
+      <a
+        key={link.url}
+        href={link.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:text-wm-text transition-colors"
+      >
+        {link.label}
+      </a>
+    ))}
+  </nav>
+);

--- a/pro-test/src/welcome/Hero.tsx
+++ b/pro-test/src/welcome/Hero.tsx
@@ -10,6 +10,7 @@ import {
   DASHBOARD_SCREENSHOT_AVIF_SRCSET,
   DASHBOARD_SCREENSHOT_WEBP_SRCSET,
 } from '../assets/dashboard-screenshot';
+import { SILICON_CANALS_2M_URL } from '../../../shared/press';
 
 const HERO_IMAGE_SIZES = '(min-width: 1072px) 1024px, (min-width: 640px) calc(100vw - 3rem), calc(100vw - 2rem)';
 
@@ -160,7 +161,15 @@ export const Hero = () => (
         className="mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-3 text-xs font-mono text-wm-muted"
       >
         <WiredBadge />
-        <span>{t('welcome.hero.trustUsers')}</span>
+        <a
+          href={SILICON_CANALS_2M_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-wm-text transition-colors"
+          title="2M+ users — Silicon Canals"
+        >
+          {t('welcome.hero.trustUsers')}
+        </a>
         <span aria-hidden="true" className="text-wm-border">|</span>
         <a
           href="https://github.com/koala73/worldmonitor"

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,11 +2,19 @@
 
 > Real-time global intelligence dashboard — AI-powered news aggregation, geopolitical monitoring, and infrastructure tracking in a unified situational awareness interface.
 
-World Monitor is an open-source (AGPL-3.0) intelligence platform that aggregates curated news feeds, a shared map-layer catalog, concrete panel implementations, and multiple AI models into a single dashboard. Used by 2M+ people across 190+ countries, as featured in WIRED. It runs as a web app, installable PWA, and native desktop application (Tauri) for macOS, Windows, and Linux.
+World Monitor is an open-source (AGPL-3.0) intelligence platform that aggregates curated news feeds, a shared map-layer catalog, concrete panel implementations, and multiple AI models into a single dashboard. Used by [2M+ people](https://siliconcanals.com/sc-n-anghami-ceos-side-project-world-monitor-now-has-2-million-users-tracking-conflicts-in-real-time/) across 190+ countries, as featured in [WIRED](https://www.wired.com/story/world-monitor-elie-habib/). It runs as a web app, installable PWA, and native desktop application (Tauri) for macOS, Windows, and Linux.
 
 A single codebase produces specialized variants — geopolitical (World Monitor), technology (Tech Monitor), finance (Finance Monitor), commodities (Commodity Monitor), positive news (Happy Monitor), and energy (Energy Monitor) — each with distinct feeds, panels, map layers, and branding. The multi-variant architecture uses build-time selection via the VITE_VARIANT environment variable, with runtime switching available via the header bar.
 
 The project is built with TypeScript, Vite, MapLibre GL JS, deck.gl, D3.js, and Tauri. Browser-side clustering, local ML, and offline analysis run in the client; server-authoritative APIs publish CII/CRI scores, briefs, forecasts, MCP tools, and cached operational data with documented methodology and provenance.
+
+## In the press
+
+- [WIRED — How a music-streaming CEO built an open-source global threat map in his spare time](https://www.wired.com/story/world-monitor-elie-habib/)
+- [Entrepreneur Middle East — How Elie Habib built World Monitor to track global events in real time](https://mena.entrepreneur.com/business-news/how-elie-habib-built-world-monitor-to-track-global-events-in-real-time)
+- [Silicon Canals — Anghami CEO's side project now has 2 million users](https://siliconcanals.com/sc-n-anghami-ceos-side-project-world-monitor-now-has-2-million-users-tracking-conflicts-in-real-time/)
+- [L'Orient Today — How the Anghami CEO's side project became a go-to for geopolitics research](https://today.lorientlejour.com/article/1496089/world-monitor-how-anghami-ceos-side-project-became-a-go-to-for-geopolitics-research.html)
+- Human about page: https://www.worldmonitor.app/docs/about
 
 ## When to Use World Monitor (Agent Guidance)
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,7 +14,7 @@ The project is built with TypeScript, Vite, MapLibre GL JS, deck.gl, D3.js, and 
 - [Entrepreneur Middle East — How Elie Habib built World Monitor to track global events in real time](https://mena.entrepreneur.com/business-news/how-elie-habib-built-world-monitor-to-track-global-events-in-real-time)
 - [Silicon Canals — Anghami CEO's side project now has 2 million users](https://siliconcanals.com/sc-n-anghami-ceos-side-project-world-monitor-now-has-2-million-users-tracking-conflicts-in-real-time/)
 - [L'Orient Today — How the Anghami CEO's side project became a go-to for geopolitics research](https://today.lorientlejour.com/article/1496089/world-monitor-how-anghami-ceos-side-project-became-a-go-to-for-geopolitics-research.html)
-- Human about page: https://www.worldmonitor.app/docs/about
+- [Human about page](https://www.worldmonitor.app/docs/about)
 
 ## When to Use World Monitor (Agent Guidance)
 

--- a/shared/press.ts
+++ b/shared/press.ts
@@ -1,0 +1,47 @@
+/**
+ * Canonical press / traction citations shared by marketing surfaces, llms.txt,
+ * docs/about, and the blog chrome (#7377).
+ *
+ * Keep URLs here so homepage, docs, and agent briefings cannot drift on the
+ * Silicon Canals 2M cite, the WIRED feature, or the country-reach figure.
+ */
+
+/** Studio lockup target — resolves (301) onto www.worldmonitor.app. */
+export const SOMEONE_CEO_URL = 'https://someone.ceo';
+
+export const WIRED_FEATURE_URL =
+  'https://www.wired.com/story/world-monitor-elie-habib/';
+
+/** Source of the public 2M+ users claim. */
+export const SILICON_CANALS_2M_URL =
+  'https://siliconcanals.com/sc-n-anghami-ceos-side-project-world-monitor-now-has-2-million-users-tracking-conflicts-in-real-time/';
+
+export const ENTREPRENEUR_ME_URL =
+  'https://mena.entrepreneur.com/business-news/how-elie-habib-built-world-monitor-to-track-global-events-in-real-time';
+
+export const LORIENT_TODAY_URL =
+  'https://today.lorientlejour.com/article/1496089/world-monitor-how-anghami-ceos-side-project-became-a-go-to-for-geopolitics-research';
+
+export const GITHUB_REPO_URL = 'https://github.com/koala73/worldmonitor';
+
+/** shields.io badge that reads stargazers_count from the GitHub API. */
+export const GITHUB_STARS_BADGE_URL =
+  'https://img.shields.io/github/stars/koala73/worldmonitor';
+
+export const GITHUB_STARGAZERS_URL = `${GITHUB_REPO_URL}/stargazers`;
+
+export const ABOUT_DOCS_PATH = '/docs/about';
+
+/** Canonical reach figures — every public surface must agree. */
+export const USERS_CLAIM = '2M+';
+export const COUNTRY_REACH_CLAIM = '190+';
+
+export type PressLink = Readonly<{ label: string; url: string }>;
+
+/** Press row for footers and agent briefings (order: WIRED first). */
+export const PRESS_LINKS: ReadonlyArray<PressLink> = [
+  { label: 'WIRED', url: WIRED_FEATURE_URL },
+  { label: 'Entrepreneur ME', url: ENTREPRENEUR_ME_URL },
+  { label: 'Silicon Canals', url: SILICON_CANALS_2M_URL },
+  { label: "L'Orient Today", url: LORIENT_TODAY_URL },
+];

--- a/shared/press.ts
+++ b/shared/press.ts
@@ -20,7 +20,7 @@ export const ENTREPRENEUR_ME_URL =
   'https://mena.entrepreneur.com/business-news/how-elie-habib-built-world-monitor-to-track-global-events-in-real-time';
 
 export const LORIENT_TODAY_URL =
-  'https://today.lorientlejour.com/article/1496089/world-monitor-how-anghami-ceos-side-project-became-a-go-to-for-geopolitics-research';
+  'https://today.lorientlejour.com/article/1496089/world-monitor-how-anghami-ceos-side-project-became-a-go-to-for-geopolitics-research.html';
 
 export const GITHUB_REPO_URL = 'https://github.com/koala73/worldmonitor';
 

--- a/tests/geo-content-credibility-7377.test.mjs
+++ b/tests/geo-content-credibility-7377.test.mjs
@@ -22,6 +22,19 @@ const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, '..');
 const read = (rel) => readFileSync(join(root, rel), 'utf8');
 
+function cssRule(source, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = source.match(new RegExp(`(?:^|\\n)\\s*${escaped}\\s*\\{`));
+  assert.ok(match && match.index !== undefined, `missing ${selector} rule`);
+  const open = source.indexOf('{', match.index);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === '{') depth += 1;
+    if (source[i] === '}' && --depth === 0) return source.slice(open + 1, i);
+  }
+  throw new Error(`unterminated ${selector} block`);
+}
+
 describe('issue #7377 GEO content credibility', () => {
   it('(a) keeps audience in frontmatter/JSON-LD but not visible body chrome', () => {
     const post = read('blog-site/src/layouts/BlogPost.astro');
@@ -48,6 +61,34 @@ describe('issue #7377 GEO content credibility', () => {
       index,
       /\{post\.data\.audience\}/,
       'blog index cards must not render the audience persona string',
+    );
+  });
+
+  it('scopes the card-title top spacer to non-pinned cards so pinned tags do not double-pad', () => {
+    const css = read('blog-site/src/styles/global.css');
+    const index = read('blog-site/src/pages/index.astro');
+
+    assert.match(
+      index,
+      /\{post\.data\.pinned && \([\s\S]*?class="tag"/,
+      'pinned cards still render the .tag block that owns the top spacer',
+    );
+
+    const tagPad = cssRule(css, '.post-card .tag');
+    assert.match(tagPad, /padding-top:\s*1\.25rem/, 'pinned .tag keeps the original 1.25rem top spacer');
+
+    const allTitles = cssRule(css, '.post-card h2');
+    assert.doesNotMatch(
+      allTitles,
+      /padding-top:\s*1\.25rem/,
+      'unqualified .post-card h2 must not add a second top spacer on pinned cards',
+    );
+
+    const ordinaryTitles = cssRule(css, '.post-card:not(.pinned) h2');
+    assert.match(
+      ordinaryTitles,
+      /padding-top:\s*1\.25rem/,
+      'ordinary cards keep the former .tag top spacer on the title',
     );
   });
 

--- a/tests/geo-content-credibility-7377.test.mjs
+++ b/tests/geo-content-credibility-7377.test.mjs
@@ -77,9 +77,16 @@ describe('issue #7377 GEO content credibility', () => {
     assert.match(llms, new RegExp(WIRED_FEATURE_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     assert.match(llms, new RegExp(SILICON_CANALS_2M_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     for (const link of PRESS_LINKS) {
-      assert.ok(llms.includes(link.url), `llms.txt must include ${link.label}`);
+      assert.ok(
+        llms.includes(`](${link.url})`) || llms.includes(link.url),
+        `llms.txt must include exact ${link.label} URL`,
+      );
       assert.ok(pressModule.includes(link.url), `shared/press.ts must include ${link.label}`);
     }
+    assert.equal(
+      PRESS_LINKS.find((l) => l.label === "L'Orient Today")?.url,
+      'https://today.lorientlejour.com/article/1496089/world-monitor-how-anghami-ceos-side-project-became-a-go-to-for-geopolitics-research.html',
+    );
 
     assert.match(hero, /SILICON_CANALS_2M_URL|siliconcanals\.com/);
     assert.ok(

--- a/tests/geo-content-credibility-7377.test.mjs
+++ b/tests/geo-content-credibility-7377.test.mjs
@@ -1,0 +1,108 @@
+/**
+ * #7377 — GEO credibility leaks: blog audience persona in body copy,
+ * contradictory reach figures, buried press cites, and an unlinked studio lockup.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+import {
+  ABOUT_DOCS_PATH,
+  COUNTRY_REACH_CLAIM,
+  GITHUB_STARS_BADGE_URL,
+  PRESS_LINKS,
+  SILICON_CANALS_2M_URL,
+  SOMEONE_CEO_URL,
+  WIRED_FEATURE_URL,
+} from '../shared/press.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '..');
+const read = (rel) => readFileSync(join(root, rel), 'utf8');
+
+describe('issue #7377 GEO content credibility', () => {
+  it('(a) keeps audience in frontmatter/JSON-LD but not visible body chrome', () => {
+    const post = read('blog-site/src/layouts/BlogPost.astro');
+    const index = read('blog-site/src/pages/index.astro');
+
+    assert.match(post, /"@type": "Audience"/, 'audience stays in BlogPosting JSON-LD');
+    assert.doesNotMatch(
+      post,
+      /\{audience && <span> &middot; \{audience\}<\/span>\}/,
+      'audience must not render in the visible article meta line',
+    );
+    assert.match(
+      post,
+      /class="author-bio/,
+      'byline must still render',
+    );
+    // Byline must appear before the layout-owned H1, not after the article body.
+    const bylineIdx = post.indexOf('class="author-bio');
+    const h1Idx = post.indexOf('<h1>{title}</h1>');
+    assert.ok(bylineIdx !== -1 && h1Idx !== -1, 'byline and H1 must both exist');
+    assert.ok(bylineIdx < h1Idx, 'byline must sit above the H1 (slot vacated by persona)');
+
+    assert.doesNotMatch(
+      index,
+      /\{post\.data\.audience\}/,
+      'blog index cards must not render the audience persona string',
+    );
+  });
+
+  it('(b) unifies country reach and renders GitHub stars from the API badge', () => {
+    const about = read('docs/about.mdx');
+    const aboutZh = read('docs/zh/about.mdx');
+    const llms = read('public/llms.txt');
+
+    assert.doesNotMatch(about, /81,?508/);
+    assert.doesNotMatch(aboutZh, /81,?508/);
+    assert.doesNotMatch(about, /more than 170 countries/);
+    assert.doesNotMatch(aboutZh, /170 多个国家/);
+    assert.match(about, new RegExp(COUNTRY_REACH_CLAIM.replace('+', '\\+')));
+    assert.match(about, new RegExp(GITHUB_STARS_BADGE_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.match(llms, /2M\+ people/);
+    assert.match(llms, /190\+ countries/);
+    assert.match(llms, new RegExp(SILICON_CANALS_2M_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  });
+
+  it('(c) surfaces press URLs, About, and the Silicon Canals 2M citation', () => {
+    const llms = read('public/llms.txt');
+    const hero = read('pro-test/src/welcome/Hero.tsx');
+    const footer = read('pro-test/src/components/Footer.tsx');
+    const pressNav = read('pro-test/src/components/PressFooterNav.tsx');
+    const pressModule = read('shared/press.ts');
+
+    assert.match(llms, new RegExp(WIRED_FEATURE_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.match(llms, new RegExp(SILICON_CANALS_2M_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    for (const link of PRESS_LINKS) {
+      assert.ok(llms.includes(link.url), `llms.txt must include ${link.label}`);
+      assert.ok(pressModule.includes(link.url), `shared/press.ts must include ${link.label}`);
+    }
+
+    assert.match(hero, /SILICON_CANALS_2M_URL|siliconcanals\.com/);
+    assert.ok(
+      footer.includes('ABOUT_DOCS_PATH') || footer.includes(ABOUT_DOCS_PATH),
+      'welcome footer must link /docs/about',
+    );
+    assert.match(footer, /<PressFooterNav\s*\/>/);
+    assert.match(pressNav, /PRESS_LINKS/);
+    assert.match(pressNav, /In the press/);
+  });
+
+  it('(d) links the Someone.ceo studio lockup to a resolvable URL', () => {
+    for (const path of [
+      'pro-test/src/components/Logo.tsx',
+      'pro-test/src/components/Footer.tsx',
+      'blog-site/src/layouts/Base.astro',
+    ]) {
+      const source = read(path);
+      assert.ok(
+        source.includes('SOMEONE_CEO_URL') || source.includes(SOMEONE_CEO_URL),
+        `${path} must link Someone.ceo via SOMEONE_CEO_URL`,
+      );
+      assert.match(source, /by Someone\.ceo/);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes #7377. Fixes GEO credibility leaks found in the 2026-08-29 audit:

- **(a)** Audience persona strings no longer render above blog H1s or on index cards; they stay in front-matter + BlogPosting JSON-LD. Author byline moves into the vacated header slot.
- **(b)** `/docs/about` (EN + ZH) uses the same **190+** country reach as homepage/`llms.txt`, cites Silicon Canals for **2M+**, and renders GitHub stars via shields.io (live GitHub API) instead of a hardcoded `81,508`.
- **(c)** Press URLs land in `llms.txt`, an “In the press” footer row, and `/docs/about` is linked from marketing footers. The homepage **2M+ users** claim links to Silicon Canals (not implied as a WIRED cite).
- **(d)** “by Someone.ceo” is a resolvable link to `https://someone.ceo` in blog chrome and marketing logos/footers.

Shared constants live in `shared/press.ts`. Follow-ups: L'Orient URL alignment, blog card spacing, and wrapping the about-page list item in `llms.txt` as a Markdown link (CI `unit` / agent-readiness contract).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: blog-site, docs/about, pro-test marketing, `public/llms.txt`

## Checklist

- [x] Local contract tests for #7377 (`tests/geo-content-credibility-7377.test.mjs`)
- [x] `tests/llms-txt-mcp-tools.test.mjs` (list-item Markdown link contract)
- [x] Related blog SEO / brand-identity contracts still pass
- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)
- [ ] New or repointed health probes N/A

## Documentation Alignment Checklist

- [x] N/A — marketing/about copy alignment only; no methodology/API claim ledger change

## Screenshots

N/A for this content/template change. Contract test log:

[geo_7377_final_contract_tests.log](https://cursor.com/agents/bc-92f72e6b-3abb-4f0e-9131-036ec6af387f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgeo_7377_final_contract_tests.log)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required — static content/template/copy surfaces only (blog Astro layouts, Mintlify about pages, `llms.txt`, marketing footer/hero). After deploy, spot-check one blog post (no persona above H1; byline above H1), `/docs/about` (190+, shields star badge, Silicon Canals cite), homepage trust row (2M+ → Silicon Canals), and `llms.txt` press section.

## Known Residuals

- `pro-test/src/App.tsx` social-proof strip still hardcodes `2M+` / `190+` literals rather than importing `USERS_CLAIM` / `COUNTRY_REACH_CLAIM` (nit from review; values already match).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92f72e6b-3abb-4f0e-9131-036ec6af387f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92f72e6b-3abb-4f0e-9131-036ec6af387f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

