### PR TITLE
fix(opensky): harden shared cooldown coordination

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1147,6 +1147,9 @@ OPENSKY_NEGATIVE_CACHE_MAX_ENTRIES=
 OPENSKY_BBOX_QUANT_STEP=
 OPENSKY_429_COOLDOWN_MS=
 OPENSKY_REQUEST_SPACING_MS=
+# Temporary v1/v2 Redis migration cutoff (ISO 8601). The code default is
+# 2026-09-07T00:00:00Z; set a later time only if the rollout is delayed.
+OPENSKY_LEGACY_COOLDOWN_COMPAT_UNTIL=
 # Bearer auth for an OpenSky fetch proxy, if you front OpenSky behind one.
 OPENSKY_PROXY_AUTH=
 

--- a/scripts/_opensky-account-cooldown.cjs
+++ b/scripts/_opensky-account-cooldown.cjs
@@ -17,6 +17,11 @@ const OPENSKY_COOLDOWN_KEY = 'opensky:cooldown-until:v2';
 // v1 stored every account under one key. Readers retain this name only while
 // migrating a matching account's still-live record into its v2 key.
 const OPENSKY_LEGACY_COOLDOWN_KEY = 'opensky:cooldown-until:v1';
+// Temporary rolling-deploy bridge. New writers update v2 and v1 atomically,
+// and new readers consult v1 only until this deadline. The override lets an
+// operator extend a delayed rollout without leaving the extra Redis read in
+// the steady-state request path forever.
+const OPENSKY_LEGACY_COOLDOWN_COMPAT_DEFAULT_UNTIL = '2026-09-07T00:00:00.000Z';
 const OPENSKY_MAX_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const OPENSKY_MAX_CLOCK_SKEW_MS = 5_000;
 // Header-less 429s still park the shared key. The seeder is a one-shot */5
@@ -32,6 +37,15 @@ function accountFingerprint(clientId) {
 
 function cooldownKeyForAccount(account) {
   return OPENSKY_COOLDOWN_KEY + ':' + (typeof account === 'string' && account ? account : 'unknown');
+}
+
+function legacyCooldownCompatibilityEnabled({
+  now = Date.now(),
+  cutoff = process.env.OPENSKY_LEGACY_COOLDOWN_COMPAT_UNTIL
+    || OPENSKY_LEGACY_COOLDOWN_COMPAT_DEFAULT_UNTIL,
+} = {}) {
+  const cutoffMs = typeof cutoff === 'number' ? cutoff : Date.parse(String(cutoff));
+  return Number.isFinite(now) && Number.isFinite(cutoffMs) && now < cutoffMs;
 }
 
 function clampCooldownMs(retryAfterSeconds, fallbackMs, maxMs = OPENSKY_MAX_COOLDOWN_MS) {
@@ -130,25 +144,32 @@ function storedCooldownJson(raw) {
 // lockout, or the reverse. Both writers EVAL this so the stored `until` is a
 // max, not a coin-flip (#6253 review).
 const OPENSKY_MAX_DEADLINE_SET_LUA = `
-local current = redis.call('GET', KEYS[1])
 local newUntil = tonumber(ARGV[3])
 local incomingAccount = ARGV[4] or ''
 if newUntil == nil then
   return 0
 end
-if current then
-  local ok, existing = pcall(cjson.decode, current)
-  if ok and type(existing) == 'table' then
-    local existingUntil = tonumber(existing['until'])
-    if type(existing['account']) == 'string'
-      and existing['account'] == incomingAccount
-      and existingUntil ~= nil and existingUntil >= newUntil then
-      return 0
+local writes = 0
+for _, key in ipairs(KEYS) do
+  local current = redis.call('GET', key)
+  local shouldWrite = true
+  if current then
+    local ok, existing = pcall(cjson.decode, current)
+    if ok and type(existing) == 'table' then
+      local existingUntil = tonumber(existing['until'])
+      if type(existing['account']) == 'string'
+        and existing['account'] == incomingAccount
+        and existingUntil ~= nil and existingUntil >= newUntil then
+        shouldWrite = false
+      end
     end
   end
+  if shouldWrite then
+    redis.call('SET', key, ARGV[1], 'EX', tonumber(ARGV[2]))
+    writes = writes + 1
+  end
 end
-redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]))
-return 1
+return writes
 `.trim();
 
 // Unconditional DEL after a success can erase a newer, longer cooldown that
@@ -246,10 +267,14 @@ function applyCompareAndDelete(store, key, opts) {
   return decision;
 }
 
-function maxDeadlineSetCommand(key, record, ttlSeconds) {
+function maxDeadlineSetCommand(keyOrKeys, record, ttlSeconds) {
+  const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
+  if (keys.length === 0 || keys.some((key) => typeof key !== 'string' || key === '')) {
+    throw new TypeError('maxDeadlineSetCommand requires at least one Redis key');
+  }
   return [
-    'EVAL', OPENSKY_MAX_DEADLINE_SET_LUA, '1',
-    key,
+    'EVAL', OPENSKY_MAX_DEADLINE_SET_LUA, String(keys.length),
+    ...keys,
     serializeCooldownRecord(record),
     String(ttlSeconds),
     String(record.until),
@@ -274,6 +299,7 @@ function compareAndDelCommand(key, {
 module.exports = {
   OPENSKY_COOLDOWN_KEY,
   OPENSKY_LEGACY_COOLDOWN_KEY,
+  OPENSKY_LEGACY_COOLDOWN_COMPAT_DEFAULT_UNTIL,
   OPENSKY_MAX_COOLDOWN_MS,
   OPENSKY_MAX_CLOCK_SKEW_MS,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,
@@ -281,6 +307,7 @@ module.exports = {
   OPENSKY_COMPARE_AND_DEL_LUA,
   accountFingerprint,
   cooldownKeyForAccount,
+  legacyCooldownCompatibilityEnabled,
   clampCooldownMs,
   ttlSecondsForCooldown,
   inspectCooldownRecord,

--- a/scripts/_opensky-account-cooldown.cjs
+++ b/scripts/_opensky-account-cooldown.cjs
@@ -14,6 +14,9 @@
 const { createHash } = require('node:crypto');
 
 const OPENSKY_COOLDOWN_KEY = 'opensky:cooldown-until:v2';
+// v1 stored every account under one key. Readers retain this name only while
+// migrating a matching account's still-live record into its v2 key.
+const OPENSKY_LEGACY_COOLDOWN_KEY = 'opensky:cooldown-until:v1';
 const OPENSKY_MAX_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const OPENSKY_MAX_CLOCK_SKEW_MS = 5_000;
 // Header-less 429s still park the shared key. The seeder is a one-shot */5
@@ -270,6 +273,7 @@ function compareAndDelCommand(key, {
 
 module.exports = {
   OPENSKY_COOLDOWN_KEY,
+  OPENSKY_LEGACY_COOLDOWN_KEY,
   OPENSKY_MAX_COOLDOWN_MS,
   OPENSKY_MAX_CLOCK_SKEW_MS,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,

--- a/scripts/_opensky-account-cooldown.cjs
+++ b/scripts/_opensky-account-cooldown.cjs
@@ -13,8 +13,9 @@
 
 const { createHash } = require('node:crypto');
 
-const OPENSKY_COOLDOWN_KEY = 'opensky:cooldown-until:v1';
+const OPENSKY_COOLDOWN_KEY = 'opensky:cooldown-until:v2';
 const OPENSKY_MAX_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const OPENSKY_MAX_CLOCK_SKEW_MS = 5_000;
 // Header-less 429s still park the shared key. The seeder is a one-shot */5
 // cron, so any deadline under 300s expires before the next tick and
 // suppresses exactly zero seeder requests. Two ticks (10 min) is the persist
@@ -24,6 +25,10 @@ const OPENSKY_SHARED_FALLBACK_COOLDOWN_MS = 10 * 60_000;
 function accountFingerprint(clientId) {
   if (!clientId) return null;
   return createHash('sha256').update(clientId).digest('hex').slice(0, 12);
+}
+
+function cooldownKeyForAccount(account) {
+  return OPENSKY_COOLDOWN_KEY + ':' + (typeof account === 'string' && account ? account : 'unknown');
 }
 
 function clampCooldownMs(retryAfterSeconds, fallbackMs, maxMs = OPENSKY_MAX_COOLDOWN_MS) {
@@ -52,9 +57,20 @@ function inspectCooldownRecord(record, {
   }
   const remainingMs = until - now;
   // Beyond the documented maximum the record cannot have come from this code
-  // path, so obey the clock rather than the value. Logged as a raw number:
-  // `new Date(n).toISOString()` throws RangeError past ±8.64e15 (#6241).
+  // path, unless this writer recorded the exact clamped duration. That lets a
+  // reader whose clock is slightly behind still honor a valid maximum window.
   if (remainingMs > maxMs) {
+    const recordedAt = record?.recordedAt;
+    const cooldownMs = record?.cooldownMs;
+    const hasRecordedDuration = typeof recordedAt === 'number'
+      && typeof cooldownMs === 'number'
+      && Number.isFinite(recordedAt)
+      && Number.isFinite(cooldownMs)
+      && cooldownMs >= 0
+      && cooldownMs <= maxMs
+      && until === recordedAt + cooldownMs
+      && recordedAt <= now + OPENSKY_MAX_CLOCK_SKEW_MS;
+    if (hasRecordedDuration) return { remainingMs: maxMs };
     return { remainingMs: 0, ignoreReason: 'implausible-deadline', until };
   }
   return { remainingMs: Math.max(0, remainingMs) };
@@ -113,14 +129,19 @@ function storedCooldownJson(raw) {
 const OPENSKY_MAX_DEADLINE_SET_LUA = `
 local current = redis.call('GET', KEYS[1])
 local newUntil = tonumber(ARGV[3])
+local incomingAccount = ARGV[4] or ''
 if newUntil == nil then
   return 0
 end
 if current then
   local ok, existing = pcall(cjson.decode, current)
-  local existingUntil = ok and tonumber(existing['until']) or nil
-  if existingUntil ~= nil and existingUntil >= newUntil then
-    return 0
+  if ok and type(existing) == 'table' then
+    local existingUntil = tonumber(existing['until'])
+    if type(existing['account']) == 'string'
+      and existing['account'] == incomingAccount
+      and existingUntil ~= nil and existingUntil >= newUntil then
+      return 0
+    end
   end
 end
 redis.call('SET', KEYS[1], ARGV[1], 'EX', tonumber(ARGV[2]))
@@ -164,10 +185,14 @@ function decideMaxDeadlineWrite(existingRecord, incomingRecord) {
     return { write: false, reason: 'invalid-incoming' };
   }
   const existingUntil = Number(existingRecord?.until);
-  if (Number.isFinite(existingUntil) && existingUntil >= incomingUntil) {
+  const existingAccount = existingRecord?.account;
+  const accountsMatch = typeof existingAccount === 'string'
+    && existingAccount !== ''
+    && existingAccount === incomingRecord?.account;
+  if (accountsMatch && Number.isFinite(existingUntil) && existingUntil >= incomingUntil) {
     return { write: false, reason: 'existing-deadline-wins', existingUntil };
   }
-  return { write: true, reason: Number.isFinite(existingUntil) ? 'newer-deadline' : 'missing' };
+  return { write: true, reason: Number.isFinite(existingUntil) && accountsMatch ? 'newer-deadline' : 'missing' };
 }
 
 function decideCompareAndDelete(currentRaw, {
@@ -225,6 +250,7 @@ function maxDeadlineSetCommand(key, record, ttlSeconds) {
     serializeCooldownRecord(record),
     String(ttlSeconds),
     String(record.until),
+    typeof record.account === 'string' ? record.account : '',
   ];
 }
 
@@ -245,10 +271,12 @@ function compareAndDelCommand(key, {
 module.exports = {
   OPENSKY_COOLDOWN_KEY,
   OPENSKY_MAX_COOLDOWN_MS,
+  OPENSKY_MAX_CLOCK_SKEW_MS,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,
   OPENSKY_MAX_DEADLINE_SET_LUA,
   OPENSKY_COMPARE_AND_DEL_LUA,
   accountFingerprint,
+  cooldownKeyForAccount,
   clampCooldownMs,
   ttlSecondsForCooldown,
   inspectCooldownRecord,

--- a/scripts/ais-relay-opensky-shared-cooldown.test.cjs
+++ b/scripts/ais-relay-opensky-shared-cooldown.test.cjs
@@ -8,6 +8,7 @@ const { spawn } = require('node:child_process');
 const test = require('node:test');
 const {
   cooldownKeyForAccount,
+  OPENSKY_LEGACY_COOLDOWN_KEY,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,
   OPENSKY_MAX_DEADLINE_SET_LUA,
   accountFingerprint,
@@ -251,6 +252,40 @@ test('a relay 429 persists the shared cooldown key the seeder reads (#6253)', as
   }
 });
 
+test('a matching legacy v1 cooldown is honored and copied into the account v2 key', async () => {
+  const record = buildCooldownRecord({
+    cooldownMs: 10 * 60_000,
+    retryAfterSeconds: 900,
+    account: accountFingerprint('test-client'),
+    recordedBy: 'seed-military-flights',
+  });
+  const redis = await createUpstashMock({
+    getResponses: {
+      [OPENSKY_COOLDOWN_KEY]: { result: null },
+      [OPENSKY_LEGACY_COOLDOWN_KEY]: { result: JSON.stringify(record) },
+    },
+  });
+  const { child, ready } = spawnRelay({
+    ...redis.env,
+    RELAY_TEST_OPENSKY_STATUS_SEQUENCE: '200',
+  });
+  try {
+    const { port } = await ready;
+    const response = await get(port, '/opensky/states/all?lamin=1&lomin=1&lamax=2&lomax=2');
+    assert.equal(response.status, 200);
+    assert.equal(response.headers['x-cache'], 'RATE-LIMITED');
+    const metrics = JSON.parse((await get(port, '/metrics')).body);
+    assert.equal(metrics.opensky.upstreamFetches, 0);
+    const migrations = redis.evalsFor(OPENSKY_COOLDOWN_KEY);
+    assert.equal(migrations.length, 1);
+    assert.deepEqual(JSON.parse(migrations[0].command[4]), record);
+    assert.equal(redis.evalsFor(OPENSKY_LEGACY_COOLDOWN_KEY).length, 0, 'v1 is read but never modified');
+  } finally {
+    await stop(child);
+    await redis.close();
+  }
+});
+
 test('a seeder-written shared cooldown makes the relay skip without an upstream fetch', async () => {
   const record = buildCooldownRecord({
     cooldownMs: 10 * 60_000,
@@ -340,9 +375,11 @@ test('a cooldown written after a completed handler read stops a queued relay fet
     const { port } = await ready;
     const firstRequest = get(port, '/opensky/states/all?lamin=1&lomin=1&lamax=2&lomax=2');
     await redis.waitForGets(OPENSKY_COOLDOWN_KEY, 2);
+    await redis.waitForGets(OPENSKY_LEGACY_COOLDOWN_KEY, 2);
 
     const secondRequest = get(port, '/opensky/states/all?lamin=3&lomin=3&lamax=4&lomax=4');
     await redis.waitForGets(OPENSKY_COOLDOWN_KEY, 3);
+    await redis.waitForGets(OPENSKY_LEGACY_COOLDOWN_KEY, 3);
 
     const seederCooldown = buildCooldownRecord({
       cooldownMs: 10 * 60_000,
@@ -360,6 +397,36 @@ test('a cooldown written after a completed handler read stops a queued relay fet
     const metrics = JSON.parse((await get(port, '/metrics')).body);
     assert.equal(metrics.opensky.upstreamFetches, 1, 'a newly seeded cooldown must prevent a second billed OpenSky request');
     assert.equal(redis.getsFor(OPENSKY_COOLDOWN_KEY).length, 4, 'the second queued fetch must read the newly seeded cooldown');
+  } finally {
+    await stop(child);
+    await redis.close();
+  }
+});
+
+test('a mismatched legacy v1 cooldown fails open and is not migrated', async () => {
+  const record = buildCooldownRecord({
+    cooldownMs: 10 * 60_000,
+    account: accountFingerprint('other-account'),
+    recordedBy: 'seed-military-flights',
+  });
+  const redis = await createUpstashMock({
+    getResponses: {
+      [OPENSKY_COOLDOWN_KEY]: { result: null },
+      [OPENSKY_LEGACY_COOLDOWN_KEY]: { result: JSON.stringify(record) },
+    },
+  });
+  const { child, ready } = spawnRelay({
+    ...redis.env,
+    RELAY_TEST_OPENSKY_STATUS_SEQUENCE: '200',
+  });
+  try {
+    const { port } = await ready;
+    const response = await get(port, '/opensky/states/all?lamin=1&lomin=1&lamax=2&lomax=2');
+    assert.equal(response.status, 200);
+    assert.notEqual(response.headers['x-cache'], 'RATE-LIMITED');
+    const metrics = JSON.parse((await get(port, '/metrics')).body);
+    assert.equal(metrics.opensky.upstreamFetches, 1);
+    assert.equal(redis.evalsFor(OPENSKY_COOLDOWN_KEY).length, 0);
   } finally {
     await stop(child);
     await redis.close();

--- a/scripts/ais-relay-opensky-shared-cooldown.test.cjs
+++ b/scripts/ais-relay-opensky-shared-cooldown.test.cjs
@@ -7,13 +7,14 @@ const path = require('node:path');
 const { spawn } = require('node:child_process');
 const test = require('node:test');
 const {
-  OPENSKY_COOLDOWN_KEY,
+  cooldownKeyForAccount,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,
   OPENSKY_MAX_DEADLINE_SET_LUA,
   accountFingerprint,
   buildCooldownRecord,
   ttlSecondsForCooldown,
 } = require('./_opensky-account-cooldown.cjs');
+const OPENSKY_COOLDOWN_KEY = cooldownKeyForAccount(accountFingerprint('test-client'));
 
 function get(port, requestPath) {
   return new Promise((resolve, reject) => {
@@ -86,10 +87,22 @@ function spawnRelay(extraEnv) {
 async function createUpstashMock({ getResponses = {}, failGets = false, getDelayMs = 0 } = {}) {
   const commands = [];
   const pendingTimers = new Set();
+  const getWaiters = new Set();
   const getQueues = new Map(Object.entries(getResponses).map(([key, responses]) => [
     key,
     Array.isArray(responses) ? [...responses] : [responses],
   ]));
+  const getCount = (key) => commands.filter(
+    (entry) => entry.method === 'GET' && entry.path === '/get/' + encodeURIComponent(key),
+  ).length;
+  const notifyGetWaiters = () => {
+    for (const waiter of [...getWaiters]) {
+      if (getCount(waiter.key) < waiter.count) continue;
+      clearTimeout(waiter.timer);
+      getWaiters.delete(waiter);
+      waiter.resolve();
+    }
+  };
   const server = http.createServer((req, res) => {
     const chunks = [];
     req.on('data', (chunk) => chunks.push(chunk));
@@ -97,6 +110,7 @@ async function createUpstashMock({ getResponses = {}, failGets = false, getDelay
       let command = null;
       try { command = JSON.parse(Buffer.concat(chunks).toString()); } catch { /* GET /get */ }
       commands.push({ method: req.method, path: req.url, command });
+      if (req.method === 'GET' && req.url.startsWith('/get/')) notifyGetWaiters();
       const respond = () => {
         if (res.writableEnded) return;
         res.setHeader('Content-Type', 'application/json');
@@ -134,6 +148,20 @@ async function createUpstashMock({ getResponses = {}, failGets = false, getDelay
     getsFor: (key) => commands.filter(
       (entry) => entry.method === 'GET' && entry.path === `/get/${encodeURIComponent(key)}`,
     ),
+    waitForGets: (key, count, timeoutMs = 2_000) => {
+      if (getCount(key) >= count) return Promise.resolve();
+      return new Promise((resolve, reject) => {
+        const waiter = { key, count, resolve, reject, timer: null };
+        waiter.timer = setTimeout(() => {
+          getWaiters.delete(waiter);
+          reject(new Error('timed out waiting for ' + count + ' GETs for ' + key));
+        }, timeoutMs);
+        getWaiters.add(waiter);
+      });
+    },
+    setGetResponses: (key, responses) => {
+      getQueues.set(key, Array.isArray(responses) ? [...responses] : [responses]);
+    },
     setsFor: (key) => commands.filter(
       (entry) => Array.isArray(entry.command) && entry.command[0] === 'SET' && entry.command[1] === key,
     ),
@@ -148,6 +176,11 @@ async function createUpstashMock({ getResponses = {}, failGets = false, getDelay
     close: () => {
       for (const timer of pendingTimers) clearTimeout(timer);
       pendingTimers.clear();
+      for (const waiter of getWaiters) {
+        clearTimeout(waiter.timer);
+        waiter.reject(new Error('Upstash mock closed while a GET waiter was pending'));
+      }
+      getWaiters.clear();
       return new Promise((resolve) => server.close(resolve));
     },
   };
@@ -270,7 +303,7 @@ test('a Redis read error fails open and the in-process 429 cooldown still works'
   }
 });
 
-test('a delayed Redis cooldown read fails open inside the 6s caller budget and is not repeated', async () => {
+test('a delayed Redis cooldown read fails open inside the 6s caller budget', async () => {
   const redis = await createUpstashMock({ getDelayMs: 4_000 });
   const { child, ready } = spawnRelay({
     ...redis.env,
@@ -285,11 +318,48 @@ test('a delayed Redis cooldown read fails open inside the 6s caller budget and i
     assert.notEqual(response.headers['x-cache'], 'RATE-LIMITED');
     const metrics = JSON.parse((await get(port, '/metrics')).body);
     assert.equal(metrics.opensky.upstreamFetches, 1, 'slow Redis must fail open so OpenSky still answers');
-    assert.equal(redis.getsFor(OPENSKY_COOLDOWN_KEY).length, 1, 'handler and queued fetch must share one Redis GET');
+    assert.equal(redis.getsFor(OPENSKY_COOLDOWN_KEY).length, 2, 'the queued fetch must re-check Redis immediately before OpenSky');
     assert.ok(
       elapsedMs < 3_000,
       `slow Redis must leave the 6s aviation hop enough time for OpenSky, took ${elapsedMs}ms`,
     );
+  } finally {
+    await stop(child);
+    await redis.close();
+  }
+});
+
+test('a cooldown written after a completed handler read stops a queued relay fetch', async () => {
+  const redis = await createUpstashMock();
+  const { child, ready } = spawnRelay({
+    ...redis.env,
+    RELAY_TEST_OPENSKY_STATUS_SEQUENCE: '200,200',
+    RELAY_TEST_OPENSKY_RESPONSE_DELAY_MS: '250',
+  });
+  try {
+    const { port } = await ready;
+    const firstRequest = get(port, '/opensky/states/all?lamin=1&lomin=1&lamax=2&lomax=2');
+    await redis.waitForGets(OPENSKY_COOLDOWN_KEY, 2);
+
+    const secondRequest = get(port, '/opensky/states/all?lamin=3&lomin=3&lamax=4&lomax=4');
+    await redis.waitForGets(OPENSKY_COOLDOWN_KEY, 3);
+
+    const seederCooldown = buildCooldownRecord({
+      cooldownMs: 10 * 60_000,
+      account: accountFingerprint('test-client'),
+      recordedBy: 'seed-military-flights',
+    });
+    redis.setGetResponses(OPENSKY_COOLDOWN_KEY, {
+      result: JSON.stringify(seederCooldown),
+    });
+
+    const [first, second] = await Promise.all([firstRequest, secondRequest]);
+    assert.equal(first.status, 200);
+    assert.notEqual(first.headers['x-cache'], 'RATE-LIMITED');
+    assert.equal(second.status, 429, 'the queued boundary must reject the newly armed cooldown');
+    const metrics = JSON.parse((await get(port, '/metrics')).body);
+    assert.equal(metrics.opensky.upstreamFetches, 1, 'a newly seeded cooldown must prevent a second billed OpenSky request');
+    assert.equal(redis.getsFor(OPENSKY_COOLDOWN_KEY).length, 4, 'the second queued fetch must read the newly seeded cooldown');
   } finally {
     await stop(child);
     await redis.close();

--- a/scripts/ais-relay-opensky-shared-cooldown.test.cjs
+++ b/scripts/ais-relay-opensky-shared-cooldown.test.cjs
@@ -59,6 +59,7 @@ function spawnRelay(extraEnv) {
       OPENSKY_REQUEST_SPACING_MS: '1',
       OPENSKY_CLIENT_ID: 'test-client',
       OPENSKY_CLIENT_SECRET: 'test-secret',
+      OPENSKY_LEGACY_COOLDOWN_COMPAT_UNTIL: '2099-01-01T00:00:00.000Z',
       NODE_OPTIONS: `--require=${preload}`,
       ...extraEnv,
     },
@@ -166,9 +167,11 @@ async function createUpstashMock({ getResponses = {}, failGets = false, getDelay
     setsFor: (key) => commands.filter(
       (entry) => Array.isArray(entry.command) && entry.command[0] === 'SET' && entry.command[1] === key,
     ),
-    evalsFor: (key) => commands.filter(
-      (entry) => Array.isArray(entry.command) && entry.command[0] === 'EVAL' && entry.command[3] === key,
-    ),
+    evalsFor: (key) => commands.filter((entry) => {
+      if (!Array.isArray(entry.command) || entry.command[0] !== 'EVAL') return false;
+      const keyCount = Number(entry.command[2]);
+      return entry.command.slice(3, 3 + keyCount).includes(key);
+    }),
     env: {
       UPSTASH_REDIS_REST_URL: `http://127.0.0.1:${server.address().port}`,
       UPSTASH_REDIS_REST_TOKEN: 'test-upstash-token',
@@ -187,6 +190,11 @@ async function createUpstashMock({ getResponses = {}, failGets = false, getDelay
   };
 }
 
+function evalArgs(command) {
+  const keyCount = Number(command[2]);
+  return command.slice(3 + keyCount);
+}
+
 test('a header-less relay 429 persists a seeder-cadence fallback, not the 90s local default', async () => {
   const redis = await createUpstashMock();
   const { child, ready } = spawnRelay({
@@ -203,7 +211,8 @@ test('a header-less relay 429 persists a seeder-cadence fallback, not the 90s lo
     const evals = redis.evalsFor(OPENSKY_COOLDOWN_KEY);
     assert.equal(evals.length, 1, 'relay must write the shared cooldown key on a header-less 429');
     assert.equal(evals[0].command[1], OPENSKY_MAX_DEADLINE_SET_LUA);
-    const record = JSON.parse(evals[0].command[4]);
+    const args = evalArgs(evals[0].command);
+    const record = JSON.parse(args[0]);
     assert.equal(record.recordedBy, 'ais-relay');
     assert.equal(record.retryAfterSeconds, null);
     assert.equal(record.cooldownMs, OPENSKY_SHARED_FALLBACK_COOLDOWN_MS);
@@ -212,7 +221,7 @@ test('a header-less relay 429 persists a seeder-cadence fallback, not the 90s lo
       `shared deadline ${record.until} must span the seeder */5 cadence`,
     );
     assert.equal(
-      evals[0].command[5],
+      args[1],
       String(ttlSecondsForCooldown(OPENSKY_SHARED_FALLBACK_COOLDOWN_MS)),
       'Redis TTL must cover the persist fallback, not the short local cooldown',
     );
@@ -241,11 +250,13 @@ test('a relay 429 persists the shared cooldown key the seeder reads (#6253)', as
     const evals = redis.evalsFor(OPENSKY_COOLDOWN_KEY);
     assert.equal(evals.length, 1, 'relay must write the shared cooldown key on 429');
     assert.equal(evals[0].command[1], OPENSKY_MAX_DEADLINE_SET_LUA);
-    const record = JSON.parse(evals[0].command[4]);
+    const record = JSON.parse(evalArgs(evals[0].command)[0]);
     assert.equal(record.recordedBy, 'ais-relay');
     assert.equal(record.account, accountFingerprint('test-client'));
     assert.equal(record.retryAfterSeconds, 120);
     assert.ok(record.until > Date.now());
+    assert.equal(evals[0].command[2], '2', 'the rollout write must update v2 and v1 in one EVAL');
+    assert.equal(redis.evalsFor(OPENSKY_LEGACY_COOLDOWN_KEY).length, 1, 'old readers must see the new cooldown');
   } finally {
     await stop(child);
     await redis.close();
@@ -278,8 +289,39 @@ test('a matching legacy v1 cooldown is honored and copied into the account v2 ke
     assert.equal(metrics.opensky.upstreamFetches, 0);
     const migrations = redis.evalsFor(OPENSKY_COOLDOWN_KEY);
     assert.equal(migrations.length, 1);
-    assert.deepEqual(JSON.parse(migrations[0].command[4]), record);
+    assert.deepEqual(JSON.parse(evalArgs(migrations[0].command)[0]), record);
     assert.equal(redis.evalsFor(OPENSKY_LEGACY_COOLDOWN_KEY).length, 0, 'v1 is read but never modified');
+  } finally {
+    await stop(child);
+    await redis.close();
+  }
+});
+
+test('an expired legacy cutoff avoids v1 reads on clean v2 misses', async () => {
+  const record = buildCooldownRecord({
+    cooldownMs: 10 * 60_000,
+    account: accountFingerprint('test-client'),
+    recordedBy: 'seed-military-flights',
+  });
+  const redis = await createUpstashMock({
+    getResponses: {
+      [OPENSKY_COOLDOWN_KEY]: [{ result: null }, { result: null }],
+      [OPENSKY_LEGACY_COOLDOWN_KEY]: { result: JSON.stringify(record) },
+    },
+  });
+  const { child, ready } = spawnRelay({
+    ...redis.env,
+    OPENSKY_LEGACY_COOLDOWN_COMPAT_UNTIL: '2000-01-01T00:00:00.000Z',
+    RELAY_TEST_OPENSKY_STATUS_SEQUENCE: '200',
+  });
+  try {
+    const { port } = await ready;
+    const response = await get(port, '/opensky/states/all?lamin=1&lomin=1&lamax=2&lomax=2');
+    assert.equal(response.status, 200);
+    assert.notEqual(response.headers['x-cache'], 'RATE-LIMITED');
+    assert.equal(redis.getsFor(OPENSKY_LEGACY_COOLDOWN_KEY).length, 0);
+    const metrics = JSON.parse((await get(port, '/metrics')).body);
+    assert.equal(metrics.opensky.upstreamFetches, 1);
   } finally {
     await stop(child);
     await redis.close();

--- a/scripts/ais-relay-test-preload.cjs
+++ b/scripts/ais-relay-test-preload.cjs
@@ -19,6 +19,7 @@ const openskyStatuses = (process.env.RELAY_TEST_OPENSKY_STATUS_SEQUENCE || '')
   .filter((value) => Number.isFinite(value) && value > 0);
 const openskyRetryAfterSeconds = Number(process.env.RELAY_TEST_OPENSKY_RETRY_AFTER_SECONDS || 0);
 const openskyRemainingCredits = Number(process.env.RELAY_TEST_OPENSKY_REMAINING_CREDITS || 0);
+const openskyResponseDelayMs = Number(process.env.RELAY_TEST_OPENSKY_RESPONSE_DELAY_MS || 0);
 const openskyMalformedEncoding = process.env.RELAY_TEST_OPENSKY_MALFORMED_ENCODING === '1';
 const wingbitsEchoAreas = process.env.RELAY_TEST_WINGBITS_ECHO_AREAS === '1';
 const wingbitsGhostRows = process.env.RELAY_TEST_WINGBITS_GHOST_ROWS === '1';
@@ -197,6 +198,7 @@ https.get = function patchedGet(...args) {
       statusCode: status,
       body: JSON.stringify({ states: status === 200 ? [OPENSKY_MIL_STATE] : [], time: Date.now() }),
       headers,
+      delayMs: openskyResponseDelayMs,
     });
   }
   if (parsed.hostname === 'feeds.bbci.co.uk') {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -37,6 +37,7 @@ const {
   inspectCooldownRecord,
   buildCooldownRecord,
   maxDeadlineSetCommand,
+  legacyCooldownCompatibilityEnabled,
 } = require('./_opensky-account-cooldown.cjs');
 const OPENSKY_ACCOUNT_FINGERPRINT = openSkyAccountFingerprint(process.env.OPENSKY_CLIENT_ID);
 const OPENSKY_COOLDOWN_KEY = cooldownKeyForAccount(OPENSKY_ACCOUNT_FINGERPRINT);
@@ -9139,7 +9140,11 @@ async function readLegacySharedOpenSkyCooldownMs() {
       record,
       ttlSecondsForCooldown(inspected.remainingMs),
     );
-    const written = await upstashEval(OPENSKY_MAX_DEADLINE_SET_LUA, [OPENSKY_COOLDOWN_KEY], command.slice(4));
+    const written = await upstashEval(
+      OPENSKY_MAX_DEADLINE_SET_LUA,
+      [OPENSKY_COOLDOWN_KEY],
+      command.slice(4),
+    );
     if (written == null && UPSTASH_ENABLED) {
       console.warn('[Relay] OpenSky legacy cooldown migration returned non-OK');
     }
@@ -9188,6 +9193,7 @@ async function readSharedOpenSkyCooldownMs() {
     // A v2 transport or parse failure must remain fail-open. Only a clean
     // empty, expired, or mismatched v2 read may consult the legacy key.
     if (v2ReadFailed) return 0;
+    if (!legacyCooldownCompatibilityEnabled()) return 0;
     const legacyRemainingMs = await readLegacySharedOpenSkyCooldownMs();
     if (legacyRemainingMs > 0) {
       mergeLocalOpenSkyCooldown(Date.now() + legacyRemainingMs);
@@ -9214,14 +9220,22 @@ async function persistSharedOpenSkyCooldown(retryAfterSeconds, completedAt = Dat
     recordedBy: 'ais-relay',
   });
   try {
-    // Atomic max-deadline write: a late shorter persist must not erase a
-    // longer seeder (or earlier relay) lockout already stored at this key.
+    // During the bounded rollout bridge, one EVAL updates the account-scoped
+    // key and v1 atomically so an old process cannot miss a new lockout.
+    // After the cutoff, only v2 remains on the hot path.
+    const keys = legacyCooldownCompatibilityEnabled({ now: completedAt })
+      ? [OPENSKY_COOLDOWN_KEY, OPENSKY_LEGACY_COOLDOWN_KEY]
+      : [OPENSKY_COOLDOWN_KEY];
     const command = maxDeadlineSetCommand(
-      OPENSKY_COOLDOWN_KEY,
+      keys,
       record,
       ttlSecondsForCooldown(persistCooldownMs),
     );
-    const written = await upstashEval(OPENSKY_MAX_DEADLINE_SET_LUA, [OPENSKY_COOLDOWN_KEY], command.slice(4));
+    const written = await upstashEval(
+      OPENSKY_MAX_DEADLINE_SET_LUA,
+      keys,
+      command.slice(3 + keys.length),
+    );
     if (written == null && UPSTASH_ENABLED) {
       console.warn('[Relay] OpenSky shared cooldown persist returned non-OK');
     }

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -27,6 +27,7 @@ const { WebSocketServer, WebSocket } = require('ws');
 const { parseProxyConfig, resolveProxyString, resolveProxyStringForAttempt } = require('./_proxy-utils.cjs');
 const {
   cooldownKeyForAccount,
+  OPENSKY_LEGACY_COOLDOWN_KEY,
   OPENSKY_MAX_COOLDOWN_MS,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,
   OPENSKY_MAX_DEADLINE_SET_LUA,
@@ -9116,6 +9117,38 @@ function mergeLocalOpenSkyCooldown(untilMs) {
 const OPENSKY_SHARED_COOLDOWN_READ_TIMEOUT_MS = 1_000;
 let sharedOpenSkyCooldownReadPromise = null;
 
+async function readLegacySharedOpenSkyCooldownMs() {
+  const record = await upstashGet(OPENSKY_LEGACY_COOLDOWN_KEY, (reason) => {
+    console.warn('[Relay] OpenSky legacy cooldown read failed, proceeding without it: ' + reason);
+  }, OPENSKY_SHARED_COOLDOWN_READ_TIMEOUT_MS);
+  const inspected = inspectCooldownRecord(record, {
+    account: OPENSKY_ACCOUNT_FINGERPRINT,
+  });
+  if (inspected.ignoreReason === 'account-mismatch') {
+    console.warn('[Relay] OpenSky legacy cooldown ignored — recorded for a different account');
+  } else if (inspected.ignoreReason === 'implausible-deadline') {
+    console.warn('[Relay] OpenSky legacy cooldown ignored — implausible deadline ' + inspected.until);
+  }
+  if (inspected.remainingMs <= 0) return 0;
+
+  // Copy, never delete: a rolling deploy can still have v1 writers. The
+  // account-scoped max-deadline EVAL protects a concurrent v2 writer.
+  try {
+    const command = maxDeadlineSetCommand(
+      OPENSKY_COOLDOWN_KEY,
+      record,
+      ttlSecondsForCooldown(inspected.remainingMs),
+    );
+    const written = await upstashEval(OPENSKY_MAX_DEADLINE_SET_LUA, [OPENSKY_COOLDOWN_KEY], command.slice(4));
+    if (written == null && UPSTASH_ENABLED) {
+      console.warn('[Relay] OpenSky legacy cooldown migration returned non-OK');
+    }
+  } catch (err) {
+    console.warn('[Relay] OpenSky legacy cooldown migration failed, proceeding with the observed cooldown: ' + (err.message || err));
+  }
+  return inspected.remainingMs;
+}
+
 // Shared Redis record written by this relay and by seed-military-flights.
 // Fails OPEN on every error path: a Redis problem must never disable the
 // data tier, and the in-process cooldown still works when Redis is down (#6253).
@@ -9135,7 +9168,9 @@ async function remainingSharedOpenSkyCooldownMs() {
 
 async function readSharedOpenSkyCooldownMs() {
   try {
+    let v2ReadFailed = false;
     const record = await upstashGet(OPENSKY_COOLDOWN_KEY, (reason) => {
+      v2ReadFailed = true;
       console.warn(`[Relay] OpenSky shared cooldown read failed, proceeding without it: ${reason}`);
     }, OPENSKY_SHARED_COOLDOWN_READ_TIMEOUT_MS);
     const inspected = inspectCooldownRecord(record, {
@@ -9148,8 +9183,16 @@ async function readSharedOpenSkyCooldownMs() {
     }
     if (inspected.remainingMs > 0) {
       mergeLocalOpenSkyCooldown(Date.now() + inspected.remainingMs);
+      return inspected.remainingMs;
     }
-    return inspected.remainingMs;
+    // A v2 transport or parse failure must remain fail-open. Only a clean
+    // empty, expired, or mismatched v2 read may consult the legacy key.
+    if (v2ReadFailed) return 0;
+    const legacyRemainingMs = await readLegacySharedOpenSkyCooldownMs();
+    if (legacyRemainingMs > 0) {
+      mergeLocalOpenSkyCooldown(Date.now() + legacyRemainingMs);
+    }
+    return legacyRemainingMs;
   } catch (err) {
     console.warn(`[Relay] OpenSky shared cooldown read failed, proceeding without it: ${err.message || err}`);
     return 0;

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -26,7 +26,7 @@ const v8 = require('v8');
 const { WebSocketServer, WebSocket } = require('ws');
 const { parseProxyConfig, resolveProxyString, resolveProxyStringForAttempt } = require('./_proxy-utils.cjs');
 const {
-  OPENSKY_COOLDOWN_KEY,
+  cooldownKeyForAccount,
   OPENSKY_MAX_COOLDOWN_MS,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,
   OPENSKY_MAX_DEADLINE_SET_LUA,
@@ -37,6 +37,8 @@ const {
   buildCooldownRecord,
   maxDeadlineSetCommand,
 } = require('./_opensky-account-cooldown.cjs');
+const OPENSKY_ACCOUNT_FINGERPRINT = openSkyAccountFingerprint(process.env.OPENSKY_CLIENT_ID);
+const OPENSKY_COOLDOWN_KEY = cooldownKeyForAccount(OPENSKY_ACCOUNT_FINGERPRINT);
 const {
   GROQ_DEFAULT_MODEL,
   GROQ_REASONING_EXTRA_BODY,
@@ -9107,28 +9109,20 @@ function mergeLocalOpenSkyCooldown(untilMs) {
 }
 
 // Aviation bbox callers abort this relay hop after 6s
-// (track-aircraft BBOX_RELAY_TIMEOUT_MS). The default Upstash GET waits 5s,
-// and the queued fetch used to repeat that read — a slow Redis consumed the
-// fail-open path before OpenSky could answer. Bound the GET and reuse the
-// result for the same request's second check (#6253).
+// (track-aircraft BBOX_RELAY_TIMEOUT_MS). Bound the shared Redis GET so a
+// slow read still fails open with enough time for OpenSky. Deduplicate only
+// while the read is in flight: a completed zero must not hide a cooldown that
+// the seeder writes before the queued upstream boundary (#6253).
 const OPENSKY_SHARED_COOLDOWN_READ_TIMEOUT_MS = 1_000;
-const OPENSKY_SHARED_COOLDOWN_READ_REUSE_MS = 5_000;
 let sharedOpenSkyCooldownReadPromise = null;
-let sharedOpenSkyCooldownReadResult = 0;
-let sharedOpenSkyCooldownReadExpiresAt = 0;
 
 // Shared Redis record written by this relay and by seed-military-flights.
 // Fails OPEN on every error path: a Redis problem must never disable the
 // data tier, and the in-process cooldown still works when Redis is down (#6253).
 async function remainingSharedOpenSkyCooldownMs() {
   if (sharedOpenSkyCooldownReadPromise) return sharedOpenSkyCooldownReadPromise;
-  if (Date.now() < sharedOpenSkyCooldownReadExpiresAt) return sharedOpenSkyCooldownReadResult;
 
-  const pending = readSharedOpenSkyCooldownMs().then((remainingMs) => {
-    sharedOpenSkyCooldownReadResult = remainingMs;
-    sharedOpenSkyCooldownReadExpiresAt = Date.now() + OPENSKY_SHARED_COOLDOWN_READ_REUSE_MS;
-    return remainingMs;
-  });
+  const pending = readSharedOpenSkyCooldownMs();
   sharedOpenSkyCooldownReadPromise = pending;
   try {
     return await pending;
@@ -9145,7 +9139,7 @@ async function readSharedOpenSkyCooldownMs() {
       console.warn(`[Relay] OpenSky shared cooldown read failed, proceeding without it: ${reason}`);
     }, OPENSKY_SHARED_COOLDOWN_READ_TIMEOUT_MS);
     const inspected = inspectCooldownRecord(record, {
-      account: openSkyAccountFingerprint(process.env.OPENSKY_CLIENT_ID),
+      account: OPENSKY_ACCOUNT_FINGERPRINT,
     });
     if (inspected.ignoreReason === 'account-mismatch') {
       console.warn('[Relay] OpenSky shared cooldown ignored — recorded for a different account');
@@ -9173,7 +9167,7 @@ async function persistSharedOpenSkyCooldown(retryAfterSeconds, completedAt = Dat
     now: completedAt,
     cooldownMs: persistCooldownMs,
     retryAfterSeconds,
-    account: openSkyAccountFingerprint(process.env.OPENSKY_CLIENT_ID),
+    account: OPENSKY_ACCOUNT_FINGERPRINT,
     recordedBy: 'ais-relay',
   });
   try {

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -603,7 +603,7 @@ const OPENSKY_FETCH_RETRY_DELAYS = [0, 1_500];
 // CANNOT live in a module variable the way the relay's does — the deadline has
 // to outlive the process. Redis is the only state that does (#6241).
 const {
-  OPENSKY_COOLDOWN_KEY,
+  cooldownKeyForAccount,
   OPENSKY_MAX_COOLDOWN_MS,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,
   accountFingerprint: openSkyAccountFingerprint,
@@ -614,6 +614,8 @@ const {
   maxDeadlineSetCommand,
   compareAndDelCommand,
 } = createRequire(import.meta.url)('./_opensky-account-cooldown.cjs');
+const OPENSKY_ACCOUNT_FINGERPRINT = openSkyAccountFingerprint(process.env.OPENSKY_CLIENT_ID);
+const OPENSKY_COOLDOWN_KEY = cooldownKeyForAccount(OPENSKY_ACCOUNT_FINGERPRINT);
 // OpenSky omits the retry-after header on some rejections; those repeat just as
 // reliably, so a header-less 429 still parks the tier. Sized against THIS
 // seeder's cadence, not the relay's sub-minute loop: the process is one-shot on
@@ -723,7 +725,7 @@ async function readOpenSkyCooldown() {
   try {
     const record = await redisGet(creds.url, creds.token, OPENSKY_COOLDOWN_KEY);
     const inspected = inspectCooldownRecord(record, {
-      account: openSkyAccountFingerprint(process.env.OPENSKY_CLIENT_ID),
+      account: OPENSKY_ACCOUNT_FINGERPRINT,
     });
     if (inspected.ignoreReason === 'account-mismatch') {
       console.warn('  [OpenSky Quota] ignoring cooldown recorded for a different OpenSky account');
@@ -746,7 +748,7 @@ async function recordOpenSkyCooldown(retryAfterSeconds) {
   const record = buildCooldownRecord({
     cooldownMs,
     retryAfterSeconds,
-    account: openSkyAccountFingerprint(process.env.OPENSKY_CLIENT_ID),
+    account: OPENSKY_ACCOUNT_FINGERPRINT,
     recordedBy: 'seed-military-flights',
   });
   console.warn(

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -604,6 +604,7 @@ const OPENSKY_FETCH_RETRY_DELAYS = [0, 1_500];
 // to outlive the process. Redis is the only state that does (#6241).
 const {
   cooldownKeyForAccount,
+  OPENSKY_LEGACY_COOLDOWN_KEY,
   OPENSKY_MAX_COOLDOWN_MS,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,
   accountFingerprint: openSkyAccountFingerprint,
@@ -719,6 +720,35 @@ function formatWait(ms) {
 // try — so a throw here would kill the entire run, Wingbits included, on every
 // tick until someone deleted the key by hand. That is strictly worse than the
 // bug the cooldown exists to fix, so nothing in here may escape (#6241).
+async function readLegacyOpenSkyCooldown(creds, inactiveResult) {
+  const legacyRecord = await redisGet(creds.url, creds.token, OPENSKY_LEGACY_COOLDOWN_KEY);
+  const inspected = inspectCooldownRecord(legacyRecord, {
+    account: OPENSKY_ACCOUNT_FINGERPRINT,
+  });
+  if (inspected.ignoreReason === 'account-mismatch') {
+    console.warn('  [OpenSky Quota] ignoring legacy cooldown recorded for a different OpenSky account');
+  } else if (inspected.ignoreReason === 'implausible-deadline') {
+    console.warn('  [OpenSky Quota] ignoring implausible legacy cooldown deadline ' + inspected.until);
+  }
+  if (inspected.remainingMs <= 0) return inactiveResult;
+
+  // Copy, never delete: another process may still be on the v1 writer during
+  // rollout. The v2 max-deadline EVAL protects a concurrent account-local write.
+  try {
+    await withRetry(() => redisCommand(
+      creds.url,
+      creds.token,
+      maxDeadlineSetCommand(OPENSKY_COOLDOWN_KEY, legacyRecord, ttlSecondsForCooldown(inspected.remainingMs)),
+      { label: 'Redis EVAL migrate legacy OpenSky cooldown', timeoutMs: 10_000 },
+    ), 2, 1000);
+  } catch (err) {
+    // The existing v1 record is still authoritative for this request even
+    // when the best-effort v2 copy fails; do not turn that into a billed call.
+    console.warn('  [OpenSky Quota] failed to migrate legacy cooldown: ' + (err.message || err));
+  }
+  return { remainingMs: inspected.remainingMs, record: legacyRecord, ignoreReason: null };
+}
+
 async function readOpenSkyCooldown() {
   const creds = getOptionalRedisCredentials();
   if (!creds) return { remainingMs: 0, record: null };
@@ -732,11 +762,13 @@ async function readOpenSkyCooldown() {
     } else if (inspected.ignoreReason === 'implausible-deadline') {
       console.warn(`  [OpenSky Quota] ignoring implausible cooldown deadline ${inspected.until}`);
     }
-    return {
+    const inactiveResult = {
       remainingMs: inspected.remainingMs,
       record,
       ignoreReason: inspected.ignoreReason || null,
     };
+    if (inspected.remainingMs > 0) return inactiveResult;
+    return readLegacyOpenSkyCooldown(creds, inactiveResult);
   } catch (err) {
     console.warn(`  [OpenSky Quota] cooldown read failed, proceeding without it: ${err.message || err}`);
     return { remainingMs: 0, record: null, ignoreReason: 'read-failed' };

--- a/scripts/seed-military-flights.mjs
+++ b/scripts/seed-military-flights.mjs
@@ -614,6 +614,7 @@ const {
   buildCooldownRecord,
   maxDeadlineSetCommand,
   compareAndDelCommand,
+  legacyCooldownCompatibilityEnabled,
 } = createRequire(import.meta.url)('./_opensky-account-cooldown.cjs');
 const OPENSKY_ACCOUNT_FINGERPRINT = openSkyAccountFingerprint(process.env.OPENSKY_CLIENT_ID);
 const OPENSKY_COOLDOWN_KEY = cooldownKeyForAccount(OPENSKY_ACCOUNT_FINGERPRINT);
@@ -768,6 +769,7 @@ async function readOpenSkyCooldown() {
       ignoreReason: inspected.ignoreReason || null,
     };
     if (inspected.remainingMs > 0) return inactiveResult;
+    if (!legacyCooldownCompatibilityEnabled()) return inactiveResult;
     return readLegacyOpenSkyCooldown(creds, inactiveResult);
   } catch (err) {
     console.warn(`  [OpenSky Quota] cooldown read failed, proceeding without it: ${err.message || err}`);
@@ -790,12 +792,16 @@ async function recordOpenSkyCooldown(retryAfterSeconds) {
   const creds = getOptionalRedisCredentials();
   if (!creds) return;
   try {
-    // The TTL outlives the deadline so a live key always answers the read; the
-    // successful-call path deletes it, and the TTL is only the backstop.
+    // A single EVAL dual-writes v2 and v1 during the bounded rollout bridge,
+    // so an old process sees the same account cooldown. The legacy key drops
+    // out automatically after the cutoff.
+    const keys = legacyCooldownCompatibilityEnabled({ now: record.recordedAt })
+      ? [OPENSKY_COOLDOWN_KEY, OPENSKY_LEGACY_COOLDOWN_KEY]
+      : [OPENSKY_COOLDOWN_KEY];
     await withRetry(() => redisCommand(
       creds.url,
       creds.token,
-      maxDeadlineSetCommand(OPENSKY_COOLDOWN_KEY, record, ttlSecondsForCooldown(cooldownMs)),
+      maxDeadlineSetCommand(keys, record, ttlSecondsForCooldown(cooldownMs)),
       { label: `Redis EVAL max-deadline ${OPENSKY_COOLDOWN_KEY}`, timeoutMs: 10_000 },
     ), 2, 1000);
   } catch (err) {

--- a/tests/opensky-account-cooldown.test.mjs
+++ b/tests/opensky-account-cooldown.test.mjs
@@ -4,16 +4,19 @@ import { createRequire } from 'node:module';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { lua, lauxlib, lualib, to_luastring, to_jsstring } from 'fengari';
 
 const here = dirname(fileURLToPath(import.meta.url));
 
 const {
   OPENSKY_COOLDOWN_KEY,
   OPENSKY_MAX_COOLDOWN_MS,
+  OPENSKY_MAX_CLOCK_SKEW_MS,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,
   OPENSKY_MAX_DEADLINE_SET_LUA,
   OPENSKY_COMPARE_AND_DEL_LUA,
   accountFingerprint,
+  cooldownKeyForAccount,
   clampCooldownMs,
   ttlSecondsForCooldown,
   inspectCooldownRecord,
@@ -24,10 +27,103 @@ const {
   compareAndDelCommand,
 } = createRequire(import.meta.url)('../scripts/_opensky-account-cooldown.cjs');
 
+function pushLuaValue(L, value) {
+  if (value === null || value === undefined) {
+    lua.lua_pushnil(L);
+  } else if (typeof value === 'boolean') {
+    lua.lua_pushboolean(L, value);
+  } else if (typeof value === 'number') {
+    lua.lua_pushnumber(L, value);
+  } else if (typeof value === 'string') {
+    lua.lua_pushstring(L, to_luastring(value));
+  } else {
+    const entries = Object.entries(value);
+    lua.lua_createtable(L, 0, entries.length);
+    for (const [key, entry] of entries) {
+      pushLuaValue(L, entry);
+      lua.lua_setfield(L, -2, to_luastring(key));
+    }
+  }
+}
+
+function pushLuaStringArray(L, values) {
+  lua.lua_createtable(L, values.length, 0);
+  values.forEach((value, index) => {
+    lua.lua_pushstring(L, to_luastring(String(value)));
+    lua.lua_seti(L, -2, index + 1);
+  });
+}
+
+function makeLuaRedis(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    store,
+    call(command, args) {
+      const verb = String(command).toUpperCase();
+      if (verb === 'GET') return store.get(args[0]) ?? null;
+      if (verb === 'SET') {
+        store.set(args[0], args[1]);
+        return 'OK';
+      }
+      throw new Error('Redis double: unimplemented ' + verb);
+    },
+  };
+}
+
+function runMaxDeadlineSet(redis, record) {
+  const command = maxDeadlineSetCommand(
+    OPENSKY_COOLDOWN_KEY,
+    record,
+    ttlSecondsForCooldown(record.cooldownMs),
+  );
+  const L = lauxlib.luaL_newstate();
+  lualib.luaL_openlibs(L);
+
+  lua.lua_createtable(L, 0, 1);
+  lua.lua_pushjsclosure(L, (S) => {
+    const args = [];
+    for (let index = 2; index <= lua.lua_gettop(S); index += 1) {
+      args.push(to_jsstring(lua.lua_tostring(S, index)));
+    }
+    const result = redis.call(to_jsstring(lua.lua_tostring(S, 1)), args);
+    if (result === null) lua.lua_pushnil(S);
+    else if (typeof result === 'number') lua.lua_pushnumber(S, result);
+    else lua.lua_pushstring(S, to_luastring(result));
+    return 1;
+  }, 0);
+  lua.lua_setfield(L, -2, to_luastring('call'));
+  lua.lua_setglobal(L, to_luastring('redis'));
+
+  lua.lua_createtable(L, 0, 1);
+  lua.lua_pushjsclosure(L, (S) => {
+    pushLuaValue(S, JSON.parse(to_jsstring(lua.lua_tostring(S, 1))));
+    return 1;
+  }, 0);
+  lua.lua_setfield(L, -2, to_luastring('decode'));
+  lua.lua_setglobal(L, to_luastring('cjson'));
+
+  pushLuaStringArray(L, [command[3]]);
+  lua.lua_setglobal(L, to_luastring('KEYS'));
+  pushLuaStringArray(L, command.slice(4));
+  lua.lua_setglobal(L, to_luastring('ARGV'));
+
+  const errorText = () => {
+    const message = lua.lua_tostring(L, -1);
+    return message ? to_jsstring(message) : '<no Lua error message>';
+  };
+  assert.equal(lauxlib.luaL_loadstring(L, to_luastring(OPENSKY_MAX_DEADLINE_SET_LUA)), lua.LUA_OK, errorText());
+  assert.equal(lua.lua_pcall(L, 0, 1, 0), lua.LUA_OK, errorText());
+  return lua.lua_tonumber(L, -1);
+}
+
 test('shared cooldown key and fingerprint stay stable across processes', () => {
-  assert.equal(OPENSKY_COOLDOWN_KEY, 'opensky:cooldown-until:v1');
+  assert.equal(OPENSKY_COOLDOWN_KEY, 'opensky:cooldown-until:v2');
   assert.equal(accountFingerprint('test-client'), accountFingerprint('test-client'));
   assert.notEqual(accountFingerprint('test-client'), accountFingerprint('other-client'));
+  const account = accountFingerprint('test-client');
+  assert.equal(cooldownKeyForAccount(account), OPENSKY_COOLDOWN_KEY + ':' + account);
+  assert.notEqual(cooldownKeyForAccount(account), cooldownKeyForAccount(accountFingerprint('other-client')));
+  assert.equal(cooldownKeyForAccount(null), OPENSKY_COOLDOWN_KEY + ':unknown');
   assert.equal(accountFingerprint(''), null);
   assert.equal(accountFingerprint(), null);
 });
@@ -74,6 +170,51 @@ test('inspectCooldownRecord fails open on corrupt, mismatched, and implausible r
     inspectCooldownRecord({ until: now - 1, account }, { account, now }).remainingMs,
     0,
   );
+});
+
+test('inspectCooldownRecord retains a valid maximum cooldown across small writer-reader clock skew', () => {
+  const account = accountFingerprint('test-client');
+  const recordedAt = 1_700_000_000_000;
+  const record = buildCooldownRecord({
+    now: recordedAt,
+    cooldownMs: OPENSKY_MAX_COOLDOWN_MS,
+    account,
+    recordedBy: 'seed-military-flights',
+  });
+
+  const inspected = inspectCooldownRecord(record, {
+    account,
+    now: recordedAt - 1,
+  });
+  assert.equal(inspected.remainingMs, OPENSKY_MAX_COOLDOWN_MS);
+  assert.equal(inspected.ignoreReason, undefined);
+
+  const atSkewLimit = inspectCooldownRecord(record, {
+    account,
+    now: recordedAt - OPENSKY_MAX_CLOCK_SKEW_MS,
+  });
+  assert.equal(atSkewLimit.remainingMs, OPENSKY_MAX_COOLDOWN_MS);
+
+  const malformed = inspectCooldownRecord(
+    { ...record, cooldownMs: String(record.cooldownMs) },
+    { account, now: recordedAt - 1 },
+  );
+  assert.equal(malformed.remainingMs, 0);
+  assert.equal(malformed.ignoreReason, 'implausible-deadline');
+
+  const inconsistent = inspectCooldownRecord(
+    { ...record, cooldownMs: record.cooldownMs - 1 },
+    { account, now: recordedAt - 1 },
+  );
+  assert.equal(inconsistent.remainingMs, 0);
+  assert.equal(inconsistent.ignoreReason, 'implausible-deadline');
+
+  const farFuture = inspectCooldownRecord(record, {
+    account,
+    now: recordedAt - OPENSKY_MAX_CLOCK_SKEW_MS - 1,
+  });
+  assert.equal(farFuture.remainingMs, 0);
+  assert.equal(farFuture.ignoreReason, 'implausible-deadline');
 });
 
 test('relay and seeder records are interchangeable for a matching account', () => {
@@ -134,6 +275,35 @@ test('interleaved max-deadline writes keep the longer until', () => {
   assert.equal(applyMaxDeadlineWrite(lateLong, key, longRecord).reason, 'newer-deadline');
   assert.equal(JSON.parse(lateLong[key]).until, longRecord.until);
   assert.equal(JSON.parse(lateLong[key]).recordedBy, 'seed-military-flights');
+});
+
+test('account-scoped keys preserve a new-account cooldown during rotation', () => {
+  const t0 = 1_700_000_000_000;
+  const oldAccount = accountFingerprint('old-client');
+  const newAccount = accountFingerprint('new-client');
+  const oldKey = cooldownKeyForAccount(oldAccount);
+  const newKey = cooldownKeyForAccount(newAccount);
+  const newAccountLong = buildCooldownRecord({
+    now: t0,
+    cooldownMs: 10 * 60_000,
+    account: newAccount,
+    recordedBy: 'seed-military-flights',
+  });
+  const oldAccountLaterShort = buildCooldownRecord({
+    now: t0 + 1_000,
+    cooldownMs: 90_000,
+    account: oldAccount,
+    recordedBy: 'ais-relay',
+  });
+  const store = {};
+
+  applyMaxDeadlineWrite(store, newKey, newAccountLong);
+  applyMaxDeadlineWrite(store, oldKey, oldAccountLaterShort);
+
+  assert.notEqual(oldKey, newKey);
+  assert.equal(JSON.parse(store[newKey]).account, newAccount);
+  assert.equal(JSON.parse(store[newKey]).until, newAccountLong.until);
+  assert.equal(inspectCooldownRecord(JSON.parse(store[newKey]), { account: newAccount, now: t0 }).remainingMs, 600_000);
 });
 
 test('compare-and-delete refuses a stale success after a newer longer cooldown', () => {
@@ -212,6 +382,9 @@ test('EVAL command builders carry the shared Lua and compare args', () => {
   assert.equal(setCmd[3], OPENSKY_COOLDOWN_KEY);
   assert.equal(JSON.parse(setCmd[4]).until, record.until);
   assert.equal(setCmd[6], String(record.until));
+  assert.equal(setCmd[7], record.account);
+  assert.match(OPENSKY_MAX_DEADLINE_SET_LUA, /type\(existing\) == 'table'/);
+  assert.match(OPENSKY_MAX_DEADLINE_SET_LUA, /existing\['account'\] == incomingAccount/);
 
   const delCmd = compareAndDelCommand(OPENSKY_COOLDOWN_KEY, {
     expectedJson: JSON.stringify(record),
@@ -224,14 +397,67 @@ test('EVAL command builders carry the shared Lua and compare args', () => {
   assert.equal(delCmd[6], String(record.recordedAt));
 });
 
+test('max-deadline Lua self-heals scalars and respects OpenSky account rotation', () => {
+  const key = OPENSKY_COOLDOWN_KEY;
+  const t0 = 1_700_000_000_000;
+  const oldAccount = accountFingerprint('old-client');
+  const newAccount = accountFingerprint('new-client');
+  const scalarRepair = buildCooldownRecord({
+    now: t0,
+    cooldownMs: 90_000,
+    account: newAccount,
+    recordedBy: 'ais-relay',
+  });
+  const redis = makeLuaRedis({ [key]: JSON.stringify('legacy-scalar') });
+
+  assert.equal(runMaxDeadlineSet(redis, scalarRepair), 1);
+  assert.equal(redis.store.get(key), JSON.stringify(scalarRepair));
+
+  const oldAccountLong = buildCooldownRecord({
+    now: t0,
+    cooldownMs: 10 * 60_000,
+    account: oldAccount,
+    recordedBy: 'seed-military-flights',
+  });
+  const newAccountShort = buildCooldownRecord({
+    now: t0 + 1_000,
+    cooldownMs: 90_000,
+    account: newAccount,
+    recordedBy: 'ais-relay',
+  });
+  redis.store.set(key, JSON.stringify(oldAccountLong));
+
+  assert.equal(runMaxDeadlineSet(redis, newAccountShort), 1);
+  assert.equal(redis.store.get(key), JSON.stringify(newAccountShort));
+
+  const newAccountLong = buildCooldownRecord({
+    now: t0 + 2_000,
+    cooldownMs: 10 * 60_000,
+    account: newAccount,
+    recordedBy: 'seed-military-flights',
+  });
+  const newAccountLaterShort = buildCooldownRecord({
+    now: t0 + 3_000,
+    cooldownMs: 90_000,
+    account: newAccount,
+    recordedBy: 'ais-relay',
+  });
+  redis.store.set(key, JSON.stringify(newAccountLong));
+
+  assert.equal(runMaxDeadlineSet(redis, newAccountLaterShort), 0);
+  assert.equal(redis.store.get(key), JSON.stringify(newAccountLong));
+});
+
 test('relay and seeder wire the shared atomic helpers instead of SET/DEL', () => {
   const relay = readFileSync(join(here, '../scripts/ais-relay.cjs'), 'utf8');
   const seeder = readFileSync(join(here, '../scripts/seed-military-flights.mjs'), 'utf8');
   assert.match(relay, /maxDeadlineSetCommand/);
   assert.match(relay, /OPENSKY_MAX_DEADLINE_SET_LUA/);
+  assert.match(relay, /cooldownKeyForAccount/);
   assert.doesNotMatch(relay, /upstashSet\(OPENSKY_COOLDOWN_KEY/);
   assert.match(seeder, /maxDeadlineSetCommand/);
   assert.match(seeder, /compareAndDelCommand/);
+  assert.match(seeder, /cooldownKeyForAccount/);
   assert.doesNotMatch(seeder, /redisSet\(\s*[\s\S]*OPENSKY_COOLDOWN_KEY/);
   assert.doesNotMatch(seeder, /redisDel\(\s*[\s\S]*OPENSKY_COOLDOWN_KEY/);
 });

--- a/tests/opensky-account-cooldown.test.mjs
+++ b/tests/opensky-account-cooldown.test.mjs
@@ -10,6 +10,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 
 const {
   OPENSKY_COOLDOWN_KEY,
+  OPENSKY_LEGACY_COOLDOWN_KEY,
   OPENSKY_MAX_COOLDOWN_MS,
   OPENSKY_MAX_CLOCK_SKEW_MS,
   OPENSKY_SHARED_FALLBACK_COOLDOWN_MS,
@@ -118,6 +119,7 @@ function runMaxDeadlineSet(redis, record) {
 
 test('shared cooldown key and fingerprint stay stable across processes', () => {
   assert.equal(OPENSKY_COOLDOWN_KEY, 'opensky:cooldown-until:v2');
+  assert.equal(OPENSKY_LEGACY_COOLDOWN_KEY, 'opensky:cooldown-until:v1');
   assert.equal(accountFingerprint('test-client'), accountFingerprint('test-client'));
   assert.notEqual(accountFingerprint('test-client'), accountFingerprint('other-client'));
   const account = accountFingerprint('test-client');
@@ -454,10 +456,12 @@ test('relay and seeder wire the shared atomic helpers instead of SET/DEL', () =>
   assert.match(relay, /maxDeadlineSetCommand/);
   assert.match(relay, /OPENSKY_MAX_DEADLINE_SET_LUA/);
   assert.match(relay, /cooldownKeyForAccount/);
+  assert.match(relay, /OPENSKY_LEGACY_COOLDOWN_KEY/);
   assert.doesNotMatch(relay, /upstashSet\(OPENSKY_COOLDOWN_KEY/);
   assert.match(seeder, /maxDeadlineSetCommand/);
   assert.match(seeder, /compareAndDelCommand/);
   assert.match(seeder, /cooldownKeyForAccount/);
+  assert.match(seeder, /OPENSKY_LEGACY_COOLDOWN_KEY/);
   assert.doesNotMatch(seeder, /redisSet\(\s*[\s\S]*OPENSKY_COOLDOWN_KEY/);
   assert.doesNotMatch(seeder, /redisDel\(\s*[\s\S]*OPENSKY_COOLDOWN_KEY/);
 });

--- a/tests/opensky-account-cooldown.test.mjs
+++ b/tests/opensky-account-cooldown.test.mjs
@@ -26,6 +26,7 @@ const {
   applyCompareAndDelete,
   maxDeadlineSetCommand,
   compareAndDelCommand,
+  legacyCooldownCompatibilityEnabled,
 } = createRequire(import.meta.url)('../scripts/_opensky-account-cooldown.cjs');
 
 function pushLuaValue(L, value) {
@@ -71,9 +72,9 @@ function makeLuaRedis(initial = {}) {
   };
 }
 
-function runMaxDeadlineSet(redis, record) {
+function runMaxDeadlineSet(redis, record, keys = [OPENSKY_COOLDOWN_KEY]) {
   const command = maxDeadlineSetCommand(
-    OPENSKY_COOLDOWN_KEY,
+    keys,
     record,
     ttlSecondsForCooldown(record.cooldownMs),
   );
@@ -103,9 +104,10 @@ function runMaxDeadlineSet(redis, record) {
   lua.lua_setfield(L, -2, to_luastring('decode'));
   lua.lua_setglobal(L, to_luastring('cjson'));
 
-  pushLuaStringArray(L, [command[3]]);
+  const keyCount = Number(command[2]);
+  pushLuaStringArray(L, command.slice(3, 3 + keyCount));
   lua.lua_setglobal(L, to_luastring('KEYS'));
-  pushLuaStringArray(L, command.slice(4));
+  pushLuaStringArray(L, command.slice(3 + keyCount));
   lua.lua_setglobal(L, to_luastring('ARGV'));
 
   const errorText = () => {
@@ -128,6 +130,47 @@ test('shared cooldown key and fingerprint stay stable across processes', () => {
   assert.equal(cooldownKeyForAccount(null), OPENSKY_COOLDOWN_KEY + ':unknown');
   assert.equal(accountFingerprint(''), null);
   assert.equal(accountFingerprint(), null);
+});
+
+test('legacy compatibility has a finite cutoff', () => {
+  const cutoff = '2026-09-07T00:00:00.000Z';
+  assert.equal(legacyCooldownCompatibilityEnabled({
+    now: Date.parse('2026-09-06T23:59:59.999Z'),
+    cutoff,
+  }), true);
+  assert.equal(legacyCooldownCompatibilityEnabled({
+    now: Date.parse(cutoff),
+    cutoff,
+  }), false);
+  assert.equal(legacyCooldownCompatibilityEnabled({
+    now: Date.parse('2026-09-08T00:00:00.000Z'),
+    cutoff,
+  }), false);
+});
+
+test('max-deadline command can atomically target account and legacy keys', () => {
+  const account = accountFingerprint('test-client');
+  const accountKey = cooldownKeyForAccount(account);
+  const record = buildCooldownRecord({
+    now: 1_700_000_000_000,
+    cooldownMs: 10 * 60_000,
+    account,
+    recordedBy: 'ais-relay',
+  });
+  const command = maxDeadlineSetCommand(
+    [accountKey, OPENSKY_LEGACY_COOLDOWN_KEY],
+    record,
+    ttlSecondsForCooldown(record.cooldownMs),
+  );
+
+  assert.equal(command[2], '2');
+  assert.deepEqual(command.slice(3, 5), [accountKey, OPENSKY_LEGACY_COOLDOWN_KEY]);
+  assert.deepEqual(JSON.parse(command[5]), record);
+
+  const redis = makeLuaRedis();
+  assert.equal(runMaxDeadlineSet(redis, record, [accountKey, OPENSKY_LEGACY_COOLDOWN_KEY]), 2);
+  assert.equal(redis.store.get(accountKey), JSON.stringify(record));
+  assert.equal(redis.store.get(OPENSKY_LEGACY_COOLDOWN_KEY), JSON.stringify(record));
 });
 
 test('clamp uses the caller fallback and caps at 24h', () => {

--- a/tests/seed-military-flights-opensky-shared-cooldown.test.mjs
+++ b/tests/seed-military-flights-opensky-shared-cooldown.test.mjs
@@ -13,7 +13,7 @@ delete process.env.PROXY_URL;
 
 const { fetchOpenSkyGlobal } = await import('../scripts/seed-military-flights.mjs');
 const {
-  OPENSKY_COOLDOWN_KEY,
+  cooldownKeyForAccount,
   OPENSKY_MAX_DEADLINE_SET_LUA,
   OPENSKY_COMPARE_AND_DEL_LUA,
   accountFingerprint,
@@ -21,6 +21,7 @@ const {
   applyMaxDeadlineWrite,
   applyCompareAndDelete,
 } = createRequire(import.meta.url)('../scripts/_opensky-account-cooldown.cjs');
+const OPENSKY_COOLDOWN_KEY = cooldownKeyForAccount(accountFingerprint('test-id'));
 
 const originalFetch = globalThis.fetch;
 const TOKEN_URL = 'https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token';
@@ -38,8 +39,7 @@ function isRedisUrl(raw) {
 }
 
 function isCooldownGet(raw) {
-  return raw.includes(`/get/${encodeURIComponent(OPENSKY_COOLDOWN_KEY)}`)
-    || raw.includes('/get/opensky:cooldown-until:v1');
+  return raw.includes(`/get/${encodeURIComponent(OPENSKY_COOLDOWN_KEY)}`);
 }
 
 function install({ redisRecord = null, redisError = false, allowOpenSky = false } = {}) {

--- a/tests/seed-military-flights-opensky-shared-cooldown.test.mjs
+++ b/tests/seed-military-flights-opensky-shared-cooldown.test.mjs
@@ -8,6 +8,7 @@ process.env.OPENSKY_CLIENT_SECRET = 'test-secret';
 process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
 process.env.WM_SEED_RETRY_DELAY_MS = '1';
+process.env.OPENSKY_LEGACY_COOLDOWN_COMPAT_UNTIL = '2099-01-01T00:00:00.000Z';
 delete process.env.OPENSKY_PROXY_AUTH;
 delete process.env.PROXY_URL;
 
@@ -80,7 +81,10 @@ function install({ redisRecord = null, legacyRedisRecord = null, redisError = fa
 }
 
 beforeEach(() => install());
-afterEach(() => { globalThis.fetch = originalFetch; });
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  process.env.OPENSKY_LEGACY_COOLDOWN_COMPAT_UNTIL = '2099-01-01T00:00:00.000Z';
+});
 
 function emptySources() {
   return { regions: [] };
@@ -151,6 +155,26 @@ test('a matching legacy v1 cooldown remains honored when migration fails', async
   assert.match(fetchSources.regions[0].authStatus, /^quota-cooldown:/);
 });
 
+test('an expired legacy cutoff avoids the v1 read on a clean v2 miss', async () => {
+  const record = buildCooldownRecord({
+    cooldownMs: 10 * 60_000,
+    account: accountFingerprint('test-id'),
+    recordedBy: 'ais-relay',
+  });
+  process.env.OPENSKY_LEGACY_COOLDOWN_COMPAT_UNTIL = '2000-01-01T00:00:00.000Z';
+  install({ legacyRedisRecord: record, allowOpenSky: true });
+  const fetchSources = emptySources();
+  await fetchOpenSkyGlobal({
+    source: { value: 'none' },
+    fetchSources,
+    seenIds: new Set(),
+    allStates: [],
+  });
+  assert.equal(redisGets, 1);
+  assert.ok(openskyCalls >= 1);
+  assert.match(fetchSources.regions[0].authStatus, /^(success|empty):/);
+});
+
 test('a mismatched legacy v1 cooldown fails open and is not migrated', async () => {
   const record = buildCooldownRecord({
     cooldownMs: 10 * 60_000,
@@ -205,17 +229,22 @@ function installInterleavedStore(store, { onOpenSky, allowOpenSky = true } = {})
       let command = null;
       try { command = JSON.parse(init?.body || 'null'); } catch { command = null; }
       if (Array.isArray(command) && command[0] === 'EVAL') {
-        const key = command[3];
+        const keyCount = Number(command[2]);
+        const keys = command.slice(3, 3 + keyCount);
+        const args = command.slice(3 + keyCount);
         if (command[1] === OPENSKY_MAX_DEADLINE_SET_LUA) {
-          const record = JSON.parse(command[4]);
-          const decision = applyMaxDeadlineWrite(store, key, record, Number(command[5]));
-          return Response.json({ result: decision.write ? 1 : 0 });
+          const record = JSON.parse(args[0]);
+          const writes = keys.reduce((count, key) => {
+            const decision = applyMaxDeadlineWrite(store, key, record, Number(args[1]));
+            return count + (decision.write ? 1 : 0);
+          }, 0);
+          return Response.json({ result: writes });
         }
         if (command[1] === OPENSKY_COMPARE_AND_DEL_LUA) {
-          const decision = applyCompareAndDelete(store, key, {
-            expectedJson: command[4],
-            expectedRevision: command[5],
-            watermarkUntil: Number(command[6]),
+          const decision = applyCompareAndDelete(store, keys[0], {
+            expectedJson: args[0],
+            expectedRevision: args[1],
+            watermarkUntil: Number(args[2]),
           });
           return Response.json({ result: decision.delete ? 1 : 0 });
         }
@@ -235,6 +264,25 @@ function installInterleavedStore(store, { onOpenSky, allowOpenSky = true } = {})
     throw new Error(`unexpected fetch ${raw}`);
   };
 }
+
+test('a seeder 429 atomically dual-writes v2 and v1 for old readers', async () => {
+  const store = {};
+  installInterleavedStore(store, {
+    allowOpenSky: (raw) => {
+      if (raw.startsWith(TOKEN_URL)) return Response.json({ access_token: 'tok', expires_in: 1800 });
+      return new Response('quota', { status: 429, headers: { 'Retry-After': '120' } });
+    },
+  });
+  await fetchOpenSkyGlobal({
+    source: { value: 'none' },
+    fetchSources: emptySources(),
+    seenIds: new Set(),
+    allStates: [],
+  });
+
+  assert.ok(store[OPENSKY_COOLDOWN_KEY]);
+  assert.equal(store[OPENSKY_LEGACY_KEY], store[OPENSKY_COOLDOWN_KEY]);
+});
 
 test('a Redis read failure fails open so the seeder still attempts OpenSky', async () => {
   install({ redisError: true, allowOpenSky: true });

--- a/tests/seed-military-flights-opensky-shared-cooldown.test.mjs
+++ b/tests/seed-military-flights-opensky-shared-cooldown.test.mjs
@@ -14,6 +14,7 @@ delete process.env.PROXY_URL;
 const { fetchOpenSkyGlobal } = await import('../scripts/seed-military-flights.mjs');
 const {
   cooldownKeyForAccount,
+  OPENSKY_LEGACY_COOLDOWN_KEY,
   OPENSKY_MAX_DEADLINE_SET_LUA,
   OPENSKY_COMPARE_AND_DEL_LUA,
   accountFingerprint,
@@ -22,6 +23,7 @@ const {
   applyCompareAndDelete,
 } = createRequire(import.meta.url)('../scripts/_opensky-account-cooldown.cjs');
 const OPENSKY_COOLDOWN_KEY = cooldownKeyForAccount(accountFingerprint('test-id'));
+const OPENSKY_LEGACY_KEY = OPENSKY_LEGACY_COOLDOWN_KEY;
 
 const originalFetch = globalThis.fetch;
 const TOKEN_URL = 'https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token';
@@ -39,22 +41,29 @@ function isRedisUrl(raw) {
 }
 
 function isCooldownGet(raw) {
-  return raw.includes(`/get/${encodeURIComponent(OPENSKY_COOLDOWN_KEY)}`);
+  return raw.includes('/get/' + encodeURIComponent(OPENSKY_COOLDOWN_KEY))
+    || raw.includes('/get/' + encodeURIComponent(OPENSKY_LEGACY_KEY));
 }
 
-function install({ redisRecord = null, redisError = false, allowOpenSky = false } = {}) {
+function install({ redisRecord = null, legacyRedisRecord = null, redisError = false, migrationError = false, allowOpenSky = false } = {}) {
   redisGets = 0;
   openskyCalls = 0;
-  globalThis.fetch = async (url) => {
+  globalThis.fetch = async (url, init) => {
     const raw = typeof url === 'string' ? url : url.url;
     if (isCooldownGet(raw)) {
       redisGets += 1;
       if (redisError) return new Response('redis down', { status: 500 });
+      const record = raw.includes('/get/' + encodeURIComponent(OPENSKY_LEGACY_KEY))
+        ? legacyRedisRecord
+        : redisRecord;
       return Response.json({
-        result: redisRecord == null ? null : JSON.stringify(redisRecord),
+        result: record == null ? null : JSON.stringify(record),
       });
     }
     if (isRedisUrl(raw)) {
+      if (migrationError && String(init?.body || '').startsWith('["EVAL",')) {
+        return new Response('redis down', { status: 500 });
+      }
       // SET/DEL from clearOpenSkyCooldown / recordOpenSkyCooldown — acknowledge.
       return Response.json({ result: 'OK' });
     }
@@ -100,6 +109,67 @@ test('a relay-written shared cooldown makes the seeder skip without an OpenSky r
   assert.ok(fetchSources.openSkyCooldownRemainingMs > 0);
 });
 
+test('a matching legacy v1 cooldown is honored and copied into the account v2 key', async () => {
+  const record = buildCooldownRecord({
+    cooldownMs: 10 * 60_000,
+    retryAfterSeconds: 900,
+    account: accountFingerprint('test-id'),
+    recordedBy: 'ais-relay',
+  });
+  const store = { [OPENSKY_LEGACY_KEY]: JSON.stringify(record) };
+  installInterleavedStore(store, { allowOpenSky: false });
+  const fetchSources = emptySources();
+  await fetchOpenSkyGlobal({
+    source: { value: 'none' },
+    fetchSources,
+    seenIds: new Set(),
+    allStates: [],
+  });
+  assert.equal(openskyCalls, 0);
+  assert.equal(redisGets, 2, 'the seeder must check v2 before falling back to v1');
+  assert.match(fetchSources.regions[0].authStatus, /^quota-cooldown:/);
+  assert.deepEqual(JSON.parse(store[OPENSKY_COOLDOWN_KEY]), record);
+  assert.equal(store[OPENSKY_LEGACY_KEY], JSON.stringify(record), 'migration must not delete or rewrite v1');
+});
+
+test('a matching legacy v1 cooldown remains honored when migration fails', async () => {
+  const record = buildCooldownRecord({
+    cooldownMs: 10 * 60_000,
+    account: accountFingerprint('test-id'),
+    recordedBy: 'ais-relay',
+  });
+  install({ legacyRedisRecord: record, migrationError: true, allowOpenSky: false });
+  const fetchSources = emptySources();
+  await fetchOpenSkyGlobal({
+    source: { value: 'none' },
+    fetchSources,
+    seenIds: new Set(),
+    allStates: [],
+  });
+  assert.equal(openskyCalls, 0, 'the observed legacy cooldown must still block OpenSky');
+  assert.equal(redisGets, 2);
+  assert.match(fetchSources.regions[0].authStatus, /^quota-cooldown:/);
+});
+
+test('a mismatched legacy v1 cooldown fails open and is not migrated', async () => {
+  const record = buildCooldownRecord({
+    cooldownMs: 10 * 60_000,
+    account: accountFingerprint('someone-else'),
+    recordedBy: 'ais-relay',
+  });
+  install({ legacyRedisRecord: record, allowOpenSky: true });
+  const fetchSources = emptySources();
+  await fetchOpenSkyGlobal({
+    source: { value: 'none' },
+    fetchSources,
+    seenIds: new Set(),
+    allStates: [],
+  });
+  assert.ok(openskyCalls >= 1, 'mismatch must not inherit another account lockout');
+  assert.equal(redisGets, 2);
+  assert.match(fetchSources.regions[0].authStatus, /^(success|empty):/);
+});
+
 test('an account mismatch fails open and still attempts OpenSky', async () => {
   const record = buildCooldownRecord({
     cooldownMs: 10 * 60_000,
@@ -125,7 +195,10 @@ function installInterleavedStore(store, { onOpenSky, allowOpenSky = true } = {})
     const raw = typeof url === 'string' ? url : url.url;
     if (isCooldownGet(raw)) {
       redisGets += 1;
-      const value = store[OPENSKY_COOLDOWN_KEY];
+      const key = raw.includes('/get/' + encodeURIComponent(OPENSKY_LEGACY_KEY))
+        ? OPENSKY_LEGACY_KEY
+        : OPENSKY_COOLDOWN_KEY;
+      const value = store[key];
       return Response.json({ result: value == null ? null : value });
     }
     if (isRedisUrl(raw)) {


### PR DESCRIPTION
OpenSky cooldown coordination now remains correct across credential rotation, staged v1-to-v2 rollout, and queued relay requests, so one service cannot remove a newer quota block or make a paid request after it is armed.
Account-scoped v2 Redis keys isolate credentials. A matching active v1 record is copied atomically on first use and remains honored if the copy fails, avoiding a rollout-time quota gap.
The atomic writer repairs scalar legacy data, preserves the longest same-account deadline, and readers accept valid 24-hour cooldowns across up to five seconds of skew; corrupt or implausible records fail open.
Focused unit and relay/seeder integration tests execute the Lua script and cover rotation, migration, migration failure, skew, and the queued-fetch boundary.

Related: #7190
